### PR TITLE
feat(control-plane): §CP covers the local hook-wiring config (lefthook) (#3643)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,3 +72,9 @@
 # guard-relaxing vector. The §CP `biome\.jsonc$` + `biome-plugins/` branches (ADR 0193).
 /biome.jsonc                    @kamp-us/control-plane
 /biome-plugins/                 @kamp-us/control-plane
+# Control-plane: the local hook-wiring config — `lefthook.yml` wires the CI-unbacked ref-guard
+# (#2143) and #2778 primary-index guards, and `.lefthookrc` is sourced by every generated wrapper.
+# The §CP `([^/]+/)*(lefthook|\.lefthook)[^/]+$` branch (founder ruling on #3402); `**/` is the
+# any-depth prefix (same idiom as the `**/*.sh` row above), the `*` suffix the config-name shape.
+**/lefthook*                    @kamp-us/control-plane
+**/.lefthook*                   @kamp-us/control-plane

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1591,6 +1591,17 @@ closing the #375 drift class).
     §CP** — they are CI-enforced, not human-approval-enforced. ADR 0218 records that trade, the
     three modules the core imports without retaining, and why `codeowners-cp` cannot catch a
     stale over-broad CODEOWNERS row.
+- the **local hook-wiring config** — `lefthook.yml` and its siblings, matched by the
+  `^([^/]+/)*(lefthook|\.lefthook)[^/]+$` branch. This config is what *wires* the local git hooks:
+  the ADR-0160 ref-guard (#2143) and the #2778 primary-index guards, which have **no CI backstop**
+  and are the only defense the shared local checkout has against a proven-real corruption class. An
+  edit that silently unwires them is self-weakening in exactly ADR 0187's sense, so it must not
+  auto-ship (founder ruling on #3402). The branch is a **shape, not a named list** (#2393): the same
+  depth-agnostic `([^/]+/)*` prefix the skill-`.sh` clause uses, over the `lefthook` / `.lefthook`
+  stem, so every config filename lefthook itself discovers — `lefthook.yml`, the `.yaml`/`.toml`/
+  `.json` forms, a `lefthook-local.*` override, and the `.lefthookrc` every generated hook wrapper
+  sources — is covered without enumerating one of them. The `[^/]+` leaf keeps it narrow: it matches
+  lefthook-named **leaves** only, so no other root config is swept in.
 
 A PR touching **any** path in this set is **control plane**: `ship-it` refuses to auto-merge
 it and a human merges it by hand (ADR
@@ -1618,7 +1629,10 @@ were escaping the boundary; the **lint/GritQL governance config** — `biome.jso
 since an ungated path to weaken a lint rule is a guard-relaxing vector; the **root marketplace
 manifest** — `.claude-plugin/**` — added by ADR
 [0212](https://github.com/kamp-us/phoenix/blob/main/.decisions/0212-marketplace-manifest-is-control-plane.md),
-since the file that decides what the control-plane plugin *delivers* is itself control plane).
+since the file that decides what the control-plane plugin *delivers* is itself control plane; the
+**local hook-wiring config** — `lefthook.yml` and its siblings — added on the founder ruling on
+[#3402](https://github.com/kamp-us/phoenix/issues/3402), since the config that wires the
+CI-unbacked local-integrity guards can unwire them).
 Everything else — `apps/**`,
 **non**-guard `packages/**`, `.decisions/**` (**except a guard-touching ADR** — see the content
 clause below), `.patterns/**`, every prose doc `*.md` (the
@@ -1649,7 +1663,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$|^biome\.jsonc$|^biome-plugins/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$|^biome\.jsonc$|^biome-plugins/|^([^/]+/)*(lefthook|\.lefthook)[^/]+$'
 # The list this regex is matched against is a fallible READ, so it comes from §CPREAD's
 # `cp_changed_files` (defined below) — never a bare `gh api … | grep` pipe. With pipefail off that
 # pipe reports grep's status and discards gh's, so a failed read matches nothing and reads as "no §CP

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -48,6 +48,7 @@ describe("splitTopLevelBranches", () => {
 			"packages/pipeline-cli/src/tools/tracker/gh-io\\.ts$",
 			"biome\\.jsonc$",
 			"biome-plugins/",
+			"([^/]+/)*(lefthook|\\.lefthook)[^/]+$",
 		]);
 	});
 });
@@ -127,6 +128,15 @@ describe("expandBranch", () => {
 		expect(expandBranch("biome\\.jsonc$")).toEqual([{path: "biome.jsonc", kind: "file"}]);
 		expect(expandBranch("biome-plugins/")).toEqual([{path: "biome-plugins/", kind: "dir"}]);
 	});
+
+	it("expands the lefthook branch to two any-depth globs (founder ruling on #3402)", () => {
+		// Both translations at once: `([^/]+/)*` → `**/` (any depth) and `[^/]+` → `*` (the leaf),
+		// so the shape resolves to two ownable CODEOWNERS globs rather than a named path list.
+		expect(expandBranch("([^/]+/)*(lefthook|\\.lefthook)[^/]+$")).toEqual([
+			{path: "**/lefthook*", kind: "glob"},
+			{path: "**/.lefthook*", kind: "glob"},
+		]);
+	});
 });
 
 describe("cpPaths over the live regex", () => {
@@ -164,6 +174,8 @@ describe("cpPaths over the live regex", () => {
 			"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
 			"biome.jsonc",
 			"biome-plugins/",
+			"**/lefthook*",
+			"**/.lefthook*",
 		]);
 	});
 
@@ -260,6 +272,8 @@ describe("findUncovered — the drift check", () => {
 		"/packages/pipeline-cli/src/tools/tracker/gh-io.ts @usirin",
 		"/biome.jsonc @usirin",
 		"/biome-plugins/ @usirin",
+		"**/lefthook* @usirin",
+		"**/.lefthook* @usirin",
 	].join("\n");
 
 	// The ADR-0218 narrowed rows cover every §CP path exactly — in particular the `src/*` glob row
@@ -293,6 +307,8 @@ describe("findUncovered — the drift check", () => {
 			"/packages/pipeline-cli/ @usirin",
 			"/biome.jsonc @usirin",
 			"/biome-plugins/ @usirin",
+			"**/lefthook* @usirin",
+			"**/.lefthook* @usirin",
 		].join("\n");
 		expect(findUncovered(paths, parseCodeownersPatterns(codeowners))).toEqual([]);
 	});
@@ -335,6 +351,8 @@ describe("findUncovered — the drift check", () => {
 			"packages/pipeline-cli/src/tools/trivial-diff/",
 			"packages/pipeline-cli/src/tools/verdict/",
 			"packages/pipeline-cli/src/tools/tracker/gh-io.ts",
+			"**/lefthook*",
+			"**/.lefthook*",
 		]);
 	});
 

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -35,6 +35,8 @@ const FULL_CODEOWNERS = [
 	"/packages/pipeline-cli/ @usirin",
 	"/biome.jsonc @usirin",
 	"/biome-plugins/ @usirin",
+	"**/lefthook* @usirin",
+	"**/.lefthook* @usirin",
 ].join("\n");
 
 /** A throwaway repo carrying just the two source files the gate reads. */

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -39,6 +39,35 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("biome-plugins/no-type-assertions.grit")).toBe(true);
 	});
 
+	it("classifies the local hook-wiring config as control-plane (founder ruling on #3402)", () => {
+		// `lefthook.yml` wires the ref-guard (#2143) and the #2778 primary-index guards, which have
+		// no CI backstop — an edit that unwires them must not auto-ship. The clause is a SHAPE, so
+		// every filename lefthook discovers is covered without enumerating any of them (#2393).
+		expect(isControlPlane("lefthook.yml")).toBe(true);
+		expect(isControlPlane(".lefthookrc")).toBe(true);
+		for (const ext of ["yml", "yaml", "toml", "json"]) {
+			expect(isControlPlane(`lefthook.${ext}`)).toBe(true);
+			expect(isControlPlane(`lefthook-local.${ext}`)).toBe(true);
+			expect(isControlPlane(`.lefthook.${ext}`)).toBe(true);
+		}
+		// depth-agnostic, like the skill-`.sh` clause: a nested package's own config is §CP too.
+		expect(isControlPlane("apps/web/lefthook.yml")).toBe(true);
+		expect(isControlPlane("packages/pipeline-cli/nested/lefthook.yml")).toBe(true);
+	});
+
+	it("does NOT over-widen: the lefthook clause matches lefthook-named LEAVES only", () => {
+		// The negative half of the #3402 clause — a clause that matched everything would pass a
+		// positive-only test. The stem anchors the leaf, so neither a sibling root config nor an
+		// ordinary file that merely MENTIONS lefthook is swept in.
+		expect(isControlPlane("package.json")).toBe(false);
+		expect(isControlPlane(".decisions/0068-adopt-lefthook-at-second-git-hook.md")).toBe(false);
+		expect(isControlPlane("apps/web/src/hooks/use-lefthook.ts")).toBe(false);
+		// the stem must START the leaf — a name that merely CONTAINS it stays out
+		expect(isControlPlane("docs/my-lefthook-notes.md")).toBe(false);
+		// `[^/]+` demands a leaf after the stem, so a bare `lefthook` DIRECTORY prefix is not §CP
+		expect(isControlPlane("lefthook/README.md")).toBe(false);
+	});
+
 	it("classifies the root marketplace manifest as control-plane (ADR 0212, #3933)", () => {
 		// The file declaring what the `kampus` marketplace serves — including kampus-pipeline's
 		// `source` tree, which validate-gate-path-drift.sh resolves .claude/skills against. It gets

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -32,6 +32,17 @@
  * test of ADR 0187 — merging it unreviewed CAN weaken a gate. Same class of decision as
  * ADR 0187's enforcement-surface test; recorded in ADR 0193.
  *
+ * The lefthook clause (`^([^/]+/)*(lefthook|\\.lefthook)[^/]+$`) is §CP because that config is
+ * what WIRES the local git hooks — the ADR-0160 ref-guard (#2143) and the #2778 primary-index
+ * guards, which have no CI backstop and are the only defense of the shared local checkout against
+ * a proven-real corruption class. An edit that silently unwires them must not auto-ship (founder
+ * ruling on #3402). It is a SHAPE, not a named list (#2393): a depth-agnostic `([^/]+/)*` prefix
+ * (the same idiom as the skill-`.sh` clause above) over the `lefthook` / `.lefthook` stem, so every
+ * config filename lefthook itself discovers — `lefthook.yml`, the `.yaml`/`.toml`/`.json` forms, the
+ * `lefthook-local.*` override, and the `.lefthookrc` the generated wrappers source — is covered
+ * without enumerating any of them. The stem-plus-`[^/]+` leaf is what keeps it narrow: it matches
+ * lefthook-named LEAVES only, so nothing else at the repo root is swept in.
+ *
  * The marketplace-manifest clause (`^\.claude-plugin/`) needs its OWN branch because the
  * `^(\.claude|\.github)/` branch requires a literal `/` after `.claude` — the character after
  * `.claude` in `.claude-plugin/` is a hyphen, so that branch never matched it. Anchored to the
@@ -72,4 +83,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^\\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^packages/pipeline-cli/src/tools/tracker/gh-io\\.ts$|^biome\\.jsonc$|^biome-plugins/";
+	"^(\\.claude|\\.github)/|^\\.claude-plugin/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/src/[^/]+$|^packages/pipeline-cli/src/tools/(ci-required|codeowners-cp|control-plane-paths|cp-cardinality|cp-classify|review-head|trivial-diff|verdict)/|^packages/pipeline-cli/src/tools/tracker/gh-io\\.ts$|^biome\\.jsonc$|^biome-plugins/|^([^/]+/)*(lefthook|\\.lefthook)[^/]+$";


### PR DESCRIPTION
`lefthook.yml` is the file that switches the repo's local git hooks on. Those hooks — the ref-guard and the primary-index guards — are the only thing standing between the shared local checkout and a corruption class we have already hit twice, and none of them runs in CI. That means an agent could quietly turn them off and the change would sail through on green. This PR makes the hook-wiring config control-plane, so any edit to it stops for a human.

The boundary regex gains one branch that matches lefthook config by *shape* rather than by name, so a rename or a new config format cannot slip around it.

Fixes #3643

## What changed

`CONTROL_PLANE_RE` gains one anchored branch:

```
^([^/]+/)*(lefthook|\.lefthook)[^/]+$
```

It is a **shape, not a named list** (#2393). The `([^/]+/)*` prefix is the same depth-agnostic idiom the skill-`.sh` clause uses (#2950); the `lefthook` / `.lefthook` stem plus a `[^/]+` leaf covers every config filename lefthook 2.1.9 itself discovers — `lefthook.yml`, the `.yaml` / `.toml` / `.json` forms, a `lefthook-local.*` override, and the `.lefthookrc` that every generated hook wrapper sources — without enumerating one of them. (Grounded against the shipped lefthook binary + its bundled `schema.json`, not from memory.)

Three surfaces move together, because they are required to stay in lockstep:

- `packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts` — the single-source const.
- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` — the byte-synced `CONTROL_PLANE_RE=` line the live gates re-resolve from `origin/main` (#981), plus the §CP prose bullet.
- `.github/CODEOWNERS` — the two rows (`**/lefthook*`, `**/.lefthook*`) the `codeowners-cp` drift gate requires for the branch's expansion.

Tests: `control-plane-paths.unit.test.ts` gains a positive case (the whole discovered-config family, at the root and nested) **and** a negative case (a sibling root config, an ADR that merely names lefthook, a `use-lefthook.ts` module, a `lefthook` *directory* prefix). `codeowners-cp.unit.test.ts` / `gate.test.ts` fixtures are extended for the new branch and its two-glob expansion.

## Blast radius (measured, not asserted)

Ran old vs. new regex over all **2526** tracked files. Newly §CP: **exactly two** — `lefthook.yml` and `.lefthookrc`. Declassified: **zero**.

ADR-0218 import closure: `core-import-closure.unit.test.ts` derives `isCore` from `CONTROL_PLANE_RE`, so a widening here *can* move the core. It does not — the new branch matches only lefthook-named leaves, and no such file exists under `packages/pipeline-cli/src/`. The test passes unchanged (6/6), residue still exactly the three recorded `ALLOWED_ESCAPES`.

Verification run: full `pipeline-cli` suite 2832/2832; `pnpm typecheck` clean; `pnpm lint:worktree` exit 0; live `codeowners-cp check` reports all 34 §CP paths covered; `validate-gate-path-drift.sh` OK across all 17 checks.

## Deviations

- **Class: narrowed/widened the suggested fix-shape.** *Said:* the issue names repo-root `lefthook.yml` "and sibling hook-wiring config of the same shape." *Did:* the shape also captures `.lefthookrc`, which is genuinely hook-wiring — every generated hook wrapper sources it before lefthook runs, so an edit there disables all hooks just as effectively as editing `lefthook.yml`. *Why:* a shape that stopped at `lefthook.yml` would leave the equally CI-unbacked `.lefthookrc` auto-shippable, which is the hole the ruling exists to close. *Disposition:* deliberate, measured — it is 1 of the 2 newly-§CP files; no action needed.
- **Class: bounded a scope I chose not to chase.** *Said:* nothing about lefthook's config *directory* forms. *Did:* the branch is leaf-anchored, so lefthook 2.x's `.lefthook/` and `.lefthook-local/` config **directories** are not classified §CP. *Why:* neither exists in this repo, and covering them would need a trailing-boundary alternation whose `codeowners-cp` expansion produces four awkward glob rows — cost out of proportion to a hypothetical. *Disposition:* for the reviewer to judge; say the word and I will widen the branch to `…[^/]+(/|$)` plus the matching CODEOWNERS rows.
- **Class: touched files the issue did not name.** *Said:* extend `CONTROL_PLANE_RE` and its unit test. *Did:* also edited the formats doc, `.github/CODEOWNERS`, and the `codeowners-cp` fixtures. *Why:* not optional — the const↔formats byte-equality test, `validate-gate-path-drift.sh`, and the `codeowners-cp` gate all fail closed if any one of them lags the const. *Disposition:* no action needed; this is the mandatory lockstep set.

## Merge

This PR is itself §CP (it edits `packages/pipeline-cli/`, `.github/`, and a gate skill), so it **banks for a control-plane human merge** — it must not auto-ship. That is the property `#3402` relies on: the boundary edit is classified against `origin/main`'s boundary, not its own.
