### PR TITLE
fix(pipeline-cli): gh-phoenix routeEdit finds its target by position, not the first integer (#4339)

### DIFF
--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
@@ -122,6 +122,44 @@ const readRepoFlag = (argv: ReadonlyArray<string>): RepoFlag => {
 	return {kind: "absent"};
 };
 
+/**
+ * Long flags on `gh <pr|issue> edit` that are booleans — they carry no value, so a positional
+ * scan must NOT swallow the token after them. Every other `--flag` is assumed to take a value:
+ * over-skipping ends in a refusal (no positional found → block), while under-skipping revives
+ * the defect the positional scan exists to remove — a flag's value posing as the target (#4339).
+ */
+const BOOLEAN_EDIT_FLAGS = new Set(["--help", "-h"]);
+
+/**
+ * Locate the positional `<N>` of `gh <pr|issue> edit` BY POSITION — walking left to right and
+ * skipping each flag together with its value — never by scanning for the first bare integer.
+ * The content scan let a flag value steal the target: `gh pr edit --milestone 3 5` PATCHed
+ * issue 3, silently and successfully, because `3` came first (#4339). Returns the first
+ * non-flag token, or `undefined` when the invocation carries none; the caller still requires
+ * it to be numeric, so an ambiguous argv refuses rather than guesses.
+ */
+const findPositionalTarget = (rest: ReadonlyArray<string>): string | undefined => {
+	for (let i = 0; i < rest.length; i++) {
+		const a = rest[i];
+		if (a === undefined) continue;
+		if (a === "--") return rest[i + 1]; // the end-of-flags separator: the rest is positional
+		if (a.startsWith("--")) {
+			if (a.includes("=")) continue; // `--flag=value` carries its own value
+			if (BOOLEAN_EDIT_FLAGS.has(a)) continue;
+			i++; // `--flag value`
+			continue;
+		}
+		if (a.startsWith("-") && a.length > 1) {
+			if (a.length > 2) continue; // attached shorthand value, e.g. `-Rowner/name`, `-m3`
+			if (BOOLEAN_EDIT_FLAGS.has(a)) continue;
+			i++;
+			continue;
+		}
+		return a;
+	}
+	return undefined;
+};
+
 /** Split a comma-separated `--json` field list, trimming blanks. */
 const splitFields = (raw: string): ReadonlyArray<string> =>
 	raw
@@ -211,8 +249,8 @@ const routeEdit = (
 		};
 	}
 
-	const target = rest.find((a) => /^\d+$/.test(a));
-	if (target === undefined) {
+	const target = findPositionalTarget(rest);
+	if (target === undefined || /^\d+$/.test(target) === false) {
 		return {
 			kind: "block",
 			reason: `\`gh ${verb} edit\` without a numeric #N target can't be rewritten to a REST PATCH.`,

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
@@ -246,6 +246,70 @@ describe("route — -R still reaches real `gh` untouched on the non-edit routes 
 	});
 });
 
+describe("route — the edit target is positional, not the first bare integer (#4339)", () => {
+	it("targets the positional 5, not the `--milestone 3` value that precedes it", () => {
+		const out = r(["pr", "edit", "--milestone", "3", "5", "--title", "x"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${REPO}/issues/5`);
+			assert.notInclude(out.argv, `repos/${REPO}/issues/3`);
+			assert.include(out.argv, "milestone=3");
+			assert.include(out.argv, "title=x");
+		}
+	});
+
+	it("does not consume the token after a `--milestone=3` attached value", () => {
+		const out = r(["issue", "edit", "--milestone=3", "5", "--body", "b"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${REPO}/issues/5`);
+			assert.include(out.argv, "milestone=3");
+			assert.include(out.argv, "body=b");
+		}
+	});
+
+	it("skips a value-taking flag the rewrite itself does not model", () => {
+		const out = r(["issue", "edit", "--add-label", "bug", "7", "--body", "y"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") assert.include(out.argv, `repos/${REPO}/issues/7`);
+	});
+
+	it("blocks when every integer in the argv is a flag value and no positional follows", () => {
+		const out = r(["pr", "edit", "--milestone", "3", "--title", "x"]);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") assert.include(out.hint, "-X PATCH");
+	});
+
+	it("blocks a `--body 5` whose only integer is the body text", () => {
+		const out = r(["pr", "edit", "--body", "5"]);
+		assert.strictEqual(out.kind, "block");
+	});
+
+	it("blocks a non-numeric positional (a PR branch selector) with the REST hint", () => {
+		const out = r(["pr", "edit", "my-branch", "--title", "x"]);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") {
+			assert.include(out.reason, "numeric");
+			assert.include(out.hint, `repos/${REPO}/pulls/<N>`);
+		}
+	});
+
+	it("keeps the target-first orderings working", () => {
+		const pr = r(["pr", "edit", "5", "--title", "x"]);
+		assert.strictEqual(pr.kind, "rewrite");
+		if (pr.kind === "rewrite") assert.include(pr.argv, `repos/${REPO}/issues/5`);
+		const issue = r(["issue", "edit", "7", "--body", "y"]);
+		assert.strictEqual(issue.kind, "rewrite");
+		if (issue.kind === "rewrite") assert.include(issue.argv, `repos/${REPO}/issues/7`);
+	});
+
+	it("reads the target after an `--` end-of-flags separator", () => {
+		const out = r(["pr", "edit", "--title", "x", "--", "5"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") assert.include(out.argv, `repos/${REPO}/issues/5`);
+	});
+});
+
 describe("isMilestoneTitle", () => {
 	it("treats a bare integer as a number (not a title)", () => {
 		assert.isFalse(isMilestoneTitle("12"));


### PR DESCRIPTION
The `gh-phoenix` shim picked which issue or PR to edit by grabbing the first bare integer it saw in the command line — including a number that belonged to a flag. So `gh pr edit --milestone 3 5 --title x` quietly retitled issue 3 instead of issue 5, exited 0, and said nothing. This teaches the shim to find the target the way `gh` does: by position, walking the arguments and stepping over each flag together with its value.

Ambiguity now refuses instead of guessing. If no positional number survives the walk, or the positional token is not a number, the shim blocks with the same REST hint it already gave.

## What changed

- `packages/pipeline-cli/src/tools/gh-phoenix/router.ts` — `routeEdit` replaces `rest.find((a) => /^\d+$/.test(a))` with a positional walk (`findPositionalTarget`): left to right, skipping `--flag value`, `--flag=value`, attached shorthands (`-Rowner/name`, `-m3`), and honoring `--` as the end-of-flags separator. Unlisted long flags are assumed to take a value, because over-skipping ends in a refusal while under-skipping is the defect itself. The target must still be numeric, so the existing `block` and its hint are unchanged.
- `packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts` — a `#4339` describe block: the `--milestone 3 5` regression, the `--milestone=3 5` attached form, an unmodelled value-taking flag (`--add-label bug 7`), the two block cases (all integers are flag values; a non-numeric positional), the `--` separator, and the target-first orderings.

`route`'s passthrough and `routeView` are untouched. The 38 router unit tests pass (103 across the `gh-phoenix` tool); `pnpm typecheck` and `pnpm lint:worktree` are clean.

Classification: `pipeline-cli cp-classify classify` returns `not-control-plane [path-clear-no-content-source]` (exit 3) — proven ordinary.

Fixes #4339

## Deviations

- **Class: narrowed a suggested fix-shape.** Said: triage noted it "may prefer a fuller argv-parse over a targeted skip-flag-values walk." Did: implemented the targeted positional walk, not a general `gh` argv parser. Why: the acceptance criteria specify the walk verbatim, and a full parser would need `gh`'s per-verb flag arity tables — scope the issue does not ask for and a surface that rots against upstream `gh`. Disposition: no action needed.
- **Class: made a judgment call the issue did not specify.** Said: nothing about flags the shim does not model. Did: an unrecognized bare `--flag` is treated as value-taking, so its value can never be mistaken for the target. Why: the two failure directions are asymmetric — over-skipping degrades to the existing `block` (a loud refusal), under-skipping reproduces the silent wrong-write. Disposition: for the reviewer to judge; a boolean flag the shim does not know, placed immediately before the target, now blocks rather than resolves.
