### PR TITLE
fix(main-sync): verify the exact-pin PATH pnpm, keep corepack as the fallback

### DIFF
--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -44,9 +44,10 @@ import {Command, Flag} from "effect/unstable/cli";
 import {isControlPlaneDeletion, parseNameStatus} from "../primary-index-guard/index.ts";
 import {
 	changedPathsForceDepRefresh,
-	decidePnpmVersionGuard,
+	decidePnpmResolution,
 	depPathsForcingRefresh,
-	type PnpmVersion,
+	describePnpmResolutionFailure,
+	type PnpmProbeResult,
 	parsePackageManagerPnpm,
 	parsePnpmVersionOutput,
 } from "./dep-refresh.ts";
@@ -60,10 +61,19 @@ interface GitResult {
 
 // A best-effort captured-output runner: a non-zero exit is fully absorbed into a {ok:false}
 // GitResult the caller branches on, never the E channel — a total helper, not Effect-cosplay.
-const runCaptured = (cmd: string, args: ReadonlyArray<string>, cwd?: string): GitResult => {
+const runCaptured = (
+	cmd: string,
+	args: ReadonlyArray<string>,
+	cwd?: string,
+	timeoutMs?: number,
+): GitResult => {
 	// biome-ignore lint/plugin: see the note above — total by construction, the E channel is never used.
 	try {
-		const stdout = execFileSync(cmd, [...args], {encoding: "utf8", ...(cwd ? {cwd} : {})});
+		const stdout = execFileSync(cmd, [...args], {
+			encoding: "utf8",
+			...(cwd ? {cwd} : {}),
+			...(timeoutMs ? {timeout: timeoutMs} : {}),
+		});
 		return {ok: true, stdout, stderr: ""};
 	} catch (cause) {
 		const e = cause as {stdout?: Buffer | string; stderr?: Buffer | string};
@@ -125,6 +135,29 @@ const repoRoot = (): string | null => {
 	return r.ok && r.stdout.trim() !== "" ? r.stdout.trim() : null;
 };
 
+// `execFileSync`'s own `timeout` option — a portable Node bound, NOT the `timeout(1)` binary,
+// which some crew shells don't have. Only the PATH leg gets it: a corepack first run may DOWNLOAD
+// the pinned pnpm, and killing that would turn a slow network into a false refusal.
+const PATH_PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * The IO half of the ordered pnpm resolution (#4063): run one `--version` probe and report what
+ * it OBSERVED. A missing binary, a stripped PATH, a non-zero exit, and a timeout all land here as
+ * `probe-failed` — "unknown", never "wrong version"; only a probe that ran and printed a parseable
+ * version reports a version at all.
+ */
+const probePnpmVersion = (
+	cmd: string,
+	args: ReadonlyArray<string>,
+	cwd: string,
+	timeoutMs?: number,
+): PnpmProbeResult => {
+	const r = runCaptured(cmd, args, cwd, timeoutMs);
+	if (!r.ok) return {ran: false, cause: "probe-failed"};
+	const version = parsePnpmVersionOutput(r.stdout);
+	return version === null ? {ran: false, cause: "unparseable-output"} : {ran: true, version};
+};
+
 /** The `packageManager` pin from the root package.json, or `undefined` if unreadable/absent. */
 const readPackageManagerPin = (root: string): string | undefined => {
 	// biome-ignore lint/plugin: total pre-runtime helper — a missing file / bad JSON maps to `undefined`, which the guard treats as unresolved-required (fail-closed); no E channel to model.
@@ -142,11 +175,11 @@ const readPackageManagerPin = (root: string): string | undefined => {
  * Re-install deps after a ff merge IFF the merge pulled a `patches/**`/`pnpm-lock.yaml`
  * change — the #3498 fix. Without it the ff advances the SOURCE patch/lockfile but not the
  * installed `.pnpm/…/patched` copy the runtime executes, so a re-booted crew silently runs
- * the PRE-merge patched dep (a merged fix reads as "still broken"). Resolves pnpm via corepack
- * against the repo's `packageManager` pin — NEVER a bare-PATH pnpm, whose wrong major silently
- * leaves a stale patched dir — and FAILS LOUD (exit 1) if it can't resolve the pinned pnpm, the
- * resolved major mismatches the repo requirement, or the frozen install fails. `preSha` is HEAD
- * captured immediately before the merge, so `preSha..HEAD` is exactly what the ff pulled.
+ * the PRE-merge patched dep (a merged fix reads as "still broken"). Resolves pnpm against the
+ * repo's `packageManager` pin through the ordered strategy in `dep-refresh.ts` — a PATH pnpm at
+ * EXACTLY the pin, else corepack — and FAILS LOUD (exit 1) if neither resolves it or the frozen
+ * install fails. `preSha` is HEAD captured immediately before the merge, so `preSha..HEAD` is
+ * exactly what the ff pulled.
  */
 const refreshDepsAfterMerge = Effect.fn(function* (preSha: string) {
 	const diff = runGit(["diff", "--name-only", preSha, "HEAD"]);
@@ -177,41 +210,31 @@ const refreshDepsAfterMerge = Effect.fn(function* (preSha: string) {
 	}
 
 	const required = parsePackageManagerPnpm(readPackageManagerPin(root));
-	// Resolve pnpm via corepack AGAINST THE PIN (`corepack pnpm@<version> …`), never the bare-PATH
-	// pnpm — the wrong-major hazard #3498 exists to close. A failed probe ⇒ unresolved ⇒ fail-closed.
-	let resolved: PnpmVersion | null = null;
-	if (required !== null) {
-		const ver = runCaptured("corepack", [`pnpm@${required.version}`, "--version"], root);
-		resolved = ver.ok ? parsePnpmVersionOutput(ver.stdout) : null;
-	}
-	const guard = decidePnpmVersionGuard(required, resolved);
-	if (!guard.ok) {
-		const detail =
-			guard.reason === "unresolved-required"
-				? "the root package.json `packageManager` pin is absent or unparseable — cannot determine the required pnpm major"
-				: guard.reason === "unresolved-pnpm"
-					? "could not resolve the repo-pinned pnpm via corepack (corepack absent or errored) — refusing to fall back to a bare-PATH pnpm, whose wrong major silently leaves a stale patched dir"
-					: `resolved pnpm ${guard.resolved.version} (major ${guard.resolved.major}) does NOT match the repo-required major ${guard.required.major} (${guard.required.version}) — a wrong-major install silently leaves a stale patched dir`;
-		const provision = required
-			? `corepack pnpm@${required.version} install --frozen-lockfile`
-			: "corepack pnpm install --frozen-lockfile";
+	const resolution = decidePnpmResolution(
+		required,
+		probePnpmVersion("pnpm", ["--version"], root, PATH_PROBE_TIMEOUT_MS),
+		(pin) => probePnpmVersion("corepack", [`pnpm@${pin.version}`, "--version"], root),
+	);
+	if (!resolution.ok) {
+		const {detail, remedy} = describePnpmResolutionFailure(resolution);
 		yield* Console.error(
-			`main-sync dep refresh FAILED (fail-closed): the merge changed ${forcing.join(", ")} but ${detail}. node_modules is STALE and a re-booted crew would run the PRE-merge patched dep (#3498). Provision with the pinned pnpm (\`${provision}\`) and re-run.`,
+			`main-sync dep refresh FAILED (fail-closed): the merge changed ${forcing.join(", ")} but the repo-pinned pnpm did not resolve — ${detail}. node_modules is STALE and a re-booted crew would run the PRE-merge patched dep (#3498). To recover: ${remedy}.`,
 		);
 		return yield* Effect.sync(() => process.exit(1));
 	}
 
+	const install: readonly [string, ReadonlyArray<string>] =
+		resolution.resolver === "path"
+			? ["pnpm", ["install", "--frozen-lockfile"]]
+			: ["corepack", [`pnpm@${resolution.resolved.version}`, "install", "--frozen-lockfile"]];
+	const shown = `${install[0]} ${install[1].join(" ")}`;
 	yield* Console.log(
-		`  dep refresh: resolved pnpm ${guard.resolved.version} via corepack (matches the pinned major ${guard.resolved.major}) — running the frozen-lockfile install.`,
+		`  dep refresh: resolved pnpm ${resolution.resolved.version} via ${resolution.resolver === "path" ? "the PATH pnpm (exactly the pinned version)" : "corepack (matches the pinned major)"} — running \`${shown}\`.`,
 	);
-	const installed = runCaptured(
-		"corepack",
-		[`pnpm@${guard.resolved.version}`, "install", "--frozen-lockfile"],
-		root,
-	);
+	const installed = runCaptured(install[0], install[1], root);
 	if (!installed.ok) {
 		yield* Console.error(
-			`main-sync dep refresh FAILED (fail-closed): \`corepack pnpm@${guard.resolved.version} install --frozen-lockfile\` exited non-zero — ${installed.stderr.trim() || "install error"}. node_modules may be STALE (#3498). Resolve the install by hand before booting the crew.`,
+			`main-sync dep refresh FAILED (fail-closed): \`${shown}\` exited non-zero — ${installed.stderr.trim() || "install error"}. node_modules may be STALE (#3498). Resolve the install by hand before booting the crew.`,
 		);
 		return yield* Effect.sync(() => process.exit(1));
 	}

--- a/packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts
@@ -8,7 +8,13 @@
  * SOURCE patch/lockfile but never the installed `.pnpm/…/patched` copy the runtime
  * executes — so a re-booted crew silently runs the PRE-merge patched dep (a merged fix
  * reads as "still broken"). The fix re-installs with the REPO-PINNED pnpm on any such ff,
- * or FAILS LOUD — never a bare-PATH pnpm (whose wrong major silently leaves a stale dir).
+ * or FAILS LOUD — never an unverified PATH pnpm (whose wrong major silently leaves a stale dir).
+ *
+ * The pin resolves through an ORDERED strategy (#4063): a PATH pnpm whose full version is
+ * EXACTLY the pin, else corepack, else fail closed. Exact equality is strictly stronger than
+ * the major-only comparison the corepack path already trusts, so admitting it cannot reopen
+ * the hazard above — while a corepack-less machine (volta ships none) stops dead-ending in a
+ * refusal whose printed remedy was itself un-runnable there.
  */
 
 /** A semver-ish pnpm version reduced to what the guard needs: the full string + its major. */
@@ -70,8 +76,8 @@ export type PnpmGuardResult =
 	| {readonly ok: true; readonly resolved: PnpmVersion}
 	// The `packageManager` pin was absent/unparseable — the required version is unknown.
 	| {readonly ok: false; readonly reason: "unresolved-required"}
-	// `corepack pnpm --version` didn't resolve (corepack absent / errored) — never fall back to
-	// a bare-PATH pnpm, which is the wrong-major hazard this whole fix exists to close.
+	// `corepack pnpm --version` didn't resolve (corepack absent / errored). The only sanctioned
+	// PATH pnpm is an EXACT pin match, decided upstream by `classifyPathPnpm` — never here.
 	| {readonly ok: false; readonly reason: "unresolved-pnpm"}
 	// Resolved pnpm's major differs from the repo requirement — a `pnpm@8` install silently
 	// leaves a stale patched dir (#3498), so fail closed instead of installing under it.
@@ -83,9 +89,11 @@ export type PnpmGuardResult =
 	  };
 
 /**
- * Decide the pnpm-version guard. Total over the two nullable inputs (required = the parsed
- * `packageManager` pin, resolved = the parsed `corepack pnpm --version`): a `null` on either
- * side is a fail-closed refusal, and only an equal-major pair authorizes the install.
+ * Decide the pnpm-version guard for the COREPACK leg. Total over the two nullable inputs
+ * (required = the parsed `packageManager` pin, resolved = the parsed `corepack pnpm --version`):
+ * a `null` on either side is a fail-closed refusal, and only an equal-major pair authorizes the
+ * install. Major-only is right here because corepack was asked for `pnpm@<pin>` by name; the PATH
+ * leg, which asks for nothing, is held to exact equality instead (`classifyPathPnpm`).
  */
 export const decidePnpmVersionGuard = (
 	required: PnpmVersion | null,
@@ -97,4 +105,147 @@ export const decidePnpmVersionGuard = (
 		return {ok: false, reason: "major-mismatch", required, resolved};
 	}
 	return {ok: true, resolved};
+};
+
+/**
+ * Why a `pnpm --version` probe yielded no version. Both values mean the SAME thing to the
+ * decision — the version is UNKNOWN, not wrong — and that distinction is the point: a probe
+ * that could not execute (missing binary, stripped PATH, non-zero exit, timeout) must never be
+ * reported as "the pnpm on this machine is the wrong version". Only a probe that actually ran
+ * and produced a version may conclude that.
+ */
+export type PnpmProbeFailure = "probe-failed" | "unparseable-output";
+
+/** The outcome of one IO probe of a pnpm binary, as handed to the pure decision. */
+export type PnpmProbeResult =
+	| {readonly ran: true; readonly version: PnpmVersion}
+	| {readonly ran: false; readonly cause: PnpmProbeFailure};
+
+/**
+ * The three outcomes of checking the PATH `pnpm` against the pin — deliberately three, not two.
+ * `version-mismatch` is a VERIFIED fact about this machine (a pnpm ran and it is not the pin);
+ * `undetermined` is the absence of any fact. They demand different remedies, so they are never
+ * collapsed into one refusal (#4063).
+ */
+export type PathPnpmVerdict =
+	| {readonly kind: "exact-match"; readonly version: PnpmVersion}
+	| {
+			readonly kind: "version-mismatch";
+			readonly required: PnpmVersion;
+			readonly found: PnpmVersion;
+	  }
+	| {readonly kind: "undetermined"; readonly cause: PnpmProbeFailure | "no-required-version"};
+
+/**
+ * Classify a PATH `pnpm --version` probe against the pin. Acceptance is FULL-STRING equality,
+ * never the major-only comparison the corepack leg uses: the PATH pnpm is authorized only when
+ * it is provably the pinned binary.
+ */
+export const classifyPathPnpm = (
+	required: PnpmVersion | null,
+	probe: PnpmProbeResult,
+): PathPnpmVerdict => {
+	if (required === null) return {kind: "undetermined", cause: "no-required-version"};
+	if (!probe.ran) return {kind: "undetermined", cause: probe.cause};
+	if (probe.version.version !== required.version) {
+		return {kind: "version-mismatch", required, found: probe.version};
+	}
+	return {kind: "exact-match", version: probe.version};
+};
+
+/** Which strategy produced the pnpm the install runs under — reported so a transcript names it. */
+export type PnpmResolver = "path" | "corepack";
+
+/**
+ * The ordered resolution's outcome. A refusal carries BOTH legs' reasons, so the message can say
+ * what is actually true of the machine rather than blaming whichever leg happened to run last.
+ */
+export type PnpmResolution =
+	| {readonly ok: true; readonly resolver: PnpmResolver; readonly resolved: PnpmVersion}
+	| {
+			readonly ok: false;
+			/** The pin itself, `null` only when it was the pin that failed to parse. */
+			readonly required: PnpmVersion | null;
+			// An exact match authorizes the install, so it can never be a refusal's reason.
+			readonly path: Exclude<PathPnpmVerdict, {kind: "exact-match"}>;
+			readonly corepack: Extract<PnpmGuardResult, {ok: false}>;
+	  };
+
+/**
+ * Resolve the pnpm the install runs under: PATH-exact, else corepack, else fail closed.
+ *
+ * `probeCorepack` is a thunk so the corepack probe is NOT run when PATH already matched (and can
+ * never be run without a pin to ask for); the IO itself stays at the `command.ts` boundary, and
+ * this stays a total decision a unit test can drive.
+ */
+export const decidePnpmResolution = (
+	required: PnpmVersion | null,
+	pathProbe: PnpmProbeResult,
+	probeCorepack: (required: PnpmVersion) => PnpmProbeResult,
+): PnpmResolution => {
+	const path = classifyPathPnpm(required, pathProbe);
+	if (path.kind === "exact-match") return {ok: true, resolver: "path", resolved: path.version};
+	if (required === null) {
+		return {ok: false, required, path, corepack: {ok: false, reason: "unresolved-required"}};
+	}
+
+	const probe = probeCorepack(required);
+	const guard = decidePnpmVersionGuard(required, probe.ran ? probe.version : null);
+	if (guard.ok) return {ok: true, resolver: "corepack", resolved: guard.resolved};
+	return {ok: false, required, path, corepack: guard};
+};
+
+/** The `detail` + `remedy` halves of the fail-closed message, split so each is asserted directly. */
+export interface PnpmResolutionFailureMessage {
+	readonly detail: string;
+	readonly remedy: string;
+}
+
+const describePathLeg = (path: Exclude<PathPnpmVerdict, {kind: "exact-match"}>): string => {
+	switch (path.kind) {
+		case "version-mismatch":
+			return `PATH \`pnpm\` ran and reported ${path.found.version}, which is NOT the pinned ${path.required.version} — a non-exact PATH pnpm is never used for the install`;
+		case "undetermined":
+			return path.cause === "no-required-version"
+				? "the PATH pnpm was not checked (no pin to check it against)"
+				: "PATH `pnpm` could not be probed (absent, not on PATH, or the probe errored), so its version is UNKNOWN — not wrong";
+	}
+};
+
+const describeCorepackLeg = (corepack: Extract<PnpmGuardResult, {ok: false}>): string => {
+	switch (corepack.reason) {
+		case "unresolved-required":
+			return "the root package.json `packageManager` pin is absent or unparseable — cannot determine the required pnpm version";
+		case "unresolved-pnpm":
+			return "corepack could not resolve the pinned pnpm either (corepack absent or errored)";
+		case "major-mismatch":
+			return `corepack resolved pnpm ${corepack.resolved.version} (major ${corepack.resolved.major}), which does NOT match the repo-required major ${corepack.required.major} (${corepack.required.version})`;
+	}
+};
+
+/**
+ * Build the fail-closed message. The remedy is chosen from what the machine has PROVEN it has, so
+ * it is never `corepack …` on a machine whose corepack is the thing that just failed (#4063) — a
+ * printed recovery the operator cannot run is worse than none.
+ */
+export const describePnpmResolutionFailure = (
+	failure: Extract<PnpmResolution, {ok: false}>,
+): PnpmResolutionFailureMessage => {
+	const {path, corepack} = failure;
+	if (corepack.reason === "unresolved-required") {
+		return {
+			detail: describeCorepackLeg(corepack),
+			remedy:
+				"restore the root package.json `packageManager` pin (a `pnpm@<full-version>` string), then re-run",
+		};
+	}
+	const pin = failure.required?.version ?? null;
+	const pinned = pin === null ? "the pinned pnpm" : `pnpm@${pin}`;
+	// A verified-wrong PATH pnpm still proves a working pnpm exists, so `pnpm dlx` is runnable
+	// there; an undetermined PATH proves nothing, so the remedy is to install the pin outright.
+	const remedy =
+		path.kind === "version-mismatch"
+			? `run \`pnpm dlx ${pinned} install --frozen-lockfile\` from the repo root, or pin pnpm to ${pin} in your toolchain manager, then re-run`
+			: `install ${pinned} with your toolchain manager (or enable corepack), then re-run`;
+	return {detail: `${describePathLeg(path)}; ${describeCorepackLeg(corepack)}`, remedy};
 };

--- a/packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts
@@ -1,8 +1,12 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
 	changedPathsForceDepRefresh,
+	classifyPathPnpm,
+	decidePnpmResolution,
 	decidePnpmVersionGuard,
 	depPathsForcingRefresh,
+	describePnpmResolutionFailure,
+	type PnpmProbeResult,
 	type PnpmVersion,
 	parsePackageManagerPnpm,
 	parsePnpmVersionOutput,
@@ -136,5 +140,165 @@ describe("decidePnpmVersionGuard — candidate 3, folded into the install path",
 			ok: false,
 			reason: "unresolved-required",
 		});
+	});
+});
+
+const v = (version: string, major: number): PnpmVersion => ({version, major});
+const PIN = v("10.27.0", 10);
+const ran = (version: PnpmVersion): PnpmProbeResult => ({ran: true, version});
+const failed: PnpmProbeResult = {ran: false, cause: "probe-failed"};
+const unparseable: PnpmProbeResult = {ran: false, cause: "unparseable-output"};
+
+describe("classifyPathPnpm — three outcomes, and 'could not run' is never 'wrong version'", () => {
+	it("PATH pnpm exactly equal to the pin → exact-match", () => {
+		assert.deepStrictEqual(classifyPathPnpm(PIN, ran(v("10.27.0", 10))), {
+			kind: "exact-match",
+			version: v("10.27.0", 10),
+		});
+	});
+
+	it("same major, different patch → version-mismatch (exact equality, NOT the corepack leg's major rule)", () => {
+		assert.deepStrictEqual(classifyPathPnpm(PIN, ran(v("10.28.1", 10))), {
+			kind: "version-mismatch",
+			required: PIN,
+			found: v("10.28.1", 10),
+		});
+	});
+
+	it("wrong major → version-mismatch (the #3498 hazard stays closed)", () => {
+		const verdict = classifyPathPnpm(PIN, ran(v("8.15.6", 8)));
+		assert.strictEqual(verdict.kind, "version-mismatch");
+	});
+
+	it("an unrunnable probe is UNDETERMINED, not a mismatch (absent binary / stripped PATH / timeout)", () => {
+		assert.deepStrictEqual(classifyPathPnpm(PIN, failed), {
+			kind: "undetermined",
+			cause: "probe-failed",
+		});
+	});
+
+	it("output that parsed to nothing is undetermined too — it observed no version", () => {
+		assert.deepStrictEqual(classifyPathPnpm(PIN, unparseable), {
+			kind: "undetermined",
+			cause: "unparseable-output",
+		});
+	});
+
+	it("no pin → undetermined; a PATH pnpm can't be checked against nothing", () => {
+		assert.deepStrictEqual(classifyPathPnpm(null, ran(v("10.27.0", 10))), {
+			kind: "undetermined",
+			cause: "no-required-version",
+		});
+	});
+});
+
+describe("decidePnpmResolution — PATH-exact, else corepack, else fail closed", () => {
+	const neverProbed = (): PnpmProbeResult => {
+		throw new Error("corepack must not be probed");
+	};
+
+	it("an exactly-pinned PATH pnpm authorizes the install and corepack is never probed", () => {
+		assert.deepStrictEqual(decidePnpmResolution(PIN, ran(v("10.27.0", 10)), neverProbed), {
+			ok: true,
+			resolver: "path",
+			resolved: v("10.27.0", 10),
+		});
+	});
+
+	it("corepack-less machine + exactly-pinned PATH pnpm → ok (the #4063 volta case)", () => {
+		const r = decidePnpmResolution(PIN, ran(v("10.27.0", 10)), () => failed);
+		assert.deepStrictEqual(r, {ok: true, resolver: "path", resolved: v("10.27.0", 10)});
+	});
+
+	it("no PATH pnpm → falls back to corepack, which authorizes on a matching major", () => {
+		assert.deepStrictEqual(
+			decidePnpmResolution(PIN, failed, () => ran(v("10.28.1", 10))),
+			{
+				ok: true,
+				resolver: "corepack",
+				resolved: v("10.28.1", 10),
+			},
+		);
+	});
+
+	it("a NON-exact PATH pnpm is never used for the install — the fallback still runs", () => {
+		const r = decidePnpmResolution(PIN, ran(v("8.15.6", 8)), () => ran(v("10.27.0", 10)));
+		assert.deepStrictEqual(r, {ok: true, resolver: "corepack", resolved: v("10.27.0", 10)});
+	});
+
+	it("a wrong-version PATH pnpm with no corepack → fail closed, carrying BOTH legs' reasons", () => {
+		const r = decidePnpmResolution(PIN, ran(v("8.15.6", 8)), () => failed);
+		assert.deepStrictEqual(r, {
+			ok: false,
+			required: PIN,
+			path: {kind: "version-mismatch", required: PIN, found: v("8.15.6", 8)},
+			corepack: {ok: false, reason: "unresolved-pnpm"},
+		});
+	});
+
+	it("neither resolver runs → fail closed, with the PATH leg reported as UNDETERMINED", () => {
+		const r = decidePnpmResolution(PIN, failed, () => failed);
+		assert.deepStrictEqual(r, {
+			ok: false,
+			required: PIN,
+			path: {kind: "undetermined", cause: "probe-failed"},
+			corepack: {ok: false, reason: "unresolved-pnpm"},
+		});
+	});
+
+	it("corepack resolves the wrong major → fail closed on major-mismatch", () => {
+		const r = decidePnpmResolution(PIN, failed, () => ran(v("8.15.6", 8)));
+		assert.isFalse(r.ok);
+		assert.deepStrictEqual(r.ok === false && r.corepack, {
+			ok: false,
+			reason: "major-mismatch",
+			required: PIN,
+			resolved: v("8.15.6", 8),
+		});
+	});
+
+	it("no pin → fail closed without probing corepack at all", () => {
+		assert.deepStrictEqual(decidePnpmResolution(null, ran(v("10.27.0", 10)), neverProbed), {
+			ok: false,
+			required: null,
+			path: {kind: "undetermined", cause: "no-required-version"},
+			corepack: {ok: false, reason: "unresolved-required"},
+		});
+	});
+});
+
+describe("describePnpmResolutionFailure — a remedy the machine can actually run", () => {
+	const failureOf = (path: PnpmProbeResult, corepack: () => PnpmProbeResult) => {
+		const r = decidePnpmResolution(PIN, path, corepack);
+		assert.isFalse(r.ok);
+		if (r.ok) throw new Error("unreachable");
+		return describePnpmResolutionFailure(r);
+	};
+
+	it("no corepack anywhere → the remedy never tells the operator to run corepack", () => {
+		const {detail, remedy} = failureOf(failed, () => failed);
+		assert.notInclude(remedy, "corepack pnpm@");
+		assert.include(remedy, "install pnpm@10.27.0");
+		assert.include(detail, "UNKNOWN");
+	});
+
+	it("a verified-wrong PATH pnpm is reported as wrong, and its remedy uses the pnpm that exists", () => {
+		const {detail, remedy} = failureOf(ran(v("8.15.6", 8)), () => failed);
+		assert.include(detail, "8.15.6");
+		assert.include(detail, "NOT the pinned 10.27.0");
+		assert.include(remedy, "pnpm dlx pnpm@10.27.0 install --frozen-lockfile");
+	});
+
+	it("an undetermined PATH is never described as a wrong version", () => {
+		const {detail} = failureOf(failed, () => failed);
+		assert.notInclude(detail, "NOT the pinned");
+		assert.include(detail, "not wrong");
+	});
+
+	it("an unparseable pin routes to the fix-the-pin remedy", () => {
+		const r = decidePnpmResolution(null, failed, () => failed);
+		assert.isFalse(r.ok);
+		if (r.ok) throw new Error("unreachable");
+		assert.include(describePnpmResolutionFailure(r).remedy, "packageManager");
 	});
 });


### PR DESCRIPTION
`pipeline-cli main-sync --post-merge --execute` re-installs deps after a fast-forward that moves the lockfile or a patch. It looked for the repo-pinned pnpm through corepack and nowhere else — so on a machine with no corepack (volta deliberately ships none) every such sync dead-ended, and the recovery command it printed was itself a `corepack …` line the operator could not run.

It now looks on PATH first: if `pnpm --version` is *exactly* the `packageManager` pin, that is provably the pinned binary, so the install runs under it. Corepack stays as the fallback, and if neither resolves the pin the tool still fails closed and exits non-zero — the stale-`node_modules` guard from #3498 is untouched.

The interesting part is what the tool now says when it refuses. The PATH check has **three** outcomes, not two, and it never conflates them:

- **verified-correct** — a pnpm ran and its full version equals the pin. Install authorized under PATH; corepack is never even probed.
- **verified-wrong** — a pnpm ran and reported a different version. Never used for the install (an exact match is strictly stronger than the major-only rule the corepack leg already trusts, so #3498 cannot reopen). The fallback still runs, and if it also fails the message states the observed version and that it is not the pin.
- **could-not-determine** — the probe could not execute at all: binary absent, PATH stripped, non-zero exit, or the bound below tripped. This reports the version as **UNKNOWN, not wrong**. A probe that could not run is never evidence that anything is misconfigured.

The remedy line is built from what the machine has *proven* it has, so it never names the tool whose absence caused the failure: a verified-wrong PATH pnpm gets `pnpm dlx pnpm@<pin> install --frozen-lockfile` (a working pnpm demonstrably exists there), an undetermined PATH gets "install the pin with your toolchain manager". The success log names the resolver — PATH or corepack — so an operator can tell the two apart from the transcript.

## What changed

- `packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts` — new pure core: `PnpmProbeResult` (what an IO probe *observed*), `classifyPathPnpm` (the three-outcome verdict, full-string equality), `decidePnpmResolution` (PATH-exact → corepack → fail closed), and `describePnpmResolutionFailure` (detail + a runnable remedy). `decidePnpmVersionGuard` is unchanged and still owns the corepack leg's major-only rule.
- `packages/pipeline-cli/src/tools/main-sync/command.ts` — the IO boundary: one `probePnpmVersion` helper that maps an unrunnable probe to `probe-failed` rather than a version claim, and the ordered call. The corepack probe is a thunk, so it is not run when PATH already matched.
- `packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts` — 20 new cases covering the three outcomes, the ordering, the fallback, both fail-closed shapes, and the remedy text.

## Notes for the reviewer

- **Probe bounding.** The PATH probe is bounded with `execFileSync`'s own `timeout` option — a portable Node option, deliberately *not* the `timeout(1)` binary, which is absent on some crew shells and would make a missing wrapper indistinguishable from a real failure. The corepack leg is passed no bound on purpose: its first run may download the pinned pnpm, and killing that would turn a slow network into a false refusal. A tripped bound lands as could-not-determine, never as a version claim.
- **PATH-resilience.** Nothing here becomes newly fatal on a missing binary. `runCaptured` already absorbs a spawn failure into `{ok: false}`; the new probe maps that to "unknown" and moves on to the next strategy.
- **Verified against a real environment**, per the triage note not to take the report on faith: on this machine `pnpm` is volta-managed at exactly 10.27.0 and `corepack` is not on PATH. End-to-end, the resolution returns `{ok: true, resolver: "path", resolved: 10.27.0}` — the case that previously dead-ended.

Fixes #4063