### PR TITLE
docs(pipeline-cli): cite #3471, not #3929, in the symlink-reconstruction comments (#3981)

### DIFF
--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
@@ -71,7 +71,7 @@ const walk = (
 			// reachability tests are NEGATIONS (`!consumingConstants.has` / `!journeyKeys.has`), so
 			// a wider walk can only turn a RED into a GREEN — purely fail-open for a fail-closed
 			// gate (ADR 0092/0173) — and, since the ignore-list screens by NAME with no visited set,
-			// a symlink cycle would be unbounded recursion (#3929). Symlinked FILES stay in scope as
+			// a symlink cycle would be unbounded recursion (#3471). Symlinked FILES stay in scope as
 			// at base, hence the check gates the Directory arm only; a link is also never `stat`ed,
 			// so a broken one is ignored rather than surfacing as an IoError, again as at base.
 			const isSymlink = yield* fs.readLink(abs).pipe(

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
@@ -58,7 +58,7 @@ export const listWorkflowScripts = (
 			// A symlinked `.js` is out of scope, reconstructing the pre-migration `Dirent.isFile()`
 			// (lstat-based, so a link-to-file was excluded). `fs.stat` follows links and v4's
 			// FileSystem exposes no `lstat`, but `readLink` succeeds only on a link — the equivalent
-			// test (same reconstruction as `reachability-guard`'s walk, #3929).
+			// test (same reconstruction as `reachability-guard`'s walk, #3471).
 			const isSymlink = yield* fs.readLink(abs).pipe(
 				Effect.as(true),
 				Effect.orElseSucceed(() => false),


### PR DESCRIPTION
Fixes #3981

Two symlink-reconstruction comments in `pipeline-cli` cited `#3929`, which is an unrelated open issue ("No repair path for 'PR already PASSED/approved, defect found later'"). A reader chasing that number for the rationale lands on nothing — and these comments are the only in-source record of *why* each walk's symlink gate sits on the arm it does.

**Comment-only change. No behavior change, no test change.**

## Provenance, verified via `gh api`

| ref | what it actually is |
| --- | --- |
| `#3929` | open, unrelated — "No repair path for 'PR already PASSED/approved, defect found later'" |
| `#3471` | closed — "Migrate pipeline-cli fanout / reachability / workflow / path-filter guards to v4 platform idiom (§CP)" |
| PR `#3915` | merged as `fe764d95` — "route fanout/reachability/workflow/path-filter guards through the FileSystem/Path seam (#3471)" |

`#3471` is the correct provenance; `fe764d95` is the commit that introduced both comments.

## The two sites

- `packages/pipeline-cli/src/tools/workflow-contract/gate.ts` — the `readLink` block ahead of the `.type === "File"` test in the workflow-script listing walk.
- `packages/pipeline-cli/src/tools/reachability-guard/gate.ts` — the `readLink` block gating the Directory arm of the walk.

## The mechanics were verified, not assumed

I checked each comment's claim against the pre-migration source (`git show fe764d95^`) before touching the prose. Both are accurate, so **only the number changed**:

- `workflow-contract`'s base was `.filter((e) => e.isFile() && e.name.endsWith(".js"))`. `Dirent.isFile()` is **lstat**-based, so it returns `false` for a symlink, whereas effect v4's `fs.stat` **follows** symlinks. To preserve the original scope the `readLink` check must therefore sit **ahead of** the `.type === "File"` test — which is exactly what the code does (`if (isSymlink) continue;`). That code is correct and is left untouched.
- `reachability-guard`'s base recursed on `entry.isDirectory()`, likewise lstat-based, so its link check correctly gates the Directory arm only.

## Verification

- `grep -rn '3929' packages/pipeline-cli/` — clean, no occurrences remain.
- `pnpm typecheck` — 29/29 tasks green.
- `pnpm lint:worktree` — 2 files checked, clean.
- `pnpm --filter @kampus/pipeline-cli test` — 146 files, 2058 tests passing.

## Control-plane

`packages/pipeline-cli/` is control-plane by path, so this needs a human control-plane approval before merge. Not to be auto-merged.
