### PR TITLE
refactor(pipeline-cli): reconcile gh-phoenix/bin.ts + resolve.ts against the m32 platform sweep (#3934)

### DIFF
--- a/packages/pipeline-cli/src/tools/gh-phoenix/bin.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/bin.ts
@@ -23,9 +23,8 @@
  * before the Effect CLI runtime.
  */
 import {spawnSync} from "node:child_process";
-import {readFileSync} from "node:fs";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command} from "effect/unstable/cli";
 import {isZeroScope, lintCorpus, type ScanFile} from "./lint.ts";
@@ -77,8 +76,16 @@ class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()(
 ) {}
 class ZeroScope extends Schema.TaggedErrorClass<ZeroScope>()("@kampus/gh-phoenix/ZeroScope", {}) {}
 
-const readFileOrSkip = (file: string): Effect.Effect<string | null> =>
-	Effect.try(() => readFileSync(file, "utf8")).pipe(Effect.orElseSucceed(() => null));
+/**
+ * Read one corpus file through the Effect `FileSystem` seam (over this bin's
+ * `NodeServices.layer`, .patterns/effect-platform-access.md) — an unreadable file still
+ * degrades to `null`, which the caller skips, so it never enters the scanned scope and the
+ * zero-scope fail-closed stays the only refusal. Mirrors `command.ts`'s `readFileOrSkip`.
+ */
+const readFileOrSkip = (file: string): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(file, "utf8")).pipe(
+		Effect.orElseSucceed((): string | null => null),
+	);
 
 const fileArg = Argument.string("file").pipe(
 	Argument.atLeast(1),

--- a/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
@@ -10,6 +10,17 @@
  * injectable (default `selfPath`) so the self-skip is testable independent of the
  * runtime's `argv[1]`. `resolveRepo` resolves the repo the REST rewrites target:
  * `$CLAUDE_PIPELINE_REPO`, else `gh repo view`, else the phoenix default.
+ *
+ * **Exempt from the epic #3462 `@effect/platform` sweep, adjudicated in #3934.** The raw
+ * `node:fs` / `node:path` here is the bin-boundary case of
+ * .patterns/effect-platform-access.md § "The bright line": every consumer is `bin.ts`'s
+ * `runShim`, a *pre-Effect-runtime* argv dispatch that short-circuits before
+ * `NodeRuntime.runMain`, so there is no runtime and no `NodeServices.layer` in scope to
+ * `yield*` a service from. It is also synchronous by contract — `fileExists` is injected
+ * into the sync `route` core as `bodyFileExists`, and `selfPath` is computed at module load
+ * — so an effectful `FileSystem`/`Path` would have to make the router seam effectful to
+ * reach it. The raw calls stay at this boundary and are never woven through a service
+ * method, which is exactly what the bright line permits.
  */
 import {execFileSync} from "node:child_process";
 import {accessSync, constants, realpathSync} from "node:fs";


### PR DESCRIPTION
Two files in the `gh-phoenix` tool directory were left on raw `node:fs` by the milestone-32 platform-migration wave — they appeared in none of the five children's file lists, so the epic would have read as a finished sweep with no record of whether they were missed or deliberately kept raw. This reconciles them: the one read that genuinely belongs on the Effect `FileSystem` seam is migrated, and the one that belongs at the pre-runtime boundary now carries its exemption in the file, citing the bright line it rests on.

### What changed

- **`packages/pipeline-cli/src/tools/gh-phoenix/bin.ts` — migrated.** `readFileOrSkip` (`readFileSync`) runs inside the Effect CLI path of `lint-skills`, where `NodeServices.layer` is already provided, so it now reads through `FileSystem.FileSystem` — the same shape the sibling `command.ts` landed under #3473. The `node:fs` import is gone. The `gh` shim path is untouched: it is a pre-Effect-runtime argv dispatch that must inherit stdio and pass through the real `gh`'s exit code, and its `spawnSync` is `node:child_process`, outside the wave's fs/os/path scope.
- **`packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts` — exempt, now on the record.** Every consumer is the shim's `runShim`, which short-circuits *before* `NodeRuntime.runMain`, so there is no runtime and no `NodeServices.layer` in scope to yield a service from; the calls are also synchronous by contract (`fileExists` is injected into the sync `route` core as `bodyFileExists`, `selfPath` is computed at module load). That is the bin-boundary case of `.patterns/effect-platform-access.md` § "The bright line" — raw `node:*` kept at a boundary, never woven through a service method. The rationale lives in the file's docblock, pointing at the pattern doc and this issue.

### Behavior is unchanged — established differentially, not from the diff

This wave shipped fail-open regressions where a `Dirent.isDirectory()` → `fs.stat` swap silently widened a walk, so the current behavior was measured rather than reasoned about. The real bin was run over identical fixtures before and after the change, across every branch of the read path:

| case | before | after |
|---|---|---|
| clean skill file | exit 0, scanned 1 | exit 0, scanned 1 |
| missing file | exit 3 (zero-scope FAIL) | exit 3 (zero-scope FAIL) |
| directory argument | exit 3 (zero-scope FAIL) | exit 3 (zero-scope FAIL) |
| directory + clean file | exit 0, scanned 1 | exit 0, scanned 1 |

stdout, stderr and exit codes are byte-identical. The directory-argument case is the local analogue of the lstat-vs-stat class: a directory still degrades to a skip, so it never enters the scanned scope and the ADR 0092 exit-3 fail-closed stays the only refusal. No traversal and no guard exit-code path is otherwise touched by this diff.

`pnpm --filter @kampus/pipeline-cli test` is green (142 files, 2003 tests), as are `pnpm typecheck` and `pnpm lint:worktree`. The `resolve.ts` injectable-seam unit tests pass unchanged.

### The wave-completeness check

Re-running the enumeration that sized the epic — raw `node:fs`/`node:os`/`node:path` production imports under `packages/pipeline-cli/**` and `packages/pipeline-crew-mcp/**`, excluding `*.test.ts` — against this head shows `gh-phoenix/resolve.ts` as the only remaining `gh-phoenix` entry, now with a recorded reason. The wider remainder is **not** empty: it still covers the design/docs/roadmap cluster that child #3470 owns (open), the stdin fd-0 sites tracked separately, and a further set of tools in no child's list. That last group is beyond this issue's scope and is filed separately rather than folded in here.

§CP: this diff is `packages/pipeline-cli/**`, so it banks for a control-plane approval and does not auto-ship.

Fixes #3934
Relates to #3462
