### PR TITLE
feat(pipeline-cli): publish-isolation guard — published packages link no private @kampus deps (#3833)

### DIFF
--- a/.github/workflows/publish-isolation-guard.yml
+++ b/.github/workflows/publish-isolation-guard.yml
@@ -1,0 +1,47 @@
+name: publish-isolation-guard
+
+# CI gate for ADR 0201 §3 (isolated publishing = decoupled dependency graph): every
+# package the release pipeline (`publish.yml`) ships must be installable from a clean
+# registry state — zero phoenix-private `@kampus/*` deps, no `workspace:*` links. The
+# forcing incident: `pipeline-cli@0.2.0` published green yet was uninstallable because
+# it declared three phoenix-private `workspace:*` packages as registry deps (#3802,
+# inlined in #3805). This job derives the published-package set from publish.yml's
+# release-tag grammar, walks each published package's runtime deps, and fails closed on
+# any private/workspace link, on a tag prefix that maps to no member (drift), or on
+# zero published packages (ADR 0092). It reuses pipeline-cli's
+# `publish-isolation-guard check` mode — the scan lives once in the tool.
+on:
+  pull_request:
+
+# Least-privilege GITHUB_TOKEN: the job only checks out + reads the repo and runs the
+# guard, which fails via exit code — it posts no check-run/status/PR comment — so
+# contents:read is all it needs; default-deny every other scope (CodeQL least-privilege).
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: "check every published pipeline package is installable in isolation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 when a published pipeline package links a private/unpublished @kampus dep
+      # or a workspace: specifier (report on stderr), when a publish.yml tag prefix maps
+      # to no member (drift), or when zero published packages are in scope (fail-closed).
+      # See ADR 0201 §3 and #3802.
+      - name: "Check every published pipeline package links no private @kampus deps"
+        run: node packages/pipeline-cli/src/bin.ts publish-isolation-guard check

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -50,6 +50,7 @@ import {patchGuardCommand} from "./tools/patch-guard/command.ts";
 import {pathFilterGuardCommand} from "./tools/path-filter-guard/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {primaryIndexGuardCommand} from "./tools/primary-index-guard/command.ts";
+import {publishIsolationGuardCommand} from "./tools/publish-isolation-guard/command.ts";
 import {reachabilityGuardCommand} from "./tools/reachability-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {redactLeaksCommand} from "./tools/redact-leaks/command.ts";
@@ -198,4 +199,9 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// on PR #3733). The one tested reader every CI-state consumer cites instead of re-rolling
 	// the query, the single-source shape of `verdict read` (#3686).
 	checksCommand,
+	// #3833 — ADR 0201 §3's isolated-publishing invariant: reds when a package the
+	// release pipeline (publish.yml) ships links a private/unpublished @kampus dep or a
+	// workspace: specifier, making the #3802 uninstallable-publish class unrepresentable.
+	// Scope derived from publish.yml's tag grammar; fail-closed on zero scope (ADR 0092).
+	publishIsolationGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/publish-isolation-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/publish-isolation-guard/command.ts
@@ -1,0 +1,98 @@
+/**
+ * The `publish-isolation-guard` tool — `pipeline-cli publish-isolation-guard check [--root <d>]`.
+ *
+ * The CI surface for ADR 0201 §3's isolated-publishing mandate: every package the
+ * release pipeline (`publish.yml`) ships must be installable from a clean registry
+ * state — zero phoenix-private `@kampus/*` deps, no `workspace:*` links. Enforced
+ * fail-closed so the #3802 class (pipeline-cli@0.2.0 published green yet uninstallable)
+ * can't silently re-drift:
+ *
+ *   pipeline-cli publish-isolation-guard check            # CI gate: exit non-zero on any private/workspace dep link
+ *   pipeline-cli publish-isolation-guard check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * SCOPE — DERIVED from publish.yml's release-tag grammar (`<name>-v<version>`), mapped
+ * to workspace members by unscoped package name; never a hardcoded ad-hoc list. Only
+ * the runtime dep fields (`dependencies`/`optionalDependencies`/`peerDependencies`)
+ * ship in the tarball, so `devDependencies` are out of scope. Fail-closed on a tag
+ * prefix that maps to no member (drift) and on zero published packages (ADR 0092). The
+ * scan/IO lives in `gate.ts`; this file wires it to the CLI (the thin-CLI-over-`gate.ts`
+ * idiom shared across the guards).
+ *
+ * With no --root the repo root is resolved by walking UP from cwd for a workspace
+ * marker (so `pnpm --filter <pkg> …`, whose cwd is the package dir, scans the whole
+ * repo, not just the package).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — both a gate failure (a
+ * private/workspace dep link; report on stderr) and an IO failure (fs unreadable) exit
+ * non-zero, undistinguished. `CheckFailed` is caught inside the handler (not at the
+ * bin's run boundary) so the contract survives folding into the shared `pipeline-cli`
+ * bin, which provides only `NodeServices.layer` and no per-tool catch.
+ */
+import {Effect, FileSystem, Option, Path} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {type CheckFailed, checkPublishIsolation} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). Marker-existence faults fall through as
+// false, matching `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root to derive the published-package set + scan manifests under (default: walk up for one)",
+	),
+);
+
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
+// default error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkPublishIsolation(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if any published pipeline package links a private/unpublished @kampus dep",
+	),
+);
+
+export const publishIsolationGuardCommand = Command.make("publish-isolation-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: every published pipeline package is installable in isolation, zero private @kampus deps (ADR 0201 §3, #3802)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/publish-isolation-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/publish-isolation-guard/gate.ts
@@ -1,0 +1,163 @@
+/**
+ * The `publish-isolation-guard` filesystem gate — the IO seam behind ADR 0201 §3's
+ * "every published pipeline package is installable in isolation" check, split from
+ * `command.ts` so it's crossable in unit tests over a fake repo dir rather than only
+ * by spawning the bin (the core-in-its-own-file idiom; #855).
+ *
+ * `checkPublishIsolation` is the CI gate. It (1) derives the published-package set
+ * from `.github/workflows/publish.yml`'s release-tag grammar, (2) enumerates the
+ * workspace members declared in `pnpm-workspace.yaml`, (3) maps the tag prefixes onto
+ * members by unscoped package name, and (4) delegates the verdict to the pure core
+ * (`publish-isolation-guard.ts`). It fails `CheckFailed` (exit non-zero) when a
+ * published package links a private/unpublished `@kampus/*` dep or a `workspace:*`
+ * specifier, when a tag prefix maps to no member (publish.yml/workspace drift), or
+ * when zero published packages are in scope (fail-closed, ADR 0092). A directory/file
+ * IO failure is an `IoError` (also non-zero — both failures, undistinguished, per the
+ * bin's contract).
+ */
+import {Console, Effect, FileSystem, Path} from "effect";
+import * as Schema from "effect/Schema";
+import {
+	judge,
+	manifestRuntimeDeps,
+	type PublishedManifest,
+	parsePublishedTagPrefixes,
+	parseWorkspacePackageGlobs,
+	renderReport,
+	resolvePublished,
+} from "./publish-isolation-guard.ts";
+
+/** Repo-relative path to the release pipeline that defines which packages publish. */
+const PUBLISH_WORKFLOW = ".github/workflows/publish.yml";
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+/**
+ * Expand the declared workspace globs into repo-relative `package.json` paths. Each
+ * glob is either a `<dir>/*` member glob (enumerate immediate subdirs that carry a
+ * `package.json`) or a literal member path. The root `package.json` is NOT in scope —
+ * the root workspace never publishes, so it can't be a published pipeline package.
+ *
+ * All directory/path IO goes through the Effect `FileSystem`/`Path` seam (over the
+ * bin's `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for
+ * real disk (.patterns/effect-platform-access.md); a fs fault folds `PlatformError`
+ * → the `IoError` this gate already carries. This is the one why-note for the file's
+ * platform-seam — the other IO helpers below follow the same shape.
+ */
+const enumerateMemberPaths = (
+	root: string,
+	globs: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const paths = new Set<string>();
+		for (const glob of globs) {
+			if (glob.endsWith("/*")) {
+				const parent = glob.slice(0, -2);
+				const base = path.join(root, parent);
+				if (!(yield* fs.exists(base))) continue;
+				for (const name of yield* fs.readDirectory(base)) {
+					const abs = path.join(base, name);
+					if ((yield* fs.stat(abs)).type !== "Directory") continue;
+					if (yield* fs.exists(path.join(abs, "package.json")))
+						paths.add(`${parent}/${name}/package.json`);
+				}
+			} else if (yield* fs.exists(path.join(root, glob, "package.json"))) {
+				paths.add(`${glob}/package.json`);
+			}
+		}
+		return [...paths].sort();
+	}).pipe(Effect.mapError((cause) => new IoError({path: root, cause})));
+
+/** Read + parse each member path into the pure core's `PublishedManifest` shape (runtime deps only). */
+const readMembers = (
+	root: string,
+	paths: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<PublishedManifest>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		return yield* Effect.forEach(
+			paths,
+			(rel) => {
+				const abs = path.join(root, rel);
+				return fs.readFileString(abs, "utf8").pipe(
+					Effect.mapError((cause) => new IoError({path: abs, cause})),
+					Effect.flatMap((text) =>
+						Effect.try({
+							try: (): PublishedManifest => {
+								const pkg = JSON.parse(text) as Record<string, unknown>;
+								return {
+									path: rel,
+									name: typeof pkg.name === "string" ? pkg.name : rel,
+									deps: manifestRuntimeDeps(pkg),
+								};
+							},
+							catch: (cause) => new IoError({path: abs, cause}),
+						}),
+					),
+				);
+			},
+			{concurrency: 1},
+		);
+	});
+
+const readTextRelative = (
+	root: string,
+	rel: string,
+): Effect.Effect<string, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, rel);
+		return yield* fs
+			.readFileString(target, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
+	});
+
+/**
+ * The CI gate: succeed when every published pipeline package (derived from
+ * publish.yml, mapped to workspace members) links no private/unpublished `@kampus/*`
+ * dep or `workspace:*` specifier, else `CheckFailed`. Fails closed on a tag prefix
+ * with no matching member (drift) and on zero published packages (ADR 0092).
+ */
+export const checkPublishIsolation = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const workflowText = yield* readTextRelative(root, PUBLISH_WORKFLOW);
+		const prefixes = parsePublishedTagPrefixes(workflowText);
+		const globs = parseWorkspacePackageGlobs(yield* readTextRelative(root, "pnpm-workspace.yaml"));
+		const memberPaths = yield* enumerateMemberPaths(root, globs);
+		const members = yield* readMembers(root, memberPaths);
+		const {published, unmatchedPrefixes} = resolvePublished(prefixes, members);
+		if (unmatchedPrefixes.length > 0) {
+			// Drift: publish.yml names a release tag whose prefix maps to no workspace
+			// member. Fail closed rather than silently narrow scope — the derived set must
+			// stay honest against publish.yml (the criterion's "kept in sync with it").
+			return yield* Effect.fail(
+				new CheckFailed({
+					reason:
+						`publish-isolation-guard: publish.yml release-tag prefix(es) [${unmatchedPrefixes.join(", ")}] ` +
+						"map to no workspace member — fail-closed. The tag grammar and the package name (unscoped) have drifted; " +
+						"re-sync publish.yml's `<name>-v<version>` grammar with the package's name.",
+				}),
+			);
+		}
+		const verdict = judge(published);
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/publish-isolation-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/publish-isolation-guard/gate.unit.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `checkPublishIsolation` over a fake repo dir — the filesystem-seam test (#855, ADR
+ * 0201 §3). The pure verdict is covered in `publish-isolation-guard.unit.test.ts`;
+ * this crosses the IO gate over a real temp dir, asserting the exit-code contract (a
+ * clean published graph succeeds; a workspace: link, a private @kampus dep, a
+ * prefix-with-no-member drift, and a zero-scope publish.yml all `CheckFailed`) from
+ * observable outcomes — never by spawning the bin.
+ */
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
+import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
+import {CheckFailed, checkPublishIsolation} from "./gate.ts";
+
+let root: string;
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "publish-isolation-guard-gate-"));
+});
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const writeWorkspace = (globs: ReadonlyArray<string> = ["packages/*", "apps/*", "infra/*"]) =>
+	writeFileSync(
+		join(root, "pnpm-workspace.yaml"),
+		`packages:\n${globs.map((g) => `  - ${g}`).join("\n")}\n`,
+		"utf8",
+	);
+
+// A publish.yml that publishes the given tag prefixes via the `^<prefix>-v(...)` grammar.
+const writePublishWorkflow = (prefixes: ReadonlyArray<string> = ["pipeline-cli"]) => {
+	mkdirSync(join(root, ".github", "workflows"), {recursive: true});
+	const guards = prefixes
+		.map((p) => `          if [[ ! "$TAG" =~ ^${p}-v([0-9].*)$ ]]; then exit 1; fi`)
+		.join("\n");
+	writeFileSync(
+		join(root, ".github", "workflows", "publish.yml"),
+		`name: publish\non:\n  release:\n    types: [published]\njobs:\n  publish:\n    steps:\n${guards}\n`,
+		"utf8",
+	);
+};
+
+const mkPackage = (name: string, pkg: Record<string, unknown> | null) => {
+	const dir = join(root, "packages", name);
+	mkdirSync(dir, {recursive: true});
+	if (pkg) writeFileSync(join(dir, "package.json"), JSON.stringify(pkg), "utf8");
+};
+
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3469);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
+
+const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
+	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
+
+describe("checkPublishIsolation — the CI exit-code gate over a fake repo dir", () => {
+	it("SUCCEEDS when the published package's runtime deps are all public/catalog", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli"]);
+		mkPackage("pipeline-cli", {
+			name: "@kampus/pipeline-cli",
+			dependencies: {effect: "catalog:", yaml: "catalog:"},
+			devDependencies: {vitest: "catalog:"},
+		});
+		const exit = await run(checkPublishIsolation(root));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("IGNORES a private, non-published member's dirty graph — only the published set is in scope", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli"]);
+		mkPackage("pipeline-cli", {name: "@kampus/pipeline-cli", dependencies: {effect: "catalog:"}});
+		// This member is NOT published (no matching tag prefix), so its workspace: link is fine.
+		mkPackage("pipeline-crew-mcp", {
+			name: "@kampus/pipeline-crew-mcp",
+			dependencies: {"@kampus/internal-only": "workspace:*"},
+		});
+		const exit = await run(checkPublishIsolation(root));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed) when the published package links a workspace:* dep (the #3802 class)", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli"]);
+		mkPackage("pipeline-cli", {
+			name: "@kampus/pipeline-cli",
+			dependencies: {effect: "catalog:", "@kampus/epic-ledger": "workspace:*"},
+		});
+		const exit = await run(checkPublishIsolation(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed) when the published package links a private @kampus dep by version", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli"]);
+		mkPackage("pipeline-cli", {
+			name: "@kampus/pipeline-cli",
+			dependencies: {"@kampus/leak-guard": "^1.0.0"},
+		});
+		const exit = await run(checkPublishIsolation(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (fail-closed) when a publish.yml tag prefix maps to no workspace member (drift)", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli"]);
+		// No member named @kampus/pipeline-cli exists — the prefix can't resolve.
+		mkPackage("something-else", {
+			name: "@kampus/something-else",
+			dependencies: {effect: "catalog:"},
+		});
+		const exit = await run(checkPublishIsolation(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (fail-closed, zero-scope) when publish.yml declares no release-tag grammar", async () => {
+		writeWorkspace();
+		writePublishWorkflow([]); // no `^<prefix>-v(...)` anchors → zero published packages
+		mkPackage("pipeline-cli", {name: "@kampus/pipeline-cli", dependencies: {effect: "catalog:"}});
+		const exit = await run(checkPublishIsolation(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+});

--- a/packages/pipeline-cli/src/tools/publish-isolation-guard/publish-isolation-guard.ts
+++ b/packages/pipeline-cli/src/tools/publish-isolation-guard/publish-isolation-guard.ts
@@ -1,0 +1,248 @@
+/**
+ * `publish-isolation-guard` pure core — decide whether every PUBLISHED pipeline
+ * package's runtime dependency graph is self-contained: zero phoenix-private
+ * `@kampus/*` links, installable from a clean registry state. IO-free and total;
+ * every decision is a deterministic transform over already-gathered facts. The
+ * filesystem + `publish.yml` boundary lives in `gate.ts`; this module never touches
+ * disk.
+ *
+ * The rule enforces ADR 0201 §3 (isolated publishing = decoupled dependency graph):
+ * a published artifact must depend only on things a clean registry can resolve. The
+ * forcing incident: `pipeline-cli@0.2.0` published green yet was uninstallable because
+ * it declared three phoenix-private `workspace:*` packages as registry deps (#3802,
+ * inlined in #3805). ADR 0201 turns that from review vigilance into this fail-closed
+ * invariant — the #3802 class becomes unrepresentable.
+ *
+ * Scope is DERIVED, never a hand-maintained parallel list: the published-package set
+ * comes from `publish.yml`'s release-tag grammar (`parsePublishedTagPrefixes`), mapped
+ * to workspace members by unscoped package name (`resolvePublished`). A prefix that
+ * maps to no member is drift and fails closed in `gate.ts`. Fail-closed on zero scope
+ * too (ADR 0092): an empty published set is a misconfiguration, not a vacuous green.
+ */
+
+/**
+ * The dep fields that ship in the published artifact — `optionalDependencies` and
+ * `peerDependencies` resolve from the registry at install time just like
+ * `dependencies`. `devDependencies` are OUT of scope: they don't ship in the tarball,
+ * so a private `@kampus/*` devDep can't break an external install (ADR 0201 §3).
+ */
+export const RUNTIME_DEP_FIELDS = [
+	"dependencies",
+	"optionalDependencies",
+	"peerDependencies",
+] as const;
+
+/** One runtime dependency entry from a published manifest, reduced to the facts the decision needs. */
+export interface DepEntry {
+	/** Which runtime field it came from — one of `RUNTIME_DEP_FIELDS`. */
+	readonly field: string;
+	readonly name: string;
+	/** The raw version specifier, e.g. `catalog:`, `workspace:*`, or `^1.2.3`. */
+	readonly value: string;
+}
+
+/** A published `package.json` reduced to its repo-relative path, package name, and runtime deps. */
+export interface PublishedManifest {
+	/** Repo-relative path, e.g. `packages/pipeline-cli/package.json`. */
+	readonly path: string;
+	/** The `name` field, e.g. `@kampus/pipeline-cli`. */
+	readonly name: string;
+	readonly deps: ReadonlyArray<DepEntry>;
+}
+
+/**
+ * A dep that breaks publish isolation. Two kinds, both the #3802 class:
+ * - `workspace-link`: a `workspace:*` specifier — never resolvable from a registry.
+ * - `private-kampus-dep`: a `@kampus/*` dep whose target is not itself in the published
+ *   set, so it's unpublished/private and a clean registry can't resolve it.
+ */
+export interface IsolationViolation {
+	readonly path: string;
+	readonly field: string;
+	readonly name: string;
+	readonly value: string;
+	readonly kind: "workspace-link" | "private-kampus-dep";
+}
+
+/**
+ * The guard verdict. A discriminated union so an invalid state is unrepresentable: a
+ * pass never carries violations, and the two failure shapes (zero-scope vs linked
+ * private deps) are distinct and each carries exactly its evidence. `scanned` is the
+ * set of published package NAMES the verdict covered.
+ */
+export type PublishIsolationVerdict =
+	| {readonly pass: true; readonly scanned: ReadonlyArray<string>}
+	/** No published package in scope — fail closed, never a vacuous pass (ADR 0092). */
+	| {readonly pass: false; readonly reason: "zero-scope"}
+	/** Published packages exist but at least one links a private/unpublished dep. */
+	| {
+			readonly pass: false;
+			readonly reason: "linked-private-deps";
+			readonly scanned: ReadonlyArray<string>;
+			readonly violations: ReadonlyArray<IsolationViolation>;
+	  };
+
+const KAMPUS_SCOPE = "@kampus/";
+
+/** The unscoped part of a package name — `@kampus/pipeline-cli` → `pipeline-cli`, `effect` → `effect`. */
+export const unscopedName = (name: string): string =>
+	name.startsWith("@") ? (name.split("/")[1] ?? name) : name;
+
+/**
+ * Decide the verdict over the published manifests. Fails closed on an empty set (ADR
+ * 0092), else reds on any runtime dep that is a `workspace:*` link or a `@kampus/*`
+ * dep whose target is not itself published (the #3802 class). A `@kampus/*` dep that
+ * IS in the published set resolves cleanly, so it passes.
+ */
+export const judge = (manifests: ReadonlyArray<PublishedManifest>): PublishIsolationVerdict => {
+	if (manifests.length === 0) {
+		return {pass: false, reason: "zero-scope"};
+	}
+	const publishedNames = new Set(manifests.map((m) => m.name));
+	const scanned = manifests.map((m) => m.name);
+	const violations: Array<IsolationViolation> = [];
+	for (const m of manifests) {
+		for (const dep of m.deps) {
+			// `workspace:*` is checked first: it's the most actionable diagnosis (the exact
+			// #3802 form) even when the dep is also `@kampus/*`-scoped.
+			if (dep.value.startsWith("workspace:")) {
+				violations.push({
+					path: m.path,
+					field: dep.field,
+					name: dep.name,
+					value: dep.value,
+					kind: "workspace-link",
+				});
+			} else if (dep.name.startsWith(KAMPUS_SCOPE) && !publishedNames.has(dep.name)) {
+				violations.push({
+					path: m.path,
+					field: dep.field,
+					name: dep.name,
+					value: dep.value,
+					kind: "private-kampus-dep",
+				});
+			}
+		}
+	}
+	if (violations.length > 0) {
+		return {pass: false, reason: "linked-private-deps", scanned, violations};
+	}
+	return {pass: true, scanned};
+};
+
+/** Render the human-readable report for a verdict (ADR 0092 §1 "emit what you scanned"). */
+export const renderReport = (verdict: PublishIsolationVerdict): string => {
+	if (verdict.pass) {
+		return `publish-isolation-guard: ${verdict.scanned.length} published package${verdict.scanned.length === 1 ? "" : "s"} (${verdict.scanned.join(", ")}) link${verdict.scanned.length === 1 ? "s" : ""} no private/unpublished @kampus deps`;
+	}
+	if (verdict.reason === "zero-scope") {
+		return (
+			"publish-isolation-guard: derived ZERO published packages — fail-closed (ADR 0092). " +
+			"Does publish.yml still declare a `<name>-v<version>` release-tag grammar, and does its prefix map to a workspace member?"
+		);
+	}
+	const lines = verdict.violations.map((v) =>
+		v.kind === "workspace-link"
+			? `  ${v.path}: ${v.field} \`${v.name}\` links \`${v.value}\` — a workspace: specifier never resolves from a clean registry (the #3802 class). ` +
+				`Fix: inline it as a tool, or depend on a PUBLISHED version instead.`
+			: `  ${v.path}: ${v.field} \`${v.name}\` (\`${v.value}\`) is a private/unpublished @kampus package — an external install can't resolve it (the #3802 class, ADR 0201 §3). ` +
+				`Fix: inline it, or publish that package and depend on its registry version.`,
+	);
+	return (
+		`publish-isolation-guard: ${verdict.violations.length} publish-isolation violation${verdict.violations.length === 1 ? "" : "s"} ` +
+		`across ${verdict.scanned.length} published package${verdict.scanned.length === 1 ? "" : "s"} (${verdict.scanned.join(", ")}):\n${lines.join("\n")}`
+	);
+};
+
+/**
+ * Extract the release-tag prefixes from `publish.yml`'s tag-grammar regexes. Each
+ * `^<prefix>-v(...)` anchor names a published artifact (e.g. `^pipeline-cli-v([0-9].*)$`
+ * → prefix `pipeline-cli`). This grounds the guard's scope in the release pipeline's
+ * OWN source of truth (ADR 0201 §4) rather than a parallel hand-kept list — the
+ * criterion's "never a hardcoded ad-hoc list divorced from what actually publishes."
+ *
+ * Minimal and dependency-free: it keys on the regex-anchor form `^<prefix>-v(`, which
+ * is discriminating — the bare `pipeline-cli-v<version>` mentions in prose comments
+ * carry no leading `^` and no `(`, so they don't match.
+ */
+export const parsePublishedTagPrefixes = (workflowYaml: string): ReadonlyArray<string> => {
+	const out = new Set<string>();
+	const re = /\^([A-Za-z0-9][\w.-]*?)-v\(/g;
+	for (let m = re.exec(workflowYaml); m !== null; m = re.exec(workflowYaml)) {
+		if (m[1] !== undefined) out.add(m[1]);
+	}
+	return [...out].sort();
+};
+
+/** The outcome of mapping publish.yml's tag prefixes onto workspace members. */
+export interface PublishedResolution {
+	/** Members whose unscoped name matches a published tag prefix. */
+	readonly published: ReadonlyArray<PublishedManifest>;
+	/** Prefixes that matched no member — publish.yml/workspace drift; the gate fails closed on these. */
+	readonly unmatchedPrefixes: ReadonlyArray<string>;
+}
+
+/**
+ * Map the published tag prefixes onto the enumerated workspace members by unscoped
+ * package name (`@kampus/pipeline-cli`'s unscoped `pipeline-cli` matches the
+ * `pipeline-cli` tag). A prefix with no matching member is surfaced as drift so the
+ * gate can fail closed rather than silently narrow scope — keeping the derived set
+ * honest against publish.yml.
+ */
+export const resolvePublished = (
+	prefixes: ReadonlyArray<string>,
+	members: ReadonlyArray<PublishedManifest>,
+): PublishedResolution => {
+	const byUnscoped = new Map<string, Array<PublishedManifest>>();
+	for (const m of members) {
+		const key = unscopedName(m.name);
+		const bucket = byUnscoped.get(key);
+		if (bucket) bucket.push(m);
+		else byUnscoped.set(key, [m]);
+	}
+	const published: Array<PublishedManifest> = [];
+	const unmatchedPrefixes: Array<string> = [];
+	for (const prefix of prefixes) {
+		const hits = byUnscoped.get(prefix);
+		if (hits === undefined || hits.length === 0) unmatchedPrefixes.push(prefix);
+		else published.push(...hits);
+	}
+	return {published, unmatchedPrefixes};
+};
+
+/**
+ * Extract the `packages:` sequence globs from a `pnpm-workspace.yaml`'s text — the
+ * declared workspace shape the member scan grounds in, rather than a hardcoded literal.
+ * A minimal, dependency-free YAML slice (reads the top-level `packages:` block's
+ * `- <glob>` items, stops at the next top-level key); sufficient for this file's flat
+ * shape, not a general YAML parser.
+ */
+export const parseWorkspacePackageGlobs = (yaml: string): ReadonlyArray<string> => {
+	const out: Array<string> = [];
+	let inPackages = false;
+	for (const raw of yaml.split("\n")) {
+		const line = raw.replace(/\r$/, "");
+		if (/^packages:\s*$/.test(line)) {
+			inPackages = true;
+			continue;
+		}
+		if (!inPackages) continue;
+		if (/^\S/.test(line) && !line.startsWith("-")) break;
+		const m = /^\s*-\s*(.+?)\s*$/.exec(line);
+		if (m?.[1] !== undefined) out.push(m[1].replace(/^['"]|['"]$/g, ""));
+	}
+	return out;
+};
+
+/** Flatten a parsed `package.json` object into `DepEntry`s over the runtime dep fields only. */
+export const manifestRuntimeDeps = (pkg: Record<string, unknown>): ReadonlyArray<DepEntry> => {
+	const out: Array<DepEntry> = [];
+	for (const field of RUNTIME_DEP_FIELDS) {
+		const block = pkg[field];
+		if (block === null || typeof block !== "object") continue;
+		for (const [name, value] of Object.entries(block as Record<string, unknown>)) {
+			if (typeof value === "string") out.push({field, name, value});
+		}
+	}
+	return out;
+};

--- a/packages/pipeline-cli/src/tools/publish-isolation-guard/publish-isolation-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/publish-isolation-guard/publish-isolation-guard.unit.test.ts
@@ -1,0 +1,179 @@
+/**
+ * `publish-isolation-guard` pure-core tests (ADR 0201 §3, #3802) — the verdict logic
+ * over already-gathered facts: a clean runtime dep set passes, a `workspace:*` link or
+ * a private/unpublished `@kampus/*` dep fails, a published `@kampus/*` sibling passes,
+ * and an empty published set fails closed (ADR 0092). Plus the two derivation helpers:
+ * parsing publish.yml's tag grammar and mapping prefixes onto members. No disk — the
+ * IO seam is covered in `gate.unit.test.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	judge,
+	manifestRuntimeDeps,
+	type PublishedManifest,
+	parsePublishedTagPrefixes,
+	resolvePublished,
+	unscopedName,
+} from "./publish-isolation-guard.ts";
+
+const manifest = (
+	path: string,
+	name: string,
+	deps: PublishedManifest["deps"],
+): PublishedManifest => ({path, name, deps});
+
+describe("judge — the publish-isolation verdict", () => {
+	it("PASSES when every runtime dep is a public/catalog registry dep", () => {
+		const v = judge([
+			manifest("packages/pipeline-cli/package.json", "@kampus/pipeline-cli", [
+				{field: "dependencies", name: "effect", value: "catalog:"},
+				{field: "dependencies", name: "@effect/platform-node", value: "catalog:"},
+				{field: "dependencies", name: "yaml", value: "catalog:"},
+			]),
+		]);
+		expect(v.pass).toBe(true);
+	});
+
+	it("PASSES the current pipeline-crew-mcp-shaped clean graph", () => {
+		const v = judge([
+			manifest("packages/pipeline-crew-mcp/package.json", "@kampus/pipeline-crew-mcp", [
+				{field: "dependencies", name: "@effect/platform-node", value: "catalog:"},
+				{field: "dependencies", name: "effect", value: "catalog:"},
+				{field: "dependencies", name: "proper-lockfile", value: "catalog:"},
+			]),
+		]);
+		expect(v.pass).toBe(true);
+	});
+
+	it("FAILS on a workspace:* link, with kind workspace-link in the evidence (the #3802 class)", () => {
+		const v = judge([
+			manifest("packages/pipeline-cli/package.json", "@kampus/pipeline-cli", [
+				{field: "dependencies", name: "@kampus/epic-ledger", value: "workspace:*"},
+			]),
+		]);
+		expect(v.pass).toBe(false);
+		if (v.pass || v.reason !== "linked-private-deps")
+			throw new Error("expected linked-private-deps");
+		expect(v.violations).toEqual([
+			{
+				path: "packages/pipeline-cli/package.json",
+				field: "dependencies",
+				name: "@kampus/epic-ledger",
+				value: "workspace:*",
+				kind: "workspace-link",
+			},
+		]);
+	});
+
+	it("FAILS on a private @kampus dep pinned to a version (not published, not workspace:)", () => {
+		const v = judge([
+			manifest("packages/pipeline-cli/package.json", "@kampus/pipeline-cli", [
+				{field: "dependencies", name: "@kampus/leak-guard", value: "^1.0.0"},
+			]),
+		]);
+		expect(v.pass).toBe(false);
+		if (v.pass || v.reason !== "linked-private-deps")
+			throw new Error("expected linked-private-deps");
+		expect(v.violations[0]?.kind).toBe("private-kampus-dep");
+	});
+
+	it("scans optionalDependencies and peerDependencies, not just dependencies", () => {
+		const v = judge([
+			manifest("packages/pipeline-cli/package.json", "@kampus/pipeline-cli", [
+				{field: "optionalDependencies", name: "@kampus/optional-private", value: "workspace:*"},
+				{field: "peerDependencies", name: "@kampus/peer-private", value: "^2.0.0"},
+			]),
+		]);
+		expect(v.pass).toBe(false);
+		if (v.pass || v.reason !== "linked-private-deps")
+			throw new Error("expected linked-private-deps");
+		expect(v.violations.map((x) => x.field).sort()).toEqual([
+			"optionalDependencies",
+			"peerDependencies",
+		]);
+	});
+
+	it("PASSES a @kampus dep that is ITSELF in the published set", () => {
+		// Two published packages; one depends on the other by a registry version — resolvable.
+		const v = judge([
+			manifest("packages/pipeline-cli/package.json", "@kampus/pipeline-cli", [
+				{field: "dependencies", name: "@kampus/pipeline-crew-mcp", value: "^0.1.0"},
+			]),
+			manifest("packages/pipeline-crew-mcp/package.json", "@kampus/pipeline-crew-mcp", [
+				{field: "dependencies", name: "effect", value: "catalog:"},
+			]),
+		]);
+		expect(v.pass).toBe(true);
+	});
+
+	it("FAILS (fail-closed, zero-scope) when no published packages are in scope", () => {
+		const v = judge([]);
+		expect(v.pass).toBe(false);
+		if (v.pass) throw new Error("expected fail");
+		expect(v.reason).toBe("zero-scope");
+	});
+});
+
+describe("parsePublishedTagPrefixes — derive the published set from publish.yml", () => {
+	it("extracts the prefix from a `^<prefix>-v(...)` release-tag regex", () => {
+		const yaml = 'if [[ ! "$TAG" =~ ^pipeline-cli-v([0-9].*)$ ]]; then';
+		expect(parsePublishedTagPrefixes(yaml)).toEqual(["pipeline-cli"]);
+	});
+
+	it("ignores bare `pipeline-cli-v<version>` prose mentions (no ^ anchor, no capture group)", () => {
+		const yaml = "# Release tag grammar: `pipeline-cli-v<version>` (e.g. `pipeline-cli-v0.1.0`)";
+		expect(parsePublishedTagPrefixes(yaml)).toEqual([]);
+	});
+
+	it("dedupes and sorts multiple distinct prefixes", () => {
+		const yaml =
+			"=~ ^pipeline-crew-mcp-v([0-9].*)$ ... =~ ^pipeline-cli-v([0-9].*)$ ... =~ ^pipeline-cli-v(.*)$";
+		expect(parsePublishedTagPrefixes(yaml)).toEqual(["pipeline-cli", "pipeline-crew-mcp"]);
+	});
+});
+
+describe("resolvePublished — map prefixes onto members by unscoped name", () => {
+	const members: ReadonlyArray<PublishedManifest> = [
+		manifest("packages/pipeline-cli/package.json", "@kampus/pipeline-cli", []),
+		manifest("packages/pipeline-crew-mcp/package.json", "@kampus/pipeline-crew-mcp", []),
+		manifest("apps/web/package.json", "@kampus/web", []),
+	];
+
+	it("resolves a prefix to the member whose unscoped name matches", () => {
+		const {published, unmatchedPrefixes} = resolvePublished(["pipeline-cli"], members);
+		expect(published.map((m) => m.name)).toEqual(["@kampus/pipeline-cli"]);
+		expect(unmatchedPrefixes).toEqual([]);
+	});
+
+	it("surfaces a prefix with no matching member as drift (fail-closed signal)", () => {
+		const {published, unmatchedPrefixes} = resolvePublished(["does-not-exist"], members);
+		expect(published).toEqual([]);
+		expect(unmatchedPrefixes).toEqual(["does-not-exist"]);
+	});
+});
+
+describe("manifestRuntimeDeps — runtime fields only", () => {
+	it("reads dependencies / optionalDependencies / peerDependencies and IGNORES devDependencies", () => {
+		const deps = manifestRuntimeDeps({
+			dependencies: {a: "catalog:"},
+			optionalDependencies: {b: "^1.0.0"},
+			peerDependencies: {c: "workspace:*"},
+			devDependencies: {d: "workspace:*"},
+			scripts: {build: "tsc"},
+		});
+		expect(deps).toEqual([
+			{field: "dependencies", name: "a", value: "catalog:"},
+			{field: "optionalDependencies", name: "b", value: "^1.0.0"},
+			{field: "peerDependencies", name: "c", value: "workspace:*"},
+		]);
+	});
+});
+
+describe("unscopedName", () => {
+	it("strips the @scope/ prefix", () => {
+		expect(unscopedName("@kampus/pipeline-cli")).toBe("pipeline-cli");
+	});
+	it("returns an unscoped name unchanged", () => {
+		expect(unscopedName("effect")).toBe("effect");
+	});
+});


### PR DESCRIPTION
Fixes #3833

## What

Adds a fail-closed CI guard enforcing ADR 0201 §3's isolated-publishing mandate: every package the release pipeline (`publish.yml`) ships must be installable from a clean registry state — zero phoenix-private `@kampus/*` deps, no `workspace:*` links. Makes the #3802 class (`pipeline-cli@0.2.0` published green yet uninstallable because it declared three phoenix-private `workspace:*` packages as registry deps) unrepresentable.

## Shape (readme-guard / catalog-guard idiom, ADR 0092)

- **`pipeline-cli publish-isolation-guard check`** — new tool under `packages/pipeline-cli/src/tools/publish-isolation-guard/`: a pure, IO-free core (`publish-isolation-guard.ts`), a filesystem gate (`gate.ts`), and a thin `effect/unstable/cli` bin (`command.ts`), registered in the router (`registry.ts`).
- **`.github/workflows/publish-isolation-guard.yml`** — required job, same trigger/least-privilege shape as the sibling guards; runs `node packages/pipeline-cli/src/bin.ts publish-isolation-guard check`.

## Scope derivation (never a divorced list)

The published-package set is **derived from publish.yml's release-tag grammar** (`^<name>-v(...)$` → prefix `pipeline-cli`), mapped to workspace members by unscoped package name. A tag prefix that maps to no member is **drift** and fails closed. Today this resolves to `{@kampus/pipeline-cli}`; the guard runs green against it (its deps are all `catalog:`).

## The rule

For each published package, walk the runtime dep fields — `dependencies`, `optionalDependencies`, `peerDependencies` (**`devDependencies` are out of scope**: they don't ship in the tarball) — and red on:
- any `workspace:*` specifier (never resolvable from a registry), or
- any `@kampus/*` dep whose target is not itself in the published set (private/unpublished).

A `@kampus/*` dep that IS itself published passes. Fails closed on zero published packages (ADR 0092).

## Acceptance criteria

- [x] `pipeline-cli publish-isolation-guard check` tool exists (pure core + thin bin, registered in the router), readme-guard/catalog-guard idiom.
- [x] Published set derived from publish.yml's tag patterns — not a hardcoded ad-hoc list; drift fails closed.
- [x] Walks runtime dep fields (`dependencies`/`optional`/`peer`), reds on private `@kampus/*` or `workspace:*`; `devDependencies` excluded.
- [x] Fails closed on zero scope (ADR 0092).
- [x] `publish-isolation-guard.yml` runs the check as a required job, sibling-guard trigger shape.
- [x] Unit tests: green (clean graph, incl. the pipeline-crew-mcp shape), red on private `@kampus`/`workspace:*`, red on zero scope, red on drift.

## Verification

- 21 new unit tests pass (pure core + IO gate over a temp repo dir).
- `pnpm --filter @kampus/pipeline-cli typecheck` clean; biome clean.
- Guard runs green against the real repo (derives `@kampus/pipeline-cli`, confirms its deps are clean).

Campaign: Pipeline Anywhere (tracking #3827).

🤖 Generated with [Claude Code](https://claude.com/claude-code)