### PR TITLE
fix(pano): thread the owner-scoped sandboxed flag onto the Comment wire (#4282)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -16,6 +16,7 @@ import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
+import {ReviewBadge} from "../ui/ReviewBadge";
 import {useVoteFlash} from "../useVoteFlash";
 import {VoteTriangle} from "../VoteTriangle";
 import {currentLocationReturnTo, useVoteToggle} from "./useVoteToggle";
@@ -27,6 +28,7 @@ export const CommentTreeNodeView = view<Comment>()({
 	body: true,
 	score: true,
 	myVote: true,
+	sandboxed: true,
 	createdAt: true,
 	updatedAt: true,
 	deletedAt: true,
@@ -116,6 +118,9 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 						{actorLabel(data.authorDisplayName ?? null, data.authorUsername ?? null, data.author)}
 					</a>
 				)}
+				{/* Owner-only in-review signal (#4282): `sandboxed` is owner-scoped server-side,
+				    re-gated on `isOwner` — same shape as `PanoPostHeader` / `DefinitionCard`. */}
+				{isOwner && data.sandboxed ? <ReviewBadge /> : null}
 				<span>{formatAgoTR(toIso(data.createdAt))}</span>
 				<EditedIndicator createdAt={toIso(data.createdAt)} updatedAt={toIso(data.updatedAt)} />
 				{!isDeleted ? (

--- a/apps/web/src/fate/optimisticCommentAdd.realstore.test.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.realstore.test.ts
@@ -104,6 +104,7 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 			body: "merhaba",
 			author: "umut",
 			authorId: "user_1",
+			sandboxed: false,
 			now,
 		});
 		const tempId = toEntityId("Comment", record.id);
@@ -127,6 +128,7 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 			body: "merhaba",
 			author: "umut",
 			authorId: "user_1",
+			sandboxed: false,
 			now,
 		});
 		const tempId = toEntityId("Comment", record.id);
@@ -155,6 +157,7 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 			body: "merhaba",
 			author: "umut",
 			authorId: "user_1",
+			sandboxed: false,
 			now,
 		});
 		const tempId = toEntityId("Comment", record.id);
@@ -191,6 +194,7 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 			body: "merhaba",
 			author: "umut",
 			authorId: "user_1",
+			sandboxed: false,
 			now,
 		});
 		// The pre-fix id: the bare record id, NOT toEntityId-qualified.

--- a/apps/web/src/fate/optimisticCommentAdd.test.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.test.ts
@@ -28,6 +28,7 @@ describe("optimisticCommentRecord — the temp node payload", () => {
 			body: "merhaba",
 			author: "umut",
 			authorId: "user_1",
+			sandboxed: false,
 			now: fixedNow,
 		});
 		expect(record).toEqual({
@@ -39,11 +40,29 @@ describe("optimisticCommentRecord — the temp node payload", () => {
 			// server initial: score 0, no self-vote (else a phantom self-upvote flash, #707)
 			score: 0,
 			myVote: null,
+			// a yazar's comment is live on arrival — no `incelemede` badge
+			sandboxed: false,
 			createdAt: fixedNow,
 			updatedAt: fixedNow,
 			// live node, not a [silindi] tombstone
 			deletedAt: null,
 		});
+	});
+
+	// The false-publish this whole change exists to close (#4282): without the flag the
+	// çaylak's own node renders identically to a published one for the entire optimistic
+	// window, and the reconciled server row then flips it — a visible lie, then a flicker.
+	it("carries sandboxed for a çaylak author so the temp node never poses as published", () => {
+		const record = optimisticCommentRecord({
+			postId: "post_1",
+			parentId: null,
+			body: "ilk yorumum",
+			author: "umut",
+			authorId: "user_1",
+			sandboxed: true,
+			now: fixedNow,
+		});
+		expect(record.sandboxed).toBe(true);
 	});
 
 	it("carries the parentId for a reply (same nested connection as top-level)", () => {
@@ -53,6 +72,7 @@ describe("optimisticCommentRecord — the temp node payload", () => {
 			body: "yanıt",
 			author: "umut",
 			authorId: "user_1",
+			sandboxed: false,
 			now: fixedNow,
 		});
 		expect(record.parentId).toBe("comm_parent");

--- a/apps/web/src/fate/optimisticCommentAdd.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.ts
@@ -44,6 +44,13 @@ export interface OptimisticCommentInput {
 	readonly author: string;
 	/** The author's user id — drives the edit/delete affordance gate on the node. */
 	readonly authorId: string;
+	/**
+	 * Whether this author's new comment lands sandboxed — `sandboxesNewContent(me.tier)`,
+	 * the SAME rule the server's `sandboxedAtForAuthor` applies. Required, not optional:
+	 * a forgotten flag renders a çaylak's comment as published for the whole optimistic
+	 * window, which is the false-publish this exists to prevent (#4282).
+	 */
+	readonly sandboxed: boolean;
 	/** The submit instant — seeds the temp id and `createdAt`/`updatedAt`. */
 	readonly now: Date;
 }
@@ -54,7 +61,8 @@ export interface OptimisticCommentInput {
  * the HTTP result arrives. `score`/`myVote` mirror the server's initial comment row
  * (score 0, no self-vote — `comment-operations.ts` `addComment`), else the reconciled
  * row flashes a phantom self-upvote (the #707 class); `deletedAt: null` renders the
- * node live (not a `[silindi]` tombstone).
+ * node live (not a `[silindi]` tombstone). `sandboxed` mirrors the server's create-time
+ * tier rule so a çaylak's node shows `incelemede` from the instant of submit (#4282).
  */
 export function optimisticCommentRecord(input: OptimisticCommentInput) {
 	return {
@@ -65,6 +73,7 @@ export function optimisticCommentRecord(input: OptimisticCommentInput) {
 		authorId: input.authorId,
 		score: 0,
 		myVote: null,
+		sandboxed: input.sandboxed,
 		createdAt: input.now,
 		updatedAt: input.now,
 		deletedAt: null,

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -14,7 +14,9 @@ import * as React from "react";
 import {useFateClient, useLiveListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link, useLocation, useNavigate, useParams} from "react-router";
 import type {Post, ReportReceipt} from "../../worker/features/fate/views";
+import {sandboxesNewContent} from "../../worker/features/kunye/standing";
 import {useSession} from "../auth/client";
+import {useMe} from "../auth/useMe";
 import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
 import {actorLabel} from "../components/moderation/actor-identity";
 import {CommentTreeNode, CommentTreeNodeView} from "../components/pano/CommentTreeNode";
@@ -626,6 +628,10 @@ function Comments(props: CommentsProps) {
 	// into the SAME nested `Post.comments` connection). Null unless the author identity
 	// is known — the temp node mirrors the author, so a missing name/id degrades cleanly
 	// to the non-optimistic round-trip.
+	// `sandboxed` comes from the trusted account tier on the fate `me` view (#1297), the
+	// same signal `FirstContributionOnramp` gates on — so the temp node predicts the
+	// server's create-time answer instead of flashing as published (#4282).
+	const {me} = useMe();
 	const optimisticComment = React.useMemo(
 		() =>
 			props.currentUserId != null && props.currentUserName != null
@@ -633,9 +639,10 @@ function Comments(props: CommentsProps) {
 						connection: post.comments,
 						author: props.currentUserName,
 						authorId: props.currentUserId,
+						sandboxed: sandboxesNewContent(me?.tier),
 					}
 				: null,
-		[post.comments, props.currentUserId, props.currentUserName],
+		[post.comments, props.currentUserId, props.currentUserName, me?.tier],
 	);
 
 	const composerFor = React.useCallback(
@@ -795,6 +802,8 @@ function CommentComposer({
 		connection: unknown;
 		author: string;
 		authorId: string;
+		/** Whether this author's comment lands in the çaylak sandbox (#4282). */
+		sandboxed: boolean;
 	} | null;
 	autoFocus?: boolean;
 }) {
@@ -819,6 +828,7 @@ function CommentComposer({
 						body: value,
 						author: optimistic.author,
 						authorId: optimistic.authorId,
+						sandboxed: optimistic.sandboxed,
 						now: new Date(),
 					})
 				: undefined;

--- a/apps/web/tests/e2e/17-pano-add-comment.spec.ts
+++ b/apps/web/tests/e2e/17-pano-add-comment.spec.ts
@@ -62,6 +62,17 @@ test.describe("Pano addComment", () => {
 			timeout: 10_000,
 		});
 
+		// The owner-scoped in-review signal (#4282). This author signed up in this test and
+		// was never promoted, so they are a çaylak by default and their comment really is
+		// sandboxed — the flag is derived from live server state, not a fixture. Scoped to
+		// the comment's own `<article id="comment-…">` because the çaylak's POST is
+		// sandboxed too and renders its own badge in the header.
+		const ownComment = page
+			.locator('article[id^="comment-"]')
+			.filter({hasText: topLevelBody})
+			.first();
+		await expect(ownComment.getByTestId("incelemede-badge")).toBeVisible({timeout: 10_000});
+
 		// Click "yanıtla" on the top-level comment. Pick the first reply trigger
 		// — there's only one comment so this is unambiguous.
 		const replyTrigger = page.locator('[data-testid^="pano-comment-reply-trigger-"]').first();

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -24,6 +24,7 @@ import {Brand, Effect} from "effect";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {Kunye} from "./Kunye.ts";
 import {requireModeration} from "./moderate.ts";
+import {sandboxesNewContent} from "./standing.ts";
 
 /**
  * The `sandboxed_at` timestamp a new piece of content by `authorId` is created
@@ -37,7 +38,7 @@ export const sandboxedAtForAuthor = (
 	Effect.gen(function* () {
 		const kunye = yield* Kunye;
 		const tier = yield* kunye.tierOf(authorId);
-		return tier === "çaylak" ? now : null;
+		return sandboxesNewContent(tier) ? now : null;
 	});
 
 /**

--- a/apps/web/worker/features/kunye/standing.ts
+++ b/apps/web/worker/features/kunye/standing.ts
@@ -26,6 +26,15 @@ export const STORED_TIERS = ["çaylak", "yazar"] as const;
 export type StoredTier = (typeof STORED_TIERS)[number];
 
 /**
+ * Whether content authored at this tier lands in the mod-only sandbox (#1205): a
+ * çaylak's does, a yazar's is live. Pure and dependency-free so the SAME rule serves
+ * both sides of the create — the server's `sandboxedAtForAuthor` (`kunye/sandbox.ts`)
+ * and the client's optimistic comment node, which must predict the server's answer or
+ * the çaylak's own comment flashes as published before reconciliation (#4282).
+ */
+export const sandboxesNewContent = (tier: Tier | undefined): boolean => tier === "çaylak";
+
+/**
  * The `visitor < çaylak < yazar` ladder (ADR 0107 §4) — the canonical kamp.us
  * `Scale` the `Authorship` `Capability.Level` instances (#1235) floor against
  * (`AddEntry` = çaylak, `OpenTerm` = yazar).

--- a/apps/web/worker/features/kunye/standing.unit.test.ts
+++ b/apps/web/worker/features/kunye/standing.unit.test.ts
@@ -7,7 +7,12 @@
  */
 import {describe, it} from "@effect/vitest";
 import {assert} from "vitest";
-import {KARMA_THRESHOLDS, promotionBarFor, VOUCH_PROMOTION_KARMA_BAR} from "./standing.ts";
+import {
+	KARMA_THRESHOLDS,
+	promotionBarFor,
+	sandboxesNewContent,
+	VOUCH_PROMOTION_KARMA_BAR,
+} from "./standing.ts";
 
 describe("promotionBarFor", () => {
 	it("a vouched çaylak clears the reduced tandem bar", () => {
@@ -20,5 +25,29 @@ describe("promotionBarFor", () => {
 
 	it("the vouch-assisted bar is strictly lower than the unassisted one", () => {
 		assert.isBelow(promotionBarFor(true), promotionBarFor(false));
+	});
+});
+
+/**
+ * The create-time sandbox rule, shared by BOTH sides of a write (#4282): the server's
+ * `sandboxedAtForAuthor` and the client's optimistic comment node. They must agree —
+ * a client that guesses differently renders a çaylak's comment as published for the
+ * whole optimistic window, which is exactly the false-publish being closed.
+ */
+describe("sandboxesNewContent", () => {
+	it("a çaylak's new content lands sandboxed", () => {
+		assert.strictEqual(sandboxesNewContent("çaylak"), true);
+	});
+
+	it("a yazar's new content is live", () => {
+		assert.strictEqual(sandboxesNewContent("yazar"), false);
+	});
+
+	// A visitor authors nothing, and an unresolved tier (the `me` read still settling on
+	// the client) must not guess `true` — an unwarranted `incelemede` on a yazar's comment
+	// is as dishonest as the missing one on a çaylak's.
+	it("a visitor and an unresolved tier both read false", () => {
+		assert.strictEqual(sandboxesNewContent("visitor"), false);
+		assert.strictEqual(sandboxesNewContent(undefined), false);
 	});
 });

--- a/apps/web/worker/features/pano/comment-fields.ts
+++ b/apps/web/worker/features/pano/comment-fields.ts
@@ -51,6 +51,13 @@ type IntrinsicRow = {[K in keyof typeof intrinsicFields]: ReturnType<(typeof int
 export interface CommentRow extends IntrinsicRow {
 	myVote?: boolean | null;
 	/**
+	 * The owner-scoped in-review flag (#4282, the `Comment` leg of #2200) — the twin of
+	 * `PostSummaryRow.sandboxed`: stamped by the read paths via `ownSandboxed`, so it is
+	 * `true` only for the author's own still-sandboxed comment. `undefined` when a read
+	 * doesn't stamp it; the shaper then defaults `false`.
+	 */
+	sandboxed?: boolean;
+	/**
 	 * The author's LIVE handle (`user_profile.username` / `.displayName`), stamped by
 	 * `stampAuthorIdentity` after the batched `getProfileIdentitiesByIds` read (#2139)
 	 * so the client renders the CURRENT display name via `actorLabel`, not the write-time
@@ -81,6 +88,7 @@ export type CommentFields = Omit<IntrinsicRow, "updatedAt" | "deletedAt"> & {
 	updatedAt?: Date | null;
 	deletedAt?: Date | null;
 	myVote?: boolean | null;
+	sandboxed?: boolean;
 	authorUsername?: string | null;
 	authorDisplayName?: string | null;
 	reactions?: ReactionAggregate;
@@ -112,6 +120,7 @@ export const commentViewFields = {
 	updatedAt: true,
 	deletedAt: true,
 	myVote: true,
+	sandboxed: true,
 	authorUsername: true,
 	authorDisplayName: true,
 	reactions: true,

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -28,6 +28,7 @@ import {applyRemovalTransition} from "../lifecycle/apply-removal-transition.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
+	ownSandboxed,
 	resolveSandboxViewer,
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
@@ -303,18 +304,27 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 	// wire-facing `CommentRow` is the removal timestamp (presentation contract).
 	// The live shape comes from the `comment-fields.ts` column→field map; the
 	// tombstone overrides the four presentation fields it elides.
-	const rowToCommentRow = (row: typeof schema.commentRecord.$inferSelect): CommentRow => {
+	// `viewerId` is a REQUIRED parameter, not an optional with a default: `sandboxed` is
+	// owner-scoped, so every call site must state whose view it is shaping. A viewer-blind
+	// call site (the moderator queue, a broadcast payload) passes `null` deliberately and
+	// gets `false` — the one safe answer for a row that may reach a non-author (#4282).
+	const rowToCommentRow = (
+		row: typeof schema.commentRecord.$inferSelect,
+		viewerId: string | null,
+	): CommentRow => {
+		const sandboxed = ownSandboxed(row, viewerId);
 		const lifecycle = Removal.fromColumns(row);
 		if (Removal.isRemoved(lifecycle)) {
 			return {
 				...toCommentRow(row),
+				sandboxed,
 				author: "",
 				authorId: "",
 				body: SILINDI_PLACEHOLDER,
 				deletedAt: lifecycle.removedAt,
 			};
 		}
-		return toCommentRow(row);
+		return {...toCommentRow(row), sandboxed};
 	};
 
 	const listCommentsKeyset = Effect.fn("Pano.listCommentsKeyset")(function* (
@@ -404,7 +414,12 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				.limit(first + 1),
 		);
 
-		const page = forwardPage(fetched, first, (r: CommentRow) => r.id, rowToCommentRow);
+		const page = forwardPage(
+			fetched,
+			first,
+			(r: CommentRow) => r.id,
+			(row) => rowToCommentRow(row, viewerId),
+		);
 		const rows = yield* stampComments(page.rows, viewerId, opts.parallelStamps ?? false);
 
 		return {...page, rows, totalCount} satisfies CommentConnectionPage;
@@ -442,7 +457,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				),
 		);
 		return yield* stampComments(
-			fetched.map(rowToCommentRow),
+			fetched.map((row) => rowToCommentRow(row, viewerId)),
 			viewerId,
 			opts.parallelStamps ?? false,
 		);
@@ -471,7 +486,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				)
 				.orderBy(desc(schema.commentRecord.createdAt)),
 		);
-		return fetched.map(rowToCommentRow);
+		// The moderator queue is viewer-blind by construction — it reads OTHER people's
+		// pending comments, so the owner-scoped flag is `false` for every row here.
+		return fetched.map((row) => rowToCommentRow(row, null));
 	});
 
 	const lookupCommentPostId = Effect.fn("Pano.lookupCommentPostId")(function* (commentId: string) {
@@ -642,7 +659,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				commentId: input.commentId,
 				deleted: false,
 				hasReplies: true,
-				placeholder: rowToCommentRow(row),
+				// Viewer-blind: the placeholder is published to the whole thread topic
+				// (`live.comment.update`), so it must never carry an owner-scoped flag.
+				placeholder: rowToCommentRow(row, null),
 			} satisfies DeleteCommentResult;
 		}
 

--- a/apps/web/worker/features/pano/comment-sandboxed-wire.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-sandboxed-wire.unit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The `Comment` owner-scoped in-review flag on the wire (#4282) — the third leg of
+ * #2200, which threaded `sandboxed` onto `Post` and `Definition` and left `Comment`
+ * out. Without it a çaylak's own comment renders identically to a published one and
+ * they quietly believe they contributed.
+ *
+ * Three things are pinned here, in the order a value travels:
+ *   1. the derivation is the SHARED `ownSandboxed` helper — owner-only by
+ *      construction, so no other viewer (member, anonymous, moderator) ever reads
+ *      `true` off someone else's comment;
+ *   2. the field is in the closed `commentViewFields` literal, so the fate view
+ *      actually carries it (the `satisfies Record<keyof CommentRow, true>` pin means
+ *      an omission is a compile error, but a *present* field is worth asserting —
+ *      that literal is what `CommentView` derives from);
+ *   3. the wire shaper defaults an unstamped row to `false`, matching `toPost`.
+ *
+ * The stamping call sites are compile-locked rather than tested here: `rowToCommentRow`
+ * takes `viewerId` as a REQUIRED parameter, so a read path cannot forget to state whose
+ * view it is shaping.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {ownSandboxed} from "../lifecycle/SandboxVisibility.ts";
+import {commentViewFields} from "./comment-fields.ts";
+import {toComment} from "./shapers.ts";
+
+const AUTHOR = "user-author";
+const OTHER = "user-other";
+
+const commentFields = (over: {sandboxed?: boolean} = {}) => ({
+	id: "comm-1",
+	parentId: null,
+	author: "umut",
+	authorId: AUTHOR,
+	body: "merhaba",
+	score: 0,
+	createdAt: new Date(1000),
+	...over,
+});
+
+describe("ownSandboxed over a comment record — owner-only by construction", () => {
+	const sandboxedRecord = {sandboxedAt: new Date(1000), authorId: AUTHOR};
+	const liveRecord = {sandboxedAt: null, authorId: AUTHOR};
+
+	it("the author of a still-sandboxed comment reads true", () => {
+		assert.strictEqual(ownSandboxed(sandboxedRecord, AUTHOR), true);
+	});
+
+	it("another signed-in member reads false, never the author's review state", () => {
+		assert.strictEqual(ownSandboxed(sandboxedRecord, OTHER), false);
+	});
+
+	// A moderator IS a viewer with an id, and the sandbox read filter admits them to the
+	// row — so the flag must stay keyed on authorship, not on visibility, or the mod queue
+	// would render every pending comment as the moderator's own in-review content.
+	it("a moderator reading someone else's pending comment reads false", () => {
+		assert.strictEqual(ownSandboxed(sandboxedRecord, "user-moderator"), false);
+	});
+
+	it("an anonymous viewer reads false", () => {
+		assert.strictEqual(ownSandboxed(sandboxedRecord, null), false);
+	});
+
+	it("a live comment reads false even for its own author", () => {
+		assert.strictEqual(ownSandboxed(liveRecord, AUTHOR), false);
+	});
+});
+
+describe("the Comment wire shape carries sandboxed", () => {
+	it("commentViewFields selects it, so CommentView exposes it to the client", () => {
+		assert.strictEqual(commentViewFields.sandboxed, true);
+	});
+
+	it("toComment passes a stamped flag through", () => {
+		assert.strictEqual(toComment(commentFields({sandboxed: true})).sandboxed, true);
+	});
+
+	// The safe default, matching `toPost`: a read path that doesn't stamp the flag yields
+	// a published-looking node, never an accidental `incelemede` on live content.
+	it("toComment defaults an unstamped row to false", () => {
+		assert.strictEqual(toComment(commentFields()).sandboxed, false);
+	});
+});

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -27,6 +27,7 @@ import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {InsufficientKarma} from "../kunye/errors.ts";
 import {gateContentOnKarma} from "../kunye/privilege.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {ownSandboxed} from "../lifecycle/SandboxVisibility.ts";
 import {authorDisplayLabel} from "../pasaport/author-label.ts";
 import {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {Bookmark} from "./Bookmark.ts";
@@ -158,6 +159,10 @@ const shapePost = (r: {
 		tags: r.tags,
 	});
 
+// `sandboxed` is REQUIRED here, never optional-with-a-default: it is owner-scoped
+// (#4282), and every one of these results is either returned to a specific viewer or
+// broadcast to the viewer-blind thread topic. Forcing each call site to state the value
+// is what keeps a broadcast payload from silently inheriting an author's review state.
 const shapeComment = (r: {
 	commentId: string;
 	parentId: string | null;
@@ -168,6 +173,7 @@ const shapeComment = (r: {
 	createdAt: Date;
 	updatedAt?: Date;
 	myVote?: boolean | null;
+	sandboxed: boolean;
 }): Comment =>
 	toComment({
 		id: r.commentId,
@@ -179,6 +185,7 @@ const shapeComment = (r: {
 		createdAt: r.createdAt,
 		updatedAt: r.updatedAt ?? null,
 		myVote: r.myVote ?? null,
+		sandboxed: r.sandboxed,
 	});
 
 export const mutations = {
@@ -544,7 +551,14 @@ export const mutations = {
 					sandboxedAt,
 					...(input.parentId ? {parentId: input.parentId} : {}),
 				});
-				const comment = shapeComment({...r, myVote: null});
+				// Safe to stamp the owner-scoped flag on this value even though it is also the
+				// broadcast node (#4282): the append below is `decidePublish`-gated, so a node
+				// whose flag is `true` is exactly the node that is never broadcast.
+				const comment = shapeComment({
+					...r,
+					myVote: null,
+					sandboxed: ownSandboxed({sandboxedAt, authorId: r.authorId}, user.id),
+				});
 				// Append to the `Post.comments` topic keyed by the parent post id — but
 				// only when the comment is live: the thread topic is viewer-blind, so a
 				// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
@@ -585,7 +599,9 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.voteOnComment({commentId: input.id, voterId: UserId.make(user.id)});
-			const comment = shapeComment(r);
+			// Viewer-blind broadcast payload: a self-vote is rejected, so the voter is never the
+			// author and the owner-scoped flag is `false` for them regardless (#4282).
+			const comment = shapeComment({...r, sandboxed: false});
 			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
 			// Aggregated vote notification (#1698): see `post.vote` — a landed upvote
 			// notifies the comment author, rolled up per item, on a real state change only.
@@ -614,7 +630,8 @@ export const mutations = {
 				commentId: input.id,
 				voterId: UserId.make(user.id),
 			});
-			const comment = shapeComment(r);
+			// Viewer-blind broadcast payload — see `comment.vote`.
+			const comment = shapeComment({...r, sandboxed: false});
 			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
 			return comment;
 		}),
@@ -689,8 +706,18 @@ export const mutations = {
 				body: input.body,
 			});
 			const [fresh] = yield* pano.getCommentsByIds([r.commentId], {viewerId: user.id});
-			const comment = shapeComment({...r, myVote: fresh?.myVote ?? null});
-			yield* live.comment.update(comment.id, {changed: ["body"], data: comment});
+			const comment = shapeComment({
+				...r,
+				myVote: fresh?.myVote ?? null,
+				sandboxed: fresh?.sandboxed ?? false,
+			});
+			// The thread topic is viewer-blind (#1205), so the broadcast payload is stripped of
+			// the owner-scoped flag while the author's own returned node keeps it — an edit must
+			// not fan a çaylak's review state out to subscribers (#4282).
+			yield* live.comment.update(comment.id, {
+				changed: ["body"],
+				data: {...comment, sandboxed: false},
+			});
 			return comment;
 		}),
 	),

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -115,5 +115,6 @@ export const toComment = (r: CommentFields): Comment => ({
 	updatedAt: r.updatedAt ?? r.createdAt,
 	deletedAt: r.deletedAt ?? null,
 	myVote: r.myVote ?? null,
+	sandboxed: r.sandboxed ?? false,
 	reactions: r.reactions ?? EMPTY_REACTION_AGGREGATE,
 });


### PR DESCRIPTION
A brand-new user (a çaylak) has their first comments held for review, but nothing on
screen said so — the comment rendered exactly like a published one, so the author
believed they had contributed, got no replies, and had no way to know why. Posts and
definitions already show their author an "incelemede" badge in this state; comments
never did, because the flag that drives it was missing from the comment's wire shape
entirely. This adds it, and mounts the same badge in the comment tree.

Fixes #4282

## What changed

**Worker — the wire shape.** `sandboxed` joins `CommentRow`, `commentViewFields`, and
`CommentFields`; `toComment` defaults it to `false` exactly like `toPost`. The
`satisfies Record<keyof CommentRow, true>` pin means the row, the view, and the shaper
moved together or not at all.

**Worker — the stamps.** Every read path derives the value through the existing shared
`ownSandboxed(record, viewerId)` helper — no second derivation. `rowToCommentRow` now
takes `viewerId` as a **required** parameter rather than an optional one, so no call
site can silently forget whose view it is shaping; the two viewer-blind call sites (the
moderator sandbox queue, the delete tombstone placeholder) pass `null` deliberately and
therefore read `false`.

**Worker — the mutations.** `shapeComment` requires `sandboxed` for the same reason. The
values are chosen per site so a viewer-blind broadcast can never carry an author's
review state:

- `comment.add` carries the owner-scoped value. Safe because its thread append is
  `decidePublish`-gated — a node whose flag is `true` is exactly the node that is never
  broadcast.
- `comment.edit` returns the owner-scoped node to the author but strips the flag from
  its `live.comment.update` frame, which is not sandbox-gated.
- `comment.vote` / `comment.retractVote` pass `false`: a self-vote is rejected, so the
  voter is never the author.

**Client.** `CommentTreeNode` selects `sandboxed` and mounts the existing `ReviewBadge`
behind the established `isOwner && sandboxed` gate — the same shape `PanoPostHeader` and
`DefinitionCard` already use. No new visual vocabulary.

**Client — the optimistic node.** `optimisticCommentRecord` now requires a `sandboxed`
flag, fed from a new shared predicate `sandboxesNewContent(tier)` in
`kunye/standing.ts`. The server's `sandboxedAtForAuthor` now reads that same predicate,
so the optimistic node cannot guess a different answer than the server will give — which
is what kept the çaylak's comment looking published for the whole optimistic window.

## Containment

Unchanged, and deliberately so. Reads stay filtered by `sandboxVisibleWhere`, the
`/fate/live` thread append stays gated by `decidePublish`, and `nextCommentCount` still
steps the parent post's public count by `0` for a sandboxed comment. `comment.add` is a
fanned mutation and still publishes its invalidation; `pipeline-cli fanout-guard check`
passes (49 classified, 24 fanned).

## Verification

- `pnpm typecheck` — clean. Making `sandboxed` a required parameter is what surfaced
  every call site; nothing was found by reading.
- `pnpm lint:worktree` — clean.
- Unit tier — full suite green (287 files / 2420 tests). New coverage:
  `comment-sandboxed-wire.unit.test.ts` pins the owner-scoping across all five viewer
  cases (author, other member, moderator, anonymous, live comment) plus the view-field
  and shaper-default legs; `standing.unit.test.ts` pins the shared tier predicate
  including the unresolved-tier case.
- E2E — `17-pano-add-comment.spec.ts` gains an assertion that the badge renders on the
  author's own comment, scoped to that comment's `<article>` so the çaylak's own
  sandboxed *post* badge cannot satisfy it. **I could not execute this locally — see
  Deviations.**

## Deviations

**Class: a check I could not run.** I attempted the real-state e2e verification rather
than arguing from source. `pnpm dev` boots the Vite SPA but `alchemy dev` fails to
provision the Flagship app resource without Cloudflare API credentials, which are not
present in this environment (`Unauthorized: Authentication error` on
`GET /accounts/{account_id}/flagship/apps`; the worker never binds `:1337`, so every
`/api/*` call is `ECONNREFUSED` and the spec's sign-up cannot complete). *Said:* verify
the badge against a real çaylak's real comment. *Did:* wrote the e2e assertion and
shipped it, but ran only the unit tier locally. *Why:* no credentials in this
environment. *Disposition:* for the reviewer to judge — CI/preview runs the e2e lane, so
the assertion is exercised there; I am explicitly not claiming I saw the badge render.

**Class: a judgment call the issue did not specify.** The issue's fix direction said to
default `sandboxed` in `toComment` and stamp it at the read paths. I additionally made
`rowToCommentRow`'s `viewerId` and `shapeComment`'s `sandboxed` **required** rather than
optional. *Why:* an owner-scoped flag that a call site can omit is a state where the
value silently defaults to something plausible; requiring it moves that from a review
question to a compile error, and it did in fact catch every site. *Disposition:* no
action needed.

**Class: a shared helper the issue did not ask for.** I extracted
`sandboxesNewContent(tier)` into `kunye/standing.ts` and pointed both the server's
`sandboxedAtForAuthor` and the client's optimistic node at it. *Why:* the client needs
the create-time rule to satisfy AC#4, and the alternative was a second `tier === "çaylak"`
literal on the client — the "no second derivation" the ACs ask for on the read side
applies equally here. *Disposition:* no action needed.

**Class: overlap with a just-merged sibling.** #4295 (issue #4283) landed on `main`
while this was in flight and touches `apps/web/src/pages/PanoPostDetail.tsx`, which this
PR also edits (the optimistic bundle). This branch is cut from the post-#4295 tip, so it
is rebased *onto* it, not around it. The edits are in different functions and did not
conflict. *Disposition:* no action needed; flagged so the reviewer knows the two touched
one file.
