### PR TITLE
chore(pipeline-cli): migrate design/docs/roadmap guards to the v4 Effect platform idiom (#3470)

### DIFF
--- a/packages/pipeline-cli/src/tools/design-token-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/command.ts
@@ -25,25 +25,33 @@
  * inside the handler (not at the bin's run boundary) so the contract survives folding
  * into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkDesignTokens, writeBaseline} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). A marker-existence fault falls through as
+// false, matching the old `existsSync`; the walk falls back to the start on no hit.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -54,8 +62,10 @@ const writeBaselineFlag = Flag.boolean("write-baseline").pipe(
 	Flag.withDescription("regenerate the raw-px ceilings from the current tree instead of checking"),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
@@ -70,7 +80,7 @@ const check = Command.make(
 	"check",
 	{root: rootFlag, writeBaseline: writeBaselineFlag},
 	Effect.fn(function* ({root: rootOpt, writeBaseline: doWrite}) {
-		const root = resolveRoot(rootOpt);
+		const root = yield* resolveRoot(rootOpt);
 		if (doWrite) {
 			yield* writeBaseline(root);
 			return;

--- a/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
@@ -78,11 +78,18 @@ const walkCss = (fs: FileSystem.FileSystem, path: Path.Path, base: string) =>
 			if (dir === undefined) break;
 			for (const name of yield* fs.readDirectory(dir)) {
 				const abs = path.join(dir, name);
-				// A failing stat is a broken symlink (or an entry racing an unlink) — skip it, as
-				// the dirent walk silently did; surfacing it as `IoError` would let one dangling
-				// link anywhere under the root red the whole gate.
+				// A failing stat is a dangling symlink (or an entry racing an unlink). The dirent
+				// walk classified it by NAME alone, and the two halves differ: a `*.css` one was
+				// pushed and then hard-failed at `readFileSync` (`IoError`, exit 1 — the
+				// tree-corruption alarm), while a non-`.css` one matched neither arm and was
+				// silently ignored. Push it here to reproduce that alarm at the read; skipping it
+				// would turn a CSS file replaced by a dangling link from "gate reds" into
+				// "file silently leaves scope".
 				const stat = yield* Effect.option(fs.stat(abs));
-				if (Option.isNone(stat)) continue;
+				if (Option.isNone(stat)) {
+					if (name.endsWith(".css")) found.push(abs);
+					continue;
+				}
 				if (stat.value.type === "Directory") {
 					if (name === "node_modules" || name === "dist") continue;
 					// `readLink` succeeds only on a symlink, so success here means "symlinked dir".

--- a/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
@@ -14,10 +14,13 @@
  *
  * `writeBaseline` regenerates the `rawPxCeilings` map from the current tree (the
  * `--write-baseline` ergonomic), preserving every other config field and note.
+ *
+ * All directory/file/path IO goes through the Effect `FileSystem`/`Path` seam (over
+ * the bin's `NodeServices.layer`), so a gate `unit` test crosses an in-memory/real fs
+ * rather than welding to `node:fs` — see `.patterns/effect-platform-access.md`. A fs
+ * fault folds `PlatformError` → the `IoError` this gate already carries.
  */
-import {readdirSync, readFileSync, writeFileSync} from "node:fs";
-import {join, relative, sep} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	type CssFileFacts,
@@ -41,57 +44,83 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 	reason: Schema.String,
 }) {}
 
-const CSS_ROOT = join("apps", "web", "src");
-const CONFIG_PATH = join("apps", "web", "src", "styles", "design-token-lint.config.json");
+const CSS_ROOT = "apps/web/src";
+const CONFIG_PATH = "apps/web/src/styles/design-token-lint.config.json";
 /** The one file where hex + raw px legitimately live — the raw-scale layer. */
-const RAW_LAYER = join("apps", "web", "src", "styles", "tokens.css");
+const RAW_LAYER = "apps/web/src/styles/tokens.css";
 
 /** Repo-relative POSIX path — the key the ceilings map and reports use. */
-const toRel = (root: string, abs: string): string => relative(root, abs).split(sep).join("/");
+const toRel = (path: Path.Path, root: string, abs: string): string =>
+	path.relative(root, abs).split(path.sep).join("/");
 
-const walkCss = (dir: string, acc: Array<string>): void => {
-	for (const entry of readdirSync(dir, {withFileTypes: true})) {
-		const abs = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			if (entry.name === "node_modules" || entry.name === "dist") continue;
-			walkCss(abs, acc);
-		} else if (entry.name.endsWith(".css")) {
-			acc.push(abs);
+/**
+ * Enumerate every `*.css` under `base` (skipping `node_modules`/`dist`), walking the
+ * tree through the `fs`/`path` seam. Iterative (an explicit stack) rather than
+ * recursive; discovery order is irrelevant — the core sorts every reported list and
+ * counts the rest, so the verdict is order-independent.
+ */
+const walkCss = (fs: FileSystem.FileSystem, path: Path.Path, base: string) =>
+	Effect.gen(function* () {
+		const found: Array<string> = [];
+		const stack = [base];
+		for (;;) {
+			const dir = stack.pop();
+			if (dir === undefined) break;
+			for (const name of yield* fs.readDirectory(dir)) {
+				const abs = path.join(dir, name);
+				if ((yield* fs.stat(abs)).type === "Directory") {
+					if (name === "node_modules" || name === "dist") continue;
+					stack.push(abs);
+				} else if (name.endsWith(".css")) {
+					found.push(abs);
+				}
+			}
 		}
-	}
-};
+		return found;
+	});
 
 /** Enumerate + parse every CSS file under `apps/web/src` into the core's fact shape. */
-const gatherCssFacts = (root: string): Effect.Effect<ReadonlyArray<CssFileFacts>, IoError> =>
-	Effect.try({
-		try: () => {
-			const base = join(root, CSS_ROOT);
-			const files: Array<string> = [];
-			walkCss(base, files);
-			const rawLayerAbs = join(root, RAW_LAYER);
-			return files.map((abs): CssFileFacts => {
-				const src = readFileSync(abs, "utf8");
-				return {
-					path: toRel(root, abs),
-					isRawLayer: abs === rawLayerAbs,
-					declared: parseDeclaredProperties(src),
-					varRefs: parseVarReferences(src),
-					hexLiterals: parseHexLiterals(src),
-					rawPx: parseRawPxOverTwo(src),
-				};
-			});
-		},
-		catch: (cause) => new IoError({path: join(root, CSS_ROOT), cause}),
+const gatherCssFacts = (
+	root: string,
+): Effect.Effect<ReadonlyArray<CssFileFacts>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const base = path.join(root, CSS_ROOT);
+		const rawLayerAbs = path.join(root, RAW_LAYER);
+		return yield* Effect.gen(function* () {
+			const files = yield* walkCss(fs, path, base);
+			return yield* Effect.forEach(
+				files,
+				(abs) =>
+					fs.readFileString(abs, "utf8").pipe(
+						Effect.map(
+							(src): CssFileFacts => ({
+								path: toRel(path, root, abs),
+								isRawLayer: abs === rawLayerAbs,
+								declared: parseDeclaredProperties(src),
+								varRefs: parseVarReferences(src),
+								hexLiterals: parseHexLiterals(src),
+								rawPx: parseRawPxOverTwo(src),
+							}),
+						),
+					),
+				{concurrency: 1},
+			);
+		}).pipe(Effect.mapError((cause) => new IoError({path: base, cause})));
 	});
 
 /** Read + parse the app-side allow-list config; a missing/broken config fails closed. */
-const readConfig = (root: string): Effect.Effect<DesignTokenConfig, IoError | CheckFailed> =>
+const readConfig = (
+	root: string,
+): Effect.Effect<DesignTokenConfig, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
-		const configPath = join(root, CONFIG_PATH);
-		const text = yield* Effect.try({
-			try: () => readFileSync(configPath, "utf8"),
-			catch: (cause) => new IoError({path: configPath, cause}),
-		});
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const configPath = path.join(root, CONFIG_PATH);
+		const text = yield* fs
+			.readFileString(configPath, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: configPath, cause})));
 		const parsed = yield* Effect.try({
 			try: () => JSON.parse(text) as Partial<DesignTokenConfig>,
 			catch: (cause) => new IoError({path: configPath, cause}),
@@ -123,7 +152,9 @@ const readConfig = (root: string): Effect.Effect<DesignTokenConfig, IoError | Ch
  * raw hex outside the raw layer, no raw-px regression), else `CheckFailed`. Fails
  * closed on zero CSS files in scope (ADR 0092).
  */
-export const checkDesignTokens = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkDesignTokens = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const config = yield* readConfig(root);
 		const files = yield* gatherCssFacts(root);
@@ -141,17 +172,20 @@ export const checkDesignTokens = (root: string): Effect.Effect<void, IoError | C
  * `--write-baseline` ergonomic: after a genuine cleanup leg, snapshot the new raw-px
  * floor so the ratchet stays tight (like a snapshot-test update).
  */
-export const writeBaseline = (root: string): Effect.Effect<void, IoError> =>
+export const writeBaseline = (
+	root: string,
+): Effect.Effect<void, IoError, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
-		const configPath = join(root, CONFIG_PATH);
-		const raw = yield* Effect.try({
-			try: () => readFileSync(configPath, "utf8"),
-			catch: (cause) => new IoError({path: configPath, cause}),
-		});
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const configPath = path.join(root, CONFIG_PATH);
+		const raw = yield* fs
+			.readFileString(configPath, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: configPath, cause})));
 		const files = yield* gatherCssFacts(root);
-		yield* Effect.try({
+		// Preserve the full object (notes + allow-lists) and only replace ceilings.
+		const next = yield* Effect.try({
 			try: () => {
-				// Preserve the full object (notes + allow-lists) and only replace ceilings.
 				const parsed = JSON.parse(raw) as Record<string, unknown>;
 				const ceilings: Record<string, number> = {};
 				for (const f of files) {
@@ -163,10 +197,13 @@ export const writeBaseline = (root: string): Effect.Effect<void, IoError> =>
 					Object.entries(ceilings).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
 				);
 				parsed.rawPxCeilings = sorted;
-				writeFileSync(configPath, `${JSON.stringify(parsed, null, "\t")}\n`, "utf8");
+				return `${JSON.stringify(parsed, null, "\t")}\n`;
 			},
 			catch: (cause) => new IoError({path: configPath, cause}),
 		});
+		yield* fs
+			.writeFileString(configPath, next)
+			.pipe(Effect.mapError((cause) => new IoError({path: configPath, cause})));
 		yield* Console.log(
 			`design-token-guard: rewrote rawPxCeilings in ${CONFIG_PATH} from the current tree.`,
 		);

--- a/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
@@ -20,7 +20,7 @@
  * rather than welding to `node:fs` — see `.patterns/effect-platform-access.md`. A fs
  * fault folds `PlatformError` → the `IoError` this gate already carries.
  */
-import {Console, Effect, FileSystem, Path} from "effect";
+import {Console, Effect, FileSystem, Option, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	type CssFileFacts,
@@ -58,6 +58,16 @@ const toRel = (path: Path.Path, root: string, abs: string): string =>
  * tree through the `fs`/`path` seam. Iterative (an explicit stack) rather than
  * recursive; discovery order is irrelevant — the core sorts every reported list and
  * counts the rest, so the verdict is order-independent.
+ *
+ * Symlink semantics are load-bearing and deliberately match the pre-migration
+ * `readdirSync(…, {withFileTypes: true})` walk, whose `Dirent.isDirectory()` was
+ * **lstat**-based: a symlinked directory was never a directory and was never recursed
+ * into. v4's `FileSystem.stat` is `fs.stat` (it FOLLOWS symlinks) and v4 exposes no
+ * `lstat`, so the two arms below reconstruct the old semantics explicitly. Widening the
+ * walk through a symlinked dir is fail-OPEN, not merely noisier: `judge` builds
+ * `declaredUniverse` corpus-wide, so declarations behind a link can SILENCE a real
+ * `undefinedRefs` red on a fail-closed CI gate (ADR 0092). Not following links also
+ * keeps a symlink cycle unreachable — there is no visited-set or depth cap here.
  */
 const walkCss = (fs: FileSystem.FileSystem, path: Path.Path, base: string) =>
 	Effect.gen(function* () {
@@ -68,10 +78,18 @@ const walkCss = (fs: FileSystem.FileSystem, path: Path.Path, base: string) =>
 			if (dir === undefined) break;
 			for (const name of yield* fs.readDirectory(dir)) {
 				const abs = path.join(dir, name);
-				if ((yield* fs.stat(abs)).type === "Directory") {
+				// A failing stat is a broken symlink (or an entry racing an unlink) — skip it, as
+				// the dirent walk silently did; surfacing it as `IoError` would let one dangling
+				// link anywhere under the root red the whole gate.
+				const stat = yield* Effect.option(fs.stat(abs));
+				if (Option.isNone(stat)) continue;
+				if (stat.value.type === "Directory") {
 					if (name === "node_modules" || name === "dist") continue;
+					// `readLink` succeeds only on a symlink, so success here means "symlinked dir".
+					if (yield* Effect.isSuccess(fs.readLink(abs))) continue;
 					stack.push(abs);
 				} else if (name.endsWith(".css")) {
+					// A symlinked .css FILE is still in scope (the dirent walk pushed it too).
 					found.push(abs);
 				}
 			}

--- a/packages/pipeline-cli/src/tools/design-token-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/gate.unit.test.ts
@@ -7,8 +7,9 @@
 import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {dirname, join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkDesignTokens, writeBaseline} from "./gate.ts";
 
 let root: string;
@@ -39,7 +40,11 @@ const writeConfig = (over: Partial<Record<string, unknown>> = {}) =>
 		}),
 	);
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3470);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
 

--- a/packages/pipeline-cli/src/tools/design-token-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/gate.unit.test.ts
@@ -10,7 +10,7 @@ import {dirname, join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
 import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
-import {CheckFailed, checkDesignTokens, writeBaseline} from "./gate.ts";
+import {CheckFailed, checkDesignTokens, IoError, writeBaseline} from "./gate.ts";
 
 let root: string;
 beforeEach(() => {
@@ -54,6 +54,8 @@ const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path
 	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
+const isIoError = (exit: Exit.Exit<unknown, unknown>): boolean =>
+	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof IoError;
 
 describe("checkDesignTokens — the CI exit-code gate over a fake tree", () => {
 	it("SUCCEEDS on a clean tree (role tokens only)", async () => {
@@ -130,13 +132,23 @@ describe("walkCss symlink semantics", () => {
 		expect(isCheckFailed(await run(checkDesignTokens(root)))).toBe(true);
 	});
 
-	it("tolerates a broken symlink under the root (skipped, not an IoError)", async () => {
+	it("ignores a dangling NON-.css symlink under the root (matches the dirent walk)", async () => {
+		writeConfig();
+		write(join(CSS_DIR, "tokens.css"), `:root{ --accent: #e54d2e; }`);
+		write(join(CSS_DIR, "a.css"), `.a{ color: var(--accent); }`);
+		link(join(CSS_DIR, "dangling-dir"), "gone-dir");
+		expect(Exit.isSuccess(await run(checkDesignTokens(root)))).toBe(true);
+	});
+
+	// The dirent walk pushed any non-directory entry named `*.css` and then `readFileSync`'d it,
+	// so a dangling one raised ENOENT and red'd the gate. That is a tree-corruption alarm: a real
+	// CSS file replaced by a dangling link must not silently leave scope.
+	it("HARD-FAILS (IoError) on a dangling .css symlink under the root", async () => {
 		writeConfig();
 		write(join(CSS_DIR, "tokens.css"), `:root{ --accent: #e54d2e; }`);
 		write(join(CSS_DIR, "a.css"), `.a{ color: var(--accent); }`);
 		link(join(CSS_DIR, "dangling.css"), join("outside", "gone.css"));
-		link(join(CSS_DIR, "dangling-dir"), "gone-dir");
-		expect(Exit.isSuccess(await run(checkDesignTokens(root)))).toBe(true);
+		expect(isIoError(await run(checkDesignTokens(root)))).toBe(true);
 	});
 
 	it("terminates on a symlink cycle under the root", async () => {

--- a/packages/pipeline-cli/src/tools/design-token-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/gate.unit.test.ts
@@ -4,7 +4,7 @@
  * `design-token-guard.unit.test.ts`; this crosses the IO gate over a real temp tree,
  * asserting the exit-code contract from observable outcomes — never by spawning the bin.
  */
-import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {dirname, join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
@@ -27,6 +27,13 @@ const write = (rel: string, contents: string) => {
 	const abs = join(root, rel);
 	mkdirSync(dirname(abs), {recursive: true});
 	writeFileSync(abs, contents, "utf8");
+};
+
+/** `root/<rel>` → `root/<target>` (target need not exist — that's the dangling case). */
+const link = (rel: string, target: string) => {
+	const abs = join(root, rel);
+	mkdirSync(dirname(abs), {recursive: true});
+	symlinkSync(join(root, target), abs);
 };
 
 const writeConfig = (over: Partial<Record<string, unknown>> = {}) =>
@@ -100,6 +107,45 @@ describe("checkDesignTokens — the CI exit-code gate over a fake tree", () => {
 		write(join(CSS_DIR, "a.css"), `.a{ color: red; }`);
 		expect(isCheckFailed(await run(checkDesignTokens(root)))).toBe(true);
 	});
+});
+
+// The walk must keep the lstat semantics of the pre-v4 `Dirent` walk: symlinked DIRS are not
+// descended, symlinked `.css` FILES still are. The dir half is a fail-OPEN when it regresses —
+// `judge` builds `declaredUniverse` corpus-wide, so declarations behind a link silence a real
+// undefined-ref red on a fail-closed gate (ADR 0092) — hence these pin the behaviour directly.
+describe("walkCss symlink semantics", () => {
+	it("does NOT let a declaration behind a symlinked DIR into the corpus (stays RED)", async () => {
+		writeConfig();
+		write(join(CSS_DIR, "a.css"), `.a{ color: var(--foo); }`);
+		write(join("outside", "o.css"), `:root{ --foo: red; }`);
+		link(join(CSS_DIR, "linked"), "outside");
+		expect(isCheckFailed(await run(checkDesignTokens(root)))).toBe(true);
+	});
+
+	it("still scans a symlinked .css FILE (its violations are caught)", async () => {
+		writeConfig();
+		write(join(CSS_DIR, "a.css"), `.a{ color: red; }`);
+		write(join("outside", "ext.css"), `.x{ color: #60a5fa; }`);
+		link(join(CSS_DIR, "linked.css"), join("outside", "ext.css"));
+		expect(isCheckFailed(await run(checkDesignTokens(root)))).toBe(true);
+	});
+
+	it("tolerates a broken symlink under the root (skipped, not an IoError)", async () => {
+		writeConfig();
+		write(join(CSS_DIR, "tokens.css"), `:root{ --accent: #e54d2e; }`);
+		write(join(CSS_DIR, "a.css"), `.a{ color: var(--accent); }`);
+		link(join(CSS_DIR, "dangling.css"), join("outside", "gone.css"));
+		link(join(CSS_DIR, "dangling-dir"), "gone-dir");
+		expect(Exit.isSuccess(await run(checkDesignTokens(root)))).toBe(true);
+	});
+
+	it("terminates on a symlink cycle under the root", async () => {
+		writeConfig();
+		write(join(CSS_DIR, "tokens.css"), `:root{ --accent: #e54d2e; }`);
+		write(join(CSS_DIR, "a.css"), `.a{ color: var(--accent); }`);
+		link(join(CSS_DIR, "loop"), CSS_DIR);
+		expect(Exit.isSuccess(await run(checkDesignTokens(root)))).toBe(true);
+	}, 15_000);
 });
 
 describe("writeBaseline — regenerate the ceilings", () => {

--- a/packages/pipeline-cli/src/tools/glossary-drift/command.ts
+++ b/packages/pipeline-cli/src/tools/glossary-drift/command.ts
@@ -25,12 +25,9 @@
  * (git/gh IO at the boundary, a total core behind it).
  */
 import {execFileSync} from "node:child_process";
-import {existsSync, readFileSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Console, Effect, Option} from "effect";
+import {Console, Effect, FileSystem, Option, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {findDrift, parseKnownTerms, renderIssueBody, renderReport} from "./drift.ts";
 import {GIT_LOG_RECORD_SEP, parseGitLog} from "./gitlog.ts";
 
@@ -43,15 +40,26 @@ class SweepIoError extends Schema.TaggedErrorClass<SweepIoError>()("SweepIoError
 	cause: Schema.Unknown,
 }) {}
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). A marker-existence fault falls through as
+// false, matching the old `existsSync`; the walk falls back to the start on no hit.
+// (`git`/`gh` stay raw `execFileSync` — the subprocess boundary is a separate seam.)
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const windowFlag = Flag.integer("window").pipe(
 	Flag.optional,
@@ -81,10 +89,12 @@ const gatherMergeLog = (window: number): Effect.Effect<string, SweepIoError> =>
 		catch: (cause) => new SweepIoError({step: "git log", cause}),
 	});
 
-const readTerms = (path: string): Effect.Effect<string, SweepIoError> =>
-	Effect.try({
-		try: () => readFileSync(path, "utf8"),
-		catch: (cause) => new SweepIoError({step: `read ${path}`, cause}),
+const readTerms = (termsPath: string): Effect.Effect<string, SweepIoError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		return yield* fs
+			.readFileString(termsPath, "utf8")
+			.pipe(Effect.mapError((cause) => new SweepIoError({step: `read ${termsPath}`, cause})));
 	});
 
 /** File the drift as a status:needs-triage issue via `gh` (the report skill's intake path). */
@@ -110,9 +120,15 @@ const sweep = Command.make(
 	{window: windowFlag, terms: termsFlag, fileIssue: fileIssueFlag},
 	Effect.fn(function* ({window: windowOpt, terms: termsOpt, fileIssue}) {
 		const window = Option.getOrElse(windowOpt, () => DEFAULT_WINDOW);
-		const termsPath = Option.getOrElse(termsOpt, () =>
-			join(defaultRoot(), ".glossary", "TERMS.md"),
-		);
+		const termsPath = yield* Option.match(termsOpt, {
+			onNone: () =>
+				Effect.gen(function* () {
+					const path = yield* Path.Path;
+					const root = yield* defaultRoot();
+					return path.join(root, ".glossary", "TERMS.md");
+				}),
+			onSome: Effect.succeed,
+		});
 
 		yield* Effect.gen(function* () {
 			const [logBlob, termsMd] = yield* Effect.all([gatherMergeLog(window), readTerms(termsPath)], {

--- a/packages/pipeline-cli/src/tools/readme-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/command.ts
@@ -26,34 +26,43 @@
  * bin's run boundary) so the contract survives folding into the shared `pipeline-cli`
  * bin, which provides only `NodeServices.layer` and no per-tool catch.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkReadmes} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). A marker-existence fault falls through as
+// false, matching the old `existsSync`; the walk falls back to the start on no hit.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
 	Flag.withDescription("the repo root to scan packages/* under (default: walk up for one)"),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
@@ -68,7 +77,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkReadmes(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkReadmes(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription("Fail the build if any packages/* workspace member lacks a README.md"),

--- a/packages/pipeline-cli/src/tools/readme-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/gate.ts
@@ -11,10 +11,13 @@
  * `CheckFailed` (exit non-zero) when a real member lacks a README OR when zero
  * members are in scope (fail-closed, ADR 0092). A directory/file IO failure is an
  * `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
+ *
+ * All directory/file/path IO goes through the Effect `FileSystem`/`Path` seam (over the
+ * bin's `NodeServices.layer`), so a gate `unit` test crosses an in-memory/real fs rather
+ * than welding to `node:fs` — see `.patterns/effect-platform-access.md`. A fs fault folds
+ * `PlatformError` → the `IoError` this gate already carries.
  */
-import {existsSync, readdirSync, readFileSync, statSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	judge,
@@ -45,35 +48,39 @@ const PACKAGES_DIR = "packages";
  */
 const enumeratePackageCandidates = (
 	root: string,
-): Effect.Effect<ReadonlyArray<PackageDirCandidate>, IoError> =>
-	Effect.try({
-		try: () => {
-			const base = join(root, PACKAGES_DIR);
-			const entries = readdirSync(base, {withFileTypes: true});
+): Effect.Effect<ReadonlyArray<PackageDirCandidate>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const base = path.join(root, PACKAGES_DIR);
+		return yield* Effect.gen(function* () {
 			const candidates: Array<PackageDirCandidate> = [];
-			for (const entry of entries) {
-				// A symlink to a dir still resolves through statSync; skip plain files.
-				const abs = join(base, entry.name);
-				if (!statSync(abs).isDirectory()) continue;
+			for (const name of yield* fs.readDirectory(base)) {
+				// `fs.stat` follows symlinks (matching the old statSync), so a symlink-to-dir
+				// still counts; skip plain files.
+				const abs = path.join(base, name);
+				if ((yield* fs.stat(abs)).type !== "Directory") continue;
 				candidates.push({
-					dir: `${PACKAGES_DIR}/${entry.name}`,
-					hasPackageJson: existsSync(join(abs, "package.json")),
-					hasReadme: existsSync(join(abs, "README.md")),
+					dir: `${PACKAGES_DIR}/${name}`,
+					hasPackageJson: yield* fs.exists(path.join(abs, "package.json")),
+					hasReadme: yield* fs.exists(path.join(abs, "README.md")),
 				});
 			}
 			return candidates;
-		},
-		catch: (cause) => new IoError({path: join(root, PACKAGES_DIR), cause}),
+		}).pipe(Effect.mapError((cause) => new IoError({path: base, cause})));
 	});
 
 /** Read `pnpm-workspace.yaml` and assert `packages/*` is a declared member glob. */
-const assertPackagesGlobDeclared = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+const assertPackagesGlobDeclared = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
-		const workspacePath = join(root, "pnpm-workspace.yaml");
-		const text = yield* Effect.try({
-			try: () => readFileSync(workspacePath, "utf8"),
-			catch: (cause) => new IoError({path: workspacePath, cause}),
-		});
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const workspacePath = path.join(root, "pnpm-workspace.yaml");
+		const text = yield* fs
+			.readFileString(workspacePath, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: workspacePath, cause})));
 		const globs = parseWorkspacePackageGlobs(text);
 		if (!globs.includes(PACKAGES_GLOB)) {
 			// The workspace no longer declares packages/* — the guard's scope assumption
@@ -91,7 +98,9 @@ const assertPackagesGlobDeclared = (root: string): Effect.Effect<void, IoError |
  * `package.json`) carries a `README.md`, else `CheckFailed`. Fails closed on zero
  * members in scope (ADR 0092).
  */
-export const checkReadmes = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkReadmes = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		yield* assertPackagesGlobDeclared(root);
 		const candidates = yield* enumeratePackageCandidates(root);

--- a/packages/pipeline-cli/src/tools/readme-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/gate.unit.test.ts
@@ -9,8 +9,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkReadmes} from "./gate.ts";
 
 let root: string;
@@ -35,7 +36,11 @@ const mkPackage = (name: string, opts: {pkgJson?: boolean; readme?: boolean}) =>
 	if (opts.readme) writeFileSync(join(dir, "README.md"), `# ${name}\n`, "utf8");
 };
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3470);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;

--- a/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
@@ -25,11 +25,8 @@
  * exit non-zero, undistinguished. `CheckFailed` is caught inside the handler so the
  * contract survives folding into the shared `pipeline-cli` bin.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkRoadmap} from "./gate.ts";
 import {MilestonesLive} from "./github.ts";
 
@@ -37,23 +34,35 @@ const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). A marker-existence fault falls through as
+// false, matching the old `existsSync`; the walk falls back to the start on no hit.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
 	Flag.withDescription("the repo root holding ROADMAP.md (default: walk up for one)"),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, gh failures) still get the
@@ -68,7 +77,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkRoadmap(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkRoadmap(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
@@ -7,9 +7,7 @@
  * zero-scope fail-closed (ADR 0092). An IO/`gh` failure is a distinct typed error (also
  * non-zero — both are failures, undistinguished, per the bin's contract).
  */
-import {existsSync, readFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Milestones} from "./github.ts";
@@ -28,16 +26,25 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 
 const ROADMAP_FILE = "ROADMAP.md";
 
-const readRoadmap = (root: string): Effect.Effect<string, IoError> =>
-	Effect.try({
-		try: () => {
-			const path = join(root, ROADMAP_FILE);
-			if (!existsSync(path)) {
-				throw new Error(`${ROADMAP_FILE} not found at repo root`);
-			}
-			return readFileSync(path, "utf8");
-		},
-		catch: (cause) => new IoError({path: join(root, ROADMAP_FILE), cause}),
+// The file read goes through the `FileSystem`/`Path` seam (over the bin's
+// `NodeServices.layer`), so the wiring is crossable off real disk in a test — see
+// `.patterns/effect-platform-access.md`. A missing ROADMAP.md keeps its specific
+// "not found at repo root" diagnostic; a read fault folds `PlatformError` → `IoError`.
+const readRoadmap = (
+	root: string,
+): Effect.Effect<string, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, ROADMAP_FILE);
+		if (!(yield* fs.exists(target).pipe(Effect.orElseSucceed(() => false)))) {
+			return yield* Effect.fail(
+				new IoError({path: target, cause: new Error(`${ROADMAP_FILE} not found at repo root`)}),
+			);
+		}
+		return yield* fs
+			.readFileString(target, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
 	});
 
 /**
@@ -51,7 +58,7 @@ export const checkRoadmap = (
 ): Effect.Effect<
 	void,
 	IoError | CheckFailed | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
-	Milestones
+	Milestones | FileSystem.FileSystem | Path.Path
 > =>
 	Effect.gen(function* () {
 		const md = yield* readRoadmap(root);

--- a/packages/pipeline-cli/src/tools/roadmap/command.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/command.ts
@@ -19,11 +19,8 @@
  * fetch in `view.ts`/`github.ts`. `GithubLive` is baked in with `Command.provide(...)` so the
  * registered command's residual requirement is the Node platform union (the registry seam, #994).
  */
-import {existsSync, readFileSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Console, Effect, Option} from "effect";
+import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {generateDiagram, parseDependencies} from "./diagram.ts";
 import {GithubLive} from "./github.ts";
 import {parseRoadmap} from "./roadmap.ts";
@@ -32,29 +29,41 @@ import {renderRoadmap} from "./view.ts";
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). A marker-existence fault falls through as
+// false, matching the old `existsSync`; the walk falls back to the start on no hit.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
 	Flag.withDescription("the repo root holding ROADMAP.md (default: walk up for one)"),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 const view = Command.make(
 	"view",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* renderRoadmap(resolveRoot(rootOpt));
+		yield* renderRoadmap(yield* resolveRoot(rootOpt));
 	}),
 ).pipe(
 	Command.withDescription(
@@ -70,8 +79,10 @@ const diagram = Command.make(
 	"diagram",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		const root = resolveRoot(rootOpt);
-		const md = yield* Effect.try(() => readFileSync(join(root, "ROADMAP.md"), "utf8"));
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const root = yield* resolveRoot(rootOpt);
+		const md = yield* fs.readFileString(path.join(root, "ROADMAP.md"), "utf8");
 		const {arcs, campaigns} = parseRoadmap(md);
 		yield* Console.log(generateDiagram(arcs, campaigns, parseDependencies(md)));
 	}),

--- a/packages/pipeline-cli/src/tools/roadmap/view.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/view.ts
@@ -6,9 +6,7 @@
  * tree, and prints it to stdout. Read-only — no verdict, no `CheckFailed`; the only failure is a
  * genuine IO/`gh` crash (also non-zero, per the bin's contract). This is a render, not a guard.
  */
-import {existsSync, readFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Github} from "./github.ts";
@@ -22,16 +20,25 @@ export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
 
 const ROADMAP_FILE = "ROADMAP.md";
 
-const readRoadmap = (root: string): Effect.Effect<string, IoError> =>
-	Effect.try({
-		try: () => {
-			const path = join(root, ROADMAP_FILE);
-			if (!existsSync(path)) {
-				throw new Error(`${ROADMAP_FILE} not found at repo root`);
-			}
-			return readFileSync(path, "utf8");
-		},
-		catch: (cause) => new IoError({path: join(root, ROADMAP_FILE), cause}),
+// The file read goes through the `FileSystem`/`Path` seam (over the bin's
+// `NodeServices.layer`), so the wiring is crossable off real disk in a test — see
+// `.patterns/effect-platform-access.md`. A missing ROADMAP.md keeps its specific
+// "not found at repo root" diagnostic; a read fault folds `PlatformError` → `IoError`.
+const readRoadmap = (
+	root: string,
+): Effect.Effect<string, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, ROADMAP_FILE);
+		if (!(yield* fs.exists(target).pipe(Effect.orElseSucceed(() => false)))) {
+			return yield* Effect.fail(
+				new IoError({path: target, cause: new Error(`${ROADMAP_FILE} not found at repo root`)}),
+			);
+		}
+		return yield* fs
+			.readFileString(target, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
 	});
 
 /**
@@ -43,7 +50,7 @@ export const renderRoadmap = (
 ): Effect.Effect<
 	void,
 	IoError | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
-	Github
+	Github | FileSystem.FileSystem | Path.Path
 > =>
 	Effect.gen(function* () {
 		const md = yield* readRoadmap(root);


### PR DESCRIPTION
## What

Migrates the raw `node:fs` / `node:path` **production** imports in the design / docs / roadmap guard cluster to the v4 Effect platform idiom (`.patterns/effect-platform-access.md`): file/dir/path IO now goes through `FileSystem.FileSystem` / `Path.Path` yielded from `effect`, discharged by the `NodeServices.layer` that `run.ts` already provides. No new layer wiring is added — this matches the already-merged `catalog-guard` shape.

Files (all in the disjoint m32 design/docs/roadmap slice):

- `design-token-guard/command.ts`, `.../gate.ts`
- `readme-guard/command.ts`, `.../gate.ts`
- `roadmap/command.ts`, `.../view.ts`
- `roadmap-guard/command.ts`, `.../gate.ts`
- `glossary-drift/command.ts`

Each tool's `defaultRoot` root-dir upward walk becomes an `Effect.fn` probing markers via `fs.exists`/`path.*` (the same seam as `catalog-guard`), and each gate's file read / directory walk / config write crosses `FileSystem`/`Path`. The two gate unit tests (`design-token-guard`, `readme-guard`) now provide `NodeServices.layer` so their real-temp-dir IO still runs.

## Behavior preserved

Behavior-preserving refactor (Containment: exempt per the issue). Identical exit codes / stdout / stderr / fail-closed semantics:

- Guard verdicts are unchanged — the pure cores (which sort every reported list and count the rest) are untouched, so traversal-order changes are unobservable.
- A missing `ROADMAP.md` keeps its specific `"ROADMAP.md not found at repo root"` diagnostic.
- Bright-line raw `node:*` kept per the doc: `execFileSync` (`git`/`gh` in `glossary-drift`) stays a subprocess boundary; deliberate real-fs `*.test.ts` fixtures keep `node:fs`; `bin.ts` is untouched.

## Acceptance criteria

- [x] Every raw `node:fs`/`node:path` **production** import in the slice replaced by `FileSystem`/`Path` from `effect`, discharged by `run.ts`'s existing `NodeServices.layer` (no new wiring).
- [x] v4 idiom (`FileSystem`/`Path` from `effect` + `@effect/platform-node` `NodeServices.layer`), not v3 `@effect/platform`/`NodeContext`.
- [x] Bright-line raw boundaries preserved (`execFileSync`, real-fs test code); `bin.ts` untouched.
- [x] Observable behavior unchanged; `pnpm --filter @kampus/pipeline-cli typecheck` green and the full package test suite passes (**1948 tests / 139 files**).
- [x] **§CP:** touches `packages/pipeline-cli/` → banks for a human merge by **@kamp-us/control-plane**, does **not** auto-ship.

Fixes #3470
