### PR TITLE
fix(triage): price priority on merit — a roadmap row confers no band (#4284)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -70,14 +70,17 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **Classify into exactly ONE type.** Follow the skill's type taxonomy and pick a single
   `type:*` label; resolve the decision-vs-epic / feature-vs-epic boundaries by the
   skill's rules. One issue, one type.
-- **Prioritize milestone-relative — the default is `p2`, not `p1`.** Follow the skill's
-  priority rubric exactly: `p1` means "serves an active milestone / you'd pull it next"
-  (bounded to an `active` `## Arcs` **or** `## Campaigns` row of `ROADMAP.md` — an active
-  campaign confers `p1` exactly as the active arc does, and an issue homed in neither is
-  *not* `p1`; it is never a general "worth doing soon" tier — ADR 0214), `p2` is the
-  **default** for real, actionable work that isn't the current focus (most of the
-  backlog), and `p0` is fire only. Do not treat the middle bucket as the catch-all — an
-  inflated `p1` is what makes the backlog unsequenceable.
+- **Prioritize on merit — the default is `p2`, not `p1`.** Follow the skill's priority
+  rubric exactly: price the work on its own worth — value shipped, or ship-rate raised
+  (ADR 0202 §1) — never on where it is homed. An `active` `## Arcs` or `## Campaigns` row
+  of `ROADMAP.md` confers **no** band: membership is neither necessary nor sufficient for
+  any band, `p0` included, and product work in no campaign may outrank factory work in one
+  (ADR 0219, superseding 0214; it restores ADR 0072's "p0 stays sovereign"). So `p1` means
+  "you'd pull it next" on merit and is never a general "worth doing soon" tier, `p2` is the
+  **default** for real, actionable work you would not pull next (most of the backlog), and
+  `p0` is ship-work and fires. Homing is a **separate, unchanged** requirement — every
+  triaged issue still leaves with a home. Do not treat the middle bucket as the catch-all —
+  an inflated `p1` is what makes the backlog unsequenceable.
 - **Classify only — never chain into plan-epic.** When you type an issue `type:epic`,
   you classify and stop. You do **not** run plan-epic, draft a ledger, or spawn children
   — routing a triaged epic to the planner is the executor's job, not yours. Likewise you

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -572,31 +572,37 @@ one of them** — home, exempt, or kill:
 Every triaged issue gets exactly one of `p0` / `p1` / `p2`. Priority is *your*
 judgment, deliberately coarse — it sets write-code's pick order (highest bucket first,
 oldest first within a bucket), so it only has to be *directionally* right, not a precise
-ranking. Priority is **milestone-relative**, not an absolute urgency score: `p1` means
-"serves an active milestone / you'd pull it next," so it stays naturally bounded by the
-active arc and campaigns instead of becoming the catch-all. The **default is `p2`** — most
-real work isn't the current focus.
+ranking. Priority is assigned **on the work's own merit** — what the work is worth
+against everything else on the board: value shipped, or ship-rate raised (ADR
+[0202](https://github.com/kamp-us/phoenix/blob/main/.decisions/0202-forward-motion-doctrine-crewops.md) §1).
+The **default is `p2`** — most real work isn't worth pulling ahead of what's already in
+flight.
 
-The **active milestone is not a judgment call**: it is any row marked `active` in
-[`ROADMAP.md`](../../../../ROADMAP.md)'s `## Arcs` **or** `## Campaigns` table — the
-founder-voice roadmap that projects each arc/campaign onto a GitHub milestone (ADR
-[0078](https://github.com/kamp-us/phoenix/blob/main/.decisions/0078-product-driven-decisions-by-default.md);
-exactly one arc is `active` at a time, alongside any number of active campaigns). An active
-campaign confers a `p1` band exactly as the active arc does — campaigns are milestone-backed
-pushes that run *concurrently* with the arc, so both are `p1` homes (ADR
-[0214](https://github.com/kamp-us/phoenix/blob/main/.decisions/0214-active-campaign-confers-p1.md)).
-Read those rows to know what `p1` is bounded to. A `done` or `queued` row confers nothing.
-If no row in either table is marked `active`, there is no active milestone and the
-fallbacks below apply.
+**A roadmap row confers no band, in either direction.** An `active` row of
+[`ROADMAP.md`](../../../../ROADMAP.md)'s `## Arcs` or `## Campaigns` table says where work
+*lives*, not what it is *worth*: campaign membership is neither necessary nor sufficient
+for any band, `p0` included, and product work homed in no campaign may outrank factory
+work homed in one (ADR
+[0219](https://github.com/kamp-us/phoenix/blob/main/.decisions/0219-priority-decoupled-from-campaign-membership.md),
+superseding 0214). So never argue a band from a roadmap row, never cap campaign-homed work
+at `p1`, and never floor-gate a band on membership. This restores ADR
+[0072](https://github.com/kamp-us/phoenix/blob/main/.decisions/0072-milestones-encode-strategic-sequencing.md)'s
+**p0 stays sovereign**: campaign bias is a within-bucket tiebreaker for write-code's
+*picker*, never a re-ordering of the bands themselves.
+
+**Homing is a separate requirement and is unchanged.** Every issue you mark
+`status:triaged` still leaves with a home —
+[Assign a home](#assign-a-home--milestone-standing-lane-or-kill-required), next section.
+ADR 0219 changes what priority *means*; it changes nothing about what needs a home.
 
 | Priority | Use when… |
 |---|---|
-| **`p0`** | **Ship-work and fires — and it is never homeless.** Mint `p0` **freely** for work that moves us forward: shipped user/revenue value, or work that directly raises ship-rate (ADR 0202 §1). Fires still qualify — actively breaking something people rely on, a data-loss or security risk, a release gate. The one hard bound is homing: **a `p0` belongs to the active arc's documented structure, so an orphan (un-homed) `p0` is invalid** (ADR 0202 §2). If you can't home it below, it isn't `p0`. |
-| **`p1`** | **Serves an active milestone** — an `active` row of `ROADMAP.md`'s `## Arcs` **or** `## Campaigns` table (defined just above). Real, actionable work that belongs to that active arc or campaign — you'd pull it next. Milestone-bounded on purpose: p1 is *not* a general "worth doing soon" tier, so a solid issue homed in neither an active arc nor an active campaign is **not** p1. If no row in either table is marked `active`, keep p1 for the small set of things you'd genuinely pick up next; everything else is p2. |
-| **`p2`** | **The default.** Real, actionable work that isn't the current focus — most of the backlog. Also nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure to pull it ahead of the active arc or campaigns. |
+| **`p0`** | **Ship-work and fires — and it is never homeless.** Mint `p0` **freely** for work that moves us forward: shipped user/revenue value, or work that directly raises ship-rate (ADR 0202 §1). Fires still qualify — actively breaking something people rely on, a data-loss or security risk, a release gate. The one hard bound is homing: **an orphan (un-homed) `p0` is invalid** (ADR 0202 §2, as amended in part by ADR 0219 — any milestone or standing lane satisfies it, not only the active arc's structure). If you can't home it below, it isn't `p0`. |
+| **`p1`** | **You'd pull it next.** Real, actionable work whose value you would argue for ahead of the rest of the backlog — that judgment *is* the test, not a proxy for one. `p1` is a claim about worth, not a general "worth doing soon" tier and not a restatement of the milestone column: an issue in no active milestone can be `p1`, and an issue in an active campaign is not `p1` by that fact. Keep the set small enough that "next" still means something. |
+| **`p2`** | **The default.** Real, actionable work you would not pull next — most of the backlog. Also nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no case for jumping the queue. |
 
-Most of a healthy backlog is `p2`, with a bounded `p1` set tracking the active
-milestones. When unsure between `p1` and `p2`, pick the lower one — over-escalation erodes
+Most of a healthy backlog is `p2`, with a small `p1` set you could genuinely pick up
+next. When unsure between `p1` and `p2`, pick the lower one — over-escalation erodes
 the signal faster than under-escalation, and an inflated `p1` is exactly what makes the
 backlog unsequenceable.
 


### PR DESCRIPTION
Triage used to hand an issue a `p1` just for living in an active roadmap arc or campaign. That made the priority column a restatement of the milestone column, so factory work inherited a band while product work outside every campaign could never rise. This PR rewrites the rule in both places it is taught: priority is now argued from the work's own worth, and a roadmap row confers nothing either way. What needs a home is completely unchanged.

Fixes #4284

## What changed

Two carriers, moved together — fixing only one leaves the other teaching the withdrawn rule, and the agent definition is what a spawned triager actually loads:

- **`claude-plugins/kampus-pipeline/skills/triage/SKILL.md`** — the rubric under `### Assign a priority` (anchored on the heading; the "Step 6" numbering has drifted). The conferral paragraph is replaced by a merit rule plus an explicit "a roadmap row confers no band, in either direction" statement. The `p1` table row no longer reads **Serves an active milestone**; its operative test is now *"you'd pull it next"* on merit — stated as **the** test rather than left as a second gate alongside a membership test, which is what #4187 asked to be settled. The `p0` row's homing bound keeps its no-orphan rule and drops the active-arc restriction (ADR 0202 §2 as amended in part by 0219).
- **`claude-plugins/kampus-pipeline/agents/triager.md`** — the priority bullet, which restated the same conferral independently, now carries the same merit rule and the same "homing is separate and unchanged" note.

Both cite ADR 0219 in place of 0214, and name ADR 0072's *"p0 stays sovereign"* as the older grounding 0219 restores rather than invents.

## Sequencing — my ruling, and what I need from the merger

**Hold this merge until PR #4286 (ADR 0219) lands. Merge #4286 first, then this.**

Verified live on `origin/main` at the time of writing: the highest ADR present is `0218`; there is no `.decisions/0219-*`. ADR 0219 exists only on #4286's head.

The tension the intake desk flagged is real in both directions, so here is the reasoning rather than an assumption:

- **Landing this first** makes a control-plane skill and a control-plane agent definition cite an ADR that is not law and whose file does not exist — two dangling `.decisions/0219-…` links in the plugin corpus. That is precisely the stale-citation class this repo keeps filing bugs about (#4227, #4249, #4260, #4120), and it would be self-inflicted rather than discovered.
- **Landing this after** leaves a window in which triage keeps pricing under the withdrawn rule. That window is real but small and bounded: #4286 is already gated-PASS and banked, so it is minutes-to-hours ahead of this PR, not days. Nothing in that window is unrecoverable — ADR 0219 states explicitly that no repricing sweep is owed.
- **A hedge — citing only 0072 and naming 0219 as pending — was considered and rejected.** It would satisfy the letter of "correct either way" but produce prose that hedges about which rule governs, in the one document whose job is to state the rule flatly. It also fails the issue's acceptance criterion that both carriers cite 0219 in place of 0214.

So the text is written for the post-#4286 world, and the ordering constraint moves to the merge queue where it costs one decision instead of living in the prose forever. The substance is defensible under today's `main` too: ADR 0072 (already law) says *"campaign bias is a within-bucket tiebreaker … not a re-ordering of p0 work"* — 0214 inverted that, and this rewrite restores it. Only the **citations** need #4286 to have landed.

**Reviewer, please check:** that `.decisions/0219-priority-decoupled-from-campaign-membership.md` is on `origin/main` before this merges. If it is not, that is an ordering problem, not a content problem.

## Control-plane routing

Re-resolved live against current `origin/main`, not inherited from the triage pass (`CONTROL_PLANE_RE` was narrowed by #4258 shortly beforehand):

```
pipeline-cli cp-classify classify --files-file <run-scratch>/files.txt --repo kamp-us/phoenix
cp-classify: control-plane [path-match] — claude-plugins/kampus-pipeline/skills/triage/SKILL.md matches the live CONTROL_PLANE_RE. BLOCKING (human merge).
control-plane
```

State word: **`control-plane`**. Exit code: **0**. (Exit 3 is the proven-ordinary verdict under the repaired probe; this run never reached it, and exit 1 is the pre-#4255 value that no longer means anything here.) This PR banks for control-plane approval.

## Out of scope, deliberately

- `ROADMAP.md` line 11 (*"priority is relative to it (`p1` = current arc)"*) is untouched. Founder-voice, revised on the conversation-authored path (ADR 0075); 0219 governs in the interim.
- `homing-guard`, `EXEMPT_LABELS`, and every other guard: untouched. No guard code is in this diff.
- No repricing sweep of already-triaged issues.

## Verification

- `pnpm typecheck` — 29/29 tasks green.
- `pnpm lint:worktree` — clean skip (markdown-only diff, no biome-handled files).
- `git grep` over `claude-plugins/` confirms no remaining "Serves an active milestone" criterion, and that `0214` now survives only inside the phrase "superseding 0214" — never as the authority for a rule.

## Deviations

**1. Class: sequencing / deferred landing.** *Said:* the issue's first acceptance criterion is a hard gate — ADR 0219 must be on `origin/main` with `status: accepted` **before any edit is made**, and otherwise "leave this issue untouched." *Did:* implemented the rewrite while 0219 is still unmerged on PR #4286, and moved the gate from "before the edit" to "before the merge." *Why:* the dispatching lane explicitly re-opened this as my call and asked that whoever reads both files at the live tip rule on it; the gate's purpose is that no carrier ever cites a non-existent ADR, and enforcing it at merge time serves that purpose exactly while removing the window in which triage keeps minting priorities under the withdrawn rule. *Disposition:* **for the reviewer to judge** — the ordering requirement is stated above and in the report back to the dispatcher, who has said they will hold the merge.

**2. Class: scope narrowed relative to a suggestion in the issue.** *Said:* the issue's near-duplicate note observes that #4287 covers the same unit and is superseded by #4284. *Did:* did not touch, close, or comment on #4287. *Why:* it is a cross-issue write this run holds no pre-authorization for. *Disposition:* **reported to the dispatcher** — #4287 still needs closing as a duplicate of #4284 by whoever holds that authority.

**3. Class: prose beyond the literal ask.** *Said:* the acceptance criteria require the homing text be *untouched*. *Did:* left the `### Assign a home` section byte-identical, but **added** a short paragraph in the priority section stating that homing is a separate, unchanged requirement. *Why:* removing the conferral removes the only sentence linking the two, and without the note a reader can easily read "a roadmap row confers nothing" as a weakening of homing — the exact misreading ADR 0219 warns against. *Disposition:* no action needed; it adds no requirement and changes no guard.
