### PR TITLE
fix(ship-it): the §CP approval gate resolves its four reads, or stops as UNKNOWN (#4223)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1833,6 +1833,92 @@ if ! cp_changed_files "$REPO" "$PR"; then
 fi
 ```
 
+#### §CPREAD-APPROVAL. The three reads the ADR-0175 discharge makes — UNKNOWN is not a cardinality (#4223)
+
+Classifying a PR as §CP is only half the boundary; **discharging** it (the ADR-0175 approval gate in
+[`ship-it`](ship-it/SKILL.md)) makes three more network reads — the `control-plane` team roster, the
+PR author, and a per-approver team-membership probe. They take the same three properties, plus a
+fourth that the file-list read does not need:
+
+4. **A failed read and a genuinely-empty answer are different FACTS with the same non-firing
+   outcome — never collapse them.** For the roster they are distinguishable by **content**: a failed
+   read is a one-line JSON error document, an empty team is an empty stream. So the discriminator is
+   a **shape check**, not a bare `|| exit`. Measured (#4223): an unreadable roster leaves a ~120-byte
+   error blob on **one** line, so a line-counting cardinality computes **N=1 on a phantom member
+   whose login is an error body** — `cp-cardinality`'s `n === 0` "the team is empty" branch is never
+   reached, and anyone hardening *that* branch hardens a branch this failure cannot enter. An
+   unresolved roster must therefore resolve to **UNKNOWN and stop under its own reason line**, never
+   to a cardinality and never to "the team is empty".
+
+```bash
+# cp_team_roster — the control-plane roster read. Sets CP_MEMBERS (logins, one per line) +
+# CP_MEMBERS_N; returns NON-ZERO ⇒ UNKNOWN (never a cardinality). A read that SUCCEEDS and returns
+# zero members is a DIFFERENT, honest state — the ADR-0175 N==0 STOP — and returns zero here, so the
+# §ZS zero-scope rule does NOT apply: unlike a PR's file list, an empty team is a real answer.
+cp_team_roster() {   # $1 = ORG
+  CP_MEMBERS="$(gh api --paginate "orgs/$1/teams/control-plane/members?per_page=100" \
+    --jq 'if type=="array" then .[].login else ("payload is not a member array"|halt_error(1)) end' 2>/dev/null)" || {
+      CP_MEMBERS=""; CP_MEMBERS_N=0
+      echo "§CP roster: @$1/control-plane member list READ FAILED (gh exited non-zero; payload discarded) — roster UNKNOWN, NOT empty" >&2
+      return 1; }
+  # Shape, then interpret. A status check alone still admits a 200 carrying something that is not a
+  # roster; a bare non-empty test admits the error blob outright. Only the login charset rejects both.
+  if printf '%s\n' "$CP_MEMBERS" | grep -qvE '^[A-Za-z0-9-]*$'; then
+    CP_MEMBERS=""; CP_MEMBERS_N=0
+    echo "§CP roster: @$1/control-plane member list carries a non-login entry — payload discarded, roster UNKNOWN, NOT empty" >&2
+    return 1
+  fi
+  CP_MEMBERS_N="$(printf '%s\n' "$CP_MEMBERS" | grep -c . || true)"
+  echo "§CP roster: @$1/control-plane read OK — $CP_MEMBERS_N member(s) scanned"   # §ZS #1: emit the scope
+}
+
+# cp_pr_author — the PR author login. An unresolved author is UNKNOWN: it un-skips the author in the
+# approver walk (a self-approval would count as a non-author approval) and mis-keys the cardinality
+# branch. Same dead-guard reason as cp_head_sha: on failure gh writes its error document to STDOUT,
+# so `[ -n "$AUTHOR" ]` can never fire — check the status, discard the payload, then shape-assert.
+cp_pr_author() {   # $1 = REPO, $2 = PR; sets CP_PR_AUTHOR (EMPTY on failure), NON-ZERO ⇒ UNKNOWN
+  CP_PR_AUTHOR="$(gh api "repos/$1/pulls/$2" \
+    --jq 'if type=="object" and (.user.login|type)=="string" then .user.login else ("payload is not a PR object"|halt_error(1)) end' 2>/dev/null)" || {
+      CP_PR_AUTHOR=""
+      echo "§CP author: PR #$2 author READ FAILED (gh exited non-zero; payload discarded) — author UNKNOWN" >&2
+      return 1; }
+  case "$CP_PR_AUTHOR" in
+    ""|*[!A-Za-z0-9-]*) CP_PR_AUTHOR=""
+      echo "§CP author: PR #$2 author is not a bare login — discarded, author UNKNOWN" >&2; return 1 ;;
+  esac
+}
+
+# cp_team_membership — is login $2 on @$1/control-plane? THREE outcomes, not two: `-i` keeps the
+# status line on stdout even when gh exits non-zero, which is the whole point — a 404 is a DEFINITE
+# non-member, anything else is UNKNOWN. The bare `--jq '.state' 2>/dev/null` this replaces made a
+# 5xx indistinguishable from a definite non-member, silently under-counting an approver.
+# Composition, measured: an ABSENT team namespace 404s here too, so this endpoint alone cannot tell
+# "not a member of a team that exists" from "no such team". It does not have to — call it only after
+# cp_team_roster has proven the team readable, which is what makes a 404 here definite.
+cp_team_membership() {   # $1 = ORG, $2 = login; sets CP_MEMBERSHIP = <state>|absent; NON-ZERO ⇒ UNKNOWN
+  _resp="$(gh api "orgs/$1/teams/control-plane/memberships/$2" -i 2>/dev/null)"; _rc=$?
+  _status="$(printf '%s\n' "$_resp" | head -n1 | awk '{print $2}')"   # $? already stashed above
+  case "$_status" in
+    200)
+      CP_MEMBERSHIP="$(printf '%s\n' "$_resp" | awk 'b{print} /^\r?$/{b=1}' \
+        | jq -r 'if type=="object" and (.state|type)=="string" then .state else ("payload is not a membership object"|halt_error(1)) end' 2>/dev/null)" || {
+          CP_MEMBERSHIP=""
+          echo "§CP membership: '$2' returned 200 with a non-membership payload — discarded, membership UNKNOWN" >&2
+          return 1; }
+      return 0 ;;
+    404) CP_MEMBERSHIP=absent; return 0 ;;
+    *)   CP_MEMBERSHIP=""
+      echo "§CP membership: '$2' on @$1/control-plane READ FAILED (HTTP ${_status:-none}, gh exit $_rc) — UNKNOWN, NOT a definite non-member" >&2
+      return 1 ;;
+  esac
+}
+```
+
+Consumers of these three resolve a failure to **UNKNOWN and stop under a reason line that names the
+read that failed** — never under `awaiting control-plane approval`, which asserts a fact about a
+human that no one established. Same outcome as a genuine wait, different fact; reporting the first as
+the second sends an operator to debug a person instead of an outage.
+
 ### A path-only §CP answer is NEVER authoritative — use `cp-classify` (#4161)
 
 The two clauses above are **independent sources** of §CP membership, and `CONTROL_PLANE_RE` has

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1850,6 +1850,13 @@ fourth that the file-list read does not need:
    unresolved roster must therefore resolve to **UNKNOWN and stop under its own reason line**, never
    to a cardinality and never to "the team is empty".
 
+   **Read that at its measured size: a correctness and observability defect, not a privilege
+   escalation.** The phantom-member `N=1` lands on `single-owner-other`, which discharges on the
+   **identical** `nonAuthorApprovalAtHead` signal as the `multi-member` branch it displaces — so it
+   cannot lower an approval bar, and a 30-day audit of 1194 merged PRs (356 of them §CP) found no
+   case where it did. What it costs is a true answer: the gate reports an outage as a finding about
+   the team's shape.
+
 ```bash
 # cp_team_roster — the control-plane roster read. Sets CP_MEMBERS (logins, one per line) +
 # CP_MEMBERS_N; returns NON-ZERO ⇒ UNKNOWN (never a cardinality). A read that SUCCEEDS and returns

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -532,29 +532,77 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
   source ship-it runs, so the verdict cannot drift across shippers (the class-probe/control-plane-paths
   precedent). Resolve the roster + the two signals over REST, never GraphQL, then decide:
 
+  **Every input to this gate is a fallible READ, and an unresolved one is UNKNOWN — never a
+  cardinality, never "the team is empty", never `awaiting control-plane approval` (#4223).** All four
+  — roster, author, head, per-approver membership — come from **§CPREAD** / **§CPREAD-APPROVAL** of
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); copy those helpers verbatim from
+  there (single source; the why, and the measurement behind it, live there, not here). Each failure
+  branch stops under a message that names the read that failed.
+
   ```bash
   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
   # ADR 0175: DETERMINISTIC §CP discharge keyed on control-plane team cardinality, not judgment.
   ORG="${REPO%%/*}"                                            # owner half of owner/repo
-  # N = present, active, human control-plane members (REST, never GraphQL — ADR 0135/0175)
-  MEMBERS="$(gh api --paginate "orgs/$ORG/teams/control-plane/members?per_page=100" --jq '.[].login')"
-  AUTHOR="$(gh api "repos/$REPO/pulls/$PR" --jq '.user.login')"
-  HEAD="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"    # every signal binds THIS head (ADR 0058)
-  sha_binds_head() { [ -n "$1" ] || return 1; case "$HEAD" in "$1"*) return 0;; esac; case "$1" in "$HEAD"*) return 0;; esac; return 1; }
+  # The one non-firing exit that is NOT a definite answer: it names the read that could not execute,
+  # so a broken read is never reported as a human-approval wait (#4223).
+  cp_unknown() { echo "§CP approval: STOP — $1 UNKNOWN (read failed); the discharge is UNRESOLVED, NOT 'awaiting control-plane approval' (ADR 0175, #4223)" >&2; }
+
+  # N = present, active, human control-plane members (REST, never GraphQL — ADR 0135/0175).
+  # A SUCCESSFUL read of an empty team still flows through to cp-cardinality's honest N==0 STOP; only
+  # an UNREADABLE roster stops here, because those are different facts with the same outcome.
+  cp_team_roster "$ORG" || { cp_unknown "the @$ORG/control-plane roster"; exit 1; }
+  MEMBERS="$CP_MEMBERS"
+  cp_pr_author "$REPO" "$PR" || { cp_unknown "the PR author"; exit 1; }
+  AUTHOR="$CP_PR_AUTHOR"
+  cp_head_sha "$REPO" "$PR" || { cp_unknown "the PR head SHA"; exit 1; }
+  HEAD="$CP_HEAD_SHA"                                          # every signal binds THIS head (ADR 0058)
+
+  # Bidirectional prefix match so a 7-hex short SHA binds a 40-hex head — but ONLY once BOTH sides
+  # are proven hex. With $HEAD empty the second pattern degenerates to `*` and binds ANY candidate,
+  # so a self-approval marker on a superseded head counts as current (#4223). Asserting $HEAD is
+  # duplicated work given cp_head_sha above, and it stays: this matcher is the last thing between a
+  # stale marker and a discharge, so it proves its own precondition rather than inheriting it.
+  # The reverse direction is unreachable while that 40-hex assertion holds (a candidate can only be
+  # a prefix OF a full head, never the other way round); kept so the matcher's shape is unchanged and
+  # the assertion is the only thing this fix takes away from its reach.
+  sha_binds_head() {
+    case "$HEAD" in *[!0-9a-f]*|"") return 1;; esac
+    [ "${#HEAD}" -eq 40 ] || return 1
+    case "$1" in *[!0-9a-f]*|"") return 1;; esac
+    [ "${#1}" -ge 7 ] || return 1
+    case "$HEAD" in "$1"*) return 0;; esac
+    case "$1" in "$HEAD"*) return 0;; esac
+    return 1
+  }
 
   # Signal 1 — a current-head APPROVED review by a control-plane member who is NOT the author
   # (the N>=2 and N==1-sole!=author discharge). Latest review per author, APPROVED, commit_id == HEAD.
   NON_AUTHOR_APPROVAL_AT_HEAD=false
+  MEMBERSHIP_UNKNOWN=false
   CURRENT_APPROVERS="$(gh api --paginate "repos/$REPO/pulls/$PR/reviews?per_page=100" \
     --jq "group_by(.user.login) | map(max_by(.submitted_at))
-          | map(select(.state == \"APPROVED\" and .commit_id == \"$HEAD\") | .user.login) | .[]")"
+          | map(select(.state == \"APPROVED\" and .commit_id == \"$HEAD\") | .user.login) | .[]")" \
+    || { cp_unknown "the PR's review list"; exit 1; }
   while IFS= read -r u; do
     [ -z "$u" ] && continue
+    # cp_pr_author proved $AUTHOR is a bare login, so this skip cannot silently stop skipping. The
+    # assertion is kept at the skip itself because THAT is where an unresolved author would let a
+    # self-approval count as a non-author approval — the one direction that is not safe (#4223).
+    : "${AUTHOR:?§CP approval: author unresolved at the approver walk — refusing to count approvals}"
     [ "$u" = "$AUTHOR" ] && continue                          # self-approval never counts here (ADR 0175)
-    st="$(gh api "orgs/$ORG/teams/control-plane/memberships/$u" --jq '.state' 2>/dev/null)"
-    [ "$st" = "active" ] && { NON_AUTHOR_APPROVAL_AT_HEAD=true; break; }
+    # THREE outcomes: active member, definite non-member (404), or UNKNOWN. An UNKNOWN probe must not
+    # silently under-count into a `stop` that reads as "awaiting approval" — record it and keep
+    # scanning, since a LATER approver proving `active` still discharges honestly.
+    if cp_team_membership "$ORG" "$u"; then
+      [ "$CP_MEMBERSHIP" = "active" ] && { NON_AUTHOR_APPROVAL_AT_HEAD=true; break; }
+    else
+      MEMBERSHIP_UNKNOWN=true
+    fi
   done <<<"$CURRENT_APPROVERS"
+  if [ "$NON_AUTHOR_APPROVAL_AT_HEAD" = false ] && [ "$MEMBERSHIP_UNKNOWN" = true ]; then
+    cp_unknown "at least one approver's control-plane membership"; exit 1
+  fi
 
   # Signal 2 — a deliberate current-head self-approval MARKER by the sole owner (the ONLY N==1
   # sole-owner discharge). GitHub records no native self-approval, so the signal is a marker comment:
@@ -562,13 +610,19 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
   # it can never leak a §CP PR into the auto-merge namespace (ADR 0111) — authored by the sole owner
   # and SHA-bound to the current head. The sole owner posts it to consciously self-approve their own
   # §CP PR; it is inert unless N==1 and they are the author (cp-cardinality ignores it otherwise).
+  # Capture, CHECK, then pipe the variable: `pipefail` is off in the agent shell, so piping `gh`
+  # straight into `grep` reports grep's status and discards the read's (§CPREAD #1).
   SELF_APPROVAL_AT_HEAD=false
-  SELF_SHA="$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
+  SELF_MARKERS="$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
     --jq "[.[] | select(.user.login == \"$AUTHOR\")
                | select(.body | test(\"(?i)^\\\\s*\\\\**\\\\s*control-plane-self-approval\\\\b\"))]
-          | last | .body // \"\"" \
+          | last | .body // \"\"")" \
+    || { cp_unknown "the PR's comment list"; exit 1; }
+  # `tail -n1`, not `head`: --paginate runs this aggregate --jq PER PAGE and emits one body each, in
+  # page order, so the LAST match is the latest marker — `head` would pin page 1's older one (#725).
+  SELF_SHA="$(printf '%s\n' "$SELF_MARKERS" \
     | grep -ioE 'control-plane-self-approval[[:space:]]*@?[[:space:]]*[0-9a-f]{7,40}' \
-    | grep -ioE '[0-9a-f]{7,40}' | head -n1)"
+    | grep -ioE '[0-9a-f]{7,40}' | tail -n1)"
   sha_binds_head "$SELF_SHA" && SELF_APPROVAL_AT_HEAD=true
 
   # The DETERMINISTIC decision — the whole ADR-0175 `case "$N"` branch lives in the tested pure core.
@@ -584,6 +638,8 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
        $([ "$SELF_APPROVAL_AT_HEAD" = true ] && printf -- '--self-approval-at-head'); then
     echo "§CP approval: discharged deterministically (ADR 0175) → carry on to machine gates"
   else
+    # Reachable ONLY with every input proven readable, so this message states a fact: the branch's
+    # required human signal is genuinely absent.
     echo "§CP approval: STOP (awaiting control-plane approval) — cardinality branch not satisfied (ADR 0175)"
   fi
   ```

--- a/packages/pipeline-cli/src/tools/cp-cardinality/README.md
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/README.md
@@ -48,10 +48,12 @@ marker); this tool owns the branch. It never calls the network.
 ## Usage
 
 ```bash
-# ship-it's §CP gate resolves the roster + signals over REST, then decides deterministically:
+# ship-it's §CP gate resolves the roster + signals over REST, then decides deterministically.
+# The roster is a GUARDED read — `cp_team_roster` from §CPREAD-APPROVAL of
+# claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md, never a bare capture.
 ORG="${REPO%%/*}"
-MEMBERS="$(gh api --paginate "orgs/$ORG/teams/control-plane/members?per_page=100" --jq '.[].login')"
-printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide \
+cp_team_roster "$ORG" || { echo "roster UNKNOWN (read failed) — STOP, do not decide" >&2; exit 1; }
+printf '%s\n' "$CP_MEMBERS" | pipeline-cli cp-cardinality decide \
   --author "$AUTHOR" \
   --non-author-approval-at-head \   # pass iff a current-head APPROVED review by a member != author exists
   --self-approval-at-head           # pass iff a current-head self-approval marker by the sole owner exists
@@ -60,3 +62,10 @@ printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide \
 The decision word (`discharge` | `stop`) goes to **stdout**; a human reason goes to
 **stderr**. Exit is **0 on `discharge`, 1 on `stop`**, so the gate bash fails closed with
 `… && carry-on || STOP`.
+
+**The caller owns roster validity — this core cannot recover it.** A bare
+`MEMBERS="$(gh api … --jq …)"` does not fail loudly: `gh` skips `--jq` on an error response and
+writes the error body to **stdout**, so the capture is a one-line JSON blob and this tool is handed
+`N = 1` on a phantom member. `n === 0`'s "the team is empty" branch is never reached, and the
+reason line then reports an outage as a finding about team shape (#4223). Feed it a roster resolved
+by `cp_team_roster`, or the decision is about a payload rather than a team.


### PR DESCRIPTION
Fixes #4223

## What this is, stated accurately

The ADR-0175 §CP approval discharge in `ship-it` captured four network reads with no exit-status check: the `control-plane` roster, the PR author, the PR head SHA, and each approver's team membership. This makes them resolve, or stop as UNKNOWN.

**It is not a privilege-escalation fix.** The issue's re-price settles that: `single-owner-other` and `multi-member` require the *identical* `nonAuthorApprovalAtHead` signal, so the phantom roster is decision-equivalent to an honest read in every cell, and a 30-day audit of 1194 merged PRs (356 of them §CP) found no merge where this lowered a bar. The real blast radius is (a) **observability** — the gate reports "sole member" for a four-person team — and (b) it defeats ADR 0175's `N == 0` STOP. That framing now lives at the site it protects: the §CPREAD-APPROVAL note in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, which is the single source the `ship-it` gate block points to for the why. A future reader of the gate meets the de-inflation there, not only in this PR body.

## The mechanism, re-measured on this branch

`gh` does not apply `--jq` to an error response — it writes the raw error body to **stdout**. So a failed roster read is not empty; it is a one-line JSON blob:

```
== C. old unguarded capture, absent namespace (the defect being fixed)
  old-capture bytes=121 lines=1  => phantom N
```

A line-counting cardinality therefore computes **N=1 on a phantom member whose login is an error document**, and `cp-cardinality`'s `n === 0` "the team is empty" branch is **never reached**. Anyone hardening that branch would harden a branch this failure cannot enter — which is why the fix is a **shape check on content**, not a bare `|| exit`. A read failure and a genuinely-empty roster are distinguishable (a JSON blob vs an empty stream), and collapsing them is the whole defect.

## The change

Three new hardened readers land in **§CPREAD-APPROVAL** of `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, next to the `cp_changed_files` / `cp_head_sha` that PR #4229 shipped — consumed by `ship-it`, not minted as a fourth copy of the idiom:

- **`cp_team_roster`** — array-shape jq, status check, payload discarded on failure, then a **login-charset assertion per line** so the error blob cannot pass as a member. A read that *succeeds* and returns zero members still flows to `cp-cardinality`'s honest `N == 0` STOP; only an *unreadable* roster is UNKNOWN. §ZS's zero-scope rule deliberately does not apply here — unlike a PR's file list, an empty team is a real answer.
- **`cp_pr_author`** — status-checked, payload-discarded, shape-asserted bare login.
- **`cp_team_membership`** — three-way over `-i`, which keeps the status line on stdout even when `gh` exits non-zero: **200** is a state, **404** is a definite non-member, **anything else is UNKNOWN**. Composition noted in the source: an absent team namespace 404s here too, so this endpoint alone cannot tell "not a member" from "no such team" — it does not have to, because `cp_team_roster` runs first and stops on an unreadable roster.

Alongside those helpers, §CPREAD-APPROVAL now also **states the defect at its measured size** — that the phantom `N=1` lands on `single-owner-other`, which discharges on the same `nonAuthorApprovalAtHead` signal as the `multi-member` branch it displaces, so it cannot lower an approval bar. That is the note that keeps a later reader of the gate from re-inflating a correctness-and-observability defect into a privilege-escalation story.

In `ship-it`'s gate block:

- `sha_binds_head` proves `$HEAD` is bare 40-hex **before** matching. With `$HEAD` empty the reverse pattern degenerated to `*` and bound *any* candidate, so a self-approval marker on a superseded SHA counted as current. The bidirectional short-SHA match is kept in shape; only the unasserted-head case is taken out of its reach.
- The Signal-1 author-skip asserts a resolved `$AUTHOR` **at the skip itself** — that is where an unresolved author would let a self-approval count as a non-author approval, the one direction that is not safe.
- An UNKNOWN membership probe no longer silently under-counts: it is recorded, the scan continues (a later `active` approver still discharges honestly), and if no approver was proven the gate stops as UNKNOWN rather than as a wait.
- The self-approval marker read **captures, checks, then pipes the variable** (`pipefail` is off in the agent shell), and takes the **last** per-page match rather than page 1's older one — `--paginate` runs that aggregate `--jq` per page and emits one body each, so `head -n1` pinned the oldest marker (#725).
- Every failure branch stops under `cp_unknown`, a line that **names the read that failed** — never `awaiting control-plane approval`, which asserts a fact about a human that no one established. Same outcome, different fact; reporting the first as the second sends an operator to debug a person instead of an outage. The surviving `awaiting control-plane approval` message is now reachable only with every input proven readable, so it states a fact.

`cp-cardinality`'s README no longer shows the unguarded capture as its usage, and says plainly that the caller owns roster validity because the pure core cannot recover it.

ADR 0175's own snippet is left untouched — it is the historical decision record, not the live implementation.

## Verification

A read-only probe ran the new helpers against the live API (real org, an absent namespace, a real member, a definite non-member) and the matcher against its regression table. All outcomes matched:

```
A. roster, real org                    -> rc=0 N=4
B. roster, absent namespace            -> rc=1 captured=''      (UNKNOWN, not N=1)
C. old unguarded capture, same         -> bytes=121 lines=1     (the phantom)
D/E. author, real / nonexistent PR     -> rc=0 'login' / rc=1 ''
F/G. membership, member / non-member   -> rc=0 active / rc=0 absent
I. sha_binds_head:
   empty HEAD vs stale 40-hex -> 1     blob HEAD vs stale -> 1
   good HEAD  vs stale        -> 1     good HEAD vs exact -> 0
   good HEAD  vs 7-hex short  -> 0     good HEAD vs 6-hex -> 1
   good HEAD  vs empty        -> 1
```

Corpus guards, all clean on this branch (re-run at head after the §CPREAD-APPROVAL note landed): `gh-phoenix lint-skills` (full CI scope), `adoption-lint check` (full CI scope), `codeowners-cp check` (32 §CP paths covered), `validate-skills.sh` (26 skills), plus `pointer-guard` and `leak-guard`.

## Acceptance criteria

- [x] `HEAD` resolved by an exit-status-checked read that discards the payload and shape-asserts bare 40-hex; unresolved stops the gate — via `cp_head_sha`, not a `[ -n "$HEAD" ]` test.
- [x] `sha_binds_head` cannot return 0 on an empty or non-40-hex `$HEAD`; bidirectional short-SHA match otherwise preserved.
- [x] `MEMBERS` and `AUTHOR` resolved by exit-status-checked reads that discard the payload on failure, stopping at the **shell** — the load-bearing clause, since `cp-cardinality`'s downstream guard demonstrably does not fire here.
- [x] The Signal-1 author-skip cannot silently stop skipping on an unresolved `$AUTHOR`.
- [x] The per-approver membership read distinguishes 200 / 404 / other; UNKNOWN does not under-count into a pass.
- [x] `SELF_SHA`'s pipeline no longer masks the read's status (capture, check, then pipe).
- [x] An unreadable input stops under a message distinct from `awaiting control-plane approval`.
- [x] The §CP text passes `gh-phoenix lint-skills`, `adoption-lint`, `codeowners-cp check`, and `validate-skills.sh`.

## §CP

`cp-classify` on this diff: **`control-plane` [path-match]** — `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` matches the live `CONTROL_PLANE_RE`, and `ship-it` is a gate-critical skill. This PR needs a human control-plane approval before it can enqueue. That is expected, and it is the same gate this PR is repairing.
