### PR TITLE
fix(pipeline-cli): review-head trees are born locked, and both reclaimers read that lock (#4004)

### DIFF
--- a/packages/pipeline-cli/src/session-registry.ts
+++ b/packages/pipeline-cli/src/session-registry.ts
@@ -1,0 +1,55 @@
+/**
+ * The harness's live-session registry, as this package reads it: where the files live, what a
+ * session id looks like, and what one entry means.
+ *
+ * It sits at the `src/` root rather than under either consumer because it is owned by neither.
+ * `worktree-sweep` / `worktree-reap` read the registry to decide whether a worktree's owner is
+ * still running; `review-head materialize` reads the same registry to stamp a tree's lock with its
+ * owning session's pid. One rule, two callers on opposite sides of the §CP boundary — a copy per
+ * side would be two liveness rules free to drift (ADR 0218; ruling on #4149).
+ *
+ * IO-free: the location rule takes its joiner as an argument and the parser takes text, so each
+ * caller keeps its own path/filesystem seam (the Effect `Path` service in the sweep, `node:path` in
+ * `materialize`).
+ */
+
+/** A bare session-UUID (the shape both the registry and the worktree sidecar layout use). */
+export const SESSION_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The registry directory — one `<pid>.json` per RUNNING session, deleted when the session exits.
+ * `$CLAUDE_CONFIG_DIR` is the harness's own override for the config root; absent it, the tool's
+ * default config home under the user's home dir.
+ */
+export const sessionRegistryDir = (args: {
+	readonly configDir: string | undefined;
+	readonly home: string;
+	readonly join: (...segments: Array<string>) => string;
+}): string => args.join(args.configDir?.trim() || args.join(args.home, ".claude"), "sessions");
+
+/** One `<config>/sessions/<pid>.json` entry — a session the harness records as running. */
+export interface SessionRegistryEntry {
+	readonly pid: number;
+	readonly sessionId: string;
+}
+
+/**
+ * Parse one registry file; `null` unless it yields BOTH a positive integer pid and a session id of
+ * the expected UUID shape. Requiring the shape (not merely a non-empty string) keeps a truncated or
+ * placeholder id from resolving to something that can never match a real session — which downstream
+ * would read as a dead owner rather than an unresolvable one.
+ */
+export const parseSessionRegistryEntry = (raw: string): SessionRegistryEntry | null => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw) as unknown;
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== "object" || parsed === null) return null;
+	const {pid, sessionId} = parsed as {readonly pid?: unknown; readonly sessionId?: unknown};
+	if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return null;
+	if (typeof sessionId !== "string") return null;
+	const id = sessionId.trim();
+	return SESSION_UUID.test(id) ? {pid, sessionId: id} : null;
+};

--- a/packages/pipeline-cli/src/session-registry.unit.test.ts
+++ b/packages/pipeline-cli/src/session-registry.unit.test.ts
@@ -1,0 +1,42 @@
+import {assert, describe, it} from "@effect/vitest";
+import {parseSessionRegistryEntry, sessionRegistryDir} from "./session-registry.ts";
+
+const SID_A = "85123b6c-d220-46c5-ac19-77ccedffb3d7";
+const join = (...segments: Array<string>): string => segments.join("/");
+
+describe("sessionRegistryDir", () => {
+	it("defaults to <home>/.claude/sessions", () => {
+		assert.strictEqual(
+			sessionRegistryDir({configDir: undefined, home: "/home/dev", join}),
+			"/home/dev/.claude/sessions",
+		);
+	});
+
+	it("honours $CLAUDE_CONFIG_DIR, and treats a blank one as unset", () => {
+		assert.strictEqual(
+			sessionRegistryDir({configDir: "/cfg", home: "/home/dev", join}),
+			"/cfg/sessions",
+		);
+		assert.strictEqual(
+			sessionRegistryDir({configDir: "   ", home: "/home/dev", join}),
+			"/home/dev/.claude/sessions",
+		);
+	});
+});
+
+describe("parseSessionRegistryEntry", () => {
+	it("reads pid + sessionId off a registry file", () => {
+		const raw = `{"pid":58920,"sessionId":"${SID_A}","cwd":"/repo","status":"busy"}`;
+		assert.deepStrictEqual(parseSessionRegistryEntry(raw), {pid: 58920, sessionId: SID_A});
+	});
+
+	it("rejects an entry with no usable pid or no session id", () => {
+		assert.isNull(parseSessionRegistryEntry(`{"sessionId":"${SID_A}"}`));
+		assert.isNull(parseSessionRegistryEntry(`{"pid":0,"sessionId":"${SID_A}"}`));
+		assert.isNull(parseSessionRegistryEntry(`{"pid":-1,"sessionId":"${SID_A}"}`));
+		assert.isNull(parseSessionRegistryEntry(`{"pid":1.5,"sessionId":"${SID_A}"}`));
+		assert.isNull(parseSessionRegistryEntry('{"pid":42,"sessionId":"nope"}'));
+		assert.isNull(parseSessionRegistryEntry("garbage"));
+		assert.isNull(parseSessionRegistryEntry("null"));
+	});
+});

--- a/packages/pipeline-cli/src/tools/review-head/agent-lock.ts
+++ b/packages/pipeline-cli/src/tools/review-head/agent-lock.ts
@@ -11,7 +11,7 @@
  * keeps working in it — never this CLI process's, which exits seconds after `git worktree add` and
  * would mark a live tree orphaned immediately.
  */
-import type {SessionRegistryEntry} from "../worktree-sweep/owner-liveness.ts";
+import type {SessionRegistryEntry} from "../../session-registry.ts";
 
 /**
  * The lock reason, in the exact grammar `parseAgentLockOwner` accepts (`claude agent <id> (pid <N>

--- a/packages/pipeline-cli/src/tools/review-head/agent-lock.ts
+++ b/packages/pipeline-cli/src/tools/review-head/agent-lock.ts
@@ -1,0 +1,44 @@
+/**
+ * The pid-bearing git lock `review-head materialize` stamps on its throwaway tree, and the pure
+ * half of resolving WHOSE pid that is (#4004).
+ *
+ * A `review-head-*` tree used to be born unlocked, which cost it both halves of the presence
+ * system: no git-level fence against a `worktree remove` while a reviewer was live in it, and no
+ * provable owner once it was orphaned — the reclaimers read a worktree's owner off its lock reason
+ * (`parseAgentLockOwner`, ADR 0191), so an unlocked tree has no owner at all.
+ *
+ * The pid the reason carries is the OWNING SESSION's — the reviewer that asked for the tree and
+ * keeps working in it — never this CLI process's, which exits seconds after `git worktree add` and
+ * would mark a live tree orphaned immediately.
+ */
+import type {SessionRegistryEntry} from "../worktree-sweep/owner-liveness.ts";
+
+/**
+ * The lock reason, in the exact grammar `parseAgentLockOwner` accepts (`claude agent <id> (pid <N>
+ * start <date>)`) — the same shape the harness writes for a build tree, so a review tree lands in
+ * one presence system rather than a parallel one. The round-trip is asserted in the unit test.
+ */
+export const formatAgentLockReason = (args: {
+	readonly pr: number;
+	readonly pid: number;
+	readonly startedAt: Date;
+}): string =>
+	`claude agent review-head-${args.pr} (pid ${args.pid} start ${args.startedAt.toISOString()})`;
+
+/**
+ * The pid of the session registered under `sessionId`, or `null` when no entry matches. Pure over
+ * already-read registry entries; the caller reads `<config>/sessions/*.json` (`sessionRegistryDir`).
+ * A `null` here means the lock is skipped rather than written with a pid we cannot vouch for — a
+ * stale pid would read as an orphan and hand a live reviewer's tree to the reaper.
+ */
+export const sessionPid = (
+	entries: ReadonlyArray<SessionRegistryEntry>,
+	sessionId: string | undefined,
+): number | null => {
+	const wanted = sessionId?.trim().toLowerCase();
+	if (!wanted) return null;
+	for (const entry of entries) {
+		if (entry.sessionId.toLowerCase() === wanted) return entry.pid;
+	}
+	return null;
+};

--- a/packages/pipeline-cli/src/tools/review-head/agent-lock.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/review-head/agent-lock.unit.test.ts
@@ -1,0 +1,55 @@
+import {assert, describe, it} from "@effect/vitest";
+import {parseAgentLockOwner} from "../worktree-reap/worktree-reap.ts";
+import {isReviewHeadWorktree} from "../worktree-sweep/worktree-sweep.ts";
+import {formatAgentLockReason, sessionPid} from "./agent-lock.ts";
+
+describe("formatAgentLockReason — the reason materialize writes round-trips to the reaper (#4004)", () => {
+	it("parses back to the owning pid through parseAgentLockOwner (the contract, both sides)", () => {
+		const reason = formatAgentLockReason({
+			pr: 4004,
+			pid: 58975,
+			startedAt: new Date("2026-07-25T23:48:53.000Z"),
+		});
+		assert.deepStrictEqual(parseAgentLockOwner(reason), {pid: 58975});
+	});
+
+	it("carries the `claude agent` prefix — without it the reaper reads NO owner at all", () => {
+		const reason = formatAgentLockReason({pr: 7, pid: 42, startedAt: new Date(0)});
+		assert.isTrue(reason.startsWith("claude agent "));
+		assert.include(reason, "review-head-7");
+	});
+
+	it("names the tree a review-head tree, matching what the reclaimers scope on", () => {
+		// The lock's agent id and the tree's basename are the two halves of the same class; a
+		// mismatch would lock a tree nothing scopes over.
+		assert.isTrue(isReviewHeadWorktree("/var/folders/8f/tmp.x/review-head-4004-aBc"));
+	});
+});
+
+describe("sessionPid — the OWNING session's pid, never this CLI process's", () => {
+	const registry = [
+		{pid: 111, sessionId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+		{pid: 222, sessionId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"},
+	];
+
+	it("finds the registered pid for this run's session id", () => {
+		assert.strictEqual(sessionPid(registry, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), 222);
+	});
+
+	it("matches case-insensitively and ignores surrounding whitespace", () => {
+		assert.strictEqual(sessionPid(registry, " AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA "), 111);
+	});
+
+	it("returns null for an unregistered session — no lock rather than an unattributable one", () => {
+		assert.isNull(sessionPid(registry, "cccccccc-cccc-cccc-cccc-cccccccccccc"));
+	});
+
+	it("returns null when the session id is absent or empty (no $CLAUDE_CODE_SESSION_ID)", () => {
+		assert.isNull(sessionPid(registry, undefined));
+		assert.isNull(sessionPid(registry, "   "));
+	});
+
+	it("returns null against an empty/unreadable registry", () => {
+		assert.isNull(sessionPid([], "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+	});
+});

--- a/packages/pipeline-cli/src/tools/review-head/materialize.ts
+++ b/packages/pipeline-cli/src/tools/review-head/materialize.ts
@@ -10,15 +10,16 @@
  *    review-design needs (it reviews a preview URL, not a checked-out tree).
  *  - `materialize(pr, {worktree})` — the §HEAD read path: resolve, then fetch `pull/<pr>/head` into a
  *    per-run ref (never the launched tree), assert the fetched ref IS the resolved head SHA, and —
- *    with `--worktree` — add a throwaway DETACHED worktree on that ref (never a branch switch, §RO).
+ *    with `--worktree` — add a throwaway DETACHED worktree on that ref (never a branch switch, §RO),
+ *    locked with its owning session's pid so the tree joins the presence system (see `agent-lock.ts`).
  *
  * REST only (GraphQL is broken on the kamp-us org); every infra failure is a typed error. The caller
  * is responsible for the §RO-iso primary-checkout preflight BEFORE calling `materialize` — this verb
  * is the deterministic mechanism, not the isolation gate.
  */
 import {randomUUID} from "node:crypto";
-import {mkdtempSync} from "node:fs";
-import {tmpdir} from "node:os";
+import {mkdtempSync, readdirSync, readFileSync} from "node:fs";
+import {homedir, tmpdir} from "node:os";
 import {join} from "node:path";
 import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
@@ -30,6 +31,12 @@ import {
 	type RepoResolutionError,
 	resolveRepo,
 } from "../tracker/gh-io.ts";
+import {
+	parseSessionRegistryEntry,
+	type SessionRegistryEntry,
+	sessionRegistryDir,
+} from "../worktree-sweep/owner-liveness.ts";
+import {formatAgentLockReason, sessionPid} from "./agent-lock.ts";
 import {type GitCommandError, runGit} from "./git-io.ts";
 import {
 	type MaterializePlan,
@@ -62,6 +69,12 @@ export interface MaterializeResult {
 	readonly prRef: string;
 	/** The throwaway detached worktree path, or `null` for a ref-only materialization. */
 	readonly worktreeDir: string | null;
+	/**
+	 * The pid-bearing lock reason the tree was created with, or `null` when it was left unlocked —
+	 * a ref-only materialization, or an unresolvable owning session (#4004). Reported so the caller
+	 * can SEE whether the tree carries the removal fence, rather than assume it.
+	 */
+	readonly lockReason: string | null;
 }
 
 // Only the fields review-head reads; head/head.repo are NullOr for a deleted head / deleted fork.
@@ -98,6 +111,44 @@ const pullArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	`repos/${repo}/pulls/${pr}`,
 ];
 
+/**
+ * The harness's live-session registry as this process can read it — one entry per RUNNING session.
+ * A best-effort read: an absent, unreadable, or unparseable registry yields an empty list, which
+ * resolves to no owning pid and so to an UNLOCKED tree (today's behavior), never to a guessed one.
+ */
+const readSessionRegistry = (): ReadonlyArray<SessionRegistryEntry> => {
+	const dir = sessionRegistryDir({
+		configDir: process.env.CLAUDE_CONFIG_DIR,
+		home: homedir(),
+		join,
+	});
+	const entries: Array<SessionRegistryEntry> = [];
+	// biome-ignore lint/plugin: best-effort registry read — an absent/unreadable registry is absorbed into an empty list the caller branches on (⇒ no lock), never the E channel; a total helper, not Effect-cosplay.
+	try {
+		for (const name of readdirSync(dir)) {
+			if (!name.endsWith(".json")) continue;
+			// biome-ignore lint/plugin: a single unreadable entry must not lose the rest of the registry — absorbed to a skip, never the E channel.
+			try {
+				const entry = parseSessionRegistryEntry(readFileSync(join(dir, name), "utf8"));
+				if (entry !== null) entries.push(entry);
+			} catch {}
+		}
+	} catch {}
+	return entries;
+};
+
+/**
+ * The lock reason for this materialization's tree, or `null` to leave it unlocked. The pid is the
+ * OWNING SESSION's, resolved from the harness registry by `$CLAUDE_CODE_SESSION_ID` — never this
+ * CLI process's pid, which dies seconds later and would present a live reviewer's tree as an
+ * orphan. Unresolvable ⇒ no lock: a lock nobody can attribute is worse than none (it would pin the
+ * tree past its reviewer without ever proving an owner).
+ */
+const lockReasonFor = (pr: number): string | null => {
+	const pid = sessionPid(readSessionRegistry(), process.env.CLAUDE_CODE_SESSION_ID);
+	return pid === null ? null : formatAgentLockReason({pr, pid, startedAt: new Date()});
+};
+
 /** REST-resolve the PR's current head, decode it, and run the pure `resolveHead` — the shared front half of both verbs. */
 const resolve = Effect.fn("ReviewHead.resolve")(function* (repo: string, pr: number) {
 	const raw = yield* decodePull(yield* json(pullArgs(repo, pr)));
@@ -112,8 +163,9 @@ const resolve = Effect.fn("ReviewHead.resolve")(function* (repo: string, pr: num
  * Materialize the head per the plan: fetch `pull/<pr>/head` into the per-run ref (the head reaches a
  * ref, never the launched working tree — §RO), assert the fetched ref IS the resolved head SHA (a
  * moved head between resolve and fetch aborts rather than reviewing a stale tree — §HEAD #2), then —
- * when `worktree` — `git worktree add --detach` a throwaway tree on that ref. Detached by construction
- * (the `resolve-head` plan's `detach: true`): never `git checkout <headRef>`, safe for cross-fork heads.
+ * when `worktree` — `git worktree add --detach` a throwaway tree on that ref, LOCKED with the owning
+ * session's pid (#4004). Detached by construction (the `resolve-head` plan's `detach: true`): never
+ * `git checkout <headRef>`, safe for cross-fork heads.
  */
 const materialize = Effect.fn("ReviewHead.materialize")(function* (
 	repo: string,
@@ -132,9 +184,15 @@ const materialize = Effect.fn("ReviewHead.materialize")(function* (
 	}
 
 	let worktreeDir: string | null = null;
+	let lockReason: string | null = null;
 	if (worktree) {
 		worktreeDir = mkdtempSync(join(tmpdir(), `review-head-${pr}-`));
-		yield* runGit(["worktree", "add", "--detach", worktreeDir, plan.prRef]);
+		// Born LOCKED, with the owning reviewer session's pid (#4004): the lock is both the git-level
+		// fence that makes a `worktree remove` refuse while the review is live, and the presence
+		// signal the reclaimers read an owner from once it is not.
+		lockReason = lockReasonFor(pr);
+		const lock = lockReason === null ? [] : ["--lock", "--reason", lockReason];
+		yield* runGit(["worktree", "add", "--detach", ...lock, worktreeDir, plan.prRef]);
 	}
 
 	return {
@@ -144,6 +202,7 @@ const materialize = Effect.fn("ReviewHead.materialize")(function* (
 		crossFork: plan.crossFork,
 		prRef: plan.prRef,
 		worktreeDir,
+		lockReason,
 	} satisfies MaterializeResult;
 });
 

--- a/packages/pipeline-cli/src/tools/review-head/materialize.ts
+++ b/packages/pipeline-cli/src/tools/review-head/materialize.ts
@@ -25,17 +25,17 @@ import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcessSpawner} from "effect/unstable/process";
 import {
+	parseSessionRegistryEntry,
+	type SessionRegistryEntry,
+	sessionRegistryDir,
+} from "../../session-registry.ts";
+import {
 	type GhCommandError,
 	type GhParseError,
 	json,
 	type RepoResolutionError,
 	resolveRepo,
 } from "../tracker/gh-io.ts";
-import {
-	parseSessionRegistryEntry,
-	type SessionRegistryEntry,
-	sessionRegistryDir,
-} from "../worktree-sweep/owner-liveness.ts";
 import {formatAgentLockReason, sessionPid} from "./agent-lock.ts";
 import {type GitCommandError, runGit} from "./git-io.ts";
 import {

--- a/packages/pipeline-cli/src/tools/worktree-reap/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/command.ts
@@ -52,12 +52,11 @@ import {homedir} from "node:os";
 import {join} from "node:path";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {parseSessionRegistryEntry, sessionRegistryDir} from "../../session-registry.ts";
 import {
 	liveSessionIds,
 	parseOwnerStamp,
-	parseSessionRegistryEntry,
 	resolveOwnerLiveness,
-	sessionRegistryDir,
 } from "../worktree-sweep/owner-liveness.ts";
 import {runRefReclaim} from "../worktree-sweep/ref-reclaim-io.ts";
 import {isReviewHeadWorktree} from "../worktree-sweep/worktree-sweep.ts";
@@ -114,7 +113,7 @@ const pidAlive = (pid: number): boolean => {
 	}
 };
 
-/** This verb's `node:path` binding of the shared registry-location rule (`owner-liveness.ts`). */
+/** This verb's `node:path` binding of the shared registry-location rule (`session-registry.ts`). */
 const registryDir = (): string =>
 	sessionRegistryDir({configDir: process.env.CLAUDE_CONFIG_DIR, home: homedir(), join});
 

--- a/packages/pipeline-cli/src/tools/worktree-reap/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/command.ts
@@ -5,7 +5,9 @@
  * sessions leave their `isolation:worktree` trees (and checked-out branches) behind under
  * `.claude/worktrees/`, where they accumulate and block their branches from being
  * re-checked-out elsewhere. This verb identifies trees whose owning SESSION is provably
- * dead, and reclaims only the ones that hold nothing recoverable.
+ * dead, and reclaims only the ones that hold nothing recoverable. The `$TMPDIR`-rooted
+ * `review-head-*` review checkouts are in scope too, since they now carry the same pid-bearing
+ * crew-agent lock (#4004) — see `worktree-reap.ts` for what that changes for them.
  *
  * Eligibility is session-presence-based, never age-based (ADR 0191), read from two owner
  * signals gathered here and folded by the pure classifier:
@@ -55,8 +57,10 @@ import {
 	parseOwnerStamp,
 	parseSessionRegistryEntry,
 	resolveOwnerLiveness,
+	sessionRegistryDir,
 } from "../worktree-sweep/owner-liveness.ts";
 import {runRefReclaim} from "../worktree-sweep/ref-reclaim-io.ts";
+import {isReviewHeadWorktree} from "../worktree-sweep/worktree-sweep.ts";
 import {
 	computeWorktreeReapPlan,
 	isManagedAgentWorktree,
@@ -110,13 +114,9 @@ const pidAlive = (pid: number): boolean => {
 	}
 };
 
-/**
- * The harness's live-session registry directory — one `<pid>.json` per RUNNING session, deleted
- * when the session exits. `$CLAUDE_CONFIG_DIR` is the harness's own override for the config root;
- * absent it, the default config home under the user's home dir.
- */
-const sessionRegistryDir = (): string =>
-	join(process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude"), "sessions");
+/** This verb's `node:path` binding of the shared registry-location rule (`owner-liveness.ts`). */
+const registryDir = (): string =>
+	sessionRegistryDir({configDir: process.env.CLAUDE_CONFIG_DIR, home: homedir(), join});
 
 /** Read a file, or `null` on ANY failure — an unreadable input is never evidence about a session. */
 const readTextOrNull = (path: string): string | null => {
@@ -135,7 +135,7 @@ const readTextOrNull = (path: string): string | null => {
  * running") lives in `liveSessionIds`; this is only its IO.
  */
 const probeLiveSessions = (): ReadonlySet<string> | null => {
-	const dir = sessionRegistryDir();
+	const dir = registryDir();
 	let names: ReadonlyArray<string>;
 	// biome-ignore lint/plugin: best-effort enumeration — an unreadable registry dir is reported as `readable: false`, the fail-closed input `liveSessionIds` turns into "trust nothing", never the E channel.
 	try {
@@ -160,9 +160,10 @@ const OWNER_STAMP_FILE = "kampus-owner.json";
 
 /**
  * Signal 2 for one tree: its owner stamp resolved against the live-session registry. Unlike the
- * sweep, this takes NO session-id-from-path fallback — that fallback exists for `$TMPDIR`-rooted
- * `review-head-*` trees, which are not `.claude/worktrees/` managed trees and so never reach this
- * verb. An unresolvable gitdir, an absent stamp, a malformed stamp, or an untrusted registry all
+ * sweep, this takes NO session-id-from-path fallback — that fallback guesses an owner from a
+ * `$TMPDIR` path, and a review-head tree is not called here at all (#4004): it carries its own
+ * `review-head materialize` lock, which is signal 1 and a far better fact than a path guess. An
+ * unresolvable gitdir, an absent stamp, a malformed stamp, or an untrusted registry all
  * read `"unknown"` (⇒ the tree is spared unless the lock signal independently proves death).
  */
 const stampPresenceOf = (worktreePath: string, live: ReadonlySet<string> | null): OwnerPresence => {
@@ -255,8 +256,9 @@ const worktreeReap = Command.make(
 			.map((p) => {
 				// The primary checkout and any foreign tree short-circuit to a SPARE record — the
 				// classifier never consults the other fields for them, so no stamp read, pid probe,
-				// `git status`, or ancestry walk ever fires outside `.claude/worktrees/`.
-				if (!isManagedAgentWorktree(p.path)) {
+				// `git status`, or ancestry walk ever fires outside the two in-scope classes.
+				const reviewHead = isReviewHeadWorktree(p.path);
+				if (!isManagedAgentWorktree(p.path) && !reviewHead) {
 					return {
 						path: p.path,
 						branch: p.branch,
@@ -275,8 +277,11 @@ const worktreeReap = Command.make(
 					lockOwner:
 						parsedLock === null ? null : {pid: parsedLock.pid, alive: pidAlive(parsedLock.pid)},
 					foreignLock,
-					// An operator-pinned tree is spared whatever its owner says, so don't read its stamp.
-					stampPresence: foreignLock ? ("unknown" as const) : stampPresenceOf(p.path, live),
+					// An operator-pinned tree is spared whatever its owner says, so don't read its stamp —
+					// nor is there one to read for a `$TMPDIR`-rooted review-head tree, which no hook
+					// provisions: signal 1, its own `review-head materialize` lock, is all it ever carries.
+					stampPresence:
+						foreignLock || reviewHead ? ("unknown" as const) : stampPresenceOf(p.path, live),
 				};
 				// Only a tree whose owner is PROVEN dead needs its recoverable-work facts gathered; a
 				// live or unprovable owner is spared before those checks are ever consulted, so the
@@ -288,7 +293,9 @@ const worktreeReap = Command.make(
 				return {
 					...facts,
 					hasUncommitted: worktreeHasUncommitted(p.path),
-					hasUnpushed: hasUnpushed(p.head),
+					// The ancestry probe is meaningless for a review-head tree — its detached head came
+					// off the remote, so the classifier does not consult this fact for it (#4004).
+					hasUnpushed: reviewHead ? false : hasUnpushed(p.head),
 				};
 			});
 

--- a/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
@@ -1,8 +1,9 @@
 /**
- * `worktree-reap` pure core — classify each managed agent worktree into REAP /
- * KEEP-DIRTY / SPARE with a reason, for the safe reaping of worktrees orphaned by
- * DEAD crew sessions (issue #3754). IO-free and total: every decision is a
- * deterministic transform over already-gathered facts. The git + process boundary
+ * `worktree-reap` pure core — classify each agent worktree (a managed build tree, or a
+ * `review-head-*` throwaway review checkout) into REAP / KEEP-DIRTY / SPARE with a
+ * reason, for the safe reaping of worktrees orphaned by DEAD crew sessions (issue
+ * #3754). IO-free and total: every decision is a deterministic transform over
+ * already-gathered facts. The git + process boundary
  * (enumerate / status / ancestry / pid-liveness / unlock+remove) lives in
  * `command.ts`; this module never runs a command and never removes anything.
  *
@@ -52,6 +53,7 @@
  * this core only chooses WHETHER to attempt the remove, and never escalates to a forced one.
  */
 import type {OwnerLiveness} from "../worktree-sweep/owner-liveness.ts";
+import {isReviewHeadWorktree} from "../worktree-sweep/worktree-sweep.ts";
 
 /** The segment that marks a harness-managed agent worktree: `<main>/.claude/worktrees/<id>`. */
 const MANAGED_SEGMENT = "/.claude/worktrees/";
@@ -170,8 +172,11 @@ export type ReapDecision =
 /**
  * Classify a single worktree. The order of checks IS the safety policy:
  *
- *   1. Not a managed agent worktree → SPARE (`not-managed`). The primary checkout and any
- *      foreign tree are never candidates, regardless of their other facts.
+ *   1. Neither a managed agent worktree nor a `review-head-*` throwaway review checkout → SPARE
+ *      (`not-managed`). The primary checkout and any foreign tree are never candidates, regardless
+ *      of their other facts. Review-head trees are in scope since they too carry a pid-bearing
+ *      crew-agent lock (#4004) — signal 1, the only one that resolves for that class (they are not
+ *      `.claude/worktrees/` trees, so no hook ever stamps them).
  *   2. Locked by someone else → SPARE (`foreign-lock`). An operator pin outranks both owner
  *      signals, because reclaiming would mean unlocking what a human deliberately locked.
  *   3. Some signal says ALIVE → SPARE (`live-session`). The ADR 0191 presence gate, and the
@@ -179,12 +184,14 @@ export type ReapDecision =
  *   4. No signal proves DEATH → SPARE (`owner-unknown`). Orphanhood unprovable — never reap
  *      what we cannot prove dead. This is where the unstamped, unlocked historical pile sits.
  *   5. (Dead session) uncommitted → KEEP-DIRTY (`uncommitted`). Recoverable working-tree work.
- *   6. (Dead session) unpushed → KEEP-DIRTY (`unpushed`). Committed work not on `origin/main`.
+ *   6. (Dead session, BUILD tree) unpushed → KEEP-DIRTY (`unpushed`). Committed work not on
+ *      `origin/main`. Not applied to a review-head tree, whose detached head came off the remote.
  *   7. Otherwise → REAP (`orphan-clean`). Dead session, clean tree, all commits landed —
  *      nothing recoverable to strand.
  */
 export const classifyCandidate = (c: ReapCandidate): ReapDecision => {
-	if (!isManagedAgentWorktree(c.path)) {
+	const reviewHead = isReviewHeadWorktree(c.path);
+	if (!isManagedAgentWorktree(c.path) && !reviewHead) {
 		return {kind: "spare", reason: "not-managed"};
 	}
 	if (c.foreignLock) {
@@ -200,7 +207,11 @@ export const classifyCandidate = (c: ReapCandidate): ReapDecision => {
 	if (c.hasUncommitted) {
 		return {kind: "keep-dirty", reason: "uncommitted"};
 	}
-	if (c.hasUnpushed) {
+	// N/A for a review-head tree: it is DETACHED at a head fetched from the remote
+	// (`pull/<pr>/head`), so its HEAD is on origin by construction and "not reachable from
+	// origin/main" is its normal state for an open PR, not unpushed work. Applying the build-tree
+	// gate to it would keep every such orphan forever (#4004). The uncommitted gate above still runs.
+	if (c.hasUnpushed && !reviewHead) {
 		return {kind: "keep-dirty", reason: "unpushed"};
 	}
 	return {kind: "reap", reason: "orphan-clean"};

--- a/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.unit.test.ts
@@ -242,6 +242,59 @@ describe("classifyCandidate — the #3989 stamp signal (the unlocked majority is
 	});
 });
 
+describe("classifyCandidate — review-head trees join the presence system (#4004)", () => {
+	/** A $TMPDIR-rooted throwaway review checkout, as `review-head materialize` creates it. */
+	const reviewHead = (over: Partial<ReapCandidate> = {}): ReapCandidate =>
+		candidate({
+			path: "/var/folders/8f/tmp.aBcD1234/review-head-4004-xY9",
+			branch: null,
+			// A detached PR head is normally NOT reachable from origin/main while the PR is open —
+			// the state that used to read as unpushed work.
+			hasUnpushed: true,
+			...over,
+		});
+
+	it("DEAD owner + clean → REAP, even though its detached head is not on origin/main", () => {
+		// The head came off `pull/<pr>/head`, so it is on the remote by construction: the build-tree
+		// unpushed gate does not apply, and without this the orphan would be kept forever.
+		assert.deepStrictEqual(classifyCandidate(reviewHead()), {kind: "reap", reason: "orphan-clean"});
+	});
+
+	it("LIVE owner → SPARED by PRESENCE (never owner-unknown) — a reviewer is working in it", () => {
+		const d = classifyCandidate(reviewHead({lockOwner: {pid: 4242, alive: true}}));
+		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
+	});
+
+	it("UNLOCKED (no provable owner) → still SPARED owner-unknown — the lock is its only owner proof", () => {
+		// No hook stamps a `$TMPDIR` tree, so signal 2 is permanently `unknown` for this class and an
+		// unlocked one has NO signal at all (#3989's stamp never reaches it).
+		const d = classifyCandidate(reviewHead({lockOwner: null, stampPresence: "unknown"}));
+		assert.deepStrictEqual(d, {kind: "spare", reason: "owner-unknown"});
+	});
+
+	it("an operator's foreign lock on one is SPARED even with a dead pid — the #4169 pin still outranks", () => {
+		const d = classifyCandidate(reviewHead({foreignLock: true, lockOwner: null}));
+		assert.deepStrictEqual(d, {kind: "spare", reason: "foreign-lock"});
+	});
+
+	it("DEAD owner + UNCOMMITTED changes → KEEP-DIRTY: the recoverable-work guard still applies", () => {
+		const d = classifyCandidate(reviewHead({hasUncommitted: true}));
+		assert.deepStrictEqual(d, {kind: "keep-dirty", reason: "uncommitted"});
+	});
+
+	it("the unpushed exemption is scoped to the class — a BUILD tree is still kept as unpushed", () => {
+		const d = classifyCandidate(candidate({hasUnpushed: true}));
+		assert.deepStrictEqual(d, {kind: "keep-dirty", reason: "unpushed"});
+	});
+
+	it("a review-head-named path is scoped by BASENAME — a nested tree is not the class", () => {
+		const d = classifyCandidate(
+			reviewHead({path: "/var/folders/8f/tmp.aBcD1234/review-head-4004-xY9/nested"}),
+		);
+		assert.deepStrictEqual(d, {kind: "spare", reason: "not-managed"});
+	});
+});
+
 describe("computeWorktreeReapPlan — partitions into reap / kept-dirty / spared", () => {
 	it("routes each candidate to exactly one bucket", () => {
 		const reapable = candidate({path: wtPath("agent-reap")});

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -192,6 +192,89 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		);
 	});
 
+	it("reads a review-head tree's OWN pid-bearing lock as presence: live pid KEPT, dead pid reclaimed — #4004", async () => {
+		const reviewRoot = mkdtempSync(join(tmpdir(), "wts-lock-"));
+		reviewRoots.push(reviewRoot);
+		const lockReason = (pid: number) => `claude agent review-head-x (pid ${pid} start now)`;
+		// A pid that is provably GONE: the shell prints its own pid and exits before the sweep runs.
+		const deadPid = Number.parseInt(execFileSync("sh", ["-c", "echo $$"], {encoding: "utf8"}), 10);
+
+		// Locked with THIS process's pid — a live reviewer. Otherwise fully reclaimable (clean, idle,
+		// no stamp), so only the lock's presence signal can save it.
+		const liveWt = join(reviewRoot, "review-head-9001");
+		git(
+			mainRepo,
+			"worktree",
+			"add",
+			"-q",
+			"--detach",
+			"--lock",
+			"--reason",
+			lockReason(process.pid),
+			liveWt,
+			"HEAD",
+		);
+		backdate(liveWt);
+
+		// Same shape, locked with a dead pid — a stale pin, so the lock must not keep it forever.
+		const orphanWt = join(reviewRoot, "review-head-9002");
+		git(
+			mainRepo,
+			"worktree",
+			"add",
+			"-q",
+			"--detach",
+			"--lock",
+			"--reason",
+			lockReason(deadPid),
+			orphanWt,
+			"HEAD",
+		);
+		backdate(orphanWt);
+
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], sweepEnv);
+		assert.strictEqual(code, 0, stdout);
+		assert.isTrue(existsSync(liveWt), "a live reviewer's locked tree must be KEPT");
+		assert.isFalse(
+			existsSync(orphanWt),
+			"a stale-locked orphan must be reclaimed, not pinned forever",
+		);
+
+		git(mainRepo, "worktree", "unlock", liveWt);
+	});
+
+	it("prunes a torn-down review tree's LOCKED metadata — plain `git worktree prune` skips it — #4004", async () => {
+		const reviewRoot = mkdtempSync(join(tmpdir(), "wts-gone-"));
+		reviewRoots.push(reviewRoot);
+		const goneWt = join(reviewRoot, "review-head-9003");
+		git(
+			mainRepo,
+			"worktree",
+			"add",
+			"-q",
+			"--detach",
+			"--lock",
+			"--reason",
+			"claude agent review-head-x (pid 4242 start now)",
+			goneWt,
+			"HEAD",
+		);
+		// Exactly what the review gates' teardown does: `rm -rf "$REVIEW_WT" && git worktree prune`.
+		rmSync(goneWt, {recursive: true, force: true});
+		git(mainRepo, "worktree", "prune");
+		assert.isTrue(
+			git(mainRepo, "worktree", "list", "--porcelain").includes(goneWt),
+			"precondition: git's own prune leaves a LOCKED gone-dir entry behind",
+		);
+
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"], sweepEnv);
+		assert.strictEqual(code, 0, stdout);
+		assert.isFalse(
+			git(mainRepo, "worktree", "list", "--porcelain").includes(goneWt),
+			"the sweep must unlock the stale crew-agent lock and prune the metadata",
+		);
+	});
+
 	it("dry-run (no --execute) touches nothing — even a clean+idle+unlocked orphan", async () => {
 		const keepWt = join(mainRepo, ".claude", "worktrees", "wf_dryrun");
 		git(mainRepo, "worktree", "add", "-q", "--detach", keepWt, "HEAD");

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -42,6 +42,7 @@ import {execFileSync} from "node:child_process";
 import {homedir} from "node:os";
 import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {parseAgentLockOwner} from "../worktree-reap/worktree-reap.ts";
 import {
 	liveSessionIds,
 	type OwnerLiveness,
@@ -50,6 +51,7 @@ import {
 	parseSessionRegistryEntry,
 	resolveOwnerLiveness,
 	sessionIdFromPath,
+	sessionRegistryDir,
 } from "./owner-liveness.ts";
 import {runRefReclaim} from "./ref-reclaim-io.ts";
 import {
@@ -195,14 +197,6 @@ const worktreeIdleFacts = (
 	});
 
 /**
- * The harness's live-session registry directory — one `<pid>.json` per RUNNING session, deleted
- * when the session exits. `$CLAUDE_CONFIG_DIR` is the harness's own override for the config root;
- * absent it, the tool's default config home under the user's home dir.
- */
-const sessionRegistryDir = (path: Path.Path): string =>
-	path.join(process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(homedir(), ".claude"), "sessions");
-
-/**
  * Is `pid` running? Fails toward TRUE, which is what keeps a tree: `ESRCH` is the only positive
  * evidence of absence, `EPERM` proves the process EXISTS under another uid, and any other error
  * means the probe could not execute — never that the process is gone (#3943, and the #787 class
@@ -230,7 +224,11 @@ const probeLiveSessions = (): Effect.Effect<
 	Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
 		const pathSvc = yield* Path.Path;
-		const dir = sessionRegistryDir(pathSvc);
+		const dir = sessionRegistryDir({
+			configDir: process.env.CLAUDE_CONFIG_DIR,
+			home: homedir(),
+			join: (...segments) => pathSvc.join(...segments),
+		});
 		const names = yield* fs
 			.readDirectory(dir)
 			.pipe(Effect.orElseSucceed((): ReadonlyArray<string> | null => null));
@@ -364,11 +362,38 @@ const worktreeSweep = Command.make(
 			parsed.filter((p) => !p.bare),
 			(p) =>
 				Effect.gen(function* () {
+					const managed = isManagedWorktree(p.path);
+					// A review-head tree is a swept candidate too (#2785), so its liveness (idle mtime)
+					// must be probed. Its detached HEAD carries no branch, so the open-PR probe below
+					// (branch-keyed) is N/A for it — the dirty/locked/idle triple carries its liveness.
+					const reviewHead = isReviewHeadWorktree(p.path);
+					const swept = managed || reviewHead;
+					// A `review-head-*` tree's lock is written by this repo (`review-head materialize`,
+					// #4004) with the owning REVIEWER session's pid, so for that class the lock reason is
+					// the exact presence signal — strictly better than the stamp/path heuristic below,
+					// which a multi-UUID temp root cannot resolve. Scoped to the class we write: a build
+					// tree's lock is an opaque pin whose keep-behavior stays untouched.
+					const lockOwner = reviewHead ? parseAgentLockOwner(p.lockReason) : null;
+					const lockOwnerLiveness: OwnerLiveness =
+						lockOwner === null ? "unknown" : pidIsAlive(lockOwner.pid) ? "alive" : "dead";
+					// git withholds the `prunable` flag from a LOCKED worktree — including one whose
+					// directory is already gone, which is exactly what a review gate's teardown leaves
+					// behind (`rm -rf "$REVIEW_WT" && git worktree prune`) now that the tree is born
+					// locked (#4004). Recover the fact ourselves for the class we lock: dir missing ⇒
+					// gone-dir, the same #3654 case, reaped by unlock+prune below. An unresolvable
+					// existence check reads "present" (fail-safe KEEP).
+					const dirGone =
+						lockOwner !== null &&
+						!(yield* (yield* FileSystem.FileSystem)
+							.exists(p.path)
+							.pipe(Effect.orElseSucceed(() => true)));
+					const prunable = p.prunable || dirGone;
+
 					// A gone-dir tree's working directory is missing, so every probe below is either
 					// meaningless or actively errors (`git -C <gone> status` fails → fail-safe dirty,
 					// which would mis-KEEP it). Short-circuit to the safe-to-prune record: the classifier
 					// checks `prunable` first, so the other facts are never consulted for it (#3654).
-					if (p.prunable) {
+					if (prunable) {
 						return {
 							path: p.path,
 							branch: p.branch,
@@ -377,6 +402,12 @@ const worktreeSweep = Command.make(
 							reachableFromOriginMain: false,
 							squashMergedToOriginMain: false,
 							locked: p.locked,
+							// A gone-dir tree's crew-agent lock is stale WHATEVER its pid says — the reviewer
+							// tore the directory down (`rm -rf $REVIEW_WT`) and only admin metadata is left.
+							// It must be recorded, because `git worktree prune` SKIPS a locked entry: without
+							// the unlock this flag drives, every torn-down review tree would leave a permanent
+							// `.git/worktrees/<id>` stub — the #3654 pile, re-created by the #4004 lock.
+							staleAgentLock: lockOwner !== null,
 							recentlyActive: false,
 							hasOpenPr: false,
 							// Moot for a gone-dir tree — `prunable` short-circuits the classifier before any
@@ -386,11 +417,6 @@ const worktreeSweep = Command.make(
 							idleBeyondLauncherGrace: false,
 						};
 					}
-					const managed = isManagedWorktree(p.path);
-					// A review-head tree is a swept candidate too (#2785), so its liveness (idle mtime)
-					// must be probed. Its detached HEAD carries no branch, so the open-PR probe below
-					// (branch-keyed) is N/A for it — the dirty/locked/idle triple carries its liveness.
-					const swept = managed || isReviewHeadWorktree(p.path);
 					const isDirty = worktreeIsDirty(p.path);
 					const reachable = reachableFromOriginMain(p.head);
 					// Only probe the costlier squash signal when ancestry already missed.
@@ -400,9 +426,16 @@ const worktreeSweep = Command.make(
 						: {recentlyActive: false, idleBeyondLauncherGrace: false};
 					// Presence beats recency (#3943): a live shipper lane is mtime-idle, so `recentlyActive`
 					// cannot see it. Probed only for a swept tree — an unswept one is already KEEP.
-					const ownerLiveness: OwnerLiveness = swept
-						? resolveOwnerLiveness({owner: yield* ownerOf(p.path), liveSessionIds: live})
-						: "unknown";
+					// The lock-derived presence wins where it exists (#4004): it names the session that
+					// materialized THIS tree, where the stamp/path fallback below only ever names a
+					// launcher (#4001). It is computed for the review-head class alone, so a build tree
+					// still resolves exactly as before.
+					const ownerLiveness: OwnerLiveness =
+						lockOwnerLiveness !== "unknown"
+							? lockOwnerLiveness
+							: swept
+								? resolveOwnerLiveness({owner: yield* ownerOf(p.path), liveSessionIds: live})
+								: "unknown";
 					// Mirrors the classifier's owner gates so the probe below fires for exactly the trees
 					// that can reach the open-PR branch — including a launcher-owned one past its grace
 					// window (#4001), which would otherwise skip the probe and be reaped with a PR open.
@@ -429,6 +462,7 @@ const worktreeSweep = Command.make(
 						reachableFromOriginMain: reachable,
 						squashMergedToOriginMain: squashMerged,
 						locked: p.locked,
+						staleAgentLock: lockOwnerLiveness === "dead",
 						recentlyActive,
 						hasOpenPr,
 						ownerLiveness,
@@ -497,6 +531,12 @@ const worktreeSweep = Command.make(
 		/** Branches whose tree this run actually reclaimed — the ref pass's default scope (#4190). */
 		const reclaimedBranches: Array<string> = [];
 		if (goneDir.length > 0) {
+			// `git worktree prune` SKIPS a locked entry, so a torn-down review tree's stale crew-agent
+			// lock (#4004) would keep its metadata forever. Free it first — the directory is already
+			// gone, so there is no working surface to pull out from under anyone.
+			for (const r of goneDir) {
+				if (r.worktree.staleAgentLock) runGit(["worktree", "unlock", r.worktree.path]);
+			}
 			const res = runGit(["worktree", "prune", "--verbose"]);
 			if (res.ok) {
 				pruned = goneDir.length;
@@ -512,6 +552,10 @@ const worktreeSweep = Command.make(
 		let removed = 0;
 		let refused = 0;
 		for (const r of toRemovePaths) {
+			// A stale crew-agent lock (#4004) makes the non-forced remove refuse, so free it first —
+			// scoped to a tree the classifier already proved dead+clean+idle, never a live lane's lock.
+			// Unlock, never `--force`: the dirty-work refusal below stays git's to make.
+			if (r.worktree.staleAgentLock) runGit(["worktree", "unlock", r.worktree.path]);
 			// NEVER --force: git refuses a tree it judges unsafe, and we KEEP it (report, don't escalate).
 			const res = runGit(["worktree", "remove", r.worktree.path]);
 			if (res.ok) {

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -42,16 +42,15 @@ import {execFileSync} from "node:child_process";
 import {homedir} from "node:os";
 import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {parseSessionRegistryEntry, sessionRegistryDir} from "../../session-registry.ts";
 import {parseAgentLockOwner} from "../worktree-reap/worktree-reap.ts";
 import {
 	liveSessionIds,
 	type OwnerLiveness,
 	type OwnerStamp,
 	parseOwnerStamp,
-	parseSessionRegistryEntry,
 	resolveOwnerLiveness,
 	sessionIdFromPath,
-	sessionRegistryDir,
 } from "./owner-liveness.ts";
 import {runRefReclaim} from "./ref-reclaim-io.ts";
 import {

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
@@ -13,11 +13,13 @@
  * pid-bearing reason (`claude agent <id> (pid <N> start <date>)`) that `worktree-reap` already parses
  * as a presence signal. So the lock gate is real and does protect some live lanes. What it is not is
  * *reliable*: coverage is partial (most registered trees carry no lock at a given moment, and a lock
- * can outlive its session), and the `$TMPDIR`-rooted `review-head-*` class is never locked at all —
- * `review-head materialize` runs `git worktree add --detach` with no `--lock` — so the
- * `review-head-idle` removal path had no lock protection for a live reviewer's tree. The root cause
- * of the two observed agent-tree removals is NOT established; this gate is justified as the missing
- * *presence* signal, not as a replacement for a defeated lock.
+ * can outlive its session). The `$TMPDIR`-rooted `review-head-*` class was not locked at all when
+ * this gate was written, leaving the `review-head-idle` removal path with no lock protection for a
+ * live reviewer's tree; `review-head materialize` now locks its tree with the owning session's pid
+ * (#4004), which adds a fence but does not make this gate redundant — the lock is one owner signal,
+ * this module is the other, and both fail toward KEEP. The root cause of the two observed agent-tree
+ * removals is NOT established; this gate is justified as the missing *presence* signal, not as a
+ * replacement for a defeated lock.
  *
  * ADR 0191 is the rule the sweep was missing: a resource claim's liveness rides its HOLDER's
  * presence, never an age window.
@@ -127,6 +129,19 @@ export const parseOwnerStamp = (raw: string): OwnerStamp | null => {
 	const kind = asString(objectField(parsed, "ownerKind"));
 	return {sessionId, kind: kind === "occupant" ? "occupant" : "launcher"};
 };
+
+/**
+ * The harness's live-session registry directory — one `<pid>.json` per RUNNING session, deleted
+ * when the session exits. `$CLAUDE_CONFIG_DIR` is the harness's own override for the config root;
+ * absent it, the tool's default config home under the user's home dir. The joiner is a parameter so
+ * each caller keeps its own path seam (the Effect `Path` service in the sweep, `node:path` in
+ * `review-head materialize`) while the LOCATION rule lives here once.
+ */
+export const sessionRegistryDir = (args: {
+	readonly configDir: string | undefined;
+	readonly home: string;
+	readonly join: (...segments: Array<string>) => string;
+}): string => args.join(args.configDir?.trim() || args.join(args.home, ".claude"), "sessions");
 
 /** One `<config>/sessions/<pid>.json` entry — a session the harness records as running. */
 export interface SessionRegistryEntry {

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
@@ -42,7 +42,9 @@
  *      rather than a considered spare. Do not build a decision on stamp coverage until #4180
  *      lands a producer that actually fires.
  *   2. **liveness** — the harness's session registry: one `<config>/sessions/<pid>.json` per
- *      RUNNING session, carrying `{pid, sessionId}` and deleted when the session exits.
+ *      RUNNING session, carrying `{pid, sessionId}` and deleted when the session exits. Where those
+ *      files live and how one is read is `../../session-registry.ts` — shared with the lock-writer
+ *      on the other side of the §CP boundary, owned by neither (ADR 0218).
  *
  * **The owner is the LAUNCHER, never the occupant (#4001).** Both owner sources above resolve the
  * session that *spawned* the tree, not the ephemeral subagent that *occupies* it: the hook runs in
@@ -71,6 +73,7 @@
  * work. So "cannot prove dead" and "dead" must never collapse into one verdict — a missing stamp,
  * an unreadable registry, or a probe that could not execute is not evidence of death.
  */
+import {SESSION_UUID} from "../../session-registry.ts";
 
 /**
  * `"dead"` is the only verdict that lets a removal proceed outright. `"unknown"` is a distinct
@@ -95,9 +98,6 @@ export interface OwnerStamp {
 	readonly sessionId: string;
 	readonly kind: OwnerKind;
 }
-
-/** A bare session-UUID path segment (the shape both the registry and the sidecar layout use). */
-const SESSION_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const asString = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
 
@@ -128,34 +128,6 @@ export const parseOwnerStamp = (raw: string): OwnerStamp | null => {
 	if (!SESSION_UUID.test(sessionId)) return null;
 	const kind = asString(objectField(parsed, "ownerKind"));
 	return {sessionId, kind: kind === "occupant" ? "occupant" : "launcher"};
-};
-
-/**
- * The harness's live-session registry directory — one `<pid>.json` per RUNNING session, deleted
- * when the session exits. `$CLAUDE_CONFIG_DIR` is the harness's own override for the config root;
- * absent it, the tool's default config home under the user's home dir. The joiner is a parameter so
- * each caller keeps its own path seam (the Effect `Path` service in the sweep, `node:path` in
- * `review-head materialize`) while the LOCATION rule lives here once.
- */
-export const sessionRegistryDir = (args: {
-	readonly configDir: string | undefined;
-	readonly home: string;
-	readonly join: (...segments: Array<string>) => string;
-}): string => args.join(args.configDir?.trim() || args.join(args.home, ".claude"), "sessions");
-
-/** One `<config>/sessions/<pid>.json` entry — a session the harness records as running. */
-export interface SessionRegistryEntry {
-	readonly pid: number;
-	readonly sessionId: string;
-}
-
-/** Parse one registry file; `null` unless it yields BOTH a positive pid and a session id. */
-export const parseSessionRegistryEntry = (raw: string): SessionRegistryEntry | null => {
-	const parsed = parseJson(raw);
-	const pid = objectField(parsed, "pid");
-	const sessionId = asString(objectField(parsed, "sessionId"));
-	if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return null;
-	return SESSION_UUID.test(sessionId) ? {pid, sessionId} : null;
 };
 
 /**

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.unit.test.ts
@@ -2,7 +2,6 @@ import {assert, describe, it} from "@effect/vitest";
 import {
 	liveSessionIds,
 	parseOwnerStamp,
-	parseSessionRegistryEntry,
 	resolveOwnerLiveness,
 	sessionIdFromPath,
 } from "./owner-liveness.ts";
@@ -41,21 +40,6 @@ describe("parseOwnerStamp", () => {
 		assert.isNull(parseOwnerStamp('{"worktreeName":"agent-abc"}'));
 		assert.isNull(parseOwnerStamp('{"sessionId":"pending"}'));
 		assert.isNull(parseOwnerStamp('{"sessionId":""}'));
-	});
-});
-
-describe("parseSessionRegistryEntry", () => {
-	it("reads pid + sessionId off a registry file", () => {
-		const raw = `{"pid":58920,"sessionId":"${SID_A}","cwd":"/repo","status":"busy"}`;
-		assert.deepStrictEqual(parseSessionRegistryEntry(raw), {pid: 58920, sessionId: SID_A});
-	});
-
-	it("rejects an entry with no usable pid or no session id", () => {
-		assert.isNull(parseSessionRegistryEntry(`{"sessionId":"${SID_A}"}`));
-		assert.isNull(parseSessionRegistryEntry(`{"pid":0,"sessionId":"${SID_A}"}`));
-		assert.isNull(parseSessionRegistryEntry(`{"pid":-1,"sessionId":"${SID_A}"}`));
-		assert.isNull(parseSessionRegistryEntry('{"pid":42,"sessionId":"nope"}'));
-		assert.isNull(parseSessionRegistryEntry("garbage"));
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -53,8 +53,8 @@
  * Session-presence liveness (#3943): the three signals above are all the sweep had, and none of
  * them is presence — so a live SHIPPER lane read as an orphan (clean, its PR just squash-merged, and
  * mtime-idle because a ship touches no file in the tree) and had its worktree removed mid-run, twice.
- * The `locked` gate is real presence-ish signal but only partially covers the pile (and never covers
- * `review-head-*`); see `owner-liveness.ts`. Removal now additionally requires the owning session to be **provably
+ * The `locked` gate is real presence-ish signal but only partially covers the pile; see
+ * `owner-liveness.ts`. Removal now additionally requires the owning session to be **provably
  * dead**: `ownerLiveness` must be `"dead"`, resolved from holder presence per ADR 0191, never from
  * age. `"alive"` and `"unknown"` both KEEP — see `owner-liveness.ts` for the resolution and for why
  * "cannot prove dead" must never collapse into "dead".
@@ -132,6 +132,14 @@ export interface WorktreeRecord {
 	 * removed only when all three are false.
 	 */
 	readonly locked: boolean;
+	/**
+	 * The lock is a crew-agent lock (`claude agent … (pid <N> …)`) whose pid is provably GONE — a
+	 * stale pin, not a live claim, so it must not keep the tree. Resolved at the boundary for the
+	 * `review-head-*` class only, whose locks this repo writes (`review-head materialize`, #4004); a
+	 * build tree's lock stays opaque, so its keep-on-`locked` behavior is unchanged. Without this,
+	 * locking review-head trees would pin every one of them forever and re-open the #2785 leak.
+	 */
+	readonly staleAgentLock: boolean;
 	readonly recentlyActive: boolean;
 	readonly hasOpenPr: boolean;
 	/**
@@ -158,7 +166,7 @@ export type KeepReason =
 	| "not-managed"
 	/** Uncommitted/untracked changes present — keep, never `--force` (unpushed work is sacred). */
 	| "dirty"
-	/** `git worktree lock` is set — an operator/agent pinned it as in-use (#2240). */
+	/** `git worktree lock` is set by a live/unattributable holder — pinned as in-use (#2240). */
 	| "locked"
 	/** The owning agent session is still running — a LIVE lane; kept whatever its other facts say (#3943). */
 	| "live-session"
@@ -194,7 +202,8 @@ export type RemoveReason =
 	/** Clean; tip not an ancestor, but the branch's content squash-merged to `origin/main` (#1328). */
 	| "squash-merged-clean"
 	/**
-	 * A `review-head-*` throwaway detached checkout that is clean + unlocked + idle (#2785). No
+	 * A `review-head-*` throwaway detached checkout that is clean + idle + not pinned by a LIVE lock
+	 * (its own crew-agent lock counts as a pin only while that session runs — #4004). No
 	 * merge gate: it holds a detached, already-pushed PR head and no branch/unpushed work, so once
 	 * it is clean, unlocked, and idle it is a pure leak — nothing to strand. Requiring merge here
 	 * would strand it for the PR's entire open life (a review is a bounded one-shot event, not tied
@@ -234,13 +243,13 @@ export interface WorktreeSweepPlan {
  *      tree with a LIVE directory are never candidates, regardless of their other facts.
  *   2. Dirty → KEEP (`dirty`). Wins over every other signal for BOTH classes: a worktree
  *      with working-tree changes is never removed, even when its branch has merged.
- *   3. Liveness gates — locked (#2240) / owner alive-or-unprovable (#3943) / launcher-alive within
- *      grace (#4001) / recently-active (#2240) → KEEP, for BOTH classes. A clean tree may still
- *      belong to a LIVE lane (a build tree just committed+pushed; a review still running against
- *      its head). These run BEFORE any remove branch, so each is a necessary condition on REMOVE.
- *      The presence gate subsumes the mtime one it sits above — an idle-but-live shipper is exactly
- *      what mtime could not see — and `recently-active` is retained below it because it can only
- *      ever KEEP more.
+ *   3. Liveness gates — locked (#2240; a STALE crew-agent lock, its session proven dead, does not
+ *      keep — #4004) / owner alive-or-unprovable (#3943) / launcher-alive within grace (#4001) /
+ *      recently-active (#2240) → KEEP, for BOTH classes. A clean tree may still belong to a LIVE
+ *      lane (a build tree just committed+pushed; a review still running against its head). These
+ *      run BEFORE any remove branch, so each is a necessary condition on REMOVE. The presence gate
+ *      subsumes the mtime one it sits above — an idle-but-live shipper is exactly what mtime could
+ *      not see — and `recently-active` is retained below it because it can only ever KEEP more.
  *
  *      The `locked` gate is what makes step 3's launcher branch safe, and its position is load-
  *      bearing: the harness holds a `git worktree lock` on an agent tree for its occupant's
@@ -248,6 +257,15 @@ export interface WorktreeSweepPlan {
  *      already had its occupancy released by the harness. That is the occupant-keyed presence
  *      signal a launcher stamp cannot be (#4001) — hence a `"launcher-alive"` owner is held only
  *      for the grace window, not forever. Never reorder `locked` below the owner gates.
+ *
+ *      `staleAgentLock` is a carve-out INSIDE that rule, not an exception to it: the gate keeps its
+ *      position, and the carve-out is scoped at the boundary to the one class the harness does NOT
+ *      lock — the `$TMPDIR`-rooted `review-head-*` trees, whose lock this repo writes itself with
+ *      the owning session's pid (#4004). A build tree's lock stays opaque and absolute, so the
+ *      occupancy premise above is untouched; and the carve-out fires only on POSITIVE proof that
+ *      the locking session's process is gone, which for that class also proves no occupant remains
+ *      (a subagent runs inside its session's process).
+
  *   4. Review-head tree → REMOVE (`review-head-idle`). Past the dirty+locked+recently-active
  *      guards, a detached throwaway review checkout holds no branch and no unpushed work, so
  *      it is a pure leak — no merge/open-PR gate applies (see `review-head-idle`). Returns here
@@ -272,7 +290,7 @@ export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	if (wt.isDirty) {
 		return {kind: "keep", reason: "dirty"};
 	}
-	if (wt.locked) {
+	if (wt.locked && !wt.staleAgentLock) {
 		return {kind: "keep", reason: "locked"};
 	}
 	if (wt.ownerLiveness === "alive") {
@@ -329,6 +347,12 @@ export interface ParsedWorktree {
 	readonly branch: string | null;
 	readonly bare: boolean;
 	readonly locked: boolean;
+	/**
+	 * The lock reason: `null` when the tree is NOT locked, `""` when locked with no reason, else the
+	 * reason string. Kept alongside `locked` because a crew-agent lock's reason carries the owning
+	 * session's pid — the presence fact that tells a live pin from a stale one (#4004).
+	 */
+	readonly lockReason: string | null;
 	/** `git worktree list --porcelain` flagged the tree `prunable` — its working dir is gone (#3654). */
 	readonly prunable: boolean;
 }
@@ -346,17 +370,19 @@ export const parseWorktreeList = (porcelain: string): ReadonlyArray<ParsedWorktr
 	let branch: string | null = null;
 	let bare = false;
 	let locked = false;
+	let lockReason: string | null = null;
 	let prunable = false;
 
 	const flush = () => {
 		if (path !== null) {
-			out.push({path, head, branch, bare, locked, prunable});
+			out.push({path, head, branch, bare, locked, lockReason, prunable});
 		}
 		path = null;
 		head = null;
 		branch = null;
 		bare = false;
 		locked = false;
+		lockReason = null;
 		prunable = false;
 	};
 
@@ -378,8 +404,12 @@ export const parseWorktreeList = (porcelain: string): ReadonlyArray<ParsedWorktr
 			branch = null;
 		} else if (line === "bare") {
 			bare = true;
-		} else if (line.startsWith("locked")) {
+		} else if (line === "locked") {
 			locked = true;
+			lockReason = "";
+		} else if (line.startsWith("locked ")) {
+			locked = true;
+			lockReason = line.slice("locked ".length);
 		} else if (line.startsWith("prunable")) {
 			prunable = true;
 		}

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -24,6 +24,7 @@ const reviewRecord = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	reachableFromOriginMain: false,
 	squashMergedToOriginMain: false,
 	locked: false,
+	staleAgentLock: false,
 	recentlyActive: false,
 	hasOpenPr: false,
 	// The fixtures default to a PROVABLY-DEAD owner so each pre-#3943 case still exercises the
@@ -41,6 +42,7 @@ const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	reachableFromOriginMain: true,
 	squashMergedToOriginMain: false,
 	locked: false,
+	staleAgentLock: false,
 	recentlyActive: false,
 	hasOpenPr: false,
 	ownerLiveness: "dead",
@@ -62,6 +64,7 @@ const shipperShaped = (over: Partial<WorktreeRecord> = {}): WorktreeRecord =>
 		reachableFromOriginMain: false,
 		squashMergedToOriginMain: true,
 		locked: false,
+		staleAgentLock: false,
 		recentlyActive: false,
 		hasOpenPr: false,
 		...over,
@@ -124,6 +127,26 @@ describe("classifyWorktree — review-head trees (#2785)", () => {
 	it("keeps a LOCKED review-head tree (an operator/agent pinned it — #2240 liveness preserved)", () => {
 		const d = classifyWorktree(reviewRecord({locked: true}));
 		assert.deepStrictEqual(d, {kind: "keep", reason: "locked"});
+	});
+
+	it("RECLAIMS one whose lock is a STALE crew-agent lock — a dead session's pin never pins forever", () => {
+		// `review-head materialize` now locks every tree it creates (#4004). Were `locked` alone a
+		// keep, that lock would pin each of them past its reviewer's death and re-open the #2785
+		// unbounded leak — so a lock whose owning session is PROVEN dead does not keep.
+		const d = classifyWorktree(reviewRecord({locked: true, staleAgentLock: true}));
+		assert.deepStrictEqual(d, {kind: "remove", reason: "review-head-idle"});
+	});
+
+	it("keeps a stale-locked tree that is still RECENTLY ACTIVE — the idle gate outlives the lock gate", () => {
+		const d = classifyWorktree(
+			reviewRecord({locked: true, staleAgentLock: true, recentlyActive: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep", reason: "recently-active"});
+	});
+
+	it("keeps a stale-locked tree that is DIRTY — recoverable work outranks every liveness signal", () => {
+		const d = classifyWorktree(reviewRecord({locked: true, staleAgentLock: true, isDirty: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "dirty"});
 	});
 
 	it("keeps a RECENTLY-ACTIVE review-head tree (a review still running against the head — #2240)", () => {
@@ -540,6 +563,7 @@ describe("parseWorktreeList", () => {
 			branch: "main",
 			bare: false,
 			locked: false,
+			lockReason: null,
 			prunable: false,
 		});
 		assert.strictEqual(parsed[1]?.branch, "umut/1234-thing");
@@ -559,6 +583,29 @@ describe("parseWorktreeList", () => {
 		const parsed = parseWorktreeList(porcelain);
 		assert.strictEqual(parsed.length, 1);
 		assert.isTrue(parsed[0]?.locked);
+		assert.strictEqual(parsed[0]?.lockReason, "some reason");
+	});
+
+	it("keeps the lock REASON — it carries the owning session's pid (#4004)", () => {
+		const reason = "claude agent review-head-4004 (pid 58975 start 2026-07-25T23:48:53.000Z)";
+		const parsed = parseWorktreeList(
+			[
+				`worktree /var/folders/8f/tmp.x/review-head-4004-aBc`,
+				"HEAD dddd4444",
+				"detached",
+				`locked ${reason}`,
+				"",
+			].join("\n"),
+		);
+		assert.strictEqual(parsed[0]?.lockReason, reason);
+	});
+
+	it("distinguishes locked-with-no-reason ('') from unlocked (null)", () => {
+		const parsed = parseWorktreeList(
+			[`worktree ${wtPath("agent-z")}`, "HEAD dddd4444", "detached", "locked", ""].join("\n"),
+		);
+		assert.isTrue(parsed[0]?.locked);
+		assert.strictEqual(parsed[0]?.lockReason, "");
 	});
 
 	it("captures a prunable (gone-dir) worktree — #3654", () => {


### PR DESCRIPTION
Fixes #4004

## What changed

`review-head materialize` created its throwaway `review-head-*` tree with a bare `git worktree add --detach` — no `--lock` — so the tree carried neither half of the presence system: no git-level fence against a `worktree remove` while a reviewer was live in it, and no provable owner once it was orphaned (the reclaimers read a worktree's owner off its lock reason, so an unlocked tree has no owner at all).

**The tree is now born locked** (`packages/pipeline-cli/src/tools/review-head/materialize.ts`), with the reason `claude agent review-head-<pr> (pid <N> start <iso>)` — the exact grammar `parseAgentLockOwner` accepts, formatted by a new pure module (`packages/pipeline-cli/src/tools/review-head/agent-lock.ts`) whose unit test round-trips the string through that parser.

**Whose pid** is the load-bearing judgment: it is the **owning session's**, resolved from the harness live-session registry (`<config>/sessions/<pid>.json`) by `$CLAUDE_CODE_SESSION_ID` — *never* this CLI process's pid, which exits seconds after `worktree add` and would present a live reviewer's tree as an instantly-reapable orphan. An unresolvable session leaves the tree **unlocked** (today's behavior) rather than pinned by a pid nobody can attribute. The registry-location rule is single-sourced in `owner-liveness.ts` (`sessionRegistryDir`), which `worktree-sweep` now consumes instead of its own copy.

## Why the two reclaimers changed too

Adding the lock in isolation would have traded one leak for a worse one, so both reclaim paths learn the new fact. This is the part that goes past the issue's one-line fix shape, and it is not optional:

- **`worktree-reap`** — the `review-head-*` class is now in scope, so an orphan resolves by presence (live pid → spared `live-session`; dead pid → reaped) instead of being spared unconditionally. Its detached head was fetched from `pull/<pr>/head`, so it is on the remote by construction: the build-tree `unpushed` gate is N/A for it and would otherwise keep every such orphan forever. The **uncommitted** gate still runs, and reclaim stays `unlock` → `remove` **without `--force`**.
- **`worktree-sweep`** — `locked` alone can no longer pin this class forever (`if (wt.locked && !wt.staleAgentLock)`); a crew-agent lock whose session is proven dead is a stale pin, and for this class the lock pid becomes the presence signal (strictly better than the stamp/path heuristic, which a multi-UUID temp root cannot resolve). Build-tree behavior is deliberately untouched — `staleAgentLock` is only ever computed for the class we lock.

Two git behaviors were **verified against real repos**, not assumed, and both are handled:

1. `git worktree remove` (no `--force`) **refuses** a locked tree → the sweep unlocks the stale lock immediately before the remove, still never `--force`.
2. `git worktree prune` **skips a locked entry**, and git also **withholds the `prunable` flag** from a locked worktree whose directory is gone. That is exactly what the gates' teardown (`rm -rf "$REVIEW_WT" && git worktree prune`) now leaves behind, so the sweep recovers the gone-dir fact itself (dir missing + our own agent lock) and unlocks before pruning. Without this the change would have re-created the #3654 stale-metadata pile.

## Acceptance criteria

- [x] `review-head materialize --worktree` creates its tree locked with a pid-bearing reason that parses to a live owner — and reports it as `lockReason` in its JSON output so the caller can see the fence exists rather than assume it.
- [x] A materialized tree with a **live** owner is spared by presence (`live-session`), and with a **dead** owner pid becomes reap-eligible — covered in `worktree-reap.unit.test.ts` and end-to-end against a real repo in `worktree-sweep/command.hook.test.ts` (live pid → KEPT, dead pid → reclaimed, torn-down locked tree → metadata pruned).
- [x] Unit coverage that the reason string materialize writes round-trips through `parseAgentLockOwner`.

## Safety

The no-`--force` house rule is intact everywhere: every reclaim is still `unlock` → `remove` with no force, and git's own refusal on a dirty tree is caught and reported as KEPT. The uncommitted/dirty guard runs ahead of every liveness signal, and each new fact fails safe toward KEEP (an unresolvable existence check reads "present", an unparseable lock reads no-owner).

`pnpm exec vitest run` in `packages/pipeline-cli`: 164 files / 2381 tests pass; `tsc --noEmit` and `biome check` clean.

## Follow-up (not in scope here)

The review gates' teardown could unlock its own tree before `rm -rf` so the metadata is reclaimed immediately instead of at the next sweep. That touches the review skills (§CP) and is an optimization, not a correctness need now that the sweep handles it — worth its own issue.
