### PR TITLE
fix(worktree-sweep): never remove a worktree whose owning agent session is still running (#3943)

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -240,11 +240,20 @@ Both classes share the **#2240 liveness guard**: a **locked**, **recently-active
 within the idle threshold), or (build class) **open-PR** tree is **KEPT**.
 
 Above all of those sits the **owner-presence gate** (#3943): a tree is removable only when its
-**owning agent session is provably dead**. None of the #2240 signals is presence, and a live
-*shipper* lane defeats all three at once — it is clean (a shipper only reads), its PR has just
-squash-merged onto `origin/main` (so the merge gate passes and the open-PR gate goes quiet), and its
-mtime never moves (a ship runs `gh api`, not edits). Two live shipper worktrees were removed mid-run
-under exactly that state. Presence rides the owner, per
+**owning agent session is provably dead**. The reason the #2240 signals were not enough is that
+**none of them is presence** — not that all of them were bypassed. A live *shipper* lane is clean (a
+shipper only reads), its PR has just squash-merged onto `origin/main` (so the merge gate passes and
+the open-PR gate goes quiet), and its mtime never moves (a ship runs `gh api`, not edits). The
+`locked` gate is the one #2240 signal that *does* carry real liveness: the harness locks each
+harness-provisioned agent worktree with a pid-bearing reason (`claude agent <id> (pid <N> start
+<date>)`, surfaced on the porcelain `locked` line), the sweep KEEPs any locked tree, and a non-forced
+`git worktree remove` refuses one anyway. But its **coverage is partial**, so it cannot be relied on
+as the liveness line: only a handful of the registered trees carry a lock at any moment, a lock can
+go stale and outlive its session by weeks, and the `$TMPDIR`-rooted `review-head-*` class is **never
+locked at all** (`review-head materialize` runs `git worktree add --detach`, no `--lock`) — which
+leaves the `review-head-idle` removal path able to take a **live reviewer's** tree with no lock
+protection whatsoever. Two live shipper worktrees were removed mid-run; **which** reaper and which
+signal state produced those two removals is not established. Presence rides the owner, per
 [ADR 0191](../.decisions/0191-crew-claim-lifecycle.md): `create-worktree.sh` stamps
 the owning `sessionId` into the tree's git admin dir (`<gitdir>/kampus-owner.json`, invisible to
 `git status`), and the sweep resolves it against the harness's live-session registry
@@ -254,6 +263,14 @@ per running session).
 `dead` permits a removal — so an unstamped tree, an unreadable registry, or a liveness probe that
 could not execute leaks an orphan rather than destroying a live tree. A sweep that removes nothing
 and reports `registry UNRESOLVED` is the gate working, not a no-op.
+
+**Expect near-silence, and not only from legacy trees.** The stamp carries the **launcher's**
+session id, and a crew pane is long-lived — so every tree that pane provisioned reads `alive` for the
+pane's entire lifetime, not just for as long as the subagent that used it ran. Combined with the
+pre-#3943 pile, which carries no stamp and resolves `owner-unknown`, the sweep goes near-silent
+during any crew run and only the gone-dir `prunable` class still drains. That is the safe direction,
+but it means the worktree pileup (#3887) will not bend from this gate; draining the pile needs a
+separate, liveness-keyed operator-confirmed path (#3892).
 
 It runs `git worktree
 remove` **without `--force`**, so git itself refuses any tree it judges unsafe and that refusal is

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -237,7 +237,25 @@ It sweeps **two leaked classes** (#2785):
   `not-managed` and never reaped, so they were the bulk of the 562-worktree leak.
 
 Both classes share the **#2240 liveness guard**: a **locked**, **recently-active** (mtime
-within the idle threshold), or (build class) **open-PR** tree is **KEPT**. It runs `git worktree
+within the idle threshold), or (build class) **open-PR** tree is **KEPT**.
+
+Above all of those sits the **owner-presence gate** (#3943): a tree is removable only when its
+**owning agent session is provably dead**. None of the #2240 signals is presence, and a live
+*shipper* lane defeats all three at once — it is clean (a shipper only reads), its PR has just
+squash-merged onto `origin/main` (so the merge gate passes and the open-PR gate goes quiet), and its
+mtime never moves (a ship runs `gh api`, not edits). Two live shipper worktrees were removed mid-run
+under exactly that state. Presence rides the owner, per
+[ADR 0191](../.decisions/0191-crew-claim-lifecycle.md): `create-worktree.sh` stamps
+the owning `sessionId` into the tree's git admin dir (`<gitdir>/kampus-owner.json`, invisible to
+`git status`), and the sweep resolves it against the harness's live-session registry
+(`$CLAUDE_CONFIG_DIR`, else the agent tool's default config home → `sessions/<pid>.json`, one file
+per running session).
+**The three-state resolution is the safety property:** `alive` and `unknown` both KEEP, and only
+`dead` permits a removal — so an unstamped tree, an unreadable registry, or a liveness probe that
+could not execute leaks an orphan rather than destroying a live tree. A sweep that removes nothing
+and reports `registry UNRESOLVED` is the gate working, not a no-op.
+
+It runs `git worktree
 remove` **without `--force`**, so git itself refuses any tree it judges unsafe and that refusal is
 reported as kept, never escalated (mirrors the `@kampus/worktree-guard` reaper's rule, MEMORY
 "Safe worktree prune"). Draining the pile is the operator's explicit call; the command never

--- a/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
+++ b/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
@@ -47,6 +47,7 @@ extract() {
 
 cwd="$(extract cwd)"
 name="$(extract name)"
+session_id="$(extract session_id)"
 
 # cwd + name are both mandatory — the path is CONSTRUCTED from them, so either missing
 # means there is nothing safe to create. Fail-closed (never a silent no-op).
@@ -96,6 +97,24 @@ fi
 if ! git worktree add --detach "$worktree_path" FETCH_HEAD >&2; then
 	echo "create-worktree: git worktree add --detach '$worktree_path' FETCH_HEAD failed — refusing (fail-closed)." >&2
 	exit 1
+fi
+
+# Stamp the OWNING SESSION into the new tree's git admin dir, so a reaper can ask "is this tree's
+# owner still running?" instead of guessing from age (#3943, ADR 0191). Without a stamp the sweep
+# had only mtime, which cannot see a live shipper lane — it removed two mid-run. The stamp lives in
+# `.git/worktrees/<name>/`, NOT the working tree: it must never dirty `git status` (a dirty tree is
+# KEPT forever) and it must vanish with the worktree, which git's own admin dir gives for free.
+# Best-effort by design — a missing stamp reads as owner-unknown, which the sweep KEEPS, so a failure
+# here can only ever leak a tree, never destroy a live one. Never fail the spawn over it.
+if [ -n "$session_id" ]; then
+	if gitdir="$(git -C "$worktree_path" rev-parse --absolute-git-dir 2>/dev/null)"; then
+		printf '{"sessionId":"%s","worktreeName":"%s","stampedAt":"%s"}\n' \
+			"$session_id" "$name" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			>"$gitdir/kampus-owner.json" 2>/dev/null \
+			|| echo "create-worktree: could not stamp owner session (tree reads owner-unknown → never reaped)." >&2
+	fi
+else
+	echo "create-worktree: payload carried no session_id — tree reads owner-unknown (never reaped, #3943)." >&2
 fi
 
 # Success: emit ONLY the path on stdout (all git/install chatter went to stderr above).

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -14,7 +14,7 @@
  * the worktree dir + its per-tree `HEAD`/`logs/HEAD` mtimes past the 30-min threshold.
  */
 import {execFile, execFileSync} from "node:child_process";
-import {existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
+import {existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
@@ -30,23 +30,47 @@ interface RunResult {
 
 // Run `pipeline-cli worktree-sweep [--execute]` with the process cwd inside `mainRepo`
 // (the sweep enumerates the current repo's worktrees), exactly as the SessionStart hook does.
-const runSweep = (cwd: string, flags: ReadonlyArray<string>): Promise<RunResult> =>
+// `env` overlays the inherited environment — the tests point `$CLAUDE_CONFIG_DIR` at a synthetic
+// session registry so owner presence (#3943) is a fact the test controls, not the live machine's.
+const runSweep = (
+	cwd: string,
+	flags: ReadonlyArray<string>,
+	env: Record<string, string> = {},
+): Promise<RunResult> =>
 	new Promise((resolve) => {
-		execFile("node", [BIN, "worktree-sweep", ...flags], {cwd}, (error, stdout, stderr) => {
-			const code =
-				error && typeof (error as {code?: unknown}).code === "number"
-					? (error as {code: number}).code
-					: 0;
-			resolve({code, stdout, stderr});
-		});
+		execFile(
+			"node",
+			[BIN, "worktree-sweep", ...flags],
+			{cwd, env: {...process.env, ...env}},
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
 	});
+
+/** A session id the synthetic registry records as RUNNING, and one it does not (⇒ provably dead). */
+const LIVE_SID = "11111111-1111-4111-8111-111111111111";
+const DEAD_SID = "22222222-2222-4222-8222-222222222222";
 
 describe("worktree-sweep --execute — SessionStart cadence against a REAL git repo (#2238/#2240)", () => {
 	let mainRepo: string;
+	/** A `$CLAUDE_CONFIG_DIR` holding a `sessions/` registry with exactly one live entry (#3943). */
+	let configDir: string;
+	let sweepEnv: Record<string, string>;
 	// $TMPDIR-shaped roots for review-head trees (removed in afterAll — any the sweep KEEPS must be cleaned).
 	const reviewRoots: Array<string> = [];
 	const git = (cwd: string, ...args: string[]) =>
 		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
+
+	/** Stamp an owning session into a worktree's git admin dir, as `create-worktree.sh` does. */
+	const stampOwner = (wtPath: string, sessionId: string) => {
+		const gitdir = git(mainRepo, "-C", wtPath, "rev-parse", "--absolute-git-dir").trim();
+		writeFileSync(join(gitdir, "kampus-owner.json"), JSON.stringify({sessionId}));
+	};
 
 	// Push a managed worktree's dir + per-tree HEAD/logs mtimes ~2h into the past so it reads
 	// idle (well past the 30-min threshold) — simulating an orphaned tree a live lane would not be.
@@ -69,10 +93,22 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		// `origin/main` is the reachability oracle the classifier consults — point it at self.
 		git(mainRepo, "remote", "add", "origin", mainRepo);
 		git(mainRepo, "fetch", "-q", "origin");
+
+		// The presence oracle, made deterministic: one registry entry for LIVE_SID carrying THIS
+		// test process's pid (trivially running), so the sweep's registry-trust gate resolves and
+		// any other stamped session is provably not running.
+		configDir = mkdtempSync(join(tmpdir(), "wts-cfg-"));
+		mkdirSync(join(configDir, "sessions"));
+		writeFileSync(
+			join(configDir, "sessions", `${process.pid}.json`),
+			JSON.stringify({pid: process.pid, sessionId: LIVE_SID}),
+		);
+		sweepEnv = {CLAUDE_CONFIG_DIR: configDir};
 	});
 
 	afterAll(() => {
 		rmSync(mainRepo, {recursive: true, force: true});
+		rmSync(configDir, {recursive: true, force: true});
 		for (const r of reviewRoots) rmSync(r, {recursive: true, force: true});
 	});
 
@@ -80,25 +116,29 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		// Clean + reachable + IDLE (backdated) + unlocked → the only genuinely-orphaned tree → removed.
 		const orphanWt = join(mainRepo, ".claude", "worktrees", "wf_orphan");
 		git(mainRepo, "worktree", "add", "-q", "--detach", orphanWt, "HEAD");
+		stampOwner(orphanWt, DEAD_SID);
 		backdate(orphanWt);
 
 		// Clean + reachable but RECENTLY-ACTIVE (fresh mtime, not backdated) → live lane → KEPT.
 		const liveWt = join(mainRepo, ".claude", "worktrees", "wf_live");
 		git(mainRepo, "worktree", "add", "-q", "--detach", liveWt, "HEAD");
+		stampOwner(liveWt, DEAD_SID);
 
 		// Clean + reachable + idle but LOCKED → pinned in-use → KEPT.
 		const lockedWt = join(mainRepo, ".claude", "worktrees", "wf_locked");
 		git(mainRepo, "worktree", "add", "-q", "--detach", lockedWt, "HEAD");
 		git(mainRepo, "worktree", "lock", lockedWt);
+		stampOwner(lockedWt, DEAD_SID);
 		backdate(lockedWt);
 
 		// Dirty → must be KEPT with its unpushed file intact (proves no --force).
 		const dirtyWt = join(mainRepo, ".claude", "worktrees", "wf_dirty");
 		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyWt, "HEAD");
 		writeFileSync(join(dirtyWt, "uncommitted.txt"), "unpushed work");
+		stampOwner(dirtyWt, DEAD_SID);
 		backdate(dirtyWt);
 
-		const {stdout, code} = await runSweep(mainRepo, ["--execute"]);
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], sweepEnv);
 		assert.strictEqual(code, 0, stdout);
 		assert.isFalse(existsSync(orphanWt), "clean+idle+unlocked orphan must be removed");
 		assert.isTrue(existsSync(liveWt), "recently-active worktree must be kept (live sibling lane)");
@@ -122,15 +162,17 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		// Clean + idle + unlocked leaked review head → reclaimed (no merge gate for this class).
 		const leakedReviewWt = join(reviewRoot, "review-head-8001");
 		git(mainRepo, "worktree", "add", "-q", "--detach", leakedReviewWt, "HEAD");
+		stampOwner(leakedReviewWt, DEAD_SID);
 		backdate(leakedReviewWt);
 
 		// Dirty review head → KEPT, its scratch file intact (proves the reclaim never --force-nukes).
 		const dirtyReviewWt = join(reviewRoot, "review-doc-head-8002");
 		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyReviewWt, "HEAD");
 		writeFileSync(join(dirtyReviewWt, "scratch.txt"), "mid-review edit");
+		stampOwner(dirtyReviewWt, DEAD_SID);
 		backdate(dirtyReviewWt);
 
-		const {stdout, code} = await runSweep(mainRepo, ["--execute"]);
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], sweepEnv);
 		assert.strictEqual(code, 0, stdout);
 		assert.isFalse(existsSync(leakedReviewWt), "clean+idle leaked review-head must be reclaimed");
 		assert.isTrue(existsSync(dirtyReviewWt), "dirty review-head must be kept (no --force)");
@@ -143,10 +185,61 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 	it("dry-run (no --execute) touches nothing — even a clean+idle+unlocked orphan", async () => {
 		const keepWt = join(mainRepo, ".claude", "worktrees", "wf_dryrun");
 		git(mainRepo, "worktree", "add", "-q", "--detach", keepWt, "HEAD");
+		stampOwner(keepWt, DEAD_SID);
 		backdate(keepWt);
-		const {code} = await runSweep(mainRepo, []);
+		const {code} = await runSweep(mainRepo, [], sweepEnv);
 		assert.strictEqual(code, 0);
 		assert.isTrue(existsSync(keepWt), "dry-run must never remove a worktree");
+	}, 30_000);
+
+	// The #3943 regression, end to end: the shipper-shaped state that got two LIVE worktrees removed
+	// — clean, content-merged, unlocked, and mtime-idle — must survive purely because its owning
+	// session is registered as running. The unstamped sibling pins the other half: an owner we cannot
+	// prove dead is KEPT, so a fix that reads "unprovable" as "orphan" turns this red.
+	it("KEEPS a live-session-owned tree AND an unstamped tree in the exact clean+merged+idle state that is otherwise reaped (#3943)", async () => {
+		const liveOwnedWt = join(mainRepo, ".claude", "worktrees", "wf_live_session");
+		git(mainRepo, "worktree", "add", "-q", "--detach", liveOwnedWt, "HEAD");
+		stampOwner(liveOwnedWt, LIVE_SID);
+		backdate(liveOwnedWt);
+
+		const unstampedWt = join(mainRepo, ".claude", "worktrees", "wf_unstamped");
+		git(mainRepo, "worktree", "add", "-q", "--detach", unstampedWt, "HEAD");
+		backdate(unstampedWt);
+
+		// A dead-owner control in the identical state — proves the KEEPs above come from presence,
+		// not from the sweep having gone inert.
+		const deadOwnedWt = join(mainRepo, ".claude", "worktrees", "wf_dead_session");
+		git(mainRepo, "worktree", "add", "-q", "--detach", deadOwnedWt, "HEAD");
+		stampOwner(deadOwnedWt, DEAD_SID);
+		backdate(deadOwnedWt);
+
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], sweepEnv);
+		assert.strictEqual(code, 0, stdout);
+		assert.isTrue(existsSync(liveOwnedWt), "a LIVE session's worktree must never be removed");
+		assert.isTrue(existsSync(unstampedWt), "an owner we cannot prove dead must be KEPT");
+		assert.isFalse(existsSync(deadOwnedWt), "the dead-owner control must still be reclaimed");
+		assert.include(stdout, "live-session");
+		assert.include(stdout, "owner-unknown");
+	}, 30_000);
+
+	// The fail-closed half of the presence gate: with no readable registry there is no way to prove
+	// any owner dead, so the sweep must remove NOTHING — not fall back to the age signal.
+	it("removes nothing when the session registry is unreadable — fail-closed, not age-based (#3943)", async () => {
+		const wt = join(mainRepo, ".claude", "worktrees", "wf_no_registry");
+		git(mainRepo, "worktree", "add", "-q", "--detach", wt, "HEAD");
+		stampOwner(wt, DEAD_SID);
+		backdate(wt);
+
+		const emptyConfig = mkdtempSync(join(tmpdir(), "wts-cfg-none-"));
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], {
+			CLAUDE_CONFIG_DIR: emptyConfig,
+		});
+		rmSync(emptyConfig, {recursive: true, force: true});
+		assert.strictEqual(code, 0, stdout);
+		assert.isTrue(existsSync(wt), "with no trustworthy registry, nothing may be removed");
+		assert.include(stdout, "registry UNRESOLVED");
+
+		git(mainRepo, "worktree", "remove", wt);
 	}, 30_000);
 
 	// #3654: a tree whose working dir was cleaned out from under it (a dead session's temp root)
@@ -181,7 +274,7 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		git(liveWt, "commit", "-q", "-m", "unmerged feature");
 		backdate(liveWt);
 
-		const {stdout, code} = await runSweep(mainRepo, ["--execute"]);
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], sweepEnv);
 		assert.strictEqual(code, 0, stdout);
 		assert.isFalse(listsPath(goneWt), "gone-dir metadata must be pruned from git's worktree list");
 		assert.isTrue(existsSync(liveWt), "a present unmerged tree must be kept");
@@ -194,7 +287,7 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		const goneWt = join(mainRepo, ".claude", "worktrees", "wf_gone_dry");
 		git(mainRepo, "worktree", "add", "-q", "--detach", goneWt, "HEAD");
 		rmSync(goneWt, {recursive: true, force: true});
-		const {code} = await runSweep(mainRepo, []);
+		const {code} = await runSweep(mainRepo, [], sweepEnv);
 		assert.strictEqual(code, 0);
 		assert.isTrue(listsPath(goneWt), "dry-run must not prune gone-dir metadata");
 		git(mainRepo, "worktree", "prune"); // clean up the fixture's stale metadata

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -15,9 +15,10 @@
  *
  * Safe by construction (enforcement lines):
  *   1. The pure classifier only marks a worktree removable when it is CLEAN, reachable
- *      from `origin/main`, AND provably not-in-use — unlocked, mtime-idle past a
- *      threshold, and with no open PR (the #2240 liveness guard). Dirty / unmerged /
- *      live trees are KEPT, so a running sibling lane is never swept.
+ *      from `origin/main`, AND provably not-in-use — its owning session provably DEAD
+ *      (#3943), unlocked, mtime-idle past a threshold, and with no open PR (the #2240
+ *      liveness guard). Dirty / unmerged / live / can't-prove-dead trees are KEPT, so a
+ *      running sibling lane is never swept.
  *   2. `git worktree remove` runs WITHOUT `--force` — git itself refuses a tree it
  *      judges unsafe (dirty/locked/current), and that refusal is caught and reported
  *      as KEPT, never escalated. This is a dirty-work guard, orthogonal to liveness
@@ -31,8 +32,17 @@
  * (.patterns/effect-platform-access.md, #3473).
  */
 import {execFileSync} from "node:child_process";
+import {homedir} from "node:os";
 import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {
+	liveSessionIds,
+	type OwnerLiveness,
+	parseOwnerStamp,
+	parseSessionRegistryEntry,
+	resolveOwnerLiveness,
+	sessionIdFromPath,
+} from "./owner-liveness.ts";
 import {
 	computeWorktreeSweepPlan,
 	isManagedWorktree,
@@ -153,6 +163,87 @@ const worktreeRecentlyActive = (
 		return Date.now() - newest < IDLE_THRESHOLD_MS;
 	});
 
+/**
+ * The harness's live-session registry directory — one `<pid>.json` per RUNNING session, deleted
+ * when the session exits. `$CLAUDE_CONFIG_DIR` is the harness's own override for the config root;
+ * absent it, the tool's default config home under the user's home dir.
+ */
+const sessionRegistryDir = (path: Path.Path): string =>
+	path.join(process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(homedir(), ".claude"), "sessions");
+
+/**
+ * Is `pid` running? Fails toward TRUE, which is what keeps a tree: `ESRCH` is the only positive
+ * evidence of absence, `EPERM` proves the process EXISTS under another uid, and any other error
+ * means the probe could not execute — never that the process is gone (#3943, and the #787 class
+ * where a stripped exec env made a probe's own failure look like a signal).
+ */
+const pidIsAlive = (pid: number): boolean => {
+	// biome-ignore lint/plugin: signal-0 presence probe — `process.kill` throws to report absence, so the branch IS the result; a total helper, never E.
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (cause) {
+		return (cause as {code?: string}).code !== "ESRCH";
+	}
+};
+
+/**
+ * The set of session ids proven alive, or `null` when the registry can't be trusted — in which
+ * case every worktree's owner resolves `"unknown"` and nothing is removed (`liveSessionIds`).
+ */
+const probeLiveSessions = (): Effect.Effect<
+	ReadonlySet<string> | null,
+	never,
+	FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathSvc = yield* Path.Path;
+		const dir = sessionRegistryDir(pathSvc);
+		const names = yield* fs
+			.readDirectory(dir)
+			.pipe(Effect.orElseSucceed((): ReadonlyArray<string> | null => null));
+		if (names === null) return liveSessionIds({readable: false, entries: []});
+		const entries: Array<{sessionId: string; alive: boolean}> = [];
+		for (const name of names) {
+			if (!name.endsWith(".json")) continue;
+			const raw = yield* fs
+				.readFileString(pathSvc.join(dir, name), "utf8")
+				.pipe(Effect.orElseSucceed((): string | null => null));
+			if (raw === null) continue;
+			const entry = parseSessionRegistryEntry(raw);
+			if (entry === null) continue;
+			entries.push({sessionId: entry.sessionId, alive: pidIsAlive(entry.pid)});
+		}
+		return liveSessionIds({readable: true, entries});
+	});
+
+/** The stamp `hooks/create-worktree.sh` writes into `<gitdir>/`; the two names must stay in sync. */
+const OWNER_STAMP_FILE = "kampus-owner.json";
+
+/**
+ * The session that OWNS this worktree: the `WorktreeCreate` stamp in its git admin dir
+ * (`hooks/create-worktree.sh`), else a bare session-UUID segment in its own path — the fallback for
+ * a `$TMPDIR`-rooted review-head tree, which no hook provisions. `null` when neither resolves, so
+ * an unstamped tree is never judged dead.
+ */
+const ownerSessionIdOf = (
+	worktreePath: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const gitdir = runGit(["-C", worktreePath, "rev-parse", "--absolute-git-dir"]);
+		if (gitdir.ok) {
+			const fs = yield* FileSystem.FileSystem;
+			const pathSvc = yield* Path.Path;
+			const raw = yield* fs
+				.readFileString(pathSvc.join(gitdir.stdout.trim(), OWNER_STAMP_FILE), "utf8")
+				.pipe(Effect.orElseSucceed((): string | null => null));
+			const stamped = raw === null ? null : parseOwnerStamp(raw);
+			if (stamped !== null) return stamped;
+		}
+		return sessionIdFromPath(worktreePath);
+	});
+
 const runGh = (args: ReadonlyArray<string>): GitResult => {
 	// biome-ignore lint/plugin: best-effort gh shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
 	try {
@@ -216,6 +307,10 @@ const worktreeSweep = Command.make(
 		}
 
 		const parsed = parseWorktreeList(listed.stdout);
+		// Probed ONCE per run: the registry is a property of the machine, not of a worktree, and a
+		// per-tree re-read could observe a session exit mid-sweep and split one run's verdicts
+		// across two different truths.
+		const live = yield* probeLiveSessions();
 		// Sequential (concurrency 1) on purpose: the liveness probe now crosses the `FileSystem`
 		// seam, and the per-worktree git shell-outs must stay in the same order as before.
 		const records: ReadonlyArray<WorktreeRecord> = yield* Effect.forEach(
@@ -237,6 +332,10 @@ const worktreeSweep = Command.make(
 							locked: p.locked,
 							recentlyActive: false,
 							hasOpenPr: false,
+							// Moot for a gone-dir tree — `prunable` short-circuits the classifier before any
+							// liveness gate, and a prune only clears admin metadata for a tree that is already
+							// gone from disk, so there is no live working surface to pull out from under an owner.
+							ownerLiveness: "unknown" as OwnerLiveness,
 						};
 					}
 					const managed = isManagedWorktree(p.path);
@@ -249,12 +348,25 @@ const worktreeSweep = Command.make(
 					// Only probe the costlier squash signal when ancestry already missed.
 					const squashMerged = reachable ? false : squashMergedToOriginMain(p.head);
 					const recentlyActive = swept ? yield* worktreeRecentlyActive(p.path) : false;
+					// Presence beats recency (#3943): a live shipper lane is mtime-idle, so `recentlyActive`
+					// cannot see it. Probed only for a swept tree — an unswept one is already KEEP.
+					const ownerLiveness: OwnerLiveness = swept
+						? resolveOwnerLiveness({
+								ownerSessionId: yield* ownerSessionIdOf(p.path),
+								liveSessionIds: live,
+							})
+						: "unknown";
 					// The network open-PR probe fires ONLY for a BUILD tree that would otherwise be swept —
 					// managed, clean, unlocked, idle, and content-merged — so SessionStart makes at most
 					// one gh call per reap candidate (usually zero), never one per worktree. A review-head
 					// tree never enters here (no branch, and its classifier branch precedes the open-PR gate).
 					const wouldRemove =
-						managed && !isDirty && !p.locked && !recentlyActive && (reachable || squashMerged);
+						managed &&
+						!isDirty &&
+						!p.locked &&
+						ownerLiveness === "dead" &&
+						!recentlyActive &&
+						(reachable || squashMerged);
 					const hasOpenPr = wouldRemove ? branchHasOpenPr(p.branch) : false;
 					return {
 						path: p.path,
@@ -266,6 +378,7 @@ const worktreeSweep = Command.make(
 						locked: p.locked,
 						recentlyActive,
 						hasOpenPr,
+						ownerLiveness,
 					};
 				}),
 			{concurrency: 1},
@@ -273,7 +386,14 @@ const worktreeSweep = Command.make(
 
 		const plan = computeWorktreeSweepPlan(records);
 
-		// ADR 0092 "emit what you scanned": the full plan is observable before any action.
+		// ADR 0092 "emit what you scanned": the full plan is observable before any action —
+		// including WHICH presence truth the run resolved, so an all-KEEP sweep reads as a
+		// fail-closed registry rather than as a silent no-op.
+		yield* Console.log(
+			live === null
+				? "worktree-sweep: session registry UNRESOLVED — every swept tree KEPT as owner-unknown (fail-closed, #3943)"
+				: `worktree-sweep: ${live.size} live session(s) in the registry — owner presence decides removal (ADR 0191)`,
+		);
 		yield* Console.log(
 			`worktree-sweep: ${records.length} worktree(s) scanned — ${plan.toRemove.length} removable, ${plan.kept.length} kept${execute ? " (EXECUTE)" : " (dry-run)"}`,
 		);

--- a/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
@@ -19,7 +19,7 @@
  * from cwd+name → the git command it runs → the stdout path contract → the fail-closed exits.
  */
 import {execFileSync} from "node:child_process";
-import {existsSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from "node:fs";
+import {existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
@@ -261,6 +261,44 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 
 		rmSync(consumer, {recursive: true, force: true});
 		rmSync(originRepo, {recursive: true, force: true});
+	});
+
+	// The producer half of the #3943 presence gate: the sweep can only ask "is this tree's owner
+	// still running?" if creation recorded WHO owns it. The stamp must land in the git ADMIN dir,
+	// never the working tree — an untracked file there would read as dirty and pin the tree forever.
+	it("stamps the owning session into <gitdir>/kampus-owner.json, leaving the working tree clean (#3943)", () => {
+		const golden = loadGoldenPayload(import.meta.url, GOLDEN);
+		const name = "agent-stamped001";
+		const expected = join(mainRepo, ".claude", "worktrees", name);
+		const {code} = run(mainRepo, goldenPayloadFor(mainRepo, name));
+		assert.strictEqual(code, 0);
+		const gitdir = git(expected, "rev-parse", "--absolute-git-dir").trim();
+		const stamp = JSON.parse(readFileSync(join(gitdir, "kampus-owner.json"), "utf8"));
+		assert.strictEqual(
+			stamp.sessionId,
+			golden.session_id,
+			"the stamp must carry the owning session",
+		);
+		assert.strictEqual(stamp.worktreeName, name);
+		assert.strictEqual(
+			git(expected, "status", "--porcelain").trim(),
+			"",
+			"the stamp must not dirty the working tree (a dirty tree is KEPT forever)",
+		);
+	});
+
+	// Best-effort by design: an unstamped tree resolves owner-unknown, which the sweep KEEPS — so a
+	// missing session_id may leak a tree but must never block a spawn.
+	it("still provisions when the payload carries no session_id (unstamped ⇒ owner-unknown ⇒ never reaped)", () => {
+		const golden = loadGoldenPayload(import.meta.url, GOLDEN);
+		const {session_id: _sid, ...noSession} = golden;
+		const name = "agent-nosession01";
+		const expected = join(mainRepo, ".claude", "worktrees", name);
+		const {code, stdout} = run(mainRepo, JSON.stringify({...noSession, cwd: mainRepo, name}));
+		assert.strictEqual(code, 0, "a missing session_id must not fail-close the spawn");
+		assert.strictEqual(stdout.trim(), expected);
+		const gitdir = git(expected, "rev-parse", "--absolute-git-dir").trim();
+		assert.isFalse(existsSync(join(gitdir, "kampus-owner.json")));
 	});
 
 	// Guard the anti-fabrication invariant directly: the raw fixture bytes fed to the handler

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
@@ -3,12 +3,24 @@
  * worktree is still running, so the sweep can never remove a live lane's tree (issue #3943).
  *
  * The defect this closes: the sweep's original liveness triple (locked / mtime-idle / open-PR)
- * carries no session-presence signal at all, and a live *shipper* lane is indistinguishable from
- * an orphan under it — clean (a shipper only reads), content-merged (its PR just squashed onto
- * `origin/main`), unlocked (this harness never `git worktree lock`s a provisioned tree), and
- * file-mtime idle (a >30min ship touches nothing in the tree; it only runs `gh api`). Two LIVE
- * shipper worktrees were removed mid-run under exactly that state. ADR 0191 is the rule the sweep
- * was missing: a resource claim's liveness rides its HOLDER's presence, never an age window.
+ * carries no session-presence signal, and a live *shipper* lane is indistinguishable from an orphan
+ * under the age-based half of it — clean (a shipper only reads), content-merged (its PR just squashed
+ * onto `origin/main`), and file-mtime idle (a >30min ship touches nothing in the tree; it only runs
+ * `gh api`). Two LIVE shipper worktrees were removed mid-run.
+ *
+ * `locked` is the exception worth stating precisely, because the fix's justification does NOT rest
+ * on it being absent: the harness DOES `git worktree lock` each agent worktree it provisions, with a
+ * pid-bearing reason (`claude agent <id> (pid <N> start <date>)`) that `worktree-reap` already parses
+ * as a presence signal. So the lock gate is real and does protect some live lanes. What it is not is
+ * *reliable*: coverage is partial (most registered trees carry no lock at a given moment, and a lock
+ * can outlive its session), and the `$TMPDIR`-rooted `review-head-*` class is never locked at all —
+ * `review-head materialize` runs `git worktree add --detach` with no `--lock` — so the
+ * `review-head-idle` removal path had no lock protection for a live reviewer's tree. The root cause
+ * of the two observed agent-tree removals is NOT established; this gate is justified as the missing
+ * *presence* signal, not as a replacement for a defeated lock.
+ *
+ * ADR 0191 is the rule the sweep was missing: a resource claim's liveness rides its HOLDER's
+ * presence, never an age window.
  *
  * The presence chain — both halves grounded in observed on-disk artifacts, not inferred:
  *   1. **owner** — the `sessionId` the `WorktreeCreate` hook stamps into the worktree's own git

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
@@ -1,0 +1,137 @@
+/**
+ * `worktree-sweep` owner-liveness core — decide whether the agent session that OWNS a swept
+ * worktree is still running, so the sweep can never remove a live lane's tree (issue #3943).
+ *
+ * The defect this closes: the sweep's original liveness triple (locked / mtime-idle / open-PR)
+ * carries no session-presence signal at all, and a live *shipper* lane is indistinguishable from
+ * an orphan under it — clean (a shipper only reads), content-merged (its PR just squashed onto
+ * `origin/main`), unlocked (this harness never `git worktree lock`s a provisioned tree), and
+ * file-mtime idle (a >30min ship touches nothing in the tree; it only runs `gh api`). Two LIVE
+ * shipper worktrees were removed mid-run under exactly that state. ADR 0191 is the rule the sweep
+ * was missing: a resource claim's liveness rides its HOLDER's presence, never an age window.
+ *
+ * The presence chain — both halves grounded in observed on-disk artifacts, not inferred:
+ *   1. **owner** — the `sessionId` the `WorktreeCreate` hook stamps into the worktree's own git
+ *      admin dir (`<gitdir>/kampus-owner.json`, written by `hooks/create-worktree.sh`). For a
+ *      `$TMPDIR`-rooted `review-head-*` tree, which no hook provisions, the fallback is a bare
+ *      session-UUID segment in its own path (the harness roots a session's `$TMPDIR` scratchpad
+ *      at `…/<session-uuid>/scratchpad/`).
+ *   2. **liveness** — the harness's session registry: one `<config>/sessions/<pid>.json` per
+ *      RUNNING session, carrying `{pid, sessionId}` and deleted when the session exits.
+ *
+ * IO-free by design: the caller reads the files and probes the pids, so every rule below is
+ * unit-testable without a filesystem or a spawned agent.
+ *
+ * **The asymmetry is the whole point.** Every unresolvable input collapses to `"unknown"`, which
+ * the classifier KEEPS: a leaked orphan is a cleanup problem, a removed live tree is destroyed
+ * work. So "cannot prove dead" and "dead" must never collapse into one verdict — a missing stamp,
+ * an unreadable registry, or a probe that could not execute is not evidence of death.
+ */
+
+/**
+ * `"dead"` is the ONLY verdict that lets a removal proceed. `"unknown"` is a distinct third
+ * state on purpose — collapsing it into `"dead"` is the over-reaping defect (#3943).
+ */
+export type OwnerLiveness = "alive" | "dead" | "unknown";
+
+/** A bare session-UUID path segment (the shape both the registry and the sidecar layout use). */
+const SESSION_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const asString = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+
+const parseJson = (raw: string): unknown => {
+	try {
+		return JSON.parse(raw) as unknown;
+	} catch {
+		return null;
+	}
+};
+
+const objectField = (v: unknown, key: string): unknown =>
+	typeof v === "object" && v !== null ? (v as Record<string, unknown>)[key] : undefined;
+
+/**
+ * The owning session id read off a worktree's `kampus-owner.json` stamp, or `null` when the file
+ * is absent, malformed, or carries no session-UUID-shaped `sessionId`. Requiring the UUID shape
+ * (not merely a non-empty string) keeps a truncated or placeholder stamp from resolving to an id
+ * that can never match a registry entry — which would read as `"dead"` rather than `"unknown"`.
+ */
+export const parseOwnerStamp = (raw: string): string | null => {
+	const id = asString(objectField(parseJson(raw), "sessionId"));
+	return SESSION_UUID.test(id) ? id : null;
+};
+
+/** One `<config>/sessions/<pid>.json` entry — a session the harness records as running. */
+export interface SessionRegistryEntry {
+	readonly pid: number;
+	readonly sessionId: string;
+}
+
+/** Parse one registry file; `null` unless it yields BOTH a positive pid and a session id. */
+export const parseSessionRegistryEntry = (raw: string): SessionRegistryEntry | null => {
+	const parsed = parseJson(raw);
+	const pid = objectField(parsed, "pid");
+	const sessionId = asString(objectField(parsed, "sessionId"));
+	if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return null;
+	return SESSION_UUID.test(sessionId) ? {pid, sessionId} : null;
+};
+
+/**
+ * The owning session id recovered from a worktree's own path — the fallback for a `$TMPDIR`-rooted
+ * `review-head-*` tree, which no hook provisions and so carries no stamp. Matches only a segment
+ * that is a bare session UUID, and returns `null` on **ambiguity** (two different UUID segments)
+ * as well as absence: guessing which of two ids owns the tree could name a dead session for a live
+ * tree, and the fail-closed `null` (⇒ `"unknown"` ⇒ KEEP) is the only safe answer.
+ */
+export const sessionIdFromPath = (path: string): string | null => {
+	const found = new Set<string>();
+	for (const segment of path.replace(/\\/g, "/").split("/")) {
+		if (SESSION_UUID.test(segment)) found.add(segment.toLowerCase());
+	}
+	if (found.size !== 1) return null;
+	for (const only of found) return only;
+	return null;
+};
+
+/**
+ * The registry as the boundary observed it. `readable` is false when the registry directory could
+ * not be enumerated at all — a missing directory, a permission error, a harness that does not
+ * write one. `alive` per entry is the boundary's pid-presence probe, which must fail toward TRUE:
+ * a probe that could not execute is not evidence the process is gone. A pid reused by an unrelated
+ * process also reads alive, which only ever KEEPS a tree, so no `procStart` identity check is
+ * needed here (the registry does carry one).
+ */
+export interface SessionRegistryProbe {
+	readonly readable: boolean;
+	readonly entries: ReadonlyArray<{readonly sessionId: string; readonly alive: boolean}>;
+}
+
+/**
+ * The set of session ids proven alive, or `null` when the registry cannot be trusted to be
+ * complete — in which case every owner resolves `"unknown"` and nothing is removed.
+ *
+ * Two fail-closed conditions, and the second is the load-bearing one: the sweep itself runs from a
+ * `SessionStart` hook, i.e. **inside a session that is by definition alive**, so a complete
+ * registry always holds at least one live entry. Zero live entries therefore means the registry is
+ * absent, stale, or written in a shape this parser does not understand — never "no session is
+ * running". Without that self-corroboration a harness that stopped writing the registry would
+ * silently mark every worktree on the machine `"dead"`, which is the failure mode this whole module
+ * exists to prevent.
+ */
+export const liveSessionIds = (probe: SessionRegistryProbe): ReadonlySet<string> | null => {
+	if (!probe.readable) return null;
+	const live = new Set(probe.entries.filter((e) => e.alive).map((e) => e.sessionId.toLowerCase()));
+	return live.size === 0 ? null : live;
+};
+
+/**
+ * Resolve one worktree's owner liveness. `null` for either input is the unprovable case:
+ * an unresolvable owner (no stamp, no session segment in the path) or an untrustworthy registry.
+ */
+export const resolveOwnerLiveness = (args: {
+	readonly ownerSessionId: string | null;
+	readonly liveSessionIds: ReadonlySet<string> | null;
+}): OwnerLiveness => {
+	if (args.liveSessionIds === null || args.ownerSessionId === null) return "unknown";
+	return args.liveSessionIds.has(args.ownerSessionId.toLowerCase()) ? "alive" : "dead";
+};

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.unit.test.ts
@@ -1,0 +1,123 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	liveSessionIds,
+	parseOwnerStamp,
+	parseSessionRegistryEntry,
+	resolveOwnerLiveness,
+	sessionIdFromPath,
+} from "./owner-liveness.ts";
+
+const SID_A = "85123b6c-d220-46c5-ac19-77ccedffb3d7";
+const SID_B = "ddf8f459-b75f-4de2-9051-8df10da5b55c";
+
+describe("parseOwnerStamp", () => {
+	it("reads the sessionId the WorktreeCreate hook stamped", () => {
+		const raw = `{"sessionId":"${SID_A}","worktreeName":"agent-abc","stampedAt":"2026-07-24T22:00:00Z"}`;
+		assert.strictEqual(parseOwnerStamp(raw), SID_A);
+	});
+
+	it("returns null for malformed JSON, a missing field, and a non-UUID id (⇒ unknown ⇒ KEEP)", () => {
+		assert.isNull(parseOwnerStamp("{not json"));
+		assert.isNull(parseOwnerStamp('{"worktreeName":"agent-abc"}'));
+		assert.isNull(parseOwnerStamp('{"sessionId":"pending"}'));
+		assert.isNull(parseOwnerStamp('{"sessionId":""}'));
+	});
+});
+
+describe("parseSessionRegistryEntry", () => {
+	it("reads pid + sessionId off a registry file", () => {
+		const raw = `{"pid":58920,"sessionId":"${SID_A}","cwd":"/repo","status":"busy"}`;
+		assert.deepStrictEqual(parseSessionRegistryEntry(raw), {pid: 58920, sessionId: SID_A});
+	});
+
+	it("rejects an entry with no usable pid or no session id", () => {
+		assert.isNull(parseSessionRegistryEntry(`{"sessionId":"${SID_A}"}`));
+		assert.isNull(parseSessionRegistryEntry(`{"pid":0,"sessionId":"${SID_A}"}`));
+		assert.isNull(parseSessionRegistryEntry(`{"pid":-1,"sessionId":"${SID_A}"}`));
+		assert.isNull(parseSessionRegistryEntry('{"pid":42,"sessionId":"nope"}'));
+		assert.isNull(parseSessionRegistryEntry("garbage"));
+	});
+});
+
+describe("sessionIdFromPath", () => {
+	it("recovers the owning session from a session-rooted $TMPDIR review-head path", () => {
+		assert.strictEqual(
+			sessionIdFromPath(`/private/tmp/claude-501/-Users-dev-phoenix/${SID_A}/scratchpad/rh-3917`),
+			SID_A,
+		);
+	});
+
+	it("returns null when no segment is a bare session UUID (an unrooted $TMPDIR)", () => {
+		assert.isNull(sessionIdFromPath("/private/var/folders/8f/tmp.ZE2abJOOnR/review-head-3861"));
+	});
+
+	it("returns null on AMBIGUITY — two different UUID segments could name a dead owner for a live tree", () => {
+		assert.isNull(sessionIdFromPath(`/tmp/${SID_A}/nested/${SID_B}/scratchpad/review-head-1`));
+	});
+
+	it("does not read a UUID embedded inside a longer segment as the owner", () => {
+		assert.isNull(sessionIdFromPath(`/private/tmp/claude-501/-Users-dev-crew-run-${SID_A}/wt`));
+	});
+});
+
+describe("liveSessionIds — the registry trust gate", () => {
+	it("returns the alive session ids when the registry is readable and has a live entry", () => {
+		const live = liveSessionIds({
+			readable: true,
+			entries: [
+				{sessionId: SID_A, alive: true},
+				{sessionId: SID_B, alive: false},
+			],
+		});
+		assert.deepStrictEqual(live === null ? null : [...live], [SID_A]);
+	});
+
+	it("returns null when the registry directory could not be enumerated (probe could not execute)", () => {
+		assert.isNull(liveSessionIds({readable: false, entries: []}));
+	});
+
+	it("returns null when NO entry is alive — the sweep itself runs inside a live session, so an empty live set means the registry is untrustworthy, never 'nothing is running'", () => {
+		assert.isNull(liveSessionIds({readable: true, entries: []}));
+		assert.isNull(liveSessionIds({readable: true, entries: [{sessionId: SID_A, alive: false}]}));
+	});
+});
+
+describe("resolveOwnerLiveness", () => {
+	const live: ReadonlySet<string> = new Set([SID_A]);
+
+	it("resolves ALIVE when the owner is a registered live session", () => {
+		assert.strictEqual(
+			resolveOwnerLiveness({ownerSessionId: SID_A, liveSessionIds: live}),
+			"alive",
+		);
+	});
+
+	it("matches case-insensitively (the UUID's hex case is not identity)", () => {
+		assert.strictEqual(
+			resolveOwnerLiveness({ownerSessionId: SID_A.toUpperCase(), liveSessionIds: live}),
+			"alive",
+		);
+	});
+
+	it("resolves DEAD only for a resolvable owner absent from a trusted live set", () => {
+		assert.strictEqual(resolveOwnerLiveness({ownerSessionId: SID_B, liveSessionIds: live}), "dead");
+	});
+
+	it("resolves UNKNOWN — never dead — for an unresolvable owner (no stamp, no session in the path)", () => {
+		assert.strictEqual(
+			resolveOwnerLiveness({ownerSessionId: null, liveSessionIds: live}),
+			"unknown",
+		);
+	});
+
+	it("resolves UNKNOWN — never dead — for every owner when the registry is untrustworthy", () => {
+		assert.strictEqual(
+			resolveOwnerLiveness({ownerSessionId: SID_B, liveSessionIds: null}),
+			"unknown",
+		);
+		assert.strictEqual(
+			resolveOwnerLiveness({ownerSessionId: null, liveSessionIds: null}),
+			"unknown",
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -43,7 +43,17 @@
  * a dirty-work guard, orthogonal to liveness). So a clean+merged tree is removed only
  * when it is also provably NOT in use: unlocked AND idle past a threshold (mtime) AND
  * with no open PR for its branch. Every liveness signal fails safe toward KEEP.
+ *
+ * Session-presence liveness (#3943): the three signals above are all the sweep had, and none of
+ * them is presence — so a live SHIPPER lane read as an orphan (clean, its PR just squash-merged,
+ * unlocked, and mtime-idle because a ship touches no file in the tree) and had its worktree
+ * removed mid-run, twice. Removal now additionally requires the owning session to be **provably
+ * dead**: `ownerLiveness` must be `"dead"`, resolved from holder presence per ADR 0191, never from
+ * age. `"alive"` and `"unknown"` both KEEP — see `owner-liveness.ts` for the resolution and for why
+ * "cannot prove dead" must never collapse into "dead".
  */
+
+import type {OwnerLiveness} from "./owner-liveness.ts";
 
 /** The segment that marks a harness-managed agent worktree: `<main>/.claude/worktrees/<id>`. */
 const MANAGED_SEGMENT = "/.claude/worktrees/";
@@ -109,6 +119,12 @@ export interface WorktreeRecord {
 	readonly locked: boolean;
 	readonly recentlyActive: boolean;
 	readonly hasOpenPr: boolean;
+	/**
+	 * Whether the agent session that OWNS this worktree is still running (#3943), resolved from
+	 * holder presence at the boundary (`owner-liveness.ts`). Only `"dead"` permits a removal:
+	 * `"alive"` is a live lane and `"unknown"` is an owner we could not prove dead — both KEEP.
+	 */
+	readonly ownerLiveness: OwnerLiveness;
 }
 
 /** Why a worktree is KEPT — the audit trail, so the plan is never an opaque list. */
@@ -119,6 +135,10 @@ export type KeepReason =
 	| "dirty"
 	/** `git worktree lock` is set — an operator/agent pinned it as in-use (#2240). */
 	| "locked"
+	/** The owning agent session is still running — a LIVE lane; kept whatever its other facts say (#3943). */
+	| "live-session"
+	/** The owning session could not be proven dead (no stamp, or an untrustworthy registry) — kept (#3943). */
+	| "owner-unknown"
 	/** Touched within the idle threshold — presumed a live lane, never swept (#2240). */
 	| "recently-active"
 	/** The branch has an open PR — an in-flight lane, kept until it merges + goes idle (#2240). */
@@ -183,10 +203,12 @@ export interface WorktreeSweepPlan {
  *      tree with a LIVE directory are never candidates, regardless of their other facts.
  *   2. Dirty → KEEP (`dirty`). Wins over every other signal for BOTH classes: a worktree
  *      with working-tree changes is never removed, even when its branch has merged.
- *   3. Liveness gates (#2240) — locked / recently-active → KEEP, for BOTH classes. A clean
- *      tree may still belong to a LIVE lane (a build tree just committed+pushed; a review
- *      still running against its head). These run BEFORE any remove branch, so each is a
- *      necessary condition on REMOVE.
+ *   3. Liveness gates — locked (#2240) / owner alive-or-unprovable (#3943) / recently-active
+ *      (#2240) → KEEP, for BOTH classes. A clean tree may still belong to a LIVE lane (a build
+ *      tree just committed+pushed; a review still running against its head). These run BEFORE any
+ *      remove branch, so each is a necessary condition on REMOVE. The presence gate subsumes the
+ *      mtime one it sits above — an idle-but-live shipper is exactly what mtime could not see —
+ *      and `recently-active` is retained below it because it can only ever KEEP more.
  *   4. Review-head tree → REMOVE (`review-head-idle`). Past the dirty+locked+recently-active
  *      guards, a detached throwaway review checkout holds no branch and no unpushed work, so
  *      it is a pure leak — no merge/open-PR gate applies (see `review-head-idle`). Returns here
@@ -213,6 +235,12 @@ export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	}
 	if (wt.locked) {
 		return {kind: "keep", reason: "locked"};
+	}
+	if (wt.ownerLiveness === "alive") {
+		return {kind: "keep", reason: "live-session"};
+	}
+	if (wt.ownerLiveness !== "dead") {
+		return {kind: "keep", reason: "owner-unknown"};
 	}
 	if (wt.recentlyActive) {
 		return {kind: "keep", reason: "recently-active"};

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -45,9 +45,10 @@
  * with no open PR for its branch. Every liveness signal fails safe toward KEEP.
  *
  * Session-presence liveness (#3943): the three signals above are all the sweep had, and none of
- * them is presence — so a live SHIPPER lane read as an orphan (clean, its PR just squash-merged,
- * unlocked, and mtime-idle because a ship touches no file in the tree) and had its worktree
- * removed mid-run, twice. Removal now additionally requires the owning session to be **provably
+ * them is presence — so a live SHIPPER lane read as an orphan (clean, its PR just squash-merged, and
+ * mtime-idle because a ship touches no file in the tree) and had its worktree removed mid-run, twice.
+ * The `locked` gate is real presence-ish signal but only partially covers the pile (and never covers
+ * `review-head-*`); see `owner-liveness.ts`. Removal now additionally requires the owning session to be **provably
  * dead**: `ownerLiveness` must be `"dead"`, resolved from holder presence per ADR 0191, never from
  * age. `"alive"` and `"unknown"` both KEEP — see `owner-liveness.ts` for the resolution and for why
  * "cannot prove dead" must never collapse into "dead".

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -26,6 +26,9 @@ const reviewRecord = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	locked: false,
 	recentlyActive: false,
 	hasOpenPr: false,
+	// The fixtures default to a PROVABLY-DEAD owner so each pre-#3943 case still exercises the
+	// branch it was written for. The live/unknown owners are the explicit guard cases below.
+	ownerLiveness: "dead",
 	...over,
 });
 
@@ -39,8 +42,27 @@ const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	locked: false,
 	recentlyActive: false,
 	hasOpenPr: false,
+	ownerLiveness: "dead",
 	...over,
 });
+
+/**
+ * The exact state that got two LIVE shipper worktrees removed mid-run (#3943): clean (a shipper
+ * only reads), its PR just squash-merged onto `origin/main`, unlocked (this harness never locks a
+ * provisioned tree), and mtime-idle (a >30min ship touches no file in the tree). Every pre-#3943
+ * signal reads "orphan"; only owner presence tells it apart from one.
+ */
+const shipperShaped = (over: Partial<WorktreeRecord> = {}): WorktreeRecord =>
+	record({
+		branch: "usirin/ship-3913",
+		isDirty: false,
+		reachableFromOriginMain: false,
+		squashMergedToOriginMain: true,
+		locked: false,
+		recentlyActive: false,
+		hasOpenPr: false,
+		...over,
+	});
 
 describe("isManagedWorktree", () => {
 	it("matches a path under .claude/worktrees/", () => {
@@ -185,6 +207,65 @@ describe("classifyWorktree — KEEP branches (the safety cases)", () => {
 	it("dirty wins over a liveness signal (still kept, reported as dirty)", () => {
 		const d = classifyWorktree(record({isDirty: true, locked: true, hasOpenPr: true}));
 		assert.deepStrictEqual(d, {kind: "keep", reason: "dirty"});
+	});
+});
+
+// The defect these pin is OVER-reaping, so these are the load-bearing tests: a dead-owner case
+// only proves the reap still works, while a live or unprovable owner reaching REMOVE is destroyed
+// work. Deleting the `ownerLiveness` gate from `classifyWorktree` turns every case here red.
+describe("classifyWorktree — owner-presence liveness (#3943, ADR 0191)", () => {
+	it("KEEPS a LIVE owner's worktree in the exact shipper-shaped state that was reaped: clean + squash-merged + unlocked + idle", () => {
+		const d = classifyWorktree(shipperShaped({ownerLiveness: "alive"}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "live-session"});
+	});
+
+	it("KEEPS an UNPROVABLE owner's worktree in that same shipper-shaped state — cannot prove dead is not dead", () => {
+		const d = classifyWorktree(shipperShaped({ownerLiveness: "unknown"}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "owner-unknown"});
+	});
+
+	it("KEEPS a LIVE owner's clean, ancestor-merged worktree (presence beats the merge gate)", () => {
+		const d = classifyWorktree(record({reachableFromOriginMain: true, ownerLiveness: "alive"}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "live-session"});
+	});
+
+	it("KEEPS a LIVE reviewer's review-head tree (the same mid-run removal, on the review class)", () => {
+		const d = classifyWorktree(reviewRecord({ownerLiveness: "alive"}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "live-session"});
+	});
+
+	it("KEEPS an unstamped review-head tree whose owner is unprovable (leak the orphan, never the live tree)", () => {
+		const d = classifyWorktree(reviewRecord({ownerLiveness: "unknown"}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "owner-unknown"});
+	});
+
+	it("reports DIRTY ahead of presence — a live owner's dirty tree is still kept, never --force", () => {
+		const d = classifyWorktree(shipperShaped({isDirty: true, ownerLiveness: "alive"}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "dirty"});
+	});
+
+	it("still PRUNES a gone-dir tree regardless of owner liveness (no working surface to pull away)", () => {
+		const d = classifyWorktree(record({prunable: true, ownerLiveness: "alive"}));
+		assert.deepStrictEqual(d, {kind: "remove", reason: "gone-dir"});
+	});
+
+	it("removes the shipper-shaped tree ONLY once its owner is provably dead", () => {
+		const d = classifyWorktree(shipperShaped({ownerLiveness: "dead"}));
+		assert.deepStrictEqual(d, {kind: "remove", reason: "squash-merged-clean"});
+	});
+
+	it("partitions a live and a dead sibling into kept vs removable in one plan", () => {
+		const alive = shipperShaped({path: wtPath("agent-live"), ownerLiveness: "alive"});
+		const dead = shipperShaped({path: wtPath("agent-dead"), ownerLiveness: "dead"});
+		const plan = computeWorktreeSweepPlan([alive, dead]);
+		assert.deepStrictEqual(
+			plan.toRemove.map((r) => r.worktree.path),
+			[dead.path],
+		);
+		assert.deepStrictEqual(
+			plan.kept.map((k) => [k.worktree.path, k.reason]),
+			[[alive.path, "live-session"]],
+		);
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -47,10 +47,11 @@ const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 });
 
 /**
- * The exact state that got two LIVE shipper worktrees removed mid-run (#3943): clean (a shipper
- * only reads), its PR just squash-merged onto `origin/main`, unlocked (this harness never locks a
- * provisioned tree), and mtime-idle (a >30min ship touches no file in the tree). Every pre-#3943
- * signal reads "orphan"; only owner presence tells it apart from one.
+ * The shipper-shaped state a live lane presents to the age-based signals (#3943): clean (a shipper
+ * only reads), its PR just squash-merged onto `origin/main`, and mtime-idle (a >30min ship touches no
+ * file in the tree). `locked: false` here is the reapable *fixture* state under test, NOT a claim
+ * that a live tree is never locked — see `owner-liveness.ts` for what the lock gate does and does not
+ * cover. Under these signals only owner presence tells a live lane apart from an orphan.
  */
 const shipperShaped = (over: Partial<WorktreeRecord> = {}): WorktreeRecord =>
 	record({


### PR DESCRIPTION
Twice in one session the SessionStart worktree sweep deleted a shipper agent's worktree while that agent was still running, which makes every later command in the lane fail with a confusing `MODULE_NOT_FOUND` or exit 127 instead of "your filesystem was removed". The same timing during a coder's edits would destroy uncommitted work. This PR stops the sweep from removing any worktree unless the agent session that owns it is provably no longer running.

The old rule could not tell a live shipper from an orphan on its age-based signals, because a shipper defeats every one of them: it never edits files, its PR has just merged, and its file timestamps never move during a half-hour ship. Age is not liveness. The new rule asks who owns the tree and whether that owner is still alive — and when it cannot answer, it keeps the tree. Leaking an orphan is a cleanup chore; removing a live tree is destroyed work, so the bias is deliberately one-sided.

## What changed

- **`hooks/create-worktree.sh`** stamps the owning `sessionId` into the new tree's git admin dir (`<gitdir>/kampus-owner.json`). It lives there, not in the working tree, so it can never dirty `git status` — a dirty tree would be pinned forever. Best-effort: a failed stamp reads as owner-unknown, which is KEEP.
- **`packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts`** (new, pure) resolves the owner and its liveness: the stamp, else a bare session-UUID segment in a `$TMPDIR` review-head tree's own path; liveness from the harness's live-session registry (one file per running session, deleted on exit).
- **`worktree-sweep.ts`** gains `ownerLiveness: "alive" | "dead" | "unknown"` on `WorktreeRecord` and two KEEP reasons (`live-session`, `owner-unknown`). Only `"dead"` lets a removal proceed.
- **`command.ts`** probes the registry once per run, resolves each swept tree's owner, and prints which presence truth the run resolved, so an all-KEEP sweep reads as a fail-closed registry rather than a silent no-op.
- **`.patterns/worktree-agent-constraints.md`** documents the gate above the existing #2240 triple.

## Attribution (AC 1) — corrected

**An earlier revision of this section was wrong and is retracted.** It claimed that `git worktree list --porcelain` emits no `locked` line for agent worktrees / that this harness never locks a provisioned tree. That is **false**, and it was falsified on the live machine. The corrected reading, re-verified independently before this rewrite:

- **Porcelain does emit `locked` lines on harness-provisioned agent worktrees**, carrying exactly the pid-bearing reason the retracted text said nothing writes: `locked claude agent agent-<id> (pid <N> start <date>)`. The pids name live crew session processes, including this lane's own tree.
- **So `locked` is a real liveness signal, and it does protect some live trees.** The sweep already KEEPs any locked tree (`line.startsWith("locked")` in `parseWorktreeList` → `keep`/`locked`, ordered ahead of every remove branch), and a non-forced `git worktree remove` refuses a locked tree anyway.
- **`worktree-reap` is therefore not structurally inert for the stated reason.** It parses that same `claude agent … (pid N …)` reason as its presence signal (`parseAgentLockOwner`), and the reason *is* written by the harness. It is inert only by **non-invocation** — nothing but `registry.ts` references it; no hook, CI job, or skill invokes it. It is also *more* aggressive than the retracted text implied: it runs `git worktree unlock` on a stale-locked tree before a non-forced `remove`.
- **Locking predates the incidents.** One live lock is ~5 weeks stale (`pid 4299`, dated Jun 19), so the mechanism is not new and a lock can outlive its session.

**What survives, on different evidence.** The fix still targets a real hole — but the hole is partial coverage, not an absent signal:

- **Lock coverage is partial, not universal.** Measured live: **6 of 214** registered worktrees carry a lock; of the **51** agent trees whose mtime falls inside 24h, **46 carry no lock**. So "unlocked" cannot be read as "not live", and the lock gate cannot be relied on as *the* liveness line.
- **`review-head-*` trees are never locked at all.** `review-head materialize` runs `git worktree add --detach` with **no `--lock`** (`packages/pipeline-cli/src/tools/review-head/materialize.ts`), and only the harness's own agent-worktree provisioning writes the `claude agent …` lock. So the `review-head-idle` removal path could remove a **live reviewer's** tree with zero lock protection. That is the specific unprotected hole this gate closes.
- **The root cause of the two originally-observed *agent-tree* removals is NOT established.** The `SubagentStop` `worktree-guard reap` still only ever removes the stopping agent's own `$WORKTREE_ROOT` (the #2798 owner gate), so it cannot remove a different, live agent's tree — but with the `locked` premise retracted, attributing the two removals to the sweep's age-based gates is no longer supported by evidence. This PR is justified as adding the missing **presence** signal, not as closing a proven attribution.

The change is strictly KEEP-biased — it only ever adds a necessary condition for removal — so it cannot introduce over-reaping regardless of which reaper was at fault.

## Tests

`ownerLiveness` was removed from the classifier to confirm the guards are load-bearing: **8 tests go red**, covering both the live case and the unknown case, at the pure-core and the real-git-command levels. Restored, all 2037 pipeline-cli tests pass.

The load-bearing cases pin the *over-*reaping direction, since a dead-owner test only proves the reap still works:

- a LIVE owner in the exact shipper-shaped state (clean + squash-merged + unlocked + idle) must be KEPT;
- an UNPROVABLE owner in that same state must be KEPT;
- a live reviewer's review-head tree must be KEPT;
- with no readable registry, the sweep must remove **nothing** rather than fall back to age;
- a dead-owner control in the identical state is still reclaimed, so the KEEPs above are presence, not inertness.

No reaper was run against this machine while validating; every case runs against a throwaway git repo with a synthetic registry under `$CLAUDE_CONFIG_DIR`.

## Notes

- **No removal path escalates to `--force`** (AC 4), verified in source across all three surfaces: `worktree-sweep/command.ts`, `worktree-reap/command.ts`, and `worktree-guard/command.ts` all run a bare `git worktree remove`. (`worktree-reap` does `unlock` a stale-locked tree first, but never `--force`s the removal.)
- The `gone-dir` prune path is untouched: a tree whose working directory is already gone has no live surface to pull away, and it is the bulk of the orphan pile (#3887).
- **Expect near-silence, and not only from legacy trees.** The stamp carries the **launcher's** session id, and a crew pane is long-lived — so every tree that pane provisioned reads `alive` for the pane's *entire* lifetime, not merely while the subagent using it runs. Together with the unstamped pre-change pile (`owner-unknown` → KEEP), the sweep goes near-silent during any crew run and only the gone-dir `prunable` class still drains. That is the safe direction, but it means **#3887's pileup curve will not bend from this change**; #3892 remains the decision surface for a liveness-keyed, operator-confirmed drain, and this PR deliberately does not make any reaper more aggressive to clear the pile.

Part of #3943

