### PR TITLE
fix(pipeline-cli): claim release — a completed run gives its own claim up (#3780)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2746,15 +2746,82 @@ so closing it means claiming before any branch, build, or spawn:
   made at **Step 3** using the coder's own `CLAUDE_CODE_SESSION_ID` as the token, before it
   branches or builds. Either way the claim precedes the work.
 
+<a id="release-the-claim-ends-when-its-run-does"></a>
+### Release — the claim ends when its run does (affirmative, never inferred)
+
+A claim is **held for the duration of the work it protects, and given up when that work is
+done**. The owner performs that release itself:
+
+```bash
+pipeline-cli claim release --issue <N>            # retract our own marker; --session <token> to release a delegated claim
+```
+
+**Who calls it, and when.** The run that holds the claim, at its terminus: `write-code` Step 8
+(PR open, progress logged, epic handed off) and the end of repair Step R3 (fix pushed, PR handed
+back to the gate). Nothing else calls it.
+
+**What it does and refuses to do.** It DELETEs only the `CLAIM_RE` markers carrying the caller's
+own token, leaves every other claim standing (and names them), is idempotent (releasing twice
+retracts nothing and succeeds), and fails closed with a non-zero exit when there is no token to
+prove ownership under. It does **not** touch the **assignee**: the coarse availability gate stays
+set while the PR is open, so the Step-1 picker still skips the issue and no second lane picks up
+work already in review. What release frees is the *fine* resolver — so a **directed** re-dispatch
+(a repair, a follow-up round, a stalled lane re-driven) claims the lane cleanly instead of
+resolving `lost` against a marker whose run finished hours ago (#3780).
+
+**Release is affirmative — the claim's end is a recorded fact, not an inference from absence.**
+This is the load-bearing property, and it is what keeps release outside ADR 0115 §5's deferral:
+an owner giving its claim up cannot evict anybody, so none of the eviction risk that deferred
+automatic reclaim applies. The inverse must never be built in its place:
+
+- **Never key a release on age.** A TTL evicts a slow-but-live agent — §5's original hazard,
+  unchanged.
+- **Never key a release on session-id mismatch.** "The claiming session id is not the current
+  session id" does **not** mean the work is done: a live process can rotate its session id
+  mid-run (#4045), after which the marker names a token the still-working agent no longer
+  carries. A rule that evicted on mismatch would evict exactly that live lane. Release is keyed
+  on the token the caller **presents**, so a rotated run releases nothing by accident — and an
+  operator releasing a delegated or pre-rotation claim passes it explicitly with `--session
+  <the token the marker carries>`.
+- **Never treat an unreleased claim as released.** A run that crashed before its terminus leaves
+  its marker standing; that case is the crashed-agent residual below, not something release
+  infers.
+
 ### Staleness / reclaim — owner-defer (ADR 0115 §5)
 
-A claim whose agent crashed mid-run is **sticky until a human clears it** (un-assigns the
-issue / removes the claim, re-opening it to the picker) **unless its claimant is provably
-dead** (the next subsection). Automatic **age/TTL-based** reclaim remains an explicitly
+A claim whose agent **crashed** mid-run — dying before it could
+[release](#release-the-claim-ends-when-its-run-does) — is **sticky until a human clears it**
+(un-assigns the issue / removes the claim, re-opening it to the picker) **unless its claimant is
+provably dead** (the next subsection). Automatic **age/TTL-based** reclaim remains an explicitly
 deferred follow-up — GitHub exposes no TTL primitive, and an age-keyed reclaim risks evicting
 a slow-but-live agent, re-introducing the exact double-implement this design prevents. That
 hazard is about *time*, not *liveness*: a claim superseded on **proven claimant death** cannot
 evict a live agent, which is why supersession is permitted where a TTL is not.
+
+**Surfacing a stale claim — read it, then clear it by hand.** A claim nothing retracted used to
+be invisible; stranded lanes accumulated silently until a dispatch read `lost` and stalled. The
+read-only inventory is the surface:
+
+```bash
+pipeline-cli claim status --issue <N>   # every marker: author, authorization, liveness, and the resolved owner
+```
+
+Read it before concluding a lane is stuck. A row with `liveness: dead` is already superseded and
+needs nothing. A row with `liveness: unknown` is **indeterminate — it stands**, and clearing it is
+a **human's** decision on evidence outside this keyspace (the run's PR landed, the operator knows
+the session is gone), never a rule the pipeline applies for you. Clear it by deleting that claim
+comment and un-assigning the issue.
+
+**The two claim substrates differ, deliberately — don't read one's rule onto the other.** The
+crew tracker's **resource claim** (ADR
+[0191](https://github.com/kamp-us/phoenix/blob/main/.decisions/0191-crew-claim-lifecycle.md),
+`packages/pipeline-crew-mcp/src/tracker/registry-core.ts`) frees on explicit `releaseClaim` **or
+self-reaps** once its holder's presence lease lapses — a stale claim there reads as free. This
+**GitHub-marker claim** has no lease to lapse: it frees on an explicit `claim release`, or on
+proven claimant death, and otherwise **stands**. So the same lane can read free in the tracker and
+held here. That is not a bug to reconcile in passing; the cross-keyspace reconciliation is #3938 /
+epic #3766. Until then, the claim your coder actually consults is this one, and "ADR 0191
+self-reaping" does **not** govern it.
 
 <a id="dead-claimant-supersession-proven-death-only-adr-0191"></a>
 ### Dead-claimant supersession — proven death only (ADR 0191 presence liveness)

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1688,11 +1688,46 @@ A standalone (non-sub-issue) issue has no parent epic — skip this step.
 
 ---
 
-## Step 8 — Hard-stop at PR-open: hand the gate to a separate reviewer (never self-review)
+## Step 8 — Release your claim, then hard-stop: hand the gate to a separate reviewer
 
 This is the **terminus of initial-build mode**, and it is a hard stop. Once the PR is open
-(Step 5), progress is logged (Step 6), and any epic handoff is posted (Step 7), **you are
-done — full stop.** Do **not** continue into the review gate on the PR you just opened:
+(Step 5), progress is logged (Step 6), and any epic handoff is posted (Step 7), do one last
+thing and then stop.
+
+### Release the claim — the last act of the run that held it
+
+The claim you took in Step 3 protected *this* build. The build is over, so give it up:
+
+```bash
+# the last mutation of the run — retract OUR OWN claim marker on the issue we just built.
+# --session carries the token we owned the work under (the orchestrator's delegated token on the
+# orchestrated path), because that is the token the marker itself carries.
+pipeline-cli claim release --issue "<N>" --session "$MY_CLAIM"
+```
+
+**Why this is mandatory, not tidy-up.** A claim that outlives its run never expires, and the
+resolver returns the **earliest** authorized claim — so an unreleased marker owns the issue
+permanently and **every later dispatch on it reads `lost`**: a repair round, a follow-up, a
+stalled lane re-driven. That is not hypothetical — six lanes stalled at once behind claims whose
+work was already complete, five of them unstamped and therefore unsupersedable by liveness
+(#3780). Releasing here is what makes the re-dispatch of an already-worked issue a normal event
+again.
+
+**It frees the resolver, not the lane.** Release retracts the claim comment and **leaves the
+assignee set**, so Step 1's picker still skips the issue while your PR is in review — a
+re-dispatch can claim it, an idle picker cannot pick it up and re-implement it.
+
+**Never route around a claim you cannot release.** Release retracts only markers carrying the
+token you present; it cannot and must not evict another session's claim, whatever that claim's
+age or liveness. If you find yourself wanting to clear someone else's marker, that is a routed
+blocker for the operator (`pipeline-cli claim status --issue <N>` prints the inventory), never
+your call — the contract's
+[§7 Release / Staleness](../gh-issue-intake-formats.md#release-the-claim-ends-when-its-run-does)
+owns both halves.
+
+### Then stop — the gate is a separate reviewer's
+
+**You are done — full stop.** Do **not** continue into the review gate on the PR you just opened:
 
 - **Never run `review-code`/`review-doc`/`review-skill` on your own PR.** The gate is a
   **separate reviewer's** job by design (the split-role firewall in the intro). Running the
@@ -2081,6 +2116,14 @@ you changed (REST, on the same review-comment thread):
 # reply on the inline comment thread you addressed ($CID = the comment id from R2)
 gh api -X POST "repos/$REPO/pulls/$PR/comments/$CID/replies" \
   -f body="Addressed in <short-sha>: <one line on the fix>."
+```
+
+**Release the lane's claim before you stop**, exactly as Step 8 does for the initial build — the
+repair round is over, and a claim left held is what makes the *next* repair dispatch on this PR
+read `lost` (#3780; the observed stall was a repair refused by a claim whose run had finished):
+
+```bash
+pipeline-cli claim release --issue "$N" --session "$MY_CLAIM"   # retract OUR OWN marker; never another session's
 ```
 
 A reply is the acknowledgement this skill performs. **Resolving** the thread (collapsing it)

--- a/packages/pipeline-cli/src/tools/claim/claim-release.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-release.ts
@@ -1,0 +1,59 @@
+/**
+ * The pure release decision — which claim comments a finished run may retract, IO-free and total.
+ *
+ * Release is the **affirmative** half of a claim's lifetime: a claim ends because its owner says
+ * its work is done, never because a reader inferred the owner is gone. That asymmetry is the
+ * design, not an implementation detail. Inference from absence is what a claim-lifetime rule must
+ * not do — an age/TTL bound evicts a slow-but-live agent (the hazard ADR 0115 §5 deferred reclaim
+ * over), and "the claiming session id is not the current session id" is not evidence of completion
+ * either, because a live process can rotate its session id mid-run (#4045). So release retracts
+ * **only** markers carrying the token the caller owns; every other claim is `kept` — whatever its
+ * age, its liveness, or whether it carries a presence stamp at all (#3780).
+ *
+ * This introduces no second claim keyspace: the comments released here are the same `CLAIM_RE`
+ * markers `resolveWinner` resolves over (gh-issue-intake-formats.md §7), so a released claim
+ * simply stops being an owner — the one resolution stays the one resolution.
+ */
+import {
+	type ClaimComment,
+	type ClaimWinner,
+	parseClaimSession,
+} from "../epic-lock/claim-resolution.ts";
+
+/** What a release will and will not touch — the decision the IO shell executes and the command reports. */
+export interface ReleasePlan {
+	/** The comment ids to DELETE: exactly the markers carrying our own token. */
+	readonly retract: ReadonlyArray<number>;
+	/**
+	 * Every claim marker left standing because it is not ours. Reported, not evicted: naming them
+	 * is what makes "release freed the lane but #N is still claimed" answerable from the run log.
+	 */
+	readonly kept: ReadonlyArray<ClaimWinner>;
+}
+
+const asWinner = (comment: ClaimComment, session: string): ClaimWinner => ({
+	session,
+	id: comment.id,
+	createdAt: comment.createdAt,
+});
+
+/**
+ * Split an issue's claim markers into ours (retractable) and everyone else's (kept). A missing
+ * session id retracts nothing and keeps everything — with no token there is no claim we can prove
+ * is ours, and guessing one would be an eviction (the command turns this into a loud refusal).
+ */
+export const releasePlan = (
+	comments: ReadonlyArray<ClaimComment>,
+	sessionId: string | null | undefined,
+): ReleasePlan => {
+	const mine = sessionId?.trim().toLowerCase() ?? "";
+	const retract: number[] = [];
+	const kept: ClaimWinner[] = [];
+	for (const comment of comments) {
+		const session = parseClaimSession(comment.body);
+		if (session === null) continue;
+		if (mine !== "" && session === mine) retract.push(comment.id);
+		else kept.push(asWinner(comment, session));
+	}
+	return {retract, kept};
+};

--- a/packages/pipeline-cli/src/tools/claim/claim-release.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-release.unit.test.ts
@@ -1,0 +1,206 @@
+import {assert, describe, it} from "@effect/vitest";
+import {type LocalPresence, livenessByComment, type PidState} from "../epic-lock/claim-presence.ts";
+import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
+import {claimIsMine} from "./claim-is-mine.ts";
+import {releasePlan} from "./claim-release.ts";
+import {claimStatus} from "./claim-status.ts";
+
+const OWNER = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const NEWCOMER = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const HOST = "abc123def456";
+const AUTHORIZED = ["usirin"];
+
+const claim = (over: {
+	readonly id: number;
+	readonly session: string;
+	readonly at: string;
+	readonly presence?: string;
+	readonly login?: string;
+}): ClaimComment => ({
+	id: over.id,
+	author: over.login ?? "usirin",
+	createdAt: over.at,
+	body: `claim: ${over.session} · ${over.at}${over.presence ? ` · presence ${over.presence}` : ""}`,
+});
+
+const local = (probe: PidState): LocalPresence => ({host: HOST, probePid: () => probe});
+
+/** The resolution a later dispatch performs: is this lane mine, given who still holds a marker? */
+const resolveFor = (
+	comments: ReadonlyArray<ClaimComment>,
+	session: string,
+	presence: LocalPresence,
+) =>
+	claimIsMine({
+		comments,
+		authorizedAuthors: AUTHORIZED,
+		sessionId: session,
+		liveness: livenessByComment(comments, presence),
+	});
+
+describe("release — a completed run gives its own claim up (#3780)", () => {
+	it("retracts our own marker and frees the lane for the next dispatch", () => {
+		const held = claim({id: 100, session: OWNER, at: "2026-07-25T06:31:38Z"});
+
+		// Before release the lane is owned: a re-dispatch under a fresh session reads `lost` — the
+		// observed stall (a repair on #3983 refused by a claim whose run had long finished).
+		const before = resolveFor([held], NEWCOMER, local("unprobeable"));
+		assert.strictEqual(before.mine, false);
+		assert.strictEqual(before.reason, "lost");
+
+		// The owner releases: exactly its own marker, nothing else.
+		const plan = releasePlan([held], OWNER);
+		assert.deepStrictEqual(plan.retract, [100]);
+		assert.deepStrictEqual(plan.kept, []);
+
+		// After release the lane resolves as claimable, and the re-dispatch's own claim wins.
+		const reclaimed = claim({id: 200, session: NEWCOMER, at: "2026-07-25T09:00:00Z"});
+		assert.strictEqual(resolveFor([], NEWCOMER, local("unprobeable")).reason, "no-winner");
+		assert.strictEqual(resolveFor([reclaimed], NEWCOMER, local("unprobeable")).mine, true);
+	});
+
+	it("is idempotent — releasing an already-released claim retracts nothing and does not fail", () => {
+		assert.deepStrictEqual(releasePlan([], OWNER), {retract: [], kept: []});
+	});
+
+	it("retracts every marker our session posted across retried acquires", () => {
+		const first = claim({id: 100, session: OWNER, at: "2026-07-25T06:31:38Z"});
+		const second = claim({id: 140, session: OWNER, at: "2026-07-25T06:33:00Z"});
+		assert.deepStrictEqual(releasePlan([first, second], OWNER).retract, [100, 140]);
+	});
+});
+
+describe("release never evicts — a live claim stands even when the session id differs", () => {
+	it("a genuinely-alive claimant is NOT reclaimable, and its marker is not retractable by another token", () => {
+		// The marker is presence-stamped and its pid probes ALIVE — the sixth claim of the #3780
+		// incident. The claiming session id differs from the running agent's current one, which is
+		// exactly what a mid-run session-id rotation produces (#4045): identity mismatch is NOT
+		// evidence the work is done, so nothing here may treat it as reclaimable.
+		const live = claim({
+			id: 100,
+			session: OWNER,
+			at: "2026-07-25T06:31:38Z",
+			presence: `${HOST}/4242`,
+		});
+
+		const verdict = resolveFor([live], NEWCOMER, local("running"));
+		assert.strictEqual(verdict.mine, false);
+		assert.strictEqual(verdict.reason, "lost");
+		assert.strictEqual(verdict.winner?.session, OWNER);
+		assert.deepStrictEqual(verdict.superseded, []);
+
+		// And a run holding a DIFFERENT token cannot retract it: release is keyed on the token the
+		// caller owns, so it has no way to express "evict the other guy".
+		const plan = releasePlan([live], NEWCOMER);
+		assert.deepStrictEqual(plan.retract, []);
+		assert.deepStrictEqual(
+			plan.kept.map((c) => c.session),
+			[OWNER],
+		);
+	});
+
+	it("a later claim posted alongside a live one still loses — a newer marker never takes over", () => {
+		const live = claim({
+			id: 100,
+			session: OWNER,
+			at: "2026-07-25T06:31:38Z",
+			presence: `${HOST}/4242`,
+		});
+		const newer = claim({id: 200, session: NEWCOMER, at: "2026-07-25T09:00:00Z"});
+		const verdict = resolveFor([live, newer], NEWCOMER, local("running"));
+		assert.strictEqual(verdict.mine, false);
+		assert.strictEqual(verdict.winner?.session, OWNER);
+	});
+});
+
+describe("fail-closed is unchanged — indeterminate liveness still means the claim stands", () => {
+	it("an unstamped legacy claim is indeterminate: not superseded, not reclaimable, not releasable by another token", () => {
+		const legacy = claim({id: 100, session: OWNER, at: "2026-07-20T07:48:00Z"});
+		const presence = local("gone"); // even a probe that would prove death cannot apply: no stamp
+
+		const verdict = resolveFor([legacy], NEWCOMER, presence);
+		assert.strictEqual(verdict.mine, false);
+		assert.strictEqual(verdict.reason, "lost");
+		assert.deepStrictEqual(verdict.superseded, []);
+
+		assert.deepStrictEqual(releasePlan([legacy], NEWCOMER).retract, []);
+
+		// It surfaces as exactly what it is — an indeterminate owner a human may clear.
+		const report = claimStatus({
+			comments: [legacy],
+			authorizedAuthors: AUTHORIZED,
+			liveness: livenessByComment([legacy], presence),
+		});
+		assert.strictEqual(report.owner?.session, OWNER);
+		assert.strictEqual(report.claims[0]?.liveness, "unknown");
+		assert.strictEqual(report.claims[0]?.owner, true);
+	});
+
+	it("an unprobeable pid resolves unknown, never dead — the claim stands", () => {
+		const stamped = claim({
+			id: 100,
+			session: OWNER,
+			at: "2026-07-25T06:31:38Z",
+			presence: `${HOST}/4242`,
+		});
+		const verdict = resolveFor([stamped], NEWCOMER, local("unprobeable"));
+		assert.strictEqual(verdict.reason, "lost");
+		assert.deepStrictEqual(verdict.superseded, []);
+	});
+
+	it("a claim stamped on another machine is unprobeable here, so it stands", () => {
+		const elsewhere = claim({
+			id: 100,
+			session: OWNER,
+			at: "2026-07-25T06:31:38Z",
+			presence: "999999999999/4242",
+		});
+		const verdict = resolveFor([elsewhere], NEWCOMER, local("gone"));
+		assert.strictEqual(verdict.reason, "lost");
+		assert.deepStrictEqual(verdict.superseded, []);
+	});
+
+	it("release with no session id retracts nothing and keeps every claim (the command refuses loudly)", () => {
+		const held = claim({id: 100, session: OWNER, at: "2026-07-25T06:31:38Z"});
+		const plan = releasePlan([held], null);
+		assert.deepStrictEqual(plan.retract, []);
+		assert.strictEqual(plan.kept.length, 1);
+	});
+});
+
+describe("claim status — the stale-claim inventory (read-only)", () => {
+	it("reports every marker with its authorization, liveness, and the resolved owner", () => {
+		const dead = claim({
+			id: 100,
+			session: OWNER,
+			at: "2026-07-20T07:48:00Z",
+			presence: `${HOST}/4242`,
+		});
+		const forged = claim({id: 120, session: NEWCOMER, at: "2026-07-21T00:00:00Z", login: "nobody"});
+		const comments = [forged, dead];
+		const report = claimStatus({
+			comments,
+			authorizedAuthors: AUTHORIZED,
+			liveness: livenessByComment(comments, local("gone")),
+		});
+
+		assert.deepStrictEqual(
+			report.claims.map((c) => [c.id, c.authorized, c.liveness, c.owner]),
+			[
+				[100, true, "dead", false],
+				[120, false, "unknown", false],
+			],
+		);
+		assert.strictEqual(report.owner, null);
+		assert.deepStrictEqual(
+			report.superseded.map((c) => c.id),
+			[100],
+		);
+	});
+
+	it("an unclaimed issue reports no owner — the lane is claimable", () => {
+		const report = claimStatus({comments: [], authorizedAuthors: AUTHORIZED});
+		assert.strictEqual(report.owner, null);
+		assert.deepStrictEqual(report.claims, []);
+	});
+});

--- a/packages/pipeline-cli/src/tools/claim/claim-status.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-status.ts
@@ -1,0 +1,75 @@
+/**
+ * The pure claim-inventory projection — the read-only operational surface for "who holds #N, and
+ * is that claim still doing anything?", IO-free and total.
+ *
+ * A claim that outlived its run used to be invisible: nothing listed it, so stranded lanes
+ * accumulated silently until a re-dispatch read `lost` and stalled (#3780). This projection is the
+ * surface an operator reads before deciding to clear one by hand. It **reports, it never evicts** —
+ * every row carries the same liveness the resolver used (`live` / `dead` / `unknown`), and
+ * `unknown` (unstamped, another host, unprobeable pid) is shown as exactly what it is: a claim that
+ * stands. Deciding a claim is stale from what this prints is a human's call, not a rule.
+ */
+import {
+	type ClaimComment,
+	type ClaimLiveness,
+	type ClaimWinner,
+	parseClaimSession,
+	resolveWinner,
+	supersededClaims,
+} from "../epic-lock/claim-resolution.ts";
+
+/** One claim marker on the target, as an operator needs to see it. */
+export interface ClaimRow {
+	readonly session: string;
+	readonly id: number;
+	readonly createdAt: string;
+	readonly author: string;
+	/** Whether the author holds write+ — an unauthorized marker resolves nothing (ADR 0055). */
+	readonly authorized: boolean;
+	/** ADR 0191 presence liveness; `unknown` means indeterminate, which counts as a live claim. */
+	readonly liveness: ClaimLiveness;
+	/** Whether this marker is the resolved owner (the earliest live-or-indeterminate authorized claim). */
+	readonly owner: boolean;
+}
+
+export interface ClaimStatus {
+	/** The resolved owner, or `null` when nothing authorized stands — the lane is claimable. */
+	readonly owner: ClaimWinner | null;
+	/** Every claim marker on the target, earliest-first. */
+	readonly claims: ReadonlyArray<ClaimRow>;
+	/** The authorized claims dropped from the tiebreak on proven claimant death (ADR 0191). */
+	readonly superseded: ReadonlyArray<ClaimWinner>;
+}
+
+export interface ClaimStatusInput {
+	readonly comments: ReadonlyArray<ClaimComment>;
+	readonly authorizedAuthors: ReadonlyArray<string>;
+	readonly liveness?: ReadonlyMap<number, ClaimLiveness> | undefined;
+}
+
+export const claimStatus = (input: ClaimStatusInput): ClaimStatus => {
+	const authorized = new Set(input.authorizedAuthors);
+	const owner = resolveWinner(input.comments, input.authorizedAuthors, input.liveness);
+	const claims: ClaimRow[] = [];
+	for (const comment of input.comments) {
+		const session = parseClaimSession(comment.body);
+		if (session === null) continue;
+		claims.push({
+			session,
+			id: comment.id,
+			createdAt: comment.createdAt,
+			author: comment.author,
+			authorized: authorized.has(comment.author),
+			liveness: input.liveness?.get(comment.id) ?? "unknown",
+			owner: owner !== null && owner.id === comment.id,
+		});
+	}
+	claims.sort((a, b) =>
+		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
+	);
+	return {
+		owner,
+		claims,
+		superseded: supersededClaims(input.comments, input.authorizedAuthors, input.liveness),
+	};
+};

--- a/packages/pipeline-cli/src/tools/claim/command.ts
+++ b/packages/pipeline-cli/src/tools/claim/command.ts
@@ -1,5 +1,5 @@
 /**
- * The `claim` tool — `pipeline-cli claim is-mine --issue <N> [--session <sid>]`.
+ * The `claim` tool — `pipeline-cli claim is-mine|release|status --issue <N> [--session <sid>]`.
  *
  * The issue-scoped "is this claim mine?" resolver (#3687): resolve the earliest
  * authorized claim on an arbitrary issue (ADR 0115 §2 / gh-issue-intake-formats.md
@@ -16,6 +16,14 @@
  * prose. The resolved verdict is printed as JSON on stdout for a caller that wants
  * the detail (the resolved owner, the outcome reason).
  *
+ * `release` is the other end of the same claim's life (#3780): a finished run retracts its
+ * **own** marker so the lane stops reading `lost` forever. It is affirmative — the owner gives
+ * the claim up — never inferred from staleness, so it can retract only markers carrying the
+ * token the caller presents and leaves every other claim standing. `status` is the read-only
+ * inventory (every marker, its authorization, its ADR-0191 liveness, the resolved owner) — the
+ * surface that makes a claim no release ever retracted visible instead of silently stranding a
+ * lane. Neither verb evicts a claim it cannot prove is ours.
+ *
  * The session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable
  * signal under the shared `usirin` login); `--session` overrides it for the
  * orchestrated/delegated-token path (`MY_CLAIM`) and for tests. An absent session id
@@ -29,7 +37,8 @@ import {Command, Flag} from "effect/unstable/cli";
 import type {ClaimVerdict} from "./claim-is-mine.ts";
 import {Github, GithubLive} from "./github.ts";
 
-const NOT_MINE_EXIT_CODE = 1;
+/** Both refusals — `is-mine` not-mine and `release` with no provable token — exit non-zero. */
+const REFUSE_EXIT_CODE = 1;
 
 const issueFlag = Flag.integer("issue").pipe(
 	Flag.withDescription("the issue (or PR) number whose claim to resolve"),
@@ -38,7 +47,7 @@ const issueFlag = Flag.integer("issue").pipe(
 const sessionFlag = Flag.string("session").pipe(
 	Flag.optional,
 	Flag.withDescription(
-		"the session id to resolve ownership against (default: $CLAUDE_CODE_SESSION_ID); the delegated MY_CLAIM token on the orchestrated path",
+		"the session id to act under (default: $CLAUDE_CODE_SESSION_ID); the delegated MY_CLAIM token on the orchestrated path, and — for `release` — the token the claim was POSTED under, which a session-id rotation (#4045) leaves unchanged on the marker",
 	),
 );
 
@@ -83,7 +92,7 @@ const isMine = Command.make(
 		// the human-readable verdict + back-off reason goes to stderr, mirroring verdict/epic-lock.
 		yield* Console.log(JSON.stringify({issue, ...verdict}));
 		process.stderr.write(`claim: ${reasonLine(issue, verdict)}${supersededNote(verdict)}\n`);
-		if (!verdict.mine) process.exit(NOT_MINE_EXIT_CODE);
+		if (!verdict.mine) process.exit(REFUSE_EXIT_CODE);
 	}),
 ).pipe(
 	Command.withDescription(
@@ -91,10 +100,61 @@ const isMine = Command.make(
 	),
 );
 
-export const claimCommand = Command.make("claim").pipe(
-	Command.withSubcommands([isMine]),
+const release = Command.make(
+	"release",
+	{issue: issueFlag, session: sessionFlag},
+	Effect.fn(function* ({issue, session}) {
+		const sessionId = resolveSession(session);
+		if (sessionId === null) {
+			// Fail closed, loudly: with no token we cannot prove which marker is ours, and a release
+			// that guessed would be an eviction. Exiting non-zero (rather than no-op'ing quietly) is
+			// what makes a leaked claim a routed blocker instead of a silently stranded lane.
+			process.stderr.write(
+				`claim: #${issue}: no session id to release under (CLAUDE_CODE_SESSION_ID absent and no --session) — refusing to retract a claim we cannot prove is ours. Re-run with --session <the token the claim was posted under>.\n`,
+			);
+			process.exit(REFUSE_EXIT_CODE);
+			return;
+		}
+		const plan = yield* (yield* Github).release(issue, sessionId);
+		yield* Console.log(JSON.stringify({issue, session: sessionId, ...plan}));
+		process.stderr.write(
+			`claim: #${issue}: released — retracted ${plan.retract.length} own claim comment(s)` +
+				(plan.kept.length === 0
+					? "; no other claim remains."
+					: `; left ${plan.kept.length} claim(s) by other sessions standing (${plan.kept
+							.map((claim) => claim.session)
+							.join(", ")}) — release never evicts a claim that is not ours.`) +
+				"\n",
+		);
+	}),
+).pipe(
 	Command.withDescription(
-		"Resolve issue-claim ownership (ADR 0115 earliest-authorized-claim) — the default-deny 'is this claim mine' verb",
+		"Retract our OWN claim comment(s) on an issue when the run is done (affirmative release; never evicts another session's claim)",
+	),
+);
+
+const status = Command.make(
+	"status",
+	{issue: issueFlag},
+	Effect.fn(function* ({issue}) {
+		const report = yield* (yield* Github).status(issue);
+		yield* Console.log(JSON.stringify({issue, ...report}));
+		process.stderr.write(
+			`claim: #${issue}: ${report.claims.length} claim marker(s); owner ${
+				report.owner?.session ?? "(none — the lane is claimable)"
+			}. A claim reading liveness=unknown is INDETERMINATE and stands; clearing one is a human's call.\n`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Print an issue's claim inventory — every marker, its authorization, its ADR-0191 liveness, and the resolved owner (read-only)",
+	),
+);
+
+export const claimCommand = Command.make("claim").pipe(
+	Command.withSubcommands([isMine, release, status]),
+	Command.withDescription(
+		"Resolve, release, and inspect issue claims (ADR 0115 earliest-authorized-claim): default-deny 'is this mine', affirmative self-release, and the stale-claim inventory",
 	),
 	Command.provide(GithubLive),
 );

--- a/packages/pipeline-cli/src/tools/claim/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/github-service.unit.test.ts
@@ -176,3 +176,101 @@ describe("Github.isMine — the issue-scoped default-deny resolver over a mock g
 		),
 	);
 });
+
+describe("Github.release — the affirmative end of our own claim (#3780)", () => {
+	// A DELETE the release must NOT issue is mapped to a hard 403: if the implementation ever
+	// reached for another session's marker, the fault would surface instead of passing silently.
+	const foreignDeleteIsForbidden = {
+		stdout: "",
+		exitCode: 1,
+		stderr: "HTTP 403: Must have admin rights",
+	};
+
+	it.effect("retracts our own claim comment and leaves another session's standing", () =>
+		Effect.gen(function* () {
+			const plan = yield* (yield* Github).release(ISSUE, SID_MINE);
+			assert.deepStrictEqual(plan.retract, [800]);
+			assert.deepStrictEqual(
+				plan.kept.map((claim) => claim.session),
+				[SID_OTHER],
+			);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+					claimComment({id: 500, login: "usirin", session: SID_OTHER, at: "2026-07-08T00:00:01Z"}),
+					claimComment({id: 800, login: "usirin", session: SID_MINE, at: "2026-07-08T00:00:02Z"}),
+				]),
+				[`DELETE ${P}/issues/comments/800`]: "",
+				[`DELETE ${P}/issues/comments/500`]: foreignDeleteIsForbidden,
+			}),
+		),
+	);
+
+	it.effect("is 404-benign — an already-retracted claim releases cleanly", () =>
+		Effect.gen(function* () {
+			const plan = yield* (yield* Github).release(ISSUE, SID_MINE);
+			assert.deepStrictEqual(plan.retract, [800]);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+					claimComment({id: 800, login: "usirin", session: SID_MINE}),
+				]),
+				[`DELETE ${P}/issues/comments/800`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Not Found",
+				},
+			}),
+		),
+	);
+
+	it.effect(
+		"is LOUD on a non-404 DELETE fault — a swallowed failure would leave the claim held",
+		() =>
+			Effect.gen(function* () {
+				const error = yield* Effect.flip((yield* Github).release(ISSUE, SID_MINE));
+				assert.strictEqual(error._tag, "@kampus/claim/GhCommandError");
+			}).pipe((effect) =>
+				provide(effect, {
+					[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+						claimComment({id: 800, login: "usirin", session: SID_MINE}),
+					]),
+					[`DELETE ${P}/issues/comments/800`]: foreignDeleteIsForbidden,
+				}),
+			),
+	);
+});
+
+describe("Github.status — the read-only stale-claim inventory", () => {
+	it.effect("lists every marker with its authorization and the resolved owner", () =>
+		Effect.gen(function* () {
+			const report = yield* (yield* Github).status(ISSUE);
+			assert.strictEqual(report.owner?.session, SID_OTHER);
+			assert.deepStrictEqual(
+				report.claims.map((claim) => [claim.id, claim.authorized, claim.liveness]),
+				[
+					[500, true, "unknown"],
+					[10, false, "unknown"],
+				],
+			);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+					claimComment({id: 500, login: "usirin", session: SID_OTHER, at: "2026-07-08T00:00:01Z"}),
+					claimComment({
+						id: 10,
+						login: "attacker",
+						session: SID_FORGED,
+						at: "2026-07-08T00:00:02Z",
+					}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				[`GET ${P}/collaborators/attacker/permission`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Not Found",
+				},
+			}),
+		),
+	);
+});

--- a/packages/pipeline-cli/src/tools/claim/github.ts
+++ b/packages/pipeline-cli/src/tools/claim/github.ts
@@ -8,9 +8,10 @@
  * every infra failure a typed error in the `E` channel (`.patterns/effect-errors.md`)
  * — a non-zero `gh` exit is `GhCommandError`, malformed output is `GhParseError`, an
  * unresolvable repo is `RepoResolutionError` — and Schema-decoded untrusted REST JSON
- * at the boundary. Unlike epic-lock this verb only READS: it lists the issue's
- * comments, resolves the write+ authorized-author set (ADR 0055), and resolves the
- * earliest authorized claim against our session id. No label, no comment write.
+ * at the boundary. `isMine` and `status` only read; `release` is the one mutation, and
+ * it deletes **only** comment ids the pure `releasePlan` proved carry our own token.
+ * No label, no claim write — posting a claim stays `pipeline-cli tracker claim`'s job,
+ * so this tool never becomes a second claim writer.
  */
 import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
@@ -18,7 +19,10 @@ import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {livenessByComment} from "../epic-lock/claim-presence.ts";
 import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
 import {localPresence} from "../epic-lock/presence-io.ts";
+import {deleteCommentArgs} from "../tracker/gh-io.ts";
 import {type ClaimVerdict, claimIsMine} from "./claim-is-mine.ts";
+import {type ReleasePlan, releasePlan} from "./claim-release.ts";
+import {type ClaimStatus, claimStatus} from "./claim-status.ts";
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
 export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
@@ -217,10 +221,55 @@ const isMine = Effect.fn("Github.isMine")(function* (
 	return claimIsMine({comments, authorizedAuthors: authorized, sessionId, liveness});
 });
 
+/** A clean 404 — the only `gh` failure that means "the comment is already gone". */
+const is404 = (stderr: string): boolean => /404|not found/i.test(stderr);
+
 /**
- * `Github` — the read-only IO shell over `gh api` REST. `isMine` is the one verb the
- * `claim` tool exposes: it takes the issue number and the resolving session id and
- * returns the default-deny `ClaimVerdict`. Built by `GithubLive`, whose `R` is
+ * Retract our own claim on `issue` — the affirmative end of a run's claim (#3780). The pure
+ * `releasePlan` decides the set; this only executes the DELETEs, so the invariant that release
+ * never touches another session's marker is a property of the tested core, not of this loop.
+ * A DELETE that 404s is benign (already retracted, idempotent re-release); any other fault is
+ * LOUD — a silently-swallowed DELETE leaves the claim standing while the caller believes the
+ * lane is free, which is the stall this verb exists to end.
+ */
+const release = Effect.fn("Github.release")(function* (
+	repo: string,
+	issue: number,
+	sessionId: string,
+) {
+	const comments = yield* listClaimComments(repo, issue);
+	const plan = releasePlan(comments, sessionId);
+	yield* Effect.forEach(
+		plan.retract,
+		(id) =>
+			runGh(deleteCommentArgs(repo, id)).pipe(
+				Effect.catchTag("@kampus/claim/GhCommandError", (error) =>
+					is404(error.stderr) ? Effect.void : Effect.fail(error),
+				),
+			),
+		{concurrency: "unbounded", discard: true},
+	);
+	return plan;
+});
+
+/**
+ * The read-only claim inventory of `issue` — every marker, its authorization, its ADR-0191
+ * liveness, and which one owns the lane. The operational surface for a stale claim that no
+ * release ever retracted (a crashed run, a pre-release-era marker): it makes the claim visible
+ * so a human can clear it, and evicts nothing on its own.
+ */
+const status = Effect.fn("Github.status")(function* (repo: string, issue: number) {
+	const comments = yield* listClaimComments(repo, issue);
+	const authors = [...new Set(comments.map((c) => c.author).filter((a) => a.length > 0))];
+	const authorized = yield* authorizedAuthors(repo, authors);
+	const liveness = livenessByComment(comments, localPresence());
+	return claimStatus({comments, authorizedAuthors: authorized, liveness});
+});
+
+/**
+ * `Github` — the IO shell over `gh api` REST behind the three `claim` verbs: `isMine`
+ * (the default-deny `ClaimVerdict`), `release` (retract our own marker when the run is
+ * done), and `status` (the read-only claim inventory). Built by `GithubLive`, whose `R` is
  * `ChildProcessSpawner`: provide the platform spawner (`NodeServices.layer`) in
  * production; a test provides a mock spawner via `ChildProcessSpawner.make`.
  */
@@ -232,6 +281,19 @@ export class Github extends Context.Service<
 			sessionId: string | null,
 		) => Effect.Effect<
 			ClaimVerdict,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+		readonly release: (
+			issue: number,
+			sessionId: string,
+		) => Effect.Effect<
+			ReleasePlan,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+		readonly status: (
+			issue: number,
+		) => Effect.Effect<
+			ClaimStatus,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
 		>;
 	}
@@ -255,6 +317,9 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 			return {
 				isMine: (issue: number, sessionId: string | null) =>
 					repo.pipe(Effect.flatMap((r) => withSpawner(isMine(r, issue, sessionId)))),
+				release: (issue: number, sessionId: string) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(release(r, issue, sessionId)))),
+				status: (issue: number) => repo.pipe(Effect.flatMap((r) => withSpawner(status(r, issue)))),
 			};
 		}),
 	);


### PR DESCRIPTION
A coder's claim on an issue never ended. The resolver picks the earliest authorized claim, so a marker left behind by a run that already finished owned that issue permanently, and every later dispatch on it — a repair round, a follow-up, a stalled lane re-driven — read `lost` and stalled. This adds `pipeline-cli claim release`, called by the run that holds the claim at its terminus, so a completed lane gives its claim up instead of holding it forever.

Release is deliberately **affirmative**: the claim ends because its owner said the work is done, never because a reader inferred the owner is gone. Inference from absence is what got us here, and every inference rule on offer is unsafe — an age/TTL bound evicts a slow-but-live agent, and "the claiming session id is not the current session id" is not evidence of completion either, because a live process can rotate its session id mid-run (#4045).

## What changed

- **`pipeline-cli claim release --issue N [--session <token>]`** — retracts **only** the claim markers carrying the token the caller presents. It is idempotent (releasing twice retracts nothing and succeeds), 404-benign on an already-deleted comment, loud on any other DELETE fault, and **fails closed with a non-zero exit when there is no token** to prove ownership under. The pure decision lives in `packages/pipeline-cli/src/tools/claim/claim-release.ts`; the IO shell only executes the ids that core produced, so "release never touches another session's marker" is a property of a tested function rather than of a loop.
- **`pipeline-cli claim status --issue N`** — the read-only inventory: every marker with its author, its write+ authorization, its ADR-0191 liveness, and the resolved owner. This is the operational surface for a claim no release ever retracted; it reports and evicts nothing.
- **`write-code` Step 8 and repair Step R3** now call `claim release` as the last act of the run, and `gh-issue-intake-formats.md` §7 gains a Release subsection plus the staleness runbook and the two-substrate note.

## Fail-closed is not weakened — the constraint that outranked the fix

- No age rule, no TTL, and **no session-id-mismatch rule**. Release is keyed on the token the caller presents, so it has no way to express "evict the other guy". In the rotation case a live agent whose session id rotated releases nothing by accident, and an operator releasing a delegated or pre-rotation claim passes the marker's token explicitly with `--session`.
- `unknown` / indeterminate liveness still means the claim **stands**. `dead` still requires all three of a present stamp, a host match, and a provably-gone pid; a probe that could not execute is still `unknown`, never `dead`. No liveness code was touched, and the regression tests assert this end to end.
- Release **does not touch the assignee**. The coarse availability gate stays set while the PR is in review, so Step 1's picker still skips the issue and no idle lane re-implements work already in flight. What release frees is the fine resolver, which is exactly what a directed re-dispatch needs.

## Why the crashed-agent case is still out of scope

A run that dies before its terminus leaves its marker standing. That residual stays deferred exactly where ADR 0115 §5 left it — `claim status` makes it visible, and clearing it is a human's call on evidence outside this keyspace. This PR smuggles in no automatic reclaim.

## Regression coverage

`packages/pipeline-cli/src/tools/claim/claim-release.unit.test.ts` proves the three mandated cases plus the surrounding fail-closed edges:

- a claim whose run completed is reclaimable (before release a fresh session reads `lost`; after it, the lane resolves `no-winner` and the re-dispatch's own claim wins);
- a claim whose process is genuinely **alive** is **not** reclaimable even though the session id differs — it stays the owner, is not superseded, and is not retractable by another token;
- an unstamped legacy claim is indeterminate: not superseded even when the local probe would prove death, not reclaimable, not releasable by another token;
- an unprobeable pid and an off-host stamp both resolve `unknown` and stand; release with no session id retracts nothing.

`github-service.unit.test.ts` covers the IO half, including a foreign comment's DELETE mapped to a hard 403 so any attempt to retract another session's marker fails the test instead of passing silently.

## Adjacent work this does not touch

`claim-writer.ts` / `presence-io.ts` / `claim-presence.ts` are untouched (#3987 / PR #4015 is in flight there), and no second claim writer is introduced — posting a claim stays `pipeline-cli tracker claim`'s job. The released comments are the same `CLAIM_RE` markers `resolveWinner` already resolves over, so this adds no second claim-lifetime mechanism (#3751's constraint) and leaves the two-keyspace reconciliation (#3938) and `epic-lock`'s reader (#4020) alone — the two substrates' differing semantics are now written down in §7 rather than half-wired here.

Checks run at this head: `pnpm typecheck`, `pnpm lint:worktree`, the full `pipeline-cli` vitest suite (2083 passing), `adoption-lint check` and `gh-phoenix lint-skills` over the CI corpus, `commands check`, and `leak-guard scan` over the changed files.

Note for the merge authority: this diff is control-plane by path (`packages/pipeline-cli/**`, `claude-plugins/**`), so it needs human control-plane approval.

Fixes #3780
