### PR TITLE
fix(worktree-reap): read owner presence from the #3988 owner stamp, not the lock alone (#3989)

### DIFF
--- a/packages/pipeline-cli/src/tools/worktree-reap/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/command.ts
@@ -7,13 +7,20 @@
  * re-checked-out elsewhere. This verb identifies trees whose owning SESSION is provably
  * dead, and reclaims only the ones that hold nothing recoverable.
  *
- * Eligibility is session-presence-based, never age-based (ADR 0191). The presence signal
- * is the owning process the harness stamps into each agent worktree's git lock reason —
- * `claude agent <id> (pid <N> start <date>)` (surfaced by `git worktree list --porcelain`
- * as the `locked <reason>` line). That pid is the top-level crew session process; a worktree
- * is orphan-eligible ONLY when its pid is provably not running (`process.kill(pid, 0)` →
- * ESRCH). This is the deliberate contrast with the age-based `worktree-sweep` (mtime-idle,
- * #2240): a genuinely idle-but-live session is spared here because its process still resolves.
+ * Eligibility is session-presence-based, never age-based (ADR 0191), read from two owner
+ * signals gathered here and folded by the pure classifier:
+ *
+ *   1. the git lock reason — `claude agent <id> (pid <N> start <date>)`, its pid probed with
+ *      `process.kill(pid, 0)` (ESRCH is the only proof of death);
+ *   2. the `kampus-owner.json` stamp `hooks/create-worktree.sh` writes into the tree's git
+ *      admin dir, resolved against the harness live-session registry through
+ *      `worktree-sweep`'s `owner-liveness.ts` — the shared resolution, not a second one (#3989).
+ *
+ * Signal 2 is what makes the verb effective at all: only a minority of managed trees carry a
+ * lock at any moment, so a lock-only gate spared essentially the whole population as
+ * `owner-unknown` (#3989). This is the deliberate contrast with the age-based `worktree-sweep`
+ * (mtime-idle, #2240): a genuinely idle-but-live session is spared here because its process
+ * still resolves.
  *
  * Safe by construction (enforcement lines):
  *   1. The pure classifier (`worktree-reap.ts`) marks a worktree reapable ONLY when its
@@ -32,13 +39,25 @@
  * registry provides.
  */
 import {execFileSync} from "node:child_process";
+import {readdirSync, readFileSync} from "node:fs";
+import {homedir} from "node:os";
+import {join} from "node:path";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {
+	liveSessionIds,
+	parseOwnerStamp,
+	parseSessionRegistryEntry,
+	resolveOwnerLiveness,
+} from "../worktree-sweep/owner-liveness.ts";
+import {
 	computeWorktreeReapPlan,
 	isManagedAgentWorktree,
+	type OwnerPresence,
+	ownerPresence,
 	parseAgentLockOwner,
 	parseWorktreeList,
+	presenceFromOwnerLiveness,
 	type ReapCandidate,
 } from "./worktree-reap.ts";
 
@@ -51,7 +70,14 @@ interface GitResult {
 const runGit = (args: ReadonlyArray<string>): GitResult => {
 	// biome-ignore lint/plugin: best-effort git shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
 	try {
-		const stdout = execFileSync("git", [...args], {encoding: "utf8"});
+		// Capture stderr instead of letting it inherit: over a few hundred worktrees, a tree whose
+		// directory is already gone makes git print `fatal: cannot change to …` for every probe, which
+		// would bury the plan this verb exists to show. The failure is not lost — it lands in the
+		// GitResult the caller branches on, and each probe already fails safe toward KEEP.
+		const stdout = execFileSync("git", [...args], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
 		return {ok: true, stdout, stderr: ""};
 	} catch (cause) {
 		const e = cause as {stdout?: Buffer | string; stderr?: Buffer | string};
@@ -75,6 +101,68 @@ const pidAlive = (pid: number): boolean => {
 	} catch (cause) {
 		return (cause as {code?: string}).code !== "ESRCH";
 	}
+};
+
+/**
+ * The harness's live-session registry directory — one `<pid>.json` per RUNNING session, deleted
+ * when the session exits. `$CLAUDE_CONFIG_DIR` is the harness's own override for the config root;
+ * absent it, the default config home under the user's home dir.
+ */
+const sessionRegistryDir = (): string =>
+	join(process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude"), "sessions");
+
+/** Read a file, or `null` on ANY failure — an unreadable input is never evidence about a session. */
+const readTextOrNull = (path: string): string | null => {
+	// biome-ignore lint/plugin: best-effort read — every failure mode (absent, unreadable, a race with the tree's removal) collapses into the same `null` the caller branches on, never the E channel. A total helper, not Effect-cosplay.
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * The set of session ids proven alive, or `null` when the registry can't be trusted to be complete
+ * — in which case every stamp resolves `"unknown"` and signal 2 spares everything. The trust rule
+ * (including the load-bearing "zero live entries means the registry is broken, not that nothing is
+ * running") lives in `liveSessionIds`; this is only its IO.
+ */
+const probeLiveSessions = (): ReadonlySet<string> | null => {
+	const dir = sessionRegistryDir();
+	let names: ReadonlyArray<string>;
+	// biome-ignore lint/plugin: best-effort enumeration — an unreadable registry dir is reported as `readable: false`, the fail-closed input `liveSessionIds` turns into "trust nothing", never the E channel.
+	try {
+		names = readdirSync(dir);
+	} catch {
+		return liveSessionIds({readable: false, entries: []});
+	}
+	const entries: Array<{sessionId: string; alive: boolean}> = [];
+	for (const name of names) {
+		if (!name.endsWith(".json")) continue;
+		const raw = readTextOrNull(join(dir, name));
+		if (raw === null) continue;
+		const entry = parseSessionRegistryEntry(raw);
+		if (entry === null) continue;
+		entries.push({sessionId: entry.sessionId, alive: pidAlive(entry.pid)});
+	}
+	return liveSessionIds({readable: true, entries});
+};
+
+/** The stamp `hooks/create-worktree.sh` writes into `<gitdir>/`; the two names must stay in sync. */
+const OWNER_STAMP_FILE = "kampus-owner.json";
+
+/**
+ * Signal 2 for one tree: its owner stamp resolved against the live-session registry. Unlike the
+ * sweep, this takes NO session-id-from-path fallback — that fallback exists for `$TMPDIR`-rooted
+ * `review-head-*` trees, which are not `.claude/worktrees/` managed trees and so never reach this
+ * verb. An unresolvable gitdir, an absent stamp, a malformed stamp, or an untrusted registry all
+ * read `"unknown"` (⇒ the tree is spared unless the lock signal independently proves death).
+ */
+const stampPresenceOf = (worktreePath: string, live: ReadonlySet<string> | null): OwnerPresence => {
+	const gitdir = runGit(["-C", worktreePath, "rev-parse", "--absolute-git-dir"]);
+	const raw = gitdir.ok ? readTextOrNull(join(gitdir.stdout.trim(), OWNER_STAMP_FILE)) : null;
+	const owner = raw === null ? null : parseOwnerStamp(raw);
+	return presenceFromOwnerLiveness(resolveOwnerLiveness({owner, liveSessionIds: live}));
 };
 
 /** `git status --porcelain` non-empty ⇒ uncommitted. Indeterminate (command failed) ⇒ uncommitted (fail-safe KEEP). */
@@ -131,6 +219,13 @@ const executeFlag = Flag.boolean("execute").pipe(
 
 const reasonLine = (path: string, reason: string): string => `  ${reason.padEnd(14)} ${path}`;
 
+/** Which signal(s) proved this tree's owner dead — so a reap line says WHY, not just that it will. */
+const deadOwnerLabel = (c: ReapCandidate): string => {
+	const lock = c.lockOwner === null ? null : `lock pid ${c.lockOwner.pid} dead`;
+	const stamp = c.stampPresence === "dead" ? "stamped session dead" : null;
+	return [lock, stamp].filter((s) => s !== null).join(" + ") || "owner dead";
+};
+
 const worktreeReap = Command.make(
 	"worktree-reap",
 	{execute: executeFlag},
@@ -143,40 +238,48 @@ const worktreeReap = Command.make(
 			return yield* Effect.sync(() => process.exit(1));
 		}
 
+		// Probed ONCE for the whole run, not per tree: it is a directory read plus one pid probe per
+		// running session, and a per-tree re-read would also let the answer drift mid-scan.
+		const live = probeLiveSessions();
+
 		const parsed = parseWorktreeList(listed.stdout);
 		const candidates: ReadonlyArray<ReapCandidate> = parsed
 			.filter((p) => !p.bare)
 			.map((p) => {
-				// Only a managed agent worktree with a provable crew-agent owner is probed for facts —
-				// everything else short-circuits to a SPARE record (the classifier never consults the
-				// other fields for it), so no `git status` / ancestry / pid probe fires on the primary
-				// checkout or a foreign tree.
-				const owner = isManagedAgentWorktree(p.path) ? parseAgentLockOwner(p.lockReason) : null;
-				if (owner === null) {
+				// The primary checkout and any foreign tree short-circuit to a SPARE record — the
+				// classifier never consults the other fields for them, so no stamp read, pid probe,
+				// `git status`, or ancestry walk ever fires outside `.claude/worktrees/`.
+				if (!isManagedAgentWorktree(p.path)) {
 					return {
 						path: p.path,
 						branch: p.branch,
-						owner: null,
+						lockOwner: null,
+						foreignLock: false,
+						stampPresence: "unknown" as const,
 						hasUncommitted: false,
 						hasUnpushed: false,
 					};
 				}
-				const alive = pidAlive(owner.pid);
-				// A LIVE session is spared regardless of tree state, so skip the costlier status/ancestry
-				// probes for it — only a dead-session tree needs its recoverable-work facts gathered.
-				if (alive) {
-					return {
-						path: p.path,
-						branch: p.branch,
-						owner: {pid: owner.pid, alive: true},
-						hasUncommitted: false,
-						hasUnpushed: false,
-					};
-				}
-				return {
+				const parsedLock = parseAgentLockOwner(p.lockReason);
+				const foreignLock = parsedLock === null && p.lockReason !== null;
+				const facts = {
 					path: p.path,
 					branch: p.branch,
-					owner: {pid: owner.pid, alive: false},
+					lockOwner:
+						parsedLock === null ? null : {pid: parsedLock.pid, alive: pidAlive(parsedLock.pid)},
+					foreignLock,
+					// An operator-pinned tree is spared whatever its owner says, so don't read its stamp.
+					stampPresence: foreignLock ? ("unknown" as const) : stampPresenceOf(p.path, live),
+				};
+				// Only a tree whose owner is PROVEN dead needs its recoverable-work facts gathered; a
+				// live or unprovable owner is spared before those checks are ever consulted, so the
+				// costlier status/ancestry probes are skipped for it. Gating on the classifier's own
+				// `ownerPresence` keeps that decision in one place instead of re-deriving it here.
+				if (ownerPresence(facts) !== "dead") {
+					return {...facts, hasUncommitted: false, hasUnpushed: false};
+				}
+				return {
+					...facts,
 					hasUncommitted: worktreeHasUncommitted(p.path),
 					hasUnpushed: hasUnpushed(p.head),
 				};
@@ -184,9 +287,16 @@ const worktreeReap = Command.make(
 
 		const plan = computeWorktreeReapPlan(candidates);
 
-		// ADR 0092 "emit what you scanned": the full plan is observable before any action.
+		// ADR 0092 "emit what you scanned": the full plan is observable before any action, and so is
+		// the registry's trust state — an untrusted registry silently disables signal 2 entirely, so
+		// it must be readable in the output rather than inferred from a wall of `owner-unknown`.
 		yield* Console.log(
 			`worktree-reap: ${candidates.length} worktree(s) scanned — ${plan.toReap.length} orphaned-clean (reapable), ${plan.keptDirty.length} kept-dirty, ${plan.spared.length} spared${execute ? " (EXECUTE)" : " (dry-run)"}`,
+		);
+		yield* Console.log(
+			live === null
+				? "  session registry: UNTRUSTED (absent/unreadable/no live entry) — owner stamps prove nothing this run"
+				: `  session registry: ${live.size} live session(s) — owner stamps resolved against it`,
 		);
 		if (plan.spared.length > 0) {
 			yield* Console.log("spared:");
@@ -199,7 +309,7 @@ const worktreeReap = Command.make(
 		if (plan.toReap.length > 0) {
 			yield* Console.log("orphaned-clean (reapable):");
 			for (const r of plan.toReap)
-				yield* Console.log(reasonLine(r.worktree.path, `pid ${r.worktree.owner?.pid ?? "?"} dead`));
+				yield* Console.log(reasonLine(r.worktree.path, deadOwnerLabel(r.worktree)));
 		}
 
 		if (!execute) {
@@ -212,9 +322,10 @@ const worktreeReap = Command.make(
 		const freedBranches: Array<string> = [];
 		for (const r of plan.toReap) {
 			const path = r.worktree.path;
-			// The tree is locked with a stale pid-lock (its session is proven dead). Unlock it —
-			// scoped to this classified-dead+clean tree — so the non-forced remove can proceed. This
-			// unlock never touches a live lane: a live session was spared before ever reaching here.
+			// If the tree still holds a lock it is OUR OWN stale pid-lock (its session is proven dead,
+			// and an operator's foreign lock was spared before reaching here). Unlock it — scoped to
+			// this classified-dead+clean tree — so the non-forced remove can proceed. Most reapable
+			// trees are simply unlocked, which reports "not locked" and is absorbed below.
 			const unlocked = runGit(["worktree", "unlock", path]);
 			if (!unlocked.ok) {
 				// An already-unlocked tree reports failure here; that is benign — proceed to remove.

--- a/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
@@ -7,15 +7,31 @@
  * `command.ts`; this module never runs a command and never removes anything.
  *
  * Eligibility is SESSION-PRESENCE-based, never age-based (issue #3754 AC; ADR 0191 —
- * a resource claim's liveness rides its holder's presence). The presence signal is
- * grounded in an observable git fact: the harness locks each agent worktree with a
- * reason that embeds the owning session's process — `claude agent <id> (pid <N>
- * start <date>)` (git worktree list --porcelain surfaces it as the `locked <reason>`
- * line). That pid is the top-level crew SESSION process shared by all worktrees it
- * provisioned; when it dies the session is gone and its worktrees are orphaned. A
- * worktree is reap-eligible ONLY when that owning pid is provably not running — the
- * presence-derived liveness ADR 0191 mandates, not an mtime idle window (the
- * distinction from the age-based `worktree-sweep`, #2240).
+ * a resource claim's liveness rides its holder's presence), and presence is read from
+ * TWO independent owner signals (#3989):
+ *
+ *   1. **the git lock reason** — `claude agent <id> (pid <N> start <date>)`, surfaced by
+ *      `git worktree list --porcelain` as the `locked <reason>` line, with that pid probed
+ *      for liveness at the boundary.
+ *   2. **the `kampus-owner.json` owner stamp** — the session id `hooks/create-worktree.sh`
+ *      writes into the tree's git admin dir, resolved against the harness's live-session
+ *      registry by `worktree-sweep`'s `owner-liveness.ts` (the shared resolution, #3943).
+ *
+ * The second signal is why this verb stopped being inert over the population it was shipped
+ * for: only a small minority of managed trees carry a lock at any moment (9 of 252 on the
+ * crew host at the time of writing), so a lock-only gate spared essentially everything as
+ * `owner-unknown` — indistinguishable from correct fail-closed behaviour, the silent-no-op
+ * class (#3989, #3887).
+ *
+ * BOTH signals name the LAUNCHER — the crew pane that provisioned the tree — never the
+ * subagent occupying it: the lock pid is the pane's, the stamp is written by the hook before
+ * the subagent exists, and a subagent has no session identity of its own on this platform
+ * (#4001). That makes launcher death sound in exactly one direction, which is the only
+ * direction this verb uses: a subagent runs inside its launcher's process, so a DEAD launcher
+ * proves every tree it spawned is unoccupied. A live launcher proves nothing about occupancy
+ * — and needs to prove nothing here, because this verb only ever acts on proven death (the
+ * distinction from the age-based `worktree-sweep`, #2240, which must reclaim under a live
+ * launcher and therefore carries the `launcher-alive` grace window this verb does not need).
  *
  * The safety property is the whole point (issue #3754 AC; MEMORY "Safe worktree
  * prune"): a worktree is reaped ONLY when its owning session is DEAD *and* the tree
@@ -23,10 +39,13 @@
  * or unpushed tree is KEPT (surfaced in the report as kept-dirty), never `--force`d.
  * Every fact fails safe toward KEEP: an unprovable owner reads SPARE (never reaped), an
  * indeterminate status reads uncommitted, an unresolvable ancestry reads unpushed, a
- * pid that still resolves (incl. a reused pid) reads alive → spared. `git worktree
- * remove` *without* `--force` is the second enforcement line in `command.ts`; this
- * core only chooses WHETHER to attempt the remove, and never escalates to a forced one.
+ * pid that still resolves (incl. a reused pid) reads alive → spared. With two signals the
+ * fail-safe becomes a two-key rule: ANY alive signal spares, and death must be POSITIVELY
+ * proven by at least one — so conflicting signals (one alive, one dead) resolve to spare.
+ * `git worktree remove` *without* `--force` is the second enforcement line in `command.ts`;
+ * this core only chooses WHETHER to attempt the remove, and never escalates to a forced one.
  */
+import type {OwnerLiveness} from "../worktree-sweep/owner-liveness.ts";
 
 /** The segment that marks a harness-managed agent worktree: `<main>/.claude/worktrees/<id>`. */
 const MANAGED_SEGMENT = "/.claude/worktrees/";
@@ -62,36 +81,73 @@ export const parseAgentLockOwner = (lockReason: string | null): AgentLockOwner |
 	return Number.isFinite(pid) && pid > 0 ? {pid} : null;
 };
 
+/** What one owner signal says about the owning session, three-state and fail-safe toward `alive`. */
+export type OwnerPresence = "alive" | "dead" | "unknown";
+
 /**
- * One worktree reduced to exactly the facts the decision needs. `owner` is the parsed
- * session with its liveness already probed at the boundary (`null` when no crew-agent
- * owner is provable). `hasUncommitted` (git status dirty) and `hasUnpushed` (commits not
- * yet landed on `origin/main`) are gathered at the git boundary, both fail-safe toward
- * KEEP: an indeterminate status reads uncommitted, an unresolvable ancestry reads unpushed.
+ * Read `worktree-sweep`'s stamp+registry verdict as a reap presence. Only `"dead"` licenses a
+ * removal and only `"unknown"` is genuinely no-signal; EVERY other verdict — `"alive"`,
+ * `"launcher-alive"`, and any variant added later — collapses to `"alive"` ⇒ SPARE. Naming the
+ * two act-permitting verdicts positively (rather than switching exhaustively over the union) is
+ * what makes a future verdict fail safe by default instead of by remembering to handle it.
+ */
+export const presenceFromOwnerLiveness = (liveness: OwnerLiveness): OwnerPresence =>
+	liveness === "dead" ? "dead" : liveness === "unknown" ? "unknown" : "alive";
+
+/**
+ * One worktree reduced to exactly the facts the decision needs. `hasUncommitted` (git status
+ * dirty) and `hasUnpushed` (commits not yet landed on `origin/main`) are gathered at the git
+ * boundary, both fail-safe toward KEEP: an indeterminate status reads uncommitted, an
+ * unresolvable ancestry reads unpushed.
  */
 export interface ReapCandidate {
 	readonly path: string;
 	/** Short branch name, or `null` for a detached HEAD. Reported as the freed branch on a reap. */
 	readonly branch: string | null;
 	/**
-	 * The parsed owning session AND its probed liveness, or `null` when no crew-agent owner is
-	 * provable from the lock (unlocked, operator-locked, or unparseable). `alive` is the boundary's
-	 * `pid`-presence probe: it reads TRUE unless the pid is provably gone (a still-resolving or
-	 * reused pid fails safe toward alive → SPARE).
+	 * Signal 1 — the owning session parsed off the git lock reason AND its probed liveness, or
+	 * `null` when no crew-agent owner is provable from the lock (unlocked, operator-locked, or
+	 * unparseable). `alive` is the boundary's `pid`-presence probe: it reads TRUE unless the pid is
+	 * provably gone (a still-resolving or reused pid fails safe toward alive → SPARE).
 	 */
-	readonly owner: (AgentLockOwner & {readonly alive: boolean}) | null;
+	readonly lockOwner: (AgentLockOwner & {readonly alive: boolean}) | null;
+	/**
+	 * The tree carries a lock this reaper did NOT author (an operator's `git worktree lock`). Such
+	 * a pin is honored unconditionally: reclaiming requires `git worktree unlock`, and unlocking a
+	 * tree a human deliberately pinned is exactly the intent this verb must not override — so it is
+	 * spared even when the other signal proves its session dead.
+	 */
+	readonly foreignLock: boolean;
+	/** Signal 2 — the `kampus-owner.json` stamp resolved against the live-session registry (#3989). */
+	readonly stampPresence: OwnerPresence;
 	readonly hasUncommitted: boolean;
 	readonly hasUnpushed: boolean;
 }
+
+/**
+ * The two owner signals folded into one presence. ANY alive signal wins (a live lane is never
+ * touched), death requires POSITIVE proof from at least one signal, and everything else is
+ * `"unknown"` — so a tree with one alive and one dead signal reads alive, never dead.
+ */
+export const ownerPresence = (
+	c: Pick<ReapCandidate, "lockOwner" | "foreignLock" | "stampPresence">,
+): OwnerPresence => {
+	if (c.foreignLock) return "unknown";
+	if (c.lockOwner?.alive === true || c.stampPresence === "alive") return "alive";
+	if (c.lockOwner?.alive === false || c.stampPresence === "dead") return "dead";
+	return "unknown";
+};
 
 /** Why a worktree is SPARED — never a candidate this run, or its session is still live. */
 export type SpareReason =
 	/** Not under `.claude/worktrees/` — the primary checkout or a foreign tree; never touched. */
 	| "not-managed"
-	/** No crew-agent owner is provable from the lock (unlocked, operator-locked, unparseable) — can't prove orphaned. */
+	/** Neither signal proves an owner (unlocked+unstamped, or an untrustworthy registry) — can't prove orphaned. */
 	| "owner-unknown"
-	/** The owning session's process is still running — a LIVE lane; spared (the ADR 0191 presence gate). */
-	| "live-session";
+	/** The owning session is still running per some signal — a LIVE lane; spared (the ADR 0191 presence gate). */
+	| "live-session"
+	/** Locked by someone other than this reaper (an operator pin) — never unlocked, never reaped. */
+	| "foreign-lock";
 
 /** Why an orphan is KEPT despite a dead session — it holds recoverable work; never destroyed. */
 export type KeepDirtyReason =
@@ -110,25 +166,30 @@ export type ReapDecision =
  *
  *   1. Not a managed agent worktree → SPARE (`not-managed`). The primary checkout and any
  *      foreign tree are never candidates, regardless of their other facts.
- *   2. No provable crew-agent owner → SPARE (`owner-unknown`). Without a parseable owning
- *      pid the session's liveness cannot be established, so orphanhood is unprovable — never
- *      reap what we cannot prove dead.
- *   3. Owning session ALIVE → SPARE (`live-session`). The ADR 0191 presence gate: a running
- *      owner pid means a live lane; spared even when the tree is clean.
- *   4. (Dead session) uncommitted → KEEP-DIRTY (`uncommitted`). Recoverable working-tree work.
- *   5. (Dead session) unpushed → KEEP-DIRTY (`unpushed`). Committed work not on `origin/main`.
- *   6. Otherwise → REAP (`orphan-clean`). Dead session, clean tree, all commits landed —
+ *   2. Locked by someone else → SPARE (`foreign-lock`). An operator pin outranks both owner
+ *      signals, because reclaiming would mean unlocking what a human deliberately locked.
+ *   3. Some signal says ALIVE → SPARE (`live-session`). The ADR 0191 presence gate, and the
+ *      reason conflicting signals are safe: any alive reading beats any dead one.
+ *   4. No signal proves DEATH → SPARE (`owner-unknown`). Orphanhood unprovable — never reap
+ *      what we cannot prove dead. This is where the unstamped, unlocked historical pile sits.
+ *   5. (Dead session) uncommitted → KEEP-DIRTY (`uncommitted`). Recoverable working-tree work.
+ *   6. (Dead session) unpushed → KEEP-DIRTY (`unpushed`). Committed work not on `origin/main`.
+ *   7. Otherwise → REAP (`orphan-clean`). Dead session, clean tree, all commits landed —
  *      nothing recoverable to strand.
  */
 export const classifyCandidate = (c: ReapCandidate): ReapDecision => {
 	if (!isManagedAgentWorktree(c.path)) {
 		return {kind: "spare", reason: "not-managed"};
 	}
-	if (c.owner === null) {
-		return {kind: "spare", reason: "owner-unknown"};
+	if (c.foreignLock) {
+		return {kind: "spare", reason: "foreign-lock"};
 	}
-	if (c.owner.alive) {
+	const presence = ownerPresence(c);
+	if (presence === "alive") {
 		return {kind: "spare", reason: "live-session"};
+	}
+	if (presence === "unknown") {
+		return {kind: "spare", reason: "owner-unknown"};
 	}
 	if (c.hasUncommitted) {
 		return {kind: "keep-dirty", reason: "uncommitted"};

--- a/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.unit.test.ts
@@ -3,19 +3,23 @@ import {
 	classifyCandidate,
 	computeWorktreeReapPlan,
 	isManagedAgentWorktree,
+	ownerPresence,
 	parseAgentLockOwner,
 	parseWorktreeList,
+	presenceFromOwnerLiveness,
 	type ReapCandidate,
 } from "./worktree-reap.ts";
 
 const MAIN = "/Users/dev/phoenix";
 const wtPath = (id: string) => `${MAIN}/.claude/worktrees/${id}`;
 
-/** A dead-session, clean, all-pushed candidate — the reapable shape. Override per case. */
+/** A dead-session (via the lock), clean, all-pushed candidate — the reapable shape. Override per case. */
 const candidate = (over: Partial<ReapCandidate> = {}): ReapCandidate => ({
 	path: wtPath("agent-dead"),
 	branch: "umut/1234-thing",
-	owner: {pid: 4242, alive: false},
+	lockOwner: {pid: 4242, alive: false},
+	foreignLock: false,
+	stampPresence: "unknown",
 	hasUncommitted: false,
 	hasUnpushed: false,
 	...over,
@@ -76,13 +80,13 @@ describe("classifyCandidate — the #3754 safety policy (dead+clean → reap; de
 	});
 
 	it("LIVE session → SPARED even when the tree is clean (the ADR 0191 presence gate)", () => {
-		const d = classifyCandidate(candidate({owner: {pid: 4242, alive: true}}));
+		const d = classifyCandidate(candidate({lockOwner: {pid: 4242, alive: true}}));
 		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
 	});
 
 	it("LIVE session with dirty work → still SPARED (liveness precedes the work checks)", () => {
 		const d = classifyCandidate(
-			candidate({owner: {pid: 4242, alive: true}, hasUncommitted: true, hasUnpushed: true}),
+			candidate({lockOwner: {pid: 4242, alive: true}, hasUncommitted: true, hasUnpushed: true}),
 		);
 		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
 	});
@@ -103,22 +107,138 @@ describe("classifyCandidate — the #3754 safety policy (dead+clean → reap; de
 	});
 
 	it("owner unprovable (null) → SPARED (owner-unknown), never reaped — can't prove orphaned", () => {
-		const d = classifyCandidate(candidate({owner: null}));
+		const d = classifyCandidate(candidate({lockOwner: null}));
 		assert.deepStrictEqual(d, {kind: "spare", reason: "owner-unknown"});
 	});
 
 	it("owner unprovable wins even on a clean tree — no age fallback, no reap without a dead-session proof", () => {
 		const d = classifyCandidate(
-			candidate({owner: null, hasUncommitted: false, hasUnpushed: false}),
+			candidate({lockOwner: null, hasUncommitted: false, hasUnpushed: false}),
 		);
 		assert.strictEqual(d.kind, "spare");
 	});
 
 	it("non-managed path → SPARED (not-managed), never touched — even with a dead owner + clean tree", () => {
 		const d = classifyCandidate(
-			candidate({path: "/Users/dev/some/bespoke/wt", owner: {pid: 4242, alive: false}}),
+			candidate({path: "/Users/dev/some/bespoke/wt", lockOwner: {pid: 4242, alive: false}}),
 		);
 		assert.deepStrictEqual(d, {kind: "spare", reason: "not-managed"});
+	});
+});
+
+describe("presenceFromOwnerLiveness — only `dead` licenses action, only `unknown` is no-signal", () => {
+	it("maps the sweep's four verdicts, reading a live LAUNCHER as alive (never a reap license)", () => {
+		assert.strictEqual(presenceFromOwnerLiveness("dead"), "dead");
+		assert.strictEqual(presenceFromOwnerLiveness("unknown"), "unknown");
+		assert.strictEqual(presenceFromOwnerLiveness("alive"), "alive");
+		// #4001's `launcher-alive` is uninformative about the OCCUPANT — but this verb only acts on
+		// proven death, so reading it as alive is the correct fail-safe here, not the #4001 over-KEEP.
+		assert.strictEqual(presenceFromOwnerLiveness("launcher-alive"), "alive");
+	});
+});
+
+describe("ownerPresence — two signals: any alive wins, death needs positive proof", () => {
+	const facts = (over: Partial<ReapCandidate> = {}) => {
+		const c = candidate(over);
+		return {lockOwner: c.lockOwner, foreignLock: c.foreignLock, stampPresence: c.stampPresence};
+	};
+
+	it("locked-only: the lock pid carries the verdict", () => {
+		assert.strictEqual(ownerPresence(facts({stampPresence: "unknown"})), "dead");
+		assert.strictEqual(
+			ownerPresence(facts({lockOwner: {pid: 1, alive: true}, stampPresence: "unknown"})),
+			"alive",
+		);
+	});
+
+	it("stamped-only (the unlocked majority): the stamp carries the verdict", () => {
+		assert.strictEqual(ownerPresence(facts({lockOwner: null, stampPresence: "dead"})), "dead");
+		assert.strictEqual(ownerPresence(facts({lockOwner: null, stampPresence: "alive"})), "alive");
+	});
+
+	it("neither signal → unknown, never dead", () => {
+		assert.strictEqual(
+			ownerPresence(facts({lockOwner: null, stampPresence: "unknown"})),
+			"unknown",
+		);
+	});
+
+	it("agreeing signals → that verdict", () => {
+		assert.strictEqual(ownerPresence(facts({stampPresence: "dead"})), "dead");
+		assert.strictEqual(
+			ownerPresence(facts({lockOwner: {pid: 1, alive: true}, stampPresence: "alive"})),
+			"alive",
+		);
+	});
+
+	it("CONFLICTING signals fail safe toward alive, in both directions", () => {
+		// dead lock + live stamp, and live lock + dead stamp: a live reading always wins, because
+		// being wrong about death destroys work while being wrong about life only leaks a tree.
+		assert.strictEqual(
+			ownerPresence(facts({lockOwner: {pid: 1, alive: false}, stampPresence: "alive"})),
+			"alive",
+		);
+		assert.strictEqual(
+			ownerPresence(facts({lockOwner: {pid: 1, alive: true}, stampPresence: "dead"})),
+			"alive",
+		);
+	});
+
+	it("a foreign (operator) lock suppresses both signals → unknown", () => {
+		assert.strictEqual(
+			ownerPresence(facts({foreignLock: true, lockOwner: null, stampPresence: "dead"})),
+			"unknown",
+		);
+	});
+});
+
+describe("classifyCandidate — the #3989 stamp signal (the unlocked majority is finally classifiable)", () => {
+	it("UNLOCKED but stamped, session provably dead, clean + pushed → REAP (the #3989 AC)", () => {
+		const d = classifyCandidate(candidate({lockOwner: null, stampPresence: "dead"}));
+		assert.deepStrictEqual(d, {kind: "reap", reason: "orphan-clean"});
+	});
+
+	it("unlocked + stamped-dead but DIRTY → KEEP-DIRTY, never reaped", () => {
+		const d = classifyCandidate(
+			candidate({lockOwner: null, stampPresence: "dead", hasUncommitted: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep-dirty", reason: "uncommitted"});
+	});
+
+	it("unlocked + stamped-ALIVE → SPARED (live-session), clean tree or not", () => {
+		const d = classifyCandidate(candidate({lockOwner: null, stampPresence: "alive"}));
+		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
+	});
+
+	it("unlocked + UNSTAMPED (the pre-#3988 historical pile) → SPARED (owner-unknown)", () => {
+		const d = classifyCandidate(candidate({lockOwner: null, stampPresence: "unknown"}));
+		assert.deepStrictEqual(d, {kind: "spare", reason: "owner-unknown"});
+	});
+
+	it("harness-locked trees keep working: a dead lock pid still reaps with no stamp at all", () => {
+		const d = classifyCandidate(candidate({lockOwner: {pid: 4242, alive: false}}));
+		assert.deepStrictEqual(d, {kind: "reap", reason: "orphan-clean"});
+	});
+
+	it("live lock + dead stamp → SPARED (live-session): conflict never reaps", () => {
+		const d = classifyCandidate(
+			candidate({lockOwner: {pid: 7, alive: true}, stampPresence: "dead"}),
+		);
+		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
+	});
+
+	it("dead lock + live stamp → SPARED (live-session): conflict never reaps, other direction", () => {
+		const d = classifyCandidate(
+			candidate({lockOwner: {pid: 7, alive: false}, stampPresence: "alive"}),
+		);
+		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
+	});
+
+	it("an operator's foreign lock is SPARED even with a provably dead stamp — never unlocked", () => {
+		const d = classifyCandidate(
+			candidate({foreignLock: true, lockOwner: null, stampPresence: "dead"}),
+		);
+		assert.deepStrictEqual(d, {kind: "spare", reason: "foreign-lock"});
 	});
 });
 
@@ -127,8 +247,8 @@ describe("computeWorktreeReapPlan — partitions into reap / kept-dirty / spared
 		const reapable = candidate({path: wtPath("agent-reap")});
 		const dirty = candidate({path: wtPath("agent-dirty"), hasUncommitted: true});
 		const unpushed = candidate({path: wtPath("agent-unpushed"), hasUnpushed: true});
-		const live = candidate({path: wtPath("agent-live"), owner: {pid: 7, alive: true}});
-		const unknown = candidate({path: wtPath("agent-unknown"), owner: null});
+		const live = candidate({path: wtPath("agent-live"), lockOwner: {pid: 7, alive: true}});
+		const unknown = candidate({path: wtPath("agent-unknown"), lockOwner: null});
 		const foreign = candidate({path: "/Users/dev/other-wt"});
 
 		const plan = computeWorktreeReapPlan([reapable, dirty, unpushed, live, unknown, foreign]);
@@ -228,7 +348,9 @@ describe("parseWorktreeList — preserves the lock reason (the age-based sweep d
 		const d = classifyCandidate({
 			path: block.path,
 			branch: block.branch,
-			owner: owner === null ? null : {...owner, alive: false},
+			lockOwner: owner === null ? null : {...owner, alive: false},
+			foreignLock: false,
+			stampPresence: "unknown",
 			hasUncommitted: false,
 			hasUnpushed: false,
 		});


### PR DESCRIPTION
Closes #3989

## What was broken

`worktree-reap`'s only owner-presence signal was the harness git lock reason. Verified live on the crew host at build time: **9 of 252 registered worktrees carry a lock**. Every other managed tree resolved `parseAgentLockOwner → null → spare/owner-unknown`, unconditionally — so over the orphan population the verb was shipped to reclaim (#3754, #3887) it was inert, and its output was indistinguishable from correct fail-closed behaviour (the silent-no-op class).

## What changed

`packages/pipeline-cli/src/tools/worktree-reap/` only. Owner presence is now read from **two** signals:

1. **the git lock reason** — unchanged: `claude agent <id> (pid <N> …)` with the pid probed via `process.kill(pid, 0)`;
2. **the `kampus-owner.json` owner stamp** (#3988, merged) — the session id `hooks/create-worktree.sh` writes into the tree's git admin dir, resolved against the harness live-session registry **through `worktree-sweep`'s `owner-liveness.ts`**. That is the shared resolution, imported, not re-derived: `parseOwnerStamp` / `parseSessionRegistryEntry` / `liveSessionIds` / `resolveOwnerLiveness`.

The two fold in the pure core (`ownerPresence`) by a **two-key rule**: any alive reading spares, death needs positive proof from at least one signal, everything else is `unknown`. New classify order:

```
not-managed → foreign-lock → live-session → owner-unknown → uncommitted → unpushed → reap
```

`foreign-lock` is new and strictly tightening: a tree locked with a reason this reaper did not author (an operator's `git worktree lock`) is now spared *explicitly*, because reclaiming means `git worktree unlock` — overriding a pin a human placed deliberately. Previously that case fell out incidentally as `owner-unknown`; with a second signal it had to become a first-class rule, or a dead stamp could have unlocked an operator's pin.

Also: `runGit` now captures git's stderr instead of letting it inherit. Over a few hundred trees, a registered-but-deleted directory printed a raw `fatal:` per probe and buried the plan the verb exists to show (the ADR 0092 "emit what you scanned" output). The failure is not lost — it lands in the `GitResult` the caller already branches on. The run header now also prints the registry's trust state, so "signal 2 was disabled this run" is readable rather than inferred from a wall of `owner-unknown`.

## Why no path in this change can reap a live occupant

The #3943 incident (two LIVE shipper worktrees removed mid-run, PRs #3913/#3923) is the property this had to preserve. Four independent reasons it holds:

1. **The gate is death-only, and death needs positive proof.** `ownerPresence` returns `"dead"` **only** when a signal positively proves it: an `ESRCH` pid probe, or a stamped session absent from a *trusted* registry. A probe that could not execute, an absent/malformed stamp, an unreadable registry, an unresolvable gitdir — every one of them is `"unknown"`, which spares. There is no fallback, no age window, no "nothing else matched, so reap".
2. **Conflicting signals resolve to alive, in both directions.** dead-lock + live-stamp and live-lock + dead-stamp both classify `spare/live-session` (unit-tested both ways). Adding a signal can therefore only ever *spare more* than the old one-signal gate did, never less.
3. **Both signals name the LAUNCHER — and launcher death is sound in exactly the direction used here.** Verified live: this build's own worktree lock names pid 23575, and the registry entry for that pid is the *launching pane's* session, not this subagent's; the registry has an entry for the pane and none for the subagent, i.e. a subagent has no session identity of its own on this platform (matching #4001's finding). A subagent runs **inside** its launcher's process, so a dead launcher proves every tree it spawned is unoccupied. The converse is *not* used: a live launcher (#4001's `launcher-alive`) reads alive here and spares. `presenceFromOwnerLiveness` names only the two act-permitting verdicts positively — `"dead"` and `"unknown"` — so **any verdict added to `OwnerLiveness` later collapses to alive ⇒ spare by default**, rather than by someone remembering to handle it.
4. **The work guards and the removal guard are untouched.** A dead-session tree is still probed for uncommitted changes and unpushed/unsquash-merged commits, both fail-safe toward KEEP, and removal is still `git worktree remove` **without** `--force`, with git's refusal reported as KEPT and never escalated.

The stamp's `"alive"` state being unreachable in production while nothing writes an `occupant` stamp does not weaken this: reap never needed `"alive"` to be protective, because it only acts on `"dead"` — and a live occupant is protected by its launcher being alive (signal 2) *and* by the harness lock naming a running pane pid (signal 1). Both must fail before anything can be classified dead.

## Evidence

**Unit** — 38 tests pass, covering the AC matrix (stamped-only, locked-only, both agreeing, both conflicting, neither) plus the foreign-lock and `launcher-alive` cases.

**End-to-end, in a throwaway repo** (a fabricated registry + three worktrees: stamped-dead, stamped-live, unstamped):

```
worktree-reap: 4 worktree(s) scanned — 1 orphaned-clean (reapable), 0 kept-dirty, 3 spared (dry-run)
  session registry: 1 live session(s) — owner stamps resolved against it
  live-session   …/.claude/worktrees/agent-live
  owner-unknown  …/.claude/worktrees/agent-unstamped
orphaned-clean (reapable):
  stamped session dead …/.claude/worktrees/agent-dead
```

`--execute` then reaped exactly `agent-dead`; `agent-live` and `agent-unstamped` survived.

**Live dry-run on this host** (read-only): `251 worktree(s) scanned — 0 reapable, 1 kept-dirty, 250 spared`, registry trusted with 6 live sessions. Zero reapable is the *expected* result today and not a regression: no `kampus-owner.json` stamp exists on disk yet, because every registered tree predates #3988's merge. Stamps start existing for trees created from now on, which is exactly the scope #3989 defines — structurally sound going forward, not retroactively omniscient.

## Deliberately out of scope

- **The ~250-tree historical pile stays `owner-unknown`.** Unlocked *and* unstamped is unprovable by construction; clearing that backlog is #3892's open decision.
- **#4150 (the stale dead-lock) is NOT absorbed.** The one tree of 252 whose lock names dead pid 4299 still classifies `keep-dirty` here (its directory is gone, so the status probe fails → reads uncommitted → KEEP). Fixing it means relaxing the #2240 `locked` guard, which #3989's ACs do not require and which should not be done casually right after #3943.
- **No file owned by #4138 is edited.** `worktree-sweep/**` and `hooks/create-worktree.sh` are imported/read-only here. One shared-helper note for a follow-up: the *boundary* IO around `owner-liveness.ts` now exists twice — `worktree-sweep/command.ts` reads the registry and stamps through Effect `FileSystem`/`Path`, this verb through `node:fs` (matching its own existing `execFileSync` style). The pure resolution is shared; the ~30 lines of IO around it could be unified into one module in a follow-up, rather than being pulled out under this fix.

## Control plane

`packages/pipeline-cli/**` is §CP — this banks for a control-plane approval rather than auto-shipping.
