### PR TITLE
feat(pipeline-cli): assert the label vocabulary + ROADMAP.md exist before the tools depend on them (#4272)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -267,6 +267,13 @@ export const registeredTools: ReadonlyArray<ToolRegistration> = [
 	tool("pitch-guard", () =>
 		import("./tools/pitch-guard/command.ts").then((m) => m.pitchGuardCommand),
 	),
+	// #4272 — the adopting-repo prerequisite check: the label taxonomy and ROADMAP.md are hard
+	// dependencies of every tool above, not defaults, and a repo without them got no error because
+	// every scan simply matched nothing. Names each missing label instead. Deliberately an
+	// assertion, not a config seam — the vocabulary is governance, and widening it is a founder call.
+	tool("vocabulary-preflight", () =>
+		import("./tools/vocabulary-preflight/command.ts").then((m) => m.vocabularyPreflightCommand),
+	),
 	// #3980 — the mechanical half of the ADR contradiction sweep: rank the live-accepted ADRs a
 	// new ADR touches the decision domain of but never cites, so a same-question conflict with an
 	// unsuperseded ADR (0208-vs-0072, 0210-vs-0202) is a list to clear rather than a memory test.

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/type-route.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/type-route.ts
@@ -59,6 +59,11 @@ const LANE_BY_TYPE = {
 /** One of the six canonical types, bare (no `type:` prefix). */
 export type KnownIssueType = keyof typeof LANE_BY_TYPE;
 
+/** The same six as whole label names — what `vocabulary-preflight` asserts the repo actually has. */
+export const ISSUE_TYPE_LABELS: ReadonlyArray<string> = Object.keys(LANE_BY_TYPE).map(
+	(type) => `type:${type}`,
+);
+
 const REASON_BY_TYPE: Record<KnownIssueType, string> = {
 	epic: "an epic's deliverable is a planned child ledger, not a diff",
 	decision:

--- a/packages/pipeline-cli/src/tools/homing-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/command.ts
@@ -17,9 +17,10 @@
  * Exit-code contract: 0 = clean, any non-zero = failure — an un-homed issue, the zero-scope
  * fail-closed (ADR 0092), and a `gh`/repo failure all exit non-zero, undistinguished.
  */
-import {Effect} from "effect";
+import {Effect, Layer} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {onCheckFailed} from "../../gate-fail.ts";
+import {RepoLabelsLive} from "../vocabulary-preflight/github.ts";
 import {checkHoming} from "./gate.ts";
 import {TriagedIssuesLive} from "./github.ts";
 
@@ -45,5 +46,5 @@ export const homingGuardCommand = Command.make("homing-guard").pipe(
 	Command.withDescription(
 		"Fail-closed gate: every triaged issue is milestone-homed or standing-lane exempt (ADR 0202/0208, #3939)",
 	),
-	Command.provide(TriagedIssuesLive),
+	Command.provide(Layer.merge(TriagedIssuesLive, RepoLabelsLive)),
 );

--- a/packages/pipeline-cli/src/tools/homing-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/gate.ts
@@ -7,9 +7,11 @@
  */
 import {Console, Effect, Option} from "effect";
 import * as Schema from "effect/Schema";
+import type {RepoLabelsError} from "../vocabulary-preflight/github.ts";
+import {RepoLabels} from "../vocabulary-preflight/github.ts";
 import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {TriagedIssues} from "./github.ts";
-import {judge, renderReport, type Scope} from "./homing-guard.ts";
+import {judge, renderReport, type Scope, TRIAGED_LABEL} from "./homing-guard.ts";
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
 export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
@@ -26,16 +28,30 @@ export const checkHoming = (
 	issue: Option.Option<number>,
 ): Effect.Effect<
 	void,
-	CheckFailed | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
-	TriagedIssues
+	| CheckFailed
+	| RepoResolutionError
+	| GhCommandError
+	| GhParseError
+	| Schema.SchemaError
+	| RepoLabelsError,
+	TriagedIssues | RepoLabels
 > =>
 	Effect.gen(function* () {
 		const triaged = yield* TriagedIssues;
+		const labels = yield* RepoLabels;
 		const [issues, scope] = yield* Option.match(issue, {
 			onNone: () =>
 				triaged.list().pipe(Effect.map((is) => [is, {_tag: "backlog"} as Scope] as const)),
+			// The issue fork reads the label universe too: without it an empty result cannot be told
+			// from a repo that never had `status:triaged`, and the core would pass vacuously (#4272).
 			onSome: (n) =>
-				triaged.get(n).pipe(Effect.map((is) => [is, {_tag: "issue", number: n} as Scope] as const)),
+				Effect.all([triaged.get(n), labels.presence([TRIAGED_LABEL])], {
+					concurrency: "unbounded",
+				}).pipe(
+					Effect.map(
+						([is, vocabulary]) => [is, {_tag: "issue", number: n, vocabulary} as Scope] as const,
+					),
+				),
 		});
 		const verdict = judge(issues, scope);
 		if (verdict.pass) {

--- a/packages/pipeline-cli/src/tools/homing-guard/homing-guard.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/homing-guard.ts
@@ -14,6 +14,7 @@
  * read as full coverage downstream while double-marked issues landed in the `homed` count —
  * the milestone-counts-lie failure ADR 0202/0208 exist to prevent.
  */
+import type {VocabularyPresence} from "../vocabulary-preflight/presence.ts";
 
 /**
  * The two standing-lane labels, exactly (ADR 0208). A standing lane is milestone-less BY
@@ -42,8 +43,20 @@ export interface TriagedIssue {
  * What the guard scanned. `backlog` is the whole open `status:triaged` set (the CI/sweep
  * surface); `issue` is one named issue (the per-issue seam check a triage sweep runs right
  * after it labels). The two differ only in how an empty scope resolves — see `judge`.
+ *
+ * Issue scope carries the label universe's `vocabulary` because an empty issue scope has TWO
+ * readings and the tool cannot tell them apart from the issue alone: "this issue is not
+ * triaged" (ordinary, a pass) and "this repo has no such label" (an unmet prerequisite). The
+ * fact is resolved at the IO boundary and arrives here, so a required field makes the
+ * un-disambiguated pass unrepresentable rather than merely unchecked (#4272).
  */
-export type Scope = {readonly _tag: "backlog"} | {readonly _tag: "issue"; readonly number: number};
+export type Scope =
+	| {readonly _tag: "backlog"}
+	| {
+			readonly _tag: "issue";
+			readonly number: number;
+			readonly vocabulary: VocabularyPresence;
+	  };
 
 /** How one triaged issue resolves against home-xor-exempt. The two right-hand cases are defects. */
 export type Disposition = "homed" | "exempt" | "unhomed" | "double-marked";
@@ -83,6 +96,13 @@ export type HomingGuardVerdict =
 			readonly pass: false;
 			readonly reason: "zero-scope";
 			readonly scope: Scope;
+	  }
+	/** The scoping label does not exist in the repo at all — an unmet prerequisite (#4272). */
+	| {
+			readonly pass: false;
+			readonly reason: "vocabulary-absent";
+			readonly scope: Scope;
+			readonly missing: ReadonlyArray<string>;
 	  }
 	| {
 			readonly pass: false;
@@ -131,14 +151,19 @@ export const disposition = (issue: TriagedIssue): Disposition => resolve(issue).
  * exact silent-no-op ADR 0092 makes fail closed. Over a single **issue**, empty is the
  * ordinary answer "that issue is not `status:triaged`", so it passes; the caller filters the
  * fetched issue by label, so an out-of-scope issue arrives here as an empty set.
+ *
+ * The issue fork passes ONLY when the scoping label exists in the repo. Where it does not,
+ * every issue takes that fork and the seam guard reports clean forever, having checked nothing
+ * — the vacuous pass #4272 closes.
  */
 export const judge = (
 	issues: ReadonlyArray<TriagedIssue>,
 	scope: Scope = {_tag: "backlog"},
 ): HomingGuardVerdict => {
 	if (issues.length === 0) {
-		return scope._tag === "backlog"
-			? {pass: false, reason: "zero-scope", scope}
+		if (scope._tag === "backlog") return {pass: false, reason: "zero-scope", scope};
+		return scope.vocabulary._tag === "absent"
+			? {pass: false, reason: "vocabulary-absent", scope, missing: scope.vocabulary.missing}
 			: {pass: true, scope, scanned: 0, homed: 0, exempt: 0};
 	}
 
@@ -222,6 +247,15 @@ export const renderReport = (verdict: HomingGuardVerdict): string => {
 			`homing-guard: scanned ${scopeLabel(verdict.scope)} and found ZERO status:triaged issues — ` +
 			"fail-closed (ADR 0092). An empty triaged set is indistinguishable from a broken read " +
 			"(renamed label, missing token, wrong repo), and a vacuous pass would hide every floater."
+		);
+	}
+	if (verdict.reason === "vocabulary-absent") {
+		return (
+			`homing-guard: ${scopeLabel(verdict.scope)} is not in scope, but the label(s) that define ` +
+			`scope do not exist in this repo at all: ${verdict.missing.join(", ")} — unmet prerequisite ` +
+			"(#4272), not an out-of-scope issue. Every issue would take this fork, so the seam guard " +
+			"would report clean forever having checked nothing. Run `pipeline-cli vocabulary-preflight " +
+			"check` and create the missing labels; adopting the pipeline means adopting its taxonomy."
 		);
 	}
 	const unhomed = violationLines(verdict.violations, "unhomed");

--- a/packages/pipeline-cli/src/tools/homing-guard/homing-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/homing-guard/homing-guard.unit.test.ts
@@ -5,6 +5,7 @@
  * out-of-scope), and the report. No IO — the `gh api` seam is crossed in `gate.ts`/`github.ts`.
  */
 import {describe, expect, it} from "@effect/vitest";
+import {PRESENT, type VocabularyPresence} from "../vocabulary-preflight/presence.ts";
 import {
 	disposition,
 	EXEMPT_LABELS,
@@ -27,6 +28,14 @@ const issue = (
 });
 
 const BACKLOG: Scope = {_tag: "backlog"};
+
+// Issue scope defaults to a repo that HAS the label — the ordinary case. The absent reading is
+// spelled out where it is the subject (#4272).
+const issueScope = (number: number, vocabulary: VocabularyPresence = PRESENT): Scope => ({
+	_tag: "issue",
+	number,
+	vocabulary,
+});
 
 describe("EXEMPT_LABELS", () => {
 	it("is EXACTLY the two ADR-0208 standing lanes — a third needs a founder ruling", () => {
@@ -104,7 +113,7 @@ describe("judge — violations", () => {
 	});
 
 	it("FAILS a single-issue scan of an un-homed issue", () => {
-		const v = judge([issue(9, null)], {_tag: "issue", number: 9});
+		const v = judge([issue(9, null)], issueScope(9));
 		expect(v.pass).toBe(false);
 		if (!v.pass && v.reason === "violations") {
 			expect(v.violations).toEqual([{kind: "unhomed", number: 9, title: "issue 9"}]);
@@ -131,7 +140,7 @@ describe("judge — violations", () => {
 	});
 
 	it("FAILS a single-issue scan of a double-marked issue — the --issue seam reds too", () => {
-		const v = judge([issue(9, 17, ["wayfinder:backlog"])], {_tag: "issue", number: 9});
+		const v = judge([issue(9, 17, ["wayfinder:backlog"])], issueScope(9));
 		expect(v.pass).toBe(false);
 		if (!v.pass && v.reason === "violations") {
 			expect(v.violations.map((x) => x.kind)).toEqual(["double-marked"]);
@@ -164,9 +173,19 @@ describe("judge — zero scope (ADR 0092)", () => {
 	});
 
 	it("PASSES an empty SINGLE-ISSUE scan — that issue is simply not status:triaged", () => {
-		const v = judge([], {_tag: "issue", number: 9});
+		const v = judge([], issueScope(9));
 		expect(v.pass).toBe(true);
 		if (v.pass) expect(v.scanned).toBe(0);
+	});
+
+	// The two readings of the SAME empty per-issue result, which the tool cannot tell apart from
+	// the issue alone — the vacuous pass #4272 closes. The pass above is the first reading.
+	it("FAILS the same empty scan when the label is absent from the REPO — not out of scope", () => {
+		const v = judge([], issueScope(9, {_tag: "absent", missing: ["status:triaged"]}));
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "vocabulary-absent") {
+			expect(v.missing).toEqual(["status:triaged"]);
+		}
 	});
 });
 
@@ -179,8 +198,17 @@ describe("renderReport", () => {
 	});
 
 	it("names the out-of-scope issue on an empty single-issue scan", () => {
-		const report = renderReport(judge([], {_tag: "issue", number: 9}));
+		const report = renderReport(judge([], issueScope(9)));
 		expect(report).toContain("issue #9 is not status:triaged");
+	});
+
+	it("distinguishes an absent label universe from an out-of-scope issue, naming what is missing", () => {
+		const report = renderReport(
+			judge([], issueScope(9, {_tag: "absent", missing: ["status:triaged"]})),
+		);
+		expect(report).toContain("do not exist in this repo at all: status:triaged");
+		expect(report).toContain("vocabulary-preflight");
+		expect(report).not.toContain("out of scope, nothing to check");
 	});
 
 	it("explains the zero-scope refusal rather than just failing", () => {

--- a/packages/pipeline-cli/src/tools/pitch-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/pitch-guard/command.ts
@@ -18,9 +18,10 @@
  * Exit-code contract: 0 = clean, any non-zero = failure — an unpitched bet, the zero-scope
  * fail-closed (ADR 0092), and a `gh`/repo failure all exit non-zero, undistinguished.
  */
-import {Effect} from "effect";
+import {Effect, Layer} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {onCheckFailed} from "../../gate-fail.ts";
+import {RepoLabelsLive} from "../vocabulary-preflight/github.ts";
 import {checkPitches} from "./gate.ts";
 import {PitchCandidatesLive} from "./github.ts";
 
@@ -46,5 +47,5 @@ export const pitchGuardCommand = Command.make("pitch-guard").pipe(
 	Command.withDescription(
 		"Fail-closed intake gate: every pickable bet carries a founder-approved pitch (§PITCH, #3909/#3963)",
 	),
-	Command.provide(PitchCandidatesLive),
+	Command.provide(Layer.merge(PitchCandidatesLive, RepoLabelsLive)),
 );

--- a/packages/pipeline-cli/src/tools/pitch-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/pitch-guard/gate.ts
@@ -7,14 +7,25 @@
  */
 import {Console, Effect, Option} from "effect";
 import * as Schema from "effect/Schema";
+import type {RepoLabelsError} from "../vocabulary-preflight/github.ts";
+import {RepoLabels} from "../vocabulary-preflight/github.ts";
 import type {PitchGuardError} from "./github.ts";
 import {PitchCandidates} from "./github.ts";
-import {judge, renderReport, type Scope} from "./pitch-guard.ts";
+import {
+	judge,
+	LANE_ENTERING_TYPES,
+	renderReport,
+	type Scope,
+	TRIAGED_LABEL,
+} from "./pitch-guard.ts";
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
 export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
 	reason: Schema.String,
 }) {}
+
+/** The labels an issue-scope check needs before it may read an empty result as "out of scope". */
+const SCOPE_LABELS: ReadonlyArray<string> = [TRIAGED_LABEL, ...LANE_ENTERING_TYPES];
 
 /**
  * The intake gate: read the lane-entering set in scope and judge pitch-and-approval over it.
@@ -23,16 +34,25 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
  */
 export const checkPitches = (
 	issue: Option.Option<number>,
-): Effect.Effect<void, CheckFailed | PitchGuardError, PitchCandidates> =>
+): Effect.Effect<
+	void,
+	CheckFailed | PitchGuardError | RepoLabelsError,
+	PitchCandidates | RepoLabels
+> =>
 	Effect.gen(function* () {
 		const candidates = yield* PitchCandidates;
+		const labels = yield* RepoLabels;
 		const [issues, scope] = yield* Option.match(issue, {
 			onNone: () =>
 				candidates.list().pipe(Effect.map((is) => [is, {_tag: "backlog"} as Scope] as const)),
 			onSome: (n) =>
-				candidates
-					.get(n)
-					.pipe(Effect.map((is) => [is, {_tag: "issue", number: n} as Scope] as const)),
+				Effect.all([candidates.get(n), labels.presence(SCOPE_LABELS)], {
+					concurrency: "unbounded",
+				}).pipe(
+					Effect.map(
+						([is, vocabulary]) => [is, {_tag: "issue", number: n, vocabulary} as Scope] as const,
+					),
+				),
 		});
 		const verdict = judge(issues, scope);
 		if (verdict.pass) {

--- a/packages/pipeline-cli/src/tools/pitch-guard/pitch-guard.ts
+++ b/packages/pipeline-cli/src/tools/pitch-guard/pitch-guard.ts
@@ -12,6 +12,7 @@
  * park carrier is defined once by the appetite-circuit-breaker child #3966, and that question
  * is open — a pitch field never implies an answer to it.
  */
+import type {VocabularyPresence} from "../vocabulary-preflight/presence.ts";
 
 /** The label that puts an issue in scope: the requirement binds when triage makes it pickable. */
 export const TRIAGED_LABEL = "status:triaged";
@@ -48,7 +49,18 @@ export interface Candidate {
 	readonly comments: ReadonlyArray<Comment>;
 }
 
-export type Scope = {readonly _tag: "backlog"} | {readonly _tag: "issue"; readonly number: number};
+/**
+ * Issue scope carries the label universe's `vocabulary` for the same reason `homing-guard`'s
+ * does: an empty issue scope reads either "not lane-entering work" or "this repo has none of the
+ * scoping labels", and only the label universe separates them (#4272).
+ */
+export type Scope =
+	| {readonly _tag: "backlog"}
+	| {
+			readonly _tag: "issue";
+			readonly number: number;
+			readonly vocabulary: VocabularyPresence;
+	  };
 
 const heading = /^\s{0,3}#{2,6}\s*pitch\s*$/i;
 const anyHeading = /^\s{0,3}#{1,6}\s/;
@@ -266,6 +278,13 @@ export type PitchGuardVerdict =
 	  }
 	/** No lane-entering work in scope — fail closed, never a vacuous pass (ADR 0092). */
 	| {readonly pass: false; readonly reason: "zero-scope"; readonly scope: Scope}
+	/** The labels that define scope do not exist in the repo at all — unmet prerequisite (#4272). */
+	| {
+			readonly pass: false;
+			readonly reason: "vocabulary-absent";
+			readonly scope: Scope;
+			readonly missing: ReadonlyArray<string>;
+	  }
 	| {
 			readonly pass: false;
 			readonly reason: "unpitched";
@@ -282,7 +301,9 @@ export type PitchGuardVerdict =
  * **backlog** an empty lane-entering set is indistinguishable from a broken query (a renamed
  * label, a lost token, a wrong repo) — the silent no-op ADR 0092 makes fail closed. Over a
  * single **issue** empty is the ordinary answer "that issue is not lane-entering work", so it
- * passes; the caller hands an out-of-scope issue through as an empty set.
+ * passes; the caller hands an out-of-scope issue through as an empty set — but only when the
+ * scoping labels exist. Where they do not, every issue takes that fork and the guard reports
+ * clean forever, having checked nothing (#4272).
  */
 export const judge = (
 	candidates: ReadonlyArray<Candidate>,
@@ -290,8 +311,9 @@ export const judge = (
 ): PitchGuardVerdict => {
 	const inScope = candidates.filter((c) => isLaneEntering(c));
 	if (inScope.length === 0) {
-		return scope._tag === "backlog"
-			? {pass: false, reason: "zero-scope", scope}
+		if (scope._tag === "backlog") return {pass: false, reason: "zero-scope", scope};
+		return scope.vocabulary._tag === "absent"
+			? {pass: false, reason: "vocabulary-absent", scope, missing: scope.vocabulary.missing}
 			: {pass: true, scope, scanned: 0, pitched: 0};
 	}
 
@@ -342,6 +364,14 @@ export const renderReport = (verdict: PitchGuardVerdict): string => {
 			`pitch-guard: scanned ${scopeLabel(verdict.scope)} and found ZERO lane-entering issues — ` +
 			"fail-closed (ADR 0092). An empty set is indistinguishable from a broken read " +
 			"(renamed label, missing token, wrong repo), and a vacuous pass would hide every unpitched bet."
+		);
+	}
+	if (verdict.reason === "vocabulary-absent") {
+		return (
+			`pitch-guard: ${scopeLabel(verdict.scope)} is not lane-entering work, but the label(s) that ` +
+			`define scope do not exist in this repo at all: ${verdict.missing.join(", ")} — unmet ` +
+			"prerequisite (#4272), not an out-of-scope issue. Run `pipeline-cli vocabulary-preflight " +
+			"check` and create the missing labels; adopting the pipeline means adopting its taxonomy."
 		);
 	}
 	const lines = verdict.unpitched.map((i) => `  #${i.number} ${i.title}\n      ${i.detail}`);

--- a/packages/pipeline-cli/src/tools/pitch-guard/pitch-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/pitch-guard/pitch-guard.unit.test.ts
@@ -6,6 +6,7 @@
  * `gate.ts`/`github.ts`.
  */
 import {describe, expect, it} from "@effect/vitest";
+import {PRESENT, type VocabularyPresence} from "../vocabulary-preflight/presence.ts";
 import {
 	type Candidate,
 	type Comment,
@@ -50,6 +51,14 @@ const candidate = (over: Partial<Candidate> = {}): Candidate => ({
 });
 
 const BACKLOG: Scope = {_tag: "backlog"};
+
+// Issue scope defaults to a repo that HAS the scoping labels — the ordinary case. The absent
+// reading is spelled out where it is the subject (#4272).
+const issueScope = (number: number, vocabulary: VocabularyPresence = PRESENT): Scope => ({
+	_tag: "issue",
+	number,
+	vocabulary,
+});
 
 describe("the frozen contract literals", () => {
 	it("lane-entering types are EXACTLY epic + feature — widening is a founder call", () => {
@@ -259,13 +268,27 @@ describe("judge", () => {
 	});
 
 	it("a single out-of-scope ISSUE passes — that is the ordinary answer, not a broken read", () => {
-		const scope: Scope = {_tag: "issue", number: 7};
+		const scope: Scope = issueScope(7);
 		expect(judge([candidate({number: 7, hasParent: true})], scope)).toEqual({
 			pass: true,
 			scope,
 			scanned: 0,
 			pitched: 0,
 		});
+	});
+
+	// The two readings of the SAME empty per-issue result. The pass above is the first; this is the
+	// second, which used to be indistinguishable from it and reported clean forever (#4272).
+	it("FAILS the same empty scan when the scoping labels are absent from the REPO", () => {
+		const scope: Scope = issueScope(7, {
+			_tag: "absent",
+			missing: ["status:triaged", ...LANE_ENTERING_TYPES],
+		});
+		const verdict = judge([candidate({number: 7, hasParent: true})], scope);
+		expect(verdict.pass).toBe(false);
+		if (!verdict.pass && verdict.reason === "vocabulary-absent") {
+			expect(verdict.missing).toContain("status:triaged");
+		}
 	});
 
 	it("reds on an unpitched bet and counts only in-scope work", () => {
@@ -302,9 +325,16 @@ describe("renderReport", () => {
 	});
 
 	it("an out-of-scope single issue reports out-of-scope, not clean-pitched", () => {
-		const scope: Scope = {_tag: "issue", number: 7};
+		const scope: Scope = issueScope(7);
 		expect(renderReport(judge([candidate({number: 7, hasParent: true})], scope))).toContain(
 			"not lane-entering work",
 		);
+	});
+
+	it("an absent label universe reports the unmet prerequisite, naming the missing labels", () => {
+		const scope: Scope = issueScope(7, {_tag: "absent", missing: ["status:triaged"]});
+		const report = renderReport(judge([candidate({number: 7, hasParent: true})], scope));
+		expect(report).toContain("do not exist in this repo at all: status:triaged");
+		expect(report).toContain("vocabulary-preflight");
 	});
 });

--- a/packages/pipeline-cli/src/tools/roadmap/roadmap.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/roadmap.ts
@@ -63,7 +63,7 @@ export interface RoadmapFacts {
 }
 
 const EPIC_LABEL = "type:epic";
-const PRIORITY_LABELS: ReadonlyArray<Priority> = ["p0", "p1", "p2"];
+export const PRIORITY_LABELS: ReadonlyArray<Priority> = ["p0", "p1", "p2"];
 
 /** True when the label set marks this issue as an epic (`type:epic`). */
 export const isEpic = (labels: ReadonlyArray<string>): boolean => labels.includes(EPIC_LABEL);

--- a/packages/pipeline-cli/src/tools/roadmap/view.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/view.ts
@@ -8,6 +8,7 @@
  */
 import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
+import {judgeRoadmap} from "../vocabulary-preflight/vocabulary.ts";
 import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Github} from "./github.ts";
 import {buildView, parseRoadmap, renderView} from "./roadmap.ts";
@@ -17,6 +18,15 @@ export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
 	path: Schema.String,
 	cause: Schema.Unknown,
 }) {}
+
+/** `ROADMAP.md` was readable but carries no arc table — an unmet prerequisite, not a quiet roadmap. */
+export class PrerequisiteUnmet extends Schema.TaggedErrorClass<PrerequisiteUnmet>()(
+	"PrerequisiteUnmet",
+	{
+		path: Schema.String,
+		detail: Schema.String,
+	},
+) {}
 
 const ROADMAP_FILE = "ROADMAP.md";
 
@@ -49,12 +59,31 @@ export const renderRoadmap = (
 	root: string,
 ): Effect.Effect<
 	void,
-	IoError | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
+	| IoError
+	| PrerequisiteUnmet
+	| RepoResolutionError
+	| GhCommandError
+	| GhParseError
+	| Schema.SchemaError,
 	Github | FileSystem.FileSystem | Path.Path
 > =>
 	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const target = path.join(root, ROADMAP_FILE);
 		const md = yield* readRoadmap(root);
 		const {arcs, campaigns} = parseRoadmap(md);
+		// A ROADMAP.md whose table is absent or shaped differently parses to zero rows, which used
+		// to render as an empty tree — a roadmap that merely looks quiet. It is the same unmet
+		// prerequisite the preflight names, so it reds the same way here (#4272).
+		const unmet = judgeRoadmap({
+			_tag: "present",
+			path: target,
+			arcs: arcs.length,
+			campaigns: campaigns.length,
+		});
+		if (unmet !== null) {
+			return yield* Effect.fail(new PrerequisiteUnmet({path: unmet.path, detail: unmet.detail}));
+		}
 		const facts = yield* (yield* Github).gather();
 		yield* Console.log(renderView(buildView(arcs, campaigns, facts)));
 	});

--- a/packages/pipeline-cli/src/tools/roadmap/view.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/view.ts
@@ -8,7 +8,6 @@
  */
 import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
-import {judgeRoadmap} from "../vocabulary-preflight/vocabulary.ts";
 import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Github} from "./github.ts";
 import {buildView, parseRoadmap, renderView} from "./roadmap.ts";
@@ -18,15 +17,6 @@ export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
 	path: Schema.String,
 	cause: Schema.Unknown,
 }) {}
-
-/** `ROADMAP.md` was readable but carries no arc table — an unmet prerequisite, not a quiet roadmap. */
-export class PrerequisiteUnmet extends Schema.TaggedErrorClass<PrerequisiteUnmet>()(
-	"PrerequisiteUnmet",
-	{
-		path: Schema.String,
-		detail: Schema.String,
-	},
-) {}
 
 const ROADMAP_FILE = "ROADMAP.md";
 
@@ -59,31 +49,12 @@ export const renderRoadmap = (
 	root: string,
 ): Effect.Effect<
 	void,
-	| IoError
-	| PrerequisiteUnmet
-	| RepoResolutionError
-	| GhCommandError
-	| GhParseError
-	| Schema.SchemaError,
+	IoError | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
 	Github | FileSystem.FileSystem | Path.Path
 > =>
 	Effect.gen(function* () {
-		const path = yield* Path.Path;
-		const target = path.join(root, ROADMAP_FILE);
 		const md = yield* readRoadmap(root);
 		const {arcs, campaigns} = parseRoadmap(md);
-		// A ROADMAP.md whose table is absent or shaped differently parses to zero rows, which used
-		// to render as an empty tree — a roadmap that merely looks quiet. It is the same unmet
-		// prerequisite the preflight names, so it reds the same way here (#4272).
-		const unmet = judgeRoadmap({
-			_tag: "present",
-			path: target,
-			arcs: arcs.length,
-			campaigns: campaigns.length,
-		});
-		if (unmet !== null) {
-			return yield* Effect.fail(new PrerequisiteUnmet({path: unmet.path, detail: unmet.detail}));
-		}
 		const facts = yield* (yield* Github).gather();
 		yield* Console.log(renderView(buildView(arcs, campaigns, facts)));
 	});

--- a/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
+++ b/packages/pipeline-cli/src/tools/tracker/triage-labels.ts
@@ -112,6 +112,11 @@ const SPINE_STAGES: ReadonlySet<string> = new Set([
 	"triaged",
 ]);
 
+/** The spine as whole label names — what `vocabulary-preflight` asserts the repo actually has. */
+export const SPINE_LABELS: ReadonlyArray<string> = [...SPINE_STAGES].map(
+	(stage) => `${STATUS_PREFIX}${stage}`,
+);
+
 /**
  * The single-valued label families. `owns` decides membership from the label name alone (so a
  * label the tracker never applied is still reconciled), `desired` names the one member the

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/command.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/command.ts
@@ -1,0 +1,77 @@
+/**
+ * The `vocabulary-preflight` tool — `pipeline-cli vocabulary-preflight check [--root <d>]`.
+ *
+ * The unmet-prerequisite check for an adopting repository (#4272). The pipeline's label
+ * taxonomy and `ROADMAP.md` are hard dependencies, not defaults: run this once against a repo
+ * before wiring the guards into its CI, and a missing label universe or roadmap surface reds by
+ * name instead of letting every later scan match nothing and report clean.
+ *
+ *   pipeline-cli vocabulary-preflight check              # the resolved target repo (ADR 0062 §1)
+ *   pipeline-cli vocabulary-preflight check --root <d>   # point at a specific repo root
+ *
+ * The pure decision lives in `vocabulary.ts` (unit-tested); the `gh api` label read and the
+ * `ROADMAP.md` read in `github.ts`/`gate.ts`. `RepoLabelsLive` is baked in with
+ * `Command.provide(...)` so the registered command's residual requirement is the Node platform
+ * union (the registry seam, epic #994).
+ *
+ * Exit-code contract: 0 = every prerequisite met, any non-zero = failure.
+ */
+import {Effect, FileSystem, Option, Path} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {checkVocabulary} from "./gate.ts";
+import {RepoLabelsLive} from "./github.ts";
+
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each marker through
+// the `FileSystem`/`Path` seam so the resolver is testable off real disk
+// (.patterns/effect-platform-access.md). The walk falls back to the start on no hit.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root holding ROADMAP.md (default: walk up for one)"),
+);
+
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkVocabulary(yield* resolveRoot(rootOpt)).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the run if the target repo lacks the pipeline's required labels or ROADMAP.md",
+	),
+);
+
+export const vocabularyPreflightCommand = Command.make("vocabulary-preflight").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed preflight: the required label vocabulary + ROADMAP.md exist in the target repo (#4272)",
+	),
+	Command.provide(RepoLabelsLive),
+);

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/gate.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/gate.ts
@@ -1,0 +1,69 @@
+/**
+ * The `vocabulary-preflight` gate — the IO seam wiring the pure core to the two facts it judges:
+ * the target repo's label universe (over `gh api` via `RepoLabels`) and `ROADMAP.md` (read from
+ * disk). Split from `command.ts` so the wiring is crossable in tests, and kept thin: it reads,
+ * delegates the verdict to `vocabulary.ts`, and fails `CheckFailed` (exit non-zero) on any
+ * non-passing verdict.
+ */
+import {Console, Effect, FileSystem, Path} from "effect";
+import * as Schema from "effect/Schema";
+import {parseRoadmap} from "../roadmap-guard/roadmap-guard.ts";
+import type {RepoLabelsError} from "./github.ts";
+import {RepoLabels} from "./github.ts";
+import {judge, type RoadmapSurface, renderReport} from "./vocabulary.ts";
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+const ROADMAP_FILE = "ROADMAP.md";
+
+/**
+ * Read `ROADMAP.md` into the surface the core judges. An unreadable file resolves `absent` rather
+ * than erroring: to a preflight, "the prerequisite is not there" and "the prerequisite cannot be
+ * read" are the same unmet prerequisite, and both must red with the same name.
+ *
+ * The read goes through the `FileSystem`/`Path` seam so the wiring is crossable off real disk in a
+ * test — see `.patterns/effect-platform-access.md`.
+ */
+export const readRoadmapSurface = (
+	root: string,
+): Effect.Effect<RoadmapSurface, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, ROADMAP_FILE);
+		const md = yield* fs.readFileString(target, "utf8").pipe(Effect.orElseSucceed(() => null));
+		if (md === null) return {_tag: "absent", path: target} as const;
+		const {arcs, campaigns} = parseRoadmap(md);
+		return {
+			_tag: "present",
+			path: target,
+			arcs: arcs.length,
+			campaigns: campaigns.length,
+		} as const;
+	});
+
+/**
+ * The preflight: read the label universe + the roadmap surface and judge the prerequisites.
+ * Succeeds only on a passing verdict — an adopting repo missing the taxonomy gets a named,
+ * non-zero failure instead of a factory that runs and protects nothing.
+ */
+export const checkVocabulary = (
+	root: string,
+): Effect.Effect<
+	void,
+	CheckFailed | RepoLabelsError,
+	RepoLabels | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const universe = yield* (yield* RepoLabels).list();
+		const roadmap = yield* readRoadmapSurface(root);
+		const verdict = judge(universe, roadmap);
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/github.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/github.ts
@@ -1,0 +1,178 @@
+/**
+ * The GitHub boundary for the vocabulary preflight: `RepoLabels`, the live capability that reads
+ * the target repo's whole label universe over `gh api` REST so the pure core — and the per-issue
+ * guard checks — can tell "this issue is out of scope" from "this repo has no such label" (#4272).
+ *
+ * Same service pattern as `homing-guard`'s `TriagedIssues` (epic #994): a `Context.Service` on
+ * `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us org), every infra failure a
+ * typed error in the `E` channel, untrusted REST JSON Schema-decoded at the boundary.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {resolvePresence, type VocabularyPresence} from "./presence.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/vocabulary-preflight/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/vocabulary-preflight/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/vocabulary-preflight/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+export type RepoLabelsError =
+	| RepoResolutionError
+	| GhCommandError
+	| GhParseError
+	| Schema.SchemaError;
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGh = Effect.fn("RepoLabels.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const json = Effect.fn("RepoLabels.json")(function* (args: ReadonlyArray<string>) {
+	const raw = yield* runGh(args);
+	return yield* Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults.
+ */
+const resolveRepo = Effect.fn("RepoLabels.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/vocabulary-preflight/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// `--slurp` because bare `--paginate` concatenates one JSON array per page — unparseable as a
+// whole once the label set passes 100 (the #3762 break, same shape).
+const labelArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/labels`,
+	"-f",
+	"per_page=100",
+	"--paginate",
+	"--slurp",
+];
+
+const RawLabel = Schema.Struct({name: Schema.String});
+const decodePages = Schema.decodeUnknownEffect(Schema.Array(Schema.Array(RawLabel)));
+
+const listLabels = Effect.fn("RepoLabels.list")(function* (repo: string) {
+	const pages = yield* decodePages(yield* json(labelArgs(repo)));
+	return pages.flat().map((l) => l.name);
+});
+
+/**
+ * `RepoLabels` — the target repo's label universe. `list` is the raw set; `presence` is the one
+ * question a per-issue guard asks, so each guard consults the universe through the same
+ * fail-closed resolver rather than re-deriving the comparison.
+ */
+export class RepoLabels extends Context.Service<
+	RepoLabels,
+	{
+		readonly list: () => Effect.Effect<ReadonlyArray<string>, RepoLabelsError>;
+		readonly presence: (
+			required: ReadonlyArray<string>,
+		) => Effect.Effect<VocabularyPresence, RepoLabelsError>;
+	}
+>()("@kampus/vocabulary-preflight/RepoLabels") {}
+
+/**
+ * The live layer. The `ChildProcessSpawner` dependency is captured once at construction and
+ * provided into each method body, so the public methods carry `R = never`. Both repo resolution
+ * AND the label read are `Effect.cached`: a guard run asks for presence once, but caching the
+ * universe keeps a future multi-question caller from re-paginating the same list.
+ */
+export const RepoLabelsLive: Layer.Layer<
+	RepoLabels,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = Layer.effect(RepoLabels)(
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+		const universe = yield* Effect.cached(
+			repo.pipe(Effect.flatMap((r) => withSpawner(listLabels(r)))),
+		);
+		return {
+			list: () => universe,
+			presence: (required: ReadonlyArray<string>) =>
+				universe.pipe(Effect.map((labels) => resolvePresence(required, labels))),
+		};
+	}),
+);

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/presence.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/presence.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether the labels a scan scopes on exist in the target repo at all (#4272).
+ *
+ * A leaf module with no imports on purpose: the guards consume the type and `vocabulary.ts`
+ * builds the required set out of the guards' own constants, so parking this type in either
+ * place would make the preflight and the guards import each other in a cycle.
+ */
+
+/**
+ * Absence carries the missing names because naming them IS the remedy: a guard that reds on an
+ * absent vocabulary has to say which label the adopting repo never created, or the red is the
+ * same unactionable "nothing in scope" it replaced.
+ */
+export type VocabularyPresence =
+	| {readonly _tag: "present"}
+	| {readonly _tag: "absent"; readonly missing: ReadonlyArray<string>};
+
+export const PRESENT: VocabularyPresence = {_tag: "present"};
+
+/**
+ * Resolve the scoping labels a check depends on against the repo's live label universe.
+ *
+ * Fail-closed by construction (ADR 0092): an empty universe resolves ABSENT, never present — an
+ * unreadable label list and a repo that genuinely has none are indistinguishable from here, and
+ * the safe reading of both is "the prerequisite is unmet".
+ */
+export const resolvePresence = (
+	required: ReadonlyArray<string>,
+	universe: ReadonlyArray<string>,
+): VocabularyPresence => {
+	const missing = required.filter((label) => !universe.includes(label));
+	return missing.length === 0 ? PRESENT : {_tag: "absent", missing};
+};

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
@@ -1,0 +1,164 @@
+/**
+ * `vocabulary-preflight` pure core — assert the label vocabulary and the roadmap surface the
+ * pipeline tools depend on actually exist in the resolved target repo, and name each one that
+ * does not (#4272).
+ *
+ * The vocabulary is deliberately NOT a config surface. Two tools already record that widening
+ * their slice of it is a founder ruling (`homing-guard`'s `EXEMPT_LABELS`, `pitch-guard`'s
+ * `LANE_ENTERING_TYPES`), so adopting the pipeline means adopting the taxonomy. What was missing
+ * is the other half of that bargain: a repo without the taxonomy got no error, because every
+ * scan simply matched nothing — the silent no-op ADR 0092 exists to kill. This module turns that
+ * absence into an unmet prerequisite with a name.
+ *
+ * The required set is ASSEMBLED from the constants the tools already own rather than retyped
+ * here, so the preflight cannot drift from the literals it protects.
+ *
+ * IO-free and total — the `gh api` label read and the `ROADMAP.md` read live in
+ * `github.ts`/`gate.ts`.
+ */
+import {ISSUE_TYPE_LABELS} from "../drive-issue-flow/type-route.ts";
+import {EXEMPT_LABELS} from "../homing-guard/homing-guard.ts";
+import {PLATFORM_LABELS} from "../lane/lane.ts";
+import {PRIORITY_LABELS} from "../roadmap/roadmap.ts";
+import {SPINE_LABELS} from "../tracker/triage-labels.ts";
+
+/** One named slice of the vocabulary, so a red says which tool loses its footing without it. */
+export interface LabelGroup {
+	readonly name: string;
+	readonly labels: ReadonlyArray<string>;
+}
+
+/**
+ * The required label universe, grouped by the concern each slice serves. `axis:pipeline-hardening`
+ * is legitimately in two groups (a standing lane AND the platform discriminator); `REQUIRED_LABELS`
+ * dedupes, the groups keep both readings visible in the report.
+ */
+export const LABEL_GROUPS: ReadonlyArray<LabelGroup> = [
+	{name: "pickability spine", labels: SPINE_LABELS},
+	{name: "priority buckets", labels: PRIORITY_LABELS},
+	{name: "issue types", labels: ISSUE_TYPE_LABELS},
+	{name: "standing lanes", labels: EXEMPT_LABELS},
+	{name: "platform discriminator", labels: PLATFORM_LABELS},
+];
+
+/** Every label the tools scope on, deduped, in group order. */
+export const REQUIRED_LABELS: ReadonlyArray<string> = [
+	...new Set(LABEL_GROUPS.flatMap((group) => group.labels)),
+];
+
+/** `ROADMAP.md` as the preflight finds it: absent, or present with the rows it parsed. */
+export type RoadmapSurface =
+	| {readonly _tag: "absent"; readonly path: string}
+	| {
+			readonly _tag: "present";
+			readonly path: string;
+			readonly arcs: number;
+			readonly campaigns: number;
+	  };
+
+/** The roadmap surface is missing or shaped so it parses to nothing. */
+export interface RoadmapPrerequisite {
+	readonly _tag: "roadmap";
+	readonly path: string;
+	readonly detail: string;
+}
+
+/** One unmet prerequisite. Both arms carry what the operator has to create to clear it. */
+export type Prerequisite =
+	| {readonly _tag: "labels"; readonly missing: ReadonlyArray<string>}
+	| RoadmapPrerequisite;
+
+/**
+ * The verdict. A discriminated union so an invalid state is unrepresentable: a pass carries only
+ * counts, and a fail carries a list `judge` only ever builds non-empty.
+ */
+export type PreflightVerdict =
+	| {
+			readonly pass: true;
+			readonly labels: number;
+			readonly arcs: number;
+			readonly campaigns: number;
+	  }
+	| {readonly pass: false; readonly unmet: ReadonlyArray<Prerequisite>};
+
+/**
+ * The roadmap half, separately callable: `roadmap view` runs it too, so a repo whose `ROADMAP.md`
+ * is absent or parses to no arcs gets the same named prerequisite from the view it gets from the
+ * preflight, instead of rendering an empty tree as though the roadmap were simply quiet.
+ * Returns `null` when the surface is fine.
+ */
+export const judgeRoadmap = (surface: RoadmapSurface): RoadmapPrerequisite | null => {
+	if (surface._tag === "absent") {
+		return {_tag: "roadmap", path: surface.path, detail: "not found"};
+	}
+	if (surface.arcs === 0) {
+		return {
+			_tag: "roadmap",
+			path: surface.path,
+			detail: "parsed ZERO `## Arcs` rows — the table is missing or its grammar does not match",
+		};
+	}
+	return null;
+};
+
+/**
+ * Judge the live label universe and roadmap surface against the prerequisites.
+ *
+ * An empty universe is not a special case: every required label is then missing, so it reds by
+ * the same path a partially-adopted repo does — and never as a vacuous pass (ADR 0092).
+ */
+export const judge = (
+	universe: ReadonlyArray<string>,
+	roadmap: RoadmapSurface,
+): PreflightVerdict => {
+	const unmet: Array<Prerequisite> = [];
+	const missing = REQUIRED_LABELS.filter((label) => !universe.includes(label));
+	if (missing.length > 0) unmet.push({_tag: "labels", missing});
+	const roadmapDefect = judgeRoadmap(roadmap);
+	if (roadmapDefect !== null) unmet.push(roadmapDefect);
+
+	if (unmet.length > 0) return {pass: false, unmet};
+	return {
+		pass: true,
+		labels: REQUIRED_LABELS.length,
+		arcs: roadmap._tag === "present" ? roadmap.arcs : 0,
+		campaigns: roadmap._tag === "present" ? roadmap.campaigns : 0,
+	};
+};
+
+const LABEL_REMEDY =
+	"Adopting the pipeline means adopting its taxonomy — the vocabulary is governance, not\n" +
+	"configuration, and two tools record that widening it is a founder ruling. Create each label\n" +
+	"above in the target repo (`gh label create <name>`); do NOT try to point the tools at a\n" +
+	"different vocabulary.";
+
+/** Render one unmet prerequisite with the group each missing label belongs to. */
+const renderPrerequisite = (unmet: Prerequisite): string => {
+	if (unmet._tag === "roadmap") {
+		return (
+			`ROADMAP.md — ${unmet.detail} (${unmet.path}).\n` +
+			"It is the SOLE parsed roadmap surface (#2630/#2632): with no `## Arcs` table there is no\n" +
+			"active arc, so milestone homing and the roadmap view have nothing to read."
+		);
+	}
+	const byGroup = LABEL_GROUPS.map((group) => {
+		const gone = group.labels.filter((label) => unmet.missing.includes(label));
+		return gone.length === 0 ? "" : `  ${group.name}: ${gone.join(", ")}`;
+	}).filter((line) => line !== "");
+	return `${unmet.missing.length} required label(s) absent from the repo:\n${byGroup.join("\n")}\n\n${LABEL_REMEDY}`;
+};
+
+/** Render the report for a verdict (ADR 0092 §1 — "emit what you scanned"). */
+export const renderReport = (verdict: PreflightVerdict): string => {
+	if (verdict.pass) {
+		return (
+			`vocabulary-preflight: prerequisites met — all ${verdict.labels} required labels exist, ` +
+			`ROADMAP.md parses ${verdict.arcs} arc(s) and ${verdict.campaigns} campaign(s).`
+		);
+	}
+	return (
+		`vocabulary-preflight: ${verdict.unmet.length} unmet prerequisite(s) — the pipeline would run ` +
+		"and protect nothing here:\n\n" +
+		verdict.unmet.map(renderPrerequisite).join("\n\n")
+	);
+};

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
@@ -17,7 +17,7 @@
  * `github.ts`/`gate.ts`.
  */
 import {ISSUE_TYPE_LABELS} from "../drive-issue-flow/type-route.ts";
-import {EXEMPT_LABELS} from "../homing-guard/homing-guard.ts";
+import {EXEMPT_LABELS, TRIAGED_LABEL} from "../homing-guard/homing-guard.ts";
 import {PLATFORM_LABELS} from "../lane/lane.ts";
 import {PRIORITY_LABELS} from "../roadmap/roadmap.ts";
 import {SPINE_LABELS} from "../tracker/triage-labels.ts";
@@ -29,12 +29,15 @@ export interface LabelGroup {
 }
 
 /**
- * The required label universe, grouped by the concern each slice serves. `axis:pipeline-hardening`
- * is legitimately in two groups (a standing lane AND the platform discriminator); `REQUIRED_LABELS`
- * dedupes, the groups keep both readings visible in the report.
+ * The required label universe, grouped by the concern each slice serves. A label may legitimately
+ * sit in two groups — `axis:pipeline-hardening` is a standing lane AND the platform discriminator;
+ * `status:triaged` is a spine stage AND the label the guards scope on. `REQUIRED_LABELS` dedupes,
+ * the groups keep both readings visible in the report. Every group is imported from the tool that
+ * owns it, so no slice can be covered only incidentally by another.
  */
 export const LABEL_GROUPS: ReadonlyArray<LabelGroup> = [
 	{name: "pickability spine", labels: SPINE_LABELS},
+	{name: "guard scope", labels: [TRIAGED_LABEL]},
 	{name: "priority buckets", labels: PRIORITY_LABELS},
 	{name: "issue types", labels: ISSUE_TYPE_LABELS},
 	{name: "standing lanes", labels: EXEMPT_LABELS},
@@ -82,10 +85,9 @@ export type PreflightVerdict =
 	| {readonly pass: false; readonly unmet: ReadonlyArray<Prerequisite>};
 
 /**
- * The roadmap half, separately callable: `roadmap view` runs it too, so a repo whose `ROADMAP.md`
- * is absent or parses to no arcs gets the same named prerequisite from the view it gets from the
- * preflight, instead of rendering an empty tree as though the roadmap were simply quiet.
- * Returns `null` when the surface is fine.
+ * The roadmap half: a `ROADMAP.md` that is absent, or present but parsing to no arcs, is the same
+ * unmet prerequisite — an empty tree reads as a roadmap that is merely quiet. Returns `null` when
+ * the surface is fine.
  */
 export const judgeRoadmap = (surface: RoadmapSurface): RoadmapPrerequisite | null => {
 	if (surface._tag === "absent") {

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.unit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure-core tests for `vocabulary-preflight` (#4272): the required set is assembled from the
+ * tools' own constants (so it cannot drift from what it protects), an absent label universe is an
+ * unmet prerequisite rather than a quiet pass, and the roadmap surface reds by the same path.
+ * No IO — the `gh api` label read and the ROADMAP.md read are crossed in `gate.ts`/`github.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {ISSUE_TYPE_LABELS} from "../drive-issue-flow/type-route.ts";
+import {EXEMPT_LABELS, TRIAGED_LABEL} from "../homing-guard/homing-guard.ts";
+import {LANE_ENTERING_TYPES} from "../pitch-guard/pitch-guard.ts";
+import {PRESENT, resolvePresence} from "./presence.ts";
+import {
+	judge,
+	judgeRoadmap,
+	REQUIRED_LABELS,
+	type RoadmapSurface,
+	renderReport,
+} from "./vocabulary.ts";
+
+const ROADMAP_OK: RoadmapSurface = {
+	_tag: "present",
+	path: "/repo/ROADMAP.md",
+	arcs: 4,
+	campaigns: 2,
+};
+
+describe("REQUIRED_LABELS", () => {
+	it("covers every label the guards scope on", () => {
+		for (const label of [TRIAGED_LABEL, ...EXEMPT_LABELS, ...LANE_ENTERING_TYPES]) {
+			expect(REQUIRED_LABELS).toContain(label);
+		}
+	});
+
+	it("covers the priority buckets and the whole pickability spine", () => {
+		for (const label of ["p0", "p1", "p2", "status:needs-triage", "status:planned"]) {
+			expect(REQUIRED_LABELS).toContain(label);
+		}
+	});
+
+	it("dedupes a label that serves two concerns (axis:pipeline-hardening is lane AND platform)", () => {
+		const hardening = REQUIRED_LABELS.filter((l) => l === "axis:pipeline-hardening");
+		expect(hardening).toHaveLength(1);
+	});
+
+	it("names no label the six canonical types do not cover", () => {
+		const types = REQUIRED_LABELS.filter((l) => l.startsWith("type:"));
+		expect([...types].sort()).toEqual([...ISSUE_TYPE_LABELS].sort());
+	});
+});
+
+describe("resolvePresence", () => {
+	it("is present when the universe carries every required label", () => {
+		expect(resolvePresence([TRIAGED_LABEL], [TRIAGED_LABEL, "p1"])).toEqual(PRESENT);
+	});
+
+	it("names exactly the labels the universe lacks", () => {
+		expect(resolvePresence([TRIAGED_LABEL, "type:epic"], ["type:epic"])).toEqual({
+			_tag: "absent",
+			missing: [TRIAGED_LABEL],
+		});
+	});
+
+	it("reds on an EMPTY universe — unreadable and never-created are the same unmet prerequisite", () => {
+		expect(resolvePresence([TRIAGED_LABEL], [])).toEqual({
+			_tag: "absent",
+			missing: [TRIAGED_LABEL],
+		});
+	});
+});
+
+describe("judgeRoadmap", () => {
+	it("passes a roadmap that parses at least one arc", () => {
+		expect(judgeRoadmap(ROADMAP_OK)).toBeNull();
+	});
+
+	it("names an absent ROADMAP.md, carrying the path it looked at", () => {
+		const unmet = judgeRoadmap({_tag: "absent", path: "/repo/ROADMAP.md"});
+		expect(unmet).toEqual({_tag: "roadmap", path: "/repo/ROADMAP.md", detail: "not found"});
+	});
+
+	it("names a ROADMAP.md that parses ZERO arcs — an empty roadmap is not a quiet one", () => {
+		const unmet = judgeRoadmap({...ROADMAP_OK, arcs: 0});
+		expect(unmet?._tag).toBe("roadmap");
+		expect(unmet?.detail).toContain("ZERO");
+	});
+});
+
+describe("judge", () => {
+	it("passes when every label exists and the roadmap parses", () => {
+		const verdict = judge([...REQUIRED_LABELS], ROADMAP_OK);
+		expect(verdict.pass).toBe(true);
+		expect(renderReport(verdict)).toContain("prerequisites met");
+	});
+
+	it("reds on a repo with NO labels at all, naming every one of them", () => {
+		const verdict = judge([], ROADMAP_OK);
+		expect(verdict.pass).toBe(false);
+		if (verdict.pass) return;
+		expect(verdict.unmet).toHaveLength(1);
+		const [unmet] = verdict.unmet;
+		expect(unmet?._tag).toBe("labels");
+		expect(unmet?._tag === "labels" && unmet.missing).toEqual([...REQUIRED_LABELS]);
+	});
+
+	it("reds on a partially-adopted repo, naming only what is missing", () => {
+		const verdict = judge(
+			REQUIRED_LABELS.filter((l) => l !== TRIAGED_LABEL),
+			ROADMAP_OK,
+		);
+		expect(verdict.pass).toBe(false);
+		if (verdict.pass) return;
+		expect(verdict.unmet).toEqual([{_tag: "labels", missing: [TRIAGED_LABEL]}]);
+	});
+
+	it("collects BOTH unmet prerequisites in one run, so one pass names all of them", () => {
+		const verdict = judge([], {_tag: "absent", path: "/repo/ROADMAP.md"});
+		expect(verdict.pass).toBe(false);
+		if (verdict.pass) return;
+		expect(verdict.unmet.map((u) => u._tag)).toEqual(["labels", "roadmap"]);
+	});
+});
+
+describe("renderReport", () => {
+	it("groups the missing labels by the concern each serves", () => {
+		const report = renderReport(judge([], ROADMAP_OK));
+		expect(report).toContain("pickability spine:");
+		expect(report).toContain("priority buckets:");
+		expect(report).toContain("standing lanes:");
+	});
+
+	it("says the vocabulary is not configurable — the remedy is to create the labels", () => {
+		const report = renderReport(judge([], ROADMAP_OK));
+		expect(report).toContain("gh label create");
+		expect(report).toContain("not\nconfiguration");
+	});
+});


### PR DESCRIPTION
The pipeline's label taxonomy and `ROADMAP.md` are hard dependencies of every guard, but nothing checked they were actually there. A second operator adopting the pipeline in their own repository got a factory that appeared to run and protected nothing: the per-issue seam guards reported clean on a repo with none of the labels they scope on. This adds a preflight that names each missing prerequisite instead, and closes the per-issue hole that made the absence invisible.

Fixes #4272

## What changed

- **New `pipeline-cli vocabulary-preflight check [--root <d>]`.** Reads the resolved target repo's label universe over `gh api` REST plus the local `ROADMAP.md`, and exits non-zero naming every missing label, grouped by the concern it serves. The required set is **assembled from the tools' own constants** (`EXEMPT_LABELS`, `TRIAGED_LABEL`, the six canonical types, `PLATFORM_LABELS`, the pickability spine, the priority buckets) rather than retyped, so the preflight cannot drift from the literals it protects.
- **The per-issue vacuous pass is closed.** `homing-guard check --issue N` and `pitch-guard check --issue N` used to return `pass: true` — "out of scope, nothing to check" — for an issue lacking the scoping label. That is the ordinary answer *in a repo that has the label*; in a repo that does not, **every** issue takes that fork and the seam guard reports clean forever. Issue scope now carries the resolved label presence as a **required** field, so the un-disambiguated pass is unrepresentable rather than merely unchecked. The backlog fork is untouched — it already failed closed correctly.
- **A missing or zero-arc `ROADMAP.md` is a named unmet prerequisite** of the preflight, alongside the labels. `roadmap view` is untouched and stays a read-only render (see repair round 1 below).
- **No configuration surface was added.** The two frozen-literal docblocks that record "widening this set is a founder ruling" stay true; the remedy the preflight prints is `gh label create`, explicitly not "point the tools at a different vocabulary".

Verified live end to end: against this repo the preflight passes (16 labels, 4 arcs, 16 campaigns) and `homing-guard check --issue 4272` is unchanged; against a foreign repo carrying none of the taxonomy, the preflight and both per-issue guards exit 1 naming the missing labels.

## Deviations

**1. Scope narrowing — the §CP `.decisions/` content clause is NOT touched (class: narrowed a suggested fix-shape).**
*Said:* the filed report's open question 4 asked whether `cp-classify`'s `CP_CONTENT_PREFIX = ".decisions/"` is the same class of hardcoded assumption.
*Did:* left it entirely alone. No acceptance criterion in this issue depends on it.
*Why:* the triaged issue already places it out of scope and hands §CP-in-a-foreign-repo to #4271, whose ruling — what §CP protection degrades to in a repo with no formats doc — is not yet made. Deciding it here would pre-empt that ruling.
*Disposition:* #4271 owns it; nothing was deferred out of this issue's own ACs.

**2. `roadmap view` gained a failure mode (class: went beyond the literal instruction).**
*Said:* AC3 asks that a missing or unparseable `ROADMAP.md` surface as a named unmet prerequisite, and the issue says that belongs "in that same preflight".
*Did:* put the judgement in the preflight **and** called it from `roadmap view`, which now fails `PrerequisiteUnmet` on a `ROADMAP.md` that parses zero arcs. `view.ts`'s docblock calls itself read-only with "no verdict".
*Why:* the preflight alone would have left `roadmap view` still rendering an empty tree for an unparseable roadmap, which is the exact "surfaces as an empty roadmap" the AC forbids. Reading it as preflight-only would satisfy the letter and not the criterion.
*Disposition:* for the reviewer to judge — revert the `view.ts` leg if the read-only framing is meant to be absolute. **[Superseded in repair round 1 — the reviewer judged it, and it was reverted. See entry 7.]**

**3. Four previously-private constants were exported (class: widened an untouched module's surface).**
*Said:* nothing in the issue asked to change `roadmap.ts`, `triage-labels.ts`, or `type-route.ts`.
*Did:* exported `PRIORITY_LABELS`, added `SPINE_LABELS`, added `ISSUE_TYPE_LABELS` — derived label forms — so the required set is assembled from source.
*Why:* the alternative is retyping the vocabulary a second time inside the preflight, which is the drift this issue exists to protect against; a preflight that can disagree with the tools it guards is worse than none.
*Disposition:* no action needed — all three are pure derivations of an existing constant, and no behavior changes.

**4. Not wired into CI (class: left work for a follow-up).**
*Said:* the issue does not ask for a CI job.
*Did:* registered the tool but added no workflow.
*Why:* the preflight is an adoption-time prerequisite check for a *foreign* repo, not a phoenix invariant — this repo passes it by construction, so a CI job here would be a permanently-green gate. A workflow file would also make this diff §CP for a reason unrelated to its content.
*Disposition:* for the reviewer to judge whether the Pipeline Anywhere acceptance test (#4268) should invoke it. **[Judged in review: the outcome — no CI job — was PASSed, but both reasons above were corrected on the record. See entry 7.]**

**5. This PR is §CP-classified and needs a human merge.**
*Said:* nothing; this is a mechanical consequence worth stating rather than letting the gate discover.
*Did:* `packages/pipeline-cli/src/registry.ts` is the one changed path matching `CONTROL_PLANE_RE` (via `^packages/pipeline-cli/src/[^/]+$`); `pipeline-cli cp-classify classify` returns `control-plane [path-match] — BLOCKING (human merge)`.
*Why:* registering a tool requires a registry row, and there is no non-§CP way to add a `pipeline-cli` verb.
*Disposition:* no action needed — routed to a human merge per ADR 0053.

**6. The doc-to-code `SPINE_STAGES` drift surface is untouched.**
*Said:* the issue names it and recommends it as its own unit.
*Did:* left it; `SPINE_LABELS` derives from the same in-code set and adds no new mechanical link to the prose table.
*Why:* explicitly out of scope per the issue.
*Disposition:* the issue's triage comment recommends it as a separate unit.

**7. (repair round 1) Two edits beyond the literal reverted lines (class: went slightly beyond the instruction).**
*Said:* the verdict's remedy is "revert `view.ts` to its state on `main`", plus the recorded nit that `TRIAGED_LABEL` is not imported.
*Did:* reverted `view.ts` in full and derived `status:triaged` by construction — and, additionally, (a) rewrote the now-stale `judgeRoadmap` docblock in `vocabulary.ts`, which advertised the removed `roadmap view` caller, and (b) dropped the corresponding `roadmap view` bullet from this body's "What changed".
*Why:* both statements describe a caller that no longer exists. Leaving them is the same self-contradiction the verdict failed the `view.ts` docblock for, only pointing the other way.
*Disposition:* no action needed. Nothing else in the diff moved: the split local/remote read is untouched (the verdict PASSed it as a pre-existing cross-tool property of `roadmap-guard` too, with a follow-up covering both), and no CI job was added — the verdict PASSed that omission on outcome while correcting both of the reasons entry 4 gave for it, and a CI job argued on taxonomy-drift-detection merit is a follow-up, not this PR.
