### PR TITLE
fix(pipeline-cli): an unreadable --files-from refuses, never reads as zero files (#4061)

### DIFF
--- a/.patterns/effect-platform-access.md
+++ b/.patterns/effect-platform-access.md
@@ -205,10 +205,12 @@ sometimes the only option, in these grounded cases:
   [0092](../.decisions/0092-gates-fail-closed-on-zero-scope.md) exists to stop. Keep the
   path branch's failure hard (`verdict`'s `Effect.orDie`, or a typed failure that exits
   non-zero) and let the stdin branch run only when no path was given at all. `class-probe`'s
-  `readFiles` is the counter-example on `main` today — an unreadable `--files-from` is
-  absorbed to `""`, i.e. to *no files* — which is the shape this paragraph rules against, not
-  a second sanctioned option; it is part of what
-  [#3924](https://github.com/kamp-us/phoenix/issues/3924) tightens.
+  `readFiles` used to be the counter-example — an unreadable `--files-from` was absorbed to
+  `""`, i.e. to *no files*, so an unread input and an empty one were one value. It now resolves
+  an unreadable path to `null` and refuses non-zero on it, while a readable-but-empty file still
+  classifies through the tool's own fail-closed no-input path — the two outcomes stay distinct
+  in both value and exit code ([#4061](https://github.com/kamp-us/phoenix/issues/4061); the
+  stdin half was [#3924](https://github.com/kamp-us/phoenix/issues/3924)).
 
 The rule is not "never write `node:`" — it's "**domain Effect code depends on the
 platform service, so the filesystem stays a swappable seam.**" When you keep a raw

--- a/packages/pipeline-cli/src/tools/class-probe/README.md
+++ b/packages/pipeline-cli/src/tools/class-probe/README.md
@@ -48,9 +48,16 @@ pipeline-cli class-probe classify --root <dir>     # read §CLASS under a specif
 ```
 
 Present classes go to **stdout** (one per line); a human summary goes to **stderr**.
-`classify` always exits 0 — it classifies, it does not gate. `review-design` (the
-UI-affecting class) is resolved separately from ship-it's `UI_RE` (`ui_reresolve`) and is
-out of this tool's scope.
+`classify` exits 0 on every *classification* — it classifies, it does not gate.
+`review-design` (the UI-affecting class) is resolved separately from ship-it's `UI_RE`
+(`ui_reresolve`) and is out of this tool's scope.
+
+The one non-zero exit is **not** a verdict: an input this tool could never read (an
+unreadable `--files-from`, or a failed stdin read) exits `4` with a reason on stderr and
+prints nothing, rather than classifying over an input it does not have (#3924 / #4061). A
+`--files-from` that exists and is genuinely **empty** is a different outcome and keeps the
+exit-0 path: it reads as zero files and fails closed to `has-code` / `review-code` (#3786),
+so "unreadable" and "empty" never collapse into the same answer.
 
 ## `doc-vocab-surface-only` — the issueless allowance's axis (#3953)
 
@@ -67,6 +74,7 @@ link). Keying the allowance on the class is what false-refused that shape at `re
 Step 1 (#3953), so the gates key it here instead.
 
 The `DOC_VOCAB_EXCLUDE_RE` / `DOC_VOCAB_SURFACE_RE` pair is parsed from the same §CLASS
-single source, and every failure mode resolves **not** surface-only — unreadable §CLASS,
-dropped stdin, uncompilable regex. This probe can only ever *refuse* the allowance, the
-mirror of `classify`'s over-dispatch (ADR 0092).
+single source, and every failure mode is non-zero, i.e. the allowance is refused — unreadable
+§CLASS, dropped stdin, uncompilable regex all resolve **not** surface-only (exit 1), and an
+unreadable input exits `4` without a verdict at all. This probe can only ever *refuse* the
+allowance, the mirror of `classify`'s over-dispatch (ADR 0092).

--- a/packages/pipeline-cli/src/tools/class-probe/command.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.test.ts
@@ -57,3 +57,32 @@ describe("class-probe classify — empty stdin fails closed to review-code, neve
 		expect(stdout.trim().split("\n").filter(Boolean)).toEqual(["has-code"]);
 	});
 });
+
+describe("class-probe --files-from — an unreadable path refuses; an empty one still classifies (#4061)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("an UNREADABLE --files-from exits non-zero with its own reason, never as a change set", () => {
+		const {code, stdout, stderr} = runSh(`${INNER} --files-from /nonexistent/changed.txt`);
+		expect(code).toBe(4);
+		expect(stdout.trim()).toBe("");
+		expect(stderr).toContain("could not read --files-from");
+		expect(stderr).toContain("#4061");
+	});
+
+	it("a readable-but-EMPTY --files-from still classifies, fail-closed to review-code", () => {
+		const {code, stdout, stderr} = runSh(`${INNER} --files-from /dev/null`);
+		// The non-collapse, asserted on the observable pair: same "zero files" shape as above,
+		// opposite exit and opposite output.
+		expect(code).toBe(0);
+		expect(stdout.trim().split("\n").filter(Boolean)).toEqual(["review-code"]);
+		expect(stderr).toContain("read 0 files");
+	});
+
+	it("doc-vocab-surface-only refuses on an unreadable --files-from too (exit 4, not its exit-1 verdict)", () => {
+		const {code, stdout} = runSh(
+			`node "${BIN}" class-probe doc-vocab-surface-only --files-from /nonexistent/changed.txt`,
+		);
+		expect(code).toBe(4);
+		expect(stdout.trim()).toBe("");
+	});
+});

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -17,8 +17,8 @@
  * instead, appending `review-design`). Folding has-ui in here is the #2485/#2483 fix: the
  * reviewer fan dispatches review-design deterministically off this output instead of eyeballing
  * a non-visual `apps/web/src/*.ts` away and deadlocking ship-it on an empty review-design
- * namespace. A human summary goes to **stderr**; `classify` always exits 0 — it classifies, it
- * does not gate.
+ * namespace. A human summary goes to **stderr**; `classify` exits 0 on every *classification* — it
+ * classifies, it does not gate; a refusal to read the input is not a classification (below).
  *
  * The sibling `doc-vocab-surface-only` subcommand answers a **different** question on the same
  * file set — is a missing `Fixes #N` legitimate here (ADR 0075/0184, #3953) — and *does* carry

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -26,11 +26,13 @@
  *
  * IO here (the thin bin), classification in `class-probe.ts` (the pure core). An
  * unreadable §CLASS falls back to the fail-closed probes (`FAILCLOSED_PROBES`), which
- * over-dispatch every gate rather than skip one.
+ * over-dispatch every gate rather than skip one. An unreadable *input* is different in kind and
+ * is never absorbed into a value: both branches of the changed-file read refuse non-zero rather
+ * than classify over an input they could not read (stdin #3924, `--files-from` #4061).
  */
 import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {readStdinTextOrExit} from "../../read-stdin.ts";
+import {readStdinTextOrExit, STDIN_READ_FAILED_EXIT_CODE} from "../../read-stdin.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {
 	classify,
@@ -87,25 +89,48 @@ const namespacesFlag = Flag.boolean("namespaces").pipe(
 	Flag.withDescription("print the required review-* namespaces instead of the has-* classes"),
 );
 
-/** Read the changed-file list from `--files-from` or stdin; empty/failed read ⇒ no files. */
-const readFiles = (
+/**
+ * Read the changed-file list from `--files-from` or stdin. An unreadable `--files-from` resolves
+ * to **`null`**, never to zero files: "I could not read the input" and "the input was legitimately
+ * empty" must stay two different values at this boundary (#4061). A readable-but-empty file still
+ * yields `[]`, which the callers route through their own fail-closed no-input path.
+ */
+export const readFiles = (
 	filesFrom: Option.Option<string>,
-): Effect.Effect<ReadonlyArray<string>, never, FileSystem.FileSystem> =>
+): Effect.Effect<ReadonlyArray<string> | null, never, FileSystem.FileSystem> =>
 	Effect.gen(function* () {
 		const raw = yield* Option.match(filesFrom, {
 			onSome: (path) =>
 				Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf8")).pipe(
-					Effect.orElseSucceed(() => ""),
+					Effect.orElseSucceed((): string | null => null),
 				),
 			// stdin: a failed read exits non-zero through the shared reader — probing "no files
 			// changed" over a pipe that was never read is the defect (#3924).
 			onNone: () => readStdinTextOrExit(),
 		});
+		if (raw === null) return null;
 		return raw
 			.split("\n")
 			.map((line) => line.trim())
 			.filter((line) => line.length > 0);
 	});
+
+/**
+ * The refusal both subcommands take on an unreadable `--files-from` — the path branch's failure
+ * stays hard, exactly as `.patterns/effect-platform-access.md` rules (#4061). Distinct from every
+ * classification outcome: a readable-but-empty list still classifies (exit 0 / the doc-vocab
+ * verdict), an unreadable one never does.
+ */
+const exitUnreadableFilesFrom = (filesFrom: Option.Option<string>): Effect.Effect<never> =>
+	Effect.sync(() => {
+		const path = Option.getOrElse(filesFrom, () => "(unset)");
+		process.stderr.write(
+			`class-probe: could not read --files-from ${path} — refusing to classify over an input that was never read. This is NOT an empty change set: a readable-but-empty file still classifies, an unreadable path does not (#4061).\n`,
+		);
+		// The same non-zero code the stdin branch exits with (read-stdin.ts) — one code for "the
+		// input was never read", whichever branch was reading it.
+		process.exit(STDIN_READ_FAILED_EXIT_CODE);
+	}).pipe(Effect.andThen(Effect.never));
 
 /** Read local §CLASS text; null (⇒ fail-closed probes) if the file is unreadable. */
 const readFormats = (
@@ -145,6 +170,7 @@ const classifyCmd = Command.make(
 		const uiRe = parseUiProbe(shipIt ?? "");
 		const uiExclude = parseUiExclude(shipIt ?? "");
 		const files = yield* readFiles(filesFrom);
+		if (files === null) return yield* exitUnreadableFilesFrom(filesFrom);
 		// Fail closed on zero input (#3786): this probe is only ever piped a PR's changed-file
 		// list, which is never legitimately empty — an empty read is a dropped/undelivered stdin,
 		// indistinguishable at the pure core from a gate-free PR. Route it through the same has-code
@@ -209,6 +235,7 @@ const docVocabCmd = Command.make(
 		const formats = yield* readFormats(rootDir);
 		const probe = parseDocVocabProbe(formats ?? "");
 		const files = yield* readFiles(filesFrom);
+		if (files === null) return yield* exitUnreadableFilesFrom(filesFrom);
 		const surfaceOnly = isDocVocabSurfaceOnly(files, probe);
 
 		if (formats === null) {

--- a/packages/pipeline-cli/src/tools/class-probe/read-files.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/read-files.unit.test.ts
@@ -1,0 +1,46 @@
+/**
+ * `readFiles`' `--files-from` branch over a substituted `FileSystem` — the three outcomes that
+ * used to collapse into two (#4061). No real disk: the seam is the whole filesystem
+ * (`.patterns/effect-platform-access.md`).
+ */
+
+import {Effect, FileSystem, Option, PlatformError} from "effect";
+import {describe, expect, it} from "vitest";
+import {readFiles} from "./command.ts";
+
+const FILES_FROM = "changed.txt";
+
+const unreadable = FileSystem.layerNoop({
+	readFileString: (path: string) =>
+		Effect.fail(
+			PlatformError.systemError({
+				_tag: "NotFound",
+				module: "FileSystem",
+				method: "readFileString",
+				pathOrDescriptor: path,
+			}),
+		),
+});
+
+const readable = (contents: string) =>
+	FileSystem.layerNoop({readFileString: () => Effect.succeed(contents)});
+
+const run = (layer: ReturnType<typeof readable>) =>
+	Effect.runPromise(Effect.provide(readFiles(Option.some(FILES_FROM)), layer));
+
+describe("readFiles --files-from — an unreadable path never reads as an empty one (#4061)", () => {
+	it("resolves an UNREADABLE path to null, not to zero files", async () => {
+		await expect(run(unreadable)).resolves.toBeNull();
+	});
+
+	it("resolves a readable-but-EMPTY file to [] — a distinct value from the unreadable null", async () => {
+		await expect(run(readable(""))).resolves.toEqual([]);
+	});
+
+	it("resolves a readable NON-EMPTY file to its trimmed, blank-stripped lines", async () => {
+		await expect(run(readable("apps/web/src/a.tsx\n\n  DEVELOPMENT.md  \n"))).resolves.toEqual([
+			"apps/web/src/a.tsx",
+			"DEVELOPMENT.md",
+		]);
+	});
+});


### PR DESCRIPTION
Fixes #4061

`class-probe`'s `--files-from` branch absorbed an unreadable path into `""` — i.e. into *no
files* — via `Effect.orElseSucceed(() => "")`. So "I could not read the input" and "the input
was legitimately empty" were the same value at that boundary. The stdin half of the same read
was already fail-closed (#3924 / PR #4010); the file half was not.

## What changed

- **`packages/pipeline-cli/src/tools/class-probe/command.ts`** — `readFiles` now resolves an
  unreadable `--files-from` to a typed **`null`**, never to zero files. Both subcommands
  (`classify` and `doc-vocab-surface-only`) refuse on it: exit **4** — the shared "the input was
  never read" code the stdin branch already uses (`src/read-stdin.ts`) — with a reason on stderr
  naming the path, and **nothing printed on stdout**. This is the shape
  `.patterns/effect-platform-access.md` already rules for (`guard-content-probe`'s `readBody` is
  the sibling): keep the path branch's failure hard, let stdin run only when no path was given.
- **The genuinely-empty case is untouched.** A `--files-from` that exists and reads empty still
  yields `[]`, still routes through `NO_INPUT_FAILCLOSED_CLASSES`, and still exits 0 printing
  `has-code` / `review-code` (#3786). Unreadable vs. empty now differ in **both** the value and
  the exit code — they cannot collapse.
- **The stdin branch is unchanged** — no `--files-from` still reads stdin through
  `readStdinTextOrExit`, and a broken `--files-from` never degrades into a stdin read.
- **Tests.** New `read-files.unit.test.ts` pins all three outcomes (unreadable / readable-empty /
  readable-non-empty) through a substituted `FileSystem.layerNoop` — no real disk, per
  `.patterns/effect-platform-access.md`. `command.test.ts` gains the bin-level exit contract:
  unreadable path → exit 4 + empty stdout, `--files-from /dev/null` → exit 0 + `review-code`,
  and `doc-vocab-surface-only` → exit 4 rather than its exit-1 verdict.
- **Docs.** `.patterns/effect-platform-access.md` no longer describes this site as `main`'s
  counter-example, and no longer names the closed #3924 as the owner of this branch. The tool's
  `README.md` correspondingly narrows "`classify` always exits 0" to "exits 0 on every
  *classification*", and states the one non-zero, non-verdict exit.

## Verification

The new bin-level case fails against base: with `command.ts` reverted to `main`'s version,
`--files-from /nonexistent/changed.txt` returns `expected +0 to be 4` — the fail-open reproduced
exactly (it printed `review-code` and exited 0). With the fix, `src/tools/class-probe` is 53/53,
and the whole `@kampus/pipeline-cli` suite is 2609/2609. `pnpm typecheck` and `pnpm
lint:worktree` are clean.

## Note for the reviewer

This is a §CP (control-plane) path — `packages/pipeline-cli/`. Do not merge; the operator owns
shipping.

#4060 is the other half of the same `readFiles` seam (a dropped stdin read under parallel
invocation). It is a distinct defect and this change does not touch the stdin branch, so the two
should not conflict.
