### PR TITLE
chore(taste-skills): cite the firewall once, and give a mode-split aspect a STANDARDS.md owner (#4402)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/taste-animation-improve/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-animation-improve/SKILL.md
@@ -22,15 +22,15 @@ Grounded exclusively in three artifacts, and there is no fourth:
 - [`design-system-inventory.md`](https://github.com/kamp-us/phoenix/blob/main/design-system-inventory.md) — which primitives exist and when to use them (ADR [0194](https://github.com/kamp-us/phoenix/blob/main/.decisions/0194-design-law-jsdoc-firewall.md)).
 - The blessed goldens — the visual reference a surface is measured against (ADR [0183](https://github.com/kamp-us/phoenix/blob/main/.decisions/0183-golden-screen-storage-depo-git-pointer.md)).
 
-**This skill advises creation; it never authors law** (the ADR 0194 firewall). Findings tagged
-**LAW** cite the design law and are binding; findings tagged **CRAFT** are advisory defaults that
-yield to LAW. Where the law is silent, say so rather than filling the gap, and route a
-load-bearing gap through the [`report`](../report/SKILL.md) skill.
+**This skill advises creation; it never authors law.** The firewall itself — the two-tier LAW /
+CRAFT provenance rule and the obligation to say so and surface the gap where the law is silent — is
+stated once, in [§2 of the library conventions](../taste-library-conventions.md#2-the-firewall--skills-advise-creation-they-never-author-law).
+For this skill's output that means every brief carries its finding's tag, and a **CRAFT** finding
+is written as a default the executor may decline, never as a blocking requirement.
 
 Values come from [`taste-animation-review/STANDARDS.md`](../taste-animation-review/STANDARDS.md) —
-the single values file for this aspect. Cite it; never copy figures into a brief's own vocabulary
-or approximate them. Library conventions:
-[`taste-library-conventions.md`](../taste-library-conventions.md).
+the animation aspect's single values file, owned by the review mode (§4). Cite it; never copy
+figures into a brief's own vocabulary or approximate them.
 
 ## Hard rules
 

--- a/claude-plugins/kampus-pipeline/skills/taste-animation-opportunities/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-animation-opportunities/SKILL.md
@@ -22,13 +22,14 @@ Grounded exclusively in three artifacts, and there is no fourth:
 - [`design-system-inventory.md`](https://github.com/kamp-us/phoenix/blob/main/design-system-inventory.md) — which primitives exist and when to use them (ADR [0194](https://github.com/kamp-us/phoenix/blob/main/.decisions/0194-design-law-jsdoc-firewall.md)).
 - The blessed goldens — the visual reference a surface is measured against (ADR [0183](https://github.com/kamp-us/phoenix/blob/main/.decisions/0183-golden-screen-storage-depo-git-pointer.md)).
 
-**This skill advises creation; it never authors law** (the ADR 0194 firewall). A suggestion tagged
-**LAW** cites the design law; everything else is **CRAFT** and yields to LAW. Where the law is
-silent, say so rather than filling the gap. A suggestion may never propose a new token, a new
-easing scale, or a new design rule — it composes what exists, or it is not a suggestion.
+**This skill advises creation; it never authors law.** The firewall itself — the two-tier LAW /
+CRAFT provenance rule and the obligation to say so and surface the gap where the law is silent — is
+stated once, in [§2 of the library conventions](../taste-library-conventions.md#2-the-firewall--skills-advise-creation-they-never-author-law).
+For this skill's output that means a suggestion may never propose a new token, a new easing scale,
+or a new design rule — it composes what exists, or it is not a suggestion.
 
-Values come from [`taste-animation-review/STANDARDS.md`](../taste-animation-review/STANDARDS.md).
-Library conventions: [`taste-library-conventions.md`](../taste-library-conventions.md).
+Values come from [`taste-animation-review/STANDARDS.md`](../taste-animation-review/STANDARDS.md) —
+the animation aspect's single values file, owned by the review mode (§4).
 
 ## Operating posture
 

--- a/claude-plugins/kampus-pipeline/skills/taste-animation-review/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-animation-review/SKILL.md
@@ -23,15 +23,14 @@ Grounded exclusively in three artifacts, and there is no fourth:
 - [`design-system-inventory.md`](https://github.com/kamp-us/phoenix/blob/main/design-system-inventory.md) — which primitives exist and when to use them (ADR [0194](https://github.com/kamp-us/phoenix/blob/main/.decisions/0194-design-law-jsdoc-firewall.md)).
 - The blessed goldens — the visual reference a surface is measured against (ADR [0183](https://github.com/kamp-us/phoenix/blob/main/.decisions/0183-golden-screen-storage-depo-git-pointer.md)).
 
-**This skill advises creation; it never authors law** (the ADR 0194 firewall). Findings tagged
-**LAW** cite the design law and are binding. Findings tagged **CRAFT** are advisory defaults for
-questions the law does not answer — they yield to LAW, and they are never written up as
-prohibitions. Where the law is silent, say so; where the gap is load-bearing, tell the author to
-file it via the [`report`](../report/SKILL.md) skill. Never edit `design-system-manifest.md`.
+**This skill advises creation; it never authors law.** The firewall itself — the two-tier LAW /
+CRAFT provenance rule and the obligation to say so and surface the gap where the law is silent — is
+stated once, in [§2 of the library conventions](../taste-library-conventions.md#2-the-firewall--skills-advise-creation-they-never-author-law).
+For this skill's output that means a **CRAFT** finding is written up as an advisory default in the
+findings table and the verdict, never as a prohibition and never as a Block criterion.
 
-Exact values live in [`STANDARDS.md`](STANDARDS.md) — cite them, never approximate. The
-library-wide conventions live in
-[`taste-library-conventions.md`](../taste-library-conventions.md).
+Exact values live in [`STANDARDS.md`](STANDARDS.md) — this aspect's single values file, owned here
+because this is the mode that grades against the figures (§4). Cite them, never approximate.
 
 ## Operating posture
 

--- a/claude-plugins/kampus-pipeline/skills/taste-animation-vocabulary/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-animation-vocabulary/SKILL.md
@@ -20,18 +20,17 @@ Grounded exclusively in three artifacts, and there is no fourth:
 - [`design-system-inventory.md`](https://github.com/kamp-us/phoenix/blob/main/design-system-inventory.md) — which primitives exist and when to use them (ADR [0194](https://github.com/kamp-us/phoenix/blob/main/.decisions/0194-design-law-jsdoc-firewall.md)).
 - The blessed goldens — the visual reference a surface is measured against (ADR [0183](https://github.com/kamp-us/phoenix/blob/main/.decisions/0183-golden-screen-storage-depo-git-pointer.md)).
 
-**This skill advises creation; it never authors law** (the ADR 0194 firewall). The glossary below
-is **CRAFT** vocabulary — the industry names for effects, adopted so a brief can be precise. It is
-not design law: naming an effect never licenses it, and every named effect is still subject to the
-manifest's prohibitions and to the gates in
-[`taste-animation-review`](../taste-animation-review/SKILL.md).
+**This skill advises creation; it never authors law.** The firewall itself — the two-tier LAW /
+CRAFT provenance rule and the obligation to say so and surface the gap where the law is silent — is
+stated once, in [§2 of the library conventions](../taste-library-conventions.md#2-the-firewall--skills-advise-creation-they-never-author-law).
+For this skill's output that means the glossary below is **CRAFT** vocabulary: naming an effect
+never licenses it, and every named effect stays subject to the manifest's prohibitions and to the
+gates in [`taste-animation-review`](../taste-animation-review/SKILL.md).
 
 **It is also not the repo's term register.** Where a word also names a phoenix concept, the
 repo's [`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md) and
 [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md) win.
 These terms are English technical vocabulary; product and brand copy stays Turkish.
-
-Library conventions: [`taste-library-conventions.md`](../taste-library-conventions.md).
 
 ## How to answer
 

--- a/claude-plugins/kampus-pipeline/skills/taste-library-conventions.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-library-conventions.md
@@ -59,6 +59,7 @@ claude-plugins/kampus-pipeline/skills/
   taste-<aspect>/SKILL.md             one skill per aspect (color, layout, iconography, …)
   taste-<aspect>/STANDARDS.md         optional, values-only (§4)
   taste-<aspect>-<mode>/SKILL.md      when one aspect needs several modes
+  taste-<aspect>-<mode>/STANDARDS.md  a mode-split aspect's one values file, on its owner (§4)
 ```
 
 - **`taste-<aspect>`** is the default: one skill per design aspect. `taste-color`,
@@ -109,8 +110,22 @@ git diff --name-only origin/main... | "$PCLI" cp-classify classify
 
   Anything longer than that is a rule, and a rule lives in `SKILL.md`.
 
-**One `STANDARDS.md` per aspect, owned by the aspect's primary skill.** Sibling modes link to it;
-they never copy values into their own file. A duplicated value is a value that drifts.
+**One `STANDARDS.md` per aspect, and exactly one file owns it.** Sibling skills link to it; they
+never copy values into their own file. A duplicated value is a value that drifts.
+
+**Which file owns it follows the aspect's shape (§3), and both shapes are legitimate:**
+
+- **A single-skill aspect** owns its values at `taste-<aspect>/STANDARDS.md` — the aspect has one
+  skill, so there is nothing to disambiguate.
+- **A mode-split aspect** has no `taste-<aspect>/` directory to hold the file, so the owner is the
+  **mode that grades against the figures** — the review mode where one exists, otherwise the mode
+  whose procedure cites the most rows. The file lives in that mode's own directory and the sibling
+  modes link across into it. The animation cluster is the worked example:
+  [`taste-animation-review/STANDARDS.md`](taste-animation-review/STANDARDS.md) is the animation
+  aspect's single values file, and `taste-animation-improve` and `taste-animation-opportunities`
+  cite it there. **Never mint a `taste-<aspect>/` directory just to home the file** — a directory
+  holding a `STANDARDS.md` and no `SKILL.md` is a shape the library does not have and
+  [`validate-skills.sh`](validate-skills.sh) has never been checked against.
 
 A `STANDARDS.md` is optional — add one when the aspect has enough concrete figures that a skill
 would otherwise guess at them.
@@ -194,8 +209,14 @@ Before you open the PR:
       `claude-plugins/kampus-pipeline/skills/`, and frontmatter `name` matches the dir.
 - [ ] `description` states what the skill is **and** the situations it fires on — it is the
       routing surface, not a summary.
-- [ ] The SKILL.md opens with a **Grounding and firewall** section naming all three artifacts
-      (§1) and stating the advise-never-author rule (§2).
+- [ ] The SKILL.md opens with a **Grounding and firewall** section that names all three artifacts
+      (§1) in full, each as an absolute `blob/main` URL — a skill loads standalone into a spawn
+      that may never open this contract, and the three artifacts live outside this plugin, so a
+      repo-relative path to them does not resolve.
+- [ ] That section **cites §2 for the firewall — it does not restate it.** Restating it is what
+      forked the rule across the first four skills, each in its own wording. Point at §2 (a
+      sibling of your dir, so a relative link resolves) and add at most one skill-specific
+      sentence saying what LAW/CRAFT means for *this* skill's own output shape.
 - [ ] Every rule is tagged **LAW** (with its manifest section), **CRAFT**, or the compound
       **CRAFT, serving LAW — `<section>`** (§5); a standard bundling clauses of different tiers
       tags each clause inline rather than flattening to one; no CRAFT rule is written as a


### PR DESCRIPTION
The taste-skill library's four skills each spelled out the same firewall rule — advise creation, never author law — in their own words, and the four wordings had already drifted apart. This PR states that rule once, in the shared contract, and points all four skills at it. It also fixes a rule in the contract that nothing in the library could satisfy: §4 said an aspect's values file is owned by "the aspect's primary skill", but the only aspect that ships is split into four modes and has no primary.

Fixes #4402

## What changed

**Finding 1 — the firewall is cited, not re-derived.**

- All four `SKILL.md` files keep their `## Grounding and firewall` heading, the `Grounded exclusively in three artifacts, and there is no fourth:` line, and the three artifact bullets **verbatim**, absolute `blob/main` URLs and all. That block is load-bearing for a standalone-loaded skill and was not touched.
- The 4–5 line re-derivation below it is replaced by one **byte-identical** three-line pointer to `taste-library-conventions.md` §2, plus exactly one skill-specific sentence per file saying what LAW/CRAFT means for *that* skill's own output shape.
- `claude-plugins/kampus-pipeline/skills/taste-library-conventions.md` §8: the checklist item that said the section must be "**stating** the advise-never-author rule (§2)" — the forcing function that produced the four wordings — now says **cite §2, do not restate it**, and is split into two items so the three-artifact requirement (§1, absolute URLs, with the reason) stays explicit.

**Finding 2 — §4's ownership rule now has a referent, and §3 agrees with the tree.**

- §4's sentence becomes "One `STANDARDS.md` per aspect, and exactly one file owns it", followed by ownership for both aspect shapes: a single-skill aspect owns `taste-<aspect>/STANDARDS.md`; a **mode-split** aspect has no `taste-<aspect>/` directory, so the owner is the mode that grades against the figures — the review mode where one exists. The animation cluster is named as the worked example, and minting a `taste-<aspect>/` dir just to home the file is prohibited (a dir with a `STANDARDS.md` and no `SKILL.md` is a shape `validate-skills.sh` has never been checked against).
- §3's layout block grows the matching row, `taste-<aspect>-<mode>/STANDARDS.md`, so §3 and §4 agree with the tree.
- `taste-animation-review/STANDARDS.md` is **not moved**. No file or directory is created — the diff is five modified files, zero added.

## On the direction of the §4 fix

The rule is amended, not deleted, and not satisfied by moving the file. Triage ruled option (a) — bless what exists — over option (b) — create `taste-animation/STANDARDS.md` — and this PR follows that ruling. The guarantee §4 exists to give (one values file per aspect, siblings link, values never copied) is unchanged and now stronger, because an author can name the owner from the contract instead of inspecting the tree. Deleting the ownership rule to make the corpus compliant was never on the table; if a reviewer thinks the mode-split ownership heuristic ("the mode that grades against the figures") is the wrong tiebreak, that is the judgment call to contest — the rule itself is not relaxed.

## Single-sourcing, not removal — every pointer verified to resolve from its site

Each site collapsed to a pointer, and where the guarantee now lives:

| Collapsed at | What it said | Now stated once at |
|---|---|---|
| all four skills | LAW cites the design law and is binding | §2, LAW bullet |
| all four skills | CRAFT is advisory and yields to LAW | §2, CRAFT bullet + "CRAFT always yields to LAW" |
| all four skills | where the law is silent, say so, do not fill the gap | §2, "Where the law is silent, say so and surface the gap" |
| `improve`, `review` | route a load-bearing gap through the `report` skill | §2, same paragraph, linking `report/SKILL.md` |
| `review` only | never edit `design-system-manifest.md` | §2, closing clause |
| `review` only | CRAFT findings are never written as prohibitions | §2 ("never as a prohibition") + kept as `review`'s own output-shape sentence |

Nothing was dropped without a home. Verification of the pointers themselves:

- `../taste-library-conventions.md` resolves on disk from **all four** skill directories — they are siblings under `claude-plugins/kampus-pipeline/skills/`, checked by resolving the literal relative path from each of the four dirs.
- The pointer is deliberately **relative**, unlike the three grounding artifacts, and the difference is grounded rather than stylistic: `design-system-manifest.md`, `design-system-inventory.md`, and the goldens live in the **repo**, outside this plugin, so a plugin-installed skill cannot reach them by relative path and needs the absolute URL. `taste-library-conventions.md` is a **sibling in the same plugin directory** and ships with the skill, so the relative link resolves in both the in-repo and plugin-installed contexts. §8's new checklist item states this reason so the next author does not have to re-derive it.
- The `#2-the-firewall--skills-advise-creation-they-never-author-law` fragment was computed from the live heading text `## 2. The firewall — skills advise creation, they never author law` under GitHub's slug rule and matches. If the heading is ever renamed the link degrades to the top of the file, never to a missing file, and the literal "§2" in the sentence still directs the reader.
- The two peer links this ticket protects — `taste-animation-opportunities/SKILL.md` and `taste-animation-improve/SKILL.md` pointing at `../taste-animation-review/STANDARDS.md` — are kept and still resolve; both gained a `(§4)` cite naming why the file lives in a peer's directory.
- §4's new links, `taste-animation-review/STANDARDS.md` and `validate-skills.sh`, both resolve relative to the contract's own directory.

## Verification

- `cp-classify classify` over the five changed paths: `not-control-plane [path-clear-no-content-source]`, **exit 3, proven-ordinary**. No `.sh` file added anywhere.
- `pnpm typecheck`: 29/29 tasks successful.
- `pnpm lint:worktree`: clean skip (markdown-only diff, no biome-handled files).
- Pre-commit hooks green: `biome`, `leak-guard` ("no user-local paths in any scanned doc surface"), `primary-index-guard`, `primary-index-tripwire`.
- No values were inlined: no figure from `STANDARDS.md` appears in any `SKILL.md`; every values reference is still a citation.

## Deviations

**Class: narrowed a suggested fix-shape.**
- *Said:* AC "In each of the four `SKILL.md` files, the generic LAW/CRAFT re-derivation is replaced by the one-line cite … that all four already carry."
- *Did:* The cite is three source lines, not one, and it names the rule it points at ("the two-tier LAW / CRAFT provenance rule and the obligation to say so and surface the gap where the law is silent") before linking §2.
- *Why:* A bare `Library conventions: …` line was decorative while the prose sat next to it; now that it carries the whole invariant, a reader who does not follow it must still learn that the rule exists and what it governs. A pointer that does not say what it points at is how single-sourcing turns into removal. The line is byte-identical across all four files, so it cannot drift — which is the AC's actual objective.
- *Disposition:* no action needed; for the reviewer to judge if a literal one line is required.

**Class: left a sibling item in place that a strict reading of an AC might sweep.**
- *Said:* AC "the only remaining per-skill prose is the skill-specific sentence above."
- *Did:* `taste-animation-vocabulary/SKILL.md` keeps its separate "**It is also not the repo's term register.**" paragraph (glossary terms vs `.glossary/TERMS.md` / `LANGUAGE.md` precedence, and the TR/EN split).
- *Why:* That AC scopes to prose *stating the advise-never-author rule*; the term-register note states a different invariant, it is unique to this skill, and it is not single-sourced anywhere in §2. Deleting it to satisfy a literal read would remove a live guarantee under cover of a duplication fix — the exact thing this ticket must not do.
- *Disposition:* for the reviewer to judge.

**Class: dropped a link that the collapsed prose carried.**
- *Said:* nothing explicit.
- *Did:* `taste-animation-improve` and `taste-animation-review` no longer link `../report/SKILL.md` directly; the "file a load-bearing gap via `report`" obligation now reaches the reader through §2, which links `report/SKILL.md` itself.
- *Why:* Keeping the link would re-derive the obligation at the site, which is the duplication being removed. The link is one hop away and verified present in §2.
- *Disposition:* no action needed.

## Out of scope, unchanged

Untouched, per the issue: the absolute-URL multiplication (five `blob/main` URLs per skill stay), a §8 length cap, #4356's LAW/CRAFT ruling, the `taste-*` tree's control-plane status, and PR #4387 / the phase-2 build tickets. This PR is a fix *to* the template; #4387 builds *against* it and is a separate lane.
