### PR TITLE
refactor(skills): heal-ci's shell + the tail's residual glue move into scripts/ (#4454)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -7,20 +7,30 @@ description: Record an architecture decision in `.decisions/`. Trigger when the 
 
 Capture one decision per file in `.decisions/`. There is no committed index (ADR [0126](https://github.com/kamp-us/phoenix/blob/main/.decisions/0126-ambient-adr-discovery.md)) and **no `SessionStart` ADR-map hook** (ADR [0129](https://github.com/kamp-us/phoenix/blob/main/.decisions/0129-adr-discovery-is-the-claude-md-contract.md), dropping 0126's hook as needless indirection) — discovery is the CLAUDE.md contract alone, the same in every context: `ls .decisions/` + each file's frontmatter (`id`/`title`/`status`), with `pipeline-cli decisions-index compact` rendering the full `id · title · status` map **on demand** (never auto-injected). An ADR PR is **purely additive**: it adds one `.decisions/NNNN-slug.md` file (plus the status-line edit on a file it supersedes or amends-in-part), and never touches or regenerates an index.
 
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced block is an **invocation** of one
+(epic #4435 phase 1 — the shell moved as-is; turning its glue into tested `pipeline-cli` verbs is
+#1929). They set `set -uo pipefail`, deliberately not `-e`, and install no `EXIT` trap: the moved glue
+steers its own control flow, `errexit` would abort a fail-closed branch before it printed its refusal,
+and on bash 3.2 a `set -u` abort that reaches an `EXIT` trap yields exit **0** — a fail-closed script
+exiting clean having printed its FAIL (#4476, class #4479).
+
+**[`scripts/claimed-numbers.sh`](scripts/claimed-numbers.sh) fails closed on an unreadable query, and
+that is the whole point of the reservation lock.** An empty in-flight set reads as "nothing reserved",
+which is exactly the stale-on-disk fall-back ADR 0074 removes — so a failed enumeration exits non-zero
+rather than printing nothing, and an empty listing is only "nothing reserved" on **exit 0**.
+
 ## Steps
 
 1. **Claim the next number with an in-flight reservation lock** (ADR [0074](https://github.com/kamp-us/phoenix/blob/main/.decisions/0074-adr-number-claim-lock.md)) — not next-free-on-disk. Numbers are 4-digit zero-padded, monotonic. Compute the next number from the **union of two sets** and take `max(union) + 1`:
    - **Merged set** — the `NNNN` on the base ref, read from the `.decisions/NNNN-*.md` *filenames* (the authority; there is no committed index to consult — ADR [0126](https://github.com/kamp-us/phoenix/blob/main/.decisions/0126-ambient-adr-discovery.md)). Don't eyeball this — run **`"$PCLI" decisions-index next`** (resolve `$PCLI` with §CLI's canonical preamble — [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §CLI), the deterministic allocator (#2064): it reuses the same frontmatter parse `validate` runs and prints `max(id) + 1` zero-padded (e.g. `0155`). That kills the stale-guess case (a local checkout reading `0150` while origin/main is `0151`); run it against a **freshly fetched** base ref so the merged set is current. Take the `max` of *its* output and the in-flight set below.
    - **In-flight set** — the `NNNN` **claimed by open ADR PRs**. An open PR that adds a `.decisions/NNNN-*.md` file *is* the reservation for `NNNN` (no separate artifact, exactly as ADR 0059's `status:planning` label *is* the epic lock — opening the PR reserves, merging/closing releases). Enumerate via **`gh api` REST, never GraphQL** (the org's Projects-classic integration breaks GraphQL):
      ```bash
-     # NNNN claimed by any open PR that ADDS a .decisions/00NN-*.md file (REST, per-PR files endpoint)
-     for PR in $(gh api "repos/$REPO/pulls?state=open&per_page=100" --jq '.[].number'); do
-       gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-         --jq '.[] | select(.status=="added") | .filename
-               | capture("^\\.decisions/(?<n>[0-9]{4})-") | .n'   # --paginate + streaming --jq: a >100-file PR that adds .decisions/NNNN past file #100 still claims its number (the API caps per_page at 100; #725)
-     done
+     # every NNNN claimed by an open PR that ADDS a .decisions/NNNN-*.md file, one per line
+     "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/adr/scripts/claimed-numbers.sh" || exit 1
      ```
-     (`$REPO` resolves the same way write-code's does: `${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}`.) **Fail closed** (ADR 0074, ADR 0059's fail-closed acquire): if the in-flight query errors, **surface it and re-run** — never silently fall back to the on-disk-only number. That stale-on-disk fall-back is the bug this step removes.
+     (The script resolves `$REPO` itself, the same way write-code does.) **Fail closed** (ADR 0074, ADR 0059's fail-closed acquire): if the in-flight query errors it exits non-zero — **surface it and re-run**, and never silently fall back to the on-disk-only number. That stale-on-disk fall-back is the bug this step removes, so an empty listing is only "nothing reserved" on **exit 0**.
 
    This is **detect-and-serialize, not a CAS** — it *narrows* the collision window, it does not eliminate it. Two authors who enumerate in the same window before either PR is visible both pick the same number; that residual is **backstopped by the CI duplicate-`id` check** (the `decisions-index validate` PR job — see [ADR number lock](#adr-number-lock)), which reddens the second-to-merge PR for a manual renumber. The lock turns the *common* "branch after another's ADR PR is open" case from collide-and-renumber into don't-collide; the CI check remains the safety net for the rare residual.
 2. Pick a kebab-case slug from the title (≤ 5 words).

--- a/claude-plugins/kampus-pipeline/skills/adr/scripts/claimed-numbers.sh
+++ b/claude-plugins/kampus-pipeline/skills/adr/scripts/claimed-numbers.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# The IN-FLIGHT set: every `NNNN` claimed by an open PR that ADDS a `.decisions/NNNN-*.md` file. One
+# number per line, unsorted (the caller takes the max of this and the merged set).
+#
+# usage: claimed-numbers.sh
+#
+# `--paginate` plus a STREAMING `--jq` is load-bearing: a >100-file PR that adds `.decisions/NNNN` past
+# file #100 still claims its number (the API caps per_page at 100; #725). REST only — the org's
+# Projects-classic integration breaks GraphQL.
+#
+# FAIL CLOSED (ADR 0074, ADR 0059's fail-closed acquire): if the in-flight query errors, this exits
+# NON-ZERO with its own line on stdout, because the caller reads an empty in-flight set as "nothing
+# reserved" and would silently fall back to the on-disk-only number — the exact stale-on-disk bug the
+# reservation lock exists to remove. An empty set on exit 0 legitimately means no open ADR PR.
+#
+# Extracted from adr/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+REPO="$(kp_repo)" || { echo "adr: target repo unresolved — the in-flight set was NOT read (UNKNOWN, never 'nothing reserved')."; exit 1; }
+
+OPEN_PRS="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --jq '.[].number')" ||
+	{ echo "adr: could not enumerate open PRs — the in-flight set is UNKNOWN, never 'nothing reserved'. Re-run; do NOT fall back to the on-disk number."; exit 1; }
+
+for PR in $OPEN_PRS; do
+	gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+		--jq '.[] | select(.status=="added") | .filename
+              | capture("^\\.decisions/(?<n>[0-9]{4})-") | .n' ||
+		{ echo "adr: could not read PR #$PR's file list — the in-flight set is INCOMPLETE, so it is UNKNOWN. Re-run; do NOT fall back to the on-disk number."; exit 1; }
+done

--- a/claude-plugins/kampus-pipeline/skills/campaign/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/campaign/SKILL.md
@@ -67,6 +67,10 @@ above all — before it printed its refusal. Two notes:
   ([`scripts/open-roadmap-pr.sh`](scripts/open-roadmap-pr.sh)). A script that ran `git switch -c`
   would mutate whichever checkout the caller happened to be sitting in — a footgun the extraction
   would have *introduced* rather than moved.
+- **A zero-length listing is an exit code, not silence.** [`scripts/list-wave.sh`](scripts/list-wave.sh)
+  exits 4 on a label naming zero issues and 1 on a read that never landed, because "no members" is the
+  permissive-looking answer and must never be what a failed read looks like (§ZS / ADR 0092). Read the
+  exit status before the lines.
 
 ## Preconditions — the wave label, the lifecycle direction, the campaign name
 
@@ -77,8 +81,9 @@ You need three inputs before the ritual:
 
    ```bash
    WAVE_LABEL="<the shared wave label>"
-   gh api -X GET "repos/$REPO/issues" -f "labels=$WAVE_LABEL" -f state=all -f per_page=100 --paginate \
-     --jq '.[] | select(.pull_request | not) | "#\(.number)\t\(.state)\t\(.title)"'
+   # one `#<n>\t<state>\t<title>` line per member. Exit 4 = the label names ZERO issues (no wave);
+   # exit 1 = the read never landed, which is UNKNOWN and never an empty cluster.
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/list-wave.sh" "$WAVE_LABEL"
    ```
 
 2. **The lifecycle direction — `active` (create) or `done` (complete).** Default is `active`
@@ -127,7 +132,7 @@ product arc:
   milestone for this wave, attach to it. List open milestones and match by title/description:
 
   ```bash
-  gh api "repos/$REPO/milestones?state=all&per_page=100" --jq '.[] | "#\(.number)\t\(.state)\t\(.title)"'
+  "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/list-milestones.sh"
   ```
 
 - **Otherwise provision the campaign's own milestone** — the roadmap act the founder approval
@@ -135,10 +140,9 @@ product arc:
   milestone):
 
   ```bash
-  MILESTONE_NUMBER=$(gh api -X POST "repos/$REPO/milestones" \
-    -f "title=<Campaign name> campaign" \
-    -f "description=<one-line campaign scope> (bounded, platform-lane drained)." \
-    --jq .number)
+  MILESTONE_NUMBER="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/create-milestone.sh" \
+    "<Campaign name> campaign" \
+    "<one-line campaign scope> (bounded, platform-lane drained).")" || exit 1
   ```
 
 Then **stamp the milestone on every wave-labeled issue** so the milestone projection matches the
@@ -230,7 +234,8 @@ run the **same gate** (Step 1), so completing a campaign is exactly as guarded a
   2. **Close the milestone** — the operational projection of a finished campaign:
 
      ```bash
-     gh api -X PATCH "repos/$REPO/milestones/$MILESTONE_NUMBER" -f state=closed >/dev/null
+     "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/close-milestone.sh" \
+       "$MILESTONE_NUMBER" || exit 1
      ```
   3. **Flip the ROADMAP row to `done`** in a Campaigns-row PR (Step 4, `done` variant) — the row's
      `State` cell goes `active → done`, keeping the milestone pin.

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/close-milestone.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/close-milestone.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Close the campaign milestone — the operational projection of a finished campaign, the `done` path's
+# step 2.
+#
+# usage: close-milestone.sh <milestone-number>
+#
+# Closing the milestone and flipping the ROADMAP row to `done` are PAIRED (roadmap-guard's I3 only
+# requires *open* milestones to be claimed). That pairing is the skill's to hold — this script closes
+# one milestone and reports whether it landed.
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "campaign: close-milestone.sh needs a milestone number — NOTHING was closed."; echo "usage: close-milestone.sh <milestone-number>" >&2; exit 2; }
+MILESTONE_NUMBER="$1"
+REPO="$(kp_repo)" || { echo "campaign: target repo unresolved — NOTHING was closed."; exit 1; }
+
+gh api -X PATCH "repos/$REPO/milestones/$MILESTONE_NUMBER" -f state=closed >/dev/null ||
+	{ echo "campaign: milestone #$MILESTONE_NUMBER did NOT close — do not flip the ROADMAP row to \`done\` over an open milestone."; exit 1; }
+
+printf 'milestone #%s closed\n' "$MILESTONE_NUMBER"

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/create-milestone.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/create-milestone.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Provision the campaign's OWN milestone — the roadmap act the founder-approval trace authorizes.
+# Prints the new milestone NUMBER on stdout.
+#
+# usage: create-milestone.sh "<Campaign name> campaign" "<one-line campaign scope> (bounded, platform-lane drained)."
+#
+# Never reuse an arc milestone: a campaign runs concurrent with, not inside, a product arc (ADR 0072).
+# That precedence is the skill's to apply — this script only creates what it is told to.
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "campaign: create-milestone.sh needs <title> <description> — NO milestone was created."; echo "usage: create-milestone.sh \"<Campaign name> campaign\" \"<one-line scope>.\"" >&2; exit 2; }
+TITLE="$1"
+DESCRIPTION="$2"
+REPO="$(kp_repo)" || { echo "campaign: target repo unresolved — NO milestone was created."; exit 1; }
+
+MILESTONE_NUMBER=$(gh api -X POST "repos/$REPO/milestones" \
+	-f "title=$TITLE" \
+	-f "description=$DESCRIPTION" \
+	--jq .number)
+[ -n "$MILESTONE_NUMBER" ] || { echo "campaign: the create call returned no milestone number — it may or may not exist; list milestones before retrying."; exit 1; }
+
+printf '%s\n' "$MILESTONE_NUMBER"

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/list-milestones.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/list-milestones.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Print one `#<n>\t<state>\t<title>` line per milestone (any state), so an existing founder-curated
+# campaign milestone can be matched by title/description before a new one is provisioned.
+#
+# usage: list-milestones.sh
+#
+# An empty list would read as "no milestone to attach to ⇒ create one", so a failed read must not
+# arrive as the same emptiness: exit 1 with its own line on stdout.
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+REPO="$(kp_repo)" || { echo "campaign: target repo unresolved — milestones NOT read (UNKNOWN, never 'none exist')."; exit 1; }
+
+gh api "repos/$REPO/milestones?state=all&per_page=100" --jq '.[] | "#\(.number)\t\(.state)\t\(.title)"' ||
+	{ echo "campaign: could not read the milestone list — UNKNOWN, never 'none exist'."; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/campaign/scripts/list-wave.sh
+++ b/claude-plugins/kampus-pipeline/skills/campaign/scripts/list-wave.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Print one `#<n>\t<state>\t<title>` line per issue carrying the wave label — the membership read that
+# confirms the wave names a NON-EMPTY cluster before anything mutates.
+#
+# usage: list-wave.sh <wave-label>
+#
+# ZERO SCOPE FAILS (§ZS / ADR 0092): an empty cluster is exit 4, and an unreadable one exit 1, each
+# with its own line on stdout. Emptiness here is the permissive-looking answer — "no members, nothing
+# to re-price" — so it must never be what a failed read looks like.
+#
+# Extracted from campaign/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "campaign: list-wave.sh needs a wave label — the cluster was NOT read."; echo "usage: list-wave.sh <wave-label>" >&2; exit 2; }
+WAVE_LABEL="$1"
+REPO="$(kp_repo)" || { echo "campaign: target repo unresolved — the cluster was NOT read (UNKNOWN, never empty)."; exit 1; }
+
+MEMBERS=$(gh api -X GET "repos/$REPO/issues" -f "labels=$WAVE_LABEL" -f state=all -f per_page=100 --paginate \
+	--jq '.[] | select(.pull_request | not) | "#\(.number)\t\(.state)\t\(.title)"') ||
+	{ echo "campaign: could not read the '$WAVE_LABEL' cluster — UNKNOWN, never empty."; exit 1; }
+[ -n "$MEMBERS" ] || { echo "campaign: '$WAVE_LABEL' names ZERO issues — there is no wave to run a campaign over."; exit 4; }
+
+printf '%s\n' "$MEMBERS"

--- a/claude-plugins/kampus-pipeline/skills/canon/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/canon/SKILL.md
@@ -48,11 +48,18 @@ it once, at the top of your run, per the shared contract's **Target repo resolut
 REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/resolve-repo.sh")" || exit 1
 ```
 
+## The extracted scripts
+
 This skill's shell lives in [`scripts/`](scripts/), and each fenced block is an **invocation** of one
 (epic #4435 phase 1 — the shell moved as-is; turning its glue into tested `pipeline-cli` verbs is
-#1929). They set `set -uo pipefail`, deliberately not `-e`: the self-checks below use a `grep` whose
-empty result is an *answer*, and `errexit` would abort on it. Each check therefore prints an explicit
-verdict word, so "the check found nothing" and "the check never ran" are never the same output.
+#1929). They set `set -uo pipefail`, deliberately not `-e`, and install no `EXIT` trap: the self-checks
+below use a `grep` whose empty result is an *answer*, `errexit` would abort on it, and on bash 3.2 a
+`set -u` abort that reaches an `EXIT` trap yields exit **0** — a fail-closed script exiting clean having
+printed its FAIL (#4476, class #4479). Each check therefore prints an explicit verdict word, so "the
+check found nothing" and "the check never ran" are never the same output — and the two listing scripts
+([`scripts/list-pattern-docs.sh`](scripts/list-pattern-docs.sh),
+[`scripts/pattern-doc-drift.sh`](scripts/pattern-doc-drift.sh)) give an empty result its own exit code
+(4) so it can never be read as a clean one (§ZS / ADR 0092).
 
 The **paths themselves are repo-relative** — `.patterns/` at the repo root — resolved from
 the working tree, never an absolute or home path. Resolve the repo root with
@@ -141,8 +148,8 @@ Run it when there's no doc worth preserving for a pattern that clears the index 
    don't duplicate one:
 
    ```bash
-   ROOT="$(git rev-parse --show-toplevel)"
-   ls "$ROOT"/.patterns/*.md
+   # exit 4 = there is no pattern-doc library (or it is empty) — a fact to confirm, not a listing
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/list-pattern-docs.sh"
    ```
 
 2. **Read the source for the concern, in layers.** Stop as soon as you can name the decision
@@ -187,16 +194,15 @@ change. Surgical — touch the drifted parts, preserve everything else.
    last update; scan what changed in the source it describes since then, not the whole repo:
 
    ```bash
-   ROOT="$(git rev-parse --show-toplevel)"
-   # the commit that last touched this pattern doc — the lower bound of "what changed since"
-   LAST=$(git -C "$ROOT" log -1 --format=%H -- .patterns/<name>.md)
-   # the source surfaces that changed since then (scope to the dirs the doc describes)
-   git -C "$ROOT" diff --name-status "$LAST"..HEAD -- <source-dirs>
+   # the source surfaces that changed since the doc last moved. Exit 4 = the doc has never been
+   # committed, which is the BOOTSTRAP case below and not an empty drift.
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/pattern-doc-drift.sh" \
+     "<name>" <source-dirs>
    ```
 
-   If the doc has never been committed, that's the bootstrap case. If `LAST` is empty for
-   another reason, fall back to the working-tree diff
-   (`git -C "$ROOT" diff --name-status HEAD -- <source-dirs>`).
+   Exit 4 means the doc has never been committed — that's the bootstrap case. If the doc *is*
+   committed and the lower bound still won't resolve, fall back to the working-tree diff
+   (`git -C "$(git rev-parse --show-toplevel)" diff --name-status HEAD -- <source-dirs>`).
 
 2. **Classify each source change against the doc:**
    - **A new approach / API shape** the doc doesn't cover → **add** the section, grounded in

--- a/claude-plugins/kampus-pipeline/skills/canon/scripts/list-pattern-docs.sh
+++ b/claude-plugins/kampus-pipeline/skills/canon/scripts/list-pattern-docs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# List the existing `.patterns/*.md` docs, so a new doc slots into the right layer/prefix and does not
+# duplicate one.
+#
+# usage: list-pattern-docs.sh
+#
+# ZERO SCOPE FAILS (§ZS / ADR 0092): a repo with no pattern docs at all is exit 4, not silence — an
+# empty listing would otherwise read as "nothing to duplicate, write freely", which is the wrong
+# conclusion when the real cause is an unresolvable repo root or an unmatched glob (bash has no
+# `nullglob` here, so an unmatched pattern survives as a literal path).
+#
+# Extracted from canon/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "canon: not inside a git repository — .patterns/ was NOT listed."; exit 1; }
+[ -d "$ROOT/.patterns" ] || { echo "canon: $ROOT/.patterns does not exist — there is no pattern-doc library in this checkout."; exit 4; }
+
+DOCS="$(find "$ROOT/.patterns" -maxdepth 1 -type f -name '*.md' | LC_ALL=C sort)"
+[ -n "$DOCS" ] || { echo "canon: .patterns/ holds no *.md docs — an EMPTY library, which is a fact to confirm, not a listing."; exit 4; }
+
+printf '%s\n' "$DOCS"

--- a/claude-plugins/kampus-pipeline/skills/canon/scripts/pattern-doc-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/canon/scripts/pattern-doc-drift.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Scope the drift for one pattern doc: print the source surfaces that changed since the commit that
+# last touched `.patterns/<name>.md`.
+#
+# usage: pattern-doc-drift.sh <name> <source-dir> [<source-dir> …]
+#
+# THE BOOTSTRAP CASE IS EXIT 4, NOT AN EMPTY DIFF. An uncommitted doc has no `LAST`, and a
+# `git diff ""..HEAD` is not "nothing drifted" — it is a different question entirely (the skill's own
+# prose says so). Distinguishing the two is why the empty `LAST` gets its own exit code and its own
+# line on stdout (§ZS / ADR 0092).
+#
+# Extracted from canon/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+[ "$#" -ge 2 ] || { echo "canon: pattern-doc-drift.sh needs <name> and at least one source dir — NO drift was scoped."; echo "usage: pattern-doc-drift.sh <name> <source-dir> [<source-dir> …]" >&2; exit 2; }
+NAME="$1"
+shift
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "canon: not inside a git repository — NO drift was scoped."; exit 1; }
+
+# the commit that last touched this pattern doc — the lower bound of "what changed since"
+LAST=$(git -C "$ROOT" log -1 --format=%H -- ".patterns/$NAME.md")
+[ -n "$LAST" ] || { echo "canon: .patterns/$NAME.md has never been committed — this is the BOOTSTRAP case, not an empty drift."; exit 4; }
+
+# the source surfaces that changed since then (scope to the dirs the doc describes)
+git -C "$ROOT" diff --name-status "$LAST"..HEAD -- "$@" ||
+	{ echo "canon: the drift diff against $LAST failed — UNKNOWN, never 'nothing drifted'."; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/glossary/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/glossary/SKILL.md
@@ -54,6 +54,22 @@ In phoenix this defaults to `kamp-us/phoenix` with no config, so the behavior is
 root — resolved from the working tree, never an absolute or home path. Resolve the repo root
 with `git rev-parse --show-toplevel` and operate on `<root>/.glossary/TERMS.md`.
 
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced block is an **invocation** of one
+(epic #4435 phase 1 — the shell moved as-is; turning its glue into tested `pipeline-cli` verbs is
+#1929). They set `set -uo pipefail`, deliberately not `-e`, and install no `EXIT` trap: the moved glue
+steers its own control flow, `errexit` would abort a fail-closed branch before it printed its refusal,
+and on bash 3.2 a `set -u` abort that reaches an `EXIT` trap yields exit **0** — a fail-closed script
+exiting clean having printed its FAIL (#4476, class #4479).
+
+**Both scoping scripts give emptiness its own exit code (4), because this skill has two modes and an
+empty answer means a different one.** [`scripts/list-surfaces.sh`](scripts/list-surfaces.sh) exits 4
+when the repo has no `apps/*/src/features` and no `packages/*` at all, and
+[`scripts/glossary-drift.sh`](scripts/glossary-drift.sh) exits 4 when `TERMS.md` has never been
+committed — which is **bootstrap mode**, not an empty incremental drift. Read the exit status before
+the lines (§ZS / ADR 0092).
+
 ## The file you maintain
 
 `.glossary/TERMS.md` is a markdown file: a short top-of-file note (what it is + that the **code
@@ -103,10 +119,9 @@ The first-run seed. Run it when there's no glossary worth preserving.
    the equivalent top-level domains. List them from the tree, not from memory:
 
    ```bash
-   ROOT="$(git rev-parse --show-toplevel)"
-   # feature/domain folders + package names — the surfaces whose nouns the glossary covers
-   ls "$ROOT"/apps/*/src/features 2>/dev/null
-   ls -d "$ROOT"/packages/*/ 2>/dev/null
+   # feature/domain folders + package names. Exit 4 = this repo has NO such surfaces, which is a fact
+   # to confirm rather than an empty listing to read past.
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/glossary/scripts/list-surfaces.sh"
    ```
 
 2. **Harvest the nouns.** For each surface, read enough to name its domain nouns: the product
@@ -137,16 +152,14 @@ the change. The discipline is surgical — touch the affected rows, preserve eve
    The file's last-touch commit bounds the sweep:
 
    ```bash
-   ROOT="$(git rev-parse --show-toplevel)"
-   # the commit that last touched the glossary — the lower bound of "what changed since"
-   LAST=$(git -C "$ROOT" log -1 --format=%H -- .glossary/TERMS.md)
-   # the code surfaces that changed since then (feature folders, public exports, renames)
-   git -C "$ROOT" diff --name-status "$LAST"..HEAD -- apps packages
+   # the code surfaces that changed since the glossary last moved (feature folders, exports, renames)
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/glossary/scripts/glossary-drift.sh"
    ```
 
-   If the file has never been committed (you're staging a fresh seed), that's the bootstrap case,
-   not this one. If `LAST` is empty for a reason other than absence, fall back to reviewing the
-   working-tree diff (`git -C "$ROOT" diff --name-status HEAD -- apps packages`).
+   Exit 4 means the file has never been committed (you're staging a fresh seed) — that's the
+   bootstrap case, not this one. If the file *is* committed and the lower bound still won't resolve,
+   fall back to reviewing the working-tree diff
+   (`git -C "$(git rev-parse --show-toplevel)" diff --name-status HEAD -- apps packages`).
 
 2. **Classify each change against the vocabulary:**
    - **A new noun** (a new feature folder, a new public export, a new entity/table) → **add** a row

--- a/claude-plugins/kampus-pipeline/skills/glossary/scripts/glossary-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/glossary/scripts/glossary-drift.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Scope the glossary update: print the code surfaces that changed since the commit that last touched
+# `.glossary/TERMS.md`.
+#
+# usage: glossary-drift.sh [<source-dir> …]   (defaults to `apps packages`)
+#
+# THE BOOTSTRAP CASE IS EXIT 4, NOT AN EMPTY DIFF. An uncommitted TERMS.md has no lower bound, and
+# `git diff ""..HEAD` is not "nothing changed" — it is bootstrap mode, a different mode entirely (the
+# skill's own prose says so). Distinguishing the two is why the empty lower bound gets its own exit code
+# and its own line on stdout (§ZS / ADR 0092).
+#
+# Extracted from glossary/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "glossary: not inside a git repository — NO drift was scoped."; exit 1; }
+
+# the commit that last touched the glossary — the lower bound of "what changed since"
+LAST=$(git -C "$ROOT" log -1 --format=%H -- .glossary/TERMS.md)
+[ -n "$LAST" ] || { echo "glossary: .glossary/TERMS.md has never been committed — this is BOOTSTRAP mode, not an empty drift."; exit 4; }
+
+# the code surfaces that changed since then (feature folders, public exports, renames)
+if [ "$#" -ge 1 ]; then
+	git -C "$ROOT" diff --name-status "$LAST"..HEAD -- "$@"
+else
+	git -C "$ROOT" diff --name-status "$LAST"..HEAD -- apps packages
+fi || { echo "glossary: the drift diff against $LAST failed — UNKNOWN, never 'nothing changed'."; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/glossary/scripts/list-surfaces.sh
+++ b/claude-plugins/kampus-pipeline/skills/glossary/scripts/list-surfaces.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# The product/feature surfaces whose nouns the glossary covers: each app's `src/features` directory
+# and each workspace package directory. Listed from the tree, never from memory.
+#
+# usage: list-surfaces.sh
+#
+# ZERO SCOPE FAILS (§ZS / ADR 0092): the moved fence swallowed both listings with `2>/dev/null`, so a
+# repo with neither `apps/*/src/features` nor `packages/*` printed nothing and the caller had no way to
+# tell "this repo has no such surfaces" from "the read failed". Emptiness is now exit 4 with its own
+# line. bash here has no `nullglob`, so an unmatched glob survives as a literal path — which is why
+# each candidate is existence-tested rather than expanded blind.
+#
+# Extracted from glossary/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "glossary: not inside a git repository — NO surfaces were listed."; exit 1; }
+
+FOUND=0
+for d in "$ROOT"/apps/*/src/features "$ROOT"/packages/*/; do
+	[ -d "$d" ] || continue
+	printf '%s\n' "$d"
+	FOUND=1
+done
+[ "$FOUND" -eq 1 ] || { echo "glossary: no apps/*/src/features and no packages/* in $ROOT — there are NO surfaces here, which is a fact to confirm rather than an empty listing."; exit 4; }

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
@@ -35,8 +35,33 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/resolve-repo.sh")" || exit 1
 ```
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/), and each fenced `bash` block is an **invocation**
+of one; the prose keeps the *why* (epic #4435 phase 1 — the shell moved as-is, and turning its glue
+into tested `pipeline-cli` verbs is #1929). Three properties are load-bearing:
+
+- **They set `set -uo pipefail`, deliberately not `-e`, and install no `EXIT` trap.** The moved glue
+  steers its own control flow through the guards written into it, and `errexit` would abort a
+  fail-closed branch before it printed its refusal. The pairing is worse than cosmetic: on bash 3.2 a
+  `set -u` abort that reaches an `EXIT` trap yields **exit 0**, so a fail-closed script would exit
+  clean having printed its FAIL (#4476, class #4479).
+- **Every early exit prints its own fail-closed line on stdout.** heal-ci's prose reads emptiness as a
+  positive answer in three places — an empty `--log-failed`, `rerun-markers=0`, `ROUNDS < 3` — and each
+  of those is the permissive branch. A read that *could not run* must therefore not arrive as the same
+  emptiness: **read the exit status before the stdout** (§ZS / ADR 0092, the #4231 / #4010 class).
+- **[`scripts/rerun-once.sh`](scripts/rerun-once.sh) owns the marker phrasing that
+  [`scripts/already-rerun.sh`](scripts/already-rerun.sh) greps for.** That paired contract is unchanged
+  by the move; it is now two files rather than two fences.
+
+**One block is deliberately still inline** — the repair-in-flight verdict resolution in Step 3, whose
+interior is being edited by open PR #4372 (the §CP-awareness `CP_FLAG` addition). Relocating a block
+another PR is editing is how an in-flight change gets silently dropped in a conflict resolution, so it
+waits for #4372; only its self-contained N=3 round count moved out
+([`scripts/repair-rounds.sh`](scripts/repair-rounds.sh)).
 
 ## What you do NOT do
 
@@ -69,21 +94,20 @@ once, up front, then use the vars in every command below:
 ```bash
 RUN=<run id>     # the failed run
 PR=<n>           # the PR, if this is a PR run (else leave unset)
-gh run view $RUN --log-failed
-# the job/step rollup, to know which job died (and its databaseId, for the fallback below)
-gh run view $RUN --json conclusion,headBranch,jobs \
-  --jq '{conclusion, headBranch, jobs: [.jobs[] | select(.conclusion=="failure") | {name, databaseId, steps: [.steps[] | select(.conclusion=="failure") | .name]}]}'
+# the failed logs, then the job/step rollup that names which job died (and its databaseId)
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/failed-logs.sh" "$RUN"
 ```
 
 If `--log-failed` returns nothing (it sometimes does — e.g. a bare `exit 1` with no
 annotated failed-step rows), fall back to the failed job's full log: take its `databaseId`
 from the rollup above and read the job log directly via the REST API, then grep/scope to the
 failed step's output. You must **always** be able to reach the actual log body to match the
-taxonomy — never stay stuck with only step names.
+taxonomy — never stay stuck with only step names. **Read the script's exit status before its
+emptiness**: a non-zero exit means the read never landed, which is not "no annotated failed steps".
 
 ```bash
 JOB=<failed job databaseId from the rollup above>
-gh api repos/$REPO/actions/jobs/$JOB/logs
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/job-log.sh" "$JOB"
 ```
 
 ### Entering from a PR — resolve the failing run over REST
@@ -94,49 +118,29 @@ from an earlier attempt can't send you at a run that has since gone green (#3762
 the head is genuinely red; exit 2 means it was **unreadable**, which is not "nothing is failing":
 
 ```bash
-CHECKS="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli checks"
-CI_JSON="$($CHECKS read --pr "$PR" --expect red 2>/dev/null)"; rc=$?
-CONCLUSION="$(printf '%s' "$CI_JSON" | jq -r '.conclusion? // empty' 2>/dev/null)"
-case "$rc:$CONCLUSION" in
-  0:red)     ;;   # genuinely red — resolve the failing check's run below
-  1:green)   echo "heal-ci: head is green — nothing to classify"; exit 0 ;;
-  1:pending) ;;   # not red yet — take the running/wedged branch below
-  *)         echo "heal-ci: head CI unreadable — re-dispatch once the API answers; an unreadable head is not a green one (#3999)" >&2; exit 1 ;;
-esac
+# prints `CONTEXT=<name> JOB=<id> RUN=<id>` on exit 0. Exit 3 green · 4 pending · 5 not-an-Actions-check
+# · 1 unreadable. READ THE STATUS BEFORE THE STDOUT — an unreadable head is not a green one.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/resolve-failing-run.sh" "$PR"
 ```
 
-**A pending head is two different facts, and only one of them is yours.** `.running` is genuinely
-in flight and settles on its own — there is no failure to classify yet, so stop and say so.
+One script, because the three fences this replaces shared a `$CI_JSON` that **never survived**: each
+agent shell invocation is a fresh process, so the second and third re-read an empty variable and the
+resolution was hand-stitched per call (epic #4435, story 1). The three facts it decides between:
+
+**A pending head (exit 4) is two different facts, and only one of them is yours.** `.running` is
+genuinely in flight and settles on its own — there is no failure to classify yet, so stop and say so.
 `.wedged` is stranded in the queue (`status: queued`, `started_at` still null): a run that never
 starts, so it has produced **no log body** to match the taxonomy against, and rerunning it is not
 the lever. Report the stranded contexts by name and stop — an operator, not a rerun, unwedges it.
 Collapsing the two is the defect #3999 removed from the merge gate; don't reintroduce it here.
 
-```bash
-jq -r '.running | join(", ")' <<<"$CI_JSON"   # still in flight — wait, don't classify
-jq -r '.wedged  | join(", ")' <<<"$CI_JSON"   # queued, never started — report, don't rerun
-```
-
-On a red head, take one failing context (one routed action per invocation) and resolve its run
-id. **For a GitHub Actions check run, the check-run `id` IS the Actions job id** — verified live
+On a red head the script takes one failing context (one routed action per invocation) and resolves its
+run id. **For a GitHub Actions check run, the check-run `id` IS the Actions job id** — verified live
 on this repo: check run `89736644366` reads back at `actions/jobs/89736644366` with
 `run_id: 30180715802`, the same pair its `details_url` spells out. So one REST hop yields both
-`JOB` (what the log fallback above needs) and `RUN`:
+`JOB` (what the log fallback above needs) and `RUN`.
 
-```bash
-FAILING="$(jq -r '.failing[0] // empty' <<<"$CI_JSON")"
-HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
-# The check-runs endpoint returns an object per page, so --slurp is what makes a busy head (>100
-# runs) parseable at all. Pick the latest run for the named context — later `started_at` wins,
-# ties fall back to the id — the same recency order the rollup used to name it.
-JOB="$(gh api --paginate --slurp "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
-  | jq -r --arg name "$FAILING" '[.[].check_runs[]
-      | select(.name == $name and .app.slug == "github-actions")]
-      | sort_by(.started_at // "", .id) | last | .id // empty')"
-RUN="$(gh api "repos/$REPO/actions/jobs/$JOB" --jq '.run_id')"
-```
-
-An empty `JOB` means the failing context is **not** a GitHub Actions check (a third-party app's
+**Exit 5** means the failing context is **not** a GitHub Actions check (a third-party app's
 check run has no Actions job and no log to read). Don't guess at it: file it via `report` as an
 unknown, naming the context, and stop.
 
@@ -145,11 +149,9 @@ the one-rerun rule hold across invocations (this skill is per-invocation memoryl
 but the run/PR state itself remembers a prior rerun). Read two facts:
 
 ```bash
-# 1) the run's own attempt count: a rerun bumps `attempt` to 2+
-ATTEMPT=$(gh run view $RUN --json attempt --jq '.attempt')
-# 2) a prior heal-ci rerun marker on the PR (if this is a PR run)
-gh api repos/$REPO/issues/$PR/comments --jq \
-  '[.[] | select(.body | test("heal-ci:.*rerun queued"))] | length'
+# prints `attempt=<n> rerun-markers=<n>`. A non-zero exit means a read did not land — UNKNOWN, and
+# UNKNOWN is never "not yet rerun". READ THE STATUS BEFORE THE NUMBERS.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/already-rerun.sh" "$RUN" "$PR"
 ```
 
 **The one-rerun rule (canonical statement — every later step points here).** A flake gets
@@ -221,13 +223,13 @@ reads back (without it, the cross-invocation one-rerun rule rests only on `attem
 manual rerun can also bump):
 
 ```bash
-gh run rerun $RUN --failed
-# on a PR run, write the marker Step 1's already-rerun detector queries:
-gh api repos/$REPO/issues/$PR/comments \
-  -f body="heal-ci: <signature> — rerun queued (run $RUN). One rerun only; a recurring failure becomes a defect."
+# reruns the failed jobs, then — on a PR run — writes the marker Step 1's detector queries. Omit the
+# PR argument on a non-PR run. A failed rerun writes NO marker.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/rerun-once.sh" \
+  "$RUN" "<signature>" "$PR"
 ```
 
-This marker string and Step 1's `test("heal-ci:.*rerun queued")` grep are a paired contract — change the phrasing here and you must update the matcher there (same discipline ship-it uses for its `review-code:` / `review-doc:` anchors).
+The marker string the script writes and Step 1's `test("heal-ci:.*rerun queued")` grep are a paired contract — change the phrasing in [`scripts/rerun-once.sh`](scripts/rerun-once.sh) and you must update the matcher in [`scripts/already-rerun.sh`](scripts/already-rerun.sh) (same discipline ship-it uses for its `review-code:` / `review-doc:` anchors).
 
 One rerun, then stop — see the canonical one-rerun rule in Step 1 for why this holds across
 invocations (the `attempt` bump + the marker you just posted are what a later invocation reads).
@@ -333,30 +335,10 @@ if [ -n "$RSHA" ] && [ -n "$RAT" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
 ;; esac; fi
 
 # the N=3 repair cap `verdict read` does NOT count: a PR already at 3 FAIL rounds is escalated to a
-# human, NOT an active repair. Author-gate the FAIL markers to write+ collaborators (ADR 0055) and
-# cluster by >120s gap — the same round identity write-code uses.
-comments_file=$(mktemp)
-gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file"
-markerAuthors=$(jq -r '[.[]
-    | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
-    | .user.login] | unique | .[]' "$comments_file")
-authorized='[]'
-while IFS= read -r a; do
-  [ -z "$a" ] && continue
-  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
-  case "$perm" in
-    admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
-  esac
-done <<<"$markerAuthors"
-ROUNDS=$(jq --argjson authorized "$authorized" \
-  '[.[] | select(.user.login | IN($authorized[]))
-        | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*FAIL"; "i"))
-        | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
-   | sort
-   | reduce .[] as $t ({n:0, prev:null};
-       if (.prev == null) or ($t - .prev) > 120
-       then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
-   | .n' "$comments_file")
+# human, NOT an active repair. The script author-gates the FAIL markers to write+ collaborators
+# (ADR 0055) and clusters by >120s gap — the same round identity write-code uses. A non-zero exit is
+# UNKNOWN, never 0 rounds; read the status before the number.
+ROUNDS="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/repair-rounds.sh" "$PR")" || exit 1
 ```
 
 If `VERDICT_UNKNOWN=1` the verdict never resolved (a GitHub read failure, not a verdict) — **defer
@@ -374,8 +356,8 @@ with the `Filed #N` comment the no-repair path posts, but routed to the in-fligh
 of a fresh issue — and stop. That comment *is* your one routed action for this invocation:
 
 ```bash
-gh api repos/$REPO/issues/$PR/comments \
-  -f body="heal-ci: CI red — <signature>. Active write-code repair in flight (latest gate verdict FAIL); not filing a twin. Run <run url> — fold into the in-flight fix."
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/comment-active-repair.sh" \
+  "$PR" "<signature>" "<run url>"
 ```
 
 Report: `defect: <signature> — active repair on #$PR, routed (no twin filed)`. Otherwise — no
@@ -406,8 +388,9 @@ that real number — never post the `Filed #<N>` line with an unresolved `<N>` p
 
 ```bash
 N=<the .number report returned>
-gh api repos/$REPO/issues/$PR/comments \
-  -f body="heal-ci: CI red — <signature>. Filed #$N (needs-triage). Not merged."
+# refuses a non-numeric N, so the `Filed #<N>` line can never post with an unresolved placeholder
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/comment-filed.sh" \
+  "$PR" "$N" "<signature>"
 ```
 
 ### Unknown → file via `report`, flagged unknown

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/already-rerun.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/already-rerun.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# The two facts the stateless one-rerun guard reads: the run's own attempt count, and how many prior
+# `heal-ci: … rerun queued` markers sit on the PR.
+#
+# usage: already-rerun.sh <run-id> [pr]
+#
+# Prints `attempt=<n> rerun-markers=<n>` (markers=n/a with no PR). It DERIVES NOTHING: the one-rerun
+# rule is a decision and it stays in the skill's prose, which is the canonical statement (ADR 0228 —
+# a script relays, it never derives the decision).
+#
+# FAIL-CLOSED, and this one matters: the caller reads `attempt=1 rerun-markers=0` as "not yet rerun,
+# so rerun it". A read that could not run must therefore never arrive as a zero — it exits non-zero
+# with its own line on stdout, and the prose reads the status before the numbers (§ZS / ADR 0092).
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "heal-ci: already-rerun.sh needs a run id — the guard did NOT run (UNKNOWN, never 'not yet rerun')."; echo "usage: already-rerun.sh <run-id> [pr]" >&2; exit 2; }
+RUN="$1"
+PR="${2:-}"
+
+# 1) the run's own attempt count: a rerun bumps `attempt` to 2+
+ATTEMPT=$(gh run view "$RUN" --json attempt --jq '.attempt')
+[ -n "$ATTEMPT" ] || { echo "heal-ci: could not read run $RUN's attempt count — UNKNOWN, never 'not yet rerun'."; exit 1; }
+
+MARKERS="n/a"
+if [ -n "$PR" ]; then
+	REPO="$(kp_repo)" || { echo "heal-ci: target repo unresolved — the PR rerun-marker count did NOT run (UNKNOWN)."; exit 1; }
+	# 2) a prior heal-ci rerun marker on the PR (if this is a PR run)
+	MARKERS=$(gh api "repos/$REPO/issues/$PR/comments" --jq \
+		'[.[] | select(.body | test("heal-ci:.*rerun queued"))] | length')
+	[ -n "$MARKERS" ] || { echo "heal-ci: could not read PR #$PR's comments — the marker count is UNKNOWN, never 0."; exit 1; }
+fi
+
+printf 'attempt=%s rerun-markers=%s\n' "$ATTEMPT" "$MARKERS"

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/comment-active-repair.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/comment-active-repair.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# An active write-code repair is in flight: route the red run to it instead of filing a twin defect.
+# This comment IS the invocation's one routed action.
+#
+# usage: comment-active-repair.sh <pr> <signature> <run-url>
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "heal-ci: comment-active-repair.sh needs <pr> <signature> <run-url> — NOTHING was routed, so the red run is still unrouted."; echo "usage: comment-active-repair.sh <pr> <signature> <run-url>" >&2; exit 2; }
+PR="$1"
+SIGNATURE="$2"
+RUN_URL="$3"
+REPO="$(kp_repo)" || { echo "heal-ci: target repo unresolved — NOTHING was routed."; exit 1; }
+
+gh api "repos/$REPO/issues/$PR/comments" \
+	-f body="heal-ci: CI red — $SIGNATURE. Active write-code repair in flight (latest gate verdict FAIL); not filing a twin. Run $RUN_URL — fold into the in-flight fix." >/dev/null ||
+	{ echo "heal-ci: the routing comment did NOT post on #$PR — the red run is UNROUTED; do not report it as routed."; exit 1; }
+
+printf 'defect: %s — active repair on #%s, routed (no twin filed)\n' "$SIGNATURE" "$PR"

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/comment-filed.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/comment-filed.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Point a PR at the defect `report` just filed, so write-code's fix loop can pick it up.
+#
+# usage: comment-filed.sh <pr> <filed-issue-number> <signature>
+#
+# The issue number is a REQUIRED argument, and a non-numeric one is refused: the `Filed #<N>` line must
+# never post with an unresolved placeholder, which is why the skill's prose says to capture the number
+# `report` returns FIRST and compose with that real number.
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "heal-ci: comment-filed.sh needs <pr> <filed-issue-number> <signature> — NOTHING was posted."; echo "usage: comment-filed.sh <pr> <filed-issue-number> <signature>" >&2; exit 2; }
+PR="$1"
+N="$2"
+SIGNATURE="$3"
+case "$N" in
+	'' | *[!0-9]*)
+		echo "heal-ci: '$N' is not an issue number — refusing to post a \`Filed #<N>\` line with an unresolved placeholder. NOTHING was posted."
+		exit 2
+		;;
+esac
+REPO="$(kp_repo)" || { echo "heal-ci: target repo unresolved — NOTHING was posted."; exit 1; }
+
+gh api "repos/$REPO/issues/$PR/comments" \
+	-f body="heal-ci: CI red — $SIGNATURE. Filed #$N (needs-triage). Not merged." >/dev/null ||
+	{ echo "heal-ci: the \`Filed #$N\` comment did NOT post on #$PR — write-code's fix loop has no pointer; do not report it as routed."; exit 1; }
+
+printf 'defect: %s — filed #%s, pointed from #%s\n' "$SIGNATURE" "$N" "$PR"

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/failed-logs.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/failed-logs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The failed run's logs plus the job/step rollup that names which job died (and its databaseId, for
+# the job-log fallback).
+#
+# usage: failed-logs.sh <run-id>
+#
+# EMPTY `--log-failed` OUTPUT IS A DOCUMENTED POSITIVE ANSWER in the caller's prose ("if it returns
+# nothing … fall back to the failed job's full log"), so a read that COULD NOT RUN must not arrive as
+# the same emptiness — it would send the caller down the fallback with no way to tell a bare `exit 1`
+# run from a dead API. Each read therefore prints its own fail-closed line on stdout and exits
+# non-zero; read the exit status before the stdout (§ZS / ADR 0092).
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+
+[ "$#" -ge 1 ] || { echo "heal-ci: failed-logs.sh needs a run id — no logs read (UNKNOWN, not 'no failed steps')."; echo "usage: failed-logs.sh <run-id>" >&2; exit 2; }
+RUN="$1"
+
+gh run view "$RUN" --log-failed || {
+	echo "heal-ci: could not read run $RUN's failed logs — UNKNOWN, NOT 'no annotated failed steps'."
+	exit 1
+}
+# the job/step rollup, to know which job died (and its databaseId, for the fallback below)
+gh run view "$RUN" --json conclusion,headBranch,jobs \
+	--jq '{conclusion, headBranch, jobs: [.jobs[] | select(.conclusion=="failure") | {name, databaseId, steps: [.steps[] | select(.conclusion=="failure") | .name]}]}' || {
+	echo "heal-ci: could not read run $RUN's job rollup — UNKNOWN, so no failed job databaseId is available."
+	exit 1
+}

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/job-log.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/job-log.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# The failed job's FULL log, for when `--log-failed` returned nothing. Grep/scope it to the failed
+# step's output yourself — the taxonomy match needs the actual log body, never step names alone.
+#
+# usage: job-log.sh <failed-job-databaseId>
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "heal-ci: job-log.sh needs a job databaseId — no log body read."; echo "usage: job-log.sh <failed-job-databaseId>" >&2; exit 2; }
+JOB="$1"
+REPO="$(kp_repo)" || { echo "heal-ci: target repo unresolved — no log body read (UNKNOWN)."; exit 1; }
+
+gh api "repos/$REPO/actions/jobs/$JOB/logs" || {
+	echo "heal-ci: could not read job $JOB's log — UNKNOWN, and you cannot match the taxonomy without a log body."
+	exit 1
+}

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/repair-rounds.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/repair-rounds.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# The N=3 FAIL-round count that `pipeline-cli verdict read` does NOT do — it resolves the latest
+# verdict, it does not count rounds. A PR already at 3 FAIL rounds is escalated to a human, NOT an
+# active repair, so the twin-suppression guard counts the rounds itself.
+#
+# usage: repair-rounds.sh <pr>
+#
+# Prints the round count on stdout. Author-gated to write+ collaborators (ADR 0055) so a forged
+# `review-*: FAIL` cannot inflate it, and clustered by >120s gap — the same round identity write-code
+# uses (a both-namespace round counts once).
+#
+# FAIL-CLOSED: the caller reads `ROUNDS < 3` as "not escalated", which is the branch that can SUPPRESS
+# a defect filing. A count that could not be read must therefore never arrive as 0 — it exits non-zero
+# with its own line on stdout, and the prose reads the status before the number (§ZS / ADR 0092). An
+# empty authorized set legitimately counts zero rounds; that is fail-closed in the other direction
+# (zero rounds means "not capped", so the guard falls through to filing rather than suppressing).
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "heal-ci: repair-rounds.sh needs a PR number — the round count did NOT run (UNKNOWN, never 0)."; echo "usage: repair-rounds.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || { echo "heal-ci: target repo unresolved — the round count did NOT run (UNKNOWN, never 0)."; exit 1; }
+
+comments_file=$(mktemp)
+gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file" || {
+	rm -f "$comments_file"
+	echo "heal-ci: could not read PR #$PR's comments — the FAIL-round count is UNKNOWN, never 0."
+	exit 1
+}
+markerAuthors=$(jq -r '[.[]
+    | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
+    | .user.login] | unique | .[]' "$comments_file")
+authorized='[]'
+while IFS= read -r a; do
+	[ -z "$a" ] && continue
+	perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
+	case "$perm" in
+		admin | maintain | write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
+	esac
+done <<<"$markerAuthors"
+ROUNDS=$(jq --argjson authorized "$authorized" \
+	'[.[] | select(.user.login | IN($authorized[]))
+        | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*FAIL"; "i"))
+        | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
+   | sort
+   | reduce .[] as $t ({n:0, prev:null};
+       if (.prev == null) or ($t - .prev) > 120
+       then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
+   | .n' "$comments_file")
+rm -f "$comments_file"
+[ -n "$ROUNDS" ] || { echo "heal-ci: the FAIL-round reduction produced no count — UNKNOWN, never 0."; exit 1; }
+
+printf '%s\n' "$ROUNDS"

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/rerun-once.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/rerun-once.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Rerun the failed jobs exactly ONCE and — on a PR run — write the durable marker the one-rerun guard
+# reads back. Reach this only when the `already-rerun` flag is NOT set; the rule itself lives in the
+# skill's prose (ADR 0228).
+#
+# usage: rerun-once.sh <run-id> <signature> [pr]
+#
+# The marker body below and `already-rerun.sh`'s `test("heal-ci:.*rerun queued")` grep are a PAIRED
+# CONTRACT: change the phrasing here and you must update the matcher there. Extraction moved both
+# halves out of prose, so the pair is now two files instead of two fences — the coupling is unchanged.
+#
+# The rerun is attempted BEFORE the marker on purpose, and a failed rerun does not write one: a marker
+# with no rerun behind it would make a later invocation refuse to rerun a run that never was.
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "heal-ci: rerun-once.sh needs a run id and a signature — nothing was rerun."; echo "usage: rerun-once.sh <run-id> <signature> [pr]" >&2; exit 2; }
+RUN="$1"
+SIGNATURE="$2"
+PR="${3:-}"
+
+gh run rerun "$RUN" --failed || { echo "heal-ci: rerun of run $RUN FAILED — no marker written, nothing was queued."; exit 1; }
+
+if [ -n "$PR" ]; then
+	REPO="$(kp_repo)" || { echo "heal-ci: run $RUN was rerun but the target repo is unresolved — the marker is MISSING; write it by hand before re-invoking."; exit 1; }
+	# on a PR run, write the marker the already-rerun detector queries:
+	gh api "repos/$REPO/issues/$PR/comments" \
+		-f body="heal-ci: $SIGNATURE — rerun queued (run $RUN). One rerun only; a recurring failure becomes a defect." >/dev/null ||
+		{ echo "heal-ci: run $RUN was rerun but the marker comment did NOT post — the cross-invocation guard now rests on \`attempt\` alone."; exit 1; }
+fi
+
+printf 'rerun queued (run %s): %s — will not retry again\n' "$RUN" "$SIGNATURE"

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/resolve-failing-run.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/resolve-failing-run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Entering from a PR: resolve the failing run. Reads the head's CI state through
+# `pipeline-cli checks read` (REST check-runs, rolled up latest-per-context, so a superseded red from
+# an earlier attempt can't send you at a run that has since gone green — #3762), then resolves the
+# first failing context's Actions job id and run id in one REST hop.
+#
+# usage: resolve-failing-run.sh <pr>
+#
+# EXIT CODES — read the status BEFORE the stdout (§ZS / ADR 0092). Each is a different fact and the
+# caller's prose routes on it; none of them is "nothing is failing":
+#   0  red   — stdout `CONTEXT=<name> JOB=<id> RUN=<id>`; go match the taxonomy
+#   3  green — nothing to classify, stop
+#   4  pending — stdout `running: …` / `wedged: …`; wait (running) or report the stranded contexts
+#      (wedged). Rerunning a wedged run is not the lever, and it has produced no log body at all.
+#   5  the failing context is NOT a GitHub Actions check — no job, no log; file it via `report` as an
+#      unknown, naming the context, and stop
+#   1  unreadable — UNKNOWN, which is NOT a green head (#3999)
+#   2  usage
+#
+# THREE FENCES COLLAPSE HERE, and that is the point. The `$CI_JSON` the second and third fences read
+# was set by the first, in a DIFFERENT agent shell process — so it was always empty by the time they
+# ran, and the resolution was hand-stitched per call. Folding the three into one process is what makes
+# the cross-block state survive (epic #4435, story 1); every moved line is otherwise byte-faithful.
+# One further seam: the green arm's in-shell `echo … ; exit 0` becomes exit 3, because a script's
+# exit 0 means "keep going" to its caller and would read as a red head.
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "heal-ci: resolve-failing-run.sh needs a PR number — head CI NOT read (UNKNOWN, not green)."; echo "usage: resolve-failing-run.sh <pr>" >&2; exit 2; }
+PR="$1"
+PCLI="$(kp_pcli)" || { echo "heal-ci: the CLI shim is unresolved — head CI NOT read (UNKNOWN, not green)."; exit 1; }
+REPO="$(kp_repo)" || { echo "heal-ci: target repo unresolved — head CI NOT read (UNKNOWN, not green)."; exit 1; }
+
+CI_JSON="$("$PCLI" checks read --pr "$PR" --expect red 2>/dev/null)"; rc=$?
+CONCLUSION="$(printf '%s' "$CI_JSON" | jq -r '.conclusion? // empty' 2>/dev/null)"
+case "$rc:$CONCLUSION" in
+	0:red) ;; # genuinely red — resolve the failing check's run below
+	1:green)
+		echo "heal-ci: head is green — nothing to classify"
+		exit 3
+		;;
+	1:pending)
+		# A pending head is TWO different facts and only one of them is heal-ci's. `.running` settles
+		# on its own — there is no failure to classify yet. `.wedged` is stranded in the queue
+		# (`status: queued`, `started_at` still null): it has produced NO log body, and an operator,
+		# not a rerun, unwedges it. Collapsing the two is the defect #3999 removed from the merge gate.
+		printf 'running: %s\n' "$(jq -r '.running | join(", ")' <<<"$CI_JSON")"
+		printf 'wedged: %s\n' "$(jq -r '.wedged  | join(", ")' <<<"$CI_JSON")"
+		exit 4
+		;;
+	*)
+		echo "heal-ci: head CI unreadable — re-dispatch once the API answers; an unreadable head is not a green one (#3999)"
+		exit 1
+		;;
+esac
+
+# Take ONE failing context (one routed action per invocation) and resolve its run id. For a GitHub
+# Actions check run the check-run `id` IS the Actions job id, so one REST hop yields both JOB and RUN.
+FAILING="$(jq -r '.failing[0] // empty' <<<"$CI_JSON")"
+[ -n "$FAILING" ] || { echo "heal-ci: head reported red with no named failing context — UNKNOWN, not green."; exit 1; }
+HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+[ -n "$HEAD_SHA" ] || { echo "heal-ci: could not read PR #$PR's head SHA — UNKNOWN."; exit 1; }
+# The check-runs endpoint returns an object per page, so --slurp is what makes a busy head (>100
+# runs) parseable at all. Pick the latest run for the named context — later `started_at` wins,
+# ties fall back to the id — the same recency order the rollup used to name it.
+JOB="$(gh api --paginate --slurp "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
+	| jq -r --arg name "$FAILING" '[.[].check_runs[]
+			| select(.name == $name and .app.slug == "github-actions")]
+			| sort_by(.started_at // "", .id) | last | .id // empty')"
+# An empty JOB means the failing context is NOT a GitHub Actions check (a third-party app's check run
+# has no Actions job and no log to read). Don't guess at it.
+[ -n "$JOB" ] || { echo "CONTEXT=$FAILING JOB= — not a GitHub Actions check: no job, no log. File it via report as an unknown, naming the context."; exit 5; }
+RUN="$(gh api "repos/$REPO/actions/jobs/$JOB" --jq '.run_id')"
+[ -n "$RUN" ] || { echo "CONTEXT=$FAILING JOB=$JOB — could not resolve the job's run_id (UNKNOWN)."; exit 1; }
+
+printf 'CONTEXT=%s JOB=%s RUN=%s\n' "$FAILING" "$JOB" "$RUN"

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/resolve-repo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print the target repo as `owner/name` (§Target repo resolution, ADR 0062 §1).
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+kp_repo

--- a/claude-plugins/kampus-pipeline/skills/release/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/release/SKILL.md
@@ -70,11 +70,13 @@ You need two things before the ritual:
    touch a flag:
 
    ```bash
-   cd packages/anka-ops
-   node src/bin.ts auth status   # reports where each credential resolves from and whether it authenticates
+   # reports where each credential resolves from and whether it authenticates
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/auth-status.sh"
    ```
 
-   If `auth status` reports the effective resolution does **not** authenticate, run
+   **Read its exit status before its output.** A non-zero exit means the pre-flight never ran, which is
+   UNKNOWN and not "credentials fine" — the absence of a failure line is only reassuring on exit 0. If
+   `auth status` reports the effective resolution does **not** authenticate, run
    `node src/bin.ts auth login` (prompts for the token + account id, validates them against an
    authenticated read **before** persisting, stores both in the Keychain) and re-check. Do not
    proceed on unauthenticated credentials — every step below would fail mid-ritual.

--- a/claude-plugins/kampus-pipeline/skills/release/scripts/auth-status.sh
+++ b/claude-plugins/kampus-pipeline/skills/release/scripts/auth-status.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Report where each anka-ops credential resolves from and whether it authenticates — the Step-0
+# credential pre-flight.
+#
+# usage: auth-status.sh
+#
+# Relays anka-ops' own output and exit status; it derives no release decision (ADR 0228). A non-zero
+# exit means the pre-flight never landed — UNKNOWN, never "credentials fine". The prose reads the ABSENCE
+# of a "does not authenticate" line as permission to proceed, so each locate/cd failure prints its own
+# refusal on stdout rather than exiting silent (§ZS / ADR 0092; the #4485 class).
+#
+# Extracted from release/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=./lib.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+ANKA="$(release_anka_ops_dir)" || { echo "release: the flag lever is unlocatable — credentials NOT checked (UNKNOWN, never 'fine'). Do not touch a flag."; exit 1; }
+cd "$ANKA" || { echo "release: could not enter the flag lever's package — credentials NOT checked (UNKNOWN, never 'fine'). Do not touch a flag."; exit 1; }
+node src/bin.ts auth status

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-working-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-working-diff.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# §CP self-check over your OWN uncommitted work, before you open the PR: classify every path in
+# `git diff --name-only origin/main...`. Proven-ordinary ⇒ exit 3. control-plane ⇒ exit 0 ⇒ something
+# under your diff is owned; find it.
+#
+# usage: cp-classify-working-diff.sh
+#
+# This lives in `shared/scripts/` and not under a `<skill>/scripts/` directory because its caller,
+# `../../taste-library-conventions.md`, is a CROSS-SKILL standards doc — it governs every `taste-*`
+# skill and owns no skill directory of its own. It is `.sh` under `skills/`, which is the property that
+# matters: `.github/CODEOWNERS` gates `/claude-plugins/kampus-pipeline/skills/**/*.sh` to
+# @kamp-us/control-plane and §CP's CONTROL_PLANE_RE carries the matching branch (ADR 0174), so no new
+# destination is invented and no ungated window opens (#4446).
+#
+# Relays the verb's own exit status (ADR 0228); it derives no §CP answer. A non-zero-and-not-3 exit
+# means the classification never ran — UNKNOWN, never "ordinary".
+#
+# Extracted from taste-library-conventions.md (#4454, epic #4435 phase 1).
+set -uo pipefail
+# shellcheck source=../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../lib" && pwd)/common.sh"
+
+PCLI="$(kp_pcli)" || { echo "BLOCKING (§CP classifier could not run — the CLI shim is unresolved; UNKNOWN, never 'ordinary')"; exit 1; }
+
+git diff --name-only origin/main... | "$PCLI" cp-classify classify

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/extraction-coverage-proof.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/extraction-coverage-proof.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# THE ZERO-COVERAGE-DELTA PROOF for epic #4435's extractions, as a runnable harness rather than a table
+# in a PR body. Extraction moves content out of one scan surface and into another; a guard that follows
+# the markdown but not the `.sh` stays GREEN while guarding nothing (#4470, and the two rows PR #4492
+# had to correct from "preserved" to "narrowed"). A table asserting the delta cannot be re-run at the
+# next SHA. This can.
+#
+# usage: extraction-coverage-proof.sh <moved-file...>
+#
+# It proves TWO different things, and they are not interchangeable:
+#   1. SCOPE — each guard actually admits every handed `.sh` into its scanned surface, read off the
+#      guard's own emitted scope line rather than inferred from a clean exit. A clean exit over zero
+#      scanned files is the false green this harness exists to catch.
+#   2. TEETH — each guard REDS on planted bait in a `.sh`, so "clean" is a finding about the files and
+#      not about the matcher. A row that cannot be made to fail is not a guard.
+#
+# The bait strings are ASSEMBLED AT RUN TIME from fragments, never written as literals: a literal
+# user-home path or a literal bare CLI token in this file would be a real finding in the very corpus the
+# guards scan, and papering over it with a `DOC_SELF_EXEMPT` entry would weaken the guard to test it
+# (the trap PR #4503 fell into, #4517). No exemption is needed, and none is requested.
+#
+# `set -uo pipefail` without `-e`, and NO `EXIT` trap: every probe's exit status is the datum, `errexit`
+# would abort on the first (expected) red, and on bash 3.2 a `set -u` abort reaching an `EXIT` trap
+# yields exit **0** — a fail-closed harness exiting clean having printed its FAIL (#4476, class #4479).
+set -uo pipefail
+
+[ "$#" -ge 1 ] || {
+	echo "extraction-coverage-proof: no files handed — ZERO SCOPE, which is a failure and NOT a zero-delta proof (§ZS / ADR 0092)."
+	echo "usage: extraction-coverage-proof.sh <moved-file...>" >&2
+	exit 2
+}
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "extraction-coverage-proof: not inside a git repository — NOTHING was proven."; exit 1; }
+PCLI="$ROOT/claude-plugins/kampus-pipeline/bin/pipeline-cli"
+[ -x "$PCLI" ] || { echo "extraction-coverage-proof: the CLI shim is not executable at the in-repo path — NOTHING was proven (UNKNOWN, never 'clean')."; exit 1; }
+
+WORK="$(mktemp -d)" || { echo "extraction-coverage-proof: could not create a work dir — NOTHING was proven."; exit 1; }
+FAILS=0
+
+# Every probe below runs the guard UNPIPED and reads its raw exit status. Never through a pipe or
+# `xargs`, both of which remap the status these rows rest on (the #4485 lesson).
+#
+# assert_rc <label> <expected-rc> -- <cmd...>: exact status match.
+assert_rc() {
+	label="$1"
+	want="$2"
+	shift 2
+	[ "$1" = "--" ] && shift
+	"$@" >"$WORK/out" 2>"$WORK/err"
+	got=$?
+	if [ "$got" = "$want" ]; then
+		printf 'ok    %-58s rc=%s\n' "$label" "$got"
+	else
+		printf 'FAIL  %-58s rc=%s (want %s)\n' "$label" "$got" "$want"
+		FAILS=$((FAILS + 1))
+	fi
+}
+
+# assert_red <label> <needle> -- <cmd...>: non-zero exit AND the named violation on the output. Both
+# halves are required, because these guards ALSO fail closed on a per-surface zero scope (exit 3) — so a
+# bare "non-zero" would pass a teeth row that never looked at the bait at all. That is why every teeth
+# probe below hands the bait TOGETHER WITH a real corpus `.md`: it keeps every surface non-empty, so the
+# only thing left that can red the run is the bait.
+assert_red() {
+	label="$1"
+	needle="$2"
+	shift 2
+	[ "$1" = "--" ] && shift
+	"$@" >"$WORK/out" 2>"$WORK/err"
+	got=$?
+	if [ "$got" -ne 0 ] && grep -q -- "$needle" "$WORK/out" "$WORK/err"; then
+		printf 'ok    %-58s rc=%s, reported: %s\n' "$label" "$got" "$needle"
+	else
+		printf 'FAIL  %-58s rc=%s, did NOT report: %s\n' "$label" "$got" "$needle"
+		FAILS=$((FAILS + 1))
+	fi
+}
+
+# assert_scope <label> <needle> -- <cmd...>: the guard's own emitted scope line must contain <needle>.
+# This is the row that catches a NARROWED surface: a guard can exit clean while its scope line says it
+# scanned zero of the files it was handed.
+assert_scope() {
+	label="$1"
+	needle="$2"
+	shift 2
+	[ "$1" = "--" ] && shift
+	"$@" >"$WORK/out" 2>"$WORK/err"
+	if grep -q -- "$needle" "$WORK/out" "$WORK/err"; then
+		printf 'ok    %-58s scope contains: %s\n' "$label" "$needle"
+	else
+		printf 'FAIL  %-58s scope does NOT contain: %s\n' "$label" "$needle"
+		FAILS=$((FAILS + 1))
+	fi
+}
+
+SH_COUNT=0
+MD_COUNT=0
+COMPANION_MD=""
+for f in "$@"; do
+	[ -f "$f" ] || { echo "extraction-coverage-proof: '$f' does not exist — the handed set is wrong, so NOTHING is proven."; rm -rf "$WORK"; exit 1; }
+	case "$f" in
+		*.sh) SH_COUNT=$((SH_COUNT + 1)) ;;
+		*.md)
+			MD_COUNT=$((MD_COUNT + 1))
+			[ -n "$COMPANION_MD" ] || COMPANION_MD="$f"
+			;;
+	esac
+done
+[ "$SH_COUNT" -gt 0 ] || { echo "extraction-coverage-proof: not one .sh among the handed files — there is no extracted surface to prove coverage over."; rm -rf "$WORK"; exit 1; }
+[ -n "$COMPANION_MD" ] || { echo "extraction-coverage-proof: no .md among the handed files — the teeth probes need one to keep the markdown surface non-empty, so NOTHING is proven."; rm -rf "$WORK"; exit 1; }
+printf 'handed: %d file(s) — %d .sh, %d .md (teeth companion: %s)\n\n' "$#" "$SH_COUNT" "$MD_COUNT" "$COMPANION_MD"
+
+echo '--- 1. SCOPE: every handed .sh enters each guard'"'"'s scanned surface ---'
+assert_scope "leak-guard: .sh is a scanned surface" "$SH_COUNT shell surface" -- "$PCLI" leak-guard scan "$@"
+assert_scope "cli-invocation-guard: .sh is an implicit fence" "$SH_COUNT shell file(s) as implicit fences" -- "$PCLI" cli-invocation-guard check "$@"
+assert_scope "gh-phoenix lint-skills: .sh in the gh-call scan" "gh-call scan scanned $# file(s)" -- "$PCLI" gh-phoenix lint-skills "$@"
+
+echo
+echo '--- 2. TEETH: each guard REDS on planted bait in a .sh ---'
+# A user-home absolute path, assembled so this file carries no such literal.
+BAIT_HOME="$WORK/bait-home.sh"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf 'X=/%s/%s/code/thing\n' Users someone
+} >"$BAIT_HOME"
+assert_red "leak-guard reds a home path in a .sh" "bait-home.sh" -- "$PCLI" leak-guard scan "$BAIT_HOME" "$COMPANION_MD"
+
+# A bare CLI invocation, token assembled from fragments for the same reason.
+CLI_TOKEN="pipeline""-cli"
+BAIT_CLI="$WORK/bait-cli.sh"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf '%s tracker create-issue\n' "$CLI_TOKEN"
+} >"$BAIT_CLI"
+assert_red "cli-invocation-guard reds a bare CLI call in a .sh" "bait-cli.sh" -- "$PCLI" cli-invocation-guard check "$BAIT_CLI" "$COMPANION_MD"
+
+BAIT_GQL="$WORK/bait-graphql.sh"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf 'gh api %s -f query=%s\n' graphql '"{viewer{login}}"'
+} >"$BAIT_GQL"
+assert_red "lint-skills reds a GraphQL gh call in a .sh" "bait-graphql.sh" -- "$PCLI" gh-phoenix lint-skills "$BAIT_GQL" "$COMPANION_MD"
+
+echo
+echo '--- 3. The handed files themselves are clean on every surface above ---'
+assert_rc "leak-guard clean over the handed set" 0 -- "$PCLI" leak-guard scan "$@"
+assert_rc "cli-invocation-guard clean over the handed set" 0 -- "$PCLI" cli-invocation-guard check "$@"
+assert_rc "lint-skills clean over the handed set" 0 -- "$PCLI" gh-phoenix lint-skills "$@"
+
+rm -rf "$WORK"
+echo
+printf 'violations: %d\n' "$FAILS"
+[ "$FAILS" -eq 0 ] || { echo "extraction-coverage-proof: FAILED — at least one guard neither scans the extracted surface nor reds on it."; exit 1; }
+echo "extraction-coverage-proof: OK — every guard admits the extracted .sh into its surface AND reds on planted bait there."

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/skill-shell-census.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/skill-shell-census.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# THE CORPUS RE-COUNT — epic #4435's done-proof, as a committed runnable harness rather than a recipe
+# pasted into a PR body (#4454 AC5: the fence matcher must be reproducible by a reviewer against the
+# merged tree, and a matcher that lives only in prose cannot be re-run at the next SHA).
+#
+# usage: skill-shell-census.sh [<skills-dir>]
+#
+# Prints one `blocks<TAB>lines<TAB>path` row per markdown file that still carries a fenced bash/sh/shell
+# block, then a `TOTAL` row. Files with zero blocks are omitted from the rows and counted in the scanned
+# total, so "no rows" and "nothing scanned" are distinguishable.
+#
+# THE MATCHER, stated once so a reader need not infer it from the awk: a block opens at a line whose
+# first non-blank token is ``` immediately followed by `bash`, `sh` or `shell` (any trailing info string
+# is ignored) and closes at the next ``` line. Lines strictly between the fences are shell lines. It is
+# deliberately WIDER than the epic-plan recipe's `^```(bash|sh)$`, which missed an indented fence and a
+# `shell`/info-string fence — a matcher that under-counts would report a zero the corpus does not have.
+#
+# ZERO SCOPE FAILS (§ZS / ADR 0092): a run that scans no markdown files at all exits 4, because zero
+# blocks over zero files is the same output as zero blocks over the whole corpus, and that is the
+# permissive answer this harness exists to make unavailable.
+#
+# `set -uo pipefail` without `-e`, and no `EXIT` trap: on bash 3.2 a `set -u` abort that reaches an
+# `EXIT` trap yields exit **0**, so a fail-closed harness would exit clean having printed its FAIL
+# (#4476, class #4479).
+set -uo pipefail
+
+# shellcheck disable=SC1007  # `CDPATH= cd` clears CDPATH for this one command — the corpus idiom
+DEFAULT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILLS_DIR="${1:-$DEFAULT_DIR}"
+[ -d "$SKILLS_DIR" ] || { echo "skill-shell-census: '$SKILLS_DIR' is not a directory — NOTHING was scanned (§ZS: not a zero count)."; exit 2; }
+
+FILES="$(find "$SKILLS_DIR" -type f -name '*.md' | LC_ALL=C sort)"
+[ -n "$FILES" ] || { echo "skill-shell-census: no *.md under '$SKILLS_DIR' — ZERO SCOPE, which is a failure and NOT a zero-glue proof."; exit 4; }
+
+SCANNED=0
+TOTAL_BLOCKS=0
+TOTAL_LINES=0
+while IFS= read -r f; do
+	[ -n "$f" ] || continue
+	SCANNED=$((SCANNED + 1))
+	row="$(awk '
+		/^[ \t]*```/ {
+			if (!inb) {
+				lang = $0
+				sub(/^[ \t]*```[ \t]*/, "", lang)
+				sub(/[ \t].*$/, "", lang)
+				if (lang == "bash" || lang == "sh" || lang == "shell") { inb = 1; blocks++ }
+				next
+			}
+			inb = 0
+			next
+		}
+		inb { lines++ }
+		END { printf "%d\t%d\n", blocks + 0, lines + 0 }
+	' "$f")"
+	b="${row%%	*}"
+	l="${row##*	}"
+	TOTAL_BLOCKS=$((TOTAL_BLOCKS + b))
+	TOTAL_LINES=$((TOTAL_LINES + l))
+	[ "$b" -gt 0 ] && printf '%s\t%s\t%s\n' "$b" "$l" "${f#"$SKILLS_DIR"/}"
+done <<EOF
+$FILES
+EOF
+
+printf 'TOTAL\tfiles-scanned=%d\tblocks=%d\tshell-lines=%d\n' "$SCANNED" "$TOTAL_BLOCKS" "$TOTAL_LINES"

--- a/claude-plugins/kampus-pipeline/skills/taste-library-conventions.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-library-conventions.md
@@ -81,10 +81,8 @@ an existing `pipeline-cli` subcommand; if you believe a script is genuinely requ
 raise it as a scope decision. Verify before opening the PR:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-git diff --name-only origin/main... | "$PCLI" cp-classify classify
 # proven-ordinary ⇒ exit 3. control-plane ⇒ exit 0 ⇒ something under your diff is owned; find it.
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-classify-working-diff.sh"
 ```
 
 ## 4. The SKILL.md / STANDARDS.md split

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -86,6 +86,13 @@ printed its refusal. The **emission** step deliberately calls `report`'s own
 is agent-filed intake through the *same* footer and create envelope, so the two cannot drift (the
 same reason this skill already sourced `report`'s footer).
 
+**[`scripts/create-map.sh`](scripts/create-map.sh) and
+[`scripts/add-frontier-ticket.sh`](scripts/add-frontier-ticket.sh) take the body on stdin and REFUSE an
+empty one.** The fences they replace carried the body as a `$BODY` variable *inside* the block; a pipe
+makes it an external input, and an unread pipe is byte-identical to an empty one — so filing on it
+would open a bodyless map or ticket that reads as a successful chart (#3924 / #4010). That refusal is a
+guard the extraction itself owes, not a rewrite of moved glue.
+
 ## CHART mode — name the destination, map the frontier (plan-don't-do)
 
 CHART is invoked with **no map yet** (a fresh foggy idea) or **a named destination against an
@@ -191,12 +198,11 @@ plan-don't-do line, so it enters the pipeline only via emission, never as fog.
    re-lay the `## Open frontier`, but it preserves what earlier runs settled.
 
    ```bash
-   REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
-   # new map (REST only — the org bans GraphQL for issue ops):
-   MAP=$(gh api -X POST repos/$REPO/issues \
-     -f title="<destination, as a short noun phrase>" \
-     -f "labels[]=wayfinder:map" \
-     -f body="$BODY" --jq '.number')
+   # new map (REST only — the org bans GraphQL for issue ops); prints the map's issue number.
+   # The four-section body arrives on stdin from a per-run (§SP) file, because it is multi-line
+   # authored markdown; an EMPTY stdin is refused rather than filed as a bodyless map.
+   MAP="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/wayfinder/scripts/create-map.sh" \
+     "<destination, as a short noun phrase>" < "<path/to/map-body.md>")" || exit 1
    ```
 
 2. **Name the `## Destination`.** State *where we want to be* in one or two sentences, concrete
@@ -233,11 +239,10 @@ plan-don't-do line, so it enters the pipeline only via emission, never as fog.
    internal **database id** (`.id`), not its issue number:
 
    ```bash
-   CHILD_ID=$(gh api -X POST repos/$REPO/issues \
-     -f title="Investigation: <the open question>" \
-     -f "labels[]=type:investigation" \
-     -f body="<what's unknown, and what an answer would unblock>" --jq '.id')
-   gh api -X POST repos/$REPO/issues/$MAP/sub_issues -F sub_issue_id="$CHILD_ID" >/dev/null
+   # files the ticket and links it under $MAP in one act; prints the child's issue number. The body
+   # (what's unknown, and what an answer would unblock) arrives on stdin; an empty stdin is refused.
+   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/wayfinder/scripts/add-frontier-ticket.sh" \
+     "$MAP" "Investigation: <the open question>" type:investigation < "<path/to/ticket-body.md>"
    ```
 
    Frontier tickets are **wayfinder-worked, not `write-code`-pickable** — they carry no

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/scripts/add-frontier-ticket.sh
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/scripts/add-frontier-ticket.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# File one frontier ticket and link it to the map as a NATIVE sub-issue. Prints the new child's issue
+# number on stdout.
+#
+# usage: add-frontier-ticket.sh <map-issue> "<title>" <type:investigation|type:decision> < body.md
+#
+# The `sub_issues` endpoint takes the child's internal DATABASE id (`.id`), not its issue number —
+# which is why the create call reads back both.
+#
+# The body arrives on STDIN and an EMPTY stdin is REFUSED, for the same reason `create-map.sh` refuses
+# one: the fence carried the body as a literal, the pipe makes it an external input, and an unread pipe
+# is byte-identical to an empty one (#3924 / #4010).
+#
+# Extracted from wayfinder/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "wayfinder: add-frontier-ticket.sh needs <map-issue> <title> <type-label> — NO ticket was filed."; echo "usage: add-frontier-ticket.sh <map-issue> \"<title>\" <type:investigation|type:decision> < body.md" >&2; exit 2; }
+MAP="$1"
+TITLE="$2"
+TYPE="$3"
+case "$TYPE" in
+	type:investigation | type:decision) ;;
+	*)
+		echo "wayfinder: '$TYPE' is not a frontier type — the translation table admits only type:investigation and type:decision. NO ticket was filed."
+		exit 2
+		;;
+esac
+REPO="$(kp_repo)" || { echo "wayfinder: target repo unresolved — NO ticket was filed."; exit 1; }
+
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "wayfinder: stdin was empty — refusing to file a BODYLESS frontier ticket. NOTHING was filed."; exit 3; }
+
+CHILD_JSON=$(gh api -X POST "repos/$REPO/issues" \
+	-f title="$TITLE" \
+	-f "labels[]=$TYPE" \
+	-f body="$BODY" --jq '{id, number}')
+CHILD_ID=$(jq -r '.id // empty' <<<"$CHILD_JSON")
+CHILD_NUMBER=$(jq -r '.number // empty' <<<"$CHILD_JSON")
+[ -n "$CHILD_ID" ] && [ -n "$CHILD_NUMBER" ] || { echo "wayfinder: the create call returned no id/number — the ticket may or may not exist, and it is NOT linked to map #$MAP."; exit 1; }
+
+gh api -X POST "repos/$REPO/issues/$MAP/sub_issues" -F sub_issue_id="$CHILD_ID" >/dev/null ||
+	{ echo "wayfinder: filed #$CHILD_NUMBER but the sub-issue LINK to map #$MAP did NOT land — link it before charting on."; exit 1; }
+
+printf '%s\n' "$CHILD_NUMBER"

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/scripts/create-map.sh
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/scripts/create-map.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Open a new `wayfinder:map` issue. Prints the new map's issue NUMBER on stdout.
+#
+# usage: create-map.sh "<destination, as a short noun phrase>" < body.md
+#
+# REST only — the org bans GraphQL for issue ops.
+#
+# The body arrives on STDIN, and an EMPTY stdin is REFUSED: the map body is authored prose, and moving
+# it from a `$BODY` variable inside the fence to a pipe made it an external input. An unread pipe is
+# byte-identical to an empty one, so filing on it would open a bodyless map that reads as a successful
+# chart (#3924 / #4010). This guard is added because the extraction created the hazard.
+#
+# Extracted from wayfinder/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "wayfinder: create-map.sh needs a destination title — NO map was created."; echo "usage: create-map.sh \"<destination>\" < body.md" >&2; exit 2; }
+TITLE="$1"
+REPO="$(kp_repo)" || { echo "wayfinder: target repo unresolved — NO map was created."; exit 1; }
+
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "wayfinder: stdin was empty — refusing to open a BODYLESS map. NO map was created."; exit 3; }
+
+MAP=$(gh api -X POST "repos/$REPO/issues" \
+	-f title="$TITLE" \
+	-f "labels[]=wayfinder:map" \
+	-f body="$BODY" --jq '.number')
+[ -n "$MAP" ] || { echo "wayfinder: the create call returned no issue number — the map may or may not exist; check before retrying."; exit 1; }
+
+printf '%s\n' "$MAP"


### PR DESCRIPTION
Phase-1 byte-move continuing #4454 where PR #4492 stopped: **`heal-ci`'s shell** (it had no
`scripts/` at all) plus the **eight residual multi-line glue blocks** in the twelve files #4492
shipped, plus the epic's done-proof and the coverage proof as **committed runnable harnesses**
instead of PR-body recipes. No moved glue is rewritten — that is #1929 / phase 2, per the founder's
ruling on #4435 and the ADR-0228 boundary.

Part of #4454. **#4454 remains open** — one `heal-ci` block is deliberately left inline for an
open-PR overlap, named in *Not in this PR*.

## The number I am claiming, and which metric it is

**53 shell lines leave the markdown surface** (the metric the epic measures: shell removed from an
*unscanned* surface, not lines removed from the repo), and **2 fenced blocks** disappear from the
corpus. Measured by the committed census, base vs head — not asserted:

```
base c7de87f9   TOTAL  files-scanned=49  blocks=278  shell-lines=2374
head            TOTAL  files-scanned=49  blocks=276  shell-lines=2321
```

The repo-wide line delta is **+918** (1053 insertions / 135 deletions across 32 files) and that is
expected: 896 of those lines are the 24 new `.sh` files, which carry the moved shell *plus* each
script's exit-code contract and fail-closed rationale, and two of them are verification harnesses the
epic did not previously have in the tree at all.

| file | fences before → after | shell lines before → after |
|---|---|---|
| `heal-ci/SKILL.md` | 11 → 9 | 112 → 71 |
| `adr/SKILL.md` | 4 → 4 | 14 → 10 |
| `glossary/SKILL.md` | 3 → 3 | 10 → 6 |
| `wayfinder/SKILL.md` | 4 → 4 | 27 → 25 |
| `taste-library-conventions.md` | 1 → 1 | 4 → 2 |
| `canon/SKILL.md` | 4 → 4 | 10 → 9 |
| `campaign/SKILL.md` | 10 → 10 | 16 → 17 |
| `release/SKILL.md` | 11 → 11 | 28 → 28 |

`campaign` and `release` come out flat-or-up on lines while their **glue** leaves: four `gh api`
blocks and a `cd packages/anka-ops` + `node` pair become invocations that carry the exit-code contract
in a comment. That is the trade the epic's own framing sanctions, stated rather than hidden.

## Scope shipped

**`heal-ci` — 10 of 11 fences, 8 new scripts.** Three of them collapsed into one, and that collapse
is the point: the fences at the old `SKILL.md:96`, `:115` and `:126` all read a `$CI_JSON` that the
*first* one set — in a different agent shell process, so it was **always empty** by the time the
second and third ran. `scripts/resolve-failing-run.sh` runs the whole PR → (context, job, run)
resolution in one process, which is epic #4435's story 1 (cross-step state survives). Its five exit
codes are each a different fact the prose routes on: 0 red · 3 green · 4 pending
(running-vs-**wedged**, the #3999 distinction, preserved) · 5 not-an-Actions-check · 1 unreadable.

Also: `resolve-repo.sh`, `failed-logs.sh`, `job-log.sh`, `already-rerun.sh`, `rerun-once.sh`,
`repair-rounds.sh`, `comment-active-repair.sh`, `comment-filed.sh`.

**The tail's residual glue — 13 new scripts** across seven files:
`adr/scripts/claimed-numbers.sh` · `campaign/scripts/{list-wave,list-milestones,create-milestone,close-milestone}.sh`
· `canon/scripts/{list-pattern-docs,pattern-doc-drift}.sh` ·
`glossary/scripts/{list-surfaces,glossary-drift}.sh` · `release/scripts/auth-status.sh` ·
`wayfinder/scripts/{create-map,add-frontier-ticket}.sh` ·
`shared/scripts/cp-classify-working-diff.sh`.

**Two committed harnesses** — `shared/scripts/skill-shell-census.sh` (AC5's fence matcher) and
`shared/scripts/extraction-coverage-proof.sh` (the zero-coverage-delta proof).

## `taste-library-conventions.md` needed a destination, and it did not need a ruling

#4492 left this file untouched, reading it as needing a third destination or a founder ruling. It
needs neither. The file is a **cross-skill standards doc** — it governs every `taste-*` skill and owns
no skill directory — so its shell is cross-skill shell, which is exactly what `shared/scripts/`
already is (13 files, landed via #4489). The only property that is load-bearing is the one #4446
pinned: `.sh` at any depth under `skills/`. Measured, not assumed —
`cp-classify classify` returns `control-plane` for
`claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-working-diff.sh`. No new
destination, no ungated window.

## The census, verbatim and runnable (AC4 + AC5)

AC5 allows the matcher in the PR description *or* as a committed script. It is committed, because a
matcher that lives only in prose cannot be re-run at the next SHA — which is the whole reason the
epic's done-proof needs to be reproducible:

```bash
claude-plugins/kampus-pipeline/skills/shared/scripts/skill-shell-census.sh
```

Its matcher is **deliberately wider** than the epic-plan recipe's `^```(bash|sh)$`: it accepts an
indented fence, a `shell` language tag, and a trailing info string. A narrower matcher would report a
zero the corpus does not have. That is why my counts differ from #4492's table on some rows — same
tree, wider matcher — and the wider one is the honest number.

**Zero scope fails.** Handed a directory with no markdown it exits **4** with a stated refusal, not a
zero count (§ZS / ADR 0092). Proven below.

## The zero-coverage-delta proof — measured, and it has teeth

`leak-guard` now scans `.sh` as a second surface (#4496 → PR #4507, `c7de87f9`), and
`cli-invocation-guard` follows extracted shell as a whole-file implicit fence (#4486 → PR #4494). Both
narrowings PR #4492 had to disclose are **closed on this base**. This PR does not take that on faith:

```bash
claude-plugins/kampus-pipeline/skills/shared/scripts/extraction-coverage-proof.sh \
  $(git diff --name-only c7de87f9..HEAD)
```

Result at this head — **9 rows, 0 violations**:

```
handed: 32 file(s) — 24 .sh, 8 .md (teeth companion: claude-plugins/kampus-pipeline/skills/adr/SKILL.md)

--- 1. SCOPE: every handed .sh enters each guard's scanned surface ---
ok    leak-guard: .sh is a scanned surface                       scope contains: 24 shell surface
ok    cli-invocation-guard: .sh is an implicit fence             scope contains: 24 shell file(s) as implicit fences
ok    gh-phoenix lint-skills: .sh in the gh-call scan            scope contains: gh-call scan scanned 32 file(s)

--- 2. TEETH: each guard REDS on planted bait in a .sh ---
ok    leak-guard reds a home path in a .sh                       rc=2, reported: bait-home.sh
ok    cli-invocation-guard reds a bare CLI call in a .sh         rc=2, reported: bait-cli.sh
ok    lint-skills reds a GraphQL gh call in a .sh                rc=2, reported: bait-graphql.sh

--- 3. The handed files themselves are clean on every surface above ---
ok    leak-guard clean over the handed set                       rc=0
ok    cli-invocation-guard clean over the handed set             rc=0
ok    lint-skills clean over the handed set                      rc=0

violations: 0
```

Two design notes on that harness, both about not weakening a guard in order to test it:

- **The bait strings are assembled at run time from fragments**, never written as literals. A literal
  user-home path or a literal bare CLI token in a committed file under `skills/` is a *real* finding in
  the very corpus these guards scan — and papering over it with a `DOC_SELF_EXEMPT` entry is exactly
  the trap PR #4503 fell into (**#4517**). **This PR requests no `leak-guard` exemption and needs
  none**: `leak-guard scan` over the 32 changed files reports `0 self-exempt`.
- **A teeth row asserts non-zero AND the named violation, and hands the bait together with a real
  corpus `.md`.** Both guards also fail closed on a *per-surface zero scope* (exit 3), so a bare
  "non-zero" would have passed a row that never looked at the bait at all. I hit this while writing it:
  the first version passed two rows for the wrong reason.

**Guards I checked, and the ones I did not.** Checked and green at this head:
`leak-guard` · `cli-invocation-guard` · `gh-phoenix lint-skills` · `adoption-lint` (full 189-file
corpus, `.claude/workflows/drive-issue.js` in scope) · `validate-skills.sh` (30 skills) ·
`validate-cycle-absence.sh` (14 checks) · `validate-cycle-presence.sh` (18 checks) ·
`validate-gate-path-drift.sh` (34 checks). **Not applicable, stated rather than skipped silently:**
`validate-gate-path-drift`'s column-0 canonicals live in `gh-issue-intake-formats.md` and
`ship-it/SKILL.md`, neither of which this PR touches; the two `validate-cycle-*` validators scope to
the four cycle-aware skills (`plan-epic`, `write-code`, `review-code`, `ship-it`), none of which this
PR touches — I ran both anyway and confirmed their scanned-scope lines still name the same skills.
**Not run:** `fanout-guard`, `catalog-guard`, `readme-guard`, `design-token-guard` — no
`apps/web/worker` mutation, no `package.json`, no `packages/*` member, no UI surface in this diff.

## Typed-consumer enumeration — done independently, not inherited

The brief's warning is well earned: two authors were wrong about this. I enumerated three ways over
`packages/pipeline-cli/src`, for each of the eight markdown files:

1. **Heading-sliced parsers.** The two known ones —
   `adoption-lint/command.test.ts` (slices `write-code/SKILL.md` by `/^### Delegated claim/m`) and
   `checks/step3-contract.ts` + `merge-queue-classify/step55-contract.ts` (slice `ship-it/SKILL.md`) —
   read files this PR **does not touch**.
2. **Path literals.** Every hit naming one of my eight files is either a **unit-test fixture string**
   (`adoption-lint.unit.test.ts` uses `"skills/heal-ci/SKILL.md"` as a synthetic `ScanFile` path;
   `class-probe.unit.test.ts` uses `"…/wayfinder/SKILL.md"` in a classification input array;
   `gh-phoenix/lint.unit.test.ts` and `control-plane-paths.unit.test.ts` likewise) or a **comment**
   (`verdict/github.ts`, `verdict/command.ts`, `adoption-lint/manifest.ts`,
   `control-plane-paths/control-plane-re.ts`). **Not one reads any of these files from disk.**
   `glossary-drift/drift.ts:318` emits `…/glossary/SKILL.md` as a *pointer string in output*, not a
   read.
3. **Name lists.** No `CLAIM_WRITERS`-style roster names any file, script or heading in this diff.
   `adoption-lint`'s exemption manifest declares no exemption over any of them — confirmed by the full
   corpus run reporting `every declared exemption is valid`.

**And I ran the full suite by hand, because green checks are not evidence here** —
`ci.yml:141` makes `packages_required` true for `merge_group` **or** the path filter, so a skills-only
PR skips `packages unit tests` at head and the queue forces it on:

```
pnpm vitest run   →  183 test files passed, 2953 tests passed
pnpm typecheck    →  29/29 successful
```

## Fail-closed, proven by captured exit code AND captured stdout bytes

The #4485 class is a non-zero exit with **0 bytes** on stdout where the caller reads *empty* as a
*positive* answer. `heal-ci`'s prose has three such readings — an empty `--log-failed`,
`rerun-markers=0`, and `ROUNDS < 3` — and each is the **permissive** branch. Every guard path in every
new script was walked with rc and stdout byte count captured, unpiped:

**32 probes, 0 violations.** Every one exits non-zero with a non-empty fail-closed line on stdout.
Sample of the classes covered: no-args (15 scripts, rc=2, 65–125 bytes) · a non-numeric issue number
handed to `comment-filed.sh` (rc=2, refuses to post a placeholder `Filed #<N>`) · an unresolvable
target repo (rc=1) · an unresolvable CLI shim (rc=1) · outside a git repository (rc=1) · the census on
zero scope (rc=4) and on a non-directory (rc=2) · empty stdin to the two `wayfinder` creators (rc=3) ·
a bad type label (rc=2).

**One violation surfaced and was fixed rather than argued away.** `release/scripts/auth-status.sh`
first exited 1 with **0 bytes** when the flag-lever package was unlocatable, and the skill's prose
reads the *absence* of a "does not authenticate" line as permission to proceed. It now prints its own
refusal on stdout, and the prose says to read the status first. Note this shape is inherited from the
landed `release/scripts/*` siblings (`flag-get.sh` and friends do `|| exit 1` silently) — for those the
*status* answers, so it is not a defect there; I am flagging the family, not fixing it in this PR.

**Where a script has a permissive branch, exit 0 needs positive evidence.** `already-rerun.sh` and
`repair-rounds.sh` print facts only and **derive nothing** — the one-rerun rule and the N=3 cap are
*decisions*, and they stay in the prose (ADR 0228). `rerun-once.sh` attempts the rerun **before** the
marker and writes no marker on a failed rerun, because a marker with no rerun behind it would make a
later invocation refuse to rerun a run that never was.

## The `.sh` disclosure list — complete, every file added or edited

**24 added** (all `.sh` under `skills/**`, so all §CP by path):

- `heal-ci/scripts/`: `resolve-repo.sh`, `failed-logs.sh`, `job-log.sh`, `resolve-failing-run.sh`,
  `already-rerun.sh`, `rerun-once.sh`, `repair-rounds.sh`, `comment-active-repair.sh`,
  `comment-filed.sh`
- `adr/scripts/claimed-numbers.sh`
- `campaign/scripts/`: `list-wave.sh`, `list-milestones.sh`, `create-milestone.sh`,
  `close-milestone.sh`
- `canon/scripts/`: `list-pattern-docs.sh`, `pattern-doc-drift.sh`
- `glossary/scripts/`: `list-surfaces.sh`, `glossary-drift.sh`
- `release/scripts/auth-status.sh`
- `wayfinder/scripts/`: `create-map.sh`, `add-frontier-ticket.sh`
- `shared/scripts/`: `cp-classify-working-diff.sh`, `skill-shell-census.sh`,
  `extraction-coverage-proof.sh`

**0 `.sh` edited.** `shared/lib/common.sh` is **not** in the file list and is byte-identical to
`origin/main`; no existing `.sh` under `shared/scripts/`, `ship-it/scripts/` or anywhere else is
modified. I did transiently `chmod +x` 30 existing scripts while testing and **reverted every mode
bit**; `git diff --summary` against the base reports **no mode change** on any pre-existing file.

**The three new `shared/scripts/` files are the only reason that directory appears in the diff, and
they are additions.** Flagging it explicitly because #4487 and #4510 are open against
`shared/lib/common.sh`: neither is touched. The landed `shared/scripts/*.sh` are `100644` because every
one of them is **sourced**; my three are **executed** (invoked directly from a fence), so they are
`100755`.

**8 markdown edited:** `heal-ci/SKILL.md`, `adr/SKILL.md`, `campaign/SKILL.md`, `canon/SKILL.md`,
`glossary/SKILL.md`, `release/SKILL.md`, `wayfinder/SKILL.md`, `taste-library-conventions.md`.

## Byte-fidelity recipe

```bash
git diff c7de87f9..HEAD -- \
  'claude-plugins/kampus-pipeline/skills/*/SKILL.md' \
  'claude-plugins/kampus-pipeline/skills/taste-library-conventions.md' \
  'claude-plugins/kampus-pipeline/skills/*/scripts/*.sh' \
  'claude-plugins/kampus-pipeline/skills/shared/scripts/*.sh'
```

Read each deleted markdown block against the script that received it. The moved shell is unchanged
apart from the seams below. `shellcheck -x` is clean over all 24.

## The seams — every deviation from a pure byte-move, named

1. **Three `heal-ci` fences became one script** (`resolve-failing-run.sh`), because their shared
   `$CI_JSON` never survived between agent shell processes. Every moved line is otherwise byte-faithful.
2. **`heal-ci`'s green arm: `echo … ; exit 0` → exit 3.** Mandatory, not stylistic — in the agent's own
   shell `exit 0` *stops*; from a script it means "keep going", so a green head would have read as red.
3. **In-shell variables became arguments or exit codes** where a separate process cannot set the
   caller's shell: `RUN`/`PR`/`JOB`/`N`/`MILESTONE_NUMBER`/`WAVE_LABEL` are now positional.
4. **`heal-ci`'s hand-rolled `${CLAUDE_PLUGIN_ROOT:-…}/bin/pipeline-cli` → the shared lib's `kp_pcli`**,
   the landed idiom `cli-invocation-guard` requires.
5. **`wayfinder`'s two creators take the body on stdin and refuse an empty one.** The fences carried it
   as a `$BODY` variable *inside* the block; a pipe makes it an external input, and an unread pipe is
   byte-identical to an empty one (#3924 / #4010). A guard the extraction itself owes.
6. **`add-frontier-ticket.sh` reads back `{id, number}` in one call** — the `sub_issues` endpoint needs
   the database `id`, the caller needs the issue number, and the fence used two variables from two
   blocks. It also refuses a type label outside `type:investigation|type:decision`, the translation
   table's own set.
7. **`release`'s `cd packages/anka-ops` → resolved from the git root** via the existing
   `release/scripts/lib.sh`, matching the sibling flag scripts (`lib.sh` itself is unmodified).
8. **Emptiness got its own exit code** in five listing/scoping scripts (`list-wave.sh` 4,
   `list-pattern-docs.sh` 4, `list-surfaces.sh` 4, `pattern-doc-drift.sh` 4, `glossary-drift.sh` 4).
   For `canon` and `glossary` this is load-bearing: an uncommitted doc has no lower bound, and
   `git diff ""..HEAD` is **bootstrap mode**, not "nothing drifted" — the skills' own prose says so, and
   the pre-extraction fences could not tell the two apart.
9. **Three `shellcheck disable` pragmas**, each with its reason inline: `SC1007` ×3 on the
   `CDPATH= cd` sourcing idiom the whole corpus uses. No other suppression anywhere in the added lines.
10. **`canon`'s existing extraction paragraph got the `## The extracted scripts` heading its own
    scripts already pointed at**, and `adr` / `glossary` got the section they lacked. #4492's
    `canon/scripts/resolve-repo.sh` cites `../SKILL.md § The extracted scripts`, a heading that did not
    exist — a dangling pointer, fixed in passing rather than replicated.

## Not in this PR — the honest remainder on #4454

**One `heal-ci` block stays inline, for an open-PR overlap.** The Step-3 repair-in-flight verdict
resolution (~44 lines) is the block **open PR #4372** edits the *interior* of — it adds the
`cp_changed_files` / `CP_FLAG` §CP-awareness at `heal-ci/SKILL.md:296–306`. Relocating a block another
PR is editing is how an in-flight change gets silently dropped in a conflict resolution (the reason
#4485 shipped 3 of 4 files and #4492 skipped this one). Verified against #4372's own file list and
patch: it has exactly one hunk in `heal-ci/SKILL.md`. So I extracted only the part of that block
**#4372 does not touch** — the self-contained N=3 round count at the old `:338–359`, now
`scripts/repair-rounds.sh`, with ≈28 lines of untouched context between my edit and #4372's hunk
boundary, so its patch still applies. #4372 is currently 2 days stale and already
`mergeable_state: dirty`, so **sequencing it is the operator's call, not mine** — once it lands, the
last block is a one-script follow-up.

**`doctor/SKILL.md` needed nothing.** #4492 listed it as skipped for PR #4389's overlap. Re-derived at
this head: its single fence is already a bare invocation of `doctor/doctor.sh`, one line, no glue. AC1
holds for it as-is, so #4389 is not blocking anything.

**Left as illustrative, not glue** (the epic's test is "does its output feed a gate/merge/classification
decision"): `adr/SKILL.md`'s `ls .decisions/NNNN-*.md` (demonstrates a filename convention);
`campaign`'s `FOUNDER="${CAMPAIGN_FOUNDER_LOGIN:?…}"` and `WAVE_LABEL=`, `release`'s `FLAG_KEY`/`ENV`
and `LINKED_ISSUE`, `heal-ci`'s `RUN`/`PR`/`JOB`, `wayfinder`'s `MAP` — agent-set placeholders a
subprocess **cannot** set in the caller's shell.

**Out of scope by design:** the phase-2 files (`ship-it`, `write-code`, `gh-issue-intake-formats.md`,
`review-code`, `plan-epic`/`review-plan`) and the phase-3 sibling #4453's review-gate tail, all their
own children — and several of them live PRs right now (#4503, #4504, #4506, #4515).

## Acceptance criteria

- **AC1** (every remaining fence is a script invocation; no multi-line glue in the listed files) —
  **met for 7 of the 8 files touched; one `heal-ci` block remains**, disclosed above with its
  forcing constraint. `doctor` and the twelve #4492 files hold. Dumped every remaining fence in the
  eight files: each is an invocation, its comments, an agent-set placeholder, or authored heredoc
  content.
- **AC2** (byte-faithful, reviewer-runnable recipe) — met; recipe + the ten seams above.
- **AC3** (pinned destination, shellcheck, shared common lib) — met; 24 `.sh` under
  `skills/**`, `shellcheck -x` clean, all source `shared/lib/common.sh` except the three that need no
  repo/CLI/scratch state (`skill-shell-census.sh`, `extraction-coverage-proof.sh`, and
  `release/scripts/auth-status.sh`, which sources the release-local `lib.sh` instead).
- **AC4** (corpus-wide zero multi-line glue) — **not met, and no single PR can meet it.** It is
  corpus-wide by construction: phase-2's #4448–#4452 and the phase-3 sibling #4453 still hold ~2,250
  of the 2,321 remaining shell lines. The census output above is the current state, per file.
- **AC5** (the exact re-count command recorded reproducibly) — **met, as a committed script** rather
  than a body recipe, so the done-proof can be re-run at the merged tree's SHA.

## §CP

Every file is `claude-plugins/kampus-pipeline/skills/**`, control-plane by path in its entirety
(#4462, ADR 0174). **This banks for a human `@kamp-us/control-plane` approval at head**; no gate
verdict authorizes the merge either way. Nothing under `packages/pipeline-cli/src/[^/]+$` or
`.github/**` is touched, so there is no §CP subset to separate (ADR 0218).

## Deviations

Walked all seven §DEV classes. Four fired.

- **(1) Scope narrowing** — **Said:** #4454's AC1 covers every fence in the listed files and AC4 asks
  for a corpus-wide zero. **Did:** 8 files; one `heal-ci` block untouched; AC4 unmet. **Why:** PR #4372
  edits that block's interior, and AC4 cannot close until five sibling children land. **Disposition:**
  disclosed, `Part of #4454` with no closing keyword, remainder named.
- **(3) Known defect left unfixed** — two, both deliberate. The `release/scripts/*` family's silent
  `|| exit 1` on an unlocatable flag lever is *inherited* and correct where the status answers; I fixed
  only the one instance whose prose reads emptiness as permission (`auth-status.sh`) and flagged the
  family rather than rewriting landed siblings. And `report/SKILL.md`'s `dedup-check.sh` prose still
  lacks the "only on exit 0" qualifier #4492 disclosed — unchanged here, still open.
- **(5) Guard or gate bypassed** — none. No `--no-verify`, no skipped hook, no `biome-ignore` /
  `@ts-expect-error` / `test.skip` / `.only`. Disclosed rather than left for the diff: **three
  `shellcheck disable=SC1007` pragmas** on the `CDPATH= cd` idiom, each with its reason inline. And
  explicitly: **no `leak-guard` `DOC_SELF_EXEMPT` entry is added or requested** — the coverage harness
  assembles its bait at run time precisely so it does not need one (#4517's lesson).
- **(7) Out-of-scope change** — three, each stated with why it belongs. `wayfinder`'s two creators
  **add** an empty-stdin refusal (the extraction created the hazard, seam 5). Five scoping scripts
  **add** a distinct exit code for emptiness (§ZS; for `canon`/`glossary` it separates bootstrap mode
  from an empty drift, which the fences conflated). And **`shared/scripts/extraction-coverage-proof.sh`
  is new machinery the issue does not ask for** — it exists because every sibling gate demanded a
  zero-coverage-delta proof and a table cannot be re-run.
- **(2) Governing-ADR departure — did not fire.** ADR 0228's boundary holds (every script relays; the
  one-rerun rule, the N=3 cap and the §CP precedence all stay in prose). ADR 0092's fail-closed
  direction is strengthened, never weakened. The #4435 no-rewrite ruling holds.
- **(4) Declined guidance — did not fire.** No reviewer suggestion or appended criterion was declined.
- **(6) Pre-existing test or fixture changed — did not fire.** No test or fixture file is in the diff.
