### PR TITLE
[SCRATCH-DELETE] codeowners proof D2: released tool vs base=main (pre-narrowing)

### DIFF
--- a/packages/pipeline-cli/src/tools/catalog-guard/CP-PROOF.txt
+++ b/packages/pipeline-cli/src/tools/catalog-guard/CP-PROOF.txt
@@ -1,0 +1,1 @@
+scratch


### PR DESCRIPTION
Throwaway probe for the CODEOWNERS proof on #4258. Closed immediately.