### PR TITLE
fix(pipeline): run-evidence lookup reports pending/absent/unknown as distinct facts (#3991)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -442,61 +442,63 @@ CI logs; that is what makes a criterion's evidence *reproducible* rather than a 
 summary. The bundle is a verdict **input**, never a merge authority: you still verify each
 criterion and you still never merge.
 
-Fetch it the way the storage ADR fixed (inline `gh api` per 0056 — resolve the PR head SHA,
-find the `run-evidence` workflow run for *that exact SHA*, download its `run-evidence`
-artifact, read `manifest.json`). The **head-SHA filter is load-bearing**: a bundle from a
-stale earlier push is not evidence for this commit.
+Fetch it through the **one tested verb — never a hand-rolled `gh api` chain**:
+`pipeline-cli run-evidence read` (#3991) resolves the producer run for *that exact SHA*,
+downloads the artifact, and **validates it before interpreting it** (the ZIP magic bytes prove
+you received an archive and not a 503 error body; `schemaVersion` and
+`manifest.commit == HEAD_SHA` prove the manifest attests *this* head). The **head-SHA filter is
+load-bearing**: a bundle from a stale earlier push is not evidence for this commit.
 
 ```bash
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')"
-# the run-evidence workflow run for THIS exact head SHA (newest wins), never just "latest on branch"
-RUN_ID="$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
-  --jq '[.workflow_runs[] | select(.name=="run-evidence")] | sort_by(.created_at) | last | .id')"
-BUNDLE_DIR="$(mktemp -d)/run-evidence-${PR}"; MANIFEST=""
-if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
-  ART_ID="$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
-    --jq '.artifacts[] | select(.name=="run-evidence") | .id' | head -1)"
-  if [ -n "$ART_ID" ]; then
-    mkdir -p "$BUNDLE_DIR"
-    gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > "$BUNDLE_DIR/run-evidence.zip" \
-      && unzip -o -q "$BUNDLE_DIR/run-evidence.zip" -d "$BUNDLE_DIR" \
-      && [ -f "$BUNDLE_DIR/manifest.json" ] && MANIFEST="$BUNDLE_DIR/manifest.json"
-  fi
-fi
+# Exit 0 means `present` — a validated, head-bound bundle. Every other state comes back on stdout
+# as JSON, so read the state rather than branching on the exit alone.
+BUNDLE="$(pipeline-cli run-evidence read --pr "$PR")" || true
+BUNDLE_STATE="$(jq -r '.state' <<<"$BUNDLE")"     # present | pending | absent | unknown
+BUNDLE_LINE="$(jq -r '.reportLine' <<<"$BUNDLE")" # the verdict line, evidence already in it
 ```
 
-When `$MANIFEST` is present, read its structured results (ADR 0054 §2 fields, `schemaVersion`
-the JSON number `1` — `Schema.Number`, not a string; compare numerically if you assert on it):
-`checks[]` is each gate step (`{name, status: pass|fail, exitCode}`), `tests` is the
-folded JUnit summary (`{total, passed, failed, skipped, failures[]}`, each failure
-`{suite, name, message}`):
+When the state is `present`, `.manifest` carries the structured results (ADR 0054 §2 fields):
+`checks[]` is each gate step (`{name, status: pass|fail}`), `tests` is the folded JUnit summary
+(`{total, passed, failed, skipped, failingSuites[]}`).
 
 ```bash
-[ -n "$MANIFEST" ] && jq '{
-  commit, schemaVersion,
-  checks: [.checks[] | {name, status}],
-  tests: {total: .tests.total, passed: .tests.passed, failed: .tests.failed, skipped: .tests.skipped,
-          failing_suites: [.tests.failures[] | "\(.suite) › \(.name)"]}
-}' "$MANIFEST"
+[ "$BUNDLE_STATE" = present ] && jq '.manifest | {commit, schemaVersion, checks, tests}' <<<"$BUNDLE"
 ```
 
 Cite those numbers as the evidence for any criterion they speak to — "lint/typecheck/unit
 all `pass` per the bundle's `checks[]`", "`tests`: 47 passed / 0 failed (bundle for
 `<short-sha>`)", or on a miss the named failing suites — rather than re-deriving them from a
-log scrape. **Sanity-check `manifest.commit == HEAD_SHA`**; the producer stamps it, but a
-mismatch means the bundle is not for this commit — treat it as absent (below).
+log scrape. The verb has already asserted `manifest.commit == HEAD_SHA` and the schema version, so
+a `present` state *is* the sanity check; don't re-derive it.
 
-**Degrade gracefully — a missing bundle is never an error.** If no `run-evidence` run exists
-for the head SHA, the artifact is absent/expired (GitHub expires run artifacts; 0056), the
-download fails, or `manifest.commit != HEAD_SHA`, then `$MANIFEST` is empty: **note the
-bundle's absence in the verdict and fall back to the current behavior** — verify the criteria
-from the diff, the tests you run in the review worktree above, and the PR's checks the
-ordinary way. Do **not** fail the gate, refuse to review, or block on the bundle: it
-*strengthens* evidence when present; its absence costs only reproducibility, not the review.
+**Degrade gracefully — but report WHICH state you observed. A pending or unreadable bundle is
+not an absent one (#3991).** Three of the four states are non-`present`, they are **different
+facts**, and reporting any of them as "absent" is a false claim about the PR:
+
+- **`pending`** — the producer exists but has published nothing for this head *yet* (no run at the
+  head, or a run still in flight). This says nothing about the PR; calling it absent invents a CI
+  gap (PR #3913: the verdict posted 11 minutes before the producer's only run at that head was
+  even created).
+- **`absent`** — positive evidence the producer yielded nothing: no `run-evidence` workflow in the
+  repo, a run that **completed** and published no artifact, or an expired artifact.
+- **`unknown`** — the lookup could not be read (a 5xx after retries, a non-archive payload, a
+  non-conforming response, a `gh` non-zero exit). A failed read is **not** a missing bundle; the
+  same distinction `ship-it` Step 3.5 draws between `unverified-transient` and `no bundle`.
+
+On any non-`present` state, **paste `$BUNDLE_LINE` verbatim into the verdict** — it already names
+the state, the queried head, the producer run id (or an explicit zero-runs result) and the artifact
+id, so the claim is falsifiable from the comment alone — then fall back to verifying the criteria
+from the diff, the tests you run in the review worktree above, and the PR's checks the ordinary
+way. Do **not** fail the gate, refuse to review, or block on the bundle: it *strengthens* evidence
+when present; its absence costs only reproducibility, not the review. And never write the state as
+free prose: a rationale you did not read off the lookup ("skipped by change-detection" — a
+mechanism `.github/workflows/run-evidence.yml` does not have) is the confabulated-verified-claim
+class ADR [0152](https://github.com/kamp-us/phoenix/blob/main/.decisions/0152-confabulation-guardrail-and-resume-cap.md) forbids.
 
 **But fail closed on the test surface (ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)) — a `PASS` must never be reachable on a strictly-narrower
-test surface than the change's blast radius.** When the bundle degrades and you fall back to
-running tests in the review worktree, the SHA-bound proof of *what CI ran* is gone, so a
+test surface than the change's blast radius.** On any non-`present` state you fall back to
+running tests in the review worktree, and the SHA-bound proof of *what CI ran* is gone, so a
 feature-scoped run (`--project unit <feature-path>`) can miss a **cross-cutting contract
 test** that lives outside the changed feature's cone — e.g. a new server-emittable wire code
 has repo-wide contract blast radius against `apps/web/worker/features/fate/wireCodes.unit.test.ts`
@@ -1419,8 +1421,8 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 - [PASS] <criterion 2> — <evidence>
 - …
 
-Run-evidence bundle: <one of — "cited for `<short-sha>`: checks all pass; tests 47/0/2
-(passed/failed/skipped)" | "absent for this head SHA — verified from diff + worktree run">.
+<$BUNDLE_LINE — the `Run-evidence bundle:` line from `run-evidence read`, pasted verbatim; on a
+non-`present` state append "— verified from diff + worktree run">
 
 Read the PR head (§HEAD): all files under review sourced from `<HEAD_SHA>` via `$REVIEW_WT` /
 `git show "$PR_REF:<path>"`, never the launched checkout's working copy.
@@ -1526,7 +1528,7 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time —
 - [PASS] <criterion 1> — <evidence>
 - [PASS] <criterion 2> — <evidence>
 
-Run-evidence bundle: <cited for `<short-sha>` | absent — verified from diff + worktree run>.
+<$BUNDLE_LINE, pasted verbatim; on a non-`present` state append "— verified from diff + worktree run">
 ```
 
 ---
@@ -1594,8 +1596,9 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 - [FAIL] <criterion 2> — asked <X>, but the PR <does Y / does nothing>; <pointer>
 - [UNVERIFIABLE] <criterion 3> — <why it can't be confirmed; what'd make it checkable>
 
-Run-evidence bundle: <one of — "cited for `<short-sha>`: tests 45/2/0 — failing suites:
-`<suite › name>`, …" | "absent for this head SHA — verified from diff + worktree run">.
+<$BUNDLE_LINE, pasted verbatim — it already names the failing suites on a `present` state; on a
+non-`present` state append "— verified from diff + worktree run">
+
 
 Failing criteria above must be addressed before this PR can merge. The PR stays open
 and unmerged; #<ISSUE> stays open and assigned. Re-request review once the failing

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -59,6 +59,7 @@ import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
 import {reviewHeadCommand} from "./tools/review-head/command.ts";
 import {roadmapCommand} from "./tools/roadmap/command.ts";
 import {roadmapGuardCommand} from "./tools/roadmap-guard/command.ts";
+import {runEvidenceCommand} from "./tools/run-evidence/command.ts";
 import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
 import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
@@ -208,4 +209,11 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// workspace: specifier, making the #3802 uninstallable-publish class unrepresentable.
 	// Scope derived from publish.yml's tag grammar; fail-closed on zero scope (ADR 0092).
 	publishIsolationGuardCommand,
+	// #3991 — the SHA-bound run-evidence bundle lookup as FOUR states: present / pending / absent /
+	// unknown. review-code's inline `gh api` chain collapsed every non-success path into the prose
+	// "absent for this head SHA", so a producer that had not run yet and a 5xx during the download
+	// both read as a missing bundle. Validates the archive (ZIP magic) and the manifest
+	// (schemaVersion, commit == head) before interpreting either, and carries the lookup evidence
+	// (queried SHA, run id, artifact id) so the claim is falsifiable from the verdict comment alone.
+	runEvidenceCommand,
 ];

--- a/packages/pipeline-cli/src/tools/run-evidence/command.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/command.ts
@@ -1,0 +1,97 @@
+/**
+ * The `run-evidence` tool — `pipeline-cli run-evidence read --pr N | --sha S [--expect <state>]`.
+ *
+ *   node src/bin.ts run-evidence read --pr 3951                    # exit 0 = a validated bundle is PRESENT
+ *   node src/bin.ts run-evidence read --pr 3951 --expect pending   # exit 0 = genuinely not-yet-published
+ *
+ * The single tested bundle lookup a gate cites instead of hand-rolling the `gh api` chain (#3991,
+ * the same single-source move as `verdict read` / `checks read`). stdout is the JSON reading —
+ * including `reportLine`, the ready-to-paste `Run-evidence bundle:` line a verdict carries with its
+ * lookup evidence — and the exit status answers "is it the state I expected" (default `present`).
+ *
+ * A non-`present` exit is NOT an error the caller should treat as absence: read `state` for which of
+ * the four it was. `RunEvidenceIoLive` is baked in with `Command.provide(...)` so the registered
+ * command's residual requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {RunEvidenceIo, RunEvidenceIoLive} from "./github.ts";
+import {type BundleState, classifyBundle, renderReportLine} from "./run-evidence.ts";
+
+const FAIL_EXIT_CODE = 1;
+
+const STATES: ReadonlyArray<BundleState> = ["present", "pending", "absent", "unknown"];
+
+const prFlag = Flag.integer("pr").pipe(
+	Flag.optional,
+	Flag.withDescription("the pull request whose live head the bundle must be bound to"),
+);
+
+const shaFlag = Flag.string("sha").pipe(
+	Flag.optional,
+	Flag.withDescription("the head SHA to look up directly (alternative to --pr)"),
+);
+
+const expectFlag = Flag.string("expect").pipe(
+	Flag.optional,
+	Flag.withDescription(`the state an exit 0 means: ${STATES.join(" | ")} (default: present)`),
+);
+
+const fail = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`run-evidence: ${reason}\n`);
+		process.exit(FAIL_EXIT_CODE);
+	});
+
+const parseExpect = (raw: Option.Option<string>): Effect.Effect<BundleState> => {
+	const value = Option.getOrElse(raw, () => "present")
+		.trim()
+		.toLowerCase();
+	return (STATES as ReadonlyArray<string>).includes(value)
+		? Effect.succeed(value as BundleState)
+		: fail(`invalid --expect '${value}' — expected one of ${STATES.join(" | ")}`);
+};
+
+const read = Command.make(
+	"read",
+	{pr: prFlag, sha: shaFlag, expect: expectFlag},
+	Effect.fn(function* ({pr, sha, expect}) {
+		const expected = yield* parseExpect(expect);
+		const io = yield* RunEvidenceIo;
+		const pinned = Option.getOrUndefined(sha);
+		const prNumber = Option.getOrUndefined(pr);
+		if ((pinned === undefined) === (prNumber === undefined)) {
+			return yield* fail("pass exactly one of --pr <n> or --sha <sha>");
+		}
+		const head = pinned ?? (yield* io.headSha(prNumber as number));
+		const reading = classifyBundle(yield* io.probe(head));
+		const reportLine = renderReportLine(reading);
+		yield* Console.log(
+			JSON.stringify({
+				state: reading.state,
+				reason: reading.reason,
+				detail: reading.detail,
+				evidence: reading.evidence,
+				manifest: reading.manifest,
+				reportLine,
+			}),
+		);
+		if (reading.state === expected) {
+			process.stderr.write(`${reportLine}\n`);
+			return;
+		}
+		return yield* fail(`${reportLine} (expected ${expected})`);
+	}),
+).pipe(
+	Command.withDescription(
+		"Resolve a PR head's run-evidence bundle to present | pending | absent | unknown with its lookup evidence (exit 0 = the state matches --expect, default present)",
+	),
+);
+
+export const runEvidenceCommand = Command.make("run-evidence").pipe(
+	Command.withSubcommands([read]),
+	Command.withDescription(
+		"Read a PR head's SHA-bound run-evidence bundle — the shared four-state lookup that never reports a pending or unreadable bundle as absent (#3991)",
+	),
+	Command.provide(RunEvidenceIoLive),
+);

--- a/packages/pipeline-cli/src/tools/run-evidence/fixtures.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/fixtures.ts
@@ -1,0 +1,92 @@
+/**
+ * Test fixtures for `run-evidence`: a real ZIP writer and a valid ADR 0054 §2 manifest.
+ *
+ * The archive is assembled byte-by-byte rather than mocked so the reader is exercised against an
+ * actual central directory — a stubbed "unzip returns this string" fixture would prove nothing about
+ * the case that mattered, an error body arriving where an archive was expected.
+ */
+import {deflateRawSync} from "node:zlib";
+import type {Manifest} from "../crabbox-manifest/Manifest.ts";
+
+const encoder = new TextEncoder();
+
+export interface ZipEntryInput {
+	readonly name: string;
+	readonly content: string;
+	/** `stored` (method 0) or `deflated` (method 8) — both shapes a real artifact can carry. */
+	readonly compression?: "stored" | "deflated";
+}
+
+const u16 = (view: DataView, at: number, value: number): void => view.setUint16(at, value, true);
+const u32 = (view: DataView, at: number, value: number): void => view.setUint32(at, value, true);
+
+/** Assemble a minimal but genuinely well-formed ZIP archive. CRCs are zeroed — the reader ignores them. */
+export const makeZip = (entries: ReadonlyArray<ZipEntryInput>): Uint8Array => {
+	const prepared = entries.map((entry) => {
+		const raw = encoder.encode(entry.content);
+		const deflated = entry.compression === "deflated";
+		const data = deflated ? new Uint8Array(deflateRawSync(raw)) : raw;
+		return {name: encoder.encode(entry.name), data, uncompressed: raw.length, deflated};
+	});
+
+	const localSize = prepared.reduce((sum, e) => sum + 30 + e.name.length + e.data.length, 0);
+	const centralSize = prepared.reduce((sum, e) => sum + 46 + e.name.length, 0);
+	const out = new Uint8Array(localSize + centralSize + 22);
+	const view = new DataView(out.buffer);
+
+	let at = 0;
+	const offsets: Array<number> = [];
+	for (const entry of prepared) {
+		offsets.push(at);
+		u32(view, at, 0x04034b50);
+		u16(view, at + 4, 20);
+		u16(view, at + 8, entry.deflated ? 8 : 0);
+		u32(view, at + 18, entry.data.length);
+		u32(view, at + 22, entry.uncompressed);
+		u16(view, at + 26, entry.name.length);
+		out.set(entry.name, at + 30);
+		out.set(entry.data, at + 30 + entry.name.length);
+		at += 30 + entry.name.length + entry.data.length;
+	}
+
+	const centralStart = at;
+	for (const [index, entry] of prepared.entries()) {
+		u32(view, at, 0x02014b50);
+		u16(view, at + 4, 20);
+		u16(view, at + 6, 20);
+		u16(view, at + 10, entry.deflated ? 8 : 0);
+		u32(view, at + 20, entry.data.length);
+		u32(view, at + 24, entry.uncompressed);
+		u16(view, at + 28, entry.name.length);
+		u32(view, at + 42, offsets[index] ?? 0);
+		out.set(entry.name, at + 46);
+		at += 46 + entry.name.length;
+	}
+
+	u32(view, at, 0x06054b50);
+	u16(view, at + 8, prepared.length);
+	u16(view, at + 10, prepared.length);
+	u32(view, at + 12, centralSize);
+	u32(view, at + 16, centralStart);
+	return out;
+};
+
+/** A valid manifest for `commit`, with `checks` all pass and a clean test summary. */
+export const manifestFor = (commit: string): Manifest => ({
+	schemaVersion: 1,
+	commit,
+	run: {producer: "crabbox", timestamp: "2026-07-25T04:57:44Z", environment: "ci"},
+	checks: [
+		{name: "unit", status: "pass", exitCode: 0},
+		{name: "bundle-node-core-free", status: "pass", exitCode: 0},
+	],
+	tests: {total: 2362, passed: 2362, failed: 0, skipped: 0, failures: []},
+	logs: {ref: "run-log"},
+});
+
+/** The `run-evidence` artifact archive a producer publishes for `commit`. */
+export const bundleZipFor = (commit: string): Uint8Array =>
+	makeZip([
+		{name: "manifest.json", content: JSON.stringify(manifestFor(commit)), compression: "deflated"},
+		{name: "junit.xml", content: "<testsuites/>"},
+	]);

--- a/packages/pipeline-cli/src/tools/run-evidence/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/github-service.unit.test.ts
@@ -1,0 +1,273 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Schedule, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {bundleZipFor} from "./fixtures.ts";
+import {
+	allArgBuilders,
+	makeRunEvidenceIoLive,
+	type RepoResolutionError,
+	RunEvidenceIo,
+} from "./github.ts";
+import {classifyBundle} from "./run-evidence.ts";
+
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+const HEAD = "05de8f09aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const RUN_ID = 30144746535;
+const ARTIFACT_ID = 8615655601;
+const enc = new TextEncoder();
+
+interface Reply {
+	readonly stdout: Uint8Array | string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+
+const bytesOf = (value: Uint8Array | string): Uint8Array =>
+	typeof value === "string" ? enc.encode(value) : value;
+
+/** A `ChildProcessSpawner` answering `gh api` from a REST-path fixture map, bytes included. */
+const mockSpawner = (
+	replies: Record<string, Reply>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const path = (args.find((a) => a.startsWith("repos/")) ?? "").replace(/\?.*$/, "");
+				const reply = replies[path];
+				const stdout = reply === undefined ? new Uint8Array(0) : bytesOf(reply.stdout);
+				const exitCode = reply?.exitCode ?? (reply === undefined ? 1 : 0);
+				const stderr =
+					reply?.stderr ?? (reply === undefined ? `gh: Not Found (HTTP 404) ${path}` : "");
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([stdout]),
+					stderr: Stream.fromIterable([enc.encode(stderr)]),
+					all: Stream.fromIterable([stdout]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+// One immediate retry: enough to exercise the transient path without a real backoff delay.
+const TEST_SCHEDULE = Schedule.recurs(1);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, RunEvidenceIo>,
+	replies: Record<string, Reply>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(
+		Effect.provide(makeRunEvidenceIoLive(TEST_SCHEDULE).pipe(Layer.provide(mockSpawner(replies)))),
+	);
+
+const path = (suffix: string) => `repos/${PINNED_REPO}/${suffix}`;
+const WORKFLOWS = path("actions/workflows");
+const RUNS = path("actions/runs");
+const ARTIFACTS = path(`actions/runs/${RUN_ID}/artifacts`);
+const ZIP = path(`actions/artifacts/${ARTIFACT_ID}/zip`);
+
+const producerDefined = {stdout: JSON.stringify([{workflows: [{name: "run-evidence"}]}])};
+
+const runsAtHead = (
+	over: {status?: string; conclusion?: string | null; headSha?: string} = {},
+) => ({
+	stdout: JSON.stringify([
+		{
+			workflow_runs: [
+				{
+					id: RUN_ID,
+					name: "run-evidence",
+					head_sha: over.headSha ?? HEAD,
+					status: over.status ?? "completed",
+					conclusion: over.conclusion ?? "success",
+					created_at: "2026-07-25T04:57:44Z",
+				},
+			],
+		},
+	]),
+});
+
+const artifactListed = {
+	stdout: JSON.stringify([{artifacts: [{id: ARTIFACT_ID, name: "run-evidence", expired: false}]}]),
+};
+
+const readingFor = (replies: Record<string, Reply>) =>
+	provide(
+		Effect.flatMap(RunEvidenceIo, (io) => io.probe(HEAD)),
+		replies,
+	).pipe(Effect.map(classifyBundle));
+
+describe("the gh boundary never uses --silent", () => {
+	// `gh api --silent` discards the response body: the artifact download "succeeds" with 0 bytes and
+	// the missing manifest reads as a missing bundle. Asserted here so it cannot be reintroduced.
+	it("no arg list this boundary builds carries --silent", () => {
+		for (const args of allArgBuilders(PINNED_REPO)) {
+			assert.notInclude(args, "--silent");
+		}
+	});
+
+	it("the runs query pins head_sha — the binding filter (ADR 0056 §2)", () => {
+		const runsQuery = allArgBuilders(PINNED_REPO).find((args) =>
+			args.some((a) => a.includes("actions/runs?")),
+		);
+		assert.isDefined(runsQuery);
+		assert.isTrue(runsQuery?.some((a) => a.includes("head_sha=")));
+	});
+});
+
+describe("probe → classify, end to end over the real decode path", () => {
+	it("PRESENT: a published, head-bound archive resolves present with its numbers", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: runsAtHead(),
+				[ARTIFACTS]: artifactListed,
+				[ZIP]: {stdout: bundleZipFor(HEAD)},
+			});
+			assert.strictEqual(reading.state, "present");
+			assert.strictEqual(reading.evidence.runId, RUN_ID);
+			assert.strictEqual(reading.evidence.artifactId, ARTIFACT_ID);
+			assert.strictEqual(reading.manifest?.tests.total, 2362);
+		}).pipe(Effect.runPromise));
+
+	it("PENDING: a run in flight at the head is pending, not absent", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: runsAtHead({status: "in_progress", conclusion: null}),
+			});
+			assert.strictEqual(reading.state, "pending");
+			assert.strictEqual(reading.reason, "run-not-completed");
+		}).pipe(Effect.runPromise));
+
+	it("PENDING: no producer run at the head yet is pending, not absent (the #3913 instance)", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: {stdout: JSON.stringify([{workflow_runs: []}])},
+			});
+			assert.strictEqual(reading.state, "pending");
+			assert.strictEqual(reading.reason, "no-run-at-head-yet");
+			assert.strictEqual(reading.evidence.runsAtHead, 0);
+		}).pipe(Effect.runPromise));
+
+	it("PENDING: a run bound to an EARLIER push is not evidence for this head", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: runsAtHead({headSha: "c7e6549cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}),
+			});
+			assert.strictEqual(reading.state, "pending");
+			assert.strictEqual(reading.reason, "no-run-at-head-yet");
+		}).pipe(Effect.runPromise));
+
+	it("ABSENT: a completed run that published no artifact", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: runsAtHead(),
+				[ARTIFACTS]: {stdout: JSON.stringify([{artifacts: []}])},
+			});
+			assert.strictEqual(reading.state, "absent");
+			assert.strictEqual(reading.reason, "run-completed-without-artifact");
+		}).pipe(Effect.runPromise));
+
+	it("ABSENT: a repo that defines no producer workflow", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: {stdout: JSON.stringify([{workflows: [{name: "ci"}]}])},
+			});
+			assert.strictEqual(reading.state, "absent");
+			assert.strictEqual(reading.reason, "no-producer-workflow");
+		}).pipe(Effect.runPromise));
+
+	it("UNKNOWN: a 503 on the runs read is unknown, and names the captured cause", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: {stdout: "", exitCode: 1, stderr: "gh: Server Error (HTTP 503)"},
+			});
+			assert.strictEqual(reading.state, "unknown");
+			assert.strictEqual(reading.reason, "runs-unreadable");
+			assert.include(reading.detail, "HTTP 503");
+			assert.strictEqual(reading.evidence.runsAtHead, null);
+		}).pipe(Effect.runPromise));
+
+	it("UNKNOWN: a 503 error body served in place of the archive (the #3693 payload)", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: runsAtHead(),
+				[ARTIFACTS]: artifactListed,
+				[ZIP]: {stdout: JSON.stringify({message: "Server Error"})},
+			});
+			assert.strictEqual(reading.state, "unknown");
+			assert.strictEqual(reading.reason, "archive-unreadable");
+			assert.include(reading.detail, "not a ZIP archive");
+		}).pipe(Effect.runPromise));
+
+	it("UNKNOWN: an EMPTY artifact download — the `--silent` 0-byte failure mode", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: runsAtHead(),
+				[ARTIFACTS]: artifactListed,
+				[ZIP]: {stdout: new Uint8Array(0)},
+			});
+			assert.strictEqual(reading.state, "unknown");
+			assert.strictEqual(reading.reason, "archive-unreadable");
+		}).pipe(Effect.runPromise));
+
+	it("UNKNOWN: a non-conforming runs response (wrong shape) is a failed read, not absence", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: {stdout: JSON.stringify({message: "Not Found"})},
+			});
+			assert.strictEqual(reading.state, "unknown");
+			assert.strictEqual(reading.reason, "runs-unreadable");
+			assert.include(reading.detail, "did not conform");
+		}).pipe(Effect.runPromise));
+
+	it("UNKNOWN: a stale manifest whose commit is not this head", () =>
+		Effect.gen(function* () {
+			const reading = yield* readingFor({
+				[WORKFLOWS]: producerDefined,
+				[RUNS]: runsAtHead(),
+				[ARTIFACTS]: artifactListed,
+				[ZIP]: {stdout: bundleZipFor("c7e6549cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")},
+			});
+			assert.strictEqual(reading.state, "unknown");
+			assert.strictEqual(reading.reason, "manifest-commit-mismatch");
+		}).pipe(Effect.runPromise));
+});
+
+describe("headSha — the live head the bundle must be bound to", () => {
+	it("reads .head.sha off the pulls endpoint", () =>
+		provide(
+			Effect.flatMap(RunEvidenceIo, (io) => io.headSha(3951)),
+			{[path("pulls/3951")]: {stdout: JSON.stringify({head: {sha: HEAD}})}},
+		).pipe(
+			Effect.tap((sha) => Effect.sync(() => assert.strictEqual(sha, HEAD))),
+			Effect.runPromise,
+		));
+});

--- a/packages/pipeline-cli/src/tools/run-evidence/github.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/github.ts
@@ -1,0 +1,481 @@
+/**
+ * The `gh api` REST boundary for `run-evidence read`: resolve a PR's head SHA, find the producer
+ * run at that EXACT head, list its artifacts, download the archive, and read `manifest.json` out of
+ * it — handing the pure classifier one `Observation` (`run-evidence.ts`).
+ *
+ * Same service shape as `leak-guard`'s `PrComments` / `checks`'s `Github` (a `Context.Service` on
+ * `ChildProcessSpawner`, repo resolved once per ADR 0062 §1, REST only — GraphQL is broken on the
+ * kamp-us org, untrusted REST JSON Schema-decoded at the boundary).
+ *
+ * Two boundary rules this tool exists to hold, both of which a hand-rolled `gh` snippet got wrong:
+ *
+ *  - **A read that fails is UNKNOWN, never absence.** Every leg captures its cause and converts to
+ *    an `*Unreadable` observation; nothing here can hand the classifier an empty value that reads as
+ *    "the producer published nothing" (#3991). Transient 5xx/429/transport faults are retried with
+ *    bounded backoff first — the same transient class `leak-guard`'s `isTransientGh` owns.
+ *  - **Never `gh api --silent`.** `--silent` discards the response body, so an artifact download
+ *    "succeeds" with zero bytes and the missing manifest reads as a missing bundle. The arg builders
+ *    below are exported so that invariant is asserted by a test, not by reviewer vigilance.
+ */
+import {Context, Effect, Layer, Schedule, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {Manifest} from "../crabbox-manifest/Manifest.ts";
+import {
+	MANIFEST_ENTRY,
+	type ManifestSummary,
+	type Observation,
+	PRODUCER_NAME,
+	type Probe,
+	type ProducerRun,
+	resolveProducerRun,
+} from "./run-evidence.ts";
+import {readZipEntry} from "./zip.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, 5xx …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/run-evidence/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/run-evidence/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/run-evidence/RepoResolutionError",
+	{message: Schema.String},
+) {}
+
+// The transient class worth retrying: the 5xx gateway/overload family plus 429. Everything else —
+// 401/403/404/422 — is a real terminal answer and fails fast, so an auth/not-found error is never
+// masked as a blip. Kept identical to leak-guard's `isTransientGh` (#3710).
+const TRANSIENT_HTTP_STATUS_RE = /\bHTTP\s+(429|5\d\d)\b/i;
+const TRANSIENT_TRANSPORT_RE =
+	/\b(ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|ENOTFOUND|connection reset|connection refused|timed?\s*out|TLS handshake|i\/o timeout|network is unreachable|temporary failure|EOF occurred)\b/i;
+
+/** Is this `gh` failure a transient transport/availability blip (retry) or a terminal answer? */
+export const isTransientGh = (error: GhCommandError): boolean =>
+	error.exitCode === -1 ||
+	TRANSIENT_HTTP_STATUS_RE.test(error.stderr) ||
+	TRANSIENT_TRANSPORT_RE.test(error.stderr);
+
+const collectText = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const concatBytes = (chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
+	const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+	const out = new Uint8Array(total);
+	let at = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, at);
+		at += chunk.length;
+	}
+	return out;
+};
+
+const collectBytes = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<Uint8Array> =>
+	Stream.runCollect(stream).pipe(
+		Effect.map(concatBytes),
+		Effect.orElseSucceed(() => new Uint8Array(0)),
+	);
+
+/** Spawn `gh`, returning stdout as raw bytes — the artifact archive is binary, so never as text. */
+const runGhBytes = Effect.fn("RunEvidence.runGhBytes")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collectBytes(handle.stdout), collectText(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const runGh = (
+	args: ReadonlyArray<string>,
+): Effect.Effect<string, GhCommandError, ChildProcessSpawner.ChildProcessSpawner> =>
+	runGhBytes(args).pipe(Effect.map((bytes) => new TextDecoder().decode(bytes)));
+
+const json = Effect.fn("RunEvidence.json")(function* (args: ReadonlyArray<string>) {
+	const raw = yield* runGh(args);
+	return yield* Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** Resolve the target repo (`owner/name`) per ADR 0062 §1: env override → CI env → `gh repo view`. */
+const resolveRepo = Effect.fn("RunEvidence.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/run-evidence/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+/** The PR whose live head the bundle must be bound to. */
+export const prArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/pulls/${pr}`,
+];
+
+/** Does this repo define the producer at all? An adopter without it has no bundle to miss (ADR 0086). */
+export const workflowsArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	"--slurp",
+	`repos/${repo}/actions/workflows?per_page=100`,
+];
+
+/** Producer runs keyed on the EXACT head SHA — the binding filter (ADR 0056 §2). */
+export const runsAtHeadArgs = (repo: string, sha: string): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	"--slurp",
+	`repos/${repo}/actions/runs?head_sha=${sha}&per_page=100`,
+];
+
+export const artifactsArgs = (repo: string, runId: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	"--slurp",
+	`repos/${repo}/actions/runs/${runId}/artifacts?per_page=100`,
+];
+
+export const artifactZipArgs = (repo: string, artifactId: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/actions/artifacts/${artifactId}/zip`,
+];
+
+/** Every `gh` arg list this boundary builds — the surface the no-`--silent` invariant is asserted over. */
+export const allArgBuilders = (repo: string): ReadonlyArray<ReadonlyArray<string>> => [
+	prArgs(repo, 1),
+	workflowsArgs(repo),
+	runsAtHeadArgs(repo, "deadbeef"),
+	artifactsArgs(repo, 1),
+	artifactZipArgs(repo, 1),
+];
+
+const RawPr = Schema.Struct({head: Schema.Struct({sha: Schema.String})});
+const decodePr = Schema.decodeUnknownEffect(RawPr);
+
+const RawWorkflowPages = Schema.Array(
+	Schema.Struct({workflows: Schema.Array(Schema.Struct({name: Schema.String}))}),
+);
+const decodeWorkflowPages = Schema.decodeUnknownEffect(RawWorkflowPages);
+
+const RawRunPages = Schema.Array(
+	Schema.Struct({
+		workflow_runs: Schema.Array(
+			Schema.Struct({
+				id: Schema.Number,
+				name: Schema.NullOr(Schema.String),
+				head_sha: Schema.String,
+				status: Schema.NullOr(Schema.String),
+				conclusion: Schema.NullOr(Schema.String),
+				created_at: Schema.String,
+			}),
+		),
+	}),
+);
+const decodeRunPages = Schema.decodeUnknownEffect(RawRunPages);
+
+const RawArtifactPages = Schema.Array(
+	Schema.Struct({
+		artifacts: Schema.Array(
+			Schema.Struct({
+				id: Schema.Number,
+				name: Schema.String,
+				expired: Schema.optionalKey(Schema.Boolean),
+			}),
+		),
+	}),
+);
+const decodeArtifactPages = Schema.decodeUnknownEffect(RawArtifactPages);
+
+const decodeManifest = Schema.decodeUnknownEffect(Manifest);
+
+type LegError = GhCommandError | GhParseError | Schema.SchemaError;
+
+/**
+ * One read leg as a SINGLE effect: fetch, parse, decode. Composed rather than `yield*`-ed
+ * step-by-step on purpose — a `yield*` inside the retry/catch wrapper escapes it, and an escaped
+ * fault is exactly the silent path this tool exists to close.
+ */
+const readDecoded = <A>(
+	args: ReadonlyArray<string>,
+	decode: (input: unknown) => Effect.Effect<A, Schema.SchemaError>,
+): Effect.Effect<A, LegError, ChildProcessSpawner.ChildProcessSpawner> =>
+	json(args).pipe(Effect.flatMap(decode));
+
+const firstLine = (text: string): string => (text.split("\n")[0] ?? "").trim().slice(0, 200);
+
+/** Render a leg failure as the one-line cause an UNKNOWN reading carries into the verdict. */
+const describeLegError = (error: LegError): string => {
+	if (error._tag === "@kampus/run-evidence/GhCommandError") {
+		return `gh exited ${error.exitCode} — ${firstLine(error.stderr) || "no stderr captured"}`;
+	}
+	if (error._tag === "@kampus/run-evidence/GhParseError") {
+		return `response was not JSON — ${firstLine(error.message)}`;
+	}
+	return `response did not conform to the expected shape — ${firstLine(String(error))}`;
+};
+
+type Attempt<A> =
+	| {readonly ok: true; readonly value: A}
+	| {readonly ok: false; readonly cause: string};
+
+// Bounded exponential backoff (~0.5s, 1, 2, 4s over 4 retries) — enough to ride out a GH 5xx blip
+// without holding a review open through a sustained outage. Same idiom/budget as leak-guard's read.
+const MAX_RETRIES = 4;
+const DEFAULT_RETRY_SCHEDULE = Schedule.both(
+	Schedule.exponential("500 millis"),
+	Schedule.recurs(MAX_RETRIES),
+);
+
+const isTransientLeg = (error: LegError): error is GhCommandError =>
+	error._tag === "@kampus/run-evidence/GhCommandError" && isTransientGh(error);
+
+const attempt = <A>(
+	effect: Effect.Effect<A, LegError, ChildProcessSpawner.ChildProcessSpawner>,
+	retrySchedule: Schedule.Schedule<unknown, unknown>,
+): Effect.Effect<Attempt<A>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	effect.pipe(
+		Effect.retry({schedule: retrySchedule, while: isTransientLeg}),
+		Effect.map((value): Attempt<A> => ({ok: true, value})),
+		Effect.catch((error: LegError) =>
+			Effect.succeed<Attempt<A>>({ok: false, cause: describeLegError(error)}),
+		),
+	);
+
+const summarize = (manifest: Manifest): ManifestSummary => ({
+	commit: manifest.commit,
+	schemaVersion: manifest.schemaVersion,
+	checks: manifest.checks.map((check) => ({name: check.name, status: check.status})),
+	tests: {
+		total: manifest.tests.total,
+		passed: manifest.tests.passed,
+		failed: manifest.tests.failed,
+		skipped: manifest.tests.skipped,
+		failingSuites: manifest.tests.failures.map((failure) => `${failure.suite} › ${failure.name}`),
+	},
+});
+
+const headSha = Effect.fn("RunEvidence.headSha")(function* (repo: string, pr: number) {
+	const args = prArgs(repo, pr);
+	return (yield* decodePr(yield* json(args))).head.sha;
+});
+
+/**
+ * Walk the lookup to exactly one `Observation`. Ordered so that an unreadable step never falls
+ * through into a step whose empty result would look like absence.
+ */
+const probe = Effect.fn("RunEvidence.probe")(function* (
+	repo: string,
+	sha: string,
+	retrySchedule: Schedule.Schedule<unknown, unknown>,
+) {
+	const observed = (observation: Observation, runsAtHead: number | null = null): Probe => ({
+		queriedSha: sha,
+		runsAtHead,
+		observation,
+	});
+
+	const workflows = yield* attempt(
+		readDecoded(workflowsArgs(repo), decodeWorkflowPages),
+		retrySchedule,
+	);
+	if (!workflows.ok) {
+		return observed({_tag: "ProducerUnreadable", cause: workflows.cause});
+	}
+	const producerDefined = workflows.value.some((page) =>
+		page.workflows.some((workflow) => workflow.name === PRODUCER_NAME),
+	);
+	if (!producerDefined) {
+		return observed({_tag: "ProducerWorkflowAbsent"});
+	}
+
+	const runs = yield* attempt(
+		readDecoded(runsAtHeadArgs(repo, sha), decodeRunPages),
+		retrySchedule,
+	);
+	if (!runs.ok) {
+		return observed({_tag: "RunsUnreadable", cause: runs.cause});
+	}
+	const producerRuns: ReadonlyArray<ProducerRun> = runs.value
+		.flatMap((page) => page.workflow_runs)
+		.filter((run) => run.name === PRODUCER_NAME)
+		.map((run) => ({
+			id: run.id,
+			headSha: run.head_sha,
+			status: run.status ?? "unknown",
+			conclusion: run.conclusion,
+			createdAt: run.created_at,
+		}));
+	const atHead = producerRuns.filter((run) => run.headSha === sha).length;
+	const run = resolveProducerRun(producerRuns, sha);
+	if (run === null) {
+		return observed({_tag: "NoRunAtHead"}, 0);
+	}
+	if (run.status !== "completed") {
+		return observed({_tag: "RunNotCompleted", run}, atHead);
+	}
+
+	const artifacts = yield* attempt(
+		readDecoded(artifactsArgs(repo, run.id), decodeArtifactPages),
+		retrySchedule,
+	);
+	if (!artifacts.ok) {
+		return observed({_tag: "ArtifactsUnreadable", run, cause: artifacts.cause}, atHead);
+	}
+	const artifact = artifacts.value
+		.flatMap((page) => page.artifacts)
+		.find((candidate) => candidate.name === PRODUCER_NAME);
+	if (artifact === undefined) {
+		return observed({_tag: "ArtifactMissing", run}, atHead);
+	}
+	if (artifact.expired === true) {
+		return observed({_tag: "ArtifactExpired", run, artifactId: artifact.id}, atHead);
+	}
+
+	const download = yield* attempt(runGhBytes(artifactZipArgs(repo, artifact.id)), retrySchedule);
+	if (!download.ok) {
+		return observed(
+			{_tag: "DownloadUnreadable", run, artifactId: artifact.id, cause: download.cause},
+			atHead,
+		);
+	}
+	const entry = readZipEntry(download.value, MANIFEST_ENTRY);
+	if (entry._tag === "Malformed") {
+		return observed(
+			{_tag: "ArchiveUnreadable", run, artifactId: artifact.id, cause: entry.reason},
+			atHead,
+		);
+	}
+	if (entry._tag === "NotFound") {
+		return observed(
+			{
+				_tag: "ArchiveUnreadable",
+				run,
+				artifactId: artifact.id,
+				cause: `no \`${MANIFEST_ENTRY}\` in the archive (entries: ${entry.names.join(", ") || "none"})`,
+			},
+			atHead,
+		);
+	}
+	const decoded = yield* attempt(
+		Effect.try({
+			try: () => JSON.parse(new TextDecoder().decode(entry.bytes)) as unknown,
+			catch: (cause) =>
+				new GhParseError({
+					args: artifactZipArgs(repo, artifact.id),
+					message: cause instanceof Error ? cause.message : String(cause),
+				}),
+		}).pipe(Effect.flatMap(decodeManifest)),
+		retrySchedule,
+	);
+	if (!decoded.ok) {
+		return observed(
+			{_tag: "ManifestUnreadable", run, artifactId: artifact.id, cause: decoded.cause},
+			atHead,
+		);
+	}
+	return observed(
+		{
+			_tag: "ManifestRead",
+			run,
+			artifactId: artifact.id,
+			manifest: summarize(decoded.value),
+		},
+		atHead,
+	);
+});
+
+type GhError = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+
+/**
+ * `RunEvidenceIo` — the IO shell over `gh api` REST. `probe` carries no failure channel beyond repo
+ * resolution: every read fault is folded into an `*Unreadable` observation so the classifier, not
+ * an exception path, decides the state.
+ */
+export class RunEvidenceIo extends Context.Service<
+	RunEvidenceIo,
+	{
+		readonly headSha: (pr: number) => Effect.Effect<string, GhError>;
+		readonly probe: (sha: string) => Effect.Effect<Probe, RepoResolutionError>;
+	}
+>()("@kampus/run-evidence/RunEvidenceIo") {}
+
+/**
+ * The layer, parameterized by its retry schedule so a unit test can inject a zero-delay budget.
+ * Repo resolution is deferred to first use (`Effect.cached`, ADR 0062 §1) — the build is
+ * side-effect-free.
+ */
+export const makeRunEvidenceIoLive = (
+	retrySchedule: Schedule.Schedule<unknown, unknown> = DEFAULT_RETRY_SCHEDULE,
+): Layer.Layer<RunEvidenceIo, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.effect(RunEvidenceIo)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				headSha: (pr) => repo.pipe(Effect.flatMap((r) => withSpawner(headSha(r, pr)))),
+				probe: (sha) => repo.pipe(Effect.flatMap((r) => withSpawner(probe(r, sha, retrySchedule)))),
+			};
+		}),
+	);
+
+/** The production layer — the bounded-backoff retry over the real `gh` boundary. */
+export const RunEvidenceIoLive: Layer.Layer<
+	RunEvidenceIo,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = makeRunEvidenceIoLive();

--- a/packages/pipeline-cli/src/tools/run-evidence/run-evidence.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/run-evidence.ts
@@ -1,0 +1,337 @@
+/**
+ * The pure classifier behind `run-evidence read` — IO-free, total, unit-testable.
+ *
+ * One decision, and the whole point of the tool: given what a lookup actually observed at a PR's
+ * head SHA, is the SHA-bound run-evidence bundle PRESENT, PENDING, ABSENT, or UNKNOWN?
+ *
+ * The four states are not a taxonomy for its own sake — they are four different facts that a
+ * binary present/absent read collapsed into one false claim (#3991). `review-code` reported
+ * "absent for this head SHA" twice for bundles that were present or merely unpublished-yet,
+ * because every non-success path in its inline lookup — a producer that had not run, a run still
+ * in flight, a 5xx during the download, a non-archive error body — left the same empty variable
+ * and was narrated as absence. So:
+ *
+ *   - PENDING is not ABSENT. A producer that exists but has not published for this head yet says
+ *     nothing about the PR; reporting it absent invents a CI gap (the #3913 instance).
+ *   - UNKNOWN is not ABSENT. A read that failed is a failed read, not a missing bundle; collapsing
+ *     the two makes a GitHub hiccup look like a producer that never ran (the #3693 / #3716 class,
+ *     which `ship-it` Step 3.5 already separates and `review-code` did not).
+ *   - ABSENT is claimed only on positive evidence that the producer yielded nothing for this head:
+ *     no producer workflow in the repo, a run that COMPLETED and published no artifact, or an
+ *     expired artifact.
+ *
+ * Every reading also carries the lookup evidence it was decided from (the queried SHA, the run id,
+ * the run's status, the artifact id), so the claim is falsifiable from the verdict comment alone
+ * instead of being free prose.
+ */
+import {SCHEMA_VERSION} from "../crabbox-manifest/Manifest.ts";
+
+/** The GitHub Actions workflow + artifact name the producer publishes under (ADR 0056 fetch contract). */
+export const PRODUCER_NAME = "run-evidence";
+
+/** The manifest entry inside the artifact archive. */
+export const MANIFEST_ENTRY = "manifest.json";
+
+/** The four states a bundle lookup can resolve to. Exhaustive, and pairwise distinct by design. */
+export type BundleState = "present" | "pending" | "absent" | "unknown";
+
+/** Why the lookup resolved to its state — a stable code a consumer may branch on. */
+export type ReasonCode =
+	| "validated"
+	| "no-producer-workflow"
+	| "no-run-at-head-yet"
+	| "run-not-completed"
+	| "run-completed-without-artifact"
+	| "artifact-expired"
+	| "producer-unreadable"
+	| "runs-unreadable"
+	| "artifacts-unreadable"
+	| "download-unreadable"
+	| "archive-unreadable"
+	| "manifest-unreadable"
+	| "unsupported-schema-version"
+	| "manifest-commit-mismatch";
+
+/** A producer workflow run, as the runs endpoint surfaces it (only these fields decide). */
+export interface ProducerRun {
+	readonly id: number;
+	/** The commit the run executed against — the binding key; only an EXACT head match counts. */
+	readonly headSha: string;
+	/** `queued` | `in_progress` | `completed` — anything but `completed` is PENDING, never absent. */
+	readonly status: string;
+	readonly conclusion: string | null;
+	readonly createdAt: string;
+}
+
+/** The manifest fields a verdict cites (ADR 0054 §2), folded once for the report line. */
+export interface ManifestSummary {
+	readonly commit: string;
+	readonly schemaVersion: number;
+	readonly checks: ReadonlyArray<{readonly name: string; readonly status: string}>;
+	readonly tests: {
+		readonly total: number;
+		readonly passed: number;
+		readonly failed: number;
+		readonly skipped: number;
+		readonly failingSuites: ReadonlyArray<string>;
+	};
+}
+
+/**
+ * What the lookup terminated on. The shell's only job is to produce exactly one of these; every
+ * classification decision — including validating the manifest before interpreting it — is made here.
+ */
+export type Observation =
+	| {readonly _tag: "ProducerUnreadable"; readonly cause: string}
+	| {readonly _tag: "ProducerWorkflowAbsent"}
+	| {readonly _tag: "RunsUnreadable"; readonly cause: string}
+	| {readonly _tag: "NoRunAtHead"}
+	| {readonly _tag: "RunNotCompleted"; readonly run: ProducerRun}
+	| {readonly _tag: "ArtifactsUnreadable"; readonly run: ProducerRun; readonly cause: string}
+	| {readonly _tag: "ArtifactMissing"; readonly run: ProducerRun}
+	| {readonly _tag: "ArtifactExpired"; readonly run: ProducerRun; readonly artifactId: number}
+	| {
+			readonly _tag: "DownloadUnreadable";
+			readonly run: ProducerRun;
+			readonly artifactId: number;
+			readonly cause: string;
+	  }
+	| {
+			readonly _tag: "ArchiveUnreadable";
+			readonly run: ProducerRun;
+			readonly artifactId: number;
+			readonly cause: string;
+	  }
+	| {
+			readonly _tag: "ManifestUnreadable";
+			readonly run: ProducerRun;
+			readonly artifactId: number;
+			readonly cause: string;
+	  }
+	| {
+			readonly _tag: "ManifestRead";
+			readonly run: ProducerRun;
+			readonly artifactId: number;
+			readonly manifest: ManifestSummary;
+	  };
+
+export interface Probe {
+	/** The PR's live head SHA the lookup keyed on — the whole binding (ADR 0054 §1). */
+	readonly queriedSha: string;
+	/** Producer runs found at that exact head; `null` when the runs list itself was unreadable. */
+	readonly runsAtHead: number | null;
+	readonly observation: Observation;
+}
+
+/** The checkable lookup evidence a verdict line carries, so a reader can re-derive the claim. */
+export interface LookupEvidence {
+	readonly queriedSha: string;
+	readonly runsAtHead: number | null;
+	readonly runId: number | null;
+	readonly runStatus: string | null;
+	readonly runConclusion: string | null;
+	readonly artifactId: number | null;
+}
+
+export interface BundleReading {
+	readonly state: BundleState;
+	readonly reason: ReasonCode;
+	/** The human cause — a captured `gh` stderr line, a magic mismatch, a decode message. */
+	readonly detail: string;
+	readonly evidence: LookupEvidence;
+	/** The validated manifest. Non-null iff `state === "present"`. */
+	readonly manifest: ManifestSummary | null;
+}
+
+/**
+ * The newest producer run whose `head_sha` EXACTLY equals the queried head. The exact-match filter
+ * is load-bearing: a run from an earlier push is not evidence for this commit (ADR 0056 §2).
+ */
+export const resolveProducerRun = (
+	runs: ReadonlyArray<ProducerRun>,
+	headSha: string,
+): ProducerRun | null => {
+	const atHead = runs.filter((run) => run.headSha === headSha);
+	return atHead.reduce<ProducerRun | null>((newest, run) => {
+		if (newest === null) return run;
+		if (run.createdAt !== newest.createdAt) return run.createdAt > newest.createdAt ? run : newest;
+		return run.id > newest.id ? run : newest;
+	}, null);
+};
+
+const runEvidence = (probe: Probe, run: ProducerRun | null, artifactId: number | null) => ({
+	queriedSha: probe.queriedSha,
+	runsAtHead: probe.runsAtHead,
+	runId: run?.id ?? null,
+	runStatus: run?.status ?? null,
+	runConclusion: run?.conclusion ?? null,
+	artifactId,
+});
+
+/** Classify one lookup. Total over `Observation`; the manifest is validated before it is trusted. */
+export const classifyBundle = (probe: Probe): BundleReading => {
+	const observation = probe.observation;
+	const reading = (
+		state: BundleState,
+		reason: ReasonCode,
+		detail: string,
+		run: ProducerRun | null,
+		artifactId: number | null,
+		manifest: ManifestSummary | null = null,
+	): BundleReading => ({
+		state,
+		reason,
+		detail,
+		evidence: runEvidence(probe, run, artifactId),
+		manifest,
+	});
+
+	switch (observation._tag) {
+		case "ProducerUnreadable":
+			return reading("unknown", "producer-unreadable", observation.cause, null, null);
+		case "ProducerWorkflowAbsent":
+			return reading(
+				"absent",
+				"no-producer-workflow",
+				`this repo defines no \`${PRODUCER_NAME}\` workflow, so no bundle is produced for any head`,
+				null,
+				null,
+			);
+		case "RunsUnreadable":
+			return reading("unknown", "runs-unreadable", observation.cause, null, null);
+		case "NoRunAtHead":
+			return reading(
+				"pending",
+				"no-run-at-head-yet",
+				`the \`${PRODUCER_NAME}\` producer exists but has no run at this head yet`,
+				null,
+				null,
+			);
+		case "RunNotCompleted":
+			return reading(
+				"pending",
+				"run-not-completed",
+				`producer run is \`${observation.run.status}\`, not \`completed\``,
+				observation.run,
+				null,
+			);
+		case "ArtifactsUnreadable":
+			return reading("unknown", "artifacts-unreadable", observation.cause, observation.run, null);
+		case "ArtifactMissing":
+			return reading(
+				"absent",
+				"run-completed-without-artifact",
+				`producer run completed (${observation.run.conclusion ?? "no conclusion"}) and published no \`${PRODUCER_NAME}\` artifact`,
+				observation.run,
+				null,
+			);
+		case "ArtifactExpired":
+			return reading(
+				"absent",
+				"artifact-expired",
+				"the published artifact has expired (GitHub artifact retention)",
+				observation.run,
+				observation.artifactId,
+			);
+		case "DownloadUnreadable":
+			return reading(
+				"unknown",
+				"download-unreadable",
+				observation.cause,
+				observation.run,
+				observation.artifactId,
+			);
+		case "ArchiveUnreadable":
+			return reading(
+				"unknown",
+				"archive-unreadable",
+				observation.cause,
+				observation.run,
+				observation.artifactId,
+			);
+		case "ManifestUnreadable":
+			return reading(
+				"unknown",
+				"manifest-unreadable",
+				observation.cause,
+				observation.run,
+				observation.artifactId,
+			);
+		case "ManifestRead": {
+			const {run, artifactId, manifest} = observation;
+			if (manifest.schemaVersion !== SCHEMA_VERSION) {
+				return reading(
+					"unknown",
+					"unsupported-schema-version",
+					`bundle schemaVersion ${manifest.schemaVersion}, this reader understands ${SCHEMA_VERSION}`,
+					run,
+					artifactId,
+				);
+			}
+			// A run resolved by exact head_sha whose manifest attests a DIFFERENT commit is a
+			// producer/consumer binding break, not an absent bundle: something published evidence for
+			// another tree. Unreadable-as-evidence ⇒ UNKNOWN, never a claim about this head.
+			if (manifest.commit !== probe.queriedSha) {
+				return reading(
+					"unknown",
+					"manifest-commit-mismatch",
+					`manifest.commit ${manifest.commit} != queried head ${probe.queriedSha}`,
+					run,
+					artifactId,
+				);
+			}
+			return reading(
+				"present",
+				"validated",
+				`manifest.commit == head, schemaVersion ${manifest.schemaVersion}`,
+				run,
+				artifactId,
+				manifest,
+			);
+		}
+	}
+};
+
+const short = (sha: string): string => (sha.length > 8 ? sha.slice(0, 8) : sha);
+
+const checksSummary = (manifest: ManifestSummary): string => {
+	const passed = manifest.checks.filter((check) => check.status === "pass").length;
+	const failing = manifest.checks
+		.filter((check) => check.status !== "pass")
+		.map((check) => check.name);
+	const total = manifest.checks.length;
+	return failing.length === 0
+		? `checks ${passed}/${total} pass`
+		: `checks ${passed}/${total} pass (failing: ${failing.join(", ")})`;
+};
+
+const testsSummary = (manifest: ManifestSummary): string => {
+	const {total, passed, failed, skipped, failingSuites} = manifest.tests;
+	const counts = `tests ${passed}/${total} passed, ${failed} failed, ${skipped} skipped`;
+	return failingSuites.length === 0 ? counts : `${counts} (${failingSuites.join("; ")})`;
+};
+
+/**
+ * The `Run-evidence bundle:` line a verdict carries. Every state names itself and the evidence it
+ * was decided from, and the two non-ABSENT non-passing states say so in the line — the reader of a
+ * verdict comment must be able to tell a not-yet-published bundle and a failed read apart from a
+ * missing one without re-running the lookup.
+ */
+export const renderReportLine = (reading: BundleReading): string => {
+	const {evidence, manifest} = reading;
+	const head = short(evidence.queriedSha);
+	const run = evidence.runId === null ? "no producer run" : `producer run ${evidence.runId}`;
+	const queried = `queried head_sha=${head}, ${evidence.runsAtHead ?? "unreadable"} \`${PRODUCER_NAME}\` run(s) at head`;
+	switch (reading.state) {
+		case "present":
+			return manifest === null
+				? `Run-evidence bundle: PRESENT for head \`${head}\` — ${run} (${queried}).`
+				: `Run-evidence bundle: PRESENT for head \`${head}\` — ${run}, artifact ${evidence.artifactId}, ${reading.detail}; ${checksSummary(manifest)}; ${testsSummary(manifest)}.`;
+		case "pending":
+			return `Run-evidence bundle: PENDING for head \`${head}\` — ${reading.detail} (${queried}${evidence.runId === null ? "" : `, ${run}`}). PENDING is not ABSENT: the producer has not published for this head yet.`;
+		case "absent":
+			return `Run-evidence bundle: ABSENT for head \`${head}\` — ${reading.detail} (${queried}${evidence.runId === null ? "" : `, ${run}`}).`;
+		case "unknown":
+			return `Run-evidence bundle: UNKNOWN for head \`${head}\` — the lookup could not be read (${reading.reason}: ${reading.detail}) (${queried}). UNKNOWN is not ABSENT: this is a failed read, not a missing bundle.`;
+	}
+};

--- a/packages/pipeline-cli/src/tools/run-evidence/run-evidence.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/run-evidence.unit.test.ts
@@ -1,0 +1,227 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	classifyBundle,
+	type ManifestSummary,
+	type Observation,
+	type Probe,
+	type ProducerRun,
+	renderReportLine,
+	resolveProducerRun,
+} from "./run-evidence.ts";
+
+const HEAD = "05de8f09aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER = "c7e6549cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const run = (over: Partial<ProducerRun> = {}): ProducerRun => ({
+	id: 30144746535,
+	headSha: HEAD,
+	status: "completed",
+	conclusion: "success",
+	createdAt: "2026-07-25T04:57:44Z",
+	...over,
+});
+
+const manifest = (over: Partial<ManifestSummary> = {}): ManifestSummary => ({
+	commit: HEAD,
+	schemaVersion: 1,
+	checks: [
+		{name: "unit", status: "pass"},
+		{name: "bundle-node-core-free", status: "pass"},
+	],
+	tests: {total: 2362, passed: 2362, failed: 0, skipped: 0, failingSuites: []},
+	...over,
+});
+
+const probe = (observation: Observation, runsAtHead: number | null = 1): Probe => ({
+	queriedSha: HEAD,
+	runsAtHead,
+	observation,
+});
+
+describe("resolveProducerRun — only an EXACT head match is evidence for this commit", () => {
+	it("ignores a run from an earlier push", () => {
+		const resolved = resolveProducerRun([run({id: 1, headSha: OTHER})], HEAD);
+		assert.strictEqual(resolved, null);
+	});
+
+	it("takes the newest run at the head, breaking a created_at tie on the run id", () => {
+		const resolved = resolveProducerRun(
+			[
+				run({id: 1, createdAt: "2026-07-25T03:00:00Z"}),
+				run({id: 3, createdAt: "2026-07-25T05:00:00Z"}),
+				run({id: 9, createdAt: "2026-07-25T05:00:00Z"}),
+				run({id: 7, headSha: OTHER, createdAt: "2026-07-25T06:00:00Z"}),
+			],
+			HEAD,
+		);
+		assert.strictEqual(resolved?.id, 9);
+	});
+});
+
+// The regression the tool exists for: three non-success paths that a binary lookup narrated
+// identically as "absent for this head SHA" (#3991, PRs #3913 and #3951).
+describe("classifyBundle — PRESENT", () => {
+	it("a validated, head-bound manifest is present, and carries the run + artifact ids", () => {
+		const reading = classifyBundle(
+			probe({_tag: "ManifestRead", run: run(), artifactId: 8615655601, manifest: manifest()}),
+		);
+		assert.strictEqual(reading.state, "present");
+		assert.strictEqual(reading.reason, "validated");
+		assert.strictEqual(reading.evidence.runId, 30144746535);
+		assert.strictEqual(reading.evidence.artifactId, 8615655601);
+		assert.strictEqual(reading.manifest?.tests.passed, 2362);
+	});
+
+	it("the report line cites the run, the artifact, the checks and the test counts", () => {
+		const line = renderReportLine(
+			classifyBundle(
+				probe({_tag: "ManifestRead", run: run(), artifactId: 8615655601, manifest: manifest()}),
+			),
+		);
+		assert.include(line, "PRESENT");
+		assert.include(line, "producer run 30144746535");
+		assert.include(line, "artifact 8615655601");
+		assert.include(line, "checks 2/2 pass");
+		assert.include(line, "tests 2362/2362 passed");
+	});
+});
+
+describe("classifyBundle — PENDING is never reported as ABSENT", () => {
+	// The #3913 instance: the verdict posted 11 minutes BEFORE the producer's only run at that head
+	// was created. Zero runs at a head a producer serves is "not published yet", not "missing".
+	it("a producer that has not run at this head yet is pending", () => {
+		const reading = classifyBundle(probe({_tag: "NoRunAtHead"}, 0));
+		assert.strictEqual(reading.state, "pending");
+		assert.strictEqual(reading.reason, "no-run-at-head-yet");
+	});
+
+	it("a run at the head that has not completed is pending", () => {
+		const reading = classifyBundle(
+			probe({_tag: "RunNotCompleted", run: run({status: "in_progress", conclusion: null})}),
+		);
+		assert.strictEqual(reading.state, "pending");
+		assert.strictEqual(reading.reason, "run-not-completed");
+		assert.strictEqual(reading.evidence.runStatus, "in_progress");
+	});
+
+	it("the report line says PENDING and states outright that it is not ABSENT", () => {
+		const line = renderReportLine(classifyBundle(probe({_tag: "NoRunAtHead"}, 0)));
+		assert.include(line, "PENDING");
+		assert.include(line, "PENDING is not ABSENT");
+		assert.notInclude(line, "ABSENT for");
+	});
+});
+
+describe("classifyBundle — ABSENT is claimed only on positive evidence", () => {
+	it("a repo with no producer workflow has no bundle to miss", () => {
+		const reading = classifyBundle(probe({_tag: "ProducerWorkflowAbsent"}, null));
+		assert.strictEqual(reading.state, "absent");
+		assert.strictEqual(reading.reason, "no-producer-workflow");
+	});
+
+	it("a COMPLETED run that published no artifact is genuinely absent", () => {
+		const reading = classifyBundle(probe({_tag: "ArtifactMissing", run: run()}));
+		assert.strictEqual(reading.state, "absent");
+		assert.strictEqual(reading.reason, "run-completed-without-artifact");
+		assert.include(renderReportLine(reading), "ABSENT");
+	});
+
+	it("an expired artifact is absent, and names the artifact it lost", () => {
+		const reading = classifyBundle(
+			probe({_tag: "ArtifactExpired", run: run(), artifactId: 8615655601}),
+		);
+		assert.strictEqual(reading.state, "absent");
+		assert.strictEqual(reading.reason, "artifact-expired");
+		assert.strictEqual(reading.evidence.artifactId, 8615655601);
+	});
+});
+
+describe("classifyBundle — UNKNOWN is a failed read, distinctly reported", () => {
+	const unreadable: ReadonlyArray<readonly [string, Observation]> = [
+		["producer-unreadable", {_tag: "ProducerUnreadable", cause: "gh exited 1 — HTTP 503"}],
+		["runs-unreadable", {_tag: "RunsUnreadable", cause: "gh exited 1 — HTTP 502"}],
+		[
+			"artifacts-unreadable",
+			{_tag: "ArtifactsUnreadable", run: run(), cause: "gh exited 1 — HTTP 503"},
+		],
+		[
+			"download-unreadable",
+			{_tag: "DownloadUnreadable", run: run(), artifactId: 1, cause: "gh exited 1 — HTTP 503"},
+		],
+		[
+			"archive-unreadable",
+			{
+				_tag: "ArchiveUnreadable",
+				run: run(),
+				artifactId: 1,
+				cause: "not a ZIP archive — 169-byte payload",
+			},
+		],
+		[
+			"manifest-unreadable",
+			{_tag: "ManifestUnreadable", run: run(), artifactId: 1, cause: "response was not JSON"},
+		],
+	];
+
+	for (const [reason, observation] of unreadable) {
+		it(`${reason} resolves unknown, not absent`, () => {
+			const reading = classifyBundle(probe(observation));
+			assert.strictEqual(reading.state, "unknown");
+			assert.strictEqual(reading.reason, reason);
+			const line = renderReportLine(reading);
+			assert.include(line, "UNKNOWN");
+			assert.include(line, "UNKNOWN is not ABSENT");
+			assert.include(line, reason);
+		});
+	}
+
+	it("a runs list that could not be read reports its count as unreadable, not as zero", () => {
+		const reading = classifyBundle(
+			probe({_tag: "RunsUnreadable", cause: "gh exited 1 — HTTP 502"}, null),
+		);
+		assert.strictEqual(reading.evidence.runsAtHead, null);
+		assert.include(renderReportLine(reading), "unreadable `run-evidence` run(s) at head");
+	});
+
+	it("a stale manifest (commit != head) is unknown — validated before it is interpreted", () => {
+		const reading = classifyBundle(
+			probe({
+				_tag: "ManifestRead",
+				run: run(),
+				artifactId: 1,
+				manifest: manifest({commit: OTHER}),
+			}),
+		);
+		assert.strictEqual(reading.state, "unknown");
+		assert.strictEqual(reading.reason, "manifest-commit-mismatch");
+		assert.isNull(reading.manifest);
+	});
+
+	it("an unsupported schemaVersion is unknown, never read as evidence", () => {
+		const reading = classifyBundle(
+			probe({
+				_tag: "ManifestRead",
+				run: run(),
+				artifactId: 1,
+				manifest: manifest({schemaVersion: 99}),
+			}),
+		);
+		assert.strictEqual(reading.state, "unknown");
+		assert.strictEqual(reading.reason, "unsupported-schema-version");
+	});
+});
+
+describe("every reading carries checkable lookup evidence", () => {
+	it("the queried head is always in the line, so the claim is falsifiable from the comment", () => {
+		const observations: ReadonlyArray<Observation> = [
+			{_tag: "ManifestRead", run: run(), artifactId: 1, manifest: manifest()},
+			{_tag: "NoRunAtHead"},
+			{_tag: "ArtifactMissing", run: run()},
+			{_tag: "RunsUnreadable", cause: "HTTP 503"},
+		];
+		for (const observation of observations) {
+			const line = renderReportLine(classifyBundle(probe(observation)));
+			assert.include(line, "05de8f09");
+		}
+	});
+});

--- a/packages/pipeline-cli/src/tools/run-evidence/zip.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/zip.ts
@@ -1,0 +1,141 @@
+/**
+ * A minimal in-memory ZIP reader — enough to pull one named entry out of a downloaded GitHub
+ * Actions artifact without shelling out to `unzip` and without landing a scratch file.
+ *
+ * Why the bytes never leave memory (#3991): the run-evidence lookup has to decide PRESENT vs
+ * UNKNOWN *from the bytes it received*. Routing them through a temp file + `unzip` puts the
+ * decisive validation behind a subprocess, where a 503 error body written where an archive was
+ * expected reads back as "no manifest" — indistinguishable from a bundle that was never
+ * published. Keeping `hasZipMagic` and the directory walk pure makes "this is not an archive"
+ * positive, unit-testable evidence for UNKNOWN instead of an absence inferred from a missing file.
+ *
+ * Reads the CENTRAL directory rather than the local headers on purpose: a streamed ZIP writes
+ * zeroed sizes into the local header and defers them to a trailing data descriptor, so the local
+ * header alone cannot bound an entry's compressed bytes.
+ */
+import {inflateRawSync} from "node:zlib";
+
+/** The ZIP local-file-header magic, hex — what proves a download is an archive and not an error body. */
+export const ZIP_MAGIC = "504b0304";
+
+const LOCAL_HEADER_SIG = 0x04034b50;
+const CENTRAL_HEADER_SIG = 0x02014b50;
+const EOCD_SIG = 0x06054b50;
+const EOCD_FIXED_SIZE = 22;
+const CENTRAL_HEADER_FIXED_SIZE = 46;
+const LOCAL_HEADER_FIXED_SIZE = 30;
+const MAX_COMMENT_SIZE = 0xffff;
+const METHOD_STORED = 0;
+const METHOD_DEFLATED = 8;
+
+const decoder = new TextDecoder();
+
+/** The first four bytes as lowercase hex — the observed magic, for a legible UNKNOWN reason. */
+export const magicOf = (bytes: Uint8Array): string =>
+	[...bytes.subarray(0, 4)].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+/** Does this payload open with the ZIP local-file-header magic (`PK\x03\x04`)? */
+export const hasZipMagic = (bytes: Uint8Array): boolean =>
+	bytes.length >= 4 &&
+	bytes[0] === 0x50 &&
+	bytes[1] === 0x4b &&
+	bytes[2] === 0x03 &&
+	bytes[3] === 0x04;
+
+/**
+ * Reading one entry has three outcomes, and they are not interchangeable: `Found` is the entry,
+ * `NotFound` is a real archive that simply lacks it, `Malformed` is "these bytes are not a
+ * readable archive" — the UNKNOWN seam.
+ */
+export type ZipEntryRead =
+	| {readonly _tag: "Found"; readonly bytes: Uint8Array}
+	| {readonly _tag: "NotFound"; readonly names: ReadonlyArray<string>}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+const findEocd = (view: DataView): number => {
+	const last = view.byteLength - EOCD_FIXED_SIZE;
+	const first = Math.max(0, last - MAX_COMMENT_SIZE);
+	for (let at = last; at >= first; at--) {
+		if (view.getUint32(at, true) === EOCD_SIG) return at;
+	}
+	return -1;
+};
+
+const readEntryData = (
+	bytes: Uint8Array,
+	view: DataView,
+	localOffset: number,
+	method: number,
+	compressedSize: number,
+): ZipEntryRead => {
+	if (
+		localOffset + LOCAL_HEADER_FIXED_SIZE > view.byteLength ||
+		view.getUint32(localOffset, true) !== LOCAL_HEADER_SIG
+	) {
+		return {
+			_tag: "Malformed",
+			reason: "no local file header at the offset the central directory names",
+		};
+	}
+	const nameLength = view.getUint16(localOffset + 26, true);
+	const extraLength = view.getUint16(localOffset + 28, true);
+	const start = localOffset + LOCAL_HEADER_FIXED_SIZE + nameLength + extraLength;
+	const end = start + compressedSize;
+	if (end > bytes.length) {
+		return {_tag: "Malformed", reason: "entry data runs past the end of the archive (truncated)"};
+	}
+	const raw = bytes.subarray(start, end);
+	if (method === METHOD_STORED) return {_tag: "Found", bytes: raw};
+	if (method !== METHOD_DEFLATED) {
+		return {_tag: "Malformed", reason: `unsupported compression method ${method}`};
+	}
+	try {
+		return {_tag: "Found", bytes: new Uint8Array(inflateRawSync(raw))};
+	} catch (cause) {
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		return {_tag: "Malformed", reason: `inflate failed: ${detail}`};
+	}
+};
+
+/** Extract one entry by exact name from an in-memory ZIP archive. */
+export const readZipEntry = (bytes: Uint8Array, name: string): ZipEntryRead => {
+	if (!hasZipMagic(bytes)) {
+		return {
+			_tag: "Malformed",
+			reason: `not a ZIP archive — ${bytes.length}-byte payload opening with magic ${magicOf(bytes) || "(empty)"}, expected ${ZIP_MAGIC}`,
+		};
+	}
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const eocd = findEocd(view);
+	if (eocd < 0) {
+		return {_tag: "Malformed", reason: "no end-of-central-directory record (truncated archive)"};
+	}
+	const entryCount = view.getUint16(eocd + 10, true);
+	let cursor = view.getUint32(eocd + 16, true);
+	const names: Array<string> = [];
+	for (let index = 0; index < entryCount; index++) {
+		if (
+			cursor + CENTRAL_HEADER_FIXED_SIZE > view.byteLength ||
+			view.getUint32(cursor, true) !== CENTRAL_HEADER_SIG
+		) {
+			return {
+				_tag: "Malformed",
+				reason: `central directory entry ${index} is not where the record says it is`,
+			};
+		}
+		const method = view.getUint16(cursor + 10, true);
+		const compressedSize = view.getUint32(cursor + 20, true);
+		const nameLength = view.getUint16(cursor + 28, true);
+		const extraLength = view.getUint16(cursor + 30, true);
+		const commentLength = view.getUint16(cursor + 32, true);
+		const localOffset = view.getUint32(cursor + 42, true);
+		const nameStart = cursor + CENTRAL_HEADER_FIXED_SIZE;
+		const entryName = decoder.decode(bytes.subarray(nameStart, nameStart + nameLength));
+		names.push(entryName);
+		if (entryName === name) {
+			return readEntryData(bytes, view, localOffset, method, compressedSize);
+		}
+		cursor = nameStart + nameLength + extraLength + commentLength;
+	}
+	return {_tag: "NotFound", names};
+};

--- a/packages/pipeline-cli/src/tools/run-evidence/zip.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/run-evidence/zip.unit.test.ts
@@ -1,0 +1,67 @@
+import {assert, describe, it} from "@effect/vitest";
+import {bundleZipFor, makeZip} from "./fixtures.ts";
+import {hasZipMagic, magicOf, readZipEntry, ZIP_MAGIC} from "./zip.ts";
+
+const decoder = new TextDecoder();
+
+// The #3693 payload class: a GitHub outage answers the artifact download with a JSON error body.
+// Written where an archive was expected, it has to be positively recognizable as "not an archive".
+const ERROR_BODY = new TextEncoder().encode(
+	JSON.stringify({message: "Server Error", documentation_url: "https://docs.github.com"}),
+);
+
+describe("hasZipMagic — an archive is proven by its magic bytes, never assumed", () => {
+	it("a real archive opens with PK\\x03\\x04", () => {
+		const zip = bundleZipFor("deadbeef");
+		assert.isTrue(hasZipMagic(zip));
+		assert.strictEqual(magicOf(zip), ZIP_MAGIC);
+	});
+
+	it("a JSON error body does not", () => {
+		assert.isFalse(hasZipMagic(ERROR_BODY));
+	});
+
+	it("an empty payload does not — the `gh api --silent` 0-byte class", () => {
+		assert.isFalse(hasZipMagic(new Uint8Array(0)));
+	});
+});
+
+describe("readZipEntry — three outcomes, and a non-archive is Malformed not NotFound", () => {
+	it("reads a deflated entry out of a real archive", () => {
+		const read = readZipEntry(bundleZipFor("c0ffee"), "manifest.json");
+		assert.strictEqual(read._tag, "Found");
+		if (read._tag !== "Found") return;
+		assert.strictEqual(JSON.parse(decoder.decode(read.bytes)).commit, "c0ffee");
+	});
+
+	it("reads a stored entry too", () => {
+		const read = readZipEntry(makeZip([{name: "a.txt", content: "hello"}]), "a.txt");
+		assert.strictEqual(read._tag, "Found");
+		if (read._tag !== "Found") return;
+		assert.strictEqual(decoder.decode(read.bytes), "hello");
+	});
+
+	it("a well-formed archive missing the entry is NotFound, and names what it does carry", () => {
+		const read = readZipEntry(
+			makeZip([{name: "junit.xml", content: "<testsuites/>"}]),
+			"manifest.json",
+		);
+		assert.strictEqual(read._tag, "NotFound");
+		if (read._tag !== "NotFound") return;
+		assert.deepStrictEqual(read.names, ["junit.xml"]);
+	});
+
+	it("a JSON error body is Malformed — the failed-read signal, not a missing entry", () => {
+		const read = readZipEntry(ERROR_BODY, "manifest.json");
+		assert.strictEqual(read._tag, "Malformed");
+		if (read._tag !== "Malformed") return;
+		assert.match(read.reason, /not a ZIP archive/);
+		assert.include(read.reason, ZIP_MAGIC);
+	});
+
+	it("a truncated archive is Malformed", () => {
+		const zip = bundleZipFor("deadbeef");
+		const read = readZipEntry(zip.subarray(0, zip.length - 8), "manifest.json");
+		assert.strictEqual(read._tag, "Malformed");
+	});
+});


### PR DESCRIPTION
When a reviewer finishes a PR it writes one line saying whether CI's run-evidence bundle — the
SHA-bound proof of what actually ran — was there for the commit it reviewed. That line has been
saying "absent" for bundles that were sitting right there, and a human approving a control-plane PR
reads it. This PR replaces the reviewer's hand-written lookup with a tested one that tells four
different answers apart instead of one, and says which of them it saw.

Fixes #3991

## The diagnosis

The reporter guessed a race. Triage found two instances with **different** mechanisms, and this PR
covers both — because the real cause is neither race nor slip, it is **structural**.

`review-code` Step 2's inline `gh api` chain had one output variable, `$MANIFEST`, and left it
**empty on every non-success path**: a producer that had not run at the head, a run still in flight,
a listed artifact whose download failed, a 503 error body written where an archive was expected, a
missing `manifest.json`, a commit mismatch. The skill's degrade text then narrated the single empty
value one way — "a missing bundle" — so four distinct facts arrived at the reader as one false one.

- **PR #3913** (verdict `5076753780`, head `c7e6549c`): the head had **zero** producer runs when the
  verdict posted; the only run (`30143091127`) was created 11 minutes later. True at emit, but
  reported as "absent" rather than not-yet-published — the pending-vs-absent conflation.
- **PR #3951** (verdict `5077086679`, head `05de8f09`): run `30144746535` had **already completed
  `success` 17 minutes before the verdict**, with the artifact, 2/2 checks and 2362/2362 tests. On
  the question the issue asks — silently-failed lookup or never-run lookup — the available artifacts
  do **not** decide it: the verdict's stated rationale ("code-class suites skipped by
  change-detection") describes a mechanism `.github/workflows/run-evidence.yml` does not have (it
  runs on every `pull_request`, no `paths` filter, no skip condition), so it was not read off any
  lookup output. Per the issue's own instruction the fix hardens **both** branches: a failed lookup
  can no longer degrade to prose, and the verdict line is now generated from the lookup rather than
  written by hand.

Live reproduction of both, through the new verb at those exact head SHAs:

```
Run-evidence bundle: PRESENT for head `c7e6549c` — producer run 30143091127, artifact 8615161621,
manifest.commit == head, schemaVersion 1; checks 2/2 pass; tests 2362/2362 passed, 0 failed, 0 skipped.

Run-evidence bundle: PRESENT for head `05de8f09` — producer run 30144746535, artifact 8615655601,
manifest.commit == head, schemaVersion 1; checks 2/2 pass; tests 2362/2362 passed, 0 failed, 0 skipped.
```

## What changed

**New verb — `pipeline-cli run-evidence read --pr N | --sha S [--expect <state>]`**
(`packages/pipeline-cli/src/tools/run-evidence/`). A pure classifier plus a thin `gh api` REST shell,
the same shape as `checks read` / `verdict read`.

Four states, pairwise distinct:

| state | meaning |
| --- | --- |
| `present` | a validated, head-bound manifest |
| `pending` | the producer exists but has published nothing for this head **yet** (no run at head, or a run not `completed`) |
| `absent` | positive evidence the producer yielded nothing: no producer workflow in the repo, a **completed** run with no artifact, or an expired artifact |
| `unknown` | the lookup could not be read: a 5xx/429/transport fault surviving bounded retries, a non-archive payload, a non-conforming response shape, a `gh` non-zero exit, an unsupported `schemaVersion`, or a manifest whose `commit` is not this head |

- **Validate before interpreting.** The download is checked for the ZIP local-header magic
  (`504b0304`) before anything is parsed, then `schemaVersion` and `manifest.commit == head` are
  asserted. A stale or mis-stamped manifest is `unknown`, never cited as evidence.
- **Never `gh api --silent`.** `--silent` discards the response body, so an artifact download
  "succeeds" with 0 bytes and the missing manifest reads as a missing bundle. The arg builders are
  exported and a test asserts none of them carries it, so it cannot be reintroduced quietly.
- **The bytes never leave memory.** `zip.ts` reads the entry out of the central directory, so "this
  is not an archive" is *positive* evidence for `unknown` instead of an absence inferred from a
  missing temp file — and there is no scratch file to collide across concurrent lanes.
- **Checkable lookup evidence.** Every reading carries the queried SHA, the producer run id (or an
  explicit zero-runs count), the run status/conclusion and the artifact id, plus a ready-to-paste
  `reportLine`. The claim is falsifiable from the verdict comment alone.

**`review-code` Step 2 now cites the verb** instead of carrying the inline chain, and its degrade
section enumerates the four states with the standing rule that `pending` and `unknown` are never
reported as `absent`. All three verdict-body templates (PASS, no-link PASS, FAIL) emit the
generated line rather than a hand-written one, closing the free-prose path that produced the
confabulated rationale (ADR 0152).

## Acceptance criteria

- [x] The #3951-class mechanism diagnosed with evidence — and shown **undecidable** from available
      artifacts between silently-failed and never-run, with the fix hardening against both.
- [x] `pending` is distinguished from `absent`; a producer run that exists but has not
      completed/published is never reported absent.
- [x] The run-evidence line carries checkable lookup evidence (run id, or the queried SHA with an
      explicit zero-runs result).
- [x] Out-of-scope residue filed via `report`, not fixed inline (see below).

## Out of scope, filed not fixed

`ship-it` Step 3.5 keeps its own hand-rolled copy of this fetch — it is already the hardened
version (#3716) and is the one that read both bundles correctly, so it is not the defect here. Its
own note anticipates the extraction ("extract a helper later if a third consumer appears"), which
this verb now is. Consolidating it onto the verb touches merge-gate behavior, so it is filed as
follow-up residue rather than folded in.

## Verification

- `pnpm vitest run` in `packages/pipeline-cli` — 149 files / 2100 tests pass, including 42 new:
  all four states covered end-to-end through the real decode path (present, pending × 3, absent × 2,
  unknown × 7), the ZIP reader's Found/NotFound/Malformed split, and the no-`--silent` assertion.
- `pnpm typecheck` — clean.
- `pnpm lint:worktree` — clean.
- `pipeline-cli commands check` — 65 tools, all documented.
- `adoption-lint check` over the plugin corpus — clean.
- Live runs against the two reported head SHAs, above.

## Control plane

This diff touches `claude-plugins/kampus-pipeline/skills/review-code/**` (a gate-critical skill),
so it is **control-plane by path** and needs a human control-plane approval before merge. Not
merging it.
