### PR TITLE
fix(review-doc): key Step 1's issueless allowance on the doc/vocab surface, not the artifact class

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1706,6 +1706,51 @@ HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed:
 HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed: every path is a doc
 ```
 
+### The doc/vocab-surface predicate — the issueless allowance's axis (`DOC_VOCAB_*_RE`)
+
+The three gates' Step 1 no-linked-issue rules ask a **different question** from the class probes
+above: not *which gate verifies this path* but *is a missing `Fixes #N` legitimate here*. The two
+axes disagree on exactly one surface — `.glossary/**` classes **has-code** (#919, so `review-code`
+Step 3c owns the glossary-freshness contract) yet is a **conversation-authored vocabulary** surface
+whose canonical PR — an ADR co-locating the `.glossary/**` row it coins — is issueless *by design*
+(ADR [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md),
+extended to the code lane by ADR
+[0184](https://github.com/kamp-us/phoenix/blob/main/.decisions/0184-review-code-issueless-carve-out.md)).
+Keying the issueless allowance on the *class* therefore false-refuses that PR — the #3953
+divergence, where `review-doc` Step 1 hard-stopped a shape `ship-it` Step 1 and `review-code`
+Step 1 both bless by name.
+
+So the allowance keys on the **surface**, single-sourced here as its own carve-then-test pair —
+adjacent to the class probes, deliberately **not** one of them:
+
+```bash
+DOC_VOCAB_EXCLUDE_RE='^(apps|packages|infra|claude-plugins)/'
+DOC_VOCAB_SURFACE_RE='^(\.decisions|\.patterns|\.glossary)/|\.md$'
+```
+
+A path is a **doc/vocab surface** iff it does **not** match `DOC_VOCAB_EXCLUDE_RE` (the real code
+roots + skills source) **and** matches `DOC_VOCAB_SURFACE_RE`. A PR is **doc/vocab-surface-only**
+iff its changed-file set is non-empty and **every** path is one. `DOC_VOCAB_EXCLUDE_RE` omits
+`.glossary` where `HAS_DOCS_EXCLUDE_RE` excludes it — that is the surface-vs-class distinction, not
+a drift between the two lines, so the has-code/docs-exclusion lockstep invariant above does **not**
+extend to this pair.
+
+The predicate is **narrow by construction**, which is what keeps it from becoming a general
+"missing issue is fine" escape: a code-root `*.md` (`apps/web/README.md`) is excluded *before* the
+`.md$` test, and an unclassified root file (`biome.jsonc`, `turbo.json`) fails the surface test — so
+a PR that touches code and merely forgot its issue link still refuses. Run it through the shared
+verb rather than hand-rolling the greps — `pipeline-cli class-probe doc-vocab-surface-only` (exit 0
+⇒ doc/vocab-surface-only, non-zero ⇒ not). Re-resolution fails closed **toward refusal**, the
+mirror image of the class probes' over-dispatch: `DOC_VOCAB_EXCLUDE_RE` defaults to `.` (every path
+excluded) and `DOC_VOCAB_SURFACE_RE` to `$^` (no path is a surface), and zero input resolves *not*
+surface-only (ADR 0092) — an unreadable source can never **grant** the allowance.
+
+**Consumers.** `review-doc` Step 1 consumes this line directly. `ship-it` Step 1 and `review-code`
+Step 1 state the same boundary in prose today (each scoped to its own lane); until they are
+converted to cite it, this pair is the definition they must agree with.
+
+---
+
 **No-class fail-closed — a non-empty diff can never require zero gates (#2765).** A changed file
 that matches **none** of the three class probes above — root-level executable build/lint tooling
 outside the code roots (`biome-plugins/**`, `biome.jsonc`, `turbo.json`, `pnpm-workspace.yaml`, a

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -297,25 +297,46 @@ The `issues/$PR/timeline` endpoint accepts the PR number, and the
 `connected`/`cross-referenced` events resolve PR→issue — so `.source.issue.number` is the
 linked *issue*, not a bug. This is the same idiom `review-code` uses. Pin down `ISSUE=<N>`.
 
-If there is **no** linked issue, the rule is **class-aware** — reuse the artifact class Step 0
-already computed (do **not** re-derive it; ADR
-[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)). This
-mirrors `ship-it` Step 1's docs-only carve-out, scoped to the doc lane this gate serves:
+If there is **no** linked issue, the rule is **surface-aware, not class-aware** — and that
+distinction is the whole rule (#3953). Do **not** key the allowance on Step 0's artifact class:
+`.glossary/**` classes **has-code** (#919), so a class-keyed rule false-refuses the canonical
+issueless shape — a conversation-authored ADR co-locating the `.glossary/**` row it coins — which
+`ship-it` Step 1 and `review-code` Step 1 both bless by name. Key it on the **doc/vocab surface**
+instead: the single-sourced `DOC_VOCAB_*_RE` predicate in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §CLASS (cite it, don't re-derive
+it — ADR [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md),
+extended to the code lane by ADR
+[0184](https://github.com/kamp-us/phoenix/blob/main/.decisions/0184-review-code-issueless-carve-out.md)).
+Resolve it **mechanically, never by eye**:
 
-- **A code class is present** (the mixed code+doc routing of Step 0) → stop and report `no
-  linked issue`. In this pipeline `write-code` always writes `Fixes #N`, so a missing link on a
-  PR carrying code is a broken seam, not a normal state — there is dangling code work with no AC
-  to verify against. (Skills-only and pure-code PRs never reach here — Step 0 already routed them
-  to `review-skill`/`review-code` and stopped.)
-- **Docs-only** (Step 0 classed the diff as docs with **no** code class present) → a missing
-  `Fixes #N` is a **legitimate state, not a broken seam**. A conversation-authored ADR/doc (the
-  [`/adr`](../adr/SKILL.md) path) records a settled choice that was never tracked work, so there
-  is nothing for a `Fixes #N` to close and **no acceptance criteria to verify against**. Leave
-  `ISSUE` unset, treat the acceptance-criteria half as **N/A** (skip Step 3 — there is no
-  checklist), and **proceed to the doc-hygiene checklist (Step 4) as the sole gate**. Emit **no**
-  no-linked-issue refusal; it is not an anomaly. This relaxes **only** the linked-issue half — the
-  Step 4 hygiene checklist is AC-independent and still applies in full, and the verdict for such a
-  PR rests on it alone (Step 5).
+```bash
+# doc/vocab-surface-only? exit 0 = yes (issueless is legitimate), non-zero = no (hard-stop below).
+# Predicate single-sourced in §CLASS (DOC_VOCAB_EXCLUDE_RE / DOC_VOCAB_SURFACE_RE); fails closed to
+# "no" on an unreadable source or zero input (ADR 0092) — it can only ever REFUSE the allowance.
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | pipeline-cli class-probe doc-vocab-surface-only
+```
+
+- **Not doc/vocab-surface-only** — any changed path under `apps/**`, `packages/**`, `infra/**`, or
+  `claude-plugins/**` (skills source), or any path off the doc/vocab surfaces → stop and report `no
+  linked issue`. In this pipeline `write-code` always writes `Fixes #N`, so a missing link on a PR
+  carrying code is a broken seam, not a normal state — there is dangling code work with no AC to
+  verify against. The carve-out below **never** widens to behavioral code: a PR that touches code
+  and merely forgot its link still refuses here. (Skills-only and pure-code PRs never reach here —
+  Step 0 already routed them to `review-skill`/`review-code` and stopped.)
+- **Doc/vocab-surface-only** (every changed path is `.decisions/**`, `.patterns/**`, `.glossary/**`,
+  or prose `*.md` — **no** `apps/**`/`packages/**`/`infra/**` code and **no** `claude-plugins/**`
+  skills source) → a missing `Fixes #N` is a **legitimate state, not a broken seam**. A
+  conversation-authored ADR/doc (the [`/adr`](../adr/SKILL.md) path) records a settled choice that
+  was never tracked work, so there is nothing for a `Fixes #N` to close and **no acceptance criteria
+  to verify against**. This holds **even when `.glossary/**` makes a code class present** — that
+  has-code label decides *which gate verifies the glossary*, not whether a glossary touch needs a
+  `Fixes #N`. Leave `ISSUE` unset, treat the acceptance-criteria half as **N/A** (skip Step 3 —
+  there is no checklist), and **proceed to the doc-hygiene checklist (Step 4) as the sole gate**.
+  Emit **no** no-linked-issue refusal; it is not an anomaly. This relaxes **only** the linked-issue
+  half: Step 0's mixed-class routing is untouched, so an ADR + `.glossary/**` PR still needs a
+  current-head PASS in **both** `review-doc` and `review-code`, and the Step 4 hygiene checklist is
+  AC-independent and still applies in full — the verdict for such a PR rests on it alone (Step 5).
 
 When `ISSUE` **is** set, honor it as today: pull the issue and its acceptance criteria:
 

--- a/packages/pipeline-cli/src/tools/class-probe/README.md
+++ b/packages/pipeline-cli/src/tools/class-probe/README.md
@@ -47,7 +47,26 @@ pipeline-cli class-probe classify --files-from changed.txt
 pipeline-cli class-probe classify --root <dir>     # read §CLASS under a specific root (default: walk up)
 ```
 
-Present classes go to **stdout** (one per line); a human summary goes to **stderr**. Exit
-is always 0 — this classifies, it does not gate. `review-design` (the UI-affecting class)
-is resolved separately from ship-it's `UI_RE` (`ui_reresolve`) and is out of this tool's
-scope.
+Present classes go to **stdout** (one per line); a human summary goes to **stderr**.
+`classify` always exits 0 — it classifies, it does not gate. `review-design` (the
+UI-affecting class) is resolved separately from ship-it's `UI_RE` (`ui_reresolve`) and is
+out of this tool's scope.
+
+## `doc-vocab-surface-only` — the issueless allowance's axis (#3953)
+
+```bash
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | pipeline-cli class-probe doc-vocab-surface-only   # exit 0 = yes, non-zero = no
+```
+
+A **different question** from `classify`: not *which gate verifies this path* but *is a
+missing `Fixes #N` legitimate here* (ADR 0075 / 0184). The two axes disagree on exactly one
+surface — `.glossary/**` is has-code (so `review-code` gates it) **and** a
+conversation-authored vocab surface (so an ADR co-locating the row it coins owes no issue
+link). Keying the allowance on the class is what false-refused that shape at `review-doc`
+Step 1 (#3953), so the gates key it here instead.
+
+The `DOC_VOCAB_EXCLUDE_RE` / `DOC_VOCAB_SURFACE_RE` pair is parsed from the same §CLASS
+single source, and every failure mode resolves **not** surface-only — unreadable §CLASS,
+dropped stdin, uncompilable regex. This probe can only ever *refuse* the allowance, the
+mirror of `classify`'s over-dispatch (ADR 0092).

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
@@ -148,6 +148,57 @@ export const classify = (
  */
 export const NO_INPUT_FAILCLOSED_CLASSES: ReadonlyArray<ArtifactClass> = ["has-code"];
 
+/**
+ * The §CLASS doc/vocab-surface carve-then-test pair — a **different axis** from the class
+ * probes above: not "which gate verifies this path" but "is a missing `Fixes #N` legitimate
+ * here". The two disagree on `.glossary/**` alone (has-code, yet conversation-authored and
+ * issueless by design), which is why the gates' Step 1 keys on this and not on the class.
+ * See ADR 0075 / 0184 and §CLASS; #3953.
+ */
+export interface DocVocabProbe {
+	readonly exclude: string;
+	readonly surface: string;
+}
+
+/**
+ * Fail-closed defaults, the mirror image of `FAILCLOSED_PROBES`: the class probes over-dispatch
+ * gates, this one refuses the allowance. `exclude: "."` excludes every path and `surface: "$^"`
+ * makes no path a surface, so an unreadable §CLASS resolves NOT surface-only ⇒ the missing-link
+ * hard-stop stands.
+ */
+export const FAILCLOSED_DOC_VOCAB_PROBE: DocVocabProbe = {
+	exclude: ".",
+	surface: "$^",
+};
+
+/** Parse the canonical `DOC_VOCAB_*_RE='…'` lines out of §CLASS (single-quoted assignment only). */
+export const parseDocVocabProbe = (formatsText: string): DocVocabProbe => {
+	const read = (name: string, fallback: string): string =>
+		formatsText.match(new RegExp(`^${name}='([^']*)'`, "m"))?.[1] ?? fallback;
+	return {
+		exclude: read("DOC_VOCAB_EXCLUDE_RE", FAILCLOSED_DOC_VOCAB_PROBE.exclude),
+		surface: read("DOC_VOCAB_SURFACE_RE", FAILCLOSED_DOC_VOCAB_PROBE.surface),
+	};
+};
+
+/**
+ * Is every changed path a doc/vocab surface (⇒ a missing `Fixes #N` is legitimate, ADR 0075/0184)?
+ *
+ * Empty input is **not** surface-only: this probe is only ever piped a PR's changed-file list, so
+ * an empty read is a dropped stdin, and granting an issueless allowance off one would be
+ * fail-open (the same #3786 reasoning `NO_INPUT_FAILCLOSED_CLASSES` encodes for classify).
+ * Uncompilable-regex fallbacks likewise point at refusal, inverting `classify`'s: a broken
+ * exclude matches everything, a broken surface matches nothing.
+ */
+export const isDocVocabSurfaceOnly = (
+	files: ReadonlyArray<string>,
+	probe: DocVocabProbe,
+): boolean => {
+	const isExcluded = matcher(probe.exclude, () => true);
+	const isSurface = matcher(probe.surface, () => false);
+	return files.length > 0 && files.every((f) => !isExcluded(f) && isSurface(f));
+};
+
 /** The `review-*` namespaces a diff requires — one per present class, in canonical order. */
 export const requiredNamespaces = (
 	classes: ReadonlyArray<ArtifactClass>,

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
@@ -4,12 +4,15 @@ import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {
 	classify,
+	FAILCLOSED_DOC_VOCAB_PROBE,
 	FAILCLOSED_PROBES,
 	FAILCLOSED_UI_EXCLUDE_RE,
 	FAILCLOSED_UI_RE,
+	isDocVocabSurfaceOnly,
 	isUiAffecting,
 	NO_INPUT_FAILCLOSED_CLASSES,
 	parseClassProbes,
+	parseDocVocabProbe,
 	parseUiExclude,
 	parseUiProbe,
 	requiredNamespaces,
@@ -352,6 +355,59 @@ describe("isUiAffecting — a src-colocated *.test.ts[x] / *.spec.* mints NO rev
 		// exempt. `$^` never matches, so the test file falls through to the UI_RE test.
 		expect(isUiAffecting(["apps/web/src/Foo.test.tsx"], LIVE_UI_RE, FAILCLOSED_UI_EXCLUDE_RE)).toBe(
 			true,
+		);
+	});
+});
+
+// The issueless allowance's axis (ADR 0075/0184, #3953). These pin the property that keeps the
+// three gates' Step 1 from drifting again: it is the SURFACE that decides, not the class — so a
+// `.glossary/**` path is simultaneously has-code (needs review-code) and a doc/vocab surface
+// (needs no `Fixes #N`), and the two facts must not be conflated.
+describe("isDocVocabSurfaceOnly — the surface axis, not the class axis", () => {
+	const LIVE_DOC_VOCAB = parseDocVocabProbe(readFileSync(FORMATS_PATH, "utf8"));
+
+	it("extracts the canonical DOC_VOCAB_*_RE pair off the live contract", () => {
+		expect(LIVE_DOC_VOCAB.exclude).toBe("^(apps|packages|infra|claude-plugins)/");
+		expect(LIVE_DOC_VOCAB.surface).toBe("^(\\.decisions|\\.patterns|\\.glossary)/|\\.md$");
+	});
+
+	it("a doc-only PR with no linked issue is surface-only ⇒ Step 1 must not refuse it", () => {
+		expect(isDocVocabSurfaceOnly([".decisions/0200-some-adr.md"], LIVE_DOC_VOCAB)).toBe(true);
+		expect(isDocVocabSurfaceOnly([".patterns/index.md", "README.md"], LIVE_DOC_VOCAB)).toBe(true);
+	});
+
+	it("the canonical ADR + .glossary/** shape is surface-only, YET still requires review-code", () => {
+		// The exact divergence #3953 closes: has-code (so review-code gates it) and issueless
+		// (so no `Fixes #N` is owed) answer different questions — both hold at once.
+		const files = [".decisions/0200-some-adr.md", ".glossary/TERMS.md"];
+		expect(isDocVocabSurfaceOnly(files, LIVE_DOC_VOCAB)).toBe(true);
+		expect(requiredNamespaces(classify(files, LIVE_PROBES))).toEqual(["review-code", "review-doc"]);
+	});
+
+	it("a code-touching PR is NOT surface-only ⇒ the missing-link hard-stop stands", () => {
+		expect(isDocVocabSurfaceOnly(["apps/web/worker/index.ts"], LIVE_DOC_VOCAB)).toBe(false);
+		// a doc companion never launders the code path
+		expect(
+			isDocVocabSurfaceOnly([".decisions/0200-some-adr.md", "packages/x/src/y.ts"], LIVE_DOC_VOCAB),
+		).toBe(false);
+		// a code-root *.md is excluded BEFORE the `\.md$` test — it rides its code artifact
+		expect(isDocVocabSurfaceOnly(["apps/web/README.md"], LIVE_DOC_VOCAB)).toBe(false);
+		// skills source is behavioral, never a doc/vocab surface
+		expect(
+			isDocVocabSurfaceOnly(
+				["claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md"],
+				LIVE_DOC_VOCAB,
+			),
+		).toBe(false);
+		// an unclassified root file fails the surface test rather than sliding through
+		expect(isDocVocabSurfaceOnly(["biome.jsonc"], LIVE_DOC_VOCAB)).toBe(false);
+	});
+
+	it("fails closed toward refusal: empty input and an unreadable §CLASS both resolve NOT surface-only", () => {
+		expect(isDocVocabSurfaceOnly([], LIVE_DOC_VOCAB)).toBe(false);
+		expect(parseDocVocabProbe("")).toEqual(FAILCLOSED_DOC_VOCAB_PROBE);
+		expect(isDocVocabSurfaceOnly([".decisions/0200-some-adr.md"], FAILCLOSED_DOC_VOCAB_PROBE)).toBe(
+			false,
 		);
 	});
 });

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -17,8 +17,12 @@
  * instead, appending `review-design`). Folding has-ui in here is the #2485/#2483 fix: the
  * reviewer fan dispatches review-design deterministically off this output instead of eyeballing
  * a non-visual `apps/web/src/*.ts` away and deadlocking ship-it on an empty review-design
- * namespace. A human summary goes to **stderr**; exit is always 0 — this classifies, it does
- * not gate.
+ * namespace. A human summary goes to **stderr**; `classify` always exits 0 — it classifies, it
+ * does not gate.
+ *
+ * The sibling `doc-vocab-surface-only` subcommand answers a **different** question on the same
+ * file set — is a missing `Fixes #N` legitimate here (ADR 0075/0184, #3953) — and *does* carry
+ * its decision in the exit code, since the gates' Step 1 branches on it.
  *
  * IO here (the thin bin), classification in `class-probe.ts` (the pure core). An
  * unreadable §CLASS falls back to the fail-closed probes (`FAILCLOSED_PROBES`), which
@@ -31,9 +35,11 @@ import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {
 	classify,
 	DESIGN_NAMESPACE,
+	isDocVocabSurfaceOnly,
 	isUiAffecting,
 	NO_INPUT_FAILCLOSED_CLASSES,
 	parseClassProbes,
+	parseDocVocabProbe,
 	parseUiExclude,
 	parseUiProbe,
 	requiredNamespaces,
@@ -196,8 +202,47 @@ const classifyCmd = Command.make(
 	),
 );
 
+// The gates' Step 1 issueless allowance (ADR 0075/0184, #3953) — a SEPARATE axis from `classify`
+// (surface, not class), so it is its own subcommand rather than a flag on the class output. Exit
+// code carries the decision so the gate bash reads it directly; every failure mode (unreadable
+// §CLASS, dropped stdin) resolves NOT surface-only ⇒ the missing-link hard-stop stands.
+const docVocabCmd = Command.make(
+	"doc-vocab-surface-only",
+	{filesFrom: filesFromFlag, root: rootFlag},
+	Effect.fn(function* ({filesFrom, root}) {
+		const rootDir = yield* Option.match(root, {
+			onNone: () => defaultRoot(),
+			onSome: Effect.succeed,
+		});
+		const formats = yield* readFormats(rootDir);
+		const probe = parseDocVocabProbe(formats ?? "");
+		const files = yield* readFiles(filesFrom);
+		const surfaceOnly = isDocVocabSurfaceOnly(files, probe);
+
+		if (formats === null) {
+			yield* Effect.sync(() =>
+				process.stderr.write(
+					`class-probe: could not read ${FORMATS_PATH} under ${rootDir} — using the fail-closed doc/vocab probe (no path is a surface ⇒ NOT surface-only).\n`,
+				),
+			);
+		}
+		const offSurface = files.filter((f) => !isDocVocabSurfaceOnly([f], probe));
+		yield* Effect.sync(() =>
+			process.stderr.write(
+				`class-probe: ${files.length} changed file(s) → ${surfaceOnly ? "doc/vocab-surface-only (issueless Fixes #N is legitimate — ADR 0075/0184)" : `NOT doc/vocab-surface-only${offSurface.length > 0 ? ` (off-surface: ${offSurface.join(", ")})` : " (read 0 files — dropped stdin, failing closed)"}`}\n`,
+			),
+		);
+		yield* Console.log(surfaceOnly ? "doc-vocab-surface-only" : "not-doc-vocab-surface-only");
+		if (!surfaceOnly) return yield* Effect.sync(() => process.exit(1));
+	}),
+).pipe(
+	Command.withDescription(
+		"Is every changed path a doc/vocab surface (⇒ a missing Fixes #N is legitimate)? exit 0 = yes (#3953)",
+	),
+);
+
 export const classProbeCommand = Command.make("class-probe").pipe(
-	Command.withSubcommands([classifyCmd]),
+	Command.withSubcommands([classifyCmd, docVocabCmd]),
 	Command.withDescription(
 		"Deterministic artifact-class probe shared by the reviewer fan and ship-it Step 0 (#2434)",
 	),


### PR DESCRIPTION
## What

`review-doc` Step 1's no-linked-issue rule now keys the issueless allowance on the **doc/vocab
surface**, not on Step 0's artifact class — bringing it into line with the two sibling gates that
already bless the shape it was refusing.

Fixes #3953

## The asymmetry, verified against the live texts

| gate | Step 1 rule for a missing `Fixes #N` | keys on |
| --- | --- | --- |
| `ship-it` | doc/vocab-surface-only ⇒ ships issueless; names the ADR + `.glossary/**` PR as canonical | **surface** |
| `review-code` | `.glossary/**` coining site + `.decisions/**`/`.patterns/**` companions ⇒ "a legitimate state, not a broken seam" (ADR 0184) | **surface** (its lane) |
| `review-doc` (before) | two branches only: "a code class is present → stop and report `no linked issue`" vs "docs-only → legitimate" | **class** |
| `review-skill` | no carve-out — correct, its lane is `claude-plugins/**` skills source, which is never a doc/vocab surface | n/a |

`HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'`, so `.glossary/**` **is** a code class. A PR that
is one `.decisions/**` ADR plus the `.glossary/**` row it coins therefore took `review-doc`'s
code-class branch and was hard-stopped for `no linked issue` — a shape that is issueless by design
(ADR 0075) and that `ship-it` Step 1 names canonical verbatim. Confirmed: no surface-based exception
existed in that branch. The asymmetry is exactly as the issue describes.

## The fix — one predicate, single-sourced, not a third phrasing

`gh-issue-intake-formats.md` §CLASS gains the canonical pair, adjacent to the class probes and
deliberately not one of them:

```bash
DOC_VOCAB_EXCLUDE_RE='^(apps|packages|infra|claude-plugins)/'
DOC_VOCAB_SURFACE_RE='^(\.decisions|\.patterns|\.glossary)/|\.md$'
```

Because the two axes answer different questions — *which gate verifies this path* vs *is a missing
`Fixes #N` legitimate here* — they disagree on exactly one surface, `.glossary/**`. That is why
`DOC_VOCAB_EXCLUDE_RE` omits `.glossary` where `HAS_DOCS_EXCLUDE_RE` excludes it; the §CLASS text
says so explicitly, so the has-code/docs-exclusion lockstep invariant isn't mistakenly read as
extending to this pair.

`review-doc` Step 1 now branches on that predicate and resolves it mechanically, never by eye, via
a new shared verb: `pipeline-cli class-probe doc-vocab-surface-only` (exit 0 = surface-only). Live:

```
$ printf '.decisions/0200-x.md\n.glossary/TERMS.md\n' | pipeline-cli class-probe doc-vocab-surface-only
doc/vocab-surface-only (issueless Fixes #N is legitimate — ADR 0075/0184)   exit=0
$ printf 'apps/web/src/App.tsx\n.decisions/0200-x.md\n' | pipeline-cli class-probe doc-vocab-surface-only
NOT doc/vocab-surface-only (off-surface: apps/web/src/App.tsx)              exit=1
$ printf '.decisions/0200-x.md\n.glossary/TERMS.md\n' | pipeline-cli class-probe classify --namespaces
review-code
review-doc
```

## The gate is not weakened

- The carve-out requires **every** changed path to be a doc/vocab surface — it is not "a missing
  issue link is fine".
- A code-root `*.md` (`apps/web/README.md`) is excluded *before* the `\.md$` test; `claude-plugins/**`
  skills source and unclassified root files (`biome.jsonc`, `turbo.json`) fail the surface test. A PR
  that touches code and merely forgot its link still refuses.
- Every failure mode resolves **not** surface-only — unreadable §CLASS (`exclude` defaults to `.`,
  `surface` to `$^`), dropped stdin, uncompilable regex. The probe can only ever *refuse* the
  allowance; it is the mirror image of `classify`'s fail-closed over-dispatch (ADR 0092).
- Every other Step 1 refusal is preserved; only the surface-vs-class branch changed.
- Mixed-class routing is untouched: an ADR + `.glossary/**` PR still requires a current-head PASS in
  **both** `review-doc` and `review-code` (pinned by a test).

`ship-it` Step 1 and `review-code` Step 1 are **unedited** (AC4's first option), deliberately — see
the collision note below. §CLASS records that they state the same boundary in prose and that this
pair is the definition they must agree with.

## Coverage

`packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts` gains a
`isDocVocabSurfaceOnly` block pinning, against the **live** on-disk contract (not a fixture):

- a doc-only PR with no linked issue is surface-only ⇒ Step 1 must not refuse it;
- the ADR + `.glossary/**` shape is surface-only **and** still requires `["review-code", "review-doc"]`
  — the two facts hold at once, which is the property that keeps the Step 1s from re-diverging;
- code paths, a doc companion alongside code, a code-root README, skills source, and `biome.jsonc`
  all resolve NOT surface-only;
- empty input and an unreadable §CLASS both fail closed toward refusal.

## Checks

`pnpm typecheck` (29/29), `pnpm lint`, `pnpm --filter @kampus/pipeline-cli test` (152 files, 2180
tests, all passing).

## Notes for review

- **§CP / control-plane.** `claude-plugins/kampus-pipeline/skills/review-doc/**` and
  `gh-issue-intake-formats.md` are both in the canonical §CP set, so this banks for a
  `@kamp-us/control-plane` approval at head and cannot auto-merge (ADR 0135 / ADR 0053). Not merging.
- **Concurrent lanes.** Several PRs are in flight against `claude-plugins/kampus-pipeline/skills/**`.
  This touches `review-doc/SKILL.md` Step 1 and appends a new subsection to
  `gh-issue-intake-formats.md` §CLASS (between the `reresolve_re` block and the "No-class fail-closed"
  paragraph). If another lane is editing either region, flagging it rather than resolving it
  unilaterally.
- **`Refs #N` is not introduced anywhere** — it is not a linkage seam (#647). The only recognized
  references remain the closing keywords and `ship-it`'s explicit non-closing `Part of #N`.
- Converting `ship-it` Step 1 and `review-code` Step 1 to *cite* the new pair rather than restate it
  in prose is the remaining half of the single-sourcing; left out here to keep the splice small and
  the collision surface minimal, per the issue's triage note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
