### PR TITLE
docs(patterns): replace the uniform Directory-arm rule with the base-polarity precondition (#3983)

### DIFF
--- a/.patterns/effect-platform-access.md
+++ b/.patterns/effect-platform-access.md
@@ -170,6 +170,12 @@ wrapper), never woven through a service method.
 > matching `@patch-pin:`"), the shape most of the guard stack has — a RED becomes GREEN and the
 > guard fails **open**. (A positively-shaped predicate only gains violations: GREEN→RED, noisy but
 > fail-closed.) CI cannot catch it, because a fresh checkout contains no stray symlinks.
+>
+> **So the only detection method is a differential A/B of the built binaries against a planted
+> symlink fixture:** build the pre-migration base and the head, plant a real symlinked dir / a real
+> symlinked file / a dangling link under the walk root, run both binaries over that tree, and diff
+> exit code + report. A code review of the diff will not surface the widening (the swapped line reads
+> as equivalent), and no CI job can — the fixture cannot exist in a checkout.
 
 The three facts, at the pinned `effect@4.0.0-beta.92` / `@effect/platform-node-shared@4.0.0-beta.92`:
 
@@ -184,32 +190,66 @@ stat that *is* a link (`stat.isSymbolicLink()`), which `fs.stat` never returns �
 `type === "SymbolicLink"` is dead code on that path.
 
 Observed instances of the swap, for reviewers of the remaining
-[#3462](https://github.com/kamp-us/phoenix/issues/3462) migration waves — all three are `readLink`-gated
-on `main` today; none is still latent:
-[#3472](https://github.com/kamp-us/phoenix/issues/3472) / PR
-[#3898](https://github.com/kamp-us/phoenix/pull/3898) (`patch-guard`) — **confirmed fail-open**, a
-`@patch-pin:` marker behind a symlinked dir flipped the gate RED→GREEN;
-[#3470](https://github.com/kamp-us/phoenix/issues/3470) / PR
-[#3897](https://github.com/kamp-us/phoenix/pull/3897) (`design-token-guard`) and
-[#3471](https://github.com/kamp-us/phoenix/issues/3471) / PR
-[#3915](https://github.com/kamp-us/phoenix/pull/3915) (`reachability-guard`) — same shape, fixed in
-the migration PR rather than after it.
+[#3462](https://github.com/kamp-us/phoenix/issues/3462) migration waves — all four are `readLink`-gated
+on `main` today; none is still latent. The **pre-migration file arm** is recorded for each, because it
+is what decides which arm the gate belongs on (the base-polarity table below):
 
-### The sanctioned idiom — gate the `Directory` arm on `readLink` failing
+- [#3472](https://github.com/kamp-us/phoenix/issues/3472) / PR
+  [#3898](https://github.com/kamp-us/phoenix/pull/3898) — `patch-guard`, **confirmed fail-open**: a
+  `@patch-pin:` marker behind a symlinked dir flipped the gate RED→GREEN. Base file arm was
+  `if (!statSync(abs).isFile() || !isTestFile(entry.name)) continue;` — a link-*following* `statSync`.
+- [#3470](https://github.com/kamp-us/phoenix/issues/3470) / PR
+  [#3897](https://github.com/kamp-us/phoenix/pull/3897) — `design-token-guard` (`walkCss`), fixed in
+  the migration PR. Base file arm screened by name only (`e.name.endsWith(".css")`).
+- [#3471](https://github.com/kamp-us/phoenix/issues/3471) / PR
+  [#3915](https://github.com/kamp-us/phoenix/pull/3915) — `reachability-guard`, fixed in the
+  migration PR. Base file arm was the bare `} else if (matches(entry.name)) {` — **no type test at all**.
+- [#3471](https://github.com/kamp-us/phoenix/issues/3471) / PR
+  [#3915](https://github.com/kamp-us/phoenix/pull/3915) — `workflow-contract`, the **counter-example**:
+  its base file arm was a *positive* `.filter((e) => e.isFile() && e.name.endsWith(".js"))`, so
+  symlinked `.js` files were **excluded** at base and its gate sits on the **file** arm — the opposite
+  direction from the other three.
+
+### The sanctioned idiom — reconstruct `lstat` with `readLink`
 
 `readLink` is `effectify(NFS.readlink, …)` (`NodeFileSystem.js:280`) and POSIX `readlink(2)`
 succeeds **only** on a symbolic link (`EINVAL` on anything else) — so "`readLink` succeeded" is the
-`lstat`-free test for link-ness. Keep `stat` for the type, gate the recursion on it. Shipped shape,
-`packages/pipeline-cli/src/tools/patch-guard/gate.ts` (`gatherMarkers`), covered by two
-`gate.unit.test.ts` cases that plant a real symlinked dir and a real symlinked file:
+`lstat`-free test for link-ness. Keep `stat` for the type; put the `readLink` test on whichever arm
+the walk you are replacing already excluded links from.
+
+#### First establish the call site's base polarity — it decides which arm to guard
+
+**Which arm the gate belongs on is a property of the pre-migration line, not a constant.** Read that
+line before copying anything:
+
+| Pre-migration file arm | Symlinked files were… | The gate goes on |
+|---|---|---|
+| a *negative* `Dirent` test (`if (!entry.isFile()) continue`), a link-**following** `statSync(abs).isFile()`, or **no type test at all** | in scope | the **`Directory`** arm only — the file arm needs nothing |
+| a *positive* `entry.isFile()` test | **excluded** — `Dirent.isFile()` is `lstat`-based, so a link-to-file is `false` | the **file** arm, **ahead of** the type test |
+
+Both polarities ship in this repo, which is why the trail above records each site's base arm: three
+sites guard the `Directory` arm, `workflow-contract` guards the file arm.
+
+**Directory-arm shape** (the common case). The `readLink` gate is `patch-guard`'s `gatherMarkers`
+(`packages/pipeline-cli/src/tools/patch-guard/gate.ts`, covered by two `gate.unit.test.ts` cases that
+plant a real symlinked dir and a real symlinked file); the `Effect.option` stat and the
+dangling-entry split are `design-token-guard`'s `walkCss`
+(`packages/pipeline-cli/src/tools/design-token-guard/gate.ts`). Copy **both** — the `readLink` gate
+alone satisfies obligation 1 below but not obligation 2:
 
 ```ts
 const walk = (dir: string): Effect.Effect<void, PlatformError.PlatformError> =>
 	Effect.gen(function* () {
 		for (const name of yield* fs.readDirectory(dir)) {
 			const abs = path.join(dir, name);
-			const stat = yield* fs.stat(abs);
-			if (stat.type === "Directory") {
+			const stat = yield* Effect.option(fs.stat(abs));
+			if (Option.isNone(stat)) {
+				// Dangling link (or an entry racing an unlink): in scope iff the walk's OWN name
+				// predicate matches, per obligation 2 — never a blanket skip.
+				if (isTestFile(name)) found.push(abs);
+				continue;
+			}
+			if (stat.value.type === "Directory") {
 				const isSymlink = yield* fs.readLink(abs).pipe(
 					Effect.as(true),
 					Effect.orElseSucceed(() => false),
@@ -217,15 +257,27 @@ const walk = (dir: string): Effect.Effect<void, PlatformError.PlatformError> =>
 				if (!isSymlink && !IGNORE_DIRS.has(name)) yield* walk(abs);
 				continue;
 			}
-			// … the file arm: a symlinked FILE still stats as "File" and stays in scope,
-			// which matches the Dirent walk — hence the guard sits on the Directory arm only.
+			// No gate on the file arm AT THIS POLARITY: a symlinked file stats as "File" and stays
+			// in scope, which is what a base arm of this polarity admitted (see the table above).
+			if (isTestFile(name)) found.push(abs);
 		}
 	});
 ```
 
-Reach for this **first** when migrating any walk. Following symlinked dirs is a deliberate
-behavior change, not a migration detail — if a tool genuinely wants it, say so and take on the two
-obligations below.
+**File-arm shape**, when the base arm was a positive `Dirent.isFile()` — the gate moves *ahead of*
+the type test so a symlinked entry never reaches it
+(`packages/pipeline-cli/src/tools/workflow-contract/gate.ts`):
+
+```ts
+if (!name.endsWith(".js")) continue;
+const isSymlink = yield* fs.readLink(abs).pipe(Effect.as(true), Effect.orElseSucceed(() => false));
+if (isSymlink) continue; // reconstructs the base `Dirent.isFile()`, which excluded links
+if ((yield* fs.stat(abs)).type === "File") scripts.push(abs);
+```
+
+Reach for the shape matching your call site's polarity **first** when migrating any walk. Following
+symlinked dirs is a deliberate behavior change, not a migration detail — if a tool genuinely wants
+it, say so and take on the two obligations below.
 
 ### Two obligations that ride along with the swap
 
@@ -235,13 +287,32 @@ obligations below.
   unbounded recursion (stack overflow, not a typed failure). A walk that follows links **must**
   carry a visited-set keyed on `fs.realPath(abs)`, or a depth cap. The `readLink` gate above sidesteps
   this entirely, which is the second reason to prefer it.
-- **Broken-symlink tolerance.** `fs.stat` on a dangling link fails (`ENOENT`) — as a
-  `PlatformError` on the `E` channel, so one broken symlink anywhere under the walk root hard-fails
-  the whole gate, where the `Dirent` walk classified the entry and moved on. If the walk stats every
-  entry, make the per-entry stat skippable (`Effect.option` / `Effect.orElseSucceed`) rather than
-  letting a stray dangling link decide a gate's exit code. `reachability-guard`'s walk
-  (`packages/pipeline-cli/src/tools/reachability-guard/gate.ts`) buys this for free by testing
-  `readLink` **before** `stat` — it never `stat`s a link at all.
+- **Broken-symlink tolerance — skippable at the *stat*, then split by the name predicate.**
+  `fs.stat` on a dangling link fails `ENOENT` as a `PlatformError` on the `E` channel, so a walk that
+  stats every entry unconditionally lets one stray link hard-fail the whole gate, where the `Dirent`
+  walk classified the entry by name and moved on. Make the per-entry stat skippable
+  (`Effect.option` / `Effect.orElseSucceed`) — but do **not** then drop every dangling entry, because
+  the base walk did not treat the two halves alike:
+  - name **does not** match the walk's predicate → **skip it**, exactly as the `Dirent` walk did (it
+    matched neither arm);
+  - name **does** match → **keep it in scope** and let the downstream read red the gate. This is
+    `design-token-guard`'s deliberate choice in `walkCss`, settled in PR
+    [#3897](https://github.com/kamp-us/phoenix/pull/3897)'s repair round: a `.css` file replaced by a
+    dangling link must stay "gate reds" rather than become "file silently leaves scope."
+
+  That choice carries one **accepted residual**, recorded so nobody reads it as a fresh defect: a
+  link *named* `*.css` whose target is a **directory** resolves through `fs.stat` as `"Directory"`
+  and is skipped as a symlinked dir (exit 0), where the base walk pushed it by name and hard-failed
+  at `readFileSync` with `EISDIR` (exit 1). That divergence is tracked separately in
+  [#3950](https://github.com/kamp-us/phoenix/issues/3950) — do not "fix" it by reverting the split
+  above.
+
+  Skippability belongs on the stat, never on the downstream read. `reachability-guard`
+  (`packages/pipeline-cli/src/tools/reachability-guard/gate.ts`) tests `readLink` before `stat`, so it
+  never fails *at the stat* — but that is not blanket tolerance: a dangling `*.tsx` is still pushed by
+  `matches(name)` and then reds at `gatherConsumers`'s unguarded `fs.readFileString` (`ENOENT` →
+  `IoError` → exit 1), while a dangling non-matching entry is silently ignored. Two exit codes, one
+  per side of the split — which is the correct behavior, not an exemption from this obligation.
 
 ## Testing — substitute the `FileSystem` seam
 

--- a/.patterns/effect-platform-access.md
+++ b/.patterns/effect-platform-access.md
@@ -224,8 +224,18 @@ line before copying anything:
 
 | Pre-migration file arm | Symlinked files were… | The gate goes on |
 |---|---|---|
-| a *negative* `Dirent` test (`if (!entry.isFile()) continue`), a link-**following** `statSync(abs).isFile()`, or **no type test at all** | in scope | the **`Directory`** arm only — the file arm needs nothing |
+| a negated `Dirent` **directory** test whose else-branch is the file arm (`if (entry.isDirectory()) { … } else { /* file arm */ }`), a link-**following** `statSync(abs).isFile()`, or **no type test at all** | in scope | the **`Directory`** arm only — the file arm needs nothing |
 | a *positive* `entry.isFile()` test | **excluded** — `Dirent.isFile()` is `lstat`-based, so a link-to-file is `false` | the **file** arm, **ahead of** the type test |
+
+**The discriminator is admission, not grammatical negation.** `isFile` is `lstat`-based and
+**excludes** links; `isDirectory` is `lstat`-based too and therefore **admits** a link-to-dir into the
+else/file arm. So `if (!entry.isFile()) continue` admits exactly what a positive `entry.isFile()`
+admits — the `!` sits on control flow, not on membership — and belongs in row **two**, not row one.
+Guard whichever arm **newly gains** the link after the swap: an `isFile` base widens the **file** arm
+(`fs.stat` follows the link and reports `"File"`), an `isDirectory()`-else base widens the
+**recursion** (the link stats as `"Directory"` and is recursed). A link-**following** `statSync`
+already followed links before the swap, so it changes nothing on its own arm — it sits in row one
+only because such a walk's *directory* test is still `Dirent`-based (`patch-guard`).
 
 Both polarities ship in this repo, which is why the trail above records each site's base arm: three
 sites guard the `Directory` arm, `workflow-contract` guards the file arm.


### PR DESCRIPTION
Fixes #3983

## What this fixes

`.patterns/effect-platform-access.md`'s lstat-trap section justified its symlink rule with a **false platform claim** — "a symlinked FILE still stats as `File` and stays in scope, **which matches the Dirent walk**" — and generalized it into a uniform "the guard sits on the `Directory` arm only" rule that is **inverted** for a real shipped call site. A `.patterns/` doc exists to be copied, so a wrong rule there reproduces fail-open regressions with the doc's authority behind it. Doc-only: **no gate behavior changes** — the gates on `main` are already correct; the doc catches up to them.

## The corrected mechanics (verified against the pinned dep source + the three gates)

- `Dirent.isDirectory()` / `isFile()` (from `readdirSync(dir, {withFileTypes: true})`) are **`lstat`**-based: a symlink is **neither** File nor Directory, so `isFile()` is `false` for a link-to-file. The doc's "matches the Dirent walk" premise was therefore false.
- effect v4's `FileSystem.stat` is `effectify(NFS.stat, …)` and **follows** symlinks; the v4 `FileSystem` interface has **no `lstat`**, and `readDirectory` options are `{recursive?}` only (no `withFileTypes`). `readLink` is `effectify(NFS.readlink, …)` and succeeds **iff** the path is a symlink — the only `lstat` equivalent reachable.
- Consequence: a `Dirent` walk → `fs.stat` walk swap silently **widens** the walk, and a guard whose findings are **negations** (`missingConsumer = !consumingConstants.has(x)`) can only flip **RED → GREEN** — fail-open on a fail-closed gate.

## The rule is per-call-site, not uniform

The arm that carries the `readLink` gate is a property of the **pre-migration line's polarity**, added as a table a reader can derive from rather than pattern-match:

| Pre-migration file arm | Symlinked files were… | The gate goes on |
|---|---|---|
| negative `Dirent` test, link-**following** `statSync(abs).isFile()`, or **no type test at all** | in scope | the **`Directory`** arm only |
| a *positive* `entry.isFile()` | **excluded** (`isFile()` is `lstat`-based) | the **file** arm, **ahead of** the type test |

## The instance trail now covers all the shipped polarities

- `packages/pipeline-cli/src/tools/reachability-guard/gate.ts` — base arm was the bare `} else if (matches(entry.name)) {` (no type test) ⇒ `isSymlink` gates the **`Directory`** arm only; a glob-matching symlinked *file* deliberately **stays** in scope. (The doc's existing example.)
- `packages/pipeline-cli/src/tools/workflow-contract/gate.ts` — **added; the counter-example whose absence made the rule read as uniform.** Base arm was a *positive* `.filter((e) => e.isFile() && e.name.endsWith(".js"))`, so it correctly does `if (isSymlink) continue;` **before** the `.type === "File"` test.
- `packages/pipeline-cli/src/tools/design-token-guard/gate.ts` (`walkCss`) — base arm screened by name only; it deliberately does the opposite of the old blanket advice: `Effect.option(fs.stat(abs))`, and on `None` a `.css`-named entry is **pushed** so a CSS file replaced by a dangling link stays "gate reds" instead of "file silently leaves scope" (PR #3897's repair round).

The broken-symlink obligation now splits **"make the per-entry stat skippable"** from **"decide what happens to the skipped entry"**, and `reachability-guard`'s two distinct outcomes are stated rather than collapsed (dangling + name matches → pushed, reds at `fs.readFileString`, exit 1; dangling + non-matching → silently ignored, exit 0). `design-token-guard`'s accepted residual (a `*.css`-named link whose target is a **directory**: base exit 1 `EISDIR` vs head exit 0) is referenced to #3950 and explicitly **not** fixed here.

## Detection

Recorded in the section's warning: CI **structurally cannot** catch this class — a fresh checkout contains no symlinks — and a code review of the diff won't either, since the swapped line reads as equivalent. The only detection method is a **differential A/B of the built binaries** (base vs head) over a planted symlink fixture (symlinked dir / symlinked file / dangling link), diffing exit code + report.

## Provenance

The issue flagged a complete repair that had been written but never pushed (the stranded-work class). It was **recovered from the local object store** as commit `47d0c2ee` rather than rewritten, re-verified line-by-line against the three gates and the pinned dep source, then extended with the detection-method note and the #3950 reference.

## Acceptance criteria

- [x] The false "matches the Dirent walk" clause is deleted; the true `lstat`-vs-`stat` semantics carry the rule.
- [x] The uniform "guard the `Directory` arm only" rule is replaced with the base-polarity precondition, with both shipped shapes shown.
- [x] `workflow-contract` added to the instance trail as the positive-`Dirent.isFile()` case, symlink check ahead of the type test.
- [x] The broken-symlink bullet distinguishes skippable-stat from what-happens-to-the-skipped-entry, citing `design-token-guard`'s deliberate push and `reachability-guard`'s two exit codes.
- [x] Doc-only — no `gate.ts` touched, no gate behavior changed.

## Verification

- `pnpm lint` (biome, worktree-scoped) — clean
- `leak-guard scan .patterns/effect-platform-access.md` — clean
- `pointer-guard check` — clean
- pre-push `typecheck` + `unit-changed` — green
- one file changed: `.patterns/effect-platform-access.md` (+100 / −29)

Not §CP: `.patterns/**` is not a control-plane path.