### PR TITLE
fix(ship-it): drop the false "main has no required status checks" claim (#4249)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1371,8 +1371,11 @@ GATING_RED=$(jq -r '[.failing[]
   | select(. != "deploy (web)" and (startswith("cleanup (web,") | not))] | join(", ")' <<<"$CI_JSON")
 ```
 
-Not every red check blocks a merge. **`main` carries no required-status-check branch
-protection**, so GitHub itself blocks on nothing; the SHA-bound merge gate is the
+Not every red check blocks a merge, and **this classification is ship-it's own** — it is
+deliberately *not* the base branch's required-context set, and must never be derived from it.
+(Whatever the platform requires is live, mutable state: read it off the base branch's ruleset
+`required_status_checks` at the moment you need it, the same way the queue-regime reads below
+do — never recall it from prose.) What ship-it binds is the SHA-bound merge gate: the
 run-evidence bundle (Step 3.5) plus the review verdicts (Step 2), neither of which depends
 on a preview deploy. So a check is **gating by default** and **informational only** when it
 is on the explicit known-informational list below. Fail safe: an *unrecognized* red check


### PR DESCRIPTION
Fixes #4249

## What changed

One paragraph in `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` (the red-check classification) justified ship-it's gating-by-default rule with a falsifiable platform-state claim:

> Not every red check blocks a merge. **`main` carries no required-status-check branch protection**, so GitHub itself blocks on nothing; …

That premise is false against live state. The claim is deleted, not corrected — and deliberately **not** replaced with an enumeration of the currently-required contexts, since restating live ruleset state in committed prose is the rot surface that produced this bug. The paragraph's real point is preserved and sharpened: the gating classification is *ship-it's own* set (ADR 0061, plus the two named preview-deploy carve-outs), deliberately not derived from whatever the platform happens to require; where that platform fact is needed, the text now points at the **live read** of the base branch's ruleset `required_status_checks` — the same idiom the queue-regime reads further down this file already use.

## Grounding — what the live ruleset actually requires

Verified this run via REST (`gh api repos/<owner>/<repo>/rulesets/17377992`), not taken on the issue's word:

- ruleset `17377992` "main protection", `enforcement: active`, `target: branch`, conditions `ref_name.include: ["~DEFAULT_BRANCH"]`
- a `required_status_checks` rule with exactly three contexts: `scan changed files for leaks`, `validate skill frontmatter`, `ci-required` (`strict_required_status_checks_policy: false`)
- also present: `pull_request` (`require_code_owner_review: true`, `required_approving_review_count: 0`, `dismiss_stale_reviews_on_push: true`, `required_review_thread_resolution: true`), `merge_queue` (`merge_method: SQUASH`, `grouping_strategy: ALLGREEN`), `deletion`, `non_fast_forward`

So GitHub does block on three contexts. Live state agrees with the issue; the doc was wrong.

## Acceptance criteria

- [x] The false claim (L1374–L1375 at the branch point) is gone from the file.
- [x] The surviving text preserves the paragraph's real point — ship-it's gating-by-default classification with its two named preview-deploy carve-outs (ADR 0061) is ship-it's own set, distinct from what the platform requires — and no longer depends on the deleted premise.
- [x] No replacement sentence enumerates the currently-required contexts; the fact is stated only as a pointer to the live ruleset read.
- [x] `grep -n "blocks on nothing\|no required-status-check" claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` returns nothing (exit 1).
- [x] Treated as control-plane — see below.

## Control-plane

`pipeline-cli cp-classify classify` on the changed-file set returns:

```
cp-classify: control-plane [path-match] — claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md matches the live CONTROL_PLANE_RE. BLOCKING (human merge).
```

This PR needs a @kamp-us/control-plane approval at the current head before enqueue (ADR 0135). The coder stops at PR-open; the review verdict and the merge belong to others.

## Out of scope

Explicitly deferred by the issue, needs its own filing: the `.github/CODEOWNERS` "INERT until Phase-3" staleness, and the class-level question of whether committed control-plane artifacts may restate live platform state at all.
