### PR TITLE
refactor(skills): byte-move the last of the skill-corpus shell into executed scripts/ (#4454)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
@@ -291,72 +291,12 @@ re-deriving the resolver write-code once hand-copied, and keeps only the two thi
   the same round identity write-code uses) and treats a capped PR as fall-through-and-file.
 
 ```bash
-# is a write-code repair already in flight on this PR? (PR runs only) — resolve the verdict the
-# EXACT way write-code Step R1 does, by delegating each (PR, gate) FAIL-bound-to-head resolution to
-# `pipeline-cli verdict read` (ACL author-gate + latest-wins + SHA-staleness, ADR 0055/0058). Resolve
-# the CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin, else the pinned
-# `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653; ADR 0062/0064).
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
-
-# §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves, so pass it here
-# exactly as write-code Step R1 does (#4049): on a §CP PR the pass is the SHA-less ADVISORY, invisible
-# without --cp, so a FAIL discharged by a BODY-ONLY repair (the head never moves, so ADR 0058
-# staleness cannot retire it) would read as a live repair forever and suppress every defect filing on
-# that PR. Fail-closed on BOTH fallible inputs, exactly as write-code Step R1 is: the changed-file
-# list comes from §CPREAD's `cp_changed_files`, sourced from its canonical home (#4489), because a
-# bare `gh … | cp-classify` pipe hands the verb gh's STDOUT error document to classify and answers
-# `not-control-plane` on an unread list (#4216); and only the PROVEN `not-control-plane` state word
-# drops the flag — never a bare non-zero test, which fires on a usage error (1) or a missing bin (127).
-. "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
-if ! cp_changed_files "$REPO" "$PR"; then
-  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
-else
-  CP_STATE="$(printf '%s\n' "$CP_FILES" \
-    | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" cp-classify classify --repo "$REPO" 2>/dev/null)"
-fi
-if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
-
-# a namespace is an active-repair FAIL iff its latest authorized verdict is FAIL bound to the current
-# head — exit 0 from `verdict read … --expect FAIL`. A stale / SHA-less / PASS / none verdict exits
-# non-zero, so it is correctly NOT an active repair, matching write-code's no-op on it.
-CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code $CP_FLAG --expect FAIL 2>/dev/null)" && CODE_FAIL=1 || CODE_FAIL=0
-DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc  $CP_FLAG --expect FAIL 2>/dev/null)" && DOC_FAIL=1  || DOC_FAIL=0
-
-# UNRESOLVED ≠ "no FAIL". The verb prints its outcome JSON on BOTH exit paths, so absent JSON means the
-# namespace never resolved (a transport/5xx failure). Reading that as "no repair in flight" would file
-# a twin defect against a live repair — so treat it as UNKNOWN and defer this invocation.
-VERDICT_UNKNOWN=0
-for J in "$CODE_FAIL_JSON" "$DOC_FAIL_JSON"; do jq -e . >/dev/null 2>&1 <<<"$J" || VERDICT_UNKNOWN=1; done
-
-# the native decisive review folds into the code namespace (the verb reads only marker comments), by
-# NEWEST-WRITTEN wins — the same fold ship-it Step 2 / write-code R1 run. `at: .submitted_at` is what
-# the compare reads (a review is never upserted, so it IS the review's write time); a bare
-# "CHANGES_REQUESTED ⇒ CODE_FAIL=1" would report a repair in flight on a PR whose newer marker already
-# PASS'd at the same head, suppressing a defect that should be filed.
-CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
-REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
-  --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
-        | sort_by(.submitted_at) | last | {state, sha: .commit_id, at: .submitted_at}')
-RSTATE=$(jq -r '.state // ""' <<<"$REVIEW"); RSHA=$(jq -r '.sha // empty' <<<"$REVIEW")
-RAT=$(jq -r '.at // ""' <<<"$REVIEW")
-# `_tag == "current"` is exactly "a current-head marker verdict stands"; the verb's `writtenAt` is the
-# WRITE time the compare needs — never the comment's created_at, which an in-place upsert leaves at the
-# slot's open time and which would let a review wrongly out-rank a later-written marker (#4200).
-MARKER_AT=""
-[ "$(jq -r '._tag // ""' <<<"$CODE_FAIL_JSON" 2>/dev/null)" = "current" ] &&
-  MARKER_AT=$(jq -r '.writtenAt // empty' <<<"$CODE_FAIL_JSON" 2>/dev/null)
-if [ -n "$RSHA" ] && [ -n "$RAT" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
-  # ISO-8601-UTC sorts lexically, so `>` IS the chronological compare.
-  if [ -z "$MARKER_AT" ] || [ "$RAT" \> "$MARKER_AT" ]; then
-    [ "$RSTATE" = "CHANGES_REQUESTED" ] && CODE_FAIL=1 || CODE_FAIL=0
-  fi
-;; esac; fi
-
-# the N=3 repair cap `verdict read` does NOT count: a PR already at 3 FAIL rounds is escalated to a
-# human, NOT an active repair. The script author-gates the FAIL markers to write+ collaborators
-# (ADR 0055) and clusters by >120s gap — the same round identity write-code uses. A non-zero exit is
-# UNKNOWN, never 0 rounds; read the status before the number.
-ROUNDS="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/repair-rounds.sh" "$PR")" || exit 1
+# is a write-code repair already in flight on this PR? (PR runs only) — the script resolves each
+# namespace's verdict the EXACT way write-code Step R1 does, and keeps the two things
+# `pipeline-cli verdict read` does not do (the native-review fold, the N=3 round count).
+# It prints `VERDICT_UNKNOWN=`, `CODE_FAIL=`, `DOC_FAIL=` and `ROUNDS=` on stdout; a non-zero exit
+# means it produced NO answer, which is UNKNOWN and never "no repair in flight" (§ZS / ADR 0092).
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh "$PR" || exit 1
 ```
 
 If `VERDICT_UNKNOWN=1` the verdict never resolved (a GitHub read failure, not a verdict) — **defer

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh
@@ -1,0 +1,66 @@
+# is a write-code repair already in flight on this PR? (PR runs only) — resolve the verdict the
+# EXACT way write-code Step R1 does, by delegating each (PR, gate) FAIL-bound-to-head resolution to
+# `pipeline-cli verdict read` (ACL author-gate + latest-wins + SHA-staleness, ADR 0055/0058). Resolve
+# the CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin, else the pinned
+# `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653; ADR 0062/0064).
+VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+
+# §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves, so pass it here
+# exactly as write-code Step R1 does (#4049): on a §CP PR the pass is the SHA-less ADVISORY, invisible
+# without --cp, so a FAIL discharged by a BODY-ONLY repair (the head never moves, so ADR 0058
+# staleness cannot retire it) would read as a live repair forever and suppress every defect filing on
+# that PR. Fail-closed on BOTH fallible inputs, exactly as write-code Step R1 is: the changed-file
+# list comes from §CPREAD's `cp_changed_files`, sourced from its canonical home (#4489), because a
+# bare `gh … | cp-classify` pipe hands the verb gh's STDOUT error document to classify and answers
+# `not-control-plane` on an unread list (#4216); and only the PROVEN `not-control-plane` state word
+# drops the flag — never a bare non-zero test, which fires on a usage error (1) or a missing bin (127).
+. "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
+else
+  CP_STATE="$(printf '%s\n' "$CP_FILES" \
+    | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" cp-classify classify --repo "$REPO" 2>/dev/null)"
+fi
+if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
+
+# a namespace is an active-repair FAIL iff its latest authorized verdict is FAIL bound to the current
+# head — exit 0 from `verdict read … --expect FAIL`. A stale / SHA-less / PASS / none verdict exits
+# non-zero, so it is correctly NOT an active repair, matching write-code's no-op on it.
+CODE_FAIL_JSON="$($VERDICT read --pr "$PR" --gate code $CP_FLAG --expect FAIL 2>/dev/null)" && CODE_FAIL=1 || CODE_FAIL=0
+DOC_FAIL_JSON="$($VERDICT  read --pr "$PR" --gate doc  $CP_FLAG --expect FAIL 2>/dev/null)" && DOC_FAIL=1  || DOC_FAIL=0
+
+# UNRESOLVED ≠ "no FAIL". The verb prints its outcome JSON on BOTH exit paths, so absent JSON means the
+# namespace never resolved (a transport/5xx failure). Reading that as "no repair in flight" would file
+# a twin defect against a live repair — so treat it as UNKNOWN and defer this invocation.
+VERDICT_UNKNOWN=0
+for J in "$CODE_FAIL_JSON" "$DOC_FAIL_JSON"; do jq -e . >/dev/null 2>&1 <<<"$J" || VERDICT_UNKNOWN=1; done
+
+# the native decisive review folds into the code namespace (the verb reads only marker comments), by
+# NEWEST-WRITTEN wins — the same fold ship-it Step 2 / write-code R1 run. `at: .submitted_at` is what
+# the compare reads (a review is never upserted, so it IS the review's write time); a bare
+# "CHANGES_REQUESTED ⇒ CODE_FAIL=1" would report a repair in flight on a PR whose newer marker already
+# PASS'd at the same head, suppressing a defect that should be filed.
+CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
+REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
+  --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
+        | sort_by(.submitted_at) | last | {state, sha: .commit_id, at: .submitted_at}')
+RSTATE=$(jq -r '.state // ""' <<<"$REVIEW"); RSHA=$(jq -r '.sha // empty' <<<"$REVIEW")
+RAT=$(jq -r '.at // ""' <<<"$REVIEW")
+# `_tag == "current"` is exactly "a current-head marker verdict stands"; the verb's `writtenAt` is the
+# WRITE time the compare needs — never the comment's created_at, which an in-place upsert leaves at the
+# slot's open time and which would let a review wrongly out-rank a later-written marker (#4200).
+MARKER_AT=""
+[ "$(jq -r '._tag // ""' <<<"$CODE_FAIL_JSON" 2>/dev/null)" = "current" ] &&
+  MARKER_AT=$(jq -r '.writtenAt // empty' <<<"$CODE_FAIL_JSON" 2>/dev/null)
+if [ -n "$RSHA" ] && [ -n "$RAT" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
+  # ISO-8601-UTC sorts lexically, so `>` IS the chronological compare.
+  if [ -z "$MARKER_AT" ] || [ "$RAT" \> "$MARKER_AT" ]; then
+    [ "$RSTATE" = "CHANGES_REQUESTED" ] && CODE_FAIL=1 || CODE_FAIL=0
+  fi
+;; esac; fi
+
+# the N=3 repair cap `verdict read` does NOT count: a PR already at 3 FAIL rounds is escalated to a
+# human, NOT an active repair. The script author-gates the FAIL markers to write+ collaborators
+# (ADR 0055) and clusters by >120s gap — the same round identity write-code uses. A non-zero exit is
+# UNKNOWN, never 0 rounds; read the status before the number.
+ROUNDS="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/repair-rounds.sh" "$PR")" || exit 1

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh
@@ -54,7 +54,8 @@ VERDICT="$KP_ROOT/bin/pipeline-cli verdict"
 # drops the flag — never a bare non-zero test, which fires on a usage error (1) or a missing bin (127).
 # `>&2` routes only the §ZS scope LINE — the result arrives in $CP_FILES, and THIS script's stdout is
 # the four-line answer its caller reads, so a diagnostic on it would corrupt the answer.
-. "$KP_ROOT/skills/shared/scripts/cp-read.sh"
+# shellcheck source=../../shared/scripts/cp-read.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
 if ! cp_changed_files "$REPO" "$PR" >&2; then
   CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
 else

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh
@@ -1,9 +1,47 @@
+#!/usr/bin/env bash
+# heal-ci Step 4's twin-suppression guard: is a write-code repair already in flight on this PR?
+#
+# usage: active-repair.sh <pr>
+#
+# Prints four `KEY=value` lines on stdout — VERDICT_UNKNOWN, CODE_FAIL, DOC_FAIL, ROUNDS. Those four
+# ARE the answer heal-ci's prose reads (`ROUNDS < 3` plus a current-head FAIL in either namespace ⇒
+# an active repair ⇒ route the comment, do not file a twin).
+#
+# FAIL-CLOSED: the permissive reading here is "no repair in flight", and that branch FILES a twin
+# defect against a live repair — so an answer this script could not produce must never arrive as
+# one. A non-zero exit prints NOTHING on stdout and its diagnostic on stderr (§ZS / ADR 0092);
+# `VERDICT_UNKNOWN=1` is the in-band form of the same rule for the one input that resolves
+# per-namespace rather than per-run.
+#
+# Extracted from heal-ci/SKILL.md (#4454, epic #4435). Executed, never sourced (ADR 0232).
+# The moved lines' shellcheck findings moved with them: `$VERDICT` / `$CP_FLAG` / the `gh api`
+# path expand to argument WORDS on purpose, and quoting them would be a rewrite — phase 2 (#1929),
+# not this byte-move. SC1007/SC1091 are the shared `CDPATH= cd` source idiom's, as in every
+# sibling script.
+# shellcheck disable=SC1007,SC1091,SC2086
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+[ -n "$HERE" ] || { echo "heal-ci: could not resolve this script's own directory — the active-repair check did NOT run." >&2; exit 1; }
+KP_ROOT="$(CDPATH= cd -- "$HERE/../../.." && pwd)"
+[ -n "$KP_ROOT" ] || { echo "heal-ci: could not resolve the plugin root — the active-repair check did NOT run." >&2; exit 1; }
+
+[ "$#" -ge 1 ] || {
+	echo "heal-ci: active-repair.sh needs a PR number — the check did NOT run (UNKNOWN, never 'no repair in flight')." >&2
+	echo "usage: active-repair.sh <pr>" >&2
+	exit 2
+}
+PR="$1"
+REPO="$(kp_repo)" || { echo "heal-ci: target repo unresolved — the active-repair check did NOT run (UNKNOWN, never 'no repair in flight')." >&2; exit 1; }
+
 # is a write-code repair already in flight on this PR? (PR runs only) — resolve the verdict the
 # EXACT way write-code Step R1 does, by delegating each (PR, gate) FAIL-bound-to-head resolution to
 # `pipeline-cli verdict read` (ACL author-gate + latest-wins + SHA-staleness, ADR 0055/0058). Resolve
 # the CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin, else the pinned
 # `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653; ADR 0062/0064).
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+VERDICT="$KP_ROOT/bin/pipeline-cli verdict"
 
 # §CP-ness is part of the (PR, gate, head, §CP-ness) tuple `verdict read` resolves, so pass it here
 # exactly as write-code Step R1 does (#4049): on a §CP PR the pass is the SHA-less ADVISORY, invisible
@@ -14,12 +52,14 @@ VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli 
 # bare `gh … | cp-classify` pipe hands the verb gh's STDOUT error document to classify and answers
 # `not-control-plane` on an unread list (#4216); and only the PROVEN `not-control-plane` state word
 # drops the flag — never a bare non-zero test, which fires on a usage error (1) or a missing bin (127).
-. "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-read.sh"
-if ! cp_changed_files "$REPO" "$PR"; then
+# `>&2` routes only the §ZS scope LINE — the result arrives in $CP_FILES, and THIS script's stdout is
+# the four-line answer its caller reads, so a diagnostic on it would corrupt the answer.
+. "$KP_ROOT/skills/shared/scripts/cp-read.sh"
+if ! cp_changed_files "$REPO" "$PR" >&2; then
   CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
 else
   CP_STATE="$(printf '%s\n' "$CP_FILES" \
-    | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" cp-classify classify --repo "$REPO" 2>/dev/null)"
+    | "$KP_ROOT/bin/pipeline-cli" cp-classify classify --repo "$REPO" 2>/dev/null)"
 fi
 if [ "$CP_STATE" = "not-control-plane" ]; then CP_FLAG=""; else CP_FLAG="--cp"; fi
 
@@ -63,4 +103,11 @@ if [ -n "$RSHA" ] && [ -n "$RAT" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
 # human, NOT an active repair. The script author-gates the FAIL markers to write+ collaborators
 # (ADR 0055) and clusters by >120s gap — the same round identity write-code uses. A non-zero exit is
 # UNKNOWN, never 0 rounds; read the status before the number.
-ROUNDS="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/repair-rounds.sh" "$PR")" || exit 1
+ROUNDS="$("$HERE/repair-rounds.sh" "$PR")" || {
+	printf '%s\n' "$ROUNDS" >&2
+	echo "heal-ci: the FAIL-round count did not resolve — UNKNOWN, never 0 rounds. No answer emitted." >&2
+	exit 1
+}
+
+printf 'VERDICT_UNKNOWN=%s\nCODE_FAIL=%s\nDOC_FAIL=%s\nROUNDS=%s\n' \
+	"$VERDICT_UNKNOWN" "$CODE_FAIL" "$DOC_FAIL" "$ROUNDS"


### PR DESCRIPTION
Closes #4454

Byte-moves the **last multi-line glue block** in this child's corpus — heal-ci Step 4's
write-code active-repair detector, 66 lines of shell inline in `heal-ci/SKILL.md` — into
`claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh`, in ADR 0232's
**executed** shape: literal-path `bash ./claude-plugins/…` invocation, four `KEY=value` lines
returned on stdout, `set -uo pipefail` (never `-e`), no cleanup `EXIT` trap, shared lib sourced
in-script through the canonical `BASH_SOURCE`-relative idiom.

Split by commit on purpose, so byte-identity is checkable independently of the seams:

| commit | what |
|---|---|
| `8505be89` | the **verbatim** relocation — the new file is byte-identical to the fenced span it replaced |
| `4adccd46` | the seams that make it runnable (header, path resolution, usage guard, stdout answer) |
| `7f7296e5` | **repair round 1** — the `cp-read.sh` source line converted to ADR 0230's canonical column-0 `BASH_SOURCE` idiom (one line) |

## The re-count: the issue's estimates were high by ~2x (again)

The issue's per-file block counts are estimates, and this milestone has kept proving them
unreliable (#4451 estimated ~438 shell lines against a reality of 27). Re-counted at base
`f1553968`, **the corpus was already extracted** — every listed file but one carries invocations
and comments only. Multi-line (`payload > 1`) fenced `bash`/`sh` blocks, blocks / payload-lines:

| file | issue estimate | at base `f1553968` | at this head |
|---|---|---|---|
| `triage/SKILL.md` | 13 / ~97 | 10 / 32 | 10 / 32 |
| `triage/close-not-planned.md` | 2 / ~14 | 1 / 8 | 1 / 8 |
| `heal-ci/SKILL.md` | 11 / ~112 | **8 / 88** | **8 / 28** |
| `release/SKILL.md` | 9 / ~66 | 9 / 26 | 9 / 26 |
| `report/SKILL.md` | 3 / ~33 | 2 / 21 | 2 / 21 |
| `wayfinder/SKILL.md` | 2 / ~32 | 4 / 25 | 4 / 25 |
| `what-shipped/SKILL.md` | 8 / ~27 | 6 / 15 | 6 / 15 |
| `architecture-audit/SKILL.md` | 5 / ~27 | 4 / 10 | 4 / 10 |
| `campaign/SKILL.md` | 6 / ~20 | 4 / 11 | 4 / 11 |
| `canon/SKILL.md` | 2 / ~10 | 3 / 8 | 3 / 8 |
| `adr/SKILL.md` | (single-digit) | 3 / 9 | 3 / 9 |
| `glossary/SKILL.md` | (single-digit) | 2 / 5 | 2 / 5 |
| `taste-library-conventions.md` | (single-digit) | 1 / 2 | 1 / 2 |
| `author-skill/SKILL.md` | (single-digit) | 0 / 0 | 0 / 0 |
| `doctor/SKILL.md` | (single-digit) | 0 / 0 | 0 / 0 |
| **total** | **~102 / ~460** | **57 / 260** | **57 / 200** |

The 60 lines this PR removes from the markdown are the whole of the corpus's remaining
multi-line glue. The other 200 payload lines are invocations, their explanatory comments,
operator placeholder assignments, and heredoc body templates — see the residue audit below.

## The fence matcher (verbatim, AC5)

A column-0 `grep '^```'` misses blocks **indented inside list items or blockquotes** (live example:
`review-code/SKILL.md:482`), so the matcher strips leading whitespace and `>` before testing the
fence. Paste this at the repo root:

```bash
find claude-plugins/kampus-pipeline/skills -name '*.md' -not -path '*/node_modules/*' -print0 |
while IFS= read -r -d '' f; do
	awk -v F="$f" '
		{
			line = $0
			sub(/^[ \t>]*/, "", line)
			if (line ~ /^```/) {
				if (inblk) {
					if (line ~ /^```[ \t]*$/) { inblk=0; if (n>1) { blocks++; lines+=n } }
					else { n++ }
				} else if (line ~ /^```(bash|sh)[ \t]*$/) { inblk=1; n=0 }
			} else if (inblk) { n++ }
		}
		END { if (blocks>0) printf "%s\t%d\t%d\n", F, blocks, lines }
	' "$f"
done | sort -k2 -rn
```

Swap the `if (n>1)` guard for `if (n>0)` to count every fenced block rather than only the
multi-line ones.

## Byte-move proof (AC2), reviewer-runnable

```bash
# 1. the span as it stood in the markdown at the base commit
git show f1553968:claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md \
  | sed -n '294,359p' | shasum -a 256
# 0c0bcbc0895be30449d61d4b9243b7474d15e40a73d035a7a1c83c37e38ca6c3

# 2. the extracted file at the byte-move commit — identical, no seams yet
git show 8505be89:claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh \
  | shasum -a 256
# 0c0bcbc0895be30449d61d4b9243b7474d15e40a73d035a7a1c83c37e38ca6c3

# 3. the seams, isolated — 52 insertions / 5 deletions, each one disclosed below
git diff 8505be89 4adccd46 -- claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh

# 4. repair round 1, isolated — 2 insertions / 1 deletion, the ADR-0230 source-line fix
git diff 4adccd46 7f7296e5 -- claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh

# hash of the finished script, for reference
# at 4adccd46: 5dfee1e66b8c6bea094cb4af183b77e9e0d7ca0d46c822ae6d73eb5d812d251f
# at 7f7296e5: 94d228ee24ba6d23434de33f7c282e0ae30e73df0142cf3148d39002e0340f7a
```

Repair round 1 does **not** move the byte-move anchor: `8505be89` still hashes identical to the
base span, and `4adccd46`'s seam delta is still exactly 52/5. Both are re-derivable above.

ADR 0230 source-edge resolution at the repaired head, the same way the gate measured it —
`kp_skill_source_edges "$SKILLS" heal-ci` exits **0** with **both** edges resolving
(`lib/common.sh` and `shared/scripts/cp-read.sh`), and a sweep of all **30** skills in the corpus
reports **zero** unresolved.

Runtime + fail-closed proof (network reads only, no writes):

```bash
bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh 4585
# VERDICT_UNKNOWN=0 / CODE_FAIL=0 / DOC_FAIL=0 / ROUNDS=0   (exit 0)
bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh >/dev/null
# usage refusal on stderr, ZERO bytes on stdout, exit 2 — a could-not-run is never "no repair"
shellcheck claude-plugins/kampus-pipeline/skills/heal-ci/scripts/active-repair.sh   # exit 0
```

## The issue body's §CP-asymmetry claim is DEAD — verified live

The body says several of these skill dirs "are not control-plane by directory today, but their
extracted `.sh` scripts are control-plane by the `skills/**/*.sh` row — the shell gains a gate by
leaving the markdown." That was true when the child was written; **it is not true now.** ADR 0227
(landed via #4462, carried through the #4563 keystone) made the WHOLE
`claude-plugins/kampus-pipeline/skills/` tree §CP — the directory is the unit of coverage, and the
narrower `([^/]+/)*[^/]+\.sh$` clause it replaced is gone from `CONTROL_PLANE_RE`
(`packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts`; its docblock names
`heal-ci` / `what-shipped` / `doctor` / `wayfinder` explicitly as newly-§CP). Proven against the
live classifier rather than asserted:

```bash
printf 'claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md\n' \
  | ./claude-plugins/kampus-pipeline/bin/pipeline-cli cp-classify classify --repo kamp-us/phoenix
# control-plane [path-match] … BLOCKING (human merge)   exit=0
printf 'claude-plugins/kampus-pipeline/skills/heal-ci/scripts/x.sh\n' \
  | ./claude-plugins/kampus-pipeline/bin/pipeline-cli cp-classify classify --repo kamp-us/phoenix
# control-plane [path-match] … BLOCKING (human merge)   exit=0
```

Both §CP, both exit 0. There is no asymmetry left for this extraction to improve; nothing about
what gets built changes, but the stale rationale should not stand to be cited later as fact.

## Residue audit — what the 57 remaining blocks are

`verify-extraction.sh`'s check 1 (INVOCATION-ONLY) is stricter than "no glue": its `invocations`
counter recognizes only a `scripts/*.sh` path, so a §CLI-sanctioned `bin/pipeline-cli <verb>` call
scores 0. Run over this corpus it reports the following, and **none of it is multi-line glue**:

- **Operator placeholder assignments** — `heal-ci:94` (`RUN=<run id>`), `heal-ci:108` (`JOB=…`),
  `heal-ci:347` (`N=…`), `release:89` (`FLAG_KEY=`/`ENV=`), `release:154` (`LINKED_ISSUE=`),
  `campaign:41` (`FOUNDER=`), `campaign:82` (`WAVE_LABEL=`). These are the parameter the agent
  must fill before the invocation; turning them into scripts removes the seam, not the glue.
- **Heredoc body templates fed to an invocation** — `report:143`, `wayfinder:510`,
  `architecture-audit:241`. Authored markdown, not shell.
- **Direct `bin/pipeline-cli <verb>` calls** — `triage:247`, `triage:272`, `adr:40`, plus
  `report:60` (`report/footer.sh`), `adr:172` (a bare `ls`). Tool invocations, path-resolved per
  §CLI; the check's counter just doesn't recognize the shape.

## Deviations

1. **The move is 2 commits, not 1** (deliberate, per the byte-move discipline): `8505be89` is
   byte-identical, `4adccd46` carries every line that had to change. The script is not runnable at
   the intermediate commit — no shebang, no options — which is the point of splitting them.
2. **Seam: path resolution.** The three `${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}`
   interpolations become `$KP_ROOT` / `$HERE`, resolved from `BASH_SOURCE`. The interpolated fence
   idiom is retired by the ADR-0232 convention update on #4454; the interpolations *elsewhere* in
   these markdown files are #4575's sweep and are untouched here.
3. **Seam: inputs.** `$PR` and `$REPO` used to arrive from the agent's shell. The script now takes
   `<pr>` as an argument and resolves the repo through `kp_repo`; both refuse with an **empty
   stdout** and a non-zero exit, so a could-not-run cannot surface as "no repair in flight".
4. **Seam: `cp_changed_files … >&2`.** Under ADR 0232 stdout is this script's return channel, so
   the helper's §ZS scope line is routed to stderr — the same redirect `write-code` Step 1 already
   applies at its own consuming call site.
5. **Seam: the answer + a relayed failure.** The moved block *left* four variables in the caller's
   shell; that property is retired (ADR 0232), so the script prints
   `VERDICT_UNKNOWN=`/`CODE_FAIL=`/`DOC_FAIL=`/`ROUNDS=` on stdout instead. `repair-rounds.sh` is
   now called by sibling-relative path and its failure message is relayed to stderr — the old
   `ROUNDS="$(…)" || exit 1` swallowed it into the captured substitution.
6. **Indentation of the moved lines is preserved as-is** (2-space, markdown-fence style) rather
   than re-tabbed to the sibling scripts' style; re-indenting would have broken byte-identity for
   no behavioral gain. Only the seam lines use tabs.
7. **Shellcheck directives are file-level** (`SC1007,SC1091,SC2086`) with the rationale stated
   once. `SC2086` is the moved lines' own finding — `$VERDICT` and `$CP_FLAG` expand to argument
   words on purpose; quoting them is a rewrite, which is phase 2 (#1929), not this move.
8. **Pre-existing, NOT fixed here (out of scope, and filed elsewhere):** heal-ci's eight earlier
   scripts print their usage refusals on **stdout** (`verify-extraction.sh` check 9 reds on all of
   them), and `failed-logs.sh` does not source the shared lib. That is the IO-contract lane
   (#4510 / #4577 / #4583), not this byte-move. Also untouched by request: the `wayfinder:308`
   dead anchor (#4565) and `review-design/scripts/classify-control-plane.sh` (#4582).
9. **(repair round 1) Deviation 2 was wrong about one line, and the fix departs from byte-move
   fidelity to correct it.** Deviation 2 claimed the interpolated paths "become `$KP_ROOT` / `$HERE`,
   resolved from `BASH_SOURCE`" — sound for the `lib/common.sh` edge, not for the `cp-read.sh` one:
   ADR 0230's contract matches the **literal shape of the source line**, so an indirection through a
   `BASH_SOURCE`-derived variable is still not statically resolvable, and `kp_skill_source_edges`
   read heal-ci UNRESOLVED. `. "$KP_ROOT/skills/shared/scripts/cp-read.sh"` is now the canonical
   column-0 form the three sibling scripts already use.
10. **(repair round 1) Two lines, not one.** The fix adds a `# shellcheck source=` directive
   alongside the converted source line, matching the directive this file already carries for
   `lib/common.sh` and the same pairing in the sibling precedents. `shellcheck` still exits 0.
11. **(repair round 1) The fix landed as a third commit, not an amend of `4adccd46`.** Amending
   would have rewritten the seam commit and invalidated the reviewer-runnable 52/5 seam delta;
   a third commit keeps both anchors reachable and the round's diff isolated.
12. **(repair round 1) Pushed by refspec, verified by REST, not by `verified-push`.** The PR's head
   branch was checked out in another worktree, so the fix was built on a local branch at the same
   remote ref and pushed as an explicit refspec (fast-forward, no force). `verified-push` only
   pushes the branch checked out in its `--cwd`, so the post-push confirmation is a REST re-read of
   `git/ref/heads/…` + `pulls/4585` instead. Both report `7f7296e5`.
13. **(repair round 1) AC4 deliberately not chased.** The gate ruled it unreachable by construction
   (the AC5 matcher counts payload lines, so a correct two-line invocation scores as a "multi-line
   block"), and the cheap way to green it — wrapping tool calls in no-op scripts — inverts the
   epic's intent. This is an AC-amendment question routed to epic #4435; no further extraction was
   done for it, and this round does not restate AC4 as met.

## Lanes respected

Nothing under `skills/write-code/**` (#4578 in repair), `skills/review-code/**` (#4580 in gate),
`skills/review-design/scripts/classify-control-plane.sh` or `skills/shared/scripts/**` (#4577) is
touched. The only files in this diff are `heal-ci/SKILL.md` and `heal-ci/scripts/active-repair.sh`.

## Checks run locally

`shellcheck` (exit 0) · `validate-skills.sh` · `validate-cycle-absence.sh` ·
`validate-cycle-presence.sh` · `validate-gate-path-drift.sh` · `lib/common-test.sh` ·
`trap-status-guard check` (293 files, clean) · `cli-invocation-guard check` (clean) ·
`gh-phoenix lint-skills` (clean) · `leak-guard scan` (clean) · `adoption-lint check` (clean) ·
`pnpm lint:worktree` (no biome-handled changed files).

**Repair round 1 adds:** `kp_skill_source_edges … heal-ci` (exit 0, both edges resolve) ·
a corpus edge sweep over all 30 skills (zero unresolved) · `shellcheck` (exit 0) · the runtime
contract re-run at the repaired head (four stdout lines with a PR number; zero stdout bytes and
exit 2 with none; scope line on stderr).

CI at the repaired head `7f7296e5`, read in full (declared `total_count` **46**, entries received
**46**, `?per_page=100 --paginate`): **zero non-green**. Counts are reported as measured at the
time of writing and will move as remaining checks complete — read the head live rather than
trusting this line.

§CP — human merge. Do not auto-ship.

