### PR TITLE
feat(pipeline): mandatory `## Deviations` PR-body section with cross-gate teeth (#4064)

### DIFF
--- a/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md
+++ b/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md
@@ -68,7 +68,7 @@ Deviation disclosure is a **required section of every `write-code` PR body**, de
 4. **Repair appends, never replaces.** The section is a running log across the PR's whole life,
    round-tagged. Rewriting it to the latest round's truth destroys the trail.
 
-5. **Gate teeth, scoped deliberately.** All four PR-verdict gates (ADR 0073 §5's set: `review-code`,
+5. **Gate teeth, scoped deliberately.** All four PR-verdict gates (§6.6's set: `review-code`,
    `review-doc`, `review-skill`, `review-design`) carry one `deviation-disclosure` row in their
    conjunctive table: a deviation the gate **detects and the body does not disclose** is a blocking
    finding; a **disclosed** one is a judgment item verified on three questions (authorized? needs an

--- a/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md
+++ b/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md
@@ -1,0 +1,97 @@
+---
+id: 0216
+title: Deviation Disclosure Is a PR-Body Obligation With Cross-Gate Teeth
+status: proposed
+date: 2026-07-26
+tags: [pipeline, review, gates, write-code]
+---
+
+# 0216 — Deviation Disclosure Is a PR-Body Obligation With Cross-Gate Teeth
+
+## Context
+
+The pipeline grades a PR against the linked issue's `### Acceptance criteria`. That checklist
+answers *did the stated work land*. It does not answer *what did the author decide along the way
+that the spec did not say* — and every build makes such decisions.
+
+They are usually right. In one night's drain a coder narrowed an issue's suggested fix-shape
+(correctly), another left a sibling defect unfixed and filed a follow-up, another declined an
+optional reviewer suggestion, another pushed with `--no-verify` after hook timeouts, another
+modified a pre-existing test because it asserted the defect. Each call was defensible. The problem
+is that every one of them surfaced only because that particular run happened to volunteer it in a
+hand-written report. Disclosure was voluntary, so a less forthcoming run hides the same class of
+decision at no cost.
+
+The cost of that is already on `main`. PR #3986 narrowed ADR 0115 §5's reclaim invariant in skill
+prose. The author knew, and offered *in review conversation* to file the amending ADR — but nothing
+in the PR body carried the departure, the offer evaporated with the conversation, and the narrowing
+merged as post-merge debt that an audit had to reconstruct later (#3993 F1; F2 is the same class, a
+scope note that omitted a third issue and left half a fix inert). The information existed at PR
+authoring time, which is the cheapest moment to surface it, and had no required home in the artifact.
+
+Two adjacent surfaces already solve half of this and are the shape to copy. §9 (the closing-keyword
+seam) is a PR-body convention defined once and cited by the writer and the consumer, so the halves
+cannot drift. `review-design`'s golden-deviation class already runs the exact judgment shape needed
+here: an *unexplained* deviation from a blessed baseline hard-FAILs, an explained one is judged on
+its merits.
+
+## Decision
+
+Deviation disclosure is a **required section of every `write-code` PR body**, defined once in
+`gh-issue-intake-formats.md` §DEV, and given teeth by the PR-verdict gates.
+
+1. **One definition, five citing lanes.** §DEV defines the heading, the four fields of an entry
+   (what the spec said / what shipped instead / why / disposition), the seven deviation classes, and
+   the gate verdict rule. `write-code` Step 5 and repair R3, and each gate step, cite it. No lane
+   re-derives the classes — the drift class §CP exists to prevent.
+
+2. **`None.` is a claim against a closed list, not a default.** The seven classes are what make the
+   empty case load-bearing: writing `None.` asserts you walked scope narrowing, ADR departure,
+   known-defect-left-unfixed, declined guidance, guard bypass, pre-existing-test change, and
+   out-of-scope change, and none fired. A `None.` that a gate falsifies is blocking on two counts —
+   the deviation, and the now-untrustworthy disclosure. Disclosing costs a sentence; a wrong `None.`
+   costs a repair round. That asymmetry is the enforcement.
+
+3. **Absent is not `None.`** A body with no section is malformed, because a gate cannot distinguish
+   "nothing to disclose" from "never considered it". Absence fails closed (ADR 0092's posture applied
+   to a body section).
+
+4. **Repair appends, never replaces.** The section is a running log across the PR's whole life,
+   round-tagged. Rewriting it to the latest round's truth destroys the trail.
+
+5. **Gate teeth, scoped deliberately.** All four PR-verdict gates (ADR 0073 §5's set: `review-code`,
+   `review-doc`, `review-skill`, `review-design`) carry one `deviation-disclosure` row in their
+   conjunctive table: a deviation the gate **detects and the body does not disclose** is a blocking
+   finding; a **disclosed** one is a judgment item verified on three questions (authorized? needs an
+   ADR? needs a follow-up issue?). `review-trivial` gets a different, narrower role — a disclosed
+   deviation is by construction evidence the diff is not trivial, so it is a Step-0 bounce to the
+   full path, not a verdict row.
+
+6. **The teeth are stated honestly, in tiers.** §DEV names which classes a gate can mechanically
+   detect (in-diff suppressions, removed test assertions), which need a reader (scope narrowing, ADR
+   departure, declined guidance — reusing reads the gates already do), and which are undetectable by
+   any gate (a deliberately unfixed sibling defect; a `--no-verify` push, which leaves no trace in
+   the diff, the body, or the timeline). A passing row therefore means *nothing undisclosed that this
+   gate could see*, never *no deviations exist*.
+
+## Consequences
+
+- **The expensive catch moves to the cheapest moment.** An ADR narrowing or a discharge-before-merge
+  condition currently surfaces in post-merge audit; the obligation moves it to PR authoring, where
+  the author has full context and a sentence discharges it.
+- **The teeth are real but partial, and say so.** For the undetectable tier this converts an
+  invisible default into a rule violation with a named place to point at — genuinely weaker than
+  enforcement, and better than nothing. Overstating it would be the worse failure: a gate that
+  implies it caught everything makes the next reader trust a green row it should not.
+- **A new false-FAIL surface exists.** A gate can judge something a deviation that the author
+  reasonably did not. That is the intended direction of error (a false FAIL costs a cycle, a false
+  PASS ships undisclosed debt), and it is bounded by the existing N=3 repair cap.
+- **This is a control-plane change** — it edits `gh-issue-intake-formats.md`, `write-code`, and the
+  five reviewer skills, all in §CP — so it banks for human control-plane approval.
+- **Rejected: a CI presence check.** A mechanical "does the section exist" job was considered and
+  left out. An LLM gate reading the PR body already sees an absent section, so the job adds a
+  workflow to maintain and catches only the case the gates already catch. It stays available to file
+  separately if the gate rows prove unreliable in practice.
+- **Rejected: making `review-trivial` emit a deviation row.** Its lighter checklist is licensed by
+  the diff being bounded; a diff carrying a disclosed deviation has already broken that premise, so
+  the correct response is to decline to be its gate, not to grade the deviation on the reduced path.

--- a/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md
+++ b/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md
@@ -52,9 +52,18 @@ Deviation disclosure is a **required section of every `write-code` PR body**, de
    the deviation, and the now-untrustworthy disclosure. Disclosing costs a sentence; a wrong `None.`
    costs a repair round. That asymmetry is the enforcement.
 
-3. **Absent is not `None.`** A body with no section is malformed, because a gate cannot distinguish
-   "nothing to disclose" from "never considered it". Absence fails closed (ADR 0092's posture applied
-   to a body section).
+3. **Absent is not `None.` — on a PR that owes the section.** A body with no section is malformed,
+   because a gate cannot distinguish "nothing to disclose" from "never considered it". Absence fails
+   closed (ADR 0092's posture applied to a body section). The obligation is a **writer** obligation,
+   so it can only bind a body `write-code` composed; a PR with no `write-code` author — the
+   conversation-authored issueless lanes of ADR 0075 / 0184, a bot-opened bump, a hand-authored human
+   PR — owes nothing, and its row is `[N/A]`. **That scoping lives in §DEV alone**, and every gate
+   resolves the row by citing it. Carried as a per-skill fragment it diverged on contact: `review-doc`
+   held the exception privately while `review-code` and `review-design` did not, so an ADR-0184
+   issueless PR drew `[N/A]` from one gate and `[FAIL]` from another at the same head — and because
+   the verdicts are conjunctive and `write-code` is not the author, no repair round could clear it.
+   The N/A is deliberately narrow in the other direction too: only a carve-out the gate itself
+   established reaches it, so a pipeline PR that merely lost its `Fixes #N` buys no exemption.
 
 4. **Repair appends, never replaces.** The section is a running log across the PR's whole life,
    round-tagged. Rewriting it to the latest round's truth destroys the trail.
@@ -65,7 +74,11 @@ Deviation disclosure is a **required section of every `write-code` PR body**, de
    finding; a **disclosed** one is a judgment item verified on three questions (authorized? needs an
    ADR? needs a follow-up issue?). `review-trivial` gets a different, narrower role — a disclosed
    deviation is by construction evidence the diff is not trivial, so it is a Step-0 bounce to the
-   full path, not a verdict row.
+   full path, not a verdict row. That bounce is a **narrowing inside** ADR
+   [0120](0120-stage-right-sizing-trivial-diff-lighter-gate.md) §3's default-deny posture — "any ambiguity
+   routes to the full fan-out" — not a new routing rule: it names one more shape of ambiguity the
+   lighter path cannot resolve, and the direction of error is unchanged (pay the full gate's cost,
+   never under-gate).
 
 6. **The teeth are stated honestly, in tiers.** §DEV names which classes a gate can mechanically
    detect (in-diff suppressions, removed test assertions), which need a reader (scope narrowing, ADR

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -3258,15 +3258,50 @@ walked these seven and none fired.
    rather than added to. "It asserted the defect" is a legitimate reason and a mandatory disclosure.
 7. **Out-of-scope change** — a file or surface touched that the issue does not imply.
 
+**The classes overlap; the label is a routing hint, not the disclosure.** A change can read as two
+classes at once — an addition triage explicitly declined is both class 4 and class 7 — and picking
+one is not a mistake to litigate. A gate matches its finding against the entry's **substance** (the
+Said / Did / Why), never against the class label, so a mis-labelled but honest entry is disclosed and
+a correctly-labelled but vague one is not.
+
 **A falsified `None.` is worse than an honest entry.** When a gate finds a class-N deviation in a
 diff whose body says `None.`, the disclosure is a false statement, and the finding is blocking on
 *two* counts: the undisclosed deviation, and the fact that the section can no longer be trusted on
 this PR. That asymmetry is the section's only real enforcement — disclosing costs a sentence, and a
 wrong `None.` costs a repair round.
 
-**Absent is not `None.`** A body with no `## Deviations` heading is malformed: the gate cannot tell
-"nothing to disclose" from "never considered it", so absence fails closed (§ZS's posture, applied to
-a body section). `None.` is a complete, valid disclosure; silence is not.
+**Absent is not `None.`** On a PR that **owes** the section (below), a body with no `## Deviations`
+heading is malformed: the gate cannot tell "nothing to disclose" from "never considered it", so
+absence fails closed (§ZS's posture, applied to a body section). `None.` is a complete, valid
+disclosure; silence is not.
+
+### Who owes the section — the one `[N/A]` scoping, stated here and nowhere else
+
+The writer half binds **`write-code`**, so the gate half can only fail a body `write-code` was
+obliged to compose. A PR with **no `write-code` author** owes nothing, and its row is **`[N/A]`, not
+`[FAIL]`** — every gate that carries the row resolves it by *this* rule. Stated once here on purpose:
+carried as a per-skill fragment it diverged immediately, and two gates rendered opposite rows on the
+same head — `review-doc` `[N/A]`, `review-code` `[FAIL]` — which, because the verdicts are
+conjunctive and `write-code` is not the author, no repair round could ever clear.
+
+A gate resolves the row **`[N/A]` only on positively-established non-obligation**, in exactly two
+shapes:
+
+- **The gate's own issueless carve-out already fired.** The row inherits this gate's
+  **acceptance-criteria determination**: where the AC half renders N/A because the PR is a blessed
+  issueless lane — the conversation-authored `.glossary/**` coining PR of ADR
+  [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md) /
+  [0184](https://github.com/kamp-us/phoenix/blob/main/.decisions/0184-review-code-issueless-carve-out.md) —
+  the deviation row renders N/A with it. There is no spec to depart from and no `write-code` author
+  obliged. Tying the two together is what keeps them from drifting apart again: a gate cannot grade
+  ACs while N/A-ing deviations, or the reverse.
+- **The PR was not authored by `write-code`.** A bot-opened PR (a dependency bump) or a
+  hand-authored human PR never ran Step 5, so its body was never obliged to carry the heading.
+
+Everything else — including a pipeline PR that merely **lost** its `Fixes #N` — is **owed**, and an
+absent section is a `[FAIL]`. The exception is deliberately narrow in that direction: dropping the
+issue link buys no exemption (each gate already hard-stops that shape as a broken seam), so the only
+way to reach `[N/A]` is a carve-out the gate itself established.
 
 **Repair appends, never replaces.** Each repair round adds its entries under the same heading, tagged
 `**(repair round K)**`, and leaves the earlier ones standing. The section is a running log of what
@@ -3306,13 +3341,18 @@ shows in the run log instead of reading green:
 BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
 printf '%s' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$' \
   && echo "deviation-disclosure: ## Deviations section present" \
-  || echo "deviation-disclosure: ## Deviations section ABSENT — malformed body (absent is not None.)"
+  || echo "deviation-disclosure: ## Deviations section ABSENT — malformed body if the PR OWES the section (absent is not None.); [N/A] if it does not (see 'Who owes the section')"
 # class 5, added suppressions/skips
 DEV_SUPPRESS="$(gh pr diff "$PR" | grep -E '^\+' \
   | grep -nE 'biome-ignore|eslint-disable|@ts-(expect-error|ignore)|\.(skip|only)\(|xit\(|xdescribe\(' || true)"
-# class 6, removed assertion lines
-DEV_TESTCUTS="$(gh pr diff "$PR" | grep -nE '^-.*(expect\(|assert|toBe|toEqual|toThrow)' || true)"
-echo "deviation-disclosure: Tier-M scan — $(printf '%s\n' "$DEV_SUPPRESS" | grep -c . || echo 0) suppression/skip line(s), $(printf '%s\n' "$DEV_TESTCUTS" | grep -c . || echo 0) removed-assertion line(s)"
+# class 6, removed assertion lines — scoped to TEST files, matching the prose. Walk the diff
+# file-by-file (`+++ b/<path>` starts a file) so a `--- a/src/assert.ts` header can never match as a
+# removed assertion, and only removals inside a test file count. A bare `grep '^-'` over the whole
+# diff matched exactly that header (the `-` of `---` plus the word `assert` in the path).
+DEV_TESTCUTS="$(gh pr diff "$PR" | awk '
+  /^\+\+\+ b\// { t = ($0 ~ /(\.|\/)(test|spec)\.[a-z]+$|\/(__tests__|test|tests)\//) ; next }
+  t && /^-[^-]/ && /expect\(|assert|toBe|toEqual|toThrow/ { print }')"
+echo "deviation-disclosure: Tier-M scan — $(printf '%s' "$DEV_SUPPRESS" | grep -c .) suppression/skip line(s), $(printf '%s' "$DEV_TESTCUTS" | grep -c .) removed-assertion line(s)"
 ```
 
 A hit is a **line to judge against the disclosure**, never a FAIL by itself — a `biome-ignore` the
@@ -3329,7 +3369,9 @@ not a deviation at all.
   does it **need an ADR** (a class-2 departure with no amending ADR in the diff is a `[FAIL]` — the
   #3986 remedy)? does it **need a follow-up issue** (a class-3 defect with no filed issue is a
   `[FAIL]`)? A disclosed deviation that answers all three is a PASS row, cited.
-- **Absent section ⇒ `[FAIL]` row**, per *Absent is not `None.`* above.
+- **Absent section ⇒ `[FAIL]` row on a PR that owes it**, per *Absent is not `None.`* above — and
+  **`[N/A]` on one that does not**, per *Who owes the section*. Resolve the owed/not-owed question
+  first; it is the only branch that decides between those two rows.
 
 This is deliberately the same escalate-to-judgment shape `review-design`'s golden-deviation class
 already runs (an *unexplained* deviation from a blessed golden hard-FAILs; an explained one is
@@ -3341,8 +3383,8 @@ two surfaces, so neither has to be learned separately.
 | Half | Surface | Obligation |
 |---|---|---|
 | Writer | `write-code` Step 5 (open), repair Step R3 (append) | Emits the section on every PR; `None.` only after walking the seven classes |
-| Gate | `review-code` Step 3g, `review-doc` Step 4c, `review-skill` Step 4c, `review-design` Step 3b | Folds one `deviation-disclosure` row into its conjunctive table by the rule above |
-| Gate | `review-trivial` Step 0 | A non-`None.` section is evidence the diff is not trivial ⇒ route to the full path; an absent section is a malformed body ⇒ route to the full path |
+| Gate | `review-code` Step 3g, `review-doc` Step 4c, `review-skill` Step 4c, `review-design` Step 3b | Folds one `deviation-disclosure` row into its conjunctive table by the rule above — `[N/A]` where *Who owes the section* says the PR owes nothing |
+| Gate | `review-trivial` Step 0 | A non-`None.` section is evidence the diff is not trivial ⇒ route to the full path; an absent section is unprovable-premise ⇒ route to the full path, where the owed/not-owed branch resolves it |
 
 The rationale lives in ADR
 [0216](https://github.com/kamp-us/phoenix/blob/main/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md).

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -3338,6 +3338,9 @@ shows in the run log instead of reading green:
 
 ```bash
 # §DEV Tier M — presence of the section, plus the two diff-detectable classes.
+# The section-presence pattern below is the canonical copy; `write-code` Step 5 check (e) and
+# `review-trivial` Step 0 restate it mechanically, so a change here has to land in all three (the
+# rule is single-sourced, the pattern is not — a silent drift un-gates one lane).
 BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
 printf '%s' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$' \
   && echo "deviation-disclosure: ## Deviations section present" \
@@ -3346,11 +3349,17 @@ printf '%s' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:spa
 DEV_SUPPRESS="$(gh pr diff "$PR" | grep -E '^\+' \
   | grep -nE 'biome-ignore|eslint-disable|@ts-(expect-error|ignore)|\.(skip|only)\(|xit\(|xdescribe\(' || true)"
 # class 6, removed assertion lines — scoped to TEST files, matching the prose. Walk the diff
-# file-by-file (`+++ b/<path>` starts a file) so a `--- a/src/assert.ts` header can never match as a
-# removed assertion, and only removals inside a test file count. A bare `grep '^-'` over the whole
-# diff matched exactly that header (the `-` of `---` plus the word `assert` in the path).
+# file-by-file so a `--- a/src/assert.ts` header can never match as a removed assertion, and only
+# removals inside a test file count. A bare `grep '^-'` over the whole diff matched exactly that
+# header (the `-` of `---` plus the word `assert` in the path).
+# EVERY file header re-decides the flag, and a DELETED file (`+++ /dev/null`) takes its path from the
+# `--- a/<path>` side. Keying only on `+++ b/` left the flag STALE across a deletion, which broke the
+# scan in both directions: a deleted non-test file after a test file scored false positives, and a
+# deleted test file after a non-test file silently dropped its removed assertions — the exact class-6
+# case this scan exists to arm.
 DEV_TESTCUTS="$(gh pr diff "$PR" | awk '
-  /^\+\+\+ b\// { t = ($0 ~ /(\.|\/)(test|spec)\.[a-z]+$|\/(__tests__|test|tests)\//) ; next }
+  /^--- / { p = $0; next }
+  /^\+\+\+ / { t = ((($0 ~ /^\+\+\+ b\//) ? $0 : p) ~ /(\.|\/)(test|spec)\.[a-z]+$|\/(__tests__|test|tests)\//) ; next }
   t && /^-[^-]/ && /expect\(|assert|toBe|toEqual|toThrow/ { print }')"
 echo "deviation-disclosure: Tier-M scan — $(printf '%s' "$DEV_SUPPRESS" | grep -c .) suppression/skip line(s), $(printf '%s' "$DEV_TESTCUTS" | grep -c .) removed-assertion line(s)"
 ```

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -3191,6 +3191,164 @@ nothing.
 
 ---
 
+## DEV. The `## Deviations` PR-body disclosure section — one canonical definition
+
+The single source of the deviation-disclosure obligation, for **both** halves: the **writer**
+(`write-code` Step 5 composes the section on every PR it opens; its repair round appends to it) and
+the **gates** (`review-code`, `review-doc`, `review-skill`, `review-design` each fold it into their
+verdict; `review-trivial` bounces any PR that discloses one). Each cites **this** section rather than
+re-deriving the classes or the verdict rule, so the five lanes can't drift — the same single-sourcing
+discipline §9 and §CP hold.
+
+**The gap it closes.** A departure from the plan, the issue, an acceptance criterion, or a governing
+ADR has no required home in the artifact today, so it lives in the coder's session and dies there.
+PR [#3986](https://github.com/kamp-us/phoenix/pull/3986) narrowed ADR 0115 §5's reclaim invariant in
+skill prose. The author knew — they offered *in review conversation* to file the amending ADR — but
+the PR body carried nothing, the offer evaporated, and the narrowing landed on `main` as post-merge
+debt that an audit had to reconstruct
+([#3993](https://github.com/kamp-us/phoenix/issues/3993) F1; F2 is the same class, a scope note that
+omitted a third issue and left half a fix inert). The information existed at authoring time — the
+cheapest moment to surface it — and had nowhere to go.
+
+### Shape
+
+```markdown
+## Deviations
+
+- **Scope narrowing** — **Said:** #4064's AC asks the gate teeth to cover §6.6's four gates plus
+  `review-trivial`. **Did:** `review-trivial` gets a Step-0 bounce, not a deviation verdict.
+  **Why:** it emits a trivial-path verdict, and a disclosed deviation is by construction evidence the
+  diff is not trivial. **Disposition:** stated in the PR body per the AC; no ADR needed.
+```
+
+An entry names four things and nothing more: what the **spec** said (the issue, an acceptance
+criterion, a plan, a reviewer's guidance, or the governing ADR — cite it), what the implementation
+**did** instead, **why**, and its **disposition** (`no action needed` / `ADR #NNNN amends it` /
+`follow-up #M filed` / `for the reviewer to judge`). Lead each entry with its class from the list
+below so the gate can match its own finding against your disclosure.
+
+The empty case is an explicit sentence, never an omitted heading:
+
+```markdown
+## Deviations
+
+None.
+```
+
+### The seven classes — the enumeration is what makes `None.` a claim
+
+A mandatory section that any run can satisfy with `None.` is ceremony. What makes it load-bearing is
+that `None.` is a **checked assertion against a closed list**, not a shrug: you wrote it because you
+walked these seven and none fired.
+
+1. **Scope narrowing** — the diff delivers less than, or a different shape from, what the issue's
+   `### What to build`, a suggested fix-shape, or an acceptance criterion asked. (A `Part of #N`
+   partial-split per §9 is a *disclosed* narrowing: name it here too, don't let the token stand in
+   for the reasoning.)
+2. **Governing-ADR departure** — the implementation contradicts, narrows, or widens an accepted ADR,
+   including narrowing an invariant that lives only in skill prose, with no amending ADR in the diff.
+   This is the #3986 class.
+3. **Known defect left unfixed** — an adjacent or sibling defect you saw and deliberately did not
+   fix, whether or not you filed a follow-up.
+4. **Declined guidance** — a reviewer suggestion, a reviewer-appended acceptance criterion (§2), or a
+   triage instruction you chose not to take.
+5. **Guard or gate bypassed** — a `--no-verify` push, a skipped or disabled hook, a suppressed lint
+   or type error (`biome-ignore`, `@ts-expect-error`), a skipped / `.only` test, a widened allowlist.
+6. **Pre-existing test or fixture changed** — an existing assertion modified, weakened, or deleted
+   rather than added to. "It asserted the defect" is a legitimate reason and a mandatory disclosure.
+7. **Out-of-scope change** — a file or surface touched that the issue does not imply.
+
+**A falsified `None.` is worse than an honest entry.** When a gate finds a class-N deviation in a
+diff whose body says `None.`, the disclosure is a false statement, and the finding is blocking on
+*two* counts: the undisclosed deviation, and the fact that the section can no longer be trusted on
+this PR. That asymmetry is the section's only real enforcement — disclosing costs a sentence, and a
+wrong `None.` costs a repair round.
+
+**Absent is not `None.`** A body with no `## Deviations` heading is malformed: the gate cannot tell
+"nothing to disclose" from "never considered it", so absence fails closed (§ZS's posture, applied to
+a body section). `None.` is a complete, valid disclosure; silence is not.
+
+**Repair appends, never replaces.** Each repair round adds its entries under the same heading, tagged
+`**(repair round K)**`, and leaves the earlier ones standing. The section is a running log of what
+this PR departed from across its whole life — rewriting it to the latest round's truth destroys
+exactly the trail the incident above wanted.
+
+### Detection tiers — what a gate can actually catch
+
+A gate can only fail what it can observe. These tiers are stated so the obligation is not read as
+more enforcement than exists:
+
+- **Tier M — mechanically detectable from the diff.** Class 5's in-diff suppressions
+  (`biome-ignore`, `@ts-expect-error`, `test.skip`, `.only`) and class 6's removed assertions in test
+  files leave literal tokens in the added/removed lines; a grep over the head diff arms the check
+  deterministically. Class 7 is half-mechanical — the changed-path set is machine-readable, but
+  "out of scope" is a judgment against the issue's prose.
+- **Tier R — reader-detectable.** Classes 1, 2, and 4 need an LLM gate reading the diff against the
+  issue, the ADR, and the review threads. The gates already do all three reads (the per-criterion AC
+  table, `review-doc` Step 4a's ADR-contradiction sweep, `review-code` Step 3e's unresolved threads),
+  so this obligation **reuses** those reads rather than adding a scan.
+- **Tier D — disclosure-only, undetectable by any gate.** Class 3 lives entirely in the author's
+  head. So does the part of class 5 that leaves no artifact: a `--no-verify` push is invisible
+  afterwards — the hooks it skipped left no trace in the diff, the body, or the PR timeline. For
+  Tier D no gate can fail an omission. What the obligation buys there is that non-disclosure becomes
+  a **rule violation** rather than an oversight, and a later audit has a named place to point at.
+
+**So a `deviation-disclosure: PASS` row means "nothing undisclosed that this gate could see" — never
+"no deviations exist."** Gates state it that way in the verdict; a gate that phrases its row as the
+stronger claim is overstating its own teeth.
+
+**The canonical Tier-M scan — one snippet, run by every gate that carries the row.** It arms the
+check; it never decides it. Emit the scanned scope (§ZS #1) so a drift that silently stops matching
+shows in the run log instead of reading green:
+
+```bash
+# §DEV Tier M — presence of the section, plus the two diff-detectable classes.
+BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
+printf '%s' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$' \
+  && echo "deviation-disclosure: ## Deviations section present" \
+  || echo "deviation-disclosure: ## Deviations section ABSENT — malformed body (absent is not None.)"
+# class 5, added suppressions/skips
+DEV_SUPPRESS="$(gh pr diff "$PR" | grep -E '^\+' \
+  | grep -nE 'biome-ignore|eslint-disable|@ts-(expect-error|ignore)|\.(skip|only)\(|xit\(|xdescribe\(' || true)"
+# class 6, removed assertion lines
+DEV_TESTCUTS="$(gh pr diff "$PR" | grep -nE '^-.*(expect\(|assert|toBe|toEqual|toThrow)' || true)"
+echo "deviation-disclosure: Tier-M scan — $(printf '%s\n' "$DEV_SUPPRESS" | grep -c . || echo 0) suppression/skip line(s), $(printf '%s\n' "$DEV_TESTCUTS" | grep -c . || echo 0) removed-assertion line(s)"
+```
+
+A hit is a **line to judge against the disclosure**, never a FAIL by itself — a `biome-ignore` the
+body discloses with a reason is a passing judgment item, and a legitimately-deleted obsolete test is
+not a deviation at all.
+
+### The gate's verdict rule — two branches, mirroring the golden-deviation shape
+
+- **Detected and *not* disclosed ⇒ `[FAIL]` row (blocking).** Name the class, the site, and what the
+  spec said, so a repair round can act on it cold. This branch is what makes the section more than
+  paperwork.
+- **Disclosed ⇒ a judgment item, not an automatic pass.** Verify it on three questions: is it
+  **authorized** (does the cited spec actually permit it, or did someone with standing approve it)?
+  does it **need an ADR** (a class-2 departure with no amending ADR in the diff is a `[FAIL]` — the
+  #3986 remedy)? does it **need a follow-up issue** (a class-3 defect with no filed issue is a
+  `[FAIL]`)? A disclosed deviation that answers all three is a PASS row, cited.
+- **Absent section ⇒ `[FAIL]` row**, per *Absent is not `None.`* above.
+
+This is deliberately the same escalate-to-judgment shape `review-design`'s golden-deviation class
+already runs (an *unexplained* deviation from a blessed golden hard-FAILs; an explained one is
+judged, [review-design/SKILL.md](review-design/SKILL.md) calibration B, #2945) — one reviewing idiom,
+two surfaces, so neither has to be learned separately.
+
+### Who writes vs reads
+
+| Half | Surface | Obligation |
+|---|---|---|
+| Writer | `write-code` Step 5 (open), repair Step R3 (append) | Emits the section on every PR; `None.` only after walking the seven classes |
+| Gate | `review-code` Step 3g, `review-doc` Step 4c, `review-skill` Step 4c, `review-design` Step 3b | Folds one `deviation-disclosure` row into its conjunctive table by the rule above |
+| Gate | `review-trivial` Step 0 | A non-`None.` section is evidence the diff is not trivial ⇒ route to the full path; an absent section is a malformed body ⇒ route to the full path |
+
+The rationale lives in ADR
+[0216](https://github.com/kamp-us/phoenix/blob/main/.decisions/0216-deviation-disclosure-is-a-pr-body-obligation.md).
+
+---
+
 ## Relationship between the formats
 
 | Format | Lives on | Written by | Read by |
@@ -3206,6 +3364,7 @@ nothing.
 | review-doc FAIL marker | the PR | review-doc | write-code (fix round-trip) |
 | review-skill PASS marker | the PR | review-skill | ship-it |
 | review-skill FAIL marker | the PR | review-skill | write-code (fix round-trip) |
+| `## Deviations` section (§DEV) | the PR body | write-code (Step 5 opens it, repair R3 appends) | review-code, review-doc, review-skill, review-design (verdict row), review-trivial (triviality bounce) |
 | issue-claim (assignee) | the issue's assignees | write-code (Step 3 claim), triage (Step 0 sweep-claim) | write-code (Step 1 pick), triage (Step 0 Rule-0 back-off) |
 
 The issue-claim row is the one entry that is a **protocol over the assignee field**, not a

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1292,13 +1292,21 @@ in a **narrower shape** than the issue asked, or a suggestion in a thread the di
 deviation whether or not it earned a `[FAIL]` on its own row.
 
 Then fold **one** `deviation-disclosure` row into the conjunctive table by §DEV's verdict rule
-(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`; disclosed ⇒ judged on authorized /
-needs-an-ADR / needs-a-follow-up; clean ⇒ PASS phrased as *nothing undisclosed that this gate could
-see*), exactly as Step 3b–3f fold theirs:
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]` **on a PR that owes it**, `[N/A]` on
+one that does not; disclosed ⇒ judged on authorized / needs-an-ADR / needs-a-follow-up; clean ⇒ PASS
+phrased as *nothing undisclosed that this gate could see*, never as *no deviations exist*), exactly
+as Step 3b–3f fold theirs:
 
 ```
 - [FAIL] deviation-disclosure — the diff narrows ADR 0115 §5's reclaim invariant in claim-protocol prose (§DEV class 2) and the body's `## Deviations` says `None.`; disclose it and either cite the amending ADR or add one (the #3986/#3993 F1 remedy)
 ```
+
+**Whether the PR owes the section at all is §DEV's call, not this step's** — read *Who owes the
+section* there. Concretely for this gate: when Step 1's issueless carve-out fired (`ISSUE` unset on
+the conversation-authored `.glossary/**` coining PR, ADR 0184/0075) the AC half is already N/A, and
+this row renders N/A with it — `- [N/A] deviation-disclosure — issueless carve-out, no write-code
+author obliged (§DEV)`. Do **not** re-derive that scoping here; a per-skill copy is what made this
+gate FAIL a PR `review-doc` passed at the same head, with no repair round able to clear it.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1268,6 +1268,38 @@ This row is governed by the conjunctive rule (Step 3): a `[FAIL]` fails the PR u
 required test coverage. The firewall holds — you judge, `write-code` fixes, an independent re-review
 re-gates.
 
+### Step 3g — Deviation-disclosure gate: an undisclosed departure is a blocking finding (§DEV)
+
+Every PR body carries a `## Deviations` section stating what the implementation departed from — the
+issue, an acceptance criterion, a reviewer's guidance, or a governing ADR — or the literal `None.`.
+The section, its four fields, the **seven classes**, the detection tiers, and the two-branch verdict
+rule are defined once in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §DEV; read them there and don't
+re-derive them. This step is the `review-code` consumer.
+
+The gap it closes is on `main`: PR #3986 narrowed ADR 0115 §5's reclaim invariant in skill prose, the
+author offered *in review conversation* to file the amending ADR, the body carried nothing, and the
+narrowing merged as debt an audit reconstructed later (#3993 F1).
+
+**Run §DEV's canonical Tier-M scan** (the section-presence check plus the two diff-detectable
+classes) over the diff Step 2 already loaded — the snippet lives there; cite it, don't re-derive it.
+A hit is a line to judge against the disclosure, never a FAIL on its own.
+
+**The reader-detectable classes need no new read here.** §DEV Tier R (scope narrowing, ADR
+departure, declined guidance) is covered by reads this skill already performed: the per-criterion AC
+table above, and Step 3e's unresolved threads. Re-use those findings — an AC you graded as delivered
+in a **narrower shape** than the issue asked, or a suggestion in a thread the diff declined, is a
+deviation whether or not it earned a `[FAIL]` on its own row.
+
+Then fold **one** `deviation-disclosure` row into the conjunctive table by §DEV's verdict rule
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`; disclosed ⇒ judged on authorized /
+needs-an-ADR / needs-a-follow-up; clean ⇒ PASS phrased as *nothing undisclosed that this gate could
+see*), exactly as Step 3b–3f fold theirs:
+
+```
+- [FAIL] deviation-disclosure — the diff narrows ADR 0115 §5's reclaim invariant in claim-protocol prose (§DEV class 2) and the body's `## Deviations` says `None.`; disclose it and either cite the amending ADR or add one (the #3986/#3993 F1 remedy)
+```
+
 ---
 
 ## Step 4a — Pass path: signal merge-ready (do NOT merge)

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -558,15 +558,22 @@ intentional-redesign branch — do not re-FAIL it here. This step covers the dep
 baseline for.
 
 Fold **one** `deviation-disclosure` row into the conjunctive verdict by §DEV's rule
-(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`, absent is not `None.`; disclosed ⇒
-judged on authorized / needs-an-ADR / needs-a-follow-up; clean ⇒ PASS, phrased as *nothing
-undisclosed that this gate could see*, never as *no deviations exist*). Like the golden-deviation
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]` **on a PR that owes it**, absent is
+not `None.`, and `[N/A]` on one that does not; disclosed ⇒ judged on authorized / needs-an-ADR /
+needs-a-follow-up; clean ⇒ PASS, phrased as *nothing undisclosed that this gate could see*, never as
+*no deviations exist*). Like the golden-deviation
 class it is **purely additive** — it can only add a FAIL, and it promotes no taste note to blocking
 (ADR 0165 unchanged).
 
 ```
 - [FAIL] deviation-disclosure — the header ships a raw `#1a1a1a` where ADR 0162 mandates a role token (§DEV class 2) and the body's `## Deviations` says `None.`; disclose the departure with its reason, or use the token
 ```
+
+**Whether the PR owes the section at all is §DEV's call, not this step's** — read *Who owes the
+section* there. A PR with no `write-code` author (the ADR 0184/0075 issueless carve-out; a bot- or
+hand-authored PR) owes nothing, so an absent section is `[N/A]`, not `[FAIL]` —
+`- [N/A] deviation-disclosure — no write-code author obliged (§DEV)`. Do **not** re-derive that
+scoping here; a per-skill copy is what let two gates render opposite rows on one head.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -536,6 +536,40 @@ against the verdict.
 
 ---
 
+## Step 3b — Deviation-disclosure gate: an undisclosed departure is a blocking finding (§DEV)
+
+Every `write-code` PR body carries a `## Deviations` section stating what the implementation
+departed from — the issue, an acceptance criterion, a reviewer's guidance, or a governing ADR — or
+the literal `None.`. The section, the seven classes, the detection tiers, and the two-branch verdict
+rule live once in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §DEV; run them
+from there and don't re-derive them.
+
+**This is the generalization of the class you already run.** Step 3's golden-deviation check is
+exactly §DEV's shape on one surface: an **unexplained** deviation from a blessed baseline hard-FAILs,
+an **explained** one is judged. §DEV applies the same rule to what the PR departed from in *spec*
+rather than in *pixels* — the design law the PR is built against
+(`design-system-manifest.md`, ADR 0162), the issue's stated UI intent, and any reviewer guidance on
+the surface. On a design diff the concrete cases are: the PR reaches for a raw value where the law
+mandates a role token and the body never says why; it ships a surface the issue's UI intent did not
+ask for (class 7); it declines a prior `review-design` advisory note (class 4).
+
+**No double-FAIL.** A golden deviation the body **does** explain is already handled by Step 3's
+intentional-redesign branch — do not re-FAIL it here. This step covers the departures Step 3 has no
+baseline for.
+
+Fold **one** `deviation-disclosure` row into the conjunctive verdict by §DEV's rule
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`, absent is not `None.`; disclosed ⇒
+judged on authorized / needs-an-ADR / needs-a-follow-up; clean ⇒ PASS, phrased as *nothing
+undisclosed that this gate could see*, never as *no deviations exist*). Like the golden-deviation
+class it is **purely additive** — it can only add a FAIL, and it promotes no taste note to blocking
+(ADR 0165 unchanged).
+
+```
+- [FAIL] deviation-disclosure — the header ships a raw `#1a1a1a` where ADR 0162 mandates a role token (§DEV class 2) and the body's `## Deviations` says `None.`; disclose the departure with its reason, or use the token
+```
+
+---
+
 ## Step 4 — Land the verdict (SHA-bound, upserted, evidence embedded)
 
 **Re-resolve the head SHA** and confirm it hasn't moved since you captured — the gate is stateless;

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -788,18 +788,22 @@ whether the diff carries the amending ADR the disclosure claims. Step 4's hygien
 class 7 (a doc surface touched that the issue does not imply) the same way.
 
 Fold **one** `deviation-disclosure` row into the conjunctive verdict by §DEV's rule
-(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`, absent is not `None.`; disclosed ⇒
-judged on authorized / needs-an-ADR / needs-a-follow-up; clean ⇒ PASS, phrased as *nothing
-undisclosed that this gate could see*, never as *no deviations exist*).
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]` **on a PR that owes it**, absent is
+not `None.`, and `[N/A]` on one that does not; disclosed ⇒ judged on authorized / needs-an-ADR /
+needs-a-follow-up; clean ⇒ PASS, phrased as *nothing undisclosed that this gate could see*, never as
+*no deviations exist*).
 
 ```
 - [FAIL] deviation-disclosure — the ADR sweep (Step 4a) shows this diff narrows ADR 0115 §5's reclaim invariant (§DEV class 2) and the body's `## Deviations` says `None.`; disclose it and either cite the amending ADR or add one (the #3986/#3993 F1 remedy)
 ```
 
-**The issueless doc PR (ADR 0075) is the one N/A.** With no linked issue there is no spec to depart
-from and no `write-code` author obliged by §DEV, so render this as
-`- [N/A] deviation-disclosure — no linked issue (docs-only, ADR 0075)` and omit the check, exactly as
-the acceptance-criteria table is rendered N/A in Step 5.
+**Whether the PR owes the section at all is §DEV's call, not this step's** — read *Who owes the
+section* there. Concretely for this gate: the issueless doc PR (ADR 0075) whose acceptance-criteria
+table Step 5 already renders N/A carries the row N/A too —
+`- [N/A] deviation-disclosure — issueless carve-out, no write-code author obliged (§DEV)`. This step
+used to carry that exception as its own private paragraph, which is exactly why `review-code` and
+`review-design` rendered `[FAIL]` on the same head; the rule now lives in one place and every gate
+cites it.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -770,6 +770,39 @@ changes).
 
 ---
 
+## Step 4c — Deviation-disclosure gate: an undisclosed departure is a blocking finding (§DEV)
+
+Every `write-code` PR body carries a `## Deviations` section stating what the implementation
+departed from — the issue, an acceptance criterion, a reviewer's guidance, or a governing ADR — or
+the literal `None.`. The section, the seven classes, the detection tiers, the canonical Tier-M scan,
+and the two-branch verdict rule live once in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §DEV; run them from there and don't
+re-derive them. The gap it closes is on `main`: PR #3986 narrowed ADR 0115 §5's reclaim invariant in
+skill prose, the author offered *in review conversation* to file the amending ADR, the body carried
+nothing, and the narrowing merged as debt an audit reconstructed later (#3993 F1).
+
+**The doc-class read that feeds it is already done.** §DEV's most consequential class on a doc diff
+is class 2 — a departure from a governing ADR — and Step 4a's contradiction sweep is exactly that
+read. A contradiction the sweep found is a deviation; check whether the body discloses it, and
+whether the diff carries the amending ADR the disclosure claims. Step 4's hygiene checklist feeds
+class 7 (a doc surface touched that the issue does not imply) the same way.
+
+Fold **one** `deviation-disclosure` row into the conjunctive verdict by §DEV's rule
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`, absent is not `None.`; disclosed ⇒
+judged on authorized / needs-an-ADR / needs-a-follow-up; clean ⇒ PASS, phrased as *nothing
+undisclosed that this gate could see*, never as *no deviations exist*).
+
+```
+- [FAIL] deviation-disclosure — the ADR sweep (Step 4a) shows this diff narrows ADR 0115 §5's reclaim invariant (§DEV class 2) and the body's `## Deviations` says `None.`; disclose it and either cite the amending ADR or add one (the #3986/#3993 F1 remedy)
+```
+
+**The issueless doc PR (ADR 0075) is the one N/A.** With no linked issue there is no spec to depart
+from and no `write-code` author obliged by §DEV, so render this as
+`- [N/A] deviation-disclosure — no linked issue (docs-only, ADR 0075)` and omit the check, exactly as
+the acceptance-criteria table is rendered N/A in Step 5.
+
+---
+
 ## Step 5 — Land the verdict
 
 **Run the specialist fan-out + route step (Step 4b) before composing the verdict** so any

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -544,13 +544,21 @@ a disclosed narrowing is still a check-4 FAIL if it weakens a gate, and an autho
 change is still a §DEV FAIL if the body hid it.
 
 Fold **one** `deviation-disclosure` row into the conjunctive verdict by §DEV's rule
-(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`, absent is not `None.`; disclosed ⇒
-judged on authorized / needs-an-ADR / needs-a-follow-up; clean ⇒ PASS, phrased as *nothing
-undisclosed that this gate could see*, never as *no deviations exist*).
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]` **on a PR that owes it**, absent is
+not `None.`, and `[N/A]` on one that does not; disclosed ⇒ judged on authorized / needs-an-ADR /
+needs-a-follow-up; clean ⇒ PASS, phrased as *nothing undisclosed that this gate could see*, never as
+*no deviations exist*).
 
 ```
 - [FAIL] deviation-disclosure — skills/write-code/SKILL.md:NNN narrows ADR 0115 §5's reclaim invariant (§DEV class 2) and the body's `## Deviations` says `None.`; disclose it and either cite the amending ADR or add one (the #3986/#3993 F1 remedy)
 ```
+
+**Whether the PR owes the section at all is §DEV's call, not this step's** — read *Who owes the
+section* there. Concretely for this gate: a PR whose acceptance-criteria half is already N/A under
+the issueless carve-out (ADR 0184/0075 — the conversation-authored `.glossary/**` coining PR, which
+has no `write-code` author) carries the row N/A too —
+`- [N/A] deviation-disclosure — issueless carve-out, no write-code author obliged (§DEV)`. Do **not**
+re-derive that scoping here; a per-skill copy is what let two gates render opposite rows on one head.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -524,6 +524,36 @@ before composing the Step 5 verdict** so the appended row appears in the table.
 
 ---
 
+## Step 4c — Deviation-disclosure gate: an undisclosed departure is a blocking finding (§DEV)
+
+Every `write-code` PR body carries a `## Deviations` section stating what the implementation
+departed from — the issue, an acceptance criterion, a reviewer's guidance, or a governing ADR — or
+the literal `None.`. The section, the seven classes, the detection tiers, the canonical Tier-M scan,
+and the two-branch verdict rule live once in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §DEV; run them from there and don't
+re-derive them.
+
+**This gate owns the class the incident belongs to.** #3986 was a *skill* PR: it narrowed ADR 0115
+§5's reclaim invariant **in skill prose**, the author offered in review conversation to file the
+amending ADR, the body carried nothing, and the narrowing merged as debt an audit reconstructed
+(#3993 F1). §DEV class 2 — an ADR departure with no amending ADR — is therefore continuous with
+Step 4's check 4 (gate-invariant preservation): a quietly-narrowed invariant is *both* a weakened
+gate and an undisclosed deviation. Where check 4 asks *did this weaken a guardrail*, this step asks
+*did the author say what they changed about the governing decision*. A diff can fail either alone —
+a disclosed narrowing is still a check-4 FAIL if it weakens a gate, and an authorized, non-weakening
+change is still a §DEV FAIL if the body hid it.
+
+Fold **one** `deviation-disclosure` row into the conjunctive verdict by §DEV's rule
+(undisclosed-and-detected ⇒ `[FAIL]`; absent section ⇒ `[FAIL]`, absent is not `None.`; disclosed ⇒
+judged on authorized / needs-an-ADR / needs-a-follow-up; clean ⇒ PASS, phrased as *nothing
+undisclosed that this gate could see*, never as *no deviations exist*).
+
+```
+- [FAIL] deviation-disclosure — skills/write-code/SKILL.md:NNN narrows ADR 0115 §5's reclaim invariant (§DEV class 2) and the body's `## Deviations` says `None.`; disclose it and either cite the amending ADR or add one (the #3986/#3993 F1 remedy)
+```
+
+---
+
 ## Step 5 — Land the verdict
 
 **Run the specialist fan-out + route step (Step 4b) before composing the verdict** so any

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -122,8 +122,12 @@ CONTROL_PLANE_RE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/
   questions (authorized? needs an ADR? needs a follow-up issue?), and the reduced fan-out has no
   slot for them. You do **not** grade the deviation here — the lighter path's premise is gone, so
   you decline to be this PR's gate.
-- **The body carries no `## Deviations` heading at all** — a malformed body (§DEV: absent is not
-  `None.`), which the full gate FAILs on. Route it there rather than passing it on the light path.
+- **The body carries no `## Deviations` heading at all** — with no section there is no `None.` claim,
+  so the triviality premise is unprovable and you route to the full path. Note what this bounce does
+  **not** decide: whether the absence is a defect is §DEV's *Who owes the section* question, and the
+  full gate answers it — `[FAIL]` on a PR that owed the section, `[N/A]` on one that never did (a
+  bot-opened bump, the ADR 0184/0075 issueless lane). So this stays **default-deny** — it costs a
+  not-owed PR a full review, never a dead-end, which is why it does not need the scoping itself.
 
 On any refusal, emit a `review-trivial: not-trivial — route to full path` note (a plain note,
 **not** a verdict marker — you are declining to be this PR's gate) and stop. The executor's
@@ -138,11 +142,15 @@ fi
 # §DEV: the disclosure section decides triviality too — a disclosed deviation, or a missing heading,
 # routes to the full path. Read the section's body (heading → next heading or EOF) and compare.
 BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
+# `IGNORECASE` is a gawk extension BSD/macOS awk ignores SILENTLY, so a lowercase `## deviations`
+# heading yielded an empty DEV_BODY here while the case-insensitive `grep -i` below still saw the
+# heading — the two halves disagreed about case. Spell the case-insensitivity into the pattern
+# instead (POSIX, portable) so both halves read the same heading.
 DEV_BODY="$(printf '%s\n' "$BODY" \
-  | awk 'BEGIN{IGNORECASE=1} /^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$/{f=1;next} /^[[:space:]]*#{1,3}[[:space:]]/{f=0} f' \
+  | awk '/^[[:space:]]*###?[[:space:]]*[Dd][Ee][Vv][Ii][Aa][Tt][Ii][Oo][Nn][Ss][[:space:]]*$/{f=1;next} /^[[:space:]]*##?#?[[:space:]]/{f=0} f' \
   | grep -Ev '^[[:space:]]*$')"
 if ! printf '%s\n' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$'; then
-  echo "review-trivial: not-trivial — no ## Deviations section (malformed body, §DEV); route to full path"; exit 0
+  echo "review-trivial: not-trivial — no ## Deviations section, so no None. claim to stand on (§DEV); route to full path, which decides owed-vs-not"; exit 0
 elif [ "$(printf '%s\n' "$DEV_BODY" | grep -c .)" = 1 ] && printf '%s\n' "$DEV_BODY" | grep -Eiqx '[[:space:]]*none\.?[[:space:]]*'; then
   : # exactly one non-blank line, and it is `None.` — the triviality premise holds, continue Step 0
 else

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -115,6 +115,15 @@ CONTROL_PLANE_RE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/
 - **A new surface, control-flow change, dep, schema/migration, or config key** is visible —
   the change adds executable behavior rather than correcting existing prose or a single trivial
   line. Any new surface needs the full gate.
+- **The body's `## Deviations` section is anything other than `None.`** — the author disclosed a
+  departure from the issue, an acceptance criterion, a reviewer's guidance, or a governing ADR
+  ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §DEV). A disclosed deviation is
+  **evidence the diff is not trivial**: it is a judgment call that needs the full gate's three
+  questions (authorized? needs an ADR? needs a follow-up issue?), and the reduced fan-out has no
+  slot for them. You do **not** grade the deviation here — the lighter path's premise is gone, so
+  you decline to be this PR's gate.
+- **The body carries no `## Deviations` heading at all** — a malformed body (§DEV: absent is not
+  `None.`), which the full gate FAILs on. Route it there rather than passing it on the light path.
 
 On any refusal, emit a `review-trivial: not-trivial — route to full path` note (a plain note,
 **not** a verdict marker — you are declining to be this PR's gate) and stop. The executor's
@@ -124,6 +133,23 @@ the worst case of a miss is paying the full (correct) cost, never an under-gated
 ```bash
 if printf '%s\n' "$FILES" | grep -Eq "${CONTROL_PLANE_RE:-.}"; then
   echo "review-trivial: not-trivial — control-plane file present; route to full path (ADR 0053/0065)"; exit 0
+fi
+
+# §DEV: the disclosure section decides triviality too — a disclosed deviation, or a missing heading,
+# routes to the full path. Read the section's body (heading → next heading or EOF) and compare.
+BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
+DEV_BODY="$(printf '%s\n' "$BODY" \
+  | awk 'BEGIN{IGNORECASE=1} /^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$/{f=1;next} /^[[:space:]]*#{1,3}[[:space:]]/{f=0} f' \
+  | grep -Ev '^[[:space:]]*$')"
+if ! printf '%s\n' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$'; then
+  echo "review-trivial: not-trivial — no ## Deviations section (malformed body, §DEV); route to full path"; exit 0
+elif [ "$(printf '%s\n' "$DEV_BODY" | grep -c .)" = 1 ] && printf '%s\n' "$DEV_BODY" | grep -Eiqx '[[:space:]]*none\.?[[:space:]]*'; then
+  : # exactly one non-blank line, and it is `None.` — the triviality premise holds, continue Step 0
+else
+  # anything else — a disclosed deviation, OR an empty section (which is not the `None.` claim §DEV
+  # requires) — is outside the lighter gate's bound. Default-deny, exactly like the unreadable
+  # CONTROL_PLANE_RE above: you cannot prove the premise, so you must not treat the diff as trivial.
+  echo "review-trivial: not-trivial — the body discloses a deviation, or its ## Deviations section is empty (§DEV); route to full path"; exit 0
 fi
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1476,6 +1476,27 @@ regression of #1257/#1271). In the graceful-absence case (no `product-developmen
 substrate, ADR 0062) Step 4b never fires, so there is no `FLAG_KEY` and no `Flag:` line — the PR
 ships normally.
 
+**Every PR body carries a `## Deviations` section — no exceptions, and `None.` only after you
+walked the list.** You made judgment calls the issue did not specify: you narrowed a suggested
+fix-shape, you left a sibling defect for a follow-up, you declined a reviewer's optional
+suggestion, you pushed past a hook, you changed a test that asserted the defect. Those calls are
+usually right, and until now nothing made you say them out loud — so they lived in your session
+and died there, and the pipeline only learned about the ones a forthcoming run happened to
+volunteer. The section, its four fields, the **seven classes** you check `None.` against, and the
+gates' verdict rule are defined once in the contract's
+[§DEV](../gh-issue-intake-formats.md) — read the classes there and compose against them; do not
+re-derive them here. Two operational points that are yours, not the contract's:
+
+- **Write it last, from the whole build, not from memory of the plan.** Re-read your own diff
+  against the issue's `### What to build` + `### Acceptance criteria` and against any ADR you
+  touched, then walk the seven classes. A deviation you noticed at hour one and forgot by PR-open
+  is exactly the one that ships undisclosed.
+- **`None.` is a claim you are accountable for.** A gate that finds a class-N deviation against a
+  `None.` blocks on two counts (§DEV) — the deviation, and the false disclosure. An honest entry
+  costs one sentence and is never itself a FAIL; the disposition line is where you say what you
+  did about it (`no action needed` / `ADR #NNNN amends it` / `follow-up #M filed` /
+  `for the reviewer to judge`).
+
 ```bash
 # RE-DERIVE the branch LIVE from the worktree — never a cached/shared-file value (see the
 # live-derivation rule in Step 4). $BRANCH from Step 4 is GONE across Bash calls; wt_preflight
@@ -1486,8 +1507,8 @@ git -C "$WT" push -u origin "$BRANCH"   # gate the push ([per-mutation preflight
 # The PR opens AGAINST issue #N (Fixes #N) — gate it on the mis-attribution guard (Step 3.5): open a
 # PR closing only an issue whose claim is mine, never one mis-attributed to another agent's #N.
 claim_is_mine "<N>" || { echo "refusing to open a PR against #<N> — not my claim (Step 3.5)"; exit 1; }
-# The body carries `Fixes #N` always; ADD the `Flag: <FLAG_KEY>` line BELOW it ONLY when Step 4b
-# fired (a dark ship behind a flag — newly-declared OR prior-PR). Omit it entirely for an ungated PR.
+# The body carries `Fixes #N` and `## Deviations` ALWAYS; ADD the `Flag: <FLAG_KEY>` line ONLY when
+# Step 4b fired (a dark ship behind a flag — newly-declared OR prior-PR). Omit it for an ungated PR.
 gh pr create \
   --base main \
   --title "<concise PR title>" \
@@ -1496,6 +1517,10 @@ gh pr create \
 
 Fixes #<N>
 Flag: <FLAG_KEY>
+
+## Deviations
+
+<one entry per departure — class, Said / Did / Why / Disposition (§DEV) — or the literal `None.`>
 EOF
 )"
 ```
@@ -1547,6 +1572,14 @@ if [ -n "$FLAG_KEY" ]; then
     && echo "dark-ship Flag: line present and matches ship-it Step 5b — release queue will fire" \
     || echo "MISSING/MALFORMED Flag: line — Step 4b fired but the body has no matching plain 'Flag: <key>' line; patch it in before stopping (#1282)"
 fi
+# (e) DISCLOSURE PRESENCE, REST-only: the body carries a `## Deviations` heading. This is the
+#     PRESENCE floor only — it cannot tell an honest `None.` from a false one, and it sees none of
+#     the seven classes (§DEV's detection tiers). It exists so the one failure mode that is purely
+#     mechanical — forgetting the heading — never reaches a gate as a malformed body.
+gh api repos/$REPO/pulls/<PR> --jq '.body' \
+  | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$' \
+  && echo "## Deviations section present" \
+  || echo "MISSING ## Deviations section — an ABSENT section is a gate FAIL (§DEV: absent is not None.); patch the body before stopping"
 ```
 
 If (b) reports a broken seam, the body links `#N` with **neither** a closing keyword **nor**
@@ -1563,7 +1596,9 @@ close directive, a sibling/related `#M` carries a closing keyword that will wron
 form (`addresses`/`relates to`/`see #M`) and re-run (c), since shipping it is exactly the
 #1259 silent-auto-close. If (d) reports a missing/malformed `Flag:` line on a Step-4b dark ship,
 patch the body via REST to add the plain `Flag: <FLAG_KEY>` line and re-run (d), since shipping it
-without the line silently drops the dark ship from ship-it's release queue (#1282).
+without the line silently drops the dark ship from ship-it's release queue (#1282). If (e) reports a
+missing `## Deviations` section, patch the body the same way and re-run (e) — an absent section is a
+gate FAIL by itself (§DEV), and the heading is the one part of the obligation a grep can hold you to.
 
 ### Attach before/after composition captures (UI diffs only) — the #2964 evidence-attach
 
@@ -2094,6 +2129,18 @@ not just that boxes were checked. The same note carries into the Step 7 epic han
 ("Affects siblings") for a sub-issue, since a reviewer-added criterion is exactly the kind of
 cross-task signal a sibling should know the gate now enforces. Pushing new commits is what
 makes the **stateless** gate re-run — you do **not** re-trigger or self-approve it:
+
+**A repair round that departed from anything APPENDS to `## Deviations` — it never rewrites it.**
+The repair round is where the undisclosed call is most likely to be made and least likely to be
+written down: you declined an optional reviewer suggestion, you fixed the finding a narrower way
+than the verdict prescribed, you changed a pre-existing test the fix now contradicts, you pushed
+past a hook. Walk the contract's seven classes ([§DEV](../gh-issue-intake-formats.md)) against
+*this round's* diff, and if any fired, patch the PR body to add the entries under the existing
+`## Deviations` heading, tagged `**(repair round K)**`, leaving every earlier entry standing — the
+section is the PR's whole-life log, and a round that overwrites it erases the trail. A round that
+departed from nothing adds nothing; it does **not** rewrite a prior round's entries to `None.`
+(patch via REST — `gh api -X PATCH repos/$REPO/pulls/$PR -f body="…"` — since `gh pr edit` is
+unreliable in this org).
 
 ```bash
 # re-assert the mis-attribution guard (Step 3.5) before the resubmit push — a between-calls cwd


### PR DESCRIPTION
Coders make judgment calls the issue never specified — narrowing a suggested fix-shape, leaving a sibling defect for a follow-up, declining a reviewer's optional suggestion, pushing past a hook, changing a test that asserted the defect. Those calls are usually right, but nothing made anyone say them out loud, so they lived in a coder's session and died there. This adds a required `## Deviations` section to every write-code PR body, defines it once in the formats contract, and gives the review gates teeth: a departure a gate detects that the body did not disclose is a blocking finding, and a disclosed one is a judgment item the gate verifies.

Fixes #4064

## What's in it

- **`gh-issue-intake-formats.md` gains §DEV** — the single definition: the section shape (an entry states what the spec **said**, what the implementation **did** instead, **why**, and its **disposition**), the **seven deviation classes** that make `None.` a checked claim rather than a shrug, *absent is not `None.`*, *repair appends never replaces*, the detection tiers, the canonical Tier-M scan, and the two-branch verdict rule.
- **`write-code`** — Step 5 composes the section on every PR it opens (and self-checks its presence as check `(e)`, alongside the existing seam/stray/flag checks); repair R3 appends round-tagged entries under the same heading rather than rewriting it.
- **The four PR-verdict gates** — `review-code` Step 3g, `review-doc` Step 4c, `review-skill` Step 4c, `review-design` Step 3b each fold one `deviation-disclosure` row into their conjunctive verdict. Each cites §DEV and adds only what is gate-specific.
- **`review-trivial`** — Step 0 bounce, not a verdict row (see Scope below).
- **ADR 0216** records the cross-gate obligation and the honest limits of its teeth.

## Gate scope — decided, not inherited (AC 3)

The original report named three gates. Scope was decided against §6.6's four PR-verdict gates plus `review-trivial`:

| Gate | Role | Why |
|---|---|---|
| `review-code` | verdict row | Tier-M scan + its AC table and Step 3e threads already supply Tier R |
| `review-doc` | verdict row | Step 4a's ADR-contradiction sweep *is* the class-2 read; N/A on an issueless ADR-0075 PR |
| `review-skill` | verdict row | #3986 was a skill PR — this gate owns the incident's class, continuous with its check-4 gate-invariant preservation |
| `review-design` | verdict row | §DEV generalizes its own golden-deviation class from pixels to spec |
| `review-trivial` | **Step-0 bounce** | a disclosed deviation is evidence the diff is *not* trivial; the reduced fan-out has no slot for §DEV's three questions, so it declines to be the gate rather than grading on the light path |

## How much of this is actually enforced

"Gates fail undisclosed ones" is only true of what a gate can observe, so §DEV states the tiers rather than implying more:

- **Tier M — mechanically detectable from the diff.** In-diff suppressions (`biome-ignore`, `@ts-expect-error`, `.skip(`, `.only(`) and removed assertion lines in tests. One canonical grep, run by every gate carrying the row. Section *presence* is mechanical too.
- **Tier R — reader-detectable.** Scope narrowing, ADR departure, declined guidance. No new read: the gates already grade the AC list, sweep ADR contradictions, and surface unresolved threads.
- **Tier D — disclosure-only, catchable by nothing.** A deliberately unfixed sibling defect lives only in the author's head; a `--no-verify` push leaves no trace in the diff, the body, or the timeline. No gate can fail an omission here. What the obligation buys is that non-disclosure becomes a rule violation rather than an oversight, with a named place for an audit to point at.

So a passing row means *nothing undisclosed that this gate could see* — never *no deviations exist*, and the gates are told to phrase it that way.

## §CP classification — from the probe

`pipeline-cli control-plane-paths` (re-resolved live from `origin/main`) matched **7 of the 8 changed files**: the six skills plus `gh-issue-intake-formats.md`. `pipeline-cli class-probe classify --namespaces` returns `review-doc` + `review-skill`. **This PR is §CP** and banks for `@kamp-us/control-plane` approval.

## Deviations

- **Scope narrowing (class 1)** — **Said:** AC 3 asks each PR-verdict gate in scope to treat a detected-but-undisclosed deviation as a blocking finding, with scope decided against §6.6's four gates *plus* `review-trivial`. **Did:** `review-trivial` gets a Step-0 triviality bounce instead of a `deviation-disclosure` verdict row. **Why:** its lighter checklist is licensed by the diff being bounded-trivial; a diff carrying a disclosed deviation has already broken that premise, so grading it on the reduced fan-out would under-gate a judgment call. The AC also asks the scope decision be *stated in the PR*, which the table above does. **Disposition:** no ADR needed; recorded in ADR 0216 as a rejected alternative.
- **Addition beyond the stated scope (class 7)** — **Said:** the triage notes deliberately drop the report's "cheap mechanical floor (a CI check that the section exists)" and say to file it separately if it earns its keep. **Did:** added a section-presence grep as `write-code` Step 5 check `(e)` and inside §DEV's Tier-M scan. **Why:** neither is the declined artifact — no CI job, no workflow to maintain. `(e)` is a writer-side self-check in the same block as the existing `(b)`/`(c)`/`(d)` seam checks, and the Tier-M presence line is part of the gate read the gate was going to do anyway. **Disposition:** flagged for the reviewer to judge; a reviewer who reads this as the declined unit should say so and it comes out.
- **Nothing else fired.** Walked the remaining five classes: no governing-ADR departure (ADR 0216 is additive and cites its precedents), no known defect left unfixed, no declined reviewer guidance (no prior round), no guard bypassed (pushed clean, hooks ran, no `--no-verify`), no pre-existing test or fixture changed.

- **(repair round 1) Scope narrowing (class 1)** — **Said:** the `review-doc` / `review-skill` FAIL at `c8a69f3` names the missing N/A branch, and the out-of-scope finding it routed to #4175 is that §DEV class 2 admits only an accepted ADR, so a departure from `.patterns/`, `design-system-manifest.md`, or a CLAUDE.md convention has no class — which weakens the "closed list" premise behind `None.`. **Did:** did not widen the enumeration in this repair. **Why:** #4064's AC1 scopes an entry's spec sources to "plan / issue / governing ADR", so widening here would be the repair round deciding a question the issue did not ask; the reviewer filed it as #4175 for triage under ADR 0079's route-don't-grade. **Disposition:** follow-up #4175 filed; no ADR needed here.
- **(repair round 1) Nothing else fired.** Walked the other six classes for this round's diff: no governing-ADR departure (ADR 0216 is this PR's own decision record and the scoping is written into it, not around it), no known defect left unfixed, no declined guidance (the three rulings the FAIL made — keep the writer-side presence grep, keep `None.`-as-falsifiable-claim, keep 0216 as the number — were all followed), no guard bypassed (pushed clean, hooks ran, no `--no-verify`), no pre-existing test or fixture changed, no out-of-scope surface touched (the same 8 paths as round 0).

- **(repair round 2) Declined guidance (class 4)** — **Said:** the round-1 PASS's non-blocking `DEV_TESTCUTS` finding states the remedy is a one-line fix — reset the in-test flag on `+++ /dev/null` as well, so a file-header line always re-decides it. **Did:** two lines — every `+++ ` header re-decides the flag, *and* a deleted file (`+++ /dev/null`) takes its path from the `--- a/<path>` side. **Why:** the literal one-line remedy fixes only the first of the two consequences the gate itself reproduced. Clearing the flag on `/dev/null` stops the false positives from a deleted non-test file, but a **deleted test file** would then score `t = 0` and its removed assertions would still be silently dropped — the exact class-6 case the scan exists to arm, which was the gate's own second reproduced consequence. Reading the path from the `---` side is what actually closes both directions. **Disposition:** no ADR needed; for the reviewer to judge whether the extra line is warranted — both directions are verified below.
- **(repair round 2) Addition beyond the stated scope (class 7)** — **Said:** the round-1 PASS's third non-blocking note observes the section-presence regex now lives in three places and explicitly says *do not attempt a refactor; at most note it; not a blocker*. **Did:** added a three-line comment at the canonical site (§DEV's Tier-M scan) naming the two restating lanes. **Why:** the note was the sanctioned response, and the canonical copy is where a maintainer changing the pattern will be standing. No refactor, no new mechanism. **Disposition:** flagged for the reviewer to judge; drop it if the note reads as noise rather than a drift guard.
- **(repair round 2) Nothing else fired.** Walked the other five classes for this round's diff: no scope narrowing (both findings fixed in full, and the second one *wider* than stated, disclosed above), no governing-ADR departure (the ADR edit *removes* a false citation — ADR 0073 §5 is titled "One advisory form — converge the three gates" and never mentions `review-design`, so it cannot source a four-gate set; §6.6 is titled "one form for all four gates" and enumerates all four; both ends read at source before editing), no known defect left unfixed, no guard bypassed (pushed clean, full pre-push hook ran, no `--no-verify`), no pre-existing test or fixture changed. Two of the eight round-0 paths touched, no new surface.

## Repair round 2 — what changed

Both findings from the round-1 `review-doc` / `review-skill` PASS at `abbdf81`. Neither was blocking.

**1. A false citation in what becomes an immutable record.** ADR 0216 decision point 5 cited **ADR 0073 §5** as the source of the four-gate set. That section is titled *"One advisory form — converge the **three** gates"* and `review-design` appears nowhere in the file, so it cannot be that source. The four-gate set is defined in the contract's **§6.6**, *"The canonical advisory line — one form for all four gates"*, which enumerates all four and is what #4064's own body pointed at. Both ends verified against source before the edit. An accepted ADR's body is immutable after merge, so this was the last round in which it could be fixed.

**2. `DEV_TESTCUTS` left its in-test flag stale across a deleted file.** The scan set the flag only on `+++ b/`, so a deleted file's `+++ /dev/null` header never re-decided it. Reproduced both directions with adversarial diffs before fixing, then re-ran the shipped snippet verbatim:

| adversarial diff | before | after |
| --- | --- | --- |
| deleted **non-test** file after a test file | 2 lines — the real assertion **plus** a false positive (`-export function assert(...)` from the deleted `src/legacy.ts`) | 1 line — the real assertion only |
| deleted **test** file after a non-test file | 0 lines — `-  expect(bar()).toEqual(42);` **silently missed** | 1 line — caught |
| regression (the original `--- a/src/assert.ts` header case, an added test file, a `__tests__` removal, a non-test `expect(` removal) | 1 line, correct | 1 line, unchanged |

The fix: every `+++ ` header re-decides the flag, and a deleted file takes its path from the `--- a/<path>` side.

**3. The three-places regex note.** Non-blocking and explicitly not-a-refactor; recorded as a three-line comment at the canonical site. Disclosed as class 7 above.

The `review-doc` / `review-skill` FAIL at `c8a69f3` found one blocking root, and fixing it discharges AC 4.

**The defect.** §DEV stated *absent section ⇒ FAIL* unconditionally, but the writer obligation only binds `write-code`-authored PRs — and the N/A exception lived as a **per-skill fragment** in `review-doc` Step 4c. `review-code` 3g and `review-design` 3b carried no N/A branch. So an ADR 0184/0075 issueless PR (conversation-authored, no `write-code` author, therefore no `## Deviations` section) drew `[N/A]` from one gate and `[FAIL]` from another **at the same head**. The verdicts are conjunctive and `write-code` is not the author, so no repair round could ever clear it: a blessed lane, permanently deadlocked.

**The fix — the scoping now lives in §DEV once, and all five lanes cite it.** §DEV gains a *Who owes the section* subsection: the row is `[N/A]` only on **positively-established non-obligation**, in exactly two shapes — the gate's own issueless carve-out already fired (the row inherits that gate's acceptance-criteria determination, so the two cannot drift apart again), or the PR was not authored by `write-code` (a bot bump, a hand-authored PR). Everything else is owed; a pipeline PR that merely **lost** its `Fixes #N` buys no exemption, since each gate already hard-stops that shape as a broken seam. `review-doc`'s private paragraph is gone — it now cites §DEV like the other four. No per-skill N/A branch was added anywhere, which is what AC 4 forbids.

**The five non-blocking notes, folded in:**

1. The Tier-M scan's doubled empty count — `grep -c . || echo 0` emitted a `0` from each half. Dropped the fallback.
2. `DEV_TESTCUTS` greped `^-` across the whole diff, so a `--- a/src/assert.ts` header matched on `assert`. It now walks the diff file-by-file off `+++ b/<path>` and counts removals **inside test files only**, matching §DEV's prose.
3. `review-trivial`'s `BEGIN{IGNORECASE=1}` is a gawk extension BSD/macOS awk ignores silently, so its awk and its sibling `grep -i` disagreed about case on a lowercase `## deviations` heading. Replaced with a POSIX character-class pattern; verified both cases.
4. Classes 4 and 7 overlap in practice (this PR's own second entry reads as either). §DEV now states that a gate matches on the entry's **substance**, never the class label.
5. `review-code` 3g gains the explicit *never as "no deviations exist"* half the other three already carried.

**Not changed, deliberately.** The writer-side presence grep (Step 5 check `(e)`), `None.`-as-a-falsifiable-claim, and ADR 0216's number all stand — the FAIL ruled on each and upheld them. The missing-deviation-class gap (`.patterns/`, `design-system-manifest.md`, CLAUDE.md conventions) stays out of scope per ADR 0079, filed as #4175. ADR 0216 now records the scoping in its Decision point 3 and cites ADR 0120 for the `review-trivial` bounce.

