### PR TITLE
fix(pipeline-cli): load a tool's module only when that verb is dispatched (#4008)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -83,6 +83,37 @@ the outcome as a typed `StdinReadFailed` in the error channel. The pure retry co
 IO injected so the `EAGAIN` path is testable, lives in
 [`src/read-stdin-core.ts`](./src/read-stdin-core.ts).
 
+## How a tool is loaded
+
+Running `pipeline-cli <tool>` loads that tool's module and no other. The registry
+([`src/registry.ts`](./src/registry.ts)) holds one row per tool — the selector name, and
+the module import as a thunk — so the name is known without linking anything and the
+module is linked only once that verb is dispatched. Only a listing (`--help`,
+`commands compact`) resolves every row, because only a listing is about every tool.
+
+That containment is the point. When the registry imported every tool's module up front,
+one unresolvable row failed *every* invocation, including tools that had nothing to do
+with it — and the pipeline runs many agents against one checkout, so a tool being written
+right now is a normal state, not an exceptional one. A row that will not resolve now
+fails just the verb that asked for it.
+
+A load fault reports the registration by name:
+
+```
+pipeline-cli: registered tool `example` failed to load — its command module did not resolve (…)
+  The registration is in packages/pipeline-cli/src/registry.ts. A tool that is mid-write in the
+  working tree this CLI runs from looks exactly like this; every OTHER tool still works.
+```
+
+Two rules apply when adding a row. Write the `import()` with a **string-literal**
+specifier — the build rewrites those extensions, and cannot rewrite a computed one. And
+register the tool under the **same name** its `Command.make("<name>")` declares; the
+loader asserts the two match, because the router selects on the registered name and the
+CLI runtime dispatches on the declared one.
+
+One case is deliberately not wrapped: an unlinked dependency still propagates untouched,
+so the bin's install self-heal and its remediation message keep working.
+
 ## Development
 
 The source lives in the phoenix monorepo under

--- a/packages/pipeline-cli/TOOLS.md
+++ b/packages/pipeline-cli/TOOLS.md
@@ -35,17 +35,24 @@ Per the repo's mechanical-tooling idiom (`decisions-index` / `epic-ledger` /
 `leak-guard`): a pure, unit-tested core + a thin Effect CLI bin.
 
 - `src/registry.ts` — **the extension seam.** `registeredTools` is the array of
-  `effect/unstable/cli` `Command`s the router exposes. A Phase-2 child folds its
-  tool in by appending one `Command` here — and nothing else. The router and bin
-  consume this array opaquely.
+  **lazy registrations** the router exposes: each row carries a tool's selector name
+  eagerly and its module import as a thunk. A child folds its tool in by appending one
+  row here — and nothing else. The router and bin consume this array opaquely.
+- `src/tool-registration.ts` — the registration type and its loader. `loadRegistration`
+  resolves one row (asserting the registered name matches the module's
+  `Command.make("<name>")` name) and turns a load fault into an attributable
+  `ToolLoadError`; `loadRegistry` resolves a whole registry, keeping the rows that
+  resolve and collecting the ones that don't.
 - `src/router.ts` — the **pure router core.** `dispatch(registry, argv)` resolves
   the first argv token to a registered tool (`Ok({ tool, rest })`), or fails with
   a clear `UnknownToolError` (unknown token) / `NoToolError` (no token). It owns
   no Effect runtime, so the dispatch contract is unit-testable directly (ADR 0040
-  T0/T1) — the mirror of the runtime dispatch `Command.withSubcommands` does.
+  T0/T1). It resolves on `name` alone, so `run.ts` uses it to pick the row to load
+  *before* any module is linked.
 - `src/version.ts` — the `version` tracer tool, a normal registered tool.
-- `src/bin.ts` — the `effect/unstable/cli` bin: `Command.withSubcommands(registeredTools)`,
-  run via `NodeRuntime.runMain`.
+- `src/bin.ts` — the bootstrap; `src/run.ts` builds the
+  `effect/unstable/cli` root from this invocation's subcommands and runs it via
+  `NodeRuntime.runMain`.
 
 ## The extension seam
 
@@ -53,13 +60,39 @@ A later child registers its moved tool **without touching the router core**:
 
 ```ts
 // src/registry.ts
-import {myToolCommand} from "./my-tool.ts";
-export const registeredTools: ReadonlyArray<RegisteredTool> = [versionCommand, myToolCommand];
+export const registeredTools: ReadonlyArray<ToolRegistration> = [
+	tool("version", () => import("./version.ts").then((m) => m.versionCommand)),
+	tool("my-tool", () => import("./tools/my-tool/command.ts").then((m) => m.myToolCommand)),
+];
 ```
 
 That single append is the entire registration step. `router.ts` and `bin.ts`
 never change — the router is closed for modification, the registry is open for
 extension.
+
+Two constraints on the row (both mechanically enforced): the `import()` specifier must be
+a **string literal**, because `rewriteRelativeImportExtensions` rewrites literal
+`.ts` specifiers on build and cannot rewrite a computed one; and the registered name must
+equal the module's `Command.make("<name>")` name, which `loadRegistration` asserts.
+
+## Loading is lazy — one lane's half-written tool doesn't break the others
+
+`registry.ts` used to `import` every tool's `command.ts` statically, which coupled every
+invocation to every registration. Pipeline agents get per-lane git worktrees but execute
+`pipeline-cli` out of one shared checkout, so a tool that was registered before its
+`command.ts` was written took down *every* concurrent lane's gate tooling with an
+`ERR_MODULE_NOT_FOUND` naming a tool the caller never invoked — unattributable at the
+point of use (#4008).
+
+Dispatching a verb now links that verb's module and nothing else, and a row that won't
+resolve fails only the verb that asked for it, with a `ToolLoadError` naming the
+registration. `--help` and `commands compact` do resolve the whole registry — they are
+about every tool — but a broken row is reported and omitted there rather than fatal
+(`commands check`, being a gate, still reds on it: ADR 0092).
+
+An **unlinked dependency** miss is deliberately rethrown untouched rather than wrapped, so
+`bin.ts`'s one-shot `pnpm install` self-heal (#2459) and its install remediation (#1798)
+still classify it.
 
 ## Usage
 

--- a/packages/pipeline-cli/src/bin.ts
+++ b/packages/pipeline-cli/src/bin.ts
@@ -6,7 +6,8 @@
  *   node src/bin.ts version       # the Phase-1 tracer tool
  *   node src/bin.ts <tool> …      # dispatch to a registered tool (Phase-2 children)
  *
- * The router itself lives in `run.ts` (`Command.withSubcommands(registeredTools)`);
+ * The router itself lives in `run.ts` (it resolves this invocation's subcommands out of
+ * the registry, loading only the tool that was actually selected — #4008);
  * this file is a thin bootstrap that loads it via a **dynamic** `import()` so an
  * unlinked `catalog:` dep — the in-repo-first path hit before `pnpm install` has
  * settled on a fresh/partial checkout — is a *catchable* `ERR_MODULE_NOT_FOUND`

--- a/packages/pipeline-cli/src/index.ts
+++ b/packages/pipeline-cli/src/index.ts
@@ -4,8 +4,19 @@
  * pure router core, and one tracer tool (`version`).
  *
  * The public surface a Phase-2 child touches is `registry.ts` (append your tool's
- * `Command` to `registeredTools`); the router core and bin are consumed opaquely.
+ * `tool(<name>, () => import(<module>))` row to `registeredTools`); the router core
+ * and bin are consumed opaquely.
  */
-export {type RegisteredTool, registeredTools} from "./registry.ts";
-export {dispatch, NoToolError, toolNames, UnknownToolError} from "./router.ts";
+export {registeredTools} from "./registry.ts";
+export {dispatch, type NamedTool, NoToolError, toolNames, UnknownToolError} from "./router.ts";
+export {
+	type LoadedRegistry,
+	loadRegistration,
+	loadRegistry,
+	type RegisteredTool,
+	ToolLoadError,
+	type ToolLoadFailure,
+	type ToolRegistration,
+	tool,
+} from "./tool-registration.ts";
 export {VERSION, versionCommand} from "./version.ts";

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -1,238 +1,263 @@
 /**
  * The pipeline-cli tool registry — the extension seam (epic #994).
  *
- * Each entry is one pipeline tool exposed as `pipeline-cli <name> …`. A Phase-2
- * child folds its tool in by authoring an `effect/unstable/cli` `Command` and
- * appending it to `registeredTools` here — it never reshapes the router core
- * (`router.ts`) or the bin (`bin.ts`), both of which consume this array opaquely.
+ * Each entry is one pipeline tool exposed as `pipeline-cli <name> …`. A child folds
+ * its tool in by authoring an `effect/unstable/cli` `Command` and appending one
+ * `tool(<name>, () => import(<module>))` row to `registeredTools` here — it never
+ * reshapes the router core (`router.ts`) or the bin (`bin.ts`), both of which consume
+ * this array opaquely.
  *
- * That is the whole contract of the seam: the router is closed for modification
- * and the registry is open for extension. A tool's subcommand surface (its own
- * args/flags) lives on the `Command` it registers, not here.
- */
-import type {NodeServices} from "@effect/platform-node";
-import type {Command} from "effect/unstable/cli";
-import {adoptionLintCommand} from "./tools/adoption-lint/command.ts";
-import {adrSweepCommand} from "./tools/adr-sweep/command.ts";
-import {campaignCommand} from "./tools/campaign/command.ts";
-import {catalogGuardCommand} from "./tools/catalog-guard/command.ts";
-import {changeDetectGuardCommand} from "./tools/change-detect-guard/command.ts";
-import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
-import {checksCommand} from "./tools/checks/command.ts";
-import {ciRequiredCommand} from "./tools/ci-required/command.ts";
-import {claimCommand} from "./tools/claim/command.ts";
-import {classProbeCommand} from "./tools/class-probe/command.ts";
-import {codeownersCpCommand} from "./tools/codeowners-cp/command.ts";
-import {commandsCommand} from "./tools/commands/command.ts";
-import {controlPlanePathsCommand} from "./tools/control-plane-paths/command.ts";
-import {cpCardinalityCommand} from "./tools/cp-cardinality/command.ts";
-import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
-import {crewFanoutGuardCommand} from "./tools/crew-fanout-guard/command.ts";
-import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
-import {designInventoryCommand} from "./tools/design-inventory/command.ts";
-import {designTokenGuardCommand} from "./tools/design-token-guard/command.ts";
-import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
-import {epicLockCommand} from "./tools/epic-lock/command.ts";
-import {epicSpliceCommand} from "./tools/epic-splice/command.ts";
-import {evalHarnessCommand} from "./tools/eval-harness/command.ts";
-import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
-import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
-import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
-import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
-import {guardContentProbeCommand} from "./tools/guard-content-probe/command.ts";
-import {homingGuardCommand} from "./tools/homing-guard/command.ts";
-import {intakeComposeCommand} from "./tools/intake-compose/command.ts";
-import {intakeDedupCommand} from "./tools/intake-dedup/command.ts";
-import {leakGuardCommand} from "./tools/leak-guard/command.ts";
-import {mainSyncCommand} from "./tools/main-sync/command.ts";
-import {mergeIntentCommand} from "./tools/merge-intent/command.ts";
-import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
-import {orphanHealCommand} from "./tools/orphan-heal/command.ts";
-import {patchGuardCommand} from "./tools/patch-guard/command.ts";
-import {pathFilterGuardCommand} from "./tools/path-filter-guard/command.ts";
-import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
-import {primaryIndexGuardCommand} from "./tools/primary-index-guard/command.ts";
-import {publishIsolationGuardCommand} from "./tools/publish-isolation-guard/command.ts";
-import {reachabilityGuardCommand} from "./tools/reachability-guard/command.ts";
-import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
-import {redactLeaksCommand} from "./tools/redact-leaks/command.ts";
-import {refGuardCommand} from "./tools/ref-guard/command.ts";
-import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
-import {reviewHeadCommand} from "./tools/review-head/command.ts";
-import {roadmapCommand} from "./tools/roadmap/command.ts";
-import {roadmapGuardCommand} from "./tools/roadmap-guard/command.ts";
-import {runEvidenceCommand} from "./tools/run-evidence/command.ts";
-import {scratchpadCommand} from "./tools/scratchpad/command.ts";
-import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
-import {shipDigestCommand} from "./tools/ship-digest/command.ts";
-import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
-import {splitGuardCommand} from "./tools/split-guard/command.ts";
-import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
-import {tokenSpendCommand} from "./tools/token-spend/command.ts";
-import {trackerCommand} from "./tools/tracker/command.ts";
-import {trivialDiffCommand} from "./tools/trivial-diff/command.ts";
-import {tscAnnotateCommand} from "./tools/tsc-annotate/command.ts";
-import {unresolvedThreadsGuardCommand} from "./tools/unresolved-threads-guard/command.ts";
-import {verdictCommand} from "./tools/verdict/command.ts";
-import {wayfinderMapCommand} from "./tools/wayfinder-map/command.ts";
-import {workflowContractCommand} from "./tools/workflow-contract/command.ts";
-import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
-import {worktreeReapCommand} from "./tools/worktree-reap/command.ts";
-import {worktreeSweepCommand} from "./tools/worktree-sweep/command.ts";
-import {versionCommand} from "./version.ts";
-
-/** The Node platform service union the bin provides — the requirement ceiling for a tool. */
-type Platform = NodeServices.NodeServices;
-
-/**
- * A registered pipeline tool: a top-level `effect/unstable/cli` `Command` whose
- * `name` is the `pipeline-cli <name>` selector.
+ * That is the whole contract of the seam: the router is closed for modification and
+ * the registry is open for extension. A tool's subcommand surface (its own args/flags)
+ * lives on the `Command` it registers, not here.
  *
- * The requirement row is bounded by **the Node platform services** — the one
- * layer the bin provides at the run boundary (`bin.ts`). A tool that needs more
- * than the Node platform (a `Github` capability, a DB) must bake its own layer
- * into its `Command` with `Command.provide(...)` **before** registering, so the
- * registered command's residual requirement is the platform union. That keeps
- * the bin and the router core stable as tools fold in: a tool self-contains its
- * services, the bin never grows a per-tool layer. The `Name`/`Input`/
- * `ContextInput`/`E` slots are left at their widest so the registry stays
- * heterogeneous over tools with different names, args, flags, and error rows.
- * Both `Name` and `Input` are `any` because each sits in a contravariant slot
- * (`CommandContext<Name>`, `Variance<in Input, …>`): a concrete literal name
- * (`"version"`) is not assignable to `string`, and a tool's concrete input shape
- * (`{epic, dryRun}`) is not assignable from `object` — so only `any` admits tools
- * with different literal names and different arg/flag inputs into one registry array.
+ * Registration is **lazy** — see `tool-registration.ts` for why (#4008). Two rules follow
+ * for anyone adding a row: `import()` with a **string-literal** specifier
+ * (`rewriteRelativeImportExtensions` rewrites those on build, a computed one it cannot),
+ * and give the row the **same name** the module's `Command.make("<name>")` declares —
+ * `loadRegistration` asserts it.
  */
-export type RegisteredTool = Command.Command<any, any, object, unknown, Platform>;
+import {type ToolRegistration, tool} from "./tool-registration.ts";
+
+export type {RegisteredTool} from "./tool-registration.ts";
 
 /**
  * The registered pipeline tools, in the order they list under `--help`.
- *
- * Phase 1 ships the tracer tool only (`version`); Phase-2 children append their
- * moved tool's `Command` to this array — that single append is the entire
- * registration step (epic #994). The router and bin read this array opaquely, so
- * a new entry needs no edit anywhere else.
  */
-export const registeredTools: ReadonlyArray<RegisteredTool> = [
-	versionCommand,
-	epicLedgerCommand,
-	epicLockCommand,
-	epicSpliceCommand,
-	decisionsIndexCommand,
-	readmeGuardCommand,
-	roadmapCommand,
-	roadmapGuardCommand,
-	worktreeGuardCommand,
-	spawnGuardCommand,
-	leakGuardCommand,
-	mergeQueueClassifyCommand,
+export const registeredTools: ReadonlyArray<ToolRegistration> = [
+	tool("version", () => import("./version.ts").then((m) => m.versionCommand)),
+	tool("epic-ledger", () =>
+		import("./tools/epic-ledger/command.ts").then((m) => m.epicLedgerCommand),
+	),
+	tool("epic-lock", () => import("./tools/epic-lock/command.ts").then((m) => m.epicLockCommand)),
+	tool("epic-splice", () =>
+		import("./tools/epic-splice/command.ts").then((m) => m.epicSpliceCommand),
+	),
+	tool("decisions-index", () =>
+		import("./tools/decisions-index/command.ts").then((m) => m.decisionsIndexCommand),
+	),
+	tool("readme-guard", () =>
+		import("./tools/readme-guard/command.ts").then((m) => m.readmeGuardCommand),
+	),
+	tool("roadmap", () => import("./tools/roadmap/command.ts").then((m) => m.roadmapCommand)),
+	tool("roadmap-guard", () =>
+		import("./tools/roadmap-guard/command.ts").then((m) => m.roadmapGuardCommand),
+	),
+	tool("worktree-guard", () =>
+		import("./tools/worktree-guard/command.ts").then((m) => m.worktreeGuardCommand),
+	),
+	tool("spawn-guard", () =>
+		import("./tools/spawn-guard/command.ts").then((m) => m.spawnGuardCommand),
+	),
+	tool("leak-guard", () => import("./tools/leak-guard/command.ts").then((m) => m.leakGuardCommand)),
+	tool("merge-queue-classify", () =>
+		import("./tools/merge-queue-classify/command.ts").then((m) => m.mergeQueueClassifyCommand),
+	),
 	// #3723 — ship-it's no-parked-merge-intent enforcement (ADR 0198): clears a `gh pr merge
 	// --auto` request left armed by a run that did NOT enqueue, so a later bare approval can't
 	// enqueue a §CP PR ahead of the gate assertions. Verified by an `auto_merge` read-back.
-	mergeIntentCommand,
-	pathFilterGuardCommand,
-	pointerGuardCommand,
-	ciRequiredCommand,
-	ghPhoenixCommand,
-	crabboxManifestCommand,
-	changelogDeriveCommand,
-	structuredOutputGuardCommand,
-	workflowContractCommand,
-	worktreeSweepCommand,
-	worktreeReapCommand,
-	codeownersCpCommand,
-	controlPlanePathsCommand,
-	cpCardinalityCommand,
-	tokenSpendCommand,
-	trackerCommand,
-	trivialDiffCommand,
-	tscAnnotateCommand,
-	classProbeCommand,
-	wayfinderMapCommand,
-	shipDigestCommand,
-	glossaryDriftCommand,
-	guardContentProbeCommand,
-	failureClassifierCommand,
-	fanoutGuardCommand,
-	reachabilityGuardCommand,
-	designTokenGuardCommand,
-	designInventoryCommand,
-	resumePolicyCommand,
+	tool("merge-intent", () =>
+		import("./tools/merge-intent/command.ts").then((m) => m.mergeIntentCommand),
+	),
+	tool("path-filter-guard", () =>
+		import("./tools/path-filter-guard/command.ts").then((m) => m.pathFilterGuardCommand),
+	),
+	tool("pointer-guard", () =>
+		import("./tools/pointer-guard/command.ts").then((m) => m.pointerGuardCommand),
+	),
+	tool("ci-required", () =>
+		import("./tools/ci-required/command.ts").then((m) => m.ciRequiredCommand),
+	),
+	tool("gh-phoenix", () => import("./tools/gh-phoenix/command.ts").then((m) => m.ghPhoenixCommand)),
+	tool("crabbox-manifest", () =>
+		import("./tools/crabbox-manifest/command.ts").then((m) => m.crabboxManifestCommand),
+	),
+	tool("changelog-derive", () =>
+		import("./tools/changelog-derive/command.ts").then((m) => m.changelogDeriveCommand),
+	),
+	tool("structured-output-guard", () =>
+		import("./tools/structured-output-guard/command.ts").then(
+			(m) => m.structuredOutputGuardCommand,
+		),
+	),
+	tool("workflow-contract", () =>
+		import("./tools/workflow-contract/command.ts").then((m) => m.workflowContractCommand),
+	),
+	tool("worktree-sweep", () =>
+		import("./tools/worktree-sweep/command.ts").then((m) => m.worktreeSweepCommand),
+	),
+	tool("worktree-reap", () =>
+		import("./tools/worktree-reap/command.ts").then((m) => m.worktreeReapCommand),
+	),
+	tool("codeowners-cp", () =>
+		import("./tools/codeowners-cp/command.ts").then((m) => m.codeownersCpCommand),
+	),
+	tool("control-plane-paths", () =>
+		import("./tools/control-plane-paths/command.ts").then((m) => m.controlPlanePathsCommand),
+	),
+	tool("cp-cardinality", () =>
+		import("./tools/cp-cardinality/command.ts").then((m) => m.cpCardinalityCommand),
+	),
+	tool("token-spend", () =>
+		import("./tools/token-spend/command.ts").then((m) => m.tokenSpendCommand),
+	),
+	tool("tracker", () => import("./tools/tracker/command.ts").then((m) => m.trackerCommand)),
+	tool("trivial-diff", () =>
+		import("./tools/trivial-diff/command.ts").then((m) => m.trivialDiffCommand),
+	),
+	tool("tsc-annotate", () =>
+		import("./tools/tsc-annotate/command.ts").then((m) => m.tscAnnotateCommand),
+	),
+	tool("class-probe", () =>
+		import("./tools/class-probe/command.ts").then((m) => m.classProbeCommand),
+	),
+	tool("wayfinder-map", () =>
+		import("./tools/wayfinder-map/command.ts").then((m) => m.wayfinderMapCommand),
+	),
+	tool("ship-digest", () =>
+		import("./tools/ship-digest/command.ts").then((m) => m.shipDigestCommand),
+	),
+	tool("glossary-drift", () =>
+		import("./tools/glossary-drift/command.ts").then((m) => m.glossaryDriftCommand),
+	),
+	tool("guard-content-probe", () =>
+		import("./tools/guard-content-probe/command.ts").then((m) => m.guardContentProbeCommand),
+	),
+	tool("failure-classifier", () =>
+		import("./tools/failure-classifier/command.ts").then((m) => m.failureClassifierCommand),
+	),
+	tool("fanout-guard", () =>
+		import("./tools/fanout-guard/command.ts").then((m) => m.fanoutGuardCommand),
+	),
+	tool("reachability-guard", () =>
+		import("./tools/reachability-guard/command.ts").then((m) => m.reachabilityGuardCommand),
+	),
+	tool("design-token-guard", () =>
+		import("./tools/design-token-guard/command.ts").then((m) => m.designTokenGuardCommand),
+	),
+	tool("design-inventory", () =>
+		import("./tools/design-inventory/command.ts").then((m) => m.designInventoryCommand),
+	),
+	tool("resume-policy", () =>
+		import("./tools/resume-policy/command.ts").then((m) => m.resumePolicyCommand),
+	),
 	// The shared PR-head-checkout the review gates cite instead of hand-copying the §HEAD
 	// materialization (#793 / #1807): resolve + fetch the PR's current head into a per-run ref
 	// (+ optional detached worktree), asserting the fetched ref IS the resolved head (ADR 0058).
-	reviewHeadCommand,
-	evalHarnessCommand,
-	mainSyncCommand,
-	refGuardCommand,
-	primaryIndexGuardCommand,
-	settingsEnvGuardCommand,
-	verdictCommand,
-	campaignCommand,
-	catalogGuardCommand,
-	changeDetectGuardCommand,
-	patchGuardCommand,
-	intakeDedupCommand,
+	tool("review-head", () =>
+		import("./tools/review-head/command.ts").then((m) => m.reviewHeadCommand),
+	),
+	tool("eval-harness", () =>
+		import("./tools/eval-harness/command.ts").then((m) => m.evalHarnessCommand),
+	),
+	tool("main-sync", () => import("./tools/main-sync/command.ts").then((m) => m.mainSyncCommand)),
+	tool("ref-guard", () => import("./tools/ref-guard/command.ts").then((m) => m.refGuardCommand)),
+	tool("primary-index-guard", () =>
+		import("./tools/primary-index-guard/command.ts").then((m) => m.primaryIndexGuardCommand),
+	),
+	tool("settings-env-guard", () =>
+		import("./tools/settings-env-guard/command.ts").then((m) => m.settingsEnvGuardCommand),
+	),
+	tool("verdict", () => import("./tools/verdict/command.ts").then((m) => m.verdictCommand)),
+	tool("campaign", () => import("./tools/campaign/command.ts").then((m) => m.campaignCommand)),
+	tool("catalog-guard", () =>
+		import("./tools/catalog-guard/command.ts").then((m) => m.catalogGuardCommand),
+	),
+	tool("change-detect-guard", () =>
+		import("./tools/change-detect-guard/command.ts").then((m) => m.changeDetectGuardCommand),
+	),
+	tool("patch-guard", () =>
+		import("./tools/patch-guard/command.ts").then((m) => m.patchGuardCommand),
+	),
+	tool("intake-dedup", () =>
+		import("./tools/intake-dedup/command.ts").then((m) => m.intakeDedupCommand),
+	),
 	// The #3688 intake-body composer (epic #3258): one tested verb that emits the
 	// format-2 sub-issue body of the gh-issue-intake-formats.md prose contract, so a
 	// filer cites it instead of re-deriving the format — and owns the by-value handoff
 	// that keeps the `-f body=@file` leak class (#2002 / #754) unreachable.
-	intakeComposeCommand,
-	splitGuardCommand,
-	redactLeaksCommand,
-	commandsCommand,
+	tool("intake-compose", () =>
+		import("./tools/intake-compose/command.ts").then((m) => m.intakeComposeCommand),
+	),
+	tool("split-guard", () =>
+		import("./tools/split-guard/command.ts").then((m) => m.splitGuardCommand),
+	),
+	tool("redact-leaks", () =>
+		import("./tools/redact-leaks/command.ts").then((m) => m.redactLeaksCommand),
+	),
+	tool("commands", () => import("./tools/commands/command.ts").then((m) => m.commandsCommand)),
 	// The ADR-0158 unresolved-inline-thread merge gate's fail-closed enforcement (#3331):
 	// reds a PR when a substantive unresolved review thread is unaccounted-for in the
 	// review-code verdict, covering the §CP manual-merge path ship-it Step 3.6 never sees.
-	unresolvedThreadsGuardCommand,
+	tool("unresolved-threads-guard", () =>
+		import("./tools/unresolved-threads-guard/command.ts").then(
+			(m) => m.unresolvedThreadsGuardCommand,
+		),
+	),
 	// The #3687 issue-scoped claim resolver (epic #3258 verb wave): resolves the ADR-0115
 	// earliest-authorized-claim decision — "is this claim mine?" — default-deny, reusing
 	// epic-lock's pure `resolveClaim` core rather than a second copy.
-	claimCommand,
+	tool("claim", () => import("./tools/claim/command.ts").then((m) => m.claimCommand)),
 	// The #3254 adoption corpus-lint (epic #3258, governing AC): reds a corpus file that
 	// inline-re-derives a tool-owned decision without citing the owning verb, so the verb
 	// sweep can't grow the unreferenced-tool pile. Fail-closed on zero scope (ADR 0092).
-	adoptionLintCommand,
+	tool("adoption-lint", () =>
+		import("./tools/adoption-lint/command.ts").then((m) => m.adoptionLintCommand),
+	),
 	// #3606 — inverts the crew read-only-fanout per-bridge spawn denylist into an ENFORCED
 	// allowlist: reds when a mutating roster agent-type is neither allowlisted nor denied by a
 	// crew bridge (chief-of-staff/cartographer/intake-desk), closing the future-agent hole ADR
 	// 0196 warns of. Fail-closed on zero scope (ADR 0092); roster-law boundary (ADR 0189/0196).
-	crewFanoutGuardCommand,
+	tool("crew-fanout-guard", () =>
+		import("./tools/crew-fanout-guard/command.ts").then((m) => m.crewFanoutGuardCommand),
+	),
 	// #3650 — the orphan-red-PR detector + heal-item emitter (the #3532 boundary path, steps
 	// 1–2): convert an open, CI-red, laneless PR into one idempotent triaged "heal red CI on
 	// PR #N" item so an engine adopts the lane, rather than free-scanning arbitrary red PRs.
-	orphanHealCommand,
+	tool("orphan-heal", () =>
+		import("./tools/orphan-heal/command.ts").then((m) => m.orphanHealCommand),
+	),
 	// #3762 — the shared head-CI read: roll a SHA's check-runs up LATEST-PER-CONTEXT, so a
 	// superseded run can't red a green head (the false RED that opened a needless repair lane
 	// on PR #3733). The one tested reader every CI-state consumer cites instead of re-rolling
 	// the query, the single-source shape of `verdict read` (#3686).
-	checksCommand,
+	tool("checks", () => import("./tools/checks/command.ts").then((m) => m.checksCommand)),
 	// #3833 — ADR 0201 §3's isolated-publishing invariant: reds when a package the
 	// release pipeline (publish.yml) ships links a private/unpublished @kampus dep or a
 	// workspace: specifier, making the #3802 uninstallable-publish class unrepresentable.
 	// Scope derived from publish.yml's tag grammar; fail-closed on zero scope (ADR 0092).
-	publishIsolationGuardCommand,
+	tool("publish-isolation-guard", () =>
+		import("./tools/publish-isolation-guard/command.ts").then(
+			(m) => m.publishIsolationGuardCommand,
+		),
+	),
 	// #3991 — the SHA-bound run-evidence bundle lookup as FOUR states: present / pending / absent /
 	// unknown. review-code's inline `gh api` chain collapsed every non-success path into the prose
 	// "absent for this head SHA", so a producer that had not run yet and a 5xx during the download
 	// both read as a missing bundle. Validates the archive (ZIP magic) and the manifest
 	// (schemaVersion, commit == head) before interpreting either, and carries the lookup evidence
 	// (queried SHA, run id, artifact id) so the claim is falsifiable from the verdict comment alone.
-	runEvidenceCommand,
+	tool("run-evidence", () =>
+		import("./tools/run-evidence/command.ts").then((m) => m.runEvidenceCommand),
+	),
 	// #3939 — the teeth behind the triage rubric's home-or-exempt-or-kill outcome (ADR 0202
 	// forward-motion doctrine, ADR 0208 standing-lane exemption): reds when an issue leaves
 	// triage with neither an arc/campaign milestone nor one of the two standing-lane labels,
 	// so floaters can't regrow at the seam. Fail-closed on zero scope (ADR 0092).
-	homingGuardCommand,
+	tool("homing-guard", () =>
+		import("./tools/homing-guard/command.ts").then((m) => m.homingGuardCommand),
+	),
 	// #3980 — the mechanical half of the ADR contradiction sweep: rank the live-accepted ADRs a
 	// new ADR touches the decision domain of but never cites, so a same-question conflict with an
 	// unsuperseded ADR (0208-vs-0072, 0210-vs-0202) is a list to clear rather than a memory test.
 	// Fail-closed on an unreadable corpus / zero scope (ADR 0092); `indeterminate` is a distinct
 	// outcome from `no-overlap` by construction.
-	adrSweepCommand,
+	tool("adr-sweep", () => import("./tools/adr-sweep/command.ts").then((m) => m.adrSweepCommand)),
 	// #3718 — the per-run scratch namespace (§SP) as an allocator every agent calls instead
 	// of hand-rolling a path: unique per RUN, deterministically re-derivable across Bash
 	// calls, owner-stamped so a second run is refused rather than clobbering. Fail-closed —
 	// no fallback to a shared location, which is what made the collision silent.
-	scratchpadCommand,
+	tool("scratchpad", () =>
+		import("./tools/scratchpad/command.ts").then((m) => m.scratchpadCommand),
+	),
 ];

--- a/packages/pipeline-cli/src/router.ts
+++ b/packages/pipeline-cli/src/router.ts
@@ -10,10 +10,13 @@
  * clear typed error for an unknown one — is unit-testable without spawning a CLI
  * (ADR 0082). The router is closed for modification: new tools arrive only
  * via `registry.ts`, never by editing this file.
+ *
+ * It resolves on `name` alone, so it dispatches a lazy `ToolRegistration` — the row
+ * `run.ts` must select *before* loading any module (#4008) — as readily as a loaded
+ * `Command`; both carry the selector.
  */
 import {Result} from "effect";
 import * as Schema from "effect/Schema";
-import type {RegisteredTool} from "./registry.ts";
 
 /** The first argv token named no registered tool. Carries the offender + the known set. */
 export class UnknownToolError extends Schema.TaggedErrorClass<UnknownToolError>()(
@@ -37,8 +40,13 @@ export class NoToolError extends Schema.TaggedErrorClass<NoToolError>()("NoToolE
 	}
 }
 
+/** All the router needs of a registry row: the selector it dispatches on. */
+export interface NamedTool {
+	readonly name: string;
+}
+
 /** The names of every registered tool, in registry order. */
-export const toolNames = (registry: ReadonlyArray<RegisteredTool>): ReadonlyArray<string> =>
+export const toolNames = (registry: ReadonlyArray<NamedTool>): ReadonlyArray<string> =>
 	registry.map((tool) => tool.name);
 
 /**
@@ -50,11 +58,11 @@ export const toolNames = (registry: ReadonlyArray<RegisteredTool>): ReadonlyArra
  *   non-zero-exit-worthy failure — AC #2)
  * - empty argv ⇒ `Err(NoToolError)` (the help/usage case)
  */
-export const dispatch = (
-	registry: ReadonlyArray<RegisteredTool>,
+export const dispatch = <T extends NamedTool>(
+	registry: ReadonlyArray<T>,
 	argv: ReadonlyArray<string>,
 ): Result.Result<
-	{readonly tool: RegisteredTool; readonly rest: ReadonlyArray<string>},
+	{readonly tool: T; readonly rest: ReadonlyArray<string>},
 	UnknownToolError | NoToolError
 > => {
 	const [head, ...rest] = argv;

--- a/packages/pipeline-cli/src/run.ts
+++ b/packages/pipeline-cli/src/run.ts
@@ -1,25 +1,65 @@
 /**
  * The pipeline-cli router wiring — the real bin body, behind `bin.ts`'s bootstrap.
  *
- * This holds the static imports of the whole tool graph (`registry.ts` → every
- * tool → their deps, incl. `yaml`). It is loaded via a **dynamic** `import()`
- * from `bin.ts` on purpose (#1798): deferring the tool-graph link until inside a
- * `try` is what makes an unlinked-`catalog:`-dep `ERR_MODULE_NOT_FOUND`
- * catchable, so the bin can print a remediation instead of a raw stack. Keeping
- * the wiring here (not in `bin.ts`) keeps that boundary clean.
+ * It is loaded via a **dynamic** `import()` from `bin.ts` on purpose (#1798): deferring
+ * the link until inside a `try` is what makes an unlinked-`catalog:`-dep
+ * `ERR_MODULE_NOT_FOUND` catchable, so the bin can print a remediation instead of a raw
+ * stack. Keeping the wiring here (not in `bin.ts`) keeps that boundary clean.
  *
  * Wired per effect-smol's CLI guidance (mirrors `@kampus/decisions-index` /
- * `@kampus/epic-ledger`): `effect/unstable/cli` for the typed subcommands, the
- * Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
+ * `@kampus/epic-ledger`): `effect/unstable/cli` for the typed subcommands, the Node
+ * platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
+ *
+ * The subcommand set is resolved **for this invocation only** (see `tool-registration.ts`):
+ * selecting a tool loads that tool; only a listing (`--help`, no token) loads them all, and
+ * even there a registration that won't resolve is reported and skipped, not fatal.
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Effect} from "effect";
+import {Effect, Result} from "effect";
 import {Command} from "effect/unstable/cli";
 import {registeredTools} from "./registry.ts";
+import {dispatch} from "./router.ts";
+import {
+	loadRegistration,
+	loadRegistry,
+	type RegisteredTool,
+	ToolLoadError,
+} from "./tool-registration.ts";
 import {VERSION} from "./version.ts";
 
+const argv = process.argv.slice(2);
+const selector = argv[0];
+
+const exitWith = (message: string): never => {
+	console.error(message);
+	process.exit(1);
+};
+
+/**
+ * A leading `-` (or nothing at all) is a top-level flag, not a selector: `--help` lists
+ * every tool and `--version` needs no tool, so both fall to the load-everything branch.
+ */
+const resolveSubcommands = async (): Promise<ReadonlyArray<RegisteredTool>> => {
+	if (selector === undefined || selector.startsWith("-")) {
+		const {tools, failures} = await loadRegistry(registeredTools);
+		for (const failure of failures) console.error(failure.error.message);
+		return tools;
+	}
+	const selected = dispatch(registeredTools, argv);
+	if (Result.isFailure(selected)) return exitWith(selected.failure.message);
+	// biome-ignore lint/plugin: pre-runtime bootstrap — the tool graph is loaded to BUILD the CLI, so there is no Effect runtime yet to carry this in an `E` channel.
+	try {
+		return [await loadRegistration(selected.success.tool)];
+	} catch (err) {
+		// The attributable report is the whole point of the lazy registry; anything else
+		// (notably an unlinked dep) belongs to `bin.ts`'s self-heal, so it propagates.
+		if (err instanceof ToolLoadError) return exitWith(err.message);
+		throw err;
+	}
+};
+
 const cli = Command.make("pipeline-cli").pipe(
-	Command.withSubcommands(registeredTools),
+	Command.withSubcommands(await resolveSubcommands()),
 	Command.withDescription("The pipeline tooling router — `pipeline-cli <tool> …` (epic #994)"),
 );
 

--- a/packages/pipeline-cli/src/tool-registration.ts
+++ b/packages/pipeline-cli/src/tool-registration.ts
@@ -1,0 +1,150 @@
+/**
+ * The lazy tool registration — a tool's name is static, its module load is deferred (#4008).
+ *
+ * The registry used to `import` every tool's `command.ts` statically, so the whole
+ * tool graph linked before any tool ran. That coupled every invocation to every
+ * registration: one lane's half-written tool in the shared checkout every agent
+ * executes from made *any* `pipeline-cli <anything>` die with an `ERR_MODULE_NOT_FOUND`
+ * naming a tool the caller never asked for. A registration therefore carries only
+ * the selector name eagerly and a thunk that imports the module when — and only
+ * when — that verb is dispatched, so a broken registration is contained to itself.
+ *
+ * The containment is only as good as the error: a load fault is reported as a
+ * `ToolLoadError` naming the registration, not as a bare module-resolution stack.
+ */
+import type {NodeServices} from "@effect/platform-node";
+import type {Command} from "effect/unstable/cli";
+import {isUnlinkedDependencyError} from "./module-load-guard.ts";
+
+/** The Node platform service union the bin provides — the requirement ceiling for a tool. */
+type Platform = NodeServices.NodeServices;
+
+/**
+ * A loaded pipeline tool: a top-level `effect/unstable/cli` `Command` whose `name`
+ * is the `pipeline-cli <name>` selector.
+ *
+ * The requirement row is bounded by **the Node platform services** — the one layer
+ * the bin provides at the run boundary (`bin.ts`). A tool that needs more than the
+ * Node platform (a `Github` capability, a DB) must bake its own layer into its
+ * `Command` with `Command.provide(...)` **before** registering, so the registered
+ * command's residual requirement is the platform union. That keeps the bin and the
+ * router core stable as tools fold in: a tool self-contains its services, the bin
+ * never grows a per-tool layer. The `Name`/`Input`/`ContextInput`/`E` slots are left
+ * at their widest so the registry stays heterogeneous over tools with different
+ * names, args, flags, and error rows. Both `Name` and `Input` are `any` because each
+ * sits in a contravariant slot (`CommandContext<Name>`, `Variance<in Input, …>`): a
+ * concrete literal name (`"version"`) is not assignable to `string`, and a tool's
+ * concrete input shape (`{epic, dryRun}`) is not assignable from `object` — so only
+ * `any` admits tools with different literal names and different arg/flag inputs into
+ * one registry array.
+ */
+export type RegisteredTool = Command.Command<any, any, object, unknown, Platform>;
+
+/** One row of the registry: the selector name, plus the deferred load of its `Command`. */
+export interface ToolRegistration {
+	readonly name: string;
+	readonly load: () => Promise<RegisteredTool>;
+}
+
+/** A registration whose module could not be loaded, paired with the fault that stopped it. */
+export interface ToolLoadFailure {
+	readonly name: string;
+	readonly error: ToolLoadError;
+}
+
+/** The outcome of loading a whole registry: the tools that resolved, and the ones that didn't. */
+export interface LoadedRegistry {
+	readonly tools: ReadonlyArray<RegisteredTool>;
+	readonly failures: ReadonlyArray<ToolLoadFailure>;
+}
+
+/**
+ * A registration that did not resolve to a usable `Command`, named by its selector.
+ *
+ * This is the attributable half of the containment: the raw throw is an
+ * `ERR_MODULE_NOT_FOUND` for a path, which tells a caller nothing about *which
+ * registration* is at fault or that the fault is not theirs. The message names the
+ * registration and points at the most likely cause — a tool mid-write in the working
+ * tree this CLI is executing from.
+ */
+export class ToolLoadError extends Error {
+	readonly tool: string;
+
+	constructor(tool: string, detail: string, options?: {cause?: unknown}) {
+		super(
+			[
+				`pipeline-cli: registered tool \`${tool}\` failed to load — ${detail}`,
+				`  The registration is in packages/pipeline-cli/src/registry.ts. A tool that is mid-write in the`,
+				`  working tree this CLI runs from looks exactly like this; every OTHER tool still works.`,
+			].join("\n"),
+			options,
+		);
+		this.name = "ToolLoadError";
+		this.tool = tool;
+	}
+}
+
+/**
+ * Declare one registration. `name` MUST equal the `Command.make("<name>")` name of the
+ * loaded command — `loadRegistration` asserts it, because a drift would let the router
+ * select a registration the CLI runtime then can't dispatch.
+ */
+export const tool = (name: string, load: () => Promise<RegisteredTool>): ToolRegistration => ({
+	name,
+	load,
+});
+
+/**
+ * Load one registration's `Command`, converting any load fault into an attributable
+ * `ToolLoadError`.
+ *
+ * An **unlinked dependency** miss is deliberately rethrown untouched: `bin.ts` classifies
+ * that exact shape to run its bounded one-shot `pnpm install` self-heal (#2459) and, failing
+ * that, print the install remediation (#1798). Wrapping it here would swallow both.
+ */
+export const loadRegistration = async (registration: ToolRegistration): Promise<RegisteredTool> => {
+	let loaded: RegisteredTool;
+	// biome-ignore lint/plugin: pre-runtime bootstrap — this guards the dynamic import that loads a tool's module BEFORE any Effect runtime exists to carry an `E` channel (the exemption the rule names).
+	try {
+		loaded = await registration.load();
+	} catch (err) {
+		if (isUnlinkedDependencyError(err)) throw err;
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new ToolLoadError(registration.name, `its command module did not resolve (${detail})`, {
+			cause: err,
+		});
+	}
+	if (loaded === undefined || typeof loaded.name !== "string") {
+		throw new ToolLoadError(registration.name, "its module exported no `Command`");
+	}
+	if (loaded.name !== registration.name) {
+		throw new ToolLoadError(
+			registration.name,
+			`its module exports a command named \`${loaded.name}\` — the registered selector and the \`Command.make\` name must match`,
+		);
+	}
+	return loaded;
+};
+
+/**
+ * Load every registration, keeping the ones that resolve and collecting the ones that
+ * don't. Used only where the caller genuinely asks about *all* tools (`--help`, the
+ * `commands` index) — a single broken registration degrades that listing instead of
+ * killing it, and the caller decides whether to report or fail on `failures`.
+ */
+export const loadRegistry = async (
+	registry: ReadonlyArray<ToolRegistration>,
+): Promise<LoadedRegistry> => {
+	const tools: Array<RegisteredTool> = [];
+	const failures: Array<ToolLoadFailure> = [];
+	for (const registration of registry) {
+		// biome-ignore lint/plugin: pre-runtime bootstrap — same module-load boundary as `loadRegistration`, still before any Effect runtime.
+		try {
+			tools.push(await loadRegistration(registration));
+		} catch (err) {
+			if (!(err instanceof ToolLoadError)) throw err;
+			failures.push({name: registration.name, error: err});
+		}
+	}
+	return {tools, failures};
+};

--- a/packages/pipeline-cli/src/tool-registration.unit.test.ts
+++ b/packages/pipeline-cli/src/tool-registration.unit.test.ts
@@ -1,0 +1,111 @@
+import {Effect, Result} from "effect";
+import {Command} from "effect/unstable/cli";
+import {describe, expect, it} from "vitest";
+import {registeredTools} from "./registry.ts";
+import {dispatch} from "./router.ts";
+import {
+	loadRegistration,
+	loadRegistry,
+	type RegisteredTool,
+	ToolLoadError,
+	type ToolRegistration,
+	tool,
+} from "./tool-registration.ts";
+
+const alpha = Command.make("alpha", {}, () => Effect.void);
+const beta = Command.make("beta", {}, () => Effect.void);
+
+/** The shape Node throws for a missing relative source file — a half-written tool. */
+const missingModule = (path: string): Error =>
+	Object.assign(new Error(`Cannot find module '${path}' imported from registry.ts`), {
+		code: "ERR_MODULE_NOT_FOUND",
+	});
+
+/** The shape Node throws for an unlinked package — the install-timing case bin.ts self-heals. */
+const unlinkedDependency = (pkg: string): Error =>
+	Object.assign(new Error(`Cannot find package '${pkg}' imported from run.ts`), {
+		code: "ERR_MODULE_NOT_FOUND",
+	});
+
+const broken = (name: string, err: Error): ToolRegistration =>
+	tool(name, () => Promise.reject(err));
+
+describe("loadRegistration", () => {
+	it("loads a registration's command", async () => {
+		await expect(loadRegistration(tool("alpha", () => Promise.resolve(alpha)))).resolves.toBe(
+			alpha,
+		);
+	});
+
+	it("names the registration that failed, and keeps the underlying fault as the cause", async () => {
+		const cause = missingModule("/repo/packages/pipeline-cli/src/tools/run-evidence/command.ts");
+		const err = await loadRegistration(broken("run-evidence", cause)).catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(ToolLoadError);
+		const loadError = err as ToolLoadError;
+		expect(loadError.tool).toBe("run-evidence");
+		expect(loadError.message).toContain("`run-evidence`");
+		expect(loadError.message).toContain("registry.ts");
+		expect(loadError.cause).toBe(cause);
+	});
+
+	it("rethrows an unlinked-dependency miss untouched, so bin.ts can still self-heal it", async () => {
+		const cause = unlinkedDependency("yaml");
+		const err = await loadRegistration(broken("epic-ledger", cause)).catch((e: unknown) => e);
+		expect(err).toBe(cause);
+	});
+
+	it("rejects a registration whose name drifted from its `Command.make` name", async () => {
+		const err = await loadRegistration(tool("alpha", () => Promise.resolve(beta))).catch(
+			(e: unknown) => e,
+		);
+		expect(err).toBeInstanceOf(ToolLoadError);
+		expect((err as ToolLoadError).message).toContain("must match");
+	});
+});
+
+describe("loadRegistry", () => {
+	// The #4008 containment: one lane's half-written tool used to take out every OTHER tool,
+	// because the registry static-imported the whole graph before any tool could run.
+	it("keeps the resolvable tools when one registration fails, and attributes the failure", async () => {
+		const {tools, failures} = await loadRegistry([
+			tool("alpha", () => Promise.resolve(alpha)),
+			broken("run-evidence", missingModule("/repo/src/tools/run-evidence/command.ts")),
+			tool("beta", () => Promise.resolve(beta)),
+		]);
+		expect(tools).toEqual([alpha, beta]);
+		expect(failures.map((f) => f.name)).toEqual(["run-evidence"]);
+		expect(failures[0]?.error.message).toContain("`run-evidence`");
+	});
+});
+
+describe("laziness", () => {
+	it("loads only the dispatched registration", async () => {
+		const loaded: Array<string> = [];
+		const load = (name: string, command: RegisteredTool) =>
+			tool(name, () => {
+				loaded.push(name);
+				return Promise.resolve(command);
+			});
+		const registry = [load("alpha", alpha), load("beta", beta)];
+
+		const selected = dispatch(registry, ["beta", "--flag"]);
+		expect(Result.isSuccess(selected)).toBe(true);
+		if (Result.isSuccess(selected)) {
+			const dispatched = await loadRegistration(selected.success.tool);
+			expect(dispatched).toBe(beta);
+		}
+
+		expect(loaded).toEqual(["beta"]);
+	});
+});
+
+// The one suite that pays the whole-graph link the rest of the CLI no longer pays: it loads
+// every registration to check the name it is registered under against the name its command
+// declares. Type-stripping ~70 tool modules is well past vitest's 5s default under load.
+describe("the real registry", {timeout: 60_000}, () => {
+	it("registers every tool under the name its own command declares", async () => {
+		const {tools, failures} = await loadRegistry(registeredTools);
+		expect(failures).toEqual([]);
+		expect(tools.map((t) => t.name)).toEqual(registeredTools.map((r) => r.name));
+	});
+});

--- a/packages/pipeline-cli/src/tools/commands/command.ts
+++ b/packages/pipeline-cli/src/tools/commands/command.ts
@@ -11,10 +11,11 @@
  * fail-closed backstop: a newly-registered tool can't silently ship without a one-line
  * purpose (AC #4), and a zero-length registry reds (fail-closed on zero scope, ADR 0092).
  *
- * The `registeredTools` import closes a registry ⇄ tool cycle (this tool is itself in the
- * registry), but it is read **only inside the handler closures** — never at module-eval
- * time — so the ESM live binding is fully initialized by the time a handler runs. Do not
- * hoist `registeredTools` to a top-level reference here, or the cycle becomes a TDZ read.
+ * The index needs every tool's `description`, so this is the one tool that resolves the
+ * whole registry — the lazy rows have to be loaded to be described (#4008). A row that
+ * won't load is omitted from `compact` with a note on stderr (a discovery surface that
+ * dies on one broken sibling is worse than a short one) and reds `check`, which is the
+ * gate and so stays fail-closed.
  *
  * Exit-code contract (shared with the other gate tools): 0 = clean; a gate fail prints its
  * reason on stderr and exits non-zero *without* a stack trace, caught inside the handler so
@@ -23,7 +24,10 @@
 import {Console, Effect} from "effect";
 import {Command} from "effect/unstable/cli";
 import {registeredTools} from "../../registry.ts";
+import {type LoadedRegistry, loadRegistry} from "../../tool-registration.ts";
 import {renderCompact, undocumentedTools} from "./commands.ts";
+
+const loadAll = Effect.promise<LoadedRegistry>(() => loadRegistry(registeredTools));
 
 const GATE_FAIL_EXIT_CODE = 1;
 
@@ -31,7 +35,11 @@ const compact = Command.make(
 	"compact",
 	{},
 	Effect.fn(function* () {
-		yield* Console.log(renderCompact(registeredTools));
+		const {tools, failures} = yield* loadAll;
+		for (const failure of failures) {
+			yield* Console.error(`commands: omitting \`${failure.name}\` — ${failure.error.message}`);
+		}
+		yield* Console.log(renderCompact(tools));
 	}),
 ).pipe(
 	Command.withDescription(
@@ -43,19 +51,28 @@ const check = Command.make(
 	"check",
 	{},
 	Effect.fn(function* () {
+		const {tools, failures} = yield* loadAll;
 		// Fail-closed on zero scope: an empty registry is a wiring/load fault, not a pass (ADR 0092).
 		if (registeredTools.length === 0) {
 			yield* fail("no registered tools in scope — refusing to pass on an empty registry");
 			return;
 		}
-		const missing = undocumentedTools(registeredTools);
+		if (failures.length > 0) {
+			yield* fail(
+				`registration(s) that failed to load: ${failures.map((f) => f.name).join(", ")}\n${failures
+					.map((f) => f.error.message)
+					.join("\n")}`,
+			);
+			return;
+		}
+		const missing = undocumentedTools(tools);
 		if (missing.length > 0) {
 			yield* fail(
 				`registered tool(s) missing a one-line description (add Command.withDescription): ${missing.join(", ")}`,
 			);
 			return;
 		}
-		yield* Console.log(`commands: ${registeredTools.length} registered tools, all documented`);
+		yield* Console.log(`commands: ${tools.length} registered tools, all documented`);
 	}),
 ).pipe(
 	Command.withDescription(


### PR DESCRIPTION
Closes #4008

## The problem

`packages/pipeline-cli/src/registry.ts` statically imported every tool's `command.ts`, so the whole tool graph linked before any tool could run. Pipeline agents get per-lane git worktrees but execute `pipeline-cli` out of one shared checkout, so a tool registered before its `command.ts` was written took down **every** concurrent lane's gate tooling with an `ERR_MODULE_NOT_FOUND` naming a tool the caller never invoked — unattributable at the point of use.

## The route: lazy registry (no ADR)

The issue left the mechanism to the implementer and named two candidates. This takes the **lazy per-tool registry** one: it changes nothing about how an agent invokes the CLI, so it needs no ADR. (The committed/immutable-copy route would change every invocation and does need one; it was not taken.)

A registration is now a row carrying the selector name eagerly and the module import as a thunk (`packages/pipeline-cli/src/tool-registration.ts`):

```ts
tool("tracker", () => import("./tools/tracker/command.ts").then((m) => m.trackerCommand)),
```

`run.ts` resolves the argv token against those names through the existing pure router core (`dispatch`, now generic over anything carrying a `name`) and loads **that one row**. Only a listing (`--help`, `commands compact`) resolves the whole registry, and there a row that will not load is reported and omitted rather than fatal — `commands check`, being a gate, still reds on it (ADR 0092).

## Acceptance criteria

- [x] **One lane's half-written tool no longer breaks other tools.** Dispatching a verb links that verb's module and nothing else.
- [x] **An unresolvable registration fails attributably**, naming the registration instead of emitting a bare module-resolution stack for a tool the caller never invoked.
- [x] **Documented where the next pipeline author will look** — `packages/pipeline-cli/README.md` ("How a tool is loaded") and `packages/pipeline-cli/TOOLS.md` (the Shape / extension-seam sections + "Loading is lazy"). No ADR, per the route taken.

## Verification

A bogus row (`tool("ghost", () => import("./tools/ghost/command.ts")…)` with no such module) was injected into the registry in this worktree, exercised, and reverted:

```
$ node packages/pipeline-cli/src/bin.ts version        # an unrelated tool — used to die
pipeline-cli 0.2.1                                     # exit 0

$ node packages/pipeline-cli/src/bin.ts ghost          # the broken registration itself
pipeline-cli: registered tool `ghost` failed to load — its command module did not resolve (…)
  The registration is in packages/pipeline-cli/src/registry.ts. A tool that is mid-write in the
  working tree this CLI runs from looks exactly like this; every OTHER tool still works.
                                                       # exit 1

$ node packages/pipeline-cli/src/bin.ts --help         # reports the bad row, still lists the rest
```

Also green: `pnpm typecheck` (workspace), `pnpm lint:worktree`, `pnpm --filter @kampus/pipeline-cli test` (164 files / 2367 tests), `pipeline-cli commands check` (68 tools, all documented), `pipeline-cli readme-guard check`.

## Notes for review

- **The self-heal is preserved.** An unlinked-dependency miss is deliberately rethrown untouched rather than wrapped, so `bin.ts`'s one-shot `pnpm install` self-heal (#2459) and its install remediation (#1798) still classify it. Covered by a unit test.
- **Name drift is now an assertion.** `loadRegistration` requires the registered selector to equal the module's `Command.make("<name>")` name — with a lazy registry the router selects on the registered name and the CLI runtime dispatches on the declared one, so drift would otherwise select a row the runtime cannot dispatch. A test loads the real registry and checks all 68.
- **`import()` specifiers must stay string literals** — `rewriteRelativeImportExtensions` rewrites literal `.ts` specifiers at build and cannot rewrite a computed one. Stated in the registry docblock and TOOLS.md.
- **Three `// biome-ignore lint/plugin:` exemptions** on the raw `try/catch` in the loader and in `run.ts`: this is the module-load boundary, which runs before any Effect runtime exists to carry an `E` channel — the pre-runtime-bootstrap exemption `biome-plugins/no-raw-try-catch.grit` names explicitly.
- Side effect: `pipeline-cli <tool>` now type-strips one tool's module graph instead of ~70.

### Files changed

- `packages/pipeline-cli/src/tool-registration.ts` (new) — the registration type, `tool()`, `loadRegistration`, `loadRegistry`, `ToolLoadError`
- `packages/pipeline-cli/src/tool-registration.unit.test.ts` (new)
- `packages/pipeline-cli/src/registry.ts` — 70 static imports → 68 lazy rows (per-entry rationale comments preserved)
- `packages/pipeline-cli/src/run.ts` — resolve this invocation's subcommands
- `packages/pipeline-cli/src/router.ts` — `dispatch` generic over `{name}`
- `packages/pipeline-cli/src/tools/commands/command.ts` — resolve the registry for the index; `check` reds on a failed row
- `packages/pipeline-cli/src/index.ts`, `packages/pipeline-cli/src/bin.ts` — surface/docblock
- `packages/pipeline-cli/README.md`, `packages/pipeline-cli/TOOLS.md`
