### PR TITLE
fix(doctor): a failed workflows read is UNDETERMINED, never 'no CI workflows' (#4347)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
+++ b/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
@@ -107,12 +107,23 @@ else
 	fails=$((fails + 1))
 fi
 
-# 2b. a CI signal exists for ship-it to gate on (Step 3 reads check-runs green)
-WORKFLOWS=0
+# 2b. a CI signal exists for ship-it to gate on (Step 3 reads check-runs green).
+#     Three outcomes, per the read discipline the Tier-2 governance checks below state in full:
+#     the retired `|| echo 0` APPENDED to gh's un-`--jq`'d error body rather than replacing it, so
+#     an unreadable repo produced `{"message":"Not Found",…}0`, tripped `[: integer expression
+#     expected`, and landed on "no CI workflows defined" — a failed read reported as the negative
+#     answer (#4347).
+WORKFLOWS=""
+WF_RC=1
 if [ -n "${REPO:-}" ]; then
-	WORKFLOWS=$(gh api "repos/$REPO/actions/workflows" --jq '.total_count' 2>/dev/null || echo 0)
+	WORKFLOWS=$(gh api "repos/$REPO/actions/workflows" --jq '.total_count' 2>/dev/null)
+	WF_RC=$?
 fi
-if [ "${WORKFLOWS:-0}" -gt 0 ]; then
+if [ "$WF_RC" -ne 0 ] || ! printf '%s' "$WORKFLOWS" | grep -Eq '^[0-9]+$'; then
+	say "$FAIL" "READ FAILED: could not read the workflows of ${REPO:-<unresolved repo>} (gh exit $WF_RC, returned: $(brief "${WORKFLOWS:-<empty>}")) — the workflow count is UNKNOWN, which is neither a pass nor 'no CI workflows'"
+	fix "resolve the repo and re-run once \`gh auth status\` shows a token that can read it — this line says NOTHING about whether CI exists, so do not add a workflow on the strength of it"
+	fails=$((fails + 1))
+elif [ "$WORKFLOWS" -gt 0 ]; then
 	say "$PASS" "CI workflows defined ($WORKFLOWS) — ship-it has a checks-green signal to gate on"
 else
 	say "$FAIL" "no CI workflows defined — ship-it's checks-green gate (Step 3) passes vacuously"
@@ -204,16 +215,23 @@ for pkg in @kampus/pipeline-cli; do
 	fi
 done
 
-# 3b. the run-evidence producer (ship-it degrades gracefully without it — ADR 0086)
-RUNEV=0
+# 3b. the run-evidence producer (ship-it degrades gracefully without it — ADR 0086).
+#     Same three-outcome read discipline as 2b/2c/2d; WARN-only in all three arms, so the
+#     undetermined arm still never touches `fails` (#4347).
+RUNEV=""
+RE_RC=1
 if [ -n "${REPO:-}" ]; then
 	# No --paginate: with --paginate, gh feeds each page to --jq separately, so `| length`
 	# prints one integer PER PAGE (a multi-line "0\n0" that breaks the -gt test). per_page=100
 	# fits any realistic repo's workflow set in one page → a single integer.
 	RUNEV=$(gh api "repos/$REPO/actions/workflows?per_page=100" \
-		--jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null || echo 0)
+		--jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null)
+	RE_RC=$?
 fi
-if [ "${RUNEV:-0}" -gt 0 ]; then
+if [ "$RE_RC" -ne 0 ] || ! printf '%s' "$RUNEV" | grep -Eq '^[0-9]+$'; then
+	say "$WARN" "READ FAILED: could not read the workflows of ${REPO:-<unresolved repo>} (gh exit $RE_RC, returned: $(brief "${RUNEV:-<empty>}")) — whether a run-evidence producer exists is UNKNOWN, which is neither a pass nor 'no run-evidence producer'"
+	fix "resolve the repo and re-run once \`gh auth status\` shows a token that can read it — ship-it guard 2's mode stays undetermined until this read succeeds"
+elif [ "$RUNEV" -gt 0 ]; then
 	say "$PASS" "run-evidence producer present — ship-it guard 2 runs in strict mode"
 else
 	say "$WARN" "no run-evidence producer — ship-it guard 2 degrades to checks-green (ADR 0086)"


### PR DESCRIPTION
Fixes #4347

## What changed

`doctor.sh` checks `2b` (CI workflows) and `3b` (run-evidence producer) captured a `gh api … --jq` read as `… 2>/dev/null || echo 0`. `gh` does **not** apply `--jq` to an error response — it writes the raw error body to stdout and exits non-zero — so `|| echo 0` **appended** `0` to that body rather than replacing it. The subsequent numeric test then printed `[: integer expression expected` to stderr, evaluated false, and dropped into the negative arm: *"no CI workflows defined"*, with a `fix:` telling the operator to add a workflow. A read that never ran was being reported as a definite negative answer, and the real cause (repo resolution / auth) stayed hidden behind it.

Both sites now use the **three-outcome read discipline the file already holds** at the Tier-2 `allow_auto_merge` / merge-queue checks (and, per `claude-plugins/pipeline-crew/PROBES.md`, *"a probe that cannot itself execute must resolve to 'unknown', never 'down'"*):

- `gh`'s exit status is captured **separately** from the value (`WF_RC=$?` / `RE_RC=$?`) — `|| echo 0` is gone from both.
- The pass and genuinely-absent arms admit **only a literal integer** (`grep -Eq '^[0-9]+$'`); anything else routes to the undetermined arm.
- The undetermined arm is a distinct `READ FAILED: … — UNKNOWN, which is neither a pass nor 'no …'` line, quoting what the read actually returned via the existing `brief()` helper (from #4303 / PR #4346, now merged).
- The `fix:` on the undetermined arm addresses **the read** — resolve the repo, check `gh auth status`, re-run — and explicitly says the line establishes nothing about whether CI exists.

**Verdicts are unchanged.** `2b` still counts toward `fails`; `3b` still never does (all three of its arms are WARN-only). This changes reasons and fixes, not the exit-code contract. `doctor.sh` stays write-free — every remediation is still a command it prints.

## Verification — all three arms, run live

**Unreadable repo** (`CLAUDE_PIPELINE_REPO=kamp-us/definitely-not-a-real-repo-4347`), the issue's reproduction. No `[: … integer expression expected` line anywhere in the output; neither site prints its negative answer:

```
  ✗ READ FAILED: could not read the workflows of kamp-us/definitely-not-a-real-repo-4347 (gh exit 1,
    returned: {"message":"Not Found","documentation_url":"https://docs.github.com/rest/actions/workflows#list-repository-workflows","s)
    — the workflow count is UNKNOWN, which is neither a pass nor 'no CI workflows'
      ↳ fix: resolve the repo and re-run once `gh auth status` shows a token that can read it —
             this line says NOTHING about whether CI exists, so do not add a workflow on the strength of it
  ⚠ READ FAILED: could not read the workflows of … — whether a run-evidence producer exists is
    UNKNOWN, which is neither a pass nor 'no run-evidence producer'
```

Exit 1, 4 blocking failures — same count and same direction as before the change.

**Present** (`kamp-us/phoenix`): `✓ CI workflows defined (44)` / `✓ run-evidence producer present`, verdict pipeline-ready, exit 0.

**Genuinely absent, readable**: `octocat/git-consortium` (a real repo whose `total_count` is `0`) still prints `✗ no CI workflows defined` with the add-a-workflow fix; `octocat/Hello-World` still prints `⚠ no run-evidence producer`. The true-negative arms are intact and reachable.

`pnpm lint:worktree` is a clean skip (shell-only diff); `pnpm typecheck` green (29/29).

## Check `3a` — deliberately left out of scope

Per the acceptance criteria's explicit call: **`3a` (`npm view "$pkg" version >/dev/null 2>&1`) is NOT brought in scope.** It is the same defect *class* by a different mechanism — there is no `|| echo 0` collapse and no value to shape-validate; distinguishing "the registry was unreachable" from "the package does not exist" requires parsing npm's error output, which is a different fix with a different failure mode. It is also WARN-only and touches nothing. Triage measured this issue at exactly two sites, and #4246 / #4247 are the filed guards that mechanize the class repo-wide — `3a` is theirs, not this diff's, and folding it in would silently widen a §CP diff beyond the issue.

## Control plane

`pipeline-cli cp-classify classify` → **`control-plane [path-match]` — BLOCKING (human merge).** A `.sh` under `claude-plugins/kampus-pipeline/skills/` matches the live `CONTROL_PLANE_RE`. This PR stops at open; a human control-plane member approves and merges it.

## Sequencing

Branched off `main` **after** PR #4346 merged, so `brief()` is reused rather than reinvented and the `READ FAILED … UNKNOWN` phrasing matches the convention that PR established. PR #4337 (for #4300) is still open and rewrites `1c` / appends `3c`/`3d` — no textual overlap with `2b` or `3b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
