### PR TITLE
fix(pipeline): resolve five self-contradictions in the shared intake contract (#4395)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -330,7 +330,9 @@ that **already exists and is open**; a skill assigns to one, never **creates** o
 the set. Creating/curating milestones is a **roadmap (human / CPO) act**, deliberately *not*
 autonomous — fragmenting the set would destroy its single-source-of-truth value, so there is no
 autonomous "create-milestones" skill (ADR 0072 §3). A skill that finds no clear match to an
-existing open milestone leaves the issue **unmilestoned**; it does not invent a home.
+existing open milestone still does not invent a home — it reaches for a **standing-lane label
+or a kill**, per the fallback rule immediately below (ADR 0202/0208). "Leave it unmilestoned"
+is **not** an outcome.
 
 **Freeze-by-absence moved from an absence to a label (ADR 0208).** The signal ADR 0072 §4 carried
 — *this work is parked by design; don't force-fit it* — is not retired, but it no longer rides on
@@ -1093,9 +1095,10 @@ temp path (`@/var/folders/…`), so no SHA-bound verdict existed for `ship-it` /
 bind to (a **missing** gate verdict), **and** it leaked a machine-local path into a public comment.
 The source idiom alone can't see it; only a **post-write read-back** can.
 
-So every gate that posts a verdict marker — `review-code`, `review-doc`, `review-skill` — closes the
-loop with **one** canonical read-back guard: after the post/upsert lands, **re-read the comment you
-just wrote** and assert three invariants, failing **loud** (fail-closed, ADR
+So every gate that posts a verdict marker — `review-code`, `review-doc`, `review-skill`,
+`review-design` — closes the loop with **one** canonical read-back guard: after the post/upsert
+lands, **re-read the comment you just wrote** and assert three invariants, failing **loud**
+(fail-closed, ADR
 [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md) §ZS)
 on any miss — never a silent pass. This is the single source; each review skill **references it**
 (it does not re-derive its own copy — the three-copy drift is exactly what this contract exists to
@@ -1105,7 +1108,8 @@ prevent):
 # verdict_readback_guard <comment-id> <gate> <head-sha>: re-read the just-posted verdict comment
 # and PROVE it is a well-formed, leak-free, current-head-bound marker. FAIL LOUD (non-zero) on any
 # miss — a broken marker reads to consumers as "no verdict", or worse a human skims it as posted.
-# <gate> is one of: review-code | review-doc | review-skill.
+# <gate> is one of: review-code | review-doc | review-skill | review-design — ALL FOUR PR gates, the
+# same set the emit mandate below scopes and the same set the verdict lib enumerates (VerdictGate).
 verdict_readback_guard() {
   local cid="$1" gate="$2" sha="$3"
   local got; got="$(gh api "repos/$REPO/issues/comments/$cid" --jq .body)" || {
@@ -1212,7 +1216,8 @@ or path-leaking marker is a **fatal** error the gate cannot silently pass:
 # verdict post/upsert (native APPROVE, comment PATCH-upsert, comment POST, advisory). It does NOT
 # rely on a $MINE/$CID captured on one posting branch — it RE-SCANS the PR's live state to resolve
 # whatever landed, then proves it well-formed + leak-free. Returns 0 ONLY on a proven-clean landed
-# verdict; non-zero (FATAL) on absent / malformed / leaking. <gate> ∈ review-code|review-doc|review-skill.
+# verdict; non-zero (FATAL) on absent / malformed / leaking.
+# <gate> ∈ review-code|review-doc|review-skill|review-design — all four PR gates, same set as above.
 verdict_post_verify() {
   local PR="$1" gate="$2" sha="$3" me cid approved rbody
   me="$(gh api user --jq .login)"
@@ -1512,7 +1517,12 @@ closing the #375 drift class).
   `heal-ci`, `what-shipped`, `doctor`, and `wayfinder` skills are operational diagnostics /
   reporting / orientation — they neither gate a merge nor hold release authority nor sit on a
   gate-critical path, so they auto-merge on a `review-skill` PASS like any ordinary skill. Do
-  **not** add them to the boundary (ADR 0174).
+  **not** add them to the boundary (ADR 0174). **The one exception is per-file, not per-dir:**
+  `doctor/doctor.sh` — like every other `skills/**/*.sh` helper — **is** §CP via the `.sh` clause
+  above, because it is executable enforcement; the rest of the `doctor` skill dir (its `SKILL.md`
+  and any non-`.sh` file) is out. Same for any future `.sh` under `heal-ci`, `what-shipped`, or
+  `wayfinder`. The two bullets do not disagree: the `.sh` clause scopes to `.sh` **files** at any
+  depth, this exclusion scopes to skill **dirs**.
 - the **pipeline agent definitions** — `claude-plugins/kampus-pipeline/agents/**`: the behavior
   instructions for the very agents that run the pipeline, including `shipper.md` (the merge
   authority) and `reviewer.md` (the verdict gate). An agents-only PR matched **no** §CP clause
@@ -2821,12 +2831,19 @@ with no `@ <sha>` is a *pre-0058 legacy* shape and resolves to `unverified`, not
 
 ### Upsert, not append — one verdict per (PR, gate-namespace) (ADR 0058)
 
-`review-code` writes **exactly one** marker comment per PR in its namespace: before posting
-it scans the PR's comments for **its own** prior `review-code:` marker and, if one exists,
-`PATCH`es it (`gh api -X PATCH repos/$REPO/issues/comments/<id>`) with the fresh
-verdict + fresh `@ <sha>` instead of `POST`-ing a new comment. A re-review of a new head
-overwrites the same record; the PR thread never accumulates a stale verdict stream a
-millisecond decides. See ADR 0058 rule 2.
+`review-code` writes **exactly one** marker comment per PR in its namespace. That upsert is
+**`pipeline-cli verdict post`'s own behavior, not something a reviewer hand-rolls**: the verb
+scans the PR for **its own** prior `review-code:` marker keyed on `(namespace, head, runId)`
+and, if one exists, replaces that comment in place with the fresh verdict + fresh `@ <sha>`
+instead of appending a new one. A re-review of a new head overwrites the same record; the PR
+thread never accumulates a stale verdict stream a millisecond decides. See ADR 0058 rule 2.
+
+**Do not translate this into a raw `gh api` comment `PATCH`.** A hand-rolled patch of a verdict
+body is a marker hand-post — it skips `emissionDefect` and the post-write `verifyLanded` re-scan,
+which is exactly the emit-side bypass [The guarded emit path is
+MANDATORY](#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard)
+forbids (#2789 / #2816 / #2818). If a raw post is genuinely unavoidable, take that section's one
+escape hatch — `pipeline-cli leak-guard scan-comment` on the body **first**.
 
 ### The matcher contract: emphasis-tolerant + SHA-capturing (canonical shape)
 
@@ -2970,9 +2987,11 @@ review's `commit_id` for the staleness test; `review-doc` does not.)
 
 ### Upsert, not append (ADR 0058)
 
-`review-doc` writes **exactly one** `review-doc:` marker comment per PR: before posting it
-scans for **its own** prior `review-doc:` marker and `PATCH`es it with the fresh verdict +
-fresh `@ <sha>` rather than appending a new comment (ADR 0058 rule 2; same mechanism as §5).
+`review-doc` writes **exactly one** `review-doc:` marker comment per PR. As in §5 this is
+`pipeline-cli verdict post`'s own behavior — the verb finds **its own** prior `review-doc:`
+marker and replaces it in place with the fresh verdict + fresh `@ <sha>` rather than appending
+(ADR 0058 rule 2; same mechanism as §5, including §5's "never hand-roll this as a raw
+`gh api` `PATCH`").
 
 ### Field notes
 
@@ -3056,9 +3075,11 @@ comparable record type per lane keeps the lane resolvable.
 
 ### Upsert, not append (ADR 0058)
 
-`review-skill` writes **exactly one** `review-skill:` marker comment per PR: before posting
-it scans for **its own** prior `review-skill:` marker and `PATCH`es it with the fresh verdict
-+ fresh `@ <sha>` rather than appending (ADR 0058 rule 2; same mechanism as §5/§6).
+`review-skill` writes **exactly one** `review-skill:` marker comment per PR. As in §5 this is
+`pipeline-cli verdict post`'s own behavior — the verb finds **its own** prior `review-skill:`
+marker and replaces it in place with the fresh verdict + fresh `@ <sha>` rather than appending
+(ADR 0058 rule 2; same mechanism as §5/§6, including §5's "never hand-roll this as a raw
+`gh api` `PATCH`").
 
 ### The matcher contract — anchored, never cross-matching (canonical shape)
 
@@ -3160,8 +3181,7 @@ invariant is preserved; the reviewer marker contract is not widened).
 This is why the advisory form is namespace-uniform but binding-free: it keeps each gate's
 verdict **out** of `ship-it`'s merge path for the control plane while still leaving a
 visible, evidence-bearing verdict on the PR. (`review-code`'s historical binding-PASS +
-caveat shape is the one being retired in favor of this; the reconciliation is part of #424's
-build.)
+caveat shape was retired in favor of this; the reconciliation landed with #424.)
 
 **The first-line `@ <sha>` is omitted by design — the SHA is bound in the body's canonical
 `Reviewed-head` line, and both a delegated merge actor AND `ship-it`'s §CP enqueue confirm from
@@ -3243,9 +3263,11 @@ resolvable.
 
 ### Upsert, not append (ADR 0058)
 
-`review-design` writes **exactly one** `review-design:` marker comment per PR: before posting
-it scans for **its own** prior `review-design:` marker and `PATCH`es it with the fresh verdict
-+ fresh `@ <sha>` rather than appending (ADR 0058 rule 2; same mechanism as §5/§6/§6.5).
+`review-design` writes **exactly one** `review-design:` marker comment per PR. As in §5 this is
+`pipeline-cli verdict post`'s own behavior — the verb finds **its own** prior `review-design:`
+marker and replaces it in place with the fresh verdict + fresh `@ <sha>` rather than appending
+(ADR 0058 rule 2; same mechanism as §5/§6/§6.5, including §5's "never hand-roll this as a raw
+`gh api` `PATCH`").
 
 ### The matcher contract — anchored, never cross-matching (canonical shape)
 
@@ -3286,11 +3308,13 @@ actor (and `ship-it`'s ADR-0135 approval-aware enqueue) resolves the reviewed he
   dashes — but the `@ <sha>` is required.
 - **Two markers, two consumers.** `PASS @ <sha> — merge-ready` (every applicable prohibition
   passed or N/A, bound to that head) is the go-ahead signal `ship-it` acts on to merge a
-  **non-blocking** UI PR **iff `<sha>` is the current head** — once `review-design`'s
-  required-gate wiring lands as part of the ADR-0165 rollout (`ship-it` / `reviewer.md`
-  consumption). `FAIL @ <sha> — changes-requested` (≥1 objective prohibition violated) is read
-  by `write-code`'s fix round-trip as "my UI PR came back failed"; `ship-it` reads it as "do
-  not merge."
+  **non-blocking** UI PR **iff `<sha>` is the current head**. `review-design`'s required-gate
+  wiring **has landed** as part of the ADR-0165 rollout: `ship-it` runs the `UI_RE` probe and
+  refuses a `has-ui` PR with an empty `review-design` namespace, and §CLASS's
+  `pipeline-cli class-probe classify` folds the additive gate in.
+  `FAIL @ <sha> — changes-requested` (≥1 objective prohibition violated) is read by
+  `write-code`'s fix round-trip as "my UI PR came back failed"; `ship-it` reads it as "do not
+  merge."
 - **Advisory for the blocking set.** A UI PR in the §CP set gets the **canonical advisory
   line** (§6.6), not a PASS marker — its verdict does not authorize that merge; a
   `@kamp-us/control-plane` approval at head does, and `ship-it` enqueues on it (ADR 0135 amending

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -329,10 +329,11 @@ the surface kind (ADR 0072 §2).
 that **already exists and is open**; a skill assigns to one, never **creates** or restructures
 the set. Creating/curating milestones is a **roadmap (human / CPO) act**, deliberately *not*
 autonomous — fragmenting the set would destroy its single-source-of-truth value, so there is no
-autonomous "create-milestones" skill (ADR 0072 §3). A skill that finds no clear match to an
-existing open milestone still does not invent a home — it reaches for a **standing-lane label
-or a kill**, per the fallback rule immediately below (ADR 0202/0208). "Leave it unmilestoned"
-is **not** an outcome.
+autonomous "create-milestones" skill (ADR 0072 §3). **At the triage seam**, a skill that finds no
+clear match to an existing open milestone still does not invent a home — it reaches for a
+**standing-lane label or a kill**, per the fallback rule immediately below (ADR 0202/0208).
+"Leave it unmilestoned" is **not** a triage outcome. (`plan-epic`'s inheritance is a different
+act — children of an unmilestoned epic stay unmilestoned; see the write side below.)
 
 **Freeze-by-absence moved from an absence to a label (ADR 0208).** The signal ADR 0072 §4 carried
 — *this work is parked by design; don't force-fit it* — is not retired, but it no longer rides on
@@ -2835,8 +2836,10 @@ with no `@ <sha>` is a *pre-0058 legacy* shape and resolves to `unverified`, not
 **`pipeline-cli verdict post`'s own behavior, not something a reviewer hand-rolls**: the verb
 scans the PR for **its own** prior `review-code:` marker keyed on `(namespace, head, runId)`
 and, if one exists, replaces that comment in place with the fresh verdict + fresh `@ <sha>`
-instead of appending a new one. A re-review of a new head overwrites the same record; the PR
-thread never accumulates a stale verdict stream a millisecond decides. See ADR 0058 rule 2.
+instead of appending a new one. A re-review at a **new** head appends a fresh record and leaves
+the prior head's verdict standing (that is what the `head` dimension of the key buys — #4007,
+ADR 0213); a re-post at the **same** head upserts, so no head's slot ever accumulates a stale
+verdict stream a millisecond decides. See ADR 0058 rule 2.
 
 **Do not translate this into a raw `gh api` comment `PATCH`.** A hand-rolled patch of a verdict
 body is a marker hand-post — it skips `emissionDefect` and the post-write `verifyLanded` re-scan,


### PR DESCRIPTION
The shared intake contract is the one file 18 pipeline skills load as their source of truth, and it was giving opposite answers to five different questions. The sharpest one told reviewers to post a verdict using the exact raw `gh api` form another section declares FORBIDDEN. A contradiction here never fails loudly — each agent picks a side quietly, so two agents on two PRs follow opposite rules and both believe they complied.

This PR fixes exactly those five, in place. It deliberately does **not** restructure the file — that is epic #4407's question, and it is not built.

Fixes #4395

## The five, and how each was resolved

**1 — The contract instructed the emit form it forbids.** All four `### Upsert, not append` sections now express the upsert as `pipeline-cli verdict post`'s own behavior. The `review-code` site was the load-bearing one: it handed the reader a literal `gh api -X PATCH repos/$REPO/issues/comments/<id>` recipe. That call succeeds and the marker lands, having skipped `emissionDefect` and the post-write `verifyLanded` re-scan — a leaking or malformed marker lands looking clean. It now names the verb, states the upsert key, and points at the guarded-emit mandate's one escape hatch (`pipeline-cli leak-guard scan-comment` before a raw post). The other three sites described the same behavior without a command; they now name the verb and cite §5's "never hand-roll this as a raw `gh api` `PATCH`" rather than repeating the *why* four times.

*Evidence:* `packages/pipeline-cli/src/tools/verdict/github.ts` implements the upsert as a guarded in-place `PATCH` (`patchCommentArgs`, `_tag: "patched"`), re-runs `emissionDefect` on the **landed** body via `verifyLanded`, and keys the upsert on `(namespace, head, runId)`. So the described behavior and the verb's behavior are the same thing — the doc just had to stop expressing it as a reader-executable recipe.

**2 — A four-gate mandate with a three-gate read-back.** `verdict_readback_guard`'s header and `verdict_post_verify`'s `<gate>` set both scoped to three gates while `verdict_readback_guard` step (2) asserted four *inside the same function*. Both now scope to all four (`review-code | review-doc | review-skill | review-design`), as does the read-back section's own intro sentence, which listed three.

*Evidence:* `packages/pipeline-cli/src/tools/verdict/verdict-match.ts` — `export type VerdictGate = "code" | "doc" | "skill" | "design"` and `GATES = ["code", "doc", "skill", "design"]`. The code enumerates four; the doc now matches it.

**3 — A superseded milestone rule stated before the rule that kills it.** The "leaves the issue **unmilestoned**; it does not invent a home" sentence is replaced by the live ADR 0202/0208 rule (a standing-lane label or a kill), with a pointer to the paragraph 30 lines below that owns it. The "does not invent a home" half is preserved — that half never changed.

**4 — `doctor` in and out of §CP.** The `Deliberately OUT of §CP` bullet now carries the reconciling sentence: the `.sh` clause scopes to `.sh` **files** at any depth, this exclusion scopes to skill **dirs**, so `doctor/doctor.sh` is §CP and the rest of the `doctor` dir is not. Triage graded this a reader hazard rather than a flat contradiction (a reconciling clause existed, but in the tail of the *inclusion* bullet nine lines above), so this is a placement fix — the boundary itself is unchanged and still matches the live `CONTROL_PLANE_RE`.

**5 — Two stale in-flight references.** The `#424` sentence is past tense. The design-gate rollout clause no longer describes the wiring as future.

*Evidence for both:* a live REST read returns `#424` as `state: closed`, `state_reason: completed`, `closed_at: 2026-06-16T08:19:40Z`. And the design-gate wiring has landed in two independent places on `origin/main` — `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` runs the `UI_RE` probe and refuses a `has-ui` PR with an empty `review-design` namespace (`awaiting review-design (no review-design PASS)`), and `packages/pipeline-cli/src/tools/class-probe/class-probe.ts` folds the additive gate in (`DESIGN_NAMESPACE = "review-design"`). The same file asserted the wiring as future in one section and as done in §CLASS.

## Directions the issue did not specify

The issue specified a direction for all five, so nothing here was a coin flip. Where a fix had a shape choice, it was resolved toward what code/CI actually enforces and that grounding is cited inline above — specifically #2 (four gates, per `VerdictGate`) and #5's second half (landed, per `ship-it`'s probe and `class-probe`).

## The candidate sixth — split, not dropped

Filed as #4434. The contract's mandated comment-post form (`BODY="$(cat …)"` then `gh api … -f body="$BODY"`) is refused before execution by the isolation command verifier for a worktree-isolated agent. I reproduced that first-hand in this build — my first Bash call, a compound `||`/`&&` chain with a redirect, was refused as "too complex to verify that it stays inside the worktree." That is a second independent isolated observation on top of triage's.

It is split rather than fixed here because #4395's own acceptance criterion required establishing the **non-isolated**-agent behavior first, and that is still unverified. Both triage's observation and mine are isolated-only, so the scope of the gap (isolation-specific vs contract-wide) is unknown. #4434 records what is verified, what is not, and the shape of the likely fix.

## Not touched (flagged, not silently decided)

The `plan-epic` inheritance bullet still says children of an unmilestoned epic "stay unmilestoned." That answers a different question than finding #3 (inheritance, not triage's homing fallback), the issue did not enumerate it, and changing it would alter `plan-epic`'s behavior. Left as-is deliberately.

## Deviations

**Class: narrowed the suggested fix-shape.**
*Said:* the issue's non-binding suggestion for finding #1 was to reword the four upsert sections.
*Did:* reworded all four, but wrote the full *why* (guarded emit path, escape hatch, the #2789/#2816/#2818 class) only at the `review-code` site and made the other three cite §5.
*Why:* CLAUDE.md's "Comments earn their place or die" — a *why* stated once at its most load-bearing site, pointers elsewhere. Four near-identical paragraphs would rot in four places. The `review-code` site is the load-bearing one because it was the only one carrying an executable recipe.
*Disposition:* no action needed; all four ACs are still satisfiable by grep.

**Class: extended the change slightly past the literal AC.**
*Said:* AC 2 names `verdict_readback_guard` and `verdict_post_verify`.
*Did:* also fixed the read-back section's intro sentence, which listed the same three gates.
*Why:* AC 6 requires no remaining pair of passages giving opposite answers to the five questions; leaving that sentence at three gates would have failed it.
*Disposition:* no action needed.

**Class: left a sibling observation for a follow-up.**
*Said:* nothing.
*Did:* left the `plan-epic` inheritance "stay unmilestoned" bullet alone (see above).
*Why:* different question, not enumerated by the issue, and changing it changes `plan-epic` behavior — out of scope for a correctness-only fix.
*Disposition:* for the reviewer to judge; file a follow-up if it should move. **Resolved:** the reviewer ruled leaving it correct; repair round 1 supplies the complementary half here instead (scope + reconciling clause).

**(repair round 1) Class: narrowed the suggested fix-shape.**
*Said:* the verdict's "what to change" item 1 asked to fix the re-review sentence **and** reconcile the same paragraph's opener (`writes **exactly one** marker comment per PR in its namespace`) with ADR 0213's concurrent-run case.
*Did:* fixed only the booked sentence; left the opener — and the three sibling `### Upsert, not append` openers in §6/§6.5/§6.6 that defer to §5 for the mechanism — untouched.
*Why:* the verdict itself records the opener as predating this PR and "not booked separately". Rewording it forces the same reword through three sibling sections plus the §5 heading, which is the section-level rework epic #4407 owns — the opposite of a two-sentence repair.
*Disposition:* for the reviewer to judge; a follow-up issue is the right home if the opener should change.

**(repair round 1) Class: departed from the sanctioned push path.**
*Said:* `write-code` R3 pushes via `pipeline-cli verified-push`.
*Did:* the PR branch was already checked out in the original build lane's worktree, so this repair worktree could not check it out; the fix was committed on a detached HEAD and pushed by refspec (`HEAD:refs/heads/<branch>`, `--force-with-lease` pinned to the old head `a52956e7`). `verified-push` cannot express that — it derives the expected sha from the branch checked out in `--cwd` and resolves a detached HEAD to `UNKNOWN`.
*Why:* the alternative was mutating another agent's worktree.
*Disposition:* the push was verified the way `verified-push` verifies it — an independent read-back of the remote ref (`GET /repos/.../git/ref/heads/<branch>`) confirming it carries the new head, cross-checked against the PR's `head.sha`. Both read `643eb93f491a20fc7f13bdaddfd7886517cd7910`.

**(repair round 1) Class: moved the base.**
*Said:* nothing.
*Did:* rebased onto `origin/main` at `e227ec0d` (five PRs had landed since the branch was cut) before applying the fixes. Clean rebase, no conflicts.
*Why:* R2's freshen-the-base rule — surface a textual conflict at code-time, not merge-time. The PR carried no approval, so the head move invalidated nothing.
*Disposition:* no action needed; the re-review binds to the new head either way.

