### PR TITLE
refactor(pipeline-cli): route control-plane/worktree/spawn IO through the v4 FileSystem/Path seam (#3473)

### DIFF
--- a/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
@@ -17,7 +17,7 @@
  * caught inside the handler (not at the bin's run boundary) so the contract survives
  * folding into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
  */
-import {Effect, Option} from "effect";
+import {Effect, type FileSystem, Option, type Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {type CheckFailed, checkCodeownersCp, defaultRoot} from "./gate.ts";
 
@@ -30,8 +30,10 @@ const rootFlag = Flag.string("root").pipe(
 	),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 const onCheckFailed = (e: CheckFailed) =>
 	Effect.sync(() => {
@@ -43,9 +45,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkCodeownersCp(resolveRoot(rootOpt)).pipe(
-			Effect.catchTag("CheckFailed", onCheckFailed),
-		);
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkCodeownersCp(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription("Fail the build if a §CP control-plane path has no CODEOWNERS owner"),

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -1,8 +1,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Exit} from "effect";
+import {Effect, Exit, type FileSystem, type Path} from "effect";
 import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
 import {type CheckFailed, CODEOWNERS_PATH, checkCodeownersCp, FORMATS_PATH} from "./gate.ts";
 
@@ -48,11 +49,21 @@ const makeRepo = (opts: {formats?: string; codeowners?: string}): string => {
 	return dir;
 };
 
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3473);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const provide = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.provide(effect, NodeServices.layer);
+
+const runExit = (dir: string) => Effect.runPromiseExit(provide(checkCodeownersCp(dir)));
+
 const reasonOf = (dir: string): Promise<string> =>
 	Effect.runPromise(
-		checkCodeownersCp(dir).pipe(
-			Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
-			Effect.map((r) => (typeof r === "string" ? r : "")),
+		provide(
+			checkCodeownersCp(dir).pipe(
+				Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
+				Effect.map((r) => (typeof r === "string" ? r : "")),
+			),
 		),
 	);
 
@@ -60,7 +71,7 @@ describe("checkCodeownersCp", () => {
 	it("succeeds when CODEOWNERS covers every §CP path", async () => {
 		const dir = makeRepo({formats: `CONTROL_PLANE_RE='${LIVE_RE}'`, codeowners: FULL_CODEOWNERS});
 		try {
-			const exit = await Effect.runPromiseExit(checkCodeownersCp(dir));
+			const exit = await runExit(dir);
 			assert.isTrue(Exit.isSuccess(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
@@ -73,7 +84,7 @@ describe("checkCodeownersCp", () => {
 			.join("\n");
 		const dir = makeRepo({formats: `CONTROL_PLANE_RE='${LIVE_RE}'`, codeowners: stale});
 		try {
-			const exit = await Effect.runPromiseExit(checkCodeownersCp(dir));
+			const exit = await runExit(dir);
 			assert.isTrue(Exit.isFailure(exit));
 			assert.include(await reasonOf(dir), "packages/pipeline-cli/");
 		} finally {
@@ -117,7 +128,7 @@ describe("checkCodeownersCp", () => {
 	it("fails (IoError) when a source file is missing — refusing rather than passing", async () => {
 		const dir = makeRepo({codeowners: FULL_CODEOWNERS}); // no formats file
 		try {
-			const exit = await Effect.runPromiseExit(checkCodeownersCp(dir));
+			const exit = await runExit(dir);
 			assert.isTrue(Exit.isFailure(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
@@ -15,9 +15,7 @@
  * formats line that has drifted from the const, a CODEOWNERS with zero owned entries, OR a
  * const that resolves to ZERO §CP paths all FAIL — only a fully-covered, in-sync §CP set passes.
  */
-import {existsSync, readFileSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
 import {
@@ -45,18 +43,31 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 	reason: Schema.String,
 }) {}
 
-const readRepoFile = (root: string, rel: string): Effect.Effect<string, IoError> =>
-	Effect.try({
-		try: () => readFileSync(join(root, rel), "utf8"),
-		catch: (cause) => new IoError({path: rel, cause}),
-	});
+/**
+ * Read one repo-relative source through the Effect `FileSystem`/`Path` seam (over the
+ * bin's `NodeServices.layer`), so the gate is crossable against a substituted filesystem
+ * (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the `IoError`
+ * this gate already carries. This is the file's one why-note for the platform seam —
+ * `defaultRoot` below probes its markers through the same services.
+ */
+const readRepoFile = (
+	root: string,
+	rel: string,
+): Effect.Effect<string, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		return yield* fs.readFileString(path.join(root, rel), "utf8");
+	}).pipe(Effect.mapError((cause) => new IoError({path: rel, cause})));
 
 /**
  * The CI gate: succeed only when the §CP regex resolves a non-empty path set AND
  * every one of those paths is covered by an owned CODEOWNERS entry. Each fail-closed
  * branch is a distinct `CheckFailed` reason so the run log says *why* it refused.
  */
-export const checkCodeownersCp = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkCodeownersCp = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const formatsText = yield* readRepoFile(root, FORMATS_PATH);
 		const codeownersText = yield* readRepoFile(root, CODEOWNERS_PATH);
@@ -115,15 +126,22 @@ export const checkCodeownersCp = (root: string): Effect.Effect<void, IoError | C
 /**
  * Resolve the repo root by walking UP from `from` for a workspace marker, so
  * `pnpm --filter <pkg> …` (cwd = package dir) still finds the repo root. Mirrors
- * the shared `find-root-dir` / decisions-index walk (#447).
+ * the shared `find-root-dir` / decisions-index walk (#447). Marker-existence faults
+ * fall through as false, matching the `existsSync` this replaced.
  */
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
-export const defaultRoot = (from: string = process.cwd()): string => {
-	let dir = resolve(from);
+export const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
 	for (;;) {
-		if (ROOT_MARKERS.some((marker) => existsSync(join(dir, marker)))) return dir;
-		const parent = dirname(dir);
-		if (parent === dir) return resolve(from);
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
 		dir = parent;
 	}
-};
+});

--- a/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
@@ -37,7 +37,13 @@ const selfApprovalFlag = Flag.boolean("self-approval-at-head").pipe(
 	),
 );
 
-/** Read the control-plane member logins from stdin; empty/failed read ⇒ N==0 (fail closed). */
+/**
+ * Read the control-plane member logins from stdin; empty/failed read ⇒ N==0 (fail closed).
+ *
+ * The fd-0 read stays raw `node:fs`: the Effect `FileSystem` seam is path-keyed and exposes no
+ * stdin reader, and `Stdio.stdin` is a Stream that blocks on a TTY with no pipe — so this is the
+ * platform doc's node-only boundary case (.patterns/effect-platform-access.md), not a miss.
+ */
 const readMembers = (): ReadonlyArray<string> => {
 	let raw: string;
 	// biome-ignore lint/plugin: best-effort read — an empty/failed stdin is absorbed into [] (⇒ N==0, fail closed), never the E channel; a total helper, not Effect-cosplay.

--- a/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
@@ -27,8 +27,7 @@
  * subcommand: it intercepts arbitrary `gh` verbs in a pre-runtime argv dispatch before
  * any subcommand router runs. Here only `lint-skills` is exposed as a verb.
  */
-import {readFileSync} from "node:fs";
-import {Console, Effect, Result} from "effect";
+import {Console, Effect, FileSystem} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command} from "effect/unstable/cli";
 import {isZeroScope, type LintResult, lintCorpus, type ScanFile} from "./lint.ts";
@@ -41,10 +40,15 @@ class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()("FindingsFo
 }) {}
 class ZeroScope extends Schema.TaggedErrorClass<ZeroScope>()("ZeroScope", {}) {}
 
-const readFileOrSkip = (file: string): string | null =>
-	Result.getOrElse(
-		Result.try(() => readFileSync(file, "utf8")),
-		() => null,
+/**
+ * Read one corpus file through the Effect `FileSystem` seam (over the bin's
+ * `NodeServices.layer`, .patterns/effect-platform-access.md) — an unreadable file still
+ * degrades to `null`, which the caller skips, so it never enters the scanned scope and the
+ * zero-scope fail-closed above stays the only refusal.
+ */
+const readFileOrSkip = (file: string): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(file, "utf8")).pipe(
+		Effect.orElseSucceed((): string | null => null),
 	);
 
 const fileArg = Argument.string("file").pipe(
@@ -106,7 +110,7 @@ const lintSkills = Command.make(
 	Effect.fn(function* ({files}) {
 		const scanInput: ScanFile[] = [];
 		for (const file of files) {
-			const content = readFileOrSkip(file);
+			const content = yield* readFileOrSkip(file);
 			if (content !== null) scanInput.push({file, content});
 		}
 

--- a/packages/pipeline-cli/src/tools/resume-policy/command.ts
+++ b/packages/pipeline-cli/src/tools/resume-policy/command.ts
@@ -72,6 +72,10 @@ interface StdinPayload {
  * Read a crash signal + resume ledger from a stdin JSON object. The orchestrator can pipe
  * the whole crash payload in one shot; a non-JSON or empty stdin yields empties (the flags
  * then fill in, or the core default-denies), so this never throws.
+ *
+ * The fd-0 read stays raw `node:fs` — the Effect `FileSystem` seam is path-keyed with no stdin
+ * reader, and `Stdio.stdin` is a Stream that blocks on a TTY with no pipe: the platform doc's
+ * node-only boundary case (.patterns/effect-platform-access.md).
  */
 const readStdin = (): StdinPayload => {
 	let raw = "";

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.ts
@@ -36,9 +36,11 @@ import {decideSpawn, formatSessionCost, type SessionCostInput} from "./spawn-gua
 
 /**
  * Read all of stdin as a UTF-8 string (the hook/statusline JSON envelope). The harness
- * pipes the envelope on fd 0; a synchronous read of fd 0 mirrors `leak-guard`'s
- * `readFileSync` IO idiom and avoids a stream that hangs when run on a TTY with no pipe.
- * An empty/unreadable stdin yields `""` (the parser then degrades to `{}`).
+ * pipes the envelope on fd 0; a synchronous read of fd 0 avoids a stream that hangs when run
+ * on a TTY with no pipe. An empty/unreadable stdin yields `""` (the parser then degrades to
+ * `{}`). This is a raw `node:fs` boundary by design: the Effect `FileSystem` seam is path-keyed
+ * with no stdin reader, and `Stdio.stdin` is exactly the blocking Stream this avoids — the
+ * platform doc's node-only case (.patterns/effect-platform-access.md).
  */
 const readStdin = (): Effect.Effect<string> =>
 	Effect.try({

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -36,17 +36,17 @@
  * is dropped: the `pipeline-cli` bin imports `@effect/platform-node` statically, so
  * by the time a subcommand runs the runtime dep is always resolved.
  *
- * The sync git/fs probe helpers below are best-effort by contract: a hook must never
- * crash on a git/fs hiccup, so every probe degrades to a SAFE fallback (allow / keep /
- * dirty), absorbing the failure into a returned value rather than the `E` channel. That
- * is why each carries a per-line `biome-ignore lint/plugin` — lifting them into
- * `Effect.try` only to re-collapse the error to the same fallback is noise, not the
- * failure-modeling `no-raw-try-catch` targets (the design-capture/upload.ts precedent).
+ * The probe helpers below are best-effort by contract: a hook must never crash on a git/fs
+ * hiccup, so every probe degrades to a SAFE fallback (allow / keep / dirty), absorbing the
+ * failure into a returned value rather than the `E` channel. File/path IO crosses the Effect
+ * `FileSystem`/`Path` seam (.patterns/effect-platform-access.md, #3473) and degrades with
+ * `Effect.orElseSucceed`; the `git` shell-outs stay raw `execFileSync` (a subprocess boundary
+ * the platform services do not cover) and keep their per-line `biome-ignore lint/plugin` —
+ * lifting those into `Effect.try` only to re-collapse the error to the same fallback is noise,
+ * not the failure-modeling `no-raw-try-catch` targets (the design-capture/upload.ts precedent).
  */
 import {execFileSync} from "node:child_process";
-import {existsSync, readFileSync, statSync} from "node:fs";
-import {resolve} from "node:path";
-import {Console, Effect, Option} from "effect";
+import {Console, Effect, FileSystem, Option, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import {
@@ -59,7 +59,7 @@ import {isIsolationExpected, pinBash} from "./bash-pin.ts";
 import {decideCleanTree} from "./clean-tree.ts";
 import {guardEnterWorktree} from "./enter-guard.ts";
 import {type AgentSidecar, resolveIsolationIdentity, sidecarPathFor} from "./isolation-identity.ts";
-import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
+import {mainCheckoutPrefix, type PathDecision, resolvePath} from "./path-resolve.ts";
 import {decideReap} from "./reap.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
@@ -84,50 +84,65 @@ type TreeKind =
 	| {readonly kind: "linked"; readonly toplevel: string}
 	| {readonly kind: "unknown"};
 
-const probeTree = (cwd: string): TreeKind => {
-	const base = cwd || process.cwd();
-	// biome-ignore lint/plugin: best-effort probe — an unknowable git dir degrades to "unknown", never E (see file header).
-	try {
-		const opts = {cwd: base, encoding: "utf8" as const};
-		const gitDir = resolve(
-			base,
-			execFileSync("git", ["rev-parse", "--absolute-git-dir"], opts).trim(),
-		);
-		const commonDir = resolve(
-			base,
-			execFileSync("git", ["rev-parse", "--git-common-dir"], opts).trim(),
-		);
-		if (gitDir === commonDir) return {kind: "primary"};
-		return {
-			kind: "linked",
-			toplevel: execFileSync("git", ["rev-parse", "--show-toplevel"], opts).trim(),
-		};
-	} catch {
-		return {kind: "unknown"};
-	}
-};
+const probeTree = (cwd: string): Effect.Effect<TreeKind, never, Path.Path> =>
+	Effect.gen(function* () {
+		const pathSvc = yield* Path.Path;
+		const base = cwd || process.cwd();
+		// biome-ignore lint/plugin: best-effort probe — an unknowable git dir degrades to "unknown", never E (see file header).
+		try {
+			const opts = {cwd: base, encoding: "utf8" as const};
+			const gitDir = pathSvc.resolve(
+				base,
+				execFileSync("git", ["rev-parse", "--absolute-git-dir"], opts).trim(),
+			);
+			const commonDir = pathSvc.resolve(
+				base,
+				execFileSync("git", ["rev-parse", "--git-common-dir"], opts).trim(),
+			);
+			if (gitDir === commonDir) return {kind: "primary"} as const;
+			return {
+				kind: "linked",
+				toplevel: execFileSync("git", ["rev-parse", "--show-toplevel"], opts).trim(),
+			} as const;
+		} catch {
+			return {kind: "unknown"} as const;
+		}
+	});
 
 // Unknowable ⇒ false (degrade to today's allow, never a spurious refusal).
-const onPrimaryCheckout = (cwd: string): boolean => probeTree(cwd).kind === "primary";
+const onPrimaryCheckout = (cwd: string): Effect.Effect<boolean, never, Path.Path> =>
+	Effect.map(probeTree(cwd), (tree) => tree.kind === "primary");
 
-/** The agent's OWN worktree + agent-type, from the harness sidecar named by the hook payload. */
-const readSidecar = (input: unknown): AgentSidecar | null => {
-	const path = sidecarPathFor({
-		transcriptPath: str(field(input, "transcript_path")),
-		agentId: str(field(input, "agent_id")),
+/**
+ * The agent's OWN worktree + agent-type, from the harness sidecar named by the hook payload.
+ * The former `existsSync` pre-check is folded into the read itself: an absent sidecar fails
+ * the read, which degrades to the same `null` an absent file always produced.
+ */
+const readSidecar = (
+	input: unknown,
+): Effect.Effect<AgentSidecar | null, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const sidecarPath = sidecarPathFor({
+			transcriptPath: str(field(input, "transcript_path")),
+			agentId: str(field(input, "agent_id")),
+		});
+		if (sidecarPath === null) return null;
+		const fs = yield* FileSystem.FileSystem;
+		const raw = yield* fs
+			.readFileString(sidecarPath, "utf8")
+			.pipe(Effect.orElseSucceed((): string | null => null));
+		if (raw === null) return null;
+		// biome-ignore lint/plugin: best-effort parse — a malformed sidecar degrades to null (fall down the evidence chain), never E (see file header).
+		try {
+			const parsed = JSON.parse(raw) as unknown;
+			return {
+				worktreePath: str(field(parsed, "worktreePath")),
+				agentType: str(field(parsed, "agentType")),
+			};
+		} catch {
+			return null;
+		}
 	});
-	if (path === null || !existsSync(path)) return null;
-	// biome-ignore lint/plugin: best-effort read — an unreadable/malformed sidecar degrades to null (fall down the evidence chain), never E (see file header).
-	try {
-		const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
-		return {
-			worktreePath: str(field(parsed, "worktreePath")),
-			agentType: str(field(parsed, "agentType")),
-		};
-	} catch {
-		return null;
-	}
-};
 
 /**
  * Run-time #2778 attribution (#2784, part 2): record — never block — a bulk-staging Bash command at
@@ -143,34 +158,40 @@ const readSidecar = (input: unknown): AgentSidecar | null => {
  * This is the record-only path on purpose; it emits no permission decision, so the resolved
  * identity cannot change what any hook allows or refuses.
  */
-const recordBashStaging = (command: string, cwd: string, input: unknown): void => {
-	// biome-ignore lint/plugin: best-effort attribution — any recording failure is swallowed so it can never perturb the pin decision, never E (see file header).
-	try {
-		const tree = probeTree(cwd);
-		const identity = resolveIsolationIdentity({
-			sidecar: readSidecar(input),
-			payloadAgentType: str(field(input, "agent_type")),
-			envWorktreeRoot: WORKTREE_ROOT,
-			envAgentType: process.env.CLAUDE_CODE_AGENT ?? "",
-			gitToplevel: tree.kind === "linked" ? tree.toplevel : "",
-			isLinkedWorktree: tree.kind === "linked",
-		});
-		const decision = decideBashStagingAttribution({
-			command,
-			cwd,
-			onPrimaryCheckout: tree.kind === "primary",
-			agentType: identity.agentType,
-			sessionId: process.env.CLAUDE_CODE_SESSION_ID ?? "",
-			worktreeRoot: identity.worktreeRoot,
-			at: new Date().toISOString(),
-		});
-		if (decision.kind !== "record") return;
-		appendRecord(defaultLogPath(), `${JSON.stringify(decision.record)}\n`);
-		process.stderr.write(`${renderBashStagingNote(decision.record)}\n`);
-	} catch {
-		// Attribution is best-effort; a recording failure must never affect the pin decision.
-	}
-};
+const recordBashStaging = (
+	command: string,
+	cwd: string,
+	input: unknown,
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const tree = yield* probeTree(cwd);
+		const sidecar = yield* readSidecar(input);
+		// biome-ignore lint/plugin: best-effort attribution — any recording failure is swallowed so it can never perturb the pin decision, never E (see file header).
+		try {
+			const identity = resolveIsolationIdentity({
+				sidecar,
+				payloadAgentType: str(field(input, "agent_type")),
+				envWorktreeRoot: WORKTREE_ROOT,
+				envAgentType: process.env.CLAUDE_CODE_AGENT ?? "",
+				gitToplevel: tree.kind === "linked" ? tree.toplevel : "",
+				isLinkedWorktree: tree.kind === "linked",
+			});
+			const decision = decideBashStagingAttribution({
+				command,
+				cwd,
+				onPrimaryCheckout: tree.kind === "primary",
+				agentType: identity.agentType,
+				sessionId: process.env.CLAUDE_CODE_SESSION_ID ?? "",
+				worktreeRoot: identity.worktreeRoot,
+				at: new Date().toISOString(),
+			});
+			if (decision.kind !== "record") return;
+			appendRecord(defaultLogPath(), `${JSON.stringify(decision.record)}\n`);
+			process.stderr.write(`${renderBashStagingNote(decision.record)}\n`);
+		} catch {
+			// Attribution is best-effort; a recording failure must never affect the pin decision.
+		}
+	});
 
 // A non-force `git worktree remove` that errors means git judged the tree unsafe to
 // remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
@@ -235,6 +256,35 @@ const deny = (reason: string) =>
 		}),
 	);
 
+/**
+ * Cross the pure `resolvePath` core with the async `FileSystem` seam. The core is IO-free by
+ * design and takes a SYNCHRONOUS existence predicate, which `fs.exists` (an Effect) cannot
+ * satisfy — so probe by capture instead of making the core Effect-ful: run it once with a
+ * predicate that records the path it asks about and answers `false`, and only when it *did*
+ * ask does the fs get touched, re-running the core with the answer. The core consults the
+ * predicate at most once (with the worktree copy of a main-checkout path), so this is exactly
+ * the former `existsSync` decision — an unstattable path still degrades to `false` (absent).
+ */
+const decideFilePath = (args: {
+	readonly worktreeRoot: string;
+	readonly cwd: string;
+	readonly candidatePath: string;
+}): Effect.Effect<PathDecision, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		let probed: string | null = null;
+		const absent = resolvePath({
+			...args,
+			existsInWorktree: (p) => {
+				probed = p;
+				return false;
+			},
+		});
+		if (probed === null) return absent;
+		const fs = yield* FileSystem.FileSystem;
+		const exists = yield* fs.exists(probed).pipe(Effect.orElseSucceed(() => false));
+		return exists ? resolvePath({...args, existsInWorktree: () => true}) : absent;
+	});
+
 const preFile = Command.make(
 	"pre-file",
 	{},
@@ -243,18 +293,10 @@ const preFile = Command.make(
 		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
 		const candidate = str(toolInput.file_path);
 		const cwd = str(field(input, "cwd"));
-		const decision = resolvePath({
+		const decision = yield* decideFilePath({
 			worktreeRoot: WORKTREE_ROOT,
 			cwd,
 			candidatePath: candidate,
-			existsInWorktree: (p) => {
-				// biome-ignore lint/plugin: best-effort probe — an unstattable path degrades to false (absent), never E (see file header).
-				try {
-					return existsSync(p);
-				} catch {
-					return false;
-				}
-			},
 		});
 		switch (decision.kind) {
 			case "allow":
@@ -280,13 +322,13 @@ const preBash = Command.make(
 		const cwd = str(field(input, "cwd"));
 		// Run-time #2778 attribution (#2784): record a bulk-staging op before deciding the pin. Purely
 		// additive and best-effort — it never changes the pin decision emitted below.
-		recordBashStaging(command, cwd, input);
+		yield* recordBashStaging(command, cwd, input);
 		const decision = pinBash({
 			worktreeRoot: WORKTREE_ROOT,
 			command,
 			isolationExpected: isIsolationExpected({
 				agentType: process.env.CLAUDE_CODE_AGENT ?? "",
-				onPrimaryCheckout: onPrimaryCheckout(cwd),
+				onPrimaryCheckout: yield* onPrimaryCheckout(cwd),
 			}),
 		});
 		if (decision.kind === "allow") return yield* allow();
@@ -324,18 +366,26 @@ const preEnter = Command.make(
  * distinguishes an owner-stop from a nested stop. Anything unreadable ⇒ "" ⇒ ownership unprovable ⇒
  * `decideReap` KEEPs (fail-closed: never reap a possibly-live parent tree).
  */
-const ownedWorktreeFromPayload = (input: unknown): string => {
-	const transcriptPath = str(field(input, "transcript_path"));
-	if (!transcriptPath) return "";
-	const metaPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
-	if (metaPath === transcriptPath || !existsSync(metaPath)) return "";
-	// biome-ignore lint/plugin: best-effort read — an unreadable/malformed sidecar degrades to "" (ownership unprovable ⇒ decideReap KEEPs), never E (see file header).
-	try {
-		return str(field(JSON.parse(readFileSync(metaPath, "utf8")) as unknown, "worktreePath"));
-	} catch {
-		return "";
-	}
-};
+const ownedWorktreeFromPayload = (
+	input: unknown,
+): Effect.Effect<string, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const transcriptPath = str(field(input, "transcript_path"));
+		if (!transcriptPath) return "";
+		const metaPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+		if (metaPath === transcriptPath) return "";
+		const fs = yield* FileSystem.FileSystem;
+		const raw = yield* fs
+			.readFileString(metaPath, "utf8")
+			.pipe(Effect.orElseSucceed((): string | null => null));
+		if (raw === null) return "";
+		// biome-ignore lint/plugin: best-effort parse — a malformed sidecar degrades to "" (ownership unprovable ⇒ decideReap KEEPs), never E (see file header).
+		try {
+			return str(field(JSON.parse(raw) as unknown, "worktreePath"));
+		} catch {
+			return "";
+		}
+	});
 
 /** Is the worktree dirty? `git status --porcelain` non-empty ⇒ dirty (also dirty if we can't tell — fail-safe to KEEP). */
 const worktreeIsDirty = (root: string): boolean => {
@@ -356,22 +406,24 @@ const reap = Command.make(
 	{},
 	Effect.fn(function* () {
 		const input = yield* readStdin();
-		if (!WORKTREE_ROOT || !existsSync(WORKTREE_ROOT)) {
+		const fs = yield* FileSystem.FileSystem;
+		const rootExists =
+			WORKTREE_ROOT !== "" &&
+			(yield* fs.exists(WORKTREE_ROOT).pipe(Effect.orElseSucceed(() => false)));
+		if (!rootExists) {
 			return yield* Console.error("worktree-guard reap: no $WORKTREE_ROOT to reap (skip)");
 		}
-		let dir = true;
-		// biome-ignore lint/plugin: best-effort probe — an unstattable root degrades to not-a-directory (skip), never E (see file header).
-		try {
-			dir = statSync(WORKTREE_ROOT).isDirectory();
-		} catch {
-			dir = false;
-		}
+		// An unstattable root degrades to not-a-directory (skip) — the former `statSync` fallback.
+		const dir = yield* fs.stat(WORKTREE_ROOT).pipe(
+			Effect.map((info) => info.type === "Directory"),
+			Effect.orElseSucceed(() => false),
+		);
 		if (!dir) {
 			return yield* Console.error("worktree-guard reap: $WORKTREE_ROOT is not a directory (skip)");
 		}
 		const decision = decideReap({
 			worktreeRoot: WORKTREE_ROOT,
-			ownedWorktree: ownedWorktreeFromPayload(input),
+			ownedWorktree: yield* ownedWorktreeFromPayload(input),
 			isDirty: worktreeIsDirty(WORKTREE_ROOT),
 		});
 		switch (decision.kind) {

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -25,14 +25,13 @@
  *      classifier's liveness gate is what covers the concurrent-sibling case.
  *
  * DRY-RUN by default: with no flag it prints what it WOULD remove and exits 0
- * without touching anything. The git IO uses `execFileSync` directly (mirrors the
- * `worktree-guard` reaper), so the tool's requirement stays at the Node platform
- * ceiling the registry provides.
+ * without touching anything. The git/gh IO uses `execFileSync` directly (mirrors the
+ * `worktree-guard` reaper) — a subprocess boundary the platform services do not cover;
+ * the file/path IO crosses the Effect `FileSystem`/`Path` seam
+ * (.patterns/effect-platform-access.md, #3473).
  */
 import {execFileSync} from "node:child_process";
-import {statSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {
 	computeWorktreeSweepPlan,
@@ -108,20 +107,28 @@ const squashMergedToOriginMain = (head: string | null): boolean => {
 /** A managed worktree untouched this long is presumed orphaned, not a live lane (#2240). */
 const IDLE_THRESHOLD_MS = 30 * 60 * 1000;
 
-/** Newest mtime (ms) among the given paths, or `null` when none can be stat'd. */
-const newestMtimeMs = (paths: ReadonlyArray<string>): number | null => {
-	let newest: number | null = null;
-	for (const p of paths) {
-		// biome-ignore lint/plugin: best-effort probe — an absent/unreadable path is skipped (a wholly unresolvable set falls to the null fail-safe), never the E channel; a total helper, not Effect-cosplay.
-		try {
-			const m = statSync(p).mtimeMs;
-			if (newest === null || m > newest) newest = m;
-		} catch {
-			// path absent/unreadable — skip; a wholly unresolvable set falls to the null fail-safe below.
+/**
+ * Newest mtime (ms) among the given paths, or `null` when none can be stat'd. Each stat goes
+ * through the `FileSystem` seam and degrades to "skipped" on a fault, so an absent/unreadable
+ * path is still passed over and a wholly unresolvable set still falls to the `null` fail-safe.
+ * `Option.none()` mtime (a stat with no timestamp) counts as unresolvable, same as a fault.
+ */
+const newestMtimeMs = (
+	paths: ReadonlyArray<string>,
+): Effect.Effect<number | null, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		let newest: number | null = null;
+		for (const p of paths) {
+			const mtime = yield* fs.stat(p).pipe(
+				Effect.map((info) => info.mtime.pipe(Option.map((d) => d.getTime()))),
+				Effect.orElseSucceed(() => Option.none<number>()),
+			);
+			if (Option.isNone(mtime)) continue;
+			if (newest === null || mtime.value > newest) newest = mtime.value;
 		}
-	}
-	return newest;
-};
+		return newest;
+	});
 
 /**
  * Is a managed worktree still LIVE by recency (#2240)? Probes the worktree dir + its
@@ -130,17 +137,21 @@ const newestMtimeMs = (paths: ReadonlyArray<string>): number | null => {
  * is deliberately NOT probed: `git status` (the dirty check) can rewrite it, which would
  * mask idleness. Any unresolvable mtime ⇒ presumed active (fail-safe KEEP).
  */
-const worktreeRecentlyActive = (path: string): boolean => {
-	const gitdir = runGit(["-C", path, "rev-parse", "--absolute-git-dir"]);
-	const probes = [path];
-	if (gitdir.ok) {
-		const g = gitdir.stdout.trim();
-		probes.push(join(g, "HEAD"), join(g, "logs", "HEAD"));
-	}
-	const newest = newestMtimeMs(probes);
-	if (newest === null) return true;
-	return Date.now() - newest < IDLE_THRESHOLD_MS;
-};
+const worktreeRecentlyActive = (
+	path: string,
+): Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const pathSvc = yield* Path.Path;
+		const gitdir = runGit(["-C", path, "rev-parse", "--absolute-git-dir"]);
+		const probes = [path];
+		if (gitdir.ok) {
+			const g = gitdir.stdout.trim();
+			probes.push(pathSvc.join(g, "HEAD"), pathSvc.join(g, "logs", "HEAD"));
+		}
+		const newest = yield* newestMtimeMs(probes);
+		if (newest === null) return true;
+		return Date.now() - newest < IDLE_THRESHOLD_MS;
+	});
 
 const runGh = (args: ReadonlyArray<string>): GitResult => {
 	// biome-ignore lint/plugin: best-effort gh shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
@@ -205,55 +216,60 @@ const worktreeSweep = Command.make(
 		}
 
 		const parsed = parseWorktreeList(listed.stdout);
-		const records: ReadonlyArray<WorktreeRecord> = parsed
-			.filter((p) => !p.bare)
-			.map((p) => {
-				// A gone-dir tree's working directory is missing, so every probe below is either
-				// meaningless or actively errors (`git -C <gone> status` fails → fail-safe dirty,
-				// which would mis-KEEP it). Short-circuit to the safe-to-prune record: the classifier
-				// checks `prunable` first, so the other facts are never consulted for it (#3654).
-				if (p.prunable) {
+		// Sequential (concurrency 1) on purpose: the liveness probe now crosses the `FileSystem`
+		// seam, and the per-worktree git shell-outs must stay in the same order as before.
+		const records: ReadonlyArray<WorktreeRecord> = yield* Effect.forEach(
+			parsed.filter((p) => !p.bare),
+			(p) =>
+				Effect.gen(function* () {
+					// A gone-dir tree's working directory is missing, so every probe below is either
+					// meaningless or actively errors (`git -C <gone> status` fails → fail-safe dirty,
+					// which would mis-KEEP it). Short-circuit to the safe-to-prune record: the classifier
+					// checks `prunable` first, so the other facts are never consulted for it (#3654).
+					if (p.prunable) {
+						return {
+							path: p.path,
+							branch: p.branch,
+							prunable: true,
+							isDirty: false,
+							reachableFromOriginMain: false,
+							squashMergedToOriginMain: false,
+							locked: p.locked,
+							recentlyActive: false,
+							hasOpenPr: false,
+						};
+					}
+					const managed = isManagedWorktree(p.path);
+					// A review-head tree is a swept candidate too (#2785), so its liveness (idle mtime)
+					// must be probed. Its detached HEAD carries no branch, so the open-PR probe below
+					// (branch-keyed) is N/A for it — the dirty/locked/idle triple carries its liveness.
+					const swept = managed || isReviewHeadWorktree(p.path);
+					const isDirty = worktreeIsDirty(p.path);
+					const reachable = reachableFromOriginMain(p.head);
+					// Only probe the costlier squash signal when ancestry already missed.
+					const squashMerged = reachable ? false : squashMergedToOriginMain(p.head);
+					const recentlyActive = swept ? yield* worktreeRecentlyActive(p.path) : false;
+					// The network open-PR probe fires ONLY for a BUILD tree that would otherwise be swept —
+					// managed, clean, unlocked, idle, and content-merged — so SessionStart makes at most
+					// one gh call per reap candidate (usually zero), never one per worktree. A review-head
+					// tree never enters here (no branch, and its classifier branch precedes the open-PR gate).
+					const wouldRemove =
+						managed && !isDirty && !p.locked && !recentlyActive && (reachable || squashMerged);
+					const hasOpenPr = wouldRemove ? branchHasOpenPr(p.branch) : false;
 					return {
 						path: p.path,
 						branch: p.branch,
-						prunable: true,
-						isDirty: false,
-						reachableFromOriginMain: false,
-						squashMergedToOriginMain: false,
+						prunable: false,
+						isDirty,
+						reachableFromOriginMain: reachable,
+						squashMergedToOriginMain: squashMerged,
 						locked: p.locked,
-						recentlyActive: false,
-						hasOpenPr: false,
+						recentlyActive,
+						hasOpenPr,
 					};
-				}
-				const managed = isManagedWorktree(p.path);
-				// A review-head tree is a swept candidate too (#2785), so its liveness (idle mtime)
-				// must be probed. Its detached HEAD carries no branch, so the open-PR probe below
-				// (branch-keyed) is N/A for it — the dirty/locked/idle triple carries its liveness.
-				const swept = managed || isReviewHeadWorktree(p.path);
-				const isDirty = worktreeIsDirty(p.path);
-				const reachable = reachableFromOriginMain(p.head);
-				// Only probe the costlier squash signal when ancestry already missed.
-				const squashMerged = reachable ? false : squashMergedToOriginMain(p.head);
-				const recentlyActive = swept ? worktreeRecentlyActive(p.path) : false;
-				// The network open-PR probe fires ONLY for a BUILD tree that would otherwise be swept —
-				// managed, clean, unlocked, idle, and content-merged — so SessionStart makes at most
-				// one gh call per reap candidate (usually zero), never one per worktree. A review-head
-				// tree never enters here (no branch, and its classifier branch precedes the open-PR gate).
-				const wouldRemove =
-					managed && !isDirty && !p.locked && !recentlyActive && (reachable || squashMerged);
-				const hasOpenPr = wouldRemove ? branchHasOpenPr(p.branch) : false;
-				return {
-					path: p.path,
-					branch: p.branch,
-					prunable: false,
-					isDirty,
-					reachableFromOriginMain: reachable,
-					squashMergedToOriginMain: squashMerged,
-					locked: p.locked,
-					recentlyActive,
-					hasOpenPr,
-				};
-			});
+				}),
+			{concurrency: 1},
+		);
 
 		const plan = computeWorktreeSweepPlan(records);
 


### PR DESCRIPTION
## What

Migrates the raw `node:fs` / `node:path` **production** imports in the **control-plane / worktree / spawn-ops** cluster to the v4 Effect platform idiom (`.patterns/effect-platform-access.md`): file/dir/path IO now crosses `FileSystem.FileSystem` / `Path.Path` yielded from `effect`, discharged by the `NodeServices.layer` that `run.ts` **already** provides. No new layer wiring — this matches the already-merged `catalog-guard` shape and the #3470 / #3472 siblings.

Files (the disjoint m32 control-plane / worktree slice #3473 lists):

- `codeowners-cp/gate.ts` — the two source reads cross the seam, and `defaultRoot`'s marker walk becomes an `Effect.fn` probing via `fs.exists`/`path.*` (its in-tool caller `command.ts` threads the now-Effect root; `gate.test.ts` provides `NodeServices.layer`)
- `worktree-guard/command.ts` — the sidecar reads, the `pre-file` existence probe, the `reap` root exists/stat, and `probeTree`'s path resolution cross the seam
- `worktree-sweep/command.ts` — the mtime liveness probe + per-tree `HEAD` path joins cross the seam; record building becomes a sequential `Effect.forEach` (`concurrency: 1`) so the per-worktree probe order is unchanged
- `gh-phoenix/command.ts` — the lint-corpus reads cross the seam
- `cp-cardinality/command.ts`, `resume-policy/command.ts`, `spawn-guard/command.ts` — their only `node:fs` use is the **fd-0 stdin** read; see the bright line below

One non-obvious shape worth flagging for review: `worktree-guard`'s `pre-file` hands the **pure, IO-free** `resolvePath` core a *synchronous* existence predicate, which `fs.exists` (an Effect) cannot satisfy. Rather than make the pure core Effect-ful, `decideFilePath` **probes by capture** — run the core once with a predicate that records the path it asks about and answers `false`, touch the fs only if it *did* ask, and re-run with the answer. The core consults the predicate at most once (with the worktree copy of a main-checkout path), so the decision is exactly the former `existsSync` one.

## Bright lines preserved (per the pattern doc)

- `execFileSync` for `git`/`gh` stays a **raw subprocess boundary** (`worktree-guard`, `worktree-sweep`) — the platform services do not cover subprocesses.
- `createRequire`'s pre-runtime dep-resolution probe (`spawn-guard freshness`) stays raw.
- **fd-0 stdin stays raw `node:fs`** in `cp-cardinality` / `resume-policy` / `spawn-guard`: `FileSystem` is path-keyed with no stdin reader, and `Stdio.stdin` is a `Stream` that blocks on a TTY with no pipe (the exact hazard the sync fd-0 read exists to avoid). Each read site now states this, so it reads as the doc's node-only boundary case rather than a miss — the same call the #3472 sibling made for `class-probe`.
- Deliberate real-fs `*.test.ts` fixtures keep `node:fs`; `packages/pipeline-cli/src/bin.ts` is untouched.

## Behavior preserved

Behavior-preserving refactor (Containment: exempt per the issue). Identical exit codes / stdout / stderr / fail-closed semantics:

- Every best-effort probe keeps its **safe fallback** via `Effect.orElseSucceed` — `pre-file` allow, sidecar `null`/`""` (ownership unprovable ⇒ `decideReap` KEEPs), `probeTree` `unknown`, reap `skip`, sweep mtime "unresolvable ⇒ presumed active ⇒ KEEP", `gh-phoenix` unreadable file skipped (so it never enters scanned scope and zero-scope stays the only refusal), `defaultRoot` marker fault ⇒ false.
- The `worktree-guard` `existsSync`-then-read pairs fold into a single read: an absent file fails the read and degrades to the same value an absent file always produced.
- `codeowners-cp`'s `IoError` boundary is unchanged — a `PlatformError` folds into the same tagged error.
- The `worktree-guard` / `worktree-sweep` hook tests drive the **real bin over real worktrees** (the sweep test ages mtimes with `utimesSync` and asserts idle→removed vs active→kept), so the platform claim that `stat().mtime` carries the timestamp is verified against the actual platform, not asserted.

Verified locally from inside the worktree: `pnpm --filter @kampus/pipeline-cli typecheck` clean, `biome check` clean on every touched dir (only two pre-existing `useOptionalChain` warnings in untouched `gh-phoenix/router.ts`), and the touched tools' suites **21 files / 315 tests pass**. Full package run: **1954/1955**, the one failure being `pipeline-cli-shim.hook.test.ts` arm 1 timing out at its 5s budget under parallel load — it passes in isolation (6/6) and does not touch this diff.

## Acceptance criteria

- [x] Every raw `node:fs` / `node:path` **production** import in the slice replaced by `FileSystem` / `Path` from `effect`, discharged by `run.ts`'s existing `NodeServices.layer` (no new wiring).
- [x] The **v4** idiom (`FileSystem` / `Path` from `effect` + `@effect/platform-node` `NodeServices.layer`), not the v3 `@effect/platform` / `NodeContext` API.
- [x] Bright-line raw `node:*` boundaries preserved (`execFileSync`, `createRequire`, fd-0 stdin, real-fs test code); `bin.ts` untouched.
- [x] Observable behavior unchanged — identical exit codes / stdout / stderr / fail-closed semantics; typecheck + the tools' unit and integration tests green.
- [x] **§CP:** touches `packages/pipeline-cli/` → banks for a human merge by **@kamp-us/control-plane**, does **not** auto-ship.

Fixes #3473
