### PR TITLE
fix(leak-guard): transport-only retry + typed "unknown" outcome for scan-pr GH 5xx

### DIFF
--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -31,7 +31,7 @@ import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, CREW_DIR, sweepCrew} from "./crew-gate.ts";
-import {PrComments, PrCommentsLive} from "./github.ts";
+import {PrComments, PrCommentsLive, type UpstreamUnavailableError} from "./github.ts";
 import {findCommentLeaks, findLeaks, type Leak} from "./leak-guard.ts";
 import {scanPrComments} from "./scan-pr.ts";
 
@@ -39,6 +39,13 @@ import {scanPrComments} from "./scan-pr.ts";
 // could not complete, which the pre-commit hook treats as warn-and-allow while
 // CI treats as failure (issue #332).
 const LEAK_EXIT_CODE = 2;
+
+// 3 = the scan could not VERIFY — GitHub was transiently unavailable past the retry budget
+// (`scan-pr` only). Distinct from a leak (2) and a clean pass (0): it is one of the "any OTHER
+// non-zero = could not complete" codes, so the ship-it Step 3.7 gate still BLOCKS (fail-safe) —
+// a leak gate must never pass what it could not read — but legibly, never as an opaque stack
+// trace posing as a finding (issue #3710).
+const UPSTREAM_UNAVAILABLE_EXIT_CODE = 3;
 
 interface FileLeaks {
 	readonly file: string;
@@ -218,6 +225,18 @@ const prArg = Argument.integer("pr").pipe(
 	Argument.withDescription("the pull request number whose landed comments to scan for leaks"),
 );
 
+// The unknown outcome (#3710): GitHub stayed 5xx/unreachable past the retry budget, so the scan
+// could not READ the comments — NOT a leak finding. Print the fail-safe block reason legibly and
+// exit 3, distinct from a leak (2). Caught in-handler like LeakFound so no stack trace escapes.
+const onUpstreamUnavailable = (e: UpstreamUnavailableError) =>
+	Effect.sync(() => {
+		process.stderr.write(
+			`leak-guard: could not verify — GitHub upstream unavailable on PR #${e.pr} after ${e.attempts} attempts (${e.detail || `exit ${e.lastExitCode}`}).\n` +
+				"This is NOT a leak finding: the scan could not read the PR's comments. The merge is BLOCKED (fail-safe) until leaks can be verified — retry shortly.\n",
+		);
+		process.exit(UPSTREAM_UNAVAILABLE_EXIT_CODE);
+	});
+
 const scanPr = Command.make(
 	"scan-pr",
 	{pr: prArg},
@@ -242,7 +261,10 @@ const scanPr = Command.make(
 			);
 			return yield* Effect.fail(new LeakFound({count: leaks.length}));
 		});
-		yield* run.pipe(Effect.catchTag("LeakFound", onLeakFound));
+		yield* run.pipe(
+			Effect.catchTag("LeakFound", onLeakFound),
+			Effect.catchTag("@kampus/leak-guard/UpstreamUnavailableError", onUpstreamUnavailable),
+		);
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/leak-guard/github-transient.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/github-transient.unit.test.ts
@@ -1,0 +1,204 @@
+/**
+ * `leak-guard scan-pr` transient-GH resilience (#3710). Two contracts:
+ *
+ *   1. `isTransientGh` — the pure discrimination: a 5xx/429 or a transport reset is transient
+ *      (retry); a 4xx (auth/not-found) is a REAL terminal answer (fail fast, never masked).
+ *   2. `makePrCommentsLive` — the boundary rides out a transient blip with bounded backoff, and
+ *      a read still transient past the budget resolves to the typed `UpstreamUnavailableError`
+ *      (the third outcome), while a 4xx fails fast as a plain `GhCommandError` (unchanged).
+ *
+ * The retry schedule is injected as a zero-delay `Schedule.recurs` so the tests exercise the real
+ * retry path without real time (no TestClock dance): `recurs` has no delay, so it completes inline.
+ */
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Cause, Effect, Layer, Schedule, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	GhCommandError,
+	isTransientGh,
+	makePrCommentsLive,
+	PrComments,
+	UpstreamUnavailableError,
+} from "./github.ts";
+
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+describe("isTransientGh — 5xx/429/transport is transient, 4xx is terminal (#3710)", () => {
+	const gh = (exitCode: number, stderr: string) =>
+		new GhCommandError({args: ["api", "repos/x/y/pulls/1/comments"], exitCode, stderr});
+
+	it("retries the 5xx gateway/overload family", () => {
+		for (const status of [500, 502, 503, 504]) {
+			assert.isTrue(
+				isTransientGh(gh(1, `gh: HTTP ${status}: Service Unavailable`)),
+				`HTTP ${status}`,
+			);
+		}
+	});
+
+	it("retries a 429 rate-limit and a bare transport reset (exitCode -1)", () => {
+		assert.isTrue(isTransientGh(gh(1, "gh: HTTP 429: Too Many Requests")));
+		assert.isTrue(isTransientGh(gh(-1, "spawn failed: connection reset by peer")));
+		assert.isTrue(isTransientGh(gh(1, "error: read tcp: ECONNRESET")));
+		assert.isTrue(isTransientGh(gh(1, "dial tcp: i/o timeout")));
+	});
+
+	it("does NOT retry a 4xx — auth/not-found is a real terminal answer", () => {
+		for (const status of [401, 403, 404, 422]) {
+			assert.isFalse(isTransientGh(gh(1, `gh: HTTP ${status}: Not Found`)), `HTTP ${status}`);
+		}
+	});
+
+	it("does NOT match a 5xx-looking number that is not an HTTP status (no false positive)", () => {
+		assert.isFalse(isTransientGh(gh(1, "gh: issue 503 was closed")));
+	});
+});
+
+// ── boundary retry behavior over a stateful mock spawner ────────────────────────────────────
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+
+const enc = new TextEncoder();
+
+const handleFor = (canned: Canned) =>
+	ChildProcessSpawner.makeHandle({
+		pid: ChildProcessSpawner.ProcessId(1),
+		stdin: Sink.drain,
+		stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+		stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+		all: Stream.fromIterable([enc.encode(canned.stdout)]),
+		exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+		isRunning: Effect.succeed(false),
+		kill: () => Effect.void,
+		getInputFd: () => Sink.drain,
+		getOutputFd: () => Stream.empty,
+		unref: Effect.succeed(Effect.void),
+	});
+
+const P = "repos/kamp-us/phoenix";
+const PR = 3710;
+
+/**
+ * A spawner answering each `gh api GET <path>` from a per-path SEQUENCE of canned responses (the
+ * last entry repeats once its queue drains), tracking per-path call counts so a test can assert
+ * how many times a path was hit — the proof a 4xx is NOT retried. The whole fetch is re-run on
+ * retry, so the issue path is set to a repeating 200 while the review path carries the sequence.
+ */
+const sequenceSpawner = (sequences: Record<string, ReadonlyArray<Canned>>) => {
+	const calls: Record<string, number> = {};
+	const layer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const rawPath =
+					args.find((a) => a.startsWith("repos/")) ??
+					(args[0] === "api" ? (args[1] ?? "") : args.slice(0, 2).join(" "));
+				const path = rawPath.replace(/\?.*$/, "");
+				const seq = sequences[`GET ${path}`];
+				if (seq === undefined) {
+					return handleFor({stdout: "", exitCode: 1, stderr: `not found: GET ${path}`});
+				}
+				const i = calls[path] ?? 0;
+				calls[path] = i + 1;
+				return handleFor(seq[Math.min(i, seq.length - 1)] ?? {stdout: ""});
+			}),
+		),
+	);
+	return {layer, calls};
+};
+
+const OK_EMPTY = {stdout: "[]"};
+const OK_ISSUE = {stdout: JSON.stringify([{id: 1, body: "review-code: PASS @ abc1234"}])};
+const OK_REVIEW = {stdout: JSON.stringify([{id: 2, body: "looks good"}])};
+const GH_503 = {stdout: "", exitCode: 1, stderr: "gh: HTTP 503: Service Unavailable"};
+const GH_404 = {stdout: "", exitCode: 1, stderr: "gh: HTTP 404: Not Found"};
+
+// Zero-delay budget so the real retry path runs without real time (recurs has no backoff delay).
+const FAST_SCHEDULE = Schedule.recurs(4);
+
+const runFetch = (sequences: Record<string, ReadonlyArray<Canned>>) => {
+	const {layer, calls} = sequenceSpawner(sequences);
+	const exit = Effect.runPromiseExit(
+		PrComments.pipe(
+			Effect.flatMap((svc) => svc.fetch(PR)),
+			Effect.provide(makePrCommentsLive(FAST_SCHEDULE).pipe(Layer.provide(layer))),
+		),
+	);
+	return {exit, calls};
+};
+
+describe("makePrCommentsLive — transient retry + unknown outcome (#3710)", () => {
+	it("rides out a 503-then-200 on the review-comments read (retry succeeds)", async () => {
+		const {exit, calls} = runFetch({
+			[`GET ${P}/issues/${PR}/comments`]: [OK_ISSUE],
+			[`GET ${P}/pulls/${PR}/comments`]: [GH_503, OK_REVIEW],
+		});
+		const result = await exit;
+		assert.strictEqual(result._tag, "Success");
+		if (result._tag === "Success") {
+			assert.deepStrictEqual(
+				result.value.map((c) => ({id: c.id, kind: c.kind})),
+				[
+					{id: 1, kind: "issue"},
+					{id: 2, kind: "review"},
+				],
+			);
+		}
+		// The review path was hit twice: the 503, then the 200 on retry.
+		assert.strictEqual(calls[`${P}/pulls/${PR}/comments`], 2);
+	});
+
+	it("a sustained 5xx resolves to UpstreamUnavailableError (the third outcome, gate blocks)", async () => {
+		const {exit} = runFetch({
+			[`GET ${P}/issues/${PR}/comments`]: [OK_ISSUE],
+			[`GET ${P}/pulls/${PR}/comments`]: [GH_503],
+		});
+		const result = await exit;
+		assert.strictEqual(result._tag, "Failure");
+		if (result._tag === "Failure") {
+			const error = Cause.squash(result.cause);
+			assert.isTrue(
+				error instanceof UpstreamUnavailableError,
+				"a sustained 5xx must resolve to the typed unknown outcome, not a raw GhCommandError",
+			);
+			if (error instanceof UpstreamUnavailableError) {
+				assert.strictEqual(error.pr, PR);
+				assert.strictEqual(error.attempts, 5);
+				assert.include(error.detail, "503");
+			}
+		}
+	});
+
+	it("a 4xx (404) fails FAST as a terminal GhCommandError — never retried, never masked", async () => {
+		const {exit, calls} = runFetch({
+			[`GET ${P}/issues/${PR}/comments`]: [OK_EMPTY],
+			[`GET ${P}/pulls/${PR}/comments`]: [GH_404],
+		});
+		const result = await exit;
+		assert.strictEqual(result._tag, "Failure");
+		if (result._tag === "Failure") {
+			const error = Cause.squash(result.cause);
+			assert.isTrue(
+				error instanceof GhCommandError,
+				"a 404 stays a terminal GhCommandError, not the transient unknown outcome",
+			);
+		}
+		// Hit exactly once — a terminal 4xx is not re-driven by the retry.
+		assert.strictEqual(calls[`${P}/pulls/${PR}/comments`], 1);
+	});
+});

--- a/packages/pipeline-cli/src/tools/leak-guard/github.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/github.ts
@@ -9,7 +9,7 @@
  * resolved once per ADR 0062 §1, every infra fault a typed error) — a deliberately separate, minimal
  * boundary: this tool only READS the two comment endpoints, it never posts.
  */
-import {Context, Effect, Layer, Stream} from "effect";
+import {Context, Effect, Layer, Schedule, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import type {PrComment} from "./scan-pr.ts";
@@ -40,6 +40,48 @@ export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionE
 		message: Schema.String,
 	},
 ) {}
+
+/**
+ * The scan could not READ the PR's comments — GitHub was transiently unavailable (5xx / a
+ * transport reset) and stayed so past the bounded retry budget. The THIRD outcome the scan
+ * needs (#3710): distinct from a clean pass, a real leak finding (`LeakFound`), AND a terminal
+ * `GhCommandError` (auth/not-found). At the ship-it Step 3.7 gate this fails SAFE — a leak gate
+ * must never PASS what it could not verify — but legibly ("could not verify, retry"), never as
+ * an opaque stack trace posing as a finding.
+ */
+export class UpstreamUnavailableError extends Schema.TaggedErrorClass<UpstreamUnavailableError>()(
+	"@kampus/leak-guard/UpstreamUnavailableError",
+	{
+		pr: Schema.Number,
+		attempts: Schema.Number,
+		lastExitCode: Schema.Number,
+		detail: Schema.String,
+	},
+) {}
+
+// A transient upstream status worth retrying: the 5xx gateway/overload family plus 429
+// (rate limit). Anything else — 401/403/404/422 — is a REAL terminal answer and stays
+// fatal-fast, so a genuine auth/not-found error is never masked as a blip (issue #3710
+// scope guard; the same 429+5xx set orphan-sweep's `RETRYABLE_STATUSES` retries).
+const TRANSIENT_HTTP_STATUS_RE = /\bHTTP\s+(429|5\d\d)\b/i;
+// Network/transport faults `gh` surfaces without an HTTP status — the read never reached
+// GitHub, so it proved nothing and is retryable like a 5xx. `exitCode === -1` is our own
+// PlatformError mapping (spawn/transport failure), a transient by construction.
+const TRANSIENT_TRANSPORT_RE =
+	/\b(ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|ENOTFOUND|connection reset|connection refused|timed?\s*out|TLS handshake|i\/o timeout|network is unreachable|temporary failure|EOF occurred)\b/i;
+
+/**
+ * Is this `gh` failure a TRANSIENT transport/availability blip (retry) rather than a terminal
+ * answer (fail fast)? Pure and total over the captured error, so the discrimination is the
+ * unit-tested contract. Mirrors `orphan-heal`'s `provesAbsent` inverse: only a positive
+ * transient signal (5xx/429, a transport reset, or our `-1` PlatformError code) is retried;
+ * every other exit — a 4xx, a decode/logic error — is terminal and passes through unchanged.
+ */
+export const isTransientGh = (error: GhCommandError): boolean => {
+	if (error.exitCode === -1) return true;
+	const stderr = error.stderr ?? "";
+	return TRANSIENT_HTTP_STATUS_RE.test(stderr) || TRANSIENT_TRANSPORT_RE.test(stderr);
+};
 
 const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
 	Stream.decodeText(stream).pipe(
@@ -151,40 +193,92 @@ export class PrComments extends Context.Service<
 			pr: number,
 		) => Effect.Effect<
 			ReadonlyArray<PrComment>,
-			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+			| RepoResolutionError
+			| GhCommandError
+			| GhParseError
+			| Schema.SchemaError
+			| UpstreamUnavailableError
 		>;
 	}
 >()("@kampus/leak-guard/PrComments") {}
 
+// Bounded exponential backoff for the comment read: ~0.5s, 1, 2, 4s across up to 4 retries
+// (5 attempts total, ~7.5s worst case) — enough to ride out a transient GH 5xx blip without
+// holding the ship-it gate open through a sustained outage. Grounded in effect-smol `LLMS.md`
+// §"Working with Schedules" (`Schedule.both(exponential, recurs(N))` = capped backoff), the
+// same idiom as `apps/web/worker/features/fate-live/cold-start-retry.ts` and
+// `packages/orphan-sweep/src/cloudflare.ts`.
+const MAX_RETRIES = 4;
+const RETRY_ATTEMPTS = MAX_RETRIES + 1;
+const DEFAULT_RETRY_SCHEDULE = Schedule.both(
+	Schedule.exponential("500 millis"),
+	Schedule.recurs(MAX_RETRIES),
+);
+
+type FetchError = GhCommandError | GhParseError | Schema.SchemaError;
+
+/** A `gh` read that failed transient — the only class the retry re-drives / the unknown seam converts. */
+const isTransientFetchError = (error: FetchError): error is GhCommandError =>
+	error._tag === "@kampus/leak-guard/GhCommandError" && isTransientGh(error);
+
+/** First non-empty stderr line, trimmed — a legible reason for the unknown outcome, never a dump. */
+const firstLine = (text: string): string => (text.split("\n")[0] ?? "").trim().slice(0, 200);
+
 /**
- * The live `PrComments` layer. `ChildProcessSpawner` is captured once at construction and provided
- * into each method, so the public method carries `R = never`. Repo resolution is deferred to first
- * use (`Effect.cached`, ADR 0062 §1) — the layer build is side-effect-free.
+ * The `PrComments` layer, parameterized by its retry schedule so a unit test can inject a
+ * zero-delay budget (the production default is {@link DEFAULT_RETRY_SCHEDULE}). `ChildProcessSpawner`
+ * is captured once at construction and provided into each method, so the public method carries
+ * `R = never`. Repo resolution is deferred to first use (`Effect.cached`, ADR 0062 §1) — the layer
+ * build is side-effect-free.
  */
+export const makePrCommentsLive = (
+	retrySchedule: Schedule.Schedule<unknown, unknown> = DEFAULT_RETRY_SCHEDULE,
+): Layer.Layer<PrComments, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.effect(PrComments)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				fetch: (pr) =>
+					repo.pipe(
+						Effect.flatMap((r) =>
+							withSpawner(
+								Effect.gen(function* () {
+									const issue = yield* fetchComments(issueCommentsArgs(r, pr), "issue");
+									const review = yield* fetchComments(reviewCommentsArgs(r, pr), "review");
+									return [...issue, ...review];
+								}),
+							).pipe(
+								// Ride out a transient 5xx / transport blip with bounded backoff. A 4xx (auth /
+								// not-found) or a decode error is NOT transient, so `while` is false and it fails
+								// fast — a real terminal error is never masked as a retry.
+								Effect.retry({schedule: retrySchedule, while: isTransientFetchError}),
+								// A read STILL transient past the budget is the third outcome: map it to the typed
+								// UpstreamUnavailableError so the gate blocks legibly (fail-safe), never on a raw
+								// GhCommandError stack trace conflated with a leak finding (#3710).
+								Effect.catchIf(isTransientFetchError, (error) =>
+									Effect.fail(
+										new UpstreamUnavailableError({
+											pr,
+											attempts: RETRY_ATTEMPTS,
+											lastExitCode: error.exitCode,
+											detail: firstLine(error.stderr),
+										}),
+									),
+								),
+							),
+						),
+					),
+			};
+		}),
+	);
+
+/** The production `PrComments` layer — the bounded-backoff retry over the real GH boundary. */
 export const PrCommentsLive: Layer.Layer<
 	PrComments,
 	never,
 	ChildProcessSpawner.ChildProcessSpawner
-> = Layer.effect(PrComments)(
-	Effect.gen(function* () {
-		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-		const withSpawner = <A, E>(
-			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
-		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
-		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
-		return {
-			fetch: (pr) =>
-				repo.pipe(
-					Effect.flatMap((r) =>
-						withSpawner(
-							Effect.gen(function* () {
-								const issue = yield* fetchComments(issueCommentsArgs(r, pr), "issue");
-								const review = yield* fetchComments(reviewCommentsArgs(r, pr), "review");
-								return [...issue, ...review];
-							}),
-						),
-					),
-				),
-		};
-	}),
-);
+> = makePrCommentsLive();


### PR DESCRIPTION
Fixes #3710

## Problem

`leak-guard scan-pr` (the ship-it Step 3.7 merge gate) turned **any** non-zero `gh` exit straight into a terminal `GhCommandError`. So a transient GitHub 5xx — a live 503 outage lasted 7+ minutes while shipping #3699 — hard-blocked an otherwise-green merge with an **opaque stack trace indistinguishable from a real leak finding**. The operator couldn't tell "I couldn't check" from "I found a leak", and it trains readers to ignore a security gate's failure output.

## Fix (transport-only retry + a distinct third outcome)

- **`isTransientGh`** — a pure, unit-tested discrimination at the `gh` boundary: a 5xx / 429, or a transport reset (`ECONNRESET` / timeout / our `-1` PlatformError code) is **transient** (retry); a **4xx** (auth / not-found) is a real terminal answer that stays **fatal-fast** and is never masked. Mirrors the inverse of `orphan-heal`'s `provesAbsent`.
- **Bounded backoff on the comment read** — `Schedule.both(exponential, recurs)` + `Effect.retry({schedule, while: isTransientGh})`, the effect-smol idiom already used by `apps/web/worker/features/fate-live/cold-start-retry.ts` and `packages/orphan-sweep/src/cloudflare.ts`. Only the transient class is re-driven; a 4xx or a decode error fails fast. The schedule is injected into the layer (`makePrCommentsLive`) so the tests run the real retry path at **zero delay**.
- **The third outcome** — a read still transient past the retry budget resolves to the typed `UpstreamUnavailableError`. `scan-pr` surfaces it as **exit 3** with a legible `could not verify — GitHub upstream unavailable … retry shortly` message, never a raw stack trace conflated with a leak. Because the ship-it Step 3.7 gate refuses on **any** non-zero `scan-pr`, this **blocks the merge (fail-safe)** — a leak gate must never pass what it could not read — but legibly.
- A real leak (**exit 2**) and a real terminal 4xx (fatal-fast `GhCommandError`) are **unchanged**.

## Tests (`github-transient.unit.test.ts`)

- `isTransientGh` matrix: 500/502/503/504 + 429 + transport reset → transient; 401/403/404/422 → terminal; a bare "503" that isn't an HTTP status → no false positive.
- **503-then-200** on the review-comments read → retry rides it out (path hit twice, success).
- **Sustained 5xx** → `UpstreamUnavailableError` (pr/attempts/detail carried) → gate blocks.
- **404** → fails fast as a terminal `GhCommandError`, hit **once** (proof it is not retried).

Full `leak-guard` suite (114 tests), `pipeline-cli` typecheck, and biome are green locally.

## Notes / follow-up

- The AC's "legible unknown message" is satisfied by `scan-pr`'s own stderr line. ship-it's generic pre-enqueue refusal still says "a landed comment carries a machine-local path" — tightening that copy to distinguish leak-vs-could-not-verify is a small `ship-it/SKILL.md` follow-up, out of this tool's scope.
- Part of the transient-GH-resilience cluster (#3701 / #3715 / #3716 / #3719); each tool's fix stands alone, retry shape kept consistent across them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
