### PR TITLE
fix(verdict): `read` and `gate` resolve ONE in-force verdict, §CP-aware (#4049)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
@@ -298,11 +298,29 @@ re-deriving the resolver write-code once hand-copied, and keeps only the two thi
 # `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653; ADR 0062/0064).
 VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
 
+# §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves, so pass it here
+# exactly as write-code Step R1 does (#4049): on a §CP PR the pass is the SHA-less ADVISORY, invisible
+# without --cp, so a FAIL discharged by a BODY-ONLY repair (the head never moves, so ADR 0058
+# staleness cannot retire it) would read as a live repair forever and suppress every defect filing on
+# that PR. Fail-closed on BOTH fallible inputs, exactly as write-code Step R1 is: the changed-file
+# list comes from §CPREAD's `cp_changed_files`, sourced from its canonical home (#4489), because a
+# bare `gh … | cp-classify` pipe hands the verb gh's STDOUT error document to classify and answers
+# `not-control-plane` on an unread list (#4216); and only the PROVEN `not-control-plane` state word
+# drops the flag — never a bare non-zero test, which fires on a usage error (1) or a missing bin (127).
+. "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
+else
+  CP_STATE="$(printf '%s\n' "$CP_FILES" \
+    | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" cp-classify classify --repo "$REPO" 2>/dev/null)"
+fi
+if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
+
 # a namespace is an active-repair FAIL iff its latest authorized verdict is FAIL bound to the current
 # head — exit 0 from `verdict read … --expect FAIL`. A stale / SHA-less / PASS / none verdict exits
 # non-zero, so it is correctly NOT an active repair, matching write-code's no-op on it.
-CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code --expect FAIL 2>/dev/null)" && CODE_FAIL=1 || CODE_FAIL=0
-DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc  --expect FAIL 2>/dev/null)" && DOC_FAIL=1  || DOC_FAIL=0
+CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code $CP_FLAG --expect FAIL 2>/dev/null)" && CODE_FAIL=1 || CODE_FAIL=0
+DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc  $CP_FLAG --expect FAIL 2>/dev/null)" && DOC_FAIL=1  || DOC_FAIL=0
 
 # UNRESOLVED ≠ "no FAIL". The verb prints its outcome JSON on BOTH exit paths, so absent JSON means the
 # namespace never resolved (a transport/5xx failure). Reading that as "no repair in flight" would file

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -637,12 +637,15 @@ all, a verdict bound to a stale head, a SHA-less pre-0058 marker, a §CP advisor
 required set** (zero required gates would make the conjunction vacuously true — an un-gated merge
 dressed as a pass, ADR 0092), and an unresolvable head.
 
-**`--cp` is load-bearing in both directions.** A §CP PR's only verdict is the SHA-less advisory, so
-`verdict read --gate code` legitimately resolves `_tag: none` on it — that `none` is the **expected**
-§CP shape, not an absent verdict, and a §CP PR must **never** be required to carry (nor be satisfied
-by) a bindable first-line `PASS @ <sha>` (that drops the §CP verdict into the auto-merge namespace,
-the ADR 0111 hazard). Pass `--cp` **only** for a PR Step 0 classified §CP whose control-plane
-approval gate already passed; without it the advisory is correctly not a pass.
+**`--cp` is load-bearing in both directions, and it belongs on `read` too.** A §CP PR's pass is the
+SHA-less advisory, which a `read` **without** `--cp` cannot see at all — it resolves `_tag: none`,
+the **expected** §CP shape, not an absent verdict — and a §CP PR must **never** be required to carry
+(nor be satisfied by) a bindable first-line `PASS @ <sha>` (that drops the §CP verdict into the
+auto-merge namespace, the ADR 0111 hazard). Pass `--cp` **only** for a PR Step 0 classified §CP whose
+control-plane approval gate already passed; without it the advisory is correctly not a pass. Pass the
+**same** `$CP_FLAG` to the code-namespace `verdict read` in the native-review fold below: both verbs
+resolve one in-force verdict from the same (PR, gate, head, §CP-ness) tuple, so feeding them
+different §CP-ness is the only way left to make them disagree (#4049).
 
 **The one signal the verb does not read — apply it on top.** `verdict gate` reads marker/advisory
 *comments*, not GitHub's native reviews. So a green `verdict gate` is **necessary, not sufficient**:

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh
@@ -34,14 +34,21 @@ VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli 
 # not reviews. The per-namespace PASS/FAIL conjunction across doc / skill / design was already
 # decided by the `verdict gate` call above, which runs FIRST and refuses on non-zero; re-resolving
 # those three here set six variables nothing read, at six subprocess spawns per ship (#4405).
-# CODE_PASS=1 iff a current-head PASS marker; CODE_FAIL=1 iff a current-head FAIL (the veto). A
+# CODE_PASS=1 iff a current-head pass; CODE_FAIL=1 iff a current-head FAIL (the veto). A
 # stale / SHA-less / none verdict exits non-zero on BOTH, so it is neither — Step 2b's `unverified
-# (verdict not bound to current head)` refusal, owned by the verb. (A §CP advisory namespace is
-# SHA-less by design and resolves `none` here; `verdict gate --cp` reads its body Reviewed-head.)
+# (verdict not bound to current head)` refusal, owned by the verb.
 # The stdout JSON is kept because it carries `writtenAt`, the resolving verdict's WRITE time, which
 # is what the newest-wins fold below compares (#4200).
-CODE_JSON="$($VERDICT read --pr "$PR" --gate code --expect PASS 2>/dev/null)" && CODE_PASS=1 || CODE_PASS=0
-$VERDICT read --pr "$PR" --gate code   --expect FAIL >/dev/null 2>&1 && CODE_FAIL=1   || CODE_FAIL=0
+#
+# `$CP_FLAG` is the SAME value `step2-verdict-gate.sh` passed to `verdict gate`, and passing it here
+# is load-bearing, not symmetry: §CP-ness is part of the (PR, gate, head, §CP-ness) tuple the verb
+# resolves. Omit it on a §CP PR and the advisory is invisible to `read`, so a FAIL discharged by a
+# BODY-ONLY repair — which deliberately never moves the head, so ADR 0058 staleness cannot retire it
+# — stays resolvable as the in-force verdict forever, and `read` disagrees with `gate` on the same
+# markers (#4049). With it, a current-head all-PASS advisory IS the namespace's pass and supersedes
+# the older FAIL.
+CODE_JSON="$($VERDICT read --pr "$PR" --gate code $CP_FLAG --expect PASS 2>/dev/null)" && CODE_PASS=1 || CODE_PASS=0
+$VERDICT read --pr "$PR" --gate code   $CP_FLAG --expect FAIL >/dev/null 2>&1 && CODE_FAIL=1   || CODE_FAIL=0
 
 # fold the native decisive review into the code namespace (the verb reads only marker comments). Only
 # a review bound to the current head counts (same ADR-0058 staleness as a marker's @ <sha>).

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -203,6 +203,9 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
   echo "  Resolve to UNKNOWN, never to 'no FAIL'. This is a resolution gap, NOT worktree teardown (§CLI)." >&2
   exit 127
 }
+# §CPREAD's `cp_changed_files`, sourced from its canonical home — no skill-local copy to drift
+# (#4489). It feeds the per-PR §CP-ness derivation inside the loop.
+. "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
 # open PRs you authored; print each one whose latest verdict in EITHER namespace is FAIL,
 # UNLESS it has already hit the N=3 repair cap (then it's a human's, not yours to re-pick)
 gh api "repos/$REPO/pulls?state=open&per_page=100" \
@@ -236,13 +239,31 @@ gh api "repos/$REPO/pulls?state=open&per_page=100" \
          then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
      | .n' "$comments_file")
   [ "$ROUNDS" -ge 3 ] && continue   # at the cap → already escalated to a human, excluded from the scan
+  # §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves (#4049). On a §CP
+  # PR the pass is the SHA-less ADVISORY, which a read without --cp cannot see at all — so a FAIL
+  # discharged by a BODY-ONLY repair (which deliberately never moves the head, so ADR 0058 staleness
+  # can never retire it) reads as a standing FAIL forever and pulls this scan into a phantom repair.
+  # Derive it per PR, fail-closed on BOTH fallible inputs: the changed-file list is a network read, so
+  # it comes from `cp_changed_files` and never a bare `gh … | cp-classify` pipe, which with pipefail
+  # off hands the verb gh's STDOUT error document and answers `not-control-plane` on an unread list
+  # (#4216); and only the PROVEN `not-control-plane` state word drops the flag — never `… ||
+  # CP_FLAG=""` on mere non-zero, which fires on a usage error (1) or a missing bin (127).
+  # `>&2` routes only the §ZS scope LINE, not the result: `cp_changed_files` returns its file list in
+  # $CP_FILES, and this loop's stdout is the repairable-PR list the caller reads. The scope line is
+  # still emitted (§ZS #1), on the same stream as this helper's failure lines.
+  if ! cp_changed_files "$REPO" "$PR" >&2; then
+    CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
+  else
+    CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO" 2>/dev/null)"
+  fi
+  if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
   # resolve each namespace's latest current-head verdict through the shared verb — exit 0 iff HEAD
   # carries a current FAIL in that gate (a stale / SHA-less / PASS / none verdict exits non-zero).
   # stderr is NOT discarded and 127 is read apart from an ordinary negative: with `2>&1` swallowing
   # it, a `command not found` was byte-identical to "no FAIL verdict" and the PR dropped out of the
   # scan silently (§CLI exit-code taxonomy — "could not run" is never a verdict; #4398, #4236).
   for G in code doc skill; do
-    "$PCLI" verdict read --pr "$PR" --gate "$G" --expect FAIL >/dev/null
+    "$PCLI" verdict read --pr "$PR" --gate "$G" $CP_FLAG --expect FAIL >/dev/null
     RC=$?
     case $RC in
       0)   echo "#$PR review-$G FAIL" ;;
@@ -1864,13 +1885,24 @@ while IFS= read -r a; do
   esac
 done <<<"$markerAuthors"
 
+# §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves (#4049) — see the
+# Step-1 pre-pick scan for the full why, including why the file list comes from `cp_changed_files`
+# instead of a fail-OPEN `gh … | cp-classify` pipe.
+. "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
+else
+  CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO" 2>/dev/null)"
+fi
+if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
+
 # a namespace is a repairable FAIL iff its latest authorized verdict is FAIL bound to the current head
 # — exit 0 from `verdict read … --expect FAIL`. The verb's JSON (stdout) carries the resolving comment
 # id, which Step R2 uses to read the FAIL body. A stale / SHA-less / PASS / none verdict exits non-zero,
 # so it is correctly NOT repaired (idempotent no-op), needing no separate staleness test here.
-CODE_FAIL_JSON="$("$PCLI" verdict read --pr "$PR" --gate code  --expect FAIL 2>/dev/null)"  && CODE_FAIL=1  || CODE_FAIL=0
-DOC_FAIL_JSON="$("$PCLI"  verdict read --pr "$PR" --gate doc   --expect FAIL 2>/dev/null)"  && DOC_FAIL=1   || DOC_FAIL=0
-SKILL_FAIL_JSON="$("$PCLI" verdict read --pr "$PR" --gate skill --expect FAIL 2>/dev/null)" && SKILL_FAIL=1 || SKILL_FAIL=0
+CODE_FAIL_JSON="$("$PCLI" verdict read --pr "$PR" --gate code  $CP_FLAG --expect FAIL 2>/dev/null)"  && CODE_FAIL=1  || CODE_FAIL=0
+DOC_FAIL_JSON="$("$PCLI"  verdict read --pr "$PR" --gate doc   $CP_FLAG --expect FAIL 2>/dev/null)"  && DOC_FAIL=1   || DOC_FAIL=0
+SKILL_FAIL_JSON="$("$PCLI" verdict read --pr "$PR" --gate skill $CP_FLAG --expect FAIL 2>/dev/null)" && SKILL_FAIL=1 || SKILL_FAIL=0
 
 # UNRESOLVED ≠ "no FAIL". `verdict read` prints its outcome JSON on BOTH exit paths, so absent JSON
 # means the namespace never resolved at all (a transport/5xx error, not a verdict). Under a flaky
@@ -1925,8 +1957,11 @@ review), `DOC_FAIL=1`, or `SKILL_FAIL=1`. `verdict read` already encapsulates la
 SHA-staleness refusal: a newer FAIL is acted on even if an older PASS exists, but a FAIL whose `@ <sha>`
 is not the current head (or carries no `@ <sha>` — a pre-0058 legacy marker) resolves `stale`/`sha-less`,
 exits non-zero, and is **not** repaired — report `nothing to repair (latest FAIL not bound to current
-head)` and stop. A `review-skill: advisory` line (a blocking-set skill PR) is not a FAIL — `verdict read`
-resolves it `none` (no PASS/FAIL polarity), a clean no-op like a PASS. This keeps repair mode
+head)` and stop. A `review-skill: advisory` line (a blocking-set skill PR) is never a FAIL: without
+`--cp` it resolves `none` (no first-line polarity) and with `--cp` it resolves the §CP pass, so both
+are a clean no-op. Passing `--cp` is what makes the §CP case *correct* rather than merely quiet — a
+current-head all-PASS advisory then supersedes an older same-head FAIL that a body-only repair
+already discharged, instead of leaving that FAIL resolvable forever (#4049). This keeps repair mode
 **idempotent**: re-running it on an already-fixed/PASS PR, a no-FAIL PR, or a stale-FAIL PR is a clean
 no-op. If **more than one** namespace resolves FAIL (a mixed PR — e.g. code+doc, or skill+code), address
 **all** of them in this round.

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -4,7 +4,7 @@
  * The ADR-0058 SHA-bound verdict read/post glue, extracted from the inline `jq` the
  * `review-*` / `ship-it` / `write-code`-repair / `heal-ci` skills each hand-rolled (#2102).
  *
- * `read --pr N --gate <g> [--expect PASS|FAIL] [--head <sha>]` resolves the (PR, gate)
+ * `read --pr N --gate <g> [--cp] [--expect PASS|FAIL] [--head <sha>]` resolves the (PR, gate)
  * verdict against the PR's current head (author-gated to write+ collaborators, ADR 0055) and
  * **exits 0 only when HEAD is reviewed with the expected polarity** (default PASS) — every
  * refusal (`none`/`sha-less`/`stale`, or a current verdict of the wrong polarity) prints its
@@ -12,6 +12,12 @@
  * outcome is printed as JSON on stdout for a caller that wants the detail (comment id, sha, and
  * `writtenAt` — when the resolving verdict was WRITTEN, which is what a skill's review-vs-marker
  * fold must compare against a review's `submitted_at`, never the comment's `created_at`, #4200).
+ *
+ * **Pass `--cp` on a §CP PR, exactly as `gate` takes it.** `read` and `gate` resolve through the one
+ * `decideNamespace`, so they answer the same (PR, gate, head, §CP-ness) identically — but §CP-ness is
+ * part of that tuple. Omit `--cp` on a §CP PR and the advisory is invisible, which is how a
+ * superseded FAIL stayed resolvable forever after a body-only repair that deliberately never moved
+ * the head (#4049). Derive the flag once per PR with `pipeline-cli cp-classify classify`.
  *
  * `gate --pr N --require <namespaces> [--cp]` is the SET-level counterpart `read` cannot be: it
  * folds the same resolution over EVERY namespace the diff requires and exits 0 only when each one
@@ -109,13 +115,19 @@ const parseExpect = (raw: Option.Option<string>): Effect.Effect<Polarity, never>
 	return fail(`invalid --expect '${Option.getOrElse(raw, () => "")}' — expected PASS or FAIL`);
 };
 
+const cpFlag = Flag.boolean("cp").pipe(
+	Flag.withDescription(
+		"this is a §CP (control-plane / blocking-set) PR: accept the canonical SHA-less advisory + body `Reviewed-head` as the pass (ADR 0111/0151)",
+	),
+);
+
 const read = Command.make(
 	"read",
-	{pr: prFlag, gate: gateFlag, head: headFlag, expect: expectFlag},
-	Effect.fn(function* ({pr, gate, head, expect}) {
+	{pr: prFlag, gate: gateFlag, cp: cpFlag, head: headFlag, expect: expectFlag},
+	Effect.fn(function* ({pr, gate, cp, head, expect}) {
 		const g = yield* parseGate(gate);
 		const polarity = yield* parseExpect(expect);
-		const result = yield* (yield* Github).read(pr, g, polarity, Option.getOrUndefined(head));
+		const result = yield* (yield* Github).read(pr, g, polarity, cp, Option.getOrUndefined(head));
 		// The resolved detail goes to stdout as JSON (a caller may want the comment id / bound sha /
 		// write time); the human-readable verdict + refusal reason goes to stderr, mirroring resume-policy.
 		yield* Console.log(
@@ -123,6 +135,7 @@ const read = Command.make(
 				...result.outcome,
 				headSha: result.headSha,
 				gate: g,
+				form: result.form,
 				writtenAt: result.writtenAt,
 			}),
 		);
@@ -147,12 +160,6 @@ const read = Command.make(
 const requireFlag = Flag.string("require").pipe(
 	Flag.withDescription(
 		"the required review namespaces, comma/space separated (`review-code,review-doc` or `code,doc`) — derive with `pipeline-cli class-probe classify --namespaces`",
-	),
-);
-
-const cpFlag = Flag.boolean("cp").pipe(
-	Flag.withDescription(
-		"this is a §CP (control-plane / blocking-set) PR: accept the canonical SHA-less advisory + body `Reviewed-head` as the pass (ADR 0111/0151)",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
@@ -25,12 +25,17 @@ import {
 	compareWriteRecency,
 	GATE_KEYWORD,
 	isBoundToHead,
-	parseVerdict,
+	outcomeCommentId,
+	outcomeSha,
 	pickInForce,
 	polarityRe,
+	resolveVerdict,
 	reviewedHeadSha,
 	type VerdictComment,
 	type VerdictGate,
+	type VerdictOutcome,
+	type VerdictState,
+	verdictState,
 } from "./verdict-match.ts";
 
 /**
@@ -48,7 +53,15 @@ const failCheckboxRe = /^\s*[-*]?\s*\[\s*FAIL\s*\]/im;
 /** Which verdict FORM satisfied (or was found in) a namespace — the ADR 0111 distinction. */
 export type VerdictForm = "marker" | "advisory" | "none";
 
-/** One required namespace's resolved state against the PR's live head. */
+/**
+ * One namespace's resolved verdict against the PR's live head — the SINGLE resolution record both
+ * `verdict gate` and `verdict read` are computed from (#4049 AC2).
+ *
+ * `outcome` is the resolution; `state`, `commentId` and `sha` are DERIVED from it, never computed a
+ * second way. That is what makes the two verbs structurally unable to disagree: `gate` reads
+ * `state`, `read` prints `outcome` and tests it with `isReviewed`, and both go through
+ * `verdictState`.
+ */
 export interface NamespaceDecision {
 	readonly gate: VerdictGate;
 	/** `review-code` / `review-doc` / `review-skill` / `review-design` — the namespace label. */
@@ -59,18 +72,28 @@ export interface NamespaceDecision {
 	 * `absent` — NO consumable verdict exists in this namespace at all (the #3944 hole).
 	 * `unverified` — a verdict exists but is not bound to the live head (stale / SHA-less / not-all-PASS).
 	 */
-	readonly state: "pass" | "fail" | "absent" | "unverified";
+	readonly state: VerdictState;
 	readonly form: VerdictForm;
+	/** The resolved verdict itself — what `verdict read` prints and branches on. */
+	readonly outcome: VerdictOutcome;
 	readonly commentId: number | null;
 	/** The head the found verdict binds, when it binds one. */
 	readonly sha: string | null;
 	readonly reason: string;
 }
 
-export interface GateDecisionInput {
+/** The per-namespace inputs — `GateDecisionInput` minus the required SET (a property of the whole PR). */
+export interface NamespaceInput {
 	readonly comments: ReadonlyArray<VerdictComment>;
 	/** The write+ collaborator logins — the ADR 0055 trust root (resolved by the IO shell). */
 	readonly authorizedAuthors: ReadonlyArray<string>;
+	/** The PR's live head SHA — the head every verdict must bind (ADR 0058 rule 3). */
+	readonly headSha: string;
+	/** Is this a §CP (control-plane / blocking-set) PR, whose pass path is the advisory (ADR 0111/0151)? */
+	readonly controlPlane: boolean;
+}
+
+export interface GateDecisionInput extends NamespaceInput {
 	/**
 	 * Every namespace this PR's diff requires — the `class-probe classify --namespaces` set, which
 	 * derives one gate per artifact class present plus `review-design` when the diff is UI-affecting.
@@ -78,10 +101,6 @@ export interface GateDecisionInput {
 	 * (`.glossary/**` rides has-code), and satisfying only one must not be enough.
 	 */
 	readonly requiredGates: ReadonlyArray<VerdictGate>;
-	/** The PR's live head SHA — the head every verdict must bind (ADR 0058 rule 3). */
-	readonly headSha: string;
-	/** Is this a §CP (control-plane / blocking-set) PR, whose pass path is the advisory (ADR 0111/0151)? */
-	readonly controlPlane: boolean;
 }
 
 export interface GateDecision {
@@ -120,9 +139,97 @@ const inForceOf = (
 	return newerOf(a, b);
 };
 
-const decideNamespace = (gate: VerdictGate, input: GateDecisionInput): NamespaceDecision => {
+/** What an arm resolves; `state`/`commentId`/`sha` are then derived from `outcome`, never restated. */
+interface Resolution {
+	readonly outcome: VerdictOutcome;
+	readonly form: VerdictForm;
+	readonly reason: string;
+}
+
+/**
+ * The §CP advisory arm: classify an advisory that won the in-force pick by its ADR-0151 body anchor.
+ * The marker arm is `resolveVerdict` (which this file does not duplicate) — the two are the only
+ * ways a namespace resolves.
+ */
+const resolveAdvisory = (
+	advisory: VerdictComment,
+	namespace: string,
+	headSha: string,
+): Resolution => {
+	const sha = reviewedHeadSha(advisory.body);
+	if (sha === null) {
+		return {
+			outcome: {_tag: "sha-less", commentId: advisory.id, polarity: "PASS"},
+			form: "advisory",
+			reason: `unverified (§CP ${namespace} advisory carries no 'Reviewed-head: @ <sha>' body binding — an advisory is SHA-less in line 1 by design, so the body anchor is its only head binding, ADR 0151)`,
+		};
+	}
+	if (!isBoundToHead(sha, headSha)) {
+		return {
+			outcome: {_tag: "stale", commentId: advisory.id, polarity: "PASS", sha},
+			form: "advisory",
+			reason: `unverified (§CP ${namespace} advisory reviewed-head stale — body @ ${sha} ≠ current head ${headSha})`,
+		};
+	}
+	if (failCheckboxRe.test(advisory.body)) {
+		return {
+			outcome: {_tag: "advisory-not-all-pass", commentId: advisory.id, sha},
+			form: "advisory",
+			reason: `unverified (§CP ${namespace} advisory not all-PASS — a body checkbox is [FAIL])`,
+		};
+	}
+	return {
+		outcome: {_tag: "current", commentId: advisory.id, polarity: "PASS", sha},
+		form: "advisory",
+		reason: `§CP ${namespace} advisory at the current head, all-PASS — the ADR 0111/0151 PASS-equivalent`,
+	};
+};
+
+/**
+ * The marker arm — DELEGATED to `resolveVerdict` rather than re-deriving its four-way
+ * classification: it re-runs the identical `pickInForce(polarityRe(gate), …)` call that produced the
+ * marker candidate, so it resolves the same comment by construction, and ADR 0058's staleness rule
+ * stays written in exactly one place. Only the reason line is this file's.
+ */
+const resolveMarker = (gate: VerdictGate, namespace: string, input: NamespaceInput): Resolution => {
+	const outcome = resolveVerdict({
+		comments: input.comments,
+		authorizedAuthors: input.authorizedAuthors,
+		gate,
+		headSha: input.headSha,
+	});
+	return {
+		outcome,
+		form: outcome._tag === "none" ? "none" : "marker",
+		reason: markerReason(outcome, namespace, input.headSha),
+	};
+};
+
+/** The marker arm's reason line — the classification itself is `resolveVerdict`'s. */
+const markerReason = (outcome: VerdictOutcome, namespace: string, headSha: string): string => {
+	switch (outcome._tag) {
+		case "none":
+			return `unverified (no ${namespace} PASS): the latest authorized comment in this namespace carries no readable polarity`;
+		case "sha-less":
+			return `unverified (verdict not bound to current head): the latest ${namespace} marker is SHA-less (pre-0058)`;
+		case "stale":
+			return `unverified (verdict not bound to current head): the latest ${namespace} marker binds ${outcome.sha}, not the current head ${headSha}`;
+		case "current":
+			return outcome.polarity === "PASS"
+				? `current-head ${namespace} PASS @ ${outcome.sha}`
+				: `latest verdict is FAIL (${namespace}) @ ${outcome.sha}`;
+		case "advisory-not-all-pass":
+			// Unreachable: `resolveVerdict` is polarity-scoped and never sees an advisory.
+			return `unverified (${namespace}): an advisory reached the marker arm`;
+	}
+};
+
+/**
+ * Resolve ONE namespace against the live head — the single in-force resolution `verdict gate` folds
+ * over its required set and `verdict read` reads for its one gate (#4049).
+ */
+export const decideNamespace = (gate: VerdictGate, input: NamespaceInput): NamespaceDecision => {
 	const namespace = GATE_KEYWORD[gate];
-	const base = {gate, namespace} as const;
 	const marker = pickInForce(
 		input.comments,
 		input.authorizedAuthors,
@@ -131,111 +238,34 @@ const decideNamespace = (gate: VerdictGate, input: GateDecisionInput): Namespace
 		input.headSha,
 	);
 	// A non-§CP PR's advisory is NOT a candidate at all: it carries no bindable head and is not a
-	// PASS, so it must neither satisfy the namespace nor shadow an older bindable marker — exactly
-	// what `verdict read` already does by matching on `polarityRe` only.
+	// PASS, so it must neither satisfy the namespace nor shadow an older bindable marker.
 	const advisory = input.controlPlane
 		? pickInForce(input.comments, input.authorizedAuthors, advisoryRe(gate), gate, input.headSha)
 		: undefined;
 	const latest = inForceOf(marker, advisory, gate, input.headSha);
 
-	if (latest === undefined) {
-		return {
-			...base,
-			state: "absent",
-			form: "none",
-			commentId: null,
-			sha: null,
-			reason: input.controlPlane
-				? `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR — neither a bindable PASS marker nor a §CP advisory`
-				: `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR at all`,
-		};
-	}
+	const resolution: Resolution =
+		latest === undefined
+			? {
+					outcome: {_tag: "none"},
+					form: "none",
+					reason: input.controlPlane
+						? `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR — neither a bindable PASS marker nor a §CP advisory`
+						: `unverified (no ${namespace} PASS): no authorized ${namespace} verdict on this PR at all`,
+				}
+			: latest === advisory
+				? resolveAdvisory(latest, namespace, input.headSha)
+				: resolveMarker(gate, namespace, input);
 
-	if (latest === advisory) {
-		const sha = reviewedHeadSha(latest.body);
-		if (sha === null) {
-			return {
-				...base,
-				state: "unverified",
-				form: "advisory",
-				commentId: latest.id,
-				sha: null,
-				reason: `unverified (§CP ${namespace} advisory carries no 'Reviewed-head: @ <sha>' body binding — an advisory is SHA-less in line 1 by design, so the body anchor is its only head binding, ADR 0151)`,
-			};
-		}
-		if (!isBoundToHead(sha, input.headSha)) {
-			return {
-				...base,
-				state: "unverified",
-				form: "advisory",
-				commentId: latest.id,
-				sha,
-				reason: `unverified (§CP ${namespace} advisory reviewed-head stale — body @ ${sha} ≠ current head ${input.headSha})`,
-			};
-		}
-		if (failCheckboxRe.test(latest.body)) {
-			return {
-				...base,
-				state: "unverified",
-				form: "advisory",
-				commentId: latest.id,
-				sha,
-				reason: `unverified (§CP ${namespace} advisory not all-PASS — a body checkbox is [FAIL])`,
-			};
-		}
-		return {
-			...base,
-			state: "pass",
-			form: "advisory",
-			commentId: latest.id,
-			sha,
-			reason: `§CP ${namespace} advisory at the current head, all-PASS — the ADR 0111/0151 PASS-equivalent`,
-		};
-	}
-
-	// `polarityRe` matched, so `parseVerdict` cannot be null here — the `?? null` collapses the
-	// unreachable branch into the same fail-closed `absent` rather than asserting non-null.
-	const parsed = parseVerdict(latest.body, gate);
-	if (parsed === null) {
-		return {
-			...base,
-			state: "absent",
-			form: "none",
-			commentId: latest.id,
-			sha: null,
-			reason: `unverified (no ${namespace} PASS): the latest authorized comment in this namespace carries no readable polarity`,
-		};
-	}
-	if (parsed.sha === null) {
-		return {
-			...base,
-			state: "unverified",
-			form: "marker",
-			commentId: latest.id,
-			sha: null,
-			reason: `unverified (verdict not bound to current head): the latest ${namespace} marker is SHA-less (pre-0058)`,
-		};
-	}
-	if (!isBoundToHead(parsed.sha, input.headSha)) {
-		return {
-			...base,
-			state: "unverified",
-			form: "marker",
-			commentId: latest.id,
-			sha: parsed.sha,
-			reason: `unverified (verdict not bound to current head): the latest ${namespace} marker binds ${parsed.sha}, not the current head ${input.headSha}`,
-		};
-	}
 	return {
-		...base,
-		state: parsed.polarity === "PASS" ? "pass" : "fail",
-		form: "marker",
-		commentId: latest.id,
-		sha: parsed.sha,
-		reason:
-			parsed.polarity === "PASS"
-				? `current-head ${namespace} PASS @ ${parsed.sha}`
-				: `latest verdict is FAIL (${namespace}) @ ${parsed.sha}`,
+		gate,
+		namespace,
+		state: verdictState(resolution.outcome),
+		form: resolution.form,
+		outcome: resolution.outcome,
+		commentId: outcomeCommentId(resolution.outcome),
+		sha: outcomeSha(resolution.outcome),
+		reason: resolution.reason,
 	};
 };
 

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -1,6 +1,6 @@
 import {assert, describe, it} from "@effect/vitest";
-import {decideGate, type GateDecisionInput} from "./gate-decision.ts";
-import type {VerdictComment, VerdictGate} from "./verdict-match.ts";
+import {decideGate, decideNamespace, type GateDecisionInput} from "./gate-decision.ts";
+import {isReviewed, type VerdictComment, type VerdictGate} from "./verdict-match.ts";
 
 const HEAD = "15ae9df658ce6225b8b71f22d214cfcabb6b1c9a";
 const OLD = "92c2cf4d0000000000000000000000000000abcd";
@@ -543,4 +543,150 @@ describe("decideGate — fail-closed on its own inputs (ADR 0092)", () => {
 		const result = decide({headSha: HEAD.slice(0, 8), comments: [comment({id: 1})]});
 		assert.isTrue(result.enqueueable);
 	});
+});
+
+describe("`verdict read` and `verdict gate` resolve ONE in-force verdict (#4049)", () => {
+	// PR #3988's marker set, the issue's own reference fixture: two FAILs and a superseding all-PASS
+	// advisory, ALL THREE bound to the same live head, because the repair that discharged the FAIL was
+	// body-only and deliberately did not move the head. ADR 0058 staleness therefore never fires, so
+	// recency across the marker AND advisory candidate sets is the only thing that can retire the FAIL
+	// — and `read`, which matched on polarity alone, could not see the advisory at all. Live before
+	// this change: `gate --cp` said enqueueable while `read --expect FAIL` exited 0 on the same head.
+	const FAIL_EARLY = comment({
+		id: 1,
+		createdAt: "2026-07-25T06:51:00Z",
+		body: `review-code: FAIL @ ${HEAD} — not merge-ready`,
+	});
+	const FAIL_LATE = comment({
+		id: 2,
+		createdAt: "2026-07-25T19:16:31Z",
+		body: `review-code: FAIL @ ${HEAD} — not merge-ready`,
+	});
+	const ADVISORY = comment({
+		id: 3,
+		createdAt: "2026-07-25T19:22:59Z",
+		body: advisory("code", HEAD),
+	});
+
+	/** What `verdict read --gate code [--cp]` resolves — the same call `Github.read` makes. */
+	const read = (comments: ReadonlyArray<VerdictComment>, controlPlane: boolean) =>
+		decideNamespace("code", {
+			comments,
+			authorizedAuthors: [REVIEWER],
+			headSha: HEAD,
+			controlPlane,
+		});
+
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly comments: ReadonlyArray<VerdictComment>;
+		readonly controlPlane: boolean;
+		readonly tag: string;
+		readonly commentId: number | null;
+		readonly expectPass: boolean;
+		readonly expectFail: boolean;
+	}> = [
+		{
+			name: "§CP: the superseding all-PASS advisory is in force — the FAIL is no longer resolvable",
+			comments: [FAIL_EARLY, FAIL_LATE, ADVISORY],
+			controlPlane: true,
+			tag: "current",
+			commentId: 3,
+			expectPass: true,
+			expectFail: false,
+		},
+		{
+			name: "the SAME set read WITHOUT --cp reproduces the pre-fix answer exactly (non-§CP unchanged)",
+			comments: [FAIL_EARLY, FAIL_LATE, ADVISORY],
+			controlPlane: false,
+			tag: "current",
+			commentId: 2,
+			expectPass: false,
+			expectFail: true,
+		},
+		{
+			name: "§CP: a FAIL posted AFTER the advisory is in force again — supersession runs both ways",
+			comments: [
+				ADVISORY,
+				comment({
+					id: 4,
+					createdAt: "2026-07-25T20:00:00Z",
+					body: `review-code: FAIL @ ${HEAD} — not merge-ready`,
+				}),
+			],
+			controlPlane: true,
+			tag: "current",
+			commentId: 4,
+			expectPass: false,
+			expectFail: true,
+		},
+		{
+			name: "§CP: an advisory recording a [FAIL] criterion satisfies NEITHER expectation",
+			comments: [comment({id: 5, body: advisory("code", HEAD, "[FAIL]")})],
+			controlPlane: true,
+			tag: "advisory-not-all-pass",
+			commentId: 5,
+			expectPass: false,
+			expectFail: false,
+		},
+		{
+			name: "§CP: an advisory whose Reviewed-head is stale is unverified, never a pass",
+			comments: [comment({id: 6, body: advisory("code", OLD)})],
+			controlPlane: true,
+			tag: "stale",
+			commentId: 6,
+			expectPass: false,
+			expectFail: false,
+		},
+		{
+			name: "§CP: an anchor-less advisory binds no head ⇒ unverified (ADR 0151)",
+			comments: [
+				comment({
+					id: 7,
+					body: "review-code: advisory — blocking-set PR (manual merge)\n\n- [PASS] x",
+				}),
+			],
+			controlPlane: true,
+			tag: "sha-less",
+			commentId: 7,
+			expectPass: false,
+			expectFail: false,
+		},
+		{
+			name: "§CP: an unauthorized author's advisory is invisible (the ADR 0055 gate composes)",
+			comments: [FAIL_LATE, comment({...ADVISORY, author: "attacker"})],
+			controlPlane: true,
+			tag: "current",
+			commentId: 2,
+			expectPass: false,
+			expectFail: true,
+		},
+	];
+
+	for (const {name, comments, controlPlane, tag, commentId, expectPass, expectFail} of cases) {
+		it(name, () => {
+			const decision = read(comments, controlPlane);
+			assert.strictEqual(decision.outcome._tag, tag);
+			assert.strictEqual(decision.commentId, commentId);
+			assert.strictEqual(isReviewed(decision.outcome, "PASS"), expectPass);
+			assert.strictEqual(isReviewed(decision.outcome, "FAIL"), expectFail);
+		});
+
+		// The AC2 invariant, asserted per row rather than argued: a `read --expect PASS` and a
+		// single-namespace `verdict gate` over the identical inputs must agree. A second resolution
+		// reintroduced on either side reds here even if both sides' own tests stay green.
+		it(`${name} — gate agrees with read --expect PASS`, () => {
+			const decision = read(comments, controlPlane);
+			const gateResult = decideGate({
+				comments,
+				authorizedAuthors: [REVIEWER],
+				requiredGates: ["code"],
+				headSha: HEAD,
+				controlPlane,
+			});
+			assert.strictEqual(gateResult.enqueueable, isReviewed(decision.outcome, "PASS"));
+			assert.strictEqual(gateResult.decisions[0]?.state, decision.state);
+			assert.strictEqual(gateResult.decisions[0]?.commentId, decision.commentId);
+		});
+	}
 });

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -119,7 +119,7 @@ const comment = (over: {
 describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawner", () => {
 	it.effect("current-head PASS from a write+ author → satisfied", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", false);
 			assert.strictEqual(result.outcome._tag, "current");
 			assert.isTrue(result.satisfied);
 		}).pipe((effect) =>
@@ -135,7 +135,7 @@ describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawne
 
 	it.effect("a stale-sha PASS → not satisfied (unverified)", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", false);
 			assert.strictEqual(result.outcome._tag, "stale");
 			assert.isFalse(result.satisfied);
 		}).pipe((effect) =>
@@ -151,7 +151,7 @@ describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawne
 
 	it.effect("a forged PASS from a non-collaborator is invisible → none", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", false);
 			assert.strictEqual(result.outcome._tag, "none");
 			assert.isFalse(result.satisfied);
 		}).pipe((effect) =>
@@ -171,7 +171,7 @@ describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawne
 
 	it.effect("a --head override binds against the supplied head, not the PR's live head", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "skill", "PASS", HEAD);
+			const result = yield* (yield* Github).read(PR, "skill", "PASS", false, HEAD);
 			assert.strictEqual(result.outcome._tag, "current");
 			assert.strictEqual(result.headSha, HEAD);
 		}).pipe((effect) =>
@@ -696,7 +696,7 @@ describe("the write-recency stamp at the boundary — post writes it, read repor
 
 	it.effect("read reports the resolving verdict's writtenAt, not its created_at", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", false);
 			assert.strictEqual(result.outcome._tag, "current");
 			assert.strictEqual(result.writtenAt, "2026-07-26T00:49:26Z");
 		}).pipe((effect) =>
@@ -717,7 +717,7 @@ describe("the write-recency stamp at the boundary — post writes it, read repor
 
 	it.effect("read's writtenAt is null when no verdict resolved", () =>
 		Effect.gen(function* () {
-			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			const result = yield* (yield* Github).read(PR, "doc", "PASS", false);
 			assert.strictEqual(result.outcome._tag, "none");
 			assert.isNull(result.writtenAt);
 		}).pipe((effect) =>

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -12,9 +12,10 @@
  * Three verbs:
  *  - `gate(pr, requiredGates, controlPlane, headOverride)` — the SET-level enqueue decision: fold the
  *    same resolution over every namespace the diff requires, so an absent namespace refuses (#3982).
- *  - `read(pr, gate, expect, headOverride)` — resolve the PR's current head (REST), author-gate
- *    marker authors to write+ collaborators (ADR 0055), and run `resolveVerdict` to classify
- *    the namespace against that head. The consumer branches on the returned outcome.
+ *  - `read(pr, gate, expect, controlPlane, headOverride)` — resolve the PR's current head (REST),
+ *    author-gate marker authors to write+ collaborators (ADR 0055), and run the SAME
+ *    `decideNamespace` resolution `gate` uses to classify that one namespace against the head. The
+ *    consumer branches on the returned outcome.
  *  - `post(pr, gate, body, runId)` — the ADR-0058 rule-2 UPSERT, scoped per posting RUN (ADR 0213)
  *    and per attested HEAD (#4007): guard the body's first line is *this* gate's marker (fail-closed
  *    on a cross-namespace body), then PATCH the prior marker THIS RUN posted in the namespace AT THIS
@@ -44,17 +45,17 @@ import {
 	runGh,
 	whoAmIArgs,
 } from "../tracker/gh-io.ts";
-import {decideGate, type GateDecision} from "./gate-decision.ts";
+import {decideGate, decideNamespace, type GateDecision, type VerdictForm} from "./gate-decision.ts";
 import {
 	bindsSameHead,
 	boundHeadShas,
 	compareWriteRecency,
 	emissionDefect,
 	headBindingDefect,
+	isReviewed,
 	namespaceRe,
 	normalizeRunId,
 	type Polarity,
-	resolveVerdict,
 	runIdOf,
 	toStampIso,
 	type VerdictComment,
@@ -114,6 +115,8 @@ export interface ReadResult {
 	/** Does the outcome satisfy the caller's expected polarity (a current-head match)? */
 	readonly satisfied: boolean;
 	readonly expect: Polarity;
+	/** Which verdict FORM resolved the namespace — `marker`, the §CP `advisory`, or `none` (ADR 0111). */
+	readonly form: VerdictForm;
 	/**
 	 * When the resolving verdict was WRITTEN (`writeRecencyOf`), or `null` when nothing resolved.
 	 *
@@ -191,13 +194,22 @@ const listComments = Effect.fn("Github.listComments")(function* (repo: string, p
 /**
  * Read the PR's verdict for `gate` against its current head (or `headOverride` when the caller
  * already resolved it — e.g. a reviewer binding to the exact head it read). Author-gates the
- * distinct marker authors to write+ collaborators, then runs the pure `resolveVerdict`.
+ * distinct marker authors to write+ collaborators, then runs the SAME `decideNamespace` resolution
+ * `gate` folds over its required set — so the two verbs cannot answer one (PR, gate, head,
+ * §CP-ness) differently (#4049).
+ *
+ * `controlPlane` is an explicit input, not auto-detected: §CP-ness is a property of the PR's diff
+ * that the caller already derives (`pipeline-cli cp-classify`), and auto-detecting it here would put
+ * a REST files-fetch behind a resolution and split the two verbs' contracts again. Without it a §CP
+ * PR's advisory is correctly not a pass — and, before this, was invisible to `read` entirely, which
+ * is what left a body-only-repaired FAIL resolvable forever.
  */
 const read = Effect.fn("Github.read")(function* (
 	repo: string,
 	pr: number,
 	gate: VerdictGate,
 	expect: Polarity,
+	controlPlane: boolean,
 	headOverride: string | undefined,
 ) {
 	const headSha = headOverride?.trim() || (yield* currentHead(repo, pr));
@@ -212,12 +224,26 @@ const read = Effect.fn("Github.read")(function* (
 		),
 	];
 	const authorized = yield* authorizedAuthors(repo, markerAuthors);
-	const outcome = resolveVerdict({comments, authorizedAuthors: authorized, gate, headSha});
-	const satisfied = outcome._tag === "current" && outcome.polarity === expect;
+	const decision = decideNamespace(gate, {
+		comments,
+		authorizedAuthors: authorized,
+		headSha,
+		controlPlane,
+	});
+	const outcome = decision.outcome;
+	const satisfied = isReviewed(outcome, expect);
 	const resolving =
-		outcome._tag === "none" ? undefined : comments.find((c) => c.id === outcome.commentId);
+		decision.commentId === null ? undefined : comments.find((c) => c.id === decision.commentId);
 	const writtenAt = resolving === undefined ? null : writeRecencyOf(resolving);
-	return {outcome, headSha, gate, satisfied, expect, writtenAt} satisfies ReadResult;
+	return {
+		outcome,
+		headSha,
+		gate,
+		satisfied,
+		expect,
+		form: decision.form,
+		writtenAt,
+	} satisfies ReadResult;
 });
 
 /**
@@ -369,6 +395,7 @@ export class Github extends Context.Service<
 			pr: number,
 			gate: VerdictGate,
 			expect: Polarity,
+			controlPlane: boolean,
 			headOverride?: string,
 		) => Effect.Effect<
 			ReadResult,
@@ -417,8 +444,12 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
 			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
 			return {
-				read: (pr, gate, expect, headOverride) =>
-					repo.pipe(Effect.flatMap((r) => withSpawner(read(r, pr, gate, expect, headOverride)))),
+				read: (pr, gate, expect, controlPlane, headOverride) =>
+					repo.pipe(
+						Effect.flatMap((r) =>
+							withSpawner(read(r, pr, gate, expect, controlPlane, headOverride)),
+						),
+					),
 				gate: (pr, requiredGates, controlPlane, headOverride) =>
 					repo.pipe(
 						Effect.flatMap((r) =>

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -115,7 +115,7 @@ export const isBoundToHead = (sha: string | null | undefined, head: string): boo
 	return a.startsWith(b) || b.startsWith(a);
 };
 
-/** The resolved verdict for a (PR, gate) — exactly one of four states against the current head. */
+/** The resolved verdict for a (PR, gate) — exactly one of five states against the current head. */
 export type VerdictOutcome =
 	/** No authorized PASS/FAIL marker exists in this namespace (or the authorized set was empty). */
 	| {readonly _tag: "none"}
@@ -134,7 +134,48 @@ export type VerdictOutcome =
 			readonly commentId: number;
 			readonly polarity: Polarity;
 			readonly sha: string;
-	  };
+	  }
+	/**
+	 * The in-force artifact is a §CP advisory bound to the current head whose body records a `[FAIL]`
+	 * criterion (ADR 0111/0151). Deliberately NOT a FAIL: an advisory carries no polarity, and its
+	 * remedy is a re-review, not the author's repair round-trip — which is what a FAIL marker names.
+	 * Only `decideNamespace`'s §CP arm produces it; `resolveVerdict` (marker-only) never does.
+	 */
+	| {readonly _tag: "advisory-not-all-pass"; readonly commentId: number; readonly sha: string};
+
+/**
+ * The in-force STATE of a namespace — the one projection every consumer's satisfaction test goes
+ * through, so `verdict read --expect` and `verdict gate` cannot answer the same (PR, gate, head,
+ * §CP-ness) differently (#4049 AC2). `read` was polarity-matching while `gate` was latest-wins, and
+ * a §CP body-only repair (the head deliberately never moves, so ADR 0058 staleness never fires) made
+ * the two diverge permanently: `gate` saw the superseding advisory, `read` could not see an advisory
+ * at all and kept resolving the superseded FAIL as current.
+ */
+export type VerdictState = "pass" | "fail" | "absent" | "unverified";
+
+/** Project a resolved outcome onto its state — total, and the ONE place the mapping is written. */
+export const verdictState = (outcome: VerdictOutcome): VerdictState => {
+	switch (outcome._tag) {
+		case "none":
+			return "absent";
+		case "sha-less":
+		case "stale":
+		case "advisory-not-all-pass":
+			return "unverified";
+		case "current":
+			return outcome.polarity === "PASS" ? "pass" : "fail";
+	}
+};
+
+/** The comment that resolved an outcome, or `null` when nothing resolved. */
+export const outcomeCommentId = (outcome: VerdictOutcome): number | null =>
+	outcome._tag === "none" ? null : outcome.commentId;
+
+/** The head the resolving verdict binds, or `null` when it binds none. */
+export const outcomeSha = (outcome: VerdictOutcome): string | null =>
+	outcome._tag === "stale" || outcome._tag === "current" || outcome._tag === "advisory-not-all-pass"
+		? outcome.sha
+		: null;
 
 export interface ResolveVerdictInput {
 	readonly comments: ReadonlyArray<VerdictComment>;
@@ -294,6 +335,12 @@ export const pickInForce = (
  * `@ <sha>` prefix-matches the head, else `stale`; `sha-less` when it carries no `@ <sha>`;
  * `none` when the authorized candidate set is empty. Fail-closed everywhere: an empty authorized
  * set is `none`, never a false win.
+ *
+ * This is the MARKER arm only — an advisory carries no polarity, so `polarityRe` deliberately never
+ * matches one. The §CP-aware full resolution (marker ∪ advisory) is `decideNamespace` in
+ * `gate-decision.ts`, which delegates its marker classification here so the two arms can't drift;
+ * `Github.read` and `Github.gate` both consume THAT. Calling this directly answers "which bindable
+ * marker is in force", never "which verdict is in force on a §CP PR" (#4049).
  */
 export const resolveVerdict = (input: ResolveVerdictInput): VerdictOutcome => {
 	const latest = pickInForce(
@@ -318,13 +365,13 @@ export const resolveVerdict = (input: ResolveVerdictInput): VerdictOutcome => {
 };
 
 /**
- * The `read` verb's decision: is HEAD reviewed with the expected polarity? True **only** for a
- * current-head-bound verdict whose polarity matches — a `sha-less`, `stale`, or `none` outcome
- * is never satisfied. `ship-it` expects `PASS`; `write-code`-repair expects `FAIL` (the seam it
- * consumes). This is the single boolean the inline `is_current`-then-polarity checks recomputed.
+ * The `read` verb's decision: is HEAD reviewed with the expected polarity? Expressed on
+ * `verdictState` rather than on the raw tag, so it is satisfied by exactly what `verdict gate`
+ * calls a pass (or a fail) and by nothing else — the anti-drift construction of #4049. `ship-it`
+ * expects `PASS`; `write-code`-repair expects `FAIL` (the seam it consumes).
  */
 export const isReviewed = (outcome: VerdictOutcome, expect: Polarity): boolean =>
-	outcome._tag === "current" && outcome.polarity === expect;
+	verdictState(outcome) === (expect === "PASS" ? "pass" : "fail");
 
 /**
  * A machine-readable reason for a non-satisfying `read` outcome — the named refusal `ship-it`
@@ -338,6 +385,8 @@ export const outcomeReason = (outcome: VerdictOutcome, expect: Polarity): string
 			return "unverified (verdict not bound to current head): latest marker is SHA-less (pre-0058)";
 		case "stale":
 			return `unverified (verdict not bound to current head): latest marker bound to ${outcome.sha}, not the current head`;
+		case "advisory-not-all-pass":
+			return `unverified (§CP advisory at the current head is not all-PASS — a body checkbox is [FAIL]); its remedy is a re-review, not a repair round`;
 		case "current":
 			return outcome.polarity === expect
 				? `reviewed: current-head ${outcome.polarity} @ ${outcome.sha}`

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -10,6 +10,7 @@ import {
 	isUnboundPolarityMarker,
 	malformedEmittedSha,
 	normalizeRunId,
+	outcomeReason,
 	parseVerdict,
 	resolveVerdict,
 	runIdOf,
@@ -17,6 +18,8 @@ import {
 	type VerdictComment,
 	type VerdictGate,
 	type VerdictOutcome,
+	type VerdictState,
+	verdictState,
 	withRunId,
 	withWrittenAt,
 	writeRecencyOf,
@@ -869,5 +872,57 @@ describe("the run-identity trailer — the upsert key's run dimension (#4016)", 
 		assert.isNull(normalizeRunId("short"));
 		assert.isNull(normalizeRunId("has whitespace inside"));
 		assert.isNull(normalizeRunId("-->injected"));
+	});
+});
+
+describe("verdictState — the ONE projection `read --expect` and `gate` both satisfy on (#4049)", () => {
+	// `read` used to test `_tag === "current" && polarity === expect` while `gate` tested its own
+	// `state` field. Two predicates over one resolution is what let the verbs disagree; these rows
+	// pin that every outcome shape maps to exactly one state, and that `isReviewed` IS that map.
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly outcome: VerdictOutcome;
+		readonly state: VerdictState;
+	}> = [
+		{name: "nothing resolved", outcome: {_tag: "none"}, state: "absent"},
+		{
+			name: "a pre-0058 SHA-less marker",
+			outcome: {_tag: "sha-less", commentId: 1, polarity: "PASS"},
+			state: "unverified",
+		},
+		{
+			name: "a marker bound to a dead head",
+			outcome: {_tag: "stale", commentId: 1, polarity: "PASS", sha: OLD},
+			state: "unverified",
+		},
+		{
+			name: "a §CP advisory at the live head recording a [FAIL] criterion",
+			outcome: {_tag: "advisory-not-all-pass", commentId: 1, sha: HEAD},
+			state: "unverified",
+		},
+		{
+			name: "a current-head PASS",
+			outcome: {_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+			state: "pass",
+		},
+		{
+			name: "a current-head FAIL",
+			outcome: {_tag: "current", commentId: 1, polarity: "FAIL", sha: HEAD},
+			state: "fail",
+		},
+	];
+
+	for (const {name, outcome, state} of cases) {
+		it(`${name} ⇒ ${state}, and isReviewed agrees in both polarities`, () => {
+			assert.strictEqual(verdictState(outcome), state);
+			assert.strictEqual(isReviewed(outcome, "PASS"), state === "pass");
+			assert.strictEqual(isReviewed(outcome, "FAIL"), state === "fail");
+		});
+	}
+
+	it("a not-all-PASS advisory is NOT a FAIL — its remedy is a re-review, not a repair round", () => {
+		const outcome: VerdictOutcome = {_tag: "advisory-not-all-pass", commentId: 3, sha: HEAD};
+		assert.isFalse(isReviewed(outcome, "FAIL"));
+		assert.include(outcomeReason(outcome, "PASS"), "not all-PASS");
 	});
 });


### PR DESCRIPTION
Fixes #4049

## The defect, reproduced against `main` before the change

A §CP body-only repair deliberately does not move the head — moving it would dismiss the control-plane approval and force a full re-review. So ADR 0058's head-keyed staleness can never retire the FAIL that repair discharged, and the *only* thing that can is recency across the marker **and** advisory candidate sets.

`verdict gate --cp` already did that. `verdict read` did not: `resolveVerdict` scopes candidates with `polarityRe`, and `polarityRe` deliberately does not match an advisory first line — so the superseding advisory was never a candidate, and the superseded FAIL resolved `current` forever. Live, on the issue's own reference fixture (PR #3988, head `0368922e…`), before this change:

```
read  (no --cp, --expect FAIL): {"_tag":"current","commentId":5080209570,"polarity":"FAIL"}  exit 0
gate  (--cp):                   {"enqueueable":true,"state":"pass","form":"advisory","commentId":5080232100}
```

Two consumers, the same markers, opposite answers. That is ACs #2 and #4.

## What changed

**One in-force resolution, consumed by both verbs.**
- `decideNamespace` (`packages/pipeline-cli/src/tools/verdict/gate-decision.ts`) is exported and becomes the single resolution. Its **marker arm delegates to `resolveVerdict`** rather than re-deriving the ADR-0058 four-way classification — it re-runs the identical `pickInForce(polarityRe(gate), …)` call, so it resolves the same comment by construction, and the staleness rule stays written once.
- `NamespaceDecision` now carries the resolved `outcome`; `state`, `commentId` and `sha` are **derived** from it through the new `verdictState` projection (`verdict-match.ts`). `isReviewed` is expressed on that same projection, so `read --expect PASS` is satisfied by exactly what `gate` calls a pass, and `--expect FAIL` by exactly what it calls a fail. There is no second predicate left to drift.
- `Github.read` runs `decideNamespace` instead of a private `resolveVerdict` call, and reports the resolving `form`.

**`--cp` on `read`,** the flag `gate` already had. On a §CP PR a current-head all-PASS advisory now resolves `current`/PASS. A not-all-PASS advisory gets its own terminal outcome, `advisory-not-all-pass`, and satisfies **neither** polarity — deliberately not a FAIL, because its remedy is a re-review, not the author's repair round-trip, and mapping it to FAIL would have changed shipped `gate` semantics.

**Consumer audit (AC4).** Every runnable `verdict read` in the skill corpus now passes `$CP_FLAG`: ship-it Step 2's eight per-namespace reads (the same value it already passes to `verdict gate`), write-code's Step-1 pre-pick scan and repair R1, and heal-ci's in-flight-repair probe. write-code and heal-ci derive the flag per PR from `pipeline-cli cp-classify classify`, fail-closed — only the proven `not-control-plane` state word drops the flag, never a bare non-zero test (which fires on a usage error or a missing binary).

**Not moved:** no empty commit, no head-moving workaround anywhere (AC5).

## What was deliberately NOT done

- **`#4198`'s head-first filter and `#4234`'s write-recency key are imported, never re-declared.** `pickInForce` and `compareWriteRecency` are untouched; this change adds an arm above them, it does not reorder them. The closed PR #4135 carried its own `(createdAt, id)` `newerOf` and no `pickInForce` at all, and would have auto-merged that regression into `verdict-match.ts` silently.
- **`advisoryRe` / the `[FAIL]` tell / `VerdictForm` stay in `gate-decision.ts`.** Moving them into `verdict-match.ts` is a refactor, not a fix. This is why `controlPlane` is on `NamespaceInput` rather than on `ResolveVerdictInput`: making `resolveVerdict` itself §CP-aware would require pulling the advisory vocabulary across the file boundary (or a circular import). `resolveVerdict` is now documented as the **marker arm**, with the §CP-aware entry point named.
- **No new ADR.** This is a defect fix consistent with ADR 0058/0111/0151, and with ADR 0213's rejection of a current-head FAIL veto.
- **Non-§CP behaviour is unchanged.** Without `--cp` an advisory is still no candidate: it neither satisfies a namespace nor shadows an older bindable marker. That shape self-heals via a newer same-head PASS marker anyway.
- **No new module,** so ADR 0218's §CP import closure is untouched — `core-import-closure.unit.test.ts` passes with the same recorded residue.

## Verified by execution

- Live against the reference fixture (PR #3988 @ `0368922e…`) on this branch:
  - `read --gate code --cp --expect FAIL` → exit **1**, resolving `{"_tag":"current","commentId":5080232100,"polarity":"PASS","form":"advisory"}`
  - `read --gate code --cp --expect PASS` → exit **0**, same comment
  - `gate --require review-code --cp` → `enqueueable: true`, same `commentId`
  - `read --gate code --expect FAIL` (no `--cp`) → exit **0** on comment `5080209570` — the pre-fix answer reproduced exactly, i.e. non-§CP behaviour is unchanged.
- `pnpm typecheck` — clean. `pnpm lint` — clean.
- `pnpm vitest run` over `@kampus/pipeline-cli`: **2850 passing**, including the ADR-0218 import-closure check.
- `pipeline-cli gh-phoenix lint-skills` over the three edited skills — clean.

## Tests (AC3)

- `verdict-match.unit.test.ts` — a table over every outcome shape asserting `verdictState` is total and that `isReviewed` **is** that map in both polarities, plus the not-all-PASS advisory row.
- `gate-decision.unit.test.ts` — the PR #3988 body-only-repair sequence as a seven-row table (§CP and non-§CP, advisory stale / anchor-less / not-all-PASS, a FAIL posted *after* the advisory, an unauthorized advisory), each row asserted for **both** `--expect PASS` and `--expect FAIL`; and, per row, a cross-consumer agreement assertion that a single-namespace `verdict gate` returns exactly `isReviewed(read.outcome, "PASS")` with the same `state` and `commentId`. A second resolution reintroduced on either side reds there even if both sides' own tests stay green.

## Repair round 1 — the AC4 fail-open (`$CP_FLAG` derivation)

The round-1 `review-code` advisory found the three newly-added `$CP_FLAG` derivations fail-**open**: a bare `gh api …/files --jq '.[].filename' | cp-classify classify` pipe, with `pipefail` off and no enclosing fence setting it. gh writes its error document to **stdout**, that document classifies `not-control-plane`, so `CP_FLAG=""` and `verdict read` ran without `--cp` on a genuine §CP PR — #4049 recurring through this fix's own consumer wiring.

All three sites now take §CPREAD's sanctioned consumer form (`gh-issue-intake-formats.md` §CPREAD / `cp_changed_files`, the form spelled out verbatim there):

```bash
if ! cp_changed_files "$REPO" "$PR"; then
  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
else
  CP_STATE="$(printf '%s\n' "$CP_FILES" | … cp-classify classify --repo "$REPO" 2>/dev/null)"
fi
if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
```

Sites: `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` (Step 1 pre-pick scan, Step R1) and `claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md` (in-flight repair probe). `ship-it` already derives `$CP_FLAG` from its §CPREAD-hardened Step-0 classification and is untouched. The classify step and the `= "not-control-plane"` state-word test are unchanged — only the input is now guarded.

**Verified by execution, all four cases against the live API:**

| case | old shape | repaired shape |
|---|---|---|
| healthy read, §CP PR (#4372, 10 files) | `control-plane` → `--cp` | `control-plane` → `--cp` |
| healthy read, non-§CP PRs (#4310 / #4295 / #4335) | `not-control-plane` → `""` | `not-control-plane` → `""` |
| error read (404; the error doc lands on stdout) | `not-control-plane` → **`""`** (fail-open) | `unknown` → **`--cp`** |
| zero-file read (200, empty list) | `unknown` → `--cp` | `unknown` → `--cp`, now logged distinctly as a failed read (§ZS) |

The error case reproduced unprompted while hunting for a non-§CP fixture: five numbers that were issues rather than PRs each answered `not-control-plane` under the old shape and `unknown` under the repaired one.

`pnpm typecheck` clean; `pnpm lint:worktree` clean; `@kampus/pipeline-cli` **2858 / 2858** passing (including the ADR-0218 import-closure check); `pipeline-cli gh-phoenix lint-skills` clean over the three skills. The branch was rebased onto latest `origin/main` (`02bdd18c`) per repair Step R2; the head move needs a fresh control-plane approval and a re-gate in both namespaces.

## Repair round 2 — rebase onto current `main` (`b015fa48`)

The lane sat parked while `main` moved ~40 commits, and several of those commits moved or rewrote
every skill hunk this PR carried. The branch is rebased onto `b015fa48`, and the three SKILL.md
hunks are **re-expressed against where their targets now live** rather than replayed textually.
`mergeable` went `false`/`dirty` → `true`, which is also what defuses the diff-scoped-guard base
drift (`leak-guard.yml` is required and runs on `merge_group`, so a PR based behind a widening can
pass its own CI and red in the queue).

| hunk | at the old base (`02bdd18c`) | where the change lands now |
|---|---|---|
| write-code Step-1 pre-pick scan | inline fence, three `$VERDICT read` lines | same fence, but #4398 replaced those lines with a `for G in code doc skill` loop over `"$PCLI" verdict read` with an exit-code taxonomy — `$CP_FLAG` goes into the one looped call |
| write-code Step R1 | inline fence, `$VERDICT read` | same fence, `$VERDICT` → `"$PCLI"` (#4398) |
| write-code advisory-no-op prose | prose | unchanged location |
| ship-it "`--cp` is load-bearing" prose | prose | unchanged location; the added sentence now names the code-namespace read specifically |
| ship-it author-gate prose | prose | **dropped — absorbed by `main`.** #4426 rewrote that paragraph to say ship-it resolves no authorized-author set at all and that the verb author-gates the advisory one layer down. The hunk's entire point is now stated upstream, more strongly than the hunk stated it. |
| ship-it's eight `verdict read` calls | inline fence | `skills/ship-it/scripts/step2-native-review-fold.sh` (#4491 extraction) — and **two** calls, not eight, because #4426 dropped the doc/skill/design reads as unread. `$CP_FLAG` is already in scope there, set by the sibling `step2-verdict-gate.sh` that is sourced first. |
| heal-ci in-flight-repair probe | inline fence | same fence — #4519 extracted `repair-rounds.sh`, not this block |

`cp_changed_files` moved too: #4489 extracted §CPREAD out of `gh-issue-intake-formats.md` into
`skills/shared/scripts/cp-read.sh`, so the two new derivations **source the canonical helper**
instead of instructing the reader to paste a copy. The fail-closed shape round 1 established is
otherwise unchanged. In write-code's Step-1 scan the helper's §ZS scope line is routed to stderr,
because that loop's stdout is the repairable-PR list its caller reads.

`packages/pipeline-cli/src/tools/verdict/**` was **verified** untouched by the extractions rather
than assumed: `git log 02bdd18c..b015fa48 -- packages/pipeline-cli/src/tools/verdict/` is empty. All
seven files replayed onto the new base cleanly and are byte-identical to round 1.

The two branch commits are squashed into one on the rebase — the skill hunks had to be re-expressed,
not replayed, so replaying them twice would have doubled the chance of error for no audit gain. Both
rounds are recorded here and in `## Deviations`.

**Re-verified on the rebased head:** `pnpm typecheck` clean; `pnpm lint:worktree` clean;
`@kampus/pipeline-cli` **3017 / 3017** passing across 185 test files; and `gh-phoenix lint-skills`,
`cli-invocation-guard`, `trap-status-guard` and `leak-guard scan` each clean over the exact edited
set, with each tool's own scope line reporting the same file count it was handed.
`cp-classify classify` over the rebased file list → `control-plane` (exit 0), so this still banks
for a human control-plane approval.

### Checked while in `command.ts` — #4520 is neither worsened nor entrenched

This PR's `command.ts` change moves the existing `cpFlag` **boolean** declaration above `read` and
adds it to `read`'s flag record. It does not touch `requireFlag`, which is where #4520's fail-open
lives: `require` is a single-valued `Flag.string("require")`, so a *repeated* `--require` has nowhere
to accumulate and silently shrinks the gate conjunction — while the adjacent `parseRequired`
hard-errors on an unrecognized token precisely to stop that set shrinking. Nothing in this rebase
makes that fix incidentally safe to fold in, so #4520 is left alone as parked. No invocation this PR
adds or touches uses a repeated `--require`; the comma form (`--require a,b`) is the standing
convention while #4520 is open, and the one live call site
(`ship-it/scripts/step2-verdict-gate.sh`) already uses it.


## Deviations

None.

**(repair round 1)** — class 4, declined guidance. The round-1 advisory carried one explicit nit-not-a-FAIL: `heal-ci/SKILL.md` re-derives the #4049 *why* a third time where a pointer would do. Not taken this round — the verdict's own instruction was "keep the diff to the one finding", and collapsing that comment would widen a §CP diff that needs a fresh human approval. The comment block above the repaired derivation is left as written.

**(repair round 2)** — class 4, declined guidance, superseded. **Said:** round 1's own text (and
§CPREAD as it read then) instructed each site to copy `cp_changed_files` verbatim. **Did:** the
rebased sites `source` `skills/shared/scripts/cp-read.sh`. **Why:** #4489 extracted §CPREAD to that
canonical home while this lane was parked, so a verbatim copy would now be a copy that can drift.
**Disposition:** no action needed — identical fail-closed behaviour, one fewer copy.

**(repair round 2)** — class 1, scope narrowing forced by the base. **Said:** AC4's consumer audit
covers every runnable `verdict read` in the corpus; round 1 delivered that as eight `$CP_FLAG`
threadings in ship-it plus two prose hunks. **Did:** ship-it now takes two threadings and one prose
hunk. **Why:** #4426 deleted the six doc/skill/design reads as unread, and rewrote the author-gate
paragraph so that the second prose hunk's point is already stated upstream. **Disposition:** no
action needed — the audit is still exhaustive over the reads that exist; the target set shrank on
`main`, the intent did not.

**(repair round 2)** — class 7, out-of-scope change. **Said:** the issue asks only that `read` be
passed `--cp`. **Did:** write-code's Step-1 scan additionally routes `cp_changed_files`' §ZS scope
line to stderr (`cp_changed_files "$REPO" "$PR" >&2`). **Why:** that loop's stdout is the
repairable-PR list its caller parses, and the helper prints its scope line on stdout; without the
redirect the new derivation would inject a non-PR line into a parsed list. The scope line is still
emitted, on the same stream as the helper's own failure lines. **Disposition:** for the reviewer to
judge — it is one redirect, and the alternative is a parsed list with foreign lines in it.

## Note for the gate

This PR is §CP: it edits three gate-critical skills and the §CP enforcement core under `packages/pipeline-cli/src/tools/verdict/`. It banks for a human control-plane approval rather than auto-shipping.
