### PR TITLE
fix(pipeline): a loop exit is not evidence, and a consumed queue entry is not an ejection (#4155)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2112,6 +2112,45 @@ never mention it in what you post.
 
 ---
 
+## WL. A loop exit is not evidence, and `grep -qv` is not a condition (#4155)
+
+Two shell-level rules the pipeline's agent-executed steps share. Both fail in the **same
+direction** — a condition meaning *not yet* / *not allowed* reads as *done* / *allowed*, and
+control flow proceeds — which is the silent direction: a loop that hangs is visible, a loop that
+exits early on a false condition is not. They are stated here once so every skill cites one
+definition.
+
+**1. A wait-loop's exit is never evidence of the awaited condition.** A loop controls *when* you
+re-read; it never substitutes for the read. On exit — whether the loop broke, timed out, or
+tripped a malformed condition — **re-assert the terminal state from ground truth** before
+reporting it. The live instance: a shipper improvised a `grep -qv null` poll while waiting on a
+merge queue; the condition succeeded on poll 1 and the loop exited on a state that meant "not
+merged yet" (#4155, on PR #4076). Nothing was misreported only because that shipper concluded
+from a direct `merged_at` + timeline read instead of from the loop — discipline, not a control.
+
+**2. Never use `grep -qv` / `grep -vq` as a loop or branch condition.** Two independent
+mechanisms break it, and both land on a false-true:
+
+- **Semantics.** `grep -v <pat>` succeeds when *any* line lacks the pattern, so over a
+  multi-line/multi-field read a `grep -qv` test is true almost unconditionally — it does **not**
+  mean "no line matches".
+- **Portability.** The `-q` + `-v` combination misbehaves under some grep variants (ugrep returns
+  non-zero even when non-matching lines exist), so `! grep -qv …` — the "every line matches the
+  allowed prefix" idiom — can read true for a set that contains disallowed entries.
+
+**The remedy — capture the inverted match and test emptiness, never the exit status.** This is the
+form [`lefthook.yml`](https://github.com/kamp-us/phoenix/blob/main/lefthook.yml)'s pre-push
+`typecheck` leg already uses and documents (#3130 → #3403); that comment is the anchor, and this
+section is its pipeline-side statement — don't restate the rationale at each call site, point here:
+
+```sh
+# "every changed path is under skills/ or agents/" — the empty-output form
+OFFCLASS=$(grep -vE '^claude-plugins/kampus-pipeline/(skills|agents)/' <<<"$FILES")
+if [ -n "$FILES" ] && [ -z "$OFFCLASS" ]; then …
+```
+
+---
+
 ## HEAD. Review the PR head, never the launched checkout's working copy (#793)
 
 A review gate is frequently spawned with `isolation:worktree`, which lands it in a **fresh

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -125,10 +125,12 @@ Step-0 class):
 # Any path off those surfaces (`apps/**`, `packages/**`, `infra/**`, a code-root README, a root
 # script) is behavioral work with a missing `Fixes #N` ⇒ a broken seam ⇒ hard-stop. Same file set +
 # same path-prefix class Step 2's skills-only route uses — no second class mechanism.
+# "every path is conversation-authored" is the EMPTY-OUTPUT form, never `! grep -qv` (§WL, #4155).
 FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
+OFFSURFACE="$(grep -vE '^(\.glossary|\.decisions|\.patterns)/' <<<"$FILES")"
 if [ -n "$FILES" ] \
    && grep -qE '^\.glossary/' <<<"$FILES" \
-   && ! grep -qvE '^(\.glossary|\.decisions|\.patterns)/' <<<"$FILES"; then
+   && [ -z "$OFFSURFACE" ]; then
   echo "conversation-authored .glossary/** coining site, no Fixes #N — legitimate (ADR 0184/0075): ISSUE stays unset, AC half N/A"
 else
   echo "no linked issue on a PR carrying behavioral code — broken seam: hard-stop (dangling-code guard, ADR 0184)"
@@ -222,8 +224,11 @@ each gate hands a mis-classed PR to the gate that owns its class:
 # the file set drives the class decision (same list pulled above)
 FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
 # skills-only ⇒ every changed path is under skills/ or agents/ — review-skill's class, not yours
-# (agents/** are behavioral artifacts, review-skill-routed for the verdict — ADR 0150/#2003)
-if [ -n "$FILES" ] && ! grep -qvE '^claude-plugins/kampus-pipeline/(skills|agents)/' <<<"$FILES"; then
+# (agents/** are behavioral artifacts, review-skill-routed for the verdict — ADR 0150/#2003).
+# Empty-output form, never `! grep -qv`: a false-true here `exit 0`s the code gate on a PR that
+# does carry code (§WL of ../gh-issue-intake-formats.md, #4155).
+OFFCLASS="$(grep -vE '^claude-plugins/kampus-pipeline/(skills|agents)/' <<<"$FILES")"
+if [ -n "$FILES" ] && [ -z "$OFFCLASS" ]; then
   echo "not a code PR — route to review-skill"   # plain note, no review-code: marker; stop
   exit 0
 fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -2066,7 +2066,8 @@ reconcile shells out to it per poll and branches on the printed outcome word:
 # a PR still QUEUED at the budget's end is a well-formed pending, not a failure.
 # The classifier reads PR state (gh pr view — the sanctioned PR-state read ship-it Step 2 uses,
 # NOT a GraphQL intake query the org's Projects-classic integration breaks) + the last merge-queue
-# timeline event (gh api …/timeline, REST), cross-checks a non-merged read against the base branch
+# timeline event AND whether a `merged` event is present (gh api …/timeline, REST — the pairing
+# that tells a consumed queue entry from an ejection, #4155), cross-checks a non-merged read against the base branch
 # (gh api …/commits?sha=<base>, the read that stayed fresh while the other two lagged — #4057), and
 # prints merged/ejected/queued/pending. It is fail-closed away from a false ship: any unreadable
 # signal ⇒ pending (keep polling), never a false merged/ejected.
@@ -2098,6 +2099,34 @@ else
     echo "refused — the enqueue did not take effect at this head; the parked intent was cleared. Re-dispatch ship-it to re-assert the gates and enqueue (idempotent)."
 fi
 ```
+
+#### The loop is not the evidence — and a bare removal event is not an ejection (#4155)
+
+The block above shells out to the classifier on purpose. When you are tempted to hand-roll the
+poll instead — a `gh api` read piped into a `grep`, because the CLI was one step away — these three
+rules bind that loop too. The first two are the merge-path instance of §WL of
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) (the shared statement; read it
+there rather than re-deriving it here):
+
+- **A wait-loop's exit is never evidence that the merge landed.** The loop decides *when* to
+  re-read, never *what is true*. Merge evidence is **`merged_at` non-null PLUS a `merged` timeline
+  event**, re-asserted after the loop exits. On an **open** PR `merge_commit_sha` is GitHub's
+  throwaway test-merge commit and is evidence of nothing (the trap pinned below), and a null
+  `auto_merge` post-enqueue is **expected** under a merge queue — never read either as an outcome.
+- **Never `grep -qv` / `grep -vq` as the exit condition.** The live instance is this step: a
+  shipper's improvised `grep -qv null` poll over a multi-field read succeeded on poll 1 — every such
+  read emits lines without `null` — and the loop exited while PR #4076 was still queued (#4155).
+  Capture the inverted match and test emptiness instead.
+- **`removed_from_merge_queue` alone is not an ejection.** The queue emits that event as it
+  **consumes** the entry to land the batch, so on a successful merge it pairs with a `merged` event
+  ≤1s away — PR #4076 (removal `00:27:43Z`, merged `00:27:44Z`), #4143 (both `00:53:07Z`, with
+  `merged` returned *first* in the array), #4164 (`01:38:30Z` / `01:38:31Z`). Array order and
+  timestamp order discriminate nothing; the **presence of the `merged` event** does.
+  `merge-queue-classify` encodes exactly this — a removal paired with a `merged` event classifies
+  `queued`, never `ejected`, and does **not** promote to `merged` on that one signal (merge evidence
+  is still `merged_at` plus the event, so the reconcile keeps polling until the PR state or the
+  base-branch squash confirms). An ejection check keyed on the removal alone would report **every**
+  successful merge as an ejection.
 
 #### The timeline is authoritative but not timely — the freshness cross-check and the ejection window this reconcile accepts (#4057)
 
@@ -2152,7 +2181,8 @@ merge disposition:
   branch's regime, never this PR's own queue history: a first-attempt PR under a queue has no
   history either, so keying on history would leave exactly the #3700 arm parked.
 - **`ejected`** — the queue **dropped** the PR (still open, no longer queued, not merged) — keyed on
-  the authoritative `removed_from_merge_queue` timeline event, not on a momentary state. This is
+  the authoritative `removed_from_merge_queue` timeline event **unpaired with a `merged` event**
+  (#4155), not on a momentary state. This is
   the silent stall this step exists to catch. Do **not** report shipped. **Route it back to
   repair/re-queue** and **surface the ejection**: leave a legible comment on the PR naming the
   ejection and the likely cause (textual batch conflict vs combined-batch CI failure), so the

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/github-service.unit.test.ts
@@ -216,6 +216,34 @@ describe("Github.signals — the ground-truth reads over a mock gh spawner (#273
 		),
 	);
 
+	it.effect(
+		"the #4155 consumed-entry case: removal + a `merged` event on a lagging PR read ⇒ not ejected",
+		() =>
+			Effect.gen(function* () {
+				// The live #4164 timeline shape, read while `pulls/4164` still returned merged:false.
+				const signals = yield* (yield* Github).signals(4164, REPO);
+				assert.strictEqual(signals.lastMergeQueueEvent, "removed_from_merge_queue");
+				assert.strictEqual(signals.mergedTimelineEvent, true);
+				assert.notStrictEqual(classify(signals).outcome, "ejected");
+			}).pipe((effect) =>
+				provide(effect, {
+					prState: prView("OPEN", "CLEAN", "main"),
+					timeline: timelineEvents("added_to_merge_queue", "removed_from_merge_queue", "merged"),
+					baseCommits: baseCommits("chore: someone else's squash (#4165)"),
+				}),
+			),
+	);
+
+	it.effect("fail-closed: an unreadable timeline carries NO merge evidence either", () =>
+		Effect.gen(function* () {
+			// The timeline read exits 1 (unprovided): a fault must not fabricate a `merged` event
+			// any more than it fabricates an ejection.
+			const signals = yield* (yield* Github).signals(1906, REPO);
+			assert.strictEqual(signals.mergedTimelineEvent, false);
+			assert.strictEqual(classify(signals).outcome, "pending");
+		}).pipe((effect) => provide(effect, {prState: prView("OPEN", "CLEAN")})),
+	);
+
 	it.effect("an unreadable PR state fails GhCommandError (the command maps it to pending)", () =>
 		Effect.gen(function* () {
 			const error = yield* Effect.flip((yield* Github).signals(1906, REPO));

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
@@ -13,8 +13,9 @@
  * as a typed `E` the command handles rather than an invisible defect.
  *
  * One verb, `signals(pr)`, resolves the whole `MergeQueueSignals` input: the PR `state` +
- * `mergeStateStatus` + `baseRefName` from `gh pr view`, the LAST merge-queue timeline event from
- * `gh api .../timeline`, and — when the PR does not already read merged — whether the base branch
+ * `mergeStateStatus` + `baseRefName` from `gh pr view`, the LAST merge-queue timeline event **and
+ * whether a `merged` event is present** (#4155) from `gh api .../timeline` — one read, two facts —
+ * and — when the PR does not already read merged — whether the base branch
  * carries the PR's squash, from `gh api .../commits?sha=<base>` (#4057). The
  * fail-closed-away-from-a-false-ship posture is preserved exactly: an unreadable repo or PR state
  * propagates as a typed error the command maps to `pending`; an unreadable timeline is deliberately
@@ -32,6 +33,7 @@ import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {
 	type BaseBranchSquash,
+	hasMergedEvent,
 	type LastMergeQueueEvent,
 	lastMergeQueueEvent,
 	type MergeQueueSignals,
@@ -239,40 +241,52 @@ const readPrState = Effect.fn("Github.readPrState")(function* (repo: string, pr:
 	return toPrState(yield* decodePrState(yield* parseJson(args, yield* runGh(args))));
 });
 
+/** The two facts one timeline read resolves: the last merge-queue event + a `merged` event. */
+interface TimelineFacts {
+	readonly lastMergeQueueEvent: LastMergeQueueEvent;
+	readonly mergedTimelineEvent: boolean;
+}
+
+/** The no-evidence recovery value — the settle window, with no merge evidence. */
+const NO_TIMELINE_FACTS: TimelineFacts = {lastMergeQueueEvent: null, mergedTimelineEvent: false};
+
 /**
- * The LAST merge-queue timeline event, or `null` when the timeline carries none yet. An
- * unreadable timeline is DELIBERATELY recovered to `null` here — the fail-closed-away-from-a-
- * false-ship posture (#1921): a missing event reads as the enqueue-settle window (`pending`),
- * so a `gh`/parse/shape fault on the timeline can only keep polling, never trigger a false
- * ejection. The recovered errors are the typed `E` this read raises (not an untyped swallow):
- * the recovery is scoped to exactly `GhCommandError`/`GhParseError`/`SchemaError` at this one site.
+ * The LAST merge-queue timeline event plus whether a `merged` event is present (#4155) — both from
+ * ONE timeline read. An unreadable timeline is DELIBERATELY recovered to "no event, no merge" here —
+ * the fail-closed-away-from-a-false-ship posture (#1921): a missing event reads as the
+ * enqueue-settle window (`pending`), so a `gh`/parse/shape fault on the timeline can only keep
+ * polling, never trigger a false ejection and never a false merge. The recovered errors are the
+ * typed `E` this read raises (not an untyped swallow): the recovery is scoped to exactly
+ * `GhCommandError`/`GhParseError`/`SchemaError` at this one site.
  */
-const readLastMergeQueueEvent = Effect.fn("Github.readLastMergeQueueEvent")(
+const readTimelineFacts = Effect.fn("Github.readTimelineFacts")(
 	function* (repo: string, pr: number) {
 		const args = timelineArgs(repo, pr);
 		const raw = yield* runGh(args);
 		// `--paginate` concatenates JSON arrays; normalize `][` joins into one array before parsing.
 		const merged = raw.replace(/\]\s*\[/g, ",");
-		const entries = yield* decodeTimeline(yield* parseJson(args, merged));
+		const decoded = yield* decodeTimeline(yield* parseJson(args, merged));
 		// The core reads only `event` + `created_at`; project to its exact-optional shape, dropping
 		// a null/absent field to an omitted key rather than an explicit `undefined`.
-		return lastMergeQueueEvent(
-			entries.map((e) => {
-				const entry: {event?: string; created_at?: string} = {};
-				if (e.event != null) entry.event = e.event;
-				if (e.created_at != null) entry.created_at = e.created_at;
-				return entry;
-			}),
-		);
+		const entries = decoded.map((e) => {
+			const entry: {event?: string; created_at?: string} = {};
+			if (e.event != null) entry.event = e.event;
+			if (e.created_at != null) entry.created_at = e.created_at;
+			return entry;
+		});
+		return {
+			lastMergeQueueEvent: lastMergeQueueEvent(entries),
+			mergedTimelineEvent: hasMergedEvent(entries),
+		} satisfies TimelineFacts;
 	},
 	(effect) =>
 		effect.pipe(
 			Effect.catchTags({
 				"@kampus/merge-queue-classify/GhCommandError": () =>
-					Effect.succeed<LastMergeQueueEvent>(null),
+					Effect.succeed<TimelineFacts>(NO_TIMELINE_FACTS),
 				"@kampus/merge-queue-classify/GhParseError": () =>
-					Effect.succeed<LastMergeQueueEvent>(null),
-				SchemaError: () => Effect.succeed<LastMergeQueueEvent>(null),
+					Effect.succeed<TimelineFacts>(NO_TIMELINE_FACTS),
+				SchemaError: () => Effect.succeed<TimelineFacts>(NO_TIMELINE_FACTS),
 			}),
 		),
 );
@@ -306,7 +320,7 @@ const readBaseBranchSquash = Effect.fn("Github.readBaseBranchSquash")(
 
 const readSignals = Effect.fn("Github.signals")(function* (repo: string, pr: number) {
 	const prState = yield* readPrState(repo, pr);
-	const lastEvent = yield* readLastMergeQueueEvent(repo, pr);
+	const timeline = yield* readTimelineFacts(repo, pr);
 	// Not read once the PR itself reads merged: the cross-check exists to correct a stale
 	// not-merged read, so there is nothing left for it to corroborate.
 	const baseBranchSquash = prState.merged
@@ -315,7 +329,8 @@ const readSignals = Effect.fn("Github.signals")(function* (repo: string, pr: num
 	return {
 		merged: prState.merged,
 		state: prState.state,
-		lastMergeQueueEvent: lastEvent,
+		lastMergeQueueEvent: timeline.lastMergeQueueEvent,
+		mergedTimelineEvent: timeline.mergedTimelineEvent,
 		mergeStateStatus: prState.mergeStateStatus,
 		baseBranchSquash,
 	} satisfies MergeQueueSignals;

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.ts
@@ -61,6 +61,15 @@ export interface MergeQueueSignals {
 	 */
 	readonly lastMergeQueueEvent: LastMergeQueueEvent;
 	/**
+	 * Does the timeline carry a `merged` event? The queue emits `removed_from_merge_queue` as it
+	 * CONSUMES the entry to land the batch, so on a successful merge that removal pairs with a
+	 * `merged` event ≤1s away — #4143 both at 00:53:07Z, #4164 removal 01:38:30Z / merged
+	 * 01:38:31Z, #4076 00:27:43Z / 00:27:44Z (#4155). Either order appears in the array, so
+	 * ordering discriminates nothing; the presence of the `merged` event does. Optional: absent ⇒
+	 * no such event was read ⇒ no evidence (#4155).
+	 */
+	readonly mergedTimelineEvent?: boolean | undefined;
+	/**
 	 * `mergeStateStatus` from `gh pr view` — used only as a *positive* still-queued hint
 	 * (`QUEUED`), never to infer ejection. Optional: absent ⇒ treated as unknown.
 	 */
@@ -76,7 +85,8 @@ export interface MergeQueueSignals {
  * The terminal reconcile outcome:
  *   - `merged`  — the queue landed the batch. Terminal success.
  *   - `ejected` — a genuine dequeue: NOT merged AND the last merge-queue event is
- *                 `removed_from_merge_queue`. Route back to repair/re-queue.
+ *                 `removed_from_merge_queue` AND the timeline carries NO `merged` event.
+ *                 Route back to repair/re-queue.
  *   - `queued`  — still in the queue: NOT merged AND (last event is
  *                 `added_to_merge_queue` OR `mergeStateStatus == QUEUED`). Keep polling.
  *                 It is not proof of health — an ejection that has not yet surfaced in the
@@ -106,8 +116,13 @@ const at = (outcome: MergeOutcome, reason: string): Classification => ({outcome,
  *   1b. `merged` — the base branch already carries this PR's squash. Ranked with (1), above
  *      the ejection check, for the same reason (1) is first: a landed merge outranks both a
  *      stale not-merged read and the removal event the queue emits as it merges.
- *   2. `ejected` — NOT merged AND last merge-queue event is `removed_from_merge_queue`.
- *      This is the ONLY ejection signal: a genuine dequeue, not a momentary state read.
+ *   2. `ejected` — NOT merged AND last merge-queue event is `removed_from_merge_queue` AND the
+ *      timeline carries no `merged` event. This is the ONLY ejection signal: a genuine dequeue,
+ *      not a momentary state read, and not the removal the queue emits as it lands the batch.
+ *   2b. `queued` — the removal IS paired with a `merged` event: the queue consumed the entry to
+ *      land it. Not an ejection, and not yet `merged` either — a `merged` timeline event alone is
+ *      one signal, and merge evidence is `merged_at` non-null PLUS that event, so the reconcile
+ *      keeps polling until the PR state (or the base-branch squash) confirms (#4155).
  *   3. `queued` — NOT merged AND (last event `added_to_merge_queue` OR
  *      mergeStateStatus==QUEUED). A well-formed pending in the queue; keep polling.
  *   4. `pending` — NOT merged AND no merge-queue event yet (the settle window, incl.
@@ -130,6 +145,12 @@ export const classify = (s: MergeQueueSignals): Classification => {
 		);
 	}
 	if (s.lastMergeQueueEvent === "removed_from_merge_queue") {
+		if (s.mergedTimelineEvent === true) {
+			return at(
+				"queued",
+				"removed_from_merge_queue paired with a merged timeline event — the queue consumed the entry to land the batch, not an ejection; holding for merged_at to confirm",
+			);
+		}
 		return at(
 			"ejected",
 			"not merged and the last merge-queue event is removed_from_merge_queue — a genuine dequeue",
@@ -215,3 +236,13 @@ export const lastMergeQueueEvent = (
 	);
 	return last.event;
 };
+
+/**
+ * Does the REST issue-timeline carry a `merged` event? Presence-only, deliberately order-free: the
+ * queue emits `removed_from_merge_queue` and `merged` within a second of each other as it lands the
+ * batch, in either array order (#4143 carries `merged` BEFORE the removal at the same second),
+ * so "did the merge land" is answered by the event existing, never by its position (#4155).
+ */
+export const hasMergedEvent = (
+	timeline: ReadonlyArray<{readonly event?: string; readonly created_at?: string}>,
+): boolean => timeline.some((entry) => entry.event === "merged");

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.unit.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 import {
 	classify,
+	hasMergedEvent,
 	lastMergeQueueEvent,
 	type MergeQueueSignals,
 	squashOnBaseBranch,
@@ -128,6 +129,97 @@ describe("classify — the #4057 stale-timeline cases (the base-branch freshness
 			).outcome,
 		).toBe("ejected");
 		expect(classify(sig({lastMergeQueueEvent: "added_to_merge_queue"})).outcome).toBe("queued");
+	});
+});
+
+describe("classify — the #4155 consumed-entry cases (removal paired with a `merged` event)", () => {
+	it("the #4164 shape: removal at 01:38:30Z, merged at 01:38:31Z, PR state still lagging ⇒ NOT ejected", () => {
+		// Every signal is the live 2026-07-26 payload for PR #4164 read while `pulls/4164` still
+		// returned merged:false. Under the pre-#4155 logic the removal alone classified `ejected`
+		// on a PR that had just landed.
+		const c = classify(
+			sig({
+				merged: false,
+				state: "OPEN",
+				lastMergeQueueEvent: "removed_from_merge_queue",
+				mergedTimelineEvent: true,
+			}),
+		);
+		expect(c.outcome).not.toBe("ejected");
+		expect(c.outcome).toBe("queued");
+	});
+
+	it("a `merged` timeline event alone never promotes to merged — merge evidence is merged_at PLUS the event", () => {
+		// One signal is not evidence: the reconcile keeps polling until the PR state (or the
+		// base-branch squash) confirms. Fail-closed in BOTH directions — no false ship, no false eject.
+		const c = classify(
+			sig({
+				merged: false,
+				lastMergeQueueEvent: "removed_from_merge_queue",
+				mergedTimelineEvent: true,
+			}),
+		);
+		expect(c.outcome).not.toBe("merged");
+	});
+
+	it("a removal with NO merged event is still a genuine ejection (the discriminator, not a blanket amnesty)", () => {
+		expect(
+			classify(sig({lastMergeQueueEvent: "removed_from_merge_queue", mergedTimelineEvent: false}))
+				.outcome,
+		).toBe("ejected");
+		// absent field ⇒ the event was not read ⇒ no evidence ⇒ the pre-#4155 verdict stands
+		expect(classify(sig({lastMergeQueueEvent: "removed_from_merge_queue"})).outcome).toBe(
+			"ejected",
+		);
+	});
+
+	it("the merged-PR path is untouched: state==MERGED still wins outright", () => {
+		expect(
+			classify(
+				sig({
+					merged: true,
+					state: "MERGED",
+					lastMergeQueueEvent: "removed_from_merge_queue",
+					mergedTimelineEvent: true,
+				}),
+			).outcome,
+		).toBe("merged");
+	});
+});
+
+describe("hasMergedEvent — is a `merged` event present in the timeline?", () => {
+	it("the #4164 order: removal then merged one second later", () => {
+		expect(
+			hasMergedEvent([
+				{event: "added_to_merge_queue", created_at: "2026-07-26T01:33:36Z"},
+				{event: "removed_from_merge_queue", created_at: "2026-07-26T01:38:30Z"},
+				{event: "merged", created_at: "2026-07-26T01:38:31Z"},
+			]),
+		).toBe(true);
+	});
+
+	it("the #4143 order: merged BEFORE the removal, same second — presence, never position", () => {
+		// The live #4143 timeline returns `merged` first at 00:53:07Z with the removal at the same
+		// timestamp. Any order-sensitive read would miss the merge here.
+		expect(
+			hasMergedEvent([
+				{event: "added_to_merge_queue", created_at: "2026-07-26T00:40:22Z"},
+				{event: "merged", created_at: "2026-07-26T00:53:07Z"},
+				{event: "removed_from_merge_queue", created_at: "2026-07-26T00:53:07Z"},
+			]),
+		).toBe(true);
+	});
+
+	it("false on a timeline with no merged event (an ejection, and the empty settle window)", () => {
+		expect(
+			hasMergedEvent([
+				{event: "added_to_merge_queue"},
+				{event: "removed_from_merge_queue"},
+				{event: "labeled"},
+			]),
+		).toBe(false);
+		expect(hasMergedEvent([])).toBe(false);
+		expect(hasMergedEvent([{}])).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What this does

Closes the `grep -qv`-as-a-condition class in the pipeline skills, and the classifier gap it
surfaced: a `removed_from_merge_queue` event read as an ejection when it was the queue consuming
the entry to land the batch.

Three parts:

1. **§WL in the formats contract** (`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`)
   — the rationale pinned **once**, cross-referencing the existing `lefthook.yml` anchor rather than
   restating it: (a) a wait-loop's exit is never evidence of the awaited condition; (b) never
   `grep -qv` / `grep -vq` as a loop or branch condition — capture the inverted match and test
   emptiness (`-z`).
2. **The two live `! grep -qvE` gate-routing conditions in `review-code`** converted to that
   empty-output form, semantics preserved exactly (the ADR-0184 dangling-code carve-out at Step 1,
   and the skills-only `exit 0` off-ramp at Step 2 — a false-true there skips the code gate).
3. **`ship-it` Step 5.5 + `merge-queue-classify`.** Step 5.5 now pins the loop-exit rule, the
   merge-evidence rule (`merged_at` non-null **plus** a `merged` timeline event; on an OPEN PR
   `merge_commit_sha` is GitHub's throwaway test-merge commit and a null `auto_merge` post-enqueue
   is expected), and the removal/merged pairing — stated where a shipper improvising a poll reads.
   The classifier now **encodes** the pairing: it reads whether the timeline carries a `merged`
   event alongside the last merge-queue event, and a removal paired with a `merged` event
   classifies `queued`, never `ejected`.

## Overlap with PR #4130 (AC 1) — checked first

PR #4130 (`fix(ship-it): corroborate the Step 5.5 reconcile against the base branch, and bound the
ejection window`, issue #4057) **merged** at 2026-07-26T00:44:58Z, so it is now the committed
Step 5.5 surface. Its diff was read before writing anything here. It replaced Step 5.5's *freshness*
half — the base-branch squash cross-check that promotes a stale not-merged read to `merged` — and it
does **not** touch the exit-condition/idiom class or the removal-vs-merged discrimination. So this
issue's Step 5.5 half **folds onto #4130's surface** (added as a new subsection beside its
"authoritative but not timely" block, and its `ejected` bullet amended) rather than landing a
competing edit. Nothing #4130 shipped is reverted or duplicated.

## The classifier gap (AC 3) — verified, real, and now covered

`packages/pipeline-cli/src/tools/merge-queue-classify/` did **not** encode the subtlety. It consumed
only the last merge-queue event, never the `merged` timeline event: with the PR-state read lagging
(the #4057 regime — ~65 minutes of `merged:false` on a landed PR), a `removed_from_merge_queue`
alone classified `ejected` on a PR that had just merged. The existing precedence only saved the case
where `merged` / `state==MERGED` had already caught up, or where the base-branch squash was in the
scanned window.

Grounded in live payloads read this run (`gh api repos/kamp-us/phoenix/issues/<N>/timeline`), not
intuition:

| PR | `removed_from_merge_queue` | `merged` | array order |
|---|---|---|---|
| #4143 | 00:53:07Z | 00:53:07Z | `merged` **first** |
| #4164 | 01:38:30Z | 01:38:31Z | removal first |
| #4076 (the report) | 00:27:43Z | 00:27:44Z | removal first |

Timestamp order and array order therefore discriminate nothing — **presence of the `merged` event
does**. The fix adds an optional `mergedTimelineEvent` signal + the pure `hasMergedEvent` helper
(presence-only, deliberately order-free), resolved from the *same* timeline read, and a classify
branch: removal + `merged` event ⇒ `queued`, not `ejected`. It deliberately does **not** promote to
`merged` on that one signal — merge evidence stays `merged_at` plus the event, so the reconcile keeps
polling until PR state or the base-branch squash confirms. Fail-closed both ways: no false ship, no
false ejection. An unreadable timeline recovers to "no event, no merge evidence", unchanged.

New unit tests: the #4164 lagging-read shape (not ejected), a `merged` event alone never promoting to
`merged`, a removal with no `merged` event still ejecting (the discriminator is not a blanket
amnesty), both live array orders through `hasMergedEvent`, plus two service-level tests over the mock
`gh` spawner (the consumed-entry case, and the fail-closed unreadable timeline).

## Acceptance criteria

- [x] Overlap with PR #4130 checked first and recorded above.
- [x] Step 5.5 pins "a wait-loop's exit is never evidence" + `merged_at` **plus** a `merged` timeline
      event as the only merge evidence + `merge_commit_sha` on an OPEN PR is never evidence.
- [x] Step 5.5 records the `removed_from_merge_queue` → `merged` pairing with observed payloads;
      the classifier did **not** encode it, so that gap is fixed and unit-tested.
- [x] Both `! grep -qvE` conditions in `review-code` converted to the empty-output form, semantics
      preserved.
- [x] No `grep -qv` / `grep -vq` remains as a loop or branch condition in
      `claude-plugins/kampus-pipeline/**` — a repo-wide grep confirms the only remaining hits are the
      prose that names the banned idiom (§WL and the two call-site pointers).
- [x] The rationale is pinned once (§WL, anchored on the `lefthook.yml` comment) and cross-referenced
      at each site, not restated.

## Verification

- `pnpm typecheck` — clean (full workspace, `tsgo`).
- `pnpm lint:worktree` — clean.
- `pnpm vitest run src/tools/merge-queue-classify` — 43 passed.

## Control plane

§CP: yes. The diff touches `claude-plugins/kampus-pipeline/skills/{ship-it,review-code}/`,
`skills/gh-issue-intake-formats.md`, and `packages/pipeline-cli/` — all inside `CONTROL_PLANE_RE`
as resolved from `origin/main`. Stops at PR-open for control-plane approval.

## Deviations

- **The classifier does not add a fifth outcome for "landing".** A removal paired with a `merged`
  event resolves to the existing `queued` (keep polling) rather than a new terminal word. A new
  outcome would ripple through every Step 5.5 branch and the driving loop's shipper stage for a state
  that is transient by construction; `queued` already carries exactly the required semantics ("still
  in-flight as far as the reads can tell — not shipped, not ejected").
- **`review-code`'s condition semantics are unchanged by design.** The conversion is mechanical
  (`! grep -qvE <pat>` → capture `grep -vE <pat>`, test `-z`); the `[ -n "$FILES" ]` zero-scope guard
  and both path-prefix patterns are byte-identical to before. No routing behavior is intentionally
  altered.
- **§WL lives in the formats contract, not a new `.patterns/` doc.** The rule is about how pipeline
  *skills* write shell conditions, and the formats contract is where cross-skill rules of that shape
  are already single-sourced (§SP, §HEAD, §RO, §CP). `lefthook.yml`'s comment remains the original
  anchor and is cited, not copied.
- **The ugrep variant misbehavior was not independently reproduced.** As in triage's own note, that
  half rests on the in-repo `lefthook.yml` precedent (#3130 → #3403). The *semantic* half — and the
  classifier gap — were both verified against live payloads this run.

Fixes #4155
