### PR TITLE
refactor(skills): the long tail's fenced shell moves into per-skill scripts/ (#4454)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -54,10 +54,9 @@ arc?"*. You cannot sweep for a question you cannot phrase.
 live-accepted ADRs whose decision domain yours touches and which you do **not** cite:
 
 ```bash
-# The shim resolves the bin (in-repo, else installed, else pinned dlx reading hooks/pin.sh; #3653).
 # Exit 0 = nothing left to open. Non-zero = a shortlist to clear, or an INDETERMINATE run.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
-  --new .decisions/NNNN-slug.md
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/adr/scripts/sweep-shortlist.sh" \
+  .decisions/NNNN-slug.md
 ```
 
 `pipeline-cli decisions-index compact` is the manual fallback: scan the `id · title · status` map

--- a/claude-plugins/kampus-pipeline/skills/adr/scripts/sweep-shortlist.sh
+++ b/claude-plugins/kampus-pipeline/skills/adr/scripts/sweep-shortlist.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Print the ADR-sweep shortlist for a new ADR draft — the decisions it may supersede or amend.
+# Relays the verb (ADR 0228); it derives nothing.
+#
+# usage: sweep-shortlist.sh <path/to/.decisions/NNNN-slug.md>
+#
+#   exit 0    nothing left to open
+#   non-zero  a shortlist to clear, OR an INDETERMINATE run — the verb's own distinction, relayed.
+#             127 means the CLI never ran, which is neither.
+#
+# Extracted from adr/SKILL.md (#4454, epic #4435 phase 1).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: sweep-shortlist.sh <path/to/.decisions/NNNN-slug.md>" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" adr-sweep shortlist --new "$1"

--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
@@ -37,8 +37,18 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/resolve-repo.sh")" || exit 1
 ```
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced block is an **invocation** of
+one; the prose keeps the *why* (epic #4435 phase 1 — the shell moved as-is, and turning its glue into
+tested `pipeline-cli` verbs is #1929). They set `set -uo pipefail`, deliberately not `-e`: the moved
+glue steers its own control flow, and `errexit` would abort a fail-closed branch before it printed
+its refusal. The **filing** step calls `report`'s own
+[`file-report.sh`](../report/scripts/file-report.sh) rather than a copy — a finding is filed "exactly
+like report", so it goes through the *same* footer and create envelope and the two cannot drift.
 
 ## Vocabulary — read it from `.glossary/*`, don't carry your own
 
@@ -62,8 +72,7 @@ Read both before walking code:
 
 ```bash
 # the committed architecture + domain vocabulary the audit speaks in
-cat .glossary/LANGUAGE.md
-cat .glossary/TERMS.md
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/read-glossary.sh"
 ```
 
 If a glossary file is genuinely absent (a foreign install that hasn't adopted the glossary
@@ -96,10 +105,8 @@ committed index (ADR 0126); the `NNNN-slug` filenames are the map, and each file
 carries `id`/`title`/`status`:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-ls .decisions/                          # the map — one NNNN-slug.md per ADR
-"$PCLI" decisions-index compact         # or: the compact id · title · status map
+# the `NNNN-slug.md` filenames (the map), then the compact id · title · status index
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/decisions-map.sh"
 ```
 
 Treat a recorded decision as decided ground: don't surface a finding that contradicts a
@@ -195,13 +202,8 @@ an already-open issue covering the same observation. The audit is re-runnable an
 report agents exist, so the same friction may already be filed:
 
 ```bash
-# (a) the live needs-triage queue — read-after-write consistent, catches a just-filed twin
-gh api "repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100" \
-  --jq '.[] | "#\(.number) \(.title)"'
-# (b) the search index — covers older open issues that already left the queue
-#     join keywords with + (raw spaces produce a malformed query URL)
-gh api "search/issues?q=repo:$REPO+is:issue+is:open+<keywords>" \
-  --jq '.items[] | "#\(.number) \(.title)"'
+# (a) the live needs-triage queue, then (b) the search index; the script joins keywords with +
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/dedup-search.sh" "<keywords>"
 ```
 
 Both commands guard different failure modes — don't drop either: (a) is read-after-write
@@ -229,19 +231,18 @@ call). Map the finding into the report template:
   [DEEPENING.md](DEEPENING.md) dependency category (so the eventual implementer knows the test
   seam), explicitly labeled a guess, never a mandate.
 
+One finding, one issue — only `status:needs-triage`, exactly like `report`, through `report`'s own
+filing script. The five sections arrive on its **stdin** as a quoted heredoc; it appends the footer
+and hands the stream to the `tracker create-issue` verb, which owns this intake-create envelope
+(ADR 0190; `packages/pipeline-cli/src/tools/tracker/`). Don't hand-roll the
+`gh api repos/$REPO/issues` create — the adoption lint (#3254) flags it. There is no temp file to
+collide on, which is what retires the old `/tmp/arch-audit-body.XXXXXX` shared-`/tmp` hazard (§SP):
+
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# one finding, one issue — only status:needs-triage, exactly like report. The
-# `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
-# `packages/pipeline-cli/src/tools/tracker/`) and enters the needs-triage queue by default;
-# don't hand-roll the `gh api repos/$REPO/issues` create — the adoption lint (#3254) flags it.
-BODY_FILE="$(mktemp /tmp/arch-audit-body.XXXXXX)"   # per-run temp file (concurrent runs share /tmp)
-# … write the five sections + footer into "$BODY_FILE" …
-BODY="$(cat "$BODY_FILE")"
-"$PCLI" tracker create-issue \
-  --title "<short, type-neutral finding summary (≤ ~70 chars)>" \
-  --body "$BODY"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/file-report.sh" \
+  "<short, type-neutral finding summary (≤ ~70 chars)>" <<'EOF'
+<the five sections>
+EOF
 ```
 
 Use the `report` footer helper for the metadata block so it stays free of PII and local paths

--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/decisions-map.sh
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/decisions-map.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Print the ADR map: the `NNNN-slug.md` filenames (the map itself, ADR 0129), then the compact
+# `id · title · status` index the verb generates from the same directory.
+#
+# Extracted from architecture-audit/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ -d .decisions ] || { echo "architecture-audit: no .decisions/ from $(pwd) — run from the repo root." >&2; exit 1; }
+PCLI="$(kp_pcli)" || exit 127
+
+ls .decisions/                    # the map — one NNNN-slug.md per ADR
+"$PCLI" decisions-index compact   # the compact id · title · status map

--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/dedup-search.sh
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/dedup-search.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# The two-source pre-filing dedup read for a finding: (a) the live needs-triage queue, which is
+# read-after-write consistent and catches a just-filed twin, then (b) the search index, which covers
+# older open issues that already left the queue.
+#
+# usage: dedup-search.sh <keywords>
+#
+# Keywords are joined with `+` here — raw spaces produce a malformed query URL.
+#
+# Extracted from architecture-audit/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: dedup-search.sh <keywords>" >&2; exit 2; }
+KEYWORDS="$(printf '%s' "$1" | tr ' ' '+')"
+REPO="$(kp_repo)" || exit 1
+
+# (a) the live needs-triage queue — read-after-write consistent, catches a just-filed twin
+gh api "repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100" \
+  --jq '.[] | "#\(.number) \(.title)"'
+# (b) the search index — covers older open issues that already left the queue
+gh api "search/issues?q=repo:$REPO+is:issue+is:open+$KEYWORDS" \
+  --jq '.items[] | "#\(.number) \(.title)"'

--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/read-glossary.sh
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/read-glossary.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Print the committed architecture + domain vocabulary the audit speaks in. Both files are required:
+# auditing in half the vocabulary is how a finding gets named four ways (#851).
+#
+# Extracted from architecture-audit/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+for f in .glossary/LANGUAGE.md .glossary/TERMS.md; do
+  [ -r "$f" ] || { echo "architecture-audit: $f is unreadable from $(pwd) — run from the repo root." >&2; exit 1; }
+done
+cat .glossary/LANGUAGE.md
+cat .glossary/TERMS.md

--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from architecture-audit/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
@@ -133,9 +133,7 @@ auto-shippable. **Re-check the final path** against the live control-plane regex
 opening the PR:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" control-plane-paths
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/author-skill/scripts/control-plane-paths.sh"
 ```
 
 A skill flips to §CP (human-merge, never auto-shipped) when its path falls under a gate skill

--- a/claude-plugins/kampus-pipeline/skills/author-skill/scripts/control-plane-paths.sh
+++ b/claude-plugins/kampus-pipeline/skills/author-skill/scripts/control-plane-paths.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Print the §CP control-plane path list. Relays the verb (ADR 0228) — the path list has ONE source
+# and this is not a second copy of it.
+#
+# Extracted from author-skill/SKILL.md (#4454, epic #4435 phase 1).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" control-plane-paths

--- a/claude-plugins/kampus-pipeline/skills/campaign/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/campaign/SKILL.md
@@ -46,11 +46,27 @@ Resolve `$REPO` the repo-agnostic way the rest of the pipeline does (ADR
 [0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-agnostic-pipeline.md)):
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/resolve-repo.sh")" || exit 1
 ```
 
 All GitHub reads/writes below go through **`gh api` REST** — never GraphQL (the org's
 Projects-classic integration errors GraphQL issue/PR queries, the standing pipeline constraint).
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced block is an **invocation** of
+one; the prose keeps the *why* (epic #4435 phase 1 — the shell moved as-is, and turning its glue into
+tested `pipeline-cli` verbs is #1929). They set `set -uo pipefail`, deliberately not `-e`: the moved
+glue steers its own control flow, and `errexit` would abort a fail-closed branch — the trace refusal
+above all — before it printed its refusal. Two notes:
+
+- **The founder login is an argument, never a default.** [`scripts/verify-trace.sh`](scripts/verify-trace.sh)
+  takes it positionally and refuses an empty one, so the authorization anchor can never degrade into
+  an implicit login.
+- **The ROADMAP.md branch + edit + commit stay in the prose.** Only the PR-open half is a script
+  ([`scripts/open-roadmap-pr.sh`](scripts/open-roadmap-pr.sh)). A script that ran `git switch -c`
+  would mutate whichever checkout the caller happened to be sitting in — a footgun the extraction
+  would have *introduced* rather than moved.
 
 ## Preconditions — the wave label, the lifecycle direction, the campaign name
 
@@ -84,9 +100,7 @@ every other input (absent, malformed, non-founder author, zero scope) exits non-
 [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)):
 
 ```bash
-cd packages/pipeline-cli
-node src/bin.ts campaign verify-trace "$WAVE_LABEL" --founder "$FOUNDER" \
-  || { echo "campaign: REFUSED — no valid founder-approval trace for '$WAVE_LABEL'. The wave stays un-recorded." >&2; exit 1; }
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/verify-trace.sh" "$WAVE_LABEL" "$FOUNDER" || exit 1
 ```
 
 The trace the verifier requires is a **founder-authored comment**, on any issue carrying the wave
@@ -131,10 +145,7 @@ Then **stamp the milestone on every wave-labeled issue** so the milestone projec
 cluster (the milestone is set per-issue via the issue-edit endpoint):
 
 ```bash
-for N in $(gh api -X GET "repos/$REPO/issues" -f "labels=$WAVE_LABEL" -f state=all -f per_page=100 --paginate \
-    --jq '.[] | select(.pull_request | not) | .number'); do
-  gh api -X PATCH "repos/$REPO/issues/$N" -F "milestone=$MILESTONE_NUMBER" >/dev/null
-done
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/home-wave.sh" "$WAVE_LABEL" "$MILESTONE_NUMBER"
 ```
 
 **Assignments.** Record who owns the campaign's drain if the founder named owners (assign the wave
@@ -152,11 +163,7 @@ campaign runs alongside whichever arc is active). Swap any existing `p0`/`p2` fo
 wave issue:
 
 ```bash
-for N in $(gh api -X GET "repos/$REPO/issues" -f "labels=$WAVE_LABEL" -f state=all -f per_page=100 --paginate \
-    --jq '.[] | select((.pull_request | not) and .state=="open") | .number'); do
-  for P in p0 p2; do gh api -X DELETE "repos/$REPO/issues/$N/labels/$P" >/dev/null 2>&1; done
-  gh api -X POST "repos/$REPO/issues/$N/labels" -f "labels[]=p1" >/dev/null
-done
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/normalize-priority.sh" "$WAVE_LABEL"
 ```
 
 Only open issues need re-pricing — a closed wave issue has already drained and its priority is
@@ -188,13 +195,14 @@ never the primary):
 
 Open the PR against the wave's tracking issue so it closes on merge:
 
+1. Branch off fresh `main` **in your worktree**:
+   `git switch -c "<prefix>/campaign-<wave-label>-<active|done>" origin/main`.
+2. Edit ROADMAP.md's `## Campaigns` table and commit ROADMAP.md **by explicit path**.
+3. Open the PR:
+
 ```bash
-git switch -c "<prefix>/campaign-<wave-label>-<active|done>" origin/main   # branch off fresh main in your worktree
-# edit ROADMAP.md's ## Campaigns table, commit ROADMAP.md by explicit path
-gh api -X POST "repos/$REPO/pulls" \
-  -f "title=roadmap: record <Campaign name> campaign (<active|done>)" \
-  -f "head=<branch>" -f "base=main" \
-  -f "body=Records the <Campaign name> audit wave (\`$WAVE_LABEL\`) as a bounded campaign — milestone #<MILESTONE_NUMBER>, p1, platform-lane drained. Founder-approval trace verified. Fixes #<tracking-issue>."
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/open-roadmap-pr.sh" \
+  "<Campaign name>" "<active|done>" "<branch>" "$WAVE_LABEL" "<MILESTONE_NUMBER>" "<tracking-issue>"
 ```
 
 The PR keeps `roadmap-guard` green **by construction**: creating a campaign adds a row that

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/home-wave.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/home-wave.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Home every issue carrying the wave label into the campaign's milestone (open and closed alike).
+#
+# usage: home-wave.sh <wave-label> <milestone-number>
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: home-wave.sh <wave-label> <milestone-number>" >&2; exit 2; }
+WAVE_LABEL="$1"; MILESTONE_NUMBER="$2"
+REPO="$(kp_repo)" || exit 1
+
+for N in $(gh api -X GET "repos/$REPO/issues" -f "labels=$WAVE_LABEL" -f state=all -f per_page=100 --paginate \
+    --jq '.[] | select(.pull_request | not) | .number'); do
+  gh api -X PATCH "repos/$REPO/issues/$N" -F "milestone=$MILESTONE_NUMBER" >/dev/null
+done

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/normalize-priority.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/normalize-priority.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Normalize the wave's still-OPEN issues to p1: drop p0/p2, apply p1. Closed issues keep the
+# priority they were worked at.
+#
+# usage: normalize-priority.sh <wave-label>
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: normalize-priority.sh <wave-label>" >&2; exit 2; }
+WAVE_LABEL="$1"
+REPO="$(kp_repo)" || exit 1
+
+for N in $(gh api -X GET "repos/$REPO/issues" -f "labels=$WAVE_LABEL" -f state=all -f per_page=100 --paginate \
+    --jq '.[] | select((.pull_request | not) and .state=="open") | .number'); do
+  for P in p0 p2; do gh api -X DELETE "repos/$REPO/issues/$N/labels/$P" >/dev/null 2>&1; done
+  gh api -X POST "repos/$REPO/issues/$N/labels" -f "labels[]=p1" >/dev/null
+done

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/open-roadmap-pr.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/open-roadmap-pr.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Open the PR that records the campaign in ROADMAP.md's `## Campaigns` table.
+#
+# usage: open-roadmap-pr.sh <campaign name> <active|done> <branch> <wave-label> <milestone-number> <tracking-issue>
+#
+# The branch + the ROADMAP.md edit + the commit are NOT here on purpose: a script that ran
+# `git switch -c` would mutate whichever checkout the caller happened to be sitting in, which is a
+# footgun the extraction would have introduced rather than moved (the primary-checkout mis-branch
+# class). Those stay explicit steps in the skill; this script only opens the PR.
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 6 ] || { echo "usage: open-roadmap-pr.sh <campaign name> <active|done> <branch> <wave-label> <milestone-number> <tracking-issue>" >&2; exit 2; }
+NAME="$1"; STATE="$2"; BRANCH="$3"; WAVE_LABEL="$4"; MILESTONE_NUMBER="$5"; TRACKING="$6"
+case "$STATE" in active | done) ;; *) echo "open-roadmap-pr: state must be 'active' or 'done', got '$STATE'." >&2; exit 2 ;; esac
+REPO="$(kp_repo)" || exit 1
+
+gh api -X POST "repos/$REPO/pulls" \
+  -f "title=roadmap: record $NAME campaign ($STATE)" \
+  -f "head=$BRANCH" -f "base=main" \
+  -f "body=Records the $NAME audit wave (\`$WAVE_LABEL\`) as a bounded campaign — milestone #$MILESTONE_NUMBER, p1, platform-lane drained. Founder-approval trace verified. Fixes #$TRACKING."

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/verify-trace.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/verify-trace.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# The authorization gate: assert a valid founder-approval trace exists for this wave label before
+# anything is recorded. REFUSES on anything else — the wave stays un-recorded.
+#
+# usage: verify-trace.sh <wave-label> <founder-login>
+#
+# The founder login is a REQUIRED argument, never defaulted: the founder identity is the
+# authorization anchor, so an absent one is a refusal rather than a fall-back to any implicit login.
+# Exit 0 is the ONLY proceed answer; a guard that could not run exits non-zero like a failed one.
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: verify-trace.sh <wave-label> <founder-login>" >&2; exit 2; }
+WAVE_LABEL="$1"; FOUNDER="$2"
+[ -n "$WAVE_LABEL" ] && [ -n "$FOUNDER" ] || { echo "campaign: REFUSED — an empty wave label or founder login is not an authorization anchor." >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" campaign verify-trace "$WAVE_LABEL" --founder "$FOUNDER" \
+  || { echo "campaign: REFUSED — no valid founder-approval trace for '$WAVE_LABEL'. The wave stays un-recorded." >&2; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/canon/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/canon/SKILL.md
@@ -45,8 +45,14 @@ it once, at the top of your run, per the shared contract's **Target repo resolut
 ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)):
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/resolve-repo.sh")" || exit 1
 ```
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced block is an **invocation** of one
+(epic #4435 phase 1 — the shell moved as-is; turning its glue into tested `pipeline-cli` verbs is
+#1929). They set `set -uo pipefail`, deliberately not `-e`: the self-checks below use a `grep` whose
+empty result is an *answer*, and `errexit` would abort on it. Each check therefore prints an explicit
+verdict word, so "the check found nothing" and "the check never ran" are never the same output.
 
 The **paths themselves are repo-relative** — `.patterns/` at the repo root — resolved from
 the working tree, never an absolute or home path. Resolve the repo root with
@@ -241,15 +247,8 @@ diff.
 Run mechanically — don't self-assess, actually check:
 
 ```bash
-ROOT="$(git rev-parse --show-toplevel)"
-# 1. cross-refs resolve: every relative link target in the docs you touched exists
-grep -roh '](\.\?\.\?/[^)]*\.md)' "$ROOT"/.patterns/<name>.md | sed 's/^](//; s/)$//'
-# 2. no wikilinks / leaked absolute paths
-grep -nE '\[\[|/Users/|\$USIRIN_VAULT_PATH|file://' "$ROOT"/.patterns/<name>.md && echo "LEAK — fix" || echo "links clean"
-# 3. no stale markers
-grep -niE 'as of|currently|at the time|in newer versions|when available' "$ROOT"/.patterns/<name>.md && echo "stale marker — fix" || echo "no stale markers"
-# 4. the index row exists for the doc
-grep -n '<name>.md' "$ROOT"/.patterns/index.md || echo "MISSING index row — add it"
+# all four checks over .patterns/<name>.md — cross-refs, leaks, stale markers, the index row
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/verify-pattern-doc.sh" "<name>"
 ```
 
 Then, by judgment: for the doc — **name the specific mistake an agent makes without it**;

--- a/claude-plugins/kampus-pipeline/skills/canon/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/canon/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from canon/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/canon/scripts/verify-pattern-doc.sh
+++ b/claude-plugins/kampus-pipeline/skills/canon/scripts/verify-pattern-doc.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The four self-checks over a `.patterns/<name>.md` doc you just wrote: cross-refs resolve, no
+# wikilinks or leaked local paths, no stale markers, and an index row exists.
+#
+# usage: verify-pattern-doc.sh <name>          # <name> is the doc's basename, without `.md`
+#
+# Each check prints an EXPLICIT verdict word — `links clean` / `LEAK — fix`, `no stale markers` /
+# `stale marker — fix`, and so on — because a silent grep would make "the check found nothing" and
+# "the check never ran" byte-identical. A missing doc is a refusal (exit 2), not four clean checks.
+#
+# Extracted from canon/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+[ "$#" -ge 1 ] || { echo "usage: verify-pattern-doc.sh <name>" >&2; exit 2; }
+NAME="$1"
+ROOT="$(git rev-parse --show-toplevel)" || { echo "canon: not inside a git repository." >&2; exit 1; }
+DOC="$ROOT/.patterns/$NAME.md"
+[ -r "$DOC" ] || { echo "canon: $DOC is unreadable — nothing to verify." >&2; exit 2; }
+
+# 1. cross-refs resolve: every relative link target in the docs you touched exists
+grep -roh '](\.\?\.\?/[^)]*\.md)' "$DOC" | sed 's/^](//; s/)$//'
+# 2. no wikilinks / leaked absolute paths
+# shellcheck disable=SC2016  # the `$…` is a LITERAL to match in the doc, not a variable to expand
+grep -nE '\[\[|/Users/|\$USIRIN_VAULT_PATH|file://' "$DOC" && echo "LEAK — fix" || echo "links clean"
+# 3. no stale markers
+grep -niE 'as of|currently|at the time|in newer versions|when available' "$DOC" && echo "stale marker — fix" || echo "no stale markers"
+# 4. the index row exists for the doc
+grep -n "$NAME.md" "$ROOT/.patterns/index.md" || echo "MISSING index row — add it"

--- a/claude-plugins/kampus-pipeline/skills/glossary/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/glossary/SKILL.md
@@ -46,7 +46,7 @@ term's disambiguation note), resolve it once, at the top of your run, per the sh
 **Target repo resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)):
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/glossary/scripts/resolve-repo.sh")" || exit 1
 ```
 
 In phoenix this defaults to `kamp-us/phoenix` with no config, so the behavior is unchanged

--- a/claude-plugins/kampus-pipeline/skills/glossary/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/glossary/scripts/resolve-repo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from glossary/SKILL.md (#4454, epic #4435 phase 1).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/release/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/release/SKILL.md
@@ -92,11 +92,32 @@ You need two things before the ritual:
 Resolve `$REPO` the same way the rest of the pipeline does (it is repo-agnostic; ADR 0062):
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/resolve-repo.sh")" || exit 1
 ```
 
 All GitHub reads/writes below go through **`gh api` REST** — never GraphQL (the org's
 Projects-classic integration errors GraphQL issue/PR queries, the standing pipeline constraint).
+
+## The extracted scripts
+
+This ritual's shell lives in [`scripts/`](scripts/), one script per step, and each fenced block
+below is an **invocation** of one. The prose keeps the *why*; the scripts hold the *how* (epic #4435
+phase 1 — the shell moved as-is, and turning its `gh`/`jq` glue into tested `pipeline-cli` verbs is
+#1929). Four properties are load-bearing when you read or edit them:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue steers its own control
+  flow — the reachability refusal, a delete that may legitimately 404, a search whose zero-match
+  result is an answer. `errexit` would abort a fail-closed branch before it printed its refusal.
+- **The dry-run and the apply are two separate scripts.** The two-step is the whole safety of the
+  flip, so `--execute` lives only in [`scripts/flag-open-execute.sh`](scripts/flag-open-execute.sh)
+  and can never arrive as a defaulted flag on the script that prints the diff.
+- **Zero matches is its own exit code.** [`scripts/find-linked-issue.sh`](scripts/find-linked-issue.sh)
+  exits **4** on a *proven* empty release queue and 1/2 when it could not run, so a failed read can
+  never be read as "no queue entry to clear" and silently skip Step 4.
+- **`packages/anka-ops` is resolved from the repo root, not the caller's cwd.** The moved blocks
+  each opened with a bare `cd packages/anka-ops`; [`scripts/lib.sh`](scripts/lib.sh) resolves it
+  from the git root and fails closed when the package is absent, so the flag lever can never run in
+  the wrong tree.
 
 ---
 
@@ -108,8 +129,7 @@ anything. `flag get` reports it in the canonical form (`off (default)` for an un
 `on@100% (split)` for a released one, `on@N% (ramping)` for a partial):
 
 ```bash
-cd packages/anka-ops
-node src/bin.ts flag get "$FLAG_KEY" --env "$ENV"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-get.sh" "$FLAG_KEY" "$ENV"
 ```
 
 - **Currently `off (default)` (dark) →** this is a release you can perform: proceed to Step 2.
@@ -130,29 +150,17 @@ key rides the PR body's `Flag: <key>` line (ship-it Step 5b). Find the awaiting-
 whose closing PR dark-shipped **this** flag key:
 
 ```bash
-# candidate issues on the release queue (the label persists on the closed, linked issue; #602)
-for ISSUE in $(gh api "repos/$REPO/issues?state=all&labels=status:awaiting-release&per_page=100" \
-    --jq '.[] | select(.pull_request | not) | .number'); do
-  # find the PR(s) that closed this issue and check each body for a `Flag: <key>` line naming THIS key
-  # (the grammar write-code Step 5 writes and ship-it Step 5b reads)
-  # --paginate + a STREAMING --jq: per_page caps at 100, so the closing PR of an issue with a
-  # long timeline would otherwise fall off the read and drop the flag from the release queue (#4193)
-  for PR in $(gh api --paginate "repos/$REPO/issues/$ISSUE/timeline?per_page=100" \
-      --jq '.[] | select(.event=="cross-referenced" or .event=="closed")
-                | .source.issue.number? // empty' 2>/dev/null | sort -u); do
-    body=$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""' 2>/dev/null)
-    printf '%s' "$body" \
-      | grep -Eiq "^[[:space:]]*(#{1,6}[[:space:]]*)?\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*${FLAG_KEY}([[:space:]]|$)" \
-      && echo "match: issue #$ISSUE ← PR #$PR declares Flag: $FLAG_KEY"
-  done
-done
+# prints one `match: issue #<I> ← PR #<P> declares Flag: <key>` line per match
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/find-linked-issue.sh" "$FLAG_KEY"
 # LINKED_ISSUE is the awaiting-release issue whose closing PR body carried `Flag: $FLAG_KEY`.
 LINKED_ISSUE="<that issue number>"
 ```
 
-If no `status:awaiting-release` issue names this flag, or the match is ambiguous, **ask the human
-to confirm the issue number** (or confirm there is no queue entry to clear) rather than guessing —
-a wrong dequeue clears another feature's queue entry. Never silently skip Step 4.
+If no `status:awaiting-release` issue names this flag (**exit 4** — a proven-empty queue), or the
+match is ambiguous (more than one `match:` line), **ask the human to confirm the issue number** (or
+confirm there is no queue entry to clear) rather than guessing — a wrong dequeue clears another
+feature's queue entry. Never silently skip Step 4. Any **other** non-zero exit means the search
+never ran: that is UNKNOWN, not an empty queue, and it also goes to the human.
 
 ---
 
@@ -174,24 +182,10 @@ spec under `apps/web/tests/e2e/`, and **fails closed** (non-zero exit) naming ex
 missing. Run it for the resolved key **before the dry-run flip**:
 
 ```bash
-# the `bin/pipeline-cli` shim resolves in-repo bin, else the installed bin, else the pinned
-# `pnpm dlx` fallback reading the ONE pin (hooks/pin.sh) — no version pinned here (#3653)
-REACH="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli reachability-guard check"
-
-# HARD-REFUSE the flip on a non-zero exit — the report (on stderr) names which assertion failed
-# (no consuming UI / no journey e2e for $FLAG_KEY, or an unknown/unclassified flag). The flag
-# stays dark; do NOT proceed to Step 2.
-if ! $REACH "$FLAG_KEY"; then
-  cat >&2 <<EOF
-release: REFUSED — reachability gate. \`$FLAG_KEY\` is UNREACHABLE (see the reachability-guard
-report above): its vertical's user-facing slice is unbuilt, so it must not graduate to 100%
-(ADR 0173, epic #1943). The flag stays DARK. Build + wire the missing slice — the consuming
-.tsx and/or the @journey:$FLAG_KEY-tagged e2e the report named — then re-run /release. If this
-flag is UI-less by design (an infra/containment flag), mark it @reachability-exempt: <reason>
-at its apps/web/src/flags/keys.ts definition; the gate then passes it.
-EOF
-  exit 1
-fi
+# HARD-REFUSE the flip on a non-zero exit — the script relays the guard's report (on stderr), which
+# names which assertion failed, then prints the refusal. The flag stays dark; do NOT proceed to
+# Step 2.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/reachability-gate.sh" "$FLAG_KEY" || exit 1
 ```
 
 - **Non-zero exit → hard-refuse the flip.** This is the identical fail-closed refusal shape as
@@ -226,21 +220,20 @@ confirm it flips *this* flag in *this* env from the dark state you saw in Step 1
 live state:
 
 ```bash
-cd packages/anka-ops
-# Full release (100% — the default release act):
-node src/bin.ts flag open "$FLAG_KEY" --env "$ENV"                   # DRY-RUN: prints current → target, writes nothing
+# Full release (100% — the default release act). DRY-RUN: prints current → target, writes nothing.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-dryrun.sh" "$FLAG_KEY" "$ENV"
 
-# Ramped release (--percent N — serve `on` to N% of traffic; the remainder falls to the safe default):
-node src/bin.ts flag open "$FLAG_KEY" --percent "$N" --env "$ENV"    # DRY-RUN
+# Ramped release (serve `on` to N% of traffic; the remainder falls to the safe default). DRY-RUN.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-dryrun.sh" "$FLAG_KEY" "$ENV" "$N"
 ```
 
 Once the dry-run diff is exactly the release you intend, **execute it** by re-running the same
 command with `--execute`:
 
 ```bash
-node src/bin.ts flag open "$FLAG_KEY" --env "$ENV" --execute              # APPLY the full release
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-execute.sh" "$FLAG_KEY" "$ENV"        # APPLY the full release
 # or, for a ramp:
-node src/bin.ts flag open "$FLAG_KEY" --percent "$N" --env "$ENV" --execute
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-execute.sh" "$FLAG_KEY" "$ENV" "$N"
 ```
 
 **`--percent <n>` — the ramped-release form.** `/release <flag-key> --percent 50` runs the
@@ -264,8 +257,8 @@ A flip you didn't verify is a flip you can't trust. Re-read the **effective serv
 it now reports the live state — the dark → live transition actually landed:
 
 ```bash
-cd packages/anka-ops
-node src/bin.ts flag get "$FLAG_KEY" --env "$ENV"   # expect: on@100% (split)  — or  on@N% (ramping) for a ramp
+# expect: on@100% (split)  — or  on@N% (ramping) for a ramp
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-get.sh" "$FLAG_KEY" "$ENV"
 ```
 
 Assert the transition:
@@ -294,7 +287,7 @@ hand-cleared the night this skill was proposed):
 
 ```bash
 # remove the release-queue label from the (closed) linked issue — the consume half of #602
-gh api -X DELETE "repos/$REPO/issues/$LINKED_ISSUE/labels/status:awaiting-release"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/clear-queue-label.sh" "$LINKED_ISSUE"
 ```
 
 The label lives on a **closed** issue (the dark ship's PR closed it on merge); removing a label
@@ -314,20 +307,8 @@ linked issue so it is durable and discoverable next to the work it releases (and
 text to the human running the command):
 
 ```bash
-NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-BODY="$(cat <<EOF
-## Released 🚀 — \`$FLAG_KEY\`
-
-- **Flag:** \`$FLAG_KEY\` (env: \`$ENV\`)
-- **Serving:** dark (\`off (default)\`) → live (\`$SERVING_NOW\`)
-- **Released:** $NOW by <human releaser>
-- **Closes the release queue for:** #$LINKED_ISSUE
-
-The feature is now visible to users. The dark deploy (agent-merged) is now a release (human flip)
-— the ADR 0083 boundary, closed.
-EOF
-)"
-gh api "repos/$REPO/issues/$LINKED_ISSUE/comments" -f body="$BODY"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/post-release-note.sh" \
+  "$LINKED_ISSUE" "$FLAG_KEY" "$ENV" "$SERVING_NOW" "<human releaser>"
 ```
 
 `$SERVING_NOW` is the exact effective-serving string Step 3 confirmed (`on@100% (split)` or

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/clear-queue-label.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/clear-queue-label.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Step 4: remove the release-queue label from the (closed) linked issue — the consume half of #602.
+# Idempotent: an issue that no longer carries the label is a harmless no-op.
+#
+# usage: clear-queue-label.sh <linked-issue>
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: clear-queue-label.sh <linked-issue>" >&2; exit 2; }
+REPO="$(kp_repo)" || exit 1
+
+gh api -X DELETE "repos/$REPO/issues/$1/labels/status:awaiting-release"

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/find-linked-issue.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/find-linked-issue.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Step 1: find the `status:awaiting-release` issue whose closing PR body carried `Flag: <key>` for
+# THIS flag key — the queue entry Steps 4 and 5 dequeue and annotate.
+#
+# usage: find-linked-issue.sh <flag-key>
+#   stdout  one `match: issue #<I> ← PR #<P> declares Flag: <key>` line per match
+#   exit 0  at least one match — read them; MORE THAN ONE is the ambiguous case the skill sends to
+#           the human, so count the lines rather than taking the first
+#   exit 4  the search ran and found ZERO matches (a PROVEN empty queue, not a failed read)
+#   exit 1/2  could not run — UNKNOWN. Never read as "no queue entry": exit 4 is the only zero-match
+#           answer, so a failed read can't route the caller into skipping Step 4 (the wrong-dequeue
+#           and silent-skip hazards the prose names).
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: find-linked-issue.sh <flag-key>" >&2; exit 2; }
+FLAG_KEY="$1"
+REPO="$(kp_repo)" || exit 1
+
+MATCHES=0
+# candidate issues on the release queue (the label persists on the closed, linked issue; #602)
+for ISSUE in $(gh api "repos/$REPO/issues?state=all&labels=status:awaiting-release&per_page=100" \
+    --jq '.[] | select(.pull_request | not) | .number'); do
+  # find the PR(s) that closed this issue and check each body for a `Flag: <key>` line naming THIS key
+  # (the grammar write-code Step 5 writes and ship-it Step 5b reads)
+  # --paginate + a STREAMING --jq: per_page caps at 100, so the closing PR of an issue with a
+  # long timeline would otherwise fall off the read and drop the flag from the release queue (#4193)
+  for PR in $(gh api --paginate "repos/$REPO/issues/$ISSUE/timeline?per_page=100" \
+      --jq '.[] | select(.event=="cross-referenced" or .event=="closed")
+                | .source.issue.number? // empty' 2>/dev/null | sort -u); do
+    body=$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""' 2>/dev/null)
+    if printf '%s' "$body" \
+      | grep -Eiq "^[[:space:]]*(#{1,6}[[:space:]]*)?\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*${FLAG_KEY}([[:space:]]|$)"; then
+      echo "match: issue #$ISSUE ← PR #$PR declares Flag: $FLAG_KEY"
+      MATCHES=$((MATCHES + 1))
+    fi
+  done
+done
+
+[ "$MATCHES" -gt 0 ] || { echo "release: no status:awaiting-release issue names Flag: $FLAG_KEY (searched the whole queue)." >&2; exit 4; }

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/flag-get.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/flag-get.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Read a flag's EFFECTIVE serving in <env> through anka-ops — what the env actually serves today,
+# resolved through rules → no-match split → default. Used for both the Step-1 pre-flight and the
+# Step-3 post-flight verify.
+#
+# usage: flag-get.sh <flag-key> <env>
+#
+# Relays anka-ops' own output and exit status; it derives no release decision (ADR 0228). A
+# non-zero exit means the read never landed — UNKNOWN, never "dark".
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=./lib.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: flag-get.sh <flag-key> <env>" >&2; exit 2; }
+ANKA="$(release_anka_ops_dir)" || exit 1
+cd "$ANKA" || exit 1
+node src/bin.ts flag get "$1" --env "$2"

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-dryrun.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-dryrun.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Step 2, first half: the DRY-RUN flip. Reads current state, prints the `current → target` diff, and
+# writes NOTHING — `flag open` is dry-run by default and this script never passes `--execute`.
+#
+# usage: flag-open-dryrun.sh <flag-key> <env> [<percent>]
+#   with no <percent>: the full release (a bare `flag open` ≡ --percent 100)
+#   with <percent>:    the ramped release — serve `on` to N% of traffic, remainder falls to the
+#                      safe default
+#
+# The dry-run and the apply are two SEPARATE scripts, deliberately: the two-step is the safety, so
+# `--execute` can never arrive as a defaulted or mistyped flag on the script that prints the diff.
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=./lib.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: flag-open-dryrun.sh <flag-key> <env> [<percent>]" >&2; exit 2; }
+FLAG_KEY="$1"; ENV="$2"; PERCENT="${3:-}"
+ANKA="$(release_anka_ops_dir)" || exit 1
+cd "$ANKA" || exit 1
+
+if [ -n "$PERCENT" ]; then
+  node src/bin.ts flag open "$FLAG_KEY" --percent "$PERCENT" --env "$ENV"
+else
+  node src/bin.ts flag open "$FLAG_KEY" --env "$ENV"
+fi

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-execute.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-execute.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Step 2, second half: APPLY the release. The same `flag open` lever as the dry-run, with
+# `--execute` — the one mutating call in the whole ritual. Run it only after reading the dry-run
+# diff (see flag-open-dryrun.sh, which is a separate script for exactly that reason).
+#
+# usage: flag-open-execute.sh <flag-key> <env> [<percent>]
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=./lib.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: flag-open-execute.sh <flag-key> <env> [<percent>]" >&2; exit 2; }
+FLAG_KEY="$1"; ENV="$2"; PERCENT="${3:-}"
+ANKA="$(release_anka_ops_dir)" || exit 1
+cd "$ANKA" || exit 1
+
+if [ -n "$PERCENT" ]; then
+  node src/bin.ts flag open "$FLAG_KEY" --percent "$PERCENT" --env "$ENV" --execute
+else
+  node src/bin.ts flag open "$FLAG_KEY" --env "$ENV" --execute
+fi

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/lib.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/lib.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# release-only helpers. Sourced, never executed: it defines functions and sets no shell options, so
+# the sourcing script keeps its own `set -uo pipefail`. This lives HERE and not in
+# ../../shared/lib/common.sh because only this skill needs it — anka-ops is the flag lever, and no
+# other skill touches it.
+
+# Absolute path to the anka-ops package. The moved blocks all opened with a bare
+# `cd packages/anka-ops`, which silently resolves against whatever cwd the caller happened to have;
+# resolving it from the repo root instead makes the scripts cwd-independent, and a missing package
+# fails closed rather than running `node src/bin.ts` in the wrong tree.
+release_anka_ops_dir() {
+	local root dir
+	root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+		printf 'release: not inside a git repository — cannot locate packages/anka-ops.\n' >&2
+		return 1
+	}
+	dir="$root/packages/anka-ops"
+	if [ ! -d "$dir" ]; then
+		printf 'release: %s does not exist — the flag lever is unavailable in this checkout.\n' "$dir" >&2
+		return 1
+	fi
+	printf '%s\n' "$dir"
+}

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/post-release-note.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/post-release-note.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Step 5: post the human-readable release note on the linked issue (#1354).
+#
+# usage: post-release-note.sh <linked-issue> <flag-key> <env> <serving-now> <releaser>
+#
+# <serving-now> is the EXACT effective-serving string Step 3 confirmed (`on@100% (split)` or
+# `on@N% (ramping)`), so the note records the true post-flip state, not an assumed one. It is a
+# required argument for that reason — there is no default that could quietly record a state nobody
+# read back.
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 5 ] || { echo "usage: post-release-note.sh <linked-issue> <flag-key> <env> <serving-now> <releaser>" >&2; exit 2; }
+LINKED_ISSUE="$1"; FLAG_KEY="$2"; ENV="$3"; SERVING_NOW="$4"; RELEASER="$5"
+REPO="$(kp_repo)" || exit 1
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+BODY="$(cat <<EOF
+## Released 🚀 — \`$FLAG_KEY\`
+
+- **Flag:** \`$FLAG_KEY\` (env: \`$ENV\`)
+- **Serving:** dark (\`off (default)\`) → live (\`$SERVING_NOW\`)
+- **Released:** $NOW by $RELEASER
+- **Closes the release queue for:** #$LINKED_ISSUE
+
+The feature is now visible to users. The dark deploy (agent-merged) is now a release (human flip)
+— the ADR 0083 boundary, closed.
+EOF
+)"
+gh api "repos/$REPO/issues/$LINKED_ISSUE/comments" -f body="$BODY"

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/reachability-gate.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/reachability-gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Step 1.5's ADR-0173 reachability gate: hard-refuse the flip unless the flag's vertical is
+# reachable (a consuming apps/web/src/**/*.tsx reference + a @journey:<key>-tagged e2e), or the key
+# is stated-exempt at its keys.ts definition.
+#
+# usage: reachability-gate.sh <flag-key>
+#   exit 0    reachable or exempt → proceed to Step 2
+#   non-zero  REFUSED, or the guard could not run — either way the flag stays DARK. There is no
+#             exit code and no stdout that means "proceed" other than 0, so a guard that never ran
+#             cannot be read as a pass.
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: reachability-gate.sh <flag-key>" >&2; exit 2; }
+FLAG_KEY="$1"
+PCLI="$(kp_pcli)" || exit 127
+
+# HARD-REFUSE the flip on a non-zero exit — the report (on stderr) names which assertion failed
+# (no consuming UI / no journey e2e for $FLAG_KEY, or an unknown/unclassified flag). The flag
+# stays dark; do NOT proceed to Step 2.
+if ! "$PCLI" reachability-guard check "$FLAG_KEY"; then
+  cat >&2 <<EOF
+release: REFUSED — reachability gate. \`$FLAG_KEY\` is UNREACHABLE (see the reachability-guard
+report above): its vertical's user-facing slice is unbuilt, so it must not graduate to 100%
+(ADR 0173, epic #1943). The flag stays DARK. Build + wire the missing slice — the consuming
+.tsx and/or the @journey:$FLAG_KEY-tagged e2e the report named — then re-run /release. If this
+flag is UI-less by design (an infra/containment flag), mark it @reachability-exempt: <reason>
+at its apps/web/src/flags/keys.ts definition; the gate then passes it.
+EOF
+  exit 1
+fi

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -58,7 +58,7 @@ Below the five sections, append a footer carrying the machine context of the ses
 Gather the context with the helper, which reads it from the environment and git:
 
 ```bash
-claude-plugins/kampus-pipeline/skills/report/footer.sh
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/footer.sh"
 ```
 
 It prints a ready-to-append markdown block. Which fields appear varies by run — the helper includes only what the environment actually exposes and silently drops the rest, so a real footer might look like this (here `session` and `model` weren't available, so they're omitted — no dangling labels, no "unknown"):
@@ -86,8 +86,23 @@ All GitHub operations go through `gh api` REST. **Never GraphQL** — the kamp-u
 **Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api` call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared contract's **Target repo resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO` if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/resolve-repo.sh")" || exit 1
 ```
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced `bash` block is an **invocation**
+of one; the prose keeps the *why* (epic #4435 phase 1 — the shell moved as-is, and turning its glue
+into tested `pipeline-cli` verbs is #1929). Two properties are load-bearing:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue steers its own control flow
+  through the guards written into it; `errexit` would abort a fail-closed branch before it printed
+  its refusal.
+- **[`scripts/file-report.sh`](scripts/file-report.sh) takes the body on stdin and REFUSES an empty
+  one.** Streaming keeps §SP's "prefer no file at all" property intact, but a pipe — unlike the
+  literal heredoc it replaced — can arrive unread, and an unread pipe is byte-identical to an empty
+  one. Filing on it would post a bodyless issue that reads as a successful report, so an empty stdin
+  is a refusal, not a filing (#3924).
 
 1. Write the title: a short, specific, type-neutral summary of the observation (≤ ~70 chars). Good: "Retry helper in http worker swallows the abort reason". Bad: "Bug in worker" or "BUG: fix retry".
 2. Build the body: the `## Summary` lead, then the five sections, then a blank line, then the footer block from `footer.sh`.
@@ -100,10 +115,8 @@ REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOw
    fed your title plus a few keywords:
 
    ```bash
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-   "$PCLI" intake-dedup check \
-     --query "<the title + a few distinguishing keywords>"
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/dedup-check.sh" \
+     "<the title + a few distinguishing keywords>"
    ```
 
    It prints one `#<n>\t<title>` line per candidate duplicate to stdout (empty output
@@ -122,17 +135,13 @@ REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOw
 
 Stream the composed body **straight into the create call over stdin** — there is no named temp file to collide on and no shell variable to reuse stale, so two concurrent `report` runs cannot interleave bodies (the cross-filing hazard is structurally unrepresentable, not merely warned against — #2002). The `tracker create-issue` verb reads its `--body` from stdin when the flag is absent, so the **quoted** heredoc (`<<'EOF'`) passes the markdown through untouched — multi-line markdown, backticks, and nested fences survive intact, the "backticks survive the shell" guarantee with no round-trip through a variable. Don't hand-roll the `gh api repos/$REPO/issues` create — that inline envelope is exactly what the adoption lint (#3254) flags; the verb owns it (ADR 0190; `packages/pipeline-cli/src/tools/tracker/`) and enters the needs-triage queue by default:
 
+One command, one script invocation: the five sections arrive on the script's **stdin** as a quoted
+heredoc (`<<'EOF'` — the shell never touches the markdown, so backticks and nested ``` fences file
+intact), and the script appends the blank line + the `footer.sh` block and streams the whole thing
+into the create verb. Everything below the invocation line is your authored body, not glue:
+
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# The five sections + a blank line + the footer.sh block, piped straight into the
-# create verb over stdin. No mktemp, no $BODY_FILE, no `$(cat …)` — nothing shared to
-# collide on. `create-issue` consumes the whole stream as the body; the quoted `<<'EOF'`
-# heredoc means the shell never touches the markdown, so backticks and nested ``` fences
-# file intact. The verb passes the body by-value through a direct spawn (no `-f body=@file`),
-# so the local-path leak class is gone too.
-{
-  cat <<'EOF'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/file-report.sh" "<title>" <<'EOF'
 ## Summary
 …
 
@@ -151,9 +160,6 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 ## Suggested next step (non-binding)
 …
 EOF
-  echo   # blank line before the footer block
-  claude-plugins/kampus-pipeline/skills/report/footer.sh   # emits its own `---` + <sub>… line
-} | "$PCLI" tracker create-issue --title "<title>"
 ```
 
 The body never lands on disk under a shared name and never round-trips through a variable, so the two named failure paths this hardening closes — "simplify" to a fixed `/tmp/report-body.md`, or reuse one `$BODY_FILE` across two creates — have no surface to occur on: there is no file path to fix and no variable to reuse. This is the

--- a/claude-plugins/kampus-pipeline/skills/report/scripts/dedup-check.sh
+++ b/claude-plugins/kampus-pipeline/skills/report/scripts/dedup-check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# The mandatory pre-filing dedup query (ADR 0181): print one `#<n>\t<title>` line per candidate
+# duplicate, and the candidate count on stderr. The verb resolves the target repo itself, so it
+# needs no $REPO.
+#
+# usage: dedup-check.sh <the title + a few distinguishing keywords>
+#
+# stdout is the verb's own output RELAYED unchanged (ADR 0228). An empty stdout means "no likely
+# match" ONLY on exit 0; a non-zero exit means the check never ran, which is UNKNOWN — file rather
+# than treat it as clean (a duplicate is cheap for triage to close, a lost observation is gone).
+#
+# Extracted from report/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: dedup-check.sh <title + keywords>" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" intake-dedup check \
+  --query "$1"

--- a/claude-plugins/kampus-pipeline/skills/report/scripts/file-report.sh
+++ b/claude-plugins/kampus-pipeline/skills/report/scripts/file-report.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# File the report: read the composed five-section body on STDIN, append a blank line + the metadata
+# footer, and stream the whole thing into `tracker create-issue` (which enters the needs-triage queue
+# by default, ADR 0190). Also the emit path wayfinder's epic-emission uses.
+#
+# usage: <composed body on stdin> | file-report.sh <title>
+#
+# STDIN, not a file path, and not a `--body` argument: there is no named temp file to collide on and
+# no shared variable to reuse stale, so two concurrent runs cannot interleave bodies (#2002, §SP's
+# "prefer no file at all"). The body is held only in this process's own local `$BODY` — nothing
+# shared, nothing reused across creates — which is what lets the emptiness check below exist without
+# reintroducing that hazard.
+#
+# An EMPTY stdin is REFUSED. Moving the body from a literal heredoc to a pipe made stdin an external
+# input, and an unread pipe is byte-identical to an empty one — filing on it would post a bodyless
+# issue that looks like a successful report (#3924's class, ruled fail-closed).
+#
+# Extracted from report/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: <body on stdin> | file-report.sh <title>" >&2; exit 2; }
+TITLE="$1"
+[ -n "$TITLE" ] || { echo "file-report: empty title — refusing to file an untitled report." >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+# shellcheck disable=SC1007  # `CDPATH= cd` clears CDPATH for the subshell — the same idiom the lib source line uses
+FOOTER="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/footer.sh"
+[ -x "$FOOTER" ] || { echo "file-report: $FOOTER is not executable — refusing to file a footerless report." >&2; exit 1; }
+
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "file-report: EMPTY body on stdin — refusing to file a bodyless issue (#3924)." >&2; exit 2; }
+
+{
+  printf '%s\n' "$BODY"
+  echo        # blank line before the footer block
+  "$FOOTER"   # emits its own `---` + <sub>… line
+} | "$PCLI" tracker create-issue --title "$TITLE"

--- a/claude-plugins/kampus-pipeline/skills/report/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/report/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from report/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -44,15 +44,41 @@ resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), 
 defaulting to `kamp-us/phoenix` with no config:
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/resolve-repo.sh")" || exit 1
 ```
+
+Every script under [`scripts/`](scripts/) resolves the repo the same way through the shared lib's
+`kp_repo`, so you never thread `$REPO` into one — that assignment is for your own ad-hoc `gh api`
+reads.
 
 List the queue:
 
 ```bash
-gh api "repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100" \
-  --jq '.[] | "#\(.number) (\(.user.login)) \(.title)"'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/list-queue.sh"
 ```
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), one script per step, and each fenced block below
+is an **invocation** of one — including the blocks in [`close-not-planned.md`](./close-not-planned.md).
+The prose keeps the *why*; the scripts hold the *how* (epic #4435 phase 1 — the shell moved as-is,
+and turning its `gh`/`jq` glue into tested `pipeline-cli` verbs is #1929). Three properties are
+load-bearing when you read or edit them:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control flow
+  through the guards written into it — a `|| true` on a delete that may legitimately 404, a
+  state-word assertion instead of an exit-status test, a read whose empty result is an answer.
+  `errexit` would abort those paths mid-decision and turn a fail-closed branch into no branch at all.
+- **An exit status is the answer; an empty stdout never is.** Every script's failure paths exit
+  non-zero, and the one script with a permissive branch —
+  [`scripts/claim-issue.sh`](scripts/claim-issue.sh) — reaches exit 0 only through its checkpoint GET
+  proving the claim, printing `claim: won #N`. So "could not run" can never read as "claimed" or as
+  "no duplicate found".
+- **Cross-step state travels through the §SP scratch namespace, not shell variables.** Each agent
+  Bash call is a fresh process, so the Step-4 pair (`fetch-original.sh` → `patch-body.sh`) and the
+  duplicate-preservation pair (`fetch-duplicate-body.sh` → `post-duplicate-comment.sh`) re-derive one
+  directory through the shared lib's `kp_scratch_open` / `kp_scratch_path` — `open` resets, `path`
+  never does, which is why the second half of each pair uses `path` (#3718).
 
 ## The glossary — read `.glossary/`, use the canonical terms
 
@@ -81,39 +107,10 @@ lock; the protocol below is detect-and-tiebreak, **not** mutual exclusion. Run i
 **per issue**, immediately before any mutation (split, rewrite, or label):
 
 ```bash
-ME=$(gh api user --jq '.login')
-
-# Rule 0 — defer to a pre-existing owner. If #N is already claimed (by a sibling sweep,
-# or — see the release note below — by a write-code agent that picked an already-triaged
-# issue), back off WITHOUT POSTing and move to the next issue. A fresh arrival never
-# evicts an owner that was there before it.
-PRE=$(gh api repos/$REPO/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
-[ -n "$PRE" ] && continue   # already claimed → skip this issue, take the next
-
-# POST self; capture the FULL assignees list the write returns (one observable write).
-ASSIGNEES=$(gh api -X POST repos/$REPO/issues/<N>/assignees \
-  -f "assignees[]=$ME" --jq '[.assignees[].login] | sort | join(" ")')
-
-# Provisional tiebreak among co-racers: min-login. The POST echo only DETECTS a race
-# (staggered co-racers see different sets and both may compute themselves min); the
-# checkpoint GET below RESOLVES it. See §7 for the full derivation.
-WINNER=$(printf '%s\n' $ASSIGNEES | head -n1)
-if [ "$WINNER" = "$ME" ]; then
-  for a in $ASSIGNEES; do
-    [ "$a" = "$ME" ] && continue
-    gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$a"
-  done
-  # CHECKPOINT — re-read canonical state (a fresh GET, not the stale POST echo) and
-  # re-confirm I am still min(assignees). This is what resolves the race; do not prune it.
-  STILL=$(gh api repos/$REPO/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
-  [ "$(printf '%s\n' $STILL | head -n1)" = "$ME" ] || {
-    gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME"; continue; }
-  # claim won and confirmed → triage this issue (Steps 1–6), then RELEASE in Step 6
-else
-  # lost the tiebreak: self-clean and take the next issue (do NOT triage — do NOT co-occupy)
-  gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME"
-  continue
-fi
+# exit 0 = claim WON and confirmed → triage #N, then release in Step 6.
+# non-zero = backed off (3: already claimed, or lost the tiebreak) or could not run (1) —
+# either way, do NOT triage #N. The script's own header states the full exit-code contract.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/claim-issue.sh" <N> || continue
 ```
 
 **You MUST release the claim when you finish triaging** (Step 6) — triage's claim is a
@@ -145,15 +142,13 @@ point** for the human path: a UI/hand-filed issue never ran `report`'s pre-file 
 keywords, excluding itself so it never flags itself:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" intake-dedup check \
-  --query "<this issue's title + a few distinguishing keywords>" \
-  --exclude <N>
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup-check.sh" \
+  "<this issue's title + a few distinguishing keywords>" <N>
 ```
 
 It prints one `#<n>\t<title>` line per candidate open issue that may already cover this
-observation (empty output ⇒ no likely duplicate), fusing the read-after-write `needs-triage`
+observation — empty output ⇒ no likely duplicate, but **only on a zero exit**: a non-zero exit means
+the check never ran, which is UNKNOWN, never "clean" — fusing the read-after-write `needs-triage`
 queue with the eventually-consistent search index — the two sources this skill used to query
 by hand. It resolves the target repo itself (ADR 0062 §1), so it needs no `$REPO`.
 
@@ -306,21 +301,11 @@ How to split:
    empty husk open.
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# 1. Create-once guard: skip the POST if a child already covers this (parent, title) unit (#3464).
-EXISTING=$("$PCLI" split-guard check \
-  --parent "$N" --title "<single-unit title>")
-if [ -n "$EXISTING" ]; then
-  echo "split-guard: $EXISTING already covers this unit — reusing, not creating a twin"
-else
-  # 2. Body MUST carry the `split from #<N>` back-reference — it is the guard's create-once key.
-  #    The `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
-  #    `packages/pipeline-cli/src/tools/tracker/`), filing a status:needs-triage issue — don't
-  #    hand-roll the `gh api repos/$REPO/issues` create (the adoption lint (#3254) flags it).
-  "$PCLI" tracker create-issue --title "<single-unit title>" --body "$BODY"
-  # then cross-link via a comment on the original (Step 6 shows the comment call)
-fi
+# The script runs the create-once guard first and only files when no child covers the unit; the
+# body arrives as a FILE because it is multi-line markdown and MUST carry `split from #<N>`, the
+# guard's create-once key. Cross-link via a comment on the original afterwards (Step 6).
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/split-child.sh" \
+  <N> "<single-unit title>" "<path/to/child-body.md>"
 ```
 
 ---
@@ -403,33 +388,17 @@ in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §SP. An iss
 body**, so triage would silently preserve the wrong original inside `<details>` (#3718):
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
-# Keyed on the session id (not a bare `mktemp -d`) because the PATCH block below runs in a LATER
-# Bash call, where every shell variable is gone: it re-derives this same path to read body.md back.
-[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || {
-  echo "triage: §SP — CLAUDE_CODE_SESSION_ID unset; refusing to write issue bodies to a shared path (#3718)." >&2; exit 1; }
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/triage-<N>"
-rm -rf "$RUN_SCRATCH" && mkdir -p "$RUN_SCRATCH" || {
-  echo "triage: §SP could not create a per-run scratch dir — refusing to write issue bodies to a shared path (#3718)." >&2; exit 1; }
-
-gh api "repos/$REPO/issues/<N>" --jq '.body' > "$RUN_SCRATCH/original.md"
-# redact any machine-local path leak in the ORIGINAL before it goes into <details>; leak-free
-# originals pass through byte-for-byte. Reuses the shared leak matcher — no divergent patterns.
-"$PCLI" redact-leaks --body-file "$RUN_SCRATCH/original.md" > "$RUN_SCRATCH/original.redacted.md"
-# assemble the <details> block from the REDACTED original, never the raw one
+# Prints the §SP scratch dir; writes original.md and original.redacted.md into it. Assemble the
+# <details> block from the REDACTED original, never the raw one.
+RUN_SCRATCH="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/fetch-original.sh" <N>)" || exit 1
 ```
 
 Assemble the new body in a temp file — under `$RUN_SCRATCH` for the same reason — and read it
 into `$BODY` so multi-line markdown, backticks, and the nested fences survive the shell:
 
 ```bash
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/triage-<N>"   # §SP re-derive — same recipe as the block above, NO reset
-[ -s "$RUN_SCRATCH/body.md" ] || {
-  echo "triage: §SP — $RUN_SCRATCH/body.md is missing/empty; refusing to PATCH the issue with an empty body." >&2; exit 1; }
-BODY="$(cat "$RUN_SCRATCH/body.md")"
-gh api -X PATCH "repos/$REPO/issues/<N>" -f body="$BODY"
+# Re-derives the SAME §SP namespace (non-resetting) and refuses on a missing/empty body.md.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/patch-body.sh" <N>
 ```
 
 **Epics are the exception — wrap-in-place, never rewrite-on-top.** An epic's original
@@ -643,9 +612,9 @@ the numbers you may assign to:
 
 ```bash
 # the home candidates: the arc/campaign rows and the open milestones they pin to
-gh api "repos/$REPO/milestones?state=open" --jq '.[] | "#\(.number)\t\(.title)"'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/list-open-milestones.sh"
 # assign — one single-field, last-write-wins PATCH (benign, #91); by NUMBER, never title
-gh api -X PATCH "repos/$REPO/issues/<N>" -f milestone=<n>
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/assign-milestone.sh" <N> <n>
 ```
 
 - **Existing open milestones only — triage NEVER creates one.** Match against the set that
@@ -734,9 +703,7 @@ approval "on his behalf," and do not treat your own draft as approved.
 issue you just drafted, so a red names *this* issue rather than the whole backlog:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" pitch-guard check --issue <N>   # out-of-scope issues pass; a red is this draft
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/pitch-guard.sh" <N>   # out-of-scope issues pass; a red is this draft
 ```
 
 An **unapproved** pitch is a legitimate, expected state for a freshly-triaged issue — the guard
@@ -758,9 +725,7 @@ queue (its `status:needs-triage` removed). Apply the whole transition with the `
 verb — the classification is the parameter, the label plumbing is the verb's:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" tracker apply-triage <N> --type <type> --p <priority>
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/apply-triage.sh" <N> <type> <priority>
 ```
 
 The verb adds the `type:` / priority / `status:triaged` labels and drops the queue label
@@ -782,10 +747,8 @@ this confirms the pair landed rather than racing it; the invariant is enforced a
 not re-swept by hand later:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" homing-guard check --issue <N>   # the issue you just triaged
-"$PCLI" homing-guard check               # the whole open triaged backlog
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/homing-guard.sh" <N>   # the issue you just triaged
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/homing-guard.sh"       # the whole open triaged backlog
 ```
 
 ### Close not-planned (kill, agent issues only)
@@ -811,8 +774,7 @@ consistency: a parked `needs-info` issue or a closed one should carry no stray t
 claim. The DELETE is idempotent — a 404 means it was already unassigned, which is fine.
 
 ```bash
-ME=$(gh api user --jq '.login')
-gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" 2>/dev/null || true
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/release-claim.sh" <N>
 ```
 
 (A `closed-by-triage` issue is closed *and* unassigned; a needs-info issue is parked with
@@ -873,9 +835,7 @@ three applies is out of triage's scope (ADR
 
 ```bash
 # open milestones at 100% — 0 open issues, at least one closed (an empty milestone is not "done")
-gh api "repos/$REPO/milestones?state=open&per_page=100" \
-  --jq '.[] | select(.open_issues == 0 and .closed_issues > 0)
-        | "#\(.number)\t\(.title)\t(\(.closed_issues) closed, 0 open)"'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/completed-milestones.sh"
 ```
 
 Surface the matches in the sweep ledger (Step 5's report-back) as a **flag to the EA** — one

--- a/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
@@ -29,24 +29,23 @@ Every kill is auditable and reversible. Always:
 4. Close as **not planned** (state `closed`, reason `not_planned`).
 
 ```bash
-# step 1 only when closing as a duplicate of #M. Temps live under the §SP per-run scratch
-# namespace (gh-issue-intake-formats.md) — an issue number is NOT unique, and a clobbered file
-# reads back cleanly as another run's body, preserving the WRONG original (#3718). Keyed on the
-# session id so composing dup-comment.md in a later Bash call still resolves this same directory:
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset — refusing a shared path (#3718)}/triage-close-<N>"
-mkdir -p "$RUN_SCRATCH" || { echo "§SP: no per-run scratch dir — refusing a shared path (#3718)." >&2; exit 1; }
-gh api "repos/$REPO/issues/<N>" --jq '.body' > "$RUN_SCRATCH/dup.md"   # then wrap in <details> and:
-gh api "repos/$REPO/issues/<M>/comments" -f body="$(cat "$RUN_SCRATCH/dup-comment.md")"
+# step 1 only when closing as a duplicate of #M. Both scripts resolve the SAME §SP per-run scratch
+# namespace through the shared lib's kp_scratch_* seam — an issue number is NOT unique, and a
+# clobbered file reads back cleanly as another run's body, preserving the WRONG original (#3718).
+RUN_SCRATCH="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/fetch-duplicate-body.sh" <N>)" || exit 1
+# then wrap $RUN_SCRATCH/dup.md in <details> as $RUN_SCRATCH/dup-comment.md, and:
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/post-duplicate-comment.sh" <N> <M>
 # steps 2-4, every kill:
-gh api "repos/$REPO/issues/<N>/comments" -f body="Closing not-planned: <specific reason>."
-gh api "repos/$REPO/issues/<N>/labels" -f "labels[]=closed-by-triage"
-gh api -X PATCH "repos/$REPO/issues/<N>" -f state=closed -f state_reason=not_planned
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/close-not-planned.sh" <N> "<specific reason>."
 ```
+
+The scripts live in [`scripts/`](scripts/) alongside the rest of this skill's extracted shell; the
+extraction contract and the `set -uo pipefail`-without-`-e` rationale are in
+[`SKILL.md` § The extracted scripts](./SKILL.md#the-extracted-scripts).
 
 The maintainer audits all kills with one query, so over-closing is caught and reopened
 cheaply:
 
 ```bash
-gh api "repos/$REPO/issues?state=closed&labels=closed-by-triage" \
-  --jq '.[] | "#\(.number) \(.title)"'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/audit-kills.sh"
 ```

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/apply-triage.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/apply-triage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Apply the triage verdict to #N: the type + priority labels and the status transition, through the
+# one verb that owns that label write.
+#
+# usage: apply-triage.sh <N> <type> <priority>
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "usage: apply-triage.sh <N> <type> <priority>" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" tracker apply-triage "$1" --type "$2" --p "$3"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/assign-milestone.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/assign-milestone.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Home #N in milestone <n> — one single-field, last-write-wins PATCH (benign, #91); by NUMBER,
+# never title.
+#
+# usage: assign-milestone.sh <N> <milestone-number>
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: assign-milestone.sh <N> <milestone-number>" >&2; exit 2; }
+REPO="$(kp_repo)" || exit 1
+
+gh api -X PATCH "repos/$REPO/issues/$1" -f milestone="$2"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/audit-kills.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/audit-kills.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# The maintainer's kill audit: every issue closed by triage, so over-closing is caught and reopened
+# cheaply.
+# Extracted from triage/close-not-planned.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/issues?state=closed&labels=closed-by-triage" \
+  --jq '.[] | "#\(.number) \(.title)"'

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/claim-issue.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/claim-issue.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Step 0's concurrent-sweep claim on #N: detect-and-tiebreak by self-assigning, NOT a lock
+# (../../gh-issue-intake-formats.md §7 owns the semantics).
+#
+# usage: claim-issue.sh <N>
+#
+# EXIT-CODE CONTRACT — the loop-control seam. The moved block used `continue` to step to the
+# next issue, which a separate process cannot do, so each `continue` became an exit code the
+# caller reads (`claim-issue.sh "$N" || continue`):
+#   0  claim WON and CONFIRMED — triage #N, then release in Step 6. Prints `claim: won #N`.
+#   3  backed off: #N was already claimed, or this sweep lost the tiebreak. Nothing left behind.
+#   1  could not run (repo unresolved, bad usage is 2) — UNKNOWN, so NOT a win.
+# Exit 0 is reachable only through the checkpoint GET below returning this login as min, so an
+# unread response can never surface as a win: a failed POST leaves `$ASSIGNEES` empty and a failed
+# checkpoint leaves `$STILL` empty, and both compute a winner that is not `$ME` ⇒ exit 3. stdout
+# carries the `claim: won` line on that one path and nothing on any other, so neither the exit
+# status nor an empty stdout can be read as the permissive answer.
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: claim-issue.sh <N>" >&2; exit 2; }
+N="$1"
+REPO="$(kp_repo)" || exit 1
+
+ME=$(gh api user --jq '.login')
+
+# Rule 0 — defer to a pre-existing owner. If #N is already claimed (by a sibling sweep,
+# or — see the release note below — by a write-code agent that picked an already-triaged
+# issue), back off WITHOUT POSTing and move to the next issue. A fresh arrival never
+# evicts an owner that was there before it.
+PRE=$(gh api "repos/$REPO/issues/$N" --jq '[.assignees[].login] | sort | join(" ")')
+[ -n "$PRE" ] && { echo "claim: #$N already claimed by '$PRE' — backing off." >&2; exit 3; }
+
+# POST self; capture the FULL assignees list the write returns (one observable write).
+ASSIGNEES=$(gh api -X POST "repos/$REPO/issues/$N/assignees" \
+  -f "assignees[]=$ME" --jq '[.assignees[].login] | sort | join(" ")')
+
+# Provisional tiebreak among co-racers: min-login. The POST echo only DETECTS a race
+# (staggered co-racers see different sets and both may compute themselves min); the
+# checkpoint GET below RESOLVES it. See §7 for the full derivation.
+# shellcheck disable=SC2086  # word splitting is the point: $ASSIGNEES is a space-joined list
+WINNER=$(printf '%s\n' $ASSIGNEES | head -n1)
+if [ "$WINNER" = "$ME" ]; then
+  # shellcheck disable=SC2086
+  for a in $ASSIGNEES; do
+    [ "$a" = "$ME" ] && continue
+    gh api -X DELETE "repos/$REPO/issues/$N/assignees" -f "assignees[]=$a"
+  done
+  # CHECKPOINT — re-read canonical state (a fresh GET, not the stale POST echo) and
+  # re-confirm I am still min(assignees). This is what resolves the race; do not prune it.
+  STILL=$(gh api "repos/$REPO/issues/$N" --jq '[.assignees[].login] | sort | join(" ")')
+  # shellcheck disable=SC2086
+  [ "$(printf '%s\n' $STILL | head -n1)" = "$ME" ] || {
+    gh api -X DELETE "repos/$REPO/issues/$N/assignees" -f "assignees[]=$ME"
+    echo "claim: lost the checkpoint tiebreak on #$N — backing off." >&2
+    exit 3; }
+  # claim won and confirmed → triage this issue (Steps 1–6), then RELEASE in Step 6
+  echo "claim: won #$N"
+else
+  # lost the tiebreak: self-clean and take the next issue (do NOT triage — do NOT co-occupy)
+  gh api -X DELETE "repos/$REPO/issues/$N/assignees" -f "assignees[]=$ME"
+  echo "claim: lost the min-login tiebreak on #$N to '$WINNER' — backing off." >&2
+  exit 3
+fi

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/close-not-planned.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/close-not-planned.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Kill-protocol steps 2-4, every kill: the reason comment, the `closed-by-triage` audit label, and
+# the not-planned close. The reason is REQUIRED — an unexplained kill is not auditable.
+#
+# usage: close-not-planned.sh <N> <specific reason>
+#
+# Extracted from triage/close-not-planned.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: close-not-planned.sh <N> <specific reason>" >&2; exit 2; }
+N="$1"; REASON="$2"
+[ -n "$REASON" ] || { echo "close-not-planned: empty reason — refusing an unauditable kill." >&2; exit 2; }
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/issues/$N/comments" -f body="Closing not-planned: $REASON"
+gh api "repos/$REPO/issues/$N/labels" -f "labels[]=closed-by-triage"
+gh api -X PATCH "repos/$REPO/issues/$N" -f state=closed -f state_reason=not_planned

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/completed-milestones.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/completed-milestones.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Print the open milestones sitting at 100% — 0 open issues, at least one closed (an empty
+# milestone is not "done").
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/milestones?state=open&per_page=100" \
+  --jq '.[] | select(.open_issues == 0 and .closed_issues > 0)
+        | "#\(.number)\t\(.title)\t(\(.closed_issues) closed, 0 open)"'

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/dedup-check.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/dedup-check.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Step 1's intake-dedup read (ADR 0181): print one `#<n>\t<title>` line per open issue that may
+# already cover this observation. The verb resolves the target repo itself, so no $REPO is needed.
+#
+# usage: dedup-check.sh <query> <N>
+#
+# stdout is the verb's own output RELAYED unchanged (ADR 0228) — this script derives nothing. An
+# empty stdout means "no likely duplicate" ONLY on exit 0; every failure path here exits non-zero
+# (2 usage, 127 CLI unresolved, else the verb's own status) so an unrun check can never read as a
+# clean one.
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: dedup-check.sh <query> <N>" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" intake-dedup check \
+  --query "$1" \
+  --exclude "$2"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/fetch-duplicate-body.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/fetch-duplicate-body.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Kill-protocol step 1 (duplicates only): open the per-run scratch namespace for the close of #N
+# and fetch #N's full body into it, so the loser's content can be preserved on the survivor before
+# #N is closed. Prints the scratch directory.
+#
+# usage: fetch-duplicate-body.sh <N>
+#   writes  <scratch>/dup.md   #N's body verbatim — wrap it in <details> as <scratch>/dup-comment.md
+#
+# The §SP namespace is keyed on the session id, not the issue number: an issue number is NOT unique,
+# and a clobbered file reads back cleanly as another run's body, preserving the WRONG original
+# (#3718). post-duplicate-comment.sh re-derives this same directory through the same `kp_scratch_*`
+# seam in a LATER Bash call, where every shell variable is gone.
+#
+# Extracted from triage/close-not-planned.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: fetch-duplicate-body.sh <N>" >&2; exit 2; }
+N="$1"
+REPO="$(kp_repo)" || exit 1
+RUN_SCRATCH="$(kp_scratch_open "triage-close-$N")" || exit 1
+
+gh api "repos/$REPO/issues/$N" --jq '.body' > "$RUN_SCRATCH/dup.md" || exit 1
+printf '%s\n' "$RUN_SCRATCH"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/fetch-original.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/fetch-original.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Step 4: open the per-run scratch namespace for #N, fetch the issue's ORIGINAL body into it, and
+# redact any machine-local path leak before that original goes into the `<details>` block. Prints
+# the scratch directory so the caller can compose `body.md` there.
+#
+# usage: fetch-original.sh <N>
+#   writes  <scratch>/original.md           the raw original
+#           <scratch>/original.redacted.md  the leak-redacted original — assemble <details> FROM THIS
+#
+# The §SP namespace (../../gh-issue-intake-formats.md §SP) is keyed on the session id, not a bare
+# `mktemp -d`, because patch-body.sh runs in a LATER Bash call where every shell variable is gone
+# and must re-derive this same directory. Both scripts go through the ONE shared `kp_scratch_*`
+# seam so they cannot disagree about the path (#3718). `open` resets; `path` never does.
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: fetch-original.sh <N>" >&2; exit 2; }
+N="$1"
+REPO="$(kp_repo)" || exit 1
+PCLI="$(kp_pcli)" || exit 127
+RUN_SCRATCH="$(kp_scratch_open "triage-$N")" || exit 1
+
+gh api "repos/$REPO/issues/$N" --jq '.body' > "$RUN_SCRATCH/original.md" || exit 1
+# redact any machine-local path leak in the ORIGINAL before it goes into <details>; leak-free
+# originals pass through byte-for-byte. Reuses the shared leak matcher — no divergent patterns.
+"$PCLI" redact-leaks --body-file "$RUN_SCRATCH/original.md" > "$RUN_SCRATCH/original.redacted.md" || exit 1
+# assemble the <details> block from the REDACTED original, never the raw one
+printf '%s\n' "$RUN_SCRATCH"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/homing-guard.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/homing-guard.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run the homing-guard: with an issue number, over the issue you just triaged; with no argument,
+# over the whole open triaged backlog. Relays the verb's output and exit status (ADR 0228).
+#
+# usage: homing-guard.sh [<N>]
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+PCLI="$(kp_pcli)" || exit 127
+
+if [ "$#" -ge 1 ]; then
+  "$PCLI" homing-guard check --issue "$1"   # the issue you just triaged
+else
+  "$PCLI" homing-guard check                # the whole open triaged backlog
+fi

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/list-open-milestones.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/list-open-milestones.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Print the open milestones — the home candidates the arc/campaign rows pin to.
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/milestones?state=open" --jq '.[] | "#\(.number)\t\(.title)"'

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/list-queue.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/list-queue.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Print the open `status:needs-triage` queue, one `#<n> (<filer>) <title>` line per issue.
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100" \
+  --jq '.[] | "#\(.number) (\(.user.login)) \(.title)"'

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/patch-body.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/patch-body.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Step 4: PATCH #N's body from `<scratch>/body.md`, the enriched body the caller composed in the
+# namespace fetch-original.sh opened. Reading the body from a file is what lets multi-line markdown,
+# backticks, and the nested `<details>` fences survive the shell.
+#
+# usage: patch-body.sh <N>
+#
+# Re-derives the §SP namespace through `kp_scratch_path` — the NON-resetting read, deliberately not
+# `kp_scratch_open`, which would delete the body.md this call came to send (#3718).
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: patch-body.sh <N>" >&2; exit 2; }
+N="$1"
+REPO="$(kp_repo)" || exit 1
+RUN_SCRATCH="$(kp_scratch_path "triage-$N")" || exit 1
+
+[ -s "$RUN_SCRATCH/body.md" ] || {
+  echo "triage: §SP — $RUN_SCRATCH/body.md is missing/empty; refusing to PATCH the issue with an empty body." >&2; exit 1; }
+BODY="$(cat "$RUN_SCRATCH/body.md")"
+gh api -X PATCH "repos/$REPO/issues/$N" -f body="$BODY"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/pitch-guard.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/pitch-guard.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run the pitch-guard over #N — out-of-scope issues pass; a red is this draft.
+# Relays the verb's own output and exit status (ADR 0228); a CLI that never resolved exits 127,
+# which is UNKNOWN, not a pass.
+#
+# usage: pitch-guard.sh <N>
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pitch-guard.sh <N>" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" pitch-guard check --issue "$1"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/post-duplicate-comment.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/post-duplicate-comment.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Kill-protocol step 1 (duplicates only): post the `<details>`-wrapped body of the closing duplicate
+# #N onto the surviving issue #M, from `<scratch>/dup-comment.md`.
+#
+# usage: post-duplicate-comment.sh <N> <M>
+#
+# Re-derives the §SP namespace with `kp_scratch_path` — the NON-resetting read, deliberately not
+# `kp_scratch_open`, which would delete the dup-comment.md this call came to send (#3718).
+#
+# Extracted from triage/close-not-planned.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: post-duplicate-comment.sh <N> <M>" >&2; exit 2; }
+N="$1"; M="$2"
+REPO="$(kp_repo)" || exit 1
+RUN_SCRATCH="$(kp_scratch_path "triage-close-$N")" || exit 1
+
+[ -s "$RUN_SCRATCH/dup-comment.md" ] || {
+  echo "triage: §SP — $RUN_SCRATCH/dup-comment.md is missing/empty; refusing to post an empty preservation comment on #$M." >&2; exit 1; }
+gh api "repos/$REPO/issues/$M/comments" -f body="$(cat "$RUN_SCRATCH/dup-comment.md")"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/release-claim.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/release-claim.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Step 6: release the sweep-scoped claim on #N. Triage's claim is a mutex, not durable ownership —
+# left set, write-code's picker (which skips ANY non-null assignee) would never see the issue again.
+# Tolerates an already-released claim: the DELETE is idempotent, so a second release is a no-op.
+#
+# usage: release-claim.sh <N>
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: release-claim.sh <N>" >&2; exit 2; }
+REPO="$(kp_repo)" || exit 1
+
+ME=$(gh api user --jq '.login')
+gh api -X DELETE "repos/$REPO/issues/$1/assignees" -f "assignees[]=$ME" 2>/dev/null || true

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/split-child.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/split-child.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Step 3's create-once split: file one single-unit child of #N, unless split-guard says a child
+# already covers this (parent, title) unit (#3464).
+#
+# usage: split-child.sh <parent-N> <single-unit title> <body-file>
+#
+# The body arrives as a FILE, not an argument: it must carry the `split from #<N>` back-reference
+# (the guard's create-once key) and is multi-line markdown, which an argv string mangles.
+#
+# Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "usage: split-child.sh <parent-N> <title> <body-file>" >&2; exit 2; }
+N="$1"; TITLE="$2"; BODY_FILE="$3"
+[ -s "$BODY_FILE" ] || { echo "split-child: body file '$BODY_FILE' is missing/empty — refusing to file a bodyless child." >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+# 1. Create-once guard: skip the POST if a child already covers this (parent, title) unit (#3464).
+EXISTING=$("$PCLI" split-guard check \
+  --parent "$N" --title "$TITLE")
+if [ -n "$EXISTING" ]; then
+  echo "split-guard: $EXISTING already covers this unit — reusing, not creating a twin"
+else
+  # 2. Body MUST carry the `split from #<N>` back-reference — it is the guard's create-once key.
+  #    The `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
+  #    `packages/pipeline-cli/src/tools/tracker/`), filing a status:needs-triage issue — don't
+  #    hand-roll the `gh api repos/$REPO/issues` create (the adoption lint (#3254) flags it).
+  BODY="$(cat "$BODY_FILE")"
+  "$PCLI" tracker create-issue --title "$TITLE" --body "$BODY"
+  # then cross-link via a comment on the original (Step 6 shows the comment call)
+fi

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -75,6 +75,17 @@ transport, session gh-identity routing, and similar. The rule targets the operat
 - It is **not part of the linear execution flow** — it is the pre-triage ideation stage that
   runs *before* the pipeline picks anything up.
 
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced `bash` block is an **invocation**
+of one; the prose keeps the *why* (epic #4435 phase 1 — the shell moved as-is, and turning its glue
+into tested `pipeline-cli` verbs is #1929). They set `set -uo pipefail`, deliberately not `-e`: the
+moved glue steers its own control flow, and `errexit` would abort a fail-closed branch before it
+printed its refusal. The **emission** step deliberately calls `report`'s own
+[`file-report.sh`](../report/scripts/file-report.sh) rather than a wayfinder copy — the emitted epic
+is agent-filed intake through the *same* footer and create envelope, so the two cannot drift (the
+same reason this skill already sourced `report`'s footer).
+
 ## CHART mode — name the destination, map the frontier (plan-don't-do)
 
 CHART is invoked with **no map yet** (a fresh foggy idea) or **a named destination against an
@@ -482,15 +493,16 @@ rather than a hand-typed, human-owned issue, so triage's auto-close-eligibility 
 correctly (§the report footer in the formats contract). Stream the composed brief straight into the
 create over stdin (no shared temp file to collide on, per the report skill's filing rule):
 
+One emitted epic per coherent buildable unit. The brief is composed from map `#<MAP>`'s
+`## Destination` + the relevant `## Decisions-so-far` slice (read via the wayfinder CLI, never ad-hoc
+markdown slicing), and arrives on the filing script's **stdin** as a quoted heredoc. It files into
+the SAME `status:needs-triage` entry `report` uses — literally the same script, `report`'s own
+[`file-report.sh`](../report/scripts/file-report.sh), so the footer and the create envelope cannot
+drift from the report skill's:
+
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
-# One emitted epic per coherent buildable unit. The brief is composed from map #$MAP's
-# ## Destination + the relevant ## Decisions-so-far slice (read via the wayfinder CLI, never
-# ad-hoc markdown slicing). Files into the SAME status:needs-triage entry `report` uses.
-{
-  cat <<'EOF'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/file-report.sh" \
+  "<the epic, as one concrete deliverable>" <<'EOF'
 ## Destination
 <the epic's end-state, from the map's ## Destination>
 
@@ -500,12 +512,9 @@ REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOw
 ## Emitted from wayfinder map
 Charted and cleared on wayfinder:map #<MAP>. Downstream is the existing pipeline: triage → plan-epic → write-code.
 EOF
-  echo   # blank line before the footer block
-  claude-plugins/kampus-pipeline/skills/report/footer.sh   # emits its own `---` + <sub>… line
-} | "$PCLI" tracker create-issue --title "<the epic, as one concrete deliverable>"
 ```
 
-The `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
+The `tracker create-issue` verb the script calls owns this intake-create envelope (ADR 0190;
 `packages/pipeline-cli/src/tools/tracker/`): it files a `status:needs-triage` issue, reading the
 body from stdin so the composed heredoc streams straight in. Don't hand-roll the
 `gh api repos/$REPO/issues` create — that inline envelope is what the adoption lint (#3254) flags.
@@ -539,18 +548,11 @@ Make the ideation→execution handoff traceable from both ends, then close:
   stay as they are.
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Name every artifact the map graduated into (epics and/or ADR and/or roadmap), then close it
 # IFF the destination is FULLY graduated. A partial graduation is annotated but stays open.
-# The `tracker graduate` verb owns this graduation-close envelope (ADR 0190, #3266): it posts
-# the `Graduated into <artifact>` source → artifact provenance record and closes the source as
-# completed. Don't hand-roll the comment + `state_reason=completed` PATCH — that inline
-# re-derivation is what the adoption lint (#3254) flags.
-"$PCLI" tracker graduate "$MAP" \
-  --artifact "#$E1, #$E2 → triage → plan-epic → write-code; ADR 0176; ROADMAP.md v1" \
-  --note "Frontier cleared — closing this map as the durable record of how the plan was discovered."
-# fully-graduated only; a partial graduation is annotated (a plain comment) but stays open.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/wayfinder/scripts/graduate-map.sh" "$MAP" \
+  "#$E1, #$E2 → triage → plan-epic → write-code; ADR 0176; ROADMAP.md v1" \
+  "Frontier cleared — closing this map as the durable record of how the plan was discovered."
 ```
 
 ### What emission is not

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/scripts/graduate-map.sh
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/scripts/graduate-map.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Close a FULLY-graduated map: post the `Graduated into <artifact>` source → artifact provenance
+# record and close the source as completed. The `tracker graduate` verb owns this envelope (ADR 0190,
+# #3266) — this script relays it and derives nothing (ADR 0228).
+#
+# usage: graduate-map.sh <map> <artifact> <note>
+#
+# FULLY-graduated only. A partial graduation is annotated with a plain comment and stays OPEN, so it
+# does not come through here.
+#
+# Extracted from wayfinder/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "usage: graduate-map.sh <map> <artifact> <note>" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" tracker graduate "$1" \
+  --artifact "$2" \
+  --note "$3"

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
@@ -30,20 +30,26 @@ targets `$REPO`), per the shared contract's target-repo rule
 ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), ADR 0062):
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/resolve-repo.sh")" || exit 1
 ```
 
-## Resolve the `ship-digest` command once — in-repo-first, published-fallback
+## The extracted scripts
 
-Prefer the on-disk consolidated `packages/pipeline-cli/src/bin.ts` when it exists (phoenix-local:
-no network, no published-artifact dependency); otherwise invoke the **published**
-`@kampus/pipeline-cli` CLI via `pnpm dlx` (ADR 0064; epic #994). Build it once:
+This skill's shell lives in [`scripts/`](scripts/), and each fenced block is an **invocation** of
+one; the prose keeps the *why* (epic #4435 phase 1 — the shell moved as-is, and turning its glue into
+tested `pipeline-cli` verbs is #1929). They set `set -uo pipefail`, deliberately not `-e`: the moved
+glue steers its own control flow, and `errexit` would abort a fail-closed branch before it printed
+its refusal. Two notes:
 
-```bash
-# the `bin/pipeline-cli` shim resolves in-repo bin, else the installed bin, else the pinned
-# `pnpm dlx` fallback reading the ONE pin (hooks/pin.sh) — no version pinned here (#3653).
-DIGEST="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli ship-digest"
-```
+- **The `ship-digest` shim resolution is no longer a step.** It was a block that only built a `$DIGEST`
+  string for a later block — and no shell variable survives between agent Bash calls, so it never
+  actually reached its consumer. [`scripts/derive-digest.sh`](scripts/derive-digest.sh) resolves the
+  shim itself through the shared lib's `kp_pcli` (in-repo bin → installed bin → the pinned `pnpm dlx`
+  reading the ONE pin; ADR 0064, #3653), so the in-repo-first / published-fallback behaviour is
+  unchanged and now lands where it is used.
+- **An empty entries file is a refusal, not an empty digest.** `derive-digest.sh` reds on a
+  missing/empty `<entries.json>`, because a zero-entry array derives a plausible, well-formed
+  "nothing shipped in this window" readout that is simply wrong.
 
 ---
 
@@ -54,10 +60,12 @@ another (`/what-shipped since 2026-06-01`, `/what-shipped last 30 days`). The wi
 dates the digest heading reports over:
 
 ```bash
-SINCE="${SINCE:-$(date -u -v-7d +%Y-%m-%d 2>/dev/null || date -u -d '7 days ago' +%Y-%m-%d)}"
-UNTIL="${UNTIL:-$(date -u +%Y-%m-%d)}"
-echo "window: $SINCE → $UNTIL"
+# prints `<since> <until>`; $SINCE / $UNTIL in the environment override either end
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/window.sh"
 ```
+
+Read the two dates off that output and pass them explicitly to the calls below. No shell variable
+survives between agent Bash calls, so the window travels as **arguments**, not as `$SINCE`/`$UNTIL`.
 
 `ship-digest derive` needs `--since` (required) and optional `--until` (defaults to today), so
 `$SINCE`/`$UNTIL` flow straight through at Step 4.
@@ -73,10 +81,8 @@ Read merged PRs via `gh api` REST (never GraphQL). The `search/issues` endpoint 
 `merged:` directly:
 
 ```bash
-# merged PRs in the window — REST search, never GraphQL. `is:merged` + `merged:$SINCE..$UNTIL`.
-gh api -X GET search/issues \
-  -f q="repo:$REPO is:pr is:merged merged:$SINCE..$UNTIL" \
-  -f per_page=100 --jq '.items[] | .number'
+# merged PRs in the window — REST search, never GraphQL. `is:merged` + `merged:<since>..<until>`.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/merged-prs.sh" "$SINCE" "$UNTIL"
 ```
 
 If you prefer to anchor on the merge commits rather than trust the search index, cross-check with
@@ -89,7 +95,7 @@ For each merged PR number, read the fields the entry needs:
 ```bash
 # per merged PR: title, its `area:*` label (join-free product/infra signal, #1598), and the
 # linked issue via the `Fixes #N` / `Closes #N` in the PR body.
-gh api "repos/$REPO/pulls/$PR" --jq '{title: .title, body: .body, labels: [.labels[].name]}'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/pr-context.sh" "$PR"
 ```
 
 - **`title`** → the entry's `title` (prefer the linked-issue title once resolved in Step 2).
@@ -107,8 +113,7 @@ issue, then read that issue's metadata:
 
 ```bash
 # the linked issue's title, milestone, and type:* — the entry's title (preferred), milestone, and type.
-gh api "repos/$REPO/issues/$ISSUE" \
-  --jq '{title: .title, milestone: (.milestone.title // null), type: ([.labels[].name | select(startswith("type:")) | sub("^type:";"")] | first // null)}'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/issue-context.sh" "$ISSUE"
 ```
 
 Populate each entry from the join:
@@ -144,12 +149,8 @@ serving is truthful — a split-released flag's `defaultVariation` stays `off` f
 
 ```bash
 # authoritative Flagship state — every flag × env with its enabled/default value (ADR 0081/0123).
-# in-repo-first, published-fallback, same idiom as $DIGEST above.
-if [ -f packages/anka-ops/src/bin.ts ]; then
-  node packages/anka-ops/src/bin.ts flag list
-else
-  pnpm dlx @kampus/anka-ops@0.1.0 flag list
-fi
+# in-repo-first, published-fallback.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/flag-list.sh"
 ```
 
 Assign each merged entry a **`releaseState`** — one of `live` / `awaiting-release` / `dark` /
@@ -204,9 +205,9 @@ Write it to a scratch file (never a repo path — this is throwaway gather outpu
 artifact), then invoke:
 
 ```bash
-ENTRIES="$(mktemp -t what-shipped-entries.XXXXXX.json)"
-# … write the gathered array to "$ENTRIES" …
-$DIGEST derive --entries "$ENTRIES" --since "$SINCE" --until "$UNTIL"
+# … having written the gathered array to a per-run JSON file (§SP) …
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/derive-digest.sh" \
+  "<entries.json>" "$SINCE" "$UNTIL"
 ```
 
 `ship-digest derive` decodes the entries, runs the pure `deriveShipDigest` core, and prints the

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/derive-digest.sh
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/derive-digest.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Hand the gathered entries array to the `ship-digest derive` verb, which owns the readout derivation.
+# This script relays the verb; it derives nothing itself (ADR 0228).
+#
+# usage: derive-digest.sh <entries.json> <since> <until>
+#
+# The entries file is REQUIRED and must be non-empty: an absent or empty file would hand the verb a
+# zero-entry array, which reads as "nothing shipped in the window" — a well-formed, plausible,
+# always-wrong readout. That is a refusal here, not a digest.
+#
+# Extracted from what-shipped/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "usage: derive-digest.sh <entries.json> <since> <until>" >&2; exit 2; }
+ENTRIES="$1"
+[ -s "$ENTRIES" ] || { echo "what-shipped: entries file '$ENTRIES' is missing/empty — refusing to derive a digest from no entries." >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+
+"$PCLI" ship-digest derive --entries "$ENTRIES" --since "$2" --until "$3"

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/flag-list.sh
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/flag-list.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Print the authoritative Flagship state — every flag × env with its enabled/default value
+# (ADR 0081/0123). In-repo first, published fallback: the same shim idiom the ship-digest call uses.
+#
+# Extracted from what-shipped/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+if [ -f packages/anka-ops/src/bin.ts ]; then
+  node packages/anka-ops/src/bin.ts flag list
+else
+  pnpm dlx @kampus/anka-ops@0.1.0 flag list
+fi

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/issue-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/issue-context.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Print the linked issue's title, milestone, and `type:*` — the readout entry's title (preferred),
+# milestone, and type.
+#
+# usage: issue-context.sh <issue>
+#
+# Extracted from what-shipped/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: issue-context.sh <issue>" >&2; exit 2; }
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/issues/$1" \
+  --jq '{title: .title, milestone: (.milestone.title // null), type: ([.labels[].name | select(startswith("type:")) | sub("^type:";"")] | first // null)}'

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/merged-prs.sh
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/merged-prs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Print the numbers of the PRs merged in the window — REST search, never GraphQL.
+#
+# usage: merged-prs.sh <since> <until>
+#
+# Extracted from what-shipped/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: merged-prs.sh <since> <until>" >&2; exit 2; }
+SINCE="$1"; UNTIL="$2"
+REPO="$(kp_repo)" || exit 1
+
+# `is:merged` + `merged:$SINCE..$UNTIL`
+gh api -X GET search/issues \
+  -f q="repo:$REPO is:pr is:merged merged:$SINCE..$UNTIL" \
+  -f per_page=100 --jq '.items[] | .number'

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/pr-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/pr-context.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Print one merged PR's title, its `area:*` label (the join-free product/infra signal, #1598), and
+# its body — the body is where the `Fixes #N` / `Closes #N` linked issue lives.
+#
+# usage: pr-context.sh <pr>
+#
+# Extracted from what-shipped/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pr-context.sh <pr>" >&2; exit 2; }
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/pulls/$1" --jq '{title: .title, body: .body, labels: [.labels[].name]}'

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from what-shipped/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/window.sh
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/scripts/window.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Print the readout window as `<since> <until>` (ISO dates, UTC), defaulting to the last 7 days.
+# $SINCE / $UNTIL in the environment override either end.
+#
+# The `date -u -v-7d` / `date -u -d '7 days ago'` pair is BSD-then-GNU, in that order, because this
+# runs on both macOS and CI Linux.
+#
+# Extracted from what-shipped/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+SINCE="${SINCE:-$(date -u -v-7d +%Y-%m-%d 2>/dev/null || date -u -d '7 days ago' +%Y-%m-%d)}"
+UNTIL="${UNTIL:-$(date -u +%Y-%m-%d)}"
+[ -n "$SINCE" ] && [ -n "$UNTIL" ] || { echo "what-shipped: could not resolve the window — neither BSD nor GNU date accepted the offset." >&2; exit 1; }
+echo "window: $SINCE → $UNTIL" >&2
+printf '%s %s\n' "$SINCE" "$UNTIL"


### PR DESCRIPTION
Phase-1 byte-move for the long tail of skill shell (epic #4435, child #4454): the fenced `bash`
blocks of **12 markdown files across 11 skills** move into per-skill `scripts/` directories. The prose
keeps the *why*; every remaining fence is an **invocation**. **No moved glue is rewritten** — that is
#1929 / phase 2, per the founder's ruling on #4435 (comment 5112916299) and the ADR-0228 boundary
(a script may relay a verb's answer, never derive the decision).

Part of #4454. **#4454 remains open** — two skills in its list were skipped for open-PR overlap and one
file has no destination yet. The remainder is named in *Not in this PR*, below.

## Scope shipped

| file | blocks | shell lines before → after | markdown delta |
|---|---|---|---|
| `triage/SKILL.md` | 13 | 97 → 29 | +55 / −95 |
| `triage/close-not-planned.md` | 2 | 14 → 9 | +12 / −13 |
| `release/SKILL.md` | 9 | 66 → 24 | +45 / −64 |
| `report/SKILL.md` | 3 | 33 → 21 | +25 / −19 |
| `wayfinder/SKILL.md` | 2 | 32 → 16 | +24 / −22 |
| `what-shipped/SKILL.md` | 8 → 7 | 27 → 16 | +30 / −29 |
| `architecture-audit/SKILL.md` | 5 | 27 → 11 | +27 / −26 |
| `campaign/SKILL.md` | 6 | 20 → 7 | +27 / −19 |
| `canon/SKILL.md` | 2 | 10 → 3 | +9 / −10 |
| `adr/SKILL.md` | 1 | 4 → 3 | +2 / −3 |
| `author-skill/SKILL.md` | 1 | 3 → 1 | +1 / −3 |
| `glossary/SKILL.md` | 1 | 1 → 1 | +1 / −1 |

**334 shell lines → 141**, and the 141 that remain are invocation lines, their comments, and the
authored-content heredocs (see below). **52 new scripts**, all `.sh` under `skills/**`, so all §CP by
path. Committed per skill: `a64c1a45` triage, `d92f53ff` release, `0abae786` report+wayfinder,
`d29b9eae` the tail.

## The fail-closed invariant, proven — not asserted

PR #4485 FAIL'd because two extracted scripts returned **empty stdout on their own guard paths**
while the skill defined empty stdout as a positive answer. Every script here was walked for that,
including the `REPO="$(kp_repo)" || exit 1` path that returns *before any echo*.

**Reviewer-runnable proof** (captures exit code **and** stdout byte count on every failure path, and
asserts non-zero + zero bytes for each — a printed message is not proof):

```bash
PROOF_SH="$(mktemp -t prove-failclosed.XXXXXX)"   # no fixed scratch path in a shared artifact
cat > "$PROOF_SH" <<'PROOF'
#!/usr/bin/env bash
set -uo pipefail
ROOT="$(git rev-parse --show-toplevel)/claude-plugins/kampus-pipeline/skills"
OUT="$(mktemp -d)"; FAILS=0
probe() { local label="$1"; shift; local expect="$1"; shift; [ "$1" = "--" ] && shift
  "$@" >"$OUT/so" 2>"$OUT/se"; local rc=$? bytes; bytes=$(wc -c <"$OUT/so" | tr -d ' ')
  local v=ok
  if [ "$expect" = nonzero ]; then [ "$rc" -ne 0 ] || v="BAD(rc==0)"; else [ "$rc" = "$expect" ] || v="BAD(rc=$rc want $expect)"; fi
  [ "$bytes" = 0 ] || v="$v BAD(stdout=$bytes bytes)"
  case "$v" in ok) ;; *) FAILS=$((FAILS+1)) ;; esac
  printf '%-62s rc=%-4s stdout=%-3s bytes  %s\n' "$label" "$rc" "$bytes" "$v"; }
for dir in triage release report wayfinder what-shipped architecture-audit campaign canon adr author-skill glossary; do
  for s in "$ROOT/$dir"/scripts/*.sh; do n="$(basename "$s")"
    grep -q '^\[ "\$#" -ge' "$s" && probe "$dir/$n [no-args]" 2 -- "$s"
    grep -q 'kp_repo' "$s" && probe "$dir/$n [kp_repo unresolvable]" nonzero -- \
      env -u CLAUDE_PIPELINE_REPO HOME="$HOME" PATH="$PATH" sh -c 'cd / && exec "$0" 1 2 3' "$s"
    grep -q 'kp_pcli' "$s" && probe "$dir/$n [kp_pcli unresolvable]" nonzero -- \
      env CLAUDE_PLUGIN_ROOT=/nonexistent CLAUDE_PIPELINE_REPO=kamp-us/phoenix "$s" 1 2 3
    grep -q 'release_anka_ops_dir' "$s" && probe "$dir/$n [anka-ops unlocatable]" nonzero -- \
      env HOME="$HOME" PATH="$PATH" sh -c 'cd / && exec "$0" k prod' "$s"
    grep -q 'kp_scratch_path' "$s" && probe "$dir/$n [scratch never opened]" nonzero -- \
      env CLAUDE_PLUGIN_ROOT=/nonexistent CLAUDE_PIPELINE_REPO=kamp-us/phoenix \
      CLAUDE_CODE_SESSION_ID=proof-no-such-session TMPDIR="$OUT/tmp" "$s" 999999 999998
  done
done
echo; echo "violations: $FAILS"; [ "$FAILS" -eq 0 ]
PROOF
bash "$PROOF_SH"
```

Every failure path exits non-zero with **0 bytes** on stdout. The reviewer's independent run of this
same harness at `d29b9eae` reported **84 probes, 0 violations**; the "51 probes" this body carried
earlier was an undercount of the harness's own coverage, and 84 is the number to read. The paths the
generic classes don't reach were probed individually and are also all non-zero / 0-byte:
`read-glossary.sh` and `decisions-map.sh` from the wrong cwd (rc=1), `verify-pattern-doc.sh` outside a
git repo (rc=1) and with an absent doc (rc=2), and `file-report.sh` on an **empty stdin** (rc=2).

Where a script *has* a permissive branch, exit 0 is reachable only through positive evidence:

- **`triage/scripts/claim-issue.sh`** — exit 0 (`claim: won #N` on stdout) only via the checkpoint GET
  returning this login as `min(assignees)`. A failed POST leaves `$ASSIGNEES` empty and a failed
  checkpoint leaves `$STILL` empty; both compute a winner that is not `$ME` ⇒ exit 3 (backed off).
  Exit 1 is "could not run". The caller reads `|| continue`.
- **`release/scripts/find-linked-issue.sh`** — exit **4** is a *proven-empty* release queue; 1/2 mean
  the search never ran. So a failed read cannot be read as "no queue entry to clear" and silently skip
  the Step-4 dequeue. This is strictly stronger than the block it replaces: the pre-extraction markdown
  form (`… && echo "match: …"` inside a `for` loop) exited **0** with no output on a failed search, so
  the extraction *closes* a pre-existing fail-open rather than preserving one.
- **`release/scripts/reachability-gate.sh`** — 0 is the only proceed answer; a guard that could not
  run exits like a refused one and the flag stays dark.
- **`canon/scripts/verify-pattern-doc.sh`** — each check prints an explicit verdict word
  (`links clean` / `LEAK — fix`, `no stale markers` / `stale marker — fix`), so "found nothing" and
  "never ran" are never the same output.

No script sets an `EXIT` trap, so the `set -u`-abort-becomes-exit-0 hazard (#4476, class #4479) has no
surface here. 51 of the 52 set `set -uo pipefail` **without** `-e`, the shape #4485's gate upheld: the
moved glue steers its own control flow, and `errexit` would abort a fail-closed branch before it
printed its refusal. The 52nd is `release/scripts/lib.sh`, which is sourced-only and deliberately sets
no options, so the sourcing script keeps its own.

## Byte-fidelity recipe

```bash
git diff 22dfd0874261e04c2625397b8930e44617fc30da..HEAD -- \
  'claude-plugins/kampus-pipeline/skills/*/*.md' 'claude-plugins/kampus-pipeline/skills/*/scripts/*.sh'
```
Read each deleted markdown block against the script that received it: the shell body is unchanged
apart from the seams enumerated below. Then confirm nothing is left behind:

```bash
# THE CORPUS RE-COUNT (the epic plan's fence matcher, verbatim) — blocks + shell lines per file
find claude-plugins/kampus-pipeline/skills -name '*.md' | sort | while IFS= read -r f; do
  awk -v F="$f" '
    /^```(bash|sh)$/ { inb=1; b++; next }
    inb && /^```$/ { inb=0; next }
    inb { l++ }
    END { if (b>0) printf "%-60s blocks=%-4d lines=%d\n", F, b, l }
  ' "$f"
done
```

Every fence remaining in the twelve shipped files is an invocation of a `scripts/*.sh`, its comments,
or authored content. `shellcheck -x` is clean over all 52 scripts.

## The seams — every deviation from a pure byte-move, named

Phase 1 is "relocation plus the minimal sourcing seams." These are all of them:

1. **`continue` → an exit code.** `triage/scripts/claim-issue.sh` was written to run inside the
   caller's per-issue loop; a separate process cannot step that loop. Each `continue` became an exit
   code with a stated contract (0 won / 3 backed off / 1 could not run).
2. **Two hand-copied `${TMPDIR}/kampus-run/…` recipes → the shared lib's `kp_scratch_open` /
   `kp_scratch_path`.** The Step-4 pair and the duplicate-preservation pair each have to agree on one
   directory across two *separate* Bash calls; routing both through the one seam is what makes
   disagreement unrepresentable (#3718). `open` resets, `path` does not — which is why each pair's
   second half uses `path`. This is a **path-derivation change** (the verb owns allocation), flagged
   explicitly: it is the AC-3 "source the shared common lib for cross-step state" requirement.
3. **Authored content stayed in the markdown, as content.** `report`'s five-section body,
   `wayfinder`'s epic brief and `architecture-audit`'s finding body are per-run authored prose, not
   glue. They are now a quoted heredoc on **one script invocation's stdin** — the shim resolution,
   the brace group, the footer call and the pipe assembly all left. Streaming preserves §SP's
   prefer-no-file property and #2002's no-interleaving property; it also **retires**
   `architecture-audit`'s shared-`/tmp` `mktemp` body file.
4. **`file-report.sh` refuses an empty stdin.** Moving the body from a literal heredoc to a pipe made
   stdin an external input, and an unread pipe is byte-identical to an empty one — filing on it posts
   a bodyless issue that reads as a success (#3924's ruled class). This is the one place the
   extraction **adds** a guard, and it is added because the extraction created the hazard. The body
   lives only in the script's own process-local variable: nothing shared, nothing reused across
   creates, so #2002 is not reintroduced.
5. **`cd packages/anka-ops` → resolved from the git root** (`release/scripts/lib.sh`), failing closed
   when the package is absent, so the flag lever cannot run in the wrong tree. `lib.sh` is a
   *release-only* helper and deliberately **not** in `shared/lib/common.sh` — only this skill touches
   anka-ops. **`shared/lib/common.sh` is unmodified by this PR.**
6. **`release`'s dry-run and apply are two separate scripts.** The two-step *is* the safety, so
   `--execute` exists only in `flag-open-execute.sh` and can never arrive as a defaulted flag on the
   script that prints the diff.
7. **`what-shipped`'s `$DIGEST` block is gone, not moved.** It only built a shim string for a *later*
   block, and no shell variable survives between agent Bash calls, so it never reached its consumer.
   `derive-digest.sh` resolves the shim itself via `kp_pcli` — same in-repo-first / published-fallback
   ladder (ADR 0064, #3653), now where it is used. It also reds on an empty entries file, because a
   zero-entry array derives a plausible, well-formed, wrong "nothing shipped in this window".
8. **`campaign`'s `git switch -c` stayed prose.** Only the PR-open half is a script. A script running
   `git switch -c` would mutate whichever checkout the caller happened to be sitting in — a footgun
   the extraction would have *introduced* rather than moved.
9. **`campaign/scripts/verify-trace.sh` takes the founder login positionally** and refuses an empty
   one, so the authorization anchor cannot degrade into an implicit login. No identity is hardcoded.
10. **Cross-skill reuse over copies.** `wayfinder` and `architecture-audit` call `report`'s own
    `file-report.sh` rather than a copy, so the footer + create envelope cannot drift — the same
    reason `wayfinder` already sourced `report`'s `footer.sh`.
11. `report/SKILL.md`'s `footer.sh` invocation moved from a cwd-relative path to the
    `${CLAUDE_PLUGIN_ROOT:-…}` form the rest of the corpus uses.

## Scan-surface delta (the #4470 class) — two surfaces are NARROWED, and the delta for this diff is zero

Extraction can move content out of a guard's scan surface, leaving the guard green and guarding
nothing. **An earlier revision of this table said the surface was *preserved* on every row. That was
false on two rows** — `cli-invocation-guard` and `leak-guard` are both markdown-scoped and do **not**
follow `.sh` — and asserting *preserved* where the truth is *narrowed* is the #4470 class reproduced
inside the section claiming to close it. A false green in prose is the same defect as a false green in
a guard. Corrected, with the mechanism on each narrowed row:

| surface | follows `.sh`? | result on this head |
|---|---|---|
| `cli-invocation-guard check` | **no — NARROWED.** Scans *runnable markdown fences*; a `.sh` enters the file count and contributes **zero** scanned fences | clean, and clean is **vacuous** over the 52 `.sh` |
| `leak-guard scan` | **no — NARROWED.** Hard-scoped to markdown by extension: `DOC_SUFFIXES = [".md", ".mdx", ".markdown"]`, `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts:31` — a `.sh` is never a doc surface | clean, and clean is **vacuous** over the 52 `.sh` |
| `adoption-lint check` | yes (listed every `scripts/*.sh`) | clean |
| `gh-phoenix lint-skills` | yes (gh-call + bare-push scans listed the `.sh`) | clean |
| `validate-cycle-absence.sh` / `validate-cycle-presence.sh` | yes (widened by #4470/#4473) | OK — 14 / 18 checks |
| `validate-gate-path-drift.sh` | n/a (canonical assignments) | OK — 34 checks |
| `validate-skills.sh` | markdown frontmatter | OK — 30 skills valid |
| pre-commit `leak-guard` / `primary-index-guard` / `biome` | — | green on all four commits |

**`cli-invocation-guard` — the mechanism.** Given a bait `.sh` carrying a bare
`pipeline-cli tracker create-issue`, the guard reports `scanned 1 file(s), 0 runnable bash/sh fence(s)`
and does not red it. In the 64-file run the *markdown* fences alone satisfied its zero-scope assertion,
so the 52 `.sh` files rode through contributing nothing to the scan: they were in the file **count**,
not in the **surface**. Tracked in **#4486** (open).

**`leak-guard` — the mechanism, and this one is a security guard.** A user-home absolute path (the
shape its own home-directory arm matches) inside a markdown fence is **blocked**; the identical path in
a `.sh` reads **clean**, because leak-guard decides
"is this a doc surface" by extension at `leak-guard.ts:31`. So the moved shell leaves a **security**
guard's surface permanently, and so does every future batch: this programme has ~2,600 more shell lines
to extract under the same assumption. Fixing it means **widening a guard**, which is categorically not
a byte-move and is not attempted here. Tracked in **#4496** (open), alongside #4486.

**The coverage delta for THIS diff is zero, and both halves are measured rather than assumed** (run
against `d29b9eae`, and independently reproduced by the gate):

```bash
SK=claude-plugins/kampus-pipeline/skills
git ls-files "$SK/*/scripts/*.sh" | wc -l                                    # 52 — the scripts in question
# cli-invocation-guard's subject: a BARE `pipeline-cli` invocation. Expect zero.
git grep -nE '(^|[^-[:alnum:]_/])pipeline-cli([[:space:]]|$)' -- "$SK/*/scripts/*.sh"   # 0 hits
# leak-guard's subject: a user-local absolute path. Expect zero.
git grep -nE '/(Users|home)/[A-Za-z0-9_.-]+' -- "$SK/*/scripts/*.sh"                   # 0 hits
```

- **`cli-invocation-guard`'s subject is absent:** zero bare `pipeline-cli` tokens across the 52 — every
  CLI reach reaches the shim through the shared lib's `kp_pcli` → `"$PCLI"`. The 7 `node …/src/bin.ts`
  calls that do exist are **anka-ops** `flag` commands (`release/scripts/flag-*.sh`,
  `what-shipped/scripts/flag-list.sh`), outside this guard's subject entirely.
- **`leak-guard`'s subject is absent:** zero user-local paths across the 52. The sole literal `/Users/`
  occurrence is `canon/scripts/verify-pattern-doc.sh:25` — the leak **matcher pattern** itself, inside
  a single-quoted `grep -nE` and `SC2016`-annotated for exactly that reason.

So: the guard surfaces are **narrowed by the move**, the coverage delta **for this diff is provably
zero**, and the narrowing itself is tracked in #4486 and #4496. Those are three
separate statements, and only the middle one is a claim about this PR.

`adoption-lint` needs `.claude/workflows/drive-issue.js` in scope alongside the changed files,
otherwise it correctly reds `declared exemption names a file not in scope`; CI passes the whole corpus,
so include it when reproducing.

## Not in this PR — the honest remainder on #4454

**Skipped for open-PR overlap** (a bad conflict resolution inside a relocated block silently drops an
in-flight change — the reason #4485 shipped 1 of its 4 files):

- **`heal-ci/SKILL.md`** (11 blocks, ~112 lines) — PR #4372 edits the *interior* of the Step-0 fenced
  block, adding the `cp_changed_files` / `CP_FLAG` §CP-awareness. Exactly the overlap class.
- **`doctor/SKILL.md`** + `doctor/doctor.sh` (1 block, 1 line) — PR #4389 touches both.

**No destination yet:**

- **`taste-library-conventions.md`** (1 block, 4 lines) — a top-level file under `skills/`, not a skill
  directory, so it has no `<skill>/scripts/` home under the destination convention #4446 pinned.
  Inventing a third destination is a control-plane call, not a byte-move; it wants either a ruling or
  a `taste-library-conventions/` directory first.

**Out of scope by design:** the phase-2 files (`ship-it`, `write-code`, `gh-issue-intake-formats.md`,
`review-code`, `plan-epic`/`review-plan`) and the phase-3 sibling #4453's review-gate tail, which are
their own children.

## Deviations

Walked all seven §DEV classes. Four fired; the three that did not are stated with their reason rather
than listed bare.

- **(1) Scope narrowing** — **Said:** #4454's file list includes `heal-ci`, `doctor` and
  `taste-library-conventions.md`, and its AC1 covers "every fenced block remaining in the listed skill
  files"; AC4 asks for a corpus-wide re-count showing zero multi-line glue in `skills/**`. **Did:** 12
  files across 11 skills; the three above are untouched, and the re-count is zero only **within the
  twelve**. **Why:** `heal-ci/SKILL.md` and `doctor/*` are edited by open PRs #4372 / #4389 *inside the
  very blocks being relocated* (the #4485 conflict class, verified against those PRs' own file lists);
  `taste-library-conventions.md` has no `<skill>/scripts/` home under #4446's pinned destination, and
  inventing a third destination is a control-plane ruling, not a byte-move. AC4 is corpus-wide by
  construction and cannot close until phase-2's #4448–#4452 and the phase-3 sibling #4453 land — no
  single PR can satisfy it. **Disposition:** disclosed narrowing, linked `Part of #4454` with **no
  closing keyword**; #4454 stays open with the remainder named above.
- **(3) Known defect left unfixed** — three, each deliberate:
  - **`leak-guard` is markdown-scoped by extension** (`leak-guard.ts:31`), so every script this
    programme extracts sits outside a **security** guard. **Why not fixed here:** widening a guard is
    not a byte-move, and phase 1 is relocation only. **Disposition:** filed as **#4496**; the delta for
    this diff is measured zero above.
  - **`cli-invocation-guard` does not follow extracted shell.** **Disposition:** #4486, open; same
    measured zero delta.
  - **`report/SKILL.md` still says of `dedup-check.sh` "empty output ⇒ no likely match"** without the
    "only on exit 0" qualifier the script's own header carries — the #4485 *shape*. **Why not fixed
    here:** the permissive branch points at **filing, not closing** (the skill's own rule: a duplicate
    is cheap for triage to close, a lost observation is gone), and the exposure is unchanged from the
    pre-extraction fence, so tightening it is a prose change beyond this move. **Disposition:** left
    for a later pass; called out rather than silently carried.
- **(5) Guard or gate bypassed** — no `--no-verify`, no skipped or disabled hook, no `biome-ignore` /
  `@ts-expect-error` / `test.skip` / `.only` anywhere in the added lines. What *is* present, disclosed
  rather than left for the diff to reveal: **five `shellcheck disable` pragmas across three scripts** —
  `SC2016` in `canon/scripts/verify-pattern-doc.sh:24` (the `$…` is a literal to match in the doc),
  `SC1007` in `report/scripts/file-report.sh:28` (`CDPATH= cd`, the same idiom the lib's source line
  uses), and `SC2086` ×3 in `triage/scripts/claim-issue.sh:45/48/56` (word splitting on a space-joined
  assignee list *is* the intent). Each carries its reason inline; none suppresses a real finding, and
  `shellcheck -x` is otherwise clean over all 52.
- **(7) Out-of-scope change** — three additions the issue does not literally imply:
  - **`report/scripts/file-report.sh` refuses an empty stdin** (seam 4). The hazard is **new**, created
    by the extraction: pre-move the body was a literal heredoc inside the fence and always had content;
    post-move stdin is an external pipe, and an unread pipe is byte-identical to an empty one
    (#3924 / #4010). It is live, not dead code — rc=2 with 0-byte stdout, reached *after* the shim and
    footer checks pass. **Disposition:** kept; a guard the move itself owes.
  - **`release/scripts/lib.sh`** is a new release-only helper (seam 5), created to resolve
    `packages/anka-ops` from the git root and fail closed when absent. **Disposition:** kept, and
    deliberately *not* folded into `shared/lib/common.sh` under the 2+-skills rule.
  - **Two hand-copied scratch recipes became `kp_scratch_open` / `kp_scratch_path`** (seam 2) — a
    path-derivation change, not a pure relocation. **Disposition:** kept; it is AC-3's "source the
    shared common lib for cross-step state" requirement.
- **(2) Governing-ADR departure — did not fire.** No ADR is contradicted, narrowed or widened: the
  ADR-0228 boundary holds (a script relays a verb's answer, it never derives the decision), the phase-1
  no-rewrite ruling on #4435 holds, and no invariant living only in skill prose is weakened — the prose
  keeps every *why* it carried. The one intentional strengthening (`find-linked-issue.sh`'s exit-4
  distinction) closes a pre-existing fail-open and is declared above.
- **(4) Declined guidance — did not fire.** No reviewer suggestion, appended acceptance criterion, or
  triage instruction was declined. The three remedies the gate named at `d29b9eae` are all taken in
  this round, and the one item it explicitly did not ask for (widening `leak-guard`) is filed instead of
  half-done.
- **(6) Pre-existing test or fixture changed — did not fire.** No test or fixture file appears in the
  diff; nothing is weakened or deleted. `shared/lib/common.sh` is likewise untouched — absent from the
  file list *and* byte-identical to `origin/main`.

### Process deviation — phase order

#4454 sits in the epic's Phase 3 with no `requires:`, so the phase-boundary default would gate it on
all of Phase 2, which is still open. It was dispatched explicitly and in parallel with its phase-3
sibling #4453 (PR #4485). The extractions are per-file independent, and the per-open-PR file-overlap
check is what makes the parallelism safe: this PR's 64 paths are disjoint from #4485, #4489 and #4491.
Flagged rather than left implicit.

---

Control-plane: **every file here is §CP by path** (`skills/**`, #4462), so this banks for a human
approval. No self-approval, no self-verdict.
