### PR TITLE
docs(roadmap): add Taste-Skill Library campaign row (#42)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,6 +35,7 @@ flowchart TD
 		camp_flag_graduation["Flag Graduation"]:::active
 		camp_pipeline_cli_glue_consolidation["pipeline-cli Glue Consolidation"]:::active
 		camp_lint_gate_adoption["Lint-Gate Adoption"]:::active
+		camp_taste_skill_library["Taste-Skill Library"]:::active
 		camp_pipeline_anywhere["Pipeline Anywhere"]:::active
 		camp_pipeline_cli_effect_platform_migration["pipeline-cli @effect/platform migration"]:::active
 		camp_agentic_design_system_coverage["Agentic design-system coverage"]:::done

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,6 +87,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Flag Graduation | #39 | active |
 | pipeline-cli Glue Consolidation | #40 | active |
 | Lint-Gate Adoption | #41 | active |
+| Taste-Skill Library | #42 | active |
 | Pipeline Anywhere | #35 | active |
 | pipeline-cli @effect/platform migration | #32 | active |
 | Agentic design-system coverage | #33 | done |


### PR DESCRIPTION
Adds the Campaigns-table row for the founder-approved **Taste-Skill Library** campaign (milestone #42), which homes epic #3946 and its 9 planned children (#3961, #3969–#3976) — closing the last non-exempt unmilestoned family under the no-floaters ruling (ADR 0208 frame).

- roadmap-guard: in sync — 4 arc rows + 16 campaign rows validated against 38 milestones (I1–I5 all green), run in this branch's tree.
- One-row docs change; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuarU7Ctwdv5Z6sXc1tzKc