### PR TITLE
fix(triage): p1 is bounded to an active arc OR an active campaign (#4072)

### DIFF
--- a/.decisions/0202-forward-motion-doctrine-crewops.md
+++ b/.decisions/0202-forward-motion-doctrine-crewops.md
@@ -1,7 +1,7 @@
 ---
 id: 0202
 title: Forward-motion doctrine — p0 freely minted for arc-homed ship-work; CrewOps state
-status: accepted
+status: amended-in-part by [0214](0214-active-campaign-confers-p1.md)
 date: 2026-07-24
 tags: [process, prioritization, pipeline]
 ---

--- a/.decisions/0214-active-campaign-confers-p1.md
+++ b/.decisions/0214-active-campaign-confers-p1.md
@@ -1,0 +1,51 @@
+---
+id: 0214
+title: An active campaign confers `p1` exactly as the active arc does (amends 0202 in part)
+status: accepted
+date: 2026-07-25
+tags: [process, prioritization, triage, pipeline]
+---
+
+# 0214 — An Active Campaign Confers `p1` Exactly as the Active Arc Does (amends 0202 in part)
+
+**What this decides:** `p1` is not reserved for the one active product arc — work homed in any *active campaign* earns `p1` too. The triage rubric only ever named arcs, which accidentally made every `p1` on the board invalid; this fixes the bound, and `p1` stays milestone-relative rather than becoming a general "worth doing soon" tier.
+
+## Context
+
+Founder ruling, 2026-07-25, in conversation — recorded on the conversation-authored path (ADR 0075). It resolves a fork escalated from the intake-desk retro sweep on issue #3939.
+
+The triage rubric (`claude-plugins/kampus-pipeline/skills/triage/SKILL.md` Step 6) defined the `p1` row as *"Serves the active milestone — the arc pinned by `ROADMAP.md`'s single `active` `## Arcs` row."* It named **arcs only**. But `ROADMAP.md` carries exactly one `active` arc — **Geçit (#24)** — alongside **12 active campaigns**.
+
+The retro sweep measured the collision directly: of the **34 open `p1` issues created 2026-07-24..25, zero serve Geçit** — all of them are campaign work. Under a literal reading of the rubric, every `p1` on the board was invalid *by construction*. Six independent read-only verdict batches hit the same ambiguity and split on the remedy: some repriced campaign `p1`s up to `p0`, others down to `p2`. Both readings were defensible from the text.
+
+This sits on ADR 0072 (milestones encode strategic sequencing), ADR 0078 (engineering leads on platform/infra), and ADR 0208 (standing lanes are milestone-less by design). It **amends in part** ADR 0202 — specifically the priority rubric that decision drove into the triage skill.
+
+## Decision
+
+**An active campaign confers a `p1` band exactly as the active arc does; `p1` is bounded to "an active arc *or* an active campaign", not to the single active arc alone.**
+
+The rubric's `p1` row was **under-specified, not intentionally arc-exclusive**. Campaigns are milestone-backed pushes that run *concurrently* with the active product arc through the platform lane (ADR 0072 semantics, ADR 0078 engineering-led) — a roadmap object of the same standing as an arc for sequencing purposes.
+
+The rejected alternative — `p1` reserved to the active arc alone — would have flattened the entire pipeline-hardening and crew-mechanics backlog to `p2`, leaving it unsequenceable, and would contradict the standing position that pipeline hardening is a priority lane rather than background work.
+
+`p1` remains **milestone-relative and bounded**. The bound moves from *"the active arc"* to *"an active arc or an active campaign"* — it does not dissolve.
+
+**Binding constraints.**
+
+- `p1` requires a home in an `active` `## Arcs` row **or** an `active` `## Campaigns` row of `ROADMAP.md`.
+- An issue homed in neither is not `p1` — `p1` is never a general "worth doing soon" tier.
+- A `done` or `queued` arc/campaign confers nothing; only `active` state does.
+- `p0` semantics are untouched — ADR 0202 §1/§2 stand unchanged.
+
+## Consequences
+
+- **The existing campaign-homed `p1` issues are valid as they stand.** No repricing is owed, and the retro sweep's proposed `p1 → p2` batch is void.
+- **`p0` is unaffected.** Whether a given campaign-homed `p1` should escalate to `p0` is a separate per-issue judgment this ADR does not settle.
+- **The `p1` set grows.** Twelve active campaigns plus one active arc is a wider band than one arc, so `p1` carries less discriminating power than the rubric's "bounded set" language assumed. The discipline that keeps it honest is the state column: campaigns that finish must be moved to `done` promptly, or the band inflates by neglect.
+- **`ROADMAP.md` line 11 still reads `p1` = current arc.** That line is founder-voice and revised on the conversation-authored path (ADR 0075), so it is deliberately not reconciled here; it disagrees with this ADR until the founder calls it. This ADR governs in the interim.
+- **The ambiguity class is worth noting.** The rubric named one roadmap object (`## Arcs`) while `ROADMAP.md` carried two kinds. Any future rubric that keys on roadmap structure should name every object kind it means, or say explicitly which it excludes and why.
+
+## Records
+
+- **Vocabulary impact: none.** Re-prices already-named concepts — `arc`, `campaign` (both in `.glossary/TERMS.md`), and the `p0`/`p1`/`p2` tiers from ADR 0202's rubric.
+- Resolves the `p1` fork escalated on #3939 by the intake-desk retro sweep; routed to build as #4072.

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -71,8 +71,10 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   `type:*` label; resolve the decision-vs-epic / feature-vs-epic boundaries by the
   skill's rules. One issue, one type.
 - **Prioritize milestone-relative — the default is `p2`, not `p1`.** Follow the skill's
-  priority rubric exactly: `p1` means "serves the active milestone / you'd pull it next"
-  (bounded by the current arc, *not* a general "worth doing soon" tier), `p2` is the
+  priority rubric exactly: `p1` means "serves an active milestone / you'd pull it next"
+  (bounded to an `active` `## Arcs` **or** `## Campaigns` row of `ROADMAP.md` — an active
+  campaign confers `p1` exactly as the active arc does, and an issue homed in neither is
+  *not* `p1`; it is never a general "worth doing soon" tier — ADR 0214), `p2` is the
   **default** for real, actionable work that isn't the current focus (most of the
   backlog), and `p0` is fire only. Do not treat the middle bucket as the catch-all — an
   inflated `p1` is what makes the backlog unsequenceable.

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -566,26 +566,30 @@ Every triaged issue gets exactly one of `p0` / `p1` / `p2`. Priority is *your*
 judgment, deliberately coarse — it sets write-code's pick order (highest bucket first,
 oldest first within a bucket), so it only has to be *directionally* right, not a precise
 ranking. Priority is **milestone-relative**, not an absolute urgency score: `p1` means
-"serves the active milestone / you'd pull it next," so it stays naturally bounded by the
-current arc instead of becoming the catch-all. The **default is `p2`** — most real work
-isn't the current focus.
+"serves an active milestone / you'd pull it next," so it stays naturally bounded by the
+active arc and campaigns instead of becoming the catch-all. The **default is `p2`** — most
+real work isn't the current focus.
 
-The **active milestone is not a judgment call**: it is the arc pinned by the single
-`active` row of [`ROADMAP.md`](../../../../ROADMAP.md)'s `## Arcs` table — the founder-voice
-roadmap that projects each arc onto a GitHub milestone (ADR
+The **active milestone is not a judgment call**: it is any row marked `active` in
+[`ROADMAP.md`](../../../../ROADMAP.md)'s `## Arcs` **or** `## Campaigns` table — the
+founder-voice roadmap that projects each arc/campaign onto a GitHub milestone (ADR
 [0078](https://github.com/kamp-us/phoenix/blob/main/.decisions/0078-product-driven-decisions-by-default.md);
-exactly one arc is `active` at a time). Read that row to know what `p1` is bounded to; if
-no `## Arcs` row is marked `active`, there is no active milestone and the fallbacks below
-apply.
+exactly one arc is `active` at a time, alongside any number of active campaigns). An active
+campaign confers a `p1` band exactly as the active arc does — campaigns are milestone-backed
+pushes that run *concurrently* with the arc, so both are `p1` homes (ADR
+[0214](https://github.com/kamp-us/phoenix/blob/main/.decisions/0214-active-campaign-confers-p1.md)).
+Read those rows to know what `p1` is bounded to. A `done` or `queued` row confers nothing.
+If no row in either table is marked `active`, there is no active milestone and the
+fallbacks below apply.
 
 | Priority | Use when… |
 |---|---|
 | **`p0`** | **Ship-work and fires — and it is never homeless.** Mint `p0` **freely** for work that moves us forward: shipped user/revenue value, or work that directly raises ship-rate (ADR 0202 §1). Fires still qualify — actively breaking something people rely on, a data-loss or security risk, a release gate. The one hard bound is homing: **a `p0` belongs to the active arc's documented structure, so an orphan (un-homed) `p0` is invalid** (ADR 0202 §2). If you can't home it below, it isn't `p0`. |
-| **`p1`** | **Serves the active milestone** — the arc pinned by `ROADMAP.md`'s single `active` `## Arcs` row (defined just above). Real, actionable work that belongs to that active arc — you'd pull it next. Milestone-bounded on purpose: p1 is *not* a general "worth doing soon" tier, so a solid issue outside the active arc is **not** p1. If no `## Arcs` row is marked `active`, keep p1 for the small set of things you'd genuinely pick up next; everything else is p2. |
-| **`p2`** | **The default.** Real, actionable work that isn't the current focus — most of the backlog. Also nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure to pull it ahead of the active arc. |
+| **`p1`** | **Serves an active milestone** — an `active` row of `ROADMAP.md`'s `## Arcs` **or** `## Campaigns` table (defined just above). Real, actionable work that belongs to that active arc or campaign — you'd pull it next. Milestone-bounded on purpose: p1 is *not* a general "worth doing soon" tier, so a solid issue homed in neither an active arc nor an active campaign is **not** p1. If no row in either table is marked `active`, keep p1 for the small set of things you'd genuinely pick up next; everything else is p2. |
+| **`p2`** | **The default.** Real, actionable work that isn't the current focus — most of the backlog. Also nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure to pull it ahead of the active arc or campaigns. |
 
 Most of a healthy backlog is `p2`, with a bounded `p1` set tracking the active
-milestone. When unsure between `p1` and `p2`, pick the lower one — over-escalation erodes
+milestones. When unsure between `p1` and `p2`, pick the lower one — over-escalation erodes
 the signal faster than under-escalation, and an inflated `p1` is exactly what makes the
 backlog unsequenceable.
 


### PR DESCRIPTION
The triage rubric said an issue could only be `p1` if it served the one active product arc. But the roadmap runs twelve active campaigns alongside that arc, so read literally the rule priced out almost every `p1` on the board — of 34 open `p1` issues filed on 2026-07-24/25, none served the active arc. The founder ruled on 2026-07-25 that this was under-specification, not intent: an active campaign earns `p1` exactly as the active arc does.

This PR makes the repo say so. `p1` stays bounded — it moves from "the active arc" to "an active arc **or** an active campaign", and an issue homed in neither is still not `p1`. `p0` is untouched.

## What changed

- **`claude-plugins/kampus-pipeline/skills/triage/SKILL.md`** — Step 6's "active milestone is not a judgment call" paragraph, the `p1` row, and the `p2` row now bound `p1` to an `active` `## Arcs` **or** `## Campaigns` row of `ROADMAP.md`. A `done`/`queued` row confers nothing; neither ⇒ not `p1`.
- **`claude-plugins/kampus-pipeline/agents/triager.md`** — the same amendment to the "Prioritize milestone-relative" standing invariant. Load-bearing, not cosmetic: spawned subagents do not inherit skills, so a triager reads this file as its baked-in rubric — leaving it stale would reproduce the defect in the one surface designed to survive when the skill text isn't loaded.
- **`.decisions/0214-active-campaign-confers-p1.md`** — records the ruling. Amends ADR 0202 in part (the priority rubric only); ADR 0202 §1/§2 `p0` semantics stand unchanged.

## Notes for review

- **ADR number verified against the merged state, not this PR's base.** `main` tops at 0213; `0210` is a hole deliberately left for open PR #3955. `0214` is free on `main`, unclaimed by every open PR's file list, and unique in `git merge-tree --write-tree origin/main <head>` — `decisions-index validate` passes on that merged `.decisions/`.
- **`ROADMAP.md` is deliberately not edited.** Its line 11 (`p1` = current arc) is founder-voice, revised on the ADR-0075 conversation-authored path; triage isn't authorised to route an edit there. The ADR names the disagreement and states that it governs in the interim — flagged for a founder call.
- **No conflict with what landed today.** The founder litmus sentence PR #4051 landed is untouched (`grep -c -F` = 1, byte-exact). ADR 0202's forward-motion doctrine and the PR #3955 parking ruling ("parking is only for fog") are unchanged — this PR only moves the `p1` band's bound.
- **Routes §CP.** CODEOWNERS assigns both `skills/triage/` and `agents/` to the control-plane team, so this banks for human approval before enqueue (ADR 0135).

Fixes #4072