### PR TITLE
fix(contract-parsers): both heading-sliced parsers follow into scripts/*.sh, and #4448's residue lands (#4498)

### DIFF
--- a/.patterns/skill-derived-guards.md
+++ b/.patterns/skill-derived-guards.md
@@ -25,6 +25,43 @@ source; the guard parses the literal line it depends on and fails when that line
    the parse no longer resolves. That is what proves the binding is load-bearing rather than
    decorative.
 
+## The skill's text is not one file — parse the SURFACE
+
+A skill's shell no longer lives only in its `SKILL.md`: epic #4435 moves fenced blocks into
+`<skill>/scripts/*.sh`, sourced back by a `. "$<SKILL>_SCRIPTS/<name>.sh"` line. A parser handed
+`readFileSync(SKILL.md)` therefore stops reaching the shell it parses **on a pure relocation** — and
+the two ways that goes wrong are not equally visible:
+
+- it **reds** on a change that altered no behaviour (the noisy case), or
+- it **quietly stops asserting** — the parse resolves an empty population and every `notInclude` /
+  "these two differ" row over it passes vacuously. `adoption-lint`'s ordering pin scoped itself to
+  writers whose *text* contained a layer-one write, so when that write moved into a script the whole
+  skill dropped out of a pin about its own claim ordering, with the suite still green
+  ([#4509](https://github.com/kamp-us/phoenix/issues/4509)).
+
+**So a section's surface is its heading slice plus the content of every `scripts/*.sh` the slice
+sources.** `packages/pipeline-cli/src/skill-shell-surface.ts` owns that resolution once
+(`resolveSection`), and the rules it fixes are worth stating because each was a real trap:
+
+- **Slice on the pristine markdown, then append** the followed scripts. Inlining *before* the slice
+  lets a script that emits markdown from a heredoc carry a `## ` line that truncates the section.
+- **Sibling-scoped**, never the whole plugin tree: `shared/lib/*.sh` is a library many skills call,
+  so folding it into every caller's surface lets one shared half-procedure satisfy every skill's own
+  rule (the same scoping `kp_skill_shell_surfaces` chose, #4470).
+- **A sourced script that will not read back is UNRESOLVED, not absent** — the caller resolves its
+  fail-closed constant, even if the constant it wanted is sitting inline right beside the source
+  line. A partial read is not a read.
+- **Emit the scanned scope** (`scanned`), and have the consumer *assert* it — a zero-length scope is
+  what a renamed heading looks like, and it must red rather than resolve
+  ([ADR 0092](../.decisions/0092-gates-fail-closed-on-zero-scope.md)).
+- **Pin any population the parse derives from text.** If the parser discovers its own subject set
+  (the outcome words of a `case`, the members of a list), assert its expected *membership* against
+  an independent source — the classifier's own union, not the text — or a dropout is invisible.
+
+Non-vacuity is worth one extra assertion: pin that the markdown slice *alone* no longer carries the
+literal, so the positive match can only have come through the follow path. Counting scanned files
+does not prove it — a section that sources three scripts is satisfied by an unrelated sibling.
+
 ## Where it is used
 
 - `class-probe.ts` — `parseClassProbes` / `parseUiProbe` read the canonical `HAS_*_RE=` and `UI_RE=`
@@ -32,7 +69,10 @@ source; the guard parses the literal line it depends on and fails when that line
   over-dispatching gates on an unreadable source.
 - `step3-contract.ts` — `parseStep3EntryTest` reads ship-it Step 3's branch-2 entry condition and
   resolves the rollup fields it tests, so `checks.unit.test.ts`'s branch mirror derives its pending
-  predicate from the skill instead of copying it.
+  predicate from the skill instead of copying it. Heading-sliced, so it resolves its surface through
+  `resolveStep3Section` and reads the bindings out of the script Step 3 sources.
+- `step55-contract.ts` — `parseReconcileBudget` / `parseMergeDispositions` read ship-it Step 5.5's
+  poll budget and its three disposition renderings the same way, through `resolveStep55Section`.
 
 ## The failure it prevents
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -986,36 +986,18 @@ verb also owns the running/wedged split and the latest-per-context reduction —
 re-derive the query (#3762).
 
 ```bash
-CHECKS="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli checks"
-
-# Echo the rollup JSON; return 0 readable · 2 UNKNOWN (refuse — never a colour, never green).
-read_head_ci() {
-  local out rc conclusion
-  out="$($CHECKS read --pr "$PR" --expect green 2>/dev/null)"; rc=$?
-  # SHAPE-CHECK BEFORE INTERPRETING: an error body / truncated capture is not data. Exit 2 is the
-  # verb's own typed unknown; a body with no readable `conclusion` is treated identically.
-  conclusion="$(printf '%s' "$out" | jq -r '.conclusion? // empty' 2>/dev/null)"
-  case "$rc:$conclusion" in
-    0:green|1:red|1:pending) printf '%s' "$out"; return 0 ;;
-    *) return 2 ;;
-  esac
-}
-
-CI_JSON="$(read_head_ci)" || {
-  disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: this stop does not enqueue — park nothing
-  gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — head CI **unreadable** (the check-runs read returned no interpretable state) — **not enqueued**. An unreadable head is not a green head; re-dispatch ship-it once the API is answering — idempotent (#3999)." >/dev/null
-  echo "refused — head CI unreadable (typed unknown) — not enqueued"; exit 0
-}
-
-# The aggregate `.conclusion` is deliberately NOT bound here: it is a colour in which red wins over
-# pending, so classifying off it lets an informational red mask an unfinished check (see below).
-CONTEXTS=$(jq -r '.contexts'    <<<"$CI_JSON")   # how many contexts the rollup covered
-RUNNING=$(jq -r  '.running | join(", ")' <<<"$CI_JSON")   # genuinely in flight — these settle
-WEDGED=$(jq -r   '.wedged  | join(", ")' <<<"$CI_JSON")   # queued, never started — these do NOT
-# The known-informational carve-out, applied to the failing set (names below).
-GATING_RED=$(jq -r '[.failing[]
-  | select(. != "deploy (web)" and (startswith("cleanup (web,") | not))] | join(", ")' <<<"$CI_JSON")
+. "$SHIPIT_SCRIPTS/step3-rollup-bindings.sh"
 ```
+
+**Parser-held — keep that source line inside this section.** The script's `jq` rollup bindings
+(`RUNNING`, `WEDGED`, `GATING_RED`, `CONTEXTS`) are a contract with
+`packages/pipeline-cli/src/tools/checks/step3-contract.ts`: it
+slices this `## Step 3 — ` section, **follows the source line above into the script**, and derives
+branch 2's pending predicate from the bindings it finds there — which is what stops
+`checks.unit.test.ts`'s executable branch mirror from hand-copying them (#4054). Rename a binding,
+point it at a different rollup field, or move the block to a script this section does not source, and
+the parse resolves **no** fields and the mirror reds. Unlike `UI_RE`/`UI_EXCLUDE_RE` above, nothing
+here has to stay in the markdown — only its **reachability from this heading** is fixed (#4498).
 
 Not every red check blocks a merge, and **this classification is ship-it's own** — it is
 deliberately *not* the base branch's required-context set, and must never be derived from it.
@@ -1642,87 +1624,19 @@ yet), which is **never** an ejection. The classification is a **pure, unit-teste
 reconcile shells out to it per poll and branches on the printed outcome word:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# …and prove it resolved before polling. An unresolved CLI prints nothing, so every poll would
-# read as neither `merged` nor `ejected`, the budget would exhaust, and the run would report a
-# well-formed `pending` for a classifier that never ran — a could-not-run posing as an answer
-# (§CLI / §WL; #3314). UNKNOWN is the only honest outcome here.
-[ -x "$PCLI" ] || {
-  echo "ship-it: merge-queue-classify is UNRESOLVED at '$PCLI' — the reconcile outcome is UNKNOWN, NOT pending. Re-resolve the CLI and re-poll; do not report a merge outcome." >&2
-  exit 1
-}
-# Bounded reconcile: poll the authoritative merge-queue state within a batch window, then classify.
-# BOUNDED, not synchronous-to-merge (ADR 0132): a fixed budget of polls, then STOP and report —
-# a PR still QUEUED at the budget's end is a well-formed pending, not a failure.
-# The classifier reads PR state (gh pr view — the sanctioned PR-state read ship-it Step 2 uses,
-# NOT a GraphQL intake query the org's Projects-classic integration breaks) + the last merge-queue
-# timeline event AND whether a `merged` event is present (gh api …/timeline, REST — the pairing
-# that tells a consumed queue entry from an ejection, #4155), cross-checks a non-merged read against the base branch
-# (gh api …/commits?sha=<base>, the read that stayed fresh while the other two lagged — #4057), and
-# prints merged/ejected/queued/pending. It is fail-closed away from a false ship: any unreadable
-# signal ⇒ pending (keep polling), never a false merged/ejected.
-# The budget, and the ONE number the stand-down must report: the OBSERVATION HORIZON. Poll k fires
-# at (k-1)*SLEEP, so what the run actually watched is (TRIES-1)*SLEEP — not TRIES*SLEEP. The old
-# 10x30s pair observed to 4m30s while every sampled merge-queue dwell on this repo ran 5m17s–9m25s
-# (n=10, median 6m27s, mean 6m37s — #4403), so the budget expired mid-dwell on 10 of 10 merges, and
-# the trailing sleep after the last poll burned 30s observing nothing. 16x30s puts the horizon at
-# 7m30s, past both the median and the mean; it is NOT set past the 9m25s max because one shipper
-# invocation has a ~10-minute wall-clock ceiling and the 16 polls' own `gh` latency eats into it.
-# That ceiling is what makes over-widening WORSE than standing down: a run killed against it
-# mid-loop never reaches the ledger at all, so it emits no `merge:` line — silence, where a
-# stand-down would at least have stated the bound of what it watched.
-# So even the widened horizon can expire mid-dwell — which is exactly why the widening is the
-# secondary fix and the honest stand-down wording below is the primary one.
-RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-16}
-RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}
-RECONCILE_HORIZON=$(( (RECONCILE_TRIES - 1) * RECONCILE_SLEEP ))   # seconds ACTUALLY observed
-MERGE_OUTCOME=pending
-for i in $(seq 1 "$RECONCILE_TRIES"); do
-  MERGE_OUTCOME=$("$PCLI" merge-queue-classify classify --pr "$PR" --repo "$REPO")
-  [ "$MERGE_OUTCOME" = merged ] && break   # terminal success
-  [ "$MERGE_OUTCOME" = ejected ] && break  # a genuine dequeue (removed_from_merge_queue) — act below
-  # queued (still in the queue) or pending (enqueue-settle window) ⇒ keep polling within the budget.
-  # Sleep only BETWEEN polls: a trailing sleep after the last poll observes nothing, and only makes
-  # the reported horizon overstate the reach of the observation.
-  if [ "$i" -lt "$RECONCILE_TRIES" ]; then sleep "$RECONCILE_SLEEP"; fi
-done
-# At the budget's end a still-`pending` PR (never a merge-queue event) is reported as a well-formed
-# pending, NOT ejected — the settle window is not an ejection (#1921).
-
-# The run's merge disposition, single-sourced HERE and emitted verbatim as the ledger's `merge:`
-# line. Budget exhaustion while the PR is still in the queue is UNRESOLVED — genuinely unknown, and
-# neither a landing nor a failure — so it is worded as the bounded observation it is, carrying the
-# horizon it watched. The three renderings stay textually distinct (#4403).
-case "$MERGE_OUTCOME" in
-  merged)
-    MERGE_DISPOSITION="landed (queue merged the batch)" ;;
-  queued|pending)
-    MERGE_DISPOSITION="UNRESOLVED — still queued at my last read, ~${RECONCILE_HORIZON}s after enqueue; the merge may still land. Bounded observation, not a failure and not a landing — an independent later read closes the lane." ;;
-  ejected)
-    MERGE_DISPOSITION="EJECTED (routed to repair/re-queue)" ;;
-  *)
-    # Unreachable while the classifier prints one of its four words — which is exactly why it is
-    # here: without it an unrecognized $MERGE_OUTCOME leaves MERGE_DISPOSITION unset and the
-    # ledger's `merge:` line renders BLANK — a could-not-determine posing as nothing at all.
-    MERGE_DISPOSITION="UNKNOWN — the reconcile produced no recognized outcome word; the merge state was never determined. Not a landing, not a failure, not an ejection — re-read the PR before acting on it." ;;
-esac
-
-# Guard 6 (ADR 0198) — the reconcile's terminal read is the LAST place this run can leave an arm
-# behind, so it is also sites 3 and 4. `merged` and `queued` keep the intent (a live queue entry is
-# never disturbed); an `ejected` PR is cleared so a re-approval after its rebase cannot re-enqueue
-# it ahead of a fresh gate pass; and an arm that never became a queue entry on a QUEUE-GOVERNED
-# base branch is a PARKED intent — `merge-intent` reads the base branch's ruleset to tell the two
-# regimes apart, so a repo whose base branch has no merge queue keeps its legitimate armed
-# auto-merge while this repo's every unqueued arm is cleared.
-if [ "$MERGE_OUTCOME" = ejected ]; then
-  disarm_intent ejected || INTENT_UNCLEARED=1
-else
-  INTENT_ACTION=$("$PCLI" merge-intent disarm --pr "$PR" --repo "$REPO" --site post-enqueue) || INTENT_UNCLEARED=1
-  [ "$INTENT_ACTION" = disarmed ] && \
-    echo "refused — the enqueue did not take effect at this head; the parked intent was cleared. Re-dispatch ship-it to re-assert the gates and enqueue (idempotent)."
-fi
+. "$SHIPIT_SCRIPTS/step5_5-reconcile.sh"
 ```
+
+**Parser-held — keep that source line inside this section.** The script's `RECONCILE_TRIES` /
+`RECONCILE_SLEEP` defaults, its between-polls `sleep` guard, and its `MERGE_DISPOSITION` case arms
+are a contract with `packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.ts`: it
+slices this `### Step 5.5 — ` section, **follows the source line above into the script**, and derives
+the observation horizon and the three disposition renderings from what it finds there — which is what
+stops `step55-contract.unit.test.ts`'s executable reconcile mirror from hand-copying the budget
+(#4403). Widen the budget, drop the between-polls sleep guard, or move the block to a script this
+section does not source, and the parse resolves a **zero** horizon and the mirror reds.
+Nothing here has to stay in the markdown — only its **reachability from this heading** is fixed
+(#4498).
 
 #### The loop is not the evidence — and a bare removal event is not an ejection (#4155)
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2034,SC2086
+# Read the head's check state ONCE and bind the rollup's pending/failing sets — Step 3's classifier
+# input. `read_head_ci` is left defined for the settle poll, which re-reads the head through it.
+#
+# Extracted VERBATIM from ship-it/SKILL.md's Step 3 fenced block (epic #4435 phase 1, #4448/#4498).
+# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
+# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
+# and leaves its variables and functions in the sourcing shell, which is how the step's later
+# blocks still see them. The bare `exit 0` on an unreadable head is therefore the SHIPPER's exit,
+# which is the intended disposition: an unreadable head is never enqueued.
+#
+# PARSER-HELD (#4498): `checks/step3-contract.ts` reads the `VAR=$(jq -r '.field …)` bindings below
+# out of Step 3's surface to derive the branch-2 pending predicate. It reaches them by following
+# SKILL.md's source line into this file, so keep the bindings at column 0 and keep that source line
+# inside the `## Step 3 — ` section.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+CHECKS="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli checks"
+
+# Echo the rollup JSON; return 0 readable · 2 UNKNOWN (refuse — never a colour, never green).
+read_head_ci() {
+  local out rc conclusion
+  out="$($CHECKS read --pr "$PR" --expect green 2>/dev/null)"; rc=$?
+  # SHAPE-CHECK BEFORE INTERPRETING: an error body / truncated capture is not data. Exit 2 is the
+  # verb's own typed unknown; a body with no readable `conclusion` is treated identically.
+  conclusion="$(printf '%s' "$out" | jq -r '.conclusion? // empty' 2>/dev/null)"
+  case "$rc:$conclusion" in
+    0:green|1:red|1:pending) printf '%s' "$out"; return 0 ;;
+    *) return 2 ;;
+  esac
+}
+
+CI_JSON="$(read_head_ci)" || {
+  disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: this stop does not enqueue — park nothing
+  gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — head CI **unreadable** (the check-runs read returned no interpretable state) — **not enqueued**. An unreadable head is not a green head; re-dispatch ship-it once the API is answering — idempotent (#3999)." >/dev/null
+  echo "refused — head CI unreadable (typed unknown) — not enqueued"; exit 0
+}
+
+# The aggregate `.conclusion` is deliberately NOT bound here: it is a colour in which red wins over
+# pending, so classifying off it lets an informational red mask an unfinished check (see below).
+CONTEXTS=$(jq -r '.contexts'    <<<"$CI_JSON")   # how many contexts the rollup covered
+RUNNING=$(jq -r  '.running | join(", ")' <<<"$CI_JSON")   # genuinely in flight — these settle
+WEDGED=$(jq -r   '.wedged  | join(", ")' <<<"$CI_JSON")   # queued, never started — these do NOT
+# The known-informational carve-out, applied to the failing set (names below).
+GATING_RED=$(jq -r '[.failing[]
+  | select(. != "deploy (web)" and (startswith("cleanup (web,") | not))] | join(", ")' <<<"$CI_JSON")

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2034,SC2086
+# The bounded post-enqueue reconcile — QUEUED is not terminal success (#1906/#1921/#4403).
+#
+# Extracted VERBATIM from ship-it/SKILL.md's Step 5.5 fenced block (epic #4435 phase 1,
+# #4448/#4498). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is
+# phase 2 (#1929).
+#
+# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
+# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
+# and leaves its variables and functions in the sourcing shell, which is how the ledger still sees
+# $MERGE_OUTCOME / $MERGE_DISPOSITION / $RECONCILE_HORIZON / $INTENT_UNCLEARED.
+#
+# PARSER-HELD (#4498): `merge-queue-classify/step55-contract.ts` reads the RECONCILE_TRIES /
+# RECONCILE_SLEEP defaults, the between-polls sleep guard, and the MERGE_DISPOSITION case arms out
+# of Step 5.5's surface. It reaches them by following SKILL.md's source line into this file, so keep
+# those bindings at column 0 and keep that source line inside the `### Step 5.5 — ` section.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# …and prove it resolved before polling. An unresolved CLI prints nothing, so every poll would
+# read as neither `merged` nor `ejected`, the budget would exhaust, and the run would report a
+# well-formed `pending` for a classifier that never ran — a could-not-run posing as an answer
+# (§CLI / §WL; #3314). UNKNOWN is the only honest outcome here.
+[ -x "$PCLI" ] || {
+  echo "ship-it: merge-queue-classify is UNRESOLVED at '$PCLI' — the reconcile outcome is UNKNOWN, NOT pending. Re-resolve the CLI and re-poll; do not report a merge outcome." >&2
+  exit 1
+}
+# Bounded reconcile: poll the authoritative merge-queue state within a batch window, then classify.
+# BOUNDED, not synchronous-to-merge (ADR 0132): a fixed budget of polls, then STOP and report —
+# a PR still QUEUED at the budget's end is a well-formed pending, not a failure.
+# The classifier reads PR state (gh pr view — the sanctioned PR-state read ship-it Step 2 uses,
+# NOT a GraphQL intake query the org's Projects-classic integration breaks) + the last merge-queue
+# timeline event AND whether a `merged` event is present (gh api …/timeline, REST — the pairing
+# that tells a consumed queue entry from an ejection, #4155), cross-checks a non-merged read against the base branch
+# (gh api …/commits?sha=<base>, the read that stayed fresh while the other two lagged — #4057), and
+# prints merged/ejected/queued/pending. It is fail-closed away from a false ship: any unreadable
+# signal ⇒ pending (keep polling), never a false merged/ejected.
+# The budget, and the ONE number the stand-down must report: the OBSERVATION HORIZON. Poll k fires
+# at (k-1)*SLEEP, so what the run actually watched is (TRIES-1)*SLEEP — not TRIES*SLEEP. The old
+# 10x30s pair observed to 4m30s while every sampled merge-queue dwell on this repo ran 5m17s–9m25s
+# (n=10, median 6m27s, mean 6m37s — #4403), so the budget expired mid-dwell on 10 of 10 merges, and
+# the trailing sleep after the last poll burned 30s observing nothing. 16x30s puts the horizon at
+# 7m30s, past both the median and the mean; it is NOT set past the 9m25s max because one shipper
+# invocation has a ~10-minute wall-clock ceiling and the 16 polls' own `gh` latency eats into it.
+# That ceiling is what makes over-widening WORSE than standing down: a run killed against it
+# mid-loop never reaches the ledger at all, so it emits no `merge:` line — silence, where a
+# stand-down would at least have stated the bound of what it watched.
+# So even the widened horizon can expire mid-dwell — which is exactly why the widening is the
+# secondary fix and the honest stand-down wording below is the primary one.
+RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-16}
+RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}
+RECONCILE_HORIZON=$(( (RECONCILE_TRIES - 1) * RECONCILE_SLEEP ))   # seconds ACTUALLY observed
+MERGE_OUTCOME=pending
+for i in $(seq 1 "$RECONCILE_TRIES"); do
+  MERGE_OUTCOME=$("$PCLI" merge-queue-classify classify --pr "$PR" --repo "$REPO")
+  [ "$MERGE_OUTCOME" = merged ] && break   # terminal success
+  [ "$MERGE_OUTCOME" = ejected ] && break  # a genuine dequeue (removed_from_merge_queue) — act below
+  # queued (still in the queue) or pending (enqueue-settle window) ⇒ keep polling within the budget.
+  # Sleep only BETWEEN polls: a trailing sleep after the last poll observes nothing, and only makes
+  # the reported horizon overstate the reach of the observation.
+  if [ "$i" -lt "$RECONCILE_TRIES" ]; then sleep "$RECONCILE_SLEEP"; fi
+done
+# At the budget's end a still-`pending` PR (never a merge-queue event) is reported as a well-formed
+# pending, NOT ejected — the settle window is not an ejection (#1921).
+
+# The run's merge disposition, single-sourced HERE and emitted verbatim as the ledger's `merge:`
+# line. Budget exhaustion while the PR is still in the queue is UNRESOLVED — genuinely unknown, and
+# neither a landing nor a failure — so it is worded as the bounded observation it is, carrying the
+# horizon it watched. The three renderings stay textually distinct (#4403).
+case "$MERGE_OUTCOME" in
+  merged)
+    MERGE_DISPOSITION="landed (queue merged the batch)" ;;
+  queued|pending)
+    MERGE_DISPOSITION="UNRESOLVED — still queued at my last read, ~${RECONCILE_HORIZON}s after enqueue; the merge may still land. Bounded observation, not a failure and not a landing — an independent later read closes the lane." ;;
+  ejected)
+    MERGE_DISPOSITION="EJECTED (routed to repair/re-queue)" ;;
+  *)
+    # Unreachable while the classifier prints one of its four words — which is exactly why it is
+    # here: without it an unrecognized $MERGE_OUTCOME leaves MERGE_DISPOSITION unset and the
+    # ledger's `merge:` line renders BLANK — a could-not-determine posing as nothing at all.
+    MERGE_DISPOSITION="UNKNOWN — the reconcile produced no recognized outcome word; the merge state was never determined. Not a landing, not a failure, not an ejection — re-read the PR before acting on it." ;;
+esac
+
+# Guard 6 (ADR 0198) — the reconcile's terminal read is the LAST place this run can leave an arm
+# behind, so it is also sites 3 and 4. `merged` and `queued` keep the intent (a live queue entry is
+# never disturbed); an `ejected` PR is cleared so a re-approval after its rebase cannot re-enqueue
+# it ahead of a fresh gate pass; and an arm that never became a queue entry on a QUEUE-GOVERNED
+# base branch is a PARKED intent — `merge-intent` reads the base branch's ruleset to tell the two
+# regimes apart, so a repo whose base branch has no merge queue keeps its legitimate armed
+# auto-merge while this repo's every unqueued arm is cleared.
+if [ "$MERGE_OUTCOME" = ejected ]; then
+  disarm_intent ejected || INTENT_UNCLEARED=1
+else
+  INTENT_ACTION=$("$PCLI" merge-intent disarm --pr "$PR" --repo "$REPO" --site post-enqueue) || INTENT_UNCLEARED=1
+  [ "$INTENT_ACTION" = disarmed ] && \
+    echo "refused — the enqueue did not take effect at this head; the parked intent was cleared. Re-dispatch ship-it to re-assert the gates and enqueue (idempotent)."
+fi

--- a/packages/pipeline-cli/src/skill-shell-surface.ts
+++ b/packages/pipeline-cli/src/skill-shell-surface.ts
@@ -1,0 +1,100 @@
+/**
+ * A skill's shell surface, for the parsers that slice a step's constants out of `SKILL.md` **by
+ * markdown heading**. Epic #4435 phase 1 moves fenced shell into `<skill>/scripts/*.sh`, so a
+ * heading slice of the markdown alone stops reaching the shell it parses — the parse resolves
+ * nothing on a *pure relocation* (#4498).
+ *
+ * A section's surface is therefore its heading slice **plus the content of every `scripts/*.sh` the
+ * slice sources**. Two deliberate choices:
+ *
+ * - **Slice first, then follow.** The section boundary is computed on the pristine markdown, so a
+ *   script that emits markdown from a heredoc cannot truncate the section by carrying a `## ` line.
+ *   Followed content is appended, which also keeps the prose-position parses (a numbered item and
+ *   its continuation lines) byte-identical to the un-extracted corpus.
+ * - **Sibling-scoped, not the whole plugin tree** — the same scoping `kp_skill_shell_surfaces`
+ *   (`shared/lib/common.sh`, #4470) and `adoption-lint`'s claim pins (#4449) chose: `shared/` is a
+ *   library many skills call, so folding it into every caller's surface would let one shared
+ *   half-procedure satisfy every skill's own rule.
+ *
+ * Fail-closed direction, unchanged from the parsers that consume this (ADR 0092 / §ZS): a heading
+ * that matches nothing resolves to ZERO scanned files, and a sourced script that cannot be read is
+ * reported `unresolved` rather than skipped. Both are UNKNOWN, never "the constant is absent" — the
+ * caller turns either into its own fail-closed constant, and `scanned` is returned so a consumer can
+ * assert what was actually read instead of trusting a green.
+ */
+
+import {existsSync, readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+
+/** Reads a `scripts/<name>.sh` beside the skill. `undefined` = UNRESOLVED, never "empty". */
+export type ScriptReader = (scriptName: string) => string | undefined;
+
+export interface SkillSurface {
+	/** A repo-relative label for the markdown file, used in the emitted scanned scope. */
+	readonly label: string;
+	readonly text: string;
+	readonly readScript: ScriptReader;
+}
+
+export interface ResolvedSection {
+	/** The heading slice with every resolvable sourced script appended. `""` = heading unmatched. */
+	readonly section: string;
+	/** What was actually read: the markdown label, then each followed script. Empty = ZERO SCOPE. */
+	readonly scanned: ReadonlyArray<string>;
+	/** Scripts the section sources that did not read back — UNKNOWN, never absent. */
+	readonly unresolved: ReadonlyArray<string>;
+}
+
+export const ZERO_SCOPE: ResolvedSection = {section: "", scanned: [], unresolved: []};
+
+/**
+ * The `scripts/*.sh` a stretch of skill text sources (`. "$<SKILL>_SCRIPTS/<name>.sh"`), in first
+ * appearance order, deduplicated. Deliberately the SAME matcher `adoption-lint`'s claim pins use
+ * (#4449) — three consumers answering "which script does this text source?" three ways would be its
+ * own defect.
+ */
+export const sourcedScriptNames = (text: string): ReadonlyArray<string> => [
+	...new Set([...text.matchAll(/_SCRIPTS\}?\/([\w.-]+\.sh)/g)].flatMap((m) => m[1] ?? [])),
+];
+
+/** Resolve one heading-sliced section into its full shell surface. */
+export const resolveSection = (
+	surface: SkillSurface,
+	slice: (text: string) => string,
+): ResolvedSection => {
+	const sliced = slice(surface.text);
+	if (sliced === "") return ZERO_SCOPE;
+	const scanned = [surface.label];
+	const unresolved: string[] = [];
+	const parts = [sliced];
+	for (const name of sourcedScriptNames(sliced)) {
+		const content = surface.readScript(name);
+		if (content === undefined || content === "") {
+			unresolved.push(name);
+			continue;
+		}
+		scanned.push(join("scripts", name));
+		parts.push(content);
+	}
+	return {section: parts.join("\n"), scanned, unresolved};
+};
+
+/** A surface whose scripts come from disk, sibling-scoped to the skill's own `scripts/` dir. */
+export const skillSurfaceFromDisk = (skillMdPath: string, label: string): SkillSurface => {
+	const scriptsDir = join(dirname(skillMdPath), "scripts");
+	return {
+		label,
+		text: readFileSync(skillMdPath, "utf8"),
+		readScript: (name) => {
+			const path = join(scriptsDir, name);
+			return existsSync(path) ? readFileSync(path, "utf8") : undefined;
+		},
+	};
+};
+
+/** A surface built from strings — for fixtures, and for re-parsing a mutated corpus. */
+export const skillSurfaceFromText = (
+	text: string,
+	scripts: Readonly<Record<string, string>> = {},
+	label = "SKILL.md",
+): SkillSurface => ({label, text, readScript: (name) => scripts[name]});

--- a/packages/pipeline-cli/src/skill-shell-surface.unit.test.ts
+++ b/packages/pipeline-cli/src/skill-shell-surface.unit.test.ts
@@ -1,0 +1,101 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	resolveSection,
+	skillSurfaceFromText,
+	sourcedScriptNames,
+	ZERO_SCOPE,
+} from "./skill-shell-surface.ts";
+
+// Build a literal `${…}` shell expansion without writing it as a plain-string placeholder, so
+// biome's noTemplateCurlyInString stays quiet — every fixture here IS shell (the `settings-env-guard`
+// idiom, #2495).
+const brace = (inner: string): string => `$\{${inner}}`;
+
+const sliceStep = (text: string): string => {
+	const start = text.search(/^## Step X — /m);
+	if (start < 0) return "";
+	const rest = text.slice(start);
+	const end = rest.slice(1).search(/^## /m);
+	return end < 0 ? rest : rest.slice(0, end + 1);
+};
+
+describe("sourcedScriptNames", () => {
+	it("names every `$<SKILL>_SCRIPTS/<file>.sh` a stretch of text sources, deduplicated in order", () => {
+		const text = [
+			'. "$SHIPIT_SCRIPTS/step3-rollup-bindings.sh"',
+			`. "${brace("WRITE_CODE_SCRIPTS")}/step5_5-reconcile.sh"`,
+			'. "$SHIPIT_SCRIPTS/step3-rollup-bindings.sh"',
+		].join("\n");
+		assert.deepStrictEqual(sourcedScriptNames(text), [
+			"step3-rollup-bindings.sh",
+			"step5_5-reconcile.sh",
+		]);
+	});
+
+	it("names nothing for text that sources nothing — the un-extracted corpus", () => {
+		assert.deepStrictEqual(sourcedScriptNames(`RECONCILE_TRIES=${brace("X:-16")}\n`), []);
+	});
+});
+
+describe("resolveSection — a section's surface is its slice plus the scripts it sources", () => {
+	it("appends each resolvable script and emits both files as the scanned scope", () => {
+		const surface = skillSurfaceFromText(
+			["## Step X — do it", '. "$SHIPIT_SCRIPTS/a.sh"', "## Step Y — next"].join("\n"),
+			{"a.sh": "BUDGET=7"},
+			"ship-it/SKILL.md",
+		);
+		const resolved = resolveSection(surface, sliceStep);
+		assert.include(resolved.section, "BUDGET=7");
+		assert.deepStrictEqual(resolved.scanned, ["ship-it/SKILL.md", "scripts/a.sh"]);
+		assert.deepStrictEqual(resolved.unresolved, []);
+	});
+
+	it("computes the boundary on the PRISTINE markdown, so a script's `## ` line cannot truncate it", () => {
+		// The extracted gate scripts emit markdown from heredocs. Inlining before the slice would let
+		// such a line end the section and blind the rest of it.
+		const surface = skillSurfaceFromText(
+			[
+				"## Step X — do it",
+				'. "$SHIPIT_SCRIPTS/emits-markdown.sh"',
+				"TAIL_OF_SECTION=1",
+				"## Step Y — next",
+				"NOT_IN_SECTION=1",
+			].join("\n"),
+			{"emits-markdown.sh": "cat <<EOF\n## Step Y — a heading in a heredoc\nEOF\nBUDGET=7"},
+		);
+		const resolved = resolveSection(surface, sliceStep);
+		assert.include(resolved.section, "TAIL_OF_SECTION=1");
+		assert.include(resolved.section, "BUDGET=7");
+		assert.notInclude(resolved.section, "NOT_IN_SECTION=1");
+	});
+
+	it("reports an unreadable sourced script as UNRESOLVED — it never silently drops it", () => {
+		const surface = skillSurfaceFromText(
+			["## Step X — do it", '. "$SHIPIT_SCRIPTS/gone.sh"', "## Step Y — next"].join("\n"),
+		);
+		const resolved = resolveSection(surface, sliceStep);
+		assert.deepStrictEqual(resolved.unresolved, ["gone.sh"]);
+		assert.deepStrictEqual(resolved.scanned, ["SKILL.md"]);
+	});
+
+	it("treats an EMPTY script as unresolved, not as a script that legitimately says nothing", () => {
+		const surface = skillSurfaceFromText(
+			["## Step X — do it", '. "$SHIPIT_SCRIPTS/empty.sh"'].join("\n"),
+			{"empty.sh": ""},
+		);
+		assert.deepStrictEqual(resolveSection(surface, sliceStep).unresolved, ["empty.sh"]);
+	});
+
+	it("an unmatched heading is ZERO SCOPE — scanned is empty, which a caller must fail closed on", () => {
+		const surface = skillSurfaceFromText("## Step Z — a different step\nBUDGET=7");
+		assert.deepStrictEqual(resolveSection(surface, sliceStep), ZERO_SCOPE);
+		assert.deepStrictEqual(ZERO_SCOPE.scanned, []);
+	});
+
+	it("is a no-op on a section that sources nothing, so the un-extracted corpus still parses", () => {
+		const surface = skillSurfaceFromText("## Step X — do it\nBUDGET=7\n## Step Y — next");
+		const resolved = resolveSection(surface, sliceStep);
+		assert.include(resolved.section, "BUDGET=7");
+		assert.deepStrictEqual(resolved.scanned, ["SKILL.md"]);
+	});
+});

--- a/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
@@ -1,7 +1,7 @@
-import {readFileSync} from "node:fs";
 import {dirname, join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
+import {skillSurfaceFromDisk, skillSurfaceFromText} from "../../skill-shell-surface.ts";
 import {
 	type CheckRun,
 	type CheckSuite,
@@ -10,7 +10,12 @@ import {
 	latestPerContext,
 	rollupChecks,
 } from "./checks.ts";
-import {FAILCLOSED_STEP3_ENTRY_TEST, parseStep3EntryTest} from "./step3-contract.ts";
+import {
+	extractStep3Section,
+	FAILCLOSED_STEP3_ENTRY_TEST,
+	parseStep3EntryTest,
+	resolveStep3Section,
+} from "./step3-contract.ts";
 
 let nextId = 1;
 const run = (over: Partial<CheckRun> & {readonly name: string}): CheckRun => ({
@@ -331,14 +336,14 @@ describe("rollupChecks — a check suite with zero attached runs is not pending"
 });
 
 // The live skill — the single source for Step 3's branch order. Read repo-relative off this
-// file's own location so it resolves identically in CI and in a worktree.
-const SHIP_IT_PATH = join(
-	dirname(fileURLToPath(import.meta.url)),
-	"../../../../..",
-	"claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md",
-);
-const SHIP_IT_TEXT = readFileSync(SHIP_IT_PATH, "utf8");
-const LIVE_STEP3_ENTRY = parseStep3EntryTest(SHIP_IT_TEXT);
+// file's own location so it resolves identically in CI and in a worktree. The SURFACE, not the file:
+// the step's shell lives in the `scripts/*.sh` the section sources, and the parse follows into it
+// (#4498), so this reaches the bindings whether they were extracted or not.
+const SHIP_IT_REL = "claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md";
+const SHIP_IT_PATH = join(dirname(fileURLToPath(import.meta.url)), "../../../../..", SHIP_IT_REL);
+const SHIP_IT = skillSurfaceFromDisk(SHIP_IT_PATH, SHIP_IT_REL);
+const SHIP_IT_TEXT = SHIP_IT.text;
+const LIVE_STEP3_ENTRY = parseStep3EntryTest(SHIP_IT);
 
 /**
  * A test-local mirror of ship-it Step 3's classification order, so the branch the shipper takes on
@@ -389,12 +394,107 @@ describe("ship-it Step 3's branch-2 entry test, read off the live SKILL.md", () 
 	it("the #3999 drift is caught: an entry test rewritten to the colour resolves no pending set", () => {
 		const drifted = SHIP_IT_TEXT.replace(LIVE_STEP3_ENTRY.condition, '[ "$CI_STATE" = pending ]');
 		assert.notStrictEqual(drifted, SHIP_IT_TEXT);
-		assert.deepStrictEqual(parseStep3EntryTest(drifted).fields, []);
+		assert.deepStrictEqual(parseStep3EntryTest({...SHIP_IT, text: drifted}).fields, []);
 	});
 
 	it("fails closed on a Step 3 it cannot read, rather than resolving a green-looking empty", () => {
-		assert.deepStrictEqual(parseStep3EntryTest(""), FAILCLOSED_STEP3_ENTRY_TEST);
+		assert.deepStrictEqual(
+			parseStep3EntryTest(skillSurfaceFromText("")),
+			FAILCLOSED_STEP3_ENTRY_TEST,
+		);
 		assert.deepStrictEqual(FAILCLOSED_STEP3_ENTRY_TEST.fields, []);
+	});
+});
+
+// #4498. Before this, the parse read SKILL.md alone, so moving the bindings into a sourced script —
+// a pure relocation that changes no behaviour — resolved NO fields and reddened the mirror. Worse
+// than red is quiet: the drift pin above and the two branch-2 cases below would keep passing while
+// covering nothing, which is the #4509 silent-dropout shape. Both directions are pinned here.
+describe("Step 3's parse follows the section's sourced scripts (extraction-invariant, #4498)", () => {
+	// The one binding site, wherever it lives: exactly one of the two surfaces carries it.
+	const bindingLine = /^RUNNING=\$\(jq/m;
+
+	it("emits its scanned scope, and that scope is never empty on a resolvable section", () => {
+		const {scanned, unresolved} = resolveStep3Section(SHIP_IT);
+		assert.isAbove(scanned.length, 0, `Step 3 resolved ZERO scope — scanned: ${scanned.join()}`);
+		assert.strictEqual(scanned[0], SHIP_IT_REL);
+		assert.deepStrictEqual(unresolved, [], "every script Step 3 sources must read back");
+	});
+
+	it("reaches the rollup bindings through the source line, not only inline in the markdown", () => {
+		assert.match(
+			resolveStep3Section(SHIP_IT).section,
+			bindingLine,
+			"the resolved surface must carry the rollup bindings",
+		);
+		// Non-vacuous, and precisely so: the markdown slice ALONE no longer carries them, so the match
+		// above can only have come from a followed script. A count of scanned files would not prove
+		// this — Step 3 sources three scripts, so an unrelated sibling would satisfy it.
+		assert.notMatch(
+			extractStep3Section(SHIP_IT.text),
+			bindingLine,
+			"the bindings are extracted (#4448), so the markdown slice alone must NOT carry them",
+		);
+	});
+
+	it("resolves the bindings from the script when the markdown no longer carries them", () => {
+		const relocated = skillSurfaceFromText(
+			[
+				"## Step 3 — Confirm the *gating* checks are green",
+				'2. **Else, something is still unfinished** (`[ -n "$RUNNING$WEDGED" ]`) → poll.',
+				'. "$SHIPIT_SCRIPTS/bindings.sh"',
+				"",
+				"## Step 4 — Enqueue",
+			].join("\n"),
+			{
+				"bindings.sh": [
+					`RUNNING=$(jq -r '.running | join(", ")' <<<"$CI_JSON")`,
+					`WEDGED=$(jq -r  '.wedged  | join(", ")' <<<"$CI_JSON")`,
+				].join("\n"),
+			},
+		);
+		assert.deepStrictEqual(parseStep3EntryTest(relocated).fields, ["running", "wedged"]);
+		// …and the un-followed corpus is exactly what fails: the same markdown with no script.
+		const unfollowed = skillSurfaceFromText(relocated.text);
+		assert.deepStrictEqual(parseStep3EntryTest(unfollowed), FAILCLOSED_STEP3_ENTRY_TEST);
+	});
+
+	it("still resolves bindings that live INLINE — the old path is not traded away for the new one", () => {
+		const inline = skillSurfaceFromText(
+			[
+				"## Step 3 — Confirm the *gating* checks are green",
+				'2. **Else, something is still unfinished** (`[ -n "$RUNNING$WEDGED" ]`) → poll.',
+				"```bash",
+				`RUNNING=$(jq -r '.running | join(", ")' <<<"$CI_JSON")`,
+				`WEDGED=$(jq -r  '.wedged  | join(", ")' <<<"$CI_JSON")`,
+				"```",
+				"## Step 4 — Enqueue",
+			].join("\n"),
+		);
+		assert.deepStrictEqual(parseStep3EntryTest(inline).fields, ["running", "wedged"]);
+	});
+
+	it("a section that sources an UNREADABLE script fails closed — UNKNOWN, never 'no bindings'", () => {
+		const missing = skillSurfaceFromText(
+			[
+				"## Step 3 — Confirm the *gating* checks are green",
+				'2. **Else** (`[ -n "$RUNNING$WEDGED" ]`) → poll.',
+				'. "$SHIPIT_SCRIPTS/gone.sh"',
+				`RUNNING=$(jq -r '.running' <<<"$CI_JSON")`,
+				`WEDGED=$(jq -r '.wedged' <<<"$CI_JSON")`,
+				"## Step 4 — Enqueue",
+			].join("\n"),
+		);
+		// The bindings are RIGHT THERE inline — and it still refuses, because one file of the surface
+		// was unreadable. A partial read is not a read.
+		assert.deepStrictEqual(resolveStep3Section(missing).unresolved, ["gone.sh"]);
+		assert.deepStrictEqual(parseStep3EntryTest(missing), FAILCLOSED_STEP3_ENTRY_TEST);
+	});
+
+	it("a renamed heading is ZERO SCOPE, and zero scope fails rather than resolving", () => {
+		const renamed = skillSurfaceFromText('## Step 3a — renamed\n2. (`[ -n "$RUNNING" ]`)\n');
+		assert.deepStrictEqual(resolveStep3Section(renamed).scanned, []);
+		assert.deepStrictEqual(parseStep3EntryTest(renamed), FAILCLOSED_STEP3_ENTRY_TEST);
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/checks/step3-contract.ts
+++ b/packages/pipeline-cli/src/tools/checks/step3-contract.ts
@@ -4,11 +4,22 @@
  * instead of hand-copying it (#4054). Same drift-proof idiom as `class-probe`'s `HAS_*_RE` parse:
  * the skill's fenced block stays the single source, this reads it, no second copy exists to rot.
  *
- * Fail-closed in one direction only: a renamed Step 3, a missing entry condition, or a shell
- * variable the fenced block never binds to a rollup field all resolve to NO fields — which makes
- * the consuming guard red (nothing is ever pending ⇒ the #3999 regression cases stop settle-polling),
- * never quietly green.
+ * Fail-closed in one direction only: a renamed Step 3, a missing entry condition, an unreadable
+ * sourced script, or a shell variable the block never binds to a rollup field all resolve to NO
+ * fields — which makes the consuming guard red (nothing is ever pending ⇒ the #3999 regression cases
+ * stop settle-polling), never quietly green.
+ *
+ * The parse is **extraction-invariant**: the bindings live in `scripts/step3-rollup-bindings.sh`, and
+ * the section's `. "$SHIPIT_SCRIPTS/…"` line is followed into it (`skill-shell-surface.ts`, #4498).
+ * It reads the bindings wherever they sit — inline in the markdown or in the sourced script — so a
+ * pure relocation neither reds this nor, worse, quietly empties it.
  */
+
+import {
+	type ResolvedSection,
+	resolveSection,
+	type SkillSurface,
+} from "../../skill-shell-surface.ts";
 
 export interface Step3EntryTest {
 	/** The literal shell condition, e.g. `[ -n "$RUNNING$WEDGED" ]`. Empty when unresolvable. */
@@ -27,6 +38,14 @@ export const extractStep3Section = (shipItText: string): string => {
 	const end = section.slice(1).search(/^## /m);
 	return end < 0 ? section : section.slice(0, end + 1);
 };
+
+/**
+ * Step 3's full shell surface: the heading slice plus every `scripts/*.sh` it sources. The returned
+ * `scanned` is the emitted scope (ADR 0092) — a caller asserts what was read rather than trusting a
+ * green, since ZERO scanned files is what a renamed heading looks like.
+ */
+export const resolveStep3Section = (surface: SkillSurface): ResolvedSection =>
+	resolveSection(surface, extractStep3Section);
 
 /**
  * The fenced block's `VAR=$(jq -r '.field …' <<<"$CI_JSON")` lines, as var → rollup field. The
@@ -62,8 +81,12 @@ const numberedItem = (section: string, label: string): string => {
  * condition actually reads. `{[ -n "$RUNNING$WEDGED" ]} → ["running", "wedged"]` — the pending
  * sets. A rewrite to the rollup colour resolves elsewhere (or nowhere), which is the whole point.
  */
-export const parseStep3EntryTest = (shipItText: string): Step3EntryTest => {
-	const section = extractStep3Section(shipItText);
+export const parseStep3EntryTest = (surface: SkillSurface): Step3EntryTest => {
+	const {section, scanned, unresolved} = resolveStep3Section(surface);
+	// ZERO SCOPE and UNRESOLVED are both UNKNOWN, never "the bindings are absent": a heading that
+	// matched nothing, or a sourced script that would not read back, has told us nothing about the
+	// step. Resolve to no fields so the consuming mirror reds (ADR 0092 / §ZS).
+	if (scanned.length === 0 || unresolved.length > 0) return FAILCLOSED_STEP3_ENTRY_TEST;
 	const condition = numberedItem(section, "2").match(/`(\[[^`]*\])`/)?.[1] ?? "";
 	if (condition === "") return FAILCLOSED_STEP3_ENTRY_TEST;
 	const bindings = parseRollupBindings(section);

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.ts
@@ -7,11 +7,22 @@
  * relocated here — the poll verdict remains `merge-queue-classify`'s, the disposition wording
  * remains the skill's.
  *
- * Fail-closed in one direction only: a renamed Step 5.5, a budget the block never binds, or a
- * missing `case` arm all resolve to a ZERO horizon and NO dispositions — which makes the consuming
- * assertions red (a zero horizon covers no dwell, an absent disposition matches no contract), never
- * quietly green.
+ * Fail-closed in one direction only: a renamed Step 5.5, an unreadable sourced script, a budget the
+ * block never binds, or a missing `case` arm all resolve to a ZERO horizon and NO dispositions —
+ * which makes the consuming assertions red (a zero horizon covers no dwell, an absent disposition
+ * matches no contract), never quietly green.
+ *
+ * The parse is **extraction-invariant**: the block lives in `scripts/step5_5-reconcile.sh`, and the
+ * section's `. "$SHIPIT_SCRIPTS/…"` line is followed into it (`skill-shell-surface.ts`, #4498). It
+ * reads the budget and the case arms wherever they sit — inline in the markdown or in the sourced
+ * script — so a pure relocation neither reds this nor, worse, quietly empties it.
  */
+
+import {
+	type ResolvedSection,
+	resolveSection,
+	type SkillSurface,
+} from "../../skill-shell-surface.ts";
 
 /** The reconcile's poll budget as Step 5.5 states it, plus the horizon it actually observes. */
 export interface ReconcileBudget {
@@ -56,13 +67,23 @@ export const extractStep55Section = (shipItText: string): string => {
 	return end < 0 ? section : section.slice(0, bodyAt + end);
 };
 
+/**
+ * Step 5.5's full shell surface: the heading slice plus every `scripts/*.sh` it sources. The returned
+ * `scanned` is the emitted scope (ADR 0092) — a caller asserts what was read rather than trusting a
+ * green, since ZERO scanned files is what a renamed heading looks like.
+ */
+export const resolveStep55Section = (surface: SkillSurface): ResolvedSection =>
+	resolveSection(surface, extractStep55Section);
+
 const shellDefault = (section: string, name: string): number => {
 	const m = section.match(new RegExp(`^${name}=\\$\\{[A-Z_]+:-(\\d+)\\}`, "m"));
 	return m?.[1] === undefined ? 0 : Number.parseInt(m[1], 10);
 };
 
-export const parseReconcileBudget = (shipItText: string): ReconcileBudget => {
-	const section = extractStep55Section(shipItText);
+export const parseReconcileBudget = (surface: SkillSurface): ReconcileBudget => {
+	const {section, scanned, unresolved} = resolveStep55Section(surface);
+	// ZERO SCOPE and UNRESOLVED are both UNKNOWN, never "the budget is absent" (ADR 0092 / §ZS).
+	if (scanned.length === 0 || unresolved.length > 0) return FAILCLOSED_RECONCILE_BUDGET;
 	const tries = shellDefault(section, "RECONCILE_TRIES");
 	const sleepSeconds = shellDefault(section, "RECONCILE_SLEEP");
 	if (tries === 0 || sleepSeconds === 0) return FAILCLOSED_RECONCILE_BUDGET;
@@ -78,9 +99,16 @@ export const parseReconcileBudget = (shipItText: string): ReconcileBudget => {
 /**
  * The `MERGE_DISPOSITION` the skill renders per outcome, keyed by every outcome word its `case`
  * arm lists (`queued|pending` yields two entries pointing at the one shared rendering).
+ *
+ * This population is **derived from the text**, so it is the one place a relocation could have gone
+ * quiet rather than red: a section that reaches no `case` arm yields an EMPTY map, and a consumer
+ * that only asserts *properties of* a rendering (`notInclude`, or two renderings differing) passes
+ * vacuously on `""`. That is the silent-dropout shape #4509 names. The remedy is not here — a parser
+ * cannot know which outcomes exist — it is in the consumer, which pins the expected membership
+ * against `MergeOutcome`'s four words so a missing arm reds.
  */
-export const parseMergeDispositions = (shipItText: string): ReadonlyMap<string, string> => {
-	const section = extractStep55Section(shipItText);
+export const parseMergeDispositions = (surface: SkillSurface): ReadonlyMap<string, string> => {
+	const {section} = resolveStep55Section(surface);
 	const dispositions = new Map<string, string>();
 	for (const m of section.matchAll(/^\s*([a-z|]+)\)\s*\n?\s*MERGE_DISPOSITION="([^"]*)"\s*;;/gm)) {
 		const [, outcomes, rendering] = m;

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.unit.test.ts
@@ -1,25 +1,26 @@
-import {readFileSync} from "node:fs";
 import {dirname, join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
+import {skillSurfaceFromDisk, skillSurfaceFromText} from "../../skill-shell-surface.ts";
 import {classify, type MergeOutcome, type MergeQueueSignals} from "./merge-queue-classify.ts";
 import {
+	extractStep55Section,
 	FAILCLOSED_RECONCILE_BUDGET,
 	parseMergeDispositions,
 	parseReconcileBudget,
 	type ReconcileBudget,
+	resolveStep55Section,
 } from "./step55-contract.ts";
 
 // The live skill — the single source for Step 5.5's budget and disposition wording. Read
-// repo-relative off this file's own location so it resolves identically in CI and in a worktree.
-const SHIP_IT_PATH = join(
-	dirname(fileURLToPath(import.meta.url)),
-	"../../../../..",
-	"claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md",
-);
-const SHIP_IT_TEXT = readFileSync(SHIP_IT_PATH, "utf8");
-const LIVE_BUDGET = parseReconcileBudget(SHIP_IT_TEXT);
-const LIVE_DISPOSITIONS = parseMergeDispositions(SHIP_IT_TEXT);
+// repo-relative off this file's own location so it resolves identically in CI and in a worktree. The
+// SURFACE, not the file: the step's shell lives in the `scripts/*.sh` the section sources, and the
+// parse follows into it (#4498), so this reaches the budget whether it was extracted or not.
+const SHIP_IT_REL = "claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md";
+const SHIP_IT_PATH = join(dirname(fileURLToPath(import.meta.url)), "../../../../..", SHIP_IT_REL);
+const SHIP_IT = skillSurfaceFromDisk(SHIP_IT_PATH, SHIP_IT_REL);
+const LIVE_BUDGET = parseReconcileBudget(SHIP_IT);
+const LIVE_DISPOSITIONS = parseMergeDispositions(SHIP_IT);
 
 /** The budget as it stood before #4403 — the control the boundary cases are measured against. */
 const OLD_BUDGET: ReconcileBudget = {
@@ -27,6 +28,23 @@ const OLD_BUDGET: ReconcileBudget = {
 	sleepSeconds: 30,
 	horizonSeconds: 270, // poll 10 fires at 9*30s; the 10th sleep observed nothing
 	sleepsBetweenPollsOnly: false,
+};
+
+/**
+ * The budget as Step 5.5 writes it, for the #4498 fixtures below. Built rather than spelled out so
+ * biome's noTemplateCurlyInString stays quiet — these fixtures ARE shell, and a spelled-out
+ * `${VAR:-N}` trips the rule on every line (the `settings-env-guard` idiom, #2495).
+ */
+const BUDGET_LINES: ReadonlyArray<string> = [
+	`RECONCILE_TRIES=$\{SHIP_RECONCILE_TRIES:-16}`,
+	`RECONCILE_SLEEP=$\{SHIP_RECONCILE_SLEEP:-30}`,
+	'  if [ "$i" -lt "$RECONCILE_TRIES" ]; then sleep "$RECONCILE_SLEEP"; fi',
+];
+const BUDGET_16x30: ReconcileBudget = {
+	tries: 16,
+	sleepSeconds: 30,
+	horizonSeconds: 450,
+	sleepsBetweenPollsOnly: true,
 };
 
 /**
@@ -126,9 +144,116 @@ describe("ship-it Step 5.5's reconcile budget, read off the live SKILL.md", () =
 	});
 
 	it("fails closed on a Step 5.5 it cannot read, rather than resolving a plausible horizon", () => {
-		assert.deepStrictEqual(parseReconcileBudget(""), FAILCLOSED_RECONCILE_BUDGET);
+		assert.deepStrictEqual(
+			parseReconcileBudget(skillSurfaceFromText("")),
+			FAILCLOSED_RECONCILE_BUDGET,
+		);
 		assert.strictEqual(FAILCLOSED_RECONCILE_BUDGET.horizonSeconds, 0);
-		assert.strictEqual(parseMergeDispositions("").size, 0);
+		assert.strictEqual(parseMergeDispositions(skillSurfaceFromText("")).size, 0);
+	});
+
+	// The horizon identity above is VACUOUS at the fail-closed constant — 0 === (0-1)*0 — so it
+	// passes on a corpus the parser could not read. Pin the budget's own non-triviality here, where
+	// it is the assertion rather than a by-product, so an emptied parse reds on this row too.
+	it("resolves a real budget, not the fail-closed zero", () => {
+		assert.isAbove(LIVE_BUDGET.tries, 1);
+		assert.isAbove(LIVE_BUDGET.sleepSeconds, 0);
+		assert.isAbove(LIVE_BUDGET.horizonSeconds, 0);
+	});
+});
+
+// The disposition population is DERIVED FROM THE TEXT and, until #4498, was never pinned: a case arm
+// that stopped being reachable yielded an empty map, and every `notInclude`/`notStrictEqual` row
+// above passes vacuously on `""`. That is the #4509 silent-dropout shape — green while covering one
+// outcome fewer, with no symptom. The classifier's own union is the expected membership.
+describe("Step 5.5's disposition population is pinned against MergeOutcome, so an arm cannot drop out", () => {
+	const OUTCOMES: ReadonlyArray<MergeOutcome> = ["merged", "ejected", "queued", "pending"];
+
+	it("renders every outcome word the classifier can print, and nothing is blank", () => {
+		assert.deepStrictEqual([...LIVE_DISPOSITIONS.keys()].sort(), [...OUTCOMES].sort());
+		for (const outcome of OUTCOMES) {
+			assert.isAbove(
+				(LIVE_DISPOSITIONS.get(outcome) ?? "").length,
+				0,
+				`Step 5.5 renders no disposition for \`${outcome}\``,
+			);
+		}
+	});
+});
+
+// #4498. Before this, the parse read SKILL.md alone, so moving the reconcile block into a sourced
+// script — a pure relocation — resolved a ZERO horizon and reddened the mirror.
+describe("Step 5.5's parse follows the section's sourced scripts (extraction-invariant, #4498)", () => {
+	it("emits its scanned scope, and that scope is never empty on a resolvable section", () => {
+		const {scanned, unresolved} = resolveStep55Section(SHIP_IT);
+		assert.isAbove(scanned.length, 0, `Step 5.5 resolved ZERO scope — scanned: ${scanned.join()}`);
+		assert.strictEqual(scanned[0], SHIP_IT_REL);
+		assert.deepStrictEqual(unresolved, [], "every script Step 5.5 sources must read back");
+	});
+
+	it("reaches the budget through the source line, not only inline in the markdown", () => {
+		assert.match(resolveStep55Section(SHIP_IT).section, /^RECONCILE_TRIES=/m);
+		// Non-vacuous, and precisely so: the markdown slice ALONE no longer carries the budget, so the
+		// match above can only have come from a followed script.
+		assert.notMatch(
+			extractStep55Section(SHIP_IT.text),
+			/^RECONCILE_TRIES=/m,
+			"the budget is extracted (#4448), so the markdown slice alone must NOT carry it",
+		);
+	});
+
+	it("resolves the budget from the script when the markdown no longer carries it", () => {
+		const md = [
+			"### Step 5.5 — Bounded post-enqueue reconcile",
+			'. "$SHIPIT_SCRIPTS/reconcile.sh"',
+			"",
+			"#### Next",
+		].join("\n");
+		const script = BUDGET_LINES.join("\n");
+		assert.deepStrictEqual(
+			parseReconcileBudget(skillSurfaceFromText(md, {"reconcile.sh": script})),
+			BUDGET_16x30,
+		);
+		// …and the un-followed corpus is exactly what fails: the same markdown with no script.
+		assert.deepStrictEqual(
+			parseReconcileBudget(skillSurfaceFromText(md)),
+			FAILCLOSED_RECONCILE_BUDGET,
+		);
+	});
+
+	it("still resolves a budget that lives INLINE — the old path is not traded away for the new one", () => {
+		const inline = skillSurfaceFromText(
+			[
+				"### Step 5.5 — Bounded post-enqueue reconcile",
+				"```bash",
+				...BUDGET_LINES,
+				"```",
+				"#### Next",
+			].join("\n"),
+		);
+		assert.deepStrictEqual(parseReconcileBudget(inline), BUDGET_16x30);
+	});
+
+	it("a section that sources an UNREADABLE script fails closed — UNKNOWN, never 'no budget'", () => {
+		const missing = skillSurfaceFromText(
+			[
+				"### Step 5.5 — Bounded post-enqueue reconcile",
+				'. "$SHIPIT_SCRIPTS/gone.sh"',
+				...BUDGET_LINES,
+				"#### Next",
+			].join("\n"),
+		);
+		// The budget is RIGHT THERE inline — and it still refuses, because one file of the surface was
+		// unreadable. A partial read is not a read.
+		assert.deepStrictEqual(resolveStep55Section(missing).unresolved, ["gone.sh"]);
+		assert.deepStrictEqual(parseReconcileBudget(missing), FAILCLOSED_RECONCILE_BUDGET);
+	});
+
+	it("a renamed heading is ZERO SCOPE, and zero scope fails rather than resolving", () => {
+		const renamed = skillSurfaceFromText(`### Step 5.6 — renamed\n${BUDGET_LINES.join("\n")}\n`);
+		assert.deepStrictEqual(resolveStep55Section(renamed).scanned, []);
+		assert.deepStrictEqual(parseReconcileBudget(renamed), FAILCLOSED_RECONCILE_BUDGET);
+		assert.strictEqual(parseMergeDispositions(renamed).size, 0);
 	});
 });
 


### PR DESCRIPTION
Closes #4498

`step3-contract.ts` and `step55-contract.ts` sliced ship-it's shell out of `SKILL.md` **by markdown heading** with no file-following path, so the 119 lines PR #4491 could not move had no owner: the extraction could not take them while the parsers required them in the markdown. This gives both parsers the follow-into-scripts path and then moves the residue.

## Scope decision — I did both, deliberately

The issue's AC3 (an inline note at the Step 3 and Step 5.5 sites, carried over from #4491's `review-skill` round) **already lands in `ship-it/SKILL.md`**, so this PR is §CP whichever way the scope is cut — splitting the extraction out would have saved no approval cost, only re-created an unowned residue. And the follow path is not end-to-end provable without the relocation: with the constants still inline, every "it follows into the script" assertion is vacuous. So AC1–AC4 all land here.

The risk I weighed against it: `ship-it/SKILL.md` is live shipper infrastructure for every merge in flight. What contains it is that both moves are **byte-moves** into the same sourced-script idiom #4491 already put 16 blocks of this same file into, `sourcing` preserves the caller-visible variables and functions the later steps read (`read_head_ci`, `CI_JSON`/`RUNNING`/`WEDGED`/`GATING_RED`, `MERGE_OUTCOME`/`MERGE_DISPOSITION`/`RECONCILE_HORIZON`), and the `exit 0` on an unreadable head stays the shipper's exit — which is the intended disposition.

**#4448's third residual block stays in the markdown.** It opens with a `cd`, and a sourced script must not move the caller's cwd (§RO). That is a deliberate non-goal, not leftover residue.

## What each parser did when a constant left the markdown — before, and after

The honest answer is **(a) fail loud at the suite level, with a (c) sub-population inside it** — and the (c) rows are the dangerous part, because they are the *regression pins*.

Measured: with the extraction in place and the parsers as on `main`, the two suites exit **1**, 14 reds. So the defect is visible. But **6 rows stayed green while asserting nothing** about the relocated constant (verified by running the pre-change state with a verbose reporter, not by reading the code):

| row that stayed green | why it was vacuous |
|---|---|
| Step 3 · `the #3999 drift is caught: an entry test rewritten to the colour resolves no pending set` | `fields` was **already** `[]`, so the pin passed **for the wrong reason** — the drift it exists to catch was no longer being tested |
| Step 3 · `binds no rollup colour: .conclusion is an aggregate…` | `notInclude([], "conclusion")` |
| Step 5.5 · `observes to the LAST poll … the horizon is (tries-1)*sleep` | at the fail-closed constant, `0 === (0-1)*0` |
| Step 5.5 · `still does not cover the longest measured dwell` | `0 < 565` |
| Step 5.5 · `renders pending … with the same unresolved wording` | `"" === ""` |
| Step 5.5 · `drops the two words that asserted more than any expired reconcile observed` | `notInclude("", …)` |

**Does either parser derive its subject population from file content?** Yes — `parseMergeDispositions` does, from the `case` arms, and **its membership was never pinned**. An arm that stopped being reachable yielded an empty map with **no symptom at all** while four `notInclude` / "these differ" rows passed over `""`. That is exactly the #4509 shape, on a second consumer. `parseRollupBindings` also derives a population, but `deepStrictEqual(fields, ["running","wedged"])` already pins it.

**After this PR:**

- both parsers resolve the constant wherever it sits — inline or in the sourced script;
- an unresolvable section/script is the fail-closed constant, **loud**;
- `parseMergeDispositions`'s population is pinned against `MergeOutcome`'s four words — an **independent** source, not the text — so an arm cannot drop out silently;
- the horizon's non-triviality is its own assertion (`tries > 1`, `sleep > 0`, `horizon > 0`) rather than a by-product of an identity that holds at zero;
- each parser's follow path is pinned by asserting the **markdown slice alone no longer carries the literal**, so the positive match can only have come through the follow path. Counting scanned files would *not* prove this — Step 3 sources three scripts, so an unrelated sibling satisfies a count.

## The resolver, and the two choices in it

`packages/pipeline-cli/src/skill-shell-surface.ts` owns the resolution once (`resolveSection`), so three consumers do not answer "which script does this text source?" three ways. It reuses **the same matcher** adoption-lint's claim pins use, and the **same sibling scoping** `kp_skill_shell_surfaces` chose (#4470) — folding `shared/lib/*.sh` into every caller's surface would let one shared half-procedure satisfy every skill's own rule.

- **Slice on the pristine markdown, then append** — not inline-then-slice. The extracted gate scripts emit markdown from heredocs, so inlining first lets a `## ` line inside a heredoc **truncate the section**; and appending keeps the prose-position parses (a numbered item plus its continuation lines) byte-identical to the un-extracted corpus. A unit test pins this directly.
- **A sourced script that will not read back is UNRESOLVED, not absent.** This is the sharper fail-closed leg: the constant can be sitting **inline right beside the source line** and the parse still refuses, because a partial read is not a read.

Zero scope fails closed (ADR 0092 / §ZS): a heading that matches nothing resolves to **zero** scanned files, `scanned` is returned on the typed result, and the consumers assert it non-empty and assert its first entry — so it cannot read green on zero scope.

## Negative proof — every row my own run, both observables

Pre-change row: extraction in place, `step3-contract.ts` / `step55-contract.ts` / both test files restored from `origin/main`, one process end to end.

| row | exit | stdout bytes | FAIL lines |
|---|---|---|---|
| **PRE-CHANGE** — extraction present, parsers as on `main` | **1** | 12027 | 14 |
| **A** positive control — this PR's tree, unmodified | **0** | 291 | 0 |
| **B** un-extracted corpus — constants back inline, no scripts at all | **1** | 2383 | 2 |
| **C** Step 5.5 heading **renamed** → zero scope on that section | **1** | 13349 | 15 |
| **D** sourced script **absent** (`step5_5-reconcile.sh` deleted) | **1** | 13355 | 15 |
| **E** source line **moved past the next `## ` heading** (out of section) | **1** | 12428 | 14 |
| **F** rollup binding **renamed inside the followed script** | **1** | 2756 | 3 |
| **G** between-polls sleep guard **dropped inside the followed script** | **1** | 1180 | 1 |
| **H** a `MERGE_DISPOSITION` **case arm removed** (population shrinks) | **1** | 3024 | 3 |
| **I** positive control repeated after every restore | **0** | 291 | 0 |

Reading the two rows that need it:

- **Row B is not a regression of the old path.** All 69 parse assertions stay green on a fully inline corpus — the budget, the dispositions, the branch mirror. The 2 reds are the **two extraction-state pins** ("the markdown slice alone must NOT carry it"), which are *supposed* to red on a corpus where the extraction has been undone. The inline path is separately pinned by a unit test in each suite (`still resolves a budget that lives INLINE — the old path is not traded away for the new one`), so CI holds that direction, not just this transcript.
- **Row E needed correcting mid-run and is worth stating.** My first attempt moved the source line under the following `#### ` subsection and stayed **green** — because `extractStep55Section` requires 2–3 hashes, so a `####` heading does not end the section. The mutation had not actually left the section. Moving it past the next real `## ` boundary reds as it should. The row now asserts the fence was found before mutating, so it cannot silently become a no-op again.

`A`/`I` are the positive control in the same invocation shape as every red row, so "it reds" cannot be explained by the change simply breaking the suites.

## §CP classification — measured, not assumed

Per **ADR 0218**, `checks/` and `merge-queue-classify/` are **not** among the eight retained core tools. Live `cp-classify classify`:

| path | verdict |
|---|---|
| `packages/pipeline-cli/src/tools/checks/step3-contract.ts` | `not-control-plane` (exit 3) |
| `packages/pipeline-cli/src/tools/merge-queue-classify/step55-contract.ts` | `not-control-plane` (exit 3) |
| `packages/pipeline-cli/src/skill-shell-surface.ts` | **`control-plane`** — `/packages/pipeline-cli/src/*` is the shared-dispatch root |
| whole PR file set | **`control-plane`** — BLOCKING (human merge) |

Two notes for the reviewer:

1. **The §CP subset is not usefully separable.** AC3's note lands in `ship-it/SKILL.md` (§CP), the two extracted `.sh` files are §CP by the `skills/**/*.sh` row, and the new resolver is §CP by sitting at the `src/*` dispatch root. Only the two contract parsers and their tests are ordinary. Bundling takes the **maximum**, not the average — but here the maximum is unavoidable at every one of the four criteria.
2. **The resolver's §CP-ness is deliberate, and I think correct.** It is the resolution every heading-sliced gate parser now depends on; weakening it weakens gates silently. If a reviewer prefers it ungated, moving it under `src/tools/` would do that — flagging it rather than deciding it.

## `.sh` files added or edited — full disclosure

`leak-guard` is markdown-only today (#4496, PR #4507 in flight) and `leak-guard.yml` can resolve an unreadable diff to a clean green (#4508), so CI cannot be relied on to catch a leak in a `.sh`. Both files are declared here and were scanned by hand:

- **ADDED** `claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh` — byte-move of Step 3's 29-line rollup-binding block, plus the standard sourced-script header and a `PARSER-HELD` note.
- **ADDED** `claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh` — byte-move of Step 5.5's 80-line reconcile block, same header shape.
- **EDITED** — none. No existing `.sh` file is touched; `shared/lib/common.sh` is only *sourced*, never modified.

Hand scan over the 10 touched files with **generic patterns, no named deny-list** (#2393): home-directory, machine-local-absolute, sibling-clone and agent-worktree path shapes, temp-dir shapes, and email-shaped tokens. Clean on every added line. The single corpus-wide hit is pre-existing prose at `SKILL.md:1459` (which *describes* the leak class), untouched by this diff. `shellcheck -x` on both new scripts: exit 0, no output.

## Verification

| check | result |
|---|---|
| `packages/pipeline-cli` full suite | **184 files / 2965 tests passed**, exit 0 |
| the three contract suites | **79 passed**, exit 0 (57 before) |
| `pnpm typecheck` | 29/29 tasks, exit 0 |
| `pnpm lint` (biome) | exit 0, **0 warnings** |
| `cli-invocation-guard check` | clean — 184 files, 320 markdown fences, **108 shell files** as implicit fences |
| `validate-gate-path-drift.sh` | OK — 34 checks |
| `validate-cycle-presence.sh` | OK — 18 checks; scanned scope now lists **both new scripts** |
| `validate-cycle-absence.sh` | OK — 14 checks; same |

The `packages unit tests` job is skipped at head for a skills-touching PR and forced on in the merge queue (`ci.yml:141`), so the suite above was run **by hand** rather than read off the head checks. `.claude/` was intact in the run tree, so `adoption-lint`'s `drive-issue.js` `ENOENT` cases are real passes, not the four phantom failures a `.claude`-less tree produces.

## Related, and what stays open

- **#4448's AC1 residue is discharged** by criterion 2 here — both parser-held blocks are out of the markdown. The third block (the `cd`-opening rehearsal) stays by design.
- Sequencing prerequisite met: **#4494 landed** (`main` tip `22da64d1`), so extracting the residue does not red `cli-invocation-guard` — verified above by running that guard over the two-surface corpus.
- Sibling consumers of the same theme, untouched here: **#4495** (no shellcheck over `skills/**/*.sh` in CI), **#4496** (`leak-guard` markdown-only), **#4502** (write-code's out-of-scope fenced blocks), **#4509** (the #4015 ordering pin's silent dropout). This PR fixes the *same shape* on `parseMergeDispositions`; **#4509 remains open** on its own subject.

Refs #4448
