### PR TITLE
fix(campaign): anchor the approval marker to the comment's first line (#3831)

### DIFF
--- a/packages/pipeline-cli/src/tools/campaign/README.md
+++ b/packages/pipeline-cli/src/tools/campaign/README.md
@@ -26,8 +26,11 @@ campaign-approve: <wave-label> · <ISO-8601-UTC>
   committed artifact and the trust anchor stays configurable.
 
 The marker is emphasis-tolerant (a leading `**`), case-insensitive on the keyword, and anchored to
-line one — a comment that merely *quotes* the marker mid-body never counts (the same line-one
-anchoring the `verdict` and `claim` markers use).
+line one: the grammar is matched against the comment's **first line only**, so an approval may
+carry rationale prose on the lines below the marker, while a comment that merely *quotes* the
+marker further down never counts (the same line-one anchoring the `verdict` and `claim` markers
+use). "First line" is literal — a marker preceded by a blank line is not on line one and does not
+count.
 
 The shape is grounded in the **gated-audit-wave play**, where audit findings are returned to the
 founder for approval *before* anything is filed; this verifier is the checkable seam that pins that

--- a/packages/pipeline-cli/src/tools/campaign/campaign-trace.ts
+++ b/packages/pipeline-cli/src/tools/campaign/campaign-trace.ts
@@ -25,18 +25,28 @@
  *                    artifact; the founder login is a parameter this core compares against).
  *
  * The marker is emphasis-tolerant (a leading `**`), case-insensitive on the keyword, and anchored
- * to line one — a comment that merely *quotes* the marker mid-body never counts (the same
- * line-one anchoring the `verdict` and `claim` markers use). This module never touches the
- * network or disk; the `gh api` boundary that gathers the cluster + its markers lives in `github.ts`.
+ * to line one — the grammar is matched against the comment's FIRST line only, so an approval may
+ * carry rationale prose on the lines below it, while a comment that merely *quotes* the marker
+ * further down never counts (the same line-one anchoring the `verdict` and `claim` markers use).
+ * This module never touches the network or disk; the `gh api` boundary that gathers the cluster +
+ * its markers lives in `github.ts`.
  */
 
 /** The ISO-8601 UTC instant grammar the approval timestamp must satisfy (a `Z` suffix ⇒ UTC). */
 const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
 
 /**
- * The approval-marker keyword prefix — "does this comment even attempt an approval?" Line-one
- * anchored (no `m` flag), emphasis-tolerant, case-insensitive. Separates an approval *attempt*
- * (which, if malformed, fails closed as `malformed`) from unrelated chatter (which is `absent`).
+ * The comment's first line — the only line the approval marker may occupy. Both marker regexes
+ * below are matched against *this*, never the whole body: that is what makes "anchored to line
+ * one" literal, and it is why an otherwise-conformant approval may carry rationale prose beneath
+ * the marker (matching the whole body made a trailing paragraph read as `malformed`, #3831).
+ */
+const firstLine = (body: string): string => body.split(/\r?\n/, 1)[0] ?? "";
+
+/**
+ * The approval-marker keyword prefix — "does this comment even attempt an approval?"
+ * Emphasis-tolerant, case-insensitive. Separates an approval *attempt* (which, if malformed,
+ * fails closed as `malformed`) from unrelated chatter (which is `absent`).
  */
 const APPROVE_PREFIX_RE = /^\s*\*{0,2}\s*campaign-approve:/i;
 
@@ -127,8 +137,9 @@ const classify = (
 	comment: ApprovalComment,
 	waveLabel: string,
 ): WellFormedApproval | "attempt" | null => {
-	if (!APPROVE_PREFIX_RE.test(comment.body)) return null;
-	const m = APPROVE_RE.exec(comment.body);
+	const line = firstLine(comment.body);
+	if (!APPROVE_PREFIX_RE.test(line)) return null;
+	const m = APPROVE_RE.exec(line);
 	const label = m?.groups?.label;
 	const ts = m?.groups?.ts;
 	if (label === undefined || ts === undefined) return "attempt";
@@ -218,7 +229,7 @@ export const verifyTrace = (input: VerifyTraceInput): TraceVerdict => {
 		return {
 			pass: false,
 			reason: "malformed",
-			detail: `a campaign-approve marker was found on the '${waveLabel}' cluster but it is malformed or bound to a different wave — the trace must read exactly 'campaign-approve: ${waveLabel} · <ISO-8601-UTC>'`,
+			detail: `a campaign-approve marker was found on the '${waveLabel}' cluster but it is malformed or bound to a different wave — the comment's FIRST line must read exactly 'campaign-approve: ${waveLabel} · <ISO-8601-UTC>' (rationale prose may follow on the lines below it)`,
 		};
 	}
 	return {

--- a/packages/pipeline-cli/src/tools/campaign/campaign-trace.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/campaign/campaign-trace.unit.test.ts
@@ -69,6 +69,20 @@ describe("verifyTrace — PASS only on a present, well-formed, founder-authored,
 		expect(v.pass).toBe(true);
 	});
 
+	it("PASSES when the marker is line one and rationale prose follows below it (#3831)", () => {
+		const v = verifyTrace(
+			input({
+				comments: [
+					comment({
+						body: `campaign-approve: ${WAVE} · 2026-07-10T12:00:00Z\n\nApproving after the audit readout — the three p0 findings are worth a campaign.`,
+					}),
+				],
+			}),
+		);
+		expect(v.pass).toBe(true);
+		expect(v.pass && v.at).toBe("2026-07-10T12:00:00Z");
+	});
+
 	it("records the EARLIEST founder approval when several exist", () => {
 		const v = verifyTrace(
 			input({
@@ -120,9 +134,32 @@ describe("verifyTrace — fails closed on ABSENCE", () => {
 		);
 		expect(v.reason).toBe("absent");
 	});
+
+	it("does not count a marker pushed off line one by a leading blank line", () => {
+		const v = asFail(
+			verifyTrace(
+				input({
+					comments: [comment({body: `\ncampaign-approve: ${WAVE} · 2026-07-10T12:00:00Z`})],
+				}),
+			),
+		);
+		expect(v.reason).toBe("absent");
+	});
 });
 
 describe("verifyTrace — fails closed on MALFORMATION", () => {
+	it("FAILS malformed when line one is a broken marker followed by prose", () => {
+		const v = asFail(
+			verifyTrace(
+				input({
+					comments: [comment({body: `campaign-approve: ${WAVE}\n\nApproving this wave.`})],
+				}),
+			),
+		);
+		expect(v.reason).toBe("malformed");
+		expect(v.detail).toContain("FIRST line");
+	});
+
 	it("FAILS malformed when the separator/timestamp is missing", () => {
 		const v = asFail(
 			verifyTrace(input({comments: [comment({body: `campaign-approve: ${WAVE}`})]})),


### PR DESCRIPTION
Fixes #3831

## What

`campaign verify-trace`'s docs and implementation disagreed on where the founder-approval marker may sit. All three doc surfaces say the comment's **first line**; `classify` exec'd the `$`-anchored, no-`m`-flag `APPROVE_RE` against the **whole body**, so `$` only matched end-of-input. A doc-conformant approval — marker on line 1, rationale prose below (the natural way a founder writes one) — matched `APPROVE_PREFIX_RE` but not the full grammar, classified as an `attempt`, and failed the gate as `malformed`.

**Direction chosen: line-one anchoring wins** — it is what all three doc surfaces already promise, it matches the sibling `verdict`/`claim` marker convention the module doc cites, and it needs no change to `claude-plugins/kampus-pipeline/skills/campaign/SKILL.md` (so no control-plane skill edit).

## How

- `campaign-trace.ts`: added a `firstLine(body)` helper and matched **both** marker regexes against it instead of the whole body. The regexes themselves are untouched — extracting line one makes "anchored to line one" literal in the code rather than encoded in regex trailing-anchor trickery.
- `malformed` detail now states the real grammar: the comment's **FIRST** line must read exactly `campaign-approve: <wave> · <ISO-8601-UTC>`, and rationale prose may follow below it.
- Module doc + tool `README.md` state the same grammar, including that "first line" is literal (a marker preceded by a blank line is not on line one).

## The gate is not weakened

This only widens what may follow the marker line. Every authorization property is unchanged: founder authorship, wave-label binding, ISO-8601-UTC validity, earliest-approval selection, and default-DENY on absent/malformed/non-founder/zero-scope. A marker **quoted further down the body still never counts** (existing test unchanged and passing). One behavior is *tightened*, not loosened: a marker pushed off line one by a leading blank line previously matched (`^\s*` consumed the newline) and now does not — a fail-closed direction, newly pinned by a test.

## Tests

`packages/pipeline-cli/src/tools/campaign/campaign-trace.unit.test.ts` — 25 passing, three new cases:

- PASS: marker on line 1 + blank line + rationale prose (the divergent input from #3831).
- `malformed`: a broken marker on line 1 followed by prose, asserting the detail names the FIRST-line grammar.
- `absent`: a marker pushed off line one by a leading blank line.

Existing mid-body-quoted-marker case still resolves `absent`.

## Acceptance criteria

- [x] The three doc surfaces and the implementation state the same marker-placement grammar (the SKILL's "first line" wording needed no edit — the implementation moved to it).
- [x] A unit test covers a marker-on-line-1 body with trailing context prose.
- [x] The existing mid-body-quoted-marker case still never counts.
- [x] The `malformed` detail message states the actual grammar.

Verified locally: `pnpm vitest run src/tools/campaign/campaign-trace.unit.test.ts` (25 passed), `pnpm typecheck`, `pnpm biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UScdSr9uPL1tE1MBbSPvif
