### PR TITLE
fix(integration-harness): recover a stalled round-trip instead of reding a clean PR (#3942)

### DIFF
--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -42,6 +42,13 @@ import {
 	CloudflarePlaceholder404Error,
 	isCloudflarePlaceholder404,
 } from "./_edge-ready.ts";
+import {
+	convergeAfterStall,
+	isSafeMethod,
+	isStall,
+	RequestStallError,
+	SAFE_STALL_REPLAYS,
+} from "./_request-stall.ts";
 
 /** A fate wire result for a single operation. */
 export type FateResult =
@@ -50,6 +57,27 @@ export type FateResult =
 
 /** A single fate operation (the `version`/`operations` envelope is added for you). */
 export type FateOp = Record<string, unknown> & {id?: string};
+
+/**
+ * How one `fate` call recovers a stalled round-trip — the two modes are mutually exclusive,
+ * and the union makes passing both UNREPRESENTABLE rather than a silently-resolved conflict.
+ * Reads recover on their own (a query/list is always replayable); this is the mutation
+ * caller's declaration:
+ *
+ *   - `retry: true` — the op is IDEMPOTENT, so a blind replay is safe (`definition.vote`
+ *     re-cast is a no-op, `user.setDisplayName` is last-write-wins).
+ *   - `converge` — the op is NOT idempotent, so a replay could double-write. Supply the probe
+ *     that answers "did it land?"; a landed write is adopted, an absent one is re-sent
+ *     (#3942). This is the mode `user.setUsername` and `definition.add` need — the first
+ *     rejects a re-set with `USERNAME_ALREADY_SET` (`Pasaport.setUsername` refuses once
+ *     `user.username` is non-null), the second mints a new id per call.
+ *
+ * Declaring NEITHER means a stall surfaces — correct for an assertion the test wants to see,
+ * and the pre-existing default.
+ */
+export type FateOpts =
+	| {cookie?: string; retry?: boolean; converge?: never}
+	| {cookie?: string; retry?: never; converge: () => Promise<FateResult | undefined>};
 
 export interface Harness {
 	/** The deployed worker URL (published by the global setup). */
@@ -65,11 +93,11 @@ export interface Harness {
 	json(path: string, body: unknown, cookie?: string): Promise<Response>;
 	/**
 	 * POST one fate operation; return its single result. Reads (`kind: "query"`
-	 * / `"list"`) auto-retry on a transient stall/error; mutations retry only when
-	 * `retry: true` is passed (the caller asserting the op is idempotent, e.g.
-	 * `definition.vote`).
+	 * / `"list"`) auto-retry on a transient stall/error; a mutation declares its
+	 * stall recovery, and the two modes are mutually exclusive by construction
+	 * ({@link FateOpts}).
 	 */
-	fate(op: FateOp, opts?: {cookie?: string; retry?: boolean}): Promise<FateResult>;
+	fate(op: FateOp, opts?: FateOpts): Promise<FateResult>;
 	/** POST several fate operations; return all results in order. */
 	fateBatch(ops: FateOp[], opts?: {cookie?: string}): Promise<FateResult[]>;
 	/** Sign up a user through better-auth; return `{userId, cookie}`. */
@@ -185,23 +213,21 @@ export interface Harness {
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
+// A `definition.add` the worker REJECTED while seeding — carried as a distinct type so
+// `addDefinition`'s converge loop can widen its recovery to it without also swallowing a
+// transport failure (`convergeAfterStall` defaults to stalls only).
+class SeedAddRejected extends Error {}
+
 // The Cloudflare edge-placeholder-404 detector + its typed carrier now live in the shared
 // readiness primitive (`_edge-ready.ts`, ADR 0127) — `req` below imports them so its inline
 // placeholder detection and `awaitEdgeReady`'s scoped tolerance share ONE definition.
 
-// A per-request timeout fires an `AbortSignal.timeout` → the fetch rejects with a
-// `TimeoutError`/`AbortError`. We treat that as "the request STALLED" (distinct
-// from a connection error, which means it never reached the worker). A stall may
-// have partially applied a write, so only *idempotent* callers retry on it.
-const isAbort = (e: unknown): boolean =>
-	e instanceof Error && (e.name === "TimeoutError" || e.name === "AbortError");
-
-// One HTTP request that stalls past this is aborted and (for idempotent ops)
-// retried against a fresh connection. The worker talks to real remote Cloudflare
-// D1; a request can occasionally hang outright — without this bound the whole test
-// waits out the Vitest timeout and dies with "All fibers interrupted". 30s is high
-// enough not to chop a legitimately slow round-trip to remote D1, while still
-// catching a true hang and leaving room to retry inside the 120s test budget.
+// One HTTP request that stalls past this is aborted and retried against a fresh connection
+// where that is sound (see `_request-stall.ts` for the stall classification + recovery, and
+// for the measurement showing 30s is ~11x a healthy round-trip — a bound to REPLAY through,
+// never to widen). The worker talks to real remote Cloudflare D1; a request can occasionally
+// hang outright — without this bound the whole test waits out the Vitest timeout and dies
+// with "All fibers interrupted".
 const REQUEST_TIMEOUT_MS = 30_000;
 
 // A `/fate/live` response is READY only when the edge served the worker's real held
@@ -386,6 +412,7 @@ export function harness(
 	const req: Harness["req"] = async (path, init, opts) => {
 		const timeoutMs = opts?.timeoutMs ?? 0;
 		let lastErr: unknown;
+		let stalls = 0;
 		for (let i = 0; i < 20; i++) {
 			try {
 				const signal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : init?.signal;
@@ -408,12 +435,24 @@ export function harness(
 				}
 				return res;
 			} catch (err) {
-				// A stall (abort/timeout) may have partially applied a write, so it is
-				// NOT safe to silently retry here — surface it and let the idempotency-
-				// aware caller (`fate`, `signUp`) decide. A connection error never
-				// reached the worker, so retry it (covers worker-not-up-yet at startup).
-				if (isAbort(err)) throw err;
-				lastErr = err;
+				// A connection error never reached the worker, so retry it (covers
+				// worker-not-up-yet at startup).
+				if (!isStall(err)) {
+					lastErr = err;
+					await sleep(250);
+					continue;
+				}
+				// A stall is re-thrown ATTRIBUTED, so CI names the round-trip instead of
+				// printing a bare DOMException (#3942).
+				stalls++;
+				const stall = new RequestStallError(init?.method ?? "GET", path, timeoutMs, stalls);
+				// A stalled SAFE request applied no state change (RFC 9110 §9.2.1/§9.2.2), so a
+				// bounded replay on a fresh connection is sound with no caller assertion — the
+				// recovery an idempotent read was always entitled to and never got. An unsafe
+				// method may have committed before the response was lost, so it still surfaces
+				// for the idempotency-aware caller (`fate`, `signUp`) to decide.
+				if (!isSafeMethod(init?.method) || stalls > SAFE_STALL_REPLAYS) throw stall;
+				lastErr = stall;
 				await sleep(250);
 			}
 		}
@@ -446,13 +485,18 @@ export function harness(
 	};
 
 	// Reads are always safe to replay; a mutation only when the caller flags it
-	// idempotent (`definition.vote` re-cast is a no-op — `Vote.ts`). `definition.add`
-	// is NOT idempotent (new id per call), so it is never auto-retried here — its
-	// caller (`addDefinition`) adopts the landed row by body instead.
+	// idempotent (`definition.vote` re-cast is a no-op — `Vote.ts`).
 	const idempotentOp = (op: FateOp, opts?: {retry?: boolean}): boolean =>
 		op.kind === "query" || op.kind === "list" || opts?.retry === true;
 
 	const fate: Harness["fate"] = async (op, opts) => {
+		// A non-idempotent mutation that supplied a landed-probe converges instead of
+		// hard-failing on a stall (see `FateOpts`); the union rules out combining this
+		// with the blind-replay mode below.
+		if (opts?.converge) {
+			const probe = opts.converge;
+			return convergeAfterStall(() => fateBatch([op], opts).then(([r]) => r!), probe);
+		}
 		const attempts = idempotentOp(op, opts) ? 3 : 1;
 		let lastResult: FateResult | undefined;
 		let lastErr: unknown;
@@ -467,7 +511,7 @@ export function harness(
 			} catch (err) {
 				lastErr = err;
 				// Only a stall is retryable; a real error (or a non-retryable op) surfaces.
-				if (attempts === 1 || !isAbort(err)) throw err;
+				if (attempts === 1 || !isStall(err)) throw err;
 			}
 			if (i < attempts - 1) await sleep(300 * (i + 1));
 		}
@@ -495,7 +539,7 @@ export function harness(
 				await sleep(300 * (i + 1));
 			} catch (err) {
 				lastErr = err;
-				if (!isAbort(err)) throw err;
+				if (!isStall(err)) throw err;
 				await sleep(300 * (i + 1));
 			}
 		}
@@ -553,14 +597,24 @@ export function harness(
 		cookie: string;
 	}): Promise<{userId: string; cookie: string}> => {
 		for (let i = 0; i < SESSION_READY_ATTEMPTS; i++) {
-			const res = await req(
-				"/api/auth/get-session",
-				{headers: {cookie: session.cookie, origin: "http://localhost:3000"}},
-				{timeoutMs: REQUEST_TIMEOUT_MS},
-			);
-			if (res.ok) {
-				const data = (await res.json().catch(() => null)) as {user?: {id: string}} | null;
-				if (data?.user?.id) return session;
+			try {
+				const res = await req(
+					"/api/auth/get-session",
+					{headers: {cookie: session.cookie, origin: "http://localhost:3000"}},
+					{timeoutMs: REQUEST_TIMEOUT_MS},
+				);
+				if (res.ok) {
+					const data = (await res.json().catch(() => null)) as {user?: {id: string}} | null;
+					if (data?.user?.id) return session;
+				}
+			} catch (err) {
+				// The fail-OPEN above is the whole contract of this probe, and a stall used to
+				// break it: `req` re-throws an aborted round-trip, so a single stalled
+				// get-session propagated out of `signUp` and RED a green stage — the failure
+				// mode this probe exists to prevent, from the probe itself (#3942). It runs on
+				// every signUp, so it is the suite's most-exercised request. Swallow only a
+				// stall (`req` already replays it once); any real error still surfaces.
+				if (!isStall(err)) throw err;
 			}
 			await sleep(300 * (i + 1));
 		}
@@ -690,18 +744,18 @@ export function harness(
 		return hit ? {id: hit.node.id, authorId: hit.node.authorId} : undefined;
 	};
 
-	// `definition.add` is not idempotent, so we can't blind-retry it. On a stall
-	// (the add may or may not have committed) we look the body up: if it landed,
-	// adopt it; otherwise add again. A `!ok` result is also treated this way.
-	const addDefinition = async (
+	// `definition.add` is not idempotent, so we can't blind-retry it — this is the
+	// converge-then-adopt shape (`convergeAfterStall`), with SEEDING's wider recovery: a
+	// domain-level rejection is probed-and-retried here too, not just a stall, because a
+	// half-applied seed is worth reconciling before the fixture is declared broken.
+	const addDefinition = (
 		cookie: string,
 		slug: string,
 		title: string,
 		body: string,
-	): Promise<{id: string; authorId: string}> => {
-		let lastErr: unknown;
-		for (let i = 0; i < 3; i++) {
-			try {
+	): Promise<{id: string; authorId: string}> =>
+		convergeAfterStall<{id: string; authorId: string}>(
+			async () => {
 				const added = await fate(
 					{
 						kind: "mutation",
@@ -711,18 +765,12 @@ export function harness(
 					},
 					{cookie},
 				);
-				if (added.ok) return added.data as {id: string; authorId: string};
-				lastErr = new Error(`definition.add (${slug}): ${added.error.code}`);
-			} catch (err) {
-				if (!isAbort(err)) throw err;
-				lastErr = err;
-			}
-			const adopted = await findDefByBody(cookie, slug, body);
-			if (adopted) return adopted;
-			await sleep(400 * (i + 1));
-		}
-		throw new Error(`seedTerm add failed (${slug}) after retries: ${String(lastErr)}`);
-	};
+				if (!added.ok) throw new SeedAddRejected(`definition.add (${slug}): ${added.error.code}`);
+				return added.data as {id: string; authorId: string};
+			},
+			() => findDefByBody(cookie, slug, body),
+			{recoverable: (e) => isStall(e) || e instanceof SeedAddRejected},
+		);
 
 	const seedTerm: Harness["seedTerm"] = async (input) => {
 		const created = !seededSlugs.has(input.slug);

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -69,7 +69,7 @@ export type FateOp = Record<string, unknown> & {id?: string};
  *   - `converge` — the op is NOT idempotent, so a replay could double-write. Supply the probe
  *     that answers "did it land?"; a landed write is adopted, an absent one is re-sent
  *     (#3942). This is the mode `user.setUsername` and `definition.add` need — the first
- *     rejects a re-set with `USERNAME_ALREADY_SET` (`Pasaport.setUsername` refuses once
+ *     rejects a re-set with `ALREADY_SET` (`Pasaport.setUsername` refuses once
  *     `user.username` is non-null), the second mints a new id per call.
  *
  * Declaring NEITHER means a stall surfaces — correct for an assertion the test wants to see,

--- a/apps/web/tests/integration/_request-stall.ts
+++ b/apps/web/tests/integration/_request-stall.ts
@@ -1,0 +1,142 @@
+/**
+ * Stall attribution + recovery for the integration harness's worker-HTTP path (#3942).
+ *
+ * A "stall" is one request that never answered within `REQUEST_TIMEOUT_MS` and was aborted
+ * by `AbortSignal.timeout` — distinct from a connection error (which never reached the
+ * worker) and from a slow-but-answering round-trip. Measured against the real remote stage,
+ * a healthy round-trip is nowhere near the bound: in merge-queue batch run `30143777821` the
+ * 206-test suite had p50 462ms / p90 1698ms / p99 2842ms per TEST (each several round-trips),
+ * and the slowest PASSING test was 5616ms. A request that reaches 30s is therefore stalled,
+ * not slow — so the recovery for it is a REPLAY, never a wider budget (a wider budget only
+ * delays the same failure, and past the 120s `testTimeout` it degrades into the opaque
+ * "Hook timed out" / "All fibers interrupted" shape).
+ *
+ * Two things were missing at the seam and are supplied here:
+ *
+ *   1. **Attribution.** The raw `TimeoutError` escaped naked — CI printed a `DOMException`
+ *      code dump with no method, no path, no stack, so a flake could only be GUESSED at
+ *      (the #3942 report guessed SSE; the test opens no SSE stream). {@link RequestStallError}
+ *      names the round-trip that stalled, so the next occurrence is diagnosable instead of
+ *      re-litigated.
+ *   2. **Recovery for the two honest cases.** {@link isSafeMethod} derives replay-safety from
+ *      the REQUEST (RFC 9110 §9.2.1/§9.2.2 — GET/HEAD are safe and idempotent, so a stalled
+ *      one cannot have applied a write and is always sound to replay), rather than making
+ *      every caller assert it. {@link convergeAfterStall} covers the case a replay CANNOT
+ *      cover — a non-idempotent mutation, where a stall leaves it genuinely unknown whether
+ *      the write landed: re-send only after PROVING it did not, by probing for the landed
+ *      row and adopting it if present.
+ *
+ * A pure leaf — no `fetch`, no creds, injectable `sleep` — so the policy is unit-testable
+ * offline, matching `_d1-rest-retry.ts` / `_cf-api-throttle.ts` / `_edge-ready.ts`.
+ */
+
+/**
+ * A request that was aborted by its per-request timeout, carrying WHICH round-trip stalled.
+ * Thrown in place of the bare `TimeoutError` so a CI failure names the seam.
+ */
+export class RequestStallError extends Error {
+	readonly _tag = "RequestStall";
+	readonly method: string;
+	readonly path: string;
+	readonly timeoutMs: number;
+	readonly attempts: number;
+	constructor(method: string, path: string, timeoutMs: number, attempts: number) {
+		super(
+			`request stalled: ${method} ${path} did not answer within ${timeoutMs}ms ` +
+				`(${attempts} attempt${attempts === 1 ? "" : "s"})`,
+		);
+		this.name = "RequestStallError";
+		this.method = method;
+		this.path = path;
+		this.timeoutMs = timeoutMs;
+		this.attempts = attempts;
+	}
+}
+
+/**
+ * Is this a stall (the abort a per-request timeout fires), as opposed to a connection error
+ * or a real failure? Matches both the raw `AbortSignal.timeout` rejection and the attributed
+ * {@link RequestStallError} it is re-thrown as, so a caller downstream of `req` classifies
+ * the same event identically whichever form reaches it.
+ */
+export const isStall = (e: unknown): boolean =>
+	e instanceof RequestStallError ||
+	(e instanceof Error && (e.name === "TimeoutError" || e.name === "AbortError"));
+
+/**
+ * Is the method SAFE (RFC 9110 §9.2.1) and therefore idempotent (§9.2.2)? A stalled GET/HEAD
+ * applied no state change whatever the origin did with it, so replaying it on a fresh
+ * connection is sound by the HTTP contract — no caller assertion required. Every other method
+ * (POST above all) may have committed before the response was lost, so it is NOT replayable
+ * here; it goes to {@link convergeAfterStall} or surfaces.
+ */
+export const isSafeMethod = (method: string | undefined): boolean => {
+	const m = (method ?? "GET").toUpperCase();
+	return m === "GET" || m === "HEAD";
+};
+
+/**
+ * Replays allowed for a stalled safe request, on top of the first attempt.
+ *
+ * Held at 1 deliberately: each attempt can consume the full per-request timeout, so a worst
+ * case of two 30s attempts is 60s — half the 120s `testTimeout`, which is the room the
+ * harness's own sizing note budgets for a retry. A larger cap would let a pathological stall
+ * chain past the test budget and resurface as the opaque vitest timeout this recovery exists
+ * to prevent.
+ */
+export const SAFE_STALL_REPLAYS = 1;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export interface ConvergeOptions {
+	/** Total attempts at `send`, including the first (default 3). */
+	attempts?: number;
+	/** Base of the linear backoff between attempts, ms (default 400). */
+	backoffMs?: number;
+	/**
+	 * Which thrown failures the landed-probe recovers. Default: only a stall — a real error
+	 * (a rejected mutation, a connection failure) surfaces at once and is never retried into
+	 * a duplicate write. A caller whose op is pure setup may widen it.
+	 */
+	recoverable?: (e: unknown) => boolean;
+	/** Injected for tests — real sleep by default. */
+	sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Run a NON-idempotent mutation so that a stall converges instead of hard-failing.
+ *
+ * The stall leaves exactly one thing unknown — did the write land? So resolve it rather than
+ * guess: probe with `landed()`; a present result is ADOPTED (the write committed, only its
+ * response was lost), an absent one proves the write did not apply and the send is re-issued.
+ * That is what makes this safe where a blind replay is not, and it is the only recovery shape
+ * available to a protocol with no client idempotency key.
+ *
+ * `send` resolving is always terminal — a domain-level `!ok` is a real answer a test asserts
+ * on, never a transient to retry (widen `recoverable` only for pure seeding, where any
+ * failure is worth a probe).
+ */
+export const convergeAfterStall = async <T>(
+	send: () => Promise<T>,
+	landed: () => Promise<T | undefined>,
+	{
+		attempts = 3,
+		backoffMs = 400,
+		recoverable = isStall,
+		sleep = defaultSleep,
+	}: ConvergeOptions = {},
+): Promise<T> => {
+	let lastErr: unknown;
+	for (let i = 0; i < attempts; i++) {
+		try {
+			return await send();
+		} catch (err) {
+			if (!recoverable(err)) throw err;
+			lastErr = err;
+		}
+		const adopted = await landed();
+		if (adopted !== undefined) return adopted;
+		if (i < attempts - 1) await sleep(backoffMs * (i + 1));
+	}
+	throw lastErr;
+};

--- a/apps/web/tests/integration/_request-stall.unit.test.ts
+++ b/apps/web/tests/integration/_request-stall.unit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Pins the stall classification + recovery policy that keeps a single transient round-trip
+ * from reding a clean PR in the merge queue (#3942): a stalled SAFE request is replayable by
+ * HTTP semantics, an unsafe one is NOT blind-replayed, and a non-idempotent mutation converges
+ * by adopting the landed write. `sleep` is injected so the whole suite runs offline.
+ */
+
+import {describe, expect, it, vi} from "vitest";
+import {
+	convergeAfterStall,
+	isSafeMethod,
+	isStall,
+	RequestStallError,
+	SAFE_STALL_REPLAYS,
+} from "./_request-stall.ts";
+
+const timeoutError = (): Error => {
+	const e = new Error("The operation was aborted due to timeout");
+	e.name = "TimeoutError";
+	return e;
+};
+
+const noSleep = () => Promise.resolve();
+
+describe("isStall", () => {
+	it("matches the raw AbortSignal.timeout rejection (the shape CI printed for #3942)", () => {
+		expect(isStall(timeoutError())).toBe(true);
+		const aborted = new Error("aborted");
+		aborted.name = "AbortError";
+		expect(isStall(aborted)).toBe(true);
+	});
+
+	it("matches the attributed RequestStallError it is re-thrown as", () => {
+		expect(isStall(new RequestStallError("POST", "/fate", 30_000, 1))).toBe(true);
+	});
+
+	it("does NOT match a real failure — a connection error or a domain error still surfaces", () => {
+		expect(isStall(new Error("fetch failed"))).toBe(false);
+		expect(isStall(new TypeError("network"))).toBe(false);
+		expect(isStall(undefined)).toBe(false);
+	});
+});
+
+describe("RequestStallError", () => {
+	it("names the round-trip that stalled — the attribution the bare TimeoutError lacked", () => {
+		const e = new RequestStallError("POST", "/fate", 30_000, 2);
+		expect(e.method).toBe("POST");
+		expect(e.path).toBe("/fate");
+		expect(e.timeoutMs).toBe(30_000);
+		expect(e.attempts).toBe(2);
+		expect(e.message).toContain("POST /fate");
+		expect(e.message).toContain("30000ms");
+	});
+});
+
+describe("isSafeMethod", () => {
+	it("treats GET/HEAD as replayable (RFC 9110 safe ⇒ idempotent), including an absent method", () => {
+		expect(isSafeMethod("GET")).toBe(true);
+		expect(isSafeMethod("head")).toBe(true);
+		expect(isSafeMethod(undefined)).toBe(true); // fetch defaults to GET
+	});
+
+	it("treats a write method as NOT replayable — a stalled POST may have committed", () => {
+		expect(isSafeMethod("POST")).toBe(false);
+		expect(isSafeMethod("PUT")).toBe(false);
+		expect(isSafeMethod("DELETE")).toBe(false);
+	});
+
+	it("allows exactly one replay of a stalled safe request, bounded under the test budget", () => {
+		// Two 30s attempts = 60s, half the 120s testTimeout — the room the harness budgets.
+		expect(SAFE_STALL_REPLAYS).toBe(1);
+	});
+});
+
+describe("convergeAfterStall", () => {
+	it("returns the send result untouched when nothing stalls (no probe, no sleep)", async () => {
+		const send = vi.fn(async () => "sent");
+		const landed = vi.fn(async () => "adopted" as string | undefined);
+		const sleep = vi.fn(noSleep);
+		await expect(convergeAfterStall(send, landed, {sleep})).resolves.toBe("sent");
+		expect(landed).not.toHaveBeenCalled();
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("ADOPTS a write that landed before the stall — no duplicate send", async () => {
+		const send = vi.fn(async () => {
+			throw timeoutError();
+		});
+		const landed = vi.fn(async () => "adopted" as string | undefined);
+		await expect(convergeAfterStall(send, landed, {sleep: noSleep})).resolves.toBe("adopted");
+		expect(send).toHaveBeenCalledTimes(1); // the stalled one only — never re-sent
+	});
+
+	it("RE-SENDS once the probe proves the write did not land", async () => {
+		let attempt = 0;
+		const send = vi.fn(async () => {
+			if (attempt++ === 0) throw timeoutError();
+			return "sent-on-retry";
+		});
+		const landed = vi.fn(async () => undefined);
+		await expect(convergeAfterStall(send, landed, {sleep: noSleep})).resolves.toBe("sent-on-retry");
+		expect(send).toHaveBeenCalledTimes(2);
+		expect(landed).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT recover a real error — it surfaces at once, unprobed and un-resent", async () => {
+		const send = vi.fn(async () => {
+			throw new Error("fetch failed");
+		});
+		const landed = vi.fn(async () => "adopted" as string | undefined);
+		await expect(convergeAfterStall(send, landed, {sleep: noSleep})).rejects.toThrow(
+			"fetch failed",
+		);
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(landed).not.toHaveBeenCalled();
+	});
+
+	it("treats a RESOLVED result as terminal — a domain-level `!ok` is an answer, not a transient", async () => {
+		const send = vi.fn(async () => ({ok: false, code: "DISPLAY_NAME_EMPTY"}));
+		const landed = vi.fn(async () => undefined);
+		await expect(convergeAfterStall(send, landed, {sleep: noSleep})).resolves.toEqual({
+			ok: false,
+			code: "DISPLAY_NAME_EMPTY",
+		});
+		expect(send).toHaveBeenCalledTimes(1);
+	});
+
+	it("surfaces the last stall once the budget is spent and the write never landed", async () => {
+		const send = vi.fn(async () => {
+			throw timeoutError();
+		});
+		const landed = vi.fn(async () => undefined);
+		await expect(
+			convergeAfterStall(send, landed, {attempts: 3, sleep: noSleep}),
+		).rejects.toMatchObject({name: "TimeoutError"});
+		expect(send).toHaveBeenCalledTimes(3);
+	});
+
+	it("honors a widened `recoverable` — the seeding path probes a domain rejection too", async () => {
+		class Rejected extends Error {}
+		let attempt = 0;
+		const send = vi.fn(async () => {
+			if (attempt++ === 0) throw new Rejected("rejected");
+			return "sent-on-retry";
+		});
+		const landed = vi.fn(async () => undefined);
+		await expect(
+			convergeAfterStall(send, landed, {
+				recoverable: (e) => isStall(e) || e instanceof Rejected,
+				sleep: noSleep,
+			}),
+		).resolves.toBe("sent-on-retry");
+		expect(landed).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/tests/integration/display-name-convergence.test.ts
+++ b/apps/web/tests/integration/display-name-convergence.test.ts
@@ -54,6 +54,33 @@ const readByline = async (termSlug: string, definitionId: string): Promise<DefNo
 	return conn.items.find((e) => e.node.id === definitionId)?.node;
 };
 
+// The landed-probes for this test's two NON-idempotent setup mutations. A stalled round-trip
+// (real remote worker + D1) leaves it unknown whether the write committed, and neither op
+// tolerates a blind replay — `user.setUsername` rejects a re-set with USERNAME_ALREADY_SET,
+// `definition.add` mints a new id per call — so each declares how to tell, and a landed write
+// is adopted instead of hard-failing the whole test (#3942).
+const usernameLanded = async (cookie: string, value: string) => {
+	const me = await h.fate({kind: "query", name: "me", select: ["id", "username"]}, {cookie});
+	if (!me.ok) return undefined;
+	return (me.data as {username: string | null}).username === value ? me : undefined;
+};
+
+const definitionLanded = async (cookie: string, termSlug: string, body: string) => {
+	const result = await h.fate(
+		{
+			kind: "query",
+			name: "term",
+			args: {slug: termSlug, definitions: {first: 20}},
+			select: ["definitions.id", "definitions.body"],
+		},
+		{cookie},
+	);
+	if (!result.ok) return undefined;
+	const conn = (result.data as {definitions: Connection<{id: string; body: string}>}).definitions;
+	const hit = conn.items.find((e) => e.node.body === body);
+	return hit ? {ok: true as const, data: {id: hit.node.id}, id: "landed"} : undefined;
+};
+
 beforeAll(() => {
 	expect(typeof h.url()).toBe("string");
 });
@@ -71,19 +98,20 @@ describe("user.setDisplayName — a rename reaches the stamped author byline (#2
 					input: {value: authorUsername},
 					select: ["id"],
 				},
-				{cookie: author.cookie},
+				{cookie: author.cookie, converge: () => usernameLanded(author.cookie, authorUsername)},
 			)
 			.then((r) => expect(r.ok).toBe(true));
 
 		const termSlug = `${NS}-term`;
+		const body = "byline tracks the live name";
 		const added = await h.fate(
 			{
 				kind: "mutation",
 				name: "definition.add",
-				input: {termSlug, termTitle: "Convergence Term", body: "byline tracks the live name"},
+				input: {termSlug, termTitle: "Convergence Term", body},
 				select: ["id"],
 			},
-			{cookie: author.cookie},
+			{cookie: author.cookie, converge: () => definitionLanded(author.cookie, termSlug, body)},
 		);
 		expect(added.ok).toBe(true);
 		if (!added.ok) return;
@@ -126,7 +154,7 @@ describe("user.setDisplayName — a rename reaches the stamped author byline (#2
 					input: {value: authorUsername},
 					select: ["id"],
 				},
-				{cookie: author.cookie},
+				{cookie: author.cookie, converge: () => usernameLanded(author.cookie, authorUsername)},
 			)
 			.then((r) => expect(r.ok).toBe(true));
 

--- a/apps/web/tests/integration/display-name-convergence.test.ts
+++ b/apps/web/tests/integration/display-name-convergence.test.ts
@@ -56,7 +56,7 @@ const readByline = async (termSlug: string, definitionId: string): Promise<DefNo
 
 // The landed-probes for this test's two NON-idempotent setup mutations. A stalled round-trip
 // (real remote worker + D1) leaves it unknown whether the write committed, and neither op
-// tolerates a blind replay — `user.setUsername` rejects a re-set with USERNAME_ALREADY_SET,
+// tolerates a blind replay — `user.setUsername` rejects a re-set with ALREADY_SET,
 // `definition.add` mints a new id per call — so each declares how to tell, and a landed write
 // is adopted instead of hard-failing the whole test (#3942).
 const usernameLanded = async (cookie: string, value: string) => {


### PR DESCRIPTION
Fixes #3942

## Root cause

**Not the timeout budget.** Measured from the ejecting run itself (merge-queue batch `30143777821`, the 206-test suite), per-test wall-clock was **p50 462ms / p90 1698ms / p99 2842ms**, and the **slowest passing test was 5616ms**. A *test* contains several round-trips, so the 30s **per-request** bound is roughly **11x** a healthy round-trip. A request that reaches it is **stalled, not slow** — raising the bound would only delay the identical failure, and past the 120s `testTimeout` it degrades into the opaque "Hook timed out" / "All fibers interrupted" shape. So the bound is a thing to *replay through*, not to widen.

**The actual cause: the stall had no recovery at three sites the harness's own design intends to be recoverable.** `REQUEST_TIMEOUT_MS`'s own sizing note says 30s leaves "room to retry inside the 120s test budget" — but the failing test's chain never got that retry:

1. **`sessionReady`'s `GET /api/auth/get-session` probe violated its own written contract.** Its docblock states the probe is *fail-OPEN* — "a readiness probe must never RED a green stage" — yet `req` re-throws an aborted round-trip and nothing caught it, so a single stalled probe propagated straight out of `signUp` and failed the test. It runs on **every** `signUp`, making it the suite's most-exercised request and the highest-probability stall site in the chain.
2. **`user.setUsername`** — non-idempotent, so it correctly opts out of blind replay, and had no other recovery. Grounded in source: `Pasaport.setUsername` rejects a re-set with `ALREADY_SET` once `user.username` is non-null (`apps/web/worker/features/pasaport/Pasaport.ts`), so `retry: true` would have converted a stall into a *different* failure.
3. **`definition.add`** called directly from the test body — mints a new id per call. The harness already solved this shape for its own seeding path (`addDefinition` + `findDefByBody`), but that recovery was private to `seedTerm`; a test calling `h.fate` directly got none.

**Why this could only be guessed at before:** the abort escaped as a naked `TimeoutError` — CI printed a `DOMException` code dump with no method, no path, no stack. That is why the original report hypothesised an SSE convergence wait (this test opens no SSE stream) and why triage had to note "the log does not identify which request stalled". Attribution is therefore part of the fix, not a nicety.

Ruled out by construction: the CF REST / D1 control-plane path (`cloudflareApi` → `cfApiThrottle` → `cfFetchWithRateLimitRetry`) attaches **no `AbortSignal`**, so it cannot produce a `TimeoutError`. `AbortSignal.timeout` exists at exactly one place in the harness — `req` — so the stall was a **worker HTTP** round-trip.

## The fix

New pure leaf `apps/web/tests/integration/_request-stall.ts` (the established `_d1-rest-retry.ts` / `_cf-api-throttle.ts` / `_edge-ready.ts` shape: injectable `sleep`, no `fetch`, no creds, unit-tested offline):

- **`RequestStallError`** — attributes the stall with method + path + timeout + attempt count, so the next occurrence names the round-trip instead of being re-litigated.
- **`isSafeMethod`** — derives replay-safety from the **request** (RFC 9110 §9.2.1/§9.2.2: GET/HEAD are safe, therefore idempotent) rather than from a caller assertion, so a stalled read replays on a fresh connection with no call-site change. Bounded at **one** replay: two 30s attempts = 60s, half the 120s test budget, so a pathological stall can't chain past it.
- **`convergeAfterStall`** — resolves the one thing a stall leaves genuinely unknown ("did the write land?") instead of guessing: probe, **adopt** a landed write, re-send only once proven absent. This is the only recovery available to a protocol with no client idempotency key.

Harness changes:
- `req` re-throws stalls **attributed**, and replays a stalled safe method once.
- `sessionReady` now honors its documented fail-open (swallows a stall only; any real error still surfaces).
- `fate` gains the `converge` recovery mode; `FateOpts` is a union so `retry` and `converge` **cannot both be passed** — the contradiction is unrepresentable rather than silently resolved.
- `addDefinition` collapses onto the shared `convergeAfterStall` (it was the hand-rolled original), keeping its seeding-only wider recovery via an injected `recoverable`.

Test changes: the two non-idempotent setup mutations in `display-name-convergence.test.ts` declare their landed-probes.

## Verification

- `apps/web/tests/integration/_request-stall.unit.test.ts` — 14 offline tests pinning the policy: a landed write is adopted with **no duplicate send**; an absent one is re-sent; a **real error surfaces at once, unprobed and un-resent**; a resolved domain-level `!ok` stays terminal (so `DISPLAY_NAME_EMPTY`-style assertions are never swallowed); the safe/unsafe method split; the replay bound.
- `pnpm typecheck` clean; `pnpm lint:worktree` clean; full offline unit tier **284 files / 2376 tests passing**.

## Survey (acceptance criterion 3)

The same-shape scan across `tests/integration/**` finds the pattern is repo-wide, not local: ~32 `definition.add`, ~30 `post.submit`, ~20 `comment.add`, ~10 `user.setUsername` and more are issued as setup mutations without a recovery, across 40 files. Two of the three sites here are fixed **harness-wide with zero call-site changes** (the attributed stall, the safe-method replay, the `sessionReady` fail-open), which covers every file at once. The per-mutation `converge` probes are applied to the reported test; rolling them across the remaining suites is filed as a follow-up rather than expanded into this diff.

## Relationship to #3548 — related, distinct root cause, no scope overlap

#3548 is a **Cloudflare D1 REST 429** (`code 971`) thrown by `cloudflareApi` against `api.cloudflare.com`, surfacing as an explicit rate-limit body. This is a **`TimeoutError` on the worker HTTP path** (`req`), a different call site with a different error shape — and, as noted above, the CF REST path carries no `AbortSignal` and so cannot produce this failure at all. They are **not** the same cause, and nothing here touches #3548's throttle/retry mechanism (`_cf-api-throttle.ts` / `_d1-rest-retry.ts`), so #3548's investigation is neither pre-empted nor half-fixed under this number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

