### PR TITLE
refactor(pipeline-cli): route fanout/reachability/workflow/path-filter guards through the FileSystem/Path seam (#3471)

### DIFF
--- a/packages/pipeline-cli/src/tools/fanout-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/command.ts
@@ -25,33 +25,42 @@
  * inside the handler (not at the bin's run boundary) so the contract survives folding
  * into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkFanout} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Marker-existence faults fall through as false,
+// matching the prior `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
 	Flag.withDescription("the repo root to scan worker mutations under (default: walk up for one)"),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
@@ -66,7 +75,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkFanout(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkFanout(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/fanout-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/gate.ts
@@ -13,9 +13,7 @@
  * failure is an `IoError` (also non-zero — both failures, undistinguished, per the
  * bin's contract).
  */
-import {existsSync, readdirSync, readFileSync, statSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	type DiscoveredMutation,
@@ -44,11 +42,14 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 	reason: Schema.String,
 }) {}
 
-const FEATURES_DIR = join("apps", "web", "worker", "features");
+// Repo-relative path fragments (POSIX): combined with the absolute `root` at runtime
+// through the `Path.Path` seam, so they stay plain-string literals (the catalog-guard
+// idiom) rather than a module-level `node:path` join with no seam in scope.
+const FEATURES_DIR = "apps/web/worker/features";
 const MUTATIONS_FILE = "mutations.ts";
 const LIVE_FILE = "live.ts";
-const MANIFEST_PATH = join(FEATURES_DIR, "fate-live", "fanned-mutations.ts");
-const PROTOCOL_PATH = join(FEATURES_DIR, "fate-live", "protocol.ts");
+const MANIFEST_PATH = `${FEATURES_DIR}/fate-live/fanned-mutations.ts`;
+const PROTOCOL_PATH = `${FEATURES_DIR}/fate-live/protocol.ts`;
 
 /** The gathered facts across all feature mutation + live files. */
 interface GatheredFeatures {
@@ -64,45 +65,50 @@ interface GatheredFeatures {
  * one-hop delegation, resolved via the `LiveTopic` map). `live.ts` is scanned even for a
  * feature with no `mutations.ts`, so a delegated-through binding (report → pano/sözlük)
  * contributes its targets to the closure.
+ *
+ * All directory/file IO goes through the Effect `FileSystem`/`Path` seam (over the bin's
+ * `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for the real
+ * disk (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the
+ * `IoError` this gate already carries. This is the one why-note for the file's
+ * platform-seam migration — the other IO helpers below follow the same shape.
  */
 const gatherFeatures = (
 	root: string,
 	liveTopicMap: ReadonlyMap<string, string>,
-): Effect.Effect<GatheredFeatures, IoError> =>
-	Effect.try({
-		try: () => {
-			const base = join(root, FEATURES_DIR);
-			const entries = readdirSync(base, {withFileTypes: true});
-			const discovered: Array<DiscoveredMutation> = [];
-			const featurePublishes = new Map<string, boolean>();
-			const directTargets = new Map<string, ReadonlySet<string>>();
-			const delegations = new Map<string, ReadonlySet<string>>();
-			for (const entry of entries) {
-				const abs = join(base, entry.name);
-				if (!statSync(abs).isDirectory()) continue;
-				const mutationsPath = join(abs, MUTATIONS_FILE);
-				if (existsSync(mutationsPath)) {
-					const source = readFileSync(mutationsPath, "utf8");
-					for (const key of parseMutationKeys(source)) {
-						discovered.push({key, feature: entry.name});
-					}
-					featurePublishes.set(entry.name, referencesPublisher(source));
+): Effect.Effect<GatheredFeatures, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const base = path.join(root, FEATURES_DIR);
+		const entries = yield* fs.readDirectory(base);
+		const discovered: Array<DiscoveredMutation> = [];
+		const featurePublishes = new Map<string, boolean>();
+		const directTargets = new Map<string, ReadonlySet<string>>();
+		const delegations = new Map<string, ReadonlySet<string>>();
+		for (const name of entries) {
+			const abs = path.join(base, name);
+			if ((yield* fs.stat(abs)).type !== "Directory") continue;
+			const mutationsPath = path.join(abs, MUTATIONS_FILE);
+			if (yield* fs.exists(mutationsPath)) {
+				const source = yield* fs.readFileString(mutationsPath, "utf8");
+				for (const key of parseMutationKeys(source)) {
+					discovered.push({key, feature: name});
 				}
-				const livePath = join(abs, LIVE_FILE);
-				if (existsSync(livePath)) {
-					const liveSource = readFileSync(livePath, "utf8");
-					directTargets.set(entry.name, parseFeatureTargets(liveSource, liveTopicMap));
-					delegations.set(entry.name, parseFeatureDelegations(liveSource));
-				}
+				featurePublishes.set(name, referencesPublisher(source));
 			}
-			return {
-				discovered,
-				featurePublishes,
-				featureTargets: resolveReachableTargets(directTargets, delegations),
-			};
-		},
-		catch: (cause) => new IoError({path: join(root, FEATURES_DIR), cause}),
-	});
+			const livePath = path.join(abs, LIVE_FILE);
+			if (yield* fs.exists(livePath)) {
+				const liveSource = yield* fs.readFileString(livePath, "utf8");
+				directTargets.set(name, parseFeatureTargets(liveSource, liveTopicMap));
+				delegations.set(name, parseFeatureDelegations(liveSource));
+			}
+		}
+		return {
+			discovered,
+			featurePublishes,
+			featureTargets: resolveReachableTargets(directTargets, delegations),
+		};
+	}).pipe(Effect.mapError((cause) => new IoError({path: `${root}/${FEATURES_DIR}`, cause})));
 
 /**
  * Read + parse the `LiveTopic` map from `fate-live/protocol.ts` — the source of truth
@@ -111,26 +117,32 @@ const gatherFeatures = (
  * topic check then reports every declared connection topic as unreachable, which
  * fail-closes loudly (a moved protocol file is a real misconfiguration).
  */
-const readLiveTopicMap = (root: string): Effect.Effect<ReadonlyMap<string, string>, IoError> =>
-	Effect.try({
-		try: () => {
-			const protocolPath = join(root, PROTOCOL_PATH);
-			if (!existsSync(protocolPath)) return new Map<string, string>();
-			return parseLiveTopicMap(readFileSync(protocolPath, "utf8"));
-		},
-		catch: (cause) => new IoError({path: join(root, PROTOCOL_PATH), cause}),
-	});
+const readLiveTopicMap = (
+	root: string,
+): Effect.Effect<ReadonlyMap<string, string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const protocolPath = path.join(root, PROTOCOL_PATH);
+		if (!(yield* fs.exists(protocolPath))) return new Map<string, string>();
+		return parseLiveTopicMap(yield* fs.readFileString(protocolPath, "utf8"));
+	}).pipe(Effect.mapError((cause) => new IoError({path: `${root}/${PROTOCOL_PATH}`, cause})));
 
 /** Read + parse the fanned-mutation manifest; a missing manifest fails closed. */
 const readManifest = (
 	root: string,
-): Effect.Effect<ReadonlyArray<ManifestEntry>, IoError | CheckFailed> =>
+): Effect.Effect<
+	ReadonlyArray<ManifestEntry>,
+	IoError | CheckFailed,
+	FileSystem.FileSystem | Path.Path
+> =>
 	Effect.gen(function* () {
-		const manifestPath = join(root, MANIFEST_PATH);
-		const text = yield* Effect.try({
-			try: () => readFileSync(manifestPath, "utf8"),
-			catch: (cause) => new IoError({path: manifestPath, cause}),
-		});
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const manifestPath = path.join(root, MANIFEST_PATH);
+		const text = yield* fs
+			.readFileString(manifestPath, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: manifestPath, cause})));
 		const entries = parseManifestEntries(text);
 		if (entries.length === 0) {
 			// A present-but-empty (or unparseable) manifest is a broken scope assumption,
@@ -151,7 +163,9 @@ const readManifest = (
  * feature publishes a `/fate/live` invalidation, and each publish aims at its declared
  * topic, else `CheckFailed`. Fails closed on zero mutations in scope (ADR 0092).
  */
-export const checkFanout = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkFanout = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const manifest = yield* readManifest(root);
 		const liveTopicMap = yield* readLiveTopicMap(root);

--- a/packages/pipeline-cli/src/tools/fanout-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/gate.unit.test.ts
@@ -11,8 +11,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkFanout} from "./gate.ts";
 
 let root: string;
@@ -80,7 +81,11 @@ const writeFeature = (
 	if (live !== undefined) writeFileSync(join(dir, "live.ts"), live, "utf8");
 };
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3471);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
 

--- a/packages/pipeline-cli/src/tools/path-filter-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/command.ts
@@ -19,25 +19,32 @@
  * inside the handler (not at the bin's run boundary) so the contract survives folding
  * into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkPathFilters} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Marker-existence faults fall through as false,
+// matching the prior `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -46,8 +53,10 @@ const rootFlag = Flag.string("root").pipe(
 	),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
@@ -62,9 +71,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkPathFilters(resolveRoot(rootOpt)).pipe(
-			Effect.catchTag("CheckFailed", onCheckFailed),
-		);
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkPathFilters(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/path-filter-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/gate.ts
@@ -10,9 +10,7 @@
  * key or an empty list — fail-closed, ADR 0092). A file that cannot be read is an
  * `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
  */
-import {readFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {CI_E2E_SOURCE, DEPLOY_SOURCE, judge, renderReport} from "./path-filter-guard.ts";
 
@@ -27,10 +25,21 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 	reason: Schema.String,
 }) {}
 
-const readWorkflow = (root: string, relPath: string): Effect.Effect<string, IoError> =>
-	Effect.try({
-		try: () => readFileSync(join(root, relPath), "utf8"),
-		catch: (cause) => new IoError({path: join(root, relPath), cause}),
+// File IO goes through the Effect `FileSystem`/`Path` seam (over the bin's
+// `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for the real
+// disk (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the
+// `IoError` this gate already carries.
+const readWorkflow = (
+	root: string,
+	relPath: string,
+): Effect.Effect<string, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, relPath);
+		return yield* fs
+			.readFileString(target, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
 	});
 
 /**
@@ -38,7 +47,9 @@ const readWorkflow = (root: string, relPath: string): Effect.Effect<string, IoEr
  * dorny/paths-filter lists are the same set, else `CheckFailed`. Fails closed on any
  * zero-scope gap (ADR 0092).
  */
-export const checkPathFilters = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkPathFilters = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const ciText = yield* readWorkflow(root, CI_E2E_SOURCE.file);
 		const deployText = yield* readWorkflow(root, DEPLOY_SOURCE.file);

--- a/packages/pipeline-cli/src/tools/path-filter-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/gate.unit.test.ts
@@ -7,8 +7,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkPathFilters} from "./gate.ts";
 
 let root: string;
@@ -47,7 +48,11 @@ const writeWorkflows = (ci: string | null, deploy: string | null) => {
 };
 
 const SAMPLE = ["apps/**/src/**", "apps/**/worker/**"];
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3471);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
 

--- a/packages/pipeline-cli/src/tools/reachability-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/command.ts
@@ -25,25 +25,32 @@
  * caught inside the handler (not at the bin's run boundary) so the contract survives
  * folding into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkReachability} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Marker-existence faults fall through as false,
+// matching the prior `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const flagKeyArg = Argument.string("flag-key").pipe(
 	Argument.withDescription("the Flagship flag key to assert reachable (e.g. phoenix-reactions)"),
@@ -54,8 +61,10 @@ const rootFlag = Flag.string("root").pipe(
 	Flag.withDescription("the repo root to scan flags/UI/e2e under (default: walk up for one)"),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
@@ -70,9 +79,8 @@ const check = Command.make(
 	"check",
 	{flagKey: flagKeyArg, root: rootFlag},
 	Effect.fn(function* ({flagKey, root: rootOpt}) {
-		yield* checkReachability(resolveRoot(rootOpt), flagKey).pipe(
-			Effect.catchTag("CheckFailed", onCheckFailed),
-		);
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkReachability(root, flagKey).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
@@ -11,9 +11,7 @@
  * flag definitions (fail-closed, ADR 0092). A directory/file IO failure is an `IoError`
  * (also non-zero — both failures, undistinguished, per the bin's contract).
  */
-import {existsSync, readdirSync, readFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	consumedConstantsIn,
@@ -35,66 +33,99 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 	reason: Schema.String,
 }) {}
 
-const KEYS_PATH = join("apps", "web", "src", "flags", "keys.ts");
-const SRC_ROOT = join("apps", "web", "src");
-const E2E_DIR = join("apps", "web", "tests", "e2e");
+// Repo-relative path fragments (POSIX): combined with the absolute `root` at runtime
+// through the `Path.Path` seam, so they stay plain-string literals rather than a
+// module-level `node:path` join with no seam in scope.
+const KEYS_PATH = "apps/web/src/flags/keys.ts";
+const SRC_ROOT = "apps/web/src";
+const E2E_DIR = "apps/web/tests/e2e";
 
-// A missing UI/e2e dir is zero files, NOT an IO failure — the fail-closed scope anchor is
-// the keys.ts read (zero parsed definitions ⇒ zero-scope). An absent .tsx/e2e tree then
-// resolves as "no consumer / no journey", which judge correctly reports as unreachable.
-const walk = (dir: string, matches: (name: string) => boolean, acc: Array<string>): void => {
-	if (!existsSync(dir)) return;
-	for (const entry of readdirSync(dir, {withFileTypes: true})) {
-		const abs = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			if (entry.name === "node_modules" || entry.name === "dist") continue;
-			walk(abs, matches, acc);
-		} else if (matches(entry.name)) {
-			acc.push(abs);
+/**
+ * Recursively collect the files under `dir` matching `matches`, over the Effect
+ * `FileSystem`/`Path` seam (over the bin's `NodeServices.layer`) so a gate `unit` test
+ * substitutes an in-memory fs for the real disk (.patterns/effect-platform-access.md); a
+ * fs fault folds `PlatformError` → the `IoError` this gate already carries. This is the
+ * one why-note for the file's platform-seam migration — the readers below follow suit.
+ *
+ * A missing UI/e2e dir is zero files, NOT an IO failure — the fail-closed scope anchor is
+ * the keys.ts read (zero parsed definitions ⇒ zero-scope). An absent .tsx/e2e tree then
+ * resolves as "no consumer / no journey", which judge correctly reports as unreachable.
+ */
+const walk = (
+	dir: string,
+	matches: (name: string) => boolean,
+): Effect.Effect<ReadonlyArray<string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		if (!(yield* fs.exists(dir).pipe(Effect.orElseSucceed(() => false)))) return [];
+		const acc: Array<string> = [];
+		for (const name of yield* fs
+			.readDirectory(dir)
+			.pipe(Effect.mapError((cause) => new IoError({path: dir, cause})))) {
+			const abs = path.join(dir, name);
+			const isDir =
+				(yield* fs.stat(abs).pipe(Effect.mapError((cause) => new IoError({path: abs, cause}))))
+					.type === "Directory";
+			if (isDir) {
+				if (name === "node_modules" || name === "dist") continue;
+				acc.push(...(yield* walk(abs, matches)));
+			} else if (matches(name)) {
+				acc.push(abs);
+			}
 		}
-	}
-};
+		return acc;
+	});
 
 /** Read + parse the flag-key module; a missing module fails as IO (not a vacuous pass). */
-const readDefinitions = (root: string): Effect.Effect<ReadonlyArray<FlagDefinition>, IoError> =>
-	Effect.try({
-		try: () => parseFlagDefinitions(readFileSync(join(root, KEYS_PATH), "utf8")),
-		catch: (cause) => new IoError({path: join(root, KEYS_PATH), cause}),
+const readDefinitions = (
+	root: string,
+): Effect.Effect<ReadonlyArray<FlagDefinition>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const keysPath = path.join(root, KEYS_PATH);
+		const text = yield* fs
+			.readFileString(keysPath, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: keysPath, cause})));
+		return parseFlagDefinitions(text);
 	});
 
 /** Collect the constant names referenced by ≥1 `.tsx` under `apps/web/src`. */
 const gatherConsumers = (
 	root: string,
 	candidateNames: ReadonlyArray<string>,
-): Effect.Effect<ReadonlySet<string>, IoError> =>
-	Effect.try({
-		try: () => {
-			const files: Array<string> = [];
-			walk(join(root, SRC_ROOT), (name) => name.endsWith(".tsx"), files);
-			const consumed = new Set<string>();
-			for (const abs of files) {
-				for (const name of consumedConstantsIn(readFileSync(abs, "utf8"), candidateNames)) {
-					consumed.add(name);
-				}
-			}
-			return consumed;
-		},
-		catch: (cause) => new IoError({path: join(root, SRC_ROOT), cause}),
+): Effect.Effect<ReadonlySet<string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const files = yield* walk(path.join(root, SRC_ROOT), (name) => name.endsWith(".tsx"));
+		const consumed = new Set<string>();
+		for (const abs of files) {
+			const source = yield* fs
+				.readFileString(abs, "utf8")
+				.pipe(Effect.mapError((cause) => new IoError({path: abs, cause})));
+			for (const name of consumedConstantsIn(source, candidateNames)) consumed.add(name);
+		}
+		return consumed;
 	});
 
 /** Collect the flag keys registered via `@journey:<key>` across the e2e specs. */
-const gatherJourneyKeys = (root: string): Effect.Effect<ReadonlySet<string>, IoError> =>
-	Effect.try({
-		try: () => {
-			const files: Array<string> = [];
-			walk(join(root, E2E_DIR), (name) => name.endsWith(".spec.ts"), files);
-			const keys = new Set<string>();
-			for (const abs of files) {
-				for (const key of parseJourneyTags(readFileSync(abs, "utf8"))) keys.add(key);
-			}
-			return keys;
-		},
-		catch: (cause) => new IoError({path: join(root, E2E_DIR), cause}),
+const gatherJourneyKeys = (
+	root: string,
+): Effect.Effect<ReadonlySet<string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const files = yield* walk(path.join(root, E2E_DIR), (name) => name.endsWith(".spec.ts"));
+		const keys = new Set<string>();
+		for (const abs of files) {
+			const source = yield* fs
+				.readFileString(abs, "utf8")
+				.pipe(Effect.mapError((cause) => new IoError({path: abs, cause})));
+			for (const key of parseJourneyTags(source)) keys.add(key);
+		}
+		return keys;
 	});
 
 /**
@@ -105,7 +136,7 @@ const gatherJourneyKeys = (root: string): Effect.Effect<ReadonlySet<string>, IoE
 export const checkReachability = (
 	root: string,
 	flagKey: string,
-): Effect.Effect<void, IoError | CheckFailed> =>
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const definitions = yield* readDefinitions(root);
 		const consumingConstants = yield* gatherConsumers(

--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
@@ -64,7 +64,22 @@ const walk = (
 			.readDirectory(dir)
 			.pipe(Effect.mapError((cause) => new IoError({path: dir, cause})))) {
 			const abs = path.join(dir, name);
+			// Classify a symlink as NOT-a-directory, reconstructing the pre-migration
+			// `Dirent.isDirectory()` (lstat-based, so a link-to-dir was never recursed). `fs.stat`
+			// follows links and v4's FileSystem exposes no `lstat`, but `readLink` succeeds only on
+			// a link — the equivalent test. This gate is load-bearing, not cosmetic: both
+			// reachability tests are NEGATIONS (`!consumingConstants.has` / `!journeyKeys.has`), so
+			// a wider walk can only turn a RED into a GREEN — purely fail-open for a fail-closed
+			// gate (ADR 0092/0173) — and, since the ignore-list screens by NAME with no visited set,
+			// a symlink cycle would be unbounded recursion (#3929). Symlinked FILES stay in scope as
+			// at base, hence the check gates the Directory arm only; a link is also never `stat`ed,
+			// so a broken one is ignored rather than surfacing as an IoError, again as at base.
+			const isSymlink = yield* fs.readLink(abs).pipe(
+				Effect.as(true),
+				Effect.orElseSucceed(() => false),
+			);
 			const isDir =
+				!isSymlink &&
 				(yield* fs.stat(abs).pipe(Effect.mapError((cause) => new IoError({path: abs, cause}))))
 					.type === "Directory";
 			if (isDir) {

--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.unit.test.ts
@@ -7,7 +7,7 @@
  * The working proof: a flag with a consuming `.tsx` + a `@journey`-tagged spec SUCCEEDS;
  * the same tree with the consumer removed `CheckFailed` (the reactions-class falsification).
  */
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
@@ -16,11 +16,16 @@ import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkReachability} from "./gate.ts";
 
 let root: string;
+// A second temp tree OUTSIDE `root`, so anything the walk reaches in it was reached
+// through a symlink planted in `root` and not by ordinary recursion.
+let outside: string;
 beforeEach(() => {
 	root = mkdtempSync(join(tmpdir(), "reachability-guard-gate-"));
+	outside = mkdtempSync(join(tmpdir(), "reachability-guard-outside-"));
 });
 afterEach(() => {
 	rmSync(root, {recursive: true, force: true});
+	rmSync(outside, {recursive: true, force: true});
 });
 
 const KEYS_DIR = join("apps", "web", "src", "flags");
@@ -47,11 +52,17 @@ const writeKeys = (
 	write(join(KEYS_DIR, "keys.ts"), `${body}\n`);
 };
 
+const consumerSource = (constantName: string) =>
+	`import {${constantName}} from "../flags/keys";\nexport const C = () => <FlagGate flag={${constantName}} />;\n`;
+
 const writeConsumer = (file: string, constantName: string) =>
-	write(
-		join(COMPONENTS_DIR, file),
-		`import {${constantName}} from "../flags/keys";\nexport const C = () => <FlagGate flag={${constantName}} />;\n`,
-	);
+	write(join(COMPONENTS_DIR, file), consumerSource(constantName));
+
+/** `writeConsumer`, addressed absolutely — lets a fixture live outside `root`. */
+const writeConsumerAt = (abs: string, constantName: string) => {
+	mkdirSync(join(abs, ".."), {recursive: true});
+	writeFileSync(abs, consumerSource(constantName), "utf8");
+};
 
 const writeJourneySpec = (file: string, flagKey: string) =>
 	write(
@@ -110,6 +121,49 @@ describe("checkReachability — the exit-code gate over a fake repo dir", () => 
 		const exit = await run(checkReachability(root, "not-a-real-flag"));
 		expect(isCheckFailed(exit)).toBe(true);
 	});
+
+	// The walk's traversal semantics are part of the exit-code contract, so they get pinned
+	// here: a symlinked DIR is out of scope while a symlinked FILE is in scope, matching the
+	// pre-migration lstat-based (`Dirent`) walk. The first of these is the one that matters —
+	// both reachability tests are negations, so a wider walk can only flip a real RED to green.
+	it("does NOT recurse a symlinked directory — a consumer only reachable through one leaves the flag UNREACHABLE", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		writeJourneySpec("28-reactions.spec.ts", "phoenix-reactions");
+		writeConsumerAt(join(outside, "ReactionBar.tsx"), "PHOENIX_REACTIONS");
+		mkdirSync(join(root, "apps", "web", "src"), {recursive: true});
+		symlinkSync(outside, join(root, "apps", "web", "src", "linked"), "dir");
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("DOES read a symlinked .tsx — a consumer behind a linked file still makes the flag reachable", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		writeJourneySpec("28-reactions.spec.ts", "phoenix-reactions");
+		writeConsumerAt(join(outside, "ReactionBar.tsx"), "PHOENIX_REACTIONS");
+		mkdirSync(join(root, COMPONENTS_DIR), {recursive: true});
+		symlinkSync(join(outside, "ReactionBar.tsx"), join(root, COMPONENTS_DIR, "ReactionBar.tsx"));
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("tolerates a broken symlink under the walk root (never stats a link — as at base)", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		writeConsumer("ReactionBar.tsx", "PHOENIX_REACTIONS");
+		writeJourneySpec("28-reactions.spec.ts", "phoenix-reactions");
+		symlinkSync(join(root, "does-not-exist"), join(root, "apps", "web", "src", "dangling"));
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("terminates on a symlink cycle under the walk root (a link-to-dir is never recursed)", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		writeConsumer("ReactionBar.tsx", "PHOENIX_REACTIONS");
+		writeJourneySpec("28-reactions.spec.ts", "phoenix-reactions");
+		const src = join(root, "apps", "web", "src");
+		symlinkSync(src, join(src, "loop"), "dir");
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	}, 30_000);
 
 	it("FAILS (CheckFailed, fail-closed) when keys.ts parses zero flag definitions", async () => {
 		write(join(KEYS_DIR, "keys.ts"), "export const notAFlag = 1;\n");

--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.unit.test.ts
@@ -10,8 +10,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkReachability} from "./gate.ts";
 
 let root: string;
@@ -58,7 +59,11 @@ const writeJourneySpec = (file: string, flagKey: string) =>
 		`test.describe("some journey @journey:${flagKey}", () => { test("x", () => {}); });\n`,
 	);
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3471);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
 

--- a/packages/pipeline-cli/src/tools/workflow-contract/command.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/command.ts
@@ -27,26 +27,33 @@
  * bin's run boundary) so the contract survives folding into the shared `pipeline-cli`
  * bin, which provides only `NodeServices.layer` and no per-tool catch.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkWorkflows} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
+// through the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). Marker-existence faults fall through as false,
+// matching the prior `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -55,8 +62,10 @@ const rootFlag = Flag.string("root").pipe(
 	),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
@@ -71,7 +80,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkWorkflows(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkWorkflows(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.test.ts
@@ -1,4 +1,4 @@
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
@@ -98,6 +98,23 @@ describe("checkWorkflows", () => {
 			assert.isTrue(Exit.isFailure(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	// Scope semantics are part of the exit-code contract: a symlinked `.js` is EXCLUDED,
+	// matching the pre-migration lstat-based `Dirent.isFile()` filter (see `listWorkflowScripts`).
+	it("excludes a symlinked .js — a non-conformant script reachable only through a link does not red", async () => {
+		const outside = mkdtempSync(join(tmpdir(), "workflow-contract-outside-"));
+		const target = join(outside, "bad.js");
+		writeFileSync(target, "export default async function () {}", "utf8");
+		const dir = makeRepo({"drive-issue.js": CONFORMANT});
+		try {
+			symlinkSync(target, join(dir, ".claude", "workflows", "linked.js"));
+			const exit = await runExit(checkWorkflows(dir));
+			assert.isTrue(Exit.isSuccess(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+			rmSync(outside, {recursive: true, force: true});
 		}
 	}, 30_000);
 

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.test.ts
@@ -1,9 +1,18 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Exit} from "effect";
+import {Effect, Exit, type FileSystem, type Path} from "effect";
 import {type CheckFailed, checkWorkflows, scanWorkflowScripts} from "./gate.ts";
+
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3471);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromise(Effect.provide(effect, NodeServices.layer));
+const runExit = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 
 /** A throwaway repo root carrying `.claude/workflows/<name>.js` scripts. */
 const makeRepo = (scripts: Record<string, string>): string => {
@@ -33,7 +42,7 @@ describe("scanWorkflowScripts", () => {
 			"README.md": "not a script",
 		});
 		try {
-			const verdicts = await Effect.runPromise(scanWorkflowScripts(dir));
+			const verdicts = await run(scanWorkflowScripts(dir));
 			assert.deepStrictEqual(verdicts.map((v) => v.file).sort(), [
 				".claude/workflows/bad.js",
 				".claude/workflows/good.js",
@@ -48,7 +57,7 @@ describe("checkWorkflows", () => {
 	it("passes on a conformant drive-issue-shaped script", async () => {
 		const dir = makeRepo({"drive-issue.js": CONFORMANT});
 		try {
-			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			const exit = await runExit(checkWorkflows(dir));
 			assert.isTrue(Exit.isSuccess(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
@@ -60,7 +69,7 @@ describe("checkWorkflows", () => {
 			"bad.js": `export default async function ({ agent, args, phase, log }) {}`,
 		});
 		try {
-			const reason = await Effect.runPromise(
+			const reason = await run(
 				checkWorkflows(dir).pipe(
 					Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
 				),
@@ -75,7 +84,7 @@ describe("checkWorkflows", () => {
 	it("fails on a missing-meta script", async () => {
 		const dir = makeRepo({"nometa.js": `phase("Run");\nawait agent("x", {});`});
 		try {
-			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			const exit = await runExit(checkWorkflows(dir));
 			assert.isTrue(Exit.isFailure(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
@@ -85,7 +94,7 @@ describe("checkWorkflows", () => {
 	it("fails closed on an unparseable / garbage script (no resolvable contract)", async () => {
 		const dir = makeRepo({"garbage.js": `}{ <<< not valid (( export ?? meta`});
 		try {
-			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			const exit = await runExit(checkWorkflows(dir));
 			assert.isTrue(Exit.isFailure(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
@@ -95,7 +104,7 @@ describe("checkWorkflows", () => {
 	it("passes clean on an empty set (no .claude/workflows dir)", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "workflow-contract-empty-"));
 		try {
-			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			const exit = await runExit(checkWorkflows(dir));
 			assert.isTrue(Exit.isSuccess(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
@@ -55,6 +55,15 @@ export const listWorkflowScripts = (
 		for (const name of names) {
 			if (!name.endsWith(".js")) continue;
 			const abs = path.join(base, name);
+			// A symlinked `.js` is out of scope, reconstructing the pre-migration `Dirent.isFile()`
+			// (lstat-based, so a link-to-file was excluded). `fs.stat` follows links and v4's
+			// FileSystem exposes no `lstat`, but `readLink` succeeds only on a link — the equivalent
+			// test (same reconstruction as `reachability-guard`'s walk, #3929).
+			const isSymlink = yield* fs.readLink(abs).pipe(
+				Effect.as(true),
+				Effect.orElseSucceed(() => false),
+			);
+			if (isSymlink) continue;
 			const isFile =
 				(yield* fs.stat(abs).pipe(Effect.mapError((cause) => new IoError({path: abs, cause}))))
 					.type === "File";

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
@@ -13,9 +13,7 @@
  * a clean pass: there is nothing whose load shape could break, so there is nothing to
  * fail. A present-but-unparseable script is the case that must red, and it does.
  */
-import {existsSync, readdirSync, readFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {judge, judgeScript, renderReport, type ScriptVerdict} from "./workflow-contract.ts";
 
@@ -30,35 +28,54 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 	reason: Schema.String,
 }) {}
 
-/** The workflow-script surface this guard owns (ADR 0062 — repo-relative). */
-const WORKFLOWS_DIR = join(".claude", "workflows");
+/** The workflow-script surface this guard owns (ADR 0062 — repo-relative, POSIX). */
+const WORKFLOWS_DIR = ".claude/workflows";
 
-/** List the `*.js` workflow scripts under `<root>/.claude/workflows`, repo-relative. */
-export const listWorkflowScripts = (root: string): Effect.Effect<ReadonlyArray<string>, IoError> =>
-	Effect.try({
-		try: () => {
-			const base = join(root, WORKFLOWS_DIR);
-			if (!existsSync(base)) return [];
-			return readdirSync(base, {withFileTypes: true})
-				.filter((e) => e.isFile() && e.name.endsWith(".js"))
-				.map((e) => join(WORKFLOWS_DIR, e.name))
-				.sort();
-		},
-		catch: (cause) => new IoError({path: join(root, WORKFLOWS_DIR), cause}),
+/**
+ * List the `*.js` workflow scripts under `<root>/.claude/workflows`, repo-relative.
+ *
+ * Directory/file IO goes through the Effect `FileSystem`/`Path` seam (over the bin's
+ * `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for the real
+ * disk (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the
+ * `IoError` this gate already carries. This is the one why-note for the file's
+ * platform-seam migration — `scanWorkflowScripts` below follows the same shape.
+ */
+export const listWorkflowScripts = (
+	root: string,
+): Effect.Effect<ReadonlyArray<string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const base = path.join(root, WORKFLOWS_DIR);
+		if (!(yield* fs.exists(base).pipe(Effect.orElseSucceed(() => false)))) return [];
+		const names = yield* fs
+			.readDirectory(base)
+			.pipe(Effect.mapError((cause) => new IoError({path: base, cause})));
+		const scripts: Array<string> = [];
+		for (const name of names) {
+			if (!name.endsWith(".js")) continue;
+			const abs = path.join(base, name);
+			const isFile =
+				(yield* fs.stat(abs).pipe(Effect.mapError((cause) => new IoError({path: abs, cause}))))
+					.type === "File";
+			if (isFile) scripts.push(`${WORKFLOWS_DIR}/${name}`);
+		}
+		return scripts.sort();
 	});
 
 /** Read + judge every workflow script under `root` into per-script verdicts. */
 export const scanWorkflowScripts = (
 	root: string,
-): Effect.Effect<ReadonlyArray<ScriptVerdict>, IoError> =>
+): Effect.Effect<ReadonlyArray<ScriptVerdict>, IoError, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
 		const files = yield* listWorkflowScripts(root);
 		const verdicts: ScriptVerdict[] = [];
 		for (const file of files) {
-			const text = yield* Effect.try({
-				try: () => readFileSync(join(root, file), "utf8"),
-				catch: (cause) => new IoError({path: file, cause}),
-			});
+			const text = yield* fs
+				.readFileString(path.join(root, file), "utf8")
+				.pipe(Effect.mapError((cause) => new IoError({path: file, cause})));
 			verdicts.push(judgeScript(file, text));
 		}
 		return verdicts;
@@ -69,7 +86,9 @@ export const scanWorkflowScripts = (
  * contract, else `CheckFailed` with the per-violation report. An empty set passes
  * clean; a present-but-violating (or unparseable) script reds — fail-closed (ADR 0092).
  */
-export const checkWorkflows = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkWorkflows = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const verdicts = yield* scanWorkflowScripts(root);
 		const verdict = judge(verdicts);


### PR DESCRIPTION
## What

Migrates the raw `node:fs` / `node:path` production imports in the **fanout / reachability / workflow-contract / path-filter** guard cluster to the v4 Effect platform idiom (`.patterns/effect-platform-access.md`). Each gate's directory/file IO now `yield*`s `FileSystem.FileSystem` / `Path.Path` from `effect`; the requirement discharges through the `NodeServices.layer` **already provided by `run.ts`** — no new layer wiring.

Fixes #3471

## Files

- `packages/pipeline-cli/src/tools/fanout-guard/{command,gate}.ts` (+ `gate.unit.test.ts`)
- `packages/pipeline-cli/src/tools/reachability-guard/{command,gate}.ts` (+ `gate.unit.test.ts`)
- `packages/pipeline-cli/src/tools/workflow-contract/{command,gate}.ts` (+ `gate.test.ts`)
- `packages/pipeline-cli/src/tools/path-filter-guard/{command,gate}.ts` (+ `gate.unit.test.ts`)

Disjoint from the sibling m32 children (#3470, #3472–3474) — parallel-safe.

## How

- Each gate's IO helpers become `Effect.gen` over the `FileSystem`/`Path` seam; a `PlatformError` folds to the `IoError` each gate already carries (`Effect.mapError`), preserving the typed error channel and exit-code contract.
- Each command's `defaultRoot` walks up for the repo-root marker over the same seam (mirrors the migrated `catalog-guard`), so `resolveRoot` returns an Effect and the resolver is testable off real disk.
- Module-level repo-relative path fragments become plain POSIX string literals, combined with the absolute `root` at runtime through `Path.Path` (no module-level `node:path` join with no seam in scope).
- Reachability's recursive `walk` is rewritten as an Effect-recursive gather over the seam.

## Bright-line boundaries preserved (per the doc)

- Real-fs test **fixtures** (`mkdtempSync`/`writeFileSync` over a real temp dir) stay raw `node:fs` — the point is the real disk. Only each seam-test's runner now provides the live `NodeServices.layer` so the gate Effects it exercises can discharge `FileSystem | Path`.
- `bin.ts` and other node-only boundaries (`os.homedir`, `fileURLToPath`, `proper-lockfile`) are untouched.

## Verification

- Behavior-preserving refactor — identical exit codes / stdout / stderr / fail-closed semantics.
- `pnpm --filter @kampus/pipeline-cli typecheck` — green.
- The four tools' unit + gate tests — 107 passed.
- `biome check` — clean on all 12 files.

## §CP

Touches `packages/pipeline-cli/` → banks for a human merge by **@kamp-us/control-plane**; does **not** auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LxQ5T7AqZEowBFX5t7awW
