### PR TITLE
fix(design-capture): send `name`/`content_type` as query params so the upload stops 400ing (#3738)

### DIFF
--- a/packages/design-capture/src/index.ts
+++ b/packages/design-capture/src/index.ts
@@ -89,5 +89,10 @@ export {
 	substituteRouteParams,
 } from "./priority-surfaces.ts";
 export {resolvePreviewUrl} from "./resolve.ts";
-export type {RawUploadResponse, UploadAssetOptions, UploadOutcome} from "./upload.ts";
-export {parseUploadResponse, uploadAsset, uploadEndpoint} from "./upload.ts";
+export type {
+	RawUploadResponse,
+	UploadAssetOptions,
+	UploadEndpointParams,
+	UploadOutcome,
+} from "./upload.ts";
+export {PNG_CONTENT_TYPE, parseUploadResponse, uploadAsset, uploadEndpoint} from "./upload.ts";

--- a/packages/design-capture/src/upload.ts
+++ b/packages/design-capture/src/upload.ts
@@ -94,9 +94,53 @@ export const parseUploadResponse = (res: RawUploadResponse): UploadOutcome => {
 	return {hostedUrl, uploadError: null};
 };
 
-/** PURE: the upload endpoint URL for a target repo's numeric id. */
-export const uploadEndpoint = (repositoryId: number): string =>
-	`https://uploads.github.com/user-attachments/assets?repository_id=${repositoryId}`;
+/**
+ * The one content type this package ever uploads. The endpoint validates that
+ * `name`'s extension matches `content_type` (see {@link uploadEndpoint}), and
+ * every captured artifact is a `.png`, so pinning the pair here is what keeps
+ * the two from drifting apart.
+ */
+export const PNG_CONTENT_TYPE = "image/png";
+
+/**
+ * PURE: the upload endpoint URL for one asset.
+ *
+ * LOAD-BEARING — the endpoint's real parameter contract, probed against the live
+ * endpoint (#3738), since it is undocumented (ADR 0165) and cannot be grounded in
+ * any published source:
+ *
+ *   - `repository_id` — required; omitting it is a 404.
+ *   - `name` — required as a QUERY PARAM. Omitting it is the HTTP 400
+ *     `Invalid name for request` that left every `hostedUrl` null. The
+ *     `content-disposition: attachment; filename="…"` header does NOT supply it —
+ *     the endpoint ignores that header entirely, which is why the header-only
+ *     request always 400'd.
+ *   - `content_type` — the query param wins over the request's `content-type`
+ *     header. Absent it, GitHub derives the type from the header, so an
+ *     `application/octet-stream` body 422s twice over: the type is not in the
+ *     allowed list, AND `.png` does not match it.
+ *   - `size` — optional (a request without it is accepted), but sent because the
+ *     web composer sends it, so a future tightening finds it already there.
+ */
+export const uploadEndpoint = (params: UploadEndpointParams): string => {
+	const query = new URLSearchParams({
+		repository_id: String(params.repositoryId),
+		name: params.fileName,
+		size: String(params.size),
+		content_type: params.contentType,
+	});
+	return `https://uploads.github.com/user-attachments/assets?${query}`;
+};
+
+export interface UploadEndpointParams {
+	readonly repositoryId: number;
+	/** Attachment file name, e.g. `sozluk-home@desktop.png`. */
+	readonly fileName: string;
+	/** Byte length of the uploaded asset. */
+	readonly size: number;
+	/** Must agree with `fileName`'s extension or the endpoint 422s. */
+	readonly contentType: string;
+}
 
 export interface UploadAssetOptions {
 	readonly pngBytes: Uint8Array;
@@ -117,15 +161,18 @@ export interface UploadAssetOptions {
 export const uploadAsset = (
 	opts: UploadAssetOptions,
 ): Effect.Effect<UploadOutcome, never, HttpClient.HttpClient> => {
-	const request = HttpClientRequest.post(uploadEndpoint(opts.repositoryId)).pipe(
+	const endpoint = uploadEndpoint({
+		repositoryId: opts.repositoryId,
+		fileName: opts.fileName,
+		size: opts.pngBytes.length,
+		contentType: PNG_CONTENT_TYPE,
+	});
+	const request = HttpClientRequest.post(endpoint).pipe(
 		HttpClientRequest.setHeaders({
 			authorization: `token ${opts.token}`,
 			accept: "application/vnd.github+json",
-			"content-type": "application/octet-stream",
-			// The web-composer sends the file name so GitHub derives the asset name.
-			"content-disposition": `attachment; filename="${opts.fileName}"`,
 		}),
-		HttpClientRequest.bodyUint8Array(opts.pngBytes, "application/octet-stream"),
+		HttpClientRequest.bodyUint8Array(opts.pngBytes, PNG_CONTENT_TYPE),
 	);
 	return HttpClient.execute(request).pipe(
 		Effect.flatMap((response) =>

--- a/packages/design-capture/src/upload.unit.test.ts
+++ b/packages/design-capture/src/upload.unit.test.ts
@@ -11,16 +11,43 @@ import {Effect, Layer} from "effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
-import {parseUploadResponse, uploadAsset, uploadEndpoint} from "./upload.ts";
+import {DESKTOP_VIEWPORT, parseSurfaceSpec, surfaceFileName} from "./plan.ts";
+import {PNG_CONTENT_TYPE, parseUploadResponse, uploadAsset, uploadEndpoint} from "./upload.ts";
 
 const HOSTED = "https://github.com/user-attachments/assets/0a1b2c3d-4e5f-6789-abcd-ef0123456789";
 
 describe("uploadEndpoint", () => {
-	it("targets the undocumented endpoint with the repository_id query param", () => {
-		assert.strictEqual(
-			uploadEndpoint(1234177275),
-			"https://uploads.github.com/user-attachments/assets?repository_id=1234177275",
-		);
+	const params = {
+		repositoryId: 1234177275,
+		fileName: "sozluk@desktop.png",
+		size: 67,
+		contentType: PNG_CONTENT_TYPE,
+	};
+
+	it("carries every parameter the live endpoint requires (#3738)", () => {
+		const query = new URL(uploadEndpoint(params)).searchParams;
+		assert.strictEqual(query.get("repository_id"), "1234177275");
+		assert.strictEqual(query.get("name"), "sozluk@desktop.png");
+		assert.strictEqual(query.get("size"), "67");
+		assert.strictEqual(query.get("content_type"), "image/png");
+	});
+
+	it("targets the undocumented uploads host", () => {
+		const url = new URL(uploadEndpoint(params));
+		assert.strictEqual(url.origin, "https://uploads.github.com");
+		assert.strictEqual(url.pathname, "/user-attachments/assets");
+	});
+
+	// The regression itself: a request with no `name` query param is the HTTP 400
+	// `Invalid name for request` that nulled every hostedUrl.
+	it("never omits `name` — the parameter whose absence was the HTTP 400", () => {
+		assert.ok(new URL(uploadEndpoint(params)).searchParams.has("name"));
+	});
+
+	it("percent-encodes a name so `@` survives the query string", () => {
+		const raw = uploadEndpoint(params);
+		assert.ok(raw.includes("name=sozluk%40desktop.png"), raw);
+		assert.strictEqual(new URL(raw).searchParams.get("name"), "sozluk@desktop.png");
 	});
 });
 
@@ -121,4 +148,53 @@ describe("uploadAsset — over a stubbed transport (never fails the effect)", ()
 		assert.strictEqual(o.hostedUrl, null);
 		assert.match(o.uploadError ?? "", /request failed/);
 	});
+});
+
+/**
+ * A transport that records the URL it was handed and answers 201. It is what lets
+ * the request SHAPE — not just the response handling — be asserted, which is the
+ * only place the #3738 regression lived.
+ */
+const recordingTransport = (seen: {url?: string}): Layer.Layer<HttpClient.HttpClient> =>
+	Layer.succeed(HttpClient.HttpClient)(
+		HttpClient.make((request) => {
+			seen.url = request.url;
+			return Effect.succeed(
+				HttpClientResponse.fromWeb(
+					request,
+					new Response(JSON.stringify({url: HOSTED}), {status: 201}),
+				),
+			);
+		}),
+	);
+
+describe("uploadAsset — the request shape the live endpoint accepts (#3738)", () => {
+	// The two surfaces the reported failure covered: the rooted `/` and the nested
+	// `/admin`. Both went out with no `name` param and both came back HTTP 400.
+	for (const [token, expectedName] of [
+		["/", "root@desktop.png"],
+		["/admin", "admin@desktop.png"],
+	] as const) {
+		it(`yields a non-null hostedUrl for the ${token} surface, sending its name`, async () => {
+			const fileName = surfaceFileName(parseSurfaceSpec(token), DESKTOP_VIEWPORT);
+			assert.strictEqual(fileName, expectedName);
+
+			const seen: {url?: string} = {};
+			const outcome = await Effect.runPromise(
+				uploadAsset({
+					pngBytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+					repositoryId: 1234177275,
+					token: "unit-test-token",
+					fileName,
+				}).pipe(Effect.provide(recordingTransport(seen))),
+			);
+
+			assert.strictEqual(outcome.hostedUrl, HOSTED);
+			assert.strictEqual(outcome.uploadError, null);
+			const query = new URL(seen.url ?? "").searchParams;
+			assert.strictEqual(query.get("name"), expectedName);
+			assert.strictEqual(query.get("content_type"), "image/png");
+			assert.strictEqual(query.get("size"), "4");
+		});
+	}
 });


### PR DESCRIPTION
Fixes #3738

## Diagnosis — the root cause, probed against the live endpoint

`type:investigation`, so the diagnosis comes first. It landed on a bounded, in-scope fix, so it is collapsed into this one PR (ADR 0070).

**The `name` was never rejected — it was never sent.** `uploadEndpoint` built the URL with only `?repository_id=<id>` and passed the artifact name in a `content-disposition: attachment; filename="…"` header. The endpoint **ignores that header entirely** and requires `name` as a **query parameter**; its absence *is* the observed HTTP 400 `Invalid name for request`.

This confirms triage's refutation of the reporter's suspected cause: `surfaceFileName` was already producing valid names (`root@desktop.png`, `admin@desktop.png`) and sanitization was never the issue. (Probed directly: the endpoint even *accepts* a name with a leading slash — 201.)

The endpoint is undocumented (ADR 0165), so per CLAUDE.md's grounding rule its contract was **probed against the real endpoint** rather than assumed. Observed responses:

| request shape | result |
| --- | --- |
| `?repository_id` only, name via `content-disposition` (**the shipped code**) | **HTTP 400** `{"message":"Invalid name for request"}` |
| `+ name` (body/header `application/octet-stream`, no `content_type` param) | **HTTP 422** — `content_type is not included in the list of allowed content types` **and** `name has a file extension that does not match the content type: .png != application/octet-stream` |
| `+ name + content_type=image/png` (± `size`) | **HTTP 201** `{"url":"https://github.com/user-attachments/assets/<uuid>"}` |
| `name + content_type`, **no** `repository_id` | HTTP 404 |

So the real contract is:

- **`repository_id`** — required (404 without).
- **`name`** — required **as a query param**. **This is the root cause.**
- **`content_type`** — the query param **wins over** the request `content-type` header; absent it, GitHub derives the type from the header. So the old `application/octet-stream` body would have 422'd *even after* `name` was fixed — both a fix-`name`-only change and a header-only change are insufficient.
- **`size`** — optional (accepted without it), sent anyway to match what the web composer sends.

The parse side needed no change: the 201 body's `url` field already satisfies `extractHostedUrl`.

## The fix

`packages/design-capture/src/upload.ts`:

- `uploadEndpoint` now takes `UploadEndpointParams` (`repositoryId`, `fileName`, `size`, `contentType`) and builds the query with `URLSearchParams` — required, since `@` in `root@desktop.png` must be percent-encoded.
- The body goes out as `image/png`; the ignored `content-disposition` header is dropped.
- `PNG_CONTENT_TYPE` pins the name-extension / content-type pair the endpoint validates against each other — the two can no longer drift apart.
- The probed contract is recorded once, as a load-bearing note on `uploadEndpoint`. For an undocumented endpoint an observed-response record is the only grounding a future reader gets; ADR 0165's durability-risk *why* stays a pointer, not a re-derivation.

## Verification

`packages/design-capture/src/upload.unit.test.ts` — the existing degrade-to-`null` coverage is untouched; added:

- the required-parameter set is all present on the URL;
- **the regression itself**: `name` is never omitted;
- `@` percent-encoding round-trips;
- a **recording transport** that asserts the request **shape** — the only place the defect lived — yields a non-null `hostedUrl` for **both** surfaces the failure covered: the rooted `/` (`root@desktop.png`) and the nested `/admin` (`admin@desktop.png`).

Also verified **end-to-end against the live endpoint** through the real `uploadAsset` code path (temporary probe, not committed): both surfaces returned a `https://github.com/user-attachments/assets/…` URL with `uploadError: null`.

Green from inside the worktree: `pnpm typecheck` 29/29, `pnpm lint:worktree` clean, `pnpm vitest run` in `packages/design-capture` 115/115.

## The secondary criterion — decided, no change needed

Whether a failed upload should surface as a visible warning rather than a silent `null`: **no change**. `uploadError` is already carried on every `CaptureRecord`, already emitted in the `bin.ts` stdout JSON, and already documented in `review-design` as a tolerated degradation. The failure was quiet because a routine 400 had become the norm, not because the diagnostic was dropped — fixing the 400 removes the silence at its source. Adding a second warning surface would be a mitigation layered over an already-fixed root cause.

## Path classification

`packages/design-capture/**` only — **not** §CP (§CP is `claude-plugins/**`, `.claude/**`, `packages/pipeline-cli/**`). No skill, plugin, or pipeline-CLI file is touched; `claude-plugins/kampus-pipeline/skills/review-design/SKILL.md` needs no edit because the emitted record shape is unchanged. The reviewer classifies.
