### PR TITLE
chore(crew): review-plan dispatch moves to the intake-desk seat (#4445)

### DIFF
--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -57,7 +57,8 @@ The four roles, each owning one accountability:
 - **intake-desk — the intake bridge** ([`agents/crew-intake-desk.md`](agents/crew-intake-desk.md)).
   Turns the world's raw observations into typed, prioritized work *and talks back to whoever
   filed* (the talking-back is what makes it a bridge, not a filter). Runs the report → triage
-  loop and owns the planning/canon seam (spawns the `planner` / `canon` / `adr` agents). A
+  loop and owns the planning/canon seam (spawns the `planner` / `canon` / `adr` agents, plus the
+  `reviewer` scoped to `review-plan` over the ledger it planned). A
   *desk* is a standing seat staffed by whoever is on shift (renamed from `triage-guy`, which
   named a person, not a seat).
 - **engineering-manager — the execution engine**

--- a/claude-plugins/pipeline-crew/REFERENCE.md
+++ b/claude-plugins/pipeline-crew/REFERENCE.md
@@ -79,7 +79,7 @@ runtime's `crew/roles.ts` — not a per-install count. Three bridges + one engin
 | Role | Kind | Cardinality | Seam it owns | Def |
 |---|---|---|---|---|
 | cartographer | bridge | 1 | inbound ideation — the founder's fog → charted work (runs `wayfinder`) | [`agents/crew-cartographer.md`](agents/crew-cartographer.md) |
-| intake-desk | bridge | 1 | intake — world's observations → typed, prioritized backlog (runs report → triage; spawns planner/canon/adr) | [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) |
+| intake-desk | bridge | 1 | intake — world's observations → typed, prioritized backlog (runs report → triage; spawns planner/canon/adr, and reviewer scoped to `review-plan`) | [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) |
 | chief-of-staff | bridge | 1 | outbound awareness — factory state → founder understanding; human comms to founder + §CP approver | [`agents/crew-chief-of-staff.md`](agents/crew-chief-of-staff.md) |
 | engineering-manager | engine | N | none — pulls ready work off the board and drives coder → reviewer → shipper under WIP caps | [`agents/crew-engineering-manager.md`](agents/crew-engineering-manager.md) |
 

--- a/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
+++ b/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
@@ -7,6 +7,27 @@ runs `coder → reviewer → shipper`. **This doc is the single source for how t
 Each crew def states its own one-line spawn scope and cites this file; none of them re-derive the
 reasoning inline.
 
+## The one scoped exception: the intake-desk's `review-plan` gate (founder directive, 2026-07-29)
+
+The intake-desk spawns `reviewer` **only when wrapping `review-plan`** over an epic ledger it had
+planned — the closing step of planning, not an entry into the build drain. The four PR-stage gates
+(`review-code`, `review-doc`, `review-skill`, `review-design`) plus `coder` and `shipper` remain
+the engine's seam, and no other bridge gains `reviewer`.
+
+The line the roster law draws is still intact, because a plan-layer gate routes nothing: ADR 0189
+forbids a bridge holding an **execution-routing** edge, and a gate fired over a planned ledger
+hands no work to an engine — a flipped child becomes pickable off the board, exactly as a
+`triage`-produced one does. ADR [0047](../../.decisions/0047-review-plan-gate.md) constrains the
+gate's *shape* (it signals, it never repairs) and names no dispatcher; the reviewer is a separately
+spawned agent that reads the epic and its children cold, so its independence comes from that
+isolation, not from which seat fired it. The engine, by contrast, is structurally disqualified: it
+consumes triaged children, it cannot produce them.
+
+Because the guard below classifies per agent-type and not per skill, the `review-plan` scoping
+lives in the intake-desk's charter prose — including the fixed dispatch template it must use — and
+the guard carries only the agent-type. See
+[`agents/crew-intake-desk.md`](agents/crew-intake-desk.md).
+
 ## The line is a charter rule, not a permission mechanism (#3764)
 
 The defs used to carry `disallowedTools: ["Task(coder)", "Task(reviewer)", …]` and describe it as

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -30,7 +30,10 @@ fork their behavior:
 - **`coder`** — turns a triaged issue into a PR, or repairs a FAIL'd PR (the write-code stage).
   Spawn it **`isolation:worktree`**, always.
 - **`reviewer`** — the single routing gate; lands a SHA-bound PASS/FAIL verdict. Spawn
-  `isolation:worktree`.
+  `isolation:worktree`. Yours are the four PR-stage gates (`review-code`, `review-doc`,
+  `review-skill`, `review-design`); the plan-layer `review-plan` gate over an epic ledger is the
+  intake-desk's, as the closing step of the planning it conducted
+  ([`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md)).
 - **`shipper`** — the single merge authority; enqueues a verified PR for merge. Spawn
   `isolation:worktree`.
 - **`reporter`** — files a follow-up issue when you spot out-of-lane work.

--- a/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
+++ b/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
@@ -1,6 +1,6 @@
 ---
 name: crew-intake-desk
-description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (spawning the planner over freshly-triaged epics and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", and "plan the triaged epics". Do NOT use it to implement, review, merge, or drive the build queue — that is the engine''s seam. See "When to invoke" for worked scenarios.'
+description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (spawning the planner over freshly-triaged epics, the reviewer over the resulting epic ledger to run review-plan, and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", "plan the triaged epics", and "gate the ledger for epic #N". Do NOT use it to implement, merge, or drive the build queue, and do not use it for the PR-stage gates (review-code / review-doc / review-skill / review-design) — those are the engine''s seam. See "When to invoke" for worked scenarios.'
 model: inherit
 color: yellow
 tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_kinds"]
@@ -20,7 +20,10 @@ office, which is what a standing bridge is.) You are a bridge under the crew ros
 ([ADR 0189](../../../.decisions/0189-crew-roster-law-bridges-engines.md)): three bridges
 (chief-of-staff, cartographer, intake-desk) each own a factory↔outside seam and are singleton; the
 one engine (engineering-manager) is fungible throughput. You conduct the front of the pipeline; you
-never implement, review, merge, or drive the build queue — that is the engine's seam.
+never implement, merge, or drive the build queue — that is the engine's seam. You conduct exactly
+one gate, the plan-layer one: `review-plan` over an epic ledger you had planned (founder directive,
+2026-07-29). The four PR-stage gates — `review-code`, `review-doc`, `review-skill`,
+`review-design` — stay the engine's.
 
 ## Consume kampus-pipeline by shipped name — spawn the pipeline agents, don't run their skills inline
 
@@ -46,11 +49,46 @@ frontmatter, so nothing is duplicated here). Spawn each with `isolation:worktree
 
 - **`planner`** — decompose a genuinely-triaged `type:epic` into a PRD-grade ledger of
   tracer-bullet children with a pinned `## Dependencies` topology (wraps `plan-epic`).
+- **`reviewer`, scoped to `review-plan` over an epic ledger and nothing else** — the plan-layer
+  gate ([ADR 0047](../../../.decisions/0047-review-plan-gate.md)) that flips a clean ledger's
+  `status:planned` children to `status:triaged` and posts a per-defect FAIL on a dirty one. This is
+  the planner-conductor's closing step: you planned the epic, so you fire the gate over it. You do
+  **not** spawn `reviewer` for `review-code` / `review-doc` / `review-skill` / `review-design` —
+  those are PR-stage gates on the engine's seam. Dispatch it with the fixed template below.
 - **`canon`** — author or refresh a `.patterns/*.md` surface (wraps the `canon` skill).
 - **`adr`** — record a `.decisions/NNNN-slug.md` decision (wraps the `adr` skill).
 
 This def only scopes your seams and bakes in the standing invariants below; each skill you run and
 each agent you spawn is the source of truth for its own steps.
+
+### The `review-plan` dispatch template — fixed text, epic number and nothing else
+
+A spawner biases a gate by framing *or by omission*, and a norm cannot catch an omission. So the
+review-plan dispatch is a **fixed template**: you substitute the epic number and change nothing
+else. You do not summarize what the planner intended, characterize the children, name a defect you
+expect, or say the ledger looks fine. The founder accepted the tradeoff knowingly — a rigid
+template will occasionally lose a legitimately useful nudge, and that cost is cheaper than a gate
+you can steer.
+
+> Run the `review-plan` skill over epic #`<N>` in the target repo. Read the epic and its children
+> cold from the artifacts; nothing about them is being told to you here.
+>
+> **Verdict path.** `pipeline-cli epic-ledger <N>` emits the verdict deterministically through the
+> gate action. `verdict post` has no `review-plan` value, and hand-posting a `review-plan` verdict
+> off the gate is forbidden — the action's verdict *is* the gate's verdict.
+>
+> **Pre-authorized writes.** You are authorized to write to epic #`<N>` and to its enumerated
+> children, for this gate only: the verdict comment, the `status:planned → status:triaged` flip on
+> a clean ledger, and a reviewer-authored acceptance-criteria append
+> ([ADR 0079](../../../.decisions/0079-reviewer-authored-acceptance-criteria.md)) so that append is
+> not refused mid-gate. If a write is refused anyway, **return it flagged as undelivered** — never
+> drop it silently.
+>
+> **Verify assertions against the file, never against the child's account.** When a child's body
+> claims something about its own safety — that it touches no column-0 canonical, that a boundary
+> assignment is untouched — open the actual file and check. A child asserting its own safety is
+> evidence of nothing; the first outing of this gate caught a false no-column-0 assertion exactly
+> this way.
 
 ## Read-only fanout — dispatch an expensive read to `crew-investigator`
 
@@ -63,9 +101,11 @@ the distilled finding** (ADR [0196](../../../.decisions/0196-read-only-crew-fano
 [#3543](https://github.com/kamp-us/phoenix/issues/3543)). It is write-tool-free — a context-hygiene
 primitive, not an execution edge.
 
-This is **additive** to your existing spawns (`planner`/`canon`/`adr`/`triager`/`reporter`) — it
-does not change them, and those five plus `crew-investigator` are your **whole** spawn scope. You
-never spawn `coder`, `reviewer`, or `shipper` (the engine's execution/merge seam), never the
+This is **additive** to your existing spawns
+(`planner`/`reviewer`/`canon`/`adr`/`triager`/`reporter`) — it does not change them, and those six
+plus `crew-investigator` are your **whole** spawn scope. Your `reviewer` spawn is scoped to
+`review-plan` over an epic ledger; spawning it for any PR-stage gate is out of scope. You never
+spawn `coder` or `shipper` (the engine's execution/merge seam), never the
 `crew-engineering-manager` that would spawn them for you, and never a peer bridge or a second copy
 of yourself. Nothing below you enforces that — it is a charter rule you keep, for the reason and
 with the CI backstop in [`SPAWN-SCOPE.md`](../SPAWN-SCOPE.md). You conduct the *front* of the
@@ -108,6 +148,11 @@ session; the substrate resolves the target role's inbox for you:
   another authority already marked `status:triaged`, **spawn the `planner` agent**
   (`isolation:worktree`) to drive `plan-epic` and write its ledger. You conduct the plan; you do not
   run the decomposition inline.
+- **Gate a planned epic's ledger.** "Gate the ledger for epic #N" — once the `planner` has written
+  the ledger, **spawn the `reviewer` agent** (`isolation:worktree`) with the fixed template above to
+  run `review-plan` over it. This is the closing step of planning, not an optional follow-up: a
+  planned epic whose ledger is never gated leaves its children stranded at `status:planned`, where
+  no engine can pick them up. Abstaining is the failure, not the safeguard.
 - **Route canon/ADR-shaped work.** When triage surfaces a canon change or a decision that belongs
   in `.decisions/`, **spawn the `canon` / `adr` agent** (`isolation:worktree`) rather than running
   its skill inline or letting the work enter the build queue as ordinary code.
@@ -125,17 +170,20 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   courtesy: enrich a thin report before acting, route a human-filed issue you can't act on to
   `status:needs-info` with specific questions, and reserve closed-not-planned for an unsalvageable
   *agent*-filed issue only. A bridge that only closes is a filter; the talking-back is the seam.
-- **Intake and planning only — never implement, review, merge, or drive the build queue.** You
-  classify, enrich, prioritize, plan, and route; you never write code, run a review skill, post a
-  review verdict, merge, or pick build work off the `status:triaged` queue — the engine owns that
-  seam. Your output reaches it through the board, not by routing.
+- **Intake and planning only — never implement, merge, or drive the build queue.** You classify,
+  enrich, prioritize, plan, and route; you never write code, run a review skill **inline**, post a
+  review verdict yourself, merge, or pick build work off the `status:triaged` queue — the engine
+  owns that seam. Your output reaches it through the board, not by routing. The one gate you
+  conduct, `review-plan`, is conducted the same way as every other skill here: a separately spawned
+  `reviewer` reads the artifacts cold and posts its own verdict through `epic-ledger`. Independence
+  lives in that isolation, not in which seat dispatched it.
 - **Conduct by spawning named pipeline agents — never run their skills inline, never pass an
   explicit model.** The pipeline agents are `model: inherit`, so bring **this** session up on its
   configured model tier before conducting; a wrong-tier session silently downgrades every subagent
   it spawns. The tier is a seam key — never hardcode a model name, and never pass an explicit model
-  to a spawn (let it inherit). You spawn `planner`/`canon`/`adr`/`triager`/`reporter` and the
-  read-only `crew-investigator` (the ADR 0196 fanout) — and nothing else, per
-  [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md).
+  to a spawn (let it inherit). You spawn `planner`/`reviewer`/`canon`/`adr`/`triager`/`reporter`
+  and the read-only `crew-investigator` (the ADR 0196 fanout) — and nothing else, with `reviewer`
+  scoped to `review-plan`, per [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md).
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged
   and stepped over, never retried or escalated. The channel tool's callable allowlist token and the
@@ -179,8 +227,9 @@ full resolution rule; follow it.
 
 Return what your intake pass produced: the issues you triaged (each with its terminal outcome —
 `type:*` + priority, needs-info, or closed-not-planned), the epics you planned (with the child count
-and their `## Dependencies` topology), any canon/ADR-shaped work you routed and where, and any
-blocker — including a blocked cross-issue write surfaced as a fail-loud missing pre-authorization,
-never a silent drop. Hold the summary to the same privacy rule as issue artifacts: repo-relative
-paths only, no operator data. You conduct the front of the pipeline; you never implement, review,
-merge, or drive the build queue.
+and their `## Dependencies` topology), the `review-plan` verdict for each epic you gated (pass with
+the flipped children, or fail with the defects the gate named), any canon/ADR-shaped work you routed
+and where, and any blocker — including a blocked cross-issue write surfaced as a fail-loud missing
+pre-authorization, never a silent drop. Hold the summary to the same privacy rule as issue
+artifacts: repo-relative paths only, no operator data. You conduct the front of the pipeline; you
+never implement, merge, or drive the build queue.

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
@@ -50,12 +50,19 @@ export type BridgeName = (typeof BRIDGE_NAMES)[number];
  * seat, carrying the file-follow-ups-in-the-moment obligation — delegates capture to `reporter`
  * (write-scoped to issue creation only, so it is context-hygiene fanout, not an execution edge —
  * ADR 0196, #3888); the intake-desk owns the planning/canon seam (planner/canon/adr) plus its
- * report→triage loop (triager/reporter). See `claude-plugins/pipeline-crew/agents/`.
+ * report→triage loop (triager/reporter) and, since the 2026-07-29 founder directive, the
+ * `reviewer` that closes planning by running `review-plan` over the ledger it just planned.
+ * See `claude-plugins/pipeline-crew/agents/`.
+ *
+ * This table is agent-granular, so it cannot express the intake-desk's `review-plan`-only
+ * scoping — that half lives in the seat's charter prose, per
+ * `claude-plugins/pipeline-crew/SPAWN-SCOPE.md`. Widening the table entry to the whole
+ * agent-type is the honest encoding of what the guard can check, not a widening of the charter.
  */
 export const BRIDGE_ALLOWLIST: Record<BridgeName, ReadonlyArray<string>> = {
 	"crew-cartographer": ["coder", "planner", "canon", "adr", "triager", "reporter"],
 	"crew-chief-of-staff": ["reporter"],
-	"crew-intake-desk": ["planner", "canon", "adr", "triager", "reporter"],
+	"crew-intake-desk": ["planner", "reviewer", "canon", "adr", "triager", "reporter"],
 };
 
 /**
@@ -89,7 +96,6 @@ export const BRIDGE_OUT_OF_SCOPE: Record<BridgeName, ReadonlyArray<string>> = {
 	],
 	"crew-intake-desk": [
 		"coder",
-		"reviewer",
 		"shipper",
 		"crew-cartographer",
 		"crew-chief-of-staff",

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
@@ -131,6 +131,24 @@ describe("judge — the every-agent-type-is-classified decision", () => {
 		expect(judge(currentInput()).pass).toBe(true);
 	});
 
+	it("classifies the intake-desk's review-plan reviewer as allowed, not out of scope (#4445)", () => {
+		// The intake-desk fires `review-plan` over the ledger it just planned (founder directive,
+		// 2026-07-29). The table is agent-granular, so the review-plan-only scoping lives in the
+		// seat's charter prose — here we pin only what the guard can check: `reviewer` allowlisted
+		// and OFF the out-of-scope table for this one bridge.
+		expect(BRIDGE_ALLOWLIST["crew-intake-desk"]).toContain("reviewer");
+		expect(BRIDGE_OUT_OF_SCOPE["crew-intake-desk"]).not.toContain("reviewer");
+		// the build drain stays off the seat — the exception is the gate, not the pipeline
+		for (const buildAgent of ["coder", "shipper", "crew-engineering-manager"]) {
+			expect(BRIDGE_OUT_OF_SCOPE["crew-intake-desk"]).toContain(buildAgent);
+		}
+		// the other two bridges are untouched: no bridge but the intake-desk may spawn `reviewer`
+		expect(BRIDGE_OUT_OF_SCOPE["crew-cartographer"]).toContain("reviewer");
+		expect(BRIDGE_OUT_OF_SCOPE["crew-chief-of-staff"]).toContain("reviewer");
+		// classification stays total with reviewer moved across
+		expect(judge(currentInput()).pass).toBe(true);
+	});
+
 	it("fails closed on zero roster and on zero bridges (ADR 0092)", () => {
 		expect(judge({rosterAgents: [], bridges: [CARTOGRAPHER, CHIEF, INTAKE]})).toMatchObject({
 			pass: false,


### PR DESCRIPTION
The intake-desk seat now fires the plan-layer gate itself: after it spawns the `planner` over a triaged epic, it spawns the `reviewer` to run `review-plan` over the resulting ledger. That was a founder directive given in-session on 2026-07-29, and until now the charter docs said the opposite — the seat's own def told it never to spawn `reviewer` at all, and CI's crew-fanout-guard agreed on paper. This PR makes the paper match the ruling.

The scope is exactly one gate. `review-code`, `review-doc`, `review-skill`, `review-design`, plus `coder` and `shipper` spawning, all stay the engine's seam, and the `reviewer` agent itself is untouched — same skill, same cold read of the artifacts, same verdict posted through `epic-ledger`.

Fixes #4445

## What changed

- **`claude-plugins/pipeline-crew/agents/crew-intake-desk.md`** — `reviewer` joins the spawn-by-name list, scoped to `review-plan` over an epic ledger and nothing else; a new "Gate a planned epic's ledger" entry under *When to invoke*; the ambiguous invariant "never write code, run a review skill, post a review verdict…" is disambiguated to "never run a review skill **inline**"; the whole-spawn-scope sentence goes from five agents to six; the *Output* section now reports the gate verdict.
- **The fixed dispatch template**, in the same def. It names the epic and nothing else — no summary of what the planner intended, no characterization of the children, no pre-briefing of expected findings. It carries three standing facts: the verdict path (`pipeline-cli epic-ledger <n>` emits it; hand-posting off the gate is forbidden), the pre-authorized write set (the epic + its enumerated children, so an ADR 0079 acceptance-criteria append is not refused mid-gate, with return-flagged-as-undelivered as the fallback), and the rule that a child's assertion about its own safety is verified against the actual file rather than accepted from the child's account.
- **`claude-plugins/pipeline-crew/SPAWN-SCOPE.md`** — a new section stating the one scoped exception and why the roster law still holds: a gate over a planned ledger routes nothing to an engine, so it is not the execution-routing edge ADR 0189 forbids; ADR 0047 constrains the gate's shape and names no dispatcher.
- **`packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts`** — `reviewer` moves out of `BRIDGE_OUT_OF_SCOPE["crew-intake-desk"]` and into that bridge's `BRIDGE_ALLOWLIST`. The table is agent-granular and cannot express a per-skill scoping, so the `review-plan`-only half lives in the charter prose; the docblock says so rather than leaving the widening to look like a widened charter.
- **`packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts`** — a test pinning the new classification: `reviewer` allowlisted and off the out-of-scope table for the intake-desk only, `coder`/`shipper`/`crew-engineering-manager` still out of scope for it, and the other two bridges unchanged.
- **`claude-plugins/pipeline-crew/agents/crew-engineering-manager.md`** — the engine def carries **zero** occurrences of `review-plan` or `status:planned`, so there was no dispatch to trim. Its `reviewer` bullet gains one disambiguating clause naming its four PR-stage gates and pointing `review-plan` at the intake-desk, so the two defs cannot be read as claiming the same gate.
- **`README.md` / `REFERENCE.md`** — the two places that summarize the intake-desk's spawn set now name the scoped `reviewer`.

## §CP classification

`pipeline-cli cp-classify classify` over the seven changed files exits **3** — `not-control-plane [path-clear-no-content-source]`, proven-ordinary. The diff does **not** span gated and ungated files; every path is ungated. Two live rulings put it there: `claude-plugins/pipeline-crew/agents/**` is deliberately excluded from §CP (#3765, re-affirmed 2026-07-24), and ADR 0218 amended ADR 0100 to scope §CP to `pipeline-cli`'s enforcement core only — `crew-fanout-guard` is not in it and carries no CODEOWNERS entry. The issue's acceptance criterion anticipated one control-plane approval; the live classifier says none is required.

## Deviations

**Class: narrowed a stated acceptance criterion.**
- Said: "The engine def, if/where it implies review-plan dispatch, is trimmed to match."
- Did: added one disambiguating clause to the engine's `reviewer` bullet instead of trimming anything.
- Why: verified against the live text — `crew-engineering-manager.md` contains no occurrence of `review-plan` or `status:planned`, so there was nothing to remove. The clause prevents the generic "`reviewer` — the single routing gate" bullet from reading as a claim over the plan-layer gate.
- Disposition: no action needed; the AC's conditional ("if/where") is satisfied by the finding.

**Class: acceptance criterion whose premise the live tooling contradicts.**
- Said: "One PR, one control-plane approval (ADR 0150 covers the agent defs; ADR 0100 covers the guard package)."
- Did: shipped one PR, but classified the diff as proven-ordinary rather than routing it for a control-plane approval.
- Why: the classifier is the authority on the boundary and exits 3 over this file set. `pipeline-crew/agents/**` is excluded by #3765, and ADR 0218 narrowed ADR 0100 to the enforcement core, which `crew-fanout-guard` is outside of. The AC was written against the older boundary.
- Disposition: for the reviewer to judge — if the §CP call should stand despite the classifier, that is a boundary decision, not a code fix.

**Class: touched files beyond the three the issue named.**
- Said: amend the intake-desk def, the `SPAWN-SCOPE` doc, and the guard (plus the engine def if applicable).
- Did: also amended `README.md` and `REFERENCE.md`.
- Why: both summarize the intake-desk's spawn set explicitly (`spawns planner/canon/adr`), so leaving them would have shipped exactly the one-file-says-one-thing self-contradiction this milestone exists to remove.
- Disposition: no action needed.

**Class: added a test the issue did not ask for.**
- Said: move `reviewer` between the guard's two tables.
- Did: also added a unit test pinning the new classification.
- Why: the existing suite pins the analogous chief-of-staff `reporter` move (#3888) the same way; without it, a future table edit could silently revert this one.
- Disposition: no action needed.
