### PR TITLE
fix(pano): mount FirstContributionOnramp on the pano comment composer

### DIFF
--- a/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
@@ -41,8 +41,20 @@ describe("onrampCopy — per-surface lowercase-Turkish copy", () => {
 		expect(copy.heading).toBe("ilk gönderini paylaşmaya hazırsın");
 	});
 
+	it("uses the yorum noun on the pano comment surface", () => {
+		const copy = onrampCopy("pano-comment");
+		expect(copy.heading).toBe("ilk yorumunu yazmaya hazırsın");
+	});
+
+	it("gives every surface its own heading — no surface reuses another's noun", () => {
+		const headings = (["sozluk", "pano", "pano-comment"] as const).map(
+			(s) => onrampCopy(s).heading,
+		);
+		expect(new Set(headings).size).toBe(headings.length);
+	});
+
 	it("keeps the heading lowercase (Turkish user-facing convention)", () => {
-		for (const surface of ["sozluk", "pano"] as const) {
+		for (const surface of ["sozluk", "pano", "pano-comment"] as const) {
 			const {heading} = onrampCopy(surface);
 			expect(heading).toBe(heading.toLocaleLowerCase("tr-TR"));
 		}

--- a/apps/web/src/components/authorship/FirstContributionOnramp.tsx
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.tsx
@@ -1,9 +1,10 @@
 /**
  * `FirstContributionOnramp` — the çaylak-only nudge on a write surface (#1210,
  * epic #1202). Turns "I just joined" into "I wrote my first thing" with **honest
- * framing**: a freshly-registered çaylak's first entry lands in the mod-only
- * sandbox (#1205) pending promotion to yazar (#1206), so the copy says exactly
- * that — it never promises instant publication.
+ * framing**: a freshly-registered çaylak's first contribution — an entry or a
+ * comment (#4283) — lands in the mod-only sandbox (#1205) pending promotion to
+ * yazar (#1206), so the copy says exactly that: it never promises instant
+ * publication.
  *
  * The gate (see {@link shouldShowOnramp}): the trusted account tier read off
  * `useMe().me.tier` (#1297) being `çaylak`. A yazar (whose entries aren't sandboxed)
@@ -28,7 +29,7 @@ import {useMe} from "../../auth/useMe";
 import "./FirstContributionOnramp.css";
 
 /** The write surface the on-ramp sits on — selects the per-surface copy noun. */
-export type OnrampSurface = "sozluk" | "pano";
+export type OnrampSurface = "sozluk" | "pano" | "pano-comment";
 
 /**
  * The on-ramp's gating decision, factored DOM-free so the contract — show iff the
@@ -40,11 +41,20 @@ export function shouldShowOnramp(tier: Tier | undefined): boolean {
 	return tier === "çaylak";
 }
 
-/** Per-surface lowercase-Turkish heading. The body copy is shared. */
+/**
+ * Per-surface lowercase-Turkish heading; the body copy is shared, and stays true on
+ * the comment surface because the worker sandboxes a çaylak's comment exactly as it
+ * sandboxes an entry. Total `Record`, not a ternary chain: a surface added to the
+ * union without its copy is a compile error, never another surface's noun.
+ */
+const ONRAMP_HEADINGS: Record<OnrampSurface, string> = {
+	sozluk: "ilk tanımını yazmaya hazırsın",
+	pano: "ilk gönderini paylaşmaya hazırsın",
+	"pano-comment": "ilk yorumunu yazmaya hazırsın",
+};
+
 export function onrampCopy(surface: OnrampSurface): {heading: string} {
-	return surface === "sozluk"
-		? {heading: "ilk tanımını yazmaya hazırsın"}
-		: {heading: "ilk gönderini paylaşmaya hazırsın"};
+	return {heading: ONRAMP_HEADINGS[surface]};
 }
 
 export interface FirstContributionOnrampProps {

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -15,6 +15,7 @@ import {useFateClient, useLiveListView, useRequest, useView, type ViewRef, view}
 import {Link, useLocation, useNavigate, useParams} from "react-router";
 import type {Post, ReportReceipt} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
+import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
 import {actorLabel} from "../components/moderation/actor-identity";
 import {CommentTreeNode, CommentTreeNodeView} from "../components/pano/CommentTreeNode";
 import {buildCommentTree, type CommentNode} from "../components/pano/commentTree";
@@ -677,6 +678,10 @@ function Comments(props: CommentsProps) {
 
 	return (
 		<>
+			{/* Top-level composer only, deliberately: the reply composer is the same component
+			    rendered inline in a thread node, so mounting there would repeat the block at every
+			    open reply box. One statement at the head of the thread frames both (#4283). */}
+			<FirstContributionOnramp surface="pano-comment" />
 			<CommentComposer
 				postId={props.postId}
 				parentId={null}


### PR DESCRIPTION
A new user (çaylak) writing a comment on a pano post was told nothing beforehand about what happens to it, even though the worker holds that comment in the moderator-only area exactly as it holds a first post or definition. The honest-framing block that explains this was mounted on the two entry composers and on neither comment composer.

This mounts it above the top-level comment composer on the post detail page, with its own comment-appropriate Turkish heading ("ilk yorumunu yazmaya hazırsın") rather than the entry wording. Nothing changes for a yazar or a signed-out visitor — the existing çaylak-only gate still decides whether anything renders at all.

## What changed

- `apps/web/src/components/authorship/FirstContributionOnramp.tsx` — `OnrampSurface` gains `"pano-comment"`; `onrampCopy` becomes a total `Record<OnrampSurface, string>` so a surface added to the union without its copy is a compile error rather than a silently reused noun.
- `apps/web/src/pages/PanoPostDetail.tsx` — mounts `<FirstContributionOnramp surface="pano-comment" />` directly above the top-level `CommentComposer` (`parentId={null}`).
- `apps/web/src/components/authorship/FirstContributionOnramp.test.ts` — covers the new surface value: its heading, the lowercase-Turkish convention across all three surfaces, and that no surface reuses another's heading.

## The reply-composer decision (AC 4 — stated explicitly, not left silent)

The reply composer is **deliberately left bare.** It is the same `CommentComposer` component rendered inline inside a thread node, so mounting the on-ramp on the component itself would repeat the whole block at every open reply box, at arbitrary nesting depth. One statement at the head of the thread frames both composers on the page, which is what the block is for. The rationale is recorded at the mount site in `PanoPostDetail.tsx`, not only here.

`CommentEditComposer` is left unmounted as the issue specifies — an edit is not a first contribution.

## Verification

- `pnpm typecheck` — 29/29 tasks green.
- `pnpm lint:worktree` — clean.
- `apps/web` `test:unit` — 286 files / 2408 tests passed; `test:client` — 55 files / 268 tests passed.
- No worker change, so no fate-live fanout surface is touched: this diff only reads `useMe()` and renders.

Fixes #4283

## Deviations

- **Class 1 (scope narrowing) — the reply composer is not mounted.**
  Said: AC 4 requires the reply-composer behaviour to be decided explicitly and stated. Did: decided *not* mounted, and stated it in the PR body and at the mount site. Why: the reply composer is the same component instance shape rendered per thread node, so mounting there repeats the block at every open reply box. Disposition: no action needed — the AC asks for an explicit decision, and this is it.

- **Class 1 (scope narrowing) — the composer-wrapper refactor was not done.**
  Said: the original report asks whether the on-ramp should be a property of the composer rather than mounted per call site. Did: kept the per-call-site mount. Why: the issue's own triage note rules this open question non-blocking — mounting holds the shipped promise either way, and the wrapper is a separate chore. Disposition: for the reviewer to judge; no follow-up filed because the issue already records the question.

- **Class 7 (out-of-scope change) — `onrampCopy` reshaped from a ternary to a total `Record`.**
  Said: the issue asks to widen the union and add a copy variant. Did: also changed the copy lookup's shape. Why: a two-branch ternary widened to three surfaces silently maps the third to the pano heading; the total `Record` makes an unfilled surface a compile error instead. Disposition: no action needed — same public signature, covered by the existing and new tests.

- **Class 1 (scope narrowing) — the Step 4d render→look→fix composition self-check was not run.**
  Said: write-code Step 4d requires a rendered screenshot self-check for a UI diff. Did: verified composition statically instead (the mount reuses the existing component and CSS untouched, in the same block-above-composer position as the two existing mounts; the on-ramp's `margin-bottom: var(--s-3)` sits against the composer's `margin: var(--s-4) 0`). Why: this surface renders only for an authenticated **çaylak** viewing an **existing post with a thread**, and the local render harness renders against an empty local D1 with no seeding (a founder v1 non-goal) and no çaylak-tier session — so the harness cannot produce the state this block appears in. Disposition: for the reviewer to judge. This diff adds no CSS and no new markup shape.
