### PR TITLE
refactor(review-code): collapse the duplicated cycle-doc probe onto the shared source edge (#4549)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -85,14 +85,18 @@ load-bearing when you read or edit them:
   [`../shared/scripts/`](../shared/scripts/) (#4489 extracted them out of
   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)), and this skill's scripts source
   them directly. With no second copy there is nothing to keep in step and no byte-identity claim to
-  make about one. The **one deliberate exception** is
-  [`scripts/cycle-doc-probe.sh`](scripts/cycle-doc-probe.sh): the two cycle validators
+  make about one. That now holds **without exception**:
+  [`scripts/cycle-doc-probe.sh`](scripts/cycle-doc-probe.sh) was the last skill-local second copy
+  and has collapsed onto the shared [`../shared/scripts/cycle-doc-probe.sh`](../shared/scripts/cycle-doc-probe.sh)
+  too (#4549). It could not before, because the two cycle validators
   ([`../validate-cycle-presence.sh`](../validate-cycle-presence.sh) /
-  [`../validate-cycle-absence.sh`](../validate-cycle-absence.sh)) scope each skill's scan surface to
-  that skill's **own** directory on purpose, so sourcing the shared probe would move this skill's
-  cycle wiring out of its guarded surface and the validators would fail — per-skill wiring stays
-  per-skill (the rule is stated at `kp_skill_shell_surfaces` in
-  [`../../lib/common.sh`](../../lib/common.sh)).
+  [`../validate-cycle-absence.sh`](../validate-cycle-absence.sh)) scoped each skill's scan surface to
+  that skill's **own** directory, so sourcing the shared probe moved this skill's cycle wiring off its
+  guarded surface; ADR [0230](https://github.com/kamp-us/phoenix/blob/main/.decisions/0230-cycle-validators-follow-the-source-edge.md)
+  removed that constraint by having them follow a skill's own source edges one hop
+  (`kp_skill_source_edges` in [`../../lib/common.sh`](../../lib/common.sh)). What stays per-skill is
+  this skill's **consumption** of the probe — the `CYCLE_GATING` branch the wrapper keeps in its own
+  file, which is what the validators' own-surface checks read.
 
 ## Read-only on git working state
 
@@ -646,13 +650,18 @@ flag check on an exempt/foreign PR is the failure mode this guard exists to prev
 correct, first-class state (ADR 0062 portability), exactly as a missing milestone is.
 
 ```bash
-. "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/cycle-doc-probe.sh"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh || exit 1
 ```
 
-Sourced, not run — the point is the `$CYCLE_DOC` (`present` | `absent`) it leaves in your shell. This
-is the one script here that is **deliberately review-code-local** rather than the shared
-[`../shared/scripts/cycle-doc-probe.sh`](../shared/scripts/cycle-doc-probe.sh); the reason is in
-§ The extracted scripts above.
+**Executed, not sourced, and stdout is the answer** (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md),
+[`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md)).
+It prints two `KEY=value` lines — `CYCLE_DOC=present|absent` and
+`CYCLE_GATING=verify-gating|skip` — and the script itself sources the shared
+[`../shared/scripts/cycle-doc-probe.sh`](../shared/scripts/cycle-doc-probe.sh) for the probe, so
+there is no second copy of it here (#4549). `CYCLE_GATING=verify-gating` says the cycle *admits* the
+gating verification, not that it fires: the marker must also read `flag`. A non-zero exit is
+**UNKNOWN, never `absent`** — hold rather than skip.
 
 **Zero-scope = FAIL — a `flag`-marked PR that touches no user-facing surface fails (ADR 0092 / §ZS).**
 A `**Containment:** flag (default-off)` marker is the issue *claiming to deliver user-facing value*

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh
@@ -1,25 +1,46 @@
 #!/usr/bin/env bash
-# Step 3b — the one canonical product-development-cycle probe (formats §1). SOURCE it (`. cycle-doc-probe.sh`)
-# with REPO set: the point is the $CYCLE_DOC it leaves in the caller's shell. Extracted from
-# review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
-# ../SKILL.md § The extracted scripts. The graceful-absence *why* (ADR 0062 — absence is a
-# first-class correct state) stays in that step's prose.
+# Step 3b — resolve the product-development-cycle doc and review-code's consumption of it.
+# The *why* — graceful absence (ADR 0062): absent ⇒ Step 3b's flag-gating verification no-ops and
+# contributes no criterion — stays in ../SKILL.md § Step 3b.
 #
-# A SECOND COPY of ../../shared/scripts/cycle-doc-probe.sh, and no longer a required one. It was
-# required: the cycle validators scanned each skill's OWN directory only, so sourcing the shared copy
-# moved review-code's cycle wiring off its guarded surface and reddened them. ADR 0230 removed that
-# forcing constraint — the validators now follow a skill's own source edges one hop
-# (`kp_skill_source_edges` in ../../../lib/common.sh), so sourcing the shared probe stays green.
-# Collapsing this copy onto that edge is the intended direction and is deliberately NOT done here:
-# minting the new sourced invocation is held behind the open question about `.`-sourcing under
-# worktree isolation (#4546). Until then this copy is the drift risk it always was — see #4541.
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/cycle-doc-probe.sh
 #
-# Sets no shell options and installs no EXIT trap (#4476, class #4479).
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — two `KEY=value` lines:
+#   CYCLE_DOC=present|absent          the canonical probe's resolution
+#   CYCLE_GATING=verify-gating|skip   whether the cycle ADMITS Step 3b's gating verification at all
+# `verify-gating` does not mean the check fires: Step 3b still runs it only when the containment
+# marker also reads `flag`. `skip` is unconditional — no cycle doc, no gating criterion, no FAIL.
+# Any other $CYCLE_DOC is UNKNOWN: no stdout, a named stderr diagnostic, non-zero (§ZS, ADR 0092).
+#
+# It SOURCES the one shared implementation, ../../shared/scripts/cycle-doc-probe.sh, rather than
+# carrying a second copy of the probe (#4549). The copy was required once — the cycle validators
+# scanned each skill's OWN directory only — and ADR 0230 removed that forcing constraint by having
+# them follow a skill's own source edges one hop (`kp_skill_source_edges` in ../../../lib/common.sh).
+# In-script sourcing of a shared target stays sanctioned under ADR 0232; only sourcing at an agent's
+# top-level command is banned, which is why ../SKILL.md now EXECUTES this script.
+#
+# THE SOURCE LINE BELOW IS THE LOAD-BEARING TOKEN — this paragraph is not. The validators follow that
+# line to the shared file and grep the probe literal THERE, and every `.sh` grep they run is
+# comment-stripped, so deleting the line while keeping this text reds them by name.
+#
+# Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
-REPO="${REPO:-${1:?cycle-doc-probe.sh: REPO unset and no \$1 — refusing to probe an unnamed repo}}"
+REPO="$(kp_repo)" || exit 1
+export REPO
+# shellcheck source=../../shared/scripts/cycle-doc-probe.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cycle-doc-probe.sh"
 
-# the one canonical cycle-doc probe (formats §1); absent ⇒ no cycle ⇒ skip the gating check
-# shellcheck disable=SC2034  # $CYCLE_DOC is this script's whole output — it is read by the SOURCING caller
-gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/null 2>&1 \
-  && CYCLE_DOC=present || CYCLE_DOC=absent
-# run the gating verification below ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]
+# The two states are ENUMERATED, not interpolated: an unset or unexpected $CYCLE_DOC cannot be
+# laundered into the permissive `absent` answer by a `%s`.
+case "${CYCLE_DOC:-}" in
+present) printf 'CYCLE_DOC=present\nCYCLE_GATING=verify-gating\n' ;;
+absent) printf 'CYCLE_DOC=absent\nCYCLE_GATING=skip\n' ;;
+*)
+	echo "cycle-doc-probe.sh: the shared probe left \$CYCLE_DOC as '${CYCLE_DOC:-<unset>}' — UNKNOWN, never 'absent'. No answer produced." >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Closes #4549

`review-code/scripts/cycle-doc-probe.sh` carried a deliberate **second executable copy** of the canonical cycle-doc probe. The forcing constraint that required it is gone — ADR [0230](https://github.com/kamp-us/phoenix/blob/main/.decisions/0230-cycle-validators-follow-the-source-edge.md) has the cycle validators follow a skill's own source edges one hop — so the copy collapses onto the shared `claude-plugins/kampus-pipeline/skills/shared/scripts/cycle-doc-probe.sh`.

## The shape, re-derived against the #4546 ruling

The issue was written before the ruling and flagged that its shape would **invert** if the ruling picked executed-not-sourced. It did: ADR [0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md) bans sourcing at an agent's top-level command while **keeping in-script sourcing of a shared target sanctioned**. So this lane does both halves:

- **The collapse is an in-script source edge** — the column-0 `BASH_SOURCE` idiom `kp_skill_source_edges` matches literally, no interpolated directory (ADR 0230; precedents `review-code/scripts/classify-control-plane.sh:25`, `ship-it/scripts/step0-cp-approval.sh:18`).
- **The wrapper converts from sourced to executed**, with stdout as the answer channel per [`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md): two `KEY=value` lines, `CYCLE_DOC=present|absent` and `CYCLE_GATING=verify-gating|skip`. `SKILL.md` Step 3b now invokes it by literal path instead of `.`-sourcing it.
- The two states are **enumerated as literals**, not `printf '%s'`-interpolated, so an unset/unexpected `$CYCLE_DOC` from the shared probe exits non-zero with empty stdout and a named stderr diagnostic — UNKNOWN, never the permissive `absent` (§ZS / ADR 0092).
- `set -uo pipefail`, never `-e`; no `EXIT` trap ([`.patterns/skill-script-shell-shape.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-shell-shape.md)).

Live run at head: `REPO=kamp-us/phoenix bash …/review-code/scripts/cycle-doc-probe.sh` → `CYCLE_DOC=present` / `CYCLE_GATING=verify-gating`, exit 0. `shellcheck -x` clean.

## T5 — measured, and it dissolved without re-keying either validator

The issue's plan (from #4505's threat model) expected this migration to strand `validate-cycle-absence.sh`'s `CYCLE_DOC=absent` marker for `review-code`, needing the regex re-keyed to a new `CYCLE_GATING=skip`. **Measured before and after on all four cycle-aware skills' comment-stripped own surfaces** (`kp_surface_text` over `kp_skill_shell_surfaces`), the re-key turned out unnecessary: the enumerated consuming branch keeps every marker in `review-code`'s **own** executable text.

`review-code` own-surface matching lines, per file, before → after:

| file | `CYCLE_DOC=absent` | `PRESENT_GATE_RE` | `(verify\|run).{0,40}gating` | probe needle |
|---|---|---|---|---|
| `SKILL.md` | 0 → 0 | 0 → 1 | 1 → 3 | 0 → 0 |
| `scripts/cycle-doc-probe.sh` | 1 → 1 | 2 → 1 | 0 → 1 | 1 → **0** |

(`SKILL.md` is markdown and enters the surface raw, not comment-stripped; its counts moved because Step 3b's prose now names the two output keys. The load-bearing counts are the script's.)

The probe needle leaving the own surface is the whole point — the canonical-probe check is the one check that reads the **widened** surface, and it is now satisfied over the new edge. The other three skills are unchanged: `plan-epic` 0/0/0/0 own (its probe was already over an edge), `write-code` 1/1/0/1, `ship-it` 0/0/1/1.

**So no `CYCLE_SKILLS` row and no `PRESENT_GATE_RE` alternative was touched** — no guard regex was widened or weakened by this diff. Both validators are green as-is.

## Verification (run at head `017968a8`)

- `bash claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh` → **OK, 14 checks**, exit 0.
- `bash claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh` → **OK, 18 checks**, exit 0. Both emitted scopes now carry `shared/scripts/cycle-doc-probe.sh (edge:review-code)`.
- `kp_skill_source_edges` over `review-code` → exit 0, **6 edges, every one resolving**: `lib/common.sh`, `shared/scripts/{cp-read,wl-empty-output,cycle-doc-probe,iso-preflight,verdict-readback}.sh`.
- **Corpus sweep** over every skill directory with a `SKILL.md` under `claude-plugins/kampus-pipeline/skills/` — deliberately wider than the hardcoded four-skill `CYCLE_SKILLS` array a green CI covers: **30 skills scanned, 0 unresolved**, `kp_skill_source_edges` exit 0 for all.
- **Mutation check** (T2 discipline): with the source line deleted and the whole docblock left intact, both validators go red for `review-code` **by name** — `FAIL: review-code: does not cite the canonical cycle-doc probe ('contents/product-development-cycle.md') in executable shell or via a source edge` — `validate-cycle-presence: FAILED — 1 error(s)` and `validate-cycle-absence: FAILED — 1 error(s)`. Reverted; the working file hashes back to the committed `70adf5f0…`.

## Span hashes

This is **not** a byte-move — no shell was relocated. The shared implementation already existed at `main` and is **untouched**. What changed is that the duplicated span was **deleted** and replaced by an edge to it, so byte-identity is claimed for the *target*, not for anything moved.

| span | sha256 |
|---|---|
| removed copy, `review-code/scripts/cycle-doc-probe.sh` lines 19–25 @ `f66bc054` | `c9f6f59e4110c5870b93390f031d8138c4551201d89c33b8b24006bdafc776ea` |
| whole file @ `f66bc054` | `9368182b7f893b0be2ce4a8a43bcd987a7a8c8db0b6e2d978b9d605ff77273bc` |
| whole file @ head `017968a8` | `70adf5f0ec8841e14734d08548e16207543eb44470cca70f2bb985f226e81829` |
| shared target @ `f66bc054` **and** @ head — identical, untouched | `4bb11c2f96a9352d27a2191bd08fc6d7ce1bc067c9d0170b872b0b2207950958` |

## Deviations

- **The ADR-0232 sourced→executed conversion of this one script is in scope, and it is a change beyond "delete a copy."** `SKILL.md` Step 3b previously sourced the wrapper for `$CYCLE_DOC`; the wrapper now `exit`s on the UNKNOWN path, which a sourcing caller could not survive, and top-level `.` is banned by 0232 anyway. Converting it was forced by this diff, not opportunistic. Only **this** fenced block moved to the literal-path form — the rest of `review-code/SKILL.md` still uses the `${CLAUDE_PLUGIN_ROOT:-…}` idiom, because the corpus-wide conversion is #4435 programme fan-out, not this ticket.
- **The stdout contract gained a second key (`CYCLE_GATING`) the old sourced form did not export.** The issue's own proposed shape introduced the same variable; exposing it on stdout rather than in a caller's shell is what ADR 0232 requires. `verify-gating` deliberately means "the cycle *admits* the check", not "the check fires" — the containment marker is still the other conjunct, resolved separately in Step 3b. That distinction is stated in the script header and in the step prose so it cannot be misread as a widened gate.
- **Everything is in one commit.** The byte-move discipline's separate-commit rule (verbatim relocation apart from any changed line) has no subject here: nothing was relocated verbatim, so there is no byte-identity claim to keep independently checkable.
- **Re-measured against the issue's implied scope.** The issue implied wrapper + validator regex re-key + docblock. Actual: **2 files, +62/−32 lines, zero validator edits** — under the implied scope for the third consecutive ticket in this epic, here because the enumerated-literal branch already satisfies the existing regexes.
- **No pre-existing defect fixed in passing** — `review-design/scripts/classify-control-plane.sh`'s `|| CP_STATE=""` (#4582), `verify-extraction.sh` check 9 (#4584) and check 1 (#4587) are untouched, as are `skills/write-code/**`, `skills/heal-ci/**` and #4453's surface.
- **§CP** — every touched path is under `claude-plugins/kampus-pipeline/skills/`. Human-approved merge; no auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
