### PR TITLE
roadmap: Four Pillars arc → done, Geçit → active (arc-flip ritual)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,8 +19,8 @@ Generated top-down view of the roadmap: every **arc** and **campaign** is a node
 %% Nodes = every ## Arcs / ## Campaigns row (styled by state); edges = ## Dependencies rows (#3870).
 flowchart TD
 	subgraph arcs["Arcs"]
-		arc_four_pillars["Four Pillars"]:::active
-		arc_ge_it["Geçit"]:::queued
+		arc_four_pillars["Four Pillars"]:::done
+		arc_ge_it["Geçit"]:::active
 		arc_mecmua_v2["Mecmua v2"]:::queued
 		arc_at_lye["Atölye"]:::done
 	end
@@ -57,14 +57,14 @@ flowchart TD
 
 | Arc | Milestone | State |
 |-----|-----------|-------|
-| Four Pillars | #17 | active |
-| Geçit | #24 | queued |
+| Four Pillars | #17 | done |
+| Geçit | #24 | active |
 | Mecmua v2 | #25 | queued |
 | Atölye | #26 | done |
 
-**Four Pillars** — *active.* Frontend polish and the encoded design system: the four pillars — Performance, Cohesiveness, Usability, Accessibility — made real and enforced (ADR 0162, the design-system manifest). The surface of kamp.us becomes excellent and self-consistent. The nav-IA discipline is mid-flight here.
+**Four Pillars** — *done.* Frontend polish and the encoded design system: the four pillars — Performance, Cohesiveness, Usability, Accessibility — made real and enforced (ADR 0162, the design-system manifest). The surface of kamp.us becomes excellent and self-consistent. The nav-IA discipline is mid-flight here.
 
-**Geçit** — *the passage.* The membrane of the community: onboarding, künye (the reputation DO), and moderation. How a stranger becomes a çaylak, a çaylak becomes a yazar by vouch, and how the community governs itself. The çaylak→yazar journey — undefined today — gets designed here. (The earlier künye milestone folded in.)
+**Geçit** — *active. The passage.* The membrane of the community: onboarding, künye (the reputation DO), and moderation. How a stranger becomes a çaylak, a çaylak becomes a yazar by vouch, and how the community governs itself. The çaylak→yazar journey — undefined today — gets designed here. (The earlier künye milestone folded in.)
 
 **Mecmua v2** — The next chapter of long-form publishing: the Thinking-Machines 3-zone reading layout, and the reading/authoring experience maturing past v1.
 
@@ -85,6 +85,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | §CP Verdict Integrity | #38 | active |
 | Flag Graduation | #39 | active |
 | pipeline-cli Glue Consolidation | #40 | active |
+| Lint-Gate Adoption | #41 | active |
 | Pipeline Anywhere | #35 | active |
 | pipeline-cli @effect/platform migration | #32 | active |
 | Agentic design-system coverage | #33 | done |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,8 @@ flowchart TD
 		camp_cp_verdict_integrity["§CP Verdict Integrity"]:::active
 		camp_flag_graduation["Flag Graduation"]:::active
 		camp_pipeline_cli_glue_consolidation["pipeline-cli Glue Consolidation"]:::active
+		camp_lint_gate_adoption["Lint-Gate Adoption"]:::active
+		camp_pipeline_anywhere["Pipeline Anywhere"]:::active
 		camp_pipeline_cli_effect_platform_migration["pipeline-cli @effect/platform migration"]:::active
 		camp_agentic_design_system_coverage["Agentic design-system coverage"]:::done
 		camp_flag_retirement_adr_0136["Flag Retirement (ADR 0136)"]:::active
@@ -41,11 +43,10 @@ flowchart TD
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
-	ext_pipeline_anywhere["Pipeline Anywhere"]:::external
 	ext_adr_0202["ADR 0202"]:::external
 	ext_triage_rubric["Triage rubric"]:::external
 	ext_3642 --> camp_flag_graduation
-	ext_3833 --> ext_pipeline_anywhere
+	ext_3833 --> camp_pipeline_anywhere
 	ext_adr_0202 --> ext_triage_rubric
 	classDef active fill:#1a7f37,stroke:#116329,color:#ffffff;
 	classDef queued fill:#9a6700,stroke:#7d4e00,color:#ffffff;
@@ -62,7 +63,7 @@ flowchart TD
 | Mecmua v2 | #25 | queued |
 | Atölye | #26 | done |
 
-**Four Pillars** — *done.* Frontend polish and the encoded design system: the four pillars — Performance, Cohesiveness, Usability, Accessibility — made real and enforced (ADR 0162, the design-system manifest). The surface of kamp.us becomes excellent and self-consistent. The nav-IA discipline is mid-flight here.
+**Four Pillars** — *done.* Frontend polish and the encoded design system: the four pillars — Performance, Cohesiveness, Usability, Accessibility — made real and enforced (ADR 0162, the design-system manifest). The surface of kamp.us becomes excellent and self-consistent. The nav-IA discipline landed here.
 
 **Geçit** — *active. The passage.* The membrane of the community: onboarding, künye (the reputation DO), and moderation. How a stranger becomes a çaylak, a çaylak becomes a yazar by vouch, and how the community governs itself. The çaylak→yazar journey — undefined today — gets designed here. (The earlier künye milestone folded in.)
 
@@ -97,7 +98,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 - **Columns** are `Campaign | Milestone | State`, in that order. `Campaign` is the founder-voice name; `Milestone` pins the campaign to its GitHub milestone **by number** (`#N`) — the same row→milestone-by-number binding the roadmap-guard already enforces on `## Arcs`, and that number is the one link to the operational projection. `State` is the lifecycle cell.
 - **`State ∈ {active, done}`** — the symmetric two-state lifecycle. A campaign is `active` while its milestone is draining, and flips to `done` once that milestone is fully drained (its GitHub milestone closed). There is no `queued` state: unlike an arc, a campaign is not sequenced ahead — it opens `active` when the founder starts it and ends `done`, running concurrently with whichever arc is active.
 
-**Mentor Audit** — a security & architecture audit wave (the staff-mentor findings: the karma double-bump race, per-actor rate limiting, ops runbooks, `SECURITY.md`, …). To be solved ASAP; drains via the platform lane alongside Four Pillars.
+**Mentor Audit** — a security & architecture audit wave (the staff-mentor findings: the karma double-bump race, per-actor rate limiting, ops runbooks, `SECURITY.md`, …). To be solved ASAP; drains via the platform lane alongside Geçit.
 
 ## Dependencies
 


### PR DESCRIPTION
## The founding arc closes

Milestone #17 (The Four Pillars) finished tonight at **0 open / 94 closed** — closers PR #3900 and PR #3914, both merged 2026-07-25. Per the arc-flip ritual (pattern: #3853 / #3839):

- `## Arcs` table + mermaid + prose: **Four Pillars → done**, **Geçit → active** (Geçit already at 8 open / 24 closed, fog-charting live on #2471)
- Milestone #17 closed (board side already stamped)
- Bonus coherence fix: added the missing `## Campaigns` row for milestone #41 (**Lint-Gate Adoption**, minted per the founder ruling on #3894) — `roadmap-guard` I3 flagged it during this flip; guard now reports I1–I5 all green (4 arcs + 15 campaigns × 37 milestones)

References #3936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuarU7Ctwdv5Z6sXc1tzKc