### PR TITLE
fix(pipeline-cli): per-run scratchpad namespace as an allocator, not a naming convention

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/adr.md
+++ b/claude-plugins/kampus-pipeline/agents/adr.md
@@ -74,21 +74,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   never a `~/`, `/Users/…`, vault, or sibling-clone path, and no Obsidian `[[wikilinks]]`.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.

--- a/claude-plugins/kampus-pipeline/agents/canon.md
+++ b/claude-plugins/kampus-pipeline/agents/canon.md
@@ -79,21 +79,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   `[[wikilinks]]`.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory. Resolve it with

--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -72,21 +72,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   never a `~/`, `/Users/…`, vault, or sibling-clone path.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.

--- a/claude-plugins/kampus-pipeline/agents/planner.md
+++ b/claude-plugins/kampus-pipeline/agents/planner.md
@@ -87,21 +87,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   `/Users/…`, vault, or sibling-clone path.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.

--- a/claude-plugins/kampus-pipeline/agents/reporter.md
+++ b/claude-plugins/kampus-pipeline/agents/reporter.md
@@ -61,21 +61,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   `footer.sh`; if you ever assemble it by hand, scrub the same way.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -268,21 +268,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   sibling-clone path.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -104,21 +104,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   sibling-clone path.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -92,21 +92,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   or sibling-clone path.
 - **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
   stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
-  shared filename gets clobbered mid-run and reads back **another run's content with no
-  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, derive its path from a per-run namespace and name every leaf under it:
-  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
-  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
-  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
-  in the later call.** Your shell state does not survive between Bash calls, so a
-  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
-  yields a *new empty directory*, silently turning a read of your own earlier state into a
-  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
-  per agent run, and recomputable by any later call of that same run. Never park the path
-  itself in another file to carry it across — that just moves the collision onto that file.
-  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
   never-leak-the-path corollary are single-sourced in the skills'
   `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1943,12 +1943,51 @@ Two requirements are both real, and a namespace that satisfies only one is broke
 `$CLAUDE_CODE_SESSION_ID` delivers both. It is the per-agent-run UUID the environment already
 exports — the same token ADR 0115's claim protocol stamps — and it is **stable across Bash
 calls** while **distinct per agent run** (sibling subagents of one pane each get their own).
-So it is a run identity any later call can recompute without carrying anything:
+So it is a run identity any later call can recompute without carrying anything.
 
-The recipe is **one line, inlined at each site** — deliberately not a shell helper, because a
-helper is itself shell state that doesn't survive between Bash calls, so a later call could not
-call it. `<slug>` names the caller: the skill, plus the work item when one skill runs over
-several (`plan-epic-<EPIC>`, `write-code-<N>`, `review-skill-$PR`).
+**The harness-provided "scratchpad directory" is NOT this namespace.** A session-scoped
+scratchpad handed to an agent by the runtime is **shared across the concurrent runs of that
+session**, and generic leaf names under it (`verdict-doc.md`, `files-*.txt`) collide — which is
+exactly how, on 2026-07-24, one reviewer's `review-doc` verdict body was written over another
+reviewer's at the same path and only the ADR-0058 head-binding check (#3801) turned the
+cross-PR verdict swap into a refusal instead of a merge-gate lie. Run state that must survive a
+Bash call goes in the namespace below, never in that directory.
+
+`<slug>` names the caller: the skill, plus the work item when one skill runs over several
+(`plan-epic-<EPIC>`, `write-code-<N>`, `review-skill-$PR`).
+
+### `pipeline-cli scratchpad` — the allocator, not a naming convention
+
+Allocation is owned by one tested verb, so a caller **cites it instead of hand-rolling a path**
+(#3718). It prints the absolute directory on stdout and nothing else:
+
+```bash
+# OPEN — the run's first write of scratch state. Allocates fresh (clearing an earlier run of the
+# same slug in this session) and stamps the namespace as ours.
+RUN_SCRATCH="$(pipeline-cli scratchpad open --slug review-doc-$PR)" || exit 1
+
+# RE-DERIVE — every LATER Bash call, where shell state is already gone. Asserts the namespace
+# exists AND is still ours; it never creates one, because answering "you never opened it" with a
+# fresh empty directory is how a read of your own state silently becomes a read of nothing.
+RUN_SCRATCH="$(pipeline-cli scratchpad path --slug review-doc-$PR)" || exit 1
+VERDICT="$(pipeline-cli scratchpad file --slug review-doc-$PR --name verdict.md)" || exit 1
+```
+
+Every failure is a **refusal with its own exit code** — `2` no session id, `3` a slug/leaf name
+that isn't a single path segment, `4` the namespace belongs to another run, `5` this run never
+opened it, `6` the filesystem refused — so a caller branches on status, not prose. There is **no
+fallback to a shared or default location**: a fallback is precisely what reintroduces the silent
+clobber (ADR 0092, fail closed).
+
+The **owner stamp** is what makes the last case structural rather than polite. `open` writes the
+run's identity into the namespace, so if two runs ever share a session id *and* a slug, the
+second `open` is **refused loudly** instead of overwriting, and the first run's `path` refuses to
+hand back a namespace someone else took over. The silent-by-construction failure — a clobbered
+file that reads back successfully — has no path left to take.
+
+The verb ships with `pipeline-cli`. Where it isn't installed (a foreign install, ADR 0062), the
+equivalent one-liner below is the fallback — deliberately inlined at each site rather than made a
+shell helper, since a helper is itself shell state that doesn't survive between Bash calls.
 
 **Open the run once, re-derive freely afterwards.** The distinction is load-bearing — getting
 it backwards re-creates the empty-directory bug it exists to prevent:
@@ -1984,7 +2023,8 @@ splice guard is the live instance), so absence fails loud instead of waving work
    live from the worktree instead of caching it (#2038) — both satisfy §SP outright, with no
    path to collide on and nothing to leak.
 2. **When a file is genuinely needed, derive its path from `$RUN_SCRATCH`.** Allocate it
-   fail-closed per the recipe above — never a bare `/tmp/<name>`, and never a path keyed only
+   through `pipeline-cli scratchpad open` (or, with no CLI, the fallback one-liner) — never a
+   bare `/tmp/<name>`, never the harness scratchpad, and never a path keyed only
    on a work-item id. Leaf names then stay plain and readable (`deps.md`, not
    `deps-$PR-$RANDOM.md`) because uniqueness lives in the **directory**, so a scratch write
    added later *inherits* the guarantee instead of reintroducing the bug.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1962,8 +1962,8 @@ Allocation is owned by one tested verb, so a caller **cites it instead of hand-r
 (#3718). It prints the absolute directory on stdout and nothing else:
 
 ```bash
-# OPEN — the run's first write of scratch state. Allocates fresh (clearing an earlier run of the
-# same slug in this session) and stamps the namespace as ours.
+# OPEN — the run's first write of scratch state. Claims the namespace exclusively and stamps it
+# as ours, clearing whatever an unclaimed earlier occupant left behind.
 RUN_SCRATCH="$(pipeline-cli scratchpad open --slug review-doc-$PR)" || exit 1
 
 # RE-DERIVE — every LATER Bash call, where shell state is already gone. Asserts the namespace
@@ -1979,11 +1979,21 @@ opened it, `6` the filesystem refused — so a caller branches on status, not pr
 fallback to a shared or default location**: a fallback is precisely what reintroduces the silent
 clobber (ADR 0092, fail closed).
 
-The **owner stamp** is what makes the last case structural rather than polite. `open` writes the
-run's identity into the namespace, so if two runs ever share a session id *and* a slug, the
-second `open` is **refused loudly** instead of overwriting, and the first run's `path` refuses to
-hand back a namespace someone else took over. The silent-by-construction failure — a clobbered
-file that reads back successfully — has no path left to take.
+The **owner stamp** is what makes the last case structural rather than polite — and it is a
+**claim, not a check**. `open` creates the stamp with an exclusive create (`O_CREAT | O_EXCL`),
+so when two runs that share a session id *and* a slug open at the same instant, the kernel picks
+one winner and the loser's "already exists" **is** the refusal: exit `4`, nothing overwritten.
+The winner's `path` likewise refuses to hand back a namespace another run has taken over. Note
+what this is *not*: a stamp that is read, classified, and only then acted on leaves a real window
+between the check and the act — it was one, and eight concurrent opens on a single session and
+slug each concluded they owned it (#4028).
+
+The stamp separates runs by identity, and there is exactly one pair it cannot: two runs whose
+identity is **byte-identical** — same session id *and* same `$CLAUDE_PID`, or neither carrying
+one. Nothing in the environment tells those apart, so the loser **re-enters** the namespace
+instead of being refused. That re-entry is never destructive (`open` returns a namespace it
+re-enters exactly as it stands), so the worst case degrades to two writers who are, by every
+signal available, the same run — never one run silently reading another's state.
 
 The verb ships with `pipeline-cli`. Where it isn't installed (a foreign install, ADR 0062), the
 equivalent one-liner below is the fallback — deliberately inlined at each site rather than made a

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -62,6 +62,7 @@ import {reviewHeadCommand} from "./tools/review-head/command.ts";
 import {roadmapCommand} from "./tools/roadmap/command.ts";
 import {roadmapGuardCommand} from "./tools/roadmap-guard/command.ts";
 import {runEvidenceCommand} from "./tools/run-evidence/command.ts";
+import {scratchpadCommand} from "./tools/scratchpad/command.ts";
 import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
 import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
@@ -229,4 +230,9 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// Fail-closed on an unreadable corpus / zero scope (ADR 0092); `indeterminate` is a distinct
 	// outcome from `no-overlap` by construction.
 	adrSweepCommand,
+	// #3718 — the per-run scratch namespace (§SP) as an allocator every agent calls instead
+	// of hand-rolling a path: unique per RUN, deterministically re-derivable across Bash
+	// calls, owner-stamped so a second run is refused rather than clobbering. Fail-closed —
+	// no fallback to a shared location, which is what made the collision silent.
+	scratchpadCommand,
 ];

--- a/packages/pipeline-cli/src/tools/scratchpad/command.concurrency.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/command.concurrency.test.ts
@@ -14,6 +14,7 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts";
 
 const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
 
@@ -53,10 +54,10 @@ const open = (pid: string): Promise<RunResult> =>
 		);
 	});
 
-describe("scratchpad open — concurrent claims on one namespace", () => {
-	it("admits exactly one of eight concurrent opens; every other exits 4 (ForeignNamespace)", {
-		timeout: 60_000,
-	}, async () => {
+describe("scratchpad open — concurrent claims on one namespace", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("admits exactly one of eight concurrent opens; every other exits 4 (ForeignNamespace)", async () => {
 		const results = await Promise.all(Array.from({length: RACERS}, (_, i) => open(`pid${i}`)));
 
 		const winners = results.filter((result) => result.code === 0);

--- a/packages/pipeline-cli/src/tools/scratchpad/command.concurrency.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/command.concurrency.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The concurrent-open race, held at the process level — the one property a same-process
+ * test cannot show, because `openNamespace` is synchronous and never interleaves with
+ * itself in one process.
+ *
+ * Eight real `scratchpad open` processes are launched at once on ONE session id and ONE
+ * slug, differing only by `$CLAUDE_PID`. Before the claim was an exclusive create this
+ * exact run returned `0 4 0 6 0 0 4 0` — five of eight each reporting success on the same
+ * namespace, which is #3718's silent cross-run read back in reach. Exactly one may win.
+ */
+import {execFile} from "node:child_process";
+import {mkdtempSync, readFileSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+// Synthetic run identity — never a real machine/session value in a fixture (#4018).
+const SESSION = "cccccccc-0000-4000-8000-00000000000c";
+const SLUG = "review-doc-3951";
+const RACERS = 8;
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+}
+
+let root: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "scratchpad-race-"));
+});
+
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const open = (pid: string): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile(
+			"node",
+			[BIN, "scratchpad", "open", "--slug", SLUG, "--session", SESSION],
+			{env: {...process.env, TMPDIR: root, CLAUDE_PID: pid}},
+			(error, stdout) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout: stdout.trim()});
+			},
+		);
+	});
+
+describe("scratchpad open — concurrent claims on one namespace", () => {
+	it("admits exactly one of eight concurrent opens; every other exits 4 (ForeignNamespace)", {
+		timeout: 60_000,
+	}, async () => {
+		const results = await Promise.all(Array.from({length: RACERS}, (_, i) => open(`pid${i}`)));
+
+		const winners = results.filter((result) => result.code === 0);
+		assert.strictEqual(
+			winners.length,
+			1,
+			`expected a single winner, got exit codes [${results.map((r) => r.code).join(" ")}]`,
+		);
+		for (const loser of results.filter((result) => result.code !== 0))
+			assert.strictEqual(loser.code, 4, "a loser must be refused as ForeignNamespace, not 0 or 6");
+
+		// The winner owns what it was handed: the surviving stamp names it, and no loser
+		// printed a path it could have written into.
+		const path = winners[0]?.stdout ?? "";
+		assert.strictEqual(path, join(root, "kampus-run", SESSION, SLUG));
+		const owner: unknown = JSON.parse(readFileSync(join(path, ".kampus-run-owner"), "utf8"));
+		assert.isTrue(
+			results.every((result) => result.code === 0 || result.stdout === ""),
+			"a refused open must print no path",
+		);
+		assert.strictEqual((owner as {session: string}).session, SESSION);
+	});
+});

--- a/packages/pipeline-cli/src/tools/scratchpad/command.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/command.ts
@@ -1,0 +1,97 @@
+/**
+ * The `scratchpad` tool — `pipeline-cli scratchpad <open|path|file> --slug <slug>`.
+ *
+ * The one allocator every crew agent calls instead of hand-rolling a scratch path
+ * (#3718). It prints an absolute per-run directory (or a file inside it) on stdout and
+ * NOTHING else, so a caller captures it directly:
+ *
+ *   RUN_SCRATCH="$(pipeline-cli scratchpad open --slug review-doc-3951)" || exit 1
+ *   VERDICT="$(pipeline-cli scratchpad file --slug review-doc-3951 --name verdict.md)" || exit 1
+ *
+ * Every failure is a REFUSAL with a distinct exit code (2 missing session id, 3 bad
+ * slug/name, 4 the namespace belongs to another run, 5 not opened in this run, 6 the
+ * filesystem refused) and a reason on stderr. There is no fallback to a shared or default
+ * location — a fallback is exactly what reintroduces the silent cross-run clobber.
+ *
+ * `open` is the run's first write; `path` and `file` re-derive in every later Bash call,
+ * where shell state is already gone. See gh-issue-intake-formats.md §SP.
+ */
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {exitCodeFor, type NamespaceInput, type Resolved} from "./scratchpad.ts";
+import {openNamespace, resolveOwnFile, resolveOwnNamespace} from "./store.ts";
+
+const slugFlag = Flag.string("slug").pipe(
+	Flag.withDescription(
+		"names the caller: the skill plus its work item (e.g. `review-doc-3951`, `write-code-3718`)",
+	),
+);
+
+const sessionFlag = Flag.string("session").pipe(
+	Flag.optional,
+	Flag.withDescription("run identity to namespace under (default: $CLAUDE_CODE_SESSION_ID)"),
+);
+
+const nameFlag = Flag.string("name").pipe(
+	Flag.withDescription("the leaf file name inside the namespace (e.g. `verdict.md`)"),
+);
+
+const inputFrom = (slug: string, session: Option.Option<string>): NamespaceInput => ({
+	tmpdir: process.env.TMPDIR,
+	session: Option.getOrElse(session, () => process.env.CLAUDE_CODE_SESSION_ID ?? ""),
+	pid: process.env.CLAUDE_PID,
+	slug,
+});
+
+/** Print the resolved path on stdout, or the typed refusal on stderr and exit non-zero. */
+const emit = (resolved: Resolved<string>) =>
+	Effect.gen(function* () {
+		if (!resolved.ok) {
+			process.stderr.write(`scratchpad: ${resolved.error._tag} — ${resolved.error.message}\n`);
+			process.exit(exitCodeFor(resolved.error));
+		}
+		yield* Console.log(resolved.value);
+	});
+
+const openCommand = Command.make(
+	"open",
+	{slug: slugFlag, session: sessionFlag},
+	Effect.fn(function* ({slug, session}) {
+		const resolved = openNamespace(inputFrom(slug, session));
+		yield* emit(resolved.ok ? {ok: true, value: resolved.value.path} : resolved);
+	}),
+).pipe(
+	Command.withDescription(
+		"Allocate this run's scratch namespace fresh and stamp it as ours (refuses a namespace another run owns)",
+	),
+);
+
+const pathCommand = Command.make(
+	"path",
+	{slug: slugFlag, session: sessionFlag},
+	Effect.fn(function* ({slug, session}) {
+		const resolved = resolveOwnNamespace(inputFrom(slug, session));
+		yield* emit(resolved.ok ? {ok: true, value: resolved.value.path} : resolved);
+	}),
+).pipe(
+	Command.withDescription(
+		"Re-derive this run's scratch namespace in a later Bash call, asserting it exists and is still ours",
+	),
+);
+
+const fileCommand = Command.make(
+	"file",
+	{slug: slugFlag, session: sessionFlag, name: nameFlag},
+	Effect.fn(function* ({slug, session, name}) {
+		yield* emit(resolveOwnFile(inputFrom(slug, session), name));
+	}),
+).pipe(
+	Command.withDescription("Re-derive the path of one file inside this run's scratch namespace"),
+);
+
+export const scratchpadCommand = Command.make("scratchpad").pipe(
+	Command.withSubcommands([openCommand, pathCommand, fileCommand]),
+	Command.withDescription(
+		"Allocate and re-derive the per-run scratch namespace (§SP) — fail-closed, never a shared path",
+	),
+);

--- a/packages/pipeline-cli/src/tools/scratchpad/command.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/command.ts
@@ -29,7 +29,9 @@ const slugFlag = Flag.string("slug").pipe(
 
 const sessionFlag = Flag.string("session").pipe(
 	Flag.optional,
-	Flag.withDescription("run identity to namespace under (default: $CLAUDE_CODE_SESSION_ID)"),
+	Flag.withDescription(
+		"TEST-ONLY override of the run identity to namespace under (default: $CLAUDE_CODE_SESSION_ID). Never pass it from a skill or agent: a fixed literal re-keys every caller onto one namespace, which is the shared surface this tool exists to remove",
+	),
 );
 
 const nameFlag = Flag.string("name").pipe(

--- a/packages/pipeline-cli/src/tools/scratchpad/scratchpad.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/scratchpad.ts
@@ -18,10 +18,15 @@
  *     bare `mktemp -d` destroys: re-running it yields a new empty directory).
  *
  * The path key delivers both: `<tmpdir>/kampus-run/<session-id>/<slug>`. The OWNER STAMP
- * (`.kampus-run-owner`) is what makes the remaining case structural rather than polite —
- * if two runs ever share a session id and a slug, the second one's open is REFUSED loudly
- * instead of clobbering, and the first one's re-derive refuses to read a namespace some
- * other run took over.
+ * (`.kampus-run-owner`) covers the remaining case — two runs that resolve the SAME path.
+ * The stamp is not a marker the store checks and then acts on: it is created exclusively
+ * (`store.ts`, `wx`), so among concurrent opens exactly one run wins and every run the
+ * stamp identifies as another is refused with `ForeignNamespace` rather than clobbering,
+ * and a re-derive refuses to read a namespace another run holds. The one pair the stamp
+ * cannot separate is two runs whose identity is byte-identical (same session id AND same
+ * `$CLAUDE_PID`, or neither carrying one) — nothing in the environment distinguishes them,
+ * so the loser re-enters instead of being refused. It is never destructive: a re-entered
+ * namespace is returned as it stands, never cleared.
  */
 
 /** The directory segment that marks a per-run namespace, under the system temp root. */

--- a/packages/pipeline-cli/src/tools/scratchpad/scratchpad.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/scratchpad.ts
@@ -1,0 +1,223 @@
+/**
+ * `scratchpad` pure core — resolve the per-run scratch namespace a crew agent writes
+ * intermediate state into, and decide who owns it. IO-free and total; the filesystem
+ * boundary lives in `store.ts`, the CLI surface in `command.ts`.
+ *
+ * The whole point is that a scratch path is unique per RUN, never per session or per
+ * tool: the pipeline runs several agents concurrently by design, so a fixed or
+ * work-item-keyed leaf name is a shared mutable surface. A clobbered file reads back
+ * SUCCESSFULLY with the other run's content — no error to catch — which is how one
+ * reviewer's `git diff` returned another PR's file list, and how a `review-doc` verdict
+ * body computed for one PR was posted-attempted against another (#3718). See the
+ * gh-issue-intake-formats.md §SP contract this core owns the mechanics of.
+ *
+ * Two properties are BOTH required, and a namespace with only one is broken:
+ *   - per-run uniqueness — concurrent runs must not be able to name each other's files;
+ *   - deterministic re-derivability — an agent's shell state does not survive between
+ *     Bash calls, so a later call must recompute the same path from scratch (which a
+ *     bare `mktemp -d` destroys: re-running it yields a new empty directory).
+ *
+ * The path key delivers both: `<tmpdir>/kampus-run/<session-id>/<slug>`. The OWNER STAMP
+ * (`.kampus-run-owner`) is what makes the remaining case structural rather than polite —
+ * if two runs ever share a session id and a slug, the second one's open is REFUSED loudly
+ * instead of clobbering, and the first one's re-derive refuses to read a namespace some
+ * other run took over.
+ */
+
+/** The directory segment that marks a per-run namespace, under the system temp root. */
+export const RUN_SCRATCH_ROOT = "kampus-run";
+
+/** The owner-stamp file written at the root of every allocated namespace. */
+export const OWNER_FILE = ".kampus-run-owner";
+
+/**
+ * Who owns a namespace. `session` is `$CLAUDE_CODE_SESSION_ID`, the per-agent-run UUID
+ * the runtime exports (the same token ADR 0115's claim protocol stamps) — stable across
+ * an agent's separate Bash calls, distinct per agent run. `pid` is `$CLAUDE_PID`, an
+ * extra discriminator when it is available; `null` when the environment omits it.
+ */
+export interface RunIdentity {
+	readonly session: string;
+	readonly pid: string | null;
+}
+
+/** The inputs a namespace is resolved from — all read from the environment by the caller. */
+export interface NamespaceInput {
+	/** `$TMPDIR`; a missing value falls back to `/tmp`, the POSIX default. */
+	readonly tmpdir?: string | undefined;
+	/** `$CLAUDE_CODE_SESSION_ID`. Absent ⇒ `MissingSessionId`, never a shared-path fallback. */
+	readonly session?: string | undefined;
+	/** `$CLAUDE_PID`. Absent is fine — it only sharpens ownership, it is not the key. */
+	readonly pid?: string | undefined;
+	/** Names the caller: the skill plus its work item (`review-doc-3951`, `write-code-3718`). */
+	readonly slug: string;
+}
+
+/** A resolved namespace: where it lives, its owner stamp, and the identity that owns it. */
+export interface Namespace {
+	readonly path: string;
+	readonly ownerFile: string;
+	readonly identity: RunIdentity;
+}
+
+/**
+ * Every way resolving or claiming a namespace can fail. Each one is a REFUSAL: there is
+ * no fallback to a shared or default location, because such a fallback resurrects the
+ * exact silent clobber this tool exists to remove (ADR 0092, fail closed).
+ */
+export type ScratchpadError =
+	| {readonly _tag: "MissingSessionId"; readonly message: string}
+	| {readonly _tag: "InvalidSlug"; readonly slug: string; readonly message: string}
+	| {readonly _tag: "InvalidLeafName"; readonly name: string; readonly message: string}
+	| {
+			readonly _tag: "ForeignNamespace";
+			readonly path: string;
+			readonly owner: RunIdentity;
+			readonly mine: RunIdentity;
+			readonly message: string;
+	  }
+	| {readonly _tag: "NamespaceMissing"; readonly path: string; readonly message: string}
+	| {readonly _tag: "NamespaceUnavailable"; readonly path: string; readonly message: string};
+
+/** A total result: the value, or the typed refusal. Nothing throws, nothing falls back. */
+export type Resolved<A> =
+	| {readonly ok: true; readonly value: A}
+	| {readonly ok: false; readonly error: ScratchpadError};
+
+export const ok = <A>(value: A): Resolved<A> => ({ok: true, value});
+export const fail = <A>(error: ScratchpadError): Resolved<A> => ({ok: false, error});
+
+/**
+ * A slug names the caller, so it must be a single readable path segment. Rejecting
+ * separators and dot-segments is not cosmetic: a slug that escapes its directory would
+ * let one run address another run's namespace, which is the property being enforced.
+ */
+const SLUG_RE = /^[a-z0-9][a-z0-9._-]*$/;
+
+/** A leaf file name inside a namespace — same segment rule, so `../` can never appear. */
+const LEAF_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+const trimmed = (value: string | undefined): string => (value ?? "").trim();
+
+export const validateSlug = (slug: string): Resolved<string> => {
+	const value = trimmed(slug);
+	if (value === "")
+		return fail({
+			_tag: "InvalidSlug",
+			slug,
+			message: "slug is empty — name the caller (skill + work item, e.g. `review-doc-3951`)",
+		});
+	if (value === "." || value === ".." || !SLUG_RE.test(value))
+		return fail({
+			_tag: "InvalidSlug",
+			slug,
+			message: `slug ${JSON.stringify(slug)} is not a single lowercase path segment ([a-z0-9][a-z0-9._-]*) — a separator or dot-segment would let one run address another run's namespace`,
+		});
+	return ok(value);
+};
+
+export const validateLeafName = (name: string): Resolved<string> => {
+	const value = trimmed(name);
+	if (value === "" || value === "." || value === ".." || !LEAF_RE.test(value))
+		return fail({
+			_tag: "InvalidLeafName",
+			name,
+			message: `file name ${JSON.stringify(name)} is not a single path segment ([A-Za-z0-9][A-Za-z0-9._-]*) — keep the leaf plain; uniqueness lives in the directory`,
+		});
+	return ok(value);
+};
+
+/** The system temp root a namespace hangs under; `/tmp` is the POSIX default. */
+export const tempRoot = (tmpdir: string | undefined): string => {
+	const value = trimmed(tmpdir);
+	return value === "" ? "/tmp" : value.replace(/\/+$/, "");
+};
+
+/**
+ * Resolve the namespace for this run. Deterministic: the same environment plus the same
+ * slug recomputes the same path in any later Bash call, which is what lets a caller
+ * re-derive instead of parking the path in another file (that would just relocate the
+ * collision onto that file).
+ */
+export const resolveNamespace = (input: NamespaceInput): Resolved<Namespace> => {
+	const session = trimmed(input.session);
+	if (session === "")
+		return fail({
+			_tag: "MissingSessionId",
+			message:
+				"CLAUDE_CODE_SESSION_ID is unset — there is no run identity to namespace under, and a shared-path fallback would resurrect the cross-run clobber (#3718). Refusing.",
+		});
+	const slug = validateSlug(input.slug);
+	if (!slug.ok) return slug;
+	const pid = trimmed(input.pid);
+	const path = `${tempRoot(input.tmpdir)}/${RUN_SCRATCH_ROOT}/${session}/${slug.value}`;
+	return ok({
+		path,
+		ownerFile: `${path}/${OWNER_FILE}`,
+		identity: {session, pid: pid === "" ? null : pid},
+	});
+};
+
+/** The owner stamp written into a freshly-opened namespace. */
+export const formatOwner = (identity: RunIdentity, openedAt: string): string =>
+	`${JSON.stringify({session: identity.session, pid: identity.pid, openedAt})}\n`;
+
+/** Read an owner stamp back. Anything unparseable is `null` — an unreadable stamp is not an owner. */
+export const parseOwner = (text: string): RunIdentity | null => {
+	try {
+		const parsed: unknown = JSON.parse(text);
+		if (typeof parsed !== "object" || parsed === null) return null;
+		const record = parsed as {session?: unknown; pid?: unknown};
+		if (typeof record.session !== "string" || record.session.trim() === "") return null;
+		const pid =
+			typeof record.pid === "string" && record.pid.trim() !== "" ? record.pid.trim() : null;
+		return {session: record.session.trim(), pid};
+	} catch {
+		return null;
+	}
+};
+
+/** How an existing namespace relates to the run asking for it. */
+export type Ownership = "unowned" | "mine" | "foreign";
+
+/**
+ * Fail-closed by construction: only positive evidence that the stamp names THIS run
+ * resolves `mine`. A same-session stamp carrying a different pid is `foreign` — that is
+ * precisely the two-concurrent-runs-share-a-session case, and calling it mine is what a
+ * silent clobber looks like.
+ */
+export const classifyOwnership = (existing: RunIdentity | null, mine: RunIdentity): Ownership => {
+	if (existing === null) return "unowned";
+	if (existing.session !== mine.session) return "foreign";
+	if (existing.pid === null && mine.pid === null) return "mine";
+	return existing.pid === mine.pid ? "mine" : "foreign";
+};
+
+export const foreignNamespaceError = (
+	path: string,
+	owner: RunIdentity,
+	mine: RunIdentity,
+): ScratchpadError => ({
+	_tag: "ForeignNamespace",
+	path,
+	owner,
+	mine,
+	message: `the namespace is owned by another run (owner session ${owner.session} pid ${owner.pid ?? "-"}; mine ${mine.session} pid ${mine.pid ?? "-"}) — refusing to clobber or read it. Re-run with a run-distinguishing --slug.`,
+});
+
+/** The process exit code each refusal maps to, so a caller can branch without parsing prose. */
+export const exitCodeFor = (error: ScratchpadError): number => {
+	switch (error._tag) {
+		case "MissingSessionId":
+			return 2;
+		case "InvalidSlug":
+		case "InvalidLeafName":
+			return 3;
+		case "ForeignNamespace":
+			return 4;
+		case "NamespaceMissing":
+			return 5;
+		case "NamespaceUnavailable":
+			return 6;
+	}
+};

--- a/packages/pipeline-cli/src/tools/scratchpad/scratchpad.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/scratchpad.unit.test.ts
@@ -1,0 +1,186 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	classifyOwnership,
+	exitCodeFor,
+	formatOwner,
+	OWNER_FILE,
+	parseOwner,
+	type RunIdentity,
+	resolveNamespace,
+	tempRoot,
+	validateLeafName,
+	validateSlug,
+} from "./scratchpad.ts";
+
+// Synthetic run identities — never a real machine/session value in a fixture (#4018).
+const SESSION_A = "aaaaaaaa-0000-4000-8000-00000000000a";
+const SESSION_B = "bbbbbbbb-0000-4000-8000-00000000000b";
+
+const namespaceOf = (over: {session?: string; pid?: string; slug?: string} = {}) => {
+	const resolved = resolveNamespace({
+		tmpdir: "/scratch",
+		session: SESSION_A,
+		slug: "review-doc-3951",
+		...over,
+	});
+	assert.isTrue(resolved.ok, "expected the namespace to resolve");
+	return resolved.ok ? resolved.value : undefined;
+};
+
+describe("resolveNamespace — deterministic and per-run", () => {
+	it("keys the path on the run's session id and the caller's slug", () => {
+		assert.strictEqual(namespaceOf()?.path, `/scratch/kampus-run/${SESSION_A}/review-doc-3951`);
+	});
+
+	it("recomputes the SAME path from the same inputs — the re-derive across Bash calls", () => {
+		// Shell state does not survive between an agent's Bash calls, so the later call has to
+		// recompute the path from scratch. That is the property a bare `mktemp -d` destroys.
+		assert.strictEqual(namespaceOf()?.path, namespaceOf()?.path);
+	});
+
+	it("two concurrent runs never resolve the same path — different sessions", () => {
+		assert.notStrictEqual(namespaceOf()?.path, namespaceOf({session: SESSION_B})?.path);
+	});
+
+	it("two gates over different PRs never resolve the same path — different slugs", () => {
+		assert.notStrictEqual(namespaceOf()?.path, namespaceOf({slug: "review-doc-3955"})?.path);
+	});
+
+	it("puts the owner stamp at the namespace root", () => {
+		assert.strictEqual(namespaceOf()?.ownerFile, `${namespaceOf()?.path}/${OWNER_FILE}`);
+	});
+
+	it("carries the pid when the environment exports one, null when it does not", () => {
+		assert.strictEqual(namespaceOf({pid: "4242"})?.identity.pid, "4242");
+		assert.strictEqual(namespaceOf()?.identity.pid, null);
+	});
+});
+
+describe("resolveNamespace — fail closed, never a shared fallback", () => {
+	it("refuses with MissingSessionId when the session id is absent", () => {
+		const resolved = resolveNamespace({tmpdir: "/scratch", slug: "write-code-3718"});
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "MissingSessionId");
+	});
+
+	it("refuses a whitespace-only session id the same way", () => {
+		const resolved = resolveNamespace({
+			tmpdir: "/scratch",
+			session: "   ",
+			slug: "write-code-3718",
+		});
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "MissingSessionId");
+	});
+
+	it("falls back to /tmp only for the TEMP ROOT — never for the run namespace itself", () => {
+		assert.strictEqual(tempRoot(undefined), "/tmp");
+		assert.strictEqual(tempRoot("/scratch/"), "/scratch");
+	});
+});
+
+describe("validateSlug / validateLeafName — a slug can never escape its directory", () => {
+	for (const bad of ["", "  ", "..", ".", "review/../3955", "review doc", "Review-Doc", "/abs"]) {
+		it(`rejects ${JSON.stringify(bad)}`, () => {
+			const resolved = validateSlug(bad);
+			assert.isFalse(resolved.ok);
+			if (!resolved.ok) assert.strictEqual(resolved.error._tag, "InvalidSlug");
+		});
+	}
+
+	it("accepts a plain skill-plus-work-item slug", () => {
+		const resolved = validateSlug(" review-doc-3951 ");
+		assert.isTrue(resolved.ok);
+		if (resolved.ok) assert.strictEqual(resolved.value, "review-doc-3951");
+	});
+
+	it("rejects a leaf name that walks out of the namespace", () => {
+		const resolved = validateLeafName("../verdict.md");
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "InvalidLeafName");
+	});
+
+	it("keeps ordinary leaf names — uniqueness lives in the directory, not the file name", () => {
+		assert.isTrue(validateLeafName("verdict-doc.md").ok);
+	});
+});
+
+describe("owner stamp round-trip", () => {
+	const identity: RunIdentity = {session: SESSION_A, pid: "4242"};
+
+	it("parses back what it formatted", () => {
+		assert.deepStrictEqual(parseOwner(formatOwner(identity, "2026-07-25T00:00:00.000Z")), identity);
+	});
+
+	it("reads a pid-less stamp as pid null", () => {
+		const parsed = parseOwner(
+			formatOwner({session: SESSION_A, pid: null}, "2026-07-25T00:00:00.000Z"),
+		);
+		assert.deepStrictEqual(parsed, {session: SESSION_A, pid: null});
+	});
+
+	it("treats an unreadable stamp as no owner at all", () => {
+		assert.isNull(parseOwner("not json"));
+		assert.isNull(parseOwner("{}"));
+		assert.isNull(parseOwner('{"session":"  "}'));
+	});
+});
+
+describe("classifyOwnership — positive evidence only", () => {
+	const mine: RunIdentity = {session: SESSION_A, pid: "4242"};
+
+	it("no stamp ⇒ unowned", () => {
+		assert.strictEqual(classifyOwnership(null, mine), "unowned");
+	});
+
+	it("same session and pid ⇒ mine", () => {
+		assert.strictEqual(classifyOwnership({session: SESSION_A, pid: "4242"}, mine), "mine");
+	});
+
+	it("another session ⇒ foreign", () => {
+		assert.strictEqual(classifyOwnership({session: SESSION_B, pid: "4242"}, mine), "foreign");
+	});
+
+	it("SAME session, different pid ⇒ foreign — the two-runs-share-a-session case", () => {
+		// Calling this one "mine" is what a silent clobber looks like: two live runs would both
+		// treat the namespace as theirs and overwrite each other's files (#3718).
+		assert.strictEqual(classifyOwnership({session: SESSION_A, pid: "9999"}, mine), "foreign");
+	});
+
+	it("a stamp with a pid vs a run without one ⇒ foreign (fail closed on the ambiguity)", () => {
+		assert.strictEqual(
+			classifyOwnership({session: SESSION_A, pid: "4242"}, {session: SESSION_A, pid: null}),
+			"foreign",
+		);
+	});
+
+	it("neither side has a pid ⇒ mine (the session id is the run identity)", () => {
+		assert.strictEqual(
+			classifyOwnership({session: SESSION_A, pid: null}, {session: SESSION_A, pid: null}),
+			"mine",
+		);
+	});
+});
+
+describe("exitCodeFor — a caller branches on status, not prose", () => {
+	it("maps each refusal to its own code", () => {
+		assert.strictEqual(exitCodeFor({_tag: "MissingSessionId", message: ""}), 2);
+		assert.strictEqual(exitCodeFor({_tag: "InvalidSlug", slug: "", message: ""}), 3);
+		assert.strictEqual(exitCodeFor({_tag: "InvalidLeafName", name: "", message: ""}), 3);
+		assert.strictEqual(
+			exitCodeFor({
+				_tag: "ForeignNamespace",
+				path: "/scratch",
+				owner: {session: SESSION_B, pid: null},
+				mine: {session: SESSION_A, pid: null},
+				message: "",
+			}),
+			4,
+		);
+		assert.strictEqual(exitCodeFor({_tag: "NamespaceMissing", path: "/scratch", message: ""}), 5);
+		assert.strictEqual(
+			exitCodeFor({_tag: "NamespaceUnavailable", path: "/scratch", message: ""}),
+			6,
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/scratchpad/store.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/store.ts
@@ -1,0 +1,107 @@
+/**
+ * `scratchpad` filesystem boundary — allocate and re-derive the per-run namespace the
+ * pure core (`scratchpad.ts`) decides. Plain `node:fs`, mirroring the `worktree-sweep` /
+ * `main-sync` shape, so the tool's requirement stays at the Node platform ceiling the
+ * registry provides.
+ *
+ * Every function returns a `Resolved` — a refusal is a value here, never a throw and
+ * never a fallback to a shared path.
+ */
+import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {
+	classifyOwnership,
+	fail,
+	foreignNamespaceError,
+	formatOwner,
+	type Namespace,
+	type NamespaceInput,
+	ok,
+	parseOwner,
+	type Resolved,
+	resolveNamespace,
+	validateLeafName,
+} from "./scratchpad.ts";
+
+/** Read the owner stamp of an already-existing namespace; `null` when there is none to read. */
+const readOwner = (namespace: Namespace) => {
+	if (!existsSync(namespace.ownerFile)) return null;
+	try {
+		return parseOwner(readFileSync(namespace.ownerFile, "utf8"));
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * OPEN — the run's first write of scratch state. Allocates the namespace fresh (clearing
+ * leftovers from an earlier run of the same slug in the same session, so a re-run never
+ * reads its predecessor's files) and stamps it as ours.
+ *
+ * An existing namespace owned by ANOTHER run is refused, not clobbered: that refusal is
+ * the structural half of the fix — the silent cross-run overwrite (#3718) becomes a loud,
+ * typed `ForeignNamespace`.
+ */
+export const openNamespace = (
+	input: NamespaceInput,
+	now: () => Date = () => new Date(),
+): Resolved<Namespace> => {
+	const resolved = resolveNamespace(input);
+	if (!resolved.ok) return resolved;
+	const namespace = resolved.value;
+	if (existsSync(namespace.path)) {
+		const owner = readOwner(namespace);
+		if (owner !== null && classifyOwnership(owner, namespace.identity) === "foreign")
+			return fail(foreignNamespaceError(namespace.path, owner, namespace.identity));
+	}
+	try {
+		rmSync(namespace.path, {recursive: true, force: true});
+		mkdirSync(namespace.path, {recursive: true});
+		writeFileSync(namespace.ownerFile, formatOwner(namespace.identity, now().toISOString()));
+	} catch (cause) {
+		return fail({
+			_tag: "NamespaceUnavailable",
+			path: namespace.path,
+			message: `could not allocate the per-run scratch namespace: ${String(cause)}`,
+		});
+	}
+	return ok(namespace);
+};
+
+/**
+ * RE-DERIVE — every later Bash call. Recomputes the same path and asserts it is still
+ * there and still ours. It deliberately does NOT create anything: an absent namespace
+ * means the opening step never ran in THIS run, and answering that with a fresh empty
+ * directory is how a read of your own earlier state silently becomes a read of nothing.
+ */
+export const resolveOwnNamespace = (input: NamespaceInput): Resolved<Namespace> => {
+	const resolved = resolveNamespace(input);
+	if (!resolved.ok) return resolved;
+	const namespace = resolved.value;
+	if (!existsSync(namespace.path))
+		return fail({
+			_tag: "NamespaceMissing",
+			path: namespace.path,
+			message:
+				"the per-run scratch namespace does not exist — run `scratchpad open --slug <slug>` in THIS run before re-deriving.",
+		});
+	const owner = readOwner(namespace);
+	if (owner !== null && classifyOwnership(owner, namespace.identity) === "foreign")
+		return fail(foreignNamespaceError(namespace.path, owner, namespace.identity));
+	if (owner === null)
+		return fail({
+			_tag: "NamespaceMissing",
+			path: namespace.path,
+			message:
+				"the namespace carries no owner stamp — it was not allocated by `scratchpad open`, so it cannot be proven to hold THIS run's state.",
+		});
+	return ok(namespace);
+};
+
+/** A named file inside this run's namespace — the path every scratch write should use. */
+export const resolveOwnFile = (input: NamespaceInput, name: string): Resolved<string> => {
+	const leaf = validateLeafName(name);
+	if (!leaf.ok) return leaf;
+	const namespace = resolveOwnNamespace(input);
+	if (!namespace.ok) return namespace;
+	return ok(`${namespace.value.path}/${leaf.value}`);
+};

--- a/packages/pipeline-cli/src/tools/scratchpad/store.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/store.ts
@@ -7,7 +7,7 @@
  * Every function returns a `Resolved` — a refusal is a value here, never a throw and
  * never a fallback to a shared path.
  */
-import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import {
 	classifyOwnership,
 	fail,
@@ -15,6 +15,7 @@ import {
 	formatOwner,
 	type Namespace,
 	type NamespaceInput,
+	OWNER_FILE,
 	ok,
 	parseOwner,
 	type Resolved,
@@ -32,14 +33,39 @@ const readOwner = (namespace: Namespace) => {
 	}
 };
 
+const isEexist = (cause: unknown): boolean =>
+	typeof cause === "object" && cause !== null && (cause as {code?: unknown}).code === "EEXIST";
+
+const unavailable = (namespace: Namespace, cause: unknown): Resolved<Namespace> =>
+	fail({
+		_tag: "NamespaceUnavailable",
+		path: namespace.path,
+		message: `could not allocate the per-run scratch namespace: ${String(cause)}`,
+	});
+
 /**
- * OPEN — the run's first write of scratch state. Allocates the namespace fresh (clearing
- * leftovers from an earlier run of the same slug in the same session, so a re-run never
- * reads its predecessor's files) and stamps it as ours.
+ * Clear what a previous, unclaimed occupant left behind — never the stamp, which is this
+ * run's live claim. Only reached by the run that WON the claim, so there is no concurrent
+ * peer whose files this could delete.
+ */
+const clearLeftovers = (namespace: Namespace): void => {
+	for (const entry of readdirSync(namespace.path)) {
+		if (entry === OWNER_FILE) continue;
+		rmSync(`${namespace.path}/${entry}`, {recursive: true, force: true});
+	}
+};
+
+/**
+ * OPEN — the run's first write of scratch state. Claims the namespace and stamps it as ours.
  *
- * An existing namespace owned by ANOTHER run is refused, not clobbered: that refusal is
- * the structural half of the fix — the silent cross-run overwrite (#3718) becomes a loud,
- * typed `ForeignNamespace`.
+ * The claim is ONE exclusive create: the stamp is written with `wx` (`O_CREAT | O_EXCL`), so
+ * the kernel — not a preceding existence check — picks the single winner among concurrent
+ * opens, and the `EEXIST` it raises IS the refusal. This is the shape Node's own `fs` docs
+ * prescribe (the "write (RECOMMENDED)" example), against the check-then-act they name as a
+ * race. The earlier `existsSync` → classify → `rmSync` + write sequence had a real window
+ * between the check and the act: eight concurrent opens on one session and slug each
+ * concluded they owned it, five reporting success, which put #3718's silent cross-run read
+ * back in reach on precisely the case the stamp was added to close.
  */
 export const openNamespace = (
 	input: NamespaceInput,
@@ -48,21 +74,37 @@ export const openNamespace = (
 	const resolved = resolveNamespace(input);
 	if (!resolved.ok) return resolved;
 	const namespace = resolved.value;
-	if (existsSync(namespace.path)) {
-		const owner = readOwner(namespace);
-		if (owner !== null && classifyOwnership(owner, namespace.identity) === "foreign")
-			return fail(foreignNamespaceError(namespace.path, owner, namespace.identity));
+	try {
+		mkdirSync(namespace.path, {recursive: true});
+	} catch (cause) {
+		return unavailable(namespace, cause);
 	}
 	try {
-		rmSync(namespace.path, {recursive: true, force: true});
-		mkdirSync(namespace.path, {recursive: true});
-		writeFileSync(namespace.ownerFile, formatOwner(namespace.identity, now().toISOString()));
-	} catch (cause) {
-		return fail({
-			_tag: "NamespaceUnavailable",
-			path: namespace.path,
-			message: `could not allocate the per-run scratch namespace: ${String(cause)}`,
+		writeFileSync(namespace.ownerFile, formatOwner(namespace.identity, now().toISOString()), {
+			flag: "wx",
 		});
+	} catch (cause) {
+		if (!isEexist(cause)) return unavailable(namespace, cause);
+		// The claim is already held. Whose?
+		const owner = readOwner(namespace);
+		if (owner === null)
+			return fail({
+				_tag: "NamespaceUnavailable",
+				path: namespace.path,
+				message:
+					"the namespace carries a claim whose owner stamp cannot be read — refusing rather than assuming it is ours.",
+			});
+		if (classifyOwnership(owner, namespace.identity) === "foreign")
+			return fail(foreignNamespaceError(namespace.path, owner, namespace.identity));
+		// Held by this same run: a re-open returns it AS IS. Clearing here would be the one
+		// destructive path left — a peer this run cannot distinguish from itself would delete
+		// state the claim holder had already written.
+		return ok(namespace);
+	}
+	try {
+		clearLeftovers(namespace);
+	} catch (cause) {
+		return unavailable(namespace, cause);
 	}
 	return ok(namespace);
 };

--- a/packages/pipeline-cli/src/tools/scratchpad/store.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/store.unit.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The store's filesystem behaviour — and the #3718 regression it exists to hold: a
+ * concurrent-run scenario that previously clobbered a shared scratchpad file must never
+ * read back another run's content.
+ *
+ * These run against a real temp directory (no subprocess), so they are fast and
+ * deterministic under parallel load.
+ */
+import {existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
+import {openNamespace, resolveOwnFile, resolveOwnNamespace} from "./store.ts";
+
+// Synthetic run identities — never a real machine/session value in a fixture (#4018).
+const REVIEWER_A = {session: "aaaaaaaa-0000-4000-8000-00000000000a", pid: "1001"};
+const REVIEWER_B = {session: "bbbbbbbb-0000-4000-8000-00000000000b", pid: "1002"};
+
+let root: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "scratchpad-test-"));
+});
+
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const input = (run: {session: string; pid: string}, slug: string) => ({
+	tmpdir: root,
+	session: run.session,
+	pid: run.pid,
+	slug,
+});
+
+const pathOf = (resolved: ReturnType<typeof openNamespace>): string => {
+	assert.isTrue(resolved.ok, "expected the namespace to resolve");
+	return resolved.ok ? resolved.value.path : "";
+};
+
+describe("openNamespace", () => {
+	it("creates the namespace and stamps it as ours", () => {
+		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		assert.isTrue(existsSync(path));
+		assert.isTrue(resolveOwnNamespace(input(REVIEWER_A, "review-doc-3951")).ok);
+	});
+
+	it("clears leftovers from an earlier run of the same slug in the same session", () => {
+		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		writeFileSync(join(path, "verdict-doc.md"), "stale round-1 body");
+		openNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isFalse(existsSync(join(path, "verdict-doc.md")));
+	});
+
+	it("refuses a namespace another run owns instead of clobbering it", () => {
+		// Same session id, different run: the residual case a per-session scratchpad cannot
+		// separate. The refusal is what makes the clobber loud instead of silent (#3718).
+		openNamespace(input(REVIEWER_A, "review-doc-3951"));
+		const second = openNamespace(input({...REVIEWER_A, pid: "9999"}, "review-doc-3951"));
+		assert.isFalse(second.ok);
+		if (!second.ok) assert.strictEqual(second.error._tag, "ForeignNamespace");
+	});
+
+	it("refuses with MissingSessionId rather than allocating a shared path", () => {
+		const resolved = openNamespace({
+			tmpdir: root,
+			session: "",
+			pid: "1001",
+			slug: "review-doc-3951",
+		});
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "MissingSessionId");
+	});
+
+	it("refuses when the filesystem will not give us the namespace", () => {
+		// A regular file where the session directory must go — the create cannot succeed, and
+		// the tool must surface that rather than degrade to somewhere writable.
+		mkdirSync(join(root, "kampus-run"), {recursive: true});
+		writeFileSync(join(root, "kampus-run", REVIEWER_A.session), "not a dir");
+		const resolved = openNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "NamespaceUnavailable");
+	});
+});
+
+describe("resolveOwnNamespace — the later-Bash-call re-derive", () => {
+	it("recomputes the opened namespace and finds this run's files still there", () => {
+		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		writeFileSync(join(path, "verdict-doc.md"), "PASS @ 167a195c");
+		const rederived = resolveOwnNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isTrue(rederived.ok);
+		if (rederived.ok)
+			assert.strictEqual(
+				readFileSync(join(rederived.value.path, "verdict-doc.md"), "utf8"),
+				"PASS @ 167a195c",
+			);
+	});
+
+	it("refuses when this run never opened it — never creates a fresh empty directory", () => {
+		const resolved = resolveOwnNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "NamespaceMissing");
+	});
+
+	it("refuses an unstamped directory — an unproven namespace is not this run's state", () => {
+		mkdirSync(join(root, "kampus-run", REVIEWER_A.session, "review-doc-3951"), {recursive: true});
+		const resolved = resolveOwnNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "NamespaceMissing");
+	});
+
+	it("refuses to read a namespace another run has taken over", () => {
+		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		// Simulate the takeover the owner stamp is there to catch.
+		writeFileSync(
+			join(path, ".kampus-run-owner"),
+			JSON.stringify({session: REVIEWER_B.session, pid: REVIEWER_B.pid}),
+		);
+		const resolved = resolveOwnNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "ForeignNamespace");
+	});
+});
+
+describe("resolveOwnFile", () => {
+	it("names a leaf inside this run's namespace", () => {
+		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		const file = resolveOwnFile(input(REVIEWER_A, "review-doc-3951"), "verdict-doc.md");
+		assert.isTrue(file.ok);
+		if (file.ok) assert.strictEqual(file.value, join(path, "verdict-doc.md"));
+	});
+
+	it("refuses a leaf name that walks out of the namespace", () => {
+		openNamespace(input(REVIEWER_A, "review-doc-3951"));
+		const file = resolveOwnFile(input(REVIEWER_A, "review-doc-3951"), "../verdict-doc.md");
+		assert.isFalse(file.ok);
+		if (!file.ok) assert.strictEqual(file.error._tag, "InvalidLeafName");
+	});
+});
+
+describe("#3718 regression — concurrent reviewers on different PRs", () => {
+	it("the shared-directory convention clobbers: the victim reads back the other PR's body", () => {
+		// The failure being fixed, reproduced on the surface that caused it: one session-scoped
+		// directory plus a generic leaf name. Nothing errors — the wrong content just reads back.
+		const shared = join(root, "session-scratchpad");
+		mkdirSync(shared, {recursive: true});
+		writeFileSync(join(shared, "verdict-doc.md"), "PR 3951 · PASS @ 167a195c");
+		writeFileSync(join(shared, "verdict-doc.md"), "PR 3955 · PASS @ 05de8f09");
+		assert.strictEqual(
+			readFileSync(join(shared, "verdict-doc.md"), "utf8"),
+			"PR 3955 · PASS @ 05de8f09",
+		);
+	});
+
+	it("per-run namespaces do not: each reviewer reads back its OWN verdict body", () => {
+		const a = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		const b = pathOf(openNamespace(input(REVIEWER_B, "review-doc-3955")));
+		assert.notStrictEqual(a, b);
+
+		// Interleave the way two live gates do: A opens and writes, B opens and writes over the
+		// same LEAF name, then A re-derives and reads.
+		writeFileSync(join(a, "verdict-doc.md"), "PR 3951 · PASS @ 167a195c");
+		writeFileSync(join(b, "verdict-doc.md"), "PR 3955 · PASS @ 05de8f09");
+
+		const rederivedA = resolveOwnFile(input(REVIEWER_A, "review-doc-3951"), "verdict-doc.md");
+		const rederivedB = resolveOwnFile(input(REVIEWER_B, "review-doc-3955"), "verdict-doc.md");
+		assert.isTrue(rederivedA.ok && rederivedB.ok);
+		if (rederivedA.ok)
+			assert.strictEqual(readFileSync(rederivedA.value, "utf8"), "PR 3951 · PASS @ 167a195c");
+		if (rederivedB.ok)
+			assert.strictEqual(readFileSync(rederivedB.value, "utf8"), "PR 3955 · PASS @ 05de8f09");
+	});
+
+	it("neither reviewer can even name the other's namespace", () => {
+		openNamespace(input(REVIEWER_A, "review-doc-3951"));
+		openNamespace(input(REVIEWER_B, "review-doc-3955"));
+		// B's slug resolved under A's session is a different (unopened) path, so an accidental
+		// cross-wire fails loud rather than handing over the other run's files.
+		const crossed = resolveOwnNamespace(input(REVIEWER_A, "review-doc-3955"));
+		assert.isFalse(crossed.ok);
+		if (!crossed.ok) assert.strictEqual(crossed.error._tag, "NamespaceMissing");
+	});
+});

--- a/packages/pipeline-cli/src/tools/scratchpad/store.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/store.unit.test.ts
@@ -45,11 +45,21 @@ describe("openNamespace", () => {
 		assert.isTrue(resolveOwnNamespace(input(REVIEWER_A, "review-doc-3951")).ok);
 	});
 
-	it("clears leftovers from an earlier run of the same slug in the same session", () => {
+	it("clears leftovers nobody claimed — an unstamped directory is a dead run's residue", () => {
+		const stale = join(root, "kampus-run", REVIEWER_A.session, "review-doc-3951");
+		mkdirSync(stale, {recursive: true});
+		writeFileSync(join(stale, "verdict-doc.md"), "stale body from a run that never stamped");
 		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
-		writeFileSync(join(path, "verdict-doc.md"), "stale round-1 body");
-		openNamespace(input(REVIEWER_A, "review-doc-3951"));
 		assert.isFalse(existsSync(join(path, "verdict-doc.md")));
+	});
+
+	it("re-opening this run's OWN namespace returns it as it stands, destroying nothing", () => {
+		// The claim is exclusive, so the loser of a race lands here — and a peer this run
+		// cannot tell apart from itself must not be able to delete the holder's state.
+		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		writeFileSync(join(path, "verdict-doc.md"), "PASS @ 167a195c");
+		assert.isTrue(openNamespace(input(REVIEWER_A, "review-doc-3951")).ok);
+		assert.strictEqual(readFileSync(join(path, "verdict-doc.md"), "utf8"), "PASS @ 167a195c");
 	});
 
 	it("refuses a namespace another run owns instead of clobbering it", () => {
@@ -59,6 +69,23 @@ describe("openNamespace", () => {
 		const second = openNamespace(input({...REVIEWER_A, pid: "9999"}, "review-doc-3951"));
 		assert.isFalse(second.ok);
 		if (!second.ok) assert.strictEqual(second.error._tag, "ForeignNamespace");
+	});
+
+	it("leaves the owner's namespace untouched when it refuses", () => {
+		const path = pathOf(openNamespace(input(REVIEWER_A, "review-doc-3951")));
+		writeFileSync(join(path, "verdict-doc.md"), "PASS @ 167a195c");
+		openNamespace(input({...REVIEWER_A, pid: "9999"}, "review-doc-3951"));
+		assert.strictEqual(readFileSync(join(path, "verdict-doc.md"), "utf8"), "PASS @ 167a195c");
+		assert.isTrue(resolveOwnNamespace(input(REVIEWER_A, "review-doc-3951")).ok);
+	});
+
+	it("refuses a claim whose stamp cannot be read rather than assuming it is ours", () => {
+		const claimed = join(root, "kampus-run", REVIEWER_A.session, "review-doc-3951");
+		mkdirSync(claimed, {recursive: true});
+		writeFileSync(join(claimed, ".kampus-run-owner"), "not json");
+		const resolved = openNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "NamespaceUnavailable");
 	});
 
 	it("refuses with MissingSessionId rather than allocating a shared path", () => {


### PR DESCRIPTION
Two crew agents that run at the same time have been sharing one scratchpad directory, so both write files with the same plain names. The second run quietly overwrites the first, and the first then reads the *other run's* content back without any error — which is how one reviewer diffed the wrong PR, and how one reviewer's verdict body ended up written over another's. This PR replaces the "please name your files carefully" convention with a tool that hands each run its own directory and refuses, loudly, when two runs would ever land in the same one.

## What changed

**`pipeline-cli scratchpad <open|path|file>`** — one tested allocator every agent calls instead of hand-rolling a path:

- `open --slug <skill>-<work-item>` claims the run's namespace and stamps it as ours.
- `path --slug <same-slug>` re-derives it in a later Bash call (where shell state is already gone), asserting it exists **and** is still ours — it never creates one, because answering "you never opened it" with a fresh empty directory turns a read of your own state into a silent read of nothing.
- `file --slug … --name verdict.md` names a leaf inside it, so leaf names stay plain and uniqueness lives in the directory.

The path is `<tmpdir>/kampus-run/<session-id>/<slug>` — per-run **and** deterministically re-derivable, the two properties §SP requires (a bare `mktemp -d` gives the first and destroys the second).

**The owner stamp is a claim, not a check.** `open` creates it with a single exclusive create (`writeFileSync(…, {flag: "wx"})` = `O_CREAT | O_EXCL`), the shape Node's own `fs` docs prescribe against the check-then-act they name as a race. So when two runs sharing a session id *and* a slug open at the same instant, the kernel picks one winner and the loser's `EEXIST` **is** the refusal — surfaced as `ForeignNamespace`, exit `4`, nothing overwritten. The first run's `path` likewise refuses to hand back a namespace another run took over.

The one pair the stamp cannot separate is two runs whose identity is byte-identical — same session id *and* same `$CLAUDE_PID`, or neither carrying one — since nothing in the environment tells them apart. There the loser **re-enters** the namespace rather than being refused, and a re-entry is never destructive: `open` returns a namespace it re-enters exactly as it stands. §SP states this boundary rather than claiming more than the code delivers.

Every failure is a typed refusal with its own exit code (`2` no session id, `3` bad slug/leaf name, `4` the namespace belongs to another run, `5` this run never opened it, `6` the filesystem refused) and a reason on stderr. **There is no fallback to a shared or default location** — a fallback is exactly what reintroduces the collision invisibly. `--session` is documented TEST-ONLY: a fixed literal re-keys every caller onto one namespace.

**Contract + consumers, same commit:**

- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §SP names the verb as the allocator, keeps the inline one-liner as the no-CLI fallback (ADR 0062), and adds the clause the recurrence turned on: **the harness-provided scratchpad directory is not a per-run namespace** — it is session-scoped and shared across a session's concurrent runs.
- The eight crew-agent definitions (`reviewer`, `coder`, `shipper`, `triager`, `planner`, `reporter`, `adr`, `canon`) cite the verb instead of re-deriving the path, so the fix covers the convention across reviewer/coder/diagnostic surfaces rather than one observed file.

## Acceptance criteria

- **No two concurrent runs share a path under a fixed name** — the namespace is keyed on the run, and a same-key second run is refused by an exclusive create rather than clobbering.
- **Covers the convention, not one file** — §SP plus all eight agent definitions.
- **Prefer in-process over a file** — §SP rule 1 is unchanged and still first; the verb is only for state that genuinely must cross a Bash call.
- **The previously-clobbering scenario no longer reads back another run's content** — `packages/pipeline-cli/src/tools/scratchpad/store.unit.test.ts` reproduces the shared-directory clobber, then runs the same interleaving through per-run namespaces and asserts each reviewer reads back its own verdict body.
- **The concurrent-open race is held by a test** — `packages/pipeline-cli/src/tools/scratchpad/command.concurrency.test.ts` launches eight real `scratchpad open` processes at once on one session id and one slug and asserts exactly one exits `0` while every other exits `4`. A same-process test cannot show this: `openNamespace` is synchronous and never interleaves with itself.

The full `pipeline-cli` suite (2106 tests) is green.

Not in scope: the systemic fixed-name scratch-write lint lives in #3735, and the head-binding guard that caught this instance (#3801) stays as defense-in-depth — it is not the fix.

Fixes #3718
