### PR TITLE
chore(pipeline-agents): single-source the byte-identical shared invariants (#4406)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/STANDING-INVARIANTS.md
+++ b/claude-plugins/kampus-pipeline/agents/STANDING-INVARIANTS.md
@@ -1,0 +1,51 @@
+# Standing invariants — the shared block
+
+The `## Standing invariants` section of a `claude-plugins/kampus-pipeline/agents/` definition is
+mostly agent-specific. A few entries are not: they are **byte-identical** across two or more
+definitions, and those live here once instead of being re-carried per file.
+
+Each definition keeps the rule **named at the position its full text occupied** and cites the entry
+here for the detail. That placement is load-bearing: these are rules an agent must *apply* at a
+specific moment, not background it must merely know, so the cite has to fire where the paragraph
+used to.
+
+**Scope: the `kampus-pipeline` agent definitions only.** `claude-plugins/pipeline-crew/agents/**`
+is deliberately outside the control-plane boundary (founder ruling #3765) and does not read this
+file; nothing here is a cross-plugin dependency.
+
+<a id="sp"></a>
+
+## §SP — the per-run scratch namespace
+
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
+  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
+  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
+  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
+  over another's (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate the namespace with the verb and name every leaf under it:
+  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
+  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
+  your shell state does not survive between Bash calls, so nothing you set carries over. The
+  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
+  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
+  the path in another file to carry it across — that just moves the collision onto that file.
+  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
+
+<a id="rest"></a>
+
+## §REST — the GitHub access path
+
+- **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
+  Projects-classic integration that breaks GraphQL issue/PR queries; every read and write
+  goes through `gh api`.
+
+<a id="root"></a>
+
+## §ROOT — the working directory
+
+- **Work from the repo root**, not a nested app directory.

--- a/claude-plugins/kampus-pipeline/agents/adr.md
+++ b/claude-plugins/kampus-pipeline/agents/adr.md
@@ -72,25 +72,8 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** The ADR body, its links, and
   your return summary cite repo-relative paths only (`.decisions/NNNN-slug.md`, `apps/web/worker/…`) —
   never a `~/`, `/Users/…`, vault, or sibling-clone path, and no Obsidian `[[wikilinks]]`.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
-- **Work from the repo root**, not a nested app directory.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
+- **Work from the repo root** ([§ROOT](./STANDING-INVARIANTS.md#root)).
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal
 

--- a/claude-plugins/kampus-pipeline/agents/canon.md
+++ b/claude-plugins/kampus-pipeline/agents/canon.md
@@ -77,24 +77,7 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   row, and your return summary cite repo-relative paths only (`.patterns/<name>.md`,
   `apps/web/worker/…`) — never a `~/`, `/Users/…`, vault, or sibling-clone path, and no Obsidian
   `[[wikilinks]]`.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
 - **Work from the repo root**, not a nested app directory. Resolve it with
   `git rev-parse --show-toplevel` and operate on `<root>/.patterns/`.
 

--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -64,31 +64,12 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   path is only for a genuine standalone (non-coder) run; self-provisioning here would paper over
   the harness failure and collapse the two-layer primary-corruption defense to one, invisibly
   (the #2270 class). Surface the preflight's ROUTED BLOCKER up to the operator/EM instead.
-- **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
-  Projects-classic integration that breaks GraphQL issue/PR queries; every read and write
-  goes through `gh api`.
+- **All GitHub ops via `gh api` REST — never GraphQL** ([§REST](./STANDING-INVARIANTS.md#rest)).
 - **No home / local / absolute / sibling-repo paths in any artifact.** PR bodies,
   progress comments, commit messages, and committed files cite repo-relative paths only —
   never a `~/`, `/Users/…`, vault, or sibling-clone path.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
-- **Work from the repo root**, not a nested app directory.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
+- **Work from the repo root** ([§ROOT](./STANDING-INVARIANTS.md#root)).
 - **State a *why* ONCE — collapse duplicated docblocks to a pointer.** In the code you
   generate, apply CLAUDE.md's "Comments earn their place or die" convention: state a
   rationale at its single most load-bearing site, and collapse any docblock that

--- a/claude-plugins/kampus-pipeline/agents/planner.md
+++ b/claude-plugins/kampus-pipeline/agents/planner.md
@@ -85,25 +85,8 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** The plan body, child
   bodies, journal notes, and progress comments cite repo-relative paths only — never a `~/`,
   `/Users/…`, vault, or sibling-clone path.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
-- **Work from the repo root**, not a nested app directory.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
+- **Work from the repo root** ([§ROOT](./STANDING-INVARIANTS.md#root)).
 - **Plan only — never implement, review, or merge.** You write issues, never repo files (you
   carry no Edit/Write tool). You do not write code, do not run a review skill, do not flip a
   child `status:planned → status:triaged` (that's the `review-plan` gate's job, ADR 0047),

--- a/claude-plugins/kampus-pipeline/agents/reporter.md
+++ b/claude-plugins/kampus-pipeline/agents/reporter.md
@@ -59,25 +59,8 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   / `user.name`. Never a `/Users/…`, `~/`, vault, or sibling-clone path — in the footer
   *or* in the body. Pointers cite repo-relative paths only. Generate the footer with
   `footer.sh`; if you ever assemble it by hand, scrub the same way.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
-- **Work from the repo root**, not a nested app directory.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
+- **Work from the repo root** ([§ROOT](./STANDING-INVARIANTS.md#root)).
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal
 

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -293,31 +293,12 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   fi
   echo "reviewer coverage self-check: all $NS_COUNT required namespace(s) (${REQUIRED_NS//$'\n'/ }) have a SHA-bound marker @ $HEAD_SHA — coverage complete."
   ```
-- **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
-  Projects-classic integration that breaks GraphQL issue/PR queries; every read and write
-  goes through `gh api`.
+- **All GitHub ops via `gh api` REST — never GraphQL** ([§REST](./STANDING-INVARIANTS.md#rest)).
 - **No home / local / absolute / sibling-repo paths in any artifact.** Verdict comments
   and any prose cite repo-relative paths only — never a `~/`, `/Users/…`, vault, or
   sibling-clone path.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
-- **Work from the repo root**, not a nested app directory.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
+- **Work from the repo root** ([§ROOT](./STANDING-INVARIANTS.md#root)).
 - **Verify only — never edit, never merge, never review your own work.** You hold no
   Edit/Write tool by construction. You land a verdict; the merge is never yours — `ship-it`
   is the consumer that asserts your PASS and squash-merges. You never flip a FAIL to PASS

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -105,24 +105,7 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** Progress comments and
   any text you post cite repo-relative paths only — never a `~/`, `/Users/…`, vault, or
   sibling-clone path.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal
 

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -89,31 +89,12 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   before you close. A human-filed issue you can't act on as-is goes to `status:needs-info`
   with specific questions — **never closed**. Closing not-planned is a last resort and
   only ever for an *agent*-filed issue that can't be salvaged.
-- **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
-  Projects-classic integration that breaks GraphQL issue/PR queries; every read and write
-  goes through `gh api`.
+- **All GitHub ops via `gh api` REST — never GraphQL** ([§REST](./STANDING-INVARIANTS.md#rest)).
 - **No home / local / absolute / sibling-repo paths in any artifact.** Issue bodies,
   comments, and labels cite repo-relative paths only — never a `~/`, `/Users/…`, vault,
   or sibling-clone path.
-- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
-  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
-  `/tmp/verdict-$PR.md`), and never in the harness-provided scratchpad directory — that one is
-  session-scoped and **shared across the concurrent runs of a session**, so a generic leaf name
-  gets clobbered mid-run and reads back **another run's content with no error**: silent, and it
-  routed a reviewer's `git diff` to the wrong PR's files, then wrote one reviewer's verdict body
-  over another's (#3718).
-  Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate the namespace with the verb and name every leaf under it:
-  `RUN_SCRATCH="$(pipeline-cli scratchpad open --slug <skill>-<work-item>)" || exit 1`, and in
-  every LATER Bash call re-derive it with `pipeline-cli scratchpad path --slug <same-slug>` —
-  your shell state does not survive between Bash calls, so nothing you set carries over. The
-  verb is fail-closed: a missing session id, a namespace another run owns, and one this run
-  never opened are each a distinct non-zero exit, never a fallback to a shared path. Never park
-  the path in another file to carry it across — that just moves the collision onto that file.
-  The rule, the no-CLI fallback recipe, the single-Bash-call `mktemp` carve-out, and the
-  never-leak-the-path corollary are single-sourced in the skills'
-  `gh-issue-intake-formats.md` §SP.
-- **Work from the repo root**, not a nested app directory.
+- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.
+- **Work from the repo root** ([§ROOT](./STANDING-INVARIANTS.md#root)).
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal
 


### PR DESCRIPTION
Three rules were written out in full inside more than one of the eight `kampus-pipeline` agent definitions — the same words, character for character, in up to eight files. Every one of those copies is prompt text loaded on every agent spawn, and a future correction to any of them has to be applied by hand in every place it appears. This PR moves each of the three into one file and leaves a one-line pointer where the full text used to sit, so the rule still fires at the moment an agent needs it while existing in exactly one place.

Fixes #4406

## What I re-measured, at this PR's base

Triage measured at `38156a1f`; `main` had moved. I re-ran the byte-identity measurement myself at base `11742ba8` before changing anything, hashing three granularities across all 13 agent definitions. **The premise holds unchanged at my base**, with only cosmetic line-count drift.

| granularity | measured at `11742ba8` |
| --- | --- |
| whole `## Standing invariants` section | **13 distinct SHA-1s across 13 files — zero byte-identical pairs** |
| whole `## Repo-agnostic` section | present 13/13, **10 distinct wordings** |
| individual bullets inside `## Standing invariants` | **110 instances, 90 distinct texts.** 6 texts repeat byte-identically, covering **26 of 110 (24%)**; **84 (76%) are file-unique** |

The complete byte-identical set — SHA-1, first 12 hex, over the extracted region:

| sha1 | copies | lines | rule | files |
| --- | --- | --- | --- | --- |
| `94ff2174dbf1` | 8 | 18 | §SP per-run scratch namespace | adr, canon, coder, planner, reporter, reviewer, shipper, triager — **absent from all 5 crew defs** |
| `319740aef1bb` | 9 | 1 | `Work from the repo root` | adr, coder, planner, reporter, reviewer, triager (6 pipeline) + crew-cartographer, crew-intake-desk, crew-investigator (3 crew) |
| `b40f7f34300b` | 3 | 3 | never-GraphQL | coder, reviewer, triager |
| `918b1be42063` | 2 | 2 | never-GraphQL (shorter variant) | crew-cartographer, crew-intake-desk |
| `07fa07f0f9a5` | 2 | 6 | address-peers-by-role | crew-cartographer, crew-engineering-manager |
| `61861c7e4d80` | 2 | 6 | address-peers-by-role (variant) | crew-chief-of-staff, crew-intake-desk |

Redundant copy lines (every copy beyond the first) across all 13: **154**, of which §SP alone is 126 (82%). Combined `## Standing invariants` region: **852 lines** across the 13 files.

**Deltas from triage's `38156a1f` table, and they are cosmetic only.** The §SP hash `94ff2174dbf1` reproduced exactly, as did every count above (110 / 90 / 6 / 26 / 84 / 154). Per-file line counts moved with unrelated merges: `reviewer.md` 344 → 347, `shipper.md` 146 → 152, `crew-engineering-manager.md` 528 → 527, and the combined section region 848 → 852. **No copy of any extracted block had drifted** — the script that performed the extraction asserts byte-identity in every target file and would have aborted otherwise.

## Before / after — the win as a number

Redundant copy lines **inside the 8 pipeline defs**:

| rule | before | after |
| --- | --- | --- |
| §SP (18 lines × 7 extra copies) | 126 | 7 |
| §ROOT (1 line × 5 extra pipeline copies) | 5 | 5 |
| §REST (3 lines × 2 extra copies) | 6 | 2 |
| **total** | **137** | **14** |

Across all 13 definitions the figure falls **154 → 30**; the remaining 30 are entirely inside the untouched crew defs. The combined `## Standing invariants` region falls **852 → 710 lines**. Net diff: **68 insertions, 159 deletions** across 9 files.

Re-running the measurement after the change: among the 8 pipeline defs, **no multi-line bullet is byte-identical across 2+ files.**

## The extraction target and its gate — verified, both directions

`claude-plugins/kampus-pipeline/agents/STANDING-INVARIANTS.md`. I did not assume the inherited protection; I ran `pipeline-cli cp-classify classify` on four paths and read the exit codes:

| path probed | verdict | exit |
| --- | --- | --- |
| `claude-plugins/kampus-pipeline/agents/STANDING-INVARIANTS.md` (**this PR's destination**) | `control-plane [path-match]` | **0** |
| `claude-plugins/kampus-pipeline/agents/standing-invariants.txt` (a non-`.md` type that might escape) | `control-plane [path-match]` | **0** |
| `claude-plugins/pipeline-crew/agents/STANDING-INVARIANTS.md` (the rejected alternative) | `not-control-plane [path-clear-no-content-source]` | **3** |
| `claude-plugins/kampus-pipeline/skills/review-core.md` | `not-control-plane [path-clear-no-content-source]` | **3** |

The `.github/CODEOWNERS` row is `/claude-plugins/kampus-pipeline/agents/ @kamp-us/control-plane` — a bare directory prefix with **no extension restriction**, which the `.txt` probe confirms from the other direction. So the new file is §CP automatically and **no CODEOWNERS or ruleset edit is owed**.

One live note for the record, not a change this PR makes: the `skills/**` probe still returns **exit 3**. The founder ruling on #4446 (making `claude-plugins/kampus-pipeline/skills/**` §CP in its entirety) has **not yet landed in `CONTROL_PLANE_RE` or CODEOWNERS** — today only the per-skill directory rows (`skills/write-code/`, `skills/review-code/`, …), `skills/**/*.sh`, and `skills/gh-issue-intake-formats.md` are enumerated, so a loose `.md` directly under `skills/` is still proven-ordinary. That is a separate surface from `agents/` and is out of scope here.

## What is deliberately out of scope

- **The 5 `claude-plugins/pipeline-crew/agents/` defs — untouched, verified.** Their `## Standing invariants` section hashes are byte-for-byte identical before and after (`9d523668a277`, `571e2ba1cd2b`, `d7802484294e`, `5d5d8da6bb86`, `f5c64bb1c3e3`). That tree is deliberately outside §CP by a live founder ruling (#3765), so nothing was relocated into a gated path and no coverage was extended over it. The new file states this scope boundary in its own header so a later agent does not "helpfully" widen it.
- **The three remaining multi-line shared bullets** (`07fa07f0f9a5`, `918b1be42063`, `61861c7e4d80`) are crew-only. Extracting them would require a cross-plugin dependency from a non-§CP tree into a §CP one — exactly what #3765 rules out.
- **The `## Repo-agnostic` 10-wording spread.** Real, and re-measured at 10 distinct hashes across 13 files at this base — but it is a wording-normalization job, not an extraction. Normalizing near-identical prose *into* identity to make it extractable would be manufacturing the premise rather than measuring it.
- **The 84 file-unique bullets.** Not duplication.
- **#4375 / #4371 / #4378.** The three drifted or false restatements from the same sweep all live in non-identical prose. This PR fixes none of them and must not be read as having done so.

## Deviations

**1. Scope narrowing (class 1) — the optional residual drift check is not built.**
*Said:* the issue's last acceptance criterion, marked "Optional, and welcome", asks for a drift check in the spirit of `claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` so the copies cannot silently return.
*Did:* did not build it.
*Why:* a new guard is its own CI surface with its own wiring and zero-scope semantics, which would roughly double this diff and change its risk profile from "semantics-preserving text move" to "new fail-closed gate". The AC marks it optional precisely because it is separable.
*Disposition:* follow-up #4461 filed (`status:needs-triage`), carrying the guard sketch, the scope boundary that keeps the crew defs out of it, and the two open questions triage should settle.

**2. Scope narrowing (class 1) — the §SP cite carries the rule's name, not its operational detail.**
*Said:* replace the paragraph "with a one-line cite, at the same position in `## Standing invariants` the paragraph occupied", and leave "no multi-line bullet byte-identical across 2+ files".
*Did:* the cite is exactly one line: `- **Every intermediate file lives under a per-run scratch namespace** — apply [§SP](./STANDING-INVARIANTS.md#sp) before your first file write.` It keeps the rule *named* at the original position and keeps the trigger ("before your first file write") inline, but the `pipeline-cli scratchpad open` invocation and the #3718 incident rationale now live one hop away.
*Why:* my first attempt kept the verb inline as a 3-line cite. That version was byte-identical across all 8 files at 3 lines, which fails the "no multi-line bullet byte-identical across 2+ files" criterion outright. The two criteria are only jointly satisfiable at one line, so I took the one-line form. Note the consequence honestly: this is the issue's own must-know / must-apply caveat operating at its limit — the position is preserved, the applied detail is not.
*Disposition:* for the reviewer to judge. If the applied detail must stay inline, the fix is to relax the "no multi-line byte-identical bullet" criterion rather than to move the cite.

**3. Out-of-scope change (class 7) — §REST was extracted too, though the issue's "In scope" listed only §SP and §ROOT.**
*Said:* triage's cut names the 18-line §SP paragraph and the one-line `Work from the repo root` bullet as in scope.
*Did:* also extracted the 3-line never-GraphQL bullet (`b40f7f34300b`) from `coder.md`, `reviewer.md`, `triager.md`.
*Why:* the issue's own verification criterion — "no multi-line bullet byte-identical across 2+ files" over the 8 pipeline defs — is unsatisfiable while that bullet stands, since it is 3 lines and byte-identical in 3 of them. Extracting it costs 3 one-line replacements and 3 lines in the canonical file.
*Disposition:* no action needed — it satisfies a stated criterion rather than widening scope past one.

**4. Scope narrowing (class 1) — the §ROOT cite drops its trailing clause from the defs.**
*Said:* single-source the `Work from the repo root` bullet "the same way" in the 6 pipeline defs that carry it.
*Did:* the in-place bullet became `- **Work from the repo root** ([§ROOT](./STANDING-INVARIANTS.md#root)).`; the clarifier ", not a nested app directory" now lives only in the canonical file.
*Why:* replacing a one-line rule with a one-line cite of the same length would single-source nothing — the text would still be duplicated 6 times. Moving the clarifier is what makes it an actual extraction. The rule's name is unambiguous without it.
*Disposition:* no action needed.

**Classes checked and not fired:** 2 (governing-ADR departure — ADR 0150 puts the agent defs under §CP and this PR adds a file inside that same covered directory, neither narrowing nor widening it), 5 (no guard, hook, or lint bypassed; `pnpm lint:worktree`, `pnpm typecheck`, `pipeline-cli gh-phoenix lint-skills`, and `pipeline-cli crew-fanout-guard check` all run clean, and the push went through `pipeline-cli verified-push`), 6 (no pre-existing test or fixture changed — no test file is touched).

## Verification run locally

- `pipeline-cli gh-phoenix lint-skills` over all 9 changed files — clean (frontmatter, GraphQL-path, bare-push).
- `pipeline-cli crew-fanout-guard check` — clean. `STANDING-INVARIANTS.md` carries no frontmatter, so `parseAgentDef` returns null and the file is correctly **not** admitted to the spawnable roster (still 12 mutating agent-types).
- `pnpm lint:worktree` — markdown-only diff, clean skip.
- `pnpm typecheck` — 29/29 successful.
