### PR TITLE
chore(write-code): extract the three remaining fenced-shell blocks into executed scripts/ (#4449)

### DIFF
--- a/claude-plugins/kampus-pipeline/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/lib/common-test.sh
@@ -3,8 +3,10 @@
 # SC2016 is declared, not suppressed on principle: the fixtures below EMIT shell text, so the single
 # quotes are the point — an expanded `${v#pre}` or `$dir` would write a different fixture than the
 # one under test.
-# Executable pin for kp_skill_shell_surfaces' scan-status contract (#4487) and for the source-edge
-# surface widening + comment-stripped matching that ADR 0230 adds on top (#4541). Run it directly:
+# Executable pin for kp_skill_shell_surfaces' scan-status contract (#4487), for the source-edge
+# surface widening + comment-stripped matching that ADR 0230 adds on top (#4541), and for the
+# per-mutation worktree guard the lib hosts so its four SOURCED callers can reach it (#4449). Run it
+# directly:
 #   bash claude-plugins/kampus-pipeline/lib/common-test.sh
 #
 # Every case here is written to be FALSIFIABLE — each asserts a behaviour that the pre-ADR-0230
@@ -351,6 +353,79 @@ elif grep -qF "$probe_literal" <<<"$out"; then
 	fail "credit pin: $lib carries the cycle-doc probe literal ('$probe_literal') in executable shell — it is edge-resolved into all four cycle-aware skills, so this one file would satisfy every skill's canonical-probe check (ADR 0230 rule 1)"
 else
 	ok "the shared lib carries no cycle-doc probe literal (no blanket four-skill credit)"
+fi
+
+# ---------------------------------------------------------------------------------------------
+# #4449 — the per-mutation worktree guard, whose HOME is the seam under test.
+# ---------------------------------------------------------------------------------------------
+
+# 18. THE SEAM PIN, and the falsification of the shipped defect. `wt_preflight` / `lane_worktree` are
+# called BY NAME from four SOURCED siblings (write-code's `step4-branch.sh`, `step5-push.sh`,
+# `stepR2-branch-rebase.sh`, `stepR3-push-and-note.sh`), each of which sources this lib and nothing
+# else that could define them. Hosted in the EXECUTED `step4-wt-preflight.sh` instead, they exist
+# only in a subprocess and every one of those calls dies 127 — steps 4/5/R2/R3 inoperable, with no
+# other check able to see it. `required_fns` above cannot cover this: it derives `kp_`-prefixed names
+# only, and these two deliberately keep the unprefixed names their callers use.
+for fn in wt_preflight lane_worktree; do
+	if type "$fn" >/dev/null 2>&1; then
+		ok "$fn is defined by sourcing the lib alone — the four sourced siblings can call it (#4449)"
+	else
+		fail "$fn is NOT defined by $lib — every sourced caller of it exits 127 (#4449)"
+	fi
+done
+
+# `lane_worktree` fixture: a repo whose per-worktree git dirs are stamped by hand. It reads only
+# `--git-common-dir` plus the `kampus-lane` / `gitdir` files under it, so a real `git worktree add`
+# is unnecessary — and a hand-built fixture is what lets case 21 stamp TWO trees with one lane.
+mkdir -p "$tmp/lw/main" "$tmp/lw/wtA" "$tmp/lw/wtB"
+if ! git -C "$tmp/lw/main" init -q --template='' >/dev/null 2>&1; then
+	fail "fixture did not take: could not git-init the lane_worktree fixture — cases 19–21 were NOT exercised"
+else
+	mkdir -p "$tmp/lw/main/.git/worktrees/A" "$tmp/lw/main/.git/worktrees/B"
+	printf '%s/.git\n' "$tmp/lw/wtA" > "$tmp/lw/main/.git/worktrees/A/gitdir"
+	printf '%s/.git\n' "$tmp/lw/wtB" > "$tmp/lw/main/.git/worktrees/B/gitdir"
+	lane_sid="kp-test-lane-0001"
+
+	# 19. No tree carries this lane's stamp ⇒ REFUSE. Silence is never "use the cwd": the caller's
+	# `git -C ""` would fall back to wherever the cwd landed, which is the corruption this guards.
+	out="$(cd "$tmp/lw/main" && CLAUDE_CODE_SESSION_ID="$lane_sid" lane_worktree 2>/dev/null)"; rc=$?
+	if [ "$rc" -eq 0 ]; then
+		fail "lane_worktree returned 0 with no tree stamped for this lane — it must refuse"
+	elif [ -n "$out" ]; then
+		fail "lane_worktree emitted [$out] with no tree stamped for this lane — it must emit nothing"
+	else
+		ok "lane_worktree with no stamped tree: non-zero, empty stdout (fail-closed)"
+	fi
+
+	# 20. Exactly one stamped tree ⇒ its PHYSICAL root, on stdout, exit 0.
+	printf '%s\n' "$lane_sid" > "$tmp/lw/main/.git/worktrees/A/kampus-lane"
+	out="$(cd "$tmp/lw/main" && CLAUDE_CODE_SESSION_ID="$lane_sid" lane_worktree)"; rc=$?
+	if [ "$rc" -eq 0 ] && [ "$out" = "$tmp/lw/wtA" ]; then
+		ok "lane_worktree resolves the single tree stamped with this lane"
+	else
+		fail "lane_worktree single-stamp: rc=$rc out=[$out] expected [$tmp/lw/wtA]"
+	fi
+
+	# 21. Two trees stamped with the same lane is AMBIGUOUS, and ambiguity refuses rather than
+	# picking one — the `-eq 1` test, which is also why `set -- $hits` must stay unquoted.
+	printf '%s\n' "$lane_sid" > "$tmp/lw/main/.git/worktrees/B/kampus-lane"
+	out="$(cd "$tmp/lw/main" && CLAUDE_CODE_SESSION_ID="$lane_sid" lane_worktree 2>/dev/null)"; rc=$?
+	if [ "$rc" -eq 0 ] || [ -n "$out" ]; then
+		fail "lane_worktree picked a tree from an AMBIGUOUS two-stamp state: rc=$rc out=[$out]"
+	else
+		ok "lane_worktree with two trees on one lane: non-zero, empty stdout (ambiguity refuses)"
+	fi
+fi
+
+# 22. `wt_preflight` with no lane identity at all refuses before it looks at any tree — the
+# `${CLAUDE_CODE_SESSION_ID:?}` floor. Run in a subshell because that expansion aborts the shell.
+out="$(CLAUDE_CODE_SESSION_ID='' wt_preflight 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ]; then
+	fail "wt_preflight returned 0 with no session id — it has no lane identity to verify against"
+elif [ -n "$out" ]; then
+	fail "wt_preflight emitted [$out] with no session id — it must emit nothing"
+else
+	ok "wt_preflight with no session id: non-zero, empty stdout (fail-closed)"
 fi
 
 cleanup

--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC2016
+# shellcheck shell=bash disable=SC2016,SC2086
 # SC2016 is declared, not waved off: the awk program and the sourcing-idiom matcher below are LITERAL
-# text handed to awk and sed. Shell expansion of their `$` would destroy both.
+# text handed to awk and sed. Shell expansion of their `$` would destroy both. SC2086 is raised by
+# exactly one line — `set -- $hits` in the byte-moved `lane_worktree` — where the split IS the
+# mechanism: quoting it would collapse N candidate worktrees into one word and defeat the `-eq 1`
+# ambiguity refusal. It is declared here rather than quoted away because that block is a byte-move
+# (#4449) and rewriting the moved glue is phase 2 (#1929).
 # Cross-script state for the pipeline skills' extracted shell (epic #4435 phase 1).
 # Sourced, never executed: it defines functions and sets no shell options, so the sourcing
 # script keeps its own `set -euo pipefail`.
@@ -399,4 +403,80 @@ kp__scratch() {
 		return 5
 	fi
 	printf '%s\n' "$dir"
+}
+
+# The per-mutation worktree guard and the lane resolver under it. They live HERE, in the file every
+# pipeline shell script already sources, because they have TWO classes of caller: the EXECUTED
+# `write-code/scripts/step4-wt-preflight.sh`, which runs `wt_preflight` in a subprocess and prints
+# the root it resolved (ADR 0232), and four SOURCED siblings — `step4-branch.sh`, `step5-push.sh`,
+# `stepR2-branch-rebase.sh`, `stepR3-push-and-note.sh` — which call `wt_preflight` in the agent's own
+# shell and then read the `$WT` it leaves there. A shell function reaches a sourced caller only from
+# a file that caller sources, so hosting these in the executed script alone left those four calling a
+# function that had ceased to exist, with no CI check able to see it (#4449 repair round 2). The
+# names stay unprefixed, against this file's `kp_` convention, because they ARE the names those
+# callers and write-code/SKILL.md refer to.
+#
+# The block below is VERBATIM from write-code/SKILL.md's per-mutation-preflight blockquote (epic
+# #4435 phase 1, #4449) — two-space indent included. Byte fidelity is the extraction's contract, so
+# it is not reindented to this file's tabs.
+
+# Resolve MY worktree by IDENTITY, never from cwd (#4398). `git rev-parse --show-toplevel` answers
+# "where is the cwd" — which a between-calls reset makes a different question from "which tree is
+# mine". Deriving $WT from it and then re-deriving the toplevel to compare against is one answer
+# checked against itself: always equal, so its failure branch could never print. The stamp is
+# CONTENT written once when $WT was trustworthy, so these two operands can genuinely differ.
+lane_worktree() {   # print the absolute root of the worktree stamped with THIS lane's session id
+  common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$common" in /*) ;; *) common="$(pwd -P)/$common" ;; esac
+  common="$(cd "$common" && pwd -P)" || return 1   # -P: git answers in PHYSICAL paths, so must we
+  hits=""
+  for st in "$common"/worktrees/*/kampus-lane; do
+    [ -f "$st" ] || continue
+    [ "$(cat "$st")" = "$CLAUDE_CODE_SESSION_ID" ] || continue
+    gd="$(cat "${st%/kampus-lane}/gitdir")" || return 1   # "<worktree-root>/.git"
+    hits="$hits $(cd "${gd%/.git}" && pwd -P)"
+  done
+  set -- $hits
+  [ "$#" -eq 1 ] || return 1   # 0 ⇒ no tree is mine; >1 ⇒ ambiguous. Both REFUSE (fail-closed).
+  printf '%s\n' "$1"
+}
+wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-closed, re-correcting cwd
+  : "${CLAUDE_CODE_SESSION_ID:?wt_preflight FAILED (fail-closed): no session id — no lane identity to verify a worktree against}"
+  # CLASSIFY THE AMBIENT TREE FIRST — the lane-identity assertions live here, because this is the
+  # only place THESE operands can differ. `$AMB_STAMP` is a file some lane wrote when its worktree
+  # was proven; `$CLAUDE_CODE_SESSION_ID` is the process env. After the corrective `cd` below these
+  # two agree BY CONSTRUCTION, so re-checking THEM down there would be checking a value against its
+  # own derivation — which is exactly what shipped, and why the sibling-tree refusal never printed
+  # (#4398). That is a fact about these operands, not about position: the post-`cd` refusal below
+  # reads independent operands and does fire.
+  AMB_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+  AMB_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+  case "$AMB_COMMON" in ""|/*) ;; *) AMB_COMMON="$(pwd -P)/$AMB_COMMON" ;; esac
+  [ -n "$AMB_COMMON" ] && AMB_COMMON="$(cd "$AMB_COMMON" && pwd -P)"   # -P: compare like for like with git's physical answer
+  AMB_STAMP="$(cat "$AMB_GITDIR/kampus-lane" 2>/dev/null)"
+  echo "wt_preflight: ambient=$(git rev-parse --show-toplevel 2>/dev/null || echo '<not a repo>') ambient-git-dir=${AMB_GITDIR:-<none>} ambient-stamp=${AMB_STAMP:-<none>} lane=$CLAUDE_CODE_SESSION_ID"
+  # THE SIBLING-TREE REFUSAL: cwd sits in a LINKED worktree that is not mine. The primary checkout
+  # is the harness's documented reset target and is corrected below; a sibling lane's tree is NOT
+  # explained by anything, so stop rather than mutate next to a live lane (#832, #3458/#3580).
+  if [ -n "$AMB_GITDIR" ] && [ "$AMB_GITDIR" != "$AMB_COMMON" ] && [ "$AMB_STAMP" != "$CLAUDE_CODE_SESSION_ID" ]; then
+    echo "wt_preflight FAILED (fail-closed): cwd is inside worktree $(git rev-parse --show-toplevel), stamped '${AMB_STAMP:-<none>}' — a SIBLING lane's tree, not my lane ($CLAUDE_CODE_SESSION_ID). Refusing to mutate." >&2
+    return 1
+  fi
+  # cwd is my own tree or the PRIMARY checkout (the between-calls reset). Resolve my lane by
+  # identity and cd there — the correction. A miss REFUSES: no tree is mine (unprovisioned, torn
+  # down, or a foreign session), or several are (ambiguous).
+  WT="$(lane_worktree)" || { echo "wt_preflight FAILED (fail-closed): no single worktree carries this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2; return 1; }
+  cd "$WT" || { echo "wt_preflight FAILED: cannot cd to worktree root $WT" >&2; return 1; }
+  # DEFENCE IN DEPTH — the resolved lane must not BE the primary checkout. This sits after the
+  # `cd` and is still a genuine assertion, because its operands do not come from the cwd: it
+  # tests `lane_worktree`'s ANSWER with two DIFFERENT plumbing queries whose results coincide
+  # only on the primary. `lane_worktree` returns whatever `worktrees/<name>/gitdir` names, so an
+  # entry naming the primary root, stamped with this lane, resolves here — and this refuses.
+  # Demonstrated firing in PR #4419's review; do not delete it as "true by construction" (#4398).
+  RES_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || { echo "wt_preflight FAILED (fail-closed): resolved lane $WT is not inside a git repository — refusing to mutate." >&2; return 1; }
+  RES_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+  case "$RES_COMMON" in /*) ;; *) RES_COMMON="$(pwd -P)/$RES_COMMON" ;; esac
+  RES_COMMON="$(cd "$RES_COMMON" && pwd -P)"
+  [ "$RES_GITDIR" != "$RES_COMMON" ] || { echo "wt_preflight FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout ($WT) — git-dir == common-dir. Refusing to mutate." >&2; return 1; }
+  echo "wt_preflight OK: mutating my lane at $WT (git-dir $RES_GITDIR)"
 }

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -191,89 +191,7 @@ work, scan your own open PRs for one whose **latest** gate verdict (in *any* of 
 namespaces) is an unaddressed FAIL:
 
 ```bash
-ME=$(gh api user --jq '.login')
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314). The shim's own
-# three-tier ladder (in-repo bin → installed bin → the pinned `pnpm dlx`, hooks/pin.sh) decides WHICH
-# build runs, so no version is pinned here (#3653; ADR 0062/0064; epic #994). Each per-(PR, gate)
-# FAIL-bound-to-head resolution below delegates to `pipeline-cli verdict read` (ACL author-gate +
-# latest-wins + SHA-staleness, ADR 0055/0058; its unit tests are the contract).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# GATE-CRITICAL (§CLI): this scan's wrapper turns non-zero into "nothing to repair", so an
-# unresolved CLI would read as a clean scan and the run would fall through to new work while an
-# unaddressed FAIL sits open. Refuse up front — "could not run" is never a verdict.
-[ -x "$PCLI" ] || {
-  echo "pipeline-cli: UNRESOLVED at '$PCLI' — the repairable-PR scan has NO result." >&2
-  echo "  Resolve to UNKNOWN, never to 'no FAIL'. This is a resolution gap, NOT worktree teardown (§CLI)." >&2
-  exit 127
-}
-# §CPREAD's `cp_changed_files`, sourced from its canonical home — no skill-local copy to drift
-# (#4489). It feeds the per-PR §CP-ness derivation inside the loop.
-. "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
-# open PRs you authored; print each one whose latest verdict in EITHER namespace is FAIL,
-# UNLESS it has already hit the N=3 repair cap (then it's a human's, not yours to re-pick)
-gh api "repos/$REPO/pulls?state=open&per_page=100" \
-  --jq ".[] | select(.user.login==\"$ME\") | .number" | while read PR; do
-  # The N=3 FAIL-round count is the one thing `verdict read` does NOT do (it resolves the latest
-  # verdict, it does not count rounds) — genuinely more than a single (PR, gate) resolution, so it
-  # stays inline. Author-gate the FAIL markers to write+ collaborators (ADR 0055, supersedes 0051)
-  # so a forged review-(code|doc|skill): FAIL can't inflate the count; an empty authorized set counts
-  # zero rounds — fail-closed. Cluster by timestamp gap (>120s = new round), per fix-round not per
-  # marker (a both-namespace round counts once), the same identity the Bounding count uses.
-  comments_file=$(mktemp)
-  gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file"
-  markerAuthors=$(jq -r '[.[]
-      | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*(PASS|FAIL)"; "i"))
-      | .user.login] | unique | .[]' "$comments_file")
-  authorized='[]'
-  while IFS= read -r a; do
-    [ -z "$a" ] && continue
-    perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
-    case "$perm" in
-      admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
-    esac
-  done <<<"$markerAuthors"
-  ROUNDS=$(jq --argjson authorized "$authorized" \
-    '[.[] | select(.user.login | IN($authorized[]))
-          | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*FAIL"; "i"))
-          | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
-     | sort
-     | reduce .[] as $t ({n:0, prev:null};
-         if (.prev == null) or ($t - .prev) > 120
-         then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
-     | .n' "$comments_file")
-  [ "$ROUNDS" -ge 3 ] && continue   # at the cap → already escalated to a human, excluded from the scan
-  # §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves (#4049). On a §CP
-  # PR the pass is the SHA-less ADVISORY, which a read without --cp cannot see at all — so a FAIL
-  # discharged by a BODY-ONLY repair (which deliberately never moves the head, so ADR 0058 staleness
-  # can never retire it) reads as a standing FAIL forever and pulls this scan into a phantom repair.
-  # Derive it per PR, fail-closed on BOTH fallible inputs: the changed-file list is a network read, so
-  # it comes from `cp_changed_files` and never a bare `gh … | cp-classify` pipe, which with pipefail
-  # off hands the verb gh's STDOUT error document and answers `not-control-plane` on an unread list
-  # (#4216); and only the PROVEN `not-control-plane` state word drops the flag — never `… ||
-  # CP_FLAG=""` on mere non-zero, which fires on a usage error (1) or a missing bin (127).
-  # `>&2` routes only the §ZS scope LINE, not the result: `cp_changed_files` returns its file list in
-  # $CP_FILES, and this loop's stdout is the repairable-PR list the caller reads. The scope line is
-  # still emitted (§ZS #1), on the same stream as this helper's failure lines.
-  if ! cp_changed_files "$REPO" "$PR" >&2; then
-    CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
-  else
-    CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO" 2>/dev/null)"
-  fi
-  if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
-  # resolve each namespace's latest current-head verdict through the shared verb — exit 0 iff HEAD
-  # carries a current FAIL in that gate (a stale / SHA-less / PASS / none verdict exits non-zero).
-  # stderr is NOT discarded and 127 is read apart from an ordinary negative: with `2>&1` swallowing
-  # it, a `command not found` was byte-identical to "no FAIL verdict" and the PR dropped out of the
-  # scan silently (§CLI exit-code taxonomy — "could not run" is never a verdict; #4398, #4236).
-  for G in code doc skill; do
-    "$PCLI" verdict read --pr "$PR" --gate "$G" $CP_FLAG --expect FAIL >/dev/null
-    RC=$?
-    case $RC in
-      0)   echo "#$PR review-$G FAIL" ;;
-      127) echo "verdict read could not run (127) for #$PR/$G — UNKNOWN, not 'no FAIL'. Stop and route the blocker (§CLI)." >&2; exit 127 ;;
-    esac
-  done
-done
+. "$WRITECODE_SCRIPTS/step1-repairable-prs.sh"   # stdout IS the repairable-PR list — silence is UNKNOWN, never "nothing to repair"
 ```
 
 If such a PR exists, **repair it instead of picking new work** — go to
@@ -747,66 +665,7 @@ is intentionally left untouched here so the two changes can't double-implement o
 > bypass, same fail-closed construction as the opening preflight:
 >
 > ```bash
-> # Resolve MY worktree by IDENTITY, never from cwd (#4398). `git rev-parse --show-toplevel` answers
-> # "where is the cwd" — which a between-calls reset makes a different question from "which tree is
-> # mine". Deriving $WT from it and then re-deriving the toplevel to compare against is one answer
-> # checked against itself: always equal, so its failure branch could never print. The stamp is
-> # CONTENT written once when $WT was trustworthy, so these two operands can genuinely differ.
-> lane_worktree() {   # print the absolute root of the worktree stamped with THIS lane's session id
->   common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
->   case "$common" in /*) ;; *) common="$(pwd -P)/$common" ;; esac
->   common="$(cd "$common" && pwd -P)" || return 1   # -P: git answers in PHYSICAL paths, so must we
->   hits=""
->   for st in "$common"/worktrees/*/kampus-lane; do
->     [ -f "$st" ] || continue
->     [ "$(cat "$st")" = "$CLAUDE_CODE_SESSION_ID" ] || continue
->     gd="$(cat "${st%/kampus-lane}/gitdir")" || return 1   # "<worktree-root>/.git"
->     hits="$hits $(cd "${gd%/.git}" && pwd -P)"
->   done
->   set -- $hits
->   [ "$#" -eq 1 ] || return 1   # 0 ⇒ no tree is mine; >1 ⇒ ambiguous. Both REFUSE (fail-closed).
->   printf '%s\n' "$1"
-> }
-> wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-closed, re-correcting cwd
->   : "${CLAUDE_CODE_SESSION_ID:?wt_preflight FAILED (fail-closed): no session id — no lane identity to verify a worktree against}"
->   # CLASSIFY THE AMBIENT TREE FIRST — the lane-identity assertions live here, because this is the
->   # only place THESE operands can differ. `$AMB_STAMP` is a file some lane wrote when its worktree
->   # was proven; `$CLAUDE_CODE_SESSION_ID` is the process env. After the corrective `cd` below these
->   # two agree BY CONSTRUCTION, so re-checking THEM down there would be checking a value against its
->   # own derivation — which is exactly what shipped, and why the sibling-tree refusal never printed
->   # (#4398). That is a fact about these operands, not about position: the post-`cd` refusal below
->   # reads independent operands and does fire.
->   AMB_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
->   AMB_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
->   case "$AMB_COMMON" in ""|/*) ;; *) AMB_COMMON="$(pwd -P)/$AMB_COMMON" ;; esac
->   [ -n "$AMB_COMMON" ] && AMB_COMMON="$(cd "$AMB_COMMON" && pwd -P)"   # -P: compare like for like with git's physical answer
->   AMB_STAMP="$(cat "$AMB_GITDIR/kampus-lane" 2>/dev/null)"
->   echo "wt_preflight: ambient=$(git rev-parse --show-toplevel 2>/dev/null || echo '<not a repo>') ambient-git-dir=${AMB_GITDIR:-<none>} ambient-stamp=${AMB_STAMP:-<none>} lane=$CLAUDE_CODE_SESSION_ID"
->   # THE SIBLING-TREE REFUSAL: cwd sits in a LINKED worktree that is not mine. The primary checkout
->   # is the harness's documented reset target and is corrected below; a sibling lane's tree is NOT
->   # explained by anything, so stop rather than mutate next to a live lane (#832, #3458/#3580).
->   if [ -n "$AMB_GITDIR" ] && [ "$AMB_GITDIR" != "$AMB_COMMON" ] && [ "$AMB_STAMP" != "$CLAUDE_CODE_SESSION_ID" ]; then
->     echo "wt_preflight FAILED (fail-closed): cwd is inside worktree $(git rev-parse --show-toplevel), stamped '${AMB_STAMP:-<none>}' — a SIBLING lane's tree, not my lane ($CLAUDE_CODE_SESSION_ID). Refusing to mutate." >&2
->     return 1
->   fi
->   # cwd is my own tree or the PRIMARY checkout (the between-calls reset). Resolve my lane by
->   # identity and cd there — the correction. A miss REFUSES: no tree is mine (unprovisioned, torn
->   # down, or a foreign session), or several are (ambiguous).
->   WT="$(lane_worktree)" || { echo "wt_preflight FAILED (fail-closed): no single worktree carries this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2; return 1; }
->   cd "$WT" || { echo "wt_preflight FAILED: cannot cd to worktree root $WT" >&2; return 1; }
->   # DEFENCE IN DEPTH — the resolved lane must not BE the primary checkout. This sits after the
->   # `cd` and is still a genuine assertion, because its operands do not come from the cwd: it
->   # tests `lane_worktree`'s ANSWER with two DIFFERENT plumbing queries whose results coincide
->   # only on the primary. `lane_worktree` returns whatever `worktrees/<name>/gitdir` names, so an
->   # entry naming the primary root, stamped with this lane, resolves here — and this refuses.
->   # Demonstrated firing in PR #4419's review; do not delete it as "true by construction" (#4398).
->   RES_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || { echo "wt_preflight FAILED (fail-closed): resolved lane $WT is not inside a git repository — refusing to mutate." >&2; return 1; }
->   RES_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
->   case "$RES_COMMON" in /*) ;; *) RES_COMMON="$(pwd -P)/$RES_COMMON" ;; esac
->   RES_COMMON="$(cd "$RES_COMMON" && pwd -P)"
->   [ "$RES_GITDIR" != "$RES_COMMON" ] || { echo "wt_preflight FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout ($WT) — git-dir == common-dir. Refusing to mutate." >&2; return 1; }
->   echo "wt_preflight OK: mutating my lane at $WT (git-dir $RES_GITDIR)"
-> }
+> . "$WRITECODE_SCRIPTS/step4-wt-preflight.sh"   # leaves `lane_worktree` + `wt_preflight` in this shell
 > wt_preflight && git <commit|push|switch …>   # the guard gates the mutation; never run the mutation without it
 > ```
 >
@@ -1102,10 +961,9 @@ step is a **no-op**: you implement and ship the change exactly as Steps 4/5 alre
 graceful-absence contract `plan-epic` (stamp) and `review-code` (verify) honor:
 
 ```bash
-# the canonical cycle-doc probe (formats §1) — the SHARED script, not a skill-local copy; it leaves
-# $CYCLE_DOC in this shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cycle-doc-probe.sh"
+# the canonical cycle-doc probe (formats §1) — relayed to the SHARED script, never copied; it
+# leaves $CYCLE_DOC in this shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
+. "$WRITECODE_SCRIPTS/step4b-cycle-doc.sh"
 # ship dark ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -45,12 +45,20 @@ to `kamp-us/phoenix` with no config.
 
 ```bash
 REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
-# This skill's steps are SOURCED scripts under `scripts/` (epic #4435 phase 1, #4449) — resolved the
-# same way §CLI resolves the `pipeline-cli` shim, because neither is on PATH. Source each step's
-# script where the step says to; sourcing (not executing) is what keeps a step's variables and
-# functions visible to the steps after it, exactly as the inline fenced blocks did.
+# Most of this skill's steps are still SOURCED scripts under `scripts/` (epic #4435 phase 1, #4449),
+# resolved the same way §CLI resolves the `pipeline-cli` shim because neither is on PATH. Source each
+# one where its step says to. This variable serves ONLY that surviving sourced set — it is not a
+# second invocation convention on offer, and #4573 deletes it when the last sourced step converts.
 WRITECODE_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/write-code/scripts"
 ```
+
+**The sanctioned invocation form is literal-path execution with a stdout contract (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)) —
+`bash ./claude-plugins/…/scripts/<step>.sh`, results read off stdout.** The harness's isolation
+verifier refuses `.` itself, by *any* path form, and every executor here is worktree-isolated — so a
+sourced step cannot run as designed. The steps written in that form below are the whole of the
+convention; where a step still reads `. "$WRITECODE_SCRIPTS/…"` you are looking at the unconverted
+remainder (#4573), which is history, **not** a shape to copy for anything new.
 
 **A script's non-zero return is UNKNOWN — never an answer (§ZS, ADR
 [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)).**
@@ -191,7 +199,7 @@ work, scan your own open PRs for one whose **latest** gate verdict (in *any* of 
 namespaces) is an unaddressed FAIL:
 
 ```bash
-. "$WRITECODE_SCRIPTS/step1-repairable-prs.sh"   # stdout IS the repairable-PR list — silence is UNKNOWN, never "nothing to repair"
+bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-repairable-prs.sh || exit 1   # stdout IS the repairable-PR list — silence is UNKNOWN, never "nothing to repair"
 ```
 
 If such a PR exists, **repair it instead of picking new work** — go to
@@ -660,14 +668,22 @@ is intentionally left untouched here so the two changes can't double-implement o
 > Run this **mandatory per-mutation preflight** — `wt_preflight` — *immediately before* every
 > `git commit`, `git push`, and branch create/switch (Steps 4, 5, R2, R3). It first asserts that
 > the tree the cwd is *currently* in is not another lane's, then resolves **your** worktree from
-> the lane stamp the opening preflight wrote and `cd`s there, correcting a between-calls reset to
-> the primary checkout. A green `wt_preflight` is the **only** sanctioned path to a mutation — no
-> bypass, same fail-closed construction as the opening preflight:
+> the lane stamp the opening preflight wrote and **prints that root on stdout**. A green
+> `wt_preflight` is the **only** sanctioned path to a mutation — no bypass, same fail-closed
+> construction as the opening preflight:
 >
 > ```bash
-> . "$WRITECODE_SCRIPTS/step4-wt-preflight.sh"   # leaves `lane_worktree` + `wt_preflight` in this shell
-> wt_preflight && git <commit|push|switch …>   # the guard gates the mutation; never run the mutation without it
+> WT="$(bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh)" || exit 1
+> git -C "$WT" <commit|push|switch …>   # address git at the root the guard resolved; never mutate without it
 > ```
+>
+> **The guard decides; you apply.** The script is *executed*, not sourced (ADR 0232), so it cannot
+> `cd` your shell for you — a subprocess never changes its parent's directory, and ADR 0232 retires
+> leave-state-in-the-caller's-shell as a design property outright. What moved is the **effect**, not
+> the decision: every classification and every refusal still runs inside the script, its narration
+> goes to stderr, and stdout carries exactly the resolved root. Correcting a between-calls cwd reset
+> is then the caller's one obligation — **address git at `$WT` explicitly**, never rely on where the
+> cwd happens to be. An empty `$WT` is a refusal, so `|| exit 1` is what keeps that fail-closed.
 >
 > **What makes it able to fail, stated so a future editor can check it.** Both refusals compare
 > operands from different origins: a **stamp file** written when a worktree was proven, against the
@@ -762,8 +778,8 @@ freshly-fetched `FETCH_HEAD` is the only flow that works — don't "fix" it back
 > *filename* is what collides.
 >
 > **The rule (mandatory, at every git op after this create): re-derive the branch live from
-> your own worktree — never read it from a file.** Right after `wt_preflight` re-`cd`s you to
-> `$WT`, the checked-out branch **is** your work branch, so read it straight from the
+> your own worktree — never read it from a file.** Right after `wt_preflight` resolves `$WT`,
+> the branch checked out there **is** your work branch, so read it straight from the
 > worktree HEAD:
 >
 > ```bash
@@ -961,9 +977,9 @@ step is a **no-op**: you implement and ship the change exactly as Steps 4/5 alre
 graceful-absence contract `plan-epic` (stamp) and `review-code` (verify) honor:
 
 ```bash
-# the canonical cycle-doc probe (formats §1) — relayed to the SHARED script, never copied; it
-# leaves $CYCLE_DOC in this shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
-. "$WRITECODE_SCRIPTS/step4b-cycle-doc.sh"
+# the canonical cycle-doc probe (formats §1) — relayed to the SHARED script, never copied; stdout is
+# `present` or `absent`. Absent ⇒ no cycle ⇒ ship normally, no flag.
+CYCLE_DOC="$(bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-cycle-doc.sh)" || exit 1
 # ship dark ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-repairable-prs.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-repairable-prs.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086,SC2162
+# Step 1's pre-pick exception: print every open PR you authored whose LATEST gate verdict is an
+# unaddressed, uncapped FAIL — the arc that must be repaired before any new issue is picked.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 1 fenced block (epic #4435 phase 1, #4449).
+# This is one of the two blocks PR #4503 deliberately left in the markdown while it overlapped the
+# #4372 lane; a byte-move, not a rewrite — replacing this glue with verbs is phase 2 (#1929).
+#
+# SOURCED, never executed (the invocation-class note in `.patterns/skill-script-shell-shape.md`).
+# The fenced block it replaces ran inline in the agent's shell, so this file deliberately sets NO
+# shell options — the moved glue steers its own control flow, several of its guards depend on
+# `pipefail` being OFF (the §CP comment below turns on exactly that), and its `exit` paths are meant
+# to stop the agent's run, not a subshell. No EXIT trap: under bash 3.2 a cleanup trap's last
+# command becomes the script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+ME=$(gh api user --jq '.login')
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314). The shim's own
+# three-tier ladder (in-repo bin → installed bin → the pinned `pnpm dlx`, hooks/pin.sh) decides WHICH
+# build runs, so no version is pinned here (#3653; ADR 0062/0064; epic #994). Each per-(PR, gate)
+# FAIL-bound-to-head resolution below delegates to `pipeline-cli verdict read` (ACL author-gate +
+# latest-wins + SHA-staleness, ADR 0055/0058; its unit tests are the contract).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# GATE-CRITICAL (§CLI): this scan's wrapper turns non-zero into "nothing to repair", so an
+# unresolved CLI would read as a clean scan and the run would fall through to new work while an
+# unaddressed FAIL sits open. Refuse up front — "could not run" is never a verdict.
+[ -x "$PCLI" ] || {
+  echo "pipeline-cli: UNRESOLVED at '$PCLI' — the repairable-PR scan has NO result." >&2
+  echo "  Resolve to UNKNOWN, never to 'no FAIL'. This is a resolution gap, NOT worktree teardown (§CLI)." >&2
+  exit 127
+}
+# §CPREAD's `cp_changed_files`, sourced from its canonical home — no skill-local copy to drift
+# (#4489). It feeds the per-PR §CP-ness derivation inside the loop.
+. "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
+# open PRs you authored; print each one whose latest verdict in EITHER namespace is FAIL,
+# UNLESS it has already hit the N=3 repair cap (then it's a human's, not yours to re-pick)
+gh api "repos/$REPO/pulls?state=open&per_page=100" \
+  --jq ".[] | select(.user.login==\"$ME\") | .number" | while read PR; do
+  # The N=3 FAIL-round count is the one thing `verdict read` does NOT do (it resolves the latest
+  # verdict, it does not count rounds) — genuinely more than a single (PR, gate) resolution, so it
+  # stays inline. Author-gate the FAIL markers to write+ collaborators (ADR 0055, supersedes 0051)
+  # so a forged review-(code|doc|skill): FAIL can't inflate the count; an empty authorized set counts
+  # zero rounds — fail-closed. Cluster by timestamp gap (>120s = new round), per fix-round not per
+  # marker (a both-namespace round counts once), the same identity the Bounding count uses.
+  comments_file=$(mktemp)
+  gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file"
+  markerAuthors=$(jq -r '[.[]
+      | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*(PASS|FAIL)"; "i"))
+      | .user.login] | unique | .[]' "$comments_file")
+  authorized='[]'
+  while IFS= read -r a; do
+    [ -z "$a" ] && continue
+    perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
+    case "$perm" in
+      admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
+    esac
+  done <<<"$markerAuthors"
+  ROUNDS=$(jq --argjson authorized "$authorized" \
+    '[.[] | select(.user.login | IN($authorized[]))
+          | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*FAIL"; "i"))
+          | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
+     | sort
+     | reduce .[] as $t ({n:0, prev:null};
+         if (.prev == null) or ($t - .prev) > 120
+         then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
+     | .n' "$comments_file")
+  [ "$ROUNDS" -ge 3 ] && continue   # at the cap → already escalated to a human, excluded from the scan
+  # §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves (#4049). On a §CP
+  # PR the pass is the SHA-less ADVISORY, which a read without --cp cannot see at all — so a FAIL
+  # discharged by a BODY-ONLY repair (which deliberately never moves the head, so ADR 0058 staleness
+  # can never retire it) reads as a standing FAIL forever and pulls this scan into a phantom repair.
+  # Derive it per PR, fail-closed on BOTH fallible inputs: the changed-file list is a network read, so
+  # it comes from `cp_changed_files` and never a bare `gh … | cp-classify` pipe, which with pipefail
+  # off hands the verb gh's STDOUT error document and answers `not-control-plane` on an unread list
+  # (#4216); and only the PROVEN `not-control-plane` state word drops the flag — never `… ||
+  # CP_FLAG=""` on mere non-zero, which fires on a usage error (1) or a missing bin (127).
+  # `>&2` routes only the §ZS scope LINE, not the result: `cp_changed_files` returns its file list in
+  # $CP_FILES, and this loop's stdout is the repairable-PR list the caller reads. The scope line is
+  # still emitted (§ZS #1), on the same stream as this helper's failure lines.
+  if ! cp_changed_files "$REPO" "$PR" >&2; then
+    CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
+  else
+    CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO" 2>/dev/null)"
+  fi
+  if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
+  # resolve each namespace's latest current-head verdict through the shared verb — exit 0 iff HEAD
+  # carries a current FAIL in that gate (a stale / SHA-less / PASS / none verdict exits non-zero).
+  # stderr is NOT discarded and 127 is read apart from an ordinary negative: with `2>&1` swallowing
+  # it, a `command not found` was byte-identical to "no FAIL verdict" and the PR dropped out of the
+  # scan silently (§CLI exit-code taxonomy — "could not run" is never a verdict; #4398, #4236).
+  for G in code doc skill; do
+    "$PCLI" verdict read --pr "$PR" --gate "$G" $CP_FLAG --expect FAIL >/dev/null
+    RC=$?
+    case $RC in
+      0)   echo "#$PR review-$G FAIL" ;;
+      127) echo "verdict read could not run (127) for #$PR/$G — UNKNOWN, not 'no FAIL'. Stop and route the blocker (§CLI)." >&2; exit 127 ;;
+    esac
+  done
+done

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-repairable-prs.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-repairable-prs.sh
@@ -2,18 +2,23 @@
 # shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086,SC2162
 # Step 1's pre-pick exception: print every open PR you authored whose LATEST gate verdict is an
 # unaddressed, uncapped FAIL — the arc that must be repaired before any new issue is picked.
+# EXECUTED, never sourced (ADR 0232): stdout IS that list, one `#<PR> review-<gate> FAIL` per line,
+# and every diagnostic goes to stderr. Empty stdout with a non-zero exit is UNKNOWN, never
+# "nothing to repair" — which is why the caller carries `|| exit 1`.
 #
-# Extracted VERBATIM from write-code/SKILL.md's Step 1 fenced block (epic #4435 phase 1, #4449).
-# This is one of the two blocks PR #4503 deliberately left in the markdown while it overlapped the
-# #4372 lane; a byte-move, not a rewrite — replacing this glue with verbs is phase 2 (#1929).
+# Extracted from write-code/SKILL.md's Step 1 fenced block (epic #4435 phase 1, #4449) — one of the
+# two blocks PR #4503 left in the markdown while it overlapped the #4372 lane. Replacing this glue
+# with verbs is still phase 2 (#1929); nothing below is rewritten toward that.
 #
-# SOURCED, never executed (the invocation-class note in `.patterns/skill-script-shell-shape.md`).
-# The fenced block it replaces ran inline in the agent's shell, so this file deliberately sets NO
-# shell options — the moved glue steers its own control flow, several of its guards depend on
-# `pipefail` being OFF (the §CP comment below turns on exactly that), and its `exit` paths are meant
-# to stop the agent's run, not a subshell. No EXIT trap: under bash 3.2 a cleanup trap's last
+# `set -uo pipefail`, never `-e`: errexit would abort the §ZS refusals before they print
+# (`.patterns/skill-script-shell-shape.md`). No EXIT trap — under bash 3.2 a cleanup trap's last
 # command becomes the script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479).
+set -uo pipefail
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# `$REPO` no longer arrives from a sourcing caller — resolve it here and fail closed rather than
+# address `repos//pulls`, which would answer an empty scan that reads as "no repairable PR".
+REPO="$(kp_repo)" || exit 1
 
 ME=$(gh api user --jq '.login')
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314). The shim's own
@@ -32,7 +37,10 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 }
 # §CPREAD's `cp_changed_files`, sourced from its canonical home — no skill-local copy to drift
 # (#4489). It feeds the per-PR §CP-ness derivation inside the loop.
-. "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
+# Reached by the documented BASH_SOURCE-relative idiom, the one form ADR 0230's cycle validators
+# resolve statically; the interpolated `${CLAUDE_PLUGIN_ROOT:-…}` shape this replaced could not be,
+# so it dropped write-code out of `validate-cycle-absence`'s scanned scope entirely.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
 # open PRs you authored; print each one whose latest verdict in EITHER namespace is FAIL,
 # UNLESS it has already hit the N=3 repair cap (then it's a human's, not yours to re-pick)
 gh api "repos/$REPO/pulls?state=open&per_page=100" \

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-branch.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-branch.sh
@@ -8,10 +8,11 @@
 # (#1929).
 #
 # SOURCED, never executed. $BRANCH and $PREFIX must land in the sourcing shell exactly as the inline
-# block left them, so this file sets NO shell options. It calls `wt_preflight`, which SKILL.md's
-# per-mutation-preflight blockquote defines in that same shell — sourcing (not executing) is what
-# keeps that function reachable. No EXIT trap: under bash 3.2 a cleanup trap's last command becomes
-# the script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479).
+# block left them, so this file sets NO shell options. It calls `wt_preflight`, which the lib sourced
+# below defines — sourcing (not executing) is what keeps that function reachable, which is why the
+# guard lives in the lib and not in the EXECUTED `step4-wt-preflight.sh` (#4449). No EXIT trap: under
+# bash 3.2 a cleanup trap's last command becomes the script's status, laundering a `set -u` abort
+# into exit 0 (#4476, class #4479).
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # The one seam this move needed: the block's `<slug-for-issue-N>` metavariable was substituted by

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
+# The per-mutation worktree preflight: defines `lane_worktree` and `wt_preflight`, the guard every
+# `git commit` / `git push` / branch op in Steps 4–5 and repair R2/R3 is gated on.
+#
+# Extracted VERBATIM from write-code/SKILL.md's per-mutation-preflight blockquote (epic #4435
+# phase 1, #4449) — the second of the two blocks PR #4503 left behind. The only change is the
+# blockquote's `> ` prefix, which is markdown, not shell.
+#
+# SOURCED, never executed — and here that is the CONTRACT, not a convention: `wt_preflight`'s
+# correction is a `cd` into this lane's worktree, which only survives in the caller's own shell.
+# Sets NO shell options for the same reason its 27 siblings don't (the moved glue steers its own
+# control flow, and `return`-based refusals need the caller's shell). No EXIT trap: under bash 3.2 a
+# cleanup trap's last command becomes the script's status, laundering a `set -u` abort into exit 0
+# (#4476, class #4479).
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# Resolve MY worktree by IDENTITY, never from cwd (#4398). `git rev-parse --show-toplevel` answers
+# "where is the cwd" — which a between-calls reset makes a different question from "which tree is
+# mine". Deriving $WT from it and then re-deriving the toplevel to compare against is one answer
+# checked against itself: always equal, so its failure branch could never print. The stamp is
+# CONTENT written once when $WT was trustworthy, so these two operands can genuinely differ.
+lane_worktree() {   # print the absolute root of the worktree stamped with THIS lane's session id
+  common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$common" in /*) ;; *) common="$(pwd -P)/$common" ;; esac
+  common="$(cd "$common" && pwd -P)" || return 1   # -P: git answers in PHYSICAL paths, so must we
+  hits=""
+  for st in "$common"/worktrees/*/kampus-lane; do
+    [ -f "$st" ] || continue
+    [ "$(cat "$st")" = "$CLAUDE_CODE_SESSION_ID" ] || continue
+    gd="$(cat "${st%/kampus-lane}/gitdir")" || return 1   # "<worktree-root>/.git"
+    hits="$hits $(cd "${gd%/.git}" && pwd -P)"
+  done
+  set -- $hits
+  [ "$#" -eq 1 ] || return 1   # 0 ⇒ no tree is mine; >1 ⇒ ambiguous. Both REFUSE (fail-closed).
+  printf '%s\n' "$1"
+}
+wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-closed, re-correcting cwd
+  : "${CLAUDE_CODE_SESSION_ID:?wt_preflight FAILED (fail-closed): no session id — no lane identity to verify a worktree against}"
+  # CLASSIFY THE AMBIENT TREE FIRST — the lane-identity assertions live here, because this is the
+  # only place THESE operands can differ. `$AMB_STAMP` is a file some lane wrote when its worktree
+  # was proven; `$CLAUDE_CODE_SESSION_ID` is the process env. After the corrective `cd` below these
+  # two agree BY CONSTRUCTION, so re-checking THEM down there would be checking a value against its
+  # own derivation — which is exactly what shipped, and why the sibling-tree refusal never printed
+  # (#4398). That is a fact about these operands, not about position: the post-`cd` refusal below
+  # reads independent operands and does fire.
+  AMB_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+  AMB_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+  case "$AMB_COMMON" in ""|/*) ;; *) AMB_COMMON="$(pwd -P)/$AMB_COMMON" ;; esac
+  [ -n "$AMB_COMMON" ] && AMB_COMMON="$(cd "$AMB_COMMON" && pwd -P)"   # -P: compare like for like with git's physical answer
+  AMB_STAMP="$(cat "$AMB_GITDIR/kampus-lane" 2>/dev/null)"
+  echo "wt_preflight: ambient=$(git rev-parse --show-toplevel 2>/dev/null || echo '<not a repo>') ambient-git-dir=${AMB_GITDIR:-<none>} ambient-stamp=${AMB_STAMP:-<none>} lane=$CLAUDE_CODE_SESSION_ID"
+  # THE SIBLING-TREE REFUSAL: cwd sits in a LINKED worktree that is not mine. The primary checkout
+  # is the harness's documented reset target and is corrected below; a sibling lane's tree is NOT
+  # explained by anything, so stop rather than mutate next to a live lane (#832, #3458/#3580).
+  if [ -n "$AMB_GITDIR" ] && [ "$AMB_GITDIR" != "$AMB_COMMON" ] && [ "$AMB_STAMP" != "$CLAUDE_CODE_SESSION_ID" ]; then
+    echo "wt_preflight FAILED (fail-closed): cwd is inside worktree $(git rev-parse --show-toplevel), stamped '${AMB_STAMP:-<none>}' — a SIBLING lane's tree, not my lane ($CLAUDE_CODE_SESSION_ID). Refusing to mutate." >&2
+    return 1
+  fi
+  # cwd is my own tree or the PRIMARY checkout (the between-calls reset). Resolve my lane by
+  # identity and cd there — the correction. A miss REFUSES: no tree is mine (unprovisioned, torn
+  # down, or a foreign session), or several are (ambiguous).
+  WT="$(lane_worktree)" || { echo "wt_preflight FAILED (fail-closed): no single worktree carries this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2; return 1; }
+  cd "$WT" || { echo "wt_preflight FAILED: cannot cd to worktree root $WT" >&2; return 1; }
+  # DEFENCE IN DEPTH — the resolved lane must not BE the primary checkout. This sits after the
+  # `cd` and is still a genuine assertion, because its operands do not come from the cwd: it
+  # tests `lane_worktree`'s ANSWER with two DIFFERENT plumbing queries whose results coincide
+  # only on the primary. `lane_worktree` returns whatever `worktrees/<name>/gitdir` names, so an
+  # entry naming the primary root, stamped with this lane, resolves here — and this refuses.
+  # Demonstrated firing in PR #4419's review; do not delete it as "true by construction" (#4398).
+  RES_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || { echo "wt_preflight FAILED (fail-closed): resolved lane $WT is not inside a git repository — refusing to mutate." >&2; return 1; }
+  RES_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
+  case "$RES_COMMON" in /*) ;; *) RES_COMMON="$(pwd -P)/$RES_COMMON" ;; esac
+  RES_COMMON="$(cd "$RES_COMMON" && pwd -P)"
+  [ "$RES_GITDIR" != "$RES_COMMON" ] || { echo "wt_preflight FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout ($WT) — git-dir == common-dir. Refusing to mutate." >&2; return 1; }
+  echo "wt_preflight OK: mutating my lane at $WT (git-dir $RES_GITDIR)"
+}

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
+# shellcheck shell=bash disable=SC1007,SC1091
 # The per-mutation worktree preflight — the guard every commit / branch op / verified-push in
 # Steps 4–5 and repair R2/R3 is gated on. EXECUTED, never sourced (ADR 0232): it runs the whole
 # fail-closed classification here and prints the resolved worktree ROOT on stdout; every
@@ -9,76 +9,18 @@
 # change its parent's directory, and ADR 0232 retires leave-state-in-the-caller's-shell as a
 # design property outright.
 #
-# The guard body below is VERBATIM from write-code/SKILL.md's per-mutation-preflight blockquote
-# (epic #4435 phase 1, #4449) — every refusal branch and both `cd`s intact. The internal `cd "$WT"`
-# stays because the defence-in-depth plumbing after it reads the tree it lands in.
+# The guard body itself is NOT here: `wt_preflight` and `lane_worktree` live in `lib/common.sh`,
+# sourced below. This script owns only the EXECUTED FORM — run the guard, narrate to stderr, print
+# the resolved root. Hosting the definitions here instead would strand four SOURCED siblings
+# (`step4-branch.sh`, `step5-push.sh`, `stepR2-branch-rebase.sh`, `stepR3-push-and-note.sh`) that
+# call `wt_preflight` in the agent's own shell: a subprocess's functions never reach its parent, and
+# no CI check can see the break (#4449 repair round 2).
 #
 # `set -uo pipefail`, never `-e`: errexit aborts a fail-closed branch before it prints its BLOCKING
 # line, and paired with a cleanup EXIT trap it launders a `set -u` abort into exit 0
 # (`.patterns/skill-script-shell-shape.md`). No EXIT trap is installed here either.
 set -uo pipefail
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
-
-# Resolve MY worktree by IDENTITY, never from cwd (#4398). `git rev-parse --show-toplevel` answers
-# "where is the cwd" — which a between-calls reset makes a different question from "which tree is
-# mine". Deriving $WT from it and then re-deriving the toplevel to compare against is one answer
-# checked against itself: always equal, so its failure branch could never print. The stamp is
-# CONTENT written once when $WT was trustworthy, so these two operands can genuinely differ.
-lane_worktree() {   # print the absolute root of the worktree stamped with THIS lane's session id
-  common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
-  case "$common" in /*) ;; *) common="$(pwd -P)/$common" ;; esac
-  common="$(cd "$common" && pwd -P)" || return 1   # -P: git answers in PHYSICAL paths, so must we
-  hits=""
-  for st in "$common"/worktrees/*/kampus-lane; do
-    [ -f "$st" ] || continue
-    [ "$(cat "$st")" = "$CLAUDE_CODE_SESSION_ID" ] || continue
-    gd="$(cat "${st%/kampus-lane}/gitdir")" || return 1   # "<worktree-root>/.git"
-    hits="$hits $(cd "${gd%/.git}" && pwd -P)"
-  done
-  set -- $hits
-  [ "$#" -eq 1 ] || return 1   # 0 ⇒ no tree is mine; >1 ⇒ ambiguous. Both REFUSE (fail-closed).
-  printf '%s\n' "$1"
-}
-wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-closed, re-correcting cwd
-  : "${CLAUDE_CODE_SESSION_ID:?wt_preflight FAILED (fail-closed): no session id — no lane identity to verify a worktree against}"
-  # CLASSIFY THE AMBIENT TREE FIRST — the lane-identity assertions live here, because this is the
-  # only place THESE operands can differ. `$AMB_STAMP` is a file some lane wrote when its worktree
-  # was proven; `$CLAUDE_CODE_SESSION_ID` is the process env. After the corrective `cd` below these
-  # two agree BY CONSTRUCTION, so re-checking THEM down there would be checking a value against its
-  # own derivation — which is exactly what shipped, and why the sibling-tree refusal never printed
-  # (#4398). That is a fact about these operands, not about position: the post-`cd` refusal below
-  # reads independent operands and does fire.
-  AMB_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
-  AMB_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
-  case "$AMB_COMMON" in ""|/*) ;; *) AMB_COMMON="$(pwd -P)/$AMB_COMMON" ;; esac
-  [ -n "$AMB_COMMON" ] && AMB_COMMON="$(cd "$AMB_COMMON" && pwd -P)"   # -P: compare like for like with git's physical answer
-  AMB_STAMP="$(cat "$AMB_GITDIR/kampus-lane" 2>/dev/null)"
-  echo "wt_preflight: ambient=$(git rev-parse --show-toplevel 2>/dev/null || echo '<not a repo>') ambient-git-dir=${AMB_GITDIR:-<none>} ambient-stamp=${AMB_STAMP:-<none>} lane=$CLAUDE_CODE_SESSION_ID"
-  # THE SIBLING-TREE REFUSAL: cwd sits in a LINKED worktree that is not mine. The primary checkout
-  # is the harness's documented reset target and is corrected below; a sibling lane's tree is NOT
-  # explained by anything, so stop rather than mutate next to a live lane (#832, #3458/#3580).
-  if [ -n "$AMB_GITDIR" ] && [ "$AMB_GITDIR" != "$AMB_COMMON" ] && [ "$AMB_STAMP" != "$CLAUDE_CODE_SESSION_ID" ]; then
-    echo "wt_preflight FAILED (fail-closed): cwd is inside worktree $(git rev-parse --show-toplevel), stamped '${AMB_STAMP:-<none>}' — a SIBLING lane's tree, not my lane ($CLAUDE_CODE_SESSION_ID). Refusing to mutate." >&2
-    return 1
-  fi
-  # cwd is my own tree or the PRIMARY checkout (the between-calls reset). Resolve my lane by
-  # identity and cd there — the correction. A miss REFUSES: no tree is mine (unprovisioned, torn
-  # down, or a foreign session), or several are (ambiguous).
-  WT="$(lane_worktree)" || { echo "wt_preflight FAILED (fail-closed): no single worktree carries this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2; return 1; }
-  cd "$WT" || { echo "wt_preflight FAILED: cannot cd to worktree root $WT" >&2; return 1; }
-  # DEFENCE IN DEPTH — the resolved lane must not BE the primary checkout. This sits after the
-  # `cd` and is still a genuine assertion, because its operands do not come from the cwd: it
-  # tests `lane_worktree`'s ANSWER with two DIFFERENT plumbing queries whose results coincide
-  # only on the primary. `lane_worktree` returns whatever `worktrees/<name>/gitdir` names, so an
-  # entry naming the primary root, stamped with this lane, resolves here — and this refuses.
-  # Demonstrated firing in PR #4419's review; do not delete it as "true by construction" (#4398).
-  RES_GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || { echo "wt_preflight FAILED (fail-closed): resolved lane $WT is not inside a git repository — refusing to mutate." >&2; return 1; }
-  RES_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
-  case "$RES_COMMON" in /*) ;; *) RES_COMMON="$(pwd -P)/$RES_COMMON" ;; esac
-  RES_COMMON="$(cd "$RES_COMMON" && pwd -P)"
-  [ "$RES_GITDIR" != "$RES_COMMON" ] || { echo "wt_preflight FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout ($WT) — git-dir == common-dir. Refusing to mutate." >&2; return 1; }
-  echo "wt_preflight OK: mutating my lane at $WT (git-dir $RES_GITDIR)"
-}
 
 # `>&2` routes the guard's whole narration — the ambient-classification line and every refusal —
 # to stderr WITHOUT touching a moved line, leaving stdout carrying exactly one thing: the root.

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2086
-# The per-mutation worktree preflight: defines `lane_worktree` and `wt_preflight`, the guard every
-# `git commit` / `git push` / branch op in Steps 4–5 and repair R2/R3 is gated on.
+# The per-mutation worktree preflight — the guard every commit / branch op / verified-push in
+# Steps 4–5 and repair R2/R3 is gated on. EXECUTED, never sourced (ADR 0232): it runs the whole
+# fail-closed classification here and prints the resolved worktree ROOT on stdout; every
+# diagnostic and every refusal line goes to stderr. The caller consumes that root and addresses
+# git at it explicitly (`git -C "$WT" …`) — the DECISION stays in the script, only its EFFECT
+# moves to the caller, which is what the stdout contract (#4510) is for. A subprocess cannot
+# change its parent's directory, and ADR 0232 retires leave-state-in-the-caller's-shell as a
+# design property outright.
 #
-# Extracted VERBATIM from write-code/SKILL.md's per-mutation-preflight blockquote (epic #4435
-# phase 1, #4449) — the second of the two blocks PR #4503 left behind. The only change is the
-# blockquote's `> ` prefix, which is markdown, not shell.
+# The guard body below is VERBATIM from write-code/SKILL.md's per-mutation-preflight blockquote
+# (epic #4435 phase 1, #4449) — every refusal branch and both `cd`s intact. The internal `cd "$WT"`
+# stays because the defence-in-depth plumbing after it reads the tree it lands in.
 #
-# SOURCED, never executed — and here that is the CONTRACT, not a convention: `wt_preflight`'s
-# correction is a `cd` into this lane's worktree, which only survives in the caller's own shell.
-# Sets NO shell options for the same reason its 27 siblings don't (the moved glue steers its own
-# control flow, and `return`-based refusals need the caller's shell). No EXIT trap: under bash 3.2 a
-# cleanup trap's last command becomes the script's status, laundering a `set -u` abort into exit 0
-# (#4476, class #4479).
+# `set -uo pipefail`, never `-e`: errexit aborts a fail-closed branch before it prints its BLOCKING
+# line, and paired with a cleanup EXIT trap it launders a `set -u` abort into exit 0
+# (`.patterns/skill-script-shell-shape.md`). No EXIT trap is installed here either.
+set -uo pipefail
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # Resolve MY worktree by IDENTITY, never from cwd (#4398). `git rev-parse --show-toplevel` answers
@@ -75,3 +79,9 @@ wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-cl
   [ "$RES_GITDIR" != "$RES_COMMON" ] || { echo "wt_preflight FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout ($WT) — git-dir == common-dir. Refusing to mutate." >&2; return 1; }
   echo "wt_preflight OK: mutating my lane at $WT (git-dir $RES_GITDIR)"
 }
+
+# `>&2` routes the guard's whole narration — the ambient-classification line and every refusal —
+# to stderr WITHOUT touching a moved line, leaving stdout carrying exactly one thing: the root.
+# Silence on stdout plus a non-zero exit is therefore UNKNOWN/REFUSED, never a permissive answer.
+wt_preflight >&2 || exit 1
+printf '%s\n' "$WT"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-cycle-doc.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-cycle-doc.sh
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash disable=SC1007,SC1091,SC2016
-# Step 4b's graceful-absence probe: resolve whether this install HAS a product-development cycle,
-# leaving `$CYCLE_DOC` in the caller's shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
+# Step 4b's graceful-absence probe: resolve whether this install HAS a product-development cycle.
+# EXECUTED, never sourced (ADR 0232): it prints `present` or `absent` on stdout, and the caller
+# reads it there. Absent ⇒ no cycle ⇒ ship normally, no flag.
 #
-# Extracted VERBATIM from write-code/SKILL.md's Step 4b fenced block (epic #4435 phase 1, #4449).
-# The probe itself stays the SHARED script — this file relays the seam to it and never copies it.
+# Extracted from write-code/SKILL.md's Step 4b fenced block (epic #4435 phase 1, #4449). The probe
+# itself stays the SHARED script — this file relays the seam to it and never copies it.
 #
-# SOURCED, never executed — see `.patterns/skill-script-shell-shape.md`. Sets NO shell options and
-# installs no EXIT trap, for the reasons its siblings state.
+# `set -uo pipefail`, never `-e`, and no EXIT trap (`.patterns/skill-script-shell-shape.md`).
+set -uo pipefail
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
-# the canonical cycle-doc probe (formats §1) — the SHARED script, not a skill-local copy; it leaves
-# $CYCLE_DOC in this shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cycle-doc-probe.sh"
+# The shared probe reads `$REPO`, which no longer arrives from a sourcing caller — resolve it here
+# and fail closed, so an unresolvable repo can never probe `repos//…` and answer `absent`.
+if [ -z "${REPO:-}" ]; then
+	REPO="$(kp_repo)" || exit 1
+fi
+# the canonical cycle-doc probe (formats §1) — the SHARED script, not a skill-local copy. Reached by
+# the documented BASH_SOURCE-relative idiom, the one form ADR 0230's cycle validators resolve
+# statically; the interpolated `${CLAUDE_PLUGIN_ROOT:-…}` shape this replaced could not be.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cycle-doc-probe.sh"
 # ship dark ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]
+printf '%s\n' "$CYCLE_DOC"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-cycle-doc.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4b-cycle-doc.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# Step 4b's graceful-absence probe: resolve whether this install HAS a product-development cycle,
+# leaving `$CYCLE_DOC` in the caller's shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
+#
+# Extracted VERBATIM from write-code/SKILL.md's Step 4b fenced block (epic #4435 phase 1, #4449).
+# The probe itself stays the SHARED script — this file relays the seam to it and never copies it.
+#
+# SOURCED, never executed — see `.patterns/skill-script-shell-shape.md`. Sets NO shell options and
+# installs no EXIT trap, for the reasons its siblings state.
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# the canonical cycle-doc probe (formats §1) — the SHARED script, not a skill-local copy; it leaves
+# $CYCLE_DOC in this shell. Absent ⇒ no cycle ⇒ ship normally, no flag.
+KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
+. "$KP_SHARED/cycle-doc-probe.sh"
+# ship dark ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-push.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step5-push.sh
@@ -10,8 +10,9 @@
 # next to this file's invocation.
 #
 # SOURCED, never executed. $BRANCH must land in the sourcing shell exactly as the inline block left
-# it, and `wt_preflight` / `claim_is_mine` are defined in that same shell — sourcing (not executing)
-# is what keeps them reachable. Sets NO shell options; no EXIT trap (#4476, class #4479).
+# it; `wt_preflight` comes from the lib sourced below and `claim_is_mine` from Step 3.5's script,
+# both in that same shell — sourcing (not executing) is what keeps them reachable (#4449). Sets NO
+# shell options; no EXIT trap (#4476, class #4479).
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # The one seam this move needed: the block's `<N>` metavariable was substituted by whoever ran the

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-branch-rebase.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-branch-rebase.sh
@@ -5,9 +5,10 @@
 # Extracted VERBATIM from write-code/SKILL.md's Step R2 fenced block (epic #4435 phase 1, #4449).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed: `claim_is_mine` and `wt_preflight` are defined in the sourcing shell, and
-# the `cd` that `wt_preflight` performs must persist for the rebase and the R3 push. Sets NO shell
-# options; no EXIT trap (#4476, class #4479).
+# SOURCED, never executed: `claim_is_mine` (Step 3.5's script) and `wt_preflight` (the lib sourced
+# below) both live in the sourcing shell, and the `cd` that `wt_preflight` performs must persist for
+# the rebase and the R3 push — which is why that guard is defined in the lib rather than in the
+# EXECUTED `step4-wt-preflight.sh` (#4449). Sets NO shell options; no EXIT trap (#4476, class #4479).
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # The one seam this move needed: the block's `<the PR's head branch>` metavariable was substituted by

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-push-and-note.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR3-push-and-note.sh
@@ -8,9 +8,11 @@
 # hand-rolled $RUN_SCRATCH derivation duplicates `kp_scratch_path` (the plugin lib/common.sh), and
 # collapsing it onto that helper is phase 2's call.
 #
-# SOURCED, never executed: it reads the $N / $PR / $WT and the `claim_is_mine` + `wt_preflight`
-# functions the earlier steps left in this shell. WRITE "$RUN_SCRATCH/repair-progress.md" BEFORE
-# sourcing this. Sets NO shell options; no EXIT trap (#4476, class #4479).
+# SOURCED, never executed: it reads the $N / $PR / $WT the earlier steps left in this shell, plus
+# `claim_is_mine` (Step 3.5's script) and `wt_preflight` (the lib sourced below, which is why that
+# guard lives there and not in the EXECUTED `step4-wt-preflight.sh` — #4449). WRITE
+# "$RUN_SCRATCH/repair-progress.md" BEFORE sourcing this. Sets NO shell options; no EXIT trap
+# (#4476, class #4479).
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).


### PR DESCRIPTION
`write-code`'s SKILL.md still carried three multi-line shell blocks that PR #4503 deliberately left behind while it overlapped the #4372 lane. This moves that documented remainder — 148 shell lines — into three scripts under `skills/write-code/scripts/`, **in the executed class** ([ADR 0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)), so the markdown now holds prose and invocations only.

Closes #4449

## What moved

| Block (at base `365ed964`) | Lines | Destination | Stdout contract |
|---|---|---|---|
| Step 1's repairable-PR scan | `SKILL.md` 194–276 (83) | `scripts/step1-repairable-prs.sh` | one `#<PR> review-<gate> FAIL` per line |
| The per-mutation preflight (`lane_worktree` + `wt_preflight`) | `SKILL.md` 750–809 (60) | the two functions to `lib/common.sh`; the executed form to `scripts/step4-wt-preflight.sh` | the resolved worktree root |
| Step 4b's cycle-doc probe seam | `SKILL.md` 1105–1109 (5) | `scripts/step4b-cycle-doc.sh` | `present` or `absent` |

Each is invoked by literal path — `bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/<step>.sh` — with results read off stdout, every diagnostic on stderr, and `|| exit 1` at each site so an empty stdout can never read as a permissive answer (§ZS, ADR 0092). Each sources the shared lib at its post-#4563 home, `claude-plugins/kampus-pipeline/lib/common.sh`, through the house `BASH_SOURCE`-relative edge idiom; the old `skills/shared/lib/` path appears nowhere.

## The preflight's `cd`, and how it converts

`wt_preflight`'s correction genuinely *was* a `cd` into the lane's worktree, and a subprocess cannot change its parent's directory. That is a real conflict between a byte-faithful move and the mandated convention — and it resolves without weakening the guard, because **only the effect has to move, not the decision**:

- Every classification and all four refusal branches still run **inside** the script, on the same bytes.
- The internal `cd "$WT"` stays, because the defence-in-depth plumbing after it reads the tree it lands in.
- `wt_preflight >&2` routes the guard's whole narration to stderr *without touching a moved line*, so stdout carries exactly the resolved root.
- The caller consumes that root and addresses git at it explicitly (`git -C "$WT" …`) — which `agents/coder.md` already mandates and which `SKILL.md`'s live-branch-re-derivation block already did.

Silence on stdout plus a non-zero exit is therefore UNKNOWN/REFUSED, never "proceed". ADR 0232 retires leave-state-in-the-caller's-shell as a design property and bans designing for it, so this is the shape the ruling asks for rather than a workaround around it.

**Where the two functions live (repair round 2).** `wt_preflight` and `lane_worktree` are hosted in `lib/common.sh`, not in the executed script. The executed form is one of *two* caller classes: four still-**sourced** siblings — `step4-branch.sh`, `step5-push.sh`, `stepR2-branch-rebase.sh`, `stepR3-push-and-note.sh` — call `wt_preflight` by name in the agent's own shell and read the `$WT` it leaves there. A subprocess's functions never reach its parent, so hosting the definitions in `step4-wt-preflight.sh` alone stranded all four at exit 127. The lib is the file all four already source, so the seam is restored with no change to the executed contract and no change to the moved bytes.

## Byte-move proof (reviewer-runnable)

The preflight — the block whose fidelity was most at risk — reproduces its **entire** 60-line span unchanged. `step1`'s span reproduces in two sub-spans either side of the one line the ADR 0230 fix had to rewrite. Run from the repo root:

```bash
BASE="$(mktemp -d)/base.md"
git show 365ed964:claude-plugins/kampus-pipeline/skills/write-code/SKILL.md > "$BASE"
D=claude-plugins/kampus-pipeline/skills/write-code/scripts

# the whole preflight guard, byte-identical (only the markdown blockquote prefix stripped).
# Since repair round 2 the span's home is the shared lib, unchanged byte for byte.
sed -n '750,809p' "$BASE" | sed 's/^> //; s/^>$//' | shasum -a 256
sed -n '423,482p' claude-plugins/kampus-pipeline/lib/common.sh | shasum -a 256
#   both: 0a5036d7aef54608719d51a5fdd3351278b8ebb969b5880c57ca27cbec0ca9c7

# step1, segment A — the block up to and including the §CPREAD comment
sed -n '194,210p' "$BASE" | shasum -a 256
sed -n '23,39p' "$D/step1-repairable-prs.sh" | shasum -a 256
#   both: 0a5dc4d7ac948437713ff0c2c9606d03854bcbeb4b6b3196fa52e870bdbf4e68

# step1, segment B — everything after the cp-read.sh source line
sed -n '212,276p' "$BASE" | shasum -a 256
sed -n '44,108p' "$D/step1-repairable-prs.sh" | shasum -a 256
#   both: 52baf5314e4d34091d5f1b8adbbea697c2e07739770d8ea5cf30aa77c612d386
```

Exactly **one** moved line is not covered: base `SKILL.md:211`, the `cp-read.sh` source, rewritten to the documented idiom for the reason in Deviations round 1 (a). `step4b-cycle-doc.sh` makes no byte-move claim at all — its five-line glue *is* the invocation form, so converting it rewrote all of it; it is five lines and reads directly against the base.

## What is deliberately still fenced

- **The `$REPO` / `$WRITECODE_SCRIPTS` preamble.** `$WRITECODE_SCRIPTS` now serves *only* the 27 still-sourced sibling steps this lane did not extract, and the preamble goes when the last of them converts (#4573). Deleting it here would break 27 invocation sites in a lane scoped to 3 — see Deviations round 1 (c).
- **The `gh pr create` body template** — authored content with placeholders, not runnable glue; the surrounding prose already says so.

`verify-extraction.sh`'s AC1 check counts an invocation only when it names `skills/<skill>/scripts/<name>.sh` literally — i.e. it was written for exactly the executed form. All **three** converted sites now pass it; the blocks it still flags are the surviving sourced siblings plus the two carve-outs above.

## Deviations

**Class: convention departure — the new scripts are SOURCED, not the executed form ADR 0232 mandates.**

- **Said.** [ADR 0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md) (landed 2026-07-30, after this issue was written) rules that the sanctioned invocation form is literal-path execution with a stdout contract, and that the sourced class converts to executed scripts.
- **Did.** These three land in the **sourced** class, matching the 27 scripts already in this directory and the `. "$WRITECODE_SCRIPTS/…"` invocation form every other step in this file uses.
- **Why.** Two reasons, either sufficient. (1) `wt_preflight`'s contract *is* a `cd` into the lane's worktree — it only survives in the caller's shell. Converting it to the stdout form is a semantic rewrite of the guard, and #4449 scopes that out explicitly (*"Out of scope: any rewrite of the moved glue"*); AC2 asks for a byte-faithful move, which a contract change would forfeit. (2) Converting three scripts while 27 siblings and ~23 invocation sites across `SKILL.md` + `repair.md` stay sourced would leave the file in two regimes at once — strictly worse to read and to gate than one uniform file plus one conversion unit. ADR 0232 routes it the same way: *"Implementation fan-out files into #4435's programme as mechanical units — the conversion is not this ADR's diff."*
- **Disposition.** Follow-up filed for the whole-corpus conversion of `write-code` (30 scripts + `SKILL.md` + `repair.md`) as one ADR-0232 unit under epic #4435. Not silently deferred — this PR does not claim 0232 compliance.
- **(repair round 1) — RETRACTED. This departure is withdrawn, not restated.** The gate read the three governing sources and the refusal fails on the limb the rest rested on: ADR 0232's fan-out clause governs conversion of the **pre-existing** sourced class, not new extraction — its hold on the extraction tail lifts *"for lanes following this convention"*, and it separately **bans** *"[d]esigning a new skill script to mutate the caller's shell state."* #4435's ledger (*"#4449 — extract write-code; remainder lands executed per ADR 0232"*, *"no double conversion"*) and #4449's own body, amended 2026-07-31 (*"only newly extracted shell follows the executed shape directly"*), say the same. Round 0 also misread its out-of-scope clause: it is parenthetically bounded to *"(#1929, phase 2)"* — verbification, not the invocation convention. All three scripts now land executed. The one limb that was factually right — the preflight's caller-shell `cd` — is real but covers 1 of 3 blocks and is resolved above by moving the effect while keeping the decision and the bytes; escalation, not a unilateral landing of the banned regime, was the right move for it.

**Class: (repair round 1) departure from strict byte-fidelity — three moved lines rewritten.**

- **(a) `step1-repairable-prs.sh`, base `SKILL.md:211`.** The `cp-read.sh` source used the interpolated `${CLAUDE_PLUGIN_ROOT:-…}` form. Harmless as prose; inside a `.sh` it is a source edge [ADR 0230](https://github.com/kamp-us/phoenix/blob/main/.decisions/0230-cycle-validators-follow-the-source-edge.md)'s validators cannot resolve statically, so `write-code` dropped **out of** `validate-cycle-absence`'s scanned scope and broke the graceful-absence guarantee — the required check that was red. Rewritten to the documented `BASH_SOURCE`-relative idiom. `write-code` is back in scope with both its edges resolved (`cp-read.sh`, `cycle-doc-probe.sh`).
- **(b) `step4b-cycle-doc.sh`, base `SKILL.md:1107–1108`.** Same idiom fix for `cycle-doc-probe.sh`, plus a `kp_repo` fallback: the shared probe reads `$REPO`, which no longer arrives from a sourcing caller, and an unresolved repo would probe `repos//…` and answer `absent`. It fails closed instead. `step1` gets the same `$REPO` resolution for the same reason.
- **(c) `step4-wt-preflight.sh` header comment, line 4.** The corpus lint reds on `git … push` anywhere in a `.sh`, which is runnable in its entirety, and it deliberately carries **no pragma and no self-exempt list** (ADR 0202) — so the sanctioned fix is to reword, which is what the rewritten header does. Not routed as a linter false positive: for markdown the check already scopes to fenced blocks, and adding an escape hatch to the `.sh` path is precisely the thing the detector's docblock rules out. The **moved** span of that file is untouched and still hashes identical.

**Class: (repair round 1) narrower fix than the verdict prescribed — the `WRITECODE_SCRIPTS` preamble stays.**

The verdict expected the executed form to delete the preamble and clear AC1 outright. That holds only once *all 30* scripts convert: 27 sourced siblings still resolve their path through `$WRITECODE_SCRIPTS`, so deleting it here would break 27 invocation sites from a lane scoped to 3 — and #4573 is the already-planned unit that converts exactly those. The preamble's comment is rewritten to say it serves only the surviving sourced set and is not a second convention on offer, and a new paragraph states the literal-path form as *the* convention. **The three scripts this lane adds should be noted against #4573's enumerated scope (26 → 29 write-code scripts).**

**Class: (repair round 2) the guard's host file changed — `wt_preflight` / `lane_worktree` move to `lib/common.sh`.**

- **Found.** The round-1 conversion left both functions defined only inside the executed `step4-wt-preflight.sh`. Four still-sourced siblings call `wt_preflight` in the agent's own shell (`step4-branch.sh:41`, `step5-push.sh:31`/`:37`, `stepR2-branch-rebase.sh:27`/`:28`, `stepR3-push-and-note.sh:26`), so Steps 4, 5, R2 and R3 all died `command not found` — `write-code` could neither cut a branch nor push. It failed **closed** (127 short-circuits the `&&`), but the mandated ADR-0172 guard stopped running and no CI check could see it.
- **Did.** Moved both functions, byte-identically, into `lib/common.sh` — the file all four consumers already source — and left `step4-wt-preflight.sh` owning only the executed form (source the lib, run the guard, narrate to stderr, print the root). The 60-line span still hashes `0a5036d7…`, the four smoke tests are unchanged, and #4573's scope is untouched.
- **Why the lib and not each caller.** A per-caller copy is four copies of a fail-closed guard drifting independently; the lib is the one file every pipeline shell script already sources, and it is §CP by directory, so the guard keeps its human-approval gate.
- **Two conventions of the host file are knowingly departed from, both because the block is a byte-move.** The moved span keeps its two-space indent against the file's tabs, and the two functions keep their unprefixed names against the file's `kp_` convention — the names are what the four callers and `SKILL.md` refer to. `SC2086` is added to the file's `disable=` list for the one moved line (`set -- $hits`) where the word-splitting *is* the mechanism; declared with its reason, not blanket-suppressed.
- **Also touched:** the four siblings' docblocks each asserted that `wt_preflight` "is defined in the sourcing shell" without saying by what. Corrected to name the lib. No executable line in any of the four changed.

**Class: none other.** No behavior change beyond the invocation-class conversion and the guard's relocation, no prose restructuring beyond the invocation sites and the sentences describing the preflight's contract.

## Verification

Both jobs that were red at `9d929b85` are green locally at this head, re-run exactly as their workflows invoke them:

- **`validate skill frontmatter`** (required) — all six steps rc=0: `validate-skills` (30 skills), `validate-cycle-absence` (14 checks), `validate-cycle-presence` (18 checks), `lib/common-test.sh`, `verify-chain-resolves.sh`, `validate-gate-path-drift` (34 checks).
- **`lint skill corpus …`** — `clean — no GraphQL-path gh calls, no bare git push in an executable block, and all frontmatter parses as strict YAML` (277 files in the bare-push scan).

Also re-run: `trap-status-guard` clean (294 files, 215 shell units); `cli-invocation-guard` clean; `shellcheck -x` exit 0 over the whole `scripts/` corpus; `verify-byte-move.sh` OK; `verify-fail-closed.sh` OK.

Live smoke tests of all three converted scripts:

- `step4-wt-preflight.sh` against a purpose-built primary+linked-worktree pair — success path exits 0 with stdout equal to the worktree root and nothing else; a foreign session id and a missing session id each exit non-zero with **empty stdout**.
- `step1-repairable-prs.sh` — exits 0 with stdout exactly `#4578 review-skill FAIL` / `#4389 review-code FAIL`, all `verdict:` and `§CP scope:` narration on stderr. A transient `verdict read` failure on one run surfaced as exit 127 with empty stdout, which is the §ZS path working.
- `step4b-cycle-doc.sh` — prints `present`, exit 0.

### Repair round 2 — the relocated guard

Re-run at this head, all green: `lib/common-test.sh` (24 checks), `validate-cycle-absence` (14), `validate-cycle-presence` (18) — both name `write-code/scripts/step4-wt-preflight.sh` and `lib/common.sh (edge:write-code)` in scanned scope; `gh-phoenix lint-skills` clean; `trap-status-guard` clean (295 files, 215 shell units); `shellcheck` exit 0 on both changed files; `verify-byte-move.sh` OK; `verify-fail-closed.sh` OK.

Four cases added to `lib/common-test.sh`, each falsifiable against the reviewed head: both functions must resolve from a bare source of the lib, and `lane_worktree` must refuse on a no-stamped-tree and on an ambiguous two-stamp state while resolving the single-stamp case.

**The four sourced siblings.** Each was sourced for real in a purpose-built primary+linked-worktree fixture — the three with an argument guard via their own fail-closed early return, `stepR3` at its first call site via a `claim_is_mine` stub that refuses before any mutation. All four resolve `wt_preflight` as a function and resolve `$WT` to the lane root. The same harness run against the reviewed head `3014f51f` fails all four with `wt_preflight NOT defined after sourcing`, which is the defect reproduced and then closed.

**The four smoke tests of the executed script**, re-run on an isolated fixture and identical to round 1: success ⇒ exit 0 with stdout exactly the lane root on one line (76 bytes); foreign session id ⇒ exit 1, 0 bytes; missing session id ⇒ exit 1, 0 bytes; cwd inside a sibling lane's tree ⇒ exit 1, 0 bytes.

Head confirmed by an independent REST read of both `pulls/4578` and the branch ref, and rebased onto `main` at `f1553968`.

## §CP

This is control-plane in its entirety — it banks for a `@kamp-us/control-plane` approval and is not the author's to merge.

