### PR TITLE
feat(control-plane): narrow §CP on packages/pipeline-cli to its enforcement core (#4194)

### DIFF
--- a/.decisions/0100-control-plane-covers-enforcement-guard-packages.md
+++ b/.decisions/0100-control-plane-covers-enforcement-guard-packages.md
@@ -1,7 +1,7 @@
 ---
 id: 0100
 title: The control-plane / §CP boundary covers the enforcement-guard packages (`packages/*-guard/**` + `packages/ci-required/**`) — a guard is a self-weakening surface wherever it lives, so it is BLOCKING (human merge), not auto-merged on a `review-code` PASS
-status: accepted
+status: amended-in-part by [0218](0218-pipeline-cli-cp-enforcement-core.md)
 date: 2026-06-20
 tags: [pipeline, ship-it, control-plane, security, guards]
 ---

--- a/.decisions/0218-pipeline-cli-cp-enforcement-core.md
+++ b/.decisions/0218-pipeline-cli-cp-enforcement-core.md
@@ -161,13 +161,26 @@ addressed by name rather than by "the guards are green."
 **(a) Transitive imports of the retained core.** Computed mechanically, not asserted — see
 [`core-import-closure.unit.test.ts`](../packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts).
 
-> **The walk needs one non-obvious rule to mean anything: `registry.ts` is a SINK.** It imports all
-> 68 tools' `command.ts` to build `registeredTools[]`, so seeding through it reaches 246 modules and
-> the check degenerates to "everything is core" — vacuously true, proving nothing. The registration
-> fan-out is a *listing* edge, not a behavioral one: a gate does not run through its siblings'
-> commands. Any future closure check must cut it the same way.
+> **The walk needs two non-obvious rules to mean anything.**
+>
+> **It must see DYNAMIC `import()`.** `registry.ts` wires all 72 tool `command.ts` modules lazily
+> (`tool("verdict", () => import("./tools/verdict/command.ts"))`, #4008), and a static-only
+> `(?:from|import)\s+"…"` matcher cannot match `import(` at all — it saw two edges there and the
+> walk was blind to every dynamic import in the package. A core module that later adds
+> `import("./tools/<non-core>/x.ts")` would then be a **silent escape** with the check still green.
+> A closure walker blind to the mechanism the codebase uses to wire tools is not evidence, so the
+> matcher covers static `from`/`import`, dynamic `import(`/`require(`, and both quote styles, with
+> extension and `index.ts` resolution and a **fail-loud** throw on an unresolvable specifier.
+>
+> **`registry.ts`'s registration fan-out is cut as an EDGE, not as a node.** Following it reaches
+> 250 modules (211 escapes) and the check degenerates to "everything is core" — vacuously true,
+> proving nothing. The fan-out is a *listing* edge, not a behavioral one: a gate does not run
+> through its siblings' commands. Cutting only that one edge — while still following every other
+> edge out of `registry.ts` — is what keeps the walk tractable without over-pruning; the
+> node-scoped and edge-scoped walks give the same answer, which is how we know it does not
+> over-prune. Any future closure check must cut it the same way.
 
-With the `src/` root retained, the escapes measured on the naive-minus-registry graph collapse from
+With the `src/` root retained, the escapes measured on the fan-out-pruned graph collapse from
 eleven to four; **promoting `tracker/gh-io.ts` into the core takes it to three.** `gh-io.ts` has no
 relative imports of its own (only `effect`), so retaining it pulled nothing new into the closure —
 re-derived mechanically, not assumed. The remaining three are **retained as a recorded residue, not

--- a/.decisions/0218-pipeline-cli-cp-enforcement-core.md
+++ b/.decisions/0218-pipeline-cli-cp-enforcement-core.md
@@ -1,0 +1,202 @@
+---
+id: 0218
+title: §CP on packages/pipeline-cli/ narrows to an enforcement core — amends ADR 0100's whole-package coverage
+status: accepted
+date: 2026-07-26
+tags: [pipeline, control-plane, ship-it, codeowners, classifier, guards]
+---
+
+# 0218 — §CP on `packages/pipeline-cli/` is an enforcement core, not the whole package
+
+## Context
+
+The control-plane boundary (ADR [0053](0053-control-plane-boundary.md), enforced at GitHub per ADR
+[0071](0071-enforce-control-plane-at-github.md), hard-gated per ADR
+[0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)) marks the surfaces
+where an autonomous green-then-ship merge could compromise the pipeline's own guards. Its concrete
+form is the single-source `CONTROL_PLANE_RE` in
+[`control-plane-re.ts`](../packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts),
+its byte-synced copy in
+[`gh-issue-intake-formats.md`](../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md)
+§CP, and the matching `.github/CODEOWNERS` rows.
+
+One of its branches was the blanket `^packages/pipeline-cli/`. That package now holds **68 tools**.
+Most of them — `checks`, `main-sync`, `tracker`, `gh-phoenix`, `campaign`, `roadmap`,
+`glossary-drift`, `decisions-index`, `design-inventory`, … — are coordination and read tooling that
+gates nothing, yet every edit to any of them banked for a human control-plane approval.
+
+**Measured cost.** Over the merge window 2026-07-25 → 2026-07-26, **23** of the merged PRs were §CP
+*only* because of the `^packages/pipeline-cli/` clause. Under the core this ADR sets, **10** of them
+would newly auto-ship. (The clause-attributable count is not the relief count: the rest touch a
+retained core path and keep banking. Quote the 10, not the 23.)
+
+**The founder's reasoning, which is the decision's actual basis.** He does not read most of the §CP
+approvals he grants; he approves them on trust in the pipeline. A rubber-stamped gate provides no
+protection while imposing full approval latency, **and it manufactures a false assurance that a
+human vetted the change**. The intent is for the pipeline to self-heal via CI reds where CI can
+carry it, and to reserve the human gate for where an unreviewed merge could actually weaken a guard.
+
+**The stakes are higher than "one less review flavor," and this must not be soft-pedalled.** Branch
+protection was read first-hand for this ADR — ruleset `17377992` ("main protection", `active`):
+
+```
+required_approving_review_count: 0
+require_code_owner_review:       true
+dismiss_stale_reviews_on_push:   true
+```
+
+With `required_approving_review_count: 0`, CODEOWNERS is the *only* source of a required human
+approval. Removing a path from CODEOWNERS therefore removes **all** required human review of it, not
+merely the §CP flavor. There is no residual review floor. Everything leaving §CP here is
+CI-enforced, full stop.
+
+## The two ADRs in play
+
+**ADR [0187](0187-crew-mcp-is-not-control-plane.md) — the authority.** It already set the test:
+*"a path is §CP if merging it unreviewed could weaken the pipeline's enforcement of its own rules …
+The test is **enforcement surface**, not **proximity**,"* with the burden of proof *"Adding a package
+to §CP requires showing an unreviewed merge of it could weaken a gate."* This ADR applies that test
+**per path inside a package** rather than to the package as a unit.
+
+**ADR [0100](0100-control-plane-covers-enforcement-guard-packages.md) — amended, in two distinct
+ways.** This is not incidental bookkeeping; 0100 as written contradicts this change:
+
+1. Its 2026-06-20 amendment **explicitly considered and rejected** this sub-path split: *"The whole
+   package matches, not a `src/guards/` sub-prefix … A narrower prefix would leave that shared
+   dispatch non-§CP … the broad `^packages/pipeline-cli/` match is the correct coverage."* That
+   reasoning — the shared dispatch lives at the package root — is **correct and is honored here**,
+   by the `src/[^/]+$` root branch. What is amended is the conclusion that honoring it requires
+   swallowing the whole package.
+2. Its **primary decision** named specific guards §CP **by name** — `leak-guard`, `spawn-guard`,
+   `structured-output-guard`, `worktree-guard`, `read-guard` — on the grounds that *"a bad (or
+   adversarial) edit that flips one of these fail-open is the 'a guard auto-merges a weakening of
+   itself' case the control-plane boundary exists to prevent."* Those packages were folded into
+   `packages/pipeline-cli/src/tools/` by ADR [0103](0103-consolidate-pipeline-cli-package.md). Under
+   this core **they all leave §CP.** This ADR removes coverage 0100 granted explicitly. It is a
+   deliberate trade under 0187's test — a guard that reds in CI on every PR is CI-enforced, and the
+   founder's ruling is that CI enforcement, not a rubber-stamped approval, is the right control for
+   them.
+
+## Decision
+
+The blanket `^packages/pipeline-cli/` branch is replaced by **two** anchored branches:
+
+```
+^packages/pipeline-cli/src/[^/]+$
+^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/
+```
+
+### 1. The `src/` root, non-recursive — the shared dispatch and plumbing
+
+`registry.ts`'s `registeredTools[]` can disable any guard without touching that guard's own
+directory; `router.ts`/`bin.ts` are the dispatch; `gate-fail.ts` is how a gate reds;
+`read-stdin.ts`/`read-stdin-core.ts` are the fail-closed stdin read (#3924) that feeds
+`cp-cardinality decide`; `run.ts`, `tool-registration.ts`, `module-load-guard.ts`, `annotate.ts`,
+`find-root-dir.ts`, `version.ts` are process plumbing every gate runs through.
+
+It is expressed as a **non-recursive pattern, not a file list**, deliberately. The list originally
+proposed was four files (`registry`/`router`/`bin`/`gate-fail`) — it already lagged reality by seven
+modules the day it was written. A pattern is rot-proof by construction: a root module added tomorrow
+is §CP without anyone remembering to add it.
+
+`codeowners-cp`'s `expandBranch` translates the `[^/]+` within-segment class to a gitignore `*`, so
+the branch resolves to the §CP path `packages/pipeline-cli/src/*` and a
+`/packages/pipeline-cli/src/*` CODEOWNERS row covers it exactly. (`*` is within-segment — the
+`skills/**/*.sh` row above it needs `**` precisely because `*` does not cross `/`.)
+
+### 2. The eight enforcement-surface tools
+
+| Tool | Why an unreviewed edit could weaken a gate |
+|---|---|
+| `ci-required` | **Is** one of the branch-protection-required status checks (`ci.yml:1072` runs its `bin.ts`). |
+| `verdict` | Decides whether a required namespace carries a current-head PASS (ADR 0058) — the enqueue gate. |
+| `cp-cardinality` | Decides whether a §CP approval discharged (ADR 0175). `ship-it/SKILL.md:533` invokes it as the **local on-disk binary** with no `origin/main` re-resolution, so a merged weakening takes effect on every subsequent run. Flipping its `n === 0` branch from `stop` to `discharge` silently discharges §CP forever. |
+| `control-plane-paths` | Emits `CONTROL_PLANE_RE` — the boundary definition itself. |
+| `cp-classify` | Renders the §CP **verdict**. The only site that can return `not-control-plane`; carries the four-state `control-plane`/`content-undetermined`/`not-control-plane`/`unknown` machine whose own docblock names collapsing `unknown` → `not-control-plane` as "the recurring fail-open defect" (#3715, #4108, #4171, #4191). Also owns `CP_CONTENT_PREFIX`, the scope of the ADR-0164 content clause. |
+| `codeowners-cp` | The regex ↔ `.github/CODEOWNERS` drift gate. |
+| `trivial-diff` | Routes a PR to the lighter `review-trivial` gate (ADR 0120); its bound 3 is literally "Not control-plane." Weakening a bound rides a substantive or guard-relaxing change onto the lighter gate (#3645). |
+| `review-head` | Resolves and materializes the head every verdict binds to (ADR 0058). `verdict`'s SHA-binding is only as good as the head resolution feeding it. |
+
+The last three (`cp-classify`, `trivial-diff`, `review-head`) were **not** in the originally
+proposed nine-path list. They were added by founder ruling after measurement showed retaining them
+**costs zero relief over the measured window** — the same ten PRs leave §CP either way. On a
+security-boundary narrowing, a free widening that closes three independently-verified fail-open
+vectors is the obvious trade.
+
+`^packages/ci-required/` is a **separate, independent** branch and is byte-unchanged, as are its
+CODEOWNERS row and everything else in the regex.
+
+## Closure — what leaves, and why that is or is not argued safe
+
+ADR 0187's burden of proof runs the other way for a *removal*, so the honest question is: **is there
+a path leaving §CP through which a change could reach the enforcement surface?** Four findings, each
+addressed by name rather than by "the guards are green."
+
+**(a) Transitive imports of the retained core.** Computed mechanically, not asserted — see
+[`core-import-closure.unit.test.ts`](../packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts).
+
+> **The walk needs one non-obvious rule to mean anything: `registry.ts` is a SINK.** It imports all
+> 68 tools' `command.ts` to build `registeredTools[]`, so seeding through it reaches 246 modules and
+> the check degenerates to "everything is core" — vacuously true, proving nothing. The registration
+> fan-out is a *listing* edge, not a behavioral one: a gate does not run through its siblings'
+> commands. Any future closure check must cut it the same way.
+
+With the `src/` root retained, the escapes measured on the naive-minus-registry graph collapse from
+eleven to **four**. All four are **retained as a recorded residue, not argued unreachable**:
+
+| Escaping module | Reached from | Honest reachability |
+|---|---|---|
+| `tools/tracker/gh-io.ts` | `verdict/github.ts`, `review-head/materialize.ts` | **The sharpest one.** It exports `authorizedAuthors` — the ADR-0055 write+ ACL trust root — which `verdict/github.ts:214` feeds straight into `resolveVerdict`. Widening it to return all authors would let a **forged verdict from a non-collaborator** count. This clears 0187's burden of proof on its own terms. |
+| `tools/guard-content-probe/guard-content-probe.ts` | `trivial-diff/trivial-diff.ts` (`probeGuardContent`), `trivial-diff/command.ts` (`parseGuardAdrRe`) | Implements the **ADR-0164 §CP-by-content predicate** — the second §CP boundary definition. Weakening it makes a guard-relaxing ADR read as non-§CP to `trivial-diff`, routing it to the lighter gate. Surfaced by the mechanical check, *not* by the hand analysis, which had it as a second-order surface. |
+| `tools/leak-guard/leak-guard.ts` | `verdict/verdict-match.ts` (`findCommentLeaks`) | Feeds `emissionDefect`, the verdict-emission path-leak check (#2796/#2822). Weakening it admits a leaking verdict body; it does not flip a PASS/FAIL. Lower stakes than the two above, but ADR 0100 named `leak-guard` §CP by name. |
+| `tools/leak-guard/path-matcher.ts` | `leak-guard.ts` | Same surface, one hop further. |
+
+**These four are the boundary's known cost, recorded rather than papered over.** The allowlist in
+the test exists so the set **cannot grow silently**: a new unclosed import from the core reds the
+check and forces a fresh decision. The first two in particular are live candidates for a follow-up
+widening; nothing here argues they are safe, only that the ruled boundary is where the founder set
+it and the residue is now visible instead of implicit.
+
+**(b) Shared root modules beyond the four originally listed** — `tool-registration.ts`, `run.ts`,
+`index.ts`, `module-load-guard.ts`, `version.ts`, `read-stdin.ts`, `read-stdin-core.ts`,
+`annotate.ts`, `find-root-dir.ts`. **Closed by retention**: the non-recursive `src/[^/]+$` branch
+covers all of them, and every future root module, by construction.
+
+**(c) `packages/pipeline-cli/package.json` and the build/test configs** (`tsconfig*.json`,
+`vitest.config.ts`) leave §CP. They are **not** argued unreachable in principle — `package.json`
+declares the binary `ci-required` and `cp-cardinality` are invoked as. They are left out because
+they are covered by a different, non-discretionary control: `catalog-guard` fails closed on any
+non-`catalog:` dependency version, CI builds and runs the guard suites through those configs on
+every PR, and a config edit that breaks a gate's build reds `ci-required` directly rather than
+silently passing. This is CI enforcement, consistent with the ruling's premise.
+
+**(d) Second-order gate surfaces.** `checks`, `merge-intent`, `merge-queue-classify`,
+`class-probe`, `redact-leaks` (invoked by `ship-it`'s merge path) and `path-filter-guard` /
+`change-detect-guard` (which produce the `changes` outputs `ci-required` consumes) all leave §CP.
+They are invoked as separate processes by skills and workflows, not imported by the core, and each
+runs in CI on every PR. `guard-content-probe` was on this list and turned out to be a **hard import
+edge** — it is handled in (a) above, and its promotion from "second-order" to "in the closure" is
+the concrete reason a mechanical check beats prose here.
+
+## Consequences
+
+- **`codeowners-cp` cannot catch a stale narrowing.** It detects **under-protection** only — a §CP
+  regex path with no covering CODEOWNERS row. It **never** flags a CODEOWNERS row *broader* than the
+  regex. So leaving the old `/packages/pipeline-cli/` row in place would not have redded any gate;
+  the lockstep narrowing is an **author obligation**, not a gate-enforced one. Pinned by a test.
+- **CODEOWNERS carries a belt-and-braces owner-less row.** `/packages/pipeline-cli/src/tools/` with
+  no owners (GitHub's documented `/apps/github` unset idiom) sits between the `src/*` row and the
+  eight retained tool rows, so the ~60 non-gating tools are ungated even if `src/*` were ever read
+  as crossing `/`; last-match-wins re-owns the eight below it.
+- **The `#981` anti-self-authorization property is unchanged.** The live merge-deciding gates still
+  re-resolve `CONTROL_PLANE_RE` from `gh-issue-intake-formats.md` on `origin/main`, so this
+  boundary-narrowing PR is classified against **main's** boundary — the pre-narrowing one — and
+  banks for a human §CP approval. The narrowing cannot authorize itself.
+- **The `#2761` single-source discipline is unchanged.** The const remains the one source; the
+  formats-doc line and CODEOWNERS are drift-guarded against it by `codeowners-cp` and
+  `validate-gate-path-drift.sh`, and every in-repo fixture imports the const rather than
+  re-literaling it (the #2673 stale-fixture class).
+- **Recorded follow-on, out of scope here (#4195 or its own issue):** extend the `origin/main`
+  re-resolution idiom (#981, `control-plane-re.ts` lines ~42-46) to `cp-cardinality` and
+  `ci-required`, so a weakened local copy cannot take effect. Once that exists, even those two
+  could leave §CP.

--- a/.decisions/0218-pipeline-cli-cp-enforcement-core.md
+++ b/.decisions/0218-pipeline-cli-cp-enforcement-core.md
@@ -79,12 +79,20 @@ ways.** This is not incidental bookkeeping; 0100 as written contradicts this cha
 
 ## Decision
 
-The blanket `^packages/pipeline-cli/` branch is replaced by **two** anchored branches:
+The blanket `^packages/pipeline-cli/` branch is replaced by **three** anchored branches:
 
 ```
 ^packages/pipeline-cli/src/[^/]+$
 ^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/
+^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$
 ```
+
+In the founder's enumeration the core is **thirteen paths**: the four shared-dispatch root modules
+(`registry.ts`, `router.ts`, `bin.ts`, `gate-fail.ts` — carried here by the *broader* non-recursive
+`src/[^/]+$` branch, which covers them and every other root module), the eight enforcement tool
+**directories**, and `tracker/gh-io.ts`. The thirteenth is the only entry that gates a **single
+file inside a directory that is otherwise not core**, which is why it needs its own `$`-anchored
+branch and its own literal CODEOWNERS row (§3).
 
 ### 1. The `src/` root, non-recursive — the shared dispatch and plumbing
 
@@ -123,6 +131,24 @@ proposed nine-path list. They were added by founder ruling after measurement sho
 security-boundary narrowing, a free widening that closes three independently-verified fail-open
 vectors is the obvious trade.
 
+### 3. One file: `src/tools/tracker/gh-io.ts`
+
+`gh-io.ts` exports `authorizedAuthors` (`gh-io.ts:209`) — the **ADR 0055 write+ ACL**, the trust
+root that decides whose `review-*` marker counts at all. `verdict/github.ts:214-215` feeds its
+result straight into `resolveVerdict`. An unreviewed edit widening it to return every author would
+let a **forged verdict from a non-collaborator count as a PASS**: the enqueue gate would still
+behave exactly as written while authorizing anyone. Retaining `verdict` — the tool that consumes
+the decision — while leaving the source of the decision ungated is an incoherent line, and it
+clears ADR 0187's burden of proof on its own terms.
+
+It is anchored at the **file**, not at `tools/tracker/`. The rest of that directory is claim and
+coordination tooling (`tracker claim`, presence stamping) that gates nothing, and sweeping it into
+§CP would re-import exactly the rubber-stamp cost this ADR removes. `codeowners-cp`'s
+`expandBranch` normalizes a `$`-anchored, `\.`-escaped leaf to a `kind: "file"` path, so the branch
+resolves to the §CP path `packages/pipeline-cli/src/tools/tracker/gh-io.ts` and is owned by a
+literal CODEOWNERS row of the same name — placed **after** the owner-less
+`/packages/pipeline-cli/src/tools/` row, so last-match-wins re-owns it.
+
 `^packages/ci-required/` is a **separate, independent** branch and is byte-unchanged, as are its
 CODEOWNERS row and everything else in the regex.
 
@@ -142,20 +168,27 @@ addressed by name rather than by "the guards are green."
 > commands. Any future closure check must cut it the same way.
 
 With the `src/` root retained, the escapes measured on the naive-minus-registry graph collapse from
-eleven to **four**. All four are **retained as a recorded residue, not argued unreachable**:
+eleven to four; **promoting `tracker/gh-io.ts` into the core takes it to three.** `gh-io.ts` has no
+relative imports of its own (only `effect`), so retaining it pulled nothing new into the closure —
+re-derived mechanically, not assumed. The remaining three are **retained as a recorded residue, not
+argued unreachable**:
 
 | Escaping module | Reached from | Honest reachability |
 |---|---|---|
-| `tools/tracker/gh-io.ts` | `verdict/github.ts`, `review-head/materialize.ts` | **The sharpest one.** It exports `authorizedAuthors` — the ADR-0055 write+ ACL trust root — which `verdict/github.ts:214` feeds straight into `resolveVerdict`. Widening it to return all authors would let a **forged verdict from a non-collaborator** count. This clears 0187's burden of proof on its own terms. |
 | `tools/guard-content-probe/guard-content-probe.ts` | `trivial-diff/trivial-diff.ts` (`probeGuardContent`), `trivial-diff/command.ts` (`parseGuardAdrRe`) | Implements the **ADR-0164 §CP-by-content predicate** — the second §CP boundary definition. Weakening it makes a guard-relaxing ADR read as non-§CP to `trivial-diff`, routing it to the lighter gate. Surfaced by the mechanical check, *not* by the hand analysis, which had it as a second-order surface. |
-| `tools/leak-guard/leak-guard.ts` | `verdict/verdict-match.ts` (`findCommentLeaks`) | Feeds `emissionDefect`, the verdict-emission path-leak check (#2796/#2822). Weakening it admits a leaking verdict body; it does not flip a PASS/FAIL. Lower stakes than the two above, but ADR 0100 named `leak-guard` §CP by name. |
+| `tools/leak-guard/leak-guard.ts` | `verdict/verdict-match.ts` (`findCommentLeaks`) | Feeds `emissionDefect`, the verdict-emission path-leak check (#2796/#2822). Weakening it admits a leaking verdict body; it does not flip a PASS/FAIL. Lower stakes, but ADR 0100 named `leak-guard` §CP by name. |
 | `tools/leak-guard/path-matcher.ts` | `leak-guard.ts` | Same surface, one hop further. |
 
-**These four are the boundary's known cost, recorded rather than papered over.** The allowlist in
+`tools/tracker/gh-io.ts` was the fourth and **sharpest** of the measured escapes — it was the one
+that could flip a PASS/FAIL rather than merely degrade a report — which is why it is now in the
+core (§3 above) instead of on this list. That promotion is the answer to the question this section
+asks; the three left are the ones the founder ruled stay CI-enforced.
+
+**These three are the boundary's known cost, recorded rather than papered over.** The allowlist in
 the test exists so the set **cannot grow silently**: a new unclosed import from the core reds the
-check and forces a fresh decision. The first two in particular are live candidates for a follow-up
-widening; nothing here argues they are safe, only that the ruled boundary is where the founder set
-it and the residue is now visible instead of implicit.
+check and forces a fresh decision. `guard-content-probe` in particular remains a live candidate for
+a follow-up widening; nothing here argues it is safe, only that the ruled boundary is where the
+founder set it and the residue is now visible instead of implicit.
 
 **(b) Shared root modules beyond the four originally listed** — `tool-registration.ts`, `run.ts`,
 `index.ts`, `module-load-guard.ts`, `version.ts`, `read-stdin.ts`, `read-stdin-core.ts`,

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,7 +46,24 @@
 # The standalone *-guard packages were folded into pipeline-cli and deleted (#1003); ci-required
 # stays standalone (ADR 0092) and keeps its own owner line.
 /packages/ci-required/          @kamp-us/control-plane
-/packages/pipeline-cli/         @kamp-us/control-plane
+# Control-plane: pipeline-cli's ENFORCEMENT CORE only, not the whole package (ADR 0218, amending
+# ADR 0100). Must stay in lockstep with the two §CP `packages/pipeline-cli/` regex branches —
+# `codeowners-cp` detects UNDER-protection only, so an over-broad row here would NOT red the gate.
+# `src/*` is within-segment (like the `**/*.sh` row above, which needs `**` precisely because `*`
+# does not cross `/`), so it owns the shared-dispatch root and no deeper.
+/packages/pipeline-cli/src/*    @kamp-us/control-plane
+# Owner-less line = ownership UNSET (GitHub's documented `/apps/github` idiom). Belt-and-braces so
+# the ~60 non-gating tools are ungated even if `src/*` were ever read as crossing `/`; the eight
+# retained core tools below re-own themselves by CODEOWNERS last-match-wins.
+/packages/pipeline-cli/src/tools/
+/packages/pipeline-cli/src/tools/ci-required/          @kamp-us/control-plane
+/packages/pipeline-cli/src/tools/codeowners-cp/        @kamp-us/control-plane
+/packages/pipeline-cli/src/tools/control-plane-paths/  @kamp-us/control-plane
+/packages/pipeline-cli/src/tools/cp-cardinality/       @kamp-us/control-plane
+/packages/pipeline-cli/src/tools/cp-classify/          @kamp-us/control-plane
+/packages/pipeline-cli/src/tools/review-head/          @kamp-us/control-plane
+/packages/pipeline-cli/src/tools/trivial-diff/         @kamp-us/control-plane
+/packages/pipeline-cli/src/tools/verdict/              @kamp-us/control-plane
 # Control-plane: lint/GritQL governance config — the biome config + GritQL plugin rules. An
 # ungated path to weaken a lint rule (disable a security lint, downgrade a GritQL guard) is a
 # guard-relaxing vector. The §CP `biome\.jsonc$` + `biome-plugins/` branches (ADR 0193).

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 # stays standalone (ADR 0092) and keeps its own owner line.
 /packages/ci-required/          @kamp-us/control-plane
 # Control-plane: pipeline-cli's ENFORCEMENT CORE only, not the whole package (ADR 0218, amending
-# ADR 0100). Must stay in lockstep with the two §CP `packages/pipeline-cli/` regex branches —
+# ADR 0100). Must stay in lockstep with the three §CP `packages/pipeline-cli/` regex branches —
 # `codeowners-cp` detects UNDER-protection only, so an over-broad row here would NOT red the gate.
 # `src/*` is within-segment (like the `**/*.sh` row above, which needs `**` precisely because `*`
 # does not cross `/`), so it owns the shared-dispatch root and no deeper.
@@ -62,6 +62,9 @@
 /packages/pipeline-cli/src/tools/cp-cardinality/       @kamp-us/control-plane
 /packages/pipeline-cli/src/tools/cp-classify/          @kamp-us/control-plane
 /packages/pipeline-cli/src/tools/review-head/          @kamp-us/control-plane
+# One FILE, not its directory: `gh-io.ts` exports `authorizedAuthors`, the ADR 0055 write+ ACL
+# `verdict` resolves a marker's authority against. The rest of `tools/tracker/` stays ungated.
+/packages/pipeline-cli/src/tools/tracker/gh-io.ts      @kamp-us/control-plane
 /packages/pipeline-cli/src/tools/trivial-diff/         @kamp-us/control-plane
 /packages/pipeline-cli/src/tools/verdict/              @kamp-us/control-plane
 # Control-plane: lint/GritQL governance config — the biome config + GritQL plugin rules. An

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1565,7 +1565,7 @@ closing the #375 drift class).
     [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md),
     #1003), but ~68 tools live there and most gate nothing — so ADR
     [0187](https://github.com/kamp-us/phoenix/blob/main/.decisions/0187-crew-mcp-is-not-control-plane.md)'s
-    enforcement-surface test is applied **per path** rather than to the package as a whole. Two
+    enforcement-surface test is applied **per path** rather than to the package as a whole. Three
     clauses carry it:
     - `^packages/pipeline-cli/src/[^/]+$` — the `src/` **root, non-recursive**: the shared
       dispatch + process plumbing every tool including every gate runs through (`registry.ts`'s
@@ -1578,6 +1578,12 @@ closing the #375 drift class).
       `control-plane-paths` (this boundary), `cp-classify` (the §CP verdict, #4161),
       `codeowners-cp` (the regex↔CODEOWNERS drift gate), `trivial-diff` (routes a PR to the
       lighter gate, ADR 0120), `review-head` (resolves the head every verdict binds to).
+    - `^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$` — **one file, not its directory.**
+      `gh-io.ts` exports `authorizedAuthors`, the ADR 0055 write+ ACL, and `verdict/github.ts`
+      feeds its result straight into `resolveVerdict`: widening it to return every author would
+      let a **forged verdict from a non-collaborator count as a PASS**. Retaining `verdict` while
+      leaving its authorization source ungated is an incoherent line. The rest of `tools/tracker/`
+      is claim/coordination tooling and stays out — hence the file-level anchor.
 
     The legacy `^packages/[^/]*-guard/` clause is retired with those packages. Note what the
     narrowing means concretely: the Tier-3 guards ADR 0100 named **by name** (`leak-guard`,
@@ -1643,7 +1649,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^biome\.jsonc$|^biome-plugins/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$|^biome\.jsonc$|^biome-plugins/'
 # The list this regex is matched against is a fallible READ, so it comes from §CPREAD's
 # `cp_changed_files` (defined below) — never a bare `gh api … | grep` pipe. With pipefail off that
 # pipe reports grep's status and discards gh's, so a failed read matches nothing and reads as "no §CP

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1554,19 +1554,37 @@ closing the #375 drift class).
   - `packages/ci-required/**` — the zero-dep aggregator of the gating CI checks. Its sources were
     inlined into pipeline-cli at `packages/pipeline-cli/src/tools/ci-required/` (#3802), and its CI
     job now runs `node packages/pipeline-cli/src/tools/ci-required/bin.ts`; the aggregator's
-    CP coverage now flows through the `^packages/pipeline-cli/` clause. The `^packages/ci-required/`
+    CP coverage now flows through the pipeline-cli enforcement-core clauses below (its sources sit
+    at `src/tools/ci-required/`, a retained core path). The `^packages/ci-required/`
     clause below is retained deliberately (ADR 0100) as defense-in-depth against a re-created package
     at that path, even though it no longer carries tracked sources.
-  - `packages/pipeline-cli/**` — the consolidated guard machinery (ADR
-    [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md)),
-    now the single home for every guard the standalone `*-guard` packages used to carry
-    (`spawn-guard`, `worktree-guard`, `structured-output-guard`, `leak-guard`),
-    those packages deleted by Phase-4 (#1003). The whole package matches (`^packages/pipeline-cli/`),
-    not a `src/guards/` sub-prefix: the shared guard-dispatch infra — `registry.ts` (the
-    `registeredTools[]` array that wires every guard in), `router.ts`/`bin.ts` — lives at the
-    **package root**, so an edit there could disable or bypass every guard. The whole package is
-    a self-weakening surface. The legacy `^packages/[^/]*-guard/` clause is now retired with those
-    packages; guard coverage flows through `^packages/pipeline-cli/`.
+  - `packages/pipeline-cli/` — **an enforcement core, not the whole package** (ADR
+    [0218](https://github.com/kamp-us/phoenix/blob/main/.decisions/0218-pipeline-cli-cp-enforcement-core.md),
+    amending ADR 0100, which had rejected exactly this sub-path split). The package is the
+    consolidated home for every guard the standalone `*-guard` packages used to carry (ADR
+    [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md),
+    #1003), but ~68 tools live there and most gate nothing — so ADR
+    [0187](https://github.com/kamp-us/phoenix/blob/main/.decisions/0187-crew-mcp-is-not-control-plane.md)'s
+    enforcement-surface test is applied **per path** rather than to the package as a whole. Two
+    clauses carry it:
+    - `^packages/pipeline-cli/src/[^/]+$` — the `src/` **root, non-recursive**: the shared
+      dispatch + process plumbing every tool including every gate runs through (`registry.ts`'s
+      `registeredTools[]` can disable any guard without touching that guard's own directory;
+      plus `router.ts`/`bin.ts`/`gate-fail.ts`/`read-stdin*.ts`/`run.ts`/`tool-registration.ts`/…).
+      A non-recursive pattern, not a file list, so it cannot rot as root modules are added.
+    - `^packages/pipeline-cli/src/tools/(…)/` — the **eight** tools that are themselves the
+      enforcement surface: `ci-required` (a branch-protection-required check), `verdict` (the
+      enqueue gate, ADR 0058), `cp-cardinality` (§CP approval discharge, ADR 0175),
+      `control-plane-paths` (this boundary), `cp-classify` (the §CP verdict, #4161),
+      `codeowners-cp` (the regex↔CODEOWNERS drift gate), `trivial-diff` (routes a PR to the
+      lighter gate, ADR 0120), `review-head` (resolves the head every verdict binds to).
+
+    The legacy `^packages/[^/]*-guard/` clause is retired with those packages. Note what the
+    narrowing means concretely: the Tier-3 guards ADR 0100 named **by name** (`leak-guard`,
+    `spawn-guard`, `structured-output-guard`, `worktree-guard`, `read-guard`) are **no longer
+    §CP** — they are CI-enforced, not human-approval-enforced. ADR 0218 records that trade, the
+    three modules the core imports without retaining, and why `codeowners-cp` cannot catch a
+    stale over-broad CODEOWNERS row.
 
 A PR touching **any** path in this set is **control plane**: `ship-it` refuses to auto-merge
 it and a human merges it by hand (ADR
@@ -1577,9 +1595,11 @@ widened to the gate-critical skills by ADR
 [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md), since the gate
 that reviews the gates is itself a gate; the enforcement-guard packages added by ADR
 [0100](https://github.com/kamp-us/phoenix/blob/main/.decisions/0100-control-plane-covers-enforcement-guard-packages.md),
-since a guard is a self-weakening surface wherever it lives; that coverage now also flows
-through the consolidated `^packages/pipeline-cli/` package per ADR
-[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md);
+since a guard is a self-weakening surface wherever it lives; that coverage flowed
+through the consolidated `packages/pipeline-cli/` package per ADR
+[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md)
+and is now scoped to that package's **enforcement core** per ADR
+[0218](https://github.com/kamp-us/phoenix/blob/main/.decisions/0218-pipeline-cli-cp-enforcement-core.md);
 the **pipeline agent definitions** (`claude-plugins/kampus-pipeline/agents/**`) added by ADR
 [0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
 since a gate/merge agent's own instructions are a self-weakening surface; the **bare gate-critical
@@ -1623,7 +1643,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\.jsonc$|^biome-plugins/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^biome\.jsonc$|^biome-plugins/'
 # The list this regex is matched against is a fallible READ, so it comes from §CPREAD's
 # `cp_changed_files` (defined below) — never a bare `gh api … | grep` pipe. With pipefail off that
 # pipe reports grep's status and discards gh's, so a failed read matches nothing and reads as "no §CP

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -45,6 +45,7 @@ describe("splitTopLevelBranches", () => {
 			"packages/ci-required/",
 			"packages/pipeline-cli/src/[^/]+$",
 			"packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/",
+			"packages/pipeline-cli/src/tools/tracker/gh-io\\.ts$",
 			"biome\\.jsonc$",
 			"biome-plugins/",
 		]);
@@ -116,6 +117,12 @@ describe("expandBranch", () => {
 		]);
 	});
 
+	it("expands the file-level tracker/gh-io.ts branch to an exact file, not a dir (ADR 0218)", () => {
+		expect(expandBranch("packages/pipeline-cli/src/tools/tracker/gh-io\\.ts$")).toEqual([
+			{path: "packages/pipeline-cli/src/tools/tracker/gh-io.ts", kind: "file"},
+		]);
+	});
+
 	it("expands the biome-governance branches: an exact file + a dir prefix (ADR 0193)", () => {
 		expect(expandBranch("biome\\.jsonc$")).toEqual([{path: "biome.jsonc", kind: "file"}]);
 		expect(expandBranch("biome-plugins/")).toEqual([{path: "biome-plugins/", kind: "dir"}]);
@@ -154,6 +161,7 @@ describe("cpPaths over the live regex", () => {
 			"packages/pipeline-cli/src/tools/review-head/",
 			"packages/pipeline-cli/src/tools/trivial-diff/",
 			"packages/pipeline-cli/src/tools/verdict/",
+			"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
 			"biome.jsonc",
 			"biome-plugins/",
 		]);
@@ -249,6 +257,7 @@ describe("findUncovered — the drift check", () => {
 		"/packages/pipeline-cli/src/tools/review-head/ @usirin",
 		"/packages/pipeline-cli/src/tools/trivial-diff/ @usirin",
 		"/packages/pipeline-cli/src/tools/verdict/ @usirin",
+		"/packages/pipeline-cli/src/tools/tracker/gh-io.ts @usirin",
 		"/biome.jsonc @usirin",
 		"/biome-plugins/ @usirin",
 	].join("\n");
@@ -325,6 +334,18 @@ describe("findUncovered — the drift check", () => {
 			"packages/pipeline-cli/src/tools/review-head/",
 			"packages/pipeline-cli/src/tools/trivial-diff/",
 			"packages/pipeline-cli/src/tools/verdict/",
+			"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
+		]);
+	});
+
+	// The file-level branch is the one §CP path a directory row cannot be assumed to carry: the
+	// enclosing `tools/tracker/` is deliberately UNOWNED, so gh-io.ts needs its own literal row.
+	it("flags tracker/gh-io.ts when its own row is missing (ADR 0218's file-level branch)", () => {
+		const withoutGhIo = NARROWED_CODEOWNERS.split("\n")
+			.filter((l) => !l.includes("gh-io.ts"))
+			.join("\n");
+		expect(findUncovered(paths, parseCodeownersPatterns(withoutGhIo)).map((p) => p.path)).toEqual([
+			"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
 		]);
 	});
 

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -43,7 +43,8 @@ describe("splitTopLevelBranches", () => {
 			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$",
 			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
 			"packages/ci-required/",
-			"packages/pipeline-cli/",
+			"packages/pipeline-cli/src/[^/]+$",
+			"packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/",
 			"biome\\.jsonc$",
 			"biome-plugins/",
 		]);
@@ -144,7 +145,15 @@ describe("cpPaths over the live regex", () => {
 			"claude-plugins/kampus-pipeline/hooks/",
 			"claude-plugins/kampus-pipeline/hooks.json",
 			"packages/ci-required/",
-			"packages/pipeline-cli/",
+			"packages/pipeline-cli/src/*",
+			"packages/pipeline-cli/src/tools/ci-required/",
+			"packages/pipeline-cli/src/tools/codeowners-cp/",
+			"packages/pipeline-cli/src/tools/control-plane-paths/",
+			"packages/pipeline-cli/src/tools/cp-cardinality/",
+			"packages/pipeline-cli/src/tools/cp-classify/",
+			"packages/pipeline-cli/src/tools/review-head/",
+			"packages/pipeline-cli/src/tools/trivial-diff/",
+			"packages/pipeline-cli/src/tools/verdict/",
 			"biome.jsonc",
 			"biome-plugins/",
 		]);
@@ -210,6 +219,46 @@ describe("covers", () => {
 describe("findUncovered — the drift check", () => {
 	const paths = cpPaths(LIVE_RE);
 
+	const NARROWED_CODEOWNERS = [
+		"/.claude/ @usirin",
+		"/.github/ @usirin",
+		"/.claude-plugin/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/ship-it/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/review-skill/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/review-design/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/review-plan/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/triage/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/write-code/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/plan-epic/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/release/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/review-trivial/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/**/*.sh @usirin",
+		"/claude-plugins/kampus-pipeline/agents/ @usirin",
+		"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
+		"/claude-plugins/kampus-pipeline/hooks/ @usirin",
+		"/claude-plugins/kampus-pipeline/hooks.json @usirin",
+		"/packages/ci-required/ @usirin",
+		"/packages/pipeline-cli/src/* @usirin",
+		"/packages/pipeline-cli/src/tools/ci-required/ @usirin",
+		"/packages/pipeline-cli/src/tools/codeowners-cp/ @usirin",
+		"/packages/pipeline-cli/src/tools/control-plane-paths/ @usirin",
+		"/packages/pipeline-cli/src/tools/cp-cardinality/ @usirin",
+		"/packages/pipeline-cli/src/tools/cp-classify/ @usirin",
+		"/packages/pipeline-cli/src/tools/review-head/ @usirin",
+		"/packages/pipeline-cli/src/tools/trivial-diff/ @usirin",
+		"/packages/pipeline-cli/src/tools/verdict/ @usirin",
+		"/biome.jsonc @usirin",
+		"/biome-plugins/ @usirin",
+	].join("\n");
+
+	// The ADR-0218 narrowed rows cover every §CP path exactly — in particular the `src/*` glob row
+	// covers the `src/[^/]+$` root branch, which is the translation the narrowing relies on.
+	it("passes (zero uncovered) under the ADR-0218 narrowed pipeline-cli rows", () => {
+		expect(findUncovered(paths, parseCodeownersPatterns(NARROWED_CODEOWNERS))).toEqual([]);
+	});
+
 	it("passes (zero uncovered) when CODEOWNERS enumerates every §CP path", () => {
 		const codeowners = [
 			"/.claude/ @usirin",
@@ -267,8 +316,25 @@ describe("findUncovered — the drift check", () => {
 		expect(uncovered).toEqual([
 			"claude-plugins/kampus-pipeline/hooks/",
 			"claude-plugins/kampus-pipeline/hooks.json",
-			"packages/pipeline-cli/",
+			"packages/pipeline-cli/src/*",
+			"packages/pipeline-cli/src/tools/ci-required/",
+			"packages/pipeline-cli/src/tools/codeowners-cp/",
+			"packages/pipeline-cli/src/tools/control-plane-paths/",
+			"packages/pipeline-cli/src/tools/cp-cardinality/",
+			"packages/pipeline-cli/src/tools/cp-classify/",
+			"packages/pipeline-cli/src/tools/review-head/",
+			"packages/pipeline-cli/src/tools/trivial-diff/",
+			"packages/pipeline-cli/src/tools/verdict/",
 		]);
+	});
+
+	// The stale-over-broad direction, stated as a test because it is the one thing this gate does
+	// NOT catch (ADR 0218): a CODEOWNERS row broader than the regex leaves paths over-protected,
+	// and findUncovered — which only looks for §CP paths with no covering row — reports nothing.
+	// The ADR-0218 lockstep narrowing is therefore an author obligation, not a gate-enforced one.
+	it("does NOT flag an over-broad CODEOWNERS row (it detects under-protection only)", () => {
+		const overBroad = `${NARROWED_CODEOWNERS}\n/packages/pipeline-cli/ @usirin`;
+		expect(findUncovered(paths, parseCodeownersPatterns(overBroad))).toEqual([]);
 	});
 	it("flags a missing /.claude-plugin/ row — the /.claude/ row does NOT cover it (ADR 0212)", () => {
 		const owned = parseCodeownersPatterns(["/.claude/ @usirin", "/.github/ @usirin"].join("\n"));

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -153,10 +153,24 @@ describe("CONTROL_PLANE_RE narrows packages/pipeline-cli to its enforcement core
 		}
 	});
 
+	it("keeps tracker/gh-io.ts — the ADR-0055 write+ ACL `verdict` resolves authority against", () => {
+		// One FILE inside an otherwise non-core directory: `authorizedAuthors` feeds
+		// `resolveVerdict`, so an unreviewed widening would let a forged verdict count as a PASS.
+		expect(isControlPlane("packages/pipeline-cli/src/tools/tracker/gh-io.ts")).toBe(true);
+		// …and the anchor really is file-level — its siblings and the directory stay out.
+		for (const path of [
+			"packages/pipeline-cli/src/tools/tracker/command.ts",
+			"packages/pipeline-cli/src/tools/tracker/claim.ts",
+			"packages/pipeline-cli/src/tools/tracker/gh-io.unit.test.ts",
+			"packages/pipeline-cli/src/tools/tracker/nested/gh-io.ts",
+		]) {
+			expect(isControlPlane(path)).toBe(false);
+		}
+	});
+
 	it("releases the non-gating tools — coordination + read tooling, and the Tier-3 guards", () => {
 		for (const path of [
 			"packages/pipeline-cli/src/tools/checks/command.ts",
-			"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
 			"packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts",
 			"packages/pipeline-cli/src/tools/spawn-guard/command.ts",
 			"packages/pipeline-cli/src/tools/worktree-guard/command.ts",

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -111,6 +111,82 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 	});
 });
 
+// ADR 0218 — the pipeline-cli boundary is an enforcement CORE, not the whole package. Both
+// directions are asserted: every one of these cases flips under the pre-0218 blanket
+// `^packages/pipeline-cli/` branch, which classified all of them control-plane.
+describe("CONTROL_PLANE_RE narrows packages/pipeline-cli to its enforcement core (ADR 0218)", () => {
+	it("keeps the src/ ROOT — every shared-dispatch + plumbing module, not just the four listed", () => {
+		for (const path of [
+			"packages/pipeline-cli/src/registry.ts",
+			"packages/pipeline-cli/src/router.ts",
+			"packages/pipeline-cli/src/bin.ts",
+			"packages/pipeline-cli/src/gate-fail.ts",
+			// the modules a hand-maintained four-file list would have missed — the rot the
+			// non-recursive `src/[^/]+$` pattern closes by construction
+			"packages/pipeline-cli/src/read-stdin.ts",
+			"packages/pipeline-cli/src/read-stdin-core.ts",
+			"packages/pipeline-cli/src/tool-registration.ts",
+			"packages/pipeline-cli/src/run.ts",
+			"packages/pipeline-cli/src/module-load-guard.ts",
+			"packages/pipeline-cli/src/annotate.ts",
+			"packages/pipeline-cli/src/find-root-dir.ts",
+			"packages/pipeline-cli/src/version.ts",
+			"packages/pipeline-cli/src/some-module-added-tomorrow.ts",
+		]) {
+			expect(isControlPlane(path)).toBe(true);
+		}
+	});
+
+	it("keeps all EIGHT enforcement-core tools, including the three the 9-path list omitted", () => {
+		for (const path of [
+			"packages/pipeline-cli/src/tools/ci-required/bin.ts",
+			"packages/pipeline-cli/src/tools/verdict/verdict-match.ts",
+			"packages/pipeline-cli/src/tools/cp-cardinality/command.ts",
+			"packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts",
+			"packages/pipeline-cli/src/tools/codeowners-cp/gate.ts",
+			// the three retained by the founder ruling on top of the issue's original nine
+			"packages/pipeline-cli/src/tools/cp-classify/cp-classify.ts",
+			"packages/pipeline-cli/src/tools/trivial-diff/route.ts",
+			"packages/pipeline-cli/src/tools/review-head/resolve-head.ts",
+		]) {
+			expect(isControlPlane(path)).toBe(true);
+		}
+	});
+
+	it("releases the non-gating tools — coordination + read tooling, and the Tier-3 guards", () => {
+		for (const path of [
+			"packages/pipeline-cli/src/tools/checks/command.ts",
+			"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
+			"packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts",
+			"packages/pipeline-cli/src/tools/spawn-guard/command.ts",
+			"packages/pipeline-cli/src/tools/worktree-guard/command.ts",
+			"packages/pipeline-cli/src/tools/structured-output-guard/command.ts",
+			"packages/pipeline-cli/src/tools/guard-content-probe/command.ts",
+			"packages/pipeline-cli/src/tools/merge-intent/command.ts",
+			"packages/pipeline-cli/src/tools/roadmap/command.ts",
+		]) {
+			expect(isControlPlane(path)).toBe(false);
+		}
+	});
+
+	it("releases the package-root non-src surfaces (package.json, build + test config)", () => {
+		for (const path of [
+			"packages/pipeline-cli/package.json",
+			"packages/pipeline-cli/tsconfig.json",
+			"packages/pipeline-cli/vitest.config.ts",
+			"packages/pipeline-cli/TOOLS.md",
+			"packages/pipeline-cli/README.md",
+		]) {
+			expect(isControlPlane(path)).toBe(false);
+		}
+	});
+
+	it("leaves the independent ^packages/ci-required/ branch byte-unchanged in effect", () => {
+		expect(isControlPlane("packages/ci-required/src/bin.ts")).toBe(true);
+		expect(CONTROL_PLANE_RE).toContain("^packages/ci-required/");
+	});
+});
+
 // Drift guard: the const IS the single source, and the un-importable formats-doc copy the live
 // gates read from origin/main (#981) must stay byte-equal to it. This is the cheap in-test twin
 // of the codeowners-cp + validate-gate-path-drift.sh guards that run unconditionally in CI (#2761).

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -39,6 +39,25 @@
  * plugin's own `plugin.json`, including `claude-plugins/pipeline-crew/`, whose corpus a live
  * founder ruling deliberately keeps OUT of §CP (#3765). See ADR 0212.
  *
+ * The pipeline-cli clauses cover an **enforcement core**, not the whole package (ADR 0218,
+ * amending ADR 0100). Two branches:
+ *
+ *   - `^packages/pipeline-cli/src/[^/]+$` — the package's `src/` ROOT, non-recursive. This is the
+ *     shared dispatch + process plumbing every tool including every gate runs through
+ *     (`registry.ts`, `router.ts`, `bin.ts`, `gate-fail.ts`, `read-stdin*.ts`, `run.ts`,
+ *     `tool-registration.ts`, `module-load-guard.ts`, `annotate.ts`, `find-root-dir.ts`,
+ *     `version.ts`). Expressed as a non-recursive pattern rather than a file list so it cannot rot
+ *     as root modules are added — the four-file list this replaced already lagged reality.
+ *   - `^packages/pipeline-cli/src/tools/(…)/` — the eight tools that ARE the enforcement surface:
+ *     `ci-required` (a branch-protection-required check), `verdict` (the enqueue gate),
+ *     `cp-cardinality` (§CP approval discharge), `control-plane-paths` (this boundary),
+ *     `cp-classify` (the §CP verdict), `codeowners-cp` (the regex↔CODEOWNERS drift gate),
+ *     `trivial-diff` (routes to the lighter gate), `review-head` (the head every verdict binds to).
+ *
+ * Everything else under the package — coordination and read tooling — gates nothing and leaves §CP
+ * per ADR 0187's enforcement-surface test. The trade is recorded in ADR 0218, including the three
+ * modules the core imports without retaining, which `core-import-closure.unit.test.ts` pins.
+ *
  * Anti-self-authorization is preserved (#981): the live merge-deciding gates still
  * re-resolve the boundary from the formats doc on `origin/main` at run time, so a
  * boundary-editing PR is classified against MAIN's boundary, not its own edit. This
@@ -46,4 +65,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^\\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\\.jsonc$|^biome-plugins/";
+	"^(\\.claude|\\.github)/|^\\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^biome\\.jsonc$|^biome-plugins/";

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -40,7 +40,7 @@
  * founder ruling deliberately keeps OUT of §CP (#3765). See ADR 0212.
  *
  * The pipeline-cli clauses cover an **enforcement core**, not the whole package (ADR 0218,
- * amending ADR 0100). Two branches:
+ * amending ADR 0100). Three branches:
  *
  *   - `^packages/pipeline-cli/src/[^/]+$` — the package's `src/` ROOT, non-recursive. This is the
  *     shared dispatch + process plumbing every tool including every gate runs through
@@ -53,6 +53,13 @@
  *     `cp-cardinality` (§CP approval discharge), `control-plane-paths` (this boundary),
  *     `cp-classify` (the §CP verdict), `codeowners-cp` (the regex↔CODEOWNERS drift gate),
  *     `trivial-diff` (routes to the lighter gate), `review-head` (the head every verdict binds to).
+ *   - `^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$` — ONE file, not its directory.
+ *     `gh-io.ts` exports `authorizedAuthors`, the ADR-0055 write+ ACL whose result
+ *     `verdict/github.ts` feeds straight into `resolveVerdict` — so widening it to return every
+ *     author would let a FORGED verdict from a non-collaborator count as a PASS. Retaining the
+ *     verdict resolver while leaving its authorization source ungated is an incoherent line. The
+ *     rest of `tools/tracker/` is claim/coordination tooling and stays out, hence the file-level
+ *     anchor rather than a directory prefix.
  *
  * Everything else under the package — coordination and read tooling — gates nothing and leaves §CP
  * per ADR 0187's enforcement-surface test. The trade is recorded in ADR 0218, including the three
@@ -65,4 +72,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^\\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^biome\\.jsonc$|^biome-plugins/";
+	"^(\\.claude|\\.github)/|^\\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^packages/pipeline-cli/src/tools/tracker/gh-io\\.ts$|^biome\\.jsonc$|^biome-plugins/";

--- a/packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts
@@ -76,14 +76,15 @@ const escapingModules = (): ReadonlyArray<string> => {
 };
 
 /**
- * The ruled residue: modules the retained core imports that the ruled twelve-path core does not
+ * The ruled residue: modules the retained core imports that the ruled thirteen-path core does not
  * retain. Each is recorded in ADR 0218 with its reachability — this is a pin, not an absolution.
+ * `tracker/gh-io.ts` left this list when it was promoted INTO the core; it has no relative imports
+ * of its own, so promoting it pulled nothing new in.
  */
 const ALLOWED_ESCAPES = [
 	"packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts",
 	"packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts",
 	"packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts",
-	"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
 ];
 
 describe("the §CP enforcement core's import closure (ADR 0218)", () => {
@@ -99,5 +100,9 @@ describe("the §CP enforcement core's import closure (ADR 0218)", () => {
 		for (const m of ["read-stdin.ts", "read-stdin-core.ts", "annotate.ts", "find-root-dir.ts"]) {
 			expect(escapingModules()).not.toContain(`packages/pipeline-cli/src/${m}`);
 		}
+	});
+
+	it("no longer escapes through tracker/gh-io.ts — the ADR-0055 ACL is IN the core", () => {
+		expect(escapingModules()).not.toContain("packages/pipeline-cli/src/tools/tracker/gh-io.ts");
 	});
 });

--- a/packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The §CP enforcement core's import-closure check (ADR 0218, AC "transitively import-closed").
+ *
+ * The core is a set of PATHS, but an unreviewed edit reaches a gate through any module the core
+ * IMPORTS — so a path list that isn't import-closed silently leaks the enforcement surface. Prose
+ * closure rots on the next `import` added; this walks the graph instead.
+ *
+ * Two non-obvious rules make the walk meaningful:
+ *
+ *  - **`registry.ts` is a SINK.** It imports every one of the ~68 tools' `command.ts` to build
+ *    `registeredTools[]`, so seeding the walk through it pulls in the whole package (246 modules)
+ *    and the check degenerates to "everything is core" — which proves nothing. The registration
+ *    fan-out is a *listing* edge, not a *behavioral* one: the gate tools do not run through their
+ *    siblings' commands. Cutting it is what makes the closure tractable and honest.
+ *  - **The core is derived from `CONTROL_PLANE_RE`, never re-listed here.** A second copy of the
+ *    path list is exactly the drift #2761 exists to prevent.
+ *
+ * The allowlist below is the ruled boundary's known, bounded residue — not an argument that those
+ * modules are unreachable. Its point is that the set cannot GROW without this test reddening.
+ */
+import {readdirSync, readFileSync, statSync} from "node:fs";
+import {dirname, join, relative, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {CONTROL_PLANE_RE} from "./control-plane-re.ts";
+
+const PKG_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const SRC = join(PKG_ROOT, "src");
+/** Repo-relative, the form `CONTROL_PLANE_RE` matches against. */
+const repoPath = (abs: string): string => `packages/pipeline-cli/${relative(PKG_ROOT, abs)}`;
+
+const CP = new RegExp(CONTROL_PLANE_RE);
+const isCore = (abs: string): boolean => CP.test(repoPath(abs));
+
+const isSource = (f: string): boolean =>
+	f.endsWith(".ts") && !/\.(unit\.test|test|hook\.test)\.ts$/.test(f);
+
+const walkFiles = (dir: string): string[] =>
+	readdirSync(dir).flatMap((entry) => {
+		const p = join(dir, entry);
+		return statSync(p).isDirectory() ? walkFiles(p) : isSource(entry) ? [p] : [];
+	});
+
+/** `registry.ts`'s tool-registration fan-out — a listing edge, not a behavioral one. See the docblock. */
+const SINKS = new Set([join(SRC, "registry.ts")]);
+
+const RELATIVE_IMPORT = /(?:from|import)\s+"(\.[^"]+)"/g;
+
+const importsOf = (abs: string): string[] => {
+	const text = readFileSync(abs, "utf8");
+	const out: string[] = [];
+	for (const m of text.matchAll(RELATIVE_IMPORT)) {
+		const spec = m[1];
+		if (spec !== undefined) out.push(resolve(dirname(abs), spec));
+	}
+	return out;
+};
+
+/** Every in-package module reachable from the retained core, minus the core itself. */
+const escapingModules = (): ReadonlyArray<string> => {
+	const seeds = walkFiles(SRC).filter(isCore);
+	const seen = new Set<string>(seeds);
+	const queue = [...seeds];
+	const escaped = new Set<string>();
+	while (queue.length > 0) {
+		const cur = queue.pop() as string;
+		if (SINKS.has(cur)) continue;
+		for (const dep of importsOf(cur)) {
+			if (seen.has(dep)) continue;
+			seen.add(dep);
+			if (!isCore(dep)) escaped.add(repoPath(dep));
+			queue.push(dep);
+		}
+	}
+	return [...escaped].sort();
+};
+
+/**
+ * The ruled residue: modules the retained core imports that the ruled twelve-path core does not
+ * retain. Each is recorded in ADR 0218 with its reachability — this is a pin, not an absolution.
+ */
+const ALLOWED_ESCAPES = [
+	"packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts",
+	"packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts",
+	"packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts",
+	"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
+];
+
+describe("the §CP enforcement core's import closure (ADR 0218)", () => {
+	it("seeds a non-empty core (zero scope would make the check vacuous — ADR 0092)", () => {
+		expect(walkFiles(SRC).filter(isCore).length).toBeGreaterThan(0);
+	});
+
+	it("reaches exactly the recorded residue — a NEW unclosed import reds this", () => {
+		expect(escapingModules()).toEqual(ALLOWED_ESCAPES);
+	});
+
+	it("keeps the src/ root modules INSIDE the core (the (b) closure fix)", () => {
+		for (const m of ["read-stdin.ts", "read-stdin-core.ts", "annotate.ts", "find-root-dir.ts"]) {
+			expect(escapingModules()).not.toContain(`packages/pipeline-cli/src/${m}`);
+		}
+	});
+});

--- a/packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts
@@ -5,13 +5,21 @@
  * IMPORTS — so a path list that isn't import-closed silently leaks the enforcement surface. Prose
  * closure rots on the next `import` added; this walks the graph instead.
  *
- * Two non-obvious rules make the walk meaningful:
+ * Three non-obvious rules make the walk meaningful:
  *
- *  - **`registry.ts` is a SINK.** It imports every one of the ~68 tools' `command.ts` to build
- *    `registeredTools[]`, so seeding the walk through it pulls in the whole package (246 modules)
- *    and the check degenerates to "everything is core" — which proves nothing. The registration
- *    fan-out is a *listing* edge, not a *behavioral* one: the gate tools do not run through their
- *    siblings' commands. Cutting it is what makes the closure tractable and honest.
+ *  - **The matcher must see DYNAMIC `import()`.** `registry.ts` wires every tool lazily
+ *    (`tool("verdict", () => import("./tools/verdict/command.ts"))`, #4008) — 73 such specifiers.
+ *    A static-only `(?:from|import)\s+"…"` pattern cannot match `import(` at all (the `\s+`
+ *    requires whitespace), so it saw 2 edges there and the walk was blind to every dynamic import
+ *    in the package. A core module that adds `import("./tools/<non-core>/x.ts")` would then be a
+ *    silent escape with this test still green — the exact under-report a mechanized check exists
+ *    to prevent, on the surface that IS the evidence this narrowing is safe.
+ *  - **The registration fan-out is pruned as an EDGE, not a node.** Following it pulls in the whole
+ *    package (250 visited / 212 escapes with no sink at all) and the check degenerates to
+ *    "everything is core" — which proves nothing. The fan-out is a *listing* edge, not a
+ *    *behavioral* one: the gate tools do not run through their siblings' commands. Cutting only
+ *    that one edge out of `registry.ts` — while still following its every other edge — is what
+ *    makes the closure tractable without over-pruning.
  *  - **The core is derived from `CONTROL_PLANE_RE`, never re-listed here.** A second copy of the
  *    path list is exactly the drift #2761 exists to prevent.
  *
@@ -41,17 +49,51 @@ const walkFiles = (dir: string): string[] =>
 		return statSync(p).isDirectory() ? walkFiles(p) : isSource(entry) ? [p] : [];
 	});
 
-/** `registry.ts`'s tool-registration fan-out — a listing edge, not a behavioral one. See the docblock. */
-const SINKS = new Set([join(SRC, "registry.ts")]);
+const REGISTRY = join(SRC, "registry.ts");
+const TOOL_COMMAND = /^packages\/pipeline-cli\/src\/tools\/[^/]+\/command\.ts$/;
 
-const RELATIVE_IMPORT = /(?:from|import)\s+"(\.[^"]+)"/g;
+/**
+ * `registry.ts`'s tool-registration fan-out — a listing edge, not a behavioral one. Scoped to the
+ * EDGE (this one fan-out out of this one module), never to the node: every other edge out of
+ * `registry.ts` is still followed, so the prune cannot hide a real dependency. See the docblock.
+ */
+const isSunkEdge = (from: string, dep: string): boolean =>
+	from === REGISTRY && TOOL_COMMAND.test(repoPath(dep));
+
+/** Static `from "…"` / bare `import "…"`. Both quote styles, so a lint-rule change can't blind it. */
+const STATIC_IMPORT = /(?:from|import)\s+["'](\.[^"']+)["']/g;
+/** Dynamic `import("…")` / `require("…")` — the form the registry actually uses. See the docblock. */
+const DYNAMIC_IMPORT = /\b(?:import|require)\s*\(\s*["'](\.[^"']+)["']/g;
+
+const isFile = (p: string): boolean => {
+	try {
+		return statSync(p).isFile();
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Resolve a relative specifier the way the runtime does: exact path, then `.ts`, then `/index.ts`.
+ * An unresolvable specifier THROWS rather than being skipped — a silently-dropped edge is a silent
+ * escape, which is the failure mode this whole check exists to make impossible.
+ */
+const resolveSpec = (from: string, spec: string): string => {
+	const base = resolve(dirname(from), spec);
+	for (const candidate of [base, `${base}.ts`, join(base, "index.ts")]) {
+		if (isFile(candidate)) return candidate;
+	}
+	throw new Error(`unresolvable relative import "${spec}" from ${repoPath(from)}`);
+};
 
 const importsOf = (abs: string): string[] => {
 	const text = readFileSync(abs, "utf8");
 	const out: string[] = [];
-	for (const m of text.matchAll(RELATIVE_IMPORT)) {
-		const spec = m[1];
-		if (spec !== undefined) out.push(resolve(dirname(abs), spec));
+	for (const pattern of [STATIC_IMPORT, DYNAMIC_IMPORT]) {
+		for (const m of text.matchAll(pattern)) {
+			const spec = m[1];
+			if (spec !== undefined) out.push(resolveSpec(abs, spec));
+		}
 	}
 	return out;
 };
@@ -64,8 +106,8 @@ const escapingModules = (): ReadonlyArray<string> => {
 	const escaped = new Set<string>();
 	while (queue.length > 0) {
 		const cur = queue.pop() as string;
-		if (SINKS.has(cur)) continue;
 		for (const dep of importsOf(cur)) {
+			if (isSunkEdge(cur, dep)) continue;
 			if (seen.has(dep)) continue;
 			seen.add(dep);
 			if (!isCore(dep)) escaped.add(repoPath(dep));
@@ -90,6 +132,23 @@ const ALLOWED_ESCAPES = [
 describe("the §CP enforcement core's import closure (ADR 0218)", () => {
 	it("seeds a non-empty core (zero scope would make the check vacuous — ADR 0092)", () => {
 		expect(walkFiles(SRC).filter(isCore).length).toBeGreaterThan(0);
+	});
+
+	it("sees DYNAMIC import() edges — a static-only matcher silently under-reports", () => {
+		const fanout = importsOf(REGISTRY)
+			.map(repoPath)
+			.filter((d) => TOOL_COMMAND.test(d));
+		expect(fanout.length).toBeGreaterThan(50);
+	});
+
+	it("prunes the registration fan-out as an EDGE, not as a node", () => {
+		// `registry.ts`'s non-fan-out edges are still followed: `tool-registration.ts` is reached
+		// THROUGH it, so a node-scoped sink would have cut a real dependency along with the listing one.
+		expect(importsOf(REGISTRY).map(repoPath)).toContain(
+			"packages/pipeline-cli/src/tool-registration.ts",
+		);
+		expect(isSunkEdge(REGISTRY, join(SRC, "tool-registration.ts"))).toBe(false);
+		expect(isSunkEdge(REGISTRY, join(SRC, "tools/verdict/command.ts"))).toBe(true);
 	});
 
 	it("reaches exactly the recorded residue — a NEW unclosed import reds this", () => {


### PR DESCRIPTION
Narrows the §CP control-plane boundary on `packages/pipeline-cli/` from the blanket
`^packages/pipeline-cli/` clause to an explicit **enforcement core**, so the ~60 non-gating tools
under the package stop banking for a human control-plane merge.

Fixes #4194

## The boundary, before and after

**Before:** one branch, `^packages/pipeline-cli/` — all 68 tools §CP.

**After:** three anchored branches — a **thirteen-path** core.

```
^packages/pipeline-cli/src/[^/]+$
^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/
^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$
```

The first is the `src/` **root, non-recursive** — the shared dispatch and plumbing every tool
including every gate runs through. It replaces the originally-proposed four-file list
(`registry`/`router`/`bin`/`gate-fail`), which **already lagged reality by seven modules the day it
was written**. A pattern is rot-proof by construction: a root module added tomorrow is §CP without
anyone remembering. `codeowners-cp`'s `expandBranch` translates the `[^/]+` class to a gitignore
`*`, so the branch resolves to the §CP path `packages/pipeline-cli/src/*` and a
`/packages/pipeline-cli/src/*` CODEOWNERS row covers it — verified by running
`pipeline-cli control-plane-paths --paths` against this head, not assumed.

The second is the **eight** tools that are themselves the enforcement surface. That is the issue's
original five tool paths **plus three added by founder ruling**: `cp-classify` (renders the §CP
verdict — the only site that can return `not-control-plane`), `trivial-diff` (routes a PR to the
lighter `review-trivial` gate; its bound 3 is literally "Not control-plane"), and `review-head`
(resolves the head every verdict binds to). Measurement showed retaining all three **costs zero
relief over the merge window** — the same ten PRs leave §CP either way.

The third is **one file, not its directory**: `src/tools/tracker/gh-io.ts`. It exports
`authorizedAuthors` (`gh-io.ts:209`), the ADR-0055 write+ ACL, and `verdict/github.ts:214-215`
feeds its result straight into `resolveVerdict` — so an unreviewed edit widening it to return every
author would let a **forged verdict from a non-collaborator count as a PASS**. Retaining the
verdict resolver while leaving its authorization source ungated is an incoherent line. The rest of
`tools/tracker/` is claim/coordination tooling that gates nothing, hence the `$`-anchored file-level
branch rather than a directory prefix. It round-trips through `codeowners-cp`'s `expandBranch` to
the `kind: "file"` §CP path `packages/pipeline-cli/src/tools/tracker/gh-io.ts` — **verified by
reading `pipeline-cli control-plane-paths --paths` at this head**, not by inspection — and is owned
by a literal CODEOWNERS row placed **after** the owner-less `/packages/pipeline-cli/src/tools/` row,
so last-match-wins re-owns it.

In the founder's enumeration that is thirteen paths: four shared-dispatch root modules (carried by
the broader non-recursive `src/[^/]+$` branch), eight enforcement-tool directories, and this one
file.

## Lockstep — all four surfaces, verified in agreement at this head

| Surface | Change |
|---|---|
| `packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts` | the `CONTROL_PLANE_RE` const (single source) + its doc block |
| `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` | the byte-synced `CONTROL_PLANE_RE=` line + the §CP prose around it |
| `.github/CODEOWNERS` | line 49 replaced by one `src/*` row, an owner-less unset row, eight tool rows, and one file row |
| `.decisions/0218-pipeline-cli-cp-enforcement-core.md` | new ADR, amending ADR 0100 |

Verified green on this head:

- `pipeline-cli control-plane-paths --paths` — emits `packages/pipeline-cli/src/tools/tracker/gh-io.ts`, so the file-level branch really resolves to a coverable path
- `pipeline-cli codeowners-cp check` — `all 32 §CP path(s) covered by .github/CODEOWNERS`
- `validate-gate-path-drift.sh` — `OK — 17 checks; CONTROL_PLANE_RE copies and symlink agree`
- `pnpm typecheck` — 29/29 (`TURBO_FORCE=true`, 0 cached)
- `pnpm lint:worktree` — clean
- full `pipeline-cli` suite — 176 files / 2751 tests

**`packages/ci-required/` is byte-unchanged, asserted explicitly.** Line 48 of CODEOWNERS
(`/packages/ci-required/`) is untouched, and the `^packages/ci-required/` regex branch is an
independent alternation branch that this change does not touch. A test pins both.

## Closure demonstration, path by path

"The guards are green" does not discharge this — the guards pass on the narrowed surface by
construction. Each of findings (a)–(d) by name.

### (a) Transitive imports of the retained core — computed, not asserted

`packages/pipeline-cli/src/tools/control-plane-paths/core-import-closure.unit.test.ts` walks the
retained core's import graph and pins every in-package module that escapes.

> **Two non-obvious rules make the walk mean anything.**
>
> **The matcher must see dynamic `import()`.** `registry.ts` wires all 72 tool `command.ts` modules
> lazily (`() => import("./tools/<t>/command.ts")`, #4008). A static-only `(?:from|import)\s+"…"`
> pattern cannot match `import(` at all, so it saw 2 edges there and the walk was blind to every
> dynamic import in the package — a core module later adding `import("./tools/<non-core>/x.ts")`
> would have been a silent escape with the check still green. The matcher now covers static
> `from`/`import`, dynamic `import(`/`require(`, and both quote styles, with extension +
> `index.ts` resolution and a fail-loud throw on an unresolvable specifier.
>
> **The registration fan-out is cut as an EDGE, not as a node.** Following it reaches 250 modules
> (211 escapes) and the check degenerates to "everything is core" — vacuously true. The fan-out is
> a *listing* edge, not a behavioral one, so only that one edge out of `registry.ts` is pruned;
> every other edge out of it is still followed. Any future closure check must cut it the same way.

With the `src/` root retained, the escapes collapse from eleven to four; **promoting
`tracker/gh-io.ts` into the core takes it to three.** That promotion was re-derived, not assumed —
`gh-io.ts` imports only `effect`, no in-package module, so retaining it pulled nothing new into the
closure and surfaced no new escapes. The three left are retained as a **recorded residue, not argued
unreachable**:

| Escaping module | Reached from | Honest reachability |
|---|---|---|
| `src/tools/guard-content-probe/guard-content-probe.ts` | `trivial-diff/trivial-diff.ts`, `trivial-diff/command.ts` | The **ADR-0164 §CP-by-content predicate** — the second §CP boundary definition. Weakening it makes a guard-relaxing ADR read as non-§CP to `trivial-diff`. **Surfaced by the mechanical check, not by the hand analysis**, which had it as a second-order surface. |
| `src/tools/leak-guard/leak-guard.ts` | `verdict/verdict-match.ts` (`findCommentLeaks`) | Feeds `emissionDefect`, the verdict-emission path-leak check. Admits a leaking verdict body; does not flip a PASS/FAIL. |
| `src/tools/leak-guard/path-matcher.ts` | `leak-guard.ts` | Same surface, one hop further. |

`src/tools/tracker/gh-io.ts` was the fourth and sharpest of the measured escapes — the one that
could flip a PASS/FAIL rather than merely degrade a report — and is now **in the core** (see the
third branch above) instead of on this list.

The allowlist exists so the set **cannot grow silently** — a new unclosed import from the core reds
the check. `guard-content-probe` remains a live candidate for a follow-up widening; nothing here
argues it is safe.

### (b) Shared root modules beyond the four listed

`tool-registration.ts`, `run.ts`, `index.ts`, `module-load-guard.ts`, `version.ts`,
`read-stdin.ts`, `read-stdin-core.ts` — plus `annotate.ts` and `find-root-dir.ts`, which the
issue's list missed. **Closed by retention**: `src/[^/]+$` covers all of them and every future root
module. A test enumerates them.

### (c) `package.json` and the build/test configs

`packages/pipeline-cli/package.json`, `tsconfig*.json`, `vitest.config.ts` leave §CP. **Not argued
unreachable in principle** — `package.json` declares the binary `ci-required` and `cp-cardinality`
are invoked as. They are left out because a different, non-discretionary control covers them:
`catalog-guard` fails closed on any non-`catalog:` version, and a config edit that breaks a gate's
build reds `ci-required` directly rather than passing silently. CI enforcement, consistent with the
ruling's premise.

### (d) Second-order gate surfaces

`checks`, `merge-intent`, `merge-queue-classify`, `class-probe`, `redact-leaks`,
`path-filter-guard`, `change-detect-guard` leave §CP. They are invoked as separate processes by
skills and workflows, not imported by the core, and each runs in CI on every PR.
`guard-content-probe` was on this list and turned out to be a **hard import edge** — handled in (a).
That promotion is the concrete reason a mechanical check beats prose here.

## Branch protection — the consequence, stated plainly

Read first-hand for this PR (triage flagged it unverified): ruleset `17377992`, "main protection",
`active`.

```
required_approving_review_count: 0
require_code_owner_review:       true
dismiss_stale_reviews_on_push:   true
```

With `required_approving_review_count: 0`, CODEOWNERS is the **only** source of a required human
approval. Removing a path from CODEOWNERS removes **all** required human review of it — not merely
the §CP flavor. **There is no residual review floor.** Everything leaving §CP here is CI-enforced,
full stop. That includes the Tier-3 guards ADR 0100 named by name: `leak-guard`, `spawn-guard`,
`structured-output-guard`, `worktree-guard`, `read-guard`.

Related: **`codeowners-cp` detects under-protection only.** It flags a §CP regex path with no
CODEOWNERS row, but **never** a CODEOWNERS row broader than the regex. Leaving the old
`/packages/pipeline-cli/` row in place would not have redded any gate — the lockstep narrowing was
an author obligation, not a gate-enforced one. A test now pins that asymmetry so it is not
rediscovered.

## Relief — the honest number

Over the merge window 2026-07-25 → 2026-07-26: **10 merges** newly auto-ship under this core.

Not the 19/42 or 23/58 clause-attributable figure — that is the set of PRs §CP *only* via the
`pipeline-cli` clause, which is a different thing: the remainder touch a retained core path and keep
banking.

## ADR 0218 amends ADR 0100 on two distinct counts

1. Its 2026-06-20 amendment **explicitly considered and rejected** this sub-path split ("The whole
   package matches, not a `src/guards/` sub-prefix"). Its reasoning — the shared dispatch lives at
   the package root — is correct and is **honored** by the `src/[^/]+$` branch; what is amended is
   the conclusion that honoring it requires swallowing the whole package.
2. Its **primary decision** named `leak-guard` / `spawn-guard` / `structured-output-guard` /
   `worktree-guard` / `read-guard` as §CP by name. Under this core they all leave. This removes
   coverage 0100 granted **explicitly**, not incidentally.

ADR 0100 is not left reading as accepted law that this change contradicts.

## Tests

New/updated, and **each was run red against today's blanket regex** before being made green
(regex temporarily reverted in-place, tests run, restored — **11 failures / 45 passing** at the
current head; the earlier "4 failures" in this body understated its own tests):

- `control-plane-paths.unit.test.ts` — five new cases covering both directions: the `src/` root
  stays §CP (including the modules a four-file list would miss), all eight core tools stay §CP
  (the three newly-retained ones called out by name), the non-gating tools and Tier-3 guards are
  now ordinary, the package-root non-`src` surfaces are now ordinary, and `ci-required` is
  unchanged.
- `core-import-closure.unit.test.ts` — new; the mechanical closure walk, its zero-scope guard, the
  residue pin, plus (repair round 2) a case asserting the walk sees the dynamic-`import()` fan-out
  and a case asserting the fan-out prune is edge-scoped, not node-scoped. Both were run red against
  a static-only matcher / a node-scoped sink before being made green.
- `codeowners-cp.unit.test.ts` — fixtures updated in the same commit (the #2673 class: a stale
  fixture that only runs in `merge_group` ejects green PRs), plus a new case asserting the
  over-broad-row blind spot.
- The `gh-io.ts` promotion adds three more: `control-plane-paths.unit.test.ts` asserts it is §CP
  **and** that the anchor is genuinely file-level (siblings, a `.unit.test.ts` look-alike, and a
  nested same-named file all stay out); `codeowners-cp.unit.test.ts` asserts the branch expands to
  `kind: "file"` and that removing its CODEOWNERS row is the one uncovered path;
  `core-import-closure.unit.test.ts` asserts it no longer appears in the escape set.

## Deviations

**(repair round 1)** The founder ruling that added `tracker/gh-io.ts` to the core **widens the
retained surface beyond issue #4194's acceptance criteria**, which named that module only as an
escape to be *justified in the ADR* (criterion (a)). It is retained instead. This is the
conservative direction — more stays under human review, not less — and it is recorded in ADR 0218
§3 rather than left as an undisclosed widening.

**(repair round 2)** ADR 0100's discharge uses the **frontmatter** convention
(`status: amended-in-part by [0218](…)`, the form `.decisions/0115-…` uses) rather than the
in-body `Amended by ADR NNNN` blockquote 0100 itself carries for ADR 0103. Both are established
in-repo idioms; the frontmatter form was chosen because the defect the review named is that 0100
"still reads `status: accepted`", and the frontmatter is the surface `decisions-index` renders.
0100's body is untouched.

**(repair round 2)** Rebased onto `main` (`3c3a63bb`), resolving a conflict in
`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` against #4229, which rewrote the
same §CP region. #4229's property is preserved verbatim — a failed changed-file read still resolves
to **§CP UNKNOWN, never "not control plane"** (`cp_changed_files` + the three-branch `if`); only
the `CONTROL_PLANE_RE` value is this PR's. `validate-gate-path-drift.sh` re-confirms the line is
byte-identical to the const post-merge.

## Sequencing

~~This PR is deliberately **parked behind #4251**.~~ **Stale — #4251 is closed** as a duplicate of
#4253, and its closing analysis ruled the sequencing argument does not hold ("unpark #4194"). The
underlying gap is real but pre-existing and unchanged by this PR: `codeowners-cp.yml` still
declares `on: pull_request:` with no `merge_group` trigger, and ADR 0132 fences that workflow off
by name. The one residual precaution stands: **keep this PR's queue entry alone** — nothing checks
the `CONTROL_PLANE_RE` ↔ CODEOWNERS pair across a speculative batch.

The PR is itself §CP by the *pre-narrowing* boundary (the live gates re-resolve `CONTROL_PLANE_RE`
from `origin/main`, #981), so it banks for a human control-plane approval. That is expected and is
the anti-self-authorization property working: one approval to remove many, and the narrowing cannot
authorize itself.

## Follow-on, out of scope

Extend the `origin/main` re-resolution idiom (#981, `control-plane-re.ts` lines ~42-46) to
`cp-cardinality` and `ci-required`, so a weakened local copy cannot take effect. Recorded in ADR
0218's consequences; belongs to #4195 or its own issue.


