### PR TITLE
fix(ship-it): corroborate the Step 5.5 reconcile against the base branch, and bound the ejection window

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -2066,9 +2066,10 @@ reconcile shells out to it per poll and branches on the printed outcome word:
 # a PR still QUEUED at the budget's end is a well-formed pending, not a failure.
 # The classifier reads PR state (gh pr view — the sanctioned PR-state read ship-it Step 2 uses,
 # NOT a GraphQL intake query the org's Projects-classic integration breaks) + the last merge-queue
-# timeline event (gh api …/timeline, REST) and prints merged/ejected/queued/pending. It is
-# fail-closed away from a false ship: any unreadable signal ⇒ pending (keep polling), never a
-# false merged/ejected.
+# timeline event (gh api …/timeline, REST), cross-checks a non-merged read against the base branch
+# (gh api …/commits?sha=<base>, the read that stayed fresh while the other two lagged — #4057), and
+# prints merged/ejected/queued/pending. It is fail-closed away from a false ship: any unreadable
+# signal ⇒ pending (keep polling), never a false merged/ejected.
 RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-10}   # ~10 polls
 RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}   # ~30s apart ⇒ ~5 min batch window
 MERGE_OUTCOME=pending
@@ -2098,6 +2099,37 @@ else
 fi
 ```
 
+#### The timeline is authoritative but not timely — the freshness cross-check and the ejection window this reconcile accepts (#4057)
+
+During the #4011 ship the merge landed at `20:06:39Z` and, for the next ~65 minutes, `pulls/4011`
+kept returning `merged:false` / `state:open` while the issue timeline kept ending at
+`added_to_merge_queue`. The classifier read both faithfully and printed `queued` on 15 consecutive
+polls after the PR had already merged. Two consequences follow — one closed, one accepted:
+
+- **Closed — a stale `queued` on an already-merged PR.** The base branch stayed current through
+  that whole window, so the classifier corroborates a non-merged read against it: a **single-parent
+  commit reachable from the base branch whose subject ends with `(#PR)`** is this PR's squash, and
+  it classifies `merged` whatever the PR-state and timeline reads say. The scan window is the base
+  branch's most recent 100 commits. An absent or unreadable base-branch read carries **no**
+  evidence and never moves the verdict, so the fail-closed posture is untouched.
+- **Accepted — a not-yet-surfaced *ejection*.** `removed_from_merge_queue` is the only ejection
+  signal REST exposes, and the base-branch cross-check cannot substitute for it: an ejected PR and
+  a healthy queued one are identical in every REST read (open, not merged, last event
+  `added_to_merge_queue`, no squash on the base). The read that would tell them apart — the queue's
+  own entries — is **GraphQL-only**, which this org bans (top of this skill). So the residual is
+  accepted, with this bound: **while the timeline lags — ~60 minutes observed, unbounded in
+  principle — an ejected PR classifies `queued`.** What contains it is not over-reading that word.
+  A terminal `queued` means *still in-flight as far as the timeline can tell*, never *healthy,
+  never ejected*: it is not reported as shipped, guard 6 leaves an arm only where a live queue
+  entry exists, and the ejection surfaces on any later read once the timeline catches up — a
+  re-dispatched ship-it, or the driving loop's next pass over the PR.
+
+**The adjacent trap, pinned:** on an **open** PR, `merge_commit_sha` holds GitHub's throwaway
+*test-merge* commit and is evidence of nothing — PR #4011 carried `8dd72534…` there for an hour
+while unmerged. The load-bearing merge signals are `merged` / `merged_at`, plus the single-parent
+squash on the base branch. Never read a non-null `merge_commit_sha` as "it merged", and never
+cross-check it against the base tip.
+
 Then act on `MERGE_OUTCOME`, and only here — **never at Step 4's enqueue** — decide the run's
 merge disposition:
 
@@ -2108,8 +2140,9 @@ merge disposition:
   `pending` is the **enqueue-settle window** (OPEN, not merged, no merge-queue event yet — incl.
   OPEN + CLEAN before the CLEAN → QUEUED flip). **Both are a well-formed pending, not a failure**
   (ADR 0132: the actor does not block to the final merge). Report `enqueued: yes (→ auto-merges on
-  green)` exactly as before — the reconcile confirmed it was **still in-flight, never ejected**,
-  within the window. A `pending` PR at the budget's end is reported this way too — the settle window
+  green)` exactly as before — the reconcile confirmed it was **still in-flight as far as the
+  timeline can tell** within the window, which is not the same as "never ejected" (the accepted
+  staleness bound above). A `pending` PR at the budget's end is reported this way too — the settle window
   is **never** an ejection (#1921). **One carve-out** (guard 6): on a base branch a **merge queue
   governs** — every PR in this repo — a `pending` PR never entered the queue at all, so what it
   carries is a parked intent, not an in-flight enqueue; the guard-6 block above clears it and the
@@ -2139,9 +2172,11 @@ merge disposition:
   the re-approval alone (ADR 0198). The ejection is surfaced and handed to the repair /
   re-queue lane (the `drive-issue.js` shipper stage consumes `ejected` and re-drives), the same
   fail → fix → re-request boundary write-code owns. The **success/watch distinction is now
-  observable** — `QUEUED` never masks a stall, because the reconcile separated `merged` from
-  `queued`/`pending` from `ejected` off the authoritative merge-queue timeline event, so an
-  enqueue-settle window no longer masquerades as an ejection (#1921).
+  observable** — a surfaced ejection never masks as a ship, because the reconcile separated `merged`
+  from `queued`/`pending` from `ejected` off the authoritative merge-queue timeline event, so an
+  enqueue-settle window no longer masquerades as an ejection (#1921) and a lagging timeline no
+  longer holds a landed merge at `queued` (#4057). An ejection the timeline has not yet surfaced is
+  the one residual, bounded above.
 
 This reconcile **weakens no existing gate**: Step 0's §CP refusal, Step 2/2b's current-head PASS,
 Step 3's green CI, Step 3.5's run-evidence bundle, and the single-merge-authority contract (ADRs

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/github-service.unit.test.ts
@@ -35,13 +35,15 @@ const normalize = (response: Response): Canned =>
 	typeof response === "string" ? {stdout: response} : response;
 
 /**
- * A `ChildProcessSpawner` answering the two reads `signals` makes: `gh pr view … --json` from
- * `prState`, and `gh api …/timeline` from `timeline`; plus `gh repo view` from `repoView`. An
- * unprovided read exits 1 (the read-failure path the fail-closed posture recovers from).
+ * A `ChildProcessSpawner` answering the three reads `signals` makes: `gh pr view … --json` from
+ * `prState`, `gh api …/timeline` from `timeline`, and `gh api …/commits?sha=…` from `baseCommits`;
+ * plus `gh repo view` from `repoView`. An unprovided read exits 1 (the read-failure path the
+ * fail-closed posture recovers from).
  */
 const mockSpawner = (fixture: {
 	readonly prState?: Response;
 	readonly timeline?: Response;
+	readonly baseCommits?: Response;
 	readonly repoView?: Response;
 }): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
 	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
@@ -53,6 +55,7 @@ const mockSpawner = (fixture: {
 				const isPrView = args[0] === "pr" && args[1] === "view";
 				const isRepoView = args[0] === "repo" && args[1] === "view";
 				const isTimeline = args.some((a) => a.includes("/timeline"));
+				const isBaseCommits = args.some((a) => a.includes("/commits?sha="));
 				const pick = (): Response | undefined =>
 					isPrView
 						? fixture.prState
@@ -60,7 +63,9 @@ const mockSpawner = (fixture: {
 							? fixture.repoView
 							: isTimeline
 								? fixture.timeline
-								: undefined;
+								: isBaseCommits
+									? fixture.baseCommits
+									: undefined;
 				const found = pick();
 				const canned = found ? normalize(found) : {stdout: "", exitCode: 1, stderr: "not found"};
 				return ChildProcessSpawner.makeHandle({
@@ -86,8 +91,15 @@ const provide = <A, E>(
 ): Effect.Effect<A, E | RepoResolutionError> =>
 	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(fixture)))));
 
-const prView = (state: string, mergeStateStatus?: string): string =>
-	JSON.stringify({state, mergeStateStatus: mergeStateStatus ?? null});
+const prView = (state: string, mergeStateStatus?: string, baseRefName?: string): string =>
+	JSON.stringify({
+		state,
+		mergeStateStatus: mergeStateStatus ?? null,
+		baseRefName: baseRefName ?? null,
+	});
+
+const baseCommits = (...subjects: ReadonlyArray<string>): string =>
+	JSON.stringify(subjects.map((message) => ({message, parents: 1})));
 
 const timelineEvents = (...events: ReadonlyArray<string>): string =>
 	JSON.stringify(events.map((event, i) => ({event, created_at: `2026-01-01T00:0${i}:00Z`})));
@@ -153,6 +165,55 @@ describe("Github.signals — the ground-truth reads over a mock gh spawner (#273
 				assert.strictEqual(signals.lastMergeQueueEvent, null);
 				assert.strictEqual(classify(signals).outcome, "pending");
 			}).pipe((effect) => provide(effect, {prState: prView("OPEN", "CLEAN")})),
+	);
+
+	it.effect(
+		"the #4057 stale-timeline case: PR + timeline both lag, but the base branch carries the squash ⇒ merged",
+		() =>
+			Effect.gen(function* () {
+				const signals = yield* (yield* Github).signals(4011, REPO);
+				assert.strictEqual(signals.merged, false);
+				assert.strictEqual(signals.lastMergeQueueEvent, "added_to_merge_queue");
+				assert.strictEqual(signals.baseBranchSquash, "landed");
+				assert.strictEqual(classify(signals).outcome, "merged");
+			}).pipe((effect) =>
+				provide(effect, {
+					prState: prView("OPEN", "QUEUED", "main"),
+					timeline: timelineEvents("added_to_merge_queue"),
+					baseCommits: baseCommits("fix(ship-it): a thing (#4011)", "chore: another (#4012)"),
+				}),
+			),
+	);
+
+	it.effect(
+		"fail-closed: an unreadable base branch recovers to `unreadable`, leaving the timeline verdict",
+		() =>
+			Effect.gen(function* () {
+				// The base-commits read exits 1 (unprovided). No evidence must never promote a verdict.
+				const signals = yield* (yield* Github).signals(4011, REPO);
+				assert.strictEqual(signals.baseBranchSquash, "unreadable");
+				assert.strictEqual(classify(signals).outcome, "queued");
+			}).pipe((effect) =>
+				provide(effect, {
+					prState: prView("OPEN", "QUEUED", "main"),
+					timeline: timelineEvents("added_to_merge_queue"),
+				}),
+			),
+	);
+
+	it.effect("a merged PR skips the base-branch read entirely (nothing left to corroborate)", () =>
+		Effect.gen(function* () {
+			// No `baseCommits` fixture: had the read been made it would have exited 1, and the
+			// undefined field is what proves it was skipped rather than recovered.
+			const signals = yield* (yield* Github).signals(4011, REPO);
+			assert.strictEqual(signals.baseBranchSquash, undefined);
+			assert.strictEqual(classify(signals).outcome, "merged");
+		}).pipe((effect) =>
+			provide(effect, {
+				prState: prView("MERGED", undefined, "main"),
+				timeline: timelineEvents("added_to_merge_queue", "removed_from_merge_queue"),
+			}),
+		),
 	);
 
 	it.effect("an unreadable PR state fails GhCommandError (the command maps it to pending)", () =>

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
@@ -13,19 +13,29 @@
  * as a typed `E` the command handles rather than an invisible defect.
  *
  * One verb, `signals(pr)`, resolves the whole `MergeQueueSignals` input: the PR `state` +
- * `mergeStateStatus` from `gh pr view`, and the LAST merge-queue timeline event from
- * `gh api .../timeline`. The fail-closed-away-from-a-false-ship posture is preserved exactly:
- * an unreadable repo or PR state propagates as a typed error the command maps to `pending`, and
- * an unreadable timeline is deliberately recovered to "no event yet" (the settle window) — a
- * classifier miss can only ever keep polling, never report a false `merged`/`ejected`.
+ * `mergeStateStatus` + `baseRefName` from `gh pr view`, the LAST merge-queue timeline event from
+ * `gh api .../timeline`, and — when the PR does not already read merged — whether the base branch
+ * carries the PR's squash, from `gh api .../commits?sha=<base>` (#4057). The
+ * fail-closed-away-from-a-false-ship posture is preserved exactly: an unreadable repo or PR state
+ * propagates as a typed error the command maps to `pending`; an unreadable timeline is deliberately
+ * recovered to "no event yet" (the settle window); an unreadable base branch is recovered to
+ * `unreadable`, which carries no evidence. A read fault can only ever keep polling, never report a
+ * false `merged`/`ejected`.
+ *
+ * The PR field this boundary deliberately does NOT read is `merge_commit_sha`: on an OPEN PR it
+ * holds GitHub's throwaway *test-merge* commit, so it is evidence of nothing. The load-bearing
+ * merge signals are `merged`/`merged_at` (here: `state == MERGED`) and the single-parent squash on
+ * the base branch. Do not "improve" this read by comparing `merge_commit_sha` to the base tip.
  */
 import {Config, Context, Effect, Layer, Option, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {
+	type BaseBranchSquash,
 	type LastMergeQueueEvent,
 	lastMergeQueueEvent,
 	type MergeQueueSignals,
+	squashOnBaseBranch,
 } from "./merge-queue-classify.ts";
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
@@ -145,8 +155,9 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 // REST-only arg builders — never GraphQL.
 
 /**
- * `gh pr view --json` for the two working fields (the old `merged` field errors
+ * `gh pr view --json` for the three working fields (the old `merged` field errors
  * `Unknown JSON field` on this gh/repo, #1921); `merged` is derived from `state == MERGED`.
+ * `baseRefName` names the branch the squash cross-check scans (#4057).
  */
 const prStateArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	"pr",
@@ -155,9 +166,9 @@ const prStateArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	"--repo",
 	repo,
 	"--json",
-	"state,mergeStateStatus",
+	"state,mergeStateStatus,baseRefName",
 	"--jq",
-	"{state: .state, mergeStateStatus: .mergeStateStatus}",
+	"{state: .state, mergeStateStatus: .mergeStateStatus, baseRefName: .baseRefName}",
 ];
 
 /** The REST issue-timeline endpoint (never GraphQL) — the authoritative queue-membership signal. */
@@ -167,10 +178,27 @@ const timelineArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	"--paginate",
 ];
 
-/** The PR state as `gh pr view` returns it; `state`/`mergeStateStatus` may be absent or null. */
+/**
+ * The scan window of the base-branch squash cross-check: the base branch's most recent commits.
+ * Bounded on purpose — the window only has to span the staleness it corrects (~30–60 min observed,
+ * a few dozen commits at fleet pace), and an unbounded `--paginate` walk would grow with repo age
+ * on every poll. A squash older than the window reads `absent`, which is the no-evidence value.
+ */
+const BASE_BRANCH_SCAN = 100;
+
+/** REST list-commits on the base branch, projected to the two fields the squash predicate reads. */
+const baseCommitsArgs = (repo: string, base: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/commits?sha=${base}&per_page=${BASE_BRANCH_SCAN}`,
+	"--jq",
+	"[.[] | {message: .commit.message, parents: (.parents | length)}]",
+];
+
+/** The PR state as `gh pr view` returns it; every field may be absent or null. */
 const RawPrState = Schema.Struct({
 	state: Schema.optionalKey(Schema.NullOr(Schema.String)),
 	mergeStateStatus: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	baseRefName: Schema.optionalKey(Schema.NullOr(Schema.String)),
 });
 const decodePrState = Schema.decodeUnknownEffect(RawPrState);
 
@@ -181,11 +209,19 @@ const RawTimelineEntry = Schema.Struct({
 });
 const decodeTimeline = Schema.decodeUnknownEffect(Schema.Array(RawTimelineEntry));
 
+/** A base-branch commit as the `--jq` projection above emits it. */
+const RawBaseCommit = Schema.Struct({
+	message: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	parents: Schema.optionalKey(Schema.NullOr(Schema.Number)),
+});
+const decodeBaseCommits = Schema.decodeUnknownEffect(Schema.Array(RawBaseCommit));
+
 /** The PR state read the classifier consumes — `merged` derived from `state == MERGED`. */
 interface PrState {
 	readonly merged: boolean;
 	readonly state: string;
 	readonly mergeStateStatus: string | undefined;
+	readonly baseRefName: string;
 }
 
 const toPrState = (raw: (typeof RawPrState)["Type"]): PrState => {
@@ -194,6 +230,7 @@ const toPrState = (raw: (typeof RawPrState)["Type"]): PrState => {
 		merged: state === "MERGED",
 		state,
 		mergeStateStatus: raw.mergeStateStatus ?? undefined,
+		baseRefName: raw.baseRefName ?? "",
 	};
 };
 
@@ -240,14 +277,47 @@ const readLastMergeQueueEvent = Effect.fn("Github.readLastMergeQueueEvent")(
 		),
 );
 
+/**
+ * Whether the base branch carries this PR's squash (#4057). An unreadable base branch recovers to
+ * `unreadable` for the same fail-closed reason the timeline recovers to the settle window: no
+ * evidence never promotes a verdict, so a fault here can only leave the reconcile polling.
+ */
+const readBaseBranchSquash = Effect.fn("Github.readBaseBranchSquash")(
+	function* (repo: string, pr: number, base: string) {
+		if (base === "") return "unreadable" as const;
+		const args = baseCommitsArgs(repo, base);
+		const commits = yield* decodeBaseCommits(yield* parseJson(args, yield* runGh(args)));
+		return squashOnBaseBranch(
+			commits.map((c) => ({message: c.message ?? undefined, parents: c.parents ?? undefined})),
+			pr,
+		);
+	},
+	(effect) =>
+		effect.pipe(
+			Effect.catchTags({
+				"@kampus/merge-queue-classify/GhCommandError": () =>
+					Effect.succeed<BaseBranchSquash>("unreadable"),
+				"@kampus/merge-queue-classify/GhParseError": () =>
+					Effect.succeed<BaseBranchSquash>("unreadable"),
+				SchemaError: () => Effect.succeed<BaseBranchSquash>("unreadable"),
+			}),
+		),
+);
+
 const readSignals = Effect.fn("Github.signals")(function* (repo: string, pr: number) {
 	const prState = yield* readPrState(repo, pr);
 	const lastEvent = yield* readLastMergeQueueEvent(repo, pr);
+	// Not read once the PR itself reads merged: the cross-check exists to correct a stale
+	// not-merged read, so there is nothing left for it to corroborate.
+	const baseBranchSquash = prState.merged
+		? undefined
+		: yield* readBaseBranchSquash(repo, pr, prState.baseRefName);
 	return {
 		merged: prState.merged,
 		state: prState.state,
 		lastMergeQueueEvent: lastEvent,
 		mergeStateStatus: prState.mergeStateStatus,
+		baseBranchSquash,
 	} satisfies MergeQueueSignals;
 });
 
@@ -257,7 +327,8 @@ const readSignals = Effect.fn("Github.signals")(function* (repo: string, pr: num
  * `repoOverride` (the CLI `--repo` flag, ADR 0062 §1's highest precedence) wins over the resolved
  * repo, else the repo is resolved once (`RepoResolutionError`). An unreadable PR state propagates
  * typed (the command maps it to `pending`); an unreadable timeline is recovered to the settle
- * window. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ * window, and an unreadable base branch to `unreadable`. Built by `GithubLive`, whose `R` is
+ * `ChildProcessSpawner`.
  */
 export class Github extends Context.Service<
 	Github,

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.ts
@@ -22,6 +22,14 @@
  * `mergeStateStatus` is retained only as a *positive* still-queued hint (`QUEUED`),
  * never as the ejection discriminator.
  *
+ * Those two reads are authoritative but **not timely**: during the #4011 ship both lagged
+ * the true merge state by ~30–60 minutes, so the classifier printed `queued` on 15 polls
+ * after the PR had already merged. The base branch stayed current throughout, so a third
+ * signal corroborates a non-merged read — `baseBranchSquash`, whether the base branch
+ * already carries this PR's single-parent squash (#4057). It only ever promotes to
+ * `merged`; absence carries no evidence, which keeps the classifier fail-closed away from
+ * a false ship.
+ *
  * The IO lives in `command.ts` (the thin bin, which reads the PR state + timeline via
  * `gh`); this file is the pure predicate over already-resolved ground-truth signals so
  * the classification contract is unit-testable without a live queue (ADR 0082; the
@@ -30,6 +38,15 @@
 
 /** The last merge-queue timeline event observed for the PR, or `null` when none yet exists. */
 export type LastMergeQueueEvent = "added_to_merge_queue" | "removed_from_merge_queue" | null;
+
+/**
+ * Whether the base branch already carries this PR's squash (the freshness cross-check above):
+ *   - `landed`     — a single-parent base-branch commit carries this PR's squash subject.
+ *   - `absent`     — the scanned window carries no such commit. NOT an ejection signal — a
+ *                    healthy queued PR and an ejected one both read `absent`.
+ *   - `unreadable` — the read faulted or was not made. No evidence at all.
+ */
+export type BaseBranchSquash = "landed" | "absent" | "unreadable";
 
 /** The ground-truth signals the reconcile reads per poll — the classifier's whole input. */
 export interface MergeQueueSignals {
@@ -48,6 +65,11 @@ export interface MergeQueueSignals {
 	 * (`QUEUED`), never to infer ejection. Optional: absent ⇒ treated as unknown.
 	 */
 	readonly mergeStateStatus?: string | undefined;
+	/**
+	 * Whether the base branch carries this PR's squash. Optional: absent ⇒ the read was not
+	 * made ⇒ no evidence, exactly like `unreadable`.
+	 */
+	readonly baseBranchSquash?: BaseBranchSquash | undefined;
 }
 
 /**
@@ -57,6 +79,9 @@ export interface MergeQueueSignals {
  *                 `removed_from_merge_queue`. Route back to repair/re-queue.
  *   - `queued`  — still in the queue: NOT merged AND (last event is
  *                 `added_to_merge_queue` OR `mergeStateStatus == QUEUED`). Keep polling.
+ *                 It is not proof of health — an ejection that has not yet surfaced in the
+ *                 timeline reads identically (the residual window ship-it Step 5.5 accepts
+ *                 and bounds, #4057).
  *   - `pending` — the enqueue-settle window: NOT merged, OPEN, and NO merge-queue event
  *                 yet (incl. OPEN + CLEAN before the QUEUED flip). NEVER an ejection.
  */
@@ -78,6 +103,9 @@ const at = (outcome: MergeOutcome, reason: string): Classification => ({outcome,
  *      landed merge outranks any stale queue event (the final `removed_from_merge_queue`
  *      the queue emits *as* it merges must not read as an ejection — #1906 carried both
  *      events, but it merged).
+ *   1b. `merged` — the base branch already carries this PR's squash. Ranked with (1), above
+ *      the ejection check, for the same reason (1) is first: a landed merge outranks both a
+ *      stale not-merged read and the removal event the queue emits as it merges.
  *   2. `ejected` — NOT merged AND last merge-queue event is `removed_from_merge_queue`.
  *      This is the ONLY ejection signal: a genuine dequeue, not a momentary state read.
  *   3. `queued` — NOT merged AND (last event `added_to_merge_queue` OR
@@ -93,6 +121,12 @@ export const classify = (s: MergeQueueSignals): Classification => {
 		return at(
 			"merged",
 			"merged==true or state==MERGED — the queue landed the batch (terminal success)",
+		);
+	}
+	if (s.baseBranchSquash === "landed") {
+		return at(
+			"merged",
+			"the base branch carries this PR's single-parent squash — the merge landed, whatever the lagging PR-state and timeline reads say",
 		);
 	}
 	if (s.lastMergeQueueEvent === "removed_from_merge_queue") {
@@ -116,6 +150,39 @@ export const classify = (s: MergeQueueSignals): Classification => {
 		"pending",
 		"no merge-queue timeline event yet (enqueue-settle window) — still settling, not ejected",
 	);
+};
+
+/** One base-branch commit, projected to the two fields the squash predicate reads. */
+export interface BaseBranchCommit {
+	/** The full commit message; only its subject (first) line is matched. */
+	readonly message?: string | undefined;
+	/** How many parents the commit has. A squash has exactly one. */
+	readonly parents?: number | undefined;
+}
+
+/**
+ * Does the scanned base-branch window carry PR `pr`'s squash? Two conditions, both required:
+ * the commit's **subject line ends with `(#pr)`** — the squash title GitHub's merge queue
+ * writes — and it has **exactly one parent**, which is what makes it a squash rather than a
+ * merge commit that merely mentions the PR.
+ *
+ * Ending-anchored, never a substring match: a squash of a PR whose own title cites another
+ * issue reads `… (#3924) (#4010)`, so `contains "(#3924)"` would report #3924 as landed. Only
+ * the trailing `(#N)` is the PR this commit squashed.
+ *
+ * `absent` means "not in the scanned window" — never "ejected"; a healthy queued PR reads
+ * `absent` too (#4057).
+ */
+export const squashOnBaseBranch = (
+	commits: ReadonlyArray<BaseBranchCommit>,
+	pr: number,
+): BaseBranchSquash => {
+	const suffix = `(#${pr})`;
+	const landed = commits.some((commit) => {
+		const subject = (commit.message ?? "").split("\n")[0]?.trim() ?? "";
+		return subject.endsWith(suffix) && commit.parents === 1;
+	});
+	return landed ? "landed" : "absent";
 };
 
 /**

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.unit.test.ts
@@ -1,5 +1,10 @@
 import {describe, expect, it} from "vitest";
-import {classify, lastMergeQueueEvent, type MergeQueueSignals} from "./merge-queue-classify.ts";
+import {
+	classify,
+	lastMergeQueueEvent,
+	type MergeQueueSignals,
+	squashOnBaseBranch,
+} from "./merge-queue-classify.ts";
 
 const sig = (over: Partial<MergeQueueSignals> = {}): MergeQueueSignals => ({
 	merged: false,
@@ -69,6 +74,96 @@ describe("classify — precedence + edge cases", () => {
 
 	it("no signal at all (OPEN, nothing) ⇒ pending, never ejected", () => {
 		expect(classify(sig()).outcome).toBe("pending");
+	});
+});
+
+describe("classify — the #4057 stale-timeline cases (the base-branch freshness cross-check)", () => {
+	it("the #4011 shape: merge landed, PR still reads OPEN and the timeline still ends at added ⇒ merged", () => {
+		// Every timeline/PR-state signal is the stale pre-merge state the reconcile observed for
+		// ~65 minutes after PR #4011 merged. The base branch carries the squash, so it wins.
+		const c = classify(
+			sig({
+				merged: false,
+				state: "OPEN",
+				lastMergeQueueEvent: "added_to_merge_queue",
+				mergeStateStatus: "QUEUED",
+				baseBranchSquash: "landed",
+			}),
+		);
+		expect(c.outcome).toBe("merged");
+	});
+
+	it("a landed squash outranks a trailing removed_from_merge_queue on a stale not-merged read", () => {
+		// The queue emits the removal AS it merges; with the PR read lagging, the removal alone
+		// would classify `ejected` on a PR that in fact merged.
+		const c = classify(
+			sig({
+				merged: false,
+				state: "OPEN",
+				lastMergeQueueEvent: "removed_from_merge_queue",
+				baseBranchSquash: "landed",
+			}),
+		);
+		expect(c.outcome).toBe("merged");
+		expect(c.outcome).not.toBe("ejected");
+	});
+
+	it("fail-closed: `absent` never promotes — a genuinely queued PR stays queued", () => {
+		const c = classify(
+			sig({lastMergeQueueEvent: "added_to_merge_queue", baseBranchSquash: "absent"}),
+		);
+		expect(c.outcome).toBe("queued");
+	});
+
+	it("fail-closed: `absent` is not an ejection signal — a settling PR stays pending", () => {
+		const c = classify(sig({lastMergeQueueEvent: null, baseBranchSquash: "absent"}));
+		expect(c.outcome).toBe("pending");
+		expect(c.outcome).not.toBe("ejected");
+	});
+
+	it("fail-closed: `unreadable` and an absent field both leave the timeline verdict untouched", () => {
+		expect(
+			classify(
+				sig({lastMergeQueueEvent: "removed_from_merge_queue", baseBranchSquash: "unreadable"}),
+			).outcome,
+		).toBe("ejected");
+		expect(classify(sig({lastMergeQueueEvent: "added_to_merge_queue"})).outcome).toBe("queued");
+	});
+});
+
+describe("squashOnBaseBranch — does the scanned base-branch window carry this PR's squash?", () => {
+	const squash = (message: string) => ({message, parents: 1});
+
+	it("landed: a single-parent commit whose subject ends with (#PR)", () => {
+		expect(
+			squashOnBaseBranch(
+				[squash("feat(ship-it): reconcile freshness (#4057)\n\nbody"), squash("chore: x (#4058)")],
+				4057,
+			),
+		).toBe("landed");
+	});
+
+	it("absent: the window carries no commit for this PR", () => {
+		expect(squashOnBaseBranch([squash("chore: x (#4058)")], 4057)).toBe("absent");
+		expect(squashOnBaseBranch([], 4057)).toBe("absent");
+	});
+
+	it("ending-anchored: a squash citing another issue mid-subject is not that issue's squash", () => {
+		// `fix(x): thing (#3924) (#4010)` is PR #4010's squash, never #3924's — a substring
+		// match would report the cited issue as landed.
+		const commits = [squash("fix(pipeline-cli): fail-closed stdin read (#3924) (#4010)")];
+		expect(squashOnBaseBranch(commits, 4010)).toBe("landed");
+		expect(squashOnBaseBranch(commits, 3924)).toBe("absent");
+	});
+
+	it("single-parent required: a two-parent merge commit mentioning the PR is not a squash", () => {
+		expect(squashOnBaseBranch([{message: "Merge pull request (#4057)", parents: 2}], 4057)).toBe(
+			"absent",
+		);
+	});
+
+	it("tolerates a missing message or parent count", () => {
+		expect(squashOnBaseBranch([{}, {message: "(#4057)"}], 4057)).toBe("absent");
 	});
 });
 


### PR DESCRIPTION
When ship-it enqueues a PR it watches for a few minutes to work out what actually happened — did the queue merge it, is it still waiting, or did the queue drop it? It worked that out from two GitHub reads that turned out not to be timely: during the #4011 ship both kept reporting the pre-merge state for about an hour, so ship-it reported "still queued" fifteen times on a PR that had already merged. This PR adds a third read that stayed accurate the whole time — the base branch itself — and writes down honestly what the reconcile still cannot see.

**What changed**

- `packages/pipeline-cli/src/tools/merge-queue-classify/` — a non-merged read is now cross-checked against the base branch. A single-parent commit reachable from the base branch whose subject *ends* with `(#PR)` is this PR's squash, and classifies `merged` regardless of what the PR-state and timeline reads say. The ending anchor matters: a squash of a PR that cites another issue reads `… (#3924) (#4010)`, so a substring match would report the cited issue as landed.
- The read is skipped once the PR itself reads merged (nothing left to corroborate), and its scan window is the base branch's most recent 100 commits.
- **Fail-closed posture unchanged.** `absent` and `unreadable` carry no evidence and never move a verdict — an unreadable base branch recovers to `unreadable` exactly as an unreadable timeline recovers to the settle window, so a read fault can still only keep the reconcile polling, never report a false `merged`/`ejected`. `absent` is explicitly *not* an ejection signal.
- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` Step 5.5 — records the ejection direction as an **accepted** residual with its bound: an ejected PR and a healthy queued one are identical in every REST read, and the read that would tell them apart (the queue's own entries) is GraphQL-only, which this org bans. So while the timeline lags, an ejected PR classifies `queued`. Step 5.5 now stops calling a terminal `queued` \"still in-flight, never ejected\" and calls it \"still in-flight as far as the timeline can tell\".
- The adjacent trap is pinned in both the skill and the classifier's GitHub boundary: on an **open** PR, `merge_commit_sha` is GitHub's throwaway test-merge commit and is evidence of nothing; `merged`/`merged_at` plus the single-parent squash are the load-bearing signals.

**Tests** — `merge-queue-classify.unit.test.ts` covers the stale-timeline-but-base-branch-advanced case (including a landed squash outranking a trailing `removed_from_merge_queue`), the fail-closed non-promotion of `absent`/`unreadable`, and the ending-anchored / single-parent squash predicate; `github-service.unit.test.ts` covers the new read over the mock `gh` spawner, its recovery to `unreadable`, and the skip on an already-merged PR.

**Control plane (§CP):** this edits `ship-it`, a gate-critical skill — the PR travels the ADR 0135 human-approval path.

Fixes #4057