### PR TITLE
chore(pipeline-cli): migrate reporting & misc tools to the v4 Effect platform idiom (#3474)

### DIFF
--- a/packages/pipeline-cli/src/golden-fixture.ts
+++ b/packages/pipeline-cli/src/golden-fixture.ts
@@ -11,6 +11,10 @@
  * `baseUrl` is the caller's `import.meta.url`; `name` is the fixture path relative to it
  * (by convention `__fixtures__/<handler>.payload.golden.json`), so a handler co-locates its
  * captured payload next to its test. Reusable across every hook/harness handler in the CLI.
+ *
+ * The raw `node:fs`/`node:url` here is deliberate and stays: this is test-only scaffolding whose
+ * whole point is the real committed file on disk, and `fileURLToPath` has no `Path` equivalent —
+ * both sit on the `.patterns/effect-platform-access.md` bright line.
  */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";

--- a/packages/pipeline-cli/src/tools/changelog-derive/command.ts
+++ b/packages/pipeline-cli/src/tools/changelog-derive/command.ts
@@ -17,8 +17,7 @@
  * preserved from the former package's `bin.ts`; only the `Command.run`/`Effect.provide`/
  * `runMain` wiring is dropped — the shared `pipeline-cli` bin owns the run boundary.
  */
-import {readFileSync, writeFileSync} from "node:fs";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem} from "effect";
 import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import {type ChangelogEntry, deriveChangelog, type ReleaseMeta} from "./changelog.ts";
@@ -40,18 +39,28 @@ const EntriesSchema = Schema.Array(EntrySchema);
 
 const decodeEntries = Schema.decodeUnknownEffect(EntriesSchema);
 
-/** Read + JSON-parse + decode the entries file, all failures typed. */
+/**
+ * Read + JSON-parse + decode the entries file, all failures typed. The read crosses the
+ * `FileSystem` seam (`.patterns/effect-platform-access.md`); a `PlatformError` folds into the
+ * same `EntriesReadError` the old `readFileSync` throw did.
+ */
 const loadEntries = (
 	file: string,
-): Effect.Effect<ReadonlyArray<ChangelogEntry>, EntriesReadError> =>
-	Effect.try({
-		try: () => JSON.parse(readFileSync(file, "utf8")) as unknown,
-		catch: (cause) => new EntriesReadError({file, cause}),
-	}).pipe(
-		Effect.flatMap((raw) =>
-			decodeEntries(raw).pipe(Effect.mapError((cause) => new EntriesReadError({file, cause}))),
-		),
-	);
+): Effect.Effect<ReadonlyArray<ChangelogEntry>, EntriesReadError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const text = yield* Effect.mapError(
+			fs.readFileString(file),
+			(cause) => new EntriesReadError({file, cause}),
+		);
+		const raw = yield* Effect.try({
+			try: () => JSON.parse(text) as unknown,
+			catch: (cause) => new EntriesReadError({file, cause}),
+		});
+		return yield* decodeEntries(raw).pipe(
+			Effect.mapError((cause) => new EntriesReadError({file, cause})),
+		);
+	});
 
 const today = (): string => new Date().toISOString().slice(0, 10);
 
@@ -85,10 +94,11 @@ const derive = Command.make(
 
 		if (out._tag === "Some") {
 			const file = out.value;
-			yield* Effect.try({
-				try: () => writeFileSync(file, markdown),
-				catch: (cause) => new EntriesReadError({file, cause}),
-			});
+			const fs = yield* FileSystem.FileSystem;
+			yield* Effect.mapError(
+				fs.writeFileString(file, markdown),
+				(cause) => new EntriesReadError({file, cause}),
+			);
 			yield* Console.error(`changelog-derive: wrote ${loaded.length} entr(y/ies) to ${file}`);
 			return;
 		}

--- a/packages/pipeline-cli/src/tools/eval-harness/command.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/command.ts
@@ -16,8 +16,7 @@
  * Thin IO shell over the pure cores (the `token-spend` / `readme-guard` idiom): read the file,
  * decode, render. An unreadable path and a malformed/mismatched input both exit non-zero.
  */
-import {readFileSync} from "node:fs";
-import {Console, Effect, Result} from "effect";
+import {Console, Effect, FileSystem, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {decodeManifest, STAGES} from "./corpus.ts";
@@ -48,10 +47,11 @@ const check = Command.make(
 	{manifest: manifestArg},
 	Effect.fn(function* ({manifest}) {
 		const run = Effect.gen(function* () {
-			const text = yield* Effect.try({
-				try: () => readFileSync(manifest, "utf8"),
-				catch: () => new ManifestUnreadable({path: manifest}),
-			});
+			const fs = yield* FileSystem.FileSystem;
+			const text = yield* Effect.mapError(
+				fs.readFileString(manifest),
+				() => new ManifestUnreadable({path: manifest}),
+			);
 			const result = decodeManifest(text);
 			if (Result.isFailure(result)) {
 				yield* Console.error(
@@ -118,10 +118,11 @@ const report = Command.make(
 	},
 	Effect.fn(function* ({rows, json, baselineStage, baselineModel}) {
 		const run = Effect.gen(function* () {
-			const text = yield* Effect.try({
-				try: () => readFileSync(rows, "utf8"),
-				catch: () => new RowsUnreadable({path: rows}),
-			});
+			const fs = yield* FileSystem.FileSystem;
+			const text = yield* Effect.mapError(
+				fs.readFileString(rows),
+				() => new RowsUnreadable({path: rows}),
+			);
 			const decoded = decodeReportInput(text);
 			if (Result.isFailure(decoded)) {
 				yield* Console.error(

--- a/packages/pipeline-cli/src/tools/ship-digest/command.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/command.ts
@@ -15,8 +15,7 @@
  * `pipeline-cli` bin owns the run boundary. The git-log/`gh` gather that builds the entries
  * JSON is the `/what-shipped` skill's job, not this tool.
  */
-import {readFileSync, writeFileSync} from "node:fs";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem} from "effect";
 import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import {type DigestWindow, deriveShipDigest, type ShipEntry} from "./digest.ts";
@@ -42,16 +41,28 @@ const EntriesSchema = Schema.Array(EntrySchema);
 
 const decodeEntries = Schema.decodeUnknownEffect(EntriesSchema);
 
-/** Read + JSON-parse + decode the entries file, all failures typed. */
-const loadEntries = (file: string): Effect.Effect<ReadonlyArray<ShipEntry>, EntriesReadError> =>
-	Effect.try({
-		try: () => JSON.parse(readFileSync(file, "utf8")) as unknown,
-		catch: (cause) => new EntriesReadError({file, cause}),
-	}).pipe(
-		Effect.flatMap((raw) =>
-			decodeEntries(raw).pipe(Effect.mapError((cause) => new EntriesReadError({file, cause}))),
-		),
-	);
+/**
+ * Read + JSON-parse + decode the entries file, all failures typed. The read crosses the
+ * `FileSystem` seam (`.patterns/effect-platform-access.md`); a `PlatformError` folds into the
+ * same `EntriesReadError` the old `readFileSync` throw did.
+ */
+const loadEntries = (
+	file: string,
+): Effect.Effect<ReadonlyArray<ShipEntry>, EntriesReadError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const text = yield* Effect.mapError(
+			fs.readFileString(file),
+			(cause) => new EntriesReadError({file, cause}),
+		);
+		const raw = yield* Effect.try({
+			try: () => JSON.parse(text) as unknown,
+			catch: (cause) => new EntriesReadError({file, cause}),
+		});
+		return yield* decodeEntries(raw).pipe(
+			Effect.mapError((cause) => new EntriesReadError({file, cause})),
+		);
+	});
 
 const today = (): string => new Date().toISOString().slice(0, 10);
 
@@ -83,10 +94,11 @@ const derive = Command.make(
 
 		if (out._tag === "Some") {
 			const file = out.value;
-			yield* Effect.try({
-				try: () => writeFileSync(file, markdown),
-				catch: (cause) => new EntriesReadError({file, cause}),
-			});
+			const fs = yield* FileSystem.FileSystem;
+			yield* Effect.mapError(
+				fs.writeFileString(file, markdown),
+				(cause) => new EntriesReadError({file, cause}),
+			);
 			yield* Console.error(`ship-digest: wrote ${loaded.length} entr(y/ies) to ${file}`);
 			return;
 		}

--- a/packages/pipeline-cli/src/tools/token-spend/command.ts
+++ b/packages/pipeline-cli/src/tools/token-spend/command.ts
@@ -13,8 +13,7 @@
  * note + a non-zero exit (this is an explicit, named report target, not a best-effort
  * scan — a bad path is an error, not a silent empty report).
  */
-import {readFileSync} from "node:fs";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command} from "effect/unstable/cli";
 import {formatStageSpend, reconstructSpend} from "./token-spend.ts";
@@ -38,10 +37,11 @@ export const tokenSpendCommand = Command.make(
 	{transcript: transcriptArg},
 	Effect.fn(function* ({transcript}) {
 		const run = Effect.gen(function* () {
-			const text = yield* Effect.try({
-				try: () => readFileSync(transcript, "utf8"),
-				catch: () => new TranscriptUnreadable({path: transcript}),
-			});
+			const fs = yield* FileSystem.FileSystem;
+			const text = yield* Effect.mapError(
+				fs.readFileString(transcript),
+				() => new TranscriptUnreadable({path: transcript}),
+			);
 			const spend = reconstructSpend(text);
 			if (spend.assistantTurns === 0) {
 				yield* Console.error(

--- a/packages/pipeline-cli/src/tools/trivial-diff/command.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/command.ts
@@ -29,7 +29,7 @@
  */
 import {execFileSync} from "node:child_process";
 import {readFileSync} from "node:fs";
-import {Console, Effect, Option} from "effect";
+import {Console, Effect, FileSystem, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
@@ -67,18 +67,24 @@ const repoFlag = Flag.string("repo").pipe(
 	),
 );
 
-/** Read the diff: from `--diff-file` if given, else stdin (fd 0). Any read failure ⇒ null (fail-closed). */
-const readDiff = (diffFile: Option.Option<string>): string | null => {
-	// biome-ignore lint/plugin: best-effort read — any read failure is absorbed into null (fail-closed: the core then refuses), never the E channel; a total helper, not Effect-cosplay.
+/**
+ * Read the diff: from `--diff-file` over the `FileSystem` seam if given, else stdin (fd 0),
+ * which has no `FileSystem` equivalent and so stays a raw `node:fs` read at this boundary
+ * (`.patterns/effect-platform-access.md`). Any read failure ⇒ null (fail-closed: the core then
+ * refuses).
+ */
+const readDiff = Effect.fn(function* (diffFile: Option.Option<string>) {
+	if (Option.isSome(diffFile)) {
+		const fs = yield* FileSystem.FileSystem;
+		return yield* Effect.orElseSucceed(fs.readFileString(diffFile.value), () => null);
+	}
+	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into null (fail-closed: the core then refuses), never the E channel; a total helper, not Effect-cosplay.
 	try {
-		return Option.match(diffFile, {
-			onSome: (path) => readFileSync(path, "utf8"),
-			onNone: () => readFileSync(0, "utf8"),
-		});
+		return readFileSync(0, "utf8");
 	} catch {
 		return null;
 	}
-};
+});
 
 /** Resolve owner/repo: `--repo`, else `CLAUDE_PIPELINE_REPO`, else `gh repo view`. null on failure. */
 const resolveRepo = (repo: Option.Option<string>): string | null => {
@@ -127,7 +133,7 @@ const classifyCmd = Command.make(
 		const formatsRaw = fetchFormatsRaw(resolveRepo(repo));
 		const controlPlaneRe = formatsRaw === null ? null : extractControlPlaneRe(formatsRaw);
 		const guardAdrRe = formatsRaw === null ? null : parseGuardAdrRe(formatsRaw);
-		const diff = readDiff(diffFile);
+		const diff = yield* readDiff(diffFile);
 		if (diff === null) {
 			// Unreadable diff is itself fail-closed: classify as non-trivial.
 			yield* Effect.sync(() =>

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -27,7 +27,7 @@
  * requirement is the Node platform union (the registry seam, epic #994).
  */
 import {readFileSync} from "node:fs";
-import {Console, Effect, Option} from "effect";
+import {Console, Effect, FileSystem, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {Github, GithubLive} from "./github.ts";
 import {
@@ -107,13 +107,17 @@ const read = Command.make(
 	),
 );
 
-const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string, never> =>
-	Effect.sync(() =>
-		Option.match(bodyFile, {
-			onNone: () => readFileSync(0, "utf8"),
-			onSome: (path) => readFileSync(path, "utf8"),
-		}),
-	);
+/**
+ * Read the composed verdict body: from `--body-file` over the `FileSystem` seam, else from
+ * stdin. Stdin (fd 0) has no `FileSystem` equivalent, so that read stays a raw `node:fs` call
+ * at this boundary (`.patterns/effect-platform-access.md` bright line). An unreadable
+ * `--body-file` stays a defect (`Effect.orDie`), preserving the pre-migration crash-out.
+ */
+const readBody = Effect.fn(function* (bodyFile: Option.Option<string>) {
+	if (Option.isNone(bodyFile)) return readFileSync(0, "utf8");
+	const fs = yield* FileSystem.FileSystem;
+	return yield* Effect.orDie(fs.readFileString(bodyFile.value));
+});
 
 const post = Command.make(
 	"post",


### PR DESCRIPTION
Migrates the **reporting & misc tools** slice of the pipeline-cli `@effect/platform` wave to the v4 Effect platform idiom (`.patterns/effect-platform-access.md`). Every raw `node:fs` **production** read/write in the slice now goes through `FileSystem` yielded from `effect`; the requirement discharges through the `NodeServices.layer` that `packages/pipeline-cli/src/run.ts` already provides — **no new layer wiring**.

This is the last child of milestone 32; its landing closes the wave.

## Migrated (`FileSystem.FileSystem` from `effect`)

| File | Change |
|---|---|
| `packages/pipeline-cli/src/tools/verdict/command.ts` | `readBody` reads `--body-file` via `fs.readFileString`; unreadable file stays a **defect** (`Effect.orDie`), matching the old `readFileSync` throw |
| `packages/pipeline-cli/src/tools/ship-digest/command.ts` | `loadEntries` read + `--out` write; `PlatformError` folds into the existing `EntriesReadError` |
| `packages/pipeline-cli/src/tools/changelog-derive/command.ts` | same shape as ship-digest (read + `--out` write → `EntriesReadError`) |
| `packages/pipeline-cli/src/tools/eval-harness/command.ts` | `check` manifest read → `ManifestUnreadable`; `report` rows read → `RowsUnreadable` |
| `packages/pipeline-cli/src/tools/token-spend/command.ts` | transcript read → `TranscriptUnreadable` |
| `packages/pipeline-cli/src/tools/trivial-diff/command.ts` | `--diff-file` read via `fs.readFileString` + `Effect.orElseSucceed(() => null)` — the fail-closed `null` ⇒ `non-trivial` path is preserved exactly |

## Bright-line raw `node:*` preserved (per the doc + issue)

- **stdin (fd 0) readers stay raw** — there is no `FileSystem` stdin equivalent. Consequently the two slice files whose *only* fs call is a `readFileSync(0, …)` have nothing to migrate and are **unchanged**: `tools/failure-classifier/command.ts` and `tools/structured-output-guard/command.ts`. Recorded here rather than churned.
- **`src/golden-fixture.ts` — classification verdict: stays raw.** It is imported *only* by `tools/worktree-sweep/create-worktree.hook.test.ts`, i.e. deliberate test-only real-fs scaffolding whose whole point is the committed golden file on disk (ADR 0180), and it resolves the fixture with `fileURLToPath`, which has no `Path` equivalent. Both sit on the doc's bright line. The verdict is recorded in the file's docblock so a later sweep doesn't re-litigate it; no code change.
- `execFileSync` for `git`/`gh` (trivial-diff's repo/formats probes) stays a raw subprocess boundary; `src/bin.ts` untouched.
- Real-fs `*.test.ts` fixtures keep `node:fs`.

## Behavior preservation

Pure refactor — identical exit codes / stdout / stderr / fail-closed semantics (ADR 0092). Verified in-worktree:

- `pnpm --filter @kampus/pipeline-cli typecheck` — clean
- `pnpm --filter @kampus/pipeline-cli test` — **140 files / 1955 tests passed**, including the `ship-digest` / `changelog-derive` / `structured-output-guard` CLI tests that spawn the real bin as a subprocess (so they exercise the migrated paths end to end over the real `NodeServices.layer` — no test layer wiring needed)
- `pnpm lint` (biome) — clean on all touched files
- Live smoke of the migrated call sites: `ship-digest derive` to stdout and to `--out`; missing `--entries` ⇒ `EntriesReadError`, exit 1; `token-spend /nonexistent` ⇒ `token-spend: cannot read transcript …`, exit 1; `eval-harness check /nonexistent` ⇒ `eval-harness: cannot read manifest …`, exit 1; `trivial-diff classify --diff-file /nonexistent` ⇒ `could not read the diff — default-deny` + `non-trivial`; `trivial-diff classify` over stdin still `trivial`; `verdict validate --body-file` ⇒ `ok`, missing body-file ⇒ exit 1.

Scope is strictly the file list in #3474 — disjoint from the sibling children (#3470 PR #3897, #3471, #3472 PR #3898, #3473).

**§CP:** touches `packages/pipeline-cli/` → banks for a human merge by **@kamp-us/control-plane**; does not auto-ship.

Fixes #3474
