### PR TITLE
fix(pipeline-cli): gh-phoenix resolveRepo refuses instead of defaulting to a repo literal (#4270)

### DIFF
--- a/packages/pipeline-cli/src/tools/gh-phoenix/bin.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/bin.test.ts
@@ -14,9 +14,18 @@ interface RunResult {
 	readonly stderr: string;
 }
 
+// An explicit `undefined` UNSETS the key for the child (rather than passing the string
+// "undefined") — the only way to test the repo-resolution refusal on a machine or CI runner
+// that already exports CLAUDE_PIPELINE_REPO / GITHUB_REPOSITORY.
+const childEnv = (env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
+	const merged: NodeJS.ProcessEnv = {...process.env, ...env};
+	for (const key of Object.keys(merged)) if (merged[key] === undefined) delete merged[key];
+	return merged;
+};
+
 const run = (args: ReadonlyArray<string>, env?: NodeJS.ProcessEnv): Promise<RunResult> =>
 	new Promise((resolve) => {
-		execFile("node", [BIN, ...args], {env: {...process.env, ...env}}, (error, stdout, stderr) => {
+		execFile("node", [BIN, ...args], {env: childEnv(env)}, (error, stdout, stderr) => {
 			const code =
 				error && typeof (error as {code?: unknown}).code === "number"
 					? (error as {code: number}).code
@@ -119,5 +128,33 @@ describe("gh shim — routes via the real gh stub", {timeout: SUBPROCESS_TEST_TI
 		assert.strictEqual(code, 1);
 		assert.include(stderr, "blocked");
 		assert.include(stderr, "REST");
+	});
+
+	// #4270: with every repo tier unset, the fake `gh repo view` answers "FAKE_GH repo view …",
+	// which is not an `owner/name` slug — so resolution genuinely fails.
+	const unresolvedRepoEnv = () => ({
+		...shimEnv(),
+		CLAUDE_PIPELINE_REPO: undefined,
+		GITHUB_REPOSITORY: undefined,
+	});
+
+	it("refuses `gh pr edit` when no repo resolves — never PATCHes a defaulted repo", async () => {
+		const {code, stdout, stderr} = await run(
+			["pr", "edit", "42", "--body", "hello"],
+			unresolvedRepoEnv(),
+		);
+		assert.strictEqual(code, 1);
+		assert.include(stderr, "CLAUDE_PIPELINE_REPO");
+		// the real `gh` was never reached, so no PATCH was forwarded anywhere
+		assert.notInclude(stdout, "FAKE_GH");
+	});
+
+	it("still passes a repo-less `gh api` call through when no repo resolves", async () => {
+		const {code, stdout} = await run(
+			["api", "repos/other-owner/other-repo/issues/1"],
+			unresolvedRepoEnv(),
+		);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "FAKE_GH api repos/other-owner/other-repo/issues/1");
 	});
 });

--- a/packages/pipeline-cli/src/tools/gh-phoenix/bin.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/bin.ts
@@ -42,6 +42,9 @@ const ZERO_SCOPE_EXIT_CODE = 3;
  */
 const runShim = (argv: ReadonlyArray<string>): never => {
 	const realGh = resolveRealGh();
+	// An unresolved repo (null) is carried into the router rather than refused here: only the
+	// REST-rewrite paths need a repo, so the router refuses exactly those (as a `block`, printed
+	// and exited non-zero below) and leaves a repo-less passthrough working (#4270).
 	const repo = resolveRepo(realGh);
 	const decision = route(argv, {repo, bodyFileExists: fileExists});
 

--- a/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
@@ -9,7 +9,8 @@
  * self-recursion guard that keeps the shim from execing itself. `self` is
  * injectable (default `selfPath`) so the self-skip is testable independent of the
  * runtime's `argv[1]`. `resolveRepo` resolves the repo the REST rewrites target:
- * `$CLAUDE_PIPELINE_REPO`, else `gh repo view`, else the phoenix default.
+ * `$CLAUDE_PIPELINE_REPO`, else `$GITHUB_REPOSITORY`, else `gh repo view` — and
+ * `null` when none of them resolves.
  *
  * **Exempt from the epic #3462 `@effect/platform` sweep, adjudicated in #3934.** The raw
  * `node:fs` / `node:path` here is the bin-boundary case of
@@ -76,20 +77,31 @@ export const resolveRealGh = (self: string = selfPath): string | null => {
 	return null;
 };
 
-/** Resolve `$CLAUDE_PIPELINE_REPO` or `gh repo view` — the repo the REST rewrites target. */
-export const resolveRepo = (realGh: string | null): string => {
-	const fromEnv = process.env.CLAUDE_PIPELINE_REPO;
-	if (fromEnv && fromEnv.length > 0) return fromEnv;
+/** A well-formed `owner/name` slug — the shape every REST rewrite path is built from. */
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the repo the REST rewrites target, per ADR 0062 §1: `$CLAUDE_PIPELINE_REPO`,
+ * else `$GITHUB_REPOSITORY` (the CI tier every sibling resolver in this package carries),
+ * else `gh repo view`. **Returns `null` when none of them resolves** — an unresolved repo
+ * is a value the caller must handle, never a default. A repo literal here turned a
+ * resolution failure into a confident wrong target: a foreign repo's `gh pr edit <N>`
+ * became a `PATCH` against whatever issue held that number in *this* repo (#4270).
+ */
+export const resolveRepo = (realGh: string | null): string | null => {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) return fromEnv.trim();
 	if (realGh) {
 		try {
-			return execFileSync(
+			const viewed = execFileSync(
 				realGh,
 				["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
 				{encoding: "utf8"},
 			).trim();
+			if (REPO_RE.test(viewed)) return viewed;
 		} catch {
-			/* fall through */
+			/* unresolved — fall through */
 		}
 	}
-	return "kamp-us/phoenix";
+	return null;
 };

--- a/packages/pipeline-cli/src/tools/gh-phoenix/resolve.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/resolve.unit.test.ts
@@ -21,7 +21,12 @@ import {afterAll, afterEach, assert, beforeAll, describe, it} from "@effect/vite
 import {resolveRealGh, resolveRepo} from "./resolve.ts";
 
 let root: string;
-const ENV_KEYS = ["PATH", "GH_PHOENIX_REAL_GH", "CLAUDE_PIPELINE_REPO"] as const;
+const ENV_KEYS = [
+	"PATH",
+	"GH_PHOENIX_REAL_GH",
+	"CLAUDE_PIPELINE_REPO",
+	"GITHUB_REPOSITORY",
+] as const;
 let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
 
 const mkExecutable = (dir: string, name = "gh"): string => {
@@ -46,7 +51,12 @@ afterEach(() => {
 });
 
 const setEnv = (env: Partial<Record<(typeof ENV_KEYS)[number], string>>) => {
-	saved = {PATH: undefined, GH_PHOENIX_REAL_GH: undefined, CLAUDE_PIPELINE_REPO: undefined};
+	saved = {
+		PATH: undefined,
+		GH_PHOENIX_REAL_GH: undefined,
+		CLAUDE_PIPELINE_REPO: undefined,
+		GITHUB_REPOSITORY: undefined,
+	};
 	for (const key of ENV_KEYS) {
 		saved[key] = process.env[key];
 		delete process.env[key];
@@ -120,14 +130,38 @@ describe("resolveRealGh — self-recursion guard + PATH fallbacks over a fake FS
 	});
 });
 
-describe("resolveRepo — env override + no-real-`gh` fallback", () => {
+describe("resolveRepo — tiered resolution, unresolved is null (never a repo literal, #4270)", () => {
 	it("$CLAUDE_PIPELINE_REPO wins, never shelling `gh repo view`", () => {
 		setEnv({CLAUDE_PIPELINE_REPO: "owner/repo"});
 		assert.strictEqual(resolveRepo(null), "owner/repo");
 	});
 
-	it("falls back to the phoenix default when no env and no real `gh`", () => {
+	it("$CLAUDE_PIPELINE_REPO outranks the $GITHUB_REPOSITORY CI tier", () => {
+		setEnv({CLAUDE_PIPELINE_REPO: "owner/override", GITHUB_REPOSITORY: "ci/repo"});
+		assert.strictEqual(resolveRepo(null), "owner/override");
+	});
+
+	it("$GITHUB_REPOSITORY resolves when the explicit override is unset (the CI tier)", () => {
+		setEnv({GITHUB_REPOSITORY: "ci/repo"});
+		assert.strictEqual(resolveRepo(null), "ci/repo");
+	});
+
+	it("returns null when no env and no real `gh` — the refusal path", () => {
 		setEnv({});
-		assert.strictEqual(resolveRepo(null), "kamp-us/phoenix");
+		assert.strictEqual(resolveRepo(null), null);
+	});
+
+	it("returns null when a real `gh` answers with something that is not `owner/name`", () => {
+		// the fake `gh` echoes "fake", which no REST path can be built from — unresolved, not a
+		// default, so the caller refuses instead of PATCHing a repo nobody named.
+		const dir = mkdtempSync(join(root, "case-bad-view-"));
+		const gh = mkExecutable(join(dir, "bin"));
+		setEnv({});
+		assert.strictEqual(resolveRepo(gh), null);
+	});
+
+	it("returns null on a malformed env value rather than building a bogus REST path", () => {
+		setEnv({CLAUDE_PIPELINE_REPO: "not-a-slug"});
+		assert.strictEqual(resolveRepo(null), null);
 	});
 });

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
@@ -97,13 +97,15 @@ export const isMilestoneTitle = (value: string): boolean => !/^\d+$/.test(value.
 /**
  * The pure routing decision over a `gh` argv (the vector AFTER the `gh` binary
  * name — i.e. `process.argv.slice(2)` for the shim). `repo` is the resolved
- * `owner/name` the REST rewrites target; `bodyFileExists` reports whether a
+ * `owner/name` the REST rewrites target, or `null` when resolution failed — only the
+ * rewrite paths that must name a repo refuse on `null`, so an unresolved repo never
+ * costs a passthrough that needs none. `bodyFileExists` reports whether a
  * `--body-file <path>` argument names an existing readable file (the IO is done
  * by the caller and handed in, keeping this core pure).
  */
 export const route = (
 	argv: ReadonlyArray<string>,
-	opts: {readonly repo: string; readonly bodyFileExists?: (path: string) => boolean},
+	opts: {readonly repo: string | null; readonly bodyFileExists?: (path: string) => boolean},
 ): GhRoute => {
 	const bodyFileExists = opts.bodyFileExists ?? (() => true);
 	const [verb, sub, ...rest] = argv;
@@ -138,9 +140,20 @@ export const route = (
 const routeEdit = (
 	verb: string,
 	rest: ReadonlyArray<string>,
-	repo: string,
+	repo: string | null,
 	bodyFileExists: (path: string) => boolean,
 ): GhRoute => {
+	// The rewrite target is `repos/<repo>/issues/<N>`, so an unresolved repo has no honest
+	// value to substitute — refuse. Defaulting to any slug aims the PATCH at a repository
+	// the caller never named (#4270).
+	if (repo === null) {
+		return {
+			kind: "block",
+			reason: `\`gh ${verb} edit\` needs a target repository and none resolved — $CLAUDE_PIPELINE_REPO and $GITHUB_REPOSITORY are unset (or malformed) and \`gh repo view\` did not answer.`,
+			hint: "Set CLAUDE_PIPELINE_REPO=<owner>/<name>, or run inside a git repo whose origin `gh repo view` can read. Refusing rather than PATCHing a repository you did not name.",
+		};
+	}
+
 	const target = rest.find((a) => /^\d+$/.test(a));
 	if (target === undefined) {
 		return {

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
@@ -103,6 +103,38 @@ describe("route — safe REST verbs pass through unchanged", () => {
 	});
 });
 
+describe("route — an unresolved repo refuses the rewrite, not the whole shim (#4270)", () => {
+	const unresolved = (argv: ReadonlyArray<string>) => route(argv, {repo: null});
+
+	it("blocks `gh pr edit` and names $CLAUDE_PIPELINE_REPO instead of PATCHing a default repo", () => {
+		const out = unresolved(["pr", "edit", "42", "--body", "new body"]);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") {
+			assert.include(out.hint, "CLAUDE_PIPELINE_REPO");
+			// the refusal must not smuggle a repo slug into the argv it declined to build
+			assert.notInclude(`${out.reason} ${out.hint}`, "repos/");
+		}
+	});
+
+	it("blocks `gh issue edit` on an unresolved repo too", () => {
+		const out = unresolved(["issue", "edit", "7", "--title", "Renamed"]);
+		assert.strictEqual(out.kind, "block");
+	});
+
+	it("leaves a passthrough that needs no repo unaffected", () => {
+		const argv = ["api", "repos/other-owner/other-repo/issues/1", "--jq", ".title"];
+		const out = unresolved(argv);
+		assert.strictEqual(out.kind, "passthrough");
+		if (out.kind === "passthrough") assert.deepStrictEqual([...out.argv], argv);
+	});
+
+	it("still strips GraphQL-only view fields, which need no repo", () => {
+		const out = unresolved(["pr", "view", "9", "--json", "number,closingIssuesReferences"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") assert.include(out.stripped, "closingIssuesReferences");
+	});
+});
+
 describe("isMilestoneTitle", () => {
 	it("treats a bare integer as a number (not a title)", () => {
 		assert.isFalse(isMilestoneTitle("12"));


### PR DESCRIPTION
Fixes #4270

## What changed

`resolveRepo` in `packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts` converted a repo-resolution failure into a confident wrong target: after `$CLAUDE_PIPELINE_REPO` and a failed `gh repo view`, it returned this repo's literal slug. A foreign install's `gh pr edit <N> --title …` then became `PATCH repos/<this repo>/issues/<N>` — an unauthorized cross-repo write against whatever issue happened to hold that number here, with nothing on the failure path saying resolution had failed. Not fail-closed; fail-elsewhere.

Three edits:

1. **`resolve.ts` — the typed refusal.** `resolveRepo` now returns `string | null`; `null` is the explicit unresolved result. No path returns a repository literal. A `gh repo view` answer is also validated against the `owner/name` shape (`REPO_RE`, the same regex every sibling resolver uses) before it is trusted, so an empty or garbage answer is *unresolved* rather than a bogus REST path.
2. **`router.ts` — the refusal lands where the repo is actually needed.** `route`'s `repo` option is `string | null`; `routeEdit` (the only path that builds `repos/<repo>/issues/<N>`) returns a `block` when it is `null`, whose hint names `CLAUDE_PIPELINE_REPO`.
3. **`bin.ts` — `runShim` refuses.** The `block` flows into the existing refusal branch: it prints `gh-phoenix: blocked — <reason>` plus the hint to stderr and exits 1, without ever reaching the real `gh`. No rewrite is forwarded on an unresolved target.

## Acceptance criteria

- [x] **`resolveRepo` no longer returns a repository literal on any path.** It returns `null`, which the type system forces the caller to handle.
- [x] **`runShim` refuses on an unresolved repo, naming `$CLAUDE_PIPELINE_REPO`, non-zero, and never forwards the rewrite.** Covered end-to-end in `bin.test.ts` ("refuses `gh pr edit` when no repo resolves"): exit 1, stderr names `CLAUDE_PIPELINE_REPO`, and the fake `gh` is never invoked (`FAKE_GH` absent from stdout).
- [x] **Is there a caller that legitimately depends on today's default?** Answered by reading them: **no.** `resolveRepo` in this module has exactly one consumer, `runShim` in `packages/pipeline-cli/src/tools/gh-phoenix/bin.ts` (plus `resolve.unit.test.ts`) — nothing else imports `./resolve.ts`, and the other `resolveRepo`s across the package are unrelated same-named locals in their own `github.ts` modules. `runShim` uses the value for exactly one thing: the REST-rewrite target string. So there is no caller that wants a default, and removing it costs no working behavior — in phoenix itself the `gh repo view` tier still resolves, so nothing changes here.
- [x] **Tier order vs. the contract, and the CI tier — a deliberate choice, stated.** `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §Target repo resolution defines the *skill-level bash* order as `$CLAUDE_PIPELINE_REPO` → `gh repo view`. **I added the `$GITHUB_REPOSITORY` tier between them, deliberately**, for two reasons: (a) it is what every sibling resolver in this package already does under the same ADR 0062 §1 citation (`claim/github.ts`, `campaign/github.ts`, `checks/github.ts`, `epic-ledger/github.ts`, `epic-lock/github.ts`, …), so the shim stops being the outlier the issue named; (b) without it, a CI context whose `gh` is unauthenticated has no tier left and would refuse where the sibling tools resolve. The explicit override still outranks it (covered by a test). If reviewers would rather the shim match the two-tier bash snippet exactly, this is the one line to cut — it is isolated in `resolveRepo`.
- [x] **Unit coverage for the refusal path.** `resolve.unit.test.ts`: env unset + no real `gh` → `null`; a real `gh` answering a non-slug → `null`; a malformed env value → `null`; plus the two tier-precedence cases. `router.unit.test.ts`: `repo: null` blocks both `pr edit` and `issue edit` and names the env var. `bin.test.ts`: the shim refuses rather than PATCHing.
- [x] **A passthrough that needs no repo is unaffected.** This is why the refusal lives in `routeEdit` rather than at the top of `runShim`: an unresolved repo only costs you the paths that must name a repo. Covered twice — `router.unit.test.ts` (a `gh api …` passthrough and a `view --json` field strip both still work at `repo: null`) and `bin.test.ts` (a repo-less `gh api` call still execs the real `gh` and exits 0).

## Notes for review

- **Exit code.** The refusal rides the shim's existing `block` channel (exit 1), not a new code. `packages/pipeline-cli/src/exit-codes.ts`'s rule is that a *proven verdict* must not share an exit code with a failure to invoke — this refusal **is** a failure to invoke (`gh-phoenix` declining to run a call it cannot address), so exit 1 alongside the other blocks is the honest seat, and the shim's other codes (`127` no real `gh`, otherwise the child's) stay untouched.
- **Scope.** Site 1 only, per the triage split ruling — sites 2/3 travel with #4271, site 4 is withdrawn. Nothing outside `packages/pipeline-cli/src/tools/gh-phoenix/` is touched, so there is no ordering dependency on #4194 / PR #4258.
- Local checks: `vitest run src/tools/gh-phoenix` (5 files, 84 tests, green), `pnpm typecheck`, `biome check` (the 2 remaining `useOptionalChain` warnings are pre-existing on lines this PR does not touch).
