### PR TITLE
refactor(review-code): the ADR-0158 thread read moves into scripts/, and the guard follows (#4451)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1085,36 +1085,20 @@ fields, not `reviewThreads`; ADR
 [0158](https://github.com/kamp-us/phoenix/blob/main/.decisions/0158-unresolved-review-thread-is-a-merge-gate.md)).
 Every other read/write in this skill stays REST.
 
-> **This is the one block that did NOT move into [`scripts/`](scripts/) (#4451).** The
-> `skill-gh-lint` job runs `gh-phoenix lint-skills` over the corpus and FAILs on any `gh api graphql`
-> in a runnable block — **including a whole `.sh`**. The lint's `SELF_EXEMPT_SUFFIXES` exempts
-> `/skills/review-code/SKILL.md` as a whole file, so the read is lawful *here* and would be flagged
-> the moment it landed in a script. The idiom that would cover an extracted script already exists:
-> [#4491](https://github.com/kamp-us/phoenix/pull/4491) **landed** (`15263296`) two **per-script**
-> entries in that same array, annotated there as deliberately *not* a `scripts/`-wide exemption. But
-> adding a `review-code/scripts/*.sh` entry edits
-> `packages/pipeline-cli/src/tools/gh-phoenix/lint.ts` — a **code-class** file outside a skills-only
-> extraction child. The operative rule: a block a guard parses out of the markdown cannot move until
-> the guard follows. It stays inline until that lands, and the remainder is tracked on
-> [#4451](https://github.com/kamp-us/phoenix/issues/4451).
+The read lives in [`scripts/unresolved-threads-read.sh`](scripts/unresolved-threads-read.sh), and the
+guard followed it there: `gh-phoenix lint-skills` FAILs on any `gh api graphql` in a runnable
+surface — **including a whole `.sh`** — so that script carries its own **per-script** entry in the
+lint's self-exempt array, the shape [#4491](https://github.com/kamp-us/phoenix/pull/4491) set for
+`ship-it`'s two halves. Per-script, deliberately never a `scripts/`-wide exemption: the sanctioned
+query is one file's licence, not the directory's.
 
 ```bash
-ORG="${REPO%%/*}"; NAME="${REPO#*/}"
-# The ONE GraphQL read in review-code (ADR 0158): REST exposes no isResolved.
-gh api graphql -f query='
-  query($o:String!,$n:String!,$pr:Int!) {
-    repository(owner:$o, name:$n) {
-      pullRequest(number:$pr) {
-        reviewThreads(first:100) {
-          nodes { isResolved path line comments(first:1){ nodes { author { login } body } } }
-        }
-      }
-    }
-  }' -F o="$ORG" -F n="$NAME" -F pr="$PR" \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)
-        | {path, line, author: .comments.nodes[0].author.login, body: (.comments.nodes[0].body[0:200])}'
-echo "unresolved-threads: scanned the PR's review threads (§ZS: this read ran)"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/unresolved-threads-read.sh" "$PR"
 ```
+
+Read the script's **exit status before its stdout**: an unreadable `reviewThreads` response prints
+its own `UNREADABLE` line and exits non-zero, because at a script boundary an empty stdout would
+otherwise read as the permissive answer — no unresolved threads. UNKNOWN is never "no" (§ZS).
 
 Fold the result into the conjunctive table exactly like Step 3b/3c/3d:
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/unresolved-threads-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/unresolved-threads-read.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Step 3e — the PR's UNRESOLVED inline review threads (ADR 0158). Extracted from
+# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+#
+# This file carries review-code's ONE sanctioned GraphQL read: `isResolved` has no REST surface, so
+# ADR 0158 exempts this single query from the skill's REST-only rule. It is why `gh-phoenix
+# lint-skills` names THIS path in its self-exempt array — a per-script entry, never a `scripts/`-wide
+# one. Nothing else in this skill may reach for GraphQL.
+set -uo pipefail
+# shellcheck source=../../shared/lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: unresolved-threads-read.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || {
+	echo "unresolved-threads: UNREADABLE — could not resolve the target repo; thread state is UNKNOWN, which is never 'no unresolved threads' (§ZS)."
+	exit 1
+}
+
+ORG="${REPO%%/*}"; NAME="${REPO#*/}"
+# The ONE GraphQL read in review-code (ADR 0158): REST exposes no isResolved.
+gh api graphql -f query='
+  query($o:String!,$n:String!,$pr:Int!) {
+    repository(owner:$o, name:$n) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes { isResolved path line comments(first:1){ nodes { author { login } body } } }
+        }
+      }
+    }
+  }' -F o="$ORG" -F n="$NAME" -F pr="$PR" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)
+        | {path, line, author: .comments.nodes[0].author.login, body: (.comments.nodes[0].body[0:200])}'
+RC=$?
+# The script boundary invents a channel the inline block never had: a non-zero exit with zero bytes
+# of stdout, which the prose downstream would read as "no unresolved threads" — the permissive
+# answer. So a failed read speaks its own sentinel and exits non-zero, and the §ZS line below is
+# only ever printed on a read that actually ran.
+if [ "$RC" -ne 0 ]; then
+	echo "unresolved-threads: UNREADABLE — the reviewThreads read exited $RC; thread state is UNKNOWN, which is never 'no unresolved threads' (§ZS)."
+	exit 1
+fi
+echo "unresolved-threads: scanned the PR's review threads (§ZS: this read ran)"

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
@@ -114,6 +114,9 @@ const SELF_EXEMPT_SUFFIXES = [
 	// would silently exempt every future extracted script from a live lint.
 	"/skills/ship-it/scripts/step3_6-threads-read.sh",
 	"/skills/ship-it/scripts/step3z-dropped-trigger.sh",
+	// review-code's half of the same ADR-0158 sanctioned read, extracted by #4451. Same per-script
+	// granularity, same reason.
+	"/skills/review-code/scripts/unresolved-threads-read.sh",
 	"/skills/gh-issue-intake-formats.md",
 	"/packages/pipeline-cli/src/tools/gh-phoenix/README.md",
 ] as const;

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
@@ -73,6 +73,15 @@ describe("scanFile — flags GraphQL-path gh calls", () => {
 		assert.strictEqual(scanFile("s/SKILL.md", "the project board is classic").length, 0);
 	});
 
+	it("self-exempts the ADR-0158 sanctioned read PER SCRIPT, not the scripts/ directory", () => {
+		assert.isTrue(isSelfExempt("skills/review-code/scripts/unresolved-threads-read.sh"));
+		assert.isFalse(isSelfExempt("skills/review-code/scripts/pr-diff.sh"));
+		assert.isAbove(
+			scanFile("skills/review-code/scripts/pr-diff.sh", "gh api graphql -f query='{...}'").length,
+			0,
+		);
+	});
+
 	it("self-exempts the write-code skill (it documents the REST-only rule)", () => {
 		assert.isTrue(isSelfExempt(".claude/skills/write-code/SKILL.md"));
 		assert.strictEqual(


### PR DESCRIPTION
Part of #4451 — the second and (bar one blocked block) final pass of the review-code shell extraction. PR #4504 landed the bulk; this lands the one block that PR deliberately left inline, and the guard change that made it movable.

## Measured before / after, at `main` = `aa255c2e`

| | before | after |
|---|---|---|
| fenced blocks, all languages | 37 | 37 |
| fenced `bash`/`sh` blocks | 27 | 27 |
| …of those, carrying **more than one non-comment line** | **5** | **4** |

Re-measured on this branch, not inherited from the earlier check — the numbers were unchanged since it ran.

## Per-block classification of the five multi-line blocks

**Moved (1)**

- **Step 3e, the ADR-0158 `reviewThreads` read** (14 non-comment lines) → [`scripts/unresolved-threads-read.sh`](claude-plugins/kampus-pipeline/skills/review-code/scripts/unresolved-threads-read.sh). This is the sanctioned GraphQL exception: `isResolved` has no REST surface, so ADR 0158 exempts this single query from the skill's REST-only rule. Semantics preserved exactly — the query, its `-F` bindings, its `--jq` projection and the §ZS line are byte-identical (recipe below) — and the script's header states plainly that it is the one sanctioned read and why the lint exemption is per-script.

**Left, with reason (4)**

- **Step 1, `PR=<pr number>` + `pr-context.sh "$PR"`** (2 lines) and **Step 1, `ISSUE=<N>` + `issue-context.sh "$ISSUE"`** (2 lines). The extra line in each is a **placeholder parameter binding**, not glue: `$PR` / `$ISSUE` are the names every later step's invocation reads. Collapsing them into the invocation would delete the binding the rest of the skill depends on. The shell that *does* anything is already a bare script invocation.
- **§5 FAIL path, `HEAD_SHA="$(current-head.sh …)"` + `printf … | verdict-emit-fail.sh`** (2 lines). Both lines are already script invocations — the target shape, just two of them. Nothing to extract.
- **The ADR-0079 fan-out append fence** (25 non-comment lines) — **blocked, not skipped.** PR #4440 (open) relocates this entire `## Specialist fan-out + route-don't-grade` section out of every gate into `../shared/specialist-fan-out.md` (#4396). Extracting it here would move the same lines a second, conflicting way. Its in-file deferral note is unchanged and still tracks the remainder on #4451.

## The one added seam (why this is still a byte-move)

The script boundary invents a channel the inline block never had: **a non-zero exit with zero bytes of stdout**, which the prose downstream would read as the permissive answer — *no unresolved threads*. So the script prints its own `UNREADABLE` sentinel on stdout **and** exits non-zero on a failed read or an unresolvable repo, and the `§ZS: this read ran` line is now only reachable on a read that actually ran. That is the error-channel rule this skill's own `## The extracted scripts` section mandates for every extracted guard, not a rewrite of the glue (rewriting it into verbs is phase 2, #1929).

No `EXIT` trap, `set -uo pipefail` (never `-e`) — the house shape.

## The guard followed the block (the cross-class edit, called out)

Extracting the read required the lint to stop flagging it: `gh-phoenix lint-skills` FAILs on `gh api graphql` in any runnable surface, **including a whole `.sh`**, and `SELF_EXEMPT_SUFFIXES` only listed `/skills/review-code/SKILL.md`. This PR adds **one per-script entry** — the exact shape #4491 landed for `ship-it`'s two halves — plus a unit test that pins the granularity: the sanctioned script is exempt, a sibling `review-code/scripts/*.sh` is **not**, and a GraphQL call in that sibling still reds. Deliberately never a `scripts/`-wide exemption.

`packages/pipeline-cli/src/tools/gh-phoenix/lint.ts` is a code-class file outside a skills-only extraction child; it is touched here because the block cannot move without it, and PR #4504's in-file note named this as the exact prerequisite. It is **not** a guard-tool directory and no other open PR touches it.

## ADR-0079 fan-out section: **not touched**

Stated for the triage re-examination of #4396 / PR #4440. This PR does not edit that section, its fence, or its deferral note. It also does not touch the verdict-marker contract text or the read-back block (#4438's surface).

## Reviewer-runnable verification recipe

Byte-equivalence of the moved block, against `main`:

```bash
git show origin/main:claude-plugins/kampus-pipeline/skills/review-code/SKILL.md \
  | sed -n '1102,1115p' > /tmp/orig-block.txt
sed -n '22,35p' claude-plugins/kampus-pipeline/skills/review-code/scripts/unresolved-threads-read.sh \
  > /tmp/new-block.txt
diff /tmp/orig-block.txt /tmp/new-block.txt      # empty: 14 lines verbatim
git show origin/main:claude-plugins/kampus-pipeline/skills/review-code/SKILL.md | sed -n '1116p' \
  | diff - <(tail -n 1 claude-plugins/kampus-pipeline/skills/review-code/scripts/unresolved-threads-read.sh)
```

Block census on this head:

```bash
awk '/^```/{f=!f; if(f){lang=substr($0,4); n=0; next} else {print lang, n}} f && $0 !~ /^[[:space:]]*(#|$)/ {n++}' \
  claude-plugins/kampus-pipeline/skills/review-code/SKILL.md | awk '$1=="bash" && $2>1'
```

## Guards, unpiped exits, with scope lines

| check | scope handed | scope line | exit |
|---|---|---|---|
| `shellcheck -S style` (new script) | 1 `.sh` | — | 0 |
| `trap-status-guard check` | SKILL.md + the `.sh` | `scanned 2 file(s), 27 runnable bash/sh fence(s) in markdown, 1 shell file(s)` | 0 |
| `leak-guard scan` | 4 changed files | `4 file(s) handed: 1 doc surface, 1 shell surface, 0 self-exempt, 2 out of scope` | 0 |
| `cli-invocation-guard check` | SKILL.md + the `.sh` | `scanned 2 file(s), 27 runnable bash/sh fence(s), 1 shell file(s)` | 0 |
| `gh-phoenix lint-skills` (full corpus, as CI) | 241 corpus files | `gh-call 234 · frontmatter 39 · bare-push 241` | 0 |
| `validate-skills.sh` | corpus | `OK — 30 skills valid` | 0 |
| `validate-cycle-presence.sh` / `validate-cycle-absence.sh` | corpus | — | 0 / 0 |
| `validate-gate-path-drift.sh` | corpus | — | 0 |
| `pnpm typecheck` | repo | — | 0 |
| `pnpm lint` (biome) | repo | `Checked 5 files` | 0 |
| `@kampus/pipeline-cli` suite | — | `185 test files, 2995 tests passed` | 0 |

Test-file count is **unchanged at 185** — the new case is one `it()` added to the existing `lint.unit.test.ts` (41 tests in that file, verified running).

Handing `lint-skills` **only** the two files this PR touches correctly returns exit **3** (zero scope) now that both are self-exempt — which is the guard working, and why the table reports the full-corpus run CI actually performs.

## What remains on #4451

One block: the ADR-0079 fan-out append fence, blocked on PR #4440 landing (or being closed) first.
