### PR TITLE
fix(write-code): resolve an epic parent via the ADR-0131 sub-endpoint, fail loud on UNKNOWN (#4171)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -314,14 +314,45 @@ default — most issues carry no milestone) per the contract's REST surface.
 ### Is it a sub-issue?
 
 An issue may be a child of an epic. Check before claiming — a sub-issue carries
-dependency constraints the bare issue doesn't show:
+dependency constraints the bare issue doesn't show.
+
+Resolve the parent through **`GET /repos/{owner}/{repo}/issues/<N>/parent`**, the dedicated
+sub-endpoint ADR
+[0131](https://github.com/kamp-us/phoenix/blob/main/.decisions/0131-epic-autoclose-on-all-children-closed.md)
+§3 already names the authoritative linkage — and read **three** outcomes off it, never two:
 
 ```bash
-gh api repos/$REPO/issues/<N> --jq '.parent // "no parent (standalone)"'
+# `-i` keeps the status line on stdout even when gh exits non-zero, which is the whole point:
+# it is what distinguishes a genuine 404 ("No parent issue found" ⇒ standalone) from an
+# UNREADABLE response (5xx, rate-limit, auth, network ⇒ UNKNOWN). Collapsing those two into
+# "no parent" is a silent no-op that skips Step 2 on a real epic child (#4171, #3715, #4108).
+PARENT_RESP="$(gh api "repos/$REPO/issues/<N>/parent" -i 2>/dev/null)"
+PARENT_STATUS="$(printf '%s\n' "$PARENT_RESP" | head -n1 | awk '{print $2}')"
+case "$PARENT_STATUS" in
+  200)
+    EPIC="$(printf '%s\n' "$PARENT_RESP" | awk 'body{print} /^\r?$/{body=1}' | jq -r '.number // empty')"
+    : "${EPIC:?parent read returned 200 with no .number — UNKNOWN, not standalone; refusing to claim <N>}"
+    echo "#<N> is a sub-issue of epic #$EPIC → Step 2 (derive eligibility BEFORE claiming)" ;;
+  404)
+    echo "#<N> is standalone (404 'No parent issue found') → Step 3 (claim it)" ;;
+  *)
+    echo "write-code FAILED (fail-closed): parent read on #<N> returned HTTP '${PARENT_STATUS:-none}' — UNKNOWN, which is NOT evidence of 'no parent'. Refusing to claim: retry, or re-pick per Step 1." >&2
+    exit 1 ;;
+esac
 ```
 
-If it has a `parent`, go to Step 2 to derive eligibility before claiming. If it's
-standalone, skip to Step 3.
+- **Parent resolved (200)** → go to **Step 2** and derive eligibility before claiming.
+- **Standalone (404)** → skip to **Step 3**.
+- **Anything else** → **stop, loudly.** An unreadable parent read is *unknown*, not *absent*;
+  proceeding would claim a child whose dependencies were never checked.
+
+> **Never read `.parent` off the plain issue payload.** The single-issue REST response carries
+> **no** `parent` key at all (the linkage surfaces there as `parent_issue_url`), so the read this
+> step used to carry — a `--jq` on `.parent` with a `"no parent (standalone)"` jq-alternative
+> default — fired its default unconditionally and answered "standalone" for *every* issue: a
+> well-formed, plausible, always-wrong answer that skipped the whole Step 2 derivation on every
+> epic child and left no trace (#4171). ADR 0131 §3 states the same thing from the other side:
+> the child's own `.parent` field is unreliable, the sub-endpoint is the source of truth.
 
 ---
 
@@ -333,7 +364,7 @@ when its dependencies are all closed. There is **no `status:blocked` label**;
 eligibility is computed fresh on every pick from the epic's `## Dependencies` section.
 
 ```bash
-EPIC=<parent number>
+EPIC=<the parent number Step 1's sub-endpoint read resolved — never a guessed or remembered one>
 # the epic body carries the plan + the ## Dependencies topology
 gh api repos/$REPO/issues/$EPIC --jq '.body'
 # the real child set + each child's state (the list endpoint is source of truth;


### PR DESCRIPTION
The `write-code` skill told agents to detect an epic parent by reading a `.parent` field off
the plain issue REST payload — a field that response has never carried. The fallback fired every
time, so the check answered "no parent (standalone)" for *every* issue, including real epic
children, and the agent silently skipped the whole sub-issue eligibility derivation. This swaps
the read to the dedicated `/issues/<N>/parent` sub-endpoint that ADR 0131 already names
authoritative, and makes an unreadable response a loud stop instead of a shrug.

Fixes #4171

## What changed

`claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`, Step 1 `### Is it a sub-issue?`:

- The read is now `GET /repos/{owner}/{repo}/issues/<N>/parent` (ADR 0131 §3, "Authoritative
  linkage"), replacing the `--jq` read of the nonexistent `.parent` key.
- The check resolves **three** outcomes, not two:
  - **200** → parent epic resolved → Step 2 eligibility derivation, *before* claiming.
  - **404** ("No parent issue found") → standalone → Step 3.
  - **anything else** (5xx, rate-limit, auth, network, empty) → **UNKNOWN → fail closed and
    stop.** An unreadable read is not evidence of "no parent"; the snippet exits non-zero with a
    message that says so.
- `-i` is what makes that three-way split possible: `gh api` exits non-zero on any HTTP error
  regardless of status, but with `-i` the status line stays on stdout, so a genuine 404 is
  distinguishable from a failed read.
- A short note records why `.parent` must never be read off the plain payload, so the idiom
  doesn't get re-introduced.
- Step 2's `EPIC=` placeholder now points at the value Step 1's sub-endpoint read produced,
  rather than an unsourced "parent number".

## Why the loud branch is the actual fix

The defect was not just a wrong field name — it was that the wrong field name produced a
**well-formed, plausible answer**. Read-failed and genuinely-absent were collapsed into one
outcome, which is why nothing ever errored and the mis-sequencing left no trace. The same
collapse is the root of #3715 and #4108. Fixing only the field name would have left a two-outcome
check whose failure path still resolves to "carry on"; the UNKNOWN branch is what makes the class
non-silent.

## Verification (run live against the GitHub REST API, not assumed)

Grounded in observed payloads per the repo's platform-claims rule, using a known epic/child pair:

| Check | Observed |
|---|---|
| `gh api repos/kamp-us/phoenix/issues/3963 --jq 'keys \| map(select(test("parent")))'` | `["parent_issue_url"]` — no `parent` key |
| old snippet on child #3963 | `no parent (standalone)` — the false negative |
| new snippet on child #3963 (a real sub-issue of epic #3947) | `sub-issue of epic #3947` |
| new snippet on epic #3947 (genuine standalone) | `standalone (404)` |
| new snippet on #4171 | `standalone (404)` — consistent with this issue having no parent |
| new snippet with the API made unreachable (bad host) | `UNKNOWN status='none'` — **not** "standalone" |

The last row is the one that matters most: a forced read failure surfaces as UNKNOWN, so the
fail-closed branch is exercised, not merely written.

## Acceptance criteria

- [x] The `### Is it a sub-issue?` snippet no longer reads the nonexistent `.parent` key.
- [x] It uses ADR 0131's canonical `GET /repos/{owner}/{repo}/issues/<N>/parent`, with the 404
      case documented as standalone.
- [x] Prose routes correctly: resolved parent → Step 2 before claiming; 404 → Step 3.
- [x] `git grep -n '\.parent //' -- claude-plugins .claude packages` returns no hits (exit 1).
- [x] No other skill or tool in `claude-plugins/` or `packages/` does a parent read off a
      nonexistent field — re-confirmed at fix time (see Deviations for one note on the triage
      pointer).

## Deviations

- **The triage body cites `packages/pipeline-cli/src/tools/pitch-guard/github.ts` as a working
  `parent_issue_url` reader. That file is not on `main`** — `pitch-guard` is not among the
  registered tools in `packages/pipeline-cli/src/tools/`; it lives in the still-open PR #4170.
  So the "repo currently carries two idioms" framing is not true of `main` today: after this PR
  there is exactly one parent-read idiom in-tree, the sub-endpoint. Flagging it because the AC
  asked for a re-confirmation sweep and the pointer would otherwise read as a missed hit. If
  #4170 lands with the `parent_issue_url` read, that is a *correct* read of a real field, not a
  regression of this bug — but someone may want it converged onto the sub-endpoint for
  single-idiom hygiene.
- **The AC as literally written ("`git grep '.parent //'` returns no hits") constrained the
  prose.** The anti-pattern note deliberately describes the old read in words rather than quoting
  it verbatim, so the grep stays clean. The note is still specific enough to prevent
  re-introduction.
- **No new `pipeline-cli` verb.** CLAUDE.md prefers a tool over hand-rolled `gh` glue, and there
  is no existing verb that resolves an issue's parent. One was not added: the issue's constraints
  explicitly size this as a one-line-plus-prose change consuming a scarce §CP approval slot, and
  every other REST read in this step is an inline `gh api` snippet, so a lone extracted verb here
  would be inconsistent without a broader sweep.
- **§CP: this PR stops at open.** `claude-plugins/kampus-pipeline/skills/write-code/` matches
  `CONTROL_PLANE_RE`, and `class-probe` routes the diff to `review-skill`. `ship-it` will refuse
  it by design (ADRs 0048/0053) — it needs the control-plane human approval path.
- **The claim on #4171 is deliberately NOT released** at terminus, per the dispatch (holding it
  keeps a mid-repair re-dispatch from being refused at the Step-3.5 guard — see #4145). This
  departs from the skill's Step 8 release-the-claim instruction.
