### PR TITLE
fix(pipeline): both cycle validators follow extracted shell into scripts/*.sh (#4470)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
@@ -33,6 +33,13 @@
 # — the same guard-in-text/absent-in-effect defect, reintroduced from the other side. A skill that
 # extracts its cycle wiring into the shared lib therefore FAILS these validators, loudly, which is
 # the correct direction: per-skill wiring stays per-skill, or the validator is updated deliberately.
+#
+# EMITS NOTHING for a skill directory with no SKILL.md and no `*.sh` (and still exits 0 — an
+# empty surface is not an error here, it is a fact the CALLER must decide about). A caller that
+# collects the lines into an array must therefore check the array is non-empty BEFORE expanding
+# it: under `set -u` on bash 3.2 `"${arr[@]}"`/`"${arr[*]}"` on an empty array aborts the script,
+# and with a cleanup `trap … EXIT` installed the trap's own exit status becomes the script's — so
+# a fail-closed validator exits 0 having printed its FAIL lines. Fail OPEN, invisibly (#4470).
 kp_skill_shell_surfaces() {
 	local skills_dir="$1" skill="$2"
 	if [ -f "$skills_dir/$skill/SKILL.md" ]; then

--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
@@ -22,6 +22,28 @@
 # script in a per-skill scripts/ directory:
 #   . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
 
+# Every file a skill's shell can live in, one absolute path per line: its SKILL.md plus every
+# `*.sh` under the skill's own directory — the destination the convention above sends extracted
+# blocks to. A validator that greps SKILL.md alone stops guarding the moment a block moves out of
+# it, staying green while guarding nothing (#4470); resolving the surface HERE, next to the
+# convention that defines it, is what keeps the two in step.
+#
+# Scoped to the skill's OWN directory on purpose. shared/lib/*.sh is cross-skill, so folding it
+# into every skill's surface would let one skill's marker satisfy another skill's per-skill check
+# — the same guard-in-text/absent-in-effect defect, reintroduced from the other side. A skill that
+# extracts its cycle wiring into the shared lib therefore FAILS these validators, loudly, which is
+# the correct direction: per-skill wiring stays per-skill, or the validator is updated deliberately.
+kp_skill_shell_surfaces() {
+	local skills_dir="$1" skill="$2"
+	if [ -f "$skills_dir/$skill/SKILL.md" ]; then
+		printf '%s\n' "$skills_dir/$skill/SKILL.md"
+	fi
+	if [ -d "$skills_dir/$skill" ]; then
+		find "$skills_dir/$skill" -type f -name '*.sh' | LC_ALL=C sort
+	fi
+	return 0
+}
+
 # The target repo as `owner/name`. Fails closed rather than yielding an empty string, which
 # would silently address `gh api repos//…` (§Target repo resolution, ADR 0062 §1).
 kp_repo() {

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
@@ -83,6 +83,14 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 		[ -n "$surface" ] && surfaces+=("$surface")
 	done < <(kp_skill_shell_surfaces "$skills_dir" "$skill")
 
+	# Guard before expanding: an empty `surfaces` aborts every "${surfaces[@]}" below under
+	# `set -u`, and the EXIT trap then launders that abort into exit 0 (see the resolver's
+	# docblock in shared/lib/common.sh, #4470). Refuse the skill instead of scanning nothing.
+	if [ "${#surfaces[@]}" -eq 0 ]; then
+		fail "$skill: no shell surface resolved (no SKILL.md, no *.sh) — refusing to scan an empty surface (ADR 0092)"
+		continue
+	fi
+
 	scanned_skills=$((scanned_skills + 1))
 	for surface in "${surfaces[@]}"; do
 		scanned_paths+=("${surface#"$skills_dir/"}")
@@ -112,6 +120,10 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 	while IFS= read -r surface; do
 		[ -n "$surface" ] && surfaces+=("$surface")
 	done < <(kp_skill_shell_surfaces "$skills_dir" "$skill")
+	if [ "${#surfaces[@]}" -eq 0 ]; then
+		fail "$skill: no shell surface resolved (no SKILL.md, no *.sh) — refusing to scan an empty surface (ADR 0092)"
+		continue
+	fi
 	if grep -qiE 'cycle (doc|step) (is )?(always|unconditionally)' "${surfaces[@]}"; then
 		fail "$skill: appears to assume the cycle doc is always present — graceful absence requires the probe to gate it"
 	fi

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
@@ -37,7 +37,7 @@ if [ ! -f "$COMMON_LIB" ]; then
 	echo "validate-cycle-absence: FAILED — 1 error(s); the scan surface could not be resolved"
 	exit 1
 fi
-# shellcheck source=shared/lib/common.sh
+# shellcheck source-path=SCRIPTDIR source=shared/lib/common.sh
 . "$COMMON_LIB"
 
 # The one well-known cycle-doc path every consumer probes (formats §1, single source).

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
@@ -13,6 +13,8 @@
 #   1. STATIC wiring — each of the four skills cites THE single canonical absence-probe
 #      (the well-known repo path `product-development-cycle.md`, formats §1) and pairs it
 #      with an absent⇒no-op branch. No skill hardcodes a flag or assumes the doc exists.
+#      Scanned across the skill's whole shell surface — SKILL.md AND its extracted
+#      scripts/*.sh (#4470) — so moving a block out of SKILL.md cannot disarm this.
 #   2. HERMETIC runtime — run the canonical working-tree probe against a temp repo root
 #      with no cycle doc, assert it resolves `absent` and the no-op default holds. This is
 #      the executable scenario walkthrough of the doc-absent branch (issue #605, epic #595).
@@ -25,6 +27,18 @@ set -euo pipefail
 # Same self-locating idiom as validate-skills.sh: this script lives in .claude/skills/, so
 # its own dir IS the skills root — resolve from BASH_SOURCE so it works from any cwd.
 skills_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# kp_skill_shell_surfaces resolves each skill's scan surface — SKILL.md PLUS its extracted
+# scripts/*.sh (#4470). Sourced, not re-derived: the surface convention and its resolver live
+# together in the lib. A missing lib is a FAIL, never a narrowed scan (ADR 0092).
+COMMON_LIB="$skills_dir/shared/lib/common.sh"
+if [ ! -f "$COMMON_LIB" ]; then
+	echo "FAIL: shared lib not found at $COMMON_LIB — cannot resolve each skill's shell surface; refusing to scan a narrowed surface (ADR 0092)"
+	echo "validate-cycle-absence: FAILED — 1 error(s); the scan surface could not be resolved"
+	exit 1
+fi
+# shellcheck source=shared/lib/common.sh
+. "$COMMON_LIB"
 
 # The one well-known cycle-doc path every consumer probes (formats §1, single source).
 CYCLE_DOC_PATH="product-development-cycle.md"
@@ -44,6 +58,8 @@ declare -a CYCLE_SKILLS=(
 
 errors=0
 checks=0
+scanned_skills=0
+declare -a scanned_paths=()
 
 fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
 ok() { echo "ok: $*"; checks=$((checks + 1)); }
@@ -62,13 +78,23 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 		continue
 	fi
 
-	if ! grep -qF "$PROBE_NEEDLE" "$md"; then
+	surfaces=()
+	while IFS= read -r surface; do
+		[ -n "$surface" ] && surfaces+=("$surface")
+	done < <(kp_skill_shell_surfaces "$skills_dir" "$skill")
+
+	scanned_skills=$((scanned_skills + 1))
+	for surface in "${surfaces[@]}"; do
+		scanned_paths+=("${surface#"$skills_dir/"}")
+	done
+
+	if ! grep -qF "$PROBE_NEEDLE" "${surfaces[@]}"; then
 		fail "$skill: does not cite the canonical cycle-doc probe ('$PROBE_NEEDLE') — every cycle-step must branch on the one well-known path (formats §1)"
 	else
 		ok "$skill cites the canonical absence-probe"
 	fi
 
-	if ! grep -qiE "$noop_re" "$md"; then
+	if ! grep -qiE "$noop_re" "${surfaces[@]}"; then
 		fail "$skill: no absent⇒no-op branch found (expected /$noop_re/i) — an absent cycle doc must no-op gracefully (ADR 0062)"
 	else
 		ok "$skill has an absent⇒no-op branch"
@@ -81,9 +107,12 @@ done
 # is present without the probe that establishes it.)
 for entry in "${CYCLE_SKILLS[@]}"; do
 	skill="${entry%% *}"
-	md="$skills_dir/$skill/SKILL.md"
-	[ -f "$md" ] || continue
-	if grep -qiE 'cycle (doc|step) (is )?(always|unconditionally)' "$md"; then
+	[ -f "$skills_dir/$skill/SKILL.md" ] || continue
+	surfaces=()
+	while IFS= read -r surface; do
+		[ -n "$surface" ] && surfaces+=("$surface")
+	done < <(kp_skill_shell_surfaces "$skills_dir" "$skill")
+	if grep -qiE 'cycle (doc|step) (is )?(always|unconditionally)' "${surfaces[@]}"; then
 		fail "$skill: appears to assume the cycle doc is always present — graceful absence requires the probe to gate it"
 	fi
 done
@@ -165,6 +194,16 @@ if [ "$RELEASE_QUEUE" = "n/a (not a dark ship)" ]; then
 else
 	fail "ship-it surfaced a release queue on an absent cycle doc"
 fi
+
+# Zero-scope guard (ADR 0092): a run that matched zero cycle-aware skills — a moved or renamed
+# skills dir — would sail through layer 2's hermetic walkthrough (which touches no skill) and
+# print OK having asserted nothing about the corpus. Fail closed instead.
+if [ "$scanned_skills" -eq 0 ]; then
+	fail "zero scope: no cycle-aware skills were scanned (skills dir moved?) — a zero-scope run is a FAIL, never a silent pass (ADR 0092)"
+fi
+
+# Emitted scope (ADR 0092): every run states what it looked at.
+echo "scanned scope: ${scanned_skills} cycle-aware skill(s) [${scanned_paths[*]-}]"
 
 if [ "$errors" -gt 0 ]; then
 	echo "validate-cycle-absence: FAILED — $errors error(s); the graceful-absence guarantee (ADR 0062 / 0083) is broken"

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
@@ -42,7 +42,7 @@ if [ ! -f "$COMMON_LIB" ]; then
 	echo "validate-cycle-presence: FAILED — 1 error(s); the scan surface could not be resolved"
 	exit 1
 fi
-# shellcheck source=shared/lib/common.sh
+# shellcheck source-path=SCRIPTDIR source=shared/lib/common.sh
 . "$COMMON_LIB"
 
 # The one well-known cycle-doc path every consumer probes (formats §1, single source).

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
@@ -9,7 +9,8 @@
 #
 # This asserts the inverse, hermetically:
 #   1. STATIC wiring — each cycle-aware skill carries a PRESENT branch (CYCLE_DOC=present)
-#      paired with its present-path action, not just the absent no-op:
+#      paired with its present-path action, not just the absent no-op. Scanned across the
+#      skill's whole shell surface — SKILL.md AND its extracted scripts/*.sh (#4470):
 #        plan-epic   stamps a containment marker (flag|exempt) from the cycle policy
 #        write-code  ships dark behind a default-off flag (defaultVariation)
 #        review-code verifies the flag-gating before PASS
@@ -31,6 +32,18 @@ skills_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # script lives in the tree); fall back to the physical plugin path
 # (<root>/claude-plugins/kampus-pipeline/skills) when git is unavailable.
 repo_root="$(git -C "$skills_dir" rev-parse --show-toplevel 2>/dev/null || (cd "$skills_dir/../../.." && pwd))"
+
+# kp_skill_shell_surfaces resolves each skill's scan surface — SKILL.md PLUS its extracted
+# scripts/*.sh (#4470). Sourced, not re-derived: the surface convention and its resolver live
+# together in the lib. A missing lib is a FAIL, never a narrowed scan (ADR 0092).
+COMMON_LIB="$skills_dir/shared/lib/common.sh"
+if [ ! -f "$COMMON_LIB" ]; then
+	echo "FAIL: shared lib not found at $COMMON_LIB — cannot resolve each skill's shell surface; refusing to scan a narrowed surface (ADR 0092)"
+	echo "validate-cycle-presence: FAILED — 1 error(s); the scan surface could not be resolved"
+	exit 1
+fi
+# shellcheck source=shared/lib/common.sh
+. "$COMMON_LIB"
 
 # The one well-known cycle-doc path every consumer probes (formats §1, single source).
 CYCLE_DOC_PATH="product-development-cycle.md"
@@ -75,22 +88,30 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 		fail "$skill: SKILL.md not found at $md"
 		continue
 	fi
-	scanned_skills=$((scanned_skills + 1))
-	scanned_paths+=("$skill/SKILL.md")
 
-	if ! grep -qF "$PROBE_NEEDLE" "$md"; then
+	surfaces=()
+	while IFS= read -r surface; do
+		[ -n "$surface" ] && surfaces+=("$surface")
+	done < <(kp_skill_shell_surfaces "$skills_dir" "$skill")
+
+	scanned_skills=$((scanned_skills + 1))
+	for surface in "${surfaces[@]}"; do
+		scanned_paths+=("${surface#"$skills_dir/"}")
+	done
+
+	if ! grep -qF "$PROBE_NEEDLE" "${surfaces[@]}"; then
 		fail "$skill: does not cite the canonical cycle-doc probe ('$PROBE_NEEDLE') — the present branch must key off the one well-known path (formats §1)"
 	else
 		ok "$skill cites the canonical cycle-doc probe"
 	fi
 
-	if ! grep -qiE "$PRESENT_GATE_RE" "$md"; then
+	if ! grep -qiE "$PRESENT_GATE_RE" "${surfaces[@]}"; then
 		fail "$skill: no present-resolution of the cycle probe found (expected /$PRESENT_GATE_RE/i) — the present-path action must be gated on the doc being present"
 	else
 		ok "$skill resolves the probe to present"
 	fi
 
-	if ! grep -qiE "$action_re" "$md"; then
+	if ! grep -qiE "$action_re" "${surfaces[@]}"; then
 		fail "$skill: no present-path action found (expected /$action_re/i) — the cycle's present branch must DO something (ADR 0091/0092), not just no-op"
 	else
 		ok "$skill carries its present-path action (/$action_re/i)"

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
@@ -94,6 +94,14 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 		[ -n "$surface" ] && surfaces+=("$surface")
 	done < <(kp_skill_shell_surfaces "$skills_dir" "$skill")
 
+	# Guard before expanding: an empty `surfaces` aborts every "${surfaces[@]}" below under
+	# `set -u`, and the EXIT trap then laundered that abort into exit 0 (see the resolver's
+	# docblock in shared/lib/common.sh, #4470). Refuse the skill instead of scanning nothing.
+	if [ "${#surfaces[@]}" -eq 0 ]; then
+		fail "$skill: no shell surface resolved (no SKILL.md, no *.sh) — refusing to scan an empty surface (ADR 0092)"
+		continue
+	fi
+
 	scanned_skills=$((scanned_skills + 1))
 	for surface in "${surfaces[@]}"; do
 		scanned_paths+=("${surface#"$skills_dir/"}")
@@ -194,7 +202,7 @@ else
 fi
 
 # Emitted scope (ADR 0092): every run states what it looked at.
-echo "scanned scope: ${scanned_skills} cycle-aware skill(s) [${scanned_paths[*]}]; phoenix cycle doc: $([ -f "$repo_root/$CYCLE_DOC_PATH" ] && echo present || echo MISSING)"
+echo "scanned scope: ${scanned_skills} cycle-aware skill(s) [${scanned_paths[*]-}]; phoenix cycle doc: $([ -f "$repo_root/$CYCLE_DOC_PATH" ] && echo present || echo MISSING)"
 
 if [ "$errors" -gt 0 ]; then
 	echo "validate-cycle-presence: FAILED — $errors error(s); phoenix's present cycle-doc path is not real (a present-branch action is missing, or the gate scanned zero scope — ADR 0091/0092)"


### PR DESCRIPTION
Two CI guards check that each cycle-aware skill still carries its cycle wiring, but they only ever read that skill's `SKILL.md`. The extraction programme (#4435) is about to move fenced shell out of those files into `<skill>/scripts/*.sh`, which would take the wiring out of the guards' view — they would keep printing OK while checking nothing. This widens both guards to read a skill's scripts as well as its `SKILL.md`, so the extraction lands on guards that follow the shell instead of guards that quietly go blind.

Fixes #4470

## What changed

- `claude-plugins/kampus-pipeline/skills/shared/lib/common.sh` — new `kp_skill_shell_surfaces <skills_dir> <skill>`, which prints a skill's whole shell surface: its `SKILL.md` plus every `*.sh` under the skill's own directory. It lives next to the destination convention #4446 pinned in that same file, so the convention and the resolver that follows it stay in step.
- `claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh` — sources the lib and greps the resolved surface instead of a single `md=...SKILL.md`. All three per-skill checks (canonical probe cited / probe resolved to present / present-path action) now see the scripts.
- `claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh` — same widening for both of its loops (the probe + no-op-branch checks, and the "assumes the doc is always present" heuristic). It also gains the zero-scope guard and emitted scope it never had (ADR 0092): its layer-2 walkthrough is hermetic and touches no skill, so a run that matched zero skills used to print OK having asserted nothing about the corpus.
- A missing shared lib is a hard FAIL in both, never a silently narrowed scan.
- **The presence validator's zero-scope arm was itself failing open.** Folded in below.

## Fold-in: the zero-scope arm failed OPEN (found during the gate, routed as #4476)

This defect was found while the gate reviewed this PR and was initially routed out to a follow-up ticket. It is folded in here instead, deliberately: this PR has no human approval yet, so a new head costs one machine round and zero human cost, whereas a second control-plane PR touching the same file would cost another human approval.

`validate-cycle-presence.sh` expanded `${scanned_paths[*]}` **undefaulted** in its emitted-scope line. Three facts compose into a fail-open:

1. `set -euo pipefail` is in force.
2. On bash 3.2 (`GNU bash 3.2.57(1)-release (arm64-apple-darwin23)`), `"${arr[*]}"` on an **empty** array is treated as unbound under `set -u` and **aborts the script** — measured, not assumed: a probe script prints `count: 0` and `star-default: []` for `${#a[@]}` / `${a[*]-}`, and dies `b[*]: unbound variable` on the undefaulted form.
3. The abort happens **before** the terminal `exit 1`, and a cleanup `trap 'rm -rf "$tmp_root"' EXIT` is installed. On bash 3.2 the trap's last command's exit status becomes the script's — `rm -rf` succeeds, so the script exits **0**.

Isolated, with the same fixture and only the trap varying:

```
trap "true" EXIT             -> exit 0   (fail OPEN)
no trap                      -> exit 1   (fail CLOSED)
trap "rm -rf <tmp>" EXIT     -> exit 0   (fail OPEN)
```

`.github/workflows/ci.yml` invokes it as a bare `- run: bash .claude/skills/validate-cycle-presence.sh` with no `|| true` and no `continue-on-error`, so CI observes that 0 verbatim: a **green check** printed alongside two `FAIL:` lines and an `unbound variable` error.

**The arm is narrow, and that is what makes it serious.** Only the case where `scanned_paths` is empty aborts. A single missing skill still reds correctly, because the array is then non-empty. The one condition the guard could not report is a **total skills-dir move or rename** — precisely the drift it exists to catch.

### Proof by exit code, with the EXIT trap in place

The zero-scope condition is induced for real, not simulated: both validators plus the shared lib are copied into a scratch tree that is **not** a git repo and holds no `<skill>/SKILL.md`, so `skills_dir` resolves there, the non-git `repo_root` fallback lands on a tree with no cycle doc, and `scanned_skills` stays 0 with `scanned_paths` empty. Exit codes captured directly (`$?` on a redirected run), never inferred from output:

| validator | before | after |
|---|---|---|
| `validate-cycle-presence.sh` | **exit 0** — fail OPEN, printing `FAIL: zero scope: no cycle-aware skills were scanned`, `FAIL: zero scope: phoenix has no …/product-development-cycle.md`, then `line 197: scanned_paths[*]: unbound variable` | **exit 1** — terminal, and the emitted-scope + FAILED summary lines now actually print |
| `validate-cycle-absence.sh` | exit 1 (already used the defaulted form) | exit 1 (unchanged) |

A printed `FAIL:` line was never the proof — accepting one as proof is how this shipped. Only the captured exit code is.

### The empty-array audit of this PR's four new expansions

The four `"${surfaces[@]}"` expansions this PR adds — the `grep -qF "$PROBE_NEEDLE"` file list, the `grep -qiE "$noop_re"` file list, the `for surface in` collection loop, and the second loop's `grep -qiE 'cycle (doc|step) (is )?(always|unconditionally)'` — are all fed from `kp_skill_shell_surfaces`.

**What does `kp_skill_shell_surfaces` emit for a skill directory with no `SKILL.md` and no `scripts/`?** Nothing, and it still exits 0. Measured against a scratch skill dir that exists but is empty: `rc=0 bytes=0 output=[]`. An empty surface is not an error *in the resolver* — it is a fact the **caller** must decide about.

**Does every caller survive that on bash 3.2?** Before this fold-in, no. The same fixture, run through the pre-fix caller shape, dies `surfaces[@]: unbound variable`. Both loops do guard on `SKILL.md` existing first, so with the resolver's current definition an empty `surfaces` is **unreachable today** — but "unreachable today" is exactly the assumption this whole ticket exists to stop trusting, and the abort is silent when it does happen. So every collection site now checks the array before expanding it:

```sh
if [ "${#surfaces[@]}" -eq 0 ]; then
	fail "$skill: no shell surface resolved (no SKILL.md, no *.sh) — refusing to scan an empty surface (ADR 0092)"
	continue
fi
```

`${#arr[@]}` is safe on an empty array on bash 3.2 under `set -u` (measured: `count: 0`), so the guard itself cannot abort. The guarded caller shape exits cleanly on the fixture where the unguarded one aborted.

Note the shape deliberately: a count check plus a loud `fail`, **not** `"${surfaces[@]-}"`. The `-` default is safe for the *string* interpolation at the emitted-scope line, but on bash 3.2 it expands an empty array to **one empty-string argument**, which would hand `grep` an empty filename rather than skip it (measured: `printf 'args:%s\n' "${b[@]-}"` prints one empty row). Defaulting a file-list expansion would have replaced a loud abort with a quiet wrong answer.

The constraint is stated **once**, in `kp_skill_shell_surfaces`'s own docblock, where the emit-nothing behaviour originates; the three call sites carry a pointer, not a re-derivation.

The defaulted form is now used at the presence validator's emitted-scope line, matching what this PR's absence-validator code already used. That closes a disagreement this PR would otherwise have **created**: on `origin/main` the absence validator has no `scanned_paths` variable at all, so the drift did not pre-exist.

## Negative proof — four states, observed exit codes

Green alone proves nothing here; that is the whole reason this ticket exists. Each state below was run against a hermetic copy of the skills corpus (so no planted violation could reach this branch), with the pre-change validators taken from `origin/main` and run against the *same* fixture for contrast. **Every row below was re-run against the repaired head; none is weakened.**

### `validate-cycle-absence.sh`

The plantable violation is the guard's own positive pattern — a skill asserting the cycle doc is always present, which defeats graceful absence (ADR 0062 / 0083).

| # | state | widened | pre-change (`origin/main`) |
|---|---|---|---|
| 1 | corpus as it stands | **exit 0** (OK — 14 checks) | — |
| 2 | violation planted in `write-code/scripts/proof-extracted.sh` | **exit 1** | **exit 0** |
| 3 | same violation planted in `write-code/SKILL.md` | **exit 1** | **exit 1** |
| 4 | planted violations removed | **exit 0** (OK — 14 checks) | — |

State 2 is the load-bearing row. The pre-change guard **passes** on a corpus that violates the invariant it exists to protect — exactly the "guard present in text, absent in effect" class (#4427). The widened guard fails it:

```
FAIL: write-code: appears to assume the cycle doc is always present — graceful absence requires the probe to gate it
scanned scope: 4 cycle-aware skill(s) [plan-epic/SKILL.md write-code/SKILL.md write-code/scripts/proof-extracted.sh review-code/SKILL.md ship-it/SKILL.md]
validate-cycle-absence: FAILED — 1 error(s); the graceful-absence guarantee (ADR 0062 / 0083) is broken
```

State 3 confirms the old surface did not regress: the identical line in `SKILL.md` still fails, exactly as before.

### `validate-cycle-presence.sh`

This guard's checks are existence-based, so a "violation" is wiring that is missing or broken on whichever surface holds it. State 2 simulates the extraction #4448–#4454 will perform: `ship-it`'s `status:awaiting-release` wiring is deleted from `SKILL.md` and lives only in `ship-it/scripts/release-queue.sh`.

| # | state | widened | pre-change (`origin/main`) |
|---|---|---|---|
| 1 | corpus as it stands | **exit 0** (OK — 18 checks) | — |
| 2 | wiring extracted, intact in `ship-it/scripts/release-queue.sh` | **exit 0** — follows the shell | **exit 1** — cannot follow it |
| 3 | violation planted **in that script** (marker corrupted there; `SKILL.md` still without it) | **exit 1** | — |
| 4 | violation planted in `write-code/SKILL.md` (`defaultVariation` wiring removed) | **exit 1** | — |
| 5 | planted violations removed | **exit 0** (OK — 18 checks) | — |

State 2 proves the guard reads the new surface (its emitted scope names `ship-it/scripts/release-queue.sh`), and state 3 proves it is genuinely *guarding* there rather than merely tolerating it:

```
FAIL: ship-it: no present-path action found (expected /status:awaiting-release/i) — the cycle's present branch must DO something (ADR 0091/0092), not just no-op
scanned scope: 4 cycle-aware skill(s) [plan-epic/SKILL.md write-code/SKILL.md review-code/SKILL.md ship-it/SKILL.md ship-it/scripts/release-queue.sh]; phoenix cycle doc: present
```

State 4 confirms the `SKILL.md` surface still fails as it always did.

> One fixture note, since it nearly cost a row: the presence checks grep case-**insensitively**, so a state-2/3 substitution token must not contain the marker as a case-variant substring. A first pass replaced `status:awaiting-release` with `status:AWAITING-RELEASE-MOVED`, which still matched, and rows 2-pre-change and 3 read `exit 0` for that reason alone. With a genuinely non-matching token the rows resolve as tabled. The failure mode was the fixture's, not the guard's — recorded because a mis-built fixture that reads as a passing guard is the same class this ticket is about.

## Other checks

- Both validators run clean (exit 0) through the `.claude/skills/…` path CI actually invokes — the symlink resolution the absence script's non-physical `cd` depends on.
- `shellcheck -x` exit 0 on both validators and on the shared lib.
- `pnpm typecheck` exit 0. Shell-only diff, so biome has no changed files to handle.

## Deviations

**Class: narrowed a suggested fix-shape.**
- *Said:* the issue's (explicitly non-binding) acceptance sketch names "the `scripts/` and `shared/lib/` surfaces" as what each validator should scan.
- *Did:* scoped each skill's scan surface to that skill's **own** directory. `shared/lib/*.sh` is deliberately excluded from the per-skill surface.
- *Why:* the lib is cross-skill. Folding it into every skill's surface would let one skill's marker satisfy a different skill's per-skill check — the same guard-in-text/absent-in-effect defect this ticket removes, reintroduced from the other side. The presence validator's per-skill action regexes are distinct, but its probe and present-gate checks are identical across all four skills, so a generic cycle-probe helper landing in the lib would silently satisfy them for a skill that had dropped its wiring entirely. With the narrower scope, a skill that extracts cycle wiring into the shared lib **fails** these validators loudly, which is the correct fail-closed direction.
- *Disposition:* no action needed — recorded here for the reviewer to judge. If a future extraction genuinely needs shared cycle wiring, widening the surface should be a deliberate edit with its own negative proof, not a default.

**Class: fixed a sibling defect found in passing.**
- *Said:* the issue asks for the scan surface to be widened and to fail closed on zero scope.
- *Did:* also added the zero-scope guard and the emitted-scope line to `validate-cycle-absence.sh`, which had neither.
- *Why:* the acceptance sketch's third bullet is "fails closed on zero scope (ADR 0092)". The presence validator already had it; the absence validator did not, and its hermetic layer-2 walkthrough would have printed OK on a zero-skill scan.
- *Disposition:* no action needed — in scope for the stated criterion.

**Class: folded in a defect found during review, by operator decision.**
- *Said:* the fail-open zero-scope arm was routed out of scope as #4476 during the gate.
- *Did:* fixed it on this head instead, per an explicit operator decision.
- *Why:* this PR carries no human approval yet, so a new head is one machine round; a separate control-plane PR touching the same file would cost a second human approval. The reasoning behind #4476's premise is corrected above — the `scanned_paths` drift did not pre-exist on `origin/main`, it would have been created by this PR.
- *Disposition:* the reviewer should re-gate the folded-in change on its own terms. #4476 is now redundant with this head.

**Class: found a class defect, routed out rather than swept.**
- *Said:* nothing; this came out of the audit above.
- *Did:* did **not** sweep the corpus.
- *Why:* the general rule — *any script combining `set -u` with a cleanup `EXIT` trap converts an unbound-variable abort into exit 0 on bash 3.2* — is a real class finding that affects every `scripts/*.sh` the extraction programme is about to write. It is being routed as its own ticket and must not ride this repair round.
- *Disposition:* out of scope here by operator instruction; tracked separately.

**Class: control-plane.** Every file in this diff is `claude-plugins/kampus-pipeline/skills/**/*.sh`, which is §CP by path (ADR 0174, the #4446 verification). This PR needs control-plane approval and must not be auto-merged.
