### PR TITLE
fix(integration-harness): one throttled+retried CF REST transport with a wall-clock 429 budget (#3548)

### DIFF
--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -127,22 +127,41 @@ create/destroy surface every CF flake class scales with (#1010 / #1019 /
 
 ## CF API rate-limit discipline — two complementary halves
 
-The harness's setup-only Cloudflare REST path (`cloudflareApi` → `runD1Query` in
-`_harness.ts`; `setLastActivityAt` / `execD1` / `promoteToYazar`) hits ONE
-account's D1 control-plane, which trips the account-global rate limit (HTTP 429,
-code 971 "TooManyRequests") under concurrent-stage batch load. Two wrappers guard
-it, and a call funnels through both:
+Every integration-test Cloudflare REST call — the setup path (`cloudflareApi` →
+`runD1Query` in `_harness.ts`; `setLastActivityAt` / `execD1` / `promoteToYazar`)
+AND a test's data-plane `makeD1Rest` queries — hits ONE account's D1
+control-plane, which trips the account-global rate limit (HTTP 429, code 971
+"TooManyRequests") under concurrent-stage batch load. **All of them go through one
+transport, `_cf-rest-transport.ts`**, which composes two halves:
 
 - **Reactive per-call retry** — `cfFetchWithRateLimitRetry` (`_d1-rest-retry.ts`):
   after a 429 fires, replay the one call with full-jitter exponential backoff
-  (429 is a pre-execution reject, so replay is safe; #2915). Bounded — a
-  persistent 429 exhausts the budget and surfaces.
+  (429 is a pre-execution reject, so replay is safe; #2915), floored by a
+  CF-supplied `Retry-After`. The budget is a **wall-clock deadline**
+  (`D1_REST_BUDGET_MS`), not an attempt count: with full jitter, "5 retries" is a
+  budget with a near-zero lower bound, which is why the shipped retry burned out
+  against a ~290s 429 plateau and red five bystander suites anyway (#3548). It
+  never masks a real failure — only a 429 is retried, and exhaustion surfaces the
+  final 429 (raised by `cloudflareApi` as `CfRateLimitError`, naming the call, its
+  attempt count and the budget it spent).
 - **Proactive shared throttle** — `cfApiThrottle` (`_cf-api-throttle.ts`, #3081):
-  a concurrency cap + jittered start-pacing every harness CF REST call funnels
-  through, so fewer 429s fire in the first place. `cloudflareApi` composes it
-  AROUND the retry (`throttle.run(() => cfFetchWithRateLimitRetry(send))`), so
-  each logical call — retries included — is one throttled unit. Both knobs are
-  env-tunable (`CF_API_MAX_CONCURRENT` / `CF_API_MIN_SPACING_MS`).
+  a concurrency cap + jittered start-pacing, so fewer 429s fire in the first
+  place. Both knobs are env-tunable (`CF_API_MAX_CONCURRENT` /
+  `CF_API_MIN_SPACING_MS`).
+
+**Composition order: retry AROUND throttle** (`retry(() => throttle.run(send))`),
+inverting #3081's original note. A call sleeping in backoff is not in flight, so
+it must not hold an in-flight slot — under the old order four backing-off calls
+held all four slots and head-of-line-blocked every other CF call in the fork.
+This order also start-paces the retries themselves.
+
+**Build the client through the transport, never by hand.** Use
+`makeIntegrationD1Rest` / `integrationRestLayer`; a per-file
+`Layer.merge(CredentialsFromEnv, FetchHttpClient.layer)` or `makeD1RestFromEnv`
+is the BARE fetch with no retry and no throttle. That opt-in-ness is what red
+`pasaport-ban.test.ts` in run `29665891972` while its wrapped sibling survived
+the same 429 storm, so `_cf-rest-transport.unit.test.ts` now fails closed on any
+integration test file that re-introduces one.
 
 **Ceiling (why this isn't the whole 429 story):** the throttle is an in-process
 singleton — under `isolate:false` it is shared across files in the same fork, but

--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -137,13 +137,13 @@ transport, `_cf-rest-transport.ts`**, which composes two halves:
 - **Reactive per-call retry** — `cfFetchWithRateLimitRetry` (`_d1-rest-retry.ts`):
   after a 429 fires, replay the one call with full-jitter exponential backoff
   (429 is a pre-execution reject, so replay is safe; #2915), floored by a
-  CF-supplied `Retry-After`. The budget is a **wall-clock deadline**
-  (`D1_REST_BUDGET_MS`), not an attempt count: with full jitter, "5 retries" is a
-  budget with a near-zero lower bound, which is why the shipped retry burned out
-  against a ~290s 429 plateau and red five bystander suites anyway (#3548). It
-  never masks a real failure — only a 429 is retried, and exhaustion surfaces the
-  final 429 (raised by `cloudflareApi` as `CfRateLimitError`, naming the call, its
-  attempt count and the budget it spent).
+  CF-supplied `Retry-After`. The budget is a **deadline** (`D1_REST_BUDGET_MS`),
+  not an attempt count: with full jitter, "5 retries" is a budget with a
+  near-zero lower bound, which is why the shipped retry burned out against a
+  ~290s 429 plateau and red five bystander suites anyway (#3548). It never masks
+  a real failure — only a 429 is retried, and exhaustion surfaces the final 429
+  (raised by `cloudflareApi` as `CfRateLimitError`, naming the call, why it
+  stopped, and how its elapsed time split).
 - **Proactive shared throttle** — `cfApiThrottle` (`_cf-api-throttle.ts`, #3081):
   a concurrency cap + jittered start-pacing, so fewer 429s fire in the first
   place. Both knobs are env-tunable (`CF_API_MAX_CONCURRENT` /
@@ -154,6 +154,28 @@ inverting #3081's original note. A call sleeping in backoff is not in flight, so
 it must not hold an in-flight slot — under the old order four backing-off calls
 held all four slots and head-of-line-blocked every other CF call in the fork.
 This order also start-paces the retries themselves.
+
+**The two halves must not bill each other (#3548, the PR #4033 merge-queue
+ejection).** Holding a slot per attempt means a logical call re-enters the
+harness's own queue on every retry — and a wall-clock deadline then charges that
+self-imposed queueing to the budget it meant to spend asking Cloudflare. The
+ejecting run gave up after "2 attempts over 45136ms", ~44.6s of it queued rather
+than rate-limited: **the budget was never spent, so raising it would have fixed
+nothing.** Two rules follow, and both are pinned by unit tests:
+
+- **A sleeping call is not in flight — including one asleep in start-pacing.**
+  `pace()` runs *before* the slot is acquired, not inside it. Pacing is a rate
+  limit, the semaphore is a concurrency limit; nesting them makes the rate limit
+  eat the concurrency limit.
+- **Throttle queueing is not retry attrition.** `throttle.run` reports what it
+  made a call wait (`onQueued`); the retry deducts it, so `budgetMs` means "up to
+  this much time with CF actually answering 429". Giving up reports the split
+  (`queuedMs` / `backoffMs` / budget spent) and a `reason`, so a repeat reads off
+  the log line instead of being re-derived from the job log.
+
+A `Retry-After` longer than the remaining budget ends the loop **immediately**
+(`retry-after-exceeds-budget`) rather than sleeping out the remainder to buy one
+attempt at the moment it expires — a fast, correctly-named red beats a slow one.
 
 **Build the client through the transport, never by hand.** Use
 `makeIntegrationD1Rest` / `integrationRestLayer`; a per-file
@@ -172,6 +194,15 @@ alchemy's OWN deploy path, which the harness can't wrap. Those need the
 out-of-harness levers named in #3081 (a CI `concurrency:` group; 429 backoff in
 alchemy's deploy path via `pnpm patch`, ADR 0038). This throttle is the
 run-agnostic backoff on the slice the harness owns.
+
+Read the transport's coverage honestly when diagnosing a 429 run: **stage
+create/destroy is the bulk of the CF traffic and none of it goes through this
+transport.** In the PR #4033 ejection the teardown 429s were
+`DELETE /accounts/{id}/flagship/apps/{appId}/flags/{flagKey}` raised inside
+`alchemy`/`@distilled.cloud`, warned as leaked stages — unthrottled, competing
+for the same account bucket the tests then can't get through. The harness
+throttle governs a minority of the calls; a 429 storm is not evidence that its
+knobs are mis-set.
 
 ## Teardown is best-effort — leaked stages are a known class
 

--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -159,9 +159,16 @@ This order also start-paces the retries themselves.
 ejection).** Holding a slot per attempt means a logical call re-enters the
 harness's own queue on every retry — and a wall-clock deadline then charges that
 self-imposed queueing to the budget it meant to spend asking Cloudflare. The
-ejecting run gave up after "2 attempts over 45136ms", ~44.6s of it queued rather
-than rate-limited: **the budget was never spent, so raising it would have fixed
-nothing.** Two rules follow, and both are pinned by unit tests:
+ejecting run gave up after "2 attempts over 45136ms", most of it queued rather
+than rate-limited — CF sent no usable `Retry-After` on this path (`retryAfter:
+Millis 0`, run `29665891972`), and on that premise one backoff at attempt 0 is
+capped at 500ms. The premise is load-bearing: a `Retry-After` is a *floor* and is
+not bounded by that ceiling, so a large one also produces "2 attempts over ~45s"
+and the elapsed numbers alone cannot separate the two. Both sinks are fixed and
+the attrition breakdown now records `retryAfterMs`, so the next occurrence is
+read off the log line rather than inferred. Either way the operative conclusion
+holds: **the budget was never spent, so raising it would have fixed nothing.**
+Three rules follow, and each is pinned by a unit test:
 
 - **A sleeping call is not in flight — including one asleep in start-pacing.**
   `pace()` runs *before* the slot is acquired, not inside it. Pacing is a rate
@@ -172,6 +179,16 @@ nothing.** Two rules follow, and both are pinned by unit tests:
   this much time with CF actually answering 429". Giving up reports the split
   (`queuedMs` / `backoffMs` / budget spent) and a `reason`, so a repeat reads off
   the log line instead of being re-derived from the job log.
+- **Deducting queueing costs a bound, so keep the other one.** Once queueing is
+  uncharged, `budgetMs` no longer limits the call in wall clock — only
+  `maxRetries` times however long the throttle queues does, which at 24 attempts
+  can outlive vitest's 120s `testTimeout` and hand back the opaque "Hook timed
+  out" the named 429 exists to replace. So a hard wall-clock ceiling
+  (`D1_REST_WALL_CLOCK_CEILING_MS`) is held alongside the CF-facing budget, and
+  the `reason` names which bound fired (`wall-clock-ceiling` vs
+  `budget-exhausted`) — a give-up is never ambiguous about what ended it. The
+  guarantee is per logical call: a test making several protected CF calls during
+  a sustained plateau can still exceed `testTimeout`.
 
 A `Retry-After` longer than the remaining budget ends the loop **immediately**
 (`retry-after-exceeds-budget`) rather than sleeping out the remainder to buy one
@@ -183,7 +200,7 @@ attempt at the moment it expires — a fast, correctly-named red beats a slow on
 is the BARE fetch with no retry and no throttle. That opt-in-ness is what red
 `pasaport-ban.test.ts` in run `29665891972` while its wrapped sibling survived
 the same 429 storm, so `_cf-rest-transport.unit.test.ts` now fails closed on any
-integration test file that re-introduces one.
+non-exempt file in the integration directory that re-introduces one.
 
 **Ceiling (why this isn't the whole 429 story):** the throttle is an in-process
 singleton — under `isolate:false` it is shared across files in the same fork, but

--- a/apps/web/tests/integration/_cf-api-throttle.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.ts
@@ -13,6 +13,16 @@
  * concurrency cap. That order is wired in exactly one place, `_cf-rest-transport.ts`; see its
  * docblock for why #3081's original one-throttled-unit-per-logical-call order was inverted (#3548).
  *
+ * **A sleeping call is not in flight — and that binds start-pacing too (#3548).** `pace()` used to
+ * sleep INSIDE the slot, so the start-pacer's own waiting occupied the concurrency cap and the
+ * throttle's throughput collapsed toward one call per `minSpacingMs` per slot. Pacing is a RATE
+ * limit and the semaphore is a CONCURRENCY limit; nesting the two conflates them. `pace()` runs
+ * BEFORE `acquireSlot()`, exactly as backoff sleeps run outside it.
+ *
+ * Both knobs are also honest about their cost: whatever a caller waits here is time the HARNESS
+ * imposed, not time Cloudflare spent rate-limiting it, so `run` reports it through `onQueued` and
+ * the retry deducts it from its CF-facing budget (see `_d1-rest-retry.ts`).
+ *
  * Scope ceiling (deliberate, per #3081's "confined to the integration harness" constraint):
  * the limiter is an in-process singleton, so under `isolate:false` (`vitest.config.ts`) it is
  * shared across every file that runs in the SAME fork and genuinely paces their combined setup
@@ -48,8 +58,13 @@ export interface CfApiThrottleOptions {
 }
 
 export interface CfApiThrottle {
-	/** Run `op` under the concurrency cap + start-pacing; resolves/rejects with `op`'s result. */
-	run<T>(op: () => Promise<T>): Promise<T>;
+	/**
+	 * Run `op` under the start-pacing + concurrency cap; resolves/rejects with `op`'s result.
+	 * `onQueued` is called once, just before `op` starts, with the ms this call spent waiting for
+	 * its paced start and its slot — harness-imposed latency the caller may want to account for
+	 * separately from time Cloudflare kept it waiting.
+	 */
+	run<T>(op: () => Promise<T>, onQueued?: (ms: number) => void): Promise<T>;
 }
 
 /**
@@ -70,13 +85,22 @@ export const createCfApiThrottle = ({
 	// reserves its slot, so staggered runners de-sync instead of firing as one packet.
 	let nextStartFloor = 0;
 
+	// The slot is HANDED OVER on release rather than decremented-then-reacquired: the old
+	// `inFlight--; waiters.shift()?.()` left a window where a fresh caller could synchronously
+	// observe a free slot and take it while the woken waiter also incremented — so `inFlight`
+	// could exceed `maxConcurrent` and the cap silently stopped binding under exactly the
+	// contention it exists for.
 	const acquireSlot = async (): Promise<void> => {
-		if (inFlight >= maxConcurrent) await new Promise<void>((resolve) => waiters.push(resolve));
-		inFlight++;
+		if (inFlight < maxConcurrent) {
+			inFlight++;
+			return;
+		}
+		await new Promise<void>((resolve) => waiters.push(resolve)); // resumed holding the slot
 	};
 	const releaseSlot = (): void => {
-		inFlight--;
-		waiters.shift()?.();
+		const next = waiters.shift();
+		if (next) next();
+		else inFlight--;
 	};
 
 	// Full-jitter start pacing: reserve a start no earlier than `minSpacingMs` past the prior
@@ -93,10 +117,12 @@ export const createCfApiThrottle = ({
 	};
 
 	return {
-		async run<T>(op: () => Promise<T>): Promise<T> {
+		async run<T>(op: () => Promise<T>, onQueued?: (ms: number) => void): Promise<T> {
+			const queuedFrom = now();
+			await pace(); // outside the slot: a call sleeping until its reserved start is not in flight
 			await acquireSlot();
+			onQueued?.(now() - queuedFrom);
 			try {
-				await pace();
 				return await op();
 			} finally {
 				releaseSlot();

--- a/apps/web/tests/integration/_cf-api-throttle.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.ts
@@ -7,9 +7,11 @@
  * Relationship to the existing per-call retry (`cfFetchWithRateLimitRetry`, `_d1-rest-retry.ts`):
  * that wrapper reacts to a 429 AFTER it fires, replaying one call with backoff. This throttle
  * is the complementary PROACTIVE half — it bounds how many CF calls the harness launches at
- * once and paces their starts, so fewer 429s fire in the first place. It COMPOSES AROUND the
- * per-call retry (`throttle.run(() => cfFetchWithRateLimitRetry(send))`), never replacing it —
- * each logical CF call, retries included, counts as one throttled unit.
+ * once and paces their starts, so fewer 429s fire in the first place. The retry composes AROUND
+ * this throttle (`retry(() => throttle.run(send))`), never replacing it — a slot is held per
+ * ATTEMPT and released while a call sleeps in backoff, so a backing-off call never occupies the
+ * concurrency cap. That order is wired in exactly one place, `_cf-rest-transport.ts`; see its
+ * docblock for why #3081's original one-throttled-unit-per-logical-call order was inverted (#3548).
  *
  * Scope ceiling (deliberate, per #3081's "confined to the integration harness" constraint):
  * the limiter is an in-process singleton, so under `isolate:false` (`vitest.config.ts`) it is

--- a/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
@@ -123,3 +123,95 @@ describe("createCfApiThrottle", () => {
 		expect(CF_API_MIN_SPACING_MS).toBeGreaterThanOrEqual(0);
 	});
 });
+
+// #3548 round 2 — the defects PR #4033's merge-queue ejection exposed.
+describe("start-pacing does not consume the concurrency cap", () => {
+	it("lets a call whose paced start has arrived run while another is still waiting for its start", async () => {
+		// `pace()` used to sleep INSIDE the slot, so with one slot the first call's start-pacing
+		// blocked every other call for its whole wait — the rate limiter eating the concurrency
+		// limiter. Here the (never-resolving) pacer must not stop the second call from running.
+		let holdPacing = () => {};
+		const paced = new Promise<void>((r) => {
+			holdPacing = r;
+		});
+		let sleeps = 0;
+		const throttle = createCfApiThrottle({
+			maxConcurrent: 1,
+			minSpacingMs: 100,
+			// The first call's pace-sleep hangs; every later one returns immediately.
+			sleep: () => (sleeps++ === 0 ? paced : Promise.resolve()),
+			now: () => 0,
+			random: () => 0.5,
+		});
+
+		const first = throttle.run(async () => "first");
+		let secondRan = false;
+		const second = throttle.run(async () => {
+			secondRan = true;
+			return "second";
+		});
+		await flush();
+		expect(secondRan).toBe(true); // under the old order this is false and `second` never resolves
+		holdPacing();
+		await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
+	});
+
+	it("reports the queueing it imposed through onQueued", async () => {
+		let clock = 0;
+		const throttle = createCfApiThrottle({
+			maxConcurrent: 10,
+			minSpacingMs: 100,
+			sleep: async (ms) => {
+				clock += ms;
+			},
+			now: () => clock,
+			random: () => 0,
+		});
+		const queued: number[] = [];
+		await throttle.run(
+			async () => {},
+			(ms) => queued.push(ms),
+		);
+		await throttle.run(
+			async () => {},
+			(ms) => queued.push(ms),
+		);
+		expect(queued).toHaveLength(2);
+		expect(queued[0]).toBe(0); // first call starts immediately
+		expect(queued[1]).toBe(100); // second waits one spacing — time the HARNESS imposed, not CF
+	});
+});
+
+describe("the concurrency cap holds under contention (the slot is handed over, not re-raced)", () => {
+	it("does not admit a barging caller into a slot a waiter was just handed", async () => {
+		// The old `inFlight--; waiters.shift()?.()` left a window in which a freshly-arriving call
+		// saw a free slot and took it while the woken waiter also incremented — so `inFlight` drifted
+		// past `maxConcurrent` and the cap stopped binding under exactly the load it exists for.
+		const throttle = createCfApiThrottle({maxConcurrent: 1, minSpacingMs: 0});
+		let active = 0;
+		let peak = 0;
+		const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+		const runs = gates.map((g) =>
+			throttle.run(async () => {
+				active++;
+				peak = Math.max(peak, active);
+				await g.promise;
+				active--;
+			}),
+		);
+		await flush();
+		// Release the holder and, in the SAME tick, start a barging call: it must queue behind the
+		// waiter rather than slip into the released slot.
+		gates[0]?.resolve();
+		const barger = throttle.run(async () => {
+			active++;
+			peak = Math.max(peak, active);
+			active--;
+		});
+		await flush();
+		gates[1]?.resolve();
+		gates[2]?.resolve();
+		await Promise.all([...runs, barger]);
+		expect(peak).toBe(1);
+	});
+});

--- a/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
@@ -182,36 +182,57 @@ describe("start-pacing does not consume the concurrency cap", () => {
 	});
 });
 
-describe("the concurrency cap holds under contention (the slot is handed over, not re-raced)", () => {
-	it("does not admit a barging caller into a slot a waiter was just handed", async () => {
-		// The old `inFlight--; waiters.shift()?.()` left a window in which a freshly-arriving call
-		// saw a free slot and took it while the woken waiter also incremented — so `inFlight` drifted
-		// past `maxConcurrent` and the cap stopped binding under exactly the load it exists for.
-		const throttle = createCfApiThrottle({maxConcurrent: 1, minSpacingMs: 0});
-		let active = 0;
-		let peak = 0;
-		const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
-		const runs = gates.map((g) =>
-			throttle.run(async () => {
-				active++;
-				peak = Math.max(peak, active);
-				await g.promise;
-				active--;
-			}),
-		);
-		await flush();
-		// Release the holder and, in the SAME tick, start a barging call: it must queue behind the
-		// waiter rather than slip into the released slot.
-		gates[0]?.resolve();
-		const barger = throttle.run(async () => {
+/**
+ * Fill `maxConcurrent: 1`, hold it, then release the holder and let a fresh caller barge in
+ * `offset` microtasks later. Returns the peak number of ops running CONCURRENTLY — asserting on
+ * ops actually executing between the gates, not on the private `inFlight` counter, so the test
+ * pins the property the cap exists for rather than an implementation detail.
+ */
+const peakUnderBargeAtOffset = async (offset: number): Promise<number> => {
+	const throttle = createCfApiThrottle({maxConcurrent: 1, minSpacingMs: 0});
+	let active = 0;
+	let peak = 0;
+	const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+	const runs = gates.map((g) =>
+		throttle.run(async () => {
 			active++;
 			peak = Math.max(peak, active);
+			await g.promise;
 			active--;
-		});
-		await flush();
-		gates[1]?.resolve();
-		gates[2]?.resolve();
-		await Promise.all([...runs, barger]);
-		expect(peak).toBe(1);
+		}),
+	);
+	await flush();
+	gates[0]?.resolve();
+	for (let i = 0; i < offset; i++) await Promise.resolve();
+	const barger = throttle.run(async () => {
+		active++;
+		peak = Math.max(peak, active);
+		active--;
+	});
+	await flush();
+	gates[1]?.resolve();
+	gates[2]?.resolve();
+	await Promise.all([...runs, barger]);
+	return peak;
+};
+
+describe("the concurrency cap holds under contention (the slot is handed over, not re-raced)", () => {
+	// The old `inFlight--; waiters.shift()?.()` left a window in which a freshly-arriving call saw
+	// a free slot and took it while the woken waiter also incremented — so `inFlight` drifted past
+	// `maxConcurrent` and the cap stopped binding under exactly the load it exists for.
+	//
+	// SWEEP the arrival offset rather than pinning one number. The window is a few microtasks wide
+	// and sits wherever `run`'s prelude happens to put it (against the pre-fix slot discipline it is
+	// offset 1; a single added `await` anywhere in `run` moves it). A test pinned to one offset
+	// silently stops regressing the moment the prelude shifts — and at offset 0 it never regressed
+	// at all, since the barger reaches `acquireSlot` before the release has run and queues under
+	// both implementations. Sweeping asserts the invariant at every arrival instant instead.
+	it("does not admit a barging caller into a slot a waiter was just handed, at ANY arrival offset", async () => {
+		const violations: Array<{offset: number; peak: number}> = [];
+		for (let offset = 0; offset <= 12; offset++) {
+			const peak = await peakUnderBargeAtOffset(offset);
+			if (peak !== 1) violations.push({offset, peak});
+		}
+		expect(violations).toEqual([]);
 	});
 });

--- a/apps/web/tests/integration/_cf-rest-transport.ts
+++ b/apps/web/tests/integration/_cf-rest-transport.ts
@@ -1,0 +1,59 @@
+/**
+ * The ONE Cloudflare-REST transport every integration-test CF call goes through — proactive
+ * throttle (`_cf-api-throttle.ts`, #3081) composed with reactive 429 retry (`_d1-rest-retry.ts`,
+ * #2915/#3099), plus the Effect layer that carries it into `makeD1Rest` (#3548).
+ *
+ * **Why this module exists: the protection used to be opt-in per call site, so half the harness
+ * bypassed it.** #3099 wrapped the fetch of exactly the two test files that were failing at the
+ * time; every other file kept hand-rolling `Layer.merge(CredentialsFromEnv, FetchHttpClient.layer)`
+ * — the BARE fetch, no retry, no throttle. In run `29665891972` that gap red `pasaport-ban.test.ts`
+ * with a raw `TooManyRequests` off `@distilled.cloud/cloudflare`'s `971` mapping, while its sibling
+ * `pasaport-set-role.test.ts` (added by the very PR that got ejected, and wired to the wrapped
+ * fetch) passed through the same 429 storm. So the fix is not another wrapper: it is making the
+ * protected transport the only one a test can reach. `integrationRestLayer` is that transport, and
+ * `_cf-rest-transport.unit.test.ts` fails closed if a file re-introduces a bare one.
+ *
+ * **Composition order — retry AROUND throttle, deliberately inverting #3081's note.** #3081 wired
+ * `throttle.run(() => retry(send))` so a logical call counts as one throttled unit. That makes the
+ * concurrency cap count a call SLEEPING IN BACKOFF as "in flight": under 429 pressure four backing-off
+ * calls hold all four slots and head-of-line-block every other CF call in the fork — which the longer
+ * wall-clock budget (#3548) would have made far worse. A sleeping call is by definition not in flight,
+ * so the slot is held per ATTEMPT instead: `retry(() => throttle.run(send))`. This also start-paces
+ * the retries themselves, which #3081's order left unpaced — the attempts that most need spreading.
+ */
+
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {makeD1Rest} from "@kampus/d1-rest";
+import {Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {cfApiThrottle} from "./_cf-api-throttle.ts";
+import {
+	cfFetchWithRateLimitRetry,
+	type RateLimitRetryOptions,
+	rateLimitRetryingFetch,
+} from "./_d1-rest-retry.ts";
+
+/** Send one CF REST request under the shared throttle, retrying a 429 for the whole budget. */
+export const cfRestSend = (
+	send: () => Promise<Response>,
+	options: RateLimitRetryOptions = {},
+): Promise<Response> => cfFetchWithRateLimitRetry(() => cfApiThrottle.run(send), options);
+
+/** The throttled + 429-retrying `fetch` the REST transport is built on. */
+export const cfRestFetch: typeof globalThis.fetch = rateLimitRetryingFetch((input, init) =>
+	cfApiThrottle.run(() => fetch(input, init)),
+);
+
+/**
+ * The credentialed REST layer every integration test builds its `makeD1Rest` client from. Replaces
+ * the per-file `Layer.merge(CredentialsFromEnv, FetchHttpClient.layer)` — same credentials, same
+ * transport shape, but the `Fetch` reference is {@link cfRestFetch} rather than the bare one.
+ */
+export const integrationRestLayer = Layer.merge(
+	CredentialsFromEnv,
+	FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, cfRestFetch))),
+);
+
+/** `makeD1Rest` over {@link integrationRestLayer} — the integration analogue of `makeD1RestFromEnv`. */
+export const makeIntegrationD1Rest = (target: {accountId: string; databaseId: string}) =>
+	makeD1Rest({...target, layer: integrationRestLayer});

--- a/apps/web/tests/integration/_cf-rest-transport.ts
+++ b/apps/web/tests/integration/_cf-rest-transport.ts
@@ -20,6 +20,12 @@
  * wall-clock budget (#3548) would have made far worse. A sleeping call is by definition not in flight,
  * so the slot is held per ATTEMPT instead: `retry(() => throttle.run(send))`. This also start-paces
  * the retries themselves, which #3081's order left unpaced — the attempts that most need spreading.
+ *
+ * **The cost of that order is paid here: throttle queueing is not retry attrition.** Re-entering the
+ * throttle per attempt means a logical call sits in the harness's own queue repeatedly, which a
+ * wall-clock deadline then charges to the budget it meant to spend asking Cloudflare (`_d1-rest-retry.ts`
+ * has the measured arithmetic). Wiring `run`'s `onQueued` into the retry's `queued` sink is what
+ * keeps the two halves of the composition from cannibalising each other; the unit test pins it.
  */
 
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
@@ -33,15 +39,20 @@ import {
 	rateLimitRetryingFetch,
 } from "./_d1-rest-retry.ts";
 
-/** Send one CF REST request under the shared throttle, retrying a 429 for the whole budget. */
+/**
+ * Send one CF REST request under the shared throttle, retrying a 429 for the whole budget. The
+ * throttle's own queueing is reported into the retry's `queued` sink, so the budget measures time
+ * CLOUDFLARE spent rate-limiting the call rather than time the harness spent pacing it (#3548).
+ */
 export const cfRestSend = (
 	send: () => Promise<Response>,
 	options: RateLimitRetryOptions = {},
-): Promise<Response> => cfFetchWithRateLimitRetry(() => cfApiThrottle.run(send), options);
+): Promise<Response> =>
+	cfFetchWithRateLimitRetry((queued) => cfApiThrottle.run(send, queued), options);
 
 /** The throttled + 429-retrying `fetch` the REST transport is built on. */
-export const cfRestFetch: typeof globalThis.fetch = rateLimitRetryingFetch((input, init) =>
-	cfApiThrottle.run(() => fetch(input, init)),
+export const cfRestFetch: typeof globalThis.fetch = rateLimitRetryingFetch((input, init, queued) =>
+	cfApiThrottle.run(() => fetch(input, init), queued),
 );
 
 /**

--- a/apps/web/tests/integration/_cf-rest-transport.unit.test.ts
+++ b/apps/web/tests/integration/_cf-rest-transport.unit.test.ts
@@ -8,7 +8,11 @@ import {readdirSync, readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {createCfApiThrottle} from "./_cf-api-throttle.ts";
-import {cfFetchWithRateLimitRetry} from "./_d1-rest-retry.ts";
+import {
+	budgetSpentMs,
+	cfFetchWithRateLimitRetry,
+	type RateLimitAttrition,
+} from "./_d1-rest-retry.ts";
 
 const HERE = fileURLToPath(new URL(".", import.meta.url).href);
 
@@ -36,6 +40,45 @@ describe("retry composes AROUND the throttle (a slot is held per attempt, not pe
 		const [firstRes, secondRes] = await Promise.all([first, second]);
 		expect(firstRes.status).toBe(429);
 		expect(secondRes.status).toBe(200);
+	});
+
+	// The cost of holding a slot per ATTEMPT: a logical call re-enters the harness's queue on every
+	// retry. PR #4033's merge-queue ejection was that cost billed to the wrong account — "2 attempts
+	// over 45136ms of retry budget", ~44.6s of which was throttle queueing, so the CF-facing budget
+	// expired having asked Cloudflare twice. The throttle's `onQueued` must reach the retry's sink.
+	it("deducts the throttle's own queueing from the CF-facing retry budget", async () => {
+		let clock = 0;
+		const throttle = createCfApiThrottle({
+			maxConcurrent: 10,
+			minSpacingMs: 1000, // each start is paced a full second apart — pure harness-imposed wait
+			sleep: async (ms) => {
+				clock += ms;
+			},
+			now: () => clock,
+			random: () => 0,
+		});
+		const attrition: RateLimitAttrition[] = [];
+		const res = await cfFetchWithRateLimitRetry(
+			(queued) => throttle.run(async () => new Response("429", {status: 429}), queued),
+			{
+				budgetMs: 2000,
+				baseDelayMs: 10,
+				maxRetries: 3,
+				random: () => 0,
+				now: () => clock,
+				sleep: async (ms) => {
+					clock += ms;
+				},
+				onGiveUp: (a) => attrition.push(a),
+			},
+		);
+		expect(res.status).toBe(429);
+		// Without the deduction the 1000ms-per-attempt pacing alone exhausts a 2000ms budget in two
+		// sends; with it, the runaway guard is what stops the loop and the budget is barely touched.
+		expect(attrition[0]?.reason).toBe("max-retries");
+		expect(attrition[0]?.attempts).toBe(4);
+		expect(attrition[0]?.queuedMs).toBeGreaterThanOrEqual(3000);
+		expect(budgetSpentMs(attrition[0] as RateLimitAttrition)).toBeLessThan(2000);
 	});
 });
 

--- a/apps/web/tests/integration/_cf-rest-transport.unit.test.ts
+++ b/apps/web/tests/integration/_cf-rest-transport.unit.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Pins the two properties that make `_cf-rest-transport.ts` the ONE CF REST path (#3548):
+ * the composition releases its throttle slot while backing off, and no integration test file
+ * can quietly re-introduce a bare, unprotected REST client.
+ */
+
+import {readdirSync, readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {createCfApiThrottle} from "./_cf-api-throttle.ts";
+import {cfFetchWithRateLimitRetry} from "./_d1-rest-retry.ts";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url).href);
+
+describe("retry composes AROUND the throttle (a slot is held per attempt, not per logical call)", () => {
+	it("lets another call through while a 429 is backing off", async () => {
+		// Under #3081's original order — `throttle.run(() => retry(send))` — the backing-off call
+		// keeps the only slot, so `second` never starts, `releaseSecond` is never called, and this
+		// test HANGS to its timeout. Completing is the assertion; the expects below just confirm
+		// neither call was corrupted on the way.
+		const throttle = createCfApiThrottle({maxConcurrent: 1, minSpacingMs: 0});
+		let releaseSecond = () => {};
+		const secondRan = new Promise<void>((r) => {
+			releaseSecond = r;
+		});
+
+		const first = cfFetchWithRateLimitRetry(
+			() => throttle.run(async () => new Response("429", {status: 429})),
+			{maxRetries: 2, sleep: () => secondRan, random: () => 0, now: () => 0, onGiveUp: () => {}},
+		);
+		const second = throttle.run(async () => {
+			releaseSecond();
+			return new Response("ok", {status: 200});
+		});
+
+		const [firstRes, secondRes] = await Promise.all([first, second]);
+		expect(firstRes.status).toBe(429);
+		expect(secondRes.status).toBe(200);
+	});
+});
+
+// The #3548 bypass was structural, not a typo: #3099 wrapped the two files that happened to be
+// failing, leaving every other file on `Layer.merge(CredentialsFromEnv, FetchHttpClient.layer)` —
+// the bare fetch, no retry, no throttle. `pasaport-ban.test.ts` then red on a raw
+// `TooManyRequests` while its wrapped sibling sailed through the same 429 storm. Converting the
+// files fixes today; this scan is what keeps the next file from re-opening the hole.
+describe("no integration test builds its own unprotected CF REST client", () => {
+	// This file and `_d1-rest-retry.unit.test.ts` exercise the bare primitives on purpose.
+	const EXEMPT = new Set(["_cf-rest-transport.unit.test.ts", "_d1-rest-retry.unit.test.ts"]);
+	const BARE = [
+		[/FetchHttpClient\.layer/, "hand-rolled REST layer — use `integrationRestLayer`"],
+		[/makeD1RestFromEnv/, "bare env layer — use `makeIntegrationD1Rest`"],
+	] as const;
+
+	const files = readdirSync(HERE).filter((f) => f.endsWith(".test.ts") && !EXEMPT.has(f));
+
+	it("scans a non-empty set of integration test files (fail closed on zero scope, ADR 0092)", () => {
+		expect(files.length).toBeGreaterThan(0);
+	});
+
+	it("finds no bare CF REST client in any of them", () => {
+		const offenders = files.flatMap((file) => {
+			const src = readFileSync(`${HERE}${file}`, "utf8");
+			return BARE.filter(([re]) => re.test(src)).map(([, why]) => `${file}: ${why}`);
+		});
+		expect(offenders).toEqual([]);
+	});
+});

--- a/apps/web/tests/integration/_cf-rest-transport.unit.test.ts
+++ b/apps/web/tests/integration/_cf-rest-transport.unit.test.ts
@@ -1,7 +1,7 @@
 /**
  * Pins the two properties that make `_cf-rest-transport.ts` the ONE CF REST path (#3548):
- * the composition releases its throttle slot while backing off, and no integration test file
- * can quietly re-introduce a bare, unprotected REST client.
+ * the composition releases its throttle slot while backing off, and no file in the integration
+ * directory can quietly re-introduce a bare, unprotected REST client.
  */
 
 import {readdirSync, readFileSync} from "node:fs";
@@ -44,17 +44,27 @@ describe("retry composes AROUND the throttle (a slot is held per attempt, not pe
 // the bare fetch, no retry, no throttle. `pasaport-ban.test.ts` then red on a raw
 // `TooManyRequests` while its wrapped sibling sailed through the same 429 storm. Converting the
 // files fixes today; this scan is what keeps the next file from re-opening the hole.
-describe("no integration test builds its own unprotected CF REST client", () => {
-	// This file and `_d1-rest-retry.unit.test.ts` exercise the bare primitives on purpose.
-	const EXEMPT = new Set(["_cf-rest-transport.unit.test.ts", "_d1-rest-retry.unit.test.ts"]);
+describe("no integration file builds its own unprotected CF REST client", () => {
+	// `_cf-rest-transport.ts` IS the protected transport (it owns the one legitimate
+	// `FetchHttpClient.layer`); this file and `_d1-rest-retry.unit.test.ts` exercise the bare
+	// primitives on purpose.
+	const EXEMPT = new Set([
+		"_cf-rest-transport.ts",
+		"_cf-rest-transport.unit.test.ts",
+		"_d1-rest-retry.unit.test.ts",
+	]);
 	const BARE = [
 		[/FetchHttpClient\.layer/, "hand-rolled REST layer — use `integrationRestLayer`"],
-		[/makeD1RestFromEnv/, "bare env layer — use `makeIntegrationD1Rest`"],
+		// Call-shaped on purpose: `_harness.ts` names `makeD1RestFromEnv` in prose, and a scan
+		// that reds on a comment is a scan people delete.
+		[/makeD1RestFromEnv\s*\(/, "bare env layer — use `makeIntegrationD1Rest`"],
 	] as const;
 
-	const files = readdirSync(HERE).filter((f) => f.endsWith(".test.ts") && !EXEMPT.has(f));
+	// Every `.ts` in the directory, not just `*.test.ts`: a non-test helper that grew its own
+	// client would reopen the bypass just as wide, and unscanned.
+	const files = readdirSync(HERE).filter((f) => f.endsWith(".ts") && !EXEMPT.has(f));
 
-	it("scans a non-empty set of integration test files (fail closed on zero scope, ADR 0092)", () => {
+	it("scans a non-empty set of integration files (fail closed on zero scope, ADR 0092)", () => {
 		expect(files.length).toBeGreaterThan(0);
 	});
 

--- a/apps/web/tests/integration/_d1-rest-retry.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.ts
@@ -14,9 +14,19 @@
  * out in under a second. Measured in the ejecting run `29665891972`, account-global 429
  * pressure ran from 23:52:18 to 23:57:08 — a ~290s plateau, two orders of magnitude past that
  * budget — so the shipped retry ran, exhausted, and red five bystander suites anyway. The
- * budget is therefore a DEADLINE (`budgetMs`): keep re-sending while wall-clock budget remains,
- * with the attempt cap demoted to a runaway guard. Full jitter is retained per-wait (it is what
- * de-syncs the parallel stages), it just no longer decides when to give up.
+ * budget is therefore a DEADLINE (`budgetMs`): keep re-sending while budget remains, with the
+ * attempt cap demoted to a runaway guard. Full jitter is retained per-wait (it is what de-syncs
+ * the parallel stages), it just no longer decides when to give up.
+ *
+ * **The deadline measures time CLOUDFLARE kept us waiting, not wall clock (#3548 round 2).** The
+ * `merge_group` ejection of PR #4033 gave up "2 attempts over 45136ms of retry budget" — and 2
+ * attempts is the tell. One backoff sleep at attempt 0 is capped at `baseDelayMs` (500ms), so
+ * ~44.6s of that 45s was spent INSIDE the two sends, i.e. queued in the harness's own throttle,
+ * not being rate-limited by Cloudflare. A wall-clock deadline therefore charged the harness's
+ * self-imposed pacing to the budget it meant to spend asking CF, and the loop expired having
+ * asked twice. So `send` is handed a `queued` sink, the throttle reports what it made the call
+ * wait, and that time is deducted: `budgetMs` now means "up to this much time with CF actually
+ * answering 429". Raising the number would not have fixed this — the budget was never spent.
  *
  * Scoped to 429 ONLY: a real SQL error surfaces as a 200-with-`errors[]` (classified by
  * `runD1Query`), and a genuine API error as a non-429 4xx/5xx — neither is a 429, so neither is
@@ -31,10 +41,13 @@
 export const CF_RATE_LIMIT_STATUS = 429;
 
 /**
- * Wall-clock retry budget per logical CF REST call. Sized against the two live constraints:
- * above the ~8s the old attempt-count budget averaged, and comfortably under `vitest.config.ts`'s
- * 120s `testTimeout` — a budget that outran the test timeout would trade a named 429 for the
- * opaque "Hook timed out" shape (the failure mode `_request-stall.ts` documents).
+ * Retry budget per logical CF REST call, counted over time CF spent answering 429 (harness
+ * throttle queueing is deducted). Sized against the two live constraints: above the ~8s the old
+ * attempt-count budget averaged, and comfortably under `vitest.config.ts`'s 120s `testTimeout` —
+ * a budget that outran the test timeout would trade a named 429 for the opaque "Hook timed out"
+ * shape (the failure mode `_request-stall.ts` documents). Deliberately NOT raised for #4033's
+ * ejection: that run spent 1.2% of this budget on Cloudflare, so the number was never the binding
+ * constraint, and no sane CI budget outlasts a ~290s account-wide plateau anyway.
  */
 export const D1_REST_BUDGET_MS = 45_000;
 /** Runaway guard only — the deadline above is what normally ends the loop. */
@@ -45,6 +58,18 @@ export const D1_REST_MAX_DELAY_MS = 8_000;
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * Why the retry loop stopped. Round 1 of #3548 reported *that* a call gave up; it could not say
+ * *where the budget went*, which is why PR #4033's ejection needed the numbers re-derived by hand.
+ */
+export type GiveUpReason =
+	/** The CF-facing deadline ran out — CF really did stay 429 for the whole budget. */
+	| "budget-exhausted"
+	/** CF asked for a `Retry-After` longer than the budget left; waiting it out is CI time burnt for nothing. */
+	| "retry-after-exceeds-budget"
+	/** The runaway guard tripped — many cheap attempts, budget still unspent. */
+	| "max-retries";
+
 /** What a call spent before giving up — the payload that makes an exhausted 429 diagnosable. */
 export interface RateLimitAttrition {
 	/** Caller-supplied name of the round-trip (method + path), for the log line. */
@@ -53,7 +78,26 @@ export interface RateLimitAttrition {
 	readonly attempts: number;
 	/** Wall-clock ms from the first send to giving up. */
 	readonly elapsedMs: number;
+	/** Of {@link elapsedMs}, ms spent queued in the harness's OWN throttle — not charged to the budget. */
+	readonly queuedMs: number;
+	/** Of {@link elapsedMs}, ms slept in 429 backoff. */
+	readonly backoffMs: number;
+	/** The CF-facing budget this call was allowed, for reading `elapsedMs - queuedMs` against. */
+	readonly budgetMs: number;
+	readonly reason: GiveUpReason;
+	/** The last usable `Retry-After` CF sent, in ms; absent when CF sent none (as on the D1 path). */
+	readonly retryAfterMs?: number | undefined;
 }
+
+/** The CF-facing slice of the elapsed time — what {@link RateLimitAttrition.budgetMs} bounds. */
+export const budgetSpentMs = (a: RateLimitAttrition): number => a.elapsedMs - a.queuedMs;
+
+/** Human-readable attrition breakdown, shared by the warn line and {@link CfRateLimitError}. */
+const attritionSummary = (a: RateLimitAttrition): string =>
+	`${a.attempts} attempt${a.attempts === 1 ? "" : "s"} (${a.reason}) — ` +
+	`${budgetSpentMs(a)}ms of the ${a.budgetMs}ms CF-facing retry budget spent over ${a.elapsedMs}ms ` +
+	`wall clock (${a.queuedMs}ms queued in the harness's own throttle, ${a.backoffMs}ms in backoff)` +
+	(a.retryAfterMs === undefined ? "" : `; CF last asked for Retry-After ${a.retryAfterMs}ms`);
 
 /**
  * A CF REST call that stayed rate-limited for its whole budget, carrying WHICH call it was and
@@ -68,17 +112,18 @@ export class CfRateLimitError extends Error {
 	readonly attempts: number;
 	readonly elapsedMs: number;
 	readonly body: string;
+	readonly attrition: RateLimitAttrition;
 	constructor(method: string, path: string, attrition: RateLimitAttrition, body: string) {
 		super(
 			`Cloudflare API ${method} ${path} rate-limited (HTTP 429, code 971): gave up after ` +
-				`${attrition.attempts} attempt${attrition.attempts === 1 ? "" : "s"} over ` +
-				`${attrition.elapsedMs}ms of retry budget — ${body}`,
+				`${attritionSummary(attrition)} — ${body}`,
 		);
 		this.name = "CfRateLimitError";
 		this.method = method;
 		this.path = path;
 		this.attempts = attrition.attempts;
 		this.elapsedMs = attrition.elapsedMs;
+		this.attrition = attrition;
 		this.body = body;
 	}
 }
@@ -110,10 +155,10 @@ export interface RateLimitRetryOptions {
 	now?: () => number;
 }
 
-const warnGiveUp = ({label, attempts, elapsedMs}: RateLimitAttrition): void => {
+const warnGiveUp = (attrition: RateLimitAttrition): void => {
 	console.warn(
-		`[integration] CF rate-limit (HTTP 429, code 971) not cleared: ${label} — ` +
-			`${attempts} attempt${attempts === 1 ? "" : "s"} over ${elapsedMs}ms of retry budget (#3548)`,
+		`[integration] CF rate-limit (HTTP 429, code 971) not cleared: ${attrition.label} — ` +
+			`${attritionSummary(attrition)} (#3548)`,
 	);
 };
 
@@ -133,12 +178,19 @@ const retryAfterMs = (res: Response, nowMs: number): number | undefined => {
 };
 
 /**
- * Re-send `send()` while it answers HTTP 429, until the wall-clock budget is spent. Returns the
+ * One attempt at the round-trip. `queued` is the sink through which a transport reports ms it made
+ * this attempt wait before reaching Cloudflare (throttle pacing + slot contention); that time is
+ * deducted from the budget, because it is the harness rate-limiting itself, not CF doing it.
+ */
+export type CfSend = (queued: (ms: number) => void) => Promise<Response>;
+
+/**
+ * Re-send `send()` while it answers HTTP 429, until the CF-facing budget is spent. Returns the
  * first non-429 `Response` (a success OR a real error the caller classifies), or the final 429 if
  * the budget ran out — it never swallows a real failure and never throws of its own accord.
  */
 export const cfFetchWithRateLimitRetry = async (
-	send: () => Promise<Response>,
+	send: CfSend,
 	{
 		budgetMs = D1_REST_BUDGET_MS,
 		maxRetries = D1_REST_MAX_RETRIES,
@@ -152,24 +204,56 @@ export const cfFetchWithRateLimitRetry = async (
 	}: RateLimitRetryOptions = {},
 ): Promise<Response> => {
 	const startedAt = now();
+	let queuedMs = 0;
+	let backoffMs = 0;
+	let asked: number | undefined;
+	let reason: GiveUpReason = "budget-exhausted";
+	const queued = (ms: number): void => {
+		queuedMs += ms;
+	};
 	let attempts = 1;
-	let res = await send();
+	let res = await send(queued);
 	for (let attempt = 0; res.status === CF_RATE_LIMIT_STATUS; attempt++) {
-		const remaining = budgetMs - (now() - startedAt);
-		if (remaining <= 0 || attempt >= maxRetries) break;
+		// Harness-imposed queueing is deducted: the budget bounds how long CF is allowed to keep
+		// answering 429, not how long our own throttle made the call wait for a slot (#3548).
+		const remaining = budgetMs - (now() - startedAt - queuedMs);
+		if (remaining <= 0) break;
+		if (attempt >= maxRetries) {
+			reason = "max-retries";
+			break;
+		}
+		const askedNow = retryAfterMs(res, now());
+		if (askedNow !== undefined) asked = askedNow;
+		// CF asking for longer than the budget left is a decided answer, not something to wait out:
+		// sleeping the remainder to buy one doomed final attempt spends CI time for near-zero odds.
+		// Give up now, with `retry-after-exceeds-budget` naming why the run went red fast.
+		if (askedNow !== undefined && askedNow > remaining) {
+			reason = "retry-after-exceeds-budget";
+			break;
+		}
 		// Full-jitter backoff: the parallel stages that tripped the shared rate limit must not
 		// re-sync into a thundering herd on a fixed delay, so spread each retry uniformly over
 		// [0, ceil). A CF-supplied `Retry-After` is a floor on that — never wait less than the
 		// origin asked. Both are clamped to what's left of the budget so the deadline is hard.
 		const ceil = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
-		const wait = Math.max(Math.floor(random() * ceil), retryAfterMs(res, now()) ?? 0);
+		const wait = Math.min(Math.max(Math.floor(random() * ceil), askedNow ?? 0), remaining);
 		await res.body?.cancel().catch(() => {}); // release the discarded 429 body before re-sending
-		await sleep(Math.min(wait, remaining));
-		res = await send();
+		await sleep(wait);
+		backoffMs += wait;
+		res = await send(queued);
 		attempts++;
 	}
 	if (res.status === CF_RATE_LIMIT_STATUS) {
-		onGiveUp({label, attempts, elapsedMs: now() - startedAt});
+		onGiveUp({
+			label,
+			attempts,
+			elapsedMs: now() - startedAt,
+			queuedMs,
+			backoffMs,
+			budgetMs,
+			reason,
+			retryAfterMs: asked,
+		});
 	}
 	return res;
 };
@@ -184,12 +268,19 @@ export const cfFetchWithRateLimitRetry = async (
  * BEFORE `queryDatabase` maps a settled 429 body to a thrown `TooManyRequests`. One seam covers
  * every data-plane call, the polled and the direct reads alike (#3099).
  */
+export type QueueReportingFetch = (
+	input: Parameters<typeof globalThis.fetch>[0],
+	init: Parameters<typeof globalThis.fetch>[1],
+	/** See {@link CfSend} — a throttled base reports its queueing here so the budget can deduct it. */
+	queued: (ms: number) => void,
+) => Promise<Response>;
+
 export const rateLimitRetryingFetch = (
-	base: typeof globalThis.fetch,
+	base: QueueReportingFetch,
 	options: RateLimitRetryOptions = {},
 ): typeof globalThis.fetch =>
 	((input: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1]) =>
-		cfFetchWithRateLimitRetry(() => base(input, init), {
+		cfFetchWithRateLimitRetry((queued) => base(input, init, queued), {
 			label: fetchLabel(input, init),
 			...options,
 		})) as typeof globalThis.fetch;

--- a/apps/web/tests/integration/_d1-rest-retry.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.ts
@@ -19,14 +19,20 @@
  * the parallel stages), it just no longer decides when to give up.
  *
  * **The deadline measures time CLOUDFLARE kept us waiting, not wall clock (#3548 round 2).** The
- * `merge_group` ejection of PR #4033 gave up "2 attempts over 45136ms of retry budget" — and 2
- * attempts is the tell. One backoff sleep at attempt 0 is capped at `baseDelayMs` (500ms), so
- * ~44.6s of that 45s was spent INSIDE the two sends, i.e. queued in the harness's own throttle,
- * not being rate-limited by Cloudflare. A wall-clock deadline therefore charged the harness's
- * self-imposed pacing to the budget it meant to spend asking CF, and the loop expired having
- * asked twice. So `send` is handed a `queued` sink, the throttle reports what it made the call
- * wait, and that time is deducted: `budgetMs` now means "up to this much time with CF actually
- * answering 429". Raising the number would not have fixed this — the budget was never spent.
+ * `merge_group` ejection of PR #4033 gave up "2 attempts over 45136ms of retry budget" (four such
+ * give-ups, all 2 attempts, 45046–45195ms) — and 2 attempts is the tell. One backoff sleep at
+ * attempt 0 is capped at `baseDelayMs` (500ms) PROVIDED CF sent no `Retry-After`, which is a floor
+ * on the wait and is not bounded by that ceiling. CF sent none on this path (`retryAfter: Millis 0`,
+ * run `29665891972`); on that premise ~44.6s of the 45s was spent INSIDE the two sends, i.e. queued
+ * in the harness's own throttle, not being rate-limited by Cloudflare. The premise is load-bearing
+ * and the give-up line did not record it for the ejecting run: a large `Retry-After` also yields
+ * 2 attempts over ~45s, so the elapsed numbers alone do not separate the two. Both sinks are fixed,
+ * and the attrition breakdown below now records `retryAfterMs` so the next occurrence is read off
+ * the log line instead of re-derived. A wall-clock deadline charged the harness's self-imposed
+ * pacing to the budget it meant to spend asking CF, and the loop expired having asked twice. So
+ * `send` is handed a `queued` sink, the throttle reports what it made the call wait, and that time
+ * is deducted: `budgetMs` now means "up to this much time with CF actually answering 429". Raising
+ * the number would not have fixed this — the budget was never spent.
  *
  * Scoped to 429 ONLY: a real SQL error surfaces as a 200-with-`errors[]` (classified by
  * `runD1Query`), and a genuine API error as a non-429 4xx/5xx — neither is a 429, so neither is
@@ -42,14 +48,31 @@ export const CF_RATE_LIMIT_STATUS = 429;
 
 /**
  * Retry budget per logical CF REST call, counted over time CF spent answering 429 (harness
- * throttle queueing is deducted). Sized against the two live constraints: above the ~8s the old
- * attempt-count budget averaged, and comfortably under `vitest.config.ts`'s 120s `testTimeout` —
- * a budget that outran the test timeout would trade a named 429 for the opaque "Hook timed out"
- * shape (the failure mode `_request-stall.ts` documents). Deliberately NOT raised for #4033's
- * ejection: that run spent 1.2% of this budget on Cloudflare, so the number was never the binding
- * constraint, and no sane CI budget outlasts a ~290s account-wide plateau anyway.
+ * throttle queueing is deducted). Sized above the ~8s the old attempt-count budget averaged.
+ * Because queueing is no longer charged here, this number alone no longer bounds the call in wall
+ * clock — {@link D1_REST_WALL_CLOCK_CEILING_MS} is what keeps it under `vitest.config.ts`'s 120s
+ * `testTimeout`, i.e. what stops a named 429 becoming the opaque "Hook timed out" shape (the
+ * failure mode `_request-stall.ts` documents). Deliberately NOT raised for #4033's ejection: that
+ * run spent 1.2% of this budget on Cloudflare, so the number was never the binding constraint, and
+ * no sane CI budget outlasts a ~290s account-wide plateau anyway.
  */
 export const D1_REST_BUDGET_MS = 45_000;
+/**
+ * Hard wall-clock ceiling on ONE logical call, held alongside the CF-facing budget above.
+ *
+ * Deducting `queuedMs` bought CF its full budget back, but it also removed the wall-clock bound the
+ * sizing rationale leaned on: with queueing uncharged, the loop's only remaining wall-clock limit
+ * was `maxRetries` times however long the throttle queued each attempt — 24 attempts at even 5s of
+ * queueing is 120s, exactly the opaque "Hook timed out" the named 429 exists to replace. So the two
+ * bounds are kept as belt and braces: CF gets {@link D1_REST_BUDGET_MS} of genuine asking, and the
+ * call still cannot outlive `vitest.config.ts`'s 120s `testTimeout`. {@link GiveUpReason} names
+ * which one fired, so a give-up is never ambiguous about the bound that ended it.
+ *
+ * The guarantee is per logical call, not per test: a test making several protected CF calls during
+ * a sustained plateau can still exceed `testTimeout`. That limit predates this ceiling and is
+ * stated in `.patterns/alchemy-test-harness.md` rather than claimed away here.
+ */
+export const D1_REST_WALL_CLOCK_CEILING_MS = 90_000;
 /** Runaway guard only — the deadline above is what normally ends the loop. */
 export const D1_REST_MAX_RETRIES = 24;
 export const D1_REST_BASE_DELAY_MS = 500;
@@ -68,7 +91,9 @@ export type GiveUpReason =
 	/** CF asked for a `Retry-After` longer than the budget left; waiting it out is CI time burnt for nothing. */
 	| "retry-after-exceeds-budget"
 	/** The runaway guard tripped — many cheap attempts, budget still unspent. */
-	| "max-retries";
+	| "max-retries"
+	/** Wall clock ran out while the CF-facing budget was still unspent — i.e. we were queueing, not rate-limited. */
+	| "wall-clock-ceiling";
 
 /** What a call spent before giving up — the payload that makes an exhausted 429 diagnosable. */
 export interface RateLimitAttrition {
@@ -131,8 +156,10 @@ export class CfRateLimitError extends Error {
 export const isCfRateLimit = (e: unknown): e is CfRateLimitError => e instanceof CfRateLimitError;
 
 export interface RateLimitRetryOptions {
-	/** Wall-clock retry budget in ms (default {@link D1_REST_BUDGET_MS}); 0 disables retrying. */
+	/** CF-facing retry budget in ms (default {@link D1_REST_BUDGET_MS}); 0 disables retrying. */
 	budgetMs?: number;
+	/** Hard wall-clock ceiling on the whole call, ms (default {@link D1_REST_WALL_CLOCK_CEILING_MS}). */
+	wallClockCeilingMs?: number;
 	/** Runaway cap on retries AFTER the first attempt (default {@link D1_REST_MAX_RETRIES}). */
 	maxRetries?: number;
 	/** Base of the exponential backoff, in ms (default 500). */
@@ -193,6 +220,7 @@ export const cfFetchWithRateLimitRetry = async (
 	send: CfSend,
 	{
 		budgetMs = D1_REST_BUDGET_MS,
+		wallClockCeilingMs = D1_REST_WALL_CLOCK_CEILING_MS,
 		maxRetries = D1_REST_MAX_RETRIES,
 		baseDelayMs = D1_REST_BASE_DELAY_MS,
 		maxDelayMs = D1_REST_MAX_DELAY_MS,
@@ -216,8 +244,17 @@ export const cfFetchWithRateLimitRetry = async (
 	for (let attempt = 0; res.status === CF_RATE_LIMIT_STATUS; attempt++) {
 		// Harness-imposed queueing is deducted: the budget bounds how long CF is allowed to keep
 		// answering 429, not how long our own throttle made the call wait for a slot (#3548).
-		const remaining = budgetMs - (now() - startedAt - queuedMs);
+		const elapsed = now() - startedAt;
+		const remaining = budgetMs - (elapsed - queuedMs);
 		if (remaining <= 0) break;
+		// The other half of that deduction: with queueing uncharged, only this bounds the call in
+		// wall clock (see {@link D1_REST_WALL_CLOCK_CEILING_MS}). Checked after the CF-facing budget
+		// so a genuine 429 exhaustion keeps reporting `budget-exhausted`.
+		const wallRemaining = wallClockCeilingMs - elapsed;
+		if (wallRemaining <= 0) {
+			reason = "wall-clock-ceiling";
+			break;
+		}
 		if (attempt >= maxRetries) {
 			reason = "max-retries";
 			break;
@@ -234,9 +271,14 @@ export const cfFetchWithRateLimitRetry = async (
 		// Full-jitter backoff: the parallel stages that tripped the shared rate limit must not
 		// re-sync into a thundering herd on a fixed delay, so spread each retry uniformly over
 		// [0, ceil). A CF-supplied `Retry-After` is a floor on that — never wait less than the
-		// origin asked. Both are clamped to what's left of the budget so the deadline is hard.
+		// origin asked. Both are clamped to what's left of EITHER bound, so each deadline is hard
+		// with overshoot bounded by one in-flight send.
 		const ceil = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
-		const wait = Math.min(Math.max(Math.floor(random() * ceil), askedNow ?? 0), remaining);
+		const wait = Math.min(
+			Math.max(Math.floor(random() * ceil), askedNow ?? 0),
+			remaining,
+			wallRemaining,
+		);
 		await res.body?.cancel().catch(() => {}); // release the discarded 429 body before re-sending
 		await sleep(wait);
 		backoffMs += wait;

--- a/apps/web/tests/integration/_d1-rest-retry.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.ts
@@ -1,82 +1,206 @@
 /**
- * Bounded retry for the setup-only D1 REST path against a transient CF rate-limit (HTTP 429).
+ * Bounded retry for the integration harness's Cloudflare D1 REST path against a transient
+ * rate-limit (HTTP 429, error code 971 "TooManyRequests").
  *
  * The per-file-stage integration model (ADR 0082) hammers ONE Cloudflare account's D1
- * control-plane REST (`/d1/database/<id>/query`) from ~24 parallel stages. On a `merge_group`
- * batch the combined load trips the account rate limit — HTTP 429, error code 971
- * "TooManyRequests" — and a setup-only `execD1`/`setLastActivityAt` (`_harness.ts`) then throws,
- * reddening `integration` on the batched ref and evicting clean bystander PRs (#2915). A 429 is
- * the CF gateway REJECTING the request before it executes — no partial write — so replay is safe
- * by construction; the same class is already treated transient-retryable at the DEPLOY layer
- * (`_deploy-transient.ts`, `TooManyRequests`). This is the data-plane-setup counterpart.
+ * control-plane REST (`/d1/database/<id>/query`) from ~24 parallel stages, and several
+ * `merge_group` runs overlap on that one account. A 429 is the CF gateway REJECTING the
+ * request before it executes — no partial write — so replay is safe by construction; the same
+ * class is already treated transient-retryable at the DEPLOY layer (`_deploy-transient.ts`).
+ *
+ * **The budget is wall-clock, not an attempt count (#3548).** #2915 sized this as "5 retries
+ * with full-jitter backoff", which makes the real budget a RANDOM VARIABLE: each wait is
+ * uniform over `[0, base·2^attempt)`, so five retries average 7.75s of waiting but can burn
+ * out in under a second. Measured in the ejecting run `29665891972`, account-global 429
+ * pressure ran from 23:52:18 to 23:57:08 — a ~290s plateau, two orders of magnitude past that
+ * budget — so the shipped retry ran, exhausted, and red five bystander suites anyway. The
+ * budget is therefore a DEADLINE (`budgetMs`): keep re-sending while wall-clock budget remains,
+ * with the attempt cap demoted to a runaway guard. Full jitter is retained per-wait (it is what
+ * de-syncs the parallel stages), it just no longer decides when to give up.
  *
  * Scoped to 429 ONLY: a real SQL error surfaces as a 200-with-`errors[]` (classified by
  * `runD1Query`), and a genuine API error as a non-429 4xx/5xx — neither is a 429, so neither is
- * retried and a real failure still surfaces at once. A pure leaf (injectable `send`/`sleep`/
- * `random`, no `fetch`/creds dependency) so the retry logic is unit-testable offline.
+ * retried and a real failure still surfaces at once, undelayed. Exhaustion returns the final
+ * 429 for the caller to raise; this wrapper never converts a failure into a success.
+ *
+ * A pure leaf (injectable `send`/`sleep`/`random`/`now`, no `fetch`/creds dependency) so the
+ * retry logic is unit-testable offline. The throttle+retry COMPOSITION lives in one place,
+ * `_cf-rest-transport.ts` — not here.
  */
 
 export const CF_RATE_LIMIT_STATUS = 429;
-export const D1_REST_MAX_RETRIES = 5;
+
+/**
+ * Wall-clock retry budget per logical CF REST call. Sized against the two live constraints:
+ * above the ~8s the old attempt-count budget averaged, and comfortably under `vitest.config.ts`'s
+ * 120s `testTimeout` — a budget that outran the test timeout would trade a named 429 for the
+ * opaque "Hook timed out" shape (the failure mode `_request-stall.ts` documents).
+ */
+export const D1_REST_BUDGET_MS = 45_000;
+/** Runaway guard only — the deadline above is what normally ends the loop. */
+export const D1_REST_MAX_RETRIES = 24;
 export const D1_REST_BASE_DELAY_MS = 500;
+/** Ceiling on a single backoff wait, so one long wait can't swallow the whole budget. */
+export const D1_REST_MAX_DELAY_MS = 8_000;
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+/** What a call spent before giving up — the payload that makes an exhausted 429 diagnosable. */
+export interface RateLimitAttrition {
+	/** Caller-supplied name of the round-trip (method + path), for the log line. */
+	readonly label: string;
+	/** Total sends, including the first attempt. */
+	readonly attempts: number;
+	/** Wall-clock ms from the first send to giving up. */
+	readonly elapsedMs: number;
+}
+
+/**
+ * A CF REST call that stayed rate-limited for its whole budget, carrying WHICH call it was and
+ * what it spent. Thrown in place of a bare "failed: 429 <body>" so the next occurrence names the
+ * rate-limited round-trip and its attrition instead of being re-diagnosed from scratch (#3548,
+ * the same attribution `RequestStallError` gives the worker-HTTP stall path).
+ */
+export class CfRateLimitError extends Error {
+	readonly _tag = "CfRateLimit";
+	readonly method: string;
+	readonly path: string;
+	readonly attempts: number;
+	readonly elapsedMs: number;
+	readonly body: string;
+	constructor(method: string, path: string, attrition: RateLimitAttrition, body: string) {
+		super(
+			`Cloudflare API ${method} ${path} rate-limited (HTTP 429, code 971): gave up after ` +
+				`${attrition.attempts} attempt${attrition.attempts === 1 ? "" : "s"} over ` +
+				`${attrition.elapsedMs}ms of retry budget — ${body}`,
+		);
+		this.name = "CfRateLimitError";
+		this.method = method;
+		this.path = path;
+		this.attempts = attrition.attempts;
+		this.elapsedMs = attrition.elapsedMs;
+		this.body = body;
+	}
+}
+
+export const isCfRateLimit = (e: unknown): e is CfRateLimitError => e instanceof CfRateLimitError;
+
 export interface RateLimitRetryOptions {
-	/** Max retries AFTER the first attempt (default 5 → up to 6 sends). */
+	/** Wall-clock retry budget in ms (default {@link D1_REST_BUDGET_MS}); 0 disables retrying. */
+	budgetMs?: number;
+	/** Runaway cap on retries AFTER the first attempt (default {@link D1_REST_MAX_RETRIES}). */
 	maxRetries?: number;
 	/** Base of the exponential backoff, in ms (default 500). */
 	baseDelayMs?: number;
+	/** Ceiling on one backoff wait, in ms (default 8000). */
+	maxDelayMs?: number;
+	/** Names the round-trip in the give-up log line and any raised error. */
+	label?: string;
+	/**
+	 * Called exactly when the budget is spent and the answer is STILL 429. Defaults to a
+	 * `console.warn` naming the call — so every call site is self-identifying without opting in,
+	 * including one added later that forgets to pass a handler.
+	 */
+	onGiveUp?: (attrition: RateLimitAttrition) => void;
 	/** Injected for tests — real sleep by default. */
 	sleep?: (ms: number) => Promise<void>;
 	/** Injected for tests — `Math.random` by default. */
 	random?: () => number;
+	/** Injected for tests — `Date.now` by default. */
+	now?: () => number;
 }
 
+const warnGiveUp = ({label, attempts, elapsedMs}: RateLimitAttrition): void => {
+	console.warn(
+		`[integration] CF rate-limit (HTTP 429, code 971) not cleared: ${label} — ` +
+			`${attempts} attempt${attempts === 1 ? "" : "s"} over ${elapsedMs}ms of retry budget (#3548)`,
+	);
+};
+
 /**
- * Re-send `send()` while it answers HTTP 429, with **full-jitter** exponential backoff, up to
- * `maxRetries` extra attempts. Returns the first non-429 `Response` (a success OR a real error
- * the caller classifies), or the final 429 `Response` if the budget is exhausted — it never
- * swallows a real failure and never throws of its own accord.
+ * `Retry-After` in ms, or `undefined` when absent/unparseable. Both RFC 9110 forms are accepted
+ * (delta-seconds and HTTP-date). Observed reality on this path: CF sent NO usable value on the
+ * ejecting run (`retryAfter: Millis 0`), so honoring it is a correctness upgrade for when CF does
+ * send one, not the mechanism that fixes #3548 — the deadline is.
+ */
+const retryAfterMs = (res: Response, nowMs: number): number | undefined => {
+	const raw = res.headers.get("retry-after");
+	if (raw === null) return undefined;
+	const seconds = Number(raw);
+	if (Number.isFinite(seconds) && seconds > 0) return Math.round(seconds * 1000);
+	const at = Date.parse(raw);
+	return Number.isFinite(at) ? Math.max(0, at - nowMs) : undefined;
+};
+
+/**
+ * Re-send `send()` while it answers HTTP 429, until the wall-clock budget is spent. Returns the
+ * first non-429 `Response` (a success OR a real error the caller classifies), or the final 429 if
+ * the budget ran out — it never swallows a real failure and never throws of its own accord.
  */
 export const cfFetchWithRateLimitRetry = async (
 	send: () => Promise<Response>,
 	{
+		budgetMs = D1_REST_BUDGET_MS,
 		maxRetries = D1_REST_MAX_RETRIES,
 		baseDelayMs = D1_REST_BASE_DELAY_MS,
+		maxDelayMs = D1_REST_MAX_DELAY_MS,
+		label = "CF REST call",
+		onGiveUp = warnGiveUp,
 		sleep = defaultSleep,
 		random = Math.random,
+		now = Date.now,
 	}: RateLimitRetryOptions = {},
 ): Promise<Response> => {
+	const startedAt = now();
+	let attempts = 1;
 	let res = await send();
-	for (let attempt = 0; attempt < maxRetries && res.status === CF_RATE_LIMIT_STATUS; attempt++) {
-		// Full-jitter backoff: the ~24 parallel stages that tripped the shared rate limit must
-		// not re-sync into a thundering herd on a fixed delay, so spread each retry uniformly
-		// over [0, base·2^attempt). Release the discarded 429 body before re-sending.
-		await res.body?.cancel().catch(() => {});
-		const ceil = baseDelayMs * 2 ** attempt;
-		await sleep(Math.floor(random() * ceil));
+	for (let attempt = 0; res.status === CF_RATE_LIMIT_STATUS; attempt++) {
+		const remaining = budgetMs - (now() - startedAt);
+		if (remaining <= 0 || attempt >= maxRetries) break;
+		// Full-jitter backoff: the parallel stages that tripped the shared rate limit must not
+		// re-sync into a thundering herd on a fixed delay, so spread each retry uniformly over
+		// [0, ceil). A CF-supplied `Retry-After` is a floor on that — never wait less than the
+		// origin asked. Both are clamped to what's left of the budget so the deadline is hard.
+		const ceil = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+		const wait = Math.max(Math.floor(random() * ceil), retryAfterMs(res, now()) ?? 0);
+		await res.body?.cancel().catch(() => {}); // release the discarded 429 body before re-sending
+		await sleep(Math.min(wait, remaining));
 		res = await send();
+		attempts++;
+	}
+	if (res.status === CF_RATE_LIMIT_STATUS) {
+		onGiveUp({label, attempts, elapsedMs: now() - startedAt});
 	}
 	return res;
 };
 
 /**
- * A `fetch` that funnels every send through {@link cfFetchWithRateLimitRetry}, so the SAME 429
- * discipline the setup path has (#2915/#3089) also covers a test's DATA-PLANE D1 REST calls issued
- * over `makeD1Rest`'s `restLayer`. Inject it as the `FetchHttpClient.Fetch` reference the rest layer
- * reads (`Layer.succeed(FetchHttpClient.Fetch, rateLimitRetryingFetch(fetch))`).
+ * A `fetch` that funnels every send through {@link cfFetchWithRateLimitRetry}, so a test's
+ * DATA-PLANE D1 REST calls carry the same 429 discipline the setup path has. Inject it as the
+ * `FetchHttpClient.Fetch` reference the rest layer reads.
  *
- * Why this seam and not a per-call catch: `fetch` RESOLVES a 429 as a `Response` (an HTTP status is
- * not a network error, so it never rejects), so the retry inspects `.status` and re-sends BEFORE
- * `queryDatabase` maps a settled 429 body to a thrown error. A 429 therefore never surfaces as a
- * thrown error to drizzle or to `readYourWrite`'s poll — one seam covers every data-plane call
- * (`has`/`mint`/`remove`), the polled and the direct reads alike, reusing #3089's wrapper unchanged
- * rather than growing a second retry path (#3099).
+ * Why this seam and not a per-call catch: `fetch` RESOLVES a 429 as a `Response` (an HTTP status
+ * is not a network error, so it never rejects), so the retry inspects `.status` and re-sends
+ * BEFORE `queryDatabase` maps a settled 429 body to a thrown `TooManyRequests`. One seam covers
+ * every data-plane call, the polled and the direct reads alike (#3099).
  */
 export const rateLimitRetryingFetch = (
 	base: typeof globalThis.fetch,
 	options: RateLimitRetryOptions = {},
 ): typeof globalThis.fetch =>
 	((input: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1]) =>
-		cfFetchWithRateLimitRetry(() => base(input, init), options)) as typeof globalThis.fetch;
+		cfFetchWithRateLimitRetry(() => base(input, init), {
+			label: fetchLabel(input, init),
+			...options,
+		})) as typeof globalThis.fetch;
+
+/** `<METHOD> <url>` for a `fetch` call, across all three `input` shapes, for the give-up line. */
+const fetchLabel = (
+	input: Parameters<typeof globalThis.fetch>[0],
+	init?: Parameters<typeof globalThis.fetch>[1],
+): string => {
+	const isRequest = typeof input === "object" && input !== null && "url" in input;
+	const url = isRequest ? (input as Request).url : String(input);
+	const method = init?.method ?? (isRequest ? (input as Request).method : "GET");
+	return `${method.toUpperCase()} ${url}`;
+};

--- a/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
@@ -2,8 +2,12 @@
  * Pins that `cfFetchWithRateLimitRetry` retries ONLY the transient CF 429 (the #2915
  * D1-429 batch flake) and never masks a real failure: a non-429 answer (success or a real
  * error) is returned at once, a persistent 429 exhausts the bounded budget and surfaces the
- * final 429, and the backoff stays within its full-jitter window. `sleep`/`random` are
+ * final 429, and the backoff stays within its full-jitter window. `sleep`/`random`/`now` are
  * injected so the whole suite runs offline and instantly.
+ *
+ * The #3548 additions are pinned at the bottom: the budget is WALL-CLOCK (an attempt-count
+ * budget with full jitter could burn out in milliseconds against a minutes-long 429 plateau),
+ * a CF-supplied `Retry-After` floors the backoff, and giving up is self-identifying.
  */
 
 import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
@@ -13,8 +17,11 @@ import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {describe, expect, it, vi} from "vitest";
 import {
 	CF_RATE_LIMIT_STATUS,
+	CfRateLimitError,
 	cfFetchWithRateLimitRetry,
 	D1_REST_BASE_DELAY_MS,
+	isCfRateLimit,
+	type RateLimitAttrition,
 	rateLimitRetryingFetch,
 } from "./_d1-rest-retry.ts";
 
@@ -30,6 +37,17 @@ const sequence = (statuses: number[]) => {
 };
 
 const noSleep = () => Promise.resolve();
+const noop = () => {};
+
+/** A clock that advances by `stepMs` on every read — makes the wall-clock budget assertable. */
+const tickingClock = (stepMs: number) => {
+	let t = 0;
+	return () => {
+		const at = t;
+		t += stepMs;
+		return at;
+	};
+};
 
 describe("cfFetchWithRateLimitRetry", () => {
 	it("returns the first non-429 response without retrying (no 429 → no sleep)", async () => {
@@ -62,7 +80,7 @@ describe("cfFetchWithRateLimitRetry", () => {
 	it("exhausts the bounded budget on a persistent 429 and returns the final 429", async () => {
 		const send = sequence([429]);
 		const sleep = vi.fn(noSleep);
-		const res = await cfFetchWithRateLimitRetry(send, {maxRetries: 5, sleep});
+		const res = await cfFetchWithRateLimitRetry(send, {maxRetries: 5, sleep, onGiveUp: noop});
 		expect(res.status).toBe(429);
 		expect(send).toHaveBeenCalledTimes(6); // initial + 5 retries, then it stops
 		expect(sleep).toHaveBeenCalledTimes(5);
@@ -79,6 +97,7 @@ describe("cfFetchWithRateLimitRetry", () => {
 			baseDelayMs: D1_REST_BASE_DELAY_MS,
 			sleep,
 			random: () => 0.999999,
+			onGiveUp: noop,
 		});
 		expect(delays).toHaveLength(3);
 		delays.forEach((ms, attempt) => {
@@ -86,6 +105,138 @@ describe("cfFetchWithRateLimitRetry", () => {
 			expect(ms).toBeGreaterThanOrEqual(0);
 			expect(ms).toBeLessThan(ceil);
 		});
+	});
+});
+
+// #3548: the budget that actually decides when to give up.
+describe("the retry budget is wall-clock, not an attempt count", () => {
+	// A clock the injected sleep advances — the honest model of "waiting spends the budget".
+	const clockedSleep = () => {
+		let clock = 0;
+		return {
+			now: () => clock,
+			sleep: vi.fn(async (ms: number) => {
+				clock += ms;
+			}),
+			elapsed: () => clock,
+		};
+	};
+
+	it("keeps retrying past the old 5-retry cap while budget remains, and stops exactly at it", async () => {
+		const {now, sleep, elapsed} = clockedSleep();
+		const send = sequence([429]);
+		const res = await cfFetchWithRateLimitRetry(send, {
+			budgetMs: 10_000,
+			baseDelayMs: 1000,
+			maxDelayMs: 2000,
+			random: () => 0.999999,
+			now,
+			sleep,
+			onGiveUp: noop,
+		});
+		expect(res.status).toBe(429);
+		// The old attempt-count budget stopped at 6 sends however little time it had spent; the
+		// deadline instead spends the whole 10s — the point of the #3548 change.
+		expect(send.mock.calls.length).toBeGreaterThan(6);
+		expect(elapsed()).toBe(10_000);
+	});
+
+	it("never waits past the deadline — the last wait is clamped to what remains", async () => {
+		const {now, sleep, elapsed} = clockedSleep();
+		await cfFetchWithRateLimitRetry(sequence([429]), {
+			budgetMs: 1500,
+			baseDelayMs: 1000,
+			maxDelayMs: 8000,
+			random: () => 0.999999,
+			now,
+			sleep,
+			onGiveUp: noop,
+		});
+		expect(elapsed()).toBeLessThanOrEqual(1500);
+	});
+
+	it("budgetMs: 0 disables retrying entirely (the first answer stands)", async () => {
+		const send = sequence([429]);
+		const sleep = vi.fn(noSleep);
+		const res = await cfFetchWithRateLimitRetry(send, {budgetMs: 0, sleep, onGiveUp: noop});
+		expect(res.status).toBe(429);
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+});
+
+describe("a CF-supplied Retry-After floors the backoff", () => {
+	const with429 = (headers: Record<string, string>) =>
+		vi.fn(async () => new Response("429", {status: 429, headers}));
+
+	it("waits at least the delta-seconds CF asked for, not the (smaller) jittered backoff", async () => {
+		const delays: number[] = [];
+		await cfFetchWithRateLimitRetry(with429({"retry-after": "3"}), {
+			maxRetries: 1,
+			baseDelayMs: 100,
+			random: () => 0, // jitter alone would wait 0ms
+			sleep: async (ms) => {
+				delays.push(ms);
+			},
+			now: tickingClock(0),
+			onGiveUp: noop,
+		});
+		expect(delays).toEqual([3000]);
+	});
+
+	it("ignores an unparseable Retry-After and falls back to the jittered backoff", async () => {
+		const delays: number[] = [];
+		await cfFetchWithRateLimitRetry(with429({"retry-after": "soon"}), {
+			maxRetries: 1,
+			baseDelayMs: 100,
+			random: () => 0.999999,
+			sleep: async (ms) => {
+				delays.push(ms);
+			},
+			now: tickingClock(0),
+			onGiveUp: noop,
+		});
+		expect(delays).toEqual([99]);
+	});
+});
+
+describe("giving up is self-identifying, and never a silent pass", () => {
+	it("reports the label, attempt count and elapsed budget exactly once, only on exhaustion", async () => {
+		const seen: RateLimitAttrition[] = [];
+		await cfFetchWithRateLimitRetry(sequence([429]), {
+			label: "POST /accounts/a/d1/database/b/query",
+			maxRetries: 2,
+			sleep: noSleep,
+			now: tickingClock(10),
+			onGiveUp: (a) => seen.push(a),
+		});
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.label).toBe("POST /accounts/a/d1/database/b/query");
+		expect(seen[0]?.attempts).toBe(3);
+		expect(seen[0]?.elapsedMs).toBeGreaterThan(0);
+	});
+
+	it("does NOT fire when the 429 clears — a recovered call is not reported as rate-limited", async () => {
+		const onGiveUp = vi.fn();
+		const res = await cfFetchWithRateLimitRetry(sequence([429, 200]), {sleep: noSleep, onGiveUp});
+		expect(res.status).toBe(200);
+		expect(onGiveUp).not.toHaveBeenCalled();
+	});
+
+	it("CfRateLimitError names the call and its attrition (the #3548 diagnosability bar)", () => {
+		const err = new CfRateLimitError(
+			"POST",
+			"/accounts/a/d1/database/b/query",
+			{label: "POST /accounts/a/d1/database/b/query", attempts: 9, elapsedMs: 44_310},
+			'{"code":971}',
+		);
+		expect(isCfRateLimit(err)).toBe(true);
+		expect(err.message).toContain("POST /accounts/a/d1/database/b/query");
+		expect(err.message).toContain("9 attempts");
+		expect(err.message).toContain("44310ms");
+		expect(err.message).toContain("971");
+		// A non-429 failure must NEVER be classified as a rate-limit and retried into a fake pass.
+		expect(isCfRateLimit(new Error("D1_ERROR: no such table"))).toBe(false);
 	});
 });
 

--- a/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
@@ -5,9 +5,10 @@
  * final 429, and the backoff stays within its full-jitter window. `sleep`/`random`/`now` are
  * injected so the whole suite runs offline and instantly.
  *
- * The #3548 additions are pinned at the bottom: the budget is WALL-CLOCK (an attempt-count
- * budget with full jitter could burn out in milliseconds against a minutes-long 429 plateau),
- * a CF-supplied `Retry-After` floors the backoff, and giving up is self-identifying.
+ * The #3548 additions are pinned at the bottom: the budget is a DEADLINE (an attempt-count budget
+ * with full jitter could burn out in milliseconds against a minutes-long 429 plateau) measured
+ * over time CF spent rate-limiting the call rather than wall clock, a CF-supplied `Retry-After`
+ * floors the backoff, and giving up is self-identifying down to where the budget went.
  */
 
 import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
@@ -16,6 +17,7 @@ import {Layer} from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {describe, expect, it, vi} from "vitest";
 import {
+	budgetSpentMs,
 	CF_RATE_LIMIT_STATUS,
 	CfRateLimitError,
 	cfFetchWithRateLimitRetry,
@@ -109,7 +111,7 @@ describe("cfFetchWithRateLimitRetry", () => {
 });
 
 // #3548: the budget that actually decides when to give up.
-describe("the retry budget is wall-clock, not an attempt count", () => {
+describe("the retry budget is a deadline, not an attempt count", () => {
 	// A clock the injected sleep advances — the honest model of "waiting spends the budget".
 	const clockedSleep = () => {
 		let clock = 0;
@@ -184,6 +186,28 @@ describe("a CF-supplied Retry-After floors the backoff", () => {
 		expect(delays).toEqual([3000]);
 	});
 
+	// A `Retry-After` past the deadline used to be clamped to `remaining`, so the loop slept out the
+	// entire budget to buy one attempt at the exact moment it expired — CI time spent for near-zero
+	// odds, and a slow red where a fast, correctly-named one was available.
+	it("gives up at once when CF asks for longer than the budget left, instead of sleeping it out", async () => {
+		const seen: RateLimitAttrition[] = [];
+		const sleep = vi.fn(noSleep);
+		const send = vi.fn(
+			async () => new Response("429", {status: 429, headers: {"retry-after": "60"}}),
+		);
+		const res = await cfFetchWithRateLimitRetry(send, {
+			budgetMs: 45_000,
+			sleep,
+			now: () => 0,
+			onGiveUp: (a) => seen.push(a),
+		});
+		expect(res.status).toBe(429);
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
+		expect(seen[0]?.reason).toBe("retry-after-exceeds-budget");
+		expect(seen[0]?.retryAfterMs).toBe(60_000);
+	});
+
 	it("ignores an unparseable Retry-After and falls back to the jittered backoff", async () => {
 		const delays: number[] = [];
 		await cfFetchWithRateLimitRetry(with429({"retry-after": "soon"}), {
@@ -214,6 +238,44 @@ describe("giving up is self-identifying, and never a silent pass", () => {
 		expect(seen[0]?.label).toBe("POST /accounts/a/d1/database/b/query");
 		expect(seen[0]?.attempts).toBe(3);
 		expect(seen[0]?.elapsedMs).toBeGreaterThan(0);
+		expect(seen[0]?.reason).toBe("max-retries");
+	});
+
+	// Round 1 said "2 attempts over 45136ms of retry budget" and left WHERE those 45s went to be
+	// re-derived by hand from the job log. The breakdown is what makes the next occurrence
+	// self-diagnosing — 2 attempts with the budget barely touched reads as a queueing problem, not
+	// a Cloudflare one, without anyone reconstructing the backoff arithmetic.
+	it("breaks the elapsed time down into queued / backoff / CF-facing budget spent", async () => {
+		const seen: RateLimitAttrition[] = [];
+		let clock = 0;
+		await cfFetchWithRateLimitRetry(
+			// Every attempt reports 1000ms of harness queueing and takes 1100ms of wall clock.
+			async (queued) => {
+				queued(1000);
+				clock += 1100;
+				return resp(429);
+			},
+			{
+				budgetMs: 500,
+				baseDelayMs: 100,
+				random: () => 0.999999,
+				now: () => clock,
+				sleep: async (ms) => {
+					clock += ms;
+				},
+				onGiveUp: (a) => seen.push(a),
+			},
+		);
+		const a = seen[0] as RateLimitAttrition;
+		expect(a.reason).toBe("budget-exhausted");
+		expect(a.attempts).toBe(3);
+		expect(a.queuedMs).toBe(3000); // every attempt's throttle wait, deducted from the budget
+		expect(a.backoffMs).toBe(298);
+		expect(a.budgetMs).toBe(500);
+		// Wall clock far outruns the 500ms budget precisely because most of it was ours, not CF's —
+		// the discrepancy the round-1 line could not show.
+		expect(a.elapsedMs).toBe(3598);
+		expect(budgetSpentMs(a)).toBe(598);
 	});
 
 	it("does NOT fire when the 429 clears — a recovered call is not reported as rate-limited", async () => {
@@ -227,7 +289,15 @@ describe("giving up is self-identifying, and never a silent pass", () => {
 		const err = new CfRateLimitError(
 			"POST",
 			"/accounts/a/d1/database/b/query",
-			{label: "POST /accounts/a/d1/database/b/query", attempts: 9, elapsedMs: 44_310},
+			{
+				label: "POST /accounts/a/d1/database/b/query",
+				attempts: 9,
+				elapsedMs: 44_310,
+				queuedMs: 40_000,
+				backoffMs: 3_800,
+				budgetMs: 45_000,
+				reason: "max-retries",
+			},
 			'{"code":971}',
 		);
 		expect(isCfRateLimit(err)).toBe(true);
@@ -235,6 +305,11 @@ describe("giving up is self-identifying, and never a silent pass", () => {
 		expect(err.message).toContain("9 attempts");
 		expect(err.message).toContain("44310ms");
 		expect(err.message).toContain("971");
+		// The round-2 attribution: WHY it stopped, and how the elapsed time split — so a repeat of
+		// PR #4033's ejection reads as "queued in our own throttle" off the log line itself.
+		expect(err.message).toContain("max-retries");
+		expect(err.message).toContain("40000ms queued in the harness's own throttle");
+		expect(err.message).toContain("4310ms of the 45000ms CF-facing retry budget");
 		// A non-429 failure must NEVER be classified as a rate-limit and retried into a fake pass.
 		expect(isCfRateLimit(new Error("D1_ERROR: no such table"))).toBe(false);
 	});

--- a/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
@@ -278,6 +278,42 @@ describe("giving up is self-identifying, and never a silent pass", () => {
 		expect(budgetSpentMs(a)).toBe(598);
 	});
 
+	// The other half of deducting `queuedMs`: with queueing uncharged, the CF-facing budget alone
+	// stops bounding wall clock, and 24 attempts of deep queueing outlive vitest's 120s testTimeout
+	// — trading the named 429 back for "Hook timed out". Deep queueing must therefore end the loop
+	// on the ceiling, saying so, rather than on the untouched budget.
+	it("ends on the wall-clock ceiling when queueing (not CF) is what burnt the time", async () => {
+		const seen: RateLimitAttrition[] = [];
+		let clock = 0;
+		await cfFetchWithRateLimitRetry(
+			// Every attempt queues 20s in the harness's own throttle and answers 429 immediately.
+			async (queued) => {
+				queued(20_000);
+				clock += 20_000;
+				return resp(429);
+			},
+			{
+				budgetMs: 45_000,
+				wallClockCeilingMs: 90_000,
+				maxRetries: 24,
+				baseDelayMs: 1,
+				random: () => 0,
+				now: () => clock,
+				sleep: async (ms) => {
+					clock += ms;
+				},
+				onGiveUp: (a) => seen.push(a),
+			},
+		);
+		const a = seen[0] as RateLimitAttrition;
+		expect(a.reason).toBe("wall-clock-ceiling");
+		expect(a.elapsedMs).toBeGreaterThanOrEqual(90_000);
+		// The runaway guard never got near 24, and CF never got its budget — which is exactly the
+		// state the ceiling exists to end: we were queueing, not being rate-limited.
+		expect(a.attempts).toBeLessThan(24);
+		expect(budgetSpentMs(a)).toBeLessThan(45_000);
+	});
+
 	it("does NOT fire when the 429 clears — a recovered call is not reported as rate-limited", async () => {
 		const onGiveUp = vi.fn();
 		const res = await cfFetchWithRateLimitRetry(sequence([429, 200]), {sleep: noSleep, onGiveUp});

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -35,8 +35,8 @@
  */
 
 import {randomBytes} from "node:crypto";
-import {cfApiThrottle} from "./_cf-api-throttle.ts";
-import {cfFetchWithRateLimitRetry} from "./_d1-rest-retry.ts";
+import {cfRestSend} from "./_cf-rest-transport.ts";
+import {CfRateLimitError, type RateLimitAttrition} from "./_d1-rest-retry.ts";
 import {
 	awaitEdgeReady,
 	CloudflarePlaceholder404Error,
@@ -281,14 +281,14 @@ const cloudflareApiToken = (): string => {
 
 // One authenticated request to the Cloudflare REST API; throws on a non-2xx with the
 // response body for diagnosis. Setup-only — never on a test's black-box assertion path.
-// A transient 429 (the shared-account D1 rate-limit that reds the batched ref, #2915) is
-// bounded-retried before the throw — see `_d1-rest-retry.ts` for why 429 is safe to replay.
-// The whole call funnels through the shared `cfApiThrottle` (proactive concurrency cap +
-// jittered start-pacing, #3081) so the harness's own aggregate CF-API burst stays gentler on
-// the account-global limit; the throttle composes AROUND the per-call retry, not over it.
+// Throttled + 429-retried through the one shared transport (`_cf-rest-transport.ts`); a 429
+// that outlives the whole retry budget raises `CfRateLimitError` rather than the generic
+// non-2xx throw, so the log names the rate-limited call and what it spent (#3548).
 async function cloudflareApi(path: string, init?: RequestInit): Promise<Response> {
-	const res = await cfApiThrottle.run(() =>
-		cfFetchWithRateLimitRetry(() =>
+	const method = init?.method ?? "GET";
+	let attrition: RateLimitAttrition | undefined;
+	const res = await cfRestSend(
+		() =>
 			fetch(`${CLOUDFLARE_API_BASE}${path}`, {
 				...init,
 				headers: {
@@ -297,12 +297,17 @@ async function cloudflareApi(path: string, init?: RequestInit): Promise<Response
 					...init?.headers,
 				},
 			}),
-		),
+		{
+			label: `${method} ${path}`,
+			onGiveUp: (spent) => {
+				attrition = spent;
+			},
+		},
 	);
 	if (!res.ok) {
-		throw new Error(
-			`Cloudflare API ${init?.method ?? "GET"} ${path} failed: ${res.status} ${await res.text()}`,
-		);
+		const body = await res.text();
+		if (attrition) throw new CfRateLimitError(method, path, attrition, body);
+		throw new Error(`Cloudflare API ${method} ${path} failed: ${res.status} ${body}`);
 	}
 	return res;
 }

--- a/apps/web/tests/integration/kunye-admin-seam.test.ts
+++ b/apps/web/tests/integration/kunye-admin-seam.test.ts
@@ -17,25 +17,21 @@
  * user/tuple are cleaned up after each test.
  */
 
-import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {assignAdmin, makeGrantDb, revokeAdmin} from "@kampus/admin-grant";
 import {CurrentActor, type Grant, human, isGrant, platform} from "@kampus/authz";
-import {makeD1Rest} from "@kampus/d1-rest";
 import {Effect, Exit, Layer} from "effect";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {afterEach, beforeAll, describe, expect, it} from "vitest";
 import {createDrizzle, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
 import {AgentAuthorityV1} from "../../worker/features/kunye/AgentAuthorityV1.ts";
 import {Admin} from "../../worker/features/kunye/admin.ts";
 import type {Denied} from "../../worker/features/kunye/errors.ts";
 import {RelationStoreLive} from "../../worker/features/kunye/RelationStore.ts";
+import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
 import {sharedStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
 const h = sharedStack();
 const NS = nsToken(import.meta.url);
-
-const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
 
 const ADMIN_USER = `${NS}-admin`;
 const RANDO = `${NS}-rando`;
@@ -62,7 +58,7 @@ const cleanup = () =>
 
 beforeAll(async () => {
 	const {accountId, databaseId} = await h.d1Target();
-	d1 = makeD1Rest({accountId, databaseId, layer: restLayer});
+	d1 = makeIntegrationD1Rest({accountId, databaseId});
 	const workerDb = createDrizzle(d1);
 	const layer = Layer.mergeAll(
 		RelationStoreLive.pipe(Layer.provide(makeDrizzleLayer(workerDb))),

--- a/apps/web/tests/integration/kunye-moderate-seam.test.ts
+++ b/apps/web/tests/integration/kunye-moderate-seam.test.ts
@@ -16,25 +16,21 @@
  * (this file's deterministic token) to keep its rows its own, and the seeded
  * founder/tuple are cleaned up after each test.
  */
-import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {CurrentActor, type Grant, human, isGrant, platform} from "@kampus/authz";
-import {makeD1Rest} from "@kampus/d1-rest";
 import {makeSeedDb, seedFounders} from "@kampus/founder-seed";
 import {Effect, Exit, Layer} from "effect";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {afterEach, beforeAll, describe, expect, it} from "vitest";
 import {createDrizzle, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
 import {AgentAuthorityV1} from "../../worker/features/kunye/AgentAuthorityV1.ts";
 import type {Denied} from "../../worker/features/kunye/errors.ts";
 import {Moderate} from "../../worker/features/kunye/moderate.ts";
 import {RelationStoreLive} from "../../worker/features/kunye/RelationStore.ts";
+import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
 import {sharedStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
 const h = sharedStack();
 const NS = nsToken(import.meta.url);
-
-const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
 
 const FOUNDER = `${NS}-founder`;
 const RANDO = `${NS}-rando`;
@@ -59,7 +55,7 @@ const cleanup = () =>
 
 beforeAll(async () => {
 	const {accountId, databaseId} = await h.d1Target();
-	d1 = makeD1Rest({accountId, databaseId, layer: restLayer});
+	d1 = makeIntegrationD1Rest({accountId, databaseId});
 	const workerDb = createDrizzle(d1);
 	const layer = Layer.mergeAll(
 		RelationStoreLive.pipe(Layer.provide(makeDrizzleLayer(workerDb))),

--- a/apps/web/tests/integration/kunye-relation-store.test.ts
+++ b/apps/web/tests/integration/kunye-relation-store.test.ts
@@ -16,37 +16,20 @@
  * Runs on the run-scoped SHARED stage (ADR 0104 step 7), so every subject/object id is
  * prefixed with `NS` (this file's deterministic token) to keep its rows its own.
  */
-import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {type Relation, RelationStore, resource} from "@kampus/authz";
-import {makeD1Rest, readYourWrite} from "@kampus/d1-rest";
+import {readYourWrite} from "@kampus/d1-rest";
 import {and, eq} from "drizzle-orm";
 import {Effect, Layer} from "effect";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {afterEach, beforeAll, describe, expect, it} from "vitest";
 import {createDrizzle, type DrizzleDb, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
 import * as schema from "../../worker/db/drizzle/schema.ts";
 import {objectKey, RelationStoreLive} from "../../worker/features/kunye/RelationStore.ts";
-import {rateLimitRetryingFetch} from "./_d1-rest-retry.ts";
+import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
 import {sharedStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
 const h = sharedStack();
 const NS = nsToken(import.meta.url);
-
-// Data-plane `has`/`mint`/`remove` cross this REST transport, so its `fetch` carries the same
-// 429-retry the setup path has (#3089): a transient CF 429 (code 971) under merge_group load is
-// re-sent with full-jitter backoff at the transport, not thrown into drizzle/`readYourWrite` (#3099).
-const restLayer = Layer.merge(
-	CredentialsFromEnv,
-	FetchHttpClient.layer.pipe(
-		Layer.provide(
-			Layer.succeed(
-				FetchHttpClient.Fetch,
-				rateLimitRetryingFetch((input, init) => fetch(input, init)),
-			),
-		),
-	),
-);
 
 const object = resource("platform", NS);
 const SUBJECT = `${NS}-alice`;
@@ -76,7 +59,7 @@ const remove = (subject: string) =>
 
 beforeAll(async () => {
 	const {accountId, databaseId} = await h.d1Target();
-	db = createDrizzle(makeD1Rest({accountId, databaseId, layer: restLayer}));
+	db = createDrizzle(makeIntegrationD1Rest({accountId, databaseId}));
 	const layer = RelationStoreLive.pipe(Layer.provide(makeDrizzleLayer(db)));
 	has = (tuple) =>
 		Effect.runPromise(

--- a/apps/web/tests/integration/pano-hot-score-decay.test.ts
+++ b/apps/web/tests/integration/pano-hot-score-decay.test.ts
@@ -39,12 +39,12 @@
  * Per-file `integrationStack`: this file owns its own worker + D1, so the direct-D1
  * refresh and the feed reads see one isolated table.
  */
-import {makeD1RestFromEnv} from "@kampus/d1-rest";
 import {Effect} from "effect";
 import {beforeAll, describe, expect, it} from "vitest";
 import {createDrizzle, makeDrizzleAccess, orDieAccess} from "../../worker/db/Drizzle.ts";
 import {computeHotScore} from "../../worker/db/hotScore.ts";
 import {makeRefreshHotScores} from "../../worker/features/pano/post-operations.ts";
+import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
 import {integrationStack} from "./_integration.ts";
 
 const h = integrationStack(import.meta.url);
@@ -126,7 +126,7 @@ async function readPost(id: string): Promise<{score: number; commentCount: numbe
  */
 async function realRefreshHotScores() {
 	const target = await h.d1Target();
-	const db = createDrizzle(makeD1RestFromEnv(target));
+	const db = createDrizzle(makeIntegrationD1Rest(target));
 	const access = orDieAccess(makeDrizzleAccess(db));
 	return makeRefreshHotScores(access.run);
 }

--- a/apps/web/tests/integration/pasaport-ban.test.ts
+++ b/apps/web/tests/integration/pasaport-ban.test.ts
@@ -24,17 +24,13 @@
  * (this file's deterministic token) so its rows are its own, and each user's ban
  * events are cleaned up after the suite.
  */
-import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
-import {makeD1Rest} from "@kampus/d1-rest";
-import {Layer} from "effect";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
 import {sharedStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
 const h = sharedStack();
 const NS = nsToken(import.meta.url);
-const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
 
 let d1: D1Database;
 
@@ -101,7 +97,7 @@ const userIds: string[] = [];
 
 beforeAll(async () => {
 	const {accountId, databaseId} = await h.d1Target();
-	d1 = makeD1Rest({accountId, databaseId, layer: restLayer});
+	d1 = makeIntegrationD1Rest({accountId, databaseId});
 });
 
 afterAll(async () => {

--- a/apps/web/tests/integration/pasaport-set-role.test.ts
+++ b/apps/web/tests/integration/pasaport-set-role.test.ts
@@ -17,12 +17,10 @@
  * mutation). Runs on the run-scoped SHARED stage (ADR 0104); every id is `NS`-prefixed
  * (this file's deterministic token) so its rows are its own and are cleaned up after.
  */
-import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import type {RelationStore} from "@kampus/authz";
-import {makeD1Rest, readYourWrite} from "@kampus/d1-rest";
+import {readYourWrite} from "@kampus/d1-rest";
 import {and, eq, inArray} from "drizzle-orm";
 import {Effect, Layer} from "effect";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {createDrizzle, type DrizzleDb, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
 import * as schema from "../../worker/db/drizzle/schema.ts";
@@ -37,27 +35,12 @@ import {
 	makePasaportLive,
 	Pasaport,
 } from "../../worker/features/pasaport/Pasaport.ts";
-import {rateLimitRetryingFetch} from "./_d1-rest-retry.ts";
+import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
 import {sharedStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
 const h = sharedStack();
 const NS = nsToken(import.meta.url);
-
-// The data-plane writes/reads cross this REST transport, so its `fetch` carries the same
-// 429-retry the sibling integration tests use (#3089): a transient CF 429 under
-// merge_group load is re-sent with backoff at the transport, not thrown into drizzle.
-const restLayer = Layer.merge(
-	CredentialsFromEnv,
-	FetchHttpClient.layer.pipe(
-		Layer.provide(
-			Layer.succeed(
-				FetchHttpClient.Fetch,
-				rateLimitRetryingFetch((input, init) => fetch(input, init)),
-			),
-		),
-	),
-);
 
 // `setRole` never touches better-auth (no session/DB use on this path), so an inert
 // instance satisfies the type — the same shape the Pasaport unit tests use.
@@ -136,7 +119,7 @@ const auditRowsWhen = (
 
 beforeAll(async () => {
 	const {accountId, databaseId} = await h.d1Target();
-	db = createDrizzle(makeD1Rest({accountId, databaseId, layer: restLayer}));
+	db = createDrizzle(makeIntegrationD1Rest({accountId, databaseId}));
 	const drizzleLayer = makeDrizzleLayer(db);
 	layer = Layer.mergeAll(
 		makePasaportLive(inertAuth).pipe(Layer.provide(drizzleLayer)),

--- a/apps/web/tests/integration/sozluk-cache-reconcile.test.ts
+++ b/apps/web/tests/integration/sozluk-cache-reconcile.test.ts
@@ -35,7 +35,6 @@
  * `integrationStack`: this file owns its own worker + D1, so the direct-D1 reconcile and the
  * seeded rows see one isolated table (and `sozluk_stats` counts only this file's definitions).
  */
-import {makeD1RestFromEnv} from "@kampus/d1-rest";
 import {eq} from "drizzle-orm";
 import {type Context, Effect, Layer} from "effect";
 import {beforeAll, describe, expect, it} from "vitest";
@@ -45,6 +44,7 @@ import {PasaportIdentityStub} from "../../worker/features/pasaport/Pasaport.test
 import {ReactionStub} from "../../worker/features/reaction/Reaction.testing.ts";
 import {Sozluk, SozlukLive} from "../../worker/features/sozluk/Sozluk.ts";
 import {Vote} from "../../worker/features/vote/Vote.ts";
+import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
 import {integrationStack} from "./_integration.ts";
 
 const h = integrationStack(import.meta.url);
@@ -65,7 +65,7 @@ const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
  */
 async function realSozluk() {
 	const target = await h.d1Target();
-	const db = createDrizzle(makeD1RestFromEnv(target));
+	const db = createDrizzle(makeIntegrationD1Rest(target));
 	const access = orDieAccess(makeDrizzleAccess(db));
 	const sozlukLayer = SozlukLive.pipe(
 		Layer.provide(Layer.succeed(Drizzle, makeDrizzleAccess(db))),


### PR DESCRIPTION
Fixes #3548

> ## ⚠️ History: this PR was enqueued and then EJECTED from the merge queue
>
> Every check on the PR head was green (45/45) and both review gates PASSed — but the merge queue runs its own `merge_group` CI on the combined branch, which is a **different surface**, and that is where it red. `added_to_merge_queue` 12:55:57Z → `removed_from_merge_queue` 13:05:26Z; the failing job was `integration tests` in `merge_group` run [30158806064](https://github.com/kamp-us/phoenix/actions/runs/30158806064/job/89680622155). Green on the PR head is not green in the queue. See **Round 2** below for the diagnosis and the repair.

---

# Round 2 — the repair after the merge-queue ejection

## The good news first: the diagnostic half worked

The ejecting job failed as:

```
[integration] CF rate-limit (HTTP 429, code 971) not cleared: POST https://api.cloudflare.com/client/v4/accounts/***/d1/database/<id>/query — 2 attempts over 45136ms of retry budget (#3548)
```

That is the self-identifying error this PR added — the call, the attempt count, the budget, the issue reference. Before it, the same event was an opaque `Object.971` with no attribution, which is why the original report guessed the wrong subsystem. That property is kept and deepened below, never regressed.

## Root cause — the budget was never spent, so it was never too small

The obvious reading is "45s of budget lost to a ~290s plateau, raise the budget". **The log says otherwise: `attempts == 2`** — four independent give-ups in the ejecting run, every one of them 2 attempts, at 45136 / 45135 / 45046 / 45195ms.

With two attempts, exactly one backoff sleep ran, at attempt index 0, where the jitter ceiling is `min(baseDelayMs · 2⁰, maxDelayMs)` = **500ms**. That bounds the backoff **provided CF sent no `Retry-After`** — a `Retry-After` is a *floor* on the wait and is not bounded by that ceiling. CF sent none on this path (`retryAfter: Millis 0`, run `29665891972`), and on that premise at most 500ms of the 45136ms was backoff: the remaining ~44.6s was spent *inside the two `send()` calls* — and `send` is `cfApiThrottle.run(fetch)`. A 429 comes back from Cloudflare in well under a second, so that time was **queueing in this harness's own throttle**, not Cloudflare rate-limiting us.

That premise is load-bearing and worth stating rather than burying: the elapsed numbers **alone** do not separate "queued in our throttle" from "CF sent a large `Retry-After`" — both produce 2 attempts over ~45s. Both sinks are fixed here, and the new attrition breakdown records `retryAfterMs`, so the next occurrence is read off the log line instead of re-derived. The conclusion is unaffected either way: **the budget was never spent, so raising it would have fixed nothing.**

The composition this PR shipped holds a slot per *attempt* (correctly — a backing-off call is not in flight), which means a logical call re-enters the harness's queue on every retry. The deadline was **wall clock**, so it charged that self-imposed queueing to the budget it meant to spend asking Cloudflare. The loop expired having asked Cloudflare **twice**. A bigger constant would have bought more queueing, not more retries.

Two amplifiers made that queue far deeper than intended, both found by reading `_cf-api-throttle.ts`:

1. **`pace()` slept INSIDE the concurrency slot.** Start-pacing is a *rate* limit and the semaphore is a *concurrency* limit; nesting them let the rate limiter eat the concurrency limiter, collapsing throughput toward one call per `minSpacingMs` per slot. This is the same "a sleeping call is not in flight" rule this PR already applied to backoff — it just wasn't applied one layer in.
2. **The concurrency cap did not actually bind under contention.** `releaseSlot` did `inFlight--` then woke a waiter; in the window between, a freshly-arriving caller could observe a free slot and take it *while the woken waiter also incremented*, pushing `inFlight` past `maxConcurrent` — precisely under the load the cap exists for.

## The 429s are substantially self-inflicted, and mostly not ours to throttle

Also visible in the same log, and load-bearing for why "raise the budget" is the wrong lever: the teardown 429s are `DELETE /accounts/{id}/flagship/apps/{appId}/flags/{flagKey}`, raised inside `alchemy` / `@distilled.cloud`, warned as `stage leaked, sweep via #690 (durable fix #813)`. Those calls **never touch this transport** — they are unthrottled and unretried, and they compete for the same account bucket the tests then can't get through. Stage create/destroy is the bulk of the run's CF traffic and essentially none of it is under the harness throttle. Cloudflare's own message ("consider throttling your request speed") is aimed at that volume, not at the D1 query path this PR protects.

So a 429 storm in this suite is **not** evidence that the harness knobs are mis-set. Making the harness wait longer cannot fix pressure the harness does not generate.

## What changed

- **`_d1-rest-retry.ts` — the deadline measures time CLOUDFLARE kept us waiting.** `send` is handed a `queued` sink; the throttle reports what it made each attempt wait; the retry deducts it. `budgetMs` now means "up to this much time with CF actually answering 429".
- **`_d1-rest-retry.ts` — a `Retry-After` longer than the budget left ends the loop immediately** (`retry-after-exceeds-budget`). It used to be clamped to `remaining`, so the loop slept out the entire budget to buy one attempt at the exact moment it expired: CI time spent for near-zero odds. A fast, correctly-named red beats a slow one.
- **`_cf-api-throttle.ts` — `pace()` runs before `acquireSlot()`**, so start-pacing no longer consumes a concurrency slot.
- **`_cf-api-throttle.ts` — the slot is handed over on release** rather than decremented-then-re-raced, so the cap binds under contention.
- **`_d1-rest-retry.ts` — a hard wall-clock ceiling (`D1_REST_WALL_CLOCK_CEILING_MS`) is kept alongside the CF-facing budget.** Deducting `queuedMs` bought CF its budget back but removed the wall-clock bound the sizing rationale leaned on: with queueing uncharged, the only remaining limit was `maxRetries` × queueing, which at 24 attempts can outlive vitest's 120s `testTimeout` and hand back exactly the opaque "Hook timed out" the named 429 exists to replace. Both bounds are now held, and a fourth `GiveUpReason` (`wall-clock-ceiling`) names which one fired.
- **`_cf-rest-transport.ts`** wires `throttle.run`'s `onQueued` into the retry's `queued` sink — the one place the two halves meet.
- **`.patterns/alchemy-test-harness.md`** records both rules plus the honest coverage ceiling (stage create/destroy is not under this transport).

## Hard requirements, re-checked

- **Recovery masks nothing.** Only `status === 429` is retried; a success, a 500, or a D1 SQL error surfacing as 200-with-`errors[]` returns on the first attempt, undelayed. Exhaustion returns the final 429 for the caller to raise. Pinned, including `isCfRateLimit(new Error("D1_ERROR: no such table")) === false`.
- **Attribution is kept and deepened.** Giving up still names the call and its attempt count, and now also **why** it stopped (`budget-exhausted` / `retry-after-exceeds-budget` / `max-retries`) and **how the elapsed time split** — `queuedMs` (harness throttle) / `backoffMs` / CF-facing budget spent. Round 1's line could say the budget ran out but not where it went, which is why this diagnosis had to be re-derived by hand from the job log. The next occurrence reads off the line.
- **No budget constant was raised.** `D1_REST_BUDGET_MS` stays 45_000, and its docblock now says why: the ejecting run spent ~1.2% of it on Cloudflare, so it was never the binding constraint — and no CI-sane budget outlasts a ~290s account-wide plateau anyway (it would trade a named 429 for the opaque "Hook timed out" shape at `vitest.config.ts`'s 120s `testTimeout`).

## What I deliberately did NOT fix

- **Alchemy's own deploy/destroy CF calls.** They are the dominant 429 source in this run and they bypass this transport entirely. Fixing them means a `pnpm patch` of alchemy (ADR 0038) — already named as an out-of-harness lever in #3081, with stage-leak durability tracked in #813/#690. Not folded in here; it is a different change with a different blast radius.
- **The suite's call volume / stage count.** ~24 per-file stages against one account (ADR 0082) is the structural driver. Restructuring that is not a repair-round change.
- **Cross-run overlap.** ~4 concurrent `merge_group` runs share the account; a CI `concurrency:` group is a workflow change, also named in #3081.
- **Distinguishing the two candidate 45s sinks *empirically*.** The arithmetic above rules out backoff, but the log cannot separate "queued in our throttle" from "CF sent a large `Retry-After`" — both produce 2 attempts over ~45s. Both are now fixed, and the new attrition breakdown makes them distinguishable next time rather than requiring this analysis again.

## Verification

- `pnpm typecheck` clean; `pnpm lint:worktree` clean.
- `pnpm vitest run --project unit tests/integration` — 12 files / 136 tests pass, covering the pacing / slot-handover / queue-deduction / `Retry-After`-overrun / attrition-breakdown / wall-clock-ceiling behaviours.
- **Each new test was shown to FAIL on the code it pins, not just to pass.** The pacing test hangs on the pre-fix `pace()`-inside-slot order. The slot-handover test sweeps the barger's microtask arrival offset and, against the pre-fix `inFlight--; waiters.shift()?.()`, fails with `{offset: 1, peak: 2}` — two genuinely concurrent ops under a cap of 1 — then passes on the shipped handover. (An earlier version of that test barged at offset 0, where the barger reaches `acquireSlot` before the release runs and queues under *both* implementations: it passed on the buggy code and was therefore no regression test at all. Sweeping the offset is what fixes that, and it does not depend on the exact microtask count of `run`'s prelude.)
- The pacing test is a liveness probe: under the old order the first call's pace-sleep holds the only slot, the second call never runs, and the test hangs to its timeout.

---

# Round 1 — the original analysis (kept for the record)


## Root cause — two signatures, both from opt-in protection

I pulled the job log for run `29665891972` (job `88136143288`) rather than reasoning from the report. The six failures split cleanly into two mechanisms, and #3081/#3099's shipped throttle+retry misses each for a different reason.

**Signature A — the PROTECTED path, budget exhausted (5/6).** `sozluk-keyset` (via `setLastActivityAt`) and `account-deletion` / `content-removal-substrate` ×2 / `session-freshness-invariants` (via `promoteToYazar`) all threw at `_harness.ts` `cloudflareApi`, which *does* run `cfApiThrottle.run(() => cfFetchWithRateLimitRetry(...))`. So the retry ran and lost. The reason is the budget's *shape*: "5 retries with full-jitter backoff" makes the real wall-clock budget a random variable — each wait is uniform over `[0, base·2^attempt)`, so the mean total is 7.75s and the **lower bound is ~0s**. The log's 429 pressure ran from `23:52:18` to `23:57:08` — a ~290s plateau, two orders of magnitude past that budget. (Five sites, not four: vitest reports `sozluk-keyset` under `Failed Suites 1` rather than `Failed Tests 5`, so counting only the latter undercounts this signature by one.)

**Signature B — the BYPASSED path, no protection at all (1/6).** `pasaport-ban.test.ts` threw a raw `TooManyRequests` off `@distilled.cloud/cloudflare`'s `Object.971` mapping (`Serialized Error: { _tag: 'TooManyRequests', retryAfter: Millis 0 }`), never touching the retry. It builds its own client from `Layer.merge(CredentialsFromEnv, FetchHttpClient.layer)` — the bare fetch. #3099 wrapped the fetch of exactly the two files that were failing at the time; `pasaport-ban`, `kunye-admin-seam`, `kunye-moderate-seam` and every `makeD1RestFromEnv` caller kept the bare one. The corroborating detail: the ejected PR #3533's own new test, `pasaport-set-role.test.ts`, uses the **wrapped** layer and passed through the same 429 storm while its sibling `pasaport-ban.test.ts` red.

So the answer to the issue's three candidates is "unthrottled/bypassed client **and** exhausted budget", not one or the other — and the common defect is that the protection was **opt-in per call site**.

## Not the same root cause as #3942

Verified independently rather than assumed. #3942 was a `TimeoutError`/abort on the **worker HTTP** path (`sessionReady`'s probe). This is HTTP 429 from `api.cloudflare.com`. The CF REST path attaches no `AbortSignal` at any layer (`cloudflareApi` → `cfApiThrottle` → `cfFetchWithRateLimitRetry` — none of the three constructs one), so it cannot produce the timeout shape; and the log stacks are disjoint (`cloudflareApi` / `Object.971` vs the stall seam). #4025's `_request-stall.ts` is reused as the *idiom* for the attributed error class, not duplicated.

## The fix

**`apps/web/tests/integration/_cf-rest-transport.ts` (new) — one transport, not a second wrapper.** `integrationRestLayer` / `makeIntegrationD1Rest` is now the only way an integration test gets a D1 REST client; the files that hand-rolled a layer were converted. The safe path is the default rather than something a new file must remember to opt into.

**Composition inverted: retry AROUND throttle.** #3081 wired `throttle.run(() => retry(send))` so a logical call is one throttled unit. That makes the concurrency cap count a call *sleeping in backoff* as "in flight" — four backing-off calls hold all four slots and head-of-line-block every other CF call in the fork, which the longer budget below would have made much worse. A sleeping call is not in flight, so the slot is now held per attempt. This also start-paces the retries, which the old order left unpaced.

**`_d1-rest-retry.ts`: the budget is a wall-clock deadline.** `D1_REST_BUDGET_MS = 45_000`, sized against both live constraints — well above the ~8s the attempt-count budget averaged, and comfortably under `vitest.config.ts`'s 120s `testTimeout` (a budget outrunning the test timeout would trade a named 429 for the opaque "Hook timed out" shape `_request-stall.ts` documents). Full jitter is kept per-wait — it is what de-syncs the parallel stages — it just no longer decides when to give up. The attempt count is demoted to a runaway guard.

**`Retry-After` is honored, with an honest caveat.** A CF-supplied `Retry-After` (both RFC 9110 forms) floors the backoff. But CF sent none on this path — the observed value was `Millis 0` — so honoring it is a correctness upgrade for when CF does send one, **not** the mechanism that fixes this. The deadline is. Naming that explicitly so the next reader doesn't mistake AC3 for the fix.

**Recovery cannot mask a real failure.** Only `status === 429` is ever retried; a non-429 answer (success, `500`, a D1 SQL error surfacing as 200-with-`errors[]`) returns on the first attempt, undelayed. Budget exhaustion returns the final 429 for the caller to raise — it never converts a failure into a pass. Pinned by tests, including one asserting `isCfRateLimit(new Error("D1_ERROR: no such table")) === false`.

**The next occurrence is self-identifying.** Exhaustion reports the call label, attempt count and elapsed budget — by *default*, so a call site added later that forgets to pass a handler is still diagnosable. `cloudflareApi` raises it as `CfRateLimitError` ("… rate-limited (HTTP 429, code 971): gave up after 9 attempts over 44310ms of retry budget — …") instead of the generic non-2xx throw, so a still-red run says what was rate-limited and what it spent rather than needing the subsystem guessed.

**The bypass can't silently reopen.** `_cf-rest-transport.unit.test.ts` scans every `.ts` in `apps/web/tests/integration/` — not just `*.test.ts`, since a non-test helper that grew its own client would reopen the hole just as wide — for a bare `FetchHttpClient.layer` / `makeD1RestFromEnv(` and fails closed, including on zero scope (ADR 0092).

## What I measured / verified

- Job log for run `29665891972`: 429 window `23:52:18`–`23:57:08`; per-failure stack frames attributing 4 to `cloudflareApi` and 1 to `@distilled.cloud`'s `971` mapping.
- `pnpm typecheck` clean; `pnpm lint:worktree` clean; `pnpm vitest run --project unit` — 285 files / 2387 tests pass, including 18 in the two files here.
- The composition-inversion test is a deadlock probe: under the old order the backing-off call holds the only slot, the second call never runs, and the test hangs to its timeout.

## What this does not claim

**This PR mostly does not STOP the ejections — it survives them better.** That is the honest framing and it should be read that way. The 429 pressure in the ejecting run spanned ~13:00:40 to ~13:04:49, roughly four minutes; run `29665891972` was a ~290s plateau. A 45s CF-facing budget does not outlast either. What changes is real and large: instead of asking Cloudflare **twice**, a call now gets on the order of a dozen genuine attempts spread across 45s of CF-facing time. Against a bursty 429 that is the difference between red and green; against a multi-minute account-wide plateau it is not.

So: a 45s per-call budget does not guarantee survival of a ~290s account-wide plateau. It bounds the slice the harness owns, and closing the bypass plus releasing slots during backoff removes the ways the existing mechanism was being defeated. The lever that actually removes this ejection class is the alchemy deploy/destroy path plus a CI `concurrency:` group — both named in #3081 and both correctly out of scope here. The self-identifying error and the attrition breakdown are what make the next tuning evidence-based rather than another guess.



