### PR TITLE
fix(pipeline): trace WorktreeCreate invocation, and stop claiming a stamp nothing writes (#4180)

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -264,6 +264,15 @@ per running session).
 could not execute leaks an orphan rather than destroying a live tree. A sweep that removes nothing
 and reports `registry UNRESOLVED` is the gate working, not a no-op.
 
+**The stamp has no live producer right now ([#4180](https://github.com/kamp-us/phoenix/issues/4180)).**
+The paragraph above describes the code contract, not the runtime: the harness provisions agent
+worktrees on its own internal path — every registered tree sits on a harness-made
+`worktree-<name>` branch, which `create-worktree.sh`'s `git worktree add --detach` never produces —
+so the `WorktreeCreate` hook does not run and no tree is stamped (272 registered, 0 stamped). Read
+"the sweep resolves the owner from the stamp" as what the code *would* do; in the field it resolves
+`owner-unknown` every time and KEEPs. Safe direction, but the sweep is effectively lock-only today,
+so `0 reapable` is partly an absence of evidence.
+
 **Expect near-silence, and not only from legacy trees.** The stamp carries the **launcher's**
 session id, and a crew pane is long-lived — so every tree that pane provisioned reads `alive` for the
 pane's entire lifetime, not just for as long as the subagent that used it ran. Combined with the

--- a/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
+++ b/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
@@ -31,6 +31,14 @@
 # hook carries — the #3621 fresh-base fetch, the ADR 0178 600s install budget, the #3943
 # owner stamp — is currently inert on that path. The trace below is what makes that
 # falsifiable instead of inferred.
+#
+# The harness's own provisioning is NOT an equivalent substitute for the two inert fixes:
+#   * freshness (#3621) — the harness does fetch, but THROTTLED on `FETCH_HEAD` mtime and
+#     falling back to the local `HEAD` with only a warning when the fetch fails. This hook
+#     fails closed instead, so #3621's guarantee is strictly WEAKER in practice, not equal.
+#   * the 600s budget (ADR 0178) — that is a hook-config `timeout`; it governs this hook's
+#     invocation and nothing at all about the harness's internal provisioning.
+# Neither is visibly broken today, but neither is in effect by our doing.
 
 set -u
 

--- a/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
+++ b/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
@@ -14,15 +14,51 @@
 #      fields and fail-closed on EVERY worktree spawn crew-wide (the golden fixture +
 #      create-worktree.hook.test.ts now assert the captured shape so that can't recur).
 #  * stdout — ON SUCCESS, ONLY the resulting worktree path (Claude Code adopts it).
-#  * exit   — 0 on success; NON-ZERO on ANY failure. A non-zero WorktreeCreate blocks
-#             creation, so the coder fail-closes on the Step-4 preflight — no worse than
-#             today's fall-back-to-primary, and never a silently dep-less worktree.
+#  * exit   — 0 on success; NON-ZERO on ANY failure. A non-zero WorktreeCreate ABORTS the
+#             spawn — the harness rethrows and never falls back to its own provisioning
+#             (verified against the harness's agent-worktree creator, see #4180 below), so
+#             the coder never lands in a silently dep-less or primary-checkout tree.
 #
 # `git worktree add` fires the existing lefthook post-checkout `bootstrap-deps` install
 # (ADR 0109) — we REUSE it, never reimplement it, so 0109's provision-not-share
 # correctness is preserved unchanged.
+#
+# RUNTIME REALITY (#4180): on the harness path that provisions `isolation:worktree` agent
+# trees, this hook is NOT being invoked at all. The harness's creator takes the hook only
+# when its `hasWorktreeCreateHook()` predicate is true and otherwise provisions internally,
+# on a `worktree-<name>` branch; every registered agent tree on this checkout carries that
+# branch and none carries this hook's `--detach` head or its owner stamp. So everything this
+# hook carries — the #3621 fresh-base fetch, the ADR 0178 600s install budget, the #3943
+# owner stamp — is currently inert on that path. The trace below is what makes that
+# falsifiable instead of inferred.
 
 set -u
+
+# Unconditional invocation trace — the ONE artifact that separates "the harness never invoked
+# this hook" from "it invoked it and the hook died early" (#4180). Everything else this script
+# writes happens only AFTER `git worktree add` succeeds, so those two cases leave byte-identical
+# on-disk evidence and the question is unanswerable from artifacts alone. This line is written
+# before any parsing, any PATH manipulation, and any git call: its presence proves invocation,
+# its absence proves non-invocation.
+#
+# PATH-resilient and non-fatal BY CONSTRUCTION, and both properties are load-bearing rather than
+# polish: `git worktree add` execs hooks with a stripped PATH (#787–#789) and `.git/hooks` is
+# shared across every lane, so a trace that hard-failed here would abort worktree creation for
+# the whole crew. Hence no jq, no unguarded external command, and a failed write degrades to
+# "no trace" and never to a non-zero exit. The log lives outside any repo so it can never dirty
+# a worktree (a dirty tree is KEPT forever by the sweep).
+KAMPUS_WORKTREE_HOOK_LOG="${KAMPUS_WORKTREE_HOOK_LOG:-/tmp/kampus-worktree-create.log}"
+trace() {
+	# `date` may be unreachable under a stripped PATH; an unknown timestamp is still proof of
+	# invocation, so degrade the field rather than lose the line.
+	local ts
+	ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || ts=""
+	[ -n "$ts" ] || ts="unknown"
+	# The whole redirect is wrapped so a FAILED redirect is silenced too: `cmd >>log 2>/dev/null`
+	# applies the append first, and the shell reports its failure on the still-open stderr.
+	{ printf '%s pid=%s %s\n' "$ts" "$$" "$*" >>"$KAMPUS_WORKTREE_HOOK_LOG"; } 2>/dev/null || true
+}
+trace "entry"
 
 # Parse the payload FIRST, under the inherited PATH — before the defensive toolchain PATH
 # below. Parsing needs only jq-or-coreutils, and keeping it ahead of the toolchain prepend
@@ -52,11 +88,13 @@ session_id="$(extract session_id)"
 # cwd + name are both mandatory — the path is CONSTRUCTED from them, so either missing
 # means there is nothing safe to create. Fail-closed (never a silent no-op).
 if [ -z "$cwd" ] || [ -z "$name" ]; then
+	trace "fail: payload missing cwd/name"
 	echo "create-worktree: WorktreeCreate payload missing cwd/name — cannot provision (fail-closed)." >&2
 	exit 1
 fi
 
 worktree_path="$cwd/.claude/worktrees/$name"
+trace "payload: name=$name session=${session_id:-none} cwd=$cwd"
 
 # NOW ensure a full PATH for git + the post-checkout `pnpm install` it fires. The hook exec
 # env's PATH handling is UNDOCUMENTED (the sibling harness `git worktree add` strips PATH to
@@ -69,6 +107,7 @@ export PATH="/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin:${HOME:-}/.local/bin
 # Operate on the repo the payload names, not merely the process cwd, so the constructed path
 # and the git op agree even if the hook exec cwd ever drifts from the payload's `cwd`.
 if ! cd "$cwd" 2>/dev/null; then
+	trace "fail: cwd not accessible"
 	echo "create-worktree: payload cwd '$cwd' is not accessible — refusing (fail-closed)." >&2
 	exit 1
 fi
@@ -84,6 +123,7 @@ fi
 # here because the base is the freshly-fetched remote tip, never local `main`. Fail LOUD if the
 # fetch fails rather than silently branching from a possibly-stale base.
 if ! git fetch --quiet origin main >&2; then
+	trace "fail: git fetch origin main"
 	echo "create-worktree: git fetch origin main failed — refusing to branch from a possibly-stale base (fail-closed, #3621)." >&2
 	exit 1
 fi
@@ -95,6 +135,7 @@ fi
 # already checked out'), and the coder re-branches in its Step-4 preflight regardless, so the base
 # HEAD is throwaway. A detached checkout at FETCH_HEAD still fires post-checkout (ADR 0109).
 if ! git worktree add --detach "$worktree_path" FETCH_HEAD >&2; then
+	trace "fail: git worktree add --detach $worktree_path"
 	echo "create-worktree: git worktree add --detach '$worktree_path' FETCH_HEAD failed — refusing (fail-closed)." >&2
 	exit 1
 fi
@@ -118,11 +159,17 @@ if [ -n "$session_id" ]; then
 		printf '{"sessionId":"%s","ownerKind":"launcher","worktreeName":"%s","stampedAt":"%s"}\n' \
 			"$session_id" "$name" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 			>"$gitdir/kampus-owner.json" 2>/dev/null \
-			|| echo "create-worktree: could not stamp owner session (tree reads owner-unknown → never reaped)." >&2
+			&& trace "stamped: $gitdir/kampus-owner.json" \
+			|| { trace "fail: stamp write"; echo "create-worktree: could not stamp owner session (tree reads owner-unknown → never reaped)." >&2; }
+	else
+		trace "fail: stamp gitdir unresolved"
 	fi
 else
+	trace "unstamped: payload carried no session_id"
 	echo "create-worktree: payload carried no session_id — tree reads owner-unknown (never reaped, #3943)." >&2
 fi
+
+trace "ok: $worktree_path"
 
 # Success: emit ONLY the path on stdout (all git/install chatter went to stderr above).
 printf '%s\n' "$worktree_path"

--- a/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
@@ -17,11 +17,17 @@
  *      writes into the tree's git admin dir, resolved against the harness's live-session
  *      registry by `worktree-sweep`'s `owner-liveness.ts` (the shared resolution, #3943).
  *
- * The second signal is why this verb stopped being inert over the population it was shipped
- * for: only a small minority of managed trees carry a lock at any moment (9 of 252 on the
- * crew host at the time of writing), so a lock-only gate spared essentially everything as
- * `owner-unknown` — indistinguishable from correct fail-closed behaviour, the silent-no-op
- * class (#3989, #3887).
+ * **Signal 2 has NO live producer today (#4180) — two signals is what this verb IMPLEMENTS,
+ * not what it OBSERVES.** The harness provisions agent worktrees on its own internal path
+ * instead of invoking the `WorktreeCreate` hook that writes the stamp, so no registered tree
+ * carries one (274 registered, 0 stamped at the time of writing). The consumer side below is
+ * correct and covered by tests, and starts working the moment a producer fires — what is false
+ * is that the second signal is *available*. So in the field this is still the one-signal,
+ * lock-only gate #3989 set out to fix: only a small minority of managed trees carry a lock at
+ * any moment (9 of 252 when #3989 landed), so essentially everything resolves `owner-unknown`
+ * and is spared — indistinguishable from correct fail-closed behaviour, the silent-no-op class
+ * (#3989, #3887). Read a `0 reapable` report as partly an absence of evidence, and do not treat
+ * that inertness as fixed until #4180 lands a producer that actually fires.
  *
  * BOTH signals name the LAUNCHER — the crew pane that provisioned the tree — never the
  * subagent occupying it: the lock pid is the pane's, the stamp is written by the hook before

--- a/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
@@ -49,11 +49,20 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 	const git = (cwd: string, ...args: string[]) =>
 		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
 
+	// Every run redirects the #4180 invocation trace to a suite-scoped file, so the tests never
+	// append to the shared default log the live forensic record lives in.
+	let traceLog: string;
+
 	// Run the hook script with `payload` on stdin, cwd inside the repo — exactly as
 	// Claude Code fires it. Never throws: a non-zero exit is captured, not raised.
 	const run = (cwd: string, payload: string): RunResult => {
 		try {
-			const stdout = execFileSync("bash", [SCRIPT], {cwd, input: payload, encoding: "utf8"});
+			const stdout = execFileSync("bash", [SCRIPT], {
+				cwd,
+				input: payload,
+				encoding: "utf8",
+				env: {...process.env, KAMPUS_WORKTREE_HOOK_LOG: traceLog},
+			});
 			return {code: 0, stdout, stderr: ""};
 		} catch (e) {
 			const err = e as {status?: number; stdout?: string; stderr?: string};
@@ -72,6 +81,7 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 	};
 
 	beforeAll(() => {
+		traceLog = join(mkdtempSync(join(tmpdir(), "wtc-trace-")), "trace.log");
 		mainRepo = mkdtempSync(join(tmpdir(), "wtc-main-"));
 		git(mainRepo, "init", "-q", "-b", "main");
 		git(mainRepo, "config", "user.email", "t@t.t");
@@ -157,7 +167,7 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 				// env -i: PATH=bindir ONLY (jq-free — no /usr/bin, which carries jq on Linux) so
 				// the parse deterministically takes the fallback; the script re-adds the standard
 				// toolchain dirs AFTER parsing, so git still resolves for `worktree add`.
-				env: {PATH: bindir, HOME: mainRepo},
+				env: {PATH: bindir, HOME: mainRepo, KAMPUS_WORKTREE_HOOK_LOG: traceLog},
 			});
 		} catch (e) {
 			const err = e as {status?: number; stdout?: string};
@@ -310,6 +320,66 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 		assert.strictEqual(stdout.trim(), expected);
 		const gitdir = git(expected, "rev-parse", "--absolute-git-dir").trim();
 		assert.isFalse(existsSync(join(gitdir, "kampus-owner.json")));
+	});
+
+	// The #4180 forensic seam. Every other artifact this hook produces lands only AFTER
+	// `git worktree add` succeeds, so "the harness never invoked the hook" and "it invoked the
+	// hook and the hook died at its first line" are byte-identical on disk — which is why 272
+	// registered worktrees with 0 stamps could not name their own cause. The entry line is
+	// written before any parsing, so it separates the two.
+	it("writes an entry trace BEFORE parsing — a payload it rejects still proves invocation (#4180)", () => {
+		const {code} = run(mainRepo, "{}");
+		assert.notStrictEqual(code, 0, "an empty payload still fail-closes");
+		assert.include(
+			readFileSync(traceLog, "utf8"),
+			"entry",
+			"the entry trace must precede the fail-closed exit, or a hook that dies early is invisible",
+		);
+	});
+
+	// The trace's non-fatality is the whole reason it is safe to add: `git worktree add` execs
+	// hooks with a stripped PATH (#787–#789) against a `.git/hooks` shared by every lane, so a
+	// trace that hard-failed would abort worktree creation crew-wide. An unwritable log must
+	// degrade to "no trace", never to a failed spawn.
+	it("an unwritable trace log never changes the exit status — degrades to no trace (#787–#789)", () => {
+		const name = "agent-notrace01";
+		const expected = join(mainRepo, ".claude", "worktrees", name);
+		const stdout = execFileSync("bash", [SCRIPT], {
+			cwd: mainRepo,
+			input: goldenPayloadFor(mainRepo, name),
+			encoding: "utf8",
+			env: {
+				...process.env,
+				// a path under a directory that does not exist — every write to it fails
+				KAMPUS_WORKTREE_HOOK_LOG: join(mainRepo, "no", "such", "dir", "trace.log"),
+			},
+		});
+		assert.strictEqual(stdout.trim(), expected, "provisioning must succeed with no trace at all");
+		assert.isTrue(existsSync(expected));
+	});
+
+	// PATH-resilience, forced the same way the jq-less test forces its branch: with no PATH at
+	// all the timestamp helper is unreachable, and the line must still land (an `unknown`
+	// timestamp is a degraded field, not a lost proof of invocation).
+	it("still traces when `date` is unreachable — the timestamp degrades, the proof does not", () => {
+		// A PATH carrying ONLY bash — no `date`, the single external command the trace touches.
+		// This is the stripped-PATH exec env of #787–#789, reproduced deterministically.
+		const bindir = mkdtempSync(join(tmpdir(), "wtc-nodate-bin-"));
+		const bash = execFileSync("bash", ["-lc", "command -v bash"], {encoding: "utf8"}).trim();
+		symlinkSync(bash, join(bindir, "bash"));
+		try {
+			execFileSync(bash, [SCRIPT], {
+				cwd: mainRepo,
+				input: "{}",
+				encoding: "utf8",
+				env: {PATH: bindir, HOME: mainRepo, KAMPUS_WORKTREE_HOOK_LOG: traceLog},
+			});
+		} catch {
+			/* expected: an unparseable payload fail-closes — the trace is what's under test */
+		} finally {
+			rmSync(bindir, {recursive: true, force: true});
+		}
+		assert.include(readFileSync(traceLog, "utf8"), "unknown pid=", "the line lands date-less");
 	});
 
 	// Guard the anti-fabrication invariant directly: the raw fixture bytes fed to the handler

--- a/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
@@ -53,15 +53,23 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 	// append to the shared default log the live forensic record lives in.
 	let traceLog: string;
 
+	// A private trace target, for any test that ASSERTS on trace content. The suite-scoped
+	// `traceLog` is append-only and shared, so an `assert.include` over it is satisfied by any
+	// earlier test's line — which made both #4180 trace assertions vacuous: `entry` was already
+	// there from the first provisioning test, and `unknown pid=` from the jq-less test, whose
+	// bindir carries no `date` and so already exercises the degradation. Own log ⇒ the assertion
+	// observes only its own run and actually fails when the behaviour breaks.
+	const freshTraceLog = (): string => join(mkdtempSync(join(tmpdir(), "wtc-trace-")), "trace.log");
+
 	// Run the hook script with `payload` on stdin, cwd inside the repo — exactly as
 	// Claude Code fires it. Never throws: a non-zero exit is captured, not raised.
-	const run = (cwd: string, payload: string): RunResult => {
+	const run = (cwd: string, payload: string, logPath?: string): RunResult => {
 		try {
 			const stdout = execFileSync("bash", [SCRIPT], {
 				cwd,
 				input: payload,
 				encoding: "utf8",
-				env: {...process.env, KAMPUS_WORKTREE_HOOK_LOG: traceLog},
+				env: {...process.env, KAMPUS_WORKTREE_HOOK_LOG: logPath ?? traceLog},
 			});
 			return {code: 0, stdout, stderr: ""};
 		} catch (e) {
@@ -81,7 +89,7 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 	};
 
 	beforeAll(() => {
-		traceLog = join(mkdtempSync(join(tmpdir(), "wtc-trace-")), "trace.log");
+		traceLog = freshTraceLog();
 		mainRepo = mkdtempSync(join(tmpdir(), "wtc-main-"));
 		git(mainRepo, "init", "-q", "-b", "main");
 		git(mainRepo, "config", "user.email", "t@t.t");
@@ -328,10 +336,13 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 	// registered worktrees with 0 stamps could not name their own cause. The entry line is
 	// written before any parsing, so it separates the two.
 	it("writes an entry trace BEFORE parsing — a payload it rejects still proves invocation (#4180)", () => {
-		const {code} = run(mainRepo, "{}");
+		// Private log: the only line that can satisfy this assertion is the one this rejected
+		// payload wrote. Relocate `trace "entry"` below the fail-closed exit and the log is empty.
+		const log = freshTraceLog();
+		const {code} = run(mainRepo, "{}", log);
 		assert.notStrictEqual(code, 0, "an empty payload still fail-closes");
 		assert.include(
-			readFileSync(traceLog, "utf8"),
+			readFileSync(log, "utf8"),
 			"entry",
 			"the entry trace must precede the fail-closed exit, or a hook that dies early is invisible",
 		);
@@ -367,19 +378,26 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 		const bindir = mkdtempSync(join(tmpdir(), "wtc-nodate-bin-"));
 		const bash = execFileSync("bash", ["-lc", "command -v bash"], {encoding: "utf8"}).trim();
 		symlinkSync(bash, join(bindir, "bash"));
+		// Private log — the shared one already carries `unknown pid=` from the jq-less test above,
+		// whose bindir has no `date` either, so asserting there would pass with the degradation
+		// removed entirely.
+		const log = freshTraceLog();
 		try {
 			execFileSync(bash, [SCRIPT], {
 				cwd: mainRepo,
 				input: "{}",
 				encoding: "utf8",
-				env: {PATH: bindir, HOME: mainRepo, KAMPUS_WORKTREE_HOOK_LOG: traceLog},
+				env: {PATH: bindir, HOME: mainRepo, KAMPUS_WORKTREE_HOOK_LOG: log},
 			});
 		} catch {
 			/* expected: an unparseable payload fail-closes — the trace is what's under test */
 		} finally {
 			rmSync(bindir, {recursive: true, force: true});
 		}
-		assert.include(readFileSync(traceLog, "utf8"), "unknown pid=", "the line lands date-less");
+		// Existence first: with the degradation removed the trace writes nothing at all, and a bare
+		// readFileSync would report that as ENOENT rather than as the property that broke.
+		assert.isTrue(existsSync(log), "a date-less run must still produce a trace file");
+		assert.include(readFileSync(log, "utf8"), "unknown pid=", "the line lands date-less");
 	});
 
 	// Guard the anti-fabrication invariant directly: the raw fixture bytes fed to the handler

--- a/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts
@@ -28,6 +28,17 @@
  *      `$TMPDIR`-rooted `review-head-*` tree, which no hook provisions, the fallback is a bare
  *      session-UUID segment in its own path (the harness roots a session's `$TMPDIR` scratchpad
  *      at `…/<session-uuid>/scratchpad/`).
+ *
+ *      **This source has NO live producer today (#4180) — read every claim about it as a code
+ *      contract, not a runtime fact.** The harness is not invoking the `WorktreeCreate` hook on
+ *      the path that provisions agent worktrees, so the stamp is never written: 272 registered
+ *      worktrees, 0 stamped. Everything below is correct about what the rules *do* with a stamp;
+ *      what they never do in practice is see one. The direction of that gap is safe — an
+ *      unstamped tree resolves `"unknown"`, which the classifier KEEPs, so a stamp-less runtime
+ *      can only leak orphans, never remove a live tree — but it means the sweep is a one-signal
+ *      (lock-derived) design in the field, and `0 reapable` is partly an absence of evidence
+ *      rather than a considered spare. Do not build a decision on stamp coverage until #4180
+ *      lands a producer that actually fires.
  *   2. **liveness** — the harness's session registry: one `<config>/sessions/<pid>.json` per
  *      RUNNING session, carrying `{pid, sessionId}` and deleted when the session exits.
  *


### PR DESCRIPTION
The worktree owner stamp has never once been written on this machine — 272 registered worktrees, 0 carrying one — and the reaper that is documented to read it has therefore never had anything to read. This PR does not add a stamp. It answers *why* there is none, makes the answer permanently checkable instead of inferred, and rewrites the three places that describe the stamp as if it existed at runtime.

The reaper's behavior is unchanged: an unstamped tree still resolves `unknown` and is still kept. **Nothing here can make anything reapable that was not already reapable.** No sweep or reap was run.

## The diagnosis

#4180 could not split two hypotheses — the hook is never invoked, versus the hook is invoked, exits non-zero, and the harness silently falls back to its own provisioning. They are different bugs with different fixes, and they leave byte-identical on-disk evidence, because everything `create-worktree.sh` writes lands only *after* its `git worktree add` succeeds.

Split, from the harness's own agent-worktree creator (read out of the installed CLI binary, per the repo rule about grounding platform claims in source) plus a live artifact:

1. **The creator branches on a `hasWorktreeCreateHook()` predicate.** On the hook branch it awaits the hook and **rethrows any failure** — there is no fallback to internal provisioning, and the thrown errors are explicit (`WorktreeCreate hook failed: hook is configured but did not run …` / `… returned no worktree path`). So "invoked, failed, harness silently fell back" **cannot** produce a working tree. A hook failure aborts the spawn.
2. **The `else` branch provisions internally and puts the tree on a `worktree-<name>` branch** (`Created agent worktree at: <path> on branch: <branch>`, versus `Created hook-based agent worktree at: <path>` on the hook branch). Of the 272 registered worktrees, **252 carry exactly that `worktree-<name>` branch ref**; the remaining 20 are hand-made `head-*` / `wt-issue-*` trees. `create-worktree.sh` uses `git worktree add --detach`, which creates no branch at all.

The worktree this PR was written in is itself an instance: created on branch `worktree-agent-<id>`, with a `CLAUDE_BASE` file (written by no repo code) in its git admin dir and no `kampus-owner.json`.

**Verdict: the hook is not invoked on the agent-spawn path (hypothesis 1).** The remaining question is narrower and harness-side — why `hasWorktreeCreateHook()` resolves false when `.claude/settings.json` carries a well-formed `WorktreeCreate` registration (re-added 2026-07-19, six days before these trees).

**The session-snapshot candidate this PR originally led with has since been refuted experimentally** (see the comment on this PR): a tree provisioned minutes ago, from a session started six days *after* the registration landed, was still branch-based and still unstamped. Session age is not the explanation. The binary corroborates the shape of the refutation — the predicate does read a memoized `initialHooksConfig`, but there are explicit refresh points that recompute it, so the snapshot is not frozen for a session's lifetime. Legs still worth probing, all of which drop the project `.claude/settings.json` hooks or short-circuit the predicate regardless of session age: the settings loader's early return on `disableAllHooks`, on `allowManagedHooksOnly`/safe-mode, and on the `strictPluginOnlyCustomization` policy; and a separate feature gate that forces the predicate false outright under `CLAUDE_CODE_SIMPLE`/`--bare` or safe mode. **Those are follow-up work, not this PR** — the trace landed here is what makes the next spawn decide between them from an artifact rather than an inference.

### The stripped-PATH hazard (#787–#789), checked explicitly

It is not the cause here — under hypothesis 1 the hook never runs, so it never gets far enough to trip on PATH. But it is the binding **constraint on this PR**: `git worktree add` execs hooks with a stripped PATH, `.git/hooks` is shared across lanes, and a hook that hard-fails there aborts worktree creation for every lane at once. So the trace added below is non-fatal by construction.

### The wider blast radius, since it was asked

The same hook carries the #3621 fresh-base `git fetch` and the ADR 0178 600s dep-install budget. **Neither is in effect on the live spawn path** — they ride the hook, and the hook does not run. Neither is *visibly* broken today, but the harness's own provisioning is **not an equivalent substitute** for either, so this is not a wash:

- **Freshness (#3621).** The harness does run its own fetch, but it is **throttled on `FETCH_HEAD` mtime** and **falls back to the local `HEAD`** with only a warning when the fetch fails. Our hook fails closed instead. So #3621's guarantee is strictly **weaker** in practice, not equal — a stale-base spawn is reachable on the harness path in exactly the window #3621 was written to eliminate.
- **The 600s budget (ADR 0178).** That budget is a hook-config `timeout`. It governs the invocation of *this hook* and nothing at all about the harness's internal provisioning; the harness's `git worktree add` does still fire the lefthook `bootstrap-deps` install (`node_modules` is present in these trees), but under the harness's own readiness handling, not ours.

**Two landed fixes have been inert since they shipped**, and that is worth saying plainly rather than filing under "no visible harm."

## What this PR changes

- **`claude-plugins/kampus-pipeline/hooks/create-worktree.sh`** — an unconditional entry trace written before any parsing, plus a line at each fail-closed exit, at the stamp write, and on success. Its presence proves invocation; its absence proves non-invocation. That is the artifact that was missing.
  - **PATH-resilient**: it touches one external command (`date`), guarded, degrading to an `unknown` timestamp rather than losing the line.
  - **Non-fatal**: the whole write is wrapped so even a failed redirect is silenced, and it can only ever degrade to "no trace" — never to a non-zero exit.
  - The log lives outside any repo, so it can never dirty a worktree (a dirty tree is kept forever by the sweep).
  - Its runtime note now also records the non-equivalence above, so the next reader does not re-derive "the harness does the same thing anyway."
- **`packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts`** — three tests pinning exactly those properties: the entry line precedes the fail-closed exit, an unwritable log leaves the exit status untouched, and the line still lands with `date` unreachable. Each test that asserts on trace *content* writes to its own log file: the suite-scoped log is append-only and shared, so an `assert.include` over it was satisfiable by an earlier test's line, and two of the three assertions were vacuous until this was fixed. Both were then **falsified deliberately** — relocating `trace "entry"` below the fail-closed exit fails the first, removing the `date` degradation fails the second — so neither is a test that has never been seen to fail.
- **`packages/pipeline-cli/src/tools/worktree-sweep/owner-liveness.ts`**, **`.patterns/worktree-agent-constraints.md`**, and **`packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts`** — the over-trust the issue names. All three presented the stamp as an observed on-disk artifact; the reaper's own docblock went furthest, crediting the stamp with the verb having "stopped being inert." All three now say plainly that the second signal has no live producer, that the sweep/reap is lock-only in the field, and that `0 reapable` is partly an absence of evidence rather than a considered spare — while staying accurate in the other direction too: the consumer code is correct, tested, and starts working the moment a producer fires.

## Scope

`Part of #4180`, not `Fixes`: the issue's first acceptance criterion asks for one controlled instrumented `isolation:worktree` spawn read back off the log, and this run cannot spawn one. The instrumentation it needs is now landed, so that step is a single observation away. The issue's own AC5 rules an alternative producer seam (an occupant-side stamp) out of scope for this PR — it is a design call needing its own issue/ADR — so the stamp deliberately still does not appear.

No change to PR #4169 / issue #3989; the consumer is correct as it stands and this is producer-side only.

Part of #4180
