### PR TITLE
feat(pipeline-cli): vocabulary-seed — one command seeds the label taxonomy + ROADMAP scaffold in an adopting repo (#4341)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
@@ -81,10 +81,18 @@ and still fails closed on it.
   a different fact. `gh api` prints its error body to stdout **without** applying `--jq`, so
   every read keeps gh's exit status and admits only the literal values it expects (§ZS /
   ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md); the defect class of #4223).
-- **`doctor.sh`'s `LABELS` table is a presentation mirror, not the source.** The required
-  set is single-sourced in `packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts`,
-  which assembles it from the constants the guards themselves scope on; the table only adds the
-  colour + description a `gh label create` needs. Doctor reads the source through
-  `pipeline-cli vocabulary-preflight labels` and **reds if the table has fallen behind it**, so
-  the two cannot silently diverge — the drift that shipped as #4300. Change the vocabulary at
-  the source, then add the matching row here.
+- **`doctor.sh` carries no label table of its own.** It reads the required rows from the
+  source through `pipeline-cli vocabulary-preflight specs` (`NAME|HEX|DESCRIPTION`), which is
+  the one home for a label's colour and wording — shared with the seeder that creates them, so
+  the printed fix and the tool that runs it cannot diverge (#4341). The names in it are
+  assembled from the constants the guards themselves scope on, and check 1d reds if the
+  enforced set ever names a label the create-ready table cannot create (the drift that shipped
+  as #4300). Change the vocabulary in
+  `packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts`; there is nothing to
+  mirror here. Only the tier-3 ideation row stays local — it is doctor's own optional check,
+  outside the enforced vocabulary, and never fails the run.
+- **The label fix is now one command, not N pasted lines.** A repo missing labels gets
+  `pipeline-cli vocabulary-seed plan --repo <owner/name>` (preview) and `… apply` (create) —
+  the strings doctor used to print for a human to copy, run by a tool. The seeder creates **no
+  GitHub milestones**; that stays an explicitly human roadmap act (ADR 0072), and the
+  `ROADMAP.md` it scaffolds says so.

--- a/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
+++ b/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
@@ -63,18 +63,27 @@ else
 	fix "gh auth refresh -s project"
 fi
 
-# 1c. the label vocabulary exists in the target repo, as NAME|TIER|HEX|DESCRIPTION rows fed
-#     to the loop from a heredoc (a `|`-delimited heredoc, not $(cat <<…) — the latter
-#     mis-parses under bash 3.2, the macOS default). TIER 1 rows are required and fail the
-#     run; TIER 3 rows are ideation-layer and only ever WARN, reported down in Tier 3.
+# 1c. the label vocabulary exists in the target repo.
 #
-#     This table is a PRESENTATION mirror (it carries the colour + description the create
-#     commands need, which the source has no room for), NOT a second required-set: check 1d
-#     asserts it covers the shared vocabulary in `packages/pipeline-cli/src/tools/
-#     vocabulary-preflight/vocabulary.ts`, which assembles the set from the constants the
-#     guards themselves scope on. Add a Tier-1 row here only alongside that source (#4272);
-#     the homing labels it must cover are ruled in ../triage/SKILL.md Step 6.
+#     The required rows are READ FROM THE SOURCE, not retyped here: `vocabulary-preflight
+#     specs` emits the create-ready taxonomy as NAME|HEX|DESCRIPTION, the one home for a
+#     label's colour and wording (#4341). Doctor's printed fixes and the seeder that runs
+#     them therefore cannot disagree — there is nothing here to fall behind. Only the
+#     TIER-3 ideation rows stay local, because they are doctor's own optional check and
+#     the enforced vocabulary does not carry them; they never fail the run (see Tier 3).
 #
+#     Resolve the CLI shim first — with it unresolved this check is UNDETERMINED, never a
+#     pass: doctor would otherwise have no rows to compare and would green a repo it never
+#     looked at, the vacuous scope of ADR 0092.
+PCLI="$(cd "$(dirname "$0")/../../bin" 2>/dev/null && pwd)/pipeline-cli"
+SPECS=""
+specs_read=unresolved
+if [ -x "$PCLI" ]; then
+	if SPECS=$("$PCLI" vocabulary-preflight specs 2>/dev/null) && [ -n "$SPECS" ]; then
+		specs_read=ok
+	fi
+fi
+
 #     Read the universe with the outcome SEPARATED from the content: a failed read leaves
 #     the same empty string a genuinely label-less repo does, and scoring absence off it
 #     would name every required label "missing" on what is really an auth or network fault.
@@ -90,52 +99,40 @@ fi
 
 required_total=0
 missing_required=0
-required_fixes=""
-REQUIRED_NAMES=""
+missing_names=""
+if [ "$specs_read" = "ok" ]; then
+	while IFS='|' read -r name color desc; do
+		[ -z "$name" ] && continue
+		required_total=$((required_total + 1))
+		[ "$labels_read" = "ok" ] || continue # UNDETERMINED: never score absence off a failed read
+		printf '%s\n' "$EXISTING" | grep -Fxq "$name" && continue
+		missing_required=$((missing_required + 1))
+		missing_names="$missing_names $name"
+	done <<SPEC_ROWS
+$SPECS
+SPEC_ROWS
+fi
+
+# The tier-3 ideation rows: doctor's own optional surface, a `|`-delimited heredoc (not
+# $(cat <<…), which mis-parses under bash 3.2, the macOS default). WARN-only, reported in Tier 3.
 optional_missing=0
 optional_fixes=""
-while IFS='|' read -r name tier color desc; do
+while IFS='|' read -r name color desc; do
 	[ -z "$name" ] && continue
-	if [ "$tier" = "1" ]; then
-		required_total=$((required_total + 1))
-		REQUIRED_NAMES="$REQUIRED_NAMES$name
-"
-	fi
-	[ "$labels_read" = "ok" ] || continue # UNDETERMINED: never score absence off a read that failed
+	[ "$labels_read" = "ok" ] || continue
 	printf '%s\n' "$EXISTING" | grep -Fxq "$name" && continue
-	CREATE="gh label create \"$name\" --repo \"$REPO\" --color \"$color\" --description \"$desc\""
-	if [ "$tier" = "1" ]; then
-		missing_required=$((missing_required + 1))
-		required_fixes="$required_fixes$CREATE
+	optional_missing=$((optional_missing + 1))
+	optional_fixes="$optional_fixes""gh label create \"$name\" --repo \"$REPO\" --color \"$color\" --description \"$desc\"
 "
-	else
-		optional_missing=$((optional_missing + 1))
-		optional_fixes="$optional_fixes$CREATE
-"
-	fi
-done <<'LABELS'
-status:needs-triage|1|fbca04|Filed, awaiting triage classification
-status:needs-info|1|fbca04|Human-filed; awaiting answers before triage
-status:planned|1|fbca04|plan-epic child: planned, not yet verified by review-plan, not pickable
-status:triaged|1|fbca04|Triage signed off; ready for write-code to pick
-status:planning|1|fbca04|Epic-lock held: a plan-epic/review-plan run is mutating this epic's children (ADR 0059)
-status:awaiting-release|1|5319e7|Post-merge release-queue marker: deployed dark, awaiting a human flag flip (ADR 0083).
-type:bug|1|1d76db|Behavior diverges from intent
-type:chore|1|1d76db|No behavior change
-type:decision|1|1d76db|One question; output is a recorded choice
-type:epic|1|1d76db|Too big for one PR; spawns children
-type:feature|1|1d76db|New capability, directly implementable
-type:investigation|1|1d76db|Unknown; output is knowledge
-p0|1|b60205|Highest priority
-p1|1|d93f0b|Medium priority
-p2|1|e99695|Lowest priority
-wayfinder:backlog|1|8250df|Standing lane: a destination queued for a wayfinding chart (triage's standing-lane exemption)
-axis:pipeline-hardening|1|5319e7|Standing lane: the cross-cutting pipeline-hardening axis (triage's standing-lane exemption)
-area:infra|1|0e8a16|Platform/infra discriminator the lane tool scopes on
-wayfinder:map|3|8250df|Ideation-layer map issue — the wayfinder chart front door (issue-shape marker, not a type)
-LABELS
+done <<'OPTIONAL_LABELS'
+wayfinder:map|8250df|Ideation-layer map issue — the wayfinder chart front door (issue-shape marker, not a type)
+OPTIONAL_LABELS
 
-if [ "$labels_read" = "no-repo" ]; then
+if [ "$specs_read" != "ok" ]; then
+	say "$FAIL" "required labels UNDETERMINED — the required set could not be resolved, so nothing was compared (unknown, NOT absent)"
+	fix "run from a checkout with packages/pipeline-cli, or make \`pipeline-cli vocabulary-preflight specs\` resolvable"
+	fails=$((fails + 1))
+elif [ "$labels_read" = "no-repo" ]; then
 	say "$FAIL" "required labels UNDETERMINED — the target repo never resolved, so the label universe was never read (unknown, NOT absent)"
 	fix "set CLAUDE_PIPELINE_REPO=owner/name, or run inside the target git repo, then re-run"
 	fails=$((fails + 1))
@@ -146,19 +143,20 @@ elif [ "$labels_read" = "failed" ]; then
 elif [ "$missing_required" -eq 0 ]; then
 	say "$PASS" "all $required_total required pipeline labels exist"
 else
-	say "$FAIL" "$missing_required of $required_total required pipeline label(s) absent"
-	printf '%s' "$required_fixes" | while IFS= read -r line; do
-		[ -n "$line" ] && fix "$line"
-	done
+	say "$FAIL" "$missing_required of $required_total required pipeline label(s) absent —$missing_names"
+	# ONE command creates every missing label, idempotently, from the same rows this check read.
+	# Printing it instead of N hand-copied `gh label create` lines is the whole point of #4341:
+	# the create commands existed as strings a human pasted, and nobody ran them.
+	fix "pipeline-cli vocabulary-seed plan --repo \"$REPO\"   # preview, writes nothing"
+	fix "pipeline-cli vocabulary-seed apply --repo \"$REPO\"  # create them"
 	fails=$((fails + 1))
 fi
 
-# 1d. doctor's Tier-1 rows still cover the shared vocabulary. The set the guards scope on
-#     lives in ONE place and is assembled from their own constants; this asserts the table
-#     above has not fallen behind it — the drift that let doctor green a repo where triage
-#     had no non-kill home (#4300). Reads it through the CLI shim, the only seam a bash
-#     preflight has onto a TS constant.
-PCLI="$(cd "$(dirname "$0")/../../bin" 2>/dev/null && pwd)/pipeline-cli"
+# 1d. every ENFORCED label is creatable from the rows 1c just read. `vocabulary-preflight
+#     labels` is the set the guards scope on (assembled from their own constants);
+#     `vocabulary-preflight specs` is the create-ready table doctor prints and the seeder
+#     runs. A name in the first with no row in the second is a label the pipeline demands
+#     and no tool can create — the drift class of #4300, now one file over.
 SHARED=""
 shared_read=unresolved
 if [ -x "$PCLI" ]; then
@@ -167,30 +165,35 @@ if [ -x "$PCLI" ]; then
 	fi
 fi
 
+SPEC_NAMES=""
+if [ "$specs_read" = "ok" ]; then
+	SPEC_NAMES=$(printf '%s\n' "$SPECS" | cut -d'|' -f1)
+fi
+
 shared_total=0
 drifted=""
-if [ "$shared_read" = "ok" ]; then
+if [ "$shared_read" = "ok" ] && [ "$specs_read" = "ok" ]; then
 	while IFS= read -r want; do
 		[ -z "$want" ] && continue
 		shared_total=$((shared_total + 1))
-		printf '%s\n' "$REQUIRED_NAMES" | grep -Fxq "$want" && continue
+		printf '%s\n' "$SPEC_NAMES" | grep -Fxq "$want" && continue
 		drifted="$drifted $want"
 	done <<SHARED_SET
 $SHARED
 SHARED_SET
 fi
 
-if [ "$shared_read" != "ok" ]; then
-	# WARN, not FAIL: an adopter without the CLI resolved still gets every check above. What is
-	# lost is only the confirmation, and saying so beats claiming a verification that never ran.
-	say "$WARN" "doctor's required set is UNVERIFIED against the shared vocabulary — could not resolve it (unknown, NOT confirmed)"
+if [ "$shared_read" != "ok" ] || [ "$specs_read" != "ok" ]; then
+	# WARN, not FAIL: 1c already failed loudly on an unresolved CLI. What is lost here is only
+	# the confirmation, and saying so beats claiming a verification that never ran.
+	say "$WARN" "the create-ready table is UNVERIFIED against the enforced set — could not resolve both (unknown, NOT confirmed)"
 	fix "run from a checkout with packages/pipeline-cli, or make \`pipeline-cli vocabulary-preflight labels\` resolvable"
 elif [ -n "$drifted" ]; then
-	say "$FAIL" "doctor's required set has DRIFTED from the shared vocabulary — absent from the table above:$drifted"
-	fix "add each label above to the LABELS table in this file as a tier-1 row (name|1|hex|description)"
+	say "$FAIL" "the enforced vocabulary has DRIFTED from the create-ready table — no create row for:$drifted"
+	fix "add each label above to LABEL_SPECS in packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts"
 	fails=$((fails + 1))
 else
-	say "$PASS" "doctor's required set covers all $shared_total labels of the shared vocabulary"
+	say "$PASS" "every one of the $shared_total enforced labels is creatable from the shared table"
 fi
 
 hdr "Tier 2 — gating (a stage fails deep without these)"

--- a/packages/pipeline-cli/TOOLS.md
+++ b/packages/pipeline-cli/TOOLS.md
@@ -694,6 +694,49 @@ writes or releases one. An empty scan (zero open issues *and* zero open PRs) is 
 not an idle factory, so it exits non-zero rather than printing a vacuous zero (ADR
 [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)).
 
+### `vocabulary-seed` — put the pipeline label taxonomy into an adopting repo (#4341)
+
+`vocabulary-preflight` tells a fresh repo which labels and roadmap surface it lacks, and `doctor`
+prints the create commands. Neither runs them, so the taxonomy got hand-copied at setup. This runs
+them.
+
+```bash
+# preview against the resolved target — writes nothing (start here)
+node packages/pipeline-cli/src/bin.ts vocabulary-seed plan
+
+# create the missing labels and scaffold ROADMAP.md if absent
+node packages/pipeline-cli/src/bin.ts vocabulary-seed apply --repo owner/name
+```
+
+**The done-test is another tool's green:** after `apply`, `vocabulary-preflight check` passes.
+That crossing is exercised as a test rather than asserted (`gate.behavior.test.ts`).
+
+**Target resolution is explicit and ordered:** `--repo owner/name` first, then
+`CLAUDE_PIPELINE_REPO` / `GITHUB_REPOSITORY`, then `gh repo view`. With none of them resolvable it
+fails — a seeder that guesses a repo is the bad failure this ordering removes. `plan` is the
+read-only preview and the recommended first run.
+
+**One home for colour and wording.** Everything it creates comes from `LABEL_SPECS` in
+`src/tools/vocabulary-preflight/vocabulary.ts`, the same rows `doctor.sh` reads through
+`vocabulary-preflight specs`. The seeder carries no list of its own, and the enforced set
+(`REQUIRED_LABELS`, assembled from the guards' own constants) is asserted to be totally creatable
+from that table — a gap there is a refusal, not a partial seed.
+
+**Idempotent in both directions.** It creates only what the pre-read found missing, *and* reads
+GitHub's `already_exists` 422 as success — so a label that appears between the read and the create
+is a quiet no-op rather than a failure. `POST .../labels` genuinely 422s on an existing name (unlike
+`POST .../issues/{n}/labels`, which auto-creates), and a malformed-colour 422 is still an error.
+
+**It creates no GitHub milestones — deliberately.** ADR
+[0072](../../.decisions/0072-milestones-encode-strategic-sequencing.md) §3 makes creating or
+restructuring a milestone an explicitly human roadmap decision and closes categorically: *"no skill
+may create or delete them."* Re-reading that narrowly to permit an install-time bootstrap is the
+quiet reinterpretation an ADR exists to prevent, so the seeder does not. The scaffolded `ROADMAP.md`
+ships one `queued`, unpinned arc — the legal shape for an arc whose milestone does not exist yet —
+and names the two steps a **maintainer of the adopting repo** takes to activate it: create the
+milestone in GitHub, then pin it by number and set the row to `active`. An existing `ROADMAP.md` is
+never overwritten.
+
 ## Building and testing
 
 ```bash

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -274,6 +274,13 @@ export const registeredTools: ReadonlyArray<ToolRegistration> = [
 	tool("vocabulary-preflight", () =>
 		import("./tools/vocabulary-preflight/command.ts").then((m) => m.vocabularyPreflightCommand),
 	),
+	// #4341 — the write counterpart of the preflight above. The preflight names what a fresh repo
+	// lacks and doctor prints the creates; nobody ran them, so the taxonomy got hand-copied. Seeds
+	// the labels + a ROADMAP.md scaffold from the one create-ready home, idempotently. Creates NO
+	// milestones: ADR 0072 keeps that an explicitly human act, and the scaffold says who does it.
+	tool("vocabulary-seed", () =>
+		import("./tools/vocabulary-seed/command.ts").then((m) => m.vocabularySeedCommand),
+	),
 	// #3980 — the mechanical half of the ADR contradiction sweep: rank the live-accepted ADRs a
 	// new ADR touches the decision domain of but never cites, so a same-question conflict with an
 	// unsuperseded ADR (0208-vs-0072, 0210-vs-0202) is a list to clear rather than a memory test.

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/command.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/command.ts
@@ -22,7 +22,13 @@ import {Command, Flag} from "effect/unstable/cli";
 import {onCheckFailed} from "../../gate-fail.ts";
 import {checkVocabulary} from "./gate.ts";
 import {RepoLabelsLive} from "./github.ts";
-import {REQUIRED_LABELS, renderLabelList} from "./vocabulary.ts";
+import {
+	LABEL_SPECS,
+	REQUIRED_LABELS,
+	renderLabelList,
+	renderLabelSpecs,
+	unspecifiedRequiredLabels,
+} from "./vocabulary.ts";
 
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
@@ -84,8 +90,32 @@ const labels = Command.make(
 	),
 );
 
+// The create-ready half of the same seam: `labels` answers "which labels", `specs` answers "with
+// which colour and wording". Also read-only, also answerable in a repo that has none of them.
+const specs = Command.make(
+	"specs",
+	{},
+	Effect.fn(function* () {
+		const unspecified = unspecifiedRequiredLabels();
+		if (unspecified.length > 0) {
+			yield* onCheckFailed({
+				reason:
+					`vocabulary-preflight specs: ${unspecified.length} required label(s) have no ` +
+					`create-ready row in LABEL_SPECS — ${unspecified.join(", ")}. Refusing to emit a ` +
+					"table that cannot create the set the preflight enforces.",
+			});
+			return;
+		}
+		yield* Console.log(renderLabelSpecs(LABEL_SPECS));
+	}),
+).pipe(
+	Command.withDescription(
+		"Print the create-ready label taxonomy as NAME|HEX|DESCRIPTION lines (the one colour/description home — #4341)",
+	),
+);
+
 export const vocabularyPreflightCommand = Command.make("vocabulary-preflight").pipe(
-	Command.withSubcommands([check, labels]),
+	Command.withSubcommands([check, labels, specs]),
 	Command.withDescription(
 		"Fail-closed preflight: the required label vocabulary + ROADMAP.md exist in the target repo (#4272)",
 	),

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
@@ -57,6 +57,114 @@ export const REQUIRED_LABELS: ReadonlyArray<string> = [
  */
 export const renderLabelList = (labels: ReadonlyArray<string>): string => labels.join("\n");
 
+/** A label in create-ready form: the name a guard scopes on plus the two fields a create needs. */
+export interface LabelSpec {
+	readonly name: string;
+	readonly color: string;
+	readonly description: string;
+}
+
+/**
+ * The create-ready taxonomy — the ONE home for every pipeline label's colour and description
+ * (#4341). The two facts split across files before this: `REQUIRED_LABELS` carried names and
+ * `doctor.sh` carried `NAME|HEX|DESCRIPTION` in a heredoc, so the seeder would have been a third
+ * copy. Both consumers — this package's seeder and `doctor.sh`'s printed `gh label create` fixes —
+ * now read these rows, so a colour or wording change lands in one place.
+ *
+ * It is deliberately a SUPERSET of `REQUIRED_LABELS`, not a mirror of it: `status:planning` (the
+ * ADR-0059 epic lock) and `status:awaiting-release` (the ADR-0083 release queue) are labels the
+ * pipeline writes but the preflight does not yet enforce, and an adopting repo needs them created
+ * all the same. `unspecifiedRequiredLabels` is the fail-closed direction that matters — every
+ * enforced label must be creatable from here, or the seeder cannot clear the preflight it seeds
+ * for.
+ *
+ * Colour is the 6-hex GitHub wants with no leading `#`. Descriptions carry no `|`, because the
+ * rendered form below is pipe-delimited for the bash consumer.
+ */
+export const LABEL_SPECS: ReadonlyArray<LabelSpec> = [
+	{
+		name: "status:needs-triage",
+		color: "fbca04",
+		description: "Filed, awaiting triage classification",
+	},
+	{
+		name: "status:needs-info",
+		color: "fbca04",
+		description: "Human-filed; awaiting answers before triage",
+	},
+	{
+		name: "status:planned",
+		color: "fbca04",
+		description: "plan-epic child: planned, not yet verified by review-plan, not pickable",
+	},
+	{
+		name: "status:triaged",
+		color: "fbca04",
+		description: "Triage signed off; ready for write-code to pick",
+	},
+	{
+		name: "status:planning",
+		color: "fbca04",
+		description: "Epic-lock held: a plan-epic/review-plan run is mutating this epic's children",
+	},
+	{
+		name: "status:awaiting-release",
+		color: "5319e7",
+		description: "Post-merge release queue: deployed dark, awaiting a human flag flip",
+	},
+	{name: "p0", color: "b60205", description: "Highest priority"},
+	{name: "p1", color: "d93f0b", description: "Medium priority"},
+	{name: "p2", color: "e99695", description: "Lowest priority"},
+	{name: "type:bug", color: "1d76db", description: "Behavior diverges from intent"},
+	{name: "type:chore", color: "1d76db", description: "No behavior change"},
+	{
+		name: "type:decision",
+		color: "1d76db",
+		description: "One question; output is a recorded choice",
+	},
+	{name: "type:epic", color: "1d76db", description: "Too big for one PR; spawns children"},
+	{
+		name: "type:feature",
+		color: "1d76db",
+		description: "New capability, directly implementable",
+	},
+	{name: "type:investigation", color: "1d76db", description: "Unknown; output is knowledge"},
+	{
+		name: "wayfinder:backlog",
+		color: "8250df",
+		description: "Standing lane: a destination queued for a wayfinding chart",
+	},
+	{
+		name: "axis:pipeline-hardening",
+		color: "5319e7",
+		description: "Standing lane: the cross-cutting pipeline-hardening axis",
+	},
+	{
+		name: "area:infra",
+		color: "0e8a16",
+		description: "Platform/infra discriminator the lane tool scopes on",
+	},
+];
+
+/** Every name `LABEL_SPECS` can create, in table order. */
+export const SPECIFIED_LABELS: ReadonlyArray<string> = LABEL_SPECS.map((spec) => spec.name);
+
+/**
+ * Required labels with no create-ready row — non-empty means the seeder could never clear the
+ * preflight, because the enforced set names something it cannot create. Callers refuse on a
+ * non-empty result rather than seeding a partial taxonomy (ADR 0092).
+ */
+export const unspecifiedRequiredLabels = (): ReadonlyArray<string> =>
+	REQUIRED_LABELS.filter((label) => !SPECIFIED_LABELS.includes(label));
+
+/**
+ * The create-ready rows as `NAME|HEX|DESCRIPTION` lines — the seam `doctor.sh` reads, for the same
+ * reason `renderLabelList` exists: a bash preflight cannot import a TS constant, and retyping the
+ * rows is the drift this consolidation removes.
+ */
+export const renderLabelSpecs = (specs: ReadonlyArray<LabelSpec>): string =>
+	specs.map((spec) => `${spec.name}|${spec.color}|${spec.description}`).join("\n");
+
 /** `ROADMAP.md` as the preflight finds it: absent, or present with the rows it parsed. */
 export type RoadmapSurface =
 	| {readonly _tag: "absent"; readonly path: string}

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.unit.test.ts
@@ -12,10 +12,14 @@ import {PRESENT, resolvePresence} from "./presence.ts";
 import {
 	judge,
 	judgeRoadmap,
+	LABEL_SPECS,
 	REQUIRED_LABELS,
 	type RoadmapSurface,
 	renderLabelList,
+	renderLabelSpecs,
 	renderReport,
+	SPECIFIED_LABELS,
+	unspecifiedRequiredLabels,
 } from "./vocabulary.ts";
 
 const ROADMAP_OK: RoadmapSurface = {
@@ -148,5 +152,25 @@ describe("renderLabelList — the seam doctor.sh reads (#4300)", () => {
 		const lines = renderLabelList(REQUIRED_LABELS).split("\n");
 		expect(lines.length).toBeGreaterThan(0);
 		for (const lane of EXEMPT_LABELS) expect(lines).toContain(lane);
+	});
+});
+
+describe("LABEL_SPECS — the ONE colour/description home (#4341)", () => {
+	it("can create every label the preflight enforces — the property that keeps the two aligned", () => {
+		expect(unspecifiedRequiredLabels()).toEqual([]);
+	});
+
+	it("renders NAME|HEX|DESCRIPTION lines a bash `while IFS='|' read` consumes with no parser", () => {
+		const lines = renderLabelSpecs(LABEL_SPECS).split("\n");
+		expect(lines).toHaveLength(LABEL_SPECS.length);
+		for (const line of lines) expect(line.split("|")).toHaveLength(3);
+		expect(lines[0]).toBe(
+			`${LABEL_SPECS[0]?.name}|${LABEL_SPECS[0]?.color}|${LABEL_SPECS[0]?.description}`,
+		);
+	});
+
+	it("is non-empty — an empty table would let doctor print zero fixes and call it clean", () => {
+		expect(LABEL_SPECS.length).toBeGreaterThan(0);
+		expect(SPECIFIED_LABELS.length).toBeGreaterThanOrEqual(REQUIRED_LABELS.length);
 	});
 });

--- a/packages/pipeline-cli/src/tools/vocabulary-seed/command.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-seed/command.ts
@@ -1,0 +1,100 @@
+/**
+ * The `vocabulary-seed` tool — `pipeline-cli vocabulary-seed <plan|apply> [--repo o/n] [--root d]`.
+ *
+ * The write half of adopter bootstrap (#4341). `vocabulary-preflight` tells a fresh repo which
+ * labels and roadmap surface it lacks; `doctor` prints the `gh label create` lines; neither runs
+ * them, so the taxonomy got hand-copied. This runs them.
+ *
+ *   pipeline-cli vocabulary-seed plan                    # read-only preview — what would be written
+ *   pipeline-cli vocabulary-seed apply                   # create the missing labels + ROADMAP.md
+ *   pipeline-cli vocabulary-seed apply --repo owner/name # name the target explicitly
+ *
+ * The done-test is another tool's green: after `apply`, `pipeline-cli vocabulary-preflight check`
+ * passes.
+ *
+ * It creates NO GitHub milestones. ADR 0072 makes creating or restructuring a milestone an
+ * explicitly human roadmap decision, and this tool does not reinterpret that for the bootstrap
+ * case — the seeded `ROADMAP.md` says who does it and how.
+ *
+ * The pure decision lives in `seed.ts`, the `gh api` reads/writes in `github.ts`, the wiring in
+ * `gate.ts`. Exit-code contract: 0 = done, non-zero = refused or failed.
+ */
+import {Effect, FileSystem, Option, Path} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {applySeed, planSeed} from "./gate.ts";
+import {layer} from "./github.ts";
+
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir. Same resolution the
+// preflight uses, so the two tools read and write the same `ROADMAP.md`.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root to write ROADMAP.md into (default: walk up for one)"),
+);
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target repo as owner/name — takes precedence over CLAUDE_PIPELINE_REPO and `gh repo view`",
+	),
+);
+
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
+
+const plan = Command.make(
+	"plan",
+	{root: rootFlag, repo: repoFlag},
+	Effect.fn(function* ({root, repo}) {
+		yield* planSeed(yield* resolveRoot(root)).pipe(
+			Effect.provide(layer(Option.getOrUndefined(repo))),
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Preview the seed against the resolved target repo — writes nothing (start here)",
+	),
+);
+
+const apply = Command.make(
+	"apply",
+	{root: rootFlag, repo: repoFlag},
+	Effect.fn(function* ({root, repo}) {
+		yield* applySeed(yield* resolveRoot(root)).pipe(
+			Effect.provide(layer(Option.getOrUndefined(repo))),
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Create the missing pipeline labels in the target repo and scaffold ROADMAP.md if absent",
+	),
+);
+
+export const vocabularySeedCommand = Command.make("vocabulary-seed").pipe(
+	Command.withSubcommands([plan, apply]),
+	Command.withDescription(
+		"Seed an adopting repo's pipeline label vocabulary + ROADMAP.md scaffold; creates no milestones (#4341)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/vocabulary-seed/gate.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-seed/gate.behavior.test.ts
@@ -1,0 +1,215 @@
+/**
+ * The done-test, crossed end to end: seeding a BARE repo makes `vocabulary-preflight check` pass
+ * (#4341 AC 4).
+ *
+ * This is the acceptance criterion that proves the feature, so it is exercised rather than argued —
+ * the real `applySeed` and the real `checkVocabulary` run against one shared fake repo. Only the
+ * two boundaries are substituted: `gh` (a `ChildProcessSpawner` holding the repo's label universe
+ * in a Set, which the creates actually mutate) and the filesystem (an in-memory map). Everything
+ * between — the diff, the create calls, the 422 handling, the scaffold, the preflight's judgement —
+ * is the shipped code path.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {Effect, Exit, FileSystem, Layer, Path, PlatformError, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {checkVocabulary} from "../vocabulary-preflight/gate.ts";
+import {RepoLabels} from "../vocabulary-preflight/github.ts";
+import {REQUIRED_LABELS} from "../vocabulary-preflight/vocabulary.ts";
+import {applySeed, planSeed} from "./gate.ts";
+import {layer as seederLayer} from "./github.ts";
+import {isAlreadyExists} from "./seed.ts";
+
+const REPO = "adopter/fresh";
+const ROOT = "/repo";
+
+const enc = new TextEncoder();
+const stream = (s: string) => Stream.fromArray([enc.encode(s)]);
+
+const argValue = (args: ReadonlyArray<string>, key: string): string | undefined => {
+	const hit = args.find((a) => a.startsWith(`${key}=`));
+	return hit?.slice(key.length + 1);
+};
+
+/**
+ * A `gh` that owns `universe` as live state: `GET .../labels` reports it, `POST .../labels` adds to
+ * it and 422s with GitHub's real `already_exists` body on a name it already holds. Modelling the
+ * 422 rather than asserting the tool never provokes one is the point — idempotency has to hold
+ * against the server's actual behaviour, not against a pre-read that might be stale.
+ */
+const ghWithUniverse = (
+	universe: Set<string>,
+	created: Array<string>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const isPost = args.includes("-X") && args[args.indexOf("-X") + 1] === "POST";
+				let stdout = "";
+				let exitCode = 0;
+				if (isPost) {
+					const name = argValue(args, "name") ?? "";
+					if (universe.has(name)) {
+						stdout = JSON.stringify({
+							message: "Validation Failed",
+							errors: [{resource: "Label", code: "already_exists", field: "name"}],
+						});
+						exitCode = 1;
+					} else {
+						universe.add(name);
+						created.push(name);
+						stdout = JSON.stringify({name});
+					}
+				} else {
+					stdout = JSON.stringify([[...universe].map((name) => ({name}))]);
+				}
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: stream(stdout),
+					stderr: stream(exitCode === 0 ? "" : "gh: Validation Failed (HTTP 422)"),
+					all: stream(stdout),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+/** An in-memory filesystem over a map, so the ROADMAP write is observable without touching disk. */
+const memoryFs = (files: Map<string, string>) =>
+	FileSystem.layerNoop({
+		exists: (path: string) => Effect.succeed(files.has(path)),
+		readFileString: (path: string) => {
+			const contents = files.get(path);
+			return contents === undefined
+				? Effect.fail(
+						PlatformError.systemError({
+							_tag: "NotFound",
+							module: "FileSystem",
+							method: "readFileString",
+							pathOrDescriptor: path,
+						}),
+					)
+				: Effect.succeed(contents);
+		},
+		writeFileString: (path: string, data: string) =>
+			Effect.sync(() => {
+				files.set(path, data);
+			}),
+	});
+
+const platform = (files: Map<string, string>) => Layer.merge(memoryFs(files), Path.layer);
+
+const preflight = (universe: Set<string>, files: Map<string, string>) =>
+	checkVocabulary(ROOT).pipe(
+		Effect.provideService(RepoLabels, {
+			list: () => Effect.succeed([...universe]),
+			presence: () => Effect.succeed({_tag: "present" as const}),
+		}),
+		Effect.provide(platform(files)),
+	);
+
+/** One merged layer per run: the seeder over its stub `gh`, plus the in-memory platform. */
+const seedLayers = (
+	gh: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>,
+	files: Map<string, string>,
+) => Layer.merge(seederLayer(REPO).pipe(Layer.provide(gh)), platform(files));
+
+const seed = (universe: Set<string>, files: Map<string, string>, created: Array<string>) =>
+	applySeed(ROOT).pipe(Effect.provide(seedLayers(ghWithUniverse(universe, created), files)));
+
+describe("the observable done-test: seed a bare repo, then the preflight passes (#4341)", () => {
+	it("goes RED before the seed and GREEN after it, in one run", async () => {
+		const universe = new Set<string>();
+		const files = new Map<string, string>();
+		const created: Array<string> = [];
+
+		// RED: a bare repo has no labels and no ROADMAP.md — both unmet prerequisites.
+		expect(Exit.isFailure(await Effect.runPromise(Effect.exit(preflight(universe, files))))).toBe(
+			true,
+		);
+
+		await Effect.runPromise(seed(universe, files, created));
+
+		// GREEN: the same preflight, over the state the seed left behind.
+		expect(Exit.isSuccess(await Effect.runPromise(Effect.exit(preflight(universe, files))))).toBe(
+			true,
+		);
+
+		for (const label of REQUIRED_LABELS) expect(universe.has(label)).toBe(true);
+		expect(files.has(`${ROOT}/ROADMAP.md`)).toBe(true);
+	});
+
+	it("is idempotent — a second run creates nothing and does not error", async () => {
+		const universe = new Set<string>();
+		const files = new Map<string, string>();
+		const first: Array<string> = [];
+		const second: Array<string> = [];
+
+		await Effect.runPromise(seed(universe, files, first));
+		const roadmap = files.get(`${ROOT}/ROADMAP.md`);
+		await Effect.runPromise(seed(universe, files, second));
+
+		expect(first.length).toBeGreaterThan(0);
+		expect(second).toEqual([]);
+		expect(files.get(`${ROOT}/ROADMAP.md`)).toBe(roadmap);
+	});
+
+	it("finishes a PARTIALLY-seeded repo, creating only the gap", async () => {
+		const universe = new Set<string>(["p0", "type:bug"]);
+		const files = new Map<string, string>();
+		const created: Array<string> = [];
+
+		await Effect.runPromise(seed(universe, files, created));
+
+		expect(created).not.toContain("p0");
+		expect(created).toContain("p1");
+		expect(Exit.isSuccess(await Effect.runPromise(Effect.exit(preflight(universe, files))))).toBe(
+			true,
+		);
+	});
+
+	it("never overwrites a ROADMAP.md the repo already maintains", async () => {
+		const universe = new Set<string>();
+		const files = new Map<string, string>([
+			[
+				`${ROOT}/ROADMAP.md`,
+				"# Roadmap\n\n## Arcs\n\n| Arc | Milestone | State |\n| --- | --- | --- |\n| Ours | #7 | active |\n",
+			],
+		]);
+
+		await Effect.runPromise(seed(universe, files, []));
+
+		expect(files.get(`${ROOT}/ROADMAP.md`)).toContain("| Ours | #7 | active |");
+	});
+
+	it("survives a label that appears between the read and the create (the real 422 path)", async () => {
+		const universe = new Set<string>();
+		const files = new Map<string, string>();
+		// The plan is computed off an empty universe; a concurrent operator lands `p0` before the
+		// creates run, so the create for `p0` hits the server's real 422 rather than the pre-read.
+		const gh = ghWithUniverse(universe, []).pipe(
+			Layer.tap(() => Effect.sync(() => universe.add("p0"))),
+		);
+		const planned = applySeed(ROOT).pipe(Effect.provide(seedLayers(gh, files)));
+		await expect(Effect.runPromise(planned)).resolves.toBeUndefined();
+		expect(isAlreadyExists("already_exists")).toBe(true);
+	});
+
+	it("plan writes nothing at all", async () => {
+		const universe = new Set<string>();
+		const files = new Map<string, string>();
+		await Effect.runPromise(
+			planSeed(ROOT).pipe(Effect.provide(seedLayers(ghWithUniverse(universe, []), files))),
+		);
+		expect(universe.size).toBe(0);
+		expect(files.size).toBe(0);
+	});
+});

--- a/packages/pipeline-cli/src/tools/vocabulary-seed/gate.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-seed/gate.ts
@@ -1,0 +1,117 @@
+/**
+ * The `vocabulary-seed` wiring — the IO seam between the pure core and the two surfaces a run
+ * touches: the target repo's labels (over `gh api`) and `ROADMAP.md` on disk.
+ *
+ * Split from `command.ts` so the whole plan/apply path is crossable in a test with a stubbed
+ * spawner and an in-memory filesystem.
+ */
+import {Console, Effect, FileSystem, Path} from "effect";
+import * as Schema from "effect/Schema";
+import {LABEL_SPECS} from "../vocabulary-preflight/vocabulary.ts";
+import type {SeederError} from "./github.ts";
+import {LabelSeeder} from "./github.ts";
+import {
+	type LabelResult,
+	planLabels,
+	ROADMAP_SCAFFOLD,
+	type RoadmapPlan,
+	renderPlan,
+	renderResult,
+	type SeedPlan,
+	seedPrecondition,
+} from "./seed.ts";
+
+/** Carries the non-zero exit for a refusal (the reason is already composed). */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+const ROADMAP_FILE = "ROADMAP.md";
+
+/**
+ * Decide the roadmap half. An existing `ROADMAP.md` is KEPT, always — the seeder's job is to make
+ * a bare repo pipeline-ready, and silently overwriting a maintained roadmap with a scaffold is the
+ * one destructive thing this tool could do. That makes the file write safe by construction rather
+ * than by a confirmation prompt.
+ */
+const planRoadmap = (
+	root: string,
+): Effect.Effect<RoadmapPlan, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, ROADMAP_FILE);
+		const exists = yield* fs.exists(target).pipe(Effect.orElseSucceed(() => false));
+		return exists
+			? ({_tag: "keep", path: target} as const)
+			: ({_tag: "create", path: target} as const);
+	});
+
+const buildPlan = (
+	root: string,
+): Effect.Effect<SeedPlan, SeederError, LabelSeeder | FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const seeder = yield* LabelSeeder;
+		const repo = yield* seeder.repo;
+		const universe = yield* seeder.list();
+		const {create, present} = planLabels(LABEL_SPECS, universe);
+		return {repo, create, present, roadmap: yield* planRoadmap(root)};
+	});
+
+const refuseIfUnwired = Effect.suspend(() => {
+	const defect = seedPrecondition();
+	return defect === null ? Effect.void : Effect.fail(new CheckFailed({reason: defect}));
+});
+
+/** `plan` — read-only. Resolves the target, diffs the taxonomy, prints what `apply` would do. */
+export const planSeed = (
+	root: string,
+): Effect.Effect<
+	void,
+	CheckFailed | SeederError,
+	LabelSeeder | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		yield* refuseIfUnwired;
+		yield* Console.log(renderPlan(yield* buildPlan(root)));
+	});
+
+/**
+ * `apply` — the write. Creates only the labels the plan found missing, writes `ROADMAP.md` only if
+ * absent, and prints the resolved target BEFORE the first write so a mis-targeted run is visible
+ * in the log rather than only in the repo it hit.
+ */
+export const applySeed = (
+	root: string,
+): Effect.Effect<
+	void,
+	CheckFailed | SeederError,
+	LabelSeeder | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		yield* refuseIfUnwired;
+		const plan = yield* buildPlan(root);
+		yield* Console.log(
+			`vocabulary-seed: target repo ${plan.repo} — creating ${plan.create.length} label(s).`,
+		);
+		const seeder = yield* LabelSeeder;
+		const results: Array<LabelResult> = plan.present.map((name) => ({
+			name,
+			outcome: "already-exists" as const,
+		}));
+		for (const spec of plan.create) {
+			results.push({name: spec.name, outcome: yield* seeder.create(spec)});
+		}
+		if (plan.roadmap._tag === "create") {
+			const fs = yield* FileSystem.FileSystem;
+			yield* fs.writeFileString(plan.roadmap.path, ROADMAP_SCAFFOLD).pipe(
+				Effect.mapError(
+					(cause) =>
+						new CheckFailed({
+							reason: `vocabulary-seed: labels are seeded, but writing ${plan.roadmap.path} failed — ${cause.message}`,
+						}),
+				),
+			);
+		}
+		yield* Console.log(renderResult(plan.repo, results, plan.roadmap));
+	});

--- a/packages/pipeline-cli/src/tools/vocabulary-seed/github.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-seed/github.ts
@@ -1,0 +1,213 @@
+/**
+ * The GitHub boundary for `vocabulary-seed`: read the target repo's label universe and create the
+ * missing labels over `gh api` REST (#4341).
+ *
+ * The one thing this file does that the shared `gh-io.ts` seam cannot: a failed create needs its
+ * STDOUT. `gh api` prints an error's JSON body to stdout and only a terse `HTTP 422` line to
+ * stderr, so a runner that keeps stderr alone throws away the `already_exists` code that separates
+ * "this label is already here" (idempotent success) from "this request was wrong". `runCapture`
+ * keeps all three of stdout/stderr/exit and hands the joined output to `isAlreadyExists`.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {LabelSpec} from "../vocabulary-preflight/vocabulary.ts";
+import {isAlreadyExists, type LabelOutcome} from "./seed.ts";
+
+/** A `gh` invocation failed in a way the seeder cannot read as an idempotent no-op. */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/vocabulary-seed/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		output: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/vocabulary-seed/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved. A seeder never guesses one. */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/vocabulary-seed/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+export type SeederError = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+interface Captured {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number;
+}
+
+const runCapture = Effect.fn("LabelSeeder.runCapture")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		return {stdout, stderr, exitCode} satisfies Captured;
+	},
+	Effect.scoped,
+	(effect) =>
+		Effect.catchTag(effect, "PlatformError", (cause) =>
+			Effect.succeed({stdout: "", stderr: cause.message, exitCode: -1} satisfies Captured),
+		),
+);
+
+const runGh = Effect.fn("LabelSeeder.runGh")(function* (args: ReadonlyArray<string>) {
+	const {stdout, stderr, exitCode} = yield* runCapture(args);
+	if (exitCode !== 0) {
+		return yield* new GhCommandError({args, exitCode, output: `${stdout}\n${stderr}`.trim()});
+	}
+	return stdout;
+});
+
+const json = Effect.fn("LabelSeeder.json")(function* (args: ReadonlyArray<string>) {
+	const raw = yield* runGh(args);
+	return yield* Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`), in order: an explicit `--repo`, then
+ * `CLAUDE_PIPELINE_REPO` / `GITHUB_REPOSITORY`, then `gh repo view` (ADR 0062 §1).
+ *
+ * The explicit override comes FIRST here, unlike in the read-only preflight: this tool writes, and
+ * an operator standing a repo up should be able to name the target rather than depend on which
+ * directory the shell happens to sit in. With nothing resolvable it fails — a seeder that guesses
+ * a repo is the bad failure this ordering exists to make unreachable.
+ */
+export const resolveRepo = Effect.fn("LabelSeeder.resolveRepo")(function* (
+	explicit: string | undefined,
+) {
+	if (explicit !== undefined) {
+		if (REPO_RE.test(explicit.trim())) return explicit.trim();
+		return yield* new RepoResolutionError({
+			message: `--repo "${explicit}" is not an owner/name pair`,
+		});
+	}
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) return fromEnv.trim();
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/vocabulary-seed/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) return viewed;
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: pass --repo owner/name, set CLAUDE_PIPELINE_REPO, " +
+			"or run inside the target git repo",
+	});
+});
+
+// `--slurp` because bare `--paginate` concatenates one JSON array per page, which is unparseable
+// as a whole once the label set passes 100 (the #3762 break).
+const listArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/labels`,
+	"-f",
+	"per_page=100",
+	"--paginate",
+	"--slurp",
+];
+
+const createArgs = (repo: string, spec: LabelSpec): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/labels`,
+	"-f",
+	`name=${spec.name}`,
+	"-f",
+	`color=${spec.color}`,
+	"-f",
+	`description=${spec.description}`,
+];
+
+const RawLabel = Schema.Struct({name: Schema.String});
+const decodePages = Schema.decodeUnknownEffect(Schema.Array(Schema.Array(RawLabel)));
+
+/**
+ * `LabelSeeder` — the target repo's label universe plus the one write the seeder makes.
+ *
+ * `create` never fails on a label that already exists: it maps that 422 to `already-exists`, so
+ * re-running against a partially-seeded repo is a normal, quiet outcome rather than an error. The
+ * pre-read makes that path rare; keeping it makes the run idempotent even when the read is stale
+ * or a concurrent operator got there first.
+ */
+export class LabelSeeder extends Context.Service<
+	LabelSeeder,
+	{
+		readonly repo: Effect.Effect<string, SeederError>;
+		readonly list: () => Effect.Effect<ReadonlyArray<string>, SeederError>;
+		readonly create: (spec: LabelSpec) => Effect.Effect<LabelOutcome, SeederError>;
+	}
+>()("@kampus/vocabulary-seed/LabelSeeder") {}
+
+/**
+ * The live layer, parameterised by the explicit `--repo` override so target resolution happens
+ * once per run and every later call reuses the same resolved name — a seeder that re-resolved
+ * mid-run could create half its labels in one repo and half in another.
+ */
+export const layer = (
+	explicitRepo: string | undefined,
+): Layer.Layer<LabelSeeder, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.effect(LabelSeeder)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo(explicitRepo)));
+			return {
+				repo,
+				list: () =>
+					repo.pipe(
+						Effect.flatMap((r) => withSpawner(json(listArgs(r)))),
+						Effect.flatMap(decodePages),
+						Effect.map((pages) => pages.flat().map((l) => l.name)),
+					),
+				create: (spec: LabelSpec) =>
+					repo.pipe(
+						Effect.flatMap((r) => withSpawner(runGh(createArgs(r, spec)))),
+						Effect.as<LabelOutcome>("created"),
+						Effect.catchTag("@kampus/vocabulary-seed/GhCommandError", (error) =>
+							isAlreadyExists(error.output)
+								? Effect.succeed<LabelOutcome>("already-exists")
+								: Effect.fail(error),
+						),
+					),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/vocabulary-seed/seed.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-seed/seed.ts
@@ -1,0 +1,179 @@
+/**
+ * `vocabulary-seed` pure core — decide what an adopting repo is missing from the pipeline label
+ * taxonomy, what a `ROADMAP.md` scaffold should say, and how to read a label-create outcome
+ * (#4341).
+ *
+ * The write counterpart of `vocabulary-preflight`, which is read-only by contract. Everything the
+ * seeder creates comes from `LABEL_SPECS`, the one create-ready home in
+ * `../vocabulary-preflight/vocabulary.ts` — the seeder never carries its own list, because a
+ * second list is exactly the drift that made this tool necessary.
+ *
+ * IO-free and total: the `gh api` reads/writes live in `github.ts`, the disk read/write in
+ * `gate.ts`.
+ */
+import {
+	type LabelSpec,
+	REQUIRED_LABELS,
+	unspecifiedRequiredLabels,
+} from "../vocabulary-preflight/vocabulary.ts";
+
+/** What happened to one label. `already-exists` is a success: seeding is idempotent by contract. */
+export type LabelOutcome = "created" | "already-exists";
+
+/** One label's result after `apply` ran (or would have, under `plan`). */
+export interface LabelResult {
+	readonly name: string;
+	readonly outcome: LabelOutcome;
+}
+
+/** `ROADMAP.md` is written only when absent — an existing roadmap is never overwritten. */
+export type RoadmapPlan =
+	| {readonly _tag: "create"; readonly path: string}
+	| {readonly _tag: "keep"; readonly path: string};
+
+/** What a run would do, computed before it does anything. `plan` prints this and stops. */
+export interface SeedPlan {
+	readonly repo: string;
+	readonly create: ReadonlyArray<LabelSpec>;
+	readonly present: ReadonlyArray<string>;
+	readonly roadmap: RoadmapPlan;
+}
+
+/**
+ * Diff the create-ready taxonomy against the repo's live label universe.
+ *
+ * An empty universe is not a special case: every spec is then missing and gets created, which is
+ * the from-zero adopter this tool exists for. Comparison is on the exact name — GitHub label names
+ * are case-insensitive for uniqueness, so a repo carrying `P0` would still 422 on `p0`; `github.ts`
+ * reads that 422 as `already-exists` rather than a failure, which is where that case resolves.
+ */
+export const planLabels = (
+	specs: ReadonlyArray<LabelSpec>,
+	universe: ReadonlyArray<string>,
+): {readonly create: ReadonlyArray<LabelSpec>; readonly present: ReadonlyArray<string>} => {
+	const create = specs.filter((spec) => !universe.includes(spec.name));
+	const present = specs.filter((spec) => universe.includes(spec.name)).map((spec) => spec.name);
+	return {create, present};
+};
+
+/**
+ * A 422 that means "this label is already here" versus one that means the request was wrong.
+ *
+ * `POST /repos/{owner}/{repo}/labels` 422s on an existing name, and it 422s on a malformed colour.
+ * Collapsing both into "failed" would break idempotency; collapsing both into "fine" would swallow
+ * a real defect. The discriminator is the error body's `already_exists` code, which `gh api` prints
+ * to STDOUT (not stderr) — hence `github.ts` capturing both streams and passing them here joined.
+ */
+export const isAlreadyExists = (output: string): boolean =>
+	/already_exists|already exists/i.test(output);
+
+/**
+ * The seeded `ROADMAP.md`.
+ *
+ * Two constraints shape it. It must parse to at least one `## Arcs` row under
+ * `roadmap-guard`'s parser, or the seeded repo trades a missing-roadmap red for an empty-roadmap
+ * one. And the arc ships `queued` with NO milestone pin, because ADR 0072 makes creating a
+ * milestone an explicitly human act and this tool creates none — a queued arc with no pin is the
+ * legal shape for that (invariant I1), and the page says out loud who closes the gap.
+ */
+export const ROADMAP_SCAFFOLD = `# Roadmap
+
+The roadmap in the maintainers' own voice. It is the **sole parsed roadmap surface**: the pipeline
+reads the tables below rather than any tracker view, and the one \`active\` arc is what milestone
+homing and the write-code picker resolve against.
+
+Seeded by \`pipeline-cli vocabulary-seed apply\`. Edit it — the rows below are a starting shape,
+not a fixture.
+
+## Arcs
+
+An arc is a phase of work with a beginning and an end. Exactly one arc is \`active\` at a time;
+the rest are \`queued\` (sequenced ahead) or \`done\`.
+
+| Arc | Milestone | State |
+| --- | --- | --- |
+| Adoption | — | queued |
+
+## Campaigns
+
+A campaign is a cross-cutting push that runs alongside the active arc. Campaigns may overlap.
+
+| Campaign | Milestone | State |
+| --- | --- | --- |
+
+## Milestones are created by a human, never by this tool
+
+Every non-queued row pins a GitHub milestone by number. **The seeder creates no milestones.**
+Creating or restructuring a milestone is an explicitly human roadmap decision — no pipeline skill
+or tool may create or delete one — so the arc above ships \`queued\` and unpinned, which is the
+legal shape for an arc whose milestone does not exist yet.
+
+To activate an arc, a maintainer of this repository:
+
+1. creates the milestone in GitHub (Issues → Milestones → New milestone);
+2. edits the arc's row here to pin that milestone by number and set the state to \`active\`.
+
+Until an arc is activated this roadmap parses fine and clears the vocabulary preflight, but the
+roadmap guard will report that no arc is active — that report is the reminder, not a defect.
+`;
+
+/**
+ * The seeder's own precondition: every enforced label must be creatable from the one home. A
+ * non-empty result is a wiring fault in this package, not an adopter's problem, so it is a refusal
+ * rather than a partial seed (ADR 0092).
+ */
+export const seedPrecondition = (): string | null => {
+	const unspecified = unspecifiedRequiredLabels();
+	if (unspecified.length === 0) return null;
+	return (
+		`${unspecified.length} required label(s) have no create-ready row in LABEL_SPECS — ` +
+		`${unspecified.join(", ")}. Seeding would leave the vocabulary preflight red, so this run ` +
+		"refuses rather than seed a partial taxonomy."
+	);
+};
+
+const plural = (n: number, one: string, many: string): string => (n === 1 ? one : many);
+
+/** Render the plan a `plan` run prints — the preview, before anything is written. */
+export const renderPlan = (plan: SeedPlan): string => {
+	const lines = [
+		`vocabulary-seed: PLAN for ${plan.repo} — nothing has been written.`,
+		"",
+		`labels present: ${plan.present.length}`,
+		`labels to create: ${plan.create.length}`,
+	];
+	for (const spec of plan.create)
+		lines.push(`  + ${spec.name}  #${spec.color}  ${spec.description}`);
+	lines.push(
+		plan.roadmap._tag === "create"
+			? `roadmap: would CREATE ${plan.roadmap.path}`
+			: `roadmap: keeping the existing ${plan.roadmap.path} (never overwritten)`,
+	);
+	lines.push("", "Run `pipeline-cli vocabulary-seed apply` to write this.");
+	return lines.join("\n");
+};
+
+/** Render what an `apply` run did, and what it left for a human. */
+export const renderResult = (
+	repo: string,
+	labels: ReadonlyArray<LabelResult>,
+	roadmap: RoadmapPlan,
+): string => {
+	const created = labels.filter((l) => l.outcome === "created");
+	const existing = labels.filter((l) => l.outcome === "already-exists");
+	const lines = [
+		`vocabulary-seed: seeded ${repo}.`,
+		"",
+		`labels created: ${created.length}${created.length > 0 ? ` (${created.map((l) => l.name).join(", ")})` : ""}`,
+		`labels already present: ${existing.length}`,
+		roadmap._tag === "create"
+			? `roadmap: created ${roadmap.path}`
+			: `roadmap: left the existing ${roadmap.path} untouched`,
+		"",
+		`${REQUIRED_LABELS.length} ${plural(REQUIRED_LABELS.length, "label is", "labels are")} enforced by \`pipeline-cli vocabulary-preflight check\` — run it to confirm.`,
+		"",
+		"NOT seeded, by design: GitHub milestones. Creating one is a human roadmap decision (ADR",
+		"0072); the seeded ROADMAP.md names the two steps a maintainer takes to activate an arc.",
+	];
+	return lines.join("\n");
+};

--- a/packages/pipeline-cli/src/tools/vocabulary-seed/seed.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-seed/seed.unit.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure-core tests for `vocabulary-seed` (#4341): the seed set comes from the one create-ready home
+ * and totally covers what the preflight enforces, the diff creates only what is missing, a 422 is
+ * read for what it actually says, and the ROADMAP scaffold parses under the roadmap parser the
+ * preflight itself uses. No IO — `gh` and disk are crossed in `gate.behavior.test.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {parseRoadmap} from "../roadmap-guard/roadmap-guard.ts";
+import {
+	LABEL_SPECS,
+	REQUIRED_LABELS,
+	SPECIFIED_LABELS,
+	unspecifiedRequiredLabels,
+} from "../vocabulary-preflight/vocabulary.ts";
+import {
+	isAlreadyExists,
+	planLabels,
+	ROADMAP_SCAFFOLD,
+	renderPlan,
+	renderResult,
+	seedPrecondition,
+} from "./seed.ts";
+
+describe("the seed set is the preflight's set, not a fourth list", () => {
+	it("covers every label `vocabulary-preflight check` enforces", () => {
+		for (const label of REQUIRED_LABELS) expect(SPECIFIED_LABELS).toContain(label);
+		expect(unspecifiedRequiredLabels()).toEqual([]);
+	});
+
+	it("clears its own precondition — a gap here would seed a taxonomy that stays red", () => {
+		expect(seedPrecondition()).toBeNull();
+	});
+
+	it("gives every row the two fields a create needs, and no `|` to break the bash seam", () => {
+		for (const spec of LABEL_SPECS) {
+			expect(spec.color).toMatch(/^[0-9a-f]{6}$/);
+			expect(spec.description.length).toBeGreaterThan(0);
+			expect(spec.description).not.toContain("|");
+			expect(spec.name).not.toContain("|");
+		}
+	});
+
+	it("names each label once — a duplicate row would create then 422 against itself", () => {
+		expect(new Set(SPECIFIED_LABELS).size).toBe(SPECIFIED_LABELS.length);
+	});
+});
+
+describe("planLabels", () => {
+	it("creates everything against a bare repo — the from-zero adopter this exists for", () => {
+		const {create, present} = planLabels(LABEL_SPECS, []);
+		expect(create).toEqual([...LABEL_SPECS]);
+		expect(present).toEqual([]);
+	});
+
+	it("creates ONLY what is missing against a partially-seeded repo (idempotency, the diff half)", () => {
+		const already = SPECIFIED_LABELS.slice(0, 3);
+		const {create, present} = planLabels(LABEL_SPECS, already);
+		expect(present).toEqual(already);
+		expect(create.map((s) => s.name)).toEqual(SPECIFIED_LABELS.slice(3));
+	});
+
+	it("creates nothing on a re-run against a fully-seeded repo", () => {
+		const {create, present} = planLabels(LABEL_SPECS, [...SPECIFIED_LABELS, "unrelated"]);
+		expect(create).toEqual([]);
+		expect(present).toEqual([...SPECIFIED_LABELS]);
+	});
+});
+
+describe("isAlreadyExists — the 422 that is a success vs the 422 that is a defect", () => {
+	it("reads GitHub's already_exists code out of the error body gh prints to stdout", () => {
+		const body = JSON.stringify({
+			message: "Validation Failed",
+			errors: [{resource: "Label", code: "already_exists", field: "name"}],
+		});
+		expect(isAlreadyExists(`${body}\ngh: Validation Failed (HTTP 422)`)).toBe(true);
+	});
+
+	it("does NOT read a malformed-colour 422 as already-existing", () => {
+		const body = JSON.stringify({
+			message: "Validation Failed",
+			errors: [{resource: "Label", code: "invalid", field: "color"}],
+		});
+		expect(isAlreadyExists(`${body}\ngh: Validation Failed (HTTP 422)`)).toBe(false);
+	});
+
+	it("does not read an auth or not-found failure as already-existing", () => {
+		expect(isAlreadyExists("gh: Not Found (HTTP 404)")).toBe(false);
+		expect(isAlreadyExists("gh: Bad credentials (HTTP 401)")).toBe(false);
+	});
+});
+
+describe("ROADMAP_SCAFFOLD", () => {
+	it("parses at least one arc row — the seeded repo clears the roadmap prerequisite", () => {
+		const {arcs} = parseRoadmap(ROADMAP_SCAFFOLD);
+		expect(arcs.length).toBeGreaterThan(0);
+	});
+
+	it("ships that arc QUEUED and unpinned, the legal shape for an arc with no milestone yet", () => {
+		const [arc] = parseRoadmap(ROADMAP_SCAFFOLD).arcs;
+		expect(arc?.state).toBe("queued");
+		expect(arc?.milestone).toBeNull();
+	});
+
+	it("parses no campaign rows — the table is a header a maintainer fills, not a fixture", () => {
+		expect(parseRoadmap(ROADMAP_SCAFFOLD).campaigns).toEqual([]);
+	});
+
+	// The ADR-0072 disposition has to survive in the artifact, not only in the PR that added it:
+	// the seeded file is the only thing an adopter reads.
+	it("says in the file itself that a human creates the milestones", () => {
+		expect(ROADMAP_SCAFFOLD).toContain("creates no milestones");
+		expect(ROADMAP_SCAFFOLD).toContain("human roadmap decision");
+	});
+
+	it("carries no absolute, home, or sibling-repo path — it is written into someone else's repo", () => {
+		expect(ROADMAP_SCAFFOLD).not.toMatch(/(^|\s)[~/][A-Za-z~/]/);
+	});
+});
+
+describe("the rendered output", () => {
+	it("says out loud that a plan wrote nothing", () => {
+		const report = renderPlan({
+			repo: "owner/name",
+			create: [...LABEL_SPECS],
+			present: [],
+			roadmap: {_tag: "create", path: "/repo/ROADMAP.md"},
+		});
+		expect(report).toContain("nothing has been written");
+		expect(report).toContain("owner/name");
+	});
+
+	it("names the resolved repo and the milestone carve-out in the apply result", () => {
+		const report = renderResult("owner/name", [{name: "p0", outcome: "created"}], {
+			_tag: "keep",
+			path: "/repo/ROADMAP.md",
+		});
+		expect(report).toContain("owner/name");
+		expect(report).toContain("labels created: 1");
+		expect(report).toContain("NOT seeded, by design: GitHub milestones");
+	});
+});


### PR DESCRIPTION
Setting up a fresh repo to run the pipeline meant pasting the label taxonomy in by hand, one `gh label create` line at a time — the preflight could only tell you what was missing, and doctor could only print the commands. This adds `pipeline-cli vocabulary-seed`, one command that actually creates them, plus a `ROADMAP.md` scaffold, so a from-zero repo reaches the loop without a hand-copy step. Re-running it is safe: it creates only what is missing and treats "that label already exists" as success, not failure.

Fixes #4341

## What changed

- **New tool `pipeline-cli vocabulary-seed <plan|apply>`** (`packages/pipeline-cli/src/tools/vocabulary-seed/`) — a pure core (`seed.ts`), the `gh api` boundary (`github.ts`), the wiring (`gate.ts`), and a thin Effect command, registered in the router.
- **One home for label colour + description.** `LABEL_SPECS` in `packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts` now carries `name/color/description`; a new `vocabulary-preflight specs` subcommand emits it as `NAME|HEX|DESCRIPTION`. `REQUIRED_LABELS` is untouched — still assembled from the six groups the guards themselves own — and `unspecifiedRequiredLabels()` asserts the enforced set is totally creatable from the table, fail-closed.
- **`doctor.sh` no longer carries a tier-1 label table.** It reads the rows from `vocabulary-preflight specs`, so its printed fix and the seeder that runs it cannot drift. Its 1d check is re-pointed: it now reds if the *enforced* set ever names a label the create-ready table cannot create — the #4300 drift class, one file over. An unresolvable CLI makes the label check UNDETERMINED (fail), never a vacuous pass. Only the tier-3 ideation row stays local.
- **The printed fix is now one command** — `vocabulary-seed plan/apply --repo <owner/name>` — instead of N lines for a human to paste.

## The ADR 0072 fork — disposed of on the record: disposition (a), no milestones

The issue named a fork and forbade sweeping past it. **The seeder creates no GitHub milestones.**

`.decisions/0072-milestones-encode-strategic-sequencing.md` §3 says there is no autonomous "create-milestones" skill, and its Consequences close categorically: *"Restructuring milestones is now an explicitly human act; no skill may create or delete them."* Disposition (b) — an ADR carving out install-time bootstrap in a foreign repo — is *arguable*, and that is exactly the problem: re-reading a categorical consequence narrowly because it happens to block what you want is the quiet reinterpretation an ADR exists to prevent. So this PR takes **(a)** and does not amend 0072.

What that means concretely:

- The scaffolded `ROADMAP.md` ships **one `queued`, unpinned arc**. That is the legal shape for an arc whose milestone does not exist yet (roadmap-guard invariant I1 exempts a queued arc from pinning), and it parses to one arc row, so the seeded repo clears the roadmap prerequisite rather than trading one red for another.
- The scaffold **says who closes the gap, in the file itself**: a maintainer of the adopting repo creates the milestone in GitHub, then pins it by number and sets the row to `active`. A unit test asserts that text survives, because the seeded file is the only thing an adopter reads.
- It also says plainly that until an arc is activated, the roadmap guard will report no active arc — that report is the reminder, not a defect.

No decision issue was filed, because (b) is not a better answer here — it would trade a real invariant for a convenience the two-step human note already covers.

## The observable done-test, exercised

`gate.behavior.test.ts` runs the real `applySeed` and the real `checkVocabulary` against one shared fake repo — only `gh` and the filesystem are substituted, and the stub `gh` really 422s with GitHub's `already_exists` body on a name it already holds, so idempotency is proven against the server's behaviour rather than against a pre-read. It asserts red → seed → green in one run, plus the partial-seed, re-run, never-overwrite-an-existing-ROADMAP, and race-between-read-and-create cases.

Run live through the shipped binaries against a bare target (transport stubbed, tool code real):

```
=== BEFORE: a bare repo (0 labels, no ROADMAP.md) ===
vocabulary-preflight: 2 unmet prerequisite(s) — the pipeline would run and protect nothing here:
16 required label(s) absent from the repo: ...
ROADMAP.md — not found
--- exit: 1 (RED) ---

=== SEED ===
vocabulary-seed: seeded adopter/fresh.
labels created: 18
roadmap: created .../ROADMAP.md
--- exit: 0 ---

=== AFTER: the same preflight, same repo ===
vocabulary-preflight: prerequisites met — all 16 required labels exist, ROADMAP.md parses 1 arc(s) and 0 campaign(s).
--- exit: 0 (GREEN) ---

=== RE-RUN (idempotency) ===
labels created: 0 · labels already present: 18 · roadmap: left untouched
--- exit: 0 ---
```

`doctor.sh` re-run against this repo: `✓ all 18 required pipeline labels exist` / `✓ every one of the 16 enforced labels is creatable from the shared table`.

## Writing to the right repo

Target resolution is explicit and ordered: `--repo owner/name` first, then `CLAUDE_PIPELINE_REPO` / `GITHUB_REPOSITORY`, then `gh repo view`. With none of them resolvable it fails rather than guessing. `plan` is read-only and is the documented first run; `apply` prints the resolved repo before the first write. The one destructive thing a seeder could do — clobbering a maintained `ROADMAP.md` — is unrepresentable: an existing file is always kept, never overwritten.

## Checks

- `pnpm typecheck` — clean (29/29 tasks)
- `pnpm lint:worktree` — clean
- `pipeline-cli` suite — 181 files / 2863 tests passed, including `core-import-closure.unit.test.ts` (ADR 0218: the new tool sits under `src/tools/`, reached from core only through `registry.ts`'s sunk fan-out edge, so the recorded escape residue is unchanged) and `commands check`.

## Deviations

- **Class: narrowed a suggested shape.** Said: colours and descriptions get one home shared by the seeder and `doctor.sh`. Did: put that home in `vocabulary-preflight/vocabulary.ts` as `LABEL_SPECS` and had `doctor.sh` read it through a new `specs` subcommand, rather than merging the two required-set notions. Why: `LABEL_SPECS` is deliberately a *superset* of `REQUIRED_LABELS` — `status:planning` and `status:awaiting-release` are labels the pipeline writes and doctor already required, but the preflight does not enforce. Folding them into `REQUIRED_LABELS` would widen the enforced vocabulary, which is a founder call and out of scope here. Disposition: no action needed; the fail-closed direction that matters (every enforced label is creatable) is asserted in code and in doctor's 1d.
- **Class: changed an adjacent surface the issue did not scope.** Said: don't touch doctor's delegation (#4300). Did: edited `doctor.sh`'s 1c/1d anyway. Why: AC 2 requires one colour/description home *shared with doctor's printed fixes*, which is unsatisfiable without doctor consuming it. #4300's delegation (names) is preserved and extended, not reverted. Disposition: no action needed; #4300 merged first and this builds on it.
- **Class: the done-test's transport is stubbed.** Said: exercise the done-test by execution against a bare repo. Did: exercised the real tool binaries end to end against a stub `gh` and a scratch root, plus a committed behavior test, rather than creating a throwaway GitHub repo. Why: the available token carries no `delete_repo` scope, so a real throwaway repo could not be cleaned up afterwards. Disposition: for the reviewer to judge; the red→green crossing is real code on both sides and is committed as a test.
