### PR TITLE
fix(cli-invocation-guard): fail a PR only on violations it introduced (#4250)

### DIFF
--- a/.github/workflows/cli-invocation-guard.yml
+++ b/.github/workflows/cli-invocation-guard.yml
@@ -8,11 +8,25 @@ name: cli-invocation-guard
 #
 # The corpus is `*.md` AND `*.sh`. The skills extract their fenced shell into per-skill
 # `scripts/*.sh` (epic #4435), and a `.md`-only corpus would let each extraction take call
-# sites off this scan while the job kept exiting 0 (#4486).
+# sites off this scan while the job kept exiting 0 (#4486). Both legs of the `find` are
+# carried on BOTH steps below — a baseline enumerated over a narrower corpus than the head is
+# a baseline the per-surface zero-scope floor correctly judges unusable.
 #
-# Scans the FULL corpus (not just changed files), so a bare call anywhere is caught
-# regardless of which PR introduced it, and FAILS CLOSED on zero scope per ADR 0092 —
-# per surface: no file scanned, no runnable `.md` fence, or no `.sh` file, is exit 3.
+# DETECTION is corpus-wide on both legs — a bare call anywhere is found regardless of which
+# PR introduced it. ATTRIBUTION is what differs (#4250):
+#   pull_request  — scan the merge-base too, and fail only on violations this head INTRODUCED.
+#                   A violation already on `main` is reported as pre-existing, not charged to
+#                   an innocent PR (which halted the shipper and misled a reviewer into
+#                   "repairing" a file the PR did not touch).
+#   push: main    — no baseline, so ANY violation reds. A dirty `main` stays red until a
+#                   hotfix PR clears it; that is the leg that makes pre-existing findings a
+#                   bounded state rather than a permanent exemption.
+#
+# FAILS CLOSED on zero scope per ADR 0092, per surface — and the same way on the new inputs:
+# an unresolvable merge-base, a base tree that fails to materialize, or a base scan that saw
+# nothing all red, because none of them may read as "no newly-introduced violations". When
+# that happens the summary step still publishes WHY, so a fail-closed red never renders a
+# blank check surface — the #4250 complaint verbatim.
 
 on:
   pull_request:
@@ -32,6 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          # The merge-base scan needs history, not just the merge commit.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4.1.0
 
@@ -42,9 +59,74 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Scan the plugin corpus for bare pipeline-cli invocations
+      - name: Scan the merge-base corpus (the attribution baseline)
+        id: baseline
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
+          MERGE_BASE="$(git merge-base "$BASE_SHA" HEAD)" || {
+            echo "cli-invocation-guard: FAIL — could not resolve the merge-base against $BASE_SHA. An unresolvable base is NOT 'no pre-existing violations' (ADR 0092; #4250)." >&2
+            exit 1
+          }
+          echo "merge-base: $MERGE_BASE"
+          # Materialize the base tree WITHOUT moving a HEAD. `git worktree add --detach` is a
+          # checkout, and the CI tree is the PRIMARY checkout, so this repo's own ref-guard
+          # reference-transaction hook (ADR 0160 / #2270) aborts the HEAD-detaching update —
+          # exit 128 on every pull_request run, deterministically. `git archive` streams a tree
+          # to a tar and updates no ref, so it neither trips ref-guard nor fires the
+          # post-checkout `bootstrap-deps` hook (a redundant second install per run). Failing to
+          # read the tree fails the step under `pipefail` — a base we cannot materialize is not
+          # "no pre-existing violations" (ADR 0092).
+          mkdir -p "$RUNNER_TEMP/base"
+          git archive --format=tar "$MERGE_BASE" -- claude-plugins | tar -x -C "$RUNNER_TEMP/base"
+          # Run from the base tree so the manifest's paths are the same repo-relative paths the
+          # head scan emits — that pairing is what `attribute` keys on.
+          cd "$RUNNER_TEMP/base"
           find claude-plugins -type f \( -name '*.md' -o -name '*.sh' \) -print0 \
             | sort -z \
-            | xargs -0 node packages/pipeline-cli/src/bin.ts cli-invocation-guard check
+            | xargs -0 node "$GITHUB_WORKSPACE/packages/pipeline-cli/src/bin.ts" \
+                cli-invocation-guard baseline --out "$RUNNER_TEMP/base-findings.json"
+
+      - name: Scan the plugin corpus for bare pipeline-cli invocations
+        id: scan
+        run: |
+          set -euo pipefail
+          # Positional params, not an array: `"$@"` expands to nothing when unset under `set -u`
+          # on every bash, which an empty `"${arr[@]}"` only does from 4.4 on.
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            set -- --baseline "$RUNNER_TEMP/base-findings.json"
+          else
+            set --
+          fi
+          find claude-plugins -type f \( -name '*.md' -o -name '*.sh' \) -print0 \
+            | sort -z \
+            | xargs -0 node packages/pipeline-cli/src/bin.ts cli-invocation-guard check "$@" \
+            2>&1 | tee "$RUNNER_TEMP/guard-output.txt"
+
+      - name: Publish the attributed verdict to the check surface
+        # `always()`, with no `steps.scan` condition: when the scan never runs — the baseline step
+        # died, so `scan` is skipped — that is exactly the run whose red most needs explaining, and
+        # gating on the scan is what made it publish nothing at all (#4250).
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo '### cli-invocation-guard'
+            echo
+            if [ -s "$RUNNER_TEMP/guard-output.txt" ]; then
+              echo '```'
+              cat "$RUNNER_TEMP/guard-output.txt"
+              echo '```'
+            else
+              echo 'No attributed verdict: the corpus scan produced no output, so the guard failed before it could judge this change.'
+              echo
+              echo '| step | outcome |'
+              echo '| --- | --- |'
+              echo "| merge-base baseline | ${{ steps.baseline.outcome }} |"
+              echo "| corpus scan | ${{ steps.scan.outcome }} |"
+              echo
+              echo 'This is a guard-infrastructure failure, not a §CLI violation attributable to this change — read the failing step log for the cause.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts
@@ -20,6 +20,10 @@
  * delimiters, scanned whole. Without that reach, every extraction of fenced shell into a
  * per-skill `scripts/*.sh` takes its call sites off the scan while the guard keeps exiting 0
  * (#4486, the #4470 class; the unit-of-scan answer follows #4448's consumer precedent).
+ *
+ * Detection is corpus-wide by design; ATTRIBUTION is what `attribute` below adds (#4250). The
+ * scan still sees every violation anywhere in the tree — only the verdict is narrowed, on the
+ * PR leg, to the ones this head introduced.
  */
 
 export interface ScanFile {
@@ -147,3 +151,85 @@ export const scanCorpus = (files: ReadonlyArray<ScanFile>): GuardResult => {
  */
 export const isZeroScope = (result: GuardResult): boolean =>
 	result.scanned.length === 0 || result.fenceCount === 0 || result.shellFileCount === 0;
+
+/** Whether a head finding was already there at the merge-base, or this head introduced it. */
+export type Attribution = "new" | "pre-existing";
+
+export interface AttributedFinding extends Finding {
+	readonly attribution: Attribution;
+}
+
+/**
+ * A finding's identity for baseline comparison: the file plus the exact offending text, and
+ * deliberately NOT the line number — an unrelated edit above shifts every line below it, and a
+ * shifted line is the same pre-existing violation, not a new one. Keying on the file (rather
+ * than text alone) keeps a violation MOVED into another file attributable, which is the strict
+ * direction.
+ */
+const findingKey = (f: Finding): string => `${f.file}\t${f.text}`;
+
+/**
+ * Classify each head finding against the merge-base's findings.
+ *
+ * The diff is a MULTISET, not a set: a file carrying one offending line at the base and two at
+ * head introduced one, and the second must not hide behind the first. That is the property
+ * that keeps this from degenerating into "any file that was ever dirty is forever exempt".
+ */
+export const attribute = (
+	head: ReadonlyArray<Finding>,
+	baseline: ReadonlyArray<Finding>,
+): ReadonlyArray<AttributedFinding> => {
+	const unconsumed = new Map<string, number>();
+	for (const f of baseline) {
+		const key = findingKey(f);
+		unconsumed.set(key, (unconsumed.get(key) ?? 0) + 1);
+	}
+	return head.map((f) => {
+		const key = findingKey(f);
+		const left = unconsumed.get(key) ?? 0;
+		if (left === 0) return {...f, attribution: "new"};
+		unconsumed.set(key, left - 1);
+		return {...f, attribution: "pre-existing"};
+	});
+};
+
+/**
+ * A baseline is trustworthy only if the base-side scan actually looked at something. A zero
+ * scope on ANY axis — including the `.sh` surface (#4486) — means the base scan is broken, and a
+ * broken base scan must never read as "nothing was pre-existing": that inverts to "everything is
+ * newly introduced" on one leg and, if the emptiness came from the other direction, would mask
+ * real new violations. Callers red on false (ADR 0092 §ZS, extended to the baseline input —
+ * #4250).
+ */
+export const isUsableBaseline = (baseline: GuardResult): boolean => !isZeroScope(baseline);
+
+const isFinding = (value: unknown): value is Finding => {
+	if (typeof value !== "object" || value === null) return false;
+	const f = value as Record<string, unknown>;
+	return typeof f.file === "string" && typeof f.line === "number" && typeof f.text === "string";
+};
+
+/**
+ * Parse a `baseline`-emitted manifest back into a `GuardResult`. `null` = unusable, which reds.
+ *
+ * Every scope axis is asserted present AND numeric, `shellFileCount` included: a manifest written
+ * by a build predating the `.sh` surface (#4486) omits the field, it reads back `undefined`, and
+ * `isZeroScope`'s `=== 0` test does not catch that — so a zero-shell-scope baseline would sail
+ * through as usable. Only reachable under version skew between the base-side `baseline` and the
+ * head-side `check`, but "no pre-existing violations" is the wrong direction to be wrong in.
+ */
+export const parseBaseline = (raw: string): GuardResult | null => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw) as unknown;
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== "object" || parsed === null) return null;
+	const {findings, scanned, fenceCount, shellFileCount} = parsed as Record<string, unknown>;
+	if (!Array.isArray(findings) || !findings.every(isFinding)) return null;
+	if (!Array.isArray(scanned) || !scanned.every((s) => typeof s === "string")) return null;
+	if (typeof fenceCount !== "number") return null;
+	if (typeof shellFileCount !== "number") return null;
+	return {findings, scanned, fenceCount, shellFileCount};
+};

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.unit.test.ts
@@ -1,5 +1,12 @@
 import {assert, describe, it} from "@effect/vitest";
-import {isZeroScope, scanCorpus, scanFile} from "./cli-invocation-guard.ts";
+import {
+	attribute,
+	isUsableBaseline,
+	isZeroScope,
+	parseBaseline,
+	scanCorpus,
+	scanFile,
+} from "./cli-invocation-guard.ts";
 
 const TICKS = "```";
 const fence = (lang: string, ...lines: ReadonlyArray<string>): string =>
@@ -239,5 +246,132 @@ describe("cli-invocation-guard core", () => {
 		assert.isTrue(isZeroScope(scanCorpus([{file: "a.md", content: fence("bash", "true")}])));
 		// …and the mirror: shell files present, markdown surface collapsed.
 		assert.isTrue(isZeroScope(scanCorpus([{file: "a.sh", content: "true\n"}])));
+	});
+});
+
+describe("cli-invocation-guard attribution (#4250)", () => {
+	const OFFENDER = "pipeline-cli claim status --issue 1";
+
+	it("reproduces the #4229 shape — base carries the violation, head introduces none", () => {
+		// The `main` tree that PR #4229 was merged against already carried the offender; the PR's own
+		// files were clean. The corpus scan (the `push: main` leg) must still red, and the attributed
+		// verdict (the `pull_request` leg) must be green.
+		const offenderFile = {file: "crew/em.md", content: fence("bash", OFFENDER)};
+		const base = scanCorpus([offenderFile, {file: "skills/a.md", content: fence("bash", "true")}]);
+		const head = scanCorpus([
+			offenderFile,
+			{file: "skills/a.md", content: fence("bash", "echo edited-by-this-pr")},
+		]);
+
+		assert.strictEqual(head.findings.length, 1, "the main leg still reds on the dirty corpus");
+		const attributed = attribute(head.findings, base.findings);
+		assert.deepStrictEqual(
+			attributed.map((f) => f.attribution),
+			["pre-existing"],
+			"the PR leg attributes the sole violation to the base, not to this head",
+		);
+	});
+
+	it("still catches a violation this head introduced, in a file the base never had", () => {
+		const base = scanCorpus([{file: "skills/a.md", content: fence("bash", "true")}]);
+		const head = scanCorpus([
+			{file: "skills/a.md", content: fence("bash", "true")},
+			{file: "skills/new.md", content: fence("bash", OFFENDER)},
+		]);
+		const attributed = attribute(head.findings, base.findings);
+		assert.deepStrictEqual(
+			attributed.map((f) => f.attribution),
+			["new"],
+		);
+	});
+
+	it("still catches a violation added to a file that was ALREADY dirty (multiset, not set)", () => {
+		// The loosening that would make the guard useless: exempting a file because it was dirty at
+		// the base. A second offending line in the same file is this head's, and must red.
+		const base = scanCorpus([{file: "skills/a.md", content: fence("bash", OFFENDER)}]);
+		const head = scanCorpus([
+			{file: "skills/a.md", content: fence("bash", OFFENDER, "pipeline-cli verdict read --pr 1")},
+		]);
+		const attributed = attribute(head.findings, base.findings);
+		assert.deepStrictEqual(
+			attributed.map((f) => f.attribution),
+			["pre-existing", "new"],
+		);
+	});
+
+	it("still catches a duplicated offending line — two copies of what the base had once", () => {
+		const base = scanCorpus([{file: "skills/a.md", content: fence("bash", OFFENDER)}]);
+		const head = scanCorpus([{file: "skills/a.md", content: fence("bash", OFFENDER, OFFENDER)}]);
+		assert.strictEqual(
+			attribute(head.findings, base.findings).filter((f) => f.attribution === "new").length,
+			1,
+		);
+	});
+
+	it("ignores a line-number shift — an unrelated edit above is not a new violation", () => {
+		const base = scanCorpus([{file: "skills/a.md", content: fence("bash", OFFENDER)}]);
+		const head = scanCorpus([
+			{file: "skills/a.md", content: `prose added above\n\n${fence("bash", OFFENDER)}`},
+		]);
+		assert.notStrictEqual(head.findings[0]?.line, base.findings[0]?.line);
+		assert.deepStrictEqual(
+			attribute(head.findings, base.findings).map((f) => f.attribution),
+			["pre-existing"],
+		);
+	});
+
+	it("attributes a violation MOVED into another file — the strict direction", () => {
+		const base = scanCorpus([{file: "skills/a.md", content: fence("bash", OFFENDER)}]);
+		const head = scanCorpus([{file: "skills/b.md", content: fence("bash", OFFENDER)}]);
+		assert.deepStrictEqual(
+			attribute(head.findings, base.findings).map((f) => f.attribution),
+			["new"],
+		);
+	});
+
+	it("with an empty baseline every violation is attributable (the push: main leg)", () => {
+		const head = scanCorpus([{file: "skills/a.md", content: fence("bash", OFFENDER)}]);
+		assert.deepStrictEqual(
+			attribute(head.findings, []).map((f) => f.attribution),
+			["new"],
+		);
+	});
+
+	it("rejects a zero-scope baseline — a broken base scan is never 'nothing pre-existing'", () => {
+		const shellFile = {file: "a.sh", content: "true\n"};
+		assert.isFalse(isUsableBaseline(scanCorpus([])));
+		assert.isFalse(isUsableBaseline(scanCorpus([{file: "a.md", content: "prose, no fence"}])));
+		// Per surface (#4486): a base enumerated over `.md` only is a NARROWER corpus than the head
+		// scan, so its silent-on-shell manifest must not read as "nothing pre-existing there".
+		assert.isFalse(isUsableBaseline(scanCorpus([{file: "a.md", content: fence("bash", "true")}])));
+		assert.isFalse(isUsableBaseline(scanCorpus([shellFile])));
+		assert.isTrue(
+			isUsableBaseline(scanCorpus([{file: "a.md", content: fence("bash", "true")}, shellFile])),
+		);
+	});
+
+	describe("parseBaseline — a manifest missing a scope axis is unusable, not zero", () => {
+		const wellFormed = {findings: [], scanned: ["a.md"], fenceCount: 1, shellFileCount: 1};
+
+		it("round-trips a well-formed manifest", () => {
+			assert.deepStrictEqual(parseBaseline(JSON.stringify(wellFormed)), wellFormed);
+		});
+
+		it("rejects a manifest with no `shellFileCount` — the fail-OPEN direction (#4486)", () => {
+			// A base-side `baseline` from a build predating the `.sh` surface omits the field. Absent,
+			// it reads back `undefined`, and `undefined === 0` is false — so `isZeroScope` would call a
+			// zero-shell-scope baseline USABLE. Only reachable under version skew between the two
+			// steps, but it is the wrong direction to fail in, so the parser refuses it outright.
+			const {shellFileCount: _dropped, ...legacy} = wellFormed;
+			assert.isNull(parseBaseline(JSON.stringify(legacy)));
+		});
+
+		it("rejects unparseable JSON, a non-object, and a wrong-shaped manifest", () => {
+			assert.isNull(parseBaseline("{not json"));
+			assert.isNull(parseBaseline("[]"));
+			assert.isNull(parseBaseline(JSON.stringify({...wellFormed, findings: undefined})));
+			assert.isNull(parseBaseline(JSON.stringify({...wellFormed, scanned: [1]})));
+			assert.isNull(parseBaseline(JSON.stringify({...wellFormed, fenceCount: "1"})));
+		});
 	});
 });

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/command.ts
@@ -1,27 +1,49 @@
 /**
- * The `cli-invocation-guard` tool — `pipeline-cli cli-invocation-guard check <file>…`.
+ * The `cli-invocation-guard` tool — `pipeline-cli cli-invocation-guard check|baseline <file>…`.
  *
  * Reds on any non-canonical `pipeline-cli` invocation inside runnable shell in the pipeline
  * corpus — a bare `pipeline-cli <verb>` (#3314) or a cwd-relative
  * `node …/pipeline-cli/src/bin.ts <verb>` (#4236) — across **both** corpus surfaces: a runnable
  * fence in a `.md`, and a `.sh` file scanned whole as one implicit fence (#4486). See the formats
  * contract's §CLI for the canonical resolution this enforces and the exit-code taxonomy it
- * protects. Follows the `adoption-lint` / `gh-phoenix
- * lint-skills` shape — an IO-free core over handed-in file contents, with a thin CLI that maps
- * the verdict to a fail-closed exit contract (ADR 0092):
+ * protects. Follows the `adoption-lint` / `gh-phoenix lint-skills` shape — an IO-free core over
+ * handed-in file contents, with a thin CLI that maps the verdict to a fail-closed exit contract
+ * (ADR 0092):
  *
- *   exit 0 — clean (no non-canonical invocation in either surface)
- *   exit 2 — one or more non-canonical invocations
- *   exit 3 — zero scope on any axis: no file scanned, no runnable `.md` fence, or no `.sh` file
+ *   exit 0 — clean (no non-canonical invocation attributable to this scan)
+ *   exit 2 — one or more attributable non-canonical invocations
+ *   exit 3 — zero scope on any axis (no file scanned, no runnable `.md` fence, no `.sh` file, or
+ *            an unusable baseline)
+ *
+ * `baseline` emits the same scan as JSON for a later `check --baseline` to diff against; it is
+ * the merge-base half of the attribution split (#4250). It exits 0 on findings on purpose — a
+ * dirty base is the input to attribution, not a verdict about it — but still exits 3 on a zero
+ * scope, so a broken base-side scan reds instead of passing as "nothing pre-existing".
  */
-import {readFileSync} from "node:fs";
-import {Console, Effect, Result} from "effect";
+import {readFileSync, writeFileSync} from "node:fs";
+import {Console, Effect, Option, Result} from "effect";
 import * as Schema from "effect/Schema";
-import {Argument, Command} from "effect/unstable/cli";
-import {type GuardResult, isZeroScope, type ScanFile, scanCorpus} from "./cli-invocation-guard.ts";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {
+	type AttributedFinding,
+	attribute,
+	type GuardResult,
+	isUsableBaseline,
+	isZeroScope,
+	parseBaseline,
+	type ScanFile,
+	scanCorpus,
+} from "./cli-invocation-guard.ts";
 
 const FINDING_EXIT_CODE = 2;
 const ZERO_SCOPE_EXIT_CODE = 3;
+
+const FIX_ATTRIBUTABLE =
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion in the remediation literal a reader pastes, not a JS template
+	'  FIX (NEW — yours to edit): resolve the shim once per fence — PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/claude-plugins/kampus-pipeline}/bin/pipeline-cli" — then call "$PCLI" <verb>. See §CLI in claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md.';
+
+const FIX_PRE_EXISTING =
+	"  FIX (PRE-EXISTING — not yours to edit): the offender was already at the merge-base. The remedy is a REBASE onto a `main` where it is fixed, not an edit — editing it here puts an unrelated change in your diff (#4250).";
 
 class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()("FindingsFound", {
 	count: Schema.Number,
@@ -41,69 +63,168 @@ const fileArg = Argument.string("file").pipe(
 	),
 );
 
-const judge = (result: GuardResult): Effect.Effect<void, ZeroScope | FindingsFound> =>
+const scan = (files: ReadonlyArray<string>): GuardResult => {
+	const scanInput: ScanFile[] = [];
+	for (const file of files) {
+		const content = readFileOrSkip(file);
+		if (content !== null) scanInput.push({file, content});
+	}
+	return scanCorpus(scanInput);
+};
+
+/** One number per surface, so a collapsed surface is legible instead of hiding inside a total. */
+const emitScope = (result: GuardResult, label: string): Effect.Effect<void> =>
+	Console.log(
+		`cli-invocation-guard: ${label} scanned ${result.scanned.length} file(s), ${result.fenceCount} runnable bash/sh fence(s) in markdown, ${result.shellFileCount} shell file(s) as implicit fences`,
+	);
+
+const readBaseline = (path: string): Effect.Effect<GuardResult, ZeroScope> =>
 	Effect.gen(function* () {
-		if (isZeroScope(result)) {
+		const raw = readFileOrSkip(path);
+		const baseline = raw === null ? null : parseBaseline(raw);
+		if (baseline === null) {
 			yield* Console.error(
-				`cli-invocation-guard: FAIL — scanned ${result.scanned.length} file(s): ${result.fenceCount} runnable fence(s) in markdown, ${result.shellFileCount} shell file(s); a zero scope on ANY axis is fail-closed, per surface (ADR 0092, #4486).`,
+				`cli-invocation-guard: FAIL — the merge-base baseline at '${path}' is missing, unreadable, or missing a scope axis. A base-side scan that did not produce a well-formed manifest is a BROKEN baseline, and a broken baseline must never read as "no pre-existing violations" (ADR 0092; #4250, #4486).`,
 			);
 			return yield* Effect.fail(new ZeroScope());
 		}
-
-		if (result.findings.length === 0) {
-			yield* Console.log(
-				"cli-invocation-guard: clean — every `pipeline-cli` call in runnable shell (fenced or `.sh`) resolves the shim by path (§CLI).",
+		if (!isUsableBaseline(baseline)) {
+			yield* Console.error(
+				`cli-invocation-guard: FAIL — the merge-base baseline at '${path}' has zero scope on some axis (${baseline.scanned.length} file(s), ${baseline.fenceCount} runnable fence(s) in markdown, ${baseline.shellFileCount} shell file(s)). A base scan that saw nothing on a surface cannot be diffed against (ADR 0092; #4250, #4486).`,
 			);
+			return yield* Effect.fail(new ZeroScope());
+		}
+		yield* Console.log(
+			`cli-invocation-guard: baseline loaded — ${baseline.findings.length} violation(s) already present at the merge-base across ${baseline.scanned.length} file(s)`,
+		);
+		return baseline;
+	});
+
+/** `--baseline` absent ⇒ no attribution (fail on any violation); present ⇒ read it or red. */
+const loadBaseline = (
+	path: Option.Option<string>,
+): Effect.Effect<Option.Option<GuardResult>, ZeroScope> =>
+	Option.match(path, {
+		onNone: () => Effect.succeed(Option.none()),
+		onSome: (p) => Effect.map(readBaseline(p), Option.some),
+	});
+
+const reportFinding = (f: AttributedFinding): Effect.Effect<void> =>
+	Console.error(
+		`  [${f.attribution === "new" ? "NEW — introduced by this change" : "PRE-EXISTING at the merge-base"}] ${f.file}:${f.line}: ${f.text}`,
+	);
+
+const guardZeroScope = (result: GuardResult): Effect.Effect<void, ZeroScope> =>
+	Effect.gen(function* () {
+		if (!isZeroScope(result)) return;
+		yield* Console.error(
+			`cli-invocation-guard: FAIL — scanned ${result.scanned.length} file(s): ${result.fenceCount} runnable fence(s) in markdown, ${result.shellFileCount} shell file(s); a zero scope on ANY axis is fail-closed, per surface (ADR 0092, #4486).`,
+		);
+		return yield* Effect.fail(new ZeroScope());
+	});
+
+/**
+ * Judge a scan. With no baseline every violation is attributable (the `push: main` leg, where a
+ * dirty tree must red whoever wrote it); with one, only the violations this head introduced
+ * fail the build — but ALL of them are still reported, each labelled, so a reader can tell
+ * whose defect it is off the check surface without opening the raw log (#4250).
+ */
+const judge = (
+	result: GuardResult,
+	baseline: Option.Option<GuardResult>,
+): Effect.Effect<void, ZeroScope | FindingsFound> =>
+	Effect.gen(function* () {
+		yield* guardZeroScope(result);
+
+		const attributed = attribute(
+			result.findings,
+			Option.match(baseline, {onNone: () => [], onSome: (b) => b.findings}),
+		);
+		const attributable = attributed.filter((f) => f.attribution === "new");
+		const preExisting = attributed.filter((f) => f.attribution === "pre-existing");
+
+		if (attributable.length === 0) {
+			yield* Console.log(
+				preExisting.length === 0
+					? "cli-invocation-guard: clean — every `pipeline-cli` call in runnable shell (fenced or `.sh`) resolves the shim by path (§CLI)."
+					: `cli-invocation-guard: clean — this change introduces no non-canonical \`pipeline-cli\` invocation. ${preExisting.length} violation(s) are PRE-EXISTING at the merge-base and are NOT this change's to fix:`,
+			);
+			for (const f of preExisting) yield* reportFinding(f);
+			if (preExisting.length > 0) yield* Console.log(FIX_PRE_EXISTING);
 			return;
 		}
 
 		yield* Console.error(
-			`cli-invocation-guard: FAIL — ${result.findings.length} non-canonical \`pipeline-cli\` invocation(s) in runnable shell. A bare name is NOT on PATH where agents spawn (ADR 0207 retired PATH-shadowing) and dies \`command not found\` (exit 127); a cwd-relative \`node …/src/bin.ts\` dies \`Cannot find module\` (exit 1, empty stdout) from any dir but the repo root. Either way a fail-closed wrapper turns the miss into a wrong verdict (#3314, #4236):`,
+			`cli-invocation-guard: FAIL — ${attributable.length} non-canonical \`pipeline-cli\` invocation(s) in runnable shell attributable to this change${preExisting.length > 0 ? ` (plus ${preExisting.length} pre-existing at the merge-base, listed but not counted against you)` : ""}. A bare name is NOT on PATH where agents spawn (ADR 0207 retired PATH-shadowing) and dies \`command not found\` (exit 127); a cwd-relative \`node …/src/bin.ts\` dies \`Cannot find module\` (exit 1, empty stdout) from any dir but the repo root. Either way a fail-closed wrapper turns the miss into a wrong verdict (#3314, #4236):`,
 		);
-		for (const f of result.findings) {
-			yield* Console.error(`  ${f.file}:${f.line}: ${f.text}`);
-		}
-		yield* Console.error(
-			// biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion in the remediation literal a reader pastes, not a JS template
-			'  FIX: resolve the shim once per fence — PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/claude-plugins/kampus-pipeline}/bin/pipeline-cli" — then call "$PCLI" <verb>. See §CLI in claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md.',
-		);
-		return yield* Effect.fail(new FindingsFound({count: result.findings.length}));
+		for (const f of attributed) yield* reportFinding(f);
+		yield* Console.error(FIX_ATTRIBUTABLE);
+		if (preExisting.length > 0) yield* Console.error(FIX_PRE_EXISTING);
+		return yield* Effect.fail(new FindingsFound({count: attributable.length}));
 	});
 
 const onZeroScope = (_e: ZeroScope) => Effect.sync(() => process.exit(ZERO_SCOPE_EXIT_CODE));
 const onFindingsFound = (_e: FindingsFound) => Effect.sync(() => process.exit(FINDING_EXIT_CODE));
 
+const baselineFlag = Flag.string("baseline").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"path to a `cli-invocation-guard baseline` manifest for the merge-base; with it, only violations NOT present at the base fail the build (the pull_request leg). Omit it to fail on ANY violation (the push: main leg).",
+	),
+);
+
+const outFlag = Flag.string("out").pipe(
+	Flag.withDescription("path to write the merge-base scan manifest to (JSON)"),
+);
+
 const check = Command.make(
 	"check",
-	{files: fileArg},
-	Effect.fn(function* ({files}) {
-		const scanInput: ScanFile[] = [];
-		for (const file of files) {
-			const content = readFileOrSkip(file);
-			if (content !== null) scanInput.push({file, content});
-		}
+	{files: fileArg, baseline: baselineFlag},
+	Effect.fn(function* ({files, baseline: baselinePath}) {
+		const result = scan(files);
 
-		const result = scanCorpus(scanInput);
+		// ADR 0092: emit the scanned scope before judging it.
+		yield* emitScope(result, "head —");
 
-		// ADR 0092: emit the scanned scope before judging it — one number per surface, so a
-		// collapsed surface is legible from the log instead of hiding inside a total.
-		yield* Console.log(
-			`cli-invocation-guard: scanned ${result.scanned.length} file(s), ${result.fenceCount} runnable bash/sh fence(s) in markdown, ${result.shellFileCount} shell file(s) as implicit fences`,
+		const loaded = yield* loadBaseline(baselinePath).pipe(
+			Effect.catchTag("ZeroScope", onZeroScope),
 		);
 
-		yield* judge(result).pipe(
+		yield* judge(result, loaded).pipe(
 			Effect.catchTag("ZeroScope", onZeroScope),
 			Effect.catchTag("FindingsFound", onFindingsFound),
 		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Red on any bare or `node …/src/bin.ts` `pipeline-cli` invocation in runnable shell — a bash/sh fence or a whole `.sh` file (fails closed on zero scope, per surface)",
+		"Red on any bare or `node …/src/bin.ts` `pipeline-cli` invocation in runnable shell — a bash/sh fence or a whole `.sh` file (fails closed on zero scope, per surface; --baseline narrows the verdict to newly-introduced ones)",
+	),
+);
+
+const baseline = Command.make(
+	"baseline",
+	{files: fileArg, out: outFlag},
+	Effect.fn(function* ({files, out}) {
+		const result = scan(files);
+		yield* emitScope(result, "merge-base —");
+		// A dirty base is the INPUT to attribution, not a verdict about it, so findings here are
+		// recorded rather than judged. A zero scope is a different animal — the scan is broken, so
+		// it reds and the head-side `check --baseline` never runs against a phantom manifest.
+		yield* guardZeroScope(result).pipe(Effect.catchTag("ZeroScope", onZeroScope));
+		yield* Console.log(
+			`cli-invocation-guard: ${result.findings.length} pre-existing violation(s) recorded at the merge-base`,
+		);
+		yield* Effect.sync(() => writeFileSync(out, `${JSON.stringify(result, null, "\t")}\n`));
+		yield* Console.log(`cli-invocation-guard: merge-base manifest written to ${out}`);
+	}),
+).pipe(
+	Command.withDescription(
+		"Emit the merge-base scan as a JSON manifest for a later `check --baseline` to attribute against (exit 0 on findings, 3 on zero scope)",
 	),
 );
 
 export const cliInvocationGuardCommand = Command.make("cli-invocation-guard").pipe(
-	Command.withSubcommands([check]),
+	Command.withSubcommands([check, baseline]),
 	Command.withDescription(
 		"Enforce §CLI: every `pipeline-cli` call in the corpus resolves the shim by path, never bare on PATH (#3314)",
 	),


### PR DESCRIPTION
The `cli-invocation-guard` CI job scans the whole plugin corpus, so whenever `main` itself carried a bare `pipeline-cli` call, innocent PRs went red for a defect they neither introduced nor could fix — which halted the shipper and once sent a reviewer to "repair" a file the PR did not touch. This PR keeps the scan corpus-wide but narrows the *verdict*: on a pull request the guard now fails only on violations that are not already present at the merge-base, and it labels every violation it reports as either newly introduced (edit it) or pre-existing (rebase, don't edit). The `push: main` leg is unchanged and still reds on any violation anywhere, so a dirty `main` is still a bounded, hot-fixable state rather than a permanent exemption.

Fixes #4250

## What changed

**`packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts`**

- `attribute(head, baseline)` classifies each head finding `new` or `pre-existing`.
- `isUsableBaseline(baseline)` — a baseline with zero scope on either axis is unusable.

**`packages/pipeline-cli/src/tools/cli-invocation-guard/command.ts`**

- New `cli-invocation-guard baseline <file>… --out <json>` emits a merge-base scan as a manifest. It exits 0 on findings (a dirty base is the *input* to attribution, not a verdict about it) and 3 on zero scope.
- `cli-invocation-guard check` gains `--baseline <json>`. With it, only newly-introduced violations fail (exit 2); without it, any violation fails — the two legs.
- Every reported violation is prefixed `[NEW — introduced by this change]` or `[PRE-EXISTING at the merge-base]`, and each class gets its own `FIX:` line: the §CLI `$PCLI` resolution for a new one, "the remedy is a REBASE, not an edit" for a pre-existing one.

**`.github/workflows/cli-invocation-guard.yml`**

- `fetch-depth: 0` so the merge-base is reachable.
- A new merge-base scan step, `pull_request` only, that resolves `git merge-base`, materializes that tree with `git archive | tar -x` (no ref moves, so `ref-guard` and the `post-checkout` hook never fire), and emits the manifest. It runs from the base tree so manifest paths are the same repo-relative paths the head scan emits.
- Both steps enumerate the **same** corpus — `\( -name '*.md' -o -name '*.sh' \)`. A baseline over a narrower corpus than the head is a baseline the per-surface zero-scope floor (#4486) correctly judges unusable.
- The head scan passes `--baseline` on `pull_request` and omits it on `push: main`.
- An `if: always()` step publishes the guard's labelled output to `$GITHUB_STEP_SUMMARY`, so a reader can tell whose violation it is from the check surface without opening the raw log.

## How this cannot silently stop catching real violations

The reviewer-facing risk here is a guard loosened past its purpose. Three properties bound it, each pinned by a test:

- **The diff is a multiset keyed on `(file, offending text)`, not a set on `file`.** A file that was dirty at the base is *not* exempt: a second offending line in it is `new`. Two copies of a line the base had once ⇒ one `new`.
- **A line-number shift is not a new violation** (an unrelated edit above would otherwise flag every line below it), but a violation **moved into another file is `new`** — the strict direction.
- **The `push: main` leg has no baseline at all.** Nothing is permanently exempt: a pre-existing violation stays red on `main` until a hotfix PR clears it, exactly as it did before this change.

Fail-closed is preserved and extended. Zero scope on the head scan still reds (ADR 0092). New inputs red the same way rather than reading as "no newly-introduced violations": an unresolvable merge-base, a failed base checkout (`set -euo pipefail`), a missing or unparseable manifest, and a base scan that saw zero files or zero runnable fences.

## Deviations

**Class: narrowed a suggested fix-shape.**
- *Said:* triage ruled fix shape **(b) baseline-diff with (c) riding along as the reporting**, and rejected (a).
- *Did:* exactly that — built (b), with (c) as the labelled output plus a step summary.
- *Why:* no departure; recorded so a reviewer can check the ruling was honored rather than inferred from the title.
- *Disposition:* no action needed.

**Class: an ambiguity in the acceptance criteria I resolved rather than guessed silently.**
- *Said:* AC 1 says the PR leg fails only on violations "not present at the merge-base". It does not define *identity* — what makes a head violation "the same" violation as a base one.
- *Did:* keyed identity on `(file, exact offending line text)` with multiset counting, deliberately excluding the line number.
- *Why:* the line number is unstable under any unrelated edit above, so keying on it would flag every shifted line as new and reproduce the original noise. Keying on the file (not text alone) keeps a *moved* violation attributable. Multiset counting is what stops "this file was already dirty" from becoming a blanket exemption.
- *Disposition:* for the reviewer to judge. If a stricter identity is wanted (e.g. attribute anything in a file this PR touched), it is a one-line change in `findingKey` plus test updates — but note it would re-red #4229-shaped PRs that edit a dirty file for unrelated reasons.

**Class: left a sibling concern for a follow-up.**
- *Said:* the issue notes a sequencing dependency on #4253 (which folds the guard fleet into `ci-required`'s `needs:`), and that this should land before or with it.
- *Did:* changed nothing about registration — no `merge_group:` trigger, no `ci-required` wiring.
- *Why:* triage explicitly ruled #4238/#4253 a different root (registration vs verdict semantics) and warned against widening this issue's scope.
- *Disposition:* no action needed; #4253 remains the owner.

**Class: a note about a pre-existing behavior I did not change.**
- *Said:* nothing.
- *Did:* left the `find … | xargs` invocation shape as-is on both legs.
- *Why:* if `xargs` ever split the corpus across multiple invocations, each invocation would see a partial scope. The current corpus (75 files) is far under any `ARG_MAX` split threshold, and hardening it is not this issue's scope. The baseline path inherits the same shape, so the two legs stay symmetric.
- *Disposition:* for the reviewer to judge; file a follow-up if it should be hardened.

**(repair round 1) Class: fixed the finding a different way than the verdict's first-listed option.**
- *Said:* the review offered three materializations in preference order — `git archive | tar -x`, `ls-tree` + `git show` per file, and `-c core.hooksPath=/dev/null` as a last resort.
- *Did:* took the first, scoped to the one directory the scan reads: `git archive --format=tar "$MERGE_BASE" -- claude-plugins | tar -x -C "$RUNNER_TEMP/base"`.
- *Why:* it updates no ref, so it neither trips `ref-guard` nor fires the `post-checkout` `bootstrap-deps` hook — both problems the review named, closed by one change. The `-- claude-plugins` pathspec is not merely an optimization: it materializes exactly the corpus the baseline scan enumerates, and under `pipefail` a base tree that cannot be read still fails the step, so the ADR 0092 direction is unchanged. The guard was never weakened and hooks were never disabled.
- *Disposition:* no action needed.

**(repair round 1) Class: a compounding defect fixed alongside the blocker.**
- *Said:* the summary step was gated `steps.scan.outcome != 'skipped'`, so the failure actually occurring published nothing to the check surface.
- *Did:* made it `if: always()` and gave it a fallback branch that names which step died (`baseline` / `scan` outcomes) and states the red is guard infrastructure, not a §CLI violation of the PR's. The baseline step gained an `id` so the summary can report it.
- *Why:* a failure mode that renders no explanation is the complaint #4250 was filed about; a fail-closed red that explains nothing is only half fail-closed.
- *Disposition:* no action needed.

**(repair round 1) Class: a reviewer note left unactioned.**
- *Said:* the review flagged, as explicitly non-blocking, that on the `push: main` leg every finding prints `[NEW — introduced by this change]`, which is not literally true where no attribution applies.
- *Did:* nothing — the repair is workflow-only; the CLI core is byte-identical to the reviewed head.
- *Why:* the label lives in `judge`/`reportFinding`, the same code path every PASSed adversarial arm and both `FIX (…)` remediation lines run through. Re-labelling it in a §CP repair round would put unreviewed core churn next to the blocker fix for a cosmetic gain. Keeping the diff to the workflow is what lets the reviewer re-verify the blocker without re-verifying attribution.
- *Disposition:* for the reviewer to judge; a follow-up issue is the right home if it should change.

**(repair round 2) Class: the base moved under the branch — a conflicted rebase resolved by re-deriving, not by picking a side.**
- *Said:* the branch sat on a base ~51 commits behind `main`, and `mergeable_state` was `dirty`. #4494 landed in that window, widening this guard's corpus to `*.md` **and** `*.sh` (whole-file implicit shell fences), adding a required `shellFileCount` field to `GuardResult`, and making the zero-scope floor **per surface**.
- *Did:* rebased onto `main` and resolved all three conflicted files by taking `main`'s widened core as the base and re-applying the attribution layer on top, rather than keeping either side wholesale. Three consequences of the widening were closed: (1) `parseBaseline`'s `GuardResult` construction now carries `shellFileCount` (a compile error after rebase, so it failed loud); (2) its **runtime** validator now asserts `shellFileCount` is a number — TypeScript makes the construction loud, but the JSON path would have let a field-less manifest through as `undefined`, and `undefined === 0` is `false`, so a zero-shell-scope baseline would have read as **usable**; (3) both `find` legs (`*.md` and `*.sh`) are now carried on **both** workflow steps, since a `.md`-only baseline exits 3 under the per-surface floor and would red the `pull_request` leg.
- *Why:* consequence (2) is the only one that fails **open**, and it is the direction this whole issue is about — "no pre-existing violations" must never be inferred from a scan that did not happen.
- *Disposition:* no action needed.

**(repair round 2) Class: moved a function across a module boundary while fixing it.**
- *Said:* nothing; `parseBaseline` and its `isFinding` helper lived in `command.ts`, the thin CLI layer.
- *Did:* moved both into `cli-invocation-guard.ts` (the pure, IO-free core) and exported `parseBaseline`, dropping its `Result.try` for a plain `try`/`catch` so the core stays dependency-free.
- *Why:* the function is a pure `string → GuardResult | null` — it belongs with the core by the package's own stated shape, and the move is what makes the new `shellFileCount` assertion directly unit-testable instead of reachable only through a subprocess. The advisory's recorded gap was that the tests are all at the pure-core layer; this moves a fail-open surface **into** that layer rather than leaving it outside.
- *Disposition:* no action needed.

**(repair round 2) Class: rewrote a shell construct the review had explicitly cleared.**
- *Said:* the review noted `"${BASELINE_ARGS[@]}"` on an empty array under `set -u` is safe on bash ≥ 4.4 and "fine as written; noted so it is a known".
- *Did:* replaced the array with positional parameters (`set -- --baseline …` / `set --`, expanded as `"$@"`).
- *Why:* `"$@"` expands to nothing when unset on **every** bash, so the construct no longer depends on the runner's bash version at all — matching `.patterns/skill-script-shell-shape.md`'s rule about testing an array before expanding it into an argument list. A behavior-preserving simplification, not a fix; recorded because it touches a line the review had already cleared.
- *Disposition:* no action needed.

**(repair round 2) Class: a reviewer note left unactioned, again.**
- *Said:* the `[NEW — introduced by this change]` label is not literally true on the `push: main` leg (explicitly non-blocking in the round-1 advisory).
- *Did:* still nothing.
- *Why:* unchanged from round 1 — cosmetic, and this round's core diff is already the rebase reconciliation plus one fail-open closure. Adding label churn on top widens what has to be re-verified.
- *Disposition:* for the reviewer to judge; a follow-up issue is the right home.

**(repair round 2) Class: a stale claim in this PR body, corrected rather than left standing.**
- *Said:* an earlier deviation entry sized the corpus at "75 files" when arguing the `find | xargs` split is not reachable.
- *Did:* left that entry as written (it is the round-0 record) and note here that the corpus is now **502 files** — 290 markdown + 212 shell — after #4494.
- *Why:* still far under any `ARG_MAX` split threshold, and the round-0 argument holds; but the number a reviewer would check against has changed by ~7×, so it should not be found stale without explanation.
- *Disposition:* for the reviewer to judge; hardening `find | xargs` remains out of scope here.

