### PR TITLE
fix(author-skill): stop citing review-skill check #4 as a prose-register enforcement (#4394)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
@@ -102,7 +102,29 @@ those skills were hardened against). Their prose weight is load-bearing.
 So: when you author a **new, non-gate** skill, keep it lean. When you edit a **gate** skill,
 match its existing register — do not "deslop" its invariant prose, do not compress a
 fail-closed rationale to a one-liner, do not trim an incident pointer that anchors a guard.
-The rigor check #4 above is the enforcement; this exemption is why the prose looks heavy.
+This exemption is why the prose looks heavy.
+
+### Removing an invariant ≠ relocating one
+
+The exemption bounds **removal and weakening**. It does **not** forbid **relocating** an
+invariant to one canonical home and citing it from the sites that used to restate it — that
+operation preserves the invariant *and* removes the drift duplicate copies accumulate (the
+#375-class drift §RO names; `CONTROL_PLANE_RE` was single-sourced this way under #2761, with a
+drift-lock replacing the copies). Read as a ban on relocation, the exemption protects copies —
+and copies drift.
+
+The permission carries its own bound, so it is never license to gut a gate: the citing skill
+must **state the rule's operative teeth inline** — what the executing agent must actually do,
+in enough words to act on without following the link — and the cite carries only the
+*rationale* (the ADR, the incident, the derivation). A cite that replaces the teeth with a
+pointer is a removal, not a relocation, and stays forbidden exactly as before.
+
+**What enforces which half.** `review-skill` rigor check #4 enforces the *no-weakening* half,
+and only that half: it is scoped to a diff that "**removes or softens** an invariant, not one
+that respects it" — check #4's own out-of-scope boundary. It encodes **no** prose-register
+rule, so a relocation that keeps the teeth inline is not a check-#4 finding. The register rule
+above is an authoring convention with no gate hook: follow it because that prose is
+load-bearing, not because a gate will fail you for compressing it.
 
 ## Destination and §CP — re-check before you open the PR
 


### PR DESCRIPTION
The `author-skill` guide told skill authors that a specific reviewer check would fail them for compressing prose in a gate skill. That check does nothing of the sort — it only looks for invariants being removed or softened. This PR corrects the claim, and while it is there, spells out the distinction the wrong claim was hiding: deleting a rule from a gate skill is still forbidden, but moving a rule to one canonical home and citing it from the old sites is allowed, as long as the citing skill still tells the executing agent what to actually do.

Fixes #4394

## The miscitation, verified at `origin/main`

Both halves were read verbatim at `origin/main` before any edit.

**The cited check — `claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md:469–496`**, rigor check #4. It opens:

> 469: 4. **Gate-invariant preservation — the catastrophic case.** Does the edit *quietly weaken a
> 470:    gate*? **This is the load-bearing check neither `review-code` nor `review-doc` can catch**

and states its own boundary in the out-of-scope bullet:

> 487:    - Out of scope (do **not** flag): a PR that merely *exercises* ADR 0065's coarse
> 488:      blocking-rule (a gate-critical edit that stays human-merged) — that is the rule working,
> 489:      not a weakening. You flag a diff that **removes or softens** an invariant, not one that
> 490:      respects it.

A case-insensitive grep of that whole file for `house-style|house style|deslop|Strunk|lean prose|register` returns exactly one hit — `:405`, `"register it as a"` in a shell-trap sentence, unrelated. Check #4 encodes **no** prose-register rule.

**The citing claim — `claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md:102–105`**, the closing lines of the gate-skill house-style exemption:

> 102: So: when you author a **new, non-gate** skill, keep it lean. When you edit a **gate** skill,
> 103: match its existing register — do not "deslop" its invariant prose, do not compress a
> 104: fail-closed rationale to a one-liner, do not trim an incident pointer that anchors a guard.
> 105: The rigor check #4 above is the enforcement; this exemption is why the prose looks heavy.

Line 105 attributes the register rule on 102–104 to check #4. Check #4 does not carry it. The issue's characterization holds.

## What changed

`claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md`, one file, +23/-1.

Line 105 becomes:

> This exemption is why the prose looks heavy.

and a new `### Removing an invariant ≠ relocating one` subsection follows it, ending with:

> **What enforces which half.** `review-skill` rigor check #4 enforces the *no-weakening* half,
> and only that half: it is scoped to a diff that "**removes or softens** an invariant, not one
> that respects it" — check #4's own out-of-scope boundary. It encodes **no** prose-register
> rule, so a relocation that keeps the teeth inline is not a check-#4 finding. The register rule
> above is an authoring convention with no gate hook: follow it because that prose is
> load-bearing, not because a gate will fail you for compressing it.

## Why the citation, not the check

The issue's AC 3 leaves the direction open: amend check #4, or correct the sentence. Corrected the sentence.

Editing a rigor check changes gate behavior for **every** skill review that runs after it lands — a much wider blast radius than a sentence in an authoring guide, for a defect that is entirely on the citing side. Check #4's text is not wrong; only the claim about it was. And check #4's existing out-of-scope boundary already resolves the case correctly on its own terms: a relocation that preserves the invariant "respects it" and is therefore explicitly not-flaggable. Adding a relocation clause there would restate what the boundary already implies, in the one file where restatement is most expensive.

Secondary, but real: PR #4440 is open and touches `review-skill/SKILL.md`. Keeping this diff out of that file keeps the two from fighting.

## Acceptance criteria

- [x] The exemption distinguishes the two operations explicitly — removing/weakening forbidden, relocating-with-cite permitted. New subsection, first paragraph.
- [x] The permission carries its own bound — the citing skill must state the rule's operative teeth inline, the cite carries only rationale; a cite that replaces the teeth with a pointer is a removal, not a relocation. New subsection, second paragraph.
- [x] The enforcement claim at `:105` no longer attributes a rule check #4 does not contain. The claim is replaced by an accurate one that quotes check #4's real boundary and states outright that it encodes no prose-register rule.
- [x] Vacuous — check #4 is not amended, so the conditional does not fire. Rationale above.
- [x] The invariant preserved is named below, with the edit shown to keep it.

## The invariant this edit preserves (`author-skill`'s own self-application)

**The invariant:** a gate skill's fail-closed rationale, incident pointers, and invariant prose must not be removed or weakened.

**How the edit keeps it.** Lines 95–104 — the whole substance of the exemption, including "do not 'deslop' its invariant prose, do not compress a fail-closed rationale to a one-liner, do not trim an incident pointer that anchors a guard" — are **unchanged**, byte for byte. The diff removes exactly one clause: the false attribution of that rule to check #4. Everything else is added text that *narrows* what the exemption can be read to permit, by bounding the relocation permission with a teeth-inline requirement that did not exist before. Nothing in `review-skill`, `ship-it`, `review-code`, `review-doc`, or the formats contract is touched; no gate's behavior changes.

## Verification

- `pipeline-cli cp-classify classify` on the changed-file set → `not-control-plane [path-clear-no-content-source]`, exit 3. `author-skill` is not in the live `CONTROL_PLANE_RE` gate-skill list. This resolves the issue's open "unverified at triage" question: the PR does **not** route control-plane.
- `pipeline-cli gh-phoenix lint-skills` on the changed file → clean.
- `claude-plugins/kampus-pipeline/skills/validate-skills.sh` → `OK — 30 skills valid`.
- `pnpm lint:worktree` → no biome-handled changed files (markdown-only diff), clean skip.

## Deviations

None.

Walked all seven §DEV classes against this diff before asserting that. The one entry that had to be judged rather than dismissed is AC 3: it states its direction as an explicit disjunction — *"either check #4 is amended to encode the distinction, or the sentence is corrected to describe the real scope"* — so taking the second disjunct is a **permitted direction**, not a scope narrowing (class 1) and not declined guidance (class 4); the reasoning for the choice is in *Why the citation, not the check* above. AC 4 is conditional on the first disjunct and its antecedent is false, so it is vacuous rather than unmet. The drifted §SP pair (the issue's item 4) is not a class-3 known-defect-left-unfixed either: the issue's own **Out of scope** section excludes it by name, so leaving it is following the spec, not departing from it. Classes 2, 5, 6 and 7 have no candidate — no ADR is contradicted, the diff is markdown-only with no suppression, skip or assertion change, and it touches exactly the one file the issue names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

