### PR TITLE
fix(ship-it): an expired reconcile reports UNRESOLVED with its own horizon (#4403)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -578,8 +578,8 @@ async function drive() {
 	// check here — the shipper owns both; an `awaiting control-plane approval` stop IS the
 	// halt outcome (a human approves out-of-band, then a shipper re-run enqueues). Success is
 	// ENQUEUED + green, not merged-now: the merge queue owns the final async merge and the
-	// async `Fixes #N` issue-close (ADR 0132), so this stage returns `enqueued` (QUEUED ->
-	// auto-merges on green), never an in-run merge/close assertion.
+	// async `Fixes #N` issue-close (ADR 0132), so this stage returns `enqueued` (QUEUED — the
+	// queue owns the async merge), never an in-run merge/close assertion.
 	//
 	// QUEUED is NOT terminal: the queue can EJECT an enqueued PR (textual batch conflict or a
 	// combined-batch CI failure) without merging it, leaving it silently stalled (still open,
@@ -601,10 +601,11 @@ async function drive() {
 			`(a human approves out-of-band, then a shipper re-run enqueues). For a non-§CP PR, assert the matching gate ` +
 			`PASS, confirm CI is green, enqueue for a squash-merge with \`gh pr merge --auto\` (no method flag — the queue owns the SQUASH method), and confirm it ` +
 			`is enqueued + green. The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" ` +
-			`(QUEUED -> auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands ` +
+			`(QUEUED — the queue owns the async merge), NOT "merged now" — the linked issue auto-closes async IF AND WHEN the queue lands ` +
 			`the merge. After a successful enqueue, run your bounded post-enqueue RECONCILE (Step 5.5): poll the PR's ` +
 				`merged/state/mergeStateStatus within a batch window and classify the terminal outcome as "landed" (queue ` +
-				`merged it), "queued" (still in the queue at the window's end — a well-formed pending), or "ejected" (still ` +
+				`merged it), "queued" (still in the queue when the bounded observation expired — report it as UNRESOLVED: ` +
+				`neither a landing nor a failure), or "ejected" (still ` +
 				`open, no longer queued, not merged — the queue dropped it on a textual or combined-batch conflict). On ` +
 				`"ejected", surface it (comment on the PR) and do NOT report shipped — it routes back to repair/re-queue. ` +
 				`Return { enqueued: true|false, mergeOutcome: "landed"|"queued"|"ejected"|"n/a", awaitingControlPlaneApproval: ` +
@@ -632,7 +633,13 @@ async function drive() {
 		ejected
 			? `PR #${pr} EJECTED from the merge queue (not merged) — routing back to repair/re-queue: ${shipped.reason ?? "textual or combined-batch conflict"}`
 			: shipped.enqueued
-				? `PR #${pr} QUEUED -> auto-merges on green${shipped.mergeOutcome === "landed" ? " (reconciled: landed)" : shipped.mergeOutcome === "queued" ? " (reconciled: still queued)" : ""}`
+				// Worded off ship-it Step 5.5's `case` block — the single source for these three strings
+				// and for why an expired observation asserts neither a landing nor a failure (#4403).
+				? shipped.mergeOutcome === "landed"
+					? `PR #${pr} LANDED — the queue merged the batch`
+					: shipped.mergeOutcome === "queued"
+						? `PR #${pr} UNRESOLVED — still queued when the shipper's bounded observation expired; the merge may still land. Neither a landing nor a failure — an independent later read closes the lane`
+						: `PR #${pr} QUEUED — the queue owns the async merge; the shipper reported no reconcile outcome`
 				: shipped.awaitingControlPlaneApproval
 					? `PR #${pr} awaiting control-plane approval (§CP) — a @kamp-us/control-plane member must approve at the current head; re-run the shipper after approval`
 					: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -1,6 +1,6 @@
 ---
 name: shipper
-description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it (with isolation:worktree) once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". For control-plane PRs (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053): it enqueues a §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — the human owns the judgment (the approval), the pipeline owns the mechanics (the enqueue). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
+description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it (with isolation:worktree) once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED — the queue owns the async merge), after which the bounded post-enqueue reconcile classifies the terminal outcome as landed / UNRESOLVED (still queued at the reconcile horizon — neither a landing nor a failure) / EJECTED, and the linked issue auto-closes async if and when the queue lands the merge (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". For control-plane PRs (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053): it enqueues a §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — the human owns the judgment (the approval), the pipeline owns the mechanics (the enqueue). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
 model: inherit
 color: blue
 tools: ["Read", "Bash", "Grep", "Glob"]
@@ -38,8 +38,11 @@ plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
   Step 0 → Step 5 path on a single PR: classify the diff, assert each present class's gate
   shows a current-head PASS, confirm CI green + the run-evidence bundle, enqueue for a
   squash-merge server-side (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method), and confirm it is enqueued + green
-  (QUEUED → auto-merges on green; the `Fixes #N` seam auto-closes the issue async when the
-  queue lands the merge — ADR 0132).
+  (QUEUED — the queue owns the async merge), then run the skill's bounded post-enqueue
+  reconcile (Step 5.5) and report the disposition its `case` block rendered **verbatim**:
+  `landed`, `UNRESOLVED …` (still queued when the observation horizon expired — neither a
+  landing nor a failure), or `EJECTED`. The `Fixes #N` seam auto-closes the issue async **if
+  and when** the queue lands the merge — ADR 0132.
 - **A control-plane PR — enqueue on a team approval, else await it.** A PR touching `.claude/**`,
   `.github/**`, or a gate-critical skill is the agent control plane. The ship-it skill is
   APPROVAL-AWARE (Step 0, ADR 0135, amending 0053): it checks for a `@kamp-us/control-plane` team
@@ -137,8 +140,11 @@ the full resolution rule; follow it.
 ## Output
 
 Return what the skill produces: the PR you shipped (or refused), the enqueue outcome
-(`enqueued: yes (QUEUED → auto-merges on green)` — the queue owns the final async merge, ADR
-0132), the linked-issue status (`closes async on queue merge`), and the release-queue surface
+(`enqueued: yes (QUEUED — the queue owns the async merge)`, ADR 0132), the `merge:` line
+carrying the disposition Step 5.5's `case` block rendered **verbatim** — `landed`,
+`UNRESOLVED …` or `EJECTED`; the skill single-sources that wording, so never re-word it and
+never upgrade an `UNRESOLVED` into a landing —, the linked-issue status
+(`closes async on queue merge`), and the release-queue surface
 on a dark feature ship — or, on a stop/refusal, the distinct reason (`awaiting control-plane
 approval` for a §CP PR with no current-head team approval — ADR 0135, `latest verdict is FAIL`,
 `unverified (verdict not bound to current head)`, `checks pending`, a run-evidence refusal, …). A

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -2295,6 +2295,9 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # the trailing sleep after the last poll burned 30s observing nothing. 16x30s puts the horizon at
 # 7m30s, past both the median and the mean; it is NOT set past the 9m25s max because one shipper
 # invocation has a ~10-minute wall-clock ceiling and the 16 polls' own `gh` latency eats into it.
+# That ceiling is what makes over-widening WORSE than standing down: a run killed against it
+# mid-loop never reaches the ledger at all, so it emits no `merge:` line — silence, where a
+# stand-down would at least have stated the bound of what it watched.
 # So even the widened horizon can expire mid-dwell — which is exactly why the widening is the
 # secondary fix and the honest stand-down wording below is the primary one.
 RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-16}
@@ -2324,6 +2327,11 @@ case "$MERGE_OUTCOME" in
     MERGE_DISPOSITION="UNRESOLVED — still queued at my last read, ~${RECONCILE_HORIZON}s after enqueue; the merge may still land. Bounded observation, not a failure and not a landing — an independent later read closes the lane." ;;
   ejected)
     MERGE_DISPOSITION="EJECTED (routed to repair/re-queue)" ;;
+  *)
+    # Unreachable while the classifier prints one of its four words — which is exactly why it is
+    # here: without it an unrecognized $MERGE_OUTCOME leaves MERGE_DISPOSITION unset and the
+    # ledger's `merge:` line renders BLANK — a could-not-determine posing as nothing at all.
+    MERGE_DISPOSITION="UNKNOWN — the reconcile produced no recognized outcome word; the merge state was never determined. Not a landing, not a failure, not an ejection — re-read the PR before acting on it." ;;
 esac
 
 # Guard 6 (ADR 0198) — the reconcile's terminal read is the LAST place this run can leave an arm

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -2288,18 +2288,43 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # (gh api …/commits?sha=<base>, the read that stayed fresh while the other two lagged — #4057), and
 # prints merged/ejected/queued/pending. It is fail-closed away from a false ship: any unreadable
 # signal ⇒ pending (keep polling), never a false merged/ejected.
-RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-10}   # ~10 polls
-RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}   # ~30s apart ⇒ ~5 min batch window
+# The budget, and the ONE number the stand-down must report: the OBSERVATION HORIZON. Poll k fires
+# at (k-1)*SLEEP, so what the run actually watched is (TRIES-1)*SLEEP — not TRIES*SLEEP. The old
+# 10x30s pair observed to 4m30s while every sampled merge-queue dwell on this repo ran 5m17s–9m25s
+# (n=10, median 6m27s, mean 6m37s — #4403), so the budget expired mid-dwell on 10 of 10 merges, and
+# the trailing sleep after the last poll burned 30s observing nothing. 16x30s puts the horizon at
+# 7m30s, past both the median and the mean; it is NOT set past the 9m25s max because one shipper
+# invocation has a ~10-minute wall-clock ceiling and the 16 polls' own `gh` latency eats into it.
+# So even the widened horizon can expire mid-dwell — which is exactly why the widening is the
+# secondary fix and the honest stand-down wording below is the primary one.
+RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-16}
+RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}
+RECONCILE_HORIZON=$(( (RECONCILE_TRIES - 1) * RECONCILE_SLEEP ))   # seconds ACTUALLY observed
 MERGE_OUTCOME=pending
 for i in $(seq 1 "$RECONCILE_TRIES"); do
   MERGE_OUTCOME=$("$PCLI" merge-queue-classify classify --pr "$PR" --repo "$REPO")
   [ "$MERGE_OUTCOME" = merged ] && break   # terminal success
   [ "$MERGE_OUTCOME" = ejected ] && break  # a genuine dequeue (removed_from_merge_queue) — act below
-  # queued (still in the queue) or pending (enqueue-settle window) ⇒ keep polling within the budget
-  sleep "$RECONCILE_SLEEP"
+  # queued (still in the queue) or pending (enqueue-settle window) ⇒ keep polling within the budget.
+  # Sleep only BETWEEN polls: a trailing sleep after the last poll observes nothing, and only makes
+  # the reported horizon overstate the reach of the observation.
+  if [ "$i" -lt "$RECONCILE_TRIES" ]; then sleep "$RECONCILE_SLEEP"; fi
 done
 # At the budget's end a still-`pending` PR (never a merge-queue event) is reported as a well-formed
 # pending, NOT ejected — the settle window is not an ejection (#1921).
+
+# The run's merge disposition, single-sourced HERE and emitted verbatim as the ledger's `merge:`
+# line. Budget exhaustion while the PR is still in the queue is UNRESOLVED — genuinely unknown, and
+# neither a landing nor a failure — so it is worded as the bounded observation it is, carrying the
+# horizon it watched. The three renderings stay textually distinct (#4403).
+case "$MERGE_OUTCOME" in
+  merged)
+    MERGE_DISPOSITION="landed (queue merged the batch)" ;;
+  queued|pending)
+    MERGE_DISPOSITION="UNRESOLVED — still queued at my last read, ~${RECONCILE_HORIZON}s after enqueue; the merge may still land. Bounded observation, not a failure and not a landing — an independent later read closes the lane." ;;
+  ejected)
+    MERGE_DISPOSITION="EJECTED (routed to repair/re-queue)" ;;
+esac
 
 # Guard 6 (ADR 0198) — the reconcile's terminal read is the LAST place this run can leave an arm
 # behind, so it is also sites 3 and 4. `merged` and `queued` keep the intent (a live queue entry is
@@ -2385,10 +2410,16 @@ merge disposition:
   is confirmed in the queue (last event `added_to_merge_queue`, or `mergeStateStatus == QUEUED`);
   `pending` is the **enqueue-settle window** (OPEN, not merged, no merge-queue event yet — incl.
   OPEN + CLEAN before the CLEAN → QUEUED flip). **Both are a well-formed pending, not a failure**
-  (ADR 0132: the actor does not block to the final merge). Report `enqueued: yes (→ auto-merges on
-  green)` exactly as before — the reconcile confirmed it was **still in-flight as far as the
-  timeline can tell** within the window, which is not the same as "never ejected" (the accepted
-  staleness bound above). A `pending` PR at the budget's end is reported this way too — the settle window
+  (ADR 0132: the actor does not block to the final merge). But it is also **not a settled outcome**:
+  the run watched a bounded slice of a dwell it did not see the end of, so the merge is **UNRESOLVED
+  — genuinely unknown, and it may well land seconds later**. Report the disposition the `case` block
+  above rendered, verbatim, **carrying `$RECONCILE_HORIZON`** — the run states how long it watched
+  and that landing is unconfirmed, never a settled disposition. Two words are banned here because
+  each asserts more than any expired reconcile observed: **"reconciled"** (the window closed on an
+  answer — it did not) and **"auto-merges on green"** (a future stated as fact). The distinction
+  they erased is the one this bullet turns on: still-queued at the horizon means **still in-flight
+  as far as the timeline can tell**, which is not "never ejected" (the accepted staleness bound
+  above) and is not "it will merge". A `pending` PR at the budget's end is reported this way too — the settle window
   is **never** an ejection (#1921). **One carve-out** (guard 6): on a base branch a **merge queue
   governs** — every PR in this repo — a `pending` PR never entered the queue at all, so what it
   carries is a parked intent, not an in-flight enqueue; the guard-6 block above clears it and the
@@ -2621,7 +2652,8 @@ exists / is schema-readable / is commit-bound / is all-`pass` (Step 3.5, guard 2
 squash-merge with `--auto` (Step 4), confirm enqueued + green (Step 5), **bounded-reconcile the
 enqueue to catch a queue ejection** before reporting shipped (Step 5.5), and surface the release
 queue on a dark merge (Step 5b). The queue owns the final merge — success is **enqueued + green,
-reconciled to landed-or-still-queued** (never a silent ejection), and the issue-close is async
+observed to `landed` or left UNRESOLVED at the reconcile's horizon** (never a silent ejection, and
+never a bounded observation dressed as a settled one — #4403), and the issue-close is async
 (ADR 0132).
 
 Report back a tight terminal ledger — nothing else, because the merge itself is the
@@ -2631,20 +2663,24 @@ durable record:
 PR #<PR> — issue #<ISSUE>
 branch: <head ref>
 PR url: <html_url>
-enqueued: yes (QUEUED → auto-merges on green) | no (<reason if no>)
-merge: landed (queue merged the batch) | still queued (pending, reconciled) | EJECTED (routed to repair/re-queue)
+enqueued: yes (QUEUED — the queue owns the async merge) | no (<reason if no>)
+merge: <the MERGE_DISPOSITION Step 5.5's case block rendered — landed | UNRESOLVED … ~<N>s … may still land | EJECTED>
 issue: closes async on queue merge | n/a (doc/vocab-surface-only, no linked issue) | #<PART_OF> left open (partial split)
 release: queued (awaiting human flip) | n/a (not a dark ship)
 ```
 
-The `enqueued:` line is the enqueue success condition: `yes (QUEUED → auto-merges on green)` once
-`--auto` armed the merge (Step 4). The `merge:` line is the **reconciled terminal outcome** (Step
+The `enqueued:` line is the enqueue success condition: `yes (QUEUED — the queue owns the async
+merge)` once `--auto` armed the merge (Step 4). It reports that the PR entered the queue, never
+that it will come out of it merged. The `merge:` line is the reconcile's terminal outcome (Step
 5.5) — the queue owns the final, async merge, so the issue-close also lands async (ADR 0132),
 reported as `issue: closes async on queue merge`. There is no in-run `merged: yes` / `issue closed:
 yes` **assertion** any more — asserting an immediate merge would false-fail every enqueued PR — but
-the bounded reconcile **does** distinguish `landed` from `still queued` from `EJECTED`, so `QUEUED`
-never masks a silent stall. An `EJECTED` outcome is **not** a shipped state: it routes back to
-repair/re-queue (Step 5.5), never reported as success.
+the bounded reconcile **does** distinguish `landed` from `UNRESOLVED (still queued)` from
+`EJECTED`, so `QUEUED` never masks a silent stall. An `EJECTED` outcome is **not** a shipped state:
+it routes back to repair/re-queue (Step 5.5), never reported as success. An **UNRESOLVED** outcome
+is not a shipped state either — but it is equally **not a failure**: it says the observation ended
+at its horizon with the PR still queued, and the merge may still land. Never read it as "it did not
+merge" (#4403).
 
 The `release:` line is the deployment/release boundary made visible (ADR 0083): `queued
 (awaiting human flip)` when Step 5b's ground-truth signal fired (the PR introduced a default-off

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.ts
@@ -1,0 +1,91 @@
+/**
+ * Parse ship-it Step 5.5's **reconcile budget** and **merge-disposition rendering** out of
+ * `ship-it/SKILL.md`, so the executable mirror in `step55-contract.unit.test.ts` derives both from
+ * the shell it mirrors instead of hand-copying them (#4403). Same drift-proof idiom as
+ * `class-probe`'s `HAS_*_RE` parse and `checks/step3-contract.ts`: the skill's fenced block stays
+ * the single source, this reads it, no second copy exists to rot. No classification logic is
+ * relocated here — the poll verdict remains `merge-queue-classify`'s, the disposition wording
+ * remains the skill's.
+ *
+ * Fail-closed in one direction only: a renamed Step 5.5, a budget the block never binds, or a
+ * missing `case` arm all resolve to a ZERO horizon and NO dispositions — which makes the consuming
+ * assertions red (a zero horizon covers no dwell, an absent disposition matches no contract), never
+ * quietly green.
+ */
+
+/** The reconcile's poll budget as Step 5.5 states it, plus the horizon it actually observes. */
+export interface ReconcileBudget {
+	/** `RECONCILE_TRIES` default — the number of polls. 0 when unresolvable. */
+	readonly tries: number;
+	/** `RECONCILE_SLEEP` default — seconds between polls. 0 when unresolvable. */
+	readonly sleepSeconds: number;
+	/**
+	 * Seconds from the first poll to the LAST one — `(tries - 1) * sleep`. This, not
+	 * `tries * sleep`, is what the run observed: poll k fires at `(k-1)*sleep`.
+	 */
+	readonly horizonSeconds: number;
+	/**
+	 * Is the `sleep` guarded so it runs only BETWEEN polls? A trailing sleep after the final poll
+	 * observes nothing and makes any reported horizon overstate the observation's reach.
+	 */
+	readonly sleepsBetweenPollsOnly: boolean;
+}
+
+export const FAILCLOSED_RECONCILE_BUDGET: ReconcileBudget = {
+	tries: 0,
+	sleepSeconds: 0,
+	horizonSeconds: 0,
+	sleepsBetweenPollsOnly: false,
+};
+
+/**
+ * The Step 5.5 section: its `### Step 5.5 — …` heading up to the next `## `/`### ` heading. Two
+ * boundaries this scan must not trip over: it starts after the heading's own LINE (searching from
+ * one character in would re-match the heading itself — `### ` minus a char is still `## `), and it
+ * requires at least two hashes, because the step's fenced shell blocks are full of `# …` comment
+ * lines at column 0. A `####` subsection does not end it — four hashes then a space matches neither
+ * bound, so Step 5.5's later prose stays in scope.
+ */
+export const extractStep55Section = (shipItText: string): string => {
+	const start = shipItText.search(/^### Step 5\.5 — /m);
+	if (start < 0) return "";
+	const section = shipItText.slice(start);
+	const bodyAt = section.indexOf("\n") + 1;
+	if (bodyAt === 0) return section;
+	const end = section.slice(bodyAt).search(/^#{2,3} /m);
+	return end < 0 ? section : section.slice(0, bodyAt + end);
+};
+
+const shellDefault = (section: string, name: string): number => {
+	const m = section.match(new RegExp(`^${name}=\\$\\{[A-Z_]+:-(\\d+)\\}`, "m"));
+	return m?.[1] === undefined ? 0 : Number.parseInt(m[1], 10);
+};
+
+export const parseReconcileBudget = (shipItText: string): ReconcileBudget => {
+	const section = extractStep55Section(shipItText);
+	const tries = shellDefault(section, "RECONCILE_TRIES");
+	const sleepSeconds = shellDefault(section, "RECONCILE_SLEEP");
+	if (tries === 0 || sleepSeconds === 0) return FAILCLOSED_RECONCILE_BUDGET;
+	return {
+		tries,
+		sleepSeconds,
+		horizonSeconds: (tries - 1) * sleepSeconds,
+		// the guard as the block writes it: `if [ "$i" -lt "$RECONCILE_TRIES" ]; then sleep …`
+		sleepsBetweenPollsOnly: /\[\s*"\$i"\s+-lt\s+"\$RECONCILE_TRIES"\s*\][^\n]*sleep/.test(section),
+	};
+};
+
+/**
+ * The `MERGE_DISPOSITION` the skill renders per outcome, keyed by every outcome word its `case`
+ * arm lists (`queued|pending` yields two entries pointing at the one shared rendering).
+ */
+export const parseMergeDispositions = (shipItText: string): ReadonlyMap<string, string> => {
+	const section = extractStep55Section(shipItText);
+	const dispositions = new Map<string, string>();
+	for (const m of section.matchAll(/^\s*([a-z|]+)\)\s*\n?\s*MERGE_DISPOSITION="([^"]*)"\s*;;/gm)) {
+		const [, outcomes, rendering] = m;
+		if (outcomes === undefined || rendering === undefined) continue;
+		for (const outcome of outcomes.split("|")) dispositions.set(outcome, rendering);
+	}
+	return dispositions;
+};

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.unit.test.ts
@@ -1,0 +1,217 @@
+import {readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {classify, type MergeOutcome, type MergeQueueSignals} from "./merge-queue-classify.ts";
+import {
+	FAILCLOSED_RECONCILE_BUDGET,
+	parseMergeDispositions,
+	parseReconcileBudget,
+	type ReconcileBudget,
+} from "./step55-contract.ts";
+
+// The live skill — the single source for Step 5.5's budget and disposition wording. Read
+// repo-relative off this file's own location so it resolves identically in CI and in a worktree.
+const SHIP_IT_PATH = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"../../../../..",
+	"claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md",
+);
+const SHIP_IT_TEXT = readFileSync(SHIP_IT_PATH, "utf8");
+const LIVE_BUDGET = parseReconcileBudget(SHIP_IT_TEXT);
+const LIVE_DISPOSITIONS = parseMergeDispositions(SHIP_IT_TEXT);
+
+/** The budget as it stood before #4403 — the control the boundary cases are measured against. */
+const OLD_BUDGET: ReconcileBudget = {
+	tries: 10,
+	sleepSeconds: 30,
+	horizonSeconds: 270, // poll 10 fires at 9*30s; the 10th sleep observed nothing
+	sleepsBetweenPollsOnly: false,
+};
+
+/**
+ * Merge-queue dwell (`added_to_merge_queue` → `merged`) in seconds, measured off the REST timeline
+ * of ten landed PRs (#4403). Every one of them MERGED — none is a failure case.
+ */
+const MEASURED_DWELLS = {
+	"#4329": 565,
+	"#4384": 454,
+	"#4350": 405,
+	"#4369": 404,
+	"#4366": 395,
+	"#4376": 380,
+	"#4331": 355,
+	"#4327": 354,
+	"#4335": 339,
+	"#4362": 317,
+} as const;
+const DWELLS = Object.values(MEASURED_DWELLS);
+const MEDIAN_DWELL = 387.5;
+const MEAN_DWELL = 396.8;
+
+const queuedSignals: MergeQueueSignals = {
+	merged: false,
+	state: "OPEN",
+	lastMergeQueueEvent: "added_to_merge_queue",
+};
+
+/** A healthy PR the queue lands at `dwell` — the removal pairs with the `merged` event (#4155). */
+const landsAt =
+	(dwell: number) =>
+	(t: number): MergeQueueSignals =>
+		t >= dwell
+			? {
+					merged: true,
+					state: "MERGED",
+					lastMergeQueueEvent: "removed_from_merge_queue",
+					mergedTimelineEvent: true,
+				}
+			: queuedSignals;
+
+/** A genuine dequeue at `t0`: removed from the queue with NO `merged` event to pair it with. */
+const dequeuedAt =
+	(t0: number) =>
+	(t: number): MergeQueueSignals =>
+		t >= t0
+			? {
+					merged: false,
+					state: "OPEN",
+					lastMergeQueueEvent: "removed_from_merge_queue",
+					mergedTimelineEvent: false,
+				}
+			: queuedSignals;
+
+/**
+ * A test-local mirror of Step 5.5's reconcile loop, so the outcome a shipper reaches on a given
+ * dwell is executable rather than only prose. The budget is not hand-copied — it is parsed off the
+ * live skill, so widening or narrowing the block moves these cases with it. The per-poll verdict is
+ * the REAL classifier: this mirror adds no classification of its own.
+ */
+const reconcile = (
+	budget: ReconcileBudget,
+	signalsAt: (t: number) => MergeQueueSignals,
+): {readonly outcome: MergeOutcome; readonly lastObservedAt: number} => {
+	let outcome: MergeOutcome = "pending";
+	let lastObservedAt = 0;
+	for (let k = 1; k <= budget.tries; k++) {
+		lastObservedAt = (k - 1) * budget.sleepSeconds;
+		outcome = classify(signalsAt(lastObservedAt)).outcome;
+		if (outcome === "merged" || outcome === "ejected") break;
+	}
+	return {outcome, lastObservedAt};
+};
+
+const dispositionFor = (outcome: MergeOutcome): string => LIVE_DISPOSITIONS.get(outcome) ?? "";
+
+describe("ship-it Step 5.5's reconcile budget, read off the live SKILL.md", () => {
+	it("observes to the LAST poll, not to the loop's exit — the horizon is (tries-1)*sleep", () => {
+		assert.strictEqual(
+			LIVE_BUDGET.horizonSeconds,
+			(LIVE_BUDGET.tries - 1) * LIVE_BUDGET.sleepSeconds,
+		);
+	});
+
+	it("sleeps only BETWEEN polls, so no budget is spent observing nothing", () => {
+		assert.isTrue(LIVE_BUDGET.sleepsBetweenPollsOnly);
+	});
+
+	it("watches past the median and mean measured dwell — the old 4m30s horizon did neither", () => {
+		assert.isAbove(LIVE_BUDGET.horizonSeconds, MEDIAN_DWELL);
+		assert.isAbove(LIVE_BUDGET.horizonSeconds, MEAN_DWELL);
+		assert.isBelow(OLD_BUDGET.horizonSeconds, Math.min(...DWELLS));
+	});
+
+	it("still does not cover the longest measured dwell — which is why the wording, not the width, is the fix", () => {
+		assert.isBelow(LIVE_BUDGET.horizonSeconds, MEASURED_DWELLS["#4329"]);
+	});
+
+	it("fails closed on a Step 5.5 it cannot read, rather than resolving a plausible horizon", () => {
+		assert.deepStrictEqual(parseReconcileBudget(""), FAILCLOSED_RECONCILE_BUDGET);
+		assert.strictEqual(FAILCLOSED_RECONCILE_BUDGET.horizonSeconds, 0);
+		assert.strictEqual(parseMergeDispositions("").size, 0);
+	});
+});
+
+describe("Step 5.5's stand-down wording — an expired observation reads UNRESOLVED, never terminal", () => {
+	const unresolved = dispositionFor("queued");
+
+	it("states the outcome is unresolved and that the merge may still land", () => {
+		assert.include(unresolved, "UNRESOLVED");
+		assert.include(unresolved, "may still land");
+	});
+
+	it("carries the horizon it actually watched, from the variable — never a hardcoded number", () => {
+		assert.match(unresolved, /\$\{RECONCILE_HORIZON\}s after enqueue/);
+	});
+
+	it("says in words that it is not a failure, so no caller reads it as 'did not merge'", () => {
+		assert.include(unresolved, "not a failure");
+		assert.include(unresolved, "not a landing");
+	});
+
+	it("drops the two words that asserted more than any expired reconcile observed", () => {
+		assert.notInclude(unresolved, "reconciled");
+		assert.notInclude(unresolved, "auto-merges on green");
+	});
+
+	it("renders `pending` — the enqueue-settle window — with the same unresolved wording", () => {
+		assert.strictEqual(dispositionFor("pending"), unresolved);
+	});
+
+	it("keeps landed / unresolved / EJECTED textually distinct — the three-way is not collapsed", () => {
+		const renderings = [dispositionFor("merged"), unresolved, dispositionFor("ejected")];
+		assert.include(renderings[0] ?? "", "landed");
+		assert.include(renderings[2] ?? "", "EJECTED");
+		assert.strictEqual(new Set(renderings).size, 3);
+		for (const r of renderings) assert.notStrictEqual(r, "");
+	});
+});
+
+describe("Step 5.5's boundary, executed against the real classifier", () => {
+	it("still queued at the horizon ⇒ UNRESOLVED, not a failure (the 9m25s dwell of PR #4329)", () => {
+		const run = reconcile(LIVE_BUDGET, landsAt(MEASURED_DWELLS["#4329"]));
+		assert.strictEqual(run.outcome, "queued");
+		assert.strictEqual(run.lastObservedAt, LIVE_BUDGET.horizonSeconds);
+		assert.include(dispositionFor(run.outcome), "UNRESOLVED");
+		assert.notStrictEqual(dispositionFor(run.outcome), dispositionFor("ejected"));
+		assert.notStrictEqual(dispositionFor(run.outcome), dispositionFor("merged"));
+	});
+
+	it("a merge that lands past the OLD 5m bound is now reported as landed (the 5m17s dwell of PR #4362)", () => {
+		const dwell = MEASURED_DWELLS["#4362"];
+		assert.isAbove(dwell, OLD_BUDGET.horizonSeconds); // the regression: the old budget missed it
+		assert.strictEqual(reconcile(OLD_BUDGET, landsAt(dwell)).outcome, "queued");
+
+		const run = reconcile(LIVE_BUDGET, landsAt(dwell));
+		assert.strictEqual(run.outcome, "merged");
+		assert.include(dispositionFor(run.outcome), "landed");
+	});
+
+	it("eight of the ten measured dwells now land inside the horizon (the old budget caught none), and none of the ten reads as a failure", () => {
+		const landed = DWELLS.filter((d) => reconcile(LIVE_BUDGET, landsAt(d)).outcome === "merged");
+		assert.strictEqual(landed.length, 8);
+		assert.strictEqual(
+			DWELLS.filter((d) => reconcile(OLD_BUDGET, landsAt(d)).outcome === "merged").length,
+			0,
+		);
+		for (const d of DWELLS) {
+			const outcome = reconcile(LIVE_BUDGET, landsAt(d)).outcome;
+			assert.notStrictEqual(outcome, "ejected");
+			assert.include(["merged", "queued"], outcome);
+		}
+	});
+
+	it("a genuine dequeue-without-merge is NOT-LANDED — it ejects and breaks out early", () => {
+		const run = reconcile(LIVE_BUDGET, dequeuedAt(120));
+		assert.strictEqual(run.outcome, "ejected");
+		assert.strictEqual(run.lastObservedAt, 120);
+		assert.include(dispositionFor(run.outcome), "EJECTED");
+	});
+
+	it("the mirror is not vacuous: an unresolved run and an ejected run reach different dispositions", () => {
+		const stillQueued = reconcile(LIVE_BUDGET, () => queuedSignals);
+		const ejected = reconcile(LIVE_BUDGET, dequeuedAt(0));
+		assert.notStrictEqual(stillQueued.outcome, ejected.outcome);
+		assert.notStrictEqual(dispositionFor(stillQueued.outcome), dispositionFor(ejected.outcome));
+	});
+});


### PR DESCRIPTION
Fixes #4403

## What was wrong

ship-it Step 5.5's bounded post-enqueue reconcile watched to **4m30s** (poll 10 fires at 9x30s; the tenth `sleep` observed nothing), while every one of the ten measured merge-queue dwells on this repo ran **5m17s–9m25s**. So the budget expired mid-dwell on **10 of 10** merges — the normal case — and the run then emitted its bounded observation in settled language: `still queued (pending, reconciled)` plus `auto-merges on green`. "reconciled" says the window closed on an answer; it did not. "auto-merges on green" states a future as fact.

That wording is not cosmetic. Step 5.5 already accepts a staleness residual (an ejected PR reads `queued` while the timeline lags), and the skill names its own containment as *not over-reading that word*. The emitted ledger over-read it.

## What changed

**The classification (the primary fix).** Budget exhaustion with the PR still in the queue is now **UNRESOLVED** — first-class, explicitly not a failure and not a landing:

```
UNRESOLVED — still queued at my last read, ~${RECONCILE_HORIZON}s after enqueue; the merge may still land.
Bounded observation, not a failure and not a landing — an independent later read closes the lane.
```

The disposition is single-sourced as a `case` block inside Step 5.5 and emitted verbatim as the ledger's `merge:` line. `landed` / `UNRESOLVED` / `EJECTED` stay three textually distinct outcomes. The ledger's `enqueued:` line drops `→ auto-merges on green` for `QUEUED — the queue owns the async merge`: it reports that the PR entered the queue, never that it will come out merged.

**The bound (secondary).** The horizon is `(TRIES-1)*SLEEP` — the *last poll*, not the loop's exit — so the old comment's "~5 min batch window" overstated the reach by 30s and the trailing sleep was dead budget. Now `16x30s` with the sleep guarded to fire only *between* polls: horizon **7m30s**, exit at the same instant.

The new default is justified against the measured dwells, **not** against `min_entries_to_merge_wait_minutes` — the issue flags that parameter's semantics as an ungrounded platform claim, and nothing here depends on it. 7m30s is past the measured median (6m27s) and mean (6m37s); it is deliberately **not** set past the 9m25s max, because a single shipper invocation has a ~10-minute wall-clock ceiling and 16 polls' own `gh` latency eats into it. **Even the widened horizon can expire mid-dwell** — which is exactly why the width is the secondary half and the wording is the load-bearing one.

**Nothing else moves.** No classifier verdict changed (`merge-queue-classify` still prints `queued` mid-dwell; `merged` still needs `merged_at` + the `merged` event, or the single-parent base-branch squash). Guard 6 is untouched — a live queue entry still keeps its intent. The bound is still bounded; the shipper still never blocks to the merge. A `removed_from_merge_queue` paired with a `merged` event is still queue consumption, not an ejection.

**No logic relocated out of the skill**, so the issue's CODEOWNERS/`CONTROL_PLANE_RE` amendment clause does not fire. `step55-contract.ts` only *reads* the skill — the same drift-proof idiom as `packages/pipeline-cli/src/tools/checks/step3-contract.ts` and `class-probe`'s `HAS_*_RE` parse.

## How the boundary is demonstrated mechanically

`packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.unit.test.ts` parses the live budget and disposition renderings off `ship-it/SKILL.md` and runs a mirror of Step 5.5's poll loop whose **per-poll verdict is the real `classify`** — the mirror adds no classification of its own. 16 tests, covering the three boundaries asked for:

- **still queued at expiry ⇒ UNRESOLVED, not a failure** — the 9m25s dwell of #4329: the loop's last observation is exactly the parsed horizon, the outcome is `queued`, and its rendering is distinct from both the ejected and the landed one.
- **a genuine dequeue-without-merge ⇒ not-landed** — `removed_from_merge_queue` with no `merged` event resolves `ejected` and breaks out early.
- **a merge landing past the old 5m bound ⇒ landed** — the 5m17s dwell of #4362 resolves `queued` under the old 10x30s budget (the regression, asserted as a control) and `merged` under the new one. Across all ten measured dwells: 8 now land inside the horizon, the old budget caught **0**, and none of the ten reads as a failure.
- Plus: the horizon is `(tries-1)*sleep`; the sleep is guarded to fire only between polls; the banned words are absent from the stand-down rendering; the horizon is carried from `${RECONCILE_HORIZON}`, never hardcoded; and an unreadable Step 5.5 fails closed to a zero horizon with no dispositions rather than a plausible-looking default.

## Acceptance criteria

- [x] An expired reconcile states the bound of its own observation; "reconciled" and "auto-merges on green" are gone from what a run emits.
- [x] `still queued` stays textually distinct from `landed` and `EJECTED`.
- [x] No classifier verdict changed.
- [x] No change to guard 6.
- [x] The bound is not removed; the shipper does not block to the merge.
- [x] The new default is justified against measured dwell, not a fresh magic number, and does not rest on the ungrounded `min_entries_to_merge_wait_minutes` premise.
- [x] No logic relocated out of the skill, so no `CONTROL_PLANE_RE` / CODEOWNERS amendment is due.

## §CP

`pipeline-cli cp-classify classify` over the changed paths → **control-plane** (exit 0), on `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`. This banks for @kamp-us/control-plane approval. No `.sh` was added.

## Verification run

`pnpm typecheck` clean, `pnpm lint` clean, `pipeline-cli` suite 2937/2937 green, apps/web 2420/2420 green via `verified-push`'s pre-push hook.

---

## Repair round 1 — the emission layer (`review-code` / `review-skill` FAIL @ `6e472308`)

Both gates landed the same single finding: the skill's `merge:` ledger was genuinely fixed, but the **emission layer around it still contradicted it** — an output contract changed on one side of a seam with its readers left stale. Fixed on this branch; nothing else in the PR was touched.

| Site | Was | Now |
| --- | --- | --- |
| `claude-plugins/kampus-pipeline/agents/shipper.md` — frontmatter `description` | `success is "enqueued + green" (QUEUED → auto-merges on green)` | `(QUEUED — the queue owns the async merge)`, then the reconcile classifies `landed` / `UNRESOLVED` / `EJECTED`; the issue closes async **if and when** the queue lands the merge |
| `claude-plugins/kampus-pipeline/agents/shipper.md` — When to invoke | `(QUEUED → auto-merges on green; …)` | `(QUEUED — the queue owns the async merge)`, then report Step 5.5's disposition **verbatim** |
| `claude-plugins/kampus-pipeline/agents/shipper.md` — §Output | mandated returning `enqueued: yes (QUEUED → auto-merges on green)` | `enqueued: yes (QUEUED — the queue owns the async merge)` **plus** the `merge:` disposition verbatim, with the skill named as the single source and re-wording forbidden |
| `.claude/workflows/drive-issue.js` — the driver's human-facing log | `PR #N QUEUED -> auto-merges on green (reconciled: still queued)` — both banned phrasings, on precisely the mid-dwell-expiry case | three distinct renderings: `PR #N LANDED — the queue merged the batch` / `PR #N UNRESOLVED — still queued when the shipper's bounded observation expired; the merge may still land. Neither a landing nor a failure — an independent later read closes the lane` / `PR #N EJECTED from the merge queue (not merged)` |
| `.claude/workflows/drive-issue.js` — the stage comment and the shipper prompt | `(QUEUED -> auto-merges on green)`; `"queued" (… a well-formed pending)` | `(QUEUED — the queue owns the async merge)`; `"queued"` is to be reported as `UNRESOLVED: neither a landing nor a failure` |

**Proof the three renderings stay distinct, and that neither banned phrasing survives as an emitted string.** Parsing the live `case` block with the shipped `step55-contract.ts` parser yields `landed (queue merged the batch)` / the shared `UNRESOLVED …` string for both `queued` and `pending` / `EJECTED (routed to repair/re-queue)` — `Set(...).size === 3`. Grepping the emitted strings (comments stripped, so the *statements of the ban* in both files do not count as emissions): `auto-merges on green` → absent, `reconciled` → absent, in both `agents/shipper.md` and `.claude/workflows/drive-issue.js`. The driver's three log strings are likewise distinct.

### The two advisory notes, both addressed

- **A fail-closed `*)` arm.** The `case` block now has one. It is unreachable while the bin prints one of its four words — which is the point: without it an unrecognized `$MERGE_OUTCOME` leaves `MERGE_DISPOSITION` unset and the ledger's `merge:` line renders **blank**, a could-not-determine posing as nothing at all. It renders `UNKNOWN — … Not a landing, not a failure, not an ejection — re-read the PR before acting on it.`, a fifth state rather than a fourth wording of the three. The contract parser's `^\s*([a-z|]+)\)` does not match `*)`, so it adds no disposition entry and the three-way distinctness assertion is unchanged.
- **The wall-clock ceiling's consequence, stated.** The budget comment now says what the cited `~10-minute` ceiling actually costs: *a run killed against it mid-loop never reaches the ledger at all, so it emits no `merge:` line — silence, where a stand-down would at least have stated the bound of what it watched.* The bound itself is not re-derived.

### What was deliberately left alone

`merge-queue-classify.ts` is still **byte-identical** to `origin/main` (`git diff --exit-code` → 0). Guard 6, `merge-intent`, `CONTROL_PLANE_RE` and `UI_RE` are untouched. The Step 5.5 loop, the horizon arithmetic, and the three disposition strings are unchanged from the reviewed head — only the `*)` arm and one comment sentence were added to that file.

## Deviations

- **(repair round 1) The pre-commit `biome` leg was excluded for this commit** (`LEFTHOOK_EXCLUDE=biome`; the other legs — `leak-guard`, `primary-index-guard`, `primary-index-tripwire`, `ref-guard` — all ran and passed). The leg fails **zero-scope, not on a finding**: its staged-file pre-filter keeps `.js`, so `.claude/workflows/drive-issue.js` reaches biome, but biome's own config ignores `.claude/**`, so it reports `No files were processed` and exits 1. Verified directly: `biome check --files-ignore-unknown=true .claude/workflows/drive-issue.js` → `Checked 0 files` + exit 1, with the file listed under "provided but ignored". The hook's own comment says an all-unknown input "is NOT a finding and must not block" — this is that same case reached via the config-ignore route rather than the extension route, so the pre-filter misses it. `pnpm lint:worktree` is clean. **This is a hook bug worth filing separately**; it will block any commit whose only biome-handled file lives under `.claude/**`.
- **(repair round 1) Pushed by refspec rather than through `pipeline-cli verified-push`.** The PR's head branch was checked out in another agent's live worktree, so this repair ran on a local alias branch; `verified-push --branch` resolves `NOT-MOVED` when the named branch is not the one checked out in `--cwd`. The push guarantee was discharged instead by **two independent remote-ref reads** after the push — `git ls-remote` against the remote and `GET /repos/…/pulls/4417` — both resolving the new head. No other agent's worktree was touched or removed.
- **(repair round 1) `ship-it/SKILL.md:3` (frontmatter) and `:502` still carry "auto-merges on green".** Left as-is deliberately: the `review-code` verdict scoped them out explicitly ("mechanism prose … consistent, noted only for hygiene, not counted against AC1"), and the skill's ban is on what a *run emits*, which neither line is. Touching the frontmatter `description` would also put the `review-skill` trigger-quality check — which passed precisely because the description was untouched — back in play for no gate benefit.

## §CP (re-classified at the repair head)

`pipeline-cli cp-classify classify` over the full changed set → **`control-plane [path-match]`**, now on `.claude/workflows/drive-issue.js`. Unchanged class: still **BLOCKING (human merge)**. Both repaired readers are themselves §CP, so this repair rides the same approval path rather than needing a new one.

## Verification run (repair head)

`pipeline-cli` suite **183 files / 2937 tests, all passed**; `step55-contract.unit.test.ts` **16/16** (unchanged by the `*)` arm); `pnpm typecheck` → 29/29 tasks successful; `pnpm lint:worktree` clean; `pipeline-cli gh-phoenix lint-skills` clean on both changed skill-corpus files (no GraphQL-path `gh` calls, no bare `git push`, frontmatter still parses as strict YAML); `node --check` on the driver → OK.
