### PR TITLE
feat(pipeline-crew-mcp): package the crew MCP server as a marketplace plugin channel (#3366)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,6 +38,23 @@
 				"issue-pipeline",
 				"repo-agnostic"
 			]
+		},
+		{
+			"name": "pipeline-crew-mcp",
+			"source": "./claude-plugins/pipeline-crew-mcp",
+			"description": "The pipeline-crew channel substrate packaged as a marketplace plugin channel: declares the in-repo @kampus/pipeline-crew-mcp stdio server as a claude/channel server so --channels allowlist/production mode binds it via plugin:pipeline-crew-mcp@kampus, instead of an inline server: dev channel. References the in-repo package (nothing bundled), clean dependency set. Governed by ADR 0201.",
+			"author": {
+				"name": "kamp-us",
+				"url": "https://github.com/kamp-us"
+			},
+			"license": "MIT",
+			"keywords": [
+				"channel-mcp",
+				"agent-crew",
+				"pipeline-orchestration",
+				"claude-channel",
+				"repo-agnostic"
+			]
 		}
 	]
 }

--- a/claude-plugins/pipeline-crew-mcp/.claude-plugin/plugin.json
+++ b/claude-plugins/pipeline-crew-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+	"name": "pipeline-crew-mcp",
+	"description": "The kamp.us pipeline-crew channel substrate, packaged as a marketplace plugin channel. Declares the in-repo @kampus/pipeline-crew-mcp stdio server (the tracker + channel_send toolkit the crew addresses each other through) as a claude/channel server, so --channels allowlist/production mode can bind it via a plugin:pipeline-crew-mcp@kampus ref instead of an inline server: dev channel. References the in-repo package (nothing bundled); ships zero operator data. Governed by ADR 0201 (pipeline-as-product tenant model).",
+	"author": {
+		"name": "kamp-us",
+		"url": "https://github.com/kamp-us"
+	},
+	"homepage": "https://github.com/kamp-us/phoenix",
+	"repository": "https://github.com/kamp-us/phoenix",
+	"license": "MIT",
+	"keywords": [
+		"channel-mcp",
+		"agent-crew",
+		"pipeline-orchestration",
+		"claude-channel",
+		"repo-agnostic"
+	],
+	"channels": [
+		{
+			"server": "@kampus/pipeline-crew-mcp",
+			"displayName": "kamp.us pipeline crew"
+		}
+	]
+}

--- a/claude-plugins/pipeline-crew-mcp/.mcp.json
+++ b/claude-plugins/pipeline-crew-mcp/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"@kampus/pipeline-crew-mcp": {
+			"command": "node",
+			"args": ["${CLAUDE_PLUGIN_ROOT}/../../packages/pipeline-crew-mcp/src/bin.ts", "session"]
+		}
+	}
+}

--- a/claude-plugins/pipeline-crew-mcp/README.md
+++ b/claude-plugins/pipeline-crew-mcp/README.md
@@ -1,0 +1,89 @@
+# pipeline-crew-mcp
+
+The **pipeline-crew-mcp** plugin packages the in-repo
+[`@kampus/pipeline-crew-mcp`](../../packages/pipeline-crew-mcp/) channel substrate — the crew's
+tracker + `channel_send` toolkit — as a **marketplace plugin channel**. It exists for exactly one
+reason: to make the crew's own MCP server resolvable as a `plugin:<name>@<marketplace>` ref, so
+`--channels` **allowlist / production mode** can bind it.
+
+## Why this plugin exists
+
+Under Claude Code's `--channels` **allowlist (production) mode**, only `plugin:<name>@<marketplace>`
+marketplace refs load; an inline `server:<name>` channel is silently skipped (issue #3328). The
+crew's channel server is defined **inline** today (dev-mode `--dangerously-load-development-channels`),
+so it can only ever bind in **development mode**. This plugin is the **distribution unit** that closes
+that gap — the deliverable [ADR 0201](../../.decisions/0201-pipeline-tenant-phoenix-first.md) names for
+issue #3366: a self-contained channel packaging with a **clean dependency set**
+(`effect`, `@effect/platform-node`, `proper-lockfile` — no phoenix-private deps).
+
+It is **marketplace-bundled, not npm-published**: the plugin *references* the in-repo package (nothing
+is copied or bundled), matching the pipeline-as-**tenant** model — phoenix is the pipeline's permanent
+proving ground (ADR 0201), so the self-hosted `kampus` marketplace resolves the package straight from
+the checkout via `${CLAUDE_PLUGIN_ROOT}`.
+
+## How the channel binds
+
+Two grounded pieces make the crew server a bindable channel (verified against the installed CLI, per
+CLAUDE.md's "ground runtime claims in source"):
+
+1. **`.mcp.json`** declares the stdio server under the key `@kampus/pipeline-crew-mcp`, running the
+   in-repo bin's `session` subcommand. The path uses the `${CLAUDE_PLUGIN_ROOT}` placeholder (substituted
+   per-element as a plain string), so it resolves wherever the plugin is installed.
+2. **`plugin.json`'s `channels`** declares one channel whose `server` names that same key — the manifest
+   contract "the channel's `server` must match a key in this plugin's `mcpServers`". The crew server
+   already advertises the `claude/channel` capability at runtime (`CHANNEL_CAPABILITY`), so the CLI
+   admits it as a channel.
+
+Once installed and allowlisted, the crew binds via:
+
+```
+--channels plugin:pipeline-crew-mcp@kampus
+# with allowedChannelPlugins including "pipeline-crew-mcp"
+```
+
+### Per-session role comes from the environment
+
+The crew runs one session **per role**, but a plugin channel is **one static declaration** — it cannot
+carry a per-pane `--role`. So a plugin-channel session takes its launch inputs from the pane
+environment, which the launcher sets per pane:
+
+| env var | purpose | fallback |
+|---|---|---|
+| `CREW_ROLE` | the role this session serves | **none — fails closed** |
+| `CREW_PROJECT_ROOT` | the repo whose tracker to join | process cwd |
+| `CREW_INSTANCE` | an engine's launcher-assigned instance id | none (a bridge mints its own) |
+
+The dev-mode `server:`-ref path is **untouched**: it still passes `--role`/`--project-root` on argv, and
+the flag **wins** over the env (`packages/pipeline-crew-mcp/src/crew/session-inputs.ts`), so both launch
+paths coexist with no behavioral change to dev.
+
+## Install
+
+```
+/plugin marketplace add kamp-us/phoenix
+/plugin install pipeline-crew-mcp@kampus
+```
+
+The plugin carries **no `version`** — it is content-addressed by commit SHA (continuous-ship,
+[ADR 0110](../../.decisions/0110-plugin-carries-no-version-continuous-ship.md)).
+
+## Scope and follow-up
+
+This plugin is the **packaging + binding primitive**. Wiring the `pipeline-crew` **stand-up launcher**
+to emit the `plugin:pipeline-crew-mcp@kampus` ref (setting each pane's `CREW_ROLE` env and retiring the
+per-pane project-scope `.mcp.json` in favor of the plugin declaration) is a separate launcher change,
+tracked as a follow-up — it replaces the load-bearing per-pane isolation mechanism
+(`standup/register-project-scope.ts`) and is out of scope for this distribution unit. Dev-mode stays the
+supported dogfood path in the meantime.
+
+## See also
+
+- [`../../packages/pipeline-crew-mcp/`](../../packages/pipeline-crew-mcp/) — the channel substrate this
+  plugin packages (the `session` bin, the tracker, the `channel_send` toolkit).
+- [`../pipeline-crew/`](../pipeline-crew/) — the crew agent defs that address each other over this channel.
+- ADR [0201](../../.decisions/0201-pipeline-tenant-phoenix-first.md) — pipeline-as-product tenant model,
+  isolated publishing, and the clean dependency set that makes this packaging a distribution unit.
+- ADR [0110](../../.decisions/0110-plugin-carries-no-version-continuous-ship.md) — why the plugin carries
+  no `version`.
+- ADR [0062](../../.decisions/0062-repo-as-config-plugin.md) — the repo-as-config, repo-agnostic seam
+  (`CLAUDE_PIPELINE_REPO`) both pipeline plugins share.

--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -57,8 +57,12 @@ import {
 	collectLiveRegisteredForProject,
 	RoleUniquenessError,
 	renderCrewChannelHealth,
+	resolveSessionInstance,
+	resolveSessionProjectRoot,
+	resolveSessionRole,
 	runCrewChannelDoctor,
 	runCrewSession,
+	type SessionRoleUnresolvedError,
 } from "./crew/index.ts";
 import {
 	CREW_WINDOW,
@@ -72,38 +76,68 @@ import {
 import {isTrackerAddressInUse, launchTracker} from "./tracker/index.ts";
 import {VERSION} from "./version.ts";
 
-const roleFlag = Flag.choice("role", CREW_ROLES).pipe(
-	Flag.withDescription("the standing crew role this session serves (one of the five CREW_ROLES)"),
-);
 const projectRootFlag = Flag.string("project-root").pipe(
 	Flag.withDefault(process.cwd()),
 	Flag.withDescription(
 		"a directory inside the repo whose tracker this session joins; seeds git repo discovery only — the rendezvous is the repo's canonical one (ADR 0197)",
 	),
 );
+// The `session` command's own flags are all OPTIONAL because a marketplace plugin-channel launch
+// (#3366/ADR 0201) declares the crew server as ONE static `.mcp.json` entry that cannot carry a
+// per-pane `--role`, so a plugin-channel session takes its role/project-root/instance from the pane
+// environment (`CREW_ROLE`/`CREW_PROJECT_ROOT`/`CREW_INSTANCE`) instead. The dev-mode `server:`-ref
+// path still passes `--role`/`--project-root` on argv, and the flag WINS over the env in
+// crew/session-inputs, so both launch paths coexist. Role has no safe default — a session with
+// neither flag nor env fails closed (SessionRoleUnresolvedError); project-root falls back to cwd.
+const sessionRoleFlag = Flag.optional(Flag.choice("role", CREW_ROLES)).pipe(
+	Flag.withDescription(
+		"the standing crew role this session serves; falls back to $CREW_ROLE (plugin-channel launch)",
+	),
+);
+const sessionProjectRootFlag = Flag.optional(Flag.string("project-root")).pipe(
+	Flag.withDescription(
+		"the repo whose tracker this session joins; falls back to $CREW_PROJECT_ROOT then cwd (ADR 0197)",
+	),
+);
 // The launcher-assigned per-instance identity standup/bind.ts bakes into an engine's argv
 // (`CREW_SESSION_INSTANCE_FLAG`, #3297/#3354 seam 3). Optional: only engine roles carry it — a
 // bridge is a singleton and omits it, so the session mints its own (see `sessionInstance`). This is
 // the consumer the producer shipped without; without it Effect-CLI rejects `--instance` and every
-// engine session dies at parse (#3445).
+// engine session dies at parse (#3445). Falls back to $CREW_INSTANCE under a plugin-channel launch.
 const instanceFlag = Flag.optional(Flag.string("instance")).pipe(
 	Flag.withDescription("the launcher-assigned per-instance identity an engine session binds"),
 );
 
 const session = Command.make(
 	"session",
-	{projectRoot: projectRootFlag, role: roleFlag, instance: instanceFlag},
-	Effect.fn(function* ({projectRoot, role, instance}) {
+	{projectRoot: sessionProjectRootFlag, role: sessionRoleFlag, instance: instanceFlag},
+	Effect.fn(function* ({projectRoot: projectRootOpt, role: roleOpt, instance: instanceOpt}) {
+		// Resolve each launch input flag-or-env (crew/session-inputs): the flag wins (dev-mode argv),
+		// else the pane env (plugin-channel). Role fails closed with no safe default — neither
+		// `--role` nor a valid `$CREW_ROLE` is a session to refuse loudly, naming the valid roles.
+		const role = yield* resolveSessionRole(Option.getOrUndefined(roleOpt), process.env).pipe(
+			Effect.catch((error: SessionRoleUnresolvedError) =>
+				Console.error(
+					`refusing to start: no crew role — pass --role or set $CREW_ROLE (saw "${error.attempted}"; valid: ${error.validRoles.join(", ")})`,
+				).pipe(Effect.andThen(Effect.sync(() => process.exit(1) as never))),
+			),
+		);
+		const projectRoot = resolveSessionProjectRoot(
+			Option.getOrUndefined(projectRootOpt),
+			process.env,
+			process.cwd(),
+		);
+		const instance = resolveSessionInstance(Option.getOrUndefined(instanceOpt), process.env);
 		yield* Console.error(
 			`pipeline-crew-mcp ${VERSION} — crew session for role "${role}" (project ${projectRoot})`,
 		);
-		// Thread the flag through as an EXACT-optional key: include `instance` only when the launcher
-		// passed one (an engine), omit it entirely otherwise (a bridge/singleton, or a direct run) so
-		// `CrewSessionConfig.instance`'s absent case stays absent — `sessionInstance` then mints one.
+		// Thread the resolved instance through as an EXACT-optional key: include it only when a launcher
+		// (flag or env) assigned one (an engine), omit it otherwise (a bridge/singleton, or a direct run)
+		// so `CrewSessionConfig.instance`'s absent case stays absent — `sessionInstance` then mints one.
 		return yield* runCrewSession({
 			projectRoot,
 			role,
-			...(Option.isSome(instance) ? {instance: instance.value} : {}),
+			...(instance !== undefined ? {instance} : {}),
 		}).pipe(
 			Effect.catch((error: unknown) =>
 				Console.error(

--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -93,6 +93,16 @@ export {
 	SESSION_SERVER_NAME,
 } from "./session.ts";
 export {
+	CREW_INSTANCE_ENV,
+	CREW_PROJECT_ROOT_ENV,
+	CREW_ROLE_ENV,
+	resolveSessionInstance,
+	resolveSessionProjectRoot,
+	resolveSessionRole,
+	type SessionInputEnv,
+	SessionRoleUnresolvedError,
+} from "./session-inputs.ts";
+export {
 	type ClaimReply,
 	CrewTracker,
 	crewTrackerHostOrDialLayer,

--- a/packages/pipeline-crew-mcp/src/crew/session-inputs.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session-inputs.test.ts
@@ -1,0 +1,113 @@
+/**
+ * crew/session-inputs — the flag-or-env resolution the `session` command uses so a static marketplace
+ * plugin-channel `.mcp.json` (one declaration, no per-pane `--role`) resolves each pane's role from
+ * `$CREW_ROLE`, while the dev-mode `--role` argv path is untouched (the flag still wins). These tests
+ * pin: the flag wins over env, env is the plugin-channel fallback, role fails closed when neither
+ * resolves, and project-root/instance degrade to their safe defaults. See #3366 / ADR 0201.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	resolveSessionInstance,
+	resolveSessionProjectRoot,
+	resolveSessionRole,
+	SessionRoleUnresolvedError,
+} from "./session-inputs.ts";
+
+describe("crew/session-inputs — resolveSessionRole (fail-closed)", () => {
+	it.effect("the --role flag wins over $CREW_ROLE (dev-mode argv path unchanged)", () =>
+		Effect.gen(function* () {
+			const role = yield* resolveSessionRole("intake-desk", {CREW_ROLE: "chief-of-staff"});
+			assert.strictEqual(role, "intake-desk");
+		}),
+	);
+
+	it.effect(
+		"falls back to a valid $CREW_ROLE when the flag is absent (plugin-channel env path)",
+		() =>
+			Effect.gen(function* () {
+				const role = yield* resolveSessionRole(undefined, {CREW_ROLE: "engineering-manager"});
+				assert.strictEqual(role, "engineering-manager");
+			}),
+	);
+
+	it.effect("trims surrounding whitespace on $CREW_ROLE before validating", () =>
+		Effect.gen(function* () {
+			const role = yield* resolveSessionRole(undefined, {CREW_ROLE: "  cartographer  "});
+			assert.strictEqual(role, "cartographer");
+		}),
+	);
+
+	it.effect("fails closed when neither flag nor env resolves a role (attempted = empty)", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(resolveSessionRole(undefined, {}));
+			assert.instanceOf(error, SessionRoleUnresolvedError);
+			assert.strictEqual(error.attempted, "");
+			assert.deepStrictEqual(
+				[...error.validRoles],
+				["chief-of-staff", "cartographer", "intake-desk", "engineering-manager"],
+			);
+		}),
+	);
+
+	it.effect("a blank $CREW_ROLE reads as absent and fails closed", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(resolveSessionRole(undefined, {CREW_ROLE: "   "}));
+			assert.instanceOf(error, SessionRoleUnresolvedError);
+			assert.strictEqual(error.attempted, "");
+		}),
+	);
+
+	it.effect("fails closed on an invalid $CREW_ROLE, surfacing the offending value", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(resolveSessionRole(undefined, {CREW_ROLE: "not-a-role"}));
+			assert.instanceOf(error, SessionRoleUnresolvedError);
+			assert.strictEqual(error.attempted, "not-a-role");
+		}),
+	);
+});
+
+describe("crew/session-inputs — resolveSessionProjectRoot (total, cwd default)", () => {
+	it("the --project-root flag wins over env and cwd", () => {
+		assert.strictEqual(
+			resolveSessionProjectRoot("/flag/root", {CREW_PROJECT_ROOT: "/env/root"}, "/cwd/root"),
+			"/flag/root",
+		);
+	});
+
+	it("falls back to $CREW_PROJECT_ROOT when the flag is absent", () => {
+		assert.strictEqual(
+			resolveSessionProjectRoot(undefined, {CREW_PROJECT_ROOT: "/env/root"}, "/cwd/root"),
+			"/env/root",
+		);
+	});
+
+	it("falls back to cwd when neither flag nor env is set", () => {
+		assert.strictEqual(resolveSessionProjectRoot(undefined, {}, "/cwd/root"), "/cwd/root");
+	});
+
+	it("a blank $CREW_PROJECT_ROOT reads as absent and degrades to cwd", () => {
+		assert.strictEqual(
+			resolveSessionProjectRoot(undefined, {CREW_PROJECT_ROOT: "  "}, "/cwd/root"),
+			"/cwd/root",
+		);
+	});
+});
+
+describe("crew/session-inputs — resolveSessionInstance (optional)", () => {
+	it("the --instance flag wins over env", () => {
+		assert.strictEqual(resolveSessionInstance("flag-id", {CREW_INSTANCE: "env-id"}), "flag-id");
+	});
+
+	it("falls back to $CREW_INSTANCE when the flag is absent", () => {
+		assert.strictEqual(resolveSessionInstance(undefined, {CREW_INSTANCE: "env-id"}), "env-id");
+	});
+
+	it("is undefined when neither is set (a bridge singleton / direct run mints its own)", () => {
+		assert.strictEqual(resolveSessionInstance(undefined, {}), undefined);
+	});
+
+	it("a blank $CREW_INSTANCE reads as absent", () => {
+		assert.strictEqual(resolveSessionInstance(undefined, {CREW_INSTANCE: "  "}), undefined);
+	});
+});

--- a/packages/pipeline-crew-mcp/src/crew/session-inputs.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session-inputs.ts
@@ -1,0 +1,89 @@
+/**
+ * crew/session-inputs — resolve one crew session's launch inputs (role, project root, instance) from
+ * either the CLI flag OR the process environment, fail-closed on an unresolvable role.
+ *
+ * Why an env source at all: the marketplace plugin channel (claude-plugins/pipeline-crew-mcp,
+ * #3366 / ADR 0201) packages the crew server as ONE static `.mcp.json` entry so allowlist/production
+ * mode can bind it via a `plugin:<name>@<marketplace>` ref. A static declaration cannot carry a
+ * per-pane `--role`, because the one declaration serves every role while the role differs per
+ * session — so under the plugin-channel launch path a session reads its role/project-root/instance
+ * from the pane's environment (`CREW_ROLE`/`CREW_PROJECT_ROOT`/`CREW_INSTANCE`), which the launcher
+ * sets per pane. The dev-mode `server:`-ref path is unchanged: it still passes `--role` on argv, and
+ * the flag WINS over the env here, so the two launch paths coexist with no behavioral change to dev.
+ *
+ * The one non-obvious thing: role resolution FAILS CLOSED. Role is the one input with no safe default
+ * (project-root falls back to cwd, instance is legitimately absent for a bridge), so an absent-and-
+ * unset or an invalid role is a session to refuse with a named error, never a guessed role.
+ */
+import {Effect, Schema} from "effect";
+import {CREW_ROLES, type CrewRole, isCrewRole} from "./roles.ts";
+
+/** The pane-environment key a plugin-channel session reads its role from when `--role` is absent (#3366). */
+export const CREW_ROLE_ENV = "CREW_ROLE";
+/** The pane-environment key for the session's project root when `--project-root` is absent (falls back to cwd after this). */
+export const CREW_PROJECT_ROOT_ENV = "CREW_PROJECT_ROOT";
+/** The pane-environment key for an engine session's launcher-assigned instance when `--instance` is absent. */
+export const CREW_INSTANCE_ENV = "CREW_INSTANCE";
+
+/** The env shape the resolvers read — the three crew launch keys, each optionally set. */
+export interface SessionInputEnv {
+	readonly CREW_ROLE?: string | undefined;
+	readonly CREW_PROJECT_ROOT?: string | undefined;
+	readonly CREW_INSTANCE?: string | undefined;
+}
+
+/**
+ * Neither `--role` nor a valid `$CREW_ROLE` resolved a crew role — the session is refused (fail-closed).
+ * `attempted` is the raw env value seen (empty when unset) so the operator can tell "unset" from "typo".
+ */
+export class SessionRoleUnresolvedError extends Schema.TaggedErrorClass<SessionRoleUnresolvedError>()(
+	"@kampus/pipeline-crew-mcp/crew/SessionRoleUnresolvedError",
+	{
+		attempted: Schema.String,
+		validRoles: Schema.Array(Schema.String),
+	},
+) {}
+
+/** Trim a possibly-undefined env value to a non-empty string, or `undefined` — so a blank env var reads as absent. */
+const nonEmpty = (value: string | undefined): string | undefined => {
+	const trimmed = value?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : undefined;
+};
+
+/**
+ * Resolve the session's role: the `--role` flag if present (dev-mode argv path, always wins), else
+ * `$CREW_ROLE` validated against `CREW_ROLES` (plugin-channel env path), else fail closed. A present
+ * flag is already a `CrewRole` (the CLI validated `Flag.choice`), so only the env branch re-validates.
+ */
+export const resolveSessionRole = (
+	flagRole: CrewRole | undefined,
+	env: SessionInputEnv,
+): Effect.Effect<CrewRole, SessionRoleUnresolvedError> => {
+	if (flagRole !== undefined) return Effect.succeed(flagRole);
+	const fromEnv = nonEmpty(env.CREW_ROLE);
+	if (fromEnv !== undefined && isCrewRole(fromEnv)) return Effect.succeed(fromEnv);
+	return Effect.fail(
+		new SessionRoleUnresolvedError({attempted: fromEnv ?? "", validRoles: CREW_ROLES}),
+	);
+};
+
+/**
+ * Resolve the session's project root: the `--project-root` flag if present, else `$CREW_PROJECT_ROOT`,
+ * else the process cwd. Total — project-root always has a safe default (the repo the pane launched in),
+ * so unlike role it never fails.
+ */
+export const resolveSessionProjectRoot = (
+	flagProjectRoot: string | undefined,
+	env: SessionInputEnv,
+	cwd: string,
+): string => flagProjectRoot ?? nonEmpty(env.CREW_PROJECT_ROOT) ?? cwd;
+
+/**
+ * Resolve the session's instance: the `--instance` flag if present, else `$CREW_INSTANCE`, else
+ * `undefined`. Absent is a legitimate state (a bridge singleton, or a direct run) — `sessionInstance`
+ * mints one — so this never fails; it only threads a launcher-assigned engine identity through.
+ */
+export const resolveSessionInstance = (
+	flagInstance: string | undefined,
+	env: SessionInputEnv,
+): string | undefined => flagInstance ?? nonEmpty(env.CREW_INSTANCE);


### PR DESCRIPTION
Part of #3366 — the marketplace-plugin-channel half of the Pipeline Anywhere campaign item.

**Non-closing by design.** #3366's AC#2 ("the production-mode launcher binds the crew server through the plugin channel") is NOT delivered here: `packages/pipeline-crew-mcp/src/standup/` is unchanged, because rewiring it retires `register-project-scope.ts` — the load-bearing per-pane isolation of #3444 — which is design-bearing and tracked separately as #3920. Using a closing keyword would auto-close the issue and mark the campaign complete on a half-delivered unit. #3366 stays open until #3920 lands (or until triage/founder re-scopes AC#2 onto #3920 on the record).

## What & why

Packages the in-repo `@kampus/pipeline-crew-mcp` channel substrate as a distributable **marketplace plugin channel** so `--channels` **allowlist/production mode** can bind the crew server via a `plugin:pipeline-crew-mcp@kampus` ref, instead of the dev-mode-only inline `server:` channel (#3328 — allowlist mode silently skips inline `server:` channels).

This is the **distribution unit** [ADR 0201](https://github.com/kamp-us/phoenix/blob/main/.decisions/0201-pipeline-tenant-phoenix-first.md) names for #3366: *"pipeline-crew-mcp needs a distribution unit for external repos (#3366 — marketplace-bundled and/or npm); its dependency set is already clean."* It is **marketplace-bundled, not npm-published** — the plugin *references* the in-repo package (nothing bundled/copied), matching the pipeline-as-**tenant** model (phoenix is the pipeline's permanent proving ground). The `#3211` gate (deferred npm publish) is therefore **not** a live blocker for the marketplace-bundled path; AC#3's npm-publish framing is superseded by ADR 0201.

## Grounded against the installed CLI (2.1.219)

Per CLAUDE.md's "ground runtime claims in source":
- A plugin declares a channel MCP server via a **local in-dir `.mcp.json`** plus a **`plugin.json` `channels[]`** entry whose `server` names that `mcpServers` key (*"the channel's `server` must match a key in this plugin's mcpServers"*).
- The crew server already advertises the `claude/channel` capability at runtime (`CHANNEL_CAPABILITY`), so the CLI admits it as a channel.
- `${CLAUDE_PLUGIN_ROOT}` is substituted per-element as a plain string in `.mcp.json`, so the server command resolves the in-repo bin wherever the plugin installs.

## Changes

- **New plugin** `claude-plugins/pipeline-crew-mcp/` — `plugin.json` (with `channels[]`), `.mcp.json` (the `@kampus/pipeline-crew-mcp` stdio server via `${CLAUDE_PLUGIN_ROOT}`), and a README. Registered in the `kampus` marketplace manifest (`.claude-plugin/marketplace.json`). No `version` (continuous-ship, ADR 0110).
- **`session` command resolves launch inputs flag-or-env** (`crew/session-inputs.ts`) — `CREW_ROLE`/`CREW_PROJECT_ROOT`/`CREW_INSTANCE` — so a *static* plugin-channel declaration binds per-pane (one declaration serves every role). Role **fails closed** with no safe default. The dev-mode `--role` argv path is **unchanged** (the flag wins over env), so both launch paths coexist. Pure resolver + 14 unit tests.

## Scope & follow-up

Scoped to the **packaging + binding primitive**. Wiring the `pipeline-crew` **stand-up launcher** to emit the `plugin:` ref (setting each pane's `CREW_ROLE` env and retiring the per-pane project-scope `.mcp.json` in favor of the plugin declaration) is a separate launcher change — it replaces the load-bearing per-pane isolation mechanism (`standup/register-project-scope.ts`) and is a documented follow-up. **Dev-mode inline `--mcp-config` launch stays unbroken** and remains the supported dogfood path.

### §CP note
`claude-plugins/**` and `.claude-plugin/marketplace.json` are control-plane by path; the crew-mcp package code (`packages/pipeline-crew-mcp/**`) is not (ADR 0187). Classification is the reviewer/shipper's call.

## Verification (local, all green)
- `pnpm typecheck` — clean (tsgo, full workspace)
- `pnpm lint:worktree` — clean
- crew-mcp tests: **384 passed** (incl. 14 new `session-inputs` cases)
- `leak-guard sweep` — clean; JSON manifests valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LxQ5T7AqZEowBFX5t7awW


