### PR TITLE
fix(verdict): order same-head verdicts by when they were written, not when their slot opened (#4200)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
@@ -277,10 +277,12 @@ re-deriving the resolver write-code once hand-copied, and keeps only the two thi
 
 - **The native decisive review that folds into the code namespace.** The verb reads marker comments;
   a native review is a *different* record type. GitHub author-attributes reviews, so this path needs
-  **no** ACL gate — `commit_id` IS its bound SHA. The fold is **newest-wins by timestamp** (as in
+  **no** ACL gate — `commit_id` IS its bound SHA. The fold is **newest-WRITTEN wins** (as in
   `ship-it` Step 2 / write-code R1): the code verdict is the newest of {latest decisive review,
-  latest `review-code` marker}, so a current-head `CHANGES_REQUESTED` is a code FAIL *unless* a newer
-  current-head marker already PASS'd.
+  in-force `review-code` marker}, so a current-head `CHANGES_REQUESTED` is a code FAIL *unless* a
+  more recently written current-head marker already PASS'd. Compare the review's `submitted_at`
+  against the verb's `writtenAt`, never the marker comment's `created_at` — an upsert leaves
+  `created_at` at the slot's open time, which systematically under-ranks the marker (#4200).
 - **The N=3 FAIL-round count.** `verdict read` resolves the latest verdict; it does not count
   rounds. A PR already at 3 FAIL rounds is escalated to a human, **not** an active repair, so the
   guard counts the rounds itself (author-gated to write+ collaborators, clustered by >120s gap —
@@ -307,20 +309,22 @@ VERDICT_UNKNOWN=0
 for J in "$CODE_FAIL_JSON" "$DOC_FAIL_JSON"; do jq -e . >/dev/null 2>&1 <<<"$J" || VERDICT_UNKNOWN=1; done
 
 # the native decisive review folds into the code namespace (the verb reads only marker comments), by
-# NEWEST-WINS timestamp — the same fold ship-it Step 2 / write-code R1 run. `at: .submitted_at` is what
-# the compare reads; a bare "CHANGES_REQUESTED ⇒ CODE_FAIL=1" would report a repair in flight on a PR
-# whose newer marker already PASS'd at the same head, suppressing a defect that should be filed.
+# NEWEST-WRITTEN wins — the same fold ship-it Step 2 / write-code R1 run. `at: .submitted_at` is what
+# the compare reads (a review is never upserted, so it IS the review's write time); a bare
+# "CHANGES_REQUESTED ⇒ CODE_FAIL=1" would report a repair in flight on a PR whose newer marker already
+# PASS'd at the same head, suppressing a defect that should be filed.
 CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
 REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
         | sort_by(.submitted_at) | last | {state, sha: .commit_id, at: .submitted_at}')
 RSTATE=$(jq -r '.state // ""' <<<"$REVIEW"); RSHA=$(jq -r '.sha // empty' <<<"$REVIEW")
 RAT=$(jq -r '.at // ""' <<<"$REVIEW")
-# `_tag == "current"` is exactly "a current-head marker verdict stands"; its comment id yields the
-# created_at the compare needs (the verb's outcome carries no timestamp).
+# `_tag == "current"` is exactly "a current-head marker verdict stands"; the verb's `writtenAt` is the
+# WRITE time the compare needs — never the comment's created_at, which an in-place upsert leaves at the
+# slot's open time and which would let a review wrongly out-rank a later-written marker (#4200).
 MARKER_AT=""
 [ "$(jq -r '._tag // ""' <<<"$CODE_FAIL_JSON" 2>/dev/null)" = "current" ] &&
-  MARKER_AT=$(gh api "repos/$REPO/issues/comments/$(jq -r .commentId <<<"$CODE_FAIL_JSON")" --jq .created_at 2>/dev/null)
+  MARKER_AT=$(jq -r '.writtenAt // empty' <<<"$CODE_FAIL_JSON" 2>/dev/null)
 if [ -n "$RSHA" ] && [ -n "$RAT" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
   # ISO-8601-UTC sorts lexically, so `>` IS the chronological compare.
   if [ -z "$MARKER_AT" ] || [ "$RAT" \> "$MARKER_AT" ]; then

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -876,13 +876,23 @@ verdict), the in-force pick, and the ADR-0058 SHA-staleness refusal (Step 2b) in
 unit tests are the contract (#2102), the same resolution `write-code` reads.
 
 **The in-force rule, stated once and used by every namespace below: filter candidates to the ones
-bound to the LIVE head first, then latest-wins only among those.** Never "the newest comment in the
-namespace, then check its head" — `verdict post` upserts a verdict in place (ADR 0213/#4016/#4050), so
-`created_at` is when a comment SLOT was opened, not when the verdict it now carries was written, and a
-stale-but-freshly-created verdict outranks an at-head one that was rewritten in place. That is a false
-**refusal** of a green PR, and it cost PR #3955 an hour (#4189). The same trap catches a human skimming
-the PR, since the GitHub UI orders by creation time too — read the `@ <sha>` / `Reviewed-head:` binding,
-never the position.
+bound to the LIVE head first, then take the most recently WRITTEN of those.** Two things follow from
+`verdict post` upserting a verdict in place (ADR 0213/#4016/#4050), and `created_at` — when the comment
+SLOT was opened, not when the verdict it now carries was written — gets both wrong:
+
+- Never "the newest comment in the namespace, then check its head": a stale-but-freshly-created verdict
+  then outranks an at-head one that was rewritten in place. That is a false **refusal** of a green PR,
+  and it cost PR #3955 an hour (#4189).
+- Never order two LIVE-HEAD verdicts by `created_at` either: an in-place correction keeps its slot's
+  creation time, so it loses to a sibling run's merely-newer comment. Here the head filter admits both
+  candidates and there is no staleness test left to catch the mis-pick, so it also runs **fail-open** —
+  a FAIL upserted after a PASS is silently cleared (#4200). The ordering key is the `Verdict-written:`
+  stamp `verdict post` writes into every body (floored at `created_at`, so an unstamped legacy comment
+  is unaffected); `verdict read` reports it as `writtenAt`, which is the ONLY timestamp a fold below
+  may compare against.
+
+The same trap catches a human skimming the PR, since the GitHub UI orders by creation time too — read
+the `@ <sha>` / `Reviewed-head:` binding and the `Verdict-written:` stamp, never the position.
 The native decisive review folds into the code namespace separately (the verb reads marker comments,
 not reviews); Step 2b keeps `is_current` for it and for the §CP advisory body-SHA:
 
@@ -894,7 +904,8 @@ CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
 # GitHub author-attributes reviews, so this path is unforgeable and needs no ACL check. commit_id IS
 # the SHA the reviewer approved, so the same staleness test applies to it as to a marker's @ <sha>.
 # `at: .submitted_at` is load-bearing, not decoration: it is the timestamp the newest-wins fold below
-# compares against the marker's created_at. Drop it and the fold degenerates to a precedence rule.
+# compares against the marker's write time. A review is never upserted, so `submitted_at` IS its write
+# time — the two sides are like for like. Drop it and the fold degenerates to a precedence rule.
 REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
         | sort_by(.submitted_at) | last | {state, sha: .commit_id, at: .submitted_at}')
@@ -910,8 +921,8 @@ VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli 
 # — Step 2b's `unverified (verdict not bound to current head)` refusal, now owned by the verb. (A §CP
 # advisory namespace is SHA-less by design and resolves `none` here — Step 2.§CP handles it from the
 # body's Reviewed-head instead.)
-# the code namespace keeps the verb's stdout JSON: it names the RESOLVING comment id, which the
-# newest-wins fold below turns into the marker's created_at (the verb's outcome carries no timestamp).
+# the code namespace keeps the verb's stdout JSON: it carries `writtenAt`, the resolving verdict's
+# WRITE time, which is what the newest-wins fold below compares (#4200).
 CODE_JSON="$($VERDICT read --pr "$PR" --gate code --expect PASS 2>/dev/null)" && CODE_PASS=1 || CODE_PASS=0
 $VERDICT read --pr "$PR" --gate code   --expect FAIL >/dev/null 2>&1 && CODE_FAIL=1   || CODE_FAIL=0
 $VERDICT read --pr "$PR" --gate doc    --expect PASS >/dev/null 2>&1 && DOC_PASS=1    || DOC_PASS=0
@@ -931,13 +942,12 @@ $VERDICT read --pr "$PR" --gate design --expect FAIL >/dev/null 2>&1 && DESIGN_F
 RSTATE=$(jq -r '.state // ""' <<<"$REVIEW"); RSHA=$(jq -r '.sha // empty' <<<"$REVIEW")
 RAT=$(jq -r '.at // ""' <<<"$REVIEW")
 if [ -n "$RSHA" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
-  # the marker's created_at: the verb's outcome carries no timestamp, so resolve it from the comment
-  # id its JSON names. An empty MARKER_AT means no current-head marker verdict stands (`verdict read`
-  # already dropped a none/sha-less/stale one) ⇒ the review is the only event ⇒ it decides alone.
+  # the marker's WRITE time, straight off the verb's JSON — never the comment's created_at, which an
+  # in-place upsert leaves behind (#4200). An empty MARKER_AT means no current-head marker verdict
+  # stands (`verdict read` already dropped a none/sha-less/stale one) ⇒ the review decides alone.
   MARKER_AT=""
-  MARKER_ID=$(jq -r '.commentId // empty' <<<"$CODE_JSON" 2>/dev/null)
-  [ -n "$MARKER_ID" ] && [ "$((CODE_PASS + CODE_FAIL))" -gt 0 ] &&
-    MARKER_AT=$(gh api "repos/$REPO/issues/comments/$MARKER_ID" --jq .created_at 2>/dev/null)
+  [ "$((CODE_PASS + CODE_FAIL))" -gt 0 ] &&
+    MARKER_AT=$(jq -r '.writtenAt // empty' <<<"$CODE_JSON" 2>/dev/null)
   # ISO-8601-UTC sorts lexically, so `>` IS the chronological compare.
   if [ -z "$MARKER_AT" ] || [ "$RAT" \> "$MARKER_AT" ]; then
     case "$RSTATE" in
@@ -952,8 +962,8 @@ Now resolve **per namespace** (the marker verdict from the verb above, the nativ
 advisory folded in):
 
 - **review-code namespace** — the verdict is the **newest of {latest decisive review, in-force
-  review-code marker comment}**, compared by timestamp (review `submitted_at` vs comment
-  `created_at`) **only once both are current-head-bound** — the head-first rule above, which is
+  review-code marker comment}**, compared by WRITE time (review `submitted_at` vs the verdict's
+  `writtenAt`) **only once both are current-head-bound** — the head-first rule above, which is
   what the `case "$CURRENT_HEAD" in "$RSHA"*` guard and the `_tag == "current"` marker test encode.
   An `APPROVED` review or a `review-code: PASS … merge-ready` marker is PASS; a
   `CHANGES_REQUESTED` review or a `review-code: FAIL` marker is FAIL. The verdict's bound SHA
@@ -1084,8 +1094,8 @@ on a legitimately-approved PR (#2329):
 ```bash
 # $ADV_BODY = the IN-FORCE §CP advisory comment body for this namespace (review-code/skill/doc/design),
 # author-gated (write+, ADR 0055) and resolved head-first exactly like the markers above — an advisory
-# is upserted in place too, so its `created_at` does not order it (`pipeline-cli verdict gate --cp`
-# computes this; do not hand-roll a newest-comment read here).
+# is upserted in place too, so its `created_at` does not order it; its `Verdict-written:` stamp does
+# (`pipeline-cli verdict gate --cp` computes this; do not hand-roll a newest-comment read here).
 # (a) body's canonical Reviewed-head SHA (ADR 0151 §6.6) must prefix-match the PR's current head.
 #     Anchored to the `Reviewed-head:` line — a DISTINCT token from the first-line advisory marker,
 #     so this never mistakes a first-line marker for the body binding, and the advisory stays out of

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1933,10 +1933,12 @@ latest-wins pick, and the ADR-0058 SHA-staleness refusal) is owned by `pipeline-
 so R1 delegates to the verb rather than re-deriving it (#2102) — its unit tests are the contract.
 The native decisive review that folds into the code namespace is the one thing the verb does not
 resolve (it reads only marker comments); it needs no ACL gate — GitHub author-attributes reviews, so
-that path is unforgeable — so R1 keeps just that fold inline. The fold is **newest-wins by
-timestamp**, matching `ship-it` Step 2: the code verdict is the newest of {latest decisive review,
-latest `review-code` marker}, so a newer `APPROVED` clears an older FAIL rather than the FAIL
-standing forever.
+that path is unforgeable — so R1 keeps just that fold inline. The fold is **newest-WRITTEN wins**,
+matching `ship-it` Step 2: the code verdict is the newest of {latest decisive review, in-force
+`review-code` marker}, so a more recently written `APPROVED` clears an older FAIL rather than the FAIL
+standing forever. Compare the review's `submitted_at` against the verb's `writtenAt`, never the marker
+comment's `created_at` — an in-place upsert leaves `created_at` at the slot's open time, so a review is
+systematically over-ranked against a marker rewritten after it (#4200).
 
 ```bash
 PR=<the PR number you were handed>
@@ -1986,8 +1988,10 @@ done
 # GitHub author-attributes reviews, so this path needs no ACL gate — commit_id IS its bound SHA, and
 # only a review prefix-matching the current head participates (ADR 0058).
 #
-# The fold is NEWEST-WINS by timestamp — the resolution ship-it Step 2 states and this step mirrors.
-# `at: .submitted_at` is load-bearing, not decoration: it is what the compare reads. A bare
+# The fold is NEWEST-WRITTEN wins — the resolution ship-it Step 2 states and this step mirrors.
+# `at: .submitted_at` is load-bearing, not decoration: it is what the compare reads, and a review is
+# never upserted, so `submitted_at` IS the review's write time — like for like against the marker's
+# `writtenAt` below. A bare
 # "CHANGES_REQUESTED ⇒ CODE_FAIL=1" would be FAIL-precedence, re-entering repair on a PR whose newer
 # marker already PASS'd at the same head — a spurious repair loop, not a safe default.
 CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
@@ -1997,10 +2001,11 @@ REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
 RSTATE=$(jq -r '.state // ""' <<<"$REVIEW"); RSHA=$(jq -r '.sha // empty' <<<"$REVIEW")
 RAT=$(jq -r '.at // ""' <<<"$REVIEW")
 # marker side: `_tag == "current"` is exactly "a current-head marker verdict stands" (a none/sha-less/
-# stale one does not participate); its comment id yields the created_at newest-wins compares against.
+# stale one does not participate); the verb's `writtenAt` is the WRITE time newest-wins compares
+# against — never the comment's created_at, which an in-place upsert leaves behind (#4200).
 MARKER_AT=""
 [ "$(jq -r '._tag // ""' <<<"$CODE_FAIL_JSON" 2>/dev/null)" = "current" ] &&
-  MARKER_AT=$(gh api "repos/$REPO/issues/comments/$(jq -r .commentId <<<"$CODE_FAIL_JSON")" --jq .created_at 2>/dev/null)
+  MARKER_AT=$(jq -r '.writtenAt // empty' <<<"$CODE_FAIL_JSON" 2>/dev/null)
 if [ -n "$RSHA" ] && [ -n "$RAT" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
   # ISO-8601-UTC sorts lexically, so `>` IS the chronological compare. Empty MARKER_AT ⇒ the review is
   # the only current-head event ⇒ it decides alone. A newer APPROVED clears an older FAIL — that is the

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -9,7 +9,9 @@
  * **exits 0 only when HEAD is reviewed with the expected polarity** (default PASS) — every
  * refusal (`none`/`sha-less`/`stale`, or a current verdict of the wrong polarity) prints its
  * reason on stderr and exits non-zero, so a caller branches on exit status. The resolved
- * outcome is printed as JSON on stdout for a caller that wants the detail (comment id, sha).
+ * outcome is printed as JSON on stdout for a caller that wants the detail (comment id, sha, and
+ * `writtenAt` — when the resolving verdict was WRITTEN, which is what a skill's review-vs-marker
+ * fold must compare against a review's `submitted_at`, never the comment's `created_at`, #4200).
  *
  * `gate --pr N --require <namespaces> [--cp]` is the SET-level counterpart `read` cannot be: it
  * folds the same resolution over EVERY namespace the diff requires and exits 0 only when each one
@@ -114,9 +116,16 @@ const read = Command.make(
 		const g = yield* parseGate(gate);
 		const polarity = yield* parseExpect(expect);
 		const result = yield* (yield* Github).read(pr, g, polarity, Option.getOrUndefined(head));
-		// The resolved detail goes to stdout as JSON (a caller may want the comment id / bound sha);
-		// the human-readable verdict + refusal reason goes to stderr, mirroring resume-policy.
-		yield* Console.log(JSON.stringify({...result.outcome, headSha: result.headSha, gate: g}));
+		// The resolved detail goes to stdout as JSON (a caller may want the comment id / bound sha /
+		// write time); the human-readable verdict + refusal reason goes to stderr, mirroring resume-policy.
+		yield* Console.log(
+			JSON.stringify({
+				...result.outcome,
+				headSha: result.headSha,
+				gate: g,
+				writtenAt: result.writtenAt,
+			}),
+		);
 		if (result.satisfied) {
 			process.stderr.write(`verdict: ${outcomeReason(result.outcome, polarity)}\n`);
 			return;

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
@@ -22,6 +22,7 @@
  */
 import {
 	boundHead,
+	compareWriteRecency,
 	GATE_KEYWORD,
 	isBoundToHead,
 	parseVerdict,
@@ -91,15 +92,14 @@ export interface GateDecision {
 	readonly reason: string;
 }
 
-/** Newest of two optional candidates by `(createdAt, id)` — the same latest-wins key as the markers. */
+/** Newest of two optional candidates — the same write-recency key `pickLatestAuthorized` orders by. */
 const newerOf = (
 	a: VerdictComment | undefined,
 	b: VerdictComment | undefined,
 ): VerdictComment | undefined => {
 	if (a === undefined) return b;
 	if (b === undefined) return a;
-	if (a.createdAt !== b.createdAt) return a.createdAt > b.createdAt ? a : b;
-	return a.id > b.id ? a : b;
+	return compareWriteRecency(a, b) > 0 ? a : b;
 };
 
 /**

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -417,6 +417,115 @@ describe("decideGate — PR #3955's exact situation: the in-force verdict was cr
 	});
 });
 
+describe("decideGate — two LIVE-HEAD verdicts order by write time, not slot-open time (#4200)", () => {
+	// #4198's head-first filter admits BOTH candidates here (both bind the live head), so the tiebreak
+	// among them is the whole decision — and unlike #4189's cross-head case there is no staleness test
+	// downstream to convert a mis-pick into a refusal: whichever candidate wins is consumed at full
+	// strength. `post` upserts in place, so the corrected verdict keeps its slot's `created_at` and
+	// creation order runs INVERSE to write order.
+	const SLOT_OPENED = "2026-07-26T00:09:58Z";
+	const UPSERTED_AT = "2026-07-26T00:49:26Z";
+	const SIBLING_CREATED = "2026-07-26T00:32:02Z";
+
+	const written = (body: string, at: string) => `${body}\n\nVerdict-written: ${at}`;
+
+	it("FAIL-OPEN closed: an older slot upserted to FAIL is not cleared by a newer-created same-head PASS", () => {
+		const result = decide({
+			comments: [
+				comment({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: written(`review-doc: FAIL @ ${HEAD} — changes-requested`, UPSERTED_AT),
+				}),
+				comment({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: written(`review-doc: PASS @ ${HEAD} — merge-ready`, SIBLING_CREATED),
+				}),
+			],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "fail");
+		assert.strictEqual(result.decisions[0]?.commentId, 1);
+	});
+
+	it("the §CP advisory form carries the same rule: a [FAIL] row upserted into an older slot still blocks", () => {
+		const result = decide({
+			controlPlane: true,
+			comments: [
+				comment({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: written(advisory("doc", HEAD, "[FAIL]"), UPSERTED_AT),
+				}),
+				comment({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: written(advisory("doc", HEAD), SIBLING_CREATED),
+				}),
+			],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "unverified");
+		assert.strictEqual(result.decisions[0]?.commentId, 1);
+	});
+
+	it("the marker-vs-advisory fold uses the same key: an upserted marker outranks a newer-created advisory", () => {
+		const result = decide({
+			controlPlane: true,
+			comments: [
+				comment({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: written(`review-doc: FAIL @ ${HEAD} — changes-requested`, UPSERTED_AT),
+				}),
+				comment({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: written(advisory("doc", HEAD), SIBLING_CREATED),
+				}),
+			],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.state, "fail");
+		assert.strictEqual(result.decisions[0]?.commentId, 1);
+	});
+
+	it("write order agreeing with creation order is unchanged latest-wins (#4016/#4050 preserved)", () => {
+		const result = decide({
+			comments: [
+				comment({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: written(`review-doc: FAIL @ ${HEAD} — changes-requested`, SLOT_OPENED),
+				}),
+				comment({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: written(`review-doc: PASS @ ${HEAD} — merge-ready`, SIBLING_CREATED),
+				}),
+			],
+		});
+		assert.isTrue(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.commentId, 2);
+	});
+
+	it("unstamped pre-#4200 comments are unaffected — they order by created_at exactly as before", () => {
+		const result = decide({
+			comments: [
+				comment({id: 1, createdAt: SLOT_OPENED}),
+				comment({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+			],
+		});
+		assert.isFalse(result.enqueueable);
+		assert.strictEqual(result.decisions[0]?.commentId, 2);
+	});
+});
+
 describe("decideGate — fail-closed on its own inputs (ADR 0092)", () => {
 	it("an EMPTY required set refuses rather than passing vacuously", () => {
 		const result = decide({requiredGates: [], comments: [comment({id: 1})]});

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -664,6 +664,71 @@ describe("Github.post — the upsert also carries the attested HEAD (#4007)", ()
 // hole — a body composed for PR B (bound to B's head) that gets POSTed to PR A. `emissionDefect`
 // passes it (it's well-formed), but A's live head is not B's SHA, so the head cross-check refuses it
 // before any write. No POST/PATCH fixture is supplied on the refusal cases: a write would 404.
+describe("the write-recency stamp at the boundary — post writes it, read reports it (#4200)", () => {
+	const BODY = `review-doc: PASS @ ${HEAD40} — merge-ready`;
+
+	it.effect("post stamps `Verdict-written:` into the body it sends", () => {
+		const sent: Array<ReadonlyArray<string>> = [];
+		const before = Date.now();
+		return Effect.gen(function* () {
+			yield* (yield* Github).post(PR, "doc", BODY, RUN);
+			const posted = sent.find((args) => args.some((a) => a.startsWith("body=")));
+			const stamp = posted
+				?.join("\n")
+				.match(/Verdict-written: (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/)?.[1];
+			assert.isDefined(stamp);
+			// the stamp is THIS post's wall clock, not a value carried in from the composed body
+			assert.isAtLeast(Date.parse(stamp as string), Math.floor(before / 1000) * 1000);
+		}).pipe((effect) =>
+			provide(
+				effect,
+				{
+					[`GET ${P}/pulls/${PR}`]: HEAD40,
+					"GET user": "usirin",
+					[`GET ${P}/issues/${PR}/comments`]: "[]",
+					[`POST ${P}/issues/${PR}/comments`]: "77",
+					[`GET ${P}/issues/comments/77`]: BODY,
+				},
+				sent,
+			),
+		);
+	});
+
+	it.effect("read reports the resolving verdict's writtenAt, not its created_at", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			assert.strictEqual(result.outcome._tag, "current");
+			assert.strictEqual(result.writtenAt, "2026-07-26T00:49:26Z");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({
+						id: 1,
+						login: "usirin",
+						at: "2026-07-26T00:09:58Z",
+						body: `review-doc: PASS @ ${HEAD} — merge-ready\n\nVerdict-written: 2026-07-26T00:49:26Z`,
+					}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "admin",
+			}),
+		),
+	);
+
+	it.effect("read's writtenAt is null when no verdict resolved", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			assert.strictEqual(result.outcome._tag, "none");
+			assert.isNull(result.writtenAt);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: "[]",
+			}),
+		),
+	);
+});
+
 describe("Github.post — the post-time head cross-check (#3801, no cross-PR contamination)", () => {
 	// A's live head. FOREIGN is a DIFFERENT PR's head SHA — the value a clobbered shared-scratch body
 	// would carry. Both are full 40-hex (the emission shape), and they share no common prefix.

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -48,6 +48,7 @@ import {decideGate, type GateDecision} from "./gate-decision.ts";
 import {
 	bindsSameHead,
 	boundHeadShas,
+	compareWriteRecency,
 	emissionDefect,
 	headBindingDefect,
 	namespaceRe,
@@ -55,10 +56,13 @@ import {
 	type Polarity,
 	resolveVerdict,
 	runIdOf,
+	toStampIso,
 	type VerdictComment,
 	type VerdictGate,
 	type VerdictOutcome,
 	withRunId,
+	withWrittenAt,
+	writeRecencyOf,
 } from "./verdict-match.ts";
 
 // Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
@@ -110,6 +114,15 @@ export interface ReadResult {
 	/** Does the outcome satisfy the caller's expected polarity (a current-head match)? */
 	readonly satisfied: boolean;
 	readonly expect: Polarity;
+	/**
+	 * When the resolving verdict was WRITTEN (`writeRecencyOf`), or `null` when nothing resolved.
+	 *
+	 * Reported because the shell folds that weigh a verdict against a native review's `submitted_at`
+	 * (ship-it Step 2, heal-ci's in-flight-repair probe, write-code repair R1) need this exact value:
+	 * left to fetch a timestamp themselves they read `created_at`, which is slot-open time and
+	 * re-opens #4200 outside the resolver. One rule, computed once, handed out.
+	 */
+	readonly writtenAt: string | null;
 }
 
 /** The `post` verdict — whether we upserted this run's same-head marker or appended a fresh comment, and its id. */
@@ -201,7 +214,10 @@ const read = Effect.fn("Github.read")(function* (
 	const authorized = yield* authorizedAuthors(repo, markerAuthors);
 	const outcome = resolveVerdict({comments, authorizedAuthors: authorized, gate, headSha});
 	const satisfied = outcome._tag === "current" && outcome.polarity === expect;
-	return {outcome, headSha, gate, satisfied, expect} satisfies ReadResult;
+	const resolving =
+		outcome._tag === "none" ? undefined : comments.find((c) => c.id === outcome.commentId);
+	const writtenAt = resolving === undefined ? null : writeRecencyOf(resolving);
+	return {outcome, headSha, gate, satisfied, expect, writtenAt} satisfies ReadResult;
 });
 
 /**
@@ -255,7 +271,7 @@ const gate = Effect.fn("Github.gate")(function* (
  * — closing the verdict-integrity hole where a body composed for another PR (bound to a different
  * PR's SHA, e.g. via a clobbered shared scratch file) was postable and caught only on read-back.
  * Then scan for THIS RUN's own prior marker attesting THIS HEAD (same author, the same
- * `verdict-run:` trailer, and the same bound head, newest by `(created_at, id)`) and PATCH it if
+ * `verdict-run:` trailer, and the same bound head, newest by write-recency) and PATCH it if
  * present, else POST a fresh one.
  *
  * The head dimension makes a re-gate at a new head APPEND, leaving the prior head's verdict intact,
@@ -266,9 +282,11 @@ const gate = Effect.fn("Github.gate")(function* (
  * every pipeline review agent posts under one shared GitHub identity, so an author-keyed upsert let
  * a concurrent sibling reviewer silently PATCH another reviewer's verdict body away — a PASS could
  * replace a FAIL at the same head with no trace the FAIL existed. Keyed on the run, a sibling never
- * matches: it appends its own comment, so both verdicts survive in the record and the unchanged
- * latest-wins resolution (`resolveVerdict` / `decideGate`) picks between them by `(createdAt, id)`.
- * A run that cannot identify itself (no run id) never
+ * matches: it appends its own comment, so both verdicts survive in the record and the latest-wins
+ * resolution (`resolveVerdict` / `decideGate`) picks between them. That arbitration is why every
+ * emitted body carries a `Verdict-written:` stamp: two surviving same-head verdicts both pass the
+ * head filter, so their write order is the ONLY thing left to separate them, and an in-place PATCH
+ * does not move `created_at` (#4200). A run that cannot identify itself (no run id) never
  * PATCHes at all — it appends, which costs a comment and loses nothing. Finally, `verifyLanded`
  * re-fetches the upserted comment and re-runs `emissionDefect` on its LANDED body — the
  * defense-in-depth self-verify (#3019) that fails the post if the marker didn't land clean, rather
@@ -282,7 +300,12 @@ const post = Effect.fn("Github.post")(function* (
 	rawRunId: string | undefined,
 ) {
 	const runId = normalizeRunId(rawRunId);
-	const body = runId === null ? rawBody : withRunId(rawBody, runId);
+	// The write-recency stamp goes on unconditionally and BEFORE the run trailer, so the visible line
+	// sits above the invisible one. It is what makes an in-place PATCH orderable at all: the PATCH
+	// leaves `created_at` at the slot's open time, and this is the only field that moves with the
+	// verdict (#4200). A re-post replaces the prior stamp rather than stacking one.
+	const stamped = withWrittenAt(rawBody, toStampIso(Date.now()));
+	const body = runId === null ? stamped : withRunId(stamped, runId);
 	const defect = emissionDefect(body, gate);
 	if (defect !== null) {
 		return yield* new VerdictInputError({message: `refusing to post: ${defect}`});
@@ -311,9 +334,7 @@ const post = Effect.fn("Github.post")(function* (
 							runIdOf(c.body) === runId &&
 							bindsSameHead(c.body, body, gate),
 					)
-					.sort((a, b) =>
-						a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
-					);
+					.sort(compareWriteRecency);
 	const priorId = mine[mine.length - 1]?.id;
 	const result: PostResult = yield* Effect.gen(function* () {
 		if (priorId !== undefined) {

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -72,7 +72,7 @@ export interface VerdictComment {
 	readonly id: number;
 	/** The comment author's login (checked against the authorized set). */
 	readonly author: string;
-	/** ISO-8601 UTC creation time (the latest-wins primary key). */
+	/** ISO-8601 UTC time the comment SLOT was opened — the write-recency FLOOR, not the ordering key. */
 	readonly createdAt: string;
 	/** The raw comment body (matched against the namespace/verdict matchers). */
 	readonly body: string;
@@ -146,10 +146,84 @@ export interface ResolveVerdictInput {
 }
 
 /**
+ * The write-recency stamp `post` writes into every verdict body it emits, and the ONE key every
+ * recency comparison in this module orders by (#4200).
+ *
+ * `created_at` is when a comment SLOT was opened, not when the verdict it now carries was written:
+ * `post` upserts in place at the same head (ADR 0213/#4007), so an in-place correction keeps the
+ * `created_at` of the slot it was PATCHed into and reads as OLDER than a sibling run's comment that
+ * was merely created later. #4198 removed the cross-head half of that defect by filtering candidates
+ * to the live head first; this closes the residual, where BOTH candidates bind the live head and the
+ * tiebreak among them decides alone — with no staleness backstop, so a live FAIL upserted into an old
+ * slot silently loses to a stale PASS (the fail-OPEN direction).
+ *
+ * Deliberately a body-carried stamp rather than the REST `updated_at` (the rejected alternative, ADR
+ * 0058): `updated_at` moves on any byte edit — a typo fix, a leak redaction, a human reformatting a
+ * table — so a cosmetic edit to the older-AUTHORED verdict would re-crown it over the genuinely newer
+ * one, and invisibly, since `updated_at` is not rendered. The stamp moves only when a verdict is
+ * authored, is legible in the rendered comment, survives any storage/schema change, and sits inside
+ * the ADR-0055 authorized-author trust boundary, where a hand-forged stamp is at least a VISIBLE
+ * forgery. See the PR body for the full argument.
+ *
+ * Second-precision ISO-8601 UTC, matching GitHub's `created_at` shape exactly so the two are lexically
+ * comparable — the whole point, since one falls back to the other.
+ */
+const writtenAtRe = /^[ \t]*Verdict-written:[ \t]*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)[ \t]*$/gim;
+
+/**
+ * The write time a verdict body stamps on itself, or `null` for an unstamped body (a pre-#4200
+ * marker, or one hand-rolled through raw `gh api`). Takes the LAST match: `post` appends the stamp,
+ * so a body that also quotes an earlier stamp in its prose still resolves to the real one.
+ */
+export const writtenAtOf = (body: string): string | null => {
+	let last: string | null = null;
+	for (const match of body.matchAll(writtenAtRe)) last = match[1] ?? last;
+	return last;
+};
+
+/** Stamp `iso` onto a verdict body, replacing any stamp it already carries. */
+export const withWrittenAt = (body: string, iso: string): string =>
+	`${body.replace(writtenAtRe, "").replace(/\s+$/, "")}\n\nVerdict-written: ${iso}`;
+
+/**
+ * Normalize an epoch-millis instant to the stamp's second-precision ISO-8601 UTC shape. Dropping the
+ * milliseconds is load-bearing, not cosmetic: `2026-07-26T00:49:26.123Z` sorts BELOW
+ * `2026-07-26T00:49:26Z` lexically (`.` < `Z`), so a sub-second-precision stamp would read as older
+ * than a `created_at` in the same second — an inversion in exactly the tight race this key exists to
+ * order.
+ */
+export const toStampIso = (epochMillis: number): string =>
+	new Date(epochMillis).toISOString().replace(/\.\d{3}Z$/, "Z");
+
+/**
+ * When a comment's verdict was WRITTEN — its body stamp, floored at the comment's `created_at`.
+ *
+ * The floor is the fail-safe: a comment cannot have been written before its slot existed, so an
+ * absent stamp (every pre-#4200 comment) and a backdated one both degrade to today's `created_at`
+ * ordering — never to something worse. Forward forgery stays possible and stays visible; ADR 0055
+ * already confines it to write+ collaborators.
+ */
+export const writeRecencyOf = (comment: VerdictComment): string => {
+	const stamped = writtenAtOf(comment.body);
+	return stamped !== null && stamped > comment.createdAt ? stamped : comment.createdAt;
+};
+
+/**
+ * The single recency ordering over verdict comments: write-recency, then the server-assigned comment
+ * id. Every "which of these is newer" question in this module and in `gate-decision.ts` answers
+ * through this one comparator, so the marker set and the marker-vs-advisory fold cannot drift apart.
+ */
+export const compareWriteRecency = (a: VerdictComment, b: VerdictComment): number => {
+	const ra = writeRecencyOf(a);
+	const rb = writeRecencyOf(b);
+	return ra < rb ? -1 : ra > rb ? 1 : a.id - b.id;
+};
+
+/**
  * The latest-wins pick within an already-scoped candidate set: among the comments an authorized
- * (write+, ADR 0055) author posted whose body matches `re`, the newest by `(createdAt, id)`.
- * `undefined` when the authorized candidate set is empty — the fail-closed "nothing to consume in
- * this namespace", never a false win.
+ * (write+, ADR 0055) author posted whose body matches `re`, the newest by write-recency
+ * (`compareWriteRecency`). `undefined` when the authorized candidate set is empty — the fail-closed
+ * "nothing to consume in this namespace", never a false win.
  *
  * This is recency ALONE — it is not the in-force resolver. Scope the candidate set to the live head
  * first (`pickInForce` below, #4189), then break ties here.
@@ -163,9 +237,7 @@ export const pickLatestAuthorized = (
 	const candidates = comments.filter(
 		(comment) => authorized.has(comment.author) && re.test(comment.body),
 	);
-	candidates.sort((a, b) =>
-		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
-	);
+	candidates.sort(compareWriteRecency);
 	return candidates[candidates.length - 1];
 };
 
@@ -182,23 +254,20 @@ export const boundHead = (body: string, gate: VerdictGate): string | null =>
  *
  * This ordering is the whole fix for #4189 and it is ADR 0058's own rule: a verdict attests the
  * exact head it names, so the question "which verdict is in force" is first "which candidates
- * attest the head I am gating" and only then "which of those is newest". Picking by `(createdAt,
- * id)` and testing the head afterwards — on the winner alone — never consults the candidate that
- * binds the live head, and under the in-place upsert (#4016/#4050) that is not an edge case: an
- * at-head verdict keeps the `created_at` of the slot it was upserted into, so a stale,
- * freshly-created verdict outranks it. Observed on PR #3955 — a green §CP PR that `verdict gate`
- * refused for ~an hour because a dead-head pair created at 00:32 outranked the live-head PASSes
- * upserted at 00:49 into 00:09 slots.
+ * attest the head I am gating" and only then "which of those is newest". Picking by recency and
+ * testing the head afterwards — on the winner alone — never consults the candidate that binds the
+ * live head. Observed on PR #3955 — a green §CP PR that `verdict gate` refused for ~an hour because
+ * a dead-head pair created at 00:32 outranked the live-head PASSes upserted at 00:49 into 00:09 slots.
  *
  * The fallback to the unfiltered set when NOTHING binds the live head is load-bearing, not a
  * loophole: it preserves the fail-closed classification downstream, which still reports the
  * `stale` / `sha-less` refusal with the offending comment named, exactly as before.
  *
- * Within the live-head set this is unchanged latest-wins — the arbitration the run-keyed upsert
- * (#4016) explicitly relies on to settle two surviving same-head verdicts. That leaves the
- * same-head WRITE-RECENCY direction open (an in-place upsert of an older slot at the same head is
- * still ordered by its creation time); closing it needs a write-recency signal the boundary does
- * not decode today — tracked separately, see #4189's PR body.
+ * Within the live-head set, latest-wins arbitrates — the arbitration the run-keyed upsert (#4016)
+ * explicitly relies on to settle two surviving same-head verdicts — and it orders by WRITE recency,
+ * not slot-creation time (`compareWriteRecency`, #4200). That distinction only bites here: when both
+ * candidates bind the live head there is no staleness backstop, so a mis-pick is consumed at full
+ * strength in either polarity.
  */
 export const pickInForce = (
 	comments: ReadonlyArray<VerdictComment>,

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -13,10 +13,14 @@ import {
 	parseVerdict,
 	resolveVerdict,
 	runIdOf,
+	toStampIso,
 	type VerdictComment,
 	type VerdictGate,
 	type VerdictOutcome,
 	withRunId,
+	withWrittenAt,
+	writeRecencyOf,
+	writtenAtOf,
 } from "./verdict-match.ts";
 
 const HEAD = "abc1234def5678";
@@ -203,8 +207,9 @@ describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0
 		},
 		// The run-scoped upsert (#4016) means two reviewer RUNS can now leave two verdict comments
 		// at ONE head, where the author-keyed upsert used to collapse them to one. Resolution is
-		// unchanged by that: latest-wins on `(createdAt, id)` still decides (ADR 0058) — the newer
-		// verdict supersedes the older, exactly as a re-review at the same head always did.
+		// unchanged by that: latest-wins still decides (ADR 0058) — the newer verdict supersedes the
+		// older, exactly as a re-review at the same head always did. (Unstamped bodies like these fall
+		// back to `createdAt`; #4200 covers the case where an upsert makes the two diverge.)
 		{
 			name: "two runs at one head: the newer verdict supersedes the older (latest-wins)",
 			comments: [
@@ -394,6 +399,193 @@ describe("resolveVerdict — live-head candidates first, latest-wins only among 
 			),
 		);
 	}
+});
+
+describe("resolveVerdict — two LIVE-HEAD verdicts order by write time, not slot-open time (#4200)", () => {
+	// The residual #4198's head-first filter structurally cannot close: BOTH candidates bind the live
+	// head, so both survive the filter and the tiebreak among them decides alone — with no staleness
+	// backstop to convert a mis-pick into a refusal. `post` upserts in place at the same head, so the
+	// corrected verdict keeps the `created_at` of the slot it was PATCHed into: creation order is the
+	// INVERSE of write order here.
+	const SLOT_OPENED = "2026-07-26T00:09:58Z"; // the upserted slot, opened first
+	const UPSERTED_AT = "2026-07-26T00:49:26Z"; // …but rewritten LAST
+	const SIBLING_CREATED = "2026-07-26T00:32:02Z"; // a sibling run's fresh comment, in between
+
+	const stamped = (first: string, writtenAt: string) => `${first}\n\nVerdict-written: ${writtenAt}`;
+
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly comments: ReadonlyArray<VerdictComment>;
+		readonly expected: VerdictOutcome;
+	}> = [
+		{
+			// The direction with NO backstop: a live FAIL upserted after a live PASS. Ordering by
+			// `created_at` reports `pass` and clears the merge gate over a standing FAIL.
+			name: "FALSE CLEARANCE: an older slot upserted to FAIL beats a newer-created same-head PASS",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: stamped(`review-doc: FAIL @ ${HEAD} — changes-requested`, UPSERTED_AT),
+				}),
+				marker({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: stamped(`review-doc: PASS @ ${HEAD} — merge-ready`, SIBLING_CREATED),
+				}),
+			],
+			expected: {_tag: "current", commentId: 1, polarity: "FAIL", sha: HEAD},
+		},
+		{
+			name: "FALSE REFUSAL: an older slot upserted to PASS beats a newer-created same-head FAIL",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: stamped(`review-doc: PASS @ ${HEAD} — merge-ready`, UPSERTED_AT),
+				}),
+				marker({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: stamped(`review-doc: FAIL @ ${HEAD} — changes-requested`, SIBLING_CREATED),
+				}),
+			],
+			expected: {_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+		},
+		{
+			// Write order AGREEING with creation order must not regress: #4016/#4050's run-keyed upsert
+			// leaves two same-head verdicts to arbitrate, and the ordinary case is still latest-wins.
+			name: "write order agreeing with creation order is unchanged latest-wins (#4016 preserved)",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: stamped(`review-doc: PASS @ ${HEAD} — merge-ready`, SLOT_OPENED),
+				}),
+				marker({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: stamped(`review-doc: FAIL @ ${HEAD} — changes-requested`, SIBLING_CREATED),
+				}),
+			],
+			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+		},
+		{
+			// The floor: a stamp can never pull a verdict BELOW its own slot-open time, so a backdated
+			// (or absent) stamp degrades to today's `created_at` ordering rather than to something worse.
+			name: "a backdated stamp is floored at created_at — it cannot demote a genuinely newer comment",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: stamped(`review-doc: PASS @ ${HEAD} — merge-ready`, "2020-01-01T00:00:00Z"),
+				}),
+				marker({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+			],
+			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+		},
+		{
+			name: "a stamped verdict still loses to an unstamped one created later (mixed pre/post-#4200)",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: stamped(`review-doc: PASS @ ${HEAD} — merge-ready`, "2026-07-26T00:20:00Z"),
+				}),
+				marker({
+					id: 2,
+					createdAt: "2026-07-26T00:40:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+			],
+			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+		},
+		{
+			// The head-first filter still runs FIRST: write recency only ever orders WITHIN the live-head
+			// set, so a freshly-written stale verdict cannot climb back over a live-head one (#4189).
+			name: "a newly-written DEAD-head verdict still loses to the live-head one (#4189 preserved)",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: SLOT_OPENED,
+					body: stamped(`review-doc: PASS @ ${HEAD} — merge-ready`, SLOT_OPENED),
+				}),
+				marker({
+					id: 2,
+					createdAt: SIBLING_CREATED,
+					body: stamped(`review-doc: FAIL @ ${OLD} — changes-requested`, "2026-07-26T23:00:00Z"),
+				}),
+			],
+			expected: {_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+		},
+	];
+	for (const {name, comments, expected} of cases) {
+		it(name, () =>
+			assert.deepStrictEqual(
+				resolveVerdict({comments, authorizedAuthors: ["usirin"], gate: "doc", headSha: HEAD}),
+				expected,
+			),
+		);
+	}
+});
+
+describe("the write-recency stamp — the ordering key an in-place upsert can move (#4200)", () => {
+	const SHA40 = "a".repeat(40);
+	const BODY = `review-doc: PASS @ ${SHA40} — merge-ready`;
+	const T1 = "2026-07-26T00:09:58Z";
+	const T2 = "2026-07-26T00:49:26Z";
+
+	it("writtenAtOf reads back the stamp withWrittenAt wrote", () =>
+		assert.strictEqual(writtenAtOf(withWrittenAt(BODY, T1)), T1));
+
+	it("writtenAtOf is null for an unstamped (pre-#4200 / hand-rolled) body", () =>
+		assert.isNull(writtenAtOf(BODY)));
+
+	it("withWrittenAt replaces the prior stamp rather than stacking a second", () => {
+		const restamped = withWrittenAt(withWrittenAt(BODY, T1), T2);
+		assert.strictEqual(writtenAtOf(restamped), T2);
+		assert.strictEqual(restamped.split("Verdict-written:").length - 1, 1);
+	});
+
+	it("a stamp quoted in the body's PROSE never outranks the real appended one", () =>
+		assert.strictEqual(
+			writtenAtOf(withWrittenAt(`${BODY}\n\nthe prior run stamped Verdict-written: ${T1}`, T2)),
+			T2,
+		));
+
+	it("a stamped body still passes every emission guard (marker stays on line one)", () =>
+		assert.isNull(emissionDefect(withWrittenAt(BODY, T1), "doc")));
+
+	it("the stamp composes with the run trailer, both readable", () => {
+		const both = withRunId(withWrittenAt(BODY, T1), "ddf8f459-b75f-4de2-9051-8df10da5b55c");
+		assert.strictEqual(writtenAtOf(both), T1);
+		assert.strictEqual(runIdOf(both), "ddf8f459-b75f-4de2-9051-8df10da5b55c");
+		assert.isNull(emissionDefect(both, "doc"));
+	});
+
+	it("writeRecencyOf floors the stamp at created_at (an absent/backdated stamp never demotes)", () => {
+		assert.strictEqual(writeRecencyOf(marker({id: 1, createdAt: T1, body: BODY})), T1);
+		assert.strictEqual(
+			writeRecencyOf(marker({id: 1, createdAt: T1, body: withWrittenAt(BODY, T2)})),
+			T2,
+		);
+		assert.strictEqual(
+			writeRecencyOf(marker({id: 1, createdAt: T2, body: withWrittenAt(BODY, T1)})),
+			T2,
+		);
+	});
+
+	it("toStampIso drops milliseconds so a stamp is lexically comparable with a created_at", () => {
+		const iso = toStampIso(Date.parse("2026-07-26T00:49:26.123Z"));
+		assert.strictEqual(iso, "2026-07-26T00:49:26Z");
+		// the inversion the truncation exists to prevent: `.` sorts BELOW `Z`
+		assert.isTrue("2026-07-26T00:49:26.123Z" < "2026-07-26T00:49:26Z");
+		assert.isFalse(iso < "2026-07-26T00:49:26Z");
+	});
 });
 
 describe("isReviewed — read-verb decision over expected polarity", () => {


### PR DESCRIPTION
Fixes #4200

## Base assumed

Built on `origin/main` **with PR #4198 already merged** (`fix(verdict): resolve the in-force verdict head-first, not by created_at`). This does not fork a second selection path: `pickInForce`'s head-first filter and its unfiltered fallback are untouched, and the change is confined to the recency key applied *within* the set that filter admits.

## #4200 survived #4198 — reproduced, not inferred

Against the merged resolver, three of the new cases are red. Reproduction method: the new tests were written first, then the source fix was stashed and the suite re-run against `origin/main`'s `verdict-match.ts` / `gate-decision.ts`.

```
FAIL  decideGate — two LIVE-HEAD verdicts order by write time (#4200)
  × FAIL-OPEN closed: an older slot upserted to FAIL is not cleared by a newer-created same-head PASS
  × the §CP advisory form carries the same rule: a [FAIL] row upserted into an older slot still blocks
  × the marker-vs-advisory fold uses the same key: an upserted marker outranks a newer-created advisory
      AssertionError: expected true to be false   (enqueueable)
```

All three fail in the **fail-open** direction: `enqueueable: true` over a standing FAIL. That is the difference from #4189 — there the wrongly-crowned candidate bound a superseded head, so `decideNamespace` caught it as `unverified`; here both candidates bind the live head, so `isBoundToHead` passes on the winner and nothing downstream can reject it.

### On the live case, PR #3955 — a reachability witness, not a polarity incident

The dispatch named #3955's `review-code` pair (created `00:09:58`, upserted `00:49:26`) as the wedge. Read back over REST, four verdict comments bind head `e340fb7c`:

| id | gate | created | updated | `[FAIL]` rows |
|---|---|---|---|---|
| 5081148335 | doc | 00:09:45 | 00:49:10 | 0 |
| 5081149091 | code | 00:09:58 | 00:49:26 | 0 |
| 5081516046 | doc | 01:58:50 | 01:58:50 | 0 |
| 5081518660 | code | 01:59:28 | 01:59:28 | 0 |

So the precondition is real and observed — two live-head candidates per namespace, one of them an in-place upsert — but the **polarity was never inverted on this PR**: all four are all-PASS, and the upsert at 00:49 landed *before* the 01:59 sibling, so write order happened to agree with creation order. #3955 is a witness that the population exists, not a recorded mis-pick. Stated plainly rather than claimed as a proven outcome. (`verdict gate --pr 3955 --require review-code,review-doc --cp` returns `enqueueable: true` both before and after this change.)

The remaining three verdict comments the dispatch counted (`5081217674` / `5081217899` and the 22:20 pair) anchor superseded heads, so #4198's filter already excludes them.

## The mechanism

`verdict post` upserts in place at the same head (ADR 0213 / #4007), so an in-place correction keeps the `created_at` of the slot it was PATCHed into. Creation order is POST order; the PATCH is the only thing that can invert write order against it — which makes `created_at` a slot-open time, not a write time. #4016's run-keyed upsert then *guarantees* the two-candidate population by design (a sibling run appends rather than clobbering) and hands arbitration to exactly this key.

## The ordering key — a body-carried stamp, not `updated_at` (AC3)

`verdict post` now writes a visible `Verdict-written: <ISO-8601-UTC>` line into every body it emits, replacing any stamp already there. `writeRecencyOf` reads it and **floors it at the comment's `created_at`**; that value is the single recency key, exposed as one comparator (`compareWriteRecency`) used by the marker pick, the marker-vs-advisory fold, and the post-side own-marker scan.

`updated_at` was considered and rejected, per the issue's requirement to argue it rather than adopt it reflexively:

- **Against ADR 0058.** A verdict attests a specific review of a specific tree. `updated_at` attests *bytes changed*, which is a different fact — it moves for a typo fix, an appended note, a leak redaction, a human reformatting a rendered table. Adopting it would make the ordering key a proxy that is right only when the edit happens to be the re-authorship.
- **Against the cosmetic-edit case in (c).** Head-binding does shrink the blast radius: a byte-edit can no longer resurrect a *stale* verdict, because it never enters the candidate set. But the residual survives intact and lands in the worse direction — among two live-head candidates a cosmetic edit to the older-*authored* one re-crowns it, and per (b) a live-head winner is consumed at full strength with no staleness backstop. `updated_at` would fix the fail-open case and silently open a new one.
- **Invisibility.** `updated_at` is not rendered, so a human auditing the PR cannot see the ordering the gate used — the "human-visible workaround for a machine-invisible bug" trap #4189 named. The stamp is a visible line.
- **Forgery.** Both sit inside the ADR-0055 authorized-author boundary. A hand-forged stamp is a *visible* forgery in the rendered comment; a bumped `updated_at` is an invisible one. The `created_at` floor also makes backward forgery structurally impossible — a stamp can only ever move a verdict *later*, never demote a genuinely newer one.
- **Locality.** `updated_at` is not decoded at the boundary, and `RawComment` is shared with `Tracker` and `epic-lock`, so widening it is not local to `verdict/`. The stamp needs no schema change at all.

`updated_at` remains available as a human sanity cross-check; it is not the key.

### Compatibility

An unstamped body (every pre-#4200 comment, and anything hand-rolled through raw `gh api`) has no stamp, so `writeRecencyOf` returns `created_at` and orders exactly as today. The change is strictly additive: nothing that resolved correctly before resolves differently now.

`toStampIso` truncates milliseconds so the stamp is lexically comparable with GitHub's `created_at`. Without it `…:26.123Z` sorts *below* `…:26Z` (`.` < `Z`) — an inversion inside the same second, in exactly the tight race the key exists to order. Table-tested.

## The three skill folds (AC6)

`verdict read` now reports `writtenAt` — the resolving verdict's write time — in its stdout JSON. The three folds that weigh a native review's `submitted_at` against a marker now read it instead of fetching the comment's `created_at`:

- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` — Step 2's review-vs-marker fold
- `claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md` — the in-flight-repair probe
- `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` — repair Step R1's fold

Per the issue's explicit warning, **their head-bound guards are untouched** — only the timestamp compare moved. Each also drops a REST round-trip (`gh api .../issues/comments/$ID --jq .created_at`), because the value now rides the JSON the fold already has.

The asymmetry the issue names is why this matters: a native review is never upserted, so `submitted_at` is a true write time while the marker side was a slot-open time. The marker could only ever be wrongly *under*-ranked — a one-sided fail-open. Both sides are now write times.

## Prose restated (AC7)

Located by grep at implementation time, as instructed. Restated where the prose named the ordering **key** (`created_at` / "newest-wins by timestamp" / "the created_at the compare needs"), including ship-it's in-force paragraph, which now states both halves of the rule. Bare `latest-wins` mentions that name no key were left alone — they remain accurate (latest still wins; what changed is what "latest" measures) and rewriting them would be churn.

## Tests

- `verdict-match.unit.test.ts` — a 6-row table whose write order is the inverse of its creation order, covering both polarity directions, the `created_at` floor, mixed stamped/unstamped, and the #4189 head-first precedence still holding; plus a stamp round-trip suite (replace-not-stack, prose-quote immunity, composition with the `verdict-run` trailer, emission-guard compatibility, the millisecond truncation).
- `gate-decision.unit.test.ts` — the false-clearance case explicitly (AC2), the same rule on the §CP advisory form, the marker-vs-advisory fold, #4016/#4050's arbitration preserved (AC4), and unstamped comments unaffected.
- `github-service.unit.test.ts` — the boundary: `post` stamps the body it sends, `read` reports `writtenAt`, `writtenAt` is null when nothing resolved.

`pnpm vitest run` in `packages/pipeline-cli`: 171 files, 2686 tests, green. `pnpm typecheck` and `biome check` clean.

## Deviations

- **No ADR.** This changes the ordering key of the ADR-0058 verdict contract, which is arguably ADR-worthy. #4198 — the same contract, the same two files — landed without one, so this follows that precedent rather than unilaterally opening a decision record. Flagging it: if the reviewer wants ADR 0058 amended with the write-recency rule, say so and it lands here.
- **`writtenAt` is on `ReadResult`, not `VerdictOutcome`.** The pure core's outcome shape is unchanged, so ~20 existing `deepStrictEqual` outcome literals stay untouched. This also matches the existing split — `headSha` / `gate` / `satisfied` already live on `ReadResult`, not on the outcome.
- **Bare `latest-wins` prose left in place.** AC7 lists `latest-wins` among the phrasings to restate; sites that name no ordering key were judged still-accurate and left. Sites naming `created_at` or "by timestamp" were all restated.
- **`post`'s own-marker scan also moved to the shared comparator.** Strictly it selects among *this run's* own same-head markers, where the two keys almost never differ — changed anyway so a single comparator is the only recency rule in the tool.
- **The formats contract was not touched.** The `Verdict-written:` stamp is `post`-injected, and its sibling the `<!-- verdict-run: … -->` trailer (#4016) is likewise documented in the tool rather than in `gh-issue-intake-formats.md`. Following that precedent instead of widening scope.
- **Out of scope, as triage directed:** `write-code`'s N=3 repair-round counter still clusters `review-*: FAIL` markers by `created_at` gap. It counts review passes rather than resolving an in-force verdict, so it is a different question; not touched, not asserted as a defect.

## §CP

`packages/pipeline-cli/` plus three skills — control-plane path (ADR 0164 / ADR 0135). As with #4189, the fix lands in the tool that gates its own merge: a reviewer verdict posted against **this** PR will be written by the *installed* `verdict post`, i.e. the pre-fix one, so it will carry no `Verdict-written:` stamp and will order by `created_at` exactly as today. That is the safe direction — resolution here is unchanged from current behaviour, and the new key only takes effect for verdicts posted after this merges.
