### PR TITLE
refactor(review-gates): host the ADR-0079 fan-out reference outside any one gate (#4396)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -820,7 +820,7 @@ a missing tag as upstream-authored.
 
 This section **defines** the four fences; they are **enforced mechanically at the append site**
 by the `review-*` gates' shared
-[four-fences-enforced append procedure](review-code/SKILL.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
+[four-fences-enforced append procedure](shared/specialist-fan-out.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
 (ADR 0079) — fail-closed ACL self-check, round-K freeze-then-escalate, and append-only body
 reconstruction — so an invalid append is unrepresentable, not merely discouraged. The drain
 side of fence 4 (a frozen `ac:review-*` row escalating instead of looping) is enforced

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -230,7 +230,7 @@ not in the PR's self-description. Pull the change:
 ```
 
 This same loaded diff (and the review worktree below) is what the **specialist fan-out** runs
-over — see [Specialist fan-out + route-don't-grade](#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+over — see [Specialist fan-out + route-don't-grade](../shared/specialist-fan-out.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
 after this step; it reuses this context, it does not re-load the diff.
 
 ### Route a mis-classed PR away first (skills-only → review-skill)
@@ -549,183 +549,6 @@ held as control plane.
 
 ---
 
-## Specialist fan-out + route-don't-grade (ADR 0079) — the shared reference
-
-This is the **reference implementation** of the ADR
-[0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
-mechanism. The AC checklist (Step 3) catches what the issue *named*; it is blind to a real,
-in-scope defect the issue's AC never named — a swallowed fault, a missing invariant, an
-untested behavioral path that is genuinely part of "make this work" sails through a green gate
-because there is no open-ended correctness sweep (by design — focus over a nitpick firehose).
-The fan-out closes that blind spot by routing such a finding back into the **single converging
-mechanism the loop already drains — the AC checklist** — instead of onto a parallel
-severity/advisory track.
-
-**This section is the citable home for the other three gates.** `review-doc`, `review-skill`,
-and `review-plan` wire the *same* fan-out + route behavior into their own classes by citing
-this section (ADR 0079 §1–§2) — not by re-deriving the dimensions, the route decision, or the
-append mechanism. Read it as one logic with four call sites: only the *diff each gate already
-loads* and the *class it verifies* differ.
-
-### Fan out over the already-loaded diff (don't re-load it)
-
-Run the specialists **over the diff Step 2 already pulled** (and the review worktree it already
-materialized) — the fan-out adds no second checkout, no extra `gh`/worktree cost. The starting
-dimensions, per ADR 0079 §1 and **pinned in epic #493's Resolved questions**, are three —
-and each is a **checklist line within this single review pass, not a separately spawned agent**
-(epic #493's resolved split: a checklist line reuses the loaded context with zero added
-orchestration; a dimension *graduates* to a dedicated agent only on evidence it can't hold the
-rigor as a line, filed via `report` if/when that happens — the same seam-graduation discipline
-as ADR 0040's testing tiers):
-
-- **silent-failure** — a swallowed error, an empty `catch`, a dropped `Effect` failure channel,
-  a result whose error path is discarded — a fault the diff makes *unobservable* at runtime.
-- **type-design** — a representable invalid state, a widened type that admits what the domain
-  forbids, an invariant the types stop enforcing (the "make invalid states unrepresentable"
-  bar this repo holds).
-- **test-gap** — a behavioral path the diff adds or changes that no test exercises — coverage
-  the AC checklist didn't name but "make this work" implies.
-
-Each dimension produces zero or more **findings**: a concrete defect with its diff site. The
-fan-out **feeds** findings into the route step below; it does **not** itself emit a verdict.
-
-### Route, don't grade — a finding is a binary in/out-of-scope decision
-
-A finding is **routed, not graded** (ADR 0079 §2). There is **no severity tier and no
-confidence score** — the decision is the single binary the `plan-epic` story-trace test already
-draws:
-
-- **In-scope** — the finding **traces to the linked issue's stated goal / user story**, the
-  **same trace-to-stated-goal test `plan-epic` enforces** for story coverage (ADR
-  [0046](https://github.com/kamp-us/phoenix/blob/main/.decisions/0046-plan-epic-prd-grade-plans.md)).
-  Route it by **appending a new acceptance criterion** to the linked issue, using the
-  **reviewer-append surface defined in
-  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2** — its exact checkbox
-  shape, its canonical provenance tag (`<!-- ac:review-code pr:#<PR> round:K -->`), and its four
-  fences (append-only · in-scope-only · ACL-gated/fail-closed · frozen-after-round-K).
-  **§2 is the single source — cite it; do not restate the tag fields or the fences here**, so
-  this reference and the contract cannot drift.
-- **Out-of-scope** — the finding is real but does **not** trace to *this* issue's stated goal
-  (a tangential defect, an adjacent refactor, a pre-existing bug the diff merely surfaces).
-  File it via [`report`](../report/SKILL.md) as a fresh `status:needs-triage` issue; it
-  re-enters the pipeline at intake on its own merits. **The current PR is not blocked by it** —
-  routing a tangential finding to `report` is exactly what keeps the AC list finite and the
-  bounded repair loop converging (§2 fence 2).
-
-### What the append does (and does not) change in *this* review
-
-The fan-out + route is **additive to the existing AC-verification verdict — it does not replace
-or weaken it.** The append is the route's *output*, not a new gate:
-
-- The **conjunctive AC verdict (Step 3), the SHA-bound `review-code:` marker (§VERDICT), and the
-  single-merge-authority invariant are unchanged.** An appended criterion does **not** change
-  *this* PR's pass/fail computation beyond the existing rules: it lands as a new unchecked
-  `[ ]` row on the issue, so on the *next* review cycle it is an ordinary criterion the
-  conjunctive verdict already covers (an unmet new row is a `[FAIL]` like any other). It enters
-  the **next** cycle's work-list; `write-code`'s repair round drains it like any other `[FAIL]`
-  row (the existing converging loop), and the next review verifies it.
-- **Append the AC before composing the Step 3 / Step 4 verdict**, so the verdict you post
-  already reflects the appended row (it shows as a fresh `[FAIL]` in the table, telling
-  `write-code` exactly what to drain next round). The append is gated by §2 fence 3 (only a
-  `write+` reviewer's append counts, fail-closed — the same ACL author-gate ADR
-  [0055](https://github.com/kamp-us/phoenix/blob/main/.decisions/0055-acl-sourced-review-authz.md)
-  applies to the verdict marker) and fence 4 (an append in/after round K = N = 3 escalates to a
-  human instead of looping — §2's freeze, bound to `write-code`'s existing N=3 repair cap).
-- **Out-of-scope findings never touch the AC list or this PR's verdict** — they are `report`
-  residue only.
-
-### Performing the append — the four fences, enforced at this site (ADR 0079)
-
-§2 **defines** the four fences; this is where they are **enforced**, so an invalid append is
-unrepresentable rather than merely discouraged. §2 stays the single source of *what* each fence
-is — cite it, don't restate the definitions; the steps below are *how* the append step obeys
-them. The other three gates run **this same procedure** (one logic, four call sites). Append by
-**reconstructing the issue body** — read it, gate, append the one new row, write it back — never
-by a blind edit:
-
-> **This block also did NOT move into [`scripts/`](scripts/) (#4451), for a different reason.**
-> [PR #4440](https://github.com/kamp-us/phoenix/pull/4440) relocates this whole
-> `## Specialist fan-out + route-don't-grade` section — this fence included — out of every gate and
-> into `../shared/specialist-fan-out.md` (#4396). Extracting it here would relocate the same lines a
-> second, conflicting way, so it stays put and whichever change lands first sets the other's baseline.
-> The remainder is tracked on [#4451](https://github.com/kamp-us/phoenix/issues/4451).
-
-```bash
-# the §2 in-scope-only fence (fence 2) gates whether you may append AT ALL:
-# only an in-scope finding (traces to the issue's stated goal — Route, don't grade above)
-# reaches here. A finding that fails the trace test was already routed to `report`; it must
-# NOT arrive at this append step. If it did, route it to `report` and stop — never append it.
-
-# ── Fence 3: ACL-gated, FAILS CLOSED ──────────────────────────────────────────────────────
-# resolve your OWN authority at the GitHub ACL — the same write+ floor ADR 0055 applies to
-# verdict-marker authority — BEFORE writing anything. No checked-in allowlist; the repo ACL is
-# the trust root. Any non-write+/lookup-failure result fails closed: skip the append, route the
-# finding to `report` instead (the PR is not blocked — it still gets your normal verdict).
-ME="$(gh api user --jq .login)"
-PERM="$(gh api "repos/$REPO/collaborators/$ME/permission" --jq .permission 2>/dev/null)"
-case "$PERM" in
-  admin|maintain|write) : ;;                       # authorized — proceed
-  *) echo "below write+ floor (or ACL lookup failed) — fail closed: do NOT append, route to report"; exit 0 ;;
-esac
-
-# ── Fence 4: frozen-after-round-K (K = N = 3) ─────────────────────────────────────────────
-# resolve the round K you would tag this append with — the §5/Bounding round-cluster index for
-# THIS PR (the same count write-code's cap uses). An append in/after the final repair round has
-# no round left to drain-and-re-verify it within the bound, so it ESCALATES to a human instead
-# of appending-and-looping (the append-side of write-code's drain-side freeze — §2 fence 4).
-ROUND_K=<the §5/Bounding round-cluster index for this PR>   # 1-based; a first review is round 1
-if [ "$ROUND_K" -ge 3 ]; then
-  # frozen: append-rate must not outrun fix-rate. Escalate, never append — name the finding,
-  # hand the PR to a human, surface for re-triage (mirrors write-code's N=3 escalation path).
-  gh api repos/$REPO/issues/$ISSUE/comments -f body="$(cat <<EOF
-### Append escalation — in-scope finding raised at/after the final repair round (round $ROUND_K)
-
-A reviewer specialist surfaced an in-scope finding, but it arrives in/after \`write-code\`'s
-final repair round (K = N = 3), so there is no round left to drain-and-re-verify a fresh AC
-within the bound. Per ADR 0079 §2 fence 4 the append is **frozen** — escalating to a human
-instead of appending-and-looping:
-
-- <finding> — <the in-scope defect; what an AC would have required>
-
-Needs a human decision (accept as-is, extend the AC's life by a fresh triage, or drop it).
-EOF
-)"
-  gh api -X POST repos/$REPO/issues/$ISSUE/labels -f "labels[]=status:needs-triage"
-  exit 0   # frozen → escalated, NOT appended
-fi
-
-# ── Fence 1: append-only — add the one new row, never edit/remove a pre-existing one ───────
-# read the CURRENT body, append exactly one §2-shaped row (provenance-tagged), write it back.
-# Reconstructing the body this way makes removal/edit unrepresentable: every pre-existing line
-# is carried through byte-for-byte; only a trailing criterion is added.
-BODY="$(gh api repos/$REPO/issues/$ISSUE --jq .body)"
-NEW_AC="- [ ] <criterion — observable, checkable from the outside> <!-- ac:review-code pr:#$PR round:$ROUND_K -->"
-# append the row under the ### Acceptance criteria list; do not touch any existing row
-UPDATED="$(printf '%s\n%s\n' "$BODY" "$NEW_AC")"   # illustrative — insert under the AC heading, preserving every prior line
-# fail-closed integrity guard: refuse to write back a body that DROPPED or ALTERED any prior
-# line — append-only means every prior line survives verbatim in the new body. If a pre-existing
-# line would change, abort (never write a body that lost a criterion — the gate-weakening
-# catastrophe fence 1 forbids):
-diff <(printf '%s' "$BODY") <(printf '%s' "$UPDATED") | grep -qE '^< ' && { echo "append-only violation: a pre-existing line would change — ABORT, do not write"; exit 1; }
-gh api -X PATCH repos/$REPO/issues/$ISSUE -f body="$UPDATED"
-```
-
-The append is **append-only by construction** (fence 1): the body is rebuilt from the existing
-one with a single row added, and a `diff` guard refuses any write that would drop or mutate a
-prior line — so a reviewer flow *cannot* edit or remove an existing AC (the catastrophe
-`review-skill`'s gate-invariant check exists to catch). It is **in-scope-only** (fence 2): only
-a finding that passed the trace-to-stated-goal test (Route, don't grade) reaches this step; a
-tangential one was routed to `report` and never arrives. It is **ACL-gated and fails closed**
-(fence 3): a below-`write+` author — or any ACL lookup failure — skips the append entirely, so
-an unauthorized identity's "append" never lands on the issue and never counts toward the gate.
-And it is **frozen after round K = N = 3** (fence 4): an in-scope finding raised in/after the
-final repair round escalates to a human rather than appending-and-looping, so append-rate stays
-bounded by fix-rate. None of this changes the verdict computation — the conjunctive AC verdict,
-the SHA-bound marker, the ACL author-gate on *verdicts*, the control-plane boundary, and
-single-merge-authority are all untouched; the enforcement only makes the *append* safer.
-
----
-
 ## Step 3 — Verify one criterion at a time
 
 **Skip this step when `ISSUE` is unset** (the conversation-authored `.glossary/**` no-link
@@ -779,7 +602,7 @@ clause does.
 
 **Run the specialist fan-out + route step before you compose the verdict.** Having verified
 the named criteria above, route each specialist finding per
-[Specialist fan-out + route-don't-grade](#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference):
+[Specialist fan-out + route-don't-grade](../shared/specialist-fan-out.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference):
 an in-scope finding appends a new AC to the linked issue (§2 surface), so it shows in this
 verdict's table as a fresh `[FAIL]` row for `write-code` to drain next cycle; an out-of-scope
 finding goes to `report` and does **not** affect this verdict. The conjunctive computation is
@@ -944,7 +767,7 @@ the skip's clothes:
   case). Emit the new surface you found and that the glossary went untouched. The remedy is in
   scope by construction (name the new concept in `TERMS.md` in this PR), so it may also be routed
   as an **appended acceptance criterion** via the §2 reviewer-append surface (per the
-  [Specialist fan-out + route-don't-grade](#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+  [Specialist fan-out + route-don't-grade](../shared/specialist-fan-out.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
   procedure) — it traces to the issue's own "ship this surface" goal — landing it as a fresh
   `[FAIL]` row `write-code` drains next round. Either way the conjunctive verdict reflects it.
 - **New surface present, `.glossary/TERMS.md` touched ⇒ PASS** for this facet — the surface and its

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -781,9 +781,10 @@ contradicts, a load-bearing cross-reference left dangling, an enumerated case th
 silently omits. This gate fans out doc-class specialists to surface such a finding and
 **routes** it back into the converging AC work-list, exactly as `review-code` does for code.
 
-**This is one logic with four call sites — `review-code` is its citable home.** The fan-out
+**This is one logic with four call sites — [`../shared/specialist-fan-out.md`](../shared/specialist-fan-out.md)
+is its citable home.** The fan-out
 mechanism, the binary in/out-of-scope route decision, and the append surface are defined once
-in [`review-code`'s shared reference](../review-code/SKILL.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+in [the shared reference](../shared/specialist-fan-out.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
 (ADR [0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
 §1–§2) and the append shape + provenance tag + four fences in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2. **Cite them; do not
@@ -809,7 +810,7 @@ feed the route step; the fan-out itself emits no verdict.
   same trace test the reference and `plan-epic` use) → **append a new acceptance criterion**
   to the linked issue via the **§2 reviewer-append surface**, provenance-tagged
   `<!-- ac:review-doc pr:#<PR> round:K -->`. Perform the append by the reference's
-  [four-fences-enforced procedure](../review-code/SKILL.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
+  [four-fences-enforced procedure](../shared/specialist-fan-out.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
   — fail-closed ACL self-check, round-K freeze, append-only body reconstruction — so every fence
   is enforced at the site, not merely cited. It lands as a fresh `[ ]` row the next
   `write-code` repair round drains and the next review verifies; it shows in *this* verdict's

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -309,7 +309,7 @@ If the soft-advisor finds nothing, say so (`No advisory caveats — the plan rea
 
 The soft-advisor's reads are the plan-layer call site of the **specialist fan-out +
 route-don't-grade** mechanism — defined once in
-[`review-code`'s shared reference](../review-code/SKILL.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+[the shared reference](../shared/specialist-fan-out.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
 (ADR [0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
 §1–§2), with the append shape + provenance tag + four fences in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2. **Cite them; do not
@@ -337,7 +337,7 @@ Route each soft finding:
   via the §2 surface (tag `ac:review-plan`), *and* keep the prose caveat. Subject to all four
   §2 fences (append-only · in-scope-only · ACL-gated/fail-closed · frozen-after-round-K),
   enforced by the reference's
-  [four-fences-enforced procedure](../review-code/SKILL.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
+  [four-fences-enforced procedure](../shared/specialist-fan-out.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
   — fail-closed ACL self-check, round-K freeze, append-only body reconstruction — with the append
   target being the **child issue** (`$ISSUE` = the child), never a PR.
 - **Out-of-scope** — a real defect that doesn't trace to any child's story (a gap the brief

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -518,9 +518,10 @@ work-list, exactly as `review-code` does for code. **The fan-out is additive —
 *additional* findings into the route step; the four-check rigor checklist (Step 4), including
 gate-invariant-preservation, is preserved in full, not replaced.**
 
-**This is one logic with four call sites — `review-code` is its citable home.** The fan-out
+**This is one logic with four call sites — [`../shared/specialist-fan-out.md`](../shared/specialist-fan-out.md)
+is its citable home.** The fan-out
 mechanism, the binary in/out-of-scope route decision, and the append surface are defined once
-in [`review-code`'s shared reference](../review-code/SKILL.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+in [the shared reference](../shared/specialist-fan-out.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
 (ADR [0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
 §1–§2) and the append shape + provenance tag + four fences in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2. **Cite them; do not
@@ -547,7 +548,7 @@ verdict.
   same trace test the reference and `plan-epic` use) → **append a new acceptance criterion**
   to the linked issue via the **§2 reviewer-append surface**, provenance-tagged
   `<!-- ac:review-skill pr:#<PR> round:K -->`. Perform the append by the reference's
-  [four-fences-enforced procedure](../review-code/SKILL.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
+  [four-fences-enforced procedure](../shared/specialist-fan-out.md#performing-the-append--the-four-fences-enforced-at-this-site-adr-0079)
   — fail-closed ACL self-check, round-K freeze, append-only body reconstruction — so every fence
   is enforced at the site, not merely cited. It lands as a fresh `[ ]` row the next
   `write-code` repair round drains and the next review verifies; it shows in *this* verdict's

--- a/claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
+++ b/claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
@@ -1,0 +1,170 @@
+## Specialist fan-out + route-don't-grade (ADR 0079) — the shared reference
+
+This is the **reference implementation** of the ADR
+[0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
+mechanism. The AC checklist (Step 3) catches what the issue *named*; it is blind to a real,
+in-scope defect the issue's AC never named — a swallowed fault, a missing invariant, an
+untested behavioral path that is genuinely part of "make this work" sails through a green gate
+because there is no open-ended correctness sweep (by design — focus over a nitpick firehose).
+The fan-out closes that blind spot by routing such a finding back into the **single converging
+mechanism the loop already drains — the AC checklist** — instead of onto a parallel
+severity/advisory track.
+
+**This section is the citable home for the other three gates.** `review-doc`, `review-skill`,
+and `review-plan` wire the *same* fan-out + route behavior into their own classes by citing
+this section (ADR 0079 §1–§2) — not by re-deriving the dimensions, the route decision, or the
+append mechanism. Read it as one logic with four call sites: only the *diff each gate already
+loads* and the *class it verifies* differ.
+
+### Fan out over the already-loaded diff (don't re-load it)
+
+Run the specialists **over the diff Step 2 already pulled** (and the review worktree it already
+materialized) — the fan-out adds no second checkout, no extra `gh`/worktree cost. The starting
+dimensions, per ADR 0079 §1 and **pinned in epic #493's Resolved questions**, are three —
+and each is a **checklist line within this single review pass, not a separately spawned agent**
+(epic #493's resolved split: a checklist line reuses the loaded context with zero added
+orchestration; a dimension *graduates* to a dedicated agent only on evidence it can't hold the
+rigor as a line, filed via `report` if/when that happens — the same seam-graduation discipline
+as ADR 0040's testing tiers):
+
+- **silent-failure** — a swallowed error, an empty `catch`, a dropped `Effect` failure channel,
+  a result whose error path is discarded — a fault the diff makes *unobservable* at runtime.
+- **type-design** — a representable invalid state, a widened type that admits what the domain
+  forbids, an invariant the types stop enforcing (the "make invalid states unrepresentable"
+  bar this repo holds).
+- **test-gap** — a behavioral path the diff adds or changes that no test exercises — coverage
+  the AC checklist didn't name but "make this work" implies.
+
+Each dimension produces zero or more **findings**: a concrete defect with its diff site. The
+fan-out **feeds** findings into the route step below; it does **not** itself emit a verdict.
+
+### Route, don't grade — a finding is a binary in/out-of-scope decision
+
+A finding is **routed, not graded** (ADR 0079 §2). There is **no severity tier and no
+confidence score** — the decision is the single binary the `plan-epic` story-trace test already
+draws:
+
+- **In-scope** — the finding **traces to the linked issue's stated goal / user story**, the
+  **same trace-to-stated-goal test `plan-epic` enforces** for story coverage (ADR
+  [0046](https://github.com/kamp-us/phoenix/blob/main/.decisions/0046-plan-epic-prd-grade-plans.md)).
+  Route it by **appending a new acceptance criterion** to the linked issue, using the
+  **reviewer-append surface defined in
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2** — its exact checkbox
+  shape, its canonical provenance tag (`<!-- ac:review-code pr:#<PR> round:K -->`), and its four
+  fences (append-only · in-scope-only · ACL-gated/fail-closed · frozen-after-round-K).
+  **§2 is the single source — cite it; do not restate the tag fields or the fences here**, so
+  this reference and the contract cannot drift.
+- **Out-of-scope** — the finding is real but does **not** trace to *this* issue's stated goal
+  (a tangential defect, an adjacent refactor, a pre-existing bug the diff merely surfaces).
+  File it via [`report`](../report/SKILL.md) as a fresh `status:needs-triage` issue; it
+  re-enters the pipeline at intake on its own merits. **The current PR is not blocked by it** —
+  routing a tangential finding to `report` is exactly what keeps the AC list finite and the
+  bounded repair loop converging (§2 fence 2).
+
+### What the append does (and does not) change in *this* review
+
+The fan-out + route is **additive to the existing AC-verification verdict — it does not replace
+or weaken it.** The append is the route's *output*, not a new gate:
+
+- The **conjunctive AC verdict (Step 3), the SHA-bound `review-code:` marker (§VERDICT), and the
+  single-merge-authority invariant are unchanged.** An appended criterion does **not** change
+  *this* PR's pass/fail computation beyond the existing rules: it lands as a new unchecked
+  `[ ]` row on the issue, so on the *next* review cycle it is an ordinary criterion the
+  conjunctive verdict already covers (an unmet new row is a `[FAIL]` like any other). It enters
+  the **next** cycle's work-list; `write-code`'s repair round drains it like any other `[FAIL]`
+  row (the existing converging loop), and the next review verifies it.
+- **Append the AC before composing the Step 3 / Step 4 verdict**, so the verdict you post
+  already reflects the appended row (it shows as a fresh `[FAIL]` in the table, telling
+  `write-code` exactly what to drain next round). The append is gated by §2 fence 3 (only a
+  `write+` reviewer's append counts, fail-closed — the same ACL author-gate ADR
+  [0055](https://github.com/kamp-us/phoenix/blob/main/.decisions/0055-acl-sourced-review-authz.md)
+  applies to the verdict marker) and fence 4 (an append in/after round K = N = 3 escalates to a
+  human instead of looping — §2's freeze, bound to `write-code`'s existing N=3 repair cap).
+- **Out-of-scope findings never touch the AC list or this PR's verdict** — they are `report`
+  residue only.
+
+### Performing the append — the four fences, enforced at this site (ADR 0079)
+
+§2 **defines** the four fences; this is where they are **enforced**, so an invalid append is
+unrepresentable rather than merely discouraged. §2 stays the single source of *what* each fence
+is — cite it, don't restate the definitions; the steps below are *how* the append step obeys
+them. The other three gates run **this same procedure** (one logic, four call sites). Append by
+**reconstructing the issue body** — read it, gate, append the one new row, write it back — never
+by a blind edit:
+
+```bash
+# the §2 in-scope-only fence (fence 2) gates whether you may append AT ALL:
+# only an in-scope finding (traces to the issue's stated goal — Route, don't grade above)
+# reaches here. A finding that fails the trace test was already routed to `report`; it must
+# NOT arrive at this append step. If it did, route it to `report` and stop — never append it.
+
+# ── Fence 3: ACL-gated, FAILS CLOSED ──────────────────────────────────────────────────────
+# resolve your OWN authority at the GitHub ACL — the same write+ floor ADR 0055 applies to
+# verdict-marker authority — BEFORE writing anything. No checked-in allowlist; the repo ACL is
+# the trust root. Any non-write+/lookup-failure result fails closed: skip the append, route the
+# finding to `report` instead (the PR is not blocked — it still gets your normal verdict).
+ME="$(gh api user --jq .login)"
+PERM="$(gh api "repos/$REPO/collaborators/$ME/permission" --jq .permission 2>/dev/null)"
+case "$PERM" in
+  admin|maintain|write) : ;;                       # authorized — proceed
+  *) echo "below write+ floor (or ACL lookup failed) — fail closed: do NOT append, route to report"; exit 0 ;;
+esac
+
+# ── Fence 4: frozen-after-round-K (K = N = 3) ─────────────────────────────────────────────
+# resolve the round K you would tag this append with — the §5/Bounding round-cluster index for
+# THIS PR (the same count write-code's cap uses). An append in/after the final repair round has
+# no round left to drain-and-re-verify it within the bound, so it ESCALATES to a human instead
+# of appending-and-looping (the append-side of write-code's drain-side freeze — §2 fence 4).
+ROUND_K=<the §5/Bounding round-cluster index for this PR>   # 1-based; a first review is round 1
+if [ "$ROUND_K" -ge 3 ]; then
+  # frozen: append-rate must not outrun fix-rate. Escalate, never append — name the finding,
+  # hand the PR to a human, surface for re-triage (mirrors write-code's N=3 escalation path).
+  gh api repos/$REPO/issues/$ISSUE/comments -f body="$(cat <<EOF
+### Append escalation — in-scope finding raised at/after the final repair round (round $ROUND_K)
+
+A reviewer specialist surfaced an in-scope finding, but it arrives in/after \`write-code\`'s
+final repair round (K = N = 3), so there is no round left to drain-and-re-verify a fresh AC
+within the bound. Per ADR 0079 §2 fence 4 the append is **frozen** — escalating to a human
+instead of appending-and-looping:
+
+- <finding> — <the in-scope defect; what an AC would have required>
+
+Needs a human decision (accept as-is, extend the AC's life by a fresh triage, or drop it).
+EOF
+)"
+  gh api -X POST repos/$REPO/issues/$ISSUE/labels -f "labels[]=status:needs-triage"
+  exit 0   # frozen → escalated, NOT appended
+fi
+
+# ── Fence 1: append-only — add the one new row, never edit/remove a pre-existing one ───────
+# read the CURRENT body, append exactly one §2-shaped row (provenance-tagged), write it back.
+# Reconstructing the body this way makes removal/edit unrepresentable: every pre-existing line
+# is carried through byte-for-byte; only a trailing criterion is added.
+BODY="$(gh api repos/$REPO/issues/$ISSUE --jq .body)"
+NEW_AC="- [ ] <criterion — observable, checkable from the outside> <!-- ac:review-code pr:#$PR round:$ROUND_K -->"
+# append the row under the ### Acceptance criteria list; do not touch any existing row
+UPDATED="$(printf '%s\n%s\n' "$BODY" "$NEW_AC")"   # illustrative — insert under the AC heading, preserving every prior line
+# fail-closed integrity guard: refuse to write back a body that DROPPED or ALTERED any prior
+# line — append-only means every prior line survives verbatim in the new body. If a pre-existing
+# line would change, abort (never write a body that lost a criterion — the gate-weakening
+# catastrophe fence 1 forbids):
+diff <(printf '%s' "$BODY") <(printf '%s' "$UPDATED") | grep -qE '^< ' && { echo "append-only violation: a pre-existing line would change — ABORT, do not write"; exit 1; }
+gh api -X PATCH repos/$REPO/issues/$ISSUE -f body="$UPDATED"
+```
+
+The append is **append-only by construction** (fence 1): the body is rebuilt from the existing
+one with a single row added, and a `diff` guard refuses any write that would drop or mutate a
+prior line — so a reviewer flow *cannot* edit or remove an existing AC (the catastrophe
+`review-skill`'s gate-invariant check exists to catch). It is **in-scope-only** (fence 2): only
+a finding that passed the trace-to-stated-goal test (Route, don't grade) reaches this step; a
+tangential one was routed to `report` and never arrives. It is **ACL-gated and fails closed**
+(fence 3): a below-`write+` author — or any ACL lookup failure — skips the append entirely, so
+an unauthorized identity's "append" never lands on the issue and never counts toward the gate.
+And it is **frozen after round K = N = 3** (fence 4): an in-scope finding raised in/after the
+final repair round escalates to a human rather than appending-and-looping, so append-rate stays
+bounded by fix-rate. None of this changes the verdict computation — the conjunctive AC verdict,
+the SHA-bound marker, the ACL author-gate on *verdicts*, the control-plane boundary, and
+single-merge-authority are all untouched; the enforcement only makes the *append* safer.
+
+---
+

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -31,6 +31,19 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/report/lib/helper.sh")).toBe(true);
 	});
 
+	it("classifies gate-shared text under skills/shared/ as control-plane (#4396)", () => {
+		// Text a gate is instructed to FOLLOW is gate-critical wherever it is hosted, so extracting it
+		// out of a consumer's SKILL.md to cut per-run load cost must not buy that saving by dropping it
+		// out of §CP. The whole-tree skills clause (#4446) already covers it; this pins that, so a
+		// future re-narrowing of the clause reds here instead of silently un-gating the shared text.
+		expect(
+			isControlPlane("claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md"),
+		).toBe(true);
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/shared/anything-else.md")).toBe(
+			true,
+		);
+	});
+
 	it("classifies the lint/GritQL governance config as control-plane (ADR 0193)", () => {
 		// An ungated path to weaken a lint rule is a guard-relaxing vector — same class as ADR 0187's
 		// enforcement-surface test. The root biome config and every GritQL plugin rule are §CP.


### PR DESCRIPTION
Fixes #4396

## What this does

Tranche 1 only: the ADR-0079 fan-out section move plus the 10 link retargets. Nothing else.

`## Specialist fan-out + route-don't-grade (ADR 0079) — the shared reference`, including the `### Performing the append — the four fences` subsection, moves out of `review-code/SKILL.md` into a gate-shared file:

```
claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
```

`review-code/SKILL.md` drops from 1,675 to 1,498 lines. No gate loads a consumer's SKILL.md to read the mechanism it is instructed to follow.

**Why this depth.** `skills/shared/` sits at exactly the depth of a skill dir, so every relative link *inside* the moved text (`../gh-issue-intake-formats.md`, `../report/SKILL.md`) still resolves unchanged. That is what lets the move be byte-for-byte rather than "byte-for-byte except the links".

## No boundary change — this is issue #4396's AC4 option 1

Round 1 of this PR took the issue's **option 2** (extend `CONTROL_PLANE_RE` to reach `skills/shared/`). That is no longer correct and has been dropped in full. After the founder ruling on #4446 — landed by #4462, merged after this PR's original base — the live regex carries a whole-tree skills branch, `^claude-plugins/kampus-pipeline/skills/`, so the destination is **already** §CP with no boundary edit at all. AC4 offers "option 1: land at a path the live regex already matches"; after #4462 this path *is* option 1.

Demonstrated against the live boundary, not assumed:

```
$ echo "claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md" \
    | pipeline-cli cp-classify classify --repo kamp-us/phoenix
cp-classify: control-plane [path-match] — claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
  matches the live CONTROL_PLANE_RE. BLOCKING (human merge).
control-plane
```

So this PR now touches **zero** boundary surfaces. Confirmed on the final diff against `main` @ `d325ec5a`:

```
$ git diff origin/main HEAD -- .github/CODEOWNERS \
    packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts \
    packages/pipeline-cli/src/tools/codeowners-cp/ | wc -l
0
$ git diff origin/main HEAD -- claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md \
    | grep -c "CONTROL_PLANE_RE="
0
```

Carrying the round-1 regex over `main` would have *narrowed* the boundary back to the pre-ruling enumeration, un-gating seven skill directories (`heal-ci/`, `doctor/`, `wayfinder/`, `what-shipped/`, `author-skill/`, `canon/`, `campaign/`) under a ruleset that pairs `required_approving_review_count: 0` with `require_code_owner_review: true` and no `*` catch-all — i.e. re-opening the zero-approval hole #4462 closed. That half is gone.

The one code file that stays is the **test**: `control-plane-paths.unit.test.ts` pins that gate-shared text under `skills/shared/` classifies §CP. It passes against `main`'s whole-tree clause and is the tripwire if that clause is ever re-narrowed.

## Byte-move proof, re-taken from current `main`

The round-1 move was byte-identical to the section as it stood at the **stale base** `a255392d`. `main` has since drifted, so the move was re-extracted from `main` @ `d325ec5a`:

```
$ git show d325ec5a:claude-plugins/kampus-pipeline/skills/review-code/SKILL.md \
    | sed -n '552,728p' | shasum -a 256
e8009227e91ab5e621f00941ac730eca74ba41a2b82cf7204dae438c38218a92     <- pre-move span (177 lines)

$ shasum -a 256 claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
053a410c7247c7e2e5ac32238269a6960a1c148e1591019d101bc0e6a0bab45f     <- post-move file (170 lines)

$ git show d325ec5a:.../review-code/SKILL.md | sed -n '552,728p' | sed '95,101d' \
    | diff - claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
(empty — exit 0)
```

The 177 → 170 delta is exactly the seven-line #4451 coordination note (span lines 95–101), dropped deliberately — see Deviations. Re-taking from `main` also picks up the `(§5)` → `(§VERDICT)` contract-reference correction that the stale bytes would have reverted.

## Acceptance criteria

- [x] **The section exists in exactly one place, not inside a consumer gate's SKILL.md.** It is `skills/shared/specialist-fan-out.md`, which carries no `SKILL.md` and is therefore not a skill — `validate-skills.sh` globs `*/SKILL.md` and reports `OK — 30 skills valid`, unchanged.
- [x] **Byte-identical, verified by diff** — the three-command proof above, taken against current `main` rather than the stale base. One disclosed departure (the #4451 note).
- [x] **All 10 link sites retargeted; no orphaned anchor remains.** `review-code` (3 intra-file, now cross-file), `review-doc` (2), `review-plan` (2), `review-skill` (2), `gh-issue-intake-formats.md` (1). A grep across `claude-plugins/`, `.decisions/`, `.patterns/` for `review-code/SKILL.md#specialist-fan-out`, `review-code/SKILL.md#performing-the-append`, and the two bare intra-file anchors returns **zero hits**. Both headings are unchanged, so both anchor slugs are preserved verbatim; only the file half of each link moved.
- [x] **The new path is inside the live `CONTROL_PLANE_RE`** — the `cp-classify` run above, against the regex re-resolved from `origin/main`. No boundary extension was needed, so the option-2 clause of this criterion does not apply.
- [x] **No gate semantics change.** No dimension, route rule, fence, verdict marker, or acceptance-criteria contract is reworded, added, or dropped. The only prose touched outside the retargeted links is the sentence in `review-doc`/`review-skill` naming `review-code` as the home — false after the move.
- [x] **The ~2,500-line scaffolding consolidation is not in this PR.** Tranche 2 stays with #4407 / #1929.

## Files changed

| File | Change |
| --- | --- |
| `claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md` | **new** — the 170 moved lines |
| `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md` | −177 (section removed) + 3 link retargets |
| `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md` | 2 link retargets + the home sentence |
| `claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md` | 2 link retargets + the home sentence |
| `claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md` | 2 link retargets |
| `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` | 1 link retarget |
| `packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts` | new test: the shared path classifies §CP |

## Verification run locally at this head

- `pnpm vitest run src/tools/control-plane-paths` (in `packages/pipeline-cli`) — 25 passed / 2 files
- `pnpm typecheck` — clean (pre-push hook, 27 packages)
- `pnpm lint:worktree` — clean
- `lychee --offline --root-dir . --files-from <git ls-files '*.md'>` — 457 files in scope, **0 errors** (the `check docs have no dead internal links` job is not branch-protection-required, so it was run explicitly here — this PR retargets 10 internal links)
- `validate-gate-path-drift.sh` — `OK — 34 checks`
- `validate-skills.sh` — `OK — 30 skills valid`
- `pipeline-cli codeowners-cp check` — `all 22 §CP path(s) covered`

## §CP — this PR banks

Five §CP skill/contract files are touched (the four `review-*` SKILLs plus the formats contract), plus the `control-plane-paths` test. It needs a `@kamp-us/control-plane` approval and does not auto-merge. It no longer touches `.github/CODEOWNERS` or the boundary const.

## Deviations

- **(repair round 1) The 7-line #4451 coordination note is not carried into the moved file.** `main`'s copy of the section carries a block at `review-code/SKILL.md:646–651` saying this fence "did NOT move into `scripts/` (#4451) … whichever change lands first sets the other's baseline". Dropping it is a deliberate departure from strict byte-identity (AC2), for two reasons: (a) the condition it anticipates is *this PR landing*, so once the section lives in `shared/` the note describes a decision that has been made; (b) both of its relative links would be dead in the new home — `[scripts/](scripts/)` would resolve to a non-existent `shared/scripts/`, and `../shared/specialist-fan-out.md` would point at the file's own sibling directory. Carrying it verbatim would red the dead-internal-link gate. The remainder of the `scripts/` extraction is still tracked on #4451, which is unaffected by this move.
- **(repair round 1) The round-1 boundary change was dropped rather than rebased.** `control-plane-re.ts`, the formats-doc `CONTROL_PLANE_RE=` copy, `.github/CODEOWNERS`, and the `codeowners-cp` fixture rows are all reverted to `main`. This follows both gates' FAIL verdicts at `e718c521` and is a scope *reduction*, not a silent conflict resolution.
- **(repair round 1) The kept unit test's docblock was reworded.** Round 1's comment described the change as adding a directory branch to the boundary. With that branch gone, the comment now states what the test actually pins: the whole-tree clause already covers the path, and this test is the tripwire against a future re-narrowing.
- **(repair round 1) The branch was rebuilt on `d325ec5a` and force-pushed with a lease, not rebased commit-by-commit.** The round-1 head conflicted with `main` on exactly the lines being dropped, so a rebase would have been a "take ours"/"take theirs" resolution over the regression. The tree was reconstructed from current `main` instead; `--force-with-lease` was pinned to `e718c521`.

## Reviewer note — the #4394 policy question is live

The issue records **#4394** (the gate-skill house-style exemption in `author-skill/SKILL.md:93–105`) as a blocker: as worded it was written to stop invariants being *deleted*, but reads as blocking *single-sourcing* them. #4394 is still open, so a reviewer can correctly cite the exemption against this PR. Flagged rather than routed around: this diff deletes no invariant — every line of the mechanism survives at one address instead of inside a consumer, and the §CP gating that governs edits to it is preserved because the destination is already inside the live boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
