### PR TITLE
fix(ship-it): refuse an enqueue with no current-head verdict in a required namespace (#3982)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -741,6 +741,67 @@ no `claude-plugins/**` skills source).
 
 ## Step 2 — Resolve the *latest current-head* verdict per gate namespace, then branch on polarity (guard 1)
 
+<a id="step-2-gate"></a>
+### Step 2 gate — `verdict gate` is the enqueue precondition: run it FIRST, refuse on non-zero
+
+**Run this before any other Step-2 read, and treat a non-zero exit as a hard stop.** It resolves,
+in one fail-closed decision, the thing the rest of Step 2 describes: does **every** namespace this
+PR's diff requires carry a verdict that was **affirmatively read, bound to the PR's live head, and a
+pass**? A green exit is the **only** sanctioned path past guard 1 — no bypass, and no "I read the
+namespaces and they looked fine."
+
+The required set is **derived, never eyeballed** — the same `class-probe` output the reviewer fan
+dispatches off, so `dispatched-gate == required-gate` holds by construction:
+
+```bash
+# the required namespaces for THIS diff — one per artifact class present, plus review-design when
+# the diff is UI-affecting. `.glossary/**` rides has-code, so an ADR + a glossary row requires BOTH
+# review-doc AND review-code; satisfying one is not enough.
+REQUIRED="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+  | pipeline-cli class-probe classify --namespaces | paste -sd, -)"
+# A control-plane PR's pass path is the canonical SHA-less ADVISORY, bound in the body's
+# `Reviewed-head` line (ADR 0111/0151) — pass --cp so that form counts, and ONLY then. Set this from
+# Step 0's own classification (it printed `BLOCKING (…)` for a §CP path/content hit) AND only after
+# Step 0's approval gate discharged; leave it empty for every non-§CP PR.
+CP_FLAG=""   # → "--cp" iff Step 0 classified this PR §CP and its control-plane approval discharged
+pipeline-cli verdict gate --pr "$PR" --require "$REQUIRED" $CP_FLAG || {
+  disarm_intent refuse || INTENT_UNCLEARED=1
+  echo "ship-it: refused at guard 1 — see the named reason above; NOT enqueued."; exit 1; }
+```
+
+**Why a verb and not a careful read.** The rule below was already correct in prose ("docs present
+but the review-doc namespace is empty → `unverified (no review-doc PASS)`"), but nothing *computed*
+it: the shipper resolved each namespace with a separate `verdict read` and then decided **by
+eyeball** whether the union covered every required namespace. That leaves the **absence** branch to
+an agent's attention, and PR #3944 enqueued with **no verdict bound to its live head at all** — the
+one FAIL on it was bound to a *superseded* head, so at enqueue time nothing attested the tree being
+merged (#3982). "No verdict found" must be a **refusal**, not a pass-through, and absence is a
+property of the required **set** — so it can only be decided where the set is known, which is
+exactly what a per-namespace `read` cannot do. The verb makes the invalid state unrepresentable;
+`decideGate`'s unit tests are the contract, including the #3944 stale-head reproduction.
+
+The verb refuses, with the named reason, on **every** non-pass state: a namespace with no verdict at
+all, a verdict bound to a stale head, a SHA-less pre-0058 marker, a §CP advisory whose
+`Reviewed-head` is stale or whose body carries a `[FAIL]` checkbox, a current-head FAIL, an **empty
+required set** (zero required gates would make the conjunction vacuously true — an un-gated merge
+dressed as a pass, ADR 0092), and an unresolvable head.
+
+**`--cp` is load-bearing in both directions.** A §CP PR's only verdict is the SHA-less advisory, so
+`verdict read --gate code` legitimately resolves `_tag: none` on it — that `none` is the **expected**
+§CP shape, not an absent verdict, and a §CP PR must **never** be required to carry (nor be satisfied
+by) a bindable first-line `PASS @ <sha>` (that drops the §CP verdict into the auto-merge namespace,
+the ADR 0111 hazard). Pass `--cp` **only** for a PR Step 0 classified §CP whose control-plane
+approval gate already passed; without it the advisory is correctly not a pass.
+
+**The one signal the verb does not read — apply it on top.** `verdict gate` reads marker/advisory
+*comments*, not GitHub's native reviews. So a green `verdict gate` is **necessary, not sufficient**:
+the native-review fold below still applies to the review-code namespace, and a **newer**
+`CHANGES_REQUESTED` review than the marker still flips that namespace to FAIL and refuses. Run the
+verb first, then the fold; never let a green verb suppress a newer decisive review.
+
+The rest of Step 2 is the **explanation** of what that verb decides, plus the native-review fold it
+cannot see. Read it to understand a refusal — do not re-implement the conjunction by hand.
+
 You do **not** ship on the presence of any PASS that ever existed. Each gate is stateless and
 re-runs, so a PR can go PASS → FAIL or FAIL → PASS. Resolve **`review-code`, `review-doc`, and
 `review-skill` in separate namespaces** — three anchored regexes that never cross-match — and
@@ -972,6 +1033,12 @@ is_current () { [ -n "$1" ] || return 1; case "$CURRENT_HEAD" in "$1"*) return 0
 <a id="step-2cp--cp-advisory-namespace-resolution-adr-01350151"></a>
 ### Step 2.§CP — resolve a §CP advisory namespace from the body's `Reviewed-head` line (ADR 0135/0151)
 
+> **Owned by the verb — the bash below is the reference explanation, not a second implementation.**
+> This resolution now runs inside `pipeline-cli verdict gate --cp` ([Step 2 gate](#step-2-gate)):
+> author-gate the advisory the same way as a marker, take latest-wins across marker *and* advisory,
+> read the head from the body's `Reviewed-head` anchor, and require every body checkbox `[PASS]`. Read
+> this section to understand a §CP refusal; do not hand-roll the resolution beside the verb.
+
 **This step runs only for a PR Step 0 classified §CP whose approval gate passed** (a current-head
 `@kamp-us/control-plane` team approval is present — else Step 0 already STOPPED at `awaiting
 control-plane approval`, and you never reach here). A §CP `review-skill` / `review-doc` PR's *only*
@@ -1027,11 +1094,15 @@ A §CP namespace whose latest verdict is a `review-<code|skill|doc>: FAIL` marke
 reviewer found a miss), refused exactly as a non-§CP FAIL — the §CP advisory path is entered only
 when the latest verdict is an *advisory*, never to mask a FAIL.
 
-Then gate the merge on the classes present (Step 0):
+Then gate the merge on the classes present (Step 0). **This conjunction is what
+[Step 2 gate](#step-2-gate)'s `verdict gate` computes** — the list below names each refusal it emits,
+so a reason printed by the verb maps to a line here; it is not a second place to re-derive the check
+by hand:
 
 1. For **each class present**, its namespace must have a latest verdict, it must be **bound to
    the current head** (Step 2b, or Step 2.§CP for a §CP advisory namespace), and it must be PASS
-   (or, for a §CP advisory namespace, the Step 2.§CP PASS-equivalent).
+   (or, for a §CP advisory namespace, the Step 2.§CP PASS-equivalent). **A namespace with no
+   verdict at all is this same refusal** — absence is never a pass-through (#3982).
    - code present but the review-code namespace is empty → `unverified (no review-code PASS)`.
    - docs present but the review-doc namespace is empty → `unverified (no review-doc PASS)`.
    - skills present but the review-skill namespace is empty → `unverified (no review-skill PASS)`.

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -1,5 +1,5 @@
 /**
- * The `verdict` tool — `pipeline-cli verdict read` / `post` / `validate`.
+ * The `verdict` tool — `pipeline-cli verdict read` / `gate` / `post` / `validate`.
  *
  * The ADR-0058 SHA-bound verdict read/post glue, extracted from the inline `jq` the
  * `review-*` / `ship-it` / `write-code`-repair / `heal-ci` skills each hand-rolled (#2102).
@@ -10,6 +10,13 @@
  * refusal (`none`/`sha-less`/`stale`, or a current verdict of the wrong polarity) prints its
  * reason on stderr and exits non-zero, so a caller branches on exit status. The resolved
  * outcome is printed as JSON on stdout for a caller that wants the detail (comment id, sha).
+ *
+ * `gate --pr N --require <namespaces> [--cp]` is the SET-level counterpart `read` cannot be: it
+ * folds the same resolution over EVERY namespace the diff requires and exits 0 only when each one
+ * carries a current-head pass, so a namespace with no verdict at all is a named refusal instead of
+ * an unnoticed gap (#3982 — PR #3944 enqueued with nothing bound to its live head). On a §CP PR
+ * (`--cp`) the pass is the canonical SHA-less advisory bound by its body `Reviewed-head` line, never
+ * a bindable first-line PASS (ADR 0111/0151).
  *
  * `post --pr N --gate <g> [--body-file <f>]` upserts a SHA-bound verdict comment (ADR 0058
  * rule 2): it reads the composed verdict body from `--body-file` (or stdin), refuses fail-closed
@@ -108,6 +115,85 @@ const read = Command.make(
 );
 
 /**
+ * Deliberately REQUIRED, not stdin-defaulted: the required-namespace set is the load-bearing input,
+ * and a piped set that arrives empty (a dropped/undelivered stdin) is indistinguishable from "this
+ * PR needs no gates" — the #3786 zero-input class. An explicit flag makes the omission a usage
+ * error instead, and an explicitly-empty value still refuses on zero scope below.
+ */
+const requireFlag = Flag.string("require").pipe(
+	Flag.withDescription(
+		"the required review namespaces, comma/space separated (`review-code,review-doc` or `code,doc`) — derive with `pipeline-cli class-probe classify --namespaces`",
+	),
+);
+
+const cpFlag = Flag.boolean("cp").pipe(
+	Flag.withDescription(
+		"this is a §CP (control-plane / blocking-set) PR: accept the canonical SHA-less advisory + body `Reviewed-head` as the pass (ADR 0111/0151)",
+	),
+);
+
+/**
+ * Parse the required-namespace set, tolerating both shapes the producer emits: the
+ * `class-probe classify --namespaces` output (`review-code`) and a bare gate name (`code`). An
+ * unrecognized token is a hard input error, never a silently-dropped requirement — dropping one
+ * would shrink the conjunction, the exact fail-open this verb exists to prevent.
+ */
+const parseRequired = (raw: string): Effect.Effect<ReadonlyArray<VerdictGate>, never> => {
+	const tokens = raw
+		.split(/[\s,]+/)
+		.map((t) => t.trim().toLowerCase())
+		.filter((t) => t.length > 0);
+	const gates: VerdictGate[] = [];
+	for (const token of tokens) {
+		const name = token.startsWith("review-") ? token.slice("review-".length) : token;
+		if (!(GATES as ReadonlyArray<string>).includes(name)) {
+			return fail(
+				`unrecognized required namespace '${token}' — expected review-<gate> or <gate>, one of ${GATES.join(" | ")}. Refusing to drop it from the required set (that would shrink the gate conjunction).`,
+			);
+		}
+		gates.push(name as VerdictGate);
+	}
+	return Effect.succeed(gates);
+};
+
+/**
+ * `gate --pr N --require <namespaces> [--cp] [--head <sha>]` — the merge authority's structural
+ * enqueue check (#3982). Exit 0 **only** when EVERY required namespace carries a verdict that is
+ * affirmatively read, bound to the PR's live head, and a pass; every other state — including "no
+ * verdict found at all", the hole PR #3944 enqueued through — exits non-zero with the named reason.
+ *
+ * This is deliberately not expressible as N × `verdict read`: absence is a property of the required
+ * SET, so it can only be decided where the set is known. `--require` takes the same set
+ * `class-probe classify --namespaces` derives, so a PR spanning an ADR plus a `.glossary/**` row
+ * (which rides has-code) needs BOTH review-doc and review-code, not either.
+ */
+const gate = Command.make(
+	"gate",
+	{pr: prFlag, require: requireFlag, cp: cpFlag, head: headFlag},
+	Effect.fn(function* ({pr, require: required, cp, head}) {
+		const requiredGates = yield* parseRequired(required);
+		const decision = yield* (yield* Github).gate(
+			pr,
+			requiredGates,
+			cp,
+			Option.getOrUndefined(head),
+		);
+		// The full per-namespace decision goes to stdout as JSON (a caller may want to name which
+		// namespace blocked); the single named outcome line goes to stderr, mirroring `read`.
+		yield* Console.log(JSON.stringify(decision));
+		if (decision.enqueueable) {
+			process.stderr.write(`verdict gate: ${decision.reason}\n`);
+			return;
+		}
+		return yield* fail(decision.reason);
+	}),
+).pipe(
+	Command.withDescription(
+		"Assert EVERY required review namespace carries a current-head pass before an enqueue (exit 0 = enqueueable) — the fail-closed absence check (#3982)",
+	),
+);
+
+/**
  * Read the composed verdict body: from `--body-file` over the `FileSystem` seam, else from
  * stdin. Stdin (fd 0) has no `FileSystem` equivalent, so that read stays a raw `node:fs` call
  * at this boundary (`.patterns/effect-platform-access.md` bright line). An unreadable
@@ -176,9 +262,9 @@ const validate = Command.make(
 );
 
 export const verdictCommand = Command.make("verdict").pipe(
-	Command.withSubcommands([read, post, validate]),
+	Command.withSubcommands([read, gate, post, validate]),
 	Command.withDescription(
-		"Read/post ADR-0058 SHA-bound gate verdicts (review-code/doc/skill/design) — the shared verdict-match glue",
+		"Read/post ADR-0058 SHA-bound gate verdicts (review-code/doc/skill/design), and gate an enqueue on a current-head pass in EVERY required namespace",
 	),
 	Command.provide(GithubLive),
 );

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
@@ -1,0 +1,266 @@
+/**
+ * The pure enqueue-gate core of `verdict gate` — ship-it Step 2's per-required-namespace
+ * conjunction, made executable.
+ *
+ * Step 2's rule was already correct in prose ("code present but the review-code namespace is
+ * empty → unverified (no review-code PASS)"), but nothing *computed* it: the shipper resolved
+ * each namespace with a separate `verdict read` and then decided by eyeball whether the union
+ * covered every required namespace. That leaves the ABSENCE branch to an agent's attention span,
+ * and PR #3944 enqueued with no verdict bound to its live head at all (#3982). This core makes
+ * absence a refusal by construction: the decision is a total function of (required namespaces,
+ * comments, authorized authors, head), so "no verdict found" cannot read as "nothing blocking".
+ *
+ * Two forms of pass, and they are not interchangeable (ADR 0111/0151):
+ *  - a NON-§CP namespace passes only on a bindable first-line `review-<gate>: PASS @ <sha>`;
+ *  - a §CP namespace passes on the canonical SHA-less ADVISORY, whose head binding lives ONLY in
+ *    the body's `Reviewed-head: @ <sha>` line. A §CP PR must never be required to carry (nor be
+ *    satisfied by) a bindable first-line PASS — that drops the §CP verdict into the auto-merge
+ *    namespace, the ADR 0111 hazard.
+ * So `verdict read --gate code` legitimately resolving `none` on a §CP PR is the EXPECTED advisory
+ * shape, not an absent verdict — which is exactly the confusion a bolted-on absence check would
+ * make, refusing every §CP enqueue.
+ */
+import {
+	GATE_KEYWORD,
+	isBoundToHead,
+	parseVerdict,
+	pickLatestAuthorized,
+	polarityRe,
+	reviewedHeadSha,
+	type VerdictComment,
+	type VerdictGate,
+} from "./verdict-match.ts";
+
+/**
+ * The §CP advisory first line: `review-<gate>: advisory — blocking-set PR (manual merge)`. Anchored
+ * to the first line like every other marker matcher, and deliberately NOT polarity-bearing — an
+ * advisory carries no PASS/FAIL, so `polarityRe` never matches it and the two candidate sets are
+ * disjoint.
+ */
+export const advisoryRe = (gate: VerdictGate): RegExp =>
+	new RegExp(`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:\\s*advisory\\b`, "i");
+
+/** A recorded `[FAIL]` checkbox anywhere in an advisory body — the not-all-PASS tell. */
+const failCheckboxRe = /^\s*[-*]?\s*\[\s*FAIL\s*\]/im;
+
+/** Which verdict FORM satisfied (or was found in) a namespace — the ADR 0111 distinction. */
+export type VerdictForm = "marker" | "advisory" | "none";
+
+/** One required namespace's resolved state against the PR's live head. */
+export interface NamespaceDecision {
+	readonly gate: VerdictGate;
+	/** `review-code` / `review-doc` / `review-skill` / `review-design` — the namespace label. */
+	readonly namespace: string;
+	/**
+	 * `pass` — a current-head PASS (or §CP PASS-equivalent advisory) stands.
+	 * `fail` — the newest current-head verdict is a FAIL (the veto; the repair round-trip is the author's).
+	 * `absent` — NO consumable verdict exists in this namespace at all (the #3944 hole).
+	 * `unverified` — a verdict exists but is not bound to the live head (stale / SHA-less / not-all-PASS).
+	 */
+	readonly state: "pass" | "fail" | "absent" | "unverified";
+	readonly form: VerdictForm;
+	readonly commentId: number | null;
+	/** The head the found verdict binds, when it binds one. */
+	readonly sha: string | null;
+	readonly reason: string;
+}
+
+export interface GateDecisionInput {
+	readonly comments: ReadonlyArray<VerdictComment>;
+	/** The write+ collaborator logins — the ADR 0055 trust root (resolved by the IO shell). */
+	readonly authorizedAuthors: ReadonlyArray<string>;
+	/**
+	 * Every namespace this PR's diff requires — the `class-probe classify --namespaces` set, which
+	 * derives one gate per artifact class present plus `review-design` when the diff is UI-affecting.
+	 * A PR spanning an ADR plus a `.glossary/**` row requires BOTH review-doc AND review-code
+	 * (`.glossary/**` rides has-code), and satisfying only one must not be enough.
+	 */
+	readonly requiredGates: ReadonlyArray<VerdictGate>;
+	/** The PR's live head SHA — the head every verdict must bind (ADR 0058 rule 3). */
+	readonly headSha: string;
+	/** Is this a §CP (control-plane / blocking-set) PR, whose pass path is the advisory (ADR 0111/0151)? */
+	readonly controlPlane: boolean;
+}
+
+export interface GateDecision {
+	/** May the merge authority enqueue? True ONLY when every required namespace resolved `pass`. */
+	readonly enqueueable: boolean;
+	readonly decisions: ReadonlyArray<NamespaceDecision>;
+	/** The single named outcome line — a ship-it refusal reason, or the clearance. */
+	readonly reason: string;
+}
+
+/** Newest of two optional candidates by `(createdAt, id)` — the same latest-wins key as the markers. */
+const newerOf = (
+	a: VerdictComment | undefined,
+	b: VerdictComment | undefined,
+): VerdictComment | undefined => {
+	if (a === undefined) return b;
+	if (b === undefined) return a;
+	if (a.createdAt !== b.createdAt) return a.createdAt > b.createdAt ? a : b;
+	return a.id > b.id ? a : b;
+};
+
+const decideNamespace = (gate: VerdictGate, input: GateDecisionInput): NamespaceDecision => {
+	const namespace = GATE_KEYWORD[gate];
+	const base = {gate, namespace} as const;
+	const marker = pickLatestAuthorized(input.comments, input.authorizedAuthors, polarityRe(gate));
+	// A non-§CP PR's advisory is NOT a candidate at all: it carries no bindable head and is not a
+	// PASS, so it must neither satisfy the namespace nor shadow an older bindable marker — exactly
+	// what `verdict read` already does by matching on `polarityRe` only.
+	const advisory = input.controlPlane
+		? pickLatestAuthorized(input.comments, input.authorizedAuthors, advisoryRe(gate))
+		: undefined;
+	const latest = newerOf(marker, advisory);
+
+	if (latest === undefined) {
+		return {
+			...base,
+			state: "absent",
+			form: "none",
+			commentId: null,
+			sha: null,
+			reason: input.controlPlane
+				? `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR — neither a bindable PASS marker nor a §CP advisory`
+				: `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR at all`,
+		};
+	}
+
+	if (latest === advisory) {
+		const sha = reviewedHeadSha(latest.body);
+		if (sha === null) {
+			return {
+				...base,
+				state: "unverified",
+				form: "advisory",
+				commentId: latest.id,
+				sha: null,
+				reason: `unverified (§CP ${namespace} advisory carries no 'Reviewed-head: @ <sha>' body binding — an advisory is SHA-less in line 1 by design, so the body anchor is its only head binding, ADR 0151)`,
+			};
+		}
+		if (!isBoundToHead(sha, input.headSha)) {
+			return {
+				...base,
+				state: "unverified",
+				form: "advisory",
+				commentId: latest.id,
+				sha,
+				reason: `unverified (§CP ${namespace} advisory reviewed-head stale — body @ ${sha} ≠ current head ${input.headSha})`,
+			};
+		}
+		if (failCheckboxRe.test(latest.body)) {
+			return {
+				...base,
+				state: "unverified",
+				form: "advisory",
+				commentId: latest.id,
+				sha,
+				reason: `unverified (§CP ${namespace} advisory not all-PASS — a body checkbox is [FAIL])`,
+			};
+		}
+		return {
+			...base,
+			state: "pass",
+			form: "advisory",
+			commentId: latest.id,
+			sha,
+			reason: `§CP ${namespace} advisory at the current head, all-PASS — the ADR 0111/0151 PASS-equivalent`,
+		};
+	}
+
+	// `polarityRe` matched, so `parseVerdict` cannot be null here — the `?? null` collapses the
+	// unreachable branch into the same fail-closed `absent` rather than asserting non-null.
+	const parsed = parseVerdict(latest.body, gate);
+	if (parsed === null) {
+		return {
+			...base,
+			state: "absent",
+			form: "none",
+			commentId: latest.id,
+			sha: null,
+			reason: `unverified (no ${namespace} PASS): the latest authorized comment in this namespace carries no readable polarity`,
+		};
+	}
+	if (parsed.sha === null) {
+		return {
+			...base,
+			state: "unverified",
+			form: "marker",
+			commentId: latest.id,
+			sha: null,
+			reason: `unverified (verdict not bound to current head): the latest ${namespace} marker is SHA-less (pre-0058)`,
+		};
+	}
+	if (!isBoundToHead(parsed.sha, input.headSha)) {
+		return {
+			...base,
+			state: "unverified",
+			form: "marker",
+			commentId: latest.id,
+			sha: parsed.sha,
+			reason: `unverified (verdict not bound to current head): the latest ${namespace} marker binds ${parsed.sha}, not the current head ${input.headSha}`,
+		};
+	}
+	return {
+		...base,
+		state: parsed.polarity === "PASS" ? "pass" : "fail",
+		form: "marker",
+		commentId: latest.id,
+		sha: parsed.sha,
+		reason:
+			parsed.polarity === "PASS"
+				? `current-head ${namespace} PASS @ ${parsed.sha}`
+				: `latest verdict is FAIL (${namespace}) @ ${parsed.sha}`,
+	};
+};
+
+/**
+ * The enqueue decision: `enqueueable` iff EVERY required namespace resolves to a current-head PASS
+ * (or, for a §CP PR, a current-head all-PASS advisory). Every other state — absent, stale, SHA-less,
+ * not-all-PASS, FAIL — refuses with that namespace's named reason.
+ *
+ * Fail-closed on its own inputs, not just on the verdicts (ADR 0092):
+ *  - an EMPTY required set refuses. Zero required gates would make the conjunction vacuously true,
+ *    which is the un-gated merge dressed as a clean pass — the same zero-scope hole `class-probe`
+ *    closes on a dropped stdin (#3786).
+ *  - an EMPTY head refuses. With no head to bind against, `isBoundToHead` can never be satisfied,
+ *    so an unresolvable head must be a named refusal rather than a silent all-stale sweep.
+ * A FAIL anywhere is reported ahead of the other refusals: it is the one outcome with a different
+ * remedy (the author's repair round-trip, not a re-review or a fresh gate run).
+ */
+export const decideGate = (input: GateDecisionInput): GateDecision => {
+	if (input.requiredGates.length === 0) {
+		return {
+			enqueueable: false,
+			decisions: [],
+			reason:
+				"refused (fail-closed, zero scope): no required review namespace was supplied — a zero-length required set makes the per-namespace conjunction vacuously true, i.e. an un-gated merge reported as a pass. Derive the set with `pipeline-cli class-probe classify --namespaces` (ADR 0092, #3786).",
+		};
+	}
+	if (input.headSha.trim().length === 0) {
+		return {
+			enqueueable: false,
+			decisions: [],
+			reason:
+				"refused (fail-closed): the PR's head SHA is empty/unresolvable — no verdict can be proven bound to a head that isn't known (ADR 0058 rule 3).",
+		};
+	}
+	const decisions = [...new Set(input.requiredGates)].map((gate) => decideNamespace(gate, input));
+	const failed = decisions.find((d) => d.state === "fail");
+	const blocked = failed ?? decisions.find((d) => d.state !== "pass");
+	if (blocked !== undefined) {
+		const required = decisions.map((d) => d.namespace).join(" + ");
+		return {
+			enqueueable: false,
+			decisions,
+			reason: `refused — ${blocked.reason} [required: ${required}; head ${input.headSha}]`,
+		};
+	}
+	return {
+		enqueueable: true,
+		decisions,
+		reason: `enqueueable — every required namespace carries a current-head pass: ${decisions
+			.map((d) => `${d.namespace} (${d.form})`)
+			.join(" + ")} @ ${input.headSha}`,
+	};
+};

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -1,0 +1,317 @@
+import {assert, describe, it} from "@effect/vitest";
+import {decideGate, type GateDecisionInput} from "./gate-decision.ts";
+import type {VerdictComment, VerdictGate} from "./verdict-match.ts";
+
+const HEAD = "15ae9df658ce6225b8b71f22d214cfcabb6b1c9a";
+const OLD = "92c2cf4d0000000000000000000000000000abcd";
+const REVIEWER = "usirin";
+
+const comment = (over: Partial<VerdictComment> & {readonly id: number}): VerdictComment => ({
+	author: REVIEWER,
+	createdAt: "2026-07-25T04:54:53Z",
+	body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+	...over,
+});
+
+const decide = (over: Partial<GateDecisionInput>) =>
+	decideGate({
+		comments: [],
+		authorizedAuthors: [REVIEWER],
+		requiredGates: ["doc"],
+		headSha: HEAD,
+		controlPlane: false,
+		...over,
+	});
+
+/** The §CP advisory shape ship-it Step 2.§CP resolves: SHA-less line 1, head bound in the body. */
+const advisory = (gate: VerdictGate, sha: string, checkbox = "[PASS]") =>
+	[
+		`review-${gate}: advisory — blocking-set PR (manual merge)`,
+		"",
+		`Reviewed-head: @ ${sha}`,
+		"",
+		`- ${checkbox} the gate's own criteria`,
+	].join("\n");
+
+describe("decideGate — the required-namespace conjunction (the enqueue decision)", () => {
+	it("a current-head PASS marker in the one required namespace is enqueueable", () => {
+		const result = decide({comments: [comment({id: 1})]});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "pass");
+		assert.strictEqual(result.decisions[0]?.form, "marker");
+	});
+
+	it("a current-head FAIL marker refuses, and the reason names the FAIL", () => {
+		const result = decide({
+			comments: [comment({id: 1, body: `review-doc: FAIL @ ${HEAD} — changes-requested`})],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "fail");
+		assert.include(result.reason, "latest verdict is FAIL (review-doc)");
+	});
+
+	it("NO verdict at all in a required namespace refuses (the absence hole, #3982)", () => {
+		const result = decide({comments: []});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "absent");
+		assert.include(result.reason, "no review-doc PASS");
+	});
+
+	it("an unauthorized author's current-head PASS is invisible ⇒ absent (ADR 0055 trust root)", () => {
+		const result = decide({
+			comments: [comment({id: 1, author: "a-stranger"})],
+			authorizedAuthors: [REVIEWER],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "absent");
+	});
+
+	it("an empty authorized set resolves absent for every namespace (fail-closed)", () => {
+		const result = decide({comments: [comment({id: 1})], authorizedAuthors: []});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "absent");
+	});
+
+	it("a SHA-less (pre-0058) marker refuses as unverified, never as a pass", () => {
+		const result = decide({comments: [comment({id: 1, body: "review-doc: PASS — merge-ready"})]});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "unverified");
+		assert.include(result.reason, "not bound to current head");
+	});
+
+	it("latest-wins: a newer current-head FAIL vetoes an older current-head PASS", () => {
+		const result = decide({
+			comments: [
+				comment({id: 1, createdAt: "2026-07-25T05:11:56Z"}),
+				comment({
+					id: 2,
+					createdAt: "2026-07-25T05:18:37Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+			],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "fail");
+	});
+
+	it("latest-wins: a newer current-head PASS clears an older FAIL (the repair loop)", () => {
+		const result = decide({
+			comments: [
+				comment({
+					id: 1,
+					createdAt: "2026-07-25T04:54:53Z",
+					body: `review-doc: FAIL @ ${OLD} — changes-requested`,
+				}),
+				comment({id: 2, createdAt: "2026-07-25T05:11:56Z"}),
+			],
+		});
+		assert.isTrue(result.enqueueable);
+	});
+});
+
+describe("decideGate — PR #3944's exact situation: a verdict bound to a SUPERSEDED head", () => {
+	// The incident (#3982): PR #3944 opened at head 92c2cf4d, took a review-doc FAIL bound to THAT
+	// head, then got a repair push moving the head to 15ae9df6. At `added_to_merge_queue` the only
+	// verdict on the PR was that FAIL, bound to the superseded 92c2cf4d — i.e. NOTHING was bound to
+	// the live head, and the enqueue proceeded anyway. The defect is the absence branch, not
+	// FAIL-detection: a stale verdict of EITHER polarity leaves the live head un-attested, so both
+	// polarities must refuse here.
+	const staleCases: ReadonlyArray<{readonly name: string; readonly polarity: "PASS" | "FAIL"}> = [
+		{name: "stale FAIL at the superseded head (the observed #3944 state)", polarity: "FAIL"},
+		{name: "stale PASS at the superseded head (the head-moved race)", polarity: "PASS"},
+	];
+
+	for (const {name, polarity} of staleCases) {
+		it(`${name} ⇒ MUST refuse`, () => {
+			const result = decide({
+				comments: [comment({id: 5077016090, body: `review-doc: ${polarity} @ ${OLD} — round 1`})],
+			});
+			assert.isFalse(result.enqueueable);
+			assert.strictEqual(result.decisions[0]?.state, "unverified");
+			assert.strictEqual(result.decisions[0]?.sha, OLD);
+			assert.include(result.reason, "not bound to current head");
+		});
+	}
+
+	it("the repaired head with a fresh current-head PASS is what unblocks it", () => {
+		const result = decide({
+			comments: [
+				comment({
+					id: 5077016090,
+					createdAt: "2026-07-25T04:54:53Z",
+					body: `review-doc: FAIL @ ${OLD} — round 1`,
+				}),
+				comment({
+					id: 5077016099,
+					createdAt: "2026-07-25T05:11:56Z",
+					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+				}),
+			],
+		});
+		assert.isTrue(result.enqueueable);
+	});
+});
+
+describe("decideGate — the §CP advisory is the pass, and only on a §CP PR (ADR 0111/0151)", () => {
+	it("a §CP advisory bound to the current head passes", () => {
+		const result = decide({
+			comments: [comment({id: 1, body: advisory("doc", HEAD)})],
+			controlPlane: true,
+		});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "pass");
+		assert.strictEqual(result.decisions[0]?.form, "advisory");
+		assert.strictEqual(result.decisions[0]?.sha, HEAD);
+	});
+
+	it("a §CP review-code advisory passes too — all four gates converge on the one form (#2329)", () => {
+		const result = decide({
+			comments: [comment({id: 1, body: advisory("code", HEAD)})],
+			requiredGates: ["code"],
+			controlPlane: true,
+		});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.form, "advisory");
+	});
+
+	it("a §CP PR is NOT required to carry a bindable first-line PASS (the ADR 0111 hazard)", () => {
+		// The advisory alone clears it: nothing in the decision demands `review-doc: PASS @ <sha>`
+		// on a §CP PR, so the forge-a-marker workaround stays unnecessary.
+		const result = decide({
+			comments: [comment({id: 1, body: advisory("doc", HEAD)})],
+			controlPlane: true,
+		});
+		assert.isTrue(result.enqueueable);
+		assert.notInclude(JSON.stringify(result.decisions), '"form":"marker"');
+	});
+
+	it("a §CP advisory bound to a stale head refuses", () => {
+		const result = decide({
+			comments: [comment({id: 1, body: advisory("doc", OLD)})],
+			controlPlane: true,
+		});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "advisory reviewed-head stale");
+	});
+
+	it("a §CP advisory with no Reviewed-head body binding refuses", () => {
+		const result = decide({
+			comments: [comment({id: 1, body: "review-doc: advisory — blocking-set PR (manual merge)"})],
+			controlPlane: true,
+		});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "no 'Reviewed-head: @ <sha>' body binding");
+	});
+
+	it("a §CP advisory carrying a [FAIL] checkbox refuses (not all-PASS)", () => {
+		const result = decide({
+			comments: [comment({id: 1, body: advisory("doc", HEAD, "[FAIL]")})],
+			controlPlane: true,
+		});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "not all-PASS");
+	});
+
+	it("a §CP advisory never masks a NEWER current-head FAIL marker", () => {
+		const result = decide({
+			comments: [
+				comment({id: 1, createdAt: "2026-07-25T05:00:00Z", body: advisory("doc", HEAD)}),
+				comment({
+					id: 2,
+					createdAt: "2026-07-25T05:30:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+			],
+			controlPlane: true,
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "fail");
+	});
+
+	it("on a NON-§CP PR an advisory is not a pass — it resolves absent", () => {
+		const result = decide({comments: [comment({id: 1, body: advisory("doc", HEAD)})]});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "absent");
+	});
+
+	it("on a NON-§CP PR an advisory does not shadow an older bindable PASS", () => {
+		const result = decide({
+			comments: [
+				comment({id: 1, createdAt: "2026-07-25T05:00:00Z"}),
+				comment({id: 2, createdAt: "2026-07-25T05:30:00Z", body: advisory("doc", HEAD)}),
+			],
+		});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.form, "marker");
+	});
+});
+
+describe("decideGate — EVERY required namespace must pass, not just one", () => {
+	it("an ADR + a .glossary row requires BOTH review-doc and review-code; one PASS is not enough", () => {
+		// `.glossary/**` rides has-code (HAS_CODE_RE = ^(apps|packages|\.glossary|infra)/), so such a
+		// diff spans has-docs + has-code — the #2430 miss ship-it's conjunction caught late.
+		const result = decide({
+			requiredGates: ["doc", "code"],
+			comments: [comment({id: 1})],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions.length, 2);
+		assert.strictEqual(result.decisions[0]?.state, "pass");
+		assert.strictEqual(result.decisions[1]?.state, "absent");
+		assert.include(result.reason, "no review-code PASS");
+	});
+
+	it("both namespaces at the current head ⇒ enqueueable", () => {
+		const result = decide({
+			requiredGates: ["doc", "code"],
+			comments: [
+				comment({id: 1}),
+				comment({id: 2, body: `review-code: PASS @ ${HEAD} — merge-ready`}),
+			],
+		});
+		assert.isTrue(result.enqueueable);
+	});
+
+	it("a UI PR's additive review-design namespace is required alongside review-code", () => {
+		const result = decide({
+			requiredGates: ["code", "design"],
+			comments: [comment({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "no review-design PASS");
+	});
+
+	it("a FAIL is reported ahead of an absence — its remedy is the author's repair round-trip", () => {
+		const result = decide({
+			requiredGates: ["doc", "code"],
+			comments: [comment({id: 1, body: `review-doc: FAIL @ ${HEAD} — changes-requested`})],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "latest verdict is FAIL (review-doc)");
+	});
+
+	it("a repeated namespace is decided once (the set, not the list)", () => {
+		const result = decide({requiredGates: ["doc", "doc"], comments: [comment({id: 1})]});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions.length, 1);
+	});
+});
+
+describe("decideGate — fail-closed on its own inputs (ADR 0092)", () => {
+	it("an EMPTY required set refuses rather than passing vacuously", () => {
+		const result = decide({requiredGates: [], comments: [comment({id: 1})]});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "zero scope");
+	});
+
+	it("an empty/unresolvable head SHA refuses", () => {
+		const result = decide({headSha: "", comments: [comment({id: 1})]});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "head SHA is empty");
+	});
+
+	it("an abbreviated head still prefix-matches a full bound SHA (ADR 0058 rule 3)", () => {
+		const result = decide({headSha: HEAD.slice(0, 8), comments: [comment({id: 1})]});
+		assert.isTrue(result.enqueueable);
+	});
+});

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -515,3 +515,139 @@ describe("Github.post — the folded-in landed-comment self-verify (#3019)", () 
 		),
 	);
 });
+
+describe("Github.gate — the required-namespace enqueue decision over a mock gh spawner (#3982)", () => {
+	it.effect("PR #3944's shape: the only verdict is bound to a SUPERSEDED head → REFUSE", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, ["doc"], false);
+			assert.isFalse(decision.enqueueable);
+			assert.strictEqual(decision.decisions[0]?.state, "unverified");
+			assert.include(decision.reason, "not bound to current head");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: `review-doc: FAIL @ ${OLD} — round 1`}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "admin",
+			}),
+		),
+	);
+
+	it.effect("no verdict at all in a required namespace → REFUSE (the absence hole)", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, ["doc"], false);
+			assert.isFalse(decision.enqueueable);
+			assert.strictEqual(decision.decisions[0]?.state, "absent");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+
+	it.effect("a mixed doc+code PR with only review-doc PASS → REFUSE on the empty namespace", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, ["doc", "code"], false);
+			assert.isFalse(decision.enqueueable);
+			assert.include(decision.reason, "no review-code PASS");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: `review-doc: PASS @ ${HEAD} — merge-ready`}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "admin",
+			}),
+		),
+	);
+
+	it.effect("both namespaces at the current head → enqueueable", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, ["doc", "code"], false);
+			assert.isTrue(decision.enqueueable);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: `review-doc: PASS @ ${HEAD} — merge-ready`}),
+					comment({id: 2, login: "usirin", body: `review-code: PASS @ ${HEAD} — merge-ready`}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "admin",
+			}),
+		),
+	);
+
+	// A §CP PR's ONLY verdict is the SHA-less advisory (ADR 0111): `read` resolves it `none`, and that
+	// `none` is the EXPECTED shape, not an absent verdict. The advisory author is ACL-checked here via
+	// `namespaceRe` — which `read`'s polarity-only scope structurally cannot do for the advisory form.
+	const CP_ADVISORY = [
+		"review-skill: advisory — blocking-set PR (manual merge)",
+		"",
+		`Reviewed-head: @ ${HEAD}`,
+		"",
+		"- [PASS] the skill gate's own criteria",
+	].join("\n");
+
+	it.effect("a §CP advisory at the current head PASSES (--cp)", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, ["skill"], true);
+			assert.isTrue(decision.enqueueable);
+			assert.strictEqual(decision.decisions[0]?.form, "advisory");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: CP_ADVISORY}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "admin",
+			}),
+		),
+	);
+
+	it.effect("the same advisory on a NON-§CP PR is not a pass → REFUSE", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, ["skill"], false);
+			assert.isFalse(decision.enqueueable);
+			assert.strictEqual(decision.decisions[0]?.state, "absent");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: CP_ADVISORY}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "admin",
+			}),
+		),
+	);
+
+	it.effect("a §CP advisory from a read-only author is ACL-dropped → REFUSE (ADR 0055)", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, ["skill"], true);
+			assert.isFalse(decision.enqueueable);
+			assert.strictEqual(decision.decisions[0]?.state, "absent");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "a-stranger", body: CP_ADVISORY}),
+				]),
+				[`GET ${P}/collaborators/a-stranger/permission`]: "read",
+			}),
+		),
+	);
+
+	it.effect("an empty required set REFUSES rather than passing vacuously (ADR 0092)", () =>
+		Effect.gen(function* () {
+			const decision = yield* (yield* Github).gate(PR, [], false);
+			assert.isFalse(decision.enqueueable);
+			assert.include(decision.reason, "zero scope");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+});

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -9,7 +9,9 @@
  * `RepoResolutionError`), untrusted REST JSON Schema-decoded at the boundary into the domain
  * `VerdictComment` the core resolves over.
  *
- * Two verbs:
+ * Three verbs:
+ *  - `gate(pr, requiredGates, controlPlane, headOverride)` — the SET-level enqueue decision: fold the
+ *    same resolution over every namespace the diff requires, so an absent namespace refuses (#3982).
  *  - `read(pr, gate, expect, headOverride)` — resolve the PR's current head (REST), author-gate
  *    marker authors to write+ collaborators (ADR 0055), and run `resolveVerdict` to classify
  *    the namespace against that head. The consumer branches on the returned outcome.
@@ -39,6 +41,7 @@ import {
 	runGh,
 	whoAmIArgs,
 } from "../tracker/gh-io.ts";
+import {decideGate, type GateDecision} from "./gate-decision.ts";
 import {
 	boundHeadShas,
 	emissionDefect,
@@ -195,6 +198,45 @@ const read = Effect.fn("Github.read")(function* (
 });
 
 /**
+ * Resolve the ENQUEUE decision for a PR: does every namespace the diff requires carry a pass bound
+ * to the live head? One comment read + one ACL resolution feed the pure `decideGate` — the same
+ * head-binding and author-gate the single-namespace `read` applies, folded over the whole required
+ * set so an ABSENT namespace is a refusal rather than an unnoticed gap (#3982 / PR #3944).
+ *
+ * The author-gate scope is `namespaceRe` (which matches PASS / FAIL / advisory alike) across every
+ * required gate, so a §CP advisory's author is ACL-checked exactly like a marker author — the one
+ * thing single-namespace `read` structurally cannot do for the SHA-less advisory form (ADR 0111).
+ */
+const gate = Effect.fn("Github.gate")(function* (
+	repo: string,
+	pr: number,
+	requiredGates: ReadonlyArray<VerdictGate>,
+	controlPlane: boolean,
+	headOverride: string | undefined,
+) {
+	const headSha = headOverride?.trim() || (yield* currentHead(repo, pr));
+	const comments = yield* listComments(repo, pr);
+	const inAnyNamespace = (body: string): boolean =>
+		requiredGates.some((g) => namespaceRe(g).test(body));
+	const markerAuthors = [
+		...new Set(
+			comments
+				.filter((c) => inAnyNamespace(c.body))
+				.map((c) => c.author)
+				.filter((a) => a.length > 0),
+		),
+	];
+	const authorized = yield* authorizedAuthors(repo, markerAuthors);
+	return decideGate({
+		comments,
+		authorizedAuthors: authorized,
+		requiredGates,
+		headSha,
+		controlPlane,
+	});
+});
+
+/**
  * Upsert this PR's `gate` verdict (ADR 0058 rule 2). Three fail-closed emission guards run first:
  * the body's first line must be *this* gate's marker (rejects a cross-namespace body); a
  * polarity-bearing (PASS/FAIL) body must carry a well-formed `@ <sha>` (rejects the unbindable
@@ -276,6 +318,15 @@ export class Github extends Context.Service<
 			ReadResult,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
 		>;
+		readonly gate: (
+			pr: number,
+			requiredGates: ReadonlyArray<VerdictGate>,
+			controlPlane: boolean,
+			headOverride?: string,
+		) => Effect.Effect<
+			GateDecision,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
 		readonly post: (
 			pr: number,
 			gate: VerdictGate,
@@ -310,6 +361,12 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 			return {
 				read: (pr, gate, expect, headOverride) =>
 					repo.pipe(Effect.flatMap((r) => withSpawner(read(r, pr, gate, expect, headOverride)))),
+				gate: (pr, requiredGates, controlPlane, headOverride) =>
+					repo.pipe(
+						Effect.flatMap((r) =>
+							withSpawner(gate(r, pr, requiredGates, controlPlane, headOverride)),
+						),
+					),
 				post: (pr, gate, body) =>
 					repo.pipe(Effect.flatMap((r) => withSpawner(post(r, pr, gate, body)))),
 			};

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -146,6 +146,27 @@ export interface ResolveVerdictInput {
 }
 
 /**
+ * The latest-wins pick, shared by `resolveVerdict` and the §CP advisory resolution: among the
+ * comments an authorized (write+, ADR 0055) author posted whose body matches `re`, the newest by
+ * `(createdAt, id)`. `undefined` when the authorized candidate set is empty — the fail-closed
+ * "nothing to consume in this namespace", never a false win.
+ */
+export const pickLatestAuthorized = (
+	comments: ReadonlyArray<VerdictComment>,
+	authorizedAuthors: ReadonlyArray<string>,
+	re: RegExp,
+): VerdictComment | undefined => {
+	const authorized = new Set(authorizedAuthors);
+	const candidates = comments.filter(
+		(comment) => authorized.has(comment.author) && re.test(comment.body),
+	);
+	candidates.sort((a, b) =>
+		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
+	);
+	return candidates[candidates.length - 1];
+};
+
+/**
  * Resolve the (PR, gate) verdict against the current head, re-encoding ADR 0058 rule 3
  * exactly: author-gate to write+ collaborators (a forged marker is invisible), keep only
  * PASS/FAIL markers in this namespace, take the **newest** by `(createdAt, id)` (latest-wins,
@@ -155,15 +176,11 @@ export interface ResolveVerdictInput {
  * set is empty. Fail-closed everywhere: an empty authorized set is `none`, never a false win.
  */
 export const resolveVerdict = (input: ResolveVerdictInput): VerdictOutcome => {
-	const authorized = new Set(input.authorizedAuthors);
-	const re = polarityRe(input.gate);
-	const candidates = input.comments.filter(
-		(comment) => authorized.has(comment.author) && re.test(comment.body),
+	const latest = pickLatestAuthorized(
+		input.comments,
+		input.authorizedAuthors,
+		polarityRe(input.gate),
 	);
-	candidates.sort((a, b) =>
-		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
-	);
-	const latest = candidates[candidates.length - 1];
 	// `latest` is absent only for an empty candidate set, and `parseVerdict` is null only for a
 	// non-PASS/FAIL body — but polarityRe already filtered candidates to PASS/FAIL markers, so both
 	// guards collapse to the same fail-closed `none` (no consumable verdict in this namespace).
@@ -273,6 +290,15 @@ export const malformedEmittedSha = (body: string, gate: VerdictGate): string | n
  * `malformedEmittedSha`. Capture group 1 is the bound SHA.
  */
 const reviewedHeadShaRe = /^\s*Reviewed-head:\s*@?\s*([0-9a-f]{7,40})/im;
+
+/**
+ * The head a §CP advisory binds itself to — its body's `Reviewed-head: @ <sha>` anchor (ADR 0151),
+ * lowercased, or `null` when the body carries no well-formed anchor. A §CP advisory is SHA-less in
+ * its FIRST line by design (ADR 0111), so this body anchor is the only head binding it has, and the
+ * only thing that can make it a current-head verdict.
+ */
+export const reviewedHeadSha = (body: string): string | null =>
+	reviewedHeadShaRe.exec(body)?.[1]?.toLowerCase() ?? null;
 
 /**
  * Every head SHA a verdict body binds itself to: the first-line `PASS|FAIL @ <sha>` marker and the


### PR DESCRIPTION
The merge authority could enqueue a PR that had no review verdict attached to the code actually being merged. The rule was written down correctly, but nothing in the pipeline computed it — each review namespace was checked one at a time and an agent then decided by eye whether they added up, which is how PR #3944 got into the merge queue with nothing attesting its live head. This change turns that judgement into one executable, fail-closed check: unless every review namespace the diff requires carries a pass bound to the exact commit being merged, the enqueue is refused by name.

Fixes #3982

## The defect, precisely

PR #3944 opened at head `92c2cf4d`, took a `review-doc: FAIL` bound to **that** head, then took a repair push moving the head to `15ae9df6`. At `added_to_merge_queue` (`05:16:57Z`) the only verdict on the PR was that FAIL, bound to the **superseded** head — the verdict comment's `updated_at` (`05:18:37Z`) *post-dates* the enqueue, so whatever it says today, it did not say it then.

So this is **not** a FAIL-detection defect in `verdict read`. Nothing was bound to the live head, and the enqueue proceeded anyway. The hole is ship-it Step 2's **absence** branch.

Step 2's prose already had the rule right (`docs present but the review-doc namespace is empty → unverified (no review-doc PASS)`), but nothing *computed* it: the shipper resolved each namespace with a separate `verdict read` and then judged the union by eyeball. Absence is a property of the required **set**, so a per-namespace read structurally cannot decide it.

## What changed

**`pipeline-cli verdict gate --pr N --require <namespaces> [--cp]`** — one total, fail-closed decision over the whole required set. Exit 0 **only** when every required namespace carries a verdict that is affirmatively read, bound to the PR's live head, and a pass. Every other state exits non-zero with the named reason: no verdict at all, a stale-head verdict, a SHA-less pre-0058 marker, a current-head FAIL, a §CP advisory whose `Reviewed-head` is stale or whose body carries a `[FAIL]` checkbox.

- `packages/pipeline-cli/src/tools/verdict/gate-decision.ts` — the pure core (`decideGate`), IO-free and total.
- `packages/pipeline-cli/src/tools/verdict/github.ts` — one comment read + one ACL resolution feeding the core; the author-gate scopes on `namespaceRe` so a **§CP advisory's** author is ACL-checked exactly like a marker author, which the polarity-only single-namespace `read` cannot do.
- `packages/pipeline-cli/src/tools/verdict/command.ts` — the `gate` subcommand.
- `packages/pipeline-cli/src/tools/verdict/verdict-match.ts` — extracted the latest-wins pick (`pickLatestAuthorized`) and exported the `Reviewed-head` reader so the §CP path reuses them rather than growing a second copy. `resolveVerdict`'s behaviour is unchanged.
- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` — Step 2 now runs the verb **first** and hard-stops on non-zero (clearing the `--auto` merge intent on the refusal path, ADR 0198). The surrounding prose becomes the *explanation* of what the verb decides, not a second implementation.

The required set is **derived, never eyeballed** — `class-probe classify --namespaces`, the same probe the reviewer fan dispatches off, so `dispatched-gate == required-gate` holds by construction. `.glossary/**` rides `has-code`, so a PR spanning an ADR plus a glossary row requires **both** `review-doc` and `review-code`; satisfying one is not enough (covered by a test).

## The §CP pass shape is preserved exactly

This was the main hazard to get right, since getting it wrong would refuse every control-plane ship.

- A **non-§CP** namespace passes only on a bindable first-line `review-<gate>: PASS @ <sha>`.
- A **§CP** namespace passes on the canonical SHA-less **advisory**, whose head binding lives only in the body's `Reviewed-head: @ <sha>` line (ADR 0111/0151). A §CP PR is **never** required to carry — nor satisfied by — a bindable first-line `PASS @ sha`; that would drop the §CP verdict into the auto-merge namespace, the ADR 0111 hazard.
- Consequently `verdict read --gate code` resolving `_tag: none` on a §CP PR is the **expected** advisory shape, not an absent verdict. `--cp` is what distinguishes them, and it is passed only for a PR Step 0 classified §CP whose approval gate discharged.
- A §CP advisory never masks a **newer** current-head FAIL marker (latest-wins holds across marker *and* advisory).

**Verified live, both directions:** §CP PR #3784 → `enqueueable`, both `review-skill` and `review-code` resolved `form: advisory` from the body `Reviewed-head` at the merged head. The same PR **without** `--cp` → refused (`absent`), proving the advisory is not silently accepted as a bindable pass. PR #3944 → refused.

## Fail-closed on its own inputs too (ADR 0092)

- An **empty required set refuses**. Zero required gates would make the conjunction vacuously true — an un-gated merge reported as a clean pass.
- `--require` is **mandatory**, not stdin-defaulted: a dropped/undelivered pipe would otherwise be indistinguishable from "this PR needs no gates" (the #3786 class `class-probe` already had to close).
- An empty/unresolvable head refuses rather than sweeping every namespace to stale.

## The one signal the verb cannot read

`verdict gate` reads marker/advisory *comments*, not GitHub's native reviews. A green `verdict gate` is therefore **necessary, not sufficient** — Step 2's native-review fold still applies to the review-code namespace, and a **newer** `CHANGES_REQUESTED` review than the marker still flips it to FAIL and refuses. The skill states this explicitly so a green verb can never suppress a newer decisive review.

## Coverage

`gate-decision.unit.test.ts` (28 cases) + 8 IO-level cases in `github-service.unit.test.ts`, including the two the issue asks for by name:

- **#3944's exact situation** — a verdict that exists but is bound to a superseded head **must refuse**, for **both** polarities (a stale PASS is the head-moved race; a stale FAIL is the observed state). Both leave the live head un-attested.
- **A §CP advisory at the current head still passes** — for `review-doc` and for `review-code` (all four gates converge on the one advisory form).

Plus: absence, unauthorized/empty author set, SHA-less markers, latest-wins in both directions, the doc+code conjunction, the additive `review-design` gate on a UI PR, FAIL-reported-ahead-of-absence, and the zero-scope/empty-head input refusals.

## Checks

- `pnpm typecheck` — clean (29/29 tasks).
- `pnpm lint:worktree` — clean.
- `packages/pipeline-cli` full suite — 147 files / 2094 tests pass.
- `adoption-lint` over the full crew corpus — clean.
- `leak-guard scan` over every changed file — clean.
- `validate-skills.sh` (26 skills) and `validate-gate-path-drift.sh` (17 checks) — OK.

## Note for the reviewer

This touches control-plane paths (`claude-plugins/**/skills/ship-it/SKILL.md`), so it needs a human control-plane approval before merge. Not to be merged by an agent.

One judgement call worth a second opinion: the engine that drove PR #3944's lane reports on #3982 that a genuine current-head PASS *did* exist at `~05:11:56Z` and that ship-it lawfully bound it, with the round-2 FAIL arriving ~100s **after** the enqueue via an in-place comment edit. If that account is right, #3944 was not itself an absence failure — but the absence branch it exposes is unguarded either way, which is what this PR closes. The separable questions that account raises — should a verdict upsert append a new marker instead of editing in place, and should a current-head FAIL landing on a queued PR dequeue it — are **out of scope here** and belong in their own issues.
