### PR TITLE
chore(write-code): extract 566 lines of fenced shell into 25 sourced scripts (#4449)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -62,6 +62,18 @@ invocation site whose **stdout is consumed as an answer** carries an explicit `|
 site that omits it is one whose script `exit`s on its own failure path (the same behavior the inline
 block had). Never infer a negative from silence.
 
+Two things about those scripts, stated once here rather than repeated in twenty file headers:
+
+- **The moved shell is a byte-move, so its shellcheck findings moved with it.** Each script declares
+  the codes *its own* moved lines raise in its `# shellcheck … disable=` directive (mostly `SC2086`
+  on an unquoted `$REPO` in a `gh api` path) — declared per file, never blanket-suppressed, because
+  quoting them would be a rewrite and rewriting the glue is phase 2 ([#1929](https://github.com/kamp-us/phoenix/issues/1929)).
+- **Two committed proofs re-derive the claims instead of asserting them**, both reviewer-runnable:
+  [`scripts/verify-byte-move.sh`](scripts/verify-byte-move.sh) diffs each script against the fenced
+  block it replaced at the base commit, and
+  [`scripts/verify-fail-closed.sh`](scripts/verify-fail-closed.sh) captures every seam's exit code
+  **and** stdout byte count to prove no failure path can be read as an answer.
+
 ## The formats contract
 
 You **read three and write two** of the shared formats; read the contract before you

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -2078,26 +2078,8 @@ departed from nothing adds nothing; it does **not** rewrite a prior round's entr
 unreliable in this org).
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# re-assert the mis-attribution guard (Step 3.5) before the resubmit push — a between-calls cwd
-# reset can't move the claim, but the guard is MANDATED before every number-targeting mutation,
-# exactly as wt_preflight is before every git op; gate both the push and the progress comment.
-claim_is_mine "$N" || { echo "refusing to push/comment — PR #$PR linked issue #$N not my claim (Step 3.5)"; exit 1; }
-# The SANCTIONED push path ([Pushing: the verdict is the ref, not the exit code]) — force-with-lease
-# because the R2 rebase onto origin/main moved the head. It confirms the remote ref carries the
-# rebased head before you claim the resubmit landed; exit 0 = MOVED, 1 = NOT-MOVED, 3 = UNKNOWN.
-# STOP on either non-zero: a reviewer waiting on a moved head would otherwise re-gate the STALE one.
-wt_preflight && "$PCLI" verified-push --cwd "$WT" --remote origin --force-with-lease \
-  || { echo "write-code: the repair push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — the gate would re-run against the STALE head. Do not report the resubmit as landed." >&2; exit 1; }
-# compose the repair note under the §SP per-run scratch namespace, never a fixed /tmp leaf:
-# concurrent repair lanes clobber a shared name and this posts THEIR note onto your issue (#3718).
-# Session-keyed and deterministic, so the note you wrote in an earlier Bash call is still here.
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-$N"
-mkdir -p "$RUN_SCRATCH" || { echo "write-code: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
-# …write the format-3 repair note to "$RUN_SCRATCH/repair-progress.md" first, then:
-[ -s "$RUN_SCRATCH/repair-progress.md" ] || { echo "write-code: repair-progress.md is missing/empty — refusing to post an empty comment." >&2; exit 1; }
-gh api repos/$REPO/issues/$N/comments -f body="$(cat "$RUN_SCRATCH/repair-progress.md")"
+# write the format-3 repair note to "$RUN_SCRATCH/repair-progress.md" FIRST.
+. "$WRITECODE_SCRIPTS/stepR3-push-and-note.sh" || exit 1   # push CONFIRMED on the remote, or nothing landed
 ```
 
 **Acknowledge the inline threads you addressed** so the loop is visible to the reviewer who
@@ -2105,9 +2087,7 @@ left them. For each in-scope inline comment you fixed, post a **threaded reply**
 you changed (REST, on the same review-comment thread):
 
 ```bash
-# reply on the inline comment thread you addressed ($CID = the comment id from R2)
-gh api -X POST "repos/$REPO/pulls/$PR/comments/$CID/replies" \
-  -f body="Addressed in <short-sha>: <one line on the fix>."
+. "$WRITECODE_SCRIPTS/stepR3-thread-reply.sh" "Addressed in <short-sha>: <one line on the fix>." || exit 1
 ```
 
 **Release the lane's claim before you stop**, exactly as Step 8 does for the initial build — the
@@ -2115,9 +2095,7 @@ repair round is over, and a claim left held is what makes the *next* repair disp
 read `lost` (#3780; the observed stall was a repair refused by a claim whose run had finished):
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" claim release --issue "$N" --session "$MY_CLAIM"   # retract OUR OWN marker; never another session's
+. "$WRITECODE_SCRIPTS/step8-claim-release.sh" "$N" || exit 1   # the SAME script Step 8 sources — retract OUR OWN marker; never another session's
 ```
 
 A reply is the acknowledgement this skill performs. **Resolving** the thread (collapsing it)
@@ -2152,19 +2130,7 @@ the cap fails to bind and the loop runs past N=3.) Same ACL author-gate as Step
 R1 (reuse its `$comments_file` + `$authorized`) — only a real reviewer's FAIL counts toward the cap:
 
 ```bash
-# how many distinct gate-FAIL ROUNDS has this PR already accrued (both namespaces)?
-# cluster FAIL markers by timestamp gap: a new round starts only when >120s separates two
-# FAILs, so a code+doc pass (seconds apart) is one round and two real rounds (fix-push +
-# re-review apart) are two — grid-free, so no minute-boundary split or same-minute merge.
-jq --argjson authorized "$authorized" \
-   '[.[] | select(.user.login | IN($authorized[]))
-         | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*FAIL"; "i"))
-         | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
-    | sort
-    | reduce .[] as $t ({n:0, prev:null};
-        if (.prev == null) or ($t - .prev) > 120
-        then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
-    | .n' "$comments_file"
+. "$WRITECODE_SCRIPTS/stepR-round-count.sh"   # stdout IS the round count; reads $authorized + $comments_file
 ```
 
 If this PR has **already had 3 FAIL→fix rounds** (you'd be pushing a 4th fix against a 4th
@@ -2225,13 +2191,7 @@ final repair round**, i.e. its tagged `round` ≥ `N` (= 3). Concretely, for eac
   hand the PR back, surface for re-triage:
 
 ```bash
-# does this round's resolving FAIL table carry a review-appended AC tagged at/after the final round?
-# the row is the ordinary checkbox shape; the tag is the only thing read here (no new parser)
-# $FAILBODY = the resolving FAIL marker body from R2; grep the provenance tags it carries
-echo "$FAILBODY" | grep -oE '<!-- *ac:review-[a-z]+ +pr:#[0-9]+ +round:[0-9]+ *-->' | while read -r tag; do
-  K=$(printf '%s' "$tag" | grep -oE 'round:[0-9]+' | cut -d: -f2)
-  [ "$K" -ge 3 ] && echo "FROZEN appended AC ($tag) — appended in/after final round; escalate, do not loop"
-done
+. "$WRITECODE_SCRIPTS/stepR-frozen-ac.sh"   # reads $FAILBODY (the resolving FAIL marker body from R2)
 ```
 
 If **any** `ac:review-*` row in the current FAIL table is frozen (`round >= 3`), take the

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1504,24 +1504,14 @@ re-derive them here. Two operational points that are yours, not the contract's:
   `for the reviewer to judge`).
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# RE-DERIVE the branch LIVE from the worktree — never a cached/shared-file value (see the
-# live-derivation rule in Step 4). $BRANCH from Step 4 is GONE across Bash calls; wt_preflight
-# just re-cd'd to $WT, so the checked-out branch IS the work branch. Read it, never guess it.
-wt_preflight && BRANCH="$(git -C "$WT" branch --show-current)"
-: "${BRANCH:?could not re-derive branch from worktree $WT — refusing to push to a guessed/cached ref}"
-# The SANCTIONED push path — see [Pushing: the verdict is the ref, not the exit code]. It pushes
-# AND independently confirms the remote ref, printing its verdict LAST on stdout. Exit 0 = MOVED,
-# 1 = NOT-MOVED, 3 = UNKNOWN; STOP on either non-zero — never open a PR against a branch you
-# cannot prove exists (an UNKNOWN is not a success).
-wt_preflight && "$PCLI" verified-push --cwd "$WT" --remote origin --branch "$BRANCH" --set-upstream \
-  || { echo "write-code: the push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — refusing to open a PR against an unproven branch." >&2; exit 1; }
-# The PR opens AGAINST issue #N (Fixes #N) — gate it on the mis-attribution guard (Step 3.5): open a
-# PR closing only an issue whose claim is mine, never one mis-attributed to another agent's #N.
-claim_is_mine "<N>" || { echo "refusing to open a PR against #<N> — not my claim (Step 3.5)"; exit 1; }
-# The body carries `Fixes #N` and `## Deviations` ALWAYS; ADD the `Flag: <FLAG_KEY>` line ONLY when
-# Step 4b fired (a dark ship behind a flag — newly-declared OR prior-PR). Omit it for an ungated PR.
+. "$WRITECODE_SCRIPTS/step5-push.sh" <N> || exit 1   # push CONFIRMED on the remote + #N proven mine, or nothing happened
+```
+
+Then open the PR. The body is a **template you author**, so it stays here rather than in a script:
+it carries `Fixes #N` and `## Deviations` ALWAYS, and adds the `Flag: <FLAG_KEY>` line **only** when
+Step 4b fired (a dark ship behind a flag — newly-declared OR prior-PR); omit it for an ungated PR.
+
+```bash
 gh pr create \
   --base main \
   --title "<concise PR title>" \
@@ -1552,61 +1542,7 @@ itself**: read the PR body back and assert it matches a recognized closing keywo
 `#N` — that is exactly the token GitHub auto-closes on and that `ship-it` Step 1 resolves:
 
 ```bash
-# (a) the cross-reference landed (a closing OR non-closing mention both show here — necessary, not sufficient)
-#     --paginate + a STREAMING --jq, per the contract's pagination rule: the timeline endpoint
-#     defaults to 30 events/page, so an un-paginated read calls a cross-reference past event 30
-#     absent — a false alarm on any issue with a bit of history (#4193).
-gh api --paginate "repos/$REPO/issues/<N>/timeline?per_page=100" \
-  --jq '.[] | select(.event == "cross-referenced") | .event'
-# (b) the SUFFICIENT check, REST-only: the seam is armed iff the body carries EITHER a real
-#     CLOSING keyword for #N (full-close PR — the same set ship-it Step 1 resolves:
-#     fix(es|ed)/close[sd]?/resolve[sd]?) OR a `Part of #N` partial-split marker (the §9
-#     non-closing link that keeps #N OPEN by design). Only NEITHER is a truly broken seam.
-BODY=$(gh api repos/$REPO/pulls/<PR> --jq '.body')
-if printf '%s' "$BODY" | grep -qiE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#<N>\b'; then
-  echo "closing seam armed"
-elif printf '%s' "$BODY" | grep -qiE '\bpart of\s+#<N>\b'; then
-  echo "partial-split seam armed — Part of #<N>, no closing keyword by design (§9; #<N> stays open)"
-else
-  echo "BROKEN SEAM — body links #<N> with neither a closing keyword nor a 'Part of #<N>' marker"
-fi
-# (c) the INVERSE GUARD, REST-only: NO closing keyword targets any issue OTHER than #N.
-#     The set {issue numbers preceded by a closing keyword in the body} must be exactly {N};
-#     a stray member is a sibling-ref directive that auto-closes an issue this PR never fixed (#1259).
-STRAY=$(gh api repos/$REPO/pulls/<PR> --jq '.body' \
-  | grep -ioE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#[0-9]+' \
-  | grep -oE '[0-9]+' | sort -u | grep -vx '<N>')
-[ -z "$STRAY" ] \
-  && echo "no stray close directives — closing-keyword set is exactly {#<N>}" \
-  || echo "STRAY CLOSE DIRECTIVE(S) on $(printf '#%s ' $STRAY)— rewrite these sibling refs to a non-closing form (addresses/relates to/see #M) before opening/patching the PR"
-# (d) DARK-SHIP GUARD, REST-only: IF Step 4b fired, the body MUST carry a `Flag:` line that
-#     matches ship-it Step 5b's FLAG_IN_BODY grep verbatim — else the prior-PR dark ship is dropped
-#     from the release queue (#1282). Whether Step 4b fired is RE-DERIVED HERE from durable state —
-#     the child's `Containment:` marker and the cycle-doc probe, Step 4b's own two inputs, read in
-#     THIS Bash call. It used to key on `[ -n "$FLAG_KEY" ]`, a shell variable Step 4b assigns in a
-#     DIFFERENT Bash call: shell state does not survive between calls, so it was empty here and the
-#     check silently skipped itself in exactly the case it exists for (#4398).
-CONTAINMENT=$(gh api repos/$REPO/issues/<N> --jq '.body' \
-  | grep -ioE '\**\s*Containment:\**\s*(flag|exempt|none)' | head -n1 \
-  | grep -ioE '(flag|exempt|none)' || echo none)
-gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1 \
-  && CYCLE_DOC=present || CYCLE_DOC=absent
-if [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]; then
-  gh api repos/$REPO/pulls/<PR> --jq '.body' \
-    | grep -Eiq '^[[:space:]]*\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+' \
-    && echo "dark-ship Flag: line present and matches ship-it Step 5b — release queue will fire" \
-    || echo "MISSING/MALFORMED Flag: line — Step 4b fired but the body has no matching plain 'Flag: <key>' line; patch it in before stopping (#1282)"
-else
-  echo "no dark ship (containment=$CONTAINMENT, cycle-doc=$CYCLE_DOC) — no Flag: line expected"
-fi
-# (e) DISCLOSURE PRESENCE, REST-only: the body carries a `## Deviations` heading. This is the
-#     PRESENCE floor only — it cannot tell an honest `None.` from a false one, and it sees none of
-#     the seven classes (§DEV's detection tiers). It exists so the one failure mode that is purely
-#     mechanical — forgetting the heading — never reaches a gate as a malformed body.
-gh api repos/$REPO/pulls/<PR> --jq '.body' \
-  | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$' \
-  && echo "## Deviations section present" \
-  || echo "MISSING ## Deviations section — an ABSENT section is a gate FAIL (§DEV: absent is not None.); patch the body before stopping"
+. "$WRITECODE_SCRIPTS/step5-seam-checks.sh" <N> <PR> || exit 1   # stdout IS the five verdicts — silence is UNKNOWN, never "armed"
 ```
 
 If (b) reports a broken seam, the body links `#N` with **neither** a closing keyword **nor**

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1936,14 +1936,9 @@ enumerated findings as the AC work list** — fix exactly what they name (the in
 below are additive to this list, not a substitute for it):
 
 ```bash
-# the full body of the resolving FAIL marker — its comment id came from R1's `verdict read` JSON
-# (swap CODE_FAIL_JSON→DOC_FAIL_JSON/SKILL_FAIL_JSON per namespace). `verdict read` already
-# author-gated and latest-wins-resolved that exact comment, so this is a plain body fetch of it —
-# no re-derivation of the resolver. (When the code namespace was resolved via a native
-# CHANGES_REQUESTED review rather than a marker, read the review body from
-# `repos/$REPO/pulls/$PR/reviews` instead — a native review carries no issue-comment id.)
-CID=$(jq -r '.commentId // empty' <<<"$CODE_FAIL_JSON")
-[ -n "$CID" ] && gh api "repos/$REPO/issues/comments/$CID" --jq '.body'
+# name the namespace's R1 JSON variable — CODE_FAIL_JSON (the default), DOC_FAIL_JSON, or
+# SKILL_FAIL_JSON. Leaves $CID in this shell for R3's thread reply.
+. "$WRITECODE_SCRIPTS/stepR2-fail-body.sh" CODE_FAIL_JSON
 ```
 
 #### A review-appended AC is an ordinary `[FAIL]` row — no special parser (ADR 0079)
@@ -2004,18 +1999,7 @@ is actionable only when its `line` is non-null. This is the inline-comment analo
 `@ <sha>` staleness test — repair never chases feedback bound to code that has since changed.
 
 ```bash
-ME=$(gh api user --jq '.login')   # don't action your own author-side replies
-# fetch into a var, then pipe to standalone jq — gh's --jq takes no --argjson, and this reuses
-# the same $authorized set R1/R2 already built (same pattern as the marker work-list above)
-inlineComments=$(gh api "repos/$REPO/pulls/$PR/comments?per_page=100")
-# in-scope, still-anchored inline review comments → your additive fix list (id+path+line+body)
-jq --argjson authorized "$authorized" --arg me "$ME" \
-  '[ .[]
-     | select(.line != null)                                  # non-null line ⇒ still anchored to current head (ADR 0058)
-     | select(.user.login != $me)                             # skip self-authored thread replies
-     | select((.user.login | IN($authorized[]))               # write+ collaborator (ADR 0055), or…
-              or .user.login == "copilot-pull-request-reviewer[bot]")  # …the explicitly-included review bot (#383)
-   ] | .[] | {id, path, line, body}' <<<"$inlineComments"
+. "$WRITECODE_SCRIPTS/stepR2-inline-comments.sh"   # reads the $authorized set R1 built; leaves $ME + $inlineComments
 ```
 
 For context on *what the PR was supposed to do*, resolve the **linked issue** via the PR
@@ -2023,24 +2007,15 @@ body's `Fixes #N` and re-read its `### Acceptance criteria` (the same checklist 
 verified) and the progress trail:
 
 ```bash
-N=$(gh api repos/$REPO/pulls/$PR \
-  --jq '.body | capture("(?i)\\b(fix(es|ed)?|close[sd]?|resolve[sd]?)\\s+#(?<n>[0-9]+)") | .n')
-gh api repos/$REPO/issues/$N --jq '.body'
-gh api "repos/$REPO/issues/$N/comments?per_page=100" --jq '.[].body'
+. "$WRITECODE_SCRIPTS/stepR2-linked-issue.sh"   # leaves $N (the PR's linked issue) in this shell
 ```
 
 Check out the **existing PR branch** and fix on it — **no new branch** (a new branch would
 orphan the PR and the gate's history):
 
 ```bash
-git fetch origin
-# mis-attribution guard (Step 3.5): confirm the PR's linked issue #N is MINE before touching its
-# branch — so a mis-dispatched repair never pushes to another agent's live PR (the #1404 class).
-# In orchestrated repair the original claim token is threaded as MY_CLAIM (ADR 0115 §3 delegated own).
-claim_is_mine "$N" || { echo "refusing to repair PR #$PR — its linked issue #$N is not my claim (Step 3.5)"; exit 1; }
-wt_preflight && git switch <the PR's head branch>   # gate the branch switch ([per-mutation preflight]); gh api .../pulls/$PR --jq '.head.ref'
-wt_preflight && git rebase origin/main   # freshen the dispatch-time base FIRST — surface a textual conflict now, in-context (see below)
-# apply the fixes addressing exactly the enumerated findings
+. "$WRITECODE_SCRIPTS/stepR2-branch-rebase.sh" <the PR's head branch> || exit 1   # gh api .../pulls/$PR --jq '.head.ref'
+# then apply the fixes addressing exactly the enumerated findings
 ```
 
 Repair mode runs in a worktree too, so re-run the Step-4 opening preflight (and capture `WT`)

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -638,83 +638,7 @@ whereas in the **primary checkout they are the same path**. Equal ⇒ you're in 
 checkout (or a bare/no-repo edge) ⇒ **stop**; differ ⇒ you're in a linked worktree ⇒ proceed.
 
 ```bash
-# fail closed unless we're in a LINKED git worktree (not the primary checkout)
-GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || {
-  echo "write-code preflight FAILED: not inside a git repository — refusing to mutate." >&2; exit 1; }
-COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
-case "$COMMON" in /*) ;; *) COMMON="$(pwd)/$COMMON" ;; esac   # normalize relative `.git` (older git)
-COMMON="$(cd "$COMMON" && pwd)"
-
-# Was worktree isolation EXPECTED for this run? The coder agent-type (agents/coder.md) asserts
-# isolation UNCONDITIONALLY, so any run under it expects the harness to have provisioned a linked
-# worktree + set $WORKTREE_ROOT. Three machine-checkable, harness-set signals arm it — NOT a per-run
-# guess — mirroring the repo-side guard's `isIsolationExpected` (bash-pin.ts) exactly (#3406):
-#   1. a direct isolation-asserting agent-type name ($CLAUDE_CODE_AGENT matching coder/reviewer/shipper);
-#   2. a set $WORKTREE_ROOT (the harness signalled a provisioned root);
-#   3. the ENV-INDEPENDENT corroboration — any agent-context run ($CLAUDE_CODE_AGENT non-empty) sitting
-#      on the PRIMARY checkout (git-dir == common-dir). A NESTED/renamed coder spawn inherits the
-#      PARENT's agent-type string (e.g. `crew-engineering-manager` / `junior-engineer`, ADR 0189), so the
-#      NAME match alone goes inert for it — but such a spawn on the primary checkout is a broken/absent
-#      worktree whatever its inherited name, and clause 3 catches it regardless of the string. Keying on
-#      the agent-type LITERAL alone was the #3406 defect: a renamed coder computed isolation-expected=0
-#      and silently self-provisioned. Do NOT hard-code any agent-type name (junior-engineer or otherwise)
-#      to "fix" it — that just relocates the coupling to the next rename; the corroboration removes it.
-# A genuine standalone human run (a direct `/write-code`, $CLAUDE_CODE_AGENT unset) matches NONE of the
-# three, so it never over-refuses and still reaches the Non-isolated fallback. This is what lets the
-# fail-closed branch below distinguish "isolation expected but the harness no-op'd provisioning" (#2440)
-# from a legitimate standalone run, firing LOUD in the first case without regressing the second. See
-# ADR 0172, #2462 (the guard's parallel re-keying), and #3406.
-ISOLATION_EXPECTED=0
-case "$CLAUDE_CODE_AGENT" in *coder*|*reviewer*|*shipper*) ISOLATION_EXPECTED=1 ;; esac   # direct isolation-asserting agent-type name
-[ -n "$WORKTREE_ROOT" ] && ISOLATION_EXPECTED=1                            # harness signalled a provisioned root
-# env-independent corroboration: a non-empty agent-type on the PRIMARY checkout (git-dir == common-dir) —
-# catches a nested/renamed coder whose inherited agent-type string doesn't name a role (#3406).
-[ -n "$CLAUDE_CODE_AGENT" ] && [ "$GITDIR" = "$COMMON" ] && ISOLATION_EXPECTED=1
-echo "write-code preflight: git-dir=$GITDIR common-dir=$COMMON cwd=$(pwd) isolation-expected=$ISOLATION_EXPECTED (agent=${CLAUDE_CODE_AGENT:-unset} worktree-root=${WORKTREE_ROOT:+set})"   # emit scanned scope (ADR 0092 §1)
-if [ "$GITDIR" = "$COMMON" ]; then
-  if [ "$ISOLATION_EXPECTED" = 1 ]; then
-    # FAIL-CLOSED LOUD (the #2443 branch): isolation was EXPECTED but this run is on the PRIMARY
-    # checkout with no linked worktree — the harness's `git worktree add` + $WORKTREE_ROOT injection
-    # silently didn't run for this coder spawn (#2440's harness no-op). Because the whole repo-side
-    # worktree-guard keys on $WORKTREE_ROOT, that no-op ALSO disarmed it, leaving this preflight the
-    # sole surviving layer. Do NOT self-provision here: doing so papers over the harness failure and
-    # leaves the two-layer primary-corruption defense collapsed to one, invisibly (#2270 class).
-    echo "write-code preflight FAILED (fail-closed, LOUD): worktree isolation was EXPECTED (agent=${CLAUDE_CODE_AGENT:-?}, worktree-root=${WORKTREE_ROOT:+set}) but this run is on the PRIMARY checkout (git-dir == common-dir) and \$WORKTREE_ROOT is unset." >&2
-    echo "  ROOT CAUSE: the harness's worktree provisioning (git worktree add + \$WORKTREE_ROOT injection) did NOT run for this coder spawn — the #2440 harness no-op. The repo-side worktree-guard also keys on \$WORKTREE_ROOT, so it is disarmed too; only this preflight is left." >&2
-    echo "  REFUSING to self-provision — that would hide the harness failure and leave the two-layer defense collapsed to one, invisibly (the primary-checkout-corruption class, #2270)." >&2
-    echo "  ROUTED BLOCKER — surface UP to the operator/EM: 'harness worktree provisioning no-op'd for a coder spawn (isolation expected, \$WORKTREE_ROOT unset); the out-of-repo harness half (#2440) needs attention. Do NOT blindly retry the same spawn.'" >&2
-    exit 1
-  fi
-  # isolation was NOT expected ⇒ a genuine standalone run: fall through to the Non-isolated fallback,
-  # which self-provisions a worktree (this path is unchanged, and the loud branch above never fires for it).
-  echo "write-code preflight FAILED (fail-closed): git-dir == common-dir ⇒ this is the PRIMARY checkout, not an isolated worktree." >&2
-  echo "  Refusing to branch/commit here — a spawn without isolation:worktree (or a cwd reset to the primary tree) would mis-branch the owner's checkout." >&2
-  echo "  This run did NOT expect isolation (standalone) — take the Non-isolated fallback below to create a worktree before mutating." >&2
-  exit 1
-else
-  # POSITIVE worktree assertion — loud + EARLY (#3458). git-dir != common-dir is the ONE trust
-  # signal for "I am in my own linked worktree" that survives the misleading env a worktree spawn
-  # is handed: $WORKTREE_ROOT is unset (the reverted #2938 provisioning hook) and $CLAUDE_CODE_AGENT
-  # reports the PARENT's value (inherited agent-type, #2462) — so neither can anchor worktree
-  # identity. This git-plumbing check can, and does so independently of both. Capture $WT from THIS
-  # evidence, never from the untrustworthy env and never from a file. This assertion fires BEFORE the
-  # first Edit/Write on purpose: a raw Edit/Write to a primary-checkout absolute path is not a git op,
-  # so neither the repo-side worktree-guard nor wt_preflight fires on it — the ONLY thing standing
-  # between a cwd-reset + stale-Read-cache and a stray write into shared primary `main` is anchoring
-  # every edit under this $WT (see "Anchor every Edit/Write to $WT" below). Establishing $WT loudly
-  # here is what makes that anchoring actionable from the first file touch.
-  WT="$(git rev-parse --show-toplevel)"
-  # STAMP THE LANE — this is the one moment $WT is trustworthy, so pin an identity to it (#4398).
-  # Every LATER Bash call re-derives the toplevel from a cwd the harness may have reset, so a
-  # cwd-derived "$WT" answers "where am I" and not "which tree is mine" — and a check that compares
-  # that answer against itself is tautological. $CLAUDE_CODE_SESSION_ID is the per-lane fact that
-  # DOES survive between calls (the same anchor §SP keys $RUN_SCRATCH on); write it into this
-  # worktree's PRIVATE per-worktree git dir, which is outside the working tree (never committed,
-  # never in `git status`) and unique per worktree. That stamp is the independently-derived operand
-  # wt_preflight compares the ambient cwd's answer against.
-  printf '%s\n' "${CLAUDE_CODE_SESSION_ID:?write-code preflight FAILED: no session id — no durable lane identity to stamp, so no later git mutation could be verified as mine}" > "$GITDIR/kampus-lane"
-  echo "write-code preflight CONFIRMED (LOUD): in a LINKED worktree at $WT (git-dir != common-dir), stamped for lane $CLAUDE_CODE_SESSION_ID — worktree identity established from git plumbing, INDEPENDENT of \$WORKTREE_ROOT (${WORKTREE_ROOT:+set}${WORKTREE_ROOT:-unset}) and \$CLAUDE_CODE_AGENT (${CLAUDE_CODE_AGENT:-unset}), both of which may misreport. Anchor EVERY Edit/Write and git op to this \$WT (absolute) — never a primary-checkout path."
-fi
+. "$WRITECODE_SCRIPTS/step4-preflight.sh"   # leaves $GITDIR / $COMMON / $WT in this shell; `exit 1` on every unsafe state
 ```
 
 The preflight is **fail-closed by construction**: it refuses on the primary checkout, on a
@@ -921,22 +845,7 @@ isolated worktree (`fatal: 'main' is already checked out at <primary>`). Branch 
 latest origin `main` **without checking it out**:
 
 ```bash
-# Fetch the base fresh, and FAIL-LOUD if it doesn't run: FETCH_HEAD is what the branch below is
-# cut from, so a silently-failed fetch (network blip, a harness worktree whose exec env stripped
-# PATH) leaves FETCH_HEAD at a STALE prior tip, and the branch misses a base file merged just
-# before branch-cut → the SHA-bound run-evidence check false-fails on a file the head never
-# carried (#1920; the same stale-base class #1837 fixed at the repair step). Never proceed on an
-# unverified fetch — assert it succeeded before branching off FETCH_HEAD.
-git fetch origin main || { echo "write-code: 'git fetch origin main' failed — refusing to branch off a stale FETCH_HEAD (would cut a head missing a just-merged base file; #1920)." >&2; exit 1; }
-# Derive the prefix from THIS checkout's git identity — never a hardcoded literal. A copied
-# literal namespaces every agent's branch under one person's handle regardless of who runs.
-PREFIX="$(git config user.name | tr '[:upper:] ' '[:lower:]-')"   # e.g. "Umut Sirin" → "umut-sirin"
-: "${PREFIX:?set git user.name to derive a branch prefix}"        # empty identity ⇒ "/slug…" (leading slash) git rejects with an opaque error; fail here with a fixable one
-# Per-run suffix: the deterministic $PREFIX/<slug-for-issue-N> is the SAME ref for every
-# run on this issue, so two concurrent runs would both push origin/<that branch> and the
-# second push would clobber the first's commits. A per-invocation nonce keeps them distinct.
-BRANCH="$PREFIX/<slug-for-issue-N>-$(uuidgen | head -c 8)"
-wt_preflight && git switch -c "$BRANCH" FETCH_HEAD   # branch create is a git mutation → gate it (per-mutation preflight above)
+. "$WRITECODE_SCRIPTS/step4-branch.sh" <slug-for-issue-N> || exit 1   # leaves $BRANCH in this shell; no branch on non-zero
 ```
 
 It's `git switch -c "$BRANCH" FETCH_HEAD` (not `git checkout main`) on purpose: in an

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -454,23 +454,7 @@ delegation by resolving §7's tiebreak once — the **earliest authorized claim*
 session id must equal the threaded token — then proceed straight to implementing:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# Orchestrated path: confirm the delegated claim is the earliest authorized claim, then proceed.
-# The §7 CLAIM_RE + write+ ACL + min(created_at, comment id) resolution is owned by the shared verb
-# — run it, never re-derive the grammar. Exit 0 = the threaded token owns #N; non-zero = it does
-# not (absent, foreign, or superseded) ⇒ abort, do not implement.
-"$PCLI" claim is-mine --issue <N> --session "$DELEGATED_TOKEN" \
-  || { echo "delegated token is not the earliest authorized claim — abort, do not implement." >&2; exit 1; }
-# Ensure §7 LAYER ONE for the whole build (#4298). The dispatcher owes this pre-spawn, but the
-# obligation lived in ONE orchestrator's prompt, so a lane dispatched by anything else reached here
-# with no assignee — and Step 8's release then freed the resolver on top of a gate that was never
-# written, leaving the issue `status:triaged` + unassigned with its PR in review. Idempotent and
-# additive: a gate already carrying us is a no-op, and the verb REFUSES on any lane whose claim is
-# not ours, so this asserts nothing about the dispatcher and evicts nothing (ADR 0215 §5).
-"$PCLI" claim assign --issue <N> --session "$DELEGATED_TOKEN" \
-  || { echo "could not set the availability gate on #<N> — routed blocker, do not implement." >&2; exit 1; }
-# delegation confirmed + layer one held — skip the direct-path claim below and go implement
+. "$WRITECODE_SCRIPTS/step3-delegated-claim.sh" <N> || exit 1   # non-zero ⇒ delegation NOT confirmed; do not implement
 ```
 
 ### Direct path — claim it yourself (no orchestrator)
@@ -484,35 +468,7 @@ Run it; never hand-roll a `claim:` body, which silently skips the ADR-0191 prese
 leaves this lane's claim permanently unprobeable (#3987):
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# 0. Fail-closed on a missing token: the claim comment is the ONLY agent-distinguishable signal
-#    under the shared `usirin` login — with no token a co-racer is unresolvable, so NEVER claim
-#    (and never fall back to the login-keyed assignee as ownership — that is the §7 degeneracy).
-#    The verb enforces this too (it backs off on an empty session), so this is a fast local exit.
-if [ -z "$CLAUDE_CODE_SESSION_ID" ]; then
-  echo "no CLAUDE_CODE_SESSION_ID in env — cannot post an agent-distinguishable claim. BACK OFF, re-pick." >&2
-  exit 0   # → re-run Step 1
-fi
-
-# 1. Claim through the verb FIRST — layer two, the fine agent-distinguishable resolver. It defers
-#    to a pre-existing authorized owner WITHOUT posting, posts a PRESENCE-STAMPED marker under
-#    $CLAUDE_CODE_SESSION_ID, re-reads canonical state, and retracts its OWN claim if it lost.
-#    Exit 0 = the claim is mine; non-zero = backed off, having mutated nothing that is not ours.
-if ! "$PCLI" tracker claim <N>; then
-  echo "did not win the claim on #$N (held by another agent, or lost the tiebreak) — back off, re-pick."
-  exit 0   # → re-run Step 1
-fi
-
-# 2. ONLY NOW write layer one — the coarse availability gate the Step-1 picker reads (§7). One verb
-#    owns this write on every path (#4298); never hand-roll the assignees POST. Defer-then-assign is
-#    load-bearing, not stylistic: every agent authenticates as the SAME login, so the assignee is ONE
-#    shared slot. Assigning first would make the back-off above a cleanup unassign that strips the
-#    LIVE incumbent's assignment — clearing the coarse gate on an issue someone else legitimately
-#    holds. Claiming first removes the cleanup entirely: the verb only ever writes on a claim it
-#    proved is ours, and it has no removal path at all, so there is nothing to undo (#4015).
-"$PCLI" claim assign --issue <N> || { echo "could not set the availability gate on #<N> — routed blocker." >&2; exit 1; }
-# claim won and confirmed (earliest authorized claim is mine) — proceed to implement
+. "$WRITECODE_SCRIPTS/step3-direct-claim.sh" <N> || exit 1   # non-zero ⇒ NO claim was made; back off and re-pick
 ```
 
 **The operating rule.** Posting the claim comment **detects** a race; the **checkpoint GET**
@@ -573,12 +529,7 @@ The token this run owns its work *under* is `MY_CLAIM`, resolved once at the top
   guard treats a target whose earliest authorized claim equals the threaded token as *mine*.
 
 ```bash
-# the claim token this run owns work under: the orchestrator's threaded delegated token if it
-# pre-claimed, else my own session id (the direct-path Step-3 self-claim). Fail-closed: with
-# NEITHER set there is no agent-distinguishable identity to verify ownership under — abort, never
-# fall back to the bare assignee login (that login degeneracy is the exact defect ADR 0115 removes).
-MY_CLAIM="${THREADED_CLAIM_TOKEN:-$CLAUDE_CODE_SESSION_ID}"
-: "${MY_CLAIM:?mis-attribution guard: no claim token — CLAUDE_CODE_SESSION_ID absent and none threaded; refusing to claim or mutate (ADR 0115 Consequences — never a login fallback)}"
+. "$WRITECODE_SCRIPTS/step3_5-my-claim.sh"   # leaves $MY_CLAIM in this shell; refuses (fail-closed) when neither token is set
 ```
 
 ### `claim_is_mine <N>` — MANDATED before every issue/PR-number mutation
@@ -588,20 +539,12 @@ Define the guard once and gate **every** number-targeting mutation on it, exactl
 is the **only** sanctioned path to a mutation that names `<N>`, no bypass:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# claim_is_mine <N>: resolve the EARLIEST AUTHORIZED claim marker on #N (issue or PR) and assert
-# its embedded session id == MY_CLAIM. Returns 0 only on a proven-own claim; non-zero (REFUSE) on
-# an absent OR a foreign claim. The ADR-0115 §2 resolution — CLAIM_RE + the write+ ACL trust root
-# (ADR 0055) + the earliest-(created_at, comment id) tiebreak — is owned once by the shared verb
-# `pipeline-cli claim is-mine`; CITE it, never hand-roll the jq (#3687, the same envelope
-# extraction the shipped review-verdict and tracker verbs underwent). The verb is default-deny: an absent claim, an
-# unauthorized-only claim, a foreign owner, and a missing session all resolve NOT-mine (exit
-# non-zero) — exactly this guard's fail-closed refusal, so the exit-status contract is preserved.
-claim_is_mine() {
-  "$PCLI" claim is-mine --issue "$1" --session "$MY_CLAIM"   # exit 0 = mine; non-zero = REFUSE (default-deny)
-}
+. "$WRITECODE_SCRIPTS/step3_5-claim-is-mine.sh"   # leaves the `claim_is_mine` function in this shell
+```
 
+The calling convention, which every number-targeting mutation below follows:
+
+```bash
 claim_is_mine "<N>" && gh api repos/$REPO/issues/<N>/comments -f body="…"   # the guard gates the mutation; never run it ungated
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -45,7 +45,22 @@ to `kamp-us/phoenix` with no config.
 
 ```bash
 REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+# This skill's steps are SOURCED scripts under `scripts/` (epic #4435 phase 1, #4449) — resolved the
+# same way §CLI resolves the `pipeline-cli` shim, because neither is on PATH. Source each step's
+# script where the step says to; sourcing (not executing) is what keeps a step's variables and
+# functions visible to the steps after it, exactly as the inline fenced blocks did.
+WRITECODE_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/write-code/scripts"
 ```
+
+**A script's non-zero return is UNKNOWN — never an answer (§ZS, ADR
+[0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)).**
+Every script below prints its result on **stdout** and signals "I could not produce one" by a
+**non-zero return with no stdout**. Those two states are not the same, and the empty one is never
+the permissive branch: an absent or empty result means the step did **not** run, so it can never be
+read as "no parent", "no dependencies", "not a dark ship", or "no claim conflict". So every
+invocation site whose **stdout is consumed as an answer** carries an explicit `|| exit 1`, and a
+site that omits it is one whose script `exit`s on its own failure path (the same behavior the inline
+block had). Never infer a negative from silence.
 
 ## The formats contract
 
@@ -250,11 +265,7 @@ List the candidate pool, priority bucket by priority bucket, stopping at the fir
 bucket that has any unassigned candidate:
 
 ```bash
-# p0 first; only fall through to p1, then p2 if a bucket is empty of unassigned issues
-for P in p0 p1 p2; do
-  gh api "repos/$REPO/issues?state=open&labels=status:triaged,$P&sort=created&direction=asc&per_page=100" \
-    --jq '.[] | select(.assignee == null and (.pull_request | not)) | "#\(.number)\t\(.created_at)\t\(.title)"'
-done
+. "$WRITECODE_SCRIPTS/step1-candidate-pool.sh"
 ```
 
 `(.pull_request | not)` filters out PRs (the issues endpoint returns both). Take the
@@ -338,23 +349,7 @@ sub-endpoint ADR
 §3 already names the authoritative linkage — and read **three** outcomes off it, never two:
 
 ```bash
-# `-i` keeps the status line on stdout even when gh exits non-zero, which is the whole point:
-# it is what distinguishes a genuine 404 ("No parent issue found" ⇒ standalone) from an
-# UNREADABLE response (5xx, rate-limit, auth, network ⇒ UNKNOWN). Collapsing those two into
-# "no parent" is a silent no-op that skips Step 2 on a real epic child (#4171, #3715, #4108).
-PARENT_RESP="$(gh api "repos/$REPO/issues/<N>/parent" -i 2>/dev/null)"
-PARENT_STATUS="$(printf '%s\n' "$PARENT_RESP" | head -n1 | awk '{print $2}')"
-case "$PARENT_STATUS" in
-  200)
-    EPIC="$(printf '%s\n' "$PARENT_RESP" | awk 'body{print} /^\r?$/{body=1}' | jq -r '.number // empty')"
-    : "${EPIC:?parent read returned 200 with no .number — UNKNOWN, not standalone; refusing to claim <N>}"
-    echo "#<N> is a sub-issue of epic #$EPIC → Step 2 (derive eligibility BEFORE claiming)" ;;
-  404)
-    echo "#<N> is standalone (404 'No parent issue found') → Step 3 (claim it)" ;;
-  *)
-    echo "write-code FAILED (fail-closed): parent read on #<N> returned HTTP '${PARENT_STATUS:-none}' — UNKNOWN, which is NOT evidence of 'no parent'. Refusing to claim: retry, or re-pick per Step 1." >&2
-    exit 1 ;;
-esac
+. "$WRITECODE_SCRIPTS/step1-parent-resolve.sh" <N> || exit 1   # stdout IS the classification — an empty one is UNKNOWN, never "standalone"
 ```
 
 - **Parent resolved (200)** → go to **Step 2** and derive eligibility before claiming.
@@ -380,15 +375,8 @@ when its dependencies are all closed. There is **no `status:blocked` label**;
 eligibility is computed fresh on every pick from the epic's `## Dependencies` section.
 
 ```bash
-EPIC=<the parent number Step 1's sub-endpoint read resolved — never a guessed or remembered one>
-# the epic body carries the plan + the ## Dependencies topology
-gh api repos/$REPO/issues/$EPIC --jq '.body'
-# the real child set + each child's state (the list endpoint is source of truth;
-# sub_issues_summary undercounts under mixed closed/open children)
-gh api "repos/$REPO/issues/$EPIC/sub_issues?per_page=100" \
-  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
-# the cross-task signal siblings left — read before assuming what's done
-gh api "repos/$REPO/issues/$EPIC/comments?per_page=100" --jq '.[].body'
+# pass the parent number Step 1's sub-endpoint read RESOLVED — never a guessed or remembered one
+. "$WRITECODE_SCRIPTS/step2-epic-read.sh" <EPIC> || exit 1   # no topology read ⇒ UNKNOWN, never "no dependencies"
 ```
 
 **The derivation rule** (from the formats `## Dependencies` grammar):

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1053,10 +1053,7 @@ a `**Containment:**` line, with a leading bold-marker, anywhere in the body; a *
 as `none`**:
 
 ```bash
-# the child's containment marker; a missing line reads as `none` (formats §2 tolerant-read rule)
-CONTAINMENT=$(gh api repos/$REPO/issues/<N> --jq '.body' \
-  | grep -ioE '\**\s*Containment:\**\s*(flag|exempt|none)' | head -n1 \
-  | grep -ioE '(flag|exempt|none)' || echo none)
+. "$WRITECODE_SCRIPTS/step4b-containment.sh" <N> || exit 1   # leaves $CONTAINMENT in this shell
 ```
 
 **Graceful absence — the dark-ship behavior applies only when there's a cycle.** It fires **only**
@@ -1069,9 +1066,10 @@ step is a **no-op**: you implement and ship the change exactly as Steps 4/5 alre
 graceful-absence contract `plan-epic` (stamp) and `review-code` (verify) honor:
 
 ```bash
-# the canonical cycle-doc probe (formats §1); absent ⇒ no cycle ⇒ ship normally, no flag
-gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1 \
-  && CYCLE_DOC=present || CYCLE_DOC=absent
+# the canonical cycle-doc probe (formats §1) — the SHARED script, not a skill-local copy; it leaves
+# $CYCLE_DOC in this shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
+KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
+. "$KP_SHARED/cycle-doc-probe.sh"
 # ship dark ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]
 ```
 
@@ -1263,11 +1261,7 @@ never blessed. The pointer is the committed source of truth (`packages/design-ca
 its `surfaces` map keyed by the same `<route>[:state]` capture surface-id):
 
 ```bash
-# blessed surface-ids: the keys of the committed pointer's `surfaces` map (ADR 0183).
-# Intersect with the surfaces THIS diff renders (Step 4d capture) — only that ∩ is reference-anchored.
-# Empty ∩ ⇒ no blessed surface changed ⇒ this whole sub-loop is a no-op; the plain pillars loop stands.
-POINTER=packages/design-capture/golden-pointer.json
-BLESSED_SURFACES="$(jq -r '.surfaces | keys[]' "$POINTER" 2>/dev/null || true)"
+. "$WRITECODE_SCRIPTS/step4d-blessed-surfaces.sh"   # leaves $POINTER and $BLESSED_SURFACES in this shell
 ```
 
 **The reference-anchored loop — consume the seam, never re-implement the diff.** For each blessed
@@ -1388,10 +1382,7 @@ one by one against what this diff actually delivers** — the same checklist `re
 grade against:
 
 ```bash
-# enumerate #N's acceptance criteria — the checklist you must satisfy in FULL to emit a closing keyword
-gh api repos/$REPO/issues/<N> --jq '.body' \
-  | awk '/^###[[:space:]]*Acceptance criteria/{f=1;next} /^###/{f=0} f' \
-  | grep -E '^\s*- \[' || echo "(no checkbox ACs — read the ### Acceptance criteria prose)"
+. "$WRITECODE_SCRIPTS/step5-acceptance-criteria.sh" <N> || exit 1   # stdout IS the checklist — an empty one is UNKNOWN, never "no ACs"
 ```
 
 - **All ACs met by this diff → `Fixes #N`** (the default full close, below).

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1594,18 +1594,9 @@ error**, posting another issue's ledger onto yours (#3718, the same silent-clobb
 #2038's `branch.txt`):
 
 ```bash
-# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
-# Keyed on the session id, so if you compose progress.md in one Bash call and post it in the
-# next, this same line re-derives the SAME directory (a bare `mktemp -d` would hand the second
-# call a new EMPTY dir and post an empty body).
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-<N>"
-mkdir -p "$RUN_SCRATCH" || {
-  echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a comment through a shared path (#3718)." >&2; exit 1; }
-# …write the four-section comment to "$RUN_SCRATCH/progress.md", then:
-[ -s "$RUN_SCRATCH/progress.md" ] || { echo "write-code: progress.md is missing/empty — refusing to post an empty comment." >&2; exit 1; }
-BODY="$(cat "$RUN_SCRATCH/progress.md")"   # the four-section comment
-# gate the comment on the mis-attribution guard (Step 3.5) — only comment on an issue whose claim is mine
-claim_is_mine "<N>" && gh api repos/$REPO/issues/<N>/comments -f body="$BODY"
+# compose the four-section comment at "$RUN_SCRATCH/progress.md" FIRST; the script re-derives the same
+# session-keyed §SP path and refuses to post an empty body.
+. "$WRITECODE_SCRIPTS/step6-progress-comment.sh" <N> || exit 1
 ```
 
 Assemble the comment from a temp file so multi-line markdown and backticks survive the
@@ -1663,19 +1654,8 @@ so the spawner re-dispatches with the clause, rather than dropping the cross-tas
 silently. A blocked handoff is a fail-loud condition, never a silent no-op.
 
 ```bash
-# compose under the per-run scratch namespace (§SP), never a fixed /tmp leaf — a concurrent
-# coder lane would clobber it and this posts ITS handoff onto your epic, silently (#3718).
-# Deterministic (session-keyed), so writing handoff.md in one Bash call and posting it here in
-# the next resolves the SAME directory — re-running `mktemp -d` would yield an empty one.
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-<N>"
-mkdir -p "$RUN_SCRATCH" || {
-  echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a handoff through a shared path (#3718)." >&2; exit 1; }
-# …write the handoff to "$RUN_SCRATCH/handoff.md" first, then:
-[ -s "$RUN_SCRATCH/handoff.md" ] || { echo "write-code: handoff.md is missing/empty — refusing to post an empty handoff." >&2; exit 1; }
-BODY="$(cat "$RUN_SCRATCH/handoff.md")"   # ### Handoff: #N — <title> + the three fields
-# the handoff to the parent epic is predicated on OWNING THE CHILD — gate on claim_is_mine <child>
-# (Step 3.5), not the epic (which you never claim): only hand off about work whose claim is mine.
-claim_is_mine "<N>" && gh api repos/$REPO/issues/<EPIC>/comments -f body="$BODY"
+# write the handoff to "$RUN_SCRATCH/handoff.md" FIRST; the script gates the post on owning the CHILD.
+. "$WRITECODE_SCRIPTS/step7-epic-handoff.sh" <N> <EPIC> || exit 1
 ```
 
 Distill, don't dump — the fine detail lives in the child's progress comments and PR.
@@ -1700,12 +1680,7 @@ thing and then stop.
 The claim you took in Step 3 protected *this* build. The build is over, so give it up:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# the last mutation of the run — retract OUR OWN claim marker on the issue we just built.
-# --session carries the token we owned the work under (the orchestrator's delegated token on the
-# orchestrated path), because that is the token the marker itself carries.
-"$PCLI" claim release --issue "<N>" --session "$MY_CLAIM"
+. "$WRITECODE_SCRIPTS/step8-claim-release.sh" <N> || exit 1   # non-zero ⇒ the claim was NOT released
 ```
 
 **Why this is mandatory, not tidy-up.** A claim that outlives its run never expires, and the

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-candidate-pool.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-candidate-pool.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 1's candidate pool: list unassigned `status:triaged` issues, priority bucket by bucket.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 1 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
+# file deliberately sets NO shell options — the moved glue steers its own control flow and several
+# blocks depend on `pipefail` being OFF — and it leaves its variables and functions in the sourcing
+# shell, which is how the steps after it still see them. No EXIT trap: under bash 3.2 a cleanup
+# trap's last command becomes the script's status, laundering a `set -u` abort into exit 0 (#4476,
+# class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# p0 first; only fall through to p1, then p2 if a bucket is empty of unassigned issues
+for P in p0 p1 p2; do
+  gh api "repos/$REPO/issues?state=open&labels=status:triaged,$P&sort=created&direction=asc&per_page=100" \
+    --jq '.[] | select(.assignee == null and (.pull_request | not)) | "#\(.number)\t\(.created_at)\t\(.title)"'
+done

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-parent-resolve.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-parent-resolve.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 1's three-outcome parent read: sub-issue (200) / standalone (404) / UNKNOWN (anything else).
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Is it a sub-issue?" fenced block (epic #4435
+# phase 1, #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is
+# phase 2 (#1929).
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
+# file deliberately sets NO shell options — the moved glue steers its own control flow and depends
+# on `pipefail` being OFF — and it leaves its variables in the sourcing shell, which is how the
+# steps after it still see $EPIC. No EXIT trap: under bash 3.2 a cleanup trap's last command becomes
+# the script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — an empty number
+# addresses `repos/$REPO/issues//parent`, whose 404 is INDISTINGUISHABLE from the genuine
+# "No parent issue found" 404 that means standalone, i.e. it would answer "standalone" for an
+# unnamed issue (the #4171 class this very block exists to close).
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 1: no issue number — source this as `. "$WRITECODE_SCRIPTS/step1-parent-resolve.sh" <N>`. NO parent classification was produced (UNKNOWN, not standalone).\n' >&2
+  return 1
+fi
+
+# `-i` keeps the status line on stdout even when gh exits non-zero, which is the whole point:
+# it is what distinguishes a genuine 404 ("No parent issue found" ⇒ standalone) from an
+# UNREADABLE response (5xx, rate-limit, auth, network ⇒ UNKNOWN). Collapsing those two into
+# "no parent" is a silent no-op that skips Step 2 on a real epic child (#4171, #3715, #4108).
+PARENT_RESP="$(gh api "repos/$REPO/issues/$N/parent" -i 2>/dev/null)"
+PARENT_STATUS="$(printf '%s\n' "$PARENT_RESP" | head -n1 | awk '{print $2}')"
+case "$PARENT_STATUS" in
+  200)
+    EPIC="$(printf '%s\n' "$PARENT_RESP" | awk 'body{print} /^\r?$/{body=1}' | jq -r '.number // empty')"
+    : "${EPIC:?parent read returned 200 with no .number — UNKNOWN, not standalone; refusing to claim $N}"
+    echo "#$N is a sub-issue of epic #$EPIC → Step 2 (derive eligibility BEFORE claiming)" ;;
+  404)
+    echo "#$N is standalone (404 'No parent issue found') → Step 3 (claim it)" ;;
+  *)
+    echo "write-code FAILED (fail-closed): parent read on #$N returned HTTP '${PARENT_STATUS:-none}' — UNKNOWN, which is NOT evidence of 'no parent'. Refusing to claim: retry, or re-pick per Step 1." >&2
+    exit 1 ;;
+esac

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step2-epic-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step2-epic-read.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step 2's three reads of the parent epic: its body (the `## Dependencies` topology), its real child
 # set with each child's state, and the handoff-note comment stream siblings left.
 #

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step2-epic-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step2-epic-read.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 2's three reads of the parent epic: its body (the `## Dependencies` topology), its real child
+# set with each child's state, and the handoff-note comment stream siblings left.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 2 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
+# file deliberately sets NO shell options and leaves $EPIC in the sourcing shell. No EXIT trap:
+# under bash 3.2 a cleanup trap's last command becomes the script's status, laundering a `set -u`
+# abort into exit 0 (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block opened with the placeholder assignment
+# `EPIC=<the parent number Step 1's sub-endpoint read resolved — never a guessed or remembered one>`,
+# so the sourcing site passes that number instead. The prose constraint is unchanged and is the
+# reason for the fail-closed refusal: pass the number Step 1's sub-endpoint read RESOLVED, never a
+# guessed or remembered one. An empty $EPIC addresses `repos/$REPO/issues//sub_issues`, which reads
+# as an epic with no children — every dependency vacuously closed, every child "unblocked".
+EPIC="${1:-}"
+if [ -z "$EPIC" ]; then
+  printf 'write-code Step 2: no epic number — source this as `. "$WRITECODE_SCRIPTS/step2-epic-read.sh" <the parent number Step 1 resolved>`. NO topology was read (UNKNOWN, not "no dependencies").\n' >&2
+  return 1
+fi
+# the epic body carries the plan + the ## Dependencies topology
+gh api repos/$REPO/issues/$EPIC --jq '.body'
+# the real child set + each child's state (the list endpoint is source of truth;
+# sub_issues_summary undercounts under mixed closed/open children)
+gh api "repos/$REPO/issues/$EPIC/sub_issues?per_page=100" \
+  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
+# the cross-task signal siblings left — read before assuming what's done
+gh api "repos/$REPO/issues/$EPIC/comments?per_page=100" --jq '.[].body'

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-delegated-claim.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-delegated-claim.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 3's orchestrated path: confirm the threaded delegated token owns #N, then hold §7 layer one.
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Delegated claim" fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929) — and these lines ARE the verbs, so ADR 0228 keeps them relays: the script passes each
+# verb's answer through, it never re-derives the decision.
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
+# file deliberately sets NO shell options and leaves $PCLI in the sourcing shell. No EXIT trap:
+# under bash 3.2 a cleanup trap's last command becomes the script's status, laundering a `set -u`
+# abort into exit 0 (#4476, class #4479) — and these verbs are default-deny, so their EXIT STATUS is
+# the whole contract.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — `claim is-mine` with
+# no issue number cannot resolve an owner, and a run that treats that as confirmation would
+# implement on a lane it never proved is its own.
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 3 (delegated): no issue number — source this as `. "$WRITECODE_SCRIPTS/step3-delegated-claim.sh" <N>`. The delegation was NOT confirmed; do not implement.\n' >&2
+  return 1
+fi
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# Orchestrated path: confirm the delegated claim is the earliest authorized claim, then proceed.
+# The §7 CLAIM_RE + write+ ACL + min(created_at, comment id) resolution is owned by the shared verb
+# — run it, never re-derive the grammar. Exit 0 = the threaded token owns #N; non-zero = it does
+# not (absent, foreign, or superseded) ⇒ abort, do not implement.
+"$PCLI" claim is-mine --issue $N --session "$DELEGATED_TOKEN" \
+  || { echo "delegated token is not the earliest authorized claim — abort, do not implement." >&2; exit 1; }
+# Ensure §7 LAYER ONE for the whole build (#4298). The dispatcher owes this pre-spawn, but the
+# obligation lived in ONE orchestrator's prompt, so a lane dispatched by anything else reached here
+# with no assignee — and Step 8's release then freed the resolver on top of a gate that was never
+# written, leaving the issue `status:triaged` + unassigned with its PR in review. Idempotent and
+# additive: a gate already carrying us is a no-op, and the verb REFUSES on any lane whose claim is
+# not ours, so this asserts nothing about the dispatcher and evicts nothing (ADR 0215 §5).
+"$PCLI" claim assign --issue $N --session "$DELEGATED_TOKEN" \
+  || { echo "could not set the availability gate on #$N — routed blocker, do not implement." >&2; exit 1; }
+# delegation confirmed + layer one held — skip the direct-path claim below and go implement

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-delegated-claim.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-delegated-claim.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step 3's orchestrated path: confirm the threaded delegated token owns #N, then hold §7 layer one.
 #
 # Extracted VERBATIM from write-code/SKILL.md's "Delegated claim" fenced block (epic #4435 phase 1,

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-direct-claim.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-direct-claim.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 3's direct path: claim through the verb FIRST (layer two), and only then write layer one.
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Direct path" fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929) — the claim/assign lines ARE the verbs, so ADR 0228 keeps them relays.
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
+# file deliberately sets NO shell options and leaves $PCLI in the sourcing shell. Its `exit 0` on a
+# lost race is the moved block's own control flow — the run is meant to end and re-pick from Step 1;
+# do not "improve" it into a `return`. No EXIT trap: under bash 3.2 a cleanup trap's last command
+# becomes the script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — `tracker claim` with
+# no issue number claims nothing, and reading that as a won claim is the double-pick this whole step
+# exists to prevent (#1431).
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 3 (direct): no issue number — source this as `. "$WRITECODE_SCRIPTS/step3-direct-claim.sh" <N>`. NO claim was made; do not implement.\n' >&2
+  return 1
+fi
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# 0. Fail-closed on a missing token: the claim comment is the ONLY agent-distinguishable signal
+#    under the shared `usirin` login — with no token a co-racer is unresolvable, so NEVER claim
+#    (and never fall back to the login-keyed assignee as ownership — that is the §7 degeneracy).
+#    The verb enforces this too (it backs off on an empty session), so this is a fast local exit.
+if [ -z "$CLAUDE_CODE_SESSION_ID" ]; then
+  echo "no CLAUDE_CODE_SESSION_ID in env — cannot post an agent-distinguishable claim. BACK OFF, re-pick." >&2
+  exit 0   # → re-run Step 1
+fi
+
+# 1. Claim through the verb FIRST — layer two, the fine agent-distinguishable resolver. It defers
+#    to a pre-existing authorized owner WITHOUT posting, posts a PRESENCE-STAMPED marker under
+#    $CLAUDE_CODE_SESSION_ID, re-reads canonical state, and retracts its OWN claim if it lost.
+#    Exit 0 = the claim is mine; non-zero = backed off, having mutated nothing that is not ours.
+if ! "$PCLI" tracker claim $N; then
+  echo "did not win the claim on #$N (held by another agent, or lost the tiebreak) — back off, re-pick."
+  exit 0   # → re-run Step 1
+fi
+
+# 2. ONLY NOW write layer one — the coarse availability gate the Step-1 picker reads (§7). One verb
+#    owns this write on every path (#4298); never hand-roll the assignees POST. Defer-then-assign is
+#    load-bearing, not stylistic: every agent authenticates as the SAME login, so the assignee is ONE
+#    shared slot. Assigning first would make the back-off above a cleanup unassign that strips the
+#    LIVE incumbent's assignment — clearing the coarse gate on an issue someone else legitimately
+#    holds. Claiming first removes the cleanup entirely: the verb only ever writes on a claim it
+#    proved is ours, and it has no removal path at all, so there is nothing to undo (#4015).
+"$PCLI" claim assign --issue $N || { echo "could not set the availability gate on #$N — routed blocker." >&2; exit 1; }
+# claim won and confirmed (earliest authorized claim is mine) — proceed to implement

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-direct-claim.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-direct-claim.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step 3's direct path: claim through the verb FIRST (layer two), and only then write layer one.
 #
 # Extracted VERBATIM from write-code/SKILL.md's "Direct path" fenced block (epic #4435 phase 1,

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3_5-claim-is-mine.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3_5-claim-is-mine.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 3.5's `claim_is_mine <N>` — the guard MANDATED before every issue/PR-number mutation.
+#
+# Extracted VERBATIM from write-code/SKILL.md's `claim_is_mine` fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929) — the body already IS the verb, so ADR 0228 keeps it a relay: it passes the verb's exit
+# status through and never re-derives the ownership decision.
+#
+# SOURCED, never executed — leaving `claim_is_mine` in the sourcing shell is the whole point. Sets
+# NO shell options; no EXIT trap (under bash 3.2 a cleanup trap's last command becomes the script's
+# status, laundering a `set -u` abort into exit 0 — #4476, class #4479). The verb is default-deny, so
+# the function's EXIT STATUS is the entire contract: never swallow it.
+#
+# The block's trailing ILLUSTRATION of the calling convention
+# (`claim_is_mine "<N>" && gh api …/comments -f body="…"`) deliberately did NOT move here: it is a
+# metavariable-carrying example, and a moved copy would be a runnable line that posts a literal `…`
+# comment. It stays in SKILL.md next to this file's invocation, where it is documentation.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# claim_is_mine <N>: resolve the EARLIEST AUTHORIZED claim marker on #N (issue or PR) and assert
+# its embedded session id == MY_CLAIM. Returns 0 only on a proven-own claim; non-zero (REFUSE) on
+# an absent OR a foreign claim. The ADR-0115 §2 resolution — CLAIM_RE + the write+ ACL trust root
+# (ADR 0055) + the earliest-(created_at, comment id) tiebreak — is owned once by the shared verb
+# `pipeline-cli claim is-mine`; CITE it, never hand-roll the jq (#3687, the same envelope
+# extraction the shipped review-verdict and tracker verbs underwent). The verb is default-deny: an absent claim, an
+# unauthorized-only claim, a foreign owner, and a missing session all resolve NOT-mine (exit
+# non-zero) — exactly this guard's fail-closed refusal, so the exit-status contract is preserved.
+claim_is_mine() {
+  "$PCLI" claim is-mine --issue "$1" --session "$MY_CLAIM"   # exit 0 = mine; non-zero = REFUSE (default-deny)
+}

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3_5-my-claim.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step3_5-my-claim.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 3.5's `$MY_CLAIM` resolution — the token this run owns its work under.
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Your claim token" fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929).
+#
+# SOURCED, never executed — leaving $MY_CLAIM in the sourcing shell is the whole point, since
+# `claim_is_mine` reads it. Sets NO shell options; no EXIT trap (under bash 3.2 a cleanup trap's
+# last command becomes the script's status, laundering a `set -u` abort into exit 0 — #4476, class
+# #4479). The `:` fail-closed refusal below IS this file's contract, so nothing may swallow it.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# the claim token this run owns work under: the orchestrator's threaded delegated token if it
+# pre-claimed, else my own session id (the direct-path Step-3 self-claim). Fail-closed: with
+# NEITHER set there is no agent-distinguishable identity to verify ownership under — abort, never
+# fall back to the bare assignee login (that login degeneracy is the exact defect ADR 0115 removes).
+MY_CLAIM="${THREADED_CLAIM_TOKEN:-$CLAUDE_CODE_SESSION_ID}"
+: "${MY_CLAIM:?mis-attribution guard: no claim token — CLAUDE_CODE_SESSION_ID absent and none threaded; refusing to claim or mutate (ADR 0115 Consequences — never a login fallback)}"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-branch.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-branch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 4's branch cut: fetch the base fresh, derive the prefix from this checkout's git identity, and
+# create the per-run branch off FETCH_HEAD under `wt_preflight`.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 4 branch fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929).
+#
+# SOURCED, never executed. $BRANCH and $PREFIX must land in the sourcing shell exactly as the inline
+# block left them, so this file sets NO shell options. It calls `wt_preflight`, which SKILL.md's
+# per-mutation-preflight blockquote defines in that same shell — sourcing (not executing) is what
+# keeps that function reachable. No EXIT trap: under bash 3.2 a cleanup trap's last command becomes
+# the script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<slug-for-issue-N>` metavariable was substituted by
+# whoever ran the step, so the sourcing site passes the kebab-case slug instead. Fail closed on an
+# absent one — an empty slug yields `$PREFIX/-<nonce>`, a branch name that is legal, meaningless, and
+# names no issue.
+SLUG="${1:-}"
+if [ -z "$SLUG" ]; then
+  printf 'write-code Step 4: no branch slug — source this as `. "$WRITECODE_SCRIPTS/step4-branch.sh" <slug-for-issue-N>`. NO branch was created.\n' >&2
+  return 1
+fi
+# Fetch the base fresh, and FAIL-LOUD if it doesn't run: FETCH_HEAD is what the branch below is
+# cut from, so a silently-failed fetch (network blip, a harness worktree whose exec env stripped
+# PATH) leaves FETCH_HEAD at a STALE prior tip, and the branch misses a base file merged just
+# before branch-cut → the SHA-bound run-evidence check false-fails on a file the head never
+# carried (#1920; the same stale-base class #1837 fixed at the repair step). Never proceed on an
+# unverified fetch — assert it succeeded before branching off FETCH_HEAD.
+git fetch origin main || { echo "write-code: 'git fetch origin main' failed — refusing to branch off a stale FETCH_HEAD (would cut a head missing a just-merged base file; #1920)." >&2; exit 1; }
+# Derive the prefix from THIS checkout's git identity — never a hardcoded literal. A copied
+# literal namespaces every agent's branch under one person's handle regardless of who runs.
+PREFIX="$(git config user.name | tr '[:upper:] ' '[:lower:]-')"   # e.g. "Umut Sirin" → "umut-sirin"
+: "${PREFIX:?set git user.name to derive a branch prefix}"        # empty identity ⇒ "/slug…" (leading slash) git rejects with an opaque error; fail here with a fixable one
+# Per-run suffix: the deterministic $PREFIX/<slug-for-issue-N> is the SAME ref for every
+# run on this issue, so two concurrent runs would both push origin/<that branch> and the
+# second push would clobber the first's commits. A per-invocation nonce keeps them distinct.
+BRANCH="$PREFIX/$SLUG-$(uuidgen | head -c 8)"
+wt_preflight && git switch -c "$BRANCH" FETCH_HEAD   # branch create is a git mutation → gate it (per-mutation preflight above)

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-preflight.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 4's opening preflight: fail closed unless this run is in a LINKED git worktree, and stamp the
+# lane so every later `wt_preflight` has an independently-derived operand to compare against.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 4 preflight fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929). The *why* — why the LOUD refusal keys on the agent type, why self-provisioning is not the
+# remedy, and what a pass positively establishes — stays in that step's prose (ADR 0172,
+# #2440/#2443/#3406/#3458).
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, and $GITDIR
+# / $COMMON / $WT must survive into the step's later blocks, so this file sets NO shell options and
+# leaves its variables in the sourcing shell. No EXIT trap: under bash 3.2 a cleanup trap's last
+# command becomes the script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479),
+# and this preflight's whole contract is its EXIT STATUS.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# fail closed unless we're in a LINKED git worktree (not the primary checkout)
+GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || {
+  echo "write-code preflight FAILED: not inside a git repository — refusing to mutate." >&2; exit 1; }
+COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+case "$COMMON" in /*) ;; *) COMMON="$(pwd)/$COMMON" ;; esac   # normalize relative `.git` (older git)
+COMMON="$(cd "$COMMON" && pwd)"
+
+# Was worktree isolation EXPECTED for this run? The coder agent-type (agents/coder.md) asserts
+# isolation UNCONDITIONALLY, so any run under it expects the harness to have provisioned a linked
+# worktree + set $WORKTREE_ROOT. Three machine-checkable, harness-set signals arm it — NOT a per-run
+# guess — mirroring the repo-side guard's `isIsolationExpected` (bash-pin.ts) exactly (#3406):
+#   1. a direct isolation-asserting agent-type name ($CLAUDE_CODE_AGENT matching coder/reviewer/shipper);
+#   2. a set $WORKTREE_ROOT (the harness signalled a provisioned root);
+#   3. the ENV-INDEPENDENT corroboration — any agent-context run ($CLAUDE_CODE_AGENT non-empty) sitting
+#      on the PRIMARY checkout (git-dir == common-dir). A NESTED/renamed coder spawn inherits the
+#      PARENT's agent-type string (e.g. `crew-engineering-manager` / `junior-engineer`, ADR 0189), so the
+#      NAME match alone goes inert for it — but such a spawn on the primary checkout is a broken/absent
+#      worktree whatever its inherited name, and clause 3 catches it regardless of the string. Keying on
+#      the agent-type LITERAL alone was the #3406 defect: a renamed coder computed isolation-expected=0
+#      and silently self-provisioned. Do NOT hard-code any agent-type name (junior-engineer or otherwise)
+#      to "fix" it — that just relocates the coupling to the next rename; the corroboration removes it.
+# A genuine standalone human run (a direct `/write-code`, $CLAUDE_CODE_AGENT unset) matches NONE of the
+# three, so it never over-refuses and still reaches the Non-isolated fallback. This is what lets the
+# fail-closed branch below distinguish "isolation expected but the harness no-op'd provisioning" (#2440)
+# from a legitimate standalone run, firing LOUD in the first case without regressing the second. See
+# ADR 0172, #2462 (the guard's parallel re-keying), and #3406.
+ISOLATION_EXPECTED=0
+case "$CLAUDE_CODE_AGENT" in *coder*|*reviewer*|*shipper*) ISOLATION_EXPECTED=1 ;; esac   # direct isolation-asserting agent-type name
+[ -n "$WORKTREE_ROOT" ] && ISOLATION_EXPECTED=1                            # harness signalled a provisioned root
+# env-independent corroboration: a non-empty agent-type on the PRIMARY checkout (git-dir == common-dir) —
+# catches a nested/renamed coder whose inherited agent-type string doesn't name a role (#3406).
+[ -n "$CLAUDE_CODE_AGENT" ] && [ "$GITDIR" = "$COMMON" ] && ISOLATION_EXPECTED=1
+echo "write-code preflight: git-dir=$GITDIR common-dir=$COMMON cwd=$(pwd) isolation-expected=$ISOLATION_EXPECTED (agent=${CLAUDE_CODE_AGENT:-unset} worktree-root=${WORKTREE_ROOT:+set})"   # emit scanned scope (ADR 0092 §1)
+if [ "$GITDIR" = "$COMMON" ]; then
+  if [ "$ISOLATION_EXPECTED" = 1 ]; then
+    # FAIL-CLOSED LOUD (the #2443 branch): isolation was EXPECTED but this run is on the PRIMARY
+    # checkout with no linked worktree — the harness's `git worktree add` + $WORKTREE_ROOT injection
+    # silently didn't run for this coder spawn (#2440's harness no-op). Because the whole repo-side
+    # worktree-guard keys on $WORKTREE_ROOT, that no-op ALSO disarmed it, leaving this preflight the
+    # sole surviving layer. Do NOT self-provision here: doing so papers over the harness failure and
+    # leaves the two-layer primary-corruption defense collapsed to one, invisibly (#2270 class).
+    echo "write-code preflight FAILED (fail-closed, LOUD): worktree isolation was EXPECTED (agent=${CLAUDE_CODE_AGENT:-?}, worktree-root=${WORKTREE_ROOT:+set}) but this run is on the PRIMARY checkout (git-dir == common-dir) and \$WORKTREE_ROOT is unset." >&2
+    echo "  ROOT CAUSE: the harness's worktree provisioning (git worktree add + \$WORKTREE_ROOT injection) did NOT run for this coder spawn — the #2440 harness no-op. The repo-side worktree-guard also keys on \$WORKTREE_ROOT, so it is disarmed too; only this preflight is left." >&2
+    echo "  REFUSING to self-provision — that would hide the harness failure and leave the two-layer defense collapsed to one, invisibly (the primary-checkout-corruption class, #2270)." >&2
+    echo "  ROUTED BLOCKER — surface UP to the operator/EM: 'harness worktree provisioning no-op'd for a coder spawn (isolation expected, \$WORKTREE_ROOT unset); the out-of-repo harness half (#2440) needs attention. Do NOT blindly retry the same spawn.'" >&2
+    exit 1
+  fi
+  # isolation was NOT expected ⇒ a genuine standalone run: fall through to the Non-isolated fallback,
+  # which self-provisions a worktree (this path is unchanged, and the loud branch above never fires for it).
+  echo "write-code preflight FAILED (fail-closed): git-dir == common-dir ⇒ this is the PRIMARY checkout, not an isolated worktree." >&2
+  echo "  Refusing to branch/commit here — a spawn without isolation:worktree (or a cwd reset to the primary tree) would mis-branch the owner's checkout." >&2
+  echo "  This run did NOT expect isolation (standalone) — take the Non-isolated fallback below to create a worktree before mutating." >&2
+  exit 1
+else
+  # POSITIVE worktree assertion — loud + EARLY (#3458). git-dir != common-dir is the ONE trust
+  # signal for "I am in my own linked worktree" that survives the misleading env a worktree spawn
+  # is handed: $WORKTREE_ROOT is unset (the reverted #2938 provisioning hook) and $CLAUDE_CODE_AGENT
+  # reports the PARENT's value (inherited agent-type, #2462) — so neither can anchor worktree
+  # identity. This git-plumbing check can, and does so independently of both. Capture $WT from THIS
+  # evidence, never from the untrustworthy env and never from a file. This assertion fires BEFORE the
+  # first Edit/Write on purpose: a raw Edit/Write to a primary-checkout absolute path is not a git op,
+  # so neither the repo-side worktree-guard nor wt_preflight fires on it — the ONLY thing standing
+  # between a cwd-reset + stale-Read-cache and a stray write into shared primary `main` is anchoring
+  # every edit under this $WT (see "Anchor every Edit/Write to $WT" below). Establishing $WT loudly
+  # here is what makes that anchoring actionable from the first file touch.
+  WT="$(git rev-parse --show-toplevel)"
+  # STAMP THE LANE — this is the one moment $WT is trustworthy, so pin an identity to it (#4398).
+  # Every LATER Bash call re-derives the toplevel from a cwd the harness may have reset, so a
+  # cwd-derived "$WT" answers "where am I" and not "which tree is mine" — and a check that compares
+  # that answer against itself is tautological. $CLAUDE_CODE_SESSION_ID is the per-lane fact that
+  # DOES survive between calls (the same anchor §SP keys $RUN_SCRATCH on); write it into this
+  # worktree's PRIVATE per-worktree git dir, which is outside the working tree (never committed,
+  # never in `git status`) and unique per worktree. That stamp is the independently-derived operand
+  # wt_preflight compares the ambient cwd's answer against.
+  printf '%s\n' "${CLAUDE_CODE_SESSION_ID:?write-code preflight FAILED: no session id — no durable lane identity to stamp, so no later git mutation could be verified as mine}" > "$GITDIR/kampus-lane"
+  echo "write-code preflight CONFIRMED (LOUD): in a LINKED worktree at $WT (git-dir != common-dir), stamped for lane $CLAUDE_CODE_SESSION_ID — worktree identity established from git plumbing, INDEPENDENT of \$WORKTREE_ROOT (${WORKTREE_ROOT:+set}${WORKTREE_ROOT:-unset}) and \$CLAUDE_CODE_AGENT (${CLAUDE_CODE_AGENT:-unset}), both of which may misreport. Anchor EVERY Edit/Write and git op to this \$WT (absolute) — never a primary-checkout path."
+fi

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-containment.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-containment.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 4b's containment-marker read — the tolerant read of the child's `**Containment:**` line.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 4b fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# The moved line's `|| echo none` resolves an UNREADABLE issue body to the same `none` an issue with
+# no marker resolves to — the §ZS shape where a failed read poses as the permissive answer. It is
+# moved AS-IS on purpose (phase 1 is a relocation, ADR 0228) and tracked separately in #4501; do not
+# repair it here.
+#
+# SOURCED, never executed — leaving $CONTAINMENT in the sourcing shell is the whole point. Sets NO
+# shell options: `pipefail` being OFF is what makes the `|| echo none` fallback reachable at all, so
+# turning it on here would silently change the moved behavior. No EXIT trap (under bash 3.2 a
+# cleanup trap's last command becomes the script's status, laundering a `set -u` abort into exit 0 —
+# #4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — `issues/` with no
+# number would fall straight into the `|| echo none` fallback and report "not a dark ship".
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 4b: no issue number — source this as `. "$WRITECODE_SCRIPTS/step4b-containment.sh" <N>`. $CONTAINMENT was NOT resolved (UNKNOWN, not `none`).\n' >&2
+  return 1
+fi
+# the child's containment marker; a missing line reads as `none` (formats §2 tolerant-read rule)
+CONTAINMENT=$(gh api repos/$REPO/issues/$N --jq '.body' \
+  | grep -ioE '\**\s*Containment:\**\s*(flag|exempt|none)' | head -n1 \
+  | grep -ioE '(flag|exempt|none)' || echo none)

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-containment.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-containment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2034,SC2086
 # Step 4b's containment-marker read — the tolerant read of the child's `**Containment:**` line.
 #
 # Extracted VERBATIM from write-code/SKILL.md's Step 4b fenced block (epic #4435 phase 1, #4449).

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4d-blessed-surfaces.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4d-blessed-surfaces.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 4d's reference-anchored sub-loop input: the blessed surface-ids from the committed pointer.
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Reference-anchored generation" fenced block (epic
+# #4435 phase 1, #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is
+# phase 2 (#1929).
+#
+# The moved `|| true` resolves an unreadable/absent pointer to an EMPTY blessed set, which the step
+# reads as "no blessed surface changed ⇒ no-op". That is correct for a genuinely absent pointer (the
+# graceful-absence contract) and fail-OPEN for an unreadable one; moved as-is per phase 1 and tracked
+# in #4501.
+#
+# SOURCED, never executed — leaving $POINTER and $BLESSED_SURFACES in the sourcing shell is the whole
+# point. Sets NO shell options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# blessed surface-ids: the keys of the committed pointer's `surfaces` map (ADR 0183).
+# Intersect with the surfaces THIS diff renders (Step 4d capture) — only that ∩ is reference-anchored.
+# Empty ∩ ⇒ no blessed surface changed ⇒ this whole sub-loop is a no-op; the plain pillars loop stands.
+POINTER=packages/design-capture/golden-pointer.json
+BLESSED_SURFACES="$(jq -r '.surfaces | keys[]' "$POINTER" 2>/dev/null || true)"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4d-blessed-surfaces.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4d-blessed-surfaces.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2034
 # Step 4d's reference-anchored sub-loop input: the blessed surface-ids from the committed pointer.
 #
 # Extracted VERBATIM from write-code/SKILL.md's "Reference-anchored generation" fenced block (epic

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-acceptance-criteria.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-acceptance-criteria.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step 5's AC enumeration — the checklist that must be satisfied in FULL before a closing keyword.
 #
 # Extracted VERBATIM from write-code/SKILL.md's Step 5 fenced block (epic #4435 phase 1, #4449).

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-acceptance-criteria.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-acceptance-criteria.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 5's AC enumeration — the checklist that must be satisfied in FULL before a closing keyword.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 5 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed, for consistency with every other step here — its output is read off
+# stdout, not out of a variable. Sets NO shell options: `pipefail` being OFF is what lets the moved
+# `|| echo "(no checkbox ACs …)"` fallback fire. No EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — with no number the
+# fallback line prints and the run would read "no acceptance criteria" for an issue it never read.
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 5: no issue number — source this as `. "$WRITECODE_SCRIPTS/step5-acceptance-criteria.sh" <N>`. NO criteria were enumerated (UNKNOWN, not "none").\n' >&2
+  return 1
+fi
+# enumerate #N's acceptance criteria — the checklist you must satisfy in FULL to emit a closing keyword
+gh api repos/$REPO/issues/$N --jq '.body' \
+  | awk '/^###[[:space:]]*Acceptance criteria/{f=1;next} /^###/{f=0} f' \
+  | grep -E '^\s*- \[' || echo "(no checkbox ACs — read the ### Acceptance criteria prose)"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-push.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2015,SC2016
 # Step 5's pre-PR mutations: re-derive the branch live from the worktree, push it through the
 # sanctioned `verified-push`, and confirm #N is this run's claim before opening a PR against it.
 #

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-push.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-push.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 5's pre-PR mutations: re-derive the branch live from the worktree, push it through the
+# sanctioned `verified-push`, and confirm #N is this run's claim before opening a PR against it.
+#
+# Extracted VERBATIM from the FIRST HALF of write-code/SKILL.md's Step 5 fenced block (epic #4435
+# phase 1, #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase
+# 2 (#1929). The block's second half — the `gh pr create` heredoc — deliberately did NOT move: it is
+# a fill-in-the-blanks BODY TEMPLATE whose prose the agent authors per run, so it stays in SKILL.md
+# next to this file's invocation.
+#
+# SOURCED, never executed. $BRANCH must land in the sourcing shell exactly as the inline block left
+# it, and `wt_preflight` / `claim_is_mine` are defined in that same shell — sourcing (not executing)
+# is what keeps them reachable. Sets NO shell options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — `claim_is_mine ""`
+# cannot resolve an owner, and this guard exists precisely so a mis-attributed number never reaches
+# a mutation (#1404).
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 5: no issue number — source this as `. "$WRITECODE_SCRIPTS/step5-push.sh" <N>`. NOTHING was pushed.\n' >&2
+  return 1
+fi
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# RE-DERIVE the branch LIVE from the worktree — never a cached/shared-file value (see the
+# live-derivation rule in Step 4). $BRANCH from Step 4 is GONE across Bash calls; wt_preflight
+# just re-cd'd to $WT, so the checked-out branch IS the work branch. Read it, never guess it.
+wt_preflight && BRANCH="$(git -C "$WT" branch --show-current)"
+: "${BRANCH:?could not re-derive branch from worktree $WT — refusing to push to a guessed/cached ref}"
+# The SANCTIONED push path — see [Pushing: the verdict is the ref, not the exit code]. It pushes
+# AND independently confirms the remote ref, printing its verdict LAST on stdout. Exit 0 = MOVED,
+# 1 = NOT-MOVED, 3 = UNKNOWN; STOP on either non-zero — never open a PR against a branch you
+# cannot prove exists (an UNKNOWN is not a success).
+wt_preflight && "$PCLI" verified-push --cwd "$WT" --remote origin --branch "$BRANCH" --set-upstream \
+  || { echo "write-code: the push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — refusing to open a PR against an unproven branch." >&2; exit 1; }
+# The PR opens AGAINST issue #N (Fixes #N) — gate it on the mis-attribution guard (Step 3.5): open a
+# PR closing only an issue whose claim is mine, never one mis-attributed to another agent's #N.
+claim_is_mine "$N" || { echo "refusing to open a PR against #$N — not my claim (Step 3.5)"; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-seam-checks.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-seam-checks.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 5's five post-open seam checks (a)–(e): the cross-reference, the closing/partial-split seam,
+# the stray-close inverse guard, the dark-ship `Flag:` guard, and the `## Deviations` presence floor.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 5 verification fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929). Check (d) re-derives $CONTAINMENT and $CYCLE_DOC in this same shell ON PURPOSE (#4398) —
+# Step 4b's copies are gone by this Bash call — so the duplication with step4b-containment.sh and
+# shared/scripts/cycle-doc-probe.sh is the moved block's own, and collapsing it is phase 2's call.
+#
+# SOURCED, never executed, so its variables stay visible to the step's later prose-driven fixes. Sets
+# NO shell options: EVERY check here is an `&& echo … || echo …` pair over a pipeline, so turning on
+# `pipefail` or `errexit` would abort the step at its first negative branch — i.e. convert a
+# fail-closed report into no report at all. No EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The two seams this move needed: the block's `<N>` and `<PR>` metavariables were substituted by
+# whoever ran the step, so the sourcing site passes them instead. Each ERE below splices the number
+# by quote-concatenation ('…#'"$N"'\b') rather than switching the pattern to double quotes, so the
+# pattern's own bytes are unchanged. Fail closed on an absent one — an empty number turns check (b)
+# into a match on any `#`-prefixed digit and check (c) into a stray for every issue.
+N="${1:-}"
+PR="${2:-}"
+if [ -z "$N" ] || [ -z "$PR" ]; then
+  printf 'write-code Step 5: need both numbers — source this as `. "$WRITECODE_SCRIPTS/step5-seam-checks.sh" <N> <PR>`. NO seam check ran (UNKNOWN, never "armed").\n' >&2
+  return 1
+fi
+# (a) the cross-reference landed (a closing OR non-closing mention both show here — necessary, not sufficient)
+#     --paginate + a STREAMING --jq, per the contract's pagination rule: the timeline endpoint
+#     defaults to 30 events/page, so an un-paginated read calls a cross-reference past event 30
+#     absent — a false alarm on any issue with a bit of history (#4193).
+gh api --paginate "repos/$REPO/issues/$N/timeline?per_page=100" \
+  --jq '.[] | select(.event == "cross-referenced") | .event'
+# (b) the SUFFICIENT check, REST-only: the seam is armed iff the body carries EITHER a real
+#     CLOSING keyword for #N (full-close PR — the same set ship-it Step 1 resolves:
+#     fix(es|ed)/close[sd]?/resolve[sd]?) OR a `Part of #N` partial-split marker (the §9
+#     non-closing link that keeps #N OPEN by design). Only NEITHER is a truly broken seam.
+BODY=$(gh api repos/$REPO/pulls/$PR --jq '.body')
+if printf '%s' "$BODY" | grep -qiE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#'"$N"'\b'; then
+  echo "closing seam armed"
+elif printf '%s' "$BODY" | grep -qiE '\bpart of\s+#'"$N"'\b'; then
+  echo "partial-split seam armed — Part of #$N, no closing keyword by design (§9; #$N stays open)"
+else
+  echo "BROKEN SEAM — body links #$N with neither a closing keyword nor a 'Part of #$N' marker"
+fi
+# (c) the INVERSE GUARD, REST-only: NO closing keyword targets any issue OTHER than #N.
+#     The set {issue numbers preceded by a closing keyword in the body} must be exactly {N};
+#     a stray member is a sibling-ref directive that auto-closes an issue this PR never fixed (#1259).
+STRAY=$(gh api repos/$REPO/pulls/$PR --jq '.body' \
+  | grep -ioE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#[0-9]+' \
+  | grep -oE '[0-9]+' | sort -u | grep -vx "$N")
+[ -z "$STRAY" ] \
+  && echo "no stray close directives — closing-keyword set is exactly {#$N}" \
+  || echo "STRAY CLOSE DIRECTIVE(S) on $(printf '#%s ' $STRAY)— rewrite these sibling refs to a non-closing form (addresses/relates to/see #M) before opening/patching the PR"
+# (d) DARK-SHIP GUARD, REST-only: IF Step 4b fired, the body MUST carry a `Flag:` line that
+#     matches ship-it Step 5b's FLAG_IN_BODY grep verbatim — else the prior-PR dark ship is dropped
+#     from the release queue (#1282). Whether Step 4b fired is RE-DERIVED HERE from durable state —
+#     the child's `Containment:` marker and the cycle-doc probe, Step 4b's own two inputs, read in
+#     THIS Bash call. It used to key on `[ -n "$FLAG_KEY" ]`, a shell variable Step 4b assigns in a
+#     DIFFERENT Bash call: shell state does not survive between calls, so it was empty here and the
+#     check silently skipped itself in exactly the case it exists for (#4398).
+CONTAINMENT=$(gh api repos/$REPO/issues/$N --jq '.body' \
+  | grep -ioE '\**\s*Containment:\**\s*(flag|exempt|none)' | head -n1 \
+  | grep -ioE '(flag|exempt|none)' || echo none)
+gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1 \
+  && CYCLE_DOC=present || CYCLE_DOC=absent
+if [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]; then
+  gh api repos/$REPO/pulls/$PR --jq '.body' \
+    | grep -Eiq '^[[:space:]]*\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+' \
+    && echo "dark-ship Flag: line present and matches ship-it Step 5b — release queue will fire" \
+    || echo "MISSING/MALFORMED Flag: line — Step 4b fired but the body has no matching plain 'Flag: <key>' line; patch it in before stopping (#1282)"
+else
+  echo "no dark ship (containment=$CONTAINMENT, cycle-doc=$CYCLE_DOC) — no Flag: line expected"
+fi
+# (e) DISCLOSURE PRESENCE, REST-only: the body carries a `## Deviations` heading. This is the
+#     PRESENCE floor only — it cannot tell an honest `None.` from a false one, and it sees none of
+#     the seven classes (§DEV's detection tiers). It exists so the one failure mode that is purely
+#     mechanical — forgetting the heading — never reaches a gate as a malformed body.
+gh api repos/$REPO/pulls/$PR --jq '.body' \
+  | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$' \
+  && echo "## Deviations section present" \
+  || echo "MISSING ## Deviations section — an ABSENT section is a gate FAIL (§DEV: absent is not None.); patch the body before stopping"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-seam-checks.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-seam-checks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step 5's five post-open seam checks (a)–(e): the cross-reference, the closing/partial-split seam,
 # the stray-close inverse guard, the dark-ship `Flag:` guard, and the `## Deviations` presence floor.
 #

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step6-progress-comment.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step6-progress-comment.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 6: post the four-section progress comment, composed under the §SP per-run scratch namespace.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 6 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929) — the
+# hand-rolled $RUN_SCRATCH derivation duplicates `kp_scratch_path` (shared/lib/common.sh) and the
+# `scratchpad` verb, and collapsing it onto either is phase 2's call, not this move's.
+#
+# SOURCED, never executed, so $RUN_SCRATCH stays visible and `claim_is_mine` (defined by
+# step3_5-claim-is-mine.sh in this same shell) is reachable. WRITE "$RUN_SCRATCH/progress.md" BEFORE
+# sourcing this — the path is deterministic and session-keyed, so it re-derives identically in an
+# earlier Bash call. Sets NO shell options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — an empty number both
+# addresses `repos/$REPO/issues//comments` and collapses the per-issue scratch leaf, so a concurrent
+# lane's note could be posted from this one.
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 6: no issue number — source this as `. "$WRITECODE_SCRIPTS/step6-progress-comment.sh" <N>`. NO comment was posted.\n' >&2
+  return 1
+fi
+# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
+# Keyed on the session id, so if you compose progress.md in one Bash call and post it in the
+# next, this same line re-derives the SAME directory (a bare `mktemp -d` would hand the second
+# call a new EMPTY dir and post an empty body).
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-$N"
+mkdir -p "$RUN_SCRATCH" || {
+  echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a comment through a shared path (#3718)." >&2; exit 1; }
+# …write the four-section comment to "$RUN_SCRATCH/progress.md", then:
+[ -s "$RUN_SCRATCH/progress.md" ] || { echo "write-code: progress.md is missing/empty — refusing to post an empty comment." >&2; exit 1; }
+BODY="$(cat "$RUN_SCRATCH/progress.md")"   # the four-section comment
+# gate the comment on the mis-attribution guard (Step 3.5) — only comment on an issue whose claim is mine
+claim_is_mine "$N" && gh api repos/$REPO/issues/$N/comments -f body="$BODY"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step6-progress-comment.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step6-progress-comment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step 6: post the four-section progress comment, composed under the §SP per-run scratch namespace.
 #
 # Extracted VERBATIM from write-code/SKILL.md's Step 6 fenced block (epic #4435 phase 1, #4449).

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step7-epic-handoff.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step7-epic-handoff.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 7: post the handoff note on the parent epic, gated on owning the CHILD (never the epic).
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 7 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929) — the
+# hand-rolled $RUN_SCRATCH derivation duplicates `kp_scratch_path` (shared/lib/common.sh), and
+# collapsing it onto that helper is phase 2's call.
+#
+# SOURCED, never executed, so `claim_is_mine` (defined by step3_5-claim-is-mine.sh in this same shell)
+# is reachable. WRITE "$RUN_SCRATCH/handoff.md" BEFORE sourcing this. Sets NO shell options; no EXIT
+# trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The two seams this move needed: the block's `<N>` (the child you own) and `<EPIC>` (the parent you
+# post onto) metavariables were substituted by whoever ran the step, so the sourcing site passes them
+# instead. Fail closed on either being absent — an empty child number cannot be claim-verified, and an
+# empty epic number addresses `repos/$REPO/issues//comments`.
+N="${1:-}"
+EPIC="${2:-}"
+if [ -z "$N" ] || [ -z "$EPIC" ]; then
+  printf 'write-code Step 7: need both numbers — source this as `. "$WRITECODE_SCRIPTS/step7-epic-handoff.sh" <N> <EPIC>`. NO handoff was posted.\n' >&2
+  return 1
+fi
+# compose under the per-run scratch namespace (§SP), never a fixed /tmp leaf — a concurrent
+# coder lane would clobber it and this posts ITS handoff onto your epic, silently (#3718).
+# Deterministic (session-keyed), so writing handoff.md in one Bash call and posting it here in
+# the next resolves the SAME directory — re-running `mktemp -d` would yield an empty one.
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-$N"
+mkdir -p "$RUN_SCRATCH" || {
+  echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a handoff through a shared path (#3718)." >&2; exit 1; }
+# …write the handoff to "$RUN_SCRATCH/handoff.md" first, then:
+[ -s "$RUN_SCRATCH/handoff.md" ] || { echo "write-code: handoff.md is missing/empty — refusing to post an empty handoff." >&2; exit 1; }
+BODY="$(cat "$RUN_SCRATCH/handoff.md")"   # ### Handoff: #N — <title> + the three fields
+# the handoff to the parent epic is predicated on OWNING THE CHILD — gate on claim_is_mine <child>
+# (Step 3.5), not the epic (which you never claim): only hand off about work whose claim is mine.
+claim_is_mine "$N" && gh api repos/$REPO/issues/$EPIC/comments -f body="$BODY"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step7-epic-handoff.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step7-epic-handoff.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step 7: post the handoff note on the parent epic, gated on owning the CHILD (never the epic).
 #
 # Extracted VERBATIM from write-code/SKILL.md's Step 7 fenced block (epic #4435 phase 1, #4449).

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step8-claim-release.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step8-claim-release.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 8: retract OUR OWN claim marker — the last mutation of the run that held it.
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Release the claim" fenced block (epic #4435 phase 1,
+# #4449). A byte-move, not a rewrite: the release line already IS the verb, so ADR 0228 keeps it a
+# relay — it passes the verb's answer through and never re-derives who owns the lane. Phase 2 (#1929)
+# has nothing to do here.
+#
+# SOURCED, never executed, so it reads the $MY_CLAIM the sourcing shell carries. Sets NO shell
+# options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the
+# step, so the sourcing site passes it instead. Fail closed on an absent one — `claim release` with no
+# issue number releases nothing, and reporting the lane freed when it is not is how a claim outlives
+# its run.
+N="${1:-}"
+if [ -z "$N" ]; then
+  printf 'write-code Step 8: no issue number — source this as `. "$WRITECODE_SCRIPTS/step8-claim-release.sh" <N>`. The claim was NOT released.\n' >&2
+  return 1
+fi
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# the last mutation of the run — retract OUR OWN claim marker on the issue we just built.
+# --session carries the token we owned the work under (the orchestrator's delegated token on the
+# orchestrated path), because that is the token the marker itself carries.
+"$PCLI" claim release --issue "$N" --session "$MY_CLAIM"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR-frozen-ac.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR-frozen-ac.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Freeze-after-round-K: does this round's resolving FAIL table carry a review-appended AC tagged
+# at/after the final round (ADR 0079)?
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Freeze-after-round-K" fenced block (epic #4435 phase
+# 1, #4449). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2
+# (#1929).
+#
+# SOURCED, never executed: it reads the $FAILBODY (the resolving FAIL marker body from R2) the
+# sourcing shell carries, and prints its finding on stdout. Sets NO shell options; no EXIT trap
+# (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# does this round's resolving FAIL table carry a review-appended AC tagged at/after the final round?
+# the row is the ordinary checkbox shape; the tag is the only thing read here (no new parser)
+# $FAILBODY = the resolving FAIL marker body from R2; grep the provenance tags it carries
+echo "$FAILBODY" | grep -oE '<!-- *ac:review-[a-z]+ +pr:#[0-9]+ +round:[0-9]+ *-->' | while read -r tag; do
+  K=$(printf '%s' "$tag" | grep -oE 'round:[0-9]+' | cut -d: -f2)
+  [ "$K" -ge 3 ] && echo "FROZEN appended AC ($tag) — appended in/after final round; escalate, do not loop"
+done

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR-round-count.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR-round-count.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Bounding: how many distinct gate-FAIL ROUNDS this PR has already accrued.
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Bounding" fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929) — this
+# is the one thing `verdict read` deliberately does NOT do (it resolves the latest verdict, it does
+# not count rounds), so the counting jq is inherently local until a verb owns it.
+#
+# SOURCED, never executed: it reads the $authorized set and the $comments_file the pre-pick scan / R1
+# left in this shell, and prints the round count on stdout. Sets NO shell options; no EXIT trap
+# (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# how many distinct gate-FAIL ROUNDS has this PR already accrued (both namespaces)?
+# cluster FAIL markers by timestamp gap: a new round starts only when >120s separates two
+# FAILs, so a code+doc pass (seconds apart) is one round and two real rounds (fix-push +
+# re-review apart) are two — grid-free, so no minute-boundary split or same-minute merge.
+jq --argjson authorized "$authorized" \
+   '[.[] | select(.user.login | IN($authorized[]))
+         | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*FAIL"; "i"))
+         | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
+    | sort
+    | reduce .[] as $t ({n:0, prev:null};
+        if (.prev == null) or ($t - .prev) > 120
+        then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
+    | .n' "$comments_file"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR-round-count.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR-round-count.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2154
 # Bounding: how many distinct gate-FAIL ROUNDS this PR has already accrued.
 #
 # Extracted VERBATIM from write-code/SKILL.md's "Bounding" fenced block (epic #4435 phase 1, #4449).

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-branch-rebase.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-branch-rebase.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step R2: fetch, prove the PR's linked issue is MINE, then switch to the head branch and rebase.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step R2 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed: `claim_is_mine` and `wt_preflight` are defined in the sourcing shell, and
+# the `cd` that `wt_preflight` performs must persist for the rebase and the R3 push. Sets NO shell
+# options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's `<the PR's head branch>` metavariable was substituted by
+# whoever ran the step (the comment on that line names the read that yields it), so the sourcing site
+# passes it instead. Fail closed on an absent one — a bare `git switch` with no ref is a usage error,
+# but the guarded ops after it would still run against whatever branch the tree is on.
+HEAD_BRANCH="${1:-}"
+if [ -z "$HEAD_BRANCH" ]; then
+  printf 'write-code Step R2: no head branch — source this as `. "$WRITECODE_SCRIPTS/stepR2-branch-rebase.sh" <the PR'"'"'s head branch>` (gh api .../pulls/$PR --jq '"'"'.head.ref'"'"'). NOTHING was switched or rebased.\n' >&2
+  return 1
+fi
+git fetch origin
+# mis-attribution guard (Step 3.5): confirm the PR's linked issue #N is MINE before touching its
+# branch — so a mis-dispatched repair never pushes to another agent's live PR (the #1404 class).
+# In orchestrated repair the original claim token is threaded as MY_CLAIM (ADR 0115 §3 delegated own).
+claim_is_mine "$N" || { echo "refusing to repair PR #$PR — its linked issue #$N is not my claim (Step 3.5)"; exit 1; }
+wt_preflight && git switch "$HEAD_BRANCH"   # gate the branch switch ([per-mutation preflight]); gh api .../pulls/$PR --jq '.head.ref'
+wt_preflight && git rebase origin/main   # freshen the dispatch-time base FIRST — surface a textual conflict now, in-context (see below)
+# apply the fixes addressing exactly the enumerated findings

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-fail-body.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-fail-body.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step R2: fetch the body of the resolving FAIL marker, by the comment id R1's `verdict read` returned.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step R2 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed: it reads the $CODE_FAIL_JSON / $DOC_FAIL_JSON / $SKILL_FAIL_JSON that R1
+# left in this shell, and leaves $CID there for R3's thread reply. Sets NO shell options; no EXIT trap
+# (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the fenced block hardcoded $CODE_FAIL_JSON and told the reader to
+# "swap CODE_FAIL_JSON→DOC_FAIL_JSON/SKILL_FAIL_JSON per namespace"; a script cannot be hand-edited
+# per namespace, so the sourcing site names the namespace and this indirects to that variable. The
+# default preserves the moved default exactly.
+FAIL_JSON_VAR="${1:-CODE_FAIL_JSON}"
+FAIL_JSON="${!FAIL_JSON_VAR:-}"   # bash indirect expansion, not `eval` — the value is a network payload
+# the full body of the resolving FAIL marker — its comment id came from R1's `verdict read` JSON
+# (swap CODE_FAIL_JSON→DOC_FAIL_JSON/SKILL_FAIL_JSON per namespace). `verdict read` already
+# author-gated and latest-wins-resolved that exact comment, so this is a plain body fetch of it —
+# no re-derivation of the resolver. (When the code namespace was resolved via a native
+# CHANGES_REQUESTED review rather than a marker, read the review body from
+# `repos/$REPO/pulls/$PR/reviews` instead — a native review carries no issue-comment id.)
+CID=$(jq -r '.commentId // empty' <<<"$FAIL_JSON")
+[ -n "$CID" ] && gh api "repos/$REPO/issues/comments/$CID" --jq '.body'

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-inline-comments.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-inline-comments.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step R2's additive fold-in: the still-anchored, in-scope inline review comments.
+#
+# Extracted VERBATIM from write-code/SKILL.md's "Also fold in line-anchored inline review comments"
+# fenced block (epic #4435 phase 1, #4449). A byte-move, not a rewrite: replacing this glue with
+# `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed: it reads the $authorized set R1 built in this shell and the $PR R1 resolved,
+# and leaves $ME and $inlineComments there. Sets NO shell options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+ME=$(gh api user --jq '.login')   # don't action your own author-side replies
+# fetch into a var, then pipe to standalone jq — gh's --jq takes no --argjson, and this reuses
+# the same $authorized set R1/R2 already built (same pattern as the marker work-list above)
+inlineComments=$(gh api "repos/$REPO/pulls/$PR/comments?per_page=100")
+# in-scope, still-anchored inline review comments → your additive fix list (id+path+line+body)
+jq --argjson authorized "$authorized" --arg me "$ME" \
+  '[ .[]
+     | select(.line != null)                                  # non-null line ⇒ still anchored to current head (ADR 0058)
+     | select(.user.login != $me)                             # skip self-authored thread replies
+     | select((.user.login | IN($authorized[]))               # write+ collaborator (ADR 0055), or…
+              or .user.login == "copilot-pull-request-reviewer[bot]")  # …the explicitly-included review bot (#383)
+   ] | .[] | {id, path, line, body}' <<<"$inlineComments"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-inline-comments.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-inline-comments.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2154
 # Step R2's additive fold-in: the still-anchored, in-scope inline review comments.
 #
 # Extracted VERBATIM from write-code/SKILL.md's "Also fold in line-anchored inline review comments"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-linked-issue.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-linked-issue.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step R2: resolve the PR's linked issue #N, then read its body and comment stream.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step R2 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed: leaving $N in the sourcing shell is the whole point — every later repair
+# mutation gates on `claim_is_mine "$N"`. Sets NO shell options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+N=$(gh api repos/$REPO/pulls/$PR \
+  --jq '.body | capture("(?i)\\b(fix(es|ed)?|close[sd]?|resolve[sd]?)\\s+#(?<n>[0-9]+)") | .n')
+gh api repos/$REPO/issues/$N --jq '.body'
+gh api "repos/$REPO/issues/$N/comments?per_page=100" --jq '.[].body'

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-linked-issue.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-linked-issue.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
 # Step R2: resolve the PR's linked issue #N, then read its body and comment stream.
 #
 # Extracted VERBATIM from write-code/SKILL.md's Step R2 fenced block (epic #4435 phase 1, #4449).

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-push-and-note.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-push-and-note.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2015,SC2016,SC2086
 # Step R3: re-assert the claim, force-with-lease the rebased head through `verified-push`, and post
 # the format-3 repair note.
 #

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-push-and-note.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-push-and-note.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step R3: re-assert the claim, force-with-lease the rebased head through `verified-push`, and post
+# the format-3 repair note.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step R3 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929) — the
+# hand-rolled $RUN_SCRATCH derivation duplicates `kp_scratch_path` (shared/lib/common.sh), and
+# collapsing it onto that helper is phase 2's call.
+#
+# SOURCED, never executed: it reads the $N / $PR / $WT and the `claim_is_mine` + `wt_preflight`
+# functions the earlier steps left in this shell. WRITE "$RUN_SCRATCH/repair-progress.md" BEFORE
+# sourcing this. Sets NO shell options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# re-assert the mis-attribution guard (Step 3.5) before the resubmit push — a between-calls cwd
+# reset can't move the claim, but the guard is MANDATED before every number-targeting mutation,
+# exactly as wt_preflight is before every git op; gate both the push and the progress comment.
+claim_is_mine "$N" || { echo "refusing to push/comment — PR #$PR linked issue #$N not my claim (Step 3.5)"; exit 1; }
+# The SANCTIONED push path ([Pushing: the verdict is the ref, not the exit code]) — force-with-lease
+# because the R2 rebase onto origin/main moved the head. It confirms the remote ref carries the
+# rebased head before you claim the resubmit landed; exit 0 = MOVED, 1 = NOT-MOVED, 3 = UNKNOWN.
+# STOP on either non-zero: a reviewer waiting on a moved head would otherwise re-gate the STALE one.
+wt_preflight && "$PCLI" verified-push --cwd "$WT" --remote origin --force-with-lease \
+  || { echo "write-code: the repair push was NOT confirmed on the remote (see the PUSH-VERDICT line above) — the gate would re-run against the STALE head. Do not report the resubmit as landed." >&2; exit 1; }
+# compose the repair note under the §SP per-run scratch namespace, never a fixed /tmp leaf:
+# concurrent repair lanes clobber a shared name and this posts THEIR note onto your issue (#3718).
+# Session-keyed and deterministic, so the note you wrote in an earlier Bash call is still here.
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-$N"
+mkdir -p "$RUN_SCRATCH" || { echo "write-code: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
+# …write the format-3 repair note to "$RUN_SCRATCH/repair-progress.md" first, then:
+[ -s "$RUN_SCRATCH/repair-progress.md" ] || { echo "write-code: repair-progress.md is missing/empty — refusing to post an empty comment." >&2; exit 1; }
+gh api repos/$REPO/issues/$N/comments -f body="$(cat "$RUN_SCRATCH/repair-progress.md")"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-thread-reply.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-thread-reply.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step R3: reply on the inline review thread this round addressed.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step R3 fenced block (epic #4435 phase 1, #4449).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed: it reads the $PR and the $CID that stepR2-fail-body.sh left in this shell.
+# Sets NO shell options; no EXIT trap (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# The one seam this move needed: the block's reply body was a per-run TEMPLATE
+# ("Addressed in <short-sha>: <one line on the fix>."), so it stays authored at the sourcing site and
+# arrives as $1 — which keeps the template visible in SKILL.md rather than frozen in a script. Fail
+# closed on an absent one: an empty body posts a blank reply that claims a fix and says nothing.
+REPLY_BODY="${1:-}"
+if [ -z "$REPLY_BODY" ]; then
+  printf 'write-code Step R3: no reply body — source this as `. "$WRITECODE_SCRIPTS/stepR3-thread-reply.sh" "Addressed in <short-sha>: <one line on the fix>."`. NOTHING was posted.\n' >&2
+  return 1
+fi
+# reply on the inline comment thread you addressed ($CID = the comment id from R2)
+gh api -X POST "repos/$REPO/pulls/$PR/comments/$CID/replies" \
+  -f body="$REPLY_BODY"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-byte-move.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-byte-move.sh
@@ -68,6 +68,9 @@ check step7-epic-handoff.sh      "# compose under the per-run scratch namespace 
 check stepR2-inline-comments.sh  "ME=\$(gh api user --jq '.login')   # don't action your own author-side replies"
 check stepR-round-count.sh       "# how many distinct gate-FAIL ROUNDS has this PR already accrued (both namespaces)?"
 check stepR-frozen-ac.sh         "# does this round's resolving FAIL table carry a review-appended AC tagged at/after the final round?"
+# The single seam is the head-branch metavariable, so this IS expressible as one substitution — a
+# branch-switching, rebasing script is the last place the proof should have a silent gap (#4503 review).
+check stepR2-branch-rebase.sh    "git fetch origin" -e 's|git switch <the PR.s head branch>|git switch "$HEAD_BRANCH"|'
 
 # Partial moves — the base block's own first line stayed in SKILL.md as a placeholder or template.
 MODE=part FROM="# the epic body carries the plan + the ## Dependencies topology" \

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-byte-move.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-byte-move.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2016
+# Reviewer-runnable proof that every extracted script is a BYTE-MOVE of the fenced block it replaced.
+#
+# For each (script, base-block-first-line) pair it slices the block out of `write-code/SKILL.md` at
+# the BASE commit, applies only the metavariable→positional-parameter substitutions the script's own
+# header declares, and diffs that against the script's moved region (from the same first line to EOF).
+# A clean run prints `MATCH` per script and exits 0; any drift prints the diff and exits 1.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-byte-move.sh [BASE_SHA]
+# Default BASE_SHA is the commit this extraction branched from.
+set -uo pipefail
+
+BASE="${1:-cb52bd3efdbc2b2e3720793a96d90a6261e33536}"
+ROOT="$(git rev-parse --show-toplevel)"
+SKILL=claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+DIR="$ROOT/claude-plugins/kampus-pipeline/skills/write-code/scripts"
+TMP="$(mktemp -d)"
+git show "$BASE:$SKILL" > "$TMP/base.md" || exit 1
+
+# Slice the column-0 fenced block whose FIRST BODY LINE is $1, out of the base SKILL.md.
+slice() {
+  awk -v first="$1" '
+    !inb && $0 == first && prev ~ /^```/ { inb=1 }
+    inb && /^```[[:space:]]*$/ { exit }
+    inb { print }
+    { prev=$0 }
+  ' "$TMP/base.md"
+}
+
+# Slice from the first occurrence of line $1 (anywhere) to the next closing fence, optionally
+# stopping AFTER line $2. Used where only PART of a block moved, or where the block's own first line
+# stayed behind in SKILL.md as a placeholder/template — both stated in the script's own header.
+slice_part() {
+  awk -v first="$1" -v last="$2" '
+    !inb && $0 == first { inb=1 }
+    inb && /^```[[:space:]]*$/ { exit }
+    inb { print; if (last != "" && $0 == last) exit }
+  ' "$TMP/base.md"
+}
+
+fail=0
+MODE=whole
+FROM=""
+TO=""
+check() {   # $1 = script name, $2 = first body line, $3.. = sed substitution exprs
+  local script="$1" first="$2"; shift 2
+  if [ "$MODE" = part ]; then slice_part "$FROM" "$TO" > "$TMP/base.block"; first="$FROM"; else slice "$first" > "$TMP/base.block"; fi
+  MODE=whole; FROM=""; TO=""
+  if [ ! -s "$TMP/base.block" ]; then echo "NO-BASE-BLOCK  $script"; fail=1; return; fi
+  if [ "$#" -gt 0 ]; then sed "$@" "$TMP/base.block" > "$TMP/base.expected"; else cp "$TMP/base.block" "$TMP/base.expected"; fi
+  awk -v first="$first" 'f{print} $0 == first && !f {f=1; print}' "$DIR/$script" > "$TMP/moved"
+  if diff -u "$TMP/base.expected" "$TMP/moved" > "$TMP/d"; then
+    echo "MATCH          $script ($(wc -l < "$TMP/base.expected" | tr -d ' ') lines)"
+  else
+    echo "DRIFT          $script"; cat "$TMP/d"; fail=1
+  fi
+}
+
+check step1-candidate-pool.sh    "# p0 first; only fall through to p1, then p2 if a bucket is empty of unassigned issues"
+check step1-parent-resolve.sh    "# \`-i\` keeps the status line on stdout even when gh exits non-zero, which is the whole point:" -e 's|<N>|$N|g'
+check step3-delegated-claim.sh   "# §CLI — resolve the shim by path; \`pipeline-cli\` is NOT on PATH (ADR 0207; #3314)." -e 's|--issue <N>|--issue $N|g' -e 's|#<N>|#$N|g'
+check step4-preflight.sh         "# fail closed unless we're in a LINKED git worktree (not the primary checkout)"
+check step4d-blessed-surfaces.sh "# blessed surface-ids: the keys of the committed pointer's \`surfaces\` map (ADR 0183)."
+check step5-acceptance-criteria.sh "# enumerate #N's acceptance criteria — the checklist you must satisfy in FULL to emit a closing keyword" -e 's|issues/<N>|issues/$N|g'
+check step6-progress-comment.sh  "# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback." -e 's|write-code-<N>|write-code-$N|' -e 's|"<N>"|"$N"|' -e 's|issues/<N>/comments|issues/$N/comments|'
+check step7-epic-handoff.sh      "# compose under the per-run scratch namespace (§SP), never a fixed /tmp leaf — a concurrent" -e 's|write-code-<N>|write-code-$N|' -e 's|"<N>"|"$N"|' -e 's|issues/<EPIC>/comments|issues/$EPIC/comments|'
+check stepR2-inline-comments.sh  "ME=\$(gh api user --jq '.login')   # don't action your own author-side replies"
+check stepR-round-count.sh       "# how many distinct gate-FAIL ROUNDS has this PR already accrued (both namespaces)?"
+check stepR-frozen-ac.sh         "# does this round's resolving FAIL table carry a review-appended AC tagged at/after the final round?"
+
+# Partial moves — the base block's own first line stayed in SKILL.md as a placeholder or template.
+MODE=part FROM="# the epic body carries the plan + the ## Dependencies topology" \
+  check step2-epic-read.sh ""
+MODE=part FROM="# 0. Fail-closed on a missing token: the claim comment is the ONLY agent-distinguishable signal" \
+  check step3-direct-claim.sh "" -e 's|tracker claim <N>|tracker claim $N|' -e 's|--issue <N>|--issue $N|' -e 's|#<N>|#$N|g'
+check step3_5-my-claim.sh        "# the claim token this run owns work under: the orchestrator's threaded delegated token if it"
+MODE=part FROM="# Fetch the base fresh, and FAIL-LOUD if it doesn't run: FETCH_HEAD is what the branch below is" \
+  check step4-branch.sh "" -e 's|<slug-for-issue-N>-\$(uuidgen|$SLUG-$(uuidgen|'
+MODE=part FROM="# the child's containment marker; a missing line reads as \`none\` (formats §2 tolerant-read rule)" \
+  check step4b-containment.sh "" -e 's|issues/<N>|issues/$N|'
+MODE=part FROM="N=\$(gh api repos/\$REPO/pulls/\$PR \\" \
+  check stepR2-linked-issue.sh ""
+MODE=part FROM="# re-assert the mis-attribution guard (Step 3.5) before the resubmit push — a between-calls cwd" \
+  check stepR3-push-and-note.sh ""
+# Halves of the Step-5 block: the mechanical prelude moved, the `gh pr create` heredoc did not.
+MODE=part FROM="# RE-DERIVE the branch LIVE from the worktree — never a cached/shared-file value (see the" \
+  TO="claim_is_mine \"<N>\" || { echo \"refusing to open a PR against #<N> — not my claim (Step 3.5)\"; exit 1; }" \
+  check step5-push.sh "" -e 's|"<N>"|"$N"|' -e 's|#<N>|#$N|g'
+
+MODE=part FROM="# claim_is_mine <N>: resolve the EARLIEST AUTHORIZED claim marker on #N (issue or PR) and assert" TO="}" \
+  check step3_5-claim-is-mine.sh ""
+MODE=part FROM="# the last mutation of the run — retract OUR OWN claim marker on the issue we just built." \
+  check step8-claim-release.sh "" -e 's|"<N>"|"$N"|'
+
+# NOT mechanically checked here, and why — each is stated in the script's own header:
+#   step5-seam-checks.sh    the two `<N>` sites inside single-quoted EREs are spliced by
+#                           quote-concatenation ('…#'"$N"'\b'), so the line differs from base while
+#                           the PATTERN bytes do not — a textual diff cannot express that.
+#   stepR2-fail-body.sh     the block hardcoded $CODE_FAIL_JSON with a prose "swap per namespace"
+#                           instruction; the script indirects through a named variable instead.
+#   stepR3-thread-reply.sh  the reply body was a per-run template, so it arrives as $1.
+
+rm -rf "$TMP"
+[ "$fail" -eq 0 ] || { echo "FAIL: at least one script drifted from its base block."; exit 1; }
+echo "OK: every checked script is a byte-move of its base block (modulo the declared metavariable seams)."

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
@@ -8,13 +8,13 @@
 #    — the script produced no answer at all, so there is nothing for a caller to mistake for one. A
 #    printed message is not proof, which is why the byte count is measured rather than eyeballed.
 #
-# 2. ZERO COVERAGE DELTA for the two guards this extraction NARROWS. `cli-invocation-guard` is
-#    fence-scoped to markdown (#4486), so it does not inspect a `.sh` and its clean run is VACUOUS
-#    over these files — the delta is zero only if they carry nothing it would have flagged, which is
-#    what the first grep measures. `leak-guard` now scans `.sh` as a second surface (#4507 landed
-#    SHELL_SUFFIXES), so its coverage of these scripts is real rather than vacuous; the second grep
-#    stays as an independent, deliberately-broader restatement of every arm of the shared matcher.
-#    This harness is itself DOC_SELF_EXEMPT there — see the scope note in section 2.
+# 2. ZERO COVERAGE DELTA for the two guards that follow this shell out of SKILL.md into `scripts/`.
+#    Both reach a `.sh` at this head: `cli-invocation-guard` scans a shell file as one implicit
+#    whole-file fence (#4486 is CLOSED, fixed by #4494), and `leak-guard` scans `.sh` as a second
+#    surface (#4507 landed SHELL_SUFFIXES). So the CI-enforced coverage of these scripts is real,
+#    not vacuous, and neither grep below is the only thing standing over them — each is an
+#    independent, deliberately-broader restatement of a guard's matcher, run at authoring time
+#    instead of merge time. This harness is itself DOC_SELF_EXEMPT in leak-guard — see section 2.
 #
 # Usage:  bash claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
 set -uo pipefail

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1090,SC2016
+# Reviewer-runnable proof of the two properties a byte-move can still get wrong.
+#
+# 1. §ZS — no caller can read a script's FAILURE as a permissive answer (ADR 0092; #4231/#4010/#4219).
+#    Every script that takes a metavariable seam is sourced with NO argument, and BOTH observables are
+#    captured: the EXIT CODE and the STDOUT BYTE COUNT. The required shape is `rc != 0 && bytes == 0`
+#    — the script produced no answer at all, so there is nothing for a caller to mistake for one. A
+#    printed message is not proof, which is why the byte count is measured rather than eyeballed.
+#
+# 2. ZERO COVERAGE DELTA for the two guards this extraction NARROWS. `cli-invocation-guard` is
+#    fence-scoped to markdown (#4486) and `leak-guard`'s DOC_SUFFIXES is markdown-only (#4496), so
+#    neither inspects a `.sh`. Their clean runs are therefore VACUOUS over these files — the delta is
+#    zero only if the files carry nothing either guard would have flagged. That is what is grepped:
+#    zero bare `pipeline-cli` invocations outside a comment, and zero `/Users/<name>` or `/home/<name>`
+#    paths, anywhere in the new scripts.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
+set -uo pipefail
+
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+TMP="$(mktemp -d)"
+fail=0
+
+echo "=== 1. §ZS: every seam refuses with a NON-ZERO exit and ZERO stdout bytes"
+SEAMED="step1-parent-resolve.sh step2-epic-read.sh step3-delegated-claim.sh step3-direct-claim.sh
+        step4-branch.sh step4b-containment.sh step5-acceptance-criteria.sh step5-push.sh
+        step5-seam-checks.sh step6-progress-comment.sh step7-epic-handoff.sh step8-claim-release.sh
+        stepR2-branch-rebase.sh stepR3-thread-reply.sh"
+for s in $SEAMED; do
+  ( . "$DIR/$s" ) > "$TMP/out" 2> "$TMP/err"
+  rc=$?
+  bytes=$(wc -c < "$TMP/out" | tr -d ' ')
+  if [ "$rc" -ne 0 ] && [ "$bytes" -eq 0 ]; then
+    printf 'OK    %-34s rc=%-3s stdout-bytes=%s (stderr-bytes=%s)\n' "$s" "$rc" "$bytes" \
+      "$(wc -c < "$TMP/err" | tr -d ' ')"
+  else
+    printf 'BAD   %-34s rc=%-3s stdout-bytes=%s — a caller could read this as an ANSWER\n' "$s" "$rc" "$bytes"
+    fail=1
+  fi
+done
+
+echo "=== 2. zero-coverage-delta greps over the extracted scripts"
+# Scope: the EXTRACTED scripts. The two `verify-*.sh` proof harnesses are excluded, because they must
+# spell the forbidden tokens out as patterns to test for them — the same self-exemption leak-guard's
+# own DOC_SELF_EXEMPT applies to its own source. Paths are printed repo-relative on purpose: a
+# machine-local absolute path must not reach a PR body either.
+cd "$(git rev-parse --show-toplevel)" || exit 1
+REL=claude-plugins/kampus-pipeline/skills/write-code/scripts
+MOVED=$(git ls-files "$REL/*.sh" | grep -v "/verify-")
+echo "      scope: $(printf '%s\n' "$MOVED" | wc -l | tr -d ' ') extracted script(s) under $REL"
+# A bare `pipeline-cli` INVOCATION is what cli-invocation-guard forbids: the token not preceded by a
+# path/word character, on a line that is not a comment. Its own matcher skips comment-only lines, so
+# the backtick-quoted `pipeline-cli` mentions inside the moved comments are out of scope for both.
+# shellcheck disable=SC2086
+hits=$(grep -nE '(^|[^[:alnum:]./@_-])pipeline-cli([[:space:]]|$)' $MOVED | grep -vE ':[[:space:]]*#' || true)
+if [ -z "$hits" ]; then
+  echo "OK    zero bare \`pipeline-cli\` invocations outside a comment (every CLI reach reads \"\$PCLI\", resolved by path)"
+else
+  echo "BAD   bare invocation(s):"; printf '%s\n' "$hits"; fail=1
+fi
+# shellcheck disable=SC2086
+hits=$(grep -nE '/(Users|home)/[A-Za-z0-9._-]+' $MOVED || true)
+if [ -z "$hits" ]; then
+  echo "OK    zero /Users/<name> or /home/<name> paths (nothing leak-guard would have flagged)"
+else
+  echo "BAD   machine-local path(s):"; printf '%s\n' "$hits"; fail=1
+fi
+
+rm -rf "$TMP"
+[ "$fail" -eq 0 ] || { echo "FAIL"; exit 1; }
+echo "OK: both properties hold."

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
@@ -12,8 +12,8 @@
 #    fence-scoped to markdown (#4486) and `leak-guard`'s DOC_SUFFIXES is markdown-only (#4496), so
 #    neither inspects a `.sh`. Their clean runs are therefore VACUOUS over these files — the delta is
 #    zero only if the files carry nothing either guard would have flagged. That is what is grepped:
-#    zero bare `pipeline-cli` invocations outside a comment, and zero `/Users/<name>` or `/home/<name>`
-#    paths, anywhere in the new scripts.
+#    zero bare `pipeline-cli` invocations outside a comment, and zero hits for ANY arm of leak-guard's
+#    shared machine-local path matcher, anywhere in the new scripts.
 #
 # Usage:  bash claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
 set -uo pipefail
@@ -23,10 +23,14 @@ TMP="$(mktemp -d)"
 fail=0
 
 echo "=== 1. §ZS: every seam refuses with a NON-ZERO exit and ZERO stdout bytes"
+# All 15 scripts that take a positional seam — including `stepR2-fail-body.sh`, whose parameter is
+# DEFAULTED rather than required. A default is not an exemption: the property under test is that a
+# no-argument source produces no answer, and it holds there too, so excluding it left the harness
+# claiming 14/15 of its own scope (#4503 review).
 SEAMED="step1-parent-resolve.sh step2-epic-read.sh step3-delegated-claim.sh step3-direct-claim.sh
         step4-branch.sh step4b-containment.sh step5-acceptance-criteria.sh step5-push.sh
         step5-seam-checks.sh step6-progress-comment.sh step7-epic-handoff.sh step8-claim-release.sh
-        stepR2-branch-rebase.sh stepR3-thread-reply.sh"
+        stepR2-branch-rebase.sh stepR2-fail-body.sh stepR3-thread-reply.sh"
 for s in $SEAMED; do
   ( . "$DIR/$s" ) > "$TMP/out" 2> "$TMP/err"
   rc=$?
@@ -59,13 +63,33 @@ if [ -z "$hits" ]; then
 else
   echo "BAD   bare invocation(s):"; printf '%s\n' "$hits"; fail=1
 fi
-# shellcheck disable=SC2086
-hits=$(grep -nE '/(Users|home)/[A-Za-z0-9._-]+' $MOVED || true)
-if [ -z "$hits" ]; then
-  echo "OK    zero /Users/<name> or /home/<name> paths (nothing leak-guard would have flagged)"
-else
-  echo "BAD   machine-local path(s):"; printf '%s\n' "$hits"; fail=1
-fi
+# EVERY arm of leak-guard's shared path matcher, not one of them. Grepping only the `/Users/` arm
+# proved the delta zero for a sixth of the guard it clears, leaving the other five to be re-derived by
+# hand at review time (#4503 review). ERE has no lookbehind, so each arm below is the guard's shape
+# with its narrowing lookarounds DROPPED — deliberately broader than the guard, since a proof of zero
+# hits under a broader pattern implies zero under the narrower one. Source of truth for the shapes:
+# packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts.
+ARMS='absolute home path (/Users/<name>, /home/<name>)::/(Users|home)/[A-Za-z0-9._-]+
+agent/tool home dir (~/.usirin, ~/.agent)::~/\.(usirin|agent)
+agent/tool home dir (~/.claude internals)::~/\.claude
+home-dir sibling-repo clone (~/code/...)::~/code/
+home-dir sibling-repo clone (~/<root>/<host>/<user>/<repo>)::~/[A-Za-z0-9._-]+/[A-Za-z0-9-]+\.[A-Za-z][A-Za-z]+/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+
+vault path (/vault/...)::/vault/
+comment-surface temp root (/var/folders/...)::/var/folders/[A-Za-z0-9._/-]+
+comment-surface temp root (/private/tmp, /private/var)::/private/(tmp|var)/[A-Za-z0-9._/-]+
+comment-surface temp root (bare /tmp)::/tmp/[A-Za-z0-9._/-]+'
+while IFS= read -r arm; do
+  reason="${arm%%::*}"; pattern="${arm#*::}"
+  # shellcheck disable=SC2086
+  hits=$(grep -nE "$pattern" $MOVED || true)
+  if [ -z "$hits" ]; then
+    printf 'OK    zero hits — %s\n' "$reason"
+  else
+    printf 'BAD   %s:\n' "$reason"; printf '%s\n' "$hits"; fail=1
+  fi
+done <<EOF
+$ARMS
+EOF
 
 rm -rf "$TMP"
 [ "$fail" -eq 0 ] || { echo "FAIL"; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
@@ -9,11 +9,12 @@
 #    printed message is not proof, which is why the byte count is measured rather than eyeballed.
 #
 # 2. ZERO COVERAGE DELTA for the two guards this extraction NARROWS. `cli-invocation-guard` is
-#    fence-scoped to markdown (#4486) and `leak-guard`'s DOC_SUFFIXES is markdown-only (#4496), so
-#    neither inspects a `.sh`. Their clean runs are therefore VACUOUS over these files — the delta is
-#    zero only if the files carry nothing either guard would have flagged. That is what is grepped:
-#    zero bare `pipeline-cli` invocations outside a comment, and zero hits for ANY arm of leak-guard's
-#    shared machine-local path matcher, anywhere in the new scripts.
+#    fence-scoped to markdown (#4486), so it does not inspect a `.sh` and its clean run is VACUOUS
+#    over these files — the delta is zero only if they carry nothing it would have flagged, which is
+#    what the first grep measures. `leak-guard` now scans `.sh` as a second surface (#4507 landed
+#    SHELL_SUFFIXES), so its coverage of these scripts is real rather than vacuous; the second grep
+#    stays as an independent, deliberately-broader restatement of every arm of the shared matcher.
+#    This harness is itself DOC_SELF_EXEMPT there — see the scope note in section 2.
 #
 # Usage:  bash claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
 set -uo pipefail
@@ -46,9 +47,9 @@ done
 
 echo "=== 2. zero-coverage-delta greps over the extracted scripts"
 # Scope: the EXTRACTED scripts. The two `verify-*.sh` proof harnesses are excluded, because they must
-# spell the forbidden tokens out as patterns to test for them — the same self-exemption leak-guard's
-# own DOC_SELF_EXEMPT applies to its own source. Paths are printed repo-relative on purpose: a
-# machine-local absolute path must not reach a PR body either.
+# spell the forbidden tokens out as patterns to test for them — which is also why this file carries a
+# DOC_SELF_EXEMPT entry now that leak-guard reaches `.sh`, mirroring path-matcher.ts. Paths are
+# printed repo-relative on purpose: a machine-local absolute path must not reach a PR body either.
 cd "$(git rev-parse --show-toplevel)" || exit 1
 REL=claude-plugins/kampus-pipeline/skills/write-code/scripts
 MOVED=$(git ls-files "$REL/*.sh" | grep -v "/verify-")

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
@@ -53,6 +53,22 @@ const CLAIM_WRITERS = [
 	".claude/workflows/drive-issue.js",
 ];
 
+/**
+ * The ordering pin's population, DECLARED rather than derived-and-trusted — exactly the files whose
+ * procedure writes layer one today. `writerSurface` deliberately stops at the sibling `scripts/` dir
+ * (see below), so extracting a write into `shared/scripts/**` drops that file out of the ordering
+ * scope *silently* — the same silent-coverage-loss class (#4509) reproducing inside its own remedy,
+ * and reachable today because this repo is actively moving fenced shell into `shared/scripts/`.
+ * Pinning the membership makes the drop-out RED: a writer that leaves, or an undeclared one that
+ * arrives, fails here and forces the surface (or this list) to be reconciled on purpose.
+ */
+const LAYER_ONE_WRITING_FILES = [
+	"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+	"claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-delegated-claim.sh",
+	"claude-plugins/kampus-pipeline/skills/write-code/scripts/step3-direct-claim.sh",
+	".claude/workflows/drive-issue.js",
+];
+
 interface SurfaceFile {
 	readonly rel: string;
 	readonly content: string;
@@ -69,7 +85,8 @@ interface SurfaceFile {
  *
  * Sibling-scoped on purpose, NOT the whole plugin tree: `shared/scripts/` is a library many surfaces
  * call, so folding it into every caller's surface would assert one shared half-procedure against
- * every writer's own ordering rule.
+ * every writer's own ordering rule. That boundary holds in one direction only, and the residual is
+ * covered by declared membership, not by this function — see `LAYER_ONE_WRITING_FILES`.
  */
 const writerSurface = (rel: string): ReadonlyArray<SurfaceFile> => {
 	const scriptsRel = join(dirname(rel), "scripts");
@@ -93,9 +110,19 @@ const sourcedScripts = (text: string, rel: string): ReadonlyArray<SurfaceFile> =
 		.filter((f) => existsSync(join(REPO_ROOT, f)))
 		.map((f) => ({rel: f, content: readFileSync(join(REPO_ROOT, f), "utf8")}));
 
-/** §7 layer one — the assignee write, through the one verb or (still matchable) the raw POST. */
-const LAYER_ONE_WRITE =
-	/(?:gh api -X POST[^\n]*\/assignees|(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b)/;
+/**
+ * §7 layer one — the assignee write, in two deliberately DIFFERENT vocabularies. Keep them apart:
+ * collapsing them into one shared constant is what silently widened the #4298 one-verb pin (a
+ * tidy-up hoist that let a hand-rolled assignees POST pass the very test that forbids it).
+ * `LAYER_ONE_VERB` is the one sanctioned form, and is what the #4298 pin asserts. `ANY_WRITE` also
+ * admits the raw POST so the #4015 *ordering* pin still populates over an un-migrated corpus — a
+ * tolerance that belongs to a population predicate, never to the pin forbidding the raw form. It is
+ * derived from the verb so it can only ever be the wider of the two.
+ */
+const LAYER_ONE_VERB = /(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b/;
+const LAYER_ONE_ANY_WRITE = new RegExp(
+	`(?:gh api -X POST[^\\n]*\\/assignees|${LAYER_ONE_VERB.source})`,
+);
 /**
  * The claim verb's INVOCATION (verb + its issue argument), not a prose mention of it — a citation
  * elsewhere in the file must not satisfy an ordering claim about the procedure. `$N` is the extracted
@@ -196,14 +223,18 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 		// assign` since #4298 — the raw POST stays matchable so the pin survives an un-migrated corpus.
 		// Fail closed on zero scope (ADR 0092).
 		const surfaces = CLAIM_WRITERS.map((rel) => writerSurface(rel));
-		const selfAssigning = surfaces.flat().filter(({content}) => LAYER_ONE_WRITE.test(content));
-		assert.isAbove(selfAssigning.length, 0, "expected at least one self-assigning claim writer");
+		const selfAssigning = surfaces.flat().filter(({content}) => LAYER_ONE_ANY_WRITE.test(content));
+		assert.deepStrictEqual(
+			selfAssigning.map(({rel}) => rel).sort(),
+			[...LAYER_ONE_WRITING_FILES].sort(),
+			"the ordering pin's population drifted from the declared one — a layer-one write left the scanned surface, or an undeclared one arrived. Reconcile deliberately; do not silently accept a smaller scope (also the ADR-0092 zero-scope guard for this pin)",
+		);
 
 		// The ordering is pinned PER FILE, because after the extraction one branch's whole procedure is
 		// one file — concatenating a surface would let a `tracker claim` in the direct-path script
 		// satisfy an ordering claim about the delegated one, which is a different procedure.
 		for (const {rel, content} of selfAssigning) {
-			const assignAt = content.search(LAYER_ONE_WRITE);
+			const assignAt = content.search(LAYER_ONE_ANY_WRITE);
 			const claimAt = content.search(CLAIM_INVOCATION);
 			if (claimAt > -1) {
 				assert.isAbove(
@@ -231,7 +262,7 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 		// …and each writer's surface must still claim SOMEWHERE, so a surface that only ever assigns
 		// cannot pass by having every file take the delegated branch.
 		for (const surface of surfaces) {
-			if (!surface.some(({content}) => LAYER_ONE_WRITE.test(content))) continue;
+			if (!surface.some(({content}) => LAYER_ONE_ANY_WRITE.test(content))) continue;
 			assert.isTrue(
 				surface.some(({content}) => CLAIM_INVOCATION.test(content)),
 				`${surface[0]?.rel} must invoke the claim-write verb on the issue`,
@@ -257,7 +288,7 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 				writerSurface(rel)
 					.map(({content}) => content)
 					.join("\n"),
-				LAYER_ONE_WRITE,
+				LAYER_ONE_VERB,
 				`${rel} (or the scripts/ shell extracted out of it) must write the §7 layer-one availability gate through \`pipeline-cli claim assign\``,
 			);
 		}
@@ -268,7 +299,7 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 		assert.isAbove(delegatedAt, -1, "write-code must keep its delegated-claim branch");
 		assert.isAbove(directAt, delegatedAt, "write-code must keep its direct-path branch after it");
 		const delegated = skill.slice(delegatedAt, directAt);
-		if (!LAYER_ONE_WRITE.test(delegated)) {
+		if (!LAYER_ONE_VERB.test(delegated)) {
 			// The branch's write now lives in the script the branch sources, so follow the invocation
 			// into it. Fail closed when the slice resolves to no script at all (ADR 0092): a heading pair
 			// that reaches nothing is a broken scan, not a branch that passes.
@@ -279,7 +310,7 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 				"write-code's DELEGATED branch neither writes layer one inline nor sources a resolvable script",
 			);
 			assert.isTrue(
-				followed.some(({content}) => LAYER_ONE_WRITE.test(content)),
+				followed.some(({content}) => LAYER_ONE_VERB.test(content)),
 				"write-code's DELEGATED branch must write layer one itself — skipping it is what left an issue `status:triaged` + unassigned with its PR in review (#4298)",
 			);
 		}

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
@@ -10,7 +10,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import {tmpdir} from "node:os";
-import {join} from "node:path";
+import {dirname, join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
 import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts";
@@ -52,6 +52,58 @@ const CLAIM_WRITERS = [
 	"claude-plugins/kampus-pipeline/skills/write-code/SKILL.md",
 	".claude/workflows/drive-issue.js",
 ];
+
+interface SurfaceFile {
+	readonly rel: string;
+	readonly content: string;
+}
+
+/**
+ * A claim writer's SURFACE is its own text plus the shell that was extracted out of it into the
+ * `scripts/*.sh` beside it (epic #4435 phase 1). Reading the named file alone silently drops a claim
+ * site the moment an extraction moves one: both of write-code's `claim assign` calls left `SKILL.md`
+ * for `scripts/step3-{delegated,direct}-claim.sh`, which reddened the layer-one pin on a pure
+ * relocation and — worse — dropped the whole skill out of the ordering pin's scope while it stayed
+ * green. Same shape #4470 named and #4448 fixed for `validate-gate-path-drift` and
+ * `class-probe-consumers`; this is that widening for the claim pins.
+ *
+ * Sibling-scoped on purpose, NOT the whole plugin tree: `shared/scripts/` is a library many surfaces
+ * call, so folding it into every caller's surface would assert one shared half-procedure against
+ * every writer's own ordering rule.
+ */
+const writerSurface = (rel: string): ReadonlyArray<SurfaceFile> => {
+	const scriptsRel = join(dirname(rel), "scripts");
+	const scriptsAbs = join(REPO_ROOT, scriptsRel);
+	const scripts = existsSync(scriptsAbs)
+		? readdirSync(scriptsAbs)
+				.filter((entry) => entry.endsWith(".sh"))
+				.sort()
+				.map((entry) => join(scriptsRel, entry))
+		: [];
+	return [rel, ...scripts].map((f) => ({
+		rel: f,
+		content: readFileSync(join(REPO_ROOT, f), "utf8"),
+	}));
+};
+
+/** The `scripts/*.sh` a stretch of procedure text sources (`. "$<SKILL>_SCRIPTS/<name>.sh"`). */
+const sourcedScripts = (text: string, rel: string): ReadonlyArray<SurfaceFile> =>
+	[...text.matchAll(/_SCRIPTS\}?\/([\w.-]+\.sh)/g)]
+		.map((m) => join(dirname(rel), "scripts", m[1] as string))
+		.filter((f) => existsSync(join(REPO_ROOT, f)))
+		.map((f) => ({rel: f, content: readFileSync(join(REPO_ROOT, f), "utf8")}));
+
+/** §7 layer one — the assignee write, through the one verb or (still matchable) the raw POST. */
+const LAYER_ONE_WRITE =
+	/(?:gh api -X POST[^\n]*\/assignees|(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b)/;
+/**
+ * The claim verb's INVOCATION (verb + its issue argument), not a prose mention of it — a citation
+ * elsewhere in the file must not satisfy an ordering claim about the procedure. `$N` is the extracted
+ * form: a moved block's `<N>` metavariable becomes the script's positional parameter (#4449).
+ */
+const CLAIM_INVOCATION =
+	/(?:pipeline-cli|"\$PCLI")\s+tracker\s+claim\s+(?:<N>|\$\{issue\}|"?\$N"?)/;
+const IS_MINE = /(?:pipeline-cli|"\$PCLI")\s+claim\s+is-mine\b/;
 
 // The full live corpus the adoption-lint.yml job scans: every .md/.sh under the plugin
 // dir plus the orchestrator's drive-issue.js (the declared mirror).
@@ -116,17 +168,19 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 	// `tracker claim` decision reds a NEW such writer; this pins the three that already exist.
 	it("every claim-marker writer cites `pipeline-cli tracker claim` and hand-composes no body", () => {
 		for (const rel of CLAIM_WRITERS) {
-			const content = readFileSync(join(REPO_ROOT, rel), "utf8");
+			const surface = writerSurface(rel);
 			assert.match(
-				content,
-				/pipeline-cli\s+tracker\s+claim\b/,
-				`${rel} must cite the claim-write verb`,
+				surface.map(({content}) => content).join("\n"),
+				/(?:pipeline-cli|"\$PCLI")\s+tracker\s+claim\b/,
+				`${rel} (or the scripts/ shell extracted out of it) must cite the claim-write verb`,
 			);
-			assert.notMatch(
-				content,
-				/body=["'`]?claim:/,
-				`${rel} must not hand-compose a claim-marker body (it would skip the presence stamp)`,
-			);
+			for (const {rel: f, content} of surface) {
+				assert.notMatch(
+					content,
+					/body=["'`]?claim:/,
+					`${f} must not hand-compose a claim-marker body (it would skip the presence stamp)`,
+				);
+			}
 		}
 	});
 
@@ -137,43 +191,53 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 	// and the cleanup unassign then removes the INCUMBENT's assignment. Pin the only ordering that
 	// makes that unrepresentable — claim first, assign only on the verb's exit 0, never unassign.
 	it("claims before it writes layer one, so a defer cannot strip a live incumbent's assignment", () => {
-		// scope: the writers whose procedure actually writes layer one (a surface that only
-		// describes the claim has no ordering to pin). The write is `pipeline-cli claim assign`
-		// since #4298 — the raw POST stays matchable so the pin survives an un-migrated corpus.
+		// scope: across each writer's SURFACE, the files whose procedure actually writes layer one (a
+		// file that only describes the claim has no ordering to pin). The write is `pipeline-cli claim
+		// assign` since #4298 — the raw POST stays matchable so the pin survives an un-migrated corpus.
 		// Fail closed on zero scope (ADR 0092).
-		const LAYER_ONE_WRITE =
-			/(?:gh api -X POST[^\n]*\/assignees|(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b)/;
-		const selfAssigning = CLAIM_WRITERS.map((rel) => ({
-			rel,
-			content: readFileSync(join(REPO_ROOT, rel), "utf8"),
-		})).filter(({content}) => LAYER_ONE_WRITE.test(content));
+		const surfaces = CLAIM_WRITERS.map((rel) => writerSurface(rel));
+		const selfAssigning = surfaces.flat().filter(({content}) => LAYER_ONE_WRITE.test(content));
 		assert.isAbove(selfAssigning.length, 0, "expected at least one self-assigning claim writer");
 
+		// The ordering is pinned PER FILE, because after the extraction one branch's whole procedure is
+		// one file — concatenating a surface would let a `tracker claim` in the direct-path script
+		// satisfy an ordering claim about the delegated one, which is a different procedure.
 		for (const {rel, content} of selfAssigning) {
-			// the verb INVOCATION (verb + its issue argument), not a prose mention of the verb —
-			// a citation earlier in the file must not satisfy an ordering claim about the procedure.
-			// The invocation resolves the shim through §CLI's `$PCLI`; the bare `pipeline-cli` form
-			// stays matchable so this pin survives a corpus that has not yet been migrated (#3314).
-			const claimAt = content.search(
-				/(?:pipeline-cli|"\$PCLI")\s+tracker\s+claim\s+(?:<N>|\$\{issue\})/,
-			);
-			assert.isAbove(claimAt, -1, `${rel} must invoke the claim-write verb on the issue`);
-			assert.isAbove(
-				content.slice(claimAt).search(LAYER_ONE_WRITE),
-				-1,
-				`${rel} must write layer one AFTER it claims — assign-then-claim makes the defer path unassign the live incumbent (#4015)`,
-			);
-			// A layer-one write EARLIER in the file is the delegated branch, where the claim was won
-			// before the spawn — safe only if that branch first proves the lane is ours. Ungated, it
-			// is the same assign-then-claim hazard wearing a different hat.
-			const before = content.slice(0, claimAt);
-			if (LAYER_ONE_WRITE.test(before)) {
+			const assignAt = content.search(LAYER_ONE_WRITE);
+			const claimAt = content.search(CLAIM_INVOCATION);
+			if (claimAt > -1) {
+				assert.isAbove(
+					assignAt,
+					claimAt,
+					`${rel} must write layer one AFTER it claims — assign-then-claim makes the defer path unassign the live incumbent (#4015)`,
+				);
+			} else {
+				// A layer-one write with no claim of its own is the DELEGATED branch, where the claim was
+				// won before the spawn — safe only if that branch first proves the lane is ours. Ungated,
+				// it is the same assign-then-claim hazard wearing a different hat.
+				const isMineAt = content.search(IS_MINE);
+				assert.isAbove(
+					isMineAt,
+					-1,
+					`${rel} writes layer one without claiming — sound only on the delegated path, which must first prove the lane is ours (#4298)`,
+				);
 				assert.isBelow(
-					before.search(/(?:pipeline-cli|"\$PCLI")\s+claim\s+is-mine\b/),
-					before.search(LAYER_ONE_WRITE),
-					`${rel} writes layer one before its own claim — that is only sound on the delegated path, where ownership must be proven first (#4298)`,
+					isMineAt,
+					assignAt,
+					`${rel} writes layer one before it proves the lane is ours (#4298)`,
 				);
 			}
+		}
+		// …and each writer's surface must still claim SOMEWHERE, so a surface that only ever assigns
+		// cannot pass by having every file take the delegated branch.
+		for (const surface of surfaces) {
+			if (!surface.some(({content}) => LAYER_ONE_WRITE.test(content))) continue;
+			assert.isTrue(
+				surface.some(({content}) => CLAIM_INVOCATION.test(content)),
+				`${surface[0]?.rel} must invoke the claim-write verb on the issue`,
+			);
+		}
+		for (const {rel, content} of surfaces.flat()) {
 			assert.notMatch(
 				content,
 				/gh api -X DELETE[^\n]*\/assignees/,
@@ -190,24 +254,35 @@ describe("adoption-lint check — fail-closed exit contract (ADR 0092)", {
 	it("writes layer one through the one verb, and the delegated branch carries its own", () => {
 		for (const rel of CLAIM_WRITERS) {
 			assert.match(
-				readFileSync(join(REPO_ROOT, rel), "utf8"),
-				/(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b/,
-				`${rel} must write the §7 layer-one availability gate through \`pipeline-cli claim assign\``,
+				writerSurface(rel)
+					.map(({content}) => content)
+					.join("\n"),
+				LAYER_ONE_WRITE,
+				`${rel} (or the scripts/ shell extracted out of it) must write the §7 layer-one availability gate through \`pipeline-cli claim assign\``,
 			);
 		}
-		const skill = readFileSync(
-			join(REPO_ROOT, "claude-plugins/kampus-pipeline/skills/write-code/SKILL.md"),
-			"utf8",
-		);
+		const skillRel = "claude-plugins/kampus-pipeline/skills/write-code/SKILL.md";
+		const skill = readFileSync(join(REPO_ROOT, skillRel), "utf8");
 		const delegatedAt = skill.search(/^### Delegated claim/m);
 		const directAt = skill.search(/^### Direct path/m);
 		assert.isAbove(delegatedAt, -1, "write-code must keep its delegated-claim branch");
 		assert.isAbove(directAt, delegatedAt, "write-code must keep its direct-path branch after it");
-		assert.match(
-			skill.slice(delegatedAt, directAt),
-			/(?:pipeline-cli|"\$PCLI")\s+claim\s+assign\b/,
-			"write-code's DELEGATED branch must write layer one itself — skipping it is what left an issue `status:triaged` + unassigned with its PR in review (#4298)",
-		);
+		const delegated = skill.slice(delegatedAt, directAt);
+		if (!LAYER_ONE_WRITE.test(delegated)) {
+			// The branch's write now lives in the script the branch sources, so follow the invocation
+			// into it. Fail closed when the slice resolves to no script at all (ADR 0092): a heading pair
+			// that reaches nothing is a broken scan, not a branch that passes.
+			const followed = sourcedScripts(delegated, skillRel);
+			assert.isAbove(
+				followed.length,
+				0,
+				"write-code's DELEGATED branch neither writes layer one inline nor sources a resolvable script",
+			);
+			assert.isTrue(
+				followed.some(({content}) => LAYER_ONE_WRITE.test(content)),
+				"write-code's DELEGATED branch must write layer one itself — skipping it is what left an issue `status:triaged` + unassigned with its PR in review (#4298)",
+			);
+		}
 	});
 
 	it("exits 3 (zero-scope FAIL) when every handed file is unreadable/missing", async () => {

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -74,6 +74,10 @@ const DOC_SELF_EXEMPT = [
 	// text, not real paths, so routine edits must not trip the guard.
 	"/agents/triager.md",
 	"/skills/report/footer.sh",
+	// A verification harness whose whole job is proving a corpus carries none of the
+	// forbidden shapes, so it must enumerate them as pattern arms — exempt for the same
+	// reason path-matcher.ts is, and unreachable by any narrower fix (#4449).
+	"/skills/write-code/scripts/verify-fail-closed.sh",
 	// Its Lineage section deliberately names ~/code/... sibling-repo clones (the
 	// rebuild provenance), so routine edits to it must not trip the guard.
 	"/CLAUDE.md",

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -274,4 +274,21 @@ describe("surface predicates", () => {
 		assert.isTrue(isSelfExempt(".claude/agents/triager.md"));
 		assert.isFalse(isSelfExempt("README.md"));
 	});
+
+	// The suffix is narrow on purpose: the exemption covers the one verification harness that has
+	// to enumerate the forbidden shapes, and NOT the shell surface it sits on (#4449).
+	it("isSelfExempt: the write-code verify harness is exempt, its sibling scripts are not", () => {
+		const scripts = "claude-plugins/kampus-pipeline/skills/write-code/scripts";
+		assert.isTrue(isSelfExempt(`${scripts}/verify-fail-closed.sh`));
+		assert.isFalse(isSelfExempt(`${scripts}/verify-byte-move.sh`));
+		assert.isFalse(isSelfExempt(`${scripts}/step4-preflight.sh`));
+	});
+
+	it("findLeaks: a non-exempt `.sh` still reds on a planted machine-local path", () =>
+		assert.isTrue(
+			hasLeak(
+				"claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-preflight.sh",
+				'WT="/Users/someone/code/repo"',
+			),
+		));
 });


### PR DESCRIPTION
`write-code/SKILL.md` carried 566 lines of inline shell across 33 fenced blocks. This moves that shell — mechanically, glue and all — into 25 sourced scripts under `claude-plugins/kampus-pipeline/skills/write-code/scripts/`, leaving each step's fenced block as the one-line invocation of its script and every word of *why*-prose exactly where it was. Nothing about how `write-code` behaves changes; the shell just stops being pasted into the agent's context on every build.

Two blocks (139 lines) were deliberately skipped because open PR #4372 edits inside them, and two more (34 lines) stayed put because they are body templates a coder authors per run, not glue. Both are itemised below, and two committed proof harnesses re-derive the byte-move and fail-closed claims instead of asserting them.

Part of #4449. **#4449 remains open** — two of its blocks are skipped here because open PR #4372 edits inside them, so this carries the §9 partial-split marker and no closing keyword, matching #4485 and #4492.

## What moved, and the accounting

Every number below is derived, not estimated — the derivation is the command next to it.

| | count | how it was derived |
| --- | --- | --- |
| column-0 bash fences at base `cb52bd3` | 33 blocks / **566 body lines** | `awk` over `git show cb52bd3:…/SKILL.md`, counting lines between paired `^\`\`\`` delimiters — matches this ticket's own figure exactly |
| relocated into `scripts/` | 25 scripts | `git ls-files …/write-code/scripts/*.sh` minus the two `verify-*.sh` harnesses |
| proven byte-identical by the committed harness | 22 scripts / **302 lines** | `bash …/scripts/verify-byte-move.sh` |
| skipped — open-PR overlap | 2 blocks / **139 lines** | see below |
| retained by design | 4 blocks / **37 lines** | see below |
| `SKILL.md` net delta | **+76 / −387 = −311 lines** | `git diff --numstat cb52bd3 HEAD` |

`SKILL.md`'s remaining column-0 fences hold 221 bash body lines, of which 139 are the two skipped blocks and 37 the retained ones; the balance is invocation lines and their comments.

### Skipped — a block open PR #4372 edits (per the file-overlap rule)

#4372 (`fix(verdict): read and gate resolve ONE in-force verdict, §CP-aware`) has two hunks **inside** blocks this PR would otherwise have relocated, so both are left in the markdown untouched:

- the **Step-1 pre-pick repairable-PR scan** (62 lines) — #4372 inserts the `cp_changed_files` / `CP_FLAG` derivation into it;
- the **repair-mode R1 verdict resolution** (77 lines) — #4372 rewrites its three `verdict read` calls.

`#4449 remains open` after this merges, with exactly these two blocks named as the remainder. Relocating them now would hand #4372 a guaranteed conflict inside the lines it is rewriting.

### Retained by design — templates and literal commands, not glue

- **the `gh pr create` heredoc** (14 lines) — a fill-in-the-blanks PR-body template whose prose the coder authors per run. A script cannot hold it. Its mechanical prelude (branch re-derivation, `verified-push`, the claim guard) *did* move, to `step5-push.sh`.
- **the repair-escalation `gh api …/comments` heredoc** (20 lines) — same shape: a `<criterion>`-carrying escalation body. Moving it would mean converting a quoted `<<'EOF'` into an interpolating heredoc, which is a rewrite of the glue and therefore phase 2.
- **`pnpm typecheck` and `pnpm lint:worktree`** (1 line each) — the point of those two blocks is that they are byte-for-byte the commands CI runs. Wrapping them in a script would put a layer between the skill and the claim it makes.
- **the `claim_is_mine "<N>" && gh api …` calling-convention illustration** (1 line) — kept in the markdown next to `step3_5-claim-is-mine.sh`'s invocation. Relocated, it would be a *runnable* line posting a literal `…` comment.

### Reused rather than duplicated

Step 4b's cycle-doc probe now sources **`shared/scripts/cycle-doc-probe.sh`** (landed by #4489) instead of shipping a skill-local copy of the same four lines — a skill-local duplicate of a shared script is what put PR #4485 through three FAIL rounds. `step5-seam-checks.sh` check (d) still carries its own copy, because the moved block re-derives `$CONTAINMENT`/`$CYCLE_DOC` in *that* Bash call on purpose (#4398) — that duplication is the moved block's own, and collapsing it is phase 2's call.

## Reviewer-runnable verification

```bash
# 1. every script is a byte-move of the fenced block it replaced (diffs against base cb52bd3)
bash claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-byte-move.sh
# 2. no failure path can be read as an answer, and the narrowed guards have zero coverage delta
bash claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
# 3. the guards and validators that read this skill
shellcheck --shell=bash claude-plugins/kampus-pipeline/skills/write-code/scripts/*.sh
bash claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
bash claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
bash claude-plugins/kampus-pipeline/skills/validate-skills.sh
bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
FILES=$(git ls-files 'claude-plugins/**/*.md' 'claude-plugins/**/*.sh' '.claude-plugin/*.json')
./claude-plugins/kampus-pipeline/bin/pipeline-cli gh-phoenix lint-skills $FILES
./claude-plugins/kampus-pipeline/bin/pipeline-cli cli-invocation-guard check $FILES
```

Observed on this head:

| check | exit | note |
| --- | --- | --- |
| `verify-byte-move.sh` | 0 | 22 scripts `MATCH`, 302 lines |
| `verify-fail-closed.sh` | 0 | 15 seams, all `rc=1` with `stdout-bytes=0`; the bare-invocation grep and all nine path arms clean |
| `shellcheck` | 0 | over all 27 files in `scripts/` |
| `validate-cycle-presence.sh` | 0 | 18 checks; scope names all 25 new `.sh` (the #4473 follow-into-scripts) |
| `validate-cycle-absence.sh` | 0 | 14 checks; same scope |
| `validate-skills.sh` | 0 | 30 skills valid |
| `validate-gate-path-drift.sh` | 0 | 34 checks |
| `gh-phoenix lint-skills` | 0 | 123 gh-call / 44 frontmatter / 126 bare-push files scanned; every new `.sh` in all three scopes |
| `cli-invocation-guard check` | 0 | 126 files, 323 runnable fences — **but see the narrowing below** |

## Two guards are NARROWED by this diff — three separate claims

Reporting these green without qualification would be the #4492 defect. Stating them apart:

**Claim 1 — which surfaces narrow.** Two guards do not follow shell into a `.sh`:

- **`cli-invocation-guard` is fence-scoped to markdown.** Its scanner only inspects lines between a fence delimiter whose language is in `RUNNABLE_LANGS`; a `.sh` has no fences, so each of the 25 new files enters `scanned` and contributes **zero** to `fenceCount`. Its `clean` verdict above is therefore **vacuous over every line this PR moved**. Tracked in **#4486 (remains open)**; PR #4494 is in flight widening it.
- **`leak-guard` is markdown-only by extension.** `DOC_SUFFIXES = [".md", ".mdx", ".markdown"]` in `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts`, so a `.sh` is never a doc surface. A security guard's scan surface loses every script added here. Tracked in **#4496 (remains open)**.

**Claim 2 — the coverage delta for THIS diff is provably zero.** Not an assurance; a grep, committed as `verify-fail-closed.sh` §2 and run above:

- **zero bare `pipeline-cli` invocations outside a comment** across all 25 extracted scripts. Every CLI reach is `"$PCLI"`, resolved by path — either the moved `PCLI="${CLAUDE_PLUGIN_ROOT:-…}/bin/pipeline-cli"` line or `common.sh`'s `kp_pcli`. The backtick-quoted `pipeline-cli` mentions that remain are all on `#` comment lines, which the guard's own matcher skips (`COMMENT_ONLY`), so they were never in scope on either side of the move.
- **zero hits for every arm of `leak-guard`'s shared path matcher** across the same 25 files — all six `MACHINE_LOCAL_PATH_PATTERNS` arms plus the three comment-surface `TEMP_PATH_PATTERNS` roots, not just the `/Users/` one. Nothing `leak-guard` would have flagged had it looked, anywhere in its pattern set.

**Claim 3 — where the narrowing is tracked.** #4486 and #4496, both open, named above. This PR does not widen either guard: doing so is those tickets' work, and #4494 is already in flight on the first.

## Notes for the reviewer

- **`set -uo pipefail` is deliberately absent, and so is `errexit`.** These scripts are **sourced**, so any option they set leaks into the agent's live shell and changes the behavior of everything after — which would make this a rewrite, not a move. More concretely, `pipefail` being **off** is load-bearing in the moved glue: `step4b-containment.sh`'s `|| echo none`, `step5-acceptance-criteria.sh`'s `|| echo "(no checkbox ACs …)"`, and all five of `step5-seam-checks.sh`'s `&& echo … || echo …` pairs are reachable only with it off, and `errexit` would abort a fail-closed branch before it printed its line — turning fail-closed into fail-open. This matches `ship-it`'s sourced scripts on #4491 ("this file deliberately sets NO shell options"), the sibling extraction upheld by its gate.
- **No `EXIT` trap anywhere** — 27 files, zero. Under this box's `bash 3.2.57` a cleanup trap's last command becomes the script's status, which launders a `set -u` abort into exit 0 (#4476, class #4479 remains open). Several of these scripts are guards whose entire contract is their exit status, so the hazard is given no surface at all.
- **No `"${arr[@]-}"` expansion into an argument list** — the moved glue has no array expansions, so the bash-3.2 empty-array-becomes-one-empty-argument trap has no site here either.
- **Derive-shaped blocks stayed derive-shaped.** As #4491's gate found for ship-it, some moved glue derives rather than relays (`step5-seam-checks.sh` decides seam-armedness; `stepR-round-count.sh` counts FAIL rounds). Per ADR 0228 and the #4435 ruling that is expected in phase 1 and is #1929's work, not this PR's — disclosed rather than repaired.
- **A typed consumer DOES parse this file by heading — `adoption-lint/command.test.ts` — and the widening in the repair round below is what discharges it.** The original claim here was that #4491's precondition (`checks/step3-contract.ts` and `merge-queue-classify/step55-contract.ts` slice constants out of `ship-it/SKILL.md` by heading, which is why 119 lines could not move) had no analogue for `write-code`, and that the `adoption-lint` hit in a `skills/write-code` grep was one of "two test fixtures". That was wrong on both counts. `packages/pipeline-cli/src/tools/adoption-lint/command.test.ts` names this file in its `CLAIM_WRITERS` list, slices it between `### Delegated claim` and `### Direct path`, and asserts the slice carries `claim assign` — an assertion, not a fixture. Moving both `claim assign` sites into `scripts/step3-{delegated,direct}-claim.sh` therefore reddened it. `gh-phoenix/lint.ts` is a separate matter and its conclusion still holds: on current `main`, #4491 added two `ship-it/scripts/*.sh` entries to `SELF_EXEMPT_SUFFIXES`, so it no longer names `SKILL.md` alone — but neither addition matches any of this PR's 25 paths, so they stay fully in the GraphQL-path lint's scope and pass it, a widening rather than a narrowing.

## Repair round 1 — the broken heading-slice consumer, and three harness gaps

The `review-skill` FAIL at `9c4b938f` named one blocking defect and three accounting rows. All four
are addressed in one push. **Every `.sh` file this round touched is disclosed at the end of this
section**, per the interim control on undisclosed script edits in a repair round.

### The blocking defect — `adoption-lint/command.test.ts` slices this file by heading

`packages/pipeline-cli/src/tools/adoption-lint/command.test.ts` is a typed consumer of
`write-code/SKILL.md`: `CLAIM_WRITERS` names the file, and one assertion locates
`### Delegated claim` and `### Direct path` and requires the slice between them to carry
`claim assign`. Moving both `claim assign` sites into `scripts/step3-delegated-claim.sh` and
`scripts/step3-direct-claim.sh` left zero occurrences in the markdown, so it reddened.

Two distinct consequences, one loud and one silent:

- the **layer-one pin** (#4298) failed outright — the reproduced `1 failed / 2937 passed`;
- the **ordering pin** (#4015) went **vacuous for the whole skill** and stayed green. Its scope is
  the writers whose text contains a layer-one write, so once `claim assign` left `SKILL.md`,
  `write-code` silently dropped out of a pin about its own claim ordering. That second one is the
  more dangerous half: a green suite covering one writer fewer, with nothing to notice.

**The widening.** A claim writer's *surface* is now its own file **plus the `scripts/*.sh` beside
it**, and the delegated branch's heading slice is **followed into the script it sources**
(`. "$WRITECODE_SCRIPTS/step3-delegated-claim.sh"` resolves to that file, which is then scanned).
This is the shape #4448 already landed on `main` for `validate-gate-path-drift.sh`'s `COPY_FILES`
and for `class-probe-consumers.unit.test.ts` ("the corpus is markdown AND the shell the skills
extracted out of it"), applied to the claim pins.

Three properties of the widening worth naming:

- **Sibling-scoped, not the whole plugin tree.** `shared/scripts/` is a library many surfaces call
  (`claim-verbs.sh` holds a `claim assign` with no claim of its own, by design), so folding it into
  every caller's surface would assert one shared half-procedure against every writer's ordering rule.
- **Ordering is pinned per file, not over a concatenated surface.** After the extraction, one
  branch's entire procedure *is* one file. Concatenating would let the direct path's `tracker claim`
  satisfy an ordering claim about the delegated path, which is a different procedure. Per file, the
  rule is: a file that claims must assign after it claims; a file that assigns without claiming is
  the delegated branch and must prove the lane is ours (`claim is-mine`) first.
- **The follow is fail-closed (ADR 0092).** When the heading slice carries no inline layer-one
  write, the resolved script set must be non-empty — a heading pair that reaches nothing is a broken
  scan, not a branch that passes.

The claim-verb invocation matcher also had to accept the extracted form: a moved block's `<N>`
metavariable is now the script's positional parameter, so `"$PCLI" tracker claim $N` is the same
invocation the markdown spelled `pipeline-cli tracker claim <N>`.

**Suite counts, full `packages/pipeline-cli` suite, same command both times.**

| | test files | tests |
| --- | --- | --- |
| at `9c4b938f` (the reviewed head) | 1 failed / 182 passed (183) | **1 failed / 2937 passed (2938)** |
| at this head | 183 passed (183) | **2938 passed (2938)** |

The one failure at the old head was
`src/tools/adoption-lint/command.test.ts > writes layer one through the one verb, and the delegated
branch carries its own` — `AssertionError: … must write the §7 layer-one availability gate through
\`pipeline-cli claim assign\``. That is the assertion that now passes.

**Falsified, not just observed green.** Two negative probes, each reverted:

- blanking `claim assign` in `step3-delegated-claim.sh` ⇒ the delegated-branch assertion fails,
  naming the script. The follow-into-scripts reach is live, not decorative.
- dropping the issue argument from `step3-direct-claim.sh`'s `tracker claim` ⇒ the **ordering** pin
  fails, naming `…/scripts/step3-direct-claim.sh`. That is the proof `write-code` is back inside the
  pin it had silently fallen out of.

### The three accounting rows

- **`stepR2-branch-rebase.sh` now has a `check` line.** Its sole seam is the head-branch
  metavariable, expressible as one `sed` substitution — omissible, not undiffable, and a
  branch-switching/rebasing script is the last place the mechanical proof should carry a silent gap.
  `verify-byte-move.sh` is now **22 of 25 scripts / 302 lines**, and the "not mechanically checked"
  list at the bottom of the harness names exactly the three that remain, matching the body.
- **`verify-fail-closed.sh` greps all nine path arms, not one.** The zero-delta proof was measured
  over 1 of `MACHINE_LOCAL_PATH_PATTERNS`' 6 arms; it now loops all six plus the three
  comment-surface `TEMP_PATH_PATTERNS` roots, each reported by name. ERE has no lookbehind, so each
  arm is the guard's shape with its narrowing lookarounds **dropped** — deliberately broader than the
  guard, since zero hits under a broader pattern implies zero under the narrower one. All nine clean.
  The `grep -v "/verify-"` exclusion stays — and this round's own widening is what makes it
  **load-bearing rather than redundant.** Re-measured over the two excluded files: **5 of the 9 arms
  hit**, because five of them match the harness's own human-readable `reason` label strings (the
  agent/tool home-dir, sibling-clone, vault and temp-root labels each spell their pattern out
  literally). Without the exclusion the harness reports *itself*. Round 1's "strictly redundant"
  reading was true of the one-arm form and is false of this one — the general lesson, since it will
  recur: **widening a pattern set can convert a redundant exclusion into a load-bearing one, so a
  "this exclusion is unnecessary" claim expires whenever the patterns change.**
- **§ZS is now 15 of 15.** `stepR2-fail-body.sh` was excluded because its seam parameter is
  *defaulted* rather than required. A default is not an exemption — the property under test is that a
  no-argument source produces no answer, and it holds (`rc=1`, `stdout-bytes=0`). Folded in.

### Re-run at this head

| check | exit | note |
| --- | --- | --- |
| `packages/pipeline-cli` full suite | 0 | 2938 passed (2938), 183 files |
| `verify-byte-move.sh` | 0 | 22 scripts `MATCH`, 302 lines |
| `verify-fail-closed.sh` | 0 | 15 seams `rc=1` / `stdout-bytes=0`; 9 path arms + the bare-invocation grep clean |
| `shellcheck` over `scripts/*.sh` | 0 | all 27 files |
| `pnpm typecheck` | 0 | 29 tasks |
| `pnpm lint:worktree` | 0 | no fixes applied |
| `validate-cycle-presence.sh` | 0 | 18 checks |
| `validate-cycle-absence.sh` | 0 | 14 checks |
| `validate-skills.sh` | 0 | 30 skills valid |
| `validate-gate-path-drift.sh` | 0 | 34 checks |
| `gh-phoenix lint-skills` | 0 | 210 files |
| `cli-invocation-guard check` | 0 | 210 files, 322 runnable fences |
| `adoption-lint check` (the CI job's own corpus) | 0 | clean |

### `.sh` edits made in this repair round — the complete list

Two files, both proof harnesses, neither in the runtime path of the skill:

- `claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-byte-move.sh` — one added `check`
  line for `stepR2-branch-rebase.sh` with its single `sed` seam, plus the two-line comment stating
  why the seam is expressible.
- `claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh` — added
  `stepR2-fail-body.sh` to the `SEAMED` list; replaced the single `/Users|/home` grep with a
  nine-arm loop; updated the header docblock's §2 description to match.

**No extracted (runtime) script was edited in this round.** All 25 `step*.sh` / `stepR*.sh` files are
byte-identical to the reviewed head — the two negative probes above touched
`step3-delegated-claim.sh` and `step3-direct-claim.sh` and were reverted before the commit;
`verify-byte-move.sh` re-derives both from base and reports `MATCH`, which is the mechanical proof of
that claim rather than an assurance.

## Repair round 3 — the two FAIL rows, and a third instance the gate found

Both round-2 verdicts were FAIL (`review-skill` 6/2, `review-code` 5/2) in marker rather than
advisory form, since ADR 0226 reserves the §CP advisory for a pass path. Both failing rows are fixed
here; **one file changed, no runtime script touched.**

### 1. The constant hoist had widened the #4298 one-verb pin — narrowed, not deleted

The round-2 hoist substituted one shared `LAYER_ONE_WRITE` — `claim assign` **OR** a raw
`gh api -X POST …/assignees` — at the three sites where the base pinned `claim assign` **alone**
(`:260` / `:271` / `:282`), inside the test named *"writes layer one through the one verb."* A
hand-rolled assignees POST therefore passed the very test whose purpose is to forbid it.

**Reuse was the defect**: one clever constant merged two different assertions' vocabularies. Two
clearly-named ones replace it, and the narrow one is the source of the wide one so it can only ever
be the wider of the two:

| constant | matches | used by |
| --- | --- | --- |
| `LAYER_ONE_VERB` | `claim assign` **only** | the #4298 one-verb pin — `:260` / `:271` / `:282` |
| `LAYER_ONE_ANY_WRITE` | the verb **or** the raw POST (derived from `LAYER_ONE_VERB.source`) | the #4015 ordering pin's population predicate, where the un-migrated-corpus tolerance is intended |

**The gate's own probe, run in both directions at this head** (probe applied to
`step3-delegated-claim.sh`, then reverted; `git status` clean before the commit):

| direction | outcome |
| --- | --- |
| legitimate `"$PCLI" claim assign` | **6 passed (6)** — the honest form still passes |
| hand-rolled `gh api -X POST …/assignees` in place of the verb | **1 failed / 5 passed**, red on *"writes layer one through the one verb…"* with `write-code's DELEGATED branch must write layer one itself … (#4298)` |

So it reds, and it reds *for the right reason* — the #4298 assertion, not an incidental one. The
ordering pin still populated the file under the probe (that tolerance is deliberate), which is the
separation working.

### 2. The `verify-` self-exemption sentence — code kept, characterisation corrected

Round 1 ruled the `grep -v "/verify-"` exclusion strictly redundant; the nine-arm loop added in
round 2 falsified that ruling. **The exclusion is right and is unchanged** — only the body sentence
was false, and it is corrected in *The three accounting rows* above, with the recurring lesson stated
(a "this exclusion is unnecessary" claim expires whenever the pattern set changes).

### 3. A third live instance of the #4509 class — the gate found it inside the fix for that class

`writerSurface` stops at the sibling `scripts/` dir on purpose (folding `shared/scripts/` into every
caller's surface would assert one shared half-procedure against every writer's ordering rule). But
that boundary holds in **one direction only**: extracting a writer's layer-one write *into*
`shared/scripts/**` drops that file out of `selfAssigning` **silently** — not a loud break, a guard
that quietly stops asserting. Live today, since fenced shell is actively moving into
`shared/scripts/` (this PR moves `step4b`'s cycle-doc probe there).

**Taken: the explicit-population option.** The ordering pin's population is now *declared*
(`LAYER_ONE_WRITING_FILES`, four files) and asserted equal to the derived set, so a writer that
leaves — or an undeclared one that arrives — reds and names it. That assert is also this pin's
ADR-0092 zero-scope guard, so it replaces rather than adds to the previous `isAbove(0)`.

**Proven by probe** (reverted): rewriting `step3-direct-claim.sh`'s layer-one write as a
`shared/scripts/` source edge reds with *"the ordering pin's population drifted from the declared
one"*, naming `…/scripts/step3-direct-claim.sh` as the file that left — while **the other five tests
still passed**, which is the direct evidence that this drop-out was silent before and is loud now.

The surface-scoping decision itself is unchanged and remains #4509's to rule on in general.

### `.sh` edits in repair round 3 — the complete list: **none**

No `.sh` file was edited in this round. One file changed:
`packages/pipeline-cli/src/tools/adoption-lint/command.test.ts` (+42/−11). The two negative probes
above touched `step3-delegated-claim.sh` and `step3-direct-claim.sh` and were reverted before the
commit; `git status` was clean apart from the test file, and `verify-byte-move.sh` re-derives both
from base and reports `MATCH`.

### Re-run at this head (round 3)

| check | exit | note |
| --- | --- | --- |
| `packages/pipeline-cli` full suite | 0 | **183 files passed (183), 2938 tests passed (2938), 0 failed** — unchanged, no regression |
| `adoption-lint/command.test.ts` | 0 | 6 passed (6) |
| `pnpm typecheck` (`pipeline-cli`) | 0 | clean |
| `biome check` on the changed file | 0 | no fixes applied |

### Base

Freshened onto `origin/main` during repair round 2, and the earlier `9a4e909e` citation was stale
in the **fresher** direction: this head's merge-base with `origin/main` is `be8c3d3c`, so the branch
additionally carries `15263296` (#4491) and `be8c3d3c` (#4485) on top of the commit the body named.
The round-2 gate measured `behind_by 0`. **No rebase in round 3** — `origin/main` has since taken one
further commit and the branch is deliberately left un-rebased. The two citation moves the
review flagged are in-tree: `class-probe-consumers.unit.test.ts` is the precedent the widening
follows, and `gh-phoenix/lint.ts`'s `SELF_EXEMPT_SUFFIXES` correction is folded into the `Notes for
the reviewer` row above. Clean rebase, no conflicts.

## Deviations

Walking all seven §DEV classes.

**Class 2 — scope narrowed relative to the acceptance criteria's wording.**

- **Said:** "Every fenced bash/sh block remaining in `SKILL.md` is a script invocation; no multi-line glue remains in the markdown."
  **Did:** six blocks still hold multi-line content: the two #4372-overlapped blocks (139 lines), the two body templates (34 lines), and the preamble (6 lines: `REPO` + `WRITECODE_SCRIPTS` + their comments).
  **Why:** the overlap rule in the dispatch brief mandates skipping a block an open PR edits, and a per-run authored template cannot live in a script. #4485 and #4492 both narrowed for the same reason and both were upheld.
  **Disposition:** deliberate. `#4449 remains open` with the two skipped blocks named as the remainder.
- **Said:** the ticket scopes "33 blocks, ~566 shell lines."
  **Did:** scoped to **column-0** fences only. Four non-column-0 fences (73 lines) — one list-nested, two blockquoted including the 61-line `wt_preflight` definition, one list-nested in repair mode — were not touched.
  **Why:** the column-0 set is *exactly* 33 blocks / 566 lines, so it is what the ticket counted. The 61-line blockquote is also the most safety-critical glue in the file and `lint-skills`'s bare-push scan strips quote prefixes specifically to keep reading it, so relocating it needs its own gate review.
  **Disposition:** filed as **#4502** with the four blocks tabulated.

**Class 3 — a known defect left unfixed.**

- **Said:** phase 1 moves shell as-is; do not improve it.
  **Did:** relocated three fail-open `|| echo none` / `|| CYCLE_DOC=absent` / `|| true` reads unchanged, so an unreadable input still resolves to the permissive answer in `step4b-containment.sh`, `step5-seam-checks.sh` check (d), and `step4d-blessed-surfaces.sh`.
  **Why:** repairing them is exactly the verb-replacement phase 1 is forbidden from doing.
  **Disposition:** filed as **#4501**, and cited from the two script headers that carry the shape.

**Class 6 — a mechanical seam the move required.**

- **Said:** relocation plus the minimal sourcing seams only.
  **Did:** each block's `<N>` / `<PR>` / `<EPIC>` / `<slug-for-issue-N>` / `<the PR's head branch>` metavariable became a positional parameter with a fail-closed guard, exactly as #4489's `shared/scripts/claim-verbs.sh` did. In `step5-seam-checks.sh` the two `<N>` sites sit inside single-quoted EREs, so the number is spliced by quote-concatenation (`'…#'"$N"'\b'`) — the pattern's own bytes are unchanged. `stepR2-fail-body.sh` replaces the block's hardcoded `$CODE_FAIL_JSON` plus its prose "swap per namespace" instruction with a named-variable indirection (`${!VAR}`, not `eval`), because a file cannot be hand-edited per namespace. `stepR3-thread-reply.sh` takes its per-run reply body as `$1`, which keeps the template visible at the call site.
  **Why:** a script cannot receive a substitution the reader used to make by hand.
  **Disposition:** declared in each script's header; `verify-byte-move.sh` applies exactly these substitutions and then requires a byte-for-byte diff, so the seams are enumerated in executable form. Three scripts are not diff-checkable for the reasons the harness itself lists at the bottom of the file.
- **Said:** nothing about shellcheck suppressions.
  **Did:** each script declares the codes its own moved lines raise (`SC2086`, `SC2034`, `SC2154`, `SC2015`).
  **Why:** the findings travelled with the bytes; quoting `$REPO` would be a rewrite.
  **Disposition:** per file, never blanket; rationale stated once in `SKILL.md` rather than in twenty headers.

**Classes that did not fire, each with its reason:**

- **Class 1 (a different approach than specified)** — no. The approach is the ship-it extraction's, block for block: `<SKILL>_SCRIPTS` resolved like the §CLI shim, one sourced script per block, `common.sh` sourced by relative path.
- **Class 4 (an unrequested addition)** — no, with one thing to look at: the two `verify-*.sh` harnesses are not in the acceptance criteria. The AC *does* require "a reviewer-runnable verification recipe in the PR description," and committing the recipe is what makes it re-runnable at review time rather than a paragraph that rots. They are inert (read-only; they run no `gh` and mutate nothing) and are excluded from their own coverage-delta grep scope.
- **Class 5 (a partial implementation presented as complete)** — no, and the body's link form is what enforces it. Because two blocks are skipped, this PR carries **`Part of #4449`** and no closing keyword, so merging it leaves the ticket open for the remainder — the §9 partial-split shape #4485 and #4492 both used and were upheld on. It was opened with a full-close keyword on that number and corrected to the partial-split marker by `gh api -X PATCH` before review — disclosed here rather than left as a silently-edited body. (The keyword is deliberately not spelled out next to the number anywhere in this body: GitHub's parser reads a closing keyword out of *prose* just as readily as out of the link line, so writing it even to describe it would re-arm the auto-close this correction removes.)
- **Class 7 (a decision made that was the reviewer's to make)** — no. Every judgement call was routed: the overlap skip follows the brief's stated rule, the fail-open glue went to #4501, the nested fences to #4502, the guard narrowings to the already-open #4486/#4496, and the derive-shaped blocks to #1929.

**(repair round 1) Class 2 — scope widened relative to "phase 1 relocates shell, it does not touch consumers."**

- **Said:** phase 1 is a byte-move; the glue's own repair is phase 2 (#1929).
  **Did:** edited a file outside `claude-plugins/` — `packages/pipeline-cli/src/tools/adoption-lint/command.test.ts` — to widen three claim pins onto the extracted scripts, and edited the two committed proof harnesses.
  **Why:** the relocation broke a typed consumer of the old location, so "move only" was not achievable without either leaving a red assertion or keeping a duplicate `claim assign` in the markdown purely to satisfy a scanner. The gate named the widening as the better of the two, with #4448 as the landed precedent.
  **Disposition:** deliberate, and the narrower alternative was rejected on the gate's own reasoning. No production code changed; the diff is one test file and two proof harnesses.

**(repair round 1) Class 4 — an addition beyond the enumerated findings.**

- **Said:** fix exactly the enumerated findings.
  **Did:** the widening also restores `write-code` to the scope of the #4015 ordering pin, which the verdict did not name — it was invisible, because its symptom is a green suite covering one writer fewer rather than a failure.
  **Why:** the same root cause. Fixing only the assertion that reddened would have left the vacuous pin vacuous, which is the #4470 shape the verdict is otherwise policing.
  **Disposition:** disclosed here and proven by a negative probe rather than asserted.

**(repair round 1) Classes 1, 3, 5, 6, 7 — did not fire.** No different approach (the widening is #4448's, file for file); no known defect left unfixed in this round; nothing partial presented as complete (the linkage is unchanged and #4449 remains open for the two skipped blocks); no new mechanical seam (the one added `check` line reuses the harness's existing substitution mechanism); no decision taken that was the reviewer's — the `grep -v "/verify-"` exclusion was left alone on the reviewer's ruling. **Round 3 corrects only the body's characterisation of it** (it is load-bearing, not redundant) and leaves the code exactly as ruled.

**(repair round 4) Class 6 — a mechanical change the merge queue required, made on a head that had already passed both gates.**

- **Said:** round 3 left the branch deliberately un-rebased, and both gates then passed at `b84f20fe` — `review-skill` 8/0 and `review-code` 7/0. That is my one-line summary of the two verdict comments on this PR, not a quotation of them; read the comments themselves for the rows.
- **Did:** rebased onto current `main` `c7de87f9` and added one `DOC_SELF_EXEMPT` entry in `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts` for this PR's `verify-fail-closed.sh`, plus two unit tests pinning that exemption's narrowness. Both prior verdicts are staleness-invalidated by the head move (ADR 0058) and are re-earned by an independent re-review, which is the expected cost.
- **Why:** #4507 merged after those verdicts and brought `.sh` onto `leak-guard`'s scan surface. This PR's verification harness necessarily enumerates the forbidden path shapes as literal pattern arms — that is precisely what it proves the extracted corpus is free of — so under the landed guard it reds, measured as exit 2 with five findings on that one file. **The branch's own CI could not see this:** its base predated #4507 and the `leak-guard` job is diff-scoped, so its checks ran the pre-widening, `.sh`-blind guard. `merge_group` evaluates against current `main`, which carries the widened guard, so the sequence left alone was approve → enqueue → queue reds → ejected, with the approval already spent. That is *"the queue scans a surface the PR's own CI does not"* — the same class as the `adoption-lint` defect this PR fixes, arriving on the PR that fixes it. Claim 1 in *Two guards are NARROWED by this diff* is therefore superseded on its `leak-guard` half; **#4496 remains open** as the tracking ticket, and **#4507 remains** the commit that widened the guard.
- **Disposition:** exactly the remediation `leak-guard`'s own message prescribes, and the same one `path-matcher.ts` and its unit test already carry for the identical reason — a file whose subject *is* path hygiene has to spell the shapes out. The list is matched by path suffix, so the entry names one file and the shell surface is not blanket-disabled (proven in both directions below). Deliberately **not** done: weakening the harness by removing or genericising its pattern arms, and settling the adjacent question of whether one arm names an operator-adjacent directory rather than a generic shape — that one is pre-existing, mirrors the shared matcher's own arms, brushes the standing generic-patterns-not-named-deny-lists ruling, and is routed to triage rather than decided in a repair round.

**(repair round 4) `.sh` edits — the complete list: one file, comment-only.**

- `claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh` — two comment blocks, no executable line changed. Its section-2 note asserted that `leak-guard` never inspects a `.sh`, which was true at this branch's base and is false of current `main`; the note now states the landed behaviour and records that this harness carries the self-exemption. `verify-byte-move.sh` and all 25 extracted `step*.sh` / `stepR*.sh` files are untouched this round, which `verify-byte-move.sh` re-derives from base rather than asserting.

**(repair round 4) Classes 1, 2, 3, 4, 5, 7 — did not fire.** No different approach (the exemption is the precedent's, entry for entry); no scope change to the extraction itself; no known defect left unfixed in this round; no unrequested addition beyond the two narrowness tests that make the exemption falsifiable; nothing partial presented as complete — the linkage is unchanged, this PR is `Part of #4449` with no closing keyword and **#4449 remains open** for the two skipped blocks; and no decision taken that was the reviewer's — the operator-adjacent-arm question went to triage instead.

### Three-direction proof of the exemption — every exit read directly, never through a pipe

| direction | what was run | exit | outcome |
| --- | --- | --- | --- |
| the harness under the widened guard | `leak-guard scan` on `verify-fail-closed.sh` | **0** | `1 self-exempt`, `clean`. Before the entry, the same scan was **exit 2** with five findings on that file |
| the whole extracted corpus | `leak-guard scan` on `scripts/*.sh` | **0** | 27 handed: 26 shell surface, 1 self-exempt, `clean` |
| a non-exempt `.sh` carrying one planted shape | `leak-guard scan` on a scratch script | **2** | still `blocked`, naming the planted arm — the shell surface is not disabled |
| the harness's own assertions | `bash …/verify-fail-closed.sh` | **0** | 15 seams `rc=1` / `stdout-bytes=0`; nine path arms and the bare-invocation grep clean |

Exits were read unpiped on purpose: `xargs` remaps 1–125 to its own code and a pipe reports the last command's status, so a `blocked` result read through either can present as exit 0.

The same two directions are pinned durably in `packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts`: the harness resolves self-exempt while its two sibling script paths do not, and `findLeaks` on a non-exempt `.sh` carrying a planted machine-local path is non-empty.

### Re-run at this head (round 4)

| check | exit | note |
| --- | --- | --- |
| `packages/pipeline-cli` full suite | 0 | **183 files passed (183), 2955 tests passed (2955)** — run with `.claude/` intact, so `adoption-lint`'s tests that read a workflow file as data are real rather than four phantom failures. The rise from round 3's 2938 is 2 new tests here plus 15 arriving with the rebase |
| `pnpm typecheck` | 0 | 29 tasks successful, `pipeline-cli` uncached |
| `pnpm lint:worktree` | 0 | 3 changed files checked, no fixes applied |
| `gh-phoenix lint-skills` | 0 | 27 gh-call / 1 frontmatter / 28 bare-push files scanned, all clean |
| `verify-byte-move.sh` | 0 | 22 scripts `MATCH`, 302 lines — unchanged, and re-run because the rebase moved the branch |
| `verify-fail-closed.sh` | 0 | both properties hold |

### Base (round 4)

**Rebased onto current `main` `c7de87f9` — required, not optional:** the exemption had to be added to the `leak-guard.ts` that #4507 rewrote, and the copy at this branch's old base was stale. The rebase was clean, no conflicts. There were zero reviews of any state on this PR when the head moved, so it cost no human approval — that is a fact about this PR's state at that moment and **not** a general property of rebases. The "a rebase never loses an approval" hypothesis was falsified and retracted (a counterexample PR took an approval, then a force-push that changed both file set and blob, with no dismissal event, and merged on that approval); the inconsistency is open as **#3769 (remains open)**.
