### PR TITLE
fix(pipeline): thread the claim token through repair dispatches, supersede dead claimants (#3751)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -443,6 +443,15 @@ async function drive() {
 			`Repair PR #${pr}. You are the coder in REPAIR mode — consume the gate's latest FAIL verdict on PR #${pr}, ` +
 				`fix the issues on the existing branch, and re-push so the stateless gate re-runs. Do not write a PASS and ` +
 				`do not merge. ` +
+				// A repair dispatch MUST carry the lane's claim token, or the coder's Step-3.5 mis-attribution
+				// guard resolves the issue's claim to a session that is not its own and can neither authorize
+				// nor refuse the repair — the fail-open judgment call of #3751. This lane was claimed pre-spawn
+				// above, so the same delegated token covers the repair rounds.
+				`NOTE: this lane was claimed pre-spawn per ADR 0115 §3 — your delegated claim token is ` +
+				`"${claim.token}". Use it as MY_CLAIM for the Step-3.5 mis-attribution guard; the claim comment ` +
+				`whose session id equals this token is YOURS, so do NOT re-race or post a second claim. If the ` +
+				`guard still refuses (the token is not the earliest live authorized claim on the linked issue), ` +
+				`STOP and report the refusal — do not repair on a corroborated-brief judgment call. ` +
 				`Return { pr: ${pr}, headSha: "<new head commit sha after the repair push>" }.`,
 			{ agentType: "coder", isolation: "worktree", schema: repairSchema },
 		));

--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -35,6 +35,10 @@ the resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 - **Repair a FAIL'd PR.** "Repair PR #N" / "fix the FAIL on #N" — enter the skill's
   repair mode: consume the gate's latest FAIL verdict, fix on the existing branch, push
   so the stateless gate re-runs, then stop. You never write the PASS and never merge.
+  A repair dispatch **must hand you the lane's claim token** (skill Step R0): with no token, or
+  with a token the Step-3.5 guard refuses, you **stop and report the refusal** — never proceed
+  because the dispatch brief looked explicit or because the PR/branch/issue/verdict corroborate
+  each other (that is dispatch coherence, not lane ownership — #3751).
 
 ## Standing invariants — baked in, not advisory
 

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2613,8 +2613,18 @@ markers (§5/§6) are. Its **canonical grammar**:
 
 ```
 claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC>
+claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC> · presence <host-fingerprint>/<session-pid>
 ```
 
+- **The optional `presence` stamp** names the claiming **session process** (the long-lived
+  `claude` ancestor of whatever posted the claim) and an opaque **fingerprint** of its host (a
+  truncated hash — liveness only ever asks "is this my host?", and a machine name has no business
+  in a public timeline). It exists so a later
+  reader can *probe* this claimant's liveness instead of guessing — see
+  [Dead-claimant supersession](#dead-claimant-supersession-proven-death-only-adr-0191). It is
+  written by `pipeline-cli tracker claim` and is **optional**: an unresolvable session stamps
+  nothing, and an unstamped marker reads as indeterminate (⇒ still a valid owner), so legacy
+  markers keep their exact old meaning.
 - **Token source:** the claiming process's `CLAUDE_CODE_SESSION_ID` environment variable
   (the orchestrator's when it claims pre-spawn; the coder's when `write-code` is invoked
   directly — see §The pre-spawn claim protocol).
@@ -2738,11 +2748,51 @@ so closing it means claiming before any branch, build, or spawn:
 ### Staleness / reclaim — owner-defer (ADR 0115 §5)
 
 A claim whose agent crashed mid-run is **sticky until a human clears it** (un-assigns the
-issue / removes the claim, re-opening it to the picker). Automatic TTL/hybrid reclaim is an
-**explicitly deferred follow-up** — GitHub exposes no TTL primitive, and an automated
-reclaim risks evicting a slow-but-live agent, re-introducing the exact double-implement this
-design prevents. The marker's `<ISO-8601-UTC>` field (and server `created_at`) is the field
-a future policy would key on, so the marker is forward-compatible without committing now.
+issue / removes the claim, re-opening it to the picker) **unless its claimant is provably
+dead** (the next subsection). Automatic **age/TTL-based** reclaim remains an explicitly
+deferred follow-up — GitHub exposes no TTL primitive, and an age-keyed reclaim risks evicting
+a slow-but-live agent, re-introducing the exact double-implement this design prevents. That
+hazard is about *time*, not *liveness*: a claim superseded on **proven claimant death** cannot
+evict a live agent, which is why supersession is permitted where a TTL is not.
+
+<a id="dead-claimant-supersession-proven-death-only-adr-0191"></a>
+### Dead-claimant supersession — proven death only (ADR 0191 presence liveness)
+
+A claim whose claimant is **provably dead** is **superseded**: it drops out of the
+earliest-authorized-claim tiebreak, so the earliest **live-or-indeterminate** authorized claim
+is the owner. Without this, a dead session's older marker shadows every later legitimate claim
+forever — which made the `write-code` mis-attribution guard *unrunnable* on an orchestrated
+repair of an abandoned lane: even an engine that correctly re-claimed the lane in its own
+session lost to the dead claimant's earlier marker, so the guard could neither authorize nor
+refuse and degraded into a per-agent judgment call (#3751).
+
+Liveness is **presence-derived, never age-derived** (ADR
+[0191](https://github.com/kamp-us/phoenix/blob/main/.decisions/0191-crew-claim-lifecycle.md) — a
+claim's liveness rides its holder's presence; the same identification `worktree-reap` makes):
+the marker's `presence <host-fingerprint>/<session-pid>` stamp names the claimant's session
+process, and a reader on that host probes it. **Dead requires all three** — a stamp, a host match, and a pid
+the probe proves gone. Every other state is **indeterminate and counts as a live claim**: an
+unstamped/legacy marker, a claim stamped on another host, a pid that still resolves, and a
+reused pid all leave the claim standing, so the reader refuses. Doubt refuses; it never evicts.
+
+Both the resolution and the probe live in the shared verb — `pipeline-cli claim is-mine`
+(default-deny) and `pipeline-cli tracker claim` (which also stops deferring to a dead claimant,
+so a legitimate re-claim can land) — never a per-skill re-derivation. The verb prints the
+superseded claims next to the resolved owner, so "why is a later claim the owner?" is answerable
+from the run log.
+
+### Repair dispatches thread the lane's claim token
+
+A **repair** dispatch is the class this contract is easiest to violate on: it lands on a lane
+someone else opened, so the earliest authorized claim is by default *not* the repairing run's
+session. Every repair dispatcher **MUST** thread the lane's claim token into the coder's prompt
+under the same delegated-ownership contract as the initial build (§The pre-spawn claim protocol):
+the orchestrator threads the token it claimed pre-spawn; a crew engine re-driving a stalled lane
+**claims the lane in its own session first** (`pipeline-cli tracker claim <issue>`, which now
+supersedes a dead claimant) and threads *that* token. A repair coder handed no token **refuses**
+— deterministically, and not overridably by a coherent-looking dispatch brief (`write-code`
+Step R0). There is no repair-specific claim mechanism, and an unthreaded repair is a dispatcher
+bug to route back, not an ambiguity for the coder to resolve.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -548,10 +548,24 @@ claim_is_mine "<N>" && gh api repos/$REPO/issues/<N>/comments -f body="…"   # 
 The guard is **fail-closed by construction** — the verb proceeds (exit 0) **only** on positive
 evidence of an authorized claim whose session is `MY_CLAIM`; an absent claim, an unauthorized-only
 claim, and a foreign claim all resolve not-mine and **refuse** (exit non-zero). It is **observable**
-(the verb prints the resolved owner vs `MY_CLAIM` and the outcome reason) and **idempotent** (a
-read-only GET). **Never** route around it by widening the comparison or treating the bare assignee
-as the owner — the assignee is a coarse availability gate only (ADR 0115 §1), and a login-keyed
-ownership check is the degeneracy this guard exists to remove.
+(the verb prints the resolved owner vs `MY_CLAIM`, the outcome reason, and any **superseded**
+dead-claimant claims) and **idempotent** (a read-only GET). **Never** route around it by widening
+the comparison or treating the bare assignee as the owner — the assignee is a coarse availability
+gate only (ADR 0115 §1), and a login-keyed ownership check is the degeneracy this guard exists to
+remove. **A refusal is also never overridable by reasoning**: an explicit-looking dispatch brief,
+or independently re-deriving that the PR/branch/issue/verdict all line up, establishes that the
+*dispatch was coherent* — not *who owns the lane*. Proceeding on that corroboration is what made
+the guard advisory in the field (#3751); the only sanctioned response to a refusal is to stop and
+surface it to whoever dispatched you.
+
+**Ownership resolves against the earliest *live* authorized claim (ADR 0191 supersession).** The
+verb drops a claim whose claimant is **provably dead** — its marker's presence stamp names a
+session process this host can probe, and the process is gone — so a dead session's older marker no
+longer shadows a legitimate later claim on an abandoned lane (the orchestrated-repair case, #3751).
+Supersession needs **positive evidence of death**: an unstamped/legacy marker, a claim stamped on
+another host, and an unprobeable pid all stay indeterminate, still count as owners, and still
+refuse. So the guard's fail-closed direction is unchanged — what changed is that the *legitimate*
+case can now resolve, instead of being permanently unprovable.
 
 > **Which `<N>` to guard at each site.** The guarded number is the **work-target whose mutation
 > could clobber another agent**: Step 5 guards the **issue** you open the PR against; Step 6 the
@@ -1727,6 +1741,46 @@ it never writes a PASS marker, never merges, and the gate re-runs and re-judges 
 commits with fresh eyes. So repair mode does **not** spawn a distinct fixer; the author
 fixing its own PR and an independent gate re-judging it is the firewall, intact.
 
+### Step R0 — A repair dispatch MUST carry a claim token (no token ⇒ refuse, never a judgment call)
+
+Repair is the dispatch class the mis-attribution guard was **inert** on. A repair re-drive
+arrives on a lane someone else opened — often a *new* engine session re-driving a lane whose
+original claimant is gone — so the earliest authorized claim on the linked issue is, by default,
+**not this run's session**. With no token threaded, `claim_is_mine` can neither authorize nor
+refuse the repair on evidence, and two coders on the same wave resolved that ambiguity in
+**opposite** directions (one wrote to the issue, one withheld its progress comment — #3751).
+Fail-open ambiguity is the defect; both halves below close it.
+
+**The dispatcher's obligation.** Whatever dispatches a repair — the orchestrator
+(`.claude/workflows/drive-issue.js`, which threads the token it claimed pre-spawn) or a crew
+engine re-driving a stalled lane (which **claims the lane in its own session first**, via
+`pipeline-cli tracker claim <issue>`, and threads *that* token) — **MUST** thread the lane's
+claim token into the repair prompt, exactly as the initial-build dispatch does (ADR 0115 §3
+delegated ownership). There is no repair-specific token mechanism: it is the same
+`THREADED_CLAIM_TOKEN` contract.
+
+**Your obligation, and the one thing you may not do.** Resolve `MY_CLAIM` per
+[Step 3.5](#mis-attribution-guard) and gate the repair on `claim_is_mine "$N"` against the PR's
+linked issue. If it refuses — no token was threaded, or the threaded token is not the earliest
+**live** authorized claim — **STOP and report the refusal.** You may **not** proceed on the
+strength of an explicit-looking dispatch brief, or on independently corroborating
+PR → branch → `Fixes #N` → the FAIL verdict. That corroboration says the *dispatch was
+coherent*; it says nothing about *who owns the lane*, which is the only question the guard asks.
+Talking yourself past the refusal is the exact failure this step removes: the outcome is
+**deterministic — threaded ⇒ proceed, unthreaded ⇒ refuse** — and the refusal is a routed
+blocker for the dispatcher (it must claim and re-dispatch), never yours to override.
+
+**Why a dead claimant no longer blocks a legitimate re-drive.** The old resolution asserted
+against the *earliest* authorized claim, full stop — so a dead session's marker shadowed every
+later legitimate claim forever, and an engine that correctly re-claimed the lane in its own
+session *still* failed the guard. `pipeline-cli claim is-mine` now treats a claim whose claimant
+is **provably dead** as **superseded** (ADR 0191 presence liveness — the claimant's session
+process is stamped on the marker and probed), so the earliest *live-or-indeterminate* claim wins.
+Supersession requires **positive evidence of death**: an unstamped marker, a claim from another
+host, or an unprobeable pid stays indeterminate, still counts, and the guard still refuses — doubt
+never evicts a slow-but-live agent (the hazard `gh-issue-intake-formats.md` §7's deferred-reclaim
+note protects).
+
 ### Step R1 — Resolve the latest verdict per namespace (mirror `ship-it` Step 2)
 
 Do **not** act on the presence of any FAIL that ever existed. Resolve `review-code`,
@@ -2176,9 +2230,11 @@ indistinguishable from "still FAILing after the cap" to the picker, so the same 
   gate history stay intact.
 - **Mis-attribution guard before every push/comment ([Step 3.5](#mis-attribution-guard)).**
   Confirm the PR's linked issue `#N` carries **your own** claim (`claim_is_mine "$N"` — the
-  orchestrator threads the original claim as `MY_CLAIM` for delegated repair, ADR 0115 §3) before
-  the R2 branch switch and the R3 push/comment, so a mis-dispatched repair never clobbers another
-  agent's live PR (the #1404 class). Fail-closed: an absent or foreign claim refuses.
+  dispatcher threads the lane's claim as `MY_CLAIM` for delegated repair, ADR 0115 §3, mandated by
+  [Step R0](#step-r0--a-repair-dispatch-must-carry-a-claim-token-no-token--refuse-never-a-judgment-call))
+  before the R2 branch switch and the R3 push/comment, so a mis-dispatched repair never clobbers
+  another agent's live PR (the #1404 class). Fail-closed: an absent or foreign claim refuses, and
+  the refusal is **not overridable by a corroborated dispatch brief** (#3751).
 - **Idempotent.** Re-running on an already-fixed / PASS PR (one with no latest FAIL, or one
   whose latest FAIL is bound to a now-stale head) is a clean no-op (Step R1).
 - **SHA-bound verdicts (ADR [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md)).**

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -262,7 +262,14 @@ it adds no engine→engine and no human-facing edge.
 A lane can wedge: a coder that died mid-run, a review never posted, CI stuck red, an enqueue that
 silently dequeued. Track each lane's last-progress signal and treat a lane with no forward motion as
 stalled. Re-drive what you can (re-spawn the coder in repair mode on a red CI or a FAIL; re-request
-the gate on a missing verdict; re-verify a dropped enqueue). A stall you cannot clear is surfaced
+the gate on a missing verdict; re-verify a dropped enqueue). **A repair re-drive claims the lane in
+your own session first, then threads that claim token into the coder's prompt** — `pipeline-cli
+tracker claim <issue>` (which supersedes a provably dead claimant, so an abandoned lane is claimable)
+and then "your delegated claim token is `<token>`" in the spawn prompt, exactly as the initial-build
+dispatch does. A repair dispatch with no token leaves the coder's mis-attribution guard unable to
+either authorize or refuse, which is how one coder wrote to a foreign lane's issue while its sibling
+withheld (#3751); a coder that reports the guard refused is telling you *your dispatch* was
+unclaimed — claim and re-dispatch, never instruct it past the refusal. A stall you cannot clear is surfaced
 **on the board** — leave the issue/PR in a state whose staleness is visible (the unmoving PR, the
 climbing age), not routed to a human. A lane that looks done but never landed is the failure this
 rule exists to catch.

--- a/packages/pipeline-cli/src/tools/claim/claim-is-mine.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-is-mine.ts
@@ -18,6 +18,7 @@ import {
 	type ClaimResolutionInput,
 	type ClaimWinner,
 	resolveClaim,
+	supersededClaims,
 } from "../epic-lock/claim-resolution.ts";
 
 /** Why the decision resolved the way it did — the `resolveClaim` outcome tag, surfaced for observability. */
@@ -31,6 +32,11 @@ export interface ClaimVerdict {
 	readonly reason: ClaimReason;
 	/** The resolved earliest authorized claim, when one exists (`won`/`lost`); `null` when none resolved. */
 	readonly winner: ClaimWinner | null;
+	/**
+	 * The authorized claims dropped as superseded because their claimant is provably dead (ADR
+	 * 0191 presence liveness, #3751) — the audit trail for "why is a later claim the owner?".
+	 */
+	readonly superseded: ReadonlyArray<ClaimWinner>;
 }
 
 /**
@@ -42,14 +48,15 @@ export interface ClaimVerdict {
  */
 export const claimIsMine = (input: ClaimResolutionInput): ClaimVerdict => {
 	const outcome = resolveClaim(input);
+	const superseded = supersededClaims(input.comments, input.authorizedAuthors, input.liveness);
 	switch (outcome._tag) {
 		case "won":
-			return {mine: true, reason: "won", winner: outcome.winner};
+			return {mine: true, reason: "won", winner: outcome.winner, superseded};
 		case "lost":
-			return {mine: false, reason: "lost", winner: outcome.winner};
+			return {mine: false, reason: "lost", winner: outcome.winner, superseded};
 		case "no-winner":
-			return {mine: false, reason: "no-winner", winner: null};
+			return {mine: false, reason: "no-winner", winner: null, superseded};
 		case "no-session":
-			return {mine: false, reason: "no-session", winner: null};
+			return {mine: false, reason: "no-session", winner: null, superseded};
 	}
 };

--- a/packages/pipeline-cli/src/tools/claim/claim-is-mine.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-is-mine.unit.test.ts
@@ -1,5 +1,5 @@
 import {assert, describe, it} from "@effect/vitest";
-import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
+import type {ClaimComment, ClaimLiveness} from "../epic-lock/claim-resolution.ts";
 import {type ClaimVerdict, claimIsMine} from "./claim-is-mine.ts";
 
 const SID_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
@@ -21,6 +21,7 @@ describe("claimIsMine — the issue-scoped default-deny resolver decision", () =
 		readonly comments: ReadonlyArray<ClaimComment>;
 		readonly authorized: ReadonlyArray<string>;
 		readonly sessionId: string | null | undefined;
+		readonly liveness?: ReadonlyMap<number, ClaimLiveness>;
 		readonly expected: ClaimVerdict;
 	}> = [
 		{
@@ -32,6 +33,7 @@ describe("claimIsMine — the issue-scoped default-deny resolver decision", () =
 				mine: true,
 				reason: "won",
 				winner: {session: SID_A, id: 1, createdAt: "2026-07-08T00:00:00Z"},
+				superseded: [],
 			},
 		},
 		{
@@ -46,6 +48,7 @@ describe("claimIsMine — the issue-scoped default-deny resolver decision", () =
 				mine: false,
 				reason: "lost",
 				winner: {session: SID_A, id: 10, createdAt: "2026-07-08T00:00:01Z"},
+				superseded: [],
 			},
 		},
 		{
@@ -53,42 +56,107 @@ describe("claimIsMine — the issue-scoped default-deny resolver decision", () =
 			comments: [comment({id: 5, author: "attacker", body: claim(SID_C)})],
 			authorized: ["usirin"],
 			sessionId: SID_A,
-			expected: {mine: false, reason: "no-winner", winner: null},
+			expected: {mine: false, reason: "no-winner", winner: null, superseded: []},
 		},
 		{
 			name: "FAIL-SAFE: empty authorized set resolves no owner → not-mine (default-deny, never a false win)",
 			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
 			authorized: [],
 			sessionId: SID_A,
-			expected: {mine: false, reason: "no-winner", winner: null},
+			expected: {mine: false, reason: "no-winner", winner: null, superseded: []},
 		},
 		{
 			name: "FAIL-SAFE: missing session id → not-mine (default-deny) even with our own claim present",
 			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
 			authorized: ["usirin"],
 			sessionId: undefined,
-			expected: {mine: false, reason: "no-session", winner: null},
+			expected: {mine: false, reason: "no-session", winner: null, superseded: []},
 		},
 		{
 			name: "FAIL-SAFE: empty-string session id → not-mine (default-deny)",
 			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
 			authorized: ["usirin"],
 			sessionId: "",
-			expected: {mine: false, reason: "no-session", winner: null},
+			expected: {mine: false, reason: "no-session", winner: null, superseded: []},
 		},
 		{
 			name: "FAIL-SAFE: no claim comments at all → not-mine (default-deny)",
 			comments: [],
 			authorized: ["usirin"],
 			sessionId: SID_A,
-			expected: {mine: false, reason: "no-winner", winner: null},
+			expected: {mine: false, reason: "no-winner", winner: null, superseded: []},
+		},
+		{
+			// The #3751 orchestrated-repair case: the dead original claimant's older marker no longer
+			// shadows the re-drive's claim, so the mis-attribution guard can actually resolve MINE.
+			name: "a PROVABLY DEAD earliest claimant is superseded → our later claim wins",
+			comments: [
+				comment({id: 10, author: "usirin", createdAt: "2026-07-20T06:42:00Z", body: claim(SID_A)}),
+				comment({id: 20, author: "usirin", createdAt: "2026-07-22T05:33:00Z", body: claim(SID_B)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_B,
+			liveness: new Map<number, ClaimLiveness>([[10, "dead"]]),
+			expected: {
+				mine: true,
+				reason: "won",
+				winner: {session: SID_B, id: 20, createdAt: "2026-07-22T05:33:00Z"},
+				superseded: [{session: SID_A, id: 10, createdAt: "2026-07-20T06:42:00Z"}],
+			},
+		},
+		{
+			name: "INDETERMINATE liveness stays fail-closed: an unprobeable earliest claimant still owns → not-mine",
+			comments: [
+				comment({id: 10, author: "usirin", createdAt: "2026-07-20T06:42:00Z", body: claim(SID_A)}),
+				comment({id: 20, author: "usirin", createdAt: "2026-07-22T05:33:00Z", body: claim(SID_B)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_B,
+			liveness: new Map<number, ClaimLiveness>([[10, "unknown"]]),
+			expected: {
+				mine: false,
+				reason: "lost",
+				winner: {session: SID_A, id: 10, createdAt: "2026-07-20T06:42:00Z"},
+				superseded: [],
+			},
+		},
+		{
+			name: "a LIVE earliest claimant is never evicted → not-mine (no reclaim of a slow-but-live agent)",
+			comments: [
+				comment({id: 10, author: "usirin", createdAt: "2026-07-20T06:42:00Z", body: claim(SID_A)}),
+				comment({id: 20, author: "usirin", createdAt: "2026-07-22T05:33:00Z", body: claim(SID_B)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_B,
+			liveness: new Map<number, ClaimLiveness>([[10, "live"]]),
+			expected: {
+				mine: false,
+				reason: "lost",
+				winner: {session: SID_A, id: 10, createdAt: "2026-07-20T06:42:00Z"},
+				superseded: [],
+			},
+		},
+		{
+			name: "FAIL-SAFE: every authorized claim superseded → no-winner (default-deny), never a false win",
+			comments: [
+				comment({id: 10, author: "usirin", createdAt: "2026-07-20T06:42:00Z", body: claim(SID_A)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_B,
+			liveness: new Map<number, ClaimLiveness>([[10, "dead"]]),
+			expected: {
+				mine: false,
+				reason: "no-winner",
+				winner: null,
+				superseded: [{session: SID_A, id: 10, createdAt: "2026-07-20T06:42:00Z"}],
+			},
 		},
 	];
 
-	for (const {name, comments, authorized, sessionId, expected} of cases) {
+	for (const {name, comments, authorized, sessionId, liveness, expected} of cases) {
 		it(name, () => {
 			assert.deepStrictEqual(
-				claimIsMine({comments, authorizedAuthors: authorized, sessionId}),
+				claimIsMine({comments, authorizedAuthors: authorized, sessionId, liveness}),
 				expected,
 			);
 		});
@@ -106,6 +174,13 @@ describe("claimIsMine — the issue-scoped default-deny resolver decision", () =
 			}),
 			claimIsMine({comments: [comment({id: 1})], authorizedAuthors: [], sessionId: SID_A}),
 			claimIsMine({comments: [comment({id: 1})], authorizedAuthors: ["usirin"], sessionId: null}),
+			// A superseded-away claim set is still default-deny for a session with no claim of its own.
+			claimIsMine({
+				comments: [comment({id: 1})],
+				authorizedAuthors: ["usirin"],
+				sessionId: SID_B,
+				liveness: new Map<number, ClaimLiveness>([[1, "dead"]]),
+			}),
 		];
 		for (const verdict of denials) assert.strictEqual(verdict.mine, false);
 	});

--- a/packages/pipeline-cli/src/tools/claim/command.ts
+++ b/packages/pipeline-cli/src/tools/claim/command.ts
@@ -48,6 +48,17 @@ const resolveSession = (session: Option.Option<string>): string | null => {
 	return raw === "" ? null : raw;
 };
 
+/**
+ * The superseded-claims note appended to the reason line: naming the dead claimants that dropped
+ * out of the tiebreak is what makes "why is a later claim the owner?" answerable from the log.
+ */
+const supersededNote = (verdict: ClaimVerdict): string =>
+	verdict.superseded.length === 0
+		? ""
+		: ` (superseded ${verdict.superseded.length} dead-claimant claim(s): ${verdict.superseded
+				.map((claim) => claim.session)
+				.join(", ")} — ADR 0191 presence liveness)`;
+
 /** The stderr reason line for a resolved verdict — the human-readable "why" a caller logs. */
 const reasonLine = (issue: number, verdict: ClaimVerdict): string => {
 	switch (verdict.reason) {
@@ -71,7 +82,7 @@ const isMine = Command.make(
 		// The resolved detail goes to stdout as JSON (a caller may want the owner / reason);
 		// the human-readable verdict + back-off reason goes to stderr, mirroring verdict/epic-lock.
 		yield* Console.log(JSON.stringify({issue, ...verdict}));
-		process.stderr.write(`claim: ${reasonLine(issue, verdict)}\n`);
+		process.stderr.write(`claim: ${reasonLine(issue, verdict)}${supersededNote(verdict)}\n`);
 		if (!verdict.mine) process.exit(NOT_MINE_EXIT_CODE);
 	}),
 ).pipe(

--- a/packages/pipeline-cli/src/tools/claim/github.ts
+++ b/packages/pipeline-cli/src/tools/claim/github.ts
@@ -15,7 +15,9 @@
 import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {livenessByComment} from "../epic-lock/claim-presence.ts";
 import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
+import {localPresence} from "../epic-lock/presence-io.ts";
 import {type ClaimVerdict, claimIsMine} from "./claim-is-mine.ts";
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
@@ -208,7 +210,11 @@ const isMine = Effect.fn("Github.isMine")(function* (
 	const comments = yield* listClaimComments(repo, issue);
 	const authors = [...new Set(comments.map((c) => c.author).filter((a) => a.length > 0))];
 	const authorized = yield* authorizedAuthors(repo, authors);
-	return claimIsMine({comments, authorizedAuthors: authorized, sessionId});
+	// ADR 0191 presence liveness (#3751): a claim whose stamped session process is provably gone
+	// on THIS host is superseded, so a legitimate re-claim on an abandoned lane can resolve as
+	// mine. Every indeterminate claimant (unstamped, another host, unprobeable pid) still counts.
+	const liveness = livenessByComment(comments, localPresence());
+	return claimIsMine({comments, authorizedAuthors: authorized, sessionId, liveness});
 });
 
 /**

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-presence.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-presence.ts
@@ -1,0 +1,147 @@
+/**
+ * Claim-presence — the pure half of ADR 0191 liveness for a GitHub claim marker (#3751).
+ *
+ * A claim marker may carry an optional presence stamp, `claim: <session> · <ts> · presence
+ * <host>/<pid>`, where `<pid>` is the claiming **session process** (the long-lived `claude`
+ * ancestor of the process that posted the claim, the same identification `worktree-reap` makes)
+ * and `<host>` is the machine it runs on. That stamp is what turns "is this claimant still
+ * alive?" from a judgment call into a probe, so a dead session's marker stops shadowing every
+ * later legitimate claim on an abandoned lane.
+ *
+ * The one non-obvious thing: **only positive evidence of death supersedes a claim.** A missing
+ * stamp (a legacy marker), a stamp from another host, or an unprobeable pid all resolve
+ * `unknown`, which counts as a live claim — so an indeterminate claimant is refused, never
+ * evicted (the slow-but-live-agent hazard ADR 0115 §5 deferred reclaim over). A reused pid reads
+ * running ⇒ live, the same fail-safe direction `worktree-reap` takes.
+ */
+import type {ClaimComment, ClaimLiveness} from "./claim-resolution.ts";
+
+/** The claimant's session process, as stamped on the marker. */
+export interface ClaimPresence {
+	/**
+	 * An opaque fingerprint of the host the session process runs on — a claim stamped elsewhere is
+	 * unprobeable here. Only equality is ever asked of it, so it is a hash rather than the machine
+	 * name: an operator's hostname is not something a public issue timeline needs to carry.
+	 */
+	readonly host: string;
+	/** The session process id whose presence IS the claim's liveness (ADR 0191). */
+	readonly pid: number;
+}
+
+/**
+ * The optional presence suffix of a claim marker. Anchored to the end of the marker's FIRST
+ * line (claim markers are one line; a stamp is never read out of trailing prose), tolerant of
+ * either `·` or `-` as the separator the writers emit.
+ */
+export const PRESENCE_RE = /[·-]\s*presence\s+([^\s/]+)\/(\d+)\s*$/i;
+
+/** Format the suffix `claimCommentBody` appends — the single source of the stamp's shape. */
+export const formatClaimPresence = (presence: ClaimPresence): string =>
+	`presence ${presence.host}/${presence.pid}`;
+
+/** Parse a marker's presence stamp, or `null` when it carries none (the legacy/unstamped case). */
+export const parseClaimPresence = (body: string): ClaimPresence | null => {
+	const firstLine = body.split("\n", 1)[0] ?? "";
+	const match = PRESENCE_RE.exec(firstLine);
+	const host = match?.[1];
+	const rawPid = match?.[2];
+	if (host === undefined || rawPid === undefined) return null;
+	const pid = Number.parseInt(rawPid, 10);
+	return Number.isFinite(pid) && pid > 0 ? {host, pid} : null;
+};
+
+/** What a pid probe could establish. `unprobeable` is a failed probe, never "gone". */
+export type PidState = "running" | "gone" | "unprobeable";
+
+/** This machine's identity + its pid probe — the boundary facts the classification reads. */
+export interface LocalPresence {
+	readonly host: string;
+	readonly probePid: (pid: number) => PidState;
+}
+
+/**
+ * Classify one claim's liveness. `dead` requires all three: a stamp, a host match (we can only
+ * probe our own machine), and a pid the probe proves gone. Everything else is `unknown`.
+ */
+export const claimLiveness = (
+	presence: ClaimPresence | null,
+	local: LocalPresence,
+): ClaimLiveness => {
+	if (presence === null) return "unknown";
+	if (presence.host !== local.host) return "unknown";
+	switch (local.probePid(presence.pid)) {
+		case "gone":
+			return "dead";
+		case "running":
+			return "live";
+		case "unprobeable":
+			return "unknown";
+	}
+};
+
+/**
+ * The per-comment-id liveness map `resolveWinner`/`resolveClaim` consume. Only entries that
+ * resolve to something other than `unknown` are recorded, so the map is empty (⇒ resolution
+ * identical to the pre-supersession behaviour) whenever nothing is provable.
+ */
+export const livenessByComment = (
+	comments: ReadonlyArray<ClaimComment>,
+	local: LocalPresence,
+): ReadonlyMap<number, ClaimLiveness> => {
+	const map = new Map<number, ClaimLiveness>();
+	for (const comment of comments) {
+		const liveness = claimLiveness(parseClaimPresence(comment.body), local);
+		if (liveness !== "unknown") map.set(comment.id, liveness);
+	}
+	return map;
+};
+
+/** One row of the process table the session-pid walk reads. */
+export interface ProcessRow {
+	readonly ppid: number;
+	readonly command: string;
+}
+
+/**
+ * Parse `ps -Ao pid=,ppid=,comm=` output into a pid → `{ppid, command}` table. Tolerates the
+ * leading padding `ps` emits and a command path with spaces; a malformed row is skipped.
+ */
+export const parseProcessTable = (psOutput: string): ReadonlyMap<number, ProcessRow> => {
+	const table = new Map<number, ProcessRow>();
+	for (const line of psOutput.split("\n")) {
+		const match = /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/.exec(line);
+		const rawPid = match?.[1];
+		const rawPpid = match?.[2];
+		const command = match?.[3];
+		if (rawPid === undefined || rawPpid === undefined || command === undefined) continue;
+		table.set(Number.parseInt(rawPid, 10), {ppid: Number.parseInt(rawPpid, 10), command});
+	}
+	return table;
+};
+
+/** The session process's command basename — the harness names it `claude`. */
+const SESSION_COMMAND = "claude";
+
+/** Bound the ancestor walk so a malformed/cyclic table can never spin. */
+const MAX_ANCESTOR_HOPS = 64;
+
+/**
+ * The nearest `claude` ancestor of `startPid` (inclusive) — the long-lived session process
+ * whose presence a claim's liveness rides. `null` when the walk finds none (a CLI run outside a
+ * session, a table that could not be read): the writer then stamps NO presence, which reads
+ * `unknown` downstream, so an unresolvable session degrades to today's behaviour.
+ */
+export const resolveSessionPid = (
+	table: ReadonlyMap<number, ProcessRow>,
+	startPid: number,
+): number | null => {
+	let pid = startPid;
+	for (let hop = 0; hop < MAX_ANCESTOR_HOPS; hop++) {
+		const row = table.get(pid);
+		if (row === undefined) return null;
+		if (row.command.split("/").pop() === SESSION_COMMAND) return pid;
+		if (row.ppid <= 1 || row.ppid === pid) return null;
+		pid = row.ppid;
+	}
+	return null;
+};

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-presence.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-presence.unit.test.ts
@@ -1,0 +1,139 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	claimLiveness,
+	formatClaimPresence,
+	type LocalPresence,
+	livenessByComment,
+	type PidState,
+	parseClaimPresence,
+	parseProcessTable,
+	resolveSessionPid,
+} from "./claim-presence.ts";
+import {type ClaimComment, claimCommentBody} from "./claim-resolution.ts";
+
+const SID_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+const local = (host: string, states: Record<number, PidState>): LocalPresence => ({
+	host,
+	probePid: (pid) => states[pid] ?? "unprobeable",
+});
+
+const comment = (id: number, body: string): ClaimComment => ({
+	id,
+	author: "usirin",
+	createdAt: "2026-07-22T05:33:00Z",
+	body,
+});
+
+describe("parseClaimPresence — the optional presence stamp on a claim marker", () => {
+	it("reads host + pid off a stamped marker", () => {
+		assert.deepStrictEqual(
+			parseClaimPresence(`claim: ${SID_A} · 2026-07-20T06:42:00Z · presence box-1/4242`),
+			{host: "box-1", pid: 4242},
+		);
+	});
+
+	it("round-trips the composer's own output (one grammar, two directions)", () => {
+		const presence = {host: "box-1", pid: 4242};
+		assert.deepStrictEqual(
+			parseClaimPresence(
+				claimCommentBody(SID_A, "2026-07-20T06:42:00Z", formatClaimPresence(presence)),
+			),
+			presence,
+		);
+	});
+
+	it("an unstamped (legacy) marker carries no presence", () => {
+		assert.strictEqual(parseClaimPresence(`claim: ${SID_A} · 2026-07-20T06:42:00Z`), null);
+	});
+
+	it("never reads a stamp out of trailing prose — the marker's first line only", () => {
+		assert.strictEqual(
+			parseClaimPresence(`claim: ${SID_A} · 2026-07-20T06:42:00Z\nnot a presence box-1/4242`),
+			null,
+		);
+	});
+});
+
+describe("claimLiveness — dead requires positive evidence, everything else is indeterminate", () => {
+	it("host match + a provably gone pid ⇒ dead (the supersession trigger)", () => {
+		assert.strictEqual(
+			claimLiveness({host: "box-1", pid: 4242}, local("box-1", {4242: "gone"})),
+			"dead",
+		);
+	});
+
+	it("host match + a running pid ⇒ live (never evict a slow-but-live agent)", () => {
+		assert.strictEqual(
+			claimLiveness({host: "box-1", pid: 4242}, local("box-1", {4242: "running"})),
+			"live",
+		);
+	});
+
+	it("another host ⇒ unknown — we cannot probe someone else's machine", () => {
+		assert.strictEqual(
+			claimLiveness({host: "box-2", pid: 4242}, local("box-1", {4242: "gone"})),
+			"unknown",
+		);
+	});
+
+	it("an unprobeable pid ⇒ unknown, never dead", () => {
+		assert.strictEqual(
+			claimLiveness({host: "box-1", pid: 4242}, local("box-1", {4242: "unprobeable"})),
+			"unknown",
+		);
+	});
+
+	it("no stamp ⇒ unknown", () => {
+		assert.strictEqual(claimLiveness(null, local("box-1", {})), "unknown");
+	});
+});
+
+describe("livenessByComment — only provable states are recorded", () => {
+	it("maps the dead and live claims and omits every indeterminate one", () => {
+		const comments = [
+			comment(10, `claim: ${SID_A} · 2026-07-20T06:42:00Z · presence box-1/4242`),
+			comment(20, `claim: ${SID_B} · 2026-07-22T05:33:00Z · presence box-1/5150`),
+			comment(30, `claim: ${SID_B} · 2026-07-22T05:34:00Z · presence box-2/999`),
+			comment(40, `claim: ${SID_B} · 2026-07-22T05:35:00Z`),
+			comment(50, "not a claim at all"),
+		];
+		assert.deepStrictEqual(
+			[...livenessByComment(comments, local("box-1", {4242: "gone", 5150: "running"}))],
+			[
+				[10, "dead"],
+				[20, "live"],
+			],
+		);
+	});
+});
+
+describe("resolveSessionPid — the nearest `claude` ancestor is the session process", () => {
+	const table = parseProcessTable(
+		["  9001  8001 node", " 8001  7001 -zsh", " 7001     1 claude", "   1     0 launchd"].join(
+			"\n",
+		),
+	);
+
+	it("walks the ppid chain to the session process", () => {
+		assert.strictEqual(resolveSessionPid(table, 9001), 7001);
+	});
+
+	it("resolves to itself when the start pid IS the session", () => {
+		assert.strictEqual(resolveSessionPid(table, 7001), 7001);
+	});
+
+	it("no session ancestor ⇒ null (the writer then stamps nothing, reading indeterminate)", () => {
+		assert.strictEqual(resolveSessionPid(table, 1), null);
+	});
+
+	it("an unknown start pid ⇒ null, never a guess", () => {
+		assert.strictEqual(resolveSessionPid(table, 4242), null);
+	});
+
+	it("a self-parenting row terminates instead of spinning", () => {
+		const cyclic = parseProcessTable(" 500 500 node");
+		assert.strictEqual(resolveSessionPid(cyclic, 500), null);
+	});
+});

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
@@ -22,6 +22,17 @@
  */
 export const CLAIM_RE = /^\s*\**\s*claim:\s*([0-9a-f-]{36})\b/i;
 
+/**
+ * Compose a claim marker body: the canonical `claim: <session> · <ts>` line, plus the optional
+ * `· presence <host>/<pid>` suffix that makes the claimant's liveness machine-checkable
+ * (`claim-presence.ts`). The grammar lives here so no writer hand-concatenates it.
+ */
+export const claimCommentBody = (
+	session: string,
+	at: string,
+	presenceSuffix?: string | null,
+): string => `claim: ${session} · ${at}${presenceSuffix ? ` · ${presenceSuffix}` : ""}`;
+
 /** A claim comment as the issues/comments REST endpoint surfaces it (only these fields matter). */
 export interface ClaimComment {
 	/** Server-assigned, strictly-monotonic, globally-unique comment id (the tiebreak sub-key). */
@@ -40,12 +51,27 @@ export const parseClaimSession = (body: string): string | null => {
 	return session ? session.toLowerCase() : null;
 };
 
+/**
+ * A claimant's presence — the ADR 0191 liveness of the claim, resolved from the marker's
+ * optional presence stamp by the IO shell. `dead` is the ONLY value that supersedes a claim,
+ * and it requires positive evidence (the stamped session process is provably gone on this
+ * host); `unknown` (no stamp, another host, an unprobeable pid) counts as a live claim, so
+ * doubt refuses rather than evicts.
+ */
+export type ClaimLiveness = "live" | "dead" | "unknown";
+
 export interface ClaimResolutionInput {
 	readonly comments: ReadonlyArray<ClaimComment>;
 	/** The write+ collaborator logins — the ADR 0055 trust root (resolved by the IO shell). */
 	readonly authorizedAuthors: ReadonlyArray<string>;
 	/** Our own `CLAUDE_CODE_SESSION_ID`; absent/empty ⇒ fail-closed `no-session`. */
 	readonly sessionId: string | null | undefined;
+	/**
+	 * Per-comment-id claimant liveness (`claim-presence.ts` resolves it). A comment absent
+	 * from the map is `unknown` ⇒ its claim counts, so omitting the map entirely reproduces
+	 * the pre-supersession resolution exactly.
+	 */
+	readonly liveness?: ReadonlyMap<number, ClaimLiveness> | undefined;
 }
 
 /** The resolved lock holder — the earliest authorized claim. */
@@ -61,16 +87,11 @@ export type ClaimOutcome =
 	| {readonly _tag: "won"; readonly winner: ClaimWinner}
 	| {readonly _tag: "lost"; readonly winner: ClaimWinner};
 
-/**
- * The earliest authorized claim — min `(createdAt, id)` — among comments that both
- * match `CLAIM_RE` and are authored by a write+ collaborator. Returns `null` when
- * no such claim exists (empty authorized set, or only forged/non-claim comments):
- * an empty result is the fail-closed "no owner", never a false win.
- */
-export const resolveWinner = (
+/** Every authorized claim on the target, ordered earliest-first by `(createdAt, id)`. */
+const authorizedClaims = (
 	comments: ReadonlyArray<ClaimComment>,
 	authorizedAuthors: ReadonlyArray<string>,
-): ClaimWinner | null => {
+): ReadonlyArray<ClaimWinner> => {
 	const authorized = new Set(authorizedAuthors);
 	const claims: ClaimWinner[] = [];
 	for (const comment of comments) {
@@ -82,8 +103,47 @@ export const resolveWinner = (
 	claims.sort((a, b) =>
 		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
 	);
-	return claims[0] ?? null;
+	return claims;
 };
+
+/**
+ * The earliest **live-or-indeterminate** authorized claim — min `(createdAt, id)` — among
+ * comments that both match `CLAIM_RE` and are authored by a write+ collaborator. Returns
+ * `null` when no such claim exists (empty authorized set, only forged/non-claim comments, or
+ * every authorized claim superseded): an empty result is the fail-closed "no owner", never a
+ * false win.
+ *
+ * A claim whose claimant is **provably dead** (`liveness` says `dead` — ADR 0191 presence
+ * liveness, positive evidence only) is **superseded**: it drops out of the tiebreak so a
+ * later legitimate claim on an abandoned lane can win, which is what makes the mis-attribution
+ * guard runnable under orchestrated repair instead of shadowed forever by a dead session's
+ * older marker (#3751). Every other liveness value counts the claim, so an indeterminate
+ * claimant still wins the tiebreak and the reader still refuses — doubt never evicts a
+ * slow-but-live agent (the hazard ADR 0115 §5's deferral was protecting).
+ */
+export const resolveWinner = (
+	comments: ReadonlyArray<ClaimComment>,
+	authorizedAuthors: ReadonlyArray<string>,
+	liveness?: ReadonlyMap<number, ClaimLiveness> | undefined,
+): ClaimWinner | null =>
+	authorizedClaims(comments, authorizedAuthors).find(
+		(claim) => liveness?.get(claim.id) !== "dead",
+	) ?? null;
+
+/**
+ * The authorized claims **dropped as superseded** by the liveness projection — the audit
+ * trail a caller logs next to the resolved winner ("#N: superseded 1 dead-claimant claim").
+ * Kept as its own read rather than folded into `ClaimOutcome` so the outcome shape (and every
+ * consumer that pattern-matches it) is untouched.
+ */
+export const supersededClaims = (
+	comments: ReadonlyArray<ClaimComment>,
+	authorizedAuthors: ReadonlyArray<string>,
+	liveness?: ReadonlyMap<number, ClaimLiveness> | undefined,
+): ReadonlyArray<ClaimWinner> =>
+	authorizedClaims(comments, authorizedAuthors).filter(
+		(claim) => liveness?.get(claim.id) === "dead",
+	);
 
 /**
  * Decide our win/lose against canonical epic state. Fail-closed twice over: a
@@ -94,7 +154,7 @@ export const resolveWinner = (
  */
 export const resolveClaim = (input: ClaimResolutionInput): ClaimOutcome => {
 	if (!input.sessionId) return {_tag: "no-session"};
-	const winner = resolveWinner(input.comments, input.authorizedAuthors);
+	const winner = resolveWinner(input.comments, input.authorizedAuthors, input.liveness);
 	if (winner === null) return {_tag: "no-winner"};
 	return winner.session === input.sessionId.toLowerCase()
 		? {_tag: "won", winner}

--- a/packages/pipeline-cli/src/tools/epic-lock/presence-io.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/presence-io.ts
@@ -1,0 +1,65 @@
+/**
+ * The OS boundary for claim presence (`claim-presence.ts` holds the decisions). Two
+ * best-effort reads, both of which degrade to "nothing provable" rather than to a wrong answer:
+ * the local host + pid probe a reader classifies liveness with, and the presence stamp a writer
+ * puts on its own claim.
+ *
+ * Deliberately synchronous and outside the Effect `E` channel: every failure here is already
+ * modelled as an absence (`unprobeable` / no stamp) that the pure classification treats
+ * fail-closed, so lowering it into a typed error would add a channel no caller can act on.
+ */
+import {execFileSync} from "node:child_process";
+import {createHash} from "node:crypto";
+import {hostname} from "node:os";
+import {
+	type ClaimPresence,
+	type LocalPresence,
+	type PidState,
+	parseProcessTable,
+	resolveSessionPid,
+} from "./claim-presence.ts";
+
+/**
+ * Probe one pid with signal 0: no error ⇒ running; `ESRCH` ⇒ provably gone (the one positive
+ * death signal); `EPERM` (alive but owned by another user) and anything else ⇒ unprobeable.
+ */
+const probePid = (pid: number): PidState => {
+	// `process.kill(pid, 0)` signals all three outcomes by throwing (or not), so the try/catch IS
+	// the probe — each branch maps to a total `PidState`, never to an error channel.
+	try {
+		process.kill(pid, 0);
+		return "running";
+	} catch (cause) {
+		return (cause as {code?: string} | null)?.code === "ESRCH" ? "gone" : "unprobeable";
+	}
+};
+
+/**
+ * This machine's stamp identity: a truncated hash of the hostname. Liveness only ever asks
+ * "was this claim stamped on MY host?", so a fingerprint answers it exactly — and keeps the
+ * operator's machine name out of a public issue timeline (the no-local-identity rule the
+ * leak-guards enforce generically).
+ */
+const hostFingerprint = (): string =>
+	createHash("sha256").update(hostname()).digest("hex").slice(0, 12);
+
+/** This machine's presence facts — the reader side. */
+export const localPresence = (): LocalPresence => ({host: hostFingerprint(), probePid});
+
+/**
+ * The presence stamp for THIS run's claim: the nearest `claude` ancestor of the current process
+ * (the session whose liveness the claim rides) on this host. `null` when the process table
+ * cannot be read or no session ancestor resolves — the writer then emits an unstamped marker,
+ * which every reader treats as indeterminate.
+ */
+export const currentSessionPresence = (): ClaimPresence | null => {
+	try {
+		const table = parseProcessTable(
+			execFileSync("ps", ["-Ao", "pid=,ppid=,comm="], {encoding: "utf8"}),
+		);
+		const pid = resolveSessionPid(table, process.pid);
+		return pid === null ? null : {host: hostFingerprint(), pid};
+	} catch {
+		return null;
+	}
+};

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -36,7 +36,14 @@
 import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcessSpawner} from "effect/unstable/process";
-import {type ClaimComment, type ClaimWinner, resolveWinner} from "../epic-lock/claim-resolution.ts";
+import {formatClaimPresence, livenessByComment} from "../epic-lock/claim-presence.ts";
+import {
+	type ClaimComment,
+	type ClaimWinner,
+	claimCommentBody,
+	resolveWinner,
+} from "../epic-lock/claim-resolution.ts";
+import {currentSessionPresence, localPresence} from "../epic-lock/presence-io.ts";
 // The ADR-0058 verdict-marker grammar + emission guard is the SINGLE SOURCE — reused, never
 // re-derived, exactly as the claim decision reuses `epic-lock/claim-resolution.ts`. `postVerdict`
 // composes and self-verifies its comment through this pure core so the tool OWNS the decision the
@@ -375,7 +382,10 @@ const resolveAuthorizedWinner = Effect.fn("Tracker.resolveAuthorizedWinner")(fun
 ) {
 	const authors = [...new Set(comments.map((c) => c.author).filter((a) => a.length > 0))];
 	const authorized = yield* authorizedAuthors(repo, authors);
-	return resolveWinner(comments, authorized);
+	// A provably-dead claimant's marker is superseded (ADR 0191 presence liveness, #3751), so
+	// Rule-0 defer no longer strands an abandoned lane behind a dead session's older claim — the
+	// re-claim this enables is what a repair dispatch threads as its delegated token.
+	return resolveWinner(comments, authorized, livenessByComment(comments, localPresence()));
 });
 
 /**
@@ -399,7 +409,17 @@ const claim = Effect.fn("Tracker.claim")(function* (
 			: ({_tag: "held-by-other", owner: toOwner(before)} satisfies ClaimResult);
 	}
 	const now = new Date().toISOString();
-	const posted = yield* json(postCommentArgs(repo, target, `claim: ${session} · ${now}`));
+	// Stamp our own session's presence on the marker so a LATER reader can probe this claim's
+	// liveness instead of guessing (#3751); an unresolvable session stamps nothing, which reads
+	// indeterminate and preserves the pre-stamp behaviour exactly.
+	const presence = currentSessionPresence();
+	const posted = yield* json(
+		postCommentArgs(
+			repo,
+			target,
+			claimCommentBody(session, now, presence === null ? null : formatClaimPresence(presence)),
+		),
+	);
 	const claimId = typeof posted === "number" ? posted : null;
 	const winner = yield* resolveAuthorizedWinner(repo, yield* listClaimComments(repo, target));
 	if (winner !== null && winner.session === mine) {


### PR DESCRIPTION
Fixes #3751

## What changed

The Step-3.5 mis-attribution guard was **inert on repair** — the one dispatch class that lands on a lane someone else opened. Both halves the issue names are closed, in the existing seams.

### 1. Repair dispatches thread the lane's claim token (the existing `THREADED_CLAIM_TOKEN` contract)

- `.claude/workflows/drive-issue.js` — the repair stage now threads `claim.token`, the token the lane was already claimed under pre-spawn (it was in scope and simply not passed).
- `claude-plugins/pipeline-crew/agents/crew-engineering-manager.md` — a stall-recovery repair re-drive must **claim the lane in its own session first** (`pipeline-cli tracker claim <issue>`) and thread that token; a coder reporting a guard refusal means *the dispatch* was unclaimed — claim and re-dispatch, never instruct past it.
- `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` — new **Step R0**: no token, or a guard refusal, means STOP and report. Explicitly removes the escape hatch the field used: an explicit-looking dispatch brief, or independently corroborating PR → branch → `Fixes #N` → FAIL verdict, establishes *dispatch coherence*, not *lane ownership*. Outcome is deterministic: threaded ⇒ proceed, unthreaded ⇒ refuse.
- `claude-plugins/kampus-pipeline/agents/coder.md` — same invariant baked into the agent def so it holds regardless of the spawn prompt.

### 2. `claim is-mine` learns dead-claimant supersession (in the shared verb)

Previously the guard asserted against the **earliest** authorized claim, full stop — so a dead session's older marker shadowed every later legitimate claim forever, and even an engine that correctly re-claimed an abandoned lane failed the guard. Now a claim whose claimant is **provably dead** is superseded and the earliest **live-or-indeterminate** claim owns the lane.

Liveness is **presence-derived, never age-derived** (ADR 0191, the same identification `worktree-reap` makes): the claim marker carries an optional `presence <host-fingerprint>/<session-pid>` stamp naming the claimant's session process (the long-lived `claude` ancestor of whatever posted the claim), and a reader on that host probes the pid.

**Dead requires all three** — a stamp, a host match, and a pid the probe proves gone (`ESRCH`). Everything else stays indeterminate and **still counts as a live owner**: an unstamped/legacy marker, a claim from another host, an `EPERM`/unprobeable pid, and a reused pid. So doubt refuses and never evicts — the deferred age/TTL reclaim stays deferred, and no slow-but-live agent can be evicted. `tracker claim`'s Rule-0 defer consumes the same projection, which is what lets the legitimate re-claim land at all.

Host identity is a truncated hash rather than the machine name: liveness only ever asks "is this my machine?", and no machine identity has business in a public timeline. **On this branch that hash is over `hostname()`, which the review correctly flagged as a fail-open (F3): a hostname is not a machine identity, so two machines sharing one fingerprint identically and a pid alive on machine A but absent on machine B reads `dead`, evicting a live agent.** The fix — fingerprint a machine-scoped, reboot-stable id (macOS `IOPlatformUUID`, Linux `/etc/machine-id`), and fail toward *indeterminate* when no identity resolves — is built and verified but **could not be pushed here**, because this branch was already queue-locked; see the repair-blocked comment on this PR for the commit and branch it is parked on.

Files: `packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts` (liveness-aware tiebreak + `supersededClaims` + the marker-body composer), `.../epic-lock/claim-presence.ts` (pure: stamp grammar, liveness classification, session-pid ancestor walk), `.../epic-lock/presence-io.ts` (the OS boundary), `.../claim/{claim-is-mine,github,command}.ts`, `.../tracker/tracker.ts`.

## Acceptance criteria

- [x] **A repair dispatch carries a token the guard can verify, and omitting it is fail-loud, not a judgment call.** Orchestrator + crew-engine dispatchers thread it; Step R0 + the coder agent def make the unthreaded case a deterministic refusal with the "cannot be reasoned past" clause spelled out.
- [x] **`claim is-mine` resolves a dead-session claim as superseded; indeterminate stays fail-closed.** Implemented in the shared resolution core; `dead` needs positive evidence, every other state counts and refuses.
- [x] **The two observed behaviors converge.** Threaded ⇒ `claim_is_mine` resolves mine deterministically (the dead original claimant no longer shadows the re-claim); unthreaded ⇒ deterministic refusal, routed back to the dispatcher.
- [x] **The change lands in the shared verb** (`packages/pipeline-cli/src/tools/`), cited by the skill/formats contract — no per-skill re-derivation (#3687 envelope rule).

## Tests

`packages/pipeline-cli/src/tools/claim/claim-is-mine.unit.test.ts` — four new cases: a provably dead earliest claimant is superseded so a later claim wins; indeterminate liveness stays fail-closed; a live earliest claimant is never evicted; all-claims-superseded resolves `no-winner` (never a false win).

`packages/pipeline-cli/src/tools/epic-lock/claim-presence.unit.test.ts` (new) — stamp parse/round-trip, first-line-only anchoring, the five liveness classifications, the recorded-only-if-provable map, and the session-pid ancestor walk (incl. no-ancestor and cyclic-table termination).

**Verified the tests fail without the fix**: neutering the liveness skip in `resolveWinner` reds 2 of them (`winner` resolves to the dead claimant instead of the live claim), so the previously-untested guard path is now covered.

Also verified live on this very issue: the claim posted by `tracker claim 3751` carries a presence stamp, and `claim is-mine --issue 3751` resolves `mine: true` with `superseded: []` (live claimant ⇒ counts).

`pnpm typecheck`, `pnpm lint:worktree`, and the full `pipeline-cli` suite (2027 tests) are green.

## Scope note for the reviewer

Two things I deliberately did **not** absorb, per the issue's "implement the ACs, file the remainder":

- **The two-keyspace split (#3938)** — this change lives entirely in the **GitHub** claim keyspace (assignee + session-keyed claim comment). It does not consult the crew tracker's resource-claim keyspace, so the "tracker granted a lane GitHub already claimed" defect is untouched. The presence stamp is a *third*, self-contained liveness signal used only to project the GitHub keyspace's markers — chosen because a session UUID has no mapping into the tracker's peer keyspace today.
- **#3780 (a completed run's claim never expires)** — adjacent and partly relieved: a completed run whose session process has exited now reads `dead` and is superseded, so re-dispatch stops reading `lost` for that case. It is **not** fully fixed: a completed run inside a *still-live* session (the common subagent case, where the parent session keeps running) still holds its claim, which is exactly right for the inverse hazard #3780 also names (detached background subagents working under a claim that must not vanish). Releasing on lane-completion is a separate lifecycle change and stays #3780's.

**§CP:** yes — the diff touches `.claude/workflows/drive-issue.js` (`.claude/**`) plus gate-critical skills/agents under `claude-plugins/kampus-pipeline/{skills,agents}` and `claude-plugins/pipeline-crew/agents`, so this banks for a control-plane approval rather than auto-shipping.

- **#3987 (only `tracker claim` writes a presence stamp)** — the disclosure the reviewer asked for, stated here rather than only in the issue. Half 2 reaches only lanes whose claim carries a stamp, and `tracker claim` is the sole writer today: `.claude/workflows/drive-issue.js` (the pre-spawn claim-agent prompt), `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` (Step 3's direct path), and `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (§7's canonical write surface) all still hand-roll an **unstamped** marker, so on most build lanes supersession has nothing to read. The sharp consequence, stated plainly: in #3751's *own* scenario the marker needing supersession is the dead lane's, written unstamped — so it reads `unknown`, `tracker claim` still Rule-0 defers, and the repair still cannot obtain a valid token. The divergence AC3 asks for **is** closed (the outcome is deterministic either way), but the practical unblock generally will not arrive until the writer side is stamped. That is #3987.

**Possible follow-up worth a ruling, not silently absorbed:** `gh-issue-intake-formats.md` §7's "Staleness / reclaim — owner-defer" paragraph deferred *automatic reclaim* outright. This PR narrows that deferral (age/TTL reclaim stays deferred; proven-death supersession is permitted, since it cannot evict a live agent) and records the narrowing in §7 rather than in a new ADR — the triage brief for #3751 mandated the supersession, so the direction was bound at intake. If the reviewer judges that an amendment to ADR 0115 §5 needs to be an ADR of its own, say so and I will file it.

