### PR TITLE
feat(ci): map tsc errors to ::error workflow commands for inline PR annotations (#3873)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,16 @@ jobs:
       # mirrors that script's primary-checkout branch (`biome check .`) with the reporter added.
       - run: pnpm exec biome check --reporter=github .
 
-      - run: pnpm typecheck
+      # tsc has no `--reporter=github` equivalent, so the same inline-annotation win the biome
+      # step gets above is done by mapping its `path(line,col): error TSxxxx:` diagnostics onto
+      # `::error` workflow commands (#3873). `tsc-annotate map` is a pass-through: it re-prints
+      # stdin verbatim (the log reads exactly as before) and always exits 0, so `pipefail` is
+      # what keeps the step red — the pipeline's status is `pnpm typecheck`'s own exit code.
+      # Local `pnpm typecheck` is untouched; the mapping lives here, like the biome reporter.
+      - name: typecheck
+        run: |
+          set -o pipefail
+          pnpm typecheck | node packages/pipeline-cli/src/bin.ts tsc-annotate map
 
   unit:
     name: unit + client tests

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -67,6 +67,7 @@ import {structuredOutputGuardCommand} from "./tools/structured-output-guard/comm
 import {tokenSpendCommand} from "./tools/token-spend/command.ts";
 import {trackerCommand} from "./tools/tracker/command.ts";
 import {trivialDiffCommand} from "./tools/trivial-diff/command.ts";
+import {tscAnnotateCommand} from "./tools/tsc-annotate/command.ts";
 import {unresolvedThreadsGuardCommand} from "./tools/unresolved-threads-guard/command.ts";
 import {verdictCommand} from "./tools/verdict/command.ts";
 import {wayfinderMapCommand} from "./tools/wayfinder-map/command.ts";
@@ -141,6 +142,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	tokenSpendCommand,
 	trackerCommand,
 	trivialDiffCommand,
+	tscAnnotateCommand,
 	classProbeCommand,
 	wayfinderMapCommand,
 	shipDigestCommand,

--- a/packages/pipeline-cli/src/tools/tsc-annotate/command.ts
+++ b/packages/pipeline-cli/src/tools/tsc-annotate/command.ts
@@ -1,0 +1,142 @@
+/**
+ * The `tsc-annotate` tool — `pipeline-cli tsc-annotate map [--force] [--root <d>]`.
+ *
+ *   pnpm typecheck | node packages/pipeline-cli/src/bin.ts tsc-annotate map
+ *
+ * A pass-through filter for the CI typecheck step (#3873): it echoes stdin to stdout
+ * byte-for-byte (so the raw log stays exactly as readable as before) and then re-emits
+ * each tsc diagnostic as a GitHub `::error file=…,line=…,col=…::` workflow command, which
+ * GitHub renders as an inline annotation on the PR diff. tsc has no native annotations
+ * reporter; its diagnostic format maps onto the workflow command mechanically.
+ *
+ * Two contracts this tool must never break:
+ *
+ *   - **It always exits 0.** It is a reporter, not a gate. The redness of the typecheck is
+ *     carried by the producer's exit code through `set -o pipefail` in the CI step — this
+ *     process exiting non-zero would only ever mask which side actually failed, and
+ *     exiting non-zero on its OWN parse trouble would turn a green typecheck red.
+ *   - **It never swallows a line.** Whatever came in goes back out, unmodified, first.
+ *
+ * Annotating is CI-only (`GITHUB_ACTIONS` set), so a local `pnpm typecheck | …` sees the
+ * plain tsc output; `--force` opts in for local verification.
+ */
+import {existsSync, readdirSync, readFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {parse as parseYaml} from "yaml";
+import {findRootDir} from "../../find-root-dir.ts";
+import {annotationsFor, type WorkspaceMember} from "./tsc-annotate.ts";
+
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	return (
+		findRootDir(start, (dir) => ROOT_MARKERS.some((m) => existsSync(join(dir, m))), dirname) ??
+		start
+	);
+};
+
+/**
+ * The `packages:` globs from `pnpm-workspace.yaml` reduced to their parent dirs. Only the
+ * `<dir>/*` shape the repo actually uses is understood; anything else is skipped rather
+ * than half-resolved (a missed dir costs one un-annotated package, never a wrong path).
+ */
+const workspaceGlobDirs = (root: string): ReadonlyArray<string> => {
+	const file = join(root, "pnpm-workspace.yaml");
+	if (!existsSync(file)) return [];
+	const globs: unknown = (parseYaml(readFileSync(file, "utf8")) as {packages?: unknown})?.packages;
+	if (!Array.isArray(globs)) return [];
+	return globs
+		.filter((g): g is string => typeof g === "string" && g.endsWith("/*"))
+		.map((g) => g.slice(0, -2));
+};
+
+/** Every workspace member as `{name, dir}` with `dir` repo-relative — turbo's line prefix is the name. */
+const readMembers = (root: string): ReadonlyArray<WorkspaceMember> => {
+	const members: Array<WorkspaceMember> = [];
+	for (const parent of workspaceGlobDirs(root)) {
+		const abs = join(root, parent);
+		if (!existsSync(abs)) continue;
+		for (const child of readdirSync(abs, {withFileTypes: true})) {
+			if (!child.isDirectory()) continue;
+			const manifest = join(abs, child.name, "package.json");
+			if (!existsSync(manifest)) continue;
+			const name: unknown = JSON.parse(readFileSync(manifest, "utf8")).name;
+			if (typeof name === "string") members.push({name, dir: `${parent}/${child.name}`});
+		}
+	}
+	return members;
+};
+
+/**
+ * Stream stdin through to stdout as it arrives (the CI log stays live, not withheld until
+ * the typecheck ends) while accumulating it for the annotation pass.
+ *
+ * Deliberately NOT `readFileSync(0)`: on a non-blocking pipe that throws EAGAIN, and this
+ * filter sits on the whole typecheck log — a swallowed EAGAIN silently deletes every line
+ * of it. Observed live while rehearsing this step, not theorised.
+ */
+const passThroughStdin = Effect.callback<string>((resume) => {
+	const chunks: Array<Buffer> = [];
+	let done = false;
+	const finish = () => {
+		if (done) return;
+		done = true;
+		resume(Effect.succeed(Buffer.concat(chunks).toString("utf8")));
+	};
+	process.stdin
+		.on("data", (chunk: Buffer) => {
+			chunks.push(chunk);
+			process.stdout.write(chunk);
+		})
+		.on("end", finish)
+		// A mid-read stdin failure resolves to what was read, never to an error channel: the
+		// reporter must not fail the step it reports on.
+		.on("error", finish);
+});
+
+const forceFlag = Flag.boolean("force").pipe(
+	Flag.withDescription("emit annotations even outside GitHub Actions (local verification)"),
+);
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root the annotated paths are relative to (default: walk up)"),
+);
+
+const map = Command.make(
+	"map",
+	{force: forceFlag, root: rootFlag},
+	Effect.fn(function* ({force, root}) {
+		// Pass-through FIRST and unconditionally: the log must be intact even if nothing below runs.
+		const output = yield* passThroughStdin;
+		if (!force && process.env.GITHUB_ACTIONS === undefined) return;
+
+		const repoRoot = Option.getOrElse(root, () => defaultRoot());
+		const members = readMembers(repoRoot);
+		if (members.length === 0) {
+			// Loud, but NOT fatal: with no member map a turbo-prefixed path can't be re-rooted, and a
+			// reporter that fails the build it reports on is worse than one that reports less.
+			process.stderr.write(
+				`tsc-annotate: found no workspace members under ${repoRoot} — diagnostics from turbo-prefixed lines cannot be re-rooted and will not be annotated.\n`,
+			);
+		}
+		const annotations = annotationsFor(output, {members, root: repoRoot});
+		yield* Effect.sync(() => {
+			for (const annotation of annotations) process.stdout.write(`${annotation}\n`);
+		});
+	}),
+).pipe(
+	Command.withDescription(
+		"Echo tsc output through, re-emitting each diagnostic as a ::error workflow command (CI-only unless --force)",
+	),
+);
+
+export const tscAnnotateCommand = Command.make("tsc-annotate").pipe(
+	Command.withSubcommands([map]),
+	Command.withDescription(
+		"Map tsc/tsgo diagnostics to GitHub ::error annotations so a failed typecheck lands on the PR diff (#3873)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/tsc-annotate/tsc-annotate.ts
+++ b/packages/pipeline-cli/src/tools/tsc-annotate/tsc-annotate.ts
@@ -1,0 +1,165 @@
+/**
+ * `tsc-annotate` pure core — turn tsc/tsgo diagnostics into GitHub `::error` workflow
+ * commands so a failing CI typecheck renders inline on the PR diff (#3873). IO-free and
+ * total: every decision is a deterministic transform over already-captured text.
+ *
+ * Three non-obvious facts the parser is built around, all observed from a real
+ * `pnpm turbo run typecheck` failure rather than assumed:
+ *
+ *   1. A diagnostic's path is relative to the PACKAGE directory (turbo runs each task with
+ *      cwd = the package dir), but GitHub resolves an annotation's `file=` against the REPO
+ *      ROOT. So which package a line belongs to is not cosmetic — it is the only thing that
+ *      makes the annotation land on the right file. Hence `WorkspaceMember`.
+ *   2. turbo says which package a line belongs to in TWO different ways, and both must be
+ *      read: a per-line `<package-name>:<task>: ` prefix in its streamed mode, and — the
+ *      mode CI actually gets — a GROUPED mode where a `<package-name>:<task>` header (bare,
+ *      or as `::group::…`) is printed once and the task's own lines follow UNPREFIXED. A
+ *      parser that only knew the per-line prefix silently annotated a package-relative path
+ *      as if it were repo-relative under CI. Observed, not assumed.
+ *   3. tsc emits its plain `path(line,col): error TSxxxx: message` form when stdout is not
+ *      a TTY (always so under turbo in CI). The `path:line:col - error …` pretty form is
+ *      accepted too, so a TTY-ish runner can't silently turn every annotation off.
+ */
+
+/** A pnpm workspace member: its package name (turbo's line prefix) and its repo-relative dir. */
+export interface WorkspaceMember {
+	readonly name: string;
+	readonly dir: string;
+}
+
+/** One parsed diagnostic, with `file` already re-rooted to be repo-relative. */
+export interface TscDiagnostic {
+	readonly file: string;
+	readonly line: number;
+	readonly column: number;
+	readonly severity: "error" | "warning";
+	readonly code: string;
+	readonly message: string;
+}
+
+export interface AnnotateContext {
+	readonly members: ReadonlyArray<WorkspaceMember>;
+	/** Absolute repo root, when known — only used to make an absolute diagnostic path repo-relative. */
+	readonly root?: string;
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching SGR escapes is the point.
+const ANSI_SGR = /\u001b\[[0-9;]*m/g;
+
+const PLAIN = /^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s*(.*)$/;
+const PRETTY = /^(.+?):(\d+):(\d+)\s+-\s+(error|warning)\s+(TS\d+):\s*(.*)$/;
+
+const strip = (raw: string): string => raw.replace(ANSI_SGR, "").trimEnd();
+
+/**
+ * Strip a `<package-name>:<task>: ` turbo prefix, returning the bare diagnostic text plus
+ * the repo-relative dir its paths are relative to (`undefined` when there was no prefix —
+ * the caller then falls back to the enclosing group's package, if any).
+ */
+const stripTurboPrefix = (
+	line: string,
+	members: ReadonlyArray<WorkspaceMember>,
+): {readonly text: string; readonly base: string | undefined} => {
+	for (const member of members) {
+		const marker = `${member.name}:`;
+		if (!line.startsWith(marker)) continue;
+		const rest = line.slice(marker.length);
+		const taskEnd = rest.indexOf(": ");
+		if (taskEnd === -1) continue;
+		return {text: rest.slice(taskEnd + 2), base: member.dir};
+	}
+	return {text: line, base: undefined};
+};
+
+/**
+ * In turbo's grouped mode (what CI gets) a `<package-name>:<task>` header — bare or as a
+ * `::group::` — opens a run of UNPREFIXED lines belonging to that package. Returns the
+ * package's dir when `raw` opens such a group, `""` when it closes one, else `undefined`.
+ */
+export const groupBaseFor = (
+	raw: string,
+	members: ReadonlyArray<WorkspaceMember>,
+): string | undefined => {
+	const text = strip(raw)
+		.trimStart()
+		.replace(/^::group::/, "");
+	if (text === "::endgroup::") return "";
+	for (const member of members) {
+		// `<name>:<task>` / `<name>#<task>` and nothing else — a per-line prefix has content after it.
+		if (new RegExp(`^${escapeRegExp(member.name)}[:#][A-Za-z0-9_.-]+$`).test(text)) {
+			return member.dir;
+		}
+	}
+	return undefined;
+};
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const repoRelative = (file: string, base: string, root: string | undefined): string => {
+	const normalized = file.replace(/\\/g, "/").replace(/^\.\//, "");
+	if (normalized.startsWith("/")) {
+		if (root === undefined) return normalized;
+		const prefix = root.endsWith("/") ? root : `${root}/`;
+		return normalized.startsWith(prefix) ? normalized.slice(prefix.length) : normalized;
+	}
+	return base === "" ? normalized : `${base}/${normalized}`;
+};
+
+/**
+ * Parse one output line into a diagnostic, or `undefined` when it isn't one. `groupBase` is
+ * the repo-relative dir of the enclosing turbo group, used when the line carries no prefix
+ * of its own.
+ */
+export const parseDiagnostic = (
+	raw: string,
+	context: AnnotateContext,
+	groupBase = "",
+): TscDiagnostic | undefined => {
+	const {text, base} = stripTurboPrefix(strip(raw), context.members);
+	const match = PLAIN.exec(text) ?? PRETTY.exec(text);
+	if (match === null) return undefined;
+	// Every group is non-optional in both patterns, so a match populates all seven; `?? ""`
+	// only discharges `noUncheckedIndexedAccess`, it is not a reachable fallback.
+	const [, file = "", line = "", column = "", severity = "", code = "", message = ""] = match;
+	return {
+		file: repoRelative(file, base ?? groupBase, context.root),
+		line: Number(line),
+		column: Number(column),
+		severity: severity === "warning" ? "warning" : "error",
+		code,
+		message,
+	};
+};
+
+// Workflow-command escaping, per GitHub's documented rules: `%`/CR/LF everywhere, plus
+// `:` and `,` inside a property value (they are the property separators).
+const escapeData = (value: string): string =>
+	value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+
+const escapeProperty = (value: string): string =>
+	escapeData(value).replace(/:/g, "%3A").replace(/,/g, "%2C");
+
+/** Render one diagnostic as the `::error file=…,line=…,col=…::message` workflow command. */
+export const renderWorkflowCommand = (diagnostic: TscDiagnostic): string =>
+	`::${diagnostic.severity} file=${escapeProperty(diagnostic.file)},line=${diagnostic.line},col=${diagnostic.column}::${escapeData(`${diagnostic.code}: ${diagnostic.message}`)}`;
+
+/**
+ * Map a whole captured typecheck output to its workflow commands, in first-seen order and
+ * deduplicated (an `apps/*` package typechecks several overlapping tsconfigs, so the same
+ * diagnostic can surface twice).
+ */
+export const annotationsFor = (output: string, context: AnnotateContext): ReadonlyArray<string> => {
+	const seen = new Set<string>();
+	let groupBase = "";
+	for (const raw of output.split("\n")) {
+		const opened = groupBaseFor(raw, context.members);
+		if (opened !== undefined) {
+			groupBase = opened;
+			continue;
+		}
+		const diagnostic = parseDiagnostic(raw, context, groupBase);
+		if (diagnostic === undefined) continue;
+		seen.add(renderWorkflowCommand(diagnostic));
+	}
+	return [...seen];
+};

--- a/packages/pipeline-cli/src/tools/tsc-annotate/tsc-annotate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/tsc-annotate/tsc-annotate.unit.test.ts
@@ -1,0 +1,182 @@
+import {describe, expect, it} from "vitest";
+import {
+	type AnnotateContext,
+	annotationsFor,
+	parseDiagnostic,
+	renderWorkflowCommand,
+} from "./tsc-annotate.ts";
+
+const ctx: AnnotateContext = {
+	members: [
+		{name: "@kampus/worker-relevance", dir: "packages/worker-relevance"},
+		{name: "@kampus/web", dir: "apps/web"},
+	],
+	root: "/repo",
+};
+
+describe("parseDiagnostic — the turbo-prefixed plain form (what CI actually emits)", () => {
+	// Verbatim from a real `pnpm turbo run typecheck` failure.
+	const line =
+		"@kampus/worker-relevance:typecheck: src/__probe.ts(1,14): error TS2322: Type 'number' is not assignable to type 'string'.";
+
+	it("re-roots the package-relative path onto the package dir", () => {
+		expect(parseDiagnostic(line, ctx)).toEqual({
+			file: "packages/worker-relevance/src/__probe.ts",
+			line: 1,
+			column: 14,
+			severity: "error",
+			code: "TS2322",
+			message: "Type 'number' is not assignable to type 'string'.",
+		});
+	});
+
+	it("renders the workflow command GitHub turns into an inline annotation", () => {
+		expect(renderWorkflowCommand(parseDiagnostic(line, ctx)!)).toBe(
+			"::error file=packages/worker-relevance/src/__probe.ts,line=1,col=14::TS2322: Type 'number' is not assignable to type 'string'.",
+		);
+	});
+});
+
+describe("parseDiagnostic — the other shapes tsc can emit", () => {
+	it("un-prefixed lines are relative to the repo root already", () => {
+		expect(parseDiagnostic("src/a.ts(3,5): error TS1005: ';' expected.", ctx)?.file).toBe(
+			"src/a.ts",
+		);
+	});
+
+	it("accepts the pretty `path:line:col - error` form", () => {
+		expect(
+			parseDiagnostic("@kampus/web:typecheck: src/a.tsx:9:2 - error TS2551: Nope.", ctx),
+		).toEqual({
+			file: "apps/web/src/a.tsx",
+			line: 9,
+			column: 2,
+			severity: "error",
+			code: "TS2551",
+			message: "Nope.",
+		});
+	});
+
+	it("strips ANSI colouring before matching", () => {
+		const esc = String.fromCharCode(27);
+		const colored = `${esc}[96msrc/a.ts${esc}[0m(2,1): ${esc}[91merror${esc}[0m TS2304: Cannot find name 'x'.`;
+		expect(parseDiagnostic(colored, ctx)?.file).toBe("src/a.ts");
+	});
+
+	it("makes an absolute path repo-relative", () => {
+		expect(parseDiagnostic("/repo/apps/web/src/a.ts(1,1): error TS1: x", ctx)?.file).toBe(
+			"apps/web/src/a.ts",
+		);
+	});
+
+	it("carries severity through — a warning annotates as a warning", () => {
+		expect(parseDiagnostic("src/a.ts(1,1): warning TS6133: unused.", ctx)?.severity).toBe(
+			"warning",
+		);
+	});
+
+	it("normalises a leading ./", () => {
+		expect(parseDiagnostic("./src/a.ts(1,1): error TS1: x", ctx)?.file).toBe("src/a.ts");
+	});
+});
+
+describe("parseDiagnostic — non-diagnostic lines are not diagnostics", () => {
+	const nonDiagnostics = [
+		"",
+		"@kampus/web:typecheck: > tsgo -p tsconfig.json",
+		"Found 3 errors in 2 files.",
+		" Tasks:    0 successful, 1 total",
+		"@kampus/web:typecheck: cache bypass, force executing 81ed80673ef6",
+		"::error file=x,line=1,col=1::already an annotation",
+	];
+
+	for (const line of nonDiagnostics) {
+		it(`ignores ${JSON.stringify(line)}`, () => {
+			expect(parseDiagnostic(line, ctx)).toBeUndefined();
+		});
+	}
+});
+
+describe("renderWorkflowCommand — workflow-command escaping", () => {
+	it("escapes %, CR and LF in the message", () => {
+		// A newline in the message would otherwise end the workflow command mid-annotation.
+		expect(
+			renderWorkflowCommand({
+				file: "src/a.ts",
+				line: 1,
+				column: 1,
+				severity: "error",
+				code: "TS1",
+				message: "100% off\r\nnext",
+			}),
+		).toBe("::error file=src/a.ts,line=1,col=1::TS1: 100%25 off%0D%0Anext");
+	});
+
+	it("escapes : and , inside the file property (they separate properties)", () => {
+		expect(
+			renderWorkflowCommand({
+				file: "src/a,b:c.ts",
+				line: 1,
+				column: 1,
+				severity: "error",
+				code: "TS1",
+				message: "x",
+			}),
+		).toBe("::error file=src/a%2Cb%3Ac.ts,line=1,col=1::TS1: x");
+	});
+});
+
+describe("annotationsFor — whole-output mapping", () => {
+	const output = [
+		"@kampus/worker-relevance:typecheck: cache bypass",
+		"@kampus/worker-relevance:typecheck: src/a.ts(1,2): error TS2322: bad.",
+		"@kampus/worker-relevance:typecheck: src/a.ts(1,2): error TS2322: bad.",
+		"@kampus/web:typecheck: src/b.ts(3,4): error TS2304: worse.",
+		" Tasks:    0 successful, 2 total",
+	].join("\n");
+
+	it("emits one annotation per distinct diagnostic, in first-seen order", () => {
+		expect(annotationsFor(output, ctx)).toEqual([
+			"::error file=packages/worker-relevance/src/a.ts,line=1,col=2::TS2322: bad.",
+			"::error file=apps/web/src/b.ts,line=3,col=4::TS2304: worse.",
+		]);
+	});
+
+	// The shape CI actually gets: turbo prints the package header once, then the task's own
+	// lines UNPREFIXED. Without the group fold the path would be annotated repo-root-relative
+	// and the annotation would land on a file that doesn't exist.
+	it("attributes unprefixed lines to the package whose group header opened them", () => {
+		const esc = String.fromCharCode(27);
+		const grouped = [
+			`${esc}[;31m@kampus/worker-relevance:typecheck${esc}[;0m`,
+			"> tsgo -p tsconfig.json",
+			"src/__probe.ts(1,14): error TS2322: Type 'number' is not assignable to type 'string'.",
+			"::group::@kampus/web:typecheck",
+			"src/app.tsx(7,3): error TS2304: Cannot find name 'z'.",
+			"::endgroup::",
+			"src/root.ts(1,1): error TS2307: Cannot find module 'q'.",
+		].join("\n");
+
+		expect(annotationsFor(grouped, ctx)).toEqual([
+			"::error file=packages/worker-relevance/src/__probe.ts,line=1,col=14::TS2322: Type 'number' is not assignable to type 'string'.",
+			"::error file=apps/web/src/app.tsx,line=7,col=3::TS2304: Cannot find name 'z'.",
+			"::error file=src/root.ts,line=1,col=1::TS2307: Cannot find module 'q'.",
+		]);
+	});
+
+	it("a per-line prefix still wins over the enclosing group", () => {
+		const mixed = [
+			"::group::@kampus/web:typecheck",
+			"@kampus/worker-relevance:typecheck: src/a.ts(1,1): error TS1: x",
+		].join("\n");
+		expect(annotationsFor(mixed, ctx)).toEqual([
+			"::error file=packages/worker-relevance/src/a.ts,line=1,col=1::TS1: x",
+		]);
+	});
+
+	it("a clean typecheck produces no annotations", () => {
+		expect(
+			annotationsFor("@kampus/web:typecheck: > tsgo -p tsconfig.json\n Tasks: 2 successful", ctx),
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #3873

## What this does

A failing CI typecheck surfaced only as raw log text, so a repair agent (or a human) had to dig through the `check` job's output to find which file and line broke. tsc has no `--reporter=github` equivalent, but its `path(line,col): error TSxxxx: message` format maps mechanically onto GitHub's `::error file=…,line=…,col=…::` workflow command — the same inline-annotation win the biome step already got in #3872.

`pipeline-cli tsc-annotate map` is a **pass-through filter** on the typecheck step: it streams stdin back to stdout unchanged (the log reads exactly as before, and live) and then re-emits each diagnostic as a workflow command. The CI step becomes:

```yaml
- name: typecheck
  run: |
    set -o pipefail
    pnpm typecheck | node packages/pipeline-cli/src/bin.ts tsc-annotate map
```

## Acceptance criteria

- [x] **A typecheck failure produces inline annotations with file/line, not only log text.** Rehearsed end-to-end against a real induced type error (see below).
- [x] **The check still fails red exactly when tsc fails.** The mapper *always* exits 0 — it is a reporter, not a gate — and `set -o pipefail` carries `pnpm typecheck`'s own exit code. Verified: red run → `PIPELINE_EXIT=2`, clean run → `PIPELINE_EXIT=0` with zero annotations. The mapper can neither swallow a failure nor manufacture one out of its own parse trouble.
- [x] **Local `pnpm typecheck` behaviour/output is unchanged.** The mapping lives in the workflow, not in any package script — exactly like the biome `--reporter=github` flag. Annotating is additionally gated on `GITHUB_ACTIONS` (`--force` opts in locally).
- [x] **Mapper core is unit-tested** — 20 cases over the pure parse/render functions, per the pipeline-cli idiom (pure core + thin Effect bin).

## Rehearsal evidence

Induced a real type error and ran the *exact* CI step over the whole workspace:

```
Failed:    @kampus/worker-relevance#typecheck
 ELIFECYCLE  Command failed with exit code 2.
::error file=packages/worker-relevance/src/__probe.ts,line=1,col=14::TS2322: Type 'number' is not assignable to type 'string'.
PIPELINE_EXIT=2
```

## Two things the rehearsal caught that would otherwise have shipped broken

Both are grounded in observed output, not intuition — and both fail *silently*, which is why they're called out here:

1. **turbo names the owning package in two different ways.** A per-line `<pkg>:<task>: ` prefix when streaming, and — the mode CI actually gets — a group header printed *once* with the task's own lines **unprefixed** under it. Diagnostic paths are relative to the **package** dir while GitHub resolves `file=` against the **repo root**, so a parser that only knew the per-line prefix annotated a package-relative path as if it were repo-relative, and the annotation landed on a file that doesn't exist. The core now folds group headers (bare or `::group::`) into the path resolution; both shapes are unit-tested against verbatim turbo output.
2. **`readFileSync(0)` throws EAGAIN on a non-blocking pipe.** Catching that swallowed the *entire* typecheck log — observed live, intermittently. The reader streams stdin instead and never resolves to an error channel.

## §CP — this PR touches the control plane

- `.github/workflows/ci.yml` — the one §CP path. The edit is a single step: `- run: pnpm typecheck` becomes the two-line `pipefail` pipeline above, plus its rationale comment. Nothing else in the workflow is touched.

Everything else is ordinary `packages/**`:

- `packages/pipeline-cli/src/tools/tsc-annotate/{tsc-annotate.ts,command.ts,tsc-annotate.unit.test.ts}` (new)
- `packages/pipeline-cli/src/registry.ts` (one import + one array entry — the registry's documented extension seam)

This is expected to **bank for code-owner approval** rather than auto-ship.

## Relationship to the sibling lanes

Scoped to the workflow side of the split from #3868. It does **not** touch any file the #3868 lane owns (the shared `::error` annotate helper for the pipeline-cli guards) — the workflow-command rendering here is self-contained rather than depending on unmerged work. Once #3868 lands, `renderWorkflowCommand` and the escaping helpers in `tsc-annotate.ts` are the obvious consolidation target; noted, deliberately not pre-empted.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm --filter @kampus/pipeline-cli test` — 141 files, 1975 tests passing
- End-to-end rehearsal of the CI step, red and green paths (above)
