### PR TITLE
docs(pipeline): §CP is approve-then-enqueue, not a hand-merge (#3589)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1592,8 +1592,11 @@ closing the #375 drift class).
     three modules the core imports without retaining, and why `codeowners-cp` cannot catch a
     stale over-broad CODEOWNERS row.
 
-A PR touching **any** path in this set is **control plane**: `ship-it` refuses to auto-merge
-it and a human merges it by hand (ADR
+A PR touching **any** path in this set is **control plane**: `ship-it` never auto-merges it off a
+gate verdict alone — it merges only once a `@kamp-us/control-plane` member approves at head, and
+`ship-it` then enqueues it (ADR
+[0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
+amending ADR
 [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md),
 widened to the gate-critical skills by ADR
 [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md);
@@ -1658,7 +1661,7 @@ CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus
 if ! cp_changed_files "$REPO" "$PR"; then
   echo "BLOCKING — §CP UNKNOWN (changed-file list unreadable; never 'no control-plane path')"
 elif printf '%s\n' "$CP_FILES" | grep -Eq "$CONTROL_PLANE_RE"; then
-  echo "BLOCKING — control plane (manual merge)"
+  echo "BLOCKING — control plane (§CP — approval-gated)"
 fi
 ```
 
@@ -1666,7 +1669,7 @@ fi
 copy embedded in their own skill body.** A skill runs against the **snapshot injected into the
 agent's context at invoke time**, which can lag `origin/main` even when the on-disk copy in the
 same worktree is current — so an agent on a pre-amendment snapshot once auto-merged a
-now-control-plane PR the *current* boundary marks human-merge-only (#981). The fix makes the
+now-control-plane PR the *current* boundary marks approval-gated (#981). The fix makes the
 single source authoritative **at run time**: `ship-it` Step 0 and `review-code` Step 2 read the
 `CONTROL_PLANE_RE` line from this file on `origin/main` (REST raw, `?ref=main`) and classify
 against *that*, **failing closed** — every path treated as control-plane, so the gate refuses —
@@ -2864,8 +2867,12 @@ review-doc: FAIL @ <sha> — changes-requested
 
 For a PR in the **control-plane / blocking set** (§CP), `review-doc` is advisory only and
 instead leads with the **canonical advisory line** (§6.6 — `review-doc: advisory — blocking-set
-PR (manual merge)`) so its verdict stays *out* of `ship-it`'s PASS namespace — a human merges
-those (ADR [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md)). The advisory line
+PR (§CP — approval-gated)`) so its verdict stays *out* of `ship-it`'s PASS namespace — a §CP PR
+merges only once a `@kamp-us/control-plane` member approves at head and `ship-it` enqueues it
+(ADR [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
+amending [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md);
+`ship-it` is the single merge actor, ADR
+[0048](https://github.com/kamp-us/phoenix/blob/main/.decisions/0048-ship-it-merge-actor.md)). The advisory line
 carries **no `@ <sha>`** by design: it authorizes nothing, so there is nothing to bind.
 
 The rest of the body carries the per-criterion + per-hygiene-check evidence table. What's
@@ -2911,8 +2918,9 @@ fresh `@ <sha>` rather than appending a new comment (ADR 0058 rule 2; same mecha
   hygiene check unmet) is read by `write-code`'s fix round-trip as "my doc PR came back failed";
   `ship-it` reads it as "do not merge."
 - **Advisory for the blocking set.** A PR in the §CP set gets the canonical advisory line
-  (§6.6), not a PASS marker — `review-doc`'s verdict does not authorize that merge; a human
-  does (ADR 0053). This keeps the control-plane manual-merge invariant intact.
+  (§6.6), not a PASS marker — `review-doc`'s verdict does not authorize that merge; a
+  `@kamp-us/control-plane` approval at head does, and `ship-it` enqueues on it (ADR 0135
+  amending 0053). This keeps the control-plane approval gate intact.
 - **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on;
   `review-doc` writing it does **not** merge (see review-doc/SKILL.md §"Authority limit").
 
@@ -2948,10 +2956,12 @@ so most skill PRs that touch a gate land here), `review-skill` is **advisory onl
 instead leads with the **canonical advisory line** (§6.6):
 
 ```markdown
-review-skill: advisory — blocking-set PR (manual merge)
+review-skill: advisory — blocking-set PR (§CP — approval-gated)
 ```
 
-so its verdict stays *out* of `ship-it`'s PASS namespace — a human merges those (ADR 0053).
+so its verdict stays *out* of `ship-it`'s PASS namespace — a §CP PR merges only once a
+`@kamp-us/control-plane` member approves at head and `ship-it` enqueues it (ADR 0135 amending
+0053; `ship-it` is the single merge actor, ADR 0048).
 The advisory line carries **no `@ <sha>`** by design: it authorizes nothing, so there is
 nothing to bind.
 
@@ -3008,9 +3018,9 @@ this one rule so they can't diverge (the same discipline §5 pins for code/doc).
   `ship-it` reads it as "do not merge."
 - **Advisory for the blocking set.** A skill PR touching a gate-critical skill (or any §CP
   path) gets the **canonical advisory line** (§6.6), not a PASS marker — its verdict does not
-  authorize that merge; a human does (ADR 0053/0065). This keeps the control-plane manual-merge
-  invariant intact, and is exactly the common case for a skill PR (every gate skill is
-  gate-critical).
+  authorize that merge; a `@kamp-us/control-plane` approval at head does, and `ship-it` enqueues
+  on it (ADR 0135 amending 0053/0065). This keeps the control-plane approval gate intact, and is
+  exactly the common case for a skill PR (every gate skill is gate-critical).
 - **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on;
   `review-skill` writing it does **not** merge (see review-skill/SKILL.md §"Authority limit").
 
@@ -3029,18 +3039,19 @@ For a PR in the **control-plane / blocking set** (§CP), the gate emits a commen
 line is the **no-`@ <sha>`** advisory marker in its own namespace:
 
 ```markdown
-review-code:   advisory — blocking-set PR (manual merge)
-review-doc:    advisory — blocking-set PR (manual merge)
-review-skill:  advisory — blocking-set PR (manual merge)
-review-design: advisory — blocking-set PR (manual merge)
+review-code:   advisory — blocking-set PR (§CP — approval-gated)
+review-doc:    advisory — blocking-set PR (§CP — approval-gated)
+review-skill:  advisory — blocking-set PR (§CP — approval-gated)
+review-design: advisory — blocking-set PR (§CP — approval-gated)
 ```
 
 The rest of the body carries the same per-check evidence table the PASS/FAIL paths carry —
 the verdict is *recorded* (for the human or delegated merge actor to read), it just **authorizes
 nothing on its first line**. The advisory **first line** **carries no `@ <sha>`** on purpose: it
 does not enter any `ship-it` `PASS @ <sha> — merge-ready` namespace, so a §CP PR is never
-auto-mergeable off it (ADR 0053). A human merges it, **or** — under ADR 0135's approve-then-enqueue —
-`ship-it` enqueues it once a `@kamp-us/control-plane` approval is present at head (ADR 0053/0065/0135).
+auto-mergeable off it (ADR 0053). Under ADR 0135's approve-then-enqueue, `ship-it` enqueues it once a
+`@kamp-us/control-plane` approval is present at head (ADR 0053/0065/0135) — that approval, not a gate
+verdict, is what authorizes the merge.
 
 **The advisory body MUST carry the canonical `Reviewed-head` line (ADR 0151).** Immediately after
 the advisory's first-line marker + framing prose, the body carries **exactly one** line recording
@@ -3129,10 +3140,12 @@ For a PR in the **control-plane / blocking set** (§CP), `review-design` is **ad
 and instead leads with the **canonical advisory line** (§6.6):
 
 ```markdown
-review-design: advisory — blocking-set PR (manual merge)
+review-design: advisory — blocking-set PR (§CP — approval-gated)
 ```
 
-so its verdict stays *out* of `ship-it`'s PASS namespace — a human merges those (ADR 0053).
+so its verdict stays *out* of `ship-it`'s PASS namespace — a §CP PR merges only once a
+`@kamp-us/control-plane` member approves at head and `ship-it` enqueues it (ADR 0135 amending
+0053; `ship-it` is the single merge actor, ADR 0048).
 The advisory line carries **no `@ <sha>`** by design: it authorizes nothing, so there is
 nothing to bind.
 
@@ -3203,10 +3216,11 @@ actor (and `ship-it`'s ADR-0135 approval-aware enqueue) resolves the reviewed he
   by `write-code`'s fix round-trip as "my UI PR came back failed"; `ship-it` reads it as "do
   not merge."
 - **Advisory for the blocking set.** A UI PR in the §CP set gets the **canonical advisory
-  line** (§6.6), not a PASS marker — its verdict does not authorize that merge; a human does
-  (ADR 0053/0065). Because a design verdict is calibrated to FAIL conservatively (a borderline
-  call is downgraded to advisory), an advisory here can also mean "no objective prohibition
-  hard-failed" — but on a §CP PR the first-line advisory is always the manual-merge shape.
+  line** (§6.6), not a PASS marker — its verdict does not authorize that merge; a
+  `@kamp-us/control-plane` approval at head does, and `ship-it` enqueues on it (ADR 0135 amending
+  0053/0065). Because a design verdict is calibrated to FAIL conservatively (a borderline call is
+  downgraded to advisory), an advisory here can also mean "no objective prohibition hard-failed" —
+  but on a §CP PR the first-line advisory is always the approval-gated shape.
 - **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on;
   `review-design` writing it does **not** merge (see review-design/SKILL.md §"Authority
   limit").

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1415,8 +1415,8 @@ flag from Step 2 — **or** a non-empty `GUARD_TOUCHING`, a guard-touching `.dec
 §CP by content, ADR 0164 / #3645): a **blocking-set** PR (it touches `.claude/**`, `.github/**`, a
 gate-critical skill, or a guard-touching ADR — §CP) does **not** get a binding `PASS @ <sha> —
 merge-ready` marker. It
-gets the **canonical advisory line** instead — `review-code: advisory — blocking-set PR (manual
-merge)`, no `@ <sha>` — the one advisory shape all three gates converge on (ADR
+gets the **canonical advisory line** instead — `review-code: advisory — blocking-set PR (§CP —
+approval-gated)`, no `@ <sha>` — the one advisory shape all three gates converge on (ADR
 [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §5;
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §6.6). It carries the same
 per-criterion evidence table, but it authorizes nothing on its first line — it stays *out* of
@@ -1650,7 +1650,7 @@ code review namespace via its `commit_id`, defeating the advisory's purpose).
 > would drop the §CP verdict into `ship-it`'s auto-merge namespace, the ADR 0111 hazard).
 
 ```markdown
-review-code: advisory — blocking-set PR (manual merge)
+review-code: advisory — blocking-set PR (§CP — approval-gated)
 
 PR #<PR> is §CP — it touches the control plane (`.claude/**`, `.github/**`, or a gate-critical
 skill — ADR 0053/0065), OR a guard-touching `.decisions/**` ADR (§CP by content, ADR 0164 — the

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -715,7 +715,7 @@ auto-merge this PR on machine gates alone — it enqueues only once a `@kamp-us/
 approval is present at head (ADR 0135).
 
 ```markdown
-review-design: advisory — blocking-set PR (manual merge)
+review-design: advisory — blocking-set PR (§CP — approval-gated)
 
 PR #<PR> touches the control plane (§CP) — the agent control plane / pipeline gates (ADR
 0053/0065/0165). My verdict is **advisory only**: it does **not** authorize a merge. Under the §CP

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -1013,7 +1013,7 @@ unchanged (it is still doc-class), only the merge-authority moves (ADR 0164 / #3
 > into `ship-it`'s auto-merge namespace, the ADR 0111 hazard).
 
 ```markdown
-review-doc: advisory — blocking-set PR (manual merge)
+review-doc: advisory — blocking-set PR (§CP — approval-gated)
 
 PR #<PR> is §CP — it touches the control plane (`.claude/`/`.github/` or a gate-critical skill), OR
 it touches a **guard-touching `.decisions/**` ADR** (§CP by content, ADR 0164 — the shared
@@ -1051,7 +1051,7 @@ else `POST`):
 # opens with `review-doc:` too, so `verdict post`'s namespace guard accepts it and upserts it the
 # same way — one comment per gate, PATCH own prior marker else POST.
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
-# write your composed advisory verdict into "$VERDICT_FILE" (first line: review-doc: advisory — blocking-set PR (manual merge))
+# write your composed advisory verdict into "$VERDICT_FILE" (first line: review-doc: advisory — blocking-set PR (§CP — approval-gated))
 $VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -736,7 +736,7 @@ bind), keeping your verdict out of `ship-it`'s PASS namespace.
 > into `ship-it`'s auto-merge namespace, the ADR 0111 hazard).
 
 ```markdown
-review-skill: advisory — blocking-set PR (manual merge)
+review-skill: advisory — blocking-set PR (§CP — approval-gated)
 
 PR #<PR> touches the control plane (a gate-critical skill or a `.claude`/`.github` path — §CP) —
 the agent control plane / pipeline gates (ADR 0053/0065/0073). My verdict is **advisory only**:
@@ -770,7 +770,7 @@ canonical `Reviewed-head: @ <HEAD_SHA>` line (ADR 0151), which `ship-it`'s §CP 
 
 ```bash
 VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
-# write your composed advisory verdict into "$VERDICT_FILE" (first line: review-skill: advisory — blocking-set PR (manual merge))
+# write your composed advisory verdict into "$VERDICT_FILE" (first line: review-skill: advisory — blocking-set PR (§CP — approval-gated))
 # The guarded tool also validates the §CP advisory's `Reviewed-head: @ <sha>` anchor line is a clean
 # full 40-hex head SHA — the exact field the #2680 mktemp path leaked into (#2683).
 $VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"


### PR DESCRIPTION
The pipeline's formats contract still described control-plane PRs the way they worked before ADR 0135: it said a human merges them by hand, and every gate's canonical advisory marker was suffixed `(manual merge)`. That has not been the path for a while — a `@kamp-us/control-plane` member approves at head and `ship-it` enqueues — so anyone reading a live `(manual merge)` marker on a §CP PR was reading a stale instruction.

This retitles the canonical advisory line to `<gate>: advisory — blocking-set PR (§CP — approval-gated)` in the single source **and** in all four `review-*` templates in the same change, and restates the surrounding merge-model prose in terms of approve-then-`ship-it`-enqueue (ADR 0135 amending 0053; ADR 0048, single merge authority). It is prose only — no matcher regex moves.

Fixes #3589

## What changed

`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (the single source):

- the §CP classification echo, now `BLOCKING — control plane (§CP — approval-gated)`
- the canonical four-gate advisory block in §6.6
- the per-gate advisory lines in §6 / §6.5 / §6.7
- the three "a human merges those (ADR 0053)" sentences (§6, §6.5, §6.7), now approve-then-enqueue
- the §CP boundary statement above the classification snippet, and the three "a human does … manual-merge invariant" field notes that would otherwise contradict the retitled marker two lines away

The four copies, retitled to the byte-identical marker text:

- `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`
- `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md`
- `claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md`
- `claude-plugins/kampus-pipeline/skills/review-design/SKILL.md`

## Why the retitle cannot break verdict readback (AC4, re-verified rather than assumed)

Both live matchers anchor on the namespace + `advisory` and stop there — neither reads the trailing suffix:

- `verdict_readback_guard` (in the formats contract): `^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*advisory`
- `advisoryRe` in `packages/pipeline-cli/src/tools/verdict/gate-decision.ts`: `^\s*\*{0,2}\s*review-<gate>:\s*advisory\b`

Neither file's regexes are in this diff. `ship-it`'s three citations of the advisory line already elide the suffix (`… blocking-set PR …`), so they keep matching unchanged. The `Reviewed-head:` anchor and the `malformedEmittedSha` 40-hex check are untouched.

## How byte-identity was verified (AC3)

Extracted every occurrence of the marker text across the whole skills corpus and folded it to a unique set:

- `grep -rhoE 'advisory — blocking-set PR \(§CP — approval-gated\)' claude-plugins/kampus-pipeline/skills/ | sort | uniq -c` → **12 occurrences, one distinct string**
- the same extraction restricted to the four `review-*` skills, piped through `sort -u`, yields exactly one value
- a re-grep for `manual merge` across `claude-plugins/kampus-pipeline/skills/` returns **zero** hits

(The §6.6 block pads the gate token for column alignment, so identity is over the marker text after `<gate>:` — the part every gate shares.)

## Line numbers vs. the issue

The issue's line numbers were already stale at dispatch. Every site was re-found by string on fresh `origin/main`; the strings themselves are all still present, none had disappeared, and no new one had appeared. Current-vs-cited: `1473→1661`, `2065→2867`, `2149→2951`, `2152→2954`, `2230–2233→3032–3035`, `2330→3132`, `2333→3135`.

## Checks

`pnpm typecheck` (29/29), `pnpm lint:worktree` (no biome-handled changed files — markdown-only diff), `pipeline-cli gh-phoenix lint-skills` on all five files (clean), `pipeline-cli leak-guard scan` on all five (clean), `pipeline-cli codeowners-cp check` (32/32 §CP paths covered), and the full `@kampus/pipeline-cli` suite (179 files, 2829 tests) — all green.

## Deviations

**Class: scope — widened beyond the enumerated AC sites, within the same file and the same defect.**
Said: the ACs enumerate the `(manual merge)` markers and two "a human merges those" prose lines.
Did: also restated four adjacent sentences in the same file that assert the same retired model — the §CP boundary statement, the "human-merge-only" phrase in the `origin/main` re-resolution note, and the three "a human does (ADR 0053) … manual-merge invariant" field notes in §6/§6.5/§6.7.
Why: they sit within a few lines of the retitled markers and would have left the file asserting both models at once, which is the exact defect the issue exists to close.
Disposition: no action needed — prose only, no matcher or classification logic touched.

**Class: scope — deliberately left out of this diff.**
Said: source and copies must not diverge.
Did: left the literal `(manual merge)` string in `packages/pipeline-cli/src/tools/verdict/gate-decision.ts`'s docblock, in eight `pipeline-cli` test fixtures, in three ADRs (0073 / 0111 / 0151), and in `author-skill` / `what-shipped` / `ship-it` / `review-code` prose outside the advisory template.
Why: the ADRs are the historical record and are not edited; the test fixtures exercise the matcher, which is suffix-blind, so they stay valid either way; the remaining skill prose is a corpus-wide sweep outside this issue's enumerated surfaces. The `review-code` "§CP manual-merge path" line in particular carries a separate factual claim ("never touches ship-it Step 3.6") that a prose retitle should not silently adjudicate.
Disposition: follow-up filed — named in the progress comment on #3589.
