### PR TITLE
docs(formats): single-source the §CP path list, the §CP ADR lineage, and §7's race derivation (#4436)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2035,7 +2035,7 @@ as the artifacts it manifests — no new class or gate is invented. This is **on
 axis: `CONTROL_PLANE_RE` (§CP, who-merges) is a **separate** regex and is **untouched**, so a crew
 plugin's `agents/**` gains a `review-skill` gate yet still **auto-ships** on PASS (the founder #2342
 ruling — extras don't block — **re-affirmed 2026-07-24 on #3765** on the threat-modeled containment
-basis recorded in the §CP "Deliberately OUT — the crew engine defs" note above; the class fix and the
+basis recorded in the crew-engine-defs clause of the §CP **Deliberately OUT** paragraph above; the class fix and the
 §CP ruling compose).
 
 **Both consumers re-resolve these lines from `origin/main` at run time** (REST raw, `?ref=main`

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1467,186 +1467,35 @@ source of the set**, so every consumer cites *one* definition and the copies can
 again (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §6,
 closing the #375 drift class).
 
-**The control-plane / blocking set is, exactly:**
+**What the set governs — and where to read it.** It decides **merge authority**: who may merge a
+PR that touches it. That is the only axis it governs; which gate *verifies* the PR is a separate
+question (the callout below). The membership list is single-sourced in the `CONTROL_PLANE_RE`
+const and printed, expanded, by **`pipeline-cli control-plane-paths --paths`** — run that rather
+than read a copy, and never re-hard-code the list here or in a consumer. The regex those members
+amount to is the canonical `CONTROL_PLANE_RE=` line in the next subsection.
 
-- `.claude/**` — the agent control plane (instructions, tools, hooks).
-- `.github/**` — CI enforcement.
-- `.claude-plugin/**` — the **root marketplace manifest** (`marketplace.json`), which declares
-  what the `kampus` marketplace serves and where each plugin's `source` tree is. It governs
-  **delivery of the control plane itself**: the `kampus-pipeline` entry is how the gate-critical
-  skills and the pipeline agents reach a session, and `validate-gate-path-drift.sh` Invariant 2
-  resolves the `.claude/skills` symlink against this file's `source` field. An unreviewed edit
-  here can redirect which tree the gates are loaded from — a self-weakening surface by ADR 0187's
-  enforcement-surface test, even though nothing under it is itself a guard (ADR
-  [0212](https://github.com/kamp-us/phoenix/blob/main/.decisions/0212-marketplace-manifest-is-control-plane.md), #3933).
-  It needs its **own** `^\.claude-plugin/` branch: the `^(\.claude|\.github)/` branch requires a
-  literal `/` after `.claude`, and the next character here is a hyphen, so it never matched.
-
-  **Deliberately OUT — every NESTED `.claude-plugin/` dir** (`claude-plugins/*/.claude-plugin/plugin.json`).
-  The branch is root-anchored: an un-anchored form would also sweep in `claude-plugins/pipeline-crew/`,
-  whose corpus a live founder ruling keeps out of §CP (#3765). `kampus-pipeline`'s own `plugin.json`
-  is a genuine sibling gap — file it, don't widen the anchor by hand (ADR 0212 Consequences).
-- the **gate-critical skills** — the verification/merge machinery plus the shared marker
-  contract they all depend on:
-  - `claude-plugins/kampus-pipeline/skills/ship-it/**`
-  - `claude-plugins/kampus-pipeline/skills/review-code/**`
-  - `claude-plugins/kampus-pipeline/skills/review-doc/**`
-  - `claude-plugins/kampus-pipeline/skills/review-skill/**`
-  - `claude-plugins/kampus-pipeline/skills/review-design/**`
-  - `claude-plugins/kampus-pipeline/skills/review-plan/**`
-  - `claude-plugins/kampus-pipeline/skills/review-trivial/**` — the trivial-diff gate emits
-    SHA-bound, merge-consumed verdicts, so it is gate-critical exactly like the other reviewers;
-    its omission was a live fail-**open** §CP-bypass (ADR
-    [0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md), #2679).
-  - `claude-plugins/kampus-pipeline/skills/triage/**`
-  - `claude-plugins/kampus-pipeline/skills/write-code/**`
-  - `claude-plugins/kampus-pipeline/skills/plan-epic/**`
-  - `claude-plugins/kampus-pipeline/skills/release/**` — the release machinery (ADR 0174, #2679).
-  - `claude-plugins/kampus-pipeline/skills/**/*.sh` — every skill shell helper, at **any depth**
-    under `skills/`: the bare gate-critical guard scripts directly under `skills/`
-    (`validate-gate-path-drift.sh`, `validate-skills.sh`, `validate-cycle-*.sh`) **and** a helper
-    nested in a skill subdir (`report/footer.sh` — its `Filed by an agent` provenance marker feeds
-    triage's ADR-0159 auto-close eligibility; `doctor/doctor.sh`): executable enforcement that
-    feeds or runs the gates, control-plane *by nature* like the guard packages. The
-    `^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$` branch classifies them (ADR
-    [0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md), #2576/#2950);
-    the leaf `[^/]+\.sh$` matches a `.sh` filename and `([^/]+/)*` the intervening dirs, so it owns
-    a shell helper wherever it sits without reaching the non-`.sh` files in the skill *dirs* above.
-  - `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (this file)
-
-  **Deliberately OUT of §CP** (recorded so their absence is a decision, not an oversight): the
-  `heal-ci`, `what-shipped`, `doctor`, and `wayfinder` skills are operational diagnostics /
-  reporting / orientation — they neither gate a merge nor hold release authority nor sit on a
-  gate-critical path, so they auto-merge on a `review-skill` PASS like any ordinary skill. Do
-  **not** add them to the boundary (ADR 0174). **The one exception is per-file, not per-dir:**
-  `doctor/doctor.sh` — like every other `skills/**/*.sh` helper — **is** §CP via the `.sh` clause
-  above, because it is executable enforcement; the rest of the `doctor` skill dir (its `SKILL.md`
-  and any non-`.sh` file) is out. Same for any future `.sh` under `heal-ci`, `what-shipped`, or
-  `wayfinder`. The two bullets do not disagree: the `.sh` clause scopes to `.sh` **files** at any
-  depth, this exclusion scopes to skill **dirs**.
-- the **pipeline agent definitions** — `claude-plugins/kampus-pipeline/agents/**`: the behavior
-  instructions for the very agents that run the pipeline, including `shipper.md` (the merge
-  authority) and `reviewer.md` (the verdict gate). An agents-only PR matched **no** §CP clause
-  and **no** routing probe, so `ship-it` would have enqueued it with no human merge and no gate —
-  a gate/merge agent auto-shipping a weakening of its own instructions, the exact
-  self-modification-of-guardrails risk §CP exists to prevent (ADR
-  [0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
-  #2003; same ADR 0065 rationale that makes the gate-critical skills blocking). Agent defs are
-  behavioral artifacts like skills → **`review-skill`-routed for the verdict**, **blocking for merge**.
-
-  **Deliberately OUT of §CP — the crew engine defs** (`claude-plugins/pipeline-crew/agents/**`, the
-  sibling `pipeline-crew` plugin, `crew-engineering-manager.md` et al.): scoped **only** to the
-  `kampus-pipeline` plugin above, the crew defs class **has-skills** (they ride a `review-skill` gate,
-  #2387) but are **NOT** §CP — they auto-ship on a `review-skill` PASS. This exclusion is a **live
-  founder ruling, re-affirmed 2026-07-24** (recorded on #3765), re-affirming #2342 ("extras don't
-  block") for the crew defs on a **stated containment basis, threat-modeled** for the one path that
-  matters: a weakened crew engine def cannot produce an **un-approved merge** through any path *other
-  than the shipper*, because the actual merge authority lives in the `ship-it` skill and `shipper.md`
-  — both §CP, both re-verifying the §CP approval **independently** of whatever a crew engine def
-  believes. The crew defs orchestrate (claim, spawn, bank, watch); they never gate a verdict nor
-  perform the merge. So the worst a weakened crew def can do is **fail to bank** — which surfaces as a
-  visible unshipped §CP PR a human notices — never drive a merge past the approval §CP requires. The
-  self-modification-of-guardrails risk that pulls `kampus-pipeline/agents/**` into §CP (ADR 0150) is
-  therefore contained short of the crew corpus. Do **not** add `pipeline-crew/agents/**` to
-  `CONTROL_PLANE_RE` on this ruling — it narrows nothing and widens nothing (#3765). Re-examine if a
-  crew def ever gains independent merge/gate authority, or per the #3766 direction of travel (moving
-  N-engine lane exclusion into the tracker/tool layer makes this exclusion even less load-bearing).
-- the **plugin hook surface** — `claude-plugins/kampus-pipeline/hooks/**` (the `install.sh`
-  that drops the installed `pipeline-cli` and the `guard.sh` fail-open dispatch wrapper) plus
-  `claude-plugins/kampus-pipeline/hooks.json` (the foreign-repo hook manifest). These are
-  self-weakening by nature — they wire the guard dispatch + the CLI install the `.claude/settings.json`
-  hooks depend on (ADR [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md),
-  #1003). The `^claude-plugins/kampus-pipeline/hooks(/|\.json$)` clause covers the dir + the manifest.
-- the **enforcement-guard packages** — the executable guardrails that gate agent tooling,
-  control-plane *by nature* the same way the gate-critical skills are (ADR
-  [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md)),
-  even though they live under `packages/` rather than `.claude`/skills (ADR
-  [0100](https://github.com/kamp-us/phoenix/blob/main/.decisions/0100-control-plane-covers-enforcement-guard-packages.md)):
-  - `packages/ci-required/**` — the zero-dep aggregator of the gating CI checks. Its sources were
-    inlined into pipeline-cli at `packages/pipeline-cli/src/tools/ci-required/` (#3802), and its CI
-    job now runs `node packages/pipeline-cli/src/tools/ci-required/bin.ts`; the aggregator's
-    CP coverage now flows through the pipeline-cli enforcement-core clauses below (its sources sit
-    at `src/tools/ci-required/`, a retained core path). The `^packages/ci-required/`
-    clause below is retained deliberately (ADR 0100) as defense-in-depth against a re-created package
-    at that path, even though it no longer carries tracked sources.
-  - `packages/pipeline-cli/` — **an enforcement core, not the whole package** (ADR
-    [0218](https://github.com/kamp-us/phoenix/blob/main/.decisions/0218-pipeline-cli-cp-enforcement-core.md),
-    amending ADR 0100, which had rejected exactly this sub-path split). The package is the
-    consolidated home for every guard the standalone `*-guard` packages used to carry (ADR
-    [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md),
-    #1003), but ~68 tools live there and most gate nothing — so ADR
-    [0187](https://github.com/kamp-us/phoenix/blob/main/.decisions/0187-crew-mcp-is-not-control-plane.md)'s
-    enforcement-surface test is applied **per path** rather than to the package as a whole. Three
-    clauses carry it:
-    - `^packages/pipeline-cli/src/[^/]+$` — the `src/` **root, non-recursive**: the shared
-      dispatch + process plumbing every tool including every gate runs through (`registry.ts`'s
-      `registeredTools[]` can disable any guard without touching that guard's own directory;
-      plus `router.ts`/`bin.ts`/`gate-fail.ts`/`read-stdin*.ts`/`run.ts`/`tool-registration.ts`/…).
-      A non-recursive pattern, not a file list, so it cannot rot as root modules are added.
-    - `^packages/pipeline-cli/src/tools/(…)/` — the **eight** tools that are themselves the
-      enforcement surface: `ci-required` (a branch-protection-required check), `verdict` (the
-      enqueue gate, ADR 0058), `cp-cardinality` (§CP approval discharge, ADR 0175),
-      `control-plane-paths` (this boundary), `cp-classify` (the §CP verdict, #4161),
-      `codeowners-cp` (the regex↔CODEOWNERS drift gate), `trivial-diff` (routes a PR to the
-      lighter gate, ADR 0120), `review-head` (resolves the head every verdict binds to).
-    - `^packages/pipeline-cli/src/tools/tracker/gh-io\.ts$` — **one file, not its directory.**
-      `gh-io.ts` exports `authorizedAuthors`, the ADR 0055 write+ ACL, and `verdict/github.ts`
-      feeds its result straight into `resolveVerdict`: widening it to return every author would
-      let a **forged verdict from a non-collaborator count as a PASS**. Retaining `verdict` while
-      leaving its authorization source ungated is an incoherent line. The rest of `tools/tracker/`
-      is claim/coordination tooling and stays out — hence the file-level anchor.
-
-    The legacy `^packages/[^/]*-guard/` clause is retired with those packages. Note what the
-    narrowing means concretely: the Tier-3 guards ADR 0100 named **by name** (`leak-guard`,
-    `spawn-guard`, `structured-output-guard`, `worktree-guard`, `read-guard`) are **no longer
-    §CP** — they are CI-enforced, not human-approval-enforced. ADR 0218 records that trade, the
-    three modules the core imports without retaining, and why `codeowners-cp` cannot catch a
-    stale over-broad CODEOWNERS row.
-- the **local hook-wiring config** — `lefthook.yml` and its siblings, matched by the
-  `^([^/]+/)*(lefthook|\.lefthook)[^/]+$` branch. This config is what *wires* the local git hooks:
-  the ADR-0160 ref-guard (#2143) and the #2778 primary-index guards, which have **no CI backstop**
-  and are the only defense the shared local checkout has against a proven-real corruption class. An
-  edit that silently unwires them is self-weakening in exactly ADR 0187's sense, so it must not
-  auto-ship (founder ruling on #3402). The branch is a **shape, not a named list** (#2393): the same
-  depth-agnostic `([^/]+/)*` prefix the skill-`.sh` clause uses, over the `lefthook` / `.lefthook`
-  stem, so every config filename lefthook itself discovers — `lefthook.yml`, the `.yaml`/`.toml`/
-  `.json` forms, a `lefthook-local.*` override, and the `.lefthookrc` every generated hook wrapper
-  sources — is covered without enumerating one of them. The `[^/]+` leaf keeps it narrow: it matches
-  lefthook-named **leaves** only, so no other root config is swept in.
+**Deliberately OUT, recorded so each absence reads as a decision and not an oversight:** every
+**nested** `.claude-plugin/` dir — the branch is root-anchored, and `kampus-pipeline`'s own
+`plugin.json` is a genuine sibling gap to file rather than patch by hand (ADR
+[0212](https://github.com/kamp-us/phoenix/blob/main/.decisions/0212-marketplace-manifest-is-control-plane.md)
+Consequences); the `heal-ci`, `what-shipped`, `doctor`, and `wayfinder` skills, which gate no merge
+and hold no release authority (ADR
+[0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md))
+— that exclusion scopes to skill **dirs**, so `doctor/doctor.sh` (and any future `.sh` under those
+four) is still §CP by the `.sh` clause, which scopes to `.sh` **files** at any depth;
+and the crew engine defs under `claude-plugins/pipeline-crew/agents/**`, which class **has-skills**
+yet auto-ship on a `review-skill` PASS, because merge authority lives in `ship-it` and `shipper.md`
+— both §CP, both re-verifying the §CP approval independently — so the worst a weakened crew def can
+do is fail to bank (live founder ruling, re-affirmed 2026-07-24 on
+[#3765](https://github.com/kamp-us/phoenix/issues/3765)). Do **not** widen `CONTROL_PLANE_RE` by
+hand to cover any of them.
 
 A PR touching **any** path in this set is **control plane**: `ship-it` never auto-merges it off a
 gate verdict alone — it merges only once a `@kamp-us/control-plane` member approves at head, and
-`ship-it` then enqueues it (ADR
-[0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
-amending ADR
-[0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md),
-widened to the gate-critical skills by ADR
-[0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md);
-`review-skill/**` added to the gate-critical set by ADR
-[0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md), since the gate
-that reviews the gates is itself a gate; the enforcement-guard packages added by ADR
-[0100](https://github.com/kamp-us/phoenix/blob/main/.decisions/0100-control-plane-covers-enforcement-guard-packages.md),
-since a guard is a self-weakening surface wherever it lives; that coverage flowed
-through the consolidated `packages/pipeline-cli/` package per ADR
-[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md)
-and is now scoped to that package's **enforcement core** per ADR
-[0218](https://github.com/kamp-us/phoenix/blob/main/.decisions/0218-pipeline-cli-cp-enforcement-core.md);
-the **pipeline agent definitions** (`claude-plugins/kampus-pipeline/agents/**`) added by ADR
-[0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
-since a gate/merge agent's own instructions are a self-weakening surface; the **bare gate-critical
-`.sh` guards** under `skills/` and the **`release`/`review-trivial` skill dirs** added by ADR
-[0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md)
-(#2576/#2679), since a guard script and a SHA-bound-verdict gate are self-weakening surfaces that
-were escaping the boundary; the **lint/GritQL governance config** — `biome.jsonc` and
-`biome-plugins/**` — added by ADR
-[0193](https://github.com/kamp-us/phoenix/blob/main/.decisions/0193-lint-governance-config-is-control-plane.md),
-since an ungated path to weaken a lint rule is a guard-relaxing vector; the **root marketplace
-manifest** — `.claude-plugin/**` — added by ADR
-[0212](https://github.com/kamp-us/phoenix/blob/main/.decisions/0212-marketplace-manifest-is-control-plane.md),
-since the file that decides what the control-plane plugin *delivers* is itself control plane; the
-**local hook-wiring config** — `lefthook.yml` and its siblings — added on the founder ruling on
-[#3402](https://github.com/kamp-us/phoenix/issues/3402), since the config that wires the
-CI-unbacked local-integrity guards can unwire them).
+`ship-it` then enqueues it. Every widening of the boundary, and the reason for each, is an ADR —
+0053, 0065, 0073, 0100, 0103, 0135, 0150, 0174, 0193, 0212, 0218 — plus the founder ruling on
+[#3402](https://github.com/kamp-us/phoenix/issues/3402). Read them in `.decisions/`, where ADR
+discovery is the CLAUDE.md contract; they are not restated here.
 Everything else — `apps/**`,
 **non**-guard `packages/**`, `.decisions/**` (**except a guard-touching ADR** — see the content
 clause below), `.patterns/**`, every prose doc `*.md` (the
@@ -3446,63 +3295,34 @@ won  ==  earliest-authorized-claim.session  ==  $CLAUDE_CODE_SESSION_ID
 trust root — the same write+ collaborator gate `ship-it` Step 2 and the `write-code` repair
 scan apply: keep only claim markers **authored by an account holding `write+` on the repo**.
 A forged claim from a non-collaborator is **ignored**; an **empty authorized set resolves no
-winner — fail-closed**, never a false win. The canonical resolution (read tolerantly per the
-§Reading stance):
+winner — fail-closed**, never a false win. The matcher that resolution scans with is the one
+machine-readable copy in this file (read tolerantly per the §Reading stance):
 
 ```bash
-cf=$(mktemp); gh api "repos/$REPO/issues/<N>/comments?per_page=100" --paginate > "$cf"
+# The canonical CLAIM_RE stays here at column 0 for the same reason §CP's CONTROL_PLANE_RE line
+# does: `validate-gate-path-drift.sh` and the live gates re-resolve it from THIS file on
+# origin/main (#981, #4401), so it must remain present, byte-identical, exactly once.
 CLAIM_RE='(?i)^\s*\**\s*claim:\s*[0-9a-f-]{36}\b'
-# authors of any claim marker on the issue
-claimAuthors=$(jq -r --arg re "$CLAIM_RE" '[.[] | select(.body | test($re)) | .user.login] | unique | .[]' "$cf")
-# keep only write+ collaborators (the ADR 0055 trust root) — a forged claim is ignored, empty ⇒ no winner
-authorized='[]'
-while IFS= read -r a; do
-  [ -z "$a" ] && continue
-  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
-  case "$perm" in admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;; esac
-done <<<"$claimAuthors"
-# the EARLIEST authorized claim — min (created_at, comment id) — is the canonical winner; read its session.
-WINSID=$(jq -r --argjson authorized "$authorized" '
-  [.[] | select(.user.login | IN($authorized[]))
-       | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b"))
-       | {sid: (.body | capture("(?i)^\\s*\\**\\s*claim:\\s*(?<s>[0-9a-f-]{36})").s), at: .created_at, id: .id}]
-  | sort_by([.at, .id]) | first | .sid // ""' "$cf")
-# you won iff the earliest authorized claim is yours
-[ -n "$WINSID" ] && [ "$WINSID" = "$CLAUDE_CODE_SESSION_ID" ] && echo "claim is mine" || echo "not mine — back off"
 ```
 
-This swaps the degenerate `lexicographic-min(login)` for `earliest(authorized claim)`,
-resolved by the same **checkpoint GET against canonical issue state, fail-closed** shape the
-old design used. The race-case derivation transfers and is *strengthened* (ADR 0115 §2):
+**Do not hand-roll the resolution around it.** `pipeline-cli claim is-mine --issue <N> --session
+<token>` owns the whole read — the `CLAIM_RE` scan, the ADR 0055 write+ filter, the earliest
+`(created_at, comment id)` tiebreak, and the default-deny outcome — and `pipeline-cli adoption-lint
+check` reds a corpus file that re-derives it instead of citing the verb.
 
-- **Staggered co-racers.** Each posts a claim comment; the server stamps each a unique,
-  monotonic `id`. The checkpoint GET re-reads the same canonical comment set, so exactly one
-  finds the earliest authorized claim's session equals its own and proceeds; every other
-  recomputes the same earliest claim, sees it is not theirs, **retracts its own claim
-  comment** (`DELETE` the comment it posted), and re-picks. The comment-post detects, the GET
-  resolves — same shape as the old assignee race, but the key is now agent-distinguishable.
-- **Straggler / Rule-0 defer collapses into the tiebreak.** A late arrival's comment has a
-  strictly larger `id`, so it is **never** the earliest authorized claim — it loses by
-  construction, **and** Rule 0 (defer to a pre-existing owner — re-read before posting and
-  back off if an authorized claim from a *different* session already owns it) tells it to
-  back off before posting at all. Because **earliest-claim-wins, Rule 0 and the tiebreak are
-  the same fact**: the pre-existing owner *is* the minimum. This removes the
-  straggler-evicts-owner tension the old `min(login)` needed a separate non-revocability
-  argument to close — a lower login could belong to a later arrival; a lower comment id
-  cannot.
-- **Transient window.** The comments may transiently carry two claims before a loser retracts,
-  and — because the assignment lands only *after* a won claim (below) — a won-but-not-yet-assigned
-  issue is briefly still unassigned. Both degrade safely: the picker skips on **any non-null
-  assignee**, so a transiently double-claimed issue is passed over rather than double-picked, and
-  an agent that picks the still-unassigned issue in the other window runs the claim verb and
-  defers to the earlier claim.
+The race-case derivation this tiebreak rests on — staggered co-racers, where the comment POST
+detects and the checkpoint GET resolves; the straggler whose Rule-0 defer collapses *into* the
+tiebreak, because earliest-claim-wins makes the pre-existing owner and the minimum the same fact;
+and the transient double-claimed and won-but-not-yet-assigned windows the picker's
+skip-on-any-assignee absorbs — is ADR
+[0115](https://github.com/kamp-us/phoenix/blob/main/.decisions/0115-agent-distinguishable-claim-marker.md)
+§2. Read it there; it is not restated here.
 
-This remains **detect-and-tiebreak, not a kernel mutex** (the epic's honest non-goal): the
-comment/assignee APIs offer no conditional write, so true single-writer exclusion is off the
-table. The guarantee is the one that matters — of any set of co-window racers, exactly one
-proceeds, deterministically, and every loser self-retracts its claim comment and re-picks.
-Don't reintroduce the "it's the lock" framing, and **never fall back to the bare assignee login
-as an ownership signal** — that is the degeneracy ADR 0115 removes.
+Two consequences of that derivation are standing rules, because they get re-litigated: this is
+**detect-and-tiebreak, not a kernel mutex** — the comment and assignee APIs offer no conditional
+write, so the guarantee is that exactly one of any co-window racer set proceeds and every loser
+self-retracts, not single-writer exclusion. And **never fall back to the bare assignee login as an
+ownership signal** — that is the degeneracy ADR 0115 removes.
 
 <a id="claim-before-you-assign-a-defer-must-not-strip-the-incumbent"></a>
 ### Claim before you assign — a defer must not strip the incumbent


### PR DESCRIPTION
The formats contract had three blocks that said again what something else already says: the §CP path list (which the `control-plane-paths` verb prints), the §CP ADR lineage (which `.decisions/` holds), and §7's hand-written claim-resolution code plus its race walkthrough (which ADR 0115 §2 derives). This PR replaces each one, in place, with a pointer to its real home. Nothing moves, no section is added or removed, and every reader of the file still gets the same answers — just from the source that stays correct when it changes.

The one thing that had to stay put is the machine-readable `CLAIM_RE=` line, which lives inside the block leg (c) rewrites. CI parses it out of this exact file by path, so it survives here byte-for-byte, now with a comment saying why.

Fixes #4436

## What changed

Only `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`. 50 insertions, 230 deletions.

**(a) §CP prose path enumeration → a statement of what the set governs + the verb.** The bulleted "The control-plane / blocking set is, exactly:" list is replaced by two paragraphs: what the set decides (merge authority — not gate routing) and a cite to `pipeline-cli control-plane-paths --paths`. The section's own "The canonical matcher" subsection already instructed readers to cite the verb and *not* re-hard-code the list; the section now obeys the rule it states 40 lines later.

The **deliberate exclusions** are retained, condensed: nested `.claude-plugin/` dirs (ADR 0212), the `heal-ci`/`what-shipped`/`doctor`/`wayfinder` skills (ADR 0174), and `claude-plugins/pipeline-crew/agents/**` (founder ruling, #3765). An exclusion is a path the verb by construction does **not** print, so there is no single source to relocate it to — deleting it would have dropped an answer rather than moved it. See `## Deviations`.

**(b) §CP ADR-lineage sentence → a one-line pointer.** The enumeration of each widening, with a full blob URL and a because-clause apiece, becomes the ADR id list (0053, 0065, 0073, 0100, 0103, 0135, 0150, 0174, 0193, 0212, 0218) plus the founder ruling on #3402, read in `.decisions/` per the CLAUDE.md discovery contract.

**(c) §7 reference implementation + race derivation → ADR 0115 §2 + the verb.** The hand-rolled `mktemp`/`gh api`/`jq` resolution is replaced by the retained `CLAIM_RE=` line and a pointer to `pipeline-cli claim is-mine`, which owns that read. The three race cases (staggered co-racers, straggler/Rule-0 collapse, transient window) are cited to ADR 0115 §2 instead of restated. Two **standing rules** are kept, not cited away, because they are prohibitions rather than derivation: detect-and-tiebreak is not a kernel mutex, and never fall back to the bare assignee login as an ownership signal.

## The leg (c) `CLAIM_RE` collision, and how it was handled

The build constraint recorded on #4436 (comment 5113083848) is correct and was verified at this head: the sole column-0 `CLAIM_RE=` assignment sits *inside* the block leg (c) rewrites, and both obvious moves are red — deleting it fails `validate-gate-path-drift.sh` invariant 1d at count 0, and de-indenting the illustrative copy under `### The canonical claim marker` to substitute for it fails the same invariant at count 2.

Neither was done. The `CLAIM_RE=` line survives **in place**, at column 0, byte-identical, exactly once, and now carries a three-line comment naming why it cannot move — mirroring the comment that already guards §CP's `CONTROL_PLANE_RE=` line. Only the prose and the reference implementation around it were replaced.

## Acceptance criteria evidence, all re-measured at head `5b3959a3`

Every figure in this section was measured by this round at `5b3959a3`, the head this body describes — not carried forward from an earlier head. The baseline throughout is the PR's merge base `11742ba8`; `origin/main` has since advanced to `5511098a`, whose one commit (#4463) does not touch this file, so the file is byte-identical at both and the comparisons below hold against either.

**1. `validate-gate-path-drift.sh` passes.**

```
$ bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
ok: §CP CONTROL_PLANE_RE read from the single-source const (pipeline-cli control-plane-paths)
ok: gh-issue-intake-formats.md CONTROL_PLANE_RE matches the single-source const
ok: canonical GUARD_ADR_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical GUARD_ADR_RE matches the single-source const
ok: GUARD_ADR_RE copies across the corpus match the single-source const
ok: canonical HAS_CODE_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical HAS_CODE_RE matches the single-source const
ok: HAS_CODE_RE copies across the corpus match the single-source const
ok: canonical HAS_SKILLS_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical HAS_SKILLS_RE matches the single-source const
ok: HAS_SKILLS_RE copies across the corpus match the single-source const
ok: canonical HAS_DOCS_EXCLUDE_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical HAS_DOCS_EXCLUDE_RE matches the single-source const
ok: HAS_DOCS_EXCLUDE_RE copies across the corpus match the single-source const
ok: canonical HAS_DOCS_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical HAS_DOCS_RE matches the single-source const
ok: HAS_DOCS_RE copies across the corpus match the single-source const
ok: canonical DOC_VOCAB_EXCLUDE_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical DOC_VOCAB_EXCLUDE_RE matches the single-source const
ok: DOC_VOCAB_EXCLUDE_RE copies across the corpus match the single-source const
ok: canonical DOC_VOCAB_SURFACE_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical DOC_VOCAB_SURFACE_RE matches the single-source const
ok: DOC_VOCAB_SURFACE_RE copies across the corpus match the single-source const
ok: canonical CLAIM_RE appears exactly once in gh-issue-intake-formats.md
ok: canonical CLAIM_RE matches the single-source const
ok: CLAIM_RE copies across the corpus match the single-source const
ok: canonical UI_RE appears exactly once in SKILL.md
ok: canonical UI_RE matches the single-source const
ok: UI_RE copies across the corpus match the single-source const
ok: canonical UI_EXCLUDE_RE appears exactly once in SKILL.md
ok: canonical UI_EXCLUDE_RE matches the single-source const
ok: UI_EXCLUDE_RE copies across the corpus match the single-source const
ok: .claude/skills is a symlink
ok: .claude/skills symlink agrees with marketplace source (./claude-plugins/kampus-pipeline + /skills)
validate-gate-path-drift: OK — 34 checks; CONTROL_PLANE_RE copies and symlink agree with §CP / marketplace
```

**2. Every column-0 boundary assignment present exactly once and byte-identical to its const.** Re-derived at `5b3959a3` — each row compares the file's `^NAME='…'` line against what `pipeline-cli control-plane-paths --boundary <NAME>` prints (`CONTROL_PLANE_RE` compares against the bare `control-plane-paths` output, as invariant 1 does):

```
CONTROL_PLANE_RE      col-0 occurrences=1  line=1529  vs const: IDENTICAL
GUARD_ADR_RE          col-0 occurrences=1  line=1600  vs const: IDENTICAL
HAS_CODE_RE           col-0 occurrences=1  line=2012  vs const: IDENTICAL
HAS_SKILLS_RE         col-0 occurrences=1  line=2013  vs const: IDENTICAL
HAS_DOCS_EXCLUDE_RE   col-0 occurrences=1  line=2014  vs const: IDENTICAL
HAS_DOCS_RE           col-0 occurrences=1  line=2015  vs const: IDENTICAL
DOC_VOCAB_EXCLUDE_RE  col-0 occurrences=1  line=2097  vs const: IDENTICAL
DOC_VOCAB_SURFACE_RE  col-0 occurrences=1  line=2098  vs const: IDENTICAL
CLAIM_RE              col-0 occurrences=1  line=3305  vs const: IDENTICAL
```

The boundary-regex subset also hashes **identically** on both sides at this head — `grep -E "^[A-Za-z_][A-Za-z0-9_]*_RE=" | shasum -a 256` yields `444af9e30295eca65974b507e5078472cd38cc98713aec0687829eb6812ad53a` at `origin/main` and at `5b3959a3`. No boundary regex changed. The `CLAIM_RE=` trap holds: exactly one column-0 occurrence (line 3305), and the illustrative copy at line 3274 is still **indented**, not promoted.

**3. `pipeline-cli control-plane-paths --paths` covers everything the deleted prose enumerated.**

```
$ pipeline-cli control-plane-paths --paths
.claude/
.github/
.claude-plugin/
claude-plugins/kampus-pipeline/skills/ship-it/
claude-plugins/kampus-pipeline/skills/review-code/
claude-plugins/kampus-pipeline/skills/review-doc/
claude-plugins/kampus-pipeline/skills/review-skill/
claude-plugins/kampus-pipeline/skills/review-design/
claude-plugins/kampus-pipeline/skills/review-plan/
claude-plugins/kampus-pipeline/skills/triage/
claude-plugins/kampus-pipeline/skills/write-code/
claude-plugins/kampus-pipeline/skills/plan-epic/
claude-plugins/kampus-pipeline/skills/release/
claude-plugins/kampus-pipeline/skills/review-trivial/
claude-plugins/kampus-pipeline/skills/**/*.sh
claude-plugins/kampus-pipeline/agents/
claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
claude-plugins/kampus-pipeline/hooks/
claude-plugins/kampus-pipeline/hooks.json
packages/ci-required/
packages/pipeline-cli/src/*
packages/pipeline-cli/src/tools/ci-required/
packages/pipeline-cli/src/tools/codeowners-cp/
packages/pipeline-cli/src/tools/control-plane-paths/
packages/pipeline-cli/src/tools/cp-cardinality/
packages/pipeline-cli/src/tools/cp-classify/
packages/pipeline-cli/src/tools/review-head/
packages/pipeline-cli/src/tools/trivial-diff/
packages/pipeline-cli/src/tools/verdict/
packages/pipeline-cli/src/tools/tracker/gh-io.ts
biome.jsonc
biome-plugins/
**/lefthook*
**/.lefthook*
```

Walking the deleted bullets against that list: `.claude/**`, `.github/**`, `.claude-plugin/**`, the eleven gate-critical skill dirs, the `skills/**/*.sh` shape, `agents/**`, this file, `hooks/` + `hooks.json`, `packages/ci-required/`, the three `pipeline-cli` enforcement-core clauses (`src/*` non-recursive, the eight tool dirs, `tools/tracker/gh-io.ts`), `biome.jsonc`, `biome-plugins/`, and the lefthook shape — every enumerated member is present. The only prose *not* covered by `--paths` is the exclusion set, which is why it was retained rather than deleted (see `## Deviations`).

**4. Heading list unchanged — heading diff is empty.** Extracted fence-aware (an ATX-looking line inside a ` ```bash ` fence is a shell comment, not a heading) from the base file at `11742ba8` and from head `5b3959a3`:

```
$ diff <base headings> <head headings>
$ echo $?
0
$ wc -l <base headings> <head headings>
     119 base
     119 head
```

Zero heading lines added, removed, renamed, or reordered — so no in-repo anchor link under `claude-plugins/` is orphaned. No `<a id="…">` anchor was touched either.

**5. The PR changes only `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`.**

```
$ git diff --stat 11742ba8 5b3959a3
 .../skills/gh-issue-intake-formats.md              | 280 ++++-----------------
 1 file changed, 50 insertions(+), 230 deletions(-)
```

**6. Line count, both re-measured at this head.** Base (`11742ba8`, byte-identical to the file at `origin/main` `5511098a`): **4,171** lines. Head (`5b3959a3`): **3,991** lines. A reduction of **180** lines (−4.3%). The figures quoted in the issue brief and the triage note were both stale against this head and are deliberately not repeated here.

## Other checks run at this head

- `bash claude-plugins/kampus-pipeline/skills/validate-skills.sh` → `OK — 30 skills valid`
- `pipeline-cli adoption-lint check` over the exact CI corpus → `clean — no un-cited re-derivations of a tool-owned decision, and every declared exemption is valid`. Leg (c) *improves* this posture: it removes the hand-rolled `claim is-mine` resolution the manifest fingerprints and replaces it with the verb cite.
- `pipeline-cli gh-phoenix lint-skills` over the exact CI corpus → `clean`
- `pnpm lint:worktree` → no biome-handled changed files (markdown-only diff, clean skip)
- `pipeline-cli` unit tests for every tool that parses this file at run time — `trivial-diff`, `class-probe`, `guard-content-probe`, `codeowners-cp`, `control-plane-paths`, `adoption-lint`, `gate-boundaries` → 16 files, 241 tests, all passing

## Deviations

**Class: scope — deliberately retained content the ticket's leg (a) could be read as deleting.**

Leg (a) says to replace the §CP path enumeration with a statement of what the set governs plus a cite to `pipeline-cli control-plane-paths --paths`. The deleted block also carried three **deliberate-exclusion** notes — nested `.claude-plugin/` dirs, the `heal-ci`/`what-shipped`/`doctor`/`wayfinder` skills, and `claude-plugins/pipeline-crew/agents/**`. These are **not** paths `--paths` prints; by construction it prints only members. Deleting them would have violated the ticket's own standard — "nothing the prose said is lost, only relocated to its single source" — because there is no single source that prints a non-member.

They are therefore **retained in condensed form**: each exclusion is named with its authority (ADR 0212, ADR 0174, the founder ruling on #3765) and, for the crew defs, the one-sentence containment argument, dropping the full paragraph-per-exclusion narration. Roughly 35 lines became 13. If the reviewer's reading is that the exclusions should have gone entirely, this is the line to push back on.

**Class: scope — one adjacent lead-in sentence rewritten outside the three named blocks.**

The sentence immediately above leg (c)'s fenced block read "The canonical resolution (read tolerantly per the §Reading stance):" and introduced the reference implementation that leg (c) removes. Left alone it would have introduced a block that is no longer a resolution, so it now reads "The matcher that resolution scans with is the one machine-readable copy in this file". Six words changed, no meaning added; it is a consequence of leg (c), not separate work.

**Class: none of the other six.** No behavior/API change (this is an instruction surface with no runtime). No new dependency. No test deleted, weakened, or skipped. No suppression, pragma, or lint disable added. No assertion removed. No guard, gate, or invariant relaxed — the `CLAIM_RE=` line and all eight other column-0 boundary assignments are byte-identical, `validate-gate-path-drift.sh` passes, and no anti-self-authorization property was moved to an in-tree import.

**(rebase round) Class: scope — rebased onto `origin/main` (`11742ba8`), carrying one landed sentence across the conflict.**

The branch's base (`3ab8b882`) went stale when #4437 merged into the same file, leaving the PR `mergeable_state: dirty`. Rebased onto `11742ba8`. The single conflict was in §CP, where #4437 had appended a reconciling clause to the very `Deliberately OUT of §CP` bullet leg (a) replaces. Resolving toward this PR's condensed exclusion paragraph alone would have silently reverted that landed §CP work, so the clause was carried into the condensed paragraph: the `heal-ci`/`what-shipped`/`doctor`/`wayfinder` exclusion scopes to skill **dirs**, so `doctor/doctor.sh` is still §CP by the `.sh` clause, which scopes to `.sh` **files** at any depth. Two lines, no new claim. #4437's other two changes — §5's "a re-review at a **new** head appends and leaves the prior head's verdict standing" rule, and the Milestone section's triage-seam scoping plus its plan-epic reconciling clause — sit outside the conflict, merged verbatim, and are verified present at this head.

Re-measured at the rebased head: `validate-gate-path-drift.sh` → `OK — 34 checks`; the fence-aware heading diff against `origin/main` is empty at 119/119 headings; the diff is still one file (49 insertions, 229 deletions against the new base). The set of column-0 `^NAME=` assignments this PR removes is byte-identical to the pre-rebase head, and the **boundary-regex subset** (`^…_RE=`) hashes **identically** at `origin/main` and at this head (`444af9e30295eca65974b507e5078472cd38cc98713aec0687829eb6812ad53a`) — the boundary is untouched. The four assignments the diff does remove are the §7 reference implementation's local shell variables, exactly leg (c)'s stated cut; `CLAIM_RE=` survives at column 0, byte-identical, exactly once, with the illustrative copy still indented.

**(rebase round) Class: process — pushed by refspec rather than `pipeline-cli verified-push`.**

The PR branch is checked out in the original build lane's worktree, so this repair lane rebased on a detached HEAD — which `verified-push` resolves to UNKNOWN and refuses to push (known gap, #4414). Pushed as `HEAD:refs/heads/<branch>` with `--force-with-lease` pinned to the prior head `137f3df3`, never `--no-verify`. The landing was confirmed independently: `GET /git/ref/heads/<branch>` returns the new head, matching `pulls/4455.head.sha`.

**The prior approval is dismissed by design.** The approval was bound to `137f3df3`; the rebase moved the head, so it is staleness-invalidated under ADR 0058 and a fresh `@kamp-us/control-plane` approval at the new head is required. No route that would have avoided a genuine rebase in order to preserve it was attempted.

**(repair round 2, head `5b3959a3`) Class: scope — one pointer fixed in the file; every evidence figure in this body re-measured.**

The round-2 gate FAIL'd this PR on evidence freshness, not on the diff: it independently re-derived every substantive claim and found the diff clean. Three things were fixed.

*In the file (one line).* §CLASS cited the §CP note by its old title — *the §CP "Deliberately OUT — the crew engine defs" note above*. Leg (a) dissolved that titled note into the single condensed `Deliberately OUT` paragraph, so the title no longer resolves; the dead-link job could not see it because it is a quoted phrase, not a markdown link. It now reads *the crew-engine-defs clause of the §CP **Deliberately OUT** paragraph above*, which resolves to the paragraph at line 1477. That is the whole file change this round: one line, `1 insertion(+), 1 deletion(-)`, no substance touched — the three condensed deliberate-exclusion notes stand as upheld in round 1.

*In this body.* Every figure in `## Acceptance criteria evidence` was re-measured at `5b3959a3` by this round rather than patched: the AC2 boundary table (line numbers now 1529 / 1600 / 2012 / 2013 / 2014 / 2015 / 2097 / 2098 / 3305), the AC6 line counts (base `11742ba8` = 4,171, head = 3,991, reduction 180), and — beyond the two failed criteria — the AC4 baseline (which still named the long-superseded `e227ec0d`) and the AC5 / `## What changed` diff stat (now 50 insertions, 230 deletions, reflecting this round's one-line change). Those last two were not called out by the gate, but they are the same stale-evidence defect on the same body, and correcting only the flagged numbers would have left knowingly-false figures on the record a control-plane approver reads.

The two rebase-round entries above are left **unrewritten**, as the round they describe recorded them; the figures they quote are explicitly scoped to that round's head `6078f7cb`.

**(repair round 2) Class: process — `verified-push` mis-pushed, and the branch was restored forward.**

`pipeline-cli verified-push --branch <branch>` was tried first this round. Because this lane works on a **detached** HEAD (the branch is checked out in the original build lane's worktree), the verb pushed the *local branch ref* — which in this shared clone still sat at the pre-rebase `137f3df3` — instead of this lane's HEAD. `git push` exited 0, and the verb's own independent `ls-remote` probe caught it: `PUSH-VERDICT: NOT-MOVED … expected=5b3959a3 observed=137f3df3`. The remote branch had been force-moved **backward** to `137f3df3`.

It was restored forward in the same round by the refspec route the rebase round already used: `git push --force-with-lease=<ref>:137f3df3 origin HEAD:refs/heads/<branch>`, never `--no-verify`. Because `5b3959a3^` is `6078f7cb` and `6078f7cb^` is `11742ba8`, the restore is a strict fast-forward over everything the backward move had dropped — no commit was lost and nothing was overwritten. Confirmed independently: `GET /git/ref/heads/<branch>` → `5b3959a3…`, matching `pulls/4455.head.sha`. The transient backward window is disclosed here rather than quietly repaired. This is the #4414 gap biting a second time, in a sharper form — the verb refuses a detached HEAD when asked to derive the branch, but pushes the wrong ref when the branch is named explicitly; filing that is follow-up work, not this PR's.

## Control-plane classification

This diff touches `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, which is a named §CP path — so **this PR is control plane** and needs a `@kamp-us/control-plane` approval at head before `ship-it` may enqueue it. Re-confirmed at this head against the live boundary:

```
$ pipeline-cli cp-classify classify --files-file <changed files> --repo kamp-us/phoenix
cp-classify: control-plane [path-match] — claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md matches the live CONTROL_PLANE_RE. BLOCKING (human merge).
control-plane
$ echo $?
0
```

`ship-it` re-resolves the classification from `origin/main` itself; this block is stated for the reviewer's convenience.
