### PR TITLE
fix(crew-mcp): the schema-reject hint degrades to something a seat without channel_kinds can follow (#4038)

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
@@ -14,9 +14,9 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import {RpcSerialization} from "effect/unstable/rpc";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import {type InboxAck, PeerUnreachableError} from "../peer/index.ts";
-import {stampFromMillis} from "../protocol/index.ts";
+import {payloadSchemaForKind, stampFromMillis} from "../protocol/index.ts";
 import {CHANNEL_CAPABILITY, channelExperimentalCapability} from "./mcp-channel.ts";
-import {ChannelSend, ChannelToolkit, channelToolHandlers} from "./send-tool.ts";
+import {ChannelSend, ChannelToolkit, channelToolHandlers, expectedShapeHint} from "./send-tool.ts";
 
 class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
 	"@kampus/pipeline-crew-mcp/DisposeError",
@@ -302,6 +302,76 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 			assert.include(rendered, "from");
 			// …and the discovery tool is named as the resolve-first path out of the reject.
 			assert.include(rendered, "channel_kinds");
+		}),
+	);
+});
+
+/**
+ * #4038: a seat's granted MCP toolset is per-seat and the server cannot read it, so a reject that
+ * names `channel_kinds` as THE remediation is unfollowable for a seat that lacks the tool (observed
+ * live at a seat holding only `channel_send`/`channel_claim`). Every tier of the hint must therefore
+ * carry shape the caller can act on alone, with the tool pointer appended as a conditional extra.
+ */
+describe("edge/send-tool — the shape hint degrades without assuming channel_kinds (#4038)", () => {
+	// A struct whose SYMBOL key the JSON-Schema render refuses ("Unsupported property signature
+	// name") while `Schema.toRepresentation` — the earlier step — still resolves its keys. This is
+	// the real fixture for the fallback branch: the catalog schemas all render, so the branch is
+	// otherwise unreachable from a `channel_send` call.
+	const symbolKeyed = Schema.Struct({
+		from: Schema.String,
+		[Symbol.for("@kampus/pipeline-crew-mcp/test/unrenderable")]: Schema.String,
+	});
+	// A tuple with post-rest elements: the JSON-Schema render refuses it AND its representation is
+	// not an object, so neither the schema nor the key outline resolves — the last-resort tier.
+	const postRest = Schema.TupleWithRest(Schema.Tuple([Schema.String]), [
+		Schema.Number,
+		Schema.Boolean,
+	]);
+	// resolved through the catalog seam the send path itself uses, so the primary tier is exercised
+	// against a real payload schema rather than a stand-in
+	const intakePing =
+		payloadSchemaForKind("IntakePing") ?? assert.fail("IntakePing is a catalog kind");
+
+	it.effect("the primary tier inlines the shape and phrases the tool pointer conditionally", () =>
+		Effect.gen(function* () {
+			const hint = yield* expectedShapeHint("IntakePing", intakePing);
+			assert.include(hint, "expected shape (JSON Schema)");
+			assert.include(hint, "if your toolset includes the `channel_kinds` tool");
+		}),
+	);
+
+	it.effect(
+		"the fallback tier outlines the payload keys instead of folding to a tool pointer",
+		() =>
+			Effect.gen(function* () {
+				const hint = yield* expectedShapeHint("Unrenderable", symbolKeyed);
+				assert.include(hint, 'expected "Unrenderable" body keys');
+				// the key outline is the actionable content the old fallback branch had none of
+				assert.include(hint, "from: String");
+			}),
+	);
+
+	it.effect("the last-resort tier points at the decode error, not at a tool call", () =>
+		Effect.gen(function* () {
+			const hint = yield* expectedShapeHint("PostRest", postRest);
+			assert.include(hint, "the decode error in this message names what did not match");
+		}),
+	);
+
+	it.effect("no tier tells a caller to call channel_kinds as the way out of the reject", () =>
+		Effect.gen(function* () {
+			const tiers: ReadonlyArray<readonly [string, Schema.Constraint]> = [
+				["IntakePing", intakePing],
+				["Unrenderable", symbolKeyed],
+				["PostRest", postRest],
+			];
+			for (const [kind, schema] of tiers) {
+				const hint = yield* expectedShapeHint(kind, schema);
+				// the exact imperative the pre-#4038 hint used, in both of its branches
+				assert.notInclude(hint, "call the `channel_kinds` tool");
+				// and the pointer, where it survives, is conditional on the caller HAVING the tool
+				assert.include(hint, "if your toolset includes the `channel_kinds` tool");
+			}
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -50,23 +50,64 @@ export class ChannelSend extends Context.Service<
 >()("@kampus/pipeline-crew-mcp/edge/ChannelSend") {}
 
 /**
+ * The `channel_kinds` pointer, phrased as the CONDITIONAL extra it is. A seat's granted toolset is
+ * per-seat and the server cannot read it, so an unconditional "call `channel_kinds`" is unfollowable
+ * for a seat that was never granted the tool — the reject then names a remediation the caller cannot
+ * take (#4038, observed live at a seat holding only `channel_send`/`channel_claim`). It is appended
+ * AFTER the shape tiers below, never instead of them, so it is a bonus for seats that have the tool
+ * and inert for seats that don't.
+ */
+const kindsToolPointer =
+	" — if your toolset includes the `channel_kinds` tool, it serves every kind's full shape";
+
+/**
+ * The last-resort shape line: the payload could not be rendered here at all. It still hands the
+ * caller something followable with no further tool call — the decode error, which sits in the same
+ * `reason` string and names the keys that mismatched.
+ */
+const unrenderableShape = (kind: string): string =>
+	`the "${kind}" payload shape could not be rendered here — the decode error in this message names what did not match`;
+
+/**
+ * A best-effort key outline of a payload: each top-level key, its representation, and whether it is
+ * optional. This is the DEGRADED tier of `expectedShapeHint`, derived from `Schema.toRepresentation`
+ * — the step `toJsonSchemaDocument` runs BEFORE its JSON-Schema render, so it still resolves for a
+ * schema whose semantics JSON Schema cannot express. A payload that isn't an object shape has no
+ * keys to outline, which is the honest unrenderable case rather than an empty list.
+ */
+const payloadKeyOutline = (kind: string, schema: Schema.Constraint): string => {
+	const {representation} = Schema.toRepresentation(schema);
+	if (representation._tag !== "Objects" || representation.propertySignatures.length === 0) {
+		return unrenderableShape(kind);
+	}
+	const keys = representation.propertySignatures.map(
+		(property) =>
+			`${String(property.name)}: ${property.type._tag}${property.isOptional ? " (optional)" : ""}`,
+	);
+	return `expected "${kind}" body keys: ${keys.join(", ")}`;
+};
+
+/**
  * The self-healing hint appended to a schema-mismatch reject: the kind's expected payload rendered
  * as a JSON Schema document, so the reject SHOWS the shape to match rather than leaving the sender to
  * guess it one failed send at a time. This is the same one-step recovery the unknown-kind branch
  * already gives by enumerating the catalog kinds — the schema branch lacked its equivalent, so a
  * seat that booted with no inbound example to copy blind-guessed the body shape (#3761). The value is
  * already resolved beside us: `toJsonSchemaDocument` renders the very shape `channel_kinds` serves.
+ *
  * The render is the one fallible step (it throws on an unrepresentable schema — the same step
- * `protocol/describe` guards), folded here to the `channel_kinds` pointer rather than a native throw.
+ * `protocol/describe` guards), so it degrades through shapes the caller can act on ALONE rather than
+ * folding to a tool pointer: full JSON Schema → the key outline → naming the decode error. Every tier
+ * is followable with no further tool call, because the seat that hits the reject may not hold
+ * `channel_kinds` at all (#4038).
  */
-const expectedShapeHint = (kind: string, schema: Schema.Codec<unknown>): Effect.Effect<string> =>
+export const expectedShapeHint = (kind: string, schema: Schema.Constraint): Effect.Effect<string> =>
 	Effect.try(
-		() =>
-			`expected shape (JSON Schema): ${JSON.stringify(Schema.toJsonSchemaDocument(schema))} — or call the \`channel_kinds\` tool to resolve every kind's shape before sending`,
+		() => `expected shape (JSON Schema): ${JSON.stringify(Schema.toJsonSchemaDocument(schema))}`,
 	).pipe(
-		Effect.orElseSucceed(
-			() => `call the \`channel_kinds\` tool to resolve the "${kind}" payload shape before sending`,
-		),
+		Effect.catch(() => Effect.try(() => payloadKeyOutline(kind, schema))),
+		Effect.orElseSucceed(() => unrenderableShape(kind)),
+		Effect.map((shape) => `${shape}${kindsToolPointer}`),
 	);
 
 /**


### PR DESCRIPTION
When `channel_send` rejects a message whose body doesn't match its kind's schema, the error told the caller to call the `channel_kinds` tool. But a seat's granted MCP toolset is per-seat and the server can't read it, so a seat that was never given `channel_kinds` was handed a remediation it literally cannot take — and in the fallback branch (taken when the JSON-Schema render throws) that pointer was the *only* thing in the hint.

Now the hint degrades through shapes the caller can act on alone: the full JSON Schema, else a key outline of the payload, else naming the decode error that's already in the same message. The `channel_kinds` pointer survives as a conditional extra appended after the shape — useful for seats that have the tool, never the way out for seats that don't.

## What changed

- `packages/pipeline-crew-mcp/src/edge/send-tool.ts` — `expectedShapeHint` becomes three tiers instead of two:
  1. **`expected shape (JSON Schema): {…}`** — unchanged primary, the full rendered document.
  2. **`expected "<kind>" body keys: from: String, note: String (optional)`** — the new degraded tier, derived from `Schema.toRepresentation`. That's the step `Schema.toJsonSchemaDocument` runs *before* its fallible JSON-Schema render, so it still resolves for a schema JSON Schema can't express. This replaces the old fold-to-a-tool-pointer.
  3. **naming the decode error** — the last resort when neither the schema nor an object shape resolves. Still followable with no tool call, because the decode error sits in the same `reason` string.
- The `channel_kinds` pointer is now one shared, conditional suffix: `— if your toolset includes the \`channel_kinds\` tool, it serves every kind's full shape`. Appended to every tier, after the shape.

## Tests

`packages/pipeline-crew-mcp/src/edge/send-tool.test.ts` — a new describe block drives all three tiers directly:

- primary tier against the real catalog schema resolved through `payloadSchemaForKind`;
- the degraded tier against a symbol-keyed struct (the JSON-Schema render refuses it with `Unsupported property signature name` while the representation resolves) — the only way to reach that branch, since every catalog schema renders cleanly;
- the last-resort tier against a post-rest tuple (neither renders nor outlines);
- and a sweep asserting **no** tier contains the pre-fix imperative `call the \`channel_kinds\` tool`, while every tier carries the conditional phrasing.

`pnpm typecheck`, `pnpm lint:worktree`, and the full `pipeline-crew-mcp` suite (432 tests) are green.

Fixes #4038

## Deviations

- **Class: shape of the fix.** Said: the issue names two hint branches. Did: shipped three tiers — the key outline plus a last-resort tier that names the decode error. Why: a schema can fail *both* the JSON-Schema render and the object-shape outline (a post-rest tuple does), and folding that case back to a bare tool pointer would re-open the exact defect. Disposition: no action needed; strictly additive, and the third tier is still tool-free.
- **Class: surface widened beyond the issue.** Said: fix the hint. Did: also exported `expectedShapeHint` (it was module-private) and widened its schema parameter from `Schema.Codec<unknown>` to `Schema.Constraint`. Why: the fallback branch is unreachable through a `channel_send` call — every catalog schema renders — so the regression test has to call the function directly with a deliberately unrenderable schema; `Schema.Constraint` is the honest narrowest type (the hint only reads shape, never decodes) and it also lets the test fixtures be plain schemas instead of casts, which the repo's no-`as unknown as` lint rule forbids. Disposition: no action needed.
- **Class: adjacent work declined.** Said: #3985 (capability handshake) is named as adjacent. Did: nothing toward it. Why: the issue explicitly calls it not a prerequisite, and the server-can't-know-the-grant assumption is exactly what the conditional phrasing handles today. Disposition: for the reviewer to judge; #3985 stays where it is.