### PR TITLE
test(edge-ready): make the two eventual-success readiness cases deterministic on fake timers (#4128)

### DIFF
--- a/apps/web/tests/integration/_edge-ready.unit.test.ts
+++ b/apps/web/tests/integration/_edge-ready.unit.test.ts
@@ -36,6 +36,29 @@ import {awaitAuthRouteReady, awaitWorkerReady, WarmNotSettledError} from "./_int
 // A tiny budget so the tests drive the readiness logic in milliseconds, not the real 60s.
 const BUDGET = {deadlineMs: 120, pollMs: 5} as const;
 
+/**
+ * Runs a poll on FAKE timers and drains its sleeps, then returns its settled value.
+ *
+ * `vi.useFakeTimers()` mocks `setTimeout` AND `Date` (vitest 4's default `toFake` set is every
+ * sinon timer key except `nextTick`/`queueMicrotask`), so BOTH halves of the poll's clock —
+ * `sleep(pollMs)` and the `Date.now() < deadline` test — read the mock clock, which only advances
+ * when this helper advances it. A case that asserts "goes ready after N sends" then asserts LOGIC:
+ * it cannot lose a race against `BUDGET.deadlineMs` of REAL wall clock when the host is loaded and
+ * a nominal 5ms `setTimeout` lands tens of ms late, which reds the pre-push/CI unit gate on a diff
+ * that cannot affect it (#4128). Use it ONLY for the eventual-SUCCESS cases — the
+ * budget-EXHAUSTION cases must keep real timers, because elapsed wall clock is their assertion.
+ */
+const onFakeTimers = async <T>(start: () => Promise<T>): Promise<T> => {
+	vi.useFakeTimers();
+	try {
+		const pending = start();
+		await vi.runAllTimersAsync();
+		return await pending;
+	} finally {
+		vi.useRealTimers();
+	}
+};
+
 const okStream = () =>
 	new Response("", {status: 200, headers: {"content-type": "text/event-stream"}});
 // The `/fate/live` SSE-open readiness predicate (200 + event-stream), used across the poll tests.
@@ -52,7 +75,7 @@ describe("awaitEdgeReady — the shared cold-start readiness primitive (ADR 0127
 			return okStream();
 		});
 
-		const res = await awaitEdgeReady(send, sseReady, BUDGET);
+		const res = await onFakeTimers(() => awaitEdgeReady(send, sseReady, BUDGET));
 
 		expect(res.status).toBe(200);
 		expect(res.headers.get("content-type")).toContain("text/event-stream");
@@ -122,7 +145,7 @@ describe("awaitEdgeReady — the shared cold-start readiness primitive (ADR 0127
 			return new Response(JSON.stringify({status: "ok"}), {status: 200});
 		});
 
-		const res = await awaitEdgeReady(send, healthReady, BUDGET);
+		const res = await onFakeTimers(() => awaitEdgeReady(send, healthReady, BUDGET));
 
 		expect(await healthReady(res)).toBe(true);
 		expect(send).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
Two tests in `_edge-ready.unit.test.ts` asked "does the readiness poll give up too early?" but answered it by racing a 120ms stopwatch: they had to fit three fetches and two 5ms sleeps inside real wall clock. On a busy machine — several build lanes running vitest at once — a 5ms `setTimeout` lands far later than 5ms, the budget lapses, and a test about logic fails on timing. That red blocks the fail-closed pre-push hook and CI for whoever pushed, even when their diff cannot touch `apps/web` at all.

Both cases now run on fake timers, so the clock only moves when the test moves it. The budget itself is unchanged: raising 120ms to some bigger number would just re-run the same coin flip under heavier load later.

## What changed

One file, `apps/web/tests/integration/_edge-ready.unit.test.ts`:

- Added an `onFakeTimers(start)` helper: `vi.useFakeTimers()` → run the poll → `vi.runAllTimersAsync()` to drain its sleeps → `vi.useRealTimers()` in a `finally`.
- Routed the two exposed eventual-success cases through it:
  - `rides out a placeholder-404 that CLEARS within the budget → resolves the 200`
  - `` `/api/health` shape (ASYNC body predicate) ``
- Nothing else. `awaitEdgeReady` in `apps/web/tests/integration/_edge-ready.ts` is untouched — this is a test-determinism defect, not a defect in the readiness primitive.

## Why fake timers actually removes the dependency (grounded, not assumed)

`vi.useFakeTimers()`'s default `toFake` set in the pinned vitest (`^4.1.5`, resolved 4.1.5) is *every* sinon timer key except `nextTick`/`queueMicrotask` — and that set includes `Date` (vitest's bundled fake-timers builds `timers` as `{setTimeout, clearTimeout, setInterval, clearInterval, Date, …}`; the default is computed as `Object.keys(this._fakeTimers.timers).filter(t => t !== "nextTick" && t !== "queueMicrotask")`). So **both** halves of the poll's clock come from the mock: the `sleep(pollMs)` timer *and* the `Date.now() < deadline` deadline test. Real CPU stalls no longer consume budget, because no budget is spent unless `runAllTimersAsync` spends it.

## What deliberately keeps real timers

The budget-**exhaustion** cases are assertions *about* elapsed wall clock, and load only helps them — faking their clock would weaken them:

- `a placeholder-404 that NEVER clears …` still asserts `elapsed >= BUDGET.deadlineMs` against `Date.now()`.
- `a not-ready RESPONSE (a 503 cold-start envelope) …` still rides the real budget.
- The fast-fail cases (non-placeholder throw, genuine 4xx, terminal worker JSON 4xx) still assert `send` called exactly once.

A blanket `vi.useFakeTimers()` on the describe would have broken exactly these — hence the per-case helper rather than a hook.

## Verification

- `pnpm --filter './apps/**' test:unit` → **286 files / 2406 tests passed**.
- The file alone: 32/32 passed.
- Under synthetic CPU load (14 busy loops, load average ~17–24) the two fixed cases run in **4ms** and **3ms** and pass, while the exhaustion cases still take their real ~127ms / ~123ms — i.e. the intended semantics of each half are preserved. For contrast, the pre-fix version of the clearing case consumed 15ms of its 120ms wall-clock budget on that same loaded host (≈4ms unloaded): still green in that particular run, but that shrinking margin is precisely the coin flip this removes. I did not reproduce a red on demand and I'm not claiming a measured flake rate — the argument here is structural, matching the issue's own "frequency is unmeasured" note.
- `pnpm typecheck` and `pnpm lint:worktree` clean; the pre-push hook (`typecheck` + `unit-changed`) ran green on the push — no `--no-verify`.

## Scope boundary

This fixes the timer flakiness only. It does **not** touch the separate question of whether the pre-push `unit-changed` leg is scoping correctly (a `packages/**`-only diff appearing to run the whole `apps/web` unit project) — that is #4131, and this diff changes nothing about it. The push path issues (#4136, #4146) are likewise untouched. No `lefthook.yml`, `.github/**`, or `packages/pipeline-cli/**` changes: the diff is one file under `apps/web/tests/**`, which is outside `CONTROL_PLANE_RE`.

Closes #4128
