### PR TITLE
refactor(plan-epic,review-plan): the planning gate's 22 fenced shell blocks move into scripts/ (#4452)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -83,6 +83,13 @@ block below is an **invocation** of one. The prose keeps the *why*; the scripts 
   `epic-lock`, `intake-compose sub-issue`, `epic-splice apply`, `tracker graduate` — and never
   re-derives the decision that verb owns (ADR 0228).
 
+[`scripts/verify-extraction.sh`](scripts/verify-extraction.sh) is the runnable harness for those
+four properties across **both** halves of the planning gate (this skill and
+[`review-plan`](../review-plan/SKILL.md)) — invocation-only fences, no bare `pipeline-cli`, no
+user-local path, `shellcheck -x`, the shared-lib source, no cleanup trap on `EXIT`, no unguarded
+empty-array expansion, and the two failure-path probes asserted on **both** exit code and stdout
+byte count. Run it after editing any script here; it fails closed on zero scope.
+
 ## The formats contract
 
 You **write three of the five** shared formats; read them before you start:

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -47,8 +47,41 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/resolve-repo.sh")" || exit 1
 ```
+
+Every script under [`scripts/`](scripts/) resolves the repo the same way through the shared lib's
+`kp_repo`, so you never thread `$REPO` into one — that assignment is for your own ad-hoc `gh api`
+reads.
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), one script per step, and each fenced `bash`
+block below is an **invocation** of one. The prose keeps the *why*; the scripts hold the *how*
+(epic #4435 phase 1 — the shell moved as-is, and turning its `gh`/`jq` glue into tested
+`pipeline-cli` verbs is #1929). Four properties are load-bearing when you read or edit them:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control
+  flow through the guards written into it — the Step-5 loop's `break`-on-abort branches, an
+  `if ! $LOCK acquire` that reads a status rather than dying on it, a `.milestone.number // empty`
+  whose empty result *is* the answer. `errexit` would abort those paths mid-decision and turn a
+  fail-closed branch into no branch at all.
+- **An exit status is the answer; an empty stdout never is.** The moved blocks' back-off `exit 0`
+  ended the *agent's own* bash block, which a separate process cannot do — and an exit 0 from a
+  script would read as "proceed". So [`scripts/epic-lock-acquire.sh`](scripts/epic-lock-acquire.sh)
+  exits **3** on a back-off and **0** only when `epic-lock acquire` itself won (printing
+  `epic-lock: won #<EPIC>`), and [`scripts/splice-body.sh`](scripts/splice-body.sh) exits **non-zero**
+  on every terminal path except a confirmed round-trip — so "could not land the topology" can never
+  be read as "pinned". An unresolved shim is **127** everywhere: UNKNOWN, never a clean answer.
+- **Cross-step state travels through the §SP scratch namespace, not shell variables.** Each agent
+  Bash call is a fresh process, so Step 1's snapshot reaches Step 5 through one directory the shared
+  lib re-derives: [`scripts/scratch-open.sh`](scripts/scratch-open.sh) calls `kp_scratch_open`
+  (which resets) exactly once, and every later script calls `kp_scratch_path` (which never does) —
+  which is why re-running the open step mid-plan would delete the very snapshot Step 5 reads back
+  (#3718).
+- **They relay, they never decide.** Each script passes its verb's answer through —
+  `epic-lock`, `intake-compose sub-issue`, `epic-splice apply`, `tracker graduate` — and never
+  re-derives the decision that verb owns (ADR 0228).
 
 ## The formats contract
 
@@ -140,18 +173,10 @@ re-implementing ~50 lines of `jq` inline. Resolve the tool in-repo first, publis
 (ADR 0064), then branch on its exit status:
 
 ```bash
-# The `bin/pipeline-cli` shim resolves the CLI (in-repo bin, else the installed bin, else the
-# pinned `pnpm dlx` fallback reading hooks/pin.sh) — no version pinned here (#3653; ADR 0064).
-LOCK="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli epic-lock"
-
-# Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID
-# and exits 0 ONLY when the lock is ours; every fail-closed back-off — a held label, a 422 missing label, a
-# failed claim post, a lost co-acquire, a missing session id — prints its reason on stderr and exits NON-ZERO.
-# Branch on exit status — never mutate on a non-zero.
-if ! $LOCK acquire <EPIC>; then
-  exit 0   # backed off (held lock / setup gap / lost race is not a plan-epic failure) — re-run later.
-fi
-# WON. WE hold the lock (label + earliest claim). Release it on EVERY terminal path (below).
+# exit 0 = lock WON (prints `epic-lock: won #<EPIC>`) → mutate, then RELEASE on every exit path.
+# 3 = backed off (held lock / setup gap / lost race — not a plan-epic failure, re-run later);
+# 127 = the shim never ran (UNKNOWN). NEVER mutate on a non-zero.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/epic-lock-acquire.sh" <EPIC>
 ```
 
 **Release is an explicit agent step, not a shell `trap … EXIT`.** The acquire above runs in
@@ -164,12 +189,9 @@ the way out — run this exact `DELETE` once you reach **any** terminal state (P
 or a failure/abort mid-mutation):
 
 ```bash
-# release: run on EVERY exit path AFTER a WON acquire (done, park, or fault mid-mutation).
-# `epic-lock release` does BOTH parts: (a) retract OUR OWN claim comment(s) — re-found by session id,
-# since the acquire ran in a PRIOR process and its comment id is gone here; and (b) drop the coarse
-# label — a 404 is benign (already released), but ANY other DELETE failure is surfaced LOUDLY (a
-# silently-swallowed DELETE LEAKS the lock and wedges the epic, the exact ADR-0059 catastrophe).
-$LOCK release <EPIC>
+# A non-zero exit means the release did NOT complete — the lock is LEAKED and the epic is wedged.
+# Surface it loudly; never swallow it.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/epic-lock-release.sh" <EPIC>
 ```
 
 The release fires on **every** terminal path on purpose: you drive this as an LLM agent across
@@ -229,30 +251,20 @@ Step 1 writes this state and **Step 5 reads it back from a different Bash call**
 must be *deterministic*, not randomly allocated: shell state doesn't survive between calls, and
 a re-run of `mktemp -d` would hand Step 5 a new empty directory instead of Step 1's files. §SP
 keys the namespace on `$CLAUDE_CODE_SESSION_ID` exactly so any later call can recompute it —
-**open** the run once here (the `rm -rf` clears a previous run of this same epic in this same
-session), then **re-derive** it with the same one-liner in every later block, per §SP rule 3:
+**open** the run once here (the open clears a previous run of this same epic in this same session),
+after which every later script **re-derives** the same directory through the shared lib's
+`kp_scratch_path`, which never clears it, per §SP rule 3:
 
 ```bash
-# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
-[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || {
-  echo "plan-epic: §SP — CLAUDE_CODE_SESSION_ID unset; refusing to write plan state to a shared path (#3718)." >&2; exit 1; }
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/plan-epic-<EPIC>"
-rm -rf "$RUN_SCRATCH" && mkdir -p "$RUN_SCRATCH" || {
-  echo "plan-epic: §SP could not create a per-run scratch dir — refusing to write plan state to a shared path (#3718)." >&2; exit 1; }
+# OPEN the namespace — run this ONCE per plan; it prints the directory and clears a previous run of
+# this same epic in this same session. Every later script re-derives it and never clears it.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/scratch-open.sh" <EPIC>
 ```
 
 ```bash
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
-# the epic, its current body, its labels, and any children it already has
-gh api repos/$REPO/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
-# capture the body AND its revision marker from ONE GET — reading them in two calls lets a writer
-# land between them, yielding an updated_at newer than the captured body (TOCTOU skew); the Step 5
-# recheck would then either spuriously retry or trust a marker that doesn't match the captured body.
-gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > "$RUN_SCRATCH/snap.json"
-jq -r '.body'       "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/current.md"
-jq -r '.updated_at' "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/updated-at.txt"
-gh api 'repos/$REPO/issues/<EPIC>/sub_issues?per_page=100' \
-  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
+# the epic + its labels + child summary on stdout, and the body/updated_at snapshot written into the
+# namespace for Step 5 to read back
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/epic-read.sh" <EPIC>
 ```
 
 If the epic already has sub-issues or a plan section, you're **re-planning** — jump to
@@ -455,19 +467,8 @@ later; #1968 and #2099 the same verdict-resolver work in two places).
 **Read both sets once, before the create loop:**
 
 ```bash
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
-# 1. Already-emitted OPEN children of THIS epic — the re-dispatch idempotency set. A re-run must
-#    SKIP any proposed child that matches one of these (reconcile, don't re-create). The sub-issue
-#    list is the source of truth for what the epic already spawned; on a mixed open/closed epic
-#    prefer it over sub_issues_summary (which undercounts).
-gh api "repos/$REPO/issues/<EPIC>/sub_issues?per_page=100" \
-  --jq '.[] | select(.state=="open") | .title' > "$RUN_SCRATCH/existing-children.txt"
-
-# 2. The open backlog — the cross-backlog overlap set. A decomposition can re-mint work that
-#    already exists as an open standalone issue or another epic's child, so a proposed child that
-#    overlaps an open issue is surfaced/skipped, not minted. (REST issue list, not GraphQL.)
-gh api "repos/$REPO/issues?state=open&per_page=100" \
-  --jq '.[] | select(.pull_request | not) | "#\(.number)\t\(.title)"' > "$RUN_SCRATCH/open-backlog.txt"
+# writes existing-children.txt (set 1) and open-backlog.txt (set 2) into the §SP namespace
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/idempotency-sets.sh" <EPIC>
 ```
 
 **Then classify each proposed child before you create it:**
@@ -506,32 +507,23 @@ caught only by `review-plan`'s non-blocking advisor (#754, the same silent-clobb
 #3718's `prref.txt`). The loop writes one spec per child, so the `mktemp` template matters here
 even within a single run:
 
-```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
-mkdir -p "$RUN_SCRATCH" || exit 1
-# write this child's spec into a per-run temp file, never a shared fixed path (#754)
-CHILD_SPEC_FILE="$(mktemp "$RUN_SCRATCH/child.XXXXXX")"
-cat > "$CHILD_SPEC_FILE" <<'EOF'
+Write the child's spec JSON to a file of your own — the shape below — and hand its path to the
+script, which relocates it into a per-run `mktemp` inside `$RUN_SCRATCH` before composing (that
+relocation *is* the #754 guard) and prints the created `{number,id}`:
+
+```json
 {
   "stories": "<bare numbers, e.g. `1` or `1, 3` — no `S` prefix; or `none (pure infra — see What to build)`>",
   "tdd": "yes",
   "whatToBuild": "<the prose spec>",
   "acceptanceCriteria": ["<observable, checkable criterion>"]
 }
-EOF
-# The verb composes the format-2 body per the contract and emits it BY VALUE to stdout — no
-# hand-re-derived `### What to build` / `### Acceptance criteria`, no `-f body=@file` leak.
-BODY="$("$PCLI" intake-compose sub-issue --spec "$CHILD_SPEC_FILE")"
-# ATOMIC create — body AND its type/priority/status:planned labels in ONE REST write. `POST /issues`
-# accepts `labels` inline, so an interrupted run can never leave a label-less child: the create
-# either lands the issue WITH its labels or creates nothing. (Values chosen per the paragraph below.)
-gh api repos/$REPO/issues \
-  -f title="<sharp single-unit title>" \
-  -f body="$BODY" \
-  -f "labels[]=type:feature" -f "labels[]=p2" -f "labels[]=status:planned" \
-  --jq '{number,id}'
+```
+
+```bash
+# type + priority are yours to choose per the paragraph below; status:planned is fixed by the script.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/create-child.sh" \
+  <EPIC> "<sharp single-unit title>" type:feature p2 "<path/to/child-spec.json>"
 ```
 
 Capture both `number` and `id` from the create — Step 4 links by the `id`, so you won't need
@@ -562,8 +554,7 @@ adjust labels on an **already-existing** child:
 ```bash
 # amend-only — append/adjust labels on an EXISTING child. Fresh children are labeled AT CREATE (above),
 # so this never runs on the create path; using it there would reopen the label-less-orphan window.
-gh api repos/$REPO/issues/<CHILD>/labels \
-  -f "labels[]=type:feature" -f "labels[]=p2" -f "labels[]=status:planned"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/amend-child-labels.sh" <CHILD> type:feature p2
 ```
 
 (Type and priority are your call as planner, the same authority triage has — you're
@@ -584,10 +575,8 @@ intake dimension*); this is the inherit-logic that section says lives here and c
 Read the epic's milestone once, and **only if it has one** PATCH each created child onto it:
 
 ```bash
-EPIC_MILESTONE=$(gh api repos/$REPO/issues/<EPIC> --jq '.milestone.number // empty')
-if [ -n "$EPIC_MILESTONE" ]; then
-  gh api -X PATCH repos/$REPO/issues/<CHILD> -f milestone="$EPIC_MILESTONE"
-fi
+# a no-op (reported on stdout) when the epic has no milestone — inheritance copies, never invents
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/inherit-milestone.sh" <EPIC> <CHILD>
 ```
 
 **If the epic has no milestone, children stay unmilestoned** — inheritance *copies* the
@@ -615,12 +604,10 @@ whole step no-ops (graceful absence, ADR
 [0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-as-config-plugin.md)):
 
 ```bash
-# the formats-contract canonical probe — absent ⇒ no marker stamped (children carry `none`)
-if gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1; then
-  CYCLE_DOC=present
-else
-  CYCLE_DOC=absent
-fi
+# prints `present` or `absent`; it sources the ONE shared implementation of the formats-contract
+# canonical probe (`../shared/scripts/cycle-doc-probe.sh`), never a second copy.
+# absent ⇒ no marker stamped (children carry `none`)
+CYCLE_DOC="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/cycle-doc-probe.sh")" || exit 1
 ```
 
 - **Cycle doc present.** For each child, consult the cycle's policy and decide the child's
@@ -690,20 +677,14 @@ is the real parent/child edge, not just a `## Dependencies` mention.
 The endpoint takes the child's **database id** (`.id`), *not* its issue number:
 
 ```bash
-# the child's database id (reuse the .id from the Step 3 create if you captured it)
-CHILD_ID=$(gh api repos/$REPO/issues/<CHILD> --jq '.id')
-gh api -X POST repos/$REPO/issues/<EPIC>/sub_issues \
-  -F sub_issue_id=$CHILD_ID \
-  --jq '.sub_issues_summary'
+# the script resolves the child's database id itself and POSTs the link (`-F`, so the id is a number)
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/link-child.sh" <EPIC> <CHILD>
 ```
 
-`-F` (not `-f`) so the id is sent as a number. Confirm the link landed:
+Confirm the link landed:
 
 ```bash
-gh api repos/$REPO/issues/<EPIC> --jq '.sub_issues_summary'
-# total should equal the number of children you linked
-gh api 'repos/$REPO/issues/<EPIC>/sub_issues?per_page=100' \
-  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/confirm-links.sh" <EPIC>
 ```
 
 The exact-equality check holds on the fresh-plan path, where every linked child is
@@ -717,8 +698,7 @@ endpoint is **singular** `sub_issue` (not `sub_issues`), and the id goes in the 
 body via `--input` — `-X DELETE … -F` does **not** work here:
 
 ```bash
-echo "{\"sub_issue_id\": $CHILD_ID}" \
-  | gh api -X DELETE repos/$REPO/issues/<EPIC>/sub_issue --input -
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/unlink-child.sh" <EPIC> <CHILD>
 ```
 
 Unlinking does not close the child; it just removes the parent/child edge. Closing is
@@ -804,156 +784,11 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 "re-derive" from a comment you might skip into a precondition the script enforces.
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# §SP: re-derive the per-run scratch namespace — this is a LATER Bash call, so Step 1's
-# $RUN_SCRATCH variable is gone. Same recipe ⇒ same directory ⇒ Step 1's files are still there.
-# NO `rm -rf` here (that is the OPEN step's job only): clearing it would delete exactly the
-# snapshot this step reads back, which is the whole failure §SP rule 3 exists to prevent.
-[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || {
-  echo "plan-epic: §SP — CLAUDE_CODE_SESSION_ID unset; cannot re-derive the Step 1 scratch namespace (#3718)." >&2; exit 1; }
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/plan-epic-<EPIC>"
-# Fail closed if Step 1's state isn't there: the freshness guard below compares file mtimes, and
-# `[ existing -nt missing ]` is TRUE in bash — so a missing base would let a STALE block splice
-# through silently. Assert presence first; never let the guard decide on absent files (#3718).
-for f in current.md updated-at.txt; do
-  [ -s "$RUN_SCRATCH/$f" ] || {
-    echo "plan-epic: §SP — $RUN_SCRATCH/$f is missing/empty; Step 1's snapshot did not survive." >&2
-    echo "  Re-run Step 1 in THIS session before splicing. Refusing to evaluate the freshness guard against absent state." >&2; exit 1; }
-done
-
-# "$RUN_SCRATCH/deps.md" = the new `## Dependencies` block. On a RE-PLAN, also
-#   "$RUN_SCRATCH/plan.md" = the new `## Plan (plan-epic)` block (set REPLAN=1).
-#   Give each block a trailing blank line so the next spliced heading stays separated.
-# Landing is confirmed against the WHOLE `## Dependencies` block round-tripping byte-for-byte,
-# NOT a single line: two concurrent runs on the SAME epic likely both emit a given `- #<child>`
-# line (they share children), so a lone matching line can't tell our section from a racer's
-# clobber (see step 6). deps.md is re-derived by YOU between attempts (the recheck breaks out and
-# hands back; step 2) — the freshness guard (step 2.5) enforces it was, so each pass splices a block
-# derived against the body it's splicing onto, never a stale one.
-# A first-time plan has NO `## Dependencies` heading yet (Step 2 doesn't write one) — that case
-# APPENDS the block to EOF; a re-plan has exactly one and SPLICES it in place. Zero headings on a
-# re-plan, or more than one ever, is corruption: the `epic-splice` verb (step 3) exits non-zero.
-#
-# This block is a SKELETON you re-run per attempt, not a one-shot. When the recheck (step 2) fires
-# it stamps the fresh base, BREAKS, and hands back to you to re-derive `deps.md` (+ `plan.md` on a
-# re-plan) against `$RUN_SCRATCH/current.md` — then you re-invoke the block. The freshness
-# guard (step 2.5) refuses to splice a `deps.md` older than the base it would splice onto, so a
-# stale block can never re-clobber a racer's legitimate topology.
-# Per attempt: re-read → recheck (verify unchanged) → freshness guard → epic-splice apply (guards + splice) → PATCH
-# → re-verify our block landed. `landed=1` only after a pass confirms the round-trip; `patched=1`
-# records that a PATCH was actually issued (so the terminal verdict can tell "raced every time,
-# never wrote" from "wrote and lost"). The terminal check after the loop turns an
-# exhausted-or-aborted run into a hard STOP rather than ambiguous output.
-landed=0; patched=0
-for attempt in 1 2 3; do
-  # 1. re-read the LIVE body + its revision marker from ONE GET (coherent — no TOCTOU skew)
-  gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > "$RUN_SCRATCH/live.json"
-  jq -r '.body'       "$RUN_SCRATCH/live.json" > "$RUN_SCRATCH/live.md"
-  NOW=$(jq -r '.updated_at' "$RUN_SCRATCH/live.json")
-  WAS=$(cat "$RUN_SCRATCH/updated-at.txt")
-
-  # 2. optimistic recheck — if the body moved since we last read it, stamp the fresh base and BREAK.
-  #    Re-deriving the section is YOUR action (the script can't regenerate deps.md/plan.md inside one
-  #    bash invocation): re-run Step 2's split + Step 5's derivation against the now-fresh
-  #    `-current.md`, then re-invoke this block. The freshness guard (2.5) enforces that you did.
-  if [ "$NOW" != "$WAS" ]; then
-    echo "epic body changed since read ($WAS -> $NOW) — RE-DERIVE deps.md (+ plan.md on a re-plan)"
-    echo "  against the fresh base, then re-invoke this block. (Not auto-retried: the re-derive is an agent step.)"
-    cp "$RUN_SCRATCH/live.md" "$RUN_SCRATCH/current.md"   # fresh base to re-derive against
-    echo "$NOW" > "$RUN_SCRATCH/updated-at.txt"
-    break
-  fi
-
-  # 2.5. freshness guard — `deps.md` (and, on a re-plan, `plan.md`) MUST have been (re-)derived
-  #      against the base this attempt is splicing onto. That base is `-current.md` (stamped from the
-  #      live body the recheck above just confirmed unchanged), and your re-derive writes deps.md
-  #      AFTER it — so deps.md must be newer than current.md (`-nt` = "newer than"). If it isn't, the
-  #      re-derive precondition is unmet (you re-invoked without regenerating the block off the fresh
-  #      base): a stale block that references the wrong child set. Abort loudly, don't write — this is
-  #      what stops the `continue`-era footgun of re-splicing the originally-derived block (issue #261).
-  #      `-nt` alone CANNOT carry this check: `[ existing -nt missing ]` is TRUE in bash, so if the
-  #      derived block is absent the negation is false and the guard PASSES SILENTLY — a stale/no
-  #      block splices through. Assert the file exists and is non-empty FIRST, then compare mtimes.
-  if [ ! -s "$RUN_SCRATCH/deps.md" ] \
-     || ! [ "$RUN_SCRATCH/deps.md" -nt "$RUN_SCRATCH/current.md" ] \
-     || { [ "${REPLAN:-0}" = 1 ] && { [ ! -s "$RUN_SCRATCH/plan.md" ] \
-          || ! [ "$RUN_SCRATCH/plan.md" -nt "$RUN_SCRATCH/current.md" ]; }; }; then
-    echo "ABORT: deps.md (or plan.md on a re-plan) is NOT newer than the base it splices onto (-current.md) —"
-    echo "       you re-invoked without re-deriving. Re-run Step 2's split + Step 5's section derivation"
-    echo "       against "$RUN_SCRATCH/current.md", then re-invoke this block. Refusing to splice a stale block."
-    break
-  fi
-
-  # 3. splice/append the changed section(s) via the shared verb — `pipeline-cli epic-splice apply`
-  #    owns the deterministic transform (#3689, extracted from #261): the exact-`## Dependencies`
-  #    heading-count guards (0 + first-time → APPEND to EOF; exactly 1 → SPLICE in place; 0 on a
-  #    re-plan or >1 ever → corrupt, exit 1) and, on a re-plan, the in-place `## Plan (plan-epic)`
-  #    splice with its own exactly-one-heading guard. Everything OUTSIDE the replaced section(s) is
-  #    preserved byte-for-byte (the brief especially — layer 1). Pass `--plan-file` ONLY on a
-  #    re-plan: its presence IS the re-plan signal (both sections re-spliced); omit it first-time.
-  #    A corrupt/duplicated/drifted heading makes the verb exit non-zero — break loudly and inspect
-  #    by hand rather than blind-write. The recheck/freshness/round-trip orchestration around it
-  #    stays here (it is live-issue IO, not a text transform).
-  PLAN_ARG=(); [ "${REPLAN:-0}" = 1 ] && PLAN_ARG=(--plan-file "$RUN_SCRATCH/plan.md")
-  if ! "$PCLI" epic-splice apply \
-        --body-file "$RUN_SCRATCH/live.md" \
-        --deps-file "$RUN_SCRATCH/deps.md" \
-        "${PLAN_ARG[@]}" > "$RUN_SCRATCH/body.md"; then
-    echo "ABORT: epic-splice refused (corrupt/duplicated/drifted heading — see its stderr) — refusing to splice; inspect by hand"
-    break
-  fi
-  BODY="$(cat "$RUN_SCRATCH/body.md")"
-
-  # 5. extract THIS run's whole `## Dependencies` block (heading → EOF) from the body we're about
-  #    to write — that exact multi-line block is what we'll confirm round-tripped, so a racer who
-  #    happens to share a child number can't satisfy the check with one matching `- #` line.
-  awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' "$RUN_SCRATCH/body.md" \
-    > "$RUN_SCRATCH/deps-expected.md"
-
-  # 6. write, then re-confirm OUR WHOLE BLOCK landed — extract `## Dependencies`→EOF from the live
-  #    post-write body and diff it against the block we just wrote. A racer's clobber differs
-  #    somewhere in the block (different topology/labels/ordering), so an exact block match — not a
-  #    heading or a single child line — is what tells our section from theirs. The residual window
-  #    (below) means the PATCH is still last-write-wins; this is the honest after-the-fact check
-  #    that retries the loser.
-  gh api -X PATCH repos/$REPO/issues/<EPIC> -f body="$BODY" >/dev/null; patched=1
-  gh api repos/$REPO/issues/<EPIC> --jq '.body' \
-    | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > "$RUN_SCRATCH/deps-live.md"
-  if diff -q "$RUN_SCRATCH/deps-expected.md" "$RUN_SCRATCH/deps-live.md" >/dev/null; then
-    echo "epic body updated, our whole ## Dependencies block round-tripped"; landed=1; break
-  else
-    # A racer clobbered our write. Do NOT auto-re-splice the stale deps.md — that would
-    # silently re-clobber the racer's legitimate same-section topology change. Mirror the
-    # recheck-break (step 2): snapshot the racer's body as the FRESH base, then break to hand
-    # back to the agent to RE-DERIVE deps.md (and plan.md on a re-plan) against it before any
-    # re-splice. The freshness guard (step 2.5) then enforces the re-derive on the next invoke,
-    # so a stale block can never re-clobber.
-    echo "our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it."
-    echo "       Re-derive deps.md (and plan.md on a re-plan) against the refreshed"
-    echo "       "$RUN_SCRATCH/current.md", then re-invoke this block. Refusing to re-splice the stale block."
-    gh api repos/$REPO/issues/<EPIC> > "$RUN_SCRATCH/snap.json"   # one snapshot, no TOCTOU between body+updated_at
-    jq -r '.body'       "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/current.md"      # fresh base to re-derive against
-    jq -r '.updated_at' "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/updated-at.txt"
-    break
-  fi
-done
-
-# Terminal verdict — the loop can exit several ways; only one is success. An orchestrator (and the
-# next agent reading the transcript) must not mistake an exhausted-or-aborted run for a win. The two
-# non-success modes differ: a run that NEVER issued a PATCH (raced + re-derived, or a guard aborted)
-# left the body untouched; a run that DID PATCH but lost the round-trip left it possibly half-written.
-if [ "$landed" != 1 ]; then
-  echo "plan-epic: could NOT land the ## Dependencies block — STOP and inspect, do not proceed."
-  if [ "$patched" = 1 ]; then
-    echo "  (A PATCH was issued but our block didn't round-trip — a racer clobbered it. The epic body"
-    echo "   may be half-written with someone else's topology; the topology this run derived is NOT pinned.)"
-  else
-    echo "  (No PATCH was ever issued — either a guard aborted (corrupt/duplicated heading, or deps.md"
-    echo "   not re-derived against the fresh base), or every attempt raced and handed back to re-derive."
-    echo "   The epic body is untouched; the topology this run derived is NOT pinned.)"
-  fi
-fi
+# Re-run this PER ATTEMPT. Pass --replan to re-splice the `## Plan (plan-epic)` block too.
+# exit 0 = our whole ## Dependencies block round-tripped (the topology is pinned). Any non-zero is
+# a hard STOP: a guard aborted, every attempt raced, or a racer clobbered the write — the script
+# names which on stdout, and re-derive is YOUR next action.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/splice-body.sh" <EPIC>
 ```
 
 **Keep the brief byte-for-byte.** With the `epic-splice` verb's surgical splice/append this is
@@ -1001,35 +836,9 @@ Scan the **brief** (the top section you read in Step 1) for the graduation-prove
 close each source it names — but only a genuine `type:investigation` source, idempotently:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
-[ -s "$RUN_SCRATCH/current.md" ] || { echo "plan-epic: §SP — Step 1's current.md did not survive; re-run Step 1 in THIS session." >&2; exit 1; }
-# Extract every source the brief graduated from — tolerant of phrasing ("Emitted from resolved
-# investigation #N", "from resolved investigation #N"). The `resolved investigation` anchor is what
-# distinguishes a graduation provenance from an incidental `#N` cross-reference in the brief.
-SOURCES=$(grep -oiE 'resolved investigation #[0-9]+' "$RUN_SCRATCH/current.md" \
-  | grep -oE '[0-9]+' | sort -u)
-for SRC in $SOURCES; do
-  # Guard, fail-safe: close ONLY an open type:investigation — never a referenced epic/decision/bug,
-  # and never re-close a closed source (idempotent, so a re-plan run is a clean no-op). This is what
-  # keeps legitimately-open downstream artifacts (the epic itself, sibling epics) untouched.
-  read -r STATE TYPES < <(gh api repos/$REPO/issues/$SRC \
-    --jq '[.state, ([.labels[].name] | map(select(startswith("type:"))) | join(","))] | @tsv')
-  case "$STATE:$TYPES" in
-    open:*type:investigation*) ;;
-    *) echo "plan-epic: source #$SRC is $STATE ($TYPES) — not an open investigation, skipping close."; continue ;;
-  esac
-  # Audit trail (AC): the `tracker graduate` verb owns the graduation-close envelope (ADR 0190,
-  # #3266) — it posts the source → artifact provenance record so a reader can trace the graduation,
-  # then closes the source as completed (the work graduated, it wasn't abandoned — distinct from
-  # triage's not_planned). Don't hand-roll the comment + `state_reason=completed` PATCH; that inline
-  # re-derivation is what the adoption lint (#3254) flags.
-  "$PCLI" tracker graduate "$SRC" \
-    --artifact "epic #<EPIC> (planned by plan-epic)" \
-    --note "closing this investigation as the durable \`graduated into #<EPIC>\` record. Its diagnosis is carried forward by the epic and its planned children." >/dev/null
-  echo "plan-epic: closed graduated source investigation #$SRC → epic #<EPIC>."
-done
+# a no-op when the brief names no `resolved investigation #N`; each named source is closed only
+# if it is an OPEN type:investigation, so a re-plan run is idempotent
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/close-graduated-sources.sh" <EPIC>
 ```
 
 Only the *source* that graduated is closed; the epic and every downstream artifact it links stay
@@ -1070,12 +879,10 @@ Every supersede is auditable. Before closing a superseded child, post a comment 
 *why* and where the work went, so the trail is legible:
 
 ```bash
-gh api repos/$REPO/issues/<CHILD>/comments \
-  -f body="Superseded by re-plan of #<EPIC>: <specific reason — e.g. 'scope merged into #<NEW>' or 'dropped, the brief no longer asks for X'>."
-# unlink from the epic (singular sub_issue, id in the JSON body), then close not-planned
-CHILD_ID=$(gh api repos/$REPO/issues/<CHILD> --jq '.id')
-echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/$REPO/issues/<EPIC>/sub_issue --input -
-gh api -X PATCH repos/$REPO/issues/<CHILD> -f state=closed -f state_reason=not_planned
+# posts the journal note FIRST, then unlinks and closes not-planned — the trail exists even if a
+# later leg fails. Only ever on an OPEN child; a closed-done child is history.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/supersede-child.sh" <EPIC> <CHILD> \
+  "<specific reason — e.g. 'scope merged into #<NEW>' or 'dropped, the brief no longer asks for X'>"
 ```
 
 ### Fall back to full-supersede when reconciliation is messy
@@ -1096,13 +903,13 @@ whole-body `PATCH`. Re-plan is exactly the concurrency hot-spot the guard exists
 re-plan loop racing a fresh `plan-epic` run or a `review-plan` child-flip is the
 lost-update case in issue #261. Write the fresh `## Plan (plan-epic)` block to
 `$RUN_SCRATCH/plan.md`, the fresh `## Dependencies` block to
-`$RUN_SCRATCH/deps.md`, and run the Step 5 loop with `REPLAN=1` so it splices
+`$RUN_SCRATCH/deps.md`, and run `splice-body.sh <EPIC> --replan` so it splices
 **both** sections into the freshly-read live body in place (the live body already has exactly one
 `## Dependencies` heading and exactly one `## Plan (plan-epic)` heading to splice against — the
 loop's anchor guards abort if either drifted). When `updated_at` moved since your read, the loop
 breaks and hands back so you **re-derive both blocks against the fresh base** before re-invoking it
 — the re-derive is your step, not the script's, and the freshness guard enforces you did it. (On a
-first-time plan, leave `REPLAN` unset — the live body has no `## Dependencies` heading yet, so the
+first-time plan, omit `--replan` — the live body has no `## Dependencies` heading yet, so the
 loop appends the new block to EOF instead of splicing, and the Plan-heading guard is skipped.)
 
 ---
@@ -1117,12 +924,9 @@ scratch child not-planned, close the scratch epic, and label them so they're
 unmistakably test debris.
 
 ```bash
-# for each scratch child: unlink + close
-CHILD_ID=$(gh api repos/$REPO/issues/<CHILD> --jq '.id')
-echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/$REPO/issues/<EPIC>/sub_issue --input -
-gh api -X PATCH repos/$REPO/issues/<CHILD> -f state=closed -f state_reason=not_planned
-# then close the scratch epic
-gh api -X PATCH repos/$REPO/issues/<EPIC> -f state=closed -f state_reason=not_planned
+# THROWAWAY EPICS ONLY — it closes exactly the numbers you name, and no script can tell test
+# debris from the real backlog
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/teardown-scratch-epic.sh" <EPIC> <CHILD> [<CHILD> …]
 ```
 
 (If you have repo-admin and the GraphQL `deleteIssue` mutation is available to you,

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/amend-child-labels.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/amend-child-labels.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# AMEND-ONLY: append/adjust labels on an EXISTING child. Fresh children are labeled AT CREATE
+# (create-child.sh), so this never runs on the create path; using it there would reopen the
+# label-less-orphan window. The *why* stays in ../SKILL.md § Emit idempotently.
+#
+# usage: amend-child-labels.sh <CHILD> <type-label> <priority-label>
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "usage: amend-child-labels.sh <CHILD> <type-label> <priority-label>" >&2; exit 2; }
+CHILD="$1"; TYPE_LABEL="$2"; PRIORITY_LABEL="$3"
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/issues/$CHILD/labels" \
+  -f "labels[]=$TYPE_LABEL" -f "labels[]=$PRIORITY_LABEL" -f "labels[]=status:planned"

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/close-graduated-sources.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/close-graduated-sources.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Step 6: close every graduated source investigation the epic's brief names, idempotently. The
+# *why* — that graduation had no close-on-source forcing function and plan-epic is the deterministic
+# step that always touches a graduated epic — stays in ../SKILL.md § Step 6.
+#
+# usage: close-graduated-sources.sh <EPIC>
+#
+# A brief with no `resolved investigation #N` marker is a clean no-op. The per-source guard closes
+# ONLY an open `type:investigation`, so a referenced epic/decision/bug and an already-closed source
+# are both skipped — a re-plan run is a no-op.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: close-graduated-sources.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+REPO="$(kp_repo)" || exit 1
+PCLI="$(kp_pcli)" || exit 127
+RUN_SCRATCH="$(kp_scratch_path "plan-epic-$EPIC")" || exit 1   # §SP re-derive (see scratch-open.sh)
+[ -s "$RUN_SCRATCH/current.md" ] || { echo "plan-epic: §SP — Step 1's current.md did not survive; re-run Step 1 in THIS session." >&2; exit 1; }
+# Extract every source the brief graduated from — tolerant of phrasing ("Emitted from resolved
+# investigation #N", "from resolved investigation #N"). The `resolved investigation` anchor is what
+# distinguishes a graduation provenance from an incidental `#N` cross-reference in the brief.
+SOURCES=$(grep -oiE 'resolved investigation #[0-9]+' "$RUN_SCRATCH/current.md" \
+  | grep -oE '[0-9]+' | sort -u)
+for SRC in $SOURCES; do
+  # Guard, fail-safe: close ONLY an open type:investigation — never a referenced epic/decision/bug,
+  # and never re-close a closed source (idempotent, so a re-plan run is a clean no-op). This is what
+  # keeps legitimately-open downstream artifacts (the epic itself, sibling epics) untouched.
+  read -r STATE TYPES < <(gh api "repos/$REPO/issues/$SRC" \
+    --jq '[.state, ([.labels[].name] | map(select(startswith("type:"))) | join(","))] | @tsv')
+  case "$STATE:$TYPES" in
+    open:*type:investigation*) ;;
+    *) echo "plan-epic: source #$SRC is $STATE ($TYPES) — not an open investigation, skipping close."; continue ;;
+  esac
+  # Audit trail (AC): the `tracker graduate` verb owns the graduation-close envelope (ADR 0190,
+  # #3266) — it posts the source → artifact provenance record so a reader can trace the graduation,
+  # then closes the source as completed (the work graduated, it wasn't abandoned — distinct from
+  # triage's not_planned). Don't hand-roll the comment + `state_reason=completed` PATCH; that inline
+  # re-derivation is what the adoption lint (#3254) flags.
+  "$PCLI" tracker graduate "$SRC" \
+    --artifact "epic #$EPIC (planned by plan-epic)" \
+    --note "closing this investigation as the durable \`graduated into #$EPIC\` record. Its diagnosis is carried forward by the epic and its planned children." >/dev/null
+  echo "plan-epic: closed graduated source investigation #$SRC → epic #$EPIC."
+done

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/confirm-links.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/confirm-links.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Confirm the sub-issue links landed: the epic's summary, then the authoritative list. The *why* —
+# that `sub_issues_summary.total` UNDERCOUNTS on a mixed open/closed epic, so the list is the source
+# of truth on the re-plan path — stays in ../SKILL.md § Step 4.
+#
+# usage: confirm-links.sh <EPIC>
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: confirm-links.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/issues/$EPIC" --jq '.sub_issues_summary'
+# total should equal the number of children you linked
+gh api "repos/$REPO/issues/$EPIC/sub_issues?per_page=100" \
+  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/create-child.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/create-child.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Compose one child's format-2 body through `intake-compose sub-issue` and file it in ONE atomic
+# REST create — body AND its type/priority/status:planned labels together. The *why* — why the
+# composer owns the format, why the labels go on AT create, and why the spec lives in the §SP
+# namespace rather than a fixed /tmp path (#754) — stays in ../SKILL.md § Emit idempotently.
+#
+# usage: create-child.sh <EPIC> <title> <type-label> <priority-label> <spec-file>
+#
+# The spec arrives as a FILE, not an argument: it is multi-line JSON carrying the child's
+# `whatToBuild` prose and acceptance criteria, which an argv string mangles. This script relocates
+# it into a per-run `mktemp` inside $RUN_SCRATCH before composing — that relocation IS the #754
+# guard: concurrent plan-epic runs on sibling epics share /tmp, so a fixed path lets one run's spec
+# clobber another's and file a child with a sibling epic's body.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 5 ] || { echo "usage: create-child.sh <EPIC> <title> <type-label> <priority-label> <spec-file>" >&2; exit 2; }
+EPIC="$1"; TITLE="$2"; TYPE_LABEL="$3"; PRIORITY_LABEL="$4"; SPEC_IN="$5"
+[ -s "$SPEC_IN" ] || { echo "create-child: spec file '$SPEC_IN' is missing/empty — refusing to file a specless child." >&2; exit 2; }
+REPO="$(kp_repo)" || exit 1
+PCLI="$(kp_pcli)" || exit 127
+RUN_SCRATCH="$(kp_scratch_path "plan-epic-$EPIC")" || exit 1   # §SP re-derive (see scratch-open.sh)
+
+# write this child's spec into a per-run temp file, never a shared fixed path (#754)
+CHILD_SPEC_FILE="$(mktemp "$RUN_SCRATCH/child.XXXXXX")" || exit 1
+cat "$SPEC_IN" > "$CHILD_SPEC_FILE" || exit 1
+# The verb composes the format-2 body per the contract and emits it BY VALUE to stdout — no
+# hand-re-derived `### What to build` / `### Acceptance criteria`, no `-f body=@file` leak.
+BODY="$("$PCLI" intake-compose sub-issue --spec "$CHILD_SPEC_FILE")" || exit 1
+# ATOMIC create — body AND its type/priority/status:planned labels in ONE REST write. `POST /issues`
+# accepts `labels` inline, so an interrupted run can never leave a label-less child: the create
+# either lands the issue WITH its labels or creates nothing.
+gh api "repos/$REPO/issues" \
+  -f title="$TITLE" \
+  -f body="$BODY" \
+  -f "labels[]=$TYPE_LABEL" -f "labels[]=$PRIORITY_LABEL" -f "labels[]=status:planned" \
+  --jq '{number,id}'

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/cycle-doc-probe.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/cycle-doc-probe.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Print `present` or `absent` for the product-development cycle doc — the containment marker's
+# gate. The *why* — graceful absence (ADR 0062): absent ⇒ this whole step no-ops and children carry
+# `none (no cycle doc)` — stays in ../SKILL.md § Stamp the containment marker.
+#
+# usage: cycle-doc-probe.sh
+#
+# It SOURCES the one shared implementation, `../../shared/scripts/cycle-doc-probe.sh`, rather than
+# carrying a second copy of the probe: that helper runs the formats-contract canonical probe — the
+# content read of `contents/product-development-cycle.md` — and leaves $CYCLE_DOC in this shell.
+# Naming that path here is load-bearing, not decoration: `validate-cycle-presence.sh` /
+# `validate-cycle-absence.sh` grep for the canonical probe across plan-epic's OWN shell surface
+# only (shared/lib is deliberately excluded — see `kp_skill_shell_surfaces` in
+# ../../shared/lib/common.sh), so this citation is what keeps the cycle validators scanning a real
+# reference instead of nothing.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+REPO="$(kp_repo)" || exit 1
+export REPO
+# shellcheck source=../../shared/scripts/cycle-doc-probe.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cycle-doc-probe.sh"
+
+# `present` ⇒ consult the cycle for each child's containment (flag|exempt);
+# `absent`  ⇒ no marker stamped (children carry `none`).
+printf '%s\n' "${CYCLE_DOC:?cycle-doc-probe: the shared probe left \$CYCLE_DOC unset — UNKNOWN, never 'absent'}"

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-lock-acquire.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-lock-acquire.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Acquire the two-layer `status:planning` epic-lock on <EPIC> before you create, amend, supersede,
+# unlink, or close any child — and before the Step-5 body PATCH (ADR 0059/0115). The *why* — why
+# the coarse label alone cannot serialize under one shared login, and why every back-off must not
+# fall through to a mutation — stays in ../SKILL.md § Acquire the epic-lock.
+#
+# usage: epic-lock-acquire.sh <EPIC>
+#
+# EXIT-CODE CONTRACT — the back-off seam. The moved block ended its back-off with `exit 0`, which
+# terminated the AGENT's own bash block; a separate process cannot do that, and an exit 0 here
+# would read to the caller as "the lock is ours". So the back-off became its own code:
+#   0    WON — we hold the lock (label + earliest claim). RELEASE it on every terminal path.
+#   3    backed off (held label / 422 missing label / failed claim post / lost co-acquire /
+#        missing session id). NOT a plan-epic failure — re-run later; never mutate.
+#   127  the shim never ran — UNKNOWN, so NOT a win.
+# Exit 0 is reachable only through `epic-lock acquire` itself exiting 0, and stdout carries the
+# `epic-lock: won` line on that one path only — so neither an empty stdout nor a could-not-run
+# can be read as the permissive answer.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: epic-lock-acquire.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+# The `bin/pipeline-cli` shim resolves the CLI (in-repo bin, else the installed bin, else the
+# pinned `pnpm dlx` fallback reading hooks/pin.sh) — no version pinned here (#3653; ADR 0064).
+PCLI="$(kp_pcli)" || exit 127
+LOCK="$PCLI epic-lock"
+
+# Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID
+# and exits 0 ONLY when the lock is ours; every fail-closed back-off — a held label, a 422 missing label, a
+# failed claim post, a lost co-acquire, a missing session id — prints its reason on stderr and exits NON-ZERO.
+# Branch on exit status — never mutate on a non-zero.
+if ! $LOCK acquire "$EPIC"; then
+  echo "epic-lock: backed off on #$EPIC (held lock / setup gap / lost race is not a plan-epic failure) — re-run later." >&2
+  exit 3
+fi
+# WON. WE hold the lock (label + earliest claim). Release it on EVERY terminal path (below).
+echo "epic-lock: won #$EPIC"

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-lock-release.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-lock-release.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Release the `status:planning` epic-lock on <EPIC>. Run on EVERY exit path after a WON acquire —
+# done, park, or a fault mid-mutation. The *why* — why release is an explicit agent step and never a
+# shell `trap … EXIT`, and why only a lock YOU won may be released — stays in ../SKILL.md §
+# Acquire the epic-lock.
+#
+# usage: epic-lock-release.sh <EPIC>
+#
+# Exit status is the verb's own: non-zero means the release did NOT complete, which LEAKS the lock
+# and wedges the epic (the ADR-0059 catastrophe) — surface it, never swallow it.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: epic-lock-release.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+PCLI="$(kp_pcli)" || exit 127
+LOCK="$PCLI epic-lock"
+
+# release: run on EVERY exit path AFTER a WON acquire (done, park, or fault mid-mutation).
+# `epic-lock release` does BOTH parts: (a) retract OUR OWN claim comment(s) — re-found by session id,
+# since the acquire ran in a PRIOR process and its comment id is gone here; and (b) drop the coarse
+# label — a 404 is benign (already released), but ANY other DELETE failure is surfaced LOUDLY (a
+# silently-swallowed DELETE LEAKS the lock and wedges the epic, the exact ADR-0059 catastrophe).
+$LOCK release "$EPIC"

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-read.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Step 1's reads: the epic's shape + labels + child summary, its body and revision marker snapshotted
+# into the §SP namespace (ONE GET, so body and updated_at cannot skew), and its current sub-issue
+# list. The *why* — why the two fields come from one GET, and why Step 5 reads this snapshot back —
+# stays in ../SKILL.md § Step 1.
+#
+# usage: epic-read.sh <EPIC>
+#
+# Writes $RUN_SCRATCH/{snap.json,current.md,updated-at.txt}; prints the reads on stdout. A missing
+# namespace exits non-zero (the shared lib's `path` never creates one), so "could not read" can
+# never surface as an empty-but-fine snapshot.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: epic-read.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+REPO="$(kp_repo)" || exit 1
+RUN_SCRATCH="$(kp_scratch_path "plan-epic-$EPIC")" || exit 1   # §SP re-derive (see scratch-open.sh)
+
+# the epic, its current body, its labels, and any children it already has
+gh api "repos/$REPO/issues/$EPIC" --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
+# capture the body AND its revision marker from ONE GET — reading them in two calls lets a writer
+# land between them, yielding an updated_at newer than the captured body (TOCTOU skew); the Step 5
+# recheck would then either spuriously retry or trust a marker that doesn't match the captured body.
+gh api "repos/$REPO/issues/$EPIC" --jq '{body,updated_at}' > "$RUN_SCRATCH/snap.json"
+jq -r '.body'       "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/current.md"
+jq -r '.updated_at' "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/updated-at.txt"
+gh api "repos/$REPO/issues/$EPIC/sub_issues?per_page=100" \
+  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/idempotency-sets.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/idempotency-sets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Read the two sets a re-dispatch must reconcile against, BEFORE the create loop: this epic's
+# already-emitted open children, and the open backlog. The *why* — that emission reconciles rather
+# than re-mints, and how to classify a proposed child against each set — stays in ../SKILL.md §
+# Emit idempotently.
+#
+# usage: idempotency-sets.sh <EPIC>
+#
+# Writes $RUN_SCRATCH/{existing-children.txt,open-backlog.txt}. A missing namespace exits non-zero,
+# so an unwritten set can never be read as "nothing already exists".
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: idempotency-sets.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+REPO="$(kp_repo)" || exit 1
+RUN_SCRATCH="$(kp_scratch_path "plan-epic-$EPIC")" || exit 1   # §SP re-derive (see scratch-open.sh)
+
+# 1. Already-emitted OPEN children of THIS epic — the re-dispatch idempotency set. A re-run must
+#    SKIP any proposed child that matches one of these (reconcile, don't re-create). The sub-issue
+#    list is the source of truth for what the epic already spawned; on a mixed open/closed epic
+#    prefer it over sub_issues_summary (which undercounts).
+gh api "repos/$REPO/issues/$EPIC/sub_issues?per_page=100" \
+  --jq '.[] | select(.state=="open") | .title' > "$RUN_SCRATCH/existing-children.txt"
+
+# 2. The open backlog — the cross-backlog overlap set. A decomposition can re-mint work that
+#    already exists as an open standalone issue or another epic's child, so a proposed child that
+#    overlaps an open issue is surfaced/skipped, not minted. (REST issue list, not GraphQL.)
+gh api "repos/$REPO/issues?state=open&per_page=100" \
+  --jq '.[] | select(.pull_request | not) | "#\(.number)\t\(.title)"' > "$RUN_SCRATCH/open-backlog.txt"
+
+echo "idempotency sets written: $RUN_SCRATCH/existing-children.txt, $RUN_SCRATCH/open-backlog.txt"

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/inherit-milestone.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/inherit-milestone.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Inherit the epic's milestone onto <CHILD> — and ONLY if the epic has one. The *why* — that
+# inheritance copies the epic's state and never invents one, and that this skill never creates a
+# milestone — stays in ../SKILL.md § Inherit the epic's milestone.
+#
+# usage: inherit-milestone.sh <EPIC> <CHILD>
+#
+# An unmilestoned epic is a clean no-op (freeze-by-absence), reported on stdout so "did nothing" is
+# distinguishable from "could not run" (which exits non-zero).
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: inherit-milestone.sh <EPIC> <CHILD>" >&2; exit 2; }
+EPIC="$1"; CHILD="$2"
+REPO="$(kp_repo)" || exit 1
+
+EPIC_MILESTONE=$(gh api "repos/$REPO/issues/$EPIC" --jq '.milestone.number // empty') || exit 1
+if [ -n "$EPIC_MILESTONE" ]; then
+  gh api -X PATCH "repos/$REPO/issues/$CHILD" -f milestone="$EPIC_MILESTONE"
+else
+  echo "milestone: epic #$EPIC has none — #$CHILD stays unmilestoned (inheritance copies, it never invents)."
+fi

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/link-child.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/link-child.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Link <CHILD> to <EPIC> as a NATIVE sub-issue — the real parent/child edge, not a `## Dependencies`
+# mention. The *why* — and why the endpoint takes the database id, not the issue number — stays in
+# ../SKILL.md § Step 4.
+#
+# usage: link-child.sh <EPIC> <CHILD>
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: link-child.sh <EPIC> <CHILD>" >&2; exit 2; }
+EPIC="$1"; CHILD="$2"
+REPO="$(kp_repo)" || exit 1
+
+# the child's database id (reuse the .id from the create if you captured it)
+CHILD_ID=$(gh api "repos/$REPO/issues/$CHILD" --jq '.id') || exit 1
+[ -n "$CHILD_ID" ] || { echo "link-child: could not resolve #$CHILD's database id — refusing to POST an idless link." >&2; exit 1; }
+# `-F` (not `-f`) so the id is sent as a number.
+gh api -X POST "repos/$REPO/issues/$EPIC/sub_issues" \
+  -F sub_issue_id="$CHILD_ID" \
+  --jq '.sub_issues_summary'

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/scratch-open.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/scratch-open.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# OPEN the per-run scratch namespace for this plan of <EPIC> and print its absolute path (§SP,
+# #3718). Run ONCE, in Step 1 — every later script re-derives the same directory with
+# `kp_scratch_path`, which never clears it. The *why* — why the path must be deterministic rather
+# than `mktemp -d`, and why an epic number alone is not unique — stays in ../SKILL.md § Step 1.
+#
+# usage: scratch-open.sh <EPIC>
+#
+# Fail-closed on a missing session id: the shared lib refuses rather than falling back to a shared
+# path, so a non-zero exit is the answer and an empty stdout is never a usable directory.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: scratch-open.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+
+# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
+kp_scratch_open "plan-epic-$EPIC" || {
+  echo "plan-epic: §SP could not open a per-run scratch dir — refusing to write plan state to a shared path (#3718)." >&2; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/splice-body.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/splice-body.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Step 5's guarded read-modify-write of the epic body: re-read → optimistic recheck → freshness
+# guard → `epic-splice apply` → PATCH → confirm OUR WHOLE `## Dependencies` block round-tripped.
+# The *why* — the two layers, the honest residual, and why the re-derive between attempts is YOUR
+# action and not this script's — stays in ../SKILL.md § The write is a guarded read-modify-write.
+#
+# usage: splice-body.sh <EPIC> [--replan]
+#
+# This is a SKELETON you re-run per attempt, not a one-shot: when the recheck fires it stamps the
+# fresh base, BREAKS, and hands back to you to re-derive deps.md (+ plan.md on a re-plan) against
+# $RUN_SCRATCH/current.md before you re-invoke. `--replan` is the moved block's `REPLAN=1`.
+#
+# Reads  $RUN_SCRATCH/{current.md,updated-at.txt,deps.md} (+ plan.md on a re-plan).
+# Writes $RUN_SCRATCH/{live.json,live.md,body.md,deps-expected.md,deps-live.md} and re-stamps
+#        current.md/updated-at.txt on a race.
+#
+# Exit 0 iff the block LANDED (the round-trip confirmed); every other terminal path — an aborted
+# guard, an exhausted loop, a racer's clobber — exits non-zero with its verdict on stdout, so
+# "could not land" can never be read as "pinned".
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: splice-body.sh <EPIC> [--replan]" >&2; exit 2; }
+EPIC="$1"; shift
+REPLAN=0
+case "${1:-}" in
+  --replan) REPLAN=1 ;;
+  "") ;;
+  *) echo "usage: splice-body.sh <EPIC> [--replan]" >&2; exit 2 ;;
+esac
+REPO="$(kp_repo)" || exit 1
+PCLI="$(kp_pcli)" || exit 127
+# §SP: re-derive the per-run scratch namespace — this is a LATER Bash call, so Step 1's
+# $RUN_SCRATCH variable is gone. Same recipe ⇒ same directory ⇒ Step 1's files are still there.
+# NO `rm -rf` here (that is the OPEN step's job only): clearing it would delete exactly the
+# snapshot this step reads back, which is the whole failure §SP rule 3 exists to prevent.
+RUN_SCRATCH="$(kp_scratch_path "plan-epic-$EPIC")" || exit 1
+# Fail closed if Step 1's state isn't there: the freshness guard below compares file mtimes, and
+# `[ existing -nt missing ]` is TRUE in bash — so a missing base would let a STALE block splice
+# through silently. Assert presence first; never let the guard decide on absent files (#3718).
+for f in current.md updated-at.txt; do
+  [ -s "$RUN_SCRATCH/$f" ] || {
+    echo "plan-epic: §SP — $RUN_SCRATCH/$f is missing/empty; Step 1's snapshot did not survive." >&2
+    echo "  Re-run Step 1 in THIS session before splicing. Refusing to evaluate the freshness guard against absent state." >&2; exit 1; }
+done
+
+# "$RUN_SCRATCH/deps.md" = the new `## Dependencies` block. On a RE-PLAN, also
+#   "$RUN_SCRATCH/plan.md" = the new `## Plan (plan-epic)` block (pass --replan).
+#   Give each block a trailing blank line so the next spliced heading stays separated.
+# Landing is confirmed against the WHOLE `## Dependencies` block round-tripping byte-for-byte,
+# NOT a single line: two concurrent runs on the SAME epic likely both emit a given `- #<child>`
+# line (they share children), so a lone matching line can't tell our section from a racer's
+# clobber (see step 6). deps.md is re-derived by YOU between attempts (the recheck breaks out and
+# hands back; step 2) — the freshness guard (step 2.5) enforces it was, so each pass splices a block
+# derived against the body it's splicing onto, never a stale one.
+# A first-time plan has NO `## Dependencies` heading yet (Step 2 doesn't write one) — that case
+# APPENDS the block to EOF; a re-plan has exactly one and SPLICES it in place. Zero headings on a
+# re-plan, or more than one ever, is corruption: the `epic-splice` verb (step 3) exits non-zero.
+#
+# Per attempt: re-read → recheck (verify unchanged) → freshness guard → epic-splice apply (guards + splice) → PATCH
+# → re-verify our block landed. `landed=1` only after a pass confirms the round-trip; `patched=1`
+# records that a PATCH was actually issued (so the terminal verdict can tell "raced every time,
+# never wrote" from "wrote and lost"). The terminal check after the loop turns an
+# exhausted-or-aborted run into a hard STOP rather than ambiguous output.
+landed=0; patched=0
+for attempt in 1 2 3; do
+  echo "attempt $attempt"
+  # 1. re-read the LIVE body + its revision marker from ONE GET (coherent — no TOCTOU skew)
+  gh api "repos/$REPO/issues/$EPIC" --jq '{body,updated_at}' > "$RUN_SCRATCH/live.json" || break
+  jq -r '.body'       "$RUN_SCRATCH/live.json" > "$RUN_SCRATCH/live.md"
+  NOW=$(jq -r '.updated_at' "$RUN_SCRATCH/live.json")
+  WAS=$(cat "$RUN_SCRATCH/updated-at.txt")
+
+  # 2. optimistic recheck — if the body moved since we last read it, stamp the fresh base and BREAK.
+  #    Re-deriving the section is YOUR action (the script can't regenerate deps.md/plan.md inside one
+  #    bash invocation): re-run Step 2's split + Step 5's derivation against the now-fresh
+  #    `current.md`, then re-invoke this script. The freshness guard (2.5) enforces that you did.
+  if [ "$NOW" != "$WAS" ]; then
+    echo "epic body changed since read ($WAS -> $NOW) — RE-DERIVE deps.md (+ plan.md on a re-plan)"
+    echo "  against the fresh base, then re-invoke this script. (Not auto-retried: the re-derive is an agent step.)"
+    cp "$RUN_SCRATCH/live.md" "$RUN_SCRATCH/current.md"   # fresh base to re-derive against
+    echo "$NOW" > "$RUN_SCRATCH/updated-at.txt"
+    break
+  fi
+
+  # 2.5. freshness guard — `deps.md` (and, on a re-plan, `plan.md`) MUST have been (re-)derived
+  #      against the base this attempt is splicing onto. That base is `current.md` (stamped from the
+  #      live body the recheck above just confirmed unchanged), and your re-derive writes deps.md
+  #      AFTER it — so deps.md must be newer than current.md (`-nt` = "newer than"). If it isn't, the
+  #      re-derive precondition is unmet (you re-invoked without regenerating the block off the fresh
+  #      base): a stale block that references the wrong child set. Abort loudly, don't write — this is
+  #      what stops the `continue`-era footgun of re-splicing the originally-derived block (issue #261).
+  #      `-nt` alone CANNOT carry this check: `[ existing -nt missing ]` is TRUE in bash, so if the
+  #      derived block is absent the negation is false and the guard PASSES SILENTLY — a stale/no
+  #      block splices through. Assert the file exists and is non-empty FIRST, then compare mtimes.
+  if [ ! -s "$RUN_SCRATCH/deps.md" ] \
+     || ! [ "$RUN_SCRATCH/deps.md" -nt "$RUN_SCRATCH/current.md" ] \
+     || { [ "$REPLAN" = 1 ] && { [ ! -s "$RUN_SCRATCH/plan.md" ] \
+          || ! [ "$RUN_SCRATCH/plan.md" -nt "$RUN_SCRATCH/current.md" ]; }; }; then
+    echo "ABORT: deps.md (or plan.md on a re-plan) is NOT newer than the base it splices onto (current.md) —"
+    echo "       you re-invoked without re-deriving. Re-run Step 2's split + Step 5's section derivation"
+    echo "       against \"$RUN_SCRATCH/current.md\", then re-invoke this script. Refusing to splice a stale block."
+    break
+  fi
+
+  # 3. splice/append the changed section(s) via the shared verb — `pipeline-cli epic-splice apply`
+  #    owns the deterministic transform (#3689, extracted from #261): the exact-`## Dependencies`
+  #    heading-count guards (0 + first-time → APPEND to EOF; exactly 1 → SPLICE in place; 0 on a
+  #    re-plan or >1 ever → corrupt, exit 1) and, on a re-plan, the in-place `## Plan (plan-epic)`
+  #    splice with its own exactly-one-heading guard. Everything OUTSIDE the replaced section(s) is
+  #    preserved byte-for-byte (the brief especially — layer 1). Pass `--plan-file` ONLY on a
+  #    re-plan: its presence IS the re-plan signal (both sections re-spliced); omit it first-time.
+  #    A corrupt/duplicated/drifted heading makes the verb exit non-zero — break loudly and inspect
+  #    by hand rather than blind-write. The recheck/freshness/round-trip orchestration around it
+  #    stays here (it is live-issue IO, not a text transform).
+  #    The argv is built as ONE array that is never empty: on bash 3.2 under `set -u`, expanding an
+  #    EMPTY array (`"${PLAN_ARG[@]}"` on a first-time plan) aborts the script mid-decision.
+  SPLICE_ARGS=(epic-splice apply --body-file "$RUN_SCRATCH/live.md" --deps-file "$RUN_SCRATCH/deps.md")
+  [ "$REPLAN" = 1 ] && SPLICE_ARGS+=(--plan-file "$RUN_SCRATCH/plan.md")
+  if ! "$PCLI" "${SPLICE_ARGS[@]}" > "$RUN_SCRATCH/body.md"; then
+    echo "ABORT: epic-splice refused (corrupt/duplicated/drifted heading — see its stderr) — refusing to splice; inspect by hand"
+    break
+  fi
+  BODY="$(cat "$RUN_SCRATCH/body.md")"
+
+  # 5. extract THIS run's whole `## Dependencies` block (heading → EOF) from the body we're about
+  #    to write — that exact multi-line block is what we'll confirm round-tripped, so a racer who
+  #    happens to share a child number can't satisfy the check with one matching `- #` line.
+  awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' "$RUN_SCRATCH/body.md" \
+    > "$RUN_SCRATCH/deps-expected.md"
+
+  # 6. write, then re-confirm OUR WHOLE BLOCK landed — extract `## Dependencies`→EOF from the live
+  #    post-write body and diff it against the block we just wrote. A racer's clobber differs
+  #    somewhere in the block (different topology/labels/ordering), so an exact block match — not a
+  #    heading or a single child line — is what tells our section from theirs. The residual window
+  #    (below) means the PATCH is still last-write-wins; this is the honest after-the-fact check
+  #    that retries the loser.
+  gh api -X PATCH "repos/$REPO/issues/$EPIC" -f body="$BODY" >/dev/null; patched=1
+  gh api "repos/$REPO/issues/$EPIC" --jq '.body' \
+    | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > "$RUN_SCRATCH/deps-live.md"
+  if diff -q "$RUN_SCRATCH/deps-expected.md" "$RUN_SCRATCH/deps-live.md" >/dev/null; then
+    echo "epic body updated, our whole ## Dependencies block round-tripped"; landed=1; break
+  else
+    # A racer clobbered our write. Do NOT auto-re-splice the stale deps.md — that would
+    # silently re-clobber the racer's legitimate same-section topology change. Mirror the
+    # recheck-break (step 2): snapshot the racer's body as the FRESH base, then break to hand
+    # back to the agent to RE-DERIVE deps.md (and plan.md on a re-plan) against it before any
+    # re-splice. The freshness guard (step 2.5) then enforces the re-derive on the next invoke,
+    # so a stale block can never re-clobber.
+    echo "our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it."
+    echo "       Re-derive deps.md (and plan.md on a re-plan) against the refreshed"
+    echo "       \"$RUN_SCRATCH/current.md\", then re-invoke this script. Refusing to re-splice the stale block."
+    gh api "repos/$REPO/issues/$EPIC" > "$RUN_SCRATCH/snap.json"   # one snapshot, no TOCTOU between body+updated_at
+    jq -r '.body'       "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/current.md"      # fresh base to re-derive against
+    jq -r '.updated_at' "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/updated-at.txt"
+    break
+  fi
+done
+
+# Terminal verdict — the loop can exit several ways; only one is success. An orchestrator (and the
+# next agent reading the transcript) must not mistake an exhausted-or-aborted run for a win. The two
+# non-success modes differ: a run that NEVER issued a PATCH (raced + re-derived, or a guard aborted)
+# left the body untouched; a run that DID PATCH but lost the round-trip left it possibly half-written.
+if [ "$landed" != 1 ]; then
+  echo "plan-epic: could NOT land the ## Dependencies block — STOP and inspect, do not proceed."
+  if [ "$patched" = 1 ]; then
+    echo "  (A PATCH was issued but our block didn't round-trip — a racer clobbered it. The epic body"
+    echo "   may be half-written with someone else's topology; the topology this run derived is NOT pinned.)"
+  else
+    echo "  (No PATCH was ever issued — either a guard aborted (corrupt/duplicated heading, or deps.md"
+    echo "   not re-derived against the fresh base), or every attempt raced and handed back to re-derive."
+    echo "   The epic body is untouched; the topology this run derived is NOT pinned.)"
+  fi
+  # The moved block ended here with the verdict on stdout only; a script's caller reads the exit
+  # status too, so the non-success paths must NOT exit 0 — that is exactly "could not land" read as
+  # "pinned" (§ZS).
+  exit 1
+fi

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/supersede-child.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/supersede-child.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# The re-plan journal note: post *why* a child is superseded and where the work went, then unlink it
+# from the epic and close it not-planned. The *why* — that every supersede is auditable, and that a
+# closed-done child is history and is never superseded — stays in ../SKILL.md § The journal note.
+#
+# usage: supersede-child.sh <EPIC> <CHILD> <reason>
+#
+# <reason> is the specific sentence, e.g. "scope merged into #<NEW>" or "dropped, the brief no
+# longer asks for X". Order is load-bearing: the note lands BEFORE the close, so the trail exists
+# even if a later leg fails.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "usage: supersede-child.sh <EPIC> <CHILD> <reason>" >&2; exit 2; }
+EPIC="$1"; CHILD="$2"; REASON="$3"
+REPO="$(kp_repo)" || exit 1
+
+gh api "repos/$REPO/issues/$CHILD/comments" \
+  -f body="Superseded by re-plan of #$EPIC: $REASON." || exit 1
+# unlink from the epic (singular sub_issue, id in the JSON body), then close not-planned
+CHILD_ID=$(gh api "repos/$REPO/issues/$CHILD" --jq '.id') || exit 1
+[ -n "$CHILD_ID" ] || { echo "supersede-child: could not resolve #$CHILD's database id — refusing to DELETE an idless edge." >&2; exit 1; }
+echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE "repos/$REPO/issues/$EPIC/sub_issue" --input - || exit 1
+gh api -X PATCH "repos/$REPO/issues/$CHILD" -f state=closed -f state_reason=not_planned

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/teardown-scratch-epic.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/teardown-scratch-epic.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Dry-run cleanup: unlink + close each scratch child not-planned, then close the scratch epic. The
+# *why* — that issues cannot be deleted over the public REST API, and that dry-run validation must
+# never run against a real epic — stays in ../SKILL.md § Cleaning up after a dry-run.
+#
+# usage: teardown-scratch-epic.sh <EPIC> [<CHILD> …]
+#
+# THROWAWAY EPICS ONLY. It closes exactly the numbers you name, so naming a real epic closes a real
+# epic — there is no way for a script to tell test debris from the backlog.
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: teardown-scratch-epic.sh <EPIC> [<CHILD> …]" >&2; exit 2; }
+EPIC="$1"; shift
+REPO="$(kp_repo)" || exit 1
+
+# for each scratch child: unlink + close
+for CHILD in "$@"; do
+  CHILD_ID=$(gh api "repos/$REPO/issues/$CHILD" --jq '.id') || exit 1
+  [ -n "$CHILD_ID" ] || { echo "teardown: could not resolve #$CHILD's database id — refusing to DELETE an idless edge." >&2; exit 1; }
+  echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE "repos/$REPO/issues/$EPIC/sub_issue" --input - || exit 1
+  gh api -X PATCH "repos/$REPO/issues/$CHILD" -f state=closed -f state_reason=not_planned || exit 1
+done
+# then close the scratch epic
+gh api -X PATCH "repos/$REPO/issues/$EPIC" -f state=closed -f state_reason=not_planned

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/unlink-child.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/unlink-child.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Unlink <CHILD> from <EPIC>. The endpoint is SINGULAR `sub_issue` and the id goes in the JSON body
+# via `--input` — `-X DELETE … -F` does NOT work here. Unlinking does not close the child; closing is
+# a separate state change. The *why* stays in ../SKILL.md § Step 4.
+#
+# usage: unlink-child.sh <EPIC> <CHILD>
+#
+# Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: unlink-child.sh <EPIC> <CHILD>" >&2; exit 2; }
+EPIC="$1"; CHILD="$2"
+REPO="$(kp_repo)" || exit 1
+
+CHILD_ID=$(gh api "repos/$REPO/issues/$CHILD" --jq '.id') || exit 1
+[ -n "$CHILD_ID" ] || { echo "unlink-child: could not resolve #$CHILD's database id — refusing to DELETE an idless edge." >&2; exit 1; }
+echo "{\"sub_issue_id\": $CHILD_ID}" \
+  | gh api -X DELETE "repos/$REPO/issues/$EPIC/sub_issue" --input -

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# The reviewer-runnable harness for #4452's extraction, covering BOTH halves of the planning gate —
+# plan-epic and review-plan. It is committed rather than pasted as a results table so a gate can
+# RE-RUN it instead of trusting a claim (#4449's precedent).
+#
+# usage: verify-extraction.sh            # both skills
+#        verify-extraction.sh <skill> …  # a named subset
+#
+# Nine checks, each fail-closed and each printing what it scanned. FAILS CLOSED ON ZERO SCOPE
+# (ADR 0092): a run that resolved no SKILL.md or no scripts is a FAIL, never a silent pass. This
+# harness excludes ITSELF from the extracted-script set — it is the verifier, not moved shell.
+#
+#   1. INVOCATION-ONLY — every fenced bash/sh block left in each SKILL.md contains nothing but
+#      script invocations (comments, blanks and trailing `\` continuations allowed); no multi-line
+#      glue remains.
+#   2. NO BARE `pipeline-cli` — the extracted scripts reach the shim only through `kp_pcli`, so a
+#      PATH-resolved `pipeline-cli` (not on PATH, ADR 0207) cannot re-enter the corpus.
+#   3. NO USER-LOCAL PATHS — no /Users/<name> or /home/<name> absolute path. This is the check
+#      whose CI counterpart does NOT reach a `.sh`: leak-guard's DOC_SUFFIXES is
+#      [".md",".mdx",".markdown"] (packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts), so a
+#      `.sh` is out of its scope until #4496 lands. Until then THIS is the only thing holding the
+#      property for these files.
+#   4. SHELLCHECK — `shellcheck -x` clean on every extracted script (reported as a SKIP with no
+#      result, never as a pass, when the binary is absent).
+#   5. SOURCES THE SHARED LIB — every script sources ../../shared/lib/common.sh, so no skill-local
+#      copy of kp_repo / kp_pcli / kp_scratch_* can drift (the PR #4485 lesson: source, don't copy).
+#   6. NO CLEANUP TRAP ON EXIT — on bash 3.2 such a trap makes its last command the script's exit
+#      status, laundering a `set -u` abort into exit 0 (#4476, class #4479).
+#   7. NO UNGUARDED EMPTY-ARRAY EXPANSION — `"${arr[@]}"` on an EMPTY array aborts under `set -u` on
+#      bash 3.2, so an array built conditionally must be non-empty by construction or length-guarded.
+#   8. SHIM MISS IS 127 WITH EMPTY STDOUT — probed live on the shared primitive (`kp_pcli` under a
+#      bogus CLAUDE_PLUGIN_ROOT), asserting BOTH the captured exit code and the captured stdout byte
+#      count; plus every script that reaches a verb resolves it as `PCLI="$(kp_pcli)" || exit 127`,
+#      so a could-not-run can never surface as an answer. Network-free.
+#   9. USAGE MISS IS NON-ZERO WITH EMPTY STDOUT — every script that takes arguments, run with none,
+#      asserted on BOTH the captured exit code and the captured stdout byte count. Network-free
+#      (the usage guard precedes every `gh` call).
+#
+# Checks 2, 6 and 7 match against a COMMENT-STRIPPED copy of each script (everything from the first
+# `#` on a line is dropped) so the skills can keep *writing about* a bare shim, a cleanup trap, or an
+# empty-array expansion in the prose that explains why each is forbidden. That strip is naive about a
+# `#` inside a string literal, which errs toward scanning less of a line — never toward passing a
+# line it should have read, since a real violation is executable code and sits before any comment.
+set -uo pipefail
+
+# shellcheck disable=SC1007  # `CDPATH= cd` is the corpus idiom: an empty CDPATH for this one command
+SKILLS_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1007
+SELF="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/$(basename -- "${BASH_SOURCE[0]}")"
+SKILLS=(plan-epic review-plan)
+[ "$#" -gt 0 ] && SKILLS=("$@")
+
+errors=0
+checks=0
+scanned_md=0
+scanned_sh=0
+fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
+ok() { echo "ok: $*"; checks=$((checks + 1)); }
+
+# A comment-stripped copy of every extracted script, one per line as `<path>:<lineno>:<code>`.
+code_lines() {
+	local f
+	for f in "${SCRIPT_PATHS[@]}"; do
+		sed -e 's/#.*$//' "$f" | grep -n . | sed -e "s|^|$f:|"
+	done
+}
+
+SCRIPT_PATHS=()
+for skill in "${SKILLS[@]}"; do
+	md="$SKILLS_DIR/$skill/SKILL.md"
+	dir="$SKILLS_DIR/$skill/scripts"
+	[ -f "$md" ] || { fail "$skill: no SKILL.md at $md"; continue; }
+	[ -d "$dir" ] || { fail "$skill: no scripts/ dir at $dir"; continue; }
+	scanned_md=$((scanned_md + 1))
+	while IFS= read -r f; do
+		[ -n "$f" ] || continue
+		[ "$f" = "$SELF" ] && continue   # the harness is not moved shell
+		SCRIPT_PATHS+=("$f")
+		scanned_sh=$((scanned_sh + 1))
+	done < <(find "$dir" -type f -name '*.sh' | LC_ALL=C sort)
+
+	# 1. every remaining fenced bash/sh block contains only script invocations
+	bad="$(awk -v skill="$skill" '
+		/^[[:space:]]*```(bash|sh)[[:space:]]*$/ { inb=1; start=NR; n=0; inv=0; cont=0; next }
+		inb && /^[[:space:]]*```[[:space:]]*$/ {
+			if (n == 0 || inv != n) printf "%s:%d (payload lines=%d, invocations=%d)\n", skill, start, n, inv
+			inb=0; next
+		}
+		inb {
+			line=$0
+			sub(/^[[:space:]]+/, "", line)
+			if (line == "" || line ~ /^#/) next          # comments and blanks are not glue
+			if (cont) { cont = (line ~ /\\$/); next }    # a continuation of the counted line
+			n++
+			if (line ~ /skills\/[a-z-]+\/scripts\/[a-z0-9_-]+\.sh/) inv++
+			cont = (line ~ /\\$/)
+		}
+	' "$md")"
+	if [ -n "$bad" ]; then
+		fail "$skill/SKILL.md: fenced block(s) carry something other than script invocations:"
+		printf '  %s\n' "$bad"
+	else
+		ok "$skill/SKILL.md: every fenced bash/sh block carries only scripts/*.sh invocations"
+	fi
+done
+
+if [ "$scanned_md" -eq 0 ] || [ "$scanned_sh" -eq 0 ]; then
+	fail "zero scope: resolved $scanned_md SKILL.md and $scanned_sh script(s) — refusing to report a pass over nothing (ADR 0092)"
+	echo "verify-extraction: FAILED — $errors error(s)"
+	exit 1
+fi
+
+# 2. no bare `pipeline-cli` token in executable code — the shim is reached only through kp_pcli
+if hits="$(code_lines | grep -E '(^|[^/[:alnum:]_-])pipeline-cli([[:space:]]|$)' || true)"; [ -n "$hits" ]; then
+	fail "bare \`pipeline-cli\` token(s) in executable code — resolve the shim through kp_pcli (ADR 0207):"
+	printf '  %s\n' "$hits"
+else
+	ok "no bare \`pipeline-cli\` token in the executable code of any extracted script (${#SCRIPT_PATHS[@]} file(s))"
+fi
+
+# 3. no user-local absolute paths anywhere in the file, comments included (the #4496 scope gap)
+if hits="$(grep -nE '/(Users|home)/[A-Za-z0-9._-]+' "${SCRIPT_PATHS[@]}" || true)"; [ -n "$hits" ]; then
+	fail "user-local absolute path(s) in an extracted script:"
+	printf '  %s\n' "$hits"
+else
+	ok "no /Users/<name> or /home/<name> path in any extracted script (${#SCRIPT_PATHS[@]} file(s))"
+fi
+
+# 4. shellcheck
+if command -v shellcheck >/dev/null 2>&1; then
+	if out="$(shellcheck -x "${SCRIPT_PATHS[@]}" 2>&1)"; then
+		ok "shellcheck -x clean on all ${#SCRIPT_PATHS[@]} extracted script(s)"
+	else
+		fail "shellcheck -x findings:"
+		printf '%s\n' "$out"
+	fi
+else
+	echo "SKIP: shellcheck not installed — check 4 produced NO result (not a pass)"
+fi
+
+# 5. every script sources the shared lib
+missing=""
+for f in "${SCRIPT_PATHS[@]}"; do
+	grep -qF 'shared/lib" && pwd)/common.sh' "$f" || missing="$missing $f"
+done
+if [ -n "$missing" ]; then
+	fail "script(s) that do not source shared/lib/common.sh (a local copy would drift):$missing"
+else
+	ok "all ${#SCRIPT_PATHS[@]} script(s) source the shared lib's common.sh"
+fi
+
+# 6. no cleanup trap on EXIT in executable code
+if hits="$(code_lines | grep -E 'trap[[:space:]].*[[:space:]]EXIT' || true)"; [ -n "$hits" ]; then
+	fail "cleanup trap(s) on EXIT — on bash 3.2 the trap's status becomes the script's, laundering an abort into exit 0 (#4476):"
+	printf '  %s\n' "$hits"
+else
+	ok "no cleanup trap on EXIT in any extracted script (#4476, class #4479)"
+fi
+
+# 7. every conditionally-built array is non-empty by construction or length-guarded
+arr_bad=0
+for f in "${SCRIPT_PATHS[@]}"; do
+	while IFS= read -r arr; do
+		[ -n "$arr" ] || continue
+		# non-empty by construction: its declaring assignment carries at least one element
+		grep -qE "^[[:space:]]*${arr}=\([^)]" "$f" && continue
+		grep -qE "\\\$\{#${arr}\[@\]\}" "$f" && continue
+		fail "$f: \"\${${arr}[@]}\" may expand an EMPTY array under set -u on bash 3.2 — declare it non-empty or length-guard it"
+		arr_bad=1
+	done < <(sed -e 's/#.*$//' "$f" | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}' | sed -E 's/^\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\}$/\1/' | LC_ALL=C sort -u)
+done
+[ "$arr_bad" = 0 ] && ok "every \"\${arr[@]}\" expansion is non-empty by construction or length-guarded (bash 3.2 + set -u)"
+
+# 8. a shim miss is 127 with EMPTY stdout — probed live on the shared primitive, network-free
+probe_out="$(CLAUDE_PLUGIN_ROOT=/nonexistent-kampus-plugin-root bash -c '
+	set -uo pipefail
+	. "'"$SKILLS_DIR"'/shared/lib/common.sh"
+	kp_pcli
+' 2>/dev/null)"
+probe_rc=$?
+probe_bytes=$(printf '%s' "$probe_out" | wc -c | tr -d ' ')
+if [ "$probe_rc" = 127 ] && [ "$probe_bytes" = 0 ]; then
+	ok "kp_pcli under a bogus CLAUDE_PLUGIN_ROOT: exit=$probe_rc, stdout bytes=$probe_bytes — UNKNOWN, never an answer"
+else
+	fail "kp_pcli under a bogus CLAUDE_PLUGIN_ROOT: exit=$probe_rc, stdout bytes=$probe_bytes (want exit 127, 0 bytes)"
+fi
+pcli_bad=0
+for f in "${SCRIPT_PATHS[@]}"; do
+	grep -q 'kp_pcli' "$f" || continue
+	grep -qE 'PCLI="\$\(kp_pcli\)" \|\| exit 127' "$f" && continue
+	fail "$f: calls kp_pcli without \`|| exit 127\` — a could-not-run could fall through as an answer"
+	pcli_bad=1
+done
+[ "$pcli_bad" = 0 ] && ok "every script that reaches a verb resolves it as PCLI=\"\$(kp_pcli)\" || exit 127"
+
+# 9. a usage miss is non-zero with EMPTY stdout — asserted on BOTH operands, network-free
+probed=0
+usage_bad=0
+for f in "${SCRIPT_PATHS[@]}"; do
+	grep -qE '^\[ "\$#" -ge [0-9]+ \] \|\|' "$f" || continue
+	probed=$((probed + 1))
+	out="$(bash "$f" 2>/dev/null)"
+	rc=$?
+	bytes=$(printf '%s' "$out" | wc -c | tr -d ' ')
+	if [ "$rc" = 0 ] || [ "$bytes" != 0 ]; then
+		fail "$(basename "$f") with no args: exit=$rc, stdout bytes=$bytes (want non-zero exit, 0 bytes)"
+		usage_bad=1
+	fi
+done
+if [ "$probed" -eq 0 ]; then
+	fail "zero scope: no argument-taking script was probed for its usage refusal (ADR 0092)"
+elif [ "$usage_bad" = 0 ]; then
+	ok "all $probed argument-taking script(s) refuse a no-args call with a non-zero exit AND 0 bytes of stdout"
+fi
+
+echo "scanned scope: ${scanned_md} SKILL.md, ${scanned_sh} extracted script(s) across [${SKILLS[*]}]"
+if [ "$errors" -gt 0 ]; then
+	echo "verify-extraction: FAILED — $errors error(s)"
+	exit 1
+fi
+echo "verify-extraction: OK — $checks checks over ${scanned_sh} script(s) in ${scanned_md} skill(s)"

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -88,6 +88,10 @@ is #1929). Three properties are load-bearing when you read or edit them:
   straight through; the pass/fail decision stays the validator's, exactly as Step 1 requires
   (ADR 0228).
 
+The runnable harness for those properties covers **both** halves of the planning gate and lives with
+the other half: [`../plan-epic/scripts/verify-extraction.sh`](../plan-epic/scripts/verify-extraction.sh).
+Run it after editing any script here; it fails closed on zero scope.
+
 ## Read-only on git working state
 
 **You never mutate the git working tree of the checkout you run in** — the single canonical

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -59,8 +59,34 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/resolve-repo.sh")" || exit 1
 ```
+
+Every script under [`scripts/`](scripts/) resolves the repo the same way through the shared lib's
+`kp_repo`, so you never thread `$REPO` into one — that assignment is for your own hand-run `gh api`
+reads.
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), one script per step, and each fenced `bash`
+block below is an **invocation** of one. The prose keeps the *why*; the scripts hold the *how*
+(epic #4435 phase 1 — the shell moved as-is, and turning its glue into tested `pipeline-cli` verbs
+is #1929). Three properties are load-bearing when you read or edit them:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control
+  flow through the guards written into it — an `if ! $LOCK acquire` that branches on a status
+  rather than dying on it. `errexit` would abort those paths mid-decision and turn a fail-closed
+  branch into no branch at all.
+- **An exit status is the answer; an empty stdout never is.** Every script's failure paths exit
+  non-zero, and the moved blocks' back-off `exit 0` — which used to end the *agent's own* bash
+  block — became a distinct code, because a separate process's exit 0 would read as "proceed".
+  [`scripts/epic-lock-acquire.sh`](scripts/epic-lock-acquire.sh) exits **3** on a back-off (a held
+  lock, a setup gap, a lost race — not a review-plan failure, re-run later) and **0** only when
+  `epic-lock acquire` itself won, printing `epic-lock: won #<EPIC>`. An unresolved shim is **127**
+  everywhere — UNKNOWN, never a win and never a verdict.
+- **They relay, they never decide.** `run-gate.sh` passes `epic-ledger`'s verdict and exit status
+  straight through; the pass/fail decision stays the validator's, exactly as Step 1 requires
+  (ADR 0228).
 
 ## Read-only on git working state
 
@@ -124,19 +150,10 @@ re-implementing ~50 lines of `jq` inline. Resolve the tool the same way `$GATE` 
 in-repo first, published fallback (ADR 0064) — then branch on its exit status:
 
 ```bash
-# The `bin/pipeline-cli` shim resolves the CLI (in-repo bin, else the installed bin, else the
-# pinned `pnpm dlx` fallback) — no version is pinned here; the one pin lives in hooks/pin.sh,
-# which the shim sources (#3653, per #3457).
-LOCK="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli epic-lock"
-
-# Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID
-# and exits 0 ONLY when the lock is ours; every fail-closed back-off — a held label, a 422 missing label, a
-# failed claim post, a lost co-acquire, a missing session id — prints its reason on stderr and exits NON-ZERO.
-# Branch on exit status — never flip/loop on a non-zero.
-if ! $LOCK acquire <EPIC>; then
-  exit 0   # backed off (held lock / setup gap / lost race is not a review-plan failure) — re-run later.
-fi
-# WON. WE hold the lock (label + earliest claim). Release it on EVERY terminal path (below).
+# exit 0 = lock WON (prints `epic-lock: won #<EPIC>`) → gate/loop, then RELEASE on every exit path.
+# 3 = backed off (held lock / setup gap / lost race — not a review-plan failure, re-run later);
+# 127 = the shim never ran (UNKNOWN). NEVER flip or loop on a non-zero.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/epic-lock-acquire.sh" <EPIC>
 ```
 
 **Release is an explicit agent step, not a shell `trap … EXIT`.** The acquire above runs in
@@ -148,12 +165,9 @@ snippet; it is an action **you** take, deliberately, on the way out — run this
 you reach **any** terminal state (PASS-and-flipped, parked, or a fault mid-flight):
 
 ```bash
-# release: run on EVERY exit path AFTER a WON acquire (PASS/flip, park, or fault mid-flight).
-# `epic-lock release` does BOTH parts: (a) retract OUR OWN claim comment(s) — re-found by session id,
-# since the acquire ran in a PRIOR process and its comment id is gone here; and (b) drop the coarse
-# label — a 404 is benign (already released), but ANY other DELETE failure is surfaced LOUDLY (a
-# silently-swallowed DELETE LEAKS the lock and wedges the epic, the exact ADR-0059 catastrophe).
-$LOCK release <EPIC>
+# A non-zero exit means the release did NOT complete — the lock is LEAKED and the epic is wedged.
+# Surface it loudly; never swallow it.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/epic-lock-release.sh" <EPIC>
 ```
 
 The release fires on **every** terminal path on purpose: the gate and the convergence loop can
@@ -212,21 +226,20 @@ no network, no published-artifact dependency on the daily pipeline), and otherwi
 once into a `$GATE` command and use it everywhere below, so there is exactly one resolution site:
 
 ```bash
-# resolve the gate command once via the `bin/pipeline-cli` shim — it resolves in-repo bin,
-# else the installed bin, else the pinned `pnpm dlx` fallback, reading the ONE pin from
-# hooks/pin.sh; no version is pinned here (#3653; ADR 0064; epic #994).
-GATE="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli epic-ledger"
+# for your own ad-hoc `$GATE …` reads; `run-gate.sh` resolves the shim through the same one
+# primitive, so there is still exactly one resolution mechanism. Exit 127 ⇒ no gate command at all.
+GATE="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/resolve-gate.sh")" || exit 127
 ```
 
 The shim yields a runnable `$GATE`, so a foreign install **runs** the gate rather than
 degrading — and no raw `ERR_MODULE_NOT_FOUND` can surface, because the shim only runs the
 in-repo bin when it is on disk and otherwise fetches the pinned published package before running.
-Then run the gate through `$GATE`:
+Then run the gate:
 
 ```bash
-# from the repo root:
-$GATE <EPIC>            # the live gate — flips + comments
-$GATE <EPIC> --dry-run  # read-only: validate + print, no mutation
+# from the repo root. Exit status + stdout are the gate's own, relayed; 127 = no verdict at all.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/run-gate.sh" <EPIC>            # the live gate — flips + comments
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/run-gate.sh" <EPIC> --dry-run  # read-only: validate + print, no mutation
 ```
 
 `runGate(<EPIC>)` is the underlying action the CLI calls (`epic-ledger`'s `runGate`,

--- a/claude-plugins/kampus-pipeline/skills/review-plan/scripts/epic-lock-acquire.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/scripts/epic-lock-acquire.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Acquire the two-layer `status:planning` epic-lock on <EPIC> before the gate's first flip and
+# before the convergence loop's first rePlan (ADR 0059/0115). The *why* — why the coarse label
+# alone cannot serialize under one shared login, and why every back-off must not fall through —
+# stays in ../SKILL.md § Acquire the epic-lock.
+#
+# usage: epic-lock-acquire.sh <EPIC>
+#
+# EXIT-CODE CONTRACT — the back-off seam. The moved block ended its back-off with `exit 0`, which
+# terminated the AGENT's own bash block; a separate process cannot do that, and an exit 0 here
+# would read to the caller as "the lock is ours". So the back-off became its own code:
+#   0    WON — we hold the lock (label + earliest claim). RELEASE it on every terminal path.
+#   3    backed off (held label / 422 missing label / failed claim post / lost co-acquire /
+#        missing session id). NOT a review-plan failure — re-run later; never flip/loop.
+#   127  the shim never ran — UNKNOWN, so NOT a win.
+# Exit 0 is reachable only through `epic-lock acquire` itself exiting 0, and stdout carries the
+# `epic-lock: won` line on that one path only — so neither an empty stdout nor a could-not-run
+# can be read as the permissive answer.
+#
+# Extracted from review-plan/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: epic-lock-acquire.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+# The `bin/pipeline-cli` shim resolves the CLI (in-repo bin, else the installed bin, else the
+# pinned `pnpm dlx` fallback) — no version is pinned here; the one pin lives in hooks/pin.sh,
+# which the shim sources (#3653, per #3457).
+PCLI="$(kp_pcli)" || exit 127
+LOCK="$PCLI epic-lock"
+
+# Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID
+# and exits 0 ONLY when the lock is ours; every fail-closed back-off — a held label, a 422 missing label, a
+# failed claim post, a lost co-acquire, a missing session id — prints its reason on stderr and exits NON-ZERO.
+# Branch on exit status — never flip/loop on a non-zero.
+if ! $LOCK acquire "$EPIC"; then
+  echo "epic-lock: backed off on #$EPIC (held lock / setup gap / lost race is not a review-plan failure) — re-run later." >&2
+  exit 3
+fi
+# WON. WE hold the lock (label + earliest claim). Release it on EVERY terminal path (below).
+echo "epic-lock: won #$EPIC"

--- a/claude-plugins/kampus-pipeline/skills/review-plan/scripts/epic-lock-release.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/scripts/epic-lock-release.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Release the `status:planning` epic-lock on <EPIC>. Run on EVERY exit path after a WON acquire.
+# The *why* — why release is an explicit agent step and never a shell `trap … EXIT`, and why only
+# a lock YOU won may be released — stays in ../SKILL.md § Acquire the epic-lock.
+#
+# usage: epic-lock-release.sh <EPIC>
+#
+# Exit status is the verb's own: non-zero means the release did NOT complete, which LEAKS the lock
+# and wedges the epic (the ADR-0059 catastrophe) — surface it, never swallow it.
+#
+# Extracted from review-plan/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: epic-lock-release.sh <EPIC>" >&2; exit 2; }
+EPIC="$1"
+PCLI="$(kp_pcli)" || exit 127
+LOCK="$PCLI epic-lock"
+
+# release: run on EVERY exit path AFTER a WON acquire (PASS/flip, park, or fault mid-flight).
+# `epic-lock release` does BOTH parts: (a) retract OUR OWN claim comment(s) — re-found by session id,
+# since the acquire ran in a PRIOR process and its comment id is gone here; and (b) drop the coarse
+# label — a 404 is benign (already released), but ANY other DELETE failure is surfaced LOUDLY (a
+# silently-swallowed DELETE LEAKS the lock and wedges the epic, the exact ADR-0059 catastrophe).
+$LOCK release "$EPIC"

--- a/claude-plugins/kampus-pipeline/skills/review-plan/scripts/resolve-gate.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/scripts/resolve-gate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Print the resolved `$GATE` command — the `epic-ledger` floor, in-repo first, published fallback
+# (ADR 0064; epic #994). The *why* — portability, and why no version is pinned at the call site —
+# stays in ../SKILL.md § Step 1.
+#
+# usage: resolve-gate.sh
+#
+# This is for your OWN ad-hoc `$GATE …` reads. `run-gate.sh` resolves the shim through the same one
+# primitive (the shared lib's `kp_pcli`), so there is still exactly one resolution mechanism.
+# Exit 127 = the shim never ran, so there is NO gate command — UNKNOWN, never a degraded run.
+#
+# Extracted from review-plan/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# resolve the gate command once via the `bin/pipeline-cli` shim — it resolves in-repo bin,
+# else the installed bin, else the pinned `pnpm dlx` fallback, reading the ONE pin from
+# hooks/pin.sh; no version is pinned here (#3653; ADR 0064; epic #994).
+PCLI="$(kp_pcli)" || exit 127
+printf '%s epic-ledger\n' "$PCLI"

--- a/claude-plugins/kampus-pipeline/skills/review-plan/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from review-plan/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/review-plan/scripts/run-gate.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/scripts/run-gate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run the deterministic gate over <EPIC>: `epic-ledger`'s runGate, which validates the ledger and —
+# on a clean floor — flips every `status:planned` child to `status:triaged` and posts the PASS
+# verdict itself. The *why* — that this is the WHOLE pass/fail decision and must never be
+# re-derived in prose — stays in ../SKILL.md § Step 1.
+#
+# usage: run-gate.sh <EPIC>              # the live gate — flips + comments
+#        run-gate.sh <EPIC> --dry-run    # read-only: validate + print, no mutation
+#
+# Exit status is the gate's own. 127 = the shim never ran, so there is NO verdict — UNKNOWN, never
+# a PASS. This script RELAYS the gate's answer; it never derives one (ADR 0228).
+#
+# Extracted from review-plan/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: run-gate.sh <EPIC> [--dry-run]" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+GATE="$PCLI epic-ledger"
+
+# from the repo root:
+$GATE "$@"


### PR DESCRIPTION
Part of #4452 — and #4452 remains open only until a human approves this; there is no remainder, the
whole 22-block scope landed (see **Scope: complete** below).

## What this does

Byte-moves the fenced shell of **both halves of the planning gate** into sourced scripts:

| skill | blocks moved | fenced shell lines moved | destination |
|---|---|---|---|
| `plan-epic` | 17 | 290 | `claude-plugins/kampus-pipeline/skills/plan-epic/scripts/` |
| `review-plan` | 5 | 27 | `claude-plugins/kampus-pipeline/skills/review-plan/scripts/` |
| **total** | **22** | **317** | 22 new scripts |

Every fenced `bash` block remaining in either `SKILL.md` is now a single invocation of one of those
scripts. The *why*-prose stays exactly where it was.

**Phase 1 discipline (the founder's ruling on #4435, comment 5112916299).** The glue moved
mechanically. No verb replacement, no rewrite of the moved shell — that is phase 2 (#1929). Per
ADR 0228 a script may **relay** a verb's answer and never **derive** the decision: each of these
relays `epic-lock`, `epic-ledger`, `epic-splice apply`, `intake-compose sub-issue`, or
`tracker graduate`, and derives nothing those verbs own.

### Line delta per SKILL.md

- `plan-epic/SKILL.md` — **+99 / −288 = −189**
- `review-plan/SKILL.md` — **+45 / −28 = +17** (net positive: the 27 shell lines it lost are
  outweighed by its new `## The extracted scripts` contract section, the exit-code contract prose,
  and the harness pointer — disclosed, not hidden)
- whole diff — **+1130 / −316 = +814**, all of the growth in the 22 new scripts plus the 221-line
  verification harness

## Source, don't copy

- `shared/scripts/cycle-doc-probe.sh` is **sourced**, not copied — `plan-epic/scripts/cycle-doc-probe.sh`
  is a 30-line wrapper that sources the one shared implementation and prints its `$CYCLE_DOC`.
- `shared/lib/common.sh` supplies `kp_repo`, `kp_pcli`, `kp_scratch_open` / `kp_scratch_path` to all
  22 scripts. Zero skill-local reimplementations; the harness asserts every script sources it.
- `shared/scripts/cp-classify-entry.sh` was **deliberately not used.** It exits 127 with 0 bytes on
  stdout when `REPO`/`PR` are unset (its refusals go to stderr only), so a caller that reads "no
  `BLOCKING (…)` line" as a positive answer fails open. Neither skill needs a §CP classification, so
  leaning on it would have imported that hazard for nothing. #4488 remains open on it.
- Cross-call state: `plan-epic`'s Step 1 → Step 5 snapshot travels through `kp_scratch_open` (once)
  and `kp_scratch_path` (every later call, never re-clearing). Measured: `pipeline-cli scratchpad
  open --slug plan-epic-<N>` yields `$TMPDIR/kampus-run/<session>/plan-epic-<N>`, byte-identical in
  shape to the inline §SP recipe it replaces, so the snapshot path is unchanged.

## Reviewer-runnable verification

The proof is committed as a harness, not pasted as a table — re-run it rather than trust this body:

```
bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
```

Eleven checks, fail-closed on zero scope (ADR 0092). Observed on head:

```
ok: plan-epic/SKILL.md: every fenced bash/sh block carries only scripts/*.sh invocations
ok: review-plan/SKILL.md: every fenced bash/sh block carries only scripts/*.sh invocations
ok: no bare `pipeline-cli` token in the executable code of any extracted script (22 file(s))
ok: no /Users/<name> or /home/<name> path in any extracted script (22 file(s))
ok: shellcheck -x clean on all 22 extracted script(s)
ok: all 22 script(s) source the shared lib's common.sh
ok: no cleanup trap on EXIT in any extracted script (#4476, class #4479)
ok: every "${arr[@]}" expansion is non-empty by construction or length-guarded (bash 3.2 + set -u)
ok: kp_pcli under a bogus CLAUDE_PLUGIN_ROOT: exit=127, stdout bytes=0 — UNKNOWN, never an answer
ok: every script that reaches a verb resolves it as PCLI="$(kp_pcli)" || exit 127
ok: all 18 argument-taking script(s) refuse a no-args call with a non-zero exit AND 0 bytes of stdout
scanned scope: 2 SKILL.md, 22 extracted script(s) across [plan-epic review-plan]
verify-extraction: OK — 11 checks over 22 script(s) in 2 skill(s)
```

**Both failure-path checks assert both operands — captured exit code AND captured stdout byte
count** — because either alone lets a failure read as the permissive answer (§ZS; #4231, #4010,
#4219). Both probes are network-free: the usage guard precedes every `gh` call, and the shim probe
runs `kp_pcli` under a bogus `CLAUDE_PLUGIN_ROOT`.

Note `REPO="$(kp_repo)" || exit 1` specifically: `kp_repo` returns **before any echo** on failure,
and the call site is `REPO="$(kp_repo)" || exit 1` — **not** `local REPO="$(...)"`, which would mask
the exit status. That shape is used in every script that resolves a repo.

Also run green on head: `gh-phoenix lint-skills` (clean), `cli-invocation-guard check` over
`claude-plugins/**/*.md` (76 files, 321 fences, clean), `adoption-lint check` over the CI corpus (175
files, clean), `leak-guard scan` over the changed set (clean), `validate-skills.sh` (30 skills),
`validate-cycle-presence.sh` (18 checks), `validate-cycle-absence.sh` (14 checks),
`validate-gate-path-drift.sh` (34 checks), `pnpm lint:worktree` (no biome-handled changed files).

## Guard-surface delta — three separate claims

**1. Which surfaces narrow.** Two, both markdown-scoped:

- **`cli-invocation-guard`** is fence-scoped to markdown, so shell that leaves a fence leaves its
  reach. Measured precisely, not asserted: the guard scans **22 runnable fences across these two
  files before and after** (unchanged — each moved block became an invocation fence), but the **6
  executable shim-resolution lines** inside them (`plan-epic`: one `LOCK=` + three `PCLI=`;
  `review-plan`: `LOCK=` + `GATE=`) are now in `.sh` files it does not read. #4486 remains open on
  the narrowing; PR #4494 is in flight widening the guard to follow extracted shell.
- **`leak-guard`** is markdown-only by extension: `DOC_SUFFIXES = [".md",".mdx",".markdown"]` at
  `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts`. The 22 new `.sh` files are outside its
  scope. #4496 remains open on that.

Not narrowed: `gh-phoenix lint-skills`'s bare-push check (`isBarePushScoped` takes `.md` **and**
`.sh`, and treats a whole `.sh` as one fence), `adoption-lint` (its corpus is every `.md`/`.sh` under
the plugin dir), and both cycle validators (`kp_skill_shell_surfaces` resolves `SKILL.md` **plus**
every `*.sh` under the skill dir — the scanned-scope line now names all 17 `plan-epic/scripts/*.sh`).

**2. The coverage delta is provably zero for the properties, and the proof is runnable.** Each
narrowed guard's property is re-established on the moved lines by a committed check, not by
assertion:

- `cli-invocation-guard`'s property (a `pipeline-cli` call resolves the shim by path, never bare) →
  harness check 2: **zero** bare `pipeline-cli` tokens in the executable code of all 22 scripts; all
  reach the shim through `kp_pcli`. This is **stronger** than the lines it replaces: the moved inline
  `PCLI=...` assignment never tested `-x`, whereas `kp_pcli` fail-closes 127 with empty stdout —
  probed live in check 8.
- `leak-guard`'s property (no machine-local path) → harness check 3: **zero** `/Users/<name>` or
  `/home/<name>` paths across all 22 scripts, matching comments included.

**3. Where the narrowing is tracked.** #4486 (cli-invocation-guard, PR #4494 in flight) and #4496
(leak-guard). Both remain open; neither is claimed as fixed here.

## Heading-slicing consumers — checked, none reach these files

The rule is that a block a guard parses out of the markdown cannot move until the guard follows.
Checked both typed consumers that slice constants out of markdown by heading:

- `packages/pipeline-cli/src/tools/checks/step3-contract.ts` — `/^## Step 3 — /m`, and its docblock
  and `shipItText` parameter bind it to **`ship-it/SKILL.md`** only.
- `packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.ts` — `/^### Step 5\.5 — /m`,
  likewise bound to **`ship-it/SKILL.md`** only.

Neither references `plan-epic/SKILL.md` or `review-plan/SKILL.md`. A repo-wide grep for
`plan-epic|review-plan` across `packages/`, `.github/`, `claude-plugins/` and `.claude/workflows/`
turns up **no other typed consumer that regexes either file's text** — every hit is a prose mention,
a label/marker string (`review-plan: PASS`, `status:planned`), or a `.claude/workflows/drive-issue.js`
dispatch that names the *skill*, not a section of it. This is the shape that kept 119 lines of
`ship-it` from moving (#4498 remains open on that); it does not apply here.

`review-plan` is now the intake-desk's gate and its dispatch moved to that seat (#4445) — checked
that too: `crew-fanout-guard` scopes the intake-desk's `review-plan` lane by **agent and skill name**,
never by reading a section of `review-plan/SKILL.md`.

## Cycle-aware wiring — the one thing worth a reviewer's eye

`plan-epic` is one of the four cycle-aware skills the two cycle validators scan, and both are green
over the new surface. The mechanism is worth stating because it is not obvious:

`kp_skill_shell_surfaces` deliberately scopes each skill's scan surface to **its own directory** —
`shared/lib` is excluded so one skill's marker cannot satisfy another's check. Sourcing the shared
probe therefore moves the literal `contents/product-development-cycle.md` out of `plan-epic`'s
surface. `plan-epic/scripts/cycle-doc-probe.sh` names that path in its docblock **for exactly this
reason**, and says so at the site. So the validators scan a real reference to the probe the wrapper
actually delegates to — not a marker planted to satisfy a grep. Disclosed as class 2 below, because
"the citation is a comment" is a fact a reviewer should judge rather than discover.

## Files skipped for overlap

None. Every open PR's file list was read before starting. The only overlap is **PR #4440**, which
touches `review-plan/SKILL.md` — but its change is **prose-only** (two link retargets at the
soft-advisor section, pointing at `../shared/specialist-fan-out.md`) and sits **outside every block
this PR relocates**. Those two lines are untouched here. #4503 (write-code), #4485 (review-design),
#4494/#4383 (cli-invocation-guard), #4389, #4387, #4393, #4379, #4372 touch no file this PR touches.

## Scope: complete

The issue's full 22-block scope landed. There is no named remainder, so nothing else needs filing:
17 `plan-epic` blocks + 5 `review-plan` blocks = 22, all now invocations, verified by harness check 1
over both files.

## Deviations

- **Governing-ADR / contract departure (class 2)** — **Said:** phase 1 moves the shell as-is; and
  `validate-cycle-presence.sh` / `validate-cycle-absence.sh` require each cycle-aware skill's own
  shell surface to cite the canonical probe `contents/product-development-cycle.md`. **Did:**
  `plan-epic/scripts/cycle-doc-probe.sh` sources the one shared implementation instead of carrying
  the probe's five lines, so the canonical path appears in that file as a **docblock citation** rather
  than as executable code. **Why:** copying the probe was the alternative, and a skill-local copy of
  shared shell is the defect PR #4485 paid three FAIL rounds for; `kp_skill_shell_surfaces` excludes
  `shared/lib` by design, so no executable line in `plan-epic/`'s own surface can carry the literal
  once the probe is shared. **Disposition:** for the reviewer to judge. The wrapper states the
  reason at the site. If a reviewer prefers the copy, the fix is four lines — but the underlying gap
  is structural: a skill that *correctly* sources a shared cycle helper can only satisfy these
  validators with a comment. Filed as a follow-up (see the class-3 entry) rather than papered over.
- **Seam-forced exit-code re-expression (class 2, adjacent)** — **Said:** move the glue as-is.
  **Did:** three exit-status changes. (a) Both `epic-lock-acquire.sh` scripts exit **3** on a
  back-off where the fence wrote `exit 0`. (b) `splice-body.sh` exits **1** on every non-success
  terminal path where the fence only printed its verdict. (c) `splice-body.sh` builds the
  `epic-splice` argv as one never-empty `SPLICE_ARGS` array instead of the fence's conditionally-empty
  `PLAN_ARG`. **Why:** (a) the fence's `exit 0` ended the *agent's own* bash block; from a separate
  process an exit 0 reads to the caller as "the lock is ours" — a fail-open, and the exact §ZS class.
  The precedent is in-repo: `triage/scripts/claim-issue.sh` maps the same `continue` seam to exit 3.
  (b) same reason on the other side: a caller reading exit 0 would treat "could not land the
  topology" as "pinned". (c) on bash 3.2 (`GNU bash 3.2.57`) under `set -u`, `"${PLAN_ARG[@]}"` on an
  empty array **aborts the script mid-decision** on the first-time-plan path — the fence had no
  `set -u`, a script must. **Disposition:** no action needed; each is documented in the script's
  exit-code contract and in each SKILL.md's `## The extracted scripts`. These are seam
  re-expressions, not improvements to the glue's logic.
- **Quoting corrected where parameterization required it (class 2, adjacent)** — **Said:** the moved
  lines are byte-identical. **Did:** two `gh api 'repos/$REPO/issues/<EPIC>/sub_issues?…'` calls
  (`plan-epic/SKILL.md` Step 1 and Step 4 on `main`) are double-quoted in `epic-read.sh` /
  `confirm-links.sh`. **Why:** those two were single-quoted, so `$REPO` never expanded — the calls
  addressed a literal `repos/$REPO/...`. Binding the `<EPIC>` metavariable to `"$EPIC"` *requires*
  expansion, so the quote change is part of the mandated metavariable binding, not a drive-by fix;
  the alternative was committing a knowingly-broken line into an executable file. **Disposition:** no
  action needed — stated here so the reviewer sees it in the diff deliberately.
- **Known defect left unfixed (class 3)** — **Said:** nothing; this is an adjacent gap I saw.
  **Did:** did not fix `kp_skill_shell_surfaces`'s per-skill scoping, which makes a comment the only
  way a skill that *correctly* sources a shared cycle helper can satisfy the cycle validators.
  **Why:** it changes a validator's scan-surface contract across four cycle-aware skills — out of
  scope for a mechanical phase-1 move, and exactly the kind of guard change that wants its own
  adversarial review. **Disposition:** follow-up filed — #4505 (filed on this run; it remains open).
- **Scope narrowing (class 1)** — did not fire. The issue's whole 22-block scope landed with no
  remainder; the `Part of` linkage is used only because a control-plane PR does not auto-close its
  issue on merge.
- **Declined guidance (class 4)** — did not fire. No reviewer suggestion, appended AC, or triage
  instruction was declined; this is round 1.
- **Guard or gate bypassed (class 5)** — did not fire. No `--no-verify`, no skipped hook, no
  suppressed lint or type error, no skipped test, no widened allowlist. The push went through
  `pipeline-cli verified-push` (`PUSH-VERDICT: MOVED`).
- **Pre-existing test or fixture changed (class 6)** — did not fire. No test or fixture is touched;
  the diff adds one new harness and changes no existing assertion.
- **Out-of-scope change (class 7)** — did not fire. Every file is under
  `claude-plugins/kampus-pipeline/skills/plan-epic/` or `.../review-plan/`, both named by the issue.
  `verify-extraction.sh` sits under `plan-epic/scripts/` while covering both skills — the issue's AC
  asks for "a reviewer-runnable verification recipe", so it is in scope; its placement in one of the
  two named directories rather than a third is noted so it is not read as scope creep.

## Control plane

`claude-plugins/kampus-pipeline/skills/**` is control-plane in its entirety (#4462), so this **banks
for a human approval**. I have posted no verdict, will not self-approve, and will not merge.
