### PR TITLE
fix(write-code): make three guards that could not fire able to fire (#4398)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -878,11 +878,13 @@ is intentionally left untouched here so the two changes can't double-implement o
 > }
 > wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-closed, re-correcting cwd
 >   : "${CLAUDE_CODE_SESSION_ID:?wt_preflight FAILED (fail-closed): no session id — no lane identity to verify a worktree against}"
->   # CLASSIFY THE AMBIENT TREE FIRST — every assertion lives here, because this is the only place
->   # the operands can differ. `$AMB_STAMP` is a file some lane wrote when its worktree was proven;
->   # `$CLAUDE_CODE_SESSION_ID` is the process env. After the corrective `cd` below they agree BY
->   # CONSTRUCTION, so a check down there would be checking a value against its own derivation —
->   # which is exactly what shipped, and why the sibling-tree refusal never printed (#4398).
+>   # CLASSIFY THE AMBIENT TREE FIRST — the lane-identity assertions live here, because this is the
+>   # only place THESE operands can differ. `$AMB_STAMP` is a file some lane wrote when its worktree
+>   # was proven; `$CLAUDE_CODE_SESSION_ID` is the process env. After the corrective `cd` below these
+>   # two agree BY CONSTRUCTION, so re-checking THEM down there would be checking a value against its
+>   # own derivation — which is exactly what shipped, and why the sibling-tree refusal never printed
+>   # (#4398). That is a fact about these operands, not about position: the post-`cd` refusal below
+>   # reads independent operands and does fire.
 >   AMB_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
 >   AMB_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
 >   case "$AMB_COMMON" in ""|/*) ;; *) AMB_COMMON="$(pwd -P)/$AMB_COMMON" ;; esac
@@ -901,7 +903,18 @@ is intentionally left untouched here so the two changes can't double-implement o
 >   # down, or a foreign session), or several are (ambiguous).
 >   WT="$(lane_worktree)" || { echo "wt_preflight FAILED (fail-closed): no single worktree carries this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2; return 1; }
 >   cd "$WT" || { echo "wt_preflight FAILED: cannot cd to worktree root $WT" >&2; return 1; }
->   echo "wt_preflight OK: mutating my lane at $WT (git-dir $(git rev-parse --absolute-git-dir))"
+>   # DEFENCE IN DEPTH — the resolved lane must not BE the primary checkout. This sits after the
+>   # `cd` and is still a genuine assertion, because its operands do not come from the cwd: it
+>   # tests `lane_worktree`'s ANSWER with two DIFFERENT plumbing queries whose results coincide
+>   # only on the primary. `lane_worktree` returns whatever `worktrees/<name>/gitdir` names, so an
+>   # entry naming the primary root, stamped with this lane, resolves here — and this refuses.
+>   # Demonstrated firing in PR #4419's review; do not delete it as "true by construction" (#4398).
+>   RES_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || { echo "wt_preflight FAILED (fail-closed): resolved lane $WT is not inside a git repository — refusing to mutate." >&2; return 1; }
+>   RES_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+>   case "$RES_COMMON" in /*) ;; *) RES_COMMON="$(pwd -P)/$RES_COMMON" ;; esac
+>   RES_COMMON="$(cd "$RES_COMMON" && pwd -P)"
+>   [ "$RES_GITDIR" != "$RES_COMMON" ] || { echo "wt_preflight FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout ($WT) — git-dir == common-dir. Refusing to mutate." >&2; return 1; }
+>   echo "wt_preflight OK: mutating my lane at $WT (git-dir $RES_GITDIR)"
 > }
 > wt_preflight && git <commit|push|switch …>   # the guard gates the mutation; never run the mutation without it
 > ```
@@ -911,9 +924,16 @@ is intentionally left untouched here so the two changes can't double-implement o
 > **process env**. Put cwd in a sibling lane's tree and they differ, so the refusal prints. The
 > assertion this replaces compared `git rev-parse --show-toplevel` against `git rev-parse
 > --show-toplevel` run in the same directory after a `cd` to it — always equal, so its failure
-> message could never print, and the `git-dir != common-dir` check beside it caught only the primary
-> checkout. Note where the assertions sit: **before** the corrective `cd`, never after it. Anything
-> asserted after the `cd` is true by construction and is not a guard.
+> message could never print.
+>
+> **The rule is about where the operands come from, not about where the line sits.** An assertion
+> that re-derives the value the `cd` just set — asking the cwd where the cwd is — is true by
+> construction and is not a guard; that, specifically, is the defect above. An assertion whose
+> operands come from somewhere else is a real guard wherever it sits, **including after the `cd`**:
+> the primary-checkout refusal above tests `lane_worktree`'s *answer* with two different plumbing
+> queries (`--absolute-git-dir` vs `--git-common-dir`) that coincide only on the primary, and it
+> fires on a `worktrees/<name>/gitdir` naming the primary root. So never delete a later assertion
+> merely because it follows the `cd` — check its operands first.
 
 <a id="anchor-edits-to-wt"></a>
 > **Anchor EVERY `Edit`/`Write` to `$WT` — the raw-write path no git guard covers (#3458).**

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -162,12 +162,20 @@ namespaces) is an unaddressed FAIL:
 
 ```bash
 ME=$(gh api user --jq '.login')
-# resolve the verdict CLI once via the `bin/pipeline-cli` shim — in-repo bin, else the installed
-# bin, else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned
-# here (#3653; ADR 0062/0064; epic #994). Each per-(PR, gate) FAIL-bound-to-head resolution below
-# delegates to `pipeline-cli verdict read` (ACL author-gate + latest-wins + SHA-staleness, ADR
-# 0055/0058; its unit tests are the contract).
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314). The shim's own
+# three-tier ladder (in-repo bin → installed bin → the pinned `pnpm dlx`, hooks/pin.sh) decides WHICH
+# build runs, so no version is pinned here (#3653; ADR 0062/0064; epic #994). Each per-(PR, gate)
+# FAIL-bound-to-head resolution below delegates to `pipeline-cli verdict read` (ACL author-gate +
+# latest-wins + SHA-staleness, ADR 0055/0058; its unit tests are the contract).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# GATE-CRITICAL (§CLI): this scan's wrapper turns non-zero into "nothing to repair", so an
+# unresolved CLI would read as a clean scan and the run would fall through to new work while an
+# unaddressed FAIL sits open. Refuse up front — "could not run" is never a verdict.
+[ -x "$PCLI" ] || {
+  echo "pipeline-cli: UNRESOLVED at '$PCLI' — the repairable-PR scan has NO result." >&2
+  echo "  Resolve to UNKNOWN, never to 'no FAIL'. This is a resolution gap, NOT worktree teardown (§CLI)." >&2
+  exit 127
+}
 # open PRs you authored; print each one whose latest verdict in EITHER namespace is FAIL,
 # UNLESS it has already hit the N=3 repair cap (then it's a human's, not yours to re-pick)
 gh api "repos/$REPO/pulls?state=open&per_page=100" \
@@ -203,9 +211,17 @@ gh api "repos/$REPO/pulls?state=open&per_page=100" \
   [ "$ROUNDS" -ge 3 ] && continue   # at the cap → already escalated to a human, excluded from the scan
   # resolve each namespace's latest current-head verdict through the shared verb — exit 0 iff HEAD
   # carries a current FAIL in that gate (a stale / SHA-less / PASS / none verdict exits non-zero).
-  $VERDICT read --pr "$PR" --gate code  --expect FAIL >/dev/null 2>&1 && echo "#$PR review-code FAIL"
-  $VERDICT read --pr "$PR" --gate doc   --expect FAIL >/dev/null 2>&1 && echo "#$PR review-doc FAIL"
-  $VERDICT read --pr "$PR" --gate skill --expect FAIL >/dev/null 2>&1 && echo "#$PR review-skill FAIL"
+  # stderr is NOT discarded and 127 is read apart from an ordinary negative: with `2>&1` swallowing
+  # it, a `command not found` was byte-identical to "no FAIL verdict" and the PR dropped out of the
+  # scan silently (§CLI exit-code taxonomy — "could not run" is never a verdict; #4398, #4236).
+  for G in code doc skill; do
+    "$PCLI" verdict read --pr "$PR" --gate "$G" --expect FAIL >/dev/null
+    RC=$?
+    case $RC in
+      0)   echo "#$PR review-$G FAIL" ;;
+      127) echo "verdict read could not run (127) for #$PR/$G — UNKNOWN, not 'no FAIL'. Stop and route the blocker (§CLI)." >&2; exit 127 ;;
+    esac
+  done
 done
 ```
 
@@ -757,7 +773,16 @@ else
   # every edit under this $WT (see "Anchor every Edit/Write to $WT" below). Establishing $WT loudly
   # here is what makes that anchoring actionable from the first file touch.
   WT="$(git rev-parse --show-toplevel)"
-  echo "write-code preflight CONFIRMED (LOUD): in a LINKED worktree at $WT (git-dir != common-dir) — worktree identity established from git plumbing, INDEPENDENT of \$WORKTREE_ROOT (${WORKTREE_ROOT:+set}${WORKTREE_ROOT:-unset}) and \$CLAUDE_CODE_AGENT (${CLAUDE_CODE_AGENT:-unset}), both of which may misreport. Anchor EVERY Edit/Write and git op to this \$WT (absolute) — never a primary-checkout path."
+  # STAMP THE LANE — this is the one moment $WT is trustworthy, so pin an identity to it (#4398).
+  # Every LATER Bash call re-derives the toplevel from a cwd the harness may have reset, so a
+  # cwd-derived "$WT" answers "where am I" and not "which tree is mine" — and a check that compares
+  # that answer against itself is tautological. $CLAUDE_CODE_SESSION_ID is the per-lane fact that
+  # DOES survive between calls (the same anchor §SP keys $RUN_SCRATCH on); write it into this
+  # worktree's PRIVATE per-worktree git dir, which is outside the working tree (never committed,
+  # never in `git status`) and unique per worktree. That stamp is the independently-derived operand
+  # wt_preflight compares the ambient cwd's answer against.
+  printf '%s\n' "${CLAUDE_CODE_SESSION_ID:?write-code preflight FAILED: no session id — no durable lane identity to stamp, so no later git mutation could be verified as mine}" > "$GITDIR/kampus-lane"
+  echo "write-code preflight CONFIRMED (LOUD): in a LINKED worktree at $WT (git-dir != common-dir), stamped for lane $CLAUDE_CODE_SESSION_ID — worktree identity established from git plumbing, INDEPENDENT of \$WORKTREE_ROOT (${WORKTREE_ROOT:+set}${WORKTREE_ROOT:-unset}) and \$CLAUDE_CODE_AGENT (${CLAUDE_CODE_AGENT:-unset}), both of which may misreport. Anchor EVERY Edit/Write and git op to this \$WT (absolute) — never a primary-checkout path."
 fi
 ```
 
@@ -823,29 +848,72 @@ is intentionally left untouched here so the two changes can't double-implement o
 > cross-contaminating each other's PRs (#832). One pass at Step-4 start does **not** hold for
 > the whole run.
 >
-> Capture your worktree root once, then run this **mandatory per-mutation preflight** —
-> `wt_preflight` — *immediately before* every `git commit`, `git push`, and branch
-> create/switch (Steps 4, 5, R2, R3). It re-`cd`s to your own worktree root first (correcting
-> a between-calls reset), then re-runs the same fail-closed check **and** asserts the toplevel
-> is your worktree. A green `wt_preflight` is the **only** sanctioned path to a mutation — no
-> bypass, same construction as the opening preflight:
+> Run this **mandatory per-mutation preflight** — `wt_preflight` — *immediately before* every
+> `git commit`, `git push`, and branch create/switch (Steps 4, 5, R2, R3). It first asserts that
+> the tree the cwd is *currently* in is not another lane's, then resolves **your** worktree from
+> the lane stamp the opening preflight wrote and `cd`s there, correcting a between-calls reset to
+> the primary checkout. A green `wt_preflight` is the **only** sanctioned path to a mutation — no
+> bypass, same fail-closed construction as the opening preflight:
 >
 > ```bash
-> WT="$(git rev-parse --show-toplevel)"   # same $WT the opening preflight CONFIRMED; re-derive per Bash call (shell state doesn't survive), never from a file
+> # Resolve MY worktree by IDENTITY, never from cwd (#4398). `git rev-parse --show-toplevel` answers
+> # "where is the cwd" — which a between-calls reset makes a different question from "which tree is
+> # mine". Deriving $WT from it and then re-deriving the toplevel to compare against is one answer
+> # checked against itself: always equal, so its failure branch could never print. The stamp is
+> # CONTENT written once when $WT was trustworthy, so these two operands can genuinely differ.
+> lane_worktree() {   # print the absolute root of the worktree stamped with THIS lane's session id
+>   common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+>   case "$common" in /*) ;; *) common="$(pwd -P)/$common" ;; esac
+>   common="$(cd "$common" && pwd -P)" || return 1   # -P: git answers in PHYSICAL paths, so must we
+>   hits=""
+>   for st in "$common"/worktrees/*/kampus-lane; do
+>     [ -f "$st" ] || continue
+>     [ "$(cat "$st")" = "$CLAUDE_CODE_SESSION_ID" ] || continue
+>     gd="$(cat "${st%/kampus-lane}/gitdir")" || return 1   # "<worktree-root>/.git"
+>     hits="$hits $(cd "${gd%/.git}" && pwd -P)"
+>   done
+>   set -- $hits
+>   [ "$#" -eq 1 ] || return 1   # 0 ⇒ no tree is mine; >1 ⇒ ambiguous. Both REFUSE (fail-closed).
+>   printf '%s\n' "$1"
+> }
 > wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-closed, re-correcting cwd
+>   : "${CLAUDE_CODE_SESSION_ID:?wt_preflight FAILED (fail-closed): no session id — no lane identity to verify a worktree against}"
+>   # CLASSIFY THE AMBIENT TREE FIRST — every assertion lives here, because this is the only place
+>   # the operands can differ. `$AMB_STAMP` is a file some lane wrote when its worktree was proven;
+>   # `$CLAUDE_CODE_SESSION_ID` is the process env. After the corrective `cd` below they agree BY
+>   # CONSTRUCTION, so a check down there would be checking a value against its own derivation —
+>   # which is exactly what shipped, and why the sibling-tree refusal never printed (#4398).
+>   AMB_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+>   AMB_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+>   case "$AMB_COMMON" in ""|/*) ;; *) AMB_COMMON="$(pwd -P)/$AMB_COMMON" ;; esac
+>   [ -n "$AMB_COMMON" ] && AMB_COMMON="$(cd "$AMB_COMMON" && pwd -P)"   # -P: compare like for like with git's physical answer
+>   AMB_STAMP="$(cat "$AMB_GITDIR/kampus-lane" 2>/dev/null)"
+>   echo "wt_preflight: ambient=$(git rev-parse --show-toplevel 2>/dev/null || echo '<not a repo>') ambient-git-dir=${AMB_GITDIR:-<none>} ambient-stamp=${AMB_STAMP:-<none>} lane=$CLAUDE_CODE_SESSION_ID"
+>   # THE SIBLING-TREE REFUSAL: cwd sits in a LINKED worktree that is not mine. The primary checkout
+>   # is the harness's documented reset target and is corrected below; a sibling lane's tree is NOT
+>   # explained by anything, so stop rather than mutate next to a live lane (#832, #3458/#3580).
+>   if [ -n "$AMB_GITDIR" ] && [ "$AMB_GITDIR" != "$AMB_COMMON" ] && [ "$AMB_STAMP" != "$CLAUDE_CODE_SESSION_ID" ]; then
+>     echo "wt_preflight FAILED (fail-closed): cwd is inside worktree $(git rev-parse --show-toplevel), stamped '${AMB_STAMP:-<none>}' — a SIBLING lane's tree, not my lane ($CLAUDE_CODE_SESSION_ID). Refusing to mutate." >&2
+>     return 1
+>   fi
+>   # cwd is my own tree or the PRIMARY checkout (the between-calls reset). Resolve my lane by
+>   # identity and cd there — the correction. A miss REFUSES: no tree is mine (unprovisioned, torn
+>   # down, or a foreign session), or several are (ambiguous).
+>   WT="$(lane_worktree)" || { echo "wt_preflight FAILED (fail-closed): no single worktree carries this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2; return 1; }
 >   cd "$WT" || { echo "wt_preflight FAILED: cannot cd to worktree root $WT" >&2; return 1; }
->   GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || {
->     echo "wt_preflight FAILED: not in a git repo at $WT" >&2; return 1; }
->   COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
->   case "$COMMON" in /*) ;; *) COMMON="$(pwd)/$COMMON" ;; esac
->   COMMON="$(cd "$COMMON" && pwd)"
->   TOP="$(git rev-parse --show-toplevel)"
->   echo "wt_preflight: git-dir=$GITDIR common-dir=$COMMON toplevel=$TOP wt=$WT"
->   [ "$GITDIR" != "$COMMON" ] || { echo "wt_preflight FAILED (fail-closed): on the PRIMARY checkout, not the worktree — refusing to mutate." >&2; return 1; }
->   [ "$TOP" = "$WT" ]        || { echo "wt_preflight FAILED (fail-closed): toplevel ($TOP) != my worktree ($WT) — cwd reset landed me in a sibling/primary tree." >&2; return 1; }
+>   echo "wt_preflight OK: mutating my lane at $WT (git-dir $(git rev-parse --absolute-git-dir))"
 > }
 > wt_preflight && git <commit|push|switch …>   # the guard gates the mutation; never run the mutation without it
 > ```
+>
+> **What makes it able to fail, stated so a future editor can check it.** Both refusals compare
+> operands from different origins: a **stamp file** written when a worktree was proven, against the
+> **process env**. Put cwd in a sibling lane's tree and they differ, so the refusal prints. The
+> assertion this replaces compared `git rev-parse --show-toplevel` against `git rev-parse
+> --show-toplevel` run in the same directory after a `cd` to it — always equal, so its failure
+> message could never print, and the `git-dir != common-dir` check beside it caught only the primary
+> checkout. Note where the assertions sit: **before** the corrective `cd`, never after it. Anything
+> asserted after the `cd` is true by construction and is not a guard.
 
 <a id="anchor-edits-to-wt"></a>
 > **Anchor EVERY `Edit`/`Write` to `$WT` — the raw-write path no git guard covers (#3458).**
@@ -1162,7 +1230,11 @@ The change gates behind a default-off flag, which is **one of two shapes** that 
   shape: a feature gated behind the prior-PR #1204 authorship flag.
 
 Whichever shape applies, **capture the exact kebab-case flag key as `FLAG_KEY`** — it is the single
-fact that flows out of this step. The load-bearing invariant the patterns own is **default =
+fact that flows out of this step — and it flows as **text you carry into Step 5's body**, not as a
+shell variable. `$FLAG_KEY` is gone by the next Bash call, so no later step may branch on it (#4398);
+Step 5's dark-ship check re-derives whether this step fired from the issue's `Containment:` marker.
+
+The load-bearing invariant the patterns own is **default =
 safe-state**, the three facets `review-code` Step 3b will verify, so build to make each checkable
 from the outside:
 
@@ -1658,12 +1730,23 @@ STRAY=$(gh api repos/$REPO/pulls/<PR> --jq '.body' \
   || echo "STRAY CLOSE DIRECTIVE(S) on $(printf '#%s ' $STRAY)— rewrite these sibling refs to a non-closing form (addresses/relates to/see #M) before opening/patching the PR"
 # (d) DARK-SHIP GUARD, REST-only: IF Step 4b fired, the body MUST carry a `Flag:` line that
 #     matches ship-it Step 5b's FLAG_IN_BODY grep verbatim — else the prior-PR dark ship is dropped
-#     from the release queue (#1282). Run this check ONLY when Step 4b fired (FLAG_KEY is set).
-if [ -n "$FLAG_KEY" ]; then
+#     from the release queue (#1282). Whether Step 4b fired is RE-DERIVED HERE from durable state —
+#     the child's `Containment:` marker and the cycle-doc probe, Step 4b's own two inputs, read in
+#     THIS Bash call. It used to key on `[ -n "$FLAG_KEY" ]`, a shell variable Step 4b assigns in a
+#     DIFFERENT Bash call: shell state does not survive between calls, so it was empty here and the
+#     check silently skipped itself in exactly the case it exists for (#4398).
+CONTAINMENT=$(gh api repos/$REPO/issues/<N> --jq '.body' \
+  | grep -ioE '\**\s*Containment:\**\s*(flag|exempt|none)' | head -n1 \
+  | grep -ioE '(flag|exempt|none)' || echo none)
+gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1 \
+  && CYCLE_DOC=present || CYCLE_DOC=absent
+if [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]; then
   gh api repos/$REPO/pulls/<PR> --jq '.body' \
     | grep -Eiq '^[[:space:]]*\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+' \
     && echo "dark-ship Flag: line present and matches ship-it Step 5b — release queue will fire" \
     || echo "MISSING/MALFORMED Flag: line — Step 4b fired but the body has no matching plain 'Flag: <key>' line; patch it in before stopping (#1282)"
+else
+  echo "no dark ship (containment=$CONTAINMENT, cycle-doc=$CYCLE_DOC) — no Flag: line expected"
 fi
 # (e) DISCLOSURE PRESENCE, REST-only: the body carries a `## Deviations` heading. This is the
 #     PRESENCE floor only — it cannot tell an honest `None.` from a false one, and it sees none of
@@ -1978,13 +2061,17 @@ systematically over-ranked against a marker rewritten after it (#4200).
 
 ```bash
 PR=<the PR number you were handed>
-# resolve the verdict CLI once via the `bin/pipeline-cli` shim — in-repo bin, else the installed
-# bin, else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned
-# here (#3653; ADR 0062/0064; epic #994). The per-(PR, gate) FAIL-bound-to-head resolution
-# delegates to `pipeline-cli verdict read`: the ADR-0055 write+ author-gate, the latest-wins pick,
-# and the ADR-0058 SHA-staleness test folded into one exit code (its unit tests are the contract,
-# #2102) — the same resolution ship-it Step 2 reads.
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314). The per-(PR,
+# gate) FAIL-bound-to-head resolution delegates to `pipeline-cli verdict read`: the ADR-0055 write+
+# author-gate, the latest-wins pick, and the ADR-0058 SHA-staleness test folded into one exit code
+# (its unit tests are the contract, #2102) — the same resolution ship-it Step 2 reads.
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# GATE-CRITICAL (§CLI): an unresolved CLI here would print no outcome JSON, which the UNKNOWN test
+# below already defers on — refuse up front anyway, so the reason is legible instead of inferred.
+[ -x "$PCLI" ] || {
+  echo "pipeline-cli: UNRESOLVED at '$PCLI' — this repair has NO verdict; resolve to UNKNOWN, never to 'nothing to repair' (§CLI)." >&2
+  exit 127
+}
 
 # The write+ author-set (ADR 0055) — `verdict read` computes it internally for the marker resolution,
 # but two DOWNSTREAM steps that are genuinely more than a single (PR, gate) resolution reuse it: the
@@ -2007,9 +2094,9 @@ done <<<"$markerAuthors"
 # — exit 0 from `verdict read … --expect FAIL`. The verb's JSON (stdout) carries the resolving comment
 # id, which Step R2 uses to read the FAIL body. A stale / SHA-less / PASS / none verdict exits non-zero,
 # so it is correctly NOT repaired (idempotent no-op), needing no separate staleness test here.
-CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code  --expect FAIL 2>/dev/null)"  && CODE_FAIL=1  || CODE_FAIL=0
-DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc   --expect FAIL 2>/dev/null)"  && DOC_FAIL=1   || DOC_FAIL=0
-SKILL_FAIL_JSON="$($VERDICT read --pr "$PR" --gate skill --expect FAIL 2>/dev/null)" && SKILL_FAIL=1 || SKILL_FAIL=0
+CODE_FAIL_JSON="$("$PCLI" verdict read --pr "$PR" --gate code  --expect FAIL 2>/dev/null)"  && CODE_FAIL=1  || CODE_FAIL=0
+DOC_FAIL_JSON="$("$PCLI"  verdict read --pr "$PR" --gate doc   --expect FAIL 2>/dev/null)"  && DOC_FAIL=1   || DOC_FAIL=0
+SKILL_FAIL_JSON="$("$PCLI" verdict read --pr "$PR" --gate skill --expect FAIL 2>/dev/null)" && SKILL_FAIL=1 || SKILL_FAIL=0
 
 # UNRESOLVED ≠ "no FAIL". `verdict read` prints its outcome JSON on BOTH exit paths, so absent JSON
 # means the namespace never resolved at all (a transport/5xx error, not a verdict). Under a flaky


### PR DESCRIPTION
Three safety checks in the `write-code` skill were written as enforcement but could never actually fail: one compared a value against itself, one tested a shell variable that is always empty by the time it runs, and one of the two ways the skill locates the pipeline CLI breaks in the directory coders normally work from. A check that cannot fail is worse than no check, because its silence looks exactly like success. This PR rewrites all three so each can fail on the condition it was built to catch, and shows each one firing.

Fixes #4398

## What changed

**1 — the `wt_preflight` sibling-tree assertion.** It ran `git rev-parse --show-toplevel`, `cd`'d to that path, ran the same command again, and compared the two. Always equal, so the "cwd reset landed me in a sibling/primary tree" message could never print.

The lane is now identified by content, not by a path derivation. The Step-4 opening preflight — the one moment `$WT` is trustworthy — writes `$CLAUDE_CODE_SESSION_ID` into the worktree's private per-worktree git dir (outside the working tree, so it is never committed and never appears in `git status`). `wt_preflight` then classifies the **ambient** tree *before* the corrective `cd`, which is the only place *those* operands can differ: a stamp file's content against the process env. A cwd sitting in a linked worktree that is not mine is refused; the primary checkout stays the documented, corrected reset target. The `[ "$GITDIR" != "$COMMON" ]` primary-checkout refusal is **kept**, re-derived *after* the correction against `lane_worktree`'s answer (see the repair round below).

The session id is the anchor triage could not find. It is the same per-lane fact §SP already keys `$RUN_SCRATCH` on, and it is stable across an agent's separate Bash calls.

**2 — the dark-ship `Flag:` check.** It guarded on `[ -n "$FLAG_KEY" ]`. `FLAG_KEY` is assigned in Step 4b, in a different Bash call, and shell state does not survive between calls — so it was empty at the test and the block skipped itself in exactly the prior-PR case #1282 exists for. It now re-derives whether Step 4b fired from durable state read in the same call: the child issue's `Containment:` marker and the cycle-doc probe, Step 4b's own two inputs. Step 4b's prose no longer claims `FLAG_KEY` flows onward as a variable.

**3 — the two CLI-resolution recipes.** Both `VERDICT=` sites used a cwd-relative fallback; the seven others used the §CLI canonical git-toplevel form. A grep for `CLAUDE_PLUGIN_ROOT` now shows nine sites and one recipe. The Step-1 repairable scan no longer discards stderr and reads 127 apart from an ordinary negative, and both sites carry the §CLI gate-critical `[ -x "$PCLI" ]` refusal — a resolution failure can no longer be laundered into "no FAIL verdict".

## Each guard demonstrated firing

The guard bodies were extracted verbatim from the fences in this diff (blockquote markers stripped) and driven against a two-lane git worktree sandbox and a stubbed REST surface — not retyped.

**Guard 1**, four cases against a primary checkout with two linked worktrees `lane-a` (stamped `SESSION-A`) and `lane-b` (stamped `SESSION-B`), running as `SESSION-A`:

| cwd | result |
|---|---|
| own tree `lane-a` | `wt_preflight OK: mutating my lane at …/lane-a` — exit 0 |
| **sibling tree `lane-b`** | `FAILED (fail-closed): cwd is inside worktree …/lane-b, stamped 'SESSION-B' … not my lane (SESSION-A)` — **exit 1** |
| primary checkout | drift corrected to `lane-a` — exit 0 |
| **no tree carries my stamp** | `FAILED (fail-closed): no single worktree carries this lane's stamp` — **exit 1** |

Consequence check: `wt_preflight && git commit` from the sibling reset left `lane-b` at its prior commit count — the contamination commit did not land. Control: the **old** assertion run on that same sibling reset printed `EXIT=0` and would have committed into `lane-b`. That is the tautology, live.

**Guard 2**, check (d) extracted and driven against a stubbed `gh`:

| issue `Containment:` | cycle doc | PR body | result |
|---|---|---|---|
| `flag` | present | **no `Flag:` line** | **`MISSING/MALFORMED Flag: line …` — fires** |
| `flag` | present | `Flag: pano-authorship-badge` | `present and matches ship-it Step 5b` |
| `none` | present | no `Flag:` line | `no dark ship … no Flag: line expected` |
| `flag` | absent | no `Flag:` line | `no dark ship …` (graceful absence, ADR 0062) |

Control: the old `if [ -n "$FLAG_KEY" ]` form on the first row, in a fresh shell, printed nothing at all.

**Guard 3**, both recipes run from the worktree subdirectory `apps/web/worker` with `$CLAUDE_PLUGIN_ROOT` unset (verified unset in a spawned subagent shell):

- old recipe resolved to `claude-plugins/kampus-pipeline/bin/pipeline-cli` → `No such file or directory`, **exit 127**; inside the shipped wrapper (`>/dev/null 2>&1 && echo …`) it printed nothing, i.e. read as "no FAIL verdict";
- new recipe resolved to the worktree's absolute shim path, `[ -x ]` true, verb ran and returned its own result (`verdict: no authorized verdict in this namespace`, exit 1) with its diagnostic now reaching stderr;
- the new `[ -x "$PCLI" ]` refusal fires on an absent shim.

## Repair round — the primary-checkout refusal is restored (`review-skill` FAIL @ `8521d12d`)

The gate found one blocking defect and it was real: the earlier round removed `[ "$GITDIR" != "$COMMON" ]` from `wt_preflight`, arguing it had become true by construction. It had not.

`lane_worktree` maps a stamp to a root by reading `worktrees/<name>/gitdir`, so it returns **whatever that file names**. An entry naming the **primary** root, stamped with the running session, resolves through it — and the shipped body then reported success on the primary checkout, the exact outcome this preflight stack exists to prevent.

Why the "tautology" argument was wrong on the specifics: the original defect compared `git rev-parse --show-toplevel` against **itself** — one derivation run twice. `--absolute-git-dir` and `--git-common-dir` are two **different** plumbing queries that merely *coincide* on the primary checkout. In that position the line is not a tautology; it is an assertion resting on `lane_worktree` being sound, and the gate made it fire.

**What is restored.** A primary-checkout refusal placed **after** the corrective `cd`, between the `cd` and the success echo. It is a genuine assertion there because its operands do not come from the cwd the `cd` just set — they are two independent plumbing queries applied to `lane_worktree`'s **answer**. The lane-identity assertions stay **before** the `cd`, where their operands (stamp file vs process env) can differ; nothing else was moved.

**Demonstrated, against shipped bytes.** Both guard bodies were `sed`-extracted verbatim from their fences (blockquote markers stripped) — the head `8521d12d` body via `git show`, the repaired body from the worktree — and executed against one sandbox: a throwaway primary checkout with a planted `worktrees/planted/` entry whose `gitdir` names the primary root and whose `kampus-lane` carries the running session id.

| body | outcome, run from the sandbox primary |
|---|---|
| shipped head `8521d12d` | `wt_preflight OK: mutating my lane at <sandbox>/primary` — **exit 0, on the primary checkout** |
| repaired | `FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout (<sandbox>/primary) — git-dir == common-dir. Refusing to mutate.` — **exit 1** |

The diff between the two extracted bodies is exactly the restored assertion plus two comment blocks; no other line of the guard changed.

**The six regression cases still hold** for the repaired body (re-run, same extraction method): own lane → OK exit 0; sibling lane → sibling refusal exit 1; primary reset → corrected to `lane-a` exit 0; no stamp for my lane → refusal exit 1; two trees stamped with my lane → refusal exit 1; and the consequence control — `wt_preflight && git commit` from a sibling reset left `lane-b` at 2 commits, unchanged.

**The false generalization is corrected.** The sentence *"Anything asserted after the `cd` is true by construction and is not a guard"* was the reasoning that produced the removal, shipped as guidance to the next editor. It now reads that the rule is about **where the operands come from, not where the line sits**: an assertion that re-derives the value the `cd` just set is not a guard, but an assertion whose operands come from somewhere else is a real guard wherever it sits — including after the `cd` — with the restored refusal named as the worked instance. The in-fence comment that made the same claim is scoped the same way.

## Checks

`pipeline-cli cli-invocation-guard check` clean over 37 runnable fences. `gh-phoenix lint-skills` clean over the whole plugin corpus (65/38/69 files, exit 0); re-run on the repaired file, the bare-push scan is clean. `pnpm typecheck` 29/29. `cp-classify classify` → `control-plane`, exit 0 at the repaired head — this banks for human approval. No shell script added; the skill directory stays `.sh`-free.

## Deviations

- **Class: narrowed/changed the suggested fix-shape.** Said: triage's spin-off caveat allowed the bounded fix of simply *removing* the tautological assertion, on the grounds that an agent worktree's directory name encodes no lane identity. Did: implemented the full identity anchor instead, using `$CLAUDE_CODE_SESSION_ID`. Why: the dispatch required a guard demonstrably able to fail on the real condition, and the session id is a durable per-lane anchor the skill already depends on elsewhere (§SP). Disposition: no action needed; the `type:decision` spin-off the caveat reserved is not required.

- **Class: removed an existing check — RETRACTED at `465ab7fc`.** Said: the issue records `[ "$GITDIR" != "$COMMON" ]` as the assertion that still fires and carries the load. Did (at `8521d12d`): removed it, on the reasoning that `lane_worktree()` only ever returns a linked worktree so the comparison had become true by construction. That reasoning was **wrong** — `lane_worktree` returns whatever `worktrees/<name>/gitdir` names, and the gate built that case and made the check fire. The check is **restored** after the corrective `cd`, where its operands come from `lane_worktree`'s answer rather than from the cwd, and the guidance sentence that generalized the removal is corrected. Disposition: resolved; see the repair round above for the executed demonstration.

- **Class: a sibling defect found and not fixed.** Said: nothing. Did: while testing I found `pwd` is logical, so the existing `COMMON="$(cd "$COMMON" && pwd)"` normalization compares a logical path against git's physical answer; on a symlinked path (`/tmp` → `/private/tmp` on macOS) that misclassified a primary checkout as a linked worktree. My new code uses `pwd -P`. The identical latent mismatch is in the **Step-4 opening preflight**, where it would fail *open* (primary checkout read as a worktree). Why not fixed: out of this issue's scope, and the dispatch was explicit about not restructuring this file alongside #4404 / #4395 / #4407. Disposition: follow-up #4420 filed.

- **Class: partial application of an acceptance criterion.** Said: AC 4 — the fail-closed wrappers around the verdict scan must not discard stderr. Did: applied it fully to the Step-1 repairable scan (stderr kept, 127 read apart). Left R1's `2>/dev/null` on the three `verdict read` calls, because R1 already resolves an absent-JSON namespace to UNKNOWN-and-defer; added the `[ -x "$PCLI" ]` refusal there instead so the reason is stated rather than inferred. Why: R1's existing UNKNOWN path already satisfies "could not run is never a verdict"; removing its redirect would have added noise without changing an outcome. Disposition: for the reviewer to judge.

- **Class: touched a line outside the literal AC list.** Said: the ACs name the check, not Step 4b. Did: also corrected Step 4b's sentence claiming `FLAG_KEY` "is the single fact that flows out of this step". Why: that claim is what licensed the dead conditional; leaving it would have left the next editor a documented reason to re-add one. Disposition: no action needed.

- **Class: a reviewer non-blocking suggestion not taken.** Said: the gate flagged two optional items — the subshell-scoped `exit 127` in the pipe-fed `while read PR` loop, and Guard 2 reading a failed REST call as `containment=none`. Did: neither. Why: both were explicitly marked non-blocking and no-new-defect (the first is backstopped by the top-level `[ -x "$PCLI" ]` refusal; the second is the same shape as the pre-existing Step-4b derivation), and this repair round is scoped to the one blocking finding in a file with three other live lanes. Disposition: worth a follow-up issue for the §CPREAD capture-and-check on Guard 2.
