### PR TITLE
fix(pipeline-cli): make the needs-info park a first-class tracker transition (#4042)

### DIFF
--- a/packages/pipeline-cli/src/tools/tracker/command.ts
+++ b/packages/pipeline-cli/src/tools/tracker/command.ts
@@ -118,12 +118,26 @@ const readBack = Command.make(
 
 // Judgment-as-parameter (#3252): the classification is supplied, not decided by the tool.
 // `--status` defaults to the `triaged` lifecycle stage — the common triage transition.
+//
+// `--type`/`--p` are optional AT THE PARSER because whether they are required is a function of the
+// target stage, which the parser cannot see: a classified stage needs both, the `needs-info` park
+// forbids both. That conditional contract is the domain's (`classify`), and it fails closed either
+// way — so an omitted `--type` on a triaged run is still refused, just with a domain message
+// instead of a parser one. Making them unconditionally required is what left the park inexpressible
+// through the verb and pushed triagers to hand-rolled label calls, or to a minted filler
+// classification (#4042).
 const typeFlag = Flag.string("type").pipe(
-	Flag.withDescription("the domain type classification (e.g. feature, bug, chore)"),
+	Flag.optional,
+	Flag.withDescription(
+		"the domain type classification (e.g. feature, bug, chore) — required for a classified stage, forbidden when parking to needs-info",
+	),
 );
 
 const priorityFlag = Flag.string("p").pipe(
-	Flag.withDescription("the domain priority (e.g. p0, p1, p2)"),
+	Flag.optional,
+	Flag.withDescription(
+		"the domain priority (e.g. p0, p1, p2) — required for a classified stage, forbidden when parking to needs-info",
+	),
 );
 
 const statusFlag = Flag.string("status").pipe(
@@ -132,24 +146,32 @@ const statusFlag = Flag.string("status").pipe(
 );
 
 const reportTriage = (target: number, result: TriageResult): Effect.Effect<void> =>
-	Console.log(
-		`tracker: triaged #${target} — type:${result.type} ${result.priority} status:${result.status}.`,
-	);
+	result._tag === "parked"
+		? Console.log(`tracker: parked #${target} — status:${result.status}, no type and no priority.`)
+		: Console.log(
+				`tracker: triaged #${target} — type:${result.type} ${result.priority} status:${result.status}.`,
+			);
 
 const applyTriage = Command.make(
 	"apply-triage",
 	{target: targetArg, type: typeFlag, p: priorityFlag, status: statusFlag},
 	Effect.fn(function* ({target, type, p, status}) {
-		const result = yield* (yield* Tracker).applyTriage(target, {
-			type,
-			priority: p,
-			status: Option.getOrElse(status, () => "triaged"),
-		});
+		const result = yield* (yield* Tracker)
+			.applyTriage(target, {
+				type: Option.getOrUndefined(type),
+				priority: Option.getOrUndefined(p),
+				status: Option.getOrElse(status, () => "triaged"),
+			})
+			.pipe(
+				// A judgment the stage's contract refuses (a park carrying a type/priority, a classified
+				// stage missing one) fails loud before any label write — never a silent misclassification.
+				Effect.catchTag("@kampus/tracker/TrackerInputError", (error) => backOff(error.message)),
+			);
 		yield* reportTriage(target, result);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Apply a triage classification (type / priority / status) to a tracker entity, leaving the needs-triage queue",
+		"Apply a triage classification (type / priority / status) to a tracker entity, leaving the needs-triage queue; omit --type/--p with --status needs-info to park it un-classified",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -54,6 +54,9 @@ const mockSpawner = (
 	// Every `-f body=…` the verb sent, in order — what proves WHAT a writer posted, not just that
 	// it posted (the #3987 regression: an unstamped claim marker is indistinguishable by key alone).
 	bodies?: Array<string>,
+	// Every `-f labels[]=…` the verb ADDED, for the same reason: the park's contract is about which
+	// labels were applied, and a POST key alone can't tell a bare status from a minted classification.
+	added?: Array<string>,
 ): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> => {
 	const seen = new Map<string, number>();
 	return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
@@ -71,6 +74,7 @@ const mockSpawner = (
 				calls?.push(key);
 				for (const arg of args) {
 					if (arg.startsWith("body=")) bodies?.push(arg.slice("body=".length));
+					if (arg.startsWith("labels[]=")) added?.push(arg.slice("labels[]=".length));
 				}
 				const nth = seen.get(key) ?? 0;
 				seen.set(key, nth + 1);
@@ -106,9 +110,12 @@ const provide = <A, E>(
 	responses: Record<string, Response>,
 	calls?: Array<string>,
 	bodies?: Array<string>,
+	added?: Array<string>,
 ): Effect.Effect<A, E | RepoResolutionError> =>
 	effect.pipe(
-		Effect.provide(GithubTrackerLive.pipe(Layer.provide(mockSpawner(responses, calls, bodies)))),
+		Effect.provide(
+			GithubTrackerLive.pipe(Layer.provide(mockSpawner(responses, calls, bodies, added))),
+		),
 	);
 
 const TARGET = 900;
@@ -421,13 +428,13 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 			const result = yield* tracker.applyTriage(TARGET, {
 				type: "bug",
 				priority: "p1",
-				status: "needs-info",
+				status: "planned",
 			});
 			assert.deepStrictEqual(result, {
 				_tag: "triaged",
 				type: "bug",
 				priority: "p1",
-				status: "needs-info",
+				status: "planned",
 			});
 		}).pipe((effect) =>
 			provide(effect, {
@@ -435,10 +442,108 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: "",
 				[`GET ${L}`]: [
 					labelSet("status:needs-triage"),
-					labelSet("type:bug", "p1", "status:needs-info"),
+					labelSet("type:bug", "p1", "status:planned"),
 				],
 			}),
 		),
+	);
+
+	// #4042: the needs-info park is the triage skill's Step-5 outcome — "not a type, not a
+	// priority, not triaged". It was inexpressible through the verb, so every park either
+	// hand-rolled the REST label calls or minted a filler classification (observed on #4067).
+	it.effect("parks to needs-info with the status alone — no type, no priority applied", () =>
+		Effect.gen(function* () {
+			const calls: Array<string> = [];
+			const added: Array<string> = [];
+			const result = yield* Effect.gen(function* () {
+				return yield* (yield* Tracker).applyTriage(TARGET, {status: "needs-info"});
+			}).pipe((effect) =>
+				provide(
+					effect,
+					{
+						[`POST ${L}`]: labelSet("status:needs-info"),
+						[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: "",
+						[`GET ${L}`]: [labelSet("status:needs-triage"), labelSet("status:needs-info")],
+					},
+					calls,
+					undefined,
+					added,
+				),
+			);
+			assert.deepStrictEqual(result, {_tag: "parked", status: "needs-info"});
+			// the whole point: the ONLY label added is the stage — no fabricated classification.
+			assert.deepStrictEqual(added, ["status:needs-info"]);
+			// and the park still leaves the queue (the status facet's one rule).
+			assert.deepStrictEqual(
+				calls.filter((call) => call.startsWith("DELETE")),
+				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`],
+			);
+		}),
+	);
+
+	it.effect("bouncing an already-typed issue back to needs-info strips its type and priority", () =>
+		Effect.gen(function* () {
+			const calls: Array<string> = [];
+			const result = yield* Effect.gen(function* () {
+				return yield* (yield* Tracker).applyTriage(TARGET, {status: "needs-info"});
+			}).pipe((effect) =>
+				provide(
+					effect,
+					{
+						[`POST ${L}`]: labelSet("status:needs-info"),
+						[`DELETE ${P}/issues/${TARGET}/labels/type:bug`]: "",
+						[`DELETE ${P}/issues/${TARGET}/labels/p2`]: "",
+						[`DELETE ${P}/issues/${TARGET}/labels/status:triaged`]: "",
+						[`GET ${L}`]: [
+							labelSet("type:bug", "p2", "status:triaged", "epic"),
+							labelSet("status:needs-info", "epic"),
+						],
+					},
+					calls,
+				),
+			);
+			assert.deepStrictEqual(result, {_tag: "parked", status: "needs-info"});
+			// a parked entity carries no classification, so all three superseded facets go —
+			// `epic` is outside the contract and survives.
+			assert.deepStrictEqual(calls.filter((call) => call.startsWith("DELETE")).sort(), [
+				`DELETE ${P}/issues/${TARGET}/labels/p2`,
+				`DELETE ${P}/issues/${TARGET}/labels/status:triaged`,
+				`DELETE ${P}/issues/${TARGET}/labels/type:bug`,
+			]);
+		}),
+	);
+
+	// The minting path, closed: a caller that satisfies the parser with filler facets on a stage
+	// DEFINED as un-classified is refused outright — and refused before any write, so a rejected
+	// judgment can never leave the entity half-transitioned.
+	it.effect("refuses a needs-info judgment carrying a type/priority — before any gh call", () =>
+		Effect.gen(function* () {
+			const calls: Array<string> = [];
+			const error = yield* Effect.gen(function* () {
+				return yield* Effect.flip(
+					(yield* Tracker).applyTriage(TARGET, {
+						type: "bug",
+						priority: "p2",
+						status: "needs-info",
+					}),
+				);
+			}).pipe((effect) => provide(effect, {}, calls));
+			assert.isTrue(error instanceof TrackerInputError);
+			assert.deepStrictEqual(calls, []);
+		}),
+	);
+
+	it.effect(
+		"refuses a classified stage that omits a facet — the triaged path still needs both",
+		() =>
+			Effect.gen(function* () {
+				const calls: Array<string> = [];
+				const error = yield* Effect.gen(function* () {
+					return yield* Effect.flip((yield* Tracker).applyTriage(TARGET, {type: "bug"}));
+				}).pipe((effect) => provide(effect, {}, calls));
+				assert.isTrue(error instanceof TrackerInputError);
+				assert.deepStrictEqual(calls, []);
+			}),
 	);
 
 	it.effect("the queue label already absent → no remove is attempted (idempotent)", () =>

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -74,7 +74,7 @@ import {
 } from "./gh-io.ts";
 // The one-label-per-facet triage contract lives in its own IO-free core, tested directly —
 // `applyTriage` is the shell that applies its decision (#3771).
-import {desiredLabels, supersededLabels} from "./triage-labels.ts";
+import {classify, desiredLabels, supersededLabels} from "./triage-labels.ts";
 
 // Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
 // service module — the single-source classes now live in `gh-io.ts` (#3262 AC 5).
@@ -153,24 +153,31 @@ export type ReadBackResult =
  * default `triaged`). Domain vocabulary only — `type`/`priority`/`status` are the crew's
  * own terms; `GithubTrackerLive` maps them to `type:` / `status:` label strings at the
  * boundary, so no GitHub label string leaks into the signature (ADR 0190).
+ *
+ * `type`/`priority` are optional at the *judgment* boundary because the un-classified park
+ * (`status: "needs-info"`) has neither; which combinations are well-formed is `classify`'s
+ * call, and a violation is a `TrackerInputError` raised before any write (#4042).
  */
 export interface TriageJudgment {
-	readonly type: string;
-	readonly priority: string;
-	readonly status?: string;
+	readonly type?: string | undefined;
+	readonly priority?: string | undefined;
+	readonly status?: string | undefined;
 }
 
 /**
  * The `applyTriage` verdict — the entity now carries the classification, with `status`
  * read back from the entity (so the caller sees the stage that actually landed, not just
- * the one requested). A domain owner, never a raw REST label payload.
+ * the one requested). A domain owner, never a raw REST label payload. The two arms mirror
+ * the classification's: `parked` reports no type and no priority because it applied none.
  */
-export type TriageResult = {
-	readonly _tag: "triaged";
-	readonly type: string;
-	readonly priority: string;
-	readonly status: string;
-};
+export type TriageResult =
+	| {
+			readonly _tag: "triaged";
+			readonly type: string;
+			readonly priority: string;
+			readonly status: string;
+	  }
+	| {readonly _tag: "parked"; readonly status: string};
 
 /**
  * A create-issue judgment (#3264): the `title` + `body` of the new entity, and the
@@ -448,6 +455,11 @@ const readBack = Effect.fn("Tracker.readBack")(function* (repo: string, target: 
  * longer carries the label — a concurrent edit): the triaged end-state is reached either
  * way. Reads the labels back and Schema-decodes them at the boundary, reporting the
  * `status` stage that actually landed.
+ *
+ * The judgment is routed through `classify` first, so the un-classified `needs-info` park is a
+ * first-class transition — status only, with any stale `type:*`/`p*` superseded away — and an
+ * ill-formed judgment fails with a `TrackerInputError` before any write reaches the tracker
+ * (#4042).
  */
 const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 	repo: string,
@@ -455,7 +467,10 @@ const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 	judgment: TriageJudgment,
 ) {
 	const status = judgment.status ?? "triaged";
-	const classification = {type: judgment.type, priority: judgment.priority, status};
+	const classification = classify({type: judgment.type, priority: judgment.priority, status});
+	if (classification._tag === "invalid") {
+		return yield* new TrackerInputError({message: classification.reason});
+	}
 	const before = yield* decodeLabels(yield* json(listLabelsArgs(repo, target)));
 	yield* runGh(addLabelsArgs(repo, target, desiredLabels(classification)));
 	yield* Effect.forEach(
@@ -477,12 +492,17 @@ const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 		.filter((name) => name.startsWith(LABEL_STATUS_PREFIX))
 		.map((name) => name.slice(LABEL_STATUS_PREFIX.length))
 		.find((stage) => stage !== QUEUE_STATUS);
-	return {
-		_tag: "triaged",
-		type: judgment.type,
-		priority: judgment.priority,
-		status: landedStatus ?? status,
-	} satisfies TriageResult;
+	const landed = landedStatus ?? status;
+	return (
+		classification._tag === "parked"
+			? {_tag: "parked", status: landed}
+			: {
+					_tag: "triaged",
+					type: classification.type,
+					priority: classification.priority,
+					status: landed,
+				}
+	) satisfies TriageResult;
 });
 
 /** Map a domain gate name to the ADR-0058 `VerdictGate`, or `null` if it is not a known gate. */
@@ -674,6 +694,8 @@ const graduate = Effect.fn("Tracker.graduate")(function* (
 
 type TrackerErrors = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
 
+type ApplyTriageErrors = TrackerErrors | TrackerInputError;
+
 type PostVerdictErrors = TrackerErrors | TrackerInputError | TrackerVerifyError;
 
 type GraduateErrors = TrackerErrors | TrackerVerifyError;
@@ -695,7 +717,7 @@ export class Tracker extends Context.Service<
 		readonly applyTriage: (
 			target: TargetId,
 			judgment: TriageJudgment,
-		) => Effect.Effect<TriageResult, TrackerErrors>;
+		) => Effect.Effect<TriageResult, ApplyTriageErrors>;
 		readonly createIssue: (
 			judgment: CreateIssueJudgment,
 		) => Effect.Effect<CreateIssueResult, TrackerErrors>;

--- a/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
+++ b/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
@@ -11,14 +11,84 @@
  *
  * The queue-label drop (`status:needs-triage`) is not a special case here — it is just the
  * status facet's instance of the same rule.
+ *
+ * Triage has TWO outcomes, not one: a `classified` issue carries all three facets, and a `parked`
+ * one (`status:needs-info`) carries a status and *deliberately* no type and no priority — the
+ * triage skill's Step 5 contract, "not a type, not a priority, not triaged". Modeling them as one
+ * record with three required facets made the park inexpressible, so the verb minted a filler
+ * `type:`/`p*` for an issue triage had explicitly declined to classify (#4042, observed on #4067).
  */
 
-/** The domain classification a triage decision assigns: one value per single-valued facet. */
-export interface TriageClassification {
-	readonly type: string;
-	readonly priority: string;
-	readonly status: string;
+/**
+ * The domain classification a triage decision assigns. The two arms make the invalid combination
+ * — an un-classified stage carrying a type or a priority — unrepresentable rather than merely
+ * unchecked; `classify` is the only way in, and it is total.
+ */
+export type TriageClassification =
+	| {
+			readonly _tag: "classified";
+			readonly type: string;
+			readonly priority: string;
+			readonly status: string;
+	  }
+	| {readonly _tag: "parked"; readonly status: string};
+
+/** A judgment the contract refuses, carrying the reason a caller must surface. */
+export interface InvalidClassification {
+	readonly _tag: "invalid";
+	readonly reason: string;
 }
+
+/**
+ * The lifecycle stages that are *defined* as un-classified: the entity is parked pending an
+ * answer, so a type or a priority on it would be a fabrication, not a judgment (triage skill
+ * Step 5). Every other stage is a real classification and needs both facets.
+ */
+const UNCLASSIFIED_STAGES: ReadonlySet<string> = new Set(["needs-info"]);
+
+const supplied = (value: string | undefined): string | null => {
+	const trimmed = value?.trim() ?? "";
+	return trimmed === "" ? null : trimmed;
+};
+
+/**
+ * The one way to build a `TriageClassification` from a caller's judgment: it routes on the target
+ * stage and rejects the two ill-formed shapes — a park that supplies facets, and a classification
+ * that omits them.
+ */
+export const classify = (judgment: {
+	readonly type?: string | undefined;
+	readonly priority?: string | undefined;
+	readonly status: string;
+}): TriageClassification | InvalidClassification => {
+	const status = judgment.status.trim();
+	const type = supplied(judgment.type);
+	const priority = supplied(judgment.priority);
+
+	if (UNCLASSIFIED_STAGES.has(status)) {
+		const offered = [type === null ? null : `type ${type}`, priority === null ? null : priority]
+			.filter((facet) => facet !== null)
+			.join(" and ");
+		return offered === ""
+			? {_tag: "parked", status}
+			: {
+					_tag: "invalid",
+					reason: `status:${status} parks an entity with no type and no priority, but this judgment supplies ${offered} — drop them, or target a classified stage`,
+				};
+	}
+
+	if (type === null || priority === null) {
+		const missing = [type === null ? "type" : null, priority === null ? "priority" : null]
+			.filter((facet) => facet !== null)
+			.join(" and ");
+		return {
+			_tag: "invalid",
+			reason: `status:${status} is a classified stage and requires both a type and a priority — missing ${missing}`,
+		};
+	}
+
+	return {_tag: "classified", type, priority, status};
+};
 
 // A priority label is the bare bucket name (`p0`/`p1`/`p2`); `\d+` rather than a closed set so a
 // future bucket is reconciled too instead of silently surviving as a second priority.
@@ -45,14 +115,22 @@ const SPINE_STAGES: ReadonlySet<string> = new Set([
 /**
  * The single-valued label families. `owns` decides membership from the label name alone (so a
  * label the tracker never applied is still reconciled), `desired` names the one member the
- * classification keeps.
+ * classification keeps — or `null` when it desires *no* member of that facet, which the
+ * convergent reconcile reads as "supersede every member": parking to `needs-info` strips a stale
+ * `type:*`/`p*` rather than leaving the entity classified on a stage defined as un-classified.
  */
 const FACETS: ReadonlyArray<{
 	readonly owns: (label: string) => boolean;
-	readonly desired: (classification: TriageClassification) => string;
+	readonly desired: (classification: TriageClassification) => string | null;
 }> = [
-	{owns: (label) => label.startsWith(TYPE_PREFIX), desired: (c) => `${TYPE_PREFIX}${c.type}`},
-	{owns: (label) => PRIORITY_RE.test(label), desired: (c) => c.priority},
+	{
+		owns: (label) => label.startsWith(TYPE_PREFIX),
+		desired: (c) => (c._tag === "classified" ? `${TYPE_PREFIX}${c.type}` : null),
+	},
+	{
+		owns: (label) => PRIORITY_RE.test(label),
+		desired: (c) => (c._tag === "classified" ? c.priority : null),
+	},
 	{
 		owns: (label) =>
 			label.startsWith(STATUS_PREFIX) && SPINE_STAGES.has(label.slice(STATUS_PREFIX.length)),
@@ -60,13 +138,17 @@ const FACETS: ReadonlyArray<{
 	},
 ];
 
-/** The labels a triaged entity must carry — exactly one per facet, in facet order. */
+/** The labels the classification must carry — at most one per facet, in facet order. */
 export const desiredLabels = (classification: TriageClassification): ReadonlyArray<string> =>
-	FACETS.map((facet) => facet.desired(classification));
+	FACETS.map((facet) => facet.desired(classification)).filter(
+		(label): label is string => label !== null,
+	);
 
 /**
  * The labels to remove so `current` converges on `classification`: every currently-carried label
- * that belongs to a facet but isn't that facet's desired member. Labels outside the three facets
+ * that belongs to a facet but isn't that facet's desired member — which, for a facet the
+ * classification desires nothing from (a park's type/priority), is every member it carries.
+ * Labels outside the three facets
  * (`epic`, `good first issue`, an orthogonal `status:awaiting-release`, …) are never touched —
  * this is the narrow triage contract, not a
  * general label reconciler. De-duplicated and idempotent: on an entity already in the contract's

--- a/packages/pipeline-cli/src/tools/tracker/triage-labels.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/triage-labels.unit.test.ts
@@ -1,7 +1,48 @@
 import {assert, describe, it} from "@effect/vitest";
-import {desiredLabels, supersededLabels} from "./triage-labels.ts";
+import {classify, desiredLabels, supersededLabels} from "./triage-labels.ts";
 
-const TRIAGED = {type: "bug", priority: "p2", status: "triaged"} as const;
+const TRIAGED = {_tag: "classified", type: "bug", priority: "p2", status: "triaged"} as const;
+const PARKED = {_tag: "parked", status: "needs-info"} as const;
+
+describe("classify", () => {
+	it("a full judgment on a classified stage is a classification", () => {
+		assert.deepStrictEqual(classify({type: "bug", priority: "p2", status: "triaged"}), TRIAGED);
+	});
+
+	it("a bare stage judgment on needs-info is the un-classified park", () => {
+		assert.deepStrictEqual(classify({status: "needs-info"}), PARKED);
+	});
+
+	// The #4042 defect: `--type`/`--p` were unconditionally required, so the ONLY way through the
+	// verb was to mint a classification for an issue triage had declined to classify (observed on
+	// #4067: type:bug + p2 applied alongside status:needs-info in one write, then hand-corrected).
+	it("refuses a needs-info judgment that supplies a type or a priority", () => {
+		const withType = classify({type: "bug", status: "needs-info"});
+		assert.strictEqual(withType._tag, "invalid");
+		assert.include(withType._tag === "invalid" ? withType.reason : "", "no type and no priority");
+
+		assert.strictEqual(classify({priority: "p2", status: "needs-info"})._tag, "invalid");
+		assert.strictEqual(
+			classify({type: "bug", priority: "p2", status: "needs-info"})._tag,
+			"invalid",
+		);
+	});
+
+	it("a blank facet is an absent one, not a supplied empty label", () => {
+		assert.deepStrictEqual(classify({type: "  ", priority: "", status: "needs-info"}), PARKED);
+	});
+
+	// The triaged path is unchanged: both facets are still mandatory — the requirement just moved
+	// from the flag parser to the stage's own contract, which is what makes it conditional.
+	it("refuses a classified stage that omits a facet", () => {
+		const missingBoth = classify({status: "triaged"});
+		assert.strictEqual(missingBoth._tag, "invalid");
+		assert.include(missingBoth._tag === "invalid" ? missingBoth.reason : "", "type and priority");
+
+		assert.strictEqual(classify({type: "bug", status: "triaged"})._tag, "invalid");
+		assert.strictEqual(classify({priority: "p2", status: "planned"})._tag, "invalid");
+	});
+});
 
 describe("desiredLabels", () => {
 	it("is exactly one label per facet — type, priority, status", () => {
@@ -9,11 +50,15 @@ describe("desiredLabels", () => {
 	});
 
 	it("carries the requested stage when it is not the default", () => {
-		assert.deepStrictEqual(desiredLabels({...TRIAGED, status: "needs-info"}), [
+		assert.deepStrictEqual(desiredLabels({...TRIAGED, status: "planned"}), [
 			"type:bug",
 			"p2",
-			"status:needs-info",
+			"status:planned",
 		]);
+	});
+
+	it("the park desires the status alone — no type label, no priority label", () => {
+		assert.deepStrictEqual(desiredLabels(PARKED), ["status:needs-info"]);
 	});
 });
 
@@ -21,6 +66,7 @@ describe("supersededLabels", () => {
 	it("the #3771 defect: a re-prioritize supersedes the old priority", () => {
 		assert.deepStrictEqual(
 			supersededLabels(["type:decision", "status:triaged", "p2"], {
+				_tag: "classified",
 				type: "decision",
 				priority: "p1",
 				status: "triaged",
@@ -32,6 +78,7 @@ describe("supersededLabels", () => {
 	it("a re-type supersedes the old type — the same rule, the same shape", () => {
 		assert.deepStrictEqual(
 			supersededLabels(["type:bug", "status:triaged", "p2"], {
+				_tag: "classified",
 				type: "chore",
 				priority: "p2",
 				status: "triaged",
@@ -46,12 +93,40 @@ describe("supersededLabels", () => {
 		]);
 	});
 
+	it("the park drops the queue label, the same one rule", () => {
+		assert.deepStrictEqual(supersededLabels(["status:needs-triage"], PARKED), [
+			"status:needs-triage",
+		]);
+	});
+
+	// A facet the classification desires NOTHING from supersedes every member it carries: bouncing
+	// an already-typed issue back to needs-info leaves it un-classified, per the skill's "not a
+	// type, not a priority" contract — never classified on a stage defined as un-classified.
+	it("the park supersedes a pre-existing type AND priority", () => {
+		assert.deepStrictEqual(
+			[...supersededLabels(["type:bug", "p2", "status:triaged"], PARKED)].sort(),
+			["p2", "status:triaged", "type:bug"],
+		);
+	});
+
+	it("the park still never touches a label outside the three facets", () => {
+		assert.deepStrictEqual(
+			supersededLabels(["epic", "good first issue", "status:awaiting-release"], PARKED),
+			[],
+		);
+	});
+
+	it("the park is idempotent on an already-parked entity", () => {
+		assert.deepStrictEqual(supersededLabels(["status:needs-info"], PARKED), []);
+	});
+
 	// The status facet owns the pickability SPINE, not the whole `status:` namespace.
 	// `status:awaiting-release` is the release queue's membership marker: superseding it on a
 	// re-prioritize would silently drop a dark-shipped issue out of the human release queue.
 	it("never supersedes `status:awaiting-release` — it is orthogonal to the pickability spine", () => {
 		assert.deepStrictEqual(
 			supersededLabels(["type:bug", "status:triaged", "p2", "status:awaiting-release"], {
+				_tag: "classified",
 				type: "bug",
 				priority: "p1",
 				status: "triaged",


### PR DESCRIPTION
Closes #4042

## The gap

`tracker apply-triage` required `--type`/`--p` unconditionally, so the triage skill's **needs-info** outcome — Step 5's "not a type, not a priority, not triaged" — could not go through the sanctioned verb at all. Both branches out of that dead end were bad, and both were observed live in one session:

- **#4065** hand-rolled the two REST label calls — the exact bypass the verb (#3263, ADR 0190) exists to remove, and what the #3254 adoption lint flags.
- **#4067** took the verb and paid its toll: `type:bug` + `p2` + `status:needs-info` landed in one atomic write at 21:38:27, a classification *minted* for an issue triage had explicitly declined to classify, then hand-stripped two minutes later.

## The shape

**`TriageClassification` is now two arms**, because triage has two genuinely different outcomes:

- `classified` — all three facets, every non-park stage.
- `parked` — a stage alone (`needs-info`), no type, no priority.

The only way in is the total `classify`, which routes on the target stage: `needs-info` **forbids** a type/priority, every other stage **requires** both. The invalid combination is not merely unchecked — it cannot be constructed, and a judgment that asks for it is refused **before any write**, so a rejected park can never leave an entity half-transitioned.

**A facet the classification desires nothing from supersedes every member it carries.** This resolves the open question the triage notes left for the implementer — *does parking strip a pre-existing type/priority, or keep it?* It **strips**: the skill's contract is that a parked issue carries no classification, so leaving a stale `type:*`/`p*` would leave the issue classified on a stage *defined* as un-classified and indistinguishable from a triaged one to anything reading labels. This is not a new rule — it is the same convergent facet-reconcile as #3771, with "desired: none" as a legal desired state. Labels outside the three facets (`epic`, `status:awaiting-release`, the `status:planning` epic-lock) are untouched, as before.

**`--type`/`--p` are now parser-optional** because whether they are required is a function of the target stage, which the parser cannot see. The requirement moved into the domain, where it still fails closed — an omitted `--type` on a triaged run is refused just the same, with a domain message instead of a parser one.

## Acceptance criteria

- **The verb can express the park** — `tracker apply-triage <N> --status needs-info` applies `status:needs-info`, drops `status:needs-triage`, and applies no `type:*`/`p*`. Asserted on the exact `labels[]=` args the verb sent, not just the POST key.
- **The triaged path is unchanged** — `--type <t> --p <p>` still requires both and reconciles all three facets; every pre-existing behavior test still passes as written (one fixture moved from `needs-info` to `planned`, since it was exercising "an explicit non-default stage" with a full classification).
- **The invalid combination is rejected, not silently accepted** — `--status needs-info` with a type or a priority fails with a `TrackerInputError` and zero `gh` calls.
- **Unit tests** — `classify`, the park's desired/superseded labels in `triage-labels.unit.test.ts`; the park transition, the strip-on-bounce, and both refusals in `tracker.behavior.test.ts`.
- **Skill instructions** — no change needed: the invocation shape is unchanged, so the triage skill's Step 6 line ("Pass `--status <stage>` to target a different lifecycle stage (e.g. `needs-info`)") now works exactly as written. Verified live that the park invocation parses and reaches the label read.

## Verification

- `vitest run` on `packages/pipeline-cli`: 163 files, 2374 tests pass.
- `tsc --noEmit` on `packages/pipeline-cli`: clean.
- Pre-push gates (whole-repo typecheck + `vitest --changed origin/main`, 2406 tests) ran green twice on this exact tree; the transfer itself needed a retry, and the final push skipped a third redundant run of those already-green gates.
- Live CLI: the two refusals print their domain reasons and exit non-zero; `--status needs-info` alone parses and proceeds to the label read.
