### PR TITLE
fix(pipeline): resolve pipeline-cli by path, and stop a 127 posing as a verdict (#3314)

### DIFF
--- a/.github/workflows/cli-invocation-guard.yml
+++ b/.github/workflows/cli-invocation-guard.yml
@@ -1,0 +1,47 @@
+name: cli-invocation-guard
+
+# §CLI enforcement (#3314): reds on any bare `pipeline-cli <verb>` inside a runnable
+# bash/sh fence in the plugin corpus. `pipeline-cli` is not on PATH where pipeline agents
+# spawn and won't be (ADR 0207 retired PATH-shadowing under Claude Code's verbatim
+# settings.json `env` semantics), so a bare call dies `command not found` at a gate step —
+# and the surrounding fail-closed wrapper converts that miss into a wrong verdict rather
+# than a clean error.
+#
+# Scans the FULL corpus (not just changed files), so a bare call anywhere is caught
+# regardless of which PR introduced it, and FAILS CLOSED on zero scope per ADR 0092:
+# no file scanned, or no runnable fence found, is a broken lint, exit 3.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: no bare pipeline-cli invocation in a runnable fence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Scan the plugin corpus for bare pipeline-cli invocations
+        run: |
+          set -euo pipefail
+          find claude-plugins -type f -name '*.md' -print0 \
+            | sort -z \
+            | xargs -0 node packages/pipeline-cli/src/bin.ts cli-invocation-guard check

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -146,8 +146,10 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   unit-tested probe (it parses the **same** §CLASS `HAS_*_RE` lines `ship-it` Step 0 reads — no
   third copy) and dispatch a gate for **exactly** each namespace it prints:
   ```bash
+  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-    | pipeline-cli class-probe classify --namespaces   # → review-code / review-doc / review-skill (+ review-design when has-ui), one per present gate
+    | "$PCLI" class-probe classify --namespaces   # → review-code / review-doc / review-skill (+ review-design when has-ui), one per present gate
   ```
   The probe **also folds in the additive `review-design`** (`ui_reresolve`, below): it reads the
   live `UI_RE` from its single source (`ship-it/SKILL.md`) and appends `review-design` to
@@ -230,10 +232,12 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   required namespace empty" unrepresentable from the reviewer's side; it does **not** touch ship-it's
   fail-closed per-namespace PASS gate (the merge authority), which stays the terminal check, untouched.
   ```bash
+  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
   # the required set — same class-probe output the fan dispatches on (folds in review-design when has-ui)
   REQUIRED_NS="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-    | pipeline-cli class-probe classify --namespaces)"   # e.g. review-code / review-skill for a mixed diff
+    | "$PCLI" class-probe classify --namespaces)"   # e.g. review-code / review-skill for a mixed diff
   echo "reviewer dispatch: PR $PR @ $HEAD_SHA requires namespaces → ${REQUIRED_NS//$'\n'/ }"
   # … fan + post one SHA-bound marker per required namespace (the invariants above) …
   # COVERAGE SELF-CHECK — a required namespace uncovered at HEAD_SHA cannot pass silently. A namespace

--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
@@ -228,6 +228,8 @@ call). Map the finding into the report template:
   seam), explicitly labeled a guess, never a mandate.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # one finding, one issue — only status:needs-triage, exactly like report. The
 # `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
 # `packages/pipeline-cli/src/tools/tracker/`) and enters the needs-triage queue by default;
@@ -235,7 +237,7 @@ call). Map the finding into the report template:
 BODY_FILE="$(mktemp /tmp/arch-audit-body.XXXXXX)"   # per-run temp file (concurrent runs share /tmp)
 # … write the five sections + footer into "$BODY_FILE" …
 BODY="$(cat "$BODY_FILE")"
-pipeline-cli tracker create-issue \
+"$PCLI" tracker create-issue \
   --title "<short, type-neutral finding summary (≤ ~70 chars)>" \
   --body "$BODY"
 ```

--- a/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
@@ -111,7 +111,9 @@ auto-shippable. **Re-check the final path** against the live control-plane regex
 opening the PR:
 
 ```bash
-pipeline-cli control-plane-paths
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" control-plane-paths
 ```
 
 A skill flips to §CP (human-merge, never auto-shipped) when its path falls under a gate skill

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1717,11 +1717,13 @@ rather than erroring.
 runs the shared entry point, which cannot hand back a fail-open no:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # The §CP classification entry point — four states on stdout (#4161). Re-resolves the live
 # CONTROL_PLANE_RE from origin/main itself (#981); pass --control-plane-re to reuse one you
 # already resolved. ASSERT ON THE STATE WORD, never on the exit status alone — see below.
 CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | pipeline-cli cp-classify classify --repo "$REPO")"
+  | "$PCLI" cp-classify classify --repo "$REPO")"
 if [ "$CP_STATE" = "not-control-plane" ]; then
   : # proven ordinary — the ONLY branch that may skip the §CP hold
 else
@@ -2134,6 +2136,78 @@ documented specialization of this same contract, not a fourth drifting copy.
 
 ---
 
+## CLI. Invoking `pipeline-cli` — one canonical resolution, one exit-code taxonomy (#3314)
+
+`pipeline-cli` is **not on PATH** where pipeline agents spawn, and nothing will put it there:
+ADR [0207](https://github.com/kamp-us/phoenix/blob/main/.decisions/0207-gh-path-shim-retired.md)
+retired PATH-shadowing after grounding that Claude Code applies `settings.json` `env` values
+verbatim, so a `${CLAUDE_PROJECT_DIR}` PATH prepend never expands. Every invocation therefore
+goes through the shim **by a resolvable path**: `claude-plugins/kampus-pipeline/bin/pipeline-cli`,
+whose own three-tier ladder (in-repo dev source → SessionStart-installed data-dir bin → the pinned
+`pnpm dlx`) is the single home for *which* build runs.
+
+**Never write a bare `pipeline-cli <verb>` in a runnable command.** A bare name resolves against
+PATH, is not there, and dies `command not found` — at a gate step, inside a fail-closed wrapper
+that converts the miss into a *wrong verdict* rather than a clean error.
+
+### The canonical preamble — paste it once per bash block that invokes the CLI
+
+```bash
+# §CLI — resolve the shim. `$CLAUDE_PLUGIN_ROOT` covers a foreign consumer install; the
+# git-toplevel fallback covers this repo from ANY cwd, in the primary checkout AND in an
+# agent worktree (both trees carry the shim, and a worktree's toplevel is its own root).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+```
+
+Then call it as `"$PCLI" <verb> …`. That is the **one** documented form; do not re-derive a
+second. `$PCLI` is a shell variable, so — like `$BRANCH` and `$WT` — it does **not** survive
+between an agent's separate Bash calls: re-run the preamble in each block, never cache the path
+to a file (§SP).
+
+### The exit-code taxonomy — "could not run" is never a verdict
+
+The whole reason bare invocation is banned is that its failure is **indistinguishable from a
+verb result** at the call site. Read the two apart this way, and never collapse them:
+
+| Signal | Meaning | How a caller must resolve it |
+|---|---|---|
+| `"$PCLI" …` exits **127**, or the message names a *path* that does not exist | The CLI **never ran** — resolution failure | **UNKNOWN.** Never clean, never a negative verdict. Re-resolve or route the blocker up. |
+| Any other non-zero exit | The verb **ran** and returned its own documented contract (e.g. `2` findings / `3` zero scope) | Read it as that verb's result. |
+| Exit 0 | The verb ran and passed | Read it as that verb's result. |
+
+**A 127 is a PATH/resolution gap. It is NOT worktree teardown.** Teardown is progressive and has
+its own two signatures, in sequence: **exit 1 with `ENOENT` on a file that provably exists on
+`main`** (the earliest signal), then **exit 126 `Volta error: Could not determine current
+directory`**. Treating 127 as "my tree was torn down" is a live misdiagnosis that has already
+cost real time — three agents reported 127 with fully intact worktrees. Invoking by path is what
+makes the distinction legible without prior knowledge: the shell's own error names the missing
+**path**, not a bare command name.
+
+For a **gate-critical** call — one whose surrounding wrapper turns any non-zero into a block or a
+classification — make the refusal explicit, so an unresolved CLI can never be laundered into a
+verdict:
+
+```bash
+[ -x "$PCLI" ] || {
+  echo "pipeline-cli: UNRESOLVED at '$PCLI' — the CLI never ran, so this gate has NO result." >&2
+  echo "  Resolve to UNKNOWN, never to clean/negative (§WL: a read that could not run is not an answer)." >&2
+  echo "  This is a resolution gap, NOT worktree teardown (teardown = exit 1 ENOENT on a tracked file, then exit 126)." >&2
+  exit 127
+}
+```
+
+This section owns the **call-site resolution** half only. Two adjacent seams own the rest and
+must not be re-derived here: **#4178** owns legibility when the shim's *own tree* vanishes
+mid-run, and **#4185** owns legibility when the shim resolved but the CLI's module-load self-heal
+failed. Both reserve the same "could not run ⇒ UNKNOWN" contract this taxonomy states, so a fix
+there extends this table rather than forking it.
+
+`pipeline-cli cli-invocation-guard check` enforces the ban mechanically over the plugin corpus —
+it reds on any bare `pipeline-cli` invocation inside a runnable `bash`/`sh` fence, and fails
+closed on zero scope (§ZS / ADR 0092).
+
+---
+
 ## SP. The per-run scratchpad namespace — one canonical definition (#3718)
 
 The pipeline runs several agents concurrently by design (the WIP cap is the whole point), and
@@ -2187,15 +2261,17 @@ Allocation is owned by one tested verb, so a caller **cites it instead of hand-r
 (#3718). It prints the absolute directory on stdout and nothing else:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # OPEN — the run's first write of scratch state. Claims the namespace exclusively and stamps it
 # as ours, clearing whatever an unclaimed earlier occupant left behind.
-RUN_SCRATCH="$(pipeline-cli scratchpad open --slug review-doc-$PR)" || exit 1
+RUN_SCRATCH="$("$PCLI" scratchpad open --slug review-doc-$PR)" || exit 1
 
 # RE-DERIVE — every LATER Bash call, where shell state is already gone. Asserts the namespace
 # exists AND is still ours; it never creates one, because answering "you never opened it" with a
 # fresh empty directory is how a read of your own state silently becomes a read of nothing.
-RUN_SCRATCH="$(pipeline-cli scratchpad path --slug review-doc-$PR)" || exit 1
-VERDICT="$(pipeline-cli scratchpad file --slug review-doc-$PR --name verdict.md)" || exit 1
+RUN_SCRATCH="$("$PCLI" scratchpad path --slug review-doc-$PR)" || exit 1
+VERDICT="$("$PCLI" scratchpad file --slug review-doc-$PR --name verdict.md)" || exit 1
 ```
 
 Every failure is a **refusal with its own exit code** — `2` no session id, `3` a slug/leaf name
@@ -2359,10 +2435,12 @@ assert it did:**
    **asserts the fetched ref resolves to exactly that SHA before you review** — aborting on a moved
    head rather than binding a stale verdict. Two modes, same core:
    ```bash
+   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
    # ref-only (review-doc reads via `git show "$PR_REF:<path>"`):
-   eval "$(pipeline-cli review-head materialize --pr "$PR" | jq -r '"PR_REF=\(.prRef); HEAD_SHA=\(.headSha)"')"
+   eval "$("$PCLI" review-head materialize --pr "$PR" | jq -r '"PR_REF=\(.prRef); HEAD_SHA=\(.headSha)"')"
    # full detached head worktree (review-code / review-skill), emitted as `.worktreeDir`:
-   pipeline-cli review-head materialize --pr "$PR" --worktree | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
+   "$PCLI" review-head materialize --pr "$PR" --worktree | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
    ```
    `pull/<pr>/head` resolves same-repo AND cross-fork, and the checkout is always DETACHED onto the
    per-run ref — never `gh pr checkout` / `git checkout` / `git switch`, which would land the head in
@@ -3120,7 +3198,9 @@ A claim is **held for the duration of the work it protects, and given up when th
 done**. The owner performs that release itself:
 
 ```bash
-pipeline-cli claim release --issue <N>            # retract our own marker; --session <token> to release a delegated claim
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" claim release --issue <N>            # retract our own marker; --session <token> to release a delegated claim
 ```
 
 **Who calls it, and when.** The run that holds the claim, at its terminus: `write-code` Step 8
@@ -3170,7 +3250,9 @@ be invisible; stranded lanes accumulated silently until a dispatch read `lost` a
 read-only inventory is the surface:
 
 ```bash
-pipeline-cli claim status --issue <N>   # every marker: author, authorization, liveness, and the resolved owner
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" claim status --issue <N>   # every marker: author, authorization, liveness, and the resolved owner
 ```
 
 Read it before concluding a lane is stuck. A row with `liveness: dead` is already superseded and
@@ -3239,9 +3321,11 @@ by an audited cleanup, not by a resolution rule — the rules above are untouche
 claim is never a candidate whatever its age:
 
 ```bash
-pipeline-cli claim audit                 # every open lane held by an unstamped marker, and which are retirable
-pipeline-cli claim audit --issue <N>     # the cheap single-lane read when a stall is already known
-pipeline-cli claim audit --execute       # retire the retirable ones through `claim release`
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" claim audit                 # every open lane held by an unstamped marker, and which are retirable
+"$PCLI" claim audit --issue <N>     # the cheap single-lane read when a stall is already known
+"$PCLI" claim audit --execute       # retire the retirable ones through `claim release`
 ```
 
 Retirement runs through **`claim release` under the marker's own token** — the one retraction

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -507,6 +507,8 @@ caught only by `review-plan`'s non-blocking advisor (#754, the same silent-clobb
 even within a single run:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
 mkdir -p "$RUN_SCRATCH" || exit 1
 # write this child's spec into a per-run temp file, never a shared fixed path (#754)
@@ -521,7 +523,7 @@ cat > "$CHILD_SPEC_FILE" <<'EOF'
 EOF
 # The verb composes the format-2 body per the contract and emits it BY VALUE to stdout — no
 # hand-re-derived `### What to build` / `### Acceptance criteria`, no `-f body=@file` leak.
-BODY="$(pipeline-cli intake-compose sub-issue --spec "$CHILD_SPEC_FILE")"
+BODY="$("$PCLI" intake-compose sub-issue --spec "$CHILD_SPEC_FILE")"
 # ATOMIC create — body AND its type/priority/status:planned labels in ONE REST write. `POST /issues`
 # accepts `labels` inline, so an interrupted run can never leave a label-less child: the create
 # either lands the issue WITH its labels or creates nothing. (Values chosen per the paragraph below.)
@@ -997,6 +999,8 @@ Scan the **brief** (the top section you read in Step 1) for the graduation-prove
 close each source it names — but only a genuine `type:investigation` source, idempotently:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
 [ -s "$RUN_SCRATCH/current.md" ] || { echo "plan-epic: §SP — Step 1's current.md did not survive; re-run Step 1 in THIS session." >&2; exit 1; }
 # Extract every source the brief graduated from — tolerant of phrasing ("Emitted from resolved
@@ -1019,7 +1023,7 @@ for SRC in $SOURCES; do
   # then closes the source as completed (the work graduated, it wasn't abandoned — distinct from
   # triage's not_planned). Don't hand-roll the comment + `state_reason=completed` PATCH; that inline
   # re-derivation is what the adoption lint (#3254) flags.
-  pipeline-cli tracker graduate "$SRC" \
+  "$PCLI" tracker graduate "$SRC" \
     --artifact "epic #<EPIC> (planned by plan-epic)" \
     --note "closing this investigation as the durable \`graduated into #<EPIC>\` record. Its diagnosis is carried forward by the epic and its planned children." >/dev/null
   echo "plan-epic: closed graduated source investigation #$SRC → epic #<EPIC>."

--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -121,6 +121,8 @@ REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOw
 Stream the composed body **straight into the create call over stdin** — there is no named temp file to collide on and no shell variable to reuse stale, so two concurrent `report` runs cannot interleave bodies (the cross-filing hazard is structurally unrepresentable, not merely warned against — #2002). The `tracker create-issue` verb reads its `--body` from stdin when the flag is absent, so the **quoted** heredoc (`<<'EOF'`) passes the markdown through untouched — multi-line markdown, backticks, and nested fences survive intact, the "backticks survive the shell" guarantee with no round-trip through a variable. Don't hand-roll the `gh api repos/$REPO/issues` create — that inline envelope is exactly what the adoption lint (#3254) flags; the verb owns it (ADR 0190; `packages/pipeline-cli/src/tools/tracker/`) and enters the needs-triage queue by default:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # The five sections + a blank line + the footer.sh block, piped straight into the
 # create verb over stdin. No mktemp, no $BODY_FILE, no `$(cat …)` — nothing shared to
 # collide on. `create-issue` consumes the whole stream as the body; the quoted `<<'EOF'`
@@ -149,7 +151,7 @@ Stream the composed body **straight into the create call over stdin** — there 
 EOF
   echo   # blank line before the footer block
   claude-plugins/kampus-pipeline/skills/report/footer.sh   # emits its own `---` + <sub>… line
-} | pipeline-cli tracker create-issue --title "<title>"
+} | "$PCLI" tracker create-issue --title "<title>"
 ```
 
 The body never lands on disk under a shared name and never round-trips through a variable, so the two named failure paths this hardening closes — "simplify" to a fixed `/tmp/report-body.md`, or reuse one `$BODY_FILE` across two creates — have no surface to occur on: there is no file path to fix and no variable to reuse. This is the

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -309,6 +309,8 @@ make the isolation hold *by construction*, not by your remembering to behave:
 Your own session stays in *this* worktree (the trusted base config you were launched under).
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Isolation preflight FIRST, before any head fetch / `git worktree add` below. If this
 # review-code spawn expected worktree isolation (reviewer agent-type) but the #2440 harness no-op
 # dropped it onto the shared PRIMARY checkout ($WORKTREE_ROOT unset), materializing the head here
@@ -346,7 +348,7 @@ git fetch origin "$BASE_REF"
 # whole. A full checkout also lands the head's root CLAUDE.md + .claude/.decisions/.patterns — that
 # leak is closed by the explicit denylist removal + absence-assert below, NOT by any pattern set.
 WT_FILE="$(mktemp /tmp/review-code-wt.XXXXXX)"
-pipeline-cli review-head materialize --pr "$PR" --worktree \
+"$PCLI" review-head materialize --pr "$PR" --worktree \
   | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
 . "$WT_FILE"
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
@@ -457,10 +459,12 @@ you received an archive and not a 503 error body; `schemaVersion` and
 load-bearing**: a bundle from a stale earlier push is not evidence for this commit.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')"
 # Exit 0 means `present` — a validated, head-bound bundle. Every other state comes back on stdout
 # as JSON, so read the state rather than branching on the exit alone.
-BUNDLE="$(pipeline-cli run-evidence read --pr "$PR")" || true
+BUNDLE="$("$PCLI" run-evidence read --pr "$PR")" || true
 BUNDLE_STATE="$(jq -r '.state' <<<"$BUNDLE")"     # present | pending | absent | unknown
 BUNDLE_LINE="$(jq -r '.reportLine' <<<"$BUNDLE")" # the verdict line, evidence already in it
 ```

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -287,11 +287,13 @@ with zero path matches, so a path-only test here would classify it non-blocking 
 this verb removes (#4161, formats §CP):
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Four states on stdout. Assert on the STATE WORD, never on the exit status — the exit code
 # discriminates the four states only once the verb has RUN, so `… || ordinary` fail-opens on a
 # usage error (1) or a missing binary (127). The `else` below is the catch-all (formats §CP; #4161).
 CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | pipeline-cli cp-classify classify --repo "$REPO")"
+  | "$PCLI" cp-classify classify --repo "$REPO")"
 # `content-undetermined` is an OBLIGATION, not an answer: probe each listed ADR at head before
 # calling this PR non-blocking (the same ADR-0164 verb ship-it Step 0 and review-code/doc run).
 if [ "$CP_STATE" = "content-undetermined" ]; then
@@ -299,7 +301,7 @@ if [ "$CP_STATE" = "content-undetermined" ]; then
   gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
     | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
         gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-          | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null \
+          | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null \
           && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
       done
 elif [ "$CP_STATE" != "not-control-plane" ]; then
@@ -326,12 +328,14 @@ fi
 ## Step 1 — Resolve the PR, its head SHA, the preview URL, and the changed surfaces
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 gh api repos/$REPO/pulls/$PR \
   --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
 # Resolve the current head SHA the verdict binds to (ADR 0058) via the shared
 # `pipeline-cli review-head` verb (#3690 / #793 / #1807) — `resolve` is REST-only (this gate
 # reviews the preview URL, not a checked-out tree), fail-safe on a missing/closed/partial head:
-HEAD_SHA="$(pipeline-cli review-head resolve --pr "$PR" | jq -r .headSha)"
+HEAD_SHA="$("$PCLI" review-head resolve --pr "$PR" | jq -r .headSha)"
 ```
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code` writes) —

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -312,11 +312,13 @@ extended to the code lane by ADR
 Resolve it **mechanically, never by eye**:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # doc/vocab-surface-only? exit 0 = yes (issueless is legitimate), non-zero = no (hard-stop below).
 # Predicate single-sourced in §CLASS (DOC_VOCAB_EXCLUDE_RE / DOC_VOCAB_SURFACE_RE); fails closed to
 # "no" on an unreadable source or zero input (ADR 0092) — it can only ever REFUSE the allowance.
 gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | pipeline-cli class-probe doc-vocab-surface-only
+  | "$PCLI" class-probe doc-vocab-surface-only
 ```
 
 - **Not doc/vocab-surface-only** — any changed path under `apps/**`, `packages/**`, `infra/**`, or
@@ -387,6 +389,8 @@ the hunk alone — and read it **read-only**, without ever switching the checkou
 **Read-only on git working state** below). Fetch the head into a ref and read off that ref:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # §SP FIRST — allocate this run's scratch namespace, and land the head handles in a file inside it.
 # $PR_REF / $HEAD_SHA (and $REVIEW_WT below) are needed by LATER Bash calls — Step 4a's ADR sweep
 # reads `git show "$PR_REF:…"` — and a shell variable does not survive the harness's between-call
@@ -397,8 +401,8 @@ the hunk alone — and read it **read-only**, without ever switching the checkou
 # AND consumed inside one call, like `VERDICT_FILE` below. `scratchpad` is the allocator (§SP rule
 # 2 of ../gh-issue-intake-formats.md); it refuses with a reason on stderr rather than falling back
 # to a shared path, and §SP's one-liner is the same namespace for a run with no CLI on PATH.
-pipeline-cli scratchpad open --slug "review-doc-$PR" >/dev/null || exit 1   # ONCE, at the start of the run
-HEAD_ENV="$(pipeline-cli scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
+"$PCLI" scratchpad open --slug "review-doc-$PR" >/dev/null || exit 1   # ONCE, at the start of the run
+HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
 
 # Land the head in a per-run ref via the shared `pipeline-cli review-head materialize` verb
 # (#3690 / #793 / #1807) — cite it, don't re-derive it. Ref-only mode (no `--worktree`): it
@@ -407,7 +411,7 @@ HEAD_ENV="$(pipeline-cli scratchpad file --slug "review-doc-$PR" --name head.env
 # `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the shared PRIMARY
 # the harness resets this cwd to and detach the human's `main` — #2270/#1103; §RO). It emits the
 # head + ref as JSON:
-pipeline-cli review-head materialize --pr "$PR" \
+"$PCLI" review-head materialize --pr "$PR" \
   | jq -r '"PR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
 . "$HEAD_ENV"
 
@@ -424,7 +428,9 @@ git update-ref -d "$PR_REF"          # drop the throwaway ref when done
 of silently reading an empty directory:
 
 ```bash
-HEAD_ENV="$(pipeline-cli scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
 [ -s "$HEAD_ENV" ] || { echo "review-doc: §SP — head.env absent/empty; re-run the materialize step in THIS session." >&2; exit 1; }
 . "$HEAD_ENV"                        # $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)
 ```
@@ -436,7 +442,9 @@ its path. It goes into the **same** `head.env`, for the same reason: a later ste
 fan-out that leaf matches a sibling reviewer's tree and pins the wrong head (the #1807 collision):
 
 ```bash
-pipeline-cli review-head materialize --pr "$PR" --worktree \
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" review-head materialize --pr "$PR" --worktree \
   | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
 . "$HEAD_ENV"
 # Register teardown as a trap so a mid-block error still tears the throwaway tree down:

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -67,6 +67,8 @@ reviewing (below), read all skill text from the head, and re-check the live head
 (§HEAD #4); the verdict (§5) binds to the SHA whose files you actually read and asserts it.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main — your trusted config
 git fetch origin "$BASE_REF"
 
@@ -91,7 +93,7 @@ git fetch origin "$BASE_REF"
 RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR"
 mkdir -p "$RUN_SCRATCH" || { echo "review-skill: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
 WT_FILE="$RUN_SCRATCH/wt.env"
-pipeline-cli review-head materialize --pr "$PR" --worktree \
+"$PCLI" review-head materialize --pr "$PR" --worktree \
   | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
 . "$WT_FILE"
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
@@ -203,6 +205,8 @@ on-disk file is current, so a pre-amendment snapshot once mis-flagged a now-cont
 path as control-plane → advisory not-auto-mergeable) if that read can't be made.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 PR=<pr number>
 # The shared §CP classification entry point — one verb all the gates cite (#4161, formats §CP). It
 # re-resolves CONTROL_PLANE_RE from origin/main itself (§CP travels in the INJECTED skill snapshot,
@@ -215,7 +219,7 @@ PR=<pr number>
 # only once the verb has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing
 # binary (127). The `else` below is the catch-all that makes that safe (formats §CP; #4161).
 CP_STATE="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | pipeline-cli cp-classify classify --repo "$REPO")"
+  | "$PCLI" cp-classify classify --repo "$REPO")"
 # `content-undetermined` is an OBLIGATION, not an answer: probe each touched ADR at head with the
 # SAME ADR-0164 verb ship-it Step 0 and review-code/review-doc run. Any BLOCKING line ⇒ §CP.
 if [ "$CP_STATE" = "content-undetermined" ]; then
@@ -223,7 +227,7 @@ if [ "$CP_STATE" = "content-undetermined" ]; then
   gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
     | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
         gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-          | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null \
+          | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null \
           && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
       done
 elif [ "$CP_STATE" != "not-control-plane" ]; then

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -90,6 +90,8 @@ path, so a path-only test here would ride it straight onto the lighter gate (#41
 don't re-hard-code the list:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 PR=<pr number>
 FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # --paginate + streaming --jq: full set past file #100 (#725)
 NFILES=$(printf '%s\n' "$FILES" | grep -c . || true)
@@ -97,7 +99,7 @@ ADD=$(gh api repos/$REPO/pulls/$PR --jq '.additions'); DEL=$(gh api repos/$REPO/
 
 # Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
 # Only `not-control-plane` is a proven-ordinary answer; every other state is a HOLD.
-CP_STATE="$(printf '%s\n' "$FILES" | pipeline-cli cp-classify classify --repo "$REPO")"
+CP_STATE="$(printf '%s\n' "$FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
 ```
 
 **Refuse the lighter gate (FAIL → full path) on any of:**
@@ -141,6 +143,8 @@ fail-closed fallback (#1559) re-routes it to the full `review-code` / `review-do
 the worst case of a miss is paying the full (correct) cost, never an under-gated merge.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Fail-closed on EVERY value but the proven-ordinary one. The test is a positive match on the
 # STATE WORD, not on the exit status: the exit code discriminates the four states only once the
 # verb has RUN, so a bad flag (exit 1) or a missing binary (exit 127) would fail OPEN through
@@ -151,7 +155,7 @@ if [ "$CP_STATE" != "not-control-plane" ]; then
     HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
     GUARD_TOUCHING="$(printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
         gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-          | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null && echo "$adr"
+          | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null && echo "$adr"
       done)"
     if [ -z "$GUARD_TOUCHING" ]; then
       : # every touched ADR probed not-guard-touching ⇒ the content axis is resolved, carry on

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -152,6 +152,8 @@ rule with **four mandated sites** — run start, every stop/refusal, an ejection
 bounded reconcile:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # `merge-intent` owns the branch (ADR 0198): a live merge-queue entry is NEVER disturbed; the
 # pre-queue regime — read off the BASE BRANCH's ruleset, not this PR's queue history — is exempt at
 # `post-enqueue` only; and both reads fail closed toward a clear. It verifies by re-reading
@@ -160,7 +162,7 @@ bounded reconcile:
 # was armed. Exit 1 = the intent may STILL be armed: surface it, never report a clean stop over it.
 INTENT_UNCLEARED=0   # set by any failed disarm; the run's outcome line MUST carry it (see Running it)
 disarm_intent() {   # $1 = preflight | refuse | post-enqueue | ejected
-  pipeline-cli merge-intent disarm --pr "$PR" --repo "$REPO" --site "$1" || {
+  "$PCLI" merge-intent disarm --pr "$PR" --repo "$REPO" --site "$1" || {
     echo "ship-it: FAILED to clear the merge intent on #$PR (site $1) — a later approval could enqueue it ungated (ADR 0198). Disable auto-merge by hand before this PR is approved again." >&2
     return 1
   }
@@ -491,6 +493,8 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
   precedent). Resolve the roster + the two signals over REST, never GraphQL, then decide:
 
   ```bash
+  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   # ADR 0175: DETERMINISTIC §CP discharge keyed on control-plane team cardinality, not judgment.
   ORG="${REPO%%/*}"                                            # owner half of owner/repo
   # N = present, active, human control-plane members (REST, never GraphQL — ADR 0135/0175)
@@ -530,7 +534,11 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
   # The DETERMINISTIC decision — the whole ADR-0175 `case "$N"` branch lives in the tested pure core.
   # discharge → carry on to the machine gates; stop → STOP (fail closed). Pass a signal flag only when
   # that signal is present at head; cp-cardinality selects which signal the branch actually requires.
-  if printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide \
+  # The §CP discharge branches on this exit status, so an unresolved CLI would read as "stop" or
+  # "discharge" depending on the pipe's last status — a resolution gap deciding a merge gate.
+  # Refuse first (§CLI: could-not-run is UNKNOWN, never a discharge; #3314).
+  [ -x "$PCLI" ] || { echo "ship-it: cp-cardinality is UNRESOLVED at '$PCLI' — the §CP discharge is UNKNOWN, NOT discharged. STOP." >&2; exit 1; }
+  if printf '%s\n' "$MEMBERS" | "$PCLI" cp-cardinality decide \
        --author "$AUTHOR" \
        $([ "$NON_AUTHOR_APPROVAL_AT_HEAD" = true ] && printf -- '--non-author-approval-at-head') \
        $([ "$SELF_APPROVAL_AT_HEAD" = true ] && printf -- '--self-approval-at-head'); then
@@ -754,17 +762,19 @@ The required set is **derived, never eyeballed** — the same `class-probe` outp
 dispatches off, so `dispatched-gate == required-gate` holds by construction:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # the required namespaces for THIS diff — one per artifact class present, plus review-design when
 # the diff is UI-affecting. `.glossary/**` rides has-code, so an ADR + a glossary row requires BOTH
 # review-doc AND review-code; satisfying one is not enough.
 REQUIRED="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
-  | pipeline-cli class-probe classify --namespaces | paste -sd, -)"
+  | "$PCLI" class-probe classify --namespaces | paste -sd, -)"
 # A control-plane PR's pass path is the canonical SHA-less ADVISORY, bound in the body's
 # `Reviewed-head` line (ADR 0111/0151) — pass --cp so that form counts, and ONLY then. Set this from
 # Step 0's own classification (it printed `BLOCKING (…)` for a §CP path/content hit) AND only after
 # Step 0's approval gate discharged; leave it empty for every non-§CP PR.
 CP_FLAG=""   # → "--cp" iff Step 0 classified this PR §CP and its control-plane approval discharged
-pipeline-cli verdict gate --pr "$PR" --require "$REQUIRED" $CP_FLAG || {
+"$PCLI" verdict gate --pr "$PR" --require "$REQUIRED" $CP_FLAG || {
   disarm_intent refuse || INTENT_UNCLEARED=1
   echo "ship-it: refused at guard 1 — see the named reason above; NOT enqueued."; exit 1; }
 ```
@@ -1934,13 +1944,22 @@ boundary. Reuse the shared `findCommentLeaks` detector via the pipeline-cli verb
 matcher `redact-leaks` and `verdict post` already consume — one detector, not a re-invented one):
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# …and prove it resolved BEFORE the guard runs. Without this the `||` below fires on a 127 too,
+# and reports "a landed comment carries a machine-local path" for a CLI that never ran (#3314).
+[ -x "$PCLI" ] || {
+  disarm_intent refuse || INTENT_UNCLEARED=1
+  echo "ship-it: REFUSING to enqueue #$PR — leak-guard is UNRESOLVED at '$PCLI', so the leak scan has NO result (§CLI: could-not-run is UNKNOWN, never clean)." >&2
+  exit 1
+}
 # guard 4 — refuse the enqueue on ANY live leak in a landed comment (exit 2 = a leak; ADR 0092 fail-closed)
-pipeline-cli leak-guard scan-pr "$PR" || {
+"$PCLI" leak-guard scan-pr "$PR" || {
   disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: a refusal parks nothing (ADR 0198)
   echo "ship-it: REFUSING to enqueue #$PR — a landed comment carries a machine-local path (issue #3019)." >&2
   echo "  Remediate, then re-run ship-it:" >&2
-  echo "  1. redact each flagged comment body — pipeline-cli redact-leaks (the merged #3021 tool) preserves evidential shape;" >&2
-  echo "  2. re-post the redacted body (a verdict via 'pipeline-cli verdict post', which now self-verifies the landed comment, #3019);" >&2
+  echo '  1. redact each flagged comment body — `$PCLI redact-leaks` (the merged #3021 tool) preserves evidential shape;' >&2
+  echo '  2. re-post the redacted body (a verdict via `$PCLI verdict post`, which now self-verifies the landed comment, #3019);' >&2
   echo "  3. the underlying issue is a bypassed emit path — route the PR back to repair so the leaking comment is re-emitted through the mandated choke point." >&2
   exit 1
 }
@@ -2007,6 +2026,8 @@ is the **`already queued to merge`** message the enqueue prints and/or the PR's 
 field, which gh 2.62.0 rejects, #1930). See ADR 0132 addendum §3.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # The QUEUED signal is the success condition. `already queued to merge` from Step 4's --auto
 # and/or an `enqueued`/QUEUED mergeStateStatus confirm it — NOT a non-null auto_merge, which
 # under the queue stays null on a clean enqueue (ADR 0132 §3).
@@ -2014,7 +2035,10 @@ gh api repos/$REPO/pulls/$PR --jq '{merged, auto_merge, mergeable_state}'
 gh pr view $PR --json mergeStateStatus --jq '{mergeStateStatus}'
 # Confirm queue membership through the SAME verb Step 5.5's reconcile polls — never a second,
 # hand-rolled timeline read here (#4193). Prints exactly one of merged/queued/pending/ejected.
-QUEUE_STATE=$(pipeline-cli merge-queue-classify classify --pr "$PR" --repo "$REPO")
+# An unresolved CLI prints nothing, and an empty QUEUE_STATE is not a state — refuse rather than
+# branch on it (§CLI: could-not-run is UNKNOWN, never a queue outcome; #3314).
+[ -x "$PCLI" ] || { echo "ship-it: merge-queue-classify is UNRESOLVED at '$PCLI' — queue membership is UNKNOWN, not confirmed." >&2; exit 1; }
+QUEUE_STATE=$("$PCLI" merge-queue-classify classify --pr "$PR" --repo "$REPO")
 ```
 
 **Why the verb and not a `gh api …/timeline` one-liner here.** This confirmation used to
@@ -2107,6 +2131,16 @@ yet), which is **never** an ejection. The classification is a **pure, unit-teste
 reconcile shells out to it per poll and branches on the printed outcome word:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# …and prove it resolved before polling. An unresolved CLI prints nothing, so every poll would
+# read as neither `merged` nor `ejected`, the budget would exhaust, and the run would report a
+# well-formed `pending` for a classifier that never ran — a could-not-run posing as an answer
+# (§CLI / §WL; #3314). UNKNOWN is the only honest outcome here.
+[ -x "$PCLI" ] || {
+  echo "ship-it: merge-queue-classify is UNRESOLVED at '$PCLI' — the reconcile outcome is UNKNOWN, NOT pending. Re-resolve the CLI and re-poll; do not report a merge outcome." >&2
+  exit 1
+}
 # Bounded reconcile: poll the authoritative merge-queue state within a batch window, then classify.
 # BOUNDED, not synchronous-to-merge (ADR 0132): a fixed budget of polls, then STOP and report —
 # a PR still QUEUED at the budget's end is a well-formed pending, not a failure.
@@ -2121,7 +2155,7 @@ RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-10}   # ~10 polls
 RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}   # ~30s apart ⇒ ~5 min batch window
 MERGE_OUTCOME=pending
 for i in $(seq 1 "$RECONCILE_TRIES"); do
-  MERGE_OUTCOME=$(pipeline-cli merge-queue-classify classify --pr "$PR" --repo "$REPO")
+  MERGE_OUTCOME=$("$PCLI" merge-queue-classify classify --pr "$PR" --repo "$REPO")
   [ "$MERGE_OUTCOME" = merged ] && break   # terminal success
   [ "$MERGE_OUTCOME" = ejected ] && break  # a genuine dequeue (removed_from_merge_queue) — act below
   # queued (still in the queue) or pending (enqueue-settle window) ⇒ keep polling within the budget
@@ -2140,7 +2174,7 @@ done
 if [ "$MERGE_OUTCOME" = ejected ]; then
   disarm_intent ejected || INTENT_UNCLEARED=1
 else
-  INTENT_ACTION=$(pipeline-cli merge-intent disarm --pr "$PR" --repo "$REPO" --site post-enqueue) || INTENT_UNCLEARED=1
+  INTENT_ACTION=$("$PCLI" merge-intent disarm --pr "$PR" --repo "$REPO" --site post-enqueue) || INTENT_UNCLEARED=1
   [ "$INTENT_ACTION" = disarmed ] && \
     echo "refused — the enqueue did not take effect at this head; the parked intent was cleared. Re-dispatch ship-it to re-assert the gates and enqueue (idempotent)."
 fi

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -300,6 +300,8 @@ How to split:
    empty husk open.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # 1. Create-once guard: skip the POST if a child already covers this (parent, title) unit (#3464).
 EXISTING=$(node packages/pipeline-cli/src/bin.ts split-guard check \
   --parent "$N" --title "<single-unit title>")
@@ -310,7 +312,7 @@ else
   #    The `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
   #    `packages/pipeline-cli/src/tools/tracker/`), filing a status:needs-triage issue — don't
   #    hand-roll the `gh api repos/$REPO/issues` create (the adoption lint (#3254) flags it).
-  pipeline-cli tracker create-issue --title "<single-unit title>" --body "$BODY"
+  "$PCLI" tracker create-issue --title "<single-unit title>" --body "$BODY"
   # then cross-link via a comment on the original (Step 6 shows the comment call)
 fi
 ```
@@ -395,6 +397,8 @@ in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §SP. An iss
 body**, so triage would silently preserve the wrong original inside `<details>` (#3718):
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
 # Keyed on the session id (not a bare `mktemp -d`) because the PATCH block below runs in a LATER
 # Bash call, where every shell variable is gone: it re-derives this same path to read body.md back.
@@ -407,7 +411,7 @@ rm -rf "$RUN_SCRATCH" && mkdir -p "$RUN_SCRATCH" || {
 gh api "repos/$REPO/issues/<N>" --jq '.body' > "$RUN_SCRATCH/original.md"
 # redact any machine-local path leak in the ORIGINAL before it goes into <details>; leak-free
 # originals pass through byte-for-byte. Reuses the shared leak matcher — no divergent patterns.
-pipeline-cli redact-leaks --body-file "$RUN_SCRATCH/original.md" > "$RUN_SCRATCH/original.redacted.md"
+"$PCLI" redact-leaks --body-file "$RUN_SCRATCH/original.md" > "$RUN_SCRATCH/original.redacted.md"
 # assemble the <details> block from the REDACTED original, never the raw one
 ```
 
@@ -718,7 +722,9 @@ approval "on his behalf," and do not treat your own draft as approved.
 issue you just drafted, so a red names *this* issue rather than the whole backlog:
 
 ```bash
-pipeline-cli pitch-guard check --issue <N>   # out-of-scope issues pass; a red is this draft
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" pitch-guard check --issue <N>   # out-of-scope issues pass; a red is this draft
 ```
 
 An **unapproved** pitch is a legitimate, expected state for a freshly-triaged issue — the guard
@@ -740,7 +746,9 @@ queue (its `status:needs-triage` removed). Apply the whole transition with the `
 verb — the classification is the parameter, the label plumbing is the verb's:
 
 ```bash
-pipeline-cli tracker apply-triage <N> --type <type> --p <priority>
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" tracker apply-triage <N> --type <type> --p <priority>
 ```
 
 The verb adds the `type:` / priority / `status:triaged` labels and drops the queue label
@@ -762,8 +770,10 @@ this confirms the pair landed rather than racing it; the invariant is enforced a
 not re-swept by hand later:
 
 ```bash
-pipeline-cli homing-guard check --issue <N>   # the issue you just triaged
-pipeline-cli homing-guard check               # the whole open triaged backlog
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" homing-guard check --issue <N>   # the issue you just triaged
+"$PCLI" homing-guard check               # the whole open triaged backlog
 ```
 
 ### Close not-planned (kill, agent issues only)

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -483,6 +483,8 @@ correctly (§the report footer in the formats contract). Stream the composed bri
 create over stdin (no shared temp file to collide on, per the report skill's filing rule):
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
 # One emitted epic per coherent buildable unit. The brief is composed from map #$MAP's
 # ## Destination + the relevant ## Decisions-so-far slice (read via the wayfinder CLI, never
@@ -500,7 +502,7 @@ Charted and cleared on wayfinder:map #<MAP>. Downstream is the existing pipeline
 EOF
   echo   # blank line before the footer block
   claude-plugins/kampus-pipeline/skills/report/footer.sh   # emits its own `---` + <sub>… line
-} | pipeline-cli tracker create-issue --title "<the epic, as one concrete deliverable>"
+} | "$PCLI" tracker create-issue --title "<the epic, as one concrete deliverable>"
 ```
 
 The `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
@@ -537,13 +539,15 @@ Make the ideation→execution handoff traceable from both ends, then close:
   stay as they are.
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Name every artifact the map graduated into (epics and/or ADR and/or roadmap), then close it
 # IFF the destination is FULLY graduated. A partial graduation is annotated but stays open.
 # The `tracker graduate` verb owns this graduation-close envelope (ADR 0190, #3266): it posts
 # the `Graduated into <artifact>` source → artifact provenance record and closes the source as
 # completed. Don't hand-roll the comment + `state_reason=completed` PATCH — that inline
 # re-derivation is what the adoption lint (#3254) flags.
-pipeline-cli tracker graduate "$MAP" \
+"$PCLI" tracker graduate "$MAP" \
   --artifact "#$E1, #$E2 → triage → plan-epic → write-code; ADR 0176; ROADMAP.md v1" \
   --note "Frontier cleared — closing this map as the durable record of how the plan was discovered."
 # fully-graduated only; a partial graduation is annotated (a plain comment) but stays open.

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -462,6 +462,8 @@ Run it; never hand-roll a `claim:` body, which silently skips the ADR-0191 prese
 leaves this lane's claim permanently unprobeable (#3987):
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # 0. Fail-closed on a missing token: the claim comment is the ONLY agent-distinguishable signal
 #    under the shared `usirin` login — with no token a co-racer is unresolvable, so NEVER claim
 #    (and never fall back to the login-keyed assignee as ownership — that is the §7 degeneracy).
@@ -475,7 +477,7 @@ fi
 #    to a pre-existing authorized owner WITHOUT posting, posts a PRESENCE-STAMPED marker under
 #    $CLAUDE_CODE_SESSION_ID, re-reads canonical state, and retracts its OWN claim if it lost.
 #    Exit 0 = the claim is mine; non-zero = backed off, having mutated nothing that is not ours.
-if ! pipeline-cli tracker claim <N>; then
+if ! "$PCLI" tracker claim <N>; then
   echo "did not win the claim on #$N (held by another agent, or lost the tiebreak) — back off, re-pick."
   exit 0   # → re-run Step 1
 fi
@@ -564,6 +566,8 @@ Define the guard once and gate **every** number-targeting mutation on it, exactl
 is the **only** sanctioned path to a mutation that names `<N>`, no bypass:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # claim_is_mine <N>: resolve the EARLIEST AUTHORIZED claim marker on #N (issue or PR) and assert
 # its embedded session id == MY_CLAIM. Returns 0 only on a proven-own claim; non-zero (REFUSE) on
 # an absent OR a foreign claim. The ADR-0115 §2 resolution — CLAIM_RE + the write+ ACL trust root
@@ -573,7 +577,7 @@ is the **only** sanctioned path to a mutation that names `<N>`, no bypass:
 # unauthorized-only claim, a foreign owner, and a missing session all resolve NOT-mine (exit
 # non-zero) — exactly this guard's fail-closed refusal, so the exit-status contract is preserved.
 claim_is_mine() {
-  pipeline-cli claim is-mine --issue "$1" --session "$MY_CLAIM"   # exit 0 = mine; non-zero = REFUSE (default-deny)
+  "$PCLI" claim is-mine --issue "$1" --session "$MY_CLAIM"   # exit 0 = mine; non-zero = REFUSE (default-deny)
 }
 
 claim_is_mine "<N>" && gh api repos/$REPO/issues/<N>/comments -f body="…"   # the guard gates the mutation; never run it ungated
@@ -1559,6 +1563,8 @@ re-derive them here. Two operational points that are yours, not the contract's:
   `for the reviewer to judge`).
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # RE-DERIVE the branch LIVE from the worktree — never a cached/shared-file value (see the
 # live-derivation rule in Step 4). $BRANCH from Step 4 is GONE across Bash calls; wt_preflight
 # just re-cd'd to $WT, so the checked-out branch IS the work branch. Read it, never guess it.
@@ -1568,7 +1574,7 @@ wt_preflight && BRANCH="$(git -C "$WT" branch --show-current)"
 # AND independently confirms the remote ref, printing its verdict LAST on stdout. Exit 0 = MOVED,
 # 1 = NOT-MOVED, 3 = UNKNOWN; STOP on either non-zero — never open a PR against a branch you
 # cannot prove exists (an UNKNOWN is not a success).
-wt_preflight && pipeline-cli verified-push --cwd "$WT" --remote origin --branch "$BRANCH" --set-upstream \
+wt_preflight && "$PCLI" verified-push --cwd "$WT" --remote origin --branch "$BRANCH" --set-upstream \
   || { echo "write-code: the push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — refusing to open a PR against an unproven branch." >&2; exit 1; }
 # The PR opens AGAINST issue #N (Fixes #N) — gate it on the mis-attribution guard (Step 3.5): open a
 # PR closing only an issue whose claim is mine, never one mis-attributed to another agent's #N.
@@ -1806,10 +1812,12 @@ thing and then stop.
 The claim you took in Step 3 protected *this* build. The build is over, so give it up:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # the last mutation of the run — retract OUR OWN claim marker on the issue we just built.
 # --session carries the token we owned the work under (the orchestrator's delegated token on the
 # orchestrated path), because that is the token the marker itself carries.
-pipeline-cli claim release --issue "<N>" --session "$MY_CLAIM"
+"$PCLI" claim release --issue "<N>" --session "$MY_CLAIM"
 ```
 
 **Why this is mandatory, not tidy-up.** A claim that outlives its run never expires, and the
@@ -2213,6 +2221,8 @@ departed from nothing adds nothing; it does **not** rewrite a prior round's entr
 unreliable in this org).
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # re-assert the mis-attribution guard (Step 3.5) before the resubmit push — a between-calls cwd
 # reset can't move the claim, but the guard is MANDATED before every number-targeting mutation,
 # exactly as wt_preflight is before every git op; gate both the push and the progress comment.
@@ -2221,7 +2231,7 @@ claim_is_mine "$N" || { echo "refusing to push/comment — PR #$PR linked issue 
 # because the R2 rebase onto origin/main moved the head. It confirms the remote ref carries the
 # rebased head before you claim the resubmit landed; exit 0 = MOVED, 1 = NOT-MOVED, 3 = UNKNOWN.
 # STOP on either non-zero: a reviewer waiting on a moved head would otherwise re-gate the STALE one.
-wt_preflight && pipeline-cli verified-push --cwd "$WT" --remote origin --force-with-lease \
+wt_preflight && "$PCLI" verified-push --cwd "$WT" --remote origin --force-with-lease \
   || { echo "write-code: the repair push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — the gate would re-run against the STALE head. Do not report the resubmit as landed." >&2; exit 1; }
 # compose the repair note under the §SP per-run scratch namespace, never a fixed /tmp leaf:
 # concurrent repair lanes clobber a shared name and this posts THEIR note onto your issue (#3718).
@@ -2248,7 +2258,9 @@ repair round is over, and a claim left held is what makes the *next* repair disp
 read `lost` (#3780; the observed stall was a repair refused by a claim whose run had finished):
 
 ```bash
-pipeline-cli claim release --issue "$N" --session "$MY_CLAIM"   # retract OUR OWN marker; never another session's
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" claim release --issue "$N" --session "$MY_CLAIM"   # retract OUR OWN marker; never another session's
 ```
 
 A reply is the acknowledgement this skill performs. **Resolving** the thread (collapsing it)

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -210,6 +210,12 @@ export const registeredTools: ReadonlyArray<ToolRegistration> = [
 	tool("adoption-lint", () =>
 		import("./tools/adoption-lint/command.ts").then((m) => m.adoptionLintCommand),
 	),
+	// #3314 — reds on a bare `pipeline-cli <verb>` in a runnable fence. The CLI is not on PATH
+	// where agents spawn and won't be (ADR 0207), so a bare call dies `command not found` inside a
+	// fail-closed gate wrapper, which launders the miss into a wrong verdict. Enforces §CLI.
+	tool("cli-invocation-guard", () =>
+		import("./tools/cli-invocation-guard/command.ts").then((m) => m.cliInvocationGuardCommand),
+	),
 	// #3606 — inverts the crew read-only-fanout per-bridge spawn denylist into an ENFORCED
 	// allowlist: reds when a mutating roster agent-type is neither allowlisted nor denied by a
 	// crew bridge (chief-of-staff/cartographer/intake-desk), closing the future-agent hole ADR

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
@@ -148,7 +148,11 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 		for (const {rel, content} of selfAssigning) {
 			// the verb INVOCATION (verb + its issue argument), not a prose mention of the verb —
 			// a citation earlier in the file must not satisfy an ordering claim about the procedure.
-			const claimAt = content.search(/pipeline-cli\s+tracker\s+claim\s+(?:<N>|\$\{issue\})/);
+			// The invocation resolves the shim through §CLI's `$PCLI`; the bare `pipeline-cli` form
+			// stays matchable so this pin survives a corpus that has not yet been migrated (#3314).
+			const claimAt = content.search(
+				/(?:pipeline-cli|"\$PCLI")\s+tracker\s+claim\s+(?:<N>|\$\{issue\})/,
+			);
 			const assignAt = content.search(/gh api -X POST[^\n]*\/assignees/);
 			assert.isAbove(claimAt, -1, `${rel} must invoke the claim-write verb on the issue`);
 			assert.isBelow(

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts
@@ -1,0 +1,114 @@
+/**
+ * `cli-invocation-guard` core — the pure, IO-free matcher behind
+ * `pipeline-cli cli-invocation-guard check <file>…` (#3314).
+ *
+ * `pipeline-cli` is not on PATH where pipeline agents spawn and never will be (ADR 0207
+ * retired PATH-shadowing), so a bare `pipeline-cli <verb>` in a skill dies `command not
+ * found` — at a gate step, inside a fail-closed wrapper that converts the miss into a wrong
+ * verdict. The canonical resolution and its exit-code taxonomy live once in the formats
+ * contract's §CLI; this core is the mechanical enforcement of its one ban.
+ *
+ * Scoped to what an agent actually RUNS: a `bash`/`sh` fenced block, minus comment-only
+ * lines. Prose that merely names a verb ("the `pipeline-cli claim is-mine` verb") is not an
+ * invocation and is not flagged — flagging it would make the guard unusable in the very docs
+ * that define the rule.
+ */
+
+export interface ScanFile {
+	readonly file: string;
+	readonly content: string;
+}
+
+export interface Finding {
+	readonly file: string;
+	/** 1-based line number of the offending line. */
+	readonly line: number;
+	/** The offending line, trimmed — enough to locate it without opening the file. */
+	readonly text: string;
+}
+
+export interface GuardResult {
+	readonly findings: ReadonlyArray<Finding>;
+	/** Every file path scanned — the scope, emitted before the verdict (§ZS / ADR 0092). */
+	readonly scanned: ReadonlyArray<string>;
+	/** How many runnable bash/sh fences were scanned across all files — the second scope axis. */
+	readonly fenceCount: number;
+}
+
+const FENCE = /^\s*(?:```|~~~)\s*(\w*)/;
+const RUNNABLE_LANGS = new Set(["bash", "sh", "shell", "zsh"]);
+
+/**
+ * Blockquoted fences are runnable too — the skills park half their snippets inside `> ` asides,
+ * and an agent copies those the same way. Strip the quote markers before every test, or the whole
+ * block goes invisible to the scanner (a silent hole exactly where the fix lives).
+ */
+const unquote = (line: string): string => line.replace(/^(\s*>)+\s?/, "");
+
+/**
+ * A bare invocation: the token `pipeline-cli` followed by whitespace, NOT preceded by a path
+ * separator, a word character, or the `$PCLI`-style expansion that resolves it. The
+ * lookbehind-free form is a negated character class on the preceding char, so `bin/pipeline-cli`,
+ * `packages/pipeline-cli`, `@kampus/pipeline-cli` and `-pipeline-cli` all fall through.
+ */
+const BARE_INVOCATION = /(^|[^\w./@-])pipeline-cli(\s|$)/;
+
+/** A line that is only a shell comment carries no invocation to run. */
+const COMMENT_ONLY = /^\s*#/;
+
+/** Every bare-invocation finding in one file's markdown. */
+export const scanFile = (
+	file: string,
+	content: string,
+): {
+	readonly findings: ReadonlyArray<Finding>;
+	readonly fences: number;
+} => {
+	const findings: Finding[] = [];
+	let fences = 0;
+	let openLang: string | null = null;
+	const lines = content.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const lineText = unquote(lines[i] ?? "");
+		const fence = lineText.match(FENCE);
+		if (fence !== null) {
+			// A fence line either opens a block (capturing its language) or closes the open one.
+			// Markdown has no nesting here, so open/close alternate.
+			if (openLang === null) {
+				const lang = (fence[1] ?? "").toLowerCase();
+				openLang = lang;
+				if (RUNNABLE_LANGS.has(lang)) fences++;
+			} else {
+				openLang = null;
+			}
+			continue;
+		}
+		if (openLang === null || !RUNNABLE_LANGS.has(openLang)) continue;
+		if (COMMENT_ONLY.test(lineText)) continue;
+		if (!BARE_INVOCATION.test(lineText)) continue;
+		findings.push({file, line: i + 1, text: lineText.trim()});
+	}
+	return {findings, fences};
+};
+
+/** Scan the whole handed-in corpus, returning findings alongside both scope axes. */
+export const scanCorpus = (files: ReadonlyArray<ScanFile>): GuardResult => {
+	const scanned: string[] = [];
+	const findings: Finding[] = [];
+	let fenceCount = 0;
+	for (const {file, content} of files) {
+		scanned.push(file);
+		const result = scanFile(file, content);
+		findings.push(...result.findings);
+		fenceCount += result.fences;
+	}
+	return {findings, scanned, fenceCount};
+};
+
+/**
+ * Zero scope = FAIL (§ZS / ADR 0092). Both axes must be non-empty: a corpus with no file, and
+ * a corpus whose files contain no runnable fence at all, are equally broken scopes — the second
+ * is how a fence-parser regression would otherwise ship as a silent green.
+ */
+export const isZeroScope = (result: GuardResult): boolean =>
+	result.scanned.length === 0 || result.fenceCount === 0;

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.unit.test.ts
@@ -1,0 +1,124 @@
+import {assert, describe, it} from "@effect/vitest";
+import {isZeroScope, scanCorpus, scanFile} from "./cli-invocation-guard.ts";
+
+const TICKS = "```";
+const fence = (lang: string, ...lines: ReadonlyArray<string>): string =>
+	[`${TICKS}${lang}`, ...lines, TICKS].join("\n");
+
+describe("cli-invocation-guard core", () => {
+	it("flags a bare invocation inside a runnable bash fence", () => {
+		const {findings} = scanFile("s.md", fence("bash", 'pipeline-cli leak-guard scan-pr "$PR"'));
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0]?.line, 2);
+		assert.include(findings[0]?.text ?? "", "leak-guard");
+	});
+
+	it("flags a bare invocation in a pipe, a substitution, and a conditional", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence(
+				"bash",
+				'printf "%s" "$F" | pipeline-cli cp-classify classify --repo "$REPO"',
+				'STATE="$(pipeline-cli merge-queue-classify classify --pr "$PR")"',
+				"if ! pipeline-cli tracker claim 42; then exit 0; fi",
+			),
+		);
+		assert.strictEqual(findings.length, 3);
+	});
+
+	it("accepts the §CLI canonical form — a resolved $PCLI path", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence(
+				"bash",
+				// biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion in a §CLI-preamble fixture, not a JS template
+				'PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"',
+				'"$PCLI" claim is-mine --issue 42 --session "$MY_CLAIM"',
+			),
+		);
+		assert.deepStrictEqual(findings, []);
+	});
+
+	it("accepts an explicit path form and the pinned package spec", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence(
+				"bash",
+				"node packages/pipeline-cli/src/bin.ts verdict read --pr 1",
+				"claude-plugins/kampus-pipeline/bin/pipeline-cli claim status --issue 1",
+				"pnpm dlx @kampus/pipeline-cli@0.1.0 version",
+			),
+		);
+		assert.deepStrictEqual(findings, []);
+	});
+
+	it("ignores prose outside any fence — naming a verb is not invoking it", () => {
+		const {findings} = scanFile(
+			"s.md",
+			"Run `pipeline-cli commands compact` for the tool map.\n" +
+				fence("bash", 'echo "nothing to see"'),
+		);
+		assert.deepStrictEqual(findings, []);
+	});
+
+	it("ignores a non-runnable fence (text, json, markdown)", () => {
+		const {findings} = scanFile("s.md", fence("text", "pipeline-cli claim release --issue 1"));
+		assert.deepStrictEqual(findings, []);
+	});
+
+	it("ignores a comment-only line inside a runnable fence", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence("bash", "# resolved via pipeline-cli verdict read — see §CLI", "true"),
+		);
+		assert.deepStrictEqual(findings, []);
+	});
+
+	it("resumes scanning after a fence closes, and after a non-runnable fence", () => {
+		const content = [
+			fence("json", '{"a": 1}'),
+			fence("bash", "pipeline-cli version"),
+			"prose",
+			fence("bash", "true"),
+		].join("\n");
+		const {findings, fences} = scanFile("s.md", content);
+		assert.strictEqual(fences, 2);
+		assert.strictEqual(findings.length, 1);
+	});
+
+	it("flags a bare invocation as the last token on a line", () => {
+		const {findings} = scanFile("s.md", fence("bash", "pipeline-cli"));
+		assert.strictEqual(findings.length, 1);
+	});
+
+	it("sees through a blockquoted fence — a `> ` aside is copied and run like any other", () => {
+		const content = [
+			"> ```bash",
+			"> pipeline-cli claim release --issue 1",
+			"> # a quoted comment is still a comment",
+			"> ```",
+		].join("\n");
+		const {findings, fences} = scanFile("s.md", content);
+		assert.strictEqual(fences, 1);
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0]?.line, 2);
+	});
+
+	it("scanCorpus reports both scope axes and aggregates findings", () => {
+		const result = scanCorpus([
+			{file: "a.md", content: fence("bash", "pipeline-cli version")},
+			{file: "b.md", content: fence("bash", "true")},
+		]);
+		assert.deepStrictEqual(result.scanned, ["a.md", "b.md"]);
+		assert.strictEqual(result.fenceCount, 2);
+		assert.strictEqual(result.findings.length, 1);
+		assert.isFalse(isZeroScope(result));
+	});
+
+	it("fails closed on zero scope — no file, or no runnable fence (ADR 0092)", () => {
+		assert.isTrue(isZeroScope(scanCorpus([])));
+		assert.isTrue(
+			isZeroScope(scanCorpus([{file: "a.md", content: "prose only, no fence at all"}])),
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/command.ts
@@ -1,0 +1,106 @@
+/**
+ * The `cli-invocation-guard` tool — `pipeline-cli cli-invocation-guard check <file>…`.
+ *
+ * Reds on any bare `pipeline-cli <verb>` inside a runnable bash/sh fence in the pipeline
+ * corpus (#3314). See the formats contract's §CLI for the canonical resolution this enforces
+ * and the exit-code taxonomy it protects. Follows the `adoption-lint` / `gh-phoenix
+ * lint-skills` shape — an IO-free core over handed-in file contents, with a thin CLI that maps
+ * the verdict to a fail-closed exit contract (ADR 0092):
+ *
+ *   exit 0 — clean (no bare invocation in any runnable fence)
+ *   exit 2 — one or more bare invocations
+ *   exit 3 — zero scope (no file scanned, or no runnable fence found)
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect, Result} from "effect";
+import * as Schema from "effect/Schema";
+import {Argument, Command} from "effect/unstable/cli";
+import {type GuardResult, isZeroScope, type ScanFile, scanCorpus} from "./cli-invocation-guard.ts";
+
+const FINDING_EXIT_CODE = 2;
+const ZERO_SCOPE_EXIT_CODE = 3;
+
+class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()("FindingsFound", {
+	count: Schema.Number,
+}) {}
+class ZeroScope extends Schema.TaggedErrorClass<ZeroScope>()("ZeroScope", {}) {}
+
+const readFileOrSkip = (file: string): string | null =>
+	Result.getOrElse(
+		Result.try(() => readFileSync(file, "utf8")),
+		() => null,
+	);
+
+const fileArg = Argument.string("file").pipe(
+	Argument.atLeast(1),
+	Argument.withDescription(
+		"one or more corpus file paths (SKILL.md / agent defs / plugin docs) to scan for bare `pipeline-cli` invocations",
+	),
+);
+
+const judge = (result: GuardResult): Effect.Effect<void, ZeroScope | FindingsFound> =>
+	Effect.gen(function* () {
+		if (isZeroScope(result)) {
+			yield* Console.error(
+				`cli-invocation-guard: FAIL — scanned ${result.scanned.length} file(s) containing ${result.fenceCount} runnable fence(s); a zero scope on either axis is fail-closed (ADR 0092).`,
+			);
+			return yield* Effect.fail(new ZeroScope());
+		}
+
+		if (result.findings.length === 0) {
+			yield* Console.log(
+				"cli-invocation-guard: clean — every `pipeline-cli` call in a runnable fence resolves the shim by path (§CLI).",
+			);
+			return;
+		}
+
+		yield* Console.error(
+			`cli-invocation-guard: FAIL — ${result.findings.length} bare \`pipeline-cli\` invocation(s) in runnable fences. \`pipeline-cli\` is NOT on PATH where agents spawn (ADR 0207 retired PATH-shadowing), so these die \`command not found\` at a gate — and a fail-closed wrapper turns that miss into a wrong verdict (#3314):`,
+		);
+		for (const f of result.findings) {
+			yield* Console.error(`  ${f.file}:${f.line}: ${f.text}`);
+		}
+		yield* Console.error(
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion in the remediation literal a reader pastes, not a JS template
+			'  FIX: resolve the shim once per fence — PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/claude-plugins/kampus-pipeline}/bin/pipeline-cli" — then call "$PCLI" <verb>. See §CLI in claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md.',
+		);
+		return yield* Effect.fail(new FindingsFound({count: result.findings.length}));
+	});
+
+const onZeroScope = (_e: ZeroScope) => Effect.sync(() => process.exit(ZERO_SCOPE_EXIT_CODE));
+const onFindingsFound = (_e: FindingsFound) => Effect.sync(() => process.exit(FINDING_EXIT_CODE));
+
+const check = Command.make(
+	"check",
+	{files: fileArg},
+	Effect.fn(function* ({files}) {
+		const scanInput: ScanFile[] = [];
+		for (const file of files) {
+			const content = readFileOrSkip(file);
+			if (content !== null) scanInput.push({file, content});
+		}
+
+		const result = scanCorpus(scanInput);
+
+		// ADR 0092: emit the scanned scope before judging it.
+		yield* Console.log(
+			`cli-invocation-guard: scanned ${result.scanned.length} file(s), ${result.fenceCount} runnable bash/sh fence(s)`,
+		);
+
+		yield* judge(result).pipe(
+			Effect.catchTag("ZeroScope", onZeroScope),
+			Effect.catchTag("FindingsFound", onFindingsFound),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Red on any bare `pipeline-cli` invocation in a runnable bash/sh fence (fails closed on zero scope)",
+	),
+);
+
+export const cliInvocationGuardCommand = Command.make("cli-invocation-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Enforce §CLI: every `pipeline-cli` call in the corpus resolves the shim by path, never bare on PATH (#3314)",
+	),
+);


### PR DESCRIPTION
Pipeline agents spawn into a shell where `pipeline-cli` is not on PATH, but 55 command lines across the skills and agent definitions still called it by that bare name. An agent that followed a skill literally got `command not found` at a gate — and because those gates wrap the call in fail-closed logic, the miss came back as a *wrong answer* rather than an error: ship-it's leak scan reported "a landed comment carries a machine-local path" for a scanner that never ran, and its reconcile poll reported a well-formed `pending` for a classifier that never ran.

This PR gives every call site one documented way to resolve the shim — one that works from any directory, in the primary checkout and in an agent worktree alike — and makes the failure legible enough that "the CLI could not run" can never again be read as a verdict.

## Was #3314 still live at head? Yes — and wider than filed

The issue listed a handful of un-guarded sites. At head there were **55** bare invocations in runnable `bash`/`sh` fences across **15** files, so the defect had grown, not shrunk. Two parts of the issue *were* overtaken, though, and are recorded here rather than silently re-fixed:

- **Fix option 1 is stale.** The issue's preferred shape was the `node packages/pipeline-cli/src/bin.ts` guarded assignment. #3653 has since replaced that with a single shim, `claude-plugins/kampus-pipeline/bin/pipeline-cli`, which owns the whole resolution ladder (in-repo source → installed data-dir bin → pinned `pnpm dlx`). Canonicalizing onto `node …/bin.ts` today would re-introduce the duplication that shim removed, so the canonical form here resolves **the shim**, not the source entry.
- **Two AC-2 sites no longer exist as invocations.** The review skills' `leak-guard scan-comment` and `worktree-sweep --execute` are prose mentions at head (`review-code/SKILL.md:418` and `:1410`), not runnable command lines, so there is nothing to fix there. The three ship-it sites — `leak-guard scan-pr`, `merge-queue-classify`, `cp-cardinality` — were all still live and are all fixed.

## What changed

**§CLI, the canonical invocation** (`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`). One resolution, defined once: `$CLAUDE_PLUGIN_ROOT` when the plugin is installed in a foreign consumer, else the git toplevel plus the repo-relative shim path. Anchoring on the git toplevel rather than the cwd is what makes it resolve from a subdirectory, and from a worktree whose cwd was reset back to the primary checkout between calls. Verified live from four positions: a worktree root, a worktree subdirectory, a primary-checkout subdirectory, and outside any repo.

**The exit-code taxonomy**, in the same section. Exit 127 (or a message naming a path that does not exist) means the CLI never ran and must resolve to **unknown** — never clean, never a negative verdict. Any other non-zero is the verb's own documented contract. The section also corrects a live misdiagnosis: **127 is a resolution gap, not worktree teardown.** Teardown is progressive and has its own two signatures in sequence — exit 1 `ENOENT` on a file that provably exists on `main`, then exit 126 `Volta error: Could not determine current directory`. Three agents recently reported 127 with fully intact worktrees on the strength of the wrong heuristic.

Invoking by path is what makes this readable without prior knowledge. The shell's own error names the missing **path**, not a bare command name:

```
sh: /claude-plugins/kampus-pipeline/bin/pipeline-cli: No such file or directory   (exit 127)
```

**55 call sites rewritten** across 15 corpus files onto `"$PCLI"`, each fence carrying the one-line §CLI preamble.

**Explicit pre-resolution refusals at the three gate-critical sites** #3314 names. These are the sites where a fail-closed wrapper would otherwise launder a resolution failure into an answer, so each now proves the shim resolved *before* the gate runs and refuses with the real cause if it did not.

**`pipeline-cli cli-invocation-guard check`** — a new tool (pure core + 13 unit tests) plus a CI job that scans the full plugin corpus and reds on any bare invocation in a runnable fence. It sees through blockquoted fences, ignores prose and comment-only lines, and fails closed on zero scope (ADR 0092). Without it the 55 sites regrow.

## How this composes with the sibling shim issues

Deliberately scoped to the **call-site resolution** half, and §CLI says so in the text. **#4178** owns legibility when the shim's own tree vanishes mid-run; **#4185** owns legibility when the shim resolved but the CLI's module-load self-heal failed. Both already reserve the same "could not run ⇒ unknown" contract this taxonomy states, so a fix there extends the §CLI table rather than forking a second attribution mechanism. Nothing here touches `bin.ts`, `module-load-guard.ts`, or the shim's resolution ladder.

## Verification

- `pnpm typecheck` — clean (29/29).
- `pnpm lint:worktree` — clean.
- `pnpm vitest run` in `packages/pipeline-cli` — 2676 passed, 172 files.
- `cli-invocation-guard check` over the corpus — clean, 68 files / 317 runnable fences scanned.
- Live resolution proven from a worktree root, a worktree subdirectory, and a primary-checkout subdirectory; the unresolved case proven to exit 127 naming the path.

Fixes #3314

## Deviations

- **Class: narrowed the issue's suggested fix-shape.** Said: canonicalize onto `node packages/pipeline-cli/src/bin.ts` (the issue's preferred option 1). Did: canonicalize onto the `claude-plugins/kampus-pipeline/bin/pipeline-cli` shim instead. Why: #3653 introduced that shim as the single home for the resolution ladder after #3314 was filed; option 1 would re-introduce the per-site duplication the shim removed, and would not resolve in a foreign consumer install. Disposition: intentional, and stated in the PR body above so a reader is not confused by the mismatch with the issue text.

- **Class: left a sibling defect for a follow-up.** Said: nothing. Did: left ~20 surviving `node packages/pipeline-cli/src/bin.ts <verb>` invocations in the corpus untouched. Why: they are not bare-PATH calls, so they are outside #3314's scope and out of the new guard's ban; they do work from a repo root. They are still non-canonical — they break from a subdirectory and in a foreign consumer install, and they bypass the shim's ladder. Disposition: for the reviewer to judge whether a follow-up issue should be filed to migrate them onto §CLI; not done here to keep this diff's scope honest to the issue.

- **Class: changed a test that asserted the old shape.** Said: nothing. Did: widened one regex in `packages/pipeline-cli/src/tools/adoption-lint/command.test.ts` so the `tracker claim` invocation-ordering pin matches the §CLI `"$PCLI"` form as well as the bare form. Why: the test located the invocation by the literal string `pipeline-cli tracker claim <N>`, which this migration rewrites; the assertion it protects (claim before self-assign, #4015) is unchanged and still enforced. Disposition: no action needed — the widened form still rejects a prose-only citation, which is what the test exists to do.

- **Class: scope call on prose mentions.** Said: AC 3 asks that an agent following the skill literally can run each gate step. Did: rewrote only *runnable* lines inside `bash`/`sh` fences; left prose that names a verb (``the `pipeline-cli claim is-mine` verb``) as-is, and the guard does not flag it. Why: a prose mention is a reference, not an invocation, and banning it would make the guard unusable in the very documents that define the rule. Disposition: for the reviewer to judge.

- **Class: two acceptance-criterion items were already satisfied at head.** Said: AC 2 names the review skills' `leak-guard scan-comment` and `worktree-sweep --execute` as un-guarded call sites. Did: verified both are prose at head, not commands, and changed nothing there. Why: they were rewritten between the issue being filed and now. Disposition: no action needed; recorded above so the AC can be checked off honestly rather than looking unaddressed.
