### PR TITLE
refactor(review-code): the last two fences carry the invocation only (#4451)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -135,11 +135,10 @@ the register is the single source. (ADR 0099.)
 
 ## Step 1 — Resolve the PR and its linked issue
 
-You're given a PR number (or you're told to review the PR for issue #N). Establish the
-PR ↔ issue pairing, because the issue is where the acceptance criteria live.
+You're given a PR number (or you're told to review the PR for issue #N). Bind `PR` to that
+number, then establish the PR ↔ issue pairing — the issue is where the acceptance criteria live.
 
 ```bash
-PR=<pr number>
 "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/pr-context.sh" "$PR"
 ```
 
@@ -191,10 +190,10 @@ holds the PR at the broken-seam stop rather than waving it through as legitimate
   (ADR [0164](https://github.com/kamp-us/phoenix/blob/main/.decisions/0164-guard-relaxing-adr-cp-gate.md))
   are all unchanged and still apply in full, and the verdict for such a PR rests on them alone.
 
-When `ISSUE` **is** set, honor it as today — pull the issue and its acceptance criteria:
+When `ISSUE` **is** set, honor it as today — bind `ISSUE` to that number and pull the issue
+and its acceptance criteria:
 
 ```bash
-ISSUE=<N>
 "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/issue-context.sh" "$ISSUE"
 ```
 


### PR DESCRIPTION
Closes #4451.

`review-code`'s two remaining non-invocation fences become invocation-only. This is the tail
of the extraction child — the bulk landed in #4504 and #4532; what was left is exactly what
`verify-extraction.sh review-code` check 1 still reds.

## The re-count — the issue's "26 blocks, ~438 lines" is stale by two merged PRs and a relocation

Measured at base `2775e4fd` and at this head, counting **every** bash/sh fence including the
one indented inside a list item at `SKILL.md:482` (a column-0 `grep '^```'` misses it):

| | issue's estimate | base `2775e4fd` | this head |
|---|---|---|---|
| `SKILL.md` total lines | 1,873 | 1,498 | 1,497 |
| fenced bash/sh blocks | 26 | 26 | 26 |
| shell payload lines in those blocks | ~438 | 29 | 27 |

The block *count* coincidentally still reads 26; the *shell* behind it is down from ~438 lines
to 27, because #4504 + #4532 moved it into `scripts/` and PR #4440 relocated the 170-line
ADR-0079 fan-out section out of this file entirely. Every one of the 26 is now a single script
invocation.

Reproduce:

```
git show 2775e4fd:claude-plugins/kampus-pipeline/skills/review-code/SKILL.md > /tmp/base.md
grep -cE '^[[:space:]]*```(bash|sh)[[:space:]]*$' /tmp/base.md
awk '/^[[:space:]]*```(bash|sh)[[:space:]]*$/{f=1;next} f&&/^[[:space:]]*```[[:space:]]*$/{f=0;next} f' /tmp/base.md | wc -l
```

## What changed

Step 1's two fences each carried a placeholder binding above their invocation:

```
PR=<pr number>                      # SKILL.md:142 at base
ISSUE=<N>                           # SKILL.md:197 at base
```

Neither is a script invocation, so check 1 counted the blocks as `payload lines=2,
invocations=1`. Both bindings move into the surrounding prose sentence ("Bind `PR` to that
number, then…" / "bind `ISSUE` to that number and pull…"), unchanged in meaning. The
invocation lines are untouched.

## Byte-identity of the moved span

The span here is the fenced shell payload of the whole file, and the claim is that the **only**
delta is the deletion of those two lines — nothing else in any fence moved a byte.

```
payload()  { awk '/^[[:space:]]*```(bash|sh)[[:space:]]*$/{f=1;next} f&&/^[[:space:]]*```[[:space:]]*$/{f=0;next} f' "$1"; }

payload /tmp/base.md                                | shasum -a 256
#  5a92e135f89d751e856e00cf4278caa3e973f04e2e2b105778c268357b834c5d   (base, 29 lines)

payload claude-plugins/kampus-pipeline/skills/review-code/SKILL.md | shasum -a 256
#  674c115e929f9113789e9078a843619c12ccf2bed26e2e9948c749aa83ad3abd   (head, 27 lines)

payload /tmp/base.md | grep -v '^PR=<pr number>$' | grep -v '^ISSUE=<N>$' | shasum -a 256
#  674c115e929f9113789e9078a843619c12ccf2bed26e2e9948c749aa83ad3abd   == head, exactly
```

Base-minus-the-two-lines hashes **identical** to head, so no other fenced line changed.

## Verification

```
bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh review-code
```

Check 1 flips red → green:

```
ok: review-code/SKILL.md: every fenced bash/sh block carries only scripts/*.sh invocations
ok: no bare `pipeline-cli` token in the executable code of any extracted script (27 file(s))
ok: no /Users/<name> or /home/<name> path in any extracted script (27 file(s))
ok: shellcheck -x clean on all 27 extracted script(s)
ok: no cleanup trap on EXIT in any extracted script (#4476, class #4479)
ok: every "${arr[@]}" expansion is non-empty by construction or length-guarded (bash 3.2 + set -u)
```

The verifier still reports 8 other errors on this skill. **None are discharged here, and each is
deliberate** — see Deviations.

## AC4 — was the ADR-0079 fan-out section touched?

**No.** It is no longer in this file to touch. PR #4440 (squash `cdbee3c0`, merged
2026-07-31T17:22Z) removed the section from `review-code/SKILL.md` and rehoused it at
`claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md`. That relocation landed
first, so per this issue's own coordination note it shifted this child's baseline; the section
is outside this PR's diff entirely.

**But it took a 58-line multi-line glue block with it** — `specialist-fan-out.md:95–153`, an
unextracted `gh api` / `diff` append-fence block that was counted inside this issue's original
438-line estimate. It is now in the `skills/shared/` corpus, which belongs to #4571 / #4454,
not to this child, and it is not extracted anywhere. Flagging for triage rather than racing
those lanes.

## Deviations

The verifier's other 8 errors on `review-code` are **left standing on purpose**. Each was
weighed, and none is a mechanical defect this PR may fix without a ruling:

1. **`cycle-doc-probe.sh` does not source `lib/common.sh` (check 5).** This is #4549's
   surface — a filed, unclaimed ticket to collapse review-code's duplicated cycle-doc probe onto
   the shared source edge. Left alone by dispatch.

2. **Six scripts print a value on stdout at their usage-miss path (check 9)** —
   `classify-control-plane.sh`, `classify-issueless.sh`, `classify-skills-only.sh`,
   `containment-marker.sh`, `glossary-freshness.sh`, `userfacing-scope.sh`. Check 9 wants
   non-zero exit **and 0 bytes**; these exit non-zero but print the *restrictive* answer
   (`flag`, the hard-stop line, the `[FAIL]` row). That is a documented design, stated in each
   script's header, and satisfying check 9 naively would be **fail-open** for at least one live
   caller: `SKILL.md:632` reads `CONTAINMENT="$(… containment-marker.sh "$ISSUE")"` and branches
   on the value, so replacing `flag` with an empty string sends an unrunnable probe down the
   permissive branch. Two fail-closed conventions genuinely collide here (emit-the-safe-answer
   vs emit-nothing-and-signal), and picking one is a decision, not a byte-move. Not touched.

3. **`classify-control-plane.sh:55` uses `PCLI="$(kp_pcli)" || PCLI=""`, not `|| exit 127`
   (check 8).** Also deliberate: the script must still write its §CP sentinel into the per-run
   handle before exiting, and an empty `$PCLI` is caught downstream by the `*)` arm at line
   `122`, which holds the ADR as `undetermined` ⇒ §CP. Exiting 127 there would skip the handle
   write. Fail-closed either way; the shape differs from the plan-epic corpus the verifier
   encodes.

4. **The interpolated `"${CLAUDE_PLUGIN_ROOT:-…}"` invocation idiom is retained.** ADR 0232
   retires it in favour of literal-path execution, but converting review-code's fences and its
   one sourced probe is #4574's chartered scope ("do not convert them here"), and the doc-wide
   literal-path sweep is #4575's. Converting in passing would double-implement those children.

5. **No script was added, moved, or edited.** This PR is `SKILL.md`-only.

§CP: this PR touches `claude-plugins/kampus-pipeline/skills/**`, so it is control-plane by
CODEOWNERS and needs a `@kamp-us/control-plane` approval before `ship-it` can enqueue it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
