### PR TITLE
fix(pipeline): the claim winner writes layer one on both paths (#4298)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -342,8 +342,10 @@ async function drive() {
 			`(3) on a NON-ZERO exit, mutate NOTHING — you never assigned, so there is nothing to undo, and you must NEVER unassign ` +
 			`a slot you did not fill: every agent authenticates as the SAME login, so a cleanup unassign here would strip the LIVE ` +
 			`incumbent's assignment (#4015) — return { won: false, token: "", reason: "<the verb's stderr back-off reason>" }; ` +
-			`(4) ONLY on exit 0, self-assign (the coarse availability gate, §7 layer one) via ` +
-			`\`gh api -X POST repos/$REPO/issues/${issue}/assignees\`. ` +
+			`(4) ONLY on exit 0, write §7 LAYER ONE — the coarse availability gate the write-code Step-1 picker reads — through the ` +
+			`SHARED VERB: \`pipeline-cli claim assign --issue ${issue}\`. Never hand-roll the assignees POST: the verb refuses on any ` +
+			`lane whose claim is not ours, is additive/idempotent, and reads the landed gate back, so an unwritten gate is loud ` +
+			`rather than a lane that silently re-enters the claimable pool the moment the PR opens (#4298). ` +
 			`Do NOT hand-roll the claim POST or re-derive the tiebreak jq. On a confirmed win (exit 0) return { won: true, token: "<TOKEN>", reason: "" }.`,
 		{
 			schema: {

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -3254,6 +3254,9 @@ The claim is **two layers** (ADR 0115 §1):
   cheap, list-visible "is this taken at all?" signal the Step-1 picker reads (`skip on any
   non-null assignee`). It is **login-blind by design** and decides nothing about *which*
   agent owns the work — it only narrows the field and tolerates a transient double-assign.
+  It is also the **only** layer the picker reads, so it is what keeps a finished lane out of an
+  idle picker's pool while the PR is in review — see
+  [Who writes layer one](#who-writes-layer-one-the-claim-winner-on-both-paths).
 - **Fine, agent-distinguishable resolution — the claim comment (the resolver).** A
   structured issue comment carrying the claiming agent's `CLAUDE_CODE_SESSION_ID` — the
   per-session UUID Claude Code exposes in every (sub)agent's environment (read today by
@@ -3396,6 +3399,58 @@ unrepresentable rather than merely handled: a deferring agent never assigned, so
 undo and mutates nothing. The rule for every writer, stated once here: **never unassign a slot you
 did not fill.**
 
+<a id="who-writes-layer-one-the-claim-winner-on-both-paths"></a>
+### Who writes layer one — the claim winner, on BOTH paths (#4298)
+
+Layer two has a named writer on every path; layer one did not, and the gap fell exactly on the
+**delegated (orchestrated) path**. `write-code` Step 3's orchestrated branch skips the direct-path
+block — which carries *both* the claim comment and the self-assign — and the contract never
+re-assigned the second half to anybody. The obligation survived only inside one orchestrator's
+inline claim-agent prompt, so any other dispatcher (a crew engine threading a token by hand)
+satisfied the delegated-claim contract in full while leaving the gate unset. The result was an
+issue sitting `status:triaged` **and unassigned** with a finished implementation already open as a
+PR — precisely the shape the Step-1 picker selects (observed on #4283 / PR #4295).
+
+**The rule, stated once for every dispatcher: whoever wins the claim writes layer one, immediately
+after the win, before it hands the lane on.**
+
+- **Delegated path** — the dispatcher wins the claim pre-spawn, so the **dispatcher** owes layer
+  one before it spawns the coder. This binds *every* dispatcher — the orchestrator
+  (`.claude/workflows/drive-issue.js`) and any crew engine that claims a lane and threads the
+  token — not just the one whose prompt happens to say so.
+- **Direct path** — `write-code` wins its own claim at Step 3, so the **coder** owes it there.
+- **Either way the coder re-asserts it**, idempotently, once it has confirmed the claim is its own
+  (`write-code` Step 3). That re-assert is what makes the gate true **for the whole build**
+  whatever the dispatcher did, so Step 8's release can cite it instead of assuming it.
+
+The write goes through **one verb** — never a hand-rolled `gh api … /assignees`:
+
+```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" claim assign --issue <N>                    # layer one under our own session
+"$PCLI" claim assign --issue <N> --session <token>  # …or under the threaded delegated token
+```
+
+The verb is the enforcement, not the prose: it resolves ownership through the same **default-deny**
+resolution `claim is-mine` uses and **refuses (non-zero, no write) on any lane it cannot prove is
+ours** — an absent claim, a foreign owner, and a missing session each refuse. On a proven-own lane
+it is **additive and idempotent**: a gate already carrying our login is a no-op, otherwise ours is
+added, and the landed gate is read back (a write that did not land fails loud rather than reporting
+a gate that isn't there). **It cannot unassign** — there is no removal arm — so "never unassign a
+slot you did not fill" holds by construction, and re-running it is always free.
+
+**This is not an inference from absence, and must never become one.** The verb writes the gate
+because the run holds the lane, never because a missing assignee was read as evidence that some
+other party failed. Nothing here evicts a claim, keys on age, or acts on a marker's absence — the
+shapes ADR
+[0215](https://github.com/kamp-us/phoenix/blob/main/.decisions/0215-claim-identity-continuity-proof.md)
+§5 forbids. **Picker semantics are unchanged**: Step 1 still skips on any non-null assignee and
+still does not read claim comments.
+
+**Out of scope here:** *who may release layer two* on the delegated path is a separate, still-open
+question (#4145) — this rule settles the other layer and pre-empts none of it.
+
 ### Fail-closed on a missing token
 
 If `CLAUDE_CODE_SESSION_ID` is **absent** from the agent's environment, the claim **cannot
@@ -3413,9 +3468,13 @@ so closing it means claiming before any branch, build, or spawn:
   claim in a pre-step **before** the `agent(coder, …)` dispatch (delegated to a thin
   claim-only agent that runs this §7 primitive verbatim): `pipeline-cli tracker claim <N>`
   (the write surface above — defer, post the stamped marker, tiebreak, retract on loss), then
-  **self-assign only on a win**, and **only on a win spawn the coder**, threading the winning
-  claim **token** into the coder's prompt. On a lost claim it aborts the dispatch — no coder
-  spawns, and it leaves the assignee untouched (see [Claim before you assign](#claim-before-you-assign-a-defer-must-not-strip-the-incumbent)).
+  **write layer one only on a win** (`pipeline-cli claim assign --issue <N>`), and **only on a win
+  spawn the coder**, threading the winning claim **token** into the coder's prompt. On a lost claim
+  it aborts the dispatch — no coder spawns, and it leaves the assignee untouched (see
+  [Claim before you assign](#claim-before-you-assign-a-defer-must-not-strip-the-incumbent)).
+  **This binds every dispatcher, not only `drive-issue.js`** — a crew engine that claims a lane and
+  threads the token owes layer one on exactly the same terms
+  ([Who writes layer one](#who-writes-layer-one-the-claim-winner-on-both-paths)).
 - **Delegated ownership.** The orchestrator and the coder are distinct sessions (the spawned
   coder carries `CLAUDE_CODE_CHILD_SESSION=1` and its own id), so the claim token is
   **whoever posted the claim** — the orchestrator. The orchestrator threads its token to the
@@ -3447,7 +3506,11 @@ own token, leaves every other claim standing (and names them), is idempotent (re
 retracts nothing and succeeds), and fails closed with a non-zero exit when there is no token to
 prove ownership under. It does **not** touch the **assignee**: the coarse availability gate stays
 set while the PR is open, so the Step-1 picker still skips the issue and no second lane picks up
-work already in review. What release frees is the *fine* resolver — so a **directed** re-dispatch
+work already in review. That backstop holds because the gate was actually **written** — by the
+claim winner on both paths, re-asserted by the coder
+([Who writes layer one](#who-writes-layer-one-the-claim-winner-on-both-paths)). Before #4298 the
+delegated path wrote no gate at all, so this sentence promised a backstop that was not there.
+What release frees is the *fine* resolver — so a **directed** re-dispatch
 (a repair, a follow-up round, a stalled lane re-driven) claims the lane cleanly instead of
 resolving `lost` against a marker whose run finished hours ago (#3780).
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -434,6 +434,12 @@ availability gate the Step-1 picker reads (`skip on any non-null assignee`), and
 **session-id claim comment** is the fine, agent-distinguishable resolver. You self-assign
 *and* post the claim comment; the comment, not the assignee, decides who owns the work.
 
+**Both layers get written on both paths.** Layer one is owed by whoever wins the claim — the
+dispatcher on the delegated path, you on the direct path — and **you re-assert it, idempotently,
+once your claim is confirmed**, so the gate is set for the whole build whatever dispatched you
+(§7 [Who writes layer one](../gh-issue-intake-formats.md#who-writes-layer-one-the-claim-winner-on-both-paths),
+#4298). Both branches below end with the same one-line ensure.
+
 ### Delegated claim — the orchestrated path (recognize, don't re-race)
 
 If the orchestrator (`.claude/workflows/drive-issue.js`) claimed pre-spawn and **threaded a
@@ -444,11 +450,23 @@ delegation by resolving §7's tiebreak once — the **earliest authorized claim*
 session id must equal the threaded token — then proceed straight to implementing:
 
 ```bash
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Orchestrated path: confirm the delegated claim is the earliest authorized claim, then proceed.
-# WINSID is resolved by the §7 CLAIM_RE + write+ ACL + min(created_at, comment id) resolver — do
-# NOT re-derive that grammar here; run §7's canonical resolution snippet against issue <N>.
-[ "$WINSID" = "$DELEGATED_TOKEN" ] || { echo "delegated token is not the earliest authorized claim — abort, do not implement." >&2; exit 1; }
-# delegation confirmed — skip the direct-path claim below and go implement
+# The §7 CLAIM_RE + write+ ACL + min(created_at, comment id) resolution is owned by the shared verb
+# — run it, never re-derive the grammar. Exit 0 = the threaded token owns #N; non-zero = it does
+# not (absent, foreign, or superseded) ⇒ abort, do not implement.
+"$PCLI" claim is-mine --issue <N> --session "$DELEGATED_TOKEN" \
+  || { echo "delegated token is not the earliest authorized claim — abort, do not implement." >&2; exit 1; }
+# Ensure §7 LAYER ONE for the whole build (#4298). The dispatcher owes this pre-spawn, but the
+# obligation lived in ONE orchestrator's prompt, so a lane dispatched by anything else reached here
+# with no assignee — and Step 8's release then freed the resolver on top of a gate that was never
+# written, leaving the issue `status:triaged` + unassigned with its PR in review. Idempotent and
+# additive: a gate already carrying us is a no-op, and the verb REFUSES on any lane whose claim is
+# not ours, so this asserts nothing about the dispatcher and evicts nothing (ADR 0215 §5).
+"$PCLI" claim assign --issue <N> --session "$DELEGATED_TOKEN" \
+  || { echo "could not set the availability gate on #<N> — routed blocker, do not implement." >&2; exit 1; }
+# delegation confirmed + layer one held — skip the direct-path claim below and go implement
 ```
 
 ### Direct path — claim it yourself (no orchestrator)
@@ -482,14 +500,14 @@ if ! "$PCLI" tracker claim <N>; then
   exit 0   # → re-run Step 1
 fi
 
-# 2. ONLY NOW self-assign — the coarse availability gate the Step-1 picker reads (§7 layer one).
-#    Defer-then-assign is load-bearing, not stylistic: every agent authenticates as the SAME login,
-#    so the assignee is ONE shared slot. Assigning first would make the back-off above a cleanup
-#    unassign that strips the LIVE incumbent's assignment — clearing the coarse gate on an issue
-#    someone else legitimately holds. Claiming first removes the cleanup entirely: we only ever
-#    assign on a won claim, so there is no assignment of ours to undo (#4015).
-ME=$(gh api user --jq '.login')
-gh api -X POST repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" >/dev/null
+# 2. ONLY NOW write layer one — the coarse availability gate the Step-1 picker reads (§7). One verb
+#    owns this write on every path (#4298); never hand-roll the assignees POST. Defer-then-assign is
+#    load-bearing, not stylistic: every agent authenticates as the SAME login, so the assignee is ONE
+#    shared slot. Assigning first would make the back-off above a cleanup unassign that strips the
+#    LIVE incumbent's assignment — clearing the coarse gate on an issue someone else legitimately
+#    holds. Claiming first removes the cleanup entirely: the verb only ever writes on a claim it
+#    proved is ours, and it has no removal path at all, so there is nothing to undo (#4015).
+"$PCLI" claim assign --issue <N> || { echo "could not set the availability gate on #<N> — routed blocker." >&2; exit 1; }
 # claim won and confirmed (earliest authorized claim is mine) — proceed to implement
 ```
 
@@ -1831,6 +1849,16 @@ again.
 **It frees the resolver, not the lane.** Release retracts the claim comment and **leaves the
 assignee set**, so Step 1's picker still skips the issue while your PR is in review — a
 re-dispatch can claim it, an idle picker cannot pick it up and re-implement it.
+
+That backstop is only real because **Step 3 wrote layer one on the path you came in on** — the
+claim winner sets it and you re-assert it idempotently, on the orchestrated path as much as the
+direct one (§7
+[Who writes layer one](../gh-issue-intake-formats.md#who-writes-layer-one-the-claim-winner-on-both-paths)).
+It used to be asserted unconditionally while the orchestrated branch skipped the block that set it,
+so on a delegated build this release freed the resolver over a gate that was never written and the
+issue went back to fully unowned — `status:triaged`, unassigned, implementation already in review
+(#4298). If you ever find yourself here without a gate, that is a **routed blocker**, not something
+to reason past: do not release on an assumed backstop.
 
 **Never route around a claim you cannot release.** Release retracts only markers carrying the
 token you present; it cannot and must not evict another session's claim, whatever that claim's

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
@@ -136,13 +136,17 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 	// back-off: the self-assign is a no-op (the slot already shows that login), the verb defers,
 	// and the cleanup unassign then removes the INCUMBENT's assignment. Pin the only ordering that
 	// makes that unrepresentable — claim first, assign only on the verb's exit 0, never unassign.
-	it("claims before it self-assigns, so a defer cannot strip a live incumbent's assignment", () => {
-		// scope: the writers whose procedure actually issues the self-assign (a surface that only
-		// describes the claim has no ordering to pin). Fail closed on zero scope (ADR 0092).
+	it("claims before it writes layer one, so a defer cannot strip a live incumbent's assignment", () => {
+		// scope: the writers whose procedure actually writes layer one (a surface that only
+		// describes the claim has no ordering to pin). The write is `pipeline-cli claim assign`
+		// since #4298 — the raw POST stays matchable so the pin survives an un-migrated corpus.
+		// Fail closed on zero scope (ADR 0092).
+		const LAYER_ONE_WRITE =
+			/(?:gh api -X POST[^\n]*\/assignees|(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b)/;
 		const selfAssigning = CLAIM_WRITERS.map((rel) => ({
 			rel,
 			content: readFileSync(join(REPO_ROOT, rel), "utf8"),
-		})).filter(({content}) => /gh api -X POST[^\n]*\/assignees/.test(content));
+		})).filter(({content}) => LAYER_ONE_WRITE.test(content));
 		assert.isAbove(selfAssigning.length, 0, "expected at least one self-assigning claim writer");
 
 		for (const {rel, content} of selfAssigning) {
@@ -153,19 +157,57 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 			const claimAt = content.search(
 				/(?:pipeline-cli|"\$PCLI")\s+tracker\s+claim\s+(?:<N>|\$\{issue\})/,
 			);
-			const assignAt = content.search(/gh api -X POST[^\n]*\/assignees/);
 			assert.isAbove(claimAt, -1, `${rel} must invoke the claim-write verb on the issue`);
-			assert.isBelow(
-				claimAt,
-				assignAt,
-				`${rel} must claim BEFORE it self-assigns — assign-then-claim makes the defer path unassign the live incumbent (#4015)`,
+			assert.isAbove(
+				content.slice(claimAt).search(LAYER_ONE_WRITE),
+				-1,
+				`${rel} must write layer one AFTER it claims — assign-then-claim makes the defer path unassign the live incumbent (#4015)`,
 			);
+			// A layer-one write EARLIER in the file is the delegated branch, where the claim was won
+			// before the spawn — safe only if that branch first proves the lane is ours. Ungated, it
+			// is the same assign-then-claim hazard wearing a different hat.
+			const before = content.slice(0, claimAt);
+			if (LAYER_ONE_WRITE.test(before)) {
+				assert.isBelow(
+					before.search(/(?:pipeline-cli|"\$PCLI")\s+claim\s+is-mine\b/),
+					before.search(LAYER_ONE_WRITE),
+					`${rel} writes layer one before its own claim — that is only sound on the delegated path, where ownership must be proven first (#4298)`,
+				);
+			}
 			assert.notMatch(
 				content,
 				/gh api -X DELETE[^\n]*\/assignees/,
 				`${rel} must not unassign as claim cleanup — under the shared login that slot may be the incumbent's (#4015)`,
 			);
 		}
+	});
+
+	// #4298: layer one (the assignee) is the ONLY layer the write-code Step-1 picker reads, and the
+	// delegated path wrote none — the orchestrated branch skips the direct-path block that carries
+	// it, and the obligation survived only inside one orchestrator's prompt. Pin the two facts that
+	// close it: every claim-writing surface routes layer one through the one verb, and write-code's
+	// DELEGATED branch carries its own write rather than inheriting the direct path's.
+	it("writes layer one through the one verb, and the delegated branch carries its own", () => {
+		for (const rel of CLAIM_WRITERS) {
+			assert.match(
+				readFileSync(join(REPO_ROOT, rel), "utf8"),
+				/(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b/,
+				`${rel} must write the §7 layer-one availability gate through \`pipeline-cli claim assign\``,
+			);
+		}
+		const skill = readFileSync(
+			join(REPO_ROOT, "claude-plugins/kampus-pipeline/skills/write-code/SKILL.md"),
+			"utf8",
+		);
+		const delegatedAt = skill.search(/^### Delegated claim/m);
+		const directAt = skill.search(/^### Direct path/m);
+		assert.isAbove(delegatedAt, -1, "write-code must keep its delegated-claim branch");
+		assert.isAbove(directAt, delegatedAt, "write-code must keep its direct-path branch after it");
+		assert.match(
+			skill.slice(delegatedAt, directAt),
+			/(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b/,
+			"write-code's DELEGATED branch must write layer one itself — skipping it is what left an issue `status:triaged` + unassigned with its PR in review (#4298)",
+		);
 	});
 
 	it("exits 3 (zero-scope FAIL) when every handed file is unreadable/missing", async () => {

--- a/packages/pipeline-cli/src/tools/claim/claim-assign.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-assign.ts
@@ -1,0 +1,62 @@
+/**
+ * The pure layer-one decision — may this run write the coarse availability gate (the assignee)
+ * on a lane, and does it still need writing? IO-free and total.
+ *
+ * The claim is two layers (gh-issue-intake-formats.md §7): the **assignee** is the coarse,
+ * login-blind availability gate the write-code Step-1 picker reads, and the session-stamped
+ * **claim comment** is the fine resolver. Only layer one stands between a finished lane and an
+ * idle picker while a PR is in review, and on the delegated (orchestrated) path nobody the
+ * contract named was writing it — so an issue could sit `status:triaged` + unassigned with a
+ * finished implementation awaiting a gate (#4298).
+ *
+ * Two properties are the whole design, and both are structural here rather than a caller's
+ * discipline:
+ *
+ *  - **Positive proof, never inference from absence.** The plan is `refuse` unless the caller's
+ *    claim verdict is a proven `mine`. A missing assignee is *not* read as evidence about any
+ *    other party — the run writes layer one because it holds the lane, not because it concluded
+ *    someone else failed. That is the shape ADR 0215 §5 forbids, and it stays unrepresentable:
+ *    there is no arm of `AssignPlan` that clears or reassigns a slot.
+ *  - **Additive and idempotent.** A gate already carrying our login is `already-set` (no write);
+ *    otherwise `assign` adds ours. Nothing here can unassign — every agent authenticates as the
+ *    same login, so the assignee is one shared slot and "never unassign a slot you did not fill"
+ *    (§7, #4015) is enforced by the type, not by review.
+ */
+import type {ClaimReason, ClaimVerdict} from "./claim-is-mine.ts";
+
+/** Why layer one was refused: the claim did not resolve as ours, or we have no login to write. */
+export type AssignRefusal = ClaimReason | "no-login";
+
+/** What an assign will do: nothing (refused), nothing (already gated), or add our login. */
+export type AssignPlan =
+	| {readonly _tag: "refuse"; readonly reason: AssignRefusal; readonly owner: string | null}
+	| {readonly _tag: "already-set"; readonly login: string}
+	| {readonly _tag: "assign"; readonly login: string};
+
+const has = (assignees: ReadonlyArray<string>, login: string): boolean =>
+	assignees.some((a) => a.trim().toLowerCase() === login.trim().toLowerCase());
+
+/**
+ * Decide layer one for a lane: refuse unless the claim resolved as ours, no-op when the gate
+ * already carries our login, else add it. `login` is the authenticated account the write would
+ * name; an empty one refuses rather than posting an unnamed assignee.
+ */
+export const assignPlan = (input: {
+	readonly verdict: ClaimVerdict;
+	readonly login: string;
+	readonly assignees: ReadonlyArray<string>;
+}): AssignPlan => {
+	if (!input.verdict.mine) {
+		return {
+			_tag: "refuse",
+			reason: input.verdict.reason,
+			owner: input.verdict.winner?.session ?? null,
+		};
+	}
+	if (input.login.trim() === "") {
+		return {_tag: "refuse", reason: "no-login", owner: input.verdict.winner?.session ?? null};
+	}
+	return has(input.assignees, input.login)
+		? {_tag: "already-set", login: input.login}
+		: {_tag: "assign", login: input.login};
+};

--- a/packages/pipeline-cli/src/tools/claim/claim-assign.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-assign.unit.test.ts
@@ -1,0 +1,103 @@
+import {assert, describe, it} from "@effect/vitest";
+import {type AssignPlan, assignPlan} from "./claim-assign.ts";
+import type {ClaimVerdict} from "./claim-is-mine.ts";
+
+const SID_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+const mine: ClaimVerdict = {
+	mine: true,
+	reason: "won",
+	winner: {session: SID_A, id: 1, createdAt: "2026-07-26T00:00:00Z"},
+	superseded: [],
+};
+
+const notMine = (reason: ClaimVerdict["reason"], winner: string | null): ClaimVerdict => ({
+	mine: false,
+	reason,
+	winner: winner === null ? null : {session: winner, id: 1, createdAt: "2026-07-26T00:00:00Z"},
+	superseded: [],
+});
+
+describe("assignPlan — the layer-one decision (gh-issue-intake-formats.md §7, #4298)", () => {
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly verdict: ClaimVerdict;
+		readonly login: string;
+		readonly assignees: ReadonlyArray<string>;
+		readonly expected: AssignPlan;
+	}> = [
+		{
+			name: "our claim + an empty gate → write layer one",
+			verdict: mine,
+			login: "usirin",
+			assignees: [],
+			expected: {_tag: "assign", login: "usirin"},
+		},
+		{
+			name: "our claim + a gate already carrying us → idempotent no-op",
+			verdict: mine,
+			login: "usirin",
+			assignees: ["usirin"],
+			expected: {_tag: "already-set", login: "usirin"},
+		},
+		{
+			name: "our claim + a gate carrying only someone else → add ours, never displace theirs",
+			verdict: mine,
+			login: "usirin",
+			assignees: ["cansirin"],
+			expected: {_tag: "assign", login: "usirin"},
+		},
+		{
+			name: "login case differs → still already-set (GitHub logins are case-insensitive)",
+			verdict: mine,
+			login: "usirin",
+			assignees: ["USirin"],
+			expected: {_tag: "already-set", login: "usirin"},
+		},
+		{
+			name: "DEFAULT-DENY: a foreign owner → refuse, whatever the gate says",
+			verdict: notMine("lost", SID_B),
+			login: "usirin",
+			assignees: [],
+			expected: {_tag: "refuse", reason: "lost", owner: SID_B},
+		},
+		{
+			name: "DEFAULT-DENY: no authorized claim at all → refuse (never infer ownership from an empty lane)",
+			verdict: notMine("no-winner", null),
+			login: "usirin",
+			assignees: [],
+			expected: {_tag: "refuse", reason: "no-winner", owner: null},
+		},
+		{
+			name: "DEFAULT-DENY: no session id to resolve under → refuse",
+			verdict: notMine("no-session", null),
+			login: "usirin",
+			assignees: [],
+			expected: {_tag: "refuse", reason: "no-session", owner: null},
+		},
+		{
+			name: "our claim but no resolvable login → refuse rather than write an unnamed gate",
+			verdict: mine,
+			login: "  ",
+			assignees: [],
+			expected: {_tag: "refuse", reason: "no-login", owner: SID_A},
+		},
+	];
+
+	for (const c of cases) {
+		it(c.name, () => {
+			assert.deepStrictEqual(
+				assignPlan({verdict: c.verdict, login: c.login, assignees: c.assignees}),
+				c.expected,
+			);
+		});
+	}
+
+	it("the gate is never read as ownership: a not-mine verdict refuses even when it already carries us", () => {
+		assert.deepStrictEqual(
+			assignPlan({verdict: notMine("lost", SID_B), login: "usirin", assignees: ["usirin"]}),
+			{_tag: "refuse", reason: "lost", owner: SID_B},
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/claim/command.ts
+++ b/packages/pipeline-cli/src/tools/claim/command.ts
@@ -16,6 +16,14 @@
  * prose. The resolved verdict is printed as JSON on stdout for a caller that wants
  * the detail (the resolved owner, the outcome reason).
  *
+ * `assign` writes the OTHER layer (#4298). The claim is two layers (§7): this one is the coarse,
+ * login-blind availability gate the write-code Step-1 picker reads, and it is the only thing
+ * standing between a finished lane and an idle picker while the PR is in review. On the delegated
+ * (orchestrated) path nobody the contract named was writing it, so an issue could sit
+ * `status:triaged` + unassigned with the implementation already open as a PR. The verb is
+ * default-deny on the same resolution as `is-mine`, additive, and idempotent — it never unassigns,
+ * so re-running it is free and no run can strip an incumbent's slot (§7, #4015).
+ *
  * `release` is the other end of the same claim's life (#3780): a finished run retracts its
  * **own** marker so the lane stops reading `lost` forever. It is affirmative — the owner gives
  * the claim up — never inferred from staleness, so it can retract only markers carrying the
@@ -41,6 +49,7 @@
  */
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import type {AssignPlan} from "./claim-assign.ts";
 import {DEFAULT_MIN_AGE_HOURS, type LockedLane, STAMPING_CUTOFF} from "./claim-audit.ts";
 import type {ClaimVerdict} from "./claim-is-mine.ts";
 import {Github, GithubLive} from "./github.ts";
@@ -141,6 +150,45 @@ const release = Command.make(
 	),
 );
 
+/** The stderr reason line for a refused assign — why layer one was not written. */
+const refusalLine = (issue: number, plan: Extract<AssignPlan, {_tag: "refuse"}>): string =>
+	plan.reason === "no-login"
+		? `#${issue}: could not resolve the authenticated login to assign — refusing to write an unnamed availability gate.`
+		: `#${issue}: the claim did not resolve as mine (${plan.reason}${
+				plan.owner === null ? "" : `, owner ${plan.owner}`
+			}) — refusing to write layer one on a lane we cannot prove is ours (default-deny).`;
+
+const assign = Command.make(
+	"assign",
+	{issue: issueFlag, session: sessionFlag},
+	Effect.fn(function* ({issue, session}) {
+		const sessionId = resolveSession(session);
+		const {plan, assignees} = yield* (yield* Github).assign(issue, sessionId).pipe(
+			// A gate that did not land is loud, never a false "layer one is set" (#4298).
+			Effect.catchTag("@kampus/claim/ClaimVerifyError", (error) => {
+				process.stderr.write(`claim: ${error.message}\n`);
+				process.exit(REFUSE_EXIT_CODE);
+				return Effect.never;
+			}),
+		);
+		yield* Console.log(JSON.stringify({issue, plan, assignees}));
+		if (plan._tag === "refuse") {
+			process.stderr.write(`claim: ${refusalLine(issue, plan)}\n`);
+			process.exit(REFUSE_EXIT_CODE);
+			return;
+		}
+		process.stderr.write(
+			`claim: #${issue}: availability gate ${
+				plan._tag === "already-set" ? "already carried" : "now carries"
+			} ${plan.login} — the Step-1 picker skips this lane until the issue closes.\n`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Set the coarse availability gate (§7 layer one, the assignee) on a lane whose claim is ours — additive and idempotent; never unassigns, and refuses on a lane we cannot prove is ours",
+	),
+);
+
 const status = Command.make(
 	"status",
 	{issue: issueFlag},
@@ -230,9 +278,9 @@ const audit = Command.make(
 );
 
 export const claimCommand = Command.make("claim").pipe(
-	Command.withSubcommands([isMine, release, status, audit]),
+	Command.withSubcommands([isMine, assign, release, status, audit]),
 	Command.withDescription(
-		"Resolve, release, and inspect issue claims (ADR 0115 earliest-authorized-claim): default-deny 'is this mine', affirmative self-release, the stale-claim inventory, and the pre-stamping legacy audit",
+		"Resolve, gate, release, and inspect issue claims (ADR 0115 earliest-authorized-claim): default-deny 'is this mine', the layer-one availability gate, affirmative self-release, the stale-claim inventory, and the pre-stamping legacy audit",
 	),
 	Command.provide(GithubLive),
 );

--- a/packages/pipeline-cli/src/tools/claim/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/github-service.unit.test.ts
@@ -46,7 +46,9 @@ const mockSpawner = (
 				let cmd = command;
 				while (cmd._tag === "PipedCommand") cmd = cmd.left;
 				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
-				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				// `user` is a path too — the authenticated-login probe `assign` runs before it writes
+				// layer one — so the fixture key covers it alongside the `repos/…` routes.
+				const rawPath = args.find((a) => a.startsWith("repos/") || a === "user") ?? "";
 				const path = rawPath.replace(/\?.*$/, "");
 				const key = `${methodOf(args)} ${path}`;
 				const canned =
@@ -238,6 +240,94 @@ describe("Github.release — the affirmative end of our own claim (#3780)", () =
 					[`DELETE ${P}/issues/comments/800`]: foreignDeleteIsForbidden,
 				}),
 			),
+	);
+});
+
+describe("Github.assign — the layer-one availability gate on a proven-own lane (#4298)", () => {
+	// A write the verb must NOT issue is mapped to a hard 403: were it ever reached, the fault
+	// surfaces as a test failure instead of passing silently.
+	const writeIsForbidden = {stdout: "", exitCode: 1, stderr: "HTTP 403: Forbidden"};
+	const ownClaim = JSON.stringify([claimComment({id: 700, login: "usirin", session: SID_MINE})]);
+	const issueWith = (...logins: ReadonlyArray<string>) =>
+		JSON.stringify({assignees: logins.map((login) => ({login}))});
+
+	it.effect("our claim + an unassigned lane → writes the gate and reads it back", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).assign(ISSUE, SID_MINE);
+			assert.deepStrictEqual(result.plan, {_tag: "assign", login: "usirin"});
+			assert.deepStrictEqual(result.assignees, ["usirin"]);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: ownClaim,
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				"GET user": "usirin\n",
+				[`GET ${P}/issues/${ISSUE}`]: issueWith(),
+				[`POST ${P}/issues/${ISSUE}/assignees`]: issueWith("usirin"),
+			}),
+		),
+	);
+
+	it.effect("idempotent — a gate already carrying us issues no write", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).assign(ISSUE, SID_MINE);
+			assert.deepStrictEqual(result.plan, {_tag: "already-set", login: "usirin"});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: ownClaim,
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				"GET user": "usirin\n",
+				[`GET ${P}/issues/${ISSUE}`]: issueWith("usirin"),
+				[`POST ${P}/issues/${ISSUE}/assignees`]: writeIsForbidden,
+			}),
+		),
+	);
+
+	it.effect("DEFAULT-DENY: a foreign claim → refuses without reading or writing the gate", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).assign(ISSUE, SID_MINE);
+			assert.deepStrictEqual(result.plan, {_tag: "refuse", reason: "lost", owner: SID_OTHER});
+			assert.deepStrictEqual(result.assignees, []);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+					claimComment({id: 500, login: "usirin", session: SID_OTHER, at: "2026-07-08T00:00:01Z"}),
+					claimComment({id: 800, login: "usirin", session: SID_MINE, at: "2026-07-08T00:00:02Z"}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				// Both the gate read and the gate write are faults: the refusal must short-circuit first.
+				[`GET ${P}/issues/${ISSUE}`]: writeIsForbidden,
+				[`POST ${P}/issues/${ISSUE}/assignees`]: writeIsForbidden,
+			}),
+		),
+	);
+
+	it.effect("DEFAULT-DENY: an unclaimed lane → refuses, never assigns off an empty claim set", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).assign(ISSUE, SID_MINE);
+			assert.deepStrictEqual(result.plan, {_tag: "refuse", reason: "no-winner", owner: null});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([]),
+				[`GET ${P}/issues/${ISSUE}`]: writeIsForbidden,
+				[`POST ${P}/issues/${ISSUE}/assignees`]: writeIsForbidden,
+			}),
+		),
+	);
+
+	it.effect("a write that does not land fails LOUD rather than reporting the gate set", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip((yield* Github).assign(ISSUE, SID_MINE));
+			assert.strictEqual(error._tag, "@kampus/claim/ClaimVerifyError");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: ownClaim,
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				"GET user": "usirin\n",
+				[`GET ${P}/issues/${ISSUE}`]: issueWith(),
+				// the POST "succeeds" but the gate reads back empty — the class the read-back exists for
+				[`POST ${P}/issues/${ISSUE}/assignees`]: issueWith(),
+			}),
+		),
 	);
 });
 

--- a/packages/pipeline-cli/src/tools/claim/github.ts
+++ b/packages/pipeline-cli/src/tools/claim/github.ts
@@ -8,10 +8,11 @@
  * every infra failure a typed error in the `E` channel (`.patterns/effect-errors.md`)
  * — a non-zero `gh` exit is `GhCommandError`, malformed output is `GhParseError`, an
  * unresolvable repo is `RepoResolutionError` — and Schema-decoded untrusted REST JSON
- * at the boundary. `isMine` and `status` only read; `release` is the one mutation, and
- * it deletes **only** comment ids the pure `releasePlan` proved carry our own token.
- * No label, no claim write — posting a claim stays `pipeline-cli tracker claim`'s job,
- * so this tool never becomes a second claim writer.
+ * at the boundary. `isMine` and `status` only read; `release` deletes **only** comment ids the
+ * pure `releasePlan` proved carry our own token, and `assign` writes **only** the coarse
+ * availability gate (§7 layer one) on a lane whose claim resolved as ours. No claim write —
+ * posting a claim stays `pipeline-cli tracker claim`'s job, so this tool never becomes a second
+ * claim writer; layer one is a different layer, not a second claim.
  */
 import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
@@ -20,6 +21,7 @@ import {livenessByComment} from "../epic-lock/claim-presence.ts";
 import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
 import {localPresence} from "../epic-lock/presence-io.ts";
 import {deleteCommentArgs} from "../tracker/gh-io.ts";
+import {type AssignPlan, assignPlan} from "./claim-assign.ts";
 import {
 	type AuditPolicy,
 	type AuditReport,
@@ -46,6 +48,18 @@ export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
 	"@kampus/claim/GhParseError",
 	{
 		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/**
+ * An `assign` wrote layer one and the read-back did not carry our login. The read-back folds INTO
+ * the write so a caller can never report the availability gate set when it is not — that false
+ * report is the whole failure this verb exists to end (#4298), so it fails loud instead.
+ */
+export class ClaimVerifyError extends Schema.TaggedErrorClass<ClaimVerifyError>()(
+	"@kampus/claim/ClaimVerifyError",
+	{
 		message: Schema.String,
 	},
 ) {}
@@ -146,6 +160,25 @@ const listCommentsArgs = (repo: string, issue: number): ReadonlyArray<string> =>
 	`repos/${repo}/issues/${issue}/comments?per_page=100`,
 ];
 
+const issueArgs = (repo: string, issue: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${issue}`,
+];
+
+// Layer one is written with the additive assignees endpoint — it co-assigns and never displaces,
+// which is precisely why it is a coarse availability gate and not a claim (§7). There is no
+// DELETE counterpart anywhere in this tool.
+const addAssigneeArgs = (repo: string, issue: number, login: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${issue}/assignees`,
+	"-f",
+	`assignees[]=${login}`,
+];
+
+const whoAmIArgs: ReadonlyArray<string> = ["api", "user", "--jq", ".login"];
+
 const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
 	"api",
 	`repos/${repo}/collaborators/${login}/permission`,
@@ -226,6 +259,62 @@ const isMine = Effect.fn("Github.isMine")(function* (
 	// mine. Every indeterminate claimant (unstamped, another host, unprobeable pid) still counts.
 	const liveness = livenessByComment(comments, localPresence());
 	return claimIsMine({comments, authorizedAuthors: authorized, sessionId, liveness});
+});
+
+/** An issue as the issues endpoint returns it; only the availability gate is read. */
+const RawAssignedIssue = Schema.Struct({
+	assignees: Schema.optionalKey(Schema.NullOr(Schema.Array(Schema.Struct({login: Schema.String})))),
+});
+const decodeAssignedIssue = Schema.decodeUnknownEffect(RawAssignedIssue);
+
+const assigneeLogins = Effect.fn("Github.assigneeLogins")(function* (args: ReadonlyArray<string>) {
+	const issue = yield* decodeAssignedIssue(yield* json(args));
+	return (issue.assignees ?? []).map((a) => a.login);
+});
+
+/** What an assign resolved to, and the availability gate as it stands after the verb ran. */
+export interface AssignResult {
+	readonly plan: AssignPlan;
+	readonly assignees: ReadonlyArray<string>;
+}
+
+/**
+ * Write §7 layer one — the coarse availability gate — on a lane whose claim is ours (#4298).
+ *
+ * Ownership is resolved through the same default-deny `isMine` the mis-attribution guard uses, and
+ * a refusal short-circuits **before any read of the gate**: an un-owned lane is never even measured,
+ * let alone written. On a proven-own lane the write is additive and idempotent (the pure
+ * `assignPlan` decides), and the POST's response is decoded as the read-back — a landed gate that
+ * does not carry our login raises `ClaimVerifyError` rather than reporting a gate that isn't there.
+ */
+const assign = Effect.fn("Github.assign")(function* (
+	repo: string,
+	issue: number,
+	sessionId: string | null,
+) {
+	const verdict = yield* isMine(repo, issue, sessionId);
+	if (!verdict.mine) {
+		return {
+			plan: assignPlan({verdict, login: "", assignees: []}),
+			assignees: [],
+		} satisfies AssignResult;
+	}
+	const login = yield* runGh(whoAmIArgs).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/claim/GhCommandError", () => Effect.succeed("")),
+	);
+	const before = yield* assigneeLogins(issueArgs(repo, issue));
+	const plan = assignPlan({verdict, login, assignees: before});
+	if (plan._tag !== "assign") {
+		return {plan, assignees: before} satisfies AssignResult;
+	}
+	const landed = yield* assigneeLogins(addAssigneeArgs(repo, issue, plan.login));
+	if (!landed.some((a) => a.toLowerCase() === plan.login.toLowerCase())) {
+		return yield* new ClaimVerifyError({
+			message: `assigned #${issue} to ${plan.login} but the gate read back as [${landed.join(", ") || "empty"}] — refusing to report layer one set when it is not (#4298)`,
+		});
+	}
+	return {plan, assignees: landed} satisfies AssignResult;
 });
 
 /** A clean 404 — the only `gh` failure that means "the comment is already gone". */
@@ -382,6 +471,13 @@ export class Github extends Context.Service<
 			ReleasePlan,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
 		>;
+		readonly assign: (
+			issue: number,
+			sessionId: string | null,
+		) => Effect.Effect<
+			AssignResult,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError | ClaimVerifyError
+		>;
 		readonly status: (
 			issue: number,
 		) => Effect.Effect<
@@ -419,6 +515,8 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 					repo.pipe(Effect.flatMap((r) => withSpawner(isMine(r, issue, sessionId)))),
 				release: (issue: number, sessionId: string) =>
 					repo.pipe(Effect.flatMap((r) => withSpawner(release(r, issue, sessionId)))),
+				assign: (issue: number, sessionId: string | null) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(assign(r, issue, sessionId)))),
 				status: (issue: number) => repo.pipe(Effect.flatMap((r) => withSpawner(status(r, issue)))),
 				audit: (options) => repo.pipe(Effect.flatMap((r) => withSpawner(audit(r, options)))),
 			};


### PR DESCRIPTION
When an orchestrator hands an issue to a coder, the issue was being left with **nobody's name on it** the moment the PR opened — so another agent scanning for work could pick it up and re-implement something already finished and waiting on review. This PR makes the party that wins the claim also mark the issue as taken, on every path, and gives that write a single fail-closed tool instead of a line of prose in one orchestrator's prompt.

Fixes #4298

## What was broken

The claim is two layers (`gh-issue-intake-formats.md` §7): the **assignee** is the coarse availability gate the `write-code` Step-1 picker reads, and the **session-stamped claim comment** is the fine resolver. The picker never reads the claim comment, so while a PR is in review the assignee is the *only* thing keeping a finished lane out of the claimable pool.

On the delegated (orchestrated) path nobody the contract named wrote it:

1. `write-code` Step 3's orchestrated branch skips the direct-path block — which carries *both* the claim comment and the self-assign — and the skill never re-assigned the second half.
2. The obligation survived only inside `.claude/workflows/drive-issue.js`'s inline claim-agent prompt, so any other dispatcher (a crew engine threading a token by hand) satisfied the delegated-claim contract in full while leaving the gate unset.
3. Step 8 then released layer two citing a backstop — *"release … leaves the assignee set"* — that on that path did not exist.

Live confirmation while building this: **#4298 itself was `status:triaged`, `p1`, claimed, and unassigned** when this lane started — exactly the reported shape.

## What changed

**One producer for layer one — `pipeline-cli claim assign --issue <N> [--session <token>]`.**
It resolves ownership through the same default-deny resolution `claim is-mine` uses and **refuses (non-zero, no write) on any lane it cannot prove is ours** — absent claim, foreign owner, and missing session each refuse, and the refusal short-circuits before the gate is even read. On a proven-own lane it is **additive and idempotent** (a gate already carrying us is a no-op) and the landed gate is **read back**, so a write that did not take fails loud instead of reporting a gate that isn't there. It has **no removal arm at all**, so "never unassign a slot you did not fill" (#4015) holds by construction rather than by review.

**The contract names the owing party, for every dispatcher.** §7 gains *Who writes layer one — the claim winner, on BOTH paths*: the dispatcher owes it pre-spawn on the delegated path, the coder owes it at Step 3 on the direct path, and the coder **re-asserts it idempotently** once its claim is confirmed — which is what makes the gate true *for the whole build* whatever dispatched the lane. The pre-spawn protocol bullet now binds every dispatcher, not just `drive-issue.js`, and `drive-issue.js`'s claim-agent prompt routes its step (4) through the verb instead of a hand-rolled assignees POST.

**Step 8 no longer asserts an unverified backstop.** Its release paragraph cites where the gate was written (Step 3, both paths) and names the case it used to hide; the same qualification lands on §7's release section. Release still never touches the assignee.

## Acceptance criteria

- **Layer one held for the whole build on the delegated path** — Step 3's orchestrated branch confirms delegation through `claim is-mine`, then ensures the gate through `claim assign`, before implementing.
- **The obligation is in the shared contract, naming the party** — §7 *Who writes layer one* + `write-code` Step 3; it no longer lives only inside one orchestrator's prompt.
- **Step 8's justification is made true on both paths** and rewritten to cite where the gate comes from.
- **No eviction, no inference from absence (ADR 0215 §5)** — the verb writes because the run *holds* the lane (positively resolved), never because a missing assignee was read as evidence about another party. Nothing keys on age, and no code path can clear a marker or a slot.
- **Picker semantics unchanged** — Step 1 still skips on any non-null assignee and still does not read claim comments.
- **#4145 left open** — release authority on the delegated path is explicitly out of scope and called out as such in §7 and in the commit.

## Tests

- `claim-assign.unit.test.ts` — the pure decision: assign / idempotent no-op / additive next to a foreign assignee / case-insensitive login / four default-deny refusals, plus "a not-mine verdict refuses even when the gate already carries us" (the gate is never read as ownership).
- `github-service.unit.test.ts` — the verb over a mock `gh`: writes and reads back; issues no write when already set; refuses a foreign and an unclaimed lane **without touching the gate** (both routes mapped to hard faults, so a stray call would surface); and fails loud when the write does not land.
- `adoption-lint/command.test.ts` — the corpus pins: the ordering pin now follows the verb, a pre-claim layer-one write must be ownership-gated, every claim writer routes layer one through the verb, and **`write-code`'s delegated branch must carry its own layer-one write** (a direct regression pin for this defect).

`pnpm typecheck`, `pnpm lint:worktree`, the full `pipeline-cli` suite (2842 tests), `adoption-lint check` and `gh-phoenix lint-skills` over the live corpus are all green. The verb was also exercised live against this issue: assign → idempotent re-run → refusal under a foreign token.

## Notes for the reviewer

- **Considered and not done: an `adoption-lint` DECISIONS entry for the assignees POST.** `triage` uses the assignee for its own coarse claim (POST *and* DELETE), so a fingerprint broad enough to catch a hand-rolled layer-one write also reds `triage/SKILL.md` — it would need a fresh grandfathered exemption, which the manifest exists to shrink. The enforcement here is instead the verb's default-deny + read-back and the corpus pins above.
- Classification: `cp-classify` → **control-plane (path-match, `.claude/workflows/drive-issue.js`)** — blocking, human merge.

## Deviations

None.
