### PR TITLE
fix(crew-mcp): reconcile a seat's declared MCP tokens against the tools the crew server serves (#4002)

### DIFF
--- a/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
+++ b/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
@@ -71,6 +71,25 @@ message to an inbox — which is why the claim needs its own tool (#3509). Only 
 it; the bridges (chief-of-staff, cartographer, intake-desk) claim nothing, so they carry
 `channel_send` + `channel_kinds` but not `channel_claim`.
 
+## What the launcher asserts before a seat boots — and the one gap it cannot close
+
+Stand-up refuses to launch a seat whose def and the crew server disagree
+(`packages/pipeline-crew-mcp/src/standup/toolset-assert.ts`). Post-connect a seat's granted set is
+exactly **declared ∩ served**, and both sides are known before launch, so the runtime outcome is
+settled with zero panes up instead of mid-drain by a rejected send (#4002):
+
+- a token for **this** server naming a tool it does not serve (a typo, a renamed or removed tool) is
+  refused — no connect window can produce a name that will never be on a `tools/list`;
+- a def that **omits** `channel_send` or `channel_kinds` is refused — those two are mandatory for
+  every seat, so the pair can never go silently missing from a def again;
+- a token for **another** MCP server stays exempt: its toolset is unknowable here.
+
+**The gap this does not close, stated plainly.** A live session's grant is fixed at ITS boot, from the
+def as it stood THEN, and a seat has no way to read its own granted toolset back. So editing a def
+under a running crew changes nothing for that crew, and the skew is invisible from inside it — the
+seat sees the new def on disk while holding the old grant. The remedy is a re-stand-up, not a wait:
+that is what re-runs the assert against the defs the seats will actually boot from.
+
 ## The boot window — wait and re-check, never diagnose infra
 
 Even with the token in place, the crew server does not advertise `channel_send` the instant a

--- a/claude-plugins/pipeline-crew/REFERENCE.md
+++ b/claude-plugins/pipeline-crew/REFERENCE.md
@@ -38,12 +38,16 @@ sanitized (`[^a-zA-Z0-9_-]` → `_`, so `@`/`/` become `_`, hyphens preserved) +
 `channel_send`. The leading `_` of the sanitized name makes the join a **triple** underscore.
 A wrong string fails closed (present-but-uncallable). Single source: [`CHANNEL-TOOL.md`](CHANNEL-TOOL.md).
 
-The **engineering-manager** (the one engine) carries a **second** channel token on top of
-`channel_send` — `mcp___kampus_pipeline-crew-mcp__channel_claim` — which claims a tracker
-resource before it opens a lane (cross-engine deconfliction, a real lock rather than a relayed
-message). Only the engine lists it; the three bridges list `channel_send` alone. So when
-reconstructing the engine def from the roster table below, note its `tools:` array is five
-entries, not four. Why it needs its own tool: [`CHANNEL-TOOL.md`](CHANNEL-TOOL.md).
+Every def carries the discovery token `mcp___kampus_pipeline-crew-mcp__channel_kinds` alongside it,
+derived the same way — a seat that can send but cannot resolve a kind's shape rediscovers every
+payload by rejected send. The pair is **mandatory** and the launcher refuses a stand-up whose seat
+def drops either one (see [`CHANNEL-TOOL.md`](CHANNEL-TOOL.md)).
+
+The **engineering-manager** (the one engine) carries a **third** channel token on top of that pair —
+`mcp___kampus_pipeline-crew-mcp__channel_claim` — which claims a tracker resource before it opens a
+lane (cross-engine deconfliction, a real lock rather than a relayed message). Only the engine lists
+it; the three bridges carry the mandatory pair alone. Why it needs its own tool:
+[`CHANNEL-TOOL.md`](CHANNEL-TOOL.md).
 
 ### Per-def frontmatter values
 
@@ -51,16 +55,15 @@ The exact shipped values, matching each def head:
 
 | Def file | `name` | `color` | `tools` |
 |---|---|---|---|
-| [`agents/crew-cartographer.md`](agents/crew-cartographer.md) | `crew-cartographer` | `green` | `Read`, `Bash`, `Task`, `channel_send` |
-| [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) | `crew-intake-desk` | `yellow` | `Read`, `Bash`, `Task`, `channel_send` |
-| [`agents/crew-engineering-manager.md`](agents/crew-engineering-manager.md) | `crew-engineering-manager` | `cyan` | `Task`, `Bash`, `Read`, `channel_send`, `channel_claim` |
-| [`agents/crew-chief-of-staff.md`](agents/crew-chief-of-staff.md) | `crew-chief-of-staff` | `magenta` | `Read`, `Bash`, `Task`, `channel_send` |
+| [`agents/crew-cartographer.md`](agents/crew-cartographer.md) | `crew-cartographer` | `green` | `Read`, `Bash`, `Task`, `channel_send`, `channel_kinds` |
+| [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) | `crew-intake-desk` | `yellow` | `Read`, `Bash`, `Task`, `channel_send`, `channel_kinds` |
+| [`agents/crew-engineering-manager.md`](agents/crew-engineering-manager.md) | `crew-engineering-manager` | `cyan` | `Task`, `Bash`, `Read`, `channel_send`, `channel_claim`, `channel_kinds` |
+| [`agents/crew-chief-of-staff.md`](agents/crew-chief-of-staff.md) | `crew-chief-of-staff` | `magenta` | `Read`, `Bash`, `Task`, `channel_send`, `channel_kinds` |
 
-`channel_send` above is the full `mcp___kampus_pipeline-crew-mcp__channel_send` token,
-abbreviated in this table for width; `channel_claim` on the engineering-manager row is
-likewise the full `mcp___kampus_pipeline-crew-mcp__channel_claim` token. Only the
-engineering-manager (the one engine) carries `channel_claim` — the three bridges list
-`channel_send` alone (see the channel-token subsection above). `model` is `inherit` for all four.
+Each `channel_*` above is the full `mcp___kampus_pipeline-crew-mcp__<tool>` token, abbreviated in
+this table for width. All four carry the mandatory `channel_send` + `channel_kinds` pair; only the
+engineering-manager (the one engine) adds `channel_claim` (see the channel-token subsection above).
+`model` is `inherit` for all four.
 
 The `Task` tool marks a role that **spawns subagents**: the three spawning roles
 (cartographer, intake-desk, engineering-manager) carry it; the chief-of-staff, which only

--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -84,6 +84,15 @@ export {
 	kindOf,
 } from "./roles.ts";
 export {
+	CREW_MCP_TOOL_PREFIX,
+	CREW_SERVED_TOOL_NAMES,
+	CREW_SESSION_TOOLKITS,
+	crewMcpToolName,
+	crewMcpToolToken,
+	REQUIRED_SEAT_CHANNEL_TOOLS,
+	sanitizeMcpServerName,
+} from "./served-toolset.ts";
+export {
 	type CrewSessionConfig,
 	channelSendFromPeer,
 	crewSessionLayer,

--- a/packages/pipeline-crew-mcp/src/crew/served-toolset.ts
+++ b/packages/pipeline-crew-mcp/src/crew/served-toolset.ts
@@ -1,0 +1,58 @@
+/**
+ * crew/served-toolset — the ONE declaration of what a live crew session's MCP server serves, and of
+ * how a seat's `tools:` allowlist names those tools. `assembleCrewSession` schema-fences and registers
+ * exactly `CREW_SESSION_TOOLKITS`; the launcher's seat assert (`standup/toolset-assert.ts`) reconciles
+ * every seat's declared `mcp__*` token against the same array. One source, so "declared" and "served"
+ * cannot drift through a hand-maintained second list.
+ *
+ * The one non-obvious thing: a seat's allowlist token is the CLI's callable name for a served tool —
+ * `mcp__` + the server name sanitized by `replace(/[^a-zA-Z0-9_-]/g, "_")` + `__` + the tool name
+ * (the derivation is single-sourced in `claude-plugins/pipeline-crew/CHANNEL-TOOL.md`). Deriving the
+ * token here instead of hand-writing the string is what makes "can this declared token EVER resolve?"
+ * a decidable, static question rather than something only a live boot can answer.
+ */
+import type {Tool, Toolkit} from "effect/unstable/ai";
+import {ClaimToolkit} from "../edge/claim-tool.ts";
+import {KindsToolkit} from "../edge/kinds-tool.ts";
+import {ReleaseToolkit} from "../edge/release-tool.ts";
+import {ChannelToolkit} from "../edge/send-tool.ts";
+
+/** The MCP server identity a crew session advertises over stdio when none is configured. */
+export const SESSION_SERVER_NAME = "@kampus/pipeline-crew-mcp" as const;
+
+/** Every toolkit a live crew session registers on its one served `McpServer` (`assembleCrewSession`). */
+export const CREW_SESSION_TOOLKITS: ReadonlyArray<Toolkit.Any> = [
+	ChannelToolkit,
+	ClaimToolkit,
+	ReleaseToolkit,
+	KindsToolkit,
+];
+
+/** The tool names a connected crew session server actually serves, read off the toolkits it registers. */
+export const CREW_SERVED_TOOL_NAMES: ReadonlySet<string> = new Set(
+	CREW_SESSION_TOOLKITS.flatMap((toolkit) =>
+		Object.values(toolkit.tools).map((tool: Tool.Any) => tool.name),
+	),
+);
+
+/** Sanitize an MCP server name into the segment claude-code builds a tool token from. */
+export const sanitizeMcpServerName = (server: string): string =>
+	server.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+/** The `mcp__<sanitized server>__` prefix every crew channel tool's allowlist token carries. */
+export const CREW_MCP_TOOL_PREFIX = `mcp__${sanitizeMcpServerName(SESSION_SERVER_NAME)}__`;
+
+/** The `tools:` allowlist token a seat must declare to call one crew channel tool. */
+export const crewMcpToolToken = (tool: string): string => `${CREW_MCP_TOOL_PREFIX}${tool}`;
+
+/** The crew tool an allowlist entry names, or null when the entry is not a crew-server MCP token. */
+export const crewMcpToolName = (entry: string): string | null =>
+	entry.startsWith(CREW_MCP_TOOL_PREFIX) ? entry.slice(CREW_MCP_TOOL_PREFIX.length) : null;
+
+/**
+ * The channel tools EVERY launched crew seat must declare. A seat that can send but cannot resolve a
+ * kind's shape discovers every payload by rejected send (CHANNEL-TOOL.md, #3761/#3622) — so the pair is
+ * a contract, not a per-role choice. `channel_claim`/`channel_release` stay role-scoped by design: only
+ * the engine deconflicts resources, so they are deliberately absent from the bridges' declarations.
+ */
+export const REQUIRED_SEAT_CHANNEL_TOOLS: readonly string[] = ["channel_send", "channel_kinds"];

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -68,10 +68,10 @@ import {resolveChannelContract} from "./contract.ts";
 import type {RoleUniquenessError} from "./errors.ts";
 import {crewHeartbeatLayer} from "./heartbeat.ts";
 import {type CrewRole, kindOf} from "./roles.ts";
+import {CREW_SESSION_TOOLKITS, SESSION_SERVER_NAME} from "./served-toolset.ts";
 import {type CrewTracker, crewTrackerHostOrDialLayer, peerTrackerLayer} from "./tracker.ts";
 
-/** The MCP server identity a crew session advertises over stdio when none is configured. */
-export const SESSION_SERVER_NAME = "@kampus/pipeline-crew-mcp" as const;
+export {SESSION_SERVER_NAME};
 
 export interface CrewSessionConfig {
 	readonly role: CrewRole;
@@ -215,7 +215,7 @@ export const assembleCrewSession = <RIn, RSub = never>(
 			// Startup invariant (#3753): every tool this session will register must generate a spec-valid
 			// top-level `{"type":"object"}` inputSchema. A client rejects the WHOLE tools/list response on
 			// one bad schema, so the failure mode without this fence is a silently tool-less session.
-			yield* assertToolSchemas([ChannelToolkit, ClaimToolkit, ReleaseToolkit, KindsToolkit]);
+			yield* assertToolSchemas(CREW_SESSION_TOOLKITS);
 			const channel = yield* makeCrewChannel({role: config.role, address});
 			// Startup invariant (#3622): resolve the full discoverable channel contract BEFORE serving.
 			// A shared kind set that can't be fully resolved to a shape fails the build HERE (on the boot

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -148,6 +148,7 @@ export {
 	type DeclaredToolset,
 	GRANTABLE_SESSION_TOOLS,
 	isMcpToolToken,
+	missingSeatChannelTools,
 	parseDeclaredToolset,
 	readSeatToolsetFromDef,
 	resolveDeclaredToolset,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -11,7 +11,13 @@
 import {NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {CREW_ROLES, isAutobooted, kindOf} from "../crew/index.ts";
+import {
+	CREW_ROLES,
+	crewMcpToolToken,
+	isAutobooted,
+	kindOf,
+	REQUIRED_SEAT_CHANNEL_TOOLS,
+} from "../crew/index.ts";
 import {CREW_PLUGIN_CHANNEL_REF, CREW_SESSION_INSTANCE_FLAG} from "./bind.ts";
 import {
 	DEFAULT_CONFIG_PATH,
@@ -54,7 +60,11 @@ const SERVER = "@kampus/pipeline-crew-mcp";
  * fake path with no `claude-plugins/` under it.
  */
 const WELL_DECLARED_SEAT: SeatToolsetReader = () =>
-	Effect.succeed({_tag: "allowlist", tools: ["Read", "Bash", "Task"], disallowedTools: []});
+	Effect.succeed({
+		_tag: "allowlist",
+		tools: ["Read", "Bash", "Task", ...REQUIRED_SEAT_CHANNEL_TOOLS.map(crewMcpToolToken)],
+		disallowedTools: [],
+	});
 
 // The per-session bind reaches the platform through the FileSystem/Path seam; provide the real Node
 // platform (the bin's NodeServices.layer) so runStandUp discharges it in-test. These tests inject

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -583,9 +583,10 @@ export const runStandUp = (
 		// The roster set is derived here — ahead of the tracker — only so the next assert can name the
 		// exact seats this stand-up launches. `deriveSessionSet` is pure; nothing observable moved.
 		const sessions = deriveSessionSet({engineCount: config.engineCount, instanceId});
-		// Refuse a seat whose def declares a toolset the CLI would not grant intact (#3764): an ungrantable
-		// or self-denied tool is dropped SILENTLY, so without this a bridge boots without the `Task` its
-		// charter conducts through and nothing surfaces it (toolset-assert.ts).
+		// Refuse a seat whose def declares a toolset the CLI would not grant intact (#3764/#4002): an
+		// ungrantable, self-denied, or unserved-MCP tool is dropped SILENTLY, so without this a bridge
+		// boots without the `Task` its charter conducts through — or without `channel_kinds` — and nothing
+		// surfaces it (toolset-assert.ts).
 		yield* assertCrewSeatToolsets(
 			projectRoot,
 			[...new Set(sessions.map((session) => session.role))],

--- a/packages/pipeline-crew-mcp/src/standup/single-role.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/single-role.test.ts
@@ -13,7 +13,7 @@
 import {NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {inboxAddressFor} from "../crew/index.ts";
+import {crewMcpToolToken, inboxAddressFor, REQUIRED_SEAT_CHANNEL_TOOLS} from "../crew/index.ts";
 import {
 	DEFAULT_CONFIG_PATH,
 	decodeLaunchConfig,
@@ -171,7 +171,7 @@ const baseSpawn = (
 			readSeatToolset: (() =>
 				Effect.succeed({
 					_tag: "allowlist" as const,
-					tools: ["Read", "Bash", "Task"],
+					tools: ["Read", "Bash", "Task", ...REQUIRED_SEAT_CHANNEL_TOOLS.map(crewMcpToolToken)],
 					disallowedTools: [],
 				})) satisfies SeatToolsetReader,
 			instanceId: (() => {

--- a/packages/pipeline-crew-mcp/src/standup/toolset-assert.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/toolset-assert.test.ts
@@ -11,18 +11,27 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {CREW_ROLES} from "../crew/index.ts";
 import {
+	CREW_SERVED_TOOL_NAMES,
+	crewMcpToolToken,
+	REQUIRED_SEAT_CHANNEL_TOOLS,
+} from "../crew/served-toolset.ts";
+import {
 	assertCrewSeatToolsets,
 	assertSeatToolset,
 	baseToolName,
 	CrewSeatDefUnreadableError,
 	CrewSeatToolsetMismatchError,
 	type DeclaredToolset,
+	missingSeatChannelTools,
 	parseDeclaredToolset,
 	readSeatToolsetFromDef,
 	resolveDeclaredToolset,
 	type SeatToolsetReader,
 	seatDefRelativePath,
 } from "./toolset-assert.ts";
+
+/** The two tokens every seat must carry — built through the same derivation the assert compares against. */
+const CHANNEL_TOKENS = REQUIRED_SEAT_CHANNEL_TOOLS.map(crewMcpToolToken);
 
 /** The repo root the shipped crew defs live under — resolved from this file, never a machine path. */
 const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
@@ -101,7 +110,52 @@ describe("standup/toolset-assert — resolveDeclaredToolset", () => {
 			granted: [],
 			ungrantable: [],
 			selfDenied: [],
+			unservedMcp: [],
 		});
+	});
+
+	// Rule 3 (#4002): the connect-window exemption now covers a SERVED tool only.
+	it("drops a crew MCP token naming a tool the crew server does not serve", () => {
+		const {granted, unservedMcp} = resolveDeclaredToolset(
+			allowlist([crewMcpToolToken("channel_kind"), crewMcpToolToken("channel_kinds")]),
+		);
+		assert.deepStrictEqual(unservedMcp, [crewMcpToolToken("channel_kind")]);
+		assert.deepStrictEqual(granted, [crewMcpToolToken("channel_kinds")]);
+	});
+
+	it("leaves a FOREIGN server's MCP token exempt — its toolset is unknowable before launch", () => {
+		const {granted, unservedMcp} = resolveDeclaredToolset(
+			allowlist(["mcp__some_other_server__anything"]),
+		);
+		assert.deepStrictEqual(granted, ["mcp__some_other_server__anything"]);
+		assert.deepStrictEqual(unservedMcp, []);
+	});
+});
+
+describe("standup/toolset-assert — missingSeatChannelTools (rule 4)", () => {
+	it("names the channel tools a declaration omits", () => {
+		assert.deepStrictEqual(missingSeatChannelTools(allowlist(["Read", "Bash"])), CHANNEL_TOKENS);
+		assert.deepStrictEqual(
+			missingSeatChannelTools(allowlist(["Read", crewMcpToolToken("channel_send")])),
+			[crewMcpToolToken("channel_kinds")],
+		);
+	});
+
+	it("counts a self-denied channel token as missing — a subtracted tool is not callable", () => {
+		assert.deepStrictEqual(
+			missingSeatChannelTools(allowlist([...CHANNEL_TOKENS], [crewMcpToolToken("channel_kinds")])),
+			[crewMcpToolToken("channel_kinds")],
+		);
+	});
+
+	it("requires nothing of a def that declares no allowlist — it inherits the full toolset", () => {
+		assert.deepStrictEqual(missingSeatChannelTools({_tag: "inherit"}), []);
+	});
+
+	it("requires only the send/discovery pair — claim and release stay role-scoped", () => {
+		assert.deepStrictEqual(missingSeatChannelTools(allowlist([...CHANNEL_TOKENS])), []);
+		assert.isTrue(CREW_SERVED_TOOL_NAMES.has("channel_claim"));
+		assert.isTrue(CREW_SERVED_TOOL_NAMES.has("channel_release"));
 	});
 });
 
@@ -169,8 +223,49 @@ describe("standup/toolset-assert — assertSeatToolset", () => {
 			assertSeatToolset(
 				"intake-desk",
 				"def.md",
-				allowlist(["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]),
+				allowlist(["Read", "Bash", "Task", ...CHANNEL_TOKENS]),
 			),
+		));
+
+	// #4002: the reported shape — a seat that coordinates over the channel but cannot resolve a kind's
+	// shape, so it rediscovers every payload by rejected send. Silent before rule 4.
+	it("refuses a seat that can send but cannot call channel_kinds", () =>
+		Effect.runSync(
+			Effect.gen(function* () {
+				const err = yield* Effect.flip(
+					assertSeatToolset(
+						"engineering-manager",
+						"def.md",
+						allowlist([
+							"Task",
+							"Bash",
+							"Read",
+							crewMcpToolToken("channel_send"),
+							crewMcpToolToken("channel_claim"),
+						]),
+					),
+				);
+				assert.instanceOf(err, CrewSeatToolsetMismatchError);
+				assert.deepStrictEqual(err.missingChannelTools, [crewMcpToolToken("channel_kinds")]);
+				assert.include(err.reason, "channel_kinds");
+				assert.include(err.reason, "uncallable");
+			}),
+		));
+
+	it("refuses a crew MCP token no connect window can ever resolve", () =>
+		Effect.runSync(
+			Effect.gen(function* () {
+				const err = yield* Effect.flip(
+					assertSeatToolset(
+						"cartographer",
+						"def.md",
+						allowlist([...CHANNEL_TOKENS, crewMcpToolToken("channel_kindz")]),
+					),
+				);
+				assert.instanceOf(err, CrewSeatToolsetMismatchError);
+				assert.deepStrictEqual(err.unservedMcp, [crewMcpToolToken("channel_kindz")]);
+				assert.include(err.reason, "connect window can never resolve");
+			}),
 		));
 });
 
@@ -192,7 +287,7 @@ describe("standup/toolset-assert — assertCrewSeatToolsets", () => {
 			assertCrewSeatToolsets(
 				"/repo",
 				["intake-desk", "engineering-manager"],
-				readerOf(allowlist(["Read", "Bash", "Task"])),
+				readerOf(allowlist(["Read", "Bash", "Task", ...CHANNEL_TOKENS])),
 			),
 		));
 
@@ -211,31 +306,11 @@ describe("standup/toolset-assert — assertCrewSeatToolsets", () => {
 
 	// The regression the whole module exists for: every SHIPPED crew def must boot the seat with the
 	// toolset it declares. This reads the real defs off disk, so a def edit that reintroduces `Grep`,
-	// `Glob`, or a self-denying `disallowedTools` reds here rather than at a live stand-up.
+	// `Glob`, a self-denying `disallowedTools`, a crew tool token the server does not serve, or a
+	// dropped `channel_send`/`channel_kinds` (#3761/#4002) reds here rather than at a live stand-up.
 	it.effect("every shipped crew def declares a toolset that resolves intact", () =>
 		assertCrewSeatToolsets(REPO_ROOT, [...CREW_ROLES], readSeatToolsetFromDef).pipe(
 			Effect.provide(NodeServices.layer),
 		),
-	);
-
-	// #3761: the discovery tool `channel_kinds` must be CALLABLE from every sending seat, not just
-	// served — the def's `tools:` allowlist is the hard gate, so its token must be present (MCP tokens
-	// are exempt from the grantable check, so a listed token lands in `granted`). Reads the real defs:
-	// a seat that drops the token — the exact defect that left channel_kinds present-but-uncallable in
-	// every seat — reds here rather than at a live stand-up.
-	it.effect(
-		"every shipped crew seat can call channel_kinds (its token is in the granted set)",
-		() =>
-			Effect.gen(function* () {
-				for (const role of CREW_ROLES) {
-					const declared = yield* readSeatToolsetFromDef(REPO_ROOT, role);
-					const {granted} = resolveDeclaredToolset(declared);
-					assert.include(
-						granted,
-						"mcp___kampus_pipeline-crew-mcp__channel_kinds",
-						`crew-${role} must list the channel_kinds allowlist token so the discovery tool is callable`,
-					);
-				}
-			}).pipe(Effect.provide(NodeServices.layer)),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/toolset-assert.ts
+++ b/packages/pipeline-crew-mcp/src/standup/toolset-assert.ts
@@ -22,6 +22,16 @@
  *      `Glob` are not tools a top-level session is granted on this CLI at all, so declaring them is a
  *      no-op that reads like a grant.
  *
+ * Two further rules close the MCP hole those two left open (#4002 — a seat declaring `channel_kinds`
+ * that ran a whole drain without it, discovered by two rejected sends). Post-connect a seat's granted
+ * set is exactly `declared ∩ served`, and BOTH operands are known before launch, so the runtime outcome
+ * is decidable here rather than mid-drain:
+ *
+ *   3. UNSERVED CREW TOOL — a token for the crew's own MCP server naming a tool that server does not
+ *      serve. No connect window can produce it, so it is a declaration error, not boot timing.
+ *   4. MISSING CHANNEL TOOL — a served channel tool the declaration omits, leaving it present-but-
+ *      uncallable from the seat (the #3483 shape). Which tools are mandatory is `REQUIRED_SEAT_CHANNEL_TOOLS`.
+ *
  * The one non-obvious thing: this FAILS CLOSED like every other launcher precondition (version-assert,
  * bind's three refusals) — a declaration that would not resolve intact refuses the launch with a named
  * error carrying the role, the dropped names, and which rule dropped them, rather than booting a
@@ -31,6 +41,12 @@
  */
 import {Effect, FileSystem, Path, Schema} from "effect";
 import type {CrewRole} from "../crew/index.ts";
+import {
+	CREW_SERVED_TOOL_NAMES,
+	crewMcpToolName,
+	crewMcpToolToken,
+	REQUIRED_SEAT_CHANNEL_TOOLS,
+} from "../crew/served-toolset.ts";
 import {CREW_PLUGIN_SUBDIR} from "./bind.ts";
 
 /**
@@ -74,9 +90,13 @@ export const GRANTABLE_SESSION_TOOLS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * An MCP tool token (`mcp__<sanitized server>__<tool>`) is exempt from the grantable check: it is
+ * An MCP tool token (`mcp__<sanitized server>__<tool>`) is exempt from the GRANTABLE check: it is
  * served by a connected MCP server rather than the CLI's own registry, so its absence at boot is the
  * channel's connect window (CHANNEL-TOOL.md), not a declaration error.
+ *
+ * It once exempted an `mcp__*` entry from EVERY refusal bucket, which is why a declared-vs-actual MCP
+ * gap could stay silent for a seat's whole life. The invariant now: this exemption covers
+ * PRESENCE-AT-BOOT only, and rules 3/4 (module docblock, #4002) decide the rest statically.
  */
 export const isMcpToolToken = (entry: string): boolean => entry.startsWith("mcp__");
 
@@ -102,22 +122,47 @@ export interface ToolsetResolution {
 	readonly ungrantable: readonly string[];
 	/** Declared names subtracted by the def's own `disallowedTools` base-name match (rule 1). */
 	readonly selfDenied: readonly string[];
+	/** Declared crew-server MCP tokens naming a tool that server does not serve (rule 3). */
+	readonly unservedMcp: readonly string[];
 }
 
-/** Resolve a declaration through both silent-drop rules — the pure core the assert and its tests share. */
+/** Resolve a declaration through every silent-drop rule — the pure core the assert and its tests share. */
 export const resolveDeclaredToolset = (declared: DeclaredToolset): ToolsetResolution => {
-	if (declared._tag === "inherit") return {granted: [], ungrantable: [], selfDenied: []};
+	if (declared._tag === "inherit")
+		return {granted: [], ungrantable: [], selfDenied: [], unservedMcp: []};
 	const denied = new Set(declared.disallowedTools.map(baseToolName));
 	const granted: string[] = [];
 	const ungrantable: string[] = [];
 	const selfDenied: string[] = [];
+	const unservedMcp: string[] = [];
 	for (const entry of declared.tools) {
 		const base = baseToolName(entry);
-		if (!isMcpToolToken(entry) && !GRANTABLE_SESSION_TOOLS.has(base)) ungrantable.push(entry);
+		const crewTool = crewMcpToolName(entry);
+		// Rule 3 is checked FIRST and only for the crew's OWN server: a foreign server's toolset is
+		// unknowable here, so its token keeps the blanket connect-window exemption.
+		if (crewTool !== null && !CREW_SERVED_TOOL_NAMES.has(crewTool)) unservedMcp.push(entry);
+		else if (!isMcpToolToken(entry) && !GRANTABLE_SESSION_TOOLS.has(base)) ungrantable.push(entry);
 		else if (denied.has(base)) selfDenied.push(entry);
 		else granted.push(entry);
 	}
-	return {granted, ungrantable, selfDenied};
+	return {granted, ungrantable, selfDenied, unservedMcp};
+};
+
+/**
+ * RULE 4 — the channel tools a seat must declare to be a functioning crew member, missing from this
+ * declaration. The complement of rule 3: rule 3 catches a token naming nothing, this catches a served
+ * tool no token names — the shape #4002 reports, where a seat coordinates over the channel yet cannot
+ * call `channel_kinds` and rediscovers every payload shape by rejected send.
+ *
+ * This is a LAUNCH-time assert, not the repo's own def test: stand-up reads the defs under the launched
+ * `projectRoot`, which may be an older install than the checkout whose unit tests pass — the very skew
+ * that lets a seat boot missing a tool its (current) def declares.
+ */
+export const missingSeatChannelTools = (declared: DeclaredToolset): readonly string[] => {
+	// An `inherit` def has no allowlist to narrow: the CLI grants its default toolset, MCP tools included.
+	if (declared._tag === "inherit") return [];
+	const granted = new Set(resolveDeclaredToolset(declared).granted);
+	return REQUIRED_SEAT_CHANNEL_TOOLS.map(crewMcpToolToken).filter((token) => !granted.has(token));
 };
 
 /**
@@ -131,6 +176,8 @@ export class CrewSeatToolsetMismatchError extends Schema.TaggedErrorClass<CrewSe
 		defPath: Schema.String,
 		ungrantable: Schema.Array(Schema.String),
 		selfDenied: Schema.Array(Schema.String),
+		unservedMcp: Schema.Array(Schema.String),
+		missingChannelTools: Schema.Array(Schema.String),
 		reason: Schema.String,
 	},
 ) {}
@@ -248,14 +295,27 @@ export const assertSeatToolset = (
 	defPath: string,
 	declared: DeclaredToolset,
 ): Effect.Effect<void, CrewSeatToolsetMismatchError> => {
-	const {ungrantable, selfDenied} = resolveDeclaredToolset(declared);
-	if (ungrantable.length === 0 && selfDenied.length === 0) return Effect.void;
+	const {ungrantable, selfDenied, unservedMcp} = resolveDeclaredToolset(declared);
+	const missingChannelTools = missingSeatChannelTools(declared);
+	if (
+		ungrantable.length === 0 &&
+		selfDenied.length === 0 &&
+		unservedMcp.length === 0 &&
+		missingChannelTools.length === 0
+	)
+		return Effect.void;
 	const parts = [
 		ungrantable.length > 0
 			? `${JSON.stringify(ungrantable)} name no tool this CLI grants a top-level session, so they are silently dropped`
 			: undefined,
 		selfDenied.length > 0
 			? `${JSON.stringify(selfDenied)} are subtracted by this def's own \`disallowedTools\` (an entry matches by BASE tool name — the \`(specifier)\` is ignored and the WHOLE tool goes)`
+			: undefined,
+		unservedMcp.length > 0
+			? `${JSON.stringify(unservedMcp)} name no tool the crew MCP server serves (it serves ${JSON.stringify([...CREW_SERVED_TOOL_NAMES])}), so the connect window can never resolve them — the seat would boot declaring a tool it can never call`
+			: undefined,
+		missingChannelTools.length > 0
+			? `${JSON.stringify(missingChannelTools)} are absent from the declaration, so those channel tools are served-but-uncallable from this seat — every crew seat must carry them (CHANNEL-TOOL.md)`
 			: undefined,
 	].filter((part) => part !== undefined);
 	return Effect.fail(
@@ -264,7 +324,9 @@ export const assertSeatToolset = (
 			defPath,
 			ungrantable,
 			selfDenied,
-			reason: `the "${role}" seat would boot without tools its def declares: ${parts.join("; ")} — fix the def rather than boot a silently degraded seat`,
+			unservedMcp,
+			missingChannelTools,
+			reason: `the "${role}" seat would boot with a toolset its def does not describe: ${parts.join("; ")} — fix the def rather than boot a silently degraded seat`,
 		}),
 	);
 };


### PR DESCRIPTION
Closes #4002

## What was actually wrong (the seat that lacked it, verified)

**No shipped seat def is missing `channel_kinds` today** — all four launched seats
(`crew-cartographer`, `crew-chief-of-staff`, `crew-intake-desk`, `crew-engineering-manager`)
declare `mcp___kampus_pipeline-crew-mcp__channel_kinds` on line 6, and the crew session server
serves it to every seat unconditionally (`crew/session.ts` registers all four toolkits with no
per-role gating). A live engine seat confirms it holds and can call the tool. So the defect is
**not** a missing declaration in an agent def — nothing needed changing there.

The defect is the **verification hole**: the pre-launch seat-toolset assert
(`standup/toolset-assert.ts`, #3784) exempted every `mcp__*` token from *every* refusal bucket
(`isMcpToolToken` → the entry can never reach `ungrantable`), so a declared-vs-actual gap on the
crew's most load-bearing tools was structurally unreportable. The one check that *did* pin
`channel_kinds` presence was a **unit test over this repo's checkout**, not an assert over the defs
a stand-up actually boots from — so a crew stood up from an install whose defs predate
`d904a06b` (#3860, merged 2026-07-24, one day before the report) boots with `channel_send` +
`channel_claim` and no `channel_kinds`, exactly as reported, while the repo's tests stay green.

## The mechanism chosen

Post-connect, a seat's granted set is exactly **`declared ∩ served`** — and *both* operands are
known before launch. So the post-connect outcome is **decidable at stand-up**, with zero panes up,
rather than needing a post-connect probe. Two rules were added next to the existing two:

3. **UNSERVED CREW TOOL** — a token for the crew's *own* MCP server naming a tool that server does
   not serve (typo, rename, removal). No connect window can produce a name that will never be on a
   `tools/list`, so this is a declaration error, not boot timing → refuse the launch.
4. **MISSING CHANNEL TOOL** — a served channel tool the declaration omits, leaving it
   present-but-uncallable from the seat. `channel_send` + `channel_kinds` are now a
   **launch-enforced pair** rather than prose in `CHANNEL-TOOL.md` with a repo-only unit test
   behind it. `channel_claim` / `channel_release` stay role-scoped by design.

A **foreign** MCP server's token keeps the blanket connect-window exemption — its toolset is
genuinely unknowable at launch, so it stays fail-open there rather than false-positive.

`crew/served-toolset.ts` is the new single source for *what the session server serves* and *how a
`tools:` entry names it* (the `mcp__` + sanitized-server + `__` + tool derivation). `session.ts`'s
schema fence and the launcher assert now read the same array, so "declared" and "served" cannot
drift through a hand-maintained second list.

## Acceptance criteria

- [x] A seat declaring an `mcp__*` tool absent from its actual granted set gets a loud, attributable
      signal — `CrewSeatToolsetMismatchError` naming the role, the def path, and the exact tokens,
      refusing the launch. It fires *before* the connect window instead of after, because the
      post-connect result is fully determined by two facts known at stand-up (see above).
- [x] The connect window is preserved: a declared, *served* crew tool and any foreign-server token
      are still exempt from a presence check — nothing here is timing-sensitive, so the
      `CHANNEL-TOOL.md` contract is untouched.
- [x] `isMcpToolToken`'s exemption is narrowed *and* complemented, with its docblock updated to say
      which invariant now holds (presence-at-boot only; rules 3/4 decide the rest statically).
- [x] The residual constraint is recorded — see below, and in the new `CHANNEL-TOOL.md` section.

## The residual constraint, stated plainly (AC 4)

A live session's grant is fixed at **its** boot from the def as it stood **then**, and a seat has no
way to read its own granted toolset back. So **editing a def under a running crew changes nothing
for that crew, and the skew is invisible from inside it** — the seat reads the new def off disk
while holding the old grant. That is the most likely explanation of the reported incident. The
remedy is a **re-stand-up**, not a wait; that is what re-runs this assert against the defs the seats
will actually boot from. A launcher-side post-connect probe was rejected: reading a seat's granted
set requires booting a second `claude` session on the same agent def, which would contend for that
role's tracker lease (the #3444 hazard) for a fact already decidable statically.

## Scope

- **Does not** absorb #4038 (the `channel_send` schema-error hint naming `channel_kinds` for a caller
  that may lack it). This PR makes a *launched crew seat* always have the tool, so the hint is
  followable for those seats — but the hint is emitted by the generic `edge/send-tool.ts` to **any**
  MCP client, so #4038 is **not** moot and still owns making the hint degrade honestly.
- `packages/pipeline-crew-mcp/src/edge/**` is untouched (#4075 owns that surface).
- No ADR authored in this lane.
- Neither `packages/pipeline-crew-mcp/**` (ADR 0187) nor `claude-plugins/pipeline-crew/**` is §CP.

## Spotted, not fixed here

`channel_release` is served by every seat's session server but declared by **no** seat def, so it is
present-but-uncallable everywhere — rule 4 deliberately does not require it (only the mandatory
send/discovery pair), so this PR neither fixes nor masks it. Worth a triage look as its own item.

## Verification

- `pnpm typecheck` — 29/29 green.
- `pnpm lint:worktree` — clean.
- `pnpm vitest run` in `packages/pipeline-crew-mcp` — 427/428. The one failure,
  `standup/ensure-tracker.test.ts > starts a detached tracker that serves the socket…`, was
  **reproduced on a stashed baseline of this branch's merge-base** and is pre-existing/environmental
  (a detached-process socket test); it passes when that file runs alone and this diff touches
  nothing it uses.

## Files changed

- `packages/pipeline-crew-mcp/src/crew/served-toolset.ts` (new) — the served-toolset + token-derivation source
- `packages/pipeline-crew-mcp/src/crew/session.ts` — schema fence reads the shared toolkit array
- `packages/pipeline-crew-mcp/src/crew/index.ts` — barrel
- `packages/pipeline-crew-mcp/src/standup/toolset-assert.ts` — rules 3 + 4, narrowed exemption, error shape
- `packages/pipeline-crew-mcp/src/standup/toolset-assert.test.ts` — cases for both rules + both exemptions
- `packages/pipeline-crew-mcp/src/standup/orchestrate.ts` — comment
- `packages/pipeline-crew-mcp/src/standup/index.ts` — barrel
- `packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts`, `single-role.test.ts` — seat stubs carry the mandatory pair
- `claude-plugins/pipeline-crew/CHANNEL-TOOL.md` — what the launcher asserts + the residual constraint
- `claude-plugins/pipeline-crew/REFERENCE.md` — the tools table was drifted (omitted `channel_kinds` on all four rows)
