### PR TITLE
fix(claim-presence): fingerprint a machine identity, not the hostname (#3992)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2613,18 +2613,19 @@ markers (§5/§6) are. Its **canonical grammar**:
 
 ```
 claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC>
-claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC> · presence <host-fingerprint>/<session-pid>
+claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC> · presence <machine-fingerprint>/<session-pid>
 ```
 
 - **The optional `presence` stamp** names the claiming **session process** (the long-lived
-  `claude` ancestor of whatever posted the claim) and an opaque **fingerprint** of its host (a
-  truncated hash — liveness only ever asks "is this my host?", and a machine name has no business
-  in a public timeline). It exists so a later
-  reader can *probe* this claimant's liveness instead of guessing — see
+  `claude` ancestor of whatever posted the claim) and an opaque **fingerprint of the machine** it
+  runs on — a truncated hash of a *machine-scoped* id (macOS `IOPlatformUUID` / Linux
+  `/etc/machine-id`), **never the hostname**: liveness only asks "is this my machine?", a hostname
+  is not unique to one machine, and no machine identity belongs in a public timeline. It exists so
+  a later reader can *probe* this claimant's liveness instead of guessing — see
   [Dead-claimant supersession](#dead-claimant-supersession-proven-death-only-adr-0191). It is
-  written by `pipeline-cli tracker claim` and is **optional**: an unresolvable session stamps
-  nothing, and an unstamped marker reads as indeterminate (⇒ still a valid owner), so legacy
-  markers keep their exact old meaning.
+  written by `pipeline-cli tracker claim` and is **optional**: an unresolvable session — or an
+  unresolvable machine identity — stamps nothing, and an unstamped marker reads as indeterminate
+  (⇒ still a valid owner), so legacy markers keep their exact old meaning.
 - **Token source:** the claiming process's `CLAUDE_CODE_SESSION_ID` environment variable
   (the orchestrator's when it claims pre-spawn; the coder's when `write-code` is invoked
   directly — see §The pre-spawn claim protocol).
@@ -2769,10 +2770,11 @@ refuse and degraded into a per-agent judgment call (#3751).
 Liveness is **presence-derived, never age-derived** (ADR
 [0191](https://github.com/kamp-us/phoenix/blob/main/.decisions/0191-crew-claim-lifecycle.md) — a
 claim's liveness rides its holder's presence; the same identification `worktree-reap` makes):
-the marker's `presence <host-fingerprint>/<session-pid>` stamp names the claimant's session
-process, and a reader on that host probes it. **Dead requires all three** — a stamp, a host match, and a pid
-the probe proves gone. Every other state is **indeterminate and counts as a live claim**: an
-unstamped/legacy marker, a claim stamped on another host, a pid that still resolves, and a
+the marker's `presence <machine-fingerprint>/<session-pid>` stamp names the claimant's session
+process, and a reader on that machine probes it. **Dead requires all three** — a stamp, a match
+against a *resolved* local machine fingerprint, and a pid the probe proves gone. Every other state
+is **indeterminate and counts as a live claim**: an unstamped/legacy marker, a claim stamped on
+another machine, a machine identity this reader cannot resolve, a pid that still resolves, and a
 reused pid all leave the claim standing, so the reader refuses. Doubt refuses; it never evicts.
 
 Both the resolution and the probe live in the shared verb — `pipeline-cli claim is-mine`

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-presence.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-presence.ts
@@ -4,24 +4,26 @@
  * A claim marker may carry an optional presence stamp, `claim: <session> · <ts> · presence
  * <host>/<pid>`, where `<pid>` is the claiming **session process** (the long-lived `claude`
  * ancestor of the process that posted the claim, the same identification `worktree-reap` makes)
- * and `<host>` is the machine it runs on. That stamp is what turns "is this claimant still
- * alive?" from a judgment call into a probe, so a dead session's marker stops shadowing every
- * later legitimate claim on an abandoned lane.
+ * and `<host>` is a fingerprint of the machine it runs on. That stamp is what turns "is this
+ * claimant still alive?" from a judgment call into a probe, so a dead session's marker stops
+ * shadowing every later legitimate claim on an abandoned lane.
  *
  * The one non-obvious thing: **only positive evidence of death supersedes a claim.** A missing
- * stamp (a legacy marker), a stamp from another host, or an unprobeable pid all resolve
- * `unknown`, which counts as a live claim — so an indeterminate claimant is refused, never
- * evicted (the slow-but-live-agent hazard ADR 0115 §5 deferred reclaim over). A reused pid reads
- * running ⇒ live, the same fail-safe direction `worktree-reap` takes.
+ * stamp (a legacy marker), a stamp from another machine, an unresolvable local machine identity,
+ * or an unprobeable pid all resolve `unknown`, which counts as a live claim — so an indeterminate
+ * claimant is refused, never evicted (the slow-but-live-agent hazard ADR 0115 §5 deferred reclaim
+ * over). A reused pid reads running ⇒ live, the same fail-safe direction `worktree-reap` takes.
  */
+import {createHash} from "node:crypto";
 import type {ClaimComment, ClaimLiveness} from "./claim-resolution.ts";
 
 /** The claimant's session process, as stamped on the marker. */
 export interface ClaimPresence {
 	/**
-	 * An opaque fingerprint of the host the session process runs on — a claim stamped elsewhere is
-	 * unprobeable here. Only equality is ever asked of it, so it is a hash rather than the machine
-	 * name: an operator's hostname is not something a public issue timeline needs to carry.
+	 * An opaque fingerprint of the **machine identity** the session process runs on — a claim
+	 * stamped elsewhere is unprobeable here. Only equality is ever asked of it, so it is a hash
+	 * rather than the identity itself. Why it must fingerprint a machine-scoped id and never the
+	 * hostname: `presence-io.ts` `readMachineId`.
 	 */
 	readonly host: string;
 	/** The session process id whose presence IS the claim's liveness (ADR 0191). */
@@ -55,19 +57,48 @@ export type PidState = "running" | "gone" | "unprobeable";
 
 /** This machine's identity + its pid probe — the boundary facts the classification reads. */
 export interface LocalPresence {
-	readonly host: string;
+	/**
+	 * This machine's fingerprint, or `null` when the machine identity could not be resolved. `null`
+	 * is not a wildcard: it makes the host comparison **inconclusive** (⇒ `unknown` ⇒ the claim
+	 * stands), because a machine we cannot identify is a machine whose pids we cannot attribute.
+	 */
+	readonly host: string | null;
 	readonly probePid: (pid: number) => PidState;
 }
 
+/** How many hex chars of the digest the fingerprint carries — collision-free at machine scale. */
+const FINGERPRINT_LEN = 12;
+
 /**
- * Classify one claim's liveness. `dead` requires all three: a stamp, a host match (we can only
- * probe our own machine), and a pid the probe proves gone. Everything else is `unknown`.
+ * Fingerprint a machine identity for the stamp: a truncated SHA-256, or `null` for an absent or
+ * blank id. Hashing is what keeps the raw identity out of a public timeline — and it is required
+ * of a Linux `/etc/machine-id`, which systemd's `machine-id(5)` declares confidential and directs
+ * callers to use only via an application-specific derivation (`sd_id128_get_machine_app_specific`).
+ */
+export const machineFingerprint = (machineId: string | null | undefined): string | null => {
+	const id = machineId?.trim().toLowerCase() ?? "";
+	if (id === "") return null;
+	return createHash("sha256").update(id).digest("hex").slice(0, FINGERPRINT_LEN);
+};
+
+/** The `IOPlatformUUID` property line `ioreg -rd1 -c IOPlatformExpertDevice` prints on macOS. */
+const IOREG_PLATFORM_UUID_RE = /"IOPlatformUUID"\s*=\s*"([^"]+)"/;
+
+/** Read the hardware UUID out of `ioreg` output, or `null` when the property is absent. */
+export const parseIOPlatformUuid = (ioregOutput: string): string | null =>
+	IOREG_PLATFORM_UUID_RE.exec(ioregOutput)?.[1]?.trim() || null;
+
+/**
+ * Classify one claim's liveness. `dead` requires all three: a stamp, a host match against a
+ * RESOLVED local machine fingerprint (we can only probe our own machine), and a pid the probe
+ * proves gone. Everything else — including an unresolvable local identity — is `unknown`.
  */
 export const claimLiveness = (
 	presence: ClaimPresence | null,
 	local: LocalPresence,
 ): ClaimLiveness => {
 	if (presence === null) return "unknown";
+	if (local.host === null) return "unknown";
 	if (presence.host !== local.host) return "unknown";
 	switch (local.probePid(presence.pid)) {
 		case "gone":

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-presence.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-presence.unit.test.ts
@@ -101,7 +101,7 @@ describe("claimLiveness — dead requires positive evidence, everything else is 
 	});
 
 	it("two machines that SHARE a hostname but not a machine id never match ⇒ unknown, never dead", () => {
-		const stampedOnMachineA = machineFingerprint("6553E4B9-1D64-5AFC-82F5-C0A5B666C380");
+		const stampedOnMachineA = machineFingerprint("0A1B2C3D-4E5F-5A6B-8C7D-9E0F1A2B3C4D");
 		const readerIsMachineB = machineFingerprint("1FA3D0C7-9E2B-5D11-B4A6-77C1E0F58322");
 		assert.notStrictEqual(stampedOnMachineA, readerIsMachineB);
 		assert.strictEqual(
@@ -116,15 +116,15 @@ describe("claimLiveness — dead requires positive evidence, everything else is 
 
 describe("machineFingerprint — a hashed MACHINE identity, or nothing", () => {
 	it("is stable for one id and distinct across machines (the only two properties asked of it)", () => {
-		const a = machineFingerprint("6553E4B9-1D64-5AFC-82F5-C0A5B666C380");
-		assert.strictEqual(a, machineFingerprint("6553e4b9-1d64-5afc-82f5-c0a5b666c380"));
+		const a = machineFingerprint("0A1B2C3D-4E5F-5A6B-8C7D-9E0F1A2B3C4D");
+		assert.strictEqual(a, machineFingerprint("0a1b2c3d-4e5f-5a6b-8c7d-9e0f1a2b3c4d"));
 		assert.notStrictEqual(a, machineFingerprint("1FA3D0C7-9E2B-5D11-B4A6-77C1E0F58322"));
 	});
 
 	it("never leaks the raw identity into the stamp", () => {
-		const fingerprint = machineFingerprint("6553E4B9-1D64-5AFC-82F5-C0A5B666C380");
+		const fingerprint = machineFingerprint("0A1B2C3D-4E5F-5A6B-8C7D-9E0F1A2B3C4D");
 		assert.strictEqual(fingerprint?.length, 12);
-		assert.isFalse((fingerprint ?? "").includes("6553e4b9"));
+		assert.isFalse((fingerprint ?? "").includes("0a1b2c3d"));
 	});
 
 	it("an absent or blank machine id ⇒ null (fail toward indeterminate, never a shared bucket)", () => {
@@ -140,10 +140,10 @@ describe("parseIOPlatformUuid — the darwin machine identity", () => {
 			parseIOPlatformUuid(
 				[
 					'    "IOPlatformSerialNumber" = "XXXXXXXXXXXX"',
-					'    "IOPlatformUUID" = "6553E4B9-1D64-5AFC-82F5-C0A5B666C380"',
+					'    "IOPlatformUUID" = "0A1B2C3D-4E5F-5A6B-8C7D-9E0F1A2B3C4D"',
 				].join("\n"),
 			),
-			"6553E4B9-1D64-5AFC-82F5-C0A5B666C380",
+			"0A1B2C3D-4E5F-5A6B-8C7D-9E0F1A2B3C4D",
 		);
 	});
 

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-presence.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-presence.unit.test.ts
@@ -4,8 +4,10 @@ import {
 	formatClaimPresence,
 	type LocalPresence,
 	livenessByComment,
+	machineFingerprint,
 	type PidState,
 	parseClaimPresence,
+	parseIOPlatformUuid,
 	parseProcessTable,
 	resolveSessionPid,
 } from "./claim-presence.ts";
@@ -14,7 +16,7 @@ import {type ClaimComment, claimCommentBody} from "./claim-resolution.ts";
 const SID_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const SID_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
 
-const local = (host: string, states: Record<number, PidState>): LocalPresence => ({
+const local = (host: string | null, states: Record<number, PidState>): LocalPresence => ({
 	host,
 	probePid: (pid) => states[pid] ?? "unprobeable",
 });
@@ -87,6 +89,66 @@ describe("claimLiveness — dead requires positive evidence, everything else is 
 
 	it("no stamp ⇒ unknown", () => {
 		assert.strictEqual(claimLiveness(null, local("box-1", {})), "unknown");
+	});
+
+	// #3992: the fingerprint must identify a MACHINE, and an identity we cannot resolve must be
+	// inconclusive — never a match that licenses a pid probe against a foreign machine's pid.
+	it("an UNRESOLVABLE local machine identity ⇒ unknown even for a provably gone pid", () => {
+		assert.strictEqual(
+			claimLiveness({host: "box-1", pid: 4242}, local(null, {4242: "gone"})),
+			"unknown",
+		);
+	});
+
+	it("two machines that SHARE a hostname but not a machine id never match ⇒ unknown, never dead", () => {
+		const stampedOnMachineA = machineFingerprint("6553E4B9-1D64-5AFC-82F5-C0A5B666C380");
+		const readerIsMachineB = machineFingerprint("1FA3D0C7-9E2B-5D11-B4A6-77C1E0F58322");
+		assert.notStrictEqual(stampedOnMachineA, readerIsMachineB);
+		assert.strictEqual(
+			claimLiveness(
+				{host: stampedOnMachineA ?? "", pid: 4242},
+				local(readerIsMachineB, {4242: "gone"}),
+			),
+			"unknown",
+		);
+	});
+});
+
+describe("machineFingerprint — a hashed MACHINE identity, or nothing", () => {
+	it("is stable for one id and distinct across machines (the only two properties asked of it)", () => {
+		const a = machineFingerprint("6553E4B9-1D64-5AFC-82F5-C0A5B666C380");
+		assert.strictEqual(a, machineFingerprint("6553e4b9-1d64-5afc-82f5-c0a5b666c380"));
+		assert.notStrictEqual(a, machineFingerprint("1FA3D0C7-9E2B-5D11-B4A6-77C1E0F58322"));
+	});
+
+	it("never leaks the raw identity into the stamp", () => {
+		const fingerprint = machineFingerprint("6553E4B9-1D64-5AFC-82F5-C0A5B666C380");
+		assert.strictEqual(fingerprint?.length, 12);
+		assert.isFalse((fingerprint ?? "").includes("6553e4b9"));
+	});
+
+	it("an absent or blank machine id ⇒ null (fail toward indeterminate, never a shared bucket)", () => {
+		assert.strictEqual(machineFingerprint(null), null);
+		assert.strictEqual(machineFingerprint(undefined), null);
+		assert.strictEqual(machineFingerprint("   \n"), null);
+	});
+});
+
+describe("parseIOPlatformUuid — the darwin machine identity", () => {
+	it("reads IOPlatformUUID out of ioreg output", () => {
+		assert.strictEqual(
+			parseIOPlatformUuid(
+				[
+					'    "IOPlatformSerialNumber" = "XXXXXXXXXXXX"',
+					'    "IOPlatformUUID" = "6553E4B9-1D64-5AFC-82F5-C0A5B666C380"',
+				].join("\n"),
+			),
+			"6553E4B9-1D64-5AFC-82F5-C0A5B666C380",
+		);
+	});
+
+	it("no such property ⇒ null (⇒ no fingerprint ⇒ indeterminate)", () => {
+		assert.strictEqual(parseIOPlatformUuid('  "IOPlatformSerialNumber" = "XXXXXXXXXXXX"'), null);
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
@@ -55,8 +55,8 @@ export const parseClaimSession = (body: string): string | null => {
  * A claimant's presence — the ADR 0191 liveness of the claim, resolved from the marker's
  * optional presence stamp by the IO shell. `dead` is the ONLY value that supersedes a claim,
  * and it requires positive evidence (the stamped session process is provably gone on this
- * host); `unknown` (no stamp, another host, an unprobeable pid) counts as a live claim, so
- * doubt refuses rather than evicts.
+ * machine); `unknown` (no stamp, another machine, an unresolvable local machine identity, an
+ * unprobeable pid) counts as a live claim, so doubt refuses rather than evicts.
  */
 export type ClaimLiveness = "live" | "dead" | "unknown";
 

--- a/packages/pipeline-cli/src/tools/epic-lock/presence-io.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/presence-io.ts
@@ -9,12 +9,13 @@
  * fail-closed, so lowering it into a typed error would add a channel no caller can act on.
  */
 import {execFileSync} from "node:child_process";
-import {createHash} from "node:crypto";
-import {hostname} from "node:os";
+import {readFileSync} from "node:fs";
 import {
 	type ClaimPresence,
 	type LocalPresence,
+	machineFingerprint,
 	type PidState,
+	parseIOPlatformUuid,
 	parseProcessTable,
 	resolveSessionPid,
 } from "./claim-presence.ts";
@@ -35,30 +36,70 @@ const probePid = (pid: number): PidState => {
 };
 
 /**
- * This machine's stamp identity: a truncated hash of the hostname. Liveness only ever asks
- * "was this claim stamped on MY host?", so a fingerprint answers it exactly — and keeps the
- * operator's machine name out of a public issue timeline (the no-local-identity rule the
+ * This machine's identity, per platform, or `null` when none can be read.
+ *
+ * A **hostname is not a machine identity** — two machines routinely share one (`localhost`, a
+ * default container/CI name), and a colliding fingerprint would make a cross-machine claim look
+ * same-machine, probe a foreign pid locally, and evict a live agent (#3992). So each source below
+ * is machine-scoped and reboot-stable, grounded rather than assumed:
+ *
+ * - **darwin:** `IOPlatformUUID` on `IOPlatformExpertDevice` — the same value
+ *   `system_profiler SPHardwareDataType` reports as **Hardware UUID**, the per-unit hardware
+ *   identifier, which is why it is stable across reboots and distinct per machine.
+ * - **linux:** `/etc/machine-id`, falling back to `/var/lib/dbus/machine-id` — systemd's
+ *   `machine-id(5)`: an id "unique for the local system", set at install and "stable across
+ *   reboots".
+ *
+ * Any other platform, or an unreadable source, yields `null` ⇒ the host comparison is
+ * inconclusive ⇒ every claim reads indeterminate and stands. Never substitute the hostname here.
+ */
+export const readMachineId = (): string | null => {
+	try {
+		if (process.platform === "darwin") {
+			return parseIOPlatformUuid(
+				execFileSync("ioreg", ["-rd1", "-c", "IOPlatformExpertDevice"], {encoding: "utf8"}),
+			);
+		}
+		if (process.platform === "linux") {
+			for (const path of ["/etc/machine-id", "/var/lib/dbus/machine-id"]) {
+				try {
+					const id = readFileSync(path, "utf8").trim();
+					if (id !== "") return id;
+				} catch {}
+			}
+		}
+		return null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * This machine's stamp identity: a truncated hash of its machine id, or `null` when unresolvable.
+ * Liveness only ever asks "was this claim stamped on MY machine?", so a fingerprint answers it
+ * exactly — and keeps the identity out of a public issue timeline (the no-local-identity rule the
  * leak-guards enforce generically).
  */
-const hostFingerprint = (): string =>
-	createHash("sha256").update(hostname()).digest("hex").slice(0, 12);
+const machineStampIdentity = (): string | null => machineFingerprint(readMachineId());
 
 /** This machine's presence facts — the reader side. */
-export const localPresence = (): LocalPresence => ({host: hostFingerprint(), probePid});
+export const localPresence = (): LocalPresence => ({host: machineStampIdentity(), probePid});
 
 /**
  * The presence stamp for THIS run's claim: the nearest `claude` ancestor of the current process
- * (the session whose liveness the claim rides) on this host. `null` when the process table
- * cannot be read or no session ancestor resolves — the writer then emits an unstamped marker,
- * which every reader treats as indeterminate.
+ * (the session whose liveness the claim rides) on this machine. `null` when the process table
+ * cannot be read, no session ancestor resolves, or this machine has no resolvable identity — the
+ * writer then emits an unstamped marker, which every reader treats as indeterminate.
  */
 export const currentSessionPresence = (): ClaimPresence | null => {
 	try {
+		const host = machineStampIdentity();
+		if (host === null) return null;
 		const table = parseProcessTable(
 			execFileSync("ps", ["-Ao", "pid=,ppid=,comm="], {encoding: "utf8"}),
 		);
 		const pid = resolveSessionPid(table, process.pid);
-		return pid === null ? null : {host: hostFingerprint(), pid};
+		return pid === null ? null : {host, pid};
 	} catch {
 		return null;
 	}

--- a/packages/pipeline-cli/src/tools/epic-lock/presence-io.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/presence-io.ts
@@ -7,6 +7,13 @@
  * Deliberately synchronous and outside the Effect `E` channel: every failure here is already
  * modelled as an absence (`unprobeable` / no stamp) that the pure classification treats
  * fail-closed, so lowering it into a typed error would add a channel no caller can act on.
+ *
+ * That absence-on-failure contract is why every subprocess probe below carries `timeout: 2000`:
+ * a wedged `ioreg`/`ps` would otherwise block the whole command indefinitely (fail-slow), and
+ * the kill raises like any other probe failure, routing to `null` ⇒ indeterminate ⇒ the claim
+ * stands. 2s is ~60x the measured cost. It must be node's own option, never a shell `timeout`
+ * wrapper — that binary is absent on macOS, so it would fail OPEN on the very platform the
+ * machine-identity probe matters most on.
  */
 import {execFileSync} from "node:child_process";
 import {readFileSync} from "node:fs";
@@ -57,7 +64,10 @@ export const readMachineId = (): string | null => {
 	try {
 		if (process.platform === "darwin") {
 			return parseIOPlatformUuid(
-				execFileSync("ioreg", ["-rd1", "-c", "IOPlatformExpertDevice"], {encoding: "utf8"}),
+				execFileSync("ioreg", ["-rd1", "-c", "IOPlatformExpertDevice"], {
+					encoding: "utf8",
+					timeout: 2000,
+				}),
 			);
 		}
 		if (process.platform === "linux") {
@@ -96,7 +106,7 @@ export const currentSessionPresence = (): ClaimPresence | null => {
 		const host = machineStampIdentity();
 		if (host === null) return null;
 		const table = parseProcessTable(
-			execFileSync("ps", ["-Ao", "pid=,ppid=,comm="], {encoding: "utf8"}),
+			execFileSync("ps", ["-Ao", "pid=,ppid=,comm="], {encoding: "utf8", timeout: 2000}),
 		);
 		const pid = resolveSessionPid(table, process.pid);
 		return pid === null ? null : {host, pid};

--- a/packages/pipeline-cli/src/tools/epic-lock/presence-io.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/presence-io.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * The OS boundary of claim presence, asserted against the real machine — the one thing the pure
+ * tests cannot reach: that the stamp identity fingerprints a MACHINE and not the hostname (why
+ * that distinction decides whether a live agent gets evicted: `presence-io.ts` `readMachineId`).
+ */
+import {hostname} from "node:os";
+import {assert, describe, it} from "@effect/vitest";
+import {machineFingerprint} from "./claim-presence.ts";
+import {localPresence, readMachineId} from "./presence-io.ts";
+
+describe("localPresence — the stamp identity is machine-scoped, never hostname-scoped", () => {
+	const machineId = readMachineId();
+
+	it("fingerprints this machine's id, and NOT its hostname", () => {
+		const host = localPresence().host;
+		if (machineId === null) {
+			// No resolvable machine identity on this platform ⇒ inconclusive by construction.
+			assert.strictEqual(host, null);
+			return;
+		}
+		assert.strictEqual(host, machineFingerprint(machineId));
+		assert.notStrictEqual(host, machineFingerprint(hostname()));
+	});
+
+	it("resolves the same fingerprint on every read (stable within a machine)", () => {
+		assert.strictEqual(localPresence().host, localPresence().host);
+	});
+
+	it("a probe of an impossible pid is `gone`, and of pid 1 is never `gone`", () => {
+		// The real boundary, not a stub: `gone` (ESRCH) is the sole eviction signal, and a
+		// live-but-unownable pid must read `unprobeable` rather than misread as death.
+		const {probePid} = localPresence();
+		assert.strictEqual(probePid(0x7ffffff), "gone");
+		assert.notStrictEqual(probePid(1), "gone");
+	});
+});


### PR DESCRIPTION
Fixes #3992

## The bug

The ADR 0191 claim-presence stamp (landed in #3986) fingerprinted **`hostname()`**, and a hostname is not a machine identity. Two machines that share one (`localhost`, a default container/CI name, two same-model laptops with a default name) produce the **same** fingerprint — so `claimLiveness`'s host-match arm, the only gate between a foreign machine's pid and a `dead` verdict, opens:

machine B reads A's stamp → equal fingerprints → "same machine" → probes A's pid **locally** → `ESRCH` → `gone` → `dead` → **a live agent's claim is superseded and evicted.**

`dead` is the only liveness value that supersedes a claim (`resolveWinner` drops it from the tiebreak; `supersededClaims` records the eviction), so this inverted the design's core invariant — *doubt refuses and never evicts* — in the one direction the mechanism must not fail. The benign direction (a hostname *change*) already resolved `unknown`; the collision was the dangerous one.

## The fix

**1. Fingerprint a machine-scoped, reboot-stable id — grounded per platform, not asserted** (`presence-io.ts` `readMachineId`):

- **darwin:** `IOPlatformUUID` on `IOPlatformExpertDevice` — the same value `system_profiler SPHardwareDataType` reports as **Hardware UUID**, the per-unit hardware identifier (verified on an Apple-silicon machine: equal to the Hardware UUID, and different from that machine's hostname).
- **linux:** `/etc/machine-id`, falling back to `/var/lib/dbus/machine-id` — systemd's `machine-id(5)`: an id "unique for the local system", set at install and "stable across reboots".

**2. An unresolvable identity is inconclusive BY TYPE, never a false match.** `LocalPresence.host` becomes `string | null`; `claimLiveness` returns `unknown` when the local host is `null` (before any comparison); the writer stamps **nothing** when it cannot identify its own machine. A machine we cannot identify is a machine whose pids we cannot attribute — so the comparison is inconclusive and the claim **stands**. Every unsupported platform and every unreadable source lands here, so the failure mode is "refuse", not "evict".

**3. No raw identity reaches a posted marker.** `machineFingerprint` is a truncated SHA-256 (12 hex chars) of the normalized id, and returns `null` for an absent/blank id rather than hashing the empty string into a shared bucket. Hashing is also *required* of a Linux `/etc/machine-id`, which systemd declares confidential and directs callers to consume only via an application-specific derivation.

**4. The failure direction is pinned in tests:**

- `claimLiveness` with two machines that share a hostname but not a machine id ⇒ `unknown`, never `dead`.
- `claimLiveness` with an unresolvable local identity + a **provably gone** pid ⇒ `unknown`.
- `machineFingerprint`: stable per id, distinct across ids, never leaks the raw id, `null` on absent/blank.
- `parseIOPlatformUuid`: reads the property, `null` when absent (⇒ no fingerprint ⇒ indeterminate).
- A **real-machine boundary test** (`presence-io.unit.test.ts`) asserts the stamp equals `machineFingerprint(readMachineId())` and **not** `machineFingerprint(hostname())` — red on the old hash, green on the new — plus that `probePid` still reads an impossible pid as `gone` and pid 1 as never-`gone`.

**5. §7's stamp grammar realigned** to `presence <machine-fingerprint>/<session-pid>` in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, including the supersession contract's indeterminate list (now naming "another machine" and "a machine identity this reader cannot resolve"), so the documented grammar matches what the writer emits.

## Acceptance criteria

- [x] The presence stamp's host field fingerprints a machine-scoped identity (not `hostname()`), grounded in a verifiable source for each platform's id semantics.
- [x] An unresolvable machine identity makes the host comparison inconclusive (`unknown` ⇒ claim kept), never a false match.
- [x] No raw machine identity or hostname reaches a posted marker (fingerprint stays hashed).
- [x] A test pins the failure direction: same-fingerprint-but-different-machine never resolves `dead`.
- [x] §7's stamp grammar still matches what the writers emit after the change.

## Scope

Rebuilt on current `main` rather than reusing the stale `umut/3986-machine-id-not-hostname` branch (that branch predates several merged commits and would have reverted them). The #3987 disclosure fold that branch also carried is **left out** — it belongs to #3987, not here. The reporter's finding **F1** on #3986 (whether machine clearing authority is granted at all vs ADR 0115 §5) remains out of scope, per triage.

## Checks

- `pnpm typecheck` — green (29/29 tasks).
- `pnpm lint:worktree` — clean.
- `pipeline-cli` epic-lock suite — 53/53 pass. (Three unrelated subprocess-spawning suites — `pipeline-cli-shim.hook`, `class-probe/command`, `guard-content-probe/command` — time out at their 5s budget under load on this machine; they share no code path with this diff.)
- `leak-guard` — clean (pre-commit).
