### PR TITLE
fix(pipeline-cli): give the seven source-less gate boundaries a typed source (#4401)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -179,7 +179,10 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'; HAS_SKILLS_RE='^claude-plugins/[^/]+/(skills|agents)/|^\.claude-plugin/'   # fail-closed reference; §CLASS is authoritative
   HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'; HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'
   CLASS_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
-  reresolve_re() { live="$(printf '%s\n' "$CLASS_RAW" | grep "^$1=" | head -n1 || true)"; if [ -n "$live" ]; then printf '%s' "$live" | sed "s/^$1='//; s/'\$//"; else printf '%s' "$2"; fi; }
+  # accept_re is §CLASS's NON-TRIVIALITY ASSERT (#4401): an empty or prefix-carrying strip still
+  # compiles, and `grep -Ev ""` then excludes nothing — a silent fail-OPEN on the docs carve-out.
+  accept_re() { case "$2" in *"$1='"*) : ;; *) if [ "${#2}" -ge 4 ]; then printf '%s' "$2"; return 0; fi ;; esac; printf 'TRIVIAL-GATE-BOUNDARY: %s did not resolve to a usable pattern — failing closed.\n' "$1" >&2; printf '%s' "$3"; }
+  reresolve_re() { live="$(printf '%s\n' "$CLASS_RAW" | grep "^$1=" | head -n1 || true)"; if [ -z "$live" ]; then printf '%s' "$2"; else accept_re "$1" "$(printf '%s' "$live" | sed "s/^$1='//; s/'\$//")" "$2"; fi; }
   HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"; HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
   HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"; HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"   # unreadable ⇒ exclude nothing / every path a doc ⇒ dispatch review-doc
   CHANGED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
@@ -215,8 +218,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'   # #3071: a src-colocated *.test.tsx/*.spec.ts renders no surface — carve it out (mirrors §CLASS has-docs carve-then-test; ERE has no lookahead, hence the exclude pair)
   UI_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
   UI_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_RE=' | head -n1 || true)"; UX_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_EXCLUDE_RE=' | head -n1 || true)"
-  if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # unreadable ⇒ '.' ⇒ every path is UI-affecting ⇒ dispatch review-design (never silently drop it)
-  if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")"; else UI_EXCLUDE_RE='$^'; fi   # unreadable ⇒ '$^' never-match ⇒ carve nothing ⇒ dispatch review-design for every src path (fail-closed)
+  accept_re() { case "$2" in *"$1='"*) : ;; *) if [ "${#2}" -ge 4 ]; then printf '%s' "$2"; return 0; fi ;; esac; printf 'TRIVIAL-GATE-BOUNDARY: %s did not resolve to a usable pattern — failing closed.\n' "$1" >&2; printf '%s' "$3"; }   # §CLASS non-triviality assert (#4401)
+  if [ -n "$UI_LIVE" ]; then UI_RE="$(accept_re UI_RE "$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")" '.')"; else UI_RE='.'; fi   # unreadable or trivial ⇒ '.' ⇒ every path is UI-affecting ⇒ dispatch review-design (never silently drop it)
+  if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(accept_re UI_EXCLUDE_RE "$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")" '$^')"; else UI_EXCLUDE_RE='$^'; fi   # unreadable or trivial ⇒ '$^' never-match ⇒ carve nothing ⇒ dispatch review-design for every src path (fail-closed)
   CHANGED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
   echo "$CHANGED" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "UI-affecting → dispatch review-design alongside the class gate"
   ```

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1719,9 +1719,15 @@ guard-*relaxer* (which would auto-ship a weakened gate) — "you cannot relax a 
 it," so a content probe over guard vocabulary catches the class an author tag would let slip. This
 is the same fail-closed stance as §ZS / ADR 0092.
 
-The predicate is **single-sourced here** as one canonical regex — the same discipline that keeps
-`CONTROL_PLANE_RE` from drifting (ADR 0073 §6). Cite this line; do **not** re-hard-code the
-vocabulary. `validate-gate-path-drift.sh` locks `ship-it`'s copy byte-identical to this canonical.
+The predicate is **single-sourced** in the `GUARD_ADR_RE` const at
+[`packages/pipeline-cli/src/gate-boundaries.ts`](https://github.com/kamp-us/phoenix/blob/main/packages/pipeline-cli/src/gate-boundaries.ts)
+(issue #4401) — run `pipeline-cli control-plane-paths --boundary GUARD_ADR_RE` to print it. The one
+canonical copy below is kept byte-in-sync with that const by `validate-gate-path-drift.sh`, which
+also fails if a **second** `GUARD_ADR_RE=` line reappears: there used to be two, byte-identical, and
+every consumer resolves first-occurrence-wins, so a corrective edit could land on the shadow and
+appear to work. Cite this line; do **not** re-hard-code the vocabulary. The line is retained (rather
+than replaced by an import) for the same reason `CONTROL_PLANE_RE`'s is — the live gates re-resolve
+it from THIS file on `origin/main`, which is the anti-self-authorization property (#981).
 
 ```
 GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\bgat(e|es|ing|ed)\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out'
@@ -1732,9 +1738,14 @@ GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|contai
 # §CP. Resolve GUARD_ADR_RE from origin/main at run time (like CONTROL_PLANE_RE, #981); read each
 # ADR's body at the PR head. FAIL CLOSED: an unreadable boundary ⇒ match-everything; an unreadable
 # ADR (delete/404) ⇒ §CP — never auto-ship an ADR that could not be read and proven guard-free.
-GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\bgat(e|es|ing|ed)\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out'
+# This recipe carries NO seed copy of GUARD_ADR_RE: it used to, byte-identical to the canonical
+# above, and since every consumer resolves first-occurrence-wins that second line was an unguarded
+# shadow a corrective edit could land on and appear to work (#4401). The live read below is the
+# only resolution, and it already fails closed when it can't be made.
 GA_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^GUARD_ADR_RE=' | head -n1 || true)"
-if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(printf '%s' "$GA_LIVE" | sed "s/^GUARD_ADR_RE='//; s/'$//")"; else GUARD_ADR_RE='.'; fi   # FAIL CLOSED: '.' ⇒ every ADR word matches ⇒ every touched ADR is §CP
+# accept_re (§CLASS) is the NON-TRIVIALITY ASSERT: a stripped value that is empty, or that still
+# carries the assignment prefix, is refused here rather than gated on (#4401).
+if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(accept_re GUARD_ADR_RE "$(printf '%s' "$GA_LIVE" | sed "s/^GUARD_ADR_RE='//; s/'$//")" '.')"; else GUARD_ADR_RE='.'; fi   # FAIL CLOSED: '.' ⇒ every ADR word matches ⇒ every touched ADR is §CP
 # The ref and the file list are fallible reads too — both come from §CPREAD (below), so an
 # unreadable head SHA leaves HEAD_SHA EMPTY (payload discarded) rather than holding gh's error body.
 cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
@@ -2109,11 +2120,15 @@ gap where a PR carrying one class's PASS reaches `ship-it` and fail-closes on an
 sibling class, a late stall (#2383; PR #2378 touched docs+skills+code, reached `ship-it` with
 only `review-doc: PASS`).
 
-So these probes are **single-sourced here** as canonical named `_RE=` lines — the same
-discipline that single-sources `CONTROL_PLANE_RE`/`GUARD_ADR_RE` (§CP) and `UI_RE`
-(`ship-it/SKILL.md`). A third inline copy in `reviewer.md` is the exact drift `#375`/`#981`/`#2341`
-fought — the class probes were previously inline grep literals in `ship-it` Step 0 *only*, with
-no reusable line for the reviewer to consume:
+So these probes are **single-sourced** in
+[`packages/pipeline-cli/src/gate-boundaries.ts`](https://github.com/kamp-us/phoenix/blob/main/packages/pipeline-cli/src/gate-boundaries.ts)
+(issue #4401), with the canonical named `_RE=` lines below kept byte-in-sync with those consts by
+`validate-gate-path-drift.sh` — the same arrangement `CONTROL_PLANE_RE`/`GUARD_ADR_RE` (§CP) and
+`UI_RE` (`ship-it/SKILL.md`) use, and for the same reason: the lines stay because the live consumers
+re-resolve them from `origin/main` (#981), the consts exist so a reflowed or emptied line is a red
+test rather than a changed gate decision. A third inline copy in `reviewer.md` is the exact drift
+`#375`/`#981`/`#2341` fought — the class probes were previously inline grep literals in `ship-it`
+Step 0 *only*, with no reusable line for the reviewer to consume:
 
 ```bash
 HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'
@@ -2156,11 +2171,25 @@ and every path falls through to the doc test). This is the same stance as §CP's
 
 ```bash
 # Re-resolve a canonical _RE= line from gh-issue-intake-formats.md@main (#981 ?ref=main idiom).
-# Prints the live value, or the fail-closed default $2 when the line is unreadable.
+# Prints the live value, or the fail-closed default $2 when the line is unreadable OR TRIVIAL.
 FORMATS_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+# NON-TRIVIALITY ASSERT (#4401) — the guard every resolution site below runs before it gates on a
+# freshly-stripped pattern. A strip that silently did NOT strip (a surviving `grep -n` line-number
+# prefix broke the `^NAME='` anchor) or that yielded nothing still COMPILES: `grep -E ""` matches
+# every path and `grep -Ev ""` matches none, BOTH at exit 0 — so the polarity, not the error, decides
+# whether the miss is loud or silent. Absence was already handled; triviality was not.
+accept_re() {   # $1=name, $2=resolved value, $3=fail-closed default
+  case "$2" in
+    *"$1='"*) : ;;   # the assignment prefix survived the strip ⇒ not a pattern, a whole line
+    *) if [ "${#2}" -ge 4 ]; then printf '%s' "$2"; return 0; fi ;;
+  esac
+  printf 'TRIVIAL-GATE-BOUNDARY: %s did not resolve to a usable pattern — failing closed.\n' "$1" >&2
+  printf '%s' "$3"
+}
 reresolve_re() {   # $1=var name, $2=fail-closed default
   live="$(printf '%s\n' "$FORMATS_RAW" | grep "^$1=" | head -n1 || true)"
-  if [ -n "$live" ]; then printf '%s' "$live" | sed "s/^$1='//; s/'\$//"; else printf '%s' "$2"; fi
+  if [ -z "$live" ]; then printf '%s' "$2"; return 0; fi
+  accept_re "$1" "$(printf '%s' "$live" | sed "s/^$1='//; s/'\$//")" "$2"
 }
 HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"
 HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
@@ -2182,8 +2211,9 @@ Keying the issueless allowance on the *class* therefore false-refuses that PR �
 divergence, where `review-doc` Step 1 hard-stopped a shape `ship-it` Step 1 and `review-code`
 Step 1 both bless by name.
 
-So the allowance keys on the **surface**, single-sourced here as its own carve-then-test pair —
-adjacent to the class probes, deliberately **not** one of them:
+So the allowance keys on the **surface**, its own carve-then-test pair — adjacent to the class
+probes, deliberately **not** one of them, and single-sourced in `gate-boundaries.ts` alongside them
+(`pipeline-cli control-plane-paths --boundary DOC_VOCAB_SURFACE_RE`):
 
 ```bash
 DOC_VOCAB_EXCLUDE_RE='^(apps|packages|infra|claude-plugins)/'
@@ -3342,7 +3372,9 @@ claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC> · presence <machine-fingerpri
   re-derives this write instead of citing the verb.
 - **Read surface — the canonical `CLAIM_RE`.** A claim comment is matched by this **one**
   anchored, case-insensitive, emphasis-tolerant regex; every consumer cites it and **none
-  re-hard-codes the grammar** (it pairs with §5/§6's marker-matcher discipline):
+  re-hard-codes the grammar** (it pairs with §5/§6's marker-matcher discipline). The executable
+  matcher is the `RegExp` in `tools/epic-lock/claim-resolution.ts`; the jq/PCRE rendering below is
+  single-sourced in `gate-boundaries.ts` and drift-locked to both (#4401):
 
   ```
   CLAIM_RE='(?i)^\s*\**\s*claim:\s*[0-9a-f-]{36}\b'

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1744,7 +1744,18 @@ GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|contai
 # only resolution, and it already fails closed when it can't be made.
 GA_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^GUARD_ADR_RE=' | head -n1 || true)"
 # accept_re (§CLASS) is the NON-TRIVIALITY ASSERT: a stripped value that is empty, or that still
-# carries the assignment prefix, is refused here rather than gated on (#4401).
+# carries the assignment prefix, is refused here rather than gated on (#4401). Single-sourced in
+# §CLASS and copied down here — as ship-it's Step 0 copies it — because a fenced recipe must run
+# standalone when pasted; a cross-block call resolves to `command not found`, an empty pattern,
+# and every touched ADR classified §CP (#4413).
+accept_re() {   # $1=name, $2=resolved value, $3=fail-closed default
+  case "$2" in
+    *"$1='"*) : ;;
+    *) if [ "${#2}" -ge 4 ]; then printf '%s' "$2"; return 0; fi ;;
+  esac
+  printf 'TRIVIAL-GATE-BOUNDARY: %s did not resolve to a usable pattern — failing closed.\n' "$1" >&2
+  printf '%s' "$3"
+}
 if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(accept_re GUARD_ADR_RE "$(printf '%s' "$GA_LIVE" | sed "s/^GUARD_ADR_RE='//; s/'$//")" '.')"; else GUARD_ADR_RE='.'; fi   # FAIL CLOSED: '.' ⇒ every ADR word matches ⇒ every touched ADR is §CP
 # The ref and the file list are fallible reads too — both come from §CPREAD (below), so an
 # unreadable head SHA leaves HEAD_SHA EMPTY (payload discarded) rather than holding gh's error body.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -356,13 +356,25 @@ FILES="$CP_FILES"   # proven-arrived, scope already emitted ($CP_FILES_N files) 
 # §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
 # run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
 # (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+# NON-TRIVIALITY ASSERT (#4401) — single-sourced in §CLASS of gh-issue-intake-formats.md; copied
+# here verbatim because Step 0 runs as one shell block. EVERY boundary this step strips out of a
+# network read goes through it before anything gates on it: an empty or prefix-carrying value still
+# COMPILES, and `grep -E ""` matches every path while `grep -Ev ""` matches none, both at exit 0.
+accept_re() {   # $1=name, $2=resolved value, $3=fail-closed default
+  case "$2" in
+    *"$1='"*) : ;;   # the assignment prefix survived the strip ⇒ not a pattern, a whole line
+    *) if [ "${#2}" -ge 4 ]; then printf '%s' "$2"; return 0; fi ;;
+  esac
+  printf 'TRIVIAL-GATE-BOUNDARY: %s did not resolve to a usable pattern — failing closed.\n' "$1" >&2
+  printf '%s' "$3"
+}
 CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-classify a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL, top-of-skill rule). origin/main's line wins over the snapshot.
 CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
 if [ -n "$CP_LIVE" ]; then
-  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # classification tracks origin/main, not the snapshot's age (AC1/AC2)
+  CONTROL_PLANE_RE="$(accept_re CONTROL_PLANE_RE "$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")" '.')"   # classification tracks origin/main, not the snapshot's age (AC1/AC2); a trivial strip fails closed to '.'
 else
   CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ treat EVERY path as control-plane (refuse), never trust the possibly-stale snapshot
 fi
@@ -423,7 +435,7 @@ HAS_SKILLS_RE='^claude-plugins/[^/]+/(skills|agents)/|^\.claude-plugin/'
 HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'
 HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'
 CLASS_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
-reresolve_re() { live="$(printf '%s\n' "$CLASS_RAW" | grep "^$1=" | head -n1 || true)"; if [ -n "$live" ]; then printf '%s' "$live" | sed "s/^$1='//; s/'\$//"; else printf '%s' "$2"; fi; }
+reresolve_re() { live="$(printf '%s\n' "$CLASS_RAW" | grep "^$1=" | head -n1 || true)"; if [ -z "$live" ]; then printf '%s' "$2"; else accept_re "$1" "$(printf '%s' "$live" | sed "s/^$1='//; s/'\$//")" "$2"; fi; }
 HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"
 HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
 HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed: exclude NOTHING ⇒ every path reaches the doc test
@@ -468,8 +480,8 @@ UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
 UI_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
 UI_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_RE=' | head -n1 || true)"
 UX_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_EXCLUDE_RE=' | head -n1 || true)"
-if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # FAIL CLOSED: can't read origin/main's UI_RE ⇒ '.' ⇒ every path UI-affecting ⇒ REQUIRE review-design, never silently skip (#2341)
-if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")"; else UI_EXCLUDE_RE='$^'; fi   # FAIL CLOSED: unreadable ⇒ '$^' never-match ⇒ carve out NOTHING ⇒ every apps/web/src path (incl. tests) gates review-design
+if [ -n "$UI_LIVE" ]; then UI_RE="$(accept_re UI_RE "$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")" '.')"; else UI_RE='.'; fi   # FAIL CLOSED: can't read origin/main's UI_RE — or it resolves TRIVIAL — ⇒ '.' ⇒ every path UI-affecting ⇒ REQUIRE review-design, never silently skip (#2341/#4401)
+if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(accept_re UI_EXCLUDE_RE "$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")" '$^')"; else UI_EXCLUDE_RE='$^'; fi   # FAIL CLOSED: unreadable or trivial ⇒ '$^' never-match ⇒ carve out NOTHING ⇒ every apps/web/src path (incl. tests) gates review-design
 echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"   # carve test/spec first, THEN require review-design ALONGSIDE the class gate(s)
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -73,80 +73,106 @@ else
   formats: $FORMATS_RE"
 fi
 
-# Invariant 1b: the §CP canonical GUARD_ADR_RE is present (ADR 0164, #3645).
+# Invariants 1b / 1c / 1d: every OTHER single-sourced gate boundary (issue #4401).
 #
-# The guard-touching-ADR content predicate (ADR 0164, #2191) is single-sourced in §CP as one
-# canonical GUARD_ADR_RE= line in gh-issue-intake-formats.md. Since #3645 there is NO
-# hand-copied consumer literal to drift-lock: ship-it Step 0, the review gate, and the driver
-# (via trivial-diff) all run the SHARED `pipeline-cli guard-content-probe` verb, whose core
-# parses this canonical line directly (like class-probe parses HAS_*_RE) — so the byte-compare
-# of a consumer copy is obsolete. This invariant now only asserts the canonical still EXISTS
-# (the single source the verb reads); a drift would be a same-file edit, not a copy skew.
-GA_CANONICAL=$(grep "^GUARD_ADR_RE=" "$FORMATS_MD" | head -n1 | sed 's/^GUARD_ADR_RE=//' || true)
-if [ -z "$GA_CANONICAL" ]; then
-	fail "§CP canonical GUARD_ADR_RE= not found in $FORMATS_MD — line must start with GUARD_ADR_RE= (ADR 0164; the guard-content-probe verb reads this single source)"
-else
-	ok "§CP canonical GUARD_ADR_RE present in gh-issue-intake-formats.md (read by pipeline-cli guard-content-probe)"
-fi
-
-# Invariant 1c: HAS_*_RE class-fan copies match §CP (issue #2488).
+# Until #4401 only CONTROL_PLANE_RE had a typed source. The other ten — GUARD_ADR_RE (ADR 0164),
+# the four HAS_*_RE class probes (#2488), the two DOC_VOCAB_*_RE surface probes, CLAIM_RE (ADR
+# 0115) and the UI_RE/UI_EXCLUDE_RE pair (#2341/#3071) — lived ONLY as prose lines, so invariant
+# 1b could assert no more than "a GUARD_ADR_RE= line exists" and DOC_VOCAB/CLAIM/UI were locked
+# by nothing at all. They now have consts in packages/pipeline-cli/src/gate-boundaries.ts, emitted
+# by `pipeline-cli control-plane-paths --boundary <NAME>` — so all three checks below are the SAME
+# const-vs-copy compare invariant 1 already runs for CONTROL_PLANE_RE, generalized:
 #
-# The four class-classification probes — HAS_CODE_RE / HAS_SKILLS_RE /
-# HAS_DOCS_EXCLUDE_RE / HAS_DOCS_RE — are single-sourced as canonical HAS_*_RE='…'
-# lines in §CP exactly like CONTROL_PLANE_RE, then copied verbatim into ship-it Step
-# 0's class fan. A stale copy mis-classes a PR's changed-path fan (the #2434
-# `.glossary/**→has-code` miss that emptied a review namespace and stalled ship-it),
-# and that drift was caught only by hand during #2434/#2486 — the exact gap this
-# invariant closes. Kept as a pure-bash grep-extract-then-diff (the HAS_*_RE regexes
-# are not part of #2761's CONTROL_PLANE_RE single-sourcing) rather than routed through
-# `pipeline-cli class-probe`, even though Invariant 1 now makes `node` available in the job.
-HAS_NAMES="HAS_CODE_RE HAS_SKILLS_RE HAS_DOCS_EXCLUDE_RE HAS_DOCS_RE"
-# Surfaces carrying a copy of the §CP block, enumerated like Invariant 1's CONSUMERS.
-# ship-it's copies are one-per-line; reviewer.md's `class_reresolve` fail-closed reference
-# packs two per COMPOUND line (`HAS_A='x'; HAS_B='y'   # c`), which the per-assignment
-# extraction below handles. Both copy sites must track §CP or the class fan silently drifts
-# (issue #2488: reviewer.md's copy was unguarded — drifting it left this gate GREEN). Paths
-# are relative to skills_dir, so the sibling agents/ dir is reached with `../agents/…`.
-HAS_CONSUMERS="ship-it/SKILL.md ../agents/reviewer.md"
+#   1b — the canonical prose line equals the const (a VALUE compare, not a presence check).
+#   1c — every other copy of the name in the corpus equals it too (ship-it's class fan,
+#        reviewer.md's compound fail-closed reference, the doc's own illustrative fenced copies).
+#   1d — the canonical appears EXACTLY ONCE in its source file. GUARD_ADR_RE appeared twice,
+#        byte-identical, and every consumer resolves first-occurrence-wins — so a corrective edit
+#        could land on the shadow copy and appear to work (#4401).
+#
+# The canonical is the COLUMN-0 assignment, because that is what every live consumer resolves
+# (`grep '^NAME='` in shell, `/^NAME='…'/m` in TypeScript). An indented occurrence is prose
+# illustration, not a machine surface — 1c still value-locks it, 1d does not count it.
+BOUNDARY_NAMES="GUARD_ADR_RE HAS_CODE_RE HAS_SKILLS_RE HAS_DOCS_EXCLUDE_RE HAS_DOCS_RE DOC_VOCAB_EXCLUDE_RE DOC_VOCAB_SURFACE_RE CLAIM_RE UI_RE UI_EXCLUDE_RE"
+SHIPIT_MD="$skills_dir/ship-it/SKILL.md"
+REVIEWER_MD="$skills_dir/../agents/reviewer.md"
+# Every corpus file that may carry an assignment copy of a boundary name.
+COPY_FILES="$FORMATS_MD $SHIPIT_MD $REVIEWER_MD"
 
-for name in $HAS_NAMES; do
-	# Canonical: the single-quoted §CP assignment (NAME='…'). Anchor on the opening
-	# quote so this never grabs the double-quoted `NAME="$(reresolve_re …)"` line below it.
-	HAS_CANONICAL=$(grep "^$name='" "$FORMATS_MD" | head -n1 | sed "s/^$name=//" || true)
-	if [ -z "$HAS_CANONICAL" ]; then
-		fail "§CP canonical $name= not found in $FORMATS_MD — line must start with $name='…' (issue #2488)"
+# An ASSIGNMENT occurrence: the name preceded by start-of-line, whitespace, or `; ` (reviewer.md
+# packs two per compound line). Deliberately NOT a bare substring match — `grep '^NAME='` and
+# `sed "s/^NAME='//"` recipe lines also contain `NAME='`, and treating those as copies extracts
+# the substitution expression and false-FAILs.
+assignment_lines() { grep -nE "(^|[[:space:]]|;)$1='" "$2" 2>/dev/null || true; }
+# Pull ONLY this name's own single-quoted value off a line. A single-quoted bash string cannot
+# contain a `'`, so `[^']*` up to the next quote is exactly the value (issue #2488).
+assignment_value() { printf '%s\n' "$2" | sed "s/.*$1='\([^']*\)'.*/\1/"; }
+
+for name in $BOUNDARY_NAMES; do
+	# The single source: the const the emitter prints. `|| true` so a failed run yields empty and
+	# hits the explicit empty-check below instead of aborting under set -e.
+	CONST_VAL=$(node "$repo_root/packages/pipeline-cli/src/bin.ts" control-plane-paths --boundary "$name" 2>/dev/null || true)
+	if [ -z "$CONST_VAL" ]; then
+		fail "could not read the $name const via \`pipeline-cli control-plane-paths --boundary $name\` (single source: packages/pipeline-cli/src/gate-boundaries.ts) — issue #4401"
 		continue
 	fi
-	ok "§CP canonical $name extracted from gh-issue-intake-formats.md"
 
-	for rel in $HAS_CONSUMERS; do
-		md="$skills_dir/$rel"
+	# UI_RE/UI_EXCLUDE_RE are single-sourced in ship-it/SKILL.md, not §CP (§CLASS keeps them there
+	# deliberately, and every consumer re-resolves that file from origin/main).
+	case "$name" in
+		UI_RE|UI_EXCLUDE_RE) SRC_MD="$SHIPIT_MD" ;;
+		*) SRC_MD="$FORMATS_MD" ;;
+	esac
+
+	# 1d — exactly one column-0 canonical in the source file.
+	CANON_COUNT=$(grep -c "^$name='" "$SRC_MD" 2>/dev/null || true)
+	[ -n "$CANON_COUNT" ] || CANON_COUNT=0
+	if [ "$CANON_COUNT" -eq 0 ]; then
+		fail "canonical $name='…' not found at column 0 in $SRC_MD — the live consumers resolve it with ^$name= (issue #4401)"
+		continue
+	elif [ "$CANON_COUNT" -gt 1 ]; then
+		fail "canonical $name='…' appears $CANON_COUNT times at column 0 in $SRC_MD — every consumer resolves first-occurrence-wins, so the later copies are unguarded shadows a corrective edit can land on (issue #4401)"
+		continue
+	fi
+	ok "canonical $name appears exactly once in $(basename "$SRC_MD")"
+
+	# 1b — the canonical equals the const.
+	CANON_VAL=$(assignment_value "$name" "$(grep "^$name='" "$SRC_MD" | head -n1)")
+	if [ "$CANON_VAL" = "$CONST_VAL" ]; then
+		ok "canonical $name matches the single-source const"
+	else
+		fail "canonical $name has drifted from the single-source const
+  const: $CONST_VAL
+  prose: $CANON_VAL"
+	fi
+
+	# 1c — every other assignment copy in the corpus equals it too.
+	for md in $COPY_FILES; do
 		if [ ! -f "$md" ]; then
-			fail "$rel: file not found — cannot verify $name copy"
+			fail "$md: file not found — cannot verify $name copies"
 			continue
 		fi
-		# The single-quoted copy (tolerant of leading whitespace); the `'` in the
-		# pattern excludes the `NAME="$(reresolve_re …)"` re-assignment line.
-		LINE=$(grep "$name='" "$md" | head -n1 || true)   # || true: no-match hits the fail below, not a set -e abort
-		if [ -z "$LINE" ]; then
-			fail "$rel: no $name='…' line found — consumer must carry a copy matching §CP (issue #2488)"
-			continue
-		fi
-		# Per-assignment extraction (compound-line-aware): pull ONLY this NAME's own
-		# single-quoted value, whether it sits alone (ship-it, one per line) or shares a
-		# compound line with a sibling assignment + trailing comment (reviewer.md,
-		# `HAS_A='x'; HAS_B='y'   # c`). A single-quoted bash string cannot contain a `'`,
-		# so `[^']*` up to the next quote is the exact value — the old whole-line strip
-		# swallowed the sibling assignment on a compound line and false-FAILed (issue #2488).
-		VAL_CLEAN=$(printf '%s\n' "$LINE" | sed "s/.*$name='\([^']*\)'.*/'\1'/")
-		if [ "$VAL_CLEAN" = "$HAS_CANONICAL" ]; then
-			ok "$rel $name matches §CP canonical"
-		else
-			fail "$rel $name has drifted from §CP canonical
-  §CP:  $HAS_CANONICAL
-  copy: $VAL_CLEAN"
-		fi
+		COPIES=$(assignment_lines "$name" "$md")
+		[ -n "$COPIES" ] || continue
+		while IFS= read -r hit; do
+			[ -z "$hit" ] && continue
+			LINE_NO=${hit%%:*}
+			COPY_VAL=$(assignment_value "$name" "${hit#*:}")
+			# A FAIL-CLOSED SENTINEL (`.`, `$^`) is not a copy of the boundary — it is the value a
+			# recipe assigns when the live read fails, and locking it to the const would demand the
+			# recipe carry the 300-char pattern as its fallback. Every real boundary is far longer
+			# than any sentinel, so the length bound separates them without enumerating either.
+			[ "${#COPY_VAL}" -lt 4 ] && continue
+			if [ "$COPY_VAL" != "$CONST_VAL" ]; then
+				fail "$(basename "$md"):$LINE_NO $name has drifted from the single-source const
+  const: $CONST_VAL
+  copy:  $COPY_VAL"
+			fi
+		done <<EOF
+$COPIES
+EOF
 	done
+	ok "$name copies across the corpus match the single-source const"
 done
 
 # Invariant 2: .claude/skills symlink agrees with marketplace source.

--- a/packages/pipeline-cli/src/gate-boundaries.ts
+++ b/packages/pipeline-cli/src/gate-boundaries.ts
@@ -1,0 +1,144 @@
+/**
+ * The typed source for every gate boundary that had none (issue #4401).
+ *
+ * `CONTROL_PLANE_RE` got a const in #2761; these ten did not — they lived only as `_RE=`
+ * shell-assignment lines inside prose (`gh-issue-intake-formats.md`, `ship-it/SKILL.md`) and were
+ * pulled back out at decision time by regex-over-prose or `grep`+`sed`. Nothing type-checked them,
+ * nothing asserted they compiled, and a reflow or a stray `grep -n` prefix surviving into the `sed`
+ * strip emptied one — at which point `grep -E ""` matches every line and `grep -Ev ""` matches none,
+ * both at exit 0. This module is the machine source those prose lines are now drift-locked against
+ * by `validate-gate-path-drift.sh`, plus the non-triviality predicate every runtime resolution site
+ * checks before it uses a freshly-extracted pattern.
+ *
+ * PLACEMENT IS A CORRECTNESS PROPERTY, NOT A STYLE CALL. This file sits at the `src/` ROOT because
+ * `CONTROL_PLANE_RE`'s `^packages/pipeline-cli/src/[^/]+$` clause is non-recursive: a root module is
+ * §CP and human-merge-gated, while a fresh `src/tools/<dir>/` module is NOT §CP under ADR 0218's
+ * enumerated core — so parking the single source of every gate boundary there would make it
+ * mergeable with zero human review, a strictly worse hole than the one this closes. Do not relocate
+ * it into a new tool directory; see ADR 0218 and #4401.
+ *
+ * The values are byte-identical copies of the prose lines, and stay that way by force: the
+ * drift validator compares each one against `pipeline-cli control-plane-paths --boundary <NAME>`.
+ * Backslashes are doubled as TS string escapes, so `\\.` is the value `\.` — the same convention
+ * `control-plane-re.ts` uses.
+ *
+ * Runtime resolution is UNCHANGED and must stay that way (the #981 anti-self-authorization
+ * property): the merge-deciding gates still re-resolve these patterns from the prose on
+ * `origin/main`, so a boundary-editing PR is classified against MAIN's boundary rather than its own
+ * edit. This module is the drift-lock target and the fail-closed reference — never a compile-time
+ * substitute for that read.
+ *
+ * Zero imports on purpose: `src/` root is inside the §CP enforcement core, whose transitive import
+ * closure `core-import-closure.unit.test.ts` pins (ADR 0218).
+ */
+
+/** §CP content clause — the guard-touching-ADR vocabulary (ADR 0164; formats §CP). */
+export const GUARD_ADR_RE =
+	"guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\\bgat(e|es|ing|ed)\\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out";
+
+/**
+ * The four artifact-class probes (formats §CLASS). `HAS_CODE_RE` and `HAS_DOCS_EXCLUDE_RE` name the
+ * SAME code roots — the has-code/docs-exclusion agreement invariant — so they move in lockstep.
+ */
+export const HAS_CODE_RE = "^(apps|packages|\\.glossary|infra)/";
+export const HAS_SKILLS_RE = "^claude-plugins/[^/]+/(skills|agents)/|^\\.claude-plugin/";
+export const HAS_DOCS_EXCLUDE_RE = "^(claude-plugins|apps|packages|\\.glossary|infra)/";
+export const HAS_DOCS_RE = "^(\\.decisions|\\.patterns)/|\\.md$";
+
+/**
+ * The doc/vocab-surface carve-then-test pair (formats §CLASS) — the issueless-allowance axis, NOT a
+ * class probe. It omits `.glossary` where `HAS_DOCS_EXCLUDE_RE` excludes it; that divergence is the
+ * surface-vs-class distinction (ADR 0075/0184), so the lockstep above does not extend to this pair.
+ */
+export const DOC_VOCAB_EXCLUDE_RE = "^(apps|packages|infra|claude-plugins)/";
+export const DOC_VOCAB_SURFACE_RE = "^(\\.decisions|\\.patterns|\\.glossary)/|\\.md$";
+
+/**
+ * The agent-distinguishable claim marker (ADR 0115; formats §7), in the jq/PCRE form the prose and
+ * the `gh api … | jq` resolution snippets use. The executable matcher stays the `RegExp` literal in
+ * `tools/epic-lock/claim-resolution.ts`; `gate-boundaries.unit.test.ts` derives this string from
+ * that literal, so the two cannot drift.
+ */
+export const CLAIM_RE = "(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b";
+
+/**
+ * The additive has-ui probe (`ship-it/SKILL.md`) — carve test/spec out FIRST, then test for a
+ * rendered surface, because ERE has no negative lookahead. `ship-it/SKILL.md@main` remains the live
+ * source every consumer re-resolves from (#2341/#2470/#3071); these are its drift-lock target.
+ */
+export const UI_RE = "^apps/web/src/";
+export const UI_EXCLUDE_RE = "\\.(test|spec)\\.tsx?$";
+
+/**
+ * Every boundary single-sourced here, keyed by the canonical shell-assignment name the prose lines
+ * and the drift validator use. `CONTROL_PLANE_RE` is deliberately absent — it has its own const in
+ * `tools/control-plane-paths/control-plane-re.ts`; the emitter composes the two into one namespace.
+ */
+export const GATE_BOUNDARIES: Readonly<Record<string, string>> = {
+	GUARD_ADR_RE,
+	HAS_CODE_RE,
+	HAS_SKILLS_RE,
+	HAS_DOCS_EXCLUDE_RE,
+	HAS_DOCS_RE,
+	DOC_VOCAB_EXCLUDE_RE,
+	DOC_VOCAB_SURFACE_RE,
+	CLAIM_RE,
+	UI_RE,
+	UI_EXCLUDE_RE,
+};
+
+/**
+ * The shortest a resolved boundary may legitimately be. Every real pattern here is ≥ 14 characters;
+ * the shortest fail-closed SENTINEL (`.`, `$^`) is 2. The bound sits between them on purpose: it
+ * rejects the empty/truncated extraction without ever rejecting a value a caller chose deliberately
+ * — a sentinel is never routed through this predicate, it is what the predicate falls back TO.
+ */
+export const MIN_BOUNDARY_LENGTH = 4;
+
+/**
+ * Did an extraction actually yield a pattern? A trivial value is the #4401 failure: it reads back
+ * successfully, compiles, and silently inverts the gate's polarity — fail-CLOSED under `grep -E`,
+ * fail-OPEN and output-less under `grep -Ev`. Absence is checkable; triviality is not, unless
+ * something checks it.
+ */
+export const isNonTrivialBoundary = (value: string | null | undefined): value is string =>
+	typeof value === "string" && value.trim().length >= MIN_BOUNDARY_LENGTH;
+
+/** Thrown by `assertNonTrivialBoundary` — named so a caller can report WHICH boundary went trivial. */
+export class TrivialGateBoundaryError extends Error {
+	readonly boundaryName: string;
+	readonly resolved: string | null | undefined;
+
+	constructor(boundaryName: string, resolved: string | null | undefined) {
+		super(
+			`TRIVIAL-GATE-BOUNDARY: ${boundaryName} resolved to ${
+				resolved === null || resolved === undefined
+					? "nothing"
+					: `a trivial value (${resolved.length} chars): ${JSON.stringify(resolved)}`
+			} — refusing to gate on it (min ${MIN_BOUNDARY_LENGTH}; issue #4401)`,
+		);
+		this.name = "TrivialGateBoundaryError";
+		this.boundaryName = boundaryName;
+		this.resolved = resolved;
+	}
+}
+
+/** Fail-closed-and-LOUD form, for a caller with nowhere safe to fall back to. */
+export const assertNonTrivialBoundary = (
+	boundaryName: string,
+	resolved: string | null | undefined,
+): string => {
+	if (!isNonTrivialBoundary(resolved)) throw new TrivialGateBoundaryError(boundaryName, resolved);
+	return resolved;
+};
+
+/**
+ * Fail-closed-and-QUIET form, for a parser whose fallback is itself the safe direction: take the
+ * resolved value only if it is non-trivial, else the caller's fail-closed sentinel. Distinct from a
+ * plain `?? fallback`, which the empty string sails straight past — that is exactly how a truncated
+ * extraction became a live gate decision (#4401).
+ */
+export const boundaryOrFailClosed = (
+	resolved: string | null | undefined,
+	failClosed: string,
+): string => (isNonTrivialBoundary(resolved) ? resolved : failClosed);

--- a/packages/pipeline-cli/src/gate-boundaries.unit.test.ts
+++ b/packages/pipeline-cli/src/gate-boundaries.unit.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The gate boundaries compile, are non-trivial, and mean what they meant in prose (issue #4401).
+ *
+ * The prose lines had no compile step and no test — the only thing standing between a reflow and a
+ * changed gate decision was that nobody reflowed the line. Each boundary here gets three checks: it
+ * compiles, it clears the non-triviality bound, and it separates a positive from a negative fixture
+ * path. The third is the one that catches a "cleaned-up" regex, which the first two would pass.
+ *
+ * `CLAIM_RE` is pinned to the executable matcher rather than fixture-checked in isolation: the jq
+ * form here and the `RegExp` literal in `tools/epic-lock/claim-resolution.ts` are two renderings of
+ * one grammar, so the test DERIVES one from the other.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	assertNonTrivialBoundary,
+	boundaryOrFailClosed,
+	CLAIM_RE,
+	DOC_VOCAB_EXCLUDE_RE,
+	DOC_VOCAB_SURFACE_RE,
+	GATE_BOUNDARIES,
+	GUARD_ADR_RE,
+	HAS_CODE_RE,
+	HAS_DOCS_EXCLUDE_RE,
+	HAS_DOCS_RE,
+	HAS_SKILLS_RE,
+	isNonTrivialBoundary,
+	MIN_BOUNDARY_LENGTH,
+	TrivialGateBoundaryError,
+	UI_EXCLUDE_RE,
+	UI_RE,
+} from "./gate-boundaries.ts";
+import {CLAIM_RE as CLAIM_MATCHER} from "./tools/epic-lock/claim-resolution.ts";
+
+/** One positive and one negative path (or, for `GUARD_ADR_RE`, one phrase) per boundary. */
+const FIXTURES: ReadonlyArray<readonly [string, string, string, string]> = [
+	[
+		"GUARD_ADR_RE",
+		GUARD_ADR_RE,
+		"this ADR relaxes the fail-closed guard",
+		"this ADR renames a product noun",
+	],
+	["HAS_CODE_RE", HAS_CODE_RE, "packages/pipeline-cli/src/run.ts", ".decisions/0218-scope.md"],
+	[
+		"HAS_SKILLS_RE",
+		HAS_SKILLS_RE,
+		"claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md",
+		"apps/web/src/App.tsx",
+	],
+	["HAS_DOCS_EXCLUDE_RE", HAS_DOCS_EXCLUDE_RE, ".glossary/LANGUAGE.md", ".decisions/0218-scope.md"],
+	["HAS_DOCS_RE", HAS_DOCS_RE, ".patterns/index.md", "apps/web/worker/index.ts"],
+	[
+		"DOC_VOCAB_EXCLUDE_RE",
+		DOC_VOCAB_EXCLUDE_RE,
+		"packages/pipeline-cli/README.md",
+		".glossary/LANGUAGE.md",
+	],
+	["DOC_VOCAB_SURFACE_RE", DOC_VOCAB_SURFACE_RE, ".glossary/LANGUAGE.md", "biome.jsonc"],
+	[
+		"CLAIM_RE",
+		// The jq `(?i)` inline flag is not JS syntax; the paired matcher below is what runs.
+		CLAIM_RE.replace("(?i)", ""),
+		"claim: fcd74bd3-8872-4023-b100-a81ac870eb43 · 2026-07-27T05:13:23Z",
+		"claimed by another agent",
+	],
+	["UI_RE", UI_RE, "apps/web/src/App.tsx", "apps/web/worker/index.ts"],
+	["UI_EXCLUDE_RE", UI_EXCLUDE_RE, "apps/web/src/App.test.tsx", "apps/web/src/App.tsx"],
+];
+
+describe("the single-sourced gate boundaries (#4401)", () => {
+	it("covers every exported boundary with a fixture pair — a new export without one reds this", () => {
+		expect(FIXTURES.map(([name]) => name).sort()).toEqual(Object.keys(GATE_BOUNDARIES).sort());
+	});
+
+	for (const [name, pattern, positive, negative] of FIXTURES) {
+		describe(name, () => {
+			it("compiles", () => {
+				expect(() => new RegExp(pattern)).not.toThrow();
+			});
+
+			it("is non-trivial", () => {
+				expect(isNonTrivialBoundary(pattern)).toBe(true);
+				expect(pattern.length).toBeGreaterThanOrEqual(MIN_BOUNDARY_LENGTH);
+			});
+
+			it("matches its positive fixture and rejects its negative one", () => {
+				const re = new RegExp(pattern, "i");
+				expect(re.test(positive)).toBe(true);
+				expect(re.test(negative)).toBe(false);
+			});
+		});
+	}
+
+	it("renders the same claim grammar as the executable matcher", () => {
+		expect(CLAIM_MATCHER.flags).toContain("i");
+		expect(`(?i)${CLAIM_MATCHER.source.replace("([0-9a-f-]{36})", "[0-9a-f-]{36}")}`).toBe(
+			CLAIM_RE,
+		);
+	});
+
+	it("keeps the has-code / docs-exclusion roots in lockstep", () => {
+		const roots = (re: string): ReadonlyArray<string> =>
+			(re.match(/\(([^)]*)\)/)?.[1] ?? "").split("|").filter((r) => r !== "claude-plugins");
+		expect(roots(HAS_DOCS_EXCLUDE_RE)).toEqual(roots(HAS_CODE_RE));
+	});
+});
+
+describe("the non-triviality predicate — the check the prose extraction never had", () => {
+	it("rejects the shapes a truncated extraction produces", () => {
+		for (const trivial of ["", "   ", ".", "$^", null, undefined]) {
+			expect(isNonTrivialBoundary(trivial)).toBe(false);
+		}
+	});
+
+	it("falls back rather than passing an empty pattern through, unlike `??`", () => {
+		expect(boundaryOrFailClosed("", "$^")).toBe("$^");
+		expect(boundaryOrFailClosed(undefined, "$^")).toBe("$^");
+		expect(boundaryOrFailClosed(HAS_CODE_RE, "$^")).toBe(HAS_CODE_RE);
+	});
+
+	it("names the boundary when it throws", () => {
+		expect(() => assertNonTrivialBoundary("HAS_DOCS_EXCLUDE_RE", "")).toThrow(
+			TrivialGateBoundaryError,
+		);
+		expect(() => assertNonTrivialBoundary("HAS_DOCS_EXCLUDE_RE", "")).toThrow(
+			/HAS_DOCS_EXCLUDE_RE/,
+		);
+		expect(assertNonTrivialBoundary("HAS_CODE_RE", HAS_CODE_RE)).toBe(HAS_CODE_RE);
+	});
+});

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
@@ -17,7 +17,13 @@
  * own single source, `ship-it/SKILL.md` (§CLASS keeps it there deliberately, never in
  * §CLASS itself) — folding it in here is what makes review-design a deterministic probe
  * output the reviewer fan dispatches rather than an eyeball it can skip (#2485/#2483).
+ *
+ * Every parse below routes the extracted value through `boundaryOrFailClosed` rather than `??`:
+ * a `??` accepts the empty string a truncated extraction produces, and an empty ERE inverts the
+ * gate silently — `grep -Ev ""` excludes nothing, so the docs carve-out fails OPEN (#4401).
  */
+
+import {boundaryOrFailClosed} from "../../gate-boundaries.ts";
 
 /** The three artifact classes a PR diff can span — each maps to one `review-*` gate. */
 export type ArtifactClass = "has-code" | "has-docs" | "has-skills";
@@ -64,13 +70,13 @@ export const FAILCLOSED_PROBES: ClassProbes = {
 /**
  * Parse the canonical `HAS_*_RE='…'` lines out of `gh-issue-intake-formats.md` §CLASS.
  * Matches only the single-quoted canonical assignment (`NAME='…'`), never the
- * double-quoted `reresolve_re` re-assignment lines below it. A missing line falls back to
- * its fail-closed default — the source is single, so this only bites on a truncated read.
+ * double-quoted `reresolve_re` re-assignment lines below it. A missing OR trivial line falls back
+ * to its fail-closed default — the source is single, so this only bites on a truncated read.
  */
 export const parseClassProbes = (formatsText: string): ClassProbes => {
 	const read = (name: string, fallback: string): string => {
 		const m = formatsText.match(new RegExp(`^${name}='([^']*)'`, "m"));
-		return m?.[1] ?? fallback;
+		return boundaryOrFailClosed(m?.[1], fallback);
 	};
 	return {
 		hasCode: read("HAS_CODE_RE", FAILCLOSED_PROBES.hasCode),
@@ -174,7 +180,7 @@ export const FAILCLOSED_DOC_VOCAB_PROBE: DocVocabProbe = {
 /** Parse the canonical `DOC_VOCAB_*_RE='…'` lines out of §CLASS (single-quoted assignment only). */
 export const parseDocVocabProbe = (formatsText: string): DocVocabProbe => {
 	const read = (name: string, fallback: string): string =>
-		formatsText.match(new RegExp(`^${name}='([^']*)'`, "m"))?.[1] ?? fallback;
+		boundaryOrFailClosed(formatsText.match(new RegExp(`^${name}='([^']*)'`, "m"))?.[1], fallback);
 	return {
 		exclude: read("DOC_VOCAB_EXCLUDE_RE", FAILCLOSED_DOC_VOCAB_PROBE.exclude),
 		surface: read("DOC_VOCAB_SURFACE_RE", FAILCLOSED_DOC_VOCAB_PROBE.surface),
@@ -233,10 +239,13 @@ export const FAILCLOSED_UI_EXCLUDE_RE = "$^";
  * fourth char diverges — so the two never cross-capture.)
  */
 export const parseUiProbe = (shipItText: string): string =>
-	shipItText.match(/^UI_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_UI_RE;
+	boundaryOrFailClosed(shipItText.match(/^UI_RE='([^']*)'/m)?.[1], FAILCLOSED_UI_RE);
 
 export const parseUiExclude = (shipItText: string): string =>
-	shipItText.match(/^UI_EXCLUDE_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_UI_EXCLUDE_RE;
+	boundaryOrFailClosed(
+		shipItText.match(/^UI_EXCLUDE_RE='([^']*)'/m)?.[1],
+		FAILCLOSED_UI_EXCLUDE_RE,
+	);
 
 /**
  * Is the diff UI-affecting (has-ui)? Carve-then-test, mirroring §CLASS's has-docs probe: a file

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
@@ -22,6 +22,7 @@
  * merge is actually decided. See the classification-site register in `gh-issue-intake-formats.md`
  * §CP.
  */
+import {isNonTrivialBoundary} from "../../gate-boundaries.ts";
 
 /**
  * One §CP path the regex marks control-plane: a path + its shape.
@@ -51,10 +52,14 @@ export interface OwnedPattern {
  * from THAT line, not the fenced prose copy, so we track the exact string the gates
  * run against. Returns `null` when no such assignment is found — the caller fails
  * closed on a `null` (ADR 0092: can't parse the source ⇒ refuse, never pass).
+ *
+ * A TRIVIAL match is `null` too, not a boundary (#4401). `m?.[1] ?? null` passed an empty capture
+ * straight through, and an empty ERE is not an absent one: it compiles, matches every path under
+ * `grep -E`, and matches none under `grep -Ev` — a 757-char line one reflow away from either.
  */
 export const extractControlPlaneRe = (formatsText: string): string | null => {
-	const m = formatsText.match(/CONTROL_PLANE_RE='([^']*)'/);
-	return m?.[1] ?? null;
+	const captured = formatsText.match(/CONTROL_PLANE_RE='([^']*)'/)?.[1];
+	return isNonTrivialBoundary(captured) ? captured : null;
 };
 
 /**

--- a/packages/pipeline-cli/src/tools/control-plane-paths/command.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/command.ts
@@ -1,28 +1,68 @@
 /**
  * `control-plane-paths` — emit the canonical §CP boundary deterministically (issue #2761).
  *
- *   pipeline-cli control-plane-paths            # print CONTROL_PLANE_RE (the grep/jq regex)
- *   pipeline-cli control-plane-paths --paths    # print the expanded §CP path set, one per line
+ *   pipeline-cli control-plane-paths                       # print CONTROL_PLANE_RE (the grep/jq regex)
+ *   pipeline-cli control-plane-paths --paths               # print the expanded §CP path set, one per line
+ *   pipeline-cli control-plane-paths --boundary HAS_CODE_RE  # print one single-sourced gate boundary
+ *   pipeline-cli control-plane-paths --boundary-names      # list every single-sourced boundary name
  *
  * The single-source emitter: the shell drift guard (`validate-gate-path-drift.sh`)
  * reads the regex from HERE instead of byte-comparing N hand-copied literals, so a
  * boundary change is one edit to the const, not the ~11-file lockstep the copies used
  * to force (#2673). The regex is printed with NO trailing formatting so `$(…)` capture
  * in bash yields exactly the value to compare against the formats-doc line.
+ *
+ * `--boundary` extends that same read to the ten boundaries #4401 gave a typed source
+ * (`src/gate-boundaries.ts`), so the validator locks every prose `_RE=` line the same way rather
+ * than only `CONTROL_PLANE_RE`. It lives in THIS enumerated §CP tool deliberately: the emitter is
+ * what the validator trusts, so an emitter that could be edited without control-plane sign-off
+ * could lie to the guard about what the boundary is.
  */
-import {Console, Effect} from "effect";
+import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {GATE_BOUNDARIES} from "../../gate-boundaries.ts";
 import {cpPaths} from "../codeowners-cp/codeowners-cp.ts";
 import {CONTROL_PLANE_RE} from "./control-plane-re.ts";
+
+/** Every boundary with a typed source, under the canonical shell-assignment name the prose uses. */
+const ALL_BOUNDARIES: Readonly<Record<string, string>> = {CONTROL_PLANE_RE, ...GATE_BOUNDARIES};
 
 const pathsFlag = Flag.boolean("paths").pipe(
 	Flag.withDescription("print the expanded §CP path set (one per line) instead of the regex"),
 );
 
+const boundaryFlag = Flag.string("boundary").pipe(
+	Flag.optional,
+	Flag.withDescription("print one single-sourced gate boundary by its canonical name"),
+);
+
+const boundaryNamesFlag = Flag.boolean("boundary-names").pipe(
+	Flag.withDescription("list every single-sourced gate-boundary name, one per line"),
+);
+
 export const controlPlanePathsCommand = Command.make(
 	"control-plane-paths",
-	{paths: pathsFlag},
-	Effect.fn(function* ({paths}) {
+	{paths: pathsFlag, boundary: boundaryFlag, boundaryNames: boundaryNamesFlag},
+	Effect.fn(function* ({paths, boundary, boundaryNames}) {
+		if (boundaryNames) {
+			for (const name of Object.keys(ALL_BOUNDARIES)) yield* Console.log(name);
+			return;
+		}
+		if (Option.isSome(boundary)) {
+			const value = ALL_BOUNDARIES[boundary.value];
+			// Exit non-zero on an unknown name rather than printing nothing: a silent empty read is
+			// precisely the trivial-pattern failure this whole surface exists to make impossible.
+			if (value === undefined) {
+				yield* Effect.sync(() =>
+					process.stderr.write(
+						`control-plane-paths: unknown boundary '${boundary.value}' — known: ${Object.keys(ALL_BOUNDARIES).join(", ")}\n`,
+					),
+				);
+				return yield* Effect.sync(() => process.exit(1));
+			}
+			yield* Console.log(value);
+			return;
+		}
 		if (paths) {
 			for (const p of cpPaths(CONTROL_PLANE_RE)) yield* Console.log(p.path);
 			return;
@@ -31,6 +71,6 @@ export const controlPlanePathsCommand = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Emit the canonical §CP CONTROL_PLANE_RE (the single source), or its expanded path set with --paths (#2761)",
+		"Emit the canonical §CP CONTROL_PLANE_RE (the single source), its expanded path set with --paths, or any single-sourced gate boundary with --boundary (#2761, #4401)",
 	),
 );

--- a/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts
@@ -27,6 +27,7 @@
  * merely-guard-*citing* ADR to a cheap human approval rather than risk missing a
  * guard-*relaxer* that would auto-ship a weakened gate.
  */
+import {boundaryOrFailClosed} from "../../gate-boundaries.ts";
 
 /**
  * Fail-closed default: `.` matches every ADR word ⇒ every touched `.decisions/**` file is
@@ -38,11 +39,12 @@ export const FAILCLOSED_GUARD_ADR_RE = ".";
 /**
  * Parse the canonical `GUARD_ADR_RE='…'` line out of `gh-issue-intake-formats.md` §CP.
  * Matches only the single-quoted canonical assignment (`GUARD_ADR_RE='…'`), never a
- * double-quoted re-assignment. A missing line falls back to the fail-closed default — the
- * source is single, so this only bites on a truncated read.
+ * double-quoted re-assignment. A missing OR trivial line falls back to the fail-closed default —
+ * a `??` would accept the empty string a truncated extraction yields, and `new RegExp("")` matches
+ * every ADR body, which looks like the fail-closed answer while proving nothing (#4401).
  */
 export const parseGuardAdrRe = (formatsText: string): string =>
-	formatsText.match(/^GUARD_ADR_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_GUARD_ADR_RE;
+	boundaryOrFailClosed(formatsText.match(/^GUARD_ADR_RE='([^']*)'/m)?.[1], FAILCLOSED_GUARD_ADR_RE);
 
 /** Why the probe decided as it did — surfaced for the human reason line. */
 export type GuardProbeReason =

--- a/packages/pipeline-cli/src/tools/trivial-diff/command.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/command.ts
@@ -30,6 +30,7 @@
 import {execFileSync} from "node:child_process";
 import {Console, Effect, FileSystem, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {isNonTrivialBoundary} from "../../gate-boundaries.ts";
 import {readStdinTextOrExit} from "../../read-stdin.ts";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
@@ -127,6 +128,23 @@ const classifyCmd = Command.make(
 		const formatsRaw = fetchFormatsRaw(resolveRepo(repo));
 		const controlPlaneRe = formatsRaw === null ? null : extractControlPlaneRe(formatsRaw);
 		const guardAdrRe = formatsRaw === null ? null : parseGuardAdrRe(formatsRaw);
+		// Name the boundary that failed to resolve. Both parsers now demote a TRIVIAL extraction to
+		// their fail-closed value (#4401), so the classification is already safe — what was missing
+		// is any trace of WHICH boundary went empty, the gap that made the live incident look like a
+		// confident answer instead of an unresolved one.
+		if (formatsRaw !== null) {
+			for (const [name, resolved] of [
+				["CONTROL_PLANE_RE", controlPlaneRe],
+				["GUARD_ADR_RE", guardAdrRe],
+			] as const) {
+				if (isNonTrivialBoundary(resolved)) continue;
+				yield* Effect.sync(() =>
+					process.stderr.write(
+						`trivial-diff: TRIVIAL-GATE-BOUNDARY: ${name} did not resolve to a usable pattern from origin/main — failing closed.\n`,
+					),
+				);
+			}
+		}
 		const diff = yield* readDiff(diffFile);
 		if (diff === null) {
 			// Unreadable diff is itself fail-closed: classify as non-trivial.


### PR DESCRIPTION
Fixes #4401
Fixes #4413

Ten `_RE=` gate boundaries lived only as prose assignment lines inside `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` and `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`, and every consumer pulled them back out at decision time. Nothing type-checked them, nothing asserted they compiled, and an extraction that yielded an **empty** pattern still classified — `grep -E ""` matches every path, `grep -Ev ""` matches none, both at exit 0.

## The placement gate — proven, not asserted

The constants module is at **`packages/pipeline-cli/src/gate-boundaries.ts`** (the non-recursive `src/` root), not a new `src/tools/<dir>/`. Proven against the live boundary, with the non-triviality assertion on that boundary run first:

```
$ pipeline-cli control-plane-paths | wc -c
739                       # 738 bytes + newline — non-trivial, so the classification below means something

$ printf 'packages/pipeline-cli/src/gate-boundaries.ts\n' | pipeline-cli cp-classify classify --repo kamp-us/phoenix
control-plane             # exit 0

$ printf 'packages/pipeline-cli/src/tools/gate-boundaries/constants.ts\n' | pipeline-cli cp-classify classify --repo kamp-us/phoenix
not-control-plane         # exit 3
```

That counterfactual is the whole reason placement is a correctness property here and not a style call: under ADR 0218's enumerated enforcement core, a fresh `src/tools/<dir>/` has **no** CODEOWNERS entry, so the single source of truth for every gate boundary would have become mergeable with **zero** human review — a strictly worse hole than the one being closed. No new directory was created and no `CONTROL_PLANE_RE`/CODEOWNERS widening is proposed.

## What changed

- **`packages/pipeline-cli/src/gate-boundaries.ts`** (new) — the seven with no machine source (`GUARD_ADR_RE`, the four `HAS_*_RE`, the two `DOC_VOCAB_*_RE`) plus the three previously-unguarded prose copies (`CLAIM_RE`, `UI_RE`, `UI_EXCLUDE_RE`), as typed exported constants, with `isNonTrivialBoundary` / `assertNonTrivialBoundary` / `boundaryOrFailClosed` and the named `TrivialGateBoundaryError`. **Zero imports**, so the §CP core's transitive import closure is unchanged.
- **`control-plane-paths --boundary <NAME>` / `--boundary-names`** — the emitter the drift validator reads. It lives inside an already-enumerated §CP tool deliberately: the emitter is what the guard trusts, so an emitter editable without control-plane sign-off could lie to the guard about what the boundary is.
- **Non-triviality asserted at every runtime resolution site, before use:**
  - `class-probe` / `guard-content-probe` — `boundaryOrFailClosed` replaces `?? fallback`, which accepted the empty string a truncated extraction produces.
  - `codeowners-cp`'s `extractControlPlaneRe` — a trivial capture is now `null` (the caller's existing fail-closed), not a boundary.
  - `trivial-diff` — emits a named `TRIVIAL-GATE-BOUNDARY: <NAME> …` line naming *which* boundary failed to resolve.
  - The shell recipes in `ship-it/SKILL.md`, `agents/reviewer.md` and the formats contract gain `accept_re`, which refuses an empty value **and** a value that still carries the assignment prefix — the exact shape a surviving `grep -n` line-number prefix produced in the live incident.
- **The duplicate `GUARD_ADR_RE=` line is deleted.** It was byte-identical and every consumer resolves first-occurrence-wins, so a corrective edit could land on the shadow and appear to work. The recipe that carried it now relies on its live `origin/main` read plus the existing fail-closed default.
- **`validate-gate-path-drift.sh`** — invariants 1b/1c generalize from "a `GUARD_ADR_RE=` line exists" to a **value** compare of all eleven boundaries against the consts, across every prose copy in the corpus; new invariant 1d fails if any single-sourced name reappears at column 0. `DOC_VOCAB_*_RE`, `CLAIM_RE` and `UI_RE`/`UI_EXCLUDE_RE` are now covered, where the validator touched none of them before.

## Anti-self-authorization preserved

The merge-deciding gates still re-resolve each boundary from `origin/main` at run time (#981), so a boundary-editing PR — including this one — is classified against MAIN's boundary, not its own edit. The constants are the drift-lock target and the fail-closed reference; they are **not** a compile-time substitute for that read.

## Verification

- **Byte-identity of the move, proven by extraction + compare** — all **22** assignment copies across `gh-issue-intake-formats.md`, `ship-it/SKILL.md` and `agents/reviewer.md` are byte-identical to the emitted consts. The constant values were generated *from* the prose rather than transcribed by hand, so no regex was silently "cleaned up".
- `validate-gate-path-drift.sh` — **OK, 34 checks** (was 4 boundaries covered, now 11 + the duplicate guard).
- `core-import-closure.unit.test.ts` — **6/6 pass**. The new root module is a core seed and imports nothing, so it adds no escape and `ALLOWED_ESCAPES` is unchanged.
- `control-plane-paths.unit.test.ts` — passes.
- `gate-boundaries.unit.test.ts` (new) — every boundary compiles, clears the length bound, and separates a positive from a negative fixture; `CLAIM_RE`'s jq form is *derived* from the executable `RegExp` in `tools/epic-lock/claim-resolution.ts` so the two cannot drift.
- Full `pipeline-cli` suite: **182 files / 2921 tests pass**. `pnpm typecheck` and `pnpm lint:worktree` clean. `gh-phoenix lint-skills` and `adoption-lint check` clean on the changed corpus files.

## Expected to bank

This diff touches the shared intake contract, `ship-it/SKILL.md`, the drift validator and the enforcement core, so it classifies **§CP** and holds for control-plane approval at head. That is the intended outcome, not a problem to route around.

## Repair round 1 — the §CP guard-ADR recipe block is copy-pasteable again (#4413)

The `accept_re` assert this PR introduced was **called** from the §CP guard-ADR recipe block but
**defined** only in the §CLASS block further down the file. A fenced block is meant to run standalone
when pasted, and this one no longer did — reproduced by extracting the block from head `33d4df18` and
executing it in a clean shell:

```
before:  accept_re: command not found   →  GUARD_ADR_RE length 0  →  grep -Eiq "" matches every ADR body
after:   (no error)                     →  GUARD_ADR_RE length 301, byte-identical to the emitted const
```

The definition is now inlined into that block, following the two precedents already in this corpus
rather than a third shape: `ship-it/SKILL.md` keeps one correctly-scoped block, and
`agents/reviewer.md` defines `accept_re` inline in each of its two blocks.

**Swept, not spot-fixed.** Every fenced block in the corpus that calls `accept_re` was checked for
whether it can reach a definition. Before: 1 unreachable call site (the one reported). After: **0** —
the other four call sites (`agents/reviewer.md` ×3, `gh-issue-intake-formats.md` §CLASS ×1) and
`ship-it/SKILL.md`'s four already resolve within their own block.

**Re-verified at the new head, unchanged from the numbers above:**

- **22** const-vs-copy comparisons across the three corpus files, **0** mismatches.
- `validate-gate-path-drift.sh` — **OK, 34 checks**.
- `core-import-closure.unit.test.ts` — **6/6**, `ALLOWED_ESCAPES` untouched.
- Full `pipeline-cli` suite **182 files / 2921 tests**, `pnpm typecheck`, `pnpm lint:worktree`,
  `validate-skills.sh` — all clean.

The diff is one file, +12/−1, entirely inside the guard-ADR recipe block.

## Deviations

**(repair round 1)** The resubmit push used `git push origin HEAD:refs/heads/<branch>` rather than
`pipeline-cli verified-push`. The verb re-derives the branch checked out in `--cwd` and resolves a
detached HEAD to UNKNOWN without pushing; this branch was already checked out in a sibling agent
worktree, so it could not be checked out here and the verb's precondition was unmeetable. The
guarantee it exists for was discharged directly instead: the remote ref was confirmed at
`df61ac0b` via `gh api` on both `pulls/4412` and `git/ref/heads/<branch>` after the push.
