### PR TITLE
fix(stand-up): a dead crew channel is a named outcome, not silent success (#4297)

### DIFF
--- a/claude-plugins/pipeline-crew-mcp/README.md
+++ b/claude-plugins/pipeline-crew-mcp/README.md
@@ -88,6 +88,14 @@ before anyone looks. Its text is the gate's own reason string, and it names whic
 **So: a stand-up that reports success but whose panes never talk to each other is this check, not the
 launcher.** Verify (2) before spending any time on launcher-side diagnosis.
 
+Since #4297 the launcher no longer leaves that entirely to the toast. Before it launches anything it
+reads the org managed-settings sources it can reach and reports one of three verdicts — **verified**,
+**blocked** (a read surface that excludes the plugin: stand-up aborts, naming the remedy), or
+**unverified/unknown** (the effective allowlist could not be resolved — most often because no managed
+settings exist at all and the CLI falls back to the vendor ledger). An `unverified` stand-up still
+launches, but its headline says `CHANNEL UNVERIFIED`, so a dead channel is no longer indistinguishable
+from a healthy one at the launcher. See `claude-plugins/pipeline-crew/commands/stand-up.md`.
+
 ### Per-session role comes from the environment
 
 The crew runs one session **per role**, but a plugin channel is **one static declaration** — it cannot

--- a/claude-plugins/pipeline-crew/commands/stand-up.md
+++ b/claude-plugins/pipeline-crew/commands/stand-up.md
@@ -35,13 +35,47 @@ Invoke the substrate's `stand-up` subcommand (pass through `$ARGUMENTS`, e.g.
 pipeline-crew-mcp stand-up $ARGUMENTS
 ```
 
-The launcher runs, **in order**: assert the pinned CLI version → ensure the per-project
-tracker is up → derive the roster session set (one per bridge + N engines) → build each
-session's channel bind + screen placement → launch each `claude` session bound to its role
-lease. It is **fail-loud with no partial crew**: a drifted CLI pin, a missing config
-dimension, an unstartable tracker, an inert channel, or a failed screen placement
-aborts **before any session is launched** and names the cause. Nothing is hand-launched.
+The launcher runs, **in order**: assert the pinned CLI version → check the CLI-side channel
+allowlist → ensure the per-project tracker is up → derive the roster session set (one per
+bridge + N engines) → build each session's channel bind + screen placement → launch each
+`claude` session bound to its role lease. It is **fail-loud with no partial crew**: a drifted
+CLI pin, a missing config dimension, an unstartable tracker, an inert channel, or a failed
+screen placement aborts **before any session is launched** and names the cause. Nothing is
+hand-launched.
 
-Report the tracker pid + socket and the launched sessions on success, or the named abort
-cause on failure. Do not hand-launch any session to "finish" a partial stand-up — re-run
-this command once the named precondition is fixed.
+## "An inert channel" — what aborts, and what can only be reported
+
+Two separate gates decide whether the crew channel binds, and only one of them is the
+launcher's to satisfy:
+
+- **The launcher's own gate.** The crew's channel ref must be registered, and any *third-party*
+  plugin channel must be listed in your config's `allowedChannelPlugins`. Both are checked
+  before launch and both **abort**.
+- **The CLI's gate.** Claude Code enforces a separate, identically-named `allowedChannelPlugins`
+  living in **org managed settings** — a different file, a different shape, a different enforcer.
+  Your crew config cannot satisfy it. When it is unmet the CLI does not error: it **skips** the
+  channel, the session launches, and the crew comes up with a dead channel.
+
+The launcher can only *read* that second gate, so it reports **three** outcomes and keeps them
+distinct (the rule is [PROBES.md](../PROBES.md)'s: a check that could not run resolves to
+"unknown", never to "down"):
+
+- **verified** — a managed-settings source was read and lists the crew plugin. The channel binds.
+- **blocked** — a managed-settings source was read, sets `allowedChannelPlugins`, and the crew
+  plugin is not on it. This is a proven inert channel: stand-up **aborts before any session
+  launches** and names the managed-settings remedy.
+- **unverified (unknown)** — the effective allowlist could not be resolved: no managed-settings
+  source exists (the CLI then falls back to a vendor-controlled ledger the launcher cannot read),
+  a source is present but unreadable or malformed, or an MDM-managed policy surface is in play.
+  This **never** aborts — refusing on a surface nobody could read is the fail-closed probe
+  PROBES.md exists to forbid — but it is **never reported as success either**: the stand-up
+  headline says `CHANNEL UNVERIFIED` and prints what it consulted plus the remedy.
+
+Development channel mode reports **not applicable**: the CLI's allowlist gate is bypassed there,
+so nothing was verified and nothing needed to be.
+
+Report the tracker pid + socket, the launched sessions, **and the channel-allowlist verdict** on
+success, or the named abort cause on failure. A completed stand-up is not by itself a working
+channel — if the verdict is `UNVERIFIED`, say so rather than reporting a clean stand-up. Do not
+hand-launch any session to "finish" a partial stand-up — re-run this command once the named
+precondition is fixed.

--- a/claude-plugins/pipeline-crew/commands/stand-up.md
+++ b/claude-plugins/pipeline-crew/commands/stand-up.md
@@ -60,13 +60,16 @@ The launcher can only *read* that second gate, so it reports **three** outcomes 
 distinct (the rule is [PROBES.md](../PROBES.md)'s: a check that could not run resolves to
 "unknown", never to "down"):
 
-- **verified** — a managed-settings source was read and lists the crew plugin. The channel binds.
+- **verified** — a managed-settings source was read and lists the crew plugin. **This gate is
+  satisfied** — not a promise the channel binds: the CLI runs other skip checks after it.
 - **blocked** — a managed-settings source was read, sets `allowedChannelPlugins`, and the crew
   plugin is not on it. This is a proven inert channel: stand-up **aborts before any session
   launches** and names the managed-settings remedy.
 - **unverified (unknown)** — the effective allowlist could not be resolved: no managed-settings
   source exists (the CLI then falls back to a vendor-controlled ledger the launcher cannot read),
-  a source is present but unreadable or malformed, or an MDM-managed policy surface is in play.
+  a source is present but unreadable or malformed, the drop-in directory exists but could not be
+  enumerated, an MDM-managed policy surface is in play, or the platform carries a policy surface
+  (the Windows registry) the launcher cannot interrogate at all.
   This **never** aborts — refusing on a surface nobody could read is the fail-closed probe
   PROBES.md exists to forbid — but it is **never reported as success either**: the stand-up
   headline says `CHANNEL UNVERIFIED` and prints what it consulted plus the remedy.

--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -66,6 +66,7 @@ import {
 } from "./crew/index.ts";
 import {
 	CREW_WINDOW,
+	renderChannelAllowlistOutcome,
 	renderStandUpError,
 	renderTaggedError,
 	retireRole,
@@ -182,10 +183,13 @@ const standUp = Command.make(
 		// operator crew config itself (config.ts's typed reader, #3354 seam 1); nothing to inject here.
 		return yield* runStandUp({projectRoot}).pipe(
 			Effect.flatMap((result) =>
+				// The headline states the channel verdict, not just the pane count (#4297): a crew whose
+				// channel could not be verified must not read as a plain success at a glance, because a
+				// dead channel presents downstream as four unrelated-looking bugs and never as this one.
 				Console.error(
-					`crew up: tracker pid ${result.tracker.pid ?? "?"} on ${result.tracker.socketPath}; ${result.launched.length} panes launched in the ${CREW_WINDOW} window (${result.launched
+					`crew up${result.channelAllowlist.status === "unknown" ? " — CHANNEL UNVERIFIED" : ""}: tracker pid ${result.tracker.pid ?? "?"} on ${result.tracker.socketPath}; ${result.launched.length} panes launched in the ${CREW_WINDOW} window (${result.launched
 						.map((s) => `${s.role}→${s.pane}`)
-						.join(", ")})`,
+						.join(", ")})\n  ${renderChannelAllowlistOutcome(result.channelAllowlist)}`,
 				),
 			),
 			// Fail-loud, no partial crew: a bad config, a version drift, an unstartable tracker, an inert

--- a/packages/pipeline-crew-mcp/src/standup/channel-allowlist.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/channel-allowlist.test.ts
@@ -26,6 +26,7 @@ const SURFACES: PolicySurfaces = {
 	settingsFile: "/policy/managed-settings.json",
 	dropInDir: "/policy/managed-settings.d",
 	opaque: [],
+	undeterminable: [],
 };
 
 /** A whole filesystem backed by one in-memory path→content map; anything unlisted is absent. */
@@ -48,7 +49,11 @@ const fakeFs = (
 				: Effect.succeed(content);
 		},
 		readDirectory: (path) => {
-			const prefix = `${String(path)}/`;
+			const key = String(path);
+			// A directory in `unreadable` EXISTS but cannot be enumerated (EACCES) — distinct from one
+			// that is simply absent, which is the distinction the drop-in read has to preserve.
+			if (unreadable.has(key)) return Effect.fail(new Error("EACCES") as never);
+			const prefix = `${key}/`;
 			const names = Object.keys(files)
 				.filter((f) => f.startsWith(prefix))
 				.map((f) => f.slice(prefix.length));
@@ -88,9 +93,25 @@ describe("standup/channel-allowlist — policy surface resolution", () => {
 		assert.strictEqual(surfaces.dropInDir, "/etc/claude-code/managed-settings.d");
 	});
 
-	it("treats macOS MDM preferences as an opaque surface, and nothing on other platforms", () => {
-		assert.isAbove(opaquePolicySurfaces("darwin").length, 0);
+	it("lists BOTH macOS MDM plists, per-user first — the order the CLI resolves them in", () => {
+		// The CLI builds per-user then device-level and takes the first that exists and parses, so a
+		// device-level-only guard misses the surface it actually consulted on a per-user managed host.
+		assert.deepStrictEqual(opaquePolicySurfaces("darwin", "someone"), [
+			"/Library/Managed Preferences/someone/com.anthropic.claudecode.plist",
+			"/Library/Managed Preferences/com.anthropic.claudecode.plist",
+		]);
+		assert.deepStrictEqual(opaquePolicySurfaces("darwin", null), [
+			"/Library/Managed Preferences/com.anthropic.claudecode.plist",
+		]);
 		assert.deepStrictEqual(opaquePolicySurfaces("linux"), []);
+	});
+
+	it("names the Windows registry keys as UNDETERMINABLE, not as existence-checkable paths", () => {
+		// A registry key is not a filesystem path: `fs.exists` on one answers "absent" for a key that
+		// is in fact set. Claiming coverage the code did not have was the docblock's overclaim.
+		assert.deepStrictEqual(policySurfacesFor("win32").opaque, []);
+		assert.isAbove(policySurfacesFor("win32").undeterminable.length, 0);
+		assert.deepStrictEqual(policySurfacesFor("linux").undeterminable, []);
 	});
 });
 
@@ -184,6 +205,52 @@ describe("standup/channel-allowlist — probeChannelAllowlist", () => {
 				[SURFACES.settingsFile]: JSON.stringify({allowedChannelPlugins: [CREW_CHANNEL_PLUGIN]}),
 			});
 			assert.strictEqual(outcome.status, "unknown");
+		}),
+	);
+
+	it.effect(
+		"UNKNOWN — never blocked — when the drop-in directory exists but cannot be enumerated",
+		() =>
+			Effect.gen(function* () {
+				// The regression this test exists for: a root-only drop-in dir beside a world-readable
+				// settings file that sets the list without the crew plugin. Collapsing the failed
+				// enumeration to "no drop-in files" turns an unread surface into a launch-aborting
+				// `blocked` — a definite answer drawn from a partial read.
+				const outcome = yield* probe(
+					{[SURFACES.settingsFile]: settingsListing([{marketplace: "acme", plugin: "acme-chat"}])},
+					{unreadable: [SURFACES.dropInDir]},
+				);
+				assert.strictEqual(outcome.status, "unknown");
+				assert.include(outcome.reason, SURFACES.dropInDir);
+			}),
+	);
+
+	it.effect("consults the drop-in directory by name even when it is simply absent", () =>
+		Effect.gen(function* () {
+			// An absent dir still resolves normally — but the operator log must show it was attempted,
+			// otherwise "what did the probe look at" is unanswerable for the surface most likely to
+			// hold the missing entry.
+			const outcome = yield* probe({
+				[SURFACES.settingsFile]: settingsListing([{marketplace: "acme", plugin: "acme-chat"}]),
+			});
+			assert.strictEqual(outcome.status, "blocked");
+			assert.include(outcome.consulted, SURFACES.dropInDir);
+		}),
+	);
+
+	it.effect("UNKNOWN — never blocked — when an undeterminable policy surface is in scope", () =>
+		Effect.gen(function* () {
+			const withRegistry: PolicySurfaces = {
+				...SURFACES,
+				undeterminable: ["HKLM\\SOFTWARE\\Policies\\ClaudeCode"],
+			};
+			const outcome = yield* probe(
+				{[SURFACES.settingsFile]: settingsListing([{marketplace: "acme", plugin: "acme-chat"}])},
+				{},
+				withRegistry,
+			);
+			assert.strictEqual(outcome.status, "unknown");
+			assert.include(outcome.consulted, "HKLM\\SOFTWARE\\Policies\\ClaudeCode");
 		}),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/channel-allowlist.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/channel-allowlist.test.ts
@@ -1,0 +1,274 @@
+/**
+ * standup/channel-allowlist — the pre-launch probe of the CLI-side org-managed channel allowlist
+ * (issue #4297). These tests pin the property the fix exists for: the probe resolves THREE outcomes
+ * and never collapses them, so "the channel is verified working" and "we could not check the channel"
+ * are distinguishable states. Only a policy surface actually READ and found non-matching yields
+ * `blocked` (the sole launch-aborting verdict); an absent, unreadable, malformed, or MDM-opaque
+ * surface yields `unknown`, which proceeds and must be reported. The whole filesystem is substituted
+ * via `FileSystem.layerNoop`, so no real managed-settings file is touched.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, FileSystem, Layer} from "effect";
+import {CREW_CHANNEL_MARKETPLACE, CREW_CHANNEL_PLUGIN, CREW_PLUGIN_CHANNEL_REF} from "./bind.ts";
+import {
+	assertChannelAllowlist,
+	ChannelAllowlistBlockedError,
+	type ChannelAllowlistOutcome,
+	managedSettingsDir,
+	opaquePolicySurfaces,
+	type PolicySurfaces,
+	policySurfacesFor,
+	probeChannelAllowlist,
+	renderChannelAllowlistOutcome,
+} from "./channel-allowlist.ts";
+
+const SURFACES: PolicySurfaces = {
+	settingsFile: "/policy/managed-settings.json",
+	dropInDir: "/policy/managed-settings.d",
+	opaque: [],
+};
+
+/** A whole filesystem backed by one in-memory path→content map; anything unlisted is absent. */
+const fakeFs = (
+	files: Readonly<Record<string, string>>,
+	opts: {readonly opaquePresent?: readonly string[]; readonly unreadable?: readonly string[]} = {},
+) => {
+	const unreadable = new Set(opts.unreadable ?? []);
+	// An unreadable path is PRESENT — that is the whole distinction under test: a surface that exists
+	// but cannot be read must not be classified the same as one that is simply absent.
+	const present = new Set([...Object.keys(files), ...unreadable, ...(opts.opaquePresent ?? [])]);
+	return FileSystem.layerNoop({
+		exists: (path) => Effect.succeed(present.has(String(path))),
+		readFileString: (path) => {
+			const key = String(path);
+			if (unreadable.has(key)) return Effect.fail(new Error("EACCES") as never);
+			const content = files[key];
+			return content === undefined
+				? Effect.fail(new Error("ENOENT") as never)
+				: Effect.succeed(content);
+		},
+		readDirectory: (path) => {
+			const prefix = `${String(path)}/`;
+			const names = Object.keys(files)
+				.filter((f) => f.startsWith(prefix))
+				.map((f) => f.slice(prefix.length));
+			const opaqueNames = [...unreadable]
+				.filter((f) => f.startsWith(prefix))
+				.map((f) => f.slice(prefix.length));
+			return Effect.succeed([...names, ...opaqueNames]);
+		},
+	});
+};
+
+const probe = (
+	files: Readonly<Record<string, string>>,
+	opts: Parameters<typeof fakeFs>[1] = {},
+	surfaces: PolicySurfaces = SURFACES,
+): Effect.Effect<ChannelAllowlistOutcome> =>
+	probeChannelAllowlist({
+		plugin: CREW_CHANNEL_PLUGIN,
+		marketplace: CREW_CHANNEL_MARKETPLACE,
+		ref: CREW_PLUGIN_CHANNEL_REF,
+		surfaces,
+	}).pipe(Effect.provide(Layer.mergeAll(fakeFs(files, opts))));
+
+const settingsListing = (entries: readonly {marketplace: string; plugin: string}[]): string =>
+	JSON.stringify({allowedChannelPlugins: entries});
+
+describe("standup/channel-allowlist — policy surface resolution", () => {
+	it("resolves each platform's managed-settings directory verbatim from the CLI's own resolver", () => {
+		assert.strictEqual(managedSettingsDir("darwin"), "/Library/Application Support/ClaudeCode");
+		assert.strictEqual(managedSettingsDir("win32"), "C:\\Program Files\\ClaudeCode");
+		assert.strictEqual(managedSettingsDir("linux"), "/etc/claude-code");
+	});
+
+	it("names the managed-settings file and its drop-in dir under that directory", () => {
+		const surfaces = policySurfacesFor("linux");
+		assert.strictEqual(surfaces.settingsFile, "/etc/claude-code/managed-settings.json");
+		assert.strictEqual(surfaces.dropInDir, "/etc/claude-code/managed-settings.d");
+	});
+
+	it("treats macOS MDM preferences as an opaque surface, and nothing on other platforms", () => {
+		assert.isAbove(opaquePolicySurfaces("darwin").length, 0);
+		assert.deepStrictEqual(opaquePolicySurfaces("linux"), []);
+	});
+});
+
+describe("standup/channel-allowlist — probeChannelAllowlist", () => {
+	it.effect("ALLOWED when a readable policy surface lists the crew plugin", () =>
+		Effect.gen(function* () {
+			const outcome = yield* probe({
+				[SURFACES.settingsFile]: settingsListing([
+					{marketplace: CREW_CHANNEL_MARKETPLACE, plugin: CREW_CHANNEL_PLUGIN},
+				]),
+			});
+			assert.strictEqual(outcome.status, "allowed");
+			assert.include(outcome.consulted, SURFACES.settingsFile);
+		}),
+	);
+
+	it.effect("ALLOWED when a drop-in file lists it even though the base file does not", () =>
+		Effect.gen(function* () {
+			const outcome = yield* probe({
+				[SURFACES.settingsFile]: settingsListing([{marketplace: "other", plugin: "other"}]),
+				[`${SURFACES.dropInDir}/10-channels.json`]: settingsListing([
+					{marketplace: CREW_CHANNEL_MARKETPLACE, plugin: CREW_CHANNEL_PLUGIN},
+				]),
+			});
+			assert.strictEqual(outcome.status, "allowed");
+		}),
+	);
+
+	it.effect("BLOCKED when a readable surface sets the list and the crew plugin is not on it", () =>
+		Effect.gen(function* () {
+			const outcome = yield* probe({
+				[SURFACES.settingsFile]: settingsListing([{marketplace: "acme", plugin: "acme-chat"}]),
+			});
+			assert.strictEqual(outcome.status, "blocked");
+			assert.include(outcome.reason, "dead channel");
+		}),
+	);
+
+	it.effect("BLOCKED on a same-name/different-marketplace entry — both fields must match", () =>
+		Effect.gen(function* () {
+			// The CLI matches `plugin === name && marketplace === marketplace`; a name-only match is not a match.
+			const outcome = yield* probe({
+				[SURFACES.settingsFile]: settingsListing([
+					{marketplace: "someone-elses-marketplace", plugin: CREW_CHANNEL_PLUGIN},
+				]),
+			});
+			assert.strictEqual(outcome.status, "blocked");
+		}),
+	);
+
+	it.effect(
+		"UNKNOWN when no managed-settings source exists at all (the vendor-ledger fallback)",
+		() =>
+			Effect.gen(function* () {
+				const outcome = yield* probe({});
+				assert.strictEqual(outcome.status, "unknown");
+				assert.include(outcome.reason, "ledger");
+			}),
+	);
+
+	it.effect("UNKNOWN when a source sets no allowedChannelPlugins key", () =>
+		Effect.gen(function* () {
+			const outcome = yield* probe({
+				[SURFACES.settingsFile]: JSON.stringify({channelsEnabled: true}),
+			});
+			assert.strictEqual(outcome.status, "unknown");
+		}),
+	);
+
+	it.effect("UNKNOWN — never blocked — when a present source cannot be read", () =>
+		Effect.gen(function* () {
+			// The PROBES.md distinction the whole module turns on: "I could not ask" is not "the answer is no".
+			const outcome = yield* probe({}, {unreadable: [SURFACES.settingsFile]});
+			assert.strictEqual(outcome.status, "unknown");
+			assert.include(outcome.reason, SURFACES.settingsFile);
+		}),
+	);
+
+	it.effect("UNKNOWN when a present source is not valid JSON", () =>
+		Effect.gen(function* () {
+			const outcome = yield* probe({[SURFACES.settingsFile]: "{ not json"});
+			assert.strictEqual(outcome.status, "unknown");
+		}),
+	);
+
+	it.effect("UNKNOWN when allowedChannelPlugins is set in an unrecognized shape", () =>
+		Effect.gen(function* () {
+			// A bare string list is the CLI's OTHER identically-named field (the launcher's own). Reading it
+			// as an empty effective allowlist would manufacture a `blocked` verdict out of a shape mismatch.
+			const outcome = yield* probe({
+				[SURFACES.settingsFile]: JSON.stringify({allowedChannelPlugins: [CREW_CHANNEL_PLUGIN]}),
+			});
+			assert.strictEqual(outcome.status, "unknown");
+		}),
+	);
+
+	it.effect("UNKNOWN — never blocked — when an opaque MDM policy surface is present", () =>
+		Effect.gen(function* () {
+			const withMdm: PolicySurfaces = {...SURFACES, opaque: ["/policy/mdm.plist"]};
+			const outcome = yield* probe(
+				{[SURFACES.settingsFile]: settingsListing([{marketplace: "acme", plugin: "acme-chat"}])},
+				{opaquePresent: ["/policy/mdm.plist"]},
+				withMdm,
+			);
+			assert.strictEqual(outcome.status, "unknown");
+		}),
+	);
+});
+
+describe("standup/channel-allowlist — assertChannelAllowlist", () => {
+	// The assert declares a `FileSystem` requirement for its production probe; each injected probe here
+	// already carries its own fake filesystem, so an empty one discharges the leftover declared context.
+	const assertWith = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem>) =>
+		effect.pipe(Effect.provide(fakeFs({})));
+
+	it.effect("aborts on BLOCKED, naming the ref and the managed-settings remedy", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(
+				assertWith(
+					assertChannelAllowlist(
+						{mode: "allowlist"},
+						probe({
+							[SURFACES.settingsFile]: settingsListing([
+								{marketplace: "acme", plugin: "acme-chat"},
+							]),
+						}),
+					),
+				),
+			);
+			assert.instanceOf(error, ChannelAllowlistBlockedError);
+			assert.strictEqual(error.ref, CREW_PLUGIN_CHANNEL_REF);
+			assert.include(error.remedy, "allowedChannelPlugins");
+			assert.include(error.remedy, CREW_CHANNEL_PLUGIN);
+		}),
+	);
+
+	it.effect("returns UNKNOWN rather than aborting — an unrunnable check never gates", () =>
+		Effect.gen(function* () {
+			const outcome = yield* assertWith(assertChannelAllowlist({mode: "allowlist"}, probe({})));
+			assert.strictEqual(outcome.status, "unknown");
+		}),
+	);
+
+	it.effect("short-circuits development mode to NOT APPLICABLE without probing", () =>
+		Effect.gen(function* () {
+			const probeNeverRuns = Effect.die("the probe must not run in development mode");
+			const outcome = yield* assertWith(
+				assertChannelAllowlist({mode: "development"}, probeNeverRuns),
+			);
+			assert.strictEqual(outcome.status, "not-applicable");
+		}),
+	);
+});
+
+describe("standup/channel-allowlist — renderChannelAllowlistOutcome", () => {
+	const outcomeAt = (status: ChannelAllowlistOutcome["status"]): ChannelAllowlistOutcome => ({
+		status,
+		ref: CREW_PLUGIN_CHANNEL_REF,
+		reason: "because",
+		consulted: [SURFACES.settingsFile],
+	});
+
+	it("renders a verified channel as VERIFIED", () => {
+		assert.include(renderChannelAllowlistOutcome(outcomeAt("allowed")), "VERIFIED");
+	});
+
+	it("renders an unresolvable channel as UNVERIFIED, and says it is not a confirmation", () => {
+		// The load-bearing assertion of the whole issue: the unknown line must not read as a success.
+		const rendered = renderChannelAllowlistOutcome(outcomeAt("unknown"));
+		assert.include(rendered, "UNVERIFIED");
+		assert.include(rendered, "NOT a confirmation");
+		assert.include(rendered, "allowedChannelPlugins");
+		assert.notInclude(renderChannelAllowlistOutcome(outcomeAt("allowed")), "UNVERIFIED");
+	});
+
+	it("renders development mode as NOT APPLICABLE, distinct from VERIFIED", () => {
+		const rendered = renderChannelAllowlistOutcome(outcomeAt("not-applicable"));
+		assert.include(rendered, "NOT APPLICABLE");
+		assert.notInclude(rendered, "VERIFIED");
+	});
+});

--- a/packages/pipeline-crew-mcp/src/standup/channel-allowlist.ts
+++ b/packages/pipeline-crew-mcp/src/standup/channel-allowlist.ts
@@ -25,10 +25,14 @@
  * The one non-obvious thing: this probe resolves THREE outcomes and refuses to collapse them, per
  * `claude-plugins/pipeline-crew/PROBES.md`. Only a policy surface the launcher actually READ and found
  * non-matching yields `blocked` (the sole outcome that may abort a launch). A surface it could not read
- * — absent, unparseable, or an opaque MDM channel — yields `unknown`, which never aborts but is never
- * reported as success either: the caller must say "unverified" out loud. That is the point of the
- * issue, not a detail of it — a skip that cannot be told apart from a success is the defect.
+ * — absent, unparseable, an unenumerable drop-in directory, an existing MDM plist, or the Windows
+ * registry it cannot interrogate at all — yields `unknown`, which never aborts but is never reported
+ * as success either: the caller must say "unverified" out loud. That is the point of the issue, not a
+ * detail of it — a skip that cannot be told apart from a success is the defect. The corollary that
+ * keeps biting (#4223, #3715, #4290, and this module's own first round): a read that FAILS must never
+ * be folded into the same value as a read that succeeded and found nothing.
  */
+import os from "node:os";
 import {Effect, FileSystem, Schema} from "effect";
 import {CREW_CHANNEL_MARKETPLACE, CREW_CHANNEL_PLUGIN, CREW_PLUGIN_CHANNEL_REF} from "./bind.ts";
 import type {ChannelConfig} from "./config.ts";
@@ -49,20 +53,69 @@ export const managedSettingsDir = (platform: NodeJS.Platform): string => {
 	return "/etc/claude-code";
 };
 
-/**
- * Policy surfaces the CLI merges into `policySettings` that the launcher CANNOT parse — macOS MDM
- * preference domains (and, on Windows, the registry). Their mere EXISTENCE is what matters: one
- * present means the effective allowlist may carry entries this probe cannot see, so any `blocked`
- * verdict would be a guess. The probe downgrades to `unknown` instead of guessing.
- */
-export const opaquePolicySurfaces = (platform: NodeJS.Platform): readonly string[] =>
-	platform === "darwin" ? ["/Library/Managed Preferences/com.anthropic.claudecode.plist"] : [];
+/** The macOS managed-preference domain the CLI loads its MDM settings from, and its parent dir. */
+const MDM_PREFERENCE_DOMAIN = "com.anthropic.claudecode";
+const MACOS_MANAGED_PREFERENCES_DIR = "/Library/Managed Preferences";
 
-/** Where a probe run looks: the readable JSON policy files/dirs, and the surfaces it cannot parse. */
+/**
+ * The Windows policy registry keys the CLI merges into `policySettings`. Named as KEYS, not values —
+ * this probe never reads them (see `PolicySurfaces.undeterminable`).
+ */
+export const WINDOWS_POLICY_REGISTRY_KEYS: readonly string[] = [
+	"HKLM\\SOFTWARE\\Policies\\ClaudeCode",
+	"HKCU\\SOFTWARE\\Policies\\ClaudeCode",
+];
+
+/**
+ * The current login name, or `null` when the host has no resolvable passwd entry for it — the one
+ * case `os.userInfo()` throws. `null` costs only the per-user plist from the opaque list, which is
+ * safe: it can never turn an unread surface into a `blocked`, only into one fewer `unknown` trigger.
+ */
+const currentUsername = (): string | null => {
+	// biome-ignore lint/plugin: pre-runtime bootstrap guard — this is the default parameter of a pure synchronous surface-name resolver, evaluated where no Effect runtime exists to carry an `E` channel.
+	try {
+		return os.userInfo().username || null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * macOS managed-preference plists: present-checkable, unparseable-if-present (the `opaque` half of
+ * `PolicySurfaces`). Both are listed, PER-USER FIRST, because that is the order the CLI builds them
+ * in and it takes the first that exists and parses — so on a host carrying only a per-user plist,
+ * a device-level-only guard would miss the very surface the CLI consulted.
+ */
+export const opaquePolicySurfaces = (
+	platform: NodeJS.Platform,
+	username: string | null = currentUsername(),
+): readonly string[] => {
+	if (platform !== "darwin") return [];
+	const deviceLevel = `${MACOS_MANAGED_PREFERENCES_DIR}/${MDM_PREFERENCE_DOMAIN}.plist`;
+	return username === null
+		? [deviceLevel]
+		: [`${MACOS_MANAGED_PREFERENCES_DIR}/${username}/${MDM_PREFERENCE_DOMAIN}.plist`, deviceLevel];
+};
+
+/**
+ * Policy surfaces whose PRESENCE this probe cannot even test — the Windows registry, which is not a
+ * filesystem path at all. `fs.exists` on a registry key would answer "absent" for a key that is in
+ * fact set, which is precisely the unread-surface-yields-a-definite-answer defect this module exists
+ * to avoid, so one of these in scope resolves `unknown` outright rather than being existence-probed.
+ */
+export const undeterminablePolicySurfaces = (platform: NodeJS.Platform): readonly string[] =>
+	platform === "win32" ? WINDOWS_POLICY_REGISTRY_KEYS : [];
+
+/**
+ * Where a probe run looks. Three kinds, and the split IS the AC: `settingsFile`/`dropInDir` are read
+ * and parsed; `opaque` surfaces are existence-checked but not parsed; `undeterminable` surfaces
+ * cannot be interrogated at all. Anything but the first kind forces `unknown`, never `blocked`.
+ */
 export interface PolicySurfaces {
 	readonly settingsFile: string;
 	readonly dropInDir: string;
 	readonly opaque: readonly string[];
+	readonly undeterminable: readonly string[];
 }
 
 /** The default surfaces for a platform — the production wiring, and the shape tests substitute. */
@@ -73,6 +126,7 @@ export const policySurfacesFor = (platform: NodeJS.Platform): PolicySurfaces => 
 		settingsFile: `${dir}${sep}${MANAGED_SETTINGS_FILE}`,
 		dropInDir: `${dir}${sep}${MANAGED_SETTINGS_DROPIN_DIR}`,
 		opaque: opaquePolicySurfaces(platform),
+		undeterminable: undeterminablePolicySurfaces(platform),
 	};
 };
 
@@ -185,6 +239,39 @@ const readJsonSource = (fs: FileSystem.FileSystem, path: string): Effect.Effect<
 		),
 	);
 
+/**
+ * The drop-in dir's `*.json` files, or why they could not be listed. Same three-way shape (and same
+ * reason for it) as `SourceRead`: an unreadable DIRECTORY is not an absent one either. `readDirectory`
+ * fails identically on `ENOENT` and `EACCES`/`ENOTDIR`, so without the `fs.exists` disambiguation a
+ * root-only drop-in dir beside a world-readable settings file yields `blocked` off a partial read.
+ */
+type DropInRead =
+	| {readonly kind: "files"; readonly paths: readonly string[]}
+	| {readonly kind: "absent"}
+	| {readonly kind: "unreadable"; readonly detail: string};
+
+const readDropInDir = (fs: FileSystem.FileSystem, dir: string): Effect.Effect<DropInRead> =>
+	fs.readDirectory(dir).pipe(
+		Effect.map(
+			(names): DropInRead => ({
+				kind: "files",
+				paths: names
+					.filter((name) => name.endsWith(".json"))
+					.sort()
+					.map((name) => `${dir}/${name}`),
+			}),
+		),
+		Effect.catch((cause) =>
+			fs.exists(dir).pipe(
+				Effect.map(
+					(present): DropInRead =>
+						present ? {kind: "unreadable", detail: String(cause)} : {kind: "absent"},
+				),
+				Effect.orElseSucceed((): DropInRead => ({kind: "unreadable", detail: String(cause)})),
+			),
+		),
+	);
+
 export interface ChannelAllowlistProbeInput {
 	readonly plugin: string;
 	readonly marketplace: string;
@@ -205,6 +292,17 @@ export const probeChannelAllowlist = (
 		const {plugin, marketplace, ref, surfaces} = input;
 		const consulted: string[] = [];
 
+		const undeterminable = surfaces.undeterminable[0];
+		if (undeterminable !== undefined) {
+			consulted.push(...surfaces.undeterminable);
+			return {
+				status: "unknown",
+				ref,
+				consulted,
+				reason: `a policy surface this probe cannot interrogate at all (${undeterminable}) is in scope on this platform, so the CLI's effective channel allowlist cannot be resolved from here`,
+			};
+		}
+
 		for (const path of surfaces.opaque) {
 			consulted.push(path);
 			const present = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => true));
@@ -218,15 +316,17 @@ export const probeChannelAllowlist = (
 			}
 		}
 
-		const dropInFiles = yield* fs.readDirectory(surfaces.dropInDir).pipe(
-			Effect.map((names) =>
-				names
-					.filter((name) => name.endsWith(".json"))
-					.sort()
-					.map((name) => `${surfaces.dropInDir}/${name}`),
-			),
-			Effect.orElseSucceed(() => [] as readonly string[]),
-		);
+		consulted.push(surfaces.dropInDir);
+		const dropIn = yield* readDropInDir(fs, surfaces.dropInDir);
+		if (dropIn.kind === "unreadable") {
+			return {
+				status: "unknown",
+				ref,
+				consulted,
+				reason: `the managed-settings drop-in directory (${surfaces.dropInDir}) is present but could not be enumerated: ${dropIn.detail} — a drop-in file it holds could carry the entry, so no verdict can be drawn from the sources that did read`,
+			};
+		}
+		const dropInFiles = dropIn.kind === "files" ? dropIn.paths : [];
 
 		const reads: SourceRead[] = [];
 		for (const path of [surfaces.settingsFile, ...dropInFiles]) {

--- a/packages/pipeline-crew-mcp/src/standup/channel-allowlist.ts
+++ b/packages/pipeline-crew-mcp/src/standup/channel-allowlist.ts
@@ -1,0 +1,360 @@
+/**
+ * standup/channel-allowlist — the pre-launch probe of the CLI-side channel allowlist, the ONE gate
+ * on the crew channel that no launcher-owned config can satisfy (issue #4297).
+ *
+ * `bind.ts` enforces the launcher's own `allowedChannelPlugins` and auto-allowlists the crew's own
+ * plugin there, which is right — the launcher emits that ref, so it cannot be misconfigured. But the
+ * Claude Code CLI enforces a SEPARATE, identically-named `allowedChannelPlugins` living in ORG MANAGED
+ * SETTINGS (a different file, a different shape, a different enforcer), and when that one is unmet the
+ * CLI's channel gate returns `{action: "skip", kind: "allowlist"}` — a SKIP, not an error. The session
+ * launches, every launcher-side guard stays green, and the crew comes up with a dead channel. Nothing
+ * on the launch path could observe that, so stand-up reported plain success on a silently dead crew.
+ *
+ * Grounded against the installed CLI bundle at 2.1.220, not intuited (CLAUDE.md's "ground falsifiable
+ * runtime claims in source"). The gate's own code:
+ *
+ *     if(!o.dev){ let {entries:s,source:a} = getEffectiveChannelAllowlist(n?.allowedChannelPlugins);
+ *       if(!s.some(l => l.plugin===o.name && l.marketplace===o.marketplace))
+ *         return {action:"skip", kind:"allowlist", reason: a==="org" ? … : …} }
+ *
+ * Two facts follow, and they are the whole design: the check is bypassed entirely under
+ * `--dangerously-load-development-channels` (the `!o.dev` guard), and when managed settings do NOT set
+ * `allowedChannelPlugins` the effective list comes from a vendor-controlled remote-config ledger the
+ * launcher has no way to read.
+ *
+ * The one non-obvious thing: this probe resolves THREE outcomes and refuses to collapse them, per
+ * `claude-plugins/pipeline-crew/PROBES.md`. Only a policy surface the launcher actually READ and found
+ * non-matching yields `blocked` (the sole outcome that may abort a launch). A surface it could not read
+ * — absent, unparseable, or an opaque MDM channel — yields `unknown`, which never aborts but is never
+ * reported as success either: the caller must say "unverified" out loud. That is the point of the
+ * issue, not a detail of it — a skip that cannot be told apart from a success is the defect.
+ */
+import {Effect, FileSystem, Schema} from "effect";
+import {CREW_CHANNEL_MARKETPLACE, CREW_CHANNEL_PLUGIN, CREW_PLUGIN_CHANNEL_REF} from "./bind.ts";
+import type {ChannelConfig} from "./config.ts";
+
+/** The managed-settings file name the CLI reads its org policy settings from, on every platform. */
+export const MANAGED_SETTINGS_FILE = "managed-settings.json";
+/** The drop-in directory sitting beside it, whose `*.json` files layer onto the same policy settings. */
+export const MANAGED_SETTINGS_DROPIN_DIR = "managed-settings.d";
+
+/**
+ * The platform's managed-settings directory, verbatim from the installed CLI bundle's own resolver
+ * (2.1.220: `switch(platform){case"macos":…;case"windows":…;default:"/etc/claude-code"}`). These are
+ * OS-standard administrative locations, not operator data — nothing here varies per install.
+ */
+export const managedSettingsDir = (platform: NodeJS.Platform): string => {
+	if (platform === "darwin") return "/Library/Application Support/ClaudeCode";
+	if (platform === "win32") return "C:\\Program Files\\ClaudeCode";
+	return "/etc/claude-code";
+};
+
+/**
+ * Policy surfaces the CLI merges into `policySettings` that the launcher CANNOT parse — macOS MDM
+ * preference domains (and, on Windows, the registry). Their mere EXISTENCE is what matters: one
+ * present means the effective allowlist may carry entries this probe cannot see, so any `blocked`
+ * verdict would be a guess. The probe downgrades to `unknown` instead of guessing.
+ */
+export const opaquePolicySurfaces = (platform: NodeJS.Platform): readonly string[] =>
+	platform === "darwin" ? ["/Library/Managed Preferences/com.anthropic.claudecode.plist"] : [];
+
+/** Where a probe run looks: the readable JSON policy files/dirs, and the surfaces it cannot parse. */
+export interface PolicySurfaces {
+	readonly settingsFile: string;
+	readonly dropInDir: string;
+	readonly opaque: readonly string[];
+}
+
+/** The default surfaces for a platform — the production wiring, and the shape tests substitute. */
+export const policySurfacesFor = (platform: NodeJS.Platform): PolicySurfaces => {
+	const dir = managedSettingsDir(platform);
+	const sep = platform === "win32" ? "\\" : "/";
+	return {
+		settingsFile: `${dir}${sep}${MANAGED_SETTINGS_FILE}`,
+		dropInDir: `${dir}${sep}${MANAGED_SETTINGS_DROPIN_DIR}`,
+		opaque: opaquePolicySurfaces(platform),
+	};
+};
+
+/**
+ * What the probe concluded about whether the crew channel will actually bind:
+ *
+ * - `allowed` — a policy surface was READ and lists this plugin. The channel will bind.
+ * - `blocked` — a policy surface was READ, sets `allowedChannelPlugins`, and this plugin is not in it.
+ *   The channel will NOT bind. The only outcome that aborts a launch.
+ * - `unknown` — the probe could not determine it. Never a launch abort, never reportable as success.
+ * - `not-applicable` — development mode bypasses the CLI's allowlist gate outright, so there is
+ *   nothing to ask. Distinct from `allowed`: nothing was verified, but nothing needed to be.
+ */
+export type ChannelAllowlistStatus = "allowed" | "blocked" | "unknown" | "not-applicable";
+
+export interface ChannelAllowlistOutcome {
+	readonly status: ChannelAllowlistStatus;
+	/** The `plugin:<name>@<marketplace>` channel ref this verdict is about. */
+	readonly ref: string;
+	/** Operator-facing prose: what was concluded and why, in the probe's own words. */
+	readonly reason: string;
+	/** Every policy surface the probe consulted — so "what did it look at" is answerable from the log. */
+	readonly consulted: readonly string[];
+}
+
+/**
+ * The managed-settings entry an operator adds to make the crew channel bind. Named as a KEY + shape,
+ * never a filled-in example carrying anyone's real data.
+ */
+export const MANAGED_SETTINGS_REMEDY = `add an "allowedChannelPlugins" entry {"marketplace": "${CREW_CHANNEL_MARKETPLACE}", "plugin": "${CREW_CHANNEL_PLUGIN}"} to the org's managed settings (${MANAGED_SETTINGS_FILE}), or run the crew in development channel mode`;
+
+/**
+ * The crew channel is proven not to bind: an org policy surface the launcher READ sets
+ * `allowedChannelPlugins` and the crew plugin is not on it, so the CLI would skip the channel and the
+ * crew would come up dead. Refuse the launch — this is the "inert channel" abort
+ * `claude-plugins/pipeline-crew/commands/stand-up.md` already promises.
+ */
+export class ChannelAllowlistBlockedError extends Schema.TaggedErrorClass<ChannelAllowlistBlockedError>()(
+	"@kampus/pipeline-crew-mcp/standup/ChannelAllowlistBlockedError",
+	{
+		ref: Schema.String,
+		reason: Schema.String,
+		remedy: Schema.String,
+		consulted: Schema.Array(Schema.String),
+	},
+) {}
+
+/** One `allowedChannelPlugins` entry as the CLI's own settings schema declares it: `{marketplace, plugin}`. */
+interface AllowlistEntry {
+	readonly marketplace: string;
+	readonly plugin: string;
+}
+
+/**
+ * Read `allowedChannelPlugins` out of one parsed policy-settings object. Three results, kept distinct
+ * for the same reason the outcome is: the key absent (the CLI then falls back to the vendor ledger),
+ * a well-formed list, and a list whose shape this probe does not recognize — which is a read it cannot
+ * trust, not an empty list.
+ */
+type ExtractedAllowlist =
+	| {readonly kind: "absent"}
+	| {readonly kind: "entries"; readonly entries: readonly AllowlistEntry[]}
+	| {readonly kind: "malformed"};
+
+const extractAllowlist = (settings: unknown): ExtractedAllowlist => {
+	if (typeof settings !== "object" || settings === null) return {kind: "malformed"};
+	const raw = (settings as Record<string, unknown>).allowedChannelPlugins;
+	if (raw === undefined || raw === null) return {kind: "absent"};
+	if (!Array.isArray(raw)) return {kind: "malformed"};
+	const entries: AllowlistEntry[] = [];
+	for (const item of raw) {
+		if (typeof item !== "object" || item === null) return {kind: "malformed"};
+		const {marketplace, plugin} = item as Record<string, unknown>;
+		if (typeof marketplace !== "string" || typeof plugin !== "string") return {kind: "malformed"};
+		entries.push({marketplace, plugin});
+	}
+	return {kind: "entries", entries};
+};
+
+/** A JSON policy source the probe managed to read, or the reason it could not. */
+type SourceRead =
+	| {readonly kind: "read"; readonly path: string; readonly settings: unknown}
+	| {readonly kind: "absent"; readonly path: string}
+	| {readonly kind: "unreadable"; readonly path: string; readonly detail: string};
+
+/** Parse one source's text, folding a parse failure into the `unreadable` variant rather than a throw. */
+const parseSettings = (path: string, text: string): Effect.Effect<SourceRead> =>
+	Effect.try({
+		try: (): SourceRead => ({kind: "read", path, settings: JSON.parse(text)}),
+		catch: (cause): SourceRead => ({
+			kind: "unreadable",
+			path,
+			detail: `not valid JSON: ${String(cause)}`,
+		}),
+	}).pipe(Effect.catch(Effect.succeed));
+
+const readJsonSource = (fs: FileSystem.FileSystem, path: string): Effect.Effect<SourceRead> =>
+	fs.readFileString(path).pipe(
+		Effect.flatMap((text) => parseSettings(path, text)),
+		Effect.catch((cause) =>
+			fs.exists(path).pipe(
+				Effect.map(
+					(present): SourceRead =>
+						present ? {kind: "unreadable", path, detail: String(cause)} : {kind: "absent", path},
+				),
+				// The existence probe itself faulting is the PROBES.md "could not ask" case: an unreadable
+				// surface, never an absent one — collapsing it to absent is what would fabricate a verdict.
+				Effect.orElseSucceed((): SourceRead => ({kind: "unreadable", path, detail: String(cause)})),
+			),
+		),
+	);
+
+export interface ChannelAllowlistProbeInput {
+	readonly plugin: string;
+	readonly marketplace: string;
+	readonly ref: string;
+	readonly surfaces: PolicySurfaces;
+}
+
+/**
+ * Probe whether the CLI's effective channel allowlist admits the crew plugin. Never fails — every
+ * fault folds into `unknown`, because a probe that could not run carries no information about the
+ * target (PROBES.md's outcome 3, applied to a config surface instead of a liveness endpoint).
+ */
+export const probeChannelAllowlist = (
+	input: ChannelAllowlistProbeInput,
+): Effect.Effect<ChannelAllowlistOutcome, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const {plugin, marketplace, ref, surfaces} = input;
+		const consulted: string[] = [];
+
+		for (const path of surfaces.opaque) {
+			consulted.push(path);
+			const present = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => true));
+			if (present) {
+				return {
+					status: "unknown",
+					ref,
+					consulted,
+					reason: `an MDM-managed policy surface (${path}) is present and the launcher cannot parse it, so the CLI's effective channel allowlist cannot be resolved from here`,
+				};
+			}
+		}
+
+		const dropInFiles = yield* fs.readDirectory(surfaces.dropInDir).pipe(
+			Effect.map((names) =>
+				names
+					.filter((name) => name.endsWith(".json"))
+					.sort()
+					.map((name) => `${surfaces.dropInDir}/${name}`),
+			),
+			Effect.orElseSucceed(() => [] as readonly string[]),
+		);
+
+		const reads: SourceRead[] = [];
+		for (const path of [surfaces.settingsFile, ...dropInFiles]) {
+			consulted.push(path);
+			reads.push(yield* readJsonSource(fs, path));
+		}
+
+		const unreadable = reads.find((read) => read.kind === "unreadable");
+		if (unreadable !== undefined && unreadable.kind === "unreadable") {
+			return {
+				status: "unknown",
+				ref,
+				consulted,
+				reason: `a managed-settings source (${unreadable.path}) exists but could not be read: ${unreadable.detail}`,
+			};
+		}
+
+		// A later source that lists the plugin wins over an earlier one that does not: the CLI layers its
+		// policy sources, so "some readable source admits it" is the only claim this probe can soundly make.
+		let sawAllowlist = false;
+		for (const read of reads) {
+			if (read.kind !== "read") continue;
+			const extracted = extractAllowlist(read.settings);
+			if (extracted.kind === "malformed") {
+				return {
+					status: "unknown",
+					ref,
+					consulted,
+					reason: `a managed-settings source (${read.path}) sets "allowedChannelPlugins" in a shape this probe does not recognize (expected an array of {"marketplace","plugin"} objects), so its effective entries cannot be resolved`,
+				};
+			}
+			if (extracted.kind === "absent") continue;
+			sawAllowlist = true;
+			if (extracted.entries.some((e) => e.plugin === plugin && e.marketplace === marketplace)) {
+				return {
+					status: "allowed",
+					ref,
+					consulted,
+					reason: `org managed settings list ${plugin}@${marketplace} in "allowedChannelPlugins" (${read.path})`,
+				};
+			}
+		}
+
+		if (sawAllowlist) {
+			return {
+				status: "blocked",
+				ref,
+				consulted,
+				reason: `org managed settings set "allowedChannelPlugins" and ${plugin}@${marketplace} is not on it — the CLI would skip this channel ({action:"skip", kind:"allowlist"}) and the crew would come up with a dead channel`,
+			};
+		}
+
+		return {
+			status: "unknown",
+			ref,
+			consulted,
+			reason: `no managed-settings source sets "allowedChannelPlugins", so the CLI resolves its effective allowlist from the vendor-controlled channel ledger — a remote-config value the launcher cannot read. A self-published plugin is not expected to be on that ledger, so the channel may well come up dead`,
+		};
+	});
+
+/** The probe as the orchestration injects it — substituted wholesale in tests, no filesystem needed. */
+export type ChannelAllowlistProbe = Effect.Effect<
+	ChannelAllowlistOutcome,
+	never,
+	FileSystem.FileSystem
+>;
+
+/** The production probe: the crew's own channel ref against this platform's policy surfaces. */
+export const productionChannelAllowlistProbe: ChannelAllowlistProbe = Effect.suspend(() =>
+	probeChannelAllowlist({
+		plugin: CREW_CHANNEL_PLUGIN,
+		marketplace: CREW_CHANNEL_MARKETPLACE,
+		ref: CREW_PLUGIN_CHANNEL_REF,
+		surfaces: policySurfacesFor(process.platform),
+	}),
+);
+
+/**
+ * Assert the crew channel will bind, before any session launches. Returns the outcome for the caller
+ * to REPORT (an `unknown` must reach the operator verbatim — that is the whole fix), and fails only on
+ * `blocked`, the one verdict backed by a surface the probe actually read.
+ *
+ * Development mode short-circuits to `not-applicable` without touching the filesystem: the CLI's
+ * allowlist check sits behind its own `!dev` guard, so under
+ * `--dangerously-load-development-channels` there is no gate to clear.
+ */
+export const assertChannelAllowlist = (
+	channels: Pick<ChannelConfig, "mode">,
+	probe: ChannelAllowlistProbe = productionChannelAllowlistProbe,
+): Effect.Effect<ChannelAllowlistOutcome, ChannelAllowlistBlockedError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		if (channels.mode !== "allowlist") {
+			return {
+				status: "not-applicable",
+				ref: CREW_PLUGIN_CHANNEL_REF,
+				consulted: [],
+				reason:
+					"development channel mode bypasses the CLI's plugin allowlist gate, so there is nothing to verify",
+			} satisfies ChannelAllowlistOutcome;
+		}
+		const outcome = yield* probe;
+		if (outcome.status === "blocked") {
+			return yield* new ChannelAllowlistBlockedError({
+				ref: outcome.ref,
+				reason: outcome.reason,
+				remedy: MANAGED_SETTINGS_REMEDY,
+				consulted: outcome.consulted,
+			});
+		}
+		return outcome;
+	});
+
+/**
+ * Render an outcome as the operator-facing line stand-up prints. `unknown` is deliberately as loud as
+ * an abort and never blends into the success summary — an unverified channel is not a verified one.
+ */
+export const renderChannelAllowlistOutcome = (outcome: ChannelAllowlistOutcome): string => {
+	const consulted =
+		outcome.consulted.length > 0 ? ` [consulted: ${outcome.consulted.join(", ")}]` : "";
+	if (outcome.status === "allowed") {
+		return `channel allowlist VERIFIED for ${outcome.ref} — ${outcome.reason}${consulted}`;
+	}
+	if (outcome.status === "not-applicable") {
+		return `channel allowlist NOT APPLICABLE for ${outcome.ref} — ${outcome.reason}`;
+	}
+	return [
+		`channel allowlist UNVERIFIED (unknown) for ${outcome.ref} — ${outcome.reason}${consulted}.`,
+		`This is NOT a confirmation that the channel works: the crew may come up with a dead channel (no channel_send, no tracker traffic, no error anywhere).`,
+		`To make it verifiable: ${MANAGED_SETTINGS_REMEDY}.`,
+	].join("\n  ");
+};

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -42,6 +42,8 @@ export {
 	probeChannelAllowlist,
 	productionChannelAllowlistProbe,
 	renderChannelAllowlistOutcome,
+	undeterminablePolicySurfaces,
+	WINDOWS_POLICY_REGISTRY_KEYS,
 } from "./channel-allowlist.ts";
 export {
 	CHANNEL_PLUGIN_REF_RE,

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -26,6 +26,24 @@ export {
 	type SessionBindInput,
 } from "./bind.ts";
 export {
+	assertChannelAllowlist,
+	ChannelAllowlistBlockedError,
+	type ChannelAllowlistOutcome,
+	type ChannelAllowlistProbe,
+	type ChannelAllowlistProbeInput,
+	type ChannelAllowlistStatus,
+	MANAGED_SETTINGS_DROPIN_DIR,
+	MANAGED_SETTINGS_FILE,
+	MANAGED_SETTINGS_REMEDY,
+	managedSettingsDir,
+	opaquePolicySurfaces,
+	type PolicySurfaces,
+	policySurfacesFor,
+	probeChannelAllowlist,
+	productionChannelAllowlistProbe,
+	renderChannelAllowlistOutcome,
+} from "./channel-allowlist.ts";
+export {
 	CHANNEL_PLUGIN_REF_RE,
 	CHANNEL_SERVER_REF_RE,
 	ChannelConfig,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -27,6 +27,9 @@ import {
 } from "./config.ts";
 import {type TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
 import {
+	ChannelAllowlistBlockedError,
+	type ChannelAllowlistProbe,
+	type ChannelAllowlistStatus,
 	CliVersionAssertError,
 	CREW_WINDOW,
 	type CrewMcpEntry,
@@ -226,6 +229,15 @@ const recordingProjectScope = (order: string[]) => {
 	return {registrar, reaped, registered, registeredCtx, cwdCalls};
 };
 
+/** A channel-allowlist probe pinned to one verdict, so the composition tests never touch a real policy file. */
+const stubbedAllowlistProbe = (status: ChannelAllowlistStatus): ChannelAllowlistProbe =>
+	Effect.succeed({
+		status,
+		ref: CREW_PLUGIN_CHANNEL_REF,
+		reason: `stubbed ${status}`,
+		consulted: [],
+	});
+
 const trackerHandle: TrackerHandle = {pid: 4242, socketPath: "/tmp/crew.sock"};
 
 /** A recording tracker-ensurer: counts calls so "was the tracker reached before the abort?" is checkable. */
@@ -295,6 +307,9 @@ const baseInput = (
 			instanceId: counter(),
 			runId: () => RUN_ID,
 			localScope: registrar,
+			// Stub the CLI-side channel-allowlist probe (#4297) so these composition tests never read the
+			// host's real org managed settings — a machine-dependent read would make them non-deterministic.
+			probeChannelAllowlist: stubbedAllowlistProbe("allowed"),
 			ensureTracker,
 			resolveTargetSession,
 			launch,
@@ -544,6 +559,58 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 				// Every pane cwd is distinct — so a pane booting in its cwd sees ONLY its own leaf .mcp.json.
 				const cwds = entries.map((e) => e.cwd);
 				assert.strictEqual(new Set(cwds).size, cwds.length);
+			}),
+	);
+
+	it.effect(
+		"allowlist mode: a BLOCKED CLI-side channel allowlist aborts with zero panes launched (#4297)",
+		() =>
+			Effect.gen(function* () {
+				const {input, launched, order, trackerCalls} = baseInput({
+					engineCount: 2,
+					config: allowlistConfigAt(2),
+					probeChannelAllowlist: stubbedAllowlistProbe("blocked"),
+				});
+				const error = yield* Effect.flip(standUp(input));
+				assert.instanceOf(error, ChannelAllowlistBlockedError);
+				// The abort names the remedy, and names it as a managed-settings KEY the operator can act on.
+				assert.include(error.remedy, "allowedChannelPlugins");
+				assert.include(renderStandUpError(error), CREW_PLUGIN_CHANNEL_REF);
+				// No partial crew, and the abort lands before the tracker is even started.
+				assert.strictEqual(launched.length, 0);
+				assert.strictEqual(trackerCalls(), 0);
+				assert.notInclude(order, "reap");
+			}),
+	);
+
+	it.effect(
+		"allowlist mode: an UNKNOWN channel allowlist launches but the result reports the unverified verdict (#4297)",
+		() =>
+			Effect.gen(function* () {
+				const {input, launched} = baseInput({
+					engineCount: 1,
+					config: allowlistConfigAt(1),
+					probeChannelAllowlist: stubbedAllowlistProbe("unknown"),
+				});
+				const result = yield* standUp(input);
+				// PROBES.md: a check that could not run never gates — the crew still comes up.
+				assert.strictEqual(result.launched.length, launched.length);
+				assert.isAbove(result.launched.length, 0);
+				// …but the verdict rides out on the result, so "could not verify" is not "verified".
+				assert.strictEqual(result.channelAllowlist.status, "unknown");
+			}),
+	);
+
+	it.effect(
+		"development mode: the CLI-side allowlist gate is not applicable and is never probed (#4297)",
+		() =>
+			Effect.gen(function* () {
+				// A probe that would fail proves it is never run: dev mode bypasses the CLI's `!dev`-guarded
+				// allowlist check outright, so there is no policy surface to read.
+				const probeNeverRuns = Effect.die("the allowlist probe must not run in development mode");
+				const {input} = baseInput({engineCount: 1, probeChannelAllowlist: probeNeverRuns});
+				const result = yield* standUp(input);
+				assert.strictEqual(result.channelAllowlist.status, "not-applicable");
 			}),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -6,14 +6,22 @@
  * (#3297), bind (#3296), tmux-placement (#3298).
  *
  * The one non-obvious thing: the orchestration is FAIL-LOUD with NO PARTIAL CREW. The steps run in
- * the mandated order — read config → assert the pinned CLI version → derive the roster session set →
+ * the mandated order — read config → assert the pinned CLI version → probe the CLI-side channel
+ * allowlist → derive the roster session set →
  * assert every seat's declared toolset resolves → ensure the tracker → build EVERY per-session bind +
  * compute ALL tmux placements → launch. Every
  * bind and every placement is resolved (and validated) BEFORE the first session launches, so any
  * precondition failure — a drifted CLI pin, a seat that would boot without a tool its def declares
  * (#3764), a missing config dimension, an inert channel, a colliding
  * pane label — aborts with a named error while zero sessions are up, never a half-launched
- * crew. No session is hand-launched: the launch of each `claude` session, bound to its role lease, is
+ * crew.
+ *
+ * "Inert channel" covers two distinct gates, and only one of them can abort. `bind.ts` refuses a
+ * launch whose crew ref is unregistered or whose foreign plugin is not launcher-allowlisted. The
+ * CLI's own org-managed-settings allowlist (channel-allowlist.ts, #4297) is a surface the launcher
+ * can only read, never satisfy — so it aborts when it READ a policy surface that blocks the channel,
+ * and otherwise returns an `unknown` that rides out on `StandUpResult` for the caller to report. A
+ * completed stand-up therefore does not imply a verified channel; it implies a REPORTED verdict. No session is hand-launched: the launch of each `claude` session, bound to its role lease, is
  * the injected `launch` step the orchestration drives for the whole derived set (all panes of one
  * tiled crew window, founder ruling #3424).
  *
@@ -39,6 +47,12 @@ import {
 	type CrewSessionBinUnresolvableError,
 	type SessionBind,
 } from "./bind.ts";
+import {
+	assertChannelAllowlist,
+	type ChannelAllowlistBlockedError,
+	type ChannelAllowlistOutcome,
+	type ChannelAllowlistProbe,
+} from "./channel-allowlist.ts";
 import {type LaunchConfig, type LaunchConfigError, readLaunchConfig} from "./config.ts";
 import {
 	ensureTrackerRunning,
@@ -180,6 +194,7 @@ export type StandUpError =
 	| CrewSessionBinUnresolvableError
 	| CrewServerNotRegisteredError
 	| ChannelPluginNotAllowedError
+	| ChannelAllowlistBlockedError
 	| ProjectScopeWriteError
 	| TmuxPaneCollisionError
 	| TmuxSessionEnsureError
@@ -262,6 +277,8 @@ export interface StandUpInput {
 	readonly config?: Effect.Effect<LaunchConfig, LaunchConfigError>;
 	/** The installed-CLI-version reader the pin is asserted against. Default: the real `claude --version`. */
 	readonly readVersionOutput?: Effect.Effect<string, unknown>;
+	/** Probes the CLI-side channel allowlist (#4297). Default: the real org-managed-settings read. */
+	readonly probeChannelAllowlist?: ChannelAllowlistProbe;
 	/** Reads a seat's declared toolset for the declared-vs-actual assert (#3764). Default: the real agent def under `projectRoot`. */
 	readonly readSeatToolset?: SeatToolsetReader;
 	/** Start-or-reuse the repo's tracker at its canonical rendezvous. Default: `ensureTrackerRunning` (detached standing process). */
@@ -292,6 +309,13 @@ export interface StandUpInput {
 export interface StandUpResult {
 	readonly tracker: TrackerHandle;
 	readonly launched: readonly LaunchedSession[];
+	/**
+	 * What the pre-launch probe concluded about the CLI-side channel allowlist (#4297). A completed
+	 * stand-up is NOT the same as a verified channel, so the verdict rides out on the result and the
+	 * caller must report it — an `unknown` here is the "we could not check" state that used to be
+	 * indistinguishable from success.
+	 */
+	readonly channelAllowlist: ChannelAllowlistOutcome;
 }
 
 /**
@@ -579,6 +603,16 @@ export const runStandUp = (
 		// Fail fast on a version drift before starting the tracker or any session — channels vary
 		// across CLI versions, so a mismatch is a stand-up to refuse (version-assert.ts / #3295).
 		yield* assertPinnedCliVersion(config, input.readVersionOutput ?? readInstalledCliVersionOutput);
+		// The CLI-side channel allowlist (#4297) — the one channel gate no launcher-owned config can
+		// satisfy, and the one whose failure is a SKIP rather than an error. A proven-blocked allowlist
+		// aborts here, with zero sessions up, which is the "inert channel" abort commands/stand-up.md
+		// already promises; an unresolvable one returns `unknown` and rides out on the result for the
+		// caller to report, because refusing on a surface we could not read is exactly the fail-closed
+		// probe PROBES.md forbids.
+		const channelAllowlist = yield* assertChannelAllowlist(
+			config.channels,
+			input.probeChannelAllowlist,
+		);
 
 		// The roster set is derived here — ahead of the tracker — only so the next assert can name the
 		// exact seats this stand-up launches. `deriveSessionSet` is pure; nothing observable moved.
@@ -673,7 +707,7 @@ export const runStandUp = (
 			launched.push(session);
 			crewWindow ??= session.window;
 		}
-		return {tracker, launched};
+		return {tracker, launched, channelAllowlist};
 	});
 
 /** What a stand-down consumes: the project whose crew `.mcp.json` files + crew-run dirs + server approval to tear down. */


### PR DESCRIPTION
A crew stand-up could report complete success while the crew came up with a channel that was never actually connected — no messages, no tracker traffic, and no error anywhere. This PR makes that state impossible to mistake for success: the launcher now checks the one channel gate it could never satisfy on its own, and either refuses to launch, confirms the channel, or says plainly that it could not tell.

Fixes #4297

## The defect

`packages/pipeline-crew-mcp/src/standup/bind.ts` enforces the *launcher's* `allowedChannelPlugins` and auto-allowlists the crew's own plugin there — correct, since the launcher is what emits that ref. But the Claude Code CLI enforces a **separate, identically-named** `allowedChannelPlugins` in **org managed settings**: a different file, a different shape, a different enforcer. When that one is unmet the CLI does not error. It returns `{action: "skip", kind: "allowlist"}`, the session launches, every launcher guard stays green, and the crew comes up dead. Nothing on the launch path could observe it.

`claude-plugins/pipeline-crew/commands/stand-up.md` already promised that "an inert channel … aborts before any session is launched". This closes that divergence.

## What changed

New `packages/pipeline-crew-mcp/src/standup/channel-allowlist.ts`: a pre-launch probe of the CLI-side allowlist, wired into `runStandUp` right after the version assert (before the tracker, before any pane). It resolves **three outcomes and never collapses them**, which is the whole point — a skip that cannot be told apart from a success is the defect, not a detail of it.

| outcome | when | what stand-up does |
|---|---|---|
| `blocked` | a policy surface was **read** and excludes the crew plugin | **aborts** with zero sessions up, naming the cause and the managed-settings remedy |
| `unknown` | the effective allowlist could not be resolved | launches, but the headline reads `CHANNEL UNVERIFIED` and the line says explicitly this is *not* a confirmation |
| `allowed` | a policy surface lists the plugin | reports `VERIFIED` — this gate is satisfied, which is not the same as "the channel binds" |
| `not-applicable` | development mode | reports it as such — nothing was verified, nothing needed to be |

`unknown` covers every way a policy surface can fail to answer: no managed-settings source at all (the CLI then falls back to a vendor-controlled ledger the launcher cannot read), a present-but-unreadable source, a malformed `allowedChannelPlugins` shape, a drop-in directory that exists but cannot be enumerated, an MDM-managed plist this probe cannot parse, and a platform surface it cannot interrogate at all (the Windows registry).

The verdict rides out on `StandUpResult.channelAllowlist`, so a completed stand-up no longer implies a verified channel — it implies a *reported* one.

## Reconciling `PROBES.md` (AC2)

`claude-plugins/pipeline-crew/PROBES.md` requires an **unrunnable** check to resolve "unknown", never "down". So only a surface the probe actually read can produce `blocked` — the sole launch-aborting verdict. Everything unreadable resolves `unknown`, which never gates. But `unknown` is not silently swallowed either: it is a named, printed, non-success outcome, which is the second half of the rule ("the stand-up says so explicitly, instead of silently passing"). An MDM surface being merely *present* is enough to downgrade a would-be `blocked` to `unknown`, because a verdict drawn from a partial read would be a guess.

`PolicySurfaces` makes the three kinds of surface distinct rather than leaving the distinction to be re-derived at each call site: `settingsFile`/`dropInDir` are read and parsed, `opaque` surfaces are existence-checked but never parsed, and `undeterminable` surfaces cannot be interrogated at all. Only the first kind can contribute to a `blocked`.

No precedence between MDM managed preferences and `managed-settings.json` is asserted anywhere in this PR. That ordering could not be established from the bundle, and the probe does not need it: an unread surface of any kind forces `unknown` regardless of which would win.

## Runtime confirmation (AC3)

The issue flagged its runtime claim as predicted, not observed. Two observations against the installed CLI at **2.1.220**, neither of which is a re-read of `packages/pipeline-crew-mcp/README.md`:

1. **The gate's own code, read out of the installed CLI bundle.** It confirms the described behaviour exactly — a non-matching effective allowlist yields `{action:"skip", kind:"allowlist"}` alongside sibling skip kinds (`capability`/`provider`/`disabled`/`policy`/`session`/`marketplace`), and `{action:"register"}` is reached only when every check passes. It also confirms the `!dev` guard that makes development mode exempt, and the `plugin === name && marketplace === marketplace` two-field match. The platform managed-settings locations, the `managed-settings.d` drop-in dir, and both macOS managed-preference plists (per-user first, device-level second) come from the bundle's own resolver, not from our docs. The `channels-blocked-allowlist` notification id is there too — composed as the prefix `"channels-blocked-"` concatenated with the skip kind, which is why an earlier literal-string search missed it.
2. **A live run.** A session launched with `--channels plugin:pipeline-crew-mcp@kampus` on a host with **no** managed-settings directory at all completed normally, exited 0, and — even under `--debug --verbose` — emitted **zero** diagnostic output about the channel that could not bind. The silence is confirmed, not predicted. The run exercised the bundle's `kind:"marketplace"` skip, which runs *before* the allowlist check, because the crew plugin was not installed from its marketplace on that host.

**Still not exercised end to end:** the "allowlist-kind skip in a fully installed plugin" path, for the reason above. What the two observations do establish is the load-bearing half: an unbindable `--channels` ref is a silent, successful, zero-output launch, and the skip-not-error branch is read directly out of the gate's source.

## Scope (AC5)

One halt only. No other silent-skip site is touched, and no change is made to plugin packaging/binding or to post-boot tracker liveness. The bundle's `kind:"marketplace"` skip is a second silent dead-channel launch of the same family and is **deliberately not addressed here** — it wants its own issue.

## Deviations

**(repair round 1)** `currentUsername()` in `channel-allowlist.ts` carries a `// biome-ignore lint/plugin:` suppression for the repo's ban on raw `try/catch` in an Effect-importing file. `os.userInfo()` throws when the host has no passwd entry for the caller, and this helper is the default parameter of a pure synchronous surface-name resolver — evaluated where no Effect runtime exists to carry an `E` channel. This is the "pre-runtime bootstrap guard" exception the rule's own message names. Failure is total and lossless: it yields `null`, which drops only the per-user plist from the opaque list and can never turn an unread surface into a `blocked`.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint:worktree` — clean
- `pnpm --filter @kampus/pipeline-crew-mcp test` — 458 passed (53 files); the channel-allowlist suite is 23 cases covering every outcome and each way a read can be lossy, including an unenumerable drop-in directory resolving `unknown` rather than `blocked`
- `pipeline-cli cp-classify classify` — `not-control-plane [path-clear-no-content-source]`
