### PR TITLE
feat(control-plane): §CP covers the root marketplace manifest (.claude-plugin/) (#3933)

### DIFF
--- a/.decisions/0212-marketplace-manifest-is-control-plane.md
+++ b/.decisions/0212-marketplace-manifest-is-control-plane.md
@@ -97,10 +97,16 @@ this decision from silently reversing that one.
 - **Two sibling gaps stay open, deliberately, and are not closed here** — closing them by widening
   an anchor without a ruling is the exact anti-pattern #981 guards:
   - `claude-plugins/kampus-pipeline/.claude-plugin/plugin.json` — the pipeline plugin's own
-    manifest, which declares the components it ships. Same shape as this gap, different path; it
-    needs its own ruling because any branch reaching it also reaches `pipeline-crew`'s.
+    manifest, which declares the components it ships. Same shape as this gap, different path. It is
+    deferred for **scope**, not because it is unreachable: a fully-qualified branch
+    (`^claude-plugins/kampus-pipeline/\.claude-plugin/`) would reach that manifest alone and
+    nothing under `pipeline-crew`, so closing the gap is a scoping decision, not a technical
+    problem. #3933 asks exactly one question, and widening past the ruling being sought is the
+    anti-pattern #981 guards. Tracked at #4056.
   - `claude-plugins/<plugin>/**` for any plugin other than `kampus-pipeline` — a whole new plugin
-    directory matches nothing today (raised on #3933).
+    directory matches nothing today (raised on #3933). Unlike the sibling above, this one does
+    re-open the #3765 ruling, since it asks whether a third-party plugin corpus is control plane.
+    Tracked at #4056.
   - The same shape is on the record for `lefthook.yml` hook-wiring config (#3402 / #3643).
 - This ADR governs *who merges*, not *which gate verifies*: routing is a separate axis and is
   untouched.

--- a/.decisions/0212-marketplace-manifest-is-control-plane.md
+++ b/.decisions/0212-marketplace-manifest-is-control-plane.md
@@ -1,0 +1,106 @@
+---
+id: 0212
+title: the root marketplace manifest (.claude-plugin/) is §CP — the file governing control-plane delivery is itself control plane
+status: accepted
+date: 2026-07-25
+tags: [pipeline, control-plane, ship-it, marketplace, plugin, classifier]
+---
+
+# 0212 — the root marketplace manifest is control-plane
+
+## Context
+
+The control-plane boundary (ADR [0053](0053-control-plane-boundary.md), enforced at GitHub per
+ADR [0071](0071-enforce-control-plane-at-github.md), hard-gated per ADR
+[0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)) marks the surfaces
+where an autonomous green-then-ship merge could compromise the pipeline's own guards. The concrete
+boundary is the single-source path regex in
+[`packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts`](../packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts),
+its byte-synced `CONTROL_PLANE_RE=` copy in
+[`gh-issue-intake-formats.md`](../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md),
+and `.github/CODEOWNERS`.
+
+`.claude-plugin/marketplace.json` is the manifest declaring what the `kampus` marketplace serves —
+including `kampus-pipeline`, the plugin that ships the gate-critical skills (`ship-it`,
+`review-code`, `review-doc`, `review-skill`, `review-plan`, `review-trivial`, `triage`,
+`write-code`, `plan-epic`, `release`) and the pipeline agent definitions. Each entry names a
+`source` tree; that field is not decorative — `validate-gate-path-drift.sh` Invariant 2 resolves
+the `.claude/skills` symlink *against* it, precisely because "both express the same plugin root;
+divergence means the harness loads skills from a different tree than the one the marketplace
+advertises."
+
+**The file was outside §CP on both enforcement surfaces**, verified against the live boundary:
+
+- **`CONTROL_PLANE_RE`** — the relevant branch is `^(\.claude|\.github)/`, which requires a
+  literal `/` immediately after `.claude`. The character after `.claude` in `.claude-plugin/` is a
+  **hyphen**, so the branch never matched, and no other branch covers it (the `claude-plugins`
+  branches are all scoped under `claude-plugins/kampus-pipeline/`). Re-checked mechanically
+  against the live regex: `.claude/settings.json` matches, `.claude-plugin/marketplace.json` does
+  not.
+- **`.github/CODEOWNERS`** — the row is `/.claude/` (trailing slash); no `.claude-plugin` row, so
+  `require_code_owner_review` did not bind either. (The drift gate agreed with itself: with no §CP
+  branch there was no path for `codeowners-cp` to demand a row for.)
+
+The consequence, observed live on PR #3919: a PR that registers a plugin in the marketplace
+manifest classified as non-§CP with zero path matches and would auto-ship on green, while a
+one-line docstring change under `packages/pipeline-cli/**` requires a human control-plane
+approver. The delivery channel for the gates was less protected than a comment inside them.
+
+ADR [0187](0187-crew-mcp-is-not-control-plane.md) fixed the §CP discriminator as an
+**enforcement-surface test**: a path is §CP if merging it unreviewed could weaken the pipeline's
+enforcement of its own rules — not because it is merely pipeline-adjacent. The marketplace
+manifest passes that test one step removed but decisively: it does not *contain* a guard, it
+**decides which tree the guards are loaded from**. An unreviewed edit to `source` redirects
+delivery of the entire enforcement corpus, which is strictly stronger than weakening any single
+guard inside it.
+
+Tracked as #3933 (filed `type:decision` — the deliverable is a recorded ruling either way). The
+issue's anti-self-authorization criterion (#981) — "the regex is not widened ahead of the ruling" —
+is satisfied **structurally**, not by promise: the PR carrying this ADR edits `CONTROL_PLANE_RE`'s
+single source, `packages/pipeline-cli/**`, and `.github/CODEOWNERS`, so it is §CP under the
+**current** boundary and cannot merge without a non-author control-plane approval. That approval
+*is* the ruling; the widening lands only with it.
+
+## Decision
+
+`.claude-plugin/**` — the repo-root marketplace manifest directory — is **§CP**. Both mechanisms
+cover it:
+
+- **`CONTROL_PLANE_RE`** gains its **own** anchored branch, `^\.claude-plugin/`. It cannot be
+  folded into `^(\.claude|\.github)/`: that branch's `/` is what excluded the hyphenated dir in
+  the first place. Widening it to a bare `^\.claude` prefix is **rejected** — that would capture
+  both directories implicitly and leave the boundary illegible.
+- **`.github/CODEOWNERS`** gains `/.claude-plugin/ @kamp-us/control-plane`, the merge-time teeth.
+  The existing `/.claude/` row does **not** cover it (a directory pattern covers only paths under
+  itself), so the row is load-bearing, not decorative.
+
+The branch is **directory-scoped, not `marketplace.json`-scoped**. `.claude-plugin/` is the
+manifest directory by the marketplace convention; every file in it is plugin-delivery metadata by
+construction, and a file-anchored branch would be routed around by a rename or a companion
+manifest. Today the directory holds exactly one tracked file, so the widening admits exactly one
+path: `.claude-plugin/marketplace.json`.
+
+The branch is **root-anchored**, deliberately. An un-anchored form (`(^|/)\.claude-plugin/`) would
+also capture every nested plugin's `plugin.json`, including `claude-plugins/pipeline-crew/`, whose
+corpus a live founder ruling re-affirmed 2026-07-24 keeps **out** of §CP (#3765). Anchoring keeps
+this decision from silently reversing that one.
+
+## Consequences
+
+- A PR touching `.claude-plugin/**` no longer auto-ships on green; it banks for a human §CP merge,
+  where a second human confirms it does not redirect what the control plane delivers.
+- **Exactly one path newly becomes §CP**: `.claude-plugin/marketplace.json`. Nothing else moves —
+  every prior branch is unchanged, and the classifier tests assert the known non-matches still do
+  not match (`packages/pipeline-crew-mcp/**` per ADR 0187, `.patterns/**`, `.decisions/**`,
+  `.glossary/**`, `ROADMAP.md`, `turbo.json`, and the nested `claude-plugins/*/.claude-plugin/`
+  manifests).
+- **Two sibling gaps stay open, deliberately, and are not closed here** — closing them by widening
+  an anchor without a ruling is the exact anti-pattern #981 guards:
+  - `claude-plugins/kampus-pipeline/.claude-plugin/plugin.json` — the pipeline plugin's own
+    manifest, which declares the components it ships. Same shape as this gap, different path; it
+    needs its own ruling because any branch reaching it also reaches `pipeline-crew`'s.
+  - `claude-plugins/<plugin>/**` for any plugin other than `kampus-pipeline` — a whole new plugin
+    directory matches nothing today (raised on #3933).
+  - The same shape is on the record for `lefthook.yml` hook-wiring config (#3402 / #3643).
+- This ADR governs *who merges*, not *which gate verifies*: routing is a separate axis and is
+  untouched.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,11 @@
 # ADR 0135 and ADR 0071 §3).
 /.claude/                       @kamp-us/control-plane
 /.github/                       @kamp-us/control-plane
+# Control-plane: the root marketplace manifest — it declares what the `kampus` marketplace
+# serves and each plugin's `source` tree, so it governs DELIVERY of the control-plane plugin.
+# The §CP `^\.claude-plugin/` branch; root-anchored, so nested plugin.json files are NOT
+# owned here (ADR 0212, #3933).
+/.claude-plugin/                @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/ship-it/                    @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/review-code/                @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/review-doc/                 @kamp-us/control-plane

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1346,6 +1346,21 @@ closing the #375 drift class).
 
 - `.claude/**` — the agent control plane (instructions, tools, hooks).
 - `.github/**` — CI enforcement.
+- `.claude-plugin/**` — the **root marketplace manifest** (`marketplace.json`), which declares
+  what the `kampus` marketplace serves and where each plugin's `source` tree is. It governs
+  **delivery of the control plane itself**: the `kampus-pipeline` entry is how the gate-critical
+  skills and the pipeline agents reach a session, and `validate-gate-path-drift.sh` Invariant 2
+  resolves the `.claude/skills` symlink against this file's `source` field. An unreviewed edit
+  here can redirect which tree the gates are loaded from — a self-weakening surface by ADR 0187's
+  enforcement-surface test, even though nothing under it is itself a guard (ADR
+  [0212](https://github.com/kamp-us/phoenix/blob/main/.decisions/0212-marketplace-manifest-is-control-plane.md), #3933).
+  It needs its **own** `^\.claude-plugin/` branch: the `^(\.claude|\.github)/` branch requires a
+  literal `/` after `.claude`, and the next character here is a hyphen, so it never matched.
+
+  **Deliberately OUT — every NESTED `.claude-plugin/` dir** (`claude-plugins/*/.claude-plugin/plugin.json`).
+  The branch is root-anchored: an un-anchored form would also sweep in `claude-plugins/pipeline-crew/`,
+  whose corpus a live founder ruling keeps out of §CP (#3765). `kampus-pipeline`'s own `plugin.json`
+  is a genuine sibling gap — file it, don't widen the anchor by hand (ADR 0212 Consequences).
 - the **gate-critical skills** — the verification/merge machinery plus the shared marker
   contract they all depend on:
   - `claude-plugins/kampus-pipeline/skills/ship-it/**`
@@ -1455,7 +1470,11 @@ since a gate/merge agent's own instructions are a self-weakening surface; the **
 were escaping the boundary; the **lint/GritQL governance config** — `biome.jsonc` and
 `biome-plugins/**` — added by ADR
 [0193](https://github.com/kamp-us/phoenix/blob/main/.decisions/0193-lint-governance-config-is-control-plane.md),
-since an ungated path to weaken a lint rule is a guard-relaxing vector). Everything else — `apps/**`,
+since an ungated path to weaken a lint rule is a guard-relaxing vector; the **root marketplace
+manifest** — `.claude-plugin/**` — added by ADR
+[0212](https://github.com/kamp-us/phoenix/blob/main/.decisions/0212-marketplace-manifest-is-control-plane.md),
+since the file that decides what the control-plane plugin *delivers* is itself control plane).
+Everything else — `apps/**`,
 **non**-guard `packages/**`, `.decisions/**` (**except a guard-touching ADR** — see the content
 clause below), `.patterns/**`, every prose doc `*.md` (the
 §DOC class), and every **non**-gate-critical `skills/**` — is **non-blocking** and
@@ -1485,7 +1504,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\.jsonc$|^biome-plugins/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\.jsonc$|^biome-plugins/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -36,6 +36,7 @@ describe("splitTopLevelBranches", () => {
 		const branches = splitTopLevelBranches(LIVE_RE);
 		expect(branches).toEqual([
 			"(\\.claude|\\.github)/",
+			"\\.claude-plugin/",
 			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/",
 			"claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$",
 			"claude-plugins/kampus-pipeline/agents/",
@@ -55,6 +56,10 @@ describe("expandBranch", () => {
 			{path: ".claude/", kind: "dir"},
 			{path: ".github/", kind: "dir"},
 		]);
+	});
+
+	it("expands the root marketplace-manifest branch as a dir (ADR 0212)", () => {
+		expect(expandBranch("\\.claude-plugin/")).toEqual([{path: ".claude-plugin/", kind: "dir"}]);
 	});
 
 	it("expands the eleven skill dirs", () => {
@@ -121,6 +126,7 @@ describe("cpPaths over the live regex", () => {
 		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
 			".claude/",
 			".github/",
+			".claude-plugin/",
 			"claude-plugins/kampus-pipeline/skills/ship-it/",
 			"claude-plugins/kampus-pipeline/skills/review-code/",
 			"claude-plugins/kampus-pipeline/skills/review-doc/",
@@ -208,6 +214,7 @@ describe("findUncovered — the drift check", () => {
 		const codeowners = [
 			"/.claude/ @usirin",
 			"/.github/ @usirin",
+			"/.claude-plugin/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/ship-it/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
@@ -237,6 +244,7 @@ describe("findUncovered — the drift check", () => {
 		const stale = [
 			"/.claude/ @usirin",
 			"/.github/ @usirin",
+			"/.claude-plugin/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/ship-it/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
@@ -261,6 +269,12 @@ describe("findUncovered — the drift check", () => {
 			"claude-plugins/kampus-pipeline/hooks.json",
 			"packages/pipeline-cli/",
 		]);
+	});
+	it("flags a missing /.claude-plugin/ row — the /.claude/ row does NOT cover it (ADR 0212)", () => {
+		const owned = parseCodeownersPatterns(["/.claude/ @usirin", "/.github/ @usirin"].join("\n"));
+		const marketplace = paths.filter((p) => p.path === ".claude-plugin/");
+		expect(marketplace).toHaveLength(1);
+		expect(findUncovered(marketplace, owned).map((p) => p.path)).toEqual([".claude-plugin/"]);
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -14,6 +14,7 @@ const LIVE_RE = CONTROL_PLANE_RE;
 const FULL_CODEOWNERS = [
 	"/.claude/ @usirin",
 	"/.github/ @usirin",
+	"/.claude-plugin/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/ship-it/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -39,6 +39,23 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("biome-plugins/no-type-assertions.grit")).toBe(true);
 	});
 
+	it("classifies the root marketplace manifest as control-plane (ADR 0212, #3933)", () => {
+		// The file declaring what the `kampus` marketplace serves — including kampus-pipeline's
+		// `source` tree, which validate-gate-path-drift.sh resolves .claude/skills against. It gets
+		// its own branch because `^(\.claude|\.github)/` demands a literal `/` after `.claude` and
+		// the character here is a hyphen.
+		expect(isControlPlane(".claude-plugin/marketplace.json")).toBe(true);
+	});
+
+	it("does NOT over-widen: the marketplace branch is ROOT-anchored (ADR 0212)", () => {
+		// A NESTED plugin manifest stays out — an un-anchored form would sweep in pipeline-crew's
+		// own plugin.json, whose corpus a live founder ruling keeps out of §CP (#3765).
+		expect(isControlPlane("claude-plugins/pipeline-crew/.claude-plugin/plugin.json")).toBe(false);
+		expect(isControlPlane("claude-plugins/kampus-pipeline/.claude-plugin/plugin.json")).toBe(false);
+		// and a look-alike sibling of the root dir is not swallowed either
+		expect(isControlPlane(".claude-plugins/marketplace.json")).toBe(false);
+	});
+
 	it("does NOT classify the four deliberately-OUT skill dirs (operational, not gate-critical)", () => {
 		for (const skill of ["heal-ci", "what-shipped", "doctor", "wayfinder"]) {
 			expect(isControlPlane(`claude-plugins/kampus-pipeline/skills/${skill}/SKILL.md`)).toBe(false);
@@ -65,6 +82,15 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("turbo.json")).toBe(false);
 		expect(isControlPlane("pnpm-workspace.yaml")).toBe(false);
 		expect(isControlPlane("biome.jsonc.bak")).toBe(false);
+		// §CP by PATH is a separate axis from §CP by CONTENT: a `.decisions/**` ADR is §CP only
+		// when the guard-content probe (ADR 0164) matches its prose, never by path. These stay
+		// non-§CP by path — asserted so a boundary widening can't silently capture them.
+		expect(isControlPlane(".decisions/0193-lint-governance-config-is-control-plane.md")).toBe(
+			false,
+		);
+		expect(isControlPlane(".patterns/index.md")).toBe(false);
+		expect(isControlPlane(".glossary/LANGUAGE.md")).toBe(false);
+		expect(isControlPlane("ROADMAP.md")).toBe(false);
 	});
 
 	it("still classifies every PRE-EXISTING §CP path (no branch dropped)", () => {

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -32,6 +32,13 @@
  * test of ADR 0187 — merging it unreviewed CAN weaken a gate. Same class of decision as
  * ADR 0187's enforcement-surface test; recorded in ADR 0193.
  *
+ * The marketplace-manifest clause (`^\.claude-plugin/`) needs its OWN branch because the
+ * `^(\.claude|\.github)/` branch requires a literal `/` after `.claude` — the character after
+ * `.claude` in `.claude-plugin/` is a hyphen, so that branch never matched it. Anchored to the
+ * ROOT dir on purpose: an un-anchored `(^|/)\.claude-plugin/` would also sweep in every nested
+ * plugin's own `plugin.json`, including `claude-plugins/pipeline-crew/`, whose corpus a live
+ * founder ruling deliberately keeps OUT of §CP (#3765). See ADR 0212.
+ *
  * Anti-self-authorization is preserved (#981): the live merge-deciding gates still
  * re-resolve the boundary from the formats doc on `origin/main` at run time, so a
  * boundary-editing PR is classified against MAIN's boundary, not its own edit. This
@@ -39,4 +46,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\\.jsonc$|^biome-plugins/";
+	"^(\\.claude|\\.github)/|^\\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\\.jsonc$|^biome-plugins/";


### PR DESCRIPTION
Fixes #3933

## What this does

Brings the **root marketplace manifest directory `.claude-plugin/`** inside the §CP
control-plane path set, on both enforcement surfaces, and records the ruling as ADR 0212.

`.claude-plugin/marketplace.json` declares what the `kampus` marketplace serves — including
`kampus-pipeline`, the plugin that delivers the gate-critical skills (`ship-it`, `review-*`,
`triage`, `write-code`, `plan-epic`, `release`) and the pipeline agent definitions. Its `source`
field is not cosmetic: `claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh`
Invariant 2 resolves the `.claude/skills` symlink *against it*, precisely because a divergence
means the harness loads skills from a different tree than the marketplace advertises. So the file
governs **delivery of the control plane** while sitting outside §CP.

## Why the regex missed it — verified, not assumed

The §CP branch is `^(\.claude|\.github)/`, which requires a literal `/` immediately after
`.claude`. The character after `.claude` in `.claude-plugin/` is a **hyphen**, so the branch never
matched, and no other branch covers it (every `claude-plugins` branch is scoped under
`claude-plugins/kampus-pipeline/`). Re-checked mechanically against the live regex printed by
`pipeline-cli control-plane-paths`: `.claude/settings.json` matched, `.claude-plugin/marketplace.json`
did not. `.github/CODEOWNERS` has the same shape of miss — its row is `/.claude/` (trailing slash),
which does not cover a sibling directory.

That is exactly the mechanism the issue described; no other cause found.

## How many copies of `CONTROL_PLANE_RE` exist

**Two literal copies, both updated:**

1. `packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts` — the single-source const.
2. The `CONTROL_PLANE_RE='…'` line in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`
   — the one un-importable copy, which the live gates re-resolve from `origin/main` (#981).

Every other consumer (`codeowners-cp`, `trivial-diff`, `control-plane-paths`, the unit fixtures)
**imports** the const rather than re-literaling it, so there is no third copy to drift. Both
byte-sync guards confirm it: `pipeline-cli codeowners-cp check` and `validate-gate-path-drift.sh`
run green (see Verification).

## The change

- **`CONTROL_PLANE_RE`** gains its own branch `^\.claude-plugin/`, inserted after
  `^(\.claude|\.github)/`. It cannot be folded into that branch — the `/` is exactly what excluded
  the hyphenated dir. Widening it to a bare `^\.claude` prefix is deliberately **rejected**: it
  would capture both directories implicitly and leave the boundary illegible.
- **`.github/CODEOWNERS`** gains `/.claude-plugin/ @kamp-us/control-plane` (the merge-time teeth).
- **ADR `.decisions/0212-marketplace-manifest-is-control-plane.md`** records the ruling, the ADR-0187
  enforcement-surface justification, the scope reasoning, and the gaps left open.

### Blast radius — exactly one path newly becomes §CP

`.claude-plugin/` holds exactly one tracked file today, so the widening admits exactly:

- `.claude-plugin/marketplace.json`

The branch is **directory-scoped**, not `marketplace.json`-scoped: `.claude-plugin/` is the
manifest directory by the marketplace convention, every file in it is plugin-delivery metadata by
construction, and a file-anchored branch would be routed around by a rename or a companion
manifest. There is no file in that directory that does *not* govern delivery, so nothing is being
swept in incidentally.

The branch is **root-anchored**, deliberately. An un-anchored form (`(^|/)\.claude-plugin/`) would
also capture every nested plugin manifest, including `claude-plugins/pipeline-crew/.claude-plugin/plugin.json`
— and the `pipeline-crew` corpus is kept out of §CP by a live founder ruling re-affirmed 2026-07-24
(#3765). Anchoring keeps this decision from silently reversing that one.

### Known non-matches, asserted in tests

Verified still **non**-§CP by path after the change (each is a real regression risk for a §CP
widening, so each is now a test assertion):

- `packages/pipeline-crew-mcp/**` (deliberately un-§CP'd by ADR 0187) — pre-existing assertions retained
- `claude-plugins/pipeline-crew/.claude-plugin/plugin.json` and
  `claude-plugins/kampus-pipeline/.claude-plugin/plugin.json` — new
- `.claude-plugins/marketplace.json` (look-alike sibling of the root dir) — new
- `.patterns/**`, `.decisions/**`, `.glossary/**`, `ROADMAP.md` — new
- `turbo.json`, `pnpm-workspace.yaml`, `biome.jsonc.bak`, the four deliberately-OUT skill dirs —
  pre-existing assertions retained

This is a §CP-**by-path** change only. The separate §CP-**by-content** mechanism (the
`GUARD_ADR_RE` guard-content probe over `.decisions/*.md`, ADR 0164) is untouched.

### Deliberately NOT fixed here

Named in ADR 0212's Consequences so they are visible rather than silently absorbed:

- `claude-plugins/kampus-pipeline/.claude-plugin/plugin.json` — the pipeline plugin's *own*
  manifest. Same shape of gap, deferred for **scope, not reachability**: a fully-qualified branch
  (`^claude-plugins/kampus-pipeline/\.claude-plugin/`) would reach that manifest alone and nothing
  under `pipeline-crew`, so closing the gap is a scoping decision rather than a technical problem.
  #3933 asks exactly one question, and widening past the ruling being sought is the anti-pattern
  #981 guards. Tracked at #4056.
- `claude-plugins/<plugin>/**` for any plugin other than `kampus-pipeline` — a whole new plugin
  directory matches nothing today (raised in the second comment on #3933). Unlike the sibling
  above, this one *does* re-open #3765, since it asks whether a third-party plugin corpus is
  control plane. Tracked at #4056.
- **Sibling on the record:** the same shape is already filed for `lefthook.yml` hook-wiring config
  (#3402 / #3643). Not touched here — flagged so triage can see the pattern across all four.

## Self-referential property — read this before merging

**This PR changes what counts as control plane, and it will itself require a control-plane approval
to merge.** It edits `CONTROL_PLANE_RE`'s single source, `packages/pipeline-cli/**`, and
`.github/CODEOWNERS` — all §CP under the **current** boundary — so it classifies §CP without
relying on its own widening.

That is what satisfies the issue's anti-self-authorization criterion (#981) *structurally* rather
than by promise: the boundary is not widened by opening this PR, only by merging it, and the merge
requires a non-author control-plane approval at the current head. **That approval is the founder
ruling this `type:decision` issue asks for.** No agent has ruled here; the ADR is written so that
its landing *is* the ruling.

## Verification

Run in the isolated worktree at head `b054b92b` (rebased onto `main` @ `11d36871`; the repair round
is prose-only — the regex, the CODEOWNERS row, the tests, and the scope are byte-identical to the
reviewed head `3f656dd7`):

- `pipeline-cli control-plane-paths` — prints the new regex; `codeowners-cp check`: `all 23 §CP path(s) covered by .github/CODEOWNERS` (was 22).
- `bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` — OK, 17 checks (const ↔ formats-doc line byte-equal; symlink ↔ marketplace source agree).
- `bash claude-plugins/kampus-pipeline/skills/validate-skills.sh` — OK, 26 skills valid.
- `bash claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh` / `validate-cycle-presence.sh` — OK.
- `vitest run src/tools/control-plane-paths src/tools/codeowners-cp src/tools/trivial-diff` — 71 passed.
- `pnpm --filter @kampus/pipeline-cli typecheck` — clean; `biome check` on the changed sources — clean.

Note on the full `pipeline-cli` suite: it reported 9 failures under full parallel load, all
5-second timeouts in shell-spawning tests (`worktree-sweep/create-worktree.hook.test.ts`,
`guard-content-probe`). Re-running those files on their own passes (26/26) — environmental
contention on this machine, unrelated to this diff and untouched by it.

## Repair round 1 — `review-doc` FAIL addressed

The `review-doc` verdict at `3f656dd7` was **10 PASS / 1 FAIL**; `review-code` (26/0) and
`review-skill` (14/0) passed and are untouched by this round.

The single FAIL: ADR 0212's Consequences (and the mirrored bullet above) deferred the
`claude-plugins/kampus-pipeline/.claude-plugin/plugin.json` gap on the claim that *any branch
reaching it also reaches `pipeline-crew`'s* — which is **false**, as the reviewer verified
mechanically. The deferral itself is correct and stays; only the stated reason is now the honest
one (scope discipline), with the note that a fully-qualified branch *would* reach it. Both gaps
now cite the tracking issue #4056.

The corresponding passage in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` is
already accurate — it speaks of an *un-anchored* form sweeping in `pipeline-crew`, which is true —
and was deliberately left alone.
