### PR TITLE
refactor(pipeline-cli): route leak/redact/patch/settings-env/class-probe IO through the v4 FileSystem/Path seam (#3472)

### DIFF
--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -24,11 +24,9 @@
  * unreadable §CLASS falls back to the fail-closed probes (`FAILCLOSED_PROBES`), which
  * over-dispatch every gate rather than skip one.
  */
-import {existsSync, readFileSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Console, Effect, Option} from "effect";
+import {readFileSync} from "node:fs";
+import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {
 	classify,
@@ -46,15 +44,26 @@ const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 /** The single source for the additive `UI_RE` (has-ui → review-design), read locally like §CLASS. */
 const SHIP_IT_PATH = "claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md";
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Mirrors `findRootDir`'s pure upward walk (dirname to
+// the fixpoint, then fall back to the start), but the marker check is the fs seam — `fs.exists`
+// yields an Effect. Marker-existence faults fall through as false, matching `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const filesFromFlag = Flag.string("files-from").pipe(
 	Flag.optional,
@@ -73,54 +82,71 @@ const namespacesFlag = Flag.boolean("namespaces").pipe(
 );
 
 /** Read the changed-file list from `--files-from` or stdin; empty/failed read ⇒ no files. */
-const readFiles = (filesFrom: Option.Option<string>): ReadonlyArray<string> => {
-	let raw: string;
-	// biome-ignore lint/plugin: best-effort read — an empty/failed read is absorbed into no files ([]), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		raw = Option.match(filesFrom, {
-			onSome: (path) => readFileSync(path, "utf8"),
-			onNone: () => readFileSync(0, "utf8"),
+const readFiles = (
+	filesFrom: Option.Option<string>,
+): Effect.Effect<ReadonlyArray<string>, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const raw = yield* Option.match(filesFrom, {
+			onSome: (path) =>
+				Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf8")).pipe(
+					Effect.orElseSucceed(() => ""),
+				),
+			// stdin (fd 0): a node-only boundary — FileSystem exposes no stdin reader, so kept raw. A
+			// failed/empty read is absorbed into no files (""), never the E channel; a total helper.
+			onNone: () =>
+				Effect.sync(() => {
+					// biome-ignore lint/plugin: fd-0 boundary read (closed/empty stdin), absorbed to "" — not Effect-cosplay.
+					try {
+						return readFileSync(0, "utf8");
+					} catch {
+						return "";
+					}
+				}),
 		});
-	} catch {
-		return [];
-	}
-	return raw
-		.split("\n")
-		.map((line) => line.trim())
-		.filter((line) => line.length > 0);
-};
+		return raw
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+	});
 
 /** Read local §CLASS text; null (⇒ fail-closed probes) if the file is unreadable. */
-const readFormats = (root: string): string | null => {
-	// biome-ignore lint/plugin: best-effort read — an unreadable file is absorbed into null (⇒ fail-closed probes), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		return readFileSync(join(root, FORMATS_PATH), "utf8");
-	} catch {
-		return null;
-	}
-};
+const readFormats = (
+	root: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		return yield* fs
+			.readFileString(path.join(root, FORMATS_PATH), "utf8")
+			.pipe(Effect.orElseSucceed(() => null));
+	});
 
 /** Read local ship-it/SKILL.md text; null (⇒ fail-closed `UI_RE`) if the file is unreadable. */
-const readShipIt = (root: string): string | null => {
-	// biome-ignore lint/plugin: best-effort read — an unreadable file is absorbed into null (⇒ fail-closed UI_RE), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		return readFileSync(join(root, SHIP_IT_PATH), "utf8");
-	} catch {
-		return null;
-	}
-};
+const readShipIt = (
+	root: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		return yield* fs
+			.readFileString(path.join(root, SHIP_IT_PATH), "utf8")
+			.pipe(Effect.orElseSucceed(() => null));
+	});
 
 const classifyCmd = Command.make(
 	"classify",
 	{filesFrom: filesFromFlag, root: rootFlag, namespaces: namespacesFlag},
 	Effect.fn(function* ({filesFrom, root, namespaces}) {
-		const rootDir = Option.getOrElse(root, () => defaultRoot());
-		const formats = readFormats(rootDir);
+		const rootDir = yield* Option.match(root, {
+			onNone: () => defaultRoot(),
+			onSome: Effect.succeed,
+		});
+		const formats = yield* readFormats(rootDir);
 		const probes = parseClassProbes(formats ?? "");
-		const shipIt = readShipIt(rootDir);
+		const shipIt = yield* readShipIt(rootDir);
 		const uiRe = parseUiProbe(shipIt ?? "");
 		const uiExclude = parseUiExclude(shipIt ?? "");
-		const files = readFiles(filesFrom);
+		const files = yield* readFiles(filesFrom);
 		// Fail closed on zero input (#3786): this probe is only ever piped a PR's changed-file
 		// list, which is never legitimately empty — an empty read is a dropped/undelivered stdin,
 		// indistinguishable at the pure core from a gate-free PR. Route it through the same has-code

--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -24,12 +24,10 @@
  * is dropped: the `pipeline-cli` bin imports `@effect/platform-node` statically,
  * so by the time this command runs the runtime dep is always resolved.
  */
-import {existsSync, readFileSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Console, Effect, Option} from "effect";
+import {readFileSync} from "node:fs";
+import {Console, Effect, FileSystem, Option, Path, type PlatformError} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, CREW_DIR, sweepCrew} from "./crew-gate.ts";
 import {PrComments, PrCommentsLive, type UpstreamUnavailableError} from "./github.ts";
 import {findCommentLeaks, findLeaks, type Leak} from "./leak-guard.ts";
@@ -58,13 +56,12 @@ class LeakFound extends Schema.TaggedErrorClass<LeakFound>()("LeakFound", {
 }) {}
 
 /** Read a file as UTF-8, or `null` when it is missing/unreadable (skip, never crash). */
-const readFileOrSkip = (file: string): Effect.Effect<string | null> =>
-	Effect.try({
-		try: () => readFileSync(file, "utf8"),
-		catch: () => null,
-	}).pipe(Effect.orElseSucceed(() => null));
+const readFileOrSkip = (file: string): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(file, "utf8")).pipe(
+		Effect.orElseSucceed(() => null),
+	);
 
-const scanFile = (file: string): Effect.Effect<FileLeaks> =>
+const scanFile = (file: string): Effect.Effect<FileLeaks, never, FileSystem.FileSystem> =>
 	readFileOrSkip(file).pipe(
 		Effect.map((content) => ({
 			file,
@@ -122,15 +119,26 @@ const scan = Command.make(
 const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Mirrors `findRootDir`'s pure upward walk (dirname to
+// the fixpoint, then fall back to the start), but the marker check is the fs seam — `fs.exists`
+// yields an Effect. Marker-existence faults fall through as false, matching `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -154,7 +162,7 @@ const sweep = Command.make(
 	"sweep",
 	{root: rootFlag, dir: dirFlag},
 	Effect.fn(function* ({root, dir}) {
-		const base = Option.getOrElse(root, () => defaultRoot());
+		const base = yield* Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 		yield* sweepCrew(
 			base,
 			Option.getOrElse(dir, () => CREW_DIR),
@@ -177,13 +185,16 @@ const commentBodyFlag = Flag.string("body-file").pipe(
 	Flag.withDescription("path to the comment body to scan (default: read the body from stdin)"),
 );
 
-const readCommentBody = (bodyFile: Option.Option<string>): Effect.Effect<string> =>
-	Effect.sync(() =>
-		Option.match(bodyFile, {
-			onNone: () => readFileSync(0, "utf8"),
-			onSome: (path) => readFileSync(path, "utf8"),
-		}),
-	);
+const readCommentBody = (
+	bodyFile: Option.Option<string>,
+): Effect.Effect<string, PlatformError.PlatformError, FileSystem.FileSystem> =>
+	Option.match(bodyFile, {
+		// stdin (fd 0): a node-only boundary — FileSystem exposes no stdin reader, so kept raw
+		// (.patterns/effect-platform-access.md bright line). A `--body-file` path routes the fs seam.
+		onNone: () => Effect.sync(() => readFileSync(0, "utf8")),
+		onSome: (path) =>
+			Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf8")),
+	});
 
 const scanComment = Command.make(
 	"scan-comment",

--- a/packages/pipeline-cli/src/tools/leak-guard/crew-gate.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/crew-gate.test.ts
@@ -9,8 +9,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, CREW_DIR, sweepCrew} from "./crew-gate.ts";
 
 let root: string;
@@ -32,7 +33,11 @@ const writeCrewFile = (rel: string, body: string) => {
 	writeFileSync(abs, body, "utf8");
 };
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// `sweepCrew` requires the `FileSystem | Path` seam (v4 platform migration, #3472); provide the
+// live Node layer — the same NodeServices.layer run.ts gives the bin — so this real-temp-dir IO
+// test exercises the actual disk path it asserts over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
 

--- a/packages/pipeline-cli/src/tools/leak-guard/crew-gate.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/crew-gate.ts
@@ -9,10 +9,13 @@
  * personal-data hit OR when zero files are in scope (fail-closed, ADR 0092 — an empty
  * scan is a misconfiguration, never a vacuous green). A directory/file IO failure is
  * an `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
+ *
+ * All directory/path IO goes through the Effect `FileSystem`/`Path` seam (over the bin's
+ * `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for real disk
+ * (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the `IoError`
+ * this gate already carries.
  */
-import {readdirSync, readFileSync, statSync} from "node:fs";
-import {join, relative} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path, type PlatformError} from "effect";
 import * as Schema from "effect/Schema";
 import {type CrewLeak, findCrewLeaks} from "./crew-leak.ts";
 
@@ -35,18 +38,31 @@ interface FileHits {
 	readonly leaks: ReadonlyArray<CrewLeak>;
 }
 
-/** Recursively collect every regular file's absolute path under `dir`. */
-const walkFiles = (dir: string): ReadonlyArray<string> => {
-	const out: Array<string> = [];
-	for (const entry of readdirSync(dir, {withFileTypes: true})) {
-		const abs = join(dir, entry.name);
-		// Resolve symlinks through statSync; recurse dirs, collect files.
-		const st = statSync(abs);
-		if (st.isDirectory()) out.push(...walkFiles(abs));
-		else if (st.isFile()) out.push(abs);
-	}
-	return out;
-};
+/** Recursively collect every regular file's absolute path under `root`. */
+const walkFiles = (
+	root: string,
+): Effect.Effect<
+	ReadonlyArray<string>,
+	PlatformError.PlatformError,
+	FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const walk = (dir: string): Effect.Effect<ReadonlyArray<string>, PlatformError.PlatformError> =>
+			Effect.gen(function* () {
+				const out: Array<string> = [];
+				for (const name of yield* fs.readDirectory(dir)) {
+					const abs = path.join(dir, name);
+					// `fs.stat` resolves symlinks (like the former `statSync`); recurse dirs, collect files.
+					const st = yield* fs.stat(abs);
+					if (st.type === "Directory") out.push(...(yield* walk(abs)));
+					else if (st.type === "File") out.push(abs);
+				}
+				return out;
+			});
+		return yield* walk(root);
+	});
 
 /**
  * The CI gate: succeed when a non-empty crew tree carries zero personal-data hits,
@@ -56,13 +72,14 @@ const walkFiles = (dir: string): ReadonlyArray<string> => {
 export const sweepCrew = (
 	root: string,
 	dir: string = CREW_DIR,
-): Effect.Effect<void, IoError | CheckFailed> =>
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
-		const base = join(root, dir);
-		const files = yield* Effect.try({
-			try: () => walkFiles(base),
-			catch: (cause) => new IoError({path: base, cause}),
-		});
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const base = path.join(root, dir);
+		const files = yield* walkFiles(base).pipe(
+			Effect.mapError((cause) => new IoError({path: base, cause})),
+		);
 
 		if (files.length === 0) {
 			return yield* Effect.fail(
@@ -76,12 +93,11 @@ export const sweepCrew = (
 
 		const results: Array<FileHits> = [];
 		for (const abs of files) {
-			const content = yield* Effect.try({
-				try: () => readFileSync(abs, "utf8"),
-				catch: (cause) => new IoError({path: abs, cause}),
-			});
+			const content = yield* fs
+				.readFileString(abs, "utf8")
+				.pipe(Effect.mapError((cause) => new IoError({path: abs, cause})));
 			const leaks = findCrewLeaks(content);
-			if (leaks.length > 0) results.push({file: relative(root, abs), leaks});
+			if (leaks.length > 0) results.push({file: path.relative(root, abs), leaks});
 		}
 
 		if (results.length === 0) {

--- a/packages/pipeline-cli/src/tools/patch-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/patch-guard/command.ts
@@ -27,25 +27,33 @@
  * inside the handler (not at the bin's run boundary) so the contract survives folding
  * into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkPatchGuard} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Mirrors `findRootDir`'s pure upward walk (dirname to
+// the fixpoint, then fall back to the start), but the marker check is the fs seam — `fs.exists`
+// yields an Effect. Marker-existence faults fall through as false, matching `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -54,8 +62,10 @@ const rootFlag = Flag.string("root").pipe(
 	),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
@@ -70,9 +80,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkPatchGuard(resolveRoot(rootOpt)).pipe(
-			Effect.catchTag("CheckFailed", onCheckFailed),
-		);
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkPatchGuard(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/patch-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/patch-guard/gate.ts
@@ -11,10 +11,13 @@
  * on a patched dep with no pin, a stale pin marker, or zero patchedDependencies in
  * scope (fail-closed, ADR 0092). A directory/file IO failure is an `IoError` (also
  * non-zero — both failures, undistinguished, per the bin's contract).
+ *
+ * All directory/path IO goes through the Effect `FileSystem`/`Path` seam (over the bin's
+ * `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for real disk
+ * (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the `IoError`
+ * this gate already carries.
  */
-import {readdirSync, readFileSync, statSync} from "node:fs";
-import {join, relative, sep} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path, type PlatformError} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	judge,
@@ -54,10 +57,20 @@ const IGNORE_DIRS = new Set([
 /** The behavior pin lives on a test — scope the marker scan to test files (any tier). */
 const isTestFile = (name: string): boolean => /\.test\.(ts|tsx)$/.test(name);
 
-const readWorkspacePatches = (root: string): Effect.Effect<ReadonlyArray<PatchedDep>, IoError> =>
-	Effect.try({
-		try: () => parsePatchedDependencies(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8")),
-		catch: (cause) => new IoError({path: join(root, "pnpm-workspace.yaml"), cause}),
+const readWorkspacePatches = (
+	root: string,
+): Effect.Effect<ReadonlyArray<PatchedDep>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, "pnpm-workspace.yaml");
+		const text = yield* fs
+			.readFileString(target, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
+		return yield* Effect.try({
+			try: () => parsePatchedDependencies(text),
+			catch: (cause) => new IoError({path: target, cause}),
+		});
 	});
 
 /**
@@ -66,34 +79,39 @@ const readWorkspacePatches = (root: string): Effect.Effect<ReadonlyArray<Patched
  * markers with a repo-relative (POSIX-normalized) path so the report is stable across
  * platforms and carries no absolute path.
  */
-const gatherMarkers = (root: string): Effect.Effect<ReadonlyArray<PinMarker>, IoError> =>
-	Effect.try({
-		try: () => {
-			const markers: Array<PinMarker> = [];
-			const walk = (dir: string): void => {
-				for (const entry of readdirSync(dir, {withFileTypes: true})) {
-					const abs = join(dir, entry.name);
-					if (entry.isDirectory()) {
-						if (!IGNORE_DIRS.has(entry.name)) walk(abs);
+const gatherMarkers = (
+	root: string,
+): Effect.Effect<ReadonlyArray<PinMarker>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const markers: Array<PinMarker> = [];
+		const walk = (dir: string): Effect.Effect<void, PlatformError.PlatformError> =>
+			Effect.gen(function* () {
+				for (const name of yield* fs.readDirectory(dir)) {
+					const abs = path.join(dir, name);
+					const stat = yield* fs.stat(abs);
+					if (stat.type === "Directory") {
+						if (!IGNORE_DIRS.has(name)) yield* walk(abs);
 						continue;
 					}
-					if (!statSync(abs).isFile() || !isTestFile(entry.name)) continue;
-					const relPath = relative(root, abs).split(sep).join("/");
-					markers.push(...parsePinMarkers(readFileSync(abs, "utf8"), relPath));
+					if (stat.type !== "File" || !isTestFile(name)) continue;
+					const relPath = path.relative(root, abs).split(path.sep).join("/");
+					markers.push(...parsePinMarkers(yield* fs.readFileString(abs, "utf8"), relPath));
 				}
-			};
-			walk(root);
-			return markers;
-		},
-		catch: (cause) => new IoError({path: root, cause}),
-	});
+			});
+		yield* walk(root);
+		return markers;
+	}).pipe(Effect.mapError((cause) => new IoError({path: root, cause})));
 
 /**
  * The CI gate: succeed when every maintained patch carries ≥1 matching `@patch-pin:`
  * marker and no marker is stale, else `CheckFailed`. Fails closed on zero
  * patchedDependencies in scope (ADR 0092).
  */
-export const checkPatchGuard = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkPatchGuard = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const patched = yield* readWorkspacePatches(root);
 		const markers = yield* gatherMarkers(root);

--- a/packages/pipeline-cli/src/tools/patch-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/patch-guard/gate.ts
@@ -92,7 +92,19 @@ const gatherMarkers = (
 					const abs = path.join(dir, name);
 					const stat = yield* fs.stat(abs);
 					if (stat.type === "Directory") {
-						if (!IGNORE_DIRS.has(name)) yield* walk(abs);
+						// A symlinked dir is NEVER recursed: `fs.stat` follows links, but the
+						// pre-migration `Dirent.isDirectory()` was lstat-based, so a link-to-dir
+						// fell through and was skipped. v4's FileSystem exposes no `lstat`, and
+						// `readDirectory` takes no `withFileTypes` — but `readLink` succeeds only
+						// on a link, which is the equivalent test. Recursing one would both widen
+						// the pin scan (a guard failing OPEN) and admit a symlink cycle, since
+						// IGNORE_DIRS screens by name, not link-ness. Symlinked FILES stay in
+						// scope, as at base — hence the guard sits on this arm only.
+						const isSymlink = yield* fs.readLink(abs).pipe(
+							Effect.as(true),
+							Effect.orElseSucceed(() => false),
+						);
+						if (!isSymlink && !IGNORE_DIRS.has(name)) yield* walk(abs);
 						continue;
 					}
 					if (stat.type !== "File" || !isTestFile(name)) continue;

--- a/packages/pipeline-cli/src/tools/patch-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/patch-guard/gate.unit.test.ts
@@ -9,7 +9,7 @@
  * this file — itself a `*.test.ts` the real-tree scan reads — never contributes a stray
  * pin marker of its own; the fixtures it writes live under an out-of-repo temp dir.
  */
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {dirname, join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
@@ -21,11 +21,16 @@ import {CheckFailed, checkPatchGuard} from "./gate.ts";
 const TAG = ["@patch", "pin:"].join("-");
 
 let root: string;
+// A second temp tree OUTSIDE `root`, so anything the walk reaches in it was reached
+// through a symlink planted in `root` and not by ordinary recursion.
+let outside: string;
 beforeEach(() => {
 	root = mkdtempSync(join(tmpdir(), "patch-guard-gate-"));
+	outside = mkdtempSync(join(tmpdir(), "patch-guard-outside-"));
 });
 afterEach(() => {
 	rmSync(root, {recursive: true, force: true});
+	rmSync(outside, {recursive: true, force: true});
 });
 
 const writeWorkspace = (
@@ -44,7 +49,11 @@ const writeWorkspace = (
 
 /** Write a `*.test.ts` file carrying a pin marker for `key`, at a nested repo path. */
 const writePin = (relPath: string, key: string) => {
-	const abs = join(root, relPath);
+	writePinAt(join(root, relPath), key);
+};
+
+/** `writePin`, addressed absolutely — lets a fixture live outside `root`. */
+const writePinAt = (abs: string, key: string) => {
 	mkdirSync(dirname(abs), {recursive: true});
 	writeFileSync(abs, `// ${TAG} ${key}\nimport {expect} from "vitest";\n`, "utf8");
 };
@@ -74,6 +83,27 @@ describe("checkPatchGuard — the CI exit-code gate over a fake repo dir", () =>
 		writePin(".claude/worktrees/sib/y.test.ts", "alchemy@2.0.0-beta.59");
 		const exit = await run(checkPatchGuard(root));
 		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	// Traversal semantics are part of the exit-code contract, so they get pinned here: a
+	// symlinked DIR is out of scope and a symlinked FILE is in scope, matching the
+	// pre-migration lstat-based walk (see `gatherMarkers`). Without the gate in gate.ts the
+	// first of these flips a real red to green — a guard failing open.
+	it("does NOT recurse a symlinked directory — a pin only reachable through one leaves the patch UNPINNED", async () => {
+		writeWorkspace(["alchemy@2.0.0-beta.59"]);
+		writePinAt(join(outside, "pinned.test.ts"), "alchemy@2.0.0-beta.59");
+		symlinkSync(outside, join(root, "linked"), "dir");
+		const exit = await run(checkPatchGuard(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("DOES scan a symlinked file — a pin behind a linked *.test.ts still satisfies the patch", async () => {
+		writeWorkspace(["alchemy@2.0.0-beta.59"]);
+		writePinAt(join(outside, "pinned.test.ts"), "alchemy@2.0.0-beta.59");
+		mkdirSync(join(root, "apps/web/tests"), {recursive: true});
+		symlinkSync(join(outside, "pinned.test.ts"), join(root, "apps/web/tests/linked.test.ts"));
+		const exit = await run(checkPatchGuard(root));
+		expect(Exit.isSuccess(exit)).toBe(true);
 	});
 
 	it("FAILS (CheckFailed) when a patched dep has no pin marker", async () => {

--- a/packages/pipeline-cli/src/tools/patch-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/patch-guard/gate.unit.test.ts
@@ -12,8 +12,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {dirname, join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkPatchGuard} from "./gate.ts";
 
 // The literal marker tag, kept non-contiguous in source (see file docblock).
@@ -48,7 +49,11 @@ const writePin = (relPath: string, key: string) => {
 	writeFileSync(abs, `// ${TAG} ${key}\nimport {expect} from "vitest";\n`, "utf8");
 };
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3472);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
 

--- a/packages/pipeline-cli/src/tools/redact-leaks/command.ts
+++ b/packages/pipeline-cli/src/tools/redact-leaks/command.ts
@@ -12,7 +12,7 @@
  * (not `Console.log`) so a leak-free body is emitted byte-for-byte, no appended newline (#3021 AC5).
  */
 import {readFileSync} from "node:fs";
-import {Console, Effect, Option} from "effect";
+import {Console, Effect, FileSystem, Option, type PlatformError} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {findCommentLeaks} from "../leak-guard/leak-guard.ts";
 import {redactLeaks} from "./redact-leaks.ts";
@@ -22,13 +22,16 @@ const bodyFileFlag = Flag.string("body-file").pipe(
 	Flag.withDescription("path to the body to redact (default: read the body from stdin)"),
 );
 
-const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string> =>
-	Effect.sync(() =>
-		Option.match(bodyFile, {
-			onNone: () => readFileSync(0, "utf8"),
-			onSome: (path) => readFileSync(path, "utf8"),
-		}),
-	);
+const readBody = (
+	bodyFile: Option.Option<string>,
+): Effect.Effect<string, PlatformError.PlatformError, FileSystem.FileSystem> =>
+	Option.match(bodyFile, {
+		// stdin (fd 0): a node-only boundary — FileSystem exposes no stdin reader, so kept raw
+		// (.patterns/effect-platform-access.md bright line). A `--body-file` path routes the fs seam.
+		onNone: () => Effect.sync(() => readFileSync(0, "utf8")),
+		onSome: (path) =>
+			Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf8")),
+	});
 
 export const redactLeaksCommand = Command.make(
 	"redact-leaks",

--- a/packages/pipeline-cli/src/tools/settings-env-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/command.ts
@@ -16,26 +16,34 @@
  * file, undistinguished). `CheckFailed` is caught inside the handler (not at the
  * bin's run boundary) so the contract survives folding into the shared bin.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkSettingsEnv} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Mirrors `findRootDir`'s pure upward walk (dirname to
+// the fixpoint, then fall back to the start), but the marker check is the fs seam — `fs.exists`
+// yields an Effect. Marker-existence faults fall through as false, matching `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -44,8 +52,10 @@ const rootFlag = Flag.string("root").pipe(
 	),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
@@ -60,9 +70,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkSettingsEnv(resolveRoot(rootOpt)).pipe(
-			Effect.catchTag("CheckFailed", onCheckFailed),
-		);
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkSettingsEnv(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/settings-env-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/gate.ts
@@ -9,10 +9,13 @@
  * core (`settings-env-guard.ts`). It fails `CheckFailed` (exit non-zero) when any
  * env value carries a `${...}`; a missing/unreadable/unparseable settings.json is
  * an `IoError` (also non-zero) — fail-closed on the file we can't scan (ADR 0092).
+ *
+ * The settings-file read goes through the Effect `FileSystem`/`Path` seam (over the bin's
+ * `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for real disk
+ * (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the `IoError`
+ * this gate already carries.
  */
-import {readFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {type EnvEntry, judge, renderReport} from "./settings-env-guard.ts";
 
@@ -40,10 +43,20 @@ const envEntries = (settings: unknown): ReadonlyArray<EnvEntry> => {
 };
 
 /** Read + JSON-parse `<root>/.claude/settings.json`; an IO/parse failure is fail-closed. */
-const readSettings = (root: string): Effect.Effect<unknown, IoError> =>
-	Effect.try({
-		try: () => JSON.parse(readFileSync(join(root, SETTINGS_PATH), "utf8")) as unknown,
-		catch: (cause) => new IoError({path: join(root, SETTINGS_PATH), cause}),
+const readSettings = (
+	root: string,
+): Effect.Effect<unknown, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, SETTINGS_PATH);
+		const text = yield* fs
+			.readFileString(target, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
+		return yield* Effect.try({
+			try: () => JSON.parse(text) as unknown,
+			catch: (cause) => new IoError({path: target, cause}),
+		});
 	});
 
 /**
@@ -51,7 +64,9 @@ const readSettings = (root: string): Effect.Effect<unknown, IoError> =>
  * unexpanded `${...}`, else `CheckFailed`. Fails closed (`IoError`) on a
  * missing/unreadable/unparseable settings file (ADR 0092).
  */
-export const checkSettingsEnv = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkSettingsEnv = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const settings = yield* readSettings(root);
 		const verdict = judge(envEntries(settings));

--- a/packages/pipeline-cli/src/tools/settings-env-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/gate.unit.test.ts
@@ -8,8 +8,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkSettingsEnv, IoError} from "./gate.ts";
 
 let root: string;
@@ -29,7 +30,11 @@ const writeSettings = (settings: unknown) => {
 	);
 };
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3472);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;


### PR DESCRIPTION
## What

Migrate the raw `node:fs` / `node:path` production imports in the **leak / redact / patch / settings-env** security-guard cluster (m32 @effect/platform migration) to the v4 Effect platform idiom per [`.patterns/effect-platform-access.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/effect-platform-access.md): IO routes through `FileSystem.FileSystem` / `Path.Path` yielded from `effect`, discharged by the `NodeServices.layer` that `run.ts` already provides — **no new layer wiring**.

Behavior-preserving refactor; the fail-closed security semantics are unchanged.

## Files (this issue's disjoint tool cluster)

- `leak-guard/command.ts`, `leak-guard/crew-gate.ts` (+ `crew-gate.test.ts`)
- `redact-leaks/command.ts`
- `patch-guard/command.ts`, `patch-guard/gate.ts` (+ `gate.unit.test.ts`)
- `settings-env-guard/command.ts`, `settings-env-guard/gate.ts` (+ `gate.unit.test.ts`)
- `class-probe/command.ts`

## How

- **Gate cores** (`patch-guard/gate.ts`, `settings-env-guard/gate.ts`, `leak-guard/crew-gate.ts`) now cross their working-tree/config reads and recursive directory walks over the fs seam. A `PlatformError` folds into the `IoError` each gate already carries, so exit codes and fail-closed (ADR 0092) behavior are identical.
- **`defaultRoot` repo-root resolvers** become the `fs.exists` / `Path` upward-walk Effect (mirroring the already-migrated `catalog-guard`); `resolveRoot` returns an Effect and the handlers `yield*` it.
- **v4 idiom** (`FileSystem` / `Path` from `effect` + `@effect/platform-node` `NodeServices.layer`), not the v3 `@effect/platform` / `NodeContext` API.
- **Bright-line raw `node:*` boundaries preserved** per the doc: stdin (fd 0) reads have no `FileSystem` reader and stay raw (`readFileSync(0)`); only the `--body-file` / `--files-from` path branches route the seam. `bin.ts` is untouched.
- The three gate `unit` tests provide `NodeServices.layer` in their `run` helper so the real-temp-dir IO they assert over resolves the seam (same pattern as `catalog-guard/gate.unit.test.ts`).

## Verification

- `pnpm --filter @kampus/pipeline-cli typecheck` — clean
- `pnpm biome check` (touched files) — clean
- Full package suite: **1954 tests passed** (incl. the 201 across these five tool clusters)

## Scope note

Strictly within this issue's tool cluster — disjoint from the sibling m32 children (#3470, #3471, #3473, #3474) to stay parallel-safe.

**§CP:** touches `packages/pipeline-cli/` → banks for a human merge by **@kamp-us/control-plane**; does not auto-ship.

Fixes #3472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LxQ5T7AqZEowBFX5t7awW