### PR TITLE
feat(pipeline-cli): verify the push landed the ref, with a verdict a pipe can't eat (#4213)

### DIFF
--- a/.github/workflows/skill-gh-lint.yml
+++ b/.github/workflows/skill-gh-lint.yml
@@ -1,12 +1,16 @@
 name: skill-gh-lint
 
-# Two mechanical gates over the skill+agent corpus, both in pipeline-cli's
+# Three mechanical gates over the skill+agent corpus, all in pipeline-cli's
 # `gh-phoenix lint-skills` mode (match logic lives once in lint.ts, never re-grepped here):
 #   1. REST-only-on-this-org (#743): FAIL on any GraphQL-path `gh` invocation
 #      (`gh project`, GraphQL `gh pr/issue edit`, `gh api graphql`).
 #   2. Frontmatter YAML validity (#1766): FAIL on any SKILL.md / agents/*.md whose
 #      `---`-fenced frontmatter does not parse as strict YAML (the recurring
 #      unquoted-`description:`-with-a-colon-space defect that breaks GitHub's renderer).
+#   3. Sanctioned push path (#4213): FAIL on a git push invocation in any RUNNABLE block
+#      (a fenced shell block, or a whole .sh) — a bare push cannot report whether the ref
+#      landed, so `pipeline-cli verified-push` is the only sanctioned path. Prose ABOUT a
+#      bare push is untouched; the skills have to explain why it is forbidden.
 #
 # Scans the FULL corpus (not just changed files) so a bad call/frontmatter anywhere
 # is caught regardless of which PR introduced it, and FAILS CLOSED on zero scope per
@@ -27,7 +31,7 @@ permissions:
 
 jobs:
   lint:
-    name: lint skill corpus for GraphQL-path gh calls + invalid YAML frontmatter
+    name: lint skill corpus for GraphQL-path gh calls + invalid YAML frontmatter + bare git push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -46,8 +50,8 @@ jobs:
       # subagent definitions, also frontmatter-bearing #1766). Root the walk at the
       # plugin dir so both are covered; hand the CLI every .md/.sh file. The tool
       # self-scopes (gh-grep drops self-exempt files; the frontmatter check scopes to
-      # SKILL.md / agents/*.md) and fails closed (exit 3) if either scope is empty
-      # (ADR 0092).
+      # SKILL.md / agents/*.md; the push check takes every .md/.sh) and fails closed
+      # (exit 3) if ANY scope is empty (ADR 0092).
       - name: Lint skill + agent corpus
         run: |
           set -euo pipefail

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -844,6 +844,36 @@ is intentionally left untouched here so the two changes can't double-implement o
 > `$WT`; for every edit, confirm the path begins with `$WT`. Treat a primary-checkout absolute path
 > in your context as **stale** (cwd-reset + Read-cache), not as your worktree.
 
+<a id="pushing-the-verdict-is-the-ref-not-the-exit-code"></a>
+> **Pushing: the verdict is the ref, not the exit code — always `pipeline-cli verified-push` (#4213).**
+> A push is the one mutation whose failure is **invisible by default**, and not because of git.
+> Two observation-layer defects destroy the signal independently: piping a push through `tail`
+> reports `tail`'s status (`pipefail` is **off** on this platform, measured — so the pipeline
+> returns 0 however git died), and a **detached** run's output file carries **no exit status at
+> all**, so success gets inferred from the absence of an `error:` line — which is exactly what a
+> SIGPIPE'd git, printing nothing, looks like. Both fired on one lane (#4042 / PR #4142): the
+> branch simply was not there, and every downstream stage — reviewer checkout, SHA-bound verdict,
+> shipper merge — assumed a branch that did not exist.
+>
+> So **never invoke git's push porcelain directly from this skill.** Use `pipeline-cli
+> verified-push`, which pushes and then reads the remote ref back independently, and emits its
+> verdict as a single grep-able line **last on stdout** — `PUSH-VERDICT: MOVED`, `NOT-MOVED`, or
+> `UNKNOWN` — *in addition to* the exit code (0 / 1 / 3). stdout is the one channel that survives
+> **both** masking layers, so `… | tail -1` now yields *exactly* the verdict instead of erasing
+> it, and a detached run's output file ends with it.
+>
+> **Three outcomes, and the third is not a success.** `MOVED` means the remote ref was confirmed
+> at your local head. `NOT-MOVED` means it was confirmed *not* to be. `UNKNOWN` means the probe
+> could not determine it — a dead transport, an unresolvable head, a ref that matches while the
+> push itself misbehaved. Treat `UNKNOWN` exactly like a failure: **stop and surface it.** Do not
+> re-run the push hoping it takes (the verb deliberately does not retry — a blind retry hides the
+> contention it exists to expose, #4136), and do not proceed to open a PR, request a re-review, or
+> report the work landed.
+>
+> This is enforced mechanically, not by attention (ADR 0202): `pipeline-cli gh-phoenix lint-skills`
+> reds on a git push invocation in any runnable block of the skill corpus and fails closed on zero
+> scope, so a bare push cannot re-enter this file.
+
 This constrains how you branch: `main`
 is already checked out in the primary tree, so `git checkout main` **fails** inside an
 isolated worktree (`fatal: 'main' is already checked out at <primary>`). Branch from
@@ -1534,7 +1564,12 @@ re-derive them here. Two operational points that are yours, not the contract's:
 # just re-cd'd to $WT, so the checked-out branch IS the work branch. Read it, never guess it.
 wt_preflight && BRANCH="$(git -C "$WT" branch --show-current)"
 : "${BRANCH:?could not re-derive branch from worktree $WT — refusing to push to a guessed/cached ref}"
-git -C "$WT" push -u origin "$BRANCH"   # gate the push ([per-mutation preflight]); branch re-derived live, never cross-lane-cached
+# The SANCTIONED push path — see [Pushing: the verdict is the ref, not the exit code]. It pushes
+# AND independently confirms the remote ref, printing its verdict LAST on stdout. Exit 0 = MOVED,
+# 1 = NOT-MOVED, 3 = UNKNOWN; STOP on either non-zero — never open a PR against a branch you
+# cannot prove exists (an UNKNOWN is not a success).
+wt_preflight && pipeline-cli verified-push --cwd "$WT" --remote origin --branch "$BRANCH" --set-upstream \
+  || { echo "write-code: the push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — refusing to open a PR against an unproven branch." >&2; exit 1; }
 # The PR opens AGAINST issue #N (Fixes #N) — gate it on the mis-attribution guard (Step 3.5): open a
 # PR closing only an issue whose claim is mine, never one mis-attributed to another agent's #N.
 claim_is_mine "<N>" || { echo "refusing to open a PR against #<N> — not my claim (Step 3.5)"; exit 1; }
@@ -2178,7 +2213,12 @@ unreliable in this org).
 # reset can't move the claim, but the guard is MANDATED before every number-targeting mutation,
 # exactly as wt_preflight is before every git op; gate both the push and the progress comment.
 claim_is_mine "$N" || { echo "refusing to push/comment — PR #$PR linked issue #$N not my claim (Step 3.5)"; exit 1; }
-wt_preflight && git push --force-with-lease origin HEAD   # gate the push ([per-mutation preflight]); --force-with-lease because the R2 rebase onto origin/main moved the head
+# The SANCTIONED push path ([Pushing: the verdict is the ref, not the exit code]) — force-with-lease
+# because the R2 rebase onto origin/main moved the head. It confirms the remote ref carries the
+# rebased head before you claim the resubmit landed; exit 0 = MOVED, 1 = NOT-MOVED, 3 = UNKNOWN.
+# STOP on either non-zero: a reviewer waiting on a moved head would otherwise re-gate the STALE one.
+wt_preflight && pipeline-cli verified-push --cwd "$WT" --remote origin --force-with-lease \
+  || { echo "write-code: the repair push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — the gate would re-run against the STALE head. Do not report the resubmit as landed." >&2; exit 1; }
 # compose the repair note under the §SP per-run scratch namespace, never a fixed /tmp leaf:
 # concurrent repair lanes clobber a shared name and this posts THEIR note onto your issue (#3718).
 # Session-keyed and deterministic, so the note you wrote in an earlier Bash call is still here.

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -2171,7 +2171,8 @@ fixes. Two outcomes:
   incoming `main` change and your branch's intent), `git add` the resolved files, `git rebase
   --continue`, and only then apply the review findings on top. Do **not** `git rebase --abort`
   and push the stale base — that just re-buries the conflict until merge. Because a rebase moves
-  the head, the eventual R3 push is a force-push (`git push --force-with-lease origin HEAD`), and
+  the head, the eventual R3 push needs `--force-with-lease` (pass that flag to the R3
+  `pipeline-cli verified-push` — never a bare push, which the corpus lint rejects), and
   the fresh re-review re-binds the verdict to the new head (the [rebase → re-review → ship is
   atomic](#a-rebase-invalidates-the-pass--rebase--re-review--ship-is-atomic) rule already covers
   this — the R3 push *is* that head-move, and the independent gate re-reviews it).

--- a/packages/pipeline-cli/TOOLS.md
+++ b/packages/pipeline-cli/TOOLS.md
@@ -374,6 +374,63 @@ This is a **control-plane** surface (it guards the shared primary checkout's `ma
 [`.patterns/worktree-agent-constraints.md`](../../.patterns/worktree-agent-constraints.md)
 for the surrounding primary-checkout discipline it completes.
 
+### `verified-push` — push and confirm the ref moved, with a verdict that survives a pipe (#4213)
+
+The **sanctioned push path** for the pipeline skills. It runs the push, then reads the remote
+ref back with an independent `git ls-remote`, and reports one of **three** outcomes — never two:
+
+| verdict line (last on stdout) | exit | meaning |
+| --- | --- | --- |
+| `PUSH-VERDICT: MOVED …` | 0 | the remote ref is confirmed at your local head |
+| `PUSH-VERDICT: NOT-MOVED …` | 1 | the ref is confirmed *not* to carry it (absent, or at another commit) |
+| `PUSH-VERDICT: UNKNOWN …` | 3 | it could not be determined — **never a success** |
+
+**Why a verb at all, when `git push` already returns a status.** Two observation-layer
+defects — neither of them git's — destroyed that status in practice (#4146, the remedy half of
+which this is):
+
+1. `git push … | tail -N` reports `tail`'s status. `pipefail` is **off** on this platform
+   (measured), so the pipeline returns 0 however git died. It is the *dominant* idiom, because
+   the `pre-push` hook's output is long enough that agents reach for `tail` by reflex.
+2. A **detached** run's output file carries **no exit status at all**, so success gets inferred
+   from the absence of an `error:` line — and a SIGPIPE'd git prints nothing, which is exactly
+   what that absence looks like.
+
+Both layers destroy the *exit code*, so an exit-code-only verdict defeats neither. The one
+channel that survives a pipe **and** a detached output-file read is **stdout**, so the verdict
+is a single grep-able terminal line emitted **last on stdout**, in addition to the exit code —
+`… | tail -1` now yields *exactly* the verdict instead of erasing it. The whole report goes to
+one stream on purpose: splitting it across stdout and stderr would let a stderr line land after
+the verdict under `2>&1 | tail`.
+
+And even an unmasked exit status answers *"did the process fail"*, not *"did the ref move"* —
+the ref is the fact every downstream stage assumes (reviewer checkout, SHA-bound verdict,
+shipper merge), so the verdict is decided by the independent ref read, never by the push's own
+self-report. `MOVED` requires positive evidence on both: the ref resolved at the expected sha
+**and** the push itself ran cleanly.
+
+**No retry, deliberately.** A blind re-push would have "worked" for the #4042 lane and would
+have buried #4136's transport mechanism — the contention this verb exists to expose. It is also
+unsound on its own terms: the verb cannot tell a transient transport death from a rejected
+non-fast-forward, so a retry loop would hammer a legitimately refused push. The caller decides.
+
+The probe is bounded by `execFileSync`'s own `timeout` option — a portable Node bound, **never**
+the `timeout(1)` binary, which is absent on this platform (#3411), where a bare `timeout …`
+would exit command-not-found and, under masking layer 1, read as success.
+
+```bash
+# initial branch push (write-code Step 5)
+node packages/pipeline-cli/src/bin.ts verified-push --cwd "$WT" --remote origin --branch "$BRANCH" --set-upstream
+# repair resubmit after a rebase moved the head (write-code Step R3); branch re-derived live
+node packages/pipeline-cli/src/bin.ts verified-push --cwd "$WT" --remote origin --force-with-lease
+# exit 0 = MOVED · 1 = NOT-MOVED · 3 = UNKNOWN. Treat 3 exactly like a failure.
+```
+
+This is a **control-plane** surface: `gh-phoenix lint-skills` reds on a git push invocation in
+any runnable block of the skill corpus (fails closed on zero scope, ADR 0092), which is what
+makes this verb the *only* sanctioned path rather than merely the available one — mechanical
+enforcement, not attention-based (ADR 0202).
+
 ### `ship-digest` — the merged-since founder projection (#1595)
 
 Renders a **founder-facing** ship digest for a `--since` window from a pre-gathered

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -152,6 +152,9 @@ export const registeredTools: ReadonlyArray<ToolRegistration> = [
 	),
 	tool("main-sync", () => import("./tools/main-sync/command.ts").then((m) => m.mainSyncCommand)),
 	tool("ref-guard", () => import("./tools/ref-guard/command.ts").then((m) => m.refGuardCommand)),
+	tool("verified-push", () =>
+		import("./tools/verified-push/command.ts").then((m) => m.verifiedPushCommand),
+	),
 	tool("primary-index-guard", () =>
 		import("./tools/primary-index-guard/command.ts").then((m) => m.primaryIndexGuardCommand),
 	),

--- a/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
@@ -4,13 +4,14 @@
  * The skill grep-lint for issue #743 (the pure `lintCorpus` core), moved into the
  * pipeline-cli registry (epic #994, Phase 2 / #1002). Lints the handed skill-corpus
  * files for GraphQL-path `gh` invocations (Projects-classic-only on the kamp-us org)
- * AND for invalid YAML frontmatter (#1766 — the durable gate for the unquoted-scalar
- * colon-space defect), emits both checks' scanned scope, and FAILS CLOSED on zero
- * scope per ADR 0092:
+ * for invalid YAML frontmatter (#1766 — the durable gate for the unquoted-scalar
+ * colon-space defect), AND for a bare `git push` in an executable block (#4213 — the
+ * sanctioned path is `pipeline-cli verified-push`), emits each check's scanned scope, and
+ * FAILS CLOSED on zero scope per ADR 0092:
  *
- *   exit 0 — clean (no GraphQL-path gh calls, all frontmatter parses as strict YAML)
- *   exit 2 — one or more findings (a gh-call finding OR an invalid-frontmatter finding)
- *   exit 3 — zero scope in EITHER check (ADR 0092: zero scope is a FAIL, never a silent PASS)
+ *   exit 0 — clean (no GraphQL-path gh calls, no bare push, frontmatter parses)
+ *   exit 2 — one or more findings from any check
+ *   exit 3 — zero scope in ANY check (ADR 0092: zero scope is a FAIL, never a silent PASS)
  *
  * The `lint-skills` surface + its exit-code/stdout contract is preserved byte-for-byte
  * from the former package's `bin.ts`. The exit-3/exit-2 mapping, formerly done at the
@@ -69,10 +70,11 @@ const judge = (result: LintResult): Effect.Effect<void, ZeroScope | FindingsFoun
 			return yield* Effect.fail(new ZeroScope());
 		}
 
-		const total = result.findings.length + result.frontmatterFindings.length;
+		const total =
+			result.findings.length + result.frontmatterFindings.length + result.barePushFindings.length;
 		if (total === 0) {
 			yield* Console.log(
-				"gh-phoenix lint-skills: clean — no GraphQL-path gh calls and all frontmatter parses as strict YAML.",
+				"gh-phoenix lint-skills: clean — no GraphQL-path gh calls, no bare `git push` in an executable block, and all frontmatter parses as strict YAML.",
 			);
 			return;
 		}
@@ -92,6 +94,15 @@ const judge = (result: LintResult): Effect.Effect<void, ZeroScope | FindingsFoun
 			);
 			for (const f of result.frontmatterFindings) {
 				yield* Console.error(`  ${f.file}: ${f.reason}`);
+			}
+		}
+
+		if (result.barePushFindings.length > 0) {
+			yield* Console.error(
+				`gh-phoenix lint-skills: FAIL — ${result.barePushFindings.length} bare \`git push\` invocation(s) in an executable block (the sanctioned path is \`pipeline-cli verified-push\`, #4213):`,
+			);
+			for (const f of result.barePushFindings) {
+				yield* Console.error(`  ${f.file}:${f.line}: ${f.matched} — ${f.reason}`);
 			}
 		}
 
@@ -127,6 +138,11 @@ const lintSkills = Command.make(
 				(result.frontmatterScanned.length > 0 ? `:` : ` (zero scope)`),
 		);
 		for (const f of result.frontmatterScanned) yield* Console.log(`  frontmatter-scanned: ${f}`);
+		yield* Console.log(
+			`gh-phoenix lint-skills: bare-push scan scanned ${result.barePushScanned.length} file(s)` +
+				(result.barePushScanned.length > 0 ? `:` : ` (zero scope)`),
+		);
+		for (const f of result.barePushScanned) yield* Console.log(`  push-scanned: ${f}`);
 
 		yield* judge(result).pipe(
 			Effect.catchTag("ZeroScope", onZeroScope),

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
@@ -176,8 +176,23 @@ export const checkFrontmatter = (file: string, content: string): FrontmatterFind
  * A `git push` invocation, allowing the option forms that appear at real push sites —
  * `git -C "$WT" push`, `git --git-dir=… push`, `git -c foo=bar push`. Anchored on the `git`
  * verb so prose that merely says "push" is never matched.
+ *
+ * The two alternatives inside the `*` are deliberately DISJOINT, and keeping them so is a
+ * security property of this line, not a style choice: this is the enforcement mechanism the
+ * whole check rests on, `skill-gh-lint.yml` runs it on every `pull_request`, and a hung job
+ * presents as *running* rather than failed — so a backtrackable pattern here is a wedge any
+ * crafted corpus line can pull. Two alternatives that can both consume the same token give
+ * k ways to split each of n tokens, i.e. exponential backtracking on input that never reaches
+ * `push` (CodeQL `js/redos`, #4217). Concretely, both of these were exponential and are gone:
+ *   - `--\S+=\S+\s+` alongside `-\S+\s+` — subsumed, and `\S+=\S+` re-split at every `=`
+ *     (165 chars → 75 s);
+ *   - `-[cC]\s+\S+\s+` alongside `-\S+\s+` with an unconstrained value token, which let a
+ *     `-c` run be consumed one token or two ways (140 chars → 64 s).
+ * The surviving disambiguator is `[^-\s]`: a `-c`/`-C` VALUE may not itself start with `-`,
+ * so exactly one alternative can ever consume a given token. 40 KB of the worst shapes now
+ * matches in under a millisecond, and `lint.unit.test.ts` pins that with a wall-clock bound.
  */
-const BARE_GIT_PUSH = /\bgit\s+(?:-[cC]\s+\S+\s+|--\S+=\S+\s+|-\S+\s+)*push\b/g;
+const BARE_GIT_PUSH = /\bgit\s+(?:-[cC]\s+[^-\s]\S*\s+|-\S+\s+)*push\b/g;
 
 /** Every file the bare-push check looks at: the whole handed-in corpus (`.md` + `.sh`). */
 export const isBarePushScoped = (path: string): boolean => {

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
@@ -12,6 +12,12 @@
  *     pre-flight`) reparses as a nested mapping and breaks GitHub's renderer
  *     (#1281 shipper.md ×2, #1769 release/SKILL.md) — the tolerant harness loader
  *     accepts it, strict parsers reject it, so it shipped uncaught ≥3×.
+ *  3. Bare `git push` in an executable block (issue #4213) — flags any `git … push`
+ *     inside a runnable shell block in the corpus, because a bare push cannot report
+ *     whether the ref landed: `| tail` eats its exit status (`pipefail` is off here)
+ *     and a detached run's output file carries no status at all, so a dead push reads
+ *     as a clean one. `pipeline-cli verified-push` is the sanctioned path; this check
+ *     is what makes that mechanical rather than attention-based (ADR 0202).
  *
  * Fails CLOSED on zero scope (ADR 0092): `lintCorpus` returns the set of files
  * scanned alongside the findings, and `isZeroScope` reports when nothing was
@@ -51,10 +57,14 @@ export interface LintResult {
 	readonly findings: ReadonlyArray<Finding>;
 	/** Files whose frontmatter block failed to parse as strict YAML (#1766). */
 	readonly frontmatterFindings: ReadonlyArray<FrontmatterFinding>;
+	/** Executable `git push` invocations in the corpus (#4213). */
+	readonly barePushFindings: ReadonlyArray<Finding>;
 	/** Every file path the gh-call scan looked at — its scope (ADR 0092). */
 	readonly scanned: ReadonlyArray<string>;
 	/** Every file path the frontmatter check looked at — its scope (ADR 0092). */
 	readonly frontmatterScanned: ReadonlyArray<string>;
+	/** Every file path the bare-push scan looked at — its scope (ADR 0092). */
+	readonly barePushScanned: ReadonlyArray<string>;
 }
 
 interface LintPattern {
@@ -163,6 +173,66 @@ export const checkFrontmatter = (file: string, content: string): FrontmatterFind
 };
 
 /**
+ * A `git push` invocation, allowing the option forms that appear at real push sites —
+ * `git -C "$WT" push`, `git --git-dir=… push`, `git -c foo=bar push`. Anchored on the `git`
+ * verb so prose that merely says "push" is never matched.
+ */
+const BARE_GIT_PUSH = /\bgit\s+(?:-[cC]\s+\S+\s+|--\S+=\S+\s+|-\S+\s+)*push\b/g;
+
+/** Every file the bare-push check looks at: the whole handed-in corpus (`.md` + `.sh`). */
+export const isBarePushScoped = (path: string): boolean => {
+	const p = normalize(path).toLowerCase();
+	return p.endsWith(".md") || p.endsWith(".sh");
+};
+
+/**
+ * A fence delimiter — ``` or ~~~ — after any blockquote prefix is stripped. The corpus nests
+ * runnable blocks inside blockquotes (`> ```bash`), so the prefix strip is what keeps those
+ * blocks in scope; without it the most safety-critical blocks in write-code would be invisible
+ * to this check.
+ */
+const stripQuotePrefix = (line: string): string => line.replace(/^\s*(?:>\s?)+/, "");
+
+const FENCE = /^\s*(?:```|~~~)/;
+
+/**
+ * `git push` inside an EXECUTABLE region — a fenced code block in markdown, or the whole file
+ * for a `.sh`. Scoping to code blocks is what lets the skills keep *writing about* a bare
+ * `git push` in prose (they must, to explain why it is forbidden) while making the runnable
+ * form impossible to ship. There is deliberately no per-line pragma and no self-exempt list:
+ * an escape hatch that an agent can reach for is the attention-based enforcement ADR 0202
+ * rules out, and today the corpus needs none — `pipeline-cli verified-push` covers every
+ * sanctioned push site.
+ */
+export const scanBarePush = (file: string, content: string): ReadonlyArray<Finding> => {
+	if (!isBarePushScoped(file)) return [];
+	const isShell = normalize(file).toLowerCase().endsWith(".sh");
+	const findings: Finding[] = [];
+	const lines = content.split("\n");
+	let inFence = isShell;
+	for (let i = 0; i < lines.length; i++) {
+		const raw = lines[i] ?? "";
+		const text = isShell ? raw : stripQuotePrefix(raw);
+		if (!isShell && FENCE.test(text)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (!inFence) continue;
+		BARE_GIT_PUSH.lastIndex = 0;
+		for (const match of text.matchAll(BARE_GIT_PUSH)) {
+			findings.push({
+				file,
+				line: i + 1,
+				matched: match[0].trim(),
+				reason:
+					"a bare `git push` cannot report whether the ref landed (`| tail` eats its exit status, a detached run's output file carries none) — use `pipeline-cli verified-push`, which confirms the remote ref and emits a PUSH-VERDICT terminal line on stdout (#4213)",
+			});
+		}
+	}
+	return findings;
+};
+
+/**
  * Scan the whole handed-in corpus. Runs BOTH checks and returns their findings
  * and their (independent) scopes. The caller pairs this with `isZeroScope` to
  * fail closed when EITHER scope is empty (ADR 0092).
@@ -172,25 +242,43 @@ export const lintCorpus = (files: ReadonlyArray<ScanFile>): LintResult => {
 	const findings: Finding[] = [];
 	const frontmatterScanned: string[] = [];
 	const frontmatterFindings: FrontmatterFinding[] = [];
+	const barePushScanned: string[] = [];
+	const barePushFindings: Finding[] = [];
 	for (const {file, content} of files) {
 		if (isFrontmatterScoped(file)) {
 			frontmatterScanned.push(file);
 			const fm = checkFrontmatter(file, content);
 			if (fm !== null) frontmatterFindings.push(fm);
 		}
+		// Deliberately NOT narrowed by `isSelfExempt`: write-code is the file that owns both
+		// push sites, so exempting it would exempt the only thing this check protects.
+		if (isBarePushScoped(file)) {
+			barePushScanned.push(file);
+			barePushFindings.push(...scanBarePush(file, content));
+		}
 		if (isSelfExempt(file)) continue;
 		scanned.push(file);
 		findings.push(...scanFile(file, content));
 	}
-	return {findings, frontmatterFindings, scanned, frontmatterScanned};
+	return {
+		findings,
+		frontmatterFindings,
+		barePushFindings,
+		scanned,
+		frontmatterScanned,
+		barePushScanned,
+	};
 };
 
 /**
- * Zero-scope test (ADR 0092): true when EITHER check scanned NO files. A
- * zero-scope run is a FAIL, never a silent PASS — a lint that looked at nothing
- * protects nothing. The caller maps `true` → non-zero exit. Both scopes must be
- * non-empty: a corpus with no frontmatter-bearing file is as broken a scope for
- * the frontmatter gate as an empty gh-call scope is for the grep.
+ * Zero-scope test (ADR 0092): true when ANY check scanned NO files. A zero-scope run
+ * is a FAIL, never a silent PASS — a lint that looked at nothing protects nothing. The
+ * caller maps `true` → non-zero exit. Every scope must be non-empty: a corpus with no
+ * frontmatter-bearing file is as broken a scope for the frontmatter gate as an empty
+ * gh-call scope is for the grep, and an empty push scope would silently stop enforcing
+ * the sanctioned push path.
  */
 export const isZeroScope = (result: LintResult): boolean =>
-	result.scanned.length === 0 || result.frontmatterScanned.length === 0;
+	result.scanned.length === 0 ||
+	result.frontmatterScanned.length === 0 ||
+	result.barePushScanned.length === 0;

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
@@ -6,6 +6,7 @@ import {
 	isZeroScope,
 	lintCorpus,
 	type ScanFile,
+	scanBarePush,
 	scanFile,
 } from "./lint.ts";
 
@@ -189,6 +190,82 @@ describe("lintCorpus — frontmatter findings + scope (ADR 0092)", () => {
 		// A corpus of only non-frontmatter files: gh-scan has scope, frontmatter check has none.
 		const result = lintCorpus([{file: "skills/foo/helper.sh", content: "echo hi"}]);
 		assert.strictEqual(result.frontmatterScanned.length, 0);
+		assert.isTrue(isZeroScope(result));
+	});
+});
+
+// #4213 — the bare-`git push` check. The corpus must be able to *talk about* a bare push
+// (it has to, to explain why it is forbidden) while the runnable form is impossible to ship.
+const fenced = (...body: ReadonlyArray<string>) => ["```bash", ...body, "```"].join("\n");
+
+describe("scanBarePush — executable `git push` only (#4213)", () => {
+	it("flags a bare `git push` inside a fenced shell block", () => {
+		const f = scanBarePush("skills/x/SKILL.md", fenced('git push -u origin "$BRANCH"'));
+		assert.strictEqual(f.length, 1);
+		assert.strictEqual(f[0]?.line, 2);
+		assert.include(f[0]?.reason ?? "", "verified-push");
+	});
+
+	it('flags the `git -C "$WT" push` form (the write-code Step-5 shape)', () => {
+		const f = scanBarePush("skills/x/SKILL.md", fenced('git -C "$WT" push -u origin "$BRANCH"'));
+		assert.strictEqual(f.length, 1);
+	});
+
+	it("flags a force-push (the write-code Step-R3 shape)", () => {
+		const f = scanBarePush(
+			"skills/x/SKILL.md",
+			fenced("wt_preflight && git push --force-with-lease origin HEAD"),
+		);
+		assert.strictEqual(f.length, 1);
+	});
+
+	it("flags a push inside a BLOCKQUOTED fence — the corpus nests its most critical blocks that way", () => {
+		const content = ["> ```bash", "> git push origin HEAD", "> ```"].join("\n");
+		assert.strictEqual(scanBarePush("skills/x/SKILL.md", content).length, 1);
+	});
+
+	it("does NOT flag prose mentioning `git push` outside any fence", () => {
+		const content = "A `git push`/`git commit` op after a cwd reset runs in the primary tree.";
+		assert.strictEqual(scanBarePush("skills/x/SKILL.md", content).length, 0);
+	});
+
+	it("does NOT flag the sanctioned verb, which contains no `git push` at all", () => {
+		const f = scanBarePush(
+			"skills/x/SKILL.md",
+			fenced('pipeline-cli verified-push --cwd "$WT" --branch "$BRANCH" --set-upstream'),
+		);
+		assert.strictEqual(f.length, 0);
+	});
+
+	it("does NOT flag a placeholder like `git <commit|push|switch …>`", () => {
+		assert.strictEqual(
+			scanBarePush("skills/x/SKILL.md", fenced("git <commit|push|switch …>")).length,
+			0,
+		);
+	});
+
+	it("treats a .sh file as executable throughout (no fence needed)", () => {
+		assert.strictEqual(scanBarePush("hooks/deploy.sh", "git push origin main\n").length, 1);
+	});
+
+	it("is out of scope for a non-.md/.sh file", () => {
+		assert.strictEqual(scanBarePush("src/thing.ts", "git push origin main").length, 0);
+	});
+});
+
+describe("lintCorpus — bare-push findings + scope (ADR 0092)", () => {
+	it("does NOT exempt write-code, the very file that owns both push sites", () => {
+		const result = lintCorpus([
+			{file: "skills/write-code/SKILL.md", content: fenced('git push -u origin "$BRANCH"')},
+		]);
+		assert.strictEqual(result.findings.length, 0); // gh-grep self-exempt
+		assert.strictEqual(result.barePushFindings.length, 1); // push check is NOT
+		assert.deepStrictEqual([...result.barePushScanned], ["skills/write-code/SKILL.md"]);
+	});
+
+	it("is zero scope — a FAIL — when the push check was handed nothing to scan", () => {
+		const result = lintCorpus([{file: "agents/coder.txt", content: "git push origin main"}]);
+		assert.strictEqual(result.barePushScanned.length, 0);
 		assert.isTrue(isZeroScope(result));
 	});
 });

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
@@ -251,6 +251,59 @@ describe("scanBarePush — executable `git push` only (#4213)", () => {
 	it("is out of scope for a non-.md/.sh file", () => {
 		assert.strictEqual(scanBarePush("src/thing.ts", "git push origin main").length, 0);
 	});
+
+	// #4217 — the pattern itself must not be wedgeable. This gate runs on every
+	// `pull_request` over a corpus anyone can add a line to, and a hung job presents as
+	// *running*, not failed, so a crafted line that never reaches `push` must still return.
+	// Both shapes below hung for 60+ SECONDS on real, shipped-at-the-time patterns; the 1 s
+	// bound is a ~60x margin over the fixed pattern's sub-millisecond time, so it pins the
+	// linearity without flaking on a loaded CI box. Deleting these is how the ambiguity
+	// silently comes back.
+	describe("is not exponentially backtrackable (#4217)", () => {
+		const boundedScan = (line: string) => {
+			const t0 = performance.now();
+			const findings = scanBarePush("skills/x/SKILL.md", fenced(line));
+			return {ms: performance.now() - t0, findings};
+		};
+
+		it("returns fast on a long `--a=b=c` run that never reaches `push`", () => {
+			// `--\S+=\S+\s+` overlapping `-\S+\s+`, re-split at every `=`: 165 chars → 74.8 s.
+			const {ms, findings} = boundedScan(`git ${"--a=b=c ".repeat(400)}x`);
+			assert.strictEqual(findings.length, 0);
+			assert.isBelow(ms, 1000);
+		});
+
+		it("returns fast on a long `-c` run that never reaches `push`", () => {
+			// `-[cC]\s+\S+\s+` overlapping `-\S+\s+` on a bare `-c` token: 140 chars → 64.0 s.
+			const {ms, findings} = boundedScan(`git ${"-c ".repeat(400)}x`);
+			assert.strictEqual(findings.length, 0);
+			assert.isBelow(ms, 1000);
+		});
+
+		it("returns fast on a mixed option flood that never reaches `push`", () => {
+			const {ms, findings} = boundedScan(`git ${"-c a=b --x=y -C /d ".repeat(200)}x`);
+			assert.strictEqual(findings.length, 0);
+			assert.isBelow(ms, 1000);
+		});
+
+		// The disambiguator (`[^-\s]` on the `-c` VALUE) must not have narrowed what matches.
+		it("still flags every real option form the push sites use", () => {
+			for (const line of [
+				"git -c a=b push",
+				"git -c user.name=x -C /d push origin main",
+				"git --git-dir=/x/.git push",
+				"git --no-pager push",
+				"git -c core.hooksPath=/dev/null push --force-with-lease origin HEAD",
+				"git -C /d -c a=b --git-dir=/x/.git push",
+			]) {
+				assert.strictEqual(
+					scanBarePush("skills/x/SKILL.md", fenced(line)).length,
+					1,
+					`expected a finding for: ${line}`,
+				);
+			}
+		});
+	});
 });
 
 describe("lintCorpus — bare-push findings + scope (ADR 0092)", () => {

--- a/packages/pipeline-cli/src/tools/verified-push/command.ts
+++ b/packages/pipeline-cli/src/tools/verified-push/command.ts
@@ -145,7 +145,7 @@ const remoteFlag = Flag.string("remote").pipe(
 const branchFlag = Flag.string("branch").pipe(
 	Flag.withDefault(""),
 	Flag.withDescription(
-		"the branch to push (default: the branch currently checked out in --cwd, re-derived live). A detached HEAD resolves to UNKNOWN and pushes nothing.",
+		"the branch to push (default: the branch currently checked out in --cwd, re-derived live). A detached HEAD resolves to UNKNOWN and pushes nothing. Naming a branch OTHER than the one checked out in --cwd yields NOT-MOVED, since the expected sha is always --cwd's HEAD.",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/verified-push/command.ts
+++ b/packages/pipeline-cli/src/tools/verified-push/command.ts
@@ -1,0 +1,244 @@
+/**
+ * The `verified-push` tool — `pipeline-cli verified-push [--cwd DIR] [--remote origin]
+ * [--branch NAME] [--set-upstream] [--force-with-lease]`.
+ *
+ * The sanctioned push path for the pipeline skills (#4213). It pushes AND independently
+ * confirms the remote ref, then emits a loud, grep-able TERMINAL LINE on stdout — the one
+ * channel that survives both masking layers a bare `git push` dies in (`| tail` eats the
+ * exit status; a detached run's output file carries none at all). The decision itself is the
+ * pure `decidePush` in `verified-push.ts`; this file is only the git boundary.
+ *
+ * Two properties of the output are load-bearing, not cosmetic:
+ *
+ *   - **Everything goes to stdout, and the verdict line is emitted LAST.** Splitting the
+ *     report across stdout and stderr would reintroduce the defect under `2>&1 | tail -1`:
+ *     inter-stream ordering is not guaranteed, so a stderr line could land after the verdict.
+ *     One stream is ordered by construction, so `… | tail -1` is *exactly* the verdict.
+ *   - **`Console.log` then `process.exit` does not truncate here.** Node's docs specify that
+ *     writes to `process.stdout` are synchronous for pipes on Linux/macOS (asynchronous only
+ *     on Windows), which is this platform and CI's; so the verdict cannot be lost to an
+ *     unflushed buffer on exit.
+ *
+ * The ref probe is `git ls-remote`, deliberately: it is a read-only, host-agnostic query
+ * over git's own transport, so it needs no REST surface, no auth beyond git's, and no repo
+ * literal (ADR 0062). Its tradeoff is honest — if the transport is dead, the probe fails and
+ * the verdict is UNKNOWN, which is precisely the loud third outcome, never a false pass.
+ *
+ * The probe carries a portable bound via `execFileSync`'s own `timeout` option, NOT the
+ * `timeout(1)` binary — which is ABSENT on this platform (#3411), where a bare `timeout …`
+ * would exit command-not-found and, under masking layer 1, read as success.
+ *
+ * There is no retry. See the core's docblock for the argument on the record.
+ */
+import {execFileSync} from "node:child_process";
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {
+	decidePush,
+	type PushAttempt,
+	type PushFacts,
+	type PushVerdict,
+	parseLsRemote,
+	type RefProbe,
+} from "./verified-push.ts";
+
+/**
+ * A portable Node-level bound on the read-only probe (never `timeout(1)`, #3411). Generous:
+ * a timeout resolves to UNKNOWN, so the only cost of being slow to give up is a later loud
+ * verdict, while being too eager would manufacture UNKNOWNs out of an ordinary slow network.
+ */
+const PROBE_TIMEOUT_MS = 60_000;
+
+interface RunResult {
+	readonly ok: boolean;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number | null;
+	readonly signal: string | null;
+}
+
+/**
+ * Run git with its output captured. A non-zero exit, a signal death, and a spawn failure are
+ * all absorbed into the returned record — the caller branches on the facts, so no failure is
+ * silently lost and none escapes to the E channel.
+ */
+const runGit = (args: ReadonlyArray<string>, timeoutMs?: number): RunResult => {
+	// biome-ignore lint/plugin: total boundary — every git failure mode (non-zero exit, signal death, spawn failure) is absorbed into the returned facts record that the pure core then judges, never the E channel; lifting to Effect.try would only re-collapse to the same record.
+	try {
+		const stdout = execFileSync("git", [...args], {
+			encoding: "utf8",
+			// Capture BOTH streams. `execFileSync` inherits stderr by default, which would let
+			// git's own output escape onto the parent's stderr — reintroducing exactly the
+			// cross-stream interleaving the single-stream report exists to prevent (and printing
+			// every git error twice). stdin stays inherited so an interactive credential/SSH
+			// prompt behaves as it does under a bare push.
+			stdio: ["inherit", "pipe", "pipe"],
+			...(timeoutMs === undefined ? {} : {timeout: timeoutMs}),
+		});
+		return {ok: true, stdout, stderr: "", exitCode: 0, signal: null};
+	} catch (cause) {
+		const e = cause as {
+			stdout?: Buffer | string;
+			stderr?: Buffer | string;
+			status?: number | null;
+			signal?: string | null;
+			message?: string;
+		};
+		return {
+			ok: false,
+			stdout: String(e.stdout ?? ""),
+			// A spawn failure (git absent, cwd gone) has no stderr — surface its message instead,
+			// so the UNKNOWN it produces still names what happened.
+			stderr: String(e.stderr ?? "") || String(e.message ?? ""),
+			exitCode: e.status ?? null,
+			signal: e.signal ?? null,
+		};
+	}
+};
+
+/** Read the remote ref back, independently of what the push claimed. */
+const probeRef = (cwd: string, remote: string, ref: string): RefProbe => {
+	const r = runGit(["-C", cwd, "ls-remote", remote, ref], PROBE_TIMEOUT_MS);
+	if (!r.ok) {
+		return {
+			kind: "failed",
+			detail: r.stderr.trim() || `git ls-remote exited ${r.exitCode ?? `signal ${r.signal}`}`,
+		};
+	}
+	const sha = parseLsRemote(r.stdout, ref);
+	// A successful ls-remote that lists nothing is POSITIVE evidence the ref is absent — that
+	// is the one "no output" this verb is allowed to read as a fact rather than as unknown,
+	// because the probe itself exited cleanly.
+	return sha === null ? {kind: "absent"} : {kind: "resolved", sha};
+};
+
+const cwdFlag = Flag.string("cwd").pipe(
+	Flag.withDefault(""),
+	Flag.withDescription(
+		"the worktree to push from (default: the process cwd). Pass your $WT so a between-calls cwd reset cannot push from the primary checkout.",
+	),
+);
+
+const remoteFlag = Flag.string("remote").pipe(
+	Flag.withDefault("origin"),
+	Flag.withDescription("the remote to push to (default: origin)"),
+);
+
+const branchFlag = Flag.string("branch").pipe(
+	Flag.withDefault(""),
+	Flag.withDescription(
+		"the branch to push (default: the branch currently checked out in --cwd, re-derived live). A detached HEAD resolves to UNKNOWN and pushes nothing.",
+	),
+);
+
+const setUpstreamFlag = Flag.boolean("set-upstream").pipe(
+	Flag.withDescription("pass -u, for the first push of a new branch"),
+);
+
+const forceWithLeaseFlag = Flag.boolean("force-with-lease").pipe(
+	Flag.withDescription(
+		"pass --force-with-lease, for a repair resubmit whose rebase moved the head",
+	),
+);
+
+/** Emit the whole report on ONE stream, verdict LAST — see the file docblock for why. */
+const report = (lines: ReadonlyArray<string>, verdict: PushVerdict) =>
+	Effect.gen(function* () {
+		for (const l of lines) yield* Console.log(l);
+		yield* Console.log(verdict.terminalLine);
+		return yield* Effect.sync(() => process.exit(verdict.exitCode));
+	});
+
+/** Indent captured git output so it can never be mistaken for one of this verb's own lines. */
+const quote = (label: string, text: string): ReadonlyArray<string> => {
+	const body = text.trimEnd();
+	if (body === "") return [`  ${label}: (no output)`];
+	return [`  ${label}:`, ...body.split("\n").map((l) => `    | ${l}`)];
+};
+
+const verifiedPush = Command.make(
+	"verified-push",
+	{
+		cwd: cwdFlag,
+		remote: remoteFlag,
+		branch: branchFlag,
+		setUpstream: setUpstreamFlag,
+		forceWithLease: forceWithLeaseFlag,
+	},
+	Effect.fn(function* ({cwd, remote, branch, setUpstream, forceWithLease}) {
+		const dir = cwd === "" ? process.cwd() : cwd;
+
+		const notAttempted = (detail: string, lines: ReadonlyArray<string>) =>
+			report(lines, decidePush({kind: "not-attempted", detail} satisfies PushFacts));
+
+		const top = runGit(["-C", dir, "rev-parse", "--show-toplevel"]);
+		if (!top.ok) {
+			return yield* notAttempted(`\`${dir}\` is not a git worktree`, [
+				`verified-push: resolving the worktree at ${dir}`,
+				...quote("git rev-parse", top.stderr),
+			]);
+		}
+		const worktree = top.stdout.trim();
+
+		// Re-derive the branch LIVE from the worktree unless one was named — the same rule the
+		// skill applies at its push sites: never a cached or cross-lane-carried ref.
+		const resolvedBranch =
+			branch !== "" ? branch : runGit(["-C", dir, "branch", "--show-current"]).stdout.trim();
+		if (resolvedBranch === "") {
+			return yield* notAttempted("HEAD is detached — there is no branch to push", [
+				`verified-push: worktree=${worktree}`,
+			]);
+		}
+
+		const headRead = runGit(["-C", dir, "rev-parse", "HEAD"]);
+		const expectedSha = headRead.stdout.trim();
+		if (!headRead.ok || expectedSha === "") {
+			return yield* notAttempted("the local HEAD commit could not be resolved", [
+				`verified-push: worktree=${worktree} branch=${resolvedBranch}`,
+				...quote("git rev-parse HEAD", headRead.stderr),
+			]);
+		}
+
+		const ref = `refs/heads/${resolvedBranch}`;
+		const pushArgs = [
+			"-C",
+			dir,
+			"push",
+			...(setUpstream ? ["--set-upstream"] : []),
+			...(forceWithLease ? ["--force-with-lease"] : []),
+			remote,
+			// Explicit src:dst so the push targets exactly the ref that gets probed, regardless of
+			// the remote's push.default / refspec configuration.
+			`${resolvedBranch}:${ref}`,
+		];
+
+		const lines: string[] = [
+			`verified-push: worktree=${worktree} branch=${resolvedBranch} head=${expectedSha}`,
+			// No `timeout` on the push itself: a slow push must be allowed to finish, and killing
+			// it would manufacture exactly the indeterminate state this verb exists to eliminate.
+			`verified-push: running \`git ${pushArgs.join(" ")}\``,
+		];
+		const pushed = runGit(pushArgs);
+		lines.push(...quote("push stdout", pushed.stdout), ...quote("push stderr", pushed.stderr));
+
+		const attempt: PushAttempt = {exitCode: pushed.exitCode, signal: pushed.signal};
+		lines.push(
+			`verified-push: probing the remote ref independently — \`git ls-remote ${remote} ${ref}\``,
+		);
+		const after = probeRef(dir, remote, ref);
+		lines.push(
+			`  probe: ${after.kind === "resolved" ? after.sha : after.kind === "absent" ? "ref absent on the remote" : `FAILED — ${after.detail}`}`,
+		);
+
+		return yield* report(
+			lines,
+			decidePush({kind: "attempted", remote, ref, expectedSha, attempt, after}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Push a branch AND confirm the remote ref moved, emitting a grep-able PUSH-VERDICT terminal line on stdout (MOVED / NOT-MOVED / UNKNOWN) that survives a `| tail` pipeline and a detached output-file read — the sanctioned replacement for a bare `git push` (#4213)",
+	),
+);
+
+export const verifiedPushCommand = verifiedPush;

--- a/packages/pipeline-cli/src/tools/verified-push/command.ts
+++ b/packages/pipeline-cli/src/tools/verified-push/command.ts
@@ -39,6 +39,7 @@ import {
 	type PushFacts,
 	type PushVerdict,
 	parseLsRemote,
+	quoteTail,
 	type RefProbe,
 } from "./verified-push.ts";
 
@@ -48,6 +49,22 @@ import {
  * verdict, while being too eager would manufacture UNKNOWNs out of an ordinary slow network.
  */
 const PROBE_TIMEOUT_MS = 60_000;
+
+/**
+ * Well above `execFileSync`'s 1 MB default, because exceeding `maxBuffer` **kills the child**
+ * — and the `pre-push` hook runs the whole test suite, whose output blew 1 MB on the very
+ * first live run of this verb. A push killed by the buffer limit is a manufactured failure of
+ * exactly the kind this verb exists to eliminate, so the limit must never be the thing that
+ * decides the verdict.
+ */
+const MAX_BUFFER_BYTES = 256 * 1024 * 1024;
+
+/**
+ * How many trailing lines of each captured stream to quote. The hook's output is thousands of
+ * lines; quoting it whole would bury the verdict under a wall the reader must scroll past, and
+ * the interesting part of a push (`* [new branch]`, a rejection) is always at the end.
+ */
+const QUOTED_TAIL_LINES = 40;
 
 interface RunResult {
 	readonly ok: boolean;
@@ -73,6 +90,7 @@ const runGit = (args: ReadonlyArray<string>, timeoutMs?: number): RunResult => {
 			// every git error twice). stdin stays inherited so an interactive credential/SSH
 			// prompt behaves as it does under a bare push.
 			stdio: ["inherit", "pipe", "pipe"],
+			maxBuffer: MAX_BUFFER_BYTES,
 			...(timeoutMs === undefined ? {} : {timeout: timeoutMs}),
 		});
 		return {ok: true, stdout, stderr: "", exitCode: 0, signal: null};
@@ -149,12 +167,8 @@ const report = (lines: ReadonlyArray<string>, verdict: PushVerdict) =>
 		return yield* Effect.sync(() => process.exit(verdict.exitCode));
 	});
 
-/** Indent captured git output so it can never be mistaken for one of this verb's own lines. */
-const quote = (label: string, text: string): ReadonlyArray<string> => {
-	const body = text.trimEnd();
-	if (body === "") return [`  ${label}: (no output)`];
-	return [`  ${label}:`, ...body.split("\n").map((l) => `    | ${l}`)];
-};
+const quote = (label: string, text: string): ReadonlyArray<string> =>
+	quoteTail(label, text, QUOTED_TAIL_LINES);
 
 const verifiedPush = Command.make(
 	"verified-push",

--- a/packages/pipeline-cli/src/tools/verified-push/verified-push.ts
+++ b/packages/pipeline-cli/src/tools/verified-push/verified-push.ts
@@ -111,6 +111,24 @@ export interface PushVerdict {
 /** Collapse to a single line: the terminal line must be greppable as ONE line, always. */
 const oneLine = (s: string): string => s.replace(/\s+/g, " ").trim();
 
+/**
+ * Quote the TAIL of a captured stream into the report, indented so it can never be mistaken
+ * for one of the verb's own lines. Only the trailing `maxLines` are kept: the `pre-push` hook
+ * emits thousands of lines, and the part of a push that carries meaning (` * [new branch]`, a
+ * rejection) is always at the end — quoting it whole would bury the verdict under a wall.
+ */
+export const quoteTail = (label: string, text: string, maxLines: number): ReadonlyArray<string> => {
+	const body = text.trimEnd();
+	if (body === "") return [`  ${label}: (no output)`];
+	const all = body.split("\n");
+	const kept = all.slice(Math.max(0, all.length - maxLines));
+	const elided = all.length - kept.length;
+	return [
+		`  ${label}:${elided > 0 ? ` (last ${kept.length} of ${all.length} lines; ${elided} elided)` : ""}`,
+		...kept.map((l) => `    | ${l}`),
+	];
+};
+
 /** `git ls-remote` prints `<sha>\t<ref>` per matching ref; `""` means the ref does not exist. */
 export const parseLsRemote = (stdout: string, ref: string): string | null => {
 	for (const line of stdout.split("\n")) {

--- a/packages/pipeline-cli/src/tools/verified-push/verified-push.ts
+++ b/packages/pipeline-cli/src/tools/verified-push/verified-push.ts
@@ -1,0 +1,199 @@
+/**
+ * `verified-push` pure core — decide whether a push actually landed the ref, given the
+ * already-gathered facts. IO-free and total; the git boundary (running the push, running
+ * the `ls-remote` probe) lives in `command.ts`.
+ *
+ * Why this exists (#4213, the remedy half of #4146): push success was *inferred* rather
+ * than observed, through two masking layers that are not git's fault at all —
+ *
+ *   1. `git push … | tail -N` reports `tail`'s status. `pipefail` is off on this platform
+ *      (measured, not assumed), so the pipeline returns 0 however git died.
+ *   2. A detached run's output file carries **no exit status at all**, so success gets
+ *      inferred from the absence of an `error:` line — and a SIGPIPE'd git prints nothing,
+ *      which is exactly what that absence looks like.
+ *
+ * Both layers destroy the *exit code*, so an exit-code-only verdict defeats neither. The
+ * one channel that survives a pipe **and** a detached output-file read is **stdout**, so
+ * the verdict is a single grep-able TERMINAL LINE emitted last on stdout, in addition to
+ * the exit code. `tail -1` now *preserves* the verdict instead of erasing it.
+ *
+ * And even an unmasked exit status answers "did the process fail", not "did the ref move".
+ * The ref is the fact every downstream stage assumes (reviewer checkout, SHA-bound verdict,
+ * shipper merge), so the verdict is decided by an independent read of the remote ref, never
+ * by the push's own self-report.
+ *
+ * Three outcomes, never two — `moved` / `not-moved` / `unknown`. `unknown` never collapses
+ * into success: only positive evidence (the remote ref resolved, and it carries the exact
+ * local head) yields `moved`. A probe that could not execute is `unknown`, never a pass and
+ * never a fail.
+ *
+ * **No retry, deliberately.** A blind re-push would have "worked" for the #4042 lane and
+ * would have buried #4136's transport mechanism, making the real defect harder to find — the
+ * contention this verb exists to expose would be silently absorbed. Retrying is also unsound
+ * on its own terms here: the verb cannot distinguish a transient transport death from a
+ * rejected non-fast-forward, so a retry loop would hammer a legitimately refused push. The
+ * caller decides what to do with a `not-moved`/`unknown`; this verb only reports it.
+ */
+
+/** The three outcomes. `unknown` is a first-class result, never a degraded success. */
+export type PushOutcome = "moved" | "not-moved" | "unknown";
+
+/**
+ * The single grep-able token per outcome, emitted as the LAST line on stdout. Callers (and
+ * the write-code skill) match on `PUSH-VERDICT: <TOKEN>`; keep these stable — they are the
+ * wire format, not a log string.
+ */
+export const VERDICT_PREFIX = "PUSH-VERDICT:";
+
+export const VERDICT_TOKEN: Readonly<Record<PushOutcome, string>> = {
+	moved: "MOVED",
+	"not-moved": "NOT-MOVED",
+	unknown: "UNKNOWN",
+};
+
+/**
+ * Exit codes, distinct per outcome so a caller that *does* read the status can tell a real
+ * failure from an indeterminate one. `unknown` gets its own code (3, the repo's established
+ * "dedicated, not 1" convention — see `ref-guard`'s `REFUSE_EXIT_CODE`) so it can never be
+ * mistaken for the ordinary failure path, and 0 is reserved for a *confirmed* landed ref.
+ */
+export const EXIT_CODE: Readonly<Record<PushOutcome, number>> = {
+	moved: 0,
+	"not-moved": 1,
+	unknown: 3,
+};
+
+/** What the `git push` process reported. `exitCode: null` = it could not be determined. */
+export interface PushAttempt {
+	readonly exitCode: number | null;
+	/** The signal that killed the push (`SIGPIPE`, …), or `null`. */
+	readonly signal: string | null;
+}
+
+/**
+ * The independent, read-only remote-ref probe. `failed` is the honest third state: the probe
+ * could not execute (no transport, timed out, unparseable output), which is *unknown* — never
+ * "the ref is absent", which is a positive claim the probe did not establish.
+ */
+export type RefProbe =
+	| {readonly kind: "resolved"; readonly sha: string}
+	| {readonly kind: "absent"}
+	| {readonly kind: "failed"; readonly detail: string};
+
+/**
+ * The gathered facts. `not-attempted` covers everything that went wrong *before* the push
+ * could be issued (cwd is not a repo, detached HEAD, unresolvable local head) — all of which
+ * are `unknown` rather than failure: nothing was pushed, so nothing about the remote is known.
+ */
+export type PushFacts =
+	| {readonly kind: "not-attempted"; readonly detail: string}
+	| {
+			readonly kind: "attempted";
+			readonly remote: string;
+			/** The full remote ref the push targeted, e.g. `refs/heads/umut/foo`. */
+			readonly ref: string;
+			/** The local commit the push was supposed to land. */
+			readonly expectedSha: string;
+			readonly attempt: PushAttempt;
+			/** The remote ref as read back AFTER the push, independently of the push's own report. */
+			readonly after: RefProbe;
+	  };
+
+export interface PushVerdict {
+	readonly outcome: PushOutcome;
+	/** One line, no newlines — it is embedded in the terminal line. */
+	readonly reason: string;
+	/** The exact last-line-on-stdout the caller greps. */
+	readonly terminalLine: string;
+	readonly exitCode: number;
+}
+
+/** Collapse to a single line: the terminal line must be greppable as ONE line, always. */
+const oneLine = (s: string): string => s.replace(/\s+/g, " ").trim();
+
+/** `git ls-remote` prints `<sha>\t<ref>` per matching ref; `""` means the ref does not exist. */
+export const parseLsRemote = (stdout: string, ref: string): string | null => {
+	for (const line of stdout.split("\n")) {
+		const [sha, name] = line.trim().split(/\s+/);
+		if (name === ref && sha !== undefined && /^[0-9a-f]{40}$/.test(sha)) return sha;
+	}
+	return null;
+};
+
+/** A push that neither exited 0 nor is even known to have exited — anything but a clean run. */
+const attemptIsClean = (a: PushAttempt): boolean => a.exitCode === 0 && a.signal === null;
+
+const describeAttempt = (a: PushAttempt): string =>
+	a.signal !== null
+		? `git push was killed by ${a.signal}`
+		: a.exitCode === null
+			? "git push's exit status could not be determined"
+			: `git push exited ${a.exitCode}`;
+
+const verdict = (
+	outcome: PushOutcome,
+	reason: string,
+	ctx: {readonly where: string; readonly observed: string} | null,
+): PushVerdict => {
+	const body = ctx === null ? "" : ` ${ctx.where} observed=${ctx.observed}`;
+	const line = oneLine(`${VERDICT_PREFIX} ${VERDICT_TOKEN[outcome]}${body} — ${reason}`);
+	return {outcome, reason: oneLine(reason), terminalLine: line, exitCode: EXIT_CODE[outcome]};
+};
+
+/**
+ * The whole decision. Ordered so that every path to `moved` requires POSITIVE evidence —
+ * the probe resolved AND it carries the expected sha AND the push itself ran cleanly. Every
+ * indeterminate fact routes to `unknown`; only a probe that positively established the remote
+ * ref is somewhere other than the local head yields `not-moved`.
+ */
+export const decidePush = (facts: PushFacts): PushVerdict => {
+	if (facts.kind === "not-attempted") {
+		return verdict("unknown", `no push was attempted — ${facts.detail}`, null);
+	}
+
+	const {remote, ref, expectedSha, attempt, after} = facts;
+	const where = `remote=${remote} ref=${ref} expected=${expectedSha}`;
+
+	if (after.kind === "failed") {
+		// The probe could not execute. This is the case the whole third outcome exists for:
+		// the push may well have landed, but nothing here PROVES it, so it must not pass.
+		return verdict(
+			"unknown",
+			`the remote-ref probe could not execute (${after.detail}) — the ref was neither confirmed nor refuted, so this is NOT a success; ${describeAttempt(attempt)}`,
+			{where, observed: "probe-failed"},
+		);
+	}
+
+	if (after.kind === "absent") {
+		return verdict(
+			"not-moved",
+			`${ref} does not exist on ${remote} after the push — the branch was NOT landed; ${describeAttempt(attempt)}`,
+			{where, observed: "absent"},
+		);
+	}
+
+	if (after.sha !== expectedSha) {
+		return verdict(
+			"not-moved",
+			`${ref} on ${remote} is at ${after.sha}, not the local head ${expectedSha} — the push did NOT land this commit; ${describeAttempt(attempt)}`,
+			{where, observed: after.sha},
+		);
+	}
+
+	if (!attemptIsClean(attempt)) {
+		// The postcondition holds but the operation misbehaved: someone else may have put that
+		// sha there, or git partially failed. Fail closed — report it, do not launder it into a
+		// pass just because the ref happens to match.
+		return verdict(
+			"unknown",
+			`${ref} on ${remote} IS at the local head ${expectedSha}, but ${describeAttempt(attempt)} — cannot attribute the landed ref to this push`,
+			{where, observed: after.sha},
+		);
+	}
+
+	return verdict(
+		"moved",
+		`${ref} on ${remote} confirmed at the local head ${expectedSha} by an independent ls-remote read`,
+		{where, observed: after.sha},
+	);
+};

--- a/packages/pipeline-cli/src/tools/verified-push/verified-push.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verified-push/verified-push.unit.test.ts
@@ -1,0 +1,141 @@
+import {describe, expect, it} from "vitest";
+import {
+	decidePush,
+	EXIT_CODE,
+	type PushAttempt,
+	type PushFacts,
+	parseLsRemote,
+	type RefProbe,
+	VERDICT_PREFIX,
+} from "./verified-push.ts";
+
+const HEAD = "a".repeat(40);
+const OTHER = "b".repeat(40);
+const REF = "refs/heads/umut/some-branch";
+
+const clean: PushAttempt = {exitCode: 0, signal: null};
+
+const attempted = (after: RefProbe, attempt: PushAttempt = clean): PushFacts => ({
+	kind: "attempted",
+	remote: "origin",
+	ref: REF,
+	expectedSha: HEAD,
+	attempt,
+	after,
+});
+
+/** The terminal line is the wire format: exactly one line, starting with the grep token. */
+const expectTerminalLine = (line: string, token: string) => {
+	expect(line.split("\n")).toHaveLength(1);
+	expect(line.startsWith(`${VERDICT_PREFIX} ${token} `)).toBe(true);
+};
+
+describe("decidePush — the three outcomes", () => {
+	it("MOVED only on positive evidence: the probe resolved the ref at the local head after a clean push", () => {
+		const v = decidePush(attempted({kind: "resolved", sha: HEAD}));
+		expect(v.outcome).toBe("moved");
+		expect(v.exitCode).toBe(0);
+		expectTerminalLine(v.terminalLine, "MOVED");
+		expect(v.terminalLine).toContain(`observed=${HEAD}`);
+	});
+
+	it("NOT-MOVED when the remote ref does not exist after the push", () => {
+		const v = decidePush(attempted({kind: "absent"}, {exitCode: 1, signal: null}));
+		expect(v.outcome).toBe("not-moved");
+		expect(v.exitCode).toBe(1);
+		expectTerminalLine(v.terminalLine, "NOT-MOVED");
+	});
+
+	it("NOT-MOVED when the remote ref exists but carries a different commit", () => {
+		const v = decidePush(attempted({kind: "resolved", sha: OTHER}));
+		expect(v.outcome).toBe("not-moved");
+		expect(v.terminalLine).toContain(`observed=${OTHER}`);
+	});
+
+	it("UNKNOWN when the ref probe could not execute — never collapsed into success", () => {
+		const v = decidePush(attempted({kind: "failed", detail: "ls-remote timed out"}));
+		expect(v.outcome).toBe("unknown");
+		expect(v.exitCode).toBe(EXIT_CODE.unknown);
+		expect(v.exitCode).not.toBe(EXIT_CODE.moved);
+		expectTerminalLine(v.terminalLine, "UNKNOWN");
+		expect(v.reason).toContain("could not execute");
+	});
+
+	it("UNKNOWN when no push was attempted at all (detached HEAD, unresolvable head, not a repo)", () => {
+		const v = decidePush({kind: "not-attempted", detail: "HEAD is detached"});
+		expect(v.outcome).toBe("unknown");
+		expectTerminalLine(v.terminalLine, "UNKNOWN");
+	});
+
+	it("UNKNOWN when the ref matches but the push itself did not run cleanly — the match is not attributed", () => {
+		const v = decidePush(attempted({kind: "resolved", sha: HEAD}, {exitCode: 128, signal: null}));
+		expect(v.outcome).toBe("unknown");
+		expect(v.reason).toContain("cannot attribute");
+	});
+});
+
+describe("decidePush — the masked-failure shapes this exists to catch", () => {
+	// The #4146 signature: a SIGPIPE'd git prints nothing and, piped through `tail`, reports 0.
+	// The verdict must not depend on the push's self-report at all.
+	it("a SIGPIPE'd push whose ref did not land is NOT-MOVED, whatever it reported", () => {
+		const v = decidePush(attempted({kind: "absent"}, {exitCode: null, signal: "SIGPIPE"}));
+		expect(v.outcome).toBe("not-moved");
+		expect(v.reason).toContain("SIGPIPE");
+	});
+
+	it("an exit-0 push whose ref did not land is still NOT-MOVED (exit status is not the fact)", () => {
+		const v = decidePush(attempted({kind: "absent"}, clean));
+		expect(v.outcome).toBe("not-moved");
+	});
+
+	it("an undeterminable exit status with a confirmed landed ref is UNKNOWN, not MOVED", () => {
+		const v = decidePush(attempted({kind: "resolved", sha: HEAD}, {exitCode: null, signal: null}));
+		expect(v.outcome).toBe("unknown");
+	});
+});
+
+describe("the terminal line — the channel that survives a pipe and a detached read", () => {
+	it("every outcome emits exactly one greppable line carrying its own token", () => {
+		const lines = [
+			decidePush(attempted({kind: "resolved", sha: HEAD})).terminalLine,
+			decidePush(attempted({kind: "absent"})).terminalLine,
+			decidePush(attempted({kind: "failed", detail: "boom"})).terminalLine,
+		];
+		expect(lines.map((l) => l.split(" ")[1])).toEqual(["MOVED", "NOT-MOVED", "UNKNOWN"]);
+		for (const l of lines) expect(l.split("\n")).toHaveLength(1);
+	});
+
+	it("a multi-line probe detail is collapsed so the terminal line stays a single line", () => {
+		const v = decidePush(attempted({kind: "failed", detail: "fatal: could not read\nfrom remote"}));
+		expect(v.terminalLine.split("\n")).toHaveLength(1);
+		expect(v.terminalLine).toContain("could not read from remote");
+	});
+
+	it("the three tokens are mutually distinguishable by a whole-token grep", () => {
+		const moved = decidePush(attempted({kind: "resolved", sha: HEAD})).terminalLine;
+		// NOT-MOVED contains "MOVED" as a substring, so the token must be matched with its
+		// prefix — the skill greps `PUSH-VERDICT: MOVED`, which the NOT-MOVED line never matches.
+		const notMoved = decidePush(attempted({kind: "absent"})).terminalLine;
+		expect(notMoved.includes(`${VERDICT_PREFIX} MOVED`)).toBe(false);
+		expect(moved.includes(`${VERDICT_PREFIX} MOVED`)).toBe(true);
+	});
+});
+
+describe("parseLsRemote", () => {
+	it("reads the sha for the exact ref", () => {
+		expect(parseLsRemote(`${HEAD}\t${REF}\n`, REF)).toBe(HEAD);
+	});
+
+	it("returns null when the ref is absent from the output", () => {
+		expect(parseLsRemote("", REF)).toBeNull();
+		expect(parseLsRemote(`${HEAD}\trefs/heads/other\n`, REF)).toBeNull();
+	});
+
+	it("does not match a ref that merely shares a prefix", () => {
+		expect(parseLsRemote(`${HEAD}\t${REF}-suffix\n`, REF)).toBeNull();
+	});
+
+	it("ignores a malformed sha rather than reporting a bogus ref value", () => {
+		expect(parseLsRemote(`not-a-sha\t${REF}\n`, REF)).toBeNull();
+	});
+});

--- a/packages/pipeline-cli/src/tools/verified-push/verified-push.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verified-push/verified-push.unit.test.ts
@@ -5,6 +5,7 @@ import {
 	type PushAttempt,
 	type PushFacts,
 	parseLsRemote,
+	quoteTail,
 	type RefProbe,
 	VERDICT_PREFIX,
 } from "./verified-push.ts";
@@ -118,6 +119,29 @@ describe("the terminal line — the channel that survives a pipe and a detached 
 		const notMoved = decidePush(attempted({kind: "absent"})).terminalLine;
 		expect(notMoved.includes(`${VERDICT_PREFIX} MOVED`)).toBe(false);
 		expect(moved.includes(`${VERDICT_PREFIX} MOVED`)).toBe(true);
+	});
+});
+
+describe("quoteTail — the pre-push hook's output must not bury the verdict", () => {
+	// Found live on this verb's own first push: the hook runs the whole test suite, so the
+	// captured stream is thousands of lines. Quoting it whole made `| tail -30` show hook
+	// noise instead of the verdict.
+	it("keeps only the trailing lines and says how many it elided", () => {
+		const text = Array.from({length: 500}, (_, i) => `line ${i}`).join("\n");
+		const out = quoteTail("push stdout", text, 5);
+		expect(out).toHaveLength(6);
+		expect(out[0]).toContain("last 5 of 500 lines; 495 elided");
+		expect(out.at(-1)).toBe("    | line 499");
+	});
+
+	it("adds no elision note when everything fits", () => {
+		const out = quoteTail("push stderr", "a\nb", 40);
+		expect(out[0]).toBe("  push stderr:");
+		expect(out).toEqual(["  push stderr:", "    | a", "    | b"]);
+	});
+
+	it("reports an empty stream explicitly rather than silently omitting it", () => {
+		expect(quoteTail("push stdout", "   \n", 40)).toEqual(["  push stdout: (no output)"]);
 	});
 });
 


### PR DESCRIPTION
A lane had no way to know its `git push` actually landed a branch — success was inferred, not observed, and when the inference was wrong the lane reported itself complete with nothing on the remote. This adds `pipeline-cli verified-push`, which pushes *and* independently confirms the remote ref, then announces the result as a loud line anyone can grep. Both places the coder skill pushes now go through it, and a corpus lint stops a bare `git push` from coming back.

## The constraint that shaped the design

The masking was never git's. Two observation-layer defects destroyed the signal independently:

1. **The `| tail` idiom** — `git push … | tail -N` reports `tail`'s status. `pipefail` is **off** on this platform (measured, per the issue), so the pipeline returns 0 however git died. It is the dominant idiom precisely *because* the `pre-push` hook's output is long.
2. **The detached run** — its output file carries **no exit status at all**, so success gets inferred from the absence of an `error:` line, and a SIGPIPE'd git prints nothing.

Both layers destroy the **exit code**. So a verb that pushes and checks the ref but reports only through its exit status would defeat *neither*: piped it is just as silent, detached it still leaves nothing to read. The one channel that survives both is **stdout** — hence the acceptance criterion this build is anchored on:

> The verdict is a loud, grep-able **terminal line on stdout, emitted LAST**, in addition to the exit code.

`… | tail -1` now yields *exactly* the verdict instead of erasing it, and a detached run's output file ends with it. The whole report goes to **one stream** on purpose: splitting it across stdout and stderr would let a stderr line land after the verdict under `2>&1 | tail`, since inter-stream ordering is not guaranteed.

## Three outcomes, and the third is not a success

| terminal line | exit | meaning |
| --- | --- | --- |
| `PUSH-VERDICT: MOVED …` | 0 | the remote ref is confirmed at the local head |
| `PUSH-VERDICT: NOT-MOVED …` | 1 | confirmed *not* to carry it — absent, or at another commit |
| `PUSH-VERDICT: UNKNOWN …` | 3 | could not be determined — **never mapped onto success** |

`MOVED` requires positive evidence on both legs: the ref resolved at the expected sha **and** the push itself ran cleanly. Every indeterminate fact routes to `UNKNOWN` — a probe that could not execute, an unresolvable head, a detached HEAD, and the odd case where the ref *does* match but the push misbehaved (the match cannot be attributed to this push). An exit-0 push whose ref did not land is still `NOT-MOVED`: the exit status is not the fact, the ref is.

The probe is `git ls-remote` — read-only, host-agnostic, no repo literal (ADR 0062). Its tradeoff is stated honestly in the code: if the transport is dead the probe fails and the verdict is `UNKNOWN`, which is exactly the loud third outcome rather than a false pass.

## No retry — the argument, on the record

A blind re-push would have "worked" for the #4042 lane and would have **buried #4136's transport mechanism**, silently absorbing the contention this verb exists to expose. It is also unsound on its own terms: the verb cannot distinguish a transient transport death from a rejected non-fast-forward, so a retry loop would hammer a legitimately refused push. The caller decides what to do with a non-`MOVED` verdict; the verb only reports it.

## The wiring is mechanical, not advisory

Both `write-code` push sites are rewired — Step 5's initial `-u` push and Step R3's repair `--force-with-lease` — each stopping the run on any non-zero verdict, with a stated-once rationale section they both point at. Enforcement copies the existing in-repo precedent rather than inventing one: `gh-phoenix lint-skills` gains a **third** check that reds on a git push invocation in any **runnable** block of the skill corpus (a fenced shell block, or a whole `.sh`), reported through the same `skill-gh-lint.yml` job, and **fails closed on zero scope** (ADR 0092) — the push scope joins the two existing scopes in `isZeroScope`. Prose *about* a bare push is deliberately untouched: the skills have to be able to explain why it is forbidden. There is no per-line pragma and no self-exempt entry — an escape hatch an agent can reach for is the attention-based enforcement ADR 0202 rules out, and `write-code` is explicitly **not** exempted, since it is the one file that owns both push sites.

Live proof both directions: the lint is clean over all 62 corpus files as they now stand, and reds (exit 2) on a fixture carrying the two pre-change push lines verbatim.

## Never a bare `timeout`

The probe's bound is `execFileSync`'s own `timeout` option — a portable Node bound, **not** the `timeout(1)` binary, which is absent on this platform (#3411), where a bare `timeout …` would exit command-not-found and, under masking layer 1, read as success.

## What dogfooding caught

The first live push through the verb hit `execFileSync`'s **default 1 MB `maxBuffer`**, which *kills the child* — the `pre-push` hook runs the whole test suite, so the buffer limit, not git, ended the push. That is precisely the manufactured-indeterminacy failure this verb exists to eliminate, so it is fixed in its own commit and covered by tests: the limit is raised well clear, and each captured stream is quoted by its **tail** with an elision count, so the verdict is findable without a `tail -1` that happens to be exactly right. The second push then reported `MOVED` and was confirmed over `gh api`.

## Scope

The **general** detached-execution gap — that *any* detached run's output file carries no exit status, for any command — is out of scope and not fixable by a push verb, as the issue specifies. Noted, not built.

**Control plane (§CP):** touches `packages/pipeline-cli/` and the `write-code` skill; full path with a human merge, not collapse-eligible.

## What review caught

The lint pattern the whole enforcement claim rests on was itself wedgeable: `BARE_GIT_PUSH` carried overlapping alternatives, so input that never reaches `push` backtracked exponentially (CodeQL `js/redos`). The gate runs on every `pull_request` over a corpus anyone can add a line to, and a hung job presents as *running* rather than failed — the exact confusion milestone #36 exists to remove. Fixed by making the alternatives disjoint; `165 chars → 73.7 s` and `140 chars → 64.0 s` both become `0.0 ms`, and three wall-clock-bounded unit tests pin it.

## Deviations

- **(repair round 1) The prescribed fix was insufficient, so a different one shipped.** The `review-code` FAIL prescribed deleting the `--\S+=\S+\s+` alternative, verified as behavior-identical. It is — but it removes only *one* of the two overlaps. `-[cC]\s+\S+\s+` and `-\S+\s+` can both consume a bare `-c` token, so `"git " + "-c ".repeat(45) + "x"` (140 characters) still took **64.0 s** under the prescribed pattern. The shipped fix deletes that alternative *and* constrains the `-c` value to `[^-\s]`, so exactly one alternative can consume any given token. Both blowups go to 0.0 ms, 40 KB of the worst shapes matches in under a millisecond, and output is identical to the pre-change pattern on all 16 real and near-miss forms.
- **(repair round 1) One non-blocking note was declined.** `runGit` returning `stderr: ""` on success (so a `MOVED` report prints `push stderr: (no output)`) is left as-is. The fix is `spawnSync`, which changes the throw-based control flow the reviewer verified for `exitCode`/`signal` semantics — not a cheap change to the one boundary the three-outcome argument rests on, for a diagnostic the failure paths already capture. The other two notes are folded in.

Fixes #4213

