### PR TITLE
fix(crew-mcp): stamp message times from a clock, never accept one from the sender (#3895)

### DIFF
--- a/.decisions/0210-crew-message-times-are-stamped-not-composed.md
+++ b/.decisions/0210-crew-message-times-are-stamped-not-composed.md
@@ -1,0 +1,85 @@
+---
+id: 0210
+title: Crew message times are stamped by the substrate, never composed by the sender
+status: accepted
+date: 2026-07-25
+tags: [pipeline, pipeline-crew, crew-mcp, protocol]
+---
+
+# 0210 — Crew message times are stamped by the substrate, never composed by the sender
+
+**What this decides:** No crew message payload carries a time the sender wrote. Every instant on the
+substrate is read off a clock by the transport, the receiver, or the tracker, and an unreadable
+clock resolves to a typed unknown rather than a plausible-looking time.
+
+## Context
+
+Every kind in the crew message catalog carried an `at: Timestamp` field, and `Timestamp` was
+`Schema.String` — any string that looked like a time. On this substrate a `channel_send` caller is a
+language model composing JSON, so that field was filled in by *writing a timestamp into the
+payload*. Nothing read it off a clock.
+
+The consequences were exactly what you would predict of generated text in a field consumers read as
+an observation, and #3895 caught all of them in one session:
+
+- **Plausible-but-wrong values.** Ack times drifted minutes, then hours, from wall clock across one
+  session — monotonic, accelerating, and surviving a server respawn. No process clock behaves that
+  way; a narrative being extended one message at a time does.
+- **Placeholders indistinguishable from readings.** A board comment carried `2026-07-24T00:00:00Z` —
+  midnight to the second, obviously composed — sitting in a field consumers treat as an instant.
+- **No way to tell them apart.** A confabulated instant, a placeholder, and a real reading were the
+  same type and the same shape.
+
+This is the indeterminate-read-rendered-as-a-confident-value defect: the honest answer was "this
+substrate does not know when that happened," and the wire had no way to say it.
+
+Two facts bound the fix. First, the tracker never consumed the sender's `at` at all — presence and
+claim liveness already run on `Clock.currentTimeMillis` against the tracker's own clock, so the
+field was write-only decoration that only ever misled a reader. Second, the transport and the
+receiver *already* stamped real times (the envelope's and the ack's), so an authoritative instant
+existed at the right layer the whole time — it was just duplicated, unvalidated, and, in the
+`<channel>` wake tag a session actually reads, dropped in favour of the body's composed one.
+
+## Decision
+
+**A time is a `StampedInstant`, and only a clock reading produces one.**
+
+1. **Delete `at` from every sender-composed payload** — `ClaimRequest`, `ReleaseClaim`,
+   `DrainProgressTally`, `IntakePing`, `EngineNudge`, `PresenceAnnouncement`, `Heartbeat`. There is
+   no sender-intent field to carry instead: no consumer needed one, and re-adding it under another
+   name would recreate the field this ADR removes.
+2. **`StampedInstant` replaces `Timestamp` everywhere.** It is a tagged union —
+   `{_tag: "ObservedInstant", iso}` or `{_tag: "UnknownInstant", reason}` — so a consumer must
+   branch before it can read a time, and the unknown case carries **no time field at all**. The
+   `Timestamp = Schema.String` alias is gone; no protocol field is "a string that looks like a
+   time" any more.
+3. **The producers are the substrate, named once each:** the transport stamps the envelope's `at`
+   at send (`peer/peer.ts`), the receiver stamps the ack's at delivery (`peer/inbox.ts`,
+   `edge/bridge.ts`), and the tracker stamps `since` / `lastSeen` from its own clock
+   (`tracker/handlers.ts`). All of them go through `stampNow` / `stampFromMillis`; none accepts a
+   caller-supplied value.
+4. **An unusable reading fails closed to `UnknownInstant`** — non-finite, or outside a plausible
+   epoch window. The lower bound is what makes a leaked `TestClock` (parked at epoch 0) surface as
+   unknown instead of a confident `1970-01-01T00:00:00.000Z`.
+5. **The wake tag carries the stamped instant** — `<channel from=… kind=… at=…>` — and it is the
+   only time on the surface a receiving session reads. An unknown renders the literal word
+   `unknown`, which cannot be misread as an instant.
+6. **A body carrying an `at` is rejected at the send path**, not silently stripped. A
+   `Schema.Struct` decode would drop the excess key and leave the sender believing it sent a time;
+   the reject names why and points at where the real instant comes from.
+
+## Consequences
+
+- The wire shape changed: `at` / `since` / `lastSeen` are objects, not strings, and payloads lost
+  `at`. Every reader in the package moved in lockstep — there is no version negotiation here, and a
+  skewed host answers `Unknown request tag` loudly rather than mis-decoding (the #3977 shape).
+- Senders get a hard error on the old habit instead of a silent drop, which costs one failed send
+  and teaches the new shape through the existing schema hint.
+- Consumers must branch on the tag. That is the point: "we don't know when" is now representable
+  and unavoidable, where before it was rendered as a confident time.
+- The sanity window is a heuristic, and deliberately a coarse one. It catches the uninitialized and
+  synthetic clocks; it cannot catch a real clock that is merely wrong. Detecting *that* needs a
+  second reference (the ack-time sanity canary the investigation floated) and is out of scope here.
+- Liveness is untouched. The tracker already measured TTLs against its own `Clock.currentTimeMillis`
+  and ignored the payload time, so nothing about presence, leases, or claim expiry changes — this
+  ADR removes a misleading wire field, it does not alter the liveness clock.

--- a/.decisions/0211-crew-message-times-are-stamped-not-composed.md
+++ b/.decisions/0211-crew-message-times-are-stamped-not-composed.md
@@ -1,12 +1,12 @@
 ---
-id: 0210
+id: 0211
 title: Crew message times are stamped by the substrate, never composed by the sender
 status: accepted
 date: 2026-07-25
 tags: [pipeline, pipeline-crew, crew-mcp, protocol]
 ---
 
-# 0210 — Crew message times are stamped by the substrate, never composed by the sender
+# 0211 — Crew message times are stamped by the substrate, never composed by the sender
 
 **What this decides:** No crew message payload carries a time the sender wrote. Every instant on the
 substrate is read off a clock by the transport, the receiver, or the tracker, and an unreadable

--- a/.decisions/0211-crew-message-times-are-stamped-not-composed.md
+++ b/.decisions/0211-crew-message-times-are-stamped-not-composed.md
@@ -19,12 +19,17 @@ Every kind in the crew message catalog carried an `at: Timestamp` field, and `Ti
 language model composing JSON, so that field was filled in by *writing a timestamp into the
 payload*. Nothing read it off a clock.
 
-The consequences were exactly what you would predict of generated text in a field consumers read as
+The consequences were exactly what you would predict of generated text sitting where consumers read
 an observation, and #3895 caught all of them in one session:
 
-- **Plausible-but-wrong values.** Ack times drifted minutes, then hours, from wall clock across one
-  session — monotonic, accelerating, and surviving a server respawn. No process clock behaves that
-  way; a narrative being extended one message at a time does.
+- **Plausible-but-wrong values.** Ack times reported across one session drifted minutes, then hours,
+  from wall clock — monotonic, accelerating, and surviving a server respawn. No process clock behaves
+  that way; a narrative extended one message at a time does. This one takes an extra step, because
+  `InboxAck.at` was *not* a sender-composed payload field — the receiving peer stamped it with
+  `new Date().toISOString()`. That is what makes the reading conclusive rather than merely
+  suspicious: a real `new Date()` on a host with a correct clock cannot drift 9.5 hours, so the times
+  #3895 reports were never what the tool returned. They were composed somewhere between the ack and
+  the report — the same defect as the payload field, one layer up.
 - **Placeholders indistinguishable from readings.** A board comment carried `2026-07-24T00:00:00Z` —
   midnight to the second, obviously composed — sitting in a field consumers treat as an instant.
 - **No way to tell them apart.** A confabulated instant, a placeholder, and a real reading were the

--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -118,7 +118,7 @@ the substrate resolves the target role's inbox for you:
 - **`channel_send {targetRole, kind, body}`** — discovery is implicit inside the send (the
   library resolves the role's inbox; there is no separate discover/claim tool). Success returns
   an `InboxAck`; an unreachable peer returns a `PeerUnreachableError {target, reason}`.
-- **Inbound arrives as a wake tag** — `<channel from="inbox://<role>" kind="…">…JSON…</channel>`.
+- **Inbound arrives as a wake tag** — `<channel from="inbox://<role>" kind="…" at="…">…JSON…</channel>`.
 - **An ack means delivered-to-inbox + wake enqueued — never seen-by-model.** The peer reads it
   when it wakes; the ack is not a read receipt and never an answer. (This is the load-bearing
   corollary the chief-of-staff carries: *conversing is not evidence* — coordinate over the

--- a/claude-plugins/pipeline-crew/REFERENCE.md
+++ b/claude-plugins/pipeline-crew/REFERENCE.md
@@ -144,8 +144,13 @@ session via `--channels server:@kampus/pipeline-crew-mcp`).
   substrate resolves the target role's inbox; there is no separate discover/claim tool.
 - **Results** — success returns an `InboxAck` (delivered-to-inbox + wake enqueued, **never**
   seen-by-model); an unreachable peer returns a `PeerUnreachableError {target, reason}`.
+- **Never write a time into `body`** — no kind's payload has one, and a body carrying an `at` is
+  rejected. You are a model composing JSON, so a time you write is prose that looks like a reading,
+  not a reading. The instant is stamped for you: the transport stamps the wake tag's `at`, the
+  receiver stamps the ack's. Read those; don't author one (ADR 0210).
 - **Inbound** — arrives to the recipient as a wake tag
-  `<channel from="inbox://<role>" kind="…">…JSON…</channel>`.
+  `<channel from="inbox://<role>" kind="…" at="…">…JSON…</channel>`. The `at` is the
+  transport-stamped instant, or the literal `unknown (…)` when the clock could not be read.
 - **Offline behavior** — log and continue. A `PeerUnreachableError` is logged and dropped; no
   retry, no escalation, no ack-required kinds (every edge is a latency optimization over the
   board, so a failed send costs latency, not correctness).

--- a/claude-plugins/pipeline-crew/REFERENCE.md
+++ b/claude-plugins/pipeline-crew/REFERENCE.md
@@ -147,7 +147,7 @@ session via `--channels server:@kampus/pipeline-crew-mcp`).
 - **Never write a time into `body`** — no kind's payload has one, and a body carrying an `at` is
   rejected. You are a model composing JSON, so a time you write is prose that looks like a reading,
   not a reading. The instant is stamped for you: the transport stamps the wake tag's `at`, the
-  receiver stamps the ack's. Read those; don't author one (ADR 0210).
+  receiver stamps the ack's. Read those; don't author one (ADR 0211).
 - **Inbound** — arrives to the recipient as a wake tag
   `<channel from="inbox://<role>" kind="…" at="…">…JSON…</channel>`. The `at` is the
   transport-stamped instant, or the literal `unknown (…)` when the clock could not be read.

--- a/claude-plugins/pipeline-crew/agents/crew-cartographer.md
+++ b/claude-plugins/pipeline-crew/agents/crew-cartographer.md
@@ -90,7 +90,7 @@ session; the substrate resolves the target role's inbox for you:
 
 - **`channel_send {targetRole, kind, body}`** is the whole idiom. Discovery is implicit inside the
   send; success returns an `InboxAck`, an unreachable peer a `PeerUnreachableError {target, reason}`.
-  Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>` wake tag; an ack
+  Inbound arrives to you as a `<channel from="inbox://<role>" kind="…" at="…">…</channel>` wake tag; an ack
   means delivered-to-inbox + wake enqueued, never seen-by-model.
 - **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
   (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid

--- a/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
+++ b/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
@@ -75,7 +75,7 @@ session; the substrate resolves the target role's inbox for you:
 - **`channel_send {targetRole, kind, body}`** is the whole idiom. Discovery is implicit inside
   the send (the library resolves the role's inbox); you never call a separate discover/claim.
   Success returns an `InboxAck`; an unreachable peer returns a `PeerUnreachableError {target,
-  reason}`. Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>`
+  reason}`. Inbound arrives to you as a `<channel from="inbox://<role>" kind="…" at="…">…</channel>`
   wake tag.
 - **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
   (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -60,7 +60,7 @@ session; the substrate resolves the target role's inbox for you:
 
 - **`channel_send {targetRole, kind, body}`** is the whole idiom. Discovery is implicit inside the
   send; success returns an `InboxAck`, an unreachable peer a `PeerUnreachableError {target, reason}`.
-  Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>` wake tag; an ack
+  Inbound arrives to you as a `<channel from="inbox://<role>" kind="…" at="…">…</channel>` wake tag; an ack
   means delivered-to-inbox + wake enqueued, never seen-by-model.
 - **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
   (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid

--- a/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
+++ b/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
@@ -78,7 +78,7 @@ session; the substrate resolves the target role's inbox for you:
 
 - **`channel_send {targetRole, kind, body}`** is the whole idiom. Discovery is implicit inside the
   send; success returns an `InboxAck`, an unreachable peer a `PeerUnreachableError {target,
-  reason}`. Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>` wake
+  reason}`. Inbound arrives to you as a `<channel from="inbox://<role>" kind="…" at="…">…</channel>` wake
   tag; an ack means delivered-to-inbox + wake enqueued, never seen-by-model.
 - **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
   (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid

--- a/packages/pipeline-crew-mcp/docs/how-to.md
+++ b/packages/pipeline-crew-mcp/docs/how-to.md
@@ -66,11 +66,11 @@ and the one-liveness-clock rule, or it reintroduces a failure those choices desi
    transition must not mutate `claims`, and a claim transition must not fabricate a lease.
 2. **Expose it on the service** in [`src/tracker/registry.ts`](../src/tracker/registry.ts): add a
    method to the `Registry` `Context.Service` and implement it in `RegistryLive`, drawing "now"
-   from `Clock.currentTimeMillis` — **never** a client-supplied `at`, so a peer cannot extend its
-   own liveness by lying about the time.
+   from `Clock.currentTimeMillis` — **never** a client-supplied time, so a peer cannot extend its
+   own liveness by lying about the clock (no payload carries one; ADR 0210).
 3. **Map the RPC** in [`src/tracker/handlers.ts`](../src/tracker/handlers.ts): wire the registry
-   kind onto the new `Registry` method, converting `Timestamp` strings ↔ epoch millis at the
-   boundary. If the semantic is a new *wire* kind, it must also be in the protocol catalog (see
+   kind onto the new `Registry` method, converting epoch millis to a `StampedInstant` through
+   `stampFromMillis` at the boundary, so an unusable reading crosses as a typed unknown. If the semantic is a new *wire* kind, it must also be in the protocol catalog (see
    [Add a message kind](#add-a-message-kind)) and in the `TrackerRegistry` subset
    ([`src/tracker/group.ts`](../src/tracker/group.ts)).
 4. **Surface the crew seam** in [`src/crew/tracker.ts`](../src/crew/tracker.ts): add the method to

--- a/packages/pipeline-crew-mcp/docs/how-to.md
+++ b/packages/pipeline-crew-mcp/docs/how-to.md
@@ -67,7 +67,7 @@ and the one-liveness-clock rule, or it reintroduces a failure those choices desi
 2. **Expose it on the service** in [`src/tracker/registry.ts`](../src/tracker/registry.ts): add a
    method to the `Registry` `Context.Service` and implement it in `RegistryLive`, drawing "now"
    from `Clock.currentTimeMillis` — **never** a client-supplied time, so a peer cannot extend its
-   own liveness by lying about the clock (no payload carries one; ADR 0210).
+   own liveness by lying about the clock (no payload carries one; ADR 0211).
 3. **Map the RPC** in [`src/tracker/handlers.ts`](../src/tracker/handlers.ts): wire the registry
    kind onto the new `Registry` method, converting epoch millis to a `StampedInstant` through
    `stampFromMillis` at the boundary, so an unusable reading crosses as a typed unknown. If the semantic is a new *wire* kind, it must also be in the protocol catalog (see

--- a/packages/pipeline-crew-mcp/docs/how-to.md
+++ b/packages/pipeline-crew-mcp/docs/how-to.md
@@ -20,10 +20,13 @@ so a well-placed addition needs no edits at those sites (see the
 [message-kind catalog](./reference.md#message-kind-catalog)).
 
 1. **Define the payload** in [`src/protocol/schema.ts`](../src/protocol/schema.ts) as an
-   `effect/Schema` `Struct`. Reuse the shared field types (`PeerId`, `RoleId`, `Timestamp`) so
+   `effect/Schema` `Struct`. Reuse the shared field types (`PeerId`, `RoleId`, `MessageId`) so
    the wire stays transport-agnostic; keep a role an opaque `RoleId` parameter, never a concrete
    crew-role noun (that boundary is what lets `tracker`/`peer`/`edge` code against the protocol
-   without importing `crew/`).
+   without importing `crew/`). **Give it no time field** — no sender-composed payload carries one
+   and `channel_send` rejects a body that does (ADR 0211). A time on a *reply* schema (step 2) is
+   a `StampedInstant` from [`src/protocol/instant.ts`](../src/protocol/instant.ts), filled by
+   whoever answers via `stampNow` / `stampFromMillis`, never by the caller.
 2. **Register the RPC** in [`src/protocol/group.ts`](../src/protocol/group.ts): add an
    `Rpc.make("<Tag>", { payload: … })`, and add a `success:` schema **only** if the kind expects
    a typed reply (an unset `success` defaults to `Schema.Void` — that split is what makes a kind

--- a/packages/pipeline-crew-mcp/docs/reference.md
+++ b/packages/pipeline-crew-mcp/docs/reference.md
@@ -44,7 +44,7 @@ fire-and-forget kind leaves `success` unset, so it defaults to `Schema.Void`.
 | `RoleId` | `Schema.NonEmptyString` — an opaque role identifier (a parameter, never a concrete crew-role noun). |
 | `PeerId` | `Schema.NonEmptyString` — an opaque participant (a peer / session) identifier. |
 | `MessageId` | `Schema.NonEmptyString` — an opaque message id, correlates an ack to its delivery. |
-| `StampedInstant` | A tagged union — `{_tag: "ObservedInstant", iso}` (a real clock reading, ISO-8601 UTC) or `{_tag: "UnknownInstant", reason}`. Produced only by `stampFromMillis`/`stampNow`, never composed by a sender (ADR 0210). |
+| `StampedInstant` | A tagged union — `{_tag: "ObservedInstant", iso}` (a real clock reading, ISO-8601 UTC) or `{_tag: "UnknownInstant", reason}`. Produced only by `stampFromMillis`/`stampNow`, never composed by a sender (ADR 0211). |
 
 ### Payload shapes
 
@@ -54,7 +54,7 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 composing JSON, so a time it supplies is authored prose rather than a reading — `channel_send`
 rejects a body carrying an `at`. The authoritative instants are the envelope's (stamped by the
 transport at send), the ack's (stamped by the receiver at delivery), and `since` / `lastSeen`
-(stamped by the tracker). See ADR 0210.
+(stamped by the tracker). See ADR 0211.
 
 **`ClaimRequest`** — a sender's request to claim a resource (answered by `ClaimReply`):
 

--- a/packages/pipeline-crew-mcp/docs/reference.md
+++ b/packages/pipeline-crew-mcp/docs/reference.md
@@ -44,11 +44,17 @@ fire-and-forget kind leaves `success` unset, so it defaults to `Schema.Void`.
 | `RoleId` | `Schema.NonEmptyString` — an opaque role identifier (a parameter, never a concrete crew-role noun). |
 | `PeerId` | `Schema.NonEmptyString` — an opaque participant (a peer / session) identifier. |
 | `MessageId` | `Schema.NonEmptyString` — an opaque message id, correlates an ack to its delivery. |
-| `Timestamp` | `Schema.String` — an ISO-8601 UTC instant, kept a string so the wire stays transport-agnostic. |
+| `StampedInstant` | A tagged union — `{_tag: "ObservedInstant", iso}` (a real clock reading, ISO-8601 UTC) or `{_tag: "UnknownInstant", reason}`. Produced only by `stampFromMillis`/`stampNow`, never composed by a sender (ADR 0210). |
 
 ### Payload shapes
 
 Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (absent, not nullable).
+
+**No payload carries a sender-composed time.** The sender on this substrate is a language model
+composing JSON, so a time it supplies is authored prose rather than a reading — `channel_send`
+rejects a body carrying an `at`. The authoritative instants are the envelope's (stamped by the
+transport at send), the ack's (stamped by the receiver at delivery), and `since` / `lastSeen`
+(stamped by the tracker). See ADR 0210.
 
 **`ClaimRequest`** — a sender's request to claim a resource (answered by `ClaimReply`):
 
@@ -57,7 +63,6 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | `resource` | `Schema.NonEmptyString` |
 | `claimant` | `PeerId` |
 | `role` | `RoleId` |
-| `at` | `Timestamp` |
 
 **`ClaimReply`** — the typed answer to a `ClaimRequest`:
 
@@ -67,7 +72,7 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | `granted` | `Schema.Boolean` |
 | `collision` | `Schema.Boolean` |
 | `owner` | `PeerId` |
-| `since` | `Timestamp` |
+| `since` | `StampedInstant` — tracker-stamped |
 
 **`ReleaseClaim`** — a holder freeing its own claim (fire-and-forget; `claimant` must be the holder):
 
@@ -75,7 +80,6 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | --- | --- |
 | `resource` | `Schema.NonEmptyString` |
 | `claimant` | `PeerId` |
-| `at` | `Timestamp` |
 
 **`DrainProgressTally`** — a drain-progress report:
 
@@ -86,7 +90,6 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | `inFlight` | `Schema.Int` |
 | `total` | `Schema.Int` |
 | `reporter` | `PeerId` |
-| `at` | `Timestamp` |
 
 **`IntakePing`** — an intake ping:
 
@@ -95,7 +98,6 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | `issue` | `Schema.NonEmptyString` |
 | `from` | `RoleId` |
 | `note` | `Schema.String` *(optional)* |
-| `at` | `Timestamp` |
 
 **`PresenceAnnouncement`** — a peer announcing it serves a role (fire-and-forget):
 
@@ -103,7 +105,6 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | --- | --- |
 | `peer` | `PeerId` |
 | `role` | `RoleId` |
-| `at` | `Timestamp` |
 
 **`RoleLookupQuery`** — a lookup query for peers serving a role (answered by `RoleLookupResult`):
 
@@ -124,7 +125,7 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | --- | --- |
 | `peer` | `PeerId` |
 | `role` | `RoleId` |
-| `lastSeen` | `Timestamp` |
+| `lastSeen` | `StampedInstant` — tracker-stamped |
 
 **`Heartbeat`** — a presence-TTL keepalive:
 
@@ -132,7 +133,6 @@ Each is a `Schema.Struct`; a field marked *optional* is `Schema.optionalKey` (ab
 | --- | --- |
 | `peer` | `PeerId` |
 | `ttlSeconds` | `Schema.Int` |
-| `at` | `Timestamp` |
 
 ## Tracker claim/lease semantics
 

--- a/packages/pipeline-crew-mcp/docs/tutorial.md
+++ b/packages/pipeline-crew-mcp/docs/tutorial.md
@@ -106,7 +106,6 @@ const program = Effect.gen(function* () {
 	const ack = yield* channelA.peer.send("engineering-manager", "IntakePing", {
 		issue: "3565",
 		from: "intake-desk",
-		at: new Date().toISOString(),
 	});
 	yield* Console.log("ack   :", JSON.stringify(ack));
 	yield* Console.log("B woke:", JSON.stringify((yield* Ref.get(wakes))[0]));
@@ -138,7 +137,7 @@ Three things are worth pausing on, because they are the substrate's real seams:
   `granted` / `collision` / `owner` fields are the contract you will read in Step 3.
 
 `IntakePing` is one of the message kinds in the catalog; its body shape (`issue`, `from`, optional
-`note`, `at`) is defined in [`../src/protocol/schema.ts`](../src/protocol/schema.ts). See the
+`note`) is defined in [`../src/protocol/schema.ts`](../src/protocol/schema.ts). See the
 [reference's message-kind catalog](./reference.md#message-kind-catalog) for the full list of kinds
 you can send.
 
@@ -157,17 +156,17 @@ files are the one thing a hard-killed prior run leaves behind.)
 You will see four lines. This is the guaranteed outcome — walk each one:
 
 ```
-ack   : {"messageId":"…","by":"inbox://engineering-manager/tutorial","at":"…"}
-B woke: {"content":"<channel from=\"inbox://intake-desk\" kind=\"IntakePing\">{\"issue\":\"3565\",\"from\":\"intake-desk\",\"at\":\"…\"}</channel>","meta":{"from":"inbox://intake-desk"}}
-B claim: {"resource":"issue-3565","granted":true,"collision":false,"owner":"inbox://engineering-manager/tutorial","since":"…"}
-A claim: {"resource":"issue-3565","granted":false,"collision":true,"owner":"inbox://engineering-manager/tutorial","since":"…"}
+ack   : {"messageId":"…","by":"inbox://engineering-manager/tutorial","at":{"_tag":"ObservedInstant","iso":"…"}}
+B woke: {"content":"<channel from=\"inbox://intake-desk\" kind=\"IntakePing\" at=\"…\">{\"issue\":\"3565\",\"from\":\"intake-desk\"}</channel>","meta":{"from":"inbox://intake-desk"}}
+B claim: {"resource":"issue-3565","granted":true,"collision":false,"owner":"inbox://engineering-manager/tutorial","since":{"_tag":"ObservedInstant","iso":"…"}}
+A claim: {"resource":"issue-3565","granted":false,"collision":true,"owner":"inbox://engineering-manager/tutorial","since":{"_tag":"ObservedInstant","iso":"…"}}
 ```
 
 - **`ack`** — A's send returned a delivered-to-inbox acknowledgement, stamped `by` peer B's address.
   The message reached B's inbox and B answered. (Had no peer served the role, you'd have gotten a
   `PeerUnreachableError` instead — a send never silently drops.)
 - **`B woke`** — B's inbox rendered the delivery as a `<channel>` tag carrying the sender
-  (`from`), the `kind`, and the JSON body. This is the exact shape a live session surfaces to its
+  (`from`), the `kind`, the transport-stamped `at`, and the JSON body. This is the exact shape a live session surfaces to its
   MCP client when a message arrives.
 - **`B claim`** — B asked to claim `issue-3565` and the tracker returned `granted: true`, recording
   B as `owner`.

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
@@ -20,6 +20,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer, Ref} from "effect";
 import {type ChannelNotificationPayload, ChannelSink} from "../edge/index.ts";
 import {Dialer, type InboxEnvelope} from "../peer/index.ts";
+import {stampFromMillis} from "../protocol/index.ts";
 import {
 	crewSocketDialerLayer,
 	inboxServerSocketLayer,
@@ -79,7 +80,7 @@ describe("crew/channel-server — REAL unix-socket inbox transport", () => {
 						from: "inbox://engineering-manager/1",
 						kind: "IntakePing",
 						body: {issue: 3489, from: "engineering-manager", at: new Date().toISOString()},
-						at: new Date().toISOString(),
+						at: stampFromMillis(Date.now()),
 					};
 					const dialer = yield* Dialer;
 					const ack = yield* dialer.send(address, envelope).pipe(Effect.timeout("6 seconds"));

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
@@ -21,6 +21,7 @@ import {
 	PeerInbox,
 	PeerUnreachableError,
 } from "../peer/index.ts";
+import {stampFromMillis} from "../protocol/index.ts";
 import {TrackerRegistry} from "../tracker/group.ts";
 import {TrackerHandlers} from "../tracker/handlers.ts";
 import {RegistryLive} from "../tracker/registry.ts";
@@ -152,7 +153,6 @@ describe("crew/channel-server — announce, discover, claim/collision-check (AC 
 			yield* client.AnnouncePresence({
 				peer: "inbox://b",
 				role: roleB,
-				at: new Date().toISOString(),
 			});
 			const a = yield* makeCrewChannel({role: roleA, address: "inbox://a"}).pipe(
 				Effect.provide(channelLayers(tracker, "inbox://a", Dialer.layerFromConnect(connect))),
@@ -240,7 +240,6 @@ describe("crew/channel-server — per-kind cardinality lease (AC 3)", () => {
 				yield* client.Release({
 					resource: role,
 					claimant: `inbox://${role}-a`,
-					at: new Date().toISOString(),
 				});
 
 				// a replacement bridge (a fresh peer) boots cleanly onto the freed singleton lease
@@ -285,9 +284,8 @@ describe("crew/channel-server — engine pool discovery + per-instance dial (AC 
 			// two engine instances of one role, distinct per-instance addresses, both live
 			const addr1 = `inbox://${engineRole}/1`;
 			const addr2 = `inbox://${engineRole}/2`;
-			const at = new Date().toISOString();
-			yield* client.AnnouncePresence({peer: addr1, role: engineRole, at});
-			yield* client.AnnouncePresence({peer: addr2, role: engineRole, at});
+			yield* client.AnnouncePresence({peer: addr1, role: engineRole});
+			yield* client.AnnouncePresence({peer: addr2, role: engineRole});
 
 			// a sender channel discovers the WHOLE pool, not a single collapsed holder
 			const senderAddr = `inbox://${senderRole}`;
@@ -339,9 +337,8 @@ describe("crew/channel-server — engine pool discovery + per-instance dial (AC 
 						? Effect.succeed(two.inbox)
 						: Effect.fail(new PeerUnreachableError({target: address, reason: "no route"}));
 
-			const at = new Date().toISOString();
-			yield* client.AnnouncePresence({peer: addr1, role: engineRole, at});
-			yield* client.AnnouncePresence({peer: addr2, role: engineRole, at});
+			yield* client.AnnouncePresence({peer: addr1, role: engineRole});
+			yield* client.AnnouncePresence({peer: addr2, role: engineRole});
 
 			// discover the pool, pick instance #2 specifically, and dial IT by address via the Dialer
 			const senderAddr = `inbox://${senderRole}`;
@@ -356,7 +353,7 @@ describe("crew/channel-server — engine pool discovery + per-instance dial (AC 
 					from: senderAddr,
 					kind: "IntakePing",
 					body: {issue: 3059},
-					at: new Date().toISOString(),
+					at: stampFromMillis(Date.now()),
 				});
 			}).pipe(Effect.provide(channelLayers(tracker, senderAddr, Dialer.layerFromConnect(connect))));
 

--- a/packages/pipeline-crew-mcp/src/crew/heartbeat.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/heartbeat.test.ts
@@ -53,7 +53,7 @@ describe("crew/heartbeat — a live session outlives the TTL with the loop, ages
 	it.effect("with the heartbeat loop, presence survives past DEFAULT_TTL_SECONDS", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
-			yield* client.AnnouncePresence({peer, role, at: new Date().toISOString()});
+			yield* client.AnnouncePresence({peer, role});
 			// Fork the keepalive loop into this scope; it refreshes the lease every interval.
 			yield* Layer.build(
 				crewHeartbeatLayer(peer).pipe(Layer.provide(CrewTracker.fromClient(client))),
@@ -70,7 +70,7 @@ describe("crew/heartbeat — a live session outlives the TTL with the loop, ages
 		() =>
 			Effect.gen(function* () {
 				const client = yield* RpcTest.makeClient(TrackerRegistry);
-				yield* client.AnnouncePresence({peer, role, at: new Date().toISOString()});
+				yield* client.AnnouncePresence({peer, role});
 				yield* TestClock.adjust(pastTtl);
 				const present = yield* client.LookupRole({role});
 				assert.lengthOf(present.peers, 0, "with no keepalive the one-shot announce ages out");

--- a/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
@@ -20,6 +20,7 @@ import {McpServer} from "effect/unstable/ai";
 import {RpcTest} from "effect/unstable/rpc";
 import {channelExperimentalCapability} from "../edge/index.ts";
 import {Dialer, Inbox, PeerUnreachableError} from "../peer/index.ts";
+import {stampFromMillis} from "../protocol/index.ts";
 import {TrackerRegistry} from "../tracker/group.ts";
 import {TrackerHandlers} from "../tracker/handlers.ts";
 import {RegistryLive} from "../tracker/registry.ts";
@@ -85,7 +86,7 @@ describe("crew/session — forked-stdio live-wake round-trip (session.ts:34 seam
 							from: "inbox://engineering-manager/1",
 							kind: "IntakePing",
 							body: {issue: 3489, from: "engineering-manager", at: new Date().toISOString()},
-							at: new Date().toISOString(),
+							at: stampFromMillis(Date.now()),
 						})
 						.pipe(Effect.timeout("6 seconds"));
 				}).pipe(Effect.provide(crewSocketDialerLayer), Effect.exit);

--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -96,7 +96,6 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 			yield* client.AnnouncePresence({
 				peer: receiverAddress,
 				role: receiverRole,
-				at: new Date().toISOString(),
 			});
 
 			// The sender's real ChannelSend-from-peer binding (the cutover) — the port channel_send uses.

--- a/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
@@ -25,7 +25,6 @@ const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
 // Node FileSystem so the host-or-dial layer builds in-test as under the bin's NodeServices.layer.
 const hostOrDial = (socketPath: string) =>
 	crewTrackerHostOrDialLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
-const nowIso = () => new Date().toISOString();
 
 const errWithCode = (code: string): Error => Object.assign(new Error(code), {code});
 
@@ -74,8 +73,8 @@ describe("crew/tracker — acquireClaim + release (the claim lifecycle client, A
 			const ctx = yield* Layer.build(CrewTracker.fromClient(client));
 			const tracker = Context.get(ctx, CrewTracker);
 			// both holders need live presence for their claims to be live (presence-derived liveness)
-			yield* client.AnnouncePresence({peer: "inbox://a", role: "builder", at: nowIso()});
-			yield* client.AnnouncePresence({peer: "inbox://b", role: "reviewer", at: nowIso()});
+			yield* client.AnnouncePresence({peer: "inbox://a", role: "builder"});
+			yield* client.AnnouncePresence({peer: "inbox://b", role: "reviewer"});
 
 			// hold the claim for an inner scope; while held, a foreign claim collides
 			yield* Effect.scoped(
@@ -110,8 +109,8 @@ describe("crew/tracker — acquireClaim + release (the claim lifecycle client, A
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
 			const ctx = yield* Layer.build(CrewTracker.fromClient(client));
 			const tracker = Context.get(ctx, CrewTracker);
-			yield* client.AnnouncePresence({peer: "inbox://a", role: "builder", at: nowIso()});
-			yield* client.AnnouncePresence({peer: "inbox://b", role: "reviewer", at: nowIso()});
+			yield* client.AnnouncePresence({peer: "inbox://a", role: "builder"});
+			yield* client.AnnouncePresence({peer: "inbox://b", role: "reviewer"});
 			yield* tracker.claim({resource: "issue-1", claimant: "inbox://a", role: "builder"});
 			yield* tracker.release({resource: "issue-1", claimant: "inbox://a"});
 			const reclaim = yield* tracker.claim({

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -47,8 +47,6 @@ export interface TrackerRegistryClient {
 	readonly Heartbeat: (payload: HeartbeatMessage) => Effect.Effect<void, unknown>;
 }
 
-const now = (): string => new Date().toISOString();
-
 export class CrewTracker extends Context.Service<
 	CrewTracker,
 	{
@@ -113,19 +111,16 @@ export class CrewTracker extends Context.Service<
 	static readonly fromClient = (client: TrackerRegistryClient): Layer.Layer<CrewTracker> =>
 		Layer.succeed(CrewTracker, {
 			claim: ({resource, claimant, role}) =>
-				client.Claim({resource, claimant, role, at: now()}).pipe(Effect.orDie),
+				client.Claim({resource, claimant, role}).pipe(Effect.orDie),
 			acquireClaim: ({resource, claimant, role}) =>
 				Effect.acquireRelease(
-					client.Claim({resource, claimant, role, at: now()}).pipe(Effect.orDie),
+					client.Claim({resource, claimant, role}).pipe(Effect.orDie),
 					// Free on scope close, but only a claim we actually won — release is holder-guarded, so
 					// releasing a collided (un-held) claim would no-op anyway; gating on `granted` keeps intent clear.
 					(reply) =>
-						reply.granted
-							? client.Release({resource, claimant, at: now()}).pipe(Effect.orDie)
-							: Effect.void,
+						reply.granted ? client.Release({resource, claimant}).pipe(Effect.orDie) : Effect.void,
 				),
-			release: ({resource, claimant}) =>
-				client.Release({resource, claimant, at: now()}).pipe(Effect.orDie),
+			release: ({resource, claimant}) => client.Release({resource, claimant}).pipe(Effect.orDie),
 			announce: (presence) =>
 				Effect.acquireRelease(
 					// peer-id ≡ inbox-address: announce the dialable address so a lookup can dial it back.
@@ -135,7 +130,6 @@ export class CrewTracker extends Context.Service<
 							peer: presence.address,
 							role: presence.role,
 							attached: true,
-							at: now(),
 						})
 						.pipe(Effect.orDie),
 					// No wire release kind exists, so scope close is a client-side no-op. A live session
@@ -153,13 +147,11 @@ export class CrewTracker extends Context.Service<
 							peer: presence.address,
 							role: presence.role,
 							attached: false,
-							at: now(),
 						})
 						.pipe(Effect.orDie),
 					() => Effect.void,
 				),
-			heartbeat: ({peer, ttlSeconds}) =>
-				client.Heartbeat({peer, ttlSeconds, at: now()}).pipe(Effect.orDie),
+			heartbeat: ({peer, ttlSeconds}) => client.Heartbeat({peer, ttlSeconds}).pipe(Effect.orDie),
 			// peer-id ≡ inbox-address: each present peer IS its own dialable address, so a lookup
 			// recovers the full live set of addresses (one per bridge, N across an engine pool).
 			lookup: (role) =>

--- a/packages/pipeline-crew-mcp/src/edge/bridge.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/bridge.test.ts
@@ -8,6 +8,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer, Ref} from "effect";
 import {Inbox, type InboxEnvelope} from "../peer/index.ts";
+import {stampFromMillis} from "../protocol/index.ts";
 import {channelInboxLayer, formatChannelTag} from "./bridge.ts";
 import {ChannelSink} from "./channel-sink.ts";
 import type {ChannelNotificationPayload} from "./mcp-channel.ts";
@@ -17,7 +18,7 @@ const envelope = (over?: Partial<InboxEnvelope>): InboxEnvelope => ({
 	from: "peer-a",
 	kind: "IntakePing",
 	body: {issue: 3057},
-	at: "2026-07-16T10:00:00Z",
+	at: stampFromMillis(Date.parse("2026-07-16T10:00:00Z")),
 	...over,
 });
 
@@ -44,9 +45,17 @@ describe("edge/bridge — inbound peer-inbox message wakes the session (AC2)", (
 		}),
 	);
 
-	it("formatChannelTag renders sender + kind as attributes and the body as content", () => {
+	it("formatChannelTag renders sender + kind + the stamped instant as attributes, body as content", () => {
 		const tag = formatChannelTag(envelope());
-		assert.match(tag, /^<channel from="peer-a" kind="IntakePing">/);
+		assert.match(tag, /^<channel from="peer-a" kind="IntakePing" at="2026-07-16T10:00:00\.000Z">/);
 		assert.include(tag, '{"issue":3057}');
+	});
+
+	// The `at` a session reads is the envelope's transport stamp, and it is the ONLY time on the
+	// surface — a sender-composed one would be authored prose (#3895).
+	it("formatChannelTag renders an unreadable clock as the literal word unknown, never a time", () => {
+		const tag = formatChannelTag(envelope({at: stampFromMillis(Number.NaN)}));
+		assert.include(tag, 'at="unknown (');
+		assert.notMatch(tag, /at="\d{4}-/);
 	});
 });

--- a/packages/pipeline-crew-mcp/src/edge/bridge.ts
+++ b/packages/pipeline-crew-mcp/src/edge/bridge.ts
@@ -11,15 +11,21 @@
  */
 import {Effect, Layer, Ref} from "effect";
 import {Inbox, type InboxAck, type InboxEnvelope} from "../peer/index.ts";
+import {renderInstant, stampNow} from "../protocol/index.ts";
 import {ChannelSink} from "./channel-sink.ts";
 
 /**
- * Render a delivered envelope as the `<channel>` tag the session reads: `from`/`kind` as
+ * Render a delivered envelope as the `<channel>` tag the session reads: `from`/`kind`/`at` as
  * attributes, the body as content. Identity rides in the tag because the channel carries
  * no addressing (`meta.from` on the notification is the wire-level echo of the same).
+ *
+ * `at` is the envelope's transport-stamped instant, and it is the ONLY time a reading session
+ * sees — the body carries none. That is what makes it trustworthy: it was read off a clock at
+ * send, not composed by the sending model (#3895). An unreadable clock renders the literal word
+ * `unknown`, which no reader can mistake for an instant.
  */
 export const formatChannelTag = (envelope: InboxEnvelope): string =>
-	`<channel from=${JSON.stringify(envelope.from)} kind=${JSON.stringify(envelope.kind)}>${JSON.stringify(envelope.body)}</channel>`;
+	`<channel from=${JSON.stringify(envelope.from)} kind=${JSON.stringify(envelope.kind)} at=${JSON.stringify(renderInstant(envelope.at))}>${JSON.stringify(envelope.body)}</channel>`;
 
 /**
  * A channel-bridging `Inbox`: every delivery wakes the session over the `ChannelSink` and
@@ -36,11 +42,8 @@ export const channelInboxLayer = (self: string): Layer.Layer<Inbox, never, Chann
 				deliver: (envelope) =>
 					sink.wake({content: formatChannelTag(envelope), meta: {from: envelope.from}}).pipe(
 						Effect.andThen(Ref.update(log, (xs) => [...xs, envelope])),
-						Effect.as<InboxAck>({
-							messageId: envelope.messageId,
-							by: self,
-							at: new Date().toISOString(),
-						}),
+						Effect.andThen(stampNow),
+						Effect.map((at): InboxAck => ({messageId: envelope.messageId, by: self, at})),
 					),
 				received: Ref.get(log),
 			};

--- a/packages/pipeline-crew-mcp/src/edge/claim-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/claim-tool.test.ts
@@ -121,10 +121,9 @@ describe("edge/claim-tool — the channel_claim deconfliction tool (#3509)", () 
 				const client = yield* RpcTest.makeClient(TrackerRegistry);
 				const addrA = "inbox://engineering-manager/a";
 				const addrB = "inbox://engineering-manager/b";
-				const at = new Date().toISOString();
 				// both sessions are live (presence backs claim liveness, ADR 0191 facet 2)
-				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
-				yield* client.AnnouncePresence({peer: addrB, role: "engineering-manager", at});
+				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager"});
+				yield* client.AnnouncePresence({peer: addrB, role: "engineering-manager"});
 
 				const a = yield* makeSession(sessionClaim(client, addrA));
 				const b = yield* makeSession(sessionClaim(client, addrB));
@@ -160,9 +159,8 @@ describe("edge/claim-tool — the channel_claim deconfliction tool (#3509)", () 
 				const client = yield* RpcTest.makeClient(TrackerRegistry);
 				const addrA = "inbox://engineering-manager/a";
 				const addrB = "inbox://engineering-manager/b";
-				const at = new Date().toISOString();
-				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
-				yield* client.AnnouncePresence({peer: addrB, role: "engineering-manager", at});
+				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager"});
+				yield* client.AnnouncePresence({peer: addrB, role: "engineering-manager"});
 
 				const a = yield* makeSession(sessionClaim(client, addrA));
 				const b = yield* makeSession(sessionClaim(client, addrB));

--- a/packages/pipeline-crew-mcp/src/edge/defect-a-double-encode.repro.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/defect-a-double-encode.repro.test.ts
@@ -17,6 +17,7 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import {RpcSerialization} from "effect/unstable/rpc";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import type {InboxAck, InboxEnvelope} from "../peer/index.ts";
+import {stampFromMillis} from "../protocol/index.ts";
 import {formatChannelTag} from "./bridge.ts";
 import {channelExperimentalCapability} from "./mcp-channel.ts";
 import {ChannelSend, ChannelToolkit, channelToolHandlers} from "./send-tool.ts";
@@ -31,7 +32,7 @@ const baseEnvelope = (body: unknown): InboxEnvelope => ({
 	from: "inbox://engineering-manager/1",
 	kind: "IntakePing",
 	body,
-	at: "2026-07-18T00:00:00Z",
+	at: stampFromMillis(Date.parse("2026-07-18T00:00:00Z")),
 });
 
 // A ChannelSend that records the exact `body` the handler forwards, so the test can assert the
@@ -41,7 +42,11 @@ const makeCapturingClient = Effect.gen(function* () {
 	const capturingSend = Layer.succeed(ChannelSend, {
 		send: (_targetRole, _kind, body) =>
 			Ref.set(captured, body).pipe(
-				Effect.as<InboxAck>({messageId: "m-9", by: "peer-b", at: "2026-07-18T00:00:00Z"}),
+				Effect.as<InboxAck>({
+					messageId: "m-9",
+					by: "peer-b",
+					at: stampFromMillis(Date.parse("2026-07-18T00:00:00Z")),
+				}),
 			),
 	});
 
@@ -107,7 +112,6 @@ describe("defect(a): channel_send normalizes body to a struct at the boundary (#
 					body: JSON.stringify({
 						issue: 3486,
 						from: "engineering-manager",
-						at: "2026-07-18T00:00:00Z",
 					}),
 				},
 			});
@@ -129,10 +133,7 @@ describe("defect(a): channel_send normalizes body to a struct at the boundary (#
 				/^"/,
 				"single-encoded body must not start with a quote (that is the double-encode symptom)",
 			);
-			assert.strictEqual(
-				inner,
-				'{"issue":3486,"from":"engineering-manager","at":"2026-07-18T00:00:00Z"}',
-			);
+			assert.strictEqual(inner, '{"issue":3486,"from":"engineering-manager"}');
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/edge/release-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/release-tool.test.ts
@@ -137,10 +137,9 @@ describe("edge/release-tool — the channel_release counterpart (#3796 facet 2)"
 			const addrA = "inbox://engineering-manager/a";
 			const addrB = "inbox://engineering-manager/b";
 			const addrC = "inbox://engineering-manager/c";
-			const at = new Date().toISOString();
 			// A and C are live; the claim's liveness rides presence (ADR 0191 facet 2)
-			yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
-			yield* client.AnnouncePresence({peer: addrC, role: "engineering-manager", at});
+			yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager"});
+			yield* client.AnnouncePresence({peer: addrC, role: "engineering-manager"});
 
 			// A claims #3686 (one call)
 			const claimA = yield* makeSession(sessionPorts(client, addrA));
@@ -185,8 +184,7 @@ describe("edge/release-tool — the channel_release counterpart (#3796 facet 2)"
 				const addrA = "inbox://engineering-manager/a";
 				const addrB = "inbox://engineering-manager/b";
 				const addrC = "inbox://engineering-manager/c";
-				const at = new Date().toISOString();
-				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
+				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager"});
 
 				// A holds #3686 (one call)
 				const claimA = yield* makeSession(sessionPorts(client, addrA));
@@ -221,7 +219,6 @@ describe("edge/release-tool — the channel_release counterpart (#3796 facet 2)"
 			yield* client.AnnouncePresence({
 				peer: addrA,
 				role: "engineering-manager",
-				at: new Date().toISOString(),
 			});
 			const a = yield* makeSession(sessionPorts(client, addrA));
 

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
@@ -14,6 +14,7 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import {RpcSerialization} from "effect/unstable/rpc";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import {type InboxAck, PeerUnreachableError} from "../peer/index.ts";
+import {stampFromMillis} from "../protocol/index.ts";
 import {CHANNEL_CAPABILITY, channelExperimentalCapability} from "./mcp-channel.ts";
 import {ChannelSend, ChannelToolkit, channelToolHandlers} from "./send-tool.ts";
 
@@ -27,7 +28,11 @@ class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
 const FakeSend = Layer.succeed(ChannelSend, {
 	send: (targetRole, _kind, _body) =>
 		targetRole === "reviewer"
-			? Effect.succeed<InboxAck>({messageId: "m-9", by: "peer-b", at: "2026-07-16T10:00:00Z"})
+			? Effect.succeed<InboxAck>({
+					messageId: "m-9",
+					by: "peer-b",
+					at: stampFromMillis(Date.parse("2026-07-16T10:00:00Z")),
+				})
 			: Effect.fail(
 					new PeerUnreachableError({
 						target: targetRole,
@@ -99,7 +104,7 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 				arguments: {
 					targetRole: "reviewer",
 					kind: "IntakePing",
-					body: {issue: 3057, from: "intake", at: "2026-07-16T10:00:00Z"},
+					body: {issue: 3057, from: "intake"},
 				},
 			});
 			assert.isFalse(result.isError);
@@ -117,7 +122,7 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 				arguments: {
 					targetRole: "ghost",
 					kind: "IntakePing",
-					body: {issue: 3057, from: "intake", at: "2026-07-16T10:00:00Z"},
+					body: {issue: 3057, from: "intake"},
 				},
 			});
 			assert.isTrue(result.isError);
@@ -142,7 +147,6 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 						body: {
 							target: {pr: 3649},
 							from: "chief-of-staff",
-							at: "2026-07-19T10:00:00Z",
 						},
 					},
 				});
@@ -166,7 +170,6 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 							target: {issue: 3100},
 							from: "chief-of-staff",
 							note: "worth a pass",
-							at: "2026-07-19T10:00:00Z",
 						},
 					},
 				});
@@ -196,8 +199,41 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 			const {client} = yield* makeInitializedClient;
 			const result = yield* client["tools/call"]({
 				name: "channel_send",
-				// a known kind, but the body is missing IntakePing's required `from`/`at`
+				// a known kind, but the body is missing IntakePing's required `from`
 				arguments: {targetRole: "reviewer", kind: "IntakePing", body: {issue: 3057}},
+			});
+			assert.isTrue(result.isError);
+		}),
+	);
+
+	// #3895: a sender-composed `at` is authored prose, not a reading. A `Schema.Struct` decode would
+	// silently STRIP the excess key, leaving the sender believing it sent a time — so the send path
+	// rejects it loudly instead, and the message names where the real instant comes from.
+	it.effect("channel_send rejects a body carrying a sender-composed `at`", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				arguments: {
+					targetRole: "reviewer",
+					kind: "IntakePing",
+					body: {issue: 3057, from: "intake", at: "2026-07-24T00:00:00Z"},
+				},
+			});
+			assert.isTrue(result.isError);
+		}),
+	);
+
+	it.effect("channel_send rejects a STRINGIFIED body carrying a sender-composed `at`", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				arguments: {
+					targetRole: "reviewer",
+					kind: "IntakePing",
+					body: JSON.stringify({issue: 3057, from: "intake", at: "2026-07-24T00:00:00Z"}),
+				},
 			});
 			assert.isTrue(result.isError);
 		}),
@@ -217,7 +253,7 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 						targetRole: "reviewer",
 						kind: "IntakePing",
 						// the body as the MCP client sends it for an unconstrained param: a JSON string
-						body: JSON.stringify({issue: 3057, from: "intake", at: "2026-07-16T10:00:00Z"}),
+						body: JSON.stringify({issue: 3057, from: "intake"}),
 					},
 				});
 				assert.isFalse(result.isError);

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -72,7 +72,7 @@ const expectedShapeHint = (kind: string, schema: Schema.Codec<unknown>): Effect.
 /**
  * Whether `body` carries a sender-composed `at`. No catalog payload has one any more: the sender is
  * a language model composing JSON, so a time it writes is authored prose that merely looks like a
- * reading (#3895, ADR 0210). A `Schema.Struct` decode would silently STRIP the excess key, which
+ * reading (#3895, ADR 0211). A `Schema.Struct` decode would silently STRIP the excess key, which
  * leaves the sender believing it sent a time — so the send path rejects it instead, and the reject's
  * shape hint shows the body to send. `body` may arrive JSON-stringified (the `Schema.Unknown`
  * impedance mismatch of #3486), so unwrap that form before looking.

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -9,7 +9,7 @@
  * inbox will not answer surfaces as `ChannelDeafError` (#3628) — both returned as an error result
  * to the caller, never a silent drop (#3035).
  */
-import {Context, Effect, Schema} from "effect";
+import {Context, Effect, Option, Schema} from "effect";
 import {Tool, Toolkit} from "effect/unstable/ai";
 import {ChannelDeafError, InboxAck, PeerUnreachableError, type SendOptions} from "../peer/index.ts";
 import {claimResourceKey, crewMessageKinds, payloadSchemaForKind} from "../protocol/index.ts";
@@ -70,6 +70,24 @@ const expectedShapeHint = (kind: string, schema: Schema.Codec<unknown>): Effect.
 	);
 
 /**
+ * Whether `body` carries a sender-composed `at`. No catalog payload has one any more: the sender is
+ * a language model composing JSON, so a time it writes is authored prose that merely looks like a
+ * reading (#3895, ADR 0210). A `Schema.Struct` decode would silently STRIP the excess key, which
+ * leaves the sender believing it sent a time — so the send path rejects it instead, and the reject's
+ * shape hint shows the body to send. `body` may arrive JSON-stringified (the `Schema.Unknown`
+ * impedance mismatch of #3486), so unwrap that form before looking.
+ */
+const senderComposedTimeField = (body: unknown): boolean => {
+	const value =
+		typeof body === "string"
+			? Option.getOrUndefined(
+					Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown))(body),
+				)
+			: body;
+	return typeof value === "object" && value !== null && "at" in value;
+};
+
+/**
  * Decode `body` against the catalog schema for `kind` and RETURN the decoded struct — the single
  * boundary normalization for the send path. An unknown kind or a body that fails its kind's schema
  * short-circuits with an `InvalidMessageError`, so the send never reaches `ChannelSend.send` and the
@@ -84,6 +102,15 @@ const validateOutbound = (
 	kind: string,
 	body: unknown,
 ): Effect.Effect<unknown, InvalidMessageError> => {
+	if (senderComposedTimeField(body)) {
+		return Effect.fail(
+			new InvalidMessageError({
+				kind,
+				reason:
+					'body carries an "at" field — a message time is stamped by the transport at send, never composed by the sender, so no catalog payload has one. Drop "at" and resend; the ack and the delivered `<channel>` tag both carry the stamped instant.',
+			}),
+		);
+	}
 	const schema = payloadSchemaForKind(kind);
 	if (schema === undefined) {
 		return Effect.fail(

--- a/packages/pipeline-crew-mcp/src/peer/inbox.test.ts
+++ b/packages/pipeline-crew-mcp/src/peer/inbox.test.ts
@@ -7,6 +7,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {RpcTest} from "effect/unstable/rpc";
+import {stampFromMillis} from "../protocol/index.ts";
 import {Inbox, type InboxEnvelope, inboxHandlers, PeerInbox} from "./inbox.ts";
 
 const envelope = (over?: Partial<InboxEnvelope>): InboxEnvelope => ({
@@ -14,7 +15,7 @@ const envelope = (over?: Partial<InboxEnvelope>): InboxEnvelope => ({
 	from: "peer-a",
 	kind: "IntakePing",
 	body: {issue: 3056},
-	at: "2026-07-16T10:00:00Z",
+	at: stampFromMillis(Date.parse("2026-07-16T10:00:00Z")),
 	...over,
 });
 

--- a/packages/pipeline-crew-mcp/src/peer/inbox.ts
+++ b/packages/pipeline-crew-mcp/src/peer/inbox.ts
@@ -11,7 +11,7 @@
  */
 import {Context, Effect, Layer, Ref, Schema} from "effect";
 import {Rpc, RpcGroup} from "effect/unstable/rpc";
-import {Messages} from "../protocol/index.ts";
+import {Messages, StampedInstant, stampNow} from "../protocol/index.ts";
 
 /** A dialable inbox address — opaque to the peer (a socket path, URL, …), resolved via the tracker. */
 export const PeerAddress = Schema.NonEmptyString;
@@ -27,7 +27,8 @@ export const InboxEnvelope = Schema.Struct({
 	from: Messages.PeerId,
 	kind: Schema.NonEmptyString,
 	body: Schema.Unknown,
-	at: Messages.Timestamp,
+	/** Transport-stamped at send from the sending peer's clock — never a value inside `body` (#3895). */
+	at: StampedInstant,
 });
 export type InboxEnvelope = typeof InboxEnvelope.Type;
 
@@ -39,7 +40,8 @@ export type InboxEnvelope = typeof InboxEnvelope.Type;
 export const InboxAck = Schema.Struct({
 	messageId: Messages.MessageId,
 	by: Messages.PeerId,
-	at: Messages.Timestamp,
+	/** Receiver-stamped from the receiving peer's clock — the one authority on when this landed. */
+	at: StampedInstant,
 });
 export type InboxAck = typeof InboxAck.Type;
 
@@ -55,7 +57,8 @@ export const PeerInbox = RpcGroup.make(Deliver);
 /**
  * A peer's inbox: the delivery handler that acks + the log of what landed. `deliver`
  * stamps the ack with this peer's own id (`by`) and echoes the envelope's `messageId`,
- * so the sender can correlate the ack to its send.
+ * so the sender can correlate the ack to its send. The ack's `at` is read off this
+ * receiver's clock at delivery — see ADR 0210.
  */
 export class Inbox extends Context.Service<
 	Inbox,
@@ -73,11 +76,8 @@ export class Inbox extends Context.Service<
 				return {
 					deliver: (envelope) =>
 						Ref.update(log, (xs) => [...xs, envelope]).pipe(
-							Effect.as({
-								messageId: envelope.messageId,
-								by: self,
-								at: new Date().toISOString(),
-							}),
+							Effect.andThen(stampNow),
+							Effect.map((at) => ({messageId: envelope.messageId, by: self, at})),
 						),
 					received: Ref.get(log),
 				};

--- a/packages/pipeline-crew-mcp/src/peer/inbox.ts
+++ b/packages/pipeline-crew-mcp/src/peer/inbox.ts
@@ -58,7 +58,7 @@ export const PeerInbox = RpcGroup.make(Deliver);
  * A peer's inbox: the delivery handler that acks + the log of what landed. `deliver`
  * stamps the ack with this peer's own id (`by`) and echoes the envelope's `messageId`,
  * so the sender can correlate the ack to its send. The ack's `at` is read off this
- * receiver's clock at delivery — see ADR 0210.
+ * receiver's clock at delivery — see ADR 0211.
  */
 export class Inbox extends Context.Service<
 	Inbox,

--- a/packages/pipeline-crew-mcp/src/peer/peer.ts
+++ b/packages/pipeline-crew-mcp/src/peer/peer.ts
@@ -19,6 +19,7 @@
 import {randomUUID} from "node:crypto";
 import {Duration, Effect, Option, Result, type Scope} from "effect";
 import * as Arr from "effect/Array";
+import {stampNow} from "../protocol/index.ts";
 import {Dialer} from "./dialer.ts";
 import {ChannelDeafError, PeerUnreachableError} from "./errors.ts";
 import {Inbox, type InboxAck, type InboxEnvelope} from "./inbox.ts";
@@ -159,6 +160,9 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 				? yield* tracker.claimHolder(options.claimResource)
 				: Option.none<string>();
 			const targets = selectDeliveryTargets(holders, claimOwner);
+			// The envelope's `at` is read off THIS transport's clock, here — the message body carries no
+			// time at all, because a sender-composed one is authored prose, not a reading (see ADR 0210).
+			const at = yield* stampNow;
 			// One logical message, delivered to the selected target(s). A bridge has one holder (an ordinary
 			// point-to-point send); an engine pool has N, across which a per-item advisory reaches the seat
 			// that OWNS the item — routed straight to it when the claim resolves, else fanned to all. This
@@ -169,7 +173,7 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 				from: config.self,
 				kind,
 				body,
-				at: new Date().toISOString(),
+				at,
 			};
 			// Deliver to the WHOLE selected set before deciding the result — a fan must not fail-fast on one
 			// deaf seat and skip the rest, so each dial is reified into a Result and every target is dialed.

--- a/packages/pipeline-crew-mcp/src/peer/peer.ts
+++ b/packages/pipeline-crew-mcp/src/peer/peer.ts
@@ -161,7 +161,7 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 				: Option.none<string>();
 			const targets = selectDeliveryTargets(holders, claimOwner);
 			// The envelope's `at` is read off THIS transport's clock, here — the message body carries no
-			// time at all, because a sender-composed one is authored prose, not a reading (see ADR 0210).
+			// time at all, because a sender-composed one is authored prose, not a reading (see ADR 0211).
 			const at = yield* stampNow;
 			// One logical message, delivered to the selected target(s). A bridge has one holder (an ordinary
 			// point-to-point send); an engine pool has N, across which a per-item advisory reaches the seat

--- a/packages/pipeline-crew-mcp/src/protocol/group.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.test.ts
@@ -18,6 +18,7 @@ import {
 	payloadSchemaForKind,
 	Release,
 } from "./group.ts";
+import {stampFromMillis} from "./instant.ts";
 import * as Messages from "./schema.ts";
 
 describe("protocol/group catalog", () => {
@@ -49,7 +50,7 @@ describe("protocol/group catalog", () => {
 			granted: true,
 			collision: false,
 			owner: "peer-a",
-			since: "2026-07-16T10:00:00Z",
+			since: stampFromMillis(Date.parse("2026-07-16T10:00:00Z")),
 		};
 		assert.deepStrictEqual(Schema.decodeUnknownSync(Claim.successSchema)(reply), reply);
 	});
@@ -65,7 +66,7 @@ describe("protocol/group catalog", () => {
 	it("payloadSchemaForKind resolves a catalog kind to its payload schema (#3229)", () => {
 		// the resolver is derived from the catalog, so every kind resolves and a valid payload decodes
 		assert.strictEqual(payloadSchemaForKind("IntakePing"), Messages.IntakePing);
-		const ping = {issue: 3057, from: "intake", at: "2026-07-16T10:00:00Z"};
+		const ping = {issue: 3057, from: "intake"};
 		assert.deepStrictEqual(
 			Schema.decodeUnknownSync(payloadSchemaForKind("IntakePing")!)(ping),
 			ping,
@@ -99,7 +100,6 @@ describe("protocol/group catalog", () => {
 			claimResourceKey("EngineNudge", {
 				target: {issue: 3886},
 				from: "cos",
-				at: "2026-07-24T00:00:00Z",
 			}),
 			"issue-3886",
 		);
@@ -107,7 +107,6 @@ describe("protocol/group catalog", () => {
 			claimResourceKey("EngineNudge", {
 				target: {pr: 3877},
 				from: "cos",
-				at: "2026-07-24T00:00:00Z",
 			}),
 			"pr-3877",
 		);

--- a/packages/pipeline-crew-mcp/src/protocol/index.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/index.ts
@@ -26,4 +26,16 @@ export {
 	payloadSchemaForKind,
 	Release,
 } from "./group.ts";
+export {
+	Iso8601Utc,
+	isObserved,
+	MAX_PLAUSIBLE_EPOCH_MILLIS,
+	MIN_PLAUSIBLE_EPOCH_MILLIS,
+	ObservedInstant,
+	renderInstant,
+	StampedInstant,
+	stampFromMillis,
+	stampNow,
+	UnknownInstant,
+} from "./instant.ts";
 export * as Messages from "./schema.ts";

--- a/packages/pipeline-crew-mcp/src/protocol/instant.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/instant.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The observed-instant core (#3895, ADR 0210): a clock reading becomes a typed instant or a typed
+ * unknown — never a fabricated or defaulted time.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Clock, Effect, Schema} from "effect";
+import {
+	Iso8601Utc,
+	MAX_PLAUSIBLE_EPOCH_MILLIS,
+	MIN_PLAUSIBLE_EPOCH_MILLIS,
+	renderInstant,
+	StampedInstant,
+	stampFromMillis,
+	stampNow,
+} from "./instant.ts";
+
+describe("protocol/instant — stampFromMillis", () => {
+	it("a plausible reading becomes an ObservedInstant rendered ISO-8601 UTC", () => {
+		const stamped = stampFromMillis(Date.parse("2026-07-24T17:30:05.123Z"));
+		assert.deepStrictEqual(stamped, {
+			_tag: "ObservedInstant",
+			iso: "2026-07-24T17:30:05.123Z",
+		});
+	});
+
+	it("the rendered form satisfies the Iso8601Utc check", () => {
+		const stamped = stampFromMillis(Date.parse("2026-07-24T17:30:05.123Z"));
+		assert.strictEqual(stamped._tag, "ObservedInstant");
+		if (stamped._tag !== "ObservedInstant") return;
+		assert.strictEqual(Schema.decodeUnknownSync(Iso8601Utc)(stamped.iso), stamped.iso);
+	});
+
+	// A leaked TestClock starts at 0. Rendering it would produce a confident `1970-01-01T00:00:00.000Z`
+	// — the indeterminate-read-as-confident-value defect this module exists to remove.
+	it("an epoch-0 reading resolves UNKNOWN, never a confident 1970 instant", () => {
+		const stamped = stampFromMillis(0);
+		assert.strictEqual(stamped._tag, "UnknownInstant");
+		assert.notInclude(JSON.stringify(stamped), "1970");
+	});
+
+	it("a non-finite reading resolves UNKNOWN", () => {
+		for (const bogus of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+			assert.strictEqual(stampFromMillis(bogus)._tag, "UnknownInstant", `for ${bogus}`);
+		}
+	});
+
+	it("a reading outside the plausible window resolves UNKNOWN at both ends", () => {
+		assert.strictEqual(stampFromMillis(MIN_PLAUSIBLE_EPOCH_MILLIS - 1)._tag, "UnknownInstant");
+		assert.strictEqual(stampFromMillis(MAX_PLAUSIBLE_EPOCH_MILLIS + 1)._tag, "UnknownInstant");
+		assert.strictEqual(stampFromMillis(MIN_PLAUSIBLE_EPOCH_MILLIS)._tag, "ObservedInstant");
+		assert.strictEqual(stampFromMillis(MAX_PLAUSIBLE_EPOCH_MILLIS)._tag, "ObservedInstant");
+	});
+
+	it("an UnknownInstant carries a reason and NO time field to misread", () => {
+		const stamped = stampFromMillis(Number.NaN);
+		assert.strictEqual(stamped._tag, "UnknownInstant");
+		assert.notProperty(stamped, "iso");
+		if (stamped._tag !== "UnknownInstant") return;
+		assert.isAbove(stamped.reason.length, 0);
+	});
+
+	it("every outcome decodes as the wire StampedInstant", () => {
+		for (const millis of [Date.now(), 0, Number.NaN]) {
+			const stamped = stampFromMillis(millis);
+			assert.deepStrictEqual(Schema.decodeUnknownSync(StampedInstant)(stamped), stamped);
+		}
+	});
+});
+
+describe("protocol/instant — stampNow reads the ambient clock", () => {
+	it.live("stamps the ambient clock's own reading, not a caller-supplied value", () =>
+		Effect.gen(function* () {
+			const stamped = yield* stampNow;
+			const reading = yield* Clock.currentTimeMillis;
+			assert.strictEqual(stamped._tag, "ObservedInstant");
+			if (stamped._tag !== "ObservedInstant") return;
+			assert.isAtMost(Math.abs(Date.parse(stamped.iso) - reading), 5_000);
+		}),
+	);
+
+	// `it.effect` runs under the TestClock, which starts parked at epoch 0 — the synthetic time
+	// source the investigation raised as a candidate. It stamps UNKNOWN, so a leaked test clock can
+	// never surface as a confident instant.
+	it.effect("a synthetic clock parked at epoch 0 stamps UNKNOWN, never a 1970 instant", () =>
+		Effect.gen(function* () {
+			const stamped = yield* stampNow;
+			assert.strictEqual(stamped._tag, "UnknownInstant");
+		}),
+	);
+});
+
+describe("protocol/instant — renderInstant", () => {
+	it("renders an observation as its ISO instant", () => {
+		assert.strictEqual(
+			renderInstant(stampFromMillis(Date.parse("2026-07-24T17:30:05.000Z"))),
+			"2026-07-24T17:30:05.000Z",
+		);
+	});
+
+	it("renders an unknown as the literal word unknown, unmistakable as a time", () => {
+		const rendered = renderInstant(stampFromMillis(Number.NaN));
+		assert.match(rendered, /^unknown \(/);
+		assert.notMatch(rendered, /\d{4}-\d{2}-\d{2}T/);
+	});
+});

--- a/packages/pipeline-crew-mcp/src/protocol/instant.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/instant.test.ts
@@ -1,5 +1,5 @@
 /**
- * The observed-instant core (#3895, ADR 0210): a clock reading becomes a typed instant or a typed
+ * The observed-instant core (#3895, ADR 0211): a clock reading becomes a typed instant or a typed
  * unknown — never a fabricated or defaulted time.
  */
 import {assert, describe, it} from "@effect/vitest";

--- a/packages/pipeline-crew-mcp/src/protocol/instant.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/instant.ts
@@ -1,0 +1,92 @@
+/**
+ * protocol/instant — the observed-instant type, and the only sanctioned way to produce one.
+ *
+ * A crew message's time field used to be a bare `Schema.String` the SENDER filled in. On this
+ * substrate the sender is a language model composing JSON, so that field was authored prose that
+ * merely looked like a reading: it could be plausibly wrong, or a hand-written placeholder, with
+ * nothing distinguishing either from a real observation (#3895). The fix is a type, not a warning —
+ * `StampedInstant` is producible only from a clock reading, and an unusable reading resolves to a
+ * typed `UnknownInstant` rather than a fabricated or defaulted time.
+ */
+import {Clock, Effect, Schema} from "effect";
+
+/**
+ * The lower sanity bound on a clock reading, as epoch millis (2020-01-01T00:00:00Z). A reading at
+ * or near the epoch is the signature of an uninitialized or synthetic time source — a leaked
+ * `TestClock` starts at 0 — and rendering it would produce a confident `1970-01-01T00:00:00.000Z`,
+ * the exact indeterminate-read-as-confident-value defect this module exists to remove.
+ */
+export const MIN_PLAUSIBLE_EPOCH_MILLIS = Date.UTC(2020, 0, 1);
+
+/** The upper sanity bound on a clock reading, as epoch millis (2100-01-01T00:00:00Z). */
+export const MAX_PLAUSIBLE_EPOCH_MILLIS = Date.UTC(2100, 0, 1);
+
+/** An ISO-8601 UTC instant, `Z`-suffixed — the rendered form of an observed reading. */
+const ISO_8601_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+
+export const Iso8601Utc = Schema.String.check(
+	Schema.isPattern(ISO_8601_UTC_RE, {
+		title: "Iso8601Utc",
+		description: "an ISO-8601 UTC instant, e.g. 2026-07-24T17:30:05.123Z",
+	}),
+);
+
+/** A time actually read off a clock, rendered ISO-8601 UTC. */
+export const ObservedInstant = Schema.Struct({
+	_tag: Schema.Literal("ObservedInstant"),
+	iso: Iso8601Utc,
+});
+
+/**
+ * The clock could not be read into a usable instant. It carries the `reason` and NO time field at
+ * all, so there is no slot a consumer could read a fabricated instant out of.
+ */
+export const UnknownInstant = Schema.Struct({
+	_tag: Schema.Literal("UnknownInstant"),
+	reason: Schema.NonEmptyString,
+});
+
+/**
+ * Every time a crew message carries. The union is the invariant: a consumer must branch on the tag,
+ * so "the clock was unreadable" can never be silently read as an instant.
+ */
+export const StampedInstant = Schema.Union([ObservedInstant, UnknownInstant]);
+export type StampedInstant = typeof StampedInstant.Type;
+
+/**
+ * The pure core: an epoch-millis reading becomes an observed instant, or a typed unknown naming why.
+ * Fail-closed — only a finite reading inside the plausible window renders.
+ */
+export const stampFromMillis = (millis: number): StampedInstant => {
+	if (!Number.isFinite(millis)) {
+		return {_tag: "UnknownInstant", reason: "the clock read a non-finite value"};
+	}
+	if (millis < MIN_PLAUSIBLE_EPOCH_MILLIS || millis > MAX_PLAUSIBLE_EPOCH_MILLIS) {
+		return {
+			_tag: "UnknownInstant",
+			reason: `the clock read ${millis}, outside the plausible epoch-millis window [${MIN_PLAUSIBLE_EPOCH_MILLIS}, ${MAX_PLAUSIBLE_EPOCH_MILLIS}]`,
+		};
+	}
+	// The window check above is what makes this render total: `Date#toISOString` throws only outside
+	// the representable range, which the bounds exclude by a wide margin.
+	return {_tag: "ObservedInstant", iso: new Date(millis).toISOString()};
+};
+
+/**
+ * Read the ambient clock and stamp it. This — never a caller-supplied value — is how every
+ * transport- and receiver-stamped time in the package is produced. `Clock.currentTimeMillis` rather
+ * than a raw `new Date()` so the reading goes through the one time source the runtime governs.
+ */
+export const stampNow: Effect.Effect<StampedInstant> = Clock.currentTimeMillis.pipe(
+	Effect.map(stampFromMillis),
+);
+
+/** Whether a stamp carries a real reading — the one predicate a consumer needs before trusting it. */
+export const isObserved = (instant: StampedInstant): boolean => instant._tag === "ObservedInstant";
+
+/**
+ * Render a stamp for a surface a human or a model reads. An unknown renders as the literal word
+ * `unknown` plus its reason: unmistakable as a time, so no reader can mistake it for one.
+ */
+export const renderInstant = (instant: StampedInstant): string =>
+	instant._tag === "ObservedInstant" ? instant.iso : `unknown (${instant.reason})`;

--- a/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
@@ -6,6 +6,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Schema} from "effect";
+import {stampFromMillis} from "./instant.ts";
 import * as Messages from "./schema.ts";
 
 const roundTrips = <S extends Schema.Codec<any, any>>(schema: S, value: S["Type"]): void => {
@@ -25,14 +26,13 @@ describe("protocol/schema round-trips", () => {
 			resource: "issue:3054",
 			claimant: "peer-a",
 			role: "builder",
-			at: "2026-07-16T10:00:00Z",
 		});
 		roundTrips(Messages.ClaimReply, {
 			resource: "issue:3054",
 			granted: false,
 			collision: true,
 			owner: "peer-b",
-			since: "2026-07-16T09:59:00Z",
+			since: stampFromMillis(Date.parse("2026-07-16T09:59:00Z")),
 		});
 	});
 
@@ -40,7 +40,6 @@ describe("protocol/schema round-trips", () => {
 		roundTrips(Messages.ReleaseClaim, {
 			resource: "issue:3054",
 			claimant: "peer-a",
-			at: "2026-07-16T10:05:00Z",
 		});
 	});
 
@@ -51,7 +50,6 @@ describe("protocol/schema round-trips", () => {
 			inFlight: 2,
 			total: 9,
 			reporter: "peer-em",
-			at: "2026-07-16T10:02:00Z",
 		});
 	});
 
@@ -60,12 +58,10 @@ describe("protocol/schema round-trips", () => {
 			issue: asIssue(3100),
 			from: "triage",
 			note: "needs a second look",
-			at: "2026-07-16T10:03:00Z",
 		});
 		roundTrips(Messages.IntakePing, {
 			issue: asIssue(3100),
 			from: "triage",
-			at: "2026-07-16T10:03:00Z",
 		});
 	});
 
@@ -74,12 +70,10 @@ describe("protocol/schema round-trips", () => {
 			target: {pr: asPr(3649)},
 			from: "chief-of-staff",
 			note: "reviewed + banked, worth a look",
-			at: "2026-07-19T10:03:00Z",
 		});
 		roundTrips(Messages.EngineNudge, {
 			target: {issue: asIssue(3100)},
 			from: "chief-of-staff",
-			at: "2026-07-19T10:03:00Z",
 		});
 	});
 
@@ -87,14 +81,21 @@ describe("protocol/schema round-trips", () => {
 		roundTrips(Messages.PresenceAnnouncement, {
 			peer: "peer-a",
 			role: "builder",
-			at: "2026-07-16T10:04:00Z",
 		});
 		roundTrips(Messages.RoleLookupQuery, {role: "builder"});
 		roundTrips(Messages.RoleLookupResult, {
 			role: "builder",
 			peers: [
-				{peer: "peer-a", role: "builder", lastSeen: "2026-07-16T10:04:00Z"},
-				{peer: "peer-b", role: "builder", lastSeen: "2026-07-16T10:04:30Z"},
+				{
+					peer: "peer-a",
+					role: "builder",
+					lastSeen: stampFromMillis(Date.parse("2026-07-16T10:04:00Z")),
+				},
+				{
+					peer: "peer-b",
+					role: "builder",
+					lastSeen: stampFromMillis(Date.parse("2026-07-16T10:04:30Z")),
+				},
 			],
 		});
 		roundTrips(Messages.RoleLookupResult, {role: "builder", peers: []});
@@ -104,7 +105,6 @@ describe("protocol/schema round-trips", () => {
 		roundTrips(Messages.Heartbeat, {
 			peer: "peer-a",
 			ttlSeconds: 30,
-			at: "2026-07-16T10:05:00Z",
 		});
 	});
 });

--- a/packages/pipeline-crew-mcp/src/protocol/schema.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.ts
@@ -6,8 +6,14 @@
  * crew noun — that is what lets tracker, peer, and edge code against this contract without
  * pulling in `crew/`. Every payload is an `effect/Schema` type so the wire format is
  * decode-checked at the boundary rather than trusted as an untyped bag.
+ *
+ * No payload here carries a sender-composed time. A sender on this substrate is a language model
+ * composing JSON, so a time it supplies is authored prose, not a reading (#3895); the authoritative
+ * instants are stamped by the transport (`peer/`'s envelope), the receiver (`peer/`'s inbox ack),
+ * or the tracker (`since`/`lastSeen` below) as a `StampedInstant`. See ADR 0210.
  */
 import {Schema} from "effect";
+import {StampedInstant} from "./instant.ts";
 
 /** An opaque role identifier — a parameter, never a concrete crew role noun (see the module note). */
 export const RoleId = Schema.NonEmptyString;
@@ -17,9 +23,6 @@ export const PeerId = Schema.NonEmptyString;
 
 /** An opaque message identifier, used to correlate an ack back to its delivery. */
 export const MessageId = Schema.NonEmptyString;
-
-/** An ISO-8601 UTC instant, kept as a string so the wire format stays transport-agnostic + JSON-safe. */
-export const Timestamp = Schema.String;
 
 /**
  * A GitHub issue number — a positive integer, branded so it can't be confused with a bare count
@@ -52,7 +55,6 @@ export const ClaimRequest = Schema.Struct({
 	resource: Schema.NonEmptyString,
 	claimant: PeerId,
 	role: RoleId,
-	at: Timestamp,
 });
 
 /** The typed answer to a `ClaimRequest`: whether it was granted, and who currently owns it. */
@@ -61,7 +63,8 @@ export const ClaimReply = Schema.Struct({
 	granted: Schema.Boolean,
 	collision: Schema.Boolean,
 	owner: PeerId,
-	since: Timestamp,
+	/** Tracker-stamped from the tracker's own clock — never the claimant's word for when it claimed. */
+	since: StampedInstant,
 });
 
 /**
@@ -72,7 +75,6 @@ export const ClaimReply = Schema.Struct({
 export const ReleaseClaim = Schema.Struct({
 	resource: Schema.NonEmptyString,
 	claimant: PeerId,
-	at: Timestamp,
 });
 
 // Kind 2 — drain-progress tally.
@@ -83,7 +85,6 @@ export const DrainProgressTally = Schema.Struct({
 	inFlight: Schema.Int,
 	total: Schema.Int,
 	reporter: PeerId,
-	at: Timestamp,
 });
 
 // Kind 3 — intake ping.
@@ -92,7 +93,6 @@ export const IntakePing = Schema.Struct({
 	issue: IssueNumber,
 	from: RoleId,
 	note: Schema.optionalKey(Schema.String),
-	at: Timestamp,
 });
 
 // Kind 6 — engine nudge (advisory, non-routing; chief-of-staff → engine).
@@ -115,7 +115,6 @@ export const EngineNudge = Schema.Struct({
 	target: NudgeTarget,
 	from: RoleId,
 	note: Schema.optionalKey(Schema.String),
-	at: Timestamp,
 });
 
 /**
@@ -135,7 +134,8 @@ export const nudgeTargetResourceKey = (target: typeof NudgeTarget.Type): string 
 export const PresenceEntry = Schema.Struct({
 	peer: PeerId,
 	role: RoleId,
-	lastSeen: Timestamp,
+	/** Tracker-stamped from the tracker's own clock — never the peer's word for when it was last up. */
+	lastSeen: StampedInstant,
 });
 
 /**
@@ -148,7 +148,6 @@ export const PresenceAnnouncement = Schema.Struct({
 	peer: PeerId,
 	role: RoleId,
 	attached: Schema.optional(Schema.Boolean),
-	at: Timestamp,
 });
 
 /** A lookup query for peers serving a role; answered by a `RoleLookupResult`. */
@@ -167,7 +166,6 @@ export const RoleLookupResult = Schema.Struct({
 export const Heartbeat = Schema.Struct({
 	peer: PeerId,
 	ttlSeconds: Schema.Int,
-	at: Timestamp,
 });
 
 // Kind 7 — claim-holder lookup (the read side of the resource-claim keyspace, ADR 0191).

--- a/packages/pipeline-crew-mcp/src/protocol/schema.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.ts
@@ -10,7 +10,7 @@
  * No payload here carries a sender-composed time. A sender on this substrate is a language model
  * composing JSON, so a time it supplies is authored prose, not a reading (#3895); the authoritative
  * instants are stamped by the transport (`peer/`'s envelope), the receiver (`peer/`'s inbox ack),
- * or the tracker (`since`/`lastSeen` below) as a `StampedInstant`. See ADR 0210.
+ * or the tracker (`since`/`lastSeen` below) as a `StampedInstant`. See ADR 0211.
  */
 import {Schema} from "effect";
 import {StampedInstant} from "./instant.ts";

--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
@@ -47,7 +47,6 @@ describe("tryBecomeTracker — the bind-outcome core", () => {
 			yield* client.AnnouncePresence({
 				peer: "inbox://peer-a",
 				role: "builder",
-				at: "2026-07-16T10:00:00Z",
 			});
 			const result = yield* client.LookupRole({role: "builder"});
 			assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
@@ -92,7 +91,6 @@ describe("ensureTrackerRunning — the detached standing process", () => {
 					yield* client.AnnouncePresence({
 						peer: "inbox://peer-a",
 						role: "builder",
-						at: "2026-07-16T10:00:00Z",
 					});
 					const result = yield* client.LookupRole({role: "builder"});
 					assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");

--- a/packages/pipeline-crew-mcp/src/tracker/handlers.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/handlers.ts
@@ -5,17 +5,16 @@
  * coexists); `Claim` / `Release` operate on the resource-claim keyspace (keyed by `resource`).
  * `ClaimRequest`'s `role` field is consumed here as the claim's `claimantRole`.
  *
- * `lastSeen`/`since`/`at` cross the wire as ISO-8601 strings (the protocol `Timestamp`), but the
- * registry reasons in epoch millis against its own clock — the conversion happens here at the
- * boundary. `Claim` is the only reply-carrying kind (granted/collision/owner); the rest are
- * fire-and-forget.
+ * `lastSeen`/`since` cross the wire as a `StampedInstant`, but the registry reasons in epoch millis
+ * against its own clock — the conversion happens here at the boundary, through `stampFromMillis`, so
+ * an unusable clock reading crosses as a typed unknown rather than a fabricated time (ADR 0210).
+ * `Claim` is the only reply-carrying kind (granted/collision/owner); the rest are fire-and-forget.
  */
 import {Effect} from "effect";
+import {stampFromMillis} from "../protocol/index.ts";
 import {TrackerRegistry} from "./group.ts";
 import {Registry} from "./registry.ts";
 import {DEFAULT_TTL_SECONDS} from "./registry-core.ts";
-
-const iso = (millis: number): string => new Date(millis).toISOString();
 
 export const TrackerHandlers = TrackerRegistry.toLayer(
 	Effect.gen(function* () {
@@ -34,7 +33,7 @@ export const TrackerHandlers = TrackerRegistry.toLayer(
 							granted: outcome._tag === "Granted",
 							collision: outcome._tag === "Collision",
 							owner: outcome.holder,
-							since: iso(outcome.sinceMillis),
+							since: stampFromMillis(outcome.sinceMillis),
 						})),
 					),
 			Release: (payload) =>
@@ -59,7 +58,7 @@ export const TrackerHandlers = TrackerRegistry.toLayer(
 						peers: records.map((r) => ({
 							peer: r.peer,
 							role: r.role,
-							lastSeen: iso(r.lastSeenMillis),
+							lastSeen: stampFromMillis(r.lastSeenMillis),
 						})),
 					})),
 				),

--- a/packages/pipeline-crew-mcp/src/tracker/handlers.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/handlers.ts
@@ -7,7 +7,7 @@
  *
  * `lastSeen`/`since` cross the wire as a `StampedInstant`, but the registry reasons in epoch millis
  * against its own clock — the conversion happens here at the boundary, through `stampFromMillis`, so
- * an unusable clock reading crosses as a typed unknown rather than a fabricated time (ADR 0210).
+ * an unusable clock reading crosses as a typed unknown rather than a fabricated time (ADR 0211).
  * `Claim` is the only reply-carrying kind (granted/collision/owner); the rest are fire-and-forget.
  */
 import {Effect} from "effect";

--- a/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
@@ -13,13 +13,12 @@ import {TrackerHandlers} from "./handlers.ts";
 import {RegistryLive} from "./registry.ts";
 
 const handlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
-const at = "2026-07-16T10:00:00Z";
 
 describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 	it.effect("announce then lookup round-trips a peer's role + inbox address", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
-			yield* client.AnnouncePresence({peer: "inbox://peer-a", role: "builder", at});
+			yield* client.AnnouncePresence({peer: "inbox://peer-a", role: "builder"});
 			const result = yield* client.LookupRole({role: "builder"});
 			assert.strictEqual(result.role, "builder");
 			assert.lengthOf(result.peers, 1);
@@ -40,8 +39,8 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
 			// two engine instances of the same role, distinct per-instance inbox addresses
-			yield* client.AnnouncePresence({peer: "inbox://em/one", role: "em", at});
-			yield* client.AnnouncePresence({peer: "inbox://em/two", role: "em", at});
+			yield* client.AnnouncePresence({peer: "inbox://em/one", role: "em"});
+			yield* client.AnnouncePresence({peer: "inbox://em/two", role: "em"});
 			const result = yield* client.LookupRole({role: "em"});
 			assert.lengthOf(result.peers, 2, "the second announce did not overwrite the first");
 			assert.deepStrictEqual(result.peers.map((p) => p.peer).sort(), [
@@ -55,12 +54,11 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
 			// The incumbent's claim is live only while its presence is — announce it first (ADR 0191).
-			yield* client.AnnouncePresence({peer: "peer-a", role: "builder", at});
+			yield* client.AnnouncePresence({peer: "peer-a", role: "builder"});
 			const first = yield* client.Claim({
 				resource: "issue-3054",
 				claimant: "peer-a",
 				role: "builder",
-				at,
 			});
 			assert.isTrue(first.granted);
 			assert.isFalse(first.collision);
@@ -70,7 +68,6 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 				resource: "issue-3054",
 				claimant: "peer-b",
 				role: "builder",
-				at,
 			});
 			assert.isFalse(second.granted);
 			assert.isTrue(second.collision);
@@ -81,15 +78,14 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 	it.effect("Release frees a held claim so another peer can then claim the resource", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
-			yield* client.AnnouncePresence({peer: "peer-a", role: "builder", at});
-			yield* client.AnnouncePresence({peer: "peer-b", role: "reviewer", at});
-			yield* client.Claim({resource: "issue-3054", claimant: "peer-a", role: "builder", at});
-			yield* client.Release({resource: "issue-3054", claimant: "peer-a", at});
+			yield* client.AnnouncePresence({peer: "peer-a", role: "builder"});
+			yield* client.AnnouncePresence({peer: "peer-b", role: "reviewer"});
+			yield* client.Claim({resource: "issue-3054", claimant: "peer-a", role: "builder"});
+			yield* client.Release({resource: "issue-3054", claimant: "peer-a"});
 			const reclaim = yield* client.Claim({
 				resource: "issue-3054",
 				claimant: "peer-b",
 				role: "reviewer",
-				at,
 			});
 			assert.isTrue(reclaim.granted, "the released resource is free for a new claimant");
 			assert.strictEqual(reclaim.owner, "peer-b");
@@ -99,15 +95,14 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 	it.effect("Release by a non-holder is a no-op — a peer cannot steal-release (ADR 0191)", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
-			yield* client.AnnouncePresence({peer: "peer-a", role: "builder", at});
-			yield* client.Claim({resource: "issue-3054", claimant: "peer-a", role: "builder", at});
+			yield* client.AnnouncePresence({peer: "peer-a", role: "builder"});
+			yield* client.Claim({resource: "issue-3054", claimant: "peer-a", role: "builder"});
 			// peer-b does not hold the claim: its release must not free peer-a's hold.
-			yield* client.Release({resource: "issue-3054", claimant: "peer-b", at});
+			yield* client.Release({resource: "issue-3054", claimant: "peer-b"});
 			const stillHeld = yield* client.Claim({
 				resource: "issue-3054",
 				claimant: "peer-c",
 				role: "builder",
-				at,
 			});
 			assert.isTrue(stillHeld.collision, "peer-a still holds it — the foreign release was ignored");
 			assert.strictEqual(stillHeld.owner, "peer-a");
@@ -119,8 +114,8 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 		() =>
 			Effect.gen(function* () {
 				const client = yield* RpcTest.makeClient(TrackerRegistry);
-				yield* client.AnnouncePresence({peer: "inbox://em-owner", role: "em", at});
-				yield* client.Claim({resource: "issue-3886", claimant: "inbox://em-owner", role: "em", at});
+				yield* client.AnnouncePresence({peer: "inbox://em-owner", role: "em"});
+				yield* client.Claim({resource: "issue-3886", claimant: "inbox://em-owner", role: "em"});
 				const held = yield* client.LookupClaim({resource: "issue-3886"});
 				assert.deepStrictEqual(held, {resource: "issue-3886", holder: "inbox://em-owner"});
 			}).pipe(Effect.scoped, Effect.provide(handlers)),
@@ -139,9 +134,9 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 	it.effect("LookupClaim omits the holder once a released claim frees the resource", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
-			yield* client.AnnouncePresence({peer: "inbox://em-owner", role: "em", at});
-			yield* client.Claim({resource: "issue-3886", claimant: "inbox://em-owner", role: "em", at});
-			yield* client.Release({resource: "issue-3886", claimant: "inbox://em-owner", at});
+			yield* client.AnnouncePresence({peer: "inbox://em-owner", role: "em"});
+			yield* client.Claim({resource: "issue-3886", claimant: "inbox://em-owner", role: "em"});
+			yield* client.Release({resource: "issue-3886", claimant: "inbox://em-owner"});
 			const freed = yield* client.LookupClaim({resource: "issue-3886"});
 			assert.deepStrictEqual(freed, {resource: "issue-3886"}, "the freed resource has no holder");
 		}).pipe(Effect.scoped, Effect.provide(handlers)),
@@ -150,8 +145,8 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 	it.effect("a heartbeat is accepted for a live peer", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
-			yield* client.AnnouncePresence({peer: "inbox://peer-a", role: "builder", at});
-			yield* client.Heartbeat({peer: "inbox://peer-a", ttlSeconds: 60, at});
+			yield* client.AnnouncePresence({peer: "inbox://peer-a", role: "builder"});
+			yield* client.Heartbeat({peer: "inbox://peer-a", ttlSeconds: 60});
 			const result = yield* client.LookupRole({role: "builder"});
 			assert.lengthOf(result.peers, 1);
 		}).pipe(Effect.scoped, Effect.provide(handlers)),

--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -67,7 +67,6 @@ describe("tracker over a unix socket — RpcServer round-trip", () => {
 			yield* client.AnnouncePresence({
 				peer: "inbox://peer-a",
 				role: "builder",
-				at: "2026-07-16T10:00:00Z",
 			});
 			const result = yield* client.LookupRole({role: "builder"});
 			assert.strictEqual(result.role, "builder");
@@ -123,7 +122,6 @@ describe("tracker stale-socket crash recovery (#3280)", () => {
 					yield* client.AnnouncePresence({
 						peer: "inbox://peer-a",
 						role: "builder",
-						at: "2026-07-16T10:00:00Z",
 					});
 					return yield* client.LookupRole({role: "builder"});
 				}).pipe(Effect.provide(socketClientLayer(socketPath)));
@@ -156,7 +154,6 @@ describe("tracker stale-socket crash recovery (#3280)", () => {
 				yield* client.AnnouncePresence({
 					peer: "inbox://peer-a",
 					role: "builder",
-					at: "2026-07-16T10:00:00Z",
 				});
 				const result = yield* client.LookupRole({role: "builder"});
 				assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");


### PR DESCRIPTION
Crew messages carried a time field that the *sender* filled in — and on this substrate the sender is a language model writing JSON. So a field everyone read as "when this happened" was really generated text that looked like a timestamp: it drifted hours over a session, it sometimes held an obvious placeholder like `2026-07-24T00:00:00Z`, and nothing told a reader which was which. This PR takes that field away from the sender: times are now read off a real clock by the transport, the receiver, or the tracker, and when a clock can't be read the message says so in a way no reader can mistake for a time.

This is a collapsed investigation (ADR 0070): #3895 asked for a diagnosis, the diagnosis landed, and the fix is bounded, so it ships as one PR instead of a closing comment plus residue. The diagnosis is carried below so the fix can be verified against the named cause.

## The diagnosis

The investigation looked for a skewing process clock. There isn't one — the drift is not a clock at all.

- **Which component stamped the drifting time: none of them.** Every catalog payload declared `at: Timestamp`, and `Timestamp` was `Schema.String` — any string shaped like a time. `channel_send` requires the caller to supply the whole `body`, so `at` was *written into the payload by the sending model*. No clock was consulted.
- **Why the drift is monotonic and accelerating.** It is a narrative being extended one message at a time, not a counter running fast. Each composed time is anchored on the previous one and pushed a little further; no process clock behaves that way.
- **Why it survived the server respawn.** A respawn resets the server, not the sender's context. The composer kept composing.
- **Presence and claim liveness are NOT exposed.** The tracker never read the payload `at` — `tracker/handlers.ts` discards it, and `tracker/registry.ts` measures every lease and expiry against its own `Clock.currentTimeMillis`. So the jump-vs-constant-offset question the issue raised is moot for liveness: the payload time and the liveness clock were never the same quantity. The field was write-only decoration whose only effect was to mislead whoever read it.

Two facts shaped the fix. The tracker already ignored the sender's time, so removing it costs nothing. And the transport and receiver already stamped real times (the envelope's and the ack's) — an authoritative instant existed at the right layer the whole time. It was just duplicated by a composed one, unvalidated, and dropped from the `<channel>` wake tag a session actually reads in favour of the body's.

## What changed

- **`at` is gone from all seven sender-composed payloads** — `ClaimRequest`, `ReleaseClaim`, `DrainProgressTally`, `IntakePing`, `EngineNudge`, `PresenceAnnouncement`, `Heartbeat`. No replacement sender-intent field: nothing consumed one, and re-adding it under another name would recreate the defect.
- **`StampedInstant` replaces `Timestamp`** (`packages/pipeline-crew-mcp/src/protocol/instant.ts`) — a tagged union of `ObservedInstant {iso}` and `UnknownInstant {reason}`, with `stampNow` / `stampFromMillis` its only producers in the package. A consumer has to branch on the tag before it can read a time, and the unknown case carries no time field to misread. (That is a single-producer discipline, not a nominal type barrier: `Iso8601Utc` is a `Schema.String.check`, and a `check` refines without branding, so the TS type is still a plain struct. The invariant that matters is closed a layer out — no catalog payload carries a `StampedInstant` field at all, so a sender has no slot to fill, and `channel_send` rejects the old habit outright. `Schema.brand` would add the nominal barrier, but it also stops the sole sanctioned producer's own object literal from typechecking without a cast, so it is deliberately left out of this PR rather than bolted on in a repair round.) The `Timestamp = Schema.String` alias is deleted, so no protocol field is "a string that looks like a time" any more.
- **The substrate stamps, named once each** — the transport for the envelope (`peer/peer.ts`), the receiver for the ack (`peer/inbox.ts`, `edge/bridge.ts`), the tracker for `since` / `lastSeen` (`tracker/handlers.ts`). All via `Clock.currentTimeMillis`; none accepts a caller value.
- **Fail closed on an unusable reading** — non-finite, or outside a plausible epoch window, resolves `UnknownInstant`. The lower bound is what makes a leaked `TestClock` (parked at epoch 0) surface as unknown instead of a confident `1970-01-01T00:00:00.000Z`.
- **The wake tag carries the stamped instant** — `<channel from=… kind=… at=…>` — so the one time a receiving session sees is the one read off a clock. An unknown renders the literal word `unknown`.
- **A body that still carries `at` is rejected**, not silently stripped. A `Schema.Struct` decode drops an excess key, which would leave the sender believing it sent a time; the reject names why and where the real instant comes from.

Every reader moved in lockstep: the package sources and tests, `packages/pipeline-crew-mcp/docs/` (reference tables, tutorial output, how-to), and the crew plugin's agent-facing channel docs under `claude-plugins/pipeline-crew/` — the tag shape those docs promise is the tag shape the bridge now renders.

## Verification

- `pnpm typecheck` clean across the workspace; `pnpm lint:worktree` clean.
- `packages/pipeline-crew-mcp`: 403 tests, 52 files, all passing — including the new `protocol/instant.test.ts` (the pure core: plausible reading, epoch-0, non-finite, both window edges, wire round-trip, live-clock vs `TestClock`), the bridge's unknown-renders-as-`unknown` case, and two send-path rejects for a sender-composed `at` (object and stringified body).
- Workspace `pnpm test`: 28/29 packages green. The one failure is `@kampus/web`, which needs Cloudflare credentials this environment doesn't have (`Unauthorized: Authentication error`) — unrelated to this diff.

Records ADR [0211](.decisions/0211-crew-message-times-are-stamped-not-composed.md).

Fixes #3895

