### PR TITLE
fix(worktree-sweep): a launcher's liveness is not the occupant's (#4001)

### DIFF
--- a/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
+++ b/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
@@ -106,9 +106,16 @@ fi
 # KEPT forever) and it must vanish with the worktree, which git's own admin dir gives for free.
 # Best-effort by design — a missing stamp reads as owner-unknown, which the sweep KEEPS, so a failure
 # here can only ever leak a tree, never destroy a live one. Never fail the spawn over it.
+#
+# `ownerKind` is LAUNCHER and cannot be otherwise (#4001): this hook runs in the SPAWNING session,
+# before the subagent that will occupy the tree exists, so `session_id` is the launcher's — and for
+# a long-lived crew pane that id stays alive for hours after the occupant finishes. Recording WHICH
+# identity this is keeps the consumer from reading launcher liveness as occupancy; see
+# `packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts` for what each kind licenses.
+# Do NOT stamp `occupant` here — there is no occupant yet to name.
 if [ -n "$session_id" ]; then
 	if gitdir="$(git -C "$worktree_path" rev-parse --absolute-git-dir 2>/dev/null)"; then
-		printf '{"sessionId":"%s","worktreeName":"%s","stampedAt":"%s"}\n' \
+		printf '{"sessionId":"%s","ownerKind":"launcher","worktreeName":"%s","stampedAt":"%s"}\n' \
 			"$session_id" "$name" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 			>"$gitdir/kampus-owner.json" 2>/dev/null \
 			|| echo "create-worktree: could not stamp owner session (tree reads owner-unknown → never reaped)." >&2

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -69,21 +69,28 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 	const git = (cwd: string, ...args: string[]) =>
 		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
 
-	/** Stamp an owning session into a worktree's git admin dir, as `create-worktree.sh` does. */
-	const stampOwner = (wtPath: string, sessionId: string) => {
+	/**
+	 * Stamp an owning session into a worktree's git admin dir, as `create-worktree.sh` does. The
+	 * kind defaults to `launcher` because that is what the hook writes and what a legacy stamp
+	 * means (#4001); pass `occupant` only for the case that models a stamp naming the holder itself.
+	 */
+	const stampOwner = (wtPath: string, sessionId: string, kind = "launcher") => {
 		const gitdir = git(mainRepo, "-C", wtPath, "rev-parse", "--absolute-git-dir").trim();
-		writeFileSync(join(gitdir, "kampus-owner.json"), JSON.stringify({sessionId}));
+		writeFileSync(join(gitdir, "kampus-owner.json"), JSON.stringify({sessionId, ownerKind: kind}));
 	};
 
-	// Push a managed worktree's dir + per-tree HEAD/logs mtimes ~2h into the past so it reads
-	// idle (well past the 30-min threshold) — simulating an orphaned tree a live lane would not be.
-	const backdate = (wtPath: string) => {
-		const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+	// Push a managed worktree's dir + per-tree HEAD/logs mtimes into the past. 1h reads IDLE (well
+	// past the 30-min threshold) while staying INSIDE the 2h launcher grace window; 3h is past both,
+	// which is what makes a launcher-owned orphan sweep-eligible (#4001).
+	const backdateBy = (wtPath: string, ms: number) => {
+		const old = new Date(Date.now() - ms);
 		const gitdir = git(mainRepo, "-C", wtPath, "rev-parse", "--absolute-git-dir").trim();
 		for (const p of [wtPath, join(gitdir, "HEAD"), join(gitdir, "logs", "HEAD")]) {
 			if (existsSync(p)) utimesSync(p, old, old);
 		}
 	};
+	const backdate = (wtPath: string) => backdateBy(wtPath, 60 * 60 * 1000);
+	const backdateBeyondGrace = (wtPath: string) => backdateBy(wtPath, 3 * 60 * 60 * 1000);
 
 	beforeAll(() => {
 		mainRepo = mkdtempSync(join(tmpdir(), "wts-main-"));
@@ -199,10 +206,10 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 	// — clean, content-merged, unlocked, and mtime-idle — must survive purely because its owning
 	// session is registered as running. The unstamped sibling pins the other half: an owner we cannot
 	// prove dead is KEPT, so a fix that reads "unprovable" as "orphan" turns this red.
-	it("KEEPS a live-session-owned tree AND an unstamped tree in the exact clean+merged+idle state that is otherwise reaped (#3943)", async () => {
+	it("KEEPS an occupant-owned tree AND an unstamped tree in the exact clean+merged+idle state that is otherwise reaped (#3943)", async () => {
 		const liveOwnedWt = join(mainRepo, ".claude", "worktrees", "wf_live_session");
 		git(mainRepo, "worktree", "add", "-q", "--detach", liveOwnedWt, "HEAD");
-		stampOwner(liveOwnedWt, LIVE_SID);
+		stampOwner(liveOwnedWt, LIVE_SID, "occupant");
 		backdate(liveOwnedWt);
 
 		const unstampedWt = join(mainRepo, ".claude", "worktrees", "wf_unstamped");
@@ -223,6 +230,37 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		assert.isFalse(existsSync(deadOwnedWt), "the dead-owner control must still be reclaimed");
 		assert.include(stdout, "live-session");
 		assert.include(stdout, "owner-unknown");
+	}, 30_000);
+
+	// The #4001 regression, end to end: LIVE_SID stands in for a crew pane that is STILL RUNNING and
+	// has spawned many trees. A tree it launched, whose occupant finished long ago, must become
+	// reclaimable on its own idle clock — the pane never exits, so waiting for it is waiting forever.
+	it("reclaims a LAUNCHER-owned orphan while its launcher is still registered as running (#4001)", async () => {
+		const staleWt = join(mainRepo, ".claude", "worktrees", "wf_launcher_stale");
+		git(mainRepo, "worktree", "add", "-q", "--detach", staleWt, "HEAD");
+		stampOwner(staleWt, LIVE_SID);
+		backdateBeyondGrace(staleWt);
+
+		// Same live launcher, same stamp — but touched recently enough to sit inside the grace
+		// window. It pins the fail-closed direction: the launcher branch reclaims on IDLE, and only
+		// past the window, so a tree whose occupant may still hold it is never pulled out from under.
+		const freshWt = join(mainRepo, ".claude", "worktrees", "wf_launcher_fresh");
+		git(mainRepo, "worktree", "add", "-q", "--detach", freshWt, "HEAD");
+		stampOwner(freshWt, LIVE_SID);
+		backdate(freshWt);
+
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], sweepEnv);
+		assert.strictEqual(code, 0, stdout);
+		assert.isFalse(
+			existsSync(staleWt),
+			"a long-idle tree launched by a still-running pane must be reclaimed, not held for the pane's lifetime",
+		);
+		assert.isTrue(existsSync(freshWt), "inside the grace window the launcher-owned tree is KEPT");
+		// The near-silence was as much a diagnosability failure as a reaping one: the reason a tree
+		// was kept must name the launcher branch, not read as ordinary presence.
+		assert.include(stdout, "launcher-alive");
+
+		git(mainRepo, "worktree", "remove", freshWt);
 	}, 30_000);
 
 	// The fail-closed half of the presence gate: with no readable registry there is no way to prove

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -38,6 +38,7 @@ import {Command, Flag} from "effect/unstable/cli";
 import {
 	liveSessionIds,
 	type OwnerLiveness,
+	type OwnerStamp,
 	parseOwnerStamp,
 	parseSessionRegistryEntry,
 	resolveOwnerLiveness,
@@ -118,6 +119,18 @@ const squashMergedToOriginMain = (head: string | null): boolean => {
 const IDLE_THRESHOLD_MS = 30 * 60 * 1000;
 
 /**
+ * How long a tree whose owner is a still-running LAUNCHER is held before the ordinary age/merge
+ * gates decide it (#4001). The launcher stamp names the spawning pane, not the occupant, so its
+ * liveness cannot be a permanent KEEP — but the harness's occupancy lock (checked first) is the
+ * only occupant-keyed signal there is, and an occupant it failed to lock would be protected by
+ * nothing else. This window is that backstop: two hours of *no file activity at all* — 4x the idle
+ * threshold above, and well past the longest a live lane plausibly goes without touching its tree
+ * (a shipper polling CI through `gh api` is the worst case, and it is bounded by the run itself) —
+ * so it only ever releases a tree whose occupant has long since finished.
+ */
+const LAUNCHER_GRACE_MS = 2 * 60 * 60 * 1000;
+
+/**
  * Newest mtime (ms) among the given paths, or `null` when none can be stat'd. Each stat goes
  * through the `FileSystem` seam and degrades to "skipped" on a fault, so an absent/unreadable
  * path is still passed over and a wholly unresolvable set still falls to the `null` fail-safe.
@@ -141,15 +154,21 @@ const newestMtimeMs = (
 	});
 
 /**
- * Is a managed worktree still LIVE by recency (#2240)? Probes the worktree dir + its
- * per-tree `HEAD` and `logs/HEAD` — a commit/checkout bumps HEAD and appends the reflog,
- * a new file bumps the dir; a still-editing lane is caught earlier as `dirty`. The index
- * is deliberately NOT probed: `git status` (the dirty check) can rewrite it, which would
- * mask idleness. Any unresolvable mtime ⇒ presumed active (fail-safe KEEP).
+ * How long a managed worktree has gone untouched, as the two idle facts the classifier reads
+ * (#2240, #4001). Probes the worktree dir + its per-tree `HEAD` and `logs/HEAD` — a commit/checkout
+ * bumps HEAD and appends the reflog, a new file bumps the dir; a still-editing lane is caught
+ * earlier as `dirty`. The index is deliberately NOT probed: `git status` (the dirty check) can
+ * rewrite it, which would mask idleness. Both facts derive from ONE mtime read so they can never
+ * disagree about the same tree, and any unresolvable mtime ⇒ presumed active AND within grace
+ * (fail-safe KEEP on both).
  */
-const worktreeRecentlyActive = (
+const worktreeIdleFacts = (
 	path: string,
-): Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<
+	{recentlyActive: boolean; idleBeyondLauncherGrace: boolean},
+	never,
+	FileSystem.FileSystem | Path.Path
+> =>
 	Effect.gen(function* () {
 		const pathSvc = yield* Path.Path;
 		const gitdir = runGit(["-C", path, "rev-parse", "--absolute-git-dir"]);
@@ -159,8 +178,12 @@ const worktreeRecentlyActive = (
 			probes.push(pathSvc.join(g, "HEAD"), pathSvc.join(g, "logs", "HEAD"));
 		}
 		const newest = yield* newestMtimeMs(probes);
-		if (newest === null) return true;
-		return Date.now() - newest < IDLE_THRESHOLD_MS;
+		if (newest === null) return {recentlyActive: true, idleBeyondLauncherGrace: false};
+		const idleFor = Date.now() - newest;
+		return {
+			recentlyActive: idleFor < IDLE_THRESHOLD_MS,
+			idleBeyondLauncherGrace: idleFor >= LAUNCHER_GRACE_MS,
+		};
 	});
 
 /**
@@ -225,11 +248,12 @@ const OWNER_STAMP_FILE = "kampus-owner.json";
  * The session that OWNS this worktree: the `WorktreeCreate` stamp in its git admin dir
  * (`hooks/create-worktree.sh`), else a bare session-UUID segment in its own path — the fallback for
  * a `$TMPDIR`-rooted review-head tree, which no hook provisions. `null` when neither resolves, so
- * an unstamped tree is never judged dead.
+ * an unstamped tree is never judged dead. The path fallback is a `"launcher"` identity: the UUID
+ * roots the spawning pane's scratchpad, not the review subagent inside it (#4001).
  */
-const ownerSessionIdOf = (
+const ownerOf = (
 	worktreePath: string,
-): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<OwnerStamp | null, never, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const gitdir = runGit(["-C", worktreePath, "rev-parse", "--absolute-git-dir"]);
 		if (gitdir.ok) {
@@ -241,7 +265,8 @@ const ownerSessionIdOf = (
 			const stamped = raw === null ? null : parseOwnerStamp(raw);
 			if (stamped !== null) return stamped;
 		}
-		return sessionIdFromPath(worktreePath);
+		const fromPath = sessionIdFromPath(worktreePath);
+		return fromPath === null ? null : {sessionId: fromPath, kind: "launcher"};
 	});
 
 const runGh = (args: ReadonlyArray<string>): GitResult => {
@@ -336,6 +361,7 @@ const worktreeSweep = Command.make(
 							// liveness gate, and a prune only clears admin metadata for a tree that is already
 							// gone from disk, so there is no live working surface to pull out from under an owner.
 							ownerLiveness: "unknown" as OwnerLiveness,
+							idleBeyondLauncherGrace: false,
 						};
 					}
 					const managed = isManagedWorktree(p.path);
@@ -347,15 +373,20 @@ const worktreeSweep = Command.make(
 					const reachable = reachableFromOriginMain(p.head);
 					// Only probe the costlier squash signal when ancestry already missed.
 					const squashMerged = reachable ? false : squashMergedToOriginMain(p.head);
-					const recentlyActive = swept ? yield* worktreeRecentlyActive(p.path) : false;
+					const {recentlyActive, idleBeyondLauncherGrace} = swept
+						? yield* worktreeIdleFacts(p.path)
+						: {recentlyActive: false, idleBeyondLauncherGrace: false};
 					// Presence beats recency (#3943): a live shipper lane is mtime-idle, so `recentlyActive`
 					// cannot see it. Probed only for a swept tree — an unswept one is already KEEP.
 					const ownerLiveness: OwnerLiveness = swept
-						? resolveOwnerLiveness({
-								ownerSessionId: yield* ownerSessionIdOf(p.path),
-								liveSessionIds: live,
-							})
+						? resolveOwnerLiveness({owner: yield* ownerOf(p.path), liveSessionIds: live})
 						: "unknown";
+					// Mirrors the classifier's owner gates so the probe below fires for exactly the trees
+					// that can reach the open-PR branch — including a launcher-owned one past its grace
+					// window (#4001), which would otherwise skip the probe and be reaped with a PR open.
+					const ownerPermitsRemoval =
+						ownerLiveness === "dead" ||
+						(ownerLiveness === "launcher-alive" && idleBeyondLauncherGrace);
 					// The network open-PR probe fires ONLY for a BUILD tree that would otherwise be swept —
 					// managed, clean, unlocked, idle, and content-merged — so SessionStart makes at most
 					// one gh call per reap candidate (usually zero), never one per worktree. A review-head
@@ -364,7 +395,7 @@ const worktreeSweep = Command.make(
 						managed &&
 						!isDirty &&
 						!p.locked &&
-						ownerLiveness === "dead" &&
+						ownerPermitsRemoval &&
 						!recentlyActive &&
 						(reachable || squashMerged);
 					const hasOpenPr = wouldRemove ? branchHasOpenPr(p.branch) : false;
@@ -379,6 +410,7 @@ const worktreeSweep = Command.make(
 						recentlyActive,
 						hasOpenPr,
 						ownerLiveness,
+						idleBeyondLauncherGrace,
 					};
 				}),
 			{concurrency: 1},
@@ -398,6 +430,15 @@ const worktreeSweep = Command.make(
 			`worktree-sweep: ${records.length} worktree(s) scanned — ${plan.toRemove.length} removable, ${plan.kept.length} kept${execute ? " (EXECUTE)" : " (dry-run)"}`,
 		);
 		if (plan.kept.length > 0) {
+			// The per-reason tally is what makes a near-silent run diagnosable at a glance (#4001):
+			// a wall of `live-session` means real occupants, a wall of `launcher-alive` means one
+			// long-lived pane's spawn history, and a wall of `owner-unknown` means an unresolved
+			// registry — three very different causes the bare "N kept" collapsed into one number.
+			const tally = new Map<string, number>();
+			for (const k of plan.kept) tally.set(k.reason, (tally.get(k.reason) ?? 0) + 1);
+			yield* Console.log(
+				`kept by reason: ${[...tally].map(([reason, n]) => `${reason}=${n}`).join(" ")}`,
+			);
 			yield* Console.log("kept:");
 			for (const k of plan.kept) yield* Console.log(reasonLine(k.worktree.path, k.reason));
 		}

--- a/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
@@ -283,6 +283,14 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 			"the stamp must carry the owning session",
 		);
 		assert.strictEqual(stamp.worktreeName, name);
+		// #4001: the hook runs in the SPAWNING session, before the occupying subagent exists, so the
+		// only honest kind it can record is `launcher`. A stamp that claimed `occupant` here would
+		// hand a long-lived pane's liveness the authority to keep every tree it ever spawned.
+		assert.strictEqual(
+			stamp.ownerKind,
+			"launcher",
+			"a creation-time stamp names the launcher, never the occupant",
+		);
 		assert.strictEqual(
 			git(expected, "status", "--porcelain").trim(),
 			"",

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
@@ -31,6 +31,25 @@
  *   2. **liveness** — the harness's session registry: one `<config>/sessions/<pid>.json` per
  *      RUNNING session, carrying `{pid, sessionId}` and deleted when the session exits.
  *
+ * **The owner is the LAUNCHER, never the occupant (#4001).** Both owner sources above resolve the
+ * session that *spawned* the tree, not the ephemeral subagent that *occupies* it: the hook runs in
+ * the spawning session before the subagent exists, and the `$TMPDIR` scratchpad root is that same
+ * spawning session's. A subagent has no registry entry of its own — it runs inside its pane's
+ * process — so an occupant-keyed session id is not resolvable on this platform at all. That makes
+ * launcher liveness a strict **upper bound**, sound in one direction only:
+ *
+ *   - launcher DEAD ⇒ the occupant it spawned is necessarily gone too ⇒ `"dead"`.
+ *   - launcher ALIVE ⇒ says **nothing** about the occupant. A crew pane runs for hours and spawns
+ *     many short-lived subagent trees, so reading this as `"alive"` KEPT every tree such a pane
+ *     ever created for the pane's whole lifetime — the sweep went near-silent during exactly the
+ *     runs that generate orphans (#4001). That case is `"launcher-alive"`, a distinct verdict.
+ *
+ * Occupancy itself is carried by a separate, real signal the classifier checks *above* this one:
+ * the harness's own `git worktree lock`, held for the occupying agent's lifetime and released when
+ * it finishes. So a tree that reaches this gate is already unlocked, i.e. the harness has released
+ * its occupancy — which is why `"launcher-alive"` may fall through to the age/merge gates instead
+ * of KEEPing forever. See `classifyWorktree` for the grace window that bounds the residual risk.
+ *
  * IO-free by design: the caller reads the files and probes the pids, so every rule below is
  * unit-testable without a filesystem or a spawned agent.
  *
@@ -41,10 +60,28 @@
  */
 
 /**
- * `"dead"` is the ONLY verdict that lets a removal proceed. `"unknown"` is a distinct third
+ * `"dead"` is the only verdict that lets a removal proceed outright. `"unknown"` is a distinct
  * state on purpose — collapsing it into `"dead"` is the over-reaping defect (#3943).
+ * `"launcher-alive"` is the fourth: a live owner whose liveness proves nothing about the occupant,
+ * so it neither removes (it is not `"dead"`) nor KEEPs forever (#4001).
  */
-export type OwnerLiveness = "alive" | "dead" | "unknown";
+export type OwnerLiveness = "alive" | "launcher-alive" | "dead" | "unknown";
+
+/**
+ * Whose identity the owner record carries — the axis the #4001 defect turned on. Every owner
+ * resolvable today is a `"launcher"`: NO producer writes an `"occupant"` stamp, deliberately, since
+ * a subagent has no session identity of its own to stamp and choosing an occupant-keyed mechanism
+ * is an open design call (#3892). The variant exists so that when one arrives it must SAY it names
+ * the occupant to be granted occupant authority, instead of inheriting the launcher's over-broad
+ * authority by silence — which is exactly how the launcher stamp came to mean presence.
+ */
+export type OwnerKind = "launcher" | "occupant";
+
+/** A resolved worktree owner: whose session id it is, and what that identity actually names. */
+export interface OwnerStamp {
+	readonly sessionId: string;
+	readonly kind: OwnerKind;
+}
 
 /** A bare session-UUID path segment (the shape both the registry and the sidecar layout use). */
 const SESSION_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -63,14 +100,21 @@ const objectField = (v: unknown, key: string): unknown =>
 	typeof v === "object" && v !== null ? (v as Record<string, unknown>)[key] : undefined;
 
 /**
- * The owning session id read off a worktree's `kampus-owner.json` stamp, or `null` when the file
- * is absent, malformed, or carries no session-UUID-shaped `sessionId`. Requiring the UUID shape
- * (not merely a non-empty string) keeps a truncated or placeholder stamp from resolving to an id
- * that can never match a registry entry — which would read as `"dead"` rather than `"unknown"`.
+ * The owner read off a worktree's `kampus-owner.json` stamp, or `null` when the file is absent,
+ * malformed, or carries no session-UUID-shaped `sessionId`. Requiring the UUID shape (not merely a
+ * non-empty string) keeps a truncated or placeholder stamp from resolving to an id that can never
+ * match a registry entry — which would read as `"dead"` rather than `"unknown"`.
+ *
+ * An absent or unrecognized `ownerKind` reads `"launcher"`: every stamp the hook has ever written
+ * carries the spawning session, so that is what a legacy (pre-#4001) stamp means — the permissive
+ * reading would be to assume the narrower `"occupant"`, which is precisely the over-claim to avoid.
  */
-export const parseOwnerStamp = (raw: string): string | null => {
-	const id = asString(objectField(parseJson(raw), "sessionId"));
-	return SESSION_UUID.test(id) ? id : null;
+export const parseOwnerStamp = (raw: string): OwnerStamp | null => {
+	const parsed = parseJson(raw);
+	const sessionId = asString(objectField(parsed, "sessionId"));
+	if (!SESSION_UUID.test(sessionId)) return null;
+	const kind = asString(objectField(parsed, "ownerKind"));
+	return {sessionId, kind: kind === "occupant" ? "occupant" : "launcher"};
 };
 
 /** One `<config>/sessions/<pid>.json` entry — a session the harness records as running. */
@@ -90,7 +134,9 @@ export const parseSessionRegistryEntry = (raw: string): SessionRegistryEntry | n
 
 /**
  * The owning session id recovered from a worktree's own path — the fallback for a `$TMPDIR`-rooted
- * `review-head-*` tree, which no hook provisions and so carries no stamp. Matches only a segment
+ * `review-head-*` tree, which no hook provisions and so carries no stamp. This is a `"launcher"`
+ * identity like the stamp is: the UUID roots the *pane's* scratchpad, not the review subagent that
+ * materialized the head inside it. Matches only a segment
  * that is a bare session UUID, and returns `null` on **ambiguity** (two different UUID segments)
  * as well as absence: guessing which of two ids owns the tree could name a dead session for a live
  * tree, and the fail-closed `null` (⇒ `"unknown"` ⇒ KEEP) is the only safe answer.
@@ -139,11 +185,16 @@ export const liveSessionIds = (probe: SessionRegistryProbe): ReadonlySet<string>
 /**
  * Resolve one worktree's owner liveness. `null` for either input is the unprovable case:
  * an unresolvable owner (no stamp, no session segment in the path) or an untrustworthy registry.
+ *
+ * A live owner splits on WHOSE identity the stamp carries (#4001): an `"occupant"` stamp names the
+ * agent holding the tree, so its liveness is real presence (`"alive"`, KEEP); a `"launcher"` stamp
+ * names the spawning session, whose liveness is not evidence about the occupant (`"launcher-alive"`).
  */
 export const resolveOwnerLiveness = (args: {
-	readonly ownerSessionId: string | null;
+	readonly owner: OwnerStamp | null;
 	readonly liveSessionIds: ReadonlySet<string> | null;
 }): OwnerLiveness => {
-	if (args.liveSessionIds === null || args.ownerSessionId === null) return "unknown";
-	return args.liveSessionIds.has(args.ownerSessionId.toLowerCase()) ? "alive" : "dead";
+	if (args.liveSessionIds === null || args.owner === null) return "unknown";
+	if (!args.liveSessionIds.has(args.owner.sessionId.toLowerCase())) return "dead";
+	return args.owner.kind === "occupant" ? "alive" : "launcher-alive";
 };

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.unit.test.ts
@@ -11,9 +11,29 @@ const SID_A = "85123b6c-d220-46c5-ac19-77ccedffb3d7";
 const SID_B = "ddf8f459-b75f-4de2-9051-8df10da5b55c";
 
 describe("parseOwnerStamp", () => {
-	it("reads the sessionId the WorktreeCreate hook stamped", () => {
-		const raw = `{"sessionId":"${SID_A}","worktreeName":"agent-abc","stampedAt":"2026-07-24T22:00:00Z"}`;
-		assert.strictEqual(parseOwnerStamp(raw), SID_A);
+	it("reads the sessionId and the ownerKind the WorktreeCreate hook stamped", () => {
+		const raw = `{"sessionId":"${SID_A}","ownerKind":"launcher","worktreeName":"agent-abc","stampedAt":"2026-07-24T22:00:00Z"}`;
+		assert.deepStrictEqual(parseOwnerStamp(raw), {sessionId: SID_A, kind: "launcher"});
+	});
+
+	it("reads a LEGACY stamp with no ownerKind as a launcher — every stamp ever written is one (#4001)", () => {
+		const raw = `{"sessionId":"${SID_A}","worktreeName":"agent-abc"}`;
+		assert.deepStrictEqual(parseOwnerStamp(raw), {sessionId: SID_A, kind: "launcher"});
+	});
+
+	it("only an explicit ownerKind:occupant claims occupant authority; anything else reads launcher", () => {
+		assert.deepStrictEqual(parseOwnerStamp(`{"sessionId":"${SID_A}","ownerKind":"occupant"}`), {
+			sessionId: SID_A,
+			kind: "occupant",
+		});
+		assert.deepStrictEqual(parseOwnerStamp(`{"sessionId":"${SID_A}","ownerKind":"pane"}`), {
+			sessionId: SID_A,
+			kind: "launcher",
+		});
+		assert.deepStrictEqual(parseOwnerStamp(`{"sessionId":"${SID_A}","ownerKind":7}`), {
+			sessionId: SID_A,
+			kind: "launcher",
+		});
 	});
 
 	it("returns null for malformed JSON, a missing field, and a non-UUID id (⇒ unknown ⇒ KEEP)", () => {
@@ -84,40 +104,53 @@ describe("liveSessionIds — the registry trust gate", () => {
 
 describe("resolveOwnerLiveness", () => {
 	const live: ReadonlySet<string> = new Set([SID_A]);
+	const launcher = (sessionId: string) => ({sessionId, kind: "launcher"}) as const;
+	const occupant = (sessionId: string) => ({sessionId, kind: "occupant"}) as const;
 
-	it("resolves ALIVE when the owner is a registered live session", () => {
+	it("resolves ALIVE when the live owner is the OCCUPANT — real presence", () => {
 		assert.strictEqual(
-			resolveOwnerLiveness({ownerSessionId: SID_A, liveSessionIds: live}),
+			resolveOwnerLiveness({owner: occupant(SID_A), liveSessionIds: live}),
 			"alive",
+		);
+	});
+
+	// The #4001 case: a crew pane runs for hours and spawns many short-lived subagent trees, so its
+	// liveness says nothing about whether any given tree is still occupied. Collapsing this into
+	// "alive" is what kept every tree such a pane ever created for the pane's whole lifetime.
+	it("resolves LAUNCHER-ALIVE — not alive — when the live owner is the LAUNCHER (#4001)", () => {
+		assert.strictEqual(
+			resolveOwnerLiveness({owner: launcher(SID_A), liveSessionIds: live}),
+			"launcher-alive",
 		);
 	});
 
 	it("matches case-insensitively (the UUID's hex case is not identity)", () => {
 		assert.strictEqual(
-			resolveOwnerLiveness({ownerSessionId: SID_A.toUpperCase(), liveSessionIds: live}),
+			resolveOwnerLiveness({owner: occupant(SID_A.toUpperCase()), liveSessionIds: live}),
 			"alive",
 		);
 	});
 
-	it("resolves DEAD only for a resolvable owner absent from a trusted live set", () => {
-		assert.strictEqual(resolveOwnerLiveness({ownerSessionId: SID_B, liveSessionIds: live}), "dead");
+	it("resolves DEAD only for a resolvable owner absent from a trusted live set, whichever kind", () => {
+		assert.strictEqual(
+			resolveOwnerLiveness({owner: launcher(SID_B), liveSessionIds: live}),
+			"dead",
+		);
+		assert.strictEqual(
+			resolveOwnerLiveness({owner: occupant(SID_B), liveSessionIds: live}),
+			"dead",
+		);
 	});
 
 	it("resolves UNKNOWN — never dead — for an unresolvable owner (no stamp, no session in the path)", () => {
-		assert.strictEqual(
-			resolveOwnerLiveness({ownerSessionId: null, liveSessionIds: live}),
-			"unknown",
-		);
+		assert.strictEqual(resolveOwnerLiveness({owner: null, liveSessionIds: live}), "unknown");
 	});
 
 	it("resolves UNKNOWN — never dead — for every owner when the registry is untrustworthy", () => {
 		assert.strictEqual(
-			resolveOwnerLiveness({ownerSessionId: SID_B, liveSessionIds: null}),
+			resolveOwnerLiveness({owner: launcher(SID_B), liveSessionIds: null}),
 			"unknown",
 		);
-		assert.strictEqual(
-			resolveOwnerLiveness({ownerSessionId: null, liveSessionIds: null}),
-			"unknown",
-		);
+		assert.strictEqual(resolveOwnerLiveness({owner: null, liveSessionIds: null}), "unknown");
 	});
 });

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -52,6 +52,14 @@
  * dead**: `ownerLiveness` must be `"dead"`, resolved from holder presence per ADR 0191, never from
  * age. `"alive"` and `"unknown"` both KEEP — see `owner-liveness.ts` for the resolution and for why
  * "cannot prove dead" must never collapse into "dead".
+ *
+ * Launcher-vs-occupant (#4001): the identity a tree is stamped with is the session that SPAWNED it,
+ * never the ephemeral subagent occupying it, so a long-lived crew pane kept every tree it ever
+ * spawned `"alive"` for its whole multi-hour lifetime and the sweep went near-silent during exactly
+ * the runs that generate orphans. Such an owner now resolves `"launcher-alive"` — neither presence
+ * nor proof of death: the tree is held for a grace window and then decided by the ordinary
+ * age/merge/open-PR gates. `owner-liveness.ts` carries why launcher liveness is only an upper
+ * bound; `classifyWorktree` carries what protects a live occupant in the meantime.
  */
 
 import type {OwnerLiveness} from "./owner-liveness.ts";
@@ -122,10 +130,20 @@ export interface WorktreeRecord {
 	readonly hasOpenPr: boolean;
 	/**
 	 * Whether the agent session that OWNS this worktree is still running (#3943), resolved from
-	 * holder presence at the boundary (`owner-liveness.ts`). Only `"dead"` permits a removal:
-	 * `"alive"` is a live lane and `"unknown"` is an owner we could not prove dead — both KEEP.
+	 * holder presence at the boundary (`owner-liveness.ts`). Only `"dead"` permits a removal
+	 * outright: `"alive"` is a live lane and `"unknown"` is an owner we could not prove dead — both
+	 * KEEP. `"launcher-alive"` is the live-but-uninformative owner of #4001, gated by the grace
+	 * window below rather than by presence.
 	 */
 	readonly ownerLiveness: OwnerLiveness;
+	/**
+	 * The tree has been untouched for longer than the launcher grace window — a far longer idle
+	 * threshold than `recentlyActive`'s, consulted ONLY for a `"launcher-alive"` owner (#4001). It
+	 * is what lets an orphan spawned by a still-running pane eventually become sweep-eligible while
+	 * still giving a subagent the harness may have failed to lock a wide berth. Fail-safe toward
+	 * KEEP: an unresolvable mtime reads `false` (within grace).
+	 */
+	readonly idleBeyondLauncherGrace: boolean;
 }
 
 /** Why a worktree is KEPT — the audit trail, so the plan is never an opaque list. */
@@ -140,6 +158,12 @@ export type KeepReason =
 	| "live-session"
 	/** The owning session could not be proven dead (no stamp, or an untrustworthy registry) — kept (#3943). */
 	| "owner-unknown"
+	/**
+	 * The stamped owner is a still-running LAUNCHER, and the tree is still inside the grace window
+	 * (#4001). Distinct from `live-session` on purpose: this is not presence, it is a bounded
+	 * benefit of the doubt for an occupant that may have outlived the harness's occupancy lock.
+	 */
+	| "launcher-alive"
 	/** Touched within the idle threshold — presumed a live lane, never swept (#2240). */
 	| "recently-active"
 	/** The branch has an open PR — an in-flight lane, kept until it merges + goes idle (#2240). */
@@ -204,12 +228,20 @@ export interface WorktreeSweepPlan {
  *      tree with a LIVE directory are never candidates, regardless of their other facts.
  *   2. Dirty → KEEP (`dirty`). Wins over every other signal for BOTH classes: a worktree
  *      with working-tree changes is never removed, even when its branch has merged.
- *   3. Liveness gates — locked (#2240) / owner alive-or-unprovable (#3943) / recently-active
- *      (#2240) → KEEP, for BOTH classes. A clean tree may still belong to a LIVE lane (a build
- *      tree just committed+pushed; a review still running against its head). These run BEFORE any
- *      remove branch, so each is a necessary condition on REMOVE. The presence gate subsumes the
- *      mtime one it sits above — an idle-but-live shipper is exactly what mtime could not see —
- *      and `recently-active` is retained below it because it can only ever KEEP more.
+ *   3. Liveness gates — locked (#2240) / owner alive-or-unprovable (#3943) / launcher-alive within
+ *      grace (#4001) / recently-active (#2240) → KEEP, for BOTH classes. A clean tree may still
+ *      belong to a LIVE lane (a build tree just committed+pushed; a review still running against
+ *      its head). These run BEFORE any remove branch, so each is a necessary condition on REMOVE.
+ *      The presence gate subsumes the mtime one it sits above — an idle-but-live shipper is exactly
+ *      what mtime could not see — and `recently-active` is retained below it because it can only
+ *      ever KEEP more.
+ *
+ *      The `locked` gate is what makes step 3's launcher branch safe, and its position is load-
+ *      bearing: the harness holds a `git worktree lock` on an agent tree for its occupant's
+ *      lifetime and releases it when the occupant finishes, so a tree that gets PAST `locked` has
+ *      already had its occupancy released by the harness. That is the occupant-keyed presence
+ *      signal a launcher stamp cannot be (#4001) — hence a `"launcher-alive"` owner is held only
+ *      for the grace window, not forever. Never reorder `locked` below the owner gates.
  *   4. Review-head tree → REMOVE (`review-head-idle`). Past the dirty+locked+recently-active
  *      guards, a detached throwaway review checkout holds no branch and no unpushed work, so
  *      it is a pure leak — no merge/open-PR gate applies (see `review-head-idle`). Returns here
@@ -240,8 +272,11 @@ export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	if (wt.ownerLiveness === "alive") {
 		return {kind: "keep", reason: "live-session"};
 	}
-	if (wt.ownerLiveness !== "dead") {
+	if (wt.ownerLiveness === "unknown") {
 		return {kind: "keep", reason: "owner-unknown"};
+	}
+	if (wt.ownerLiveness === "launcher-alive" && !wt.idleBeyondLauncherGrace) {
+		return {kind: "keep", reason: "launcher-alive"};
 	}
 	if (wt.recentlyActive) {
 		return {kind: "keep", reason: "recently-active"};

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -29,6 +29,7 @@ const reviewRecord = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	// The fixtures default to a PROVABLY-DEAD owner so each pre-#3943 case still exercises the
 	// branch it was written for. The live/unknown owners are the explicit guard cases below.
 	ownerLiveness: "dead",
+	idleBeyondLauncherGrace: false,
 	...over,
 });
 
@@ -43,6 +44,7 @@ const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	recentlyActive: false,
 	hasOpenPr: false,
 	ownerLiveness: "dead",
+	idleBeyondLauncherGrace: false,
 	...over,
 });
 
@@ -266,6 +268,99 @@ describe("classifyWorktree — owner-presence liveness (#3943, ADR 0191)", () =>
 		assert.deepStrictEqual(
 			plan.kept.map((k) => [k.worktree.path, k.reason]),
 			[[alive.path, "live-session"]],
+		);
+	});
+});
+
+// The inverse defect of #3943: UNDER-reaping. A long-lived crew pane spawns many short-lived
+// subagent trees and stays alive for hours, so a launcher-keyed owner resolves live for every tree
+// it ever created — during exactly the runs that generate orphans. These pin that such a tree
+// becomes sweep-eligible on its own idle clock, without waiting for the pane to exit, while a live
+// occupant still never reaches REMOVE.
+describe("classifyWorktree — launcher-keyed ownership (#4001)", () => {
+	// The case this issue exists for: launcher still running, occupant long finished.
+	it("REMOVES a launcher-owned orphan once it is idle past the grace window — no waiting on the pane", () => {
+		const d = classifyWorktree(
+			shipperShaped({ownerLiveness: "launcher-alive", idleBeyondLauncherGrace: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "remove", reason: "squash-merged-clean"});
+	});
+
+	it("KEEPS the same tree inside the grace window, under a reason distinct from live-session", () => {
+		const d = classifyWorktree(
+			shipperShaped({ownerLiveness: "launcher-alive", idleBeyondLauncherGrace: false}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep", reason: "launcher-alive"});
+	});
+
+	// The #3943 asymmetry, unweakened: every gate that protected a live occupant still outranks the
+	// launcher branch, so no path here can remove a tree someone is working in.
+	it("never removes a launcher-owned tree the harness still LOCKS — occupancy outranks the grace window", () => {
+		const d = classifyWorktree(
+			shipperShaped({locked: true, ownerLiveness: "launcher-alive", idleBeyondLauncherGrace: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep", reason: "locked"});
+	});
+
+	it("never removes a launcher-owned tree that is dirty or has an open PR, past grace or not", () => {
+		assert.deepStrictEqual(
+			classifyWorktree(
+				shipperShaped({
+					isDirty: true,
+					ownerLiveness: "launcher-alive",
+					idleBeyondLauncherGrace: true,
+				}),
+			),
+			{kind: "keep", reason: "dirty"},
+		);
+		assert.deepStrictEqual(
+			classifyWorktree(
+				shipperShaped({
+					hasOpenPr: true,
+					ownerLiveness: "launcher-alive",
+					idleBeyondLauncherGrace: true,
+				}),
+			),
+			{kind: "keep", reason: "open-pr"},
+		);
+	});
+
+	it("keeps an UNKNOWN owner past the grace window — the grace window is not an escape from fail-closed", () => {
+		const d = classifyWorktree(
+			shipperShaped({ownerLiveness: "unknown", idleBeyondLauncherGrace: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep", reason: "owner-unknown"});
+	});
+
+	it("reclaims a launcher-owned review-head tree past grace, keeping the live-owner one", () => {
+		const stale = reviewRecord({
+			path: reviewHeadPath("review-head-4001"),
+			ownerLiveness: "launcher-alive",
+			idleBeyondLauncherGrace: true,
+		});
+		const live = reviewRecord({path: reviewHeadPath("review-head-4002"), ownerLiveness: "alive"});
+		const plan = computeWorktreeSweepPlan([stale, live]);
+		assert.deepStrictEqual(
+			plan.toRemove.map((r) => [r.worktree.path, r.reason]),
+			[[stale.path, "review-head-idle"]],
+		);
+		assert.deepStrictEqual(
+			plan.kept.map((k) => [k.worktree.path, k.reason]),
+			[[live.path, "live-session"]],
+		);
+	});
+
+	// The near-silence this issue reports is a DIAGNOSABILITY failure as much as a reaping one: a
+	// run that keeps everything must say WHY, and the three causes must not collapse into one label.
+	it("labels the three keep-causes distinctly so a near-silent run is readable", () => {
+		const plan = computeWorktreeSweepPlan([
+			shipperShaped({path: wtPath("agent-occupied"), ownerLiveness: "alive"}),
+			shipperShaped({path: wtPath("agent-launcher"), ownerLiveness: "launcher-alive"}),
+			shipperShaped({path: wtPath("agent-unstamped"), ownerLiveness: "unknown"}),
+		]);
+		assert.deepStrictEqual(
+			plan.kept.map((k) => k.reason),
+			["live-session", "launcher-alive", "owner-unknown"],
 		);
 	});
 });


### PR DESCRIPTION
`worktree-sweep` was declining to remove almost everything during crew runs, and the reason was whose name was on the tree. The owner stamp records the session that *spawned* a worktree, not the short-lived subagent that actually works in it — the `WorktreeCreate` hook runs before that subagent exists, and a subagent has no session identity of its own to record. So a crew pane that runs for hours kept every tree it had ever spawned looking "owned by a live session" for its whole lifetime, and the sweep went quiet during exactly the runs that produce the orphans.

This treats a launcher's liveness as the one-directional signal it is: a dead launcher still proves its occupant is gone, but a live one proves nothing, and now resolves as `launcher-alive` instead of `alive`. Real occupancy is already tracked by the harness's own worktree lock, which sits above the owner gates and is released when the occupying agent finishes — so a `launcher-alive` tree is held for a two-hour no-activity grace window and then judged by the ordinary idle/merge/open-PR gates, rather than being kept until the pane exits.

### What changed

- `owner-liveness.ts` — `OwnerLiveness` gains `launcher-alive`; the stamp parses into an `OwnerStamp` carrying an `OwnerKind` (`launcher` | `occupant`), and a live owner resolves `alive` only when the stamp claims to name the occupant.
- `worktree-sweep.ts` — the classifier keeps a `launcher-alive` tree under its own distinct reason while inside the grace window, and lets it fall through to the existing gates once past it.
- `command.ts` — one mtime read now yields both idle facts (`recentlyActive`, `idleBeyondLauncherGrace`), and the kept set prints a per-reason tally so an all-KEEP run says *why*.
- `hooks/create-worktree.sh` — stamps `ownerKind: "launcher"`, which is the only kind it can honestly write.

### The fail-closed direction is unchanged (#3943)

`unknown` still KEEPs, an unreadable registry still removes nothing, and `dirty` / `locked` / `open-pr` / `recently-active` all still outrank the launcher branch — so no path here can resolve a live occupant's tree as `dead`. A legacy stamp with no `ownerKind` reads as `launcher`, which is what every stamp written so far actually is; only an explicit `ownerKind: "occupant"` is granted occupant authority, so a future occupant-keyed stamp has to say so rather than inherit the launcher's reach by silence.

No producer writes an `occupant` stamp yet, deliberately — choosing that mechanism is the open design call in #3892.

### Out of lane, noted not fixed

Two things surfaced while verifying against the live worktree population and were left alone:

- A worktree whose lock names a **dead** pid (one on this machine has been held since June) is still KEPT unconditionally by the `locked` gate, so a stale lock pins a tree forever. Fixing that means changing a #2240 guard and belongs with the reaper lane.
- #3943's reaper work over `worktree-guard/reap.ts` and `worktree-reap/**` is a separate, currently-blocked lane and was not touched. #3989 will inherit the same launcher-keying limit when it extends its presence gate to this stamp.

### Verification

`pnpm typecheck`, `pnpm lint:worktree`, and all 97 `worktree-sweep` tests (unit + hook) pass. The new end-to-end case registers a launcher session as *running* and proves a tree it spawned is still reclaimed once idle past the window, while a freshly-touched sibling under the same launcher is kept.

Closes #4001
