### PR TITLE
fix(guards): cycle validators follow the source edge, so a comment stops counting as wiring

### DIFF
--- a/.patterns/skill-derived-guards.md
+++ b/.patterns/skill-derived-guards.md
@@ -49,7 +49,7 @@ sources.** `packages/pipeline-cli/src/skill-shell-surface.ts` owns that resoluti
   so folding it into every caller's surface lets one shared half-procedure satisfy every skill's own
   rule (the same scoping `kp_skill_shell_surfaces` chose, #4470).
 - **Scope by demonstrated dependency, not directory membership** — and keep the widening on the one
-  check that needs it ([ADR 0230](../.decisions/0230-cycle-validators-follow-the-source-edge.md)).
+  check that needs it (ADR 0230; the record lands separately, so this cites it by number).
   Directory scoping alone punishes the correct move: a skill that extracts its wiring into a shared
   helper and sources it has nothing left on its own surface but a comment, so the guard starts
   passing on prose (#4541). The repair is per-skill, per-edge inclusion — a shared file counts for a

--- a/.patterns/skill-derived-guards.md
+++ b/.patterns/skill-derived-guards.md
@@ -48,6 +48,16 @@ sources.** `packages/pipeline-cli/src/skill-shell-surface.ts` owns that resoluti
 - **Sibling-scoped**, never the whole plugin tree: `shared/lib/*.sh` is a library many skills call,
   so folding it into every caller's surface lets one shared half-procedure satisfy every skill's own
   rule (the same scoping `kp_skill_shell_surfaces` chose, #4470).
+- **Scope by demonstrated dependency, not directory membership** — and keep the widening on the one
+  check that needs it ([ADR 0230](../.decisions/0230-cycle-validators-follow-the-source-edge.md)).
+  Directory scoping alone punishes the correct move: a skill that extracts its wiring into a shared
+  helper and sources it has nothing left on its own surface but a comment, so the guard starts
+  passing on prose (#4541). The repair is per-skill, per-edge inclusion — a shared file counts for a
+  skill because that skill's own executable text sources it (`kp_skill_source_edges`), one hop,
+  fail-closed on an edge that will not resolve. Two rules keep this from becoming the whole-tree fold
+  by another route: feed the widened surface **only** to the check that needs the shared file, never
+  to the per-skill marker checks; and match `.sh` surfaces on **comment-stripped** text, so a
+  commented-out edge stops following and a citation in a docblock proves nothing.
 - **A sourced script that will not read back is UNRESOLVED, not absent** — the caller resolves its
   fail-closed constant, even if the constant it wanted is sitting inline right beside the source
   line. A partial read is not a read.

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/cycle-doc-probe.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/cycle-doc-probe.sh
@@ -8,11 +8,15 @@
 # It SOURCES the one shared implementation, `../../shared/scripts/cycle-doc-probe.sh`, rather than
 # carrying a second copy of the probe: that helper runs the formats-contract canonical probe — the
 # content read of `contents/product-development-cycle.md` — and leaves $CYCLE_DOC in this shell.
-# Naming that path here is load-bearing, not decoration: `validate-cycle-presence.sh` /
-# `validate-cycle-absence.sh` grep for the canonical probe across plan-epic's OWN shell surface
-# only (shared/lib is deliberately excluded — see `kp_skill_shell_surfaces` in
-# ../../shared/lib/common.sh), so this citation is what keeps the cycle validators scanning a real
-# reference instead of nothing.
+#
+# THE SOURCE LINE BELOW IS THE LOAD-BEARING TOKEN — this paragraph is not. The cycle validators
+# follow that line to the shared file and grep the probe literal THERE (`kp_skill_source_edges` in
+# ../../shared/lib/common.sh, ADR 0230), and every `.sh` grep they run is comment-stripped. Delete
+# the source line while keeping this text and they go red, by name. An earlier version of this
+# docblock claimed the opposite — that naming the path *here* is what kept the validators scanning a
+# real reference. It was true, and that was the bug: the guard was passing on this comment alone
+# (#4541). The citation stays because it tells a reader what the edge reaches, not because a grep
+# needs it.
 #
 # Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
 # shell-option rationale: ../SKILL.md § The extracted scripts.

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh
@@ -5,12 +5,14 @@
 # ../SKILL.md § The extracted scripts. The graceful-absence *why* (ADR 0062 — absence is a
 # first-class correct state) stays in that step's prose.
 #
-# DELIBERATELY NOT the shared ../../shared/scripts/cycle-doc-probe.sh, even though the two are
-# equivalent: the cycle validators (../validate-cycle-presence.sh / ../validate-cycle-absence.sh)
-# resolve each skill's scan surface via `kp_skill_shell_surfaces`, which is scoped to the skill's OWN
-# directory on purpose — so sourcing the shared copy would move review-code's cycle wiring off its
-# guarded surface and the validators would fail, correctly. Per-skill wiring stays per-skill; the rule
-# is stated once at `kp_skill_shell_surfaces` in ../../shared/lib/common.sh.
+# A SECOND COPY of ../../shared/scripts/cycle-doc-probe.sh, and no longer a required one. It was
+# required: the cycle validators scanned each skill's OWN directory only, so sourcing the shared copy
+# moved review-code's cycle wiring off its guarded surface and reddened them. ADR 0230 removed that
+# forcing constraint — the validators now follow a skill's own source edges one hop
+# (`kp_skill_source_edges` in ../../shared/lib/common.sh), so sourcing the shared probe stays green.
+# Collapsing this copy onto that edge is the intended direction and is deliberately NOT done here:
+# minting the new sourced invocation is held behind the open question about `.`-sourcing under
+# worktree isolation (#4546). Until then this copy is the drift risk it always was — see #4541.
 #
 # Sets no shell options and installs no EXIT trap (#4476, class #4479).
 

--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
@@ -25,15 +25,36 @@ fail() { printf 'FAIL: %s\n' "$*"; failures=$((failures + 1)); }
 ok() { printf 'ok: %s\n' "$*"; }
 
 # Every function under test must EXIST before any case runs. A missing function exits 127 with a
-# `command not found` on stderr — which several cases below would read as a correct fail-closed
-# refusal (non-zero, empty stdout, a diagnostic) and report as a pass. An unexercised case is
-# UNKNOWN, not a pass, so refuse up front instead.
-for fn in kp_skill_shell_surfaces kp_surface_text kp_skill_source_edges; do
+# `command not found` on stderr — which FOUR of the cases below read as a correct fail-closed
+# refusal (non-zero, empty stdout, a diagnostic on stderr) and report as a pass: the
+# unreadable-surface, broken-edge, sibling-edge and non-idiom-source cases (measured by deleting
+# this block and re-running). An unexercised case is UNKNOWN, not a pass, so refuse up front.
+#
+# The set is DERIVED from this file, never listed. A hardcoded list stops covering the moment a
+# case reaches for a fourth function, silently reopening the exact 127 class this refusal closes —
+# the same guard-in-text/absent-in-effect shape the rest of this suite pins. Derived from the RAW
+# text on purpose: it over-includes (a name appearing only in a message string is still required to
+# exist), and over-inclusion is the fail-closed direction. `kp__`-prefixed privates are excluded —
+# nothing here calls them directly. An empty derivation means this file could not be read, which is
+# UNKNOWN, never "no functions to check".
+required_fns="$(grep -oE 'kp_[a-z][a-z0-9_]*' "${BASH_SOURCE[0]}" | LC_ALL=C sort -u)"
+if [ -z "$required_fns" ]; then
+	printf 'FAIL: could not derive the exercised function set from %s — refusing to run cases whose 127 would read as a fail-closed pass.\n' "${BASH_SOURCE[0]}"
+	exit 1
+fi
+missing=0
+while IFS= read -r fn; do
+	[ -n "$fn" ] || continue
 	if ! type "$fn" >/dev/null 2>&1; then
 		printf 'FAIL: %s is not defined by %s — the cases below would resolve 127 and read as fail-closed passes. Refusing to run them.\n' "$fn" "$lib"
-		exit 1
+		missing=$((missing + 1))
 	fi
-done
+done <<EOF
+$required_fns
+EOF
+if [ "$missing" -ne 0 ]; then
+	exit 1
+fi
 if [ -z "${KP_EDGE_MAX_HOPS:-}" ]; then
 	printf 'FAIL: KP_EDGE_MAX_HOPS is not set by %s — the hop-cap case cannot be exercised.\n' "$lib"
 	exit 1
@@ -297,6 +318,26 @@ if [ "$rc" -eq 0 ] && [ "$out" = "$tmp/e/shared/scripts/first.sh" ] && [ "$KP_ED
 	ok "one hop only: the directly-sourced file enters, the file it sources does not"
 else
 	fail "twohop: rc=$rc cap=$KP_EDGE_MAX_HOPS out=[$out]"
+fi
+
+# 17. THE CREDIT PIN, on the SHIPPED lib rather than a fixture. `shared/lib/common.sh` is
+# edge-resolved into the widened surface of ALL FOUR cycle-aware skills (the validators' emitted
+# scope line names it `(edge:plan-epic)`, `(edge:write-code)`, `(edge:review-code)`,
+# `(edge:ship-it)`), because every one of them sources it — unconditionally, for reasons that have
+# nothing to do with the cycle. So a single probe literal in its executable text would green the
+# canonical-probe check for four independent skills at once, and "demonstrated dependency" would
+# degenerate into "everybody sources it" — directory membership by another name, which is what ADR
+# 0230 rule 1 exists to reject. The ADR's blessing of shared credit was written for
+# `shared/scripts/cycle-doc-probe.sh`, a file whose only purpose IS the probe; it does not transfer
+# here. Keyed on the SAME comment-stripped text the validators grep, so a mention in this file's
+# prose is correctly not a violation — only executable text is.
+probe_literal="contents/product-development-cycle.md"
+if ! out="$(kp_surface_text "$lib")"; then
+	fail "credit pin: could not read $lib — UNKNOWN, never 'the literal is absent'"
+elif grep -qF "$probe_literal" <<<"$out"; then
+	fail "credit pin: $lib carries the cycle-doc probe literal ('$probe_literal') in executable shell — it is edge-resolved into all four cycle-aware skills, so this one file would satisfy every skill's canonical-probe check (ADR 0230 rule 1)"
+else
+	ok "the shared lib carries no cycle-doc probe literal (no blanket four-skill credit)"
 fi
 
 cleanup

--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# Executable pin for kp_skill_shell_surfaces' scan-status contract (#4487). Run it directly:
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# SC2016 is declared, not suppressed on principle: the fixtures below EMIT shell text, so the single
+# quotes are the point — an expanded `${v#pre}` or `$dir` would write a different fixture than the
+# one under test.
+# Executable pin for kp_skill_shell_surfaces' scan-status contract (#4487) and for the source-edge
+# surface widening + comment-stripped matching that ADR 0230 adds on top (#4541). Run it directly:
 #   bash claude-plugins/kampus-pipeline/skills/shared/lib/common-test.sh
+#
+# Every case here is written to be FALSIFIABLE — each asserts a behaviour that the pre-ADR-0230
+# resolver did not have, so the file goes red against the old one. A fixture that fails to take is
+# reported RED, never skipped: an unexercised case is UNKNOWN, not a pass.
 #
 # `set -uo pipefail` WITHOUT `-e`, and no EXIT trap: on bash 3.2 a `-u` abort under `-e` reaches
 # an EXIT trap with `$?` already 0, so the script would exit 0 having aborted (#4479). Cleanup is
@@ -15,7 +24,26 @@ failures=0
 fail() { printf 'FAIL: %s\n' "$*"; failures=$((failures + 1)); }
 ok() { printf 'ok: %s\n' "$*"; }
 
+# Every function under test must EXIST before any case runs. A missing function exits 127 with a
+# `command not found` on stderr — which several cases below would read as a correct fail-closed
+# refusal (non-zero, empty stdout, a diagnostic) and report as a pass. An unexercised case is
+# UNKNOWN, not a pass, so refuse up front instead.
+for fn in kp_skill_shell_surfaces kp_surface_text kp_skill_source_edges; do
+	if ! type "$fn" >/dev/null 2>&1; then
+		printf 'FAIL: %s is not defined by %s — the cases below would resolve 127 and read as fail-closed passes. Refusing to run them.\n' "$fn" "$lib"
+		exit 1
+	fi
+done
+if [ -z "${KP_EDGE_MAX_HOPS:-}" ]; then
+	printf 'FAIL: KP_EDGE_MAX_HOPS is not set by %s — the hop-cap case cannot be exercised.\n' "$lib"
+	exit 1
+fi
+
 tmp="$(mktemp -d)" || { printf 'FAIL: could not create a temp fixture dir\n'; exit 1; }
+# PHYSICAL, because the edge resolver answers in physical paths and `mktemp -d` hands back a logical
+# one on macOS (/var → /private/var). Comparing its answer against a logical fixture path would fail
+# for a path-shape reason and say nothing about the behaviour under test.
+tmp="$(cd -P "$tmp" && pwd)" || { printf 'FAIL: could not resolve the temp fixture dir physically\n'; exit 1; }
 cleanup() { chmod -R u+rwx "$tmp" 2>/dev/null; rm -rf "$tmp"; }
 
 # Fixture: a complete skill (SKILL.md + two *.sh at two depths) and an empty one.
@@ -75,6 +103,201 @@ else
 	fi
 fi
 chmod 755 "$tmp/skills/complete/scripts"
+
+# ---------------------------------------------------------------------------------------------
+# ADR 0230 / #4541 — comment-stripped matching and the source-edge surface widening.
+# ---------------------------------------------------------------------------------------------
+
+# The documented sourcing idiom, built here rather than pasted, so a fixture cannot drift from the
+# matcher by a stray character. `%s` twice: the relative directory and the file name.
+idiom() { printf '. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/%s" && pwd)/%s"\n' "$1" "$2"; }
+
+# 5. Comment stripping: a whole-line comment and a trailing comment go; a `#` inside quotes, a
+# `${var#pat}` expansion and a case pattern stay. THE falsification of the shipped defect — the
+# needle in a docblock is exactly what greened the presence validator off plan-epic's prose.
+mkdir -p "$tmp/strip"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf '# NEEDLE_IN_A_DOCBLOCK\n'
+	printf 'keep_me=1   # NEEDLE_IN_A_TRAILING_COMMENT\n'
+	printf 'printf "a#b\\n"\n'
+	printf 'x="${v#pre}"\n'
+	printf 'case "$s" in *#*) : ;; esac\n'
+} > "$tmp/strip/f.sh"
+out="$(kp_surface_text "$tmp/strip/f.sh")"; rc=$?
+if [ "$rc" -ne 0 ]; then
+	fail "kp_surface_text: rc=$rc on a readable file"
+elif grep -q 'NEEDLE_IN_A_DOCBLOCK' <<<"$out"; then
+	fail "comment stripping: a docblock needle survived — the #4541 fail-open is still open"
+elif grep -q 'NEEDLE_IN_A_TRAILING_COMMENT' <<<"$out"; then
+	fail "comment stripping: a trailing-comment needle survived"
+elif ! grep -q 'a#b' <<<"$out"; then
+	fail "comment stripping: a # inside a string was eaten"
+elif ! grep -q '${v#pre}' <<<"$out"; then
+	fail "comment stripping: a \${var#pat} expansion was eaten"
+elif ! grep -q 'in \*#\*)' <<<"$out"; then
+	fail "comment stripping: a case pattern containing # was eaten"
+else
+	ok "comment stripping drops comments and keeps every non-comment #"
+fi
+
+# 6. A non-`.sh` surface file is passed through verbatim — SKILL.md is markdown, not shell.
+printf '# a markdown heading, not a comment\n' > "$tmp/strip/S.md"
+out="$(kp_surface_text "$tmp/strip/S.md")"; rc=$?
+if [ "$rc" -eq 0 ] && grep -q 'a markdown heading' <<<"$out"; then
+	ok "non-.sh surface text passes through verbatim"
+else
+	fail "non-.sh passthrough: rc=$rc out=[$out]"
+fi
+
+# 7. kp_surface_text on an unreadable file: nothing on stdout, non-zero, a diagnostic.
+printf 'x\n' > "$tmp/strip/locked.sh"
+chmod 000 "$tmp/strip/locked.sh"
+if [ -r "$tmp/strip/locked.sh" ]; then
+	fail "fixture did not take: locked.sh is still readable (running as root?) — the unreadable-file case was NOT exercised"
+else
+	err="$tmp/stderr"
+	out="$(kp_surface_text "$tmp/strip/locked.sh" 2>"$err")"; rc=$?
+	diag="$(cat "$err")"
+	if [ "$rc" -eq 0 ]; then
+		fail "unreadable surface file returned 0 — 'could not read' is being laundered into 'no match'"
+	elif [ -n "$out" ]; then
+		fail "unreadable surface file emitted [$out] — it must emit nothing"
+	elif [ -z "$diag" ]; then
+		fail "unreadable surface file returned $rc with an empty stderr — non-zero with no diagnostic is itself a fail-open"
+	else
+		ok "unreadable surface file: exit $rc, empty stdout, diagnostic on stderr"
+	fi
+fi
+chmod 644 "$tmp/strip/locked.sh"
+
+# Edge fixtures: a skill that sources a shared script, one that only names the path in a comment,
+# one whose edge target is missing, one that sources a SIBLING skill, and one that sources nothing.
+mkdir -p "$tmp/e/shared/scripts" "$tmp/e/shared/lib" \
+	"$tmp/e/sourcer/scripts" "$tmp/e/commenter/scripts" "$tmp/e/broken/scripts" \
+	"$tmp/e/sibling/scripts" "$tmp/e/lonely/scripts" "$tmp/e/owndir/scripts"
+printf 'MARKER=shared\n' > "$tmp/e/shared/scripts/probe.sh"
+printf 'x\n' > "$tmp/e/shared/lib/common.sh"
+for s in sourcer commenter broken sibling lonely owndir; do printf 'x\n' > "$tmp/e/$s/SKILL.md"; done
+
+idiom '../../shared/scripts' 'probe.sh' > "$tmp/e/sourcer/scripts/w.sh"
+printf '# ../../shared/scripts/probe.sh — named in a comment only\n' > "$tmp/e/commenter/scripts/w.sh"
+idiom '../../shared/scripts' 'gone.sh' > "$tmp/e/broken/scripts/w.sh"
+idiom '../../sourcer/scripts' 'w.sh' > "$tmp/e/sibling/scripts/w.sh"
+printf 'echo nothing sourced\n' > "$tmp/e/lonely/scripts/w.sh"
+printf 'x\n' > "$tmp/e/owndir/scripts/helper.sh"
+idiom '.' 'helper.sh' > "$tmp/e/owndir/scripts/w.sh"
+
+edges_of() { kp_skill_source_edges "$tmp/e" "$1"; }
+
+# 8. A real source edge widens the surface to the shared file — demonstrated dependency.
+out="$(edges_of sourcer)"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "$tmp/e/shared/scripts/probe.sh" ]; then
+	ok "a sourced shared script enters the surface (one hop, widen-never-replace)"
+else
+	fail "sourcer edge: rc=$rc out=[$out]"
+fi
+
+# 9. THE #4541 PIN: a comment naming the shared path resolves NO edge, so a marker that lives only
+# in the shared file cannot be claimed by a skill that merely mentions it.
+out="$(edges_of commenter)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+	fail "commenter: rc=$rc — a comment is not an error, it is simply not an edge"
+elif [ -n "$out" ]; then
+	fail "commenter: a COMMENT naming the shared path resolved an edge [$out] — commentary is being read as wiring (#4541)"
+else
+	ok "a comment naming the shared path resolves no edge"
+fi
+
+# 10. A named edge whose target is missing is UNRESOLVED — red, nothing on stdout (ADR 0230 rule 4).
+err="$tmp/stderr"
+out="$(edges_of broken 2>"$err")"; rc=$?
+diag="$(cat "$err")"
+if [ "$rc" -eq 0 ]; then
+	fail "broken edge returned 0 — an unresolvable edge is UNKNOWN, never a narrower surface"
+elif [ -n "$out" ]; then
+	fail "broken edge emitted [$out] — it must emit nothing"
+elif [ -z "$diag" ]; then
+	fail "broken edge returned $rc with an empty stderr — non-zero with no diagnostic is itself a fail-open"
+else
+	ok "broken edge: exit $rc, empty stdout, named diagnostic on stderr"
+fi
+
+# 11. An edge into a SIBLING skill is outside the allowlist — red. Without this, skill A greens off
+# wiring skill B owns and can delete at will (#4505 T4).
+out="$(edges_of sibling 2>"$err")"; rc=$?
+diag="$(cat "$err")"
+if [ "$rc" -eq 0 ]; then
+	fail "sibling-skill edge returned 0 — the followed-target allowlist is not enforced (T4)"
+elif [ -n "$out" ]; then
+	fail "sibling-skill edge emitted [$out] — it must emit nothing"
+elif [ -z "$diag" ]; then
+	fail "sibling-skill edge returned $rc with an empty stderr"
+else
+	ok "sibling-skill edge: refused, exit $rc, empty stdout, named diagnostic"
+fi
+
+# 12. A skill that sources nothing keeps EXACTLY today's surface — the widening is opt-in by
+# evidence, so #4470's property is preserved rather than traded.
+out="$(edges_of lonely)"; rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+	ok "a skill that sources nothing gains nothing (exit 0, no output)"
+else
+	fail "lonely: rc=$rc out=[$out]"
+fi
+
+# 13. An edge into the skill's OWN directory is allowlisted, and is not re-emitted: the own surface
+# already carries it, and the widening ADDS, it never duplicates.
+out="$(edges_of owndir)"; rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+	ok "an own-directory edge is allowed and adds nothing already in the own surface"
+else
+	fail "owndir: rc=$rc out=[$out]"
+fi
+
+# 14. A source line naming a shared/ target in ANY shape but the documented idiom is UNRESOLVED, not
+# quietly unfollowed — the variable-interpolated form that defeats a generic resolver (#4505 T1).
+mkdir -p "$tmp/e/interp/scripts"
+printf 'x\n' > "$tmp/e/interp/SKILL.md"
+printf '. "$dir/../../shared/scripts/probe.sh"\n' > "$tmp/e/interp/scripts/w.sh"
+out="$(edges_of interp 2>"$err")"; rc=$?
+diag="$(cat "$err")"
+if [ "$rc" -eq 0 ]; then
+	fail "an interpolated shared/ source line returned 0 — a form outside the idiom must be UNRESOLVED (T1)"
+elif [ -n "$out" ]; then
+	fail "an interpolated shared/ source line emitted [$out] — it must emit nothing"
+elif [ -z "$diag" ]; then
+	fail "an interpolated shared/ source line returned $rc with an empty stderr"
+else
+	ok "a shared/ source line outside the idiom: refused, exit $rc, empty stdout, named diagnostic"
+fi
+
+# 15. An edge is read from COMMENT-STRIPPED text: commenting the source line out drops the edge.
+# The presence validator then reds by needle-not-found, which is the whole point — a commented-out
+# edge must not keep following.
+mkdir -p "$tmp/e/commentedout/scripts"
+printf 'x\n' > "$tmp/e/commentedout/SKILL.md"
+{ printf '# '; idiom '../../shared/scripts' 'probe.sh'; } > "$tmp/e/commentedout/scripts/w.sh"
+out="$(edges_of commentedout)"; rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+	ok "a commented-out source line follows nothing"
+else
+	fail "commentedout: rc=$rc out=[$out]"
+fi
+
+# 16. The hop cap is the ADR's one-hop rule, mechanised. A literal two hops away is NOT reached, and
+# the fix for that is to source it directly rather than to raise the cap.
+mkdir -p "$tmp/e/twohop/scripts"
+printf 'x\n' > "$tmp/e/twohop/SKILL.md"
+idiom '../../shared/scripts' 'first.sh' > "$tmp/e/twohop/scripts/w.sh"
+idiom '.' 'second.sh' > "$tmp/e/shared/scripts/first.sh"
+printf 'DEEP_MARKER=1\n' > "$tmp/e/shared/scripts/second.sh"
+out="$(edges_of twohop)"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "$tmp/e/shared/scripts/first.sh" ] && [ "$KP_EDGE_MAX_HOPS" -eq 1 ]; then
+	ok "one hop only: the directly-sourced file enters, the file it sources does not"
+else
+	fail "twohop: rc=$rc cap=$KP_EDGE_MAX_HOPS out=[$out]"
+fi
 
 cleanup
 if [ "$failures" -ne 0 ]; then

--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2016
+# SC2016 is declared, not waved off: the awk program and the sourcing-idiom matcher below are LITERAL
+# text handed to awk and sed. Shell expansion of their `$` would destroy both.
 # Cross-script state for the pipeline skills' extracted shell (epic #4435 phase 1).
 # Sourced, never executed: it defines functions and sets no shell options, so the sourcing
 # script keeps its own `set -euo pipefail`.
@@ -21,6 +24,13 @@
 # SOURCING IDIOM — resolve relative to this file so the caller's cwd is irrelevant. From a
 # script in a per-skill scripts/ directory:
 #   . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+#
+# That idiom is now a MACHINE CONTRACT, not a style note (ADR 0230, #4541). `kp_skill_source_edges`
+# below matches it literally — column 0, single line, no interpolated directory — to decide which
+# shared file a skill demonstrably executes. A sourcing form outside it is not resolvable statically,
+# so a line that names a `shared/` target in any other shape is UNRESOLVED and reds the skill rather
+# than narrowing its surface in silence. Change the idiom and you change that matcher: they move
+# together, and `shared/lib/common-test.sh` pins the pair.
 
 # Every file a skill's shell can live in, one absolute path per line: its SKILL.md plus every
 # `*.sh` under the skill's own directory — the destination the convention above sends extracted
@@ -28,11 +38,11 @@
 # it, staying green while guarding nothing (#4470); resolving the surface HERE, next to the
 # convention that defines it, is what keeps the two in step.
 #
-# Scoped to the skill's OWN directory on purpose. shared/lib/*.sh is cross-skill, so folding it
-# into every skill's surface would let one skill's marker satisfy another skill's per-skill check
-# — the same guard-in-text/absent-in-effect defect, reintroduced from the other side. A skill that
-# extracts its cycle wiring into the shared lib therefore FAILS these validators, loudly, which is
-# the correct direction: per-skill wiring stays per-skill, or the validator is updated deliberately.
+# Scoped to the skill's OWN directory on purpose. shared/*.sh is cross-skill, so folding the whole
+# directory into every skill's surface would let one skill's marker satisfy another skill's
+# per-skill check — the same guard-in-text/absent-in-effect defect, reintroduced from the other
+# side (#4470). That exclusion is on DIRECTORY MEMBERSHIP, and it stands. What a caller may add on
+# top is per-skill, per-edge and evidence-bearing: see `kp_skill_source_edges` (ADR 0230).
 #
 # EMITS NOTHING for a skill directory with no SKILL.md and no `*.sh` (and still exits 0 — an
 # empty surface is not an error here, it is a fact the CALLER must decide about). A caller that
@@ -65,6 +75,244 @@ kp_skill_shell_surfaces() {
 	fi
 	[ -n "$md" ] && printf '%s\n' "$md"
 	[ -n "$sorted" ] && printf '%s\n' "$sorted"
+	return 0
+}
+
+# One line of shell minus its comment, quote-aware, per line. A guard that greps RAW `.sh` text
+# cannot tell wiring from commentary — and did not: `validate-cycle-presence.sh` passed `plan-epic`
+# off a docblock line naming the canonical probe path, that line being its ONLY match. The guard was
+# satisfied by its own prose (#4541). So every `.sh`-surface grep runs on this output instead.
+#
+# A `#` opens a comment only OUTSIDE quotes and only at line start or after whitespace, so
+# `${var#pat}`, a `*#*)` case pattern and a `#` inside a string all survive. No state crosses lines:
+# a heredoc body therefore cannot desync the scan, and the worst it can do is drop a `#` tail — which
+# REMOVES text, the fail-closed direction for a presence grep. Residue, stated rather than glossed: a
+# comment is dropped, but a needle planted in a `.sh` heredoc or an `if false` block still reads as
+# code. Distinguishing those needs a parser; that threat is deception, which §CP review of `skills/**`
+# covers, and this guard's threat is drift (ADR 0230, #4505's threat model T8).
+#
+# `\047` is a single quote, written octally so this awk program contains none and can live inside a
+# single-quoted shell string.
+kp__STRIP_AWK='
+{
+	line = $0; out = ""; inq = ""; i = 1; n = length(line)
+	while (i <= n) {
+		c = substr(line, i, 1)
+		if (inq == "") {
+			if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t]/)) break
+			if (c == "\047" || c == "\"") { inq = c }
+			else if (c == "\\") {
+				out = out c; i++
+				if (i <= n) { out = out substr(line, i, 1); i++ }
+				continue
+			}
+		} else if (inq == "\"") {
+			if (c == "\\") {
+				out = out c; i++
+				if (i <= n) { out = out substr(line, i, 1); i++ }
+				continue
+			}
+			if (c == "\"") inq = ""
+		} else if (c == "\047") { inq = "" }
+		out = out c; i++
+	}
+	print out
+}'
+
+# The greppable text of the surface files named as arguments, concatenated: `.sh` comment-stripped,
+# everything else verbatim. SKILL.md stays raw on purpose — it is markdown, where a fenced block and
+# a paragraph are equally greppable, and tightening that prose floor is a separate problem (ADR 0230,
+# "knowingly traded").
+#
+# Buffers, then prints: an unreadable file makes the text UNKNOWN, so it emits NOTHING on stdout, a
+# diagnostic on stderr, and returns non-zero (§ZS, ADR 0092). Callers must capture it UNPIPED —
+# `text="$(kp_surface_text "${files[@]}")" || …` — because through a pipe the status is unobservable.
+# Zero arguments is a caller bug, not an empty surface: `set -u` aborts on an empty array expansion,
+# so check the count first.
+kp_surface_text() {
+	local f out="" chunk
+	for f in "$@"; do
+		case "$f" in
+		*.sh)
+			if ! chunk="$(awk "$kp__STRIP_AWK" "$f")"; then
+				printf 'kp_surface_text: could not read %s — the surface text is UNKNOWN, not empty; emitting nothing.\n' "$f" >&2
+				return 1
+			fi
+			;;
+		*)
+			if ! chunk="$(cat "$f")"; then
+				printf 'kp_surface_text: could not read %s — the surface text is UNKNOWN, not empty; emitting nothing.\n' "$f" >&2
+				return 1
+			fi
+			;;
+		esac
+		out="$out$chunk
+"
+	done
+	printf '%s' "$out"
+	return 0
+}
+
+# The sourcing idiom from this file's header, as a matcher. Anchored at column 0 (the extraction
+# convention puts every moved line there), single line, literal relative directory and literal
+# `.sh` name — no `$`-interpolation anywhere in either, because an interpolated path is not
+# statically resolvable at all and pretending otherwise is how a generic resolver gets defeated
+# (#4505 threat model T1). Captures the relative directory and the file name; the sed replacement
+# rejoins them with `/`, which is unambiguous because the name capture excludes `/`.
+kp__EDGE_IDIOM='^\.  *"$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE\[0\]}")/\([^"$]*\)" && pwd)/\([^"$/]*\.sh\)"$'
+
+# One hop, and the constant IS the rule: only files sourced DIRECTLY by the skill's own surface are
+# followed. A literal hidden two hops deep is a FAIL whose fix is to source it directly — a closure
+# would re-open the whole-tree fold that the own-directory scoping exists to prevent, and would make
+# a skill's surface depend on the shared corpus's internal shape (ADR 0230 rule 2). Raising it is a
+# deliberate one-line decision, not a drift.
+KP_EDGE_MAX_HOPS=1
+
+kp__is_under() { # <path> <root> — true when <path> IS <root> or sits beneath it
+	[ -n "$2" ] || return 1
+	case "$1" in
+	"$2" | "$2"/*) return 0 ;;
+	esac
+	return 1
+}
+
+# The shared files a skill DEMONSTRABLY executes, one absolute path per line — the skill's scan
+# surface widened across its own source edges (ADR 0230). Inclusion is keyed on demonstrated
+# dependency, never on directory membership: a shared file is credited to a skill because that
+# skill's own text sources it, so a skill that sources nothing gets nothing and #4470's property —
+# one skill's marker cannot satisfy another's — survives intact.
+#
+# WIDEN, NEVER REPLACE: this is the ADDITION to `kp_skill_shell_surfaces`, not a substitute for it.
+# Callers union the two, and only for the check that needs it — feeding the widened surface to every
+# check would let one shared file satisfy every skill's per-skill marker, which is #4470 rebuilt
+# through a legitimate edge (#4505 threat model T3).
+#
+# FAIL-CLOSED, and loudly by name (ADR 0092 / §ZS, ADR 0230 rule 4). Emits NOTHING on stdout and
+# returns non-zero when: the skill's own surface will not resolve; a source line names a `shared/`
+# target in any shape but the documented idiom (UNRESOLVED — never silently unfollowed); a resolved
+# target is missing or unreadable; or a target lands outside the allowlist (the skill's own dir,
+# `shared/scripts/`, `shared/lib/`), which is what stops skill A greening off wiring skill B owns and
+# can delete (T4). A named edge that will not resolve makes the surface UNKNOWN, and UNKNOWN is never
+# "the needle is absent" — the caller must red on it by name rather than report a confusing
+# needle-not-found over a surface it never finished reading (T7).
+#
+# A source line that resolves to neither — no `shared/` in it, not the idiom — is not an edge claim
+# at all and is simply not followed. That direction is safe by construction: this function only ever
+# ADDS files, so an unfollowed line yields a NARROWER surface, and a narrower surface can only make a
+# presence grep fail.
+kp_skill_source_edges() {
+	local skills_dir="$1" skill="$2"
+	local own_root shared_scripts_root shared_lib_root own_list
+	local frontier next visited emitted f dir stripped hits line pair rel name tdir target hop grc allowed
+	local NL='
+'
+	if ! own_root="$(cd -P "$skills_dir/$skill" 2>/dev/null && pwd)"; then
+		printf 'kp_skill_source_edges: %s: cannot resolve the skill directory under %s — the edge surface is UNKNOWN, not empty; emitting nothing.\n' "$skill" "$skills_dir" >&2
+		return 1
+	fi
+	# Physical paths on both sides of every allowlist comparison: `skills/` is reached through a
+	# symlink, and a logical path compares a resolved target against an unresolved root and never
+	# matches (T7). An absent shared root is not an error — it is simply not an allowed target.
+	shared_scripts_root="$(cd -P "$skills_dir/shared/scripts" 2>/dev/null && pwd)" || shared_scripts_root=""
+	shared_lib_root="$(cd -P "$skills_dir/shared/lib" 2>/dev/null && pwd)" || shared_lib_root=""
+
+	if ! own_list="$(kp_skill_shell_surfaces "$skills_dir" "$skill")"; then
+		printf 'kp_skill_source_edges: %s: the own surface is UNKNOWN, so its edges are too; emitting nothing.\n' "$skill" >&2
+		return 1
+	fi
+
+	# bash 3.2 has no associative arrays: the visited set is a newline-delimited string with linear
+	# membership. It is seeded with the own surface so an edge back into the skill's own files is
+	# never re-emitted as an addition.
+	visited="$NL"
+	frontier=""
+	while IFS= read -r f; do
+		[ -n "$f" ] || continue
+		case "$f" in
+		*.sh) ;;
+		*) continue ;;
+		esac
+		visited="$visited$f$NL"
+		# Record the PHYSICAL form too. Edge targets are resolved physically (the allowlist demands
+		# it), so a caller that handed us a logical skills_dir would fail to recognise an own-directory
+		# edge as already-present and re-emit a file the own surface already carries.
+		case "$f" in
+		"$skills_dir/$skill/"*) visited="$visited$own_root/${f#"$skills_dir/$skill/"}$NL" ;;
+		esac
+		frontier="$frontier$f$NL"
+	done <<EOF
+$own_list
+EOF
+
+	emitted=""
+	hop=0
+	while [ "$hop" -lt "$KP_EDGE_MAX_HOPS" ]; do
+		next=""
+		while IFS= read -r f; do
+			[ -n "$f" ] || continue
+			if ! stripped="$(awk "$kp__STRIP_AWK" "$f")"; then
+				printf 'kp_skill_source_edges: %s: could not read %s — the edge surface is UNKNOWN; emitting nothing.\n' "$skill" "$f" >&2
+				return 1
+			fi
+			hits="$(grep -E '^(\.|source)[[:space:]]' <<<"$stripped")"
+			grc=$?
+			if [ "$grc" -gt 1 ]; then
+				printf 'kp_skill_source_edges: %s: grep failed scanning %s for source lines — UNKNOWN; emitting nothing.\n' "$skill" "$f" >&2
+				return 1
+			fi
+			[ "$grc" -eq 1 ] && continue
+			while IFS= read -r line; do
+				[ -n "$line" ] || continue
+				if ! pair="$(sed -n "s|$kp__EDGE_IDIOM|\\1/\\2|p" <<<"$line")"; then
+					printf 'kp_skill_source_edges: %s: sed failed matching a source line in %s — UNKNOWN; emitting nothing.\n' "$skill" "$f" >&2
+					return 1
+				fi
+				if [ -z "$pair" ]; then
+					case "$line" in
+					*shared/*)
+						printf 'kp_skill_source_edges: %s: %s carries a source line naming a shared/ target that does NOT match the documented sourcing idiom, so it cannot be resolved statically — the surface is UNKNOWN, not narrower (ADR 0230 rule 4):\n  %s\n' "$skill" "$f" "$line" >&2
+						return 1
+						;;
+					esac
+					continue
+				fi
+				rel="${pair%/*}"
+				name="${pair##*/}"
+				dir="${f%/*}"
+				if ! tdir="$(cd -P "$dir/$rel" 2>/dev/null && pwd)"; then
+					printf 'kp_skill_source_edges: %s: %s sources %s, whose directory does not resolve — a NAMED edge that will not resolve is UNKNOWN, never absent (ADR 0230 rule 4).\n' "$skill" "$f" "$pair" >&2
+					return 1
+				fi
+				target="$tdir/$name"
+				if [ ! -f "$target" ]; then
+					printf 'kp_skill_source_edges: %s: %s sources %s, which resolves to %s — no such file. A broken edge is UNKNOWN, never absent (ADR 0230 rule 4).\n' "$skill" "$f" "$pair" "$target" >&2
+					return 1
+				fi
+				allowed=0
+				if kp__is_under "$tdir" "$own_root"; then allowed=1; fi
+				if [ "$allowed" -eq 0 ] && kp__is_under "$tdir" "$shared_scripts_root"; then allowed=1; fi
+				if [ "$allowed" -eq 0 ] && kp__is_under "$tdir" "$shared_lib_root"; then allowed=1; fi
+				if [ "$allowed" -eq 0 ]; then
+					printf 'kp_skill_source_edges: %s: %s sources %s, outside the followed-target allowlist (own dir, shared/scripts, shared/lib). Following it would let this skill green off wiring another skill owns and can delete (T4); refusing.\n' "$skill" "$f" "$target" >&2
+					return 1
+				fi
+				case "$visited" in
+				*"$NL$target$NL"*) continue ;;
+				esac
+				visited="$visited$target$NL"
+				next="$next$target$NL"
+				emitted="$emitted$target$NL"
+			done <<EOF
+$hits
+EOF
+		done <<EOF
+$frontier
+EOF
+		frontier="$next"
+		hop=$((hop + 1))
+	done
+
+	printf '%s' "$emitted"
 	return 0
 }
 

--- a/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/lib/common.sh
@@ -84,12 +84,17 @@ kp_skill_shell_surfaces() {
 # satisfied by its own prose (#4541). So every `.sh`-surface grep runs on this output instead.
 #
 # A `#` opens a comment only OUTSIDE quotes and only at line start or after whitespace, so
-# `${var#pat}`, a `*#*)` case pattern and a `#` inside a string all survive. No state crosses lines:
-# a heredoc body therefore cannot desync the scan, and the worst it can do is drop a `#` tail — which
-# REMOVES text, the fail-closed direction for a presence grep. Residue, stated rather than glossed: a
-# comment is dropped, but a needle planted in a `.sh` heredoc or an `if false` block still reads as
-# code. Distinguishing those needs a parser; that threat is deception, which §CP review of `skills/**`
-# covers, and this guard's threat is drift (ADR 0230, #4505's threat model T8).
+# `${var#pat}`, a `*#*)` case pattern and a `#` inside a string all survive. No state crosses lines,
+# so a heredoc body cannot desync the scan.
+#
+# Residue, stated rather than glossed, and it runs in BOTH directions — the common case removes text
+# (fail-closed for a presence grep: a dropped `#` tail can only make a needle harder to find), but
+# that is not exhaustive. Measured counter-example in the fail-OPEN direction: on a line carrying an
+# unbalanced double quote, the scan stays in-quote to end of line, so a `#` comment after it
+# SURVIVES. Likewise a needle planted in a `.sh` heredoc or an `if false` block still reads as code.
+# All of that sits inside T8's ACCEPTED residue rather than being a defect: separating them needs a
+# parser, shellcheck reds an unbalanced quote, and the threat they serve is deception — covered by
+# §CP review of `skills/**` — where this guard's threat is drift (ADR 0230, #4505's threat model T8).
 #
 # `\047` is a single quote, written octally so this awk program contains none and can live inside a
 # single-quoted shell string.

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
@@ -15,6 +15,13 @@
 #      with an absent⇒no-op branch. No skill hardcodes a flag or assumes the doc exists.
 #      Scanned across the skill's whole shell surface — SKILL.md AND its extracted
 #      scripts/*.sh (#4470) — so moving a block out of SKILL.md cannot disarm this.
+#      TWO SURFACES, and the split is load-bearing (ADR 0230, #4541): only the canonical-probe
+#      check reads the WIDENED surface (own files + the shared files they demonstrably source,
+#      one hop); the absent⇒no-op and hardcoded-flag checks stay on the skill's OWN files. The
+#      shared probe file textually carries every skill's absence marker, so widening every check
+#      would let one shared file satisfy all four — #4470's blindness through a legitimate edge.
+#      Every `.sh` grep here runs on COMMENT-STRIPPED text, so a citation in a docblock proves
+#      nothing; the presence twin's docblock carries the full statement of what this proves.
 #   2. HERMETIC runtime — run the canonical working-tree probe against a temp repo root
 #      with no cycle doc, assert it resolves `absent` and the no-op default holds. This is
 #      the executable scenario walkthrough of the doc-absent branch (issue #605, epic #595).
@@ -28,9 +35,12 @@
 # whose failure errexit used to catch is checked explicitly below.
 set -uo pipefail
 
-# Same self-locating idiom as validate-skills.sh: this script lives in .claude/skills/, so
-# its own dir IS the skills root — resolve from BASH_SOURCE so it works from any cwd.
-skills_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Same self-locating idiom as the presence twin: this script lives in the skills root, so its own
+# dir IS that root — resolve from BASH_SOURCE, PHYSICALLY (`cd -P`). The physical form is what the
+# source-edge allowlist needs: `skills/` is reached through the `.claude/skills` symlink, and a
+# LOGICAL root would be compared against physically-resolved edge targets and never match, reding
+# every skill for a path-shape reason (#4505 T7).
+skills_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ ! -d "$skills_dir" ]; then
 	echo "FAIL: could not resolve the skills root from ${BASH_SOURCE[0]} — refusing to scan an unresolved root (ADR 0092)"
 	echo "validate-cycle-absence: FAILED — 1 error(s); the scan root could not be resolved"
@@ -69,6 +79,8 @@ errors=0
 checks=0
 scanned_skills=0
 declare -a scanned_paths=()
+declare -a surfaces=()
+declare -a edges=()
 
 fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
 ok() { echo "ok: $*"; checks=$((checks + 1)); }
@@ -100,18 +112,54 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 		continue
 	fi
 
+	# The source-edge widening, resolved UNPIPED so its status is readable. A named edge that will
+	# not resolve makes the surface UNKNOWN: red BY NAME rather than emit a confusing
+	# needle-not-found over a surface that was never finished (ADR 0230 rule 4; #4505 T7).
+	if ! edge_list="$(kp_skill_source_edges "$skills_dir" "$skill")"; then
+		fail "$skill: source-edge resolution failed (named diagnostic above) — the widened scan surface is UNKNOWN, so this skill was NOT evaluated (ADR 0230 rule 4 / ADR 0092)"
+		continue
+	fi
+	edges=()
+	while IFS= read -r edge; do
+		[ -n "$edge" ] && edges+=("$edge")
+	done <<EOF
+$edge_list
+EOF
+
 	scanned_skills=$((scanned_skills + 1))
 	for surface in "${surfaces[@]}"; do
 		scanned_paths+=("${surface#"$skills_dir/"}")
 	done
+	# Provenance in the emitted scope (ADR 0092 §1): an edge-resolved file is named with the skill
+	# whose source edge pulled it in, so "why was this file read" is answerable from the run log.
+	if [ "${#edges[@]}" -gt 0 ]; then
+		for edge in "${edges[@]}"; do
+			scanned_paths+=("${edge#"$skills_dir/"} (edge:$skill)")
+		done
+	fi
 
-	if ! grep -qF "$PROBE_NEEDLE" "${surfaces[@]}"; then
-		fail "$skill: does not cite the canonical cycle-doc probe ('$PROBE_NEEDLE') — every cycle-step must branch on the one well-known path (formats §1)"
+	if ! own_text="$(kp_surface_text "${surfaces[@]}")"; then
+		fail "$skill: could not read its own shell surface — UNKNOWN, never 'the marker is absent' (ADR 0092)"
+		continue
+	fi
+	probe_text="$own_text"
+	if [ "${#edges[@]}" -gt 0 ]; then
+		if ! edge_text="$(kp_surface_text "${edges[@]}")"; then
+			fail "$skill: could not read a source-edge target — UNKNOWN, never 'the marker is absent' (ADR 0092)"
+			continue
+		fi
+		probe_text="$own_text$edge_text"
+	fi
+
+	# Canonical-probe check: the ONE check that reads the widened surface.
+	if ! grep -qF "$PROBE_NEEDLE" <<<"$probe_text"; then
+		fail "$skill: does not cite the canonical cycle-doc probe ('$PROBE_NEEDLE') in executable shell or via a source edge — every cycle-step must branch on the one well-known path (formats §1)"
 	else
 		ok "$skill cites the canonical absence-probe"
 	fi
 
-	if ! grep -qiE "$noop_re" "${surfaces[@]}"; then
+	# The absent⇒no-op branch stays on the skill's OWN surface (#4505 T3).
+	if ! grep -qiE "$noop_re" <<<"$own_text"; then
 		fail "$skill: no absent⇒no-op branch found (expected /$noop_re/i) — an absent cycle doc must no-op gracefully (ADR 0062)"
 	else
 		ok "$skill has an absent⇒no-op branch"
@@ -133,7 +181,14 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 		fail "$skill: no shell surface resolved (no SKILL.md, no *.sh) — refusing to scan an empty surface (ADR 0092)"
 		continue
 	fi
-	if grep -qiE 'cycle (doc|step) (is )?(always|unconditionally)' "${surfaces[@]}"; then
+	# OWN surface, comment-stripped (#4505 T3/T2). This heuristic looks for a skill ASSERTING the
+	# doc is always there; widening it to shared files would blame every sourcing skill for one
+	# shared file's wording.
+	if ! own_text="$(kp_surface_text "${surfaces[@]}")"; then
+		fail "$skill: could not read its own shell surface for the hardcoded-flag heuristic — UNKNOWN, never 'clean' (ADR 0092)"
+		continue
+	fi
+	if grep -qiE 'cycle (doc|step) (is )?(always|unconditionally)' <<<"$own_text"; then
 		fail "$skill: appears to assume the cycle doc is always present — graceful absence requires the probe to gate it"
 	fi
 done

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
@@ -36,10 +36,17 @@
 set -uo pipefail
 
 # Same self-locating idiom as the presence twin: this script lives in the skills root, so its own
-# dir IS that root — resolve from BASH_SOURCE, PHYSICALLY (`cd -P`). The physical form is what the
-# source-edge allowlist needs: `skills/` is reached through the `.claude/skills` symlink, and a
-# LOGICAL root would be compared against physically-resolved edge targets and never match, reding
-# every skill for a path-shape reason (#4505 T7).
+# dir IS that root — resolve from BASH_SOURCE, PHYSICALLY (`cd -P`), because `skills/` is reached
+# through the `.claude/skills` symlink.
+#
+# What `-P` actually buys is the EMITTED SCOPE, not the allowlist. Measured: a logical-`cd` variant
+# through the symlink still exits 0, because `kp_skill_source_edges` resolves its own roots AND its
+# edge targets with `cd -P`, so that comparison is physical on both sides whatever it is handed.
+# What breaks under a logical root is the `${edge#"$skills_dir/"}` strip below: the prefix misses,
+# and every edge-resolved file is printed as a full absolute machine path instead of
+# `shared/scripts/cycle-doc-probe.sh (edge:plan-epic)`. That is an ADR 0092 §1 emission defect —
+# "what did this run look at" stops being answerable in repo terms — and a leak surface, since an
+# absolute path carries the runner's checkout layout into a CI log (#4505 T7).
 skills_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ ! -d "$skills_dir" ]; then
 	echo "FAIL: could not resolve the skills root from ${BASH_SOURCE[0]} — refusing to scan an unresolved root (ADR 0092)"

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
@@ -8,6 +8,22 @@
 # test only proves the absent path" as a confirmed instance of the class).
 #
 # This asserts the inverse, hermetically:
+# WHAT THIS PROVES, and over which surface (the split is load-bearing — ADR 0230, #4541).
+# Two surfaces, deliberately different:
+#   OWN      SKILL.md + every *.sh under the skill's own directory (kp_skill_shell_surfaces).
+#   WIDENED  OWN plus every shared file the skill's own files DEMONSTRABLY SOURCE, one hop
+#            (kp_skill_source_edges) — inclusion keyed on a live-parsed sourcing edge in the
+#            skill's own executable shell, not on directory membership.
+# ONLY the canonical-probe check reads the WIDENED surface. The present-gate and per-skill action
+# checks stay on OWN. That is not fussiness: the shared probe file textually contains every skill's
+# markers, so feeding the widened surface to every check would let ONE shared file satisfy EVERY
+# skill's per-skill check — #4470's blindness rebuilt through a legitimate edge.
+# So the probe check now proves: EITHER the skill's own executable surface carries the canonical
+# probe literal, OR its own surface sources a shared file that does. Real wiring, either way — and
+# a comment naming the path proves nothing, because every `.sh` grep here runs on COMMENT-STRIPPED
+# text. (Honest wording: a live-parsed sourcing edge reaching a file that carries the probe as
+# executable code. Not proof of execution — see kp_surface_text's residue note.)
+#
 #   1. STATIC wiring — each cycle-aware skill carries a PRESENT branch (CYCLE_DOC=present)
 #      paired with its present-path action, not just the absent no-op. Scanned across the
 #      skill's whole shell surface — SKILL.md AND its extracted scripts/*.sh (#4470):
@@ -83,6 +99,8 @@ errors=0
 checks=0
 scanned_skills=0
 declare -a scanned_paths=()
+declare -a surfaces=()
+declare -a edges=()
 
 fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
 ok() { echo "ok: $*"; checks=$((checks + 1)); }
@@ -116,24 +134,62 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 		continue
 	fi
 
+	# The source-edge widening, resolved UNPIPED so its status is readable. A named edge that will
+	# not resolve makes the surface UNKNOWN: red on it BY NAME here rather than fall through to a
+	# needle-not-found over a surface that was never finished (ADR 0230 rule 4; #4505 T7).
+	if ! edge_list="$(kp_skill_source_edges "$skills_dir" "$skill")"; then
+		fail "$skill: source-edge resolution failed (named diagnostic above) — the widened scan surface is UNKNOWN, so this skill was NOT evaluated (ADR 0230 rule 4 / ADR 0092)"
+		continue
+	fi
+	edges=()
+	while IFS= read -r edge; do
+		[ -n "$edge" ] && edges+=("$edge")
+	done <<EOF
+$edge_list
+EOF
+
 	scanned_skills=$((scanned_skills + 1))
 	for surface in "${surfaces[@]}"; do
 		scanned_paths+=("${surface#"$skills_dir/"}")
 	done
+	# Provenance in the emitted scope (ADR 0092 §1): an edge-resolved file is named with the skill
+	# whose source edge pulled it in, so "why was this file read" is answerable from the run log.
+	if [ "${#edges[@]}" -gt 0 ]; then
+		for edge in "${edges[@]}"; do
+			scanned_paths+=("${edge#"$skills_dir/"} (edge:$skill)")
+		done
+	fi
 
-	if ! grep -qF "$PROBE_NEEDLE" "${surfaces[@]}"; then
-		fail "$skill: does not cite the canonical cycle-doc probe ('$PROBE_NEEDLE') — the present branch must key off the one well-known path (formats §1)"
+	# Comment-stripped match text. `.sh` commentary is not wiring — the whole defect this closes was
+	# a docblock satisfying the probe grep (#4541).
+	if ! own_text="$(kp_surface_text "${surfaces[@]}")"; then
+		fail "$skill: could not read its own shell surface — UNKNOWN, never 'the marker is absent' (ADR 0092)"
+		continue
+	fi
+	probe_text="$own_text"
+	if [ "${#edges[@]}" -gt 0 ]; then
+		if ! edge_text="$(kp_surface_text "${edges[@]}")"; then
+			fail "$skill: could not read a source-edge target — UNKNOWN, never 'the marker is absent' (ADR 0092)"
+			continue
+		fi
+		probe_text="$own_text$edge_text"
+	fi
+
+	# Canonical-probe check: the ONE check that reads the widened surface.
+	if ! grep -qF "$PROBE_NEEDLE" <<<"$probe_text"; then
+		fail "$skill: does not cite the canonical cycle-doc probe ('$PROBE_NEEDLE') in executable shell or via a source edge — the present branch must key off the one well-known path (formats §1)"
 	else
 		ok "$skill cites the canonical cycle-doc probe"
 	fi
 
-	if ! grep -qiE "$PRESENT_GATE_RE" "${surfaces[@]}"; then
+	# Every remaining check stays on the skill's OWN surface (#4505 T3).
+	if ! grep -qiE "$PRESENT_GATE_RE" <<<"$own_text"; then
 		fail "$skill: no present-resolution of the cycle probe found (expected /$PRESENT_GATE_RE/i) — the present-path action must be gated on the doc being present"
 	else
 		ok "$skill resolves the probe to present"
 	fi
 
-	if ! grep -qiE "$action_re" "${surfaces[@]}"; then
+	if ! grep -qiE "$action_re" <<<"$own_text"; then
 		fail "$skill: no present-path action found (expected /$action_re/i) — the cycle's present branch must DO something (ADR 0091/0092), not just no-op"
 	else
 		ok "$skill carries its present-path action (/$action_re/i)"


### PR DESCRIPTION
Fixes #4541

Implements ADR 0230's ruled shape (1) — *cycle validators follow the source edge* — under the seven binding ACs of #4505's threat-model review ([comment 5128184946](https://github.com/kamp-us/phoenix/issues/4505#issuecomment-5128184946)). The ruled shape was not re-derived.

## Round 2 — the head has moved, so both advisories at `90779fc2` are VOID

The two advisory PASSes (`review-skill` [5129481034](https://github.com/kamp-us/phoenix/pull/4548#issuecomment-5129481034), `review-doc` [5129486857](https://github.com/kamp-us/phoenix/pull/4548#issuecomment-5129486857)) are bound to head `90779fc2`. This round pushes a new head, so under ADR 0058 they are **staleness-invalidated — they do not apply to the current tree** and both gates need a fresh run against the new head. Nothing they verified was touched: the fail-open reproduction, the mutation kill, AC5's vacuity, the hop-cap deviation and #4531's `find`-status handling are all byte-unchanged.

What this round adds, acting on the `review-skill` advisory's explicit recommendation:

1. **The `common.sh` credit pin** (`common-test.sh` case 17). `shared/lib/common.sh` is edge-resolved into **all four** cycle-aware skills' widened surfaces — the emitted scope line names it `(edge:plan-epic)`, `(edge:write-code)`, `(edge:review-code)`, `(edge:ship-it)` — because every skill sources it unconditionally, for reasons unrelated to the cycle. One probe literal in its executable text would therefore green the canonical-probe check for four skills at once. ADR 0230's blessing of shared credit was written for `shared/scripts/cycle-doc-probe.sh`, a file whose only purpose *is* the probe; it does not transfer to a file everybody sources, where "demonstrated dependency" degenerates into "everybody sources it" — directory membership by another name, which is what rule 1 exists to reject. The pin asserts the **shipped** lib carries zero occurrences of the literal, keyed on the same comment-stripped text the validators grep (so a mention in prose is correctly not a violation). **Falsifiable, both directions observed:** planted as executable code, the suite exits **1** naming the file; plant removed, it exits **0**, 17/17.
2. **The refusal set is derived, not listed.** Deleting the refusal block and re-running showed **four** cases false-pass on 127 — unreadable-surface, broken-edge, sibling-edge, non-idiom-source; in each, `command not found` on stderr satisfies the "named diagnostic" assertion — so a fourth function added later silently reopened the class the refusal closes. The set is now derived from this file's own raw text (`kp_[a-z][a-z0-9_]*`, `kp__` privates excluded), which **over-includes** — a name appearing only in a message string is still required to exist — and over-inclusion is the fail-closed direction. An empty derivation is UNKNOWN and refuses. Proven on a scratch copy: renaming `kp_surface_text` in the lib **and** introducing a fourth name a hardcoded list would have missed both fire, naming each, exit 1 with no case run.
3. **Two docblocks corrected to claim only what they prove.** (a) The `-P` fix is load-bearing for the **emitted scope**, not the allowlist: `kp_skill_source_edges` resolves its roots and its targets with `cd -P`, so the comparison is physical on both sides and a logical run still exits 0. What breaks is the `${edge#"$skills_dir/"}` strip — every edge-resolved file then prints as a full absolute machine path instead of `shared/scripts/cycle-doc-probe.sh (edge:plan-epic)`, which is an ADR 0092 §1 emission defect **and** a leak surface (an absolute path carries the runner's checkout layout into a CI log). (b) `kp_surface_text`'s residue claim is no longer stated as one-directional: on a line with an unbalanced double quote the scan stays in-quote and a following `#` comment **survives** — the fail-open direction. That sits inside T8's accepted residue (shellcheck reds the unbalanced quote; deception is §CP review's threat, drift is this guard's), so it is a wording fix, not a defect.

`review-code/scripts/cycle-doc-probe.sh` is **not** converted onto the shared probe — that remains held under #4546 and tracked in #4549, so AC5 stays vacuous exactly as ruled.

## The fail-open, reproduced at this PR's own base

Base `ce1684d6`, before any edit:

```
$ bash claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
ok: plan-epic cites the canonical cycle-doc probe
...
validate-cycle-presence: OK — 18 checks; phoenix's present cycle-doc path is real
EXIT=0

$ grep -rnF "contents/product-development-cycle.md" claude-plugins/kampus-pipeline/skills/plan-epic/
plan-epic/scripts/cycle-doc-probe.sh:10:# content read of `contents/product-development-cycle.md` — and leaves $CYCLE_DOC in this shell.
```

One match across the entire skill, and it is a docblock comment. The guard was passing on its own commentary.

**The mutation, measured both ways.** Delete plan-epic's `source` of the shared probe, keep the comment:

| tree | validator | result |
| --- | --- | --- |
| base `ce1684d6` | pre-fix | `EXIT=0` — `ok: plan-epic cites the canonical cycle-doc probe` |
| base `ce1684d6` | this PR | `EXIT=1` — `FAIL: plan-epic: does not cite the canonical cycle-doc probe ... in executable shell or via a source edge` |
| unmutated | this PR | `EXIT=0`, 18 checks (presence) / 14 checks (absence) |

## What changed

**`shared/lib/common.sh`**

- `kp_skill_source_edges` — a skill's scan surface widens across the shared files its own executable text **sources**, one hop, widen-never-replace. Inclusion keys on *demonstrated dependency*, never directory membership; that is what preserves #4470's property, and a skill that sources nothing gains nothing (pinned).
- The sourcing idiom in this lib's own header is promoted from style note to **machine contract** (AC1/T1): column 0, single line, literal relative directory, literal `.sh` name. A source line naming a `shared/` target in any other shape is not statically resolvable, so it is UNRESOLVED and reds **by name** rather than narrowing in silence. A source line that names no `shared/` target is not an edge claim and is simply not followed — safe by construction, since this function only ever *adds* files, so an unfollowed line yields a narrower surface, which can only make a presence grep fail.
- Fail-closed, nothing on stdout, named diagnostic on stderr for: unresolvable skill dir, unresolvable edge directory, missing target file, and a target outside the followed-target allowlist — the skill's own dir, `shared/scripts/`, `shared/lib/` — compared physical-path to physical-path (AC4/T4, AC6/T7, ADR 0092).
- `kp_surface_text` — every `.sh`-surface grep now runs on **comment-stripped** text (AC2/T2). Quote-aware and strictly per-line: `${var#pat}`, a `*#*)` case pattern and a `#` inside a string all survive, and no heredoc can desync the scan (worst case it drops a `#` tail, which removes text — the fail-closed direction).
- bash-3.2 mechanics (AC6/T6): no `declare -A` (the visited set is a newline-delimited string with linear membership), an explicit declared hop cap, `set -uo pipefail` with no `-e` and no EXIT trap, every `find`/`grep`/`sed`/`awk`/`cd` status checked. #4531's `find`-status handling is built on, not duplicated.

**Both validators**

- Only the canonical-probe check reads the widened surface (AC3/T3). The present-gate, per-skill action, absent⇒no-op and hardcoded-flag checks stay on the skill's **own** files. This is the load-bearing half: `shared/scripts/cycle-doc-probe.sh` textually carries *every* skill's markers, so feeding the widened surface to every check would let one shared file satisfy all four — #4470 rebuilt through a legitimate edge. Both docblocks now state the split and what each surface proves.
- The emitted `scanned scope` names each edge-resolved file with the skill whose edge pulled it in, e.g. `shared/scripts/cycle-doc-probe.sh (edge:plan-epic)` (AC6/T7).
- `validate-cycle-absence.sh` self-locates **physically** (`cd -P`), matching its presence twin — edge targets resolve physically, so a logical root would be compared against them and never match under the `.claude/skills` symlink (AC6/T7). Verified green invoked through the symlink, the way CI invokes it.

**Proof claim wording (AC7/T8)** — what the probe check now establishes: *either the skill's own executable surface carries the canonical probe literal, or its own surface holds a live-parsed sourcing edge reaching a file that carries it as executable code.* Not proof of execution. Dead-code plants (a needle in an `if false` block or a `.sh` heredoc) are out of this guard's scope and are delegated to §CP review of `skills/**` on the record, in `kp_surface_text`'s docblock.

**`shared/lib/common-test.sh`** — twelve new falsification cases (CI already runs this file): comment stripping vs. every non-comment `#`; a comment naming the shared path resolving **no** edge; a commented-out source line following nothing; a broken edge, a sibling-skill edge and an interpolated `shared/` source line each refusing with empty stdout + a named diagnostic; a skill that sources nothing keeping exactly today's surface; an own-directory edge allowlisted and not duplicated; one-hop-only. The file also refuses to run at all when a function under test is absent — a missing function exits 127, which several of these cases would otherwise read as a correct fail-closed refusal and report as a **pass**.

**Falsification, measured.** The new pin against the pre-fix `common.sh`: `FAIL: kp_surface_text is not defined ... Refusing to run them. EXIT=1`. Against this PR's `common.sh`: all 16 checks pass.

**Docs.** `plan-epic/scripts/cycle-doc-probe.sh`'s docblock claimed its citation "is what keeps the cycle validators scanning a real reference" — true, and that was the bug; corrected to name the source line as the load-bearing token. `.patterns/skill-derived-guards.md` gains the edge-vs-directory distinction ADR 0230 item 4 asks for.

## Deviations

1. **`review-code/scripts/cycle-doc-probe.sh` is NOT converted to source the shared probe** — the one deliberate scope cut. The threat model lists that conversion (and T5's regex re-key that follows it), and ADR 0230 notes the copy "becomes removable". It is held: converting it **mints a new `. "$(…)/cycle-doc-probe.sh"` sourced invocation in a skill script**, which is exactly what the open programme-level question about `.`-sourcing under `isolation:worktree` (#4546) is holding. That hold was confirmed live during this build — the harness refused `. "$WRITECODE_SCRIPTS/step4-preflight.sh"` outright. ADR 0230 item 3 states no skill edit is *required* to stay green, and none is: `review-code` keeps its own executable copy and stays green on its own surface. Its docblock is corrected in place — it previously justified the copy by a forcing constraint this PR removes — and now records the copy as removable-but-held, citing #4546. **Consequence for AC5 (T5):** zero skills are migrated in this PR, so the re-key is vacuous; enumerated per skill: plan-epic (already sourcing, no regex change needed — its own-surface `no-?op`, `cycle doc present` and present-gate matches all survive comment-stripping, measured), write-code / review-code / ship-it (not migrated, unchanged). No validator regex changed. A follow-up carries the conversion once #4546 resolves.

2. **The widening lands in a new `kp_skill_source_edges` rather than inside `kp_skill_shell_surfaces`.** ADR 0230's implementation note item 1 puts it in the existing resolver ("one resolver, one widening, all six greps"). The threat model's AC3/T3 — which the issue names as the *authoritative* AC list — forbids feeding the widened surface to all six greps. Since four of the six checks need the own-surface list anyway, widening in place would force both validators to immediately re-narrow, so the two lists are returned by two named functions and the union happens **at the one call site that needs it**. That makes the security-relevant split visible where it matters instead of hidden in a mode flag. ADR 0230's substance is kept: the resolution lives in `common.sh`, next to the idiom that defines it.

3. **Hop cap is 1, not T6's suggested ~4.** T6 suggested a cap of ~4 with RED on exceed; ADR 0230 rule 2 rules *one hop, no transitive closure*, and a literal two hops deep is a FAIL whose fix is to source it directly. The ADR's rule wins over the mechanics suggestion. `KP_EDGE_MAX_HOPS=1` is a declared constant driving a generic bounded loop, so the cap is mechanical and raising it is a deliberate one-line decision — no unreachable "RED on exceed" branch was added, since with the ruled cap it could never fire.

4. **Comment stripping is per-line and quote-aware, not parser-grade.** A needle planted inside a `.sh` heredoc or an `if false` block still reads as code. T8 accepts this explicitly and delegates it to §CP review; it is stated in the code rather than glossed.

5. **Two accepted false-RED shapes, per T9, now documented in `common.sh`:** the `source` keyword form and a trailing `|| exit 1` on a source line both fail the idiom match, so if either named a `shared/` target it would red toward the canonical single-line idiom. Neither shape is live in the corpus for a `shared/` target (verified across all 4 cycle-aware skills). The column-0 anchoring is what keeps `plan-epic/scripts/verify-extraction.sh:177` — a tab-indented `shared/lib/common.sh` source line inside a heredoc — from false-reding today.

6. **No `shared/` relocation.** Sequencing per triage: this lands before #4484, which carries the repoint.

7. **(repair round 2)** **The branch was rebased onto `main` at `1456a64a`** (clean, no conflict) before the round's fixes, per the freshen-the-base rule. The head therefore moved for two reasons, not one, and both prior advisories are void.
8. **(repair round 2)** **The round's own diff departs from nothing else.** The `common.sh` pin was added rather than deferred to a follow-up ticket, which is a *narrower* cut than round 1 declared; no reviewer suggestion was declined; no pre-existing test was changed (case 17 is additive, and the refusal generalization changes how its set is obtained, not what it asserts); no hook was pushed past.
9. **(repair round 2)** **The `-P` docblock correction weakens a claim.** It previously asserted a logical root would red every skill; measured, a logical run still exits 0. The stated justification is now the emission/leak defect, which is a *smaller* claim than the one it replaces — recorded because a guard's docblock claiming less than before is exactly the kind of change a later reader should be able to see was deliberate.

## Verification run

- `validate-cycle-presence.sh` — OK, 18 checks (direct and through `.claude/skills`).
- `validate-cycle-absence.sh` — OK, 14 checks (direct and through `.claude/skills`).
- `shared/lib/common-test.sh` — all 16 checks pass; RED against pre-fix `common.sh`.
- `validate-skills.sh` — OK, 30 skills. `validate-gate-path-drift.sh` — OK, 34 checks.
- `pipeline-cli trap-status-guard check` over the CI file set — clean, 286 files / 320 fences / 210 shell units (both axes non-zero). Handed my 6 changed `.sh` files as a bash **array**; it reported `scanned 6 file(s)`, matching the count handed.
- `shellcheck` clean on all six changed `.sh` files; the two `SC2016` sites are declared per file with the reason (both are literal `awk`/`sed` program text).
- `leak-guard` (pre-commit) — clean, 7 files, no user-local paths.

### Round 2, re-run at the new head (rebased onto `1456a64a`)

- `shared/lib/common-test.sh` — **17/17**, exit 0. With the probe literal planted in `common.sh` as executable code: exit **1**, one FAIL naming the file and the literal. Plant removed: exit **0** again.
- Refusal-set derivation, on a scratch copy: `kp_surface_text` renamed in the lib **plus** a fourth `kp_` name introduced in the test — both reported by name, exit 1, no case executed.
- `validate-cycle-presence.sh` — OK, 18 checks. `validate-cycle-absence.sh` — OK, 14 checks. Both scope lines print repo-relative paths (the `-P` emission property the corrected docblock now claims).
- `pipeline-cli trap-status-guard check` invoked exactly as `trap-status-guard.yml` does — clean, 286 files / 320 fences / 210 shell units, both axes non-zero.
- `pipeline-cli leak-guard scan` over the round's 3 changed files, handed as separate argv words — `3 file(s) handed: 0 doc surface, 3 shell surface`, clean; scope line matches the files handed.
- `shellcheck` — clean on all three files this round touches.
- Shell shape unchanged: `set -uo pipefail`, no `-e`, no EXIT trap added.

## §CP

`pipeline-cli cp-classify classify` (file list on **stdin**) → exit 0, `control-plane [path-match]`. Human `@kamp-us/control-plane` approval at head; no auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

