### PR TITLE
feat(pipeline): mandate an ADR contradiction sweep, independent of the ADR's citations (#3980)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -5,7 +5,7 @@ description: Record an architecture decision in `.decisions/`. Trigger when the 
 
 # adr
 
-Capture one decision per file in `.decisions/`. There is no committed index (ADR [0126](https://github.com/kamp-us/phoenix/blob/main/.decisions/0126-ambient-adr-discovery.md)) and **no `SessionStart` ADR-map hook** (ADR [0129](https://github.com/kamp-us/phoenix/blob/main/.decisions/0129-adr-discovery-is-the-claude-md-contract.md), dropping 0126's hook as needless indirection) — discovery is the CLAUDE.md contract alone, the same in every context: `ls .decisions/` + each file's frontmatter (`id`/`title`/`status`), with `pipeline-cli decisions-index compact` rendering the full `id · title · status` map **on demand** (never auto-injected). An ADR PR is **purely additive**: it adds one `.decisions/NNNN-slug.md` file (plus the superseded file's status edit when superseding), and never touches or regenerates an index.
+Capture one decision per file in `.decisions/`. There is no committed index (ADR [0126](https://github.com/kamp-us/phoenix/blob/main/.decisions/0126-ambient-adr-discovery.md)) and **no `SessionStart` ADR-map hook** (ADR [0129](https://github.com/kamp-us/phoenix/blob/main/.decisions/0129-adr-discovery-is-the-claude-md-contract.md), dropping 0126's hook as needless indirection) — discovery is the CLAUDE.md contract alone, the same in every context: `ls .decisions/` + each file's frontmatter (`id`/`title`/`status`), with `pipeline-cli decisions-index compact` rendering the full `id · title · status` map **on demand** (never auto-injected). An ADR PR is **purely additive**: it adds one `.decisions/NNNN-slug.md` file (plus the status-line edit on a file it supersedes or amends-in-part), and never touches or regenerates an index.
 
 ## Steps
 
@@ -25,7 +25,8 @@ Capture one decision per file in `.decisions/`. There is no committed index (ADR
    This is **detect-and-serialize, not a CAS** — it *narrows* the collision window, it does not eliminate it. Two authors who enumerate in the same window before either PR is visible both pick the same number; that residual is **backstopped by the CI duplicate-`id` check** (the `decisions-index validate` PR job — see [ADR number lock](#adr-number-lock)), which reddens the second-to-merge PR for a manual renumber. The lock turns the *common* "branch after another's ADR PR is open" case from collide-and-renumber into don't-collide; the CI check remains the safety net for the rare residual.
 2. Pick a kebab-case slug from the title (≤ 5 words).
 3. Write `.decisions/NNNN-slug.md` using the template below. Directly beneath the `# NNNN — <Title>` heading, write the **required** plain one-line `**What this decides:** …` summary (see the [Rules](#rules)) — the front-matter `title`/`status`/`date` are the **source of truth** for the on-demand `compact` map row (ADR 0126: the compact map derives `id · title · status` straight from frontmatter; rendered on demand, never injected — ADR 0129), so write the exact display text you want there (inline markdown and all). Keep `title` to **one dense line** — it is what the rendered `compact` map shows for this ADR.
-4. **The ADR PR is purely additive — add only `.decisions/NNNN-slug.md`** (plus the superseded file's status edit when superseding). There is no committed `.decisions/index.md` to regenerate or commit (ADR [0126](https://github.com/kamp-us/phoenix/blob/main/.decisions/0126-ambient-adr-discovery.md)); discovery is the CLAUDE.md contract — `ls .decisions/` + frontmatter, with `compact` on demand (ADR [0129](https://github.com/kamp-us/phoenix/blob/main/.decisions/0129-adr-discovery-is-the-claude-md-contract.md)) — so nothing else changes. Because ADR PRs carry no shared generated file, two concurrent ADR PRs can't collide — adding an ADR is conflict-free. To **render** the compact map locally you may run the CLI, but there is no index file to stage:
+4. **Sweep the live `accepted` ADRs for a same-question conflict, and cite or amend every real hit (required).** A new ADR that decides the opposite of an unsuperseded `accepted` ADR leaves every future agent two authoritative, incompatible rules with no signal a conflict exists. Run the sweep defined in [§Contradiction sweep](#contradiction-sweep--never-decide-against-a-live-adr-silently) **before the PR goes up** — it is the authoring-side mirror of `review-doc`'s Step 4a, and the cheapest place to resolve a hit is here, not in a repair round.
+5. **The ADR PR is purely additive — add only `.decisions/NNNN-slug.md`** (plus the status-line edit on a file this ADR supersedes or amends-in-part). There is no committed `.decisions/index.md` to regenerate or commit (ADR [0126](https://github.com/kamp-us/phoenix/blob/main/.decisions/0126-ambient-adr-discovery.md)); discovery is the CLAUDE.md contract — `ls .decisions/` + frontmatter, with `compact` on demand (ADR [0129](https://github.com/kamp-us/phoenix/blob/main/.decisions/0129-adr-discovery-is-the-claude-md-contract.md)) — so nothing else changes. Because ADR PRs carry no shared generated file, two concurrent ADR PRs can't collide — adding an ADR is conflict-free. To **render** the compact map locally you may run the CLI, but there is no index file to stage:
    ```bash
    # OPTIONAL local render of the on-demand compact map — nothing to `git add` (no committed index).
    # The `bin/pipeline-cli` shim resolves the bin (in-repo, else installed, else pinned dlx reading
@@ -33,8 +34,54 @@ Capture one decision per file in `.decisions/`. There is no committed index (ADR
    "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" decisions-index compact
    ```
    The published CLI operates on the local `.decisions/` filesystem (no GitHub target), so there is no `$REPO`/`$CLAUDE_PIPELINE_REPO` resolution here — it is purely the in-repo-vs-published invocation swap.
-5. **Record the ADR's vocabulary impact (required — a named term or an explicit "none").** An ADR is a primary *coining site*: it is where a concept most often enters the repo vocabulary — a new term, or a redefinition of an existing one (ADR 0126's "ambient discovery" was coined here and drifted silently). So before you tell the user the path, run the point-of-coining glossary catch defined in [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source). This is a **coining-time authoring hook, not the `review-code` gate** — it lives in this skill (prong (c) of ADR [0128](https://github.com/kamp-us/phoenix/blob/main/.decisions/0128-glossary-concept-trigger-off-the-gate.md), Fixes #1737); it never touches `review-code`'s fail-closed Step 3c. **You must land on one of two explicit outcomes — a named term routed to the glossary, or a recorded "no vocabulary impact"; silently skipping it is not an option.**
-6. Tell the user the path. Do not summarize the body — they just stated it.
+6. **Record the ADR's vocabulary impact (required — a named term or an explicit "none").** An ADR is a primary *coining site*: it is where a concept most often enters the repo vocabulary — a new term, or a redefinition of an existing one (ADR 0126's "ambient discovery" was coined here and drifted silently). So before you tell the user the path, run the point-of-coining glossary catch defined in [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source). This is a **coining-time authoring hook, not the `review-code` gate** — it lives in this skill (prong (c) of ADR [0128](https://github.com/kamp-us/phoenix/blob/main/.decisions/0128-glossary-concept-trigger-off-the-gate.md), Fixes #1737); it never touches `review-code`'s fail-closed Step 3c. **You must land on one of two explicit outcomes — a named term routed to the glossary, or a recorded "no vocabulary impact"; silently skipping it is not an option.**
+7. Tell the user the path. Do not summarize the body — they just stated it.
+
+## Contradiction sweep — never decide against a live ADR silently
+
+Two live `accepted` ADRs that decide opposite things on one question are worse than an open
+question: each reads as authoritative, neither hints the other exists, and which one an agent obeys
+depends on which file it happened to open. The house convention for *resolving* such a clash has
+existed for a long time; what was missing was any obligation to *look* (#3980). This section is it,
+and `review-doc`'s Step 4a is its independent mirror on the gate side.
+
+**1. Enumerate what this ADR decides — as questions, not as a summary.** From your `title`, your
+`**What this decides:**` line and your `## Decision`, write down each question the ADR settles:
+*"may an open issue exist without a milestone?"*, *"what happens to work that serves no active
+arc?"*. You cannot sweep for a question you cannot phrase.
+
+**2. Sweep the live `accepted` ADRs for those same questions.** The mechanical shortlist ranks the
+live-accepted ADRs whose decision domain yours touches and which you do **not** cite:
+
+```bash
+# The shim resolves the bin (in-repo, else installed, else pinned dlx reading hooks/pin.sh; #3653).
+# Exit 0 = nothing left to open. Non-zero = a shortlist to clear, or an INDETERMINATE run.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
+  --new .decisions/NNNN-slug.md
+```
+
+`pipeline-cli decisions-index compact` is the manual fallback: scan the `id · title · status` map
+for ADRs whose title rules on one of your questions, and open those.
+
+**3. Cite or amend every real hit — before the PR goes up.** Open each shortlist entry and decide
+whether it rules on a question you re-decide. Most are merely adjacent; for the ones that genuinely
+overlap:
+
+- **You replace it outright** → supersede it (the existing convention in the [Rules](#rules)).
+- **You change part of it and the rest still stands** → the amendment shape: set `status:
+  amended-in-part by [NNNN](NNNN-your-slug.md)` on the **older** ADR's **status line only**, leave
+  its body untouched (an accepted ADR's decision text is immutable), and name the relationship in
+  your `## Context`. Precedents: `0023`, `0028`, `0031`, `0035`.
+- **You only *refine* mechanics of your own prior ADR, the ruling standing** → the dated
+  `## Amendments` note (the [Rules](#rules)), not a status change.
+
+**The tool is a shortlist, not an oracle — do not let it stand in for move 3.** It detects lexical
+and tag adjacency on decision-bearing text minus your own citations. It does **not** detect a
+semantic contradiction: an ADR that disagrees with yours about what a *label means*, sharing no
+distinctive vocabulary, will not appear. A `no-overlap` result means "nothing mechanically adjacent
+was left to open," never "no contradiction," and an `indeterminate` result carries no information at
+all — read by hand in both cases. A corpus the tool cannot read fails closed rather than reporting a
+clean sweep (ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)).
 
 ## Vocabulary impact — catch a coined or redefined term at its source
 
@@ -43,7 +90,7 @@ The glossary ([`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/mai
 This is a **required, not-silently-skippable** authoring step. When you write the ADR, ask: *does this decision coin a new term, or redefine an existing one?* You must record **exactly one** of two outcomes — you cannot leave it blank:
 
 - **Term(s) coined/redefined → feed the glossary.** Name each term (and, for a redefinition, what changed). Then route it to `.glossary/TERMS.md`: if the term's canonical definition is short and unambiguous, add/update its row directly in the same ADR PR; if it needs the fuller treatment (a "not …" disambiguation, cross-links), **invoke `/glossary`** (`claude-plugins/kampus-pipeline/skills/glossary/SKILL.md`) or file a `report` so the glossary skill picks it up. Either way the term is surfaced, never left implicit in the ADR prose.
-- **No vocabulary impact → record it explicitly.** If the ADR coins/redefines nothing (it re-decides mechanics, sequencing, or policy over already-named concepts), state that plainly — record it in the ADR's terminal `## Records` section (see the [Rules](#rules)) and tell the user "no vocabulary impact" as part of Step 6's report. The explicit "none" is the recorded outcome; it is what distinguishes *"considered and there is none"* from *"forgot to check."*
+- **No vocabulary impact → record it explicitly.** If the ADR coins/redefines nothing (it re-decides mechanics, sequencing, or policy over already-named concepts), state that plainly — record it in the ADR's terminal `## Records` section (see the [Rules](#rules)) and tell the user "no vocabulary impact" as part of Step 7's report. The explicit "none" is the recorded outcome; it is what distinguishes *"considered and there is none"* from *"forgot to check."*
 
 This hook is **off the fail-closed gate by construction**: it is authoring-time judgment in this skill, it blocks no PR, and it does not (and must not) alter `review-code`'s Step 3c. It is the routed-term half of ADR 0128; the un-routed code-PR class is the sibling drift-sweep backstop, not this skill's job.
 
@@ -85,7 +132,7 @@ tags: [<area>, <area>]
 
 ## Records
      Merge-time bookkeeping, quarantined out of the decision body: backlog reconciliation
-     (`Closes/Reshapes #N`), blocks-cleared, and the Step-5 vocabulary-impact outcome (the
+     (`Closes/Reshapes #N`), blocks-cleared, and the Step-6 vocabulary-impact outcome (the
      term routed to .glossary/TERMS.md, or an explicit "no vocabulary impact").
 
 ## Amendments
@@ -110,7 +157,7 @@ On a **PR**, `.github/workflows/decisions-index.yml` runs `decisions-index valid
 - **Every new ADR opens with a plain one-line `**What this decides:** …` summary, directly beneath the `# NNNN — <Title>` heading and above `## Context`.** Write it in plain human language — what the decision *is*, so the founder (who ratifies ADRs — ADR [0078](https://github.com/kamp-us/phoenix/blob/main/.decisions/0078-product-driven-decisions-by-default.md)) can parse it cold, without decoding the dense agent-oriented prose below it. It is a reader-facing summary for a non-author, **not** a restatement of the one-line `title` (the `title` is the dense `compact`-map row; this is the human gloss). This line is required on every new ADR — never omit it.
 - **Title discipline — `title` is one decision-carrying clause (≤ ~12 words); the `# NNNN — <Title>` H1 repeats it verbatim.** The frontmatter `title` *is* the `compact`-map row (per the [Discovery](#discovery--the-claudemd-contract-no-committed-index) note that it renders verbatim), so it must **carry the decision, not name the topic** — `Every gate fails closed on zero scope` over `Gate scope handling` — and stay to a single dense clause. The H1 then matches it character-for-character; the human gloss lives in the `**What this decides:**` line above, not in a second, looser title. (0092/0107/0191 already do this.)
 - **`## Decision` opens with one bolded declarative sentence.** State the decision in a single bolded line *before* the mechanics (0092's `**Every gate fails closed…**`, 0107's `**instances + standing…**`) so a reader gets the ruling in one line. When — and only when — the ADR constrains future work, follow the reasoning with an **austere** list (terse, one line per item) under a bolded `**Binding constraints.**` / `**Banned.**` label. This is authoring *guidance*, not a fail-closed template section: an ADR that constrains nothing carries no such list, and nothing reds a PR for omitting it.
-- **Merge-time bookkeeping goes in a terminal `## Records` section, out of the decision body.** Backlog reconciliation (`Closes/Reshapes #N`), blocks-cleared, and the Step-5 vocabulary-impact outcome are housekeeping, not the decision — quarantine them in a terminal `## Records` so `## Decision`/`## Consequences` read as the decision alone. Omit the section when there's nothing to record.
+- **Merge-time bookkeeping goes in a terminal `## Records` section, out of the decision body.** Backlog reconciliation (`Closes/Reshapes #N`), blocks-cleared, and the Step-6 vocabulary-impact outcome are housekeeping, not the decision — quarantine them in a terminal `## Records` so `## Decision`/`## Consequences` read as the decision alone. Omit the section when there's nothing to record.
 - **Post-merge currency has one shape: a dated `## Amendments` note.** When a later change refines an *accepted* ADR (the decision itself still stands — this complements "never edit the decision text, supersede instead" above; an amendment refines mechanics/spelling, not the ruling), append a dated forward note — `- **#NNNN — <what> (YYYY-MM-DD).** …` — to a terminal `## Amendments` section (0107's form). **Never** prepend an ad-hoc `> **Update:** …` blockquote at the top of the file (0027's retired form); the top-of-file update blockquote is banned.
 - **Linking to another ADR — resolve its filename by stable number from disk, never guess the slug from the target's title.** A target ADR's slug is **not derivable from its title** (0048 is `ship-it-merge-actor`, not `single-merge-authority`; 0053 is `control-plane-boundary`, not `control-plane-human-merge`; 0075 is `issueless-doc-pr-merge-seam`, not `conversation-authored-adr-exception`). The stable number `NNNN` is the only reliable key, so **read the real filename off disk** and use it verbatim — never re-apply the Step-2 title→slug heuristic to a *different* ADR you're linking. This is the recurring `review-doc` "links resolve" FAIL (#1777); `doc-links.yml` is the CI backstop, this is the authoring-time fix. Resolve every `[NNNN](NNNN-slug.md)` link's slug this way:
   ```bash
@@ -119,6 +166,7 @@ On a **PR**, `.github/workflows/decisions-index.yml` runs `decisions-index valid
 - `status`: `accepted | proposed | superseded | deprecated` (or a richer linked phrase like `superseded by [NNNN](NNNN-slug.md)`). Default `accepted` unless the user says otherwise. Whatever you put in `status:` is what the on-demand `compact` map shows.
 - Superseding an older ADR: in the new file write `Supersedes [NNNN](NNNN-slug.md).` in `## Context`, and edit the old file's front-matter `status: superseded by [NNNN](NNNN-slug.md)` plus a body line `Superseded by [NNNN](NNNN-slug.md).` The on-demand `compact` map reflects both from frontmatter — there is no index to touch. Resolve every `NNNN-slug.md` here off disk (`ls .decisions/NNNN-*.md`) per the cross-link rule above — the guessed slug is exactly where these supersede links go dead.
 - Date is today (`date` command if unsure).
-- Never edit an accepted ADR's decision text after the fact — supersede instead.
-- **Always resolve the vocabulary-impact outcome** (Step 5 / [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source)): every ADR ends with *either* a term surfaced to `.glossary/TERMS.md` *or* an explicit recorded "no vocabulary impact." Never leave it unstated — the explicit "none" is a real outcome, not a skip.
-- Your PR adds only the ADR file (plus the superseded file's status edit); there is no committed index. Optional local render of the on-demand compact map (nothing to stage): `"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" decisions-index compact` (the shim resolves the bin — in-repo, else installed, else pinned dlx reading the one pin in hooks/pin.sh; #3653).
+- Never edit an accepted ADR's decision text after the fact — supersede instead, or amend in part (below).
+- **Amending in part: the status line only.** When your ADR changes part of a live `accepted` ADR while the rest still stands, set `status: amended-in-part by [NNNN](NNNN-slug.md)` on that older file and change **nothing else in it** — its decision text is immutable. Name the relationship in your own `## Context`. Precedents: 0023, 0028, 0031, 0035. Finding the ADRs that need this is the [§Contradiction sweep](#contradiction-sweep--never-decide-against-a-live-adr-silently), which is required on every ADR.
+- **Always resolve the vocabulary-impact outcome** (Step 6 / [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source)): every ADR ends with *either* a term surfaced to `.glossary/TERMS.md` *or* an explicit recorded "no vocabulary impact." Never leave it unstated — the explicit "none" is a real outcome, not a skip.
+- Your PR adds only the ADR file (plus the status-line edit on a file it supersedes or amends-in-part); there is no committed index. Optional local render of the on-demand compact map (nothing to stage): `"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" decisions-index compact` (the shim resolves the bin — in-repo, else installed, else pinned dlx reading the one pin in hooks/pin.sh; #3653).

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -568,6 +568,91 @@ Build the hygiene findings into the same evidence shape as the AC table:
 
 ---
 
+## Step 4a — The ADR contradiction sweep (ADR diffs only, and independent of the ADR's citations)
+
+**Fires only when the diff adds or edits a `.decisions/NNNN-*.md` file.** Any other doc diff skips
+this step entirely — the same first-class-absence shape as Step 4b.
+
+Every other check on this page follows a thread the document itself hands you: hygiene check 5
+fires only **when the doc claims** to replace a prior decision, and Step 4b's dimensions validate
+the doc's **own** citations. That is exactly the path that misses this defect. An ADR that never
+names the ADR it contradicts gives you no thread to pull, so following its citations passes it —
+which is what happened on PR #3955, where an earlier pass explicitly checked cross-references,
+found the one ADR the document cited, and PASSed an ADR that contradicted a different, uncited,
+same-day-accepted one (#3980).
+
+So this step is **citation-independent by construction**. Never derive its candidate set from the
+new ADR's reference list.
+
+**1. Enumerate what the new ADR decides — as questions it answers, not as a summary.** Read its
+`title`, its `**What this decides:**` line, its `## Decision` (including any `Binding constraints`
+/ `Banned` list) and write down each question it settles: *"may an open issue exist without a
+milestone?"*, *"what happens to work that serves no active arc?"*. A question you cannot phrase is
+a question you cannot sweep for.
+
+**2. Sweep the live `accepted` ADRs for those questions, without consulting the new ADR's
+citations.** The mechanical shortlist is one command — it ranks the live-accepted ADRs whose
+decision domain the new one touches **and which it does not cite**:
+
+```bash
+# Subject = the ADR file at the PR head (Step 2 already materialized it). Exit 0 means the
+# mechanical sweep found nothing left to open; non-zero means there is a shortlist to clear, or
+# that the sweep was INDETERMINATE and proved nothing.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
+  --new "$PR_WT/.decisions/NNNN-slug.md"
+```
+
+`pipeline-cli decisions-index compact` (the one-line `id · title · status` map) is the manual
+fallback when the shortlist is unavailable: scan it for ADRs whose title rules on one of your
+step-1 questions, and open those.
+
+**3. Open every shortlist entry and judge it.** For each: does this ADR rule on a question the new
+one re-decides? A shortlist entry is a *candidate*, never a finding — most are simply adjacent.
+Record the ones that genuinely overlap.
+
+**The verdict rule.** An **uncited, unamended** same-question conflict with a live `accepted` ADR
+(status `accepted` or `amended-in-part by …` — an amended ADR still rules over everything the
+amendment did not touch) is a **FAIL**. Two live ADRs that decide opposite things on one question
+are worse than an open question: each reads as authoritative, and which one an agent obeys depends
+on which file it happened to open.
+
+**The required resolution shape — name it in the FAIL, do not invent a new one.** The house remedy
+already exists: set `status: amended-in-part by [NNNN]` on the **older** ADR's **status line only**
+(its body stays untouched — an accepted ADR's decision text is immutable), and have the new ADR
+name the relationship in its `## Context`. Precedent ADRs carrying that form: `0023`, `0028`,
+`0031`, `0035`. Where the new ADR replaces the old outright, the existing supersession convention
+(hygiene check 5) applies instead.
+
+**What the tool does and does not discharge — read this before you lean on its exit code.** The
+shortlist detects **lexical and tag adjacency on decision-bearing text, minus the subject's own
+citations**. It does **not** detect a semantic contradiction: two ADRs that disagree about what a
+label *means* while sharing no distinctive vocabulary never appear on it — the shape that bit
+#3955's *repair*, whose bounded-parking fix then collided with a third ADR defining that same
+label's exit condition, and was again caught only by reading. So:
+
+- A **`no-overlap`** result (exit 0) means "nothing mechanically adjacent was left to open." It is
+  **not** evidence of no contradiction, and it does **not** discharge moves 1 and 3.
+- An **`indeterminate`** result is a distinct outcome from `no-overlap` and carries **no**
+  information — the sweep could not key on anything, or the corpus was too small for rarity. Treat
+  it as "unswept" and do the read by hand.
+- A **failure to read the ADR corpus** (unreadable file, malformed front-matter, zero live-accepted
+  ADRs in scope) fails closed and reds. Never record a clean sweep over a corpus you could not read
+  (ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)).
+
+Record the outcome in the same evidence shape as the hygiene findings, naming the swept set so the
+verdict says what was covered:
+
+```
+- [PASS] ADR contradiction sweep — 3 questions enumerated; 171 uncited live-accepted ADRs swept;
+         shortlist 0072/0074/0123 opened, none rules on the same question (semantic sweep by hand)
+- [FAIL] ADR contradiction sweep — 0208 decides "every open issue is milestone-homed or killed",
+         contradicting live-accepted 0072 §4 (freeze-by-absence) / §5 (milestone is optional);
+         0208 cites 0072 nowhere and 0072 carries no forward pointer. Remedy: `status:
+         amended-in-part by [0208]` on 0072's status line, plus 0208 naming the relationship.
+```
+
+---
+
 ## Step 4b — Specialist fan-out + route-don't-grade (ADR 0079)
 
 The AC checklist (Step 3) and the hygiene checklist (Step 4) catch what the issue *named*
@@ -628,7 +713,9 @@ changes).
 ## Step 5 — Land the verdict
 
 **Run the specialist fan-out + route step (Step 4b) before composing the verdict** so any
-in-scope appended AC already shows as a fresh `[FAIL]` row in the table below.
+in-scope appended AC already shows as a fresh `[FAIL]` row in the table below. On an ADR diff the
+Step-4a contradiction sweep is part of the same conjunctive verdict — its FAIL fails the gate like
+any hygiene FAIL.
 
 The overall verdict is **conjunctive across both lists**: every acceptance criterion AND
 every hygiene check must PASS. One miss anywhere → FAIL. **For the docs-only no-link PR

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -595,11 +595,13 @@ citations.** The mechanical shortlist is one command — it ranks the live-accep
 decision domain the new one touches **and which it does not cite**:
 
 ```bash
-# Subject = the ADR file at the PR head (Step 2 already materialized it). Exit 0 means the
-# mechanical sweep found nothing left to open; non-zero means there is a shortlist to clear, or
-# that the sweep was INDETERMINATE and proved nothing.
+# Subject = the ADR file at the PR head. The sweep needs a real file on disk, so this is one of
+# the rare doc checks that wants Step 2's `--worktree` materialization: run it with `--worktree`
+# and `. "$WT_FILE"` to get $REVIEW_WT. Exit 0 means the mechanical sweep found nothing left to
+# open; non-zero means there is a shortlist to clear, or that the sweep was INDETERMINATE and
+# proved nothing.
 "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
-  --new "$PR_WT/.decisions/NNNN-slug.md"
+  --new "$REVIEW_WT/.decisions/NNNN-slug.md"
 ```
 
 `pipeline-cli decisions-index compact` (the one-line `id · title · status` map) is the manual

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -595,14 +595,28 @@ citations.** The mechanical shortlist is one command — it ranks the live-accep
 decision domain the new one touches **and which it does not cite**:
 
 ```bash
-# Subject = the ADR file at the PR head. The sweep needs a real file on disk, so this is one of
-# the rare doc checks that wants Step 2's `--worktree` materialization: run it with `--worktree`
-# and `. "$WT_FILE"` to get $REVIEW_WT. Exit 0 means the mechanical sweep found nothing left to
-# open; non-zero means there is a shortlist to clear, or that the sweep was INDETERMINATE and
-# proved nothing.
+# Runs on Step 2's DEFAULT ref-only path — no `--worktree`, no materialized tree. `--new` takes
+# "a path to the ADR file" (any real file, anywhere), so a `git show` off $PR_REF is all the
+# "real file on disk" the sweep needs. $PR_REF is bound by Step 2's `review-head materialize`;
+# re-run that in THIS call if it was bound in an earlier one (the between-call shell reset).
+# CORPUS: `--dir` is deliberately unset, so the sweep reads the repo-root `.decisions/` of the
+# checkout you are running in — the BASE (pre-PR) corpus. That is the set you want: it carries
+# every live ADR the new one could contradict, and it excludes the new ADR itself, so the subject
+# can never rank against its own file. Only the subject is read from the PR head.
+# Exit 0 means the mechanical sweep found nothing left to open; non-zero means there is a
+# shortlist to clear, or that the sweep was INDETERMINATE and proved nothing.
+SUBJECT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/review-doc-adr-subject.XXXXXX")"   # §SP rule-4 carve-out: allocated AND consumed in this one call
+git show "$PR_REF:.decisions/NNNN-slug.md" > "$SUBJECT_DIR/NNNN-slug.md"
 "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
-  --new "$REVIEW_WT/.decisions/NNNN-slug.md"
+  --new "$SUBJECT_DIR/NNNN-slug.md"
+SWEEP=$?; rm -rf "$SUBJECT_DIR"   # keep the sweep's status: it, not the cleanup, is the outcome
 ```
+
+Two things worth being explicit about, because a reader will otherwise assume them wrong. **The
+swept corpus is the base `.decisions/` of the checkout you run in**, not a PR-head tree — the new
+ADR is the *only* thing read from the head. And that is why this step needs **no** materialized
+worktree: it costs one `git show`, so Step 2's `--worktree` mode stays what Step 2 says it is —
+rare for a doc PR — instead of becoming routine for the most common doc-PR shape in this repo.
 
 `pipeline-cli decisions-index compact` (the one-line `id · title · status` map) is the manual
 fallback when the shortlist is unavailable: scan it for ADRs whose title rules on one of your

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -13,6 +13,7 @@
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
 import {adoptionLintCommand} from "./tools/adoption-lint/command.ts";
+import {adrSweepCommand} from "./tools/adr-sweep/command.ts";
 import {campaignCommand} from "./tools/campaign/command.ts";
 import {catalogGuardCommand} from "./tools/catalog-guard/command.ts";
 import {changeDetectGuardCommand} from "./tools/change-detect-guard/command.ts";
@@ -222,4 +223,10 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// triage with neither an arc/campaign milestone nor one of the two standing-lane labels,
 	// so floaters can't regrow at the seam. Fail-closed on zero scope (ADR 0092).
 	homingGuardCommand,
+	// #3980 — the mechanical half of the ADR contradiction sweep: rank the live-accepted ADRs a
+	// new ADR touches the decision domain of but never cites, so a same-question conflict with an
+	// unsuperseded ADR (0208-vs-0072, 0210-vs-0202) is a list to clear rather than a memory test.
+	// Fail-closed on an unreadable corpus / zero scope (ADR 0092); `indeterminate` is a distinct
+	// outcome from `no-overlap` by construction.
+	adrSweepCommand,
 ];

--- a/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.ts
+++ b/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.ts
@@ -1,0 +1,559 @@
+/**
+ * `adr-sweep` core — pure, IO-free derivation of a **contradiction shortlist** for a new
+ * ADR: the live `accepted` ADRs that decide in the same domain and that the new ADR does
+ * **not** cite. It is the mechanical input to the ADR contradiction sweep the `adr` and
+ * `review-doc` skills mandate (#3980); the judgement — is this shortlist entry an actual
+ * contradiction? — stays with the author/reviewer.
+ *
+ * **What this detects, stated once and honestly.** The signal is *lexical + tag overlap on
+ * decision-bearing text, minus the new ADR's own citations*. It surfaces the common shape of
+ * the two motivating misses — an ADR that changes a rule in a domain another live ADR already
+ * governs, without naming it (#3896: 0208 vs 0072; #3955: 0210 vs 0202). It does **not**
+ * detect semantic contradiction: two ADRs that disagree about what a label *means* while
+ * sharing no distinctive vocabulary are invisible here (the 0210-vs-0203 relocation). So
+ * `no-overlap` means "nothing mechanically adjacent to open", never "no contradiction" —
+ * `SweepOutcome` keeps those two apart by construction, and so must every consumer.
+ */
+
+import {frontmatterBlock, parseFrontmatter} from "../decisions-index/decisions-index.ts";
+
+/** A `.decisions/` file handed to the core: its base name + full text. */
+export interface AdrDoc {
+	/** Base name only, e.g. `0072-milestones-encode-strategic-sequencing.md`. */
+	readonly file: string;
+	/** The file's full UTF-8 contents. */
+	readonly text: string;
+}
+
+/** One parsed ADR, reduced to what the sweep keys on. */
+export interface AdrRecord {
+	readonly id: string;
+	readonly title: string;
+	readonly status: string;
+	readonly file: string;
+	readonly tags: ReadonlyArray<string>;
+	/** Distinctive tokens of the ADR's decision-bearing text (tags are scored separately). */
+	readonly terms: ReadonlySet<string>;
+}
+
+/** A shortlist entry: a live-accepted ADR the new one neither cites nor amends. */
+export interface Candidate {
+	readonly id: string;
+	readonly title: string;
+	readonly status: string;
+	readonly file: string;
+	/** IDF-weighted overlap; higher = more decision-domain adjacency. */
+	readonly score: number;
+	/** The shared terms that earned the score, strongest first. */
+	readonly sharedTerms: ReadonlyArray<string>;
+	readonly sharedTags: ReadonlyArray<string>;
+}
+
+/**
+ * The three sweep outcomes. `indeterminate` is a **distinct** outcome from `no-overlap` on
+ * purpose: collapsing "I swept and found nothing adjacent" into "I could not sweep" is the
+ * exact silent-miss this tool exists to remove.
+ */
+export type SweepOutcome =
+	| {readonly _tag: "shortlist"; readonly candidates: ReadonlyArray<Candidate>}
+	| {readonly _tag: "no-overlap"}
+	| {readonly _tag: "indeterminate"; readonly reason: string};
+
+export interface SweepResult {
+	readonly newId: string;
+	readonly newFile: string;
+	/** ADR files parsed from the corpus (the new ADR excluded). */
+	readonly scanned: number;
+	/** Live-accepted corpus ADRs the new one does not cite — the swept set. */
+	readonly inScope: number;
+	/** ADR ids the new ADR cites (excluded from the swept set). */
+	readonly cited: ReadonlyArray<string>;
+	/** How many distinctive terms the new ADR yielded — 0 forces `indeterminate`. */
+	readonly termCount: number;
+	readonly outcome: SweepOutcome;
+}
+
+/** A corpus the sweep refuses to run over: malformed frontmatter, or nothing to sweep. */
+export class SweepScopeError extends Error {
+	readonly detail: string;
+	constructor(detail: string) {
+		super(detail);
+		this.name = "SweepScopeError";
+		this.detail = detail;
+	}
+}
+
+/**
+ * A shared tag AMPLIFIES vocabulary overlap; it never substitutes for it. Scoring a tag as a
+ * term in its own right let two ADRs that share only `[process, pipeline]` and not one word of
+ * decision vocabulary outrank the real hit — on the 0208 instance that pushed 0072 to rank 3
+ * behind two tag-only matches. Overlap earns the score, tags scale it.
+ */
+const TAG_BONUS = 0.5;
+
+/** Default shortlist depth — enough to hold a real hit, short enough that a reviewer opens all of them. */
+export const DEFAULT_LIMIT = 8;
+
+/**
+ * Below this many live-accepted ADRs, rarity has no corpus to be rare against: every term is
+ * carried by a large fraction of the set, every IDF clamps toward 0, and the sweep finds nothing
+ * — a **degenerate silence**, not a clean sweep. It reports `indeterminate` instead, because
+ * letting that silence read as "no contradiction" is precisely the collapse this tool exists to
+ * prevent.
+ */
+export const MIN_CORPUS_FOR_RARITY = 10;
+
+/** Tokens too short or too common to carry decision-domain signal. */
+const STOPWORDS = new Set([
+	"about",
+	"above",
+	"across",
+	"after",
+	"again",
+	"against",
+	"agent",
+	"agents",
+	"already",
+	"also",
+	"always",
+	"among",
+	"another",
+	"anything",
+	"because",
+	"become",
+	"been",
+	"before",
+	"being",
+	"below",
+	"between",
+	"both",
+	"cannot",
+	"case",
+	"cases",
+	"change",
+	"changes",
+	"come",
+	"comes",
+	"could",
+	"decide",
+	"decides",
+	"decision",
+	"decisions",
+	"does",
+	"doing",
+	"done",
+	"down",
+	"each",
+	"either",
+	"else",
+	"enough",
+	"even",
+	"ever",
+	"every",
+	"exactly",
+	"first",
+	"from",
+	"full",
+	"give",
+	"gives",
+	"goes",
+	"gets",
+	"hard",
+	"have",
+	"here",
+	"however",
+	"instead",
+	"into",
+	"itself",
+	"just",
+	"keep",
+	"keeps",
+	"kind",
+	"know",
+	"less",
+	"like",
+	"long",
+	"made",
+	"make",
+	"makes",
+	"many",
+	"means",
+	"more",
+	"most",
+	"much",
+	"must",
+	"need",
+	"needs",
+	"never",
+	"next",
+	"nothing",
+	"once",
+	"only",
+	"onto",
+	"other",
+	"others",
+	"over",
+	"own",
+	"part",
+	"place",
+	"rather",
+	"real",
+	"reason",
+	"repo",
+	"right",
+	"same",
+	"says",
+	"second",
+	"see",
+	"shape",
+	"should",
+	"significant",
+	"simply",
+	"since",
+	"some",
+	"something",
+	"still",
+	"such",
+	"take",
+	"takes",
+	"than",
+	"that",
+	"their",
+	"them",
+	"then",
+	"there",
+	"these",
+	"they",
+	"thing",
+	"things",
+	"this",
+	"those",
+	"through",
+	"thus",
+	"time",
+	"together",
+	"under",
+	"until",
+	"upon",
+	"used",
+	"uses",
+	"using",
+	"very",
+	"want",
+	"well",
+	"were",
+	"what",
+	"when",
+	"where",
+	"whether",
+	"which",
+	"while",
+	"whole",
+	"whose",
+	"will",
+	"with",
+	"within",
+	"without",
+	"would",
+	"your",
+]);
+
+const MIN_TERM_LENGTH = 4;
+
+/**
+ * Strip markdown link syntax, HTML comments, and code fences to their readable text, so a
+ * `[0072](0072-slug.md)` link contributes its label rather than its slug's tokens (the slug
+ * would otherwise inflate overlap with the very ADR the link already cites).
+ */
+const readableText = (text: string): string =>
+	text
+		.replace(/<!--[\s\S]*?-->/g, " ")
+		.replace(/```[\s\S]*?```/g, " ")
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+/**
+ * Crude de-pluralization so `milestones` and `milestone` are the same term — the shared token
+ * that ties 0208 to 0072. Only a trailing `s` is stripped, and never off an `-ss` word.
+ */
+const singular = (token: string): string =>
+	token.length > MIN_TERM_LENGTH && token.endsWith("s") && !token.endsWith("ss")
+		? token.slice(0, -1)
+		: token;
+
+/** Distinctive tokens of a passage: lowercase, de-pluralized, stopworded, non-numeric. */
+export const termsOf = (text: string): ReadonlySet<string> => {
+	const out = new Set<string>();
+	for (const raw of readableText(text)
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)) {
+		if (raw.length < MIN_TERM_LENGTH) continue;
+		if (/^\d+$/.test(raw)) continue;
+		const token = singular(raw);
+		if (token.length < MIN_TERM_LENGTH || STOPWORDS.has(token)) continue;
+		out.add(token);
+	}
+	return out;
+};
+
+const WHAT_DECIDES = /^[ \t]*\*\*What this decides:\*\*[ \t]*(.+)$/m;
+const DECISION_SECTION = /^##[ \t]+Decision[ \t]*\r?\n([\s\S]*?)(?=\r?\n##[ \t]|$)/m;
+
+/**
+ * The decision-bearing passage of an ADR: its `title`, its `**What this decides:**` gloss, and
+ * its `## Decision` section (which carries the `Binding constraints` / `Banned` lists). Context
+ * and Consequences are deliberately out — they narrate, they do not rule.
+ */
+export const decisionText = (title: string, body: string): string =>
+	[title, body.match(WHAT_DECIDES)?.[1] ?? "", body.match(DECISION_SECTION)?.[1] ?? ""].join("\n");
+
+/** The `tags: [a, b]` frontmatter row, lowercased. Absent or empty reads as no tags. */
+export const parseTags = (text: string): ReadonlyArray<string> => {
+	const block = frontmatterBlock(text);
+	if (block === null) return [];
+	const row = block.match(/^tags:[ \t]*(.*)$/m)?.[1];
+	if (row === undefined) return [];
+	return row
+		.replace(/[[\]]/g, " ")
+		.split(/[,\s]+/)
+		.map((t) => t.trim().toLowerCase())
+		.filter((t) => t.length > 0);
+};
+
+/** Parse one ADR into the record the sweep keys on. Throws `SweepScopeError` on bad frontmatter. */
+export const parseRecord = ({file, text}: AdrDoc): AdrRecord => {
+	const fm = parseFrontmatter(text);
+	for (const field of ["id", "title", "status"] as const) {
+		if (fm[field] === undefined || fm[field] === "") {
+			throw new SweepScopeError(`${file}: missing front-matter field \`${field}\``);
+		}
+	}
+	const tags = parseTags(text);
+	const terms = termsOf(decisionText(fm.title as string, text));
+	return {
+		id: fm.id as string,
+		title: fm.title as string,
+		status: fm.status as string,
+		file,
+		tags,
+		terms,
+	};
+};
+
+/**
+ * Is this ADR still ruling? `accepted` and `amended-in-part by [NNNN]` both are — an
+ * amended ADR still governs everything the amendment did not touch, which is exactly the
+ * state a fresh contradiction can land on. `proposed`, `superseded`, `deprecated`,
+ * `retired`, and `reference` are out of sweep scope.
+ */
+export const isLiveAccepted = (status: string): boolean => {
+	const normalized = status
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+		.trim()
+		.toLowerCase();
+	return normalized.startsWith("accepted") || normalized.startsWith("amended-in-part");
+};
+
+/**
+ * ADR ids the text cites. Deliberately **narrow**: only an `NNNN-slug.md` filename, a
+ * `[NNNN]` bracket, or an `ADR NNNN` mention (including slash/comma runs like `ADR 0092/0107`)
+ * counts. A missed citation only re-lists an already-cited ADR on the shortlist (noise); an
+ * over-broad match would silently drop a real conflict (a miss), so the bias runs narrow.
+ */
+export const citedIds = (text: string): ReadonlySet<string> => {
+	const out = new Set<string>();
+	for (const m of text.matchAll(/\b(\d{4}[a-z]?)-[a-z0-9-]+\.md\b/g)) out.add(m[1] as string);
+	for (const m of text.matchAll(/\[(\d{4}[a-z]?)\]/g)) out.add(m[1] as string);
+	for (const m of text.matchAll(/\bADRs?[ \t]+((?:\[?\d{4}[a-z]?\]?[ \t]*[/,]?[ \t]*)+)/gi)) {
+		for (const n of (m[1] as string).matchAll(/\d{4}[a-z]?/g)) out.add(n[0]);
+	}
+	return out;
+};
+
+/**
+ * Inverse document frequency over the swept set. A term carried by every ADR ("pipeline",
+ * "issue") clamps to 0 and contributes nothing — which is what keeps a shared house-vocabulary
+ * word from outranking a genuinely distinctive one.
+ */
+const idfTable = (records: ReadonlyArray<AdrRecord>): ReadonlyMap<string, number> => {
+	const df = new Map<string, number>();
+	for (const r of records) for (const t of r.terms) df.set(t, (df.get(t) ?? 0) + 1);
+	const n = records.length;
+	const idf = new Map<string, number>();
+	for (const [term, count] of df) idf.set(term, Math.max(0, Math.log(n / (1 + count))));
+	return idf;
+};
+
+const scoreAgainst = (
+	subject: AdrRecord,
+	candidate: AdrRecord,
+	idf: ReadonlyMap<string, number>,
+): {score: number; sharedTerms: ReadonlyArray<string>; sharedTags: ReadonlyArray<string>} => {
+	const subjectTags = new Set(subject.tags);
+	const sharedTags = candidate.tags.filter((t) => subjectTags.has(t));
+	const contributions: Array<[string, number]> = [];
+	for (const term of subject.terms) {
+		if (!candidate.terms.has(term)) continue;
+		const rarity = idf.get(term) ?? 0;
+		if (rarity > 0) contributions.push([term, rarity * rarity]);
+	}
+	contributions.sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1));
+	// Normalize by the candidate's own breadth: an ADR with a sprawling `## Decision` overlaps
+	// everything by sheer surface area, which buried the short, precisely-adjacent 0072 behind
+	// three verbose unrelated ADRs. Dividing by sqrt(|terms|) prices adjacency, not verbosity.
+	const overlap =
+		contributions.reduce((sum, [, w]) => sum + w, 0) / Math.sqrt(candidate.terms.size || 1);
+	return {
+		score: overlap * (1 + TAG_BONUS * sharedTags.length),
+		sharedTerms: contributions.map(([t]) => t),
+		sharedTags,
+	};
+};
+
+export interface SweepInput {
+	readonly newAdr: AdrDoc;
+	/** Every `.decisions/` file except the new one (a same-id/same-file entry is dropped). */
+	readonly corpus: ReadonlyArray<AdrDoc>;
+	readonly limit?: number;
+}
+
+/**
+ * Sweep a new ADR against the corpus. Throws `SweepScopeError` — never returns a green — when
+ * the corpus cannot be read as ADRs or holds no live-accepted ADR to sweep against (ADR 0092:
+ * zero scope reds, it never passes silently).
+ */
+export const sweep = ({newAdr, corpus, limit = DEFAULT_LIMIT}: SweepInput): SweepResult => {
+	const subject = parseRecord(newAdr);
+	const others = corpus
+		.filter((d) => d.file !== newAdr.file)
+		.map(parseRecord)
+		.filter((r) => r.id !== subject.id);
+	if (others.length === 0) {
+		throw new SweepScopeError(
+			"zero ADRs to sweep against — the corpus holds no ADR other than the subject. " +
+				"Refusing to report a clean sweep over an empty corpus (ADR 0092).",
+		);
+	}
+	const live = others.filter((r) => isLiveAccepted(r.status));
+	if (live.length === 0) {
+		throw new SweepScopeError(
+			`zero live-accepted ADRs in scope (${others.length} parsed, none \`accepted\`/\`amended-in-part\`). ` +
+				"Refusing to report a clean sweep over an empty swept set (ADR 0092).",
+		);
+	}
+	const cited = citedIds(newAdr.text);
+	const swept = live.filter((r) => !cited.has(r.id));
+	const base = {
+		newId: subject.id,
+		newFile: subject.file,
+		scanned: others.length,
+		inScope: swept.length,
+		cited: [...cited].sort(),
+		termCount: subject.terms.size,
+	};
+
+	if (subject.terms.size === 0) {
+		return {
+			...base,
+			outcome: {
+				_tag: "indeterminate",
+				reason:
+					"the subject ADR yielded no distinctive decision terms (empty or missing `title` / " +
+					"`**What this decides:**` / `## Decision`) — the sweep had nothing to key on, so its " +
+					"silence carries no information.",
+			},
+		};
+	}
+	if (swept.length === 0) {
+		return {
+			...base,
+			outcome: {
+				_tag: "indeterminate",
+				reason:
+					"every live-accepted ADR is already cited by the subject — nothing was left to sweep, " +
+					"so this run neither confirms nor denies a contradiction.",
+			},
+		};
+	}
+	if (live.length < MIN_CORPUS_FOR_RARITY) {
+		return {
+			...base,
+			outcome: {
+				_tag: "indeterminate",
+				reason:
+					`only ${live.length} live-accepted ADRs in the corpus (rarity needs at least ` +
+					`${MIN_CORPUS_FOR_RARITY}) — every term scores as common, so a silent result here would ` +
+					"be a degenerate silence rather than a clean sweep. Read the corpus by hand.",
+			},
+		};
+	}
+
+	const idf = idfTable(live);
+	const candidates = swept
+		.map((r) => ({record: r, ...scoreAgainst(subject, r, idf)}))
+		.filter((c) => c.score > 0)
+		.sort((a, b) => b.score - a.score || (a.record.id < b.record.id ? -1 : 1))
+		.slice(0, limit)
+		.map(
+			({record, score, sharedTerms, sharedTags}): Candidate => ({
+				id: record.id,
+				title: record.title,
+				status: record.status,
+				file: record.file,
+				score: Math.round(score * 100) / 100,
+				sharedTerms,
+				sharedTags,
+			}),
+		);
+
+	return {
+		...base,
+		outcome: candidates.length === 0 ? {_tag: "no-overlap"} : {_tag: "shortlist", candidates},
+	};
+};
+
+/**
+ * The caveat printed on **every** run, pass or fail. A guard that reads as comprehensive while
+ * missing the semantic case is worse than a narrow one that says what it covers — so the tool
+ * states its own limit in its own output rather than leaving it to a doc nobody opens.
+ */
+export const CAVEAT =
+	"adr-sweep detects LEXICAL + TAG adjacency on decision-bearing text, minus the subject's own " +
+	"citations. It does NOT detect semantic contradiction: two ADRs that disagree about what a " +
+	"term MEANS while sharing no distinctive vocabulary will not appear here. A clean sweep is " +
+	"NOT evidence of no contradiction.";
+
+const REMEDY =
+	"Remedy for a real conflict: set `status: amended-in-part by [NNNN]` on the OLDER ADR's " +
+	"status line only (body untouched — ADR immutability), and have the new ADR name the " +
+	"relationship. Precedents: 0023, 0028, 0031, 0035.";
+
+/** The human report. `--json` consumers read `SweepResult` instead. */
+export const renderReport = (result: SweepResult): string => {
+	const header = `adr-sweep: subject ${result.newId} (${result.newFile}) · scanned ${result.scanned} ADRs · ${result.inScope} live-accepted + uncited in scope · ${result.termCount} decision terms · cites ${result.cited.length > 0 ? result.cited.join(", ") : "nothing"}`;
+	const lines: Array<string> = [header];
+	switch (result.outcome._tag) {
+		case "no-overlap":
+			lines.push(
+				"NO-OVERLAP — no uncited live-accepted ADR shares distinctive decision vocabulary with this one.",
+			);
+			break;
+		case "indeterminate":
+			lines.push(`INDETERMINATE — ${result.outcome.reason}`);
+			break;
+		case "shortlist": {
+			lines.push(
+				`SHORTLIST — ${result.outcome.candidates.length} uncited live-accepted ADR(s) decide in an adjacent domain. Open each, decide whether it rules on a question this ADR re-decides, and cite or amend it.`,
+			);
+			for (const c of result.outcome.candidates) {
+				const tags = c.sharedTags.length > 0 ? ` · shared tags: ${c.sharedTags.join(", ")}` : "";
+				lines.push(
+					`  ${c.id}  score ${c.score.toFixed(2)}  ${c.title} [${c.status}]\n    shared: ${c.sharedTerms.slice(0, 12).join(", ")}${tags}\n    file: ${c.file}`,
+				);
+			}
+			lines.push(REMEDY);
+			break;
+		}
+	}
+	lines.push(CAVEAT);
+	return lines.join("\n");
+};

--- a/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.ts
+++ b/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.ts
@@ -296,7 +296,11 @@ export const termsOf = (text: string): ReadonlySet<string> => {
 };
 
 const WHAT_DECIDES = /^[ \t]*\*\*What this decides:\*\*[ \t]*(.+)$/m;
-const DECISION_SECTION = /^##[ \t]+Decision[ \t]*\r?\n([\s\S]*?)(?=\r?\n##[ \t]|$)/m;
+// The terminal alternative is `(?![\s\S])` — end of INPUT — and must not be written `$`: the `m`
+// flag (needed so `^##` matches a mid-document heading) also makes `$` match before ANY newline,
+// which let the lazy body match the empty string at the blank line that follows the heading. That
+// silently emptied the capture on 207 of the 208 corpus ADRs carrying the section (#4030).
+const DECISION_SECTION = /^##[ \t]+Decision[ \t]*\r?\n([\s\S]*?)(?=\r?\n##[ \t]|(?![\s\S]))/m;
 
 /**
  * The decision-bearing passage of an ADR: its `title`, its `**What this decides:**` gloss, and
@@ -512,9 +516,11 @@ export const sweep = ({newAdr, corpus, limit = DEFAULT_LIMIT}: SweepInput): Swee
 };
 
 /**
- * The caveat printed on **every** run, pass or fail. A guard that reads as comprehensive while
- * missing the semantic case is worse than a narrow one that says what it covers — so the tool
- * states its own limit in its own output rather than leaving it to a doc nobody opens.
+ * The caveat printed on **every completed sweep**, pass or fail — the corpus-fault path throws
+ * before a report exists and carries its own fail-closed message instead. A guard that reads as
+ * comprehensive while missing the semantic case is worse than a narrow one that says what it
+ * covers — so the tool states its own limit in its own output rather than leaving it to a doc
+ * nobody opens.
  */
 export const CAVEAT =
 	"adr-sweep detects LEXICAL + TAG adjacency on decision-bearing text, minus the subject's own " +

--- a/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.unit.test.ts
@@ -1,0 +1,321 @@
+/**
+ * The pure `adr-sweep` core: term extraction, citation parsing, live-status scope, the ranked
+ * shortlist, and the two fail-closed refusals.
+ *
+ * The last block is the **would-have-caught** check (#3980 AC 4): condensed but faithful
+ * fixtures of the two live misses — ADR 0208 vs accepted 0072, ADR 0210 vs accepted 0202 —
+ * asserting the sweep surfaces the ADR each one silently re-decided against. The companion
+ * negative asserts the honest limit: a contradiction carried entirely by what a shared label
+ * MEANS, with no shared vocabulary, does not surface.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	citedIds,
+	decisionText,
+	isLiveAccepted,
+	parseTags,
+	SweepScopeError,
+	sweep,
+	termsOf,
+} from "./adr-sweep.ts";
+
+const adr = ({
+	id,
+	title,
+	status = "accepted",
+	tags = ["pipeline"],
+	decides = "",
+	decision = "",
+	context = "",
+}: {
+	id: string;
+	title: string;
+	status?: string;
+	tags?: ReadonlyArray<string>;
+	decides?: string;
+	decision?: string;
+	context?: string;
+}) => ({
+	file: `${id}-fixture.md`,
+	text: [
+		"---",
+		`id: ${id}`,
+		`title: ${title}`,
+		`status: ${status}`,
+		"date: 2026-07-25",
+		`tags: [${tags.join(", ")}]`,
+		"---",
+		"",
+		`# ${id} — ${title}`,
+		"",
+		`**What this decides:** ${decides}`,
+		"",
+		"## Context",
+		context,
+		"",
+		"## Decision",
+		decision,
+		"",
+		"## Consequences",
+		"Filler consequence prose that must not feed the sweep.",
+		"",
+	].join("\n"),
+});
+
+/** Unrelated ADRs so the IDF table has a corpus to price rarity against. */
+const filler = (n: number) =>
+	Array.from({length: n}, (_, i) =>
+		adr({
+			id: String(900 + i).padStart(4, "0"),
+			title: `Filler decision ${i} about rendering and caching`,
+			tags: ["frontend"],
+			decides: `Filler ${i} governs rendering, caching, and hydration of the widget surface.`,
+			decision: `Rendering uses the cached widget snapshot ${i}; hydration never blocks paint.`,
+		}),
+	);
+
+describe("termsOf / decisionText — what the sweep keys on", () => {
+	it("keeps distinctive tokens and drops stopwords, short words, and bare numbers", () => {
+		const terms = termsOf("Milestones encode strategic sequencing, not 1234 feature breakdown");
+		expect([...terms].sort()).toEqual([
+			"breakdown",
+			"encode",
+			"feature",
+			"milestone",
+			"sequencing",
+			"strategic",
+		]);
+	});
+
+	it("de-pluralizes so `milestones` and `milestone` are one term, but never strips an -ss word", () => {
+		expect([...termsOf("milestones milestone process")].sort()).toEqual(["milestone", "process"]);
+	});
+
+	it("reads a markdown link's label, not its slug — a cited ADR's slug must not inflate overlap", () => {
+		// `extends` → `extend`: the crude de-pluralizer collapses a trailing -s on verbs too, which
+		// is harmless (it only ever merges two spellings of one token).
+		expect([...termsOf("extends [0202](0202-forward-motion-doctrine-crewops.md) here")]).toEqual([
+			"extend",
+		]);
+	});
+
+	it("scopes to title + `What this decides` + `## Decision`, excluding Context and Consequences", () => {
+		const doc = adr({
+			id: "0500",
+			title: "Titleword",
+			decides: "Decidesword rules.",
+			decision: "Decisionword binds.",
+			context: "Contextword narrates.",
+		});
+		const text = decisionText("Titleword", doc.text);
+		expect(text).toContain("Titleword");
+		expect(text).toContain("Decidesword");
+		expect(text).toContain("Decisionword");
+		expect(text).not.toContain("Contextword");
+		expect(text).not.toContain("Filler consequence");
+	});
+});
+
+describe("citedIds — narrow by design (a miss is noise, an over-match is a silent drop)", () => {
+	it("reads a filename reference, a bracket reference, and an `ADR NNNN` run", () => {
+		const cited = citedIds(
+			"See [0072](0072-milestones-encode.md), ADR 0092/0107, and ADR [0055] for the rule.",
+		);
+		expect([...cited].sort()).toEqual(["0055", "0072", "0092", "0107"]);
+	});
+
+	it("does not read an issue number as an ADR citation", () => {
+		expect([...citedIds("filed as #3980 after the 2026 sweep")]).toEqual([]);
+	});
+});
+
+describe("isLiveAccepted — an amended ADR still rules over what the amendment did not touch", () => {
+	it.each([
+		["accepted", true],
+		["amended-in-part by [0208](0208-slug.md)", true],
+		["proposed", false],
+		["superseded by [0009](0009-slug.md)", false],
+		["retired", false],
+		["reference", false],
+	])("%s → %s", (status, live) => {
+		expect(isLiveAccepted(status)).toBe(live);
+	});
+});
+
+describe("sweep — fail-closed refusals (ADR 0092: zero scope reds, it never passes silently)", () => {
+	it("refuses a corpus that holds no ADR other than the subject", () => {
+		const subject = adr({id: "0500", title: "Alone", decides: "Nothing else exists."});
+		expect(() => sweep({newAdr: subject, corpus: [subject]})).toThrow(SweepScopeError);
+	});
+
+	it("refuses a corpus with no live-accepted ADR rather than report a clean sweep", () => {
+		const subject = adr({id: "0500", title: "Subject", decides: "Milestones are optional."});
+		const dead = adr({
+			id: "0400",
+			title: "Retired rule",
+			status: "superseded by [0500](0500-fixture.md)",
+			decides: "Milestones are mandatory.",
+		});
+		expect(() => sweep({newAdr: subject, corpus: [subject, dead]})).toThrow(/zero live-accepted/);
+	});
+
+	it("refuses a corpus file with malformed front-matter", () => {
+		const subject = adr({id: "0500", title: "Subject", decides: "A rule."});
+		expect(() =>
+			sweep({newAdr: subject, corpus: [subject, {file: "0400-broken.md", text: "no frontmatter"}]}),
+		).toThrow(SweepScopeError);
+	});
+});
+
+describe("sweep — `indeterminate` is a distinct outcome from `no-overlap`", () => {
+	it("reports `indeterminate` when the subject yields no decision terms to key on", () => {
+		const subject = {
+			file: "0500-empty.md",
+			text: "---\nid: 0500\ntitle: a\nstatus: accepted\ndate: 2026-07-25\ntags: []\n---\n\nbody\n",
+		};
+		const result = sweep({newAdr: subject, corpus: [subject, ...filler(12)]});
+		expect(result.outcome._tag).toBe("indeterminate");
+		expect(result.termCount).toBe(0);
+	});
+
+	it("reports `indeterminate` on a corpus too small for rarity — never a clean sweep", () => {
+		const subject = adr({
+			id: "0500",
+			title: "Turnstile quota governs kefil vouches",
+			decides: "A kefil vouch consumes a turnstile quota unit.",
+		});
+		const result = sweep({newAdr: subject, corpus: [subject, ...filler(4)]});
+		expect(result.outcome._tag).toBe("indeterminate");
+		expect(result.outcome).toMatchObject({reason: expect.stringContaining("degenerate silence")});
+	});
+
+	it("reports `indeterminate`, never `no-overlap`, when every live ADR is already cited", () => {
+		const cited = filler(3);
+		const subject = adr({
+			id: "0500",
+			title: "Cites everything",
+			decides: `Extends ${cited.map((c) => `ADR ${c.file.slice(0, 4)}`).join(", ")}.`,
+		});
+		const result = sweep({newAdr: subject, corpus: [subject, ...cited]});
+		expect(result.outcome._tag).toBe("indeterminate");
+	});
+
+	it("reports `no-overlap` when the swept set shares no distinctive vocabulary", () => {
+		const subject = adr({
+			id: "0500",
+			title: "Turnstile quota governs kefil vouches",
+			tags: ["moderation"],
+			decides: "A kefil vouch consumes a turnstile quota unit.",
+			decision: "Every kefil vouch decrements the turnstile quota.",
+		});
+		const result = sweep({newAdr: subject, corpus: [subject, ...filler(14)]});
+		expect(result.outcome._tag).toBe("no-overlap");
+	});
+});
+
+// Condensed but faithful fixtures of the four ADRs in the two live misses. The decision text is
+// excerpted from each ADR's title / `What this decides` / `## Decision`; the surrounding prose is
+// dropped because the sweep never reads it.
+const ADR_0072 = adr({
+	id: "0072",
+	title: "Milestones Encode Strategic Sequencing, Not Feature Breakdown",
+	tags: ["pipeline", "roadmap", "triage"],
+	decides:
+		"A milestone encodes strategic sequencing, not feature breakdown, and it is an optional pipeline dimension.",
+	decision:
+		"Milestone is an optional pipeline dimension alongside type, priority and status. " +
+		"Deliberately leaving a cluster unmilestoned is itself the signal that it is parked or deferred: " +
+		"absence is meaningful, so never invent milestone homes for frozen work. " +
+		"If every open issue gets a milestone, absence stops meaning anything and the deferral signal is lost.",
+});
+
+const ADR_0208 = adr({
+	id: "0208",
+	title:
+		"Standing lanes exempt from 100%-homed — exactly `wayfinder:backlog` + `axis:pipeline-hardening`",
+	tags: ["process", "prioritization", "triage", "pipeline"],
+	decides:
+		"Every open issue must live in a milestone or be killed, except issues carrying one of exactly two standing-lane labels.",
+	decision:
+		"The 100%-homed rule has a standing-lane exemption for exactly two labels and nothing else inherits it. " +
+		"A home-or-kill sweep treats an issue bearing either label as exempt and never force-fits a milestone onto it. " +
+		"Every other open issue is milestone-homed or killed. " +
+		"Banned: a third milestone-less category minted without a founder ruling.",
+	context: "Extends the forward-motion doctrine in ADR [0202](0202-forward-motion-doctrine.md).",
+});
+
+const ADR_0202 = adr({
+	id: "0202",
+	title: "Forward-motion doctrine — p0 freely minted for arc-homed ship-work",
+	tags: ["process", "prioritization", "pipeline"],
+	decides:
+		"Every unit of work is priced against whether it moves us forward, inside the documented active roadmap arc.",
+	decision:
+		"Kill or close is a valid triage verdict for improvement-for-improvement's-sake work. " +
+		"Work with no forward-motion answer does not survive triage. " +
+		"The documented roadmap, board and decision chain is the single company state agents reconcile toward.",
+});
+
+const ADR_0210 = adr({
+	id: "0210",
+	title: "Direction binds at intake — pitch, platform quota, appetite circuit-breaker",
+	tags: ["governance", "roadmap", "pipeline"],
+	decides:
+		"The roadmap steers the factory when work is admitted, never by failing a finished pull request at merge time.",
+	decision:
+		"A pitch is required at triage before work enters the drain. " +
+		"Work serving no active roadmap arc parks; it does not die. " +
+		"Parked unpitched work auto-expires after three weeks and comes back with a pitch. " +
+		"Explicitly rejected: any merge-blocking conformance gate on shipped work.",
+	context: "Founder ruling recorded on the ADR [0078](0078-product-driven-decisions.md) path.",
+});
+
+describe("would-have-caught — the two live misses this tool exists for (#3980)", () => {
+	const corpus = [ADR_0072, ADR_0202, ADR_0208, ADR_0210, ...filler(12)];
+	const shortlistIds = (subject: {file: string; text: string}) => {
+		const result = sweep({newAdr: subject, corpus});
+		if (result.outcome._tag !== "shortlist")
+			throw new Error(`expected shortlist, got ${result.outcome._tag}`);
+		return result.outcome.candidates.map((c) => c.id);
+	};
+
+	it("instance 1 — ADR 0208 surfaces accepted ADR 0072, which it never cites", () => {
+		expect(citedIds(ADR_0208.text).has("0072")).toBe(false);
+		expect(shortlistIds(ADR_0208)).toContain("0072");
+	});
+
+	it("instance 2 — ADR 0210 surfaces accepted ADR 0202, which it never cites", () => {
+		expect(citedIds(ADR_0210.text).has("0202")).toBe(false);
+		expect(shortlistIds(ADR_0210)).toContain("0202");
+	});
+
+	it("does NOT surface a purely semantic conflict — the stated limit, asserted not hoped", () => {
+		// The 0210-vs-0203 relocation shape: two ADRs that disagree about what a label MEANS while
+		// sharing no distinctive vocabulary. This is the case a reviewer must still catch by reading.
+		const semantic = adr({
+			id: "0501",
+			title: "Charting is the only doorway out of the holding lane",
+			tags: ["frontend"],
+			decides: "An entry in the holding lane departs when a cartographer charts it.",
+			decision: "Charting alone releases an entry from the holding lane.",
+		});
+		const clock = adr({
+			id: "0502",
+			title: "A dormant bet retires after three weeks",
+			tags: ["moderation"],
+			decides: "A dormant bet retires automatically once three weeks elapse.",
+			decision: "The scheduler retires a dormant bet; only a founder repitch revives it.",
+		});
+		const result = sweep({newAdr: clock, corpus: [clock, semantic, ...filler(10)]});
+		const ids =
+			result.outcome._tag === "shortlist" ? result.outcome.candidates.map((c) => c.id) : [];
+		expect(ids).not.toContain("0501");
+	});
+});
+
+describe("parseTags", () => {
+	it("reads the bracketed tag row, lowercased; a missing row is no tags", () => {
+		expect(parseTags(ADR_0072.text)).toEqual(["pipeline", "roadmap", "triage"]);
+		expect(parseTags("---\nid: 1\n---\n")).toEqual([]);
+	});
+});

--- a/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.unit.test.ts
@@ -51,9 +51,15 @@ const adr = ({
 		`**What this decides:** ${decides}`,
 		"",
 		"## Context",
+		"",
 		context,
 		"",
+		// The blank line after `## Decision` is load-bearing, not formatting: it is the shape the
+		// house ADR template emits (and 207 of the 208 corpus ADRs carry), and the shape the old
+		// per-line-anchored section regex captured as EMPTY. A fixture without it cannot reproduce
+		// the real input, which is how #4030's overclaim shipped green.
 		"## Decision",
+		"",
 		decision,
 		"",
 		"## Consequences",
@@ -306,9 +312,27 @@ describe("would-have-caught — the two live misses this tool exists for (#3980)
 			decides: "A dormant bet retires automatically once three weeks elapse.",
 			decision: "The scheduler retires a dormant bet; only a founder repitch revives it.",
 		});
-		const result = sweep({newAdr: clock, corpus: [clock, semantic, ...filler(10)]});
-		const ids =
-			result.outcome._tag === "shortlist" ? result.outcome.candidates.map((c) => c.id) : [];
+		// A lexically-adjacent ADR so the sweep demonstrably PRODUCES a shortlist here. Without it
+		// the corpus shares no vocabulary with the subject at all, the outcome is `no-overlap`, and
+		// the miss below is asserted against an empty list — vacuous.
+		const lexical = adr({
+			id: "0503",
+			title: "The nightly scheduler pass owns dormant-entry retirement",
+			tags: ["moderation"],
+			decides: "A dormant entry is retired by the nightly scheduler pass, never by hand.",
+			decision: "The scheduler retires dormant entries on its nightly pass; no manual retirement.",
+		});
+		const result = sweep({newAdr: clock, corpus: [clock, semantic, lexical, ...filler(10)]});
+		// Pin the outcome shape FIRST: on any non-shortlist tag the id list is empty, so a bare
+		// `not.toContain` would pass vacuously — satisfied by the sweep failing to run at all rather
+		// than by the miss it means to assert.
+		if (result.outcome._tag !== "shortlist") {
+			throw new Error(
+				`expected a shortlist to assert the miss against, got ${result.outcome._tag}`,
+			);
+		}
+		const ids = result.outcome.candidates.map((c) => c.id);
+		expect(ids).toContain("0503");
 		expect(ids).not.toContain("0501");
 	});
 });

--- a/packages/pipeline-cli/src/tools/adr-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/adr-sweep/command.ts
@@ -1,0 +1,83 @@
+/**
+ * The `adr-sweep` tool — `pipeline-cli adr-sweep shortlist --new <NNNN|path>`.
+ *
+ * The mechanical half of the ADR contradiction sweep the `adr` (authoring) and `review-doc`
+ * (gate) skills mandate (#3980): given a new ADR, rank the live `accepted` ADRs it does NOT
+ * cite by decision-domain adjacency, so the sweep is a list to clear rather than a memory test.
+ * The judgement — is this entry actually re-decided? — stays with the author/reviewer; the
+ * exit contract and the honest statement of what this misses live in `gate.ts` / `adr-sweep.ts`.
+ */
+import {Effect, FileSystem, Option, Path} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {DEFAULT_LIMIT} from "./adr-sweep.ts";
+import {runSweep} from "./gate.ts";
+
+const DECISIONS_DIR = ".decisions";
+const ROOT_MARKERS = [DECISIONS_DIR, "pnpm-workspace.yaml", ".git"] as const;
+
+/**
+ * Resolve the default `.decisions` dir against the repo root, not the cwd — `pnpm --filter`
+ * runs with cwd = the package dir, where a bare `.decisions` ENOENTs (#447; the same resolver
+ * `decisions-index` uses, kept local so neither tool's default becomes the other's API).
+ */
+const defaultDecisionsDir = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return path.join(dir, DECISIONS_DIR);
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return path.join(start, DECISIONS_DIR);
+		dir = parent;
+	}
+});
+
+const dirFlag = Flag.string("dir").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the .decisions directory to sweep against (default: the repo-root .decisions)",
+	),
+);
+
+const newFlag = Flag.string("new").pipe(
+	Flag.withDescription(
+		"the ADR to sweep: a bare id (`0208`) already in --dir, or a path to the ADR file",
+	),
+);
+
+const limitFlag = Flag.integer("limit").pipe(
+	Flag.withDefault(DEFAULT_LIMIT),
+	Flag.withDescription("how many shortlist entries to emit"),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the SweepResult as JSON instead of the human report"),
+);
+
+const shortlist = Command.make(
+	"shortlist",
+	{dir: dirFlag, new: newFlag, limit: limitFlag, json: jsonFlag},
+	Effect.fn(function* ({dir: dirOpt, new: newRef, limit, json}) {
+		const dir = yield* Option.match(dirOpt, {
+			onNone: () => defaultDecisionsDir(),
+			onSome: Effect.succeed,
+		});
+		yield* runSweep({dir, newRef, limit, json}).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(
+	Command.withDescription(
+		"Rank the uncited live-accepted ADRs whose decision domain this ADR touches — exit 0 only when there is nothing to clear",
+	),
+);
+
+export const adrSweepCommand = Command.make("adr-sweep").pipe(
+	Command.withSubcommands([shortlist]),
+	Command.withDescription(
+		"Shortlist the live-accepted ADRs a new ADR may contradict but does not cite (#3980)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/adr-sweep/gate.ts
+++ b/packages/pipeline-cli/src/tools/adr-sweep/gate.ts
@@ -1,0 +1,111 @@
+/**
+ * The `adr-sweep` filesystem seam — split from `command.ts` so it is crossable over a fake
+ * `.decisions` dir in unit tests rather than only by spawning the bin (the core-in-its-own-file
+ * idiom; #855). The verdict itself is the pure core (`adr-sweep.ts`).
+ *
+ * **Exit contract.** Exit 0 iff the sweep ran and produced `no-overlap`. A `shortlist` and an
+ * `indeterminate` both exit non-zero — the tool cannot clear a shortlist entry (only the
+ * author/reviewer can) and it must never let "I could not sweep" read as "nothing found". A
+ * missing subject ADR, malformed front-matter anywhere in the corpus, and zero live-accepted
+ * ADRs in scope all fail closed (ADR 0092); an unreadable corpus is an `IoError`, also non-zero.
+ * Exit 0 is therefore evidence that nothing mechanically adjacent was left to open — never a
+ * certificate that no contradiction exists (see `CAVEAT`).
+ */
+import {Console, Effect, FileSystem, Path} from "effect";
+import * as Schema from "effect/Schema";
+import {numberFromFile} from "../decisions-index/decisions-index.ts";
+import {readAdrFiles} from "../decisions-index/gate.ts";
+import {
+	type AdrDoc,
+	CAVEAT,
+	renderReport,
+	type SweepResult,
+	SweepScopeError,
+	sweep,
+} from "./adr-sweep.ts";
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
+
+/** Carries the non-zero exit (the report is already on stderr). */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+const ADR_ID = /^\d{4}[A-Za-z]?$/;
+
+/**
+ * Resolve `--new`: a bare `NNNN` names an ADR already sitting in the corpus dir; anything else
+ * is a path to the ADR file (the shape an author or a reviewer has mid-PR, before the file is on
+ * the base ref). An id with no matching file fails closed rather than sweeping nothing.
+ */
+export const resolveSubject = (
+	newRef: string,
+	dir: string,
+	corpus: ReadonlyArray<AdrDoc>,
+): Effect.Effect<AdrDoc, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		if (ADR_ID.test(newRef)) {
+			const hit = corpus.find((d) => numberFromFile(d.file) === newRef);
+			if (hit === undefined) {
+				return yield* Effect.fail(
+					new CheckFailed({
+						reason: `no ADR file for id \`${newRef}\` in ${dir} — pass the file path instead when the ADR is not on this ref.`,
+					}),
+				);
+			}
+			return hit;
+		}
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const text = yield* fs
+			.readFileString(newRef, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: newRef, cause})));
+		return {file: path.basename(newRef), text};
+	});
+
+export interface SweepOptions {
+	readonly dir: string;
+	readonly newRef: string;
+	readonly limit: number;
+	readonly json: boolean;
+}
+
+/**
+ * Read the corpus, sweep the subject against it, emit the report, and carry the exit contract.
+ * `SweepScopeError` (malformed front-matter, zero scope) folds into `CheckFailed` — the sweep
+ * never reports a clean run over a corpus it could not read.
+ */
+export const runSweep = ({
+	dir,
+	newRef,
+	limit,
+	json,
+}: SweepOptions): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const corpus = yield* readAdrFiles(dir).pipe(
+			Effect.mapError((e) => new IoError({path: dir, cause: e})),
+		);
+		const subject = yield* resolveSubject(newRef, dir, corpus);
+		const result: SweepResult = yield* Effect.try({
+			try: () => sweep({newAdr: subject, corpus, limit}),
+			catch: (cause) =>
+				new CheckFailed({
+					reason:
+						cause instanceof SweepScopeError
+							? `adr-sweep: ${cause.detail}`
+							: `adr-sweep: ${String((cause as Error)?.message ?? cause)}`,
+				}),
+		});
+		const report = json
+			? JSON.stringify({...result, caveat: CAVEAT}, null, 2)
+			: renderReport(result);
+		if (result.outcome._tag === "no-overlap") {
+			yield* Console.log(report);
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: report}));
+	});

--- a/packages/pipeline-cli/src/tools/adr-sweep/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/adr-sweep/gate.unit.test.ts
@@ -1,0 +1,153 @@
+/**
+ * `runSweep` over a fake `.decisions` dir — the filesystem-seam test (#855). The ranking itself
+ * is covered in `adr-sweep.unit.test.ts`; this crosses the IO gate over a real temp dir and
+ * asserts the exit contract from observable outcomes, never by spawning the bin: exit 0 only on
+ * `no-overlap`; `shortlist`, `indeterminate`, a missing subject, malformed front-matter, and an
+ * empty corpus all `CheckFailed`.
+ */
+import {mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
+import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
+import {DEFAULT_LIMIT} from "./adr-sweep.ts";
+import {CheckFailed, runSweep} from "./gate.ts";
+
+let dir: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "adr-sweep-gate-"));
+});
+afterEach(() => {
+	rmSync(dir, {recursive: true, force: true});
+});
+
+const write = (
+	id: string,
+	{
+		title,
+		status = "accepted",
+		tags = "pipeline",
+		decision,
+	}: {title: string; status?: string; tags?: string; decision: string},
+) =>
+	writeFileSync(
+		join(dir, `${id}-fixture.md`),
+		`---\nid: ${id}\ntitle: ${title}\nstatus: ${status}\ndate: 2026-07-25\ntags: [${tags}]\n---\n\n# ${id} — ${title}\n\n**What this decides:** ${decision}\n\n## Decision\n${decision}\n`,
+		"utf8",
+	);
+
+/** Unrelated ADRs so rarity has a corpus (`MIN_CORPUS_FOR_RARITY`) and no term reads as common. */
+const writeFiller = (n = 14) => {
+	for (let i = 0; i < n; i++) {
+		write(String(700 + i).padStart(4, "0"), {
+			title: `Filler ${i} governs rendering and hydration`,
+			tags: "frontend",
+			decision: `Rendering uses cached snapshot ${i}; hydration never blocks paint.`,
+		});
+	}
+};
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
+
+const failure = (exit: Exit.Exit<unknown, unknown>): CheckFailed | null => {
+	if (!Exit.isFailure(exit)) return null;
+	const squashed = Cause.squash(exit.cause);
+	return squashed instanceof CheckFailed ? squashed : null;
+};
+
+const sweepIn = (newRef: string, json = false) =>
+	run(runSweep({dir, newRef, limit: DEFAULT_LIMIT, json}));
+
+describe("runSweep — the exit contract over a fake .decisions dir", () => {
+	it("SUCCEEDS (exit 0) when the swept set shares no decision vocabulary", async () => {
+		writeFiller();
+		write("0300", {
+			title: "Turnstile quota governs kefil vouches",
+			tags: "moderation",
+			decision: "A kefil vouch consumes a turnstile quota unit.",
+		});
+		write("0301", {
+			title: "Rendering uses a cached snapshot",
+			decision: "Hydration never blocks paint.",
+		});
+		expect(Exit.isSuccess(await sweepIn("0300"))).toBe(true);
+	});
+
+	it("FAILS with the shortlist when an uncited live-accepted ADR is adjacent", async () => {
+		writeFiller();
+		write("0300", {
+			title: "Milestones encode strategic sequencing",
+			decision: "A milestone is an optional dimension; unmilestoned means parked.",
+		});
+		write("0301", {
+			title: "Every open issue is milestone-homed or killed",
+			decision: "Every open issue takes a milestone or is killed; unmilestoned is not a home.",
+		});
+		const report = failure(await sweepIn("0301"));
+		expect(report?.reason).toContain("SHORTLIST");
+		expect(report?.reason).toContain("0300");
+	});
+
+	it("FAILS `indeterminate` — distinct from a clean sweep — when there is nothing to key on", async () => {
+		writeFileSync(
+			join(dir, "0300-empty.md"),
+			"---\nid: 0300\ntitle: a\nstatus: accepted\ndate: 2026-07-25\ntags: []\n---\n\nbody\n",
+			"utf8",
+		);
+		write("0301", {title: "Some other rule", decision: "Rendering caches the snapshot."});
+		expect(failure(await sweepIn("0300"))?.reason).toContain("INDETERMINATE");
+	});
+
+	it("FAILS CLOSED on an id with no matching ADR file", async () => {
+		write("0300", {title: "A rule", decision: "Something binds."});
+		expect(failure(await sweepIn("0999"))?.reason).toContain("no ADR file for id");
+	});
+
+	it("FAILS CLOSED on malformed front-matter anywhere in the corpus", async () => {
+		write("0300", {title: "A rule", decision: "Something binds."});
+		writeFileSync(join(dir, "0301-broken.md"), "no front-matter here\n", "utf8");
+		expect(failure(await sweepIn("0300"))?.reason).toContain("missing front-matter field");
+	});
+
+	it("FAILS CLOSED on zero scope — a corpus whose only other ADR is superseded", async () => {
+		write("0300", {title: "A rule about milestones", decision: "Milestones are optional."});
+		write("0301", {
+			title: "An old rule",
+			status: "superseded by [0300](0300-fixture.md)",
+			decision: "Milestones are mandatory.",
+		});
+		expect(failure(await sweepIn("0300"))?.reason).toContain("zero live-accepted");
+	});
+
+	it("accepts a path to an ADR not yet in the corpus dir (the mid-PR shape)", async () => {
+		writeFiller();
+		const subject = join(dir, "..", `adr-sweep-subject-${process.pid}.md`);
+		writeFileSync(
+			subject,
+			"---\nid: 0400\ntitle: Turnstile quota governs kefil vouches\nstatus: accepted\ndate: 2026-07-25\ntags: [moderation]\n---\n\n**What this decides:** A kefil vouch consumes a turnstile quota unit.\n\n## Decision\nEvery kefil vouch decrements the turnstile quota.\n",
+			"utf8",
+		);
+		const exit = await run(runSweep({dir, newRef: subject, limit: DEFAULT_LIMIT, json: false}));
+		rmSync(subject, {force: true});
+		// The subject shares no vocabulary with the corpus, so a resolvable path yields a clean run —
+		// which is what proves the path branch resolved rather than silently swept nothing.
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("emits machine-readable JSON under --json, carrying the caveat with the outcome", async () => {
+		writeFiller();
+		write("0300", {
+			title: "Milestones encode strategic sequencing",
+			decision: "A milestone is an optional dimension; unmilestoned means parked.",
+		});
+		write("0301", {
+			title: "Every open issue is milestone-homed or killed",
+			decision: "Every open issue takes a milestone or is killed; unmilestoned is not a home.",
+		});
+		const parsed = JSON.parse(failure(await sweepIn("0301", true))?.reason ?? "{}");
+		expect(parsed.outcome._tag).toBe("shortlist");
+		expect(parsed.caveat).toContain("does NOT detect semantic contradiction");
+	});
+});

--- a/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
@@ -103,6 +103,14 @@ const unquote = (value: string): string => {
 };
 
 /**
+ * The raw text between a file's leading `---` fences, or `null` when there is no
+ * front-matter block. Exported so a consumer that needs a field outside this file's
+ * four (`adr-sweep` reads `tags`) shares one notion of where front-matter ends.
+ */
+export const frontmatterBlock = (text: string): string | null =>
+	text.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? null;
+
+/**
  * Parse the four index-relevant fields out of a `---`-delimited YAML block.
  * Only the top-level `id`/`title`/`status`/`date` scalars are read; everything
  * else (tags, body) is ignored. Returns the fields present; the caller validates.
@@ -110,9 +118,8 @@ const unquote = (value: string): string => {
 export const parseFrontmatter = (
 	text: string,
 ): Partial<Record<(typeof FRONTMATTER_FIELDS)[number], string>> => {
-	const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-	if (!match || match[1] === undefined) return {};
-	const block = match[1];
+	const block = frontmatterBlock(text);
+	if (block === null) return {};
 	const out: Partial<Record<(typeof FRONTMATTER_FIELDS)[number], string>> = {};
 	for (const line of block.split(/\r?\n/)) {
 		const kv = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s?(.*)$/);


### PR DESCRIPTION
Fixes #3980

## What was missing

Nothing forced a new ADR to be swept against the live `accepted` ADRs. `review-doc`'s hygiene check 5 fires only **when the doc itself claims** to replace a prior decision, and Step 4b validates the doc's **own** citations. Both follow a thread the document hands you — which is exactly the path that misses the defect: an ADR that never names the ADR it contradicts gives a reviewer nothing to pull. On PR #3955 an earlier pass explicitly checked cross-references, followed the one ADR the document cited, and PASSed.

## What this adds

**1. `review-doc` Step 4a — the contradiction sweep (ADR diffs only, citation-independent).** Enumerate the questions the new ADR decides, sweep the live `accepted` ADRs for those questions **without consulting the ADR's reference list**, open the shortlist, judge each. An uncited, unamended same-question conflict with a live `accepted` ADR is a **FAIL**, and the FAIL names the required resolution shape.

**2. `adr` skill — the authoring-side mirror** (new step 4 plus a `## Contradiction sweep` section). Same three moves, run before the PR goes up. The amend-in-part shape is now also a Rule, and the "purely additive ADR PR" wording is extended to cover the amended file's status-line edit.

**3. `pipeline-cli adr-sweep shortlist --new <NNNN|path>` — the mechanical input.** Ranks the live-accepted ADRs whose decision domain the new ADR touches **and which it does not cite**. Pure unit-tested core plus a thin Effect gate, per the repo's Node-over-Python tooling convention. It reuses `decisions-index`'s corpus reader and front-matter parse rather than a second copy (one small `frontmatterBlock` export was factored out for the `tags` read).

Both skills name the existing remedy as the required resolution: `status: amended-in-part by [NNNN]` on the **older** ADR's **status line only**, body untouched (an accepted ADR's decision text is immutable), plus the new ADR naming the relationship. Precedents: 0023, 0028, 0031, 0035.

## What the guard catches — and what it does NOT

Stating this plainly, because a guard that reads as comprehensive while missing the semantic case is worse than a narrow one that says what it covers.

**Catches:** an ADR that changes a rule in a domain a live `accepted` ADR already governs, **without citing it** — detected as rarity-weighted vocabulary overlap on decision-bearing text (`title` + the `What this decides` line + `## Decision`, including `Binding constraints` / `Banned`), amplified by shared front-matter tags, normalized by the candidate's own breadth so a sprawling ADR cannot outrank a short precisely-adjacent one, with the subject's own citations removed from the candidate set. It also treats `amended-in-part by …` as still-live, so a partially-amended ADR stays sweepable.

**Does NOT catch:** semantic contradiction. Two ADRs that disagree about what a label *means* while sharing no distinctive vocabulary do not appear — the 0210-vs-0203 relocation shape, where the repair to #3955 collided with a third ADR defining that same label's exit condition and was again caught only by reading. It also does not catch a conflict expressed entirely in `## Context` or `## Consequences` (deliberately out of scope — those narrate, they do not rule), and a shortlist entry is a *candidate*, never a finding: the judgement is the reviewer's. `adr-sweep.unit.test.ts` asserts this limit rather than hoping for it (`does NOT surface a purely semantic conflict`).

That is why the obligation lives in the two **skills**, with the tool as input. The tool cannot be the gate.

## Fail-closed behaviour (ADR 0092)

Exit 0 **iff** the sweep ran and produced `no-overlap`. Everything else is non-zero and typed:

| Outcome | Meaning | Exit |
|---|---|---|
| `no-overlap` | Nothing mechanically adjacent left to open. **Not** evidence of no contradiction. | 0 |
| `shortlist` | Candidates the author/reviewer must open and clear. The tool cannot clear them. | non-zero |
| `indeterminate` | The sweep proved nothing — no decision terms to key on, every live ADR already cited, or a corpus too small for rarity to mean anything. **Distinct from `no-overlap` by construction.** | non-zero |
| corpus fault | Unreadable dir/file, malformed front-matter anywhere, or zero live-accepted ADRs in scope. | non-zero |

The `indeterminate`-vs-`no-overlap` split is the point: collapsing "I could not sweep" into "I found nothing" is the exact bug class that produced this issue. The corpus-too-small case was found while writing the gate tests — with a handful of ADRs every rarity weight clamps to zero and the sweep silently reported a clean run; that degenerate silence is now `indeterminate`, never green.

## Would-have-caught check (AC 4)

Run live against `.decisions/` on `main`, with each ADR taken at the head its `review-doc: FAIL` was bound to:

- **Instance 1 — ADR 0208 @ `f13aaac`** (cites 0075/0202/0203, never 0072): 209 ADRs scanned, 171 live-accepted and uncited in scope, 59 decision terms. **`0072` surfaces at rank 1 of 8**, score 16.33, shared terms `milestone`/`campaign`/`hardening`, shared tags `pipeline`/`triage`.
- **Instance 2 — ADR 0210 @ `167a195`** (cites 0078 only): 209 scanned, 173 in scope, 128 decision terms. **`0202` surfaces at rank 2 of 8**, score 16.09 — and `0072`, a fourth ADR in the same unrecorded tension, enters at rank 7 (14.27). `0203` scores 10.47 at rank 15, below the default depth of 8; it needs a raised `--limit` to appear.

Both are also pinned as unit tests over condensed but faithful fixtures of the four ADRs, so the check survives corpus drift.

## Verification

- `pnpm vitest run` in `packages/pipeline-cli` — 2089 tests / 148 files pass (31 new).
- `pnpm typecheck` — clean (29/29 tasks).
- `pnpm lint:worktree` — clean.
- `pipeline-cli commands check` — 65 registered tools, all documented.
- `pipeline-cli adoption-lint check` over the full plugin corpus — clean.
- `pipeline-cli pointer-guard check` — clean.


---

## Repair round 1 — the `review-code` FAIL (defect 1)

`DECISION_SECTION` carried the `m` flag with `$` as its terminal alternative. Under `m`, `$` matches before **any** newline, so the lazy body matched the empty string at the blank line that follows the `## Decision` heading. Measured over `.decisions/`: 208 of 209 ADRs carry the section and the capture was non-empty for **exactly 1**. The stated input scope was not the real one — the overclaim class this guard exists to catch, inside the guard.

The terminal alternative is now `(?![\s\S])` (end of **input**). Re-measured: **208 of 208** capture non-empty. The AC-4 figures above are the post-fix measurement.

The scoping test pinned the overclaim green because the fixture builder joined `## Decision` and its body with a single `\n` — a shape the house ADR template does not emit. The builder now emits the blank line after each heading, and the test **fails against the old regex** (`expected 'Titleword\nDecidesword rules.\n' to contain 'Decisionword'`) and passes against the new one.

Two coupled items from the same verdict:

- The semantic-miss test asserted `not.toContain` over a list that is empty on any non-shortlist outcome — and with the corpus it had, the outcome genuinely **was** `no-overlap`, so the miss was never pinned. It now asserts the shortlist shape first, over a corpus carrying one lexically-adjacent ADR that must surface.
- `CAVEAT`'s docstring said "every run"; it prints on every **completed sweep** (the corpus-fault path throws before a report exists and carries its own fail-closed message). The docstring now says so.

No skill edit was needed: the fix-the-code branch makes both skills' "`title` + `**What this decides:**` + `## Decision`" prose true as written.

Re-verified at this head: `pnpm vitest run` in `packages/pipeline-cli` — 2089 tests / 148 files pass; `pnpm typecheck` clean (29/29); `pnpm lint:worktree` clean.


---

## Repair round 2 — the non-blocking `review-skill` finding (both gates were PASS at `1354c85b`)

Step 4a mandated Step 2's `--worktree` materialization on a premise that did not entail it. `--new` accepts "a path to the ADR file" — any real file, anywhere on disk — so `git show "$PR_REF:.decisions/NNNN-slug.md"` produces the subject on Step 2's **default ref-only** path at zero worktree cost. And `--dir` was never passed, so the swept corpus was the base `.decisions/` all along; the full checkout bought exactly one file while the `$REVIEW_WT/.decisions/` path read as though the worktree's corpus was what got swept.

Step 4a now extracts the subject to a §SP rule-4 scratch dir (allocated **and** consumed in the one Bash call — the same carve-out `VERDICT_FILE` / `WT_FILE` already use on this page) and sweeps from there. The inline comment and the surrounding prose were rewritten to describe the path an agent actually takes, not the old one:

- **The swept corpus is now stated plainly.** `--dir` is deliberately left unset, so the sweep reads the repo-root `.decisions/` of the checkout the reviewer runs in — the **base, pre-PR** corpus. That is the set you want, because it excludes the new ADR from its own candidate set. Only the subject file comes from the PR head.
- Step 2's "rare for a doc PR" claim about `--worktree` is true again: Step 4a no longer makes a full head checkout routine for the most common doc-PR shape in this repo.
- The sweep's exit status is preserved across the scratch cleanup, since the exit code is load-bearing here (`0` = `no-overlap`).

Nothing else changed. The `DECISION_SECTION` fix and its regression test, the de-vacuumed semantic-miss test, the fail-closed outcome taxonomy, the `frontmatterBlock` extraction, and the `adr` skill's block (which passes a literal path and needed no change) are untouched.

Re-verified at this head: `adoption-lint check` over the full plugin corpus plus `.claude/workflows/drive-issue.js` — clean; `pointer-guard check` — clean; `leak-guard` (pre-commit) — clean.
