### PR TITLE
refactor(review-code): the code gate's fenced shell moves into scripts/ (#4451)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -326,77 +326,16 @@ make the isolation hold *by construction*, not by your remembering to behave:
 Your own session stays in *this* worktree (the trusted base config you were launched under).
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# Isolation preflight FIRST, before any head fetch / `git worktree add` below. If this
-# review-code spawn expected worktree isolation (reviewer agent-type) but the #2440 harness no-op
-# dropped it onto the shared PRIMARY checkout ($WORKTREE_ROOT unset), materializing the head here
-# is the #2452/#2453 primary-checkout-detach surface — fail closed LOUD and route up, never
-# materialize. Single-sourced in gh-issue-intake-formats.md §RO-iso (ADR 0172; the write-code
-# wt_preflight sibling). A genuine standalone run on the owner's checkout still proceeds.
-iso_preflight review-code || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
-
-# the trusted base — the PR's merge target at tip; your config already comes from here
-BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
-
-# Refresh the base BEFORE any "is-it-shipped on main" ground-truth check (below). The PR
-# head reaches its own ref, but the base is the *other* half of verification — a long-lived
-# or busy checkout's local main goes stale, so an "is X shipped?" check read off the working
-# tree is only as fresh as whoever's checkout the gate ran in. This is the freshness gap
-# complementary to ADR 0052's config-isolation: 0052 pins your *config* to the base; this
-# pins your *ground-truth* to the base too. (PR #305 false-FAILed on exactly this — a doc
-# whose consumers had merged minutes earlier was FAILed against a stale local main.)
-git fetch origin "$BASE_REF"
-
-# §HEAD steps 1–3 (resolve the live head SHA, fetch pull/$PR/head into a per-run ref WITHOUT
-# touching the session tree, assert the fetched ref IS that head, add a throwaway DETACHED head
-# worktree) are the shared `pipeline-cli review-head materialize` verb (#3690 / #793 / #1807) —
-# cite it, don't re-derive it. `pull/<pr>/head` resolves for same-repo AND cross-fork PRs, so there
-# is no separate cross-fork branch to check out (the trust inversion ADR 0052 closes); the verb
-# never runs `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the
-# shared PRIMARY the harness resets this cwd to and detach the human's `main` — #2270/#1103), and it
-# nonce-uniques the ref per invocation so a concurrent review of the same PR can't overwrite it
-# (#1807). It emits the resolved head + ref + worktree as JSON. Persist those to a per-run mktemp
-# handle so they survive the harness cwd/shell reset between Bash calls (a shell var is lost across
-# calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive from a shared leaf
-# name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and pins the wrong head).
-# The `--worktree` tree is a FULL checkout (ADR 0067): biome.jsonc + biome-plugins/, patches/, the
-# catalog/lockfile, and everything `fate generate` needs are present, so the typecheck bootstrap is
-# whole. A full checkout also lands the head's root CLAUDE.md + .claude/.decisions/.patterns — that
-# leak is closed by the explicit denylist removal + absence-assert below, NOT by any pattern set.
-WT_FILE="$(mktemp /tmp/review-code-wt.XXXXXX)"
-"$PCLI" review-head materialize --pr "$PR" --worktree \
-  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
-. "$WT_FILE"
-[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
-  echo "FATAL: review-head materialize did not yield a head worktree — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
-
-# LAYER-2 containment (#2666): a freshly materialized worktree MUST come up pristine — assert it
-# clean NOW, before the denylist `rm --cached` below deliberately dirties it. A dirty materialization
-# means a corrupted head checkout, and reviewing a contaminated tree is a false signal. Fail-closed
-# LOUD via the single-sourced, tested helper (packages/pipeline-cli/src/tools/worktree-guard).
-"$PCLI" worktree-guard assert-clean --path "$REVIEW_WT" || {
-  echo "FATAL: review worktree came up dirty at materialization — aborting (never review a contaminated tree; #2666)." >&2
-  exit 1
-}
-
-# Enforce the instruction denylist EXPLICITLY: remove the head's instruction surfaces from
-# the review tree so they never reach the reviewing agent's path (ADR 0049/0052 boundary; a
-# full checkout would otherwise leave root CLAUDE.md on disk). Config still comes from the
-# trusted base — this tree is run *against* via `pnpm -C`, never `cd`'d into.
-git -C "$REVIEW_WT" rm -r -q --cached --ignore-unmatch \
-  CLAUDE.md .claude .decisions .patterns
-rm -rf "$REVIEW_WT/CLAUDE.md" "$REVIEW_WT/.claude" "$REVIEW_WT/.decisions" "$REVIEW_WT/.patterns"
-
-# ASSERT absence — the load-bearing isolation check (ADR 0067 §Consequences). If any denied
-# path is still on disk the isolation is broken: abort the review rather than read head config.
-for p in CLAUDE.md .claude .decisions .patterns; do
-  if [ -e "$REVIEW_WT/$p" ]; then
-    echo "FATAL: denied instruction surface '$p' present in review worktree — isolation broken; aborting" >&2
-    exit 1
-  fi
-done
+. "$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/materialize-head.sh" "$PR")"
 ```
+
+The script's **only stdout line is the run-state handle** carrying `REVIEW_WT` / `PR_REF` /
+`HEAD_SHA` / `BASE_REF`, so sourcing its output puts those four in your shell; every progress, scope
+and FATAL line goes to stderr. On any failure path stdout is empty and the exit is non-zero, so the
+`.` itself fails loudly — **never** fall back to reading the launched checkout's working copy (that
+is the #793 false-PASS: reviewing the base tree while binding the verdict to the head SHA). Later
+steps re-derive the same four values with
+[`scripts/head-env.sh`](scripts/head-env.sh) after the harness resets the shell between calls.
 
 The cross-fork case needs no special branch: `pull/$PR/head` is the GitHub-provided ref for
 the PR head whether it lives on this repo or a fork, so the single `git fetch` above covers
@@ -408,29 +347,30 @@ an output), run the repo's commands **inside the review worktree** — behavior 
 running beats behavior inferred from a diff:
 
 ```bash
-. "$WT_FILE"                   # re-source the run-unique $REVIEW_WT/$PR_REF after a between-call reset (#1807) — never re-derive from the shared `review-head-${PR}` leaf
-pnpm -C "$REVIEW_WT" install   # the catalog/lockfile + patches/ are present, so this succeeds
-# Lint via `pnpm lint:worktree`, never `pnpm lint` / `biome check .`: bare `.` resolves to the
-# review worktree's CWD (sits under .claude/worktrees → matches `!**/.claude/worktrees`) and exits
-# 0 WITHOUT linting (false green; #236, ADR 0060). `lint:worktree` lints the EXPLICIT changed files
-# vs origin/main (committed + working-tree, biome-extension-filtered; docs-only/empty = clean skip),
-# so it catches root + `.claude/**` violations a bare `biome check apps packages` would miss and
-# reliably predicts the CI lint job (#553/#559):
-pnpm -C "$REVIEW_WT" lint:worktree   # and/or the specific test the criterion names
-# Scoping a test to the criterion is fine when the SHA-bound run-evidence bundle (Step 2)
-# corroborates the full surface. But when the bundle is DEGRADED (absent/expired/stale-for-SHA),
-# a feature-scoped run under-verifies the change's blast radius — see the "fail closed on the
-# test surface" rule in the degrade block below: run the FULL unit project, never a subset.
-rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"   # tear the throwaway tree + ref down
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/worktree-checks.sh"
 ```
 
-**Teardown runs on EVERY exit path — PASS, FAIL, or a mid-run error, not just the happy
-path.** The line above is the review's own `rm -rf` of a detached, already-pushed throwaway
+Scoping a test to the criterion is fine when the SHA-bound run-evidence bundle (Step 2) corroborates
+the full surface. But when the bundle is DEGRADED (absent/expired/stale-for-SHA), a feature-scoped
+run under-verifies the change's blast radius — see the "fail closed on the test surface" rule in the
+degrade block below: run the FULL unit project, never a subset.
+
+**Teardown is its own script, and it runs on EVERY exit path — PASS, FAIL, or a mid-run error, not
+just the happy path:**
+
+```bash
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/teardown-head.sh"
+```
+
+It is the review's own `rm -rf` of a detached, already-pushed throwaway
 it materialized itself (safe — it holds no branch and no unpushed work), so run it even when
 the review is exiting `FAIL` or aborting after a typecheck/lint error; a leaked `review-head-*`
 tree accumulates on the shared primary otherwise (#2785). To catch a mid-block error inside a
-single Bash call, register it as a trap right after `git worktree add`:
-`trap 'rm -rf "$REVIEW_WT"; git worktree prune; git update-ref -d "$PR_REF"' EXIT`. And the
+single Bash call, register the script as a trap right after materialization:
+`trap '…/scripts/teardown-head.sh' EXIT` — and note the trap belongs to **your** shell, not to any
+extracted script: none of them installs an `EXIT` trap, because under bash 3.2 the trap's last
+command becomes the script's exit status and would launder a `set -u` abort into exit 0 (#4476,
+class #4479). And the
 standing net for the un-catchable case — a session-end abort *between* Bash calls, which no
 in-shell trap can reach — is `pipeline-cli worktree-sweep --execute` (#2785): it reclaims any
 leaked `review-head-*` tree that is clean + idle + unlocked, **without** `--force` (a dirty /
@@ -443,7 +383,7 @@ the full build inputs, so the typecheck bootstrap is whole — run it and treat 
 the typecheck signal:
 
 ```bash
-pnpm -C "$REVIEW_WT" typecheck   # `pnpm install` above made patches/ hashable + `fate generate` resolvable
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/worktree-typecheck.sh"
 ```
 
 CI and the SHA-bound run-evidence bundle (below) are now **corroboration**, not the sole
@@ -476,22 +416,19 @@ you received an archive and not a 503 error body; `schemaVersion` and
 load-bearing**: a bundle from a stale earlier push is not evidence for this commit.
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')"
-# Exit 0 means `present` — a validated, head-bound bundle. Every other state comes back on stdout
-# as JSON, so read the state rather than branching on the exit alone.
-BUNDLE="$("$PCLI" run-evidence read --pr "$PR")" || true
-BUNDLE_STATE="$(jq -r '.state' <<<"$BUNDLE")"     # present | pending | absent | unknown
-BUNDLE_LINE="$(jq -r '.reportLine' <<<"$BUNDLE")" # the verdict line, evidence already in it
+. "$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/run-evidence-read.sh" "$PR")"
 ```
+
+Sourcing its one stdout line puts `HEAD_SHA`, `BUNDLE_STATE` (`present` | `pending` | `absent` |
+`unknown`) and `BUNDLE_LINE` in your shell. **Read the state word, never the exit alone** — the verb
+exits 0 only on `present`, and the other three are different facts, not one "absent".
 
 When the state is `present`, `.manifest` carries the structured results (ADR 0054 §2 fields):
 `checks[]` is each gate step (`{name, status: pass|fail}`), `tests` is the folded JUnit summary
 (`{total, passed, failed, skipped, failingSuites[]}`).
 
 ```bash
-[ "$BUNDLE_STATE" = present ] && jq '.manifest | {commit, schemaVersion, checks, tests}' <<<"$BUNDLE"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/run-evidence-manifest.sh"
 ```
 
 Cite those numbers as the evidence for any criterion they speak to — "lint/typecheck/unit
@@ -543,8 +480,7 @@ gate exists to prevent. On the degrade path therefore:
   past a degraded verification.
 
   ```bash
-  . "$WT_FILE"                              # re-source $REVIEW_WT/$PR_REF after a between-call reset (#1807)
-  pnpm -C "$REVIEW_WT/apps/web" test:unit   # FULL unit project (the apps/web script) — never path-narrowed on the degrade path
+  "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/full-unit-project.sh"
   ```
 
 - **If — and only if — the full unit project genuinely cannot run** (an environment fault

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1033,14 +1033,12 @@ relevant-but-zero-match** case, and express a no-comment diff as an **explicit n
 skip** — distinct from a FAIL.
 
 ```bash
-# the added lines this PR introduced on comment-bearing code files, off the diff Step 2 already
-# loaded (the reviewer judges WHICH are comments per the deslop-comments rubric — a regex can't,
-# which is the point). Emit the scanned scope (§ZS #1) so a future drift that silently stops
-# finding added comment lines is visible in the run output rather than reading green.
-ADDED_ON_CODE="$(gh pr diff $PR \
-  | awk '/^\+\+\+ b\/.*\.(ts|tsx|js|jsx|css)$/{f=substr($0,7);next} /^\+\+\+ /{f=""} f && /^\+[^+]/{print f": "substr($0,2)}')"
-echo "comment-discipline: scanned $(printf '%s\n' "$ADDED_ON_CODE" | grep -c . || echo 0) added line(s) on comment-bearing files"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/comment-scan.sh" "$PR"
 ```
+
+It prints the §ZS scope line, then the scanned lines themselves — the fence left those in a shell
+variable for you to read, and a script boundary has none to hand back. The scan **arms** your
+judgement; the rubric decides it.
 
 Three outcomes, folded into the per-criterion table exactly like Step 3b/3c:
 
@@ -1079,6 +1077,17 @@ REST-only rule — verified working on this org (the Projects-classic breakage i
 fields, not `reviewThreads`; ADR
 [0158](https://github.com/kamp-us/phoenix/blob/main/.decisions/0158-unresolved-review-thread-is-a-merge-gate.md)).
 Every other read/write in this skill stays REST.
+
+> **This is the one block that did NOT move into [`scripts/`](scripts/) (#4451).** The
+> `skill-gh-lint` job runs `gh-phoenix lint-skills` over the corpus and FAILs on any `gh api graphql`
+> in a runnable block — **including a whole `.sh`**. The lint's `SELF_EXEMPT_SUFFIXES` exempts
+> `/skills/review-code/SKILL.md` as a whole file, so the read is lawful *here* and would be flagged
+> the moment it landed in a script, and continuing the exemption means editing the very
+> `SELF_EXEMPT_SUFFIXES` array
+> [PR #4491](https://github.com/kamp-us/phoenix/pull/4491) is already changing for ship-it's two
+> extracted scripts. The operative rule: a block a guard parses out of the markdown cannot move until
+> the guard follows. It stays inline until that lands, and the remainder is tracked on
+> [#4451](https://github.com/kamp-us/phoenix/issues/4451).
 
 ```bash
 ORG="${REPO%%/*}"; NAME="${REPO#*/}"
@@ -1151,14 +1160,11 @@ Detect it off the diff Step 2 already loaded — emit the scanned scope (§ZS #1
 that silently stops matching is visible in the run output rather than reading green:
 
 ```bash
-# does this PR touch a session/caching seam? A hit ARMS the two-axis check below; it never
-# alone FAILs — the reviewer judges whether a hit is a genuine new caching path (per the fire
-# condition above) or an unrelated auth edit. Fail-closed on the security-load-bearing surface:
-# when in doubt that a hit is a caching path, run the check, don't skip it.
-CACHE_HITS="$(gh pr diff $PR \
-  | grep -inE 'cookieCache|session\.?cache|cacheSession|maxAge|staleness|ttl|revalidat' || true)"
-echo "session-caching gate: scanned the diff for session-caching seams — $(printf '%s\n' "$CACHE_HITS" | grep -c . || echo 0) candidate line(s)"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/session-caching-scan.sh" "$PR"
 ```
+
+It prints the §ZS scope line, then the candidate lines themselves, so you can judge each against the
+fire condition above.
 
 **When it fires, both axes MUST be verified as REQUIRED test coverage — not prose, not one axis.**
 Confirm the PR adds (or already has, exercising the new path) a deterministic integration test for

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -44,8 +44,55 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/resolve-repo.sh"
 ```
+
+Every script below resolves the repo the same way, through the shared lib's `kp_repo` — so the
+resolution is one rule in one place and it survives across steps, which a shell variable set in one
+fenced block does not (each agent shell invocation is a fresh process).
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/) and every fenced `bash` block below is an
+**invocation** of one. The prose keeps the *why*; the scripts hold the *how* (epic #4435 phase 1 —
+the shell moved as-is, and turning its `gh`/`jq` glue into tested `pipeline-cli` verbs is #1929, ADR
+0228: a script may RELAY a verb's answer, never DERIVE the decision). Four properties are
+load-bearing when you read or edit them:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control flow
+  through the guards written into it — `|| true` on a read that may legitimately match nothing, a
+  state-word assertion instead of an exit-status test (§CP), a `grep` whose empty result is an
+  answer. `errexit` would abort those paths before they print their fail-closed line, converting
+  fail-closed into fail-**open**.
+- **No script installs an `EXIT` trap.** Under bash 3.2 a cleanup trap's last command becomes the
+  script's exit status, which launders a `set -u` abort into exit 0 — a fail-closed guard that exits
+  0 having printed its refusal (#4476, class #4479).
+- **A script whose stdout answers a safety question makes every failure path speak (the
+  error-channel rule).** Moving glue behind a script boundary invents a channel the inline block
+  never had: a non-zero exit with **0 bytes on stdout**. Where a caller reads the *absence* of a
+  fail-closed line as a *positive* answer — `not-control-plane` in Step 2's §CP classification, the
+  skills-only off-ramp, Step 1's issueless carve-out — a silent guard exit is indistinguishable from
+  "proven safe". So each such script prints its **own** fail-closed sentinel on stdout
+  (`BLOCKING (…)` / `CANNOT-CLASSIFY (…)` / the hard-stop line) before every early `exit`, **and**
+  exits non-zero, and the prose reads the status before the stdout. An absent or empty result is
+  UNKNOWN, and UNKNOWN is never "no" (§ZS / ADR
+  [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md);
+  #4231, #4010, #4219). Note the discriminator on a completed run is the **absent sentinel line**,
+  not empty stdout — a §ZS scope line legitimately lands on stdout too.
+- **The shared-contract helpers are SOURCED from their canonical home — there is no skill-local
+  copy.** §CPREAD's `cp_changed_files` / `cp_head_sha`, §RO-iso's `iso_preflight`, §WL's
+  `kp_wl_all_onclass` and the `verdict_post_verify` read-back all live in
+  [`../shared/scripts/`](../shared/scripts/) (#4489 extracted them out of
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)), and this skill's scripts source
+  them directly. With no second copy there is nothing to keep in step and no byte-identity claim to
+  make about one. The **one deliberate exception** is
+  [`scripts/cycle-doc-probe.sh`](scripts/cycle-doc-probe.sh): the two cycle validators
+  ([`../validate-cycle-presence.sh`](../validate-cycle-presence.sh) /
+  [`../validate-cycle-absence.sh`](../validate-cycle-absence.sh)) scope each skill's scan surface to
+  that skill's **own** directory on purpose, so sourcing the shared probe would move this skill's
+  cycle wiring out of its guarded surface and the validators would fail — per-skill wiring stays
+  per-skill (the rule is stated at `kp_skill_shell_surfaces` in
+  [`../shared/lib/common.sh`](../shared/lib/common.sh)).
 
 ## Read-only on git working state
 
@@ -93,9 +140,7 @@ PR ↔ issue pairing, because the issue is where the acceptance criteria live.
 
 ```bash
 PR=<pr number>
-# the PR: state, head branch, body (the Fixes #N lives here), mergeability
-gh api repos/$REPO/pulls/$PR \
-  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/pr-context.sh" "$PR"
 ```
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam
@@ -103,11 +148,7 @@ Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam
 timeline if it's not obvious:
 
 ```bash
-# timeline shows "connected"/"cross-referenced" events linking PR ↔ issue
-# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
-# invisible without it on a long-lived PR's timeline (#4193)
-gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
-  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/linked-issue-timeline.sh" "$PR"
 ```
 
 Pin down `ISSUE=<N>`. If there is **no** linked issue, the rule is **class-aware** — this is
@@ -120,24 +161,12 @@ signal, **not** a second taxonomy; the ADR 0075 discipline `review-doc` follows 
 Step-0 class):
 
 ```bash
-# no linked issue → class-aware. The carve-out is scoped EXACTLY to the conversation-authored
-# coining class: the diff touches the `.glossary/**` CODE-class vocabulary coining site (ADR 0128)
-# AND every changed path lies on a conversation-authored surface — `.glossary/**`, or a doc
-# companion (`.decisions/**` / `.patterns/**`) carried in the same recording — and NOTHING else.
-# Any path off those surfaces (`apps/**`, `packages/**`, `infra/**`, a code-root README, a root
-# script) is behavioral work with a missing `Fixes #N` ⇒ a broken seam ⇒ hard-stop. Same file set +
-# same path-prefix class Step 2's skills-only route uses — no second class mechanism.
-# "every path is conversation-authored" is the EMPTY-OUTPUT form, never `! grep -qv` (§WL, #4155).
-FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
-OFFSURFACE="$(grep -vE '^(\.glossary|\.decisions|\.patterns)/' <<<"$FILES")"
-if [ -n "$FILES" ] \
-   && grep -qE '^\.glossary/' <<<"$FILES" \
-   && [ -z "$OFFSURFACE" ]; then
-  echo "conversation-authored .glossary/** coining site, no Fixes #N — legitimate (ADR 0184/0075): ISSUE stays unset, AC half N/A"
-else
-  echo "no linked issue on a PR carrying behavioral code — broken seam: hard-stop (dangling-code guard, ADR 0184)"
-fi
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/classify-issueless.sh" "$PR"
 ```
+
+Read the script's **exit status before its stdout**, and note the carve-out line is the *permissive*
+answer: on a non-zero exit it prints the hard-stop line itself, so a classifier that could not run
+holds the PR at the broken-seam stop rather than waving it through as legitimately issueless.
 
 - **Behavioral code is present** (the diff carries any path off the conversation-authored coining
   surface — `apps/**`, `packages/**`, `infra/**`, a code-root README, or any product code) → stop
@@ -166,9 +195,7 @@ When `ISSUE` **is** set, honor it as today — pull the issue and its acceptance
 
 ```bash
 ISSUE=<N>
-gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
-# the progress trail write-code left — context, not evidence
-gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/issue-context.sh" "$ISSUE"
 ```
 
 Extract the `### Acceptance criteria` checklist from the issue body. That list — every
@@ -199,11 +226,7 @@ Verification is grounded in the diff, the tests, and — where it matters — th
 not in the PR's self-description. Pull the change:
 
 ```bash
-# the full diff — gh pr diff is the reliable form; the diff media type is the REST equivalent
-gh pr diff $PR \
-  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
-# files touched, at a glance
-gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'   # --paginate: streaming --jq, pages concatenate — the full set past file #100 (#725)
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/pr-diff.sh" "$PR"
 ```
 
 This same loaded diff (and the review worktree below) is what the **specialist fan-out** runs
@@ -223,18 +246,12 @@ to `review-doc`'s skills-only / pure-code routes and `review-skill`'s "not a ski
 each gate hands a mis-classed PR to the gate that owns its class:
 
 ```bash
-# the file set drives the class decision (same list pulled above)
-FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
-# skills-only ⇒ every changed path is under skills/ or agents/ — review-skill's class, not yours
-# (agents/** are behavioral artifacts, review-skill-routed for the verdict — ADR 0150/#2003).
-# Empty-output form, never `! grep -qv`: a false-true here `exit 0`s the code gate on a PR that
-# does carry code (§WL of ../gh-issue-intake-formats.md, #4155).
-OFFCLASS="$(grep -vE '^claude-plugins/kampus-pipeline/(skills|agents)/' <<<"$FILES")"
-if [ -n "$FILES" ] && [ -z "$OFFCLASS" ]; then
-  echo "not a code PR — route to review-skill"   # plain note, no review-code: marker; stop
-  exit 0
-fi
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/classify-skills-only.sh" "$PR"
 ```
+
+Three outcomes, and the **exit status is read before the stdout**: a non-zero exit is UNKNOWN and
+prints `CANNOT-CLASSIFY (…)` — fail closed to has-code, verify here; the off-ramp line **at exit 0**
+routes to `review-skill` and stops; **no line at exit 0** means the PR carries code, so proceed.
 
 A **mixed** PR (`skills/**` *and* `apps/web`/`packages` code) is **not** skills-only — you
 verify the code class here and emit the `review-code` marker, while `review-skill` verifies the

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -801,11 +801,12 @@ per the formats §Reading stance — a `**Containment:**` line, with a leading b
 in the body:
 
 ```bash
-# the linked issue's containment marker; a missing line reads as `none` (formats §2 tolerant-read rule)
-CONTAINMENT=$(gh api repos/$REPO/issues/$ISSUE --jq '.body' \
-  | grep -ioE '\**\s*Containment:\**\s*(flag|exempt|none)' | head -n1 \
-  | grep -ioE '(flag|exempt|none)' || echo none)
+CONTAINMENT="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/containment-marker.sh" "$ISSUE")"
 ```
+
+The script prints exactly one of `flag` | `exempt` | `none`. `none` is the *skip* answer, so on a
+non-zero exit it prints `flag` instead — an unread marker is UNKNOWN, and here the conservative
+direction is the **armed** one: the gating verification runs rather than being silently skipped.
 
 **Graceful absence — skip cleanly, never false-FAIL.** The gating check runs **only** when the
 marker resolves to `flag` *and* the repo has a cycle doc. On `exempt`, `none`, a missing line, or
@@ -816,11 +817,13 @@ flag check on an exempt/foreign PR is the failure mode this guard exists to prev
 correct, first-class state (ADR 0062 portability), exactly as a missing milestone is.
 
 ```bash
-# the one canonical cycle-doc probe (formats §1); absent ⇒ no cycle ⇒ skip the gating check
-gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1 \
-  && CYCLE_DOC=present || CYCLE_DOC=absent
-# run the gating verification below ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]
+. "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/cycle-doc-probe.sh"
 ```
+
+Sourced, not run — the point is the `$CYCLE_DOC` (`present` | `absent`) it leaves in your shell. This
+is the one script here that is **deliberately review-code-local** rather than the shared
+[`../shared/scripts/cycle-doc-probe.sh`](../shared/scripts/cycle-doc-probe.sh); the reason is in
+§ The extracted scripts above.
 
 **Zero-scope = FAIL — a `flag`-marked PR that touches no user-facing surface fails (ADR 0092 / §ZS).**
 A `**Containment:** flag (default-off)` marker is the issue *claiming to deliver user-facing value*
@@ -843,17 +846,7 @@ FAIL — there is no dark feature here to gate (it is **not** a graceful skip; t
 surface and the surface came back empty):
 
 ```bash
-# the PR's user-facing surface (reachable UI + new data/API entry points), off the changed file set.
-# Emit the count + matched paths (ADR 0092 §ZS #1 — a gate states its scope), then fail closed on zero.
-FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # the changed paths (same set Step 2 pulled; --paginate past file #100, #725)
-USERFACING=$(printf '%s\n' "$FILES" | grep -E '^apps/web/src/.*\.(tsx|css)$|^apps/web/worker/.*\.(ts|tsx)$' || true)
-USERFACING_N=$(printf '%s\n' "$USERFACING" | grep -c . || true)
-echo "flag-gating user-facing scope: $USERFACING_N path(s) matched"; printf '%s\n' "$USERFACING"
-if [ "$USERFACING_N" -eq 0 ]; then
-  # relevant input (flag marker present), zero matches ⇒ FAIL CLOSED, never a silent PASS (§ZS #2).
-  # Emit ONE [FAIL] row into the conjunctive verdict; the PR is not merge-ready.
-  echo "- [FAIL] flag-gating (default-off) — \`**Containment:** flag\` marks a dark-shipped feature, but the diff touches NO user-facing surface (apps/web/src/**/*.{tsx,css}, new apps/web/worker/** resolver/route/mutation): empty scope on a flag-marked PR is a FAIL (ADR 0092 §ZS), not a pass — there is no user-facing path to gate."
-fi
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/userfacing-scope.sh" "$PR"
 ```
 
 The matched-paths emit is **load-bearing, not narration** (§ZS #1): the verdict states the exact
@@ -925,54 +918,13 @@ the same change that ships the surface.
 folder is *new* only when its marker path is absent on fresh base.
 
 ```bash
-# the file list WITH status (Step 2 already loaded the diff; this reuses the same files endpoint)
-# --paginate + streaming --jq so the full set past file #100 is seen (the API caps per_page at 100; #725)
-FILES_STATUS="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[] | "\(.status)\t\(.filename)"')"
-ADDED="$(printf '%s\n' "$FILES_STATUS" | awk -F'\t' '$1=="added"{print $2}')"
-
-# (1) a NEW feature folder: an added file under apps/web/worker/features/<dir>/... whose <dir>
-#     did not exist on fresh base. Dedupe to the folder; a folder is new iff base has no tree there.
-NEW_FEATURE_DIRS=""
-for d in $(printf '%s\n' "$ADDED" \
-            | sed -nE 's#^(apps/web/worker/features/[^/]+)/.*#\1#p' | sort -u); do
-  # read-only existence probe against FRESH base — never the working tree (formats §RO)
-  git cat-file -e "origin/$BASE_REF:$d" 2>/dev/null || NEW_FEATURE_DIRS="$NEW_FEATURE_DIRS $d"
-done
-
-# (2) a NEW public package: an added packages/<pkg>/package.json whose package dir is absent on base
-NEW_PACKAGES=""
-for p in $(printf '%s\n' "$ADDED" \
-            | sed -nE 's#^(packages/[^/]+)/package\.json$#\1#p' | sort -u); do
-  git cat-file -e "origin/$BASE_REF:$p/package.json" 2>/dev/null || NEW_PACKAGES="$NEW_PACKAGES $p"
-done
-
-# A new public EXPORT from an existing package is the third surface — a public entry point
-# (packages/<pkg>/src/index.ts, or the file a package.json "exports"/"main" names) that the diff
-# CHANGES to expose a new name. This one is read from the diff hunk, not a path-status test:
-# inspect the diff of any touched public entry for an added `export …` line. Treat a public-entry
-# file with an added export as a new surface for this gate.
-PUBLIC_ENTRY_EXPORT_ADDED="$(gh pr diff $PR \
-  | awk '/^\+\+\+ b\/packages\/[^/]+\/src\/index\.(ts|tsx)$/{e=1;next}
-         /^\+\+\+ /{e=0} e && /^\+[^+].*\bexport\b/{print}')"
-
-# the union: is there ANY new surface?
-NEW_SURFACE="$(printf '%s %s %s' "$NEW_FEATURE_DIRS" "$NEW_PACKAGES" "$PUBLIC_ENTRY_EXPORT_ADDED" | tr -s ' ')"
-
-# does the PR touch the glossary's domain-noun file? (added OR modified — any touch counts)
-GLOSSARY_TOUCHED="$(printf '%s\n' "$FILES_STATUS" | awk -F'\t' '$2==".glossary/TERMS.md"{print}')"
-
-# POSITIVE EVIDENCE OF SCOPE (§ZS / ADR 0092's "default FAIL, pass on positive evidence"): can the
-# three detectors above express ANYTHING in this repo at all? An empty $NEW_SURFACE has two causes —
-# "this PR added no surface" (a fact about the PR) and "this repo has no surface of the kind I know
-# how to look for" (a fact about the DETECTOR) — and until this probe they produced the identical
-# not-applicable line (#4299). Read-only, against fresh base, same as every probe above.
-DETECTOR_SURFACES="$(
-  git ls-tree --name-only "origin/$BASE_REF:apps/web/worker/features" 2>/dev/null
-  git ls-tree -r --name-only "origin/$BASE_REF:packages" 2>/dev/null | grep -E '^[^/]+/package\.json$'
-)"
-DETECTOR_SURFACES_N="$(printf '%s\n' "$DETECTOR_SURFACES" | grep -c . || true)"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/glossary-freshness.sh" "$PR"
 ```
+
+The three detectors, the positive-evidence-of-scope probe and the four-outcome verdict chain live in
+that one script — the chain consumes the detectors' variables, and two separate scripts would have to
+re-derive them, so the block-group moved whole. It reads `BASE_REF` off the head handle, which is what
+keeps every existence probe against the **freshly fetched** base rather than the working tree.
 
 **The self-asserting / fail-closed verdict (formats §ZS, ADR 0092) — four outcomes, never a
 silent PASS.** This gate's signature failure mode is *scanning nothing and reading green*, so it
@@ -1007,27 +959,12 @@ the skip's clothes:
   not the PR author: adopt a layout the detector expresses, drop `.glossary/TERMS.md` (which routes to
   the honest graceful-absence skip below), or make surface detection declarable.
 
-```bash
-# The graceful-absence probe LEADS the chain, EXECUTED — never asserted in prose. Every branch below
-# claims the glossary is on base, so a repo that never adopted it must be excluded by a real test or
-# the final `else` states a fact it never checked — the gate's own sin, one branch over (#4299).
-if ! git cat-file -e "origin/$BASE_REF:.glossary/TERMS.md" 2>/dev/null; then
-  echo "glossary-freshness: not applicable — no .glossary/TERMS.md on base"   # graceful absence: no row
-elif [ -n "$(printf '%s' "$NEW_SURFACE" | tr -d ' ')" ]; then
-  echo "glossary-freshness: scanned new surfaces ⇒$NEW_SURFACE"   # §ZS #1: emit what it scanned
-  if [ -n "$GLOSSARY_TOUCHED" ]; then
-    echo "glossary-freshness: PASS — new surface ships with a .glossary/TERMS.md touch"
-  else
-    echo "glossary-freshness: FAIL — new surface added but .glossary/TERMS.md untouched (§ZS relevant-but-zero-match)"
-    # fold as a FAIL facet in the verdict table (and/or append the in-scope AC per the §2 surface)
-  fi
-elif [ "$DETECTOR_SURFACES_N" -gt 0 ]; then
-  echo "glossary-freshness: not applicable — no new feature folder / public package / export in this PR (detector expressible here: $DETECTOR_SURFACES_N candidate surface(s) on base)"   # §ZS #3 skip
-else
-  echo "glossary-freshness: UNVERIFIABLE — detector blind: .glossary/TERMS.md is on origin/$BASE_REF, but this repo has ZERO surfaces the detector can express (no apps/web/worker/features/* dir, no packages/*/package.json on base). The empty scan is a fact about the DETECTOR, not this PR — it is NOT evidence the PR added no surface."
-  # fold as an [UNVERIFIABLE] facet in the verdict table — a blocking soft fail, never an omitted row
-fi
-```
+The chain is the tail of the same
+[`scripts/glossary-freshness.sh`](scripts/glossary-freshness.sh) invoked above — the graceful-absence
+probe LEADS it, EXECUTED, never asserted in prose, so the detector-blind `UNVERIFIABLE` branch is
+structurally unreachable when the glossary is absent. A fifth line,
+`glossary-freshness: CANNOT-EVALUATE (…)` at a non-zero exit, is the extraction's own fail-closed
+sentinel: fold it as `[UNVERIFIABLE]`, never as a not-applicable skip.
 
 Fold the result into the per-criterion table as one line, exactly like Step 3b's flag-gating facet —
 so the conjunctive verdict (Step 3) accounts for it like any other criterion:

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -643,6 +643,13 @@ them. The other three gates run **this same procedure** (one logic, four call si
 **reconstructing the issue body** — read it, gate, append the one new row, write it back — never
 by a blind edit:
 
+> **This block also did NOT move into [`scripts/`](scripts/) (#4451), for a different reason.**
+> [PR #4440](https://github.com/kamp-us/phoenix/pull/4440) relocates this whole
+> `## Specialist fan-out + route-don't-grade` section — this fence included — out of every gate and
+> into `../shared/specialist-fan-out.md` (#4396). Extracting it here would relocate the same lines a
+> second, conflicting way, so it stays put and whichever change lands first sets the other's baseline.
+> The remainder is tracked on [#4451](https://github.com/kamp-us/phoenix/issues/4451).
+
 ```bash
 # the §2 in-scope-only fence (fence 2) gates whether you may append AT ALL:
 # only an in-scope finding (traces to the issue's stated goal — Route, don't grade above)
@@ -1301,8 +1308,12 @@ any verdict not bound to the PR's current head (ADR
 verdict-body shape at the end of this step.
 
 ```bash
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/current-head.sh" "$PR")"   # the head you reviewed
 ```
+
+The script shape-asserts the SHA (bare 40-hex) and prints **nothing** on a failed read, so gh's error
+document can never reach the marker's `@ <sha>` field — the #2683 shape `verdict post`'s
+`emissionDefect` gate would otherwise refuse the whole verdict over.
 
 **Preferred — an approving review** (the native, unambiguous GitHub signal). Capture its
 result and check the exit status **explicitly**; on failure (e.g. a 422 when you can't
@@ -1335,39 +1346,16 @@ genuinely unavoidable, the body **MUST** first pass `pipeline-cli leak-guard sca
 [gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
 
 ```bash
-# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
-# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here
-# (#3653; ADR 0062/0064; epic #994)
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
-
-# Compose the PASS verdict straight into a shell variable (heredoc → multi-line markdown + backticks
-# survive) — NO scratch file, so no concurrent run can clobber it (#1465/#3718/#3801). First line:
-# review-code: PASS @ <HEAD_SHA> — merge-ready
-BODY="$(cat <<EOF
-review-code: PASS @ ${HEAD_SHA} — merge-ready
-… your per-criterion evidence table …
-EOF
-)"
-# Read-back assertion BEFORE the native APPROVE: the same gate `verdict post` enforces, piped on
-# stdin, so a malformed `@ <sha>` (e.g. an mktemp scratch path, #2683) fails loud here, never in a
-# review body.
-printf '%s' "$BODY" | $VERDICT validate --gate code || {
-  echo "FATAL: composed review-code marker is malformed — refusing to post (fix the @ <sha> field; #2683)" >&2
-  exit 1
-}
-if gh api -X POST repos/$REPO/pulls/$PR/reviews \
-     -f event=APPROVE -f body="$BODY"; then
-  : # native approving review posted (GitHub records its commit_id = the head you approved;
-    #  ship-it reads that commit_id for the same staleness test the marker's @ <sha> drives)
-else
-  # APPROVE failed (e.g. 422 on your own PR) — upsert the structured pass comment instead, through
-  # the guarded tool on stdin: it PATCHes your newest own review-code marker (namespace-anchored, so
-  # it also upserts a prior advisory across a non-blocking↔blocking flip) else POSTs the first, and
-  # it fail-closes on a malformed/cross-namespace body AND on a body bound to another PR's head
-  # (the #3801 post-time cross-check) so a broken/mis-bound marker never reaches GitHub.
-  printf '%s' "$BODY" | $VERDICT post --pr "$PR" --gate code
-fi
+printf '%s' "$BODY" | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-emit-pass.sh" "$PR" "$HEAD_SHA"
 ```
+
+`$BODY` is the verdict body **you** compose — its canonical shape is the markdown block at the end of
+this step; the script only receives it. Piping it on **stdin** is the collision-proof form: with no
+file on disk there is nothing for a concurrent review of the same PR to clobber and no scratch path
+that could bleed into the `@ <sha>` field. The script runs `verdict validate` as a read-back assertion
+first, then the native `APPROVE`, falling back to the `verdict post` comment upsert — as an **explicit
+`if`**, never `APPROVE || post`, because a pipe around the APPROVE call would make the pipeline's
+status mask its failure and the fallback would silently never fire.
 
 Either way, the verdict body states plainly: every acceptance criterion verified
 (the table), the PR is **merge-ready**, and — explicitly — that **review-code does not
@@ -1375,7 +1363,7 @@ merge**; the **`ship-it`** skill is the authorized merge step, and merging this 
 auto-close issue #N via its `Fixes #N`. Leave the issue as-is (it'll close on merge, not
 now).
 
-Verdict body shape (this is what you wrote to `$VERDICT_FILE` above) for the **non-blocking**
+Verdict body shape (this is the `$BODY` you pipe into the emitter above) for the **non-blocking**
 path. The first line is the **canonical bare marker** — no leading `**` emphasis, **with the
 `@ <HEAD_SHA>` you resolved above** — per the matcher contract in
 [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5; matchers tolerate an optional
@@ -1536,24 +1524,12 @@ any later use are one single-sourced read, never two independent resolutions tha
 straddle a head move:
 
 ```bash
-# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
-# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here
-# (#3653; ADR 0062/0064; epic #994)
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # resolve ONCE, before composing (mirror the PASS path)
-# Compose straight into a shell variable and pipe on stdin — NO scratch file, so no fixed/PR-keyed
-# name a concurrent run can clobber (#1465/#3718/#3801). First line: review-code: FAIL @ $HEAD_SHA — not merge-ready
-BODY="$(cat <<EOF
-review-code: FAIL @ ${HEAD_SHA} — not merge-ready
-… your per-criterion evidence table …
-EOF
-)"
-# Upsert through the guarded tool (resolved above), exactly as the PASS path: it upserts the one
-# review-code marker (namespace-anchored, advisory included) and fail-closes on a malformed/
-# cross-namespace body (so the mktemp-path `@ <sha>` leak #2683 can't land) AND on a body bound to
-# another PR's head (the #3801 post-time cross-check).
-printf '%s' "$BODY" | $VERDICT post --pr "$PR" --gate code
+HEAD_SHA="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/current-head.sh" "$PR")"   # resolve ONCE, before composing (mirror the PASS path)
+printf '%s' "$BODY" | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-emit-fail.sh" "$PR" "$HEAD_SHA"
 ```
+
+Same stdin seam as the PASS path, for the same reason — no fixed or `${PR}`-keyed scratch name a
+concurrent run can clobber (#1465/#3718/#3801). `$BODY`'s canonical shape is the markdown block below.
 
 You *may* additionally request changes via a formal review
 (`-f event=REQUEST_CHANGES`) for the native signal — but the **comment with
@@ -1644,13 +1620,13 @@ state (never a carried variable) and runs the read-back on whatever landed, on *
 [`gh-issue-intake-formats.md` §Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../gh-issue-intake-formats.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
 
 ```bash
-# UNCONDITIONAL post-verify: resolve the landed verdict from PR state (marker comment @ HEAD_SHA, the
-# advisory line, or the native APPROVE at commit_id==HEAD_SHA), then prove it present + well-formed +
-# leak-free. FATAL (non-zero) on absent / malformed / leaking — the #2264 whole-body-path leak, a
-# no-opped post, and a stale-head marker all fail here. Propagate the non-zero: never report the gate
-# done over an ungated PR. Runs no matter which 4a/4b branch posted — no $MINE, no skippable path.
-verdict_post_verify "$PR" review-code "$HEAD_SHA" || exit 1
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-readback.sh" "$PR" "$HEAD_SHA" || exit 1
 ```
+
+The script **sources** `verdict_post_verify` from
+[`../shared/scripts/verdict-readback.sh`](../shared/scripts/verdict-readback.sh) — there is no
+skill-local copy — and propagates its status. Propagate it further: never report the gate done over an
+ungated PR.
 
 `verdict_post_verify` is the load-bearing change over the old inline check: the prior presence scan
 merely *echoed* a warning on a miss and re-posted **without a non-zero exit**, so a garbled/absent

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -529,83 +529,23 @@ snapshot once mis-classified a now-control-plane PR (#981); reading §CP freshly
 
 The *boundary* is only half of it: the **changed-file list** the boundary is matched against is a
 fallible network read too, and a failed read used to resolve to "no control-plane path touched"
-(#4216). **Define `cp_changed_files` and `cp_head_sha` from
-[§CPREAD](../gh-issue-intake-formats.md#cpread) — copy them verbatim, it is the single source — before
-running the block below**, which consumes their `$CP_FILES` / `$CP_FILES_N` / `$CP_HEAD_SHA` and holds
-§CP on a non-zero return:
+(#4216). Both reads come from
+[§CPREAD](../gh-issue-intake-formats.md#cpread) — `cp_changed_files` and `cp_head_sha`, which the
+classifier **sources** from [`../shared/scripts/cp-read.sh`](../shared/scripts/cp-read.sh) rather
+than carrying a copy of, so there is nothing to keep in step (#4489). It holds §CP on a non-zero
+return:
 
 ```bash
-# §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
-# is current — a pre-amendment snapshot once mis-classified a now-control-plane PR (#981).
-# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
-# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
-# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
-CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
-# Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
-# PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
-# freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
-CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
-if [ -n "$CP_LIVE" ]; then
-  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the flag tracks origin/main, not the snapshot's age (AC1/AC2)
-else
-  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (not-auto-mergeable), never trust the possibly-stale snapshot
-fi
-# ONE hardened read of the changed-file list, feeding BOTH §CP clauses below. `cp_changed_files` is
-# §CPREAD of ../gh-issue-intake-formats.md — exit-status-checked, shape-asserted, scope-emitting; a
-# non-zero return means the read COULD NOT EXECUTE, which is UNKNOWN, not "no §CP path touched". Read
-# the why there once; do not re-derive it here. It also removes the second read this step used to make
-# (the GUARD_TOUCHING loop re-fetched the same list), so both clauses now see the same scanned scope.
-if ! cp_changed_files "$REPO" "$PR"; then
-  # FAIL CLOSED (#4216): a blinded read blinds BOTH clauses at once — the path regex AND the ADR-0164
-  # content probe, which is the only §CP signal a `.decisions/**`-only PR can produce. So resolve BOTH
-  # toward §CP; the sentinel is non-empty, which is exactly what Step 4a branches on.
-  CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
-  GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
-else
-  # grep aggregates the §CP matches ACROSS the concatenated pages — a jq `[ … ]` aggregate would
-  # instead emit one array PER PAGE. `|| true` here is now safe and means ONLY what it says: no §CP
-  # match is grep exit 1 over a list that was PROVEN to arrive (#725 + #4216).
-  CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
-  # non-empty → control-plane: emit the advisory line in the verdict (Step 4a) per ADR 0053/0065/0073
-  # §CP by CONTENT (ADR 0164): a touched .decisions/** ADR is not path-§CP, but a guard-RELAXING one is
-  # control-plane by nature. Probe each ADR's content at head with the SHARED `guard-content-probe` verb
-  # — the SAME probe ship-it Step 0, review-doc, and the driver (via trivial-diff) call, so a guard-touching
-  # ADR reads §CP consistently everywhere (issue #3645, founder ruling #3416). A mixed code+guard-ADR PR
-  # fans BOTH gates; either flagging the ADR carries the §CP merge-authority hold.
-  # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
-  # (copy it verbatim from there). It leaves HEAD_SHA EMPTY on failure by DISCARDING gh's payload,
-  # which is what makes the `[ -n ]` test below a live guard rather than a dead one.
-  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
-  # Assert on the probe's STATE WORD, never on its exit status — the exit code discriminates the two
-  # verdicts only once the verb has RUN, so the old `>/dev/null && …` shape accumulated NOTHING when it
-  # never ran (bad flag / nested-cwd module-not-found / missing shim) and read an unprobed ADR as
-  # ordinary. The `*)` arm keeps could-not-determine a HOLD, exactly as an unreadable body is (#4219).
-  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-  GUARD_TOUCHING=""
-  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"   # fail closed: no ref ⇒ no probe ⇒ UNKNOWN
-  ADR_N=0
-  while IFS= read -r adr; do
-    [ -z "$adr" ] && continue
-    [ -n "$HEAD_SHA" ] || break
-    ADR_N=$((ADR_N + 1))
-    # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
-    adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
-    if [ -z "$adr_body" ]; then
-      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # fail closed: never auto-ship an ADR that could not be read and proven guard-free
-    else
-      GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
-      case "$GC_STATE" in
-        not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
-        guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
-        *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
-      esac
-    fi
-  done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
-  echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092): a §CP classification always states its scope
-fi
-# non-empty $GUARD_TOUCHING → §CP-advisory, same as CONTROL_PLANE_TOUCHED above (Step 4a; ADR 0164/0135)
+. "$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/classify-control-plane.sh" "$PR")"
 ```
+
+Sourcing its one stdout line puts `CONTROL_PLANE_TOUCHED` and `GUARD_TOUCHING` in your shell — the
+two flags Step 4a branches on — plus the `CP_FILES_N` / `ADR_N` scope counts. **A non-empty either
+flag ⇒ §CP-advisory** (ADR 0053/0065/0073 for the path clause; ADR 0164/0135 for the content clause).
+Every failure path writes the flags as a non-empty `§CP UNKNOWN, held as control-plane` sentinel
+*before* exiting non-zero, because an empty flag is exactly what Step 4a reads as auto-mergeable —
+and if even the handle could not be written, stdout is empty, the `.` fails loudly, and the PR is
+held as control plane.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1089,10 +1089,12 @@ Every other read/write in this skill stays REST.
 > `skill-gh-lint` job runs `gh-phoenix lint-skills` over the corpus and FAILs on any `gh api graphql`
 > in a runnable block — **including a whole `.sh`**. The lint's `SELF_EXEMPT_SUFFIXES` exempts
 > `/skills/review-code/SKILL.md` as a whole file, so the read is lawful *here* and would be flagged
-> the moment it landed in a script, and continuing the exemption means editing the very
-> `SELF_EXEMPT_SUFFIXES` array
-> [PR #4491](https://github.com/kamp-us/phoenix/pull/4491) is already changing for ship-it's two
-> extracted scripts. The operative rule: a block a guard parses out of the markdown cannot move until
+> the moment it landed in a script. The idiom that would cover an extracted script already exists:
+> [#4491](https://github.com/kamp-us/phoenix/pull/4491) **landed** (`15263296`) two **per-script**
+> entries in that same array, annotated there as deliberately *not* a `scripts/`-wide exemption. But
+> adding a `review-code/scripts/*.sh` entry edits
+> `packages/pipeline-cli/src/tools/gh-phoenix/lint.ts` — a **code-class** file outside a skills-only
+> extraction child. The operative rule: a block a guard parses out of the markdown cannot move until
 > the guard follows. It stays inline until that lands, and the remainder is tracked on
 > [#4451](https://github.com/kamp-us/phoenix/issues/4451).
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Step 2 — the §CP merge-blocking flag: the path clause (CONTROL_PLANE_RE, re-resolved from
+# origin/main) and the ADR-0164 content clause (guard-touching `.decisions/**`). Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts. The *why* for each clause stays in that step's prose.
+#
+# STDOUT IS A MACHINE CHANNEL: the only stdout line is the run-state handle carrying
+# CONTROL_PLANE_TOUCHED / GUARD_TOUCHING / CP_FILES_N / ADR_N, so Step 4a can
+# `. "$(classify-control-plane.sh "$PR")"` and branch on the two flags. Scope + diagnostic lines go
+# to stderr.
+#
+# EVERY failure path WRITES THE HANDLE WITH THE §CP SENTINEL FIRST, then exits non-zero. That is the
+# whole reason this script exists in this shape: an empty `$CONTROL_PLANE_TOUCHED` is what Step 4a
+# reads as "auto-mergeable", so a classifier that could not run must never reach the caller as an
+# unset/empty flag. An absent or empty result is UNKNOWN, and UNKNOWN is never "no §CP path touched"
+# (§ZS / ADR 0092; #4216, #4231, #4010, #4219). If even the handle cannot be written, stdout stays
+# EMPTY and the caller's `.` fails loudly — hold the PR as §CP.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+# §CPREAD's `cp_changed_files` + `cp_head_sha`, sourced from their canonical home — no skill-local
+# copy to drift (#4489 extracted them out of ../../gh-issue-intake-formats.md, which is why the step
+# prose no longer says "copy them verbatim").
+# shellcheck source=../../shared/scripts/cp-read.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
+
+SENTINEL="<§CP classifier could not run — §CP UNKNOWN, held as control-plane>"
+HANDLE=""
+# emit_and_exit <status> <control-plane-touched> <guard-touching> <cp-files-n> <adr-n>
+emit_and_exit() {
+  if [ -n "$HANDLE" ]; then
+    {
+      printf 'CONTROL_PLANE_TOUCHED=%q\n' "$2"
+      printf 'GUARD_TOUCHING=%q\n' "$3"
+      printf 'CP_FILES_N=%s\n' "$4"
+      printf 'ADR_N=%s\n' "$5"
+    } > "$HANDLE"
+    printf '%s\n' "$HANDLE"
+  else
+    echo "classify-control-plane.sh: could not open the per-run handle — no §CP answer was produced. Hold the PR as CONTROL PLANE." >&2
+  fi
+  exit "$1"
+}
+
+[ "$#" -ge 1 ] || { echo "usage: classify-control-plane.sh <pr>" >&2; emit_and_exit 2 "$SENTINEL" "$SENTINEL" 0 0; }
+PR="$1"
+HANDLE="$(kp_scratch_open review-code-cp)/cp.env" || HANDLE=""
+# Top-level assignment, never `local` — `local REPO="$(kp_repo)"` masks the substitution's status,
+# and this guard's whole job is to catch it.
+REPO="$(kp_repo)" || emit_and_exit 1 "$SENTINEL" "$SENTINEL" 0 0
+PCLI="$(kp_pcli)" || PCLI=""
+
+# §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
+# is current — a pre-amendment snapshot once mis-classified a now-control-plane PR (#981).
+# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
+# Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
+# PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
+# freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
+CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+if [ -n "$CP_LIVE" ]; then
+  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the flag tracks origin/main, not the snapshot's age (AC1/AC2)
+else
+  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (not-auto-mergeable), never trust the possibly-stale snapshot
+fi
+# ONE hardened read of the changed-file list, feeding BOTH §CP clauses below. `cp_changed_files` is
+# §CPREAD of ../gh-issue-intake-formats.md — exit-status-checked, shape-asserted, scope-emitting; a
+# non-zero return means the read COULD NOT EXECUTE, which is UNKNOWN, not "no §CP path touched". Read
+# the why there once; do not re-derive it here. It also removes the second read this step used to make
+# (the GUARD_TOUCHING loop re-fetched the same list), so both clauses now see the same scanned scope.
+if ! cp_changed_files "$REPO" "$PR"; then
+  # FAIL CLOSED (#4216): a blinded read blinds BOTH clauses at once — the path regex AND the ADR-0164
+  # content probe, which is the only §CP signal a `.decisions/**`-only PR can produce. So resolve BOTH
+  # toward §CP; the sentinel is non-empty, which is exactly what Step 4a branches on.
+  CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  emit_and_exit 1 "$CONTROL_PLANE_TOUCHED" "$GUARD_TOUCHING" "${CP_FILES_N:-0}" 0
+else
+  # grep aggregates the §CP matches ACROSS the concatenated pages — a jq `[ … ]` aggregate would
+  # instead emit one array PER PAGE. `|| true` here is now safe and means ONLY what it says: no §CP
+  # match is grep exit 1 over a list that was PROVEN to arrive (#725 + #4216).
+  CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
+  # non-empty → control-plane: emit the advisory line in the verdict (Step 4a) per ADR 0053/0065/0073
+  # §CP by CONTENT (ADR 0164): a touched .decisions/** ADR is not path-§CP, but a guard-RELAXING one is
+  # control-plane by nature. Probe each ADR's content at head with the SHARED `guard-content-probe` verb
+  # — the SAME probe ship-it Step 0, review-doc, and the driver (via trivial-diff) call, so a guard-touching
+  # ADR reads §CP consistently everywhere (issue #3645, founder ruling #3416). A mixed code+guard-ADR PR
+  # fans BOTH gates; either flagging the ADR carries the §CP merge-authority hold.
+  # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
+  # (sourced above from ../../shared/scripts/cp-read.sh). It leaves HEAD_SHA EMPTY on failure by
+  # DISCARDING gh's payload, which is what makes the `[ -n ]` test below a live guard rather than a dead one.
+  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+  # Assert on the probe's STATE WORD, never on its exit status — the exit code discriminates the two
+  # verdicts only once the verb has RUN, so the old `>/dev/null && …` shape accumulated NOTHING when it
+  # never ran (bad flag / nested-cwd module-not-found / missing shim) and read an unprobed ADR as
+  # ordinary. The `*)` arm keeps could-not-determine a HOLD, exactly as an unreadable body is (#4219).
+  GUARD_TOUCHING=""
+  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"   # fail closed: no ref ⇒ no probe ⇒ UNKNOWN
+  ADR_N=0
+  while IFS= read -r adr; do
+    [ -z "$adr" ] && continue
+    [ -n "$HEAD_SHA" ] || break
+    ADR_N=$((ADR_N + 1))
+    # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
+    adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+    if [ -z "$adr_body" ]; then
+      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # fail closed: never auto-ship an ADR that could not be read and proven guard-free
+    else
+      GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+      case "$GC_STATE" in
+        not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+        guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
+        *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
+      esac
+    fi
+  done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
+  echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed" >&2   # §ZS #1 (ADR 0092): a §CP classification always states its scope
+fi
+# non-empty $GUARD_TOUCHING → §CP-advisory, same as CONTROL_PLANE_TOUCHED above (Step 4a; ADR 0164/0135)
+emit_and_exit 0 "$CONTROL_PLANE_TOUCHED" "$GUARD_TOUCHING" "$CP_FILES_N" "$ADR_N"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
@@ -42,9 +42,13 @@ emit_and_exit() {
   exit "$1"
 }
 
+# Open the handle BEFORE the argument check, so even a usage error reaches the caller as the §CP
+# sentinel IN THE HANDLE rather than as 0 bytes on stdout. Measured: with the checks the other way
+# round the usage path exited 2 with an empty stdout, which is still fail-closed (the caller's `.`
+# fails loudly) but hands it no readable flag.
+HANDLE="$(kp_scratch_open review-code-cp)/cp.env" || HANDLE=""
 [ "$#" -ge 1 ] || { echo "usage: classify-control-plane.sh <pr>" >&2; emit_and_exit 2 "$SENTINEL" "$SENTINEL" 0 0; }
 PR="$1"
-HANDLE="$(kp_scratch_open review-code-cp)/cp.env" || HANDLE=""
 # Top-level assignment, never `local` — `local REPO="$(kp_repo)"` masks the substitution's status,
 # and this guard's whole job is to catch it.
 REPO="$(kp_repo)" || emit_and_exit 1 "$SENTINEL" "$SENTINEL" 0 0
@@ -70,7 +74,11 @@ fi
 # non-zero return means the read COULD NOT EXECUTE, which is UNKNOWN, not "no §CP path touched". Read
 # the why there once; do not re-derive it here. It also removes the second read this step used to make
 # (the GUARD_TOUCHING loop re-fetched the same list), so both clauses now see the same scanned scope.
-if ! cp_changed_files "$REPO" "$PR"; then
+# `>&2` on the call, not on a subshell: cp_changed_files writes its §ZS scope line to STDOUT, and
+# stdout here is the handle channel — measured, an un-redirected call put the scope line ahead of the
+# handle path and the caller's `. "$(…)"` tried to source it. A redirection on a function invocation
+# still lets the function's assignments reach this shell (no subshell), so $CP_FILES survives.
+if ! cp_changed_files "$REPO" "$PR" >&2; then
   # FAIL CLOSED (#4216): a blinded read blinds BOTH clauses at once — the path regex AND the ADR-0164
   # content probe, which is the only §CP signal a `.decisions/**`-only PR can produce. So resolve BOTH
   # toward §CP; the sentinel is non-empty, which is exactly what Step 4a branches on.
@@ -91,7 +99,7 @@ else
   # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
   # (sourced above from ../../shared/scripts/cp-read.sh). It leaves HEAD_SHA EMPTY on failure by
   # DISCARDING gh's payload, which is what makes the `[ -n ]` test below a live guard rather than a dead one.
-  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+  cp_head_sha "$REPO" "$PR" >&2; HEAD_SHA="$CP_HEAD_SHA"   # stdout is the handle channel — see the note above
   # Assert on the probe's STATE WORD, never on its exit status — the exit code discriminates the two
   # verdicts only once the verb has RUN, so the old `>/dev/null && …` shape accumulated NOTHING when it
   # never ran (bad flag / nested-cwd module-not-found / missing shim) and read an unprobed ADR as

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-issueless.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-issueless.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Step 1 — the class-aware no-linked-issue decision (ADR 0184/0075). Prints exactly ONE of two
+# lines: the carve-out line (legitimate, `ISSUE` stays unset) or the hard-stop line. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+#
+# The carve-out line is the PERMISSIVE answer, so every path that returns before the classification
+# runs prints the HARD-STOP line first: a classifier that could not run is UNKNOWN, and UNKNOWN is
+# never "legitimately issueless" (§ZS / ADR 0092; #4231, #4010, #4219). The `FILES=` read below needs
+# no separate sentinel — gh writes its error document to STDOUT, which matches no `^\.glossary/` path,
+# so a failed read already falls into the hard-stop branch.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+HARD_STOP="no linked issue on a PR carrying behavioral code — broken seam: hard-stop (dangling-code guard, ADR 0184)"
+
+[ "$#" -ge 1 ] || {
+	echo "$HARD_STOP"
+	echo "usage: classify-issueless.sh <pr>" >&2
+	exit 2
+}
+PR="$1"
+# Top-level assignment, never `local` — `local REPO="$(kp_repo)"` masks the substitution's status.
+REPO="$(kp_repo)" || { echo "$HARD_STOP"; exit 1; }
+
+# no linked issue → class-aware. The carve-out is scoped EXACTLY to the conversation-authored
+# coining class: the diff touches the `.glossary/**` CODE-class vocabulary coining site (ADR 0128)
+# AND every changed path lies on a conversation-authored surface — `.glossary/**`, or a doc
+# companion (`.decisions/**` / `.patterns/**`) carried in the same recording — and NOTHING else.
+# Any path off those surfaces (`apps/**`, `packages/**`, `infra/**`, a code-root README, a root
+# script) is behavioral work with a missing `Fixes #N` ⇒ a broken seam ⇒ hard-stop. Same file set +
+# same path-prefix class Step 2's skills-only route uses — no second class mechanism.
+# "every path is conversation-authored" is the EMPTY-OUTPUT form, never `! grep -qv` (§WL, #4155).
+FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
+OFFSURFACE="$(grep -vE '^(\.glossary|\.decisions|\.patterns)/' <<<"$FILES")"
+if [ -n "$FILES" ] \
+   && grep -qE '^\.glossary/' <<<"$FILES" \
+   && [ -z "$OFFSURFACE" ]; then
+  echo "conversation-authored .glossary/** coining site, no Fixes #N — legitimate (ADR 0184/0075): ISSUE stays unset, AC half N/A"
+else
+  echo "no linked issue on a PR carrying behavioral code — broken seam: hard-stop (dangling-code guard, ADR 0184)"
+fi

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-skills-only.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-skills-only.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Step 2 — the skills-only off-ramp (ADR 0073 supersedes 0063's `skills/**` → review-code routing).
+# Prints `not a code PR — route to review-skill` and exits 0 ONLY on a proven skills-only diff;
+# prints nothing and exits 0 when the PR carries code. Extracted from review-code/SKILL.md (#4451,
+# epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+#
+# The off-ramp line is the answer that STOPS the code gate, so it is the permissive one here: every
+# path that returns before the predicate runs prints `CANNOT-CLASSIFY (…)` instead and exits
+# non-zero, and the caller reads the status before the stdout. A classifier that could not run is
+# UNKNOWN, and UNKNOWN is never "no code to gate" (§ZS / ADR 0092; #4231, #4010, #4219). The `FILES=`
+# read needs no separate sentinel: gh writes its error document to STDOUT, so a failed read leaves a
+# non-`skills/`-prefixed line in `$OFFCLASS` and the predicate correctly refuses the off-ramp.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+# §WL's `kp_wl_all_onclass` — the empty-output form of "every changed path is under skills/ or
+# agents/", sourced from its canonical home rather than re-copied (#4489 extracted it out of
+# ../../gh-issue-intake-formats.md). Never `! grep -qv`: a false-true there `exit 0`s the code gate
+# on a PR that does carry code (§WL, #4155).
+# shellcheck source=../../shared/scripts/wl-empty-output.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/wl-empty-output.sh"
+
+[ "$#" -ge 1 ] || {
+	echo "CANNOT-CLASSIFY (no <pr> argument — artifact class UNKNOWN, never an off-ramp)"
+	echo "usage: classify-skills-only.sh <pr>" >&2
+	exit 2
+}
+PR="$1"
+REPO="$(kp_repo)" || {
+	echo "CANNOT-CLASSIFY (target repo unresolved — artifact class UNKNOWN, never an off-ramp)"
+	exit 1
+}
+
+# the file set drives the class decision (same list Step 2 pulled)
+# shellcheck disable=SC2034  # read by the sourced kp_wl_all_onclass, which takes $FILES from the caller
+FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
+# skills-only ⇒ every changed path is under skills/ or agents/ — review-skill's class, not yours
+# (agents/** are behavioral artifacts, review-skill-routed for the verdict — ADR 0150/#2003).
+if kp_wl_all_onclass; then
+  echo "not a code PR — route to review-skill"   # plain note, no review-code: marker; stop
+  exit 0
+fi

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/comment-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/comment-scan.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Step 3d — the comment-discipline scan (ADR 0119): the added lines this PR introduced on
+# comment-bearing code files, plus the §ZS #1 scope line. Extracted from review-code/SKILL.md
+# (#4451, epic #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# The scan ARMS the judgement, it never decides it — WHICH of these lines are comments, and which of
+# those earn their place, is the reviewer's call per the `deslop-comments` rubric (a regex cannot
+# tell a load-bearing KEEP note from narration slop, which is the point). So the lines themselves go
+# to stdout after the scope line: the fence left them in `$ADDED_ON_CODE` for the reviewer to read,
+# and a script boundary has no shell variable to hand back.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: comment-scan.sh <pr>" >&2; exit 2; }
+PR="$1"
+
+# the added lines this PR introduced on comment-bearing code files, off the diff Step 2 already
+# loaded (the reviewer judges WHICH are comments per the deslop-comments rubric — a regex can't,
+# which is the point). Emit the scanned scope (§ZS #1) so a future drift that silently stops
+# finding added comment lines is visible in the run output rather than reading green.
+ADDED_ON_CODE="$(gh pr diff "$PR" \
+  | awk '/^\+\+\+ b\/.*\.(ts|tsx|js|jsx|css)$/{f=substr($0,7);next} /^\+\+\+ /{f=""} f && /^\+[^+]/{print f": "substr($0,2)}')"
+echo "comment-discipline: scanned $(printf '%s\n' "$ADDED_ON_CODE" | grep -c . || echo 0) added line(s) on comment-bearing files"
+printf '%s\n' "$ADDED_ON_CODE"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/containment-marker.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/containment-marker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Step 3b — the linked issue's `**Containment:**` marker, read tolerantly (formats §2). Prints
+# exactly one of `flag` | `exempt` | `none`; a missing line reads as `none`. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+#
+# `none` is the SKIP answer, so it is the permissive one here — every path that returns before the
+# read completes must NOT print it. On a usage error or an unresolvable repo this prints `flag`
+# instead and exits non-zero: an unread marker is UNKNOWN, and holding UNKNOWN at the ARMED value
+# means the gating verification runs rather than being silently skipped (§ZS / ADR 0092). The
+# fail-closed direction differs from the classifiers above because here the *armed* state is the
+# conservative one.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo flag; echo "usage: containment-marker.sh <issue>" >&2; exit 2; }
+ISSUE="$1"
+REPO="$(kp_repo)" || { echo flag; echo "containment-marker.sh: target repo unresolved — marker UNKNOWN, held ARMED (flag)." >&2; exit 1; }
+
+# the linked issue's containment marker; a missing line reads as `none` (formats §2 tolerant-read rule)
+CONTAINMENT=$(gh api repos/"$REPO"/issues/"$ISSUE" --jq '.body' \
+  | grep -ioE '\**\s*Containment:\**\s*(flag|exempt|none)' | head -n1 \
+  | grep -ioE '(flag|exempt|none)' || echo none)
+printf '%s\n' "$CONTAINMENT"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/current-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/current-head.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Step 4a/4b — the head SHA you actually reviewed, resolved ONCE before composing the verdict, so the
+# SHA the marker carries and every later use are one single-sourced read rather than two independent
+# resolutions that could straddle a head move. Extracted from review-code/SKILL.md (#4451, epic
+# #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# Prints a bare 40-hex SHA or NOTHING. Shape-asserted, because gh writes its error document to
+# STDOUT on failure: an unshape-checked capture would put that document into the marker's `@ <sha>`
+# field, and `verdict post`'s emissionDefect gate would then refuse the whole verdict (#2683).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: current-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+HEAD_SHA="$(gh api repos/"$REPO"/pulls/"$PR" --jq .head.sha)" || {
+  echo "current-head.sh: head SHA read FAILED (payload discarded) — no SHA to bind a verdict to." >&2; exit 1; }
+case "$HEAD_SHA" in
+  *[!0-9a-f]*|"") echo "current-head.sh: head SHA is not bare hex — discarded (never let gh's error body reach the marker's @ <sha>; #2683)." >&2; exit 1 ;;
+esac
+[ "${#HEAD_SHA}" -eq 40 ] || { echo "current-head.sh: head SHA is not a 40-char ref — discarded." >&2; exit 1; }
+printf '%s\n' "$HEAD_SHA"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Step 3b — the one canonical product-development-cycle probe (formats §1). SOURCE it (`. cycle-doc-probe.sh`)
+# with REPO set: the point is the $CYCLE_DOC it leaves in the caller's shell. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts. The graceful-absence *why* (ADR 0062 — absence is a
+# first-class correct state) stays in that step's prose.
+#
+# DELIBERATELY NOT the shared ../../shared/scripts/cycle-doc-probe.sh, even though the two are
+# equivalent: the cycle validators (../validate-cycle-presence.sh / ../validate-cycle-absence.sh)
+# resolve each skill's scan surface via `kp_skill_shell_surfaces`, which is scoped to the skill's OWN
+# directory on purpose — so sourcing the shared copy would move review-code's cycle wiring off its
+# guarded surface and the validators would fail, correctly. Per-skill wiring stays per-skill; the rule
+# is stated once at `kp_skill_shell_surfaces` in ../../shared/lib/common.sh.
+#
+# Sets no shell options and installs no EXIT trap (#4476, class #4479).
+
+REPO="${REPO:-${1:?cycle-doc-probe.sh: REPO unset and no \$1 — refusing to probe an unnamed repo}}"
+
+# the one canonical cycle-doc probe (formats §1); absent ⇒ no cycle ⇒ skip the gating check
+# shellcheck disable=SC2034  # $CYCLE_DOC is this script's whole output — it is read by the SOURCING caller
+gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1 \
+  && CYCLE_DOC=present || CYCLE_DOC=absent
+# run the gating verification below ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/full-unit-project.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/full-unit-project.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Step 2 degrade path — the FULL unit project, never a path-narrowed subset. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts. The why — that a feature-scoped green while a cross-cutting
+# contract test is red is the #1657-class false green (ADR 0092) — stays in that step's prose.
+#
+# `test:unit` lives in `apps/web/package.json`, NOT the repo root, so the `-C` target is
+# `$REVIEW_WT/apps/web`; a bare `pnpm -C "$REVIEW_WT" test:unit` hits ERR_PNPM_NO_SCRIPT.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# re-source $REVIEW_WT/$PR_REF after a between-call reset (#1807)
+# shellcheck disable=SC1007,SC1090
+. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || exit 1
+: "${REVIEW_WT:?full-unit-project.sh: REVIEW_WT unset — the head was never materialized; refusing to test the base tree (§HEAD)}"
+
+pnpm -C "$REVIEW_WT/apps/web" test:unit   # FULL unit project (the apps/web script) — never path-narrowed on the degrade path

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Step 3c — the glossary-freshness gate: the three new-surface detectors, the positive-evidence-of-scope
+# probe, and the four-outcome verdict chain. Extracted from review-code/SKILL.md (#4451, epic #4435
+# phase 1) — blocks 18 and 19 land in ONE script because the chain consumes the detectors' variables,
+# which no longer survive as shell state across two fenced blocks. Extraction contract:
+# ../SKILL.md § The extracted scripts. The *why* for each outcome stays in that step's prose.
+#
+# Prints exactly one `glossary-freshness: …` line. The two `not applicable` lines are the SKIP answers,
+# so a run that could not evaluate must never print one: every early exit prints
+# `glossary-freshness: CANNOT-EVALUATE (…)` and exits non-zero, which the caller folds as an
+# `[UNVERIFIABLE]` row — the same blocking soft-fail the detector-blind branch yields. An absent or
+# empty result is UNKNOWN, and UNKNOWN is never a skip (§ZS / ADR 0092; #4299).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+cannot() { echo "glossary-freshness: CANNOT-EVALUATE ($1) — fold as [UNVERIFIABLE], never as a not-applicable skip (§ZS, #4299)"; exit "${2:-1}"; }
+
+[ "$#" -ge 1 ] || { echo "usage: glossary-freshness.sh <pr>" >&2; cannot "no <pr> argument" 2; }
+PR="$1"
+REPO="$(kp_repo)" || cannot "target repo unresolved"
+# BASE_REF comes from the head handle materialize-head.sh wrote — the FRESHLY FETCHED base every
+# existence probe below reads against, never the working tree (formats §RO; the PR #305 false-FAIL).
+# shellcheck disable=SC1007,SC1090
+. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || cannot "no head handle — run materialize-head.sh first (its \`git fetch origin \$BASE_REF\` is what makes these probes fresh)"
+[ -n "${BASE_REF:-}" ] || cannot "handle carries no BASE_REF"
+
+# the file list WITH status (Step 2 already loaded the diff; this reuses the same files endpoint)
+# --paginate + streaming --jq so the full set past file #100 is seen (the API caps per_page at 100; #725)
+FILES_STATUS="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+  --jq '.[] | "\(.status)\t\(.filename)"')"
+ADDED="$(printf '%s\n' "$FILES_STATUS" | awk -F'\t' '$1=="added"{print $2}')"
+
+# (1) a NEW feature folder: an added file under apps/web/worker/features/<dir>/... whose <dir>
+#     did not exist on fresh base. Dedupe to the folder; a folder is new iff base has no tree there.
+NEW_FEATURE_DIRS=""
+for d in $(printf '%s\n' "$ADDED" \
+            | sed -nE 's#^(apps/web/worker/features/[^/]+)/.*#\1#p' | sort -u); do
+  # read-only existence probe against FRESH base — never the working tree (formats §RO)
+  git cat-file -e "origin/$BASE_REF:$d" 2>/dev/null || NEW_FEATURE_DIRS="$NEW_FEATURE_DIRS $d"
+done
+
+# (2) a NEW public package: an added packages/<pkg>/package.json whose package dir is absent on base
+NEW_PACKAGES=""
+for p in $(printf '%s\n' "$ADDED" \
+            | sed -nE 's#^(packages/[^/]+)/package\.json$#\1#p' | sort -u); do
+  git cat-file -e "origin/$BASE_REF:$p/package.json" 2>/dev/null || NEW_PACKAGES="$NEW_PACKAGES $p"
+done
+
+# A new public EXPORT from an existing package is the third surface — a public entry point
+# (packages/<pkg>/src/index.ts, or the file a package.json "exports"/"main" names) that the diff
+# CHANGES to expose a new name. This one is read from the diff hunk, not a path-status test:
+# inspect the diff of any touched public entry for an added `export …` line. Treat a public-entry
+# file with an added export as a new surface for this gate.
+PUBLIC_ENTRY_EXPORT_ADDED="$(gh pr diff "$PR" \
+  | awk '/^\+\+\+ b\/packages\/[^/]+\/src\/index\.(ts|tsx)$/{e=1;next}
+         /^\+\+\+ /{e=0} e && /^\+[^+].*\bexport\b/{print}')"
+
+# the union: is there ANY new surface?
+NEW_SURFACE="$(printf '%s %s %s' "$NEW_FEATURE_DIRS" "$NEW_PACKAGES" "$PUBLIC_ENTRY_EXPORT_ADDED" | tr -s ' ')"
+
+# does the PR touch the glossary's domain-noun file? (added OR modified — any touch counts)
+GLOSSARY_TOUCHED="$(printf '%s\n' "$FILES_STATUS" | awk -F'\t' '$2==".glossary/TERMS.md"{print}')"
+
+# POSITIVE EVIDENCE OF SCOPE (§ZS / ADR 0092's "default FAIL, pass on positive evidence"): can the
+# three detectors above express ANYTHING in this repo at all? An empty $NEW_SURFACE has two causes —
+# "this PR added no surface" (a fact about the PR) and "this repo has no surface of the kind I know
+# how to look for" (a fact about the DETECTOR) — and until this probe they produced the identical
+# not-applicable line (#4299). Read-only, against fresh base, same as every probe above.
+DETECTOR_SURFACES="$(
+  git ls-tree --name-only "origin/$BASE_REF:apps/web/worker/features" 2>/dev/null
+  git ls-tree -r --name-only "origin/$BASE_REF:packages" 2>/dev/null | grep -E '^[^/]+/package\.json$'
+)"
+DETECTOR_SURFACES_N="$(printf '%s\n' "$DETECTOR_SURFACES" | grep -c . || true)"
+
+# The graceful-absence probe LEADS the chain, EXECUTED — never asserted in prose. Every branch below
+# claims the glossary is on base, so a repo that never adopted it must be excluded by a real test or
+# the final `else` states a fact it never checked — the gate's own sin, one branch over (#4299).
+if ! git cat-file -e "origin/$BASE_REF:.glossary/TERMS.md" 2>/dev/null; then
+  echo "glossary-freshness: not applicable — no .glossary/TERMS.md on base"   # graceful absence: no row
+elif [ -n "$(printf '%s' "$NEW_SURFACE" | tr -d ' ')" ]; then
+  echo "glossary-freshness: scanned new surfaces ⇒$NEW_SURFACE"   # §ZS #1: emit what it scanned
+  if [ -n "$GLOSSARY_TOUCHED" ]; then
+    echo "glossary-freshness: PASS — new surface ships with a .glossary/TERMS.md touch"
+  else
+    echo "glossary-freshness: FAIL — new surface added but .glossary/TERMS.md untouched (§ZS relevant-but-zero-match)"
+    # fold as a FAIL facet in the verdict table (and/or append the in-scope AC per the §2 surface)
+  fi
+elif [ "$DETECTOR_SURFACES_N" -gt 0 ]; then
+  echo "glossary-freshness: not applicable — no new feature folder / public package / export in this PR (detector expressible here: $DETECTOR_SURFACES_N candidate surface(s) on base)"   # §ZS #3 skip
+else
+  echo "glossary-freshness: UNVERIFIABLE — detector blind: .glossary/TERMS.md is on origin/$BASE_REF, but this repo has ZERO surfaces the detector can express (no apps/web/worker/features/* dir, no packages/*/package.json on base). The empty scan is a fact about the DETECTOR, not this PR — it is NOT evidence the PR added no surface."
+  # fold as an [UNVERIFIABLE] facet in the verdict table — a blocking soft fail, never an omitted row
+fi

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Print the absolute path of the run-state handle `materialize-head.sh` wrote (REVIEW_WT / PR_REF /
+# HEAD_SHA / BASE_REF), so any later step re-derives it with `. "$(head-env.sh)"` after the harness
+# resets the shell between Bash calls. Extracted from review-code/SKILL.md's repeated
+# `. "$WT_FILE"` re-source line (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+#
+# The namespace is per-run and per-session (§SP, #3718), which is what keeps a SIBLING reviewer's
+# tree out of reach — the failure a `git worktree list` re-derivation on a shared leaf name walks
+# straight into, pinning the wrong head (#1807). Exits non-zero with EMPTY stdout when the namespace
+# was never opened, so a caller's `.` fails loudly instead of reading the base tree.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+DIR="$(kp_scratch_path review-code-head)" || exit 1
+[ -f "$DIR/head.env" ] || {
+  echo "head-env.sh: no head handle at \$namespace/head.env — run materialize-head.sh first; NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
+  exit 1
+}
+printf '%s\n' "$DIR/head.env"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/issue-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/issue-context.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Step 1 — the linked issue (its `### Acceptance criteria` lives in the body) plus the progress trail
+# write-code left. Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: issue-context.sh <issue>" >&2; exit 2; }
+ISSUE="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh api repos/"$REPO"/issues/"$ISSUE" --jq '{number, state, assignee: .assignee.login, body}'
+# the progress trail write-code left — context, not evidence
+gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/linked-issue-timeline.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/linked-issue-timeline.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Step 1 — the PR↔issue link events, the cross-check when the body's `Fixes #N` is not obvious.
+# Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# Empty output here means "no link event found", which is exactly what Step 1's class-aware branch
+# then has to decide about — it is NOT a positive "standalone PR", and the caller never reads it as
+# one: `classify-issueless.sh` is what answers that, fail-closed, on its own evidence.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: linked-issue-timeline.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+# timeline shows "connected"/"cross-referenced" events linking PR ↔ issue
+# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
+# invisible without it on a long-lived PR's timeline (#4193)
+gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
+  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Step 2 — §HEAD materialization: the isolation preflight, the fresh base fetch, the head worktree,
+# and the ADR-0049/0052 instruction-denylist removal + absence assert. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts. The *why* for every step stays in that step's prose.
+#
+# STDOUT IS A MACHINE CHANNEL: the ONLY thing this script writes to stdout is the absolute path of
+# the run-state handle carrying REVIEW_WT / PR_REF / HEAD_SHA / BASE_REF. Every progress, scope and
+# FATAL line goes to stderr, so the caller can `. "$(materialize-head.sh "$PR")"` and have the four
+# values in its own shell. On ANY failure path stdout stays EMPTY and the exit is non-zero — the
+# caller's `.` then fails loudly rather than sourcing a half-written handle (§ZS: a materialization
+# that could not run is UNKNOWN, and reviewing the BASE tree is the #793 false-PASS hazard).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+# §RO-iso's `iso_preflight`, sourced from its canonical home rather than re-copied (#4489 extracted
+# it out of ../../gh-issue-intake-formats.md).
+# shellcheck source=../../shared/scripts/iso-preflight.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/iso-preflight.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: materialize-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+PCLI="$(kp_pcli)" || exit 127
+
+# Isolation preflight FIRST, before any head fetch / `git worktree add` below. If this
+# review-code spawn expected worktree isolation (reviewer agent-type) but the #2440 harness no-op
+# dropped it onto the shared PRIMARY checkout ($WORKTREE_ROOT unset), materializing the head here
+# is the #2452/#2453 primary-checkout-detach surface — fail closed LOUD and route up, never
+# materialize. Single-sourced in gh-issue-intake-formats.md §RO-iso (ADR 0172; the write-code
+# wt_preflight sibling). A genuine standalone run on the owner's checkout still proceeds.
+iso_preflight review-code >&2 || exit 1
+
+# the trusted base — the PR's merge target at tip; your config already comes from here
+BASE_REF="$(gh api repos/"$REPO"/pulls/"$PR" --jq '.base.ref')"   # normally main
+[ -n "$BASE_REF" ] || { echo "FATAL: could not resolve the PR's base ref — aborting (the base is half of verification; §HEAD)." >&2; exit 1; }
+
+# Refresh the base BEFORE any "is-it-shipped on main" ground-truth check (Step 3). The PR
+# head reaches its own ref, but the base is the *other* half of verification — a long-lived
+# or busy checkout's local main goes stale, so an "is X shipped?" check read off the working
+# tree is only as fresh as whoever's checkout the gate ran in. This is the freshness gap
+# complementary to ADR 0052's config-isolation: 0052 pins your *config* to the base; this
+# pins your *ground-truth* to the base too. (PR #305 false-FAILed on exactly this — a doc
+# whose consumers had merged minutes earlier was FAILed against a stale local main.)
+git fetch origin "$BASE_REF" >&2
+
+# §HEAD steps 1–3 (resolve the live head SHA, fetch pull/$PR/head into a per-run ref WITHOUT
+# touching the session tree, assert the fetched ref IS that head, add a throwaway DETACHED head
+# worktree) are the shared `pipeline-cli review-head materialize` verb (#3690 / #793 / #1807) —
+# cite it, don't re-derive it. `pull/<pr>/head` resolves for same-repo AND cross-fork PRs, so there
+# is no separate cross-fork branch to check out (the trust inversion ADR 0052 closes); the verb
+# never runs `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the
+# shared PRIMARY the harness resets this cwd to and detach the human's `main` — #2270/#1103), and it
+# nonce-uniques the ref per invocation so a concurrent review of the same PR can't overwrite it
+# (#1807). It emits the resolved head + ref + worktree as JSON. Persist those to a per-run handle so
+# they survive the harness cwd/shell reset between Bash calls (a shell var is lost across calls) —
+# NEVER re-derive from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING
+# reviewer's tree and pins the wrong head).
+# The `--worktree` tree is a FULL checkout (ADR 0067): biome.jsonc + biome-plugins/, patches/, the
+# catalog/lockfile, and everything `fate generate` needs are present, so the typecheck bootstrap is
+# whole. A full checkout also lands the head's root CLAUDE.md + .claude/.decisions/.patterns — that
+# leak is closed by the explicit denylist removal + absence-assert below, NOT by any pattern set.
+WT_FILE="$(kp_scratch_open review-code-head)/head.env" || exit 1
+"$PCLI" review-head materialize --pr "$PR" --worktree \
+  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
+printf 'BASE_REF=%s\n' "$BASE_REF" >> "$WT_FILE"
+# shellcheck disable=SC1090  # the run-unique handle this script just wrote
+. "$WT_FILE"
+[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
+  echo "FATAL: review-head materialize did not yield a head worktree — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
+
+# LAYER-2 containment (#2666): a freshly materialized worktree MUST come up pristine — assert it
+# clean NOW, before the denylist `rm --cached` below deliberately dirties it. A dirty materialization
+# means a corrupted head checkout, and reviewing a contaminated tree is a false signal. Fail-closed
+# LOUD via the single-sourced, tested helper (packages/pipeline-cli/src/tools/worktree-guard).
+"$PCLI" worktree-guard assert-clean --path "$REVIEW_WT" >&2 || {
+  echo "FATAL: review worktree came up dirty at materialization — aborting (never review a contaminated tree; #2666)." >&2
+  exit 1
+}
+
+# Enforce the instruction denylist EXPLICITLY: remove the head's instruction surfaces from
+# the review tree so they never reach the reviewing agent's path (ADR 0049/0052 boundary; a
+# full checkout would otherwise leave root CLAUDE.md on disk). Config still comes from the
+# trusted base — this tree is run *against* via `pnpm -C`, never `cd`'d into.
+git -C "$REVIEW_WT" rm -r -q --cached --ignore-unmatch \
+  CLAUDE.md .claude .decisions .patterns >&2
+rm -rf "$REVIEW_WT/CLAUDE.md" "$REVIEW_WT/.claude" "$REVIEW_WT/.decisions" "$REVIEW_WT/.patterns"
+
+# ASSERT absence — the load-bearing isolation check (ADR 0067 §Consequences). If any denied
+# path is still on disk the isolation is broken: abort the review rather than read head config.
+for p in CLAUDE.md .claude .decisions .patterns; do
+  if [ -e "$REVIEW_WT/$p" ]; then
+    echo "FATAL: denied instruction surface '$p' present in review worktree — isolation broken; aborting" >&2
+    exit 1
+  fi
+done
+
+# The handle path — the ONLY stdout line, so the caller can `. "$(materialize-head.sh "$PR")"`.
+printf '%s\n' "$WT_FILE"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/pr-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/pr-context.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Step 1 — the PR's state / head / base / body (the `Fixes #N` lives in the body). Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pr-context.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+# the PR: state, head branch, body (the Fixes #N lives here), mergeability
+gh api repos/"$REPO"/pulls/"$PR" \
+  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/pr-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/pr-diff.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Step 2 — the full diff plus the changed-file list. Extracted from review-code/SKILL.md (#4451,
+# epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pr-diff.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+# the full diff — gh pr diff is the reliable form; the diff media type is the REST equivalent
+gh pr diff "$PR" \
+  || gh api repos/"$REPO"/pulls/"$PR" -H "Accept: application/vnd.github.v3.diff"
+# files touched, at a glance
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'   # --paginate: streaming --jq, pages concatenate — the full set past file #100 (#725)

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/resolve-repo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name`. Extracted from review-code/SKILL.md (#4451, epic #4435
+# phase 1). Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# Top-level assignment, never `local` — `local REPO="$(kp_repo)"` takes `local`'s own status and
+# masks the substitution's, so an unresolvable repo would sail through as the empty string and
+# address `gh api repos//…` (the kp_repo idiom's gotcha).
+REPO="$(kp_repo)" || exit 1
+printf '%s\n' "$REPO"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-manifest.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-manifest.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Step 2 — the `present` bundle's structured results (ADR 0054 §2 fields): `checks[]` per gate step
+# and the folded JUnit `tests` summary. Extracted from review-code/SKILL.md (#4451, epic #4435
+# phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# Prints the manifest ONLY on a `present` state, exactly as the fence's `[ … ] && jq …` did — and
+# says which state it saw instead when it is not `present`, so a non-`present` bundle can never be
+# mistaken for an empty manifest (the four states are different facts; #3991).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# shellcheck disable=SC1090,SC1091
+. "$(kp_scratch_path review-code-bundle)/bundle.env" || {
+  echo "run-evidence-manifest.sh: no bundle state for this run — run run-evidence-read.sh first." >&2; exit 1; }
+: "${BUNDLE_STATE:?run-evidence-manifest.sh: BUNDLE_STATE unset — the lookup never ran; that is \`unknown\`, not \`absent\`}"
+
+if [ "$BUNDLE_STATE" = present ]; then
+  jq '.manifest | {commit, schemaVersion, checks, tests}' <"$BUNDLE_JSON"
+else
+  echo "run-evidence bundle state is '$BUNDLE_STATE', not 'present' — no manifest to cite; paste \$BUNDLE_LINE verbatim into the verdict and verify from the diff + worktree run." >&2
+fi

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-read.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Step 2 — read the SHA-bound run-evidence bundle through the one tested verb (#3991, ADR 0054 §3).
+# Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+#
+# STDOUT IS A MACHINE CHANNEL: the ONLY thing this writes to stdout is the run-state handle carrying
+# BUNDLE / BUNDLE_STATE / BUNDLE_LINE, so the caller can `. "$(run-evidence-read.sh "$PR")"`. Four
+# states come back on BUNDLE_STATE and they are DIFFERENT FACTS — `present` | `pending` | `absent` |
+# `unknown`; read the state word, never the exit alone, and never report `pending`/`unknown` as
+# `absent` (that invents a CI gap — PR #3913). An UNRESOLVED shim exits 127 with EMPTY stdout, so the
+# caller's `.` fails loudly: "could not run" is not a bundle state.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: run-evidence-read.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+PCLI="$(kp_pcli)" || exit 127
+
+HEAD_SHA="$(gh api repos/"$REPO"/pulls/"$PR" --jq '.head.sha')"
+# Exit 0 means `present` — a validated, head-bound bundle. Every other state comes back on stdout
+# as JSON, so read the state rather than branching on the exit alone.
+BUNDLE="$("$PCLI" run-evidence read --pr "$PR")" || true
+BUNDLE_STATE="$(jq -r '.state' <<<"$BUNDLE")"     # present | pending | absent | unknown
+BUNDLE_LINE="$(jq -r '.reportLine' <<<"$BUNDLE")" # the verdict line, evidence already in it
+
+OUT="$(kp_scratch_open review-code-bundle)/bundle.env" || exit 1
+{
+  printf 'HEAD_SHA=%s\n' "$HEAD_SHA"
+  printf 'BUNDLE_STATE=%s\n' "$BUNDLE_STATE"
+  printf 'BUNDLE_LINE=%s\n' "$(printf '%q' "$BUNDLE_LINE")"
+} > "$OUT"
+printf '%s\n' "$BUNDLE" > "$(dirname "$OUT")/bundle.json"
+printf 'BUNDLE_JSON=%s\n' "$(dirname "$OUT")/bundle.json" >> "$OUT"
+printf '%s\n' "$OUT"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/session-caching-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/session-caching-scan.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Step 3f — the session-caching seam scan (ADR 0169), plus the §ZS #1 scope line. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+#
+# A hit ARMS the two-axis check; it never alone FAILs — the reviewer judges whether a hit is a
+# genuine new caching path or an unrelated auth edit, and the candidate lines go to stdout after the
+# scope line so that judgement has the evidence the fence left in `$CACHE_HITS`. Fail-closed on this
+# security-load-bearing surface: when in doubt that a hit is a caching path, run the check, don't
+# skip it — so a usage error prints nothing and exits non-zero rather than a reassuring zero count.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: session-caching-scan.sh <pr>" >&2; exit 2; }
+PR="$1"
+
+# does this PR touch a session/caching seam? A hit ARMS the two-axis check below; it never
+# alone FAILs — the reviewer judges whether a hit is a genuine new caching path (per the fire
+# condition above) or an unrelated auth edit. Fail-closed on the security-load-bearing surface:
+# when in doubt that a hit is a caching path, run the check, don't skip it.
+CACHE_HITS="$(gh pr diff "$PR" \
+  | grep -inE 'cookieCache|session\.?cache|cacheSession|maxAge|staleness|ttl|revalidat' || true)"
+echo "session-caching gate: scanned the diff for session-caching seams — $(printf '%s\n' "$CACHE_HITS" | grep -c . || echo 0) candidate line(s)"
+printf '%s\n' "$CACHE_HITS"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Step 2 — tear the throwaway head worktree + per-run ref down. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+#
+# It is its OWN script because the prose requires it on EVERY exit path (PASS, FAIL, mid-run error),
+# not just after the lint/typecheck run it followed in the fence — a leaked `review-head-*` tree
+# accumulates on the shared primary otherwise (#2785). Safe by construction: the tree it removes is
+# a detached, already-pushed throwaway this gate materialized itself, holding no branch and no
+# unpushed work. Idempotent — a namespace that was never opened is a clean no-op, so it may be run
+# after an aborted materialization.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# shellcheck disable=SC1007
+HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" 2>/dev/null)" || {
+  echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
+  exit 0
+}
+# shellcheck disable=SC1090
+. "$HANDLE"
+[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] || {
+  echo "teardown-head.sh: handle carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\` (no-op)." >&2
+  exit 0
+}
+
+rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"   # tear the throwaway tree + ref down

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/userfacing-scope.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/userfacing-scope.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Step 3b — the flag-gating user-facing scope scan, and the §ZS zero-scope FAIL. Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts. The *why* the reachable surface is exactly
+# `apps/web/src/**/*.{tsx,css}` + new `apps/web/worker/**` entry points stays in that step's prose.
+#
+# Prints the scope line, the matched paths, and — on zero matches — the one `[FAIL]` row. NO match is
+# the FAIL here, so "printed nothing" can never read as a pass; but a scan that could not RUN must not
+# read as either, so a usage error or an unresolvable repo prints the same `[FAIL]` row and exits
+# non-zero (§ZS / ADR 0092: a relevant-input gate with zero evidence fails closed, and UNKNOWN is
+# never a pass).
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# shellcheck disable=SC2016  # the `**Containment:** flag` / `apps/web/src/**` text is literal verdict prose, not an expansion
+ZERO_ROW='- [FAIL] flag-gating (default-off) — `**Containment:** flag` marks a dark-shipped feature, but the diff touches NO user-facing surface (apps/web/src/**/*.{tsx,css}, new apps/web/worker/** resolver/route/mutation): empty scope on a flag-marked PR is a FAIL (ADR 0092 §ZS), not a pass — there is no user-facing path to gate.'
+
+[ "$#" -ge 1 ] || { printf '%s\n' "$ZERO_ROW"; echo "usage: userfacing-scope.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || { printf '%s\n' "$ZERO_ROW"; echo "userfacing-scope.sh: target repo unresolved — scope UNKNOWN, failing closed." >&2; exit 1; }
+
+# the PR's user-facing surface (reachable UI + new data/API entry points), off the changed file set.
+# Emit the count + matched paths (ADR 0092 §ZS #1 — a gate states its scope), then fail closed on zero.
+FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # the changed paths (same set Step 2 pulled; --paginate past file #100, #725)
+USERFACING=$(printf '%s\n' "$FILES" | grep -E '^apps/web/src/.*\.(tsx|css)$|^apps/web/worker/.*\.(ts|tsx)$' || true)
+USERFACING_N=$(printf '%s\n' "$USERFACING" | grep -c . || true)
+echo "flag-gating user-facing scope: $USERFACING_N path(s) matched"; printf '%s\n' "$USERFACING"
+if [ "$USERFACING_N" -eq 0 ]; then
+  # relevant input (flag marker present), zero matches ⇒ FAIL CLOSED, never a silent PASS (§ZS #2).
+  # Emit ONE [FAIL] row into the conjunctive verdict; the PR is not merge-ready.
+  echo "- [FAIL] flag-gating (default-off) — \`**Containment:** flag\` marks a dark-shipped feature, but the diff touches NO user-facing surface (apps/web/src/**/*.{tsx,css}, new apps/web/worker/** resolver/route/mutation): empty scope on a flag-marked PR is a FAIL (ADR 0092 §ZS), not a pass — there is no user-facing path to gate."
+fi

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-emit-fail.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-emit-fail.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Step 4b — upsert the FAIL verdict through the guarded tool. Extracted from review-code/SKILL.md
+# (#4451, epic #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# THE BODY ARRIVES ON STDIN — the same declared seam as the PASS emitter, for the same reason: the
+# fence's heredoc carried a `… your per-criterion evidence table …` placeholder the reviewer authors,
+# and piping on stdin means no fixed or `${PR}`-keyed scratch name a concurrent run can clobber
+# (#1465/#3718/#3801).
+#
+# No native REQUEST_CHANGES here: the fence made that an optional nicety on top, and the comment with
+# per-criterion evidence is the REQUIRED artifact.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: printf '%s' \"\$BODY\" | verdict-emit-fail.sh <pr> <head-sha>" >&2; exit 2; }
+PR="$1"; HEAD_SHA="$2"
+PCLI="$(kp_pcli)" || exit 127
+# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
+# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here
+# (#3653; ADR 0062/0064; epic #994)
+VERDICT=("$PCLI" verdict)
+
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "verdict-emit-fail.sh: EMPTY body on stdin — refusing to post an empty verdict; the PR would read as UNGATED." >&2; exit 1; }
+
+# Upsert through the guarded tool (resolved above), exactly as the PASS path: it upserts the one
+# review-code marker (namespace-anchored, advisory included) and fail-closes on a malformed/
+# cross-namespace body (so the mktemp-path `@ <sha>` leak #2683 can't land) AND on a body bound to
+# another PR's head (the #3801 post-time cross-check).
+printf '%s' "$BODY" | "${VERDICT[@]}" post --pr "$PR" --gate code
+echo "verdict-emit-fail: review-code FAIL emitted for PR #$PR @ ${HEAD_SHA:0:7} — now run verdict-readback.sh." >&2

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-emit-pass.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-emit-pass.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Step 4a — emit the PASS verdict through the guarded path: `verdict validate` as a read-back
+# assertion, then the native approving review, falling back to the `verdict post` comment upsert.
+# Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+#
+# THE BODY ARRIVES ON STDIN — the declared seam. The fence composed it into `$BODY` with a heredoc
+# whose table was a `… your per-criterion evidence table …` placeholder; the reviewer authors that
+# body, so a script can only receive it. Composing on stdin also keeps the #1465/#3718/#3801
+# collision surface gone by construction: with no file on disk there is nothing for a concurrent
+# review of the same PR to clobber, and no scratch path that could bleed into the `@ <sha>` field.
+#
+# The APPROVE→fallback chain is an EXPLICIT `if`, never `APPROVE || post`: a shell pipe wrapping the
+# APPROVE call makes the pipeline's status mask the APPROVE failure, so the `||` fallback silently
+# never fires and no verdict lands.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: printf '%s' \"\$BODY\" | verdict-emit-pass.sh <pr> <head-sha>" >&2; exit 2; }
+PR="$1"; HEAD_SHA="$2"
+REPO="$(kp_repo)" || exit 1
+PCLI="$(kp_pcli)" || exit 127
+# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
+# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here
+# (#3653; ADR 0062/0064; epic #994)
+VERDICT=("$PCLI" verdict)
+
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "verdict-emit-pass.sh: EMPTY body on stdin — refusing to post an empty verdict; the PR would read as UNGATED." >&2; exit 1; }
+
+# Read-back assertion BEFORE the native APPROVE: the same gate `verdict post` enforces, piped on
+# stdin, so a malformed `@ <sha>` (e.g. an mktemp scratch path, #2683) fails loud here, never in a
+# review body.
+printf '%s' "$BODY" | "${VERDICT[@]}" validate --gate code || {
+  echo "FATAL: composed review-code marker is malformed — refusing to post (fix the @ <sha> field; #2683)" >&2
+  exit 1
+}
+if gh api -X POST repos/"$REPO"/pulls/"$PR"/reviews \
+     -f event=APPROVE -f body="$BODY"; then
+  : # native approving review posted (GitHub records its commit_id = the head you approved;
+    #  ship-it reads that commit_id for the same staleness test the marker's @ <sha> drives)
+else
+  # APPROVE failed (e.g. 422 on your own PR) — upsert the structured pass comment instead, through
+  # the guarded tool on stdin: it PATCHes your newest own review-code marker (namespace-anchored, so
+  # it also upserts a prior advisory across a non-blocking↔blocking flip) else POSTs the first, and
+  # it fail-closes on a malformed/cross-namespace body AND on a body bound to another PR's head
+  # (the #3801 post-time cross-check) so a broken/mis-bound marker never reaches GitHub.
+  printf '%s' "$BODY" | "${VERDICT[@]}" post --pr "$PR" --gate code
+fi
+# $HEAD_SHA is the caller's single-sourced read (current-head.sh); echo it so the run log ties the
+# emitted verdict to the head Step 4c must then find landed.
+echo "verdict-emit-pass: review-code PASS emitted for PR #$PR @ ${HEAD_SHA:0:7} — now run verdict-readback.sh, which is what makes posting an ENFORCED gate." >&2

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-readback.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-readback.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Step 4c — the UNCONDITIONAL post-verify: prove a clean, current-head `review-code:` verdict is
+# actually on the PR. Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction
+# contract: ../SKILL.md § The extracted scripts.
+#
+# `verdict_post_verify` itself is SOURCED from its canonical home,
+# ../../shared/scripts/verdict-readback.sh (#4489 extracted it out of
+# ../../gh-issue-intake-formats.md) — there is no skill-local copy to drift. It re-derives the landed
+# verdict from live PR state, never from a carried comment id: `$MINE` was set only on one posting
+# branch, which is exactly how the #2264 recurrence slipped a broken/leaking marker through.
+#
+# PROPAGATE THE NON-ZERO. This wrapper's single FATAL exit is what makes verdict-posting an ENFORCED
+# gate rather than a hopeful one — never report the gate done over an ungated PR.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: verdict-readback.sh <pr> <head-sha>" >&2; exit 2; }
+PR="$1"; HEAD_SHA="$2"
+# $REPO is what the sourced guard addresses `gh api` at, exactly as the fences did.
+REPO="$(kp_repo)" || exit 1
+export REPO
+# shellcheck source=../../shared/scripts/verdict-readback.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/verdict-readback.sh"
+
+# UNCONDITIONAL post-verify: resolve the landed verdict from PR state (marker comment @ HEAD_SHA, the
+# advisory line, or the native APPROVE at commit_id==HEAD_SHA), then prove it present + well-formed +
+# leak-free. FATAL (non-zero) on absent / malformed / leaking — the #2264 whole-body-path leak, a
+# no-opped post, and a stale-head marker all fail here. Propagate the non-zero: never report the gate
+# done over an ungated PR. Runs no matter which 4a/4b branch posted — no $MINE, no skippable path.
+verdict_post_verify "$PR" review-code "$HEAD_SHA" || exit 1

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-checks.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-checks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Step 2 — install + lint inside the review worktree (behavior verified by running beats behavior
+# inferred from a diff). Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# re-source the run-unique $REVIEW_WT/$PR_REF after a between-call reset (#1807) — never re-derive
+# from the shared `review-head-${PR}` leaf name
+# shellcheck disable=SC1007,SC1090
+. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || exit 1
+: "${REVIEW_WT:?worktree-checks.sh: REVIEW_WT unset — the head was never materialized; refusing to check the base tree (§HEAD)}"
+
+pnpm -C "$REVIEW_WT" install   # the catalog/lockfile + patches/ are present, so this succeeds
+# Lint via `pnpm lint:worktree`, never `pnpm lint` / `biome check .`: bare `.` resolves to the
+# review worktree's CWD (sits under .claude/worktrees → matches `!**/.claude/worktrees`) and exits
+# 0 WITHOUT linting (false green; #236, ADR 0060). `lint:worktree` lints the EXPLICIT changed files
+# vs origin/main (committed + working-tree, biome-extension-filtered; docs-only/empty = clean skip),
+# so it catches root + `.claude/**` violations a bare `biome check apps packages` would miss and
+# reliably predicts the CI lint job (#553/#559):
+pnpm -C "$REVIEW_WT" lint:worktree   # and/or the specific test the criterion names

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Step 2 — the authoritative in-worktree typecheck (ADR 0067, reversing 0060's deferred-to-CI
+# workaround). Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# shellcheck disable=SC1007,SC1090
+. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || exit 1
+: "${REVIEW_WT:?worktree-typecheck.sh: REVIEW_WT unset — the head was never materialized; refusing to typecheck the base tree (§HEAD)}"
+
+pnpm -C "$REVIEW_WT" typecheck   # `pnpm install` above made patches/ hashable + `fate generate` resolvable


### PR DESCRIPTION
Part of #4451. **#4451 remains open** — 2 of its 27 runnable blocks were skipped for open-PR overlap
and are named under *Skipped* below, so this PR must **not** auto-close the ticket. `Part of #N` is the
one non-closing linkage the pipeline accepts: GitHub populates no `closingIssuesReferences` from it and
`ship-it` Step 1 recognizes it as valid linked-but-non-closing (formats §9). Same disposition
[#4485](https://github.com/kamp-us/phoenix/pull/4485) and
[#4492](https://github.com/kamp-us/phoenix/pull/4492) took and had upheld.

Phase-1 mechanical extraction of `review-code`'s fenced shell into
`claude-plugins/kampus-pipeline/skills/review-code/scripts/`. **26 scripts, 24 of the 27 runnable
blocks now an invocation, `SKILL.md` net −186 lines** (+191 / −377; 1873 → 1687). The moved shell is
relocation plus the minimal sourcing seams only — verb replacement is phase 2 (#1929; ADR 0228: a
script may RELAY a verb's answer, never DERIVE the decision), so a derive-shaped block moved
unchanged and is disclosed below rather than rewritten.

## What moved

| Step | Script |
|---|---|
| repo resolution | `resolve-repo.sh` |
| 1 | `pr-context.sh` · `linked-issue-timeline.sh` · `classify-issueless.sh` · `issue-context.sh` |
| 2 | `pr-diff.sh` · `classify-skills-only.sh` · `materialize-head.sh` · `head-env.sh` · `worktree-checks.sh` · `teardown-head.sh` · `worktree-typecheck.sh` · `full-unit-project.sh` · `run-evidence-read.sh` · `run-evidence-manifest.sh` · `classify-control-plane.sh` |
| 3b | `containment-marker.sh` · `cycle-doc-probe.sh` · `userfacing-scope.sh` |
| 3c | `glossary-freshness.sh` |
| 3d | `comment-scan.sh` |
| 3f | `session-caching-scan.sh` |
| 4a/4b/4c | `current-head.sh` · `verdict-emit-pass.sh` · `verdict-emit-fail.sh` · `verdict-readback.sh` |

Two block-groups merged deliberately, because a script boundary destroys the shell state the second
half consumed: Step 3c's detectors + their four-outcome verdict chain (one script), and Step 2's
materialize + denylist-removal + absence-assert (one script). Step 2's teardown line **split out** of
the lint block instead, because the prose requires it on every exit path — not only after the lint
run it happened to follow in the fence.

## Sourced, not copied

No shared-contract helper was re-copied. `classify-control-plane.sh` sources §CPREAD's
`cp_changed_files` / `cp_head_sha` from `shared/scripts/cp-read.sh`; `materialize-head.sh` sources
§RO-iso's `iso_preflight` from `shared/scripts/iso-preflight.sh`; `classify-skills-only.sh` sources
§WL's `kp_wl_all_onclass` from `shared/scripts/wl-empty-output.sh`; `verdict-readback.sh` sources
`verdict_post_verify` from `shared/scripts/verdict-readback.sh`. Step 2's §CPREAD prose, which used to
say "copy them verbatim", now points at the sourced home instead — with no second copy there is
nothing to keep in step and no byte-identity claim to go stale.

**One deliberate exception.** `scripts/cycle-doc-probe.sh` is review-code-**local** rather than the
equivalent `shared/scripts/cycle-doc-probe.sh`: `kp_skill_shell_surfaces` scopes each cycle
validator's scan surface to the skill's **own** directory on purpose, so sourcing the shared copy
would move this skill's cycle wiring off its guarded surface and both validators would fail —
correctly. Per-skill wiring stays per-skill. The reason is stated once in `SKILL.md`
§ The extracted scripts and pointed at from the script.

## Scan-surface claims — stated separately

**1. Which surfaces narrow on an extraction — one, down from two.**

- `cli-invocation-guard` **no longer narrows.** It did when this PR opened: the guard was fence-scoped
  to markdown, so a `.sh` contributed **zero** scanned fences (tracked on **#4486**). That is now
  history — [**PR #4494**](https://github.com/kamp-us/phoenix/pull/4494) merged at
  `2026-07-30T04:00:37Z` as `22da64d1`, widening the corpus to `*.md` **and** `*.sh` and counting a
  whole shell file as an implicit fence; **#4486** is no longer open (its state flipped at
  `2026-07-30T04:00:39Z`). So the guard now **follows** extracted shell rather than losing it, and the
  26 new scripts are in scope and clean. Measured, not assumed, at the post-merge corpus
  (`main@22da64d1` with this head's 27 `review-code/**` files overlaid — the two file sets are disjoint
  in both directions, so that overlay *is* the merge result, and the overlaid `review-code/SKILL.md` was
  `cmp`-verified byte-identical to the head blob), running the exact invocation CI runs in
  [`.github/workflows/cli-invocation-guard.yml`](.github/workflows/cli-invocation-guard.yml):

  ```bash
  find claude-plugins -type f \( -name '*.md' -o -name '*.sh' \) -print0 | sort -z \
    | xargs -0 node packages/pipeline-cli/src/bin.ts cli-invocation-guard check
  ```

  `cli-invocation-guard: scanned 208 file(s), 320 runnable bash/sh fence(s) in markdown, 132 shell
  file(s) as implicit fences` → **clean, exit 0**. Run that command inside **this head's own tree** and
  you get the *pre-#4494* narrow guard instead (the guard's sources live under `packages/`, which this
  PR does not touch), which is why the figure is measured at the post-merge base. Note also that the
  green `cli-invocation-guard` check on this head **started `03:52:20Z`, eight minutes before #4494
  merged**, so live CI at head attests the narrow guard, not the widened one.
- `leak-guard` is still markdown-only by extension — `DOC_SUFFIXES = [".md", ".mdx", ".markdown"]` in
  `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts`. Tracked on **#4496** (open). This is the
  one surface that still narrows.

Two surfaces never narrowed: `skill-gh-lint` (`gh-phoenix lint-skills`) already takes every `.md`
**and** `.sh` under the plugin dir, and both cycle validators follow extracted shell into `scripts/*.sh`
via `kp_skill_shell_surfaces` (#4473).

**2. This diff's coverage delta is provably zero.** Nothing that either guard would have flagged
exists in the moved shell:

- Zero bare `pipeline-cli` invocations. Every CLI reach reaches through `kp_pcli` → `"$PCLI"` /
  `"${VERDICT[@]}"`. The only `pipeline-cli` tokens in the new scripts sit on comment-only lines,
  which the guard's own `COMMENT_ONLY` rule skips — so the delta stays zero under the now-landed #4494
  widening too, which the exit-0 measurement above confirms end-to-end rather than by argument.
  Grep of the guard's `BARE_INVOCATION` pattern minus its comment skip: **no matches**.
- Zero `node …/pipeline-cli/src/bin.ts` cwd-relative invocations: **no matches**.
- Zero `/Users/…`, `/home/<name>`, `~/` or other machine-local paths — in the new scripts **and** in
  the SKILL.md diff's added lines: **no matches** on either.

**3. Where the remaining narrowing is tracked.** #4496 (leak-guard) — the one surface still narrowed,
and not this PR's to repair. #4486 (cli-invocation-guard) is discharged: #4494 landed the widening and
took #4486 out of the open set.

## Reviewer-runnable verification recipe

```bash
S=claude-plugins/kampus-pipeline/skills/review-code/scripts

# (a) every extracted script is shellcheck-clean
shellcheck "$S"/*.sh

# (b) no runnable block over 2 lines survives in the markdown, except the two disclosed skips
awk '/^[[:space:]]*```(bash|sh|shell|zsh)[[:space:]]*$/{i=1;n=NR;c=0;next} i&&/^[[:space:]]*```[[:space:]]*$/{print n": "c; i=0; next} i{c++}' \
  claude-plugins/kampus-pipeline/skills/review-code/SKILL.md

# (c) the zero-coverage-delta proof — all four must print nothing
grep -nE '(^|[^[:alnum:]_./@-])pipeline-cli([[:space:]]|$)' "$S"/*.sh | grep -vE ':[0-9]+:[[:space:]]*#'
grep -nE 'node[[:space:]]+[^[:space:]]*pipeline-cli/src/bin\.ts' "$S"/*.sh
grep -nE '/Users/|/home/[a-z]|(^|[[:space:]])~/' "$S"/*.sh
grep -nE '\btrap\b[^#]*EXIT' "$S"/*.sh

# (d) the guards that do NOT narrow still pass, and now follow the scripts
find claude-plugins/kampus-pipeline -type f \( -name '*.md' -o -name '*.sh' \) -print0 | sort -z \
  | xargs -0 node packages/pipeline-cli/src/bin.ts gh-phoenix lint-skills
bash claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
bash claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
bash claude-plugins/kampus-pipeline/skills/validate-skills.sh

# (e) byte-faithfulness, block by block: the moved lines against the deleted fence
git diff 9a4e909e8f9ed0b408ef338f6972cc1fd5289eb1 HEAD -- \
  claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
```

Re-measured on this head (rebased onto `main@be8c3d3c`): (a) clean · (b) 27 fences — 22 at 1 line, 3 at
2, and the two skips at 57 and 15 · (c) all four print nothing · (d) `gh-phoenix lint-skills` clean
over 185 files (the tool's own emitted count on its gh-call axis), cycle-presence 18 checks OK,
cycle-absence 14 checks OK, gate-path-drift 34 checks OK, validate-skills 30 skills OK · plus the unit
suite green in the pre-push hook.

`cli-invocation-guard` is measured **separately, at the post-merge base**, because #4494 changed it
after this head was pushed: CI's exact `*.md` + `*.sh` invocation (quoted under *Scan-surface claims*
above) reads `scanned 208 file(s), 320 runnable bash/sh fence(s) in markdown, 132 shell file(s) as
implicit fences` → **clean, exit 0**. The figure this line used to carry — the `.md`-only invocation
`find claude-plugins -name '*.md'`, 76 files / 320 fences — is no longer a pass: run against the same
corpus it now **exits 3**, `a zero scope on ANY axis is fail-closed, per surface`, because #4494 made
the shell-file axis fail-closed and an `.md`-only file list scans **0** shell files. 76 was also never
CI's file set; CI's is **208**.

For (e), each script's header names the block it came from, and the moved lines sit at column 0
byte-identical to the fence apart from the seams listed under Deviations.

## Fail-closed walk — every new error path, by captured exit code AND captured stdout byte count

The script boundary invents a channel the inline blocks never had: **non-zero exit with 0 bytes on
stdout**. Where a caller reads the *absence* of a fail-closed line as a *positive* answer, that is
indistinguishable from "proven safe". Every such script therefore prints its **own** sentinel before
each early `exit`. Measured, not asserted — `rc` is the captured exit code, `bytes` the captured
stdout byte count:

| Script | Failure path | rc | stdout bytes | Discriminator the caller reads |
|---|---|---|---|---|
| `classify-issueless.sh` | no `<pr>` arg | **2** | **107** | the **hard-stop** line, never the carve-out line |
| `classify-issueless.sh` | `kp_repo` fails | **1** | **107** | same hard-stop line |
| `classify-issueless.sh` | `gh` file-list read fails | **0** | **107** | unchanged from the fence: gh's error doc matches no `^\.glossary/` path, so the `else` fires |
| `classify-skills-only.sh` | no `<pr>` arg | **2** | **80** | `CANNOT-CLASSIFY (…)`, never the off-ramp line |
| `classify-skills-only.sh` | `kp_repo` fails | **1** | **86** | same |
| `classify-control-plane.sh` | no `<pr>` arg | **2** | **118** | the handle path; sourcing it yields **non-empty** §CP sentinel in **both** flags |
| `classify-control-plane.sh` | `kp_repo` fails | **1** | **119** | same |
| `classify-control-plane.sh` | file-list read fails (`--pr 99999999`) | **1** | **118** | both flags = `<changed-file list unreadable — §CP UNKNOWN, held as control-plane>` |
| `classify-control-plane.sh` | *happy path* (`--pr 4485`), for contrast | **0** | **118** (exactly 1 line) | `CP_FILES_N=14`, `CONTROL_PLANE_TOUCHED` = `…/review-design/SKILL.md` ⇒ §CP, correctly |
| `userfacing-scope.sh` | no `<pr>` arg / `kp_repo` fails | **2** / **1** | **327** | the `[FAIL]` row, never a silent pass |
| `glossary-freshness.sh` | no `<pr>` arg | **2** | **127** | `CANNOT-EVALUATE (…)` ⇒ fold `[UNVERIFIABLE]`, never a not-applicable skip |
| `glossary-freshness.sh` | no head handle | **1** | **227** | same |
| `containment-marker.sh` | no `<issue>` arg / `kp_repo` fails | **2** / **1** | **4** | prints `flag` — UNKNOWN held at the **armed** value, so the gating check runs |
| `current-head.sh` | no arg / read fails / non-hex / wrong length | **2** / **1** | **0** | empty ⇒ no SHA to bind; gh's error doc can never reach the `@ <sha>` field (#2683) |
| `current-head.sh` | *happy path* (`4485`), for contrast | **0** | 41 | `a55b3ea509e8a25c1a1aa5f1740d633511312391` — PR #4485's real head |
| `materialize-head.sh` | any of 7 paths (usage, `kp_repo`, `kp_pcli`, `iso_preflight`, no `BASE_REF`, dirty tree, denied surface present) | **2** / 1 / 127 / 1 / 1 / 1 / 1 | **0** | empty ⇒ the caller's `.` fails loudly; **never** fall back to the launched checkout's working copy (#793) |
| `head-env.sh` | namespace never opened | **1** | **0** | empty ⇒ the caller's `.` fails; no base-tree read |
| `worktree-checks.sh` / `-typecheck.sh` / `full-unit-project.sh` | no head handle | **1** | **0** | empty ⇒ never test the base tree |
| `run-evidence-read.sh` | no arg / `kp_pcli` unresolved | **2** / 127 | **0** | empty ⇒ `.` fails; "could not run" is not a bundle state |
| `run-evidence-read.sh` | *happy path* (`4485`), for contrast | **0** | exactly 1 line | the handle; `BUNDLE_STATE` is read as a state **word**, not from the exit |
| `verdict-emit-{pass,fail}.sh` | empty body on stdin | **1** | **0** | refuses to post an empty verdict that would read as UNGATED |
| `verdict-readback.sh` | no arg | **2** | **0** | non-zero propagates: never report the gate done over an ungated PR |
| `teardown-head.sh` | no handle / handle missing `REVIEW_WT` | **0** | **0** | deliberate no-op — nothing this gate materialized, so nothing to `rm -rf`; it must not abort a FAIL path |

Note the discriminator on a **completed** run is the **absent sentinel line**, not empty stdout — the
classifiers legitimately write a §ZS scope line. `classify-control-plane.sh` is the sharpest case: its
answer travels in a run-state handle, so every failure path **writes the handle with the sentinel
first** and only then exits non-zero — an empty `$CONTROL_PLANE_TOUCHED` is exactly what Step 4a reads
as auto-mergeable (#4216). Sourced the way Step 4a does, all four of its failure paths yield a
non-empty flag and route to the §CP advisory branch.

**The measurement found two real defects in this PR's own seams, both fixed in the last commit** — this
is why the walk is measured rather than asserted:

1. The sourced `cp_changed_files` / `cp_head_sha` write their §ZS scope lines to **stdout**, which here
   is the handle channel. An un-redirected call put the scope line *ahead of* the handle path, so a
   caller's `. "$(…)"` tried to source `§CP scope: PR #4485 …`. Repaired by redirecting on the function
   invocation (not a subshell, so the assignments still reach the calling shell).
2. `classify-control-plane.sh` opened its handle *after* the argument check, so a usage error exited 2
   with **0 stdout bytes** — still fail-closed (the caller's `.` fails loudly) but handing the caller no
   readable flag. Repaired by opening the handle first; the usage path now returns the sentinel.

Two bash-3.2 traps, both avoided: **no script installs an `EXIT` trap** (a cleanup trap's last command
becomes the script's status, laundering a `set -u` abort into exit 0 — #4476, class #4479), and **no
script expands `"${arr[@]-}"`** on a possibly-empty array. `set -uo pipefail` **without `-e`** is the
established shape: `errexit` would abort a fail-closed branch before it printed its line, converting
fail-closed into fail-open. `REPO="$(kp_repo)" || …` is at top level everywhere, never `local`, so the
substitution's status is not masked.

## ADR-0079 fan-out section: TOUCHED — 7 added lines, and they collide with PR #4440

Per #4451's coordination note, and stated as the measurement rather than a reassurance, because the
whole point of this heading is to hand #4396 / #4440 triage the baseline shift:

- **The section is touched.** Hunk `@@ -752,0 +646,7 @@` adds a **7-line** inline skip annotation
  after base line **752** (head `review-code/SKILL.md:646–652`). The section spans main lines
  **659–828** (its heading at 659, `## Step 3` at 829), so the addition lands inside it.
- **The ADR-0079 append fence itself is unmodified** — it is skip 2 below, and no other hunk in this
  PR touches base lines 659–828.
- **#4440 and this PR collide.** #4440's hunk on this file is `@@ -656,176 +656,6 @@`, whose 170
  deleted lines are exactly main **659–828** — the entire section, the 7 lines added here included.
  Delete-versus-modify inside one range: **whichever of #4504 / #4440 lands first, the other
  rebases.** Which one goes first is triage's call, not this PR's.

## Skipped, and why — #4451 stays open with the remainder named

Two of the 27 runnable blocks stayed inline. Both are the file-overlap rule, and each is annotated in
`SKILL.md` next to the block it guards:

1. **Step 3e's ADR-0158 `gh api graphql` review-threads read (15 lines).** `skill-gh-lint` scans whole
   `.sh` files and FAILs on any GraphQL-path `gh` call. Its `SELF_EXEMPT_SUFFIXES` exempts
   `/skills/review-code/SKILL.md` as a whole file, so the read is lawful where it is and would be
   flagged the moment it landed in a script. The idiom that would cover an extracted script **already
   exists**: **#4491 landed** (`15263296`) two **per-script** entries in that same
   `SELF_EXEMPT_SUFFIXES` array, annotated there as deliberately *not* a `scripts/`-wide exemption.
   What blocks the move is that adding a `review-code/scripts/*.sh` entry edits
   `packages/pipeline-cli/src/tools/gh-phoenix/lint.ts` — a **code-class** file outside a skills-only
   extraction child, which would make this a mixed diff needing a second gate.
2. **The ADR-0079 append fence (57 lines).** **PR #4440** deletes this whole section from
   `review-code/SKILL.md` and relocates it to `shared/specialist-fan-out.md` (#4396). Extracting it
   here would relocate the same lines a second, conflicting way.

The operative rule in both cases: **a block a guard (or a sibling relocation) parses out of the
markdown cannot move until that lands.** Same disposition #4485 and #4492 took and had upheld.

## Deviations

Walking all seven §DEV classes.

1. **Scope narrowing — YES, disclosed.** 2 of 27 runnable blocks did not move (Step 3e's GraphQL read;
   the ADR-0079 append fence), both on the mandatory file-overlap check, both annotated inline, both
   named above. #4451 stays open with exactly that remainder.
2. **ADR departure — none.** ADR 0228's relay-never-derive line is respected: no moved block was
   reshaped to decide anything it did not already decide. `classify-control-plane.sh` is
   **derive-shaped** — it re-resolves `CONTROL_PLANE_RE` from `origin/main` and accumulates the flags
   itself rather than relaying one verb's state word (the shape `shared/scripts/cp-classify-entry.sh`
   already carries as a phase-2 target). That is **expected in phase 1** and moved unchanged;
   converting it to a `cp-classify classify` relay is #1929's work, and would be a behavior change
   here — note the shared `cp-guard-adr.sh` is **not** a drop-in either: it greps `GUARD_ADR_RE`
   where review-code calls `guard-content-probe classify`, a different mechanism.
3. **Known defect left unfixed — none introduced, one PRE-EXISTING inherited unchanged and already
   filed.** `classify-issueless.sh`'s `FILES="$(gh api …)"` is an unhardened read that §CPREAD's
   `cp_changed_files` would harden; it is byte-identical to the fence, and it is already fail-closed
   here (gh's error document on stdout matches no `^\.glossary/` path, so the hard-stop branch fires),
   so there is no new defect to file. Hardening it is phase 2 (#1929). No class-3 entry lacks a
   follow-up.
4. **Declined reviewer guidance — none.** No prior verdict on this PR.
5. **Added suppression / skip — YES, four `shellcheck disable` directives, each with its reason
   inline.** `SC2034` on `classify-skills-only.sh`'s `$FILES` and `cycle-doc-probe.sh`'s `$CYCLE_DOC`
   (both read by a sourcing consumer, so shellcheck cannot see the use); `SC2016` on
   `userfacing-scope.sh`'s `$ZERO_ROW` (the `**Containment:** flag` text is literal verdict prose, not
   an expansion); `SC1007`/`SC1090`/`SC1091` on the `CDPATH= cd` sourcing seams (the shared lib's own
   established idiom). No `biome-ignore`, no `@ts-expect-error`, no test `.skip`/`.only`.
6. **Removed assertion lines — none.** No test file is touched; 2420/2420 unit tests green.
7. **Declared seams beyond pure relocation — YES, four, all minimal and all forced by the script
   boundary:**
   - **Cross-step state moves from a `mktemp` handle to the per-run scratch namespace.** The fence
     assigned `WT_FILE` from `mktemp` against a hardcoded system-temp template (`review-code-wt.XXXXXX`
     sitting directly under the system temp dir) and re-sourced `. "$WT_FILE"` in three later blocks; a
     shell variable does not survive the boundary, so `materialize-head.sh` writes the handle under
     `kp_scratch_open` and `head-env.sh` re-derives it. This is what #4451's own "cross-block state
     comes from the shared common lib" prescribes, and it retires that bare system-temp literal (§SP,
     #3718) as a side effect.
   - **Stdout becomes a machine channel in the four state-returning scripts** (`materialize-head.sh`,
     `run-evidence-read.sh`, `classify-control-plane.sh`, and `current-head.sh`'s bare SHA): the one
     stdout line is the handle/value, and progress + scope + FATAL lines move to stderr. Every §ZS
     scope line is still emitted, just on stderr, so nothing stopped being observable.
   - **The two verdict emitters take the body on stdin.** The fences composed `$BODY` from a heredoc
     whose table was the literal placeholder `… your per-criterion evidence table …` — reviewer-authored
     content a script can only receive. Its canonical shape already lives in the adjacent `markdown`
     fence, which is unchanged. Stdin also keeps the #1465/#3718/#3801 clobber surface gone.
   - **Three scripts print their captured lines after their scope line** (`comment-scan.sh`,
     `session-caching-scan.sh`, `run-evidence-manifest.sh`'s non-`present` note): the fences left those
     in `$ADDED_ON_CODE` / `$CACHE_HITS` for the reviewer to read, and there is no variable to hand back.

**(repair round 1)** — addressing `review-skill: FAIL @ 9430220c`. **Appended, not rewritten:** items
1–7 above are round 0's walk of the seven classes and stand exactly as written. A repair round's entries
are *not* additional §DEV classes, so they are labelled by the class they revise rather than continuing
the numbering.

- **Class 4 (declined reviewer guidance) — none; supersedes round 0's class 4.** Class 4 above read
  *"no prior verdict on this PR"*; that was true when written and is superseded here, not rewritten.
  Both `[FAIL]` rows are addressed: AC4 now states the section *is* touched with both hunks named, and
  skip 1's rationale is restated against landed `main` instead of the merged #4491. The verdict's one
  out-of-scope item — `shared/scripts/cp-read.sh`'s stdout/stderr asymmetry, the root cause behind the
  locally-repaired defect 1 — is being filed as its own defect rather than repaired here, the
  disposition the verdict itself asked for.
- **No other class fired, and the round is prose-only. Zero `.sh` files edited** — the round's own
  commit (`96f94217`) changes exactly one path,
  `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`, +6/−4. The branch was also rebased
  onto `main@be8c3d3c` (clean, no conflicts; the rebase changed no content in this PR's 27 files —
  verified byte-identical against `9430220c` before the prose commit), which moves the head and
  re-binds the next verdict. The recipe's byte-faithfulness base (`9a4e909e`) still yields the same
  `SKILL.md` diff, since no main-side commit has touched `review-code/` since it.

**(repair round 2)** — addressing the one `[FAIL]` row in `review-skill: advisory @ 96f94217`,
[comment 5126389084](https://github.com/kamp-us/phoenix/pull/4504#issuecomment-5126389084) (per ADR 0226
a `[FAIL]` inside an advisory is itself the defect record). **This note is written because a re-gate at
an unchanged head upserts that comment in place** — ADR 0213 keys a verdict slot on
`(PR, gate, run, head)`, and the same key overwrites — so the advisory's text will not survive the next
re-gate and this entry is the durable record. What follows is **my summary, not a quotation.**

- **The failing row was *citation + measurement freshness against live `main`*.** Three PR-body figures
  went stale when `main` moved to `22da64d1` ten minutes after this head was pushed: #4494 — the
  widening of the very guard this PR's scan-surface analysis is about — landed, and #4486 left the open
  set with it. **What cleared it:** the three passages restated and re-measured against `main@22da64d1`
  — the `cli-invocation-guard` bullet (it no longer narrows; 208 files / 320 markdown fences / 132 shell
  files, exit 0 at the post-merge corpus), the observed-on-this-head guard figure (the old `.md`-only
  76 / 320 invocation now exits 3), and the headline delta (`1873 → 1685`, net −188 ⇒ `1873 → 1687`,
  +191 / −377, net −186 — invalidated by this PR's own round-1 commit). The gate also corrected two of
  its **own** round-1 numbers in this PR's favour: the annotation is **7 lines at head 646–652** (its
  earlier `646–651` omitted the blank line the insertion adds), and #4440's deleted base range is
  **659..828 exactly** — identical to the section span, not merely overlapping.
- **Class 1 (scope narrowing) — nothing new.** The two disclosed skips are unchanged.
- **No class fired: the round is PR-body prose only.** Zero commits, zero pushes, zero `.sh` files
  edited, and **the head is unchanged at `96f94217`**. All three stale figures live in body prose and in
  **no committed file** — `#4486` / `#4494` / `#4496` and each stale numeric figure grep to **no
  matches** across `SKILL.md` and all 26 scripts — so there is nothing to commit, and no third gate
  round is bought for prose. Moving the head would also discard a terminal green CI at head (45
  declared / 45 received, 38 success, 7 path-filtered skips, 0 failing, 0 in-flight).

## Control plane

`claude-plugins/kampus-pipeline/skills/**` is §CP in its entirety (#4462), and this PR touches a
**gate-critical** skill, so it banks for a `@kamp-us/control-plane` approval at head and `ship-it`
enqueues after. Not self-approved, no verdict posted, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

