### PR TITLE
fix(crew-mcp): degrade an unresolvable LookupClaim to the broadcast fan (#3977)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/tracker.protocol-skew.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.protocol-skew.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The host/dialer protocol-skew regression (#3977): a long-lived tracker host that predates a
+ * protocol-kind addition serves an RPC group without the new tag, so every claim-aware
+ * `EngineNudge` sent by a newer client issued `LookupClaim` into it and got `Unknown request tag:
+ * LookupClaim` back — a defect that killed the whole nudge edge instead of degrading.
+ *
+ * The skew is real here, not stubbed: a live `RpcServer` serves the PRE-#3890 five-kind group while
+ * the client speaks the current six-kind `TrackerRegistry`, wired to each other in memory the way
+ * `RpcTest.makeClient` wires a matched pair. The two transport hops therefore cross two different
+ * Rpc unions — that mismatch IS the subject under test, so each hop casts once.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Context, Effect, Exit, Layer} from "effect";
+import {RpcClient, RpcGroup, RpcServer} from "effect/unstable/rpc";
+import {type Connect, Dialer, Inbox, PeerUnreachableError, Tracker} from "../peer/index.ts";
+import * as Peer from "../peer/peer.ts";
+import {AnnouncePresence, Claim, Heartbeat, LookupRole, Release} from "../protocol/index.ts";
+import {RegistryLive, TrackerHandlers, TrackerRegistry} from "../tracker/index.ts";
+import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
+
+/** The registry group a pre-#3890 tracker host serves: the five kinds it booted with, no `LookupClaim`. */
+const PreClaimLookupRegistry = RpcGroup.make(
+	Claim,
+	Release,
+	AnnouncePresence,
+	LookupRole,
+	Heartbeat,
+);
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+
+/**
+ * A client of the CURRENT `TrackerRegistry` talking to a server of the PRE-#3890 group — the
+ * skewed pair. `LookupClaim` reaches a server whose `group.requests` has no such tag, which is
+ * where `RpcServer` answers `Exit.die("Unknown request tag: LookupClaim")`.
+ */
+const skewedRegistryClient = Effect.gen(function* () {
+	const toClient: {current: (response: unknown) => Effect.Effect<void>} = {
+		current: () => Effect.die("skew harness: the tracker answered before the client was wired"),
+	};
+	const server = yield* RpcServer.makeNoSerialization(PreClaimLookupRegistry, {
+		onFromServer: (response) => toClient.current(response),
+	});
+	const client = yield* RpcClient.makeNoSerialization(TrackerRegistry, {
+		supportsAck: true,
+		onFromClient: ({message}) => server.write(0, message as Parameters<typeof server.write>[1]),
+	});
+	toClient.current = client.write as (response: unknown) => Effect.Effect<void>;
+	return client.client;
+});
+
+const buildInbox = (id: string) =>
+	Layer.build(Inbox.layer(id)).pipe(Effect.map((ctx) => Context.get(ctx, Inbox)));
+
+describe("crew/tracker — a claim-aware send survives a skewed tracker host (#3977)", () => {
+	it.effect("LookupClaim into a pre-#3890 host dies with the reported unknown-tag defect", () =>
+		Effect.gen(function* () {
+			const client = yield* skewedRegistryClient;
+			const exit = yield* Effect.exit(client.LookupClaim({resource: "pr-3951"}));
+			assert.isTrue(Exit.isFailure(exit), "the skewed host rejects the tag it never registered");
+			if (Exit.isFailure(exit)) {
+				assert.include(String(Cause.squash(exit.cause)), "Unknown request tag: LookupClaim");
+			}
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect(
+		"an EngineNudge about a claimed PR still DELIVERS — it degrades to the broadcast fan",
+		() =>
+			Effect.scoped(
+				Effect.gen(function* () {
+					const headSeat = yield* buildInbox("em-head");
+					const ownerSeat = yield* buildInbox("em-owner");
+					const connect: Connect = (address) =>
+						address === "addr-head"
+							? Effect.succeed({Deliver: headSeat.deliver})
+							: address === "addr-owner"
+								? Effect.succeed({Deliver: ownerSeat.deliver})
+								: Effect.fail(new PeerUnreachableError({target: address, reason: "no route"}));
+					const client = yield* skewedRegistryClient;
+
+					yield* Effect.gen(function* () {
+						const tracker = yield* Tracker;
+						// peer-id ≡ inbox-address in the crew binding, so a seat announces at its dialable address.
+						yield* tracker.announce({
+							role: "engineering-manager",
+							peer: "addr-head",
+							address: "addr-head",
+						});
+						yield* tracker.announce({
+							role: "engineering-manager",
+							peer: "addr-owner",
+							address: "addr-owner",
+						});
+						const cos = yield* Peer.make({
+							self: "cos",
+							role: "chief-of-staff",
+							address: "addr-cos",
+						});
+						// The exact reported send: cartographer/chief-of-staff → an engine role, kind EngineNudge,
+						// target a PR — the only kind that derives a claim key. Before the fix this died with
+						// `Unknown request tag: LookupClaim`; now the unresolvable claim keeps the #3770 fan.
+						const ack = yield* cos.send(
+							"engineering-manager",
+							"EngineNudge",
+							{
+								target: {pr: 3951},
+								from: "cartographer",
+								note: "look at this",
+								at: new Date().toISOString(),
+							},
+							{claimResource: "pr-3951"},
+						);
+						assert.isString(ack.by, "the send resolved to a delivery receipt, not a defect");
+						assert.lengthOf(yield* headSeat.received, 1, "head seat received the nudge");
+						assert.lengthOf(
+							yield* ownerSeat.received,
+							1,
+							"the other seat received it too — a full fan",
+						);
+					}).pipe(
+						Effect.provide([
+							peerTrackerLayer.pipe(Layer.provide(CrewTracker.fromClient(client))),
+							Inbox.layer("cos"),
+							Dialer.layerFromConnect(connect),
+						]),
+					);
+				}).pipe(Effect.provide(registryHandlers)),
+			),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
@@ -10,14 +10,14 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Cause, Context, Effect, Layer} from "effect";
+import {Cause, Context, Effect, Layer, Logger, Option} from "effect";
 import {RpcTest} from "effect/unstable/rpc";
 import {SocketServerError, SocketServerOpenError} from "effect/unstable/socket/SocketServer";
 import {TrackerRegistry} from "../tracker/group.ts";
 import {TrackerHandlers} from "../tracker/handlers.ts";
 import {isTrackerAddressInUse} from "../tracker/index.ts";
 import {RegistryLive} from "../tracker/registry.ts";
-import {CrewTracker, crewTrackerHostOrDialLayer} from "./tracker.ts";
+import {CrewTracker, crewTrackerHostOrDialLayer, type TrackerRegistryClient} from "./tracker.ts";
 
 const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
 
@@ -121,6 +121,91 @@ describe("crew/tracker — acquireClaim + release (the claim lifecycle client, A
 			});
 			assert.isTrue(reclaim.granted, "the explicitly-released resource is free");
 		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});
+
+/**
+ * Capture warn-level log lines for the duration of `effect`, so a test can assert the degrade was
+ * announced rather than silently absorbed. The head is the first `logWarning` argument (its message
+ * template); the `Cause` argument is not serialized. Mirrors the same helper in `Flags.unit.test.ts`.
+ */
+const captureWarnings = <A, E, R>(
+	effect: Effect.Effect<A, E, R>,
+): Effect.Effect<{value: A; warnings: ReadonlyArray<string>}, E, R> =>
+	Effect.suspend(() => {
+		const lines: string[] = [];
+		const capture = Logger.layer([
+			Logger.make(({logLevel, message}) => {
+				if (logLevel !== "Warn") return;
+				lines.push(String(Array.isArray(message) ? message[0] : message));
+			}),
+		]);
+		return effect.pipe(
+			Effect.provide(capture),
+			Effect.map((value) => ({value, warnings: lines as ReadonlyArray<string>})),
+		);
+	});
+
+const unexercised = (kind: string) => () =>
+	Effect.die(`${kind} not exercised in the claimHolder degrade tests`);
+
+/** A registry client whose `LookupClaim` is the only exercised kind, and whose answer the test picks. */
+const clientWhoseLookupClaimIs = (
+	lookupClaim: TrackerRegistryClient["LookupClaim"],
+): TrackerRegistryClient => ({
+	Claim: unexercised("Claim"),
+	Release: unexercised("Release"),
+	AnnouncePresence: unexercised("AnnouncePresence"),
+	LookupRole: unexercised("LookupRole"),
+	Heartbeat: unexercised("Heartbeat"),
+	LookupClaim: lookupClaim,
+});
+
+const claimHolderOver = (lookupClaim: TrackerRegistryClient["LookupClaim"], resource: string) =>
+	Effect.scoped(
+		Layer.build(CrewTracker.fromClient(clientWhoseLookupClaimIs(lookupClaim))).pipe(
+			Effect.flatMap((ctx) => Context.get(ctx, CrewTracker).claimHolder(resource)),
+		),
+	);
+
+describe("crew/tracker — claimHolder degrades an unresolvable lookup to None (#3977)", () => {
+	it.effect(
+		"an RpcServer unknown-tag DEFECT (a tracker host older than the LookupClaim kind) resolves None, never a die",
+		() =>
+			Effect.gen(function* () {
+				// The exact shape a pre-#3890 tracker host answers with: RpcServer has no handler for the
+				// tag, so it replies `Exit.die("Unknown request tag: LookupClaim")` — a DEFECT the former
+				// `Effect.orDie` could not catch, which is why the whole nudge edge failed hard.
+				const {value, warnings} = yield* captureWarnings(
+					claimHolderOver(() => Effect.die("Unknown request tag: LookupClaim"), "pr-3951"),
+				);
+				assert.isTrue(Option.isNone(value), "an unresolvable claim reads as unclaimed");
+				assert.lengthOf(warnings, 1, "the degrade is observable, not silent");
+				assert.include(warnings[0] ?? "", "pr-3951", "the warn names the resource it gave up on");
+			}),
+	);
+
+	it.effect("a typed transport failure degrades the same way (one policy, not two)", () =>
+		Effect.gen(function* () {
+			const {value, warnings} = yield* captureWarnings(
+				claimHolderOver(() => Effect.fail("socket closed"), "issue-3977"),
+			);
+			assert.isTrue(Option.isNone(value));
+			assert.lengthOf(warnings, 1);
+		}),
+	);
+
+	it.effect("a resolved holder is unaffected — the degrade only fires on a failed lookup", () =>
+		Effect.gen(function* () {
+			const {value, warnings} = yield* captureWarnings(
+				claimHolderOver(
+					({resource}) => Effect.succeed({resource, holder: "inbox://em-owner"}),
+					"pr-3951",
+				),
+			);
+			assert.deepStrictEqual(value, Option.some("inbox://em-owner"));
+			assert.lengthOf(warnings, 0, "a healthy lookup logs nothing");
+		}),
 	);
 });
 

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -8,6 +8,8 @@
  *   - A tracker transport failure is unrecoverable for a session, so the registry client's
  *     transport errors are collapsed with `Effect.orDie` — the service's own error channel
  *     stays clean (only a resource collision, which is a VALUE in `ClaimReply`, crosses it).
+ *     `claimHolder` is the one exception: it is an ADVISORY read, so it degrades instead of
+ *     dying (its note below, #3977).
  *   - The crew binds peer-id ≡ inbox-address: the registry stores one `peer` field per
  *     presence, so the announced `peer` IS the dialable inbox address, and a lookup recovers
  *     that address back out (matching the `inbox://…` convention the tracker socket test uses).
@@ -99,9 +101,10 @@ export class CrewTracker extends Context.Service<
 		 */
 		readonly lookup: (role: string) => Effect.Effect<ReadonlyArray<RolePresence>>;
 		/**
-		 * The live holder of `resource` (its peer-id ≡ inbox-address), or `None` when it is unclaimed
-		 * or its holder's presence has lapsed (ADR 0191 facet 2). The claim-keyspace read the
-		 * claim-aware send path consults to route a nudge about a claimed target to its owning seat.
+		 * The live holder of `resource` (its peer-id ≡ inbox-address), or `None` when it is unclaimed,
+		 * its holder's presence has lapsed (ADR 0191 facet 2), or the lookup itself was unresolvable.
+		 * The claim-keyspace read the claim-aware send path consults to route a nudge about a claimed
+		 * target to its owning seat — advisory, so every `None` collapses to the broadcast fan.
 		 */
 		readonly claimHolder: (resource: string) => Effect.Effect<Option.Option<string>>;
 	}
@@ -170,10 +173,24 @@ export class CrewTracker extends Context.Service<
 				),
 			// peer-id ≡ inbox-address: the resolved holder IS its own dialable address, so the send
 			// path can match it against the live holder set. Absent `holder` ⇒ unclaimed/lapsed ⇒ `None`.
+			//
+			// A FAILED lookup also resolves `None`, so the send degrades to the #3770 broadcast fan
+			// rather than dying — claim-aware routing is an advisory latency optimization, and the
+			// documented intent is that any unresolvable claim keeps the fan. `catchCause`, not the
+			// former `Effect.orDie`, because the failure that actually bit is a DEFECT and `orDie`
+			// could never catch it: a tracker host that outlives a protocol-kind addition has no
+			// handler for the new tag, and `RpcServer` answers with an `Unknown request tag` die, which
+			// turned the whole nudge edge into a deterministic hard failure (#3977). The warn keeps a
+			// skewed host from silently disabling claim-aware routing forever.
 			claimHolder: (resource) =>
 				client.LookupClaim({resource}).pipe(
-					Effect.orDie,
 					Effect.map((result) => Option.fromNullishOr(result.holder)),
+					Effect.catchCause((cause) =>
+						Effect.logWarning(
+							`crew/tracker: LookupClaim for "${resource}" failed — degrading to the broadcast fan`,
+							cause,
+						).pipe(Effect.as(Option.none<string>())),
+					),
 				),
 		});
 }

--- a/packages/pipeline-crew-mcp/src/peer/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/peer/tracker.ts
@@ -39,8 +39,11 @@ export class Tracker extends Context.Service<
 		 */
 		readonly lookup: (role: string) => Effect.Effect<ReadonlyArray<RolePresence>>;
 		/**
-		 * The live holder's dialable address for a claimed `resource`, or `None` when it is unclaimed
-		 * or its holder's presence has lapsed (ADR 0191 facet 2). `resource` is an OPAQUE key — the
+		 * The live holder's dialable address for a claimed `resource`, or `None` when it is unclaimed,
+		 * its holder's presence has lapsed (ADR 0191 facet 2), or the lookup was unresolvable (a
+		 * skewed or failing registry — the impl degrades rather than dying, see `crew/tracker.ts`'s
+		 * `claimHolder`). The error channel is `never` BY CONTRACT: an advisory read may not fail a
+		 * send. `resource` is an OPAQUE key — the
 		 * port has no message semantics; the caller supplies the key (the crew maps a `NudgeTarget`
 		 * to `pr-N`/`issue-N`). `send` consults this to route a claimed target to its holder's seat,
 		 * falling back to the broadcast fan on `None` — so claim-aware delivery stays a strict subset


### PR DESCRIPTION
Sending an `EngineNudge` between crew seats has been failing every time with a raw `Unknown request tag: LookupClaim`, so one of the crew's coordination edges was down. The cause is that the nudge send asks the tracker "who already holds this PR?" to route the message to the seat that owns it — and when that question can't be answered, the send died instead of just falling back to telling everyone. This makes it fall back, and says so in the log, so a nudge always gets through.

## What was wrong

`EngineNudge` is the only kind that derives a claim-resource key (`Protocol.claimResourceKey`), so it is the only kind whose send calls `tracker.claimHolder` → `LookupClaim`. That call was `Effect.orDie`'d — which could never catch the failure that actually bit: a tracker host that outlives a protocol-kind addition has no handler for the new tag, and effect's `RpcServer` answers with an `Unknown request tag` **defect**, not a typed error. An advisory latency optimization therefore became a deterministic hard failure of the whole nudge edge, and any future protocol-kind addition replays it against every tracker host that outlives a deploy.

## The fix

`claimHolder` (`packages/pipeline-crew-mcp/src/crew/tracker.ts`) now `catchCause`es the lookup — covering a defect **and** a typed failure with one policy — logs a warn naming the resource it gave up on, and resolves `None`. The send path already treats `None` as "no owning seat", so it keeps the #3770 broadcast fan across the role's live holders. That is exactly what the port and send docblocks already documented for an unresolvable claim; the code just didn't do it. `absent holder ⇒ broadcast` is preserved unchanged — an absent `holder` key still maps to `None` via the same `Option.fromNullishOr`, and no claim-key construction was touched (`nudgeTargetResourceKey` keeps its single home in `protocol/schema.ts`).

Docblocks updated at the two ports (`crew/tracker.ts`, `packages/pipeline-crew-mcp/src/peer/tracker.ts`) to name the third `None` case; the *why* is stated once, at `claimHolder`.

## Coverage — all three fail on the pre-fix code with the reported error

- `packages/pipeline-crew-mcp/src/crew/tracker.protocol-skew.test.ts` — a **real skew**, not a stub: a live `RpcServer` serving the pre-#3890 five-kind group behind a client speaking the current six-kind `TrackerRegistry`. One case asserts the skewed host really does answer `Unknown request tag: LookupClaim`; the other sends the exact reported `EngineNudge` (target `{pr: 3951}`, an engine role with two live seats) and asserts it still delivers to **both** seats — the degrade.
- `packages/pipeline-crew-mcp/src/crew/tracker.test.ts` — unit coverage of the degrade: an unknown-tag defect and a typed transport failure both resolve `None` and emit exactly one warn naming the resource; a healthy lookup logs nothing and still resolves its holder.

Verified pre-fix by reverting `claimHolder` to `Effect.orDie` — all three fail, two with the literal `Unknown request tag: LookupClaim`. `pnpm typecheck`, `pnpm lint:worktree`, and the full package suite (51 files / 389 tests) are green.

Not in scope: restarting the standing tracker daemon (the operational half), and a tracker version/capability handshake. This is the client-side class fix the issue asked for — a skewed host now degrades observably instead of crashing the edge.

Fixes #3977