### PR TITLE
fix(skills): read PR timelines completely — a queued PR no longer reports as never enqueued (#4193)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/release/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/release/SKILL.md
@@ -135,7 +135,9 @@ for ISSUE in $(gh api "repos/$REPO/issues?state=all&labels=status:awaiting-relea
     --jq '.[] | select(.pull_request | not) | .number'); do
   # find the PR(s) that closed this issue and check each body for a `Flag: <key>` line naming THIS key
   # (the grammar write-code Step 5 writes and ship-it Step 5b reads)
-  for PR in $(gh api "repos/$REPO/issues/$ISSUE/timeline?per_page=100" \
+  # --paginate + a STREAMING --jq: per_page caps at 100, so the closing PR of an issue with a
+  # long timeline would otherwise fall off the read and drop the flag from the release queue (#4193)
+  for PR in $(gh api --paginate "repos/$REPO/issues/$ISSUE/timeline?per_page=100" \
       --jq '.[] | select(.event=="cross-referenced" or .event=="closed")
                 | .source.issue.number? // empty' 2>/dev/null | sort -u); do
     body=$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""' 2>/dev/null)

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -104,7 +104,9 @@ timeline if it's not obvious:
 
 ```bash
 # timeline shows "connected"/"cross-referenced" events linking PR ↔ issue
-gh api "repos/$REPO/issues/$PR/timeline?per_page=100" \
+# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
+# invisible without it on a long-lived PR's timeline (#4193)
+gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
   --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -325,7 +325,9 @@ cross-check via the timeline if it's not obvious — for context on *what* the U
 surfaces it targets:
 
 ```bash
-gh api "repos/$REPO/issues/$PR/timeline?per_page=100" \
+# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
+# invisible without it on a long-lived PR's timeline (#4193)
+gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
   --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -289,7 +289,9 @@ Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `wri
 writes). Cross-check via the timeline if it's not obvious:
 
 ```bash
-gh api "repos/$REPO/issues/$PR/timeline?per_page=100" \
+# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
+# invisible without it on a long-lived PR's timeline (#4193)
+gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
   --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -287,7 +287,9 @@ Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `wri
 writes). Cross-check via the timeline if it's not obvious:
 
 ```bash
-gh api "repos/$REPO/issues/$PR/timeline?per_page=100" \
+# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
+# invisible without it on a long-lived PR's timeline (#4193)
+gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
   --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1990,23 +1990,52 @@ The final merge is **async** (queue-owned), so the terminal state to verify is *
 not `merged=true` in this run. Under the merge queue a *successful* enqueue leaves `auto_merge`
 **`null`** — the queue, not an auto-merge request, owns the async merge — so the success signal
 is the **`already queued to merge`** message the enqueue prints and/or the PR's `QUEUED` state
-(read from `mergeStateStatus` + the `added_to_merge_queue` REST timeline event — **not** the
-`mergeQueueEntry` `--json` field, which gh 2.62.0 rejects, #1930). See ADR 0132 addendum §3.
+(resolved through `pipeline-cli merge-queue-classify` — **not** the `mergeQueueEntry` `--json`
+field, which gh 2.62.0 rejects, #1930). See ADR 0132 addendum §3.
 
 ```bash
 # The QUEUED signal is the success condition. `already queued to merge` from Step 4's --auto
 # and/or an `enqueued`/QUEUED mergeStateStatus confirm it — NOT a non-null auto_merge, which
 # under the queue stays null on a clean enqueue (ADR 0132 §3).
 gh api repos/$REPO/pulls/$PR --jq '{merged, auto_merge, mergeable_state}'
-# Derive QUEUED from `mergeStateStatus` PLUS the authoritative REST issue-timeline event
-# (`added_to_merge_queue`) — NOT the `mergeQueueEntry` --json field, which the pinned gh
-# 2.62.0 rejects, forcing an every-ship gh-api fallback (#1930). The last merge-queue timeline
-# event is the same gh-2.62.0-safe source Step 5.5's reconcile already reads; both steps use one
-# REST-timeline path for the QUEUED confirmation.
 gh pr view $PR --json mergeStateStatus --jq '{mergeStateStatus}'
-gh api "repos/$REPO/issues/$PR/timeline" \
-  --jq 'map(select(.event=="added_to_merge_queue" or .event=="removed_from_merge_queue")) | last | .event // "no-merge-queue-event"'
+# Confirm queue membership through the SAME verb Step 5.5's reconcile polls — never a second,
+# hand-rolled timeline read here (#4193). Prints exactly one of merged/queued/pending/ejected.
+QUEUE_STATE=$(pipeline-cli merge-queue-classify classify --pr "$PR" --repo "$REPO")
 ```
+
+**Why the verb and not a `gh api …/timeline` one-liner here.** This confirmation used to
+hand-roll its own timeline read, and that second copy diverged from the tool it duplicated in
+two ways, each of which misreports a healthy enqueue (#4193):
+
+- It read the timeline **un-paginated**, so it only ever saw the first 30 events. On PR #3955 —
+  a 122-event timeline whose `added_to_merge_queue` sits past event 30 — it printed
+  `no-merge-queue-event` while the PR was queued the whole time, and a shipper burned a run
+  chasing an enqueue failure that never happened. The verb reads `?per_page=100` **with**
+  `--paginate`. If you ever do need a raw timeline read, obey the contract's pagination rule
+  ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), the `CONTROL_PLANE_RE`
+  probe): `--paginate` composes only with a **streaming** `--jq` (`.[] | select(…)`), never an
+  aggregate one (`map(…) | last`, `length`, `add`) — gh runs the filter **per page** and emits
+  one result each, so an aggregate filter answers for page 1, then again for page 2, and a
+  caller capturing it in `$( … )` gets a multi-line value it will compare as a single word.
+- It printed the **last** merge-queue event raw, and `removed_from_merge_queue` is **not** an
+  ejection signal on its own — the queue also emits it on a *successful* merge, at a timestamp
+  matching `merged_at`. The verb ranks `merged` above that event, so a landed merge never reads
+  as a dequeue.
+
+Branch on `QUEUE_STATE`; **every** outcome has a defined response, so no value is a dead end:
+
+- **`queued`** — confirmed in the queue. Step 5's success shape; report `enqueued: yes`.
+- **`merged`** — the queue landed the batch inside this run. Terminal success.
+- **`pending`** — no merge-queue event yet. This is the enqueue-**settle** window, **not** proof
+  the enqueue failed, and never an ejection. Do **not** re-run Step 4 or re-arm auto-merge off a
+  single `pending` — a re-drive is the wrong action on a PR that may already be queued. Fall
+  through to Step 5.5, whose bounded reconcile polls this same verb; on a queue-governed base
+  branch (every PR in this repo) a PR still `pending` at the budget's end is the **parked-intent**
+  case guard 6 already owns — it clears the intent and the run reports `refused — the enqueue did
+  not take effect at this head`. That is the sanctioned way a genuinely absent enqueue is acted
+  on, and it is reached by waiting out the window, never by re-enqueuing here.
+- **`ejected`** — the queue dropped the PR. Step 5.5's `ejected` branch owns the response.
 
 A clean `--auto` under the queue leaves `auto_merge` **`null`** and reports `already queued to
 merge`; that `null` is the **expected** post-enqueue shape, **not** a failure — do not read it
@@ -2049,8 +2078,12 @@ async model (the actor does **not** block synchronously on the final merge), it 
 **bounded batch window** to classify the terminal state before it reports.
 
 Classify each poll off the **authoritative** merge-queue signal — GitHub's REST issue-timeline
-events (`added_to_merge_queue` on enqueue, `removed_from_merge_queue` on a genuine ejection;
-GitHub "Managing a merge queue") — **not** a momentary `mergeStateStatus`. The old discriminator
+events (`added_to_merge_queue` on enqueue, `removed_from_merge_queue` on a dequeue; GitHub
+"Managing a merge queue") — **not** a momentary `mergeStateStatus`. A trailing
+`removed_from_merge_queue` is an ejection **only when the PR is not merged**: the queue emits
+the same event on a *successful* merge, at a timestamp matching `merged_at`, so it must always
+be paired with `merged`/`merged_at` before concluding (the classifier does this by ranking
+`merged` above it — #4193). The old discriminator
 inferred `ejected` from `OPEN + mergeStateStatus != QUEUED`, but a freshly-enqueued PR reads
 `mergeStateStatus = CLEAN` for a few seconds *before* GitHub flips it CLEAN → QUEUED, so a
 genuinely-queued PR false-classified as `ejected` on the first poll (the #1906 live instance: an

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1546,7 +1546,10 @@ itself**: read the PR body back and assert it matches a recognized closing keywo
 
 ```bash
 # (a) the cross-reference landed (a closing OR non-closing mention both show here — necessary, not sufficient)
-gh api repos/$REPO/issues/<N>/timeline \
+#     --paginate + a STREAMING --jq, per the contract's pagination rule: the timeline endpoint
+#     defaults to 30 events/page, so an un-paginated read calls a cross-reference past event 30
+#     absent — a false alarm on any issue with a bit of history (#4193).
+gh api --paginate "repos/$REPO/issues/<N>/timeline?per_page=100" \
   --jq '.[] | select(.event == "cross-referenced") | .event'
 # (b) the SUFFICIENT check, REST-only: the seam is armed iff the body carries EITHER a real
 #     CLOSING keyword for #N (full-close PR — the same set ship-it Step 1 resolves:


### PR DESCRIPTION
`ship-it` Step 5's merge-queue confirmation read the PR timeline without pagination, so on any PR with more than 30 timeline events it reported `no-merge-queue-event` — a false "never enqueued" on a PR that was queued the whole time. This replaces that hand-rolled read with the `pipeline-cli merge-queue-classify` verb the very next step already polls, gives Step 5 a defined response for every outcome (including a genuinely absent event), and paginates the six sibling timeline reads across the other skills.

Fixes #4193

## What changed

**`ship-it` Step 5 — delegate, don't re-fix the copy.** The acceptance criteria offered two shapes; I took the preferred one. The truncating read is gone, and Step 5 now calls the same verb Step 5.5's reconcile polls:

```bash
QUEUE_STATE=$(pipeline-cli merge-queue-classify classify --pr "$PR" --repo "$REPO")
```

Delegation rather than a patched one-liner, for three reasons:

1. The duplication *is* the defect. Two hand-rolled copies of one read is how they diverged; patching the copy leaves the divergence surface intact for the next edit.
2. The verb is already correct on **both** failure modes, not just the pagination one — see the second bullet below.
3. It costs Step 5 nothing: the classifier's four outcomes are a strict superset of what the raw event name told the shipper.

Step 5 now branches on all four outcomes, so no value is a dead end. That closes the acceptance criterion about a genuinely absent event: `pending` means the enqueue-settle window, **not** a failed enqueue, and the sanctioned response is to fall through to Step 5.5's bounded reconcile — where, on a queue-governed base branch, a still-`pending` PR at the budget's end is the parked-intent case guard 6 already handles (`refused — the enqueue did not take effect at this head`). A re-enqueue from Step 5 is explicitly ruled out, since that was the wrong action the false negative invited.

**The `removed_from_merge_queue` correctness rule, recorded.** A trailing `removed_from_merge_queue` is **not** an ejection signal on its own — the queue emits it on a *successful* merge too, at a timestamp matching `merged_at`. The old Step-5 read printed the last merge-queue event raw, so a landed merge could read as a dequeue. This is a two-line clarification rather than a separate defect: `merge-queue-classify` already ranks `merged` above the removal event (`classify`'s precedence 1 before 2), and Step 5.5's prose already routes through that verb — so the only place the rule was actually violated was Step 5's raw print, which this PR deletes. Step 5.5's signal description now states the pairing requirement explicitly so a future reader can't re-derive the wrong rule from it. No separate issue filed; scoped as a clarification, per the acceptance criteria's "swept in the same pass."

**The six sibling reads, all swept — none deferred.**

| skill | before | after |
|---|---|---|
| `write-code` (`cross-referenced` check) | no `per_page`, no `--paginate` — 30-event ceiling | `?per_page=100` + `--paginate` |
| `review-code`, `review-doc`, `review-skill`, `review-design` (linked-issue cross-check) | `?per_page=100`, no `--paginate` — 100-event ceiling | `--paginate` added |
| `release` (closing-PR lookup for the flag key) | `?per_page=100`, no `--paginate` | `--paginate` added |

**No `pipeline-cli` change.** `merge-queue-classify` and `merge-intent` were already correct — they build `timeline?per_page=100` with `--paginate` and normalize the `][` page joins. They are the shape everything else now mirrors, and neither was touched.

## The pagination hazard I had to avoid, and how

The obvious fix — bolt `--paginate` onto the existing `--jq` — would have swapped one silent truncation for another, so this is worth stating explicitly.

`gh api --paginate` runs the `--jq` filter **per page** and emits one result per page. Measured on PR #3955:

```
$ gh api "repos/kamp-us/phoenix/issues/3955/timeline?per_page=100" --paginate \
    --jq 'map(select(.event=="added_to_merge_queue" or .event=="removed_from_merge_queue")) | last | .event // "no-merge-queue-event"'
no-merge-queue-event
removed_from_merge_queue
```

Two lines — the aggregate filter answered once for page 1 and once for page 2. A caller doing `LAST=$(…)` and comparing it to a single word gets a wrong answer with no error. So an **aggregate** `--jq` (`map(…) | last`, `length`, `add`) never composes with `--paginate`; only a **streaming** one does (`.[] | select(…)`, one line per element, pages concatenate). This is already the shared contract's rule at the `CONTROL_PLANE_RE` probe in `gh-issue-intake-formats.md`; Step 5's new prose cites it rather than restating the why.

That is exactly why the six swept reads only needed `--paginate` added: every one of them already used an element-level filter. And it is why Step 5 got the verb instead of a patched filter — the verb takes the timeline **raw** (no `--jq` at all) and normalizes the `][` joins in code, which is the only shape that survives multi-page output for an aggregate question like "what is the *last* merge-queue event."

## Verification against PR #3955

The reproduction and the correction, both re-run live on this branch (#3955 has since merged, which makes it a good test of the second rule too):

```
# the read as the skill used to specify it — the defect
$ gh api "repos/kamp-us/phoenix/issues/3955/timeline" --jq 'map(select(…)) | last | .event // "no-merge-queue-event"'
no-merge-queue-event

# the paginated streaming read — the events are there, both past item 30
$ gh api "repos/kamp-us/phoenix/issues/3955/timeline?per_page=100" --paginate \
    --jq '.[] | select(.event=="added_to_merge_queue" or .event=="removed_from_merge_queue") | "\(.event) \(.created_at)"'
added_to_merge_queue      2026-07-26T02:03:47Z
removed_from_merge_queue  2026-07-26T02:09:20Z

# total events on that timeline
$ gh api "…/timeline?per_page=100" --paginate --jq '.[].event' | wc -l
122

# what Step 5 now runs
$ pipeline-cli merge-queue-classify classify --pr 3955 --repo kamp-us/phoenix
merge-queue-classify: merged==true or state==MERGED — the queue landed the batch (terminal success)
merged
```

Note the last two blocks together: the raw timeline's final merge-queue event on #3955 is `removed_from_merge_queue`, and #3955 **merged**. The old Step-5 read would have printed that removal event with nothing telling the shipper it was a merge, not an ejection. The verb prints `merged`. That is the second correctness rule, demonstrated on the same PR as the first.

## §CP

Every file here is under `claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|release|write-code)/`, which the control-plane path set matches. This PR takes the control-plane approval route (ADR 0135) and does **not** auto-ship on green.

## Scope

Docs/skill prose only — seven `SKILL.md` files, no code. No pipeline-cli source touched.
