### PR TITLE
fix(pipeline-cli): gh-phoenix routeEdit honors -R/--repo instead of PATCHing the resolved repo (#4301)

### DIFF
--- a/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
@@ -26,6 +26,7 @@
 import {execFileSync} from "node:child_process";
 import {accessSync, constants, realpathSync} from "node:fs";
 import {delimiter, join} from "node:path";
+import {isRepoSlug} from "./router.ts";
 
 /** This binary's own resolved path, so PATH resolution can skip it (no self-recursion). */
 export const selfPath = (() => {
@@ -77,9 +78,6 @@ export const resolveRealGh = (self: string = selfPath): string | null => {
 	return null;
 };
 
-/** A well-formed `owner/name` slug — the shape every REST rewrite path is built from. */
-const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
-
 /**
  * Resolve the repo the REST rewrites target, per ADR 0062 §1: `$CLAUDE_PIPELINE_REPO`,
  * else `$GITHUB_REPOSITORY` (the CI tier every sibling resolver in this package carries),
@@ -90,7 +88,7 @@ const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
  */
 export const resolveRepo = (realGh: string | null): string | null => {
 	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
-	if (fromEnv && REPO_RE.test(fromEnv.trim())) return fromEnv.trim();
+	if (fromEnv && isRepoSlug(fromEnv)) return fromEnv.trim();
 	if (realGh) {
 		try {
 			const viewed = execFileSync(
@@ -98,7 +96,7 @@ export const resolveRepo = (realGh: string | null): string | null => {
 				["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
 				{encoding: "utf8"},
 			).trim();
-			if (REPO_RE.test(viewed)) return viewed;
+			if (isRepoSlug(viewed)) return viewed;
 		} catch {
 			/* unresolved — fall through */
 		}

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
@@ -79,6 +79,49 @@ const readFlag = (argv: ReadonlyArray<string>, flag: string): string | null => {
 	return null;
 };
 
+/** A well-formed `owner/name` slug — the shape every REST rewrite path is built from. */
+export const isRepoSlug = (value: string): boolean => /^[^/\s]+\/[^/\s]+$/.test(value.trim());
+
+/**
+ * What the caller said about the target repository with `-R` / `--repo`. The three cases are
+ * distinguished because an unusable value must NOT degrade to the resolved repo: silently
+ * substituting a repository the caller did not name is the defect (#4301, #4270).
+ */
+type RepoFlag =
+	| {readonly kind: "absent"}
+	| {readonly kind: "named"; readonly flag: string; readonly repo: string}
+	| {readonly kind: "unusable"; readonly flag: string; readonly raw: string | null};
+
+/**
+ * Read `-R` / `--repo` off an argv slice, in every form real `gh` accepts: `--repo value`,
+ * `--repo=value`, `-R value`, `-R=value`, and the attached shorthand `-Rowner/name`. The
+ * attached form is covered on purpose — leaving one spelling unparsed would leave one
+ * spelling silently retargeted, which is the whole defect.
+ */
+const readRepoFlag = (argv: ReadonlyArray<string>): RepoFlag => {
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === undefined) continue;
+		let flag: string | null = null;
+		let raw: string | null = null;
+		if (a === "-R" || a === "--repo") {
+			flag = a;
+			raw = argv[i + 1] ?? null;
+		} else if (a.startsWith("--repo=")) {
+			flag = "--repo";
+			raw = a.slice("--repo=".length);
+		} else if (a.startsWith("-R")) {
+			flag = "-R";
+			const attached = a.slice("-R".length);
+			raw = attached.startsWith("=") ? attached.slice(1) : attached;
+		}
+		if (flag === null) continue;
+		if (raw !== null && isRepoSlug(raw)) return {kind: "named", flag, repo: raw.trim()};
+		return {kind: "unusable", flag, raw};
+	}
+	return {kind: "absent"};
+};
+
 /** Split a comma-separated `--json` field list, trimming blanks. */
 const splitFields = (raw: string): ReadonlyArray<string> =>
 	raw
@@ -143,10 +186,24 @@ const routeEdit = (
 	repo: string | null,
 	bodyFileExists: (path: string) => boolean,
 ): GhRoute => {
+	// An explicit `-R`/`--repo` IS the target: this rewrite synthesizes a fresh argv, so a flag
+	// it does not read is a flag it drops — and the PATCH then lands on the resolved repo the
+	// caller never named (#4301). Honoring it also means an unusable value refuses rather than
+	// falling back, and a `-R` supplies a target even when resolution found none.
+	const flagged = readRepoFlag(rest);
+	if (flagged.kind === "unusable") {
+		return {
+			kind: "block",
+			reason: `\`gh ${verb} edit\` was given \`${flagged.flag}${flagged.raw === null ? "" : ` ${flagged.raw}`}\`, which is not an \`owner/name\` repository.`,
+			hint: `Pass \`${flagged.flag} <owner>/<name>\`. Refusing rather than PATCHing the repository this shim resolved, which you did not name.`,
+		};
+	}
+	const targetRepo = flagged.kind === "named" ? flagged.repo : repo;
+
 	// The rewrite target is `repos/<repo>/issues/<N>`, so an unresolved repo has no honest
 	// value to substitute — refuse. Defaulting to any slug aims the PATCH at a repository
 	// the caller never named (#4270).
-	if (repo === null) {
+	if (targetRepo === null) {
 		return {
 			kind: "block",
 			reason: `\`gh ${verb} edit\` needs a target repository and none resolved — $CLAUDE_PIPELINE_REPO and $GITHUB_REPOSITORY are unset (or malformed) and \`gh repo view\` did not answer.`,
@@ -159,13 +216,13 @@ const routeEdit = (
 		return {
 			kind: "block",
 			reason: `\`gh ${verb} edit\` without a numeric #N target can't be rewritten to a REST PATCH.`,
-			hint: `Pass the issue/PR number, e.g. \`gh api -X PATCH repos/${repo}/${verb === "pr" ? "pulls" : "issues"}/<N> -f ...\`.`,
+			hint: `Pass the issue/PR number, e.g. \`gh api -X PATCH repos/${targetRepo}/${verb === "pr" ? "pulls" : "issues"}/<N> -f ...\`.`,
 		};
 	}
 
 	// pulls and issues share the issues PATCH surface for body/title/milestone (a PR is an
 	// issue in REST); milestone/labels live on the issues resource for both.
-	const apiArgv: string[] = ["api", "-X", "PATCH", `repos/${repo}/issues/${target}`];
+	const apiArgv: string[] = ["api", "-X", "PATCH", `repos/${targetRepo}/issues/${target}`];
 	const stripped: string[] = [];
 
 	const bodyFile = readFlag(rest, "--body-file");
@@ -210,14 +267,17 @@ const routeEdit = (
 		return {
 			kind: "block",
 			reason: `\`gh ${verb} edit\` carried no rewritable field (body/title/milestone).`,
-			hint: `Use \`gh api -X PATCH repos/${repo}/issues/${target} -f <field>=<value>\` directly.`,
+			hint: `Use \`gh api -X PATCH repos/${targetRepo}/issues/${target} -f <field>=<value>\` directly.`,
 		};
 	}
 
 	return {
 		kind: "rewrite",
 		argv: apiArgv,
-		reason: `\`gh ${verb} edit\` routed to REST PATCH (GraphQL edit path breaks on Projects-classic).`,
+		reason:
+			`\`gh ${verb} edit\` routed to REST PATCH (GraphQL edit path breaks on Projects-classic)` +
+			(flagged.kind === "named" ? `, targeting \`${flagged.flag} ${targetRepo}\`` : "") +
+			".",
 		stripped,
 	};
 };

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
@@ -135,6 +135,117 @@ describe("route — an unresolved repo refuses the rewrite, not the whole shim (
 	});
 });
 
+describe("route — an explicit -R/--repo names the PATCH target (#4301)", () => {
+	const OTHER = "other-owner/other-repo";
+
+	it("PATCHes the -R repo, not the resolved one, for `pr edit`", () => {
+		const out = r(["pr", "edit", "-R", OTHER, "5", "--title", "x"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${OTHER}/issues/5`);
+			assert.notInclude(out.argv.join(" "), REPO);
+			assert.include(out.reason, OTHER);
+		}
+	});
+
+	it("PATCHes the --repo=value repo, not the resolved one, for `pr edit`", () => {
+		const out = r(["pr", "edit", "5", `--repo=${OTHER}`, "--body", "b"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${OTHER}/issues/5`);
+			assert.notInclude(out.argv.join(" "), REPO);
+		}
+	});
+
+	it("PATCHes the --repo repo, not the resolved one, for `issue edit`", () => {
+		const out = r(["issue", "edit", "--repo", OTHER, "7", "--title", "Renamed"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${OTHER}/issues/7`);
+			assert.notInclude(out.argv.join(" "), REPO);
+		}
+	});
+
+	it("PATCHes the -R=value repo, not the resolved one, for `issue edit`", () => {
+		const out = r(["issue", "edit", "7", `-R=${OTHER}`, "--body", "b"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${OTHER}/issues/7`);
+			assert.notInclude(out.argv.join(" "), REPO);
+		}
+	});
+
+	it("honors the attached shorthand `-Rowner/name`", () => {
+		const out = r(["pr", "edit", "5", `-R${OTHER}`, "--title", "x"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") assert.include(out.argv, `repos/${OTHER}/issues/5`);
+	});
+
+	it("supplies a target even when the shim resolved no repo", () => {
+		const out = route(["pr", "edit", "-R", OTHER, "5", "--title", "x"], {repo: null});
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") assert.include(out.argv, `repos/${OTHER}/issues/5`);
+	});
+
+	it("blocks a -R value that is not an owner/name slug, naming the flag and value", () => {
+		const out = r(["pr", "edit", "5", "-R", "not-a-slug", "--title", "x"]);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") {
+			assert.include(out.reason, "-R");
+			assert.include(out.reason, "not-a-slug");
+			assert.notInclude(`${out.reason} ${out.hint}`, REPO);
+		}
+	});
+
+	it("blocks a trailing --repo with no value rather than falling back to the resolved repo", () => {
+		const out = r(["pr", "edit", "5", "--title", "x", "--repo"]);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") assert.include(out.reason, "--repo");
+	});
+
+	it("leaves every other edit flag's handling unchanged alongside -R", () => {
+		const out = r([
+			"issue",
+			"edit",
+			"-R",
+			OTHER,
+			"7",
+			"--title",
+			"x",
+			"--milestone",
+			"3",
+			"--add-project",
+			"Roadmap",
+		]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, "title=x");
+			assert.include(out.argv, "milestone=3");
+			assert.include(out.stripped, "--add-project Roadmap");
+		}
+	});
+});
+
+describe("route — -R still reaches real `gh` untouched on the non-edit routes (#4301 regression)", () => {
+	const OTHER = "other-owner/other-repo";
+
+	it("passes -R through verbatim on a passthrough route", () => {
+		const argv = ["pr", "list", "-R", OTHER, "--state", "open"];
+		const out = r(argv);
+		assert.strictEqual(out.kind, "passthrough");
+		if (out.kind === "passthrough") assert.deepStrictEqual([...out.argv], argv);
+	});
+
+	it("keeps -R in the rebuilt argv of a `view --json` rewrite", () => {
+		const out = r(["pr", "view", "9", "-R", OTHER, "--json", "number,closingIssuesReferences"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, "-R");
+			assert.include(out.argv, OTHER);
+		}
+	});
+});
+
 describe("isMilestoneTitle", () => {
 	it("treats a bare integer as a number (not a title)", () => {
 		assert.isFalse(isMilestoneTitle("12"));


### PR DESCRIPTION
The `gh-phoenix` shim rewrites `gh pr edit` / `gh issue edit` into a REST `PATCH`, and that rewrite used to ignore the caller's `-R` / `--repo` flag: `gh pr edit -R other/repo 5 --title x` became `PATCH repos/<resolved>/issues/5`, so the edit landed on a repository the caller never named, with no error and nothing on stderr. This PR makes the flag decide the target.

The shim now reads `-R` / `--repo` and uses it as the PATCH repo, and says so on stderr. A flag that is present but unusable — a value that is not `owner/name`, or no value at all — blocks with a message naming the flag and the value, instead of quietly falling back. That was the last silent-retarget path left in this shim; the neighbouring one (an unresolved repo defaulting to a hardcoded literal) was fixed in #4294.

Fixes #4301

## What changed

`packages/pipeline-cli/src/tools/gh-phoenix/router.ts`

- New `readRepoFlag` reads `-R` / `--repo` in every form real `gh` accepts: `--repo value`, `--repo=value`, `-R value`, `-R=value`, and the attached shorthand `-Rowner/name`. It returns three states — absent, named, unusable — so a present-but-unusable flag cannot degrade into "absent" and silently reuse the resolved repo.
- `routeEdit` builds its REST path from the flagged repo when one is named, else the resolved one. Both the `apiArgv` target and every hint that quotes a `repos/...` path use that effective repo.
- A named `-R` also supplies a target when resolution found none, so `-R` no longer has to lose a race with the #4270 refusal.
- The `rewrite` reason names the retarget (`..., targeting \`-R other/repo\`.`), which is the shim's own observability channel — the caller sees which repository the PATCH is aimed at.
- An unusable value returns a `block` whose `reason` quotes the flag and the value and whose `hint` says it is refusing rather than PATCHing the repository the shim resolved.
- The `owner/name` shape check is now the exported `isRepoSlug`, so the flag and the resolver validate one shape.

`packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts`

- Drops its local `REPO_RE` and consumes `isRepoSlug` from the router. The pure core owns the shape; the IO seam imports it (never the reverse).

`packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts`

- Nine cases for the `-R` path: `pr edit` and `issue edit`, `--flag value` and `--flag=value` and the attached shorthand, each asserting the resolved repo is *not* the PATCH target; the unresolved-repo case; the malformed value; the valueless flag; and a case pinning that `--title` / `--milestone` / `--add-project` handling is unchanged alongside `-R`.
- Two regression cases pinning the already-correct behaviour: `-R` still reaches real `gh` verbatim on a `passthrough` route, and survives a `routeView` `--json` rewrite.

## Acceptance criteria

- [x] `routeEdit` reads `-R` and `--repo` in both `--flag value` and `--flag=value` forms (plus `-Rowner/name`).
- [x] `gh pr edit -R other/repo <N> --title x` PATCHes `repos/other/repo/issues/<N>` — never the resolved repo silently.
- [x] The same holds for `gh issue edit`.
- [x] Refuse shape not chosen (honor was), but the one refusal this adds — an unusable `-R` value — names the flag and its value in `reason`.
- [x] `router.unit.test.ts` covers `-R` for both verbs, in both flag forms, asserting the resolved repo is not the PATCH target.
- [x] Regression tests pin `-R` reaching real `gh` untouched on `passthrough` and through a `routeView` rewrite.
- [x] No behaviour change to `--body-file` / `--body` / `--title` / `--milestone` / `--add-project` / `--remove-project`.

## Verification

- `pnpm vitest run src/tools/gh-phoenix` in `packages/pipeline-cli` — 95 passed.
- `pnpm typecheck` — 29/29 tasks successful.
- `pnpm lint:worktree` — exit 0 (two pre-existing `useOptionalChain` warnings on untouched lines).
- `pipeline-cli cp-classify classify` — `not-control-plane [path-clear-no-content-source]`.
