### PR TITLE
fix(review-gates): name `Part of #N` as the only non-closing linkage a verdict may prescribe (#4047)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -3139,6 +3139,18 @@ it fits: a PR that closes nothing on its target carries `Part of #N` instead of 
   treats a literal `Part of #N` as a legitimate intentional partial-split — merge the PR, leave
   `#N` open — instead of refusing it (the #1342 consumer, landed in PR #1347).
 
+**The prescribing side — a `review-*` verdict's remedy.** The gates are the third party to this
+marker: a verdict whose finding is "this PR must stop auto-closing `#N`" prescribes **`Part of #N`**
+and nothing else. `Refs #N`, `Re: #N`, `See #N`, and a bare `#N` arm no seam, so a PR that adopts
+one hits `ship-it` Step 1's `no linked issue` refusal and becomes unmergeable — the gate's own
+advice bricks the lane it gates, silently, since nothing surfaces the refusal until merge time
+(#4047, where a `review-code` verdict prescribed `Refs #3943` on PR #3988). The remedy also
+**replaces** the closing keyword rather than joining it: a body carrying both `Fixes #N` and
+`Part of #N` still auto-closes on the closing keyword. `review-code` carries the operational
+statement of this rule ([its Step 4b](review-code/SKILL.md#prescribing-a-linkage-remedy)) and the
+other PR gates point at this subsection; the fix for a jammed lane belongs on the advice, never on
+Step 1's grammar.
+
 **Single-sourced — producer + consumer + contract, no re-definition.** This marker mirrors the
 closing-keyword seam's own single-sourcing: `write-code` Step 5 (the **producer** — emits
 `Part of #N` when the PR is an intentional partial-split, the issue staying open for a sibling lane)

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1609,6 +1609,35 @@ Do **not** touch the issue's labels, assignee, or state on a fail. The pipeline'
 invariant is that a failed gate is a *no-op on the work state* plus a comment — the
 issue is still claimed, still open, still in-progress; only the verdict changed.
 
+<a id="prescribing-a-linkage-remedy"></a>
+### Prescribing a linkage remedy — `Part of #N` is the only non-closing form you may name
+
+Some findings land on the PR body's issue reference itself: the body carries `Fixes #N` but `#N`
+must **not** auto-close on merge — the diff delivers only part of the issue, or `#N` carries an
+explicit do-not-auto-close instruction. When you prescribe that remedy, name **`Part of #N`**.
+It is the one non-closing linkage form the pipeline accepts: GitHub populates no
+`closingIssuesReferences` from it, and `ship-it` Step 1 recognizes it as a valid
+linked-but-non-closing reference and merges without closing `#N`. The marker is defined once in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §9 (its `Part of #N`
+subsection) — cite it, don't re-derive it.
+
+**Never prescribe `Refs #N`, `Re: #N`, `See #N`, or a bare `#N`.** They *look* like reasonable
+non-closing linkage — the convention is common in other repos — but they arm **no** seam here: a
+code/skills-class PR carrying neither a closing keyword nor `Part of #N` hits `ship-it` Step 1's
+`no linked issue` refusal, which disarms the merge intent. The author complies with the verdict
+and the lane becomes unmergeable, silently, because nothing surfaces the refusal until merge time
+(#647, where PR #573 shipped `Refs #569` and jammed; #4047, where a `review-code` verdict
+prescribed `Refs #3943` on PR #3988 and the gate's own advice bricked the lane it was gating).
+
+Two operational corollaries:
+
+- **The remedy is a swap of the reference, not an added line.** A body carrying both `Fixes #N`
+  and `Part of #N` still auto-closes `#N` on the closing keyword, so say "replace `Fixes #N` with
+  `Part of #N`" — never "add a `Part of #N`".
+- **The fix always lands on the advice, never on the gate.** `ship-it` Step 1's linkage grammar
+  is correct as written; a verdict that reached for an unsupported token is the defect. Never
+  prescribe loosening Step 1 to accept the form you wanted.
+
 ---
 
 ## Step 4c — Confirm the verdict landed (verdict-posting is itself a gate — ADR 0092 / §ZS)

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -708,6 +708,12 @@ Do **not** post a native `REQUEST_CHANGES` review — `review-design` is comment
 4), so the SHA-bound marker comment is the sole verdict artifact. Do **not** touch the issue's
 labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus a comment.
 
+**Prescribing a linkage remedy.** A finding that the PR must stop auto-closing its `Fixes #N`
+target has exactly one sanctioned remedy: **replace** the closing keyword with `Part of #N`. Never
+prescribe `Refs #N` / `Re: #N` / `See #N` / a bare `#N` — they arm no seam, jam `ship-it` Step 1,
+and brick the lane the verdict was gating (#4047). Rule and rationale:
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §9 (`Part of #N`).
+
 ### Confirm the verdict landed clean (the shared read-back guard, #2148)
 
 After **any** of the three upserts returns its comment id, close the loop: call the **single

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -999,6 +999,12 @@ fixed (§5): `@ <sha>` comes **immediately after** `FAIL`, before `— changes-r
 labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus a
 comment.
 
+**Prescribing a linkage remedy.** A finding that the PR must stop auto-closing its `Fixes #N`
+target has exactly one sanctioned remedy: **replace** the closing keyword with `Part of #N`. Never
+prescribe `Refs #N` / `Re: #N` / `See #N` / a bare `#N` — they arm no seam, jam `ship-it` Step 1,
+and brick the lane the verdict was gating (#4047). Rule and rationale:
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §9 (`Part of #N`).
+
 ---
 
 ## Step 5b — Confirm the verdict landed clean (the shared read-back guard, #2148)

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -750,6 +750,12 @@ tolerantly by shape (`review-skill: FAIL @ <sha>`), not exact dashes; token orde
 issue's labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus
 a comment.
 
+**Prescribing a linkage remedy.** A finding that the PR must stop auto-closing its `Fixes #N`
+target has exactly one sanctioned remedy: **replace** the closing keyword with `Part of #N`. Never
+prescribe `Refs #N` / `Re: #N` / `See #N` / a bare `#N` — they arm no seam, jam `ship-it` Step 1,
+and brick the lane the verdict was gating (#4047). Rule and rationale:
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §9 (`Part of #N`).
+
 ---
 
 ## Step 5b — Confirm the verdict landed clean (the shared read-back guard, #2148)

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -169,6 +169,13 @@ seam is missing) — note it and stop; there's nothing to gate against without t
 deliberately issue-less doc PR — ADR 0075 — is a full-`review-doc` case, not a trivial-gate one;
 route it to the full path.)
 
+When your verdict prescribes a **linkage** change — restoring the missing seam, or making a PR stop
+auto-closing its target — the only two forms you may name are `Fixes #N` (closes on merge) and
+`Part of #N` (links without closing). Never prescribe `Refs #N` / `Re: #N` / `See #N` / a bare
+`#N` — they arm no seam, jam `ship-it` Step 1, and brick the lane the verdict was gating (#4047).
+Rule and rationale: [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §9
+(`Part of #N`).
+
 ---
 
 ## Step 2 — The scoped checklist (the reduced fan-out)


### PR DESCRIPTION
A review gate once told an author to swap a PR body's closing keyword for `Refs`, so a
do-not-auto-close issue would survive the merge. The author did exactly that, and the PR became
unmergeable — `ship-it` accepts a closing keyword or the marker `Part of #N`, and nothing else, so
`Refs` reads as "no linked issue" and the merge is refused. The gate's own advice bricked the lane
it was gating, and nobody could see it until merge time.

This PR teaches the review gates the word they were missing. `Part of #N` is now named at the
surface where verdicts are written, so a reviewer who needs a PR to stop auto-closing its issue
has a form to prescribe that actually merges.

Fixes #4047

## What changed

The grammar was never inconsistent — `write-code`, the formats contract, `ship-it`, and
`orphan-heal` all agree, and `Refs` is already explicitly forbidden on the authoring side. The gap
was that `Part of #N` appeared **zero** times in every `review-*` skill, so a verdict whose finding
was "this closing keyword must go" had no sanctioned replacement to name and reached for the
ecosystem-common `Refs`.

- **`claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`** — Step 4b (the fail-path verdict
  surface) gains `### Prescribing a linkage remedy`: prescribe `Part of #N`, citing the formats
  contract §9; never prescribe `Refs #N` / `Re: #N` / `See #N` / a bare `#N`; the remedy *replaces*
  the closing keyword rather than adding a line (a body with both still auto-closes); and the fix
  for a jam lands on the advice, never on `ship-it`'s grammar.
- **`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`** — §9's `Part of #N`
  subsection gains the prescribing side, so the single source names the gates alongside the
  producer (`write-code`) and consumer (`ship-it`). The sibling pointers land here.
- **`review-doc` / `review-skill` / `review-design` / `review-trivial`** — a compact pointer at each
  one's verdict surface. The *why* stays single-sourced in §9 + `review-code`, so the same rationale
  isn't re-narrated five times.

## Audit result — `review-plan` is unchanged, deliberately

`review-plan` gates an **epic plan** (issue bodies, the `## Dependencies` topology, the child
label flip), not a PR body. It never resolves or prescribes a PR ↔ issue linkage, so there is no
remedy surface to add guidance to — per the issue's "add only where the surface exists". The four
gates that *do* read a PR body's linkage (`review-doc`, `review-skill`, `review-design`,
`review-trivial`) all carry the pointer.

## Acceptance criteria

- [x] `review-code`'s verdict/remedy guidance names `Part of #N` as the only sanctioned non-closing
  linkage form, cites the formats contract's linkage-grammar section (§9), and explicitly forbids
  prescribing `Refs #N` / `Re: #N` / `See #N` / a bare `#N`.
- [x] Every other `review-*` skill that can prescribe a linkage change carries the same guidance or
  a pointer to it — `review-doc`, `review-skill`, `review-design`, `review-trivial`; `review-plan`
  audited, no such surface.
- [x] `ship-it/SKILL.md` Step 1's linkage grammar is unchanged — no new accepted form, no
  loosening. The file is not in this diff.

## Notes for review

- **§CP:** the diff is entirely gate-critical pipeline skill text under
  `claude-plugins/kampus-pipeline/skills/**`, so this routes through the control-plane
  manual-merge path, not auto-ship.
- Prose-only diff: `pnpm lint:worktree` is a clean skip (no biome-handled changed files),
  `pnpm typecheck` green, `validate-skills.sh` OK (26 skills), `validate-gate-path-drift.sh` OK
  (17 checks — the §CP regex copies and the marketplace symlink still agree).
