### PR TITLE
fix(verdict): resolve the in-force verdict head-first, not by created_at (#4189)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -870,10 +870,19 @@ while IFS= read -r a; do
 done <<<"$markerAuthors"
 ```
 
-Resolve the latest current-head marker verdict per namespace **through `pipeline-cli verdict read`**:
-the verb folds the ADR-0055 write+ author-gate (a forged newer marker from an unauthorized author
-can't shadow a real verdict), the latest-wins pick, and the ADR-0058 SHA-staleness refusal (Step 2b)
-into one exit code — its unit tests are the contract (#2102), the same resolution `write-code` reads.
+Resolve the **in-force** verdict per namespace **through `pipeline-cli verdict read`**: the verb folds
+the ADR-0055 write+ author-gate (a forged newer marker from an unauthorized author can't shadow a real
+verdict), the in-force pick, and the ADR-0058 SHA-staleness refusal (Step 2b) into one exit code — its
+unit tests are the contract (#2102), the same resolution `write-code` reads.
+
+**The in-force rule, stated once and used by every namespace below: filter candidates to the ones
+bound to the LIVE head first, then latest-wins only among those.** Never "the newest comment in the
+namespace, then check its head" — `verdict post` upserts a verdict in place (ADR 0213/#4016/#4050), so
+`created_at` is when a comment SLOT was opened, not when the verdict it now carries was written, and a
+stale-but-freshly-created verdict outranks an at-head one that was rewritten in place. That is a false
+**refusal** of a green PR, and it cost PR #3955 an hour (#4189). The same trap catches a human skimming
+the PR, since the GitHub UI orders by creation time too — read the `@ <sha>` / `Reviewed-head:` binding,
+never the position.
 The native decisive review folds into the code namespace separately (the verb reads marker comments,
 not reviews); Step 2b keeps `is_current` for it and for the §CP advisory body-SHA:
 
@@ -942,8 +951,10 @@ if [ -n "$RSHA" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
 Now resolve **per namespace** (the marker verdict from the verb above, the native review + §CP
 advisory folded in):
 
-- **review-code namespace** — the verdict is the **newest of {latest decisive review, latest
-  review-code marker comment}** by timestamp (review `submitted_at` vs comment `created_at`).
+- **review-code namespace** — the verdict is the **newest of {latest decisive review, in-force
+  review-code marker comment}**, compared by timestamp (review `submitted_at` vs comment
+  `created_at`) **only once both are current-head-bound** — the head-first rule above, which is
+  what the `case "$CURRENT_HEAD" in "$RSHA"*` guard and the `_tag == "current"` marker test encode.
   An `APPROVED` review or a `review-code: PASS … merge-ready` marker is PASS; a
   `CHANGES_REQUESTED` review or a `review-code: FAIL` marker is FAIL. The verdict's bound SHA
   is the marker's `@ <sha>` (or, for a native review, its `commit_id`). (The native
@@ -956,8 +967,8 @@ advisory folded in):
   (ADR 0111/0151), gated on Step 0's control-plane approval — **never** from a bindable first-line
   marker (that would drop the §CP verdict into the auto-merge namespace, the ADR 0111 hazard). This
   is the written resolution path a canonical review-code §CP advisory previously lacked (#2329).
-- **review-doc namespace** — the verdict is the **latest `review-doc` marker comment** by
-  `created_at`; its bound SHA is the marker's `@ <sha>`. `review-doc: PASS … merge-ready` is
+- **review-doc namespace** — the verdict is the **in-force `review-doc` marker comment** (the rule
+  above); its bound SHA is the marker's `@ <sha>`. `review-doc: PASS … merge-ready` is
   PASS; `review-doc: FAIL … changes-requested` is FAIL. (review-doc lands no native review —
   it is comment-only, ADR 0058 — so there is no review path to fold in, and no review-vs-comment
   comparison to make.) A §CP doc PR's verdict is likewise the SHA-less-first-line advisory
@@ -965,8 +976,8 @@ advisory folded in):
   `Reviewed-head` line via the same
   **[§CP advisory resolution](#step-2cp--cp-advisory-namespace-resolution-adr-01350151)** below
   (ADR 0111/0151) — never from a bindable first-line marker.
-- **review-skill namespace** — the verdict is the **latest `review-skill` marker comment** by
-  `created_at`; its bound SHA is the marker's `@ <sha>`. `review-skill: PASS … merge-ready` is
+- **review-skill namespace** — the verdict is the **in-force `review-skill` marker comment** (the
+  rule above); its bound SHA is the marker's `@ <sha>`. `review-skill: PASS … merge-ready` is
   PASS; `review-skill: FAIL … changes-requested` is FAIL. (review-skill is comment-only too,
   ADR 0058 — same single-record-type resolution as review-doc.) For a **non-§CP** skill PR an
   **advisory** line (`review-skill: advisory — blocking-set PR …`) carries no first-line `@ <sha>`
@@ -979,8 +990,8 @@ advisory folded in):
   advisory resolves — a §CP PR is **never** required to (nor satisfied by) a bindable first-line
   `review-skill: PASS @ <sha>` marker (that would drop it into the auto-merge namespace — the ADR 0111
   hazard #2022's forge-workaround must not take).
-- **review-design namespace** — the verdict is the **latest `review-design` marker comment** by
-  `created_at`; its bound SHA is the marker's `@ <sha>`. `review-design: PASS … merge-ready` is
+- **review-design namespace** — the verdict is the **in-force `review-design` marker comment** (the
+  rule above); its bound SHA is the marker's `@ <sha>`. `review-design: PASS … merge-ready` is
   PASS; `review-design: FAIL … changes-requested` is FAIL. (review-design is comment-only, ADR
   0058 — same single-record-type resolution as review-doc/review-skill; a newer FAIL in this
   namespace vetoes an older PASS, latest-wins, exactly like the other gates.) This namespace is
@@ -1071,8 +1082,10 @@ a canonical review-code §CP advisory had no written resolution path and read as
 on a legitimately-approved PR (#2329):
 
 ```bash
-# $ADV_BODY = the latest §CP advisory comment body for this namespace (review-code/skill/doc/design),
-# author-gated (write+, ADR 0055) and latest-wins exactly like the markers above.
+# $ADV_BODY = the IN-FORCE §CP advisory comment body for this namespace (review-code/skill/doc/design),
+# author-gated (write+, ADR 0055) and resolved head-first exactly like the markers above — an advisory
+# is upserted in place too, so its `created_at` does not order it (`pipeline-cli verdict gate --cp`
+# computes this; do not hand-roll a newest-comment read here).
 # (a) body's canonical Reviewed-head SHA (ADR 0151 §6.6) must prefix-match the PR's current head.
 #     Anchored to the `Reviewed-head:` line — a DISTINCT token from the first-line advisory marker,
 #     so this never mistakes a first-line marker for the body binding, and the advisory stays out of

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
@@ -21,10 +21,11 @@
  * make, refusing every §CP enqueue.
  */
 import {
+	boundHead,
 	GATE_KEYWORD,
 	isBoundToHead,
 	parseVerdict,
-	pickLatestAuthorized,
+	pickInForce,
 	polarityRe,
 	reviewedHeadSha,
 	type VerdictComment,
@@ -101,17 +102,41 @@ const newerOf = (
 	return a.id > b.id ? a : b;
 };
 
+/**
+ * The in-force one of the two forms — the same live-head-first rule `pickInForce` applies WITHIN a
+ * form, applied ACROSS them (#4189): a candidate bound to the live head strictly outranks one that
+ * is not, and recency decides only when both bind it (or neither does, where the fallback keeps the
+ * existing stale/SHA-less refusal intact). See `pickInForce` for why recency alone is not the key.
+ */
+const inForceOf = (
+	a: VerdictComment | undefined,
+	b: VerdictComment | undefined,
+	gate: VerdictGate,
+	headSha: string,
+): VerdictComment | undefined => {
+	const aAtHead = a !== undefined && isBoundToHead(boundHead(a.body, gate), headSha);
+	const bAtHead = b !== undefined && isBoundToHead(boundHead(b.body, gate), headSha);
+	if (aAtHead !== bAtHead) return aAtHead ? a : b;
+	return newerOf(a, b);
+};
+
 const decideNamespace = (gate: VerdictGate, input: GateDecisionInput): NamespaceDecision => {
 	const namespace = GATE_KEYWORD[gate];
 	const base = {gate, namespace} as const;
-	const marker = pickLatestAuthorized(input.comments, input.authorizedAuthors, polarityRe(gate));
+	const marker = pickInForce(
+		input.comments,
+		input.authorizedAuthors,
+		polarityRe(gate),
+		gate,
+		input.headSha,
+	);
 	// A non-§CP PR's advisory is NOT a candidate at all: it carries no bindable head and is not a
 	// PASS, so it must neither satisfy the namespace nor shadow an older bindable marker — exactly
 	// what `verdict read` already does by matching on `polarityRe` only.
 	const advisory = input.controlPlane
-		? pickLatestAuthorized(input.comments, input.authorizedAuthors, advisoryRe(gate))
+		? pickInForce(input.comments, input.authorizedAuthors, advisoryRe(gate), gate, input.headSha)
 		: undefined;
-	const latest = newerOf(marker, advisory);
+	const latest = inForceOf(marker, advisory, gate, input.headSha);
 
 	if (latest === undefined) {
 		return {

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -340,6 +340,83 @@ describe("decideGate — EVERY required namespace must pass, not just one", () =
 	});
 });
 
+describe("decideGate — PR #3955's exact situation: the in-force verdict was created FIRST (#4189)", () => {
+	// The incident: `verdict post` upserts a verdict in place (#4016/#4050), so the live-head
+	// advisories kept the `created_at` of the 00:09 slots they were rewritten into at 00:49, while a
+	// superseded-head pair was created fresh at 00:32. Selecting by `(createdAt, id)` and testing the
+	// head afterwards crowned the 00:32 pair, classified it `stale` — correctly — and refused a §CP PR
+	// that was green on every required namespace, for ~an hour, with no surfaced reason.
+	const UPSERTED_AT_HEAD = "2026-07-26T00:09:45Z";
+	const CREATED_STALE = "2026-07-26T00:32:02Z";
+
+	it("the live-head all-PASS advisories are selected over the newer-created dead-head pair", () => {
+		const result = decide({
+			requiredGates: ["code", "doc"],
+			controlPlane: true,
+			comments: [
+				comment({id: 5081148335, createdAt: UPSERTED_AT_HEAD, body: advisory("doc", HEAD)}),
+				comment({id: 5081149091, createdAt: UPSERTED_AT_HEAD, body: advisory("code", HEAD)}),
+				comment({id: 5081217674, createdAt: CREATED_STALE, body: advisory("doc", OLD, "[FAIL]")}),
+				comment({id: 5081217899, createdAt: CREATED_STALE, body: advisory("code", OLD)}),
+			],
+		});
+		assert.isTrue(result.enqueueable);
+		assert.deepStrictEqual(
+			result.decisions.map((d) => d.commentId),
+			[5081149091, 5081148335],
+		);
+	});
+
+	it("a dead-head marker created later never shadows a live-head marker (non-§CP)", () => {
+		const result = decide({
+			comments: [
+				comment({id: 1, createdAt: UPSERTED_AT_HEAD}),
+				comment({
+					id: 2,
+					createdAt: CREATED_STALE,
+					body: `review-doc: FAIL @ ${OLD} — changes-requested`,
+				}),
+			],
+		});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.commentId, 1);
+	});
+
+	it("the head-first preference holds ACROSS the two forms: a live-head marker beats a newer dead-head advisory", () => {
+		const result = decide({
+			controlPlane: true,
+			comments: [
+				comment({
+					id: 1,
+					createdAt: UPSERTED_AT_HEAD,
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+				comment({id: 2, createdAt: CREATED_STALE, body: advisory("doc", OLD)}),
+			],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "fail");
+		assert.strictEqual(result.decisions[0]?.commentId, 1);
+	});
+
+	it("with NOTHING bound to the live head the refusal is unchanged — still the stale newest", () => {
+		const result = decide({
+			controlPlane: true,
+			comments: [
+				comment({id: 1, createdAt: UPSERTED_AT_HEAD, body: advisory("doc", OLD)}),
+				comment({
+					id: 2,
+					createdAt: CREATED_STALE,
+					body: `review-doc: PASS @ ${OLD} — merge-ready`,
+				}),
+			],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "unverified");
+		assert.strictEqual(result.decisions[0]?.commentId, 2);
+	});
+});
+
 describe("decideGate — fail-closed on its own inputs (ADR 0092)", () => {
 	it("an EMPTY required set refuses rather than passing vacuously", () => {
 		const result = decide({requiredGates: [], comments: [comment({id: 1})]});

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -146,10 +146,13 @@ export interface ResolveVerdictInput {
 }
 
 /**
- * The latest-wins pick, shared by `resolveVerdict` and the §CP advisory resolution: among the
- * comments an authorized (write+, ADR 0055) author posted whose body matches `re`, the newest by
- * `(createdAt, id)`. `undefined` when the authorized candidate set is empty — the fail-closed
- * "nothing to consume in this namespace", never a false win.
+ * The latest-wins pick within an already-scoped candidate set: among the comments an authorized
+ * (write+, ADR 0055) author posted whose body matches `re`, the newest by `(createdAt, id)`.
+ * `undefined` when the authorized candidate set is empty — the fail-closed "nothing to consume in
+ * this namespace", never a false win.
+ *
+ * This is recency ALONE — it is not the in-force resolver. Scope the candidate set to the live head
+ * first (`pickInForce` below, #4189), then break ties here.
  */
 export const pickLatestAuthorized = (
 	comments: ReadonlyArray<VerdictComment>,
@@ -167,19 +170,69 @@ export const pickLatestAuthorized = (
 };
 
 /**
+ * The head a candidate binds itself to: its first-line marker's `@ <sha>`, else the §CP advisory's
+ * `Reviewed-head:` body anchor (ADR 0151). `null` when it binds none — a pre-0058 SHA-less marker,
+ * or an anchor-less advisory — which `isBoundToHead` then treats as never-current, fail-closed.
+ */
+export const boundHead = (body: string, gate: VerdictGate): string | null =>
+	boundHeadShas(body, gate)[0] ?? null;
+
+/**
+ * The in-force pick: **filter to the live-head binding FIRST, latest-wins only among those.**
+ *
+ * This ordering is the whole fix for #4189 and it is ADR 0058's own rule: a verdict attests the
+ * exact head it names, so the question "which verdict is in force" is first "which candidates
+ * attest the head I am gating" and only then "which of those is newest". Picking by `(createdAt,
+ * id)` and testing the head afterwards — on the winner alone — never consults the candidate that
+ * binds the live head, and under the in-place upsert (#4016/#4050) that is not an edge case: an
+ * at-head verdict keeps the `created_at` of the slot it was upserted into, so a stale,
+ * freshly-created verdict outranks it. Observed on PR #3955 — a green §CP PR that `verdict gate`
+ * refused for ~an hour because a dead-head pair created at 00:32 outranked the live-head PASSes
+ * upserted at 00:49 into 00:09 slots.
+ *
+ * The fallback to the unfiltered set when NOTHING binds the live head is load-bearing, not a
+ * loophole: it preserves the fail-closed classification downstream, which still reports the
+ * `stale` / `sha-less` refusal with the offending comment named, exactly as before.
+ *
+ * Within the live-head set this is unchanged latest-wins — the arbitration the run-keyed upsert
+ * (#4016) explicitly relies on to settle two surviving same-head verdicts. That leaves the
+ * same-head WRITE-RECENCY direction open (an in-place upsert of an older slot at the same head is
+ * still ordered by its creation time); closing it needs a write-recency signal the boundary does
+ * not decode today — tracked separately, see #4189's PR body.
+ */
+export const pickInForce = (
+	comments: ReadonlyArray<VerdictComment>,
+	authorizedAuthors: ReadonlyArray<string>,
+	re: RegExp,
+	gate: VerdictGate,
+	headSha: string,
+): VerdictComment | undefined => {
+	const atHead = comments.filter((comment) =>
+		isBoundToHead(boundHead(comment.body, gate), headSha),
+	);
+	return (
+		pickLatestAuthorized(atHead, authorizedAuthors, re) ??
+		pickLatestAuthorized(comments, authorizedAuthors, re)
+	);
+};
+
+/**
  * Resolve the (PR, gate) verdict against the current head, re-encoding ADR 0058 rule 3
  * exactly: author-gate to write+ collaborators (a forged marker is invisible), keep only
- * PASS/FAIL markers in this namespace, take the **newest** by `(createdAt, id)` (latest-wins,
- * so a newer FAIL vetoes an older PASS and a re-review overwrites), then classify by the
- * SHA-staleness test — `current` iff its `@ <sha>` prefix-matches the head, else `stale`;
- * `sha-less` when the newest marker carries no `@ <sha>`; `none` when the authorized candidate
- * set is empty. Fail-closed everywhere: an empty authorized set is `none`, never a false win.
+ * PASS/FAIL markers in this namespace, take the in-force one (`pickInForce` — live-head
+ * candidates first, latest-wins among them, so a newer FAIL vetoes an older PASS at the same
+ * head and a re-review overwrites), then classify by the SHA-staleness test — `current` iff its
+ * `@ <sha>` prefix-matches the head, else `stale`; `sha-less` when it carries no `@ <sha>`;
+ * `none` when the authorized candidate set is empty. Fail-closed everywhere: an empty authorized
+ * set is `none`, never a false win.
  */
 export const resolveVerdict = (input: ResolveVerdictInput): VerdictOutcome => {
-	const latest = pickLatestAuthorized(
+	const latest = pickInForce(
 		input.comments,
 		input.authorizedAuthors,
 		polarityRe(input.gate),
+		input.gate,
+		input.headSha,
 	);
 	// `latest` is absent only for an empty candidate set, and `parseVerdict` is null only for a
 	// non-PASS/FAIL body — but polarityRe already filtered candidates to PASS/FAIL markers, so both
@@ -369,8 +422,8 @@ export const boundHeadShas = (body: string, gate: VerdictGate): ReadonlyArray<st
  * bound body never matches an unbound one, so neither can overwrite the other.
  */
 export const bindsSameHead = (a: string, b: string, gate: VerdictGate): boolean => {
-	const headA = boundHeadShas(a, gate)[0] ?? null;
-	const headB = boundHeadShas(b, gate)[0] ?? null;
+	const headA = boundHead(a, gate);
+	const headB = boundHead(b, gate);
 	if (headA === null || headB === null) return headA === headB;
 	return isBoundToHead(headA, headB);
 };

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -308,6 +308,94 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 	});
 });
 
+describe("resolveVerdict — live-head candidates first, latest-wins only among them (#4189)", () => {
+	// The fixture shape is PR #3955's, and its creation order is the INVERSE of its head-binding
+	// order: the live-head verdict was upserted in place (#4016/#4050) into a slot created at 00:09,
+	// while the dead-head verdict was created fresh at 00:32. A `(createdAt, id)` pick crowns the
+	// 00:32 comment, applies the head test to that winner alone, and refuses a green PR.
+	const atHead = (over: Partial<VerdictComment> & {readonly id: number}) =>
+		marker({
+			createdAt: "2026-07-26T00:09:45Z",
+			body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+			...over,
+		});
+	const atDeadHead = (over: Partial<VerdictComment> & {readonly id: number}) =>
+		marker({
+			createdAt: "2026-07-26T00:32:02Z",
+			body: `review-doc: FAIL @ ${OLD} — changes-requested`,
+			...over,
+		});
+
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly comments: ReadonlyArray<VerdictComment>;
+		readonly authorized: ReadonlyArray<string>;
+		readonly expected: VerdictOutcome;
+	}> = [
+		{
+			name: "a newer-created dead-head FAIL does not shadow an older-created live-head PASS",
+			comments: [atHead({id: 1}), atDeadHead({id: 2})],
+			authorized: ["usirin"],
+			expected: {_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+		},
+		{
+			name: "the same reordering in the FAIL direction: a newer-created dead-head PASS never clears a live-head FAIL",
+			comments: [
+				atHead({id: 1, body: `review-doc: FAIL @ ${HEAD} — changes-requested`}),
+				atDeadHead({id: 2, body: `review-doc: PASS @ ${OLD} — merge-ready`}),
+			],
+			authorized: ["usirin"],
+			expected: {_tag: "current", commentId: 1, polarity: "FAIL", sha: HEAD},
+		},
+		{
+			name: "within the live-head set latest-wins still arbitrates (#4016's two surviving runs)",
+			comments: [
+				atHead({id: 1}),
+				atHead({
+					id: 2,
+					createdAt: "2026-07-26T00:10:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+				atDeadHead({id: 3}),
+			],
+			authorized: ["usirin"],
+			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+		},
+		{
+			name: "NOTHING binds the live head ⇒ unchanged fail-closed stale refusal, naming the newest",
+			comments: [
+				atDeadHead({id: 1, createdAt: "2026-07-26T00:20:00Z"}),
+				atDeadHead({id: 2, body: `review-doc: PASS @ ${OLD} — merge-ready`}),
+			],
+			authorized: ["usirin"],
+			expected: {_tag: "stale", commentId: 2, polarity: "PASS", sha: OLD},
+		},
+		{
+			name: "a forged live-head PASS cannot win the head-first filter (ADR 0055 gate composes)",
+			comments: [atHead({id: 1, author: "attacker"}), atDeadHead({id: 2})],
+			authorized: ["usirin"],
+			expected: {_tag: "stale", commentId: 2, polarity: "FAIL", sha: OLD},
+		},
+		{
+			name: "a SHA-less legacy marker binds no head, so a live-head verdict outranks it however new",
+			comments: [
+				atHead({id: 1}),
+				marker({id: 2, createdAt: "2026-07-26T00:40:00Z", body: "review-doc: FAIL — legacy"}),
+			],
+			authorized: ["usirin"],
+			expected: {_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+		},
+	];
+	for (const {name, comments, authorized, expected} of cases) {
+		it(name, () =>
+			assert.deepStrictEqual(
+				resolveVerdict({comments, authorizedAuthors: authorized, gate: "doc", headSha: HEAD}),
+				expected,
+			),
+		);
+	}
+});
+
 describe("isReviewed — read-verb decision over expected polarity", () => {
 	it("current FAIL satisfies an expect-FAIL read (write-code repair seam)", () => {
 		const outcome: VerdictOutcome = {_tag: "current", commentId: 1, polarity: "FAIL", sha: HEAD};


### PR DESCRIPTION
The verdict resolvers picked "the newest comment, then check whether it binds the live head" — which reads the wrong verdict whenever a verdict comment was upserted in place, because an upserted comment keeps the `created_at` of the slot it was rewritten into. That is what refused PR #3955 for about an hour while every required namespace carried a green at-head advisory. This flips the order to the one ADR 0058 actually implies: keep only the candidates bound to the live head, and let recency decide among those.

The same reordering now happens in both consumers (`verdict read` and `verdict gate`) and across both verdict forms (the bindable PASS/FAIL marker and the §CP `Reviewed-head:` advisory), so the two verbs cannot disagree about which comment is in force.

## What changed

- `pickInForce` in `packages/pipeline-cli/src/tools/verdict/verdict-match.ts` — filter the authorized candidate set to the live-head binding first, then reuse the existing latest-wins pick within it. `resolveVerdict` now uses it.
- `inForceOf` in `packages/pipeline-cli/src/tools/verdict/gate-decision.ts` — the same preference applied *across* the marker/advisory pair, replacing the bare `newerOf` call. `newerOf` survives as the within-set recency tiebreak.
- `boundHead(body, gate)` — the one place that says "the head this candidate binds is its marker `@ <sha>`, else its `Reviewed-head:` anchor". `bindsSameHead` now reads through it instead of re-deriving.
- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` — see the prose split below.

## What is deliberately preserved

- **The #4016/#4050 run-keyed upsert arbitration is intact.** Inside the live-head set this is unchanged latest-wins, which is exactly the arbitration two surviving same-head verdicts rely on. Pinned by a test.
- **Fail-closed behaviour is unchanged.** When *nothing* binds the live head, the pick falls back to the whole candidate set, so the downstream classification still reports the `stale` / `sha-less` refusal naming the offending comment. Pinned by tests in both files.
- **The ADR 0055 author-gate still composes.** The head filter runs before the author gate, so a forged live-head PASS cannot displace an authorized verdict — it simply leaves the at-head set empty and the fallback applies. Pinned by a test.
- **The #4049 body-only-repair exit is intact.** There, both the FAIL marker and the superseding advisory bind the *same* (live) head, so recency still decides. All existing §CP tests pass unmodified.

## Fenced, not fixed: the same-head write-recency direction

The issue's AC asks this be fixed or explicitly fenced. **It is fenced.** Two verdicts that both bind the live head are still ordered by `created_at`, so run A upserting its own older slot to FAIL after run B posted a newer PASS still resolves to B's PASS.

The named reason: closing it requires a *write-recency* signal, and there isn't one at the boundary today. `updated_at` is present on every REST comment but is dropped in `RawComment` (`packages/pipeline-cli/src/tools/tracker/gh-io.ts`), which is shared with other tools; and — per the triage note and ADR 0058 — `updated_at` is the wrong invariant anyway, since any body edit that does not re-author the verdict (a typo fix, an appended note) would re-rank it. The robust signal is a body-carried `verdict-written-at` stamped at upsert time, which is a post-side change with its own design question. Filed as a follow-up rather than smuggled in here. **No consumer sorts by `updated_at` in this diff.**

## The prose: partially here, the rest deliberately follow-up

I read all four cited fold sites on this branch rather than taking the framing on trust, and they are not the same defect:

**Fixed here (`ship-it/SKILL.md`)** — the sites that *state the resolution rule* and go stale the moment this code lands: the Step 2 preamble (now states the head-first rule once, explicitly), the four per-namespace bullets (`review-code` / `-doc` / `-skill` / `-design`, which said "the latest marker comment by `created_at`"), and the §CP advisory read at Step 2.§CP (which said "the latest §CP advisory comment body … latest-wins exactly like the markers"). Those told a reader or a hand-reading agent to do exactly the broken thing. The *why* is stated once in the preamble; the bullets point at it rather than re-deriving it four times.

**Not fixed here, filed instead** — the shell folds in `ship-it/SKILL.md` (~L900–948), `heal-ci/SKILL.md` (~L309–329) and `write-code/SKILL.md` (~L1881–1907) that compare a native review's `submitted_at` against a marker's `created_at`. Those folds are **already head-first**: the comparison only runs inside `case "$CURRENT_HEAD" in "$RSHA"*` (the review side) and only sets `MARKER_AT` when the marker resolved `_tag == "current"` (the marker side), so a dead-head candidate never enters the compare. Their residual defect is precisely the **same-head write-recency** direction fenced above — a review submitted between a marker slot's creation and its upsert. Fixing them needs the same missing signal, and fixing them *differently* from the code would put the prose and the resolver back out of sync, which is the failure this issue is about. So it belongs in one follow-up with the code half, not split across two.

Also examined and left alone: the N=3 repair-round counter in `write-code/SKILL.md` (~L2164) clusters FAIL markers by `created_at` gap. That counts distinct review passes, not which verdict is in force — a different question, noted in the follow-up.

## On PR #4135 (#4049) — no revert, and it does not close this

Confirmed by reading its branch (`umut-sirin/in-force-verdict-4049-b7c1e2a4`): it moves the resolution into a unified `resolveInForce`, and **retains** the `(createdAt, id)` sort with the head test applied after the pick, so this defect survives it. The two changes are complementary and collide textually in the same two files: #4135 unifies *which candidate forms* are considered, this one fixes *how the candidate set is ordered*. Whichever lands second rebases onto the other — the merge is mechanical (route #4135's `resolveInForce` marker/advisory picks through `pickInForce` and its `newerOf` through `inForceOf`) and neither resolution shape needs reverting. Cross-linked on #4049.

## Verification

- `pnpm vitest run` in `packages/pipeline-cli` — 2469 tests pass, no existing test modified.
- The seven new head-first cases were confirmed to **fail** against this branch's own pre-fix sources (stash the two source files, re-run: 7 failed), so they are real regression pins rather than tautologies.
- AC1 (`verdict gate --pr 3955 … --cp` resolves `enqueueable: true`) now passes — but honestly, **PR #3955 no longer discriminates**: the incident was unblocked by dispatching a fresh re-gate, so its live-head advisories are now newest by `created_at` too, and the pre-fix code resolves that PR `enqueueable` as well. Per the AC's own fallback, the discriminating proof is the fixture in `gate-decision.unit.test.ts`, which reproduces the exact #3955 comment shape (two advisories upserted into 00:09 slots, a dead-head pair created fresh at 00:32) and fails pre-fix.
- `pnpm typecheck` and `pnpm lint:worktree` clean.

## Note for the reviewer

This PR is `packages/pipeline-cli/` + a skill, so it is §CP and banks for control-plane approval. It is also gated by the selector it fixes: the gate that runs against this PR uses the **installed/pinned** CLI, not this branch, so if it lands a verdict that is later upserted in place, this PR can stall on exactly the bug it repairs. If that happens the sanctioned unblock is a fresh re-gate at the live head, never deleting a verdict comment or overriding the gate.

Fixes #4189
