### PR TITLE
fix(skills): kp_skill_shell_surfaces fails closed on a failed find (#4487)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,6 +594,12 @@ jobs:
       # Same script runs locally: `bash .claude/skills/validate-cycle-presence.sh`.
       - run: bash .claude/skills/validate-cycle-presence.sh
 
+      # Executable pin for the shared surface resolver both cycle validators consume: a
+      # partially-failing `find` must not hand them a silently narrowed — but non-empty —
+      # surface that their zero-scope guard reads as complete (#4487).
+      # Same script runs locally: `bash .claude/skills/shared/lib/common-test.sh`.
+      - run: bash .claude/skills/shared/lib/common-test.sh
+
       # Gate-path drift guard (issue #720): assert the five CONTROL_PLANE_RE= copies
       # in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats are
       # byte-identical to the §CP canonical line, and that .claude/skills resolves to

--- a/.patterns/skill-script-shell-shape.md
+++ b/.patterns/skill-script-shell-shape.md
@@ -28,6 +28,15 @@ to ~106).
 5. **Anything `errexit` used to catch is checked explicitly.** Dropping `-e` means a failed
    command substitution no longer aborts, so the assignments a script's correctness rests on
    (`mktemp -d`, a resolved root) get their own fail-closed check.
+6. **A resolver read through process substitution withholds its output on a failed scan.** In
+   `done < <(resolve …)` the producer's exit status is unobservable *even in principle*, so a
+   partially-failing `find` (unreadable subdirectory, a race with a writer — it prints what it
+   could read and exits non-zero) would hand the caller a silently narrowed but **non-empty** list
+   that its `-eq 0` zero-scope guard reads as complete. Capture the status where the pipeline runs,
+   and on failure emit **nothing** on stdout, a diagnostic on stderr, and a non-zero return: the
+   empty stdout is what reaches the caller's existing zero-scope guard
+   ([#4487](https://github.com/kamp-us/phoenix/issues/4487)). A genuinely empty surface still
+   exits 0 — empty is a fact, a failed scan is UNKNOWN, and the two must not look alike.
 
 Mechanically enforced for rule 1 by `pipeline-cli trap-status-guard check` (the
 `trap-status-guard.yml` job), which reds on `errexit` + an `EXIT` trap inside one runnable shell
@@ -106,6 +115,11 @@ grep -q "$needle" "${files[@]-}"
   [#4473](https://github.com/kamp-us/phoenix/pull/4473)).
 - `claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` — the `[ -f "$sh" ]`
   unmatched-glob idiom (rule 4).
+- `claude-plugins/kampus-pipeline/skills/shared/lib/common.sh` — `kp_skill_shell_surfaces`, the
+  surface resolver both cycle validators consume through `< <(…)` (rule 6). Pinned by
+  `shared/lib/common-test.sh`, which forces a partial `find` failure with an unreadable
+  subdirectory and asserts non-zero + empty stdout + a stderr diagnostic; run in the `skills` CI
+  job.
 
 ## The failure it prevents
 

--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Executable pin for kp_skill_shell_surfaces' scan-status contract (#4487). Run it directly:
+#   bash claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
+#
+# `set -uo pipefail` WITHOUT `-e`, and no EXIT trap: on bash 3.2 a `-u` abort under `-e` reaches
+# an EXIT trap with `$?` already 0, so the script would exit 0 having aborted (#4479). Cleanup is
+# explicit at each exit instead.
+set -uo pipefail
+
+lib="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+# shellcheck source=./common.sh
+. "$lib"
+
+failures=0
+fail() { printf 'FAIL: %s\n' "$*"; failures=$((failures + 1)); }
+ok() { printf 'ok: %s\n' "$*"; }
+
+tmp="$(mktemp -d)" || { printf 'FAIL: could not create a temp fixture dir\n'; exit 1; }
+cleanup() { chmod -R u+rwx "$tmp" 2>/dev/null; rm -rf "$tmp"; }
+
+# Fixture: a complete skill (SKILL.md + two *.sh at two depths) and an empty one.
+mkdir -p "$tmp/skills/complete/scripts" "$tmp/skills/empty"
+printf 'x\n' > "$tmp/skills/complete/SKILL.md"
+printf 'x\n' > "$tmp/skills/complete/top.sh"
+printf 'x\n' > "$tmp/skills/complete/scripts/nested.sh"
+
+# 1. Complete surface: every file, sorted, exit 0.
+out="$(kp_skill_shell_surfaces "$tmp/skills" complete)"; rc=$?
+expected="$tmp/skills/complete/SKILL.md
+$tmp/skills/complete/scripts/nested.sh
+$tmp/skills/complete/top.sh"
+if [ "$rc" -eq 0 ] && [ "$out" = "$expected" ]; then
+	ok "complete surface resolves every file, sorted, exit 0"
+else
+	fail "complete surface: rc=$rc out=[$out]"
+fi
+
+# 2. Empty surface is a FACT, not an error: exit 0, nothing on stdout.
+out="$(kp_skill_shell_surfaces "$tmp/skills" empty 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+	ok "empty skill directory: exit 0, no output (the contract is preserved)"
+else
+	fail "empty skill directory: rc=$rc out=[$out]"
+fi
+
+# 3. Absent skill directory: same fact, same exit 0.
+out="$(kp_skill_shell_surfaces "$tmp/skills" no-such-skill 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+	ok "absent skill directory: exit 0, no output"
+else
+	fail "absent skill directory: rc=$rc out=[$out]"
+fi
+
+# 4. THE PIN: a PARTIALLY failing find must not yield a narrowed surface. An unreadable
+# subdirectory makes find exit non-zero while still printing the entries it could read.
+chmod 000 "$tmp/skills/complete/scripts"
+find "$tmp/skills/complete" -type f -name '*.sh' >/dev/null 2>&1
+find_rc=$?
+if [ "$find_rc" -eq 0 ]; then
+	# Running as root (or on a filesystem that ignores the mode) — the fixture did not take, so
+	# this case was never exercised. UNKNOWN is not a pass: red, do not skip.
+	fail "fixture did not take: find still exits 0 over an unreadable subdirectory (running as root?) — the narrowing case was NOT exercised"
+else
+	err="$tmp/stderr"
+	out="$(kp_skill_shell_surfaces "$tmp/skills" complete 2>"$err")"; rc=$?
+	diag="$(cat "$err")"
+	if [ "$rc" -eq 0 ]; then
+		fail "failed find returned 0 — the pipeline status is being discarded (#4487)"
+	elif [ -n "$out" ]; then
+		fail "failed find emitted a narrowed surface [$out] — it must emit nothing"
+	elif [ -z "$diag" ]; then
+		fail "failed find returned $rc with an empty stderr — non-zero with no diagnostic is itself a fail-open"
+	else
+		ok "failed find: exit $rc, empty stdout, diagnostic on stderr"
+	fi
+fi
+chmod 755 "$tmp/skills/complete/scripts"
+
+cleanup
+if [ "$failures" -ne 0 ]; then
+	printf '\ncommon-test: %d failure(s)\n' "$failures"
+	exit 1
+fi
+printf '\ncommon-test: all checks passed\n'

--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
@@ -40,14 +40,31 @@
 # it: under `set -u` on bash 3.2 `"${arr[@]}"`/`"${arr[*]}"` on an empty array aborts the script,
 # and with a cleanup `trap … EXIT` installed the trap's own exit status becomes the script's — so
 # a fail-closed validator exits 0 having printed its FAIL lines. Fail OPEN, invisibly (#4470).
+#
+# A FAILED scan emits NOTHING on stdout, a diagnostic on stderr, and returns non-zero (#4487).
+# `find` exits non-zero on a PARTIAL failure (unreadable subdirectory, a race with a writer)
+# while still printing what it could read, so emitting that output would hand the caller a
+# silently narrowed — but non-empty — surface, which its `-eq 0` zero-scope guard cannot tell
+# from a complete one. Both callers consume this through process substitution, where the return
+# status is unobservable even in principle; withholding the output is therefore what makes the
+# failure reach them, via the zero-scope guard they already have. Absent ⇒ UNKNOWN, never "no".
 kp_skill_shell_surfaces() {
-	local skills_dir="$1" skill="$2"
+	local skills_dir="$1" skill="$2" md="" found="" sorted=""
 	if [ -f "$skills_dir/$skill/SKILL.md" ]; then
-		printf '%s\n' "$skills_dir/$skill/SKILL.md"
+		md="$skills_dir/$skill/SKILL.md"
 	fi
 	if [ -d "$skills_dir/$skill" ]; then
-		find "$skills_dir/$skill" -type f -name '*.sh' | LC_ALL=C sort
+		if ! found="$(find "$skills_dir/$skill" -type f -name '*.sh')"; then
+			printf 'kp_skill_shell_surfaces: find failed under %s — the surface is UNKNOWN, not empty; emitting nothing (#4487).\n' "$skills_dir/$skill" >&2
+			return 1
+		fi
+		if [ -n "$found" ] && ! sorted="$(printf '%s\n' "$found" | LC_ALL=C sort)"; then
+			printf 'kp_skill_shell_surfaces: sort failed for %s — the surface is UNKNOWN, not empty; emitting nothing (#4487).\n' "$skills_dir/$skill" >&2
+			return 1
+		fi
 	fi
+	[ -n "$md" ] && printf '%s\n' "$md"
+	[ -n "$sorted" ] && printf '%s\n' "$sorted"
 	return 0
 }
 


### PR DESCRIPTION
Closes #4487

## The defect

`kp_skill_shell_surfaces` ended in an unconditional `return 0`, discarding its `find | LC_ALL=C sort` status. `find` exits non-zero on a **partial** failure (unreadable subdirectory, a race with a writer) while still printing the entries it could read — so the resolver handed back a **silently narrowed but non-empty** surface, and both cycle validators zero-scope guards (`[ "${#surfaces[@]}" -eq 0 ]`) read that as complete. A validator then grepped a subset of the real surface and reported green. The fail-open class of #4509 / ADR 0092: a scan that could not run must not resolve to the permissive answer.

## The fix (helper-only — no caller changes)

Both callers consume the resolver through process substitution (`done < <(kp_skill_shell_surfaces …)`), where the producers exit status is unobservable **even in principle**. So the status is captured where the pipeline runs, and a failed scan now:

- emits **nothing** on stdout — the empty list is what reaches the callers **existing** zero-scope guard, which already refuses the skill (`fail: … refusing to scan an empty surface`);
- prints a diagnostic on stderr (non-zero with 0 bytes of output would itself be a fail-open here);
- returns non-zero, for any future caller that can observe it.

`validate-cycle-presence.sh` / `validate-cycle-absence.sh` are **untouched** — they fail closed through the guard they already carry. (Their lane is #4505s; this PR stays out of it.)

The "empty surface is a fact, not an error" contract is preserved: a genuinely empty or absent skill directory still exits 0 emitting nothing. Empty is a fact; a failed scan is UNKNOWN; the two no longer look alike.

## The pin

`claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh` (new, wired into the `skills` CI job) forces the real failure — `chmod 000` on a nested `scripts/` directory so `find` partially fails — and asserts **non-zero + empty stdout + a non-empty stderr diagnostic**, alongside the complete / empty / absent cases. If the fixture does not take (running as root, so `find` still exits 0) it **reds** rather than skipping: an unexercised case is UNKNOWN, not a pass.

**Inversion (the pin is red-able):** run against `main`s pre-fix helper at `aa255c2e` it fails with

```
FAIL: failed find returned 0 — the pipeline status is being discarded (#4487)
common-test: 1 failure(s)   (exit 1)
```

and against the fixed helper all four checks pass.

## Verification (unpiped exits)

| check | exit |
|---|---|
| `bash .claude/skills/shared/lib/common-test.sh` | 0 (4 ok) |
| `bash .claude/skills/validate-cycle-presence.sh` | 0 — 18 checks, scanned scope unchanged |
| `bash .claude/skills/validate-cycle-absence.sh` | 0 — 14 checks, scanned scope unchanged |
| `bash .claude/skills/validate-skills.sh` | 0 — 30 skills valid |
| `trap-status-guard check` (full corpus, `.md` + `.sh`) | 0 — 258 files, 182 shell units |
| `cli-invocation-guard check` (full corpus) | 0 |
| `gh-phoenix lint-skills` (full plugin corpus) | 0 |
| `leak-guard scan` (both `.sh` + the pattern doc) | 0 — 2 shell surfaces, clean |
| `path-filter-guard check` | 0 |
| `pnpm typecheck` | 0 |

Both new/edited `.sh` files follow the house shape: `set -uo pipefail`, never `-e`, and **no EXIT trap** (cleanup is explicit) — the bash 3.2 swallow of #4479.

## Files

- `claude-plugins/kampus-pipeline/skills/shared/lib/common.sh` — the fix (edited)
- `claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh` — the pin (new)
- `.github/workflows/ci.yml` — one `- run:` line in the existing `skills` job
- `.patterns/skill-script-shell-shape.md` — rule 6: a resolver read through process substitution withholds its output on a failed scan

## Deviations

- **Scope narrowing — the helper was deliberately NOT relocated.** **Said:** #4487's Related note says "a fix here should land wherever the lib lives", pointing at #4484 (relocating this shared lib out of `skills/`). **Did:** the fix lands in place, at `claude-plugins/kampus-pipeline/skills/shared/lib/common.sh`; nothing was moved. **Why:** relocation is #4484's lane — it is a keystone that re-paths every extracted script that sources this lib, so re-pathing it here would collide head-on with that build. A behavioural fix and a path move are independently reviewable, and coupling them would make both harder to gate. **Disposition:** no action needed here; the fix travels with the file when #4484 moves it. Related: #4487's AC 4 (fold the resolution into the broader #4479 / #4482 class-level fix) is correctly `[N/A]` — it is a conditional criterion, the resolution was *not* folded, so its cross-link obligation never armed.

- **Scope narrowing — zero caller edits, deliberately.** **Said:** #4487's AC 3 asks that `validate-cycle-presence.sh` / `validate-cycle-absence.sh` "fail closed — or at minimum fail loudly — when the resolver reports a failed scan". **Did:** neither caller is touched. **Why:** both read the resolver through `done < <(kp_skill_shell_surfaces …)`, where a producer's return status is unobservable *even in principle* — there is nothing at those call sites to check. So the fix withholds stdout on a failed scan and lets each caller's pre-existing `[ "${#surfaces[@]}" -eq 0 ]` zero-scope refusal fire, which is verified end to end in the Verification table. Rewriting either caller to observe a status would have crossed into #4505's lane (`validate-cycle-*.sh`), which this PR deliberately stays out of. **Disposition:** no action needed — AC 3 is satisfied behaviourally with an empty diff at the call sites.

- **Known limitation left in place — downstream, "empty" and "failed" are indistinguishable.** **Said:** #4487's AC 2 asks that a *failed* `find` be distinguished from an *empty* result. **Did:** the distinction is real at the function boundary (rc 1 + a stderr diagnostic vs. rc 0 + silence) but **collapses downstream**: both callers see the same empty array and take the same zero-scope refusal path, so neither can tell "empty because this skill has no shell surface" from "empty because the scan failed". **Why:** it is the safe direction and costs nothing *here*, because an empty surface was already a FAIL for both callers — the two paths were always going to converge on a refusal. The distinction survives only in the return status (for any future caller that can observe one) and in the stderr diagnostic (for a human reading the log). **Disposition:** stated plainly rather than fixed, and recorded at the resolver's docblock and in `.patterns/skill-script-shell-shape.md` rule 6. **The hazard to know before writing a third consumer:** a consumer that treats an empty surface as *benign* rather than as a refusal would reintroduce exactly the fail-open this PR closes — for such a consumer, `< <(…)` is not an acceptable read shape.

- **Process incident — a worktree edit-bleed, disclosed and repaired.** **Said:** this build runs in an isolated worktree; the primary checkout is never mutated. **Did:** a first edit to `.patterns/skill-script-shell-shape.md` landed in the **primary** checkout instead of the worktree (the harness resets a Bash cwd back to the primary between calls). **Why:** operator error against that cwd reset, not a deliberate choice. **Disposition:** repaired immediately — the edit was copied into the worktree, where it is part of this diff, and the primary's copy was restored byte-identical from `git show`. The `review-skill` gate independently re-verified the primary afterwards and found it pristine: all four PR-touched paths byte-identical to `origin/main`, and no stray `common-test.sh` left behind. No residue, and nothing about the primary is load-bearing for this PR's diff.

## §CP

`skills/**/*.sh` — needs a human approval.
