### PR TITLE
fix(review-code): the glossary gate says so when it cannot see (#4299)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1068,13 +1068,25 @@ NEW_SURFACE="$(printf '%s %s %s' "$NEW_FEATURE_DIRS" "$NEW_PACKAGES" "$PUBLIC_EN
 
 # does the PR touch the glossary's domain-noun file? (added OR modified — any touch counts)
 GLOSSARY_TOUCHED="$(printf '%s\n' "$FILES_STATUS" | awk -F'\t' '$2==".glossary/TERMS.md"{print}')"
+
+# POSITIVE EVIDENCE OF SCOPE (§ZS / ADR 0092's "default FAIL, pass on positive evidence"): can the
+# three detectors above express ANYTHING in this repo at all? An empty $NEW_SURFACE has two causes —
+# "this PR added no surface" (a fact about the PR) and "this repo has no surface of the kind I know
+# how to look for" (a fact about the DETECTOR) — and until this probe they produced the identical
+# not-applicable line (#4299). Read-only, against fresh base, same as every probe above.
+DETECTOR_SURFACES="$(
+  git ls-tree --name-only "origin/$BASE_REF:apps/web/worker/features" 2>/dev/null
+  git ls-tree -r --name-only "origin/$BASE_REF:packages" 2>/dev/null | grep -E '^[^/]+/package\.json$'
+)"
+DETECTOR_SURFACES_N="$(printf '%s\n' "$DETECTOR_SURFACES" | grep -c . || true)"
 ```
 
-**The self-asserting / fail-closed verdict (formats §ZS, ADR 0092) — three outcomes, never a
+**The self-asserting / fail-closed verdict (formats §ZS, ADR 0092) — four outcomes, never a
 silent PASS.** This gate's signature failure mode is *scanning nothing and reading green*, so it
 follows §ZS exactly: it **emits what it scanned** every run, **FAILs on the relevant-but-zero-match**
-case, and expresses a legitimately-empty scope as an **explicit not-applicable skip** — distinct
-from a FAIL:
+case, expresses a legitimately-empty scope as an **explicit not-applicable skip** — distinct from a
+FAIL — and, since an empty scope has **two** causes, refuses to let the detector's own blindness wear
+the skip's clothes:
 
 - **New surface present, `.glossary/TERMS.md` NOT touched ⇒ FAIL** (the relevant-but-zero-match
   case). Emit the new surface you found and that the glossary went untouched. The remedy is in
@@ -1085,11 +1097,22 @@ from a FAIL:
   `[FAIL]` row `write-code` drains next round. Either way the conjunctive verdict reflects it.
 - **New surface present, `.glossary/TERMS.md` touched ⇒ PASS** for this facet — the surface and its
   term shipped together. Cite the new surface + the glossary touch as evidence.
-- **No new surface ⇒ explicit not-applicable skip** (the §ZS #3 out-of-surface case): emit
+- **No new surface, and the detector can express surfaces here (`DETECTOR_SURFACES_N > 0`) ⇒
+  explicit not-applicable skip** (the §ZS #3 out-of-surface case): emit
   `glossary-freshness: not applicable — no new feature folder / public package / export in this PR`
   and **omit the row from the conjunctive table** (a skip, *not* an `UNVERIFIABLE` soft-fail, exactly
   as Step 3b omits its row when the containment marker doesn't fire). The emitted line is the
-  self-assertion that the gate *fired and found nothing in its surface* — never a silent green.
+  self-assertion that the gate *fired and found nothing in its surface* — never a silent green. The
+  `DETECTOR_SURFACES_N > 0` conjunct is what earns the word *skip*: at least one surface of each kind
+  the detector knows exists on base, so "found nothing" is a fact about **this PR**.
+- **No new surface, and the detector can express NOTHING here (`DETECTOR_SURFACES_N == 0`) while
+  `.glossary/TERMS.md` IS on base ⇒ `UNVERIFIABLE` — the gate could not evaluate.** Emit a distinct
+  line naming the detector's inability to match, and fold an **`[UNVERIFIABLE]` row into the
+  conjunctive table** — a soft fail that blocks, not an omitted row. The empty scan is a property of
+  the *detector*, not of the PR, so reporting it as a skip is the accidental zero-match ADR 0092's
+  Consequences ban from wearing the sanctioned skip's clothes (#4299). The remedy belongs to the repo,
+  not the PR author: adopt a layout the detector expresses, drop `.glossary/TERMS.md` (which routes to
+  the honest graceful-absence skip below), or make surface detection declarable.
 
 ```bash
 if [ -n "$(printf '%s' "$NEW_SURFACE" | tr -d ' ')" ]; then
@@ -1100,8 +1123,11 @@ if [ -n "$(printf '%s' "$NEW_SURFACE" | tr -d ' ')" ]; then
     echo "glossary-freshness: FAIL — new surface added but .glossary/TERMS.md untouched (§ZS relevant-but-zero-match)"
     # fold as a FAIL facet in the verdict table (and/or append the in-scope AC per the §2 surface)
   fi
+elif [ "$DETECTOR_SURFACES_N" -gt 0 ]; then
+  echo "glossary-freshness: not applicable — no new feature folder / public package / export in this PR (detector expressible here: $DETECTOR_SURFACES_N candidate surface(s) on base)"   # §ZS #3 skip
 else
-  echo "glossary-freshness: not applicable — no new feature folder / public package / export in this PR"   # §ZS #3 skip
+  echo "glossary-freshness: UNVERIFIABLE — detector blind: .glossary/TERMS.md is on origin/$BASE_REF, but this repo has ZERO surfaces the detector can express (no apps/web/worker/features/* dir, no packages/*/package.json on base). The empty scan is a fact about the DETECTOR, not this PR — it is NOT evidence the PR added no surface."
+  # fold as an [UNVERIFIABLE] facet in the verdict table — a blocking soft fail, never an omitted row
 fi
 ```
 
@@ -1111,12 +1137,18 @@ so the conjunctive verdict (Step 3) accounts for it like any other criterion:
 ```
 - [PASS] glossary-freshness — new feature folder apps/web/worker/features/<x> ships with a .glossary/TERMS.md touch (TERMS.md modified)
 - [FAIL] glossary-freshness — new feature folder apps/web/worker/features/<x> added, but .glossary/TERMS.md untouched; name the surface's concept in TERMS.md (or it is appended as an AC)
+- [UNVERIFIABLE] glossary-freshness — the gate could not evaluate: .glossary/TERMS.md is on base, but this repo contains 0 surfaces the detector's patterns can express, so the empty scan says nothing about this PR
 ```
 
-When there is **no** new surface, **omit this row entirely** (the not-applicable skip), exactly as
-Step 3b omits its flag-gating row when the containment marker doesn't fire — a skip contributes
-nothing to the conjunctive verdict, by design, and is **never** a silent PASS because the emitted
-`not applicable` line above is its self-assertion.
+When there is no new surface **and the detector is expressible here**, **omit this row entirely**
+(the not-applicable skip), exactly as Step 3b omits its flag-gating row when the containment marker
+doesn't fire — a skip contributes nothing to the conjunctive verdict, by design, and is **never** a
+silent PASS because the emitted `not applicable` line above is its self-assertion. The
+detector-blind case is the one empty scan that **does** get a row: it is written into the table as
+`[UNVERIFIABLE]`, so a reader of the verdict artifact can tell "this PR added no new surface" from
+"this gate could not see any surface of the kind it knows how to look for" without opening this
+skill — and, one `UNVERIFIABLE` being a gate failure, the vacuous case stops the line instead of
+reading green.
 
 > **Graceful absence — no `.glossary/TERMS.md` on the base ⇒ no glossary to enforce against.** If
 > the repo has not yet adopted the glossary (`.glossary/TERMS.md` absent on fresh `origin/$BASE_REF`
@@ -1125,6 +1157,13 @@ nothing to the conjunctive verdict, by design, and is **never** a silent PASS be
 > `glossary-freshness: not applicable — no .glossary/TERMS.md on base` and contributes no row. This
 > is the same portability / graceful-absence contract the cycle-doc probe (Step 3b, formats §1) and
 > the milestone default follow — absence is a first-class state, not a defect.
+>
+> **This probe runs FIRST and short-circuits the step** — including the detector-blind
+> `UNVERIFIABLE` above, which is conditioned on the glossary being *present*. A repo that never
+> adopted the glossary has nothing to enforce and gets this honest skip; only a repo that adopted the
+> vocabulary while keeping a layout the detector cannot express reaches the `UNVERIFIABLE` branch.
+> That intersection is the whole defect surface (#4299) — the two states are separate outcomes with
+> separate lines, never one line covering both.
 
 ### Step 3d — Comment-discipline gate: the fresh-eyes judge of comment slop (ADR 0119)
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1115,7 +1115,12 @@ the skip's clothes:
   the honest graceful-absence skip below), or make surface detection declarable.
 
 ```bash
-if [ -n "$(printf '%s' "$NEW_SURFACE" | tr -d ' ')" ]; then
+# The graceful-absence probe LEADS the chain, EXECUTED — never asserted in prose. Every branch below
+# claims the glossary is on base, so a repo that never adopted it must be excluded by a real test or
+# the final `else` states a fact it never checked — the gate's own sin, one branch over (#4299).
+if ! git cat-file -e "origin/$BASE_REF:.glossary/TERMS.md" 2>/dev/null; then
+  echo "glossary-freshness: not applicable — no .glossary/TERMS.md on base"   # graceful absence: no row
+elif [ -n "$(printf '%s' "$NEW_SURFACE" | tr -d ' ')" ]; then
   echo "glossary-freshness: scanned new surfaces ⇒$NEW_SURFACE"   # §ZS #1: emit what it scanned
   if [ -n "$GLOSSARY_TOUCHED" ]; then
     echo "glossary-freshness: PASS — new surface ships with a .glossary/TERMS.md touch"
@@ -1158,9 +1163,10 @@ reading green.
 > is the same portability / graceful-absence contract the cycle-doc probe (Step 3b, formats §1) and
 > the milestone default follow — absence is a first-class state, not a defect.
 >
-> **This probe runs FIRST and short-circuits the step** — including the detector-blind
-> `UNVERIFIABLE` above, which is conditioned on the glossary being *present*. A repo that never
-> adopted the glossary has nothing to enforce and gets this honest skip; only a repo that adopted the
+> **This probe is the executed guard that LEADS the verdict chain above** — it is the chain's first
+> `if`, so the detector-blind `UNVERIFIABLE` branch is structurally unreachable when the glossary is
+> absent, rather than merely documented as coming second. A repo that never adopted the glossary has
+> nothing to enforce and gets this honest skip; only a repo that adopted the
 > vocabulary while keeping a layout the detector cannot express reaches the `UNVERIFIABLE` branch.
 > That intersection is the whole defect surface (#4299) — the two states are separate outcomes with
 > separate lines, never one line covering both.


### PR DESCRIPTION
The reviewer's glossary-freshness check used to say the same thing whether a pull request genuinely added no new surface or the checker simply had no idea what a surface looks like in this repository. Those are very different facts, and only one of them is good news. This change makes the checker prove it can see something before it reports "nothing to check" — and when it cannot see anything at all, it now says so out loud and blocks, instead of waving the pull request through.

Fixes #4299

## What changed

One file, one step: `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`, Step 3c.

- **New positive-evidence probe.** After the three surface detectors run, the step counts how many surfaces the detectors' *own patterns* can express on the freshly-fetched base (`DETECTOR_SURFACES_N`): directory entries under `apps/web/worker/features/`, plus `packages/<pkg>/package.json` files. Read-only against `origin/$BASE_REF`, same posture as every other probe in the step (formats §RO).
- **The empty-scan branch splits in two.**
  - `DETECTOR_SURFACES_N > 0` — the detector demonstrably works here, so an empty `NEW_SURFACE` is a fact about the pull request: the existing not-applicable skip, now also naming the candidate count.
  - `DETECTOR_SURFACES_N == 0` (with `.glossary/TERMS.md` present on base) — the emptiness is a fact about the *detector*. The step emits a distinct `detector blind` line and folds an `[UNVERIFIABLE]` row into the conjunctive table. One `UNVERIFIABLE` fails the gate, so the vacuous case now stops the line rather than reading green.
- **The graceful-absence probe leads the chain as an executed guard.** `git cat-file -e "origin/$BASE_REF:.glossary/TERMS.md"` is the verdict chain's first `if`, so a repo that never adopted the glossary takes its honest skip and the new `detector blind` branch is structurally unreachable for it — the ordering is enforced by the block, not asserted by the prose around it. The defect surface is exactly the intersection triage identified: glossary present, layout absent.

Which fork: the fail-closed one. ADR 0092's bias — "default FAIL, pass on positive evidence of scope" — makes that the floor. Configurable surface detection stays unbuilt; the new line names it as one of the three remedies a blind repo can take.

## Replay — the required confirmation (AC 1)

Triage required replaying the Step 3c detection block against a real pull request's file list with the `apps/web/worker/features/` and `packages/` prefixes altered, before building. Run against **PR #2258** (which added `packages/design-capture/`), with the base probes resolved at that pull request's own `base.sha` — the tree the reviewer would have seen at the time:

| Run | `NEW_SURFACE` | Emitted verdict line |
|---|---|---|
| Real prefixes (`apps/web/worker/features/`, `packages/`) | `packages/design-capture` | `glossary-freshness: scanned new surfaces => packages/design-capture` → `FAIL` |
| Altered prefixes (`src/modules/`, `libs/`) | *(empty)* | `glossary-freshness: not applicable — no new feature folder / public package / export in this PR` |

Same pull request, same file list, same diff. Only the layout prefixes changed, and the gate went from a correct FAIL to a clean skip. **Prediction confirmed, not falsified** — the vacuous pass is real, and its emitted line is byte-identical to a legitimate skip.

The new probe was then exercised on both sides:

- phoenix layout on `origin/main` → `DETECTOR_SURFACES_N=49` → not-applicable skip branch (AC 4: no new false FAIL here).
- simulated foreign layout (`src/modules`, `libs`) → `DETECTOR_SURFACES_N=0` → `UNVERIFIABLE` detector-blind branch.

## Repair round 1 — the ordering is now enforced, not asserted

The `review-skill` FAIL was right: the graceful-absence probe existed only as a parenthetical inside the prose blockquote that sits *after* the verdict block, so the `else` was reachable with the glossary absent and emitted a blocking `UNVERIFIABLE` asserting `.glossary/TERMS.md is on origin/$BASE_REF` — a fact it never tested. That was inert on base (the `else` was a benign skip) and load-bearing here (the paths now diverge).

The chain now leads with the executed probe. Replayed both directions against real trees:

| Base tree | `DETECTOR_SURFACES_N` | Emitted line |
|---|---|---|
| `origin/main` (glossary present) | 0 (simulated) | `UNVERIFIABLE — detector blind` — the new branch is still reachable when the glossary *is* on base |
| `026dbdf6^` (real pre-glossary tree) | 0 | `not applicable — no .glossary/TERMS.md on base` — the graceful-absence skip, `detector blind` unreachable |

Nothing else moved: the `DETECTOR_SURFACES_N` probe and its numbers, the `[UNVERIFIABLE]` table row, the count > 0 skip, and the no-fixture decision are all untouched. The diff of this round is 10 insertions / 4 deletions in one file, both hunks inside Step 3c.

## Verification

- `pipeline-cli gh-phoenix lint-skills` over the full corpus (the CI invocation shape): **clean**. Single-file invocation exits 3 on zero gh-call scope both before and after this change, so the corpus-wide run is the meaningful one.
- `pnpm lint:worktree`: no biome-handled changed files — clean skip on a markdown-only diff.
- `cp-classify classify`: **control-plane**, exit 0 (path-match on `claude-plugins/**`). This is a §CP pull request: blocking, human merge.

## Deviations

**Class: narrowed a suggested scope.**
- *Said:* triage's AC 1 prose adds that "the same fixture is the regression test the fix ships with."
- *Did:* recorded the replay in this description, as the checkbox itself requires, but shipped no committed test fixture.
- *Why:* the scope fence limits the change to Step 3c of that one file, and there is no harness in this repo that executes a skill's bash block, so a fixture would have been a new untested surface in a directory the fence excludes.
- *Disposition:* for the reviewer to judge; say the word and I will file a follow-up for an executable-block test harness rather than widen this pull request.

**Class: chose between two forks the issue left open.**
- *Said:* triage left the fail-closed fork and the configurable-detection fork both in scope for the implementer.
- *Did:* built only the fail-closed fork.
- *Why:* triage names it the floor under ADR 0092, and configurable detection is a design surface (a declaration format, its own graceful absence, its own vacuity) that would not fit the scope fence.
- *Disposition:* no action needed; the emitted line names configurable detection as an available remedy without presuming it.

**Class: did not run the full acceptance test.**
- *Said:* the report's strongest confirmation is a live `review-code` run in a repository without the phoenix layout.
- *Did:* simulated the foreign layout by altering the detector's prefixes against real base trees and a real pull request file list.
- *Why:* triage explicitly marked the live foreign-repo run not required and priced it as the expensive part of #4268.
- *Disposition:* no action needed; called out so nobody reads the table above as a foreign-repo run.

