### PR TITLE
fix(ship-it): classify head CI from REST check-runs, and tell a wedged check from a running one (#3999)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1109,13 +1109,49 @@ hole of [#1928](https://github.com/kamp-us/phoenix/issues/1928) (a shipper that 
 and died left the PR green-but-not-enqueued with **no** FAIL and **no** outcome comment). You run a
 **bounded, in-process CI-settle poll** ([§The bounded CI-settle poll](#the-bounded-ci-settle-poll--never-a-silent-park-1928))
 that always terminates in one of two PR-visible outcomes — the enqueue, or an explicit refusal
-comment — never a silent park. The human table and exit code can't cleanly separate red from
-pending, and neither tells a *gating* check from an *informational* one — so read the per-check
-**names and states** and classify by name, not by a bare bucket count:
+comment — never a silent park. A bare exit code can't cleanly separate red from pending, and no
+aggregate tells a *gating* check from an *informational* one — so read the per-check **names and
+states** and classify by name, never by a rollup colour alone.
+
+The read is **`pipeline-cli checks read`** — REST check-runs for the PR head, rolled up
+latest-per-context. **Never `gh pr checks`.** That read is GraphQL-backed, and on PR #3988 it
+reported 29 of 33 checks `IN_PROGRESS` across three consecutive reads while REST showed the same
+checks `completed`/`success` 15+ minutes earlier — so a shipper following it literally burns the
+full settle budget and then refuses a fully green PR
+([#3999](https://github.com/kamp-us/phoenix/issues/3999)). That is the transport class this
+suite's REST-only rule exists to avoid; the merge gate is the last place to reach past it. The
+verb also owns the running/wedged split and the latest-per-context reduction — cite it, don't
+re-derive the query (#3762).
 
 ```bash
-gh pr checks $PR --json name,state,bucket --jq '.[] | "\(.bucket)\t\(.name)"'
-# bucket ∈ pass | fail | pending | skipping | cancel
+CHECKS="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli checks"
+
+# Echo the rollup JSON; return 0 readable · 2 UNKNOWN (refuse — never a colour, never green).
+read_head_ci() {
+  local out rc conclusion
+  out="$($CHECKS read --pr "$PR" --expect green 2>/dev/null)"; rc=$?
+  # SHAPE-CHECK BEFORE INTERPRETING: an error body / truncated capture is not data. Exit 2 is the
+  # verb's own typed unknown; a body with no readable `conclusion` is treated identically.
+  conclusion="$(printf '%s' "$out" | jq -r '.conclusion? // empty' 2>/dev/null)"
+  case "$rc:$conclusion" in
+    0:green|1:red|1:pending) printf '%s' "$out"; return 0 ;;
+    *) return 2 ;;
+  esac
+}
+
+CI_JSON="$(read_head_ci)" || {
+  disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: this stop does not enqueue — park nothing
+  gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — head CI **unreadable** (the check-runs read returned no interpretable state) — **not enqueued**. An unreadable head is not a green head; re-dispatch ship-it once the API is answering — idempotent (#3999)." >/dev/null
+  echo "refused — head CI unreadable (typed unknown) — not enqueued"; exit 0
+}
+
+CI_STATE=$(jq -r '.conclusion'  <<<"$CI_JSON")   # green | red | pending
+CONTEXTS=$(jq -r '.contexts'    <<<"$CI_JSON")   # how many contexts the rollup covered
+RUNNING=$(jq -r  '.running | join(", ")' <<<"$CI_JSON")   # genuinely in flight — these settle
+WEDGED=$(jq -r   '.wedged  | join(", ")' <<<"$CI_JSON")   # queued, never started — these do NOT
+# The known-informational carve-out, applied to the failing set (names below).
+GATING_RED=$(jq -r '[.failing[]
+  | select(. != "deploy (web)" and (startswith("cleanup (web,") | not))] | join(", ")' <<<"$CI_JSON")
 ```
 
 Not every red check blocks a merge. **`main` carries no required-status-check branch
@@ -1135,8 +1171,22 @@ preview-deploy/teardown checks are informational; every other red, including any
 run-evidence (lint/format/typecheck, unit/integration/e2e) check, stays gating — see ADR
 [0061](https://github.com/kamp-us/phoenix/blob/main/.decisions/0061-ship-it-gating-check-set.md).
 
-An **empty** check set is ambiguous and must not be read as green on its face: it is either
-"CI ran and every check passed" or "no run ever fired for this head." Disambiguate it against
+**An unfinished check is one of two different facts, and the read tells them apart.** `$RUNNING`
+is genuinely in flight — it settles on its own, which is exactly what the settle poll waits for.
+`$WEDGED` is **stranded in the queue**: `status: queued` with a `null` `started_at`, a run that
+never starts without an operator lever. A `fanout-guard` job sat wedged for ~2.5h and blocked a
+fully-green PR while every surface an agent reads said only "pending" (#3999). Both are pending
+to the gate — a wedge is **never** green, and the classification below is unchanged in that
+direction — but they get **different outcomes**: running is waited out, wedged is *reported*.
+
+**Zero-run check suites are not pending.** The inert third-party suites (vercel, sentry,
+cloudflare-workers-and-pages) sit `queued` with **no attached check runs** on every head. A suite
+with no runs has no state to contribute, so it contributes none: the rollup names them in
+`inertSuites` for the ledger and counts none of them toward pending. This is what makes PR
+#3988's shape — 43 completed check-runs, three zero-run `queued` suites — classify **green**.
+
+An **empty** check set (`$CONTEXTS == 0`) is ambiguous and must not be read as green on its face:
+it is either "CI ran and every check passed" or "no run ever fired for this head." Disambiguate it against
 the workflow runs GitHub actually recorded for the head SHA — **both reads fail safe toward
 "do *not* nudge"** (the Step-3z remedy close→reopens a live PR; never do that on a guessed
 absence):
@@ -1156,16 +1206,21 @@ NRUNS=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
 [ -z "$NWF" ]   && NWF=0
 ```
 
-Classify in this order (`skipping`/`cancel` are non-blocking — neither a failure nor an
-in-flight wait):
+Classify in this order (a `skipped` / `cancelled` conclusion is non-blocking — neither a failure
+nor an in-flight wait — and the rollup already resolves each context to its **latest** run, so a
+superseded red can't red a green head, #3762):
 
-1. **Any *gating* check red** (a `fail` whose name is not known-informational) → do **not**
+1. **Any *gating* check red** (`$GATING_RED` non-empty) → do **not**
    merge. Run `disarm_intent refuse || INTENT_UNCLEARED=1` (guard 6), then route it to the
    self-heal lane: invoke
    [`/heal-ci`](../heal-ci/SKILL.md) with this
    PR/run, then report the result (e.g. `routed to heal-ci`). `heal-ci` decides
    flake-vs-defect; you only refuse on a gating red and hand off — you still do not merge.
-2. **Else, any check pending** (no gating red, some unfinished) → **enter the bounded CI-settle
+1b. **Else, the head reported no contexts at all (`$CONTEXTS == 0`)** → skip the poll and go
+   straight to the empty-set disambiguation (branch 3 below). Waiting is pointless when nothing
+   has reported: with zero contexts there is no check to settle, so a settle poll would burn the
+   full budget and refuse with the wrong reason instead of surfacing the dropped trigger.
+2. **Else, `$CI_STATE` is pending** (no gating red, some unfinished) → **enter the bounded CI-settle
    poll** ([§below](#the-bounded-ci-settle-poll--never-a-silent-park-1928)). Do **not** report
    `checks pending` and park: that stop-path delegated resumption to a caller that may never fire,
    and because a decline is a *successful* outcome it left the PR green-but-unenqueued with **no**
@@ -1173,7 +1228,9 @@ in-flight wait):
    on a fixed budget and **always** terminates in exactly one of two PR-visible outcomes: it reaches
    the enqueue (fall through to Step 3.5 → Step 4) the moment the gating suite goes green, or — if
    the budget is exhausted with a gating check still pending — it posts an explicit
-   `refused — CI still pending after <budget>` outcome comment on the PR and stops.
+   `refused — CI still pending after <budget>` outcome comment on the PR and stops. When what is
+   unfinished is **wedged** rather than running, the poll refuses early with the distinct
+   stranded-in-queue reason instead of waiting out a run that cannot start (§below).
 3. **Else, the repo runs Actions (`NWF ≥ 1`) but the head SHA has zero workflow runs
    (`NRUNS == 0`)** → the **dropped-trigger state** (Step 3z). This is **not** green: an empty
    check set with *no runs behind it* is "CI never fired," not "CI ran and passed." Do **not**
@@ -1221,17 +1278,22 @@ false-green Step 3z guards (that state is branch 3, never reached from here):
 ```bash
 SETTLE_BUDGET_SECS="${SHIP_IT_SETTLE_BUDGET_SECS:-600}"    # total in-process wait ceiling — BOUNDED, never unbounded
 SETTLE_INTERVAL_SECS="${SHIP_IT_SETTLE_INTERVAL_SECS:-30}" # cadence; each pass emits progress so a no-progress watchdog never fires
-ci_settle_wait() {   # returns 0=settled-green→enqueue · 1=refused (budget-exhausted OR head moved mid-settle; comment posted) · 2=gating red mid-wait→heal-ci
-  local waited=0 bucket name red pending headnow
+WEDGE_DWELL_SECS="${SHIP_IT_WEDGE_DWELL_SECS:-120}"        # how long an all-wedged pending set must persist before it is called wedged
+ci_settle_wait() {   # returns 0=settled-green→enqueue · 1=refused (budget-exhausted, wedged, OR head moved mid-settle; comment posted) · 2=gating red mid-wait→heal-ci
+  local waited=0 wedged_for=0 json red pending wedged running headnow
   while :; do
-    red=""; pending=""
-    while IFS=$'\t' read -r bucket name; do
-      case "$bucket" in
-        # same known-informational carve-out as Step 3: a red preview-deploy/teardown check never gates
-        fail)    case "$name" in "deploy (web)"|"cleanup (web,"*) ;; *) red="$red $name" ;; esac ;;
-        pending) pending="$pending $name" ;;
-      esac
-    done < <(gh pr checks "$PR" --json name,state,bucket --jq '.[] | "\(.bucket)\t\(.name)"')
+    # The SAME read as Step 3 — REST check-runs through `pipeline-cli checks read`, never
+    # `gh pr checks` (#3999). An unreadable head refuses here exactly as it does at Step 3.
+    json="$(read_head_ci)" || {
+      disarm_intent refuse || INTENT_UNCLEARED=1
+      gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — head CI became **unreadable** during the CI-settle wait — **not enqueued**. An unreadable head is not a green head; re-dispatch ship-it — idempotent (#3999)." >/dev/null
+      echo "refused — head CI unreadable mid-settle — not enqueued"; return 1
+    }
+    # same known-informational carve-out as Step 3: a red preview-deploy/teardown check never gates
+    red="$(jq -r '[.failing[] | select(. != "deploy (web)" and (startswith("cleanup (web,") | not))] | join(" ")' <<<"$json")"
+    running="$(jq -r '.running | join(" ")' <<<"$json")"
+    wedged="$(jq -r  '.wedged  | join(" ")' <<<"$json")"
+    pending="$(jq -r '(.running + .wedged) | join(" ")' <<<"$json")"
     if [ -n "$red" ]; then
       disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: this wait ends without an enqueue — park nothing
       echo "gating check went red during settle-wait ($red) — routing to heal-ci"; return 2
@@ -1251,14 +1313,32 @@ ci_settle_wait() {   # returns 0=settled-green→enqueue · 1=refused (budget-ex
       fi
       echo "gating checks settled green after ${waited}s — proceeding to Step 3.5 → enqueue"; return 0
     fi
+    # WEDGED: everything unfinished is queued-and-never-started. Such a run does not start on its
+    # own, so the remaining budget cannot clear it — refuse once the state has held for the dwell
+    # (a check queued seconds ago is normal; one queued with no start time for minutes is stuck).
+    if [ -n "$wedged" ] && [ -z "$running" ]; then
+      wedged_for=$((wedged_for + SETTLE_INTERVAL_SECS))
+    else
+      wedged_for=0
+    fi
+    if [ "$wedged_for" -ge "$WEDGE_DWELL_SECS" ]; then
+      disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: this wait ends without an enqueue — park nothing
+      gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — CI **wedged (stranded in queue)** for ${wedged_for}s — **not enqueued**. These gating checks are \`queued\` with no start time and are not running: ${wedged}. A wedged run does not start on its own, so waiting the ${SETTLE_BUDGET_SECS}s settle budget out cannot clear it — this is reported as its own state rather than waited out (#3999). Operator lever (deliberately NOT automated — see the skill): cancel the stuck workflow run, then re-run it (a plain rerun on a still-queued run returns 403):
+\`\`\`
+RUN=\$(gh api \"repos/$REPO/actions/runs?head_sha=$CURRENT_HEAD&per_page=100\" --jq '.workflow_runs[] | select(.status==\"queued\") | .id')
+gh api -X POST \"repos/$REPO/actions/runs/\$RUN/cancel\" && gh api -X POST \"repos/$REPO/actions/runs/\$RUN/rerun\"
+\`\`\`
+Re-dispatch ship-it once the re-run settles — idempotent, a re-ship on the now-green head enqueues cleanly." >/dev/null
+      echo "refused — CI wedged (stranded in queue: ${wedged}) after ${wedged_for}s — not enqueued"; return 1
+    fi
     if [ "$waited" -ge "$SETTLE_BUDGET_SECS" ]; then
       disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: the budget ran out without an enqueue — park nothing
       # Budget exhausted, still pending → the ONE required durable signal: an explicit PR-visible refusal.
       # A plain outcome note, NOT a review-* verdict marker — so it never blocks a later idempotent re-ship.
-      gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — CI still pending after ${SETTLE_BUDGET_SECS}s (gating checks unfinished:${pending}) — **not enqueued**. This head is not yet merge-ready; re-dispatch ship-it once CI settles — idempotent, a re-ship on the now-green head enqueues cleanly (#1928)." >/dev/null
+      gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — CI still pending after ${SETTLE_BUDGET_SECS}s (still running: ${running:-none}; wedged in queue: ${wedged:-none}) — **not enqueued**. This head is not yet merge-ready; re-dispatch ship-it once CI settles — idempotent, a re-ship on the now-green head enqueues cleanly (#1928)." >/dev/null
       echo "refused — CI still pending after ${SETTLE_BUDGET_SECS}s (PR outcome comment posted) — not enqueued"; return 1
     fi
-    echo "checks still pending after ${waited}s (${pending# }) — re-reading in ${SETTLE_INTERVAL_SECS}s (budget ${SETTLE_BUDGET_SECS}s)"
+    echo "checks still pending after ${waited}s (running: ${running:-none}; wedged: ${wedged:-none}) — re-reading in ${SETTLE_INTERVAL_SECS}s (budget ${SETTLE_BUDGET_SECS}s)"
     sleep "$SETTLE_INTERVAL_SECS"; waited=$((waited + SETTLE_INTERVAL_SECS))
   done
 }
@@ -1272,7 +1352,7 @@ case "$SETTLE_RC" in
      # /heal-ci for this PR (the same agent action Step 3 branch 1 takes), then exit — falling through here
      # would enqueue a red PR, the exact merge-safety hole this arm exists to close (#1928).
      echo "routed to heal-ci — gating check went red mid-settle for PR #$PR; not enqueued"; exit 0 ;;
-  1) exit 0 ;;    # refused (budget-exhausted, or head moved mid-settle) — durable outcome comment posted; a successful decline, no longer silent (#1928)
+  1) exit 0 ;;    # refused (budget-exhausted, wedged in queue, head moved mid-settle, or unreadable) — durable outcome comment posted; a successful decline, no longer silent (#1928)
 esac
 ```
 
@@ -1282,6 +1362,27 @@ Step 4 — and `1` posts the durable refusal and stops. Both non-zero returns `e
 `0` proceeds to enqueue. There is **no fourth path** where the shipper leaves the pending-wait without
 either enqueuing or landing a PR-visible outcome — the silent park of #1928 is structurally
 unreachable, and a mid-wait gating-red can never slip through to the merge queue.
+
+### Wedged is a diagnosis, not a wait — and the remedy stays the operator's lever
+
+The poll's refusals are deliberately **three different facts, named differently**: the budget ran
+out while checks were genuinely running; the head moved; or the remaining checks are **wedged** —
+`queued` with no start time, stranded. Before #3999 all three read as "CI still pending," which is
+what let a `fanout-guard` job sit wedged for ~2.5h behind a comment that told the next agent to
+just wait longer. Naming the state is the fix: "stranded in queue" and "still running" are
+different facts and must be distinguishable through the surfaces an agent reads.
+
+**ship-it reports the wedge; it does not clear it.** The remedy — `POST
+/actions/runs/<id>/cancel` then `POST /actions/runs/<id>/rerun` (a plain `rerun` on a still-queued
+run returns 403) — is spelled out in the refusal comment, but ship-it does not run it, for two
+reasons. First, **authority**: ship-it holds the single *merge* authority (ADR 0048), not a
+CI-mutation authority; cancelling and re-running another workflow's runs is a different power, and
+a merge gate that silently reruns CI to make itself pass is a gate that can launder a stuck
+producer into a green. Second, **termination**: a wedge whose cause is a genuinely broken producer
+would be cancel/rerun-looped forever by an automatic remedy, which is the same unbounded-retry
+shape the Step-3z nudge is explicitly bounded against. So the wedge exits the same way every other
+non-enqueue does — a durable, PR-visible outcome naming the state and the lever — and a human or
+`heal-ci` pulls it.
 
 **Idempotency is preserved.** The refusal comment is a plain outcome note, not a `review-*` verdict
 marker and not a merge blocker, so a later re-dispatch on the now-green head clears every guard and
@@ -2197,7 +2298,12 @@ not bound to current head)` (a SHA-less or stale-head verdict — Step 2b, ADR 0
 verdict is FAIL (<gate>)`, `routed to heal-ci` (a gating red check, handed to the self-heal lane),
 `refused — CI still pending after <budget>` (the bounded CI-settle poll ran to its budget with a
 gating check still unfinished — Step 3, #1928; a durable PR outcome comment is posted, and a
-re-dispatch on the now-green head enqueues cleanly), the dropped-trigger outcomes (Step 3z):
+re-dispatch on the now-green head enqueues cleanly), `refused — CI wedged (stranded in queue:
+<names>)` (the unfinished checks are `queued` with no start time and will not start on their own,
+so the poll refuses with the distinct diagnosis and the cancel-then-rerun lever rather than
+waiting the budget out — Step 3, #3999), `refused — head CI unreadable (typed unknown)` (the
+check-runs read returned nothing interpretable; an unreadable head is never a green head — #3999),
+the dropped-trigger outcomes (Step 3z):
 `nudged (close→reopen) — CI re-triggered, not yet merge-ready` (the head SHA had zero workflow
 runs; ship-it close→reopened it once to re-emit the trigger, posted a durable PR outcome comment,
 and stopped — re-dispatch after CI settles) or `unverified (no runs fired — nudge exhausted,

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1145,7 +1145,8 @@ CI_JSON="$(read_head_ci)" || {
   echo "refused — head CI unreadable (typed unknown) — not enqueued"; exit 0
 }
 
-CI_STATE=$(jq -r '.conclusion'  <<<"$CI_JSON")   # green | red | pending
+# The aggregate `.conclusion` is deliberately NOT bound here: it is a colour in which red wins over
+# pending, so classifying off it lets an informational red mask an unfinished check (see below).
 CONTEXTS=$(jq -r '.contexts'    <<<"$CI_JSON")   # how many contexts the rollup covered
 RUNNING=$(jq -r  '.running | join(", ")' <<<"$CI_JSON")   # genuinely in flight — these settle
 WEDGED=$(jq -r   '.wedged  | join(", ")' <<<"$CI_JSON")   # queued, never started — these do NOT
@@ -1220,7 +1221,8 @@ superseded red can't red a green head, #3762):
    straight to the empty-set disambiguation (branch 3 below). Waiting is pointless when nothing
    has reported: with zero contexts there is no check to settle, so a settle poll would burn the
    full budget and refuse with the wrong reason instead of surfacing the dropped trigger.
-2. **Else, `$CI_STATE` is pending** (no gating red, some unfinished) → **enter the bounded CI-settle
+2. **Else, something is still unfinished — the pending *sets*, never the rollup colour**
+   (`[ -n "$RUNNING$WEDGED" ]`) → **enter the bounded CI-settle
    poll** ([§below](#the-bounded-ci-settle-poll--never-a-silent-park-1928)). Do **not** report
    `checks pending` and park: that stop-path delegated resumption to a caller that may never fire,
    and because a decline is a *successful* outcome it left the PR green-but-unenqueued with **no**
@@ -1241,6 +1243,20 @@ superseded red can't red a green head, #3762):
    (web)) — not gating`, or `informational check red (cleanup (web, …)) — not gating`) and
    continue. Step 3.5 remains the SHA-bound backstop that the gating suite actually passed
    for this commit.
+
+**Branch 2 tests the pending sets, never the rollup's `.conclusion` — an informational red would
+otherwise mask an unfinished gating check.** `.conclusion` is an *aggregate colour*, in which **red
+wins over pending**, and `.failing` still carries the informational checks that the `$GATING_RED`
+carve-out strips only afterwards. So a red `deploy (web)` / `cleanup (web, …)` next to an unfinished
+gating check makes the head read `red`: branch 1 does not fire (no gating red), a colour-based
+branch 2 would not fire either, and the head falls through to branch 4 — **enqueued with CI
+unfinished**.
+The sharp case is this step's own motivating state: a wedged `fanout-guard` plus a red `cleanup
+(web, …)` would enqueue silently instead of producing the stranded-in-queue refusal — and Step 3z's
+close→reopen nudge is documented below as a cause of exactly those `cleanup` reds, so the shipper
+can manufacture the masking condition itself. `ci_settle_wait` already reads the sets (`.running` /
+`.wedged`) and never the colour; the entry test must answer "is anything unfinished?" the same way
+the poll does, or the two diverge and the gate fails open.
 
 The gating set is, by construction, the suite the run-evidence bundle attests SHA-bound in
 Step 3.5 (lint / format / typecheck, unit tests, validate skill frontmatter, integration

--- a/packages/pipeline-cli/src/tools/checks/checks.ts
+++ b/packages/pipeline-cli/src/tools/checks/checks.ts
@@ -13,6 +13,13 @@
  * a needless repair lane on PR #3733). GitHub itself evaluates the most recent run per
  * context, which is why `mergeable_state` disagreed with the naive read; `latestPerContext`
  * re-encodes that, once, here.
+ *
+ * An unconcluded context splits two ways, and conflating them is its own defect (#3999): a run
+ * that is genuinely in flight settles on its own, while one WEDGED in the queue (`status:
+ * queued` with a `null` `started_at`) never starts — a `fanout-guard` job sat that way for ~2.5h
+ * and blocked a green PR while every surface an agent reads said only "pending." Both are
+ * `pending` to the gate (fail-closed, never green); the split is the diagnosis a waiter needs to
+ * tell "still running" from "stranded in queue" instead of waiting the wedge out.
  */
 
 /** A single check run, as the check-runs REST endpoint surfaces it (only these fields decide). */
@@ -27,6 +34,26 @@ export interface CheckRun {
 	readonly completedAt: string | null;
 	/** Server-assigned, strictly-monotonic run id — the recency tiebreak. */
 	readonly id: number;
+	/**
+	 * `queued` | `in_progress` | `completed` | … . Optional: a caller that doesn't need the
+	 * running/wedged split may omit it, and an absent status resolves to `running`, never
+	 * `wedged` — the wedged verdict needs positive evidence, never an absent field.
+	 */
+	readonly status?: string | null;
+}
+
+/**
+ * A check suite, as `commits/{sha}/check-suites` surfaces it. Suites are carried for DIAGNOSIS
+ * only — see `inertSuites`; no suite can make a head pending.
+ */
+export interface CheckSuite {
+	readonly id: number;
+	/** `queued` | `in_progress` | `completed`. */
+	readonly status: string | null;
+	/** How many check runs the suite actually attached. Zero ⇒ inert. */
+	readonly latestCheckRunsCount: number;
+	/** The producing app (`github-actions`, `vercel`, `sentry`, …), for the operator-facing note. */
+	readonly appSlug: string | null;
 }
 
 /** The legacy combined-status envelope, which covers commit statuses that aren't check runs. */
@@ -51,8 +78,17 @@ export interface ChecksRollup {
 	readonly latest: ReadonlyArray<CheckRun>;
 	/** The latest-per-context runs that concluded red. Empty unless `conclusion` is `red`. */
 	readonly failing: ReadonlyArray<CheckRun>;
-	/** The latest-per-context runs that have not concluded yet. */
+	/** Unconcluded runs that are genuinely in flight — they settle on their own. */
 	readonly running: ReadonlyArray<CheckRun>;
+	/** Unconcluded runs stranded in the queue: they will not start without an operator lever. */
+	readonly wedged: ReadonlyArray<CheckRun>;
+	/**
+	 * Check suites with zero attached check runs — the inert third-party suites (vercel, sentry,
+	 * cloudflare-workers-and-pages) that sit `queued` forever on every head. Reported so the
+	 * "queued suites are holding this PR pending" reading is visibly false, never acted on: a
+	 * suite with no runs contributes NO pending-ness, by construction (#3999).
+	 */
+	readonly inertSuites: ReadonlyArray<CheckSuite>;
 }
 
 /**
@@ -72,6 +108,15 @@ export const RED_CONCLUSIONS: ReadonlySet<string> = new Set([
 /** Is this run's conclusion a failure? A `null` (unconcluded) conclusion is never a failure. */
 export const isFailing = (run: CheckRun): boolean =>
 	run.conclusion !== null && RED_CONCLUSIONS.has(run.conclusion);
+
+/**
+ * Is this run stranded in the queue rather than running? Both tells must hold — still `queued`
+ * AND never started. A queued run that already carries a `started_at` is in flight, and a run
+ * with no `status` at all is indeterminate; either way it reads as running, so a wedge is only
+ * ever declared on positive evidence of both.
+ */
+export const isWedged = (run: CheckRun): boolean =>
+	run.conclusion === null && run.status === "queued" && run.startedAt === null;
 
 /** Recency order: later `startedAt` wins; equal (or absent) start times fall back to the run id. */
 const moreRecent = (a: CheckRun, b: CheckRun): CheckRun => {
@@ -99,6 +144,12 @@ export const latestPerContext = (runs: ReadonlyArray<CheckRun>): ReadonlyArray<C
 export interface RollupInput {
 	readonly checkRuns: ReadonlyArray<CheckRun>;
 	readonly combinedStatus: CombinedStatus;
+	/**
+	 * The head's check suites, if the caller read them. Diagnosis only: a suite's runs already
+	 * speak for it in `checkRuns`, and a suite with none has nothing to say — so suites never
+	 * move the conclusion in either direction, and omitting them changes no verdict.
+	 */
+	readonly suites?: ReadonlyArray<CheckSuite>;
 }
 
 /**
@@ -108,22 +159,35 @@ export interface RollupInput {
  * contexts still run, and an unconcluded context is pending rather than green. With no signal
  * at all — no check runs and no statuses — the answer is `pending`, not `green`: nothing has
  * reported yet, and a consumer that acts on red must not be handed a green it didn't earn.
+ *
+ * A wedged context is pending exactly as a running one is — the split is reported alongside,
+ * never folded into the verdict, so no consumer that branches on `conclusion` can read a wedge
+ * as anything but "not green" (#3999).
  */
 export const rollupChecks = (input: RollupInput): ChecksRollup => {
 	const latest = latestPerContext(input.checkRuns);
 	const failing = latest.filter(isFailing);
-	const running = latest.filter((run) => run.conclusion === null);
+	const unconcluded = latest.filter((run) => run.conclusion === null);
+	const wedged = unconcluded.filter(isWedged);
+	const running = unconcluded.filter((run) => !isWedged(run));
 	const status = input.combinedStatus;
 	const statusCounts = status.totalCount > 0;
 
 	const conclusion: ChecksConclusion =
 		failing.length > 0 || (statusCounts && status.state === "failure")
 			? "red"
-			: running.length > 0 || (statusCounts && status.state === "pending")
+			: unconcluded.length > 0 || (statusCounts && status.state === "pending")
 				? "pending"
 				: latest.length === 0 && !statusCounts
 					? "pending"
 					: "green";
 
-	return {conclusion, latest, failing, running};
+	return {
+		conclusion,
+		latest,
+		failing,
+		running,
+		wedged,
+		inertSuites: (input.suites ?? []).filter((suite) => suite.latestCheckRunsCount === 0),
+	};
 };

--- a/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
@@ -325,3 +325,75 @@ describe("rollupChecks — a check suite with zero attached runs is not pending"
 		assert.strictEqual(rollupChecks({checkRuns, combinedStatus: noStatuses}).conclusion, "green");
 	});
 });
+
+/**
+ * A test-local mirror of ship-it Step 3's classification order, so the branch the shipper takes on
+ * a given rollup is executable rather than only prose. Keep it in step with the skill's branch list
+ * (`claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`, Step 3).
+ */
+type Step3Branch = "heal-ci" | "empty-set" | "settle-poll" | "proceed";
+
+const isInformational = (name: string): boolean =>
+	name === "deploy (web)" || name.startsWith("cleanup (web,");
+
+const step3Branch = (rollup: ReturnType<typeof rollupChecks>): Step3Branch => {
+	if (rollup.failing.some((c) => !isInformational(c.name))) return "heal-ci"; // 1: gating red
+	if (rollup.latest.length === 0) return "empty-set"; // 1b: zero contexts
+	// 2: the pending SETS. Reading `rollup.conclusion` here instead is the #3999 fail-open — red
+	// wins over pending in the colour, so an informational red hides an unfinished gating check.
+	if (rollup.running.length > 0 || rollup.wedged.length > 0) return "settle-poll";
+	return "proceed"; // 4: every gating check is green
+};
+
+describe("ship-it Step 3 branch 2 — an informational red never masks an unfinished check", () => {
+	const informationalRedPlus = (unfinished: CheckRun, informationalRed: string) =>
+		rollupChecks({
+			checkRuns: [
+				run({name: informationalRed, conclusion: "failure"}),
+				run({name: "lint"}),
+				unfinished,
+			],
+			combinedStatus: noStatuses,
+		});
+
+	it("informational red + running: the colour is red, yet the head must still settle-poll", () => {
+		const rollup = informationalRedPlus(
+			run({name: "e2e", conclusion: null, completedAt: null, status: "in_progress"}),
+			"deploy (web)",
+		);
+		assert.strictEqual(rollup.conclusion, "red"); // the trap: red wins over pending in the colour
+		assert.deepStrictEqual(
+			rollup.running.map((c) => c.name),
+			["e2e"],
+		);
+		assert.strictEqual(step3Branch(rollup), "settle-poll");
+	});
+
+	it("informational red + wedged: the #3999 state refuses, it does not enqueue", () => {
+		const rollup = informationalRedPlus(
+			unconcluded({name: "fanout-guard", status: "queued"}),
+			"cleanup (web, pr-1)",
+		);
+		assert.strictEqual(rollup.conclusion, "red");
+		assert.deepStrictEqual(
+			rollup.wedged.map((c) => c.name),
+			["fanout-guard"],
+		);
+		assert.strictEqual(step3Branch(rollup), "settle-poll");
+	});
+
+	it("the branch mirror is not vacuous: a gating red heals, an all-green head proceeds", () => {
+		const gatingRed = rollupChecks({
+			checkRuns: [run({name: "ci-required", conclusion: "failure"})],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(step3Branch(gatingRed), "heal-ci");
+
+		const informationalRedOnly = rollupChecks({
+			checkRuns: [run({name: "deploy (web)", conclusion: "failure"}), run({name: "lint"})],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(informationalRedOnly.conclusion, "red");
+		assert.strictEqual(step3Branch(informationalRedOnly), "proceed");
+	});
+});

--- a/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
@@ -1,5 +1,12 @@
 import {assert, describe, it} from "@effect/vitest";
-import {type CheckRun, isFailing, latestPerContext, rollupChecks} from "./checks.ts";
+import {
+	type CheckRun,
+	type CheckSuite,
+	isFailing,
+	isWedged,
+	latestPerContext,
+	rollupChecks,
+} from "./checks.ts";
 
 let nextId = 1;
 const run = (over: Partial<CheckRun> & {readonly name: string}): CheckRun => ({
@@ -179,5 +186,142 @@ describe("rollupChecks — the head verdict, computed latest-per-context", () =>
 	it("no signal at all is PENDING, not an unearned green", () => {
 		const rollup = rollupChecks({checkRuns: [], combinedStatus: noStatuses});
 		assert.strictEqual(rollup.conclusion, "pending");
+	});
+});
+
+const unconcluded = (over: {readonly name: string; readonly status?: string | null}): CheckRun =>
+	run({conclusion: null, completedAt: null, startedAt: null, ...over});
+
+describe("isWedged — stranded in the queue, on positive evidence of both tells", () => {
+	it("queued with no start time is wedged", () => {
+		assert.strictEqual(isWedged(unconcluded({name: "fanout-guard", status: "queued"})), true);
+	});
+
+	it("queued but already started is running, not wedged", () => {
+		assert.strictEqual(
+			isWedged(
+				run({
+					name: "fanout-guard",
+					conclusion: null,
+					completedAt: null,
+					status: "queued",
+					startedAt: "2026-07-25T05:00:00Z",
+				}),
+			),
+			false,
+		);
+	});
+
+	it("an absent status is indeterminate, so never wedged", () => {
+		assert.strictEqual(isWedged(unconcluded({name: "e2e"})), false);
+	});
+
+	it("a concluded run is never wedged", () => {
+		assert.strictEqual(isWedged(run({name: "lint", status: "completed"})), false);
+	});
+});
+
+describe("rollupChecks — running and wedged are told apart, both still pending", () => {
+	// The ~2.5h `fanout-guard` wedge (#3999): a queued run with a null start time never starts,
+	// so waiting it out is futile — but it is still not green, so the gate stays fail-closed.
+	it("a wedged context is PENDING and reported as wedged, not as running", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "lint"}), unconcluded({name: "fanout-guard", status: "queued"})],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "pending");
+		assert.deepStrictEqual(
+			rollup.wedged.map((c) => c.name),
+			["fanout-guard"],
+		);
+		assert.deepStrictEqual(rollup.running, []);
+	});
+
+	it("an in-flight context is running, not wedged", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "e2e", conclusion: null, completedAt: null, status: "in_progress"})],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "pending");
+		assert.deepStrictEqual(
+			rollup.running.map((c) => c.name),
+			["e2e"],
+		);
+		assert.deepStrictEqual(rollup.wedged, []);
+	});
+
+	it("a head that is both running and wedged reports both sets", () => {
+		const rollup = rollupChecks({
+			checkRuns: [
+				run({name: "e2e", conclusion: null, completedAt: null, status: "in_progress"}),
+				unconcluded({name: "fanout-guard", status: "queued"}),
+			],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "pending");
+		assert.deepStrictEqual(
+			rollup.running.map((c) => c.name),
+			["e2e"],
+		);
+		assert.deepStrictEqual(
+			rollup.wedged.map((c) => c.name),
+			["fanout-guard"],
+		);
+	});
+});
+
+const suite = (over: Partial<CheckSuite> & {readonly appSlug: string}): CheckSuite => ({
+	id: nextId++,
+	status: "queued",
+	latestCheckRunsCount: 0,
+	...over,
+});
+
+describe("rollupChecks — a check suite with zero attached runs is not pending", () => {
+	// PR #3988's head: every check run completed, while three third-party suites sat `queued`
+	// with no runs attached. The head is green; the inert suites are reported, never counted.
+	it("the PR #3988 shape — all runs completed, three zero-run queued suites — is GREEN", () => {
+		const rollup = rollupChecks({
+			checkRuns: [
+				run({name: "detect changed areas"}),
+				run({name: "ci-required"}),
+				run({name: "e2e", conclusion: "skipped"}),
+			],
+			combinedStatus: noStatuses,
+			suites: [
+				suite({appSlug: "vercel"}),
+				suite({appSlug: "sentry"}),
+				suite({appSlug: "cloudflare-workers-and-pages"}),
+			],
+		});
+		assert.strictEqual(rollup.conclusion, "green");
+		assert.deepStrictEqual(
+			rollup.inertSuites.map((s) => s.appSlug),
+			["vercel", "sentry", "cloudflare-workers-and-pages"],
+		);
+	});
+
+	it("a suite that attached runs is not inert, and still adds no pending-ness of its own", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "ci-required"})],
+			combinedStatus: noStatuses,
+			suites: [suite({appSlug: "github-actions", status: "completed", latestCheckRunsCount: 1})],
+		});
+		assert.strictEqual(rollup.conclusion, "green");
+		assert.deepStrictEqual(rollup.inertSuites, []);
+	});
+
+	it("suites never override the runs: a wedged run still holds the head pending", () => {
+		const rollup = rollupChecks({
+			checkRuns: [unconcluded({name: "fanout-guard", status: "queued"})],
+			combinedStatus: noStatuses,
+			suites: [suite({appSlug: "vercel"})],
+		});
+		assert.strictEqual(rollup.conclusion, "pending");
+	});
+
+	it("omitting suites entirely changes no verdict", () => {
+		const checkRuns = [run({name: "ci-required"})];
+		assert.strictEqual(rollupChecks({checkRuns, combinedStatus: noStatuses}).conclusion, "green");
 	});
 });

--- a/packages/pipeline-cli/src/tools/checks/command.ts
+++ b/packages/pipeline-cli/src/tools/checks/command.ts
@@ -15,6 +15,11 @@
  * on stdout for a caller that wants the failing context names. `GithubLive` is baked in with
  * `Command.provide(...)` so the registered command's residual requirement is the Node platform
  * union (the registry seam, epic #994).
+ *
+ * Exit 2 is its own answer: the head was UNREADABLE (transport fault, or a body that is not the
+ * check-runs envelope). It is deliberately not exit 1 — "I could not read this head" must be
+ * distinguishable from "I read it and it isn't what you expected", and neither may be mistaken
+ * for green (#3999).
  */
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
@@ -22,6 +27,7 @@ import type {ChecksConclusion} from "./checks.ts";
 import {Github, GithubLive} from "./github.ts";
 
 const FAIL_EXIT_CODE = 1;
+const UNKNOWN_EXIT_CODE = 2;
 
 const CONCLUSIONS: ReadonlyArray<ChecksConclusion> = ["green", "red", "pending"];
 
@@ -47,6 +53,30 @@ const fail = (reason: string): Effect.Effect<never> =>
 		process.exit(FAIL_EXIT_CODE);
 	});
 
+/**
+ * The typed unknown: emit an `unknown` rollup on stdout and exit 2. A caller that shape-checks
+ * stdout gets a `conclusion` it can branch on rather than an empty capture, and the distinct
+ * exit code means a swallowed stderr can still never be read as green.
+ */
+const unknown = (sha: string, reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stdout.write(`${JSON.stringify({conclusion: "unknown", sha, reason})}\n`);
+		process.stderr.write(`checks: unknown — could not read ${sha || "the head"}: ${reason}\n`);
+		process.exit(UNKNOWN_EXIT_CODE);
+	});
+
+/** The `{sha, reason}` a `HeadCiUnreadable` carries — the actionable form of an unknown. */
+const asUnreadable = (cause: unknown): {sha: string; reason: string} | undefined =>
+	typeof cause === "object" &&
+	cause !== null &&
+	(cause as {_tag?: unknown})._tag === "@kampus/checks/HeadCiUnreadable"
+		? (cause as {sha: string; reason: string})
+		: undefined;
+
+const describeCause = (cause: unknown): string =>
+	asUnreadable(cause)?.reason ??
+	(cause instanceof Error && cause.message !== "" ? cause.message : String(cause));
+
 const parseExpect = (raw: Option.Option<string>): Effect.Effect<ChecksConclusion, never> => {
 	const value = Option.getOrElse(raw, () => "green")
 		.trim()
@@ -67,8 +97,15 @@ const read = Command.make(
 		if ((pinned === undefined) === (prNumber === undefined)) {
 			return yield* fail("pass exactly one of --pr <n> or --sha <sha>");
 		}
-		const head = pinned ?? (yield* gh.headSha(prNumber as number));
-		const rollup = yield* gh.read(head);
+		const resolved = yield* Effect.gen(function* () {
+			const head = pinned ?? (yield* gh.headSha(prNumber as number));
+			return {head, rollup: yield* gh.read(head)};
+		}).pipe(
+			Effect.catch((cause: unknown) =>
+				unknown(asUnreadable(cause)?.sha ?? pinned ?? "", describeCause(cause)),
+			),
+		);
+		const {head, rollup} = resolved;
 		yield* Console.log(
 			JSON.stringify({
 				conclusion: rollup.conclusion,
@@ -76,13 +113,23 @@ const read = Command.make(
 				contexts: rollup.latest.length,
 				failing: rollup.failing.map((c) => c.name),
 				running: rollup.running.map((c) => c.name),
+				wedged: rollup.wedged.map((c) => c.name),
+				inertSuites: rollup.inertSuites.map((s) => s.appSlug ?? String(s.id)),
 			}),
 		);
+		const pendingDetail = [
+			rollup.running.length > 0 ? `running: ${rollup.running.map((c) => c.name).join(", ")}` : "",
+			rollup.wedged.length > 0
+				? `wedged (queued, never started): ${rollup.wedged.map((c) => c.name).join(", ")}`
+				: "",
+		]
+			.filter((part) => part !== "")
+			.join("; ");
 		const detail =
 			rollup.conclusion === "red"
 				? ` (failing: ${rollup.failing.map((c) => c.name).join(", ")})`
 				: rollup.conclusion === "pending"
-					? ` (running: ${rollup.running.map((c) => c.name).join(", ") || "nothing has reported yet"})`
+					? ` (${pendingDetail || "nothing has reported yet"})`
 					: "";
 		if (rollup.conclusion === expected) {
 			process.stderr.write(

--- a/packages/pipeline-cli/src/tools/checks/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/checks/github-service.unit.test.ts
@@ -56,6 +56,7 @@ const provide = <A, E>(
 
 const SHA = "bb21a70f0000000000000000000000000000dead";
 const checkRunsPath = `repos/${PINNED_REPO}/commits/${SHA}/check-runs`;
+const checkSuitesPath = `repos/${PINNED_REPO}/commits/${SHA}/check-suites`;
 const statusPath = `repos/${PINNED_REPO}/commits/${SHA}/status`;
 const noStatuses = JSON.stringify({state: "pending", total_count: 0});
 
@@ -133,6 +134,140 @@ describe("Github.read — the fetched head rolls up latest-per-context", () => {
 			);
 			assert.strictEqual(rollup.conclusion, "green");
 		}),
+	);
+});
+
+describe("Github.read — the three CI states survive the decode boundary", () => {
+	it.effect("a queued run with no start time decodes as wedged, not as running", () =>
+		Effect.gen(function* () {
+			const rollup = yield* provide(
+				Effect.flatMap(Github, (gh) => gh.read(SHA)),
+				{
+					[checkRunsPath]: pages([
+						{
+							id: 1,
+							name: "fanout-guard",
+							status: "queued",
+							conclusion: null,
+							started_at: null,
+							completed_at: null,
+						},
+					]),
+					[statusPath]: noStatuses,
+				},
+			);
+			assert.strictEqual(rollup.conclusion, "pending");
+			assert.deepStrictEqual(
+				rollup.wedged.map((c) => c.name),
+				["fanout-guard"],
+			);
+			assert.deepStrictEqual(rollup.running, []);
+		}),
+	);
+
+	it.effect("zero-run check suites are reported inert and leave a completed head green", () =>
+		Effect.gen(function* () {
+			const rollup = yield* provide(
+				Effect.flatMap(Github, (gh) => gh.read(SHA)),
+				{
+					[checkRunsPath]: pages([
+						{
+							id: 1,
+							name: "ci-required",
+							status: "completed",
+							conclusion: "success",
+							started_at: "2026-07-25T05:40:00Z",
+							completed_at: "2026-07-25T05:48:16Z",
+						},
+					]),
+					[checkSuitesPath]: JSON.stringify([
+						{
+							check_suites: [
+								{id: 10, status: "queued", latest_check_runs_count: 0, app: {slug: "vercel"}},
+								{
+									id: 11,
+									status: "completed",
+									latest_check_runs_count: 1,
+									app: {slug: "github-actions"},
+								},
+							],
+						},
+					]),
+					[statusPath]: noStatuses,
+				},
+			);
+			assert.strictEqual(rollup.conclusion, "green");
+			assert.deepStrictEqual(
+				rollup.inertSuites.map((s) => s.appSlug),
+				["vercel"],
+			);
+		}),
+	);
+
+	// Suites are diagnosis only, so an unreadable suites read must not block a merge — the
+	// verdict is unchanged and the inert list is simply empty.
+	it.effect("an unreadable check-suites read degrades instead of refusing", () =>
+		Effect.gen(function* () {
+			const rollup = yield* provide(
+				Effect.flatMap(Github, (gh) => gh.read(SHA)),
+				{
+					[checkRunsPath]: pages([
+						{
+							id: 1,
+							name: "ci-required",
+							status: "completed",
+							conclusion: "success",
+							started_at: "2026-07-25T05:40:00Z",
+							completed_at: "2026-07-25T05:48:16Z",
+						},
+					]),
+					[statusPath]: noStatuses,
+				},
+			);
+			assert.strictEqual(rollup.conclusion, "green");
+			assert.deepStrictEqual(rollup.inertSuites, []);
+		}),
+	);
+});
+
+describe("Github.read — an unreadable head is the typed unknown, never a colour", () => {
+	const expectUnreadable = (responses: Record<string, string>) =>
+		Effect.gen(function* () {
+			const outcome = yield* Effect.result(
+				provide(
+					Effect.flatMap(Github, (gh) => gh.read(SHA)),
+					responses,
+				),
+			);
+			assert.strictEqual(outcome._tag, "Failure");
+			assert.strictEqual(
+				(outcome as {failure: {_tag: string}}).failure._tag,
+				"@kampus/checks/HeadCiUnreadable",
+			);
+		});
+
+	// The body a failed `gh api` prints is an ERROR OBJECT, not a page array. Shape-check first:
+	// interpreting it as data is how an unreadable head becomes a fabricated verdict.
+	it.effect("an error body where the pages array belongs is unreadable", () =>
+		expectUnreadable({
+			[checkRunsPath]: JSON.stringify({message: "Not Found", status: "404"}),
+			[statusPath]: noStatuses,
+		}),
+	);
+
+	it.effect("a page whose check_runs is not an array is unreadable", () =>
+		expectUnreadable({
+			[checkRunsPath]: JSON.stringify([{check_runs: "oops"}]),
+			[statusPath]: noStatuses,
+		}),
+	);
+
+	it.effect("unparseable output is unreadable", () =>
+		expectUnreadable({[checkRunsPath]: "<html>502 Bad Gateway</html>", [statusPath]: noStatuses}),
+	);
+
+	it.effect("a check-runs read that fails outright is unreadable", () =>
+		expectUnreadable({[statusPath]: noStatuses}),
 	);
 });
 

--- a/packages/pipeline-cli/src/tools/checks/github.ts
+++ b/packages/pipeline-cli/src/tools/checks/github.ts
@@ -10,7 +10,7 @@
 import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
-import {type ChecksRollup, rollupChecks} from "./checks.ts";
+import {type CheckSuite, type ChecksRollup, rollupChecks} from "./checks.ts";
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
 export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
@@ -29,6 +29,18 @@ export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
 		args: Schema.Array(Schema.String),
 		message: Schema.String,
 	},
+) {}
+
+/**
+ * The head's CI state could not be read as data — the transport failed, or the body decoded to
+ * something that is not the check-runs envelope (a `{"message": "Not Found"}` error object, a
+ * truncated page, a non-array). It is the typed "unknown" the gate refuses on: a caller must be
+ * able to tell "I could not read this head" from any colour, and never resolve it to green
+ * (#3999).
+ */
+export class HeadCiUnreadable extends Schema.TaggedErrorClass<HeadCiUnreadable>()(
+	"@kampus/checks/HeadCiUnreadable",
+	{sha: Schema.String, reason: Schema.String},
 ) {}
 
 /** No `owner/name` target repo could be resolved (no env override, no current repo). */
@@ -111,6 +123,7 @@ const RawCheckRun = Schema.Struct({
 	id: Schema.Number,
 	name: Schema.String,
 	conclusion: Schema.NullOr(Schema.String),
+	status: Schema.optionalKey(Schema.NullOr(Schema.String)),
 	started_at: Schema.optionalKey(Schema.NullOr(Schema.String)),
 	completed_at: Schema.NullOr(Schema.String),
 });
@@ -126,8 +139,33 @@ const decodeCheckRunPages = Schema.decodeUnknownEffect(RawCheckRunPages);
 const RawCombinedStatus = Schema.Struct({state: Schema.String, total_count: Schema.Number});
 const decodeCombinedStatus = Schema.decodeUnknownEffect(RawCombinedStatus);
 
+const RawCheckSuite = Schema.Struct({
+	id: Schema.Number,
+	status: Schema.NullOr(Schema.String),
+	latest_check_runs_count: Schema.Number,
+	app: Schema.optionalKey(Schema.NullOr(Schema.Struct({slug: Schema.NullOr(Schema.String)}))),
+});
+const RawCheckSuitePages = Schema.Array(Schema.Struct({check_suites: Schema.Array(RawCheckSuite)}));
+const decodeCheckSuitePages = Schema.decodeUnknownEffect(RawCheckSuitePages);
+
 const RawPr = Schema.Struct({head: Schema.Struct({sha: Schema.String})});
 const decodePr = Schema.decodeUnknownEffect(RawPr);
+
+/**
+ * A one-line, operator-readable cause. The tagged errors carry their detail in FIELDS, not in
+ * `message`, so a bare `.message` renders empty — and an unknown that can't say why it's unknown
+ * is not actionable.
+ */
+const describeFault = (cause: GhCommandError | GhParseError | Schema.SchemaError): string => {
+	switch (cause._tag) {
+		case "@kampus/checks/GhCommandError":
+			return `gh exited ${cause.exitCode}: ${cause.stderr.trim() || "(no stderr)"}`;
+		case "@kampus/checks/GhParseError":
+			return `gh output was not JSON: ${cause.message}`;
+		default:
+			return `response did not match the expected shape: ${cause.message}`;
+	}
+};
 
 const headSha = Effect.fn("Checks.headSha")(function* (repo: string, pr: number) {
 	const args = ["api", `repos/${repo}/pulls/${pr}`];
@@ -147,13 +185,42 @@ const read = Effect.fn("Checks.read")(function* (repo: string, sha: string) {
 		`repos/${repo}/commits/${sha}/check-runs?per_page=100`,
 	];
 	const statusArgs = ["api", `repos/${repo}/commits/${sha}/status`];
-	const [pages, status] = yield* Effect.all(
+	const suiteArgs = [
+		"api",
+		"--paginate",
+		"--slurp",
+		`repos/${repo}/commits/${sha}/check-suites?per_page=100`,
+	];
+	// The two GATING reads: their shape is decoded BEFORE any conclusion is read, and a fault in
+	// either resolves to the typed `HeadCiUnreadable` — never to a colour.
+	const gating = Effect.all(
 		[
-			decodeCheckRunPages(yield* json(checkArgs)),
-			decodeCombinedStatus(yield* json(statusArgs)),
+			Effect.flatMap(json(checkArgs), decodeCheckRunPages),
+			Effect.flatMap(json(statusArgs), decodeCombinedStatus),
 		] as const,
 		{concurrency: "unbounded"},
+	).pipe(Effect.catch((cause) => new HeadCiUnreadable({sha, reason: describeFault(cause)})));
+	// The suites read is DIAGNOSTIC, so it degrades instead of blocking: suites cannot move the
+	// conclusion (see `RollupInput.suites`), and letting a flaky side read refuse a merge would
+	// re-introduce the false-negative block this whole change removes.
+	const suites = Effect.flatMap(json(suiteArgs), decodeCheckSuitePages).pipe(
+		Effect.map((suitePages) =>
+			suitePages
+				.flatMap((page) => page.check_suites)
+				.map(
+					(s): CheckSuite => ({
+						id: s.id,
+						status: s.status,
+						latestCheckRunsCount: s.latest_check_runs_count,
+						appSlug: s.app?.slug ?? null,
+					}),
+				),
+		),
+		Effect.orElseSucceed((): ReadonlyArray<CheckSuite> => []),
 	);
+	const [[pages, status], checkSuites] = yield* Effect.all([gating, suites] as const, {
+		concurrency: "unbounded",
+	});
 	return rollupChecks({
 		checkRuns: pages
 			.flatMap((page) => page.check_runs)
@@ -161,14 +228,19 @@ const read = Effect.fn("Checks.read")(function* (repo: string, sha: string) {
 				id: r.id,
 				name: r.name,
 				conclusion: r.conclusion,
+				status: r.status ?? null,
 				startedAt: r.started_at ?? null,
 				completedAt: r.completed_at,
 			})),
 		combinedStatus: {state: status.state, totalCount: status.total_count},
+		suites: checkSuites,
 	});
 });
 
 type GhError = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+
+/** `read`'s error channel: every fault on the gating reads arrives as the one typed unknown. */
+type ReadError = RepoResolutionError | HeadCiUnreadable;
 
 /**
  * `Github` — the IO shell over `gh api` REST for the head-CI reads. Built by `GithubLive`,
@@ -180,7 +252,7 @@ export class Github extends Context.Service<
 	{
 		readonly repoName: () => Effect.Effect<string, GhError>;
 		readonly headSha: (pr: number) => Effect.Effect<string, GhError>;
-		readonly read: (sha: string) => Effect.Effect<ChecksRollup, GhError>;
+		readonly read: (sha: string) => Effect.Effect<ChecksRollup, ReadError>;
 	}
 >()("@kampus/checks/Github") {}
 


### PR DESCRIPTION
The shipper decides whether a PR's CI is green by asking `gh pr checks`. That read has been
lying: on PR #3988 it called 29 of 33 checks "in progress" while GitHub's REST API showed the
same checks finished 15+ minutes earlier, so the shipper waited out its full 10-minute budget
and then refused to merge a perfectly green PR. This switches that decision to the REST
check-runs read the rest of the pipeline already uses.

It also fixes a second thing the old read hid. A check can be stuck in the queue and never
start — one sat that way for about 2.5 hours behind a green PR — and until now that looked
exactly like a check that was still running, so the only advice a shipper could give was "wait
longer." Waiting never helps a stuck check. Those are now two different, separately named
states.

Fixes #3999

## What changed

**`pipeline-cli checks read` (`packages/pipeline-cli/src/tools/checks/`)** — the shared head-CI
reader gains the three-state model and a typed unknown:

- **`running` vs `wedged`.** A `wedged` check is `queued` with a `null` `started_at` — the exact
  conjunction observed on the stuck `fanout-guard` job. Both tells must hold: a queued check that
  already has a start time is running, and a check with no `status` at all is indeterminate, so a
  wedge is only ever declared on positive evidence.
- **The gate stays 3-valued.** `conclusion` is still `red | pending | green`, and a wedge
  classifies `pending`. Adding a fourth colour would have been fail-open for any consumer shaped
  `if red … else if pending … else proceed`. The split is reported alongside the verdict, never
  folded into it.
- **Zero-run check suites count toward nothing.** The rollup reads `check-suites` and reports the
  ones with no attached runs as `inertSuites` — the vercel / sentry / cloudflare suites that sit
  `queued` on every head. They are diagnosis only; no suite can make a head pending. The suites
  read degrades on failure rather than refusing, precisely because it cannot change the verdict —
  letting a side read block a merge would re-create the defect this PR removes.
- **Unreadable ⇒ typed unknown, exit 2.** A transport fault, or a body that is not the check-runs
  envelope (a `{"message": "Not Found"}`, a non-array, unparseable output), decodes to
  `HeadCiUnreadable` and the CLI emits `{"conclusion":"unknown",…}` with its own exit code —
  distinct from "read it, didn't match," and never green. The shape is validated before anything
  is interpreted.

**`claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`** — Step 3 and `ci_settle_wait` both
read through the verb instead of `gh pr checks`, shape-check the result before branching on it,
and refuse on an unknown. The settle poll now refuses early with a distinct
`refused — CI wedged (stranded in queue: <names>)` outcome once an all-wedged pending set has
persisted past a short dwell, instead of burning the budget on runs that cannot start. The
refusal names the operator's lever — `POST /actions/runs/<id>/cancel` then `.../rerun`, since a
plain rerun on a still-queued run returns 403.

## Why ship-it reports the wedge instead of clearing it

Two reasons, both written into the skill. **Authority:** ship-it holds the single merge authority
(ADR 0048), not a CI-mutation authority — a merge gate that silently reruns CI to make itself
pass can launder a stuck producer into a green. **Termination:** a wedge caused by a genuinely
broken producer would be cancel/rerun-looped forever by an automatic remedy, the same unbounded
retry the Step-3z nudge is explicitly bounded against. So it exits like every other non-enqueue:
a durable, PR-visible outcome naming the state and the lever.

## Acceptance criteria

- [x] Step 3 and `ci_settle_wait` classify from REST check-runs for the PR head, not `gh pr checks`.
- [x] A check suite with zero attached check-runs does not count as pending (unit-tested both in
      the core and through the decode boundary).
- [x] Gating semantics preserved fail-closed: a genuinely pending or failing gating check still
      classifies pending/red exactly as before — a wedge is pending, an unknown refuses, and the
      known-informational carve-out (`deploy (web)`, `cleanup (web, …)`) is unchanged.
- [x] The PR #3988 shape classifies green — verified live: `checks read --pr 3988` →
      `{"conclusion":"green","contexts":43,"failing":[],"running":[],"wedged":[],"inertSuites":["vercel","cloudflare-workers-and-pages","sentry"]}`.

## Verification

- `pnpm vitest run` in `packages/pipeline-cli` — 2076 tests pass, including 20 new ones covering
  the wedged/running split, the inert-suite rule, and the four unreadable-payload shapes.
- `pnpm typecheck` and `pnpm lint:worktree` clean.
- Live: `checks read --pr 3988` (green, three inert suites named) and a nonexistent SHA
  (`{"conclusion":"unknown",…}`, exit 2, reason `gh exited 1: … (HTTP 422)`).
