### PR TITLE
fix(pipeline): the issue type is the router, and an unroutable type refuses to dispatch (#4113)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -10,6 +10,12 @@
 // owns both. Saved workflows are not plugin-distributable, so this lives repo-local in
 // `.claude/workflows/`, not in the kampus-pipeline plugin.
 //
+// Type routing (#4113): the Classify stage's `type:*` label IS the router. Every one of the six
+// canonical types names its lane explicitly — epic -> planner, decision -> adr, and
+// feature/chore/bug/investigation -> coder — and anything else aborts the dispatch. The guard sits
+// at LANE ENTRY, never at merge: a merge-path check on the linked issue's type would be a
+// direction gate on finished work (founder no-go #3909, restated by #3947).
+//
 // Pre-spawn claim (ADR 0115 §3, orchestrated path): the Implement branch acquires the
 // agent-distinguishable claim BEFORE the coder dispatch and spawns the coder only on a
 // win, threading the winning claim token through so the coder treats it as its delegated
@@ -20,8 +26,8 @@
 export const meta = {
 	name: "drive-issue",
 	description:
-		"Drive one triaged issue through the kampus pipeline: epics route planner -> reviewer(review-plan); everything else atomically claims the issue pre-spawn (ADR 0115) and only on a win runs coder -> reviewer -> repair(freeze-after-2) -> shipper. A control-plane PR is approval-gated (ADR 0135): the shipper enqueues it once a @kamp-us/control-plane team member approves at the current head, else halts at `awaiting control-plane approval`; a lost claim skips before any work starts.",
-	phases: ["Classify", "Plan", "Implement", "Review", "Repair", "Ship"],
+		"Drive one triaged issue through the kampus pipeline, routed by its `type:*` label: epics route planner -> reviewer(review-plan); decisions route the adr agent (never a coder); feature/chore/bug/investigation atomically claim the issue pre-spawn (ADR 0115) and only on a win run coder -> reviewer -> repair(freeze-after-2) -> shipper; an unknown or missing type aborts the dispatch fail-closed. A control-plane PR is approval-gated (ADR 0135): the shipper enqueues it once a @kamp-us/control-plane team member approves at the current head, else halts at `awaiting control-plane approval`; a lost claim skips before any work starts.",
+	phases: ["Classify", "Plan", "Decide", "Implement", "Review", "Repair", "Ship"],
 };
 
 // args carries the target issue number: accept `{ issue }` or a bare value.
@@ -69,6 +75,44 @@ function stageResult(stage, result, pr) {
 		throw new StageAborted(stage, pr);
 	}
 	return result;
+}
+
+// Type routing (#4113) — the lane each canonical `type:*` dispatches into. No default arm: a type
+// this table does not name is UNROUTABLE and aborts the dispatch, because the coder is the lane
+// with side effects (a branch, a PR, a shipped position), so defaulting into it turns every
+// classification failure into shipped work. `decision -> adr` is the fix for the #4045 mis-route (a
+// coder handed a decision implements an answer to the question the issue exists to settle);
+// `investigation -> coder` is a NAMED choice, not a fall-through — write-code owns both an
+// investigation's outcomes, its residue path and its bounded collapse to one PR (ADR 0070).
+// Inline mirror of the unit-tested pure core `routeIssueType` in
+// packages/pipeline-cli/src/tools/drive-issue-flow/type-route.ts (not importable from a workflow
+// script — top-level return + injected globals; the post-build.ts / resume-cap.ts sibling shape).
+const LANE_BY_TYPE = {
+	epic: "planner",
+	decision: "adr",
+	investigation: "coder",
+	feature: "coder",
+	chore: "coder",
+	bug: "coder",
+};
+function normalizeIssueType(raw) {
+	if (typeof raw !== "string") return "";
+	return raw
+		.trim()
+		.toLowerCase()
+		.replace(/^[`'"\s]+|[`'"\s]+$/g, "")
+		.replace(/^type:\s*/, "")
+		.trim();
+}
+function routeIssueType(raw) {
+	const type = normalizeIssueType(raw);
+	if (type === "") {
+		return { routed: false, type: "", reason: "no readable `type:*` label on the issue — fail-closed: an unclassifiable issue is not a licence to dispatch a coder" };
+	}
+	if (!Object.hasOwn(LANE_BY_TYPE, type)) {
+		return { routed: false, type, reason: `unroutable issue type \`type:${type}\` — not one of the six canonical types (bug, feature, chore, decision, investigation, epic); fail-closed rather than defaulting to a coder lane` };
+	}
+	return { routed: true, type, lane: LANE_BY_TYPE[type] };
 }
 
 // Trivial-diff tier (ADR 0120 §2-§4). The right-sized fan-out routes a trivially-classified
@@ -137,7 +181,9 @@ log(`drive-issue #${issue}`);
 async function drive() {
 	// 1. Classify — a lightweight READ of the already-triaged `type:` label to route.
 	// Deliberately NOT the triager agent: triager is needs-triage INTAKE and would
-	// mutate; the executor only reads the label to route it (epic -> planner).
+	// mutate; the executor only reads the label, and that label is the ROUTER (#4113).
+	// The stage returns the type ALONE: an `isEpic` boolean alongside it would be a second
+	// source of truth for the same fact, free to disagree with the label that decides the lane.
 	phase("Classify");
 	log(`Classifying issue #${issue} by its type: label`);
 	const klass = stageResult("classify", await agent(
@@ -145,23 +191,34 @@ async function drive() {
 			`resolve the repo as \${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}, ` +
 			`then \`gh api repos/$REPO/issues/${issue} --jq '[.labels[].name]'\`. ` +
 			`Find the single \`type:*\` label. Do NOT modify the issue, add labels, or comment — this is a read-only classification. ` +
-			`Return { isEpic: true|false, type: "<the type: label, e.g. type:epic / type:feature / type:chore>" }.`,
+			`FAIL-CLOSED: if the issue carries NO \`type:*\` label, more than one, or you cannot read the labels for any ` +
+			`reason, return { type: "" } — do NOT guess a type and do NOT infer one from the title or body. An empty type ` +
+			`aborts the dispatch, which is the correct outcome; a guessed one silently opens the wrong lane. ` +
+			`Return { type: "<the exact type: label, e.g. type:epic / type:decision / type:feature>" }.`,
 		{
 			schema: {
 				type: "object",
 				properties: {
-					isEpic: { type: "boolean" },
 					type: { type: "string" },
 				},
-				required: ["isEpic", "type"],
+				required: ["type"],
 				additionalProperties: false,
 			},
 		},
 	));
-	log(`Issue #${issue} classified as ${klass.type} (isEpic=${klass.isEpic})`);
 
-	// 2. Epic branch — plan the epic, then gate the plan with review-plan. No coder/shipper.
-	if (klass.isEpic) {
+	// 2. Route on the type. An unroutable type (absent, unknown, ambiguous) STOPS here with a
+	// structured, resumable result and spawns nothing — the fail-closed direction is "refuse to
+	// dispatch", never "dispatch the coder anyway" (#4113).
+	const route = routeIssueType(klass.type);
+	if (!route.routed) {
+		log(`Issue #${issue} is UNROUTABLE (${route.reason}) — aborting the dispatch; no planner, no adr, no coder spawns. Fix the issue's \`type:*\` label and re-run.`);
+		return { unroutable: true, issue, type: route.type, reason: route.reason };
+	}
+	log(`Issue #${issue} classified as type:${route.type} -> ${route.lane} lane`);
+
+	// 2a. Epic branch — plan the epic, then gate the plan with review-plan. No coder/shipper.
+	if (route.lane === "planner") {
 		phase("Plan");
 		log(`Planning epic #${issue} with the planner agent`);
 		const plan = stageResult("plan", await agent(
@@ -211,7 +268,53 @@ async function drive() {
 		return { epic: true, planVerdict };
 	}
 
-	// 3. Implement branch — pre-spawn claim -> coder -> reviewer -> repair(freeze-after-2) -> shipper.
+	// 2b. Decision branch — record the ruling as an ADR. A `type:decision` issue's deliverable is
+	// a settled, recorded choice; there is no feature branch to merge, so the closing artifact is
+	// `.decisions/NNNN-slug.md`, not a diff. Dispatching a coder here is the #4045 mis-route: it
+	// would implement an answer to the question the issue exists to settle, and whatever it
+	// invented would become the de-facto ruling with no ADR authorizing it.
+	//
+	// Terminal, like the planner branch, and for the same reason: the lane's deliverable is not a
+	// PR this flow gates. The `adr` agent adds exactly one ADR file and explicitly does not open a
+	// PR, review, or merge; landing that file's PR is a separate seam this routing fix deliberately
+	// does not invent (#4113 scope). No pre-spawn claim either — same as the planner branch; the
+	// ADR 0115 claim is the coder lane's contract.
+	if (route.lane === "adr") {
+		phase("Decide");
+		log(`Recording the decision for #${issue} with the adr agent (the decision seam, NOT a coder lane)`);
+		const decided = stageResult("decide", await agent(
+			`Record the decision asked for by issue #${issue} as an ADR. You are the adr agent — load and follow the ` +
+				`adr skill: claim the next number under the in-flight reservation lock (ADR 0074), run the contradiction ` +
+				`sweep, write one \`.decisions/NNNN-slug.md\` from the house template, and resolve the vocabulary-impact ` +
+				`outcome explicitly. Add ONLY that file (plus the status-line edit on a file it supersedes or amends in ` +
+				`part) — there is no committed index. Do NOT implement anything, do NOT review, do NOT merge. ` +
+				`Return { adr: "<the repo-relative .decisions/NNNN-slug.md path you wrote>", recorded: true|false, ` +
+				`reason: "<why, if you recorded nothing>" }.`,
+			{
+				agentType: "adr",
+				isolation: "worktree",
+				schema: {
+					type: "object",
+					properties: {
+						adr: { type: "string" },
+						recorded: { type: "boolean" },
+						reason: { type: "string" },
+					},
+					required: ["recorded"],
+					additionalProperties: false,
+				},
+			},
+		));
+		log(
+			decided.recorded
+				? `Decision for #${issue} recorded at ${decided.adr}`
+				: `Decision for #${issue} NOT recorded: ${decided.reason ?? "see adr agent output"}`,
+		);
+		return { decision: true, issue, recorded: !!decided.recorded, adr: decided.adr, reason: decided.reason };
+	}
+
+	// 3. Implement branch (the `coder` lane: type:feature / type:chore / type:bug /
+	// type:investigation) — pre-spawn claim -> coder -> reviewer -> repair(freeze-after-2) -> shipper.
 	phase("Implement");
 
 	// 3a. Pre-spawn atomic claim (ADR 0115 §3, orchestrated path). Acquire the

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/type-route.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/type-route.ts
@@ -1,0 +1,157 @@
+/**
+ * `drive-issue` type routing — the pure, IO-free decision that turns the Classify stage's
+ * `type:*` label into the agent lane a dispatch may enter (issue #4113).
+ *
+ * The executor `.claude/workflows/drive-issue.js` used to classify by type and then throw the
+ * answer away: `klass.type` reached exactly one log line and the sole branch was
+ * `if (klass.isEpic)`. So routing was binary — epic → planner, **everything else → the coder**
+ * — and a `type:decision` issue landed in a coder lane *by construction*. A coder handed a
+ * decision implements an answer to the very question the issue exists to settle, and whatever
+ * it invents becomes the de-facto ruling with no ADR authorizing it (#4045).
+ *
+ * This module is that routing decision as a single tested unit. The workflow inlines the same
+ * table because a workflow script — top-level `return`, injected globals — is not importable;
+ * this module is its canonical mirror and the one that carries the unit test (the
+ * `post-build.ts` / `resume-cap.ts` sibling shape).
+ *
+ * **The rule, in one line:** every one of the six canonical types names its lane explicitly,
+ * and anything else — an absent, unknown, multiple or unparseable type — is **unroutable** and
+ * aborts the dispatch. Fail-closed here means *refuse to dispatch*, never "dispatch the coder
+ * anyway": the coder is the lane with a side effect (a branch, a PR, a shipped position), so a
+ * default that falls into it converts every classification failure into shipped work.
+ *
+ * The guard is deliberately at **lane entry**, not at merge. A merge-path check on the linked
+ * issue's type would be a direction gate on finished work, which founder no-go #3909 forbids
+ * outright (#3947: "Nothing changes at merge").
+ */
+
+/** The agent lane a routable issue type dispatches into. */
+export type DispatchLane = "planner" | "adr" | "coder";
+
+/**
+ * The lane for each of the six canonical `type:*` labels (the `triage` taxonomy). Every type is
+ * a named entry — there is no default arm, which is what makes an unlisted type unroutable
+ * rather than silently a coder.
+ *
+ * The two non-obvious entries:
+ *
+ * - **`decision` → `adr`.** A decision's deliverable is a recorded choice, not a diff. It routes
+ *   to the `adr` agent, which wraps the adr skill end to end and adds exactly one
+ *   `.decisions/NNNN-slug.md`.
+ * - **`investigation` → `coder`, named rather than fallen-through.** An investigation's
+ *   deliverable is a diagnosis, and `write-code` is the skill that owns *both* of its outcomes:
+ *   the residue path (closing comment + `report`) and the bounded collapse into a single PR when
+ *   the diagnosis lands on a trivial fix (ADR 0070, the four AND-ed bounds in
+ *   `gh-issue-intake-formats.md` §8). So the coder lane is a defensible route for an
+ *   investigation in a way it is never defensible for a decision — but it is written here as an
+ *   explicit entry so it is a *choice*, re-openable by editing this table, not the residue of a
+ *   missing branch.
+ */
+const LANE_BY_TYPE = {
+	epic: "planner",
+	decision: "adr",
+	investigation: "coder",
+	feature: "coder",
+	chore: "coder",
+	bug: "coder",
+} as const satisfies Record<string, DispatchLane>;
+
+/** One of the six canonical types, bare (no `type:` prefix). */
+export type KnownIssueType = keyof typeof LANE_BY_TYPE;
+
+const REASON_BY_TYPE: Record<KnownIssueType, string> = {
+	epic: "an epic's deliverable is a planned child ledger, not a diff",
+	decision:
+		"a decision's deliverable is a recorded ADR, not a diff — a coder would implement an answer to the question the issue exists to settle (#4045)",
+	investigation:
+		"an investigation's deliverable is a diagnosis, and write-code owns both its residue path and its bounded collapse to one PR (ADR 0070) — a named route, not a fall-through",
+	feature: "a directly implementable capability — the implement-and-PR path",
+	chore: "no behavior change, but still a diff — the implement-and-PR path",
+	bug: "a nameable fix — the implement-and-PR path",
+};
+
+/**
+ * The routing decision. A discriminated union so an unroutable classification cannot be read as
+ * if it named a lane: there is no `lane` field to reach for on the `routed: false` arm.
+ */
+export type TypeRoute =
+	| {
+			readonly routed: true;
+			readonly lane: DispatchLane;
+			readonly type: KnownIssueType;
+			readonly reason: string;
+	  }
+	| {
+			readonly routed: false;
+			/** The type as read (normalized), or `""` when nothing readable came back. */
+			readonly type: string;
+			readonly reason: string;
+	  };
+
+/**
+ * Normalize whatever the Classify stage returned into a bare canonical type word: lowercase,
+ * trimmed, stripped of surrounding backticks/quotes and of the `type:` prefix. Read tolerantly,
+ * decide strictly — the tolerance only ever maps a *recognizable* spelling onto a known word;
+ * anything the table does not name still falls through to unroutable. A non-string (the stage
+ * returned a number, an object, nothing) normalizes to `""`.
+ */
+export const normalizeIssueType = (raw: unknown): string => {
+	if (typeof raw !== "string") return "";
+	return raw
+		.trim()
+		.toLowerCase()
+		.replace(/^[`'"\s]+|[`'"\s]+$/g, "")
+		.replace(/^type:\s*/, "")
+		.trim();
+};
+
+/**
+ * Route an issue by its `type:*` label. Returns the named lane for one of the six canonical
+ * types; returns the `routed: false` arm — the dispatch-aborting state — for an absent, empty,
+ * unknown, or multi-valued type. **Never** returns a coder lane it was not told to.
+ */
+export const routeIssueType = (rawType: unknown): TypeRoute => {
+	const type = normalizeIssueType(rawType);
+	if (type === "") {
+		return {
+			routed: false,
+			type: "",
+			reason:
+				"no readable `type:*` label on the issue — fail-closed: an unclassifiable issue is not a licence to dispatch a coder",
+		};
+	}
+	if (!Object.hasOwn(LANE_BY_TYPE, type)) {
+		return {
+			routed: false,
+			type,
+			reason: `unroutable issue type \`type:${type}\` — not one of the six canonical types (bug, feature, chore, decision, investigation, epic); fail-closed rather than defaulting to a coder lane`,
+		};
+	}
+	const known = type as KnownIssueType;
+	return {routed: true, lane: LANE_BY_TYPE[known], type: known, reason: REASON_BY_TYPE[known]};
+};
+
+/** The structured, resumable terminal result an unroutable classification aborts to. */
+export interface UnroutableResult {
+	readonly unroutable: true;
+	readonly issue: number;
+	readonly type: string;
+	readonly reason: string;
+}
+
+/**
+ * Build the terminal result for an unroutable type. Distinct from every other terminal shape the
+ * flow returns (`skipped`, `backedOff`, `frozen`, `aborted`) so a driving session can tell
+ * "this issue's type does not name a lane" apart from a lost claim or a dead subagent, and can
+ * resume the run after a human fixes the label. Accepts only the unroutable arm, so a routable
+ * decision can never be turned into an abort by a mis-call.
+ */
+export const unroutableResult = (
+	issue: number,
+	route: Extract<TypeRoute, {routed: false}>,
+): UnroutableResult => ({
+	unroutable: true,
+	issue,
+	type: route.type,
+	reason: route.reason,
+});

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/type-route.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/type-route.unit.test.ts
@@ -1,0 +1,160 @@
+import {describe, expect, it} from "vitest";
+import {normalizeIssueType, routeIssueType, unroutableResult} from "./type-route.ts";
+
+const lane = (raw: unknown) => {
+	const r = routeIssueType(raw);
+	return r.routed ? r.lane : "abort";
+};
+
+describe("routeIssueType — every canonical type names its lane (issue #4113)", () => {
+	it("routes type:epic to the planner", () => {
+		expect(lane("type:epic")).toBe("planner");
+	});
+
+	it("routes type:decision to the adr agent, never a coder (the #4045 mis-route)", () => {
+		expect(lane("type:decision")).toBe("adr");
+	});
+
+	it("routes type:feature / type:chore / type:bug to the coder", () => {
+		expect(lane("type:feature")).toBe("coder");
+		expect(lane("type:chore")).toBe("coder");
+		expect(lane("type:bug")).toBe("coder");
+	});
+
+	it("routes type:investigation to the coder as a NAMED branch, with its justification carried", () => {
+		const r = routeIssueType("type:investigation");
+		expect(r.routed).toBe(true);
+		expect(lane("type:investigation")).toBe("coder");
+		// AC: the choice is justified in the code, not an unnamed fall-through — the reason
+		// names write-code's ownership of the diagnosis outcomes (ADR 0070's bounded collapse).
+		expect(r.routed && r.reason).toMatch(/ADR 0070/);
+		expect(r.routed && r.reason).toMatch(/not a fall-through/);
+	});
+});
+
+describe("normalizeIssueType — tolerant read, strict decide", () => {
+	it("accepts the bare word, the prefixed label, casing, whitespace and backticks", () => {
+		expect(normalizeIssueType("decision")).toBe("decision");
+		expect(normalizeIssueType("  TYPE:Decision  ")).toBe("decision");
+		expect(normalizeIssueType("`type:decision`")).toBe("decision");
+		expect(normalizeIssueType('"type: decision"')).toBe("decision");
+	});
+
+	it("normalizes anything unreadable to the empty string", () => {
+		expect(normalizeIssueType(undefined)).toBe("");
+		expect(normalizeIssueType(null)).toBe("");
+		expect(normalizeIssueType(42)).toBe("");
+		expect(normalizeIssueType({type: "decision"})).toBe("");
+		expect(normalizeIssueType("   ")).toBe("");
+	});
+});
+
+// The whole point of the guard: fail-closed means REFUSE TO DISPATCH, never "dispatch the coder
+// anyway". Every unreadable/unknown case must land on the abort arm.
+describe("routeIssueType — fail-closed on every unreadable or unknown type (issue #4113 AC)", () => {
+	const unreadable: ReadonlyArray<readonly [string, unknown]> = [
+		["a missing type (undefined)", undefined],
+		["an explicit null", null],
+		["an empty string", ""],
+		["whitespace only", "   "],
+		["a non-string number", 7],
+		["a non-string object", {type: "type:bug"}],
+		["a non-string array", ["type:bug"]],
+		["a boolean", false],
+		["an unknown type word", "type:spike"],
+		["a status label mistaken for a type", "status:triaged"],
+		["a priority label mistaken for a type", "p1"],
+		["a wayfinder marker (not a type at all)", "wayfinder:map"],
+		["two types at once — ambiguous, never guessed", "type:bug, type:decision"],
+		["a near-miss plural", "type:decisions"],
+		["a near-miss typo", "type:desicion"],
+		["prose instead of a label", "the issue has no type label"],
+	];
+
+	for (const [name, raw] of unreadable) {
+		it(`refuses to dispatch on ${name}`, () => {
+			const r = routeIssueType(raw);
+			expect(r.routed).toBe(false);
+			expect(lane(raw)).toBe("abort");
+			// no lane field exists on the abort arm — an abort can never be read as a coder lane
+			expect(r).not.toHaveProperty("lane");
+			expect(r.reason).not.toBe("");
+		});
+	}
+
+	it("says WHY it refused — an absent type and an unknown type are distinguishable", () => {
+		const absent = routeIssueType(undefined);
+		const unknown = routeIssueType("type:spike");
+		expect(absent.reason).toMatch(/no readable `type:\*` label/);
+		expect(unknown.reason).toMatch(/unroutable issue type `type:spike`/);
+		expect(absent.reason).not.toBe(unknown.reason);
+	});
+});
+
+describe("unroutableResult — the structured, resumable terminal result (issue #4113 AC)", () => {
+	it("is unambiguously separable from the other terminal shapes", () => {
+		const r = routeIssueType("type:spike");
+		expect(r.routed).toBe(false);
+		if (r.routed) return;
+		const out = unroutableResult(4113, r);
+		expect(out).toMatchObject({unroutable: true, issue: 4113, type: "spike"});
+		// none of `skipped` / `backedOff` / `frozen` / `aborted` — the shapes never collide
+		expect(out).not.toHaveProperty("skipped");
+		expect(out).not.toHaveProperty("backedOff");
+		expect(out).not.toHaveProperty("frozen");
+		expect(out).not.toHaveProperty("aborted");
+		expect(out).not.toHaveProperty("pr");
+	});
+
+	it("carries the empty type through when nothing readable came back", () => {
+		const r = routeIssueType(undefined);
+		if (r.routed) throw new Error("expected the unroutable arm");
+		expect(unroutableResult(4113, r).type).toBe("");
+	});
+});
+
+// The property the guard exists to enforce, asserted at the routing seam: a mis-typed or
+// unclassifiable issue dispatches NO agent at all, and a decision dispatches the adr agent
+// instead of a coder. Mirrors the workflow's Classify branch over the pure decision with a fake
+// dispatcher that records every dispatch (the `post-build.unit.test.ts` sibling shape).
+describe("Classify-stage routing — the dispatch a type produces (issue #4113)", () => {
+	const driveClassify = (issue: number, rawType: unknown, dispatched: string[]) => {
+		const route = routeIssueType(rawType);
+		if (!route.routed) return unroutableResult(issue, route);
+		dispatched.push(route.lane);
+		return {dispatched: route.lane, issue};
+	};
+
+	it("dispatches the adr agent — not a coder — for a type:decision issue", () => {
+		const dispatched: string[] = [];
+		driveClassify(4045, "type:decision", dispatched);
+		expect(dispatched).toEqual(["adr"]);
+		expect(dispatched).not.toContain("coder");
+	});
+
+	it("re-dispatching #4000 (type:decision) routes to the ADR seam, not a coder lane", () => {
+		const dispatched: string[] = [];
+		const out = driveClassify(4000, "type:decision", dispatched);
+		expect(out).toMatchObject({dispatched: "adr", issue: 4000});
+		expect(dispatched).toEqual(["adr"]);
+	});
+
+	it("dispatches NO agent at all when the type is unroutable — never a silent coder", () => {
+		for (const raw of [undefined, "", "type:spike", "status:triaged", 3]) {
+			const dispatched: string[] = [];
+			const out = driveClassify(4113, raw, dispatched);
+			expect(dispatched).toEqual([]);
+			expect(out).toMatchObject({unroutable: true, issue: 4113});
+		}
+	});
+
+	it("leaves the implement and plan lanes reaching their existing agents", () => {
+		const dispatched: string[] = [];
+		driveClassify(1, "type:epic", dispatched);
+		driveClassify(2, "type:bug", dispatched);
+		driveClassify(3, "type:feature", dispatched);
+		driveClassify(4, "type:chore", dispatched);
+		driveClassify(5, "type:investigation", dispatched);
+		expect(dispatched).toEqual(["planner", "coder", "coder", "coder", "coder"]);
+	});
+});


### PR DESCRIPTION
Fixes #4113

## What was broken

`.claude/workflows/drive-issue.js` ran a Classify stage whose whole purpose was type-driven routing, then threw the answer away. `klass.type` was used in exactly one place — a log line — and the sole branch was `if (klass.isEpic)`. Routing was therefore binary: **epic → planner, everything else → the coder**. A `type:decision` issue landed in a coder lane *by construction*, and the coder's spawn prompt hardcoded the wrong deliverable for it ("implement it on a branch, open a PR that closes it with `Fixes #N`").

That fired on #4045. #4000 was sitting there as the next exposure.

## What changed

**The type is the router, and there is no default arm.** `LANE_BY_TYPE` names every one of the six canonical types:

| type | lane | why |
|---|---|---|
| `type:epic` | `planner` | unchanged — the deliverable is a planned child ledger |
| `type:decision` | **`adr`** | the deliverable is a recorded `.decisions/NNNN-slug.md`, not a diff |
| `type:feature` / `type:chore` / `type:bug` | `coder` | unchanged — the implement-and-PR path |
| `type:investigation` | `coder` | an **explicitly named entry**, justified in the table: `write-code` owns *both* of a diagnosis's outcomes — the residue path and the bounded collapse into one PR (ADR 0070) — so the coder lane is defensible for an investigation in a way it is never defensible for a decision |
| anything else | **abort** | structured `{ unroutable, issue, type, reason }`; **no agent spawns at all** |

**Fail closed means refuse to dispatch, never "dispatch the coder anyway."** The coder is the lane with side effects — a branch, a PR, a shipped position — so a default that falls into it converts every classification failure into shipped work. An absent, empty, unknown, ambiguous, or unparseable type stops the run with a structured, resumable result distinct from every other terminal shape the flow returns (`skipped`, `backedOff`, `frozen`, `aborted`), so a driving session can tell "this issue's type does not name a lane" apart from a lost claim or a dead subagent, and can resume after a human fixes the label. The Classify stage's prompt is fail-closed to match: no `type:*` label, more than one, or unreadable labels ⇒ return `type: ""`, never a guess.

**The Classify stage now returns the type alone.** The `isEpic` boolean was a second source of truth for the same fact, free to disagree with the label that decides the lane.

**The decision branch is terminal, like the planner branch.** The `adr` agent adds exactly one ADR file and explicitly does not open a PR, review, or merge; landing that file's PR is a separate seam this routing fix deliberately does not invent. Stopping at the recorded ADR is strictly better than the status quo of shipping an invented answer, and it mirrors the epic branch, which also terminates without a ship.

## Where the guard sits — lane entry, not merge

Deliberately at the point a lane is *entered*. A merge-path check on the linked issue's type would be a direction gate on finished work, which founder no-go **#3909** forbids outright and #3947 restates as "Nothing changes at merge." **No required PR check was added**, and nothing reds a finished PR for the type of its linked issue.

## Shape

The decision lives as a unit-tested pure core in `packages/pipeline-cli/src/tools/drive-issue-flow/type-route.ts`; the workflow inlines its mirror. That is the established idiom for this file (`post-build.ts` / `resume-cap.ts` / `trivial-diff/route.ts`): a workflow script — top-level `return`, injected globals — is not importable, and `.claude/workflows/drive-issue.js` is `adoption-lint`'s one sanctioned `mirror` exemption. `TypeRoute` is a discriminated union, so an unroutable classification has no `lane` field to reach for — an abort cannot be misread as a coder lane.

## Acceptance criteria

- [x] `drive-issue.js` routes on the `type:*` label: `type:decision` → `adr`, `type:epic` → planner, `type:feature`/`type:chore`/`type:bug` → coder.
- [x] `type:investigation` is an explicitly named branch with its choice justified in the code (the `LANE_BY_TYPE` docblock and its `REASON_BY_TYPE` entry, citing ADR 0070), not an unnamed fall-through.
- [x] An unknown or missing type aborts with a structured, resumable result and spawns **no** coder — 16 unreadable/unknown cases are each asserted to refuse.
- [x] Covered by a test at the routing seam, in the `drive-issue-flow/` pure-core + thin-shell idiom the flow already uses.
- [x] Re-dispatching #4000 (`type:decision`) routes to the ADR seam, not a coder lane — asserted by name in `type-route.unit.test.ts`.

## Verification

- `pnpm --filter @kampus/pipeline-cli test` — 167 files / 2532 tests green (24 new).
- `pnpm typecheck` — 29/29 green.
- `pnpm lint:worktree` — clean.
- `node --check .claude/workflows/drive-issue.js` — green, plus a parity check that extracts the workflow's inlined table and re-runs the pure core's cases against it.

## Out of scope, noted

- **The general machine-readable-dependency problem** (`requires:` edges / prose-only `[BLOCKED until #N]` constraints invisible to a board sweep) is **#4195**'s territory, not touched here.
- **`write-code`'s picker still has no type filter** (skill Step 1 keys on `status:triaged` + priority + unassigned). Its `## Type routing` section already corrects by type *after* the claim, and the ACs here scope to the orchestrator, so the narrow reading was taken: this PR fixes the dispatch seam, not the direct `/write-code` pick predicate.
- **The decision lane's PR + gate handoff** — the `adr` agent authors the ADR file but does not open its PR; the drive-issue decision branch therefore terminates at the recorded ADR.
