### PR TITLE
fix(pipeline): class-probe's namespace-set consumers read its exit status (#4231)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -148,8 +148,22 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   ```bash
   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-    | "$PCLI" class-probe classify --namespaces   # → review-code / review-doc / review-skill (+ review-design when has-ui), one per present gate
+  # <a id="probe-status-note"></a>READ THE PROBE'S EXIT STATUS — an empty set is UNKNOWN, never "no gates"
+  # (#4231). class-probe's stdin branch REFUSES with exit 4 on a failed read (#4010) and prints NOTHING,
+  # so stdout alone cannot tell a refusal from a legitimate result — capture the probe as the LAST stage
+  # of its own statement, keep its status, and fail closed on BOTH a non-zero exit and a zero-length set
+  # (§ZS / ADR 0092). NEVER pipe the probe onward (`| paste`, `| sort`, `| tr`): `pipefail` is OFF here
+  # (#4146), so the trailing stage's 0 becomes the pipeline's status and the refusal is unobservable.
+  REQUIRED_NS="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+    | "$PCLI" class-probe classify --namespaces)"; PROBE_RC=$?
+  NS_COUNT="$(printf '%s\n' "$REQUIRED_NS" | grep -c '[^[:space:]]' || true)"
+  if [ "$PROBE_RC" -ne 0 ]; then
+    echo "reviewer fan FAILED (fail-closed): class-probe REFUSED (exit $PROBE_RC) — the required-namespace set is UNKNOWN, not empty. Fan NOTHING and stop; re-run once the read succeeds." >&2; exit 1
+  fi
+  if [ "$NS_COUNT" -eq 0 ]; then
+    echo "reviewer fan FAILED (fail-closed, zero scope): class-probe exited 0 but named ZERO namespaces — its no-class fail-closed rule makes that unreachable for a non-empty diff, so this is a probe regression, not 'nothing to review'." >&2; exit 1
+  fi
+  echo "reviewer fan: PR $PR requires $NS_COUNT namespace(s) → ${REQUIRED_NS//$'\n'/ }"   # → review-code / review-doc / review-skill (+ review-design when has-ui), one per present gate
   ```
   The probe **also folds in the additive `review-design`** (`ui_reresolve`, below): it reads the
   live `UI_RE` from its single source (`ship-it/SKILL.md`) and appends `review-design` to
@@ -235,10 +249,21 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
-  # the required set — same class-probe output the fan dispatches on (folds in review-design when has-ui)
+  # the required set — same class-probe output the fan dispatches on (folds in review-design when has-ui),
+  # read under the same status contract (see the fan invariant's [probe-status note](#probe-status-note)):
+  # a refusal and a zero-length set are both UNKNOWN, and an UNKNOWN set makes the loop below vacuous.
   REQUIRED_NS="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-    | "$PCLI" class-probe classify --namespaces)"   # e.g. review-code / review-skill for a mixed diff
-  echo "reviewer dispatch: PR $PR @ $HEAD_SHA requires namespaces → ${REQUIRED_NS//$'\n'/ }"
+    | "$PCLI" class-probe classify --namespaces)"; PROBE_RC=$?   # e.g. review-code / review-skill for a mixed diff
+  NS_COUNT="$(printf '%s\n' "$REQUIRED_NS" | grep -c '[^[:space:]]' || true)"
+  if [ "$PROBE_RC" -ne 0 ]; then
+    echo "reviewer coverage self-check FAILED (fail-closed): class-probe REFUSED (exit $PROBE_RC) — the required-namespace set is UNKNOWN. An unchecked refusal here would loop over zero namespaces and report coverage complete having verified NOTHING (#4231). Do NOT return clean." >&2; exit 1
+  fi
+  if [ "$NS_COUNT" -eq 0 ]; then
+    echo "reviewer coverage self-check FAILED (fail-closed, zero scope): class-probe exited 0 but named ZERO namespaces — a zero-length required set makes the per-namespace check vacuously true (§ZS / ADR 0092). Do NOT return clean." >&2; exit 1
+  fi
+  # the COUNT is emitted, not just the set: a zero-scope read is then visible in the transcript at the
+  # point it happens, instead of surfacing later as an empty-looking but green coverage line.
+  echo "reviewer dispatch: PR $PR @ $HEAD_SHA requires $NS_COUNT namespace(s) → ${REQUIRED_NS//$'\n'/ }"
   # … fan + post one SHA-bound marker per required namespace (the invariants above) …
   # COVERAGE SELF-CHECK — a required namespace uncovered at HEAD_SHA cannot pass silently. A namespace
   # counts as COVERED by EITHER contract form bound to the current head: the auto-merge lane's
@@ -262,7 +287,7 @@ These hold on every run regardless of what the spawn prompt remembered to say:
     echo "reviewer coverage self-check FAILED (fail-loud): required namespace(s) UNCOVERED at $HEAD_SHA →$missing — dispatch the missing gate before returning; do NOT return with a required namespace empty." >&2
     exit 1
   fi
-  echo "reviewer coverage self-check: every required namespace (${REQUIRED_NS//$'\n'/ }) has a SHA-bound marker @ $HEAD_SHA — coverage complete."
+  echo "reviewer coverage self-check: all $NS_COUNT required namespace(s) (${REQUIRED_NS//$'\n'/ }) have a SHA-bound marker @ $HEAD_SHA — coverage complete."
   ```
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries; every read and write

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -767,8 +767,24 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # the required namespaces for THIS diff — one per artifact class present, plus review-design when
 # the diff is UI-affecting. `.glossary/**` rides has-code, so an ADR + a glossary row requires BOTH
 # review-doc AND review-code; satisfying one is not enough.
-REQUIRED="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
-  | "$PCLI" class-probe classify --namespaces | paste -sd, -)"
+# The probe is the LAST stage of its own capture, and its status is read — `class-probe` REFUSES with
+# exit 4 on a failed stdin read (#4010) and prints nothing, so an unchecked capture turns the refusal
+# into an empty `--require` set. Joining with `| paste -sd, -` INSIDE the capture is what made that
+# unobservable: `pipefail` is OFF here (#4146), so paste's 0 was the pipeline's status (#4231). Join
+# the ALREADY-CAPTURED value instead. The `verdict gate` zero-scope refusal downstream is untouched —
+# this removes the masking in front of it, it does not relocate the backstop.
+REQUIRED_NS="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+  | "$PCLI" class-probe classify --namespaces)"; PROBE_RC=$?
+if [ "$PROBE_RC" -ne 0 ]; then
+  disarm_intent refuse || INTENT_UNCLEARED=1
+  echo "ship-it: refused at guard 1 — class-probe REFUSED (exit $PROBE_RC); the required-namespace set is UNKNOWN, not empty. NOT enqueued." >&2; exit 1
+fi
+REQUIRED="$(printf '%s\n' "$REQUIRED_NS" | grep '[^[:space:]]' | paste -sd, - || true)"
+if [ -z "$REQUIRED" ]; then
+  disarm_intent refuse || INTENT_UNCLEARED=1
+  echo "ship-it: refused at guard 1 (zero scope) — class-probe exited 0 but named ZERO namespaces; a zero-length required set would make the per-namespace conjunction vacuously true (ADR 0092). NOT enqueued." >&2; exit 1
+fi
+echo "ship-it guard 1: PR $PR requires $(printf '%s\n' "$REQUIRED_NS" | grep -c '[^[:space:]]' || true) namespace(s) → $REQUIRED"
 # A control-plane PR's pass path is the canonical SHA-less ADVISORY, bound in the body's
 # `Reviewed-head` line (ADR 0111/0151) — pass --cp so that form counts, and ONLY then. Set this from
 # Step 0's own classification (it printed `BLOCKING (…)` for a §CP path/content hit) AND only after

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe-consumers.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe-consumers.unit.test.ts
@@ -1,0 +1,116 @@
+import {readdirSync, readFileSync} from "node:fs";
+import {dirname, join, relative} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+// Regression coverage for #4231: `class-probe`'s stdin branch REFUSES with exit 4 on a failed read
+// (#4010) and prints NOTHING, so a consumer that captures only stdout converts the refusal into an
+// empty namespace set — and an empty required set makes every per-namespace check vacuously true.
+// The consumers live in markdown (agent/skill bash fences), so the only place this can be pinned
+// mechanically is here: scan the LIVE corpus, not a fixture, the same way class-probe.unit.test.ts
+// pins the §CLASS probes off the on-disk contract.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const CORPUS_ROOT = join(REPO_ROOT, "claude-plugins/kampus-pipeline");
+
+const RUNNABLE_LANGS = new Set(["bash", "sh", "shell", "zsh"]);
+const FENCE = /^\s*(?:```|~~~)\s*(\w*)/;
+/** Blockquoted fences are runnable too — an agent copies a `> `-prefixed snippet the same way. */
+const unquote = (line: string): string => line.replace(/^(\s*>)+\s?/, "");
+const COMMENT_ONLY = /^\s*#/;
+/** The consumer under test: the namespace-set read whose empty stdout is indistinguishable from a refusal. */
+const NAMESPACE_READ = "class-probe classify --namespaces";
+
+const markdownFiles = (dir: string): ReadonlyArray<string> =>
+	readdirSync(dir, {withFileTypes: true}).flatMap((entry) => {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) return markdownFiles(full);
+		return entry.isFile() && entry.name.endsWith(".md") ? [full] : [];
+	});
+
+interface Site {
+	readonly file: string;
+	readonly line: number;
+	/** The logical statement, backslash-continuations joined. */
+	readonly text: string;
+}
+
+/** Every runnable-fence statement that reads the namespace set, with `\`-continuations joined. */
+const namespaceReadSites = (file: string, content: string): ReadonlyArray<Site> => {
+	const sites: Site[] = [];
+	const lines = content.split("\n");
+	let openLang: string | null = null;
+	for (let i = 0; i < lines.length; i++) {
+		const raw = unquote(lines[i] ?? "");
+		const fence = raw.match(FENCE);
+		if (fence !== null) {
+			openLang = openLang === null ? (fence[1] ?? "").toLowerCase() : null;
+			continue;
+		}
+		if (openLang === null || !RUNNABLE_LANGS.has(openLang)) continue;
+		if (COMMENT_ONLY.test(raw)) continue;
+		let text = raw;
+		let j = i;
+		while (text.trimEnd().endsWith("\\") && j + 1 < lines.length) {
+			j++;
+			text = `${text.trimEnd().slice(0, -1)} ${unquote(lines[j] ?? "").trim()}`;
+		}
+		if (text.includes(NAMESPACE_READ)) sites.push({file, line: i + 1, text});
+		i = j;
+	}
+	return sites;
+};
+
+const SITES = markdownFiles(CORPUS_ROOT).flatMap((file) =>
+	namespaceReadSites(relative(REPO_ROOT, file), readFileSync(file, "utf8")),
+);
+
+describe("class-probe namespace-set consumers observe the probe's exit status (#4231)", () => {
+	// §ZS / ADR 0092: a scan that found nothing is a broken scan, not a pass — without this the whole
+	// suite goes green the moment the fence parser or the corpus path regresses.
+	it("scans a non-empty corpus", () => {
+		expect(markdownFiles(CORPUS_ROOT).length).toBeGreaterThan(0);
+		expect(SITES.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it.each(
+		SITES.map((s) => [`${s.file}:${s.line}`, s] as const),
+	)("%s captures the probe into a variable", (_id, site) => {
+		expect(site.text).toMatch(/^\s*[A-Za-z_]\w*="\$\(/);
+	});
+
+	it.each(
+		SITES.map((s) => [`${s.file}:${s.line}`, s] as const),
+	)("%s puts nothing after the probe inside the capture — `pipefail` is off (#4146), so a trailing stage's 0 would mask exit 4", (_id, site) => {
+		const afterProbe = site.text.slice(site.text.indexOf(NAMESPACE_READ) + NAMESPACE_READ.length);
+		const insideCapture = afterProbe.slice(0, afterProbe.indexOf(')"'));
+		expect(insideCapture).not.toContain("|");
+	});
+
+	it.each(
+		SITES.map((s) => [`${s.file}:${s.line}`, s] as const),
+	)("%s reads the capture's exit status rather than discarding it", (_id, site) => {
+		const afterProbe = site.text.slice(site.text.indexOf(NAMESPACE_READ) + NAMESPACE_READ.length);
+		const tail = afterProbe.slice(afterProbe.indexOf(')"') + 2);
+		// Either the status is stashed (`; RC=$?`) for an explicit branch, or the statement bails inline.
+		expect(tail).toMatch(/^\s*(;\s*[A-Za-z_]\w*=\$\?|\|\|)/);
+	});
+
+	it.each(
+		SITES.map((s) => [`${s.file}:${s.line}`, s] as const),
+	)("%s refuses on a non-zero status somewhere below the capture", (_id, site) => {
+		const stashed = site.text.match(/;\s*([A-Za-z_]\w*)=\$\?/);
+		if (stashed === null) return; // the inline-`||` form carries its own refusal
+		const body = readFileSync(join(REPO_ROOT, site.file), "utf8");
+		const rc = stashed[1] as string;
+		expect(body).toMatch(new RegExp(`\\[\\s*"\\$${rc}"\\s*-ne\\s*0\\s*\\]`));
+	});
+
+	// The third outcome: a success exit that names ZERO namespaces is still UNKNOWN, never
+	// "no namespaces required" — it must be refused separately from the exit-status refusal, so the
+	// two stay distinguishable in the transcript.
+	it.each(
+		[...new Set(SITES.map((s) => s.file))].map((f) => [f] as const),
+	)("%s also refuses a zero-length namespace set", (file) => {
+		expect(readFileSync(join(REPO_ROOT, file), "utf8")).toMatch(/zero scope/i);
+	});
+});


### PR DESCRIPTION
Fixes #4231

## What was wrong

`pipeline-cli class-probe`'s stdin branch refuses with **exit 4** on a failed read (#4010) and prints **nothing**. Every consumer that captured only stdout therefore turned that refusal into an **empty required-namespace set** — and an empty set makes each per-namespace check vacuously true. The producer was correctly hardened; the consumers converted the refusal back into a benign-looking pass.

## The three outcomes, now distinguishable everywhere

Each call site refuses on **two** distinct conditions with **two** distinct messages, so a refusal, a zero-scope result, and a real namespace list can never be confused:

1. **non-zero exit ⇒ UNKNOWN** — `class-probe REFUSED (exit N) — the required-namespace set is UNKNOWN, not empty.`
2. **exit 0 with a zero-length set ⇒ zero scope** — refused separately (§ZS / ADR 0092), belt-and-braces against a future producer that returns 0 quietly. Unreachable today by the probe's no-class fail-closed rule, which is exactly why it is stated rather than assumed.
3. **exit 0 with namespaces ⇒ proceed**, and the **count** is now emitted alongside the set, so a zero-scope read is visible in the transcript at the point it happens.

## Call sites, checked independently

| Site | Verdict | Change |
| --- | --- | --- |
| `claude-plugins/kampus-pipeline/agents/reviewer.md` (fan invariant) | defective — bare pipeline, status discarded | captured + status-checked + zero-scope refusal + count emitted |
| `claude-plugins/kampus-pipeline/agents/reviewer.md` (coverage self-check) | defective — the reported bug | same; the dispatch line and the "coverage complete" line both carry the count |
| `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` (Step 2 guard 1) | defective — **pipe-masked** | see below |
| `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` (~line 380) | **not** defective | a comment line illustrating the probe, not a runnable invocation — no fix owed |
| `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md` (`doc-vocab-surface-only`) | **already correct** | branches on the exit code itself; exit 4 lands on `non-zero ⇒ not surface-only ⇒ hard-stop`. Left unchanged, as triage ruled |

### The pipe case specifically

`ship-it`'s capture ended in `| paste -sd, -`, so `class-probe`'s status was not the pipeline's status — and `pipefail` is **off** in this environment (#4146), so `paste`'s 0 was what a naive `if ! cmd | paste` would have observed. The fix does not add `pipefail` (which would change unrelated behavior in a long skill); it moves the join **off the probe's pipeline onto the already-captured value**:

```
REQUIRED_NS="$(… | "$PCLI" class-probe classify --namespaces)"; PROBE_RC=$?
…refuse on $PROBE_RC…
REQUIRED="$(printf '%s\n' "$REQUIRED_NS" | grep '[^[:space:]]' | paste -sd, - || true)"
```

The probe is the last stage of its own statement, so its status is the substitution's status. The downstream `verdict gate` zero-scope refusal is **untouched** — this removes the masking in front of the backstop, it does not relocate it.

## Regression coverage

`packages/pipeline-cli/src/tools/class-probe/class-probe-consumers.unit.test.ts` scans the **live** crew corpus (every `.md` under `claude-plugins/kampus-pipeline/`, runnable bash/sh fences only, blockquoted fences included, `\`-continuations joined) for each `class-probe classify --namespaces` read and asserts:

- it is captured into a variable (not a bare pipeline);
- **nothing follows the probe inside the capture** — the anti-`| paste` rule, cited to #4146;
- the capture's status is read (`; RC=$?` or an inline `||`), with a matching `-ne 0` refusal in the file;
- the file also refuses a zero-length set.

Zero scope is itself a failure (§ZS / ADR 0092): the suite fails if the corpus walk or the fence parser finds nothing.

**Proven against today's code.** With the two markdown fixes stashed and the test left in place, **7 of 15 tests fail** — the `reviewer.md` fan site fails the capture, status and zero-scope assertions; the `reviewer.md` coverage site fails the status assertion; the `ship-it` site fails the no-trailing-pipe, status and zero-scope assertions. With the fixes restored, 15/15 pass (68/68 across the whole `class-probe` suite), `typecheck` is clean, and `cli-invocation-guard check` is clean on both edited files.

## Scope notes

- No new guard, probe, rule or leak-pattern is invented — this applies the existing §ZS / ADR 0092 idiom at the defective call sites. The general "check a producer's status at every call site" remedy is #4215's to settle and #4195's to mechanize; a `.patterns/` doc here would preempt that open decision.
- `claude-plugins/kampus-pipeline/**` is §CP, so this banks for a control-plane approval at head. Not enqueued.
