### PR TITLE
fix(pipeline-cli): audit and retire pre-stamping claim markers no liveness can supersede (#4031)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -3007,6 +3007,33 @@ so a legitimate re-claim can land) — never a per-skill re-derivation. The verb
 superseded claims next to the resolved owner, so "why is a later claim the owner?" is answerable
 from the run log.
 
+### Pre-stamping markers — the one population supersession cannot reach
+
+Supersession needs a stamp to evaluate, so a marker written **before every writer stamped**
+(#3987, PR #4015) is permanently indeterminate: it wins the tiebreak forever, and re-claiming
+cannot help, because a fresh claim is by definition later than the one shadowing it. Every open
+issue holding such a marker is a lane no agent can repair — silently, until a dispatch hits the
+mis-attribution guard and (correctly) refuses (#4031).
+
+That population is **bounded** (it predates a fixed instant and only shrinks), so it is cleared
+by an audited cleanup, not by a resolution rule — the rules above are untouched, and a **stamped**
+claim is never a candidate whatever its age:
+
+```bash
+pipeline-cli claim audit                 # every open lane held by an unstamped marker, and which are retirable
+pipeline-cli claim audit --issue <N>     # the cheap single-lane read when a stall is already known
+pipeline-cli claim audit --execute       # retire the retirable ones through `claim release`
+```
+
+Retirement runs through **`claim release` under the marker's own token** — the one retraction
+mechanism, never a second — and touches a marker only when it is unstamped, predates the stamping
+cutoff, has aged past a safety margin, and is the only shape its session left on the lane. Every
+other unstamped marker is **reported and held**: an unstamped marker written *after* the cutoff is
+a degraded writer (`presence-io.ts` emits no stamp when it cannot read the process table or this
+machine's identity), not a legacy one, and may belong to a running agent. No margin *proves* a
+claimant is gone, so `--execute` stays an operator act on a report that names each session — never
+an automatic sweep, and never a TTL on the resolver.
+
 ### Repair dispatches thread the lane's claim token
 
 A **repair** dispatch is the class this contract is easiest to violate on: it lands on a lane

--- a/packages/pipeline-cli/src/tools/claim/claim-audit.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-audit.ts
@@ -1,0 +1,181 @@
+/**
+ * The pure legacy-claim audit — which open lanes are held by a claim marker written before
+ * presence stamping existed, and which of those may be retired. IO-free and total.
+ *
+ * ADR 0191 supersession only ever drops a claim its presence stamp proves dead, so a marker
+ * written before every writer stamped (#3987, PR #4015) is permanently indeterminate: it wins
+ * the earliest-authorized-claim tiebreak forever, and no later claim — however live, however
+ * legitimate — can displace it. The lane is silently unrepairable until a dispatch hits the
+ * mis-attribution guard and (correctly) refuses (#4031).
+ *
+ * The fix is a bounded cleanup, **not** a change to how claims resolve. Nothing here is read by
+ * `resolveWinner`, `claimIsMine`, or `claimStatus`; the resolution rule and its fail-closed
+ * direction are untouched, and a **stamped** claim is never a candidate whatever its age. What
+ * this adds is a way to name the pre-stamping population and hand each member to the one
+ * retraction mechanism that already exists (`claim release`, #3780) instead of growing a second.
+ *
+ * Retirement needs three facts, not one, because "unstamped" alone does not mean "legacy": a
+ * post-cutoff writer still emits an unstamped marker when it cannot read the process table or
+ * this machine's identity (`presence-io.ts`), and such a marker may belong to a running agent.
+ * So a candidate must (1) predate the stamping cutoff, (2) be older than a safety margin that
+ * no single run outlives, and (3) be the only shape its session left on the lane. Every doubt
+ * holds the claim — the same direction the resolver takes.
+ */
+import {parseClaimPresence} from "../epic-lock/claim-presence.ts";
+import {
+	authorizedClaims,
+	type ClaimComment,
+	type ClaimLiveness,
+	type ClaimWinner,
+	parseClaimSession,
+	resolveWinner,
+} from "../epic-lock/claim-resolution.ts";
+
+/**
+ * The instant after which every claim writer stamps presence: the merge of PR #4015 (#3987),
+ * which routed the last hand-rolled writer through the one presence-stamping producer. A marker
+ * created before this could not have been stamped by any writer; one created after it was
+ * written by a stamping writer that degraded, which is a different case and out of scope here.
+ * Overridable (`--cutoff`) so a foreign install can name its own stamping era (ADR 0062).
+ */
+export const STAMPING_CUTOFF = "2026-07-25T20:52:36Z";
+
+/**
+ * How old a pre-cutoff marker must be before retirement will touch it. The cutoff bounds the
+ * population but says nothing about liveness — a run that claimed minutes before it may still be
+ * working — so age is the only evidence left once a marker carries no stamp to probe.
+ *
+ * Two days, not the one a coder run would justify: claims are also written by long-lived crew
+ * engine sessions, which routinely outlive a single build. No margin is *proof* a claimant is
+ * gone, which is why retirement is an operator act on a report that names each session, and why
+ * `--min-age-hours` exists — lower it deliberately for a claimant you have confirmed is gone,
+ * never to make a bulk sweep reach further.
+ */
+export const DEFAULT_MIN_AGE_HOURS = 48;
+
+/** Why a locked lane's owning marker is or is not retirable — the audit's whole verdict. */
+export type LaneReason =
+	/** Unstamped, pre-cutoff, aged past the margin: the bounded legacy population. */
+	| "pre-stamping"
+	/** Unstamped but written after the cutoff — a degraded stamping writer, not a legacy marker. */
+	| "post-cutoff"
+	/** Pre-cutoff but younger than the safety margin: its session could still be running. */
+	| "within-safety-margin"
+	/** The same session also left a stamped marker here, which a token-scoped release would take. */
+	| "session-restamped"
+	/** A timestamp that would not parse — nothing to compare, so the claim stands. */
+	| "indeterminate-age";
+
+/** One open lane held by an unstamped claim: the blast-radius row, and its disposition. */
+export interface LockedLane {
+	readonly issue: number;
+	/** The unstamped marker holding the lane (the earliest live-or-indeterminate authorized claim). */
+	readonly owner: ClaimWinner;
+	/** The later authorized claims it outranks — the legitimate claimants it is shadowing. */
+	readonly shadowed: ReadonlyArray<ClaimWinner>;
+	readonly disposition: "retire" | "hold";
+	readonly reason: LaneReason;
+}
+
+/** The bounds retirement is decided against; all three are inputs so the decision stays testable. */
+export interface AuditPolicy {
+	/** ISO-8601 UTC; markers created at or after it are not pre-stamping. */
+	readonly cutoff: string;
+	readonly minAgeMs: number;
+	/** ISO-8601 UTC "now" — the clock the age is measured against. */
+	readonly now: string;
+}
+
+/** One lane's canonical claim state, as the IO shell reads it off the issue. */
+export interface LaneInput {
+	readonly issue: number;
+	readonly comments: ReadonlyArray<ClaimComment>;
+	readonly authorizedAuthors: ReadonlyArray<string>;
+	readonly liveness?: ReadonlyMap<number, ClaimLiveness> | undefined;
+}
+
+export interface AuditReport {
+	/** How many lanes were examined — a zero scan is a broken read, not a clean result (ADR 0092). */
+	readonly scanned: number;
+	/** Every examined lane whose owning marker carries no presence stamp (the blast radius). */
+	readonly locked: ReadonlyArray<LockedLane>;
+	/** The subset retirement may act on — `locked` filtered to `disposition: "retire"`. */
+	readonly retirable: ReadonlyArray<LockedLane>;
+}
+
+/** Milliseconds since `at`, or `null` when either instant will not parse. */
+const ageMs = (at: string, now: string): number | null => {
+	const then = Date.parse(at);
+	const nowMs = Date.parse(now);
+	return Number.isFinite(then) && Number.isFinite(nowMs) ? nowMs - then : null;
+};
+
+/** Does `at` fall strictly before `cutoff`? `null` when either instant will not parse. */
+const isBefore = (at: string, cutoff: string): boolean | null => {
+	const atMs = Date.parse(at);
+	const cutoffMs = Date.parse(cutoff);
+	return Number.isFinite(atMs) && Number.isFinite(cutoffMs) ? atMs < cutoffMs : null;
+};
+
+/**
+ * Decide one owner marker's disposition. Ordered so the report names the *first* reason a lane
+ * is held rather than an arbitrary one, and so `retire` is reachable only after every check.
+ */
+const disposition = (
+	owner: ClaimWinner,
+	comments: ReadonlyArray<ClaimComment>,
+	policy: AuditPolicy,
+): LaneReason => {
+	const before = isBefore(owner.createdAt, policy.cutoff);
+	const age = ageMs(owner.createdAt, policy.now);
+	if (before === null || age === null) return "indeterminate-age";
+	if (!before) return "post-cutoff";
+	if (age < policy.minAgeMs) return "within-safety-margin";
+	// Retirement runs through `claim release`, which retracts BY TOKEN — so a stamped marker from
+	// the same session would go with it. Holding here is what keeps the one retraction mechanism
+	// safe to reuse instead of forking a comment-id-scoped second one (#3780).
+	const restamped = comments.some(
+		(comment) =>
+			parseClaimSession(comment.body) === owner.session &&
+			parseClaimPresence(comment.body) !== null,
+	);
+	return restamped ? "session-restamped" : "pre-stamping";
+};
+
+/**
+ * Audit one lane: `null` when nothing authorized holds it, or when the holder carries a presence
+ * stamp — a stamped claim is resolved by ADR 0191 liveness and is none of this tool's business.
+ */
+export const auditLane = (input: LaneInput, policy: AuditPolicy): LockedLane | null => {
+	const owner = resolveWinner(input.comments, input.authorizedAuthors, input.liveness);
+	if (owner === null) return null;
+	const ownerComment = input.comments.find((comment) => comment.id === owner.id);
+	if (ownerComment === undefined || parseClaimPresence(ownerComment.body) !== null) return null;
+	const claims = authorizedClaims(input.comments, input.authorizedAuthors);
+	const shadowed = claims.filter(
+		(claim) =>
+			claim.createdAt > owner.createdAt ||
+			(claim.createdAt === owner.createdAt && claim.id > owner.id),
+	);
+	const reason = disposition(owner, input.comments, policy);
+	return {
+		issue: input.issue,
+		owner,
+		shadowed,
+		disposition: reason === "pre-stamping" ? "retire" : "hold",
+		reason,
+	};
+};
+
+export const auditReport = (inputs: ReadonlyArray<LaneInput>, policy: AuditPolicy): AuditReport => {
+	const locked: LockedLane[] = [];
+	for (const input of inputs) {
+		const lane = auditLane(input, policy);
+		if (lane !== null) locked.push(lane);
+	}
+	return {
+		scanned: inputs.length,
+		locked,
+		retirable: locked.filter((lane) => lane.disposition === "retire"),
+	};
+};

--- a/packages/pipeline-cli/src/tools/claim/claim-audit.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-audit.unit.test.ts
@@ -1,0 +1,198 @@
+import {assert, describe, it} from "@effect/vitest";
+import {type LocalPresence, livenessByComment, type PidState} from "../epic-lock/claim-presence.ts";
+import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
+import {
+	type AuditPolicy,
+	auditLane,
+	auditReport,
+	DEFAULT_MIN_AGE_HOURS,
+	type LaneInput,
+	STAMPING_CUTOFF,
+} from "./claim-audit.ts";
+import {claimIsMine} from "./claim-is-mine.ts";
+import {releasePlan} from "./claim-release.ts";
+
+const LEGACY = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const LIVE = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const HOST = "abc123def456";
+const AUTHORIZED = ["usirin"];
+
+const claim = (over: {
+	readonly id: number;
+	readonly session: string;
+	readonly at: string;
+	readonly presence?: string;
+	readonly login?: string;
+}): ClaimComment => ({
+	id: over.id,
+	author: over.login ?? "usirin",
+	createdAt: over.at,
+	body: `claim: ${over.session} · ${over.at}${over.presence ? ` · presence ${over.presence}` : ""}`,
+});
+
+const local = (probe: PidState): LocalPresence => ({host: HOST, probePid: () => probe});
+
+const policy = (over?: Partial<AuditPolicy>): AuditPolicy => ({
+	cutoff: STAMPING_CUTOFF,
+	minAgeMs: DEFAULT_MIN_AGE_HOURS * 60 * 60 * 1000,
+	now: "2026-07-28T00:00:00Z",
+	...over,
+});
+
+const lane = (issue: number, comments: ReadonlyArray<ClaimComment>): LaneInput => ({
+	issue,
+	comments,
+	authorizedAuthors: AUTHORIZED,
+	liveness: livenessByComment(comments, local("unprobeable")),
+});
+
+describe("auditLane — naming the pre-stamping population (#4031)", () => {
+	it("flags an unstamped pre-cutoff holder that shadows a later live claimant", () => {
+		// The #3718 shape: a 2026-07-20 unstamped marker outranking the session that opened the PR.
+		const legacy = claim({id: 5019741445, session: LEGACY, at: "2026-07-20T10:00:00Z"});
+		const live = claim({
+			id: 5077675710,
+			session: LIVE,
+			at: "2026-07-25T09:00:00Z",
+			presence: `${HOST}/4242`,
+		});
+
+		const audited = auditLane(lane(3718, [legacy, live]), policy());
+
+		assert.ok(audited !== null);
+		assert.strictEqual(audited.disposition, "retire");
+		assert.strictEqual(audited.reason, "pre-stamping");
+		assert.strictEqual(audited.owner.session, LEGACY);
+		assert.deepStrictEqual(
+			audited.shadowed.map((claimed) => claimed.session),
+			[LIVE],
+		);
+	});
+
+	it("ignores a lane whose holder carries a presence stamp — supersession already owns it", () => {
+		const stamped = claim({
+			id: 10,
+			session: LEGACY,
+			at: "2026-07-01T00:00:00Z",
+			presence: `${HOST}/4242`,
+		});
+
+		assert.strictEqual(auditLane(lane(1, [stamped]), policy()), null);
+	});
+
+	it("ignores a lane no authorized claim holds", () => {
+		const forged = claim({id: 10, session: LEGACY, at: "2026-07-01T00:00:00Z", login: "outsider"});
+
+		assert.strictEqual(auditLane(lane(1, [forged]), policy()), null);
+		assert.strictEqual(auditLane(lane(2, []), policy()), null);
+	});
+});
+
+describe("auditLane — every doubt holds the claim", () => {
+	it("holds an unstamped marker written after the cutoff (a degraded writer, not a legacy marker)", () => {
+		const degraded = claim({id: 10, session: LEGACY, at: "2026-07-26T00:00:00Z"});
+
+		const audited = auditLane(lane(1, [degraded]), policy());
+
+		assert.strictEqual(audited?.disposition, "hold");
+		assert.strictEqual(audited?.reason, "post-cutoff");
+	});
+
+	it("holds a pre-cutoff marker younger than the safety margin — its session may still run", () => {
+		const fresh = claim({id: 10, session: LEGACY, at: "2026-07-25T20:00:00Z"});
+
+		const audited = auditLane(lane(1, [fresh]), policy({now: "2026-07-25T22:00:00Z"}));
+
+		assert.strictEqual(audited?.disposition, "hold");
+		assert.strictEqual(audited?.reason, "within-safety-margin");
+	});
+
+	it("holds when the same session also left a stamped marker a token-scoped release would take", () => {
+		const legacy = claim({id: 10, session: LEGACY, at: "2026-07-20T10:00:00Z"});
+		const restamped = claim({
+			id: 11,
+			session: LEGACY,
+			at: "2026-07-26T10:00:00Z",
+			presence: `${HOST}/4242`,
+		});
+
+		const audited = auditLane(lane(1, [legacy, restamped]), policy());
+
+		assert.strictEqual(audited?.disposition, "hold");
+		assert.strictEqual(audited?.reason, "session-restamped");
+	});
+
+	it("holds a marker whose timestamp will not parse", () => {
+		const malformed = claim({id: 10, session: LEGACY, at: "not-a-date"});
+
+		const audited = auditLane(lane(1, [malformed]), policy());
+
+		assert.strictEqual(audited?.disposition, "hold");
+		assert.strictEqual(audited?.reason, "indeterminate-age");
+	});
+
+	it("never retires a stamped claim, whatever its age — the fail-closed rule is untouched", () => {
+		const ancient = claim({
+			id: 10,
+			session: LEGACY,
+			at: "2020-01-01T00:00:00Z",
+			presence: `${HOST}/4242`,
+		});
+
+		assert.strictEqual(auditLane(lane(1, [ancient]), policy({now: "2030-01-01T00:00:00Z"})), null);
+	});
+});
+
+describe("auditReport — the blast radius, and what retirement unlocks", () => {
+	it("separates the retirable subset from the lanes it must leave alone", () => {
+		const report = auditReport(
+			[
+				lane(1, [claim({id: 10, session: LEGACY, at: "2026-07-20T10:00:00Z"})]),
+				lane(2, [claim({id: 20, session: LEGACY, at: "2026-07-26T10:00:00Z"})]),
+				lane(3, [
+					claim({id: 30, session: LEGACY, at: "2026-07-01T00:00:00Z", presence: `${HOST}/1`}),
+				]),
+			],
+			policy(),
+		);
+
+		assert.strictEqual(report.scanned, 3);
+		assert.deepStrictEqual(
+			report.locked.map((held) => held.issue),
+			[1, 2],
+		);
+		assert.deepStrictEqual(
+			report.retirable.map((held) => held.issue),
+			[1],
+		);
+	});
+
+	it("retiring through `claim release` hands the lane to the live claimant", () => {
+		const legacy = claim({id: 5019741445, session: LEGACY, at: "2026-07-20T10:00:00Z"});
+		const live = claim({id: 5077675710, session: LIVE, at: "2026-07-25T09:00:00Z"});
+		const before = [legacy, live];
+
+		const audited = auditLane(lane(3718, before), policy());
+		assert.ok(audited !== null);
+		assert.strictEqual(audited.disposition, "retire");
+
+		// Retirement is `claim release` under the marker's own token — the one retraction
+		// mechanism (#3780), not a second one. It takes the legacy marker and nothing else.
+		const plan = releasePlan(before, audited.owner.session);
+		assert.deepStrictEqual(plan.retract, [5019741445]);
+		assert.deepStrictEqual(
+			plan.kept.map((kept) => kept.session),
+			[LIVE],
+		);
+
+		const after = before.filter((comment) => !plan.retract.includes(comment.id));
+		const verdict = claimIsMine({
+			comments: after,
+			authorizedAuthors: AUTHORIZED,
+			sessionId: LIVE,
+			liveness: livenessByComment(after, local("unprobeable")),
+		});
+		assert.strictEqual(verdict.mine, true);
+		assert.strictEqual(verdict.winner?.id, 5077675710);
+	});
+});

--- a/packages/pipeline-cli/src/tools/claim/command.ts
+++ b/packages/pipeline-cli/src/tools/claim/command.ts
@@ -1,5 +1,5 @@
 /**
- * The `claim` tool — `pipeline-cli claim is-mine|release|status --issue <N> [--session <sid>]`.
+ * The `claim` tool — `pipeline-cli claim is-mine|release|status|audit`.
  *
  * The issue-scoped "is this claim mine?" resolver (#3687): resolve the earliest
  * authorized claim on an arbitrary issue (ADR 0115 §2 / gh-issue-intake-formats.md
@@ -24,6 +24,13 @@
  * surface that makes a claim no release ever retracted visible instead of silently stranding a
  * lane. Neither verb evicts a claim it cannot prove is ours.
  *
+ * `audit` closes the one lifetime hole neither can reach (#4031): a marker written before every
+ * writer stamped presence (#3987) carries nothing for ADR 0191 liveness to evaluate, so it holds
+ * its lane forever and re-claiming cannot help. It names that bounded population across the open
+ * issues and, under `--execute`, retires each member through `release` under the marker's own
+ * token — reusing the one retraction mechanism rather than growing a second. The resolution rule
+ * is untouched: a stamped claim is never a candidate, whatever its age (`claim-audit.ts`).
+ *
  * The session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable
  * signal under the shared `usirin` login); `--session` overrides it for the
  * orchestrated/delegated-token path (`MY_CLAIM`) and for tests. An absent session id
@@ -34,6 +41,7 @@
  */
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {DEFAULT_MIN_AGE_HOURS, type LockedLane, STAMPING_CUTOFF} from "./claim-audit.ts";
 import type {ClaimVerdict} from "./claim-is-mine.ts";
 import {Github, GithubLive} from "./github.ts";
 
@@ -151,10 +159,80 @@ const status = Command.make(
 	),
 );
 
-export const claimCommand = Command.make("claim").pipe(
-	Command.withSubcommands([isMine, release, status]),
+const auditIssueFlag = Flag.integer("issue").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"audit this one lane instead of scanning every open issue (the cheap path when a stall is already known)",
+	),
+);
+
+const executeFlag = Flag.boolean("execute").pipe(
+	Flag.withDescription(
+		"retire the retirable markers through `claim release` (default: dry-run, report only)",
+	),
+);
+
+const minAgeFlag = Flag.integer("min-age-hours").pipe(
+	Flag.withDefault(DEFAULT_MIN_AGE_HOURS),
+	Flag.withDescription(
+		"how old a pre-cutoff marker must be before retirement will touch it — lower it for a claimant you have confirmed is gone, never to widen a bulk sweep",
+	),
+);
+
+const cutoffFlag = Flag.string("cutoff").pipe(
+	Flag.withDefault(STAMPING_CUTOFF),
+	Flag.withDescription(
+		"ISO-8601 UTC instant after which every claim writer stamps presence (default: this repo's stamping era)",
+	),
+);
+
+/** One report row: the lane, the marker holding it, its disposition, and what it is shadowing. */
+const laneLine = (lane: LockedLane): string =>
+	`  #${lane.issue}\t${lane.disposition === "retire" ? "RETIRE" : "hold  "}\t${lane.reason}\t` +
+	`marker ${lane.owner.id} (${lane.owner.session}, ${lane.owner.createdAt})` +
+	(lane.shadowed.length === 0 ? "" : `\tshadowing ${lane.shadowed.length} later claim(s)`);
+
+const audit = Command.make(
+	"audit",
+	{issue: auditIssueFlag, execute: executeFlag, minAgeHours: minAgeFlag, cutoff: cutoffFlag},
+	Effect.fn(function* ({issue, execute, minAgeHours, cutoff}) {
+		const scoped = Option.getOrNull(issue);
+		const {report, retired} = yield* (yield* Github).audit({
+			issues: scoped === null ? null : [scoped],
+			policy: {cutoff, minAgeMs: minAgeHours * 60 * 60 * 1000, now: new Date().toISOString()},
+			execute,
+		});
+		yield* Console.log(
+			JSON.stringify({cutoff, minAgeHours, executed: execute, ...report, retired}),
+		);
+		if (report.scanned === 0) {
+			// Fail closed on an empty scan (ADR 0092): "no lane is locked" and "the scan read nothing"
+			// are the same output otherwise, and the second is a broken read reported as a clean bill.
+			process.stderr.write(
+				"claim: audit scanned ZERO lanes — refusing to report a clean audit off an empty scan. Check `gh` auth and the resolved repo.\n",
+			);
+			process.exit(REFUSE_EXIT_CODE);
+			return;
+		}
+		for (const lane of report.locked) process.stderr.write(`${laneLine(lane)}\n`);
+		process.stderr.write(
+			`claim: audit scanned ${report.scanned} lane(s): ${report.locked.length} held by an unstamped marker, ` +
+				`${report.retirable.length} retirable (pre-stamping, aged past ${minAgeHours}h). ` +
+				(execute
+					? `Retired ${retired.length} through \`claim release\`.\n`
+					: "Dry run — re-run with --execute to retire them.\n"),
+		);
+	}),
+).pipe(
 	Command.withDescription(
-		"Resolve, release, and inspect issue claims (ADR 0115 earliest-authorized-claim): default-deny 'is this mine', affirmative self-release, and the stale-claim inventory",
+		"Audit open lanes for pre-stamping claim markers no liveness can supersede, and retire the bounded legacy population through `claim release`",
+	),
+);
+
+export const claimCommand = Command.make("claim").pipe(
+	Command.withSubcommands([isMine, release, status, audit]),
+	Command.withDescription(
+		"Resolve, release, and inspect issue claims (ADR 0115 earliest-authorized-claim): default-deny 'is this mine', affirmative self-release, the stale-claim inventory, and the pre-stamping legacy audit",
 	),
 	Command.provide(GithubLive),
 );

--- a/packages/pipeline-cli/src/tools/claim/github.ts
+++ b/packages/pipeline-cli/src/tools/claim/github.ts
@@ -20,6 +20,13 @@ import {livenessByComment} from "../epic-lock/claim-presence.ts";
 import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
 import {localPresence} from "../epic-lock/presence-io.ts";
 import {deleteCommentArgs} from "../tracker/gh-io.ts";
+import {
+	type AuditPolicy,
+	type AuditReport,
+	auditReport,
+	type LaneInput,
+	type LockedLane,
+} from "./claim-audit.ts";
 import {type ClaimVerdict, claimIsMine} from "./claim-is-mine.ts";
 import {type ReleasePlan, releasePlan} from "./claim-release.ts";
 import {type ClaimStatus, claimStatus} from "./claim-status.ts";
@@ -266,6 +273,91 @@ const status = Effect.fn("Github.status")(function* (repo: string, issue: number
 	return claimStatus({comments, authorizedAuthors: authorized, liveness});
 });
 
+/** An open-issue row; `pull_request` is how the issues endpoint marks the PRs it also returns. */
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	comments: Schema.optionalKey(Schema.Number),
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+const decodeIssues = Schema.decodeUnknownEffect(Schema.Array(RawIssue));
+
+const listOpenIssuesArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues?state=open&per_page=100`,
+];
+
+/**
+ * The open issues that could carry a claim: PRs dropped (a claim lives on the issue), and so are
+ * issues with zero comments — a marker IS a comment, so that filter removes ~60% of the per-issue
+ * comment reads without changing the result.
+ */
+const auditScope = Effect.fn("Github.auditScope")(function* (repo: string) {
+	const rows = yield* decodeIssues(yield* json(listOpenIssuesArgs(repo)));
+	return rows
+		.filter((row) => row.pull_request === undefined && (row.comments ?? 0) > 0)
+		.map((row) => row.number);
+});
+
+/** How many issues' comments are read at once — bounded so a full scan can't burst the API. */
+const AUDIT_CONCURRENCY = 8;
+
+/**
+ * Audit the open lanes for pre-stamping claim holders, and — when `execute` is set — retire the
+ * ones the pure policy proved retirable.
+ *
+ * Two things are deliberate. The write+ author set and this machine's presence are each resolved
+ * **once** for the whole scan rather than per lane: the author probe is one REST call per distinct
+ * login, and `localPresence()` spawns `ioreg`/`ps`, so per-lane resolution would turn a hundred-lane
+ * scan into hundreds of subprocesses. And retirement calls the same `release` the `claim release`
+ * verb calls, under the marker's own token — one retraction mechanism, never a second (#3780).
+ */
+const audit = Effect.fn("Github.audit")(function* (
+	repo: string,
+	options: {
+		readonly issues: ReadonlyArray<number> | null;
+		readonly policy: AuditPolicy;
+		readonly execute: boolean;
+	},
+) {
+	const issues = options.issues ?? (yield* auditScope(repo));
+	const commentsByIssue = yield* Effect.forEach(
+		issues,
+		(issue) => listClaimComments(repo, issue).pipe(Effect.map((comments) => ({issue, comments}))),
+		{concurrency: AUDIT_CONCURRENCY},
+	);
+	const authors = [
+		...new Set(
+			commentsByIssue
+				.flatMap((lane) => lane.comments.map((c) => c.author))
+				.filter((a) => a.length > 0),
+		),
+	];
+	const authorized = yield* authorizedAuthors(repo, authors);
+	const local = localPresence();
+	const inputs = commentsByIssue.map(
+		(lane): LaneInput => ({
+			issue: lane.issue,
+			comments: lane.comments,
+			authorizedAuthors: authorized,
+			liveness: livenessByComment(lane.comments, local),
+		}),
+	);
+	const report = auditReport(inputs, options.policy);
+	if (!options.execute) return {report, retired: [] as ReadonlyArray<LockedLane>};
+	yield* Effect.forEach(report.retirable, (lane) => release(repo, lane.issue, lane.owner.session), {
+		concurrency: AUDIT_CONCURRENCY,
+		discard: true,
+	});
+	return {report, retired: report.retirable};
+});
+
+/** What an audit run produced: the blast-radius report, and the lanes retirement actually took. */
+export interface AuditResult {
+	readonly report: AuditReport;
+	readonly retired: ReadonlyArray<LockedLane>;
+}
+
 /**
  * `Github` — the IO shell over `gh api` REST behind the three `claim` verbs: `isMine`
  * (the default-deny `ClaimVerdict`), `release` (retract our own marker when the run is
@@ -296,6 +388,14 @@ export class Github extends Context.Service<
 			ClaimStatus,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
 		>;
+		readonly audit: (options: {
+			readonly issues: ReadonlyArray<number> | null;
+			readonly policy: AuditPolicy;
+			readonly execute: boolean;
+		}) => Effect.Effect<
+			AuditResult,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
 	}
 >()("@kampus/claim/Github") {}
 
@@ -320,6 +420,7 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 				release: (issue: number, sessionId: string) =>
 					repo.pipe(Effect.flatMap((r) => withSpawner(release(r, issue, sessionId)))),
 				status: (issue: number) => repo.pipe(Effect.flatMap((r) => withSpawner(status(r, issue)))),
+				audit: (options) => repo.pipe(Effect.flatMap((r) => withSpawner(audit(r, options)))),
 			};
 		}),
 	);

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
@@ -87,8 +87,13 @@ export type ClaimOutcome =
 	| {readonly _tag: "won"; readonly winner: ClaimWinner}
 	| {readonly _tag: "lost"; readonly winner: ClaimWinner};
 
-/** Every authorized claim on the target, ordered earliest-first by `(createdAt, id)`. */
-const authorizedClaims = (
+/**
+ * Every authorized claim on the target, ordered earliest-first by `(createdAt, id)`. Exported
+ * so a consumer that needs the whole ordered set — the legacy audit, which reports what an
+ * unstamped holder is shadowing — reads it here rather than re-deriving the ADR 0055 filter and
+ * the ADR 0115 §2 ordering a second time.
+ */
+export const authorizedClaims = (
 	comments: ReadonlyArray<ClaimComment>,
 	authorizedAuthors: ReadonlyArray<string>,
 ): ReadonlyArray<ClaimWinner> => {


### PR DESCRIPTION
Some issues in the tracker are held by a claim marker so old that nothing can ever release it. Presence stamping — the thing that lets us prove a claimant is gone — only arrived recently, and a marker written before it carries nothing to check, so it wins the ownership tiebreak forever. Claiming the issue again does not help, because a new claim is always later than the one blocking it. This adds a command that lists every such issue and retires the ones that are provably from the old era, through the release mechanism that already exists.

## The defect

`claimLiveness` can only return `dead` for a marker that carries a presence stamp, and `dead` is the only value `resolveWinner` acts on. An unstamped marker is absent from the liveness map, counts as live, and wins the earliest-authorized-claim tiebreak unconditionally. So the ADR 0191 supersession path (#3751) is structurally inert against the entire pre-stamping population, and every open issue holding one of those markers is a lane no agent can repair — silently, until a dispatch hits the coder's mis-attribution guard and (correctly) refuses.

## The shape: a bounded cleanup, not a resolution-rule change

The population predates a fixed instant (the merge of #4015, which routed the last writer through the one presence-stamping producer) and only shrinks, so it is cleared by an audit, not by loosening how claims resolve. Concretely:

- `packages/pipeline-cli/src/tools/claim/claim-audit.ts` — the pure policy. `auditLane` reports a lane whose *owning* marker carries no stamp, and marks it retirable only when the marker (1) predates the stamping cutoff, (2) has aged past a safety margin, and (3) is the only shape its session left on that lane. Everything else is reported and **held**, each with its reason: `post-cutoff` (a stamping writer that degraded — `presence-io.ts` emits no stamp when it cannot read the process table or this machine's identity — which may be a running agent), `within-safety-margin`, `session-restamped`, `indeterminate-age`.
- `pipeline-cli claim audit [--issue N] [--execute] [--min-age-hours H] [--cutoff ISO]` — the blast-radius report by default; `--execute` retires the retirable set.
- Retirement calls the **existing** `claim release` under the marker's own token — one retraction mechanism, reconciled with #3780, never a second. The `session-restamped` hold is what makes that token-scoped reuse safe: it stops a release from taking a stamped marker the same session left on the lane.
- `authorizedClaims` is exported from the shared resolution core so the audit can report what a holder is shadowing without re-deriving the ADR 0055 author filter and the ADR 0115 §2 ordering.

## The load-bearing constraint holds

The resolver is untouched. `resolveWinner`, `claimIsMine`, and `claimStatus` read nothing from this module, and a **stamped** claim is never a candidate for retirement whatever its age — so no TTL and no doubt-based eviction enters the fail-closed path. No margin *proves* a claimant is gone, which is why `--execute` stays an operator act on a report that names each session rather than an automatic sweep, and why the default margin is 48h (claims are also written by long-lived crew engine sessions, not just minutes-long coder runs).

Because supersession policy is unchanged, the AC clause that would route this to #4000's ADR does not fire; the audit is a cleanup tool, and #4000 remains free to record the policy question on its own terms.

## Acceptance criteria

- **Blast radius measured.** `pipeline-cli claim audit` over the live repo: 102 open lanes scanned, 3 held by an unstamped marker (#3943, #3870, #3366 — all three the same session), 1 currently retirable. The report names the marker id, session, and timestamp per lane.
- **Remediation path exists, reconciled with #3780.** `claim audit --execute` retires through `claim release`; no second retraction mechanism.
- **#3718 resolves to the live claimant.** Verified: `claim is-mine --issue 3718` now returns `won` for session `ddf8f459…` (marker `5077675710`, the session that opened PR #4028). Marker `5019741445` no longer exists on the issue — it was cleared by hand before this branch; what this PR adds is the audited, repeatable way to do that.
- **Fail-closed for stamped claims untouched.** Covered by a unit test that a stamped marker is never a candidate even at ten years old.
- **No supersession policy change**, so nothing to record against #4000.

Gates run locally: `pnpm typecheck` clean, `pnpm lint:worktree` clean, the full `@kampus/pipeline-cli` suite green (2370 tests), and the pre-push apps unit suite green (2406 tests).

Control plane: this touches `packages/pipeline-cli/**` and `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, both §CP — a human merges it.

Fixes #4031
