### PR TITLE
[SCRATCH-DELETE] codeowners proof D: released tool vs base=main (pre-narrowing)

### DIFF
--- a/packages/pipeline-cli/src/tools/catalog-guard/CP-PROOF.txt
+++ b/packages/pipeline-cli/src/tools/catalog-guard/CP-PROOF.txt
@@ -1,0 +1,1 @@
+scratch


### PR DESCRIPTION
Throwaway probe for the CODEOWNERS owner-less-line proof on #4258. Will be closed immediately.