### PR TITLE
fix(pipeline): a path-only §CP answer can no longer read as "not control plane" (#4161)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1594,6 +1594,61 @@ approval is present (per POLICY, the founder's; ADR 0135). Its **verdict routing
 it is still doc-class, `review-doc`-verified (this set governs *who merges*, not *which gate
 verifies*); the content clause adds only the merge-authority hold.
 
+### A path-only §CP answer is NEVER authoritative — use `cp-classify` (#4161)
+
+The two clauses above are **independent sources** of §CP membership, and `CONTROL_PLANE_RE` has
+**no `.decisions/` clause** — so a path-only test classifies *every* ADR non-§CP. A guard-touching
+ADR is therefore §CP with **zero path matches** (live: PR #4134, both files `.decisions/**`; the
+shipper caught it only by running the content probe). The failure is **silent and fail-open**: the
+guard-relaxing change reads as ordinary product work and escapes the human §CP approval entirely,
+rather than erroring.
+
+**The rule: a bare "no path matched" is not a verdict.** Every consumer that needs "is this §CP?"
+runs the shared entry point, which cannot hand back a fail-open no:
+
+```bash
+# The §CP classification entry point — four states on stdout, fail-closed exit code (#4161).
+# Re-resolves the live CONTROL_PLANE_RE from origin/main itself (#981); pass --control-plane-re
+# to reuse one you already resolved.
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | pipeline-cli cp-classify classify --repo "$REPO"
+```
+
+| stdout | meaning | exit |
+| --- | --- | --- |
+| `control-plane` | a path matched — authoritative §CP, BLOCKING | 0 |
+| `content-undetermined` | no path matched, but `.decisions/**` files are present — **an obligation, not a verdict**: probe each with `guard-content-probe` at the PR head before claiming ordinary | 0 |
+| `not-control-plane` | path clear **and** no `.decisions/**` file, so the content clause has nothing left to decide — the one proven-ordinary verdict | 1 |
+| `unknown` | the classification could not be made (unresolvable / uncompilable boundary, empty file set) — treat as §CP and hold | 0 |
+
+`unknown` is its own state on purpose: a read that **failed** and a change that is **genuinely
+non-§CP** are different facts, and collapsing them is the recurring fail-open defect class here
+(#3715, #4108, #4171, #4191). The exit code is 0 on every hold state and 1 **only** on
+`not-control-plane`, so both naive bash shapes — `… && echo BLOCKING` and `… || ordinary` — are
+fail-closed; the ordinary branch is reachable only on positive proof. `content-undetermined`
+resolves through the **existing** ADR-0164 probe unchanged, so this widens no over-match (#2617).
+
+#### The classification-site register
+
+Every site that decides §CP membership, and which sources it consults. A new consumer joins this
+table or it does not ship.
+
+| site | sources | note |
+| --- | --- | --- |
+| `ship-it` Step 0 | path + content | the merge-deciding gate; both re-resolved from `origin/main` |
+| `review-code` Step 2 | path + content | |
+| `review-doc` Step 0 | path + content | |
+| `review-design` | `cp-classify` (path + content) | was path-only |
+| `review-skill` Step 0 | `cp-classify` (path + content) | was path-only |
+| `review-trivial` | `cp-classify` (path + content) | was path-only; routes to the lighter gate, so a fail-open here under-gates |
+| `trivial-diff` | path + content | bound 3; shares the content-clause scope with `cp-classify` |
+| `codeowners-cp` | **path only — deliberate, not a defect** | it generates `.github/CODEOWNERS`, and GitHub matches CODEOWNERS on **paths**; the format structurally cannot express a content predicate. The content clause is enforced at the gates above instead, which is where a merge is actually decided. |
+| the crew driver (EM) | *classifies §CP nowhere today* | when it does, it uses `cp-classify` — tracked by #3416, which must not be built twice |
+
+The boundary stays single-sourced on both axes: `CONTROL_PLANE_RE` in the pipeline-cli const
+(#2761), `GUARD_ADR_RE` in this file, and the content clause's **scope** (`.decisions/**`) once in
+`cp-classify`'s core. No consumer re-declares any of the three.
+
 ---
 
 ## DOC. The doc-class / review-doc surface — one canonical definition

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1607,26 +1607,41 @@ rather than erroring.
 runs the shared entry point, which cannot hand back a fail-open no:
 
 ```bash
-# The §CP classification entry point — four states on stdout, fail-closed exit code (#4161).
-# Re-resolves the live CONTROL_PLANE_RE from origin/main itself (#981); pass --control-plane-re
-# to reuse one you already resolved.
-gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | pipeline-cli cp-classify classify --repo "$REPO"
+# The §CP classification entry point — four states on stdout (#4161). Re-resolves the live
+# CONTROL_PLANE_RE from origin/main itself (#981); pass --control-plane-re to reuse one you
+# already resolved. ASSERT ON THE STATE WORD, never on the exit status alone — see below.
+CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | pipeline-cli cp-classify classify --repo "$REPO")"
+if [ "$CP_STATE" = "not-control-plane" ]; then
+  : # proven ordinary — the ONLY branch that may skip the §CP hold
+else
+  echo "BLOCKING (§CP state '$CP_STATE')"   # every other value, INCLUDING the empty string a failed invocation yields
+fi
 ```
 
 | stdout | meaning | exit |
 | --- | --- | --- |
 | `control-plane` | a path matched — authoritative §CP, BLOCKING | 0 |
 | `content-undetermined` | no path matched, but `.decisions/**` files are present — **an obligation, not a verdict**: probe each with `guard-content-probe` at the PR head before claiming ordinary | 0 |
-| `not-control-plane` | path clear **and** no `.decisions/**` file, so the content clause has nothing left to decide — the one proven-ordinary verdict | 1 |
+| `not-control-plane` | path clear **and** no `.decisions/**` file, so the content clause has nothing left to decide — the one proven-ordinary verdict | 3 |
 | `unknown` | the classification could not be made (unresolvable / uncompilable boundary, empty file set) — treat as §CP and hold | 0 |
 
 `unknown` is its own state on purpose: a read that **failed** and a change that is **genuinely
 non-§CP** are different facts, and collapsing them is the recurring fail-open defect class here
-(#3715, #4108, #4171, #4191). The exit code is 0 on every hold state and 1 **only** on
-`not-control-plane`, so both naive bash shapes — `… && echo BLOCKING` and `… || ordinary` — are
-fail-closed; the ordinary branch is reachable only on positive proof. `content-undetermined`
-resolves through the **existing** ADR-0164 probe unchanged, so this widens no over-match (#2617).
+(#3715, #4108, #4171, #4191). `content-undetermined` resolves through the **existing** ADR-0164
+probe unchanged, so this widens no over-match (#2617).
+
+**The exit code discriminates the four states only once the verb has RUN — so a consumer asserts
+on the stdout state word, never on a bare non-zero.** Both naive exit-status shapes are **UNSAFE
+and must not be used**: `… || ordinary` fires on an effect-cli usage error (exit 1, help text on
+stdout, no state word) and on a missing binary (exit 127) exactly as it does on the real verdict,
+routing a §CP change to the ordinary branch; `… && echo BLOCKING` simply emits nothing when the
+verb never ran, so the BLOCKING line the caller relied on never appears. Both fail **open**, and a
+`pipeline-cli` that does not resolve is live here — a bare `pipeline-cli` exits 127 when the shim
+is off `PATH`. That is why `not-control-plane` carries its own exit code **3**, which neither a
+usage error (1), a missing binary (127), nor an unread stdin (4, #3924) produces: an exact
+`[ "$rc" -eq 3 ]` is proof, `[ "$rc" -ne 0 ]` is not. Every wired consumer below uses the
+state-word form above; a new one that does not is not wired correctly.
 
 #### The classification-site register
 

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -287,7 +287,9 @@ with zero path matches, so a path-only test here would classify it non-blocking 
 this verb removes (#4161, formats §CP):
 
 ```bash
-# Four states on stdout; exit 0 on every hold state, 1 ONLY on a proven `not-control-plane`.
+# Four states on stdout. Assert on the STATE WORD, never on the exit status — the exit code
+# discriminates the four states only once the verb has RUN, so `… || ordinary` fail-opens on a
+# usage error (1) or a missing binary (127). The `else` below is the catch-all (formats §CP; #4161).
 CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
   | pipeline-cli cp-classify classify --repo "$REPO")"
 # `content-undetermined` is an OBLIGATION, not an answer: probe each listed ADR at head before
@@ -300,11 +302,18 @@ if [ "$CP_STATE" = "content-undetermined" ]; then
           | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null \
           && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
       done
+elif [ "$CP_STATE" != "not-control-plane" ]; then
+  # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed
+  # invocation yields included. Only a positive `not-control-plane` may skip the hold.
+  echo "BLOCKING (§CP state '$CP_STATE')"
 fi
 ```
 
 - **`not-control-plane`** (an ordinary product-UI PR — the common case for this gate) →
   **non-blocking**: your PASS marker binds `ship-it`.
+- **Any other value** — including the **empty string** a failed invocation leaves in `CP_STATE`
+  (a bad flag, or a `pipeline-cli` that is not on `PATH` and exits 127) — is **blocking**. The test
+  is a positive match on `not-control-plane`, never "the verb exited non-zero".
 - **`control-plane`**, **`unknown`**, or a `content-undetermined` that the ADR probe resolved to
   BLOCKING (the UI PR also touches a `.claude`/`.github` path, a gate-critical skill, or a
   guard-touching ADR; or the classification could not be made) → **blocking** (§CP): you review it

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -280,30 +280,35 @@ UI_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   `review-doc` verdict their classes. `ship-it` requires the latest PASS in **each** namespace
   present before it merges.)
 
-**Then classify blocking vs non-blocking via the canonical §CP set** — the same probe the sibling
-gates run, read **freshly from `origin/main`** (the embedded literal is the fail-closed reference +
-drift-lockstep target, not the live decision source; a stale injected snapshot once mis-flagged a
-now-control-plane PR, #981):
+**Then classify blocking vs non-blocking via the canonical §CP set** — through the shared
+`cp-classify` verb, which re-resolves the boundary **freshly from `origin/main`** (#981) *and*
+covers the second §CP source: a guard-touching `.decisions/**` ADR is §CP **by content** (ADR 0164)
+with zero path matches, so a path-only test here would classify it non-blocking — the fail-open
+this verb removes (#4161, formats §CP):
 
 ```bash
-# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
-# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
-# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
-CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
-CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
-if [ -n "$CP_LIVE" ]; then
-  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"
-else
-  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ treat as blocking (advisory)
+# Four states on stdout; exit 0 on every hold state, 1 ONLY on a proven `not-control-plane`.
+CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | pipeline-cli cp-classify classify --repo "$REPO")"
+# `content-undetermined` is an OBLIGATION, not an answer: probe each listed ADR at head before
+# calling this PR non-blocking (the same ADR-0164 verb ship-it Step 0 and review-code/doc run).
+if [ "$CP_STATE" = "content-undetermined" ]; then
+  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+    | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+        gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
+          | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null \
+          && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+      done
 fi
-CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
 ```
 
-- **Empty** (an ordinary product-UI PR — the common case for this gate) → **non-blocking**: your
-  PASS marker binds `ship-it`.
-- **Non-empty** (the UI PR also touches a `.claude`/`.github` path or a gate-critical skill) →
-  **blocking** (§CP): you review it and post your findings, but **advisory only** — a
+- **`not-control-plane`** (an ordinary product-UI PR — the common case for this gate) →
+  **non-blocking**: your PASS marker binds `ship-it`.
+- **`control-plane`**, **`unknown`**, or a `content-undetermined` that the ADR probe resolved to
+  BLOCKING (the UI PR also touches a `.claude`/`.github` path, a gate-critical skill, or a
+  guard-touching ADR; or the classification could not be made) → **blocking** (§CP): you review it
+  and post your findings, but **advisory only** — a
   `@kamp-us/control-plane` approval at head gates the merge and `ship-it` then enqueues it (ADR 0135
   approve-then-enqueue; ADR 0048 single merge authority). Say so in the verdict (Step 5, advisory path).
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -204,31 +204,33 @@ path as control-plane → advisory not-auto-mergeable) if that read can't be mad
 
 ```bash
 PR=<pr number>
-# the canonical §CP probe — one definition all four gates cite. §CP travels in the INJECTED skill
-# snapshot, which can lag origin/main even when the on-disk file is current — a pre-amendment snapshot
-# once mis-flagged a now-control-plane PR as auto-mergeable (#981).
-# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
-# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
-# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
-CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
-# Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
-# PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
-# freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
-CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
-if [ -n "$CP_LIVE" ]; then
-  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the advisory flag tracks origin/main, not the snapshot's age (AC1/AC2)
-else
-  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
+# The shared §CP classification entry point — one verb all the gates cite (#4161, formats §CP). It
+# re-resolves CONTROL_PLANE_RE from origin/main itself (§CP travels in the INJECTED skill snapshot,
+# which can lag origin/main even when the on-disk file is current — a pre-amendment snapshot once
+# mis-flagged a now-control-plane PR as auto-mergeable, #981) AND covers the second §CP source: a
+# guard-touching `.decisions/**` ADR is §CP BY CONTENT (ADR 0164) with zero path matches, so the old
+# path-only grep here flagged it non-blocking — the fail-open this verb removes.
+# Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
+# Exit 0 on every hold state, 1 ONLY on a proven `not-control-plane` — fail-closed in both idioms.
+CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | pipeline-cli cp-classify classify --repo "$REPO")"
+# `content-undetermined` is an OBLIGATION, not an answer: probe each touched ADR at head with the
+# SAME ADR-0164 verb ship-it Step 0 and review-code/review-doc run. Any BLOCKING line ⇒ §CP.
+if [ "$CP_STATE" = "content-undetermined" ]; then
+  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+    | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+        gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
+          | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null \
+          && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+      done
 fi
-# --paginate streams filenames (the API caps per_page at 100, NOT 300); grep aggregates the §CP
-# matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match
-# is grep exit 1, an empty (non-control-plane) result, not a failure (#725).
-CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
-# non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
+# blocking → advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
 ```
 
-- **Non-empty** (the PR touches a `.claude`/`.github` path or a **gate-critical skill** —
+- **`control-plane`**, **`unknown`** (the classification could not be made — fail closed), or a
+  `content-undetermined` the ADR probe resolved to BLOCKING (a guard-touching ADR, ADR 0164) — as
+  well as the path cases below (the PR touches a `.claude`/`.github` path or a **gate-critical skill** —
   `claude-plugins/kampus-pipeline/skills/ship-it/**`, `claude-plugins/kampus-pipeline/skills/review-code/**`, `claude-plugins/kampus-pipeline/skills/review-doc/**`, `claude-plugins/kampus-pipeline/skills/review-skill/**`,
   `claude-plugins/kampus-pipeline/skills/review-plan/**`, `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`) → the PR is in the **blocking
   set** (§CP). You review it and post your findings, but **advisory only** — your verdict does
@@ -237,9 +239,10 @@ CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page
   in the verdict (Step 5, advisory path). **This is the common case for a skill PR that edits a gate** —
   every gate skill is gate-critical, so a PR to `review-code`/`review-doc`/`review-skill`/
   `ship-it`/`review-plan`/this-formats-file lands here and your verdict is advisory.
-- **Empty** (only non-gate-critical `skills/**` — `triage`, `plan-epic`, `write-code`,
-  `heal-ci`, `report`, … — possibly alongside other non-blocking paths) → **non-blocking**.
-  Your PASS marker binds `ship-it`.
+- **`not-control-plane`** — the one proven-ordinary state (only non-gate-critical `skills/**` —
+  `triage`, `plan-epic`, `write-code`, `heal-ci`, `report`, … — possibly alongside other
+  non-blocking paths, and no `.decisions/**` file left unprobed) → **non-blocking**. Your PASS
+  marker binds `ship-it`.
 
 Your class is `claude-plugins/kampus-pipeline/skills/**` **and** the pipeline agent
 definitions `claude-plugins/kampus-pipeline/agents/**` — agent defs are behavioral artifacts

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -211,7 +211,9 @@ PR=<pr number>
 # guard-touching `.decisions/**` ADR is §CP BY CONTENT (ADR 0164) with zero path matches, so the old
 # path-only grep here flagged it non-blocking — the fail-open this verb removes.
 # Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
-# Exit 0 on every hold state, 1 ONLY on a proven `not-control-plane` — fail-closed in both idioms.
+# Assert on the STATE WORD, never on the exit status — the exit code discriminates the four states
+# only once the verb has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing
+# binary (127). The `else` below is the catch-all that makes that safe (formats §CP; #4161).
 CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
   | pipeline-cli cp-classify classify --repo "$REPO")"
 # `content-undetermined` is an OBLIGATION, not an answer: probe each touched ADR at head with the
@@ -224,6 +226,10 @@ if [ "$CP_STATE" = "content-undetermined" ]; then
           | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null \
           && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
       done
+elif [ "$CP_STATE" != "not-control-plane" ]; then
+  # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed
+  # invocation yields included. Only a positive `not-control-plane` may skip the hold.
+  echo "BLOCKING (§CP state '$CP_STATE')"
 fi
 # blocking → advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
 ```
@@ -239,6 +245,9 @@ fi
   in the verdict (Step 5, advisory path). **This is the common case for a skill PR that edits a gate** —
   every gate skill is gate-critical, so a PR to `review-code`/`review-doc`/`review-skill`/
   `ship-it`/`review-plan`/this-formats-file lands here and your verdict is advisory.
+- **Any other value** — including the **empty string** a failed invocation leaves in `CP_STATE`
+  (a bad flag, or a `pipeline-cli` that is not on `PATH` and exits 127) — is **blocking** too. The
+  test is a positive match on `not-control-plane`, never "the verb exited non-zero".
 - **`not-control-plane`** — the one proven-ordinary state (only non-gate-critical `skills/**` —
   `triage`, `plan-epic`, `write-code`, `heal-ci`, `report`, … — possibly alongside other
   non-blocking paths, and no `.decisions/**` file left unprobed) → **non-blocking**. Your PASS

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -141,8 +141,10 @@ fail-closed fallback (#1559) re-routes it to the full `review-code` / `review-do
 the worst case of a miss is paying the full (correct) cost, never an under-gated merge.
 
 ```bash
-# Fail-closed on EVERY state but the proven-ordinary one — `cp-classify` exits 0 on
-# control-plane / content-undetermined / unknown alike, so this single test cannot fail open.
+# Fail-closed on EVERY value but the proven-ordinary one. The test is a positive match on the
+# STATE WORD, not on the exit status: the exit code discriminates the four states only once the
+# verb has RUN, so a bad flag (exit 1) or a missing binary (exit 127) would fail OPEN through
+# `… || ordinary`. Here they leave CP_STATE empty, which this test routes to the full path (#4161).
 if [ "$CP_STATE" != "not-control-plane" ]; then
   # Resolve the one state that is an obligation rather than a verdict (ADR 0164, #4161).
   if [ "$CP_STATE" = "content-undetermined" ]; then

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -81,10 +81,13 @@ own eyes, the lighter gate is the wrong gate: **FAIL and route to the full path*
 under-gate a non-trivial change (ADR 0120 §3, default-deny). This is the safety hinge — never
 relax it.
 
-Pull the file set and confirm the bound. **Re-resolve the live `CONTROL_PLANE_RE` from
-`origin/main` at run time** — never a stale snapshot (the #981 mis-classification class) — per
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §CP, the single source; cite
-it, don't re-hard-code the list:
+Pull the file set and confirm the bound. **Classify §CP through the shared `cp-classify` verb**,
+which re-resolves the live boundary from `origin/main` at run time — never a stale snapshot (the
+#981 mis-classification class) — *and* covers the second §CP source: a guard-touching
+`.decisions/**` ADR is §CP **by content** (ADR 0164) with zero path matches, and an ADR is a doc by
+path, so a path-only test here would ride it straight onto the lighter gate (#4161). See
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §CP, the single source; cite it,
+don't re-hard-code the list:
 
 ```bash
 PR=<pr number>
@@ -92,23 +95,26 @@ FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].
 NFILES=$(printf '%s\n' "$FILES" | grep -c . || true)
 ADD=$(gh api repos/$REPO/pulls/$PR --jq '.additions'); DEL=$(gh api repos/$REPO/pulls/$PR --jq '.deletions')
 
-# the live control-plane boundary, read from origin/main (raw, ?ref=main) — never the head, never a local snapshot
-CONTROL_PLANE_RE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" \
-  -H 'Accept: application/vnd.github.raw' \
-  | sed -n "s/^CONTROL_PLANE_RE='\(.*\)'$/\1/p" | head -n1)"
-[ -n "$CONTROL_PLANE_RE" ] || { echo "review-trivial: cannot read live CONTROL_PLANE_RE — fail-closed, route to full path"; }   # unreadable boundary ⇒ not trivial
+# Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
+# Only `not-control-plane` is a proven-ordinary answer; every other state is a HOLD.
+CP_STATE="$(printf '%s\n' "$FILES" | pipeline-cli cp-classify classify --repo "$REPO")"
 ```
 
 **Refuse the lighter gate (FAIL → full path) on any of:**
 
-- **A control-plane file is present** — any path matching the live `CONTROL_PLANE_RE`
-  (`.claude/**`, `.github/**`, a gate-critical skill, the enforcement-guard packages). A
-  control-plane diff is **never** trivial; it takes the full path **and the §CP approve-then-enqueue
-  gate** — a `@kamp-us/control-plane` approval at head before `ship-it` enqueues it (ADR 0135; ADR
-  0053 / 0065 / 0100). It must never have routed here.
-- **The boundary could not be read** — an empty/unresolvable `CONTROL_PLANE_RE`. With no
-  boundary you cannot prove the diff is non-control-plane, so you must not treat it as trivial
-  (mirrors the gates' `CONTROL_PLANE_RE='.'` flag-everything posture).
+- **`control-plane`** — a path matched the live boundary (`.claude/**`, `.github/**`, a
+  gate-critical skill, the enforcement-guard packages). A control-plane diff is **never** trivial;
+  it takes the full path **and the §CP approve-then-enqueue gate** — a `@kamp-us/control-plane`
+  approval at head before `ship-it` enqueues it (ADR 0135; ADR 0053 / 0065 / 0100). It must never
+  have routed here.
+- **`content-undetermined` whose ADR probe comes back guard-touching** — a `.decisions/**` ADR
+  that is §CP by content (ADR 0164). Probe each touched ADR at head with the shared
+  `guard-content-probe` verb before you may treat the diff as ordinary; any `guard-touching` ⇒
+  route to the full path.
+- **`unknown`** — the classification could not be made (an unresolvable or uncompilable
+  boundary, an empty file set). With no classification you cannot prove the diff is
+  non-control-plane, so you must not treat it as trivial (mirrors the gates'
+  `CONTROL_PLANE_RE='.'` flag-everything posture). An unreadable answer is **not** a "no".
 - **The diff is not actually small / single-concern** — many files, a large hunk count, or
   visibly more than one logical concern. "Trivial" is a tiny, reviewable change; if it isn't,
   the bound that licenses the lighter checklist is gone.
@@ -135,8 +141,24 @@ fail-closed fallback (#1559) re-routes it to the full `review-code` / `review-do
 the worst case of a miss is paying the full (correct) cost, never an under-gated merge.
 
 ```bash
-if printf '%s\n' "$FILES" | grep -Eq "${CONTROL_PLANE_RE:-.}"; then
-  echo "review-trivial: not-trivial — control-plane file present; route to full path (ADR 0053/0065)"; exit 0
+# Fail-closed on EVERY state but the proven-ordinary one — `cp-classify` exits 0 on
+# control-plane / content-undetermined / unknown alike, so this single test cannot fail open.
+if [ "$CP_STATE" != "not-control-plane" ]; then
+  # Resolve the one state that is an obligation rather than a verdict (ADR 0164, #4161).
+  if [ "$CP_STATE" = "content-undetermined" ]; then
+    HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+    GUARD_TOUCHING="$(printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+        gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
+          | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null && echo "$adr"
+      done)"
+    if [ -z "$GUARD_TOUCHING" ]; then
+      : # every touched ADR probed not-guard-touching ⇒ the content axis is resolved, carry on
+    else
+      echo "review-trivial: not-trivial — guard-touching ADR (§CP by content, ADR 0164): $GUARD_TOUCHING; route to full path"; exit 0
+    fi
+  else
+    echo "review-trivial: not-trivial — §CP state '$CP_STATE'; route to full path (ADR 0053/0065; #4161)"; exit 0
+  fi
 fi
 
 # §DEV: the disclosure section decides triviality too — a disclosed deviation, or a missing heading,
@@ -321,7 +343,7 @@ review-code: PASS @ <HEAD_SHA> — merge-ready
 
 Lighter gate (ADR 0120 §2) — trivial diff verified against #<ISSUE> with the scoped checklist:
 
-- [PASS] Triviality re-affirmed — <N> file(s), +<add>/-<del>, no control-plane (live CONTROL_PLANE_RE from origin/main), no new surface
+- [PASS] Triviality re-affirmed — <N> file(s), +<add>/-<del>, §CP `not-control-plane` (cp-classify: path + ADR-0164 content, live from origin/main), no new surface
 - [PASS] Right one-liner — diff satisfies the AC: <criterion> — <evidence: file:line>
 - [PASS] No leaked secret — added lines scanned, clean
 - [PASS] No leaked local/home/absolute/sibling-repo path — added lines scanned, clean

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -95,6 +95,9 @@ export const registeredTools: ReadonlyArray<ToolRegistration> = [
 	tool("control-plane-paths", () =>
 		import("./tools/control-plane-paths/command.ts").then((m) => m.controlPlanePathsCommand),
 	),
+	tool("cp-classify", () =>
+		import("./tools/cp-classify/command.ts").then((m) => m.cpClassifyCommand),
+	),
 	tool("cp-cardinality", () =>
 		import("./tools/cp-cardinality/command.ts").then((m) => m.cpCardinalityCommand),
 	),

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
@@ -13,6 +13,14 @@
  * `require_code_owner_review` (under-protected; bit on #934/#953). This core reads
  * the §CP set FROM the regex (never a re-hardcoded copy — that's the whole point)
  * and checks every §CP path branch has a covering CODEOWNERS entry.
+ *
+ * **This is the one §CP site that is deliberately PATH-ONLY, and it is not a defect** (#4161).
+ * Everywhere else a bare path answer is non-authoritative — §CP has a second, content-inferred
+ * source (a guard-touching `.decisions/**` ADR, ADR 0164) that `cp-classify` forces callers to
+ * resolve. CODEOWNERS structurally cannot express a content predicate: GitHub matches it on
+ * paths. So the content clause is enforced at the merge-deciding gates instead, which is where a
+ * merge is actually decided. See the classification-site register in `gh-issue-intake-formats.md`
+ * §CP.
  */
 
 /**

--- a/packages/pipeline-cli/src/tools/cp-classify/README.md
+++ b/packages/pipeline-cli/src/tools/cp-classify/README.md
@@ -1,0 +1,83 @@
+# `cp-classify` — the §CP entry point that cannot fail open
+
+`pipeline-cli cp-classify classify` answers "is this change control plane?" over a changed-file
+set **without ever handing back a fail-open "no"**.
+
+## Why it exists
+
+§CP membership has **two independent sources**:
+
+1. the path regex `CONTROL_PLANE_RE` (single-sourced in
+   [`../control-plane-paths/control-plane-re.ts`](../control-plane-paths/control-plane-re.ts), #2761), and
+2. the ADR-0164 **content** probe over touched `.decisions/**` ADRs
+   ([`../guard-content-probe/`](../guard-content-probe/)).
+
+A site that consulted only the path regex read "no path matched" as the authoritative "this is
+ordinary work". That is wrong for the exact shape that matters — a guard-touching ADR is §CP by
+content with **zero** path matches (live instance: PR #4134, both files `.decisions/**`) — and it
+is wrong in the **fail-open** direction: the guard-relaxing change routes as product work and
+escapes the human control-plane approval. `CONTROL_PLANE_RE` has no `.decisions/` clause, so a
+path-only test classifies *every* ADR non-§CP (#4161).
+
+This verb makes the path-only answer **unrepresentable as a verdict**.
+
+## The four states
+
+| stdout word | meaning | exit |
+| --- | --- | --- |
+| `control-plane` | a path matched the live boundary — authoritative §CP | 0 |
+| `content-undetermined` | no path matched, but `.decisions/**` files are present — **an obligation, not a verdict**: probe each with `guard-content-probe` before claiming ordinary | 0 |
+| `not-control-plane` | path clear **and** no `.decisions/**` file, so the content clause has nothing to decide — the one proven-ordinary verdict | 1 |
+| `unknown` | the classification could not be made (unresolvable/uncompilable boundary, empty file set) — treat as §CP and hold | 0 |
+
+`unknown` is deliberately its own state. A read that failed and a change that is genuinely
+non-§CP are **different facts**; collapsing them is the recurring fail-open defect class in this
+repo (#3715, #4108, #4171, #4191).
+
+**The exit code is fail-closed in both bash idioms.** It is 0 on every hold state and 1 only on
+`not-control-plane`, so:
+
+```bash
+… | pipeline-cli cp-classify classify --repo "$REPO" && echo "BLOCKING"    # holds on §CP, undetermined, unknown
+… | pipeline-cli cp-classify classify --repo "$REPO" || echo "ordinary"    # ordinary only on positive proof
+```
+
+Neither shape can silently fail open — which matters, because those are exactly the shapes the
+path-only sites reached for.
+
+## Usage
+
+```bash
+# the canonical PR-file-set classification (paginated + streaming --jq, one path per line)
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | pipeline-cli cp-classify classify --repo "$REPO"
+
+# classify against a boundary you already resolved from origin/main
+pipeline-cli cp-classify classify --files-file changed.txt --control-plane-re "$CONTROL_PLANE_RE"
+```
+
+With no `--control-plane-re`, the boundary is re-resolved from `gh-issue-intake-formats.md` on
+**`origin/main`** (`?ref=main`) — the anti-self-authorization read (#981), so a boundary-editing
+PR is classified against main's boundary, never its own edit. A failed resolution yields
+`unknown`, never a fallback to the in-tree const.
+
+## Resolving `content-undetermined`
+
+Run the existing ADR-0164 probe over each listed ADR at the PR head; nothing about that probe
+changes here, so this verb widens no over-match (#2617):
+
+```bash
+HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' \
+  | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null && echo "BLOCKING ($adr)"
+```
+
+## Shape
+
+Pure core (`cp-classify.ts`) + thin Effect bin (`command.ts`), the repo's mechanical-tooling
+idiom. The core also owns `CP_CONTENT_PREFIX` / `isContentClassifiedPath` — the single definition
+of *which paths the content clause is scoped to* — which `trivial-diff` imports rather than
+re-declaring.
+
+The register of every §CP-classification site and which sources each consults lives in
+`gh-issue-intake-formats.md` §CP.

--- a/packages/pipeline-cli/src/tools/cp-classify/README.md
+++ b/packages/pipeline-cli/src/tools/cp-classify/README.md
@@ -27,23 +27,56 @@ This verb makes the path-only answer **unrepresentable as a verdict**.
 | --- | --- | --- |
 | `control-plane` | a path matched the live boundary — authoritative §CP | 0 |
 | `content-undetermined` | no path matched, but `.decisions/**` files are present — **an obligation, not a verdict**: probe each with `guard-content-probe` before claiming ordinary | 0 |
-| `not-control-plane` | path clear **and** no `.decisions/**` file, so the content clause has nothing to decide — the one proven-ordinary verdict | 1 |
+| `not-control-plane` | path clear **and** no `.decisions/**` file, so the content clause has nothing to decide — the one proven-ordinary verdict | 3 |
 | `unknown` | the classification could not be made (unresolvable/uncompilable boundary, empty file set) — treat as §CP and hold | 0 |
 
 `unknown` is deliberately its own state. A read that failed and a change that is genuinely
 non-§CP are **different facts**; collapsing them is the recurring fail-open defect class in this
 repo (#3715, #4108, #4171, #4191).
 
-**The exit code is fail-closed in both bash idioms.** It is 0 on every hold state and 1 only on
-`not-control-plane`, so:
+## How to call this safely — assert on the state word, never on a bare non-zero
+
+The exit code discriminates the four states **only once the verb has run.** It cannot tell you
+*whether* it ran, and the verb not running is not hypothetical here — a bare `pipeline-cli` exits
+**127** when the shim is off `PATH`. Observed, at this head:
+
+| invocation | exit | stdout |
+| --- | --- | --- |
+| a hold state (`control-plane` / `content-undetermined` / `unknown`) | 0 | the state word |
+| `not-control-plane` | 3 | `not-control-plane` |
+| unread stdin (`STDIN_READ_FAILED_EXIT_CODE`, #3924) | 4 | *(empty)* |
+| a bad flag (effect-cli usage error) | 1 | the help text — **no state word** |
+| a missing binary | 127 | *(empty)* |
+
+**The sanctioned idiom is a positive match on the stdout state word** — what all three rewired
+gates (`review-design`, `review-skill`, `review-trivial`) already do. Only that shape is proof:
 
 ```bash
-… | pipeline-cli cp-classify classify --repo "$REPO" && echo "BLOCKING"    # holds on §CP, undetermined, unknown
-… | pipeline-cli cp-classify classify --repo "$REPO" || echo "ordinary"    # ordinary only on positive proof
+CP_STATE="$(… | pipeline-cli cp-classify classify --repo "$REPO")"
+if [ "$CP_STATE" = "not-control-plane" ]; then
+  : # proven ordinary — the ONLY branch that may skip the §CP hold
+else
+  echo "BLOCKING (§CP state '$CP_STATE')"   # every other value, INCLUDING the empty string a failed invocation yields
+fi
 ```
 
-Neither shape can silently fail open — which matters, because those are exactly the shapes the
-path-only sites reached for.
+**Both naive exit-status shapes are UNSAFE. Do not use them:**
+
+```bash
+… | pipeline-cli cp-classify classify --repo "$REPO" || echo "ordinary"   # UNSAFE — fires on 1 and 127 too
+… | pipeline-cli cp-classify classify --repo "$REPO" && echo "BLOCKING"   # UNSAFE — emits nothing when the verb never ran
+```
+
+`||` treats *every* non-zero as the ordinary verdict, so a bad flag or a missing binary routes a
+§CP change to the ordinary branch; `&&` simply stays silent, so the BLOCKING line the caller was
+relying on never appears. Both fail **open**.
+
+`not-control-plane` therefore carries its own exit code, **3** — one that neither effect-cli's
+usage error (1) nor a missing binary (127) nor an unread stdin (4) produces. An exact
+`[ "$rc" -eq 3 ]` test is positive proof; `[ "$rc" -ne 0 ]` is not. This is the
+`STDIN_READ_FAILED_EXIT_CODE` convention (`../../read-stdin.ts`, #3924) applied to the verdict
+itself: *"the tool never ran"* must never be readable as an answer. Note that a pipe hides the
+verb's status entirely unless `set -o pipefail` is on — capture stdout, as above, and test that.
 
 ## Usage
 

--- a/packages/pipeline-cli/src/tools/cp-classify/command.test.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/command.test.ts
@@ -1,0 +1,130 @@
+import {spawnSync} from "node:child_process";
+import {mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts";
+import {NOT_CONTROL_PLANE_EXIT_CODE} from "./command.ts";
+
+// The exit/stdout contract of `pipeline-cli cp-classify classify`, over the REAL bin. The one
+// property under dispute in review of #4161 was the one with no test: whether a FAILURE TO INVOKE
+// is distinguishable from the `not-control-plane` verdict. It is only distinguishable if the
+// verdict owns an exit code no failure-to-run produces, and only asserted safely on the stdout
+// state word — both pinned here, alongside the four classifier states.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL("../../../../..", import.meta.url));
+const BOUNDARY = "^(\\.github|\\.claude)/";
+
+const DIR = mkdtempSync(join(tmpdir(), "cp-classify-cmd-"));
+
+/** A changed-file list on disk — `--files-file` keeps the probe off stdin and out of a pipe. */
+const fileList = (name: string, paths: ReadonlyArray<string>): string => {
+	const p = join(DIR, name);
+	writeFileSync(p, `${paths.join("\n")}\n`);
+	return p;
+};
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/**
+ * Run a shell fragment and report the status of the LAST command in it. Every probe below is
+ * pipe-free on purpose: `pipefail` is off by default, so a bare pipe reports the tail's status and
+ * would mask the exact invocation failures this suite exists to observe.
+ */
+const runSh = (cmd: string): RunResult => {
+	const r = spawnSync("sh", ["-c", cmd], {cwd: REPO_ROOT, encoding: "utf8"});
+	return {code: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? ""};
+};
+
+const classify = (args: string): RunResult =>
+	runSh(`node "${BIN}" cp-classify classify --control-plane-re '${BOUNDARY}' ${args}`);
+
+describe("cp-classify classify — the exit contract (#4161)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	const STATES: ReadonlyArray<readonly [string, ReadonlyArray<string>, number]> = [
+		["control-plane", [".github/workflows/ci.yml"], 0],
+		["content-undetermined", [".decisions/0217-lane-claim-authority.md"], 0],
+		["unknown", [], 0],
+		["not-control-plane", ["apps/web/src/routes/home.tsx"], NOT_CONTROL_PLANE_EXIT_CODE],
+	];
+
+	for (const [state, paths, code] of STATES) {
+		it(`${state} → stdout '${state}', exit ${code}`, () => {
+			const r = classify(`--files-file "${fileList(`${state}.txt`, paths)}"`);
+			expect(r.stdout.trim()).toBe(state);
+			expect(r.code).toBe(code);
+		});
+	}
+
+	// The whole point of reseating the verdict off exit 1: 1 is effect-cli's usage-error code and
+	// 127 is the shell's missing-binary code, so a verdict seated on either is unreadable as proof.
+	it("the proven-ordinary exit code collides with neither a usage error nor a missing binary", () => {
+		expect(NOT_CONTROL_PLANE_EXIT_CODE).not.toBe(0);
+		expect(NOT_CONTROL_PLANE_EXIT_CODE).not.toBe(1);
+		expect(NOT_CONTROL_PLANE_EXIT_CODE).not.toBe(127);
+	});
+
+	it("a bad flag is an invocation failure: no state word on stdout, and not the verdict code", () => {
+		const r = classify("--bogus-flag x");
+		expect(r.stdout).not.toContain("not-control-plane");
+		expect(r.code).not.toBe(NOT_CONTROL_PLANE_EXIT_CODE);
+		expect(r.code).not.toBe(0);
+	});
+
+	it("a missing binary is an invocation failure: exit 127, empty stdout", () => {
+		const r = runSh("cp-classify-no-such-binary classify");
+		expect(r.code).toBe(127);
+		expect(r.stdout.trim()).toBe("");
+		expect(r.code).not.toBe(NOT_CONTROL_PLANE_EXIT_CODE);
+	});
+});
+
+describe("cp-classify classify — the caller idiom (#4161)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	// The sanctioned shape the register publishes and all three rewired gates use: a POSITIVE match
+	// on the stdout state word. It must hold on a real ordinary verdict and refuse on every
+	// failure-to-invoke — which is exactly what the two naive exit-status shapes get wrong.
+	const stateWordIdiom = (inner: string): RunResult =>
+		runSh(
+			`CP_STATE="$(${inner} 2>/dev/null)"; if [ "$CP_STATE" = "not-control-plane" ]; then echo ordinary; else echo BLOCKING; fi`,
+		);
+
+	const ORDINARY = `node "${BIN}" cp-classify classify --control-plane-re '${BOUNDARY}' --files-file "${fileList("idiom-ordinary.txt", ["apps/web/src/a.tsx"])}"`;
+	const CP = `node "${BIN}" cp-classify classify --control-plane-re '${BOUNDARY}' --files-file "${fileList("idiom-cp.txt", [".claude/settings.json"])}"`;
+	const BAD_FLAG = `${ORDINARY} --bogus-flag x`;
+	const MISSING_BIN = "cp-classify-no-such-binary classify";
+
+	it("proven ordinary → ordinary", () => {
+		expect(stateWordIdiom(ORDINARY).stdout.trim()).toBe("ordinary");
+	});
+
+	for (const [name, inner] of [
+		["control-plane", CP],
+		["a bad flag", BAD_FLAG],
+		["a missing binary", MISSING_BIN],
+	] as const) {
+		it(`${name} → BLOCKING`, () => {
+			expect(stateWordIdiom(inner).stdout.trim()).toBe("BLOCKING");
+		});
+	}
+
+	// Why the register names `… || ordinary` UNSAFE: it reads any non-zero as the verdict, so a
+	// failure to invoke routes to the ordinary branch. Pinned so the doc's claim stays grounded in
+	// observed behavior rather than intuition, and so nobody "simplifies" a call site back onto it.
+	it("the naive `|| ordinary` shape fails OPEN on a failure to invoke", () => {
+		expect(runSh(`${MISSING_BIN} 2>/dev/null || echo ordinary`).stdout.trim()).toBe("ordinary");
+		expect(runSh(`${BAD_FLAG} >/dev/null 2>&1 || echo ordinary`).stdout.trim()).toBe("ordinary");
+	});
+
+	it("the naive `&& echo BLOCKING` shape fails OPEN on a failure to invoke — it emits nothing", () => {
+		expect(runSh(`${MISSING_BIN} 2>/dev/null && echo BLOCKING`).stdout.trim()).toBe("");
+		expect(runSh(`${BAD_FLAG} >/dev/null 2>&1 && echo BLOCKING`).stdout.trim()).toBe("");
+	});
+});

--- a/packages/pipeline-cli/src/tools/cp-classify/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/command.ts
@@ -1,0 +1,143 @@
+/**
+ * The `cp-classify` tool — `pipeline-cli cp-classify classify [flags]` (issue #4161).
+ *
+ *   gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+ *     | pipeline-cli cp-classify classify --repo "$REPO"
+ *   pipeline-cli cp-classify classify --files-file changed.txt --control-plane-re "$CONTROL_PLANE_RE"
+ *
+ * The §CP entry point that **cannot return a fail-open "not control plane"**. Reads a changed-file
+ * list (stdin, one path per line, or `--files-file`), resolves the live `CONTROL_PLANE_RE` from
+ * `origin/main` (never an in-tree snapshot — #981), and prints ONE of four state words to
+ * **stdout**: `control-plane` / `content-undetermined` / `not-control-plane` / `unknown`. The
+ * human reason (and, for `content-undetermined`, the ADRs still owed a content probe) goes to
+ * **stderr**. The predicate itself is the pure core in `cp-classify.ts`.
+ *
+ * **Exit code = the hold decision, and it is fail-closed in both directions:** 0 on every state
+ * EXCEPT `not-control-plane`, which exits 1. So `cp-classify … && echo BLOCKING` holds on §CP, on
+ * an unresolved content axis, and on an unresolvable classification; and `cp-classify … || ordinary`
+ * takes the ordinary branch only on positive proof. Neither naive shape can silently fail open —
+ * which is the whole point, since the path-only sites that motivated this verb reached for exactly
+ * those shapes.
+ *
+ * `content-undetermined` is an OBLIGATION, not a verdict: resolve it by running the existing
+ * `guard-content-probe` verb over each listed `.decisions/**` file at the PR head (ADR 0164). It is
+ * deliberately not a §CP answer, so this verb widens no over-match (#2617).
+ */
+import {execFileSync} from "node:child_process";
+import {Console, Effect, FileSystem, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {readStdinTextOrExit} from "../../read-stdin.ts";
+import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
+import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
+import {type CpClassification, classifyControlPlane, isHold} from "./cp-classify.ts";
+
+const filesFileFlag = Flag.string("files-file").pipe(
+	Flag.optional,
+	Flag.withDescription("read the changed-file list from this file (default: stdin)"),
+);
+
+const controlPlaneReFlag = Flag.string("control-plane-re").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the live CONTROL_PLANE_RE to classify against (default: re-resolve from origin/main)",
+	),
+);
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"owner/repo to resolve the live CONTROL_PLANE_RE from (default: CLAUDE_PIPELINE_REPO / gh repo view)",
+	),
+);
+
+/** Read the file list: `--files-file` over the `FileSystem` seam if given, else stdin. */
+const readFileList = Effect.fn(function* (filesFile: Option.Option<string>) {
+	if (Option.isSome(filesFile)) {
+		const fs = yield* FileSystem.FileSystem;
+		return yield* Effect.orElseSucceed(fs.readFileString(filesFile.value), () => null);
+	}
+	return yield* readStdinTextOrExit();
+});
+
+/** Resolve owner/repo: `--repo`, else `CLAUDE_PIPELINE_REPO`, else `gh repo view`. null on failure. */
+const resolveRepo = (repo: Option.Option<string>): string | null => {
+	const explicit = Option.getOrUndefined(repo) ?? process.env.CLAUDE_PIPELINE_REPO;
+	if (explicit !== undefined && explicit.trim() !== "") return explicit.trim();
+	// biome-ignore lint/plugin: best-effort probe — a failed gh repo view is absorbed into null (unresolved repo ⇒ `unknown`, fail-closed), never the E channel; a total helper, not Effect-cosplay.
+	try {
+		return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
+			encoding: "utf8",
+		}).trim();
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * The live §CP boundary from `origin/main` (`?ref=main`) — the anti-self-authorization read
+ * (#981): a boundary-editing PR is classified against MAIN's boundary, never its own edit. Any
+ * failure returns null, which the core resolves to `unknown` — never to a stale in-tree const.
+ */
+const fetchLiveControlPlaneRe = (repo: string | null): string | null => {
+	if (repo === null) return null;
+	// biome-ignore lint/plugin: best-effort probe — any failure (gh missing/unauth, repo unresolved, file absent) is absorbed into null (⇒ `unknown`, fail-closed), never the E channel; a total helper, not Effect-cosplay.
+	try {
+		const raw = execFileSync(
+			"gh",
+			[
+				"api",
+				`repos/${repo}/contents/${FORMATS_PATH}?ref=main`,
+				"-H",
+				"Accept: application/vnd.github.raw",
+			],
+			{encoding: "utf8"},
+		);
+		return extractControlPlaneRe(raw);
+	} catch {
+		return null;
+	}
+};
+
+/** The stderr reason line — states the verdict, the evidence, and any obligation it leaves open. */
+const reasonLine = (result: CpClassification): string => {
+	switch (result.state) {
+		case "control-plane":
+			return `cp-classify: control-plane [${result.reason}] — ${result.matchedPath} matches the live CONTROL_PLANE_RE. BLOCKING (human merge).\n`;
+		case "content-undetermined":
+			return `cp-classify: content-undetermined [${result.reason}] — no path matched, but ${result.contentSources.length} .decisions/** file(s) can be §CP BY CONTENT (ADR 0164). NOT a non-§CP answer: run \`pipeline-cli guard-content-probe classify\` on each at the PR head before claiming ordinary:\n${result.contentSources.map((p) => `  ${p}\n`).join("")}`;
+		case "not-control-plane":
+			return `cp-classify: not-control-plane [${result.reason}] — no path matched the live CONTROL_PLANE_RE and no .decisions/** file is present, so the ADR-0164 content clause has nothing to decide. Proven ordinary.\n`;
+		case "unknown":
+			return `cp-classify: unknown [${result.reason}] — the classification could NOT be made. This is not "not control plane": treat as §CP and hold (ADR 0092, fail-closed).\n`;
+	}
+};
+
+const classifyCmd = Command.make(
+	"classify",
+	{filesFile: filesFileFlag, controlPlaneRe: controlPlaneReFlag, repo: repoFlag},
+	Effect.fn(function* ({filesFile, controlPlaneRe, repo}) {
+		const boundary = Option.getOrElse(controlPlaneRe, () =>
+			fetchLiveControlPlaneRe(resolveRepo(repo)),
+		);
+		const listText = yield* readFileList(filesFile);
+		// An unreadable --files-file is null: classify an EMPTY set, which the core resolves to
+		// `unknown`. A read that failed and a PR with no files are both un-decidable — neither is
+		// evidence of ordinariness.
+		const result = classifyControlPlane((listText ?? "").split("\n"), boundary);
+
+		yield* Effect.sync(() => process.stderr.write(reasonLine(result)));
+		yield* Console.log(result.state);
+		if (!isHold(result.state)) return yield* Effect.sync(() => process.exit(1));
+	}),
+).pipe(
+	Command.withDescription(
+		"Classify a changed-file set against the §CP boundary, four-state and fail-closed — a path-only answer can never read as non-§CP (#4161)",
+	),
+);
+
+export const cpClassifyCommand = Command.make("cp-classify").pipe(
+	Command.withSubcommands([classifyCmd]),
+	Command.withDescription(
+		"The §CP entry point that cannot return a fail-open 'not control plane' (path + ADR-0164 content axes; #4161)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/cp-classify/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/command.ts
@@ -12,12 +12,12 @@
  * human reason (and, for `content-undetermined`, the ADRs still owed a content probe) goes to
  * **stderr**. The predicate itself is the pure core in `cp-classify.ts`.
  *
- * **Exit code = the hold decision, and it is fail-closed in both directions:** 0 on every state
- * EXCEPT `not-control-plane`, which exits 1. So `cp-classify … && echo BLOCKING` holds on §CP, on
- * an unresolved content axis, and on an unresolvable classification; and `cp-classify … || ordinary`
- * takes the ordinary branch only on positive proof. Neither naive shape can silently fail open —
- * which is the whole point, since the path-only sites that motivated this verb reached for exactly
- * those shapes.
+ * **Exit code:** 0 on every hold state, and {@link NOT_CONTROL_PLANE_EXIT_CODE} (3) — a code no
+ * failure-to-run produces — on the one proven-ordinary verdict. The exit code discriminates the
+ * four states ONLY ONCE THE VERB HAS RUN; it says nothing about whether it ran, so a caller must
+ * assert on the stdout state word (`[ "$CP_STATE" = "not-control-plane" ]`), never on mere
+ * non-zero. `… || ordinary` is UNSAFE: it fires on a usage error (1) and a missing binary (127)
+ * alike. See the README's "How to call this safely" for the observed failure modes.
  *
  * `content-undetermined` is an OBLIGATION, not a verdict: resolve it by running the existing
  * `guard-content-probe` verb over each listed `.decisions/**` file at the PR head (ADR 0164). It is
@@ -30,6 +30,15 @@ import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {type CpClassification, classifyControlPlane, isHold} from "./cp-classify.ts";
+
+/**
+ * The proven-ordinary verdict's own exit code — deliberately NOT 1, which effect-cli already
+ * returns for a usage error (a bad flag), and not 127, which the shell returns for a missing
+ * binary. Same spirit as `STDIN_READ_FAILED_EXIT_CODE` (#3924): a code that means "the tool never
+ * ran" must be separable from a code that means "the tool ran and proved it ordinary" — otherwise
+ * `[ $? -ne 0 ]` reads a failure to invoke as a verdict, the fail-open this verb exists to remove.
+ */
+export const NOT_CONTROL_PLANE_EXIT_CODE = 3;
 
 const filesFileFlag = Flag.string("files-file").pipe(
 	Flag.optional,
@@ -127,7 +136,8 @@ const classifyCmd = Command.make(
 
 		yield* Effect.sync(() => process.stderr.write(reasonLine(result)));
 		yield* Console.log(result.state);
-		if (!isHold(result.state)) return yield* Effect.sync(() => process.exit(1));
+		if (!isHold(result.state))
+			return yield* Effect.sync(() => process.exit(NOT_CONTROL_PLANE_EXIT_CODE));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/cp-classify/cp-classify.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/cp-classify.ts
@@ -126,10 +126,8 @@ export const classifyControlPlane = (
 /**
  * Is this state a HOLD — anything other than the one proven-ordinary verdict?
  *
- * This is the predicate the CLI's exit code mirrors, and it is why BOTH naive bash shapes are
- * fail-closed: `cp-classify … && BLOCKING` holds on §CP, on an unresolved content axis, and on
- * an unresolvable classification, while `cp-classify … || ordinary` takes the ordinary branch
- * only on positive proof. The exit code can never say "ordinary" without that proof; the
- * stdout state word is the refinement a caller reads to avoid over-blocking.
+ * This is the predicate the CLI's exit code mirrors, over the four states the classifier can
+ * reach. It does NOT extend to whether the classifier ran at all — a caller asserts ordinariness
+ * on the stdout state word, never on a bare non-zero exit (see the tool README).
  */
 export const isHold = (state: CpState): boolean => state !== "not-control-plane";

--- a/packages/pipeline-cli/src/tools/cp-classify/cp-classify.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/cp-classify.ts
@@ -1,0 +1,135 @@
+/**
+ * `cp-classify` pure core — the §CP classification that **cannot hand back a fail-open
+ * "not control plane"** (issue #4161).
+ *
+ * §CP membership has TWO independent sources: the path regex `CONTROL_PLANE_RE` and the
+ * ADR-0164 guard-touching-ADR CONTENT probe. A path-only site answers only the first, and its
+ * "no path matched" result was being read as the authoritative "this is ordinary work" —
+ * which is wrong for exactly the shape that matters: a guard-touching `.decisions/**` ADR is
+ * §CP by content with ZERO path matches (live instance: PR #4134, both files `.decisions/**`).
+ * The error direction is fail-open: the guard-relaxing change reads as product work.
+ *
+ * The fix is to make the path-only answer **unrepresentable as a verdict**. This core never
+ * returns a bare boolean; it returns one of four states, and only ONE of them
+ * (`not-control-plane`) means "proven ordinary" — reached only when the path regex cleared
+ * AND no content-classified file is in the set, so there is nothing left for the content probe
+ * to decide. Every other outcome is a HOLD the caller must resolve or refuse:
+ *
+ *   - `control-plane`        — a path matched. Authoritative §CP; no content probe needed.
+ *   - `content-undetermined` — no path matched, but the set contains `.decisions/**` files.
+ *                              NOT a verdict: the caller MUST run `guard-content-probe` on each
+ *                              listed ADR at head before it may claim non-§CP.
+ *   - `not-control-plane`    — proven ordinary (path clear + no content-classified file).
+ *   - `unknown`              — the classification could not be made (unresolvable boundary, or
+ *                              an empty file set). Read-failed and genuinely-non-§CP are
+ *                              DIFFERENT FACTS; collapsing them is the recurring fail-open
+ *                              defect (#3715, #4108, #4171, #4191), so `unknown` is its own
+ *                              state and never degrades to `not-control-plane`.
+ *
+ * Single-sourced, both axes (#2761 / ADR 0164): the boundary regex is passed IN by the caller
+ * (the merge-deciding gates re-resolve it from `origin/main`, #981 — this core never reads a
+ * snapshot), and the content-clause SCOPE lives here once as `CP_CONTENT_PREFIX`, imported by
+ * `trivial-diff` rather than re-declared. No second copy of either.
+ *
+ * The over-match direction is deliberately NOT widened (#2617): `content-undetermined` is an
+ * obligation to probe, not a §CP verdict — resolving it runs the existing ADR-0164 probe
+ * unchanged, so a non-guard-touching ADR still resolves to ordinary.
+ */
+
+/**
+ * The path prefix the ADR-0164 content clause is scoped to. §CP-by-content is defined over
+ * `.decisions/**` ADRs and nothing else, so a file set with no such file has no unresolved
+ * content axis — that is what makes `not-control-plane` provable rather than merely unmatched.
+ */
+export const CP_CONTENT_PREFIX = ".decisions/";
+
+/** True for a file whose §CP membership can be decided by CONTENT (ADR 0164), not just by path. */
+export const isContentClassifiedPath = (path: string): boolean =>
+	path.startsWith(CP_CONTENT_PREFIX);
+
+/**
+ * The four-state §CP answer. Only `not-control-plane` is a proven-ordinary verdict; the other
+ * three are holds. There is deliberately no state that means "path said no, content unchecked,
+ * treat as ordinary" — that state is the defect this type removes.
+ */
+export type CpState = "control-plane" | "content-undetermined" | "not-control-plane" | "unknown";
+
+/** Why the classifier landed where it did — surfaced verbatim on the human reason line. */
+export type CpReason =
+	| "boundary-unresolved"
+	| "boundary-uncompilable"
+	| "empty-file-set"
+	| "path-match"
+	| "content-source-present"
+	| "path-clear-no-content-source";
+
+export interface CpClassification {
+	readonly state: CpState;
+	readonly reason: CpReason;
+	/** The first path that matched `CONTROL_PLANE_RE`, when `state` is `control-plane`. */
+	readonly matchedPath?: string;
+	/**
+	 * The content-classified files the caller must probe, when `state` is `content-undetermined`.
+	 * Empty for every other state.
+	 */
+	readonly contentSources: ReadonlyArray<string>;
+}
+
+/**
+ * Classify a changed-file set against the live §CP path boundary. Pure and total.
+ *
+ * Resolution order — the unresolvable cases come FIRST so a broken input can never fall through
+ * to a proven-ordinary answer:
+ *   1. `controlPlaneRe` null / blank ⇒ `unknown` (`boundary-unresolved`).
+ *   2. `controlPlaneRe` won't compile ⇒ `unknown` (`boundary-uncompilable`) — a broken boundary
+ *      must never silently match nothing (ADR 0092 §ZS).
+ *   3. no files ⇒ `unknown` (`empty-file-set`) — zero scope is not evidence of innocence.
+ *   4. any path matches ⇒ `control-plane`.
+ *   5. any `.decisions/**` file present ⇒ `content-undetermined` — the caller owes a content probe.
+ *   6. otherwise ⇒ `not-control-plane`, the one proven-ordinary verdict.
+ *
+ * Blank entries are dropped before step 3, so a trailing newline in a piped file list does not
+ * masquerade as a changed file.
+ */
+export const classifyControlPlane = (
+	files: ReadonlyArray<string>,
+	controlPlaneRe: string | null | undefined,
+): CpClassification => {
+	if (controlPlaneRe === null || controlPlaneRe === undefined || controlPlaneRe.trim() === "") {
+		return {state: "unknown", reason: "boundary-unresolved", contentSources: []};
+	}
+	let cp: RegExp;
+	try {
+		cp = new RegExp(controlPlaneRe);
+	} catch {
+		return {state: "unknown", reason: "boundary-uncompilable", contentSources: []};
+	}
+
+	const paths = files.map((f) => f.trim()).filter((f) => f !== "");
+	if (paths.length === 0) {
+		return {state: "unknown", reason: "empty-file-set", contentSources: []};
+	}
+
+	const matchedPath = paths.find((p) => cp.test(p));
+	if (matchedPath !== undefined) {
+		return {state: "control-plane", reason: "path-match", matchedPath, contentSources: []};
+	}
+
+	const contentSources = paths.filter(isContentClassifiedPath);
+	if (contentSources.length > 0) {
+		return {state: "content-undetermined", reason: "content-source-present", contentSources};
+	}
+
+	return {state: "not-control-plane", reason: "path-clear-no-content-source", contentSources: []};
+};
+
+/**
+ * Is this state a HOLD — anything other than the one proven-ordinary verdict?
+ *
+ * This is the predicate the CLI's exit code mirrors, and it is why BOTH naive bash shapes are
+ * fail-closed: `cp-classify … && BLOCKING` holds on §CP, on an unresolved content axis, and on
+ * an unresolvable classification, while `cp-classify … || ordinary` takes the ordinary branch
+ * only on positive proof. The exit code can never say "ordinary" without that proof; the
+ * stdout state word is the refinement a caller reads to avoid over-blocking.
+ */
+export const isHold = (state: CpState): boolean => state !== "not-control-plane";

--- a/packages/pipeline-cli/src/tools/cp-classify/cp-classify.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/cp-classify.unit.test.ts
@@ -1,0 +1,118 @@
+import {describe, expect, it} from "vitest";
+import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
+import {
+	CP_CONTENT_PREFIX,
+	classifyControlPlane,
+	isContentClassifiedPath,
+	isHold,
+} from "./cp-classify.ts";
+
+/**
+ * The live boundary as the classifier sees it. These tests pin BEHAVIOUR, not the boundary's
+ * contents — the const is imported, never re-copied (#2761).
+ */
+const RE = CONTROL_PLANE_RE;
+
+describe("classifyControlPlane — the four states", () => {
+	it("classifies a path match as control-plane and names the matching path", () => {
+		const r = classifyControlPlane(["apps/web/src/x.ts", "packages/pipeline-cli/src/bin.ts"], RE);
+		expect(r.state).toBe("control-plane");
+		expect(r.reason).toBe("path-match");
+		expect(r.matchedPath).toBe("packages/pipeline-cli/src/bin.ts");
+	});
+
+	it("classifies an ADR-only set as content-undetermined, NOT as not-control-plane (#4161, PR #4134)", () => {
+		// The live regression: both files are `.decisions/**`, zero path matches. A path-only
+		// classifier called this ordinary work; §CP-by-content (ADR 0164) was invisible to it.
+		const r = classifyControlPlane(
+			[".decisions/0115-agent-distinguishable-claim-marker.md", ".decisions/0215-claim.md"],
+			RE,
+		);
+		expect(r.state).toBe("content-undetermined");
+		expect(r.reason).toBe("content-source-present");
+		expect(r.contentSources).toEqual([
+			".decisions/0115-agent-distinguishable-claim-marker.md",
+			".decisions/0215-claim.md",
+		]);
+	});
+
+	it("classifies a mixed ordinary+ADR set as content-undetermined", () => {
+		const r = classifyControlPlane(["apps/web/src/x.ts", ".decisions/0164-guard.md"], RE);
+		expect(r.state).toBe("content-undetermined");
+		expect(r.contentSources).toEqual([".decisions/0164-guard.md"]);
+	});
+
+	it("classifies a path-clear set with no content source as not-control-plane — the one proven-ordinary verdict", () => {
+		const r = classifyControlPlane(["apps/web/src/x.ts", "README.md"], RE);
+		expect(r.state).toBe("not-control-plane");
+		expect(r.reason).toBe("path-clear-no-content-source");
+		expect(r.contentSources).toEqual([]);
+	});
+
+	it("prefers control-plane over content-undetermined when a path matches too", () => {
+		const r = classifyControlPlane([".decisions/0164-guard.md", ".github/workflows/ci.yml"], RE);
+		expect(r.state).toBe("control-plane");
+	});
+});
+
+describe("classifyControlPlane — unresolvable inputs are `unknown`, never `not-control-plane`", () => {
+	// Read-failed and genuinely-non-§CP are DIFFERENT FACTS; collapsing them is the recurring
+	// fail-open defect (#3715, #4108, #4171, #4191).
+	it("resolves a null boundary to unknown", () => {
+		const r = classifyControlPlane(["apps/web/src/x.ts"], null);
+		expect(r.state).toBe("unknown");
+		expect(r.reason).toBe("boundary-unresolved");
+	});
+
+	it("resolves an undefined boundary to unknown", () => {
+		expect(classifyControlPlane(["apps/web/src/x.ts"], undefined).state).toBe("unknown");
+	});
+
+	it("resolves a blank boundary to unknown", () => {
+		expect(classifyControlPlane(["apps/web/src/x.ts"], "   ").reason).toBe("boundary-unresolved");
+	});
+
+	it("resolves an uncompilable boundary to unknown — a broken boundary must never match nothing", () => {
+		const r = classifyControlPlane(["apps/web/src/x.ts"], "^(unclosed");
+		expect(r.state).toBe("unknown");
+		expect(r.reason).toBe("boundary-uncompilable");
+	});
+
+	it("resolves an empty file set to unknown — zero scope is not evidence of innocence (ADR 0092)", () => {
+		const r = classifyControlPlane([], RE);
+		expect(r.state).toBe("unknown");
+		expect(r.reason).toBe("empty-file-set");
+	});
+
+	it("treats a whitespace-only list (a trailing newline) as an empty set, not as a changed file", () => {
+		expect(classifyControlPlane(["", "  ", ""], RE).reason).toBe("empty-file-set");
+	});
+
+	it("never returns not-control-plane for any unresolvable input", () => {
+		const unresolvable = [
+			classifyControlPlane(["apps/web/src/x.ts"], null),
+			classifyControlPlane(["apps/web/src/x.ts"], ""),
+			classifyControlPlane(["apps/web/src/x.ts"], "^(unclosed"),
+			classifyControlPlane([], RE),
+		];
+		for (const r of unresolvable) expect(r.state).not.toBe("not-control-plane");
+	});
+});
+
+describe("isHold — the exit-code predicate is fail-closed in both directions", () => {
+	it("holds on every state except the proven-ordinary one", () => {
+		expect(isHold("control-plane")).toBe(true);
+		expect(isHold("content-undetermined")).toBe(true);
+		expect(isHold("unknown")).toBe(true);
+		expect(isHold("not-control-plane")).toBe(false);
+	});
+});
+
+describe("the content-clause scope is single-sourced", () => {
+	it("scopes §CP-by-content to .decisions/** and nothing else (ADR 0164)", () => {
+		expect(CP_CONTENT_PREFIX).toBe(".decisions/");
+		expect(isContentClassifiedPath(".decisions/0164-guard.md")).toBe(true);
+		expect(isContentClassifiedPath(".patterns/index.md")).toBe(false);
+		expect(isContentClassifiedPath("docs/.decisions/x.md")).toBe(false);
+	});
+});

--- a/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.ts
@@ -41,6 +41,7 @@ export interface ChangedFile {
 	readonly addedLines: ReadonlyArray<string>;
 }
 
+import {isContentClassifiedPath} from "../cp-classify/cp-classify.ts";
 import {probeGuardContent} from "../guard-content-probe/guard-content-probe.ts";
 
 /** The terminal verdict — two states only, never an "unknown" a caller could read as trivial. */
@@ -106,9 +107,6 @@ const isSurfacePath = (path: string): boolean => {
 	if (path.endsWith(".sql")) return true;
 	return /(^|\/)(migrations|drizzle)\//.test(path);
 };
-
-/** True for a `.decisions/**` ADR — the class the guard-touching content bound (ADR 0164) scopes to. */
-const isAdrPath = (path: string): boolean => path.startsWith(".decisions/");
 
 /** True for a doc/comment-only file: a doc extension or a path under a docs dir. */
 const isDocPath = (path: string): boolean => {
@@ -235,7 +233,7 @@ export const classify = (diff: string, opts: ClassifyOptions): Classification =>
 	// its added content with the SAME shared verb ship-it Step 0 / the review gate call; fail-closed
 	// (null boundary ⇒ match-everything, empty added lines ⇒ guard-touching). Order is deliberate:
 	// this runs BEFORE the isDocPath trivial return, so a guard-relaxing ADR can't be masked as a doc.
-	if (isAdrPath(f.path)) {
+	if (isContentClassifiedPath(f.path)) {
 		const probe = probeGuardContent(f.addedLines.join("\n"), opts.guardAdrRe ?? ".");
 		if (probe.guardTouching) {
 			return nonTrivial(


### PR DESCRIPTION
Fixes #4161

## The defect

§CP membership has **two independent sources** — the path regex `CONTROL_PLANE_RE` and the ADR-0164 guard-touching-ADR **content** probe — and `CONTROL_PLANE_RE` has **no `.decisions/` clause**. Re-verified against `origin/main` this run (`git show origin/main:packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts`): the clauses are `.claude`/`.github`, `.claude-plugin/`, the named gate skills, `skills/**/*.sh`, `kampus-pipeline/agents/`, `gh-issue-intake-formats.md`, `kampus-pipeline/hooks`, `packages/ci-required/`, `packages/pipeline-cli/`, `biome.jsonc`, `biome-plugins/`. No ADR path is among them.

So a path-only test classifies **every** ADR non-§CP, and a guard-touching ADR is §CP with **zero path matches** (live: PR #4134, both files `.decisions/**`). The error is **silent and fail-open** — the guard-relaxing change reads as ordinary product work and escapes the human control-plane approval rather than erroring.

## The fix — `pipeline-cli cp-classify classify`

A new §CP entry point that **cannot hand back a fail-open "no"**. Four states on stdout:

| stdout | meaning | exit |
| --- | --- | --- |
| `control-plane` | a path matched — authoritative §CP | 0 |
| `content-undetermined` | no path matched, but `.decisions/**` files are present — **an obligation, not a verdict**: probe each with `guard-content-probe` at head before claiming ordinary | 0 |
| `not-control-plane` | path clear **and** no `.decisions/**` file, so the content clause has nothing left to decide — the one proven-ordinary verdict | 1 |
| `unknown` | unresolvable / uncompilable boundary, or an empty file set — treat as §CP and hold | 0 |

`unknown` is its own state on purpose: a read that **failed** and a change that is **genuinely non-§CP** are different facts, and collapsing them is the recurring fail-open defect class here (#3715, #4108, #4171, #4191). It never degrades to `not-control-plane`.

**The exit code is fail-closed in both bash idioms.** 0 on every hold state, 1 only on proven ordinary — so `… && echo BLOCKING` holds on §CP, undetermined, *and* unknown, while `… || ordinary` reaches the ordinary branch only on positive proof. Those are exactly the two shapes the path-only sites reached for.

Observed runs (this branch, against the live `origin/main` boundary):

```
$ printf '.decisions/0115-a.md\n.decisions/0215-b.md\n' | pipeline-cli cp-classify classify --repo kamp-us/phoenix
content-undetermined   (exit 0)   # the PR #4134 shape — a path-only test called this ordinary
$ printf 'apps/web/src/x.ts\n' | pipeline-cli cp-classify classify --repo kamp-us/phoenix
not-control-plane      (exit 3)
$ printf 'apps/web/src/x.ts\n' | pipeline-cli cp-classify classify --repo kamp-us/nonexistent
unknown                (exit 0)   # boundary-unresolved — NOT "not control plane"
```

## Acceptance criteria

- **A path-only answer can no longer read as an authoritative "not control plane"** — the make-invalid-states-unrepresentable form (option (b) in the issue): the entry point returns an explicit `content-undetermined` a caller must resolve, and `not-control-plane` is reachable only when the content axis is provably empty.
- **The sites are enumerated and recorded** — a classification-site register in `gh-issue-intake-formats.md` §CP. The three path-only sites (`review-design`, `review-skill`, `review-trivial`) are **rewired** onto the verb, each resolving `content-undetermined` through the existing shared `guard-content-probe`. `ship-it` / `review-code` / `review-doc` / `trivial-diff` already consult both and are recorded as such.
- **`.github/CODEOWNERS` generation stays path-only and is explicitly excepted** — recorded in the register and at `codeowners-cp`'s own docblock: GitHub matches CODEOWNERS on paths and structurally cannot consult content, so the content clause is enforced at the merge-deciding gates instead.
- **The boundary stays single-sourced** — no second copy of `CONTROL_PLANE_RE` (#2761) or of `GUARD_ADR_RE`; the merge-deciding gates keep re-resolving from `origin/main` (#981), and `cp-classify` does the same rather than importing the in-tree const. The content clause's **scope** (`.decisions/**`) now lives once in `cp-classify`'s core, which `trivial-diff` imports instead of re-declaring its local `isAdrPath`.
- **The over-match direction is not widened** (#2617) — `content-undetermined` is an obligation to run the **existing, unchanged** ADR-0164 probe, not a §CP verdict; a non-guard-touching ADR still resolves ordinary.
- **Coordinated with #3416** — the driver (EM) leg is *not* built here. It classifies §CP nowhere on `origin/main` today, so it is recorded in the register as owned by #3416, to be wired once.

## Deviations

- **No new ADR.** The rule ("a path-only §CP answer is never authoritative") is recorded in `gh-issue-intake-formats.md` §CP, which is already the canonical single source for both `CONTROL_PLANE_RE` and `GUARD_ADR_RE` and already carries the ADR-0164 content-clause prose inline. Adding a parallel ADR would put the same *why* in two places. Flagging it: if the reviewer wants this as a ratified ADR rather than §CP prose, say so and it can follow.
- **`review-code` / `review-doc` / `ship-it` were left on their existing bash.** They already consult both sources correctly; migrating the merge-deciding gates' Step 0/Step 2 bash onto the new verb is a behaviour-neutral refactor with real blast radius, and this PR's job is closing the fail-open, not rewriting the gates that never had it. They are recorded in the register as compliant.
- **The driver leg is deliberately unbuilt** (see above) — per the issue's own "wired once, not twice" criterion.
- **`content-undetermined` is resolved by the caller, not by `cp-classify`.** Resolving it needs each ADR's body at the PR head, which is REST IO; the repo idiom keeps that in the caller (`trivial-diff`, `guard-content-probe` and `class-probe` all draw the same line). The verb names the exact files owed a probe so the obligation is mechanical, not a judgement call.
- **`trivial-diff`'s local `isAdrPath` was deleted**, not left alongside the shared predicate — a second copy of the content clause's scope is exactly the drift this issue's single-sourcing criterion forbids.

### Repair round 1 — the published exit-code guarantee was false (gate FAIL @ 016ed47f)

Both gates (`review-code` 5082244279, `review-skill` 5082245830) FAIL'd on one blocking finding: the **call sites were safe, the documentation was not.** All three rewired gates assert on the stdout state word, so no wired site was ever fail-open — but this PR published the opposite advice as a guarantee in three places (the canonical §CP register, the `command.ts` docblock, the tool README), and the README **recommended the unsafe `|| echo "ordinary"` idiom verbatim**. Re-verified by running the failure modes rather than reasoning about them: with the verb absent, `… || ordinary` takes the ordinary branch and `… && BLOCKING` emits nothing — both fail **open**. That claim sat in exactly the doc AC1 exists to protect.

- **Chose remedy (a) *and* (b), not either/or.** The gate offered "make the exit-code guarantee real" or "drop it and document the state-string assertion". (a) alone is unachievable for the `||` shape — `||` fires on *every* non-zero, so no seating of the verdict code can make that idiom safe. So the docs now name the **state-word assertion** as the sanctioned idiom and both naive exit-status shapes as **UNSAFE**, *and* `not-control-plane` is reseated off exit 1 (effect-cli's usage-error code) onto a dedicated **3**. Exit 1 now means unambiguously "did not run"; an exact `[ "$rc" -eq 3 ]` is positive proof where `[ "$rc" -ne 0 ]` never was. This is the `STDIN_READ_FAILED_EXIT_CODE = 4` convention (#3924) applied to the verdict itself.
- **The exit contract is now tested** — new `command.test.ts` (absent before, unlike sibling tools) pins all four states, a usage error, a missing binary, the sanctioned idiom on each, and both naive shapes failing open. The one property under dispute was the one with no test.
- **`review-design` / `review-skill` adopted `review-trivial`'s explicit catch-all**, so an unenumerated `CP_STATE` — including the empty string a failed invocation yields — is uniformly blocking across all three (the gate's non-blocking nit).
- **Divergence from `guard-content-probe`, flagged.** That sibling verb seats its own proven-ordinary verdict (`not-guard-touching`) on exit 1 and so carries the same latent collision. Fixing it is out of scope here — a separate verb with its own consumers — but the inconsistency is deliberate and disclosed, not an oversight.
- Nothing the gate verified correct was touched: the four-state model, the unresolvable-first ordering, `unknown` never degrading, the minimal `content-undetermined`, PR #4179 still holding as `content-undetermined` with zero path matches, the completed register, the behavior-preserving `isAdrPath` deletion, and the three deviations above.

**Repair verification:** `vitest run` in `packages/pipeline-cli` — **168 files, 2530 tests, all green** (+2 files, +57 tests); `pnpm typecheck` green; `pnpm lint:worktree` clean; `validate-gate-path-drift.sh` **OK, 17 checks**; `pipeline-cli commands check` — 70 registered tools, all documented; pre-commit hooks (biome, leak-guard, primary-index-guard) green, no `--no-verify`. Rebased onto latest `origin/main` first — clean, no conflict.

## §CP classification of this PR

`pipeline-cli cp-classify classify` on this PR's own file set returns **`control-plane`** (`path-match`: `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, plus `packages/pipeline-cli/**` and three gate skills). `guard-content-probe` has nothing to classify — this PR touches no `.decisions/**` file. `class-probe classify --namespaces` → `has-code, has-skills` ⇒ `review-code` + `review-skill`.

**This PR is §CP and stops at PR-open**: it needs a current-head `@kamp-us/control-plane` approval before `ship-it` may enqueue (ADR 0135 approve-then-enqueue). Verdicts are an independent gate's.

## Verification

- `vitest run` in `packages/pipeline-cli` — **166 files, 2473 tests, all green**, including 17 new `cp-classify` unit tests (the four states, every unresolvable input, the `never returns not-control-plane` invariant, the exit-code hold predicate, the single-sourced content scope).
- `validate-gate-path-drift.sh` — **OK, 17 checks**; `CONTROL_PLANE_RE` copies and the marketplace symlink still agree.
- `pipeline-cli commands check` — 69 registered tools, all documented.
- `pnpm typecheck` green; `biome check` clean; pre-push (typecheck + unit-changed) green with no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #4208 — the exit-1 collision between a proven not-§CP verdict and a failed invocation is discharged at this head: `not-control-plane` is reseated onto exit 3, so exit 1 now means unambiguously "did not run".
