### PR TITLE
fix(pipeline): a failed changed-file read is §CP UNKNOWN, never "not control plane" (#4216)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1624,13 +1624,16 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\.jsonc$|^biome-plugins/'
-# --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
-# concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
-# API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a
-# >100-file PR — hiding a control-plane file in the tail. Never pair --paginate with an AGGREGATE
-# --jq (`[ … ]` / `length` / `add`): gh runs the filter PER PAGE and emits one result each (#725).
-gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING — control plane (manual merge)"
+# The list this regex is matched against is a fallible READ, so it comes from §CPREAD's
+# `cp_changed_files` (defined below) — never a bare `gh api … | grep` pipe. With pipefail off that
+# pipe reports grep's status and discards gh's, so a failed read matches nothing and reads as "no §CP
+# path touched" — fail-open at the definition of the boundary itself (#4216). §CPREAD owns the
+# --paginate / streaming-jq / shape-assert rationale; read it there once, don't re-derive it here.
+if ! cp_changed_files "$REPO" "$PR"; then
+  echo "BLOCKING — §CP UNKNOWN (changed-file list unreadable; never 'no control-plane path')"
+elif printf '%s\n' "$CP_FILES" | grep -Eq "$CONTROL_PLANE_RE"; then
+  echo "BLOCKING — control plane (manual merge)"
+fi
 ```
 
 **The §CP-deciding consumers resolve this line from `origin/main` at run time, not from the
@@ -1689,10 +1692,17 @@ GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|contai
 GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\bgat(e|es|ing|ed)\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out'
 GA_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^GUARD_ADR_RE=' | head -n1 || true)"
 if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(printf '%s' "$GA_LIVE" | sed "s/^GUARD_ADR_RE='//; s/'$//")"; else GUARD_ADR_RE='.'; fi   # FAIL CLOSED: '.' ⇒ every ADR word matches ⇒ every touched ADR is §CP
-HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+# The ref and the file list are fallible reads too — both come from §CPREAD (below), so an
+# unreadable head SHA leaves HEAD_SHA EMPTY (payload discarded) rather than holding gh's error body.
+cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+[ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable — ADR content unprobeable ⇒ §CP, fail-closed)"
+printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
   [ -z "$adr" ] && continue
-  body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+  [ -n "$HEAD_SHA" ] || break
+  # Capture and CHECK, never `|| true`: gh writes its error document to STDOUT, so `|| true` would
+  # leave that JSON in $body, skip the fail-closed branch below, and grep an ERROR DOC for guard
+  # vocabulary (§CPREAD property 2).
+  body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || body=""
   if [ -z "$body" ]; then echo "BLOCKING ($adr — unreadable at head ⇒ §CP, fail-closed)"
   elif printf '%s' "$body" | grep -Eiq "$GUARD_ADR_RE"; then echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
 done
@@ -1738,12 +1748,21 @@ so a zero-length list is never a valid "clean" state. "Read failed" and "read fi
 are logged **distinctly**: same outcome, different facts, and collapsing them makes an outage look
 like a clean negative.
 
-This is the **one** hardened read; every §CP site below calls it rather than re-deriving it:
+This is the **one** hardened read, and it binds **every** §CP site — *including the two blocks
+**above*** (the canonical matcher and the ADR content clause), which is why each of them reads
+`$CP_FILES` rather than piping `gh` straight into `grep`. A contract that exempts its own definition
+block is exactly how byte-identical defective copies spread from it, so the scope here is *every*
+site in this file and in every skill that cites it — not merely the ones below.
 
 ```bash
 # §CPREAD — the ONE hardened read of a PR's changed-file list, the input to BOTH §CP clauses.
 # Sets CP_FILES (the list) + CP_FILES_N (the scanned count); returns NON-ZERO on a read that could
 # not execute. A non-zero return is UNKNOWN — hold as §CP — never "no control-plane path touched".
+# --paginate + a STREAMING --jq (one line per file) is load-bearing: gh concatenates the per-page
+# element streams, so a consumer's grep aggregates matches across ALL pages. The API caps per_page at
+# 100 whatever you ask for, so a single non-paginated call truncates a >100-file PR — hiding a §CP
+# file in the tail. Never pair --paginate with an AGGREGATE --jq (`[ … ]` / `length` / `add`): gh runs
+# the filter PER PAGE and emits one result each (#725).
 cp_changed_files() {   # $1 = REPO, $2 = PR
   CP_FILES="$(gh api --paginate "repos/$1/pulls/$2/files?per_page=100" \
     --jq 'if type=="array" then .[].filename else ("payload is not a file-list array"|halt_error(1)) end' 2>/dev/null)" || {
@@ -1757,6 +1776,26 @@ cp_changed_files() {   # $1 = REPO, $2 = PR
     return 1
   fi
   echo "§CP scope: PR #$2 changed-file list read OK — $CP_FILES_N file(s) scanned"   # §ZS #1: state the scope the classification rests on
+}
+
+# The PR head SHA is the SECOND fallible read every §CP site makes — the ref the ADR-0164 content
+# probe reads each ADR body at. It gets the same three properties, and for a reason worth stating
+# once: `HEAD_SHA="$(gh api … --jq .head.sha || true)"` followed by `[ -n "$HEAD_SHA" ]` is a DEAD
+# guard. On failure gh does not apply --jq at all — it writes its error document to STDOUT
+# (property 2) — so the variable is NON-EMPTY and the emptiness test can never fire. Capture, check
+# the exit status, DISCARD the payload, then shape-assert: a ref is 40 bare lowercase hex digits, so
+# an error body (or any other unexpected 200) cannot pass for one.
+cp_head_sha() {   # $1 = REPO, $2 = PR; sets CP_HEAD_SHA (EMPTY on failure), returns NON-ZERO ⇒ UNKNOWN
+  CP_HEAD_SHA="$(gh api "repos/$1/pulls/$2" \
+    --jq 'if type=="object" and (.head.sha|type)=="string" then .head.sha else ("payload is not a PR object"|halt_error(1)) end' 2>/dev/null)" || {
+      CP_HEAD_SHA=""
+      echo "§CP scope: PR #$2 head SHA READ FAILED (gh exited non-zero; payload discarded) — ADR content unprobeable" >&2
+      return 1; }
+  case "$CP_HEAD_SHA" in
+    *[!0-9a-f]*|"") CP_HEAD_SHA=""; echo "§CP scope: PR #$2 head SHA is not bare hex — discarded" >&2; return 1 ;;
+  esac
+  [ "${#CP_HEAD_SHA}" -eq 40 ] || {
+    CP_HEAD_SHA=""; echo "§CP scope: PR #$2 head SHA is not a 40-char ref — discarded" >&2; return 1; }
 }
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1704,6 +1704,70 @@ approval is present (per POLICY, the founder's; ADR 0135). Its **verdict routing
 it is still doc-class, `review-doc`-verified (this set governs *who merges*, not *which gate
 verifies*); the content clause adds only the merge-authority hold.
 
+<a id="cpread"></a>
+### §CPREAD. The changed-file list is a fallible READ — an unread list is UNKNOWN, never "no §CP path" (#4216)
+
+Both clauses above match against **one input**: the PR's changed-file list. That input arrives over
+the network, so it can fail to arrive — and the shape every §CP site reached for
+(`gh api --paginate … --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true`) resolved a failed
+read to the **empty string**, which the surrounding control flow read as *"no control-plane path
+touched"*. That is fail-**open** on the repo's only human-judgment gate (ADR 0135): a genuinely-§CP
+PR classifies ordinary and skips the control-plane approval. It is the recurring
+read-failed-collapsed-into-a-definite-answer class (#3715, #4108, #4171, #4189, #4191, #4204).
+
+**The rule: a read that could not execute resolves to UNKNOWN and holds as §CP.** Three properties
+make that true, each verified against the live API rather than assumed (#4216):
+
+1. **The exit status is the discriminator — capture, check, *then* pipe.** `pipefail` is off in the
+   agent shell, so `gh … | grep … || true` reports `grep`'s status and **discards `gh`'s**. The
+   `|| true` was reasoned about one producer of an empty result (no match is `grep` exit 1, #725)
+   and was blind to the other (the read itself dying). Observed: the 404 pipeline exits **0** with
+   an empty capture.
+2. **The error body arrives on STDOUT.** A failed `gh api --paginate … --jq` writes
+   `{"message":"Not Found",…}` to **stdout** (exit 1), so an unchecked capture hands the §CP regex —
+   or `cp-classify` — an *error document* to classify as if it were a file list. Under a live
+   boundary regex that document matches nothing and the PR reads ordinary. The failure branch must
+   therefore **discard the payload**, not just test it.
+3. **Shape first, then interpret.** The jq guard asserts the page is an **array** before reading
+   `.filename`, so a 200-with-an-unexpected-body cannot be iterated as though it were a file list —
+   the bare non-empty test that once declared two unapproved §CP PRs approved (#3715).
+
+Plus §ZS (ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)):
+**emit the scanned scope**, and treat **zero scope as a failed read** — a PR always changes ≥1 file,
+so a zero-length list is never a valid "clean" state. "Read failed" and "read fine, matched nothing"
+are logged **distinctly**: same outcome, different facts, and collapsing them makes an outage look
+like a clean negative.
+
+This is the **one** hardened read; every §CP site below calls it rather than re-deriving it:
+
+```bash
+# §CPREAD — the ONE hardened read of a PR's changed-file list, the input to BOTH §CP clauses.
+# Sets CP_FILES (the list) + CP_FILES_N (the scanned count); returns NON-ZERO on a read that could
+# not execute. A non-zero return is UNKNOWN — hold as §CP — never "no control-plane path touched".
+cp_changed_files() {   # $1 = REPO, $2 = PR
+  CP_FILES="$(gh api --paginate "repos/$1/pulls/$2/files?per_page=100" \
+    --jq 'if type=="array" then .[].filename else ("payload is not a file-list array"|halt_error(1)) end' 2>/dev/null)" || {
+      CP_FILES=""; CP_FILES_N=0
+      echo "§CP scope: PR #$2 changed-file list READ FAILED (gh exited non-zero; payload discarded) — 0 file(s) scanned" >&2
+      return 1; }
+  CP_FILES_N="$(printf '%s\n' "$CP_FILES" | grep -c . || true)"
+  if [ "$CP_FILES_N" -eq 0 ]; then
+    CP_FILES=""
+    echo "§CP scope: PR #$2 changed-file list read returned ZERO files — a PR always changes >=1 file, so this is a FAILED READ, not a clean 'no §CP path'" >&2
+    return 1
+  fi
+  echo "§CP scope: PR #$2 changed-file list read OK — $CP_FILES_N file(s) scanned"   # §ZS #1: state the scope the classification rests on
+}
+```
+
+Consumers branch on its **return status**, and on failure resolve toward §CP:
+
+```bash
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
+fi
+```
+
 ### A path-only §CP answer is NEVER authoritative — use `cp-classify` (#4161)
 
 The two clauses above are **independent sources** of §CP membership, and `CONTROL_PLANE_RE` has
@@ -1722,8 +1786,15 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # The §CP classification entry point — four states on stdout (#4161). Re-resolves the live
 # CONTROL_PLANE_RE from origin/main itself (#981); pass --control-plane-re to reuse one you
 # already resolved. ASSERT ON THE STATE WORD, never on the exit status alone — see below.
-CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | "$PCLI" cp-classify classify --repo "$REPO")"
+# The INPUT comes from §CPREAD, never from a bare `gh api … |` pipe: with pipefail off, a failed
+# read pipes its stdout ERROR BODY into the verb, which sees one non-`.decisions/` "path", matches
+# no §CP clause, and answers `not-control-plane` — a fail-open at the very entry point that exists
+# to prevent one (#4216).
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # §CPREAD: the input never arrived ⇒ UNKNOWN ⇒ hold as §CP
+else
+  CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
+fi
 if [ "$CP_STATE" = "not-control-plane" ]; then
   : # proven ordinary — the ONLY branch that may skip the §CP hold
 else
@@ -1775,6 +1846,12 @@ table or it does not ship.
 The boundary stays single-sourced on both axes: `CONTROL_PLANE_RE` in the pipeline-cli const
 (#2761), `GUARD_ADR_RE` in this file, and the content clause's **scope** (`.decisions/**`) once in
 `cp-classify`'s core. No consumer re-declares any of the three.
+
+**Every row's *input* is §CPREAD** — the register says which *sources* a site consults; §CPREAD is
+how it obtains the file list those sources are evaluated against. A site that hardens one clause but
+reads its input unchecked is still fail-open, because a failed read blinds **both** clauses at once
+(#4216). `codeowners-cp` is the one exception on this axis too: it runs over the boundary regex, not
+over a PR's changed files, so it has no such read.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -572,7 +572,14 @@ So the verdict's not-auto-mergeable flag matches the **canonical §CP set** (the
 not from the copy embedded in this skill body.** The embedded copy travels in the *injected
 snapshot*, which can lag `origin/main` even when the on-disk file is current, so a pre-amendment
 snapshot once mis-classified a now-control-plane PR (#981); reading §CP freshly from `origin/main`
-(and **failing closed** if that read can't be made) keeps the flag tracking `main`, not snapshot age:
+(and **failing closed** if that read can't be made) keeps the flag tracking `main`, not snapshot age.
+
+The *boundary* is only half of it: the **changed-file list** the boundary is matched against is a
+fallible network read too, and a failed read used to resolve to "no control-plane path touched"
+(#4216). **Define `cp_changed_files` from
+[§CPREAD](../gh-issue-intake-formats.md#cpread) — copy it verbatim, it is the single source — before
+running the block below**, which consumes its `$CP_FILES` / `$CP_FILES_N` and holds §CP on a
+non-zero return:
 
 ```bash
 # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
@@ -590,25 +597,46 @@ if [ -n "$CP_LIVE" ]; then
 else
   CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (not-auto-mergeable), never trust the possibly-stale snapshot
 fi
-# --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
-# ACROSS the concatenated pages — a jq `[ … ]` aggregate would instead emit one array PER PAGE.
-# `|| true`: no §CP match is grep exit 1, an empty (non-control-plane) result, not a failure (#725).
-CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
-# non-empty → control-plane: emit the advisory line in the verdict (Step 4a) per ADR 0053/0065/0073
-# §CP by CONTENT (ADR 0164): a touched .decisions/** ADR is not path-§CP, but a guard-RELAXING one is
-# control-plane by nature. Probe each ADR's content at head with the SHARED `guard-content-probe` verb
-# — the SAME probe ship-it Step 0, review-doc, and the driver (via trivial-diff) call, so a guard-touching
-# ADR reads §CP consistently everywhere (issue #3645, founder ruling #3416). A mixed code+guard-ADR PR
-# fans BOTH gates; either flagging the ADR carries the §CP merge-authority hold. Fail-closed inside the verb.
-HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-GUARD_TOUCHING=""
-while IFS= read -r adr; do
-  [ -z "$adr" ] && continue
-  gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-    | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null \
-    && GUARD_TOUCHING="$GUARD_TOUCHING $adr"
-done < <(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' | grep -E '^\.decisions/.*\.md$' || true)
+# ONE hardened read of the changed-file list, feeding BOTH §CP clauses below. `cp_changed_files` is
+# §CPREAD of ../gh-issue-intake-formats.md — exit-status-checked, shape-asserted, scope-emitting; a
+# non-zero return means the read COULD NOT EXECUTE, which is UNKNOWN, not "no §CP path touched". Read
+# the why there once; do not re-derive it here. It also removes the second read this step used to make
+# (the GUARD_TOUCHING loop re-fetched the same list), so both clauses now see the same scanned scope.
+if ! cp_changed_files "$REPO" "$PR"; then
+  # FAIL CLOSED (#4216): a blinded read blinds BOTH clauses at once — the path regex AND the ADR-0164
+  # content probe, which is the only §CP signal a `.decisions/**`-only PR can produce. So resolve BOTH
+  # toward §CP; the sentinel is non-empty, which is exactly what Step 4a branches on.
+  CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+else
+  # grep aggregates the §CP matches ACROSS the concatenated pages — a jq `[ … ]` aggregate would
+  # instead emit one array PER PAGE. `|| true` here is now safe and means ONLY what it says: no §CP
+  # match is grep exit 1 over a list that was PROVEN to arrive (#725 + #4216).
+  CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
+  # non-empty → control-plane: emit the advisory line in the verdict (Step 4a) per ADR 0053/0065/0073
+  # §CP by CONTENT (ADR 0164): a touched .decisions/** ADR is not path-§CP, but a guard-RELAXING one is
+  # control-plane by nature. Probe each ADR's content at head with the SHARED `guard-content-probe` verb
+  # — the SAME probe ship-it Step 0, review-doc, and the driver (via trivial-diff) call, so a guard-touching
+  # ADR reads §CP consistently everywhere (issue #3645, founder ruling #3416). A mixed code+guard-ADR PR
+  # fans BOTH gates; either flagging the ADR carries the §CP merge-authority hold.
+  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+  GUARD_TOUCHING=""
+  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"   # fail closed: no ref ⇒ no probe ⇒ UNKNOWN
+  ADR_N=0
+  while IFS= read -r adr; do
+    [ -z "$adr" ] && continue
+    [ -n "$HEAD_SHA" ] || break
+    ADR_N=$((ADR_N + 1))
+    # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
+    adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+    if [ -z "$adr_body" ]; then
+      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # fail closed: never auto-ship an ADR that could not be read and proven guard-free
+    elif printf '%s' "$adr_body" | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null; then
+      GUARD_TOUCHING="$GUARD_TOUCHING $adr"
+    fi
+  done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
+  echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092): a §CP classification always states its scope
+fi
 # non-empty $GUARD_TOUCHING → §CP-advisory, same as CONTROL_PLANE_TOUCHED above (Step 4a; ADR 0164/0135)
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -576,10 +576,10 @@ snapshot once mis-classified a now-control-plane PR (#981); reading §CP freshly
 
 The *boundary* is only half of it: the **changed-file list** the boundary is matched against is a
 fallible network read too, and a failed read used to resolve to "no control-plane path touched"
-(#4216). **Define `cp_changed_files` from
-[§CPREAD](../gh-issue-intake-formats.md#cpread) — copy it verbatim, it is the single source — before
-running the block below**, which consumes its `$CP_FILES` / `$CP_FILES_N` and holds §CP on a
-non-zero return:
+(#4216). **Define `cp_changed_files` and `cp_head_sha` from
+[§CPREAD](../gh-issue-intake-formats.md#cpread) — copy them verbatim, it is the single source — before
+running the block below**, which consumes their `$CP_FILES` / `$CP_FILES_N` / `$CP_HEAD_SHA` and holds
+§CP on a non-zero return:
 
 ```bash
 # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
@@ -619,7 +619,10 @@ else
   # — the SAME probe ship-it Step 0, review-doc, and the driver (via trivial-diff) call, so a guard-touching
   # ADR reads §CP consistently everywhere (issue #3645, founder ruling #3416). A mixed code+guard-ADR PR
   # fans BOTH gates; either flagging the ADR carries the §CP merge-authority hold.
-  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+  # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
+  # (copy it verbatim from there). It leaves HEAD_SHA EMPTY on failure by DISCARDING gh's payload,
+  # which is what makes the `[ -n ]` test below a live guard rather than a dead one.
+  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
   GUARD_TOUCHING=""
   [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"   # fail closed: no ref ⇒ no probe ⇒ UNKNOWN
   ADR_N=0

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -292,17 +292,28 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # Four states on stdout. Assert on the STATE WORD, never on the exit status — the exit code
 # discriminates the four states only once the verb has RUN, so `… || ordinary` fail-opens on a
 # usage error (1) or a missing binary (127). The `else` below is the catch-all (formats §CP; #4161).
-CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | "$PCLI" cp-classify classify --repo "$REPO")"
+# The verb's INPUT is a fallible read, so it comes from §CPREAD's `cp_changed_files` (copy it and
+# `cp_head_sha` verbatim from ../gh-issue-intake-formats.md) — never a bare `gh api … |` pipe: with
+# pipefail off, a failed read pipes gh's stdout ERROR BODY into the verb, which matches no §CP clause
+# and answers `not-control-plane` (#4216).
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ held as §CP by the catch-all below
+else
+  CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
+fi
 # `content-undetermined` is an OBLIGATION, not an answer: probe each listed ADR at head before
 # calling this PR non-blocking (the same ADR-0164 verb ship-it Step 0 and review-code/doc run).
 if [ "$CP_STATE" = "content-undetermined" ]; then
-  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
+  [ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable — ADR content unprobeable ⇒ §CP, fail-closed)"
+  [ -z "$HEAD_SHA" ] || printf '%s\n' "$CP_FILES" \
     | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-        gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-          | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null \
-          && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+        # Capture and CHECK, never a straight pipe — gh writes its error document to STDOUT, so a
+        # pipe hands the probe an ERROR BODY as the ADR body (§CPREAD #2).
+        adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+        if [ -z "$adr_body" ]; then echo "BLOCKING ($adr — body unreadable at head ⇒ §CP, fail-closed)"
+        elif printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null; then
+          echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
       done
 elif [ "$CP_STATE" != "not-control-plane" ]; then
   # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -187,8 +187,9 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
     CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
   fi
   # The changed-file list is a fallible READ, and a failed one used to resolve to "no control-plane
-  # path touched" (#4216). `cp_changed_files` is §CPREAD of ../gh-issue-intake-formats.md — copy it
-  # verbatim from there (single source), and read the why there, not here.
+  # path touched" (#4216). `cp_changed_files` (and `cp_head_sha`, used by the content clause below)
+  # is §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim from there (single source), and
+  # read the why there, not here.
   CP_READ_FAILED=
   if ! cp_changed_files "$REPO" "$PR"; then
     CP_READ_FAILED=1   # carried into the CONTENT clause below — one read, both clauses
@@ -223,7 +224,10 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   if [ -n "$CP_READ_FAILED" ]; then
     GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
   else
-    HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+    # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
+    # (copy it verbatim from there). It DISCARDS gh's payload on failure, which is what makes the
+    # `[ -n ]` test below a live guard rather than a dead one.
+    cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
     [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"
     ADR_N=0
     while IFS= read -r adr; do

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -186,11 +186,19 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   else
     CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
   fi
-  # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
-  # ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match is
-  # grep exit 1, an empty (non-control-plane) result, not a failure (#725).
-  CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-    --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
+  # The changed-file list is a fallible READ, and a failed one used to resolve to "no control-plane
+  # path touched" (#4216). `cp_changed_files` is §CPREAD of ../gh-issue-intake-formats.md — copy it
+  # verbatim from there (single source), and read the why there, not here.
+  CP_READ_FAILED=
+  if ! cp_changed_files "$REPO" "$PR"; then
+    CP_READ_FAILED=1   # carried into the CONTENT clause below — one read, both clauses
+    CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"   # FAIL CLOSED
+  else
+    # grep aggregates the §CP matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER
+    # PAGE. `|| true` now means ONLY what it says: no match is grep exit 1 over a list PROVEN to
+    # arrive, not a swallowed read failure (#725 + #4216).
+    CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
+  fi
   # non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
   ```
 - **Any guard-touching `.decisions/**` ADR (§CP by CONTENT, ADR 0164)** — a `.decisions/**` ADR is
@@ -208,15 +216,30 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
 
   ```bash
   # Probe each touched .decisions/** ADR's CONTENT at head with the shared verb (single source of the
-  # ADR-0164 guard vocabulary; #3645). Exit 0 ⇒ guard-touching ⇒ §CP-advisory. Fail-closed inside the verb.
-  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+  # ADR-0164 guard vocabulary; #3645). Exit 0 ⇒ guard-touching ⇒ §CP-advisory.
+  # Same §CPREAD input as the path clause above — a blinded file-list read blinds the CONTENT clause
+  # too, and for a `.decisions/**`-only PR the content clause is the ONLY §CP signal there is (#4216).
   GUARD_TOUCHING=""
-  while IFS= read -r adr; do
-    [ -z "$adr" ] && continue
-    gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-      | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null \
-      && GUARD_TOUCHING="$GUARD_TOUCHING $adr"
-  done < <(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' | grep -E '^\.decisions/.*\.md$' || true)
+  if [ -n "$CP_READ_FAILED" ]; then
+    GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  else
+    HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+    [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"
+    ADR_N=0
+    while IFS= read -r adr; do
+      [ -z "$adr" ] && continue
+      [ -n "$HEAD_SHA" ] || break
+      ADR_N=$((ADR_N + 1))
+      # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
+      adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+      if [ -z "$adr_body" ]; then
+        GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
+      elif printf '%s' "$adr_body" | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null; then
+        GUARD_TOUCHING="$GUARD_TOUCHING $adr"
+      fi
+    done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
+    echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092)
+  fi
   # non-empty $GUARD_TOUCHING → blocking: §CP-advisory, same as a control-plane path above (ADR 0164/0135)
   ```
 - **Otherwise** → **non-blocking**, and the doc class — *which* `*.md`/knowledge files are

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -218,17 +218,28 @@ PR=<pr number>
 # Assert on the STATE WORD, never on the exit status — the exit code discriminates the four states
 # only once the verb has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing
 # binary (127). The `else` below is the catch-all that makes that safe (formats §CP; #4161).
-CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | "$PCLI" cp-classify classify --repo "$REPO")"
+# The verb's INPUT is a fallible read, so it comes from §CPREAD's `cp_changed_files` (copy it and
+# `cp_head_sha` verbatim from ../gh-issue-intake-formats.md) — never a bare `gh api … |` pipe: with
+# pipefail off, a failed read pipes gh's stdout ERROR BODY into the verb, which matches no §CP clause
+# and answers `not-control-plane` (#4216).
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ held as §CP by the catch-all below
+else
+  CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
+fi
 # `content-undetermined` is an OBLIGATION, not an answer: probe each touched ADR at head with the
 # SAME ADR-0164 verb ship-it Step 0 and review-code/review-doc run. Any BLOCKING line ⇒ §CP.
 if [ "$CP_STATE" = "content-undetermined" ]; then
-  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
+  [ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable — ADR content unprobeable ⇒ §CP, fail-closed)"
+  [ -z "$HEAD_SHA" ] || printf '%s\n' "$CP_FILES" \
     | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-        gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-          | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null \
-          && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+        # Capture and CHECK, never a straight pipe — gh writes its error document to STDOUT, so a
+        # pipe hands the probe an ERROR BODY as the ADR body (§CPREAD #2).
+        adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+        if [ -z "$adr_body" ]; then echo "BLOCKING ($adr — body unreadable at head ⇒ §CP, fail-closed)"
+        elif printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null; then
+          echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
       done
 elif [ "$CP_STATE" != "not-control-plane" ]; then
   # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -93,8 +93,14 @@ don't re-hard-code the list:
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 PR=<pr number>
-FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # --paginate + streaming --jq: full set past file #100 (#725)
-NFILES=$(printf '%s\n' "$FILES" | grep -c . || true)
+# The changed-file list is a fallible READ, and an unchecked capture resolved a failed one to "no §CP
+# path touched" (#4216) — at the gate that routes to the LIGHTER path, so a fail-open here UNDER-gates.
+# `cp_changed_files` / `cp_head_sha` are §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim
+# from there (single source; the why lives there, not here).
+if ! cp_changed_files "$REPO" "$PR"; then
+  echo "review-trivial: not-trivial — changed-file list unreadable (§CP UNKNOWN, never 'no §CP path'); route to full path"; exit 0
+fi
+FILES="$CP_FILES"; NFILES="$CP_FILES_N"   # proven-arrived; scope already emitted per §ZS #1 (ADR 0092)
 ADD=$(gh api repos/$REPO/pulls/$PR --jq '.additions'); DEL=$(gh api repos/$REPO/pulls/$PR --jq '.deletions')
 
 # Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
@@ -152,10 +158,16 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 if [ "$CP_STATE" != "not-control-plane" ]; then
   # Resolve the one state that is an obligation rather than a verdict (ADR 0164, #4161).
   if [ "$CP_STATE" = "content-undetermined" ]; then
-    HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+    cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
+    if [ -z "$HEAD_SHA" ]; then
+      echo "review-trivial: not-trivial — head SHA unreadable, ADR content unprobeable (§CP UNKNOWN); route to full path"; exit 0
+    fi
     GUARD_TOUCHING="$(printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-        gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-          | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null && echo "$adr"
+        # Capture and CHECK, never a straight pipe: gh writes its error document to STDOUT, so a pipe
+        # hands the probe an ERROR BODY as the ADR body (§CPREAD #2). Unreadable ⇒ §CP, fail-closed.
+        adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+        if [ -z "$adr_body" ]; then echo "$adr(body-unreadable⇒§CP)"
+        elif printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null; then echo "$adr"; fi
       done)"
     if [ -z "$GUARD_TOUCHING" ]; then
       : # every touched ADR probed not-guard-touching ⇒ the content axis is resolved, carry on

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -338,8 +338,8 @@ and **fails closed** (treats every path as control-plane → refuses) if that re
 # content clause, has-code/has-docs/has-skills, has-ui — is a `grep` over it. So a failed read used
 # to answer "no §CP path, no classes present" in one stroke: the capture's exit status was never
 # checked, and an empty $FILES made every `grep -q … && echo …` silent (#4216). `cp_changed_files` is
-# §CPREAD of ../gh-issue-intake-formats.md — copy it verbatim from there (single source; the why
-# lives there, not here). --paginate + streaming --jq inside it gets the full set past file #100 (the
+# §CPREAD of ../gh-issue-intake-formats.md — copy it (and its `cp_head_sha` companion, used by the
+# content clause below) verbatim from there (single source; the why lives there, not here). --paginate + streaming --jq inside it gets the full set past file #100 (the
 # API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725).
 if ! cp_changed_files "$REPO" "$PR"; then
   # FAIL CLOSED, and STOP — with no file list there is no classification to make: not §CP, not the
@@ -379,7 +379,10 @@ echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plan
 # never auto-ship an ADR that couldn't be read and proven guard-free. That resolution is made HERE,
 # in the shell: the verb never sees a failed read, because a straight pipe would hand it `gh`'s error
 # document as the ADR body and it would classify THAT (§CPREAD #2, #4216).
-HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+# The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files` (copy
+# it verbatim from there). It DISCARDS gh's payload on failure, which is what makes the emptiness
+# test below a live guard: with a bare `|| true` the error document lands in HEAD_SHA, non-empty.
+cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
 if [ -z "$HEAD_SHA" ]; then
   echo "BLOCKING (head SHA unreadable ⇒ no ref to probe ADR content at ⇒ §CP UNKNOWN, held)"   # fail closed: an unprobeable content clause is not an absent one
 else

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -334,7 +334,23 @@ and **fails closed** (treats every path as control-plane → refuses) if that re
   scope-consistency note after the routing.
 
 ```bash
-FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725)
+# The changed-file list is a fallible network READ, and EVERY probe in this step — §CP, the ADR
+# content clause, has-code/has-docs/has-skills, has-ui — is a `grep` over it. So a failed read used
+# to answer "no §CP path, no classes present" in one stroke: the capture's exit status was never
+# checked, and an empty $FILES made every `grep -q … && echo …` silent (#4216). `cp_changed_files` is
+# §CPREAD of ../gh-issue-intake-formats.md — copy it verbatim from there (single source; the why
+# lives there, not here). --paginate + streaming --jq inside it gets the full set past file #100 (the
+# API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725).
+if ! cp_changed_files "$REPO" "$PR"; then
+  # FAIL CLOSED, and STOP — with no file list there is no classification to make: not §CP, not the
+  # class set, not has-ui. Emitting BLOCKING is the safe resolution of the §CP axis (this step's
+  # output is what the Routing below refuses on), but the class axis is UNRESOLVED, not empty, so
+  # ship-it must not proceed to require zero gates.
+  echo "BLOCKING (changed-file list unreadable ⇒ §CP UNKNOWN, held — ADR 0092 §ZS, #4216)"
+  echo "STOP: classification unresolved — refuse to enqueue and report the failed read; do NOT read this as 'no gates required'."
+  exit 1
+fi
+FILES="$CP_FILES"   # proven-arrived, scope already emitted ($CP_FILES_N files) per §ZS #1
 # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
 # is current — a pre-amendment snapshot once auto-merged a now-control-plane PR (#981).
 # §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
@@ -360,14 +376,24 @@ echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plan
 # only here. The GUARD_ADR_RE vocabulary stays single-sourced in gh-issue-intake-formats.md §CP; the
 # verb reads it from the local checkout (immune to the #981 injected-snapshot staleness — it reads
 # disk, not this skill's prompt copy). FAIL CLOSED: an unreadable ADR body (delete/404) ⇒ §CP —
-# never auto-ship an ADR that couldn't be read and proven guard-free (the verb resolves this itself).
-HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-  [ -z "$adr" ] && continue
-  gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-    | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null \
-    && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
-done
+# never auto-ship an ADR that couldn't be read and proven guard-free. That resolution is made HERE,
+# in the shell: the verb never sees a failed read, because a straight pipe would hand it `gh`'s error
+# document as the ADR body and it would classify THAT (§CPREAD #2, #4216).
+HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+if [ -z "$HEAD_SHA" ]; then
+  echo "BLOCKING (head SHA unreadable ⇒ no ref to probe ADR content at ⇒ §CP UNKNOWN, held)"   # fail closed: an unprobeable content clause is not an absent one
+else
+  echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+    [ -z "$adr" ] && continue
+    # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
+    adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+    if [ -z "$adr_body" ]; then
+      echo "BLOCKING ($adr — ADR body unreadable ⇒ §CP UNKNOWN, held)"
+    elif printf '%s' "$adr_body" | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null; then
+      echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+    fi
+  done
+fi
 # The has-code/has-docs/has-skills probes are single-sourced as canonical HAS_*_RE= lines in
 # gh-issue-intake-formats.md §CLASS and re-resolved from origin/main here (like CONTROL_PLANE_RE/
 # UI_RE, #981) so this snapshot can't mis-classify — and so the reviewer (which consumes the SAME


### PR DESCRIPTION
Fixes #4216

## The defect

§CP membership has two independent clauses — the path regex `CONTROL_PLANE_RE` and the ADR-0164 guard-touching-ADR content probe — and **both are matched against one input: the PR's changed-file list.** That input is a network read, and the shape every §CP site reached for

```bash
gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true
```

resolves a **failed** read to the empty string, which the surrounding control flow reads as *"no control-plane path touched" ⇒ ordinary, auto-mergeable PR*. Fail-**open** on the repo's only human-judgment gate (ADR 0135). One blinded read blinds **both** clauses at once, which matters most for a `.decisions/**`-only PR: the content clause is the *only* §CP signal such a PR can produce.

## What was verified live, not reasoned about

Every claim below was run against the live API on this platform; the transcript is reproduced here.

| probe | result |
| --- | --- |
| `gh … /pulls/99999999/files --jq … \| grep -E … \|\| true` | **pipeline exit 0, empty capture** — `pipefail` is off, so the pipeline reports `grep`'s status and discards `gh`'s |
| the same read, capture only | **exit 1**, and the error document `{"message":"Not Found",…}` on **STDOUT** |
| that error body piped into `pipeline-cli cp-classify classify` | **`not-control-plane`, exit 3** — *"Proven ordinary."* |
| `HEAD_SHA="$(gh api … --jq .head.sha 2>/dev/null \|\| true)"` on a failing read | **120 chars of error JSON in the variable** — so a following `[ -n "$HEAD_SHA" ]` test is a **dead guard** that can never fire |

The third row is the one worth stopping on. `cp-classify` is the entry point PR #4204 (`febe9f38`) shipped **so that a §CP answer could not be fail-open** — but its own canonical snippet fed it a bare `gh api … |` pipe, so on a failed read it classified `gh`'s error document as a one-line file list, matched no clause, and returned the single verdict the design says means *proven ordinary*. The verb was correct; its input was not.

The fourth row is the same class one variable over: `gh` does not apply `--jq` on failure, it dumps the raw error body to **stdout**, so `|| true` + an emptiness test *looks* fail-closed and is inert.

## The fix — one hardened read, single-sourced as §CPREAD

`gh-issue-intake-formats.md` §CP gains **§CPREAD**, the hardened read of the two fallible inputs every §CP site needs: `cp_changed_files` (the changed-file list) and `cp_head_sha` (the ref the ADR-0164 content probe reads bodies at). Both compose the two house idioms the issue named (capture-then-pipe + fail-closed-on-empty) and add the §ZS pair:

- **Exit status is the discriminator** — capture, check `$?`, *then* pipe the variable. The old `|| true` comment reasoned about one producer of an empty result (`grep` exit 1, #725) and was blind to the other (the read dying); the corrected comment now names both, and `|| true` survives only where it means what it says — over a list proven to have arrived.
- **Discard the payload on failure** — because `gh` writes its error body to **stdout**, testing emptiness is not enough; the failure branch throws the payload away so no classifier ever sees it, and so the emptiness test downstream is a *live* guard.
- **Shape first** — `jq 'if type=="array" then .[].filename else halt_error(1) end'` asserts the payload is a file-list array before `.filename` is read; `cp_head_sha` likewise asserts a PR object and then that what survives is 40 bare hex digits, so a 200-with-an-unexpected-body cannot be iterated or used as a ref (#3715's class).
- **§ZS / ADR 0092** — emit the scanned changed-file count, and treat **zero scope as a failed read** (a PR always changes ≥1 file). "Read failed" and "read fine, matched nothing" are logged **distinctly**: same outcome, different facts.
- A non-zero return is **UNKNOWN**, and every consumer resolves it toward **§CP**, never away.

Every §CP site takes its input from §CPREAD — including the two blocks in the formats file *above* it, which is now what §CPREAD's own scope wording says:

| site | change |
| --- | --- |
| `gh-issue-intake-formats.md` §CP | defines §CPREAD; **its own canonical-matcher block and ADR-content-clause block** consume it instead of a bare pipe / an unchecked `HEAD_SHA` + `|| true` body read; the `cp-classify` entry-point snippet does too |
| `review-code` Step 2 | `CONTROL_PLANE_TOUCHED` **and** the `GUARD_TOUCHING` loop both consume one §CPREAD read (the loop's second, redundant fetch of the same list is gone); both hold §CP on a failed read; scope emitted as `N file(s) scanned, M ADR(s) content-probed` |
| `review-doc` Step 0 | identical treatment of the same two clauses |
| `ship-it` Step 0 | `FILES` comes from §CPREAD; a failed read emits `BLOCKING` **and stops** — with no file list the *class* axis (has-code/has-docs/has-skills/has-ui) is unresolved, not empty, so it must not fall through to "no gates required" |
| `review-skill` Step 0 | swept onto §CPREAD (was a bare pipe into `cp-classify` + an unchecked `HEAD_SHA` + a straight pipe of the ADR body into the probe) |
| `review-design` Step 0 | same sweep, same three defects |
| `review-trivial` | same sweep; its `FILES=` capture was unchecked too, and it is the gate that routes to the **lighter** path, so a fail-open there **under**-gates |

The per-ADR **body** read is hardened at every one of those sites for the same reason: `gh`'s error document on stdout was being piped straight into `guard-content-probe`, which then classified an error body as an ADR. It is now captured, checked, and an unreadable body resolves to §CP. `HEAD_SHA` is likewise fail-closed through `cp_head_sha` — no ref to probe at means the content clause is *unprobeable*, not *absent*.

## Verification

Run this branch's §CPREAD against the live API:

```
1. failed read (PR #99999999)   → §CP scope: READ FAILED … 0 file(s) scanned  ⇒ VERDICT: §CP (held)     [was: ordinary]
2. real §CP PR (#4229)          → §CP scope: read OK — N file(s) scanned       ⇒ VERDICT: §CP (held)
3. real ordinary PR (#4165)     → §CP scope: read OK — 1 file(s) scanned       ⇒ VERDICT: ordinary       [no over-match regression]
4. cp-classify fed an error body                                               ⇒ not-control-plane (exit 3)   [the fail-open]
5. cp-classify fed through §CPREAD                                             ⇒ CP_STATE=unknown            [held]
6. cp_head_sha on PR #4229      → rc=0, 40-hex SHA
7. cp_head_sha on PR #99999999  → rc=1, CP_HEAD_SHA EMPTY (payload discarded) ⇒ GUARD_TOUCHING held as §CP
8. the OLD `|| true` head-SHA shape on the same failing read → 120 chars of error JSON, `[ -n ]` reads as SUCCESS  [the dead guard]
```

Rows 6–8 were executed with the function extracted **verbatim from this head**.

Guards run green on this head: `gh-phoenix lint-skills`, `adoption-lint check` (full CI corpus), `codeowners-cp check`, `validate-gate-path-drift.sh` (17 checks), `validate-skills.sh`, `pnpm lint:worktree`.

## Acceptance criteria

- **`CONTROL_PLANE_TOUCHED` no longer derives from a pipeline whose first stage is a fallible read** — the list is captured by §CPREAD and its success checked before any `grep`.
- **A failed/empty read resolves toward §CP at both limbs** — path *and* `GUARD_TOUCHING`.
- **The scanned scope is emitted at every site** (§ZS #1): file count at all sites, plus the ADR content-probe count at the gates.
- **The `|| true` comment now names both producers of an empty result**, and is confined to the position where only `grep`'s exit can produce one.
- **`ship-it` Step 0 is fixed the same way** (triage's in-scope ruling): the capture asserts a successful, non-zero-length read, and a failure resolves toward BLOCKING — plus a stop, because the class axis is unresolved too.
- **A failed read's error body is never what the §CP regex is matched against** — the failure branch discards it, and the shape guard rejects a non-array payload.
- **The reproduction no longer yields a silent "not §CP"** — row 1 above.

## Deviations

1. **[Out-of-scope change] `review-doc` Step 0 was fixed alongside `review-code` and `ship-it`.** *Said:* the issue names two skills. *Did:* fixed a third, `review-doc`, which carries a byte-identical copy of both defective sites. *Why:* triage's own in-scope ruling for `ship-it` — "the two skills' §CP classifications are correlated, not orthogonal; the same transient window empties both; a backstop that fails in the same window is not a backstop" — applies verbatim to `review-doc`. It is a merge-deciding gate whose §CP advisory feeds `ship-it`, it is already inside the §CP boundary so it costs no extra approval round, and leaving it would have left the fixed defect live in a sibling gate. *Disposition:* no action needed.

2. **[Out-of-scope change] The canonical `cp-classify` snippet in `gh-issue-intake-formats.md` §CP was rewired too.** *Said:* the issue's fix shape is bash at the named gate sites. *Did:* also fixed the §CP *entry point*'s own input. *Why:* it was fail-open by the exact mechanism this issue describes, verified live (row 4 above) — a failed read fed `cp-classify` an error document and got back `not-control-plane`. Fixing three gates while the shared entry point they and three other gates cite stayed fail-open would have been a partial mitigation, not the root cause. *Disposition:* no action needed.

3. **[Out-of-scope change — and a RETRACTED rationale] The three gates already rewired onto `cp-classify` (`review-design`, `review-skill`, `review-trivial`) were swept in this round.** *Said, in the version of this section the gate read:* they "consume the entry point, so the entry-point fix is the load-bearing one for them." **That rationale was false and is retracted.** These are **prose** skills: an agent executes the copy of the bash in the file it is reading, not the canonical snippet in the formats contract — there is no runtime indirection, so nothing propagates from the entry point. Verified: each of the three still carried the **verbatim** defective pipe at its own call site, plus an unchecked `HEAD_SHA` and a straight pipe of the ADR body into `guard-content-probe`. *Did:* swept all three onto §CPREAD and hardened their per-ADR body reads. *Why:* leaving them is the exact propagation this PR exists to stop, and `review-trivial` routes to the **lighter** gate, so a fail-open there under-gates rather than merely mis-labels. All three are already inside `CONTROL_PLANE_RE`, so the sweep costs no extra approval round. *Disposition:* no action needed; the follow-up is now only the verb (deviation 4).

4. **[Shape choice] The head-SHA read is a second §CPREAD bash function, not three inline copies.** *Said:* the issue's own guidance — "apply an existing house idiom, do not invent one". *Did:* single-sourced the hardened head-SHA read as `cp_head_sha` next to `cp_changed_files`, rather than repeating the capture-check-discard-shape-assert shape at each of the six consuming sites. *Why:* six byte-identical copies is precisely the shape that produced the defect this PR closes; §CPREAD is already the single source for the sibling read. *Disposition:* no action needed.

5. **[Scope narrowing] No `pipeline-cli` verb was added for the hardened read.** *Said:* the issue's own guidance — "apply an existing house idiom, do not invent one". *Did:* single-sourced the idiom as §CPREAD prose in the formats contract rather than minting a `changed-files` verb with unit tests. *Why:* the issue explicitly asks for the composed house idiom, and triage sized the remedy as "one idiom applied at three sites, reviewable as one diff." A verb would be more testable; it would also be a new mechanism the issue did not ask for. The review ruled this the **load-bearing follow-up**: a verb that performs its own read given `--repo`/`--pr` collapses this whole class to one call site. *Disposition:* follow-up, not this PR.

6. **[Known defect left unfixed] Two of triage's open questions remain open.** Whether a mid-stream `--paginate` abort yields partial output or none, and whether `gh` retries internally, were **not** resolved. *Why:* neither blocks this fix — a *partial* page set is a distinct, harder problem (a truncated list can look like a valid short one), and the exit-status check catches it only if `gh` reports the abort. The review agreed: strictly narrower than the defect being closed, and better asserted from the `Link` header inside the verb of deviation 5 than in prose bash. *Disposition:* left open. Nothing in this diff claims to close it.

7. **[Rebase + invocation-form conversion] This head is a rebase onto `main` after PR #4230 merged, with every touched call converted to §CLI's `"$PCLI"` form.** *Said:* the diff at `21736714` was the reviewed shape. *Did:* rebased onto `7a2e08f8` and reconciled the one real conflict — the `cp-classify` call under `### A path-only §CP answer is NEVER authoritative`, which this PR replaces with the §CPREAD capture-check-discard shape and #4230 rewrote to the §CLI-resolved `"$PCLI"` binary. **Both fixes survive:** the resolution keeps this PR's `if ! cp_changed_files … then CP_STATE=unknown; else … fi` semantics *and* invokes the verb as `"$PCLI" cp-classify classify` (same reconciliation at the five other conflicted sites in `review-design`, `review-skill`, and `review-trivial`). The two changes compose rather than overlap: §CPREAD governs a failed `gh` **read**, §CLI governs a failed **resolution of the binary** (exit 127); §CPREAD never mentions 127, and §CLI cedes any other non-zero to the verb's own contract, so `cp-classify`'s `exit 3 = not-control-plane` is untouched. *Why:* #4230 also landed the `cli-invocation-guard` CI job, which reds on a bare `pipeline-cli` invocation in a runnable fence — a rebase alone would have left this branch red. The `node packages/pipeline-cli/src/bin.ts` calls in `review-code` / `review-doc` / `ship-it` are left as they are on `main`; the guard bans only the bare `pipeline-cli` form, and changing them would be unrelated churn. *Verification:* `cli-invocation-guard check` over the full plugin corpus at this head — `scanned 68 file(s), 319 runnable bash/sh fence(s) … clean`. *Disposition:* no action needed; the prior PASS was at `27d09b77` and this head needs a fresh review (ADR 0058).
8. **[Rebase] This head is a second rebase, onto `820f62af`, with no content change.** *Said:* deviation 7's head `00f11db9` was the reviewed shape and it PASSED. *Did:* rebased that head onto current `main` and force-pushed; the two commits, the diff, and every §CPREAD / §CLI site are unchanged. *Why:* the `no bare pipeline-cli invocation in a runnable fence` check went red at `00f11db9` on a defect that is **not in this PR** — its sole offender was a line in `claude-plugins/pipeline-crew/agents/crew-engineering-manager.md`, a file this PR does not touch. That guard scans the whole `claude-plugins` corpus, so it caught a `main` regression (introduced by #4225, already fixed by #4237); the failing run fell inside that window. Rebasing past the fix is the entire remedy — nothing in this PR needed repair, and `crew-engineering-manager.md` was deliberately left alone. *Verification:* the rebase applied cleanly, no conflict; six of the seven changed files are byte-identical to `00f11db9`, and `ship-it/SKILL.md` differs only by `main`'s own edits (this PR's hunks in it are unchanged). `cli-invocation-guard check` over the CI job's exact scope at this head — `scanned 68 file(s), 319 runnable bash/sh fence(s) … clean`. *Disposition:* no action needed; this head needs a fresh review (ADR 0058).

Classes 2 (governing-ADR departure), 5 (guard/gate bypassed), and 6 (pre-existing test/fixture changed) did not fire: no ADR is contradicted (0092/0135/0164 are all *tightened*, not narrowed), no hook or lint was skipped or suppressed, and no existing test or assertion was touched.

