### PR TITLE
fix(verdict): key the post upsert on the posting run, not the shared author (#4016)

### DIFF
--- a/.decisions/0212-verdict-upsert-keyed-on-run-not-shared-author.md
+++ b/.decisions/0212-verdict-upsert-keyed-on-run-not-shared-author.md
@@ -1,0 +1,132 @@
+---
+id: 0212
+title: The verdict upsert is keyed on the posting run, not the shared author — one comment per (PR, gate, run) (refines 0058 rule 2)
+status: accepted
+date: 2026-07-25
+tags: [pipeline, verdict, review-code, concurrency, security]
+---
+
+# 0212 — The Verdict Upsert Is Keyed on the Posting Run, Not the Shared Author (refines 0058 rule 2)
+
+**What this decides — and only this:** `verdict post` upserts one comment per **(PR, gate, posting
+run)** instead of per (PR, gate, author), so a concurrent reviewer sharing our GitHub login appends
+its verdict rather than PATCHing another reviewer's away. A namespace may therefore legitimately
+hold more than one verdict comment at one head.
+
+**What this deliberately does NOT decide: verdict precedence.** How a reader picks among the
+verdicts in a namespace is ADR [0058](0058-sha-bound-verdict-contract.md) rule 3's business, and it
+is unchanged here — latest-wins on `(createdAt, id)`, as computed by `resolveVerdict` and
+`decideGate`. This ADR is about the *poster's* key, not the *reader's* order. An earlier draft of it
+also legislated a "any current-head FAIL vetoes" resolution; that rule is **not** adopted — see
+[Rejected: a current-head FAIL veto](#rejected-a-current-head-fail-veto).
+
+## Context
+
+ADR 0058 rule 2 made the verdict an **upsert**: a producer scans for *its own* prior marker in the
+gate namespace and PATCHes it, so a (PR, gate) pair resolves to exactly one comment. Rule 2
+justified the own-authored scope explicitly:
+
+> The own-authored scope matters: a producer upserts only a marker it itself authored, so two
+> authorized reviewers do not stomp each other's records inside one namespace
+
+**That premise is false in this pipeline, and was false the day it was written.** Every review agent
+posts under the **one shared GitHub identity** the operator's checkout carries, so "own-authored"
+does not distinguish reviewers at all — it selects *any* agent's marker in the namespace. This is the
+same shared-login degeneracy ADR [0115](0115-agent-distinguishable-claim-marker.md) removed from the
+issue claim, where `min(login)` collapsed to a no-op because every racer resolved to the same login.
+
+The consequence is a **silent, server-side loss of a merge-gate artifact**. Two reviewers running
+concurrently against one PR at one head both match the *other's* comment and PATCH its body away.
+Observed on PR #3988 at head `0368922e…`: two verdict comments carry an `updated_at` later than
+their `created_at`, and the surviving `review-code` body documents the overwrite against itself
+(#4016). The outcome there happened to be safe — the surviving verdict was the stricter FAIL — but
+the loss is unconditional:
+
+- The overwritten body is **destroyed, not superseded-and-visible**. An auditor sees one verdict and
+  cannot tell it replaced another, or what it said.
+- It never reproduces under a single poster, so no single-reviewer test sees it.
+
+## Decision
+
+### 1. The upsert key gains a run dimension
+
+`verdict post` stamps every body it writes with the posting run's identity — an HTML-comment trailer,
+invisible in rendered markdown:
+
+```
+<!-- verdict-run: <run id> -->
+```
+
+The run id is the agent's `CLAUDE_CODE_SESSION_ID` (overridable with `--run-id`), the same
+agent-distinguishable token ADR 0115 claims work under and the one thing the shared login cannot
+supply. `post` then PATCHes a prior marker only when it matches on **author *and* gate namespace
+*and* this run's trailer**; anything else it appends. So a genuine same-run correction still upserts
+(no comment spam for a revision of this run's own record), and a sibling run never matches.
+
+**Absence is fail-safe, not fail-open.** A run with no resolvable run id — an unset session id, a
+pre-#4016 or hand-rolled marker with no trailer — matches nothing and therefore **appends**. The
+worst case is an extra comment; a verdict is never overwritten on an unproven claim of ownership.
+This mirrors the claim guard's default-deny: only positive evidence of ownership authorizes the
+destructive path.
+
+### 2. Rule 2's uniqueness invariant narrows to per-run
+
+Rule 2's invariant narrows from **exactly one comment per (PR, gate)** to **exactly one comment per
+(PR, gate, run)**. Multiple verdict comments in one namespace at one head are a **legal, expected
+state** whenever two reviewer runs gate the same head, not a defect to reconcile. Rule 2's "Banned:
+POSTing a new marker when this gate already has one authored by this producer on this PR" narrows in
+the same motion: the ban applies to *this run's* marker, never another run's.
+
+Rules 1 (SHA-bind every verdict), 3 (refuse a SHA-unbound or stale-head verdict, latest-wins among
+what remains), and 4 (`review-doc` emits only the comment) are **unchanged**. The author-gate (ADR
+[0055](0055-acl-sourced-review-authz.md)) still runs ahead of every resolution.
+
+### Rejected: a current-head FAIL veto
+
+It is tempting to pair the append-instead-of-overwrite fix with a read-side rule that any
+current-head FAIL vetoes, on the reasoning that a merge gate's two error directions are asymmetric.
+**That rule is rejected**, because it re-creates a worse failure than the one it prevents.
+
+A verdict does not only get superseded by a new head. A **body-only repair** — the reviewer's
+finding is answered in the PR body, the ADR text, or the verdict record itself — deliberately does
+**not** move the head, so an old FAIL at that head stays current-head-bound indefinitely. Under a
+veto rule nothing can ever out-rank it and the PR is wedged with no exit: that is
+[#4049](https://github.com/kamp-us/phoenix/issues/4049), and it is what latest-wins closes by
+letting a newer superseding verdict (a re-review marker, or a §CP advisory) out-rank an older
+same-head FAIL. PRs #3988 and #3998 both shipped through exactly that path.
+
+So the precedence rule stays **latest-wins on `(createdAt, id)`**, applied across the marker and §CP
+advisory candidate sets alike. Two reviewer runs disagreeing at one head is resolved the same way a
+single reviewer's re-review at one head has always been resolved: the newer verdict is the verdict.
+
+## Consequences
+
+- **The cross-reviewer clobber is structurally unreachable.** A sibling run cannot select another
+  run's comment, so no verdict body is destroyed server-side. Both records survive on the PR and an
+  auditor can see a second opinion existed — which is the whole win, and it is a win about
+  *evidence*, not about precedence.
+- **The residual, stated honestly: a PASS posted after a FAIL at the same head still resolves PASS.**
+  Appending stops the FAIL from being *erased*; it does not stop it from being *superseded*. That is
+  the accepted trade, and it is the trade that keeps #4049 closed. The FAIL remains readable on the
+  thread, which is strictly more than the pre-fix behaviour offered.
+- **"A repair always pushes a new head" is false, and no rule here may assume it.** A body-only
+  repair leaves the head where it is, so head-keyed staleness-invalidation (ADR 0058 rule 3) does not
+  fire and cannot be relied on as the universal escape hatch from a standing verdict. This is the
+  exact assumption that made the veto rule look safe; it is recorded here so the next reader does not
+  re-derive it.
+- **PR threads may show two verdict comments per gate at one head.** That is the intended new state,
+  and it is bounded: one per gate per run, and a run that re-posts still upserts its own.
+- **A verdict posted outside the tool is never upserted.** A hand-rolled marker carries no trailer,
+  so the next `post` appends beside it rather than overwriting it — the safe direction, and one more
+  reason to post through the tool.
+- **The trailer is machine-only.** It renders invisibly, carries no path or PII, and passes every
+  `emissionDefect` guard unchanged (the marker stays on line one; #2646/#2683/#2796 are untouched).
+- **Not fixed here:** the *head* dimension of the same upsert key — re-gating at a new head still
+  edits the prior head's verdict in place when the same run posts both. That is
+  [#4007](https://github.com/kamp-us/phoenix/issues/4007), deliberately left to its own change; the
+  run dimension and the head dimension are independent facets of one selection.
+- **Relationship:** refines [0058](0058-sha-bound-verdict-contract.md) rule 2's uniqueness key, and
+  only that — rule 3's precedence is untouched; preserves
+  [0055](0055-acl-sourced-review-authz.md)'s author-gate ahead of every resolution; applies
+  [0115](0115-agent-distinguishable-claim-marker.md)'s agent-distinguishable session token to a
+  second shared-login surface.

--- a/.decisions/0213-verdict-upsert-keyed-on-run-not-shared-author.md
+++ b/.decisions/0213-verdict-upsert-keyed-on-run-not-shared-author.md
@@ -1,12 +1,12 @@
 ---
-id: 0212
+id: 0213
 title: The verdict upsert is keyed on the posting run, not the shared author — one comment per (PR, gate, run) (refines 0058 rule 2)
 status: accepted
 date: 2026-07-25
 tags: [pipeline, verdict, review-code, concurrency, security]
 ---
 
-# 0212 — The Verdict Upsert Is Keyed on the Posting Run, Not the Shared Author (refines 0058 rule 2)
+# 0213 — The Verdict Upsert Is Keyed on the Posting Run, Not the Shared Author (refines 0058 rule 2)
 
 **What this decides — and only this:** `verdict post` upserts one comment per **(PR, gate, posting
 run)** instead of per (PR, gate, author), so a concurrent reviewer sharing our GitHub login appends

--- a/packages/pipeline-cli/TOOLS.md
+++ b/packages/pipeline-cli/TOOLS.md
@@ -122,7 +122,7 @@ semantics; it does **not** change what any gate verifies.
   seam), non-zero with a named refusal reason on stderr otherwise — so a caller branches on exit
   status.
 - **`verdict post --pr N --gate <g> [--body-file <f>] [--run-id <id>]`** — the ADR-0058 rule-2
-  **upsert**, keyed on the posting **run** (ADR 0212): read
+  **upsert**, keyed on the posting **run** (ADR 0213): read
   the composed verdict body (from `--body-file` or stdin), refuse fail-closed if its first line is
   not *this* gate's marker (the cross-namespace emission bug), then PATCH the prior marker **this
   run** posted in the namespace if one exists, else POST — one verdict comment per (PR, gate, run).

--- a/packages/pipeline-cli/TOOLS.md
+++ b/packages/pipeline-cli/TOOLS.md
@@ -121,10 +121,15 @@ semantics; it does **not** change what any gate verifies.
   is reviewed with the `--expect` polarity** (default `PASS`; `FAIL` is the `write-code`-repair
   seam), non-zero with a named refusal reason on stderr otherwise — so a caller branches on exit
   status.
-- **`verdict post --pr N --gate <g> [--body-file <f>]`** — the ADR-0058 rule-2 **upsert**: read
+- **`verdict post --pr N --gate <g> [--body-file <f>] [--run-id <id>]`** — the ADR-0058 rule-2
+  **upsert**, keyed on the posting **run** (ADR 0212): read
   the composed verdict body (from `--body-file` or stdin), refuse fail-closed if its first line is
-  not *this* gate's marker (the cross-namespace emission bug), then PATCH our own prior marker in
-  the namespace if one exists, else POST — exactly one verdict comment per (PR, gate). It then
+  not *this* gate's marker (the cross-namespace emission bug), then PATCH the prior marker **this
+  run** posted in the namespace if one exists, else POST — one verdict comment per (PR, gate, run).
+  The run id defaults to `$CLAUDE_CODE_SESSION_ID`; it is the dimension the shared GitHub login
+  cannot supply, and without it a concurrent reviewer silently PATCHed another reviewer's verdict
+  away (#4016). With no resolvable run id the post **appends** rather than upserting — an extra
+  comment, never a lost verdict. It then
   **re-fetches the landed comment and re-runs `emissionDefect` on its body** (the folded-in
   self-verify, #3019): a body that passed the input gate but did not land as a clean in-namespace,
   leak-free marker fails the post (non-zero) instead of reporting a false success — closing the
@@ -136,7 +141,7 @@ the REST-only `gh api` boundary (the `epic-lock` `github.ts` service pattern).
 ```bash
 # is PR 123's doc verdict a current-head PASS? (exit 0 = reviewed)
 node packages/pipeline-cli/src/bin.ts verdict read --pr 123 --gate doc && echo "merge-ready"
-# upsert a composed review-doc verdict (one comment per gate)
+# upsert a composed review-doc verdict (one comment per gate, per posting run)
 node packages/pipeline-cli/src/bin.ts verdict post --pr 123 --gate doc --body-file "$VERDICT_FILE"
 ```
 

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -19,7 +19,7 @@
  * a bindable first-line PASS (ADR 0111/0151).
  *
  * `post --pr N --gate <g> [--body-file <f>] [--run-id <id>]` upserts a SHA-bound verdict comment
- * (ADR 0058 rule 2 as refined by ADR 0212): it reads the composed verdict body from `--body-file`
+ * (ADR 0058 rule 2 as refined by ADR 0213): it reads the composed verdict body from `--body-file`
  * (or stdin), refuses fail-closed
  * on any `emissionDefect` (wrong namespace, unbindable `@ <sha>`, or a non-full-40-hex/path-glued
  * SHA field), then PATCHes the prior marker THIS RUN posted in the namespace if one exists, else
@@ -244,7 +244,7 @@ const post = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Upsert a SHA-bound verdict comment for a PR gate (PATCH this run's own prior marker, else POST — one per (gate, run), ADR 0058 rule 2 + ADR 0212)",
+		"Upsert a SHA-bound verdict comment for a PR gate (PATCH this run's own prior marker, else POST — one per (gate, run), ADR 0058 rule 2 + ADR 0213)",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -18,11 +18,15 @@
  * (`--cp`) the pass is the canonical SHA-less advisory bound by its body `Reviewed-head` line, never
  * a bindable first-line PASS (ADR 0111/0151).
  *
- * `post --pr N --gate <g> [--body-file <f>]` upserts a SHA-bound verdict comment (ADR 0058
- * rule 2): it reads the composed verdict body from `--body-file` (or stdin), refuses fail-closed
+ * `post --pr N --gate <g> [--body-file <f>] [--run-id <id>]` upserts a SHA-bound verdict comment
+ * (ADR 0058 rule 2 as refined by ADR 0212): it reads the composed verdict body from `--body-file`
+ * (or stdin), refuses fail-closed
  * on any `emissionDefect` (wrong namespace, unbindable `@ <sha>`, or a non-full-40-hex/path-glued
- * SHA field), then PATCHes our own prior marker in the namespace if one exists, else POSTs —
- * exactly one verdict comment per (PR, gate). It then re-fetches the landed comment and re-runs
+ * SHA field), then PATCHes the prior marker THIS RUN posted in the namespace if one exists, else
+ * POSTs — one verdict comment per (PR, gate, run). The run dimension (`--run-id`, defaulting to
+ * `$CLAUDE_CODE_SESSION_ID`) is what keeps a concurrent reviewer sharing our GitHub login from
+ * overwriting our verdict (#4016); with no run id the post appends rather than upserts. It then
+ * re-fetches the landed comment and re-runs
  * `emissionDefect` on its body (the folded-in self-verify, #3019), failing non-zero if the marker
  * didn't land clean rather than reporting a false success. It prints `patched <id>` / `posted <id>`.
  *
@@ -63,6 +67,13 @@ const headFlag = Flag.string("head").pipe(
 const expectFlag = Flag.string("expect").pipe(
 	Flag.optional,
 	Flag.withDescription("the polarity a `read` treats as satisfied: PASS (default) or FAIL"),
+);
+
+const runIdFlag = Flag.string("run-id").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the posting run's identity, the upsert key's run dimension (default: $CLAUDE_CODE_SESSION_ID; absent ⇒ append, never overwrite another run's verdict)",
+	),
 );
 
 const bodyFileFlag = Flag.string("body-file").pipe(
@@ -207,8 +218,8 @@ const readBody = Effect.fn(function* (bodyFile: Option.Option<string>) {
 
 const post = Command.make(
 	"post",
-	{pr: prFlag, gate: gateFlag, bodyFile: bodyFileFlag},
-	Effect.fn(function* ({pr, gate, bodyFile}) {
+	{pr: prFlag, gate: gateFlag, bodyFile: bodyFileFlag, runId: runIdFlag},
+	Effect.fn(function* ({pr, gate, bodyFile, runId}) {
 		const g = yield* parseGate(gate);
 		const body = (yield* readBody(bodyFile)).replace(/\s+$/, "");
 		if (body.length === 0) {
@@ -216,7 +227,11 @@ const post = Command.make(
 				"empty verdict body — nothing to post (pass --body-file or pipe the body on stdin)",
 			);
 		}
-		const result = yield* (yield* Github).post(pr, g, body).pipe(
+		// The posting run's identity, defaulted from the agent runtime's per-run session id — the
+		// dimension the shared `usirin` login cannot supply (#4016, the same token ADR 0115 claims
+		// under). Absent ⇒ this post appends instead of upserting; it never overwrites blind.
+		const run = Option.getOrUndefined(runId) ?? process.env.CLAUDE_CODE_SESSION_ID;
+		const result = yield* (yield* Github).post(pr, g, body, run).pipe(
 			Effect.catchTag("@kampus/verdict/VerdictInputError", (error) => fail(error.message)),
 			// The post-time head cross-check (#3801): a well-formed body bound to a DIFFERENT PR's head
 			// (a cross-PR scratchpad clobber, or a stale/rebased binding) is refused before it lands.
@@ -229,7 +244,7 @@ const post = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Upsert a SHA-bound verdict comment for a PR gate (PATCH own prior marker, else POST — one per gate, ADR 0058 rule 2)",
+		"Upsert a SHA-bound verdict comment for a PR gate (PATCH this run's own prior marker, else POST — one per (gate, run), ADR 0058 rule 2 + ADR 0212)",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -228,6 +228,49 @@ describe("decideGate — the §CP advisory is the pass, and only on a §CP PR (A
 		assert.strictEqual(result.decisions[0]?.state, "fail");
 	});
 
+	// The OPPOSITE direction of the case above, and the one that was left unpinned: a NEWER advisory
+	// out-ranking an OLDER same-head FAIL. This is not a nicety — it is the only exit from #4049. A
+	// body-only repair answers a finding without moving the head, so the old FAIL stays
+	// current-head-bound forever and head-keyed staleness (ADR 0058 rule 3) never fires. Latest-wins
+	// across the marker AND advisory candidate sets is what lets the superseding advisory clear it;
+	// any rule that makes a current-head FAIL an unconditional veto re-wedges every such PR (it is
+	// how PR #3988 got unstuck and how #3998 shipped). Pinned here because a veto reinstated in
+	// `decideGate`/`resolveVerdict` would otherwise pass the whole suite green — see ADR 0212
+	// §"Rejected: a current-head FAIL veto".
+	it("a NEWER §CP advisory out-ranks an OLDER same-head FAIL (the #4049 body-only-repair exit)", () => {
+		const result = decide({
+			comments: [
+				comment({
+					id: 1,
+					createdAt: "2026-07-25T05:00:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+				comment({id: 2, createdAt: "2026-07-25T05:30:00Z", body: advisory("doc", HEAD)}),
+			],
+			controlPlane: true,
+		});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "pass");
+		assert.strictEqual(result.decisions[0]?.form, "advisory");
+		assert.strictEqual(result.decisions[0]?.commentId, 2);
+	});
+
+	it("same createdAt, advisory has the larger id ⇒ the advisory still supersedes the FAIL", () => {
+		const result = decide({
+			comments: [
+				comment({
+					id: 1,
+					createdAt: "2026-07-25T05:00:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+				comment({id: 2, createdAt: "2026-07-25T05:00:00Z", body: advisory("doc", HEAD)}),
+			],
+			controlPlane: true,
+		});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.form, "advisory");
+	});
+
 	it("on a NON-§CP PR an advisory is not a pass — it resolves absent", () => {
 		const result = decide({comments: [comment({id: 1, body: advisory("doc", HEAD)})]});
 		assert.isFalse(result.enqueueable);

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -235,7 +235,7 @@ describe("decideGate — the §CP advisory is the pass, and only on a §CP PR (A
 	// across the marker AND advisory candidate sets is what lets the superseding advisory clear it;
 	// any rule that makes a current-head FAIL an unconditional veto re-wedges every such PR (it is
 	// how PR #3988 got unstuck and how #3998 shipped). Pinned here because a veto reinstated in
-	// `decideGate`/`resolveVerdict` would otherwise pass the whole suite green — see ADR 0212
+	// `decideGate`/`resolveVerdict` would otherwise pass the whole suite green — see ADR 0213
 	// §"Rejected: a current-head FAIL veto".
 	it("a NEWER §CP advisory out-ranks an OLDER same-head FAIL (the #4049 body-only-repair exit)", () => {
 		const result = decide({

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -9,6 +9,7 @@ import {
 	VerdictInputError,
 	VerdictVerifyError,
 } from "./github.ts";
+import {withRunId} from "./verdict-match.ts";
 
 const PINNED_REPO = "kamp-us/phoenix";
 let savedEnv: string | undefined;
@@ -37,9 +38,14 @@ const methodOf = (args: ReadonlyArray<string>): string => {
 	return i >= 0 ? (args[i + 1] ?? "GET") : "GET";
 };
 
-/** A `ChildProcessSpawner` answering `gh api`/`gh repo`/`gh user` from a `${method} ${key}` fixture map. */
+/**
+ * A `ChildProcessSpawner` answering `gh api`/`gh repo`/`gh user` from a `${method} ${key}` fixture
+ * map, appending each spawned arg vector to `record` when one is supplied (so a test can assert
+ * what was actually sent, not only what came back).
+ */
 const mockSpawner = (
 	responses: Record<string, Response>,
+	record?: Array<ReadonlyArray<string>>,
 ): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
 	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
 		ChildProcessSpawner.make(
@@ -47,6 +53,7 @@ const mockSpawner = (
 				let cmd = command;
 				while (cmd._tag === "PipedCommand") cmd = cmd.left;
 				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				record?.push(args);
 				// route on the REST path when present, else on the `gh <sub> <verb>` shape (user/repo)
 				const rawPath =
 					args.find((a) => a.startsWith("repos/")) ??
@@ -77,8 +84,9 @@ const mockSpawner = (
 const provide = <A, E>(
 	effect: Effect.Effect<A, E, Github>,
 	responses: Record<string, Response>,
+	record?: Array<ReadonlyArray<string>>,
 ): Effect.Effect<A, E | RepoResolutionError> =>
-	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses, record)))));
 
 const PR = 500;
 const P = `repos/kamp-us/phoenix`;
@@ -88,6 +96,10 @@ const OLD = "0000000aaaa1111";
 // emission guard (#2683) accepts on a POSTed body. `HEAD`/`OLD` stay short: they exercise the READ
 // side, whose {7,40} staleness matcher (ADR 0058 rule 3) is deliberately looser and left unchanged.
 const HEAD40 = `${"a1b2c3d4e5f6".repeat(3)}a1b2`; // 12*3 + 4 = 40 hex
+// Two reviewer runs under the SAME GitHub login — the #4016 shape. `RUN` is the single-run default.
+const RUN = "ddf8f459-b75f-4de2-9051-8df10da5b55c";
+const RUN_A = RUN;
+const RUN_B = "11111111-2222-3333-4444-555555555555";
 
 const comment = (over: {
 	readonly id: number;
@@ -194,19 +206,23 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 		),
 	);
 
-	it.effect("our own prior marker exists → PATCH it (upsert, not append)", () =>
+	it.effect("this run's own prior marker exists → PATCH it (upsert, not append)", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).post(PR, "doc", BODY);
+			const result = yield* (yield* Github).post(PR, "doc", BODY, RUN);
 			assert.deepStrictEqual(result, {_tag: "patched", commentId: 42});
 		}).pipe((effect) =>
 			provide(effect, {
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
-					comment({id: 42, login: "usirin", body: `review-doc: FAIL @ ${OLD} — changes-requested`}),
+					comment({
+						id: 42,
+						login: "usirin",
+						body: withRunId(`review-doc: FAIL @ ${OLD} — changes-requested`, RUN),
+					}),
 				]),
 				[`GET ${P}/pulls/${PR}`]: HEAD40 /* #3801: BODY binds HEAD40 */,
 				[`PATCH ${P}/issues/comments/42`]: "42",
-				[`GET ${P}/issues/comments/42`]: BODY,
+				[`GET ${P}/issues/comments/42`]: withRunId(BODY, RUN),
 			}),
 		),
 	);
@@ -363,6 +379,139 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				[`GET ${P}/issues/comments/890`]: `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD40}`,
 			}),
 		),
+	);
+});
+
+// The #4016 cross-reviewer clobber: every pipeline review agent posts under ONE shared GitHub login,
+// so the pre-fix author-keyed upsert let a concurrent sibling PATCH another reviewer's verdict body
+// away at the same head — a PASS could silently replace a FAIL. The upsert key now carries the
+// posting RUN, so a sibling never matches another run's marker. None of these cases supplies a PATCH
+// fixture: a regression that PATCHes anything 404s the write instead of passing quietly.
+describe("Github.post — the upsert is keyed on the posting RUN, not the shared author (#4016)", () => {
+	const MINE = `review-code: FAIL @ ${HEAD40} — not merge-ready`;
+	const SIBLING = `review-code: PASS @ ${HEAD40} — merge-ready`;
+
+	it.effect("a sibling RUN's marker at the same head is appended to, never PATCHed away", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "code", SIBLING, RUN_B);
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 901});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					// run A's verdict, landed at this same head under the SAME login
+					comment({id: 900, login: "usirin", body: withRunId(MINE, RUN_A)}),
+				]),
+				[`GET ${P}/pulls/${PR}`]: HEAD40,
+				[`POST ${P}/issues/${PR}/comments`]: "901",
+				[`GET ${P}/issues/comments/901`]: withRunId(SIBLING, RUN_B),
+			}),
+		),
+	);
+
+	// AC 4 end to end: two posts, one namespace, one head, one author, two runs — both bodies survive.
+	it.effect("two runs at one head leave BOTH verdict comments (no lost verdict)", () =>
+		Effect.gen(function* () {
+			const landed: Array<{readonly id: number; readonly login: string; readonly body: string}> =
+				[];
+			const first = yield* Effect.provide(
+				Effect.flatMap(Github, (gh) => gh.post(PR, "code", MINE, RUN_A)),
+				GithubLive.pipe(
+					Layer.provide(
+						mockSpawner({
+							"GET user": "usirin",
+							[`GET ${P}/issues/${PR}/comments`]: JSON.stringify(landed),
+							[`GET ${P}/pulls/${PR}`]: HEAD40,
+							[`POST ${P}/issues/${PR}/comments`]: "900",
+							[`GET ${P}/issues/comments/900`]: withRunId(MINE, RUN_A),
+						}),
+					),
+				),
+			);
+			landed.push({id: 900, login: "usirin", body: withRunId(MINE, RUN_A)});
+			const second = yield* Effect.provide(
+				Effect.flatMap(Github, (gh) => gh.post(PR, "code", SIBLING, RUN_B)),
+				GithubLive.pipe(
+					Layer.provide(
+						mockSpawner({
+							"GET user": "usirin",
+							[`GET ${P}/issues/${PR}/comments`]: JSON.stringify(
+								landed.map((c) => comment({id: c.id, login: c.login, body: c.body})),
+							),
+							[`GET ${P}/pulls/${PR}`]: HEAD40,
+							[`POST ${P}/issues/${PR}/comments`]: "901",
+							[`GET ${P}/issues/comments/901`]: withRunId(SIBLING, RUN_B),
+						}),
+					),
+				),
+			);
+			assert.deepStrictEqual(first, {_tag: "posted", commentId: 900});
+			assert.deepStrictEqual(second, {_tag: "posted", commentId: 901});
+			// run A's FAIL body was never touched — the record it wrote is still the record on the PR
+			assert.deepStrictEqual(landed, [{id: 900, login: "usirin", body: withRunId(MINE, RUN_A)}]);
+		}),
+	);
+
+	it.effect("a run-less legacy marker from our login is appended to, never PATCHed", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "code", SIBLING, RUN_B);
+			assert.strictEqual(result._tag, "posted");
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 800, login: "usirin", body: MINE}),
+				]),
+				[`GET ${P}/pulls/${PR}`]: HEAD40,
+				[`POST ${P}/issues/${PR}/comments`]: "802",
+				[`GET ${P}/issues/comments/802`]: withRunId(SIBLING, RUN_B),
+			}),
+		),
+	);
+
+	it.effect("no run id at all → append, never a blind overwrite of our own prior marker", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "code", SIBLING);
+			assert.strictEqual(result._tag, "posted");
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 810, login: "usirin", body: withRunId(MINE, RUN_A)}),
+				]),
+				[`GET ${P}/pulls/${PR}`]: HEAD40,
+				[`POST ${P}/issues/${PR}/comments`]: "811",
+				[`GET ${P}/issues/comments/811`]: SIBLING,
+			}),
+		),
+	);
+
+	it.effect(
+		"the POSTed body carries this run's trailer (what makes the key resolvable later)",
+		() =>
+			Effect.gen(function* () {
+				const calls: Array<ReadonlyArray<string>> = [];
+				yield* Effect.provide(
+					Effect.flatMap(Github, (gh) => gh.post(PR, "code", SIBLING, RUN_B)),
+					GithubLive.pipe(
+						Layer.provide(
+							mockSpawner(
+								{
+									"GET user": "usirin",
+									[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+									[`GET ${P}/pulls/${PR}`]: HEAD40,
+									[`POST ${P}/issues/${PR}/comments`]: "903",
+									[`GET ${P}/issues/comments/903`]: withRunId(SIBLING, RUN_B),
+								},
+								calls,
+							),
+						),
+					),
+				);
+				const posted = calls.find((args) => args.includes("-X") && args.includes("POST"));
+				assert.isDefined(posted);
+				assert.isTrue(posted?.some((arg) => arg.includes(`verdict-run: ${RUN_B}`)));
+			}),
 	);
 });
 

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -15,7 +15,7 @@
  *  - `read(pr, gate, expect, headOverride)` — resolve the PR's current head (REST), author-gate
  *    marker authors to write+ collaborators (ADR 0055), and run `resolveVerdict` to classify
  *    the namespace against that head. The consumer branches on the returned outcome.
- *  - `post(pr, gate, body, runId)` — the ADR-0058 rule-2 UPSERT, scoped per posting RUN (ADR 0212):
+ *  - `post(pr, gate, body, runId)` — the ADR-0058 rule-2 UPSERT, scoped per posting RUN (ADR 0213):
  *    guard the body's first line is *this* gate's marker (fail-closed on a cross-namespace body),
  *    then PATCH the prior marker THIS RUN posted in the namespace if one exists, else POST a fresh
  *    one — one verdict comment per (PR, gate, run), so a concurrent reviewer sharing our GitHub

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -15,9 +15,11 @@
  *  - `read(pr, gate, expect, headOverride)` — resolve the PR's current head (REST), author-gate
  *    marker authors to write+ collaborators (ADR 0055), and run `resolveVerdict` to classify
  *    the namespace against that head. The consumer branches on the returned outcome.
- *  - `post(pr, gate, body)` — the ADR-0058 rule-2 UPSERT: guard the body's first line is *this*
- *    gate's marker (fail-closed on a cross-namespace body), then PATCH our own prior marker in
- *    the namespace if one exists, else POST a fresh one — exactly one verdict comment per (PR, gate).
+ *  - `post(pr, gate, body, runId)` — the ADR-0058 rule-2 UPSERT, scoped per posting RUN (ADR 0212):
+ *    guard the body's first line is *this* gate's marker (fail-closed on a cross-namespace body),
+ *    then PATCH the prior marker THIS RUN posted in the namespace if one exists, else POST a fresh
+ *    one — one verdict comment per (PR, gate, run), so a concurrent reviewer sharing our GitHub
+ *    login appends rather than overwriting our verdict (#4016).
  */
 import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
@@ -47,11 +49,14 @@ import {
 	emissionDefect,
 	headBindingDefect,
 	namespaceRe,
+	normalizeRunId,
 	type Polarity,
 	resolveVerdict,
+	runIdOf,
 	type VerdictComment,
 	type VerdictGate,
 	type VerdictOutcome,
+	withRunId,
 } from "./verdict-match.ts";
 
 // Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
@@ -247,18 +252,29 @@ const gate = Effect.fn("Github.gate")(function* (
  * cross-check (#3801) fetches the target PR's live head and refuses if a bound SHA does not match it
  * — closing the verdict-integrity hole where a body composed for another PR (bound to a different
  * PR's SHA, e.g. via a clobbered shared scratch file) was postable and caught only on read-back.
- * Then scan our OWN prior marker in the namespace (newest by
- * `(created_at, id)`) and PATCH it if present else POST a fresh one. The own-authored scope means
- * two reviewers never stomp each other's records. Finally, `verifyLanded` re-fetches the upserted
- * comment and re-runs `emissionDefect` on its LANDED body — the defense-in-depth self-verify (#3019)
- * that fails the post if the marker didn't land clean, rather than reporting a false success.
+ * Then scan for THIS RUN's own prior marker in the namespace (same author AND the same
+ * `verdict-run:` trailer, newest by `(created_at, id)`) and PATCH it if present, else POST a fresh
+ * one. The run dimension is load-bearing and the author dimension alone is NOT sufficient (#4016):
+ * every pipeline review agent posts under one shared GitHub identity, so an author-keyed upsert let
+ * a concurrent sibling reviewer silently PATCH another reviewer's verdict body away — a PASS could
+ * replace a FAIL at the same head with no trace the FAIL existed. Keyed on the run, a sibling never
+ * matches: it appends its own comment, so both verdicts survive in the record and the unchanged
+ * latest-wins resolution (`resolveVerdict` / `decideGate`) picks between them by `(createdAt, id)`.
+ * A run that cannot identify itself (no run id) never
+ * PATCHes at all — it appends, which costs a comment and loses nothing. Finally, `verifyLanded`
+ * re-fetches the upserted comment and re-runs `emissionDefect` on its LANDED body — the
+ * defense-in-depth self-verify (#3019) that fails the post if the marker didn't land clean, rather
+ * than reporting a false success.
  */
 const post = Effect.fn("Github.post")(function* (
 	repo: string,
 	pr: number,
 	gate: VerdictGate,
-	body: string,
+	rawBody: string,
+	rawRunId: string | undefined,
 ) {
+	const runId = normalizeRunId(rawRunId);
+	const body = runId === null ? rawBody : withRunId(rawBody, runId);
 	const defect = emissionDefect(body, gate);
 	if (defect !== null) {
 		return yield* new VerdictInputError({message: `refusing to post: ${defect}`});
@@ -276,9 +292,14 @@ const post = Effect.fn("Github.post")(function* (
 	const me = (yield* runGh(whoAmIArgs)).trim();
 	const comments = yield* listComments(repo, pr);
 	const re = namespaceRe(gate);
-	const mine = comments
-		.filter((c) => c.author === me && re.test(c.body))
-		.sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id));
+	const mine =
+		runId === null
+			? []
+			: comments
+					.filter((c) => c.author === me && re.test(c.body) && runIdOf(c.body) === runId)
+					.sort((a, b) =>
+						a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
+					);
 	const priorId = mine[mine.length - 1]?.id;
 	const result: PostResult = yield* Effect.gen(function* () {
 		if (priorId !== undefined) {
@@ -327,10 +348,12 @@ export class Github extends Context.Service<
 			GateDecision,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
 		>;
+		/** `runId` is the posting run's identity — the upsert key's run dimension; see `post` (#4016). */
 		readonly post: (
 			pr: number,
 			gate: VerdictGate,
 			body: string,
+			runId?: string,
 		) => Effect.Effect<
 			PostResult,
 			| RepoResolutionError
@@ -367,8 +390,8 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 							withSpawner(gate(r, pr, requiredGates, controlPlane, headOverride)),
 						),
 					),
-				post: (pr, gate, body) =>
-					repo.pipe(Effect.flatMap((r) => withSpawner(post(r, pr, gate, body)))),
+				post: (pr, gate, body, runId) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(post(r, pr, gate, body, runId)))),
 			};
 		}),
 	);

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -224,6 +224,45 @@ export const outcomeReason = (outcome: VerdictOutcome, expect: Polarity): string
 };
 
 /**
+ * The run-identity trailer `post` stamps on every verdict body it writes, and matches on to find
+ * *its own* prior marker to upsert: an HTML comment (invisible in rendered markdown) carrying the
+ * posting run's id.
+ *
+ * This is the missing dimension of the upsert key (#4016). Every pipeline review agent posts under
+ * ONE shared GitHub identity, so "own-authored" does not distinguish reviewers — a concurrent
+ * sibling in the same namespace matched the other reviewer's comment and PATCHed its verdict away,
+ * server-side and silently. The run id (the agent's `CLAUDE_CODE_SESSION_ID`, the same
+ * agent-distinguishable token ADR 0115 claims work under) is what the shared login cannot provide.
+ *
+ * Anchored per line with `m` so the trailer is matched wherever it sits in the body, and never
+ * confused with prose that merely mentions one.
+ */
+const runTrailerRe =
+	/^[ \t]*<!--[ \t]*verdict-run:[ \t]*([0-9A-Za-z][0-9A-Za-z._-]{7,127})[ \t]*-->[ \t]*$/m;
+
+/**
+ * The run id a verdict body was posted under, or `null` when it carries no trailer — a pre-#4016
+ * marker, or one hand-rolled through raw `gh api`.
+ */
+export const runIdOf = (body: string): string | null =>
+	runTrailerRe.exec(body)?.[1]?.toLowerCase() ?? null;
+
+/**
+ * A usable run id, or `null` for an absent/malformed one (an unset `CLAUDE_CODE_SESSION_ID`, a
+ * value with whitespace or trailer-breaking characters). Every `null` here and in `runIdOf` is the
+ * fail-safe: a run that cannot prove which marker is its own appends instead of upserting — an
+ * extra comment, never a lost verdict.
+ */
+export const normalizeRunId = (raw: string | undefined | null): string | null => {
+	const value = (raw ?? "").trim().toLowerCase();
+	return /^[0-9a-z][0-9a-z._-]{7,127}$/.test(value) ? value : null;
+};
+
+/** Stamp `runId` onto a verdict body, replacing any trailer it already carries. */
+export const withRunId = (body: string, runId: string): string =>
+	`${body.replace(runTrailerRe, "").replace(/\s+$/, "")}\n\n<!-- verdict-run: ${runId} -->`;
+
+/**
  * The `post` namespace guard: does this body's first line open with the gate's marker? A
  * verdict body must carry its OWN gate's marker on line one — `post`-ing a `review-code`
  * marker on a doc PR is the cross-namespace emission bug this refuses fail-closed. Accepts

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -8,11 +8,14 @@ import {
 	isReviewed,
 	isUnboundPolarityMarker,
 	malformedEmittedSha,
+	normalizeRunId,
 	parseVerdict,
 	resolveVerdict,
+	runIdOf,
 	type VerdictComment,
 	type VerdictGate,
 	type VerdictOutcome,
+	withRunId,
 } from "./verdict-match.ts";
 
 const HEAD = "abc1234def5678";
@@ -183,18 +186,42 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 				marker({
 					id: 10,
 					createdAt: "2026-07-11T00:00:00Z",
-					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
 				}),
 				marker({
 					id: 20,
 					createdAt: "2026-07-11T00:00:00Z",
-					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+					body: `review-doc: PASS @ ${HEAD} — merge-ready (round 2)`,
 				}),
 			],
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
 			expected: {_tag: "current", commentId: 20, polarity: "PASS", sha: HEAD},
+			reviewedPass: true,
+		},
+		// The run-scoped upsert (#4016) means two reviewer RUNS can now leave two verdict comments
+		// at ONE head, where the author-keyed upsert used to collapse them to one. Resolution is
+		// unchanged by that: latest-wins on `(createdAt, id)` still decides (ADR 0058) — the newer
+		// verdict supersedes the older, exactly as a re-review at the same head always did.
+		{
+			name: "two runs at one head: the newer verdict supersedes the older (latest-wins)",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: "2026-07-11T00:00:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+				marker({
+					id: 2,
+					createdAt: "2026-07-11T00:00:05Z",
+					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+				}),
+			],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "current", commentId: 2, polarity: "PASS", sha: HEAD},
 			reviewedPass: true,
 		},
 		{
@@ -478,4 +505,40 @@ describe("headBindingDefect — refuse a body bound to a head other than the tar
 
 	it("fail-closed exemption: an empty head still passes a bind-nothing advisory", () =>
 		assert.isNull(headBindingDefect("review-code: advisory — see thread", "code", "")));
+});
+
+describe("the run-identity trailer — the upsert key's run dimension (#4016)", () => {
+	const RUN = "ddf8f459-b75f-4de2-9051-8df10da5b55c";
+	const OTHER_RUN = "11111111-2222-3333-4444-555555555555";
+	const SHA40 = "a".repeat(40);
+	const BODY = `review-doc: PASS @ ${SHA40} — merge-ready`;
+
+	it("runIdOf reads back the id withRunId stamped", () =>
+		assert.strictEqual(runIdOf(withRunId(BODY, RUN)), RUN));
+
+	it("runIdOf is null for a pre-#4016 / hand-rolled marker (never provably ours)", () =>
+		assert.isNull(runIdOf(BODY)));
+
+	it("runIdOf does not read a trailer merely quoted mid-line", () =>
+		assert.isNull(runIdOf(`${BODY}\n\nprose <!-- verdict-run: ${RUN} --> prose`)));
+
+	it("withRunId replaces a foreign run's trailer rather than stacking a second", () => {
+		const restamped = withRunId(withRunId(BODY, OTHER_RUN), RUN);
+		assert.strictEqual(runIdOf(restamped), RUN);
+		assert.strictEqual(restamped.split("verdict-run:").length - 1, 1);
+	});
+
+	it("a stamped body still passes every emission guard (marker stays on line one)", () =>
+		assert.isNull(emissionDefect(withRunId(BODY, RUN), "doc")));
+
+	it("normalizeRunId keeps a session-id-shaped token, lowercased", () =>
+		assert.strictEqual(normalizeRunId(` ${RUN.toUpperCase()} `), RUN));
+
+	it("normalizeRunId is null for absent/malformed ids (⇒ append, never a blind overwrite)", () => {
+		assert.isNull(normalizeRunId(undefined));
+		assert.isNull(normalizeRunId(""));
+		assert.isNull(normalizeRunId("short"));
+		assert.isNull(normalizeRunId("has whitespace inside"));
+		assert.isNull(normalizeRunId("-->injected"));
+	});
 });

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -186,12 +186,12 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 				marker({
 					id: 10,
 					createdAt: "2026-07-11T00:00:00Z",
-					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
 				}),
 				marker({
 					id: 20,
 					createdAt: "2026-07-11T00:00:00Z",
-					body: `review-doc: PASS @ ${HEAD} — merge-ready (round 2)`,
+					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
 				}),
 			],
 			authorized: ["usirin"],


### PR DESCRIPTION
Fixes #4016

## What this fixes

`pipeline-cli verdict post` selected the prior marker to PATCH by `(comment author, gate namespace)` only. Every pipeline review agent posts under **one shared GitHub identity**, so "own-authored" did not distinguish reviewers: a concurrent sibling reviewer in the same namespace matched the *other* reviewer's comment and overwrote its verdict body server-side, silently. Observed on PR #3988 at head `0368922e213a1d9b77e4144a5d38d256b1d92795`.

The `post` docblock's premise — "the own-authored scope means two reviewers never stomp each other's records" — was the bug, and it was inherited verbatim from ADR 0058 rule 2.

## The change

**1. The upsert key gains a run dimension** (`packages/pipeline-cli/src/tools/verdict/`).

`post` stamps every body it writes with an invisible trailer — `<!-- verdict-run: <id> -->` — carrying the posting run's identity (the agent's `CLAUDE_CODE_SESSION_ID`, overridable with a new `--run-id` flag). It PATCHes only a marker matching on **author AND gate namespace AND this run's trailer**:

- a genuine same-run correction still upserts (no comment spam for a revision of this run's own record);
- a sibling run never matches — it appends its own comment;
- **with no resolvable run id the post appends rather than upserting.** Ownership is never assumed on absent evidence, so the worst case is an extra comment, never a lost verdict. A hand-rolled marker (no trailer) is likewise appended beside, never overwritten.

**2. The read side is UNCHANGED — and a FAIL veto is explicitly rejected.**

`resolveVerdict` and `decideGate` are byte-identical to `main` (`git diff --numstat origin/main -- verdict-match.ts` = `39 0` — insertions only, zero deletions). Precedence stays **latest-wins on `(createdAt, id)`** across the marker and §CP advisory candidate sets alike, exactly as ADR 0058 rule 3 and #4012 landed it.

An earlier round of this PR did add a read-side rule that any current-head FAIL vetoes. **That rule is rejected and removed.** A body-only repair — the finding is answered in the PR body, the ADR text, or the verdict record itself — deliberately does *not* move the head, so an old FAIL stays current-head-bound indefinitely and head-keyed staleness never fires. Under a veto rule nothing can out-rank it and the PR is wedged with no exit: that is #4049. Latest-wins is what lets a newer superseding verdict (a re-review marker, or a §CP advisory) clear it; PRs #3988 and #3998 both shipped through that path. ADR 0213 records the rejection and its mechanism.

What this PR *adds* on the read side is a **pin against the veto's reinstatement**: a reinstated veto would otherwise pass the whole suite green.

**3. ADR [0213](.decisions/0213-verdict-upsert-keyed-on-run-not-shared-author.md) records the decision and refines ADR 0058 rule 2** — the uniqueness invariant narrows from *exactly one comment per (PR, gate)* to *per (PR, gate, run)*, and the "banned: POST when this gate already has a marker" clause now scopes to *this run's* marker. Rules 1 / 3 / 4 are untouched; precedence is explicitly out of scope.

## Acceptance criteria

- [x] A `post` whose matched prior marker was written by a different reviewer run does not PATCH it away — it posts fresh. Covered by `Github.post — the upsert is keyed on the posting RUN, not the shared author (#4016)`; none of those cases supplies a PATCH fixture, so a regression that PATCHes fails the mocked write instead of passing quietly.
- [x] `read`'s resolution still yields a deterministic current-head verdict when a namespace carries more than one verdict comment at one head — latest-wins on `(createdAt, id)`, unchanged and now pinned: `two runs at one head: the newer verdict supersedes the older (latest-wins)` in `verdict-match.unit.test.ts`, plus `a NEWER §CP advisory out-ranks an OLDER same-head FAIL (the #4049 body-only-repair exit)` and `same createdAt, advisory has the larger id ⇒ the advisory still supersedes the FAIL` in `gate-decision.unit.test.ts`.
- [x] The false docblock premise in `post` is corrected to describe the real key.
- [x] Unit coverage: two posts, same namespace, same head, same author, distinct runs → both verdict bodies survive (`two runs at one head leave BOTH verdict comments (no lost verdict)`), and the POSTed body carries this run's trailer.

Also preserved, per the triage note: the same-run correction path #4007 depends on (a re-post revising this run's own comment still upserts), and the #3801 post-time head cross-check (untouched, still runs before any write).

## Scope

Not fixed here: the **head** dimension of the same selection — re-gating at a new head still edits the prior head's verdict in place when the same run posts both. That is #4007, whose triage note records that a head-keyed fix does not resolve this issue and vice versa. One issue claimed, one issue closed.

The `review-*` skills' prose still says "exactly one marker comment per PR in its namespace". ADR 0213 is the single source for the refined rule; re-stating it across four skill files was left out of this diff deliberately rather than widening a merge-authority change.

## Verification

- `pnpm typecheck` — clean (29/29).
- `pnpm lint` (worktree mode) — clean.
- `pnpm --filter @kampus/pipeline-cli exec vitest run src/tools/verdict` — 144 passed (3 files).
- The anti-veto pin is proven by counterfactual, not by reading: injecting an equal-`createdAt` polarity-ordering rule into `pickLatestAuthorized`'s comparator reds `equal createdAt ⇒ newest by the larger comment id`; injecting a FAIL veto into `decideGate` reds the two §CP advisory cases. Both injections reverted.
- ADR number verified free at this head: `main`'s max is `0212` (`0212-marketplace-manifest-is-control-plane.md`, #4052; `0210` is a pre-existing hole, deliberately not filled), no ref or open PR claims `0213`, and `pipeline-cli decisions-index validate` run against the reconstructed merged tree (`git merge-tree --write-tree origin/main HEAD`) reports `ADR files valid (no duplicate or mismatched id)`.
