### PR TITLE
fix(pano): link-post title routes to the post detail everywhere; domain label carries the URL (#2437)

### DIFF
--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -120,6 +120,15 @@
 .kp-pano-post__site::after {
 	content: ")";
 }
+/* The domain label is the outbound source link on a link post (#2437); the ↗ cue
+   carries the affordance, this hover confirms it's clickable (a plain span for a
+   text post's "yazı" label ignores it). */
+a.kp-pano-post__site {
+	text-decoration: none;
+}
+a.kp-pano-post__site:hover {
+	color: var(--link);
+}
 
 .kp-pano-post__tags {
 	display: inline-flex;

--- a/apps/web/src/components/pano/PanoPostCard.routing.test.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.routing.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Title/domain routing on the feed card (#2437, founder ruling). A link-type row's
+ * TITLE routes to the post detail (`/pano/:id`) everywhere — never off-site — and the
+ * external URL lives on the domain label with an outbound cue. A text row (no `url`)
+ * keeps the "yazı" label as a plain span. Mirrors the compose test's fate/session mocks.
+ */
+import {render} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import type {useSession as useSessionType} from "../../auth/client";
+import {PanoPostCard} from "./PanoPostCard";
+
+type SessionResult = ReturnType<typeof useSessionType>;
+
+let rowData: Record<string, unknown>;
+
+vi.mock("react-fate", () => ({
+	useLiveView: () => rowData,
+	view: () => () => ({}),
+}));
+
+vi.mock("../../auth/client", () => ({
+	useSession: () => ({data: null, isPending: false}) as SessionResult,
+}));
+
+vi.mock("./PanoPost", () => ({
+	PostVoteWidget: () => <span data-testid="vote" />,
+	PostSaveButton: () => <span data-testid="save" />,
+}));
+
+const ref = {id: "p1"} as never;
+
+function linkRow(): Record<string, unknown> {
+	return {
+		id: "p1",
+		title: "bir bağlantı",
+		url: "https://example.com/article",
+		host: "example.com",
+		score: 7,
+		commentCount: 2,
+		createdAt: new Date("2026-07-01T00:00:00Z"),
+		author: "yazar",
+		authorId: "author-x",
+		slug: "bir-baglanti",
+		tags: [],
+	};
+}
+
+function textRow(): Record<string, unknown> {
+	return {...linkRow(), title: "bir yazı", url: null, host: null, slug: "bir-yazi"};
+}
+
+function renderCard() {
+	return render(
+		<MemoryRouter>
+			<PanoPostCard post={ref} />
+		</MemoryRouter>,
+	);
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("PanoPostCard — link-post routing (#2437)", () => {
+	it("routes the title to the post detail (/pano/:slug), NOT the external URL", () => {
+		rowData = linkRow();
+		const title = renderCard().container.querySelector(".kp-pano-post__title");
+		expect(title?.getAttribute("href")).toBe("/pano/bir-baglanti");
+	});
+
+	it("puts the external URL on the domain label, opening in a new tab", () => {
+		rowData = linkRow();
+		const site = renderCard().container.querySelector("a.kp-pano-post__site");
+		expect(site?.getAttribute("href")).toBe("https://example.com/article");
+		expect(site?.getAttribute("target")).toBe("_blank");
+		expect(site?.getAttribute("rel")).toContain("noopener");
+		expect(site?.textContent).toContain("example.com");
+	});
+
+	it("a text post (no url) keeps its title internal and renders no external link", () => {
+		rowData = textRow();
+		const {container} = renderCard();
+		expect(container.querySelector(".kp-pano-post__title")?.getAttribute("href")).toBe(
+			"/pano/bir-yazi",
+		);
+		expect(container.querySelector("a.kp-pano-post__site")).toBeNull();
+		expect(container.querySelector("span.kp-pano-post__site")?.textContent).toBe("yazı");
+	});
+});

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -133,13 +133,22 @@ export function PanoPostCard({
 							))}
 						</span>
 					) : null}
-					<a className="kp-pano-post__title kp-prose" href={data.url ?? href} title={data.title}>
+					{/* Title routes to the post detail EVERYWHERE — feed, saved, search — matching
+					    the landing row; the external URL lives on the domain label below + the
+					    detail hero. See the founder ruling on #2437 (discussion-first: the title
+					    lands people on the conversation, the domain label is the source link-out). */}
+					<Link className="kp-pano-post__title kp-prose" to={href} title={data.title}>
 						{data.title}
-					</a>
-					{data.host ? (
-						<Link className="kp-pano-post__site" to={`/pano/site/${data.host}`}>
-							{data.host}
-						</Link>
+					</Link>
+					{data.url ? (
+						<a
+							className="kp-pano-post__site"
+							href={data.url}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							{data.host ?? data.url} ↗
+						</a>
 					) : siteLabel ? (
 						<span className="kp-pano-post__site">{siteLabel}</span>
 					) : null}

--- a/apps/web/src/pages/LandingPage.css
+++ b/apps/web/src/pages/LandingPage.css
@@ -195,6 +195,18 @@
 	font-weight: 400;
 	color: var(--text-muted);
 }
+/* The outbound source link on a link post, in parity with the pano feed card's
+   domain label (#2437) — the title routes to the discussion, the domain to the URL. */
+.kp-landing-row__site {
+	display: block;
+	font: var(--t-meta);
+	color: var(--text-muted);
+	text-decoration: none;
+	margin-top: 1px;
+}
+.kp-landing-row__site:hover {
+	color: var(--link);
+}
 .kp-landing-row__meta {
 	font: var(--t-meta);
 	color: var(--text-muted);

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -34,6 +34,8 @@ const LandingPostView = view<Post>()({
 	id: true,
 	slug: true,
 	title: true,
+	url: true,
+	host: true,
 	score: true,
 	author: true,
 	createdAt: true,
@@ -215,6 +217,16 @@ function LandingPostRow({node, rank}: {node: ViewRef<"Post">; rank: number}) {
 				<Link className="kp-landing-row__title" to={`/pano/${p.slug ?? p.id}`}>
 					{p.title}
 				</Link>
+				{p.url ? (
+					<a
+						className="kp-landing-row__site"
+						href={p.url}
+						target="_blank"
+						rel="noreferrer noopener"
+					>
+						{p.host ?? p.url} ↗
+					</a>
+				) : null}
 				<div className="kp-landing-row__meta">
 					<span>{p.score} oy</span>
 					<span className="dot">·</span>


### PR DESCRIPTION
Fixes #2437 — the last open item in the Four Pillars founding arc (#17).

## What & why

Founder ruling (2026-07-19, reaffirmed in the 2026-07-24 live tiebreak that retired the earlier "HN idiom everywhere" ruling): for a **link-type** pano row the **title routes to `/pano/:id`** on **every** surface — feed, saved, search, and the landing row — so the click lands people on the discussion (kamp.us/pano is discussion-first; the link is the seed). The external URL moves to the **host/domain label** affordance with a subtle `↗` outbound cue, and stays the hero on the detail page.

## Changes

- **`PanoPostCard.tsx`** (shared by `PanoFeed`, `SavedPostsPage`, `SearchPage`): title `<a href={url ?? href}>` → `<Link to={href}>` (always the internal detail route). The site label becomes the **external link** for a link post (`{host ?? url} ↗`, new tab); a text post keeps its plain `yazı` span.
- **`PanoPost.css`**: hover affordance for the anchor variant of the domain label (`--link`).
- **`LandingPostRow`** (`LandingPage.tsx`): title was already `→ detail`; added the domain→external label for parity. `LandingPostView` gains `url`/`host`.
- **`LandingPage.css`**: the landing domain-label style.
- **Detail hero**: already present in `PanoPostHeader.tsx` (`kp-pano-postpage__url` — `{host ?? url} ↗`, `target="_blank"`). No change needed.
- **New test** `PanoPostCard.routing.test.tsx`: pins title→detail + domain→external (new tab) for a link post, and internal title with no external link for a text post.

## Design

Role tokens only (`--link`, `--text-muted`, `--t-meta`); the `↗` cue mirrors the existing detail-page external-link affordance (Pillar 2 cohesiveness). `MetaRow` / `Link` primitives reused, nothing hand-built. `design-token-guard` green.

## Displaced affordance (follow-up filed)

The card's domain label previously linked to the `/pano/site/:host` host feed; the ruling repurposes that exact element to the source URL, so the **in-card entry point** to the host feed is displaced (the route itself is unchanged and reachable). Filed as a follow-up for triage to decide whether/where to re-home it.

## Verification (local)

- `vitest --project client` — 268 passed (incl. the new routing test + the compose tests).
- `tsc --noEmit` (apps/web) — clean.
- `biome check` on changed files — clean.
- `pipeline-cli design-token-guard check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LxQ5T7AqZEowBFX5t7awW