### PR TITLE
fix(pipeline-cli): fail-closed stdin read — an unread pipe can no longer pose as empty (#3924)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -64,6 +64,25 @@ with the constructors in [`src/annotate.ts`](./src/annotate.ts) — `unlocated`,
 `atLine` — never by hand-formatting the command string, and wrap the build in
 `annotationsOrNone` so a throw while computing them can never swallow the report.
 
+## How a tool reads stdin
+
+Every tool that takes its input on a pipe reads it through `readStdinTextOrExit` in
+[`src/read-stdin.ts`](./src/read-stdin.ts) — never `readFileSync(0, …)` in a `try`/`catch`.
+
+`readFileSync(0, …)` throws `EAGAIN` when fd 0 is a non-blocking pipe, which depends on what
+is upstream and so happens intermittently. Wrapped in a swallow-to-empty, that throw made an
+*unread* pipe look exactly like an *empty* one: a gate then computed its verdict over no
+evidence and reported the vacuous green as a real zero scope. The shared reader retries
+`EAGAIN` until the pipe drains, and a pipe that stops making progress fails loud instead —
+it reports the stall on stderr and exits 4. An empty string now means an empty pipe and
+nothing else. A TTY with nothing piped in still returns immediately rather than blocking on
+a keystroke.
+
+Take `readStdinText` instead when the tool wants to handle the failed read itself: it carries
+the outcome as a typed `StdinReadFailed` in the error channel. The pure retry core, with its
+IO injected so the `EAGAIN` path is testable, lives in
+[`src/read-stdin-core.ts`](./src/read-stdin-core.ts).
+
 ## Development
 
 The source lives in the phoenix monorepo under

--- a/packages/pipeline-cli/src/read-stdin-core.ts
+++ b/packages/pipeline-cli/src/read-stdin-core.ts
@@ -1,0 +1,136 @@
+/**
+ * The pure core of the fail-closed stdin read (#3924).
+ *
+ * `readFileSync(0, "utf8")` throws `EAGAIN` when fd 0 is a non-blocking pipe — which it can
+ * be depending on what is upstream, so it is intermittent by nature. Every pipeline-cli tool
+ * wrapped that call in a swallow-to-empty, which made an *unread* pipe indistinguishable from
+ * an *empty* one: a gate then computed its verdict over no evidence and called the vacuous
+ * green a real zero scope (ADR 0092).
+ *
+ * The fix is a type, not a retry knob: a present-but-unread pipe resolves to `Failed`, and `""`
+ * is reserved for a pipe that genuinely carried nothing. The three outcomes are disjoint and
+ * exhaustive, so "unknown" can no longer be spelled the same way as "no members".
+ *
+ * The IO is injected (`StdinIo`) so the EAGAIN path is unit-testable without a real
+ * non-blocking fd; `nodeStdinIo` binds it to the process. No `effect` import here on purpose —
+ * the retry loop needs a native `try/catch` around each `readSync`, and this file is the
+ * node-boundary half that the `read-stdin.ts` Effect seam wraps.
+ */
+import {readSync} from "node:fs";
+
+/**
+ * The outcome of a stdin read.
+ *
+ * `Text.text` may be `""` — that is a *genuinely empty* pipe, which stays a legitimate answer.
+ * What can no longer happen is a failed read arriving as `Text("")`.
+ */
+export type StdinRead =
+	| {readonly _tag: "Text"; readonly text: string}
+	| {readonly _tag: "NoStdin"; readonly reason: string}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+/** The process-level reads the core needs, injected so a test can drive the EAGAIN path. */
+export interface StdinIo {
+	/** True when fd 0 is a terminal — the no-hang exit: a TTY with nothing piped never blocks. */
+	readonly isTTY: boolean;
+	/** Read up to `into.length` bytes; returns the byte count, `0` at EOF. Throws an errno error. */
+	readonly read: (into: Uint8Array) => number;
+	readonly sleep: (ms: number) => void;
+	readonly now: () => number;
+}
+
+export interface StdinReadOptions {
+	/**
+	 * How long the reader tolerates making no progress before giving up **loudly**. The bound is
+	 * what keeps "retry until the pipe drains" from becoming an unbounded hang; it resets on every
+	 * byte read, so a slow producer is fine and only a truly stalled pipe trips it.
+	 */
+	readonly idleTimeoutMs?: number;
+	readonly pollMs?: number;
+	readonly chunkBytes?: number;
+}
+
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_MS = 5;
+const DEFAULT_CHUNK_BYTES = 64 * 1024;
+
+/** Errno codes that mean "no data available yet", not "this read failed". */
+const RETRYABLE = new Set(["EAGAIN", "EWOULDBLOCK", "EINTR"]);
+
+/** Errno codes that mean fd 0 is not attached at all — an absent pipe, not an unread one. */
+const NO_STDIN = new Set(["EBADF", "ENXIO", "ENOTCONN"]);
+
+const errnoOf = (error: unknown): string =>
+	typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+		? error.code
+		: "";
+
+const messageOf = (error: unknown): string =>
+	error instanceof Error ? error.message : String(error);
+
+/**
+ * Read fd 0 to EOF, retrying a non-blocking pipe's `EAGAIN` instead of swallowing it.
+ *
+ * Terminates in every direction: a TTY returns before the first read, EOF ends the loop, and a
+ * pipe that stops making progress trips `idleTimeoutMs` into `Failed` rather than spinning.
+ */
+export const readStdinWith = (io: StdinIo, options: StdinReadOptions = {}): StdinRead => {
+	const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+	const pollMs = options.pollMs ?? DEFAULT_POLL_MS;
+	const chunkBytes = options.chunkBytes ?? DEFAULT_CHUNK_BYTES;
+
+	// The no-hang guarantee, and why it is a check rather than a timeout: on a TTY the read would
+	// block on the operator's keystrokes, which no deadline can distinguish from a slow producer.
+	if (io.isTTY) return {_tag: "NoStdin", reason: "fd 0 is a TTY — nothing was piped in"};
+
+	const chunks: Array<Buffer> = [];
+	let bytesRead = 0;
+	let lastProgress = io.now();
+
+	for (;;) {
+		const buffer = Buffer.allocUnsafe(chunkBytes);
+		let n: number;
+		try {
+			n = io.read(buffer);
+		} catch (error) {
+			const code = errnoOf(error);
+			if (RETRYABLE.has(code)) {
+				if (io.now() - lastProgress >= idleTimeoutMs) {
+					return {
+						_tag: "Failed",
+						reason: `stdin read stalled: fd 0 is a non-blocking pipe that returned ${code} with no data for ${idleTimeoutMs}ms (${bytesRead} bytes read so far). Refusing to report this as empty stdin (#3924).`,
+					};
+				}
+				io.sleep(pollMs);
+				continue;
+			}
+			if (NO_STDIN.has(code) && bytesRead === 0) {
+				return {_tag: "NoStdin", reason: `fd 0 is not readable (${code}) — nothing was piped in`};
+			}
+			return {
+				_tag: "Failed",
+				reason: `stdin read failed${code === "" ? "" : ` (${code})`}: ${messageOf(error)} (${bytesRead} bytes read so far). Refusing to report this as empty stdin (#3924).`,
+			};
+		}
+		if (n === 0) break;
+		chunks.push(buffer.subarray(0, n));
+		bytesRead += n;
+		lastProgress = io.now();
+	}
+
+	// Decode once, over the joined bytes: a multi-byte character split across two reads would be
+	// mangled by per-chunk decoding.
+	return {_tag: "Text", text: Buffer.concat(chunks).toString("utf8")};
+};
+
+const sleepSync = (ms: number): void => {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+};
+
+/** Bind `readStdinWith` to the real process (fd 0 by default; a fd argument is for tests). */
+export const nodeStdinIo = (fd = 0, isTTY = process.stdin.isTTY === true): StdinIo => ({
+	isTTY,
+	read: (into) => readSync(fd, into, 0, into.length, null),
+	sleep: sleepSync,
+	now: () => Date.now(),
+});

--- a/packages/pipeline-cli/src/read-stdin-core.unit.test.ts
+++ b/packages/pipeline-cli/src/read-stdin-core.unit.test.ts
@@ -1,0 +1,160 @@
+import {closeSync, mkdtempSync, openSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, describe, expect, it} from "vitest";
+import {nodeStdinIo, readStdinWith, type StdinIo} from "./read-stdin-core.ts";
+
+/** An errno error shaped like the one `fs.readSync` throws on a non-blocking pipe. */
+const errno = (code: string): NodeJS.ErrnoException =>
+	Object.assign(new Error(`read ${code}`), {code});
+
+/**
+ * A scripted fd: each step is either bytes to hand back or an errno to throw. `sleep`/`now` are
+ * driven off a virtual clock so the retry budget is exercised without real waiting.
+ */
+const scriptedIo = (
+	steps: ReadonlyArray<string | NodeJS.ErrnoException>,
+	overrides: Partial<StdinIo> = {},
+): StdinIo & {readonly sleeps: ReadonlyArray<number>; readonly reads: () => number} => {
+	const sleeps: Array<number> = [];
+	let clock = 0;
+	let index = 0;
+	return {
+		isTTY: false,
+		read: (into) => {
+			const step = steps[index];
+			index += 1;
+			if (step === undefined) return 0;
+			if (typeof step !== "string") throw step;
+			const bytes = Buffer.from(step, "utf8");
+			bytes.copy(into);
+			return bytes.length;
+		},
+		sleep: (ms) => {
+			sleeps.push(ms);
+			clock += ms;
+		},
+		now: () => clock,
+		sleeps,
+		reads: () => index,
+		...overrides,
+	};
+};
+
+describe("readStdinWith", () => {
+	it("reads a piped payload to EOF across chunks", () => {
+		const io = scriptedIo(["hello ", "world"]);
+		expect(readStdinWith(io)).toEqual({_tag: "Text", text: "hello world"});
+	});
+
+	it("returns an empty Text for a present-but-empty pipe", () => {
+		expect(readStdinWith(scriptedIo([]))).toEqual({_tag: "Text", text: ""});
+	});
+
+	it("retries EAGAIN to completion instead of reporting empty stdin", () => {
+		const io = scriptedIo([errno("EAGAIN"), errno("EAGAIN"), "roster", errno("EAGAIN"), ""]);
+		expect(readStdinWith(io, {pollMs: 5, idleTimeoutMs: 1000})).toEqual({
+			_tag: "Text",
+			text: "roster",
+		});
+		expect(io.sleeps).toEqual([5, 5, 5]);
+	});
+
+	it("retries EINTR and EWOULDBLOCK the same way", () => {
+		const io = scriptedIo([errno("EINTR"), errno("EWOULDBLOCK"), "ok"]);
+		expect(readStdinWith(io, {idleTimeoutMs: 1000})).toEqual({_tag: "Text", text: "ok"});
+	});
+
+	// The bug this file exists for: a pipe that never drains must not resolve to `Text("")`, which
+	// a gate would read as a real zero scope (#3924).
+	it("fails loud — never empty — when a non-blocking pipe never drains", () => {
+		const io = scriptedIo(Array.from({length: 10_000}, () => errno("EAGAIN")));
+		const outcome = readStdinWith(io, {pollMs: 10, idleTimeoutMs: 100});
+		expect(outcome._tag).toBe("Failed");
+		expect(outcome).not.toEqual({_tag: "Text", text: ""});
+		if (outcome._tag === "Failed") expect(outcome.reason).toContain("EAGAIN");
+	});
+
+	it("fails loud on a partial read that then stalls", () => {
+		const io = scriptedIo(["half a rost", ...Array.from({length: 100}, () => errno("EAGAIN"))]);
+		const outcome = readStdinWith(io, {pollMs: 10, idleTimeoutMs: 50});
+		expect(outcome._tag).toBe("Failed");
+		if (outcome._tag === "Failed") expect(outcome.reason).toContain("11 bytes read so far");
+	});
+
+	it("resets the stall budget on every byte read, so a slow producer still completes", () => {
+		const slow = [
+			errno("EAGAIN"),
+			errno("EAGAIN"),
+			"a",
+			errno("EAGAIN"),
+			errno("EAGAIN"),
+			"b",
+			errno("EAGAIN"),
+			errno("EAGAIN"),
+			"c",
+		];
+		expect(readStdinWith(scriptedIo(slow), {pollMs: 20, idleTimeoutMs: 50})).toEqual({
+			_tag: "Text",
+			text: "abc",
+		});
+	});
+
+	it("fails loud on a non-retryable read error", () => {
+		const outcome = readStdinWith(scriptedIo([errno("EIO")]));
+		expect(outcome._tag).toBe("Failed");
+		if (outcome._tag === "Failed") expect(outcome.reason).toContain("EIO");
+	});
+
+	it("reports an unattached fd 0 as NoStdin, not as a failed read", () => {
+		const outcome = readStdinWith(scriptedIo([errno("EBADF")]));
+		expect(outcome._tag).toBe("NoStdin");
+	});
+
+	// The no-hang constraint: a TTY with nothing piped returns before any read is attempted.
+	it("returns NoStdin on a TTY without reading", () => {
+		const io = scriptedIo(["never read"], {isTTY: true});
+		expect(readStdinWith(io)._tag).toBe("NoStdin");
+		expect(io.reads()).toBe(0);
+	});
+
+	it("decodes a multi-byte character split across two reads", () => {
+		const bytes = Buffer.from("çğü", "utf8");
+		const io = scriptedIo([]);
+		let call = 0;
+		const split: StdinIo = {
+			...io,
+			read: (into) => {
+				call += 1;
+				if (call === 1) {
+					bytes.subarray(0, 3).copy(into);
+					return 3;
+				}
+				if (call === 2) {
+					bytes.subarray(3).copy(into);
+					return bytes.length - 3;
+				}
+				return 0;
+			},
+		};
+		expect(readStdinWith(split)).toEqual({_tag: "Text", text: "çğü"});
+	});
+});
+
+describe("nodeStdinIo", () => {
+	const dirs: Array<string> = [];
+	afterEach(() => {
+		for (const dir of dirs.splice(0)) rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("reads a real fd to EOF through the node primitive", () => {
+		const dir = mkdtempSync(join(tmpdir(), "pipeline-cli-stdin-"));
+		dirs.push(dir);
+		const file = join(dir, "payload.txt");
+		writeFileSync(file, "usirin\ncansirin\n", "utf8");
+		const fd = openSync(file, "r");
+		const outcome = readStdinWith(nodeStdinIo(fd, false));
+		closeSync(fd);
+		expect(outcome).toEqual({_tag: "Text", text: "usirin\ncansirin\n"});
+	});
+});

--- a/packages/pipeline-cli/src/read-stdin.ts
+++ b/packages/pipeline-cli/src/read-stdin.ts
@@ -1,0 +1,64 @@
+/**
+ * The shared stdin read every pipeline-cli tool uses — the Effect seam over
+ * `read-stdin-core.ts` (#3924).
+ *
+ * One rule: a failed read of a present pipe never arrives as `""`. It lands in the error
+ * channel (`readStdinText`) or, for the tools that just want the fail-closed default, on stderr
+ * with a non-zero exit (`readStdinTextOrExit`). `""` still means an empty pipe, and a TTY with
+ * nothing piped still returns immediately rather than hanging.
+ *
+ * fd 0 stays a raw `node:fs` boundary here by design: the Effect `FileSystem` seam is path-keyed
+ * with no stdin reader, and `Stdio.stdin` is the blocking Stream that hangs on a TTY
+ * (`.patterns/effect-platform-access.md`).
+ */
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {
+	nodeStdinIo,
+	readStdinWith,
+	type StdinIo,
+	type StdinReadOptions,
+} from "./read-stdin-core.ts";
+
+/** The read could not complete — the outcome that used to be indistinguishable from empty stdin. */
+export class StdinReadFailed extends Schema.TaggedErrorClass<StdinReadFailed>()("StdinReadFailed", {
+	reason: Schema.String,
+}) {}
+
+/** Non-zero, and distinct from a gate's own verdict codes: the input was never read. */
+export const STDIN_READ_FAILED_EXIT_CODE = 4;
+
+/**
+ * All of stdin as UTF-8. Fails with `StdinReadFailed` on an unread pipe; succeeds with `""` when
+ * nothing was piped in at all (a TTY or an unattached fd 0).
+ */
+export const readStdinText = (
+	options?: StdinReadOptions,
+	io: StdinIo = nodeStdinIo(),
+): Effect.Effect<string, StdinReadFailed> =>
+	Effect.suspend(() => {
+		const outcome = readStdinWith(io, options);
+		switch (outcome._tag) {
+			case "Text":
+				return Effect.succeed(outcome.text);
+			case "NoStdin":
+				return Effect.succeed("");
+			case "Failed":
+				return Effect.fail(new StdinReadFailed({reason: outcome.reason}));
+		}
+	});
+
+/**
+ * `readStdinText`, with the fail-closed default already applied: report the failed read on stderr
+ * and exit non-zero. This is what a tool adopts when its answer is a function of the piped
+ * payload — deciding over evidence it could not read is the defect (#3924, ADR 0092).
+ */
+export const readStdinTextOrExit = (options?: StdinReadOptions): Effect.Effect<string> =>
+	readStdinText(options).pipe(
+		Effect.catchTag("StdinReadFailed", (error) =>
+			Effect.sync(() => {
+				process.stderr.write(`${error.reason}\n`);
+				process.exit(STDIN_READ_FAILED_EXIT_CODE);
+			}).pipe(Effect.andThen(Effect.never)),
+		),
+	);

--- a/packages/pipeline-cli/src/read-stdin.unit.test.ts
+++ b/packages/pipeline-cli/src/read-stdin.unit.test.ts
@@ -1,0 +1,64 @@
+import {Effect, Exit} from "effect";
+import {describe, expect, it} from "vitest";
+import {readStdinText, type StdinReadFailed} from "./read-stdin.ts";
+import type {StdinIo} from "./read-stdin-core.ts";
+
+const io = (read: StdinIo["read"], isTTY = false): StdinIo => {
+	let clock = 0;
+	return {
+		isTTY,
+		read,
+		sleep: (ms) => {
+			clock += ms;
+		},
+		now: () => clock,
+	};
+};
+
+const eagain = (): never => {
+	throw Object.assign(new Error("read EAGAIN"), {code: "EAGAIN"});
+};
+
+describe("readStdinText", () => {
+	it("succeeds with the piped text", () => {
+		let reads = 0;
+		const source = io((into) => {
+			reads += 1;
+			if (reads > 1) return 0;
+			const bytes = Buffer.from("piped", "utf8");
+			bytes.copy(into);
+			return bytes.length;
+		});
+		expect(Effect.runSync(readStdinText(undefined, source))).toBe("piped");
+	});
+
+	it("succeeds with '' when nothing was piped in — the no-hang TTY case", () => {
+		expect(
+			Effect.runSync(
+				readStdinText(
+					undefined,
+					io(() => 0, true),
+				),
+			),
+		).toBe("");
+	});
+
+	// The whole point: an unread pipe lands in the error channel, where "" used to be.
+	it("fails with StdinReadFailed on a pipe that never drains", () => {
+		const exit = Effect.runSyncExit(readStdinText({pollMs: 1, idleTimeoutMs: 10}, io(eagain)));
+		expect(Exit.isFailure(exit)).toBe(true);
+		const error = Exit.isFailure(exit) ? exit.cause : undefined;
+		expect(JSON.stringify(error)).toContain("StdinReadFailed");
+	});
+
+	it("carries a reason that names the errno, so the failure is diagnosable", () => {
+		const exit = Effect.runSyncExit(
+			readStdinText({pollMs: 1, idleTimeoutMs: 10}, io(eagain)).pipe(
+				Effect.catchTag("StdinReadFailed", (error: StdinReadFailed) =>
+					Effect.succeed(error.reason),
+				),
+			),
+		);
+		expect(Exit.isSuccess(exit) && exit.value).toContain("EAGAIN");
+	});
+});

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -24,9 +24,9 @@
  * unreadable §CLASS falls back to the fail-closed probes (`FAILCLOSED_PROBES`), which
  * over-dispatch every gate rather than skip one.
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {
 	classify,
@@ -91,17 +91,9 @@ const readFiles = (
 				Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf8")).pipe(
 					Effect.orElseSucceed(() => ""),
 				),
-			// stdin (fd 0): a node-only boundary — FileSystem exposes no stdin reader, so kept raw. A
-			// failed/empty read is absorbed into no files (""), never the E channel; a total helper.
-			onNone: () =>
-				Effect.sync(() => {
-					// biome-ignore lint/plugin: fd-0 boundary read (closed/empty stdin), absorbed to "" — not Effect-cosplay.
-					try {
-						return readFileSync(0, "utf8");
-					} catch {
-						return "";
-					}
-				}),
+			// stdin: a failed read exits non-zero through the shared reader — probing "no files
+			// changed" over a pipe that was never read is the defect (#3924).
+			onNone: () => readStdinTextOrExit(),
 		});
 		return raw
 			.split("\n")

--- a/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
@@ -16,9 +16,9 @@
  * unit-tested core). ship-it owns the `gh api` REST resolution of the members roster, the PR
  * author/head, and the two SHA-bound signals — the integration half this tool never touches.
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {type CpCardinalityInput, decideCpCardinality} from "./cp-cardinality.ts";
 
 const authorFlag = Flag.string("author").pipe(
@@ -38,25 +38,19 @@ const selfApprovalFlag = Flag.boolean("self-approval-at-head").pipe(
 );
 
 /**
- * Read the control-plane member logins from stdin; empty/failed read ⇒ N==0 (fail closed).
+ * Read the control-plane member logins from stdin. An empty roster ⇒ N==0 (fail closed); a
+ * roster that could not be *read* exits non-zero through the shared reader instead.
  *
- * The fd-0 read stays raw `node:fs`: the Effect `FileSystem` seam is path-keyed and exposes no
- * stdin reader, and `Stdio.stdin` is a Stream that blocks on a TTY with no pipe — so this is the
- * platform doc's node-only boundary case (.patterns/effect-platform-access.md), not a miss.
+ * The two used to be the same answer, and that was the bug: N==0 is a decision ship-it acts on,
+ * so an unread pipe rendered as "no members" is an outage wearing a verdict's clothes (#3924).
  */
-const readMembers = (): ReadonlyArray<string> => {
-	let raw: string;
-	// biome-ignore lint/plugin: best-effort read — an empty/failed stdin is absorbed into [] (⇒ N==0, fail closed), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		raw = readFileSync(0, "utf8");
-	} catch {
-		return [];
-	}
-	return raw
-		.split("\n")
-		.map((line) => line.trim())
-		.filter((line) => line.length > 0);
-};
+const readMembers = (): Effect.Effect<ReadonlyArray<string>> =>
+	Effect.map(readStdinTextOrExit(), (raw) =>
+		raw
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0),
+	);
 
 const decideCmd = Command.make(
 	"decide",
@@ -67,7 +61,7 @@ const decideCmd = Command.make(
 	},
 	Effect.fn(function* ({author, nonAuthorApproval, selfApproval}) {
 		const input: CpCardinalityInput = {
-			members: readMembers(),
+			members: yield* readMembers(),
 			author,
 			nonAuthorApprovalAtHead: nonAuthorApproval,
 			selfApprovalAtHead: selfApproval,

--- a/packages/pipeline-cli/src/tools/failure-classifier/command.ts
+++ b/packages/pipeline-cli/src/tools/failure-classifier/command.ts
@@ -17,9 +17,9 @@
  * construction: any input the core does not positively recognize as TRANSIENT yields
  * `logic`, so a classifier miss can only ever over-surface, never over-resume.
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {type CrashSignal, classify} from "./failure-classifier.ts";
 
 const reasonFlag = Flag.string("reason").pipe(
@@ -40,16 +40,13 @@ const stageFlag = Flag.string("stage").pipe(
 /**
  * Read a `CrashSignal` from stdin when it is a JSON object with any of the known fields —
  * the orchestrator can pipe the whole crash payload in one shot. A non-JSON or empty stdin
- * yields an empty signal (the core then default-denies), so this never throws.
+ * yields an empty signal (the core then default-denies); a *failed* read exits non-zero through
+ * the shared reader rather than classifying a payload it never read (#3924).
  */
-const readStdinSignal = (): CrashSignal => {
-	let raw = "";
-	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into an empty signal (the core default-denies), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		raw = readFileSync(0, "utf8");
-	} catch {
-		return {};
-	}
+const readStdinSignal = (): Effect.Effect<CrashSignal> =>
+	Effect.map(readStdinTextOrExit(), parseSignal);
+
+const parseSignal = (raw: string): CrashSignal => {
 	if (raw.trim() === "") return {};
 	// biome-ignore lint/plugin: best-effort parse — a non-JSON stdin is absorbed into a reason-only signal, never the E channel; a total helper, not Effect-cosplay.
 	try {
@@ -71,7 +68,7 @@ const classifyCmd = Command.make(
 	Effect.fn(function* ({reason, errorKind, stage}) {
 		// Flags win when present; otherwise fall back to a stdin JSON/text signal.
 		const anyFlag = Option.isSome(reason) || Option.isSome(errorKind) || Option.isSome(stage);
-		const base: CrashSignal = anyFlag ? {} : readStdinSignal();
+		const base: CrashSignal = anyFlag ? {} : yield* readStdinSignal();
 		const signal: CrashSignal = {
 			reason: Option.getOrUndefined(reason) ?? base.reason,
 			errorKind: Option.getOrUndefined(errorKind) ?? base.errorKind,

--- a/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
@@ -28,6 +28,7 @@ import {dirname, join, resolve} from "node:path";
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {
 	FAILCLOSED_GUARD_ADR_RE,
@@ -63,20 +64,18 @@ const rootFlag = Flag.string("root").pipe(
 );
 
 /**
- * Read the ADR body from `--body-file` or stdin. A failed read returns null, which the core
- * classifies guard-touching (fail-closed) — the same posture as an unreadable ADR at head.
+ * Read the ADR body from `--body-file` or stdin. An unreadable *file* returns null, which the
+ * core classifies guard-touching (fail-closed) — the same posture as an unreadable ADR at head;
+ * an unreadable *stdin* exits non-zero through the shared reader (#3924).
  */
-const readBody = (bodyFile: Option.Option<string>): string | null => {
-	// biome-ignore lint/plugin: best-effort read — a failed read is absorbed into null (⇒ guard-touching, fail-closed), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		return Option.match(bodyFile, {
-			onSome: (path) => readFileSync(path, "utf8"),
-			onNone: () => readFileSync(0, "utf8"),
-		});
-	} catch {
-		return null;
-	}
-};
+const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string | null> =>
+	Option.match(bodyFile, {
+		onSome: (path) =>
+			Effect.try(() => readFileSync(path, "utf8")).pipe(
+				Effect.orElseSucceed((): string | null => null),
+			),
+		onNone: () => readStdinTextOrExit(),
+	});
 
 /** Read local §CP text; null (⇒ fail-closed `GUARD_ADR_RE`) if the file is unreadable. */
 const readFormats = (root: string): string | null => {
@@ -95,7 +94,7 @@ const classifyCmd = Command.make(
 		const rootDir = Option.getOrElse(root, () => defaultRoot());
 		const formats = readFormats(rootDir);
 		const guardRe = formats === null ? FAILCLOSED_GUARD_ADR_RE : parseGuardAdrRe(formats);
-		const body = readBody(bodyFile);
+		const body = yield* readBody(bodyFile);
 		const result = probeGuardContent(body, guardRe);
 		const label = Option.getOrElse(path, () => "(stdin ADR)");
 

--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -24,11 +24,11 @@
  * is dropped: the `pipeline-cli` bin imports `@effect/platform-node` statically,
  * so by the time this command runs the runtime dep is always resolved.
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect, FileSystem, Option, Path, type PlatformError} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {onCheckFailed} from "../../gate-fail.ts";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {CREW_DIR, sweepCrew} from "./crew-gate.ts";
 import {PrComments, PrCommentsLive, type UpstreamUnavailableError} from "./github.ts";
 import {findCommentLeaks, findLeaks, type Leak} from "./leak-guard.ts";
@@ -175,9 +175,9 @@ const readCommentBody = (
 	bodyFile: Option.Option<string>,
 ): Effect.Effect<string, PlatformError.PlatformError, FileSystem.FileSystem> =>
 	Option.match(bodyFile, {
-		// stdin (fd 0): a node-only boundary — FileSystem exposes no stdin reader, so kept raw
-		// (.patterns/effect-platform-access.md bright line). A `--body-file` path routes the fs seam.
-		onNone: () => Effect.sync(() => readFileSync(0, "utf8")),
+		// A body this gate could not read must not scan as clean: the shared reader exits non-zero
+		// on a failed stdin read instead (#3924). A `--body-file` path routes the fs seam.
+		onNone: () => readStdinTextOrExit(),
 		onSome: (path) =>
 			Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf8")),
 	});

--- a/packages/pipeline-cli/src/tools/redact-leaks/command.ts
+++ b/packages/pipeline-cli/src/tools/redact-leaks/command.ts
@@ -11,9 +11,9 @@
  * shell pipeline; each redaction is reported on stderr for observability. `process.stdout.write`
  * (not `Console.log`) so a leak-free body is emitted byte-for-byte, no appended newline (#3021 AC5).
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect, FileSystem, Option, type PlatformError} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {findCommentLeaks} from "../leak-guard/leak-guard.ts";
 import {redactLeaks} from "./redact-leaks.ts";
 
@@ -26,9 +26,9 @@ const readBody = (
 	bodyFile: Option.Option<string>,
 ): Effect.Effect<string, PlatformError.PlatformError, FileSystem.FileSystem> =>
 	Option.match(bodyFile, {
-		// stdin (fd 0): a node-only boundary — FileSystem exposes no stdin reader, so kept raw
-		// (.patterns/effect-platform-access.md bright line). A `--body-file` path routes the fs seam.
-		onNone: () => Effect.sync(() => readFileSync(0, "utf8")),
+		// Emitting an empty body for a read that failed would silently truncate whatever the caller
+		// piped in; the shared reader exits non-zero instead (#3924).
+		onNone: () => readStdinTextOrExit(),
 		onSome: (path) =>
 			Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf8")),
 	});

--- a/packages/pipeline-cli/src/tools/resume-policy/command.ts
+++ b/packages/pipeline-cli/src/tools/resume-policy/command.ts
@@ -20,9 +20,9 @@
  * "resume up to K then surface" is decided by pure, unit-tested code, and this bin only
  * marshals flags/stdin into it.
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import type {CrashSignal} from "../failure-classifier/failure-classifier.ts";
 import {decideResume, type ResumeLedger} from "./resume-policy.ts";
 
@@ -71,20 +71,12 @@ interface StdinPayload {
 /**
  * Read a crash signal + resume ledger from a stdin JSON object. The orchestrator can pipe
  * the whole crash payload in one shot; a non-JSON or empty stdin yields empties (the flags
- * then fill in, or the core default-denies), so this never throws.
- *
- * The fd-0 read stays raw `node:fs` — the Effect `FileSystem` seam is path-keyed with no stdin
- * reader, and `Stdio.stdin` is a Stream that blocks on a TTY with no pipe: the platform doc's
- * node-only boundary case (.patterns/effect-platform-access.md).
+ * then fill in, or the core default-denies). A *failed* read exits non-zero through the shared
+ * reader — the resume decision must not default-deny over a payload it never read (#3924).
  */
-const readStdin = (): StdinPayload => {
-	let raw = "";
-	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into empties (the flags fill in, or the core default-denies), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		raw = readFileSync(0, "utf8");
-	} catch {
-		return {signal: {}, ledger: {}};
-	}
+const readStdin = (): Effect.Effect<StdinPayload> => Effect.map(readStdinTextOrExit(), parseStdin);
+
+const parseStdin = (raw: string): StdinPayload => {
 	if (raw.trim() === "") return {signal: {}, ledger: {}};
 	// biome-ignore lint/plugin: best-effort parse — a non-JSON stdin is absorbed into empties (the core default-denies), never the E channel; a total helper, not Effect-cosplay.
 	try {
@@ -117,7 +109,7 @@ const decideCmd = Command.make(
 		priorResumes: priorResumesFlag,
 	},
 	Effect.fn(function* ({reason, errorKind, stage, runId, scriptPath, priorResumes}) {
-		const base = readStdin();
+		const base = yield* readStdin();
 		const signal: CrashSignal = {
 			reason: Option.getOrUndefined(reason) ?? base.signal.reason,
 			errorKind: Option.getOrUndefined(errorKind) ?? base.signal.errorKind,

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.ts
@@ -28,25 +28,11 @@
  * detecting the stale tree IS its whole job, and it must run before any dep is
  * imported, so the probe is `createRequire`-based (pure; imports nothing).
  */
-import {readFileSync} from "node:fs";
 import {createRequire} from "node:module";
 import {Console, Effect} from "effect";
 import {Command} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {decideSpawn, formatSessionCost, type SessionCostInput} from "./spawn-guard.ts";
-
-/**
- * Read all of stdin as a UTF-8 string (the hook/statusline JSON envelope). The harness
- * pipes the envelope on fd 0; a synchronous read of fd 0 avoids a stream that hangs when run
- * on a TTY with no pipe. An empty/unreadable stdin yields `""` (the parser then degrades to
- * `{}`). This is a raw `node:fs` boundary by design: the Effect `FileSystem` seam is path-keyed
- * with no stdin reader, and `Stdio.stdin` is exactly the blocking Stream this avoids — the
- * platform doc's node-only case (.patterns/effect-platform-access.md).
- */
-const readStdin = (): Effect.Effect<string> =>
-	Effect.try({
-		try: () => readFileSync(0, "utf8"),
-		catch: () => "",
-	}).pipe(Effect.orElseSucceed(() => ""));
 
 const parseJson = (raw: string): Effect.Effect<Record<string, unknown>> =>
 	Effect.try({
@@ -63,7 +49,7 @@ const guard = Command.make(
 	"guard",
 	{},
 	Effect.fn(function* () {
-		const env = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const env = yield* readStdinTextOrExit().pipe(Effect.flatMap(parseJson));
 		const toolInput = asRecord(env.tool_input);
 		const requested = asString(toolInput.model);
 		const pin = asString(process.env.WORKFLOW_MODEL ?? null);
@@ -126,7 +112,7 @@ const statusline = Command.make(
 	"statusline",
 	{},
 	Effect.fn(function* () {
-		const payload = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const payload = yield* readStdinTextOrExit().pipe(Effect.flatMap(parseJson));
 		const cost = asRecord(payload.cost);
 		const input: SessionCostInput = {
 			totalCostUsd: asNumber(cost.total_cost_usd) ?? asNumber(payload.total_cost_usd),

--- a/packages/pipeline-cli/src/tools/structured-output-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/structured-output-guard/command.ts
@@ -20,9 +20,9 @@
  * from the former package's `bin.ts`; only the `Command.run`/`Effect.provide`/`runMain`
  * wiring is dropped — the shared `pipeline-cli` bin owns the run boundary (`NodeServices`).
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect} from "effect";
 import {Command} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {
 	type Decision,
 	decide,
@@ -33,15 +33,6 @@ import {
 const EXIT_ACCEPT = 0;
 const EXIT_FAIL = 1;
 const EXIT_RETRY = 2;
-
-const readStdin = (): string => {
-	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into "" (no input), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		return readFileSync(0, "utf8");
-	} catch {
-		return "";
-	}
-};
 
 interface PromptInput {
 	readonly schema: OutputSchema;
@@ -60,7 +51,7 @@ const promptCmd = Command.make(
 	"prompt",
 	{},
 	Effect.fn(function* () {
-		const input = JSON.parse(readStdin()) as PromptInput;
+		const input = JSON.parse(yield* readStdinTextOrExit()) as PromptInput;
 		yield* Console.log(renderSchemaSection(input.schema, input.example));
 	}),
 ).pipe(
@@ -76,7 +67,7 @@ const decideCmd = Command.make(
 	"decide",
 	{},
 	Effect.fn(function* () {
-		const input = JSON.parse(readStdin()) as DecideInput;
+		const input = JSON.parse(yield* readStdinTextOrExit()) as DecideInput;
 		const options: {cap?: number; example?: Record<string, unknown>} = {};
 		if (input.cap !== undefined) options.cap = input.cap;
 		if (input.example !== undefined) options.example = input.example;

--- a/packages/pipeline-cli/src/tools/tracker/command.ts
+++ b/packages/pipeline-cli/src/tools/tracker/command.ts
@@ -26,6 +26,7 @@
 import {readFileSync} from "node:fs";
 import {Console, Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {
 	type ClaimResult,
 	type CommentResult,
@@ -167,18 +168,12 @@ const stageFlag = Flag.string("stage").pipe(
 	Flag.withDescription("the lifecycle stage the new issue enters at (default: needs-triage)"),
 );
 
-/** The body from `--body`, else streamed from stdin (fd 0); an unreadable stream ⇒ empty. */
-const resolveBody = (body: Option.Option<string>): string => {
-	// biome-ignore lint/plugin: best-effort stdin read — a failed/absent stream is an empty body (the CLI's pre-verb input marshalling), never the E channel; a total helper, not Effect-cosplay. Mirrors trivial-diff's readDiff.
-	try {
-		return Option.match(body, {
-			onSome: (b) => b,
-			onNone: () => readFileSync(0, "utf8"),
-		});
-	} catch {
-		return "";
-	}
-};
+/** The body from `--body`, else stdin — where a failed read exits non-zero, never files an empty issue. */
+const resolveBody = (body: Option.Option<string>): Effect.Effect<string> =>
+	Option.match(body, {
+		onSome: (b) => Effect.succeed(b),
+		onNone: () => readStdinTextOrExit(),
+	});
 
 const reportCreated = (result: CreateIssueResult): Effect.Effect<void> =>
 	Console.log(`tracker: created #${result.target} — ${result.url}`);
@@ -189,7 +184,7 @@ const createIssue = Command.make(
 	Effect.fn(function* ({title, body, stage}) {
 		const result = yield* (yield* Tracker).createIssue({
 			title,
-			body: resolveBody(body),
+			body: yield* resolveBody(body),
 			stage: Option.getOrElse(stage, () => "needs-triage"),
 		});
 		yield* reportCreated(result);
@@ -211,7 +206,8 @@ const createComment = Command.make(
 	"create-comment",
 	{target: commentTargetArg, body: bodyFlag},
 	Effect.fn(function* ({target, body}) {
-		const result = yield* (yield* Tracker).createComment(target, {body: resolveBody(body)});
+		const resolved = yield* resolveBody(body);
+		const result = yield* (yield* Tracker).createComment(target, {body: resolved});
 		yield* reportCommented(target, result);
 	}),
 ).pipe(
@@ -246,13 +242,13 @@ const parsePassed = (raw: string): Effect.Effect<boolean, never> => {
 	return backOff(`invalid --result '${raw}' — expected PASS or FAIL`);
 };
 
-const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string, never> =>
-	Effect.sync(() =>
-		Option.match(bodyFile, {
-			onNone: () => readFileSync(0, "utf8"),
-			onSome: (path) => readFileSync(path, "utf8"),
-		}),
-	);
+const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string> =>
+	Option.match(bodyFile, {
+		// A failed stdin read exits non-zero rather than reaching the empty-body back-off below,
+		// which would report "nothing to post" for a verdict body that was never read (#3924).
+		onNone: () => readStdinTextOrExit(),
+		onSome: (path) => Effect.sync(() => readFileSync(path, "utf8")),
+	});
 
 const reportVerdict = (target: number, result: VerdictResult): Effect.Effect<void> =>
 	Console.log(

--- a/packages/pipeline-cli/src/tools/trivial-diff/command.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/command.ts
@@ -28,9 +28,9 @@
  * miss can only ever over-route to the full (correct) fan-out, never under-gate.
  */
 import {execFileSync} from "node:child_process";
-import {readFileSync} from "node:fs";
 import {Console, Effect, FileSystem, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {parseGuardAdrRe} from "../guard-content-probe/guard-content-probe.ts";
@@ -68,22 +68,16 @@ const repoFlag = Flag.string("repo").pipe(
 );
 
 /**
- * Read the diff: from `--diff-file` over the `FileSystem` seam if given, else stdin (fd 0),
- * which has no `FileSystem` equivalent and so stays a raw `node:fs` read at this boundary
- * (`.patterns/effect-platform-access.md`). Any read failure ⇒ null (fail-closed: the core then
- * refuses).
+ * Read the diff: from `--diff-file` over the `FileSystem` seam if given, else stdin. An
+ * unreadable `--diff-file` ⇒ null (fail-closed: the core then refuses); an unreadable *stdin*
+ * exits non-zero through the shared reader rather than posing as an empty diff (#3924).
  */
 const readDiff = Effect.fn(function* (diffFile: Option.Option<string>) {
 	if (Option.isSome(diffFile)) {
 		const fs = yield* FileSystem.FileSystem;
 		return yield* Effect.orElseSucceed(fs.readFileString(diffFile.value), () => null);
 	}
-	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into null (fail-closed: the core then refuses), never the E channel; a total helper, not Effect-cosplay.
-	try {
-		return readFileSync(0, "utf8");
-	} catch {
-		return null;
-	}
+	return yield* readStdinTextOrExit();
 });
 
 /** Resolve owner/repo: `--repo`, else `CLAUDE_PIPELINE_REPO`, else `gh repo view`. null on failure. */

--- a/packages/pipeline-cli/src/tools/tsc-annotate/command.ts
+++ b/packages/pipeline-cli/src/tools/tsc-annotate/command.ts
@@ -74,9 +74,10 @@ const readMembers = (root: string): ReadonlyArray<WorkspaceMember> => {
  * Stream stdin through to stdout as it arrives (the CI log stays live, not withheld until
  * the typecheck ends) while accumulating it for the annotation pass.
  *
- * Deliberately NOT `readFileSync(0)`: on a non-blocking pipe that throws EAGAIN, and this
- * filter sits on the whole typecheck log — a swallowed EAGAIN silently deletes every line
- * of it. Observed live while rehearsing this step, not theorised.
+ * This is the one stdin reader that does NOT go through the shared `readStdinTextOrExit`
+ * (#3924): that one buffers to EOF before returning, which would withhold the whole CI log
+ * until the typecheck ends. Both refuse to swallow an EAGAIN into an empty read — the failure
+ * that deleted every line of a piped typecheck log, observed live, not theorised.
  */
 const passThroughStdin = Effect.callback<string>((resume) => {
 	const chunks: Array<Buffer> = [];

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -26,9 +26,9 @@
  * `GithubLive` is baked in with `Command.provide(...)` so the registered command's residual
  * requirement is the Node platform union (the registry seam, epic #994).
  */
-import {readFileSync} from "node:fs";
 import {Console, Effect, FileSystem, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {Github, GithubLive} from "./github.ts";
 import {
 	emissionDefect,
@@ -109,12 +109,12 @@ const read = Command.make(
 
 /**
  * Read the composed verdict body: from `--body-file` over the `FileSystem` seam, else from
- * stdin. Stdin (fd 0) has no `FileSystem` equivalent, so that read stays a raw `node:fs` call
- * at this boundary (`.patterns/effect-platform-access.md` bright line). An unreadable
- * `--body-file` stays a defect (`Effect.orDie`), preserving the pre-migration crash-out.
+ * stdin through the shared fail-closed reader, which exits non-zero on a failed read rather
+ * than reporting an unread body as the empty one below (#3924). An unreadable `--body-file`
+ * stays a defect (`Effect.orDie`), preserving the pre-migration crash-out.
  */
 const readBody = Effect.fn(function* (bodyFile: Option.Option<string>) {
-	if (Option.isNone(bodyFile)) return readFileSync(0, "utf8");
+	if (Option.isNone(bodyFile)) return yield* readStdinTextOrExit();
 	const fs = yield* FileSystem.FileSystem;
 	return yield* Effect.orDie(fs.readFileString(bodyFile.value));
 });


### PR DESCRIPTION
Every pipeline-cli tool that takes input on a pipe read it with `readFileSync(0, "utf8")` inside a `try`/`catch` that turned any failure into an empty string. That call throws `EAGAIN` when fd 0 is a non-blocking pipe, so a read that failed looked exactly like a pipe that carried nothing — and the tools that decide something from the piped payload went ahead and decided, over evidence they never read.

This replaces all 13 of those reads with one shared reader that keeps the two apart. It retries `EAGAIN` until the pipe drains, and if the pipe stalls it says so on stderr and exits non-zero instead of reporting an empty read. An empty string now means an empty pipe and nothing else.

## What changed

- **`packages/pipeline-cli/src/read-stdin-core.ts`** — the pure core. It resolves fd 0 to one of three disjoint outcomes: `Text` (read to EOF; the text may legitimately be `""`), `NoStdin` (a TTY or an unattached fd 0 — nothing was piped in), `Failed` (a pipe that was present and could not be read). `EAGAIN`/`EWOULDBLOCK`/`EINTR` are retried, with the stall budget reset on every byte read, so a slow producer completes and only a genuinely stuck pipe trips the deadline into `Failed`. The IO is injected, which is what makes the `EAGAIN` path testable without a real non-blocking fd.
- **`packages/pipeline-cli/src/read-stdin.ts`** — the Effect seam. `readStdinText` carries a failed read as a typed `StdinReadFailed` in the error channel; `readStdinTextOrExit` applies the fail-closed default (report on stderr, exit 4) and is what the tools adopt.
- **All 13 call sites across the 12 tools** now read through the shared reader: `trivial-diff`, `class-probe`, `structured-output-guard`, `spawn-guard`, `cp-cardinality`, `guard-content-probe`, `tracker` (×2), `verdict`, `resume-policy`, `failure-classifier`, `leak-guard`, `redact-leaks`. `grep -rn 'readFileSync(0' packages/pipeline-cli/src/tools` now finds nothing.
- **`tsc-annotate`** keeps its own streaming reader — buffering to EOF would withhold the whole CI log until the typecheck ends — and its comment now points at the shared one rather than at the shape it avoids.
- **`packages/pipeline-cli/README.md`** — a short section on how a tool reads stdin, so the next tool reaches for the reader instead of `readFileSync(0)`.

## The gate-shaped subset

`leak-guard`, `cp-cardinality`, `spawn-guard`, `verdict`, `structured-output-guard` and `guard-content-probe` all compute a verdict from the piped payload. Each now exits non-zero on a failed read rather than deciding over no evidence — the emptiness these used to absorb was not a real zero scope but an unread pipe, which is the ADR 0092 class with the scope itself a lie.

`cp-cardinality`'s absorption was the sharpest case: its comment called the empty-read path "fail closed", but that was fail-closed against a *missing* pipe, not against a *failed read of a present* pipe. The two are now distinct — an empty roster still means `N=0`, an unreadable roster exits 4.

## The no-hang constraint

A TTY with nothing piped in still returns immediately. That is a check on `isTTY` before the first read rather than a timeout, because on a TTY the read blocks on the operator's keystrokes and no deadline can tell that apart from a slow producer. The three empty-stdin shapes the existing bin tests cover — an empty pipe, `< /dev/null`, and a closed fd 0 — all still deliver an empty read and keep their current classifications.

## Verification

- `pnpm typecheck` (workspace) clean, `pnpm lint:worktree` clean.
- `pnpm --filter @kampus/pipeline-cli test`: 148 files / 2074 tests pass, including the existing bin-level stdin contract tests for `class-probe` and `guard-content-probe`.
- 16 new tests: the retry-to-completion path, the stall that must fail loud rather than return `Text("")`, a partial read that then stalls, the budget reset across a slow producer, `EINTR`/`EWOULDBLOCK`, a non-retryable errno, an unattached fd 0, the TTY early return (asserting no read is attempted), a multi-byte character split across two reads, a real fd read through the node primitive, and the Effect seam's success/failure outcomes.
- Smoke-ran `cp-cardinality`, `class-probe`, `failure-classifier`, `resume-policy`, `spawn-guard`, `redact-leaks` and `guard-content-probe` over real pipes: output and exit codes unchanged.

The doc-side half — `.patterns/effect-platform-access.md` has no bright line for stdin at all — is #3918, which is where the pattern doc should end up pointing at this reader. Left alone here, as triage scoped it.

Fixes #3924
