### PR TITLE
fix(homing-guard): red on BOTH a milestone and a standing-lane label, not just neither (#4069)

### DIFF
--- a/.github/workflows/homing-guard.yml
+++ b/.github/workflows/homing-guard.yml
@@ -75,14 +75,14 @@ jobs:
           # filed issue body, not command substitution — nothing in it may expand.
           # shellcheck disable=SC2016
           gh issue create --repo "$GITHUB_REPOSITORY" \
-            --title "homing-guard: triaged issues left without a home" \
+            --title "homing-guard: triaged issues break home-xor-exempt" \
             --label "status:needs-triage" \
-            --body "$(printf 'The weekly homing-guard sweep found triaged issues carrying neither a milestone nor a standing-lane label. Home, exempt, or kill each one per the triage rubric (ADR 0202/0208).\n\nGuard output:\n\n```\n%s\n```\n' "$(cat guard-output.txt)")"
+            --body "$(printf 'The weekly homing-guard sweep found triaged issues that carry neither a milestone nor a standing-lane label, or that carry both. Give each one exactly one home per the triage rubric (ADR 0202/0208) — the guard output below names the remedy for each class.\n\nGuard output:\n\n```\n%s\n```\n' "$(cat guard-output.txt)")"
 
       # Red the run for the blocking triggers (an issue event, a manual dispatch). On a
       # schedule run the drift was already reported as an issue above.
-      - name: Fail the job on an un-homed issue (blocking triggers)
+      - name: Fail the job on a homing violation (blocking triggers)
         if: ${{ github.event_name != 'schedule' && steps.guard.outputs.code != '0' }}
         run: |
-          echo "homing-guard: a triaged issue has no home — see the check step output above." >&2
+          echo "homing-guard: a triaged issue has no home, or claims two — see the check step output above." >&2
           exit 1

--- a/packages/pipeline-cli/src/tools/homing-guard/homing-guard.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/homing-guard.ts
@@ -1,17 +1,18 @@
 /**
  * `homing-guard` pure core — decide whether every `status:triaged` issue left triage with
- * a home. The invariant is the triage rubric's home-or-exempt-or-kill outcome (ADR 0202
- * forward-motion doctrine, ADR 0208 standing-lane exemption): a triaged issue carries an
- * arc/campaign milestone, or one of exactly two standing-lane labels, or it was killed and
- * is no longer open. IO-free and total — the `gh api` read lives in `github.ts`/`gate.ts`.
+ * exactly one home. Home and exemption are MUTUALLY EXCLUSIVE (ADR 0202 forward-motion
+ * doctrine, ADR 0208 standing-lane exemption): a triaged issue carries an arc/campaign
+ * milestone, or one of exactly two standing-lane labels, or it was killed and is no longer
+ * open — never both marks at once, which ADR 0208 bans outright. IO-free and total — the
+ * `gh api` read lives in `github.ts`/`gate.ts`.
  *
  * The guard is the teeth behind the rubric: without it the rubric lands advisory-only and
  * floaters regrow at the seam, which is the "teeth in a sweep, not at the seam" anti-pattern
  * ADR 0202 bans (#3939).
  *
- * Deliberately NOT enforced here: ADR 0208's inverse ban (a milestone on an exempt lane).
- * That is a different invariant with a different remediation, and folding it in would red a
- * backlog for a defect this guard's report cannot explain (#3939 scope).
+ * Both directions of the invariant red here (#4069). Enforcing only the neither-marked half
+ * read as full coverage downstream while double-marked issues landed in the `homed` count —
+ * the milestone-counts-lie failure ADR 0202/0208 exist to prevent.
  */
 
 /**
@@ -44,17 +45,29 @@ export interface TriagedIssue {
  */
 export type Scope = {readonly _tag: "backlog"} | {readonly _tag: "issue"; readonly number: number};
 
-/** How one triaged issue resolves against home-or-exempt. */
-export type Disposition = "homed" | "exempt" | "unhomed";
+/** How one triaged issue resolves against home-xor-exempt. The two right-hand cases are defects. */
+export type Disposition = "homed" | "exempt" | "unhomed" | "double-marked";
 
-export interface Unhomed {
-	readonly number: number;
-	readonly title: string;
-}
+/**
+ * One issue that violates the invariant, tagged by which half it broke. One list of tagged
+ * offenders rather than two parallel arrays keeps "a failing verdict names at least one
+ * offender" the single non-empty check `judge` already made, with no both-empty state to
+ * represent — and the report renders each kind under its own remedy.
+ */
+export type Violation =
+	| {readonly kind: "unhomed"; readonly number: number; readonly title: string}
+	| {
+			readonly kind: "double-marked";
+			readonly number: number;
+			readonly title: string;
+			readonly milestone: number;
+			/** The standing-lane labels it carries alongside the milestone — the mark to drop, or keep. */
+			readonly lanes: ReadonlyArray<string>;
+	  };
 
 /**
  * The verdict. A discriminated union so an invalid state is unrepresentable: a pass carries
- * only counts, the zero-scope fail carries the scope it found empty, and the unhomed fail
+ * only counts, the zero-scope fail carries the scope it found empty, and the violation fail
  * carries its non-empty offender list.
  */
 export type HomingGuardVerdict =
@@ -73,23 +86,42 @@ export type HomingGuardVerdict =
 	  }
 	| {
 			readonly pass: false;
-			readonly reason: "unhomed";
+			readonly reason: "violations";
 			readonly scope: Scope;
 			readonly scanned: number;
 			readonly homed: number;
 			readonly exempt: number;
-			readonly unhomed: ReadonlyArray<Unhomed>;
+			readonly violations: ReadonlyArray<Violation>;
 	  };
 
 /**
- * Resolve one issue. A milestone homes it; failing that, either standing-lane label exempts
- * it. An issue carrying both is `homed` — that combination is ADR 0208's inverse ban, which
- * this guard does not enforce (see the module docblock).
+ * How one issue resolved: a clean outcome, or the `Violation` it is — one shape, so a defect
+ * always arrives carrying the detail its remedy needs, and the rule is stated in one place.
  */
-export const disposition = (issue: TriagedIssue): Disposition => {
-	if (issue.milestone !== null) return "homed";
-	return issue.labels.some((l) => EXEMPT_LABELS.includes(l)) ? "exempt" : "unhomed";
+export type Resolution = {readonly kind: "homed"} | {readonly kind: "exempt"} | Violation;
+
+/** The standing-lane labels this issue carries (ADR 0208's exact two, no prefix matching). */
+export const standingLanes = (issue: TriagedIssue): ReadonlyArray<string> =>
+	issue.labels.filter((l) => EXEMPT_LABELS.includes(l));
+
+/**
+ * Resolve one issue against home-xor-exempt. A milestone homes it and a standing-lane label
+ * exempts it, but carrying both is `double-marked` — ADR 0208 bans that combination in its
+ * Banned list, and it never counts as homed.
+ */
+export const resolve = (issue: TriagedIssue): Resolution => {
+	const lanes = standingLanes(issue);
+	const {number, title} = issue;
+	if (issue.milestone !== null) {
+		return lanes.length > 0
+			? {kind: "double-marked", number, title, milestone: issue.milestone, lanes}
+			: {kind: "homed"};
+	}
+	return lanes.length > 0 ? {kind: "exempt"} : {kind: "unhomed", number, title};
 };
+
+/** The bare outcome of `resolve` — the four-way answer, without the offender detail. */
+export const disposition = (issue: TriagedIssue): Disposition => resolve(issue).kind;
 
 /**
  * Judge the scanned set.
@@ -110,32 +142,33 @@ export const judge = (
 			: {pass: true, scope, scanned: 0, homed: 0, exempt: 0};
 	}
 
-	const unhomed: Array<Unhomed> = [];
+	const violations: Array<Violation> = [];
 	let homed = 0;
 	let exempt = 0;
 	for (const issue of issues) {
-		switch (disposition(issue)) {
+		const resolution = resolve(issue);
+		switch (resolution.kind) {
 			case "homed":
 				homed++;
 				break;
 			case "exempt":
 				exempt++;
 				break;
-			case "unhomed":
-				unhomed.push({number: issue.number, title: issue.title});
+			default:
+				violations.push(resolution);
 				break;
 		}
 	}
 
-	if (unhomed.length > 0) {
+	if (violations.length > 0) {
 		return {
 			pass: false,
-			reason: "unhomed",
+			reason: "violations",
 			scope,
 			scanned: issues.length,
 			homed,
 			exempt,
-			unhomed,
+			violations,
 		};
 	}
 	return {pass: true, scope, scanned: issues.length, homed, exempt};
@@ -144,14 +177,34 @@ export const judge = (
 const scopeLabel = (scope: Scope): string =>
 	scope._tag === "backlog" ? "the open status:triaged backlog" : `issue #${scope.number}`;
 
-/** The remediation, stated once — the three outcomes the triage rubric allows. */
-const REMEDY =
+/** The un-homed remediation, stated once — the three outcomes the triage rubric allows. */
+const UNHOMED_REMEDY =
 	"Each issue above left triage un-homed. Give it one of the three home-or-exempt-or-kill outcomes\n" +
 	"(claude-plugins/kampus-pipeline/skills/triage/SKILL.md, ADR 0202/0208):\n" +
 	"  1. home it in an EXISTING open arc/campaign milestone from ROADMAP.md (triage never creates one);\n" +
 	`  2. label it a standing lane — ${EXEMPT_LABELS.join(" or ")} — when it is milestone-less by design;\n` +
 	"  3. kill it (close not-planned) when it does not move anything forward — agent-filed issues only,\n" +
 	"     a human-filed issue is never auto-closed.";
+
+/** The double-marked remediation: home and exemption are exclusive, so exactly one mark goes. */
+const DOUBLE_MARKED_REMEDY =
+	"Each issue above claims BOTH a home and a standing-lane exemption, which ADR 0208 bans outright\n" +
+	'(Banned: "Milestones on wayfinder:backlog fog … or on axis:pipeline-hardening items"). A standing\n' +
+	"lane is milestone-less BY DESIGN, so the two marks cannot both be true. Drop exactly one:\n" +
+	"  1. drop the MILESTONE when the issue really is a standing lane — fog homes when it gets charted\n" +
+	"     (ADR 0203), and pipeline hardening never completes into an arc;\n" +
+	"  2. drop the STANDING-LANE LABEL when the issue is genuinely homed in that arc/campaign.\n" +
+	"Leaving both makes the milestone burndown count an issue that also claims exemption from it.";
+
+const violationLines = (violations: ReadonlyArray<Violation>, kind: Violation["kind"]): string =>
+	violations
+		.filter((v) => v.kind === kind)
+		.map((v) =>
+			v.kind === "double-marked"
+				? `  #${v.number} ${v.title} — milestone ${v.milestone} + ${v.lanes.join(", ")}`
+				: `  #${v.number} ${v.title}`,
+		)
+		.join("\n");
 
 /** Render the report for a verdict (ADR 0092 §1 — "emit what you scanned"). */
 export const renderReport = (verdict: HomingGuardVerdict): string => {
@@ -161,7 +214,7 @@ export const renderReport = (verdict: HomingGuardVerdict): string => {
 		}
 		return (
 			`homing-guard: ${scopeLabel(verdict.scope)} is fully homed — scanned ${verdict.scanned} triaged issue(s): ` +
-			`${verdict.homed} milestone-homed, ${verdict.exempt} standing-lane exempt, 0 un-homed.`
+			`${verdict.homed} milestone-homed, ${verdict.exempt} standing-lane exempt, 0 un-homed, 0 double-marked.`
 		);
 	}
 	if (verdict.reason === "zero-scope") {
@@ -171,10 +224,20 @@ export const renderReport = (verdict: HomingGuardVerdict): string => {
 			"(renamed label, missing token, wrong repo), and a vacuous pass would hide every floater."
 		);
 	}
-	const lines = verdict.unhomed.map((i) => `  #${i.number} ${i.title}`);
+	const unhomed = violationLines(verdict.violations, "unhomed");
+	const doubleMarked = violationLines(verdict.violations, "double-marked");
+	// Each defect class prints only when present, immediately above its own remedy, so a red is
+	// self-explanatory without reading this source (#4069).
+	const sections = [
+		unhomed === ""
+			? ""
+			: `Left triage with NEITHER a milestone nor a standing-lane label:\n${unhomed}\n\n${UNHOMED_REMEDY}`,
+		doubleMarked === ""
+			? ""
+			: `Carry BOTH a milestone and a standing-lane label:\n${doubleMarked}\n\n${DOUBLE_MARKED_REMEDY}`,
+	].filter((s) => s !== "");
 	return (
-		`homing-guard: ${verdict.unhomed.length} of ${verdict.scanned} triaged issue(s) in ${scopeLabel(verdict.scope)} ` +
-		`left triage with neither a milestone nor a standing-lane label ` +
-		`(${verdict.homed} homed, ${verdict.exempt} exempt):\n${lines.join("\n")}\n\n${REMEDY}`
+		`homing-guard: ${verdict.violations.length} of ${verdict.scanned} triaged issue(s) in ${scopeLabel(verdict.scope)} ` +
+		`break home-xor-exempt (${verdict.homed} homed, ${verdict.exempt} exempt):\n\n${sections.join("\n\n")}`
 	);
 };

--- a/packages/pipeline-cli/src/tools/homing-guard/homing-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/homing-guard.unit.test.ts
@@ -1,8 +1,8 @@
 /**
- * Pure-core tests for `homing-guard` (#3939): the home-or-exempt disposition, the verdict
- * over a scanned set, the two zero-scope forks (backlog fails closed per ADR 0092, a single
- * non-triaged issue passes as out-of-scope), and the report. No IO — the `gh api` seam is
- * crossed in `gate.ts`/`github.ts`.
+ * Pure-core tests for `homing-guard` (#3939, extended to both directions in #4069): the
+ * four-way home-xor-exempt disposition, the verdict over a scanned set, the two zero-scope
+ * forks (backlog fails closed per ADR 0092, a single non-triaged issue passes as
+ * out-of-scope), and the report. No IO — the `gh api` seam is crossed in `gate.ts`/`github.ts`.
  */
 import {describe, expect, it} from "@effect/vitest";
 import {
@@ -10,6 +10,7 @@ import {
 	EXEMPT_LABELS,
 	judge,
 	renderReport,
+	resolve,
 	type Scope,
 	type TriagedIssue,
 } from "./homing-guard.ts";
@@ -52,8 +53,24 @@ describe("disposition", () => {
 		);
 	});
 
-	it("milestone WINS over a standing-lane label (ADR 0208's inverse ban is out of scope)", () => {
-		expect(disposition(issue(1, 17, ["wayfinder:backlog"]))).toBe("homed");
+	it.each([
+		...EXEMPT_LABELS,
+	])("a milestone AND %s is double-marked — ADR 0208 bans it, and it is never homed", (label) => {
+		expect(disposition(issue(1, 17, [label]))).toBe("double-marked");
+	});
+
+	it("a double-marked resolution carries the milestone and the lanes its remedy names", () => {
+		expect(resolve(issue(42, 17, ["wayfinder:backlog", "p2"]))).toEqual({
+			kind: "double-marked",
+			number: 42,
+			title: "issue 42",
+			milestone: 17,
+			lanes: ["wayfinder:backlog"],
+		});
+	});
+
+	it("a milestone plus a look-alike label is plain homed (the exempt set is exact)", () => {
+		expect(disposition(issue(1, 17, ["axis:pipeline-hardening-ish"]))).toBe("homed");
 	});
 });
 
@@ -74,12 +91,12 @@ describe("judge — pass", () => {
 	});
 });
 
-describe("judge — un-homed", () => {
+describe("judge — violations", () => {
 	it("FAILS and names every un-homed issue, not just the first", () => {
 		const v = judge([issue(1, 17), issue(2, null), issue(3, null, ["p0"])]);
 		expect(v.pass).toBe(false);
-		if (!v.pass && v.reason === "unhomed") {
-			expect(v.unhomed.map((u) => u.number)).toEqual([2, 3]);
+		if (!v.pass && v.reason === "violations") {
+			expect(v.violations.map((u) => u.number)).toEqual([2, 3]);
 			expect(v.scanned).toBe(3);
 			expect(v.homed).toBe(1);
 			expect(v.exempt).toBe(0);
@@ -89,8 +106,47 @@ describe("judge — un-homed", () => {
 	it("FAILS a single-issue scan of an un-homed issue", () => {
 		const v = judge([issue(9, null)], {_tag: "issue", number: 9});
 		expect(v.pass).toBe(false);
-		if (!v.pass && v.reason === "unhomed") {
-			expect(v.unhomed).toEqual([{number: 9, title: "issue 9"}]);
+		if (!v.pass && v.reason === "violations") {
+			expect(v.violations).toEqual([{kind: "unhomed", number: 9, title: "issue 9"}]);
+		}
+	});
+
+	it("FAILS on a double-marked issue and keeps it OUT of the homed count", () => {
+		const v = judge([issue(1, 17), issue(2, 24, ["axis:pipeline-hardening"])]);
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "violations") {
+			expect(v.homed).toBe(1);
+			expect(v.exempt).toBe(0);
+			expect(v.scanned).toBe(2);
+			expect(v.violations).toEqual([
+				{
+					kind: "double-marked",
+					number: 2,
+					title: "issue 2",
+					milestone: 24,
+					lanes: ["axis:pipeline-hardening"],
+				},
+			]);
+		}
+	});
+
+	it("FAILS a single-issue scan of a double-marked issue — the --issue seam reds too", () => {
+		const v = judge([issue(9, 17, ["wayfinder:backlog"])], {_tag: "issue", number: 9});
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "violations") {
+			expect(v.violations.map((x) => x.kind)).toEqual(["double-marked"]);
+		}
+	});
+
+	it("carries BOTH defect classes in one verdict — neither hides the other", () => {
+		const v = judge([issue(1, null), issue(2, 24, ["wayfinder:backlog"]), issue(3, 17)]);
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "violations") {
+			expect(v.violations.map((x) => [x.kind, x.number])).toEqual([
+				["unhomed", 1],
+				["double-marked", 2],
+			]);
+			expect(v.homed).toBe(1);
 		}
 	});
 });
@@ -140,5 +196,28 @@ describe("renderReport", () => {
 		expect(report).toContain("home it in an EXISTING open arc/campaign milestone");
 		expect(report).toContain("wayfinder:backlog or axis:pipeline-hardening");
 		expect(report).toContain("kill it (close not-planned)");
+	});
+
+	it("names a double-marked issue with the two marks it carries, and its own remedy", () => {
+		const report = renderReport(judge([issue(1, 17), issue(2, 24, ["wayfinder:backlog"])]));
+		expect(report).toContain("Carry BOTH a milestone and a standing-lane label");
+		expect(report).toContain("#2 issue 2 — milestone 24 + wayfinder:backlog");
+		expect(report).toContain("ADR 0208");
+		expect(report).toContain("drop the MILESTONE");
+		expect(report).toContain("drop the STANDING-LANE LABEL");
+	});
+
+	it("separates the two defect classes, each under its own remedy", () => {
+		const report = renderReport(judge([issue(1, null), issue(2, 24, ["wayfinder:backlog"])]));
+		expect(report).toContain("2 of 2 triaged issue(s)");
+		expect(report).toContain("Left triage with NEITHER a milestone nor a standing-lane label");
+		expect(report).toContain("Carry BOTH a milestone and a standing-lane label");
+		expect(report.indexOf("#1 issue 1")).toBeLessThan(report.indexOf("#2 issue 2"));
+	});
+
+	it("prints ONLY the class that fired — no empty section for the other", () => {
+		const report = renderReport(judge([issue(1, null)]));
+		expect(report).toContain("Left triage with NEITHER");
+		expect(report).not.toContain("Carry BOTH");
 	});
 });


### PR DESCRIPTION
The `homing-guard` CI check only ever complained when a triaged issue had *no* home — it stayed silent when an issue claimed *two*, a milestone and a standing-lane label at the same time, which ADR 0208 bans outright. Those double-marked issues were silently counted as "homed", so the milestone burndowns included work that also claimed exemption from them, and the guard read as full coverage to everyone downstream. This teaches the guard the other half of its own invariant: it now reds on both directions and tells you which mark to drop.

## What changed

- **`disposition()` resolves four ways, not three** — `homed`, `exempt`, `unhomed`, and the new `double-marked`. A double-marked issue is never counted in `homed`.
- **One statement of the rule.** A new `resolve()` returns either a clean outcome or the `Violation` the issue is, carrying the milestone and the standing-lane labels the remedy has to name; `disposition()` is just its `kind`, so the rule is not restated in `judge`.
- **The failing verdict carries one kind-tagged violation list**, not two parallel arrays. That keeps "a failing verdict names at least one offender" the same single non-empty check `judge` already made — there is no both-empty state to represent — and it means neither defect class can hide the other when both are present in one scan (`reason: "unhomed"` becomes `reason: "violations"`).
- **`renderReport` prints each class only when it fired**, under its own remedy: the existing home-or-exempt-or-kill remedy for the un-homed, and a new ADR 0208 remedy for the double-marked (drop the milestone, or drop the lane label), with each offender rendered as `#N title — milestone M + <lane>`.
- **The module docblock no longer disclaims the check.** The "Deliberately NOT enforced here" paragraph is replaced by a statement that both directions red, plus why.
- **`.github/workflows/homing-guard.yml`**: the scheduled-drift issue it files, and the blocking-trigger failure line, both described only the neither case — they now describe the invariant the guard actually checks. No trigger, permission, or scoping change.
- **Unit tests** cover all four resolutions, a verdict carrying both classes at once, the `--issue` per-issue scope reding on a double-marked issue, and the report's separation of the two classes. Zero-scope stays fail-closed (ADR 0092) — untouched, and still covered.

## The detector does NOT land hot

The issue was filed against a board state with 28 double-marked open issues, so the expectation was that turning this on reds CI until #4071 reconciles them. Re-measured tonight, that is no longer true:

- `node packages/pipeline-cli/src/bin.ts homing-guard check` on this branch, against the live backlog: `the open status:triaged backlog is fully homed — scanned 231 triaged issue(s): 189 milestone-homed, 42 standing-lane exempt, 0 un-homed, 0 double-marked.`
- A direct REST sweep of every open issue carrying `wayfinder:backlog`, and every open issue carrying `axis:pipeline-hardening`, filtered to those with a milestone: **empty in both cases** — zero double-marked open issues repo-wide, in scope or out.

So the sequencing constraint the issue described has already been discharged on the board; this PR can land on its own. #4071 stays open as the record of that reconciliation — it is not a blocker for this PR, but whoever closes it should note the violations are already cleared.

## Judgment calls worth a look

- **Renaming the failure `reason` from `"unhomed"` to `"violations"`** is a deliberate breaking change to the verdict shape. The alternative — a second `reason: "double-marked"` variant — cannot represent a scan that finds both classes, which would drop offenders from the report. `gate.ts` only reads `verdict.pass`, so nothing outside the tests consumes the old tag.
- **Touching the workflow** widens the diff beyond the acceptance criteria. It is included because the text it files on a scheduled red would otherwise misdescribe the defect it just found. `class-probe classify` returns `has-code` with or without it.
- **`claude-plugins/kampus-pipeline/skills/triage/SKILL.md` is deliberately NOT touched.** Its line ("reds on any open `status:triaged` issue carrying neither a milestone nor a standing-lane label") becomes an understatement, not a falsehood, and editing it would pull the PR into the skill class for a wording change. Flagging it rather than silently widening scope.

## Verification

- `pnpm typecheck` — clean (29/29 tasks).
- `pnpm lint:worktree` — clean.
- `pnpm test` in `packages/pipeline-cli` — 163 files, 2369 tests, all passing.

Fixes #4069
