### PR TITLE
fix(verdict): one in-force resolution for read and gate, §CP-aware (#4049)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
@@ -235,11 +235,19 @@ re-deriving the resolver write-code once hand-copied, and keeps only the two thi
 # `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653; ADR 0062/0064).
 VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
 
+# §CP-ness is an input to the resolution and must match what write-code R1 passes (#4049): on a
+# control-plane PR the newest artifact is the SHA-less advisory (ADR 0111/0151), and a body-only
+# repair leaves the head deliberately unmoved, so without `--cp` a SUPERSEDED same-head FAIL reads as
+# an active repair forever. Derive it from the canonical §CP path set (the single source).
+CP_FLAG=""
+gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+  | grep -Eq "$(pipeline-cli control-plane-paths)" && CP_FLAG="--cp"
+
 # a namespace is an active-repair FAIL iff its latest authorized verdict is FAIL bound to the current
 # head — exit 0 from `verdict read … --expect FAIL`. A stale / SHA-less / PASS / none verdict exits
 # non-zero, so it is correctly NOT an active repair, matching write-code's no-op on it.
-CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code --expect FAIL 2>/dev/null)" && CODE_FAIL=1 || CODE_FAIL=0
-DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc  --expect FAIL 2>/dev/null)" && DOC_FAIL=1  || DOC_FAIL=0
+CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code --expect FAIL $CP_FLAG 2>/dev/null)" && CODE_FAIL=1 || CODE_FAIL=0
+DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc  --expect FAIL $CP_FLAG 2>/dev/null)" && DOC_FAIL=1  || DOC_FAIL=0
 
 # UNRESOLVED ≠ "no FAIL". The verb prints its outcome JSON on BOTH exit paths, so absent JSON means the
 # namespace never resolved (a transport/5xx failure). Reading that as "no repair in flight" would file

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -787,11 +787,20 @@ required set** (zero required gates would make the conjunction vacuously true �
 dressed as a pass, ADR 0092), and an unresolvable head.
 
 **`--cp` is load-bearing in both directions.** A §CP PR's only verdict is the SHA-less advisory, so
-`verdict read --gate code` legitimately resolves `_tag: none` on it — that `none` is the **expected**
-§CP shape, not an absent verdict, and a §CP PR must **never** be required to carry (nor be satisfied
-by) a bindable first-line `PASS @ <sha>` (that drops the §CP verdict into the auto-merge namespace,
-the ADR 0111 hazard). Pass `--cp` **only** for a PR Step 0 classified §CP whose control-plane
-approval gate already passed; without it the advisory is correctly not a pass.
+without `--cp` the advisory is not a candidate at all and the namespace resolves `_tag: none` — and a
+§CP PR must **never** be required to carry (nor be satisfied by) a bindable first-line `PASS @ <sha>`
+(that drops the §CP verdict into the auto-merge namespace, the ADR 0111 hazard). Pass `--cp` **only**
+for a PR Step 0 classified §CP whose control-plane approval gate already passed; without it the
+advisory is correctly not a pass.
+
+**Pass the same `$CP_FLAG` to `verdict read` and to `verdict gate` — they take the same input on
+purpose (#4049).** §CP-ness decides which artifacts are candidates for the in-force verdict, so
+handing it to one verb and not the other makes the two disagree about the *same* marker set. That
+divergence has teeth on exactly one shape: a **body-only repair**, which deliberately does not move
+the head (moving it would dismiss the control-plane approval and force a full re-review). Because
+the head never moves, ADR-0058 staleness-invalidation can never retire the FAIL the repair answered
+— only the newer advisory out-ranking it can. Read it `--cp`-blind and that superseded FAIL sets the
+veto forever, on a PR whose defect is fixed (the live PR #3988 wedge).
 
 **The one signal the verb does not read — apply it on top.** `verdict gate` reads marker/advisory
 *comments*, not GitHub's native reviews. So a green `verdict gate` is **necessary, not sufficient**:
@@ -837,11 +846,10 @@ author cannot widen it via a file in their own diff. The solo operator `usirin` 
 ADR 0048) holds `admin` and passes; any future operator or review-bot earns standing by being
 a `write+` collaborator, with no edit to this skill.
 
-For the **marker namespaces** that author-gate is applied *inside* `pipeline-cli verdict read`
-(Step 2) — it is the verb's own ADR-0055 trust root, not re-derived here. The set below is still
-resolved explicitly because the **§CP advisory** resolution (Step 2.§CP) needs it: an advisory is
-SHA-less in its first line by design (ADR 0111), so `verdict read` resolves that namespace to
-`none` and cannot author-gate it — the advisory's own latest-wins/author-gated pick is ship-it's.
+That author-gate is applied *inside* `pipeline-cli verdict read` and `verdict gate` (Step 2) — it is
+the verbs' own ADR-0055 trust root, not re-derived here, and under `--cp` its scope covers the §CP
+advisory exactly as it covers a marker. The set below is resolved explicitly only so the Step 2.§CP
+**reference explanation** can be read on its own terms; it is not a second trust root.
 
 Resolve the authorized-author set from the ACL — every distinct marker author whose repo
 permission is `write` / `maintain` / `admin`. This fails closed: a lookup error or a
@@ -895,22 +903,26 @@ REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
 # (#3653; ADR 0062/0064; epic #994)
 VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
 
-# per present namespace (Step 0), resolve the marker verdict against the current head via the verb:
-# <g>_PASS=1 iff a current-head PASS marker in that gate; <g>_FAIL=1 iff a current-head FAIL (the
-# veto). A stale / SHA-less / none verdict exits non-zero on BOTH, so it is neither a PASS nor a FAIL
-# — Step 2b's `unverified (verdict not bound to current head)` refusal, now owned by the verb. (A §CP
-# advisory namespace is SHA-less by design and resolves `none` here — Step 2.§CP handles it from the
-# body's Reviewed-head instead.)
+# per present namespace (Step 0), resolve the verdict against the current head via the verb:
+# <g>_PASS=1 iff a current-head pass in that gate; <g>_FAIL=1 iff a current-head FAIL (the veto). A
+# stale / SHA-less / none verdict exits non-zero on BOTH, so it is neither a PASS nor a FAIL —
+# Step 2b's `unverified (verdict not bound to current head)` refusal, now owned by the verb.
+#
+# $CP_FLAG (resolved above for the gate verb) is passed HERE TOO, and it is load-bearing (#4049): it
+# is the same §CP-ness input, so the two verbs resolve the SAME in-force verdict. With it, a §CP
+# namespace's advisory is a candidate and Step 2.§CP's rule holds inside the verb; without it a
+# body-only repair — which deliberately does not move the head, so ADR-0058 staleness can never
+# retire what it answered — leaves the superseded FAIL resolvable forever and wedges the PR.
 # the code namespace keeps the verb's stdout JSON: it names the RESOLVING comment id, which the
 # newest-wins fold below turns into the marker's created_at (the verb's outcome carries no timestamp).
-CODE_JSON="$($VERDICT read --pr "$PR" --gate code --expect PASS 2>/dev/null)" && CODE_PASS=1 || CODE_PASS=0
-$VERDICT read --pr "$PR" --gate code   --expect FAIL >/dev/null 2>&1 && CODE_FAIL=1   || CODE_FAIL=0
-$VERDICT read --pr "$PR" --gate doc    --expect PASS >/dev/null 2>&1 && DOC_PASS=1    || DOC_PASS=0
-$VERDICT read --pr "$PR" --gate doc    --expect FAIL >/dev/null 2>&1 && DOC_FAIL=1    || DOC_FAIL=0
-$VERDICT read --pr "$PR" --gate skill  --expect PASS >/dev/null 2>&1 && SKILL_PASS=1  || SKILL_PASS=0
-$VERDICT read --pr "$PR" --gate skill  --expect FAIL >/dev/null 2>&1 && SKILL_FAIL=1  || SKILL_FAIL=0
-$VERDICT read --pr "$PR" --gate design --expect PASS >/dev/null 2>&1 && DESIGN_PASS=1 || DESIGN_PASS=0
-$VERDICT read --pr "$PR" --gate design --expect FAIL >/dev/null 2>&1 && DESIGN_FAIL=1 || DESIGN_FAIL=0
+CODE_JSON="$($VERDICT read --pr "$PR" --gate code --expect PASS $CP_FLAG 2>/dev/null)" && CODE_PASS=1 || CODE_PASS=0
+$VERDICT read --pr "$PR" --gate code   --expect FAIL $CP_FLAG >/dev/null 2>&1 && CODE_FAIL=1   || CODE_FAIL=0
+$VERDICT read --pr "$PR" --gate doc    --expect PASS $CP_FLAG >/dev/null 2>&1 && DOC_PASS=1    || DOC_PASS=0
+$VERDICT read --pr "$PR" --gate doc    --expect FAIL $CP_FLAG >/dev/null 2>&1 && DOC_FAIL=1    || DOC_FAIL=0
+$VERDICT read --pr "$PR" --gate skill  --expect PASS $CP_FLAG >/dev/null 2>&1 && SKILL_PASS=1  || SKILL_PASS=0
+$VERDICT read --pr "$PR" --gate skill  --expect FAIL $CP_FLAG >/dev/null 2>&1 && SKILL_FAIL=1  || SKILL_FAIL=0
+$VERDICT read --pr "$PR" --gate design --expect PASS $CP_FLAG >/dev/null 2>&1 && DESIGN_PASS=1 || DESIGN_PASS=0
+$VERDICT read --pr "$PR" --gate design --expect FAIL $CP_FLAG >/dev/null 2>&1 && DESIGN_FAIL=1 || DESIGN_FAIL=0
 
 # fold the native decisive review into the code namespace (the verb reads only marker comments). Only
 # a review bound to the current head counts (same ADR-0058 staleness as a marker's @ <sha>).

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -201,11 +201,17 @@ gh api "repos/$REPO/pulls?state=open&per_page=100" \
          then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
      | .n' "$comments_file")
   [ "$ROUNDS" -ge 3 ] && continue   # at the cap → already escalated to a human, excluded from the scan
+  # §CP-ness is an input to the resolution (#4049) — on a control-plane PR the newest artifact is the
+  # SHA-less advisory, so without --cp a superseded same-head FAIL keeps pulling this scan into a
+  # phantom repair. Derive it from the canonical §CP path set, the same way R1 does.
+  CP_FLAG=""
+  gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+    | grep -Eq "$(pipeline-cli control-plane-paths)" && CP_FLAG="--cp"
   # resolve each namespace's latest current-head verdict through the shared verb — exit 0 iff HEAD
   # carries a current FAIL in that gate (a stale / SHA-less / PASS / none verdict exits non-zero).
-  $VERDICT read --pr "$PR" --gate code  --expect FAIL >/dev/null 2>&1 && echo "#$PR review-code FAIL"
-  $VERDICT read --pr "$PR" --gate doc   --expect FAIL >/dev/null 2>&1 && echo "#$PR review-doc FAIL"
-  $VERDICT read --pr "$PR" --gate skill --expect FAIL >/dev/null 2>&1 && echo "#$PR review-skill FAIL"
+  $VERDICT read --pr "$PR" --gate code  --expect FAIL $CP_FLAG >/dev/null 2>&1 && echo "#$PR review-code FAIL"
+  $VERDICT read --pr "$PR" --gate doc   --expect FAIL $CP_FLAG >/dev/null 2>&1 && echo "#$PR review-doc FAIL"
+  $VERDICT read --pr "$PR" --gate skill --expect FAIL $CP_FLAG >/dev/null 2>&1 && echo "#$PR review-skill FAIL"
 done
 ```
 
@@ -1861,13 +1867,24 @@ while IFS= read -r a; do
   esac
 done <<<"$markerAuthors"
 
+# §CP-ness is an INPUT to the resolution, not a detail of it (#4049): on a control-plane PR the
+# newest artifact in a namespace is the SHA-less advisory (ADR 0111/0151), and a body-only repair
+# leaves the head deliberately unmoved — so without `--cp` the verb keeps resolving a SUPERSEDED
+# same-head FAIL as current and this seam sees a phantom repair forever. Derive it from the canonical
+# §CP path set (`pipeline-cli control-plane-paths`, the single source) and pass it to every read
+# below, exactly as ship-it passes it to `verdict gate`.
+CP_FLAG=""
+gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+  | grep -Eq "$(pipeline-cli control-plane-paths)" && CP_FLAG="--cp"
+
 # a namespace is a repairable FAIL iff its latest authorized verdict is FAIL bound to the current head
 # — exit 0 from `verdict read … --expect FAIL`. The verb's JSON (stdout) carries the resolving comment
-# id, which Step R2 uses to read the FAIL body. A stale / SHA-less / PASS / none verdict exits non-zero,
-# so it is correctly NOT repaired (idempotent no-op), needing no separate staleness test here.
-CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code  --expect FAIL 2>/dev/null)"  && CODE_FAIL=1  || CODE_FAIL=0
-DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc   --expect FAIL 2>/dev/null)"  && DOC_FAIL=1   || DOC_FAIL=0
-SKILL_FAIL_JSON="$($VERDICT read --pr "$PR" --gate skill --expect FAIL 2>/dev/null)" && SKILL_FAIL=1 || SKILL_FAIL=0
+# id, which Step R2 uses to read the FAIL body. A stale / SHA-less / PASS / none / superseded-by-a-
+# newer-advisory verdict exits non-zero, so it is correctly NOT repaired (idempotent no-op), needing
+# no separate staleness test here.
+CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code  --expect FAIL $CP_FLAG 2>/dev/null)"  && CODE_FAIL=1  || CODE_FAIL=0
+DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc   --expect FAIL $CP_FLAG 2>/dev/null)"  && DOC_FAIL=1   || DOC_FAIL=0
+SKILL_FAIL_JSON="$($VERDICT read --pr "$PR" --gate skill --expect FAIL $CP_FLAG 2>/dev/null)" && SKILL_FAIL=1 || SKILL_FAIL=0
 
 # UNRESOLVED ≠ "no FAIL". `verdict read` prints its outcome JSON on BOTH exit paths, so absent JSON
 # means the namespace never resolved at all (a transport/5xx error, not a verdict). Under a flaky
@@ -1919,8 +1936,10 @@ review), `DOC_FAIL=1`, or `SKILL_FAIL=1`. `verdict read` already encapsulates la
 SHA-staleness refusal: a newer FAIL is acted on even if an older PASS exists, but a FAIL whose `@ <sha>`
 is not the current head (or carries no `@ <sha>` — a pre-0058 legacy marker) resolves `stale`/`sha-less`,
 exits non-zero, and is **not** repaired — report `nothing to repair (latest FAIL not bound to current
-head)` and stop. A `review-skill: advisory` line (a blocking-set skill PR) is not a FAIL — `verdict read`
-resolves it `none` (no PASS/FAIL polarity), a clean no-op like a PASS. This keeps repair mode
+head)` and stop. A `review-skill: advisory` line (a blocking-set skill PR) is not a FAIL — on a non-§CP
+PR `verdict read` resolves it `none`, and on a §CP PR (`--cp`) it is the namespace's in-force verdict
+and resolves to the ADR 0111/0151 PASS-equivalent when all-PASS; either way a clean no-op like a PASS,
+and either way it **supersedes** an older same-head FAIL it was posted to answer (#4049). This keeps repair mode
 **idempotent**: re-running it on an already-fixed/PASS PR, a no-FAIL PR, or a stale-FAIL PR is a clean
 no-op. If **more than one** namespace resolves FAIL (a mixed PR — e.g. code+doc, or skill+code), address
 **all** of them in this round.

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -4,12 +4,17 @@
  * The ADR-0058 SHA-bound verdict read/post glue, extracted from the inline `jq` the
  * `review-*` / `ship-it` / `write-code`-repair / `heal-ci` skills each hand-rolled (#2102).
  *
- * `read --pr N --gate <g> [--expect PASS|FAIL] [--head <sha>]` resolves the (PR, gate)
+ * `read --pr N --gate <g> [--expect PASS|FAIL] [--head <sha>] [--cp]` resolves the (PR, gate)
  * verdict against the PR's current head (author-gated to write+ collaborators, ADR 0055) and
  * **exits 0 only when HEAD is reviewed with the expected polarity** (default PASS) — every
  * refusal (`none`/`sha-less`/`stale`, or a current verdict of the wrong polarity) prints its
  * reason on stderr and exits non-zero, so a caller branches on exit status. The resolved
  * outcome is printed as JSON on stdout for a caller that wants the detail (comment id, sha).
+ * `--cp` carries the same §CP-ness `gate` takes, and for the same reason: on a control-plane PR the
+ * newest artifact is the SHA-less advisory (ADR 0111/0151), and a body-only repair leaves the head
+ * deliberately unmoved — so without it a superseded same-head FAIL stays the in-force verdict
+ * forever, `read` and `gate` disagree, and the repair seam sees a phantom FAIL (#4049). Pass it for
+ * every §CP PR, exactly as you would to `gate`.
  *
  * `gate --pr N --require <namespaces> [--cp]` is the SET-level counterpart `read` cannot be: it
  * folds the same resolution over EVERY namespace the diff requires and exits 0 only when each one
@@ -103,13 +108,19 @@ const parseExpect = (raw: Option.Option<string>): Effect.Effect<Polarity, never>
 	return fail(`invalid --expect '${Option.getOrElse(raw, () => "")}' — expected PASS or FAIL`);
 };
 
+const cpFlag = Flag.boolean("cp").pipe(
+	Flag.withDescription(
+		"this is a §CP (control-plane / blocking-set) PR: let the canonical SHA-less advisory + body `Reviewed-head` be a candidate for the in-force verdict (ADR 0111/0151)",
+	),
+);
+
 const read = Command.make(
 	"read",
-	{pr: prFlag, gate: gateFlag, head: headFlag, expect: expectFlag},
-	Effect.fn(function* ({pr, gate, head, expect}) {
+	{pr: prFlag, gate: gateFlag, head: headFlag, expect: expectFlag, cp: cpFlag},
+	Effect.fn(function* ({pr, gate, head, expect, cp}) {
 		const g = yield* parseGate(gate);
 		const polarity = yield* parseExpect(expect);
-		const result = yield* (yield* Github).read(pr, g, polarity, Option.getOrUndefined(head));
+		const result = yield* (yield* Github).read(pr, g, polarity, Option.getOrUndefined(head), cp);
 		// The resolved detail goes to stdout as JSON (a caller may want the comment id / bound sha);
 		// the human-readable verdict + refusal reason goes to stderr, mirroring resume-policy.
 		yield* Console.log(JSON.stringify({...result.outcome, headSha: result.headSha, gate: g}));
@@ -134,12 +145,6 @@ const read = Command.make(
 const requireFlag = Flag.string("require").pipe(
 	Flag.withDescription(
 		"the required review namespaces, comma/space separated (`review-code,review-doc` or `code,doc`) — derive with `pipeline-cli class-probe classify --namespaces`",
-	),
-);
-
-const cpFlag = Flag.boolean("cp").pipe(
-	Flag.withDescription(
-		"this is a §CP (control-plane / blocking-set) PR: accept the canonical SHA-less advisory + body `Reviewed-head` as the pass (ADR 0111/0151)",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
@@ -16,35 +16,24 @@
  *    the body's `Reviewed-head: @ <sha>` line. A §CP PR must never be required to carry (nor be
  *    satisfied by) a bindable first-line PASS — that drops the §CP verdict into the auto-merge
  *    namespace, the ADR 0111 hazard.
- * So `verdict read --gate code` legitimately resolving `none` on a §CP PR is the EXPECTED advisory
- * shape, not an absent verdict — which is exactly the confusion a bolted-on absence check would
- * make, refusing every §CP enqueue.
+ * So a §CP namespace whose only artifact is the advisory is a legitimate pass, not an absent verdict
+ * — which is exactly the confusion a bolted-on absence check would make, refusing every §CP enqueue.
+ *
+ * This module decides the SET; it no longer decides which verdict is in force in a single namespace.
+ * That is `resolveVerdict`'s, whose §CP-aware latest-wins pick `read` consumes too — one resolution,
+ * two verbs, so a superseded same-head FAIL cannot be current to one and superseded to the other
+ * (#4049).
  */
 import {
 	GATE_KEYWORD,
-	isBoundToHead,
-	parseVerdict,
-	pickLatestAuthorized,
-	polarityRe,
-	reviewedHeadSha,
+	resolveVerdict,
 	type VerdictComment,
+	type VerdictForm,
 	type VerdictGate,
+	type VerdictOutcome,
+	type VerdictState,
+	verdictState,
 } from "./verdict-match.ts";
-
-/**
- * The §CP advisory first line: `review-<gate>: advisory — blocking-set PR (manual merge)`. Anchored
- * to the first line like every other marker matcher, and deliberately NOT polarity-bearing — an
- * advisory carries no PASS/FAIL, so `polarityRe` never matches it and the two candidate sets are
- * disjoint.
- */
-export const advisoryRe = (gate: VerdictGate): RegExp =>
-	new RegExp(`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:\\s*advisory\\b`, "i");
-
-/** A recorded `[FAIL]` checkbox anywhere in an advisory body — the not-all-PASS tell. */
-const failCheckboxRe = /^\s*[-*]?\s*\[\s*FAIL\s*\]/im;
-
-/** Which verdict FORM satisfied (or was found in) a namespace — the ADR 0111 distinction. */
-export type VerdictForm = "marker" | "advisory" | "none";
 
 /** One required namespace's resolved state against the PR's live head. */
 export interface NamespaceDecision {
@@ -57,7 +46,7 @@ export interface NamespaceDecision {
 	 * `absent` — NO consumable verdict exists in this namespace at all (the #3944 hole).
 	 * `unverified` — a verdict exists but is not bound to the live head (stale / SHA-less / not-all-PASS).
 	 */
-	readonly state: "pass" | "fail" | "absent" | "unverified";
+	readonly state: VerdictState;
 	readonly form: VerdictForm;
 	readonly commentId: number | null;
 	/** The head the found verdict binds, when it binds one. */
@@ -90,127 +79,62 @@ export interface GateDecision {
 	readonly reason: string;
 }
 
-/** Newest of two optional candidates by `(createdAt, id)` — the same latest-wins key as the markers. */
-const newerOf = (
-	a: VerdictComment | undefined,
-	b: VerdictComment | undefined,
-): VerdictComment | undefined => {
-	if (a === undefined) return b;
-	if (b === undefined) return a;
-	if (a.createdAt !== b.createdAt) return a.createdAt > b.createdAt ? a : b;
-	return a.id > b.id ? a : b;
+/**
+ * The namespace-labelled prose for a resolved outcome. Prose only — the *decision* it narrates was
+ * already made by `resolveVerdict`, so there is no second rule here to drift from `read`'s.
+ */
+const namespaceReason = (
+	namespace: string,
+	outcome: VerdictOutcome,
+	input: GateDecisionInput,
+): string => {
+	switch (outcome._tag) {
+		case "none":
+			return input.controlPlane
+				? `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR — neither a bindable PASS marker nor a §CP advisory`
+				: `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR at all`;
+		case "sha-less":
+			return outcome.form === "advisory"
+				? `unverified (§CP ${namespace} advisory carries no 'Reviewed-head: @ <sha>' body binding — an advisory is SHA-less in line 1 by design, so the body anchor is its only head binding, ADR 0151)`
+				: `unverified (verdict not bound to current head): the latest ${namespace} marker is SHA-less (pre-0058)`;
+		case "stale":
+			return outcome.form === "advisory"
+				? `unverified (§CP ${namespace} advisory reviewed-head stale — body @ ${outcome.sha} ≠ current head ${input.headSha})`
+				: `unverified (verdict not bound to current head): the latest ${namespace} marker binds ${outcome.sha}, not the current head ${input.headSha}`;
+		case "advisory-not-all-pass":
+			return `unverified (§CP ${namespace} advisory not all-PASS — a body checkbox is [FAIL])`;
+		case "current":
+			if (outcome.form === "advisory") {
+				return `§CP ${namespace} advisory at the current head, all-PASS — the ADR 0111/0151 PASS-equivalent`;
+			}
+			return outcome.polarity === "PASS"
+				? `current-head ${namespace} PASS @ ${outcome.sha}`
+				: `latest verdict is FAIL (${namespace}) @ ${outcome.sha}`;
+	}
 };
 
 const decideNamespace = (gate: VerdictGate, input: GateDecisionInput): NamespaceDecision => {
 	const namespace = GATE_KEYWORD[gate];
-	const base = {gate, namespace} as const;
-	const marker = pickLatestAuthorized(input.comments, input.authorizedAuthors, polarityRe(gate));
-	// A non-§CP PR's advisory is NOT a candidate at all: it carries no bindable head and is not a
-	// PASS, so it must neither satisfy the namespace nor shadow an older bindable marker — exactly
-	// what `verdict read` already does by matching on `polarityRe` only.
-	const advisory = input.controlPlane
-		? pickLatestAuthorized(input.comments, input.authorizedAuthors, advisoryRe(gate))
-		: undefined;
-	const latest = newerOf(marker, advisory);
-
-	if (latest === undefined) {
-		return {
-			...base,
-			state: "absent",
-			form: "none",
-			commentId: null,
-			sha: null,
-			reason: input.controlPlane
-				? `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR — neither a bindable PASS marker nor a §CP advisory`
-				: `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR at all`,
-		};
-	}
-
-	if (latest === advisory) {
-		const sha = reviewedHeadSha(latest.body);
-		if (sha === null) {
-			return {
-				...base,
-				state: "unverified",
-				form: "advisory",
-				commentId: latest.id,
-				sha: null,
-				reason: `unverified (§CP ${namespace} advisory carries no 'Reviewed-head: @ <sha>' body binding — an advisory is SHA-less in line 1 by design, so the body anchor is its only head binding, ADR 0151)`,
-			};
-		}
-		if (!isBoundToHead(sha, input.headSha)) {
-			return {
-				...base,
-				state: "unverified",
-				form: "advisory",
-				commentId: latest.id,
-				sha,
-				reason: `unverified (§CP ${namespace} advisory reviewed-head stale — body @ ${sha} ≠ current head ${input.headSha})`,
-			};
-		}
-		if (failCheckboxRe.test(latest.body)) {
-			return {
-				...base,
-				state: "unverified",
-				form: "advisory",
-				commentId: latest.id,
-				sha,
-				reason: `unverified (§CP ${namespace} advisory not all-PASS — a body checkbox is [FAIL])`,
-			};
-		}
-		return {
-			...base,
-			state: "pass",
-			form: "advisory",
-			commentId: latest.id,
-			sha,
-			reason: `§CP ${namespace} advisory at the current head, all-PASS — the ADR 0111/0151 PASS-equivalent`,
-		};
-	}
-
-	// `polarityRe` matched, so `parseVerdict` cannot be null here — the `?? null` collapses the
-	// unreachable branch into the same fail-closed `absent` rather than asserting non-null.
-	const parsed = parseVerdict(latest.body, gate);
-	if (parsed === null) {
-		return {
-			...base,
-			state: "absent",
-			form: "none",
-			commentId: latest.id,
-			sha: null,
-			reason: `unverified (no ${namespace} PASS): the latest authorized comment in this namespace carries no readable polarity`,
-		};
-	}
-	if (parsed.sha === null) {
-		return {
-			...base,
-			state: "unverified",
-			form: "marker",
-			commentId: latest.id,
-			sha: null,
-			reason: `unverified (verdict not bound to current head): the latest ${namespace} marker is SHA-less (pre-0058)`,
-		};
-	}
-	if (!isBoundToHead(parsed.sha, input.headSha)) {
-		return {
-			...base,
-			state: "unverified",
-			form: "marker",
-			commentId: latest.id,
-			sha: parsed.sha,
-			reason: `unverified (verdict not bound to current head): the latest ${namespace} marker binds ${parsed.sha}, not the current head ${input.headSha}`,
-		};
-	}
+	const outcome = resolveVerdict({
+		comments: input.comments,
+		authorizedAuthors: input.authorizedAuthors,
+		gate,
+		headSha: input.headSha,
+		controlPlane: input.controlPlane,
+	});
 	return {
-		...base,
-		state: parsed.polarity === "PASS" ? "pass" : "fail",
-		form: "marker",
-		commentId: latest.id,
-		sha: parsed.sha,
-		reason:
-			parsed.polarity === "PASS"
-				? `current-head ${namespace} PASS @ ${parsed.sha}`
-				: `latest verdict is FAIL (${namespace}) @ ${parsed.sha}`,
+		gate,
+		namespace,
+		state: verdictState(outcome),
+		form: outcome.form,
+		commentId: outcome._tag === "none" ? null : outcome.commentId,
+		sha:
+			outcome._tag === "current" ||
+			outcome._tag === "stale" ||
+			outcome._tag === "advisory-not-all-pass"
+				? outcome.sha
+				: null,
+		reason: namespaceReason(namespace, outcome, input),
 	};
 };
 

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -1,6 +1,12 @@
 import {assert, describe, it} from "@effect/vitest";
 import {decideGate, type GateDecisionInput} from "./gate-decision.ts";
-import type {VerdictComment, VerdictGate} from "./verdict-match.ts";
+import {
+	isReviewed,
+	resolveVerdict,
+	type VerdictComment,
+	type VerdictGate,
+	verdictState,
+} from "./verdict-match.ts";
 
 const HEAD = "15ae9df658ce6225b8b71f22d214cfcabb6b1c9a";
 const OLD = "92c2cf4d0000000000000000000000000000abcd";
@@ -357,4 +363,87 @@ describe("decideGate — fail-closed on its own inputs (ADR 0092)", () => {
 		const result = decide({headSha: HEAD.slice(0, 8), comments: [comment({id: 1})]});
 		assert.isTrue(result.enqueueable);
 	});
+});
+
+/**
+ * The cross-consumer invariant (#4049): `read` and `gate` must name the SAME in-force verdict for
+ * the same (PR, gate, head, §CP-ness) inputs. They diverged because each computed its own — `read`
+ * by polarity-matching, `gate` by latest-wins across marker AND advisory — so on a §CP PR whose
+ * body-only repair left the head unmoved, `read` kept resolving a superseded FAIL as current while
+ * `gate` correctly saw the newer advisory. Both now project one resolution; this table is what
+ * fails if a second one is ever reintroduced.
+ */
+describe("read and gate agree on the in-force verdict (#4049)", () => {
+	const FAIL_AT_HEAD = `review-doc: FAIL @ ${HEAD} — changes-requested`;
+	const fixtures: ReadonlyArray<{
+		readonly name: string;
+		readonly comments: ReadonlyArray<VerdictComment>;
+		readonly controlPlane: boolean;
+	}> = [
+		{
+			name: "the PR #3988 body-only-repair set on a §CP PR: FAIL, FAIL, all-PASS advisory @ one head",
+			comments: [
+				comment({id: 1, createdAt: "2026-07-24T06:51:00Z", body: FAIL_AT_HEAD}),
+				comment({id: 2, createdAt: "2026-07-24T19:16:00Z", body: FAIL_AT_HEAD}),
+				comment({id: 3, createdAt: "2026-07-24T19:22:00Z", body: advisory("doc", HEAD)}),
+			],
+			controlPlane: true,
+		},
+		{
+			name: "the same set on a non-§CP PR",
+			comments: [
+				comment({id: 1, createdAt: "2026-07-24T06:51:00Z", body: FAIL_AT_HEAD}),
+				comment({id: 2, createdAt: "2026-07-24T19:16:00Z", body: FAIL_AT_HEAD}),
+				comment({id: 3, createdAt: "2026-07-24T19:22:00Z", body: advisory("doc", HEAD)}),
+			],
+			controlPlane: false,
+		},
+		{
+			name: "§CP, a FAIL posted after the advisory",
+			comments: [
+				comment({id: 1, createdAt: "2026-07-24T19:00:00Z", body: advisory("doc", HEAD)}),
+				comment({id: 2, createdAt: "2026-07-24T19:22:00Z", body: FAIL_AT_HEAD}),
+			],
+			controlPlane: true,
+		},
+		{
+			name: "§CP, the advisory is not all-PASS",
+			comments: [
+				comment({id: 1, createdAt: "2026-07-24T06:51:00Z", body: FAIL_AT_HEAD}),
+				comment({id: 2, createdAt: "2026-07-24T19:22:00Z", body: advisory("doc", HEAD, "[FAIL]")}),
+			],
+			controlPlane: true,
+		},
+		{
+			name: "§CP, the advisory's Reviewed-head is stale",
+			comments: [comment({id: 1, body: advisory("doc", OLD)})],
+			controlPlane: true,
+		},
+		{name: "an empty namespace", comments: [], controlPlane: true},
+	];
+
+	for (const {name, comments, controlPlane} of fixtures) {
+		it(name, () => {
+			const outcome = resolveVerdict({
+				comments,
+				authorizedAuthors: [REVIEWER],
+				gate: "doc",
+				headSha: HEAD,
+				controlPlane,
+			});
+			const decision = decideGate({
+				comments,
+				authorizedAuthors: [REVIEWER],
+				requiredGates: ["doc"],
+				headSha: HEAD,
+				controlPlane,
+			}).decisions[0];
+			assert.strictEqual(verdictState(outcome), decision?.state);
+			assert.strictEqual(outcome.form, decision?.form);
+			// The two exit codes a consumer branches on: ship-it's `--expect PASS` must agree with
+			// `enqueueable`, and write-code's repair seam `--expect FAIL` must agree with the veto.
+			assert.strictEqual(isReviewed(outcome, "PASS"), decision?.state === "pass");
+			assert.strictEqual(isReviewed(outcome, "FAIL"), decision?.state === "fail");
+		});
+	}
 });

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -117,7 +117,7 @@ const comment = (over: {
 describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawner", () => {
 	it.effect("current-head PASS from a write+ author → satisfied", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", undefined, false);
 			assert.strictEqual(result.outcome._tag, "current");
 			assert.isTrue(result.satisfied);
 		}).pipe((effect) =>
@@ -133,7 +133,7 @@ describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawne
 
 	it.effect("a stale-sha PASS → not satisfied (unverified)", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", undefined, false);
 			assert.strictEqual(result.outcome._tag, "stale");
 			assert.isFalse(result.satisfied);
 		}).pipe((effect) =>
@@ -149,7 +149,7 @@ describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawne
 
 	it.effect("a forged PASS from a non-collaborator is invisible → none", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", undefined, false);
 			assert.strictEqual(result.outcome._tag, "none");
 			assert.isFalse(result.satisfied);
 		}).pipe((effect) =>
@@ -169,7 +169,7 @@ describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawne
 
 	it.effect("a --head override binds against the supplied head, not the PR's live head", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "skill", "PASS", HEAD);
+			const result = yield* (yield* Github).read(PR, "skill", "PASS", HEAD, false);
 			assert.strictEqual(result.outcome._tag, "current");
 			assert.strictEqual(result.headSha, HEAD);
 		}).pipe((effect) =>

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -12,9 +12,9 @@
  * Three verbs:
  *  - `gate(pr, requiredGates, controlPlane, headOverride)` — the SET-level enqueue decision: fold the
  *    same resolution over every namespace the diff requires, so an absent namespace refuses (#3982).
- *  - `read(pr, gate, expect, headOverride)` — resolve the PR's current head (REST), author-gate
- *    marker authors to write+ collaborators (ADR 0055), and run `resolveVerdict` to classify
- *    the namespace against that head. The consumer branches on the returned outcome.
+ *  - `read(pr, gate, expect, headOverride, controlPlane)` — resolve the PR's current head (REST),
+ *    author-gate marker authors to write+ collaborators (ADR 0055), and run `resolveVerdict` to
+ *    classify the namespace against that head. The consumer branches on the returned outcome.
  *  - `post(pr, gate, body, runId)` — the ADR-0058 rule-2 UPSERT, scoped per posting RUN (ADR 0213):
  *    guard the body's first line is *this* gate's marker (fail-closed on a cross-namespace body),
  *    then PATCH the prior marker THIS RUN posted in the namespace if one exists, else POST a fresh
@@ -48,6 +48,7 @@ import {
 	boundHeadShas,
 	emissionDefect,
 	headBindingDefect,
+	isReviewed,
 	namespaceRe,
 	normalizeRunId,
 	type Polarity,
@@ -108,6 +109,8 @@ export interface ReadResult {
 	/** Does the outcome satisfy the caller's expected polarity (a current-head match)? */
 	readonly satisfied: boolean;
 	readonly expect: Polarity;
+	/** Was the namespace resolved §CP-aware (the advisory a candidate for the in-force pick)? */
+	readonly controlPlane: boolean;
 }
 
 /** The `post` verdict — whether we upserted an existing marker or posted the first one, and the comment id. */
@@ -184,6 +187,7 @@ const read = Effect.fn("Github.read")(function* (
 	gate: VerdictGate,
 	expect: Polarity,
 	headOverride: string | undefined,
+	controlPlane: boolean,
 ) {
 	const headSha = headOverride?.trim() || (yield* currentHead(repo, pr));
 	const comments = yield* listComments(repo, pr);
@@ -197,9 +201,21 @@ const read = Effect.fn("Github.read")(function* (
 		),
 	];
 	const authorized = yield* authorizedAuthors(repo, markerAuthors);
-	const outcome = resolveVerdict({comments, authorizedAuthors: authorized, gate, headSha});
-	const satisfied = outcome._tag === "current" && outcome.polarity === expect;
-	return {outcome, headSha, gate, satisfied, expect} satisfies ReadResult;
+	const outcome = resolveVerdict({
+		comments,
+		authorizedAuthors: authorized,
+		gate,
+		headSha,
+		controlPlane,
+	});
+	return {
+		outcome,
+		headSha,
+		gate,
+		satisfied: isReviewed(outcome, expect),
+		expect,
+		controlPlane,
+	} satisfies ReadResult;
 });
 
 /**
@@ -209,8 +225,8 @@ const read = Effect.fn("Github.read")(function* (
  * set so an ABSENT namespace is a refusal rather than an unnoticed gap (#3982 / PR #3944).
  *
  * The author-gate scope is `namespaceRe` (which matches PASS / FAIL / advisory alike) across every
- * required gate, so a §CP advisory's author is ACL-checked exactly like a marker author — the one
- * thing single-namespace `read` structurally cannot do for the SHA-less advisory form (ADR 0111).
+ * required gate, so a §CP advisory's author is ACL-checked exactly like a marker author — the same
+ * scope single-namespace `read` applies, now that both resolve through `resolveVerdict` (#4049).
  */
 const gate = Effect.fn("Github.gate")(function* (
 	repo: string,
@@ -330,11 +346,16 @@ const post = Effect.fn("Github.post")(function* (
 export class Github extends Context.Service<
 	Github,
 	{
+		/**
+		 * `controlPlane` is REQUIRED, never defaulted: it is the same §CP-ness `gate` takes, and the
+		 * two verbs must be handed the same value to resolve the same in-force verdict (#4049).
+		 */
 		readonly read: (
 			pr: number,
 			gate: VerdictGate,
 			expect: Polarity,
-			headOverride?: string,
+			headOverride: string | undefined,
+			controlPlane: boolean,
 		) => Effect.Effect<
 			ReadResult,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
@@ -382,8 +403,12 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
 			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
 			return {
-				read: (pr, gate, expect, headOverride) =>
-					repo.pipe(Effect.flatMap((r) => withSpawner(read(r, pr, gate, expect, headOverride)))),
+				read: (pr, gate, expect, headOverride, controlPlane) =>
+					repo.pipe(
+						Effect.flatMap((r) =>
+							withSpawner(read(r, pr, gate, expect, headOverride, controlPlane)),
+						),
+					),
 				gate: (pr, requiredGates, controlPlane, headOverride) =>
 					repo.pipe(
 						Effect.flatMap((r) =>

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -14,6 +14,13 @@
  * (ADR 0055 write+ trust root) is resolved by the shell and handed in as `authorizedAuthors`,
  * exactly as `epic-lock`'s claim core takes it — a forged marker from a non-collaborator
  * never enters the candidate set, and an empty authorized set resolves NO verdict (fail-closed).
+ *
+ * `resolveVerdict` is the ONE notion of "which verdict is in force" (#4049). It used to answer that
+ * by polarity-matching alone, while `gate-decision.ts` answered it by latest-wins across marker AND
+ * §CP advisory — so on a §CP PR whose body-only repair left the head deliberately unmoved, a
+ * superseded same-head FAIL stayed resolvable as current to `read` forever while `gate` correctly
+ * saw the newer advisory. Consumer-dependent divergence on the same marker set is the defect; the
+ * fix is that `gate` now projects THIS resolution rather than computing a second one.
  */
 import {findCommentLeaks} from "../leak-guard/leak-guard.ts";
 
@@ -66,6 +73,18 @@ export const verdictRe = (gate: VerdictGate): RegExp =>
 export const polarityRe = (gate: VerdictGate): RegExp =>
 	new RegExp(`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:\\s*(PASS|FAIL)`, "i");
 
+/**
+ * The §CP advisory first line: `review-<gate>: advisory — blocking-set PR (manual merge)`. Anchored
+ * to the first line like every other marker matcher, and deliberately NOT polarity-bearing — an
+ * advisory carries no PASS/FAIL, so `polarityRe` never matches it and the two candidate sets are
+ * disjoint.
+ */
+export const advisoryRe = (gate: VerdictGate): RegExp =>
+	new RegExp(`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:\\s*advisory\\b`, "i");
+
+/** A recorded `[FAIL]` checkbox anywhere in an advisory body — the not-all-PASS tell. */
+const failCheckboxRe = /^\s*[-*]?\s*\[\s*FAIL\s*\]/im;
+
 /** A PR/issue comment as the issues/comments REST endpoint surfaces it (only these fields matter). */
 export interface VerdictComment {
 	/** Server-assigned, strictly-monotonic, globally-unique comment id (the tiebreak sub-key). */
@@ -115,26 +134,66 @@ export const isBoundToHead = (sha: string | null | undefined, head: string): boo
 	return a.startsWith(b) || b.startsWith(a);
 };
 
-/** The resolved verdict for a (PR, gate) — exactly one of four states against the current head. */
+/**
+ * Which verdict FORM is in force — the ADR 0111/0151 distinction between a bindable first-line
+ * `PASS|FAIL @ <sha>` marker and the §CP advisory, whose head binding lives only in its body's
+ * `Reviewed-head:` anchor. `none` is the empty namespace.
+ */
+export type VerdictForm = "marker" | "advisory" | "none";
+
+/** The resolved verdict for a (PR, gate) against the current head — the in-force artifact's state. */
 export type VerdictOutcome =
-	/** No authorized PASS/FAIL marker exists in this namespace (or the authorized set was empty). */
-	| {readonly _tag: "none"}
-	/** The latest authorized marker carries no `@ <sha>` (a pre-0058 legacy marker) — refuse. */
-	| {readonly _tag: "sha-less"; readonly commentId: number; readonly polarity: Polarity}
-	/** The latest authorized marker is bound to a different (stale) head — refuse. */
+	/** No authorized verdict artifact in this namespace (or the authorized set was empty). */
+	| {readonly _tag: "none"; readonly form: "none"}
+	/**
+	 * Nothing binds the in-force artifact to a head: a pre-0058 marker with no `@ <sha>`, or a §CP
+	 * advisory with no `Reviewed-head:` anchor (an advisory is SHA-less in line 1 by design, so the
+	 * body anchor is its only binding — ADR 0151). `polarity` is null for the advisory form, which
+	 * carries no PASS/FAIL. Refuse either way.
+	 */
+	| {
+			readonly _tag: "sha-less";
+			readonly form: "marker" | "advisory";
+			readonly commentId: number;
+			readonly polarity: Polarity | null;
+	  }
+	/** The in-force artifact binds a different (stale) head — refuse. */
 	| {
 			readonly _tag: "stale";
+			readonly form: "marker" | "advisory";
+			readonly commentId: number;
+			readonly polarity: Polarity | null;
+			readonly sha: string;
+	  }
+	/**
+	 * The in-force artifact binds the current head and carries a polarity — a marker's own PASS/FAIL,
+	 * or a §CP all-PASS advisory read as the ADR 0111/0151 PASS-equivalent.
+	 */
+	| {
+			readonly _tag: "current";
+			readonly form: "marker" | "advisory";
 			readonly commentId: number;
 			readonly polarity: Polarity;
 			readonly sha: string;
 	  }
-	/** The latest authorized marker is bound to the current head — its polarity decides. */
+	/**
+	 * The in-force §CP advisory binds the current head but records a `[FAIL]` checkbox, so it is not
+	 * the all-PASS PASS-equivalent — and it is not a marker FAIL either (its remedy is a re-review,
+	 * not the author's repair round-trip). Its own terminal state, refused by both polarities.
+	 */
 	| {
-			readonly _tag: "current";
+			readonly _tag: "advisory-not-all-pass";
+			readonly form: "advisory";
 			readonly commentId: number;
-			readonly polarity: Polarity;
 			readonly sha: string;
 	  };
+
+/**
+ * The four states a namespace resolves to — the vocabulary `verdict gate` reports per required
+ * namespace, and the same projection `read`'s `--expect` matches against, so the two verbs cannot
+ * disagree about which verdict is in force (#4049).
+ */
+export type VerdictState = "pass" | "fail" | "absent" | "unverified";
 
 export interface ResolveVerdictInput {
 	readonly comments: ReadonlyArray<VerdictComment>;
@@ -143,7 +202,46 @@ export interface ResolveVerdictInput {
 	readonly gate: VerdictGate;
 	/** The PR's current head SHA every verdict must be bound to (ADR 0058 rule 3). */
 	readonly headSha: string;
+	/**
+	 * Is this a §CP (control-plane / blocking-set) PR, whose verdict form is the SHA-less advisory
+	 * (ADR 0111/0151)? Required, never defaulted: on a §CP PR the advisory is the newest artifact a
+	 * body-only repair leaves behind, and omitting it is exactly the #4049 divergence — a superseded
+	 * same-head FAIL resolving as the in-force verdict forever. A non-§CP PR's advisory is not a
+	 * candidate at all: it is not a PASS and binds no head in line one, so it must neither satisfy
+	 * the namespace nor shadow an older bindable marker.
+	 */
+	readonly controlPlane: boolean;
 }
+
+/** Newest of two optional candidates by `(createdAt, id)` — the same latest-wins key as the markers. */
+const newerOf = (
+	a: VerdictComment | undefined,
+	b: VerdictComment | undefined,
+): VerdictComment | undefined => {
+	if (a === undefined) return b;
+	if (b === undefined) return a;
+	if (a.createdAt !== b.createdAt) return a.createdAt > b.createdAt ? a : b;
+	return a.id > b.id ? a : b;
+};
+
+/**
+ * Classify a §CP advisory that won the latest-wins pick: its head binding is the body's
+ * `Reviewed-head:` anchor (ADR 0151), and it is the PASS-equivalent only when every recorded
+ * checkbox is `[PASS]`.
+ */
+const resolveAdvisory = (advisory: VerdictComment, headSha: string): VerdictOutcome => {
+	const sha = reviewedHeadSha(advisory.body);
+	if (sha === null) {
+		return {_tag: "sha-less", form: "advisory", commentId: advisory.id, polarity: null};
+	}
+	if (!isBoundToHead(sha, headSha)) {
+		return {_tag: "stale", form: "advisory", commentId: advisory.id, polarity: null, sha};
+	}
+	if (failCheckboxRe.test(advisory.body)) {
+		return {_tag: "advisory-not-all-pass", form: "advisory", commentId: advisory.id, sha};
+	}
+	return {_tag: "current", form: "advisory", commentId: advisory.id, polarity: "PASS", sha};
+};
 
 /**
  * The latest-wins pick, shared by `resolveVerdict` and the §CP advisory resolution: among the
@@ -167,42 +265,80 @@ export const pickLatestAuthorized = (
 };
 
 /**
- * Resolve the (PR, gate) verdict against the current head, re-encoding ADR 0058 rule 3
- * exactly: author-gate to write+ collaborators (a forged marker is invisible), keep only
- * PASS/FAIL markers in this namespace, take the **newest** by `(createdAt, id)` (latest-wins,
- * so a newer FAIL vetoes an older PASS and a re-review overwrites), then classify by the
- * SHA-staleness test — `current` iff its `@ <sha>` prefix-matches the head, else `stale`;
- * `sha-less` when the newest marker carries no `@ <sha>`; `none` when the authorized candidate
- * set is empty. Fail-closed everywhere: an empty authorized set is `none`, never a false win.
+ * Resolve which verdict is IN FORCE for a (PR, gate) against the current head — the single
+ * resolution `verdict read` and `verdict gate` both consume (#4049).
+ *
+ * Author-gate to write+ collaborators (a forged artifact is invisible, ADR 0055), take the
+ * **newest** authorized artifact by `(createdAt, id)` across the namespace's candidate forms — the
+ * PASS/FAIL markers always, plus the §CP advisory when `controlPlane` — then classify it by the
+ * ADR-0058 rule-3 staleness test against its own head binding (a marker's `@ <sha>`; an advisory's
+ * body `Reviewed-head:` anchor).
+ *
+ * Latest-wins across BOTH forms is the load-bearing part. A §CP body-only repair deliberately does
+ * not move the head — moving it would dismiss the control-plane approval and force a full
+ * re-review — so staleness-invalidation cannot retire the superseded FAIL markers it repaired, and
+ * a polarity-only candidate set (which an advisory, carrying no PASS/FAIL, can never enter) keeps
+ * resolving one of them as current forever (#4049). Recency across the whole namespace is what
+ * retires them; nothing here moves or needs the head to move.
+ *
+ * Fail-closed everywhere: an empty authorized set is `none`, never a false win.
  */
 export const resolveVerdict = (input: ResolveVerdictInput): VerdictOutcome => {
-	const latest = pickLatestAuthorized(
+	const marker = pickLatestAuthorized(
 		input.comments,
 		input.authorizedAuthors,
 		polarityRe(input.gate),
 	);
-	// `latest` is absent only for an empty candidate set, and `parseVerdict` is null only for a
-	// non-PASS/FAIL body — but polarityRe already filtered candidates to PASS/FAIL markers, so both
-	// guards collapse to the same fail-closed `none` (no consumable verdict in this namespace).
-	const parsed = latest ? parseVerdict(latest.body, input.gate) : null;
-	if (latest === undefined || parsed === null) return {_tag: "none"};
+	const advisory = input.controlPlane
+		? pickLatestAuthorized(input.comments, input.authorizedAuthors, advisoryRe(input.gate))
+		: undefined;
+	const latest = newerOf(marker, advisory);
+	if (latest === undefined) return {_tag: "none", form: "none"};
+	if (latest === advisory) return resolveAdvisory(latest, input.headSha);
+	// `parseVerdict` is null only for a non-PASS/FAIL body, which `polarityRe` already excluded —
+	// the unreachable branch collapses into the same fail-closed `none` rather than a non-null assert.
+	const parsed = parseVerdict(latest.body, input.gate);
+	if (parsed === null) return {_tag: "none", form: "none"};
 	if (parsed.sha === null) {
-		return {_tag: "sha-less", commentId: latest.id, polarity: parsed.polarity};
+		return {_tag: "sha-less", form: "marker", commentId: latest.id, polarity: parsed.polarity};
 	}
 	if (!isBoundToHead(parsed.sha, input.headSha)) {
-		return {_tag: "stale", commentId: latest.id, polarity: parsed.polarity, sha: parsed.sha};
+		return {
+			_tag: "stale",
+			form: "marker",
+			commentId: latest.id,
+			polarity: parsed.polarity,
+			sha: parsed.sha,
+		};
 	}
-	return {_tag: "current", commentId: latest.id, polarity: parsed.polarity, sha: parsed.sha};
+	return {
+		_tag: "current",
+		form: "marker",
+		commentId: latest.id,
+		polarity: parsed.polarity,
+		sha: parsed.sha,
+	};
 };
 
 /**
- * The `read` verb's decision: is HEAD reviewed with the expected polarity? True **only** for a
- * current-head-bound verdict whose polarity matches — a `sha-less`, `stale`, or `none` outcome
- * is never satisfied. `ship-it` expects `PASS`; `write-code`-repair expects `FAIL` (the seam it
- * consumes). This is the single boolean the inline `is_current`-then-polarity checks recomputed.
+ * Project a resolved outcome onto the four namespace states. This is the ONE place "is the in-force
+ * verdict a pass / a fail / absent / unverified" is decided, so `read`'s `--expect` match and
+ * `gate`'s per-namespace conjunction are the same question asked twice, not two rules (#4049).
+ */
+export const verdictState = (outcome: VerdictOutcome): VerdictState => {
+	if (outcome._tag === "none") return "absent";
+	if (outcome._tag === "current") return outcome.polarity === "PASS" ? "pass" : "fail";
+	return "unverified";
+};
+
+/**
+ * The `read` verb's decision: is HEAD reviewed with the expected polarity? True **only** when the
+ * in-force verdict's state matches — `ship-it` expects `PASS`, `write-code`-repair expects `FAIL`
+ * (the seam it consumes). Expressed through `verdictState` so a `read --expect PASS` is satisfied
+ * by exactly what `gate` calls a pass, and `--expect FAIL` by exactly what `gate` calls a fail.
  */
 export const isReviewed = (outcome: VerdictOutcome, expect: Polarity): boolean =>
-	outcome._tag === "current" && outcome.polarity === expect;
+	verdictState(outcome) === (expect === "PASS" ? "pass" : "fail");
 
 /**
  * A machine-readable reason for a non-satisfying `read` outcome — the named refusal `ship-it`
@@ -213,13 +349,22 @@ export const outcomeReason = (outcome: VerdictOutcome, expect: Polarity): string
 		case "none":
 			return "no authorized verdict in this namespace";
 		case "sha-less":
-			return "unverified (verdict not bound to current head): latest marker is SHA-less (pre-0058)";
+			return outcome.form === "advisory"
+				? "unverified (verdict not bound to current head): the §CP advisory carries no 'Reviewed-head: @ <sha>' body binding (ADR 0151)"
+				: "unverified (verdict not bound to current head): latest marker is SHA-less (pre-0058)";
 		case "stale":
-			return `unverified (verdict not bound to current head): latest marker bound to ${outcome.sha}, not the current head`;
+			return outcome.form === "advisory"
+				? `unverified (verdict not bound to current head): the §CP advisory's Reviewed-head is ${outcome.sha}, not the current head`
+				: `unverified (verdict not bound to current head): latest marker bound to ${outcome.sha}, not the current head`;
+		case "advisory-not-all-pass":
+			return `unverified (§CP advisory @ ${outcome.sha} is not all-PASS — a body checkbox is [FAIL])`;
 		case "current":
-			return outcome.polarity === expect
-				? `reviewed: current-head ${outcome.polarity} @ ${outcome.sha}`
-				: `current-head verdict is ${outcome.polarity}, expected ${expect}`;
+			if (outcome.polarity !== expect) {
+				return `current-head verdict is ${outcome.polarity}, expected ${expect}`;
+			}
+			return outcome.form === "advisory"
+				? `reviewed: current-head §CP all-PASS advisory @ ${outcome.sha} (the ADR 0111/0151 PASS-equivalent)`
+				: `reviewed: current-head ${outcome.polarity} @ ${outcome.sha}`;
 	}
 };
 

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -28,6 +28,19 @@ const marker = (over: Partial<VerdictComment> & {readonly id: number}): VerdictC
 	...over,
 });
 
+const CODE_FAIL_AT_HEAD = `review-code: FAIL @ ${HEAD} — changes-requested`;
+
+/** The canonical §CP advisory shape: SHA-less first line, head bound in the body (ADR 0111/0151). */
+const allPassAdvisory = (reviewedHead: string): string =>
+	[
+		"review-code: advisory — blocking-set PR (manual merge)",
+		"",
+		`Reviewed-head: @ ${reviewedHead}`,
+		"",
+		"- [PASS] the linkage seam is armed",
+		"- [PASS] the diff matches the acceptance criteria",
+	].join("\n");
+
 describe("parseVerdict — polarity + bound SHA out of a first-line marker", () => {
 	const cases: ReadonlyArray<{
 		readonly name: string;
@@ -110,8 +123,12 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 		readonly authorized: ReadonlyArray<string>;
 		readonly gate: VerdictGate;
 		readonly head: string;
+		/** §CP-ness: omitted ⇒ a plain auto-merge PR, where the advisory is not a candidate at all. */
+		readonly controlPlane?: boolean;
 		readonly expected: VerdictOutcome;
 		readonly reviewedPass: boolean;
+		/** Does the outcome satisfy an `--expect FAIL` read (the write-code repair seam)? */
+		readonly reviewedFail?: boolean;
 	}> = [
 		{
 			name: "matching @sha PASS → current PASS (reviewed)",
@@ -119,7 +136,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+			expected: {_tag: "current", form: "marker", commentId: 1, polarity: "PASS", sha: HEAD},
 			reviewedPass: true,
 		},
 		{
@@ -128,7 +145,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "sha-less", commentId: 1, polarity: "PASS"},
+			expected: {_tag: "sha-less", form: "marker", commentId: 1, polarity: "PASS"},
 			reviewedPass: false,
 		},
 		{
@@ -137,7 +154,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "stale", commentId: 1, polarity: "PASS", sha: OLD},
+			expected: {_tag: "stale", form: "marker", commentId: 1, polarity: "PASS", sha: OLD},
 			reviewedPass: false,
 		},
 		{
@@ -157,7 +174,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+			expected: {_tag: "current", form: "marker", commentId: 2, polarity: "FAIL", sha: HEAD},
 			reviewedPass: false,
 		},
 		{
@@ -177,7 +194,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+			expected: {_tag: "current", form: "marker", commentId: 2, polarity: "FAIL", sha: HEAD},
 			reviewedPass: false,
 		},
 		{
@@ -197,7 +214,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "current", commentId: 20, polarity: "PASS", sha: HEAD},
+			expected: {_tag: "current", form: "marker", commentId: 20, polarity: "PASS", sha: HEAD},
 			reviewedPass: true,
 		},
 		// The run-scoped upsert (#4016) means two reviewer RUNS can now leave two verdict comments
@@ -221,7 +238,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "current", commentId: 2, polarity: "PASS", sha: HEAD},
+			expected: {_tag: "current", form: "marker", commentId: 2, polarity: "PASS", sha: HEAD},
 			reviewedPass: true,
 		},
 		{
@@ -243,7 +260,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+			expected: {_tag: "current", form: "marker", commentId: 2, polarity: "FAIL", sha: HEAD},
 			reviewedPass: false,
 		},
 		{
@@ -252,7 +269,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: [],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "none"},
+			expected: {_tag: "none", form: "none"},
 			reviewedPass: false,
 		},
 		{
@@ -261,7 +278,7 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "none"},
+			expected: {_tag: "none", form: "none"},
 			reviewedPass: false,
 		},
 		{
@@ -270,20 +287,127 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			authorized: ["usirin"],
 			gate: "doc",
 			head: HEAD,
-			expected: {_tag: "none"},
+			expected: {_tag: "none", form: "none"},
 			reviewedPass: false,
 		},
+		// The #4049 body-only-repair sequence, the PR #3988 marker set: two FAILs and an all-PASS
+		// advisory, ALL bound to the one head the repair deliberately did not move. Recency across
+		// both forms is what retires the superseded FAILs — staleness-invalidation structurally
+		// cannot, since nothing moved.
+		{
+			name: "§CP body-only repair: the newer all-PASS advisory supersedes the same-head FAILs (#4049)",
+			comments: [
+				marker({id: 1, createdAt: "2026-07-24T06:51:00Z", body: CODE_FAIL_AT_HEAD}),
+				marker({id: 2, createdAt: "2026-07-24T19:16:00Z", body: CODE_FAIL_AT_HEAD}),
+				marker({id: 3, createdAt: "2026-07-24T19:22:00Z", body: allPassAdvisory(HEAD)}),
+			],
+			authorized: ["usirin"],
+			gate: "code",
+			head: HEAD,
+			controlPlane: true,
+			expected: {_tag: "current", form: "advisory", commentId: 3, polarity: "PASS", sha: HEAD},
+			reviewedPass: true,
+			reviewedFail: false,
+		},
+		{
+			name: "the same marker set on a NON-§CP PR: the advisory is no candidate, so the FAIL still stands",
+			comments: [
+				marker({id: 1, createdAt: "2026-07-24T06:51:00Z", body: CODE_FAIL_AT_HEAD}),
+				marker({id: 2, createdAt: "2026-07-24T19:16:00Z", body: CODE_FAIL_AT_HEAD}),
+				marker({id: 3, createdAt: "2026-07-24T19:22:00Z", body: allPassAdvisory(HEAD)}),
+			],
+			authorized: ["usirin"],
+			gate: "code",
+			head: HEAD,
+			expected: {_tag: "current", form: "marker", commentId: 2, polarity: "FAIL", sha: HEAD},
+			reviewedPass: false,
+			reviewedFail: true,
+		},
+		{
+			name: "§CP: a FAIL posted AFTER the advisory is the in-force verdict (recency, not form, decides)",
+			comments: [
+				marker({id: 1, createdAt: "2026-07-24T19:00:00Z", body: allPassAdvisory(HEAD)}),
+				marker({id: 2, createdAt: "2026-07-24T19:16:00Z", body: CODE_FAIL_AT_HEAD}),
+			],
+			authorized: ["usirin"],
+			gate: "code",
+			head: HEAD,
+			controlPlane: true,
+			expected: {_tag: "current", form: "marker", commentId: 2, polarity: "FAIL", sha: HEAD},
+			reviewedPass: false,
+			reviewedFail: true,
+		},
+		{
+			name: "§CP: a current-head advisory carrying a [FAIL] checkbox is neither a pass nor a marker FAIL",
+			comments: [
+				marker({id: 1, createdAt: "2026-07-24T06:51:00Z", body: CODE_FAIL_AT_HEAD}),
+				marker({
+					id: 2,
+					createdAt: "2026-07-24T19:22:00Z",
+					body: `${allPassAdvisory(HEAD)}\n- [FAIL] the linkage token still auto-closes`,
+				}),
+			],
+			authorized: ["usirin"],
+			gate: "code",
+			head: HEAD,
+			controlPlane: true,
+			expected: {_tag: "advisory-not-all-pass", form: "advisory", commentId: 2, sha: HEAD},
+			reviewedPass: false,
+			reviewedFail: false,
+		},
+		{
+			name: "§CP: an advisory with no Reviewed-head anchor binds nothing (ADR 0151) — unverified",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: "2026-07-24T19:22:00Z",
+					body: "review-code: advisory — blocking-set PR (manual merge)\n\n- [PASS] every check",
+				}),
+			],
+			authorized: ["usirin"],
+			gate: "code",
+			head: HEAD,
+			controlPlane: true,
+			expected: {_tag: "sha-less", form: "advisory", commentId: 1, polarity: null},
+			reviewedPass: false,
+			reviewedFail: false,
+		},
+		{
+			name: "§CP: an advisory whose Reviewed-head is a superseded head is stale, never a pass",
+			comments: [marker({id: 1, createdAt: "2026-07-24T19:22:00Z", body: allPassAdvisory(OLD)})],
+			authorized: ["usirin"],
+			gate: "code",
+			head: HEAD,
+			controlPlane: true,
+			expected: {_tag: "stale", form: "advisory", commentId: 1, polarity: null, sha: OLD},
+			reviewedPass: false,
+			reviewedFail: false,
+		},
 	];
-	for (const {name, comments, authorized, gate, head, expected, reviewedPass} of cases) {
+	for (const {
+		name,
+		comments,
+		authorized,
+		gate,
+		head,
+		controlPlane,
+		expected,
+		reviewedPass,
+		reviewedFail,
+	} of cases) {
 		it(name, () => {
 			const outcome = resolveVerdict({
 				comments,
 				authorizedAuthors: authorized,
 				gate,
 				headSha: head,
+				controlPlane: controlPlane ?? false,
 			});
 			assert.deepStrictEqual(outcome, expected);
 			assert.strictEqual(isReviewed(outcome, "PASS"), reviewedPass);
+			if (reviewedFail !== undefined) {
+				assert.strictEqual(isReviewed(outcome, "FAIL"), reviewedFail);
+			}
 		});
 	}
 
@@ -293,28 +417,58 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 			marker({id: 2, body: `review-skill: FAIL @ ${HEAD} — changes-requested`}),
 		];
 		assert.deepStrictEqual(
-			resolveVerdict({comments, authorizedAuthors: ["usirin"], gate: "code", headSha: HEAD}),
-			{_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+			resolveVerdict({
+				comments,
+				authorizedAuthors: ["usirin"],
+				gate: "code",
+				headSha: HEAD,
+				controlPlane: false,
+			}),
+			{_tag: "current", form: "marker", commentId: 1, polarity: "PASS", sha: HEAD},
 		);
 		assert.deepStrictEqual(
-			resolveVerdict({comments, authorizedAuthors: ["usirin"], gate: "skill", headSha: HEAD}),
-			{_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+			resolveVerdict({
+				comments,
+				authorizedAuthors: ["usirin"],
+				gate: "skill",
+				headSha: HEAD,
+				controlPlane: false,
+			}),
+			{_tag: "current", form: "marker", commentId: 2, polarity: "FAIL", sha: HEAD},
 		);
 		assert.deepStrictEqual(
-			resolveVerdict({comments, authorizedAuthors: ["usirin"], gate: "doc", headSha: HEAD}),
-			{_tag: "none"},
+			resolveVerdict({
+				comments,
+				authorizedAuthors: ["usirin"],
+				gate: "doc",
+				headSha: HEAD,
+				controlPlane: false,
+			}),
+			{_tag: "none", form: "none"},
 		);
 	});
 });
 
 describe("isReviewed — read-verb decision over expected polarity", () => {
 	it("current FAIL satisfies an expect-FAIL read (write-code repair seam)", () => {
-		const outcome: VerdictOutcome = {_tag: "current", commentId: 1, polarity: "FAIL", sha: HEAD};
+		const outcome: VerdictOutcome = {
+			_tag: "current",
+			form: "marker",
+			commentId: 1,
+			polarity: "FAIL",
+			sha: HEAD,
+		};
 		assert.isTrue(isReviewed(outcome, "FAIL"));
 		assert.isFalse(isReviewed(outcome, "PASS"));
 	});
 	it("a stale verdict never satisfies either polarity", () => {
-		const outcome: VerdictOutcome = {_tag: "stale", commentId: 1, polarity: "PASS", sha: OLD};
+		const outcome: VerdictOutcome = {
+			_tag: "stale",
+			form: "marker",
+			commentId: 1,
+			polarity: "PASS",
+			sha: OLD,
+		};
 		assert.isFalse(isReviewed(outcome, "PASS"));
 		assert.isFalse(isReviewed(outcome, "FAIL"));
 	});


### PR DESCRIPTION
A control-plane PR whose review finding is fixed by editing the PR **body** never moves its head — on purpose, because moving it would dismiss the control-plane approval and force a full re-review. But the machinery that retires a superseded verdict works by comparing heads, so on that shape it can never fire: the answered FAIL stays bound to the live head forever. `verdict gate` got the right answer anyway (it picks the newest artifact in a namespace, which is the advisory the repair earned); `verdict read` did not (it only ever looked at PASS/FAIL markers, and an advisory carries neither), so the same marker set said "fixed" to one consumer and "still failing" to the other. That is what left PR #3988 wedged with a defect that was already repaired.

This makes "which verdict is in force" one answer instead of two. `resolveVerdict` now takes §CP-ness as an input and picks the newest authorized artifact across both forms — the PASS/FAIL markers, plus the control-plane advisory — then classifies it by whatever head binding the winner carries. `decideGate` projects that single resolution rather than computing its own, so the two verbs cannot drift apart again. `verdict read` gains the `--cp` flag `gate` already had, and every pipeline consumer of the seam (ship-it's per-namespace reads, write-code's repair scan and Step R1, heal-ci's in-flight-repair probe) now passes it.

Nothing here moves a head, and no empty commit is introduced.

**Verified live against the reference fixture** (PR #3988, head `0368922e`, marker set: FAIL @ h, FAIL @ h, all-PASS advisory @ h):

- `verdict read --gate code --expect FAIL --cp` → exit 1, `{"_tag":"current","form":"advisory","polarity":"PASS"}` — the superseded FAIL is no longer the in-force verdict.
- `verdict read --gate code --expect PASS --cp` → exit 0 — agrees with `verdict gate --require review-code --cp`.
- Without `--cp` the old marker-only resolution is unchanged, which is correct for a non-control-plane PR (there, a body-only repair self-heals via a newer same-head PASS marker).

The sequence is table-tested for both verbs in `packages/pipeline-cli/src/tools/verdict/`, including a cross-consumer agreement table that fails if a second resolution is ever reintroduced.

Note for review: this diff touches gate-critical skills, so it is a §CP PR.

Fixes #4049
