### PR TITLE
feat(triage): home-or-exempt-or-kill rubric + fail-closed homing-guard (#3939)

### DIFF
--- a/.github/workflows/homing-guard.yml
+++ b/.github/workflows/homing-guard.yml
@@ -71,6 +71,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # The printf format must stay single-quoted: its backticks are the markdown fence of the
+          # filed issue body, not command substitution — nothing in it may expand.
+          # shellcheck disable=SC2016
           gh issue create --repo "$GITHUB_REPOSITORY" \
             --title "homing-guard: triaged issues left without a home" \
             --label "status:needs-triage" \

--- a/.github/workflows/homing-guard.yml
+++ b/.github/workflows/homing-guard.yml
@@ -1,0 +1,85 @@
+name: homing-guard
+
+# CI gate for #3939 (ADR 0202 forward-motion doctrine + ADR 0208 standing-lane exemption):
+# every issue that leaves triage carries an arc/campaign milestone, or one of exactly two
+# standing-lane labels (`wayfinder:backlog`, `axis:pipeline-hardening`), or it was killed.
+# The check lives once in pipeline-cli (`homing-guard check`); this workflow wires it to the
+# two surfaces where the invariant can break.
+#
+# There is deliberately NO `pull_request` trigger: homing is a property of the BACKLOG, not
+# of a diff, so a PR gate here would block every unrelated PR on a floater it did not create.
+# The teeth land where the state moves instead — at the labelling seam, and on a schedule.
+on:
+  # The seam: the moment an issue is stamped `status:triaged` (or its milestone moves), check
+  # THAT issue. A red run names the issue that just lost its home, not the whole backlog.
+  issues:
+    types: [labeled, unlabeled, milestoned, demilestoned]
+  # Weekly backstop for drift no single issue event covers (a milestone closed out of band,
+  # a pre-existing floater). On red, file a status:needs-triage issue — the sweep's signal.
+  schedule:
+    # Monday 06:17 UTC — off-hours, off the top of the hour (the scheduler congests on-the-hour
+    # crons), and offset from roadmap-guard's 05:23 so the two don't file in the same minute.
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # checkout
+  issues: write # file the drift issue on a scheduled red
+
+jobs:
+  check:
+    name: check every triaged issue is homed or standing-lane exempt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # An `issues` event scopes the scan to that one issue; schedule/dispatch scan the whole
+      # open triaged backlog. `continue-on-error` lets a red proceed to the issue-filing step;
+      # the final step re-fails the job for the non-schedule triggers.
+      - name: homing-guard check
+        id: guard
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -o pipefail
+          if [ -n "$ISSUE" ]; then
+            node packages/pipeline-cli/src/bin.ts homing-guard check --issue "$ISSUE" 2>&1 | tee guard-output.txt
+          else
+            node packages/pipeline-cli/src/bin.ts homing-guard check 2>&1 | tee guard-output.txt
+          fi
+          echo "code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      # Scheduled red → file a status:needs-triage issue. No issue event and no PR to block on
+      # a schedule run, so the filed issue IS the signal.
+      - name: File a status:needs-triage issue on scheduled drift
+        if: ${{ github.event_name == 'schedule' && steps.guard.outputs.code != '0' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "homing-guard: triaged issues left without a home" \
+            --label "status:needs-triage" \
+            --body "$(printf 'The weekly homing-guard sweep found triaged issues carrying neither a milestone nor a standing-lane label. Home, exempt, or kill each one per the triage rubric (ADR 0202/0208).\n\nGuard output:\n\n```\n%s\n```\n' "$(cat guard-output.txt)")"
+
+      # Red the run for the blocking triggers (an issue event, a manual dispatch). On a
+      # schedule run the drift was already reported as an issue above.
+      - name: Fail the job on an un-homed issue (blocking triggers)
+        if: ${{ github.event_name != 'schedule' && steps.guard.outputs.code != '0' }}
+        run: |
+          echo "homing-guard: a triaged issue has no home — see the check step output above." >&2
+          exit 1

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -145,8 +145,9 @@ text reads as phoenix-only) is also de-pinned: the trigger describes the *capabi
 Every issue carries one `type:*`, one `p*`, and one `status:*` (plus, transiently, the
 `status:planning` epic-lock on a locked epic — a second `status:*` that sits *alongside* the
 real one, never replacing it; see below). These three are the **mandatory** dimensions triage
-always sets. There is a fourth, **optional** dimension — `milestone` — that is *not* a label
-and not always present; it lives on its own GitHub surface and is documented in §Milestone. The
+always sets. There is a fourth dimension — `milestone` — that is *not* a label; it lives on its
+own GitHub surface, and triage homes every issue in one unless a standing-lane label or a kill
+applies (ADR 0202/0208). It is documented in §Milestone. The
 `status:*` labels are the **pipeline state** an issue sits in — the spine the intake skills key
 on. The canonical set:
 
@@ -284,13 +285,21 @@ See ADR [0059](https://github.com/kamp-us/phoenix/blob/main/.decisions/0059-epic
 (the lock) and ADR [0115](https://github.com/kamp-us/phoenix/blob/main/.decisions/0115-agent-distinguishable-claim-marker.md)
 (the agent-distinguishable claim, #1452).
 
-## Milestone — the one *optional* intake dimension
+## Milestone — the fourth intake dimension
 
 `type:*`, `p*`, and `status:*` are **mandatory** dimensions: every issue carries exactly one of
-each, and an issue missing any of them is malformed. **Milestone is the exception** — it is an
-**optional** fourth intake dimension that sits alongside the three labels, and **most issues
-carry none**. An issue with no milestone is **well-formed by default**; absence is the norm, not
-a defect (contrast the `status:*` spine, where a missing label is a triage bug).
+each, and an issue missing any of them is malformed. **Milestone is the fourth**, and it lives on
+the issue's native `milestone` field rather than a label.
+
+**Optionality is bounded by the standing-lane rule (ADR 0202/0208, #3939).** Milestone used to be
+the *optional* dimension — most issues carried none and absence was the norm. That no longer holds
+at the **triage** seam: an issue that leaves triage is **homed** in an arc/campaign milestone,
+**or** carries one of exactly two standing-lane labels (`wayfinder:backlog`,
+`axis:pipeline-hardening`), **or** is killed — ADR
+[0208](https://github.com/kamp-us/phoenix/blob/main/.decisions/0208-standing-lane-exemption-from-full-homing.md)
+amends ADR 0072 §4/§5 in part, and `triage`'s "Assign a home" step owns the behavior. Everything
+below — what a milestone encodes, the two kinds, the never-create rule, the REST surface, the read
+side — is unchanged.
 
 This section is the **single source of truth** the three behavioral skills cite for milestone —
 `triage` (assigns it), `plan-epic` (children inherit it), and `write-code` (consumes it for
@@ -323,13 +332,13 @@ autonomous — fragmenting the set would destroy its single-source-of-truth valu
 autonomous "create-milestones" skill (ADR 0072 §3). A skill that finds no clear match to an
 existing open milestone leaves the issue **unmilestoned**; it does not invent a home.
 
-**Freeze-by-absence — deliberate absence is a signal, never missing data.** A deliberately
-**unmilestoned** cluster (e.g. a frozen new-product surface — kampus-CLI / künye) is itself
-the signal that the work is **parked / deferred** (ADR 0072 §4). So a missing milestone is
-**never** "data to be backfilled": a skill must not auto-fill an empty milestone to make an issue
-"complete." Absence carries information — treat it as a value, not a gap. This is the inverse of
-the mandatory labels: for `status:*` a missing value *is* a defect to fix; for milestone a missing
-value is often the intended state.
+**Freeze-by-absence moved from an absence to a label (ADR 0208).** The signal ADR 0072 §4 carried
+— *this work is parked by design; don't force-fit it* — is not retired, but it no longer rides on
+a bare absence. It rides on the two standing-lane labels: `wayfinder:backlog` (fog, homed when
+charted — ADR 0203) and `axis:pipeline-hardening` (the permanent hardening lane). For an issue
+outside those two, an empty milestone after triage reads as **un-homed**, not parked. Unchanged:
+a skill still never force-fits or invents a home to make an issue look "complete" — the honest
+outcomes are a real home, a standing-lane label, or a kill.
 
 **Orthogonal to verification and merge.** Milestone is a **backlog/planning** dimension only.
 The gates (`review-code` / `review-doc` / `review-skill` / `review-plan`), `ship-it`, and the
@@ -346,12 +355,12 @@ each skill.
 
 **Write side:**
 
-- **`triage`** assigns a milestone on a **clear surface-match** — keying off the surface it
-  already reads to classify — and only then. The guardrails (this section is their source;
-  `triage` cites it): assign **only on a clear match**, default to **unmilestoned**, and **never
-  force-fit** — a wrong milestone pollutes that milestone's burndown worse than no milestone
-  does. Assign to an **existing open** milestone only; **never create** one. Preserve the
-  freeze-by-absence signal: a deliberately-unmilestoned surface stays unmilestoned.
+- **`triage`** **homes** every issue it triages: an **existing open** arc/campaign milestone, or
+  one of the two standing-lane labels, or a kill (ADR 0202/0208 — `triage`'s "Assign a home" step
+  owns the procedure and cites this section). The guardrails are unchanged in kind: keep the match
+  honest (a wrong milestone pollutes that burndown worse than the issue's absence from it), assign
+  to an **existing open** milestone only, and **never create** one. What changed is the fallback —
+  "leave it unmilestoned" is no longer an outcome; a standing-lane label or a kill is.
 - **`plan-epic`** **inherits the parent epic's milestone** onto each child it creates (if the
   epic has one). This is mechanical and high-value — it keeps a campaign's burndown complete by
   construction, since a campaign milestone on an epic can only be "done" when its children carry
@@ -452,8 +461,8 @@ the same probe against the same well-known path, and both must treat **absent �
 
 The probe is the **only** gate on every cycle-step: a step never assumes the doc exists, never
 hard-codes phoenix's policy, and never fails because the doc is missing. Absence is a
-first-class, correct state (exactly as a missing `milestone` is in §Milestone), not a defect to
-repair.
+first-class, correct state — a repo with no cycle is a repo the cycle steps no-op on — not a
+defect to repair.
 
 ### 2. The per-child `**Containment:**` marker
 

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -574,10 +574,10 @@ but unlike `type:*`/`p*`/`status:planned` it is **conditional and inherited, not
 as planner**. A child **inherits the parent epic's milestone when the epic has one**, so a
 campaign milestone's burndown is **complete by construction**: if a "Search" epic is in the
 "Search" milestone, every child it spawns belongs to "Search" too, and the milestone can
-actually reach 100%. The milestone is the **one optional intake dimension** — read its
+actually reach 100%. The milestone is the **fourth intake dimension** — read its
 definition and the REST surface from the formats contract's milestone section
-([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), *Milestone — the one
-optional intake dimension*); this is the inherit-logic that section says lives here and cites it.
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), *Milestone — the fourth
+intake dimension*); this is the inherit-logic that section says lives here and cites it.
 
 Read the epic's milestone once, and **only if it has one** PATCH each created child onto it:
 

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -594,34 +594,14 @@ gets `p0` on purpose, so it stops competing on equal footing with self-healing w
 Under-calling it is the failure mode there, not over-calling it. The homing bound is what
 keeps the bucket honest — `p0` is cheap to *mint* and impossible to leave *homeless*.
 
-### Apply the labels (triaged path)
-
-The canonical `type:*` / `p*` / `status:*` label set is defined by the label
-bootstrap / formats contract ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)) —
-triage *applies* labels from that existing set, and must never silently auto-mint an
-off-spec label via `POST .../labels`.
-
-A triaged issue carries the one `type:*`, one `p*`, and `status:triaged`, and leaves the
-queue (its `status:needs-triage` removed). Apply the whole transition with the `Tracker`
-verb — the classification is the parameter, the label plumbing is the verb's:
-
-```bash
-pipeline-cli tracker apply-triage <N> --type <type> --p <priority>
-```
-
-The verb adds the `type:` / priority / `status:triaged` labels and drops the queue label
-in one envelope (ADR 0190; `packages/pipeline-cli/src/tools/tracker/`). Dropping the queue
-label is idempotent: a `404 "Label does not exist"` when the issue never carried
-`status:needs-triage` (a pre-bootstrap issue predating the label) is tolerated, since the
-goal — issue out of the queue — is met either way. Pass `--status <stage>` to target a
-different lifecycle stage (e.g. `needs-info`); it defaults to `triaged`. Don't hand-roll
-the REST label calls — that inline envelope is exactly what the adoption lint (#3254) flags.
-
-`status:triaged` is an explicit signature only *you* apply — it tells write-code the
-issue was actually reviewed. Never let a type label alone stand in for it; a
-hand-slapped `type:*` with no triaged status must not look pickable.
-
 ### Assign a home — milestone, standing lane, or kill (required)
+
+**Home the issue BEFORE you stamp `status:triaged`** ([Apply the labels](#apply-the-labels-triaged-path)
+comes next, deliberately). The `homing-guard` workflow fires on the `issues` **label** event, so
+stamping first opens a real window in which the issue is triaged-but-un-homed and the guard reds
+on the *happy path* — and a guard that reds on correct triage is one people learn to ignore.
+Assigning the home first closes that window: by the time `status:triaged` lands, the home is
+already there.
 
 **Every issue you mark `status:triaged` leaves with a home.** This is no longer the optional
 "assign a milestone on a clear match" step: under ADR
@@ -688,19 +668,47 @@ it reads as un-triaged. The *signal* isn't retired, it just became greppable: th
 standing-lane labels **are** freeze-by-absence made legible. Untouched: 0072 §1–§3 (what a
 milestone encodes, the two kinds, never create one).
 
+This step is still **out of scope** for: creating milestones, the inherit logic (that is
+`plan-epic`'s job for an epic's children), and pick-order (`write-code` consumes milestone,
+it doesn't assign it).
+
+### Apply the labels (triaged path)
+
+The canonical `type:*` / `p*` / `status:*` label set is defined by the label
+bootstrap / formats contract ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)) —
+triage *applies* labels from that existing set, and must never silently auto-mint an
+off-spec label via `POST .../labels`.
+
+A triaged issue carries the one `type:*`, one `p*`, and `status:triaged`, and leaves the
+queue (its `status:needs-triage` removed). Apply the whole transition with the `Tracker`
+verb — the classification is the parameter, the label plumbing is the verb's:
+
+```bash
+pipeline-cli tracker apply-triage <N> --type <type> --p <priority>
+```
+
+The verb adds the `type:` / priority / `status:triaged` labels and drops the queue label
+in one envelope (ADR 0190; `packages/pipeline-cli/src/tools/tracker/`). Dropping the queue
+label is idempotent: a `404 "Label does not exist"` when the issue never carried
+`status:needs-triage` (a pre-bootstrap issue predating the label) is tolerated, since the
+goal — issue out of the queue — is met either way. Pass `--status <stage>` to target a
+different lifecycle stage (e.g. `needs-info`); it defaults to `triaged`. Don't hand-roll
+the REST label calls — that inline envelope is exactly what the adoption lint (#3254) flags.
+
+`status:triaged` is an explicit signature only *you* apply — it tells write-code the
+issue was actually reviewed. Never let a type label alone stand in for it; a
+hand-slapped `type:*` with no triaged status must not look pickable.
+
 **The guard, not vigilance.** `pipeline-cli homing-guard check` reds on any open
 `status:triaged` issue carrying neither a milestone nor a standing-lane label, and fails
-closed on zero scope (ADR 0092). Run it on the issue you just triaged to confirm the outcome
-landed — the invariant is enforced at this seam, not re-swept by hand later:
+closed on zero scope (ADR 0092). Run it *after* the stamp — the home is already assigned, so
+this confirms the pair landed rather than racing it; the invariant is enforced at this seam,
+not re-swept by hand later:
 
 ```bash
 pipeline-cli homing-guard check --issue <N>   # the issue you just triaged
 pipeline-cli homing-guard check               # the whole open triaged backlog
 ```
-
-This step is still **out of scope** for: creating milestones, the inherit logic (that is
-`plan-epic`'s job for an epic's children), and pick-order (`write-code` consumes milestone,
-it doesn't assign it).
 
 ### Close not-planned (kill, agent issues only)
 

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -11,19 +11,25 @@ single, actionable, correctly-typed, prioritized unit that a `write-code` agent 
 pick up cold and trust — or to close it with an audit trail if it can't be salvaged.
 
 You have **full rewrite authority**. Severity and priority are *your* call, not the
-reporter's. Splitting a bundle is in your mandate. But you are **salvage-first,
-kill-last**: enrich before you close, and never close a human's issue at all.
+reporter's. Splitting a bundle is in your mandate. But you are **salvage-first**: enrich
+an unclear issue before you judge it, and never close a human's issue at all.
+
+You are also where the **forward-motion question** binds. Every issue is priced against
+"what does this move forward?", and every triaged issue leaves with a **home** — an
+arc/campaign milestone, or a standing lane, or a kill (ADR 0202, Step 6). That is the
+doctrine's enforcement seam: teeth at intake, not in a later hand-run sweep.
 
 ## The mandate, per issue
 
 For each `status:needs-triage` issue, you produce exactly one of three outcomes:
 
-1. **Triaged** — classified, enriched, prioritized, labeled `status:triaged`. The
-   normal path. (A bundle is split first; each resulting unit is triaged.)
+1. **Triaged** — classified, enriched, prioritized, **homed**, labeled `status:triaged`.
+   The normal path. (A bundle is split first; each resulting unit is triaged.)
 2. **Needs-info** — a human-filed issue you can't act on as-is. Labeled
    `status:needs-info` with a comment asking specific questions. **Never closed.**
-3. **Closed not-planned** — an unsalvageable *agent*-filed issue. Closed with a
-   reason comment and `closed-by-triage`. Last resort, never for human issues.
+3. **Closed not-planned** — an *agent*-filed issue that is unsalvageable, **or that
+   doesn't move anything forward** (ADR 0202 — improvement-for-improvement's-sake). Closed
+   with a reason comment and `closed-by-triage`. **Never for human-filed issues.**
 
 ## All GitHub ops via `gh api` REST — never GraphQL
 
@@ -527,7 +533,33 @@ comment there rather than file anew.
 
 ---
 
-## Step 6 — Prioritize, label, and close out
+## Step 6 — Price it, prioritize, home it, and close out
+
+### Ask the forward-motion question first
+
+Before you price or home anything, ask what ADR
+[0202](https://github.com/kamp-us/phoenix/blob/main/.decisions/0202-forward-motion-doctrine-crewops.md)
+makes the pricing question for all work: **what does this move forward?** The founder's
+litmus test, verbatim:
+
+> if the founder never learned this ticket existed, would anything visibly change? If no,
+> it does not get a home by default.
+
+Apply it as written — it is a *default*, not a kill switch: a "no" means the issue does not
+get a milestone home for free, so it must then earn one of the other two outcomes below.
+Answer the question honestly rather than looking for a reason to keep the issue: shipped
+user value and work that raises ship-rate move us forward; speculative hardening, a
+no-behavior-change refactor, prose polish, and decision-meta about hypotheticals usually
+don't.
+
+The answer routes to exactly one of three outcomes, and **every triaged issue leaves with
+one of them** — home, exempt, or kill:
+
+| Answer | Outcome | Where |
+|---|---|---|
+| It moves an active arc/campaign forward | **Home** it in that milestone | [Assign a home](#assign-a-home--milestone-standing-lane-or-kill-required) |
+| It's a standing lane — fog, or pipeline hardening | **Exempt** it with the lane's label | same section |
+| Nothing visibly changes if it never existed | **Kill** it (agent-filed only) | [Close not-planned](#close-not-planned-kill-agent-issues-only) |
 
 ### Assign a priority
 
@@ -549,14 +581,19 @@ apply.
 
 | Priority | Use when… |
 |---|---|
-| **`p0`** | **Fire only.** Drop-everything: actively breaking something people rely on, blocking other work, a data-loss or security risk, or a release gate. If it's not a genuine emergency, it's not p0 — reserve it so the bucket stays meaningful. |
+| **`p0`** | **Ship-work and fires — and it is never homeless.** Mint `p0` **freely** for work that moves us forward: shipped user/revenue value, or work that directly raises ship-rate (ADR 0202 §1). Fires still qualify — actively breaking something people rely on, a data-loss or security risk, a release gate. The one hard bound is homing: **a `p0` belongs to the active arc's documented structure, so an orphan (un-homed) `p0` is invalid** (ADR 0202 §2). If you can't home it below, it isn't `p0`. |
 | **`p1`** | **Serves the active milestone** — the arc pinned by `ROADMAP.md`'s single `active` `## Arcs` row (defined just above). Real, actionable work that belongs to that active arc — you'd pull it next. Milestone-bounded on purpose: p1 is *not* a general "worth doing soon" tier, so a solid issue outside the active arc is **not** p1. If no `## Arcs` row is marked `active`, keep p1 for the small set of things you'd genuinely pick up next; everything else is p2. |
 | **`p2`** | **The default.** Real, actionable work that isn't the current focus — most of the backlog. Also nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure to pull it ahead of the active arc. |
 
 Most of a healthy backlog is `p2`, with a bounded `p1` set tracking the active
-milestone. When unsure between two buckets, pick the lower one — over-escalation erodes
+milestone. When unsure between `p1` and `p2`, pick the lower one — over-escalation erodes
 the signal faster than under-escalation, and an inflated `p1` is exactly what makes the
 backlog unsequenceable.
+
+**`p0` is the deliberate exception to that lean-lower rule** (ADR 0202 §1): homed ship-work
+gets `p0` on purpose, so it stops competing on equal footing with self-healing work.
+Under-calling it is the failure mode there, not over-calling it. The homing bound is what
+keeps the bucket honest — `p0` is cheap to *mint* and impossible to leave *homeless*.
 
 ### Apply the labels (triaged path)
 
@@ -585,67 +622,99 @@ the REST label calls — that inline envelope is exactly what the adoption lint 
 issue was actually reviewed. Never let a type label alone stand in for it; a
 hand-slapped `type:*` with no triaged status must not look pickable.
 
-### Assign a milestone (optional — only on a clear match)
+### Assign a home — milestone, standing lane, or kill (required)
 
-Milestone is the **one optional intake dimension** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md),
-§Milestone). Unlike the three mandatory labels above, **most triaged issues carry no
-milestone, and that is the well-formed default** — absence is the norm, not a defect. So
-this is an *additive* step: it never blocks, re-routes, or re-prioritizes an issue. You
-either find a clear home for it among the existing open milestones, or you leave it
-unmilestoned and move on.
+**Every issue you mark `status:triaged` leaves with a home.** This is no longer the optional
+"assign a milestone on a clear match" step: under ADR
+[0202](https://github.com/kamp-us/phoenix/blob/main/.decisions/0202-forward-motion-doctrine-crewops.md)
+and ADR
+[0208](https://github.com/kamp-us/phoenix/blob/main/.decisions/0208-standing-lane-exemption-from-full-homing.md)
+the open backlog is *milestone counts + the two standing lanes, and nothing outside both* —
+so an un-homed triaged issue is a floater, and floaters are what make the milestone counts
+lie. Take exactly one of the three outcomes below.
 
-**The rules (the contract section is the dimension definition — these are triage's behavior):**
-
-- **Assign only on a clear surface-match; default = unmilestoned.** When in doubt, assign
-  nothing. A *wrong* milestone pollutes a burndown worse than a missing one does — an issue
-  filed in the wrong campaign is harder to spot than one that's simply absent. **Never
-  force-fit.**
-- **Existing open milestones only — triage NEVER creates a milestone.** Read the repo's open
-  milestones and match against *that* set; if nothing clearly fits, assign nothing. Creating
-  or curating the milestone set is a roadmap (human) act, deliberately not autonomous (ADR
-  [0072](https://github.com/kamp-us/phoenix/blob/main/.decisions/0072-milestones-encode-strategic-sequencing.md)
-  §3). Do **not** `POST` a new milestone, ever.
-- **Preserve freeze-by-absence.** A deliberately-unmilestoned surface — a frozen new-product
-  cluster (e.g. kampus-CLI / künye) — stays unmilestoned. A missing milestone there is
-  a *signal* that the work is parked, never data to backfill; do not auto-fill it to make the
-  issue "complete" (contract §Milestone, ADR 0072 §4).
-
-**Surface vs strategic — how hard the match is.** The contract names two milestone kinds, and
-they differ in how much judgment the match takes:
-
-- **Surface milestones** (e.g. Search / Bookmarks / Account / Report) are **mechanical**: key
-  off the **product surface you already determined** reading the issue in Step 1 — a sözlük
-  bug → the sözlük surface milestone. If a surface milestone exists and open for the issue's
-  surface, the match is near-rote.
-- **Strategic milestones** (e.g. Broken core loops / Pipeline hardening / Test & CI) need
-  **judgment** — "is this broken-vs-missing? pipeline-critical?". Attempt these
-  **conservatively**: assign one only when the issue plainly belongs to that campaign, and
-  default to none on any doubt.
-
-Read the open milestones, then assign **only on a clear match**:
+**1. Home it in an existing open arc/campaign milestone.** The home candidates are the rows
+of [`ROADMAP.md`](../../../../ROADMAP.md)'s `## Arcs` and `## Campaigns` tables — the
+founder-voice roadmap that projects each arc/campaign onto a GitHub milestone by number
+(ADR 0072/0078). Read the tables for *what* each home means, and the open-milestone list for
+the numbers you may assign to:
 
 ```bash
-# the existing open milestones — the ONLY legal assignment targets (never create one)
+# the home candidates: the arc/campaign rows and the open milestones they pin to
 gh api "repos/$REPO/milestones?state=open" --jq '.[] | "#\(.number)\t\(.title)"'
-# on a clear match only — one single-field, last-write-wins PATCH (benign, #91)
+# assign — one single-field, last-write-wins PATCH (benign, #91); by NUMBER, never title
 gh api -X PATCH "repos/$REPO/issues/<N>" -f milestone=<n>
-# no clear match → assign nothing; an unmilestoned issue is well-formed (do NOT clear-then-set)
 ```
 
-This step is **out of scope** for: creating milestones, the inherit logic (that is
-`plan-epic`'s job for an epic's children), and the pick-order (`write-code` consumes
-milestone, it doesn't assign it).
+- **Existing open milestones only — triage NEVER creates one.** Match against the set that
+  already exists; creating or curating it is a roadmap (human) act, deliberately not
+  autonomous (ADR 0072 §3). Do **not** `POST` a new milestone, ever. If nothing fits, the
+  answer is one of the other two outcomes below — never a new milestone, and never a
+  force-fit into a wrong one (a wrong home pollutes that burndown worse than the issue's
+  absence from it).
+- **Surface vs strategic — how hard the match is.** *Surface* homes (Search / Bookmarks /
+  Account / Report) are **mechanical**: key off the product surface you already determined in
+  Step 1 — a sözlük bug → the sözlük surface milestone. *Strategic* homes (a campaign like
+  Merge-Gate Reliability) need **judgment**: assign one only when the issue plainly belongs
+  to that campaign.
 
-### Close not-planned (kill, last resort, agent issues only)
+**2. Exempt it with a standing-lane label — exactly two, no third.** A **standing lane** is a
+workstream that is milestone-less *by design, not by neglect* (ADR 0208). There are exactly
+two labels, and nothing else inherits the exemption without a founder ruling:
 
-The third outcome is **rare** — close an issue **only** when it's an *agent-filed* issue
-that is genuinely unsalvageable (a duplicate, an observation the code moved past, a
-non-actionable note, or noise), and **salvage first**. Because it's off the common
-triaged / needs-info path, its full protocol — the duplicate-content-preservation step,
-the auditable reason-comment + `closed-by-triage` + `not_planned` close, and the kill-audit
-query — lives in a contract you `Read` only once you've decided to close:
-[`close-not-planned.md`](./close-not-planned.md). Open it and follow it for any kill (and
-for a Step 3 empty-husk close). **Never close a human-filed issue** (Step 5).
+| Label | What it means |
+|---|---|
+| `wayfinder:backlog` | **Fog** — uncharted work upstream of any arc. It gets homed when it gets charted, not before (ADR [0203](https://github.com/kamp-us/phoenix/blob/main/.decisions/0203-fog-reports-route-to-wayfinder-backlog.md)). |
+| `axis:pipeline-hardening` | The permanent **pipeline & reliability hardening** lane — the factory maintaining itself. It never completes into a milestone. |
+
+Do **not** invent a third exempt class, and do **not** put a milestone *on* an exempt issue —
+that is the same lie in the other direction (ADR 0208, Banned).
+
+> **Parking is bounded to fog — it is not a general escape hatch.** Founder ruling,
+> 2026-07-25 (recorded on PR #3955): *"Parking is only for fog (`wayfinder:backlog`). Kill
+> stays a valid triage verdict everywhere else."* So `wayfinder:backlog` is not a place to
+> file work you'd rather not decide about; if the issue isn't genuinely uncharted fog and
+> isn't the hardening lane, it homes or it dies.
+
+**3. Kill it.** Close-not-planned is a **sanctioned forward-motion verdict**, not a
+last resort (ADR 0202 §3): improvement-for-improvement's-sake that survives triage un-homed
+is exactly what the doctrine bans. Route it to
+[Close not-planned](#close-not-planned-kill-agent-issues-only) below — **agent-filed issues
+only; a human-filed issue is never auto-closed** (Step 5, unchanged).
+
+**Freeze-by-absence moved from an absence to a label.** ADR 0072 §4/§5 — milestone is
+optional, and a deliberately-unmilestoned cluster reads as "parked" — is **amended in part**
+by ADR 0208 for every issue outside the two labels: a bare absence no longer reads as parked,
+it reads as un-triaged. The *signal* isn't retired, it just became greppable: the two
+standing-lane labels **are** freeze-by-absence made legible. Untouched: 0072 §1–§3 (what a
+milestone encodes, the two kinds, never create one).
+
+**The guard, not vigilance.** `pipeline-cli homing-guard check` reds on any open
+`status:triaged` issue carrying neither a milestone nor a standing-lane label, and fails
+closed on zero scope (ADR 0092). Run it on the issue you just triaged to confirm the outcome
+landed — the invariant is enforced at this seam, not re-swept by hand later:
+
+```bash
+pipeline-cli homing-guard check --issue <N>   # the issue you just triaged
+pipeline-cli homing-guard check               # the whole open triaged backlog
+```
+
+This step is still **out of scope** for: creating milestones, the inherit logic (that is
+`plan-epic`'s job for an epic's children), and pick-order (`write-code` consumes milestone,
+it doesn't assign it).
+
+### Close not-planned (kill, agent issues only)
+
+Close an issue when it's an *agent-filed* issue that is genuinely unsalvageable (a duplicate,
+an observation the code moved past, a non-actionable note, or noise) — **or** when the
+forward-motion question came back "nothing would visibly change" and it has no home (ADR
+0202 §3). Salvage first: enrich an issue that is merely unclear before you judge it. Because
+a kill is off the common triaged / needs-info path, its full protocol — the
+duplicate-content-preservation step, the auditable reason-comment + `closed-by-triage` +
+`not_planned` close, and the kill-audit query — lives in a contract you `Read` only once
+you've decided to close: [`close-not-planned.md`](./close-not-planned.md). Open it and follow
+it for any kill (and for a Step 3 empty-husk close). **Never close a human-filed issue**
+(Step 5) — an un-homeable human issue gets `status:needs-info` and a question, not a kill.
 
 ### Release the claim (every outcome)
 
@@ -687,9 +756,9 @@ sweeping:
    it until that sweep releases. Loop until the listing has no issue you can claim — every
    *completed* outcome (triaged / needs-info / closed) removes `status:needs-triage`, so
    that is the termination test.
-5. Report a short ledger back: per issue, the outcome (type+priority+triaged, plus the
-   milestone if one was a clear match / needs-info / closed) in one line each. Don't
-   narrate every REST call — the labels, milestone, and comments on the issues are the
+5. Report a short ledger back: per issue, the outcome (type+priority+triaged **plus its
+   home** — the milestone or the standing-lane label / needs-info / killed) in one line
+   each. Don't narrate every REST call — the labels, milestone, and comments on the issues are the
    durable record. **The ledger you hand back is a shared artifact — hold it to the same
    privacy rule as issue bodies and comments** (the "Repo-relative paths only — never
    machine-local paths" rule in Step 4): cite **repo-relative paths only** and no PII —

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -542,8 +542,7 @@ Before you price or home anything, ask what ADR
 makes the pricing question for all work: **what does this move forward?** The founder's
 litmus test, verbatim:
 
-> if the founder never learned this ticket existed, would anything visibly change? If no,
-> it does not get a home by default.
+> if the founder never learned this ticket existed, would anything visibly change? If no, it does not get a home by default.
 
 Apply it as written — it is a *default*, not a kill switch: a "no" means the issue does not
 get a milestone home for free, so it must then earn one of the other two outcomes below.

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -39,6 +39,7 @@ import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
 import {guardContentProbeCommand} from "./tools/guard-content-probe/command.ts";
+import {homingGuardCommand} from "./tools/homing-guard/command.ts";
 import {intakeComposeCommand} from "./tools/intake-compose/command.ts";
 import {intakeDedupCommand} from "./tools/intake-dedup/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
@@ -216,4 +217,9 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// (schemaVersion, commit == head) before interpreting either, and carries the lookup evidence
 	// (queried SHA, run id, artifact id) so the claim is falsifiable from the verdict comment alone.
 	runEvidenceCommand,
+	// #3939 — the teeth behind the triage rubric's home-or-exempt-or-kill outcome (ADR 0202
+	// forward-motion doctrine, ADR 0208 standing-lane exemption): reds when an issue leaves
+	// triage with neither an arc/campaign milestone nor one of the two standing-lane labels,
+	// so floaters can't regrow at the seam. Fail-closed on zero scope (ADR 0092).
+	homingGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/homing-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/command.ts
@@ -1,0 +1,49 @@
+/**
+ * The `homing-guard` tool — `pipeline-cli homing-guard check [--issue <N>]`.
+ *
+ * The enforcement half of the triage rubric's home-or-exempt-or-kill outcome (#3939, ADR
+ * 0202 forward-motion doctrine + ADR 0208 standing-lane exemption). Reds when an issue
+ * leaves triage with neither an arc/campaign milestone nor one of the two standing-lane
+ * labels — the invariant is enforced at the seam, not re-swept by hand:
+ *
+ *   pipeline-cli homing-guard check              # the whole open status:triaged backlog
+ *   pipeline-cli homing-guard check --issue 123  # one issue (the per-issue seam check)
+ *
+ * The pure decision lives in `homing-guard.ts` (unit-tested); the `gh api` read in
+ * `github.ts`/`gate.ts`. `TriagedIssuesLive` is baked in with `Command.provide(...)` so the
+ * registered command's residual requirement is the Node platform union (the registry seam,
+ * epic #994).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — an un-homed issue, the zero-scope
+ * fail-closed (ADR 0092), and a `gh`/repo failure all exit non-zero, undistinguished.
+ */
+import {Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkHoming} from "./gate.ts";
+import {TriagedIssuesLive} from "./github.ts";
+
+const issueFlag = Flag.integer("issue").pipe(
+	Flag.optional,
+	Flag.withDescription("check one issue instead of the whole open status:triaged backlog"),
+);
+
+const check = Command.make(
+	"check",
+	{issue: issueFlag},
+	Effect.fn(function* ({issue}) {
+		yield* checkHoming(issue).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if a status:triaged issue carries neither a milestone nor a standing-lane label",
+	),
+);
+
+export const homingGuardCommand = Command.make("homing-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: every triaged issue is milestone-homed or standing-lane exempt (ADR 0202/0208, #3939)",
+	),
+	Command.provide(TriagedIssuesLive),
+);

--- a/packages/pipeline-cli/src/tools/homing-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/gate.ts
@@ -1,0 +1,46 @@
+/**
+ * The `homing-guard` gate — the IO seam wiring the pure core to the one fact it judges: the
+ * open `status:triaged` set (read over `gh api` via `TriagedIssues`). Split from `command.ts`
+ * so the wiring is crossable in tests, and kept thin: it reads, delegates the verdict to
+ * `homing-guard.ts`, and fails `CheckFailed` (exit non-zero) on any non-passing verdict —
+ * including the zero-scope fail-closed of ADR 0092.
+ */
+import {Console, Effect, Option} from "effect";
+import * as Schema from "effect/Schema";
+import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
+import {TriagedIssues} from "./github.ts";
+import {judge, renderReport, type Scope} from "./homing-guard.ts";
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+/**
+ * The CI gate: read the triaged set in scope and judge home-or-exempt over it. `issue`
+ * narrows the scan to one issue — the per-issue seam check a triage sweep runs right after
+ * it stamps `status:triaged`, so a red names the issue that just lost its home rather than
+ * the whole backlog. Succeeds only on a passing verdict.
+ */
+export const checkHoming = (
+	issue: Option.Option<number>,
+): Effect.Effect<
+	void,
+	CheckFailed | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
+	TriagedIssues
+> =>
+	Effect.gen(function* () {
+		const triaged = yield* TriagedIssues;
+		const [issues, scope] = yield* Option.match(issue, {
+			onNone: () =>
+				triaged.list().pipe(Effect.map((is) => [is, {_tag: "backlog"} as Scope] as const)),
+			onSome: (n) =>
+				triaged.get(n).pipe(Effect.map((is) => [is, {_tag: "issue", number: n} as Scope] as const)),
+		});
+		const verdict = judge(issues, scope);
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/homing-guard/github.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/github.ts
@@ -1,0 +1,223 @@
+/**
+ * The GitHub boundary for `homing-guard`: the live `TriagedIssues` capability that reads
+ * the open `status:triaged` set over `gh api` REST, so the pure core can judge it. Same
+ * service pattern as `roadmap-guard`'s `Milestones` (epic #994): a `Context.Service` on
+ * `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us org), every infra
+ * failure a typed error in the `E` channel, untrusted REST JSON Schema-decoded at the
+ * boundary into the domain `TriagedIssue` the core resolves over.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {TRIAGED_LABEL, type TriagedIssue} from "./homing-guard.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/homing-guard/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/homing-guard/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/homing-guard/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the same
+ * direct-spawn shape `roadmap-guard`/`checks` use so a non-zero exit + stderr lower into a
+ * typed error rather than a throw. A spawn/IO `PlatformError` (`gh` not on PATH) folds in as
+ * exit `-1`.
+ */
+const runGh = Effect.fn("TriagedIssues.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const json = Effect.fn("TriagedIssues.json")(function* (args: ReadonlyArray<string>) {
+	const raw = yield* runGh(args);
+	return yield* Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults — with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("TriagedIssues.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/homing-guard/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// `--slurp` because bare `--paginate` concatenates one JSON array per page — unparseable as a
+// whole once the triaged set passes 100, the exact break `checks` hit live (#3762). `--slurp`
+// wraps the pages in an array instead, which the page-of-pages decode below flattens.
+const triagedArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/issues`,
+	"-f",
+	"state=open",
+	"-f",
+	`labels=${TRIAGED_LABEL}`,
+	"-f",
+	"per_page=100",
+	"--paginate",
+	"--slurp",
+];
+
+const oneIssueArgs = (repo: string, issue: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${issue}`,
+];
+
+/** A raw issue as the issues endpoint returns it; `pull_request` present ⇒ a PR, filtered out. */
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	labels: Schema.Array(Schema.Struct({name: Schema.String})),
+	milestone: Schema.NullOr(Schema.Struct({number: Schema.Number})),
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+type RawIssue = typeof RawIssue.Type;
+
+const decodePages = Schema.decodeUnknownEffect(Schema.Array(Schema.Array(RawIssue)));
+const decodeIssue = Schema.decodeUnknownEffect(RawIssue);
+
+const toIssue = (raw: RawIssue): TriagedIssue => ({
+	number: raw.number,
+	title: raw.title,
+	milestone: raw.milestone?.number ?? null,
+	labels: raw.labels.map((l) => l.name),
+});
+
+// The label filter is applied AGAIN on the client for the single-issue read, whose endpoint
+// takes no `labels` filter: an issue that is not `status:triaged` is out of scope, and the
+// core reads an empty set in issue scope as exactly that (a pass, not a fail).
+const isTriaged = (issue: TriagedIssue): boolean => issue.labels.includes(TRIAGED_LABEL);
+
+const listTriaged = Effect.fn("TriagedIssues.list")(function* (repo: string) {
+	const pages = yield* decodePages(yield* json(triagedArgs(repo)));
+	return pages
+		.flat()
+		.filter((r) => r.pull_request === undefined)
+		.map(toIssue);
+});
+
+const getTriaged = Effect.fn("TriagedIssues.get")(function* (repo: string, issue: number) {
+	const raw = yield* decodeIssue(yield* json(oneIssueArgs(repo, issue)));
+	if (raw.pull_request !== undefined) return [];
+	const one = toIssue(raw);
+	return isTriaged(one) ? [one] : [];
+});
+
+/**
+ * `TriagedIssues` — the IO shell over `gh api` REST for `homing-guard`. `list` reads the
+ * whole open `status:triaged` set; `get` reads one issue and yields it only if it is
+ * triaged (an empty result the core reads as out-of-scope). Built by `TriagedIssuesLive`,
+ * whose `R` is `ChildProcessSpawner`.
+ */
+export class TriagedIssues extends Context.Service<
+	TriagedIssues,
+	{
+		readonly list: () => Effect.Effect<
+			ReadonlyArray<TriagedIssue>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+		readonly get: (
+			issue: number,
+		) => Effect.Effect<
+			ReadonlyArray<TriagedIssue>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/homing-guard/TriagedIssues") {}
+
+/**
+ * The live `TriagedIssues` layer. The `ChildProcessSpawner` dependency is captured once at
+ * construction and provided into each method body, so the public methods carry `R = never`.
+ * Repo resolution is deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is
+ * side-effect-free, and `RepoResolutionError` lives in the methods' `E` channel.
+ */
+export const TriagedIssuesLive: Layer.Layer<
+	TriagedIssues,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = Layer.effect(TriagedIssues)(
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+		return {
+			list: () => repo.pipe(Effect.flatMap((r) => withSpawner(listTriaged(r)))),
+			get: (issue: number) => repo.pipe(Effect.flatMap((r) => withSpawner(getTriaged(r, issue)))),
+		};
+	}),
+);

--- a/packages/pipeline-cli/src/tools/homing-guard/homing-guard.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/homing-guard.ts
@@ -1,0 +1,180 @@
+/**
+ * `homing-guard` pure core — decide whether every `status:triaged` issue left triage with
+ * a home. The invariant is the triage rubric's home-or-exempt-or-kill outcome (ADR 0202
+ * forward-motion doctrine, ADR 0208 standing-lane exemption): a triaged issue carries an
+ * arc/campaign milestone, or one of exactly two standing-lane labels, or it was killed and
+ * is no longer open. IO-free and total — the `gh api` read lives in `github.ts`/`gate.ts`.
+ *
+ * The guard is the teeth behind the rubric: without it the rubric lands advisory-only and
+ * floaters regrow at the seam, which is the "teeth in a sweep, not at the seam" anti-pattern
+ * ADR 0202 bans (#3939).
+ *
+ * Deliberately NOT enforced here: ADR 0208's inverse ban (a milestone on an exempt lane).
+ * That is a different invariant with a different remediation, and folding it in would red a
+ * backlog for a defect this guard's report cannot explain (#3939 scope).
+ */
+
+/**
+ * The two standing-lane labels, exactly (ADR 0208). A standing lane is milestone-less BY
+ * DESIGN — fog (`wayfinder:backlog`) homes when it gets charted (ADR 0203), pipeline
+ * hardening never completes into a milestone. Extending this set needs a founder ruling,
+ * so it is a frozen literal, never a config surface or a pattern match.
+ */
+export const EXEMPT_LABELS: ReadonlyArray<string> = [
+	"wayfinder:backlog",
+	"axis:pipeline-hardening",
+];
+
+/** The label that puts an issue in scope: the invariant binds at the moment triage stamps it. */
+export const TRIAGED_LABEL = "status:triaged";
+
+/** One open `status:triaged` issue reduced to the two facts the invariant reads. */
+export interface TriagedIssue {
+	readonly number: number;
+	readonly title: string;
+	/** The issue's milestone number, or `null` when it carries none. */
+	readonly milestone: number | null;
+	readonly labels: ReadonlyArray<string>;
+}
+
+/**
+ * What the guard scanned. `backlog` is the whole open `status:triaged` set (the CI/sweep
+ * surface); `issue` is one named issue (the per-issue seam check a triage sweep runs right
+ * after it labels). The two differ only in how an empty scope resolves — see `judge`.
+ */
+export type Scope = {readonly _tag: "backlog"} | {readonly _tag: "issue"; readonly number: number};
+
+/** How one triaged issue resolves against home-or-exempt. */
+export type Disposition = "homed" | "exempt" | "unhomed";
+
+export interface Unhomed {
+	readonly number: number;
+	readonly title: string;
+}
+
+/**
+ * The verdict. A discriminated union so an invalid state is unrepresentable: a pass carries
+ * only counts, the zero-scope fail carries the scope it found empty, and the unhomed fail
+ * carries its non-empty offender list.
+ */
+export type HomingGuardVerdict =
+	| {
+			readonly pass: true;
+			readonly scope: Scope;
+			readonly scanned: number;
+			readonly homed: number;
+			readonly exempt: number;
+	  }
+	/** No triaged issue in scope — fail closed, never a vacuous pass (ADR 0092). */
+	| {
+			readonly pass: false;
+			readonly reason: "zero-scope";
+			readonly scope: Scope;
+	  }
+	| {
+			readonly pass: false;
+			readonly reason: "unhomed";
+			readonly scope: Scope;
+			readonly scanned: number;
+			readonly homed: number;
+			readonly exempt: number;
+			readonly unhomed: ReadonlyArray<Unhomed>;
+	  };
+
+/**
+ * Resolve one issue. A milestone homes it; failing that, either standing-lane label exempts
+ * it. An issue carrying both is `homed` — that combination is ADR 0208's inverse ban, which
+ * this guard does not enforce (see the module docblock).
+ */
+export const disposition = (issue: TriagedIssue): Disposition => {
+	if (issue.milestone !== null) return "homed";
+	return issue.labels.some((l) => EXEMPT_LABELS.includes(l)) ? "exempt" : "unhomed";
+};
+
+/**
+ * Judge the scanned set.
+ *
+ * Zero scope forks on what was scanned. Over the whole **backlog**, an empty triaged set is
+ * indistinguishable from a broken query (a renamed label, a lost token, a bad repo) — the
+ * exact silent-no-op ADR 0092 makes fail closed. Over a single **issue**, empty is the
+ * ordinary answer "that issue is not `status:triaged`", so it passes; the caller filters the
+ * fetched issue by label, so an out-of-scope issue arrives here as an empty set.
+ */
+export const judge = (
+	issues: ReadonlyArray<TriagedIssue>,
+	scope: Scope = {_tag: "backlog"},
+): HomingGuardVerdict => {
+	if (issues.length === 0) {
+		return scope._tag === "backlog"
+			? {pass: false, reason: "zero-scope", scope}
+			: {pass: true, scope, scanned: 0, homed: 0, exempt: 0};
+	}
+
+	const unhomed: Array<Unhomed> = [];
+	let homed = 0;
+	let exempt = 0;
+	for (const issue of issues) {
+		switch (disposition(issue)) {
+			case "homed":
+				homed++;
+				break;
+			case "exempt":
+				exempt++;
+				break;
+			case "unhomed":
+				unhomed.push({number: issue.number, title: issue.title});
+				break;
+		}
+	}
+
+	if (unhomed.length > 0) {
+		return {
+			pass: false,
+			reason: "unhomed",
+			scope,
+			scanned: issues.length,
+			homed,
+			exempt,
+			unhomed,
+		};
+	}
+	return {pass: true, scope, scanned: issues.length, homed, exempt};
+};
+
+const scopeLabel = (scope: Scope): string =>
+	scope._tag === "backlog" ? "the open status:triaged backlog" : `issue #${scope.number}`;
+
+/** The remediation, stated once — the three outcomes the triage rubric allows. */
+const REMEDY =
+	"Each issue above left triage un-homed. Give it one of the three home-or-exempt-or-kill outcomes\n" +
+	"(claude-plugins/kampus-pipeline/skills/triage/SKILL.md, ADR 0202/0208):\n" +
+	"  1. home it in an EXISTING open arc/campaign milestone from ROADMAP.md (triage never creates one);\n" +
+	`  2. label it a standing lane — ${EXEMPT_LABELS.join(" or ")} — when it is milestone-less by design;\n` +
+	"  3. kill it (close not-planned) when it does not move anything forward — agent-filed issues only,\n" +
+	"     a human-filed issue is never auto-closed.";
+
+/** Render the report for a verdict (ADR 0092 §1 — "emit what you scanned"). */
+export const renderReport = (verdict: HomingGuardVerdict): string => {
+	if (verdict.pass) {
+		if (verdict.scanned === 0) {
+			return `homing-guard: ${scopeLabel(verdict.scope)} is not status:triaged — out of scope, nothing to check.`;
+		}
+		return (
+			`homing-guard: ${scopeLabel(verdict.scope)} is fully homed — scanned ${verdict.scanned} triaged issue(s): ` +
+			`${verdict.homed} milestone-homed, ${verdict.exempt} standing-lane exempt, 0 un-homed.`
+		);
+	}
+	if (verdict.reason === "zero-scope") {
+		return (
+			`homing-guard: scanned ${scopeLabel(verdict.scope)} and found ZERO status:triaged issues — ` +
+			"fail-closed (ADR 0092). An empty triaged set is indistinguishable from a broken read " +
+			"(renamed label, missing token, wrong repo), and a vacuous pass would hide every floater."
+		);
+	}
+	const lines = verdict.unhomed.map((i) => `  #${i.number} ${i.title}`);
+	return (
+		`homing-guard: ${verdict.unhomed.length} of ${verdict.scanned} triaged issue(s) in ${scopeLabel(verdict.scope)} ` +
+		`left triage with neither a milestone nor a standing-lane label ` +
+		`(${verdict.homed} homed, ${verdict.exempt} exempt):\n${lines.join("\n")}\n\n${REMEDY}`
+	);
+};

--- a/packages/pipeline-cli/src/tools/homing-guard/homing-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/homing-guard.unit.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure-core tests for `homing-guard` (#3939): the home-or-exempt disposition, the verdict
+ * over a scanned set, the two zero-scope forks (backlog fails closed per ADR 0092, a single
+ * non-triaged issue passes as out-of-scope), and the report. No IO — the `gh api` seam is
+ * crossed in `gate.ts`/`github.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	disposition,
+	EXEMPT_LABELS,
+	judge,
+	renderReport,
+	type Scope,
+	type TriagedIssue,
+} from "./homing-guard.ts";
+
+const issue = (
+	number: number,
+	milestone: number | null,
+	labels: ReadonlyArray<string> = [],
+): TriagedIssue => ({
+	number,
+	title: `issue ${number}`,
+	milestone,
+	labels: ["status:triaged", ...labels],
+});
+
+const BACKLOG: Scope = {_tag: "backlog"};
+
+describe("EXEMPT_LABELS", () => {
+	it("is EXACTLY the two ADR-0208 standing lanes — a third needs a founder ruling", () => {
+		expect([...EXEMPT_LABELS]).toEqual(["wayfinder:backlog", "axis:pipeline-hardening"]);
+	});
+});
+
+describe("disposition", () => {
+	it("a milestone homes the issue", () => {
+		expect(disposition(issue(1, 17))).toBe("homed");
+	});
+
+	it.each([...EXEMPT_LABELS])("%s exempts a milestone-less issue", (label) => {
+		expect(disposition(issue(1, null, [label]))).toBe("exempt");
+	});
+
+	it("no milestone and no standing-lane label is un-homed", () => {
+		expect(disposition(issue(1, null, ["type:chore", "p2"]))).toBe("unhomed");
+	});
+
+	it("a look-alike label does NOT exempt (the set is exact, not a prefix match)", () => {
+		expect(disposition(issue(1, null, ["axis:pipeline-hardening-ish", "wayfinder:map"]))).toBe(
+			"unhomed",
+		);
+	});
+
+	it("milestone WINS over a standing-lane label (ADR 0208's inverse ban is out of scope)", () => {
+		expect(disposition(issue(1, 17, ["wayfinder:backlog"]))).toBe("homed");
+	});
+});
+
+describe("judge — pass", () => {
+	it("PASSES when every triaged issue is homed or exempt, counting each kind", () => {
+		const v = judge([
+			issue(1, 17),
+			issue(2, 24),
+			issue(3, null, ["wayfinder:backlog"]),
+			issue(4, null, ["axis:pipeline-hardening"]),
+		]);
+		expect(v.pass).toBe(true);
+		if (v.pass) {
+			expect(v.scanned).toBe(4);
+			expect(v.homed).toBe(2);
+			expect(v.exempt).toBe(2);
+		}
+	});
+});
+
+describe("judge — un-homed", () => {
+	it("FAILS and names every un-homed issue, not just the first", () => {
+		const v = judge([issue(1, 17), issue(2, null), issue(3, null, ["p0"])]);
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "unhomed") {
+			expect(v.unhomed.map((u) => u.number)).toEqual([2, 3]);
+			expect(v.scanned).toBe(3);
+			expect(v.homed).toBe(1);
+			expect(v.exempt).toBe(0);
+		}
+	});
+
+	it("FAILS a single-issue scan of an un-homed issue", () => {
+		const v = judge([issue(9, null)], {_tag: "issue", number: 9});
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "unhomed") {
+			expect(v.unhomed).toEqual([{number: 9, title: "issue 9"}]);
+		}
+	});
+});
+
+describe("judge — zero scope (ADR 0092)", () => {
+	it("FAILS CLOSED on an empty BACKLOG scan — a vacuous pass would hide every floater", () => {
+		const v = judge([], BACKLOG);
+		expect(v.pass).toBe(false);
+		if (!v.pass) expect(v.reason).toBe("zero-scope");
+	});
+
+	it("defaults to backlog scope, so a bare empty scan still fails closed", () => {
+		const v = judge([]);
+		expect(v.pass).toBe(false);
+	});
+
+	it("PASSES an empty SINGLE-ISSUE scan — that issue is simply not status:triaged", () => {
+		const v = judge([], {_tag: "issue", number: 9});
+		expect(v.pass).toBe(true);
+		if (v.pass) expect(v.scanned).toBe(0);
+	});
+});
+
+describe("renderReport", () => {
+	it("emits what it scanned on a pass (ADR 0092 §1)", () => {
+		const report = renderReport(judge([issue(1, 17), issue(2, null, ["wayfinder:backlog"])]));
+		expect(report).toContain("scanned 2 triaged issue(s)");
+		expect(report).toContain("1 milestone-homed");
+		expect(report).toContain("1 standing-lane exempt");
+	});
+
+	it("names the out-of-scope issue on an empty single-issue scan", () => {
+		const report = renderReport(judge([], {_tag: "issue", number: 9}));
+		expect(report).toContain("issue #9 is not status:triaged");
+	});
+
+	it("explains the zero-scope refusal rather than just failing", () => {
+		const report = renderReport(judge([], BACKLOG));
+		expect(report).toContain("ZERO status:triaged issues");
+		expect(report).toContain("ADR 0092");
+	});
+
+	it("lists each un-homed issue and the three remediation outcomes", () => {
+		const report = renderReport(judge([issue(1, 17), issue(2, null)]));
+		expect(report).toContain("#2 issue 2");
+		expect(report).not.toContain("#1 issue 1");
+		expect(report).toContain("home it in an EXISTING open arc/campaign milestone");
+		expect(report).toContain("wayfinder:backlog or axis:pipeline-hardening");
+		expect(report).toContain("kill it (close not-planned)");
+	});
+});


### PR DESCRIPTION
Triage now asks one question of every issue before it lets it through: what does this move forward? An issue that clears triage leaves with a home — a real arc/campaign milestone, or one of exactly two standing-lane labels, or it gets closed. A new fail-closed guard enforces that at the seam, so un-homed issues can't quietly pile up again and make the milestone counts lie.

This is the implementation of ADR 0202 (forward-motion doctrine / CrewOps) and ADR 0208 (standing-lane exemption), which were law but had no teeth in the rubric.

## What changed

**The rubric** — `claude-plugins/kampus-pipeline/skills/triage/SKILL.md`

- Step 6 opens with the forward-motion question and carries the founder's litmus test **verbatim** (2026-07-25 ruling on this issue): *"if the founder never learned this ticket existed, would anything visibly change? If no, it does not get a home by default."*
- "Assign a milestone (optional — only on a clear match)" becomes **"Assign a home — milestone, standing lane, or kill (required)"**. Home candidates are read from `ROADMAP.md`'s `## Arcs` / `## Campaigns` tables, assigned only to **existing open** milestones (triage still never creates one, ADR 0072 §3).
- The exempt set is exactly the two ADR 0208 standing lanes — `wayfinder:backlog` (fog) and `axis:pipeline-hardening`. **Parking stays bounded to fog** per the founder ruling recorded on #3955 (*"Parking is only for fog (`wayfinder:backlog`). Kill stays a valid triage verdict everywhere else."*) — the rubric names that ruling and does not reintroduce parking as a general escape hatch.
- Kill is restated as a **sanctioned forward-motion verdict**, not a last resort. The standing invariant is untouched: agent-filed only, a human-filed issue is never auto-closed.
- `p0` encodes ADR 0202: **freely minted for arc-homed ship-work / ship-rate work; an orphan (un-homed) p0 is invalid.**
- Freeze-by-absence is restated as label-carried rather than absence-carried (ADR 0208 amends ADR 0072 §4/§5 in part). `gh-issue-intake-formats.md` §Milestone follows so the contract the rubric cites doesn't contradict it; the dimension definition, the two kinds, never-create, the REST surface, and the read side are unchanged.

**The guard** — `packages/pipeline-cli/src/tools/homing-guard/`

- `pipeline-cli homing-guard check [--issue N]` reds on any open `status:triaged` issue carrying neither a milestone nor a standing-lane label. Pure core + unit tests; the `gh api` read (REST only) is the IO shell, same shape as `roadmap-guard`.
- **Fail-closed on zero scope** (ADR 0092): an empty backlog scan is indistinguishable from a broken read, so it refuses rather than passing vacuously. A single-issue scan of a non-triaged issue is the ordinary out-of-scope pass.
- `.github/workflows/homing-guard.yml` wires it to the labelling seam (`issues: labeled/unlabeled/milestoned/demilestoned`, scoped to that issue) plus a weekly backstop that files a `status:needs-triage` issue on drift. **Deliberately no `pull_request` trigger** — homing is backlog state, not diff state, so a PR gate would block unrelated PRs on floaters they didn't create.

Live run at head: 156 triaged issues scanned, 140 homed, 13 standing-lane exempt, 3 un-homed (#4026, #3949, #3894) — the guard reds, as it should, and names them.

## Ship-path

Both surfaces are §CP by path against the live `CONTROL_PLANE_RE` (`pipeline-cli control-plane-paths`): `claude-plugins/kampus-pipeline/skills/triage/`, `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, `packages/pipeline-cli/`, `.github/`. This PR **banks reviewed-ready for control-plane approval before enqueue** — no auto-ship on green.

Sequencing: PR #3896 / ADR 0208 (the exempt-label law this rubric cites) is **merged**, so the dependency is satisfied. Two closing keywords are deliberate per this issue's acceptance criteria — #3852 is the doctrine's scope-holder that ADR 0202 left open for exactly this rubric change.

Closes #3852
Closes #3939
