### PR TITLE
feat(pipeline-cli): guards emit ::error inline annotations on fail paths (#3868)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -49,6 +49,20 @@ tool registry, so it never drifts.
 For a fuller per-tool reference — what each tool does and the flags it takes — see
 [TOOLS.md](./TOOLS.md).
 
+## How a guard fails
+
+Every guard's `check` routes its `CheckFailed` through the shared handler in
+[`src/gate-fail.ts`](./src/gate-fail.ts): the human report goes to stderr, the process
+exits 1, and — only when `GITHUB_ACTIONS` is set — GitHub `::error` workflow commands go
+to stdout so the failure renders as an inline PR annotation instead of a log dig. Local
+runs are byte-identical to before.
+
+A guard that knows where its failure lives attaches `annotations` to its `CheckFailed`
+(see `catalog-guard` and `readme-guard`, which point at the offending manifest and line);
+one that doesn't gets a single bare `::error` carrying the report head. Build annotations
+with the constructors in [`src/annotate.ts`](./src/annotate.ts) — `unlocated`, `atFile`,
+`atLine` — never by hand-formatting the command string.
+
 ## Development
 
 The source lives in the phoenix monorepo under

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -61,7 +61,8 @@ A guard that knows where its failure lives attaches `annotations` to its `CheckF
 (see `catalog-guard` and `readme-guard`, which point at the offending manifest and line);
 one that doesn't gets a single bare `::error` carrying the report head. Build annotations
 with the constructors in [`src/annotate.ts`](./src/annotate.ts) — `unlocated`, `atFile`,
-`atLine` — never by hand-formatting the command string.
+`atLine` — never by hand-formatting the command string, and wrap the build in
+`annotationsOrNone` so a throw while computing them can never swallow the report.
 
 ## Development
 

--- a/packages/pipeline-cli/src/annotate.ts
+++ b/packages/pipeline-cli/src/annotate.ts
@@ -1,0 +1,112 @@
+/**
+ * GitHub workflow-command annotations — the pure core behind "a red guard lands on the
+ * PR diff, not in a log dig" (#3868).
+ *
+ * GitHub renders an inline PR annotation for any step that writes a workflow command on
+ * stdout (`::error file=<path>,line=<n>::<message>`). This module is the one place that
+ * knows that syntax: the location model, the escaping, and the "only under Actions"
+ * predicate. `gate-fail.ts` is the thin Effect side that writes what this renders.
+ *
+ * A location is a closed union rather than optional `file`/`line` fields, so the state
+ * GitHub silently drops — a `line=` with no `file=` — cannot be constructed.
+ */
+import * as Schema from "effect/Schema";
+
+export const AnnotationLevel = Schema.Literals(["error", "warning", "notice"]);
+export type AnnotationLevel = typeof AnnotationLevel.Type;
+
+/** Where a finding sits: nowhere in particular, a whole file, or one line of it. */
+export const AnnotationLocation = Schema.Union([
+	Schema.Struct({_tag: Schema.Literal("Unlocated")}),
+	Schema.Struct({_tag: Schema.Literal("File"), file: Schema.String}),
+	Schema.Struct({_tag: Schema.Literal("Line"), file: Schema.String, line: Schema.Int}),
+]);
+export type AnnotationLocation = typeof AnnotationLocation.Type;
+
+export const Annotation = Schema.Struct({
+	level: AnnotationLevel,
+	message: Schema.String,
+	location: AnnotationLocation,
+});
+export type Annotation = typeof Annotation.Type;
+
+export const unlocated = (level: AnnotationLevel, message: string): Annotation => ({
+	level,
+	message,
+	location: {_tag: "Unlocated"},
+});
+
+export const atFile = (level: AnnotationLevel, file: string, message: string): Annotation => ({
+	level,
+	message,
+	location: {_tag: "File", file},
+});
+
+export const atLine = (
+	level: AnnotationLevel,
+	file: string,
+	line: number,
+	message: string,
+): Annotation => ({level, message, location: {_tag: "Line", file, line}});
+
+// A newline would terminate the command early and a `%` would be read as the start of an
+// existing escape, so `%` goes first. This is the toolkit's `toCommandValue` encoding.
+const escapeData = (value: string): string =>
+	value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+
+// Property values live in the comma-separated `k=v,k=v` head, where `,` ends the property
+// and `:` ends the head — both need escaping on top of the data escapes above.
+const escapeProperty = (value: string): string =>
+	escapeData(value).replace(/:/g, "%3A").replace(/,/g, "%2C");
+
+const properties = (location: AnnotationLocation): string => {
+	switch (location._tag) {
+		case "Unlocated":
+			return "";
+		case "File":
+			return ` file=${escapeProperty(location.file)}`;
+		case "Line":
+			return ` file=${escapeProperty(location.file)},line=${location.line}`;
+	}
+};
+
+/** Render one annotation as the workflow command GitHub parses off stdout. */
+export const formatWorkflowCommand = (annotation: Annotation): string =>
+	`::${annotation.level}${properties(annotation.location)}::${escapeData(annotation.message)}`;
+
+/**
+ * Annotations are a CI-only output: locally they would be noise a human has to read past,
+ * and nothing outside Actions parses them. GitHub sets `GITHUB_ACTIONS=true` on every
+ * runner, so an explicit `false` (the documented way to signal "not a real runner") turns
+ * them back off.
+ */
+export const annotationsEnabled = (env: Readonly<Record<string, string | undefined>>): boolean => {
+	const flag = env.GITHUB_ACTIONS;
+	return flag !== undefined && flag !== "" && flag !== "false";
+};
+
+/**
+ * The lines to write on a fail path: the workflow commands under Actions, nothing at all
+ * anywhere else. Callers write these to stdout verbatim.
+ */
+export const renderAnnotations = (
+	annotations: ReadonlyArray<Annotation>,
+	env: Readonly<Record<string, string | undefined>>,
+): ReadonlyArray<string> => (annotationsEnabled(env) ? annotations.map(formatWorkflowCommand) : []);
+
+/** Bound how much of a multi-line guard report rides in a single fallback annotation. */
+const FALLBACK_MESSAGE_LINES = 8;
+
+/**
+ * The annotations for a gate failure that supplied none of its own. Every guard's report
+ * is human-prose on stderr; a guard that cannot name a file still gets one bare `::error`
+ * so the failure shows up in the checks summary instead of only in the log (#3868).
+ */
+export const gateFailureAnnotations = (
+	reason: string,
+	annotations: ReadonlyArray<Annotation> = [],
+): ReadonlyArray<Annotation> => {
+	if (annotations.length > 0) return annotations;
+	const head = reason.trim().split("\n").slice(0, FALLBACK_MESSAGE_LINES).join("\n");
+	return head === "" ? [] : [unlocated("error", head)];
+};

--- a/packages/pipeline-cli/src/annotate.unit.test.ts
+++ b/packages/pipeline-cli/src/annotate.unit.test.ts
@@ -1,0 +1,93 @@
+import {describe, expect, it} from "vitest";
+import {
+	annotationsEnabled,
+	atFile,
+	atLine,
+	formatWorkflowCommand,
+	gateFailureAnnotations,
+	renderAnnotations,
+	unlocated,
+} from "./annotate.ts";
+
+describe("formatWorkflowCommand", () => {
+	it("renders an unlocated error as a bare workflow command", () => {
+		expect(formatWorkflowCommand(unlocated("error", "guard failed"))).toBe("::error::guard failed");
+	});
+
+	it("renders a file location", () => {
+		expect(formatWorkflowCommand(atFile("error", "packages/x/package.json", "hardcoded"))).toBe(
+			"::error file=packages/x/package.json::hardcoded",
+		);
+	});
+
+	it("renders a file+line location", () => {
+		expect(formatWorkflowCommand(atLine("warning", "a/b.ts", 12, "stale"))).toBe(
+			"::warning file=a/b.ts,line=12::stale",
+		);
+	});
+
+	it("escapes the message so a newline cannot terminate the command early", () => {
+		expect(formatWorkflowCommand(unlocated("error", "one\ntwo\r\n100% off"))).toBe(
+			"::error::one%0Atwo%0D%0A100%25 off",
+		);
+	});
+
+	it("escapes `,` and `:` in a property value, which would otherwise end the property", () => {
+		expect(formatWorkflowCommand(atFile("error", "a,b:c.ts", "x"))).toBe(
+			"::error file=a%2Cb%3Ac.ts::x",
+		);
+	});
+});
+
+describe("annotationsEnabled", () => {
+	it("is on under a GitHub Actions runner", () => {
+		expect(annotationsEnabled({GITHUB_ACTIONS: "true"})).toBe(true);
+	});
+
+	it("is off locally", () => {
+		expect(annotationsEnabled({})).toBe(false);
+		expect(annotationsEnabled({GITHUB_ACTIONS: ""})).toBe(false);
+	});
+
+	it("is off when explicitly disabled", () => {
+		expect(annotationsEnabled({GITHUB_ACTIONS: "false"})).toBe(false);
+	});
+});
+
+describe("renderAnnotations", () => {
+	const annotations = [unlocated("error", "boom"), atFile("error", "a.ts", "bad")];
+
+	it("emits one command per annotation under Actions", () => {
+		expect(renderAnnotations(annotations, {GITHUB_ACTIONS: "true"})).toEqual([
+			"::error::boom",
+			"::error file=a.ts::bad",
+		]);
+	});
+
+	it("emits nothing outside Actions, so local output is unchanged", () => {
+		expect(renderAnnotations(annotations, {})).toEqual([]);
+	});
+});
+
+describe("gateFailureAnnotations", () => {
+	it("keeps a guard's own located annotations", () => {
+		const own = [atLine("error", "a.ts", 3, "bad")];
+		expect(gateFailureAnnotations("report text", own)).toEqual(own);
+	});
+
+	it("falls back to one bare error carrying the report head", () => {
+		expect(gateFailureAnnotations("catalog-guard: 2 deps pin hardcoded versions")).toEqual([
+			unlocated("error", "catalog-guard: 2 deps pin hardcoded versions"),
+		]);
+	});
+
+	it("truncates a long report so one annotation cannot swallow the whole log", () => {
+		const reason = Array.from({length: 20}, (_, i) => `line ${i}`).join("\n");
+		const [annotation] = gateFailureAnnotations(reason);
+		expect(annotation?.message.split("\n")).toHaveLength(8);
+	});
+
+	it("emits nothing for an empty reason rather than a blank annotation", () => {
+		expect(gateFailureAnnotations("   \n  ")).toEqual([]);
+	});
+});

--- a/packages/pipeline-cli/src/gate-fail.ts
+++ b/packages/pipeline-cli/src/gate-fail.ts
@@ -32,14 +32,38 @@ export interface GateFailure {
 export const reportGateFailure = (failure: GateFailure): Effect.Effect<void> =>
 	Effect.sync(() => {
 		process.stderr.write(`${failure.reason}\n`);
-		for (const line of renderAnnotations(
-			gateFailureAnnotations(failure.reason, failure.annotations ?? []),
-			process.env,
-		)) {
-			process.stdout.write(`${line}\n`);
-		}
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
+	}).pipe(
+		// The report is the load-bearing output and is already out by here; annotations only
+		// decorate it, so a failure to render degrades to "no annotations" rather than taking
+		// the report with it (the same invariant `annotationsOrNone` holds on the build side).
+		Effect.andThen(
+			Effect.try(() => {
+				for (const line of renderAnnotations(
+					gateFailureAnnotations(failure.reason, failure.annotations ?? []),
+					process.env,
+				)) {
+					process.stdout.write(`${line}\n`);
+				}
+			}).pipe(Effect.ignore),
+		),
+		Effect.andThen(
+			Effect.sync(() => {
+				process.exit(GATE_FAIL_EXIT_CODE);
+			}),
+		),
+	);
+
+/**
+ * Build a guard's annotations, degrading to none if the build throws. A guard's
+ * `CheckFailed({reason, annotations})` evaluates its `annotations` argument EAGERLY, so an
+ * unguarded throw while computing them lands *before* the error carrying the report is
+ * constructed — the whole human diagnostic dies exactly when the guard goes red. Every
+ * guard that computes annotations builds them through this.
+ */
+export const annotationsOrNone = (
+	build: () => ReadonlyArray<Annotation>,
+): Effect.Effect<ReadonlyArray<Annotation>> =>
+	Effect.try(build).pipe(Effect.orElseSucceed((): ReadonlyArray<Annotation> => []));
 
 /** The `Effect.catchTag("CheckFailed", …)` handler each guard command wires in. */
 export const onCheckFailed = (e: GateFailure): Effect.Effect<void> => reportGateFailure(e);

--- a/packages/pipeline-cli/src/gate-fail.ts
+++ b/packages/pipeline-cli/src/gate-fail.ts
@@ -1,0 +1,51 @@
+/**
+ * The shared guard fail path — one handler every `pipeline-cli <guard> check` routes its
+ * `CheckFailed` through.
+ *
+ * It does what each guard's own copy did (report on stderr, exit non-zero) and adds the
+ * one thing they all lacked: GitHub `::error` workflow commands on stdout, so a red guard
+ * lands as an inline PR annotation instead of a log dig (#3868). Rendering and the
+ * under-Actions gate live in `annotate.ts`; this file is the IO.
+ *
+ * The exit code is unchanged — red stays red, green stays green.
+ */
+import {Effect} from "effect";
+import {type Annotation, gateFailureAnnotations, renderAnnotations} from "./annotate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+
+/**
+ * The `CheckFailed` shape every guard already carries. `annotations` is the optional
+ * enrichment a guard adds when it knows where the failure lives; omitting it yields one
+ * bare `::error` carrying the report head.
+ */
+export interface GateFailure {
+	readonly reason: string;
+	readonly annotations?: ReadonlyArray<Annotation> | undefined;
+}
+
+/**
+ * Report a gate failure and exit non-zero. Annotations go to **stdout** (where GitHub
+ * parses workflow commands) and the human report stays on **stderr**, so neither stream
+ * changes shape for the other's reader.
+ */
+export const reportGateFailure = (failure: GateFailure): Effect.Effect<void> =>
+	Effect.sync(() => {
+		process.stderr.write(`${failure.reason}\n`);
+		for (const line of renderAnnotations(
+			gateFailureAnnotations(failure.reason, failure.annotations ?? []),
+			process.env,
+		)) {
+			process.stdout.write(`${line}\n`);
+		}
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+/** The `Effect.catchTag("CheckFailed", …)` handler each guard command wires in. */
+export const onCheckFailed = (e: GateFailure): Effect.Effect<void> => reportGateFailure(e);
+
+/** As `onCheckFailed`, for a guard whose report is printed under a tool-name prefix. */
+export const onCheckFailedWithPrefix =
+	(prefix: string) =>
+	(e: GateFailure): Effect.Effect<void> =>
+		reportGateFailure({reason: `${prefix}${e.reason}`, annotations: e.annotations});

--- a/packages/pipeline-cli/src/gate-fail.unit.test.ts
+++ b/packages/pipeline-cli/src/gate-fail.unit.test.ts
@@ -1,0 +1,28 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {atLine, gateFailureAnnotations, unlocated} from "./annotate.ts";
+import {annotationsOrNone} from "./gate-fail.ts";
+
+const run = <A>(effect: Effect.Effect<A>): Promise<A> => Effect.runPromise(effect);
+
+describe("annotationsOrNone", () => {
+	it("passes a successful build through untouched", async () => {
+		const built = [atLine("error", "a.ts", 3, "bad")];
+		expect(await run(annotationsOrNone(() => built))).toEqual(built);
+	});
+
+	// The build runs EAGERLY as the `annotations` argument of a guard's CheckFailed, so an
+	// unguarded throw kills the report before the error carrying it exists.
+	it("degrades a throwing build to no annotations, so the report survives", async () => {
+		const annotations = await run(
+			annotationsOrNone(() => {
+				throw new SyntaxError("Invalid regular expression");
+			}),
+		);
+		expect(annotations).toEqual([]);
+		// and the shared handler then still annotates the failure off the report itself
+		expect(
+			gateFailureAnnotations("catalog-guard: 1 dependency pins a hardcoded version", annotations),
+		).toEqual([unlocated("error", "catalog-guard: 1 dependency pins a hardcoded version")]);
+	});
+});

--- a/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.ts
@@ -154,13 +154,48 @@ export const findDepLine = (text: string, field: string, name: string): number |
 	let inField = false;
 	for (const [i, line] of lines.entries()) {
 		if (!inField) {
-			if (new RegExp(`^\\s*"${field}"\\s*:\\s*\\{`).test(line)) inField = true;
+			const rest = afterFieldOpen(line, field);
+			if (rest === null) continue;
+			inField = true;
+			// A compact `"dependencies": {"x": "1"},` declares its deps on the SAME line as
+			// the field; without this the scan walks past them into the next field's block.
+			const same = scanInlineKeys(rest, name);
+			if (same !== "open") return same === "found" ? i + 1 : null;
 			continue;
 		}
 		if (/^\s*\}/.test(line)) return null;
-		if (new RegExp(`^\\s*"${name}"\\s*:`).test(line)) return i + 1;
+		if (declaresKey(line, name)) return i + 1;
 	}
 	return null;
+};
+
+/**
+ * Does `segment` open with the JSON key `"<name>":`? Compared literally, never compiled
+ * into a `RegExp` — a name is arbitrary manifest input, and `.` (legal in npm names, e.g.
+ * `@distilled.cloud/cloudflare`) would silently match a neighbour while a regex
+ * metacharacter would throw a `SyntaxError` out of the annotation build.
+ */
+const declaresKey = (segment: string, name: string): boolean => {
+	const quoted = `"${name}"`;
+	const trimmed = segment.trimStart();
+	return trimmed.startsWith(quoted) && /^\s*:/.test(trimmed.slice(quoted.length));
+};
+
+/** The rest of `line` after `"<field>": {`, or `null` when the line doesn't open that field. */
+const afterFieldOpen = (line: string, field: string): string | null => {
+	const quoted = `"${field}"`;
+	const trimmed = line.trimStart();
+	if (!trimmed.startsWith(quoted)) return null;
+	const open = /^\s*:\s*\{/.exec(trimmed.slice(quoted.length));
+	return open === null ? null : trimmed.slice(quoted.length + open[0].length);
+};
+
+/** Whether the keys on the remainder of a field-opening line hold `name`, or close the block. */
+const scanInlineKeys = (rest: string, name: string): "found" | "closed" | "open" => {
+	const close = rest.indexOf("}");
+	const inside = close === -1 ? rest : rest.slice(0, close);
+	if (inside.split(",").some((part) => declaresKey(part, name))) return "found";
+	return close === -1 ? "open" : "closed";
 };
 
 /**

--- a/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.ts
@@ -17,6 +17,7 @@
  * misconfiguration (wrong root, a workspace reshape), NOT a silent pass — the
  * verdict is a failure, never a vacuous green.
  */
+import {type Annotation, atFile, atLine, unlocated} from "../../annotate.ts";
 
 /** One dependency entry from a manifest, reduced to the facts the decision needs. */
 export interface DepEntry {
@@ -140,6 +141,46 @@ export const renderReport = (verdict: CatalogGuardVerdict): string => {
 		`catalog-guard: ${verdict.violations.length} dependenc${verdict.violations.length === 1 ? "y" : "ies"} ` +
 		`pin a hardcoded version instead of catalog: (of ${verdict.scanned.length} manifests scanned):\n${lines.join("\n")}`
 	);
+};
+
+/**
+ * The 1-based line of `"<name>"` inside the `"<field>"` block of a `package.json`'s
+ * text, or `null` when it isn't there. Pure over the raw text because the parsed
+ * manifest has no positions, and a line is what puts a CI annotation on the offending
+ * diff line rather than at the top of the file (#3868).
+ */
+export const findDepLine = (text: string, field: string, name: string): number | null => {
+	const lines = text.split("\n");
+	let inField = false;
+	for (const [i, line] of lines.entries()) {
+		if (!inField) {
+			if (new RegExp(`^\\s*"${field}"\\s*:\\s*\\{`).test(line)) inField = true;
+			continue;
+		}
+		if (/^\s*\}/.test(line)) return null;
+		if (new RegExp(`^\\s*"${name}"\\s*:`).test(line)) return i + 1;
+	}
+	return null;
+};
+
+/**
+ * The CI annotations for a verdict — one per violation, on the manifest line that pins
+ * the version when `lineOf` can find it. A zero-scope failure has no file to point at,
+ * so it annotates bare.
+ */
+export const verdictAnnotations = (
+	verdict: CatalogGuardVerdict,
+	lineOf: (violation: CatalogViolation) => number | null = () => null,
+): ReadonlyArray<Annotation> => {
+	if (verdict.pass) return [];
+	if (verdict.reason === "zero-scope") return [unlocated("error", renderReport(verdict))];
+	return verdict.violations.map((v) => {
+		const message = `${v.field} \`${v.name}\` pins \`${v.value}\` instead of \`catalog:\` — a second version of a dep breaks frozen-lockfile CI (#535).`;
+		const line = lineOf(v);
+		return line === null
+			? atFile("error", v.path, message)
+			: atLine("error", v.path, line, message);
+	});
 };
 
 /**

--- a/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.unit.test.ts
@@ -7,10 +7,12 @@
 import {describe, expect, it} from "@effect/vitest";
 import {
 	type AllowlistEntry,
+	findDepLine,
 	judge,
 	manifestDeps,
 	type PackageManifest,
 	parseWorkspacePackageGlobs,
+	verdictAnnotations,
 } from "./catalog-guard.ts";
 
 const manifest = (path: string, deps: PackageManifest["deps"]): PackageManifest => ({path, deps});
@@ -115,5 +117,55 @@ describe("parseWorkspacePackageGlobs", () => {
 			"packages:\n  - packages/*\n  - apps/*\n  - infra/*\n\ncatalog:\n  react: 19.0.0\n",
 		);
 		expect(globs).toEqual(["packages/*", "apps/*", "infra/*"]);
+	});
+});
+
+describe("findDepLine", () => {
+	const text = [
+		"{",
+		'\t"name": "x",',
+		'\t"dependencies": {',
+		'\t\t"a": "catalog:",',
+		'\t\t"b": "^1.0.0"',
+		"\t}",
+		"}",
+	].join("\n");
+
+	it("finds the 1-based line of a dep inside its field block", () => {
+		expect(findDepLine(text, "dependencies", "b")).toBe(5);
+	});
+
+	it("returns null for a dep that is not in that field block", () => {
+		expect(findDepLine(text, "devDependencies", "b")).toBeNull();
+		expect(findDepLine(text, "dependencies", "name")).toBeNull();
+	});
+});
+
+describe("verdictAnnotations", () => {
+	const violating = [
+		manifest("packages/a/package.json", [{field: "dependencies", name: "foo", value: "^1.0.0"}]),
+	];
+
+	it("annotates a pass with nothing", () => {
+		expect(verdictAnnotations(judge([manifest("package.json", [])]))).toEqual([]);
+	});
+
+	it("annotates zero-scope bare — there is no file to point at", () => {
+		expect(verdictAnnotations(judge([]))[0]?.location).toEqual({_tag: "Unlocated"});
+	});
+
+	it("annotates a violation on the manifest line when the resolver finds one", () => {
+		expect(verdictAnnotations(judge(violating), () => 7)[0]?.location).toEqual({
+			_tag: "Line",
+			file: "packages/a/package.json",
+			line: 7,
+		});
+	});
+
+	it("falls back to a file-level annotation when the line is unknown", () => {
+		expect(verdictAnnotations(judge(violating))[0]?.location).toEqual({
+			_tag: "File",
+			file: "packages/a/package.json",
+		});
 	});
 });

--- a/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/catalog-guard.unit.test.ts
@@ -139,6 +139,52 @@ describe("findDepLine", () => {
 		expect(findDepLine(text, "devDependencies", "b")).toBeNull();
 		expect(findDepLine(text, "dependencies", "name")).toBeNull();
 	});
+
+	// `.` is legal in an npm name (this repo has `@distilled.cloud/cloudflare`), so an
+	// unescaped name compiled into a RegExp matched a neighbour one line up.
+	it("does not let a `.` in a dep name match a neighbouring dep", () => {
+		const dotted = [
+			"{",
+			'\t"dependencies": {',
+			'\t\t"aXb/pkg": "catalog:",',
+			'\t\t"a.b/pkg": "^1.0.0"',
+			"\t}",
+			"}",
+		].join("\n");
+		expect(findDepLine(dotted, "dependencies", "a.b/pkg")).toBe(4);
+	});
+
+	// A regex-metacharacter key used to throw a SyntaxError out of the annotation build,
+	// which took the whole guard report with it.
+	it("does not throw on a dep name carrying a regex metacharacter", () => {
+		const weird = ["{", '\t"dependencies": {', '\t\t"a(b": "^1.0.0"', "\t}", "}"].join("\n");
+		expect(() => findDepLine(weird, "dependencies", "a(b")).not.toThrow();
+		expect(findDepLine(weird, "dependencies", "a(b")).toBe(3);
+		expect(() => findDepLine(weird, "dependencies*", "zzz")).not.toThrow();
+	});
+
+	it("finds a dep declared on the same line as its field", () => {
+		const compact = [
+			"{",
+			'\t"dependencies": {"x": "1"},',
+			'\t"devDependencies": {',
+			'\t\t"x": "2"',
+			"\t}",
+			"}",
+		].join("\n");
+		expect(findDepLine(compact, "dependencies", "x")).toBe(2);
+		expect(findDepLine(compact, "devDependencies", "x")).toBe(4);
+	});
+
+	it("returns null when a compact field block closes without the dep", () => {
+		const compact = [
+			"{",
+			'\t"dependencies": {"y": "1"},',
+			'\t"devDependencies": {"x": "2"}',
+			"}",
+		].join("\n");
+		expect(findDepLine(compact, "dependencies", "x")).toBeNull();
+	});
 });
 
 describe("verdictAnnotations", () => {

--- a/packages/pipeline-cli/src/tools/catalog-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/command.ts
@@ -29,9 +29,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkCatalog} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkCatalog} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -68,15 +68,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
@@ -14,14 +14,17 @@
  */
 import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
+import {Annotation} from "../../annotate.ts";
 import {
 	type AllowlistEntry,
 	DEFAULT_ALLOWLIST,
+	findDepLine,
 	judge,
 	manifestDeps,
 	type PackageManifest,
 	parseWorkspacePackageGlobs,
 	renderReport,
+	verdictAnnotations,
 } from "./catalog-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
@@ -30,9 +33,10 @@ export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
 	cause: Schema.Unknown,
 }) {}
 
-/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+// See the `annotations` note on readme-guard's CheckFailed (#3868).
 export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
 	reason: Schema.String,
+	annotations: Schema.optionalKey(Schema.Array(Annotation)),
 }) {}
 
 /**
@@ -74,11 +78,19 @@ const enumerateManifestPaths = (
 		return [...paths].sort();
 	}).pipe(Effect.mapError((cause) => new IoError({path: root, cause})));
 
-/** Read + parse each manifest path into the pure core's `PackageManifest` shape. */
+/**
+ * Read + parse each manifest path into the pure core's `PackageManifest` shape. The raw
+ * text rides along because the parsed manifest carries no positions, and the CI
+ * annotation wants the line the offending dep sits on (#3868).
+ */
 const readManifests = (
 	root: string,
 	paths: ReadonlyArray<string>,
-): Effect.Effect<ReadonlyArray<PackageManifest>, IoError, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<
+	ReadonlyArray<{readonly manifest: PackageManifest; readonly text: string}>,
+	IoError,
+	FileSystem.FileSystem | Path.Path
+> =>
 	Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
 		const path = yield* Path.Path;
@@ -90,9 +102,12 @@ const readManifests = (
 					Effect.mapError((cause) => new IoError({path: abs, cause})),
 					Effect.flatMap((text) =>
 						Effect.try({
-							try: (): PackageManifest => ({
-								path: rel,
-								deps: manifestDeps(JSON.parse(text) as Record<string, unknown>),
+							try: () => ({
+								manifest: {
+									path: rel,
+									deps: manifestDeps(JSON.parse(text) as Record<string, unknown>),
+								},
+								text,
 							}),
 							catch: (cause) => new IoError({path: abs, cause}),
 						}),
@@ -131,11 +146,23 @@ export const checkCatalog = (
 	Effect.gen(function* () {
 		const globs = yield* readWorkspaceGlobs(root);
 		const paths = yield* enumerateManifestPaths(root, globs);
-		const manifests = yield* readManifests(root, paths);
-		const verdict = judge(manifests, allowlist);
+		const read = yield* readManifests(root, paths);
+		const verdict = judge(
+			read.map((r) => r.manifest),
+			allowlist,
+		);
 		if (verdict.pass) {
 			yield* Console.log(renderReport(verdict));
 			return;
 		}
-		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+		const texts = new Map(read.map((r) => [r.manifest.path, r.text]));
+		return yield* Effect.fail(
+			new CheckFailed({
+				reason: renderReport(verdict),
+				annotations: verdictAnnotations(verdict, (v) => {
+					const text = texts.get(v.path);
+					return text === undefined ? null : findDepLine(text, v.field, v.name);
+				}),
+			}),
+		);
 	});

--- a/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
@@ -15,6 +15,7 @@
 import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {Annotation} from "../../annotate.ts";
+import {annotationsOrNone} from "../../gate-fail.ts";
 import {
 	type AllowlistEntry,
 	DEFAULT_ALLOWLIST,
@@ -156,13 +157,11 @@ export const checkCatalog = (
 			return;
 		}
 		const texts = new Map(read.map((r) => [r.manifest.path, r.text]));
-		return yield* Effect.fail(
-			new CheckFailed({
-				reason: renderReport(verdict),
-				annotations: verdictAnnotations(verdict, (v) => {
-					const text = texts.get(v.path);
-					return text === undefined ? null : findDepLine(text, v.field, v.name);
-				}),
+		const annotations = yield* annotationsOrNone(() =>
+			verdictAnnotations(verdict, (v) => {
+				const text = texts.get(v.path);
+				return text === undefined ? null : findDepLine(text, v.field, v.name);
 			}),
 		);
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict), annotations}));
 	});

--- a/packages/pipeline-cli/src/tools/change-detect-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/command.ts
@@ -25,9 +25,9 @@ import {dirname, join, resolve} from "node:path";
 import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
-import {type CheckFailed, checkChangeDetect} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkChangeDetect} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
 const defaultRoot = (from: string = process.cwd()): string => {
@@ -47,15 +47,6 @@ const rootFlag = Flag.string("root").pipe(
 
 const resolveRoot = (root: Option.Option<string>): string =>
 	Option.getOrElse(root, () => defaultRoot());
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
-// error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/codeowners-cp/command.prefix.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/command.prefix.test.ts
@@ -1,0 +1,41 @@
+import {spawnSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
+import {CODEOWNERS_PATH, FORMATS_PATH} from "./gate.ts";
+
+// The `codeowners-cp: ` stderr prefix is applied by the COMMAND wiring, not the gate, so it is
+// only observable over the real bin — a unit test of the gate reason cannot see it. It was
+// silently dropped when the guard moved to the shared fail handler (#3868 review).
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+const makeZeroOwnerRepo = (): string => {
+	const dir = mkdtempSync(join(tmpdir(), "codeowners-cp-prefix-"));
+	const write = (rel: string, content: string) => {
+		const p = join(dir, rel);
+		mkdirSync(join(p, ".."), {recursive: true});
+		writeFileSync(p, content, "utf8");
+	};
+	write(FORMATS_PATH, `CONTROL_PLANE_RE='${CONTROL_PLANE_RE}'`);
+	write(CODEOWNERS_PATH, "# only comments\n");
+	return dir;
+};
+
+describe("codeowners-cp check — the report keeps its tool-name prefix", () => {
+	it("prefixes the stderr report with `codeowners-cp: ` and still exits 1", () => {
+		const dir = makeZeroOwnerRepo();
+		try {
+			const r = spawnSync("node", [BIN, "codeowners-cp", "check", "--root", dir], {
+				encoding: "utf8",
+			});
+			expect(r.stderr).toContain("codeowners-cp: ");
+			expect(r.stderr).toContain("ZERO owned entries");
+			expect(r.status).toBe(1);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
@@ -19,9 +19,8 @@
  */
 import {Effect, type FileSystem, Option, type Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkCodeownersCp, defaultRoot} from "./gate.ts";
-
-const GATE_FAIL_EXIT_CODE = 1;
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkCodeownersCp, defaultRoot} from "./gate.ts";
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -34,12 +33,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`codeowners-cp: ${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
@@ -19,8 +19,10 @@
  */
 import {Effect, type FileSystem, Option, type Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {onCheckFailed} from "../../gate-fail.ts";
+import {onCheckFailedWithPrefix} from "../../gate-fail.ts";
 import {checkCodeownersCp, defaultRoot} from "./gate.ts";
+
+const onCheckFailed = onCheckFailedWithPrefix("codeowners-cp: ");
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/command.ts
@@ -27,9 +27,9 @@ import {dirname, join, resolve} from "node:path";
 import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
-import {type CheckFailed, checkCrewFanout} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkCrewFanout} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -52,15 +52,6 @@ const rootFlag = Flag.string("root").pipe(
 
 const resolveRoot = (root: Option.Option<string>): string =>
 	Option.getOrElse(root, () => defaultRoot());
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
-// error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/decisions-index/command.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/command.ts
@@ -34,10 +34,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import type {CheckFailed} from "./gate.ts";
+import {onCheckFailedWithPrefix} from "../../gate-fail.ts";
 import {checkIndex, compactIndex, generateIndex, nextIndex, validateAdrs} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 const DECISIONS_DIR = ".decisions";
 // Repo-root markers, in priority order. `.decisions` itself is the strongest
 // signal (the dir we'll read); a workspace/VCS marker is the fallback.
@@ -89,16 +88,7 @@ const resolveDir = (
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(dir, {onNone: () => defaultDecisionsDir(), onSome: Effect.succeed});
 
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-// Caught per-handler (not at the bin's run boundary) so the contract survives the
-// fold into the shared `pipeline-cli` bin, which provides no per-tool catch.
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`decisions-index: ${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
+const onCheckFailed = onCheckFailedWithPrefix("decisions-index: ");
 
 const compact = Command.make(
 	"compact",

--- a/packages/pipeline-cli/src/tools/design-inventory/command.ts
+++ b/packages/pipeline-cli/src/tools/design-inventory/command.ts
@@ -28,9 +28,9 @@ import {dirname, join, resolve} from "node:path";
 import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
-import {type CheckFailed, generateInventory} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {generateInventory} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
 const defaultRoot = (from: string = process.cwd()): string => {
@@ -60,15 +60,6 @@ const checkFlag = Flag.boolean("check").pipe(
 
 const resolveRoot = (root: Option.Option<string>): string =>
 	Option.getOrElse(root, () => defaultRoot());
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, FirewallViolation) still get
-// the default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const generate = Command.make(
 	"generate",

--- a/packages/pipeline-cli/src/tools/design-token-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/command.ts
@@ -27,9 +27,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkDesignTokens, writeBaseline} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkDesignTokens, writeBaseline} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -66,15 +66,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
-// error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/fanout-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/command.ts
@@ -27,9 +27,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkFanout} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkFanout} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
 // Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
@@ -61,15 +61,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
-// error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -28,7 +28,8 @@ import {readFileSync} from "node:fs";
 import {Console, Effect, FileSystem, Option, Path, type PlatformError} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, CREW_DIR, sweepCrew} from "./crew-gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {CREW_DIR, sweepCrew} from "./crew-gate.ts";
 import {PrComments, PrCommentsLive, type UpstreamUnavailableError} from "./github.ts";
 import {findCommentLeaks, findLeaks, type Leak} from "./leak-guard.ts";
 import {scanPrComments} from "./scan-pr.ts";
@@ -111,12 +112,6 @@ const scan = Command.make(
 	}),
 ).pipe(Command.withDescription("Scan files for user-local paths leaking into shared doc surfaces"));
 
-// The repeatable pipeline-crew sanitization sweep (#2357). Where `scan` takes explicit
-// changed files and checks only the no-local-paths rule on doc surfaces, `sweep` walks
-// a whole directory and checks EVERY personal-data class the crew's "zero real operator
-// data" contract bans — fail-closed on any hit and on a zero-file scope (ADR 0092),
-// mirroring the readme-guard/fanout-guard directory-check idiom.
-const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
 // Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
@@ -148,15 +143,6 @@ const dirFlag = Flag.string("dir").pipe(
 	Flag.optional,
 	Flag.withDescription(`the crew directory to sweep, root-relative (default: ${CREW_DIR})`),
 );
-
-// CheckFailed carries the expected gate-fail signal — its report is already built; print
-// it on stderr and exit non-zero without a stack trace. Caught inside the handler (not at
-// the bin's run boundary) so the contract survives the fold into the shared pipeline-cli bin.
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const sweep = Command.make(
 	"sweep",

--- a/packages/pipeline-cli/src/tools/patch-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/patch-guard/command.ts
@@ -29,9 +29,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkPatchGuard} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkPatchGuard} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
 // Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
@@ -66,15 +66,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
-// error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/path-filter-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/command.ts
@@ -21,9 +21,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkPathFilters} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkPathFilters} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
 // Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
@@ -57,15 +57,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
-// error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/pointer-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/command.ts
@@ -26,9 +26,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkPointers} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkPointers} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -62,15 +62,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/publish-isolation-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/publish-isolation-guard/command.ts
@@ -30,9 +30,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkPublishIsolation} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkPublishIsolation} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -67,15 +67,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/reachability-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/command.ts
@@ -27,9 +27,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkReachability} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkReachability} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
 // Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker
@@ -65,15 +65,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
-// error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/readme-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/command.ts
@@ -28,9 +28,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkReadmes} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkReadmes} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -63,15 +63,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/readme-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/gate.ts
@@ -19,11 +19,13 @@
  */
 import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
+import {Annotation} from "../../annotate.ts";
 import {
 	judge,
 	type PackageDirCandidate,
 	parseWorkspacePackageGlobs,
 	renderReport,
+	verdictAnnotations,
 } from "./readme-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
@@ -32,9 +34,14 @@ export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
 	cause: Schema.Unknown,
 }) {}
 
-/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+/**
+ * Carries the non-zero gate-fail exit (the report is already on stderr). `annotations`
+ * is optional so the ~18 guards that construct a bare `{reason}` keep compiling; the
+ * shared handler falls back to one unlocated `::error` when it's absent (#3868).
+ */
 export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
 	reason: Schema.String,
+	annotations: Schema.optionalKey(Schema.Array(Annotation)),
 }) {}
 
 /** The workspace glob that scopes this guard — the convention is about `packages/*` specifically. */
@@ -109,5 +116,10 @@ export const checkReadmes = (
 			yield* Console.log(renderReport(verdict));
 			return;
 		}
-		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+		return yield* Effect.fail(
+			new CheckFailed({
+				reason: renderReport(verdict),
+				annotations: verdictAnnotations(verdict),
+			}),
+		);
 	});

--- a/packages/pipeline-cli/src/tools/readme-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/gate.ts
@@ -20,6 +20,7 @@
 import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {Annotation} from "../../annotate.ts";
+import {annotationsOrNone} from "../../gate-fail.ts";
 import {
 	judge,
 	type PackageDirCandidate,
@@ -116,10 +117,6 @@ export const checkReadmes = (
 			yield* Console.log(renderReport(verdict));
 			return;
 		}
-		return yield* Effect.fail(
-			new CheckFailed({
-				reason: renderReport(verdict),
-				annotations: verdictAnnotations(verdict),
-			}),
-		);
+		const annotations = yield* annotationsOrNone(() => verdictAnnotations(verdict));
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict), annotations}));
 	});

--- a/packages/pipeline-cli/src/tools/readme-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/gate.unit.test.ts
@@ -84,4 +84,20 @@ describe("checkReadmes — the CI exit-code gate over a fake repo dir", () => {
 		const exit = await run(checkReadmes(root));
 		expect(isCheckFailed(exit)).toBe(true);
 	});
+
+	// The CI annotation rides on the failure itself, so a red run always has one to emit (#3868).
+	it("carries a located annotation on the failure so CI can annotate the diff", async () => {
+		writeWorkspace();
+		mkPackage("has", {pkgJson: true, readme: true});
+		mkPackage("missing", {pkgJson: true});
+		const exit = await run(checkReadmes(root));
+		const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : null;
+		expect(error).toBeInstanceOf(CheckFailed);
+		expect((error as CheckFailed).annotations).toEqual([
+			expect.objectContaining({
+				level: "error",
+				location: {_tag: "File", file: "packages/missing/package.json"},
+			}),
+		]);
+	});
 });

--- a/packages/pipeline-cli/src/tools/readme-guard/readme-guard.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/readme-guard.ts
@@ -17,6 +17,7 @@
  * misconfiguration (wrong root, a workspace reshape), NOT a silent pass — the
  * verdict is a failure, never a vacuous green.
  */
+import {type Annotation, atFile, unlocated} from "../../annotate.ts";
 
 /**
  * One immediate `packages/*` subdirectory reduced to the two facts the decision
@@ -85,6 +86,23 @@ export const renderReport = (verdict: ReadmeGuardVerdict): string => {
 		`(of ${verdict.members.length} scanned):\n${lines.join("\n")}\n\n` +
 		"Every packages/* workspace package must carry a README.md (what it is, why it\n" +
 		"exists, how to use it). Add one to each listed directory."
+	);
+};
+
+/**
+ * The CI annotations for a verdict — one per member missing its README, anchored on
+ * that member's `package.json` (the file that exists, so the annotation renders on the
+ * diff; the missing README has no file to hang on). Zero-scope annotates bare (#3868).
+ */
+export const verdictAnnotations = (verdict: ReadmeGuardVerdict): ReadonlyArray<Annotation> => {
+	if (verdict.pass) return [];
+	if (verdict.reason === "zero-scope") return [unlocated("error", renderReport(verdict))];
+	return verdict.missing.map((dir) =>
+		atFile(
+			"error",
+			`${dir}/package.json`,
+			`${dir} has no README.md — every packages/* workspace package must carry one (what it is, why it exists, how to use it). Fix: add ${dir}/README.md.`,
+		),
 	);
 };
 

--- a/packages/pipeline-cli/src/tools/readme-guard/readme-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/readme-guard.unit.test.ts
@@ -9,6 +9,7 @@ import {
 	type PackageDirCandidate,
 	parseWorkspacePackageGlobs,
 	renderReport,
+	verdictAnnotations,
 } from "./readme-guard.ts";
 
 const candidate = (
@@ -106,5 +107,32 @@ describe("parseWorkspacePackageGlobs", () => {
 
 	it("returns [] when there is no packages: block", () => {
 		expect(parseWorkspacePackageGlobs("catalog:\n  effect: 1\n")).toEqual([]);
+	});
+});
+
+describe("verdictAnnotations", () => {
+	const candidate = (dir: string, hasReadme: boolean): PackageDirCandidate => ({
+		dir,
+		hasPackageJson: true,
+		hasReadme,
+	});
+
+	it("annotates a pass with nothing", () => {
+		expect(verdictAnnotations(judge([candidate("packages/a", true)]))).toEqual([]);
+	});
+
+	it("annotates zero-scope bare — there is no file to point at", () => {
+		expect(verdictAnnotations(judge([]))[0]?.location).toEqual({_tag: "Unlocated"});
+	});
+
+	it("anchors a missing README on the member's package.json, which exists in the diff", () => {
+		const annotations = verdictAnnotations(
+			judge([candidate("packages/a", false), candidate("packages/b", true)]),
+		);
+		expect(annotations).toHaveLength(1);
+		expect(annotations[0]?.location).toEqual({
+			_tag: "File",
+			file: "packages/a/package.json",
+		});
 	});
 });

--- a/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
@@ -27,10 +27,10 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkRoadmap} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkRoadmap} from "./gate.ts";
 import {MilestonesLive} from "./github.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -63,15 +63,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, gh failures) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/settings-env-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/command.ts
@@ -18,9 +18,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkSettingsEnv} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkSettingsEnv} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -56,15 +56,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",

--- a/packages/pipeline-cli/src/tools/workflow-contract/command.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/command.ts
@@ -29,9 +29,9 @@
  */
 import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type CheckFailed, checkWorkflows} from "./gate.ts";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkWorkflows} from "./gate.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -66,15 +66,6 @@ const resolveRoot = (
 	root: Option.Option<string>,
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
 	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
-
-// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
-// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-// default error report (also a non-zero exit — both are failures, undistinguished).
-const onCheckFailed = (e: CheckFailed) =>
-	Effect.sync(() => {
-		process.stderr.write(`${e.reason}\n`);
-		process.exit(GATE_FAIL_EXIT_CODE);
-	});
 
 const check = Command.make(
 	"check",


### PR DESCRIPTION
When a pipeline-cli guard goes red in CI today it prints plain text, so finding the
offending file means digging through the job log. This PR makes a failing guard also emit
GitHub `::error` workflow commands, which GitHub renders as inline annotations on the PR
diff — the failure shows up on the line that caused it. Nothing changes when you run a
guard locally, and no exit code moves.

## What changed

- **`packages/pipeline-cli/src/annotate.ts`** — the shared pure core. It owns the
  workflow-command syntax: a closed location union (`Unlocated` / `File` / `Line`), so a
  `line=` with no `file=` (which GitHub silently drops) cannot be constructed; the message
  and property escaping; and `annotationsEnabled`, which is true only when `GITHUB_ACTIONS`
  is set to something other than `false`. Unit-tested in `annotate.unit.test.ts`.
- **`packages/pipeline-cli/src/gate-fail.ts`** — one `CheckFailed` handler, replacing the
  18 near-identical copies that each guard's `command.ts` carried. Human report to stderr,
  workflow commands to stdout, exit 1. A guard that supplies no annotations of its own gets
  one bare `::error` carrying the head of its report, so every red guard annotates.
- **All 18 guard commands** now route through it (catalog-guard, fanout-guard,
  readme-guard, leak-guard, roadmap-guard, workflow-contract, reachability-guard,
  pointer-guard, patch-guard, path-filter-guard, publish-isolation-guard, codeowners-cp,
  crew-fanout-guard, change-detect-guard, design-inventory, design-token-guard,
  settings-env-guard, decisions-index).
- **catalog-guard and readme-guard attach located annotations.** catalog-guard resolves the
  `package.json` line the offending dep sits on (`findDepLine`, pure and tested);
  readme-guard anchors a missing README on the member's `package.json`, which exists in the
  diff so the annotation renders.
- **`packages/pipeline-cli/README.md`** gains a "How a guard fails" section.

## Acceptance criteria

- [x] Shared annotation helper in `packages/pipeline-cli`, pure core + unit tests, emits
      only under GitHub Actions.
- [x] Guard fail paths adopt it — a red guard produces at least one annotation, with
      file/line where the guard knows them.
- [x] Local guard runs unchanged (no workflow commands outside CI).
- [x] No exit-code changes.

## Verification

Against a throwaway fixture repo, `GITHUB_ACTIONS=true` on stdout:

```
::error file=packages/x/package.json,line=5::dependencies `b` pins `^1.0.0` instead of `catalog:` — a second version of a dep breaks frozen-lockfile CI (#535).
::error file=packages/x/package.json::packages/x has no README.md — every packages/* workspace package must carry one …
::error::readme-guard: pnpm-workspace.yaml does not declare the `packages/*` member glob …
```

The same runs without `GITHUB_ACTIONS` emit nothing on stdout and still exit 1.
`pnpm --filter @kampus/pipeline-cli test` is green (1979 tests), as are `pnpm typecheck`
and `pnpm lint:worktree`.

Fixes #3868
