### PR TITLE
fix(review-skills): state the leak check, don't spell out the tokens

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -606,6 +606,7 @@ Run each, scoped to the files the PR touches:
    # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
    PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
    # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+   # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
    gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment
    ```
 
@@ -1102,7 +1103,7 @@ Verified PR #<PR> against #<ISSUE>'s acceptance criteria + the doc-hygiene check
 
 **Doc hygiene**
 - [PASS] House-format — <evidence>
-- [FAIL] No leaked local/home paths — `<the leaked /Users/… or ~/… line>` at <file:line>
+- [FAIL] No leaked local/home paths — added-lines scan hit <the class the matcher named> at <file:line>; cite the class, never the matched token
 - [FAIL] Single Diátaxis mode — host <mode> intrudes into <mode> at <file:line>; split <what> to <surface>
 - [PASS] Clear, concise prose (Strunk, no AI-tell density) — <evidence>
 - [UNVERIFIABLE] <check> — <why; what'd make it checkable>

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -590,30 +590,39 @@ Run each, scoped to the files the PR touches:
    (check the target file is in the repo at the PR head). A dead in-repo link is a FAIL.
    In-repo links must be standard markdown relative paths, not Obsidian `[[wikilinks]]`
    (CLAUDE.md conventions).
-4. **No leaked local/home paths — the #158 class.** The diff introduces **no** absolute
-   home/local/vault path: grep the added lines for `/Users/`, a leading `~/`, `~/.claude`,
-   `~/.agent`, or vault-style sibling-repo paths. Repo-relative paths only. This is a hard
-   FAIL — a leaked path in a committed doc is the exact regression class #158 exists to
-   stop.
+4. **No leaked local/home paths — the #158 class.** The diff introduces **no** machine-local
+   path — a home directory, an absolute machine path, a scratch/temp root, or a sibling-repo
+   clone. Repo-relative paths only. This is a hard FAIL — a leaked path in a committed doc is
+   the exact regression class #158 exists to stop.
+
+   Run the shared matcher over the added lines. **Do not restate the forbidden shapes** — not
+   here, not in a character class, not in your evidence row. The pattern set is single-sourced
+   in `packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts`, so an inline copy drifts
+   from it; and because this row's evidence lands in a verdict comment, a spelled-out token is
+   read back by `leak-guard scan-pr` as a real leak and fail-closes the shipper on a PR that
+   leaks nothing (#4220).
 
    ```bash
-   # added lines only ('+'), scanned for home/local/vault path leaks
-   gh pr diff $PR | grep -E '^\+' | grep -nE '/Users/|[^A-Za-z0-9]~/|~/\.(claude|agent)|/vault/'
+   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+   # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+   gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment
    ```
 
+   Cite a hit by the **class** the scan names and the `file:line` from the diff hunk it sits
+   in — never by quoting the matched token, which just moves the leak into your verdict.
+
    A hit is a FAIL **unless it is one of the deliberate-non-leak cases — judge each in
-   context**: a fenced *example* of what-not-to-do, or — for a doc whose subject *is* path
-   hygiene (a path-hygiene check, skill, convention doc, or the check's own pattern/prose;
-   **this very SKILL.md is the canonical false positive** — it spells out `/Users/`,
-   `~/.claude`, `~/.agent`, `/vault/` as the *pattern*, not as real paths) — a token that
-   is **documented as the leak pattern** rather than **committed as a real path**. The
-   discriminator is exactly that: committed-as-a-real-path → FAIL; documented-as-a-pattern
-   → expected, pass. For an ordinary doc the default is still fail. Note that a path PR is
-   often in the blocking set anyway (this file touches `.claude/`, so your verdict here is
-   advisory — Step 0), but a sibling path-hygiene doc *outside* `.claude/`/`.github/` is
-   non-blocking and would hit this carve-out for real. The line number `grep -n` prints is
-   the position in the filtered stream, not the file line — locate the real `file:line`
-   from the diff hunk the hit sits in.
+   context**: a fenced *example* of what-not-to-do, or a doc whose subject *is* path hygiene
+   (a path-hygiene check, skill, or convention doc) where the token is **documented as the
+   pattern** rather than **committed as a real path**. The guard encodes that carve-out for
+   the *file* surface as its own self-exempt list, and this SKILL.md is on it; the added-lines
+   scan above carries no such list, so the judgment is yours. The discriminator is exactly
+   that: committed-as-a-real-path → FAIL; documented-as-a-pattern → expected, pass. For an
+   ordinary doc the default is still fail. Note that a path-hygiene PR is often in the
+   blocking set anyway (this file touches `.claude/`, so your verdict here is advisory —
+   Step 0), but a sibling path-hygiene doc *outside* `.claude/`/`.github/` is non-blocking
+   and would hit this carve-out for real.
 5. **Supersession noted + cross-linked.** If this doc replaces or amends a prior decision,
    the **superseding** doc names what it supersedes *and* the **superseded** doc is updated
    to point forward (its **frontmatter `status`** reflects `superseded by [NNNN]` — the

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -307,6 +307,7 @@ Verify **all** of the following over the head diff. Each is conjunctive; **one m
    # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
    PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
    # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+   # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
    git show "$PR_REF" | grep '^+' | "$PCLI" leak-guard scan-comment
    ```
    A repo-relative path (`apps/web/…`, `.decisions/…`) is fine; a hit is a **FAIL** — cite it by

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -291,16 +291,28 @@ Verify **all** of the following over the head diff. Each is conjunctive; **one m
    Treat any hit as a finding to confirm by eye (a variable *named* `token` referencing a binding
    is fine; a literal secret value is a **FAIL**).
 
-3. **No leaked machine-local / home / absolute / sibling-repo path.** No `~/`, `/Users/…`,
-   `/home/…`, a vault path, an absolute machine path, or a sibling-clone path in the added lines
-   — committed files, like PR bodies and comments, cite **repo-relative** paths only (the
-   standing no-local-paths invariant). Scan the added hunks:
+3. **No leaked machine-local / home / absolute / sibling-repo path.** The added lines carry no
+   machine-local path — a home directory, an absolute machine path, a scratch/temp root, or a
+   sibling-repo clone. Committed files, like PR bodies and comments, cite **repo-relative** paths
+   only (the standing no-local-paths invariant).
+
+   Scan the added hunks with the shared matcher, and **do not restate the forbidden shapes** —
+   not here, not in a character class, not in your evidence row. The pattern set is
+   single-sourced in `packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts` (a gap belongs
+   there, never in an inline copy that drifts from it), and a restated token in this row lands in
+   a verdict comment that `leak-guard scan-pr` then reads as a real leak, fail-closing the shipper
+   on a clean PR (#4220):
 
    ```bash
-   git show "$PR_REF" | grep -nE '^\+' | grep -nE '(~/|/Users/|/home/|/private/var/folders/|[A-Za-z]:\\\\)' || echo "no local/home/absolute paths in added lines"
+   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+   # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+   git show "$PR_REF" | grep '^+' | "$PCLI" leak-guard scan-comment
    ```
-   A repo-relative path (`apps/web/…`, `.decisions/…`) is fine; a machine-local/home/absolute/
-   sibling-repo path is a **FAIL**.
+   A repo-relative path (`apps/web/…`, `.decisions/…`) is fine; a hit is a **FAIL** — cite it by
+   the class the scan names, never by quoting the matched token. A hit you suspect is a documented
+   pattern rather than a real path is exactly the ambiguity this lighter gate refuses to resolve:
+   FAIL, and let the PR take the full review path.
 
 A clean pass on **all three** (plus the Step 0 triviality re-affirm) is a PASS. Any miss, **or
 any ambiguity you can't resolve from the diff**, is a FAIL — default-deny, never an


### PR DESCRIPTION
A reviewer that documented its own leak check used to trip the leak detector. The `review-doc` and `review-trivial` checklists spelled out the forbidden path shapes literally — in the criterion prose and again in a hand-written `grep -E` character class — so a reviewer writing concrete evidence restated them, and `leak-guard scan-pr` read those restated tokens in the landed verdict comment as real leaks. The shipper then fail-closed and refused to enqueue an approved, green PR that leaked nothing (seen on PR #4210).

Both checklists now state the check without naming any shape, and run the shared matcher instead of an inline character class. The pattern set stays single-sourced in `packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts`, so the reviewers' instructions can no longer drift from the guard — or re-emit its tokens into a verdict.

Fixes #4220

## What changed

- `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md`, doc-hygiene criterion 4 — the prose states the check by category, and the runnable snippet is now `gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment` in place of the inline character class. The deliberate-non-leak carve-out is kept but de-literalized: it points at the guard's own file-surface self-exempt list rather than restating the exempt tokens.
- `claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md`, criterion 3 — the same treatment, scanning the added hunks off the head ref through `leak-guard scan-comment`. Its default-deny stance is unchanged: a hit a reviewer suspects is a documented pattern rather than a real path is a FAIL that routes the PR to the full review path.
- Both rows now tell the reviewer to cite a hit by the **class** the scan names and its `file:line`, never by quoting the matched token — the emit-side habit that caused the recurrence.
- **(repair round 1)** `review-doc`'s FAIL verdict template — the leaked-paths evidence row no longer tells the reviewer to inline the offending line. It now cites the hit by the class the matcher named plus `file:line`, matching criterion 4 and `review-trivial`'s already-generic FAIL rows. On the FAIL path the inlined line is a *real* machine-local path, so the old row was strictly worse than the bug being fixed.
- **(repair round 1)** Both leak-scan snippets — one clause naming the third, non-leak non-zero exit (the fail-closed stdin read, #4010) as an *unresolved* scan rather than a pass. They previously documented only the clean and leak-found codes.

No `leak-guard` pattern, arm, or exemption is added, removed, or narrowed, and the verdict templates keep their generic `<evidence>` placeholder. The #3492 ruling — fix emit-side, never carve out the guard — holds.

## Evidence

Each of the four enumeration sites named in the issue, piped through `pipeline-cli leak-guard scan-comment` (exit 2 = leak reported, 0 = clean):

| Site | Before (`origin/main`) | After |
|---|---|---|
| `review-doc` criterion 4 block (prose + snippet) | exit 2 | **exit 0** |
| `review-doc` criterion 4 `grep -E` snippet alone | exit 2 | (line removed) |
| `review-trivial` criterion 3 block (prose + snippet) | exit 2 | **exit 0** |
| `review-trivial` criterion 3 `grep -E` snippet alone | exit 2 | (line removed) |

Also clean: the diff's added lines through `leak-guard scan-comment` (exit 0), both edited files through `leak-guard scan` (file surface, exit 0), `pipeline-cli gh-phoenix lint-skills` over both files (clean), and `pnpm lint:worktree` (markdown-only diff, clean skip).

The prescribed pipeline was exercised on fixtures, not just read: a fixture added line carrying a home path exits 2 and names its class; a repo-relative fixture exits 0.

**Repair round 1** re-ran the same checks at the repaired head: added lines through `leak-guard scan-comment` (exit 0), both files through `leak-guard scan` (exit 0), and `gh-phoenix lint-skills` over both files (clean). The third exit code documented in the new clause is grounded in source, not asserted: the leak code and the stdin-read-failure code are both declared constants in `packages/pipeline-cli/src/tools/leak-guard/command.ts` and `packages/pipeline-cli/src/read-stdin.ts`.

## §CP

`pipeline-cli cp-classify classify` returns **control-plane [path-match]** — `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md` matches the live `CONTROL_PLANE_RE`. BLOCKING: this PR takes the control-plane approval route (human merge by a @kamp-us/control-plane owner), per the issue's last acceptance criterion.

## Deviations

- **Narrowed the shape coverage of `review-trivial`'s inline check.** *Said:* point the reviewer at the shared matcher rather than a hand-maintained character class. *Did:* replaced the class with `leak-guard scan-comment`, which has no arm for two shapes the old class listed (a `/home` prefix, and a Windows drive-letter path), so the reviewer's inline check no longer catches those two. *Why:* single-sourcing is the acceptance criterion's whole point — a gap belongs in `path-matcher.ts`, where every consumer gets it, not in an inline copy that drifts. Re-adding them inline would recreate exactly the defect this issue fixes. *Disposition:* for the reviewer to judge; the criterion prose now says a gap belongs in the shared matcher. Not filed as a follow-up, because the guard is the arbiter of its own pattern set and #3492 forbids treating a reviewer's inline copy as the authority.
- **Chose the comment-surface scan over the file-surface one.** *Said:* point at `pipeline-cli leak-guard scan-comment` / the `leak-guard` tool. *Did:* used `scan-comment` in both skills, which applies no per-file self-exempt list. *Why:* it reads the added lines from stdin, so it needs no materialized head tree — and it is the verb the issue names. The cost is that `review-doc`'s carve-out for path-hygiene docs is now a reviewer judgment rather than an automatic exemption; the criterion says so explicitly, and the guard's file-surface list is cited as the reference. *Disposition:* no action needed — the carve-out was already a judgment call in the prose being replaced.
- **Dropped an obsolete caveat.** *Said:* de-literalize criterion 4. *Did:* also removed its trailing note about `grep -n` printing a filtered-stream line number. *Why:* the `grep -n` it described is gone. *Disposition:* replaced by the cite-by-class instruction.
- **(repair round 1) Did not fold the third narrowed shape into the separately-filed matcher issue.** *Said:* the review's closing advisory suggests adding the bare home-directory-with-any-segment shape to the separately-filed `path-matcher.ts` issue, since this PR body names only two of the three narrowed shapes. *Did:* left that issue untouched and named the third shape here instead. *Why:* the repair scope is the one `[FAIL]` row plus the exit-code clause, and writing to another issue is a cross-issue mutation this run holds no pre-authorization for. *Disposition:* surfaced to the dispatcher for routing; the narrowing itself is unchanged and already disclosed above.
