### PR TITLE
fix(crew-em): the approval-watcher fail-closes on every live read, not just reviews (#4108)

### DIFF
--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -236,12 +236,22 @@ it adds no engine→engine and no human-facing edge.
   approval" while the reviews guard still passed (#4108).
 
   Each guard has the same three-part shape — **SHAPE FIRST** (prove the payload before interpreting
-  it), **EXACT MEMBERSHIP** (an approver counts only on an exact login match against an active
-  control-plane member, never a substring or non-empty test), **VERIFIED HEAD** (`.commit_id ==
-  $HEAD`, ADR 0058) — and the same disposition on failure. Only the assertion differs:
+  it), **EXACT MEMBERSHIP** (an approver counts only on an exact login match against an *active*
+  control-plane member, never a substring or non-empty test; each candidate's membership read is
+  itself three-way — `404` is a definite non-member, `200` carries the state, **anything else is
+  UNKNOWN** — because collapsing the last two into "not a member" is the same false-definite one read
+  further out), **VERIFIED HEAD** (`.commit_id == $HEAD`, ADR 0058) — and the same disposition on
+  failure. Only the assertion differs.
+
+  **The block below is the tick's guards, and only its guards** — it ends where the discharge begins.
+  Proving the inputs is this def's job; *deciding* on them is not, because the decision is ship-it's
+  §CP gate via `cp-cardinality` (the bullet above) and no second copy of it may fork into this def.
+  So the block assembles no approver set, derives no signal flags, and fires nothing — the
+  per-approver membership read above is stated as a rule rather than copied here, since it runs where
+  the approver set is assembled, inside that single-source discharge.
 
   ```bash
-  # The one non-firing exit that is NOT "no approval": it names the read that could not execute.
+  # The non-firing exit that is NOT a definite answer: it names the read that could not execute.
   unknown() { echo "approval-watcher #$PR: $1 READ FAILED ($2) — UNKNOWN, re-arming; NOT 'no approval'"; }
   # `gh api --paginate` emits one JSON value per page, so slurp and assert EVERY page is an array —
   # a per-page `jq -e` reports only the last page's type and waves an early error body through.
@@ -258,44 +268,40 @@ it adds no engine→engine and no human-facing edge.
   AUTHOR="$(gh api "repos/$REPO/pulls/$PR" --jq '.user.login' 2>/dev/null)"
   [ -n "$AUTHOR" ] || { unknown author "empty login"; return 0; }
 
-  # 3. TEAM ROSTER — an unread roster piped in as empty is N==0, which cp-cardinality decides on.
+  # 3. TEAM ROSTER — an unread roster reaching the discharge as empty is N==0, a shape it decides on.
   MEMBERS_JSON="$(gh api --paginate "orgs/${REPO%%/*}/teams/control-plane/members?per_page=100" 2>/dev/null)" \
     && printf '%s' "$MEMBERS_JSON" | all_pages_are_arrays \
     || { unknown roster "unreadable payload"; return 0; }
-  MEMBERS="$(printf '%s' "$MEMBERS_JSON" | jq -r '.[].login')"
-  # …and each candidate approver's membership state (in the per-approver loop) is its own live read,
-  # read THREE ways: 404 is a definite non-member, 200 carries the state, anything else is UNKNOWN.
-  # Collapsing the last two into "not a member" is the same false-definite one read further out.
-  M_RESP="$(gh api "orgs/${REPO%%/*}/teams/control-plane/memberships/$u" -i 2>/dev/null)"
-  M_STATUS="$(printf '%s\n' "$M_RESP" | head -n1 | awk '{print $2}')"
-  case "$M_STATUS" in
-    200) st="$(printf '%s\n' "$M_RESP" | awk 'body{print} /^\r?$/{body=1}' | jq -r '.state // empty')" ;;
-    404) continue ;;                                              # definite: not a control-plane member
-    *)   unknown "membership($u)" "HTTP ${M_STATUS:-none}"; return 0 ;;
-  esac
-  [ "$st" = active ] || continue
 
   # 4. REVIEWS — the original guard, unchanged in substance: a 503 body is an object, not an array.
   REVIEWS="$(gh api --paginate "repos/$REPO/pulls/$PR/reviews?per_page=100" 2>/dev/null)" \
     && printf '%s' "$REVIEWS" | all_pages_are_arrays \
     || { unknown reviews "unreadable payload"; return 0; }
 
-  # 5. MACHINE GATES — `pipeline-cli checks read` exits 2 on its own typed unknown. An unreadable
-  #    head is not a green head and not a red one (#3999) — it is this tick's UNKNOWN.
-  CI_JSON="$(pipeline-cli checks read --pr "$PR" --expect green 2>/dev/null)"; rc=$?
-  [ "$rc" = 2 ] && { unknown "machine gates" "no interpretable CI state"; return 0; }
-
-  # 6. PREDICATE EVAL — cp-cardinality's OWN exit codes are 0 discharge / 1 stop; every other
-  #    non-zero means the decision never ran (e.g. exit 4, the unread-stdin code). Read a stop off
-  #    exit 1 only — never off "non-zero" (the collision #4204 fixed in cp-classify). $SIGNAL_FLAGS
-  #    is the pair of SHA-bound signal flags ship-it resolves, passed only when present at head.
-  printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide --author "$AUTHOR" $SIGNAL_FLAGS; rc=$?
+  # 5. MACHINE GATES — green is a PRECONDITION of firing, so this guard must PROVE it, not merely
+  #    survive it. `pipeline-cli checks read --expect green` has more than two outcomes (read them
+  #    from packages/pipeline-cli/src/tools/checks/command.ts, never guess): 0 = proven green; 1 =
+  #    the head was read and is NOT green (red/pending) — and also its bad-input exit, so treat 1 as
+  #    the fail-CLOSED definite; 2 = its typed unknown, an unreadable head that is neither green nor
+  #    red (#3999); 127 = a PATH gap and any other non-zero a crash, i.e. the read never ran.
+  #    Branching on `rc == 2` alone lets 1/127/anything-else fall through to a fire — the fail-OPEN
+  #    polarity of #3715, committed inside the fix for it. Enumerate; only a proven-green 0 continues.
+  pipeline-cli checks read --pr "$PR" --expect green >/dev/null 2>&1; rc=$?
   case "$rc" in
-    0) fire_shipper ;;                                            # discharge
-    1) echo "approval-watcher #$PR: no approval at current head (read OK, definite)" ;;
-    *) unknown "predicate eval" "cp-cardinality exit $rc" ;;
+    0) : ;;                                                       # proven green — the only continuing branch
+    1) echo "approval-watcher #$PR: machine gates not green (read OK, definite)"; return 0 ;;
+    *) unknown "machine gates" "checks exit $rc"; return 0 ;;     # 2, 127, crash — the read never ran
   esac
-  return 0
+
+  # → GUARDS END HERE. Every input is proven readable and the gates are proven green, so hand the
+  #   tick to the single-source discharge (the bullet above): ship-it's §CP gate, run through
+  #   `pipeline-cli cp-cardinality decide` on the proven $HEAD / $AUTHOR / $MEMBERS_JSON / $REVIEWS.
+  #   That call resolves the active approver set and the SHA-bound signal flags itself — do NOT
+  #   re-derive either here, which is what forks a second copy of the discharge into this def.
+  #   Read its verdict off its OWN codes: 0 discharges (fire the shipper), 1 is the definite stop;
+  #   every other non-zero means the decision never ran (e.g. exit 4, the unread-stdin code) and is
+  #   this tick's UNKNOWN — never read a stop off "non-zero" (the collision #4204 fixed in
+  #   cp-classify).
   ```
 
   The exit-code idiom is the shipped one, not a new invention: `STDIN_READ_FAILED_EXIT_CODE = 4`
@@ -303,14 +309,16 @@ it adds no engine→engine and no human-facing edge.
   "distinct from a gate's own verdict codes: the input was never read." So a tool's verdict codes are
   the only codes you read a verdict off; any other non-zero is a read that never happened.
 
-  **Log "read failed" distinctly from "no approval", and name which read failed.** They are
-  different facts with the same non-firing outcome, and collapsing them makes a GitHub outage look
-  like a human who simply hasn't approved yet — a silent stall nobody can see. So a tick ends on
-  exactly one of three lines: the discharge, `no approval at current head (read OK, definite)` when
-  every input read cleanly and the predicate said stop, or the `unknown` line above naming the input
-  that could not be read. The durable authority is still `cp-cardinality` and the shipper's own
-  re-check at enqueue; this rule is defense in depth on the trigger, so a hiccup can never *start* a
-  §CP enqueue — nor hide a stall behind a confident-sounding non-firing line.
+  **Log "read failed" distinctly from a definite non-firing answer, and name which read failed.**
+  They are different facts with the same non-firing outcome, and collapsing them makes a GitHub
+  outage look like a human who simply hasn't approved yet — a silent stall nobody can see. So a tick
+  ends on exactly one line, and every branch above reaches one: the discharge; a **definite**
+  non-firing line that says which condition held — `machine gates not green (read OK, definite)` from
+  the guard, `no approval at current head (read OK, definite)` from the discharge's stop; or the
+  `unknown` line naming the input that could not be read. The durable authority is still
+  `cp-cardinality` and the shipper's own re-check at enqueue; this rule is defense in depth on the
+  trigger, so a hiccup can never *start* a §CP enqueue — nor hide a stall behind a
+  confident-sounding non-firing line.
 - **Approved at the current head + green → wake and spawn the shipper.** When the predicate discharges
   — a non-author control-plane approval bound to the PR's *current* head, machine gates green — the
   watcher wakes you to spawn the approval-aware `shipper` on that head. The shipper re-runs the same

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -223,30 +223,94 @@ it adds no engine→engine and no human-facing edge.
   green. The §CP unblock logic lives once — in ship-it / `cp-cardinality` — and both the watcher and
   the shipper read that single source, so the trigger fires exactly when the enqueue would discharge
   and no second copy of the §CP discharge forks into this def.
-- **An unreadable review query resolves to UNKNOWN — never to an approval (fail closed).** The poll
-  reads live GitHub, so it must assume the response may not be review data at all. **Validate the
-  payload's shape before interpreting it**, and treat every non-conforming response — a 503/error
-  body, a non-array payload, a parse failure, a non-zero `gh` exit — as **UNKNOWN → do not fire,
-  re-arm**, never as a definite answer. A bare non-empty test on the response is the defect: during a
-  live GitHub partial outage an error body read as an approver's login and declared two unapproved §CP
-  PRs approved (#3715). Three rules make the positive branch fail closed:
+- **Every live input the discharge predicate consumes resolves to UNKNOWN when its read could not
+  execute — never to a definite answer (fail closed).** This is a rule over the *predicate*, not a
+  list of the reads that have failed historically: a tick may interpret an input only after proving
+  it has the shape the predicate expects — an array where an array is expected, a 40-hex SHA where a
+  SHA is expected, an interpretable CI state where a state is expected. Anything else — a 503/error
+  body, a non-array payload, a parse failure, a non-zero `gh` exit, an empty or short SHA — is
+  **UNKNOWN → do not fire, re-arm**. Guarding only the input that failed last time just moves the
+  defect one read over, twice over now: a bare non-empty test on the reviews payload let an error
+  body read as an approver's login and declared two unapproved §CP PRs approved (#3715), and then the
+  unvalidated head SHA compared as `.commit_id == ""`, matched nothing, and printed a confident "no
+  approval" while the reviews guard still passed (#4108).
+
+  Each guard has the same three-part shape — **SHAPE FIRST** (prove the payload before interpreting
+  it), **EXACT MEMBERSHIP** (an approver counts only on an exact login match against an active
+  control-plane member, never a substring or non-empty test), **VERIFIED HEAD** (`.commit_id ==
+  $HEAD`, ADR 0058) — and the same disposition on failure. Only the assertion differs:
 
   ```bash
-  # 1. SHAPE FIRST: interpret nothing until the payload is proven to be the expected JSON array.
-  #    `jq -e 'type=="array"'` is the assertion — a 503 body is an object, so it exits non-zero.
+  # The one non-firing exit that is NOT "no approval": it names the read that could not execute.
+  unknown() { echo "approval-watcher #$PR: $1 READ FAILED ($2) — UNKNOWN, re-arming; NOT 'no approval'"; }
+  # `gh api --paginate` emits one JSON value per page, so slurp and assert EVERY page is an array —
+  # a per-page `jq -e` reports only the last page's type and waves an early error body through.
+  all_pages_are_arrays() { jq -e -s 'length > 0 and all(.[]; type == "array")' >/dev/null 2>&1; }
+
+  # 1. HEAD — resolve it explicitly and prove it is a 40-hex SHA BEFORE any `.commit_id == $HEAD`
+  #    comparison is interpreted. An empty $HEAD matches no commit_id, so an unvalidated head read
+  #    lands on the definite "no approval" branch with every other guard still green (#4108).
+  HEAD="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null)"
+  printf '%s' "$HEAD" | grep -Eq '^[0-9a-f]{40}$' || { unknown head "no 40-hex SHA"; return 0; }
+
+  # 2. AUTHOR — cp-cardinality's single-owner branch keys on it, and an empty author would let a
+  #    self-approval pass as a non-author approval.
+  AUTHOR="$(gh api "repos/$REPO/pulls/$PR" --jq '.user.login' 2>/dev/null)"
+  [ -n "$AUTHOR" ] || { unknown author "empty login"; return 0; }
+
+  # 3. TEAM ROSTER — an unread roster piped in as empty is N==0, which cp-cardinality decides on.
+  MEMBERS_JSON="$(gh api --paginate "orgs/${REPO%%/*}/teams/control-plane/members?per_page=100" 2>/dev/null)" \
+    && printf '%s' "$MEMBERS_JSON" | all_pages_are_arrays \
+    || { unknown roster "unreadable payload"; return 0; }
+  MEMBERS="$(printf '%s' "$MEMBERS_JSON" | jq -r '.[].login')"
+  # …and each candidate approver's membership state (in the per-approver loop) is its own live read,
+  # read THREE ways: 404 is a definite non-member, 200 carries the state, anything else is UNKNOWN.
+  # Collapsing the last two into "not a member" is the same false-definite one read further out.
+  M_RESP="$(gh api "orgs/${REPO%%/*}/teams/control-plane/memberships/$u" -i 2>/dev/null)"
+  M_STATUS="$(printf '%s\n' "$M_RESP" | head -n1 | awk '{print $2}')"
+  case "$M_STATUS" in
+    200) st="$(printf '%s\n' "$M_RESP" | awk 'body{print} /^\r?$/{body=1}' | jq -r '.state // empty')" ;;
+    404) continue ;;                                              # definite: not a control-plane member
+    *)   unknown "membership($u)" "HTTP ${M_STATUS:-none}"; return 0 ;;
+  esac
+  [ "$st" = active ] || continue
+
+  # 4. REVIEWS — the original guard, unchanged in substance: a 503 body is an object, not an array.
   REVIEWS="$(gh api --paginate "repos/$REPO/pulls/$PR/reviews?per_page=100" 2>/dev/null)" \
-    && printf '%s' "$REVIEWS" | jq -e 'type == "array"' >/dev/null 2>&1 \
-    || { echo "approval-watcher #$PR: reviews READ FAILED (unreadable payload) — UNKNOWN, re-arming; NOT 'no approval'"; return 0; }
-  # 2. EXACT MEMBERSHIP: an approver counts only if their login matches an actual control-plane
-  #    team member exactly (`--jq '.state'` == active), never a substring or non-empty test.
-  # 3. VERIFIED HEAD: require `.commit_id == $HEAD` on this proven-array read (ADR 0058).
+    && printf '%s' "$REVIEWS" | all_pages_are_arrays \
+    || { unknown reviews "unreadable payload"; return 0; }
+
+  # 5. MACHINE GATES — `pipeline-cli checks read` exits 2 on its own typed unknown. An unreadable
+  #    head is not a green head and not a red one (#3999) — it is this tick's UNKNOWN.
+  CI_JSON="$(pipeline-cli checks read --pr "$PR" --expect green 2>/dev/null)"; rc=$?
+  [ "$rc" = 2 ] && { unknown "machine gates" "no interpretable CI state"; return 0; }
+
+  # 6. PREDICATE EVAL — cp-cardinality's OWN exit codes are 0 discharge / 1 stop; every other
+  #    non-zero means the decision never ran (e.g. exit 4, the unread-stdin code). Read a stop off
+  #    exit 1 only — never off "non-zero" (the collision #4204 fixed in cp-classify). $SIGNAL_FLAGS
+  #    is the pair of SHA-bound signal flags ship-it resolves, passed only when present at head.
+  printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide --author "$AUTHOR" $SIGNAL_FLAGS; rc=$?
+  case "$rc" in
+    0) fire_shipper ;;                                            # discharge
+    1) echo "approval-watcher #$PR: no approval at current head (read OK, definite)" ;;
+    *) unknown "predicate eval" "cp-cardinality exit $rc" ;;
+  esac
+  return 0
   ```
 
-  **Log "read failed" distinctly from "no approval."** They are different facts with the same
-  non-firing outcome, and collapsing them makes a GitHub outage look like a human who simply hasn't
-  approved yet — a silent stall nobody can see. The watcher's non-firing line must name which one it
-  was. The durable authority is still `cp-cardinality` and the shipper's own re-check at enqueue; this
-  rule is defense in depth on the trigger, so a hiccup can never *start* a §CP enqueue.
+  The exit-code idiom is the shipped one, not a new invention: `STDIN_READ_FAILED_EXIT_CODE = 4`
+  in [`packages/pipeline-cli/src/read-stdin.ts`](../../../packages/pipeline-cli/src/read-stdin.ts) —
+  "distinct from a gate's own verdict codes: the input was never read." So a tool's verdict codes are
+  the only codes you read a verdict off; any other non-zero is a read that never happened.
+
+  **Log "read failed" distinctly from "no approval", and name which read failed.** They are
+  different facts with the same non-firing outcome, and collapsing them makes a GitHub outage look
+  like a human who simply hasn't approved yet — a silent stall nobody can see. So a tick ends on
+  exactly one of three lines: the discharge, `no approval at current head (read OK, definite)` when
+  every input read cleanly and the predicate said stop, or the `unknown` line above naming the input
+  that could not be read. The durable authority is still `cp-cardinality` and the shipper's own
+  re-check at enqueue; this rule is defense in depth on the trigger, so a hiccup can never *start* a
+  §CP enqueue — nor hide a stall behind a confident-sounding non-firing line.
 - **Approved at the current head + green → wake and spawn the shipper.** When the predicate discharges
   — a non-author control-plane approval bound to the PR's *current* head, machine gates green — the
   watcher wakes you to spawn the approval-aware `shipper` on that head. The shipper re-runs the same


### PR DESCRIPTION
The engineering-manager crew agent runs an approval-watcher that tells the engine when a banked control-plane PR has been approved, so the shipper can be spawned. Its fail-closed rule only covered one of the reads it depends on — the reviews payload — so when the PR's head SHA failed to resolve, the watcher printed a confident "no approval at current head" instead of admitting the read broke. An approved PR could then sit unshipped with nothing in the log to investigate.

This restates the rule over the whole predicate: every live input it consumes must be proven to have the expected shape before it is interpreted, and any input that could not be read resolves to UNKNOWN → do not fire, re-arm — logged on a line that names which read failed, distinct from a definite non-firing answer.

Fixes #4108

## What changed

Rewrote the fail-closed bullet in `claude-plugins/pipeline-crew/agents/crew-engineering-manager.md` (the approval-watcher spec). The rule now reads over the predicate rather than over the reads that failed historically, and the code block under it is **the tick's guards and only its guards** — it proves its inputs and then hands off, rather than re-deriving the discharge.

1. **Head** — resolved explicitly and asserted 40-hex before any `.commit_id == $HEAD` comparison. This is the defect #4108 reported: `$HEAD` was previously consumed unbound, so an unresolved head compared as `.commit_id == ""`, matched nothing, and landed on the definite branch with every other guard green.
2. **Author** — non-empty, since `cp-cardinality`'s single-owner branch keys on it.
3. **Team roster** — every page asserted to be an array (an unread roster reaching the discharge as empty is `N==0`, a shape the tool decides on).
4. **Reviews** — the original guard, now asserting *every* page is an array. With `--paginate` a per-page `jq -e` reports only the last page's type, so an early error body slipped through.
5. **Machine gates** — green is a precondition of firing, so the guard proves it rather than merely surviving it. `pipeline-cli checks read --expect green` is enumerated against its source contract in `packages/pipeline-cli/src/tools/checks/command.ts`: `0` proven green is the only continuing branch, `1` is the fail-closed definite (it carries *both* not-green and bad input), and `2` / `127` / any other non-zero is UNKNOWN.

The block then stops. The decision itself stays where the preceding bullet says it lives — ship-it's §CP gate via `pipeline-cli cp-cardinality`, which resolves the active approver set and the SHA-bound signal flags itself. The per-approver membership rule (404 definite non-member / 200 carries the state / anything else UNKNOWN) is stated as a rule in the EXACT MEMBERSHIP clause, where that read actually runs.

The exit-code idiom cites the shipped precedent rather than inventing one: `STDIN_READ_FAILED_EXIT_CODE = 4` in `packages/pipeline-cli/src/read-stdin.ts` — "distinct from a gate's own verdict codes: the input was never read."

A tick ends on exactly one line: the discharge, a definite non-firing line naming which condition held (`machine gates not green (read OK, definite)` or `no approval at current head (read OK, definite)`), or the `unknown` line naming the read that could not execute.

Docs-only diff (one markdown agent definition). `pnpm typecheck` green; `pnpm lint:worktree` is a clean skip (no biome-handled files changed).

## Deviations

- **Fail-open shipped in round 1, fixed in round 2 (class 6)** — **Said:** the bullet's own rule is that no input may resolve to a definite answer on a read that could not execute. **Did:** round 1 (`2efa1c0e`) violated it on the machine-gates read — it branched on `rc == 2` alone, so a red/pending head (exit `1`), `checks`'s bad-input `1`, and a `127` PATH gap all fell through to the fire, with `CI_JSON` assigned and never read again. That is the **fail-open** polarity (#3715's shape), introduced *inside* the fix for moving the defect one read over, and it also dropped the green requirement that three other statements in the same section assert. **Why:** no excuse — the same diff's step-6 comment stated the correct exit-code rule and applied it to `cp-cardinality` while withholding it from `checks`. **Disposition:** fixed in this round; the read is now enumerated and only a proven-green `0` continues. Round 1 was contained downstream (the shipper re-runs the green check independently), so nothing shipped on it.
- **Inert code shipped in round 1, removed in round 2 (class 6)** — **Said:** an agent def's code block is procedure an agent copies. **Did:** round 1's per-approver membership fragment could not run — `$u` unbound, two `continue`s with no enclosing loop, `st` never consumed, and the step-6 pipe carrying the *unfiltered* roster regardless; `REVIEWS` was shape-proven and then dropped, with no path from it to the undefined `$SIGNAL_FLAGS`. Fail-closed in effect (no flags → `stop`), but wrong. **Why:** the block was written as a complete tick while parts of it belonged to a loop that was never shown. **Disposition:** the fragment is removed from the block and its rule moved into the EXACT MEMBERSHIP clause; every line in the block now runs end to end with bound variables.
- **Scope narrowed back after round 1 over-reached (class 7)** — **Said:** the bullet directly above the changed one says "no second copy of the §CP discharge forks into this def." **Did:** round 1 turned a guards-only block into a re-derivation of ship-it's integration half — head, author, roster, membership, CI, the `cp-cardinality` invocation, and `fire_shipper` — and re-derived it *differently*. **Why:** #4108's AC asks the rule to read over every live input, which is about the *rule*, not about relocating the discharge into this def. **Disposition:** re-scoped to guards-only; the discharge is pointed at, not restated. This is the root cause of the two deviations above.
- **Pre-existing content changed (class 6)** — **Said:** acceptance criterion 5 asks for no behavior change to the discharge, and the reviews guard was the one part already working. **Did:** tightened the reviews assertion from a per-page `jq -e 'type == "array"'` to a slurped all-pages assertion (shared with the roster read). **Why:** under `--paginate`, `jq -e`'s exit status reflects only the last value, so an error body on an early page passes the guard as written. The change is strictly tighter and never turns a stop into a discharge. **Disposition:** for the reviewer to judge.
- **Known defect left unfixed (class 3)** — **Said:** nothing in #4108 covers `ship-it`. **Did:** left `ship-it`'s own §CP approval gate unchanged, though it resolves `$HEAD`, `$AUTHOR`, and the roster with the same unguarded reads. **Why:** #4108 scopes to the watcher spec, and the merge authority is a separate surface with its own gates. **Disposition:** follow-up #4223 filed.
- **Triage-note claim corrected (class 4)** — **Said:** #4108's triage note calls this path "control-plane surface" that "will need control-plane approval to merge." **Did:** did not adopt that claim, and did not widen the boundary. `claude-plugins/pipeline-crew/agents/**` is **deliberately out of §CP** — a live founder ruling re-affirmed 2026-07-24 (recorded on #3765, re-affirming #2342), stated explicitly in the formats contract's §CP section on a threat-modelled containment basis, closing with "do **not** add `pipeline-crew/agents/**` to `CONTROL_PLANE_RE` on this ruling." `pipeline-cli cp-classify classify` agrees (`not-control-plane`), as does `.github/CODEOWNERS`. **Why:** the absence is a recorded decision, not a gap; the triage note is the thing that is wrong. **Disposition:** #4227 — filed in round 1 as a "§CP boundary gap" — has been re-scoped accordingly; it is a request to reopen a settled ruling, not a gap-fix. Route this PR on the machine classification.
