### PR TITLE
fix(doctor): cover triage's homing prerequisites, and tell a failed read from an absent one (#4300)

### DIFF
--- a/claude-plugins/kampus-pipeline/README.md
+++ b/claude-plugins/kampus-pipeline/README.md
@@ -98,7 +98,7 @@ handoff is a durable GitHub artifact, you can stop after any stage and resume la
 | `heal-ci` | Classify a red CI run into flake-vs-defect and emit one routed action — rerun a known transient once, or file a defect via `report`. |
 | `adr` | Record an architecture decision (Context / Decision / Consequences) into `.decisions/NNNN-slug.md` and the index, following supersede rules. |
 | `deslop-comments` | Ruthlessly cut comments that bury the code without earning their place — keeping load-bearing notes, collapsing duplicated "why" to ADR pointers. |
-| `doctor` | Preflight a repo against the pipeline prerequisites (gh auth + scope, the 15 required labels, repo resolution, a CI signal, the two [repo-admin merge prerequisites](#repo-admin-prerequisites), npm deps) and print a tiered pass/fail checklist with the exact fix command for each gap. |
+| `doctor` | Preflight a repo against the pipeline prerequisites (gh auth + scope, the required label vocabulary, repo resolution, a CI signal, the two [repo-admin merge prerequisites](#repo-admin-prerequisites), npm deps) and print a tiered pass/fail checklist with the exact fix command for each gap. |
 | `wayfinder` | The ideation-layer front door, upstream of the pipeline: chart a fuzzy destination into a living `wayfinder:map` issue, then work its open frontier of investigation/decision tickets — recording answers, graduating cleared fog, surfacing founder-decision-forks — until a concrete plan is ready for `triage` / `plan-epic` (epic #2421). |
 
 ## Install
@@ -208,12 +208,14 @@ the superseded file's status edit), never a regenerated index.
 
 **Start with `doctor`.** Before the first run in a freshly-adopted repo, run the `doctor`
 skill (`claude-plugins/kampus-pipeline/skills/doctor/doctor.sh`) — it asserts the prerequisites in one pass (gh
-auth + the `project` scope, the 15 required `status:*`/`type:*`/`p*` labels, repo
+auth + the `project` scope, the required `status:*`/`type:*`/`p*` label vocabulary plus the
+standing lanes and the platform discriminator `triage` homes into, repo
 resolution, a CI signal, the two [repo-admin merge prerequisites](#repo-admin-prerequisites),
 and the `@kampus/*` npm deps) and prints a tiered pass/fail
 checklist with the exact `gh label create …` / `gh auth refresh …` fix command for each
-gap. It turns "did I wire this up right?" into one checkable command instead of a first run
-that fails deep inside a `gh api` call.
+gap. It turns "did I wire this up right?" into one checkable command instead of a pipeline
+that runs green over a repo whose label scoping matches nothing (a missing label does not
+error the first write — `POST …/labels` auto-creates it; the damage lands on the read side).
 
 To re-prove a skill's gate runs outside phoenix (the repeatable procedure
 behind #368 / #432), exercise it in a throwaway non-phoenix git repo — **not** phoenix

--- a/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
@@ -12,12 +12,15 @@ the repo — label creation, auth scopes — which is theirs to authorize).
 
 The pipeline is repo-agnostic (ADR [0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-as-config-plugin.md)): an adopter installs the plugin and it
 operates on *their* issues. Several skills hard-depend on environment the host repo
-must already provide — labels, `gh` auth, a CI signal — but nothing verifies that
-up front, so a first run otherwise fails deep inside a `gh api` call (e.g. labeling
-with a `status:needs-triage` that doesn't exist) instead of failing fast with a
-clear "this repo isn't set up" message. Worst case it half-applies: an issue gets
-created, then the label step errors, leaving an untracked issue outside the queue.
-This skill closes that window.
+must already provide — labels, `gh` auth, a CI signal, a home to file work into —
+but nothing verifies that up front. This skill closes that window.
+
+A missing label does **not** announce itself: `POST /repos/{owner}/{repo}/issues/{n}/labels`
+**auto-creates** the label it is handed (measured 2026-07-26 — HTTP 200, the label
+materializes repo-wide at GitHub's default grey with no description). So `report` succeeds
+and quietly mints an off-taxonomy label, and the failure surfaces later on the **read**
+side, where `?labels=status:triaged` and every guard's label scoping match nothing and the
+pipeline runs protecting nothing (#4300; the silent no-op ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md) exists to kill).
 
 ## Running it
 
@@ -39,17 +42,19 @@ Do not run the fix commands yourself.
 |---|---|---|
 | **1 — load-bearing** | `gh` authenticated | every call is `gh api`; without auth nothing runs |
 | | `gh` token has the `project` scope | the org's Projects-classic integration requires it (the reason the suite is REST-only, never GraphQL) |
-| | the 15 required labels exist (`status:*` spine, `type:*` class, `p*` priority) | the intake skills key on them — `report` applies `status:needs-triage`, `write-code` picks `status:triaged`, etc. A missing one fails a run mid-`gh api`. |
+| | the required labels exist (`status:*` spine, `type:*` class, `p*` priority, the two standing lanes, the platform discriminator) | the intake skills key on them — `report` applies `status:needs-triage`, `write-code` picks `status:triaged`, `triage` exempts to `wayfinder:backlog` / `axis:pipeline-hardening`. A missing one makes every scan match nothing. |
+| | that set still covers the shared vocabulary | the create-commands table carries colours the source can't; this asserts it hasn't fallen behind the source (below) |
 | **2 — gating** | target repo resolves | a skill can't target a repo it can't name |
 | | at least one CI workflow exists | `ship-it` Step 3 gates on checks-green; with zero checks that gate passes vacuously |
 | | repo-level `allow_auto_merge` is enabled | `ship-it`'s `gh pr merge --auto` cannot arm without it — the enqueue fails with `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)` (ADR [0132](https://github.com/kamp-us/phoenix/blob/main/.decisions/0132-merge-queue-for-base-freshness.md) §Addendum §1) |
 | | a `merge_queue` rule applies to the **resolved** default branch | `ship-it` deliberately passes no merge-method flag because the queue owns it (ADR 0132 §Consequences); with no queue there is no method and the merge never lands |
 | **3 — optional** | `@kampus/pipeline-cli` resolves on npm | `adr` / `review-plan` reach for its `decisions-index` / `epic-ledger` tools via `pnpm dlx` as the published fallback (epic #994); absent → those stages degrade |
 | | a `run-evidence` producer is defined | `ship-it` guard 2 runs strict when present, and **degrades to checks-green when absent** (ADR [0086](https://github.com/kamp-us/phoenix/blob/main/.decisions/0086-ship-it-foreign-repo-degradation.md)) — so this is informational, not a failure |
+| | the ideation-layer labels exist (`wayfinder:map`) | `wayfinder` keys its map issue on it; it is an ideation front door, not a first-run prerequisite |
+| | at least one **open milestone** exists | `triage` Step 6 homes an issue into an arc/campaign milestone and **never creates one** (ADR [0072](https://github.com/kamp-us/phoenix/blob/main/.decisions/0072-milestones-encode-strategic-sequencing.md) §3). With none, triage can still exempt to a standing lane but cannot home into an arc — a WARN, never a fail, because a freshly-adopted repo legitimately has none yet |
 
-The load-bearing pair is **auth + labels** (Tier 1): get those wrong and the very
-first `report` → `triage` round trips into a raw GitHub API error. The Tier-2 checks
-keep `ship-it` honest; Tier-3 only ever downgrades a single stage.
+The load-bearing pair is **auth + labels** (Tier 1). The Tier-2 checks keep `ship-it`
+honest; Tier-3 only ever downgrades a single stage.
 
 The last two Tier-2 checks are the **repo-admin governance pair**, and they are the one
 prerequisite class this checklist can only *report*: `allow_auto_merge` and the
@@ -57,6 +62,12 @@ default-branch merge-queue ruleset are GitHub-side repo settings that **no repo-
 script can create** — not doctor, not any stand-up script. They also fail *last*, at the
 enqueue, after an adopter has already built, reviewed, approved, and armed a PR. Reading
 them up front is what turns that finish-line halt into a first-run checklist line.
+
+Every check reports **three** states, never two: present, absent, and **UNDETERMINED** —
+the read itself did not succeed. A failed label read is not "no labels", and no open
+milestone found is not "the milestone read worked". Collapsing those is what lets a
+checker pass while the thing it checks is absent, so doctor names the unknown as unknown
+and still fails closed on it.
 
 ## Conventions
 
@@ -70,7 +81,10 @@ them up front is what turns that finish-line halt into a first-run checklist lin
   a different fact. `gh api` prints its error body to stdout **without** applying `--jq`, so
   every read keeps gh's exit status and admits only the literal values it expects (§ZS /
   ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md); the defect class of #4223).
-- The required-label set in `doctor.sh` is the canonical one (name + color +
-  description). If the pipeline's label dimensions change (see
-  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §Pipeline labels), update the `REQUIRED_LABELS`
-  table there so a fresh adopter gets the current set.
+- **`doctor.sh`'s `LABELS` table is a presentation mirror, not the source.** The required
+  set is single-sourced in `packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts`,
+  which assembles it from the constants the guards themselves scope on; the table only adds the
+  colour + description a `gh label create` needs. Doctor reads the source through
+  `pipeline-cli vocabulary-preflight labels` and **reds if the table has fallen behind it**, so
+  the two cannot silently diverge — the drift that shipped as #4300. Change the vocabulary at
+  the source, then add the matching row here.

--- a/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
+++ b/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
@@ -5,12 +5,24 @@
 # `gh`/`npm` and writes nothing — every fix is a command it prints, never runs.
 #
 # Tiers (a foreign-repo adopter reads top-down):
-#   1  load-bearing   — gh auth + required labels. Without these the first
-#                       report/triage run fails deep inside a `gh api` call.
+#   1  load-bearing   — gh auth + the required label vocabulary.
 #   2  gating         — repo resolution, a CI signal ship-it can gate on, and the
 #                       merge-queue governance ship-it's enqueue silently depends on.
-#   3  optional       — `pnpm dlx` packages + the run-evidence producer; their
-#                       absence degrades a stage, it does not break the pipeline.
+#   3  optional       — `pnpm dlx` packages, the run-evidence producer, the
+#                       ideation-layer labels, and an open milestone; their absence
+#                       degrades a stage, it does not break the pipeline.
+#
+# Why the labels are Tier 1 is NOT "the first write errors" — that was measured and is
+# false. `POST /repos/{owner}/{repo}/issues/{n}/labels` AUTO-CREATES a missing label
+# (observed 2026-07-26: HTTP 200, label materialized repo-wide at GitHub's default grey
+# `ededed` with a null description). So `report` silently succeeds and mints an
+# off-taxonomy label; the damage lands on the READ side, where `?labels=status:triaged`
+# and every guard's label scoping then match nothing and the pipeline runs protecting
+# nothing — the silent no-op ADR 0092 exists to kill (#4300).
+#
+# Every check below reports THREE states, never two: present, absent, and UNDETERMINED
+# (the read itself did not succeed). A read that fails must never resolve to "fine" —
+# that collapse is what let a green doctor sit on top of an unusable repo.
 #
 # Exit 0 only when every Tier-1 and Tier-2 check passes; Tier-3 gaps WARN, never fail.
 set -uo pipefail
@@ -51,49 +63,134 @@ else
 	fix "gh auth refresh -s project"
 fi
 
-# 1c. required labels exist. The canonical set the intake skills key on (status:*
-#     spine, type:* class, p* priority), as NAME|HEX|DESCRIPTION rows fed to the
-#     loop from a heredoc (a `|`-delimited heredoc, not $(cat <<…) — the latter
-#     mis-parses under bash 3.2, the macOS default).
+# 1c. the label vocabulary exists in the target repo, as NAME|TIER|HEX|DESCRIPTION rows fed
+#     to the loop from a heredoc (a `|`-delimited heredoc, not $(cat <<…) — the latter
+#     mis-parses under bash 3.2, the macOS default). TIER 1 rows are required and fail the
+#     run; TIER 3 rows are ideation-layer and only ever WARN, reported down in Tier 3.
+#
+#     This table is a PRESENTATION mirror (it carries the colour + description the create
+#     commands need, which the source has no room for), NOT a second required-set: check 1d
+#     asserts it covers the shared vocabulary in `packages/pipeline-cli/src/tools/
+#     vocabulary-preflight/vocabulary.ts`, which assembles the set from the constants the
+#     guards themselves scope on. Add a Tier-1 row here only alongside that source (#4272);
+#     the homing labels it must cover are ruled in ../triage/SKILL.md Step 6.
+#
+#     Read the universe with the outcome SEPARATED from the content: a failed read leaves
+#     the same empty string a genuinely label-less repo does, and scoring absence off it
+#     would name every required label "missing" on what is really an auth or network fault.
 EXISTING=""
+labels_read=no-repo
 if [ -n "${REPO:-}" ]; then
-	EXISTING=$(gh api "repos/$REPO/labels?per_page=100" --jq '.[].name' 2>/dev/null)
+	if EXISTING=$(gh api "repos/$REPO/labels?per_page=100" --jq '.[].name' 2>/dev/null); then
+		labels_read=ok
+	else
+		labels_read=failed
+	fi
 fi
 
-missing=0
-while IFS='|' read -r name color desc; do
+required_total=0
+missing_required=0
+required_fixes=""
+REQUIRED_NAMES=""
+optional_missing=0
+optional_fixes=""
+while IFS='|' read -r name tier color desc; do
 	[ -z "$name" ] && continue
-	if printf '%s\n' "$EXISTING" | grep -Fxq "$name"; then
-		continue
+	if [ "$tier" = "1" ]; then
+		required_total=$((required_total + 1))
+		REQUIRED_NAMES="$REQUIRED_NAMES$name
+"
 	fi
-	missing=$((missing + 1))
-	fix "gh label create \"$name\" --repo \"$REPO\" --color \"$color\" --description \"$desc\""
+	[ "$labels_read" = "ok" ] || continue # UNDETERMINED: never score absence off a read that failed
+	printf '%s\n' "$EXISTING" | grep -Fxq "$name" && continue
+	CREATE="gh label create \"$name\" --repo \"$REPO\" --color \"$color\" --description \"$desc\""
+	if [ "$tier" = "1" ]; then
+		missing_required=$((missing_required + 1))
+		required_fixes="$required_fixes$CREATE
+"
+	else
+		optional_missing=$((optional_missing + 1))
+		optional_fixes="$optional_fixes$CREATE
+"
+	fi
 done <<'LABELS'
-status:needs-triage|fbca04|Filed, awaiting triage classification
-status:needs-info|fbca04|Human-filed; awaiting answers before triage
-status:planned|fbca04|plan-epic child: planned, not yet verified by review-plan, not pickable
-status:triaged|fbca04|Triage signed off; ready for write-code to pick
-status:planning|fbca04|Epic-lock held: a plan-epic/review-plan run is mutating this epic's children (ADR 0059)
-status:awaiting-release|5319e7|Post-merge release-queue marker: deployed dark, awaiting a human flag flip (ADR 0083).
-type:bug|1d76db|Behavior diverges from intent
-type:chore|1d76db|No behavior change
-type:decision|1d76db|One question; output is a recorded choice
-type:epic|1d76db|Too big for one PR; spawns children
-type:feature|1d76db|New capability, directly implementable
-type:investigation|1d76db|Unknown; output is knowledge
-p0|b60205|Highest priority
-p1|d93f0b|Medium priority
-p2|e99695|Lowest priority
+status:needs-triage|1|fbca04|Filed, awaiting triage classification
+status:needs-info|1|fbca04|Human-filed; awaiting answers before triage
+status:planned|1|fbca04|plan-epic child: planned, not yet verified by review-plan, not pickable
+status:triaged|1|fbca04|Triage signed off; ready for write-code to pick
+status:planning|1|fbca04|Epic-lock held: a plan-epic/review-plan run is mutating this epic's children (ADR 0059)
+status:awaiting-release|1|5319e7|Post-merge release-queue marker: deployed dark, awaiting a human flag flip (ADR 0083).
+type:bug|1|1d76db|Behavior diverges from intent
+type:chore|1|1d76db|No behavior change
+type:decision|1|1d76db|One question; output is a recorded choice
+type:epic|1|1d76db|Too big for one PR; spawns children
+type:feature|1|1d76db|New capability, directly implementable
+type:investigation|1|1d76db|Unknown; output is knowledge
+p0|1|b60205|Highest priority
+p1|1|d93f0b|Medium priority
+p2|1|e99695|Lowest priority
+wayfinder:backlog|1|8250df|Standing lane: a destination queued for a wayfinding chart (triage's standing-lane exemption)
+axis:pipeline-hardening|1|5319e7|Standing lane: the cross-cutting pipeline-hardening axis (triage's standing-lane exemption)
+area:infra|1|0e8a16|Platform/infra discriminator the lane tool scopes on
+wayfinder:map|3|8250df|Ideation-layer map issue — the wayfinder chart front door (issue-shape marker, not a type)
 LABELS
 
-if [ "$missing" -eq 0 ] && [ -n "$EXISTING" ]; then
-	say "$PASS" "all 15 required pipeline labels exist"
-elif [ -z "$EXISTING" ]; then
-	say "$FAIL" "could not read repo labels (repo unresolved or gh unauthenticated) — run the fixes above first"
+if [ "$labels_read" = "no-repo" ]; then
+	say "$FAIL" "required labels UNDETERMINED — the target repo never resolved, so the label universe was never read (unknown, NOT absent)"
+	fix "set CLAUDE_PIPELINE_REPO=owner/name, or run inside the target git repo, then re-run"
+	fails=$((fails + 1))
+elif [ "$labels_read" = "failed" ]; then
+	say "$FAIL" "required labels UNDETERMINED — the label read on $REPO FAILED (unknown, NOT absent; likely auth, permissions, or network)"
+	fix "gh auth status && gh api \"repos/$REPO/labels?per_page=100\"  # make the read succeed, then re-run"
+	fails=$((fails + 1))
+elif [ "$missing_required" -eq 0 ]; then
+	say "$PASS" "all $required_total required pipeline labels exist"
+else
+	say "$FAIL" "$missing_required of $required_total required pipeline label(s) absent"
+	printf '%s' "$required_fixes" | while IFS= read -r line; do
+		[ -n "$line" ] && fix "$line"
+	done
+	fails=$((fails + 1))
+fi
+
+# 1d. doctor's Tier-1 rows still cover the shared vocabulary. The set the guards scope on
+#     lives in ONE place and is assembled from their own constants; this asserts the table
+#     above has not fallen behind it — the drift that let doctor green a repo where triage
+#     had no non-kill home (#4300). Reads it through the CLI shim, the only seam a bash
+#     preflight has onto a TS constant.
+PCLI="$(cd "$(dirname "$0")/../../bin" 2>/dev/null && pwd)/pipeline-cli"
+SHARED=""
+shared_read=unresolved
+if [ -x "$PCLI" ]; then
+	if SHARED=$("$PCLI" vocabulary-preflight labels 2>/dev/null) && [ -n "$SHARED" ]; then
+		shared_read=ok
+	fi
+fi
+
+shared_total=0
+drifted=""
+if [ "$shared_read" = "ok" ]; then
+	while IFS= read -r want; do
+		[ -z "$want" ] && continue
+		shared_total=$((shared_total + 1))
+		printf '%s\n' "$REQUIRED_NAMES" | grep -Fxq "$want" && continue
+		drifted="$drifted $want"
+	done <<SHARED_SET
+$SHARED
+SHARED_SET
+fi
+
+if [ "$shared_read" != "ok" ]; then
+	# WARN, not FAIL: an adopter without the CLI resolved still gets every check above. What is
+	# lost is only the confirmation, and saying so beats claiming a verification that never ran.
+	say "$WARN" "doctor's required set is UNVERIFIED against the shared vocabulary — could not resolve it (unknown, NOT confirmed)"
+	fix "run from a checkout with packages/pipeline-cli, or make \`pipeline-cli vocabulary-preflight labels\` resolvable"
+elif [ -n "$drifted" ]; then
+	say "$FAIL" "doctor's required set has DRIFTED from the shared vocabulary — absent from the table above:$drifted"
+	fix "add each label above to the LABELS table in this file as a tier-1 row (name|1|hex|description)"
 	fails=$((fails + 1))
 else
-	say "$FAIL" "$missing required pipeline label(s) missing (create commands above)"
-	fails=$((fails + 1))
+	say "$PASS" "doctor's required set covers all $shared_total labels of the shared vocabulary"
 fi
 
 hdr "Tier 2 — gating (a stage fails deep without these)"
@@ -218,6 +315,41 @@ if [ "${RUNEV:-0}" -gt 0 ]; then
 else
 	say "$WARN" "no run-evidence producer — ship-it guard 2 degrades to checks-green (ADR 0086)"
 	fix "optional: ship .github/workflows/run-evidence.yml + packages/pipeline-cli/src/tools/crabbox-manifest for SHA-bound evidence"
+fi
+
+# 3c. the ideation-layer labels (the tier-3 rows of the table above). `wayfinder` keys its map
+#     issue on one; absent, that surface degrades — it does not block a first run.
+if [ "$labels_read" != "ok" ]; then
+	say "$WARN" "ideation-layer labels UNDETERMINED — the label read did not succeed (see Tier 1)"
+elif [ "$optional_missing" -eq 0 ]; then
+	say "$PASS" "ideation-layer labels present — the wayfinder map surface is usable"
+else
+	say "$WARN" "$optional_missing ideation-layer label(s) absent — the wayfinder map surface degrades"
+	printf '%s' "$optional_fixes" | while IFS= read -r line; do
+		[ -n "$line" ] && fix "$line"
+	done
+fi
+
+# 3d. an OPEN milestone exists — triage's arc/campaign home. Deliberately not Tier 1: a freshly
+#     adopted repo legitimately has none, and creating one is a human roadmap act triage is
+#     forbidden from doing for itself (ADR 0072 §3), so reddening here would fail the correct
+#     state of a brand-new adopter.
+MILESTONES=""
+ms_read=unknown
+if [ -n "${REPO:-}" ]; then
+	if MILESTONES=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq 'length' 2>/dev/null); then
+		ms_read=ok
+	fi
+fi
+
+if [ "$ms_read" != "ok" ]; then
+	say "$WARN" "open-milestone existence UNDETERMINED — the read did not succeed (unknown, NOT 'no milestone')"
+	fix "gh api \"repos/$REPO/milestones?state=open\"  # make the read succeed, then re-run"
+elif [ "${MILESTONES:-0}" -gt 0 ]; then
+	say "$PASS" "$MILESTONES open milestone(s) — triage can home an issue into an arc/campaign"
+else
+	say "$WARN" "no open milestone — triage can exempt an issue to a standing lane, but cannot home one into an arc/campaign"
+	fix "a human creates the first arc/campaign milestone (triage never does): gh api -X POST \"repos/$REPO/milestones\" -f title=\"<arc name>\""
 fi
 
 hdr "Verdict"

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/command.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/command.ts
@@ -8,6 +8,7 @@
  *
  *   pipeline-cli vocabulary-preflight check              # the resolved target repo (ADR 0062 §1)
  *   pipeline-cli vocabulary-preflight check --root <d>   # point at a specific repo root
+ *   pipeline-cli vocabulary-preflight labels             # print the required set, one per line
  *
  * The pure decision lives in `vocabulary.ts` (unit-tested); the `gh api` label read and the
  * `ROADMAP.md` read in `github.ts`/`gate.ts`. `RepoLabelsLive` is baked in with
@@ -16,11 +17,12 @@
  *
  * Exit-code contract: 0 = every prerequisite met, any non-zero = failure.
  */
-import {Effect, FileSystem, Option, Path} from "effect";
+import {Console, Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {onCheckFailed} from "../../gate-fail.ts";
 import {checkVocabulary} from "./gate.ts";
 import {RepoLabelsLive} from "./github.ts";
+import {REQUIRED_LABELS, renderLabelList} from "./vocabulary.ts";
 
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
@@ -68,8 +70,22 @@ const check = Command.make(
 	),
 );
 
+// Reads no repo state, so it is the one subcommand that answers in a repo the labels are missing
+// from — which is the only situation its caller runs in.
+const labels = Command.make(
+	"labels",
+	{},
+	Effect.fn(function* () {
+		yield* Console.log(renderLabelList(REQUIRED_LABELS));
+	}),
+).pipe(
+	Command.withDescription(
+		"Print the required label vocabulary, one per line (the seam `doctor.sh` reads — #4300)",
+	),
+);
+
 export const vocabularyPreflightCommand = Command.make("vocabulary-preflight").pipe(
-	Command.withSubcommands([check]),
+	Command.withSubcommands([check, labels]),
 	Command.withDescription(
 		"Fail-closed preflight: the required label vocabulary + ROADMAP.md exist in the target repo (#4272)",
 	),

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
@@ -49,6 +49,14 @@ export const REQUIRED_LABELS: ReadonlyArray<string> = [
 	...new Set(LABEL_GROUPS.flatMap((group) => group.labels)),
 ];
 
+/**
+ * The required set as a newline-delimited list — the machine-readable seam a non-Node consumer
+ * reads this module through. `doctor.sh` is the caller (#4300): a bash preflight cannot import a
+ * TS constant, so without this it would have to retype the set, which is precisely the parallel
+ * hand-written list that drifted.
+ */
+export const renderLabelList = (labels: ReadonlyArray<string>): string => labels.join("\n");
+
 /** `ROADMAP.md` as the preflight finds it: absent, or present with the rows it parsed. */
 export type RoadmapSurface =
 	| {readonly _tag: "absent"; readonly path: string}

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.unit.test.ts
@@ -14,6 +14,7 @@ import {
 	judgeRoadmap,
 	REQUIRED_LABELS,
 	type RoadmapSurface,
+	renderLabelList,
 	renderReport,
 } from "./vocabulary.ts";
 
@@ -132,5 +133,20 @@ describe("renderReport", () => {
 		const report = renderReport(judge([], ROADMAP_OK));
 		expect(report).toContain("gh label create");
 		expect(report).toContain("not\nconfiguration");
+	});
+});
+
+describe("renderLabelList — the seam doctor.sh reads (#4300)", () => {
+	it("emits one label per line and nothing else, so a `while read` consumer needs no parser", () => {
+		const lines = renderLabelList(REQUIRED_LABELS).split("\n");
+		expect(lines).toEqual([...REQUIRED_LABELS]);
+	});
+
+	// The list is doctor's Tier-1 floor, so an empty render would let doctor's drift check pass
+	// against nothing — the vacuous-scope shape of ADR 0092, one surface over.
+	it("is non-empty and carries the standing lanes doctor was missing", () => {
+		const lines = renderLabelList(REQUIRED_LABELS).split("\n");
+		expect(lines.length).toBeGreaterThan(0);
+		for (const lane of EXEMPT_LABELS) expect(lines).toContain(lane);
 	});
 });


### PR DESCRIPTION
Fixes #4300

`doctor` greened a repo where `triage` had no non-kill home for any issue. Two causes, and the second is the one worth reading: the required-label list was narrower than what the guards consume, **and** the check that read it could not tell a failed read from a genuine absence — so a checker passed while the thing it checks was unknown.

## What changed

**1. `doctor.sh` check `1c` — the label table is now a presentation mirror, not a second source.**
The required set is single-sourced in `packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts` (#4272, landed), which assembles it from the constants the guards themselves scope on. `doctor.sh`'s table only adds the colour + description a `gh label create` needs. Rows gained a `TIER` column: tier 1 fails the run, tier 3 only ever WARNs.

Tier-1 rows added: `wayfinder:backlog`, `axis:pipeline-hardening` (the two labels that make triage's standing-lane exemption reachable) and `area:infra` (the platform discriminator `lane` scopes on). `wayfinder:map` is a **tier-3** row — it is the wayfinder chart front door, an ideation surface, not a first-run prerequisite.

**2. New check `1d` — the mirror cannot silently fall behind the source.**
`doctor.sh` reads the source through a new `pipeline-cli vocabulary-preflight labels` verb (the only seam a bash preflight has onto a TS constant) and reds if its table no longer covers it. This is the check that would have caught the original bug: with `wayfinder:backlog` removed from the table, `1c` still reports `✓ all 17 required pipeline labels exist` and `1d` reports `✗ … DRIFTED … absent from the table above: wayfinder:backlog`.

**3. Every check reports THREE states, never two.**
This is the point of the fix, not a side effect. `1c` previously captured `gh api … 2>/dev/null` into a string and branched on emptiness, so a 403 and a genuinely label-less repo were the same value — and the message picked one ("could not read repo labels") for both. Now the read's **outcome** is captured separately from its **content**:

| | `1c` labels | `1d` vocabulary source | `3d` open milestone |
|---|---|---|---|
| present | `✓ all N required pipeline labels exist` | `✓ … covers all N labels of the shared vocabulary` | `✓ N open milestone(s)` |
| absent | `✗ N of M required … absent` + create commands | `✗ … has DRIFTED … absent from the table above: …` | `⚠ no open milestone — triage can exempt … but cannot home one into an arc` |
| **undetermined** | `✗ … UNDETERMINED — the label read on <repo> FAILED (unknown, NOT absent)` | `⚠ … UNVERIFIED against the shared vocabulary (unknown, NOT confirmed)` | `⚠ … UNDETERMINED — the read did not succeed (unknown, NOT 'no milestone')` |

A failed read never resolves to "fine", and never scores absence off a value it never obtained.

**4. Open-milestone existence is a Tier-3 WARN (`3d`), never a Tier-1 fail.**
Triage homes an issue into an existing open milestone and is forbidden from creating one (ADR 0072 §3), so a freshly-adopted repo legitimately has none — reddening on that would fail the correct state of a brand-new adopter. The WARN names the consequence: triage can exempt to a standing lane but cannot home into an arc/campaign.

**5. The hardcoded `15` is gone** — the count is derived from the table (`all 18 required pipeline labels exist` today).

## The label auto-create question, settled by observation

#4268 flagged as **explicitly unverified** whether `POST /repos/{owner}/{repo}/issues/{n}/labels` auto-creates a missing label. `doctor.sh`'s header rested on the assertion that it does not. **It does.** Measured 2026-07-26 against this repo: POSTing a label name that returned 404 from `GET /labels/{name}` succeeded with HTTP 200 and materialized the label repo-wide at GitHub's default grey `ededed` with a null description. (The probe label was removed from the issue and deleted repo-wide; `GET` re-confirms 404.)

Corroborating trace: `p3`, `area:infra`, and `axis:a11y` in this repo all carry exactly that signature — `color=ededed`, `description=null` — the fingerprint of labels minted by a write rather than created deliberately.

So the stated rationale for Tier 1 was **false**, and the header now says the true thing: `report` silently succeeds and mints an off-taxonomy label, and the damage lands on the **read** side, where `?labels=status:triaged` and every guard's label scoping match nothing and the pipeline runs protecting nothing. That is a stronger reason for Tier 1 than the one it replaces, so the check keeps its tier — the design is safe under either answer, and the answer is now recorded rather than assumed.

## Verification

Four states exercised by running the script, not by argument:

- **Real repo** — exit 0, `✓ all 18 required pipeline labels exist`, `✓ … covers all 16 labels of the shared vocabulary`, `✓ 14 open milestone(s)`.
- **Stubbed fresh repo, both standing-lane labels absent, no milestone** (AC6) — **exit 1**, `✗ 2 of 18 required pipeline label(s) absent` naming `wayfinder:backlog` and `axis:pipeline-hardening` each with its create command, plus the `wayfinder:map` and no-milestone WARNs.
- **Stubbed label read fails (403)** — `✗ required labels UNDETERMINED … (unknown, NOT absent)`, exit 1, and **zero** labels reported absent.
- **Vocabulary source unresolvable** (script run detached from the plugin tree) — `⚠ … UNVERIFIED … (unknown, NOT confirmed)`, every other check unaffected.
- Drift path — with a tier-1 row removed, `1c` still greens and `1d` reds by name.

Checks: `pnpm typecheck` clean; `pnpm lint:worktree` clean (3 files); `pipeline-cli` suite 177 files / 2794 tests passing, including `core-import-closure.unit.test.ts` (ADR 0218 — the new subcommand is reached only through `registry.ts`'s pruned fan-out edge and adds no core import); `gh-phoenix lint-skills` clean on both edited skill files; `shellcheck` clean on the new code (one pre-existing SC2043 on an untouched line); script re-run under `/bin/bash` 3.2 (the macOS default) since the heredoc parsing note in the file depends on it.

## Deviations / scope left out

1. **The shared vocabulary was not widened.** `REQUIRED_LABELS` (16) and doctor's tier-1 set (18) are not equal in either direction: doctor additionally requires `status:planning` and `status:awaiting-release`, which no guard scopes on but `plan-epic` and `ship-it` write. Rather than edit #4272's landed set, `1d` asserts only the direction that matters — doctor's set must **cover** the shared one. Doctor being a deliberate superset is recorded in the file.
2. **`1d` degrades to a WARN when the CLI cannot be resolved**, rather than failing Tier 1. Doctor's own Tier 3 treats `@kampus/pipeline-cli` resolving as optional, so making Tier 1 hard-depend on it would contradict the tier design for the exact fresh-repo adopter doctor serves. The honest report is "unverified", not a silent pass and not a false red.
3. **#4303** (repo `allow_auto_merge` + merge-queue ruleset) is untouched — same file, different proposition and API surface, independently pickable per triage note 4.
4. **(rebase round 1, 2026-07-26)** *Supersedes item 3's status, not its reasoning:* #4303 landed as PR #4346 while this branch waited, so this head is now rebased **on top of** it and carries both changes in `doctor.sh` / `doctor/SKILL.md`. This PR still authors none of #4303's checks — #4346's `2c`/`2d` blocks are byte-identical here (72 lines, verified by diff against `origin/main`).
5. **(rebase round 1)** **`claude-plugins/kampus-pipeline/README.md` is now in scope** — one file more than the pre-rebase head. #4346 left the README's two `the 15 required labels` phrasings standing; **this** PR is what widens the required set to 18, so that prose went stale as a direct consequence of this diff and is corrected here rather than deferred. Both sites are now count-free (a hardcoded count is the thing that goes stale; `doctor.sh` derives the number at runtime). The same edit also drops the README's copy of the **falsified** "a first run that fails deep inside a `gh api` call" claim, which this PR measured and removed from `doctor.sh` and `doctor/SKILL.md` — leaving the third copy would have shipped the PR contradicting itself.
6. **(rebase round 1)** Two conflict hunks in `doctor/SKILL.md` were resolved **semantically, keeping both sides**: (a) the "load-bearing pair" paragraph — this PR's corrected wording (which deletes the falsified round-trips-into-a-raw-API-error clause) is kept **plus** #4346's repo-admin-governance-pair paragraph, and #4346's `Tier-2 pair` → `Tier-2 checks` rewording is kept because Tier 2 now holds four checks; (b) the Conventions bullet — #4346's new `An unreadable state is UNKNOWN` bullet is kept **alongside** this PR's `LABELS table is a presentation mirror` bullet, which replaced the older canonical-set bullet the two sides fought over.

## Rebase (2026-07-26)

Rebased `c7220a75` → **`f176c618`** onto `origin/main` at `ce581d3c`, which now contains #4346 (merged 23:40:56Z). Three conflict hunks, all in the two shared `doctor/` files; the three `vocabulary-preflight` files applied clean. Re-verified against the rebased head, not inherited from the pre-rebase run: `pnpm typecheck` clean, `pnpm lint` clean, `@kampus/pipeline-cli` 177 files / **2805** tests passing, `doctor.sh` run live (exit 0, all four of this PR's checks and both of #4346's green), and the stubbed-403 label read re-reproduced — `✗ required labels UNDETERMINED … (unknown, NOT absent)`, exit 1, **zero** labels reported absent.

Per ADR 0058 the head moved, so this PR carries **no** bound verdict — it was deliberately rebased *before* review so the review binds the head that ships.

## §CP

This PR is **control-plane**: `claude-plugins/kampus-pipeline/skills/doctor/doctor.sh` matches the `^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$` clause of `CONTROL_PLANE_RE` as re-resolved from `origin/main`. It is human-merged and takes a `review-skill` verdict. The `packages/pipeline-cli/src/tools/vocabulary-preflight/**` files are *not* §CP on their own; the `.sh` is what carries it.

