### PR TITLE
fix(pipeline-cli): make tracker apply-triage convergent — one label per facet (#3771)

### DIFF
--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -28,10 +28,12 @@ interface Canned {
 	readonly exitCode?: number;
 	readonly stderr?: string;
 }
-type Response = string | Canned;
+// An array fixture answers successive calls on the same key, the last entry repeating — the only
+// way to express a read-modify-read verb (`applyTriage` reads labels before and after its writes).
+type Response = string | Canned | ReadonlyArray<string | Canned>;
 
 const enc = new TextEncoder();
-const normalize = (response: Response): Canned =>
+const normalize = (response: string | Canned): Canned =>
 	typeof response === "string" ? {stdout: response} : response;
 
 const methodOf = (args: ReadonlyArray<string>): string => {
@@ -46,8 +48,10 @@ const methodOf = (args: ReadonlyArray<string>): string => {
  */
 const mockSpawner = (
 	responses: Record<string, Response>,
-): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
-	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+	calls?: Array<string>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> => {
+	const seen = new Map<string, number>();
+	return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
 		ChildProcessSpawner.make(
 			Effect.fnUntraced(function* (command) {
 				let cmd = command;
@@ -59,10 +63,18 @@ const mockSpawner = (
 					(args[0] === "api" ? (args[1] ?? "") : args.slice(0, 2).join(" "));
 				const path = rawPath.replace(/\?.*$/, "");
 				const key = `${methodOf(args)} ${path}`;
+				calls?.push(key);
+				const nth = seen.get(key) ?? 0;
+				seen.set(key, nth + 1);
+				const fixture = responses[key];
 				const canned =
-					key in responses
-						? normalize(responses[key]!)
-						: {stdout: "", exitCode: 1, stderr: `not found: ${key}`};
+					fixture === undefined
+						? {stdout: "", exitCode: 1, stderr: `not found: ${key}`}
+						: normalize(
+								Array.isArray(fixture)
+									? (fixture[Math.min(nth, fixture.length - 1)] ?? "")
+									: (fixture as string | Canned),
+							);
 				return ChildProcessSpawner.makeHandle({
 					pid: ChildProcessSpawner.ProcessId(1),
 					stdin: Sink.drain,
@@ -79,12 +91,14 @@ const mockSpawner = (
 			}),
 		),
 	);
+};
 
 const provide = <A, E>(
 	effect: Effect.Effect<A, E, Tracker>,
 	responses: Record<string, Response>,
+	calls?: Array<string>,
 ): Effect.Effect<A, E | RepoResolutionError> =>
-	effect.pipe(Effect.provide(GithubTrackerLive.pipe(Layer.provide(mockSpawner(responses)))));
+	effect.pipe(Effect.provide(GithubTrackerLive.pipe(Layer.provide(mockSpawner(responses, calls)))));
 
 const TARGET = 900;
 const P = `repos/kamp-us/phoenix`;
@@ -318,6 +332,9 @@ describe("Tracker.readBack — resolve the current owner", () => {
 describe("Tracker.applyTriage — the label-transition envelope over a mock gh spawner", () => {
 	const L = `${P}/issues/${TARGET}/labels`;
 
+	const labelSet = (...names: ReadonlyArray<string>) =>
+		JSON.stringify(names.map((name) => ({name})));
+
 	it.effect("adds type/priority/status, removes needs-triage, reads back → triaged", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;
@@ -330,14 +347,13 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 			});
 		}).pipe((effect) =>
 			provide(effect, {
-				[`POST ${L}`]: JSON.stringify([{name: "type:feature"}, {name: "p2"}]),
+				[`POST ${L}`]: labelSet("type:feature", "p2"),
 				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: "",
-				// read-back reflects the post-transition state: the queue label is gone.
-				[`GET ${L}`]: JSON.stringify([
-					{name: "type:feature"},
-					{name: "p2"},
-					{name: "status:triaged"},
-				]),
+				// pre-read: still queued; read-back reflects the post-transition state.
+				[`GET ${L}`]: [
+					labelSet("status:needs-triage"),
+					labelSet("type:feature", "p2", "status:triaged"),
+				],
 			}),
 		),
 	);
@@ -358,18 +374,47 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 			});
 		}).pipe((effect) =>
 			provide(effect, {
-				[`POST ${L}`]: JSON.stringify([{name: "type:bug"}]),
+				[`POST ${L}`]: labelSet("type:bug"),
 				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: "",
-				[`GET ${L}`]: JSON.stringify([
-					{name: "type:bug"},
-					{name: "p1"},
-					{name: "status:needs-info"},
-				]),
+				[`GET ${L}`]: [
+					labelSet("status:needs-triage"),
+					labelSet("type:bug", "p1", "status:needs-info"),
+				],
 			}),
 		),
 	);
 
-	it.effect("the queue label already absent (404 on remove) → still triaged (idempotent)", () =>
+	it.effect("the queue label already absent → no remove is attempted (idempotent)", () =>
+		Effect.gen(function* () {
+			const calls: Array<string> = [];
+			const result = yield* Effect.gen(function* () {
+				return yield* (yield* Tracker).applyTriage(TARGET, {type: "chore", priority: "p2"});
+			}).pipe((effect) =>
+				provide(
+					effect,
+					{
+						[`POST ${L}`]: labelSet("type:chore"),
+						// a pre-bootstrap issue never carried the queue label; nothing is superseded.
+						[`GET ${L}`]: labelSet("type:chore", "p2", "status:triaged"),
+					},
+					calls,
+				),
+			);
+			assert.deepStrictEqual(result, {
+				_tag: "triaged",
+				type: "chore",
+				priority: "p2",
+				status: "triaged",
+			});
+			// no DELETE fixture exists — an attempted removal would have exited 1 and failed the verb.
+			assert.deepStrictEqual(
+				calls.filter((call) => call.startsWith("DELETE")),
+				[],
+			);
+		}),
+	);
+
+	it.effect("a concurrent removal (404 on remove) is tolerated → still triaged", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;
 			const result = yield* tracker.applyTriage(TARGET, {type: "chore", priority: "p2"});
@@ -381,23 +426,60 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 			});
 		}).pipe((effect) =>
 			provide(effect, {
-				[`POST ${L}`]: JSON.stringify([{name: "type:chore"}]),
-				// a pre-bootstrap issue never carried the queue label → the remove 404s, tolerated.
+				[`POST ${L}`]: labelSet("type:chore"),
+				// the queue label vanished between the pre-read and the remove → 404, tolerated.
 				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: {
 					stdout: "",
 					exitCode: 1,
 					stderr: "HTTP 404: Label does not exist",
 				},
-				[`GET ${L}`]: JSON.stringify([
-					{name: "type:chore"},
-					{name: "p2"},
-					{name: "status:triaged"},
-				]),
+				[`GET ${L}`]: [
+					labelSet("status:needs-triage"),
+					labelSet("type:chore", "p2", "status:triaged"),
+				],
 			}),
 		),
 	);
 
-	it.effect("a non-zero gh add-labels exit → GhCommandError in the E channel", () =>
+	// The #3771 defect: re-prioritizing an already-triaged issue was ADDITIVE, so the old `p2`
+	// survived alongside the new `p1` and the queue's pick order went ambiguous. Same for a re-type.
+	it.effect("re-triage of an already-triaged issue removes the superseded type AND priority", () =>
+		Effect.gen(function* () {
+			const calls: Array<string> = [];
+			const result = yield* Effect.gen(function* () {
+				return yield* (yield* Tracker).applyTriage(TARGET, {type: "decision", priority: "p1"});
+			}).pipe((effect) =>
+				provide(
+					effect,
+					{
+						[`POST ${L}`]: labelSet("type:decision", "p1"),
+						[`DELETE ${P}/issues/${TARGET}/labels/type:bug`]: "",
+						[`DELETE ${P}/issues/${TARGET}/labels/p2`]: "",
+						[`GET ${L}`]: [
+							// already triaged: type:bug / p2 / status:triaged, plus an unrelated label.
+							labelSet("type:bug", "status:triaged", "p2", "epic"),
+							labelSet("type:decision", "status:triaged", "p1", "epic"),
+						],
+					},
+					calls,
+				),
+			);
+			assert.deepStrictEqual(result, {
+				_tag: "triaged",
+				type: "decision",
+				priority: "p1",
+				status: "triaged",
+			});
+			// exactly the two superseded facet members are removed — `status:triaged` is already
+			// the desired member, and `epic` is outside the contract, so neither is touched.
+			assert.deepStrictEqual(calls.filter((call) => call.startsWith("DELETE")).sort(), [
+				`DELETE ${P}/issues/${TARGET}/labels/p2`,
+				`DELETE ${P}/issues/${TARGET}/labels/type:bug`,
+			]);
+		}),
+	);
+
+	it.effect("a non-zero gh label exit → GhCommandError in the E channel", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;
 			const error = yield* Effect.flip(
@@ -405,7 +487,8 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 			);
 			assert.isTrue(error instanceof GhCommandError);
 		}).pipe((effect) =>
-			// no POST fixture → the add-labels call exits 1 → GhCommandError, never a throw.
+			// no fixtures → the label read exits 1 → GhCommandError, never a throw. Only the
+			// per-label REMOVE is 404-tolerant; a failed read or add still fails the verb.
 			provide(effect, {}),
 		),
 	);

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -479,6 +479,43 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 		}),
 	);
 
+	// The status facet owns the pickability spine, not the whole `status:` namespace: an issue
+	// dark-shipped behind a flag carries `status:awaiting-release` alongside `status:triaged`, and
+	// that marker IS the human release queue's membership. A re-prioritize that removed it would
+	// silently orphan the pending flag flip.
+	it.effect("a re-prioritize retains an orthogonal `status:awaiting-release`", () =>
+		Effect.gen(function* () {
+			const calls: Array<string> = [];
+			const result = yield* Effect.gen(function* () {
+				return yield* (yield* Tracker).applyTriage(TARGET, {type: "bug", priority: "p1"});
+			}).pipe((effect) =>
+				provide(
+					effect,
+					{
+						[`POST ${L}`]: labelSet("type:bug", "p1"),
+						[`DELETE ${P}/issues/${TARGET}/labels/p2`]: "",
+						[`GET ${L}`]: [
+							labelSet("type:bug", "status:triaged", "p2", "status:awaiting-release"),
+							labelSet("type:bug", "status:triaged", "p1", "status:awaiting-release"),
+						],
+					},
+					calls,
+				),
+			);
+			assert.deepStrictEqual(result, {
+				_tag: "triaged",
+				type: "bug",
+				priority: "p1",
+				status: "triaged",
+			});
+			// only the superseded priority is removed — the release-queue marker survives.
+			assert.deepStrictEqual(
+				calls.filter((call) => call.startsWith("DELETE")),
+				[`DELETE ${P}/issues/${TARGET}/labels/p2`],
+			);
+		}),
+	);
+
 	it.effect("a non-zero gh label exit → GhCommandError in the E channel", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;
@@ -490,6 +527,19 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 			// no fixtures → the label read exits 1 → GhCommandError, never a throw. Only the
 			// per-label REMOVE is 404-tolerant; a failed read or add still fails the verb.
 			provide(effect, {}),
+		),
+	);
+
+	it.effect("a non-zero exit on the ADD → GhCommandError (only the remove is tolerant)", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const error = yield* Effect.flip(
+				tracker.applyTriage(TARGET, {type: "feature", priority: "p2"}),
+			);
+			assert.isTrue(error instanceof GhCommandError);
+		}).pipe((effect) =>
+			// the pre-read succeeds, so the add is what fails: no `POST` fixture → exit 1.
+			provide(effect, {[`GET ${L}`]: labelSet("status:needs-triage")}),
 		),
 	);
 });

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -69,6 +69,9 @@ import {
 	runGh,
 	whoAmIArgs,
 } from "./gh-io.ts";
+// The one-label-per-facet triage contract lives in its own IO-free core, tested directly —
+// `applyTriage` is the shell that applies its decision (#3771).
+import {desiredLabels, supersededLabels} from "./triage-labels.ts";
 
 // Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
 // service module — the single-source classes now live in `gh-io.ts` (#3262 AC 5).
@@ -418,12 +421,15 @@ const readBack = Effect.fn("Tracker.readBack")(function* (repo: string, target: 
 
 /**
  * Apply a triage classification to `target` (ADR 0190) — the label-transition envelope
- * the triage skill hand-rolled, now one verb with the judgment as a parameter. Adds the
- * `type:` / priority / `status:<stage>` labels, then removes the `status:needs-triage`
- * queue label so the entity leaves the queue. The removal is idempotent: a `gh` 404 (the
- * entity never carried the queue label — a pre-bootstrap issue) is not a failure of the
- * transition, since the triaged end-state is reached either way. Reads the labels back and
- * Schema-decodes them at the boundary, reporting the `status` stage that actually landed.
+ * the triage skill hand-rolled, now one verb with the judgment as a parameter. The
+ * transition is **convergent, not additive**: it reads the entity's current labels, adds
+ * the desired `type:` / priority / `status:<stage>` set, and removes every label the
+ * classification supersedes — the old priority on a re-prioritize, the old type on a
+ * re-type, and the `status:needs-triage` queue label, which is simply the status facet's
+ * instance of that one rule (#3771). Each removal tolerates a `gh` 404 (the entity no
+ * longer carries the label — a concurrent edit): the triaged end-state is reached either
+ * way. Reads the labels back and Schema-decodes them at the boundary, reporting the
+ * `status` stage that actually landed.
  */
 const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 	repo: string,
@@ -431,10 +437,21 @@ const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 	judgment: TriageJudgment,
 ) {
 	const status = judgment.status ?? "triaged";
-	const add = [`type:${judgment.type}`, judgment.priority, `${LABEL_STATUS_PREFIX}${status}`];
-	yield* runGh(addLabelsArgs(repo, target, add));
-	yield* runGh(removeLabelArgs(repo, target, `${LABEL_STATUS_PREFIX}${QUEUE_STATUS}`)).pipe(
-		Effect.catchTag("@kampus/gh-io/GhCommandError", () => Effect.succeed("")),
+	const classification = {type: judgment.type, priority: judgment.priority, status};
+	const before = yield* decodeLabels(yield* json(listLabelsArgs(repo, target)));
+	yield* runGh(addLabelsArgs(repo, target, desiredLabels(classification)));
+	yield* Effect.forEach(
+		supersededLabels(
+			before.map((label) => label.name),
+			classification,
+		),
+		(label) =>
+			runGh(removeLabelArgs(repo, target, label)).pipe(
+				Effect.catchTag("@kampus/gh-io/GhCommandError", () => Effect.succeed("")),
+			),
+		// serial on purpose: at most three removals, all mutating the SAME issue's label set — a
+		// fanned-out DELETE would race GitHub's read-modify-write of that one collection.
+		{concurrency: 1},
 	);
 	const labels = yield* decodeLabels(yield* json(listLabelsArgs(repo, target)));
 	const landedStatus = labels

--- a/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
+++ b/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
@@ -1,0 +1,65 @@
+/**
+ * The triage label contract as a pure, IO-free decision: which labels a triaged entity must
+ * carry, and which of the ones it already carries are *superseded* by that classification.
+ *
+ * A triaged entity carries EXACTLY ONE label per facet — one `type:*`, one priority, one
+ * `status:*` (the triage skill's Step 6 contract). Modeling the facets as a fixed record makes
+ * a two-priority desired state unrepresentable, and turns the transition into a **convergent
+ * reconcile** rather than an additive one: every label in a facet that isn't the desired one is
+ * superseded and removed. The re-prioritize path used to be additive, so `p1` landed alongside
+ * the old `p2` and left the queue's pick order ambiguous (#3771).
+ *
+ * The queue-label drop (`status:needs-triage`) is not a special case here — it is just the
+ * status facet's instance of the same rule.
+ */
+
+/** The domain classification a triage decision assigns: one value per single-valued facet. */
+export interface TriageClassification {
+	readonly type: string;
+	readonly priority: string;
+	readonly status: string;
+}
+
+// A priority label is the bare bucket name (`p0`/`p1`/`p2`); `\d+` rather than a closed set so a
+// future bucket is reconciled too instead of silently surviving as a second priority.
+const PRIORITY_RE = /^p\d+$/;
+
+const TYPE_PREFIX = "type:";
+const STATUS_PREFIX = "status:";
+
+/**
+ * The single-valued label families. `owns` decides membership from the label name alone (so a
+ * label the tracker never applied is still reconciled), `desired` names the one member the
+ * classification keeps.
+ */
+const FACETS: ReadonlyArray<{
+	readonly owns: (label: string) => boolean;
+	readonly desired: (classification: TriageClassification) => string;
+}> = [
+	{owns: (label) => label.startsWith(TYPE_PREFIX), desired: (c) => `${TYPE_PREFIX}${c.type}`},
+	{owns: (label) => PRIORITY_RE.test(label), desired: (c) => c.priority},
+	{owns: (label) => label.startsWith(STATUS_PREFIX), desired: (c) => `${STATUS_PREFIX}${c.status}`},
+];
+
+/** The labels a triaged entity must carry — exactly one per facet, in facet order. */
+export const desiredLabels = (classification: TriageClassification): ReadonlyArray<string> =>
+	FACETS.map((facet) => facet.desired(classification));
+
+/**
+ * The labels to remove so `current` converges on `classification`: every currently-carried label
+ * that belongs to a facet but isn't that facet's desired member. Labels outside the three facets
+ * (`epic`, `good first issue`, …) are never touched — this is the narrow triage contract, not a
+ * general label reconciler. De-duplicated and idempotent: on an entity already in the contract's
+ * shape it is empty, so a re-run of the same classification removes nothing.
+ */
+export const supersededLabels = (
+	current: ReadonlyArray<string>,
+	classification: TriageClassification,
+): ReadonlyArray<string> => {
+	const keep = new Set(desiredLabels(classification));
+	return [
+		...new Set(
+			current.filter((label) => !keep.has(label) && FACETS.some((facet) => facet.owns(label))),
+		),
+	];
+};

--- a/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
+++ b/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
@@ -3,7 +3,7 @@
  * carry, and which of the ones it already carries are *superseded* by that classification.
  *
  * A triaged entity carries EXACTLY ONE label per facet — one `type:*`, one priority, one
- * `status:*` (the triage skill's Step 6 contract). Modeling the facets as a fixed record makes
+ * `status:*` spine stage (the triage skill's Step 6 contract). Modeling the facets as a fixed record makes
  * a two-priority desired state unrepresentable, and turns the transition into a **convergent
  * reconcile** rather than an additive one: every label in a facet that isn't the desired one is
  * superseded and removed. The re-prioritize path used to be additive, so `p1` landed alongside
@@ -27,6 +27,21 @@ const PRIORITY_RE = /^p\d+$/;
 const TYPE_PREFIX = "type:";
 const STATUS_PREFIX = "status:";
 
+// The status facet is the PICKABILITY SPINE — the pipeline states an issue moves *between* —
+// enumerated, never the whole `status:` prefix. Other labels live in that namespace but sit
+// ALONGSIDE the spine rather than on it: `status:awaiting-release` is a post-merge release-queue
+// marker (`ship-it` queues it, `release` resolves a flag to its issue by querying it), and
+// `status:planning` is a transient epic-lock held next to an epic's real status. Owning the raw
+// prefix would supersede those on any re-prioritize, silently ejecting a dark-shipped issue from
+// the human release queue. Source of the set: the Pipeline-labels table in
+// `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`.
+const SPINE_STAGES: ReadonlySet<string> = new Set([
+	"needs-triage",
+	"needs-info",
+	"planned",
+	"triaged",
+]);
+
 /**
  * The single-valued label families. `owns` decides membership from the label name alone (so a
  * label the tracker never applied is still reconciled), `desired` names the one member the
@@ -38,7 +53,11 @@ const FACETS: ReadonlyArray<{
 }> = [
 	{owns: (label) => label.startsWith(TYPE_PREFIX), desired: (c) => `${TYPE_PREFIX}${c.type}`},
 	{owns: (label) => PRIORITY_RE.test(label), desired: (c) => c.priority},
-	{owns: (label) => label.startsWith(STATUS_PREFIX), desired: (c) => `${STATUS_PREFIX}${c.status}`},
+	{
+		owns: (label) =>
+			label.startsWith(STATUS_PREFIX) && SPINE_STAGES.has(label.slice(STATUS_PREFIX.length)),
+		desired: (c) => `${STATUS_PREFIX}${c.status}`,
+	},
 ];
 
 /** The labels a triaged entity must carry — exactly one per facet, in facet order. */
@@ -48,7 +67,8 @@ export const desiredLabels = (classification: TriageClassification): ReadonlyArr
 /**
  * The labels to remove so `current` converges on `classification`: every currently-carried label
  * that belongs to a facet but isn't that facet's desired member. Labels outside the three facets
- * (`epic`, `good first issue`, …) are never touched — this is the narrow triage contract, not a
+ * (`epic`, `good first issue`, an orthogonal `status:awaiting-release`, …) are never touched —
+ * this is the narrow triage contract, not a
  * general label reconciler. De-duplicated and idempotent: on an entity already in the contract's
  * shape it is empty, so a re-run of the same classification removes nothing.
  */

--- a/packages/pipeline-cli/src/tools/tracker/triage-labels.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/triage-labels.unit.test.ts
@@ -46,6 +46,27 @@ describe("supersededLabels", () => {
 		]);
 	});
 
+	// The status facet owns the pickability SPINE, not the whole `status:` namespace.
+	// `status:awaiting-release` is the release queue's membership marker: superseding it on a
+	// re-prioritize would silently drop a dark-shipped issue out of the human release queue.
+	it("never supersedes `status:awaiting-release` — it is orthogonal to the pickability spine", () => {
+		assert.deepStrictEqual(
+			supersededLabels(["type:bug", "status:triaged", "p2", "status:awaiting-release"], {
+				type: "bug",
+				priority: "p1",
+				status: "triaged",
+			}),
+			["p2"],
+		);
+	});
+
+	it("never supersedes the `status:planning` epic-lock — it sits alongside the real status", () => {
+		assert.deepStrictEqual(
+			supersededLabels(["type:epic", "status:needs-triage", "status:planning"], TRIAGED),
+			["type:epic", "status:needs-triage"],
+		);
+	});
+
 	it("supersedes every facet at once on a full re-triage", () => {
 		assert.deepStrictEqual(
 			[...supersededLabels(["type:chore", "p0", "status:needs-triage"], TRIAGED)].sort(),

--- a/packages/pipeline-cli/src/tools/tracker/triage-labels.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/triage-labels.unit.test.ts
@@ -1,0 +1,83 @@
+import {assert, describe, it} from "@effect/vitest";
+import {desiredLabels, supersededLabels} from "./triage-labels.ts";
+
+const TRIAGED = {type: "bug", priority: "p2", status: "triaged"} as const;
+
+describe("desiredLabels", () => {
+	it("is exactly one label per facet — type, priority, status", () => {
+		assert.deepStrictEqual(desiredLabels(TRIAGED), ["type:bug", "p2", "status:triaged"]);
+	});
+
+	it("carries the requested stage when it is not the default", () => {
+		assert.deepStrictEqual(desiredLabels({...TRIAGED, status: "needs-info"}), [
+			"type:bug",
+			"p2",
+			"status:needs-info",
+		]);
+	});
+});
+
+describe("supersededLabels", () => {
+	it("the #3771 defect: a re-prioritize supersedes the old priority", () => {
+		assert.deepStrictEqual(
+			supersededLabels(["type:decision", "status:triaged", "p2"], {
+				type: "decision",
+				priority: "p1",
+				status: "triaged",
+			}),
+			["p2"],
+		);
+	});
+
+	it("a re-type supersedes the old type — the same rule, the same shape", () => {
+		assert.deepStrictEqual(
+			supersededLabels(["type:bug", "status:triaged", "p2"], {
+				type: "chore",
+				priority: "p2",
+				status: "triaged",
+			}),
+			["type:bug"],
+		);
+	});
+
+	it("the queue label is not a special case — it is the status facet's superseded member", () => {
+		assert.deepStrictEqual(supersededLabels(["status:needs-triage"], TRIAGED), [
+			"status:needs-triage",
+		]);
+	});
+
+	it("supersedes every facet at once on a full re-triage", () => {
+		assert.deepStrictEqual(
+			[...supersededLabels(["type:chore", "p0", "status:needs-triage"], TRIAGED)].sort(),
+			["p0", "status:needs-triage", "type:chore"],
+		);
+	});
+
+	it("is idempotent: an entity already in the contract's shape supersedes nothing", () => {
+		assert.deepStrictEqual(supersededLabels(["type:bug", "p2", "status:triaged"], TRIAGED), []);
+	});
+
+	it("tolerates a facet that is absent entirely — nothing to remove is not a failure", () => {
+		assert.deepStrictEqual(supersededLabels([], TRIAGED), []);
+		assert.deepStrictEqual(supersededLabels(["type:bug"], TRIAGED), []);
+	});
+
+	it("never touches a label outside the three facets — this is not a label reconciler", () => {
+		assert.deepStrictEqual(
+			supersededLabels(["epic", "good first issue", "pipeline", "p1"], TRIAGED),
+			["p1"],
+		);
+	});
+
+	it("reconciles a priority bucket beyond p0/p1/p2 rather than leaving a second priority", () => {
+		assert.deepStrictEqual(supersededLabels(["p10"], TRIAGED), ["p10"]);
+	});
+
+	it("does not mistake a `p`-prefixed word for a priority label", () => {
+		assert.deepStrictEqual(supersededLabels(["pipeline", "product", "p2"], TRIAGED), []);
+	});
+
+	it("de-duplicates a repeated superseded label", () => {
+		assert.deepStrictEqual(supersededLabels(["p1", "p1"], TRIAGED), ["p1"]);
+	});
+});


### PR DESCRIPTION
Fixes #3771

## The defect

`pipeline-cli tracker apply-triage` applied the triage classification **additively**: it POSTed the new `type:` / priority / `status:` labels and removed only the `status:needs-triage` queue label. Re-prioritizing an already-triaged issue therefore left the old priority in place — an issue upgraded `p2` → `p1` ended up carrying **both**, with the verb's success line printing only the priority it applied. Silent, so bad state accumulates rather than announcing itself. The `type:*` label on a re-type had the same shape.

Priority is what sets `write-code`'s pick order, so a double-labeled issue has an ambiguous queue position depending on which label a consumer reads first.

## The fix — convergent, not additive

The triage contract (one `type:*`, one `p*`, one `status:*` — the triage skill's Step 6) now lives as a pure, IO-free core, `packages/pipeline-cli/src/tools/tracker/triage-labels.ts`, modeling the three **single-valued facets**:

- `desiredLabels(classification)` — exactly one member per facet. A two-priority desired state is unrepresentable.
- `supersededLabels(current, classification)` — every currently-carried label that belongs to a facet but isn't that facet's desired member.

`applyTriage` becomes a read-modify-read shell over that decision: read the current labels, add the desired set, remove the superseded ones, read back the landed stage.

Three properties fall out rather than being special-cased:

- **The `status:needs-triage` queue drop is not a special case** — it is the status facet's instance of the same rule.
- **Idempotent.** On an entity already in the contract's shape the superseded set is empty, so a re-run of the same classification issues zero removals.
- **Tolerant.** Nothing to remove is not a failure, and each removal keeps the existing `gh` 404 tolerance (the label vanished between the read and the delete — a concurrent edit; the triaged end-state is reached either way).

Removals run serially (`{concurrency: 1}`): at most three DELETEs, all mutating the **same** issue's label collection, so a fan-out would race GitHub's read-modify-write of it.

Per the issue's scope note, this is **not** widened into a general label reconciler — labels outside the three facets (`epic`, `good first issue`, …) are never touched.

## Acceptance criteria

- [x] `apply-triage` leaves exactly one `p0`/`p1`/`p2` label, removing any other priority as part of the operation.
- [x] The same holds for `type:*` on a re-type — one rule covers both, since they are two instances of the same facet shape.
- [x] Idempotent: re-running with the same arguments, and running against an already-triaged issue, both leave a contract-shaped label set.
- [x] Unit coverage asserts the single-`type:*` / single-`p*` / `status:triaged` invariant after a re-triage of an already-triaged issue — the exact path that produced the defect.
- [x] Removing a priority that isn't present stays tolerant (no failure), matching the verb's documented tolerance for a missing `status:needs-triage`.

## Tests

- `packages/pipeline-cli/src/tools/tracker/triage-labels.unit.test.ts` (new) — the pure core: the re-prioritize and re-type reproductions, queue-label-as-status-facet, full re-triage, idempotence, absent-facet tolerance, non-facet labels untouched, and that a `p`-prefixed word (`pipeline`, `product`) is not mistaken for a priority label.
- `packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts` — a re-triage case over the mock `gh` spawner asserting the **exact** DELETE set is `{type:bug, p2}` (the already-desired `status:triaged` and an unrelated `epic` label are left alone), plus a case proving no removal is attempted when nothing is superseded, and one proving the 404 tolerance on a concurrent removal.

The mock spawner gained two small capabilities the read-modify-read shape needs: an array fixture answering successive calls on the same key (the labels GET is read twice), and an optional call recorder so a test can assert *which* mutations were issued.

`pnpm --filter @kampus/pipeline-cli exec vitest run` — 141 files / 1969 tests pass; `tsc --noEmit` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UScdSr9uPL1tE1MBbSPvif
