### PR TITLE
refactor(pipeline): collapse the four verdict-marker sections into one gate-verdict contract (#4438)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -122,7 +122,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   on line 2 is un-anchored, resolves empty, and fail-closes a substantively-PASS PR (the PR #2456
   stall; the forbidden "stacked" emit form in
   [the gate-verdict contract](../skills/shared/gate-verdict-contract.md) §VERDICT — cited, not
-  re-derived here). Upsert each one-per-PR per its skill. The
+  re-derived here). Upsert each on the §VERDICT key — (PR, gate-namespace, head, run) — per its
+  skill, so a re-review at a new head appends rather than overwriting the prior head's record and a
+  concurrent reviewer never clobbers yours (ADR 0213); never hand-roll the `PATCH`. The
   verdicts on the PR are the whole output — a verdict returned only to the orchestrator and
   never posted is a dropped gate.
 <a id="fan-across-every-present-class-in-lockstep-with-ship-its-live-class-probes-class_reresolve"></a>

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -120,7 +120,8 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   that comment's literal first line, never two markers stacked in one comment.** Each namespace's
   `^` anchor pins its marker to the first line of *its own* comment, so a second namespace stacked
   on line 2 is un-anchored, resolves empty, and fail-closes a substantively-PASS PR (the PR #2456
-  stall; the forbidden "stacked" emit form in `gh-issue-intake-formats.md` §5 — cited, not
+  stall; the forbidden "stacked" emit form in
+  [the gate-verdict contract](../skills/shared/gate-verdict-contract.md) §VERDICT — cited, not
   re-derived here). Upsert each one-per-PR per its skill. The
   verdicts on the PR are the whole output — a verdict returned only to the orchestrator and
   never posted is a dropped gate.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -9,11 +9,14 @@ agent-operable work pipeline:
 2. The **sub-issue body format** — one executable task, mirroring a task entry.
 3. The **progress-comment format** — a per-issue work-log entry for the next agent.
 4. The **epic handoff-note format** — distilled cross-task context posted to the epic.
-5. The **review-code verdict markers** — the recognizable first line of a PR comment
-   signalling the verdict, **SHA-bound** to the head it reviewed (ADR 0058):
-   `PASS @ <sha> — merge-ready` (read by `ship-it`, the merge step) or
-   `FAIL @ <sha> — not merge-ready` (read by `write-code`'s fix round-trip).
-6. The **review-doc verdict markers** — the doc-class twin of format 5, in its own namespace.
+5. The **gate-verdict markers** — the recognizable first line of a PR comment signalling a
+   gate's verdict, **SHA-bound** to the head it reviewed (ADR 0058):
+   `PASS @ <sha> — merge-ready` (read by `ship-it`, the merge step) or the FAIL form (read by
+   `write-code`'s fix round-trip). All four gate namespaces share **one** spec, which lives in
+   [`shared/gate-verdict-contract.md`](shared/gate-verdict-contract.md) §VERDICT — not here.
+6. The **§CP advisory line** and the **verdict read-back / guarded-emit rules** — same file,
+   §ADVISORY and §READBACK. (Formats 5 and 6 left this document with #4438; the numbering is
+   kept so §7 and §8 citations still resolve.)
 7. The **issue-claim semantics** — self-assign as a detect-and-tiebreak (not a lock), the
    protocol `write-code`'s pick (Step 1) and claim (Step 3) implement.
 8. The **investigation→trivial-fix collapse rule** — the bounded exception (ADR 0070) that
@@ -1081,150 +1084,6 @@ silently leaks a local path into a **public** comment:
   route around this with `-F body=@file`: the `$BODY`-by-value form is the single idiom every
   skill here uses — reach for it, not a second mechanism.)
 
-### The verdict read-back guard — after posting a gate marker, re-read it and FAIL LOUD (`verdict_readback_guard`)
-
-The by-value form above (`-f body="$BODY"`) is the *source* idiom; it prevents a `body=@<path>`
-leak **at the call site**. But a source idiom cannot catch a **runtime deviation** — an agent that
-hand-assembles the wrong `$BODY` (the literal temp path as the marker body, a body missing its
-`Reviewed-head:` anchor, or a silently no-opped post) still lands a broken marker the by-value form
-happily transmits. That is the #2148 class: the posted verdict comment's entire body was a local
-temp path (`@/var/folders/…`), so no SHA-bound verdict existed for `ship-it` / the §CP merger to
-bind to (a **missing** gate verdict), **and** it leaked a machine-local path into a public comment.
-The source idiom alone can't see it; only a **post-write read-back** can.
-
-So every gate that posts a verdict marker — `review-code`, `review-doc`, `review-skill`,
-`review-design` — closes the loop with **one** canonical read-back guard: after the post/upsert
-lands, **re-read the comment you just wrote** and assert three invariants, failing **loud**
-(fail-closed, ADR
-[0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md) §ZS)
-on any miss — never a silent pass. This is the single source; each review skill **references it**
-(it does not re-derive its own copy — the three-copy drift is exactly what this contract exists to
-prevent):
-
-```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/verdict-readback.sh"                                  # §SHARED: both guards, one source
-verdict_readback_guard "$CID" review-code "$HEAD_SHA" || …          # <gate> ∈ review-{code,doc,skill,design}
-```
-
-[`shared/scripts/verdict-readback.sh`](shared/scripts/verdict-readback.sh) carries the four checks and
-their reasons: **(0)** a non-empty body, **(1)** a canonical `<gate>:` marker — the bindable
-`PASS|FAIL @ <sha>` first line or the SHA-less `advisory` one, **(2)** the SHA-source-aware head
-binding, **(3)** no local-filesystem-path leak. Any miss returns non-zero and names the cause.
-
-Gate it exactly like the by-value post it follows: right after the `PATCH`/`POST` upsert returns the
-comment id, call `verdict_readback_guard "$CID" <gate> "$HEAD_SHA"` and, on non-zero, **re-post the
-real verdict and re-assert** — if it still cannot land clean, surface it as a **posting failure** in
-the run ledger (the PR is genuinely ungated; a consumer must not read it as verified), never swallow
-it as a silent success. A moved `HEAD_SHA` between the post and the read-back means the head advanced
-*during* the review — re-resolve the head, re-verify against it (the gate is stateless), and re-post;
-never loosen the match to paper over a moved head. (In practice a gate never calls this primitive with
-a hand-carried id — it calls the unconditional `verdict_post_verify` wrapper below, which resolves the
-landed comment id by re-scanning PR state and passes it here.)
-
-Check (2) is **SHA-source-aware** (#2272): the read-back fires on every verdict type without
-false-failing a legitimate non-blocking PASS. The bindable PASS/FAIL first line satisfies (1) via its
-`@ <sha>` — that SHA **is** the head binding, so (2) requires no separate `Reviewed-head:` line (the
-non-blocking binding templates carry the SHA only on the first line; this is the branch that keeps a
-clean non-blocking doc/skill PASS from false-failing under the unconditional `verdict_post_verify …
-|| exit 1`). The advisory blocking-set path carries no first-line `@ <sha>` by design (ADR 0111),
-which is why (1) accepts the `<gate>: advisory` first line; it binds the head **in the body** via the
-canonical `Reviewed-head: @ <sha>` line, which §6.6/ADR 0151 mandates on **all four gates'** advisories
-— **review-code included** (#2329: the earlier "review-code's §CP advisory carries NONE by design →
-accept its absence" carve-out contradicted §6.6's MUST and blinded (2) to a drifted `**Reviewed head:**`
-variant, which ship-it's §6.6 enqueue matcher then rejects; the carve-out is removed, so a missing or
-drifted advisory head-binding fails **loud at emission** rather than surfacing as a ship-it refusal on
-an approved PR). Any `Reviewed-head:` line present but bound to the wrong sha is always fatal. The
-canonical-marker check (1) and the leak check (3) are **unconditional** on every verdict type — the
-#2148/#2264 path-leak protection is never relaxed.
-
-### Make the read-back UNCONDITIONAL — resolve the landed verdict from PR state, never a carried id (`verdict_post_verify`)
-
-`verdict_readback_guard` above is correct but only fires **if it is reached with the right comment
-id**. The #2264 recurrence (after #2148/#2153 already "fixed" the leak) proves that condition is the
-real gap: the guard was invoked as `verdict_readback_guard "$MINE" …`, and `$MINE` is populated on
-**one** posting branch only (the APPROVE-failed comment-upsert `else` fallback). A verdict that lands
-by any **other** path — the native `APPROVE`, a first-verdict `POST` on a branch that didn't set
-`$MINE`, or an agent hand-rolling `gh api -f body=@file` — reaches the guard with an **empty** id, so
-the guard reads nothing and the broken/leaking marker sails through. A guard you can skip by taking a
-different post branch is not a guard.
-
-The fix is to **stop trusting a carried variable and re-derive the landed verdict from live PR
-state**, then run the read-back **unconditionally** on whatever landed. This is the single wrapper
-every gate calls after posting — it resolves the marker comment id by re-scanning, proves *a* verdict
-actually landed for the head, and **hard-fails (non-zero)** on absent / broken / leaking so a garbled
-or path-leaking marker is a **fatal** error the gate cannot silently pass:
-
-```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/verdict-readback.sh"                                  # §SHARED: the wrapper and the guard it calls
-verdict_post_verify "$PR" review-code "$HEAD_SHA" || exit 1         # UNCONDITIONAL, after ANY post/upsert
-```
-
-It resolves the landed verdict from live PR state — **(A)** my SHA-bound or advisory marker comment,
-**(B)** a native `APPROVE` whose `commit_id` is this head — never from a carried `$MINE`/`$CID`; then
-**(C)** hard-fails when nothing bound to the head landed, **(D)** runs the read-back on the landed
-comment whichever branch posted it, and **(E)** leak-checks the native-`APPROVE` body too. Returns 0
-only on a proven-clean landed verdict.
-
-**Why this closes the #2264 recurrence — the post-path enumeration.** Every way a gate can land a
-verdict now routes through the same unconditional read-back, because `verdict_post_verify` resolves
-the landed surface from PR state instead of from a branch-local variable:
-
-- **native `APPROVE`** → resolved by (B); its body is leak-checked by (E); commit_id is its SHA anchor.
-- **comment `PATCH`-upsert** (the old `$MINE` branch) → resolved by (A); shape+leak by (D).
-- **comment `POST`** (first verdict, `$MINE` empty) → resolved by (A); shape+leak by (D). *This is the
-  branch the carried-`$MINE` call silently skipped.*
-- **advisory comment** (§CP blocking-set) → resolved by (A) via the `<gate>: advisory` arm; shape+leak by (D).
-- **hand-rolled `gh api -f body=@file`** (the literal path as the whole body) → has **no** `<gate>:`
-  first line, so (A) resolves empty and (B) is 0 ⇒ **(C) fatal** (`ungated`). A garbled marker is fatal.
-
-The single **fatal** exit on absent/broken/leaking is the load-bearing change: the prior Step-4c
-presence check merely *echoed* a warning and re-posted without a non-zero exit, so a garble read as
-green. Callers **must** propagate the non-zero — `verdict_post_verify … || exit 1` — so the gate
-cannot report itself done over an ungated PR.
-
-Gate it exactly like the by-value post it follows: right after the last of the Step-5/4a-4b upsert
-branches runs, call `verdict_post_verify "$PR" <gate> "$HEAD_SHA" || exit 1`. On a moved `HEAD_SHA`
-between post and verify the head advanced *during* review — re-resolve the head, re-verify against it
-(the gate is stateless), and re-post; never loosen the match to paper over a moved head.
-
-### The guarded emit path is MANDATORY — never hand-post a verdict marker off the guard
-
-`verdict_post_verify` above is the *read-back*: it re-scans PR state **after** a post and fails loud
-on a marker that landed broken or leaking. But a read-back cannot police a post it never sees. An
-agent that **hand-posts** the verdict marker with a raw `gh api …/comments` or `gh pr comment` call
-bypasses the verdict lib entirely, so `emissionDefect` never fires — and, worse, the marker often
-never resolves through `verdict_post_verify`'s re-scan either, so nothing catches it. That is the
-**emit-side hole** the recurrences rode: #2789 (the whole body was an `@filepath`), #2816 / #2818 (a
-`/var/folders` mktemp path glued into the `@ <sha>` field) — each leaked because the marker was
-hand-posted off the verdict lib, not because the lib's guard was wrong. Code cannot force a hand-post
-through a guard the reviewer never invokes; the **emit path itself** must be mandated, not just
-described.
-
-So for **all four PR gates** — `review-code`, `review-doc`, `review-skill`, `review-design` — routing
-every verdict-marker post through the guarded path is a **hard invariant, not a suggestion**:
-
-- **MUST** post every verdict marker through `pipeline-cli verdict post` — the single marker-emit
-  choke point that runs `emissionDefect` (the body-wide machine-local-path scan added by #2823, plus
-  the 40-hex `@ <sha>` field guards, #2683) and **refuses fail-closed** on a leaking or malformed
-  body. For the native `APPROVE` review body (which `verdict post` cannot emit), run the **same** gate
-  as an explicit read-back assertion — `verdict validate` — **before** the `APPROVE`, so a
-  malformed/leaking marker fails loud rather than landing in a public review body.
-- **FORBIDDEN:** a bare `gh api …/comments` / `gh pr comment` hand-post of a verdict marker that skips
-  the guard. The guarded tool is the **only** sanctioned emit path; a free-form raw post is a bypass,
-  never an equivalent — a reviewer must not free-form the marker even when the body "looks clean."
-- **The one escape hatch, itself guarded:** if a raw post is genuinely unavoidable, the body **MUST**
-  first pass `pipeline-cli leak-guard scan-comment` (the standalone pre-post net #2823 added — reads
-  the body on stdin / `--body-file`, exits non-zero on a machine-local path) **before** the post. A
-  raw post whose body was never scanned is the forbidden case; a scanned one is the escape hatch.
-
-This is the **enforcement complement** to #2823: #2823 hardened the guard *code* (`emissionDefect`'s
-body-wide scan + the `leak-guard scan-comment` CLI); this mandate closes the emit-side hole by
-forbidding the reviewer from routing around it — the two together are what actually close #2796. Each
-review gate **references this rule as the single source** (it does not re-derive the *why* per skill).
-Per #2393 the guard stays generic path-shape patterns, never a named-path deny-list.
-
 ---
 
 ## 3. Progress-comment format
@@ -1686,8 +1545,8 @@ over a PR's changed files, so it has no such read.
 
 ## DOC. The doc-class / review-doc surface — one canonical definition
 
-`review-doc` and the actors that cite it (`ship-it` Step 0, `write-code`, this file's §6
-marker prose) all need the *same* answer to a second question — **is this `*.md` a doc
+`review-doc` and the actors that cite it (`ship-it` Step 0, `write-code`, the gate-verdict
+contract's §VERDICT marker prose) all need the *same* answer to a second question — **is this `*.md` a doc
 artifact, or code-adjacent markdown that rides `review-code`?** The doc class was once
 described loosely as "prose `*.md` outside `.claude/`/`.github/`", which over-matched a
 **code-root** `*.md` (a `packages/**`/`apps/**` README) into the doc class even though no
@@ -2372,7 +2231,7 @@ assert it did:**
 1. **Resolve + materialize the head via the shared `pipeline-cli review-head` verb — never
    re-derive it inline** (#3690 / #793 / #1807; `packages/pipeline-cli/src/tools/review-head/`).
    The verb owns the deterministic mechanism this section used to spell out inline: it resolves the
-   live head SHA up front via REST (never GraphQL — the SHA the verdict binds to, §5/ADR 0058),
+   live head SHA up front via REST (never GraphQL — the SHA the verdict binds to, §VERDICT/ADR 0058),
    fetches the head into a per-run ref (never the launched checkout — the §RO read-only path), and
    **asserts the fetched ref resolves to exactly that SHA before you review** — aborting on a moved
    head rather than binding a stale verdict. Two modes, same core:
@@ -2401,7 +2260,7 @@ assert it did:**
 4. **Re-check the live head before posting; abort a stale-bound verdict.** If the head moved
    while you reviewed (re-resolve `headRefOid` and compare to `$HEAD_SHA`) or the head can't be
    reached, do **not** post a verdict bound to a SHA you no longer reviewed — re-resolve and
-   re-review the new head, or abort. A verdict's `@ <HEAD_SHA>` marker (§5) must name the SHA
+   re-review the new head, or abort. A verdict's `@ <HEAD_SHA>` marker (§VERDICT) must name the SHA
    whose *files you actually read*, and the verdict body must **assert it read the PR head (not
    the launched CWD)**, so a base-code review is self-evidently invalid to a human adjudicator.
 
@@ -2410,540 +2269,6 @@ Gates that materialize a full head worktree for behavior verification (`review-c
 `pnpm -C "$REVIEW_WT"`; the diff-only gate (`review-doc`) satisfies it via
 `git show "$PR_REF:<path>"`. Either way, the launched checkout's working copy is never the
 source of code under review.
-
----
-
-## 5. review-code pass marker
-
-When `review-code` lands its verdict and a native review can't be posted (e.g. org
-branch rules forbid reviewing your own PR), it falls back to a **comment whose first
-line is a recognizable marker**. That marker is a downstream contract: the **`ship-it`**
-skill scans PR comments for the PASS marker to find verified, merge-ready PRs
-unambiguously, and `write-code`'s fix round-trip scans for the FAIL marker to find a PR
-that came back failed.
-
-### Shape — SHA-bound (ADR 0058)
-
-The recognizable **first line** of the PR comment carries the **head SHA the reviewer
-inspected** (`@ <sha>`), resolved at post time from
-`gh api repos/$REPO/pulls/$PR --jq .head.sha`:
-
-```markdown
-review-code: PASS @ <sha> — merge-ready
-```
-
-```markdown
-review-code: FAIL @ <sha> — not merge-ready
-```
-
-`<sha>` is the full or abbreviated (≥7 hex) head SHA. The rest of the comment body carries
-the per-criterion evidence table (the verdict). What's load-bearing for the scanner is only
-that first marker line — the namespace, the polarity, **and the `@ <sha>`**; the table below
-it is for the human and the implementer.
-
-The `@ <sha>` is **load-bearing, not decoration**: `ship-it` and `write-code`-repair refuse a
-verdict whose `@ <sha>` does not match the PR's *current* head, and refuse a SHA-less marker
-outright — this is what closes the stale-PASS-masks-a-FAIL and head-moved-under-the-verdict
-races (ADR [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258). A marker
-with no `@ <sha>` is a *pre-0058 legacy* shape and resolves to `unverified`, not PASS.
-
-### Upsert, not append — one verdict per (PR, gate-namespace) (ADR 0058)
-
-`review-code` writes **exactly one** marker comment per PR in its namespace. That upsert is
-**`pipeline-cli verdict post`'s own behavior, not something a reviewer hand-rolls**: the verb
-scans the PR for **its own** prior `review-code:` marker keyed on `(namespace, head, runId)`
-and, if one exists, replaces that comment in place with the fresh verdict + fresh `@ <sha>`
-instead of appending a new one. A re-review at a **new** head appends a fresh record and leaves
-the prior head's verdict standing (that is what the `head` dimension of the key buys — #4007,
-ADR 0213); a re-post at the **same** head upserts, so no head's slot ever accumulates a stale
-verdict stream a millisecond decides. See ADR 0058 rule 2.
-
-**Do not translate this into a raw `gh api` comment `PATCH`.** A hand-rolled patch of a verdict
-body is a marker hand-post — it skips `emissionDefect` and the post-write `verifyLanded` re-scan,
-which is exactly the emit-side bypass [The guarded emit path is
-MANDATORY](#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard)
-forbids (#2789 / #2816 / #2818). If a raw post is genuinely unavoidable, take that section's one
-escape hatch — `pipeline-cli leak-guard scan-comment` on the body **first**.
-
-### The matcher contract: emphasis-tolerant + SHA-capturing (canonical shape)
-
-The marker line may carry **leading Markdown emphasis** — `review-code` historically emits
-it bolded (`**review-code: PASS @ <sha> — merge-ready**`), `review-doc` emits it bare. To stop
-the emitter and the matcher from drifting apart (the bolded marker once read as "no verdict"
-and stalled every code-lane merge — #219), this contract pins **one** rule both sides cite:
-
-- **Canonical emit shape** (what an emitter SHOULD write): the bare, unbolded first line —
-  `review-code: PASS @ <sha> — merge-ready`. New/converging emitters write this.
-- **Token order is fixed** (the single source every emitter cites): the `@ <sha>` comes
-  **immediately after** the `PASS`/`FAIL` polarity and **before** the `— merge-ready` /
-  `— not merge-ready` tail — `review-code: PASS @ <sha> — merge-ready`, never
-  `review-code: PASS — merge-ready @ <sha>`. The matcher below is **anchored to this order**:
-  it captures the SHA only when `@ <sha>` directly follows the polarity, so a marker that
-  pushes `@ <sha>` *past* `merge-ready` captures `sha=null` → the consumer resolves it
-  `unverified` and refuses a correct, current-head PASS (the token-order drift that silently
-  stalled #623's merge — #625). The fix is to **emit the canonical order**, not to loosen the
-  matcher to chase a trailing SHA (ADR 0058 forbids weakening the SHA-binding). §6/§6.5 inherit
-  this order for `review-doc` / `review-skill` via the same matcher contract.
-- **Matcher obligation** (what every scanner MUST accept): an **optional leading `**`** before
-  the namespace token, so a bolded marker resolves identically to a bare one, **and a captured
-  `@ <sha>`** so the consumer can apply the staleness test. The anchored, case-insensitive
-  matcher is `^\s*\**\s*review-(code|doc):\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})` — the leading
-  `\**` absorbs the emphasis; `^\s*` still pins it to the start of the body so a mid-body
-  *quote* never matches; the trailing `@\s*([0-9a-f]{7,40})` captures the bound head SHA. A
-  SHA-less marker that matches only the looser `^\s*\**\s*review-(code|doc):\s*(PASS|FAIL)`
-  prefix but **not** the `@ <sha>` tail is a legacy verdict → the consumer treats it as
-  `unverified` (ADR 0058 rule 3). Every matcher site — `ship-it` (merge gate) and `write-code`
-  (fix round-trip) — cites this rule so they can't diverge again.
-- **Forbidden emit forms** (what an emitter MUST NOT write): the matcher above is anchored, so
-  an emitter that freelances any of the shapes below produces a verdict **no consumer can read**
-  — `ship-it` resolves the PR to `unverified` and silently refuses to merge a genuine,
-  current-head PASS (the #1095 stall: a real PASS posted as `<!-- review-code: PASS sha:… -->`
-  sat unmerged). The emit contract is the mirror of the matcher — emit the canonical first line
-  and **none** of these:
-  - **HTML-comment-wrapped** — `<!-- review-code: PASS @ <sha> — merge-ready -->`. The `<!--`
-    is non-whitespace ahead of the namespace token, so it fails the `^\s*\**\s*` anchor (the
-    `\**` absorbs only Markdown emphasis, never `<!--`). The marker must be **live body text**,
-    not an HTML comment — the verdict-marker contract has no HTML-comment form (the only
-    sanctioned HTML comment in these formats is the unrelated AC-append provenance tag of §2).
-  - **`sha:` (or any non-`@`) SHA delimiter** — `review-code: PASS sha:<sha>`. The matcher
-    captures the bound SHA only from the literal `@ <sha>` tail; `sha:<sha>` matches only the
-    looser SHA-less prefix → `unverified`. The delimiter is `@`, never `sha:`/`SHA=`/`commit:`.
-  - **Heading-only / prose-only verdict** — `## review-code verdict: PASS` with no marker line.
-    A heading is not the contract: it carries no `@ <sha>` and isn't anchored at the namespace
-    token. The recognizable first line is required *in addition to* any human-facing heading.
-  - **Marker not on the literal first line** — the `^` anchor pins the marker to the **start of
-    the comment body**; a marker buried after a preamble paragraph never matches. It leads the
-    body.
-  - **Two namespace markers stacked in one comment (the multi-namespace fan)** — on a
-    mixed-class diff the reviewer fans several verdict namespaces (e.g. `review-code` +
-    `review-skill` for a skill+code PR, `review-design` for a UI PR). Each namespace's `^`
-    anchor pins its marker to the first line of **its own comment**, so stacking a second
-    namespace's marker on line 2 of the first's comment leaves that second marker un-anchored:
-    it never matches, its namespace resolves **empty**, and `ship-it` fail-closes a
-    substantively-PASS PR (the live PR #2456 stall — both reviews PASSed, but the stacked
-    `review-skill` marker was unmatchable and recovery needed a manual re-emit). **Emit each
-    fanned namespace's verdict as its OWN separate PR comment, its `<namespace>: PASS|FAIL @
-    <sha>` marker on that comment's literal first line — one comment per namespace, never two
-    markers stacked.** The upsert is still one-comment-per-`(PR, namespace)`; the fan writes
-    N such comments (one each), not one comment carrying N markers.
-  These are emitter bugs, not matcher gaps — the fix is always to **emit the canonical shape**,
-  never to loosen the anchored matcher to chase a malformed marker (ADR 0058 forbids weakening
-  the SHA-binding). §6/§6.5/§6.7 inherit this forbidden-forms list for `review-doc` /
-  `review-skill` / `review-design` via the same matcher contract.
-
-### Field notes
-
-- **First line, recognizable.** The marker leads the comment so a scan can match
-  it without parsing the whole body. Recognize it tolerantly by shape
-  (`review-code: PASS @ <sha>` … `merge-ready`) and emphasis (optional leading `**`, per the
-  matcher contract above), not by exact dashes or spacing — but the `@ <sha>` is required.
-- **Two markers, two consumers.** `PASS @ <sha> — merge-ready` (every criterion verified,
-  bound to that head) is read by `ship-it` as the go-ahead to merge **iff `<sha>` is the
-  current head**. `FAIL @ <sha> — not merge-ready` (≥1 criterion unmet) is read by
-  `write-code`'s fix round-trip as "my PR came back failed"; `ship-it` reads it as "do not
-  merge." Each marker has exactly one merge-relevant meaning.
-- **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on.
-  `review-code` writing it does **not** merge; merging is `ship-it`'s deliberate act
-  (see review-code/SKILL.md §"Authority limit" and ADR 0048).
-- The native approving review (`event=APPROVE`) is the preferred signal when it's
-  available; GitHub records its `commit_id`, which **is** the SHA the reviewer approved, so
-  `ship-it` applies the same staleness test to a native review via its `commit_id`. This
-  marker is the comment-based fallback that carries the same meaning (with the `@ <sha>`
-  doing explicitly what `commit_id` does for a native review) where a formal review can't be
-  posted.
-
----
-
-## 6. review-doc verdict marker
-
-`review-doc` is the **doc-class twin of `review-code`** — it gates a doc/knowledge PR
-(the **§DOC doc class**: `.decisions/**`, `.patterns/**`, `docs/**`, or a root/top-level
-prose `*.md` — explicitly **not** a code-root `*.md` under `apps/**`/`packages/**`, which
-rides `review-code`) against its
-linked issue's acceptance criteria *plus* a doc-hygiene checklist. It lands its verdict as a
-**comment whose first line is a recognizable, SHA-bound marker** — and **only** that comment,
-never a native approving review. The marker lives in its **own namespace**, distinct from
-§5's `review-code` marker.
-
-### Shape — SHA-bound (ADR 0058)
-
-The recognizable **first line** of the PR comment carries the head SHA the reviewer inspected
-(`@ <sha>`, from `gh api repos/$REPO/pulls/$PR --jq .head.sha`):
-
-```markdown
-review-doc: PASS @ <sha> — merge-ready
-```
-
-```markdown
-review-doc: FAIL @ <sha> — changes-requested
-```
-
-For a PR in the **control-plane / blocking set** (§CP), `review-doc` is advisory only and
-instead leads with the **canonical advisory line** (§6.6 — `review-doc: advisory — blocking-set
-PR (§CP — approval-gated)`) so its verdict stays *out* of `ship-it`'s PASS namespace — a §CP PR
-merges only once a `@kamp-us/control-plane` member approves at head and `ship-it` enqueues it
-(ADR [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
-amending [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md);
-`ship-it` is the single merge actor, ADR
-[0048](https://github.com/kamp-us/phoenix/blob/main/.decisions/0048-ship-it-merge-actor.md)). The advisory line
-carries **no `@ <sha>`** by design: it authorizes nothing, so there is nothing to bind.
-
-The rest of the body carries the per-criterion + per-hygiene-check evidence table. What's
-load-bearing for the scanner is the namespace, the polarity, **and the `@ <sha>`** — the same
-staleness contract as §5: `ship-it`/`write-code`-repair refuse a `review-doc` verdict whose
-`@ <sha>` is not the PR's current head, and refuse a SHA-less one (ADR
-[0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258).
-
-### Comment-only — the APPROVE/comment duality is resolved (ADR 0058)
-
-`review-doc` emits its verdict **only** as the SHA-bound `review-doc:` comment, **never** a
-native `APPROVE`/`REQUEST_CHANGES` review. This resolves the duality #258 flagged: a native
-GitHub review cannot carry the `@ <sha>` in the comment shape this contract controls (it
-records `commit_id` in a *different* record type), so leaving `review-doc` free to post either
-would force `ship-it` to compare a review against a comment for the doc lane — two
-incomparable records. One carrier, the comment, keeps the doc lane resolvable the same way
-the code lane is. (`review-code` keeps its native-`APPROVE` path because `ship-it` reads that
-review's `commit_id` for the staleness test; `review-doc` does not.)
-
-### Upsert, not append (ADR 0058)
-
-`review-doc` writes **exactly one** `review-doc:` marker comment per PR. As in §5 this is
-`pipeline-cli verdict post`'s own behavior — the verb finds **its own** prior `review-doc:`
-marker and replaces it in place with the fresh verdict + fresh `@ <sha>` rather than appending
-(ADR 0058 rule 2; same mechanism as §5, including §5's "never hand-roll this as a raw
-`gh api` `PATCH`").
-
-### Field notes
-
-- **Separate namespace from `review-code`.** `ship-it` matches the two markers with two
-  anchored, namespaced, emphasis-tolerant, SHA-capturing regexes —
-  `^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})` and
-  `^\s*\**\s*review-doc:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})` (the matcher contract in §5) —
-  resolves latest-verdict-wins **per namespace** by timestamp, then applies the SHA-staleness
-  test. A `review-code` scan must never match a `review-doc` marker, nor vice versa.
-  `review-doc` therefore **never** emits a `review-code` marker, and `review-code` never emits
-  a `review-doc` one.
-- **First line, recognizable.** The marker leads the comment so a scan matches it without
-  parsing the whole body. Recognize it tolerantly by shape (`review-doc: PASS @ <sha>` …
-  `merge-ready`) and emphasis (optional leading `**`, §5 matcher contract), not by exact
-  dashes or spacing — but the `@ <sha>` is required.
-- **Two markers, two consumers.** `PASS @ <sha> — merge-ready` (every AC + every hygiene check
-  verified, bound to that head) is read by `ship-it` as the go-ahead to merge a **non-blocking**
-  doc PR **iff `<sha>` is the current head**. `FAIL @ <sha> — changes-requested` (≥1 AC or
-  hygiene check unmet) is read by `write-code`'s fix round-trip as "my doc PR came back failed";
-  `ship-it` reads it as "do not merge."
-- **Advisory for the blocking set.** A PR in the §CP set gets the canonical advisory line
-  (§6.6), not a PASS marker — `review-doc`'s verdict does not authorize that merge; a
-  `@kamp-us/control-plane` approval at head does, and `ship-it` enqueues on it (ADR 0135
-  amending 0053). This keeps the control-plane approval gate intact.
-- **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on;
-  `review-doc` writing it does **not** merge (see review-doc/SKILL.md §"Authority limit").
-
----
-
-## 6.5. review-skill verdict marker
-
-`review-skill` is the **behavioral-artifact gate** — the third sibling of `review-code`
-(§5) and `review-doc` (§6). It gates a **skill PR** (`skills/**`, superseding ADR 0063's
-`skills/**` → `review-code` routing) against its linked issue's acceptance criteria *plus*
-a skill-specific rigor checklist (behavioral correctness, trigger/`description` quality,
-cross-skill conflict/shadowing, gate-invariant preservation — ADR
-[0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §1). It lands its
-verdict as a **comment whose first line is a recognizable, SHA-bound marker** — and **only**
-that comment, never a native review (like `review-doc`, ADR 0058 rule 4). The marker lives
-in its **own namespace**, distinct from §5's `review-code` and §6's `review-doc`.
-
-### Shape — SHA-bound (ADR 0058)
-
-The recognizable **first line** of the PR comment carries the head SHA the reviewer
-inspected (`@ <sha>`, from `gh api repos/$REPO/pulls/$PR --jq .head.sha`):
-
-```markdown
-review-skill: PASS @ <sha> — merge-ready
-```
-
-```markdown
-review-skill: FAIL @ <sha> — changes-requested
-```
-
-For a PR in the **control-plane / blocking set** (§CP — every gate-critical skill is in it,
-so most skill PRs that touch a gate land here), `review-skill` is **advisory only** and
-instead leads with the **canonical advisory line** (§6.6):
-
-```markdown
-review-skill: advisory — blocking-set PR (§CP — approval-gated)
-```
-
-so its verdict stays *out* of `ship-it`'s PASS namespace — a §CP PR merges only once a
-`@kamp-us/control-plane` member approves at head and `ship-it` enqueues it (ADR 0135 amending
-0053; `ship-it` is the single merge actor, ADR 0048).
-The advisory line carries **no `@ <sha>`** by design: it authorizes nothing, so there is
-nothing to bind.
-
-The rest of the body carries the per-criterion + per-rigor-check evidence table. What's
-load-bearing for the scanner is the namespace, the polarity, **and the `@ <sha>`** — the
-same staleness contract as §5/§6: `ship-it`/`write-code`-repair refuse a `review-skill`
-verdict whose `@ <sha>` is not the PR's current head, and refuse a SHA-less one (ADR
-[0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258).
-
-### Comment-only (ADR 0058)
-
-`review-skill` emits its verdict **only** as the SHA-bound `review-skill:` comment, **never**
-a native `APPROVE`/`REQUEST_CHANGES` review — for the same reason `review-doc` is comment-only
-(§6): a native review cannot carry the `@ <sha>` in the shape this contract controls, so one
-comparable record type per lane keeps the lane resolvable.
-
-### Upsert, not append (ADR 0058)
-
-`review-skill` writes **exactly one** `review-skill:` marker comment per PR. As in §5 this is
-`pipeline-cli verdict post`'s own behavior — the verb finds **its own** prior `review-skill:`
-marker and replaces it in place with the fresh verdict + fresh `@ <sha>` rather than appending
-(ADR 0058 rule 2; same mechanism as §5/§6, including §5's "never hand-roll this as a raw
-`gh api` `PATCH`").
-
-### The matcher contract — anchored, never cross-matching (canonical shape)
-
-`review-skill` adds a **third** namespace to the §5 matcher family, on the same
-emphasis-tolerant + SHA-capturing rule. The three matchers are mutually exclusive by
-construction — anchored at `^\s*` so a mid-body quote never matches, and each names its
-own token so a scan in one namespace can **never** cross-match another:
-
-- code:  `^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
-- doc:   `^\s*\**\s*review-doc:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
-- skill: `^\s*\**\s*review-skill:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
-
-A `review-code` or `review-doc` scan must **never** match a `review-skill` marker, and vice
-versa. The tokens are distinct literals (`review-code` / `review-doc` / `review-skill`), and
-because `review-code:` ends in `code:` while `review-skill:` ends in `skill:`, the anchored
-`review-code:` literal cannot prefix-match `review-skill:` — the three are disjoint. Every
-matcher site (`ship-it` merge gate, `write-code` fix round-trip, `review-skill` upsert) cites
-this one rule so they can't diverge (the same discipline §5 pins for code/doc).
-
-### Field notes
-
-- **Separate namespace.** `ship-it` resolves each gate's verdict in its **own** namespace,
-  latest-verdict-wins by timestamp, then the SHA-staleness test (§5/§6). `review-skill`
-  never emits a `review-code` or `review-doc` marker, and they never emit a `review-skill` one.
-- **First line, recognizable.** The marker leads the comment so a scan matches it without
-  parsing the whole body. Recognize it tolerantly by shape (`review-skill: PASS @ <sha>` …
-  `merge-ready`) and emphasis (optional leading `**`, §5 matcher contract), not by exact
-  dashes — but the `@ <sha>` is required.
-- **Two markers, two consumers.** `PASS @ <sha> — merge-ready` (every AC + every rigor check
-  verified, bound to that head) is read by `ship-it` as the go-ahead to merge a **non-blocking**
-  skill PR **iff `<sha>` is the current head**. `FAIL @ <sha> — changes-requested` (≥1 AC or
-  rigor check unmet) is read by `write-code`'s fix round-trip as "my skill PR came back failed";
-  `ship-it` reads it as "do not merge."
-- **Advisory for the blocking set.** A skill PR touching a gate-critical skill (or any §CP
-  path) gets the **canonical advisory line** (§6.6), not a PASS marker — its verdict does not
-  authorize that merge; a `@kamp-us/control-plane` approval at head does, and `ship-it` enqueues
-  on it (ADR 0135 amending 0053/0065). This keeps the control-plane approval gate intact, and is
-  exactly the common case for a skill PR (every gate skill is gate-critical).
-- **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on;
-  `review-skill` writing it does **not** merge (see review-skill/SKILL.md §"Authority limit").
-
----
-
-## 6.6. The canonical advisory line — one form for all four gates
-
-The gates once expressed "advisory" two ways: `review-code` emitted a binding
-`PASS @ <sha> — merge-ready` line *plus* a control-plane caveat, while `review-doc`
-suppressed the binding PASS and led with a **no-`@ <sha>`** advisory line. ADR
-[0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §5 picks
-`review-doc`'s form as the **single canonical advisory shape** and converges all the gates on
-it; the later `review-design` gate (§6.7, ADR 0165) adopts the same form from birth.
-
-For a PR in the **control-plane / blocking set** (§CP), the gate emits a comment whose first
-line is the **no-`@ <sha>`** advisory marker in its own namespace:
-
-```markdown
-review-code:   advisory — blocking-set PR (§CP — approval-gated)
-review-doc:    advisory — blocking-set PR (§CP — approval-gated)
-review-skill:  advisory — blocking-set PR (§CP — approval-gated)
-review-design: advisory — blocking-set PR (§CP — approval-gated)
-```
-
-The rest of the body carries the same per-check evidence table the PASS/FAIL paths carry —
-the verdict is *recorded* (for the human or delegated merge actor to read), it just **authorizes
-nothing on its first line**. The advisory **first line** **carries no `@ <sha>`** on purpose: it
-does not enter any `ship-it` `PASS @ <sha> — merge-ready` namespace, so a §CP PR is never
-auto-mergeable off it (ADR 0053). Under ADR 0135's approve-then-enqueue, `ship-it` enqueues it once a
-`@kamp-us/control-plane` approval is present at head (ADR 0053/0065/0135) — that approval, not a gate
-verdict, is what authorizes the merge.
-
-**The advisory body MUST carry the canonical `Reviewed-head` line (ADR 0151).** Immediately after
-the advisory's first-line marker + framing prose, the body carries **exactly one** line recording
-the reviewed head SHA in a fixed, machine-parseable form:
-
-```markdown
-Reviewed-head: @ <HEAD_SHA>
-```
-
-This is the single canonical binding for a §CP advisory — it replaces the free-prose "reviewed head"
-phrasings (which spelled the SHA half a dozen incompatible ways and made the §CP enqueue
-nondeterministic; #1932/#2022). It is a **body** line with a **distinct `Reviewed-head:` token**, so
-it is never matched by the first-line `review-(code|doc|skill): PASS @ <sha>` PASS-namespace matcher —
-the advisory stays out of `ship-it`'s auto-merge namespace exactly as ADR 0111 requires. Both a human
-delegated merge actor and `ship-it`'s ADR-0135 approval-aware §CP enqueue read the reviewed head from
-**this** line, via the anchored matcher (case-insensitive, optional `@`, 7–40 hex, ADR 0058
-prefix-match either side):
-
-```
-^\s*Reviewed-head:\s*@?\s*([0-9a-f]{7,40})\b
-```
-
-`ship-it` treats the §CP advisory namespace as an enqueue-eligible current-head PASS-equivalent iff
-(a) this `Reviewed-head` SHA prefix-matches the PR's current head, (b) every body checkbox is
-`[PASS]`, and (c) Step 0's control-plane approval is present at head — else it refuses
-deterministically (ship-it Step 2.§CP, ADR 0151). The reviewer is **never** asked to emit a bindable
-first-line PASS on a §CP PR to unblock enqueue (ADR 0111's advisory-is-SHA-less-in-first-line
-invariant is preserved; the reviewer marker contract is not widened).
-
-This is why the advisory form is namespace-uniform but binding-free: it keeps each gate's
-verdict **out** of `ship-it`'s merge path for the control plane while still leaving a
-visible, evidence-bearing verdict on the PR. (`review-code`'s historical binding-PASS +
-caveat shape was retired in favor of this; the reconciliation landed with #424.)
-
-**The first-line `@ <sha>` is omitted by design — the SHA is bound in the body's canonical
-`Reviewed-head` line, and both a delegated merge actor AND `ship-it`'s §CP enqueue confirm from
-that body line, not the first-line marker (ADR 0111/0151).** The advisory line deliberately
-withholds the first-line `@ <sha>` so it never enters `ship-it`'s `PASS @ <sha> — merge-ready`
-namespace — that withholding is exactly what makes `ship-it` refuse to *auto-merge* the §CP PR off a
-first-line PASS (ADR 0053). It is **not** a missing binding: the head SHA the reviewer inspected is
-recorded in the verdict **body** on the canonical `Reviewed-head: @ <sha>` line + the per-AC PASS
-table, per ADR 0058. So a **delegated** control-plane merge actor — an operator hand-merging a banked
-§CP PR, or `ship-it`'s ADR-0135 approval-aware enqueue acting on the maintainer's current-head
-APPROVE — must **not** try to bind the first-line marker (it will read as `unverified`, the
-SHA-less-by-design form #977 hit). It confirms the verdict by **reading the body**: the
-`Reviewed-head` `@ <sha>` against the PR's current head + every AC marked PASS, then applies
-`ship-it`'s just-in-time guards (head freshness, mergeable, no failing required check) and
-merges/enqueues. A namespace-isolated bindable *first-line* SHA was rejected (it would invite
-automated §CP auto-merge and erode ADR 0053) — ADR 0151 instead makes the *body*'s binding canonical
-and machine-read, keeping ADR 0111 intact. See
-[ADR 0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md)
-and [ADR 0151](https://github.com/kamp-us/phoenix/blob/main/.decisions/0151-cp-advisory-body-sha-resolves-approval-aware-enqueue.md).
-
----
-
-## 6.7. review-design verdict marker
-
-`review-design` is the **design-class gate** — the fourth reviewer skill alongside
-`review-code` (§5), `review-doc` (§6), and `review-skill` (§6.5). It gates a **UI-affecting
-PR** by driving Playwright over the PR's preview deploy, capturing the changed UI surfaces,
-and judging the rendered screenshots multimodally against the **four-pillars design law**
-(ADR [0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md);
-the gate itself is ADR [0165](https://github.com/kamp-us/phoenix/blob/main/.decisions/0165-review-design-gate.md),
-skill landed via #2246). It hard-FAILs **only** on the six enumerable, objective ADR-0162
-prohibitions; all holistic/taste judgment rides as advisory (non-blocking) notes in the same
-verdict comment. It lands its verdict as a **comment whose first line is a recognizable,
-SHA-bound marker** — and **only** that comment, never a native review (like `review-doc` /
-`review-skill`, ADR 0058 rule 4). The marker lives in its **own namespace**, distinct from
-§5's `review-code`, §6's `review-doc`, and §6.5's `review-skill`.
-
-### Shape — SHA-bound (ADR 0058)
-
-The recognizable **first line** of the PR comment carries the head SHA the reviewer
-inspected (`@ <sha>`, from `gh api repos/$REPO/pulls/$PR --jq .head.sha`):
-
-```markdown
-review-design: PASS @ <sha> — merge-ready
-```
-
-```markdown
-review-design: FAIL @ <sha> — changes-requested
-```
-
-For a PR in the **control-plane / blocking set** (§CP), `review-design` is **advisory only**
-and instead leads with the **canonical advisory line** (§6.6):
-
-```markdown
-review-design: advisory — blocking-set PR (§CP — approval-gated)
-```
-
-so its verdict stays *out* of `ship-it`'s PASS namespace — a §CP PR merges only once a
-`@kamp-us/control-plane` member approves at head and `ship-it` enqueues it (ADR 0135 amending
-0053; `ship-it` is the single merge actor, ADR 0048).
-The advisory line carries **no `@ <sha>`** by design: it authorizes nothing, so there is
-nothing to bind.
-
-The rest of the body carries the per-prohibition table (the six hard-FAIL checks, passing
-rows too), an **Advisory (non-blocking)** section, and an **Evidence** section embedding the
-GitHub-hosted screenshot URLs so a human can see what was judged. What's load-bearing for the
-scanner is the namespace, the polarity, **and the `@ <sha>`** — the same staleness contract as
-§5/§6/§6.5: `ship-it`/`write-code`-repair refuse a `review-design` verdict whose `@ <sha>` is
-not the PR's current head, and refuse a SHA-less one (ADR
-[0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258).
-
-### Comment-only (ADR 0058)
-
-`review-design` emits its verdict **only** as the SHA-bound `review-design:` comment,
-**never** a native `APPROVE`/`REQUEST_CHANGES` review — for the same reason `review-doc` /
-`review-skill` are comment-only (§6/§6.5): a native review cannot carry the `@ <sha>` in the
-shape this contract controls, so one comparable record type per lane keeps the lane
-resolvable.
-
-### Upsert, not append (ADR 0058)
-
-`review-design` writes **exactly one** `review-design:` marker comment per PR. As in §5 this is
-`pipeline-cli verdict post`'s own behavior — the verb finds **its own** prior `review-design:`
-marker and replaces it in place with the fresh verdict + fresh `@ <sha>` rather than appending
-(ADR 0058 rule 2; same mechanism as §5/§6/§6.5, including §5's "never hand-roll this as a raw
-`gh api` `PATCH`").
-
-### The matcher contract — anchored, never cross-matching (canonical shape)
-
-`review-design` adds a **fourth** namespace to the §5 matcher family, on the same
-emphasis-tolerant + SHA-capturing rule. The four matchers are mutually exclusive by
-construction — anchored at `^\s*` so a mid-body quote never matches, and each names its own
-token so a scan in one namespace can **never** cross-match another:
-
-- code:   `^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
-- doc:    `^\s*\**\s*review-doc:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
-- skill:  `^\s*\**\s*review-skill:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
-- design: `^\s*\**\s*review-design:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
-
-The tokens are distinct literals, and because each ends in a different word (`code:` /
-`doc:` / `skill:` / `design:`) no anchored literal prefix-matches another — the four are
-disjoint. `review-design` also inherits §5's **token-order** rule (`@ <sha>` immediately
-after the polarity, before the `— merge-ready` / `— changes-requested` tail) and its
-**forbidden emit forms** (no HTML-comment wrapper, no `sha:` delimiter, no heading-only
-verdict, marker on the literal first line). Every matcher site cites this one rule so they
-can't diverge.
-
-### The `Reviewed-head` body anchor (ADR 0151)
-
-Every `review-design` verdict body carries the canonical **`Reviewed-head: @ <sha>`** line
-(§6.6 / ADR 0151) — the read-back guard asserts it on every path, and a delegated §CP merge
-actor (and `ship-it`'s ADR-0135 approval-aware enqueue) resolves the reviewed head from
-**exactly that line** on an advisory §CP verdict, never from the first-line marker.
-
-### Field notes
-
-- **Separate namespace.** `ship-it` resolves each gate's verdict in its **own** namespace,
-  latest-verdict-wins by timestamp, then the SHA-staleness test (§5/§6/§6.5). `review-design`
-  never emits a `review-code` / `review-doc` / `review-skill` marker, and they never emit a
-  `review-design` one.
-- **First line, recognizable.** The marker leads the comment so a scan matches it without
-  parsing the whole body. Recognize it tolerantly by shape (`review-design: PASS @ <sha>` …
-  `merge-ready`) and emphasis (optional leading `**`, §5 matcher contract), not by exact
-  dashes — but the `@ <sha>` is required.
-- **Two markers, two consumers.** `PASS @ <sha> — merge-ready` (every applicable prohibition
-  passed or N/A, bound to that head) is the go-ahead signal `ship-it` acts on to merge a
-  **non-blocking** UI PR **iff `<sha>` is the current head**. `review-design`'s required-gate
-  wiring **has landed** as part of the ADR-0165 rollout: `ship-it` runs the `UI_RE` probe and
-  refuses a `has-ui` PR with an empty `review-design` namespace, and §CLASS's
-  `pipeline-cli class-probe classify` folds the additive gate in.
-  `FAIL @ <sha> — changes-requested` (≥1 objective prohibition violated) is read by
-  `write-code`'s fix round-trip as "my UI PR came back failed"; `ship-it` reads it as "do not
-  merge."
-- **Advisory for the blocking set.** A UI PR in the §CP set gets the **canonical advisory
-  line** (§6.6), not a PASS marker — its verdict does not authorize that merge; a
-  `@kamp-us/control-plane` approval at head does, and `ship-it` enqueues on it (ADR 0135 amending
-  0053/0065). Because a design verdict is calibrated to FAIL conservatively (a borderline call is
-  downgraded to advisory), an advisory here can also mean "no objective prohibition hard-failed" —
-  but on a §CP PR the first-line advisory is always the approval-gated shape.
-- **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on;
-  `review-design` writing it does **not** merge (see review-design/SKILL.md §"Authority
-  limit").
 
 ---
 
@@ -2962,7 +2287,7 @@ own before mutating it. Every consumer cites the `CLAIM_RE` and tiebreak defined
 The **resolution** side of this contract — resolve one owner by the earliest authorized
 claim and decide "is it mine?", default-deny — is implemented once as the shared verb
 `pipeline-cli claim is-mine --issue <N>` (#3687, reusing the epic-lock `resolveClaim` core);
-a consumer runs the verb rather than hand-rolling the resolution `jq`, exactly as §5/§6 route
+a consumer runs the verb rather than hand-rolling the resolution `jq`, exactly as §VERDICT routes
 every marker emit through `pipeline-cli verdict post`. The bash resolution shown below is the
 canonical *reference* the verb implements — read it to understand the tiebreak, run the verb
 to make the decision.
@@ -3001,7 +2326,7 @@ The claim is **two layers** (ADR 0115 §1):
 ### The canonical claim marker + `CLAIM_RE` — single-sourced here
 
 The claim comment is **one line, emphasis-tolerant**, exactly as the SHA-bound verdict
-markers (§5/§6) are. Its **canonical grammar**:
+markers (§VERDICT) are. Its **canonical grammar**:
 
 ```
 claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC>
@@ -3034,7 +2359,7 @@ claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC> · presence <machine-fingerpri
   re-derives this write instead of citing the verb.
 - **Read surface — the canonical `CLAIM_RE`.** A claim comment is matched by this **one**
   anchored, case-insensitive, emphasis-tolerant regex; every consumer cites it and **none
-  re-hard-codes the grammar** (it pairs with §5/§6's marker-matcher discipline). The executable
+  re-hard-codes the grammar** (it pairs with §VERDICT's marker-matcher discipline). The executable
   matcher is the `RegExp` in `tools/epic-lock/claim-resolution.ts`; the jq/PCRE rendering below is
   single-sourced in `gate-boundaries.ts` and drift-locked to both (#4401):
 
@@ -3523,7 +2848,7 @@ cheapest moment to surface it — and had nowhere to go.
 ```markdown
 ## Deviations
 
-- **Scope narrowing** — **Said:** #4064's AC asks the gate teeth to cover §6.6's four gates plus
+- **Scope narrowing** — **Said:** #4064's AC asks the gate teeth to cover §ADVISORY's four gates plus
   `review-trivial`. **Did:** `review-trivial` gets a Step-0 bounce, not a deviation verdict.
   **Why:** it emits a trivial-path verdict, and a disclosed deviation is by construction evidence the
   diff is not trivial. **Disposition:** stated in the PR body per the AC; no ADR needed.
@@ -3709,6 +3034,11 @@ The rationale lives in ADR
 | review-skill FAIL marker | the PR | review-skill | write-code (fix round-trip) |
 | `## Deviations` section (§DEV) | the PR body | write-code (Step 5 opens it, repair R3 appends) | review-code, review-doc, review-skill, review-design (verdict row), review-trivial (triviality bounce) |
 | issue-claim (assignee) | the issue's assignees | write-code (Step 3 claim), triage (Step 0 sweep-claim) | write-code (Step 1 pick), triage (Step 0 Rule-0 back-off) |
+
+The six marker rows are **shapes defined elsewhere**:
+[`shared/gate-verdict-contract.md`](shared/gate-verdict-contract.md) §VERDICT is the single
+contract for all four gate namespaces (`review-design` included), §ADVISORY the §CP advisory
+form, §READBACK the post-write read-back.
 
 The issue-claim row is the one entry that is a **protocol over the assignee field**, not a
 markdown format — §7 governs *how* an agent writes and reads that field (detect-and-tiebreak,

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1502,8 +1502,12 @@ dashes; the `@ <sha>` is required (ADR 0058). Token order is fixed (§VERDICT): 
 **immediately after** `FAIL`, before `— not merge-ready`. (And `ship-it` reads it as the mirror
 of PASS: a FAIL marker means *do not merge*.)
 
-Post it as an **upsert** — `PATCH` your own prior `review-code:` marker if one exists, else
-`POST` — exactly as the PASS path (one `review-code` verdict comment per PR, ADR 0058 rule 2).
+Post it as an **upsert on the §VERDICT key — (PR, gate-namespace, head, run)** — exactly as the
+PASS path: `verdict post` replaces a prior `review-code:` marker only when that marker matches
+*this head and this run*, and appends otherwise, so a re-review at a new head leaves the prior
+head's verdict standing and a concurrent run never overwrites another's record (ADR 0058 rule 2,
+refined by ADR 0213). Never hand-roll the `PATCH` — §VERDICT forbids a raw comment patch of a
+verdict body, which bypasses `emissionDefect` and the §READBACK re-scan.
 As on the PASS path, **resolve `HEAD_SHA` once, before composing the verdict file**, and embed
 that same value in the marker's `@ <HEAD_SHA>` first line — so the SHA the comment carries and
 any later use are one single-sourced read, never two independent resolutions that could

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -219,7 +219,7 @@ via REST (`gh pr view $PR --repo "$REPO" --json headRefOid -q .headRefOid`), fet
 per-run `$PR_REF` + assert `git rev-parse "$PR_REF"` equals it, read every full file from the
 head (`$REVIEW_WT` below, or `git show "$PR_REF:<path>"`) and **never** from CWD, and re-check
 the live head before posting (§HEAD #4). The head-worktree + denylist mechanism below *is*
-§HEAD's materialization for this gate; the verdict (§5) must bind to the SHA whose files you
+§HEAD's materialization for this gate; the verdict (§VERDICT) must bind to the SHA whose files you
 actually read and assert it read the PR head.
 
 Verification is grounded in the diff, the tests, and — where it matters — the behavior,
@@ -278,7 +278,7 @@ current-head verdict. **Emit each namespace's verdict as its OWN separate PR com
 comment per namespace, marker on that comment's literal first line — never two markers stacked
 in one comment** (the second would be un-anchored, resolve empty, and fail-close a
 substantively-PASS PR — the PR #2456 stall; the forbidden "stacked" emit form in
-`../gh-issue-intake-formats.md` §5). `ship-it`'s per-present-class requirement (its Step 2) is
+`../shared/gate-verdict-contract.md` §VERDICT). `ship-it`'s per-present-class requirement (its Step 2) is
 unchanged — it remains the **fail-closed late catch**, the safety net for a genuinely-missing
 namespace, not the *first* place the second namespace is discovered.
 
@@ -617,7 +617,7 @@ draws:
 The fan-out + route is **additive to the existing AC-verification verdict — it does not replace
 or weaken it.** The append is the route's *output*, not a new gate:
 
-- The **conjunctive AC verdict (Step 3), the SHA-bound `review-code:` marker (§5), and the
+- The **conjunctive AC verdict (Step 3), the SHA-bound `review-code:` marker (§VERDICT), and the
   single-merge-authority invariant are unchanged.** An appended criterion does **not** change
   *this* PR's pass/fail computation beyond the existing rules: it lands as a new unchecked
   `[ ]` row on the issue, so on the *next* review cycle it is an ordinary criterion the
@@ -1247,7 +1247,7 @@ merge-ready` marker. It
 gets the **canonical advisory line** instead — `review-code: advisory — blocking-set PR (§CP —
 approval-gated)`, no `@ <sha>` — the one advisory shape all three gates converge on (ADR
 [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §5;
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §6.6). It carries the same
+[the gate-verdict contract §ADVISORY](../shared/gate-verdict-contract.md)). It carries the same
 per-criterion evidence table, but it authorizes nothing on its first line — it stays *out* of
 `ship-it`'s auto-merge PASS namespace (no first-line `@ <sha>`), and it binds the reviewed head in
 the body's canonical `Reviewed-head: @ <sha>` line instead (ADR 0151). Under ADR 0135's
@@ -1309,9 +1309,9 @@ wrapping the APPROVE call (e.g. `… 2>&1 | head` for inspection) makes the pipe
 status mask the APPROVE failure, so the `||` fallback silently never fires and no verdict
 lands.
 
-The comment fallback **upserts**, it does not append: exactly **one** `review-code` verdict
-comment per PR (ADR 0058 rule 2) — a re-review of a new head overwrites the same record with
-the new `@ <sha>`. The upsert (scan your own prior `review-code:` marker → `PATCH` it, else
+The comment fallback **upserts**, it does not append — on the §VERDICT key — (PR, gate-namespace, head, run)
+(ADR 0058 rule 2, refined by ADR 0213): a re-post at your own key replaces that record in place,
+while a re-review at a NEW head appends a fresh one and leaves the prior head's verdict standing. The upsert (scan your own prior `review-code:` marker → `PATCH` it, else
 `POST`) plus its emission guards are the ADR-0058 glue **all four gates share**, so — exactly as
 `review-doc` — post through the deterministic, unit-tested tool (`pipeline-cli verdict post`,
 #2102), never a hand-rolled `jq`. **The tool is the marker-emit choke point:** `verdict post`
@@ -1329,7 +1329,7 @@ that skips the guard is **FORBIDDEN** (it is the emit-side hole #2789 / #2816 / 
 hand-posting off the verdict lib means `emissionDefect` never runs). If a raw post is ever
 genuinely unavoidable, the body **MUST** first pass `pipeline-cli leak-guard scan-comment` (the
 #2823 pre-post net) before the post. This is the single-source rule in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+[the gate-verdict contract §READBACK](../shared/gate-verdict-contract.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
 
 ```bash
 printf '%s' "$BODY" | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-emit-pass.sh" "$PR" "$HEAD_SHA"
@@ -1352,9 +1352,9 @@ now).
 Verdict body shape (this is the `$BODY` you pipe into the emitter above) for the **non-blocking**
 path. The first line is the **canonical bare marker** — no leading `**` emphasis, **with the
 `@ <HEAD_SHA>` you resolved above** — per the matcher contract in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5; matchers tolerate an optional
+[the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md); matchers tolerate an optional
 leading `**` for backward compatibility, but emit the bare form, and the `@ <sha>` is required
-(ADR 0058). **Token order is fixed** (§5): `@ <HEAD_SHA>` comes **immediately after** `PASS`,
+(ADR 0058). **Token order is fixed** (§VERDICT): `@ <HEAD_SHA>` comes **immediately after** `PASS`,
 **before** `— merge-ready` — `review-code: PASS @ <sha> — merge-ready`, never
 `review-code: PASS — merge-ready @ <sha>`. `ship-it`'s capture is anchored to that order; a
 trailing `@ <sha>` after `merge-ready` captures `sha=null` and `ship-it` refuses a correct
@@ -1407,8 +1407,8 @@ the anchored recognizer **exactly**, or `ship-it` resolves the PR to `unverified
 refuses to merge a genuine, current-head PASS. The recognizer is one anchored regex, shared
 verbatim by all three consumer sites — `ship-it` Step 2 (`^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`),
 `write-code`'s fix round-trip, and this gate's own Step 4c self-check — and pinned once in
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5. **Emit the canonical first
-line so it matches that regex; never any of the freelance forms §5 forbids.** The forms below
+[the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md). **Emit the canonical first
+line so it matches that regex; never any of the freelance forms §VERDICT forbids.** The forms below
 each fail the anchor and are exactly what stalled a real PASS on PR #1095:
 
 - **Never wrap the marker in an HTML comment** — `<!-- review-code: PASS @ <sha> — merge-ready -->`.
@@ -1437,19 +1437,19 @@ Every criterion passed but `CONTROL_PLANE_TOUCHED` **or** `GUARD_TOUCHING` (Step
 the PR touches the control plane, or a guard-touching `.decisions/**` ADR that is §CP by content (ADR
 0164 / #3645; the shared `guard-content-probe` verb returned `guard-touching`). Post the **same
 evidence**, but the first line is the **canonical advisory
-line** (§6.6), **not** a binding merge-ready marker. Its **first line** carries **no `@ <sha>`** by
+line** (§ADVISORY), **not** a binding merge-ready marker. Its **first line** carries **no `@ <sha>`** by
 design (it authorizes nothing on its first line, so it never enters `ship-it`'s auto-merge PASS
 namespace — ADR 0111); under ADR 0135's approve-then-enqueue a `@kamp-us/control-plane` member
 approves it at its current head and `ship-it` then enqueues it (ADR 0135, amending 0053; ADR 0048
-single merge authority) — no human hand-merge. Upsert it exactly as the PASS path (one `review-code:`
-marker per PR), and — like the PASS
+single merge authority) — no human hand-merge. Upsert it exactly as the PASS path (the §VERDICT
+upsert key), and — like the PASS
 fallback — post it as a **comment**, not a native `APPROVE` (a native APPROVE would re-enter the
 code review namespace via its `commit_id`, defeating the advisory's purpose).
 
 > **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
 > The advisory's first line is SHA-less by design (ADR 0111), so the reviewed head is bound **in the
 > body**, on the canonical `Reviewed-head: @ <HEAD_SHA>` line below — the one form all four gates
-> converge on (§6.6). `ship-it`'s ADR-0135 approval-aware §CP enqueue reads the reviewed head from
+> converge on (§ADVISORY). `ship-it`'s ADR-0135 approval-aware §CP enqueue reads the reviewed head from
 > **exactly** that line via the anchored matcher `^\s*Reviewed-head:\s*@?\s*([0-9a-f]{7,40})`, gated
 > on the control-plane approval — that is what makes a §CP code PR's enqueue **deterministic**
 > (#1932/#2022; free-prose "reviewed head" phrasings resolved nondeterministically and are retired).
@@ -1494,11 +1494,11 @@ review. Include the passing ones too — the full table tells the implementer ho
 they are, not just where they fell short.
 
 The first line, `review-code: FAIL @ <HEAD_SHA> — not merge-ready`, is a **recognizable,
-SHA-bound marker** — the mirror of the PASS marker (formats §5). It is the seam
+SHA-bound marker** — the mirror of the PASS marker (§VERDICT). It is the seam
 `write-code`'s resume-my-failed-PR path keys on: it scans for it to find a PR whose `Fixes #N`
 issue is still claimed by the implementer and still has failing criteria *against the current
 head* to address. Recognize it tolerantly by shape (`review-code: FAIL @ <sha>`), not by exact
-dashes; the `@ <sha>` is required (ADR 0058). Token order is fixed (§5): `@ <sha>` comes
+dashes; the `@ <sha>` is required (ADR 0058). Token order is fixed (§VERDICT): `@ <sha>` comes
 **immediately after** `FAIL`, before `— not merge-ready`. (And `ship-it` reads it as the mirror
 of PASS: a FAIL marker means *do not merge*.)
 
@@ -1594,7 +1594,7 @@ emit-and-fail-closed like any other).
 `review-code:` verdict is actually present** — a marker comment whose `@ <sha>` matches the head
 you reviewed (`$HEAD_SHA`), **or** the native approving review GitHub recorded against that same
 `commit_id`, **or** (the blocking-set path) the `review-code: advisory` line. The read-back is over
-the **same SHA-binding contract** (§5 / ADR 0058) the consumers apply, so "landed" means landed *for
+the **same SHA-binding contract** (§VERDICT / ADR 0058) the consumers apply, so "landed" means landed *for
 this head*, not "some review-code comment exists":
 
 Do **not** re-implement this inline against a `$MINE` you captured on one 4a/4b branch — that carried
@@ -1603,7 +1603,7 @@ comment-upsert `else` fallback, so the native-APPROVE, first-`POST`, and hand-ro
 guard with an empty id and a broken/leaking marker sailed through). Instead call the **single
 unconditional wrapper** from the shared contract, which re-derives the landed verdict from live PR
 state (never a carried variable) and runs the read-back on whatever landed, on **every** post path —
-[`gh-issue-intake-formats.md` §Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../gh-issue-intake-formats.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
+[the gate-verdict contract §READBACK — Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../shared/gate-verdict-contract.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-readback.sh" "$PR" "$HEAD_SHA" || exit 1

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-design
-description: Verify a UI-affecting PR against the four-pillars design law (ADR 0162) by driving Playwright over the PR's preview deploy, capturing the changed UI surfaces, and judging the rendered screenshots multimodally — the 4th reviewer skill alongside review-code / review-doc / review-skill in the configured target repo's pipeline. It hard-FAILs on the six enumerable, objective ADR-0162 prohibitions (faint-for-meaning, missing focus ring, off-grid spacing/type, void empty state, sub-36px tap target, colour-alone meaning), on an uncaught render exception, and on an unexplained deviation from a blessed golden on a blessed surface (calibration B, #2945 — the deterministic rendered-vs-golden diff via the `@kampus/design-capture` seam is escalated to multimodal judgment, never auto-failed on the raw diff); all OTHER holistic/taste judgment rides as advisory (non-blocking) notes in the same verdict comment, and it is calibrated to FAIL conservatively — a borderline call is downgraded to advisory, never a hard block. Trigger on "review the design of PR #N", "review-design #N", "run the design gate on #N", "gate the UI PR against the pillars", "does this UI PR meet the design law", "run review-design", or whenever you're asked to confirm a UI PR's rendered surfaces obey ADR 0162 before merge. This is the design-class verification stage of the issue-intake pipeline: it consumes the UI PRs write-code opens, renders and looks at them over the preview deploy, and emits a namespaced, SHA-bound `review-design: PASS @ <sha> — merge-ready` / `review-design: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR, embedding the GitHub-hosted screenshot evidence; on a FAIL it feeds the existing write-code repair loop. It never merges; it never emits a review-code / review-doc / review-skill marker.
+description: Verify a UI-affecting PR against the four-pillars design law (ADR 0162) by driving Playwright over the PR's preview deploy, capturing the changed UI surfaces, and judging the rendered screenshots multimodally — the 4th reviewer skill alongside review-code / review-doc / review-skill in the configured target repo's pipeline. It hard-FAILs on the six enumerable, objective ADR-0162 prohibitions (faint-for-meaning, missing focus ring, off-grid spacing/type, void empty state, sub-36px tap target, colour-alone meaning), on an uncaught render exception, and on an unexplained deviation from a blessed golden on a blessed surface (calibration B, #2945 — the deterministic rendered-vs-golden diff via the `@kampus/design-capture` seam is escalated to multimodal judgment, never auto-failed on the raw diff); all OTHER holistic/taste judgment rides as advisory (non-blocking) notes in the same verdict comment, and it is calibrated to FAIL conservatively — a borderline call is downgraded to advisory, never a hard block. Trigger on "review the design of PR #N", "review-design #N", "run the design gate on #N", "gate the UI PR against the pillars", "does this UI PR meet the design law", "run review-design", or whenever you're asked to confirm a UI PR's rendered surfaces obey ADR 0162 before merge. This is the design-class verification stage of the issue-intake pipeline: it consumes the UI PRs write-code opens, renders and looks at them over the preview deploy, and emits a namespaced, SHA-bound `review-design: PASS @ <sha> — merge-ready` / `review-design: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted on the (PR, gate-namespace, head, run) key, embedding the GitHub-hosted screenshot evidence; on a FAIL it feeds the existing write-code repair loop. It never merges; it never emits a review-code / review-doc / review-skill marker.
 ---
 
 # review-design
@@ -188,7 +188,7 @@ stage exists to prevent — the same invariant the sibling gates hold.
 
 `ship-it` matches the gate markers in **separate namespaces** (anchored, emphasis-tolerant,
 SHA-capturing regexes that never cross-match — your `review-design` namespace is registered in
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §6.7, on the shared §5 matcher
+[the gate-verdict contract](../shared/gate-verdict-contract.md) §VERDICT, on its shared matcher
 contract), latest-verdict-wins per
 namespace, then a SHA-staleness refusal (ADR 0058). Your verdict's first line is **always**
 `review-design: … @ <sha>` — never another gate's token. Emitting another gate's marker on a UI PR
@@ -276,9 +276,9 @@ Your inputs and output live in the shared contract — read it before you start:
 
 - **§CP** — the canonical control-plane / blocking-set definition (Step 0 classification). Cite it;
   don't re-hard-code the path list.
-- **§6.7** — your own registered marker namespace (on the shared §5 matcher contract). Your
-  `review-design` marker lives in its own namespace, distinct from `review-code` (§5), `review-doc`
-  (§6), and `review-skill` (§6.5); emit the same SHA-bound `PASS @ <sha> — merge-ready` /
+- **§VERDICT** — your own registered marker namespace (on its shared matcher contract). Your
+  `review-design` marker lives in its own namespace, distinct from the `review-code`, `review-doc`
+  and `review-skill` ones; emit the same SHA-bound `PASS @ <sha> — merge-ready` /
   `FAIL @ <sha> — changes-requested` shape and token order, under the `review-design:` token.
 - **The verdict read-back guard** (`verdict_readback_guard`) — the single canonical post-write
   read-back you call after your upsert (Step 5). It is **gate-parameterized** — call it with the
@@ -627,7 +627,8 @@ HEAD_SHA="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review
 ```
 
 Write the verdict to a per-run temp file so multi-line markdown + backticks survive the shell, then
-**upsert** it — exactly **one** `review-design` verdict comment per PR (ADR 0058 rule 2), the
+**upsert** it — on the §VERDICT key — (PR, gate-namespace, head, run) (ADR 0058 rule 2, refined by
+ADR 0213); the
 `mktemp` handle run-unique (the PR number alone isn't — two concurrent reviews would collide). That
 upsert plus its emission guards are the ADR-0058 glue **all four gates share**, so — exactly as
 `review-doc` — post through the deterministic, unit-tested tool (`pipeline-cli verdict post`, #2102).
@@ -645,14 +646,14 @@ hole #2789 / #2816 / #2818 rode: hand-posting off the verdict lib means `emissio
 runs). If a raw post is ever genuinely unavoidable, the body **MUST** first pass
 `pipeline-cli leak-guard scan-comment` (the #2823 pre-post net) before the post. This is the
 single-source rule in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+[the gate-verdict contract §READBACK](../shared/gate-verdict-contract.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
 
 The SHA in the first line is **load-bearing**: `ship-it` refuses any verdict not bound to the PR's
-current head (ADR 0058). **Token order is fixed** (§5): `@ <HEAD_SHA>` comes **immediately after**
+current head (ADR 0058). **Token order is fixed** (§VERDICT): `@ <HEAD_SHA>` comes **immediately after**
 `PASS`/`FAIL`, **before** `— merge-ready`/`— changes-requested` — never a trailing `@ <sha>` (that
 captures `sha=null` and `ship-it` refuses a correct PASS as `unverified`, #625).
 
-Every verdict body carries the canonical **`Reviewed-head: @ <HEAD_SHA>`** anchor line (§6.6 / ADR
+Every verdict body carries the canonical **`Reviewed-head: @ <HEAD_SHA>`** anchor line (§ADVISORY / ADR
 0151) — the read-back guard asserts it on every path, and `ship-it`'s §CP enqueue resolves the head
 from exactly that line. Every body also carries an **Evidence** section embedding the helper's
 GitHub-hosted screenshot URLs so a human can see what you judged.
@@ -788,7 +789,7 @@ and brick the lane the verdict was gating (#4047). Rule and rationale:
 ### Confirm the verdict landed clean (the shared read-back guard, #2148)
 
 After **any** of the three upserts returns its comment id, close the loop: call the **single
-canonical** [`verdict_readback_guard`](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard)
+canonical** [`verdict_readback_guard`](../shared/gate-verdict-contract.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard)
 from the shared contract with the **`review-design`** gate token — it re-reads the comment you just
 wrote and asserts the canonical `review-design:` marker, the anchored `Reviewed-head: @ <sha>` line,
 and **no leaked local filesystem path** (the #2148 marker-as-path leak).

--- a/claude-plugins/kampus-pipeline/skills/review-design/scripts/verdict-upsert.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-design/scripts/verdict-upsert.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Upsert the ONE `review-design` verdict comment for a PR through the guarded emit path, and print
-# the comment id. Namespace-anchored (PATCH own prior marker, else POST); fails loud on a malformed
+# Upsert the `review-design` verdict comment through the guarded emit path, and print the comment
+# id. Keyed on (PR, gate-namespace, head, run) — see ADR 0213 — so it replaces only this head+run's
+# own prior marker and appends against any other key; fails loud on a malformed
 # marker — the verdict tool refuses fail-closed before landing unless every SHA field is a clean
 # full 40-hex head SHA (#2683).
 #

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-doc
-description: Verify a doc/knowledge PR against its linked issue's acceptance criteria — plus a doc-hygiene checklist — before it merges. The doc-artifact twin of review-code in the configured target repo's pipeline. Trigger on "review this doc PR", "review-doc #N", "gate the ADR PR", "verify the docs on #N before merge", "run review-doc", "does this ADR/pattern PR meet its acceptance criteria", or whenever you're asked to confirm a `.decisions`/`.patterns`/prose-doc PR actually satisfies the issue it claims to close. This is the doc-class verification stage of the issue-intake pipeline: it consumes the doc PRs `write-code` opens and verifies them one criterion at a time, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-doc: PASS @ <sha> — merge-ready` / `review-doc: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR; for BLOCKING-set doc PRs (touching `.claude/`/`.github` or a gate-critical skill) it is advisory only; it never merges; it never emits a `review-code` marker.
+description: Verify a doc/knowledge PR against its linked issue's acceptance criteria — plus a doc-hygiene checklist — before it merges. The doc-artifact twin of review-code in the configured target repo's pipeline. Trigger on "review this doc PR", "review-doc #N", "gate the ADR PR", "verify the docs on #N before merge", "run review-doc", "does this ADR/pattern PR meet its acceptance criteria", or whenever you're asked to confirm a `.decisions`/`.patterns`/prose-doc PR actually satisfies the issue it claims to close. This is the doc-class verification stage of the issue-intake pipeline: it consumes the doc PRs `write-code` opens and verifies them one criterion at a time, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-doc: PASS @ <sha> — merge-ready` / `review-doc: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted on the (PR, gate-namespace, head, run) key; for BLOCKING-set doc PRs (touching `.claude/`/`.github` or a gate-critical skill) it is advisory only; it never merges; it never emits a `review-code` marker.
 ---
 
 # review-doc
@@ -86,7 +86,7 @@ stage exists to prevent — the same invariant `review-code` holds.
 bolding `**`, the trailing `@\s*([0-9a-f]{7,40})` captures the bound head SHA —
 `^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})` and
 `^\s*\**\s*review-doc:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`; see the matcher contract in
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5/§6), latest-verdict-wins
+[the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md)), latest-verdict-wins
 per namespace by timestamp, then a SHA-staleness refusal (ADR 0058). Your verdict's first
 line is **always** `review-doc: … @ <sha>` — never `review-code: …`. Emitting a `review-code`
 marker on a doc PR would let a code-namespace scan match your verdict (and vice versa),
@@ -124,10 +124,11 @@ fetch-into-a-ref read mechanism below is the §RO read-only path made concrete f
 Your gate is **format 2, the sub-issue body's `### Acceptance criteria` checklist** — and
 **format 6, the review-doc verdict marker** (your namespace). Read the contract so you know
 the shapes you verify against and emit:
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2 and §6. §6 defines the
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2 and [the gate-verdict
+contract](../shared/gate-verdict-contract.md) §VERDICT. §VERDICT defines the
 `review-doc` namespace (SHA-bound `PASS @ <sha> — merge-ready` / `FAIL @ <sha> — changes-requested`)
-and the advisory blocking-set line, in a namespace distinct from §5's `review-code` marker —
-emit only the §6 shapes, never a §5 `review-code` marker.
+and the advisory blocking-set line, in a namespace distinct from the `review-code` marker —
+emit only your own namespace's shapes, never a `review-code` marker.
 
 The key invariant: **every issue carries at least one acceptance criterion.** That's the
 floor that guarantees there is always something to verify. If an issue you're handed has
@@ -408,7 +409,7 @@ false-PASS hazard). Obey [`../gh-issue-intake-formats.md`](../gh-issue-intake-fo
 resolve the live head SHA via REST, fetch it into the per-run `$PR_REF`, and assert the fetched
 ref IS that head; then read every full file from the head (`git show "$PR_REF:<path>"`) and
 **never** from CWD, and re-check the live head before posting (§HEAD #4). The verb's
-fetch-into-a-ref is §HEAD's read path for this diff-only gate; the verdict (§5) must bind to the
+fetch-into-a-ref is §HEAD's read path for this diff-only gate; the verdict (§VERDICT) must bind to the
 SHA whose files you actually read and assert it read the PR head.
 
 Verification is grounded in the **diff**, not the PR's self-description. There is **no
@@ -911,8 +912,9 @@ controls, so emitting one would leave `ship-it` comparing a review against a com
 doc lane — two incomparable records. The comment is the single carrier, resolving the
 APPROVE-vs-comment duality #258 flagged.
 
-The post is an **upsert**, not an append: exactly **one** `review-doc` verdict comment per PR
-(ADR 0058 rule 2) — a re-review of a new head overwrites the same record with the new `@ <sha>`.
+The post is an **upsert**, not an append — on the §VERDICT key — (PR, gate-namespace, head, run)
+(ADR 0058 rule 2, refined by ADR 0213): a re-post at your own key replaces that record in place,
+while a re-review at a NEW head appends a fresh one and leaves the prior head's verdict standing.
 The upsert (scan your own prior `review-doc:` marker → `PATCH` it, else `POST`) plus its
 namespace guard are the ADR-0058 glue **all four gates share**, so they live in one
 deterministic, unit-tested tool — `pipeline-cli verdict post` (#2102) — rather than re-hand-rolled
@@ -929,7 +931,7 @@ skips the guard is **FORBIDDEN** (it is the emit-side hole #2789 / #2816 / #2818
 off the verdict lib means `emissionDefect` never runs). If a raw post is ever genuinely unavoidable,
 the body **MUST** first pass `pipeline-cli leak-guard scan-comment` (the #2823 pre-post net) before
 the post. This is the single-source rule in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+[the gate-verdict contract §READBACK](../shared/gate-verdict-contract.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
 
 Resolve the tool once — in-repo first, published fallback (ADR 0062/0064; epic #994) — and pass
 your composed verdict body by file:
@@ -947,9 +949,9 @@ $VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"   # upsert (PATC
 
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
 emphasis, **with the `@ <HEAD_SHA>` you resolved above** — per the matcher contract in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5/§6 (matchers tolerate an
+[the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md) (matchers tolerate an
 optional leading `**`, but emit bare; the `@ <sha>` is required, ADR 0058). **Token order is
-fixed** (§5): `@ <HEAD_SHA>` comes **immediately after** `PASS`, **before** `— merge-ready` —
+fixed** (§VERDICT): `@ <HEAD_SHA>` comes **immediately after** `PASS`, **before** `— merge-ready` —
 never `review-doc: PASS — merge-ready @ <sha>`; `ship-it`'s capture is anchored to that order,
 so a trailing `@ <sha>` captures `sha=null` and refuses a correct PASS as `unverified` (#625):
 
@@ -984,7 +986,7 @@ authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 The body carries the canonical `Reviewed-head: @ <HEAD_SHA>` line here too, so **every** verdict body
 this gate emits — non-blocking PASS, advisory, FAIL — binds the reviewed head in one uniform form
 (#2272). The non-blocking PASS is still bound primarily by its first-line `@ <sha>`; the body line is
-the same canonical token the read-back guard (§6.6) validates, so a clean non-blocking PASS never
+the same canonical token the read-back guard (§ADVISORY) validates, so a clean non-blocking PASS never
 false-fails the unconditional `verdict_post_verify … || exit 1`.
 
 ### Pass path — blocking-set PR (advisory only)
@@ -1015,7 +1017,7 @@ unchanged (it is still doc-class), only the merge-authority moves (ADR 0164 / #3
 > **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
 > `ship-it`'s ADR-0135 approval-aware enqueue reads the reviewed head from **exactly** the
 > `Reviewed-head: @ <HEAD_SHA>` line below (the anchored matcher in
-> [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §6.6), gated on the control-plane
+> [the gate-verdict contract §ADVISORY](../shared/gate-verdict-contract.md)), gated on the control-plane
 > approval — that is what makes a §CP doc PR's enqueue **deterministic** (#1932/#2022; free-prose
 > "reviewed head" phrasings resolved nondeterministically and are retired). Write it as its own line
 > with the exact `Reviewed-head:` prefix and the head SHA you reviewed — do **not** paraphrase it,
@@ -1115,7 +1117,7 @@ unmerged; #<ISSUE> stays open and assigned. Re-request review once they're satis
 Do **not** post a native `REQUEST_CHANGES` review — `review-doc` is comment-only (ADR 0058
 rule 4), so the SHA-bound marker comment is the **sole** verdict artifact. Recognize the
 marker tolerantly by shape (`review-doc: FAIL @ <sha>`), not exact dashes; token order is
-fixed (§5): `@ <sha>` comes **immediately after** `FAIL`, before `— changes-requested`. Do **not** touch the issue's
+fixed (§VERDICT): `@ <sha>` comes **immediately after** `FAIL`, before `— changes-requested`. Do **not** touch the issue's
 labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus a
 comment.
 
@@ -1143,7 +1145,7 @@ landed by any other path reached the guard with an empty id and a broken/leaking
 through). Call the **single unconditional wrapper** from the shared contract, which re-derives the
 landed verdict from live PR state (never a carried variable) and runs the read-back on whatever
 landed, on **every** post path —
-[`gh-issue-intake-formats.md` §Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../gh-issue-intake-formats.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
+[the gate-verdict contract §READBACK — Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../shared/gate-verdict-contract.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
 
 ```bash
 # UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -919,8 +919,8 @@ The upsert (scan your own prior `review-doc:` marker → `PATCH` it, else `POST`
 namespace guard are the ADR-0058 glue **all four gates share**, so they live in one
 deterministic, unit-tested tool — `pipeline-cli verdict post` (#2102) — rather than re-hand-rolled
 `jq` here. `verdict post` PATCHes only your *newest* own marker, so on a PR migrated from the
-pre-0058 append era a few older SHA-less own markers may linger — the one-per-gate invariant is
-**forward-looking**, and those legacy duplicates are tolerated because `ship-it`'s consumer
+pre-0058 append era a few older SHA-less own markers may linger — the (PR, gate-namespace, head,
+run) key is **forward-looking**, and those legacy duplicates are tolerated because `ship-it`'s consumer
 SHA-refuses any marker without an `@ <sha>` on the current head (Step 2b). It also refuses
 fail-closed if the body's first line is not a `review-doc:` marker — the cross-namespace
 emission guard (§the never-a-`review-code`-marker invariant) enforced by the tool, not by care.
@@ -1055,13 +1055,12 @@ Verified against #<ISSUE>'s acceptance criteria + doc hygiene — all checks pas
 
 Post the advisory line **as a comment, not a native `REQUEST_CHANGES`/review** — the
 blocking-set path is comment-only too, exactly like the PASS and FAIL paths (ADR 0058
-rule 4). Upsert it the same way (`PATCH` your own prior `review-doc:` marker if one exists,
-else `POST`):
+rule 4). Upsert it the same way, on the §VERDICT key — (PR, gate-namespace, head, run):
 
 ```bash
 # $VERDICT resolved above (in-repo-first, published-fallback; ADR 0062/0064). The advisory line
-# opens with `review-doc:` too, so `verdict post`'s namespace guard accepts it and upserts it the
-# same way — one comment per gate, PATCH own prior marker else POST.
+# opens with `review-doc:` too, so `verdict post`'s namespace guard accepts it and upserts it on
+# the same (PR, gate-namespace, head, run) key — replacing only this head+run's own record.
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed advisory verdict into "$VERDICT_FILE" (first line: review-doc: advisory — blocking-set PR (§CP — approval-gated))
 $VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"
@@ -1080,15 +1079,17 @@ One or more checks failed (or were unverifiable). **Nothing merges. The PR stays
 the issue stays open and assigned to whoever claimed it** — don't unassign, relabel, or
 close. Post a comment whose first line is the namespaced, SHA-bound FAIL marker (the seam
 `write-code`'s fix round-trip keys on), with the full per-check table — the passing rows
-too, so the author sees how close they are. **Upsert** it (`PATCH` your own prior
-`review-doc:` marker if one exists, else `POST`) exactly as the PASS path — one `review-doc`
-verdict comment per PR (ADR 0058 rule 2):
+too, so the author sees how close they are. **Upsert** it exactly as the PASS path, on the
+§VERDICT key — (PR, gate-namespace, head, run): `verdict post` replaces a prior `review-doc:`
+marker only when that marker matches *this head and this run*, and appends otherwise, so a
+re-review at a new head leaves the prior head's verdict standing and a concurrent run never
+overwrites another's record (ADR 0058 rule 2, refined by ADR 0213). Never hand-roll the `PATCH`:
 
 ```bash
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-doc: FAIL @ <HEAD_SHA> — changes-requested)
-# $VERDICT resolved above (ADR 0062/0064) — same one-per-gate upsert as the PASS path.
+# $VERDICT resolved above (ADR 0062/0064) — same (PR, gate-namespace, head, run) upsert as the PASS path.
 $VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-skill
-description: Verify a skill PR against its linked issue's acceptance criteria — plus a skill-specific rigor checklist (behavioral correctness, trigger/description quality, cross-skill conflict/shadowing, gate-invariant preservation) — before it merges. The behavioral-artifact sibling of review-code/review-doc in the configured target repo's pipeline. Trigger on "review this skill PR", "review-skill #N", "gate the skill PR", "verify the skill on #N before merge", "run review-skill", "does this skill PR meet its acceptance criteria", or whenever you're asked to confirm a `skills/**` PR actually satisfies the issue it claims to close and does not weaken a gate. This is the skill-class verification stage of the issue-intake pipeline: it consumes the skill PRs `write-code` opens and verifies them one criterion at a time plus the four rigor checks, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-skill: PASS @ <sha> — merge-ready` / `review-skill: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR; for BLOCKING-set skill PRs (a gate-critical skill, or any `.claude`/`.github` path) it is advisory only; it never merges; it never emits a `review-code` or `review-doc` marker.
+description: Verify a skill PR against its linked issue's acceptance criteria — plus a skill-specific rigor checklist (behavioral correctness, trigger/description quality, cross-skill conflict/shadowing, gate-invariant preservation) — before it merges. The behavioral-artifact sibling of review-code/review-doc in the configured target repo's pipeline. Trigger on "review this skill PR", "review-skill #N", "gate the skill PR", "verify the skill on #N before merge", "run review-skill", "does this skill PR meet its acceptance criteria", or whenever you're asked to confirm a `skills/**` PR actually satisfies the issue it claims to close and does not weaken a gate. This is the skill-class verification stage of the issue-intake pipeline: it consumes the skill PRs `write-code` opens and verifies them one criterion at a time plus the four rigor checks, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-skill: PASS @ <sha> — merge-ready` / `review-skill: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted on the (PR, gate-namespace, head, run) key; for BLOCKING-set skill PRs (a gate-critical skill, or any `.claude`/`.github` path) it is advisory only; it never merges; it never emits a `review-code` or `review-doc` marker.
 ---
 
 # review-skill
@@ -64,7 +64,7 @@ path, which would read the **pre-PR base** (issue
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §HEAD — cite it, don't
 re-derive: resolve the live head via REST and **assert the fetched ref equals it** before
 reviewing (below), read all skill text from the head, and re-check the live head before posting
-(§HEAD #4); the verdict (§5) binds to the SHA whose files you actually read and asserts it.
+(§HEAD #4); the verdict (§VERDICT) binds to the SHA whose files you actually read and asserts it.
 
 ```bash
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
@@ -136,7 +136,7 @@ invariant `review-code`/`review-doc` hold.
 
 `ship-it` matches the three markers in **separate namespaces** (three anchored,
 emphasis-tolerant, SHA-capturing regexes that never cross-match — see the matcher contract in
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5 / §6.5), latest-verdict-wins
+[the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md)), latest-verdict-wins
 per namespace by timestamp, then a SHA-staleness refusal (ADR 0058). Your verdict's first line
 is **always** `review-skill: … @ <sha>` — never `review-code:` or `review-doc:`. Emitting
 another gate's marker on a skill PR would let that namespace's scan match your verdict,
@@ -171,12 +171,13 @@ checked out — ADR 0052/0067).
 ## The formats contract
 
 Your gate is **format 2, the sub-issue body's `### Acceptance criteria` checklist** — and
-**format 6.5, the review-skill verdict marker** (your namespace). Read the contract so you
+**the review-skill verdict marker** (your namespace). Read the contracts so you
 know the shapes you verify against and emit:
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2 and §6.5. §6.5 defines the
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2, and
+[the gate-verdict contract](../shared/gate-verdict-contract.md) §VERDICT. §VERDICT defines the
 `review-skill` namespace (SHA-bound `PASS @ <sha> — merge-ready` / `FAIL @ <sha> —
-changes-requested`) and the canonical advisory line (§6.6), in a namespace distinct from §5's
-`review-code` and §6's `review-doc` markers — emit only the §6.5 / §6.6 shapes.
+changes-requested`) and §ADVISORY the canonical advisory line, in a namespace distinct from the
+`review-code` / `review-doc` / `review-design` markers — emit only your own namespace's shapes.
 
 The key invariant: **every issue carries at least one acceptance criterion.** That's the floor
 that guarantees there is always something to verify. If an issue you're handed has *zero*
@@ -304,7 +305,7 @@ so the PR reaches `ship-it` with a current-head PASS standing in each present na
 **Emit each namespace's verdict as its OWN separate PR comment — one comment per namespace, marker
 on that comment's literal first line — never two markers stacked in one comment** (the second
 would be un-anchored, resolve empty, and fail-close a substantively-PASS PR — the PR #2456 stall;
-the forbidden "stacked" emit form in `../gh-issue-intake-formats.md` §5).
+the forbidden "stacked" emit form in `../shared/gate-verdict-contract.md` §VERDICT).
 `ship-it`'s per-present-class requirement (its Step 2) is unchanged — it remains the
 **fail-closed late catch** for a genuinely-missing namespace, not the *first* place the second
 namespace is discovered.
@@ -481,8 +482,9 @@ rigor FAIL fails the gate** the same as an AC FAIL — the overall verdict is co
    - `review-code`/`review-doc`/`review-skill`: the **config-pin** (base-reviewed, not
      head-loaded); the **conjunctive** AC + (hygiene/rigor) verdict; the SHA-bound, upserted,
      namespaced marker; the **never-cross-match** matcher; "never merge."
-   - the formats contract (`gh-issue-intake-formats.md`): the §CP canonical set, the §5/§6/§6.5
-     matcher contracts, the ADR-0058 SHA-binding + upsert rules — none narrowed or made
+   - the formats contract (`gh-issue-intake-formats.md`): the §CP canonical set; the gate-verdict
+     contract (`shared/gate-verdict-contract.md`): §VERDICT's matcher contract and the ADR-0058
+     SHA-binding + upsert rules — none narrowed or made
      ambiguous.
    - Out of scope (do **not** flag): a PR that merely *exercises* ADR 0065's coarse
      blocking-rule (a gate-critical edit that stays human-merged) — that is the rule working,
@@ -500,7 +502,7 @@ Build the rigor findings into the same evidence shape as the AC table:
 ```
 - [PASS] Behavioral correctness — the new Step R2 fold reads exactly the enumerated findings (skills/write-code/SKILL.md:619–636)
 - [FAIL] Gate-invariant preservation — diff drops the `@ <sha>` from ship-it's matcher (Step 2, line NNN) → SHA-staleness refusal no longer fires
-- [PASS] Cross-skill conflict — review-skill marker token is disjoint from review-code/review-doc (§6.5)
+- [PASS] Cross-skill conflict — review-skill marker token is disjoint from review-code/review-doc (§VERDICT)
 ```
 
 ---
@@ -626,8 +628,9 @@ HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you revie
 `review-skill` lands its verdict **only as the SHA-bound comment, never a native review** (ADR
 0058 rule 4 — like `review-doc`): a native review can't carry the `@ <sha>` in the shape this
 contract controls, so the comment is the single carrier. The post is an **upsert**, not an
-append: exactly **one** `review-skill` verdict comment per PR (ADR 0058 rule 2), a re-review of
-a new head overwriting the same record. That upsert plus its emission guards are the ADR-0058
+append — on the §VERDICT key — (PR, gate-namespace, head, run) (ADR 0058 rule 2, refined by
+ADR 0213): a re-post at your own key replaces that record in place, while a re-review at a NEW
+head appends a fresh one and leaves the prior head's verdict standing. That upsert plus its emission guards are the ADR-0058
 glue **all four gates share**, so — exactly as `review-doc` — post through the deterministic,
 unit-tested tool (`pipeline-cli verdict post`, #2102), never a hand-rolled `jq`. **The tool is
 the marker-emit choke point:** it refuses fail-closed unless every SHA field (the first-line
@@ -641,7 +644,7 @@ skips the guard is **FORBIDDEN** (it is the emit-side hole #2789 / #2816 / #2818
 off the verdict lib means `emissionDefect` never runs). If a raw post is ever genuinely unavoidable,
 the body **MUST** first pass `pipeline-cli leak-guard scan-comment` (the #2823 pre-post net) before
 the post. This is the single-source rule in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+[the gate-verdict contract §READBACK](../shared/gate-verdict-contract.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
 
 ```bash
 # resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
@@ -666,9 +669,9 @@ $VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
 
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
 emphasis, **with the `@ <HEAD_SHA>` you resolved above** — per the matcher contract in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5/§6.5 (matchers tolerate an
+[the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md) (matchers tolerate an
 optional leading `**`, but emit bare; the `@ <sha>` is required, ADR 0058). **Token order is
-fixed** (§5): `@ <HEAD_SHA>` comes **immediately after** `PASS`, **before** `— merge-ready` —
+fixed** (§VERDICT): `@ <HEAD_SHA>` comes **immediately after** `PASS`, **before** `— merge-ready` —
 never `review-skill: PASS — merge-ready @ <sha>`; `ship-it`'s capture is anchored to that
 order, so a trailing `@ <sha>` captures `sha=null` and refuses a correct PASS as `unverified` (#625):
 
@@ -699,14 +702,14 @@ authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 The body carries the canonical `Reviewed-head: @ <HEAD_SHA>` line here too, so **every** verdict body
 this gate emits — non-blocking PASS, advisory, FAIL — binds the reviewed head in one uniform form
 (#2272). The non-blocking PASS is still bound primarily by its first-line `@ <sha>`; the body line is
-the same canonical token the read-back guard (§6.6) validates, so a clean non-blocking PASS never
+the same canonical token the read-back guard (§ADVISORY) validates, so a clean non-blocking PASS never
 false-fails the unconditional `verdict_post_verify … || exit 1`.
 
 ### Pass path — blocking-set PR (advisory only, the canonical advisory form)
 
 Every check passed but Step 0 classified the PR **blocking** (it touches a gate-critical skill
 or any §CP path — the common case for a skill PR that edits a gate). Post the **same
-evidence**, but the first line is the **canonical advisory line** (§6.6) — **not** a
+evidence**, but the first line is the **canonical advisory line** (§ADVISORY) — **not** a
 merge-ready go-ahead. `ship-it` does not auto-merge this PR on machine gates alone — it enqueues
 only once a `@kamp-us/control-plane` approval is present at head (ADR 0135). The advisory
 line carries **no first-line `@ <sha>`** by design (it authorizes nothing, so there is nothing to
@@ -728,7 +731,7 @@ bind), keeping your verdict out of `ship-it`'s PASS namespace.
 > **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
 > `ship-it`'s ADR-0135 approval-aware enqueue reads the reviewed head from **exactly** the
 > `Reviewed-head: @ <HEAD_SHA>` line below (the anchored matcher in
-> [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §6.6), gated on the control-plane
+> [the gate-verdict contract §ADVISORY](../shared/gate-verdict-contract.md)), gated on the control-plane
 > approval — that is what makes a §CP skill PR's enqueue **deterministic** (#1932/#2022; free-prose
 > "reviewed head" phrasings resolved nondeterministically and are retired). Write it as its own line
 > with the exact `Reviewed-head:` prefix and the head SHA you reviewed — do **not** paraphrase it,
@@ -763,8 +766,8 @@ Upsert it the same way as the pass/fail paths — `mktemp` the verdict file (the
 isn't unique; a fixed `/tmp/...-${PR}.md` collides under concurrent reviews), then `PATCH` your
 own prior `review-skill:` marker if one exists, else `POST`. The namespace-anchored find filter
 matches a prior PASS/FAIL too, so a re-review that flips a PR to blocking overwrites the old
-binding verdict with this advisory line — exactly one `review-skill` verdict per PR (ADR 0058
-rule 2). The advisory **first line** carries no `@ <sha>` by design (SHA-less, so it never enters
+binding verdict with this advisory line, on the §VERDICT key — (PR, gate-namespace, head, run)
+(ADR 0058 rule 2, refined by ADR 0213). The advisory **first line** carries no `@ <sha>` by design (SHA-less, so it never enters
 `ship-it`'s auto-merge namespace — ADR 0111); the reviewed head IS recorded, once, in the body's
 canonical `Reviewed-head: @ <HEAD_SHA>` line (ADR 0151), which `ship-it`'s §CP enqueue reads.
 
@@ -820,7 +823,7 @@ unmerged; #<ISSUE> stays open and assigned. Re-request review once they're satis
 
 Do **not** post a native `REQUEST_CHANGES` review — `review-skill` is comment-only (ADR 0058
 rule 4), so the SHA-bound marker comment is the **sole** verdict artifact. Recognize the marker
-tolerantly by shape (`review-skill: FAIL @ <sha>`), not exact dashes; token order is fixed (§5):
+tolerantly by shape (`review-skill: FAIL @ <sha>`), not exact dashes; token order is fixed (§VERDICT):
 `@ <sha>` comes **immediately after** `FAIL`, before `— changes-requested`. Do **not** touch the
 issue's labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus
 a comment.
@@ -849,7 +852,7 @@ landed by any other path reached the guard with an empty id and a broken/leaking
 through). Call the **single unconditional wrapper** from the shared contract, which re-derives the
 landed verdict from live PR state (never a carried variable) and runs the read-back on whatever
 landed, on **every** post path —
-[`gh-issue-intake-formats.md` §Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../gh-issue-intake-formats.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
+[the gate-verdict contract §READBACK — Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../shared/gate-verdict-contract.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
 
 ```bash
 # UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -661,8 +661,9 @@ merge on it.
 ```bash
 VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed PASS verdict into "$VERDICT_FILE" (first line: review-skill: PASS @ <HEAD_SHA> — merge-ready)
-# Upsert through the guarded tool: it PATCHes your newest own review-skill marker (namespace-
-# anchored, so a blocking↔non-blocking flip upserts a prior advisory too) else POSTs, and it
+# Upsert through the guarded tool on the (PR, gate-namespace, head, run) key: it replaces this
+# head+run's own review-skill record (namespace-anchored, so a blocking↔non-blocking flip replaces
+# a prior advisory at the same key too) and appends against any other key, and it
 # fail-closes on a malformed/cross-namespace body — the mktemp-path `@ <sha>` leak (#2683) never lands.
 $VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
 ```
@@ -763,10 +764,11 @@ Verified against #<ISSUE>'s acceptance criteria + the skill-rigor checklist — 
 ```
 
 Upsert it the same way as the pass/fail paths — `mktemp` the verdict file (the PR number alone
-isn't unique; a fixed `/tmp/...-${PR}.md` collides under concurrent reviews), then `PATCH` your
-own prior `review-skill:` marker if one exists, else `POST`. The namespace-anchored find filter
-matches a prior PASS/FAIL too, so a re-review that flips a PR to blocking overwrites the old
-binding verdict with this advisory line, on the §VERDICT key — (PR, gate-namespace, head, run)
+isn't unique; a fixed `/tmp/...-${PR}.md` collides under concurrent reviews), then upsert on the
+§VERDICT key — (PR, gate-namespace, head, run): `verdict post` replaces a prior `review-skill:`
+marker only when it matches *this head and this run*, and appends against any other key. The
+namespace-anchored filter matches a prior PASS/FAIL at that key too, so a re-review that flips a PR
+to blocking replaces this run's own binding verdict at this head with the advisory line
 (ADR 0058 rule 2, refined by ADR 0213). The advisory **first line** carries no `@ <sha>` by design (SHA-less, so it never enters
 `ship-it`'s auto-merge namespace — ADR 0111); the reviewed head IS recorded, once, in the body's
 canonical `Reviewed-head: @ <HEAD_SHA>` line (ADR 0151), which `ship-it`'s §CP enqueue reads.
@@ -789,15 +791,19 @@ One or more checks failed (or were unverifiable). **Nothing merges. The PR stays
 issue stays open and assigned to whoever claimed it** — don't unassign, relabel, or close.
 Post a comment whose first line is the namespaced, SHA-bound FAIL marker (the seam
 `write-code`'s fix round-trip keys on), with the full per-check table — the passing rows too,
-so the author sees how close they are. **Upsert** it exactly as the PASS path (one
-`review-skill` verdict comment per PR, ADR 0058 rule 2):
+so the author sees how close they are. **Upsert** it exactly as the PASS path, on the §VERDICT
+key — (PR, gate-namespace, head, run): `verdict post` replaces a prior `review-skill:` marker only
+when that marker matches *this head and this run*, and appends otherwise, so a re-review at a new
+head leaves the prior head's verdict standing and a concurrent run never overwrites another's
+record (ADR 0058 rule 2, refined by ADR 0213). Never hand-roll the `PATCH`:
 
 ```bash
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
 VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-skill: FAIL @ <HEAD_SHA> — changes-requested)
-# Upsert through the guarded tool (namespace-anchored, so a fresh FAIL upserts whatever prior
-# review-skill marker exists, advisory included) — fail-closed on a malformed marker (#2683).
+# Upsert through the guarded tool on the (PR, gate-namespace, head, run) key — namespace-anchored,
+# so a fresh FAIL replaces this head+run's own prior review-skill record (an advisory included) and
+# appends against any other key — fail-closed on a malformed marker (#2683).
 $VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -347,32 +347,30 @@ not bound to the PR's current head, and refuse a SHA-less marker outright (ADR 0
 
 **Re-check the live head before posting** (§HEAD #4): if the head moved while you reviewed, do
 **not** post a verdict bound to a SHA you no longer reviewed — re-resolve and re-review, or
-abort. Then resolve the head SHA and **upsert** (one verdict per (PR, namespace) — `PATCH` your
-own prior marker if present, else `POST`; ADR 0058 rule 2). The post is a **comment, never a
-native `APPROVE`** (a native review can't carry the `@ <sha>` this contract controls; ADR 0058
-rule 4):
+abort. Then resolve the head SHA and **upsert on the §VERDICT key — (PR, gate-namespace, head,
+run)**: `verdict post` replaces a prior marker in this namespace only when that marker matches
+*this head and this run*, and appends otherwise, so a re-review at a new head leaves the prior
+head's verdict standing and a concurrent run never overwrites another's record (ADR 0058 rule 2,
+refined by ADR 0213). The post is a **comment, never a native `APPROVE`** (a native review can't
+carry the `@ <sha>` this contract controls; ADR 0058 rule 4).
+
+**Post through the guarded tool, never a hand-rolled `PATCH`.** A raw comment patch of a verdict
+body is a marker hand-post: it resolves "my prior marker" by the shared login alone — head-blind
+and run-blind — which is exactly the ADR-0213 concurrent-reviewer clobber, and it skips
+`emissionDefect` plus the §READBACK re-scan that §VERDICT makes mandatory:
 
 ```bash
-NS=review-code   # or review-doc / review-skill, per the class above
+NS=code   # or doc / skill, per the class above — the gate namespace is `review-$NS`
 HEAD_NOW="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
 [ "$HEAD_NOW" = "$HEAD_SHA" ] || { echo "head moved under the verdict — re-review the new head or abort (ADR 0058)"; exit 1; }
 
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 VERDICT_FILE="$(mktemp /tmp/review-trivial-verdict.XXXXXX)"
 # write your composed verdict into "$VERDICT_FILE"; first line is the bare SHA-bound marker:
-#   <NS>: PASS @ <HEAD_SHA> — merge-ready          (every check passed)
-#   <NS>: FAIL @ <HEAD_SHA> — not merge-ready       (any check failed)
-BODY="$(cat "$VERDICT_FILE")"
-ME="$(gh api user --jq .login)"
-# upsert: PATCH your own newest marker in this namespace if present, else POST.
-# pipe gh api straight into standalone jq (--arg is a jq flag, not a gh-api one; binary-safe):
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" --arg ns "$NS" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*" + $ns + ":"; "i")))) | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
-fi
+#   review-<NS>: PASS @ <HEAD_SHA> — merge-ready          (every check passed)
+#   review-<NS>: FAIL @ <HEAD_SHA> — not merge-ready       (any check failed)
+"$PCLI" verdict post --pr "$PR" --gate "$NS" --body-file "$VERDICT_FILE"
 ```
 
 ### Verdict body shape

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -337,7 +337,8 @@ don't re-derive:
 - **code-class** diff (everything else — `apps/**`, `packages/**`, `.glossary/**`, a code-root
   `*.md`) → emit a **`review-code:`** marker.
 
-Whichever namespace, the verdict obeys the §5/§6/§6.5 matcher contract: the **first line** is
+Whichever namespace, the verdict obeys the [gate-verdict contract
+§VERDICT](../shared/gate-verdict-contract.md) matcher rules: the **first line** is
 the bare, canonical, SHA-bound marker, with `@ <sha>` **immediately after** the `PASS`/`FAIL`
 polarity and **before** the `— merge-ready` / `— not merge-ready` tail (token order is fixed;
 a trailing `@ <sha>` captures `sha=null` and `ship-it` refuses a correct PASS as `unverified`,

--- a/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
+++ b/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
@@ -1,0 +1,475 @@
+# The gate-verdict contract — one spec, four gate namespaces
+
+The single source for **how a review gate lands its verdict on a PR**: the SHA-bound marker
+shape, the upsert key, the matcher every consumer scans with, the forbidden emit forms, the
+control-plane advisory form, and the post-write read-back that proves the marker landed clean.
+
+**Who reads it.** The four PR gates — `review-code`, `review-doc`, `review-skill`,
+`review-design` — emit against it; `ship-it` scans it to decide a merge; `write-code`'s repair
+round-trip scans it to find a FAIL. Each **cites** this file; none re-derives it.
+
+Extracted from [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), where the same
+spec lived as four near-identical per-gate sections that drifted against each other (#4438). It
+lives under `claude-plugins/kampus-pipeline/skills/`, so it is control-plane in whole under the
+existing whole-tree `CONTROL_PLANE_RE` branch — the same gating the gate skills themselves carry,
+with no boundary amendment.
+
+## Retired section numbers — the mapping
+
+The per-gate sections were numbered against the formats contract's sequence, which is exactly
+what made them positional rather than nameable. Here they carry mnemonic tokens, matching that
+contract's own convention for factored, cross-cited sections (§CP, §DOC, §CLASS, §ZS, §SP, …).
+A record citing an old number resolves through this table:
+
+| Retired | Now |
+|---|---|
+| §5 — review-code pass marker | §VERDICT |
+| §6 — review-doc verdict marker | §VERDICT |
+| §6.5 — review-skill verdict marker | §VERDICT |
+| §6.7 — review-design verdict marker | §VERDICT |
+| §6.6 — the canonical advisory line | §ADVISORY |
+| the verdict read-back guard / unconditional read-back / mandatory guarded emit | §READBACK |
+
+---
+
+## VERDICT. The verdict marker — one contract, four namespaces
+
+A gate lands its verdict as a **comment whose first line is a recognizable, SHA-bound marker**.
+That marker is a downstream contract: `ship-it` scans for the PASS marker to find verified,
+merge-ready PRs unambiguously, and `write-code`'s fix round-trip scans for the FAIL marker to
+find a PR that came back failed.
+
+Everything below holds for **all four gates**. The two tables carry the only values that differ.
+
+### The per-gate namespace table — the values that differ
+
+| Gate | Marker namespace | PASS first line | FAIL first line | Verdict carrier |
+|---|---|---|---|---|
+| `review-code` | `review-code` | `review-code: PASS @ <sha> — merge-ready` | `review-code: FAIL @ <sha> — not merge-ready` | the comment **or** a native `APPROVE` |
+| `review-doc` | `review-doc` | `review-doc: PASS @ <sha> — merge-ready` | `review-doc: FAIL @ <sha> — changes-requested` | the comment only |
+| `review-skill` | `review-skill` | `review-skill: PASS @ <sha> — merge-ready` | `review-skill: FAIL @ <sha> — changes-requested` | the comment only |
+| `review-design` | `review-design` | `review-design: PASS @ <sha> — merge-ready` | `review-design: FAIL @ <sha> — changes-requested` | the comment only |
+
+| Gate | Surface it gates | What the verdict body carries below the marker |
+|---|---|---|
+| `review-code` | the code class | the per-criterion evidence table |
+| `review-doc` | the **§DOC doc class** — `.decisions/**`, `.patterns/**`, `docs/**`, or a root/top-level prose `*.md`; explicitly **not** a code-root `*.md` under `apps/**`/`packages/**`, which rides `review-code` | the per-criterion **+ per-hygiene-check** evidence table |
+| `review-skill` | a **skill PR** (`skills/**`, superseding ADR 0063's `skills/**` → `review-code` routing), against the ACs *plus* a rigor checklist — behavioral correctness, trigger/`description` quality, cross-skill conflict/shadowing, gate-invariant preservation (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §1) | the per-criterion **+ per-rigor-check** evidence table |
+| `review-design` | a **UI-affecting PR**, judged by driving Playwright over the PR's preview deploy, capturing the changed surfaces, and judging the rendered screenshots multimodally against the **four-pillars design law** (ADR [0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md); the gate is ADR [0165](https://github.com/kamp-us/phoenix/blob/main/.decisions/0165-review-design-gate.md), skill landed via #2246). It hard-FAILs **only** on the six enumerable, objective ADR-0162 prohibitions; all holistic/taste judgment rides as advisory (non-blocking) notes in the same comment | the per-prohibition table (the six hard-FAIL checks, passing rows too), an **Advisory (non-blocking)** section, and an **Evidence** section embedding the GitHub-hosted screenshot URLs so a human can see what was judged |
+
+### Shape — SHA-bound (ADR 0058)
+
+The recognizable **first line** of the PR comment carries the **head SHA the reviewer inspected**
+(`@ <sha>`), resolved at post time from `gh api repos/$REPO/pulls/$PR --jq .head.sha`. `<sha>` is
+the full or abbreviated (≥7 hex) head SHA. What's load-bearing for the scanner is only that first
+line — the namespace, the polarity, **and the `@ <sha>`**; the body below it is for the human and
+the implementer.
+
+The `@ <sha>` is **load-bearing, not decoration**: `ship-it` and `write-code`-repair refuse a
+verdict whose `@ <sha>` does not match the PR's *current* head, and refuse a SHA-less marker
+outright — this is what closes the stale-PASS-masks-a-FAIL and head-moved-under-the-verdict races
+(ADR [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258). A marker with no
+`@ <sha>` is a *pre-0058 legacy* shape and resolves to `unverified`, not PASS.
+
+### Upsert, not append — the record is keyed on (PR, gate-namespace, head, run) (ADR 0058, refined by ADR 0213)
+
+A verdict record is identified by **four** dimensions: the PR, the gate namespace, the **head**
+it is bound to, and the **run** that posted it. That upsert is **`pipeline-cli verdict post`'s own
+behavior, not something a reviewer hand-rolls**: the verb scans the PR for a prior marker in its
+namespace matching *this head and this run's `<!-- verdict-run: … -->` trailer* and, if one
+exists, replaces that comment in place with the fresh verdict; anything else it **appends**.
+
+So the key, not a "one comment per PR" rule, decides what happens:
+
+- **Same key** (same head, same run) → a genuine correction **upserts in place**, so no slot
+  accumulates a stale verdict stream a millisecond decides. See ADR 0058 rule 2.
+- **New head** → a fresh record is appended and the prior head's verdict is left standing; that is
+  what the `head` dimension buys (#4007, ADR
+  [0213](https://github.com/kamp-us/phoenix/blob/main/.decisions/0213-verdict-upsert-keyed-on-run-not-shared-author.md)).
+- **Different run** → a distinct record, appended. Every draining agent authenticates as one shared
+  GitHub login, so without the run dimension two concurrent reviewers each matched the *other's*
+  comment and PATCHed its body away — a server-side loss of a merge-gate artifact (ADR 0213).
+
+Consequently **a PR thread may legitimately carry more than one verdict comment in one namespace,
+including at one head** — that is the intended state, not a defect to reconcile, and no rule here
+may be written as if a namespace held exactly one comment per PR. Resolution among them is the
+reader's job, not the poster's: the ADR-0055 author-gate first, then latest-verdict-wins per
+namespace by timestamp, then the SHA-staleness test.
+
+**Do not translate this into a raw `gh api` comment `PATCH`.** A hand-rolled patch of a verdict
+body is a marker hand-post — it skips `emissionDefect` and the post-write `verifyLanded` re-scan,
+which is exactly the emit-side bypass [The guarded emit path is
+MANDATORY](#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard)
+forbids (#2789 / #2816 / #2818). If a raw post is genuinely unavoidable, take that section's one
+escape hatch — `pipeline-cli leak-guard scan-comment` on the body **first**.
+
+### Carrier — comment-only, and the one gate that keeps a native `APPROVE`
+
+`review-doc`, `review-skill` and `review-design` emit their verdict **only** as the SHA-bound
+`<namespace>:` comment, **never** a native `APPROVE`/`REQUEST_CHANGES` review (ADR 0058 rule 4).
+This resolves the duality #258 flagged: a native GitHub review cannot carry the `@ <sha>` in the
+comment shape this contract controls (it records `commit_id` in a *different* record type), so
+leaving a gate free to post either would force `ship-it` to compare a review against a comment for
+that lane — two incomparable records. One carrier per lane keeps the lane resolvable.
+
+`review-code` is the exception and keeps its native-`APPROVE` path, because `ship-it` reads that
+review's `commit_id` — which **is** the SHA the reviewer approved — and applies the same staleness
+test to it. The `review-code` comment marker is the fallback that carries the same meaning (with
+the `@ <sha>` doing explicitly what `commit_id` does for a native review) where a formal review
+can't be posted, e.g. when org branch rules forbid reviewing your own PR.
+
+### The matcher contract — emphasis-tolerant, SHA-capturing, anchored, never cross-matching
+
+The marker line may carry **leading Markdown emphasis** — `review-code` historically emitted it
+bolded (`**review-code: PASS @ <sha> — merge-ready**`), `review-doc` emits it bare. To stop the
+emitter and the matcher from drifting apart (the bolded marker once read as "no verdict" and
+stalled every code-lane merge — #219), this contract pins **one** rule both sides cite:
+
+- **Canonical emit shape** (what an emitter SHOULD write): the bare, unbolded first line —
+  `<namespace>: PASS @ <sha> — merge-ready`. New/converging emitters write this.
+- **Token order is fixed** (the single source every emitter cites): the `@ <sha>` comes
+  **immediately after** the `PASS`/`FAIL` polarity and **before** the `— merge-ready` /
+  `— not merge-ready` / `— changes-requested` tail — `review-code: PASS @ <sha> — merge-ready`,
+  never `review-code: PASS — merge-ready @ <sha>`. The matcher below is **anchored to this
+  order**: it captures the SHA only when `@ <sha>` directly follows the polarity, so a marker that
+  pushes `@ <sha>` *past* the tail captures `sha=null` → the consumer resolves it `unverified` and
+  refuses a correct, current-head PASS (the token-order drift that silently stalled #623's
+  merge — #625). The fix is to **emit the canonical order**, not to loosen the matcher to chase a
+  trailing SHA (ADR 0058 forbids weakening the SHA-binding).
+- **Matcher obligation** (what every scanner MUST accept): an **optional leading `**`** before the
+  namespace token, so a bolded marker resolves identically to a bare one, **and a captured
+  `@ <sha>`** so the consumer can apply the staleness test. The four anchored, case-insensitive
+  matchers are:
+
+  - code:   `^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
+  - doc:    `^\s*\**\s*review-doc:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
+  - skill:  `^\s*\**\s*review-skill:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
+  - design: `^\s*\**\s*review-design:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
+
+  The leading `\**` absorbs the emphasis; `^\s*` still pins the marker to the start of the body so
+  a mid-body *quote* never matches; the trailing `@\s*([0-9a-f]{7,40})` captures the bound head
+  SHA. A SHA-less marker that matches only the looser
+  `^\s*\**\s*<namespace>:\s*(PASS|FAIL)` prefix but **not** the `@ <sha>` tail is a legacy
+  verdict → the consumer treats it as `unverified` (ADR 0058 rule 3).
+- **The four namespaces are disjoint by construction.** Each matcher names its own literal token,
+  and because the tokens end in four different words (`code:` / `doc:` / `skill:` / `design:`) no
+  anchored literal can prefix-match another. A scan in one namespace can **never** cross-match
+  another, and a gate **never** emits another gate's marker.
+- **Every matcher site cites this one rule** — `ship-it`'s merge gate, `write-code`'s fix
+  round-trip, and each gate's own upsert — so they can't diverge again.
+
+### Forbidden emit forms
+
+The matcher above is anchored, so an emitter that freelances any of the shapes below produces a
+verdict **no consumer can read** — `ship-it` resolves the PR to `unverified` and silently refuses
+to merge a genuine, current-head PASS (the #1095 stall: a real PASS posted as
+`<!-- review-code: PASS sha:… -->` sat unmerged). The emit contract is the mirror of the matcher —
+emit the canonical first line and **none** of these:
+
+- **HTML-comment-wrapped** — `<!-- review-code: PASS @ <sha> — merge-ready -->`. The `<!--` is
+  non-whitespace ahead of the namespace token, so it fails the `^\s*\**\s*` anchor (the `\**`
+  absorbs only Markdown emphasis, never `<!--`). The marker must be **live body text**, not an
+  HTML comment — the verdict-marker contract has no HTML-comment form (the only sanctioned HTML
+  comments here are the unrelated AC-append provenance tag and the upsert's `verdict-run` trailer).
+- **`sha:` (or any non-`@`) SHA delimiter** — `review-code: PASS sha:<sha>`. The matcher captures
+  the bound SHA only from the literal `@ <sha>` tail; `sha:<sha>` matches only the looser SHA-less
+  prefix → `unverified`. The delimiter is `@`, never `sha:`/`SHA=`/`commit:`.
+- **Heading-only / prose-only verdict** — `## review-code verdict: PASS` with no marker line. A
+  heading is not the contract: it carries no `@ <sha>` and isn't anchored at the namespace token.
+  The recognizable first line is required *in addition to* any human-facing heading.
+- **Marker not on the literal first line** — the `^` anchor pins the marker to the **start of the
+  comment body**; a marker buried after a preamble paragraph never matches. It leads the body.
+- **Two namespace markers stacked in one comment (the multi-namespace fan)** — on a mixed-class
+  diff the reviewer fans several verdict namespaces (e.g. `review-code` + `review-skill` for a
+  skill+code PR, `review-design` for a UI PR). Each namespace's `^` anchor pins its marker to the
+  first line of **its own comment**, so stacking a second namespace's marker on line 2 of the
+  first's comment leaves that second marker un-anchored: it never matches, its namespace resolves
+  **empty**, and `ship-it` fail-closes a substantively-PASS PR (the live PR #2456 stall — both
+  reviews PASSed, but the stacked `review-skill` marker was unmatchable and recovery needed a
+  manual re-emit). **Emit each fanned namespace's verdict as its OWN separate PR comment, its
+  `<namespace>: PASS|FAIL @ <sha>` marker on that comment's literal first line — one comment per
+  namespace, never two markers stacked.** The upsert key is unchanged; the fan writes N such
+  comments (one per namespace), not one comment carrying N markers.
+
+These are emitter bugs, not matcher gaps — the fix is always to **emit the canonical shape**,
+never to loosen the anchored matcher to chase a malformed marker (ADR 0058 forbids weakening the
+SHA-binding).
+
+### Field notes
+
+- **First line, recognizable.** The marker leads the comment so a scan can match it without
+  parsing the whole body. Recognize it tolerantly by shape (`<namespace>: PASS @ <sha>` …
+  `merge-ready`) and emphasis (optional leading `**`, per the matcher contract above), not by
+  exact dashes or spacing — but the `@ <sha>` is required.
+- **Two markers, two consumers.** `PASS @ <sha> — merge-ready` (every criterion the gate owns
+  verified, bound to that head) is read by `ship-it` as the go-ahead to merge a **non-blocking**
+  PR **iff `<sha>` is the current head**. The FAIL marker (≥1 criterion unmet) is read by
+  `write-code`'s fix round-trip as "my PR came back failed"; `ship-it` reads it as "do not merge."
+  Each marker has exactly one merge-relevant meaning.
+- **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on. A gate
+  writing it does **not** merge; merging is `ship-it`'s deliberate act (see each gate's
+  §"Authority limit" and ADR
+  [0048](https://github.com/kamp-us/phoenix/blob/main/.decisions/0048-ship-it-merge-actor.md)).
+- **`review-design`'s required-gate wiring has landed** as part of the ADR-0165 rollout: `ship-it`
+  runs the `UI_RE` probe and refuses a `has-ui` PR with an empty `review-design` namespace, and
+  §CLASS's `pipeline-cli class-probe classify` folds the additive gate in.
+- **Every `review-design` verdict body carries the canonical `Reviewed-head: @ <sha>` line**
+  (§ADVISORY / ADR 0151) on *every* path, not only the advisory one — the read-back guard asserts
+  it, and a delegated §CP merge actor (and `ship-it`'s ADR-0135 approval-aware enqueue) resolves
+  the reviewed head from **exactly that line**, never from the first-line marker.
+
+---
+
+## ADVISORY. The canonical advisory line — one form for all four gates
+
+The gates once expressed "advisory" two ways: `review-code` emitted a binding
+`PASS @ <sha> — merge-ready` line *plus* a control-plane caveat, while `review-doc`
+suppressed the binding PASS and led with a **no-`@ <sha>`** advisory line. ADR
+[0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §5 picks
+`review-doc`'s form as the **single canonical advisory shape** and converges all the gates on
+it; the later `review-design` gate (ADR 0165) adopts the same form from birth.
+
+For a PR in the **control-plane / blocking set** (§CP), the gate emits a comment whose first
+line is the **no-`@ <sha>`** advisory marker in its own namespace:
+
+```markdown
+review-code:   advisory — blocking-set PR (§CP — approval-gated)
+review-doc:    advisory — blocking-set PR (§CP — approval-gated)
+review-skill:  advisory — blocking-set PR (§CP — approval-gated)
+review-design: advisory — blocking-set PR (§CP — approval-gated)
+```
+
+Every gate takes this arm on a §CP PR, and it is the **common case for a skill PR** (every gate
+skill is gate-critical, so most skill PRs that touch a gate land here).
+
+**The advisory is a PASS path only.** A gate that finds a failing criterion on a §CP PR emits its
+**FAIL** marker instead, which routes the PR into the author's repair round — an advisory whose
+body carries a `[FAIL]` criterion is a state nothing downstream can act on (ADR
+[0226](https://github.com/kamp-us/phoenix/blob/main/.decisions/0226-cp-advisory-never-carries-a-failing-criterion.md)).
+
+The rest of the body carries the same per-check evidence table the PASS/FAIL paths carry — the
+verdict is *recorded* (for the human or delegated merge actor to read), it just **authorizes
+nothing on its first line**. The advisory **first line** **carries no `@ <sha>`** on purpose: it
+does not enter any `ship-it` `PASS @ <sha> — merge-ready` namespace, so a §CP PR is never
+auto-mergeable off it (ADR 0053). Under ADR 0135's approve-then-enqueue, `ship-it` enqueues it once a
+`@kamp-us/control-plane` approval is present at head (ADR 0053/0065/0135) — that approval, not a gate
+verdict, is what authorizes the merge.
+
+**The advisory body MUST carry the canonical `Reviewed-head` line (ADR 0151).** Immediately after
+the advisory's first-line marker + framing prose, the body carries **exactly one** line recording
+the reviewed head SHA in a fixed, machine-parseable form:
+
+```markdown
+Reviewed-head: @ <HEAD_SHA>
+```
+
+This is the single canonical binding for a §CP advisory — it replaces the free-prose "reviewed head"
+phrasings (which spelled the SHA half a dozen incompatible ways and made the §CP enqueue
+nondeterministic; #1932/#2022). It is a **body** line with a **distinct `Reviewed-head:` token**, so
+it is never matched by the first-line `<namespace>: PASS @ <sha>` PASS-namespace matcher —
+the advisory stays out of `ship-it`'s auto-merge namespace exactly as ADR 0111 requires. Both a human
+delegated merge actor and `ship-it`'s ADR-0135 approval-aware §CP enqueue read the reviewed head from
+**this** line, via the anchored matcher (case-insensitive, optional `@`, 7–40 hex, ADR 0058
+prefix-match either side):
+
+```
+^\s*Reviewed-head:\s*@?\s*([0-9a-f]{7,40})\b
+```
+
+`ship-it` treats the §CP advisory namespace as an enqueue-eligible current-head PASS-equivalent iff
+(a) this `Reviewed-head` SHA prefix-matches the PR's current head, (b) every body checkbox is
+`[PASS]`, and (c) Step 0's control-plane approval is present at head — else it refuses
+deterministically (ship-it Step 2.§CP, ADR 0151). The reviewer is **never** asked to emit a bindable
+first-line PASS on a §CP PR to unblock enqueue (ADR 0111's advisory-is-SHA-less-in-first-line
+invariant is preserved; the reviewer marker contract is not widened).
+
+This is why the advisory form is namespace-uniform but binding-free: it keeps each gate's
+verdict **out** of `ship-it`'s merge path for the control plane while still leaving a
+visible, evidence-bearing verdict on the PR. (`review-code`'s historical binding-PASS +
+caveat shape was retired in favor of this; the reconciliation landed with #424.)
+
+**The first-line `@ <sha>` is omitted by design — the SHA is bound in the body's canonical
+`Reviewed-head` line, and both a delegated merge actor AND `ship-it`'s §CP enqueue confirm from
+that body line, not the first-line marker (ADR 0111/0151).** The advisory line deliberately
+withholds the first-line `@ <sha>` so it never enters `ship-it`'s `PASS @ <sha> — merge-ready`
+namespace — that withholding is exactly what makes `ship-it` refuse to *auto-merge* the §CP PR off a
+first-line PASS (ADR 0053). It is **not** a missing binding: the head SHA the reviewer inspected is
+recorded in the verdict **body** on the canonical `Reviewed-head: @ <sha>` line + the per-AC PASS
+table, per ADR 0058. So a **delegated** control-plane merge actor — an operator hand-merging a banked
+§CP PR, or `ship-it`'s ADR-0135 approval-aware enqueue acting on the maintainer's current-head
+APPROVE — must **not** try to bind the first-line marker (it will read as `unverified`, the
+SHA-less-by-design form #977 hit). It confirms the verdict by **reading the body**: the
+`Reviewed-head` `@ <sha>` against the PR's current head + every AC marked PASS, then applies
+`ship-it`'s just-in-time guards (head freshness, mergeable, no failing required check) and
+merges/enqueues. A namespace-isolated bindable *first-line* SHA was rejected (it would invite
+automated §CP auto-merge and erode ADR 0053) — ADR 0151 instead makes the *body*'s binding canonical
+and machine-read, keeping ADR 0111 intact. See
+[ADR 0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md)
+and [ADR 0151](https://github.com/kamp-us/phoenix/blob/main/.decisions/0151-cp-advisory-body-sha-resolves-approval-aware-enqueue.md).
+
+Because a design verdict is calibrated to FAIL conservatively (a borderline call is downgraded to
+advisory), a `review-design` advisory can *also* mean "no objective prohibition hard-failed" — but
+on a §CP PR the first-line advisory is always the approval-gated shape above.
+
+---
+
+## READBACK. Proving the marker landed clean
+
+The three rules below govern the *emit path* and the *post-write read-back* that together make a
+verdict marker's landing verifiable rather than assumed. They are cited, never re-derived, by each
+gate's Step-5-family verdict step.
+
+They moved here **byte-identically** — bytes verified against the pre-move span, not re-read — so
+three of their references still carry their pre-move spellings. Read them as:
+
+- *"the by-value form above"* → [§Posting a comment
+  body](../gh-issue-intake-formats.md#posting-a-comment-body--read-it-into-body-never-gh-api--f-bodyfile-the-local-path-leak)
+  of the formats contract, which stayed there.
+- *"§6.6"* → [§ADVISORY](#advisory-the-canonical-advisory-line--one-form-for-all-four-gates) above —
+  the same section under its mnemonic name.
+- the relative link `shared/scripts/verdict-readback.sh` → [`scripts/verdict-readback.sh`](scripts/verdict-readback.sh),
+  the sibling of this file (it was written from the parent directory).
+
+### The verdict read-back guard — after posting a gate marker, re-read it and FAIL LOUD (`verdict_readback_guard`)
+
+The by-value form above (`-f body="$BODY"`) is the *source* idiom; it prevents a `body=@<path>`
+leak **at the call site**. But a source idiom cannot catch a **runtime deviation** — an agent that
+hand-assembles the wrong `$BODY` (the literal temp path as the marker body, a body missing its
+`Reviewed-head:` anchor, or a silently no-opped post) still lands a broken marker the by-value form
+happily transmits. That is the #2148 class: the posted verdict comment's entire body was a local
+temp path (`@/var/folders/…`), so no SHA-bound verdict existed for `ship-it` / the §CP merger to
+bind to (a **missing** gate verdict), **and** it leaked a machine-local path into a public comment.
+The source idiom alone can't see it; only a **post-write read-back** can.
+
+So every gate that posts a verdict marker — `review-code`, `review-doc`, `review-skill`,
+`review-design` — closes the loop with **one** canonical read-back guard: after the post/upsert
+lands, **re-read the comment you just wrote** and assert three invariants, failing **loud**
+(fail-closed, ADR
+[0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md) §ZS)
+on any miss — never a silent pass. This is the single source; each review skill **references it**
+(it does not re-derive its own copy — the three-copy drift is exactly what this contract exists to
+prevent):
+
+```bash
+KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
+. "$KP_SHARED/verdict-readback.sh"                                  # §SHARED: both guards, one source
+verdict_readback_guard "$CID" review-code "$HEAD_SHA" || …          # <gate> ∈ review-{code,doc,skill,design}
+```
+
+[`shared/scripts/verdict-readback.sh`](shared/scripts/verdict-readback.sh) carries the four checks and
+their reasons: **(0)** a non-empty body, **(1)** a canonical `<gate>:` marker — the bindable
+`PASS|FAIL @ <sha>` first line or the SHA-less `advisory` one, **(2)** the SHA-source-aware head
+binding, **(3)** no local-filesystem-path leak. Any miss returns non-zero and names the cause.
+
+Gate it exactly like the by-value post it follows: right after the `PATCH`/`POST` upsert returns the
+comment id, call `verdict_readback_guard "$CID" <gate> "$HEAD_SHA"` and, on non-zero, **re-post the
+real verdict and re-assert** — if it still cannot land clean, surface it as a **posting failure** in
+the run ledger (the PR is genuinely ungated; a consumer must not read it as verified), never swallow
+it as a silent success. A moved `HEAD_SHA` between the post and the read-back means the head advanced
+*during* the review — re-resolve the head, re-verify against it (the gate is stateless), and re-post;
+never loosen the match to paper over a moved head. (In practice a gate never calls this primitive with
+a hand-carried id — it calls the unconditional `verdict_post_verify` wrapper below, which resolves the
+landed comment id by re-scanning PR state and passes it here.)
+
+Check (2) is **SHA-source-aware** (#2272): the read-back fires on every verdict type without
+false-failing a legitimate non-blocking PASS. The bindable PASS/FAIL first line satisfies (1) via its
+`@ <sha>` — that SHA **is** the head binding, so (2) requires no separate `Reviewed-head:` line (the
+non-blocking binding templates carry the SHA only on the first line; this is the branch that keeps a
+clean non-blocking doc/skill PASS from false-failing under the unconditional `verdict_post_verify …
+|| exit 1`). The advisory blocking-set path carries no first-line `@ <sha>` by design (ADR 0111),
+which is why (1) accepts the `<gate>: advisory` first line; it binds the head **in the body** via the
+canonical `Reviewed-head: @ <sha>` line, which §6.6/ADR 0151 mandates on **all four gates'** advisories
+— **review-code included** (#2329: the earlier "review-code's §CP advisory carries NONE by design →
+accept its absence" carve-out contradicted §6.6's MUST and blinded (2) to a drifted `**Reviewed head:**`
+variant, which ship-it's §6.6 enqueue matcher then rejects; the carve-out is removed, so a missing or
+drifted advisory head-binding fails **loud at emission** rather than surfacing as a ship-it refusal on
+an approved PR). Any `Reviewed-head:` line present but bound to the wrong sha is always fatal. The
+canonical-marker check (1) and the leak check (3) are **unconditional** on every verdict type — the
+#2148/#2264 path-leak protection is never relaxed.
+
+### Make the read-back UNCONDITIONAL — resolve the landed verdict from PR state, never a carried id (`verdict_post_verify`)
+
+`verdict_readback_guard` above is correct but only fires **if it is reached with the right comment
+id**. The #2264 recurrence (after #2148/#2153 already "fixed" the leak) proves that condition is the
+real gap: the guard was invoked as `verdict_readback_guard "$MINE" …`, and `$MINE` is populated on
+**one** posting branch only (the APPROVE-failed comment-upsert `else` fallback). A verdict that lands
+by any **other** path — the native `APPROVE`, a first-verdict `POST` on a branch that didn't set
+`$MINE`, or an agent hand-rolling `gh api -f body=@file` — reaches the guard with an **empty** id, so
+the guard reads nothing and the broken/leaking marker sails through. A guard you can skip by taking a
+different post branch is not a guard.
+
+The fix is to **stop trusting a carried variable and re-derive the landed verdict from live PR
+state**, then run the read-back **unconditionally** on whatever landed. This is the single wrapper
+every gate calls after posting — it resolves the marker comment id by re-scanning, proves *a* verdict
+actually landed for the head, and **hard-fails (non-zero)** on absent / broken / leaking so a garbled
+or path-leaking marker is a **fatal** error the gate cannot silently pass:
+
+```bash
+KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
+. "$KP_SHARED/verdict-readback.sh"                                  # §SHARED: the wrapper and the guard it calls
+verdict_post_verify "$PR" review-code "$HEAD_SHA" || exit 1         # UNCONDITIONAL, after ANY post/upsert
+```
+
+It resolves the landed verdict from live PR state — **(A)** my SHA-bound or advisory marker comment,
+**(B)** a native `APPROVE` whose `commit_id` is this head — never from a carried `$MINE`/`$CID`; then
+**(C)** hard-fails when nothing bound to the head landed, **(D)** runs the read-back on the landed
+comment whichever branch posted it, and **(E)** leak-checks the native-`APPROVE` body too. Returns 0
+only on a proven-clean landed verdict.
+
+**Why this closes the #2264 recurrence — the post-path enumeration.** Every way a gate can land a
+verdict now routes through the same unconditional read-back, because `verdict_post_verify` resolves
+the landed surface from PR state instead of from a branch-local variable:
+
+- **native `APPROVE`** → resolved by (B); its body is leak-checked by (E); commit_id is its SHA anchor.
+- **comment `PATCH`-upsert** (the old `$MINE` branch) → resolved by (A); shape+leak by (D).
+- **comment `POST`** (first verdict, `$MINE` empty) → resolved by (A); shape+leak by (D). *This is the
+  branch the carried-`$MINE` call silently skipped.*
+- **advisory comment** (§CP blocking-set) → resolved by (A) via the `<gate>: advisory` arm; shape+leak by (D).
+- **hand-rolled `gh api -f body=@file`** (the literal path as the whole body) → has **no** `<gate>:`
+  first line, so (A) resolves empty and (B) is 0 ⇒ **(C) fatal** (`ungated`). A garbled marker is fatal.
+
+The single **fatal** exit on absent/broken/leaking is the load-bearing change: the prior Step-4c
+presence check merely *echoed* a warning and re-posted without a non-zero exit, so a garble read as
+green. Callers **must** propagate the non-zero — `verdict_post_verify … || exit 1` — so the gate
+cannot report itself done over an ungated PR.
+
+Gate it exactly like the by-value post it follows: right after the last of the Step-5/4a-4b upsert
+branches runs, call `verdict_post_verify "$PR" <gate> "$HEAD_SHA" || exit 1`. On a moved `HEAD_SHA`
+between post and verify the head advanced *during* review — re-resolve the head, re-verify against it
+(the gate is stateless), and re-post; never loosen the match to paper over a moved head.
+
+### The guarded emit path is MANDATORY — never hand-post a verdict marker off the guard
+
+`verdict_post_verify` above is the *read-back*: it re-scans PR state **after** a post and fails loud
+on a marker that landed broken or leaking. But a read-back cannot police a post it never sees. An
+agent that **hand-posts** the verdict marker with a raw `gh api …/comments` or `gh pr comment` call
+bypasses the verdict lib entirely, so `emissionDefect` never fires — and, worse, the marker often
+never resolves through `verdict_post_verify`'s re-scan either, so nothing catches it. That is the
+**emit-side hole** the recurrences rode: #2789 (the whole body was an `@filepath`), #2816 / #2818 (a
+`/var/folders` mktemp path glued into the `@ <sha>` field) — each leaked because the marker was
+hand-posted off the verdict lib, not because the lib's guard was wrong. Code cannot force a hand-post
+through a guard the reviewer never invokes; the **emit path itself** must be mandated, not just
+described.
+
+So for **all four PR gates** — `review-code`, `review-doc`, `review-skill`, `review-design` — routing
+every verdict-marker post through the guarded path is a **hard invariant, not a suggestion**:
+
+- **MUST** post every verdict marker through `pipeline-cli verdict post` — the single marker-emit
+  choke point that runs `emissionDefect` (the body-wide machine-local-path scan added by #2823, plus
+  the 40-hex `@ <sha>` field guards, #2683) and **refuses fail-closed** on a leaking or malformed
+  body. For the native `APPROVE` review body (which `verdict post` cannot emit), run the **same** gate
+  as an explicit read-back assertion — `verdict validate` — **before** the `APPROVE`, so a
+  malformed/leaking marker fails loud rather than landing in a public review body.
+- **FORBIDDEN:** a bare `gh api …/comments` / `gh pr comment` hand-post of a verdict marker that skips
+  the guard. The guarded tool is the **only** sanctioned emit path; a free-form raw post is a bypass,
+  never an equivalent — a reviewer must not free-form the marker even when the body "looks clean."
+- **The one escape hatch, itself guarded:** if a raw post is genuinely unavoidable, the body **MUST**
+  first pass `pipeline-cli leak-guard scan-comment` (the standalone pre-post net #2823 added — reads
+  the body on stdin / `--body-file`, exits non-zero on a machine-local path) **before** the post. A
+  raw post whose body was never scanned is the forbidden case; a scanned one is the escape hatch.
+
+This is the **enforcement complement** to #2823: #2823 hardened the guard *code* (`emissionDefect`'s
+body-wide scan + the `leak-guard scan-comment` CLI); this mandate closes the emit-side hole by
+forbidding the reviewer from routing around it — the two together are what actually close #2796. Each
+review gate **references this rule as the single source** (it does not re-derive the *why* per skill).
+Per #2393 the guard stays generic path-shape patterns, never a named-path deny-list.

--- a/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
+++ b/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
@@ -319,21 +319,25 @@ The three rules below govern the *emit path* and the *post-write read-back* that
 verdict marker's landing verifiable rather than assumed. They are cited, never re-derived, by each
 gate's Step-5-family verdict step.
 
-They moved here **byte-identically** — bytes verified against the pre-move span, not re-read — so
-three of their references still carry their pre-move spellings. Read them as:
+They moved here **byte-identically except for one repaired link** (below) — bytes verified against
+the pre-move span, not re-read — so two of their references still carry their pre-move spellings.
+Read them as:
 
 - *"the by-value form above"* → [§Posting a comment
   body](../gh-issue-intake-formats.md#posting-a-comment-body--read-it-into-body-never-gh-api--f-bodyfile-the-local-path-leak)
   of the formats contract, which stayed there.
 - *"§6.6"* → [§ADVISORY](#advisory-the-canonical-advisory-line--one-form-for-all-four-gates) above —
   the same section under its mnemonic name.
-- the relative link `[shared/scripts/verdict-readback.sh](shared/scripts/verdict-readback.sh)` in
-  §READBACK is **dead at this location — do not follow it.** It was authored one directory up, so
-  from here it resolves to `skills/shared/shared/scripts/verdict-readback.sh`, which does not exist.
-  The working path is [`scripts/verdict-readback.sh`](scripts/verdict-readback.sh), the sibling of
-  this file. It is left unrepaired **deliberately**: §READBACK is a byte-identical move, and editing
-  one byte inside it would forfeit the property that makes the move auditable (#4438). Repairing the
-  link is follow-up work on the block, not on this note.
+
+The **one** byte the move did not preserve: §READBACK's link to
+[`scripts/verdict-readback.sh`](scripts/verdict-readback.sh) was authored one directory up as
+`shared/scripts/…`, which from here resolves to the nonexistent
+`skills/shared/shared/scripts/verdict-readback.sh` — a dead link inside the block readers enter by
+anchor, and a red `doc-links` CI check. It is **retargeted to the working sibling path**; nothing
+else inside the block changed. Byte-identity had already discharged its audit purpose by then — two
+independent gates hashed the pre-move and post-move spans to the same
+`3bef3217a7c61158c6320f7578e5b4aea8e47a31` — and preserving a dead link to protect a property that
+has already paid out is the wrong trade (#4438).
 
 ### The verdict read-back guard — after posting a gate marker, re-read it and FAIL LOUD (`verdict_readback_guard`)
 
@@ -361,7 +365,7 @@ KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/cl
 verdict_readback_guard "$CID" review-code "$HEAD_SHA" || …          # <gate> ∈ review-{code,doc,skill,design}
 ```
 
-[`shared/scripts/verdict-readback.sh`](shared/scripts/verdict-readback.sh) carries the four checks and
+[`scripts/verdict-readback.sh`](scripts/verdict-readback.sh) carries the four checks and
 their reasons: **(0)** a non-empty body, **(1)** a canonical `<gate>:` marker — the bindable
 `PASS|FAIL @ <sha>` first line or the SHA-less `advisory` one, **(2)** the SHA-source-aware head
 binding, **(3)** no local-filesystem-path leak. Any miss returns non-zero and names the cause.

--- a/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
+++ b/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
@@ -327,8 +327,13 @@ three of their references still carry their pre-move spellings. Read them as:
   of the formats contract, which stayed there.
 - *"§6.6"* → [§ADVISORY](#advisory-the-canonical-advisory-line--one-form-for-all-four-gates) above —
   the same section under its mnemonic name.
-- the relative link `shared/scripts/verdict-readback.sh` → [`scripts/verdict-readback.sh`](scripts/verdict-readback.sh),
-  the sibling of this file (it was written from the parent directory).
+- the relative link `[shared/scripts/verdict-readback.sh](shared/scripts/verdict-readback.sh)` in
+  §READBACK is **dead at this location — do not follow it.** It was authored one directory up, so
+  from here it resolves to `skills/shared/shared/scripts/verdict-readback.sh`, which does not exist.
+  The working path is [`scripts/verdict-readback.sh`](scripts/verdict-readback.sh), the sibling of
+  this file. It is left unrepaired **deliberately**: §READBACK is a byte-identical move, and editing
+  one byte inside it would forfeit the property that makes the move auditable (#4438). Repairing the
+  link is follow-up work on the block, not on this note.
 
 ### The verdict read-back guard — after posting a gate marker, re-read it and FAIL LOUD (`verdict_readback_guard`)
 

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/verdict-readback.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/verdict-readback.sh
@@ -46,11 +46,11 @@ verdict_readback_guard() {
   #       validated it against ${sha:0:7}, so a non-blocking binding PASS/FAIL needs no separate line
   #       (this is the branch that keeps a legitimate non-blocking PASS from false-failing; #2272).
   #     - a SHA-less advisory first line (`<gate>: advisory`, ALL FOUR gates INCL review-code) MUST
-  #       carry the canonical body `Reviewed-head: @ <sha>` line (§6.6 / ADR 0151) — absence is FATAL.
+  #       carry the canonical body `Reviewed-head: @ <sha>` line (§ADVISORY / ADR 0151) — absence is FATAL.
   #       (#2329: the prior "review-code's §CP advisory carries NONE by design → accept its absence"
-  #       carve-out contradicted §6.6's own MUST and blinded the read-back to a drifted
+  #       carve-out contradicted §ADVISORY's own MUST and blinded the read-back to a drifted
   #       `**Reviewed head:**` variant — bold, space-not-hyphen, backticked SHA — that does NOT match
-  #       `^Reviewed-head:` and that ship-it's §6.6 enqueue matcher then rejects, leaving a genuinely
+  #       `^Reviewed-head:` and that ship-it's §ADVISORY enqueue matcher then rejects, leaving a genuinely
   #       -approved §CP PASS silently unshippable until a human hand-re-posts. Requiring the canonical
   #       line on every advisory makes a drifted line read as absent → FATAL here → forces a canonical
   #       re-post at EMISSION time, never a ship-it refusal on an approved PR.)
@@ -59,7 +59,7 @@ verdict_readback_guard() {
   if printf '%s' "$got" | grep -Eiq "^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*(PASS|FAIL)[[:space:]]*@[[:space:]]*${sha:0:7}"; then
     : # bindable first line: its `@ <sha>` IS the head binding (validated by (1))
   elif ! printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:"; then
-    echo "verdict_readback_guard FAILED: SHA-less advisory in comment $cid carries no canonical 'Reviewed-head: @ ${sha:0:7}' line — §6.6/ADR 0151 requires it on ALL four gates' advisories (incl review-code); a drifted '**Reviewed head:**' variant reads as absent. Re-post the canonical 'Reviewed-head: @ <sha>' line (hyphen, no bold, no backticks around the SHA)." >&2; return 1
+    echo "verdict_readback_guard FAILED: SHA-less advisory in comment $cid carries no canonical 'Reviewed-head: @ ${sha:0:7}' line — §ADVISORY/ADR 0151 requires it on ALL four gates' advisories (incl review-code); a drifted '**Reviewed head:**' variant reads as absent. Re-post the canonical 'Reviewed-head: @ <sha>' line (hyphen, no bold, no backticks around the SHA)." >&2; return 1
   fi
   # a present `Reviewed-head:` line (advisory OR a non-blocking PASS that also carries it) must bind head:
   if printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:"; then

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -202,19 +202,19 @@ you refuse any verdict not bound to the PR's *current* head (Step 2b, ADR
 
 - **product code** (`apps/**` — every app worker, not just `apps/web` — `packages`, other code) → `review-code`, whose marker is
   `review-code: PASS @ <sha> — merge-ready` or `review-code: FAIL @ <sha> — not merge-ready`
-  (canonical shape: [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5).
+  (canonical shape: [the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md)).
   `review-code` can also land a native **approving review** (`event=APPROVE`), whose
   `commit_id` is its bound SHA.
 - **docs** (`.decisions`, `.patterns`, prose `*.md` outside `.claude`/`.github`, outside
   `claude-plugins/kampus-pipeline/skills/**`, and outside the code roots `apps/**`/`packages/**` — a package/app-internal README
   is `review-code`'s scope, not this class; see Step 0) → `review-doc`, whose marker is
   `review-doc: PASS @ <sha> — merge-ready` or
-  `review-doc: FAIL @ <sha> — changes-requested` (canonical shape: §6). `review-doc` is
+  `review-doc: FAIL @ <sha> — changes-requested` (canonical shape: §VERDICT). `review-doc` is
   **comment-only** — it never lands a native review (ADR 0058), so the doc lane is a single
   comparable record type, not a review-vs-comment mix.
 - **skills** (`claude-plugins/kampus-pipeline/skills/**`) → `review-skill`, whose marker is
   `review-skill: PASS @ <sha> — merge-ready` or `review-skill: FAIL @ <sha> — changes-requested`
-  (canonical shape: §6.5). `review-skill` is **comment-only** like `review-doc` (ADR 0058). This
+  (canonical shape: §VERDICT). `review-skill` is **comment-only** like `review-doc` (ADR 0058). This
   **supersedes ADR 0063's** `claude-plugins/kampus-pipeline/skills/**` → `review-code` routing (ADR 0073 §4): a skill is a
   behavioral artifact, gated by the gate built for it.
 - **UI-affecting** (a changed path under `apps/web/src`, a `*.tsx` file, or a style surface —
@@ -667,7 +667,7 @@ that merely *quotes* a marker mid-body doesn't match, **emphasis-tolerant** — 
 `\**` absorbs an optional bolding `**`, since `review-code` emits its marker bolded — and
 **SHA-capturing** — the trailing `@\s*([0-9a-f]{7,40})` captures the bound head SHA so Step 2b
 can apply the staleness refusal; see the matcher contract in
-[gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5/§6/§6.5 and ADR
+[the gate-verdict contract §VERDICT](../shared/gate-verdict-contract.md) and ADR
 [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md)):
 
 - code:   `^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
@@ -748,7 +748,7 @@ advisory folded in):
   is the marker's `@ <sha>` (or, for a native review, its `commit_id`). (The native
   approving-review path stays; it interleaves only with the review-code markers, never with
   review-doc.) A **§CP** code PR's verdict is likewise the SHA-less-first-line advisory
-  (`review-code: advisory — blocking-set PR …`) — §6.6/ADR 0151 converges **all four** gates on
+  (`review-code: advisory — blocking-set PR …`) — §ADVISORY/ADR 0151 converges **all four** gates on
   the one advisory form, so a §CP review-code advisory is resolved from the body's canonical
   `Reviewed-head` line via the
   **[§CP advisory resolution](#step-2cp--cp-advisory-namespace-resolution-adr-01350151)** below
@@ -842,7 +842,7 @@ refuse it as a legacy SHA-less marker. That refusal is **correct for a non-§CP 
 #1932/#2022 collision for a §CP one — the advisory is the *intended* §CP verdict, and its reviewed
 head is bound **in the body**, not the first line. So for the §CP advisory namespaces, resolve the
 reviewed head from the body's **canonical `Reviewed-head: @ <sha>` line** (mandated in
-`gh-issue-intake-formats.md` §6.6 and emitted by the review-skill/review-doc advisory templates,
+the gate-verdict contract's §ADVISORY and emitted by the review-skill/review-doc advisory templates,
 ADR 0151) instead of the first-line `@ <sha>`.
 
 This is **deterministic** — the outcome is a pure function of the PR's state (body `Reviewed-head`
@@ -859,7 +859,7 @@ For each §CP namespace whose latest verdict is a **current-head advisory** (fir
 `^\s*\**\s*review-(code|skill|doc|design):\s*advisory\b`), resolve it as an **enqueue-eligible
 current-head PASS-equivalent** iff **all three** hold, else **refuse deterministically with the
 named reason**. `review-code` is in this set: a §CP code PR's approved verdict is the same SHA-less
-advisory (§6.6/ADR 0151 converges **all four** gates on one advisory form), so its body
+advisory (§ADVISORY/ADR 0151 converges **all four** gates on one advisory form), so its body
 `Reviewed-head` line resolves the enqueue exactly like the doc/skill/design namespaces — without it,
 a canonical review-code §CP advisory had no written resolution path and read as `sha: null` → refused
 on a legitimately-approved PR (#2329).
@@ -871,7 +871,7 @@ authoritative §CP resolution to anyone auditing the merge gate (#4405). The in-
 conditions apply to is picked by the verb: author-gated write+ (ADR 0055) and ordered by its
 `Verdict-written:` stamp, never by `created_at`, because an advisory is upserted in place too.
 
-- **(a) The body's canonical `Reviewed-head: @ <sha>` line (ADR 0151 §6.6) must prefix-match the PR's
+- **(a) The body's canonical `Reviewed-head: @ <sha>` line (ADR 0151, §ADVISORY) must prefix-match the PR's
   current head.** The verb anchors on the `Reviewed-head:` token — deliberately *distinct* from the
   first-line advisory marker — so the body binding is never confused with a first-line marker and the
   advisory stays out of the PASS namespace. Two separate refusals fall out: an advisory carrying **no**

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -124,7 +124,7 @@ it is, resolve it once — `gh api repos/$REPO/pulls/<N>` succeeds for a PR and
 **The ownership boundary, stated once and load-bearing throughout:** **write-code owns
 fail → fix → re-request; `ship-it` owns PASS → merge.** You own the branch and the PR, so
 driving a FAIL'd PR back through the gate is your loop — but the merge is never yours, in
-either mode (this mirrors the `gh-issue-intake-formats.md` §5/§6/§6.5 relationship table, which
+either mode (this mirrors the `gh-issue-intake-formats.md` relationship table, which
 names write-code the consumer of *all three* FAIL markers and `ship-it` the consumer of *all
 three* PASS markers).
 
@@ -1781,7 +1781,7 @@ left to a separate reviewer.
 ## Repair mode — consume a gate FAIL verdict, fix-and-resubmit
 
 This is the second invocation shape: keyed off a **PR number**, it is the consumer the
-gate FAIL markers were written for (`gh-issue-intake-formats.md` §5/§6/§6.5 name write-code the
+gate FAIL markers were written for (`gh-issue-intake-formats.md`'s relationship table names write-code the
 reader of `review-code: FAIL @ <sha> — not merge-ready`, `review-doc: FAIL @ <sha> —
 changes-requested`, and `review-skill: FAIL @ <sha> — changes-requested`, SHA-bound per ADR
 0058). You take a PR that came back failed, apply exactly the enumerated
@@ -2285,8 +2285,9 @@ indistinguishable from "still FAILing after the cap" to the picker, so the same 
   Act only on a FAIL bound to the PR's **current head** — a FAIL whose `@ <sha>` is stale (or
   absent) judges code that has since changed, so repair mode ignores it. This mirrors
   `ship-it` Step 2b's staleness refusal on the reading side.
-- **All three namespaces.** Handle `review-code: FAIL @ <sha>` (§5), `review-doc: FAIL @ <sha>`
-  (§6), **and** `review-skill: FAIL @ <sha>` (§6.5) — latest current-head verdict per namespace —
+- **All three namespaces.** Handle `review-code: FAIL @ <sha>`, `review-doc: FAIL @ <sha>`
+  **and** `review-skill: FAIL @ <sha>` ([the gate-verdict contract
+  §VERDICT](../shared/gate-verdict-contract.md)) — latest current-head verdict per namespace —
   not just `review-code`. A skill PR's FAIL lands in the `review-skill` namespace (ADR 0073).
 - **Author-gated verdicts.** A marker counts only from a `write+` repo collaborator —
   the same GitHub-ACL gate `ship-it` Step 2 applies before the marker regex, so a forged or
@@ -2471,7 +2472,7 @@ from `status:planned` after gating a `plan-epic` ledger (epic children — ADR
 a claimed issue, a PR with `Fixes #N`, progress comments, and an epic handoff note — is
 exactly what `review-code`/`review-doc`/`review-skill` read to verify the work against its
 acceptance criteria before merge. The loop closes back on you: when a gate lands a **FAIL** marker
-(`review-code` §5, `review-doc` §6, or `review-skill` §6.5), *you* are its consumer — [Repair mode](#repair-mode--consume-a-gate-fail-verdict-fix-and-resubmit)
+(`review-code`, `review-doc`, or `review-skill` — §VERDICT), *you* are its consumer — [Repair mode](#repair-mode--consume-a-gate-fail-verdict-fix-and-resubmit)
 reads the findings, fixes, and re-submits for an independent re-gate, while `ship-it` stays
 the sole owner of PASS → merge. You also lean on two sibling skills inside type routing:
 `/adr`

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -9,7 +9,7 @@
  * as one deterministic, table-tested function (ADR 0058, the SHA-bound verdict contract).
  *
  * The marker grammar, the emphasis-tolerant anchor, and the `@ <sha>` capture are
- * single-sourced from gh-issue-intake-formats.md §5/§6 and ADR 0058; this core is the
+ * single-sourced from the gate-verdict contract's §VERDICT and ADR 0058; this core is the
  * deterministic decision the IO shell (`github.ts`) drives at the boundary. The author-gate
  * (ADR 0055 write+ trust root) is resolved by the shell and handed in as `authorizedAuthors`,
  * exactly as `epic-lock`'s claim core takes it — a forged marker from a non-collaborator
@@ -39,7 +39,7 @@ export const GATES: ReadonlyArray<VerdictGate> = ["code", "doc", "skill", "desig
  * "is this a marker in my namespace at all" test the `post` upsert scans with, and the
  * cross-namespace guard (`review-code:` never matches the `doc` namespace and vice versa).
  * Anchored at string start with no `m` flag, so it tests the very first line only — a
- * comment that merely *quotes* a marker mid-body never matches (§5/§6).
+ * comment that merely *quotes* a marker mid-body never matches (§VERDICT).
  */
 export const namespaceRe = (gate: VerdictGate): RegExp =>
 	new RegExp(`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:`, "i");
@@ -47,7 +47,7 @@ export const namespaceRe = (gate: VerdictGate): RegExp =>
 /**
  * Bindable-verdict matcher: `review-<gate>: (PASS|FAIL) @ <sha>` — captures the polarity
  * (group 1) and the bound head SHA (group 2, ≥7 hex). The `@ <sha>` **immediately after**
- * PASS/FAIL is the fixed token order (§5) — a trailing `@ <sha>` after the em-dash tail does
+ * PASS/FAIL is the fixed token order (§VERDICT) — a trailing `@ <sha>` after the em-dash tail does
  * NOT match, exactly as `ship-it`'s capture refuses it (#625).
  */
 export const verdictRe = (gate: VerdictGate): RegExp =>

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -56,7 +56,7 @@ describe("parseVerdict — polarity + bound SHA out of a first-line marker", () 
 			expected: {polarity: "FAIL", sha: HEAD},
 		},
 		{
-			name: "leading bold emphasis is tolerated (§5 \\**)",
+			name: "leading bold emphasis is tolerated (§VERDICT \\**)",
 			body: `**review-skill: PASS @ ${HEAD}** — merge-ready`,
 			gate: "skill",
 			expected: {polarity: "PASS", sha: HEAD},


### PR DESCRIPTION
Fixes #4438

Built against the [triage re-grounding amendment](https://github.com/kamp-us/phoenix/issues/4438#issuecomment-5128208074), which supersedes the issue body. Base `main` re-read at dispatch: `b015fa48913382dc118c7251f28a951e0e2703ad` — the merge commit of PR #4503, so the stated precondition is met. Every span below was re-derived at this PR's head, not quoted.

## What changed

The four verdict-marker sections (`review-code` §5, `review-doc` §6, `review-skill` §6.5, `review-design` §6.7), the already-factored advisory-line section (§6.6), and the three read-back subsections leave `gh-issue-intake-formats.md` for **one** parameterised contract:

`claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md`

- **§VERDICT** — the shape, the upsert key, the carrier rule, the matcher contract, the forbidden emit forms, the field notes, plus **two tables carrying only the values that genuinely differ per gate**.
- **§ADVISORY** — the canonical §CP advisory line and its `Reviewed-head` body anchor.
- **§READBACK** — the read-back guard, the unconditional `verdict_post_verify` wrapper, and the mandatory guarded emit path. **Moved byte-identically except for one deliberately repaired link** (round 3 — see *Deviations*).

No redirect stubs at the old anchors — the amendment rejects them on the record, and a stub is a second home for the contract.

## Destination shape, chosen on merit

The body's directory-vs-sibling argument died with the whole-tree §CP row (#4446, landed by PR #4462), so this was a fresh call. `skills/shared/` is the established home for material the gates share and none owns — it already carries `lib/common.sh` and the sixteen `scripts/*.sh` the gates source. A verdict contract that all four gates plus `ship-it` and `write-code` read is exactly that shape. It inherits §CP gating for free under `^claude-plugins/kampus-pipeline/skills/`, needing no boundary amendment, and it is the directory PR #4440 targets — so convergence is a file beside a file, never a second home for one contract.

Rejected: a top-level sibling `.md` (gated identically now, but it puts gate-shared material at the same level as the pipeline-wide intake contract, blurring "shared by the gates" and "shared by everything"); a new `gate-verdict/` directory (one file does not need a directory, and it would fork `shared/` for no benefit).

## §CP-boundary legs: not executed

`CONTROL_PLANE_RE` — the const **and** its `gh-issue-intake-formats.md` copy — and `.github/CODEOWNERS` are **untouched**, per the amendment's leg-1 discharge. Neither appears in this PR's file list. The **unchanged** live pattern, resolved at this head and asserted non-trivial (length > 100) before use, matches the new path:

```
$ printf '%s\n' claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md \
    | pipeline-cli cp-classify classify
cp-classify: control-plane [path-match] — matches the live CONTROL_PLANE_RE. BLOCKING (human merge).
control-plane
```

## The move, verified by diffing the bytes — byte-identical but for one repaired link

Spans re-derived from each file's own heading offsets at the commit being checked. At the round-2 head the move was byte-identical outright, and **two independent gates reproduced it**, each hashing the pre-move and post-move spans to the same `3bef3217a7c61158c6320f7578e5b4aea8e47a31`. Round 3 then repaired one line inside the block (below), so the spans no longer hash alike — the audit property had already paid out by then:

```
pre-move  span: gh-issue-intake-formats.md@b015fa48 lines 1084-1226 (143 lines)
post-move span: shared/gate-verdict-contract.md    lines  342-484  (143 lines)
diff -u <pre> <post>  →  exactly ONE line differs: the §READBACK relative link
shasum pre  → 3bef3217a7c61158c6320f7578e5b4aea8e47a31   (the hash both gates recorded)
shasum post → de453ceca3d38d52523016ba00aea56c3293d89a
```

Two of the block's references still carry their pre-move spellings, and a note **immediately above** it — outside the moved bytes — reconciles them rather than editing them: *"the by-value form above"* now means the formats contract's `§Posting a comment body`, and *"§6.6"* means `§ADVISORY`.

The third, the relative link `shared/scripts/verdict-readback.sh`, was **dead at the new location** — authored one directory up, so from `skills/shared/` it resolved to `skills/shared/shared/scripts/verdict-readback.sh`, which does not exist. Rounds 1–2 left it unrepaired and documented; **round 3 repairs it**, because leaving it dead was failing `doc-links` CI (see *Deviations*). The note above the block is rewritten to match: it no longer describes the link as dead-and-unrepaired, it records the one-line forfeiture and why.

## Nothing dropped, nothing in two places — per gate namespace

The collapsed contract is not byte-identical by construction, so here is every value the four sections specified and where it is now specified **exactly once**.

**Shared by all four, stated once in §VERDICT with no per-gate copy:** the SHA-bound first line and its `gh api … --jq .head.sha` resolution; `<sha>` full-or-abbreviated ≥7 hex; the `@ <sha>`-is-load-bearing and SHA-less-is-`unverified` rules (ADR 0058, #258); the upsert key plus the never-a-raw-`PATCH` rule; the emphasis-tolerant canonical emit shape; the fixed token order (#623/#625); the four anchored matchers and their disjointness argument; the five forbidden emit forms (#1095, #2456); the four field notes.

| Namespace | Values it uniquely specified | Where each lives now, once |
|---|---|---|
| `review-code` | tails `— merge-ready` / `— not merge-ready`; carrier = comment **or** native `APPROVE` (`ship-it` reads `commit_id`); the branch-rule fallback framing; per-criterion evidence body | §VERDICT namespace table (tails, carrier, body) + §VERDICT *Carrier* (the `commit_id` staleness test and the fallback framing) |
| `review-doc` | tails `— merge-ready` / `— changes-requested`; comment-only (ADR 0058 rule 4) + the two-incomparable-records rationale (#258); the §DOC class it gates; per-criterion **+ per-hygiene-check** body; advisory arm | namespace table (tails, body) + gate-identity table (§DOC class) + *Carrier* (comment-only + rationale, stated once for all three comment-only gates) + §ADVISORY |
| `review-skill` | tails as `review-doc`; comment-only; `skills/**` surface superseding ADR 0063's routing; the four rigor checks (ADR 0073 §1); per-criterion **+ per-rigor-check** body; "advisory is the common case for a skill PR" | namespace table + gate-identity table (surface + rigor checks) + *Carrier* + §ADVISORY (the common-case sentence) |
| `review-design` | tails as `review-doc`; comment-only; Playwright-over-preview + multimodal four-pillars judging (ADR 0162/0165, #2246); six objective hard-FAIL prohibitions with holistic riding advisory; per-prohibition + **Advisory (non-blocking)** + **Evidence** body; `Reviewed-head` on **every** path; the landed `UI_RE` required-gate wiring; FAIL-conservative calibration | namespace table + gate-identity table (method, prohibitions, body sections) + *Carrier* + §VERDICT field notes (`Reviewed-head`-on-every-path, `UI_RE` wiring) + §ADVISORY (the calibration caveat) |

Every §6.6 value is preserved in §ADVISORY: the ADR-0073-§5 convergence history, the four advisory first lines, the authorizes-nothing framing, the mandatory `Reviewed-head` line and its anchored matcher, `ship-it`'s (a)/(b)/(c) enqueue test, the never-widen-the-marker-contract rule, the #424 retirement, and the full first-line-omitted-by-design paragraph (#977, ADR 0111/0151).

## Cardinality, per the #4444 fold

- Stated **once**, as the record's real key: **(PR, gate-namespace, head, run)** — ADR 0058 rule 2 as refined by ADR 0213. Same key upserts in place; a **new head appends** and leaves the prior head's verdict standing; a **sibling run appends** (the shared-login clobber ADR 0213 removes).
- **No per-PR / per-(PR, namespace) cardinality claim survives anywhere under `claude-plugins/kampus-pipeline/`**, headings included. The four `### Upsert, not append — one verdict per (PR, gate-namespace)` headings are gone; the gate skills' prose copies — which additionally asserted the false "a re-review of a new head overwrites the same record" — are recut; the three `description:` frontmatter phrases `upserted to one-per-PR` are recut to the key.

  **Round-1 correction (this is what the round-1 gate caught, and the claim above is the corrected one).** At head `c9d0123f` this bullet read *"No 'exactly one per PR' claim survives anywhere"*, and that was **false**. Round 1 recut the PASS-path and advisory-path copies but missed the **FAIL path** in three gates, and missed `review-trivial` and `agents/reviewer.md` entirely. Seven sites survived; each paired the false cardinality with an unscoped, head-blind and run-blind *"`PATCH` your own prior marker if one exists, else `POST`"* — which is both the ADR-0213 shared-login clobber and the raw `PATCH` this PR's own §VERDICT forbids. Round 2 recuts all of them onto the four-dimension key and scopes the upsert instruction to it:

  | Site | What it said | What it says now |
  |---|---|---|
  | `skills/review-code/SKILL.md` Step 4b (fail path) | "one `review-code` verdict comment per PR, ADR 0058 rule 2" + blind `PATCH`/`POST` | upsert on the §VERDICT key — (PR, gate-namespace, head, run); `verdict post` replaces a prior marker only at *this head and this run*, appends otherwise; never hand-roll the `PATCH` |
  | `skills/review-doc/SKILL.md` fail path (+ its inline `$VERDICT` comment) | "one `review-doc` verdict comment per PR"; "same one-per-gate upsert as the PASS path" | the same key, same scoping, same never-hand-roll rule |
  | `skills/review-doc/SKILL.md` PASS-path paragraph + advisory path | "the one-per-gate invariant is forward-looking"; "one comment per gate, PATCH own prior marker else POST" | "the (PR, gate-namespace, head, run) key is forward-looking"; the advisory upserts on that same key |
  | `skills/review-skill/SKILL.md` fail path (+ its PASS-path and §CP-advisory tool comments) | "one `review-skill` verdict comment per PR"; "a fresh FAIL upserts whatever prior marker exists"; "PATCHes your newest own marker" | the same key throughout; a fresh verdict replaces only this head+run's own record and appends against any other key |
  | `skills/review-trivial/SKILL.md` | "one verdict per (PR, namespace)" — a **two**-dimension key — implemented as a hand-rolled login-keyed `PATCH`/`POST` over `gh api` | the four-dimension key, and the hand-rolled block is **replaced by `pipeline-cli verdict post`**, which owns the key *and* the `emissionDefect` + §READBACK guards the raw patch skipped |
  | `agents/reviewer.md` | "Upsert each one-per-PR per its skill." | "Upsert each on the §VERDICT key — (PR, gate-namespace, head, run) — per its skill … never hand-roll the `PATCH`" |
  | `skills/review-design/scripts/verdict-upsert.sh` docblock | "Upsert the **ONE** `review-design` verdict comment for a PR … (PATCH own prior marker, else POST)" | keyed on (PR, gate-namespace, head, run), replacing only this head+run's own marker |

  Rows 3, 4-partial and 7 (`review-doc`'s PASS-path + advisory copies, `review-skill`'s PASS-path + advisory tool comments, and `review-design/scripts/verdict-upsert.sh`) are **beyond the five sites the round-1 FAIL named** — found by sweeping the whole plugin tree for the pattern rather than working the list. Re-swept at this head with `grep -rn -E "per PR|per \(PR|one verdict|one-per|the ONE "` over `claude-plugins/kampus-pipeline/`: **no surviving verdict-cardinality claim.** What the sweep still returns, and why each is correct:

  - `shared/gate-verdict-contract.md:82,93,95` — the three lines that **deny** the rule ("the key, not a 'one comment per PR' rule, decides"; "a PR thread may legitimately carry more than one verdict comment in one namespace"). These are §VERDICT stating the new law.
  - "one comment per namespace" in `reviewer.md` / `review-skill` — the **anti-stacking** rule (one marker per comment, so each namespace's `^` anchor binds), a different and still-true rule.
  - `gh-issue-intake-formats.md:2739` — "one close directive per PR", the §9 closing-keyword seam, unrelated to verdicts.
  - `ship-it:1222` — the run-evidence artifact "per PR"; `the ONE pin` / `the ONE live source` in eleven scripts — single-source phrasings, unrelated.
- **Nothing forecloses #4478.** The text rules on what the *key* does and says a namespace may legitimately hold several comments at one head. It takes no position on whether a same-head re-post may erase a refused round — that is #4478's to decide.

## Convergence with #4396 / PR #4440

PR #4440 is **open and unmerged** at this head, verified by REST rather than assumed. Per the ticket, this PR's file is therefore the destination and mints nothing that twins it. `shared/` holds exactly one `.md` — this one:

```
$ find claude-plugins/kampus-pipeline/skills -maxdepth 2 -name '*.md' -not -name 'SKILL.md'
architecture-audit/DEEPENING.md · architecture-audit/SMELLS.md · rite-audit/DIMENSIONS.md ·
taste-animation-review/STANDARDS.md · writing-clearly-and-concisely/NOTICE.md ·
triage/close-not-planned.md                    ← skill-local reference docs
gh-issue-intake-formats.md · taste-library-conventions.md · taste-library-notice.md
                                               ← pipeline-wide, not gate-shared
shared/gate-verdict-contract.md                ← the one gate-shared file
```

Whichever of the two PRs lands second rebases into the same directory as a sibling file, never a second home for the same contract.

## Link retarget — count re-derived at this head

**84 citation sites across 12 files** now point at the new home, counted mechanically:

```
$ grep -rc '§VERDICT\|§ADVISORY\|§READBACK\|gate-verdict-contract\.md' \
    claude-plugins packages/pipeline-cli/src | grep -v ':0$' | grep -v 'shared/gate-verdict-contract.md'
reviewer.md:1 · gh-issue-intake-formats.md:12 · review-code:17 · review-skill:17 · review-doc:11
review-design:7 · shared/scripts/verdict-readback.sh:4 · ship-it:8 · write-code:2 · review-trivial:1
verdict-match.ts:3 · verdict-match.unit.test.ts:1
```

Every retarget was applied by an assertion-carrying script that declares an expected match count per rule and exits non-zero on any mismatch — 69 rules, all matched, zero silent no-ops.

**No orphaned anchor anywhere under `claude-plugins/`**, proven by resolving every cross-file anchor link against the target file's **fence-aware** heading set (a `#` inside a fenced block is a shell comment, not a heading — the #4407 finding):

```
anchor-check: scanned 77 md file(s), resolved 60 cross-file anchor link(s)
anchor-check OK — every cross-file anchor resolves
```

The four review gates and `ship-it` each cite the new file for the verdict contract, and none still cites a section this PR removed. The residual `§6.6` mentions live only inside the moved read-back block and in the retired-numbers mapping table, both in the new file.

## Line counts, re-measured at this head (`wc -l` at `250b8e99`)

| File | Before (`b015fa48`) | After | Δ |
|---|---|---|---|
| `skills/gh-issue-intake-formats.md` | 3,742 | 3,072 | −670 |
| `skills/shared/gate-verdict-contract.md` | — (new) | 484 | +484 |

The amendment's measurement of the source file (3,742) held exactly at this head, and its ~143-line read-back estimate was exact (143). Its ~533-line §5–§6.7 estimate measured **534** — lines 2416–2949 inclusive, counting the trailing separator.

## Gates run at this head

| Gate | Result |
|---|---|
| `bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` | OK — 34 checks; every column-0 boundary assignment still resolves from `gh-issue-intake-formats.md` **exactly once at column 0** (11 of 11 named boundaries) |
| `validate-skills.sh` | OK — 30 skills valid |
| `validate-cycle-presence.sh` | OK — 18 checks |
| `pipeline-cli gh-phoenix lint-skills`, 13 files handed | clean; 9 / 8 / 11 files scanned by the three scans |
| `pipeline-cli leak-guard scan`, 13 files handed | clean; 13 accounted (9 doc, 1 shell, 1 self-exempt, 2 out of scope) |
| `pnpm typecheck` | 29 / 29 |
| `pipeline-cli` unit suite | 185 files, 2,996 tests passed |
| repo unit suite (pre-push hook) | 287 files, 2,420 tests passed |

**Coverage delta is zero, and in one direction positive.** No boundary assignment (`CONTROL_PLANE_RE`, `GUARD_ADR_RE`, the four `HAS_*_RE`, the two `DOC_VOCAB_*_RE`, `CLAIM_RE`, `UI_RE`/`UI_EXCLUDE_RE`) moved into the new file — asserted with the validator's own assignment-shape pattern, zero hits — so `validate-gate-path-drift`'s 1c corpus loses nothing. And the new file is **not** on `gh-phoenix`'s self-exempt list while `gh-issue-intake-formats.md` is, so the moved prose is now *more* scanned than before, and it passes.

## Repair round 2 — gates re-run at this head

Round 1 FAILed on AC #4 in both namespaces (`review-skill` 5128839125, `review-code` 5128841001) for the cardinality miss above; every other row PASSED and was independently reproduced. Round 2 changes seven files, all under `claude-plugins/kampus-pipeline/`, and touches nothing else.

| Gate | Result at this head |
|---|---|
| `validate-gate-path-drift.sh` | OK — 34 checks (invariant 1's `CONTROL_PLANE_RE` byte-compare still green; the const, its doc copy and `CODEOWNERS` are untouched in this round too) |
| `pipeline-cli cli-invocation-guard check`, 7 files handed | clean — 7 scanned, 78 fences + 1 shell file; every `pipeline-cli` call resolves the shim by path (§CLI) |
| `pipeline-cli leak-guard scan`, 7 files handed | clean — 7 accounted (5 doc, 1 shell, 1 self-exempt, 0 out of scope) |
| `pipeline-cli trap-status-guard check`, **all 7 round-2 files handed** | clean — 78 runnable fences + 1 shell file, no `errexit` + `EXIT`-trap pairing. **Corrected in round 3:** the row previously read "2 shell surfaces handed \| clean", which does **not** reproduce — the guard is fail-closed per *axis* (ADR 0092), so a shell-only scope exits **3** on the zero markdown axis. It is clean only at mixed scope, which is what the round-2 run actually had. |
| `pipeline-cli adoption-lint check`, 6 files handed | clean — no un-cited re-derivation, every declared exemption valid (the `review-trivial` rewrite *removes* an inline re-derivation of the `verdict post`-owned upsert) |
| pre-push hooks (typecheck + repo unit suite) | green — push accepted |

The §READBACK block was still byte-identical after round 2: `git diff c9d0123f -- skills/shared/gate-verdict-contract.md` touched only the reconciliation note **above** the block, none of it inside. **Corrected in round 3:** that diff is **9 lines** on the contract file (`git show --stat cd632ea2` → `9 ++++--`), not "six" as this row previously said. Round 3 is the round that reaches inside the block, for exactly one line.

## Repair round 3 — the dead link, repaired; CI green

Round 2 gated **advisory** in both namespaces (§CP, approval-gated) — but `doc-links` was **RED** at that head: `check docs have no dead internal links` exited **2** with one error, `gate-verdict-contract.md` at `364:1`, the §READBACK link resolving to `…/shared/shared/scripts/verdict-readback.sh`. That check is **not** in the required set, so the merge queue would have taken the PR anyway and landed a dead link inside the newly-canonical verdict contract — in the block readers enter **by anchor**, below the warning note, which they would never see. That is a worse outcome than forfeiting byte-identity, so round 3 repairs the link.

Round 3 changes **one file, one link, plus the note above the block** (14 insertions / 10 deletions). It rebases onto current `main` `1456a64a` (two PRs had landed since base `ce1684d6`; clean rebase, no conflicts) and force-with-leases onto the same PR branch.

| Gate | Result at this head (`250b8e99`) |
|---|---|
| `lychee --offline` over 454 git-tracked `.md` (the exact `doc-links` job command + the same lychee `0.24.2`) | **exit 0** — 4417 total, 1332 unique, 3269 OK, **0 errors**. Pre-fix, the same run reproduced CI exactly: exit 2, 1 error at `364:1` |
| `bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` | **OK — 34 checks**, unchanged. Invariant 1's `CONTROL_PLANE_RE` byte-compare is still green; the const, its doc copy and `CODEOWNERS` are untouched in this round too |
| `validate-skills.sh` | OK — 30 skills valid |
| `validate-cycle-presence.sh` | OK — 18 checks |
| `pipeline-cli leak-guard scan`, this round's file handed | clean — 1 doc surface, 0 out of scope |
| `pipeline-cli cli-invocation-guard check`, mixed scope (the contract + its sibling `scripts/verdict-readback.sh`) | clean — 2 fences + 1 shell file. Handed the markdown alone it exits **3** (zero shell axis, ADR 0092 per-surface), which is the guard working, not a miss |
| `pipeline-cli trap-status-guard check`, same mixed scope | clean — 2 fences + 1 shell file |
| `pipeline-cli gh-phoenix lint-skills`, mixed scope (the contract + a `SKILL.md` so the frontmatter axis is non-empty) | clean — gh-call 2, frontmatter 1, bare-push 2 |
| pre-push hooks (typecheck + repo unit suite) | green — push accepted, no `--no-verify` |

**Both round-2 advisories are void.** They are bound to `5f23e5f0`, and this head is `250b8e99` (ADR 0058). Nothing on this PR is verified until a **fresh** gate runs against `250b8e99` in both namespaces; do not read the prior verdicts as still applying.

## Deviations

- **Scope narrowing / out-of-scope change (classes 1, 7) — the section identifiers were renamed, not just collapsed.** **Said:** the ACs say "collapse the four sections into one parameterised contract" and are silent on naming. **Did:** §5/§6/§6.5/§6.7 became **§VERDICT**, §6.6 became **§ADVISORY**, and the read-back block sits under **§READBACK**. **Why:** the numbers were positional against the formats contract's own sequence, which is exactly what stops working once the sections live in another file; mnemonic tokens are that contract's established convention for factored, cross-cited sections (§CP, §DOC, §CLASS, §ZS, §SP, §CLI, §DEV). The new file opens with a **retired-numbers mapping table** so any record citing an old number resolves. **Disposition:** stated for the reviewer to judge.
- **Out-of-scope change (class 7) — the four gate skills' own cardinality prose and three frontmatter descriptions.** **Said:** #4444's fold names the four `### Upsert, not append` openers in the formats doc. **Did:** also recut `review-code` / `review-doc` / `review-skill` / `review-design`'s own "exactly **one** verdict comment per PR" prose and their `upserted to one-per-PR` `description:` phrases. **Why:** they are copies of the same claim, and three of them additionally asserted "a re-review of a new head overwrites the same record", which ADR 0213's head dimension makes false; leaving them would leave the contract in two places saying opposite things — the exact drift this consolidation closes. **Disposition:** in scope by the AC "nothing left in two places"; flagged because the file set is wider than #4444's literal target.
- **Out-of-scope change (class 7) — two files under `packages/`.** **Said:** the ticket's surface is `claude-plugins/`. **Did:** `verdict-match.ts` (a docblock naming "§5/§6" as its single source) and `verdict-match.unit.test.ts` (a test *name* string reading "§5") were retargeted. **Why:** they are citations of a section this PR removes, and the AC forbids leaving one. No behavior changed — a comment and a test title. **Disposition:** stated; `pipeline-cli`'s 2,996 tests pass unchanged.
- **Known defect left unfixed (class 3) — `.decisions/**` ADRs still cite the retired numbers.** **Said:** the AC scopes orphan-checking to "anywhere under `claude-plugins/`". **Did:** ADRs 0111, 0151, 0216 and 0226 still spell §6/§6.5/§6.6/§6.7 and name the old file. **Why:** an ADR is an immutable record of a decision as it was made; rewriting four accepted ADRs to chase a section rename is a larger, separately-reviewable act, and the new file's retired-numbers table is what makes those citations resolve. **Disposition:** deliberate; for the reviewer to judge whether a follow-up is wanted.
- **Out-of-scope change (class 7) — one added sentence beyond the moved content.** **Said:** the ACs describe a move plus a collapse. **Did:** §ADVISORY gained a one-sentence pointer that an advisory is a PASS path only and a failing criterion emits FAIL instead (ADR 0226). **Why:** the retained §6.6 line "the rest of the body carries the same per-check evidence table the PASS/FAIL paths carry" reads as permitting a `[FAIL]` row in an advisory, which ADR 0226 forbids; rewriting the section without the pointer would have shipped prose contradicting accepted law. **Disposition:** one sentence, cited to its ADR.

- **Repair round 2 (rebase + AC #4 fix) — a false claim in this body, now corrected.** **Said:** at head `c9d0123f` this body asserted *"No 'exactly one per PR' claim survives anywhere, headings included."* **Did:** that was **false** — seven sites survived (see the round-1 correction under *Cardinality*). Round 2 rebased the branch from base `b015fa48` onto current `main` `ce1684d6` (four PRs had landed; clean rebase, no conflicts, force-with-lease onto the same PR branch), recut all seven onto the four-dimension key, scoped each accompanying upsert instruction to it, replaced `review-trivial`'s hand-rolled login-keyed `PATCH`/`POST` with `pipeline-cli verdict post`, and **rewrote the claim above to state what is actually true**. **Why:** the FAIL path carried the contract in two places saying opposite things — the exact drift #4438 exists to close — and a PR body asserting a property it does not have is worse than one that admits the gap. **Disposition:** the rebase invalidates every pre-rebase verdict by ADR 0058; this head needs a fresh review in both namespaces.
- **Known defect left unfixed (class 3) — the `§READBACK` relative link is dead and stays dead this round.** **Said:** AC #2 requires the read-back block to move **byte-identically**. **Did:** `[shared/scripts/verdict-readback.sh](shared/scripts/verdict-readback.sh)` sits inside that block and, from the new location, resolves to the nonexistent `skills/shared/shared/scripts/verdict-readback.sh`. It is **not** edited. Instead the reconciliation note above the block now names it **broken by relocation**, gives the working path `scripts/verdict-readback.sh`, and records why it is left alone. **Why:** the two requirements are in direct tension — one byte of repair forfeits byte-identity, which is the property AC #2 buys and the round-1 gate independently reproduced (`shasum 3bef3217…` on both spans). Choosing between them unilaterally is not this round's call. **Disposition:** deliberate; the reviewer decides whether a follow-up issue should repair the link once byte-identity has served its audit purpose.

- **(repair round 3) — AC #2's byte-identity is DELIBERATELY FORFEITED, for exactly one line.** **Said:** AC #2 requires the read-back block to move **byte-identically**, and the round-2 entry directly above recorded the dead link as left unrepaired *precisely to hold that property*. **Did:** round 3 edits one line inside the block — `[shared/scripts/verdict-readback.sh](shared/scripts/verdict-readback.sh)` → `[scripts/verdict-readback.sh](scripts/verdict-readback.sh)` — and nothing else inside it. The span now hashes `de453cec…` instead of `3bef3217…`; `diff -u` of the pre-move and post-move spans shows **exactly one** changed line. **Why:** the round-2 ruling was made without knowing that this exact line was **failing CI** (`doc-links`, exit 2, one error at `364:1`). That check is not in the required set, so the queue would have merged the PR with a dead link inside the newly-canonical contract and a red check on the record. And byte-identity had **already discharged its audit purpose**: two separate gates independently hashed both spans to `3bef3217a7c61158c6320f7578e5b4aea8e47a31`, which is the fact the criterion existed to establish. Preserving a dead link to protect a property that has already paid out is the wrong trade. **Disposition:** deliberate, and the one criterion this PR knowingly does not meet as literally written — for the reviewer to judge. The alternative was considered and rejected: there is no way to make the link resolve without touching the block, short of creating a bogus `skills/shared/shared/scripts/` path.
- **(repair round 3) — the reconciliation note above the block is rewritten, not appended to.** **Said:** the note existed to reconcile three pre-move spellings the block could not express, one of which was the dead link. **Did:** it now reconciles **two**, and the third bullet is replaced by a paragraph recording the one-line forfeiture, the two hashes, and why. **Why:** leaving the old note standing would have left the file asserting the link is dead-and-unrepaired directly above a link that resolves — a note contradicting its own file is worse than no note.
- **(repair round 3) — two evidence rows in this body did not reproduce, and are corrected.** **Said:** the round-2 table claimed `trap-status-guard check, 2 shell surfaces handed | clean`, and that the round-2 contract diff was "six lines". **Did:** both rows are rewritten. A shell-only scope exits **3** (zero markdown axis, ADR 0092 per-surface); the guard is clean only at mixed scope, which is what the round-2 run actually had. The contract-file diff is **9** lines, per `git show --stat cd632ea2`. The new-file line count `475` was likewise stale (it is **484** at this head) and is corrected. **Why:** an evidence table that does not reproduce is worse than no table — a reviewer who re-runs a row and gets a different answer cannot tell a stale number from a fabricated one.
- **(repair round 3) — one residual left deliberately un-widened.** **Said:** nothing forecloses fixing every stale cardinality phrase. **Did:** `claude-plugins/pipeline-crew/EXPLANATION.md:99` still describes a verdict as "one-per-gate" and is **not** touched. **Why:** the round-2 gate judged it outside this ticket's surface — descriptive attribution of ADR 0058, it instructs no upsert, and no code reads it — and widening scope in a repair round is how a repair becomes a second PR. It is being routed as a follow-up. **Disposition:** deliberate, and named here so it is not mistaken for a miss.

## Control plane

This PR is §CP in whole (`^claude-plugins/kampus-pipeline/skills/`, founder ruling #4446 landed by PR #4462). It banks for a `@kamp-us/control-plane` approval at head — no self-approval, no author enqueue. The round-3 push moved the head to `250b8e99`, so any approval or advisory bound to an earlier head is void and this head needs both a fresh gate and a fresh approval.


