### PR TITLE
fix(pipeline): every claim writer stamps presence through one producer (#3987)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -232,15 +232,14 @@ async function drive() {
 			`\${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}. Procedure: ` +
 			`(1) read your own claim token TOKEN="$CLAUDE_CODE_SESSION_ID" — if it is empty, ABORT (fail-closed, ADR 0115 §"Trust + fail-closed") ` +
 			`and return { won: false, token: "", reason: "no CLAUDE_CODE_SESSION_ID — cannot post an agent-distinguishable claim" }; ` +
-			`(2) Rule-0 defer: read the issue's assignees and its existing claim comments — if an authorized claim ` +
-			`(\`claim: <session> · <ts>\` from an account with write+ on the repo, ADR 0055 trust root) from a DIFFERENT session already owns it, ` +
-			`back off WITHOUT posting and return { won: false, token: "", reason: "already claimed by another agent" }; ` +
-			`(3) self-assign (the coarse availability gate) then post the claim comment \`claim: <TOKEN> · <ISO-8601-UTC>\` via ` +
-			`\`gh api repos/$REPO/issues/${issue}/comments\`; (4) detect-and-tiebreak: the winner is the EARLIEST authorized claim ` +
-			`(min created_at, then min comment id) — empty authorized set ⇒ no winner (fail-closed); recognize ownership by comparing that ` +
-			`winning claim's embedded session id to your TOKEN; (5) if the winner is NOT you, RETRACT your own claim comment, self-unassign, ` +
-			`and return { won: false, token: "", reason: "lost the claim tiebreak to an earlier authorized claim" }. ` +
-			`On a confirmed win return { won: true, token: "<TOKEN>", reason: "" }.`,
+			`(2) self-assign (the coarse availability gate, §7 layer one) via ` +
+			`\`gh api -X POST repos/$REPO/issues/${issue}/assignees\`; ` +
+			`(3) claim through the SHARED VERB — run \`pipeline-cli tracker claim ${issue}\`, which owns the whole write: ` +
+			`Rule-0 defer to a pre-existing authorized owner without posting, the comment POST with the ADR-0191 PRESENCE STAMP ` +
+			`(hand-rolling a \`claim:\` body skips the stamp and leaves the lane's claim unprobeable forever — #3987), the ` +
+			`checkpoint-GET earliest-authorized-claim tiebreak, and retract-our-own-claim-on-loss. Exit 0 = the claim is ours; ` +
+			`(4) on a NON-ZERO exit, self-unassign and return { won: false, token: "", reason: "<the verb's stderr back-off reason>" }. ` +
+			`Do NOT hand-roll the claim POST or re-derive the tiebreak jq. On a confirmed win (exit 0) return { won: true, token: "<TOKEN>", reason: "" }.`,
 		{
 			schema: {
 				type: "object",

--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -232,13 +232,15 @@ async function drive() {
 			`\${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}. Procedure: ` +
 			`(1) read your own claim token TOKEN="$CLAUDE_CODE_SESSION_ID" — if it is empty, ABORT (fail-closed, ADR 0115 §"Trust + fail-closed") ` +
 			`and return { won: false, token: "", reason: "no CLAUDE_CODE_SESSION_ID — cannot post an agent-distinguishable claim" }; ` +
-			`(2) self-assign (the coarse availability gate, §7 layer one) via ` +
-			`\`gh api -X POST repos/$REPO/issues/${issue}/assignees\`; ` +
-			`(3) claim through the SHARED VERB — run \`pipeline-cli tracker claim ${issue}\`, which owns the whole write: ` +
+			`(2) claim through the SHARED VERB FIRST — run \`pipeline-cli tracker claim ${issue}\`, which owns the whole write: ` +
 			`Rule-0 defer to a pre-existing authorized owner without posting, the comment POST with the ADR-0191 PRESENCE STAMP ` +
 			`(hand-rolling a \`claim:\` body skips the stamp and leaves the lane's claim unprobeable forever — #3987), the ` +
 			`checkpoint-GET earliest-authorized-claim tiebreak, and retract-our-own-claim-on-loss. Exit 0 = the claim is ours; ` +
-			`(4) on a NON-ZERO exit, self-unassign and return { won: false, token: "", reason: "<the verb's stderr back-off reason>" }. ` +
+			`(3) on a NON-ZERO exit, mutate NOTHING — you never assigned, so there is nothing to undo, and you must NEVER unassign ` +
+			`a slot you did not fill: every agent authenticates as the SAME login, so a cleanup unassign here would strip the LIVE ` +
+			`incumbent's assignment (#4015) — return { won: false, token: "", reason: "<the verb's stderr back-off reason>" }; ` +
+			`(4) ONLY on exit 0, self-assign (the coarse availability gate, §7 layer one) via ` +
+			`\`gh api -X POST repos/$REPO/issues/${issue}/assignees\`. ` +
 			`Do NOT hand-roll the claim POST or re-derive the tiebreak jq. On a confirmed win (exit 0) return { won: true, token: "<TOKEN>", reason: "" }.`,
 		{
 			schema: {

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2623,14 +2623,23 @@ claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC> · presence <machine-fingerpri
   is not unique to one machine, and no machine identity belongs in a public timeline. It exists so
   a later reader can *probe* this claimant's liveness instead of guessing — see
   [Dead-claimant supersession](#dead-claimant-supersession-proven-death-only-adr-0191). It is
-  written by `pipeline-cli tracker claim` and is **optional**: an unresolvable session — or an
-  unresolvable machine identity — stamps nothing, and an unstamped marker reads as indeterminate
-  (⇒ still a valid owner), so legacy markers keep their exact old meaning.
+  **optional**: an unresolvable session — or an unresolvable machine identity — stamps nothing,
+  and an unstamped marker reads as indeterminate (⇒ still a valid owner), so legacy markers keep
+  their exact old meaning. Optional-per-marker is **not** optional-per-writer, though: a writer
+  that never stamps makes every claim it posts permanently indeterminate, which silently switches
+  supersession off for that whole lane while the mechanism looks fixed (#3987). So the stamp is
+  emitted by **one producer** and every writer routes through it — the write surface below.
 - **Token source:** the claiming process's `CLAUDE_CODE_SESSION_ID` environment variable
   (the orchestrator's when it claims pre-spawn; the coder's when `write-code` is invoked
   directly — see §The pre-spawn claim protocol).
-- **Write surface:** an issue comment, posted via `gh api repos/$REPO/issues/{N}/comments`
-  (REST, never GraphQL): `gh api repos/$REPO/issues/<N>/comments -f "body=claim: $CLAUDE_CODE_SESSION_ID · $(date -u +%Y-%m-%dT%H:%M:%SZ)"`.
+- **Write surface — the shared verb, never a hand-rolled `gh api`.** Post the claim with
+  `pipeline-cli tracker claim <N>` (`--session <token>` to claim under a threaded/delegated
+  token). The verb owns the whole write: Rule-0 defer to a pre-existing authorized owner, the
+  comment POST with the presence stamp composed by the single producer, the checkpoint-GET
+  tiebreak, and retract-our-own-claim-on-loss. **Exit 0 = the claim is ours, non-zero = backed
+  off, do not mutate.** Never compose a `claim:` body by hand — a hand-rolled marker skips the
+  stamp (see the bullet above), and `pipeline-cli adoption-lint check` reds a corpus file that
+  re-derives this write instead of citing the verb.
 - **Read surface — the canonical `CLAIM_RE`.** A claim comment is matched by this **one**
   anchored, case-insensitive, emphasis-tolerant regex; every consumer cites it and **none
   re-hard-codes the grammar** (it pairs with §5/§6's marker-matcher discipline):
@@ -2732,8 +2741,9 @@ so closing it means claiming before any branch, build, or spawn:
 
 - **Orchestrated path (the common case).** `.claude/workflows/drive-issue.js` acquires the
   claim in a pre-step **before** the `agent(coder, …)` dispatch (delegated to a thin
-  claim-only agent that runs this §7 primitive verbatim): self-assign, post the claim
-  comment, run the tiebreak, and **only on a win spawn the coder**, threading the winning
+  claim-only agent that runs this §7 primitive verbatim): self-assign, then
+  `pipeline-cli tracker claim <N>` (the write surface above — defer, post the stamped marker,
+  tiebreak, retract on loss), and **only on a win spawn the coder**, threading the winning
   claim **token** into the coder's prompt. On a lost claim it aborts the dispatch — no coder
   spawns.
 - **Delegated ownership.** The orchestrator and the coder are distinct sessions (the spawned
@@ -2776,6 +2786,15 @@ against a *resolved* local machine fingerprint, and a pid the probe proves gone.
 is **indeterminate and counts as a live claim**: an unstamped/legacy marker, a claim stamped on
 another machine, a machine identity this reader cannot resolve, a pid that still resolves, and a
 reused pid all leave the claim standing, so the reader refuses. Doubt refuses; it never evicts.
+
+**Liveness is same-host by construction — the honest limit.** The probe is a local pid probe, so
+a claim stamped on another machine is unprobeable and stays indeterminate ⇒ it stands and the
+reader refuses. That is the correct fail-closed direction, but it means a multi-host crew gets no
+supersession at all: every claim it reads was stamped elsewhere. Closing *that* needs a
+host-independent liveness source — the crew tracker's own presence keyspace (ADR 0191 proper,
+#3938 / epic #3766), whose cross-keyspace reconciliation is where it belongs. Explicitly **out of
+scope** for this GitHub-claim keyspace: do not "fix" the multi-host case by treating an
+unprobeable claim as dead, which trades a stuck lane for live-claim eviction.
 
 Both the resolution and the probe live in the shared verb — `pipeline-cli claim is-mine`
 (default-deny) and `pipeline-cli tracker claim` (which also stops deferring to a dead claimant,

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2713,18 +2713,33 @@ old design used. The race-case derivation transfers and is *strengthened* (ADR 0
   straggler-evicts-owner tension the old `min(login)` needed a separate non-revocability
   argument to close — a lower login could belong to a later arrival; a lower comment id
   cannot.
-- **Transient window.** As before, the assignee field may transiently show two assignees and
-  the comments two claims before a loser retracts; the picker skips on **any non-null
-  assignee**, so a transiently double-claimed issue is passed over, never double-picked (safe
-  degradation).
+- **Transient window.** The comments may transiently carry two claims before a loser retracts,
+  and — because the assignment lands only *after* a won claim (below) — a won-but-not-yet-assigned
+  issue is briefly still unassigned. Both degrade safely: the picker skips on **any non-null
+  assignee**, so a transiently double-claimed issue is passed over rather than double-picked, and
+  an agent that picks the still-unassigned issue in the other window runs the claim verb and
+  defers to the earlier claim.
 
 This remains **detect-and-tiebreak, not a kernel mutex** (the epic's honest non-goal): the
 comment/assignee APIs offer no conditional write, so true single-writer exclusion is off the
 table. The guarantee is the one that matters — of any set of co-window racers, exactly one
-proceeds, deterministically, and every loser self-retracts its claim comment (and any
-self-assignee) and re-picks. Don't reintroduce the "it's the lock" framing, and **never fall
-back to the bare assignee login as an ownership signal** — that is the degeneracy ADR 0115
-removes.
+proceeds, deterministically, and every loser self-retracts its claim comment and re-picks.
+Don't reintroduce the "it's the lock" framing, and **never fall back to the bare assignee login
+as an ownership signal** — that is the degeneracy ADR 0115 removes.
+
+<a id="claim-before-you-assign-a-defer-must-not-strip-the-incumbent"></a>
+### Claim before you assign — a defer must not strip the incumbent
+
+The two layers are written in **one order: claim first, assign only on the verb's exit 0.** Every
+pipeline agent authenticates as the **same login**, so the assignee is not a per-agent slot — it is
+**one shared slot**. Assign-then-claim therefore has no safe back-off: the arriving agent's
+self-assign is a no-op on an already-held lane (the slot already shows that login), the verb
+correctly defers to the live incumbent, and the arriving agent's cleanup unassign then removes the
+**incumbent's** assignment while the incumbent is still working — silently clearing the coarse
+availability gate on an issue that is legitimately held (#4015). Claiming first makes that state
+unrepresentable rather than merely handled: a deferring agent never assigned, so it has nothing to
+undo and mutates nothing. The rule for every writer, stated once here: **never unassign a slot you
+did not fill.**
 
 ### Fail-closed on a missing token
 
@@ -2741,11 +2756,11 @@ so closing it means claiming before any branch, build, or spawn:
 
 - **Orchestrated path (the common case).** `.claude/workflows/drive-issue.js` acquires the
   claim in a pre-step **before** the `agent(coder, …)` dispatch (delegated to a thin
-  claim-only agent that runs this §7 primitive verbatim): self-assign, then
-  `pipeline-cli tracker claim <N>` (the write surface above — defer, post the stamped marker,
-  tiebreak, retract on loss), and **only on a win spawn the coder**, threading the winning
+  claim-only agent that runs this §7 primitive verbatim): `pipeline-cli tracker claim <N>`
+  (the write surface above — defer, post the stamped marker, tiebreak, retract on loss), then
+  **self-assign only on a win**, and **only on a win spawn the coder**, threading the winning
   claim **token** into the coder's prompt. On a lost claim it aborts the dispatch — no coder
-  spawns.
+  spawns, and it leaves the assignee untouched (see [Claim before you assign](#claim-before-you-assign-a-defer-must-not-strip-the-incumbent)).
 - **Delegated ownership.** The orchestrator and the coder are distinct sessions (the spawned
   coder carries `CLAUDE_CODE_CHILD_SESSION=1` and its own id), so the claim token is
   **whoever posted the claim** — the orchestrator. The orchestrator threads its token to the

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -440,19 +440,23 @@ if [ -z "$CLAUDE_CODE_SESSION_ID" ]; then
   exit 0   # → re-run Step 1
 fi
 
-# 1. Self-assign — the coarse availability gate the Step-1 picker reads (§7 layer one).
-ME=$(gh api user --jq '.login')
-gh api -X POST repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" >/dev/null
-
-# 2. Claim through the verb — layer two, the fine agent-distinguishable resolver. It defers to a
-#    pre-existing authorized owner WITHOUT posting, posts a PRESENCE-STAMPED marker under
+# 1. Claim through the verb FIRST — layer two, the fine agent-distinguishable resolver. It defers
+#    to a pre-existing authorized owner WITHOUT posting, posts a PRESENCE-STAMPED marker under
 #    $CLAUDE_CODE_SESSION_ID, re-reads canonical state, and retracts its OWN claim if it lost.
-#    Exit 0 = the claim is mine; non-zero = backed off ⇒ self-unassign and re-pick.
+#    Exit 0 = the claim is mine; non-zero = backed off, having mutated nothing that is not ours.
 if ! pipeline-cli tracker claim <N>; then
-  gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" >/dev/null 2>&1
   echo "did not win the claim on #$N (held by another agent, or lost the tiebreak) — back off, re-pick."
   exit 0   # → re-run Step 1
 fi
+
+# 2. ONLY NOW self-assign — the coarse availability gate the Step-1 picker reads (§7 layer one).
+#    Defer-then-assign is load-bearing, not stylistic: every agent authenticates as the SAME login,
+#    so the assignee is ONE shared slot. Assigning first would make the back-off above a cleanup
+#    unassign that strips the LIVE incumbent's assignment — clearing the coarse gate on an issue
+#    someone else legitimately holds. Claiming first removes the cleanup entirely: we only ever
+#    assign on a won claim, so there is no assignment of ours to undo (#4015).
+ME=$(gh api user --jq '.login')
+gh api -X POST repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" >/dev/null
 # claim won and confirmed (earliest authorized claim is mine) — proceed to implement
 ```
 
@@ -463,10 +467,12 @@ staggered co-racers proceed, a double-pick). The winner is the **earliest author
 `created_at`, then min comment `id`) whose claimant is not provably dead, recognized because its
 embedded session id equals your `CLAUDE_CODE_SESSION_ID`; because earliest-claim-wins, Rule 0
 (defer to a pre-existing owner) and the tiebreak are **the same fact**. Every loser retracts its
-**own** claim comment and self-unassigns, then re-picks — never co-occupy, and **never** delete
-another agent's claim or fall back to the login-keyed assignee as ownership. This is
-**detect-and-tiebreak, not a lock**; the residual transient 2-assignee / 2-claim window is
-tolerated by Step 1's "skip on any non-null assignee."
+**own** claim comment (the verb's own last act) and, having claimed before assigning, has no
+assignment to undo — it just re-picks. Never co-occupy, and **never** delete another agent's claim,
+**never** unassign a slot you did not fill, and never fall back to the login-keyed assignee as
+ownership. This is **detect-and-tiebreak, not a lock**; the residual transient window — a claim
+already posted while the assignee is not yet set — is tolerated, because an agent that picks the
+still-unassigned issue in that window runs the verb and defers to the earlier claim.
 
 See [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 for the canonical
 `CLAIM_RE`, the full write+-ACL resolution snippet, the staggered-co-racer / straggler / transient

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -425,36 +425,32 @@ session id must equal the threaded token — then proceed straight to implementi
 When `write-code` is invoked directly (no threaded token), make the claim here, before you
 branch or build, using your own `CLAUDE_CODE_SESSION_ID` as the token:
 
+The whole claim-comment write — Rule-0 defer, the POST, the checkpoint-GET tiebreak, and
+retract-on-loss — is owned by **one verb**, `pipeline-cli tracker claim` (§7's write surface).
+Run it; never hand-roll a `claim:` body, which silently skips the ADR-0191 presence stamp and
+leaves this lane's claim permanently unprobeable (#3987):
+
 ```bash
 # 0. Fail-closed on a missing token: the claim comment is the ONLY agent-distinguishable signal
 #    under the shared `usirin` login — with no token a co-racer is unresolvable, so NEVER claim
 #    (and never fall back to the login-keyed assignee as ownership — that is the §7 degeneracy).
+#    The verb enforces this too (it backs off on an empty session), so this is a fast local exit.
 if [ -z "$CLAUDE_CODE_SESSION_ID" ]; then
   echo "no CLAUDE_CODE_SESSION_ID in env — cannot post an agent-distinguishable claim. BACK OFF, re-pick." >&2
   exit 0   # → re-run Step 1
 fi
-CLAIM_RE='(?i)^\s*\**\s*claim:\s*[0-9a-f-]{36}\b'   # the §7 single source — cited, not re-derived
 
-# 1. Rule-0 defer: if an AUTHORIZED claim from a DIFFERENT session already owns #N, back off
-#    WITHOUT posting (a fresh arrival never evicts a pre-existing owner; §7). Resolve the current
-#    earliest-authorized-claim session per §7 (CLAIM_RE + write+ ACL + min(created_at, id)); call it WINSID0.
-[ -n "$WINSID0" ] && [ "$WINSID0" != "$CLAUDE_CODE_SESSION_ID" ] && { echo "#$N already claimed by another agent — back off, re-pick."; exit 0; }
-
-# 2. Self-assign (the coarse availability gate), then POST the claim comment (the fine resolver).
+# 1. Self-assign — the coarse availability gate the Step-1 picker reads (§7 layer one).
 ME=$(gh api user --jq '.login')
 gh api -X POST repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" >/dev/null
-MYCLAIM=$(gh api repos/$REPO/issues/<N>/comments \
-  -f "body=claim: $CLAUDE_CODE_SESSION_ID · $(date -u +%Y-%m-%dT%H:%M:%SZ)" --jq .id)
-[ -n "$MYCLAIM" ] || { echo "failed to post claim on #$N — back off, re-pick." >&2; gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME"; exit 0; }
 
-# 3. Checkpoint GET — resolve co-racers to ONE winner: the EARLIEST AUTHORIZED claim wins (§7).
-#    Re-run §7's canonical resolution against #N to get WINSID (its embedded session id).
-#    Proceed to implement IFF the earliest authorized claim is mine; else RETRACT my own claim
-#    comment AND self-unassign, then re-pick (never co-occupy, never delete another agent's claim).
-if [ "$WINSID" != "$CLAUDE_CODE_SESSION_ID" ]; then
-  gh api -X DELETE repos/$REPO/issues/comments/$MYCLAIM >/dev/null 2>&1
+# 2. Claim through the verb — layer two, the fine agent-distinguishable resolver. It defers to a
+#    pre-existing authorized owner WITHOUT posting, posts a PRESENCE-STAMPED marker under
+#    $CLAUDE_CODE_SESSION_ID, re-reads canonical state, and retracts its OWN claim if it lost.
+#    Exit 0 = the claim is mine; non-zero = backed off ⇒ self-unassign and re-pick.
+if ! pipeline-cli tracker claim <N>; then
   gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" >/dev/null 2>&1
-  echo "lost the claim tiebreak on #$N to an earlier authorized claim — back off, re-pick."
+  echo "did not win the claim on #$N (held by another agent, or lost the tiebreak) — back off, re-pick."
   exit 0   # → re-run Step 1
 fi
 # claim won and confirmed (earliest authorized claim is mine) — proceed to implement
@@ -462,14 +458,15 @@ fi
 
 **The operating rule.** Posting the claim comment **detects** a race; the **checkpoint GET**
 (re-reading the issue's comments and resolving the earliest authorized claim per §7) **resolves**
-it — keep it, never prune it as "redundant" (without it both staggered co-racers proceed, a
-double-pick). The winner is the **earliest authorized claim** (min `created_at`, then min comment
-`id`), recognized because its embedded session id equals your `CLAUDE_CODE_SESSION_ID`; because
-earliest-claim-wins, Rule 0 (defer to a pre-existing owner) and the tiebreak are **the same
-fact**. Every loser retracts its **own** claim comment and self-unassigns, then re-picks — never
-co-occupy, and **never** delete another agent's claim or fall back to the login-keyed assignee as
-ownership. This is **detect-and-tiebreak, not a lock**; the residual transient 2-assignee /
-2-claim window is tolerated by Step 1's "skip on any non-null assignee."
+it — the verb does both, and neither leg is prunable as "redundant" (without the checkpoint both
+staggered co-racers proceed, a double-pick). The winner is the **earliest authorized claim** (min
+`created_at`, then min comment `id`) whose claimant is not provably dead, recognized because its
+embedded session id equals your `CLAUDE_CODE_SESSION_ID`; because earliest-claim-wins, Rule 0
+(defer to a pre-existing owner) and the tiebreak are **the same fact**. Every loser retracts its
+**own** claim comment and self-unassigns, then re-picks — never co-occupy, and **never** delete
+another agent's claim or fall back to the login-keyed assignee as ownership. This is
+**detect-and-tiebreak, not a lock**; the residual transient 2-assignee / 2-claim window is
+tolerated by Step 1's "skip on any non-null assignee."
 
 See [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 for the canonical
 `CLAIM_RE`, the full write+-ACL resolution snippet, the staggered-co-racer / straggler / transient

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
@@ -4,6 +4,7 @@ import {
 	mkdirSync,
 	mkdtempSync,
 	readdirSync,
+	readFileSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -97,6 +98,31 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", () => {
 		assert.strictEqual(code, 0, `adoption-lint red on the live corpus:\n${stdout}\n${stderr}`);
 		assert.include(stdout, "clean");
 	}, 60_000);
+
+	// #3987: the corpus-side half of "every claim writer stamps presence". A writer that composes a
+	// `claim:` body by hand skips the ADR-0191 stamp, and an unstamped marker is indeterminate
+	// forever ⇒ supersession goes inert on that lane while the mechanism looks fixed. The declared
+	// `tracker claim` decision reds a NEW such writer; this pins the three that already exist.
+	it("every claim-marker writer cites `pipeline-cli tracker claim` and hand-composes no body", () => {
+		const writers = [
+			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+			"claude-plugins/kampus-pipeline/skills/write-code/SKILL.md",
+			".claude/workflows/drive-issue.js",
+		];
+		for (const rel of writers) {
+			const content = readFileSync(join(REPO_ROOT, rel), "utf8");
+			assert.match(
+				content,
+				/pipeline-cli\s+tracker\s+claim\b/,
+				`${rel} must cite the claim-write verb`,
+			);
+			assert.notMatch(
+				content,
+				/body=["'`]?claim:/,
+				`${rel} must not hand-compose a claim-marker body (it would skip the presence stamp)`,
+			);
+		}
+	});
 
 	it("exits 3 (zero-scope FAIL) when every handed file is unreadable/missing", async () => {
 		const {code, stderr} = await run(["check", join(dir, "does-not-exist.md")]);

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
@@ -44,6 +44,14 @@ const RE_DERIVATION = [
 	"jq 'sort_by(.created_at) | last'",
 ].join("\n");
 
+// The closed set of claim-marker writer surfaces — the procedure texts that post a `claim:`
+// comment (#3987) and, on the self-assigning ones, order it against the assignee (#4015).
+const CLAIM_WRITERS = [
+	"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+	"claude-plugins/kampus-pipeline/skills/write-code/SKILL.md",
+	".claude/workflows/drive-issue.js",
+];
+
 // The full live corpus the adoption-lint.yml job scans: every .md/.sh under the plugin
 // dir plus the orchestrator's drive-issue.js (the declared mirror).
 const corpusFiles = (): string[] => {
@@ -104,12 +112,7 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", () => {
 	// forever ⇒ supersession goes inert on that lane while the mechanism looks fixed. The declared
 	// `tracker claim` decision reds a NEW such writer; this pins the three that already exist.
 	it("every claim-marker writer cites `pipeline-cli tracker claim` and hand-composes no body", () => {
-		const writers = [
-			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
-			"claude-plugins/kampus-pipeline/skills/write-code/SKILL.md",
-			".claude/workflows/drive-issue.js",
-		];
-		for (const rel of writers) {
+		for (const rel of CLAIM_WRITERS) {
 			const content = readFileSync(join(REPO_ROOT, rel), "utf8");
 			assert.match(
 				content,
@@ -120,6 +123,40 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", () => {
 				content,
 				/body=["'`]?claim:/,
 				`${rel} must not hand-compose a claim-marker body (it would skip the presence stamp)`,
+			);
+		}
+	});
+
+	// #4015: the occupied-lane scenario. An arriving agent that meets a LIVE incumbent must defer
+	// AND leave the incumbent's assignment intact — but every agent authenticates as the same
+	// login, so the assignee is ONE shared slot. Assign-then-claim gives the defer path no safe
+	// back-off: the self-assign is a no-op (the slot already shows that login), the verb defers,
+	// and the cleanup unassign then removes the INCUMBENT's assignment. Pin the only ordering that
+	// makes that unrepresentable — claim first, assign only on the verb's exit 0, never unassign.
+	it("claims before it self-assigns, so a defer cannot strip a live incumbent's assignment", () => {
+		// scope: the writers whose procedure actually issues the self-assign (a surface that only
+		// describes the claim has no ordering to pin). Fail closed on zero scope (ADR 0092).
+		const selfAssigning = CLAIM_WRITERS.map((rel) => ({
+			rel,
+			content: readFileSync(join(REPO_ROOT, rel), "utf8"),
+		})).filter(({content}) => /gh api -X POST[^\n]*\/assignees/.test(content));
+		assert.isAbove(selfAssigning.length, 0, "expected at least one self-assigning claim writer");
+
+		for (const {rel, content} of selfAssigning) {
+			// the verb INVOCATION (verb + its issue argument), not a prose mention of the verb —
+			// a citation earlier in the file must not satisfy an ordering claim about the procedure.
+			const claimAt = content.search(/pipeline-cli\s+tracker\s+claim\s+(?:<N>|\$\{issue\})/);
+			const assignAt = content.search(/gh api -X POST[^\n]*\/assignees/);
+			assert.isAbove(claimAt, -1, `${rel} must invoke the claim-write verb on the issue`);
+			assert.isBelow(
+				claimAt,
+				assignAt,
+				`${rel} must claim BEFORE it self-assigns — assign-then-claim makes the defer path unassign the live incumbent (#4015)`,
+			);
+			assert.notMatch(
+				content,
+				/gh api -X DELETE[^\n]*\/assignees/,
+				`${rel} must not unassign as claim cleanup — under the shared login that slot may be the incumbent's (#4015)`,
 			);
 		}
 	});

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -13,8 +13,9 @@
  * SHA-bound marker-resolution three skills hand-copy (#2102). `tracker apply-triage`
  * (#3263), `tracker post-verdict` (#3265), `tracker graduate` (#3266), and
  * `review-head materialize` (#3690, the §HEAD PR-head-checkout of #793 / #1807) have since
- * landed with their consumer migrations; the remaining envelope decision (claim) arrives
- * with its sibling child.
+ * landed with their consumer migrations. The claim keyspace is declared as **both** halves —
+ * `claim is-mine` for the resolution (#3687) and `tracker claim` for the write (#3987) — since a
+ * hand-rolled claim WRITE is what silently un-stamps a lane's marker.
  */
 import type {Exemption, OwnedDecision} from "./adoption-lint.ts";
 
@@ -177,6 +178,26 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		citation: /pipeline-cli\s+claim\b/,
 		reason:
 			"re-derives the ADR-0115 earliest-authorized-claim resolution that `pipeline-cli claim is-mine` owns (resolve one owner by earliest authorized claim, default-deny), instead of citing the verb (#3687 / #3254)",
+	},
+	{
+		// `tracker claim` owns the claim-marker WRITE (#3987) — the other half of the §7 primitive
+		// from `claim is-mine`'s resolution: defer, POST a PRESENCE-STAMPED `claim:` marker,
+		// checkpoint-GET, retract-own-on-loss. A hand-rolled body is not merely duplication here: it
+		// silently omits the ADR-0191 stamp, and an unstamped marker reads indeterminate ⇒ the claim
+		// stands ⇒ dead-claimant supersession is inert on that lane while looking fixed. The
+		// fingerprint is the co-occurrence of composing a marker with a LIVE token (`body=claim:`, or
+		// `claim: $CLAUDE_CODE_SESSION_ID` / `claim: <TOKEN>`) and the comments endpoint it is posted
+		// to — so §7's grammar block (`claim: <CLAUDE_CODE_SESSION_ID>`, a placeholder, no live token)
+		// and every prose mention of the marker are not false findings. A file that cites
+		// `pipeline-cli tracker claim` is compliant.
+		verb: "tracker claim",
+		signature: [
+			/body=["'`]?claim:|claim:\s*(?:\$CLAUDE_CODE_SESSION_ID|<TOKEN>|\$\{?(?:TOKEN|sessionId)\}?)/,
+			/\/comments/, // posted to the comments endpoint
+		],
+		citation: /pipeline-cli\s+tracker\s+claim\b/,
+		reason:
+			"hand-composes the ADR-0115 claim marker that `pipeline-cli tracker claim` owns (defer, POST the presence-stamped marker, checkpoint tiebreak, retract-own-on-loss), instead of citing the verb — a hand-rolled body skips the ADR-0191 presence stamp, so the claim reads indeterminate forever and dead-claimant supersession goes inert on that lane (#3987 / #3751)",
 	},
 	{
 		// `checks read` owns the head-CI rollup (#3762): read a SHA's check runs LATEST-PER-CONTEXT

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-writer.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-writer.ts
@@ -1,0 +1,31 @@
+/**
+ * The single stamped-claim-marker producer — every claim writer composes its body here (#3987).
+ *
+ * `claim-resolution.ts` owns the marker grammar and `claim-presence.ts` the stamp's shape, but
+ * the *composition* of the two — read this run's session presence, append it when it resolved,
+ * omit it when it did not — was re-derived per writer, so exactly one writer stamped and the
+ * others posted unstampable markers. An unstamped marker reads indeterminate, and indeterminate
+ * counts as a live owner, so dead-claimant supersession (ADR 0191 liveness, #3751) was inert on
+ * every lane those writers claimed. Routing all of them through one producer is what makes
+ * liveness evaluable regardless of which path wrote the claim; the fail-closed direction is
+ * untouched — an unstamped legacy marker still stands.
+ *
+ * `presence` is a parameter with a live default rather than an internal read, so the OS boundary
+ * (`presence-io.ts`) is injectable at a writer's edge: that is what lets each writer's own test
+ * prove it stamps, on a machine (CI) where no session process resolves.
+ *
+ * Stamping makes liveness *evaluable*, not universal: the probe is local, so a marker stamped on
+ * another machine stays indeterminate and its claim stands. The host-independent signal is the
+ * crew tracker's presence keyspace (#3938 / epic #3766), out of scope here — see
+ * gh-issue-intake-formats.md §7 "Liveness is same-host by construction".
+ */
+import {type ClaimPresence, formatClaimPresence} from "./claim-presence.ts";
+import {claimCommentBody} from "./claim-resolution.ts";
+import {currentSessionPresence} from "./presence-io.ts";
+
+export const stampedClaimBody = (
+	session: string,
+	at: string,
+	presence: ClaimPresence | null = currentSessionPresence(),
+): string =>
+	claimCommentBody(session, at, presence === null ? null : formatClaimPresence(presence));

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-writer.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-writer.unit.test.ts
@@ -1,0 +1,98 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	claimLiveness,
+	type LocalPresence,
+	livenessByComment,
+	type PidState,
+	parseClaimPresence,
+} from "./claim-presence.ts";
+import {CLAIM_RE, type ClaimComment, resolveWinner} from "./claim-resolution.ts";
+import {stampedClaimBody} from "./claim-writer.ts";
+
+const SID_DEAD = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_LATER = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const AUTHORIZED = ["usirin"];
+
+const local = (host: string, states: Record<number, PidState>): LocalPresence => ({
+	host,
+	probePid: (pid) => states[pid] ?? "unprobeable",
+});
+
+const comment = (id: number, createdAt: string, body: string): ClaimComment => ({
+	id,
+	author: "usirin",
+	createdAt,
+	body,
+});
+
+describe("stampedClaimBody — the single producer every claim writer composes through (#3987)", () => {
+	it("stamps the presence it is handed, in the canonical marker grammar", () => {
+		const body = stampedClaimBody(SID_DEAD, "2026-07-25T06:42:00Z", {host: "box-1", pid: 4242});
+		assert.match(body, CLAIM_RE);
+		assert.deepStrictEqual(parseClaimPresence(body), {host: "box-1", pid: 4242});
+	});
+
+	it("omits the stamp when no session presence resolved — a legacy-shaped marker, not a wrong one", () => {
+		const body = stampedClaimBody(SID_DEAD, "2026-07-25T06:42:00Z", null);
+		assert.match(body, CLAIM_RE);
+		assert.strictEqual(parseClaimPresence(body), null);
+	});
+});
+
+describe("a stamped marker is what makes supersession reachable at all (#3987 / #3751)", () => {
+	// The end-to-end fact the writers' stamping buys: a marker COMPOSED BY A WRITER, read back by
+	// the resolver, drops out of the tiebreak once its session process is provably gone — which is
+	// what unsticks a lane whose claimant died. Before this, only `tracker claim` produced a marker
+	// this could ever be true of; a claim from any other writer was permanently indeterminate.
+	const deadClaim = comment(
+		10,
+		"2026-07-25T06:00:00Z",
+		stampedClaimBody(SID_DEAD, "2026-07-25T06:00:00Z", {host: "box-1", pid: 4242}),
+	);
+	const laterClaim = comment(
+		20,
+		"2026-07-25T07:00:00Z",
+		stampedClaimBody(SID_LATER, "2026-07-25T07:00:00Z", {host: "box-1", pid: 5150}),
+	);
+	const comments = [deadClaim, laterClaim];
+
+	it("supersedes the dead claimant's earlier marker → the later live claim owns the lane", () => {
+		const liveness = livenessByComment(comments, local("box-1", {4242: "gone", 5150: "running"}));
+		assert.strictEqual(resolveWinner(comments, AUTHORIZED, liveness)?.session, SID_LATER);
+	});
+
+	it("leaves the earlier claim standing while its claimant is alive (doubt never evicts)", () => {
+		const liveness = livenessByComment(
+			comments,
+			local("box-1", {4242: "running", 5150: "running"}),
+		);
+		assert.strictEqual(resolveWinner(comments, AUTHORIZED, liveness)?.session, SID_DEAD);
+	});
+});
+
+describe("an unstamped legacy claim still STANDS — fail-closed is unchanged (#3987)", () => {
+	// The load-bearing non-regression: making presence PRESENT is the fix; making an unstamped claim
+	// supersedable would trade a stuck lane for live-claim eviction. An unstamped marker reads
+	// indeterminate on every path — even one whose pid, coincidentally, is provably gone.
+	const legacy = comment(
+		10,
+		"2026-07-25T06:00:00Z",
+		stampedClaimBody(SID_DEAD, "2026-07-25T06:00:00Z", null),
+	);
+	const later = comment(
+		20,
+		"2026-07-25T07:00:00Z",
+		stampedClaimBody(SID_LATER, "2026-07-25T07:00:00Z", {host: "box-1", pid: 5150}),
+	);
+	const comments = [legacy, later];
+
+	it("resolves indeterminate, so the legacy claim keeps winning the tiebreak", () => {
+		assert.strictEqual(
+			claimLiveness(parseClaimPresence(legacy.body), local("box-1", {})),
+			"unknown",
+		);
+		const liveness = livenessByComment(comments, local("box-1", {4242: "gone", 5150: "running"}));
+		assert.isFalse(liveness.has(legacy.id), "an unstamped claim must record no liveness at all");
+		assert.strictEqual(resolveWinner(comments, AUTHORIZED, liveness)?.session, SID_DEAD);
+	});
+});

--- a/packages/pipeline-cli/src/tools/epic-lock/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/github-service.unit.test.ts
@@ -1,6 +1,8 @@
 import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
 import {Effect, Layer, Sink, Stream} from "effect";
 import {ChildProcessSpawner} from "effect/unstable/process";
+import {parseClaimPresence} from "./claim-presence.ts";
+import {CLAIM_RE} from "./claim-resolution.ts";
 import {GhCommandError, Github, GithubLive, type RepoResolutionError} from "./github.ts";
 
 // The live layer resolves its repo lazily (ADR 0062 §1); pin the env override so the
@@ -39,6 +41,9 @@ const methodOf = (args: ReadonlyArray<string>): string => {
  */
 const mockSpawner = (
 	responses: Record<string, Response>,
+	// Every `-f body=…` sent, in order — what proves WHAT the lock posted, not just that it posted
+	// (an unstamped claim marker is a well-formed claim no reader can ever probe; #3987).
+	bodies?: Array<string>,
 ): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
 	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
 		ChildProcessSpawner.make(
@@ -49,6 +54,9 @@ const mockSpawner = (
 				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
 				const path = rawPath.replace(/\?.*$/, "");
 				const key = `${methodOf(args)} ${path}`;
+				for (const arg of args) {
+					if (arg.startsWith("body=")) bodies?.push(arg.slice("body=".length));
+				}
 				// key on PRESENCE, not truthiness: a DELETE fixture maps to "" (empty stdout),
 				// which is falsy — a truthiness check would mis-route it to the not-found branch.
 				const canned =
@@ -196,6 +204,50 @@ describe("Github.acquire — the two-layer lock over a mock gh spawner", () => {
 				},
 			}),
 		),
+	);
+});
+
+// #3987: the planning lock's claim used to be the one writer that hand-concatenated its marker, so
+// it posted an unstampable claim. Assert the posted BODY now carries the stamp.
+describe("Github.acquire — the claim marker carries the presence stamp (#3987)", () => {
+	const cleanWin: Record<string, Response> = {
+		[`GET ${P}/issues/${EPIC}`]: JSON.stringify([]),
+		[`POST ${P}/issues/${EPIC}/labels`]: "[]",
+		[`POST ${P}/issues/${EPIC}/comments`]: "700",
+		[`GET ${P}/issues/${EPIC}/comments`]: JSON.stringify([
+			claimComment({id: 700, login: "usirin", session: SID_MINE}),
+		]),
+		[`GET ${P}/collaborators/usirin/permission`]: "write",
+	};
+
+	it.effect("stamps the injected session presence onto the marker it posts", () =>
+		Effect.gen(function* () {
+			const bodies: string[] = [];
+			yield* Effect.provide(
+				Effect.flatMap(Github, (github) =>
+					github.acquire(EPIC, SID_MINE, {host: "box-1", pid: 4242}),
+				),
+				GithubLive.pipe(Layer.provide(mockSpawner(cleanWin, bodies))),
+			);
+			const posted = bodies.at(0) ?? "";
+			assert.match(posted, CLAIM_RE, "the posted body must be a canonical claim marker");
+			assert.deepStrictEqual(parseClaimPresence(posted), {host: "box-1", pid: 4242});
+		}),
+	);
+
+	it.effect(
+		"an unresolvable session presence posts a legacy unstamped marker (no wrong stamp)",
+		() =>
+			Effect.gen(function* () {
+				const bodies: string[] = [];
+				yield* Effect.provide(
+					Effect.flatMap(Github, (github) => github.acquire(EPIC, SID_MINE, null)),
+					GithubLive.pipe(Layer.provide(mockSpawner(cleanWin, bodies))),
+				);
+				const posted = bodies.at(0) ?? "";
+				assert.match(posted, CLAIM_RE);
+				assert.strictEqual(parseClaimPresence(posted), null);
+			}),
 	);
 });
 

--- a/packages/pipeline-cli/src/tools/epic-lock/github.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/github.ts
@@ -41,7 +41,9 @@ import {
 	resolveRepo,
 	runGh,
 } from "../tracker/gh-io.ts";
+import type {ClaimPresence} from "./claim-presence.ts";
 import {type ClaimComment, ownClaimCommentIds, resolveWinner} from "./claim-resolution.ts";
+import {stampedClaimBody} from "./claim-writer.ts";
 
 // Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
 // module — the single-source classes now live in `../tracker/gh-io.ts` (#3262 AC 5).
@@ -143,6 +145,7 @@ const acquire = Effect.fn("Github.acquire")(function* (
 	repo: string,
 	epic: number,
 	sessionId: string,
+	presence?: ClaimPresence | null,
 ) {
 	if (yield* labelHeld(repo, epic)) {
 		return {_tag: "held-by-other"} satisfies AcquireResult;
@@ -157,7 +160,12 @@ const acquire = Effect.fn("Github.acquire")(function* (
 	if (labelResult !== "ok") return labelResult;
 
 	const now = new Date().toISOString();
-	const claimResult = yield* json(postCommentArgs(repo, epic, `claim: ${sessionId} · ${now}`)).pipe(
+	// Presence-stamped through the single producer, like every other claim writer (#3987): an
+	// unstamped marker would leave this lock's claimant unprobeable, so an abandoned planning
+	// lock could never be superseded on proven death.
+	const claimResult = yield* json(
+		postCommentArgs(repo, epic, stampedClaimBody(sessionId, now, presence)),
+	).pipe(
 		Effect.map((v): number | AcquireResult =>
 			typeof v === "number"
 				? v
@@ -227,6 +235,8 @@ export class Github extends Context.Service<
 		readonly acquire: (
 			epic: number,
 			sessionId: string,
+			/** The marker's presence stamp; omitted, this run's session presence is read (#3987). */
+			presence?: ClaimPresence | null,
 		) => Effect.Effect<
 			AcquireResult,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
@@ -257,8 +267,8 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
 			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
 			return {
-				acquire: (epic: number, sessionId: string) =>
-					repo.pipe(Effect.flatMap((r) => withSpawner(acquire(r, epic, sessionId)))),
+				acquire: (epic: number, sessionId: string, presence?: ClaimPresence | null) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(acquire(r, epic, sessionId, presence)))),
 				release: (epic: number, sessionId: string) =>
 					repo.pipe(Effect.flatMap((r) => withSpawner(release(r, epic, sessionId)))),
 			};

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -1,6 +1,8 @@
 import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
 import {Effect, Layer, Sink, Stream} from "effect";
 import {ChildProcessSpawner} from "effect/unstable/process";
+import {parseClaimPresence} from "../epic-lock/claim-presence.ts";
+import {CLAIM_RE} from "../epic-lock/claim-resolution.ts";
 import {
 	GhCommandError,
 	GithubTrackerLive,
@@ -49,6 +51,9 @@ const methodOf = (args: ReadonlyArray<string>): string => {
 const mockSpawner = (
 	responses: Record<string, Response>,
 	calls?: Array<string>,
+	// Every `-f body=…` the verb sent, in order — what proves WHAT a writer posted, not just that
+	// it posted (the #3987 regression: an unstamped claim marker is indistinguishable by key alone).
+	bodies?: Array<string>,
 ): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> => {
 	const seen = new Map<string, number>();
 	return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
@@ -64,6 +69,9 @@ const mockSpawner = (
 				const path = rawPath.replace(/\?.*$/, "");
 				const key = `${methodOf(args)} ${path}`;
 				calls?.push(key);
+				for (const arg of args) {
+					if (arg.startsWith("body=")) bodies?.push(arg.slice("body=".length));
+				}
 				const nth = seen.get(key) ?? 0;
 				seen.set(key, nth + 1);
 				const fixture = responses[key];
@@ -97,8 +105,11 @@ const provide = <A, E>(
 	effect: Effect.Effect<A, E, Tracker>,
 	responses: Record<string, Response>,
 	calls?: Array<string>,
+	bodies?: Array<string>,
 ): Effect.Effect<A, E | RepoResolutionError> =>
-	effect.pipe(Effect.provide(GithubTrackerLive.pipe(Layer.provide(mockSpawner(responses, calls)))));
+	effect.pipe(
+		Effect.provide(GithubTrackerLive.pipe(Layer.provide(mockSpawner(responses, calls, bodies)))),
+	);
 
 const TARGET = 900;
 const P = `repos/kamp-us/phoenix`;
@@ -277,6 +288,52 @@ describe("Tracker.claim — the ADR-0115 claim over a mock gh spawner", () => {
 				},
 			}),
 		),
+	);
+});
+
+// #3987: the claim WRITE is what makes liveness evaluable later. Assert the posted BODY, not just
+// that a POST happened — an unstamped marker is a well-formed claim that no reader can ever probe.
+describe("Tracker.claim — the posted marker carries the presence stamp (#3987)", () => {
+	// pre-check GET sees no claim (so we actually POST), then the checkpoint GET sees ours land.
+	const cleanWin: Record<string, Response> = {
+		[`GET ${P}/issues/${TARGET}/comments`]: [
+			JSON.stringify([]),
+			JSON.stringify([claimComment({id: 700, login: "usirin", session: SID_MINE})]),
+		],
+		[`POST ${P}/issues/${TARGET}/comments`]: "700",
+		[`GET ${P}/collaborators/usirin/permission`]: "write",
+	};
+
+	it.effect("stamps the injected session presence onto the marker it posts", () =>
+		Effect.gen(function* () {
+			const bodies: string[] = [];
+			yield* Effect.provide(
+				Effect.flatMap(Tracker, (tracker) =>
+					tracker.claim(TARGET, {session: SID_MINE, presence: {host: "box-1", pid: 4242}}),
+				),
+				GithubTrackerLive.pipe(Layer.provide(mockSpawner(cleanWin, undefined, bodies))),
+			);
+			const posted = bodies.at(0) ?? "";
+			assert.match(posted, CLAIM_RE, "the posted body must be a canonical claim marker");
+			assert.deepStrictEqual(parseClaimPresence(posted), {host: "box-1", pid: 4242});
+		}),
+	);
+
+	it.effect(
+		"an unresolvable session presence posts a legacy unstamped marker (no wrong stamp)",
+		() =>
+			Effect.gen(function* () {
+				const bodies: string[] = [];
+				yield* Effect.provide(
+					Effect.flatMap(Tracker, (tracker) =>
+						tracker.claim(TARGET, {session: SID_MINE, presence: null}),
+					),
+					GithubTrackerLive.pipe(Layer.provide(mockSpawner(cleanWin, undefined, bodies))),
+				);
+				const posted = bodies.at(0) ?? "";
+				assert.match(posted, CLAIM_RE);
+				assert.strictEqual(parseClaimPresence(posted), null);
+			}),
 	);
 });
 

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -36,14 +36,10 @@
 import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcessSpawner} from "effect/unstable/process";
-import {formatClaimPresence, livenessByComment} from "../epic-lock/claim-presence.ts";
-import {
-	type ClaimComment,
-	type ClaimWinner,
-	claimCommentBody,
-	resolveWinner,
-} from "../epic-lock/claim-resolution.ts";
-import {currentSessionPresence, localPresence} from "../epic-lock/presence-io.ts";
+import {type ClaimPresence, livenessByComment} from "../epic-lock/claim-presence.ts";
+import {type ClaimComment, type ClaimWinner, resolveWinner} from "../epic-lock/claim-resolution.ts";
+import {stampedClaimBody} from "../epic-lock/claim-writer.ts";
+import {localPresence} from "../epic-lock/presence-io.ts";
 // The ADR-0058 verdict-marker grammar + emission guard is the SINGLE SOURCE — reused, never
 // re-derived, exactly as the claim decision reuses `epic-lock/claim-resolution.ts`. `postVerdict`
 // composes and self-verifies its comment through this pure core so the tool OWNS the decision the
@@ -127,6 +123,12 @@ export interface ClaimOwner {
 /** The agent-distinguishable claim decision (ADR 0115): who is claiming (the session id). */
 export interface ClaimJudgment {
 	readonly session: string;
+	/**
+	 * The presence stamp to put on the marker — the boundary fact, not a judgment: omitted, the
+	 * verb reads THIS run's session presence (`presence-io.ts`). Injectable so a test can prove
+	 * the writer stamps on a machine where no session process resolves (#3987).
+	 */
+	readonly presence?: ClaimPresence | null;
 }
 
 /** The `claim` verdict — we own it, a pre-existing owner holds it, or we lost a co-race. */
@@ -400,6 +402,7 @@ const claim = Effect.fn("Tracker.claim")(function* (
 	repo: string,
 	target: TargetId,
 	session: string,
+	presence?: ClaimPresence | null,
 ) {
 	const mine = session.toLowerCase();
 	const before = yield* resolveAuthorizedWinner(repo, yield* listClaimComments(repo, target));
@@ -412,13 +415,8 @@ const claim = Effect.fn("Tracker.claim")(function* (
 	// Stamp our own session's presence on the marker so a LATER reader can probe this claim's
 	// liveness instead of guessing (#3751); an unresolvable session stamps nothing, which reads
 	// indeterminate and preserves the pre-stamp behaviour exactly.
-	const presence = currentSessionPresence();
 	const posted = yield* json(
-		postCommentArgs(
-			repo,
-			target,
-			claimCommentBody(session, now, presence === null ? null : formatClaimPresence(presence)),
-		),
+		postCommentArgs(repo, target, stampedClaimBody(session, now, presence)),
 	);
 	const claimId = typeof posted === "number" ? posted : null;
 	const winner = yield* resolveAuthorizedWinner(repo, yield* listClaimComments(repo, target));
@@ -736,7 +734,9 @@ export const GithubTrackerLive: Layer.Layer<
 		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
 		return {
 			claim: (target, judgment) =>
-				repo.pipe(Effect.flatMap((r) => withSpawner(claim(r, target, judgment.session)))),
+				repo.pipe(
+					Effect.flatMap((r) => withSpawner(claim(r, target, judgment.session, judgment.presence))),
+				),
 			readBack: (target) => repo.pipe(Effect.flatMap((r) => withSpawner(readBack(r, target)))),
 			applyTriage: (target, judgment) =>
 				repo.pipe(Effect.flatMap((r) => withSpawner(applyTriage(r, target, judgment)))),


### PR DESCRIPTION
Fixes #3987

## The defect

`pipeline-cli tracker claim` was the **only** claim writer that stamped ADR-0191 presence onto its marker. Every other path that posts a claim hand-composed the body and therefore posted it **unstamped**:

| Writer | Was | Now |
|---|---|---|
| `pipeline-cli tracker claim` | stamped | stamped, through the shared producer |
| Orchestrated lane claim (`.claude/workflows/drive-issue.js`) | raw `gh api … body=claim: …` POST | runs `pipeline-cli tracker claim` |
| Direct `write-code` Step-3 claim (+ the §7 canonical example it cites) | raw `gh api … body=claim: …` POST | runs `pipeline-cli tracker claim` |
| `status:planning` epic-lock `acquire` | inline `` `claim: ${sessionId} · ${now}` `` | posts through the shared producer |

A claim with no presence stamp cannot be probed, so it reads **indeterminate**, and indeterminate fails closed ⇒ the claim **stands**. Dead-claimant supersession (#3751) was therefore inert on most build lanes while the mechanism looked fixed.

**Live field evidence, observed this session.** A coder attempting #3992 was refused with:

```
tracker: #3992 is already claimed by another agent (session ddf8f459-…-8df10da5b55c,
at 2026-07-25T06:35:15Z) — BACK OFF, do not mutate.
```

That claim carried **no `· presence <host>/<pid>` suffix** — it came from an unstamped writer, so it read indeterminate, stood, and produced a deterministic refusal with no way to tell whether the claimant was alive. Backing off was correct in that instance, but the same shape means a genuinely **dead** claimant's claim would also have stood forever. Compare this PR's own claim on #3987, written through the stamping verb:

```
claim: 85123b6c-…-77ccedffb3d7 · 2026-07-25T06:46:07.970Z · presence 9ab808bf2cb3/58920
```

## The fix — one producer, no per-writer composition

- **`packages/pipeline-cli/src/tools/epic-lock/claim-writer.ts` (new)** — `stampedClaimBody(session, at, presence?)`: the single composition of the grammar (`claimCommentBody`) with the stamp (`formatClaimPresence`) and this run's session presence. Presence is an injectable parameter with a live default rather than an internal read, so each writer's own test can prove it stamps on a machine (CI) where no session process resolves.
- **`tracker.ts` / `epic-lock/github.ts`** both post through it. `acquire` no longer hand-concatenates its marker; `Tracker.claim`'s `ClaimJudgment` and `Github.acquire` take the optional presence as a boundary fact.
- **The three non-TS writers cite the verb instead of hand-rolling `gh api`**: §7's write-surface bullet in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, `write-code` Step 3's direct path, and the orchestrator's claim-only-agent prompt in `.claude/workflows/drive-issue.js`. Self-assign (the coarse availability gate) stays where it was; the verb owns Rule-0 defer → POST → checkpoint tiebreak → retract-own-on-loss, and its exit status is the branch.
- **`adoption-lint` declares `tracker claim` as an owned decision**, so a **new** file that hand-composes a `claim:` body without citing the verb reds CI — the "a fourth unstamped writer appears later" guard. Its fingerprint is the co-occurrence of a marker composed with a *live* token (`body=claim:` / `claim: $CLAUDE_CODE_SESSION_ID` / `claim: <TOKEN>`) and the comments endpoint, so §7's placeholder grammar block and prose mentions are not false findings.

I searched repo-wide for claim composition sites rather than trusting the three named in the issue: `plan-epic` / `review-plan` already route their planning claim through `pipeline-cli epic-lock acquire`, which now stamps, so there is no fifth writer. Every line number in the issue was re-verified against `main` before editing.

## Fail-closed is untouched

Making presence **present** is the fix; making an unstamped claim supersedable would trade a stuck lane for live-claim eviction, which is strictly worse. So:

- An unstamped legacy marker still records **no** liveness at all and still wins the tiebreak — the claim **stands**. Regression-tested directly (`claim-writer.unit.test.ts`, "an unstamped legacy claim still STANDS"), including the case where its pid happens to be provably gone.
- `dead` still requires all three of a stamp, a host match, and a probe that proves the pid gone. Nothing in the classification changed.
- No liveness probe is wrapped in `timeout`/`gtimeout`; the probe is the existing signal-0 `process.kill` and an un-executable probe resolves `unprobeable` ⇒ `unknown`, never `dead`.

## Coupling I deliberately did not touch

`presence-io.ts` and `claim-presence.ts` are consumed **as-is** — the `sha256(hostname())` host fingerprint in `presence-io.ts` is a separate fail-open being fixed on another lane, and this PR must not re-fix it. When that lane lands, the fingerprint change flows through this producer with no edit here (the producer only formats whatever `ClaimPresence` it is handed).

Multi-host liveness stays **out of scope**: a marker stamped on another machine is unprobeable, stays indeterminate, and its claim stands — the correct fail-closed direction, but it means a multi-host crew gets no supersession. The host-independent signal is the crew tracker's presence keyspace (#3938 / epic #3766). Documented in §7 ("Liveness is same-host by construction") and in the new module's docblock, with the explicit warning not to "fix" it by treating unprobeable as dead.

## Coverage

- `claim-writer.unit.test.ts` — the producer stamps what it is handed / omits when nothing resolved; a writer-composed stamped marker read back through `livenessByComment` + `resolveWinner` supersedes a dead claimant so the later live claim owns the lane (the #3751 scenario, now reachable from any writer); a live earlier claimant still wins; an unstamped legacy claim still stands.
- `tracker.behavior.test.ts` / `epic-lock/github-service.unit.test.ts` — both writers' mock spawners now capture the posted `body=`, so the assertions are on **what** was posted: the marker matches `CLAIM_RE` and `parseClaimPresence` reads back the injected stamp; with no presence it is a legacy-shaped marker, never a wrong stamp.
- `adoption-lint/command.test.ts` — each of the three writer surfaces cites the verb and hand-composes no claim body; the existing full-live-corpus green assertion covers the new decision.

## Checks

`pnpm typecheck` clean, `pnpm lint` clean, `pipeline-cli adoption-lint` clean over the live corpus, `gh-phoenix lint-skills` clean, `leak-guard scan` clean over every changed surface, `workflow-contract check` clean. The touched-tool suites pass (130/130). Three failures in the full `pipeline-cli` suite (`class-probe`, `guard-content-probe`, `pipeline-cli-shim`) are pre-existing load-induced flakes in shell-out tests — each passes in isolation and none is in this diff.

## Control plane

This touches `.claude/workflows/drive-issue.js` and two skills, so it is control-plane by path (ADR 0053 / 0065) and needs a human control-plane approval before merge. Not merging it.
