### PR TITLE
fix(tests): replace the stray NUL byte in _harness.ts with a space (#4026)

### DIFF
--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -790,7 +790,7 @@ export function harness(
 		// vote writes share the slug's term_record row; concurrent writes would
 		// race the denormalized aggregates.
 		for (const def of input.definitions) {
-			const key = `${input.slug} ${def.body}`;
+			const key = `${input.slug} ${def.body}`;
 			if (seededBodies.has(key)) {
 				skippedDefinitions++;
 				continue;


### PR DESCRIPTION
One byte in the integration-test harness was making the whole file invisible to search. `apps/web/tests/integration/_harness.ts` carried a stray NUL (`\x00`) where a space belonged, and a single NUL makes `grep`/`rg` classify the file as binary — so they return *no matches* silently instead of erroring. That already cost real time: searches during an investigation of this exact file came back empty and read as "the code isn't there" rather than "the tool refused to search it."

This replaces that one byte with a regular space. It is the entire diff.

## What changed

- `apps/web/tests/integration/_harness.ts`, line 793 — the `seedTerm` per-definition dedup key: `` `${input.slug}<NUL>${def.body}` `` → `` `${input.slug} ${def.body}` ``.

## Why it's safe

The key is a process-local dedup string built and consumed inside one `seedTerm` call. Nothing reads the separator or depends on its identity, so a space separates exactly as well as a NUL did. No behavior change.

## Verification

- `tr -cd '\0' < apps/web/tests/integration/_harness.ts | wc -c` → `0` (was `1`)
- `grep -n seedTerm apps/web/tests/integration/_harness.ts` now matches (7 hits) — plain, no `--text` needed
- `git diff --stat` → `1 file changed, 1 insertion(+), 1 deletion(-)`; the only differing bytes are the separator
- `pnpm typecheck` → 29/29 tasks successful
- `pnpm lint:worktree` → clean

## Scope

The repo-wide fail-closed CI guard against NUL bytes in tracked text source is deliberately not here — triage split it out as #4039.

Fixes #4026
