### PR TITLE
docs(decisions): ADR 0230 — cycle validators follow the source edge into shared/scripts (#4505)

### DIFF
--- a/.decisions/0229-cycle-validators-follow-the-source-edge.md
+++ b/.decisions/0229-cycle-validators-follow-the-source-edge.md
@@ -1,0 +1,170 @@
+---
+id: 0229
+title: Cycle validators widen a skill's scan surface across its own source edges — one hop, fail-closed
+status: accepted
+date: 2026-07-30
+tags: [pipeline, skills, guards, control-plane]
+---
+
+# 0229 — Cycle validators widen a skill's scan surface across its own source edges
+
+**What this decides:** `kp_skill_shell_surfaces` — and through it both cycle validators — resolves a
+cycle-aware skill's scan surface as `SKILL.md` + the skill's own `scripts/*.sh` **plus every
+`shared/scripts/*.sh` that one of those files demonstrably sources**, one hop, fail-closed on an
+edge that will not resolve. Scope inclusion is keyed on **demonstrated dependency**, never on
+directory membership. This is shape (1) of #4505; shapes (2) and (3) are rejected below.
+
+## Context
+
+Both cycle validators prove each cycle-aware skill's wiring by `grep -qF`-ing the canonical probe
+literal `contents/product-development-cycle.md` across a surface that
+`claude-plugins/kampus-pipeline/skills/shared/lib/common.sh`'s `kp_skill_shell_surfaces` resolves as
+`<skill>/SKILL.md` + every `*.sh` **under the skill's own directory**. `shared/` is deliberately
+excluded, so one skill's marker cannot satisfy another skill's per-skill check (#4470, PR #4473).
+
+The extraction programme's other rule — **source the shared helper, don't copy it** (#4435) — moves
+that literal out of a skill's own surface. A skill that correctly sources
+`shared/scripts/cycle-doc-probe.sh` no longer carries the probe as executable code anywhere the
+validators look, so its only satisfiable token is a **comment**, and the validator cannot tell an
+honest delegation citation from a marker planted to pass a grep.
+
+**The tension is live on `main`, not hypothetical.** Measured on the branch base of this ADR:
+
+```
+$ grep -nF "contents/product-development-cycle.md" \
+    plan-epic/scripts/cycle-doc-probe.sh review-code/scripts/cycle-doc-probe.sh \
+    write-code/SKILL.md ship-it/scripts/step5b-release-queue.sh
+ship-it/scripts/step5b-release-queue.sh:19:  … gh api "repos/$REPO/contents/…"   ← executable
+review-code/scripts/cycle-doc-probe.sh:21:  … gh api "repos/$REPO/contents/…"   ← executable (a COPY)
+write-code/SKILL.md:1233, 1761:            … gh api "repos/$REPO/contents/…"   ← executable
+plan-epic/scripts/cycle-doc-probe.sh:10:   # … `contents/…` …                   ← a COMMENT, and the only match
+```
+
+`validate-cycle-presence.sh` exits 0 with `ok: plan-epic cites the canonical cycle-doc probe`. The
+one skill that did the right thing — sourced the shared probe — is the only one whose evidence is
+prose; the three still green on real code are green because two of them have not been extracted yet
+and the third keeps a second copy of the probe. The guard rewards the duplication it exists
+alongside, and its own docblock claim ("proves the present branch is real wiring and not dead
+prose") is false exactly where the programme is correct.
+
+**The repo already discriminates this way.** `packages/pipeline-cli/src/skill-shell-surface.ts`
+(`resolveSection`, #4498) resolves a section's surface as its heading slice **plus every
+`scripts/*.sh` the slice sources** — a source-edge widening, already shipped, already tested. This
+ADR extends the same idea one hop further for the cycle validators' shell-side resolver.
+
+## Decision
+
+**`kp_skill_shell_surfaces "$skills_dir" "$skill"` returns, in addition to today's own-surface
+files, every `shared/scripts/*.sh` that a file in that own surface sources.** Four binding rules:
+
+1. **The edge must be executable, and it must live in this skill's own files.** A path enters the
+   surface only via a source line — a line whose first non-blank token is `.` or `source` and whose
+   argument resolves under `shared/scripts/` — in one of the skill's own files. A `#`-prefixed
+   comment naming the path is not an edge. This is what preserves #4470: a shared file is credited
+   to skill A because **A's own text executes it**, so a skill that does not source it gets nothing.
+2. **One hop, declared — no transitive closure.** Only files sourced *directly* by the skill's own
+   surface are followed. A literal hidden two hops deep is a FAIL, and the fix is to source it
+   directly. A closure would re-open the whole-tree fold rule 1 exists to prevent, and would make
+   the surface depend on the shared corpus's internal shape.
+3. **Widen, never replace.** The own-surface files stay in the returned surface unconditionally. The
+   edge adds; it does not substitute.
+4. **A named edge that will not resolve is UNRESOLVED ⇒ FAIL, never a fallback.** An edge whose
+   target is missing or unreadable makes the surface UNKNOWN. The validator fails, loudly, rather
+   than silently scanning the narrower own-surface set and reporting a pass over an unevaluated path
+   ([ADR 0092](0092-gates-fail-closed-on-zero-scope.md) / §ZS). "Could not read the surface" is not
+   "the literal is absent", and it is certainly not "ok".
+
+### What the validators prove after this change
+
+For each cycle-aware skill: **either the skill's own executable surface carries the canonical probe
+literal, or the skill's own surface executes a shared file that does.** That is *real wiring* — the
+docblock intent — and the mechanism now agrees with it. A fully-extracted skill's honest citation
+comment becomes documentation rather than the load-bearing token, and a comment planted only to pass
+the grep no longer satisfies a fully-extracted skill.
+
+### The site is the resolver, not the probe grep
+
+The change lands in `kp_skill_shell_surfaces` because **each validator runs three independent greps
+off the one `surfaces` array**: the probe literal, the present-gate / absent-no-op regex, and the
+per-skill action regex. `CYCLE_DOC=absent` — the absence validator's needle for both `write-code`
+and `review-code` — also lives in `shared/scripts/cycle-doc-probe.sh`, so it is subject to the same
+erosion. Widening only the probe grep would repair one of three checks and leave the other two to
+fail as soon as their skills extract. One resolver, one widening, all six greps.
+
+### Rejected shapes
+
+- **(2) Alternation on the sourcing line** — accept the literal *or* a proven source of the shared
+  helper. Rejected: it is name-keyed, never verifying that the sourced file carries the probe at all,
+  and it fixes only the grep it is written into (see the site argument above).
+- **(3) Promote the comment to a contract marker.** Rejected: it makes "a docblock satisfies the
+  guard" the stated design, permanently lowering the floor from executable code to prose. That is a
+  guard weakening with no compensating gain, on a guard whose whole claim is the opposite.
+- **A fourth — copy the probe into each skill** — was never live: it re-introduces the N-copies drift
+  the shared helpers exist to remove, and `review-code/scripts/cycle-doc-probe.sh`'s surviving copy is
+  the drift risk, not the model.
+
+### Knowingly traded, stated rather than glossed
+
+- **The markdown-prose floor in `SKILL.md` is unchanged.** `SKILL.md` is markdown, and a fenced block
+  satisfies `grep -qF` exactly as a paragraph does. This ADR removes the *new* degradation (a comment
+  as a fully-extracted skill's only satisfiable token); it does not solve the pre-existing softness of
+  grepping prose. Distinguishing fenced shell from narrative is a separate problem in epic #4435's
+  scan-surface class and is left open.
+- **The edge is matched as text.** A line crafted to look like a source line but never executed would
+  pass. The `.`/`source`-anchored match plus rule 4's must-resolve requirement is the same standard
+  the rest of the corpus's static checks hold; it is not a proof of execution.
+- **Two skills that source the same helper are both credited from the same file.** That is correct,
+  not a leak: both genuinely execute it, and each needed its own source line to get there.
+
+## Consequences
+
+- **#4470's property is preserved, not traded.** Its exclusion was on *directory membership*, which
+  this decision does not relax — `shared/` remains outside every skill's surface by default. What is
+  added is per-skill, per-edge, evidence-bearing inclusion.
+- Extracting a cycle-aware skill's probe into a sourced shared helper is now the green path; the
+  guard stops penalising the correct move.
+- `review-code/scripts/cycle-doc-probe.sh`'s duplicated probe becomes removable — it can source the
+  shared implementation and stay green on the edge.
+- A new fail mode exists on purpose: a skill whose source edge points at a missing file goes red
+  rather than quietly narrowing. That is the intended direction (ADR 0092).
+
+### Follow-up implementation scope (the named surfaces that change)
+
+1. **`claude-plugins/kampus-pipeline/skills/shared/lib/common.sh`** — `kp_skill_shell_surfaces` gains
+   the one-hop, `.`/`source`-anchored, fail-closed edge resolution above. It must also stop
+   discarding `find`'s exit status (#4487), since an unresolved own-surface read is the same UNKNOWN
+   as an unresolved edge.
+2. **`skills/validate-cycle-presence.sh` / `skills/validate-cycle-absence.sh`** — grep logic
+   unchanged. Their docblocks restate the surface ("SKILL.md + own `scripts/*.sh` + the shared
+   scripts this skill sources"), and the emitted `scanned scope` line marks edge-resolved paths
+   distinctly from own-surface paths so the ADR 0092 §1 emission stays honest about *why* a file was
+   read. Both keep `set -uo pipefail` with no `-e` (#4479, PR #4514) — the EXIT trap is still there.
+3. **The four cycle-aware skills** — no edit is *required* to stay green.
+   `plan-epic/scripts/cycle-doc-probe.sh`'s docblock sentence claiming its citation "is what keeps
+   the cycle validators scanning a real reference" becomes false on merge and must be corrected to
+   name the source edge instead. `review-code/scripts/cycle-doc-probe.sh` may drop its copy.
+4. **`.patterns/skill-derived-guards.md`** — its "Sibling-scoped, never the whole plugin tree" bullet
+   gains the edge-vs-directory distinction, so the pattern doc and the resolver agree.
+5. **Tests** — `kp_skill_shell_surfaces` needs falsification cases: an edge whose target is missing
+   resolves UNRESOLVED (red), a comment naming the shared path resolves no edge, and a skill that
+   sources nothing keeps exactly today's surface.
+6. **Explicitly out of scope** — `packages/pipeline-cli/src/skill-shell-surface.ts` keeps its
+   sibling-only scoping for now; whether it adopts the same one-hop rule is a separate call, since
+   its consumers are heading-sliced parsers rather than corpus-wide greps.
+
+## Records
+
+- Records the ruling on #4505 (`type:decision`). The three shapes weighed there are answered: (1)
+  accepted, (2) and (3) rejected with reasons.
+- Vocabulary impact: coins **source-edge surface** — a scan surface widened by a demonstrated source
+  edge, as against one defined by directory membership. Routed to `.glossary/LANGUAGE.md` via report
+  issue #4529, since this PR touches only `.decisions/`.
+- Contradiction sweep run against the 189 live-accepted, uncited ADRs. Its eight-entry shortlist is
+  lexical adjacency only — none rules on what a guard's *scan surface* is. The nearest neighbour,
+  [0228](0228-scripts-relay-never-derive.md), governs the same #4435 programme but decides what an
+  extracted script may compute, not what a guard may read; [0174](0174-bare-sh-guards-control-plane-gate.md)
+  and the §CP-classification ADRs decide which files are control-plane, a different question from
+  which files a check scans. No supersession or amendment is owed.
+- Adjacent, deliberately not decided here: #4510 (shared-lib stdout/stderr contract), #4487
+  (`kp_skill_shell_surfaces` discards `find`'s exit status — named as item 1's companion fix, not
+  ruled), and the epic #4435 scan-surface class the prose floor belongs to.

--- a/.decisions/0230-cycle-validators-follow-the-source-edge.md
+++ b/.decisions/0230-cycle-validators-follow-the-source-edge.md
@@ -1,12 +1,12 @@
 ---
-id: 0229
+id: 0230
 title: Cycle validators widen a skill's scan surface across its own source edges — one hop, fail-closed
 status: accepted
 date: 2026-07-30
 tags: [pipeline, skills, guards, control-plane]
 ---
 
-# 0229 — Cycle validators widen a skill's scan surface across its own source edges
+# 0230 — Cycle validators widen a skill's scan surface across its own source edges
 
 **What this decides:** `kp_skill_shell_surfaces` — and through it both cycle validators — resolves a
 cycle-aware skill's scan surface as `SKILL.md` + the skill's own `scripts/*.sh` **plus every


### PR DESCRIPTION
Closes #4505.

`type:decision` — the deliverable is a recorded choice, so this PR is purely additive: one new `.decisions/0230-cycle-validators-follow-the-source-edge.md`, nothing else. The implementation it names is deliberately **not** in this diff (see *Scope* below).

## The ruling

Shape **(1) follow the source edge**, of the three the issue put up.

`kp_skill_shell_surfaces` resolves a cycle-aware skill's scan surface as `SKILL.md` + the skill's own `scripts/*.sh` **plus every `shared/scripts/*.sh` that one of those files demonstrably sources** — one hop, no transitive closure, widen-never-replace, and an edge that will not resolve is UNRESOLVED ⇒ FAIL rather than a quiet fall back to the narrower surface (ADR 0092 / §ZS).

The crux: **scope inclusion is keyed on demonstrated dependency, not on directory membership.** #4470's exclusion was directory-shaped, and this decision does not relax it — `shared/` stays outside every skill's surface by default. What is added is per-skill, per-edge, evidence-bearing inclusion, and the evidence (the source line) has to live in *this* skill's own files. So "one skill's marker cannot satisfy another skill's check" is **preserved, not traded**.

## Why this is not a hypothetical

Measured on the branch base, `grep -nF "contents/product-development-cycle.md"` across the four cycle-aware skills' own surfaces:

| skill | match | kind |
| --- | --- | --- |
| `ship-it/scripts/step5b-release-queue.sh:19` | `gh api "repos/$REPO/contents/…"` | executable |
| `review-code/scripts/cycle-doc-probe.sh:21` | `gh api "repos/$REPO/contents/…"` | executable — but a **second copy** of the probe |
| `write-code/SKILL.md:1233,1761` | `gh api "repos/$REPO/contents/…"` | executable (un-extracted) |
| `plan-epic/scripts/cycle-doc-probe.sh:10` | `# … \`contents/…\` …` | **a comment — and the only match** |

`validate-cycle-presence.sh` exits 0 with `ok: plan-epic cites the canonical cycle-doc probe`. The one skill that did the right thing (sourced the shared probe) is the only one whose evidence is prose. The guard currently rewards the duplication it exists alongside.

## Why not (2) or (3)

- **(2) alternation on the sourcing line** — name-keyed: it never verifies the sourced file carries the probe. And it repairs only the grep it is written into. Each validator runs **three** greps off the one `surfaces` array, and `CYCLE_DOC=absent` — the absence validator's needle for both `write-code` and `review-code` — also lives in `shared/scripts/cycle-doc-probe.sh`, so it erodes identically. That is the argument for putting the fix in the **resolver**, not the probe grep: one widening, all six greps.
- **(3) promote the comment to a contract marker** — makes "a docblock satisfies the guard" the stated design, permanently lowering the floor from executable code to prose, on a guard whose whole claim is the opposite.

## What the validators prove afterwards

For each cycle-aware skill: *either its own executable surface carries the canonical probe literal, or its own surface executes a shared file that does.* Real wiring — which is what the presence validator's docblock already claims, so intent and mechanism agree.

**Stated, not glossed** (all three are in the ADR): the pre-existing markdown-prose floor in `SKILL.md` is unchanged and left open to epic #4435's scan-surface class; the edge is matched as text, so it is not a proof of execution; and two skills sourcing the same helper are both credited from it, which is correct since both execute it.

## Grounding

`packages/pipeline-cli/src/skill-shell-surface.ts` (`resolveSection`, #4498) already resolves a section's surface as its heading slice **plus every `scripts/*.sh` the slice sources** — a shipped, tested source-edge widening. This ADR extends the same discrimination one hop for the shell-side resolver, and explicitly leaves that TS module's sibling-only scoping alone.

## Scope of this PR — decision only

The issue's third acceptance criterion is *"follow-up implementation scope named"*, so the ADR names the six surfaces that change (`shared/lib/common.sh`'s resolver, the two validators' docblocks + scope emission, the four skills, `.patterns/skill-derived-guards.md`, the falsification tests, and the explicit out-of-scope) and **this PR changes none of them**. That is also the disjointness ask on this lane: `shared/lib/common.sh` and `skills/write-code/**` are held by sibling lanes, and a guard-reshaping edit belongs behind its own adversarial review anyway — which is exactly why the issue was typed `type:decision`.

## Acceptance criteria

- [x] A recorded choice among (1)/(2)/(3) — **(1)**, with #4470's per-skill-marker property **explicitly preserved** and the reasoning for why edge-scoping does not reopen the directory-fold hazard.
- [x] States what the validators prove after the change (**real wiring**), so the docblock intent and the mechanism agree — plus the three limits knowingly retained.
- [x] Follow-up implementation scope named: `shared/lib/common.sh` (`kp_skill_shell_surfaces`), both validators, the four skills, the pattern doc, the tests, and what is deliberately out of scope.

## Verification (unpiped exits)

| check | exit |
| --- | --- |
| `pnpm typecheck` | 0 |
| `pipeline-cli decisions-index validate` | 0 |
| `pipeline-cli leak-guard scan .decisions/0230-…md` (scope: 1 file handed, 1 doc surface) | 0 |
| `pipeline-cli pointer-guard check` | 0 |
| `skills/validate-cycle-presence.sh` | 0 |
| `skills/validate-cycle-absence.sh` | 0 |
| `adr/scripts/sweep-shortlist.sh` | 1 (a shortlist to clear — cleared by inspection, see below) |

Contradiction sweep: the 8-entry shortlist is lexical/tag adjacency only. Every entry was opened against the question *"does this rule on what a guard's scan surface is?"* and none does — 0228 governs what an extracted script may **compute**, the §CP ADRs (0174/0218/0220/0225/0151) govern which files are **control-plane**, 0065/0073 the gate's artifact classes, 0115/0059 claim/lock protocols. No supersession or amendment owed; 0092, 0174 and 0228 are cited as adjacent.

**`.sh` files added or edited: none.** `trap-status-guard` therefore has zero shell scope on this diff (it would exit 3 = UNKNOWN, which is not a pass, so it is reported as inapplicable rather than green). PR #4514's `set -uo pipefail` + fail-closed `skills_dir`/`tmp_root`/`repo_root` checks in both validators are untouched, and the ADR's implementation scope explicitly requires they stay that way.

## ADR number: 0230, not 0229 (collision with PR #4526)

Sibling PR #4526 opened a minute earlier and adds `.decisions/0229-mechanical-combination-is-relay.md`.
Two files claiming 0229 means whichever merges second reds on `decisions-index validate`. #4526 keeps
0229; this ADR took **0230** in a follow-up commit. Mechanical only — the file rename plus its own
frontmatter `id:` and H1. Every citation of another ADR (0092, 0174, 0228) is untouched and the
substance of the ruling is unchanged. `pipeline-cli decisions-index validate` re-run unpiped: exit 0.

Known stale reference outside this PR's write scope: report issue #4529 (the `source-edge surface`
glossary routing) still names this ADR as 0229 in its title and body. Repointing it needs a
cross-issue write this lane is not pre-authorized for — surfaced here rather than dropped.

## Deviations

Added in **repair round 1** — the section was owed at open (linked issue #4505, full `write-code`
Step-5 body shape) and was absent, which `review-doc` correctly failed. The seven §DEV classes were
walked; six entries fired, and each describes the lane's whole life, not just this round.

- **Scope narrowing (class 1)** — **Said:** #4505's third acceptance criterion asks for the
  follow-up implementation scope to be *named*, and the ADR names six surfaces:
  `shared/lib/common.sh`'s `kp_skill_shell_surfaces` resolver, the two cycle validators' docblocks
  and scope emission, the four cycle-aware skills, `.patterns/skill-derived-guards.md`, and the
  falsification tests. **Did:** this PR changes none of them — the diff is exactly one added file,
  `.decisions/0230-cycle-validators-follow-the-source-edge.md` (+170/-0).
  **Why:** #4505 is `type:decision`; the deliverable is the recorded choice. The named surfaces are
  held by sibling lanes, and a guard-reshaping edit belongs behind its own adversarial review.
  `packages/pipeline-cli/src/skill-shell-surface.ts` is cited as prior art and left explicitly out of
  scope. **Disposition:** no action needed — all three acceptance criteria ask for a recorded choice
  and a *named* scope, none asks for the implementation, so nothing is left unmet by the deferral.

- **Out-of-scope change (class 7)** — **Said:** the issue implies one ADR added at the next free
  number. **Did:** a second commit (`175b1299`) renumbered the file **0229 → 0230** after the PR was
  already open — a pure rename plus its own frontmatter `id:` and H1. **Why:** sibling PR #4526
  opened roughly 100 seconds earlier and also claimed 0229; that is ADR 0074 §2's residual
  co-acquire window, not a violation of it. #4526 opened first and keeps 0229; 0231 is claimed by
  #4533. Two files claiming 0229 would red `decisions-index validate` for whichever merged second.
  **Disposition:** no action needed — the renumber is disclosed in the body's *ADR number* section;
  every citation of another ADR (0092, 0174, 0228) is untouched and the ruling is unchanged.

- **Guard or gate bypassed (class 5)** — **Said:** the pipeline's `verified-push` is the sanctioned
  way to move a PR head. **Did:** the renumber push did not use it. The branch was checked out in
  another agent's worktree, so the commit went out from a lane-local branch via an explicit refspec,
  and the head move was confirmed by an independent REST read of `pulls/4528` instead.
  **Why:** the checkout collision left no path to `verified-push` on this lane; the compensating
  control was an out-of-band confirmation of the resulting head. **Disposition:** for the reviewer to
  judge — and independently discharged: `review-doc` re-derived the pushed tree itself and found a
  pure rename at 99% similarity with exactly two token changes (the frontmatter `id:` and the H1),
  nothing stray riding the unverified path, remote head `175b1299` confirmed by both REST and the
  fetched ref.

- **Guard or gate bypassed (class 5)** — **Said:** shell-touching PRs are gated by
  `trap-status-guard`. **Did:** it is reported here as **inapplicable, not green**. Against this
  diff's shell-free file list it prints its zero-scope refusal and exits **3** — UNKNOWN, which is
  not a pass. **Why:** reporting a fail-closed zero-scope exit as a passing check would be a false
  green (ADR 0092 / §ZS). For the record its workflow triggers are `pull_request` + `push: main`
  with no `merge_group`, so its green is not a merge-time backstop under any reading.
  **Disposition:** no action needed — `.sh` files added or edited: none. PR #4514's
  `set -uo pipefail` and fail-closed `skills_dir`/`tmp_root`/`repo_root` checks in both validators
  are untouched, and the ADR's implementation scope requires they stay that way.

- **Known defect left unfixed (class 3)** — **Said:** the evidence table's
  `write-code/SKILL.md:1233,1761` row, and the interpretive sentence *"two of them have not been
  extracted yet"*. **Did:** both are left as written, labelled *"measured on the branch base"*.
  **Why:** the row was true at branch base `aa255c2e`, but `main` has since extracted write-code's
  shell — re-measured against `main` at repair time, `write-code/SKILL.md` now carries **zero**
  matches for the canonical probe literal and the match lives at
  `claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-seam-checks.sh:66`. So the
  interpretive sentence is now wrong for write-code specifically: it **is** extracted, it just kept
  its own copy of the probe rather than sourcing the shared one. **Disposition:** for the reviewer to
  judge — the ADR's conclusion is unaffected (write-code is still green on executable code in its own
  surface, which is the property the row is cited for), and a dated ADR reporting a labelled
  point-in-time measurement stays correct. Recorded here as known drift rather than silently
  refreshed, because editing the file would move the head and invalidate a verdict whose only two
  failing rows are metadata.

- **Known defect left unfixed (class 3)** — **Said:** report issue #4529 cites this ADR by number.
  **Did:** it is not edited from this lane. **Why:** repointing another issue is a cross-issue write
  this lane is not pre-authorized for, and the intake desk owns it. **Disposition:** follow-up owned
  elsewhere — triage has since prepended a repoint note to #4529 and rewritten its title and lead
  section to 0230, but the preserved original-report section below it still names 0229 in three
  places, including a `blob/main/.decisions/0229-cycle-validators-follow-the-source-edge.md` link
  that goes dead when this PR merges. Surfaced, not dropped; still not this lane's to fix.

## §CP

This is control-plane (`.decisions/` under ADR 0164's content axis — a guard-reshaping decision) and needs a human approval. The diff is one added file, 170 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

