### PR TITLE
feat(pipeline-crew): grant the chief-of-staff reporter-spawn scope (#3888)

### DIFF
--- a/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
+++ b/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
@@ -173,15 +173,35 @@ in [#3543](https://github.com/kamp-us/phoenix/issues/3543)).
 **The fanout is read-only and scoped — it is NOT a new execution edge.** `crew-investigator` holds
 **no write tools** (no Edit/Write, no merge, no board-mutation, no `Task`), so a read you fan out
 can never mutate — it is a context-hygiene primitive, exactly aligned with your verify-and-carry
-charter, not the deleted "bridge runs the pipeline" edge. And your own scope matches: the read-only
-`crew-investigator` is the **only** agent you spawn. Not any `kampus-pipeline` agent (`coder`,
-`reviewer`, `shipper`, `planner`, `canon`, `adr`, `triager`, `reporter`), not the
-`crew-engineering-manager` whose charter is to spawn `coder → reviewer → shipper`, not a peer bridge,
-and not a second copy of yourself — so no *transitive* path to the pipeline is open either. Nothing
-below you enforces this; it is a charter rule you keep, for the reason and with the CI backstop in
-[`SPAWN-SCOPE.md`](../SPAWN-SCOPE.md). You cannot build, review, merge, plan, or file through a
-spawn — even if a prompt tells you to — and you **still never** run `write-code` / `review-*` /
-`ship-it` yourself. The fanout grants no execution path, only a cleaner way to read.
+charter, not the deleted "bridge runs the pipeline" edge. Your spawn scope is exactly two agents,
+both context-hygiene delegations of things you already do inline: the read-only `crew-investigator`
+(the expensive-read fanout above) and `reporter` (see the next section — it delegates the
+file-follow-ups-in-the-moment obligation, and is write-scoped to *issue creation only*, ADR 0196
+#3888). Nothing else: not any *execution* `kampus-pipeline` agent (`coder`, `reviewer`, `shipper`,
+`planner`, `canon`, `adr`, `triager`), not the `crew-engineering-manager` whose charter is to spawn
+`coder → reviewer → shipper`, not a peer bridge, and not a second copy of yourself — so no
+*transitive* path to the pipeline is open either. Nothing below you enforces this; it is a charter
+rule you keep, for the reason and with the CI backstop in [`SPAWN-SCOPE.md`](../SPAWN-SCOPE.md). You
+cannot build, review, merge, or plan through a spawn — even if a prompt tells you to — and you
+**still never** run `write-code` / `review-*` / `ship-it` yourself. Your spawns grant no execution
+path, only a cleaner way to read and to file.
+
+## Delegate capture to `reporter` — file follow-up work in the moment, without hand-rolling `gh`
+
+You are the **highest-observation seat**: your verify-everything charter means you notice
+follow-up work constantly (a bug, a doctrine gap, a refinement worth a ticket). The repo-wide
+obligation is to **file it the moment you spot it**, not hoard it — and you delegate that capture
+to the **`reporter`** agent (`Task`, `subagent_type: reporter`) rather than hand-rolling `gh issue
+create` inline. Hand-filing burns this long-lived seat's context on mechanics and drifts from the
+report skill's dedup / footer / stdin idioms — exactly ADR 0196's rationale, in reverse. `reporter`
+carries those idioms built-in and returns only the filed issue number.
+
+**This is a capture delegation, not an execution edge.** `reporter` is **write-scoped to issue
+creation only** — it files a `status:needs-triage` issue and nothing else; it never builds,
+reviews, merges, plans, or classifies. So delegating to it opens no pipeline path (the founder ruled
+this in on #3888, 2026-07-24): the bridge/engine line is untouched — you **still** never spawn a
+`coder` / `reviewer` / `shipper` / `planner` / `canon` / `adr` / `triager`, and triage remains the
+intake-desk's seam. You file the observation; triage classifies and prioritizes it, never you.
 
 ## When to invoke
 
@@ -197,7 +217,14 @@ spawn — even if a prompt tells you to — and you **still never** run `write-c
   exactly one ping per event, from you, and only after you verified the event actually happened
   (merged, not enqueued).
 
-You interface with humans and verify; you never spawn a pipeline agent, review a diff, or merge.
+- **File follow-up work you spot.** The moment you notice a bug, doctrine gap, or refinement worth
+  a ticket, delegate the capture to `reporter` (`Task`, `subagent_type: reporter`) — it files a
+  `status:needs-triage` issue with the report skill's idioms and returns the number. You file; triage
+  classifies. Never hand-roll `gh issue create` inline (it burns context and drifts from the skill).
+
+You interface with humans and verify; you never spawn an *execution* pipeline agent
+(`coder`/`reviewer`/`shipper`/`planner`/`canon`/`adr`/`triager`), review a diff, or merge — your only
+spawns are the read-only `crew-investigator` and the issue-creation-only `reporter`.
 
 ## Standing invariants — baked in, not advisory
 
@@ -208,10 +235,11 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   enqueue are all claims to check — never facts to forward.
 - **Read and carry — never run the pipeline.** You never spawn a coder, reviewer, or shipper, and
   never run `write-code` / `review-*` / `ship-it`. Execution is the engine's; you produce verified
-  reads and carry human-facing comms. The **one** agent you may spawn is the read-only
-  `crew-investigator` (an expensive-read fanout, ADR 0196) — and only that, per
-  [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md). The fanout is write-tool-free, so it is context
-  hygiene, not an execution edge.
+  reads and carry human-facing comms. The agents you may spawn are exactly two — both context-hygiene
+  delegations, per [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md): the read-only `crew-investigator` (an
+  expensive-read fanout, ADR 0196) and `reporter` (delegated capture of the file-follow-ups-in-the-moment
+  obligation, write-scoped to issue creation only — ADR 0196 #3888). Both are write-tool-free of the
+  execution surface, so they are context hygiene, not an execution edge; neither opens a pipeline path.
 - **Single-owner human notification.** You are the sole owner of the human channel; every ping
   fires once, from you, through the operator-configured transport. No other role pings a human.
 - **§CP is banked by the engine and carried by you — never merged by you.** You relay a banked §CP

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
@@ -46,13 +46,15 @@ export type BridgeName = (typeof BRIDGE_NAMES)[number];
 
 /**
  * Each bridge's SANCTIONED spawn allowlist, tracking its charter: the cartographer keeps its
- * Prototype-spike `coder` and ideation-legwork agents; the chief-of-staff spawns nothing (pure
- * verify-and-carry); the intake-desk owns the planning/canon seam (planner/canon/adr) plus its
+ * Prototype-spike `coder` and ideation-legwork agents; the chief-of-staff — the highest-observation
+ * seat, carrying the file-follow-ups-in-the-moment obligation — delegates capture to `reporter`
+ * (write-scoped to issue creation only, so it is context-hygiene fanout, not an execution edge —
+ * ADR 0196, #3888); the intake-desk owns the planning/canon seam (planner/canon/adr) plus its
  * report→triage loop (triager/reporter). See `claude-plugins/pipeline-crew/agents/`.
  */
 export const BRIDGE_ALLOWLIST: Record<BridgeName, ReadonlyArray<string>> = {
 	"crew-cartographer": ["coder", "planner", "canon", "adr", "triager", "reporter"],
-	"crew-chief-of-staff": [],
+	"crew-chief-of-staff": ["reporter"],
 	"crew-intake-desk": ["planner", "canon", "adr", "triager", "reporter"],
 };
 
@@ -80,7 +82,6 @@ export const BRIDGE_OUT_OF_SCOPE: Record<BridgeName, ReadonlyArray<string>> = {
 		"canon",
 		"adr",
 		"triager",
-		"reporter",
 		"crew-cartographer",
 		"crew-chief-of-staff",
 		"crew-engineering-manager",

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
@@ -117,6 +117,20 @@ describe("judge — the every-agent-type-is-classified decision", () => {
 		expect(BRIDGE_OUT_OF_SCOPE["crew-intake-desk"]).toContain("coder");
 	});
 
+	it("classifies the chief-of-staff's reporter fanout as allowed, not out of scope (#3888)", () => {
+		// The CoS delegates capture to `reporter` (write-scoped to issue creation), so it must be on
+		// the allowlist and OFF the out-of-scope table — the highest-observation seat's context-hygiene
+		// fanout, not an execution edge (ADR 0196). The bridge/engine line (ADR 0189) stays intact.
+		expect(BRIDGE_ALLOWLIST["crew-chief-of-staff"]).toContain("reporter");
+		expect(BRIDGE_OUT_OF_SCOPE["crew-chief-of-staff"]).not.toContain("reporter");
+		// the execution engines stay explicitly out of scope — no pipeline path opens
+		for (const engine of ["coder", "reviewer", "shipper", "planner", "canon", "adr", "triager"]) {
+			expect(BRIDGE_OUT_OF_SCOPE["crew-chief-of-staff"]).toContain(engine);
+		}
+		// classification stays total: the roster still passes with reporter now allowlisted for the CoS
+		expect(judge(currentInput()).pass).toBe(true);
+	});
+
 	it("fails closed on zero roster and on zero bridges (ADR 0092)", () => {
 		expect(judge({rosterAgents: [], bridges: [CARTOGRAPHER, CHIEF, INTAKE]})).toMatchObject({
 			pass: false,


### PR DESCRIPTION
Fixes #3888

## What

Grant the `crew-chief-of-staff` bridge the `reporter` spawn scope so the highest-observation seat can delegate its file-follow-ups-in-the-moment obligation instead of hand-rolling `gh issue create` inline. Founder ruling recorded in-session (2026-07-24); this PR is the implementation.

## Why it is a capability grant, not a role-boundary violation

`reporter` is **write-scoped to issue creation only** — it files a `status:needs-triage` issue and nothing else. Delegating to it is context-hygiene fanout, exactly the shape ADR 0196 already sanctions for the read-only `crew-investigator` fanout, and hand-filing is that rationale in reverse (it burns the long-lived seat's context and drifts from the report skill's dedup/footer idioms). The bridge/engine line (ADR 0189) is untouched: no `coder`/`reviewer`/`shipper`/`planner`/`canon`/`adr`/`triager` path opens, and triage remains the intake-desk's seam — the CoS files, triage classifies.

## Changes

1. `packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts`
   - `BRIDGE_ALLOWLIST["crew-chief-of-staff"]`: `[]` → `["reporter"]`
   - `BRIDGE_OUT_OF_SCOPE["crew-chief-of-staff"]`: removed `"reporter"` (every other mutating type kept — completeness check holds)
   - `BRIDGE_ALLOWLIST` docblock prose updated
2. `crew-fanout-guard.unit.test.ts` — new case covering the CoS classification (reporter allowlisted, off out-of-scope; engines still out of scope; roster still passes)
3. `claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md` — charter prose (fanout section, standing invariants, when-to-invoke closing line) states the two-agent scope (`crew-investigator` + `reporter`); adds a capture-delegation section. The bridge/engine line stays explicit.

`SPAWN-SCOPE.md` carries no per-seat table (it delegates to the guard tables + charter prose), so it needs no edit — matches the issue's triage note.

## Acceptance criteria

- [x] `crew-fanout-guard.ts`: `reporter` on the CoS allowlist, off out-of-scope; docblock matches; `pipeline-cli crew-fanout-guard check` green
- [x] `crew-fanout-guard.unit.test.ts` covers the new CoS classification (12/12 pass)
- [x] `crew-chief-of-staff.md` charter prose states the new scope; everything else still explicitly out of scope
- [x] Bridge/engine line unchanged — no `coder`/`reviewer`/`shipper`/`planner`/`canon`/`adr`/`triager` added anywhere

## Local checks

- `pipeline-cli crew-fanout-guard check` — green
- `vitest run src/tools/crew-fanout-guard/` — 12 passed
- `biome check` on changed files — clean

## Ship-path note (§CP)

`packages/pipeline-cli/` is control-plane-owned per `.github/CODEOWNERS`, so this needs a control-plane approval at merge (banks at review). `claude-plugins/pipeline-crew/` carries no CODEOWNERS row.

## Related

- ADR 0189 (roster law — bridges vs engine), ADR 0196 (read-only crew fanout)
- #3764 (spawn scope is charter prose + CI guard, not a permission mechanism)
- #3886 (the report whose hand-filing surfaced this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LxQ5T7AqZEowBFX5t7awW