### PR TITLE
fix(pipeline-cli): guard-content-probe's proven-ordinary verdict no longer collides with a failure to invoke (#4219)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -623,6 +623,12 @@ else
   # (copy it verbatim from there). It leaves HEAD_SHA EMPTY on failure by DISCARDING gh's payload,
   # which is what makes the `[ -n ]` test below a live guard rather than a dead one.
   cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+  # Assert on the probe's STATE WORD, never on its exit status — the exit code discriminates the two
+  # verdicts only once the verb has RUN, so the old `>/dev/null && …` shape accumulated NOTHING when it
+  # never ran (bad flag / nested-cwd module-not-found / missing shim) and read an unprobed ADR as
+  # ordinary. The `*)` arm keeps could-not-determine a HOLD, exactly as an unreadable body is (#4219).
+  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   GUARD_TOUCHING=""
   [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"   # fail closed: no ref ⇒ no probe ⇒ UNKNOWN
   ADR_N=0
@@ -634,8 +640,13 @@ else
     adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
     if [ -z "$adr_body" ]; then
       GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # fail closed: never auto-ship an ADR that could not be read and proven guard-free
-    elif printf '%s' "$adr_body" | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null; then
-      GUARD_TOUCHING="$GUARD_TOUCHING $adr"
+    else
+      GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+      case "$GC_STATE" in
+        not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+        guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
+        *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
+      esac
     fi
   done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
   echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092): a §CP classification always states its scope

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -312,8 +312,16 @@ if [ "$CP_STATE" = "content-undetermined" ]; then
         # pipe hands the probe an ERROR BODY as the ADR body (§CPREAD #2).
         adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
         if [ -z "$adr_body" ]; then echo "BLOCKING ($adr — body unreadable at head ⇒ §CP, fail-closed)"
-        elif printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null; then
-          echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
+        else
+          # Same rule as the cp-classify call above: assert on the probe's STATE WORD, never on its
+          # exit status — an invocation that never ran would otherwise read as proven ordinary (#4219).
+          GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+          case "$GC_STATE" in
+            not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+            guard-touching) echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)" ;;
+            *) echo "BLOCKING ($adr — probe UNDETERMINED (state '$GC_STATE') ⇒ §CP, fail-closed)" ;;
+          esac
+        fi
       done
 elif [ "$CP_STATE" != "not-control-plane" ]; then
   # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -217,9 +217,15 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
 
   ```bash
   # Probe each touched .decisions/** ADR's CONTENT at head with the shared verb (single source of the
-  # ADR-0164 guard vocabulary; #3645). Exit 0 ⇒ guard-touching ⇒ §CP-advisory.
+  # ADR-0164 guard vocabulary; #3645). Assert on the probe's STATE WORD, never on its exit status —
+  # the exit code discriminates the two verdicts only once the verb has RUN, so the old
+  # `>/dev/null && …` shape accumulated NOTHING when it never ran (bad flag / nested-cwd
+  # module-not-found / missing shim) and read an unprobed ADR as ordinary. The `*)` arm keeps
+  # could-not-determine a HOLD, exactly as an unreadable body is (#4219).
   # Same §CPREAD input as the path clause above — a blinded file-list read blinds the CONTENT clause
   # too, and for a `.decisions/**`-only PR the content clause is the ONLY §CP signal there is (#4216).
+  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   GUARD_TOUCHING=""
   if [ -n "$CP_READ_FAILED" ]; then
     GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
@@ -238,8 +244,13 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
       adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
       if [ -z "$adr_body" ]; then
         GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
-      elif printf '%s' "$adr_body" | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null; then
-        GUARD_TOUCHING="$GUARD_TOUCHING $adr"
+      else
+        GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+        case "$GC_STATE" in
+          not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+          guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
+          *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
+        esac
       fi
     done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
     echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092)

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -238,8 +238,16 @@ if [ "$CP_STATE" = "content-undetermined" ]; then
         # pipe hands the probe an ERROR BODY as the ADR body (§CPREAD #2).
         adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
         if [ -z "$adr_body" ]; then echo "BLOCKING ($adr — body unreadable at head ⇒ §CP, fail-closed)"
-        elif printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null; then
-          echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
+        else
+          # Same rule as the cp-classify call above: assert on the probe's STATE WORD, never on its
+          # exit status — an invocation that never ran would otherwise read as proven ordinary (#4219).
+          GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+          case "$GC_STATE" in
+            not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+            guard-touching) echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)" ;;
+            *) echo "BLOCKING ($adr — probe UNDETERMINED (state '$GC_STATE') ⇒ §CP, fail-closed)" ;;
+          esac
+        fi
       done
 elif [ "$CP_STATE" != "not-control-plane" ]; then
   # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -162,17 +162,27 @@ if [ "$CP_STATE" != "not-control-plane" ]; then
     if [ -z "$HEAD_SHA" ]; then
       echo "review-trivial: not-trivial — head SHA unreadable, ADR content unprobeable (§CP UNKNOWN); route to full path"; exit 0
     fi
+    # Assert on the probe's STATE WORD, never on its exit status: the exit code discriminates the
+    # two verdicts only once the verb has RUN, so `>/dev/null && echo "$adr"` collected NOTHING when
+    # it never ran and read an unprobed ADR as ordinary. Only `not-guard-touching` clears (#4219).
     GUARD_TOUCHING="$(printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
         # Capture and CHECK, never a straight pipe: gh writes its error document to STDOUT, so a pipe
         # hands the probe an ERROR BODY as the ADR body (§CPREAD #2). Unreadable ⇒ §CP, fail-closed.
         adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
         if [ -z "$adr_body" ]; then echo "$adr(body-unreadable⇒§CP)"
-        elif printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" >/dev/null; then echo "$adr"; fi
+        else
+          GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+          case "$GC_STATE" in
+            not-guard-touching) : ;;
+            guard-touching) echo "$adr" ;;
+            *) echo "$adr(undetermined:'$GC_STATE')" ;;
+          esac
+        fi
       done)"
     if [ -z "$GUARD_TOUCHING" ]; then
       : # every touched ADR probed not-guard-touching ⇒ the content axis is resolved, carry on
     else
-      echo "review-trivial: not-trivial — guard-touching ADR (§CP by content, ADR 0164): $GUARD_TOUCHING; route to full path"; exit 0
+      echo "review-trivial: not-trivial — ADR not proven ordinary by content (guard-touching, or the probe could not determine; ADR 0164): $GUARD_TOUCHING; route to full path"; exit 0
     fi
   else
     echo "review-trivial: not-trivial — §CP state '$CP_STATE'; route to full path (ADR 0053/0065; #4161)"; exit 0

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -382,6 +382,12 @@ echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plan
 # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files` (copy
 # it verbatim from there). It DISCARDS gh's payload on failure, which is what makes the emptiness
 # test below a live guard: with a bare `|| true` the error document lands in HEAD_SHA, non-empty.
+# Assert on the probe's STATE WORD, never on its exit status — the exit code discriminates the two
+# verdicts only once the verb has RUN, so the old `>/dev/null && echo BLOCKING` shape emitted NOTHING
+# when it never ran (bad flag / nested-cwd module-not-found / missing shim) and recorded an unprobed
+# ADR as ordinary. The `*)` arm holds could-not-determine, exactly as an unreadable body is (#4219).
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
 if [ -z "$HEAD_SHA" ]; then
   echo "BLOCKING (head SHA unreadable ⇒ no ref to probe ADR content at ⇒ §CP UNKNOWN, held)"   # fail closed: an unprobeable content clause is not an absent one
@@ -392,8 +398,13 @@ else
     adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
     if [ -z "$adr_body" ]; then
       echo "BLOCKING ($adr — ADR body unreadable ⇒ §CP UNKNOWN, held)"
-    elif printf '%s' "$adr_body" | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null; then
-      echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+    else
+      GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+      case "$GC_STATE" in
+        not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+        guard-touching) echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)" ;;
+        *) echo "BLOCKING ($adr — probe UNDETERMINED (state '$GC_STATE') ⇒ §CP, fail-closed)" ;;
+      esac
     fi
   done
 fi

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -83,6 +83,21 @@ the outcome as a typed `StdinReadFailed` in the error channel. The pure retry co
 IO injected so the `EAGAIN` path is testable, lives in
 [`src/read-stdin-core.ts`](./src/read-stdin-core.ts).
 
+## How a tool seats a verdict on an exit code
+
+A classifier verb that can clear a hold — `cp-classify`, `guard-content-probe` — seats its
+**proven-ordinary** verdict on `PROVEN_ORDINARY_EXIT_CODE` from
+[`src/exit-codes.ts`](./src/exit-codes.ts), never on `1`. `1` is what effect-cli returns for a
+usage error and what a module-load failure surfaces as; `127` is the shell's missing-binary code.
+A verdict sharing either is unreadable as proof — `[ $? -ne 0 ]` then reads "the tool never ran"
+as "the tool ran and proved it ordinary". This is the verdict-side twin of the stdin rule above
+(#4208, #4219).
+
+The exit code discriminates verdicts **only once the verb has run**, so a caller asserts on the
+**stdout state word** and treats every other value, including the empty string a failure to
+invoke leaves, as a hold. Three outcomes stay distinguishable: proven-ordinary, proven-hold, and
+could-not-determine.
+
 ## How a tool is loaded
 
 Running `pipeline-cli <tool>` loads that tool's module and no other. The registry

--- a/packages/pipeline-cli/src/exit-codes.ts
+++ b/packages/pipeline-cli/src/exit-codes.ts
@@ -1,0 +1,12 @@
+/**
+ * The exit-code rule that outranks any per-tool choice: **a verdict a tool PROVED must never share
+ * an exit code with a failure to invoke** (#4208, #4219).
+ *
+ * `1` is what effect-cli returns for a usage error (a bad flag, a typo'd subcommand) and what the
+ * runner returns when a module fails to load; `127` is the shell's missing-binary code. A
+ * proven-ordinary verdict seated on either is unreadable as proof — `[ $? -ne 0 ]` then reads "the
+ * tool never ran" as "the tool ran and proved it ordinary", the fail-open direction every §CP guard
+ * exists to close. `STDIN_READ_FAILED_EXIT_CODE = 4` (`read-stdin.ts`) is this same rule on the
+ * input side; this is its verdict side, shared so the §CP classifier verbs cannot drift apart.
+ */
+export const PROVEN_ORDINARY_EXIT_CODE = 3;

--- a/packages/pipeline-cli/src/tools/cp-classify/README.md
+++ b/packages/pipeline-cli/src/tools/cp-classify/README.md
@@ -100,10 +100,17 @@ Run the existing ADR-0164 probe over each listed ADR at the PR head; nothing abo
 changes here, so this verb widens no over-match (#2617):
 
 ```bash
-HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' \
-  | pipeline-cli guard-content-probe classify --path "$adr" >/dev/null && echo "BLOCKING ($adr)"
+cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # §CPREAD: EMPTY on a failed read, payload discarded
+# Capture and CHECK the body, never a straight pipe — `gh` writes its error document to stdout (#4216).
+adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+GC_STATE="$([ -n "$adr_body" ] && printf '%s' "$adr_body" | pipeline-cli guard-content-probe classify --path "$adr" 2>/dev/null)"
+[ "$GC_STATE" = "not-guard-touching" ] || echo "BLOCKING ($adr — state '$GC_STATE')"
 ```
+
+That probe's exit contract is this one's: proven-ordinary owns
+[`PROVEN_ORDINARY_EXIT_CODE`](../../exit-codes.ts), so the state-word assertion above is what
+keeps a failure to invoke out of the ordinary branch — see
+[`../guard-content-probe/README.md`](../guard-content-probe/README.md#how-to-call-this-safely).
 
 ## Shape
 

--- a/packages/pipeline-cli/src/tools/cp-classify/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/command.ts
@@ -26,19 +26,14 @@
 import {execFileSync} from "node:child_process";
 import {Console, Effect, FileSystem, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {PROVEN_ORDINARY_EXIT_CODE} from "../../exit-codes.ts";
 import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
 import {type CpClassification, classifyControlPlane, isHold} from "./cp-classify.ts";
 
-/**
- * The proven-ordinary verdict's own exit code — deliberately NOT 1, which effect-cli already
- * returns for a usage error (a bad flag), and not 127, which the shell returns for a missing
- * binary. Same spirit as `STDIN_READ_FAILED_EXIT_CODE` (#3924): a code that means "the tool never
- * ran" must be separable from a code that means "the tool ran and proved it ordinary" — otherwise
- * `[ $? -ne 0 ]` reads a failure to invoke as a verdict, the fail-open this verb exists to remove.
- */
-export const NOT_CONTROL_PLANE_EXIT_CODE = 3;
+/** The proven-ordinary verdict's own exit code — the shared rule, not a per-tool choice. */
+export const NOT_CONTROL_PLANE_EXIT_CODE = PROVEN_ORDINARY_EXIT_CODE;
 
 const filesFileFlag = Flag.string("files-file").pipe(
 	Flag.optional,

--- a/packages/pipeline-cli/src/tools/guard-content-probe/README.md
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/README.md
@@ -52,19 +52,47 @@ Every ambiguity resolves to `guard-touching` (§CP): an unreadable §CP boundary
 merely-guard-*citing* ADR to a cheap human approval rather than risk missing a
 guard-*relaxer* that would auto-ship a weakened gate.
 
-## Usage
+## How to call this safely
+
+The decision word (`guard-touching` | `not-guard-touching`) goes to **stdout**; a human
+reason goes to **stderr**. Exit is **0 on `guard-touching`** and
+**3 on `not-guard-touching`** (`PROVEN_ORDINARY_EXIT_CODE`, the shared rule in
+[`../../exit-codes.ts`](../../exit-codes.ts) — the same code `cp-classify` seats its
+proven-ordinary verdict on).
+
+**Assert on the stdout state word, never on the exit status.** The exit code discriminates
+the two verdicts only *once the verb has run*; it says nothing about whether it ran. Three
+outcomes must stay distinguishable — proven-ordinary, proven-guard, and could-not-determine —
+and only the first may skip the §CP hold:
 
 ```bash
 # ship-it Step 0 / review gate: read each touched .decisions/** ADR's body at head, probe it.
-HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# `cp_head_sha` is §CPREAD of the skills' gh-issue-intake-formats.md: it DISCARDS gh's payload on a
+# failed read, so an empty HEAD_SHA is a live guard rather than 120 chars of error JSON (#4216).
+cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+[ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable ⇒ no ref to probe at ⇒ §CP, fail-closed)"
+[ -z "$HEAD_SHA" ] || echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
   [ -z "$adr" ] && continue
-  gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
-    | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" \
-    && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+  # Capture and CHECK the body before probing, never a straight pipe — `gh` writes its error document
+  # to STDOUT, so a pipe hands the probe an ERROR BODY to classify as the ADR (§CPREAD #2, #4216).
+  adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+  if [ -z "$adr_body" ]; then
+    echo "BLOCKING ($adr — ADR body unreadable ⇒ §CP UNKNOWN, held)"
+  else
+    GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+    case "$GC_STATE" in
+      not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the hold
+      guard-touching) echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)" ;;
+      *) echo "BLOCKING ($adr — probe UNDETERMINED (state '$GC_STATE') ⇒ §CP, fail-closed)" ;;
+    esac
+  fi
 done
 ```
 
-The decision word (`guard-touching` | `not-guard-touching`) goes to **stdout**; a human
-reason goes to **stderr**. Exit is **0 on `guard-touching`, 1 on `not-guard-touching`**, so
-the gate bash fails closed with `… && echo BLOCKING`.
+**`… && echo BLOCKING` is UNSAFE and must not be reintroduced.** It emits nothing when the
+verb never ran — a bad flag (exit 1), a typo'd subcommand (1), a module-not-found from a
+nested cwd (1), a missing shim (127) — so an unprobed ADR is recorded as ordinary. That
+fail-open shape was published here and copied by every gate until
+[#4219](https://github.com/kamp-us/phoenix/issues/4219); `command.test.ts` pins both the
+verdict codes and the invocation failures so it cannot come back.

--- a/packages/pipeline-cli/src/tools/guard-content-probe/command.test.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/command.test.ts
@@ -1,14 +1,20 @@
 import {spawnSync} from "node:child_process";
+import {mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts";
+import {NOT_GUARD_TOUCHING_EXIT_CODE} from "./command.ts";
 
 // The stdin/exit contract of `pipeline-cli guard-content-probe classify` over the shared bin. Like
 // class-probe (#3786), the empty-stdin exposure is an IO-delivery fact, exercised over the ACTUAL
-// bin with real stdin wiring. The load-bearing invariant: every empty shape stays fail-closed to
-// `guard-touching` (exit 0) — only the reason EVIDENCE is sharpened.
+// bin with real stdin wiring. Two load-bearing invariants: every empty shape stays fail-closed to
+// `guard-touching` (exit 0), and the proven-ordinary verdict owns an exit code no failure-to-invoke
+// produces, so "the probe never ran" can never read as "this ADR is ordinary" (#4219).
 const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL("../../../../..", import.meta.url));
+const DIR = mkdtempSync(join(tmpdir(), "guard-content-probe-cmd-"));
 
 interface RunResult {
 	readonly code: number;
@@ -55,10 +61,107 @@ describe("guard-content-probe classify — empty stdin stays §CP, evidence is h
 		expect(stderr).toContain("[guard-vocabulary-match]");
 	});
 
-	it("an ordinary product ADR still classifies not-guard-touching, exit 1 (non-regression)", () => {
+	it("an ordinary product ADR classifies not-guard-touching on the verdict code (non-regression)", () => {
 		const body = "Term pages sort entries by score, newest first.";
 		const {code, stdout} = runSh(`printf '%s\\n' "${body}" | ${INNER}`);
 		expect(stdout.trim()).toBe("not-guard-touching");
-		expect(code).toBe(1);
+		expect(code).toBe(NOT_GUARD_TOUCHING_EXIT_CODE);
+	});
+});
+
+// The property under dispute in #4219: is a FAILURE TO INVOKE distinguishable from the
+// proven-ordinary verdict? Only if the verdict owns an exit code no failure-to-run produces — and
+// only if the caller asserts on the stdout state word. Both are pinned here, mirroring cp-classify's
+// suite (#4161), so the verdict code cannot silently drift back onto the runner's failure code.
+const ORDINARY_BODY = join(DIR, "ordinary.md");
+writeFileSync(ORDINARY_BODY, "Term pages sort entries by score, newest first.\n");
+const ORDINARY = `node "${BIN}" guard-content-probe classify --body-file "${ORDINARY_BODY}" --path .decisions/9999-x.md`;
+const BAD_FLAG = `${ORDINARY} --bogus-flag x`;
+const TYPO_SUBCOMMAND = `node "${BIN}" guard-content-probe clasify --body-file "${ORDINARY_BODY}"`;
+const MISSING_BIN = "guard-content-probe-no-such-binary classify";
+const MODULE_NOT_FOUND = `node packages/pipeline-cli/src/bin.ts guard-content-probe classify --body-file "${ORDINARY_BODY}"`;
+
+describe("guard-content-probe classify — the exit contract (#4219)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("the proven-ordinary exit code collides with neither a usage error nor a missing binary", () => {
+		expect(NOT_GUARD_TOUCHING_EXIT_CODE).not.toBe(0);
+		expect(NOT_GUARD_TOUCHING_EXIT_CODE).not.toBe(1);
+		expect(NOT_GUARD_TOUCHING_EXIT_CODE).not.toBe(127);
+	});
+
+	it("a bad flag is an invocation failure: no state word on stdout, and not the verdict code", () => {
+		const r = runSh(BAD_FLAG);
+		expect(r.stdout).not.toContain("not-guard-touching");
+		expect(r.code).not.toBe(NOT_GUARD_TOUCHING_EXIT_CODE);
+		expect(r.code).not.toBe(0);
+	});
+
+	it("a typo'd subcommand is an invocation failure: not the verdict code", () => {
+		const r = runSh(TYPO_SUBCOMMAND);
+		expect(r.stdout).not.toContain("not-guard-touching");
+		expect(r.code).not.toBe(NOT_GUARD_TOUCHING_EXIT_CODE);
+		expect(r.code).not.toBe(0);
+	});
+
+	it("a missing binary is an invocation failure: exit 127, empty stdout", () => {
+		const r = runSh(MISSING_BIN);
+		expect(r.code).toBe(127);
+		expect(r.stdout.trim()).toBe("");
+		expect(r.code).not.toBe(NOT_GUARD_TOUCHING_EXIT_CODE);
+	});
+
+	// The nested-cwd trigger the call sites actually hit: `node packages/pipeline-cli/src/bin.ts` is
+	// cwd-relative, and sessions in this repo launch in a nested app directory by convention.
+	it("a module-not-found from a nested cwd is an invocation failure: not the verdict code", () => {
+		const r = spawnSync("sh", ["-c", MODULE_NOT_FOUND], {
+			cwd: join(REPO_ROOT, "apps", "web"),
+			encoding: "utf8",
+		});
+		expect(r.stdout ?? "").not.toContain("not-guard-touching");
+		expect(r.status ?? 0).not.toBe(NOT_GUARD_TOUCHING_EXIT_CODE);
+		expect(r.status ?? 0).not.toBe(0);
+	});
+});
+
+describe("guard-content-probe classify — the caller idiom (#4219)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	// The sanctioned shape all six gate call sites now use: a POSITIVE match on the stdout state
+	// word, with every other value — including the empty string a failure to invoke leaves — routed
+	// to BLOCKING. Proven-ordinary, proven-guard, and could-not-determine stay three distinct
+	// outcomes; only the first may skip the §CP hold.
+	const stateWordIdiom = (inner: string): RunResult =>
+		runSh(
+			`GC_STATE="$(${inner} 2>/dev/null)"; case "$GC_STATE" in not-guard-touching) echo ordinary ;; guard-touching) echo BLOCKING-guard ;; *) echo BLOCKING-undetermined ;; esac`,
+		);
+
+	const GUARDY = join(DIR, "guardy.md");
+	writeFileSync(GUARDY, "This decision relaxes the fail-closed enforcement guard.\n");
+	const GUARD = `node "${BIN}" guard-content-probe classify --body-file "${GUARDY}" --path .decisions/9999-x.md`;
+
+	it("proven ordinary → ordinary", () => {
+		expect(stateWordIdiom(ORDINARY).stdout.trim()).toBe("ordinary");
+	});
+
+	it("proven guard-touching → BLOCKING-guard", () => {
+		expect(stateWordIdiom(GUARD).stdout.trim()).toBe("BLOCKING-guard");
+	});
+
+	for (const [name, inner] of [
+		["a bad flag", BAD_FLAG],
+		["a typo'd subcommand", TYPO_SUBCOMMAND],
+		["a missing binary", MISSING_BIN],
+	] as const) {
+		it(`${name} → BLOCKING-undetermined (never ordinary)`, () => {
+			expect(stateWordIdiom(inner).stdout.trim()).toBe("BLOCKING-undetermined");
+		});
+	}
+
+	// Why the old published shape was fail-OPEN: `&& echo BLOCKING` emits nothing when the verb never
+	// ran, so the ADR is recorded as ordinary. Pinned so nobody "simplifies" a call site back onto it.
+	it("the old `>/dev/null && echo BLOCKING` shape fails OPEN on a failure to invoke", () => {
+		expect(runSh(`${MISSING_BIN} 2>/dev/null && echo BLOCKING`).stdout.trim()).toBe("");
+		expect(runSh(`${BAD_FLAG} >/dev/null 2>&1 && echo BLOCKING`).stdout.trim()).toBe("");
 	});
 });

--- a/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
@@ -12,9 +12,15 @@
  * from stdin (or `--body-file`), reads the canonical `GUARD_ADR_RE` from the local
  * `gh-issue-intake-formats.md` §CP (the single source — never a second inline copy), and prints
  * `guard-touching` / `not-guard-touching` to **stdout** — the word the caller branches on. A
- * human reason goes to **stderr**. Exit code mirrors the decision: **0 on `guard-touching`, 1 on
- * `not-guard-touching`**, so the gate bash can `… guard-content-probe classify && echo BLOCKING`
- * and fail closed.
+ * human reason goes to **stderr**.
+ *
+ * **Exit code:** 0 on `guard-touching` (the hold), and {@link NOT_GUARD_TOUCHING_EXIT_CODE} (3) — a
+ * code no failure-to-run produces — on the one proven-ordinary verdict. The exit code discriminates
+ * the two verdicts ONLY ONCE THE VERB HAS RUN; it says nothing about whether it ran, so a caller
+ * must assert on the stdout state word (`[ "$GC_STATE" = "not-guard-touching" ]`), never on mere
+ * non-zero. `… && echo BLOCKING` is UNSAFE — it emits nothing on a usage error (1), a
+ * module-not-found from a nested cwd (1), or a missing binary (127), so a probe that never ran
+ * reads as an ordinary ADR (#4219). See the README's "How to call this safely".
  *
  * IO here (the thin bin); the whole ADR-0164 predicate lives in `guard-content-probe.ts` (the
  * pure, unit-tested core), the same split `class-probe` / `cp-cardinality` use. The caller owns
@@ -27,6 +33,7 @@ import {existsSync, readFileSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {PROVEN_ORDINARY_EXIT_CODE} from "../../exit-codes.ts";
 import {findRootDir} from "../../find-root-dir.ts";
 import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
@@ -35,6 +42,9 @@ import {
 	parseGuardAdrRe,
 	probeGuardContent,
 } from "./guard-content-probe.ts";
+
+/** The proven-ordinary verdict's own exit code — the shared rule, not a per-tool choice. */
+export const NOT_GUARD_TOUCHING_EXIT_CODE = PROVEN_ORDINARY_EXIT_CODE;
 
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
@@ -111,8 +121,8 @@ const classifyCmd = Command.make(
 			),
 		);
 		yield* Console.log(result.guardTouching ? "guard-touching" : "not-guard-touching");
-		// Exit code mirrors the decision so the gate bash fails closed: 0 ⇒ §CP, 1 ⇒ ordinary.
-		if (!result.guardTouching) return yield* Effect.sync(() => process.exit(1));
+		if (!result.guardTouching)
+			return yield* Effect.sync(() => process.exit(NOT_GUARD_TOUCHING_EXIT_CODE));
 	}),
 ).pipe(
 	Command.withDescription(


### PR DESCRIPTION
Fixes #4219

`guard-content-probe classify` seated its proven-ordinary verdict `not-guard-touching` on
exit **1** — the same code effect-cli returns for a usage error, a typo'd subcommand, and a
module-not-found from a cwd-relative `node packages/pipeline-cli/src/bin.ts`. Every shipped
call site discarded the stdout state word (`>/dev/null`) and branched on `&&`, so a probe
that **never ran** took the same silent no-BLOCKING path as a probe that ran and proved the
ADR ordinary. For a `.decisions/**`-only PR that probe is the whole §CP detection — no
CODEOWNERS rule covers `.decisions/**`, by design (ADR 0164) — so nothing backstopped it.

## What changed

**The verdict's exit code.** New shared constant `PROVEN_ORDINARY_EXIT_CODE = 3` in
`packages/pipeline-cli/src/exit-codes.ts`, the verdict-side twin of
`STDIN_READ_FAILED_EXIT_CODE = 4`. `guard-content-probe` exits it on `not-guard-touching`;
`cp-classify`'s `NOT_CONTROL_PLANE_EXIT_CODE` now *is* that constant rather than a second
literal `3` — one exit-code rule across both §CP classifier verbs (AC6), not two that can
drift. `guard-touching` still exits 0; an unread pipe still exits 4.

**Every call site asserts on the stdout state word.** Three outcomes stay distinguishable,
and only the first may skip the §CP hold:

| state word | outcome | branch |
|---|---|---|
| `not-guard-touching` | proven ordinary | clears |
| `guard-touching` | proven guard | BLOCKING |
| anything else (incl. the empty string a failed invocation leaves) | could-not-determine | BLOCKING, labelled `undetermined` |

The `*)` catch-all is where the fix lives: it is what stops the collapse from being
*relocated* onto the state word. Rewritten in `claude-plugins/kampus-pipeline/skills/`:
`ship-it/SKILL.md` (Step 0), `review-code/SKILL.md`, `review-doc/SKILL.md` (the three AC3
names), plus `review-skill/SKILL.md`, `review-design/SKILL.md`, `review-trivial/SKILL.md`
— see Deviations.

**The false safety claims are gone.** `command.ts`'s docblock and its inline comment at the
exit no longer advertise `… && echo BLOCKING` as fail-closed; both READMEs
(`packages/pipeline-cli/src/tools/guard-content-probe/README.md`, and the resolution snippet
in `packages/pipeline-cli/src/tools/cp-classify/README.md`) publish the state-word idiom and
name the old shape as unsafe. The module's *real* fail-closed promises (unreadable §CP
boundary, empty body) are untouched.

**Tests.** `packages/pipeline-cli/src/tools/guard-content-probe/command.test.ts` pins both
verdict exit codes and four invocation failures — bad flag, typo'd subcommand, missing
binary (127), and module-not-found run from a nested app dir — plus the caller idiom
(ordinary → clears; guard, bad flag, typo, missing binary → BLOCKING) and the old
`&& echo BLOCKING` shape's observed fail-open.

## Verification

- `pnpm vitest run` in `packages/pipeline-cli`: 2746 passed / 175 files (re-run on the
  rebased tree; 2731/174 before the rebase onto #4229 + #4254).
- **The regression test genuinely fails against today's code.** With only the exit line
  reverted to `process.exit(1)`, the test `an ordinary product ADR classifies
  not-guard-touching on the verdict code` fails with `expected 1 to be 3`. Restored, all 16
  in that file pass.
- `pnpm typecheck`: 29/29 successful. `pnpm lint:worktree`: clean.
- `pipeline-cli cli-invocation-guard check` over all six edited skills: clean.

## Deviations

- **Three more call sites than AC3 names.** AC3 names `ship-it`, `review-code`, `review-doc`.
  `review-skill`, `review-design`, and `review-trivial` call the same verb through the same
  `>/dev/null && …` idiom, reached via `cp-classify`'s `content-undetermined` obligation.
  Fixing three and leaving three would have left the identical live fail-open in half the
  gates, so all six are rewritten. Same one-line idiom, no behavior change beyond the
  fail-closed direction.
- **The three AC3 sites also move to the §CLI shim.** They invoked the cwd-relative
  `node packages/pipeline-cli/src/bin.ts` — one of the invocation failures the issue
  enumerates. They now resolve `$PCLI` by path like the other three already did (ADR 0207,
  #3314). Without this the state-word fix would make every ADR PR BLOCK from a nested cwd:
  correct, but needlessly noisy when the convention to fix it is already decided.
- **`cp-classify/command.ts` is touched** (its constant re-points at the shared one, its
  docblock collapses to a pointer). AC6 asks for one rule across both verbs; a second
  literal `3` would have been two rules that happen to agree today.
- **Not in scope, per the issue's own triage note:** the inline `grep -Eiq` reimplementation
  of the predicate in `gh-issue-intake-formats.md` §CP is a separate concern and is safe on
  this axis.
- **(repair round 1) Two README snippets picked up #4229's capture-and-check shape.** The
  rebase below composed this PR's state-word `case` into #4229's hardened loop at all six
  skill call sites. `packages/pipeline-cli/src/tools/guard-content-probe/README.md` and
  `packages/pipeline-cli/src/tools/cp-classify/README.md` publish that same idiom as the
  canonical caller example, so leaving them on the straight `gh api … |` pipe would have
  re-published the shape #4229 removed — the "byte-identical defective copies spread from
  the definition block" hazard it names. Both snippets now show `cp_head_sha` + the
  capture-and-check body read + the state-word `case`, matching what the gates actually run.
  This is wider than the literal conflict hunks.

