### PR TITLE
fix(ship-it): the sourced chain runs as written — three dropped source lines and the §CP seam (#4547)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,6 +600,15 @@ jobs:
       # Same script runs locally: `bash .claude/skills/shared/lib/common-test.sh`.
       - run: bash .claude/skills/shared/lib/common-test.sh
 
+      # Executable pin for ship-it's sourced chain (#4547): every function a step script
+      # calls must be defined in-chain, and Step 2's §CP seam must pass the caller's
+      # $CP_FLAG through to `verdict gate`. The extraction dropped three source lines and
+      # hardcoded the seam empty, and nothing in the repo noticed for a week — ship-it is
+      # the single merge authority (ADR 0048/0135), so its chain not running as written
+      # is a merge-path defect. Hermetic: gh and the CLI shim are stubbed, no network.
+      # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh`.
+      - run: bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh
+
       # Gate-path drift guard (issue #720): assert the five CONTROL_PLANE_RE= copies
       # in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats are
       # byte-identical to the §CP canonical line, and that .claude/skills resolves to

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -344,8 +344,18 @@ UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
   [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md),
   amending 0053's merge model). Run the **deterministic §CP cardinality check** (the
   [§CP approval gate](#step-0-cp-approval-gate) below, ADR 0175):
-  - **discharge** → the human-judgment gate is satisfied; **carry on** into Step 2's normal machine
-    gates (matching-gate SHA-bound PASS, CI green, run-evidence). Once those pass, ENQUEUE exactly
+  - **discharge** → the human-judgment gate is satisfied; **set the Step-2 §CP seam**, then **carry
+    on** into Step 2's normal machine
+    gates (matching-gate SHA-bound PASS, CI green, run-evidence). The seam is one assignment in this
+    same shell, and this is its **only** sanctioned site — a §CP PR's pass path is the SHA-less
+    advisory, which `verdict gate` counts only under `--cp` (Step 2), and the discharge is exactly
+    the condition that licenses it:
+
+    ```bash
+    CP_FLAG=--cp   # §CP classified AND approval discharged — the ONLY state that sets this (#4547)
+    ```
+
+    Once those pass, ENQUEUE exactly
     like a non-§CP PR (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method;
     QUEUED → auto-merges on green; §CP PRs now
     enter the ADR 0132 queue too). §CP carries **one extra** gate — the team approval — layered on
@@ -395,9 +405,10 @@ UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
   **Every input to this gate is a fallible READ, and an unresolved one is UNKNOWN — never a
   cardinality, never "the team is empty", never `awaiting control-plane approval` (#4223).** All four
   — roster, author, head, per-approver membership — come from **§CPREAD** / **§CPREAD-APPROVAL** of
-  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); copy those helpers verbatim from
-  there (single source; the why, and the measurement behind it, live there, not here). Each failure
-  branch stops under a message that names the read that failed.
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), which the step script sources
+  in-chain from their extracted home, `../shared/scripts/cp-read.sh` (single source; the why, and the
+  measurement behind it, live there, not here — and no paste step for the shipper to forget, #4547).
+  Each failure branch stops under a message that names the read that failed.
 
   ```bash
   . "$SHIPIT_SCRIPTS/step0-cp-approval.sh"
@@ -617,8 +628,15 @@ The required set is **derived, never eyeballed** — the same `class-probe` outp
 dispatches off, so `dispatched-gate == required-gate` holds by construction:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step2-verdict-gate.sh"
+. "$SHIPIT_SCRIPTS/step2-verdict-gate.sh"   # reads $CP_FLAG from this shell — set ONLY by Step 0's §CP discharge
 ```
+
+**The one input this step takes is `$CP_FLAG`, and it is already set (or deliberately unset) by the
+time you get here.** Step 0's §CP discharge branch is its only writer; every other path leaves it
+unset, which the script reads as the non-§CP branch. So this source line takes no argument and needs
+no hand-substituted value — run it as written. Setting `CP_FLAG` here, from your own reading of the
+diff, is the [defect this seam replaced](https://github.com/kamp-us/phoenix/issues/4547): it puts the
+§CP decision back where an eyeball makes it, next to the verb that is supposed to be handed it.
 
 **Why a verb and not a careful read.** The rule below was already correct in prose ("docs present
 but the review-doc namespace is empty → `unverified (no review-doc PASS)`"), but nothing *computed*

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
@@ -10,13 +10,18 @@
 # and leaves its variables and functions in the sourcing shell, which is how the step's later
 # blocks still see them.
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+# §CPREAD's `cp_changed_files` / `cp_head_sha`, sourced IN-CHAIN from their canonical home — the
+# extraction dropped this line and left both calls below command-not-found (#4547). Same idiom as
+# review-code's `classify-control-plane.sh`; never a re-copy of the helpers.
+# shellcheck source=../../shared/scripts/cp-read.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
 
 # The changed-file list is a fallible network READ, and EVERY probe in this step — §CP, the ADR
 # content clause, has-code/has-docs/has-skills, has-ui — is a `grep` over it. So a failed read used
 # to answer "no §CP path, no classes present" in one stroke: the capture's exit status was never
 # checked, and an empty $FILES made every `grep -q … && echo …` silent (#4216). `cp_changed_files` is
-# §CPREAD of ../gh-issue-intake-formats.md — copy it (and its `cp_head_sha` companion, used by the
-# content clause below) verbatim from there (single source; the why lives there, not here). --paginate + streaming --jq inside it gets the full set past file #100 (the
+# §CPREAD of ../gh-issue-intake-formats.md (and `cp_head_sha`, used by the content clause below, is
+# its companion), both sourced in-chain above (single source; the why lives there, not here). --paginate + streaming --jq inside it gets the full set past file #100 (the
 # API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725).
 if ! cp_changed_files "$REPO" "$PR"; then
   # FAIL CLOSED, and STOP — with no file list there is no classification to make: not §CP, not the
@@ -56,8 +61,8 @@ elif [ "$CP_STATE" = "content-undetermined" ]; then
   # the driver (via trivial-diff) run (#3645, founder ruling #3416) — so a guard-touching ADR
   # classifies §CP identically at every stage, not just here. The GUARD_ADR_RE vocabulary stays
   # single-sourced in gh-issue-intake-formats.md §CP.
-  # The ref is a fallible read — `cp_head_sha` is §CPREAD's companion to `cp_changed_files` (copy it
-  # verbatim from there). It DISCARDS gh's payload on failure, which is what makes the emptiness
+  # The ref is a fallible read — `cp_head_sha` is §CPREAD's companion to `cp_changed_files` (same
+  # in-chain source). It DISCARDS gh's payload on failure, which is what makes the emptiness
   # test below a live guard: with a bare `|| true` the error document lands in HEAD_SHA, non-empty.
   cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
   if [ -z "$HEAD_SHA" ]; then

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh
@@ -10,6 +10,12 @@
 # and leaves its variables and functions in the sourcing shell, which is how the step's later
 # blocks still see them.
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+# §CPREAD + §CPREAD-APPROVAL's `cp_team_roster` / `cp_pr_author` / `cp_head_sha` /
+# `cp_team_membership`, sourced IN-CHAIN. SKILL.md documents a verbatim-paste precondition ahead of
+# this step, which is a real precondition but still a hand step the shipper has to remember — the
+# same one line that repairs its two naked siblings discharges it structurally here too (#4547).
+# shellcheck source=../../shared/scripts/cp-read.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh
@@ -10,6 +10,11 @@
 # and leaves its variables and functions in the sourcing shell, which is how the step's later
 # blocks still see them.
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/lib" && pwd)/common.sh"
+# §RO-iso's `iso_preflight`, sourced IN-CHAIN from its canonical home — the extraction dropped this
+# line and left the call below command-not-found (#4547). Same idiom as review-code's
+# `materialize-head.sh`; never a re-copy of the function.
+# shellcheck source=../../shared/scripts/iso-preflight.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/iso-preflight.sh"
 
 # The one seam this move needed: the block's `PR=<pr number>` placeholder was filled by whoever ran
 # the step, so the sourcing site passes it instead — `. "$SHIPIT_SCRIPTS/step0-preflight.sh" <pr number>`.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh
@@ -38,7 +38,24 @@ echo "ship-it guard 1: PR $PR requires $(printf '%s\n' "$REQUIRED_NS" | grep -c 
 # `Reviewed-head` line (ADR 0111/0151) — pass --cp so that form counts, and ONLY then. Set this from
 # Step 0's own classification (it printed `BLOCKING (…)` for a §CP path/content hit) AND only after
 # Step 0's approval gate discharged; leave it empty for every non-§CP PR.
-CP_FLAG=""   # → "--cp" iff Step 0 classified this PR §CP and its control-plane approval discharged
+#
+# THE SEAM (#4547). $CP_FLAG arrives from the CALLER's shell — Step 0 sets `CP_FLAG=--cp` on the §CP
+# discharge branch and nothing sets it otherwise. A caller-set variable rather than a positional,
+# because this value is DERIVED by an earlier step of the same sourced chain (like $PR and $REPO,
+# which already reach here that way), whereas step0-preflight.sh's `$1` is the run's ENTRY value that
+# no earlier step could have set. A positional here would put the §CP/non-§CP choice back at the
+# source site as something the shipper types by hand — the hand-substitution this seam removes.
+# Unset ⇒ empty ⇒ the non-§CP branch, which is the STRICTER one (the SHA-less advisory does not
+# count), so an omitted seam can only refuse a §CP PR, never pass one.
+CP_FLAG="${CP_FLAG:-}"
+case "$CP_FLAG" in
+  ""|"--cp") ;;
+  # A third value is not a classification. It would reach `verdict gate` as an unrecognized flag —
+  # help text plus a non-zero exit, refused below with the wrong reason named. Refuse here instead,
+  # naming the real one (§ZS: an uninterpretable input is UNKNOWN, never the permissive branch).
+  *) disarm_intent refuse || INTENT_UNCLEARED=1
+     echo "ship-it: refused at guard 1 — CP_FLAG is '$CP_FLAG'; the only values this seam accepts are '' (non-§CP) and '--cp'. An unrecognized value is UNKNOWN, not a classification. NOT enqueued." >&2; exit 1 ;;
+esac
 "$PCLI" verdict gate --pr "$PR" --require "$REQUIRED" $CP_FLAG || {
   disarm_intent refuse || INTENT_UNCLEARED=1
   echo "ship-it: refused at guard 1 — see the named reason above; NOT enqueued."; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-chain-resolves.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-chain-resolves.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1090,SC1091,SC2016,SC2086
+# SC2086 is deliberate throughout: `$SCRIPTS` and `$(sourced_by …)` are whitespace-separated lists
+# whose splitting IS the iteration. The `$#`-eq-0 test after `set -- $SCRIPTS` is the zero-scope
+# guard that would otherwise be the reason to prefer an array.
+# Reviewer-runnable proof that ship-it's sourced chain RUNS AS WRITTEN — the property #4547 found
+# false in three places at once. Three checks, one per defect shape, each falsifiable:
+#
+#   1. STATIC — every function a `ship-it/scripts/*.sh` calls is defined in that file, in something
+#      that file sources, or in a script SKILL.md sources EARLIER in the chain. This is issue
+#      #4547's fourth acceptance criterion, mechanized: an extraction that drops a source line
+#      leaves a call that resolves nowhere, and nothing else in the repo notices.
+#   2. EXECUTABLE — the Step-0 scripts are actually sourced, against stubbed `gh` / `pipeline-cli`,
+#      and their stderr must carry no `command not found`. The static check says a name resolves;
+#      this one says the shell agrees. Neither subsumes the other: static covers branches a run
+#      does not take, executable covers resolution the regex could get wrong.
+#   3. SEAM — `step2-verdict-gate.sh` must PASS THROUGH the caller's `$CP_FLAG`. Asserted on what
+#      the stub `pipeline-cli` was actually handed, not on the script's text: `--cp` present when
+#      the caller set it, absent when it did not, and a refusal on any third value.
+#
+# Hermetic: every network call is stubbed, so this needs no `gh` auth and touches no repo state.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-chain-resolves.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, and no
+# `EXIT` trap — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this
+# harness's whole contract is its exit status.
+set -uo pipefail
+
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SKILLS="$(CDPATH= cd -- "$DIR/../.." && pwd)"
+SKILL_MD="$DIR/../SKILL.md"
+fail=0
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------------------------
+# scope
+# ---------------------------------------------------------------------------------------------
+SCRIPTS=""
+for f in "$DIR"/*.sh; do
+	[ -f "$f" ] || continue                       # bash 3.2 has no nullglob here
+	case "$(basename "$f")" in verify-*) continue ;; esac
+	SCRIPTS="$SCRIPTS $f"
+done
+set -- $SCRIPTS
+if [ "$#" -eq 0 ]; then
+	echo "FAIL: zero scope — no ship-it step script resolved under $DIR (ADR 0092)"
+	exit 1
+fi
+echo "scope: $# step script(s) under skills/ship-it/scripts, SKILL.md at skills/ship-it/SKILL.md"
+
+# ---------------------------------------------------------------------------------------------
+# 1. STATIC — every cross-file call resolves in-chain
+# ---------------------------------------------------------------------------------------------
+# The candidate names are the CROSS-FILE helper surface: everything defined in shared/lib,
+# shared/scripts, or a ship-it step script. A name defined only inside the file that calls it is
+# reachable by construction and needs no check; names from unrelated skills are out of scope, and
+# including them would match prose words (`fail`, `check`, `ok`) inside message strings.
+defs_in() { grep -oE '^[a-zA-Z_][a-zA-Z0-9_]*\(\)' "$1" 2>/dev/null | sed 's/()$//'; }
+
+CANDIDATES="$TMP/candidates"
+: > "$CANDIDATES"
+for f in "$SKILLS"/shared/lib/*.sh "$SKILLS"/shared/scripts/*.sh "$DIR"/*.sh; do
+	[ -f "$f" ] || continue
+	# `verify-*` / `*-test.sh` are harnesses, not helper surface: their private `ok`/`fail`
+	# assertion shims are not names a step script could ever be calling.
+	case "$(basename "$f")" in verify-*|*-test.sh) continue ;; esac
+	defs_in "$f" >> "$CANDIDATES"
+done
+sort -u "$CANDIDATES" -o "$CANDIDATES"
+CAND_N="$(grep -c . "$CANDIDATES" || true)"
+if [ "$CAND_N" -eq 0 ]; then
+	echo "FAIL: zero scope — no candidate helper name resolved; the audit would be vacuously green (ADR 0092)"
+	exit 1
+fi
+echo "scope: $CAND_N cross-file helper name(s) in the candidate set"
+
+# The files a script pulls in itself. Only the canonical in-chain form is recognized; anything else
+# that looks like a source line is reported UNRESOLVED rather than assumed harmless (§ZS).
+sourced_by() {
+	sed -n 's|^\. "\$(CDPATH= cd -- "\$(dirname -- "\${BASH_SOURCE\[0\]}")/\(.*\)" && pwd)/\(.*\)"$|\1/\2|p' "$1" \
+		| while IFS= read -r rel; do
+			[ -z "$rel" ] && continue
+			printf '%s\n' "$(CDPATH= cd -- "$(dirname -- "$1")" && pwd)/$rel"
+		done
+}
+
+# The chain order SKILL.md itself establishes: a script sourced EARLIER in the doc has left its
+# functions in the agent's shell by the time a later step runs. This is what makes
+# `disarm_intent` — defined in disarm-intent.sh, sourced in SKILL.md's preamble — legitimately
+# reachable from every step without any step sourcing it.
+skill_md_line_of() {   # $1 = script basename; prints the line number of its SKILL.md source, or 0
+	grep -n "SHIPIT_SCRIPTS/$1\"" "$SKILL_MD" 2>/dev/null | head -n1 | cut -d: -f1
+}
+
+for s in $SCRIPTS; do
+	base="$(basename "$s")"
+	reach="$TMP/reach"
+	: > "$reach"
+	defs_in "$s" >> "$reach"
+	for dep in $(sourced_by "$s"); do
+		if [ ! -f "$dep" ]; then
+			printf 'BAD   %-26s sources a file that does not exist: %s\n' "$base" "$dep"
+			fail=1
+			continue
+		fi
+		defs_in "$dep" >> "$reach"
+		for dep2 in $(sourced_by "$dep"); do
+			[ -f "$dep2" ] && defs_in "$dep2" >> "$reach"
+		done
+	done
+	# every source-looking line must have been recognized, or the reachable set is under-counted
+	src_lines="$(grep -cE '^[[:space:]]*(\.|source) ' "$s" || true)"
+	src_resolved="$(sourced_by "$s" | grep -c . || true)"
+	if [ "$src_lines" -ne "$src_resolved" ]; then
+		printf 'BAD   %-26s %s source line(s), %s resolved — an unrecognized source shape is UNKNOWN\n' \
+			"$base" "$src_lines" "$src_resolved"
+		fail=1
+	fi
+	# chain predecessors, per SKILL.md's own order
+	mine="$(skill_md_line_of "$base")"
+	[ -z "$mine" ] && mine=0
+	for other in $SCRIPTS; do
+		ob="$(basename "$other")"
+		[ "$ob" = "$base" ] && continue
+		ol="$(skill_md_line_of "$ob")"
+		[ -z "$ol" ] && continue
+		[ "$mine" -eq 0 ] && continue
+		[ "$ol" -lt "$mine" ] && defs_in "$other" >> "$reach"
+	done
+	sort -u "$reach" -o "$reach"
+	# calls: a candidate name in command position — not on a comment-only line, not its own
+	# definition, and with trailing `#…` comments stripped so a name merely MENTIONED after code
+	# is not read as a call.
+	body="$TMP/body"
+	grep -v '^[[:space:]]*#' "$s" | sed 's/[[:space:]]#.*$//' > "$body"
+	while IFS= read -r name; do
+		[ -z "$name" ] && continue
+		grep -q "^${name}$" "$reach" && continue
+		# `=` in the excluded prefix set: `VAR=ok` is a value, not a call.
+		if grep -qE "(^|[^=A-Za-z0-9_./\"'-])${name}([[:space:]]|\$)" "$body"; then
+			printf 'BAD   %-26s calls %s — defined in no file this chain sources\n' "$base" "$name"
+			fail=1
+		fi
+	done < "$CANDIDATES"
+done
+echo "=== 1. static: every cross-file call resolves in-chain — see BAD lines above, if any"
+
+# ---------------------------------------------------------------------------------------------
+# stubs — a hermetic gh + pipeline-cli, so checks 2 and 3 run offline
+# ---------------------------------------------------------------------------------------------
+BIN="$TMP/bin"
+PLUGIN="$TMP/plugin/bin"
+mkdir -p "$BIN" "$PLUGIN" || { echo "FAIL: cannot create the stub dirs under $TMP"; exit 1; }
+
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+# Hermetic `gh`: a changed-file list for the files endpoint, an empty (but successful) body for
+# everything else. The scripts under test read both through their own fail-closed wrappers.
+for a in "$@"; do
+  case "$a" in
+    */pulls/*/files*) printf 'claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md\napps/web/src/App.tsx\n.decisions/0001-example.md\n'; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+
+cat > "$PLUGIN/pipeline-cli" <<'STUB'
+#!/usr/bin/env bash
+# Hermetic shim: records its argv so a caller can assert what it was HANDED, then answers each
+# verb with a well-formed state word. Recording is the point — check 3 reads this file.
+[ -n "${PCLI_CALLS:-}" ] && printf '%s\n' "$*" >> "$PCLI_CALLS"
+case "${1:-}" in
+  class-probe)          cat > /dev/null; printf 'skill\n' ;;
+  # `content-undetermined` on purpose: it is the branch that reaches `cp_head_sha`, so the
+  # executable check covers BOTH §CPREAD helpers rather than just the one on the happy path.
+  cp-classify)          cat > /dev/null; printf 'content-undetermined\n' ;;
+  guard-content-probe)  cat > /dev/null; printf 'not-guard-touching\n' ;;
+  cp-cardinality)       cat > /dev/null ;;
+esac
+exit 0
+STUB
+chmod +x "$BIN/gh" "$PLUGIN/pipeline-cli"
+
+# ---------------------------------------------------------------------------------------------
+# 2. EXECUTABLE — sourcing the Step-0 scripts resolves every function they call
+# ---------------------------------------------------------------------------------------------
+# One driver invocation PER script, never one chained run: a script whose first unresolved call
+# exits would otherwise take its successors' coverage down with it, and the harness would report a
+# narrower scan as a clean one. Each run stands the script up on SKILL.md's own preamble
+# (`disarm-intent.sh`) plus the two values Step 0 resolves, and nothing else.
+cat > "$TMP/drive-one.sh" <<'DRV'
+REPO="owner/repo"
+PR=1
+. "$SHIPIT/disarm-intent.sh"          # SKILL.md's preamble source — part of the chain
+. "$SHIPIT/$STEP" ${STEP_ARG:-} > /dev/null
+DRV
+
+echo "=== 2. executable: no call in the Step-0 chain dies command-not-found"
+# `CLAUDE_CODE_AGENT=` / `WORKTREE_ROOT=` blanked deliberately: `iso_preflight`'s isolation policy is
+# not what is under test here, and inheriting an agent's env would make this harness's result depend
+# on which checkout it was launched from.
+for step in step0-preflight.sh step0-classify.sh step0-cp-approval.sh; do
+	arg=""
+	[ "$step" = "step0-preflight.sh" ] && arg=1
+	STEP="$step" STEP_ARG="$arg" PATH="$BIN:$PATH" CLAUDE_PLUGIN_ROOT="$TMP/plugin" SHIPIT="$DIR" \
+		CLAUDE_CODE_AGENT= WORKTREE_ROOT= bash "$TMP/drive-one.sh" > "$TMP/out" 2> "$TMP/err"
+	if grep -q 'command not found' "$TMP/err"; then
+		printf 'BAD   %-26s unresolved function(s):\n' "$step"
+		grep 'command not found' "$TMP/err" | sed 's/^/      /'
+		fail=1
+	else
+		printf 'OK    %-26s no '\''command not found'\'' on stderr\n' "$step"
+	fi
+done
+
+# ---------------------------------------------------------------------------------------------
+# 3. SEAM — $CP_FLAG reaches `verdict gate`
+# ---------------------------------------------------------------------------------------------
+cat > "$TMP/drive-gate.sh" <<'DRV'
+REPO="owner/repo"
+PR=1
+. "$SHIPIT/disarm-intent.sh"
+# Step 0's §CP discharge is the only writer of CP_FLAG; $SEAM stands in for it here.
+[ -n "${SEAM:-}" ] && CP_FLAG="$SEAM"
+. "$SHIPIT/step2-verdict-gate.sh"
+DRV
+
+run_gate() {   # $1 = the value Step 0 would have set (empty ⇒ Step 0 set nothing); prints nothing
+	CALLS="$TMP/calls"
+	: > "$CALLS"
+	SEAM="$1" PCLI_CALLS="$CALLS" PATH="$BIN:$PATH" CLAUDE_PLUGIN_ROOT="$TMP/plugin" SHIPIT="$DIR" \
+		bash "$TMP/drive-gate.sh" > "$TMP/gout" 2> "$TMP/gerr"
+	GATE_RC=$?
+	GATE_ARGS="$(grep '^verdict gate' "$CALLS" | tail -n1)"
+}
+
+echo "=== 3. seam: the caller's \$CP_FLAG reaches \`verdict gate\`"
+run_gate "--cp"
+case "$GATE_ARGS" in
+	*--cp*) printf 'OK    §CP discharge  → handed: %s\n' "$GATE_ARGS" ;;
+	*)      printf 'BAD   §CP discharge  → --cp DROPPED; verdict gate was handed: %s\n' "${GATE_ARGS:-<no call recorded>}"; fail=1 ;;
+esac
+
+run_gate ""
+case "$GATE_ARGS" in
+	*--cp*) printf 'BAD   non-§CP        → --cp appeared unbidden: %s\n' "$GATE_ARGS"; fail=1 ;;
+	"")     printf 'BAD   non-§CP        → verdict gate was never invoked\n'; fail=1 ;;
+	*)      printf 'OK    non-§CP        → handed: %s\n' "$GATE_ARGS" ;;
+esac
+
+run_gate "--CP-TYPO"
+if [ "$GATE_RC" -ne 0 ] && grep -q 'CP_FLAG' "$TMP/gerr" && [ -z "$GATE_ARGS" ]; then
+	printf 'OK    third value     → refused (rc=%s) with a named reason, verdict gate never invoked\n' "$GATE_RC"
+else
+	printf 'BAD   third value     → rc=%s, verdict gate handed: %s (expected a named non-zero refusal)\n' \
+		"$GATE_RC" "${GATE_ARGS:-<none>}"
+	fail=1
+fi
+
+rm -rf "$TMP"
+if [ "$fail" -ne 0 ]; then
+	echo "FAIL: ship-it's sourced chain does not run as written"
+	exit 1
+fi
+echo "PASS: ship-it's sourced chain runs as written"


### PR DESCRIPTION
Fixes #4547

ship-it's extracted step scripts were partially unrunnable as written: three of them call a
helper that nothing in their chain sources, and the Step-2 §CP flag was hardcoded empty with no
way for a caller to set it. ship-it is the single merge authority (ADR 0048/0135), so every
landing on 2026-07-30 involved an undocumented deviation from the skill to get past them.

**One acceptance shape: the chain runs as written, with no deviation.**

## The three defects, reproduced

Reproduced by copying the skills tree to a scratch dir, restoring the five touched files from
`ce1684d6` (pre-fix), and running the new harness against that copy. Verbatim, with the scratch
prefix elided:

```
BAD   step0-classify.sh          calls cp_changed_files — defined in no file this chain sources
BAD   step0-classify.sh          calls cp_head_sha — defined in no file this chain sources
BAD   step0-cp-approval.sh       calls cp_head_sha — defined in no file this chain sources
BAD   step0-cp-approval.sh       calls cp_pr_author — defined in no file this chain sources
BAD   step0-cp-approval.sh       calls cp_team_membership — defined in no file this chain sources
BAD   step0-cp-approval.sh       calls cp_team_roster — defined in no file this chain sources
BAD   step0-preflight.sh         calls iso_preflight — defined in no file this chain sources
=== 2. executable: no call in the Step-0 chain dies command-not-found
BAD   step0-preflight.sh   .../step0-preflight.sh: line 33: iso_preflight: command not found
BAD   step0-classify.sh    .../step0-classify.sh: line 21: cp_changed_files: command not found
BAD   step0-cp-approval.sh .../step0-cp-approval.sh: line 25: cp_team_roster: command not found
=== 3. seam: the caller's $CP_FLAG reaches `verdict gate`
BAD   §CP discharge  → --cp DROPPED; verdict gate was handed: verdict gate --pr 1 --require skill
OK    non-§CP        → handed: verdict gate --pr 1 --require skill
BAD   third value     → rc=0, verdict gate handed: verdict gate --pr 1 --require skill
FAIL: ship-it's sourced chain does not run as written
### harness exit: 1
```

Per defect, with observed exit codes:

- **A — `step2-verdict-gate.sh` hardcodes `CP_FLAG=""`.** Sourced with the caller having set
  `CP_FLAG=--cp`, the recorded `verdict gate` argv is `verdict gate --pr 1 --require skill` —
  `--cp` dropped, at exit **0**. On a real §CP PR that is a guard-1 refusal every time: the §CP
  pass path is the SHA-less advisory, which `verdict gate` counts only under `--cp`. Note the
  fail-open direction of the *old* hardcode's third case too — a nonsense value was silently
  ignored (rc 0) rather than refused.
- **B — `step0-preflight.sh` calls `iso_preflight`.** Sourced on a fresh shell it dies at line 33,
  `iso_preflight: command not found` (**127**), and the `|| exit 1` on that line then takes the
  whole Step-0 chain down with it.
- **C — `step0-classify.sh` calls `cp_changed_files` / `cp_head_sha`.** Dies at line 21,
  `cp_changed_files: command not found` (**127**). Because the call site is `if ! cp_changed_files
  …`, the `!` inverts 127 into the *fail-closed* branch, so the observable outcome is a `BLOCKING
  (changed-file list unreadable …)` + `exit 1` — the right refusal for the wrong reason, with the
  real cause visible only on stderr. Triage's correction is confirmed: these two live in
  `skills/shared/scripts/cp-read.sh`, not in `iso-preflight.sh`; I re-derived the chain from the
  files rather than from either account.

## The fix — the in-repo idiom, not a new one

`skills/review-code/scripts/materialize-head.sh` already sources `iso-preflight.sh` in-chain, and
`review-code`/`review-design`'s `classify-control-plane.sh` already source `cp-read.sh` in-chain.
Three source lines, same shape, same `# shellcheck source=` annotation:

| script | now sources | was |
|---|---|---|
| `step0-preflight.sh` | `../../shared/scripts/iso-preflight.sh` | nothing defining `iso_preflight` |
| `step0-classify.sh` | `../../shared/scripts/cp-read.sh` | nothing defining `cp_*` |
| `step0-cp-approval.sh` | `../../shared/scripts/cp-read.sh` | a SKILL.md paste-precondition |

`step0-cp-approval.sh` is the issue's boundary case, in scope on its own stated condition — "only
if the fix chosen for the two naked cases lands the same in-script source for it at zero marginal
cost." It is literally the same one line. A documented paste-precondition is a real precondition,
but it is still a hand step ahead of the invocation, and the acceptance bar here is *no deviation*.
SKILL.md's §CPREAD paragraph is updated to point at the in-chain source instead of instructing the
paste.

## Defect A: the input seam I chose, and why

**A caller-set variable, `CP_FLAG="${CP_FLAG:-}"`, written by Step 0's §CP discharge branch.** Not
a positional argument.

- **The value is derived by an earlier step of the same sourced chain.** `step0-preflight.sh`'s
  `$1` is the precedent for a positional — but it carries the run's *entry* value (`$PR`), which no
  earlier step could have set. `CP_FLAG` is the opposite: Step 0 classifies §CP and Step 0's
  approval gate discharges, both in this same shell, and Step 2 consumes that. Shell variables are
  already how `$PR`, `$REPO` and `$REQUIRED` cross these steps.
- **A positional would put the decision back at the source site.** `. "…/step2-verdict-gate.sh"
  --cp` is a value the shipper types by hand at the moment of sourcing — the eyeball substitution
  that is the defect class this issue exists to close. With the variable, the *only* sanctioned
  writer is Step 0's discharge branch, and SKILL.md says so at that one site.
- **Both shippers that hit this converged unprompted on this shape**, which is weak evidence but
  not zero.
- **Fail-closed direction:** unset ⇒ empty ⇒ the non-§CP branch, which is the *stricter* one. A
  forgotten seam can only refuse a §CP PR, never pass one.
- **Invalid states unrepresentable:** any third value is refused (non-zero, `disarm_intent refuse`
  first, and a stderr line naming `CP_FLAG`) rather than shipped into `verdict gate` as an
  unrecognized flag that would refuse with the wrong reason named.

**Contingent on #4546, named rather than baked in:** #4546 asks whether `.`-sourcing works at all
under `isolation:worktree`. If it rules that these scripts are *executed* rather than sourced, a
caller-set shell variable stops crossing the boundary and the seam has to become an argument or an
exported env var. That restyle is one line in this script plus one at the SKILL.md site — the
choice between the two shapes is the only thing #4546 could invalidate here, and the three
source-line repairs are correct under every convention. Not gated on it, per the ticket.

## ADR 0229's exemplar still holds

0229 cites `step2-verdict-gate.sh` as its clean-relay exemplar and records that it deliberately
sets no shell options. Both survive:

- **Total** — the seam's input domain is now exhaustively cased (`""`, `--cp`, everything else).
  It was *less* total before: a third value fell through unhandled.
- **Mechanical** — no value is introduced that was not already in a verb's answer. `CP_FLAG` is
  relayed from Step 0's classification + discharge to `verdict gate`'s argv; nothing here
  reinterprets a verb's output.
- **UNKNOWN-propagating** — the new refusal exits non-zero **and** prints a non-empty line, per
  0229's mechanical floor, and disarms the merge intent first (guard 6, ADR 0198).

No shell options were added: `pipefail` stays off, as its header requires.

## The falsification harness

`skills/ship-it/scripts/verify-chain-resolves.sh`, in the `verify-*.sh` idiom `write-code/scripts`
already uses, wired into ci.yml's existing `skills` job next to `common-test.sh`. Hermetic — `gh`
and the CLI shim are stubbed, so it needs no auth and touches no repo state. Three checks:

1. **Static** — for every `ship-it/scripts/*.sh`, every cross-file helper it calls must be defined
   in the file, in something the file sources, or in a script SKILL.md sources *earlier in the
   chain*. That last clause is what makes `disarm_intent` legitimately reachable (SKILL.md's
   preamble sources `disarm-intent.sh` before every step) — which is issue AC 4's
   "documented precondition that precedes the invocation", mechanized rather than asserted. Scope
   is emitted before the verdict and zero scope on either axis fails closed (§ZS / ADR 0092).
2. **Executable** — each Step-0 script is sourced for real against the stubs, one driver run per
   script (never one chained run: the first unresolved call would otherwise take its successors'
   coverage down with it and the harness would report a narrowed scan as a clean one), and its
   stderr must carry no `command not found`. The `cp-classify` stub answers
   `content-undetermined` on purpose — that is the branch that reaches `cp_head_sha`, so both
   §CPREAD helpers are exercised rather than just the happy-path one.
3. **Seam** — asserted on what the stub shim was *handed*, not on the script's text: `--cp`
   present when the caller set it, absent when it did not, and a named non-zero refusal with
   `verdict gate` never invoked on a third value.

The RED block at the top of this PR is that harness against the pre-fix tree; it is green against
this head. Static and executable do not subsume each other — static covers branches a run does not
take (`cp_head_sha` in `step0-cp-approval.sh`, `cp_team_membership` in the approver loop),
executable covers resolution the regex could get wrong.

## How far I could verify, and where I reasoned

Stated plainly, because it is uneven:

- **Verified by execution:** all three defects RED pre-fix and green post-fix; the seam's three
  cases against recorded argv; `shellcheck -x` clean on all five shell files; `actionlint` clean on
  `ci.yml`; `trap-status-guard`, `cli-invocation-guard`, `leak-guard scan` clean on the 6–7 files
  handed (each guard's own scope line matches the count handed); `validate-skills`,
  `validate-gate-path-drift`, `validate-cycle-presence`, `validate-cycle-absence` all green; the
  full `@kampus/pipeline-cli` suite, 185 files / 2998 tests, passing. The harness was also run
  through the `.claude/skills/...` symlink path CI uses, not only the real path.
- **Verified by reasoning, not by execution:** *an agent driving ship-it end to end by
  `. "$SHIPIT_SCRIPTS/…"` from its own shell.* This worktree-isolated harness refuses `.`/`source`,
  heredocs and shell redirects in an agent's own Bash calls (#4546), so I could not drive the
  documented protocol the way a shipper does. What I ran instead is one level down: driver scripts
  that perform exactly those `.` lines, executed with `bash`. That is the same bash semantics —
  function definitions landing in the sourcing shell — but it is *not* a proof that the agent-facing
  invocation convention works in the harness. That question is #4546's and is untouched here.
- **Not exercised at all:** the live network paths (`gh api` against a real PR, a real
  `pipeline-cli verdict gate`). Everything is stubbed. What is proven is *resolution and
  pass-through*, not the verbs' own behaviour, which their unit tests own.

## Deviations

- **Scope: `step0-cp-approval.sh` was fixed too, though #4547 calls it the boundary case.** Taken
  in scope on the ticket's own stated condition (same one line, zero marginal cost) and because
  "runs as written, no deviation" is not satisfied by a paste-precondition. This also moves a
  SKILL.md instruction (§CPREAD "copy those helpers verbatim") rather than only adding to it.
- **Scope: a new CI step in `.github/workflows/ci.yml`.** The dispatch scoped this to
  relocation-plus-repair, and a workflow edit is neither. I judged an unrun falsification test to
  be worth little — the three source lines were dropped by an extraction and nothing noticed for a
  week, which is precisely the regression a pin exists to catch. It is additive (a new `- run:` in
  the existing `skills` job), hermetic, and removes no guard. If a reviewer disagrees, dropping the
  step leaves the harness reviewer-runnable and the rest of the PR intact.
- **The `verify-chain-resolves.sh` static check carries two deliberate narrowings**, both to avoid
  false positives rather than to weaken it: candidate helper names are collected only from
  `shared/lib`, `shared/scripts` and `ship-it/scripts` (a name defined only in the file that calls
  it needs no check, and names from unrelated skills matched prose words like `fail`/`ok` inside
  message strings), and `verify-*`/`*-test.sh` harnesses are excluded from that collection for the
  same reason. Both narrowings were made *after* observing a concrete false positive (`ok`, defined
  in `shared/lib/common-test.sh`, matching `ART_FETCH_STATUS=ok`), not pre-emptively.
- **No ADR.** 0229's exemplar claim is argued above to still hold rather than amended; the seam
  shape is recorded on this PR for #4546 to restyle, per the ticket's instruction.
- **I am the implementer, not the reviewer.** No verdict marker from me; this is §CP
  (`cp-classify classify` → `control-plane`, exit 0, on `.github/workflows/ci.yml` and the
  whole-tree `claude-plugins/kampus-pipeline/skills/**` row) and banks for a
  `@kamp-us/control-plane` approval at head. I will not merge it.
