### PR TITLE
fix(e2e): make the preview-warm gate self-identifying and its hard cap real (#3179)

### DIFF
--- a/apps/web/playwright.config.cjs
+++ b/apps/web/playwright.config.cjs
@@ -102,7 +102,11 @@ module.exports = defineConfig({
 		},
 		{
 			name: "flows",
-			testIgnore: [...UNAUTH_SPECS, AUTHED_SPECS],
+			// `flows` is the catch-all (#525), so it would otherwise sweep in the
+			// harness's own pure-core `*.unit.test.ts` — vitest files that launch no
+			// browser and assert no page (#3179). Ignoring the infix keeps the
+			// catch-all's orphan guard for real specs while excluding the unit tier.
+			testIgnore: [...UNAUTH_SPECS, AUTHED_SPECS, "**/*.unit.test.ts"],
 			// The write-flow specs do a full per-test sign-up + bootstrap + create +
 			// assert chain against the remote preview; the global 15s per-test cap is
 			// for the lean read specs and is too tight for these end-to-end flows late

--- a/apps/web/tests/e2e/_setup/preview-ready-policy.cjs
+++ b/apps/web/tests/e2e/_setup/preview-ready-policy.cjs
@@ -1,0 +1,100 @@
+// Pure policy core of the e2e preview-readiness gate (`preview-ready.cjs`).
+//
+// Split out so the two things that gate can get silently wrong — its budget
+// arithmetic and its failure attribution — are unit-testable offline: nothing
+// here launches a browser, opens a socket, or reads a clock. `.cjs` because the
+// gate that consumes it is a Playwright `globalSetup` in CommonJS (ADR 0001).
+//
+// The attribution half exists because a `globalSetup` throw is reported against
+// whichever spec Playwright names first, so the gate's own output is the ONLY
+// thing that can say "the preview was not warm" rather than "the sözlük
+// create-flow is broken" — and when it couldn't, an investigation went after the
+// wrong subsystem for a week (#3179).
+
+const PROBE_KIND = {
+	spaRoute: "spa-route",
+	authRead: "auth-read",
+	authWrite: "auth-write",
+};
+
+/** A readiness probe, named so a failure says which one. */
+function describeProbe(probe) {
+	return `${probe.kind} ${probe.target}`;
+}
+
+// The poll interval rate-limits how often an ATTEMPT MAY START — it is not dead
+// time to append after every failure. A probe that fails by timing out has
+// already backed off for its whole timeout (10s ≫ the 3s interval), so sleeping
+// again spends budget buying nothing: on the live cold boot of PR #3176 the gate
+// burned 9s of its 90s cap on three such sleeps. A probe that fails FAST (an
+// auth route answering 404 immediately) is the case the interval is actually for,
+// and still gets the full remainder. See #3179.
+function sleepAfterAttemptMs({attemptElapsedMs, pollIntervalMs, remainingMs}) {
+	const owed = Math.max(0, pollIntervalMs - attemptElapsedMs);
+	return Math.max(0, Math.min(owed, remainingMs));
+}
+
+// The per-probe timeout, clamped to what is left of the hard cap. Unclamped, the
+// cap was not a cap: the deadline was only tested between attempts, so an attempt
+// whose probes each ran their full timeout could overrun it by a whole attempt
+// (5 routes x (goto 10s + topbar 10s) + 2 auth probes ~ 100s on top of the
+// documented 90s). `null` means the budget is spent — the caller must stop
+// rather than start a probe it has no time for.
+function probeTimeoutMs({remainingMs, attemptTimeoutMs}) {
+	if (remainingMs <= 0) return null;
+	return Math.min(attemptTimeoutMs, remainingMs);
+}
+
+// The gate's failure is a preview-infrastructure verdict, so it carries the
+// attribution a naked `Error` could not: which probe was outstanding, how many
+// attempts it got, how long it actually waited — and, load-bearing, that the
+// spec name Playwright prints beside it means nothing (#3179).
+class PreviewNotWarmError extends Error {
+	constructor({baseURL, budgetMs, elapsedMs, attempts, probe, lastError}) {
+		super(
+			`[preview-ready] PREVIEW READINESS GATE FAILED — ${baseURL} never became warm ` +
+				`within ${budgetMs}ms (${attempts} attempt(s), ${elapsedMs}ms elapsed).\n` +
+				`  Outstanding probe: ${probe ? describeProbe(probe) : "(no attempt completed)"}\n` +
+				`  Last failure: ${lastError}\n` +
+				"  This is the Playwright globalSetup preview-readiness gate, NOT a spec failure. " +
+				"Playwright attributes a globalSetup throw to whichever spec it reports first, so any " +
+				"spec name shown next to this error is arbitrary — investigate the per-PR preview " +
+				"deploy, not that spec, and not this PR's diff (#3179).",
+		);
+		this.name = "PreviewNotWarmError";
+		this.baseURL = baseURL;
+		this.budgetMs = budgetMs;
+		this.elapsedMs = elapsedMs;
+		this.attempts = attempts;
+		this.probe = probe;
+		this.lastError = lastError;
+	}
+}
+
+function formatAttemptFailure({attempt, probe, probeElapsedMs, remainingMs, sleepMs, lastError}) {
+	return (
+		`[preview-ready] attempt ${attempt}: ${describeProbe(probe)} not ready after ${probeElapsedMs}ms ` +
+		`(${remainingMs}ms of budget left) — ${lastError} — retrying in ${sleepMs}ms…`
+	);
+}
+
+// Says the gate PASSED, in as many words. The #3179 misdiagnosis read this run's
+// "not ready yet" retry lines as the cause of a red that happened AFTER this
+// line — so the success line has to close that reading itself.
+function formatWarm({baseURL, attempts, elapsedMs, probeCount}) {
+	return (
+		`[preview-ready] preview warm at ${baseURL} after ${attempts} attempt(s) / ${elapsedMs}ms ` +
+		`(${probeCount} probes passed) — THE READINESS GATE PASSED. Any failure later in this run is ` +
+		"a real spec failure, not preview warmth (#3179)."
+	);
+}
+
+module.exports = {
+	PROBE_KIND,
+	PreviewNotWarmError,
+	describeProbe,
+	formatAttemptFailure,
+	formatWarm,
+	probeTimeoutMs,
+	sleepAfterAttemptMs,
+};

--- a/apps/web/tests/e2e/_setup/preview-ready-policy.unit.test.ts
+++ b/apps/web/tests/e2e/_setup/preview-ready-policy.unit.test.ts
@@ -1,0 +1,131 @@
+import {describe, expect, it} from "vitest";
+import {
+	describeProbe,
+	formatAttemptFailure,
+	formatWarm,
+	PROBE_KIND,
+	PreviewNotWarmError,
+	probeTimeoutMs,
+	sleepAfterAttemptMs,
+} from "./preview-ready-policy.cjs";
+
+const route = {kind: PROBE_KIND.spaRoute, target: "/pano/yeni"};
+
+describe("probeTimeoutMs — the hard cap is actually hard", () => {
+	it("gives a probe its full timeout while the budget is wide open", () => {
+		expect(probeTimeoutMs({remainingMs: 90_000, attemptTimeoutMs: 10_000})).toBe(10_000);
+	});
+
+	it("clamps the last probe to what is left, so an attempt cannot outlive the cap", () => {
+		expect(probeTimeoutMs({remainingMs: 2_500, attemptTimeoutMs: 10_000})).toBe(2_500);
+	});
+
+	it("returns null once the budget is spent, so no probe starts on borrowed time", () => {
+		expect(probeTimeoutMs({remainingMs: 0, attemptTimeoutMs: 10_000})).toBeNull();
+		expect(probeTimeoutMs({remainingMs: -1, attemptTimeoutMs: 10_000})).toBeNull();
+	});
+});
+
+describe("sleepAfterAttemptMs — the poll interval rate-limits attempts, it is not dead time", () => {
+	it("does not sleep after a probe that already waited longer than the interval", () => {
+		// The live #3176 shape: a 10s topbar timeout is 3x the interval of backoff
+		// already; the old fixed 3s sleep spent budget buying nothing.
+		expect(
+			sleepAfterAttemptMs({attemptElapsedMs: 10_000, pollIntervalMs: 3_000, remainingMs: 60_000}),
+		).toBe(0);
+	});
+
+	it("sleeps only the unspent remainder after a fast failure", () => {
+		expect(
+			sleepAfterAttemptMs({attemptElapsedMs: 500, pollIntervalMs: 3_000, remainingMs: 60_000}),
+		).toBe(2_500);
+	});
+
+	it("never sleeps past the deadline", () => {
+		expect(
+			sleepAfterAttemptMs({attemptElapsedMs: 0, pollIntervalMs: 3_000, remainingMs: 800}),
+		).toBe(800);
+		expect(sleepAfterAttemptMs({attemptElapsedMs: 0, pollIntervalMs: 3_000, remainingMs: -5})).toBe(
+			0,
+		);
+	});
+});
+
+describe("attribution — the next occurrence names itself", () => {
+	it("names the probe kind and target", () => {
+		expect(describeProbe(route)).toBe("spa-route /pano/yeni");
+		expect(describeProbe({kind: PROBE_KIND.authWrite, target: "/api/auth/sign-up/email"})).toBe(
+			"auth-write /api/auth/sign-up/email",
+		);
+	});
+
+	it("the retry line says WHICH probe stalled, not just that something did", () => {
+		const line = formatAttemptFailure({
+			attempt: 3,
+			probe: route,
+			probeElapsedMs: 10_014,
+			remainingMs: 51_000,
+			sleepMs: 0,
+			lastError: "locator.waitFor: Timeout 10000ms exceeded.",
+		});
+		expect(line).toContain("attempt 3");
+		expect(line).toContain("spa-route /pano/yeni");
+		expect(line).toContain("51000ms of budget left");
+	});
+
+	it("the success line states the gate PASSED, closing the #3179 misreading", () => {
+		const line = formatWarm({
+			baseURL: "https://preview.example/",
+			attempts: 5,
+			elapsedMs: 57_000,
+			probeCount: 7,
+		});
+		expect(line).toContain("THE READINESS GATE PASSED");
+		expect(line).toContain("not preview warmth");
+	});
+
+	it("the failure is a named error carrying the probe, attempts and elapsed time", () => {
+		const err = new PreviewNotWarmError({
+			baseURL: "https://preview.example/",
+			budgetMs: 90_000,
+			elapsedMs: 90_120,
+			attempts: 8,
+			probe: route,
+			lastError: "locator.waitFor: Timeout 10000ms exceeded.",
+		});
+		expect(err).toBeInstanceOf(Error);
+		expect(err.name).toBe("PreviewNotWarmError");
+		expect(err.probe).toEqual(route);
+		expect(err.attempts).toBe(8);
+		expect(err.message).toContain("spa-route /pano/yeni");
+		expect(err.message).toContain("8 attempt(s)");
+	});
+
+	it("the failure disowns the spec name Playwright will print beside it", () => {
+		// The whole cost of #3179: a globalSetup throw is reported against an
+		// arbitrary spec, and a reader chased a sözlük product bug that wasn't there.
+		const err = new PreviewNotWarmError({
+			baseURL: "https://preview.example/",
+			budgetMs: 90_000,
+			elapsedMs: 90_120,
+			attempts: 8,
+			probe: route,
+			lastError: "boom",
+		});
+		expect(err.message).toContain("NOT a spec failure");
+		expect(err.message).toContain("arbitrary");
+	});
+
+	it("stays legible when the preview was dead from the first probe", () => {
+		const err = new PreviewNotWarmError({
+			baseURL: "https://preview.example/",
+			budgetMs: 90_000,
+			elapsedMs: 90_000,
+			attempts: 1,
+			probe: null,
+			lastError: "net::ERR_CONNECTION_REFUSED",
+		});
+		expect(err.message).toContain("(no attempt completed)");
+		expect(err.message).toContain("net::ERR_CONNECTION_REFUSED");
+	});
+});

--- a/apps/web/tests/e2e/_setup/preview-ready.cjs
+++ b/apps/web/tests/e2e/_setup/preview-ready.cjs
@@ -21,12 +21,24 @@
 // failure into green — the specs themselves run exactly once, under the
 // config's existing `retries`).
 //
+// The budget arithmetic and the failure attribution live in the pure, offline
+// unit-tested `preview-ready-policy.cjs`; this file is the thin I/O shell that
+// drives a browser and a request context against them (#3179).
+//
 // `.cjs` + `module.exports` (no `export default`, ADR 0001), mirroring
 // `playwright.config.cjs`. Skipped entirely when `E2E_BASE_URL` is unset — the
 // local `pnpm dev` target is already warm, there is no cold-start race, and
 // local runs stay unchanged.
 
 const {chromium, request} = require("@playwright/test");
+const {
+	PROBE_KIND,
+	PreviewNotWarmError,
+	formatAttemptFailure,
+	formatWarm,
+	probeTimeoutMs,
+	sleepAfterAttemptMs,
+} = require("./preview-ready-policy.cjs");
 
 // Auth-router readiness probe: a side-effect-free better-auth GET mounted under
 // the same `/api/auth/*` route as the `sign-up/email` POST that 404'd on the
@@ -55,61 +67,112 @@ const READY_BUDGET_MS = 90_000; // hard cap: a persistent failure reds the gate 
 const ATTEMPT_TIMEOUT_MS = 10_000; // per-attempt page-load / topbar-visible budget
 const POLL_INTERVAL_MS = 3_000;
 
+// The ordered probe list, each one NAMED so a failure identifies itself. The SPA
+// routes come first (they warm the isolate the auth probes then hit).
+const PROBES = [
+	...WARM_ROUTES.map((route) => ({kind: PROBE_KIND.spaRoute, target: route})),
+	{kind: PROBE_KIND.authRead, target: AUTH_READY_PATH},
+	{kind: PROBE_KIND.authWrite, target: AUTH_WRITE_PROBE_PATH},
+];
+
 module.exports = async function waitForPreviewReady() {
 	const baseURL = process.env.E2E_BASE_URL;
 	if (!baseURL) return; // local dev target is already warm — no cold-start race
 
-	const deadline = Date.now() + READY_BUDGET_MS;
+	const start = Date.now();
+	const deadline = start + READY_BUDGET_MS;
 	const browser = await chromium.launch();
 	const api = await request.newContext({baseURL});
 	let lastError = "(no attempt completed)";
+	let lastProbe = null;
+	let attempt = 0;
 	try {
 		const page = await browser.newPage({baseURL});
+
+		// One probe against the live preview. `timeout` is already clamped to the
+		// remaining budget by the caller, so no probe can outlive the hard cap.
+		const runProbe = async (probe, timeout) => {
+			if (probe.kind === PROBE_KIND.spaRoute) {
+				// The topbar is client-side React, so a raw fetch of the static shell
+				// can't see it — this needs a real browser render. Every first-touched
+				// route is warmed, not just `/`: a cold nested route (`/pano/yeni`)
+				// never mounted its topbar and false-redded the smoke spec.
+				await page.goto(probe.target, {waitUntil: "domcontentloaded", timeout});
+				await page.locator(".kp-topbar").waitFor({state: "visible", timeout});
+				return;
+			}
+			// A read being warm does not imply the write route is mounted (the #716
+			// cold-start signature): a `404` HTML fallback means it isn't yet. The
+			// write probe POSTs the exact path+method the setup races, with an empty
+			// body — better-auth rejects it as a validation error (non-404, no user
+			// created), so it stays side-effect-free.
+			const res =
+				probe.kind === PROBE_KIND.authRead
+					? await api.get(probe.target, {timeout})
+					: await api.post(probe.target, {data: {}, timeout});
+			if (res.status() === 404) {
+				throw new Error(`${probe.target} → 404 (auth router not warm yet)`);
+			}
+		};
+
 		while (Date.now() < deadline) {
+			attempt += 1;
+			const attemptStart = Date.now();
+			let probeStart = attemptStart;
 			try {
-				// 1) SPA shell warm — every first-touched route renders the mounted
-				//    topbar. The topbar is client-side React, so a raw fetch of the
-				//    static shell can't see it; this needs a real browser render. Warm
-				//    each route (not just `/`): a cold nested route (`/pano/yeni`) never
-				//    mounted its topbar and false-redded the smoke spec.
-				for (const route of WARM_ROUTES) {
-					await page.goto(route, {waitUntil: "domcontentloaded", timeout: ATTEMPT_TIMEOUT_MS});
-					await page.locator(".kp-topbar").waitFor({state: "visible", timeout: ATTEMPT_TIMEOUT_MS});
-				}
-
-				// 2) Auth read route warm — a non-404 proves `/api/auth/*` is mounted.
-				const readRes = await api.get(AUTH_READY_PATH);
-				if (readRes.status() === 404) {
-					throw new Error(`${AUTH_READY_PATH} → 404 (auth router not warm yet)`);
-				}
-
-				// 3) Auth WRITE route warm — POST the exact `sign-up/email` path+method
-				//    the setup races. A read being warm does not imply this write route
-				//    is mounted (the #716 cold-start signature); a `404` HTML fallback
-				//    here means it isn't yet. Empty body ⇒ validation error (non-404, no
-				//    user created), so this stays side-effect-free.
-				const writeRes = await api.post(AUTH_WRITE_PROBE_PATH, {data: {}});
-				if (writeRes.status() === 404) {
-					throw new Error(`${AUTH_WRITE_PROBE_PATH} POST → 404 (auth write route not warm yet)`);
+				for (const probe of PROBES) {
+					lastProbe = probe;
+					probeStart = Date.now();
+					// Re-checked BEFORE EVERY probe, not just between attempts: with the
+					// old between-attempts-only check an attempt whose probes each ran
+					// their full timeout could overrun the "hard cap" by a whole attempt
+					// (~100s on top of 90s), so the cap was not one.
+					const timeout = probeTimeoutMs({
+						remainingMs: deadline - Date.now(),
+						attemptTimeoutMs: ATTEMPT_TIMEOUT_MS,
+					});
+					if (timeout === null) throw new Error("readiness budget exhausted mid-attempt");
+					await runProbe(probe, timeout);
 				}
 
 				console.log(
-					`[preview-ready] preview warm at ${baseURL} ` +
-						`(${WARM_ROUTES.length} routes rendered, auth read+write routes non-404)`,
+					formatWarm({
+						baseURL,
+						attempts: attempt,
+						elapsedMs: Date.now() - start,
+						probeCount: PROBES.length,
+					}),
 				);
 				return;
 			} catch (err) {
 				lastError = err instanceof Error ? err.message : String(err);
+				const now = Date.now();
+				const sleepMs = sleepAfterAttemptMs({
+					attemptElapsedMs: now - attemptStart,
+					pollIntervalMs: POLL_INTERVAL_MS,
+					remainingMs: deadline - now,
+				});
 				console.log(
-					`[preview-ready] not ready yet: ${lastError} — retrying in ${POLL_INTERVAL_MS}ms…`,
+					formatAttemptFailure({
+						attempt,
+						probe: lastProbe,
+						probeElapsedMs: now - probeStart,
+						remainingMs: Math.max(0, deadline - now),
+						sleepMs,
+						lastError,
+					}),
 				);
-				await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+				if (sleepMs > 0) await new Promise((resolve) => setTimeout(resolve, sleepMs));
 			}
 		}
-		throw new Error(
-			`[preview-ready] preview ${baseURL} not warm within ${READY_BUDGET_MS}ms — last failure: ${lastError}. ` +
-				"This is a bounded readiness gate, not a retry of test assertions: a persistent failure reds the e2e gate.",
-		);
+		throw new PreviewNotWarmError({
+			baseURL,
+			budgetMs: READY_BUDGET_MS,
+			elapsedMs: Date.now() - start,
+			attempts: attempt,
+			probe: lastProbe,
+			lastError,
+		});
 	} finally {
 		await api.dispose();
 		await browser.close();

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -172,6 +172,11 @@ export default defineConfig({
 						// Pure-core tests of the headless build tooling (the node-core
 						// bundle assertion, #1836) — no deployed worker, runs offline here.
 						"scripts/**/*.unit.test.ts",
+						// Pure-core tests of the e2e harness substrate (the preview-readiness
+						// gate's budget + attribution policy, #3179). Playwright never sees
+						// them and they launch no browser; only the `.spec.ts` files under
+						// `tests/e2e` belong to the Playwright run.
+						"tests/e2e/**/*.unit.test.ts",
 					],
 					exclude: ["node_modules/**", "dist/**"],
 					sequence: {groupOrder: 1},


### PR DESCRIPTION
Fixes #3179

**Collapsed investigation (ADR 0070).** #3179 is `type:investigation`; the diagnosis below *is* the deliverable, and it resolves into a bounded harness fix, so it lands as one PR carrying the verdict rather than as `report` residue. The fix is independently `review-code`-gated like any other.

## The issue's premise is falsified at its only cited instance

#3179 says the e2e warm gate reds clean PRs by exhausting its 90s budget, citing PR #3176's red as the live instance. **That is not what happened.** From the failing job's own log (run `29523601245` attempt 1, job `87706416047`):

```
18:25:02  [preview-ready] preview warm at https://…workers.dev (5 routes rendered, auth read+write routes non-404)
18:25:02  Running 82 tests using 1 worker
…
18:25:59  ✘ 37 [flows] › 06-sozluk-home.spec.ts:77 › SozlukHome create-flow … (7.6s)
18:26:08  ✘ 38 [flows] › 06-sozluk-home.spec.ts:77 › … (retry #1) (8.5s)
```

The gate **passed**, at +57s of its 90s budget, and the run then failed on a genuine spec failure:

```
TimeoutError: locator.click: Timeout 5000ms exceeded.
  - locator resolved to <button type="submit" class="kp-btn kp-btn--primary">oluştur</button>
  - element is not stable
  - element was detached from the DOM, retrying
```

That signature is #3600 verbatim — *"Base UI dialog portal re-renders/detaches its popup subtree after open (sözlük + yeni tanım composer)"* — closed 2026-07-24, with the CTA's open-state hoist in #3840. So the cited red was a real, since-fixed product defect, and `06-sozluk-home` was the correct attribution, not a misattribution.

**What the reporter actually saw** were the gate's `[preview-ready] not ready yet: … — retrying in 3000ms…` lines — the gate *working* — and read them as the cause of a red that happened afterwards. The gate's output gave them no way to tell the difference. That ambiguity is the defect this PR fixes.

## Measured (acceptance criterion 1)

Every `pull_request` CI run reachable through the Actions API (~800 runs → **268 e2e jobs that actually ran the gate**), parsed from each job's `[preview-ready]` lines:

| metric | value |
| --- | --- |
| budget-exhaustion reds | **0 of 268** |
| warm on the first attempt, no retry | 192 of 268 (72%) |
| warm time p50 / p90 / max | 4.0s / 28.9s / **56.6s** |
| worst observed retry count | 9 |

So the per-PR preview under real concurrent CI load warms well inside the cap — the slowest observed run used 63% of it — and **the gate has never redded a PR in the observable window.** A `READY_BUDGET_MS` bump would have been a fix for a failure that does not occur; the collateral-blocking premise of AC 3 is unsupported by the data, and de-collateralizing a gate that has never fired would trade a loud red for a silent pass.

The same measurement does name a real, non-blind hardening: **the fixed 3s poll sleep is pure overhead once a probe has timed out.** In the 9-retry run it was **57% of the elapsed warm time** (27s of 47s); in the slowest run, 21%.

## Root cause

The gate's defect is not its budget. It is that **its output cannot identify itself**, and its documented hard cap is not hard.

1. **A `globalSetup` throw is attributed to an arbitrary spec, and the gate never said so.** The old exhaustion message named neither the probe, the attempt count, nor the elapsed time, and said nothing about the spec name Playwright would print beside it. The old retry line named the *locator* (`waiting for locator('.kp-topbar')`) but not **which of the five routes** it was waiting on. This is the #3942 cost exactly: a failure that prints nothing actionable sends the next reader at the wrong subsystem.
2. **The 90s "hard cap" was not a cap.** `Date.now() < deadline` was tested only between attempts, so an attempt whose probes each ran their full `ATTEMPT_TIMEOUT_MS` could overrun it by a whole attempt — 5 routes × (goto 10s + topbar 10s) + 2 auth probes ≈ **100s on top of the documented 90s**, on the success path as well as the failure path.
3. **The poll interval was dead time, not a rate limit.** A probe that fails by timing out has already backed off for 10s; sleeping another 3s spends budget buying nothing (measured above).

## The fix

New pure core `apps/web/tests/e2e/_setup/preview-ready-policy.cjs` — no browser, no socket, no clock, every input passed in, unit-tested offline (the `_d1-rest-retry.ts` / `_request-stall.ts` shape). `preview-ready.cjs` becomes the thin I/O shell over it.

- **`PreviewNotWarmError`** carries the outstanding probe, attempt count, elapsed time and last failure — and states outright that *"Playwright attributes a globalSetup throw to whichever spec it reports first, so any spec name shown next to this error is arbitrary."*
- **Probes are named** (`spa-route /pano/yeni`, `auth-read …`, `auth-write …`), so each retry line says which one stalled, how long it waited, and how much budget is left.
- **The success line states the gate PASSED** — *"any failure later in this run is a real spec failure, not preview warmth"* — which is precisely the reading #3179 got wrong.
- **The deadline is re-checked before every probe**, so the cap is now real.
- **The poll interval rate-limits attempt *starts*** (`max(0, interval − attemptElapsed)`) instead of appending dead time, recovering the measured 21–57% overhead into actual warm-wait within the *unchanged* 90s budget. No constant is changed.

**No recovery masks a failure.** The gate still throws on exhaustion; nothing was made non-gating, retried-into-green, or path-scoped. The one behavioral trade is deliberate and net-generous: clamping the last probe to the remaining budget can end a doomed attempt marginally earlier, while recovering the sleep overhead gives strictly more probe time inside the same cap.

## Verification

- `apps/web/tests/e2e/_setup/preview-ready-policy.unit.test.ts` — 12 offline tests pinning the budget arithmetic (full timeout while open, clamped at the end, `null` once spent, sleep = unspent remainder only, never past the deadline) and the attribution (the retry line names the probe; the success line says PASSED; the error carries probe/attempts/elapsed and disowns the spec name).
- `apps/web/vitest.config.ts` gains `tests/e2e/**/*.unit.test.ts` in the `unit` tier, mirroring the existing `tests/integration/**` and `scripts/**` entries.
- `apps/web/playwright.config.cjs`: the `flows` catch-all ignores `**/*.unit.test.ts`, so the pure-core test can't orphan into the Playwright run — verified with `playwright test --list` (89 tests / 34 files, unchanged).
- `pnpm typecheck` clean · `pnpm lint:worktree` clean · full offline unit tier **285 files / 2388 tests passing**.

## Acceptance criteria

- **Measured before any budget change** — 268 e2e jobs, table above. No budget constant changed.
- **Does not red on a slow-but-eventually-fine boot** — grounded hardening of the poll semantics (sleep-as-rate-limit, deadline honored per probe), not a threshold move.
- **Collateral blocking** — the premise is falsified: 0 exhaustions in 268 jobs, and the one cited instance was #3600. Rather than make a never-firing gate non-gating (a silent pass in exchange for a loud red), the fix recovers budget so exhaustion on a warm-but-slow preview is further out of reach. Flagged for reviewer judgment rather than settled unilaterally.
- **Misleading spec attribution addressed** — the error disowns the spec name in its own text; the success line closes the reading that produced #3179.
- **§CP** — NOT §CP. `.github/workflows/ci.yml` and `packages/ci-required` are untouched; the diff is entirely `apps/web` harness.

## Relationship to #3942 and #3548 — same family, different root cause

All three share the shape *a readiness/protection mechanism reds a green stage*, and none share a cause.

- **#3942** was a readiness probe whose docblock promised fail-open while `req` re-threw the abort. Here the docblock's promise (a bounded poll that reds only a genuinely-broken preview) **is** honored by the code — measured, 0 false reds in 268 jobs. What this gate inherits from #3942 is the *second* half of that fix: the failure had no attribution, so the report guessed the wrong subsystem. Identical lesson, applied to a mechanism whose logic was already sound.
- **#3548** was a rate-limit retry budget too small against a ~290s plateau, with protection opt-in per call site. This gate's budget is **not** undersized (max observed 56.6s of 90s) and there is exactly one poll loop — nothing to make mandatory. The overlap is method only: measure the plateau first, then decide.

Nothing here touches either fix's mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
