### PR TITLE
chore(pipeline): pin the §CP-gated scripts destination and land the sourced common lib (#4446)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Cross-script state for the pipeline skills' extracted shell (epic #4435 phase 1).
+# Sourced, never executed: it defines functions and sets no shell options, so the sourcing
+# script keeps its own `set -euo pipefail`.
+#
+# DESTINATION CONVENTION — read this before adding any file under skills/ (#4446).
+#   per-skill script   claude-plugins/kampus-pipeline/skills/<skill>/scripts/<name>.sh
+#   this shared lib    claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
+# `.sh` ONLY, at any depth. `.github/CODEOWNERS` gates
+# `/claude-plugins/kampus-pipeline/skills/**/*.sh` to @kamp-us/control-plane and §CP's
+# CONTROL_PLANE_RE carries the matching `skills/([^/]+/)*[^/]+\.sh$` branch (ADR 0174), so a
+# `.sh` file here needs a human approval to merge. A NON-`.sh` file here matches no
+# CODEOWNERS row at all — and because that file has no `*` catch-all and the branch's
+# required_approving_review_count is 0, an unmatched path merges with ZERO approvals.
+# Measured, not assumed: `pipeline-cli cp-classify classify` exits 3 `not-control-plane` for
+# `claude-plugins/kampus-pipeline/skills/shared/lib/common.env` and for an extensionless
+# `claude-plugins/kampus-pipeline/skills/shared/lib/common`, and exits 0 `control-plane` for
+# this file and for `claude-plugins/kampus-pipeline/skills/ship-it/scripts/<name>.sh`. So a
+# non-`.sh` helper must land its covering CODEOWNERS row and CONTROL_PLANE_RE branch FIRST.
+#
+# SOURCING IDIOM — resolve relative to this file so the caller's cwd is irrelevant. From a
+# script in a per-skill scripts/ directory:
+#   . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The target repo as `owner/name`. Fails closed rather than yielding an empty string, which
+# would silently address `gh api repos//…` (§Target repo resolution, ADR 0062 §1).
+kp_repo() {
+	if [ -n "${CLAUDE_PIPELINE_REPO:-}" ]; then
+		printf '%s\n' "$CLAUDE_PIPELINE_REPO"
+		return 0
+	fi
+	local repo
+	repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)" || return 1
+	if [ -z "$repo" ]; then
+		printf 'kp_repo: could not resolve the target repo — set CLAUDE_PIPELINE_REPO=owner/name, or run inside the target git repo.\n' >&2
+		return 1
+	fi
+	printf '%s\n' "$repo"
+}
+
+# Absolute path to the pipeline-cli shim. Never a bare `pipeline-cli`: that resolves against
+# PATH, is not there, and dies `command not found` inside a fail-closed wrapper that would
+# launder the miss into a verdict (§CLI, ADR 0207). Exit 127 here means the CLI never ran —
+# UNKNOWN, never a clean or negative answer.
+kp_pcli() {
+	local root pcli
+	root="${CLAUDE_PLUGIN_ROOT:-}"
+	if [ -z "$root" ]; then
+		root="$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline"
+	fi
+	pcli="$root/bin/pipeline-cli"
+	if [ ! -x "$pcli" ]; then
+		printf 'kp_pcli: UNRESOLVED at %s — the CLI never ran, so the caller has NO result (§CLI).\n' "$pcli" >&2
+		return 127
+	fi
+	printf '%s\n' "$pcli"
+}
+
+# The per-run scratch namespace for <slug> (§SP, #3718). `open` is the run's first write of
+# scratch state; `path` re-derives it in every later call. Both print the absolute directory.
+kp_scratch_open() { kp__scratch "open" "$1"; }
+kp_scratch_path() { kp__scratch "path" "$1"; }
+
+# Prefer the `pipeline-cli scratchpad` verb, which owns exclusive allocation; the inline
+# recipe is §SP's documented no-CLI fallback for a foreign install (ADR 0062). Exit codes
+# mirror the verb's taxonomy: 2 no session id, 3 bad slug, 5 never opened, 6 filesystem.
+kp__scratch() {
+	local mode="$1" slug="$2" pcli dir
+	case "$slug" in
+		'' | */* | . | ..)
+			printf 'kp_scratch: slug must be a single path segment (§SP).\n' >&2
+			return 3
+			;;
+	esac
+	if pcli="$(kp_pcli 2>/dev/null)"; then
+		"$pcli" scratchpad "$mode" --slug "$slug"
+		return
+	fi
+	if [ -z "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+		printf 'kp_scratch: CLAUDE_CODE_SESSION_ID unset — refusing to write run state to a shared scratch path (§SP).\n' >&2
+		return 2
+	fi
+	dir="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/$slug"
+	if [ "$mode" = "open" ]; then
+		# Clears what an earlier run of this same slug in this same session left behind. `path`
+		# must never do this — it would delete the state the caller came to read.
+		rm -rf "$dir"
+		if ! mkdir -p "$dir"; then
+			printf 'kp_scratch: could not create the per-run scratch dir (§SP).\n' >&2
+			return 6
+		fi
+	elif [ ! -d "$dir" ]; then
+		printf 'kp_scratch: namespace for slug %s was never opened in this session (§SP).\n' "$slug" >&2
+		return 5
+	fi
+	printf '%s\n' "$dir"
+}


### PR DESCRIPTION
Before any of the pipeline's gate-deciding shell moves out of skill markdown, we need to know the place it lands is one a human must approve. This PR pins that destination — per-skill scripts at `claude-plugins/kampus-pipeline/skills/<skill>/scripts/*.sh` plus one shared lib at `claude-plugins/kampus-pipeline/skills/shared/lib/common.sh` — proves the control-plane gate covers it in both directions, and lands the lib itself. The lib carries the three things every fenced block re-derives today: the target repo, the `pipeline-cli` shim path, and the per-run scratch namespace.

Fixes #4446

## Why the proof had to come first

`.github/CODEOWNERS` has no `*` catch-all and the branch's `required_approving_review_count` is 0, so a path matching **no** CODEOWNERS row merges with **zero** approvals. Putting the single source of every gate's behaviour somewhere unmatched would make it silently self-mergeable with all machine gates green. Hence: prove the destination, then move shell.

## The §CP proof — both directions

Run with `pipeline-cli cp-classify classify --repo kamp-us/phoenix`, resolving `CONTROL_PLANE_RE` live from `origin/main`. Exit 0 = control-plane, exit 3 = proven-ordinary.

**Accepts (`.sh` under `skills/`, at any depth):**

| Path | Verdict | Exit |
|---|---|---|
| `claude-plugins/kampus-pipeline/skills/ship-it/scripts/resolve-verdict.sh` | `control-plane [path-match]` | **0** |
| `claude-plugins/kampus-pipeline/skills/shared/lib/common.sh` | `control-plane [path-match]` | **0** |

**Rejects (non-`.sh` in the same destination tree) — the fail-closed half:**

| Path | Verdict | Exit |
|---|---|---|
| `claude-plugins/kampus-pipeline/skills/shared/lib/common.env` | `not-control-plane [path-clear-no-content-source]` | **3** |
| `claude-plugins/kampus-pipeline/skills/shared/lib/common` (extensionless) | `not-control-plane [path-clear-no-content-source]` | **3** |

`pipeline-cli codeowners-cp check` → `all 34 §CP path(s) covered by .github/CODEOWNERS`, **exit 0**.

`claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` → `OK — 34 checks`.

**Conclusion (AC 4):** every destination path this PR pins is `.sh`, so all of them are already covered by the existing CODEOWNERS row `/claude-plugins/kampus-pipeline/skills/**/*.sh` and by `CONTROL_PLANE_RE`'s `^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$` branch (ADR 0174). **No new row and no regex-branch extension is needed**, and none is landed here. The negative runs are what make that a proof rather than an assumption: they show the boundary rejecting something, and they pin the constraint that the destination convention is **`.sh` only** — a non-`.sh` helper in this tree would be ungated, so one must land its covering row first. That constraint is recorded in the lib header, not just here.

This deliberately does not touch the boundary regex, so it does not collide with the parked PR #4440 (which widens `skills/shared/**` for markdown); if that lands later it neither needs nor breaks anything here.

## What the lib carries, and what each piece is grounded against

| Function | Carries | Grounded against |
|---|---|---|
| `kp_repo` | target repo as `owner/name`, `$CLAUDE_PIPELINE_REPO` override then `gh repo view` | the intake contract's **Target repo resolution** section (ADR 0062 §1) — the one-line form appearing ~20× across the skills corpus |
| `kp_pcli` | absolute path to the `pipeline-cli` shim, refusing with exit 127 when unresolved | the contract's **§CLI canonical preamble** and its exit-code taxonomy (ADR 0207) — the identical `PCLI=` line appears 57× across the corpus |
| `kp_scratch_open` / `kp_scratch_path` | the per-run scratch namespace, via the `pipeline-cli scratchpad` verb with §SP's documented no-CLI inline recipe as fallback | the contract's **§SP** section (#3718), including its open-vs-re-derive distinction and its exit codes (2 no session, 3 bad slug, 5 never opened, 6 filesystem) |

The lib is sourced, never executed, and sets no shell options, so a sourcing script keeps its own `set -euo pipefail`.

**Verification:** `shellcheck` is installed here and the file is clean (exit 0). Sourced smoke run: `kp_repo` → `kamp-us/phoenix`; `kp_pcli` → the worktree's shim; `kp_scratch_open` then `kp_scratch_path` on the same slug re-derive the same directory and the written file survives; `kp_scratch_path` on a never-opened slug exits 5; a slug containing `/` exits 3.

**Convention note (AC 1)** lives in the lib header: the destination pattern, the `.sh`-only constraint with the measured reason, and the sourcing idiom

```
. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
```

which resolves from a per-skill `scripts/` directory regardless of the caller's cwd. All paths in the header are repo-relative.

## Scope

No skill's fenced blocks are touched. Extraction is #4448/#4449/#4450/#4451/#4452/#4453/#4454, all held behind this. One file added, 97 lines.

## Deviations

- **Scope narrowing** — **Said:** #4446's AC 1 offers "a scripts-directory README **or** the lib header" for the convention note. **Did:** the lib header only; no README. **Why:** a `README.md` in this tree is exactly the negative case proven above — it matches no CODEOWNERS row and would merge with zero approvals, so landing the convention note as an ungated file in the destination being pinned would contradict the ticket's own invariant. **Disposition:** no action needed; the AC allows either surface and the header is the one every extraction-script author reads.
- **Out-of-scope change** — **Said:** the epic's phase-1 rule is byte-preserving relocation of existing glue. **Did:** `kp_repo` fails closed with a message instead of yielding an empty string, which the canonical `REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view …)}"` one-liner does silently on a `gh` failure (it would then address `gh api repos//…`). **Why:** this is new code, not a relocated block — nothing is being byte-moved yet — and the lib is the single place a later script can inherit the check from. **Disposition:** for the reviewer to judge; the resolution order and both sources are unchanged from the contract.
- **Known defect left unfixed** — **Said:** nothing; observed while proving the boundary. **Did:** did not add any mechanical guard that a new non-`.sh` file cannot enter `skills/`. **Why:** out of this ticket's scope, and the epic explicitly parks the no-new-shell enforcement guard behind the ADR child #4447. **Disposition:** no follow-up filed — the constraint is recorded in the lib header and in this PR body, and enforcement is already an epic-level open item.
