### PR TITLE
fix(crew-em): resolve the shim by path in the approval-watcher fence (§CLI) — unreds main

### DIFF
--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -251,6 +251,8 @@ it adds no engine→engine and no human-facing edge.
   the approver set is assembled, inside that single-source discharge.
 
   ```bash
+  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   # The non-firing exit that is NOT a definite answer: it names the read that could not execute.
   unknown() { echo "approval-watcher #$PR: $1 READ FAILED ($2) — UNKNOWN, re-arming; NOT 'no approval'"; }
   # `gh api --paginate` emits one JSON value per page, so slurp and assert EVERY page is an array —
@@ -286,7 +288,7 @@ it adds no engine→engine and no human-facing edge.
   #    red (#3999); 127 = a PATH gap and any other non-zero a crash, i.e. the read never ran.
   #    Branching on `rc == 2` alone lets 1/127/anything-else fall through to a fire — the fail-OPEN
   #    polarity of #3715, committed inside the fix for it. Enumerate; only a proven-green 0 continues.
-  pipeline-cli checks read --pr "$PR" --expect green >/dev/null 2>&1; rc=$?
+  "$PCLI" checks read --pr "$PR" --expect green >/dev/null 2>&1; rc=$?
   case "$rc" in
     0) : ;;                                                       # proven green — the only continuing branch
     1) echo "approval-watcher #$PR: machine gates not green (read OK, definite)"; return 0 ;;


### PR DESCRIPTION
HOTFIX — `main` is red on the `cli-invocation-guard` job. One line plus the preamble §CLI requires to make it valid.

## The breakage

`claude-plugins/pipeline-crew/agents/crew-engineering-manager.md` carried a bare invocation inside a runnable `bash` fence — the approval-watcher's machine-gates guard:

```
pipeline-cli checks read --pr "$PR" --expect green >/dev/null 2>&1; rc=$?
```

`pipeline-cli` is not on PATH where pipeline agents spawn and never will be (ADR 0207 retired PATH-shadowing), so that call dies `command not found` — inside a fail-closed wrapper whose `case` arm would read the miss as a gate result rather than a clean error. That is exactly the class §CLI bans and the guard enforces.

## The fix

Per §CLI in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, verbatim and without variation:

- Added the canonical §CLI resolution preamble at the top of that fence (the fence had none).
- Changed the one call site to `"$PCLI" checks read …`.

Nothing else. The `pipeline-cli` mentions on the neighbouring comment lines are comment-only, which the guard's matcher skips by design, so they are untouched.

## How this happened — a sequencing error, not a defect in either PR

Two lanes landed six minutes apart in the wrong order for this file:

- **#4230 ADDED the guard**, merging at `7a2e08f8`, 09:10:30Z.
- **#4225's repair round was authored BEFORE that**, so it used the then-correct bare form. It merged at `aeafdc85`, 09:16:54Z — introducing a violation of a rule that had existed for six minutes.
- #4225's own PR checks were green because **its base predated the workflow**, so the job never ran against it.
- `513b6a0b` (#4234's merge) is red for the same inherited reason.

So the guard is working exactly as designed: it caught a real violation the moment it existed on `main`. The sequencing was the operator's and it was wrong. **This is not a defect in #4230 or in #4225** — neither PR did anything incorrect against the rules in force when it was authored.

## Verification at this head

Ran the guard locally with the CI job's exact scope (`set -uo pipefail`, so the `find | sort | xargs` chain cannot hand back a poisoned green):

```
find claude-plugins -type f -name '*.md' -print0 | sort -z \
  | xargs -0 node packages/pipeline-cli/src/bin.ts cli-invocation-guard check
```

```
cli-invocation-guard: scanned 68 file(s), 317 runnable bash/sh fence(s)
cli-invocation-guard: clean — every `pipeline-cli` call in a runnable fence resolves the shim by path (§CLI).
```

Exit 0. Both scope axes non-empty, so this is a real green and not the §ZS zero-scope shape.

## Classification

`claude-plugins/pipeline-crew/agents/**` is **deliberately NOT §CP** — a live founder ruling re-affirmed 2026-07-24 (#3765), stated in `gh-issue-intake-formats.md` §CP. Re-resolved against the contract on current `main` rather than assumed. The crew defs are **has-skills**: they ride a `review-skill` gate and auto-ship on a PASS, with no human approval required. `CONTROL_PLANE_RE` is untouched — this PR neither widens nor narrows the boundary.

## Issueless — ADR 0184

No issue exists for this breakage and none was minted. Opened issueless under ADR [0184](.decisions/0184-review-code-issueless-carve-out.md)'s carve-out (extending ADR [0075](.decisions/0075-issueless-doc-pr-merge-seam.md) to this lane): the artifact records a settled, operator-directed hotfix, there is no originating issue and nothing for a `Fixes #N` to close. Deliberately **no fabricated issue link** — 0184 bans minting a tracking issue purely to satisfy the guard.

## Deviations

None.

Per §DEV's `[N/A]` scoping, the deviation row on an ADR-0184-blessed issueless PR renders **[N/A]** alongside the acceptance-criteria determination — there is no spec to depart from. The section is stated here explicitly rather than omitted, because absent is not `None.`

## Scope discipline

One offending line plus the two-line preamble §CLI mandates. No sweep, no refactor, nothing else touched — in particular not `gh-issue-intake-formats.md` or any skill, which #4229 is mid-re-gate on.
