### PR TITLE
refactor(skills): byte-move the review-gate tail's shell into executed scripts/ (#4453)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -1031,7 +1031,7 @@ re-review at a new head leaves the prior head's verdict standing and a concurren
 overwrites another's record (ADR 0058 rule 2, refined by ADR 0213). Never hand-roll the `PATCH`:
 
 ```bash
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/current-head.sh "$PR")"   # the head you reviewed
 # $BODY is your composed FAIL verdict; first line: review-doc: FAIL @ <HEAD_SHA> — changes-requested.
 # Same (PR, gate-namespace, head, run) upsert as the PASS path.
 printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh "$PR"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -107,8 +107,47 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/resolve-repo.sh
 ```
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/) and every fenced `bash` block below is an
+**invocation** of one, run by literal path with its results on stdout — never sourced (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)).
+The prose keeps the *why*; the scripts hold the *how* (epic #4435 phase 1 — the shell moved as-is,
+and turning its `gh`/`jq` glue into tested `pipeline-cli` verbs is #1929, ADR 0228: a script may
+RELAY a verb's answer, never DERIVE the decision). Four properties are load-bearing when you read or
+edit them:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control flow
+  through the guards written into it — `|| true` on a `grep` that may legitimately match nothing, a
+  state-word assertion instead of an exit-status test (§CP). `errexit` would abort those paths before
+  they print their fail-closed line, converting fail-closed into fail-**open**
+  ([`.patterns/skill-script-shell-shape.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-shell-shape.md)).
+- **No script installs an `EXIT` trap.** Under bash 3.2 a cleanup trap's last command becomes the
+  script's exit status, which launders a `set -u` abort into exit 0 (#4476, class #4479). This bites
+  twice here: [`scripts/adr-sweep.sh`](scripts/adr-sweep.sh)'s status **is** its answer, so it
+  captures `SWEEP=$?` before the cleanup and re-exits it, and
+  [`scripts/teardown-head.sh`](scripts/teardown-head.sh) is a script the **caller** may register as
+  its own `EXIT` trap rather than one that installs a trap itself.
+- **A script whose stdout answers a safety question makes every failure path speak (the
+  error-channel rule).** Moving glue behind a script boundary invents a channel the inline block
+  never had: a non-zero exit with **0 bytes on stdout**. Where a caller reads the *absence* of a
+  flag as a *positive* answer — an empty `$CONTROL_PLANE_TOUCHED` reads as "non-blocking" — a silent
+  guard exit is indistinguishable from "proven ordinary". So
+  [`scripts/classify-control-plane.sh`](scripts/classify-control-plane.sh) writes its handle with the
+  **§CP sentinel** on every failure path *before* exiting non-zero, and if even the handle cannot be
+  written its stdout stays empty so the caller's `.` fails loudly. An absent or empty result is
+  UNKNOWN, and UNKNOWN is never "no" (§ZS / ADR
+  [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md);
+  [`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md)).
+- **The shared-contract helpers are SOURCED from their canonical home — there is no skill-local
+  copy.** §CPREAD's `cp_changed_files` / `cp_head_sha` and the `verdict_post_verify` read-back live
+  in [`../shared/scripts/`](../shared/scripts/) (#4489 extracted them out of
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)), and this skill's scripts source
+  them directly. With no second copy there is nothing to keep in step and no byte-identity claim to
+  make about one.
 
 ## Read-only on git working state
 
@@ -145,12 +184,18 @@ check is satisfied by what the diff actually shows, not by the author asserting 
 
 ## Step 0 — Classify the diff: blocking or non-blocking
 
-Pull the file list first; the classification gates everything after it.
+Pull the file list first; the classification gates everything after it. One script runs **both** §CP
+clauses — the path clause and the ADR-0164 content clause — off **one** hardened read of the changed
+files, and leaves their two flags in your shell through the run-state handle it prints:
 
 ```bash
 PR=<pr number>
-gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[] | "\(.status)\t\(.filename)"'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
+# Prints ONE line — the handle carrying CONTROL_PLANE_TOUCHED / GUARD_TOUCHING / CP_FILES_N / ADR_N.
+# The changed-file list and the §ZS scope line go to stderr. On any failure the handle is written
+# with the §CP SENTINEL first, so a classifier that could not run reaches you as a HOLD, never as an
+# empty (= non-blocking) flag; if even the handle cannot be written, stdout is empty and this `.`
+# fails loudly. Read the STATUS before the flags.
+. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh "$PR")"
 ```
 
 - **Any control-plane path** — the **canonical §CP set** in
@@ -167,42 +212,10 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   `origin/main` at run time, not from the copy embedded in this skill body** (this advisory flag
   is informational, but the embedded copy travels in the *injected snapshot*, which can lag
   `origin/main` even when the on-disk file is current, so a pre-amendment snapshot once mis-flagged
-  a now-control-plane PR; #981). The bash below reads §CP freshly from `origin/main` and **fails
+  a now-control-plane PR; #981). The script above reads §CP freshly from `origin/main` and **fails
   closed** (treats every path as control-plane → advisory not-auto-mergeable) if that read can't be
-  made:
+  made. Its answer is `$CONTROL_PLANE_TOUCHED`: non-empty ⇒ blocking.
 
-  ```bash
-  # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
-  # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981).
-  # §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
-  # run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
-  # (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
-  CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
-  # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
-  # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
-  # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
-  CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
-  if [ -n "$CP_LIVE" ]; then
-    CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the advisory flag tracks origin/main, not the snapshot's age (AC1/AC2)
-  else
-    CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
-  fi
-  # The changed-file list is a fallible READ, and a failed one used to resolve to "no control-plane
-  # path touched" (#4216). `cp_changed_files` (and `cp_head_sha`, used by the content clause below)
-  # is §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim from there (single source), and
-  # read the why there, not here.
-  CP_READ_FAILED=
-  if ! cp_changed_files "$REPO" "$PR"; then
-    CP_READ_FAILED=1   # carried into the CONTENT clause below — one read, both clauses
-    CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"   # FAIL CLOSED
-  else
-    # grep aggregates the §CP matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER
-    # PAGE. `|| true` now means ONLY what it says: no match is grep exit 1 over a list PROVEN to
-    # arrive, not a swallowed read failure (#725 + #4216).
-    CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
-  fi
-  # non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
-  ```
 - **Any guard-touching `.decisions/**` ADR (§CP by CONTENT, ADR 0164)** — a `.decisions/**` ADR is
   not path-§CP, but one that **relaxes, amends, or widens an exemption on a documented guard** is
   control-plane by *nature* and its path can't tell it from an ordinary ADR (ADR
@@ -214,50 +227,11 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   read NON-§CP here and got a bindable PASS — the latent §CP-routing hole this closes. A guard-touching
   ADR puts the PR in the **blocking set** exactly like a path-§CP file: you review it and post
   findings, but **advisory only** (Step 5's blocking-set path). Fail-closed: an unreadable ADR body ⇒
-  §CP (the verb resolves this).
+  §CP (the verb resolves this). Its answer is `$GUARD_TOUCHING`: non-empty ⇒ blocking, exactly like a
+  control-plane path. Both clauses run off the **same** hardened `cp_changed_files` read — a blinded
+  file-list read blinds the CONTENT clause too, and for a `.decisions/**`-only PR the content clause
+  is the ONLY §CP signal there is (#4216).
 
-  ```bash
-  # Probe each touched .decisions/** ADR's CONTENT at head with the shared verb (single source of the
-  # ADR-0164 guard vocabulary; #3645). Assert on the probe's STATE WORD, never on its exit status —
-  # the exit code discriminates the two verdicts only once the verb has RUN, so the old
-  # `>/dev/null && …` shape accumulated NOTHING when it never ran (bad flag / nested-cwd
-  # module-not-found / missing shim) and read an unprobed ADR as ordinary. The `*)` arm keeps
-  # could-not-determine a HOLD, exactly as an unreadable body is (#4219).
-  # Same §CPREAD input as the path clause above — a blinded file-list read blinds the CONTENT clause
-  # too, and for a `.decisions/**`-only PR the content clause is the ONLY §CP signal there is (#4216).
-  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-  GUARD_TOUCHING=""
-  if [ -n "$CP_READ_FAILED" ]; then
-    GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
-  else
-    # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
-    # (copy it verbatim from there). It DISCARDS gh's payload on failure, which is what makes the
-    # `[ -n ]` test below a live guard rather than a dead one.
-    cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
-    [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"
-    ADR_N=0
-    while IFS= read -r adr; do
-      [ -z "$adr" ] && continue
-      [ -n "$HEAD_SHA" ] || break
-      ADR_N=$((ADR_N + 1))
-      # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
-      adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
-      if [ -z "$adr_body" ]; then
-        GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
-      else
-        GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
-        case "$GC_STATE" in
-          not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
-          guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
-          *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
-        esac
-      fi
-    done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
-    echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092)
-  fi
-  # non-empty $GUARD_TOUCHING → blocking: §CP-advisory, same as a control-plane path above (ADR 0164/0135)
-  ```
 - **Otherwise** → **non-blocking**, and the doc class — *which* `*.md`/knowledge files are
   yours — is the **canonical §DOC definition** in
   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md): cite it, don't re-derive
@@ -320,18 +294,14 @@ namespace is discovered.
 ## Step 1 — Resolve the PR and its linked issue
 
 ```bash
-gh api repos/$REPO/pulls/$PR \
-  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-context.sh "$PR"
 ```
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code`
 writes). Cross-check via the timeline if it's not obvious:
 
 ```bash
-# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
-# invisible without it on a long-lived PR's timeline (#4193)
-gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
-  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/linked-issue-timeline.sh "$PR"
 ```
 
 The `issues/$PR/timeline` endpoint accepts the PR number, and the
@@ -351,13 +321,10 @@ extended to the code lane by ADR
 Resolve it **mechanically, never by eye**:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # doc/vocab-surface-only? exit 0 = yes (issueless is legitimate), non-zero = no (hard-stop below).
 # Predicate single-sourced in §CLASS (DOC_VOCAB_EXCLUDE_RE / DOC_VOCAB_SURFACE_RE); fails closed to
 # "no" on an unreadable source or zero input (ADR 0092) — it can only ever REFUSE the allowance.
-gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-  | "$PCLI" class-probe doc-vocab-surface-only
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-issueless.sh "$PR"
 ```
 
 - **Not doc/vocab-surface-only** — any changed path under `apps/**`, `packages/**`, `infra/**`, or
@@ -385,8 +352,7 @@ When `ISSUE` **is** set, honor it as today: pull the issue and its acceptance cr
 
 ```bash
 ISSUE=<N>
-gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
-gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/issue-context.sh "$ISSUE"
 ```
 
 Extract the `### Acceptance criteria` checklist from the issue body. That list — every
@@ -417,8 +383,7 @@ test-running here** — a doc PR has no behavior to exercise; the artifact *is* 
 so you read it. Pull the change:
 
 ```bash
-gh pr diff $PR \
-  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-diff.sh "$PR"
 ```
 
 For checks that need the file in context (a link target exists, an index row matches, a
@@ -428,71 +393,59 @@ the hunk alone — and read it **read-only**, without ever switching the checkou
 **Read-only on git working state** below). Fetch the head into a ref and read off that ref:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# §SP FIRST — allocate this run's scratch namespace, and land the head handles in a file inside it.
-# $PR_REF / $HEAD_SHA (and $REVIEW_WT below) are needed by LATER Bash calls — Step 4a's ADR sweep
-# reads `git show "$PR_REF:…"` — and a shell variable does not survive the harness's between-call
-# reset. So they go in `head.env` under the per-run namespace, whose path is a deterministic
-# function of this run's session id and is therefore RE-DERIVABLE in any later call. A `mktemp`
-# path is not: by the next call the handle itself is a lost shell variable with no way back to it
-# (#4041). §SP rules 2+3 apply here, NOT the rule-4 carve-out — that one is for a temp allocated
-# AND consumed inside one call, like `VERDICT_FILE` below. `scratchpad` is the allocator (§SP rule
-# 2 of ../gh-issue-intake-formats.md); it refuses with a reason on stderr rather than falling back
-# to a shared path, and §SP's one-liner is the same namespace for a run with no CLI on PATH.
-"$PCLI" scratchpad open --slug "review-doc-$PR" >/dev/null || exit 1   # ONCE, at the start of the run
-HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
-
-# Land the head in a per-run ref via the shared `pipeline-cli review-head materialize` verb
-# (#3690 / #793 / #1807) — cite it, don't re-derive it. Ref-only mode (no `--worktree`): it
-# resolves the live head SHA (REST), fetches `pull/<pr>/head` into a nonce-uniqued per-run ref
-# WITHOUT touching the working tree, and asserts the fetched ref IS that head. It never runs
-# `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the shared PRIMARY
-# the harness resets this cwd to and detach the human's `main` — #2270/#1103; §RO). It emits the
-# head + ref as JSON:
-"$PCLI" review-head materialize --pr "$PR" \
-  | jq -r '"PR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
-. "$HEAD_ENV"
+# Prints ONE line — the handle carrying PR_REF / HEAD_SHA. On any failure stdout is EMPTY, so this
+# `.` fails loudly rather than leaving you reading the launched checkout's base tree (#793).
+. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh "$PR")"
 
 # Read the head's files off the ref — read-only, no checkout:
 git show "$PR_REF:<path>"            # the file's content at the PR head
 git grep -n "<pattern>" "$PR_REF"    # search the head tree without checking it out
-
-git update-ref -d "$PR_REF"          # drop the throwaway ref when done
 ```
 
-**Every later Bash call re-derives `$HEAD_ENV`; it never inherits it.** Re-run the same
-`scratchpad file` line — same session, same slug, same path — then re-source. `scratchpad file`
-**refuses** when the namespace was never opened in this run, so a lost handle fails loud instead
+The script drives §HEAD's fetch-into-a-ref through the shared `pipeline-cli review-head materialize`
+verb (#3690 / #793 / #1807) — cite it, don't re-derive it. Ref-only mode resolves the live head SHA
+(REST), fetches `pull/<pr>/head` into a nonce-uniqued per-run ref WITHOUT touching the working tree,
+and asserts the fetched ref IS that head. It never runs `gh pr checkout` / `git checkout` /
+`git switch` (which would land the head in the shared PRIMARY the harness resets this cwd to and
+detach the human's `main` — #2270/#1103; §RO).
+
+**The handles live in this run's §SP namespace, not a `mktemp`.** `$PR_REF` / `$HEAD_SHA` (and
+`$REVIEW_WT`) are needed by LATER Bash calls — Step 4a's ADR sweep reads `git show "$PR_REF:…"` —
+and a shell variable does not survive the harness's between-call reset. So they go in `head.env`
+under the per-run namespace, whose path is a deterministic function of this run's session id and is
+therefore RE-DERIVABLE in any later call. A `mktemp` path is not: by the next call the handle itself
+is a lost shell variable with no way back to it (#4041). §SP rules 2+3 apply here, NOT the rule-4
+carve-out — that one is for a temp allocated AND consumed inside one call, like Step 4a's subject
+dir. `scratchpad` is the allocator (§SP rule 2 of
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)); it refuses with a reason on stderr
+rather than falling back to a shared path.
+
+**Every later Bash call re-derives `$HEAD_ENV`; it never inherits it.** Run
+[`scripts/head-env.sh`](scripts/head-env.sh) — same session, same slug, same path — then re-source.
+It **refuses** when the namespace was never opened in this run, so a lost handle fails loud instead
 of silently reading an empty directory:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
-[ -s "$HEAD_ENV" ] || { echo "review-doc: §SP — head.env absent/empty; re-run the materialize step in THIS session." >&2; exit 1; }
-. "$HEAD_ENV"                        # $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)
+. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh "$PR")"   # $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)
 ```
 
 If a check genuinely needs a materialized tree (rare for a doc PR), pass `--worktree` to the
-same verb — it adds a throwaway DETACHED head worktree (named `review-head-<pr>-*`) and emits
-its path. It goes into the **same** `head.env`, for the same reason: a later step must recover
-*this* run's own tree, never re-derive it from a shared, PR-namespaced leaf — under a parallel
-fan-out that leaf matches a sibling reviewer's tree and pins the wrong head (the #1807 collision):
+same script — the verb then adds a throwaway DETACHED head worktree and emits its path. It goes into
+the **same** `head.env`, for the same reason: a later step must recover *this* run's own tree, never
+re-derive it from a shared, PR-namespaced leaf — under a parallel fan-out that leaf matches a sibling
+reviewer's tree and pins the wrong head (the #1807 collision). Tear it down with the same
+[`scripts/teardown-head.sh`](scripts/teardown-head.sh), which also drops the throwaway ref:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" review-head materialize --pr "$PR" --worktree \
-  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
-. "$HEAD_ENV"
-# Register teardown as a trap so a mid-block error still tears the throwaway tree down:
-trap 'rm -rf "$REVIEW_WT"; git worktree prune' EXIT
-rm -rf "$REVIEW_WT" && git worktree prune   # tear it down on EVERY exit path — PASS or FAIL
+. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh "$PR" --worktree)"
+# Register teardown as a trap so a mid-block error still tears the throwaway tree down. The trap is
+# YOURS, not the script's — an extracted script installs no EXIT trap of its own (#4476/#4479).
+trap 'bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh "$PR"' EXIT
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh "$PR"   # on EVERY exit path — PASS or FAIL
 ```
 
 **Teardown runs on both the success and the failure path**, not just when the check passed —
-run the `rm -rf` even when the review exits `FAIL` or aborts mid-run, so no `review-doc-head-*`
+run it even when the review exits `FAIL` or aborts mid-run, so no `review-doc-head-*`
 tree leaks onto the shared primary (#2785). The `rm -rf` of the review's own detached, already-
 pushed throwaway is safe (it holds no branch/unpushed work). The standing net for a session-end
 abort between Bash calls (which no in-shell trap can reach) is `pipeline-cli worktree-sweep
@@ -516,12 +469,11 @@ that predated them. Make the freshness structural — a fetch you run, not a pro
 whoever's checkout the gate happens to run in:
 
 ```bash
-BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
-git fetch origin "$BASE_REF"                                  # refresh the merge target
+BASE_REF="$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/base-groundtruth.sh fetch "$PR")"   # resolves + refreshes the merge target
 
 # Verify shipped-state against the FETCHED remote ref, not the working tree / local main:
-git cat-file -e "origin/$BASE_REF:<path>"          # does this path exist on fresh main?
-git show "origin/$BASE_REF:<path>"                 # read its shipped content to confirm
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/base-groundtruth.sh exists "$BASE_REF" "<path>"   # does this path exist on fresh main?
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/base-groundtruth.sh show   "$BASE_REF" "<path>"   # read its shipped content to confirm
 ```
 
 You're reading, not building — no `pnpm install`, no typecheck, no test suite. The diff,
@@ -604,11 +556,9 @@ Run each, scoped to the files the PR touches:
    leaks nothing (#4220).
 
    ```bash
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
    # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
    # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
-   gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment
+   bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/leak-scan.sh "$PR"
    ```
 
    Cite a hit by the **class** the scan names and the `file:line` from the diff hunk it sits
@@ -696,24 +646,19 @@ citations.** The mechanical shortlist is one command — it ranks the live-accep
 decision domain the new one touches **and which it does not cite**:
 
 ```bash
-# Runs on Step 2's DEFAULT ref-only path — no `--worktree`, no materialized tree. `--new` takes
-# "a path to the ADR file" (any real file, anywhere), so a `git show` off $PR_REF is all the
-# "real file on disk" the sweep needs. $PR_REF is bound by Step 2's `review-head materialize`;
-# if that ran in an EARLIER Bash call the variable is gone, so re-source Step 2's `head.env` here
-# (`pipeline-cli scratchpad file --slug "review-doc-$PR" --name head.env`) — never re-run the
-# materialize just to rebind it, and never carry the path in a variable across the reset.
-# CORPUS: `--dir` is deliberately unset, so the sweep reads the repo-root `.decisions/` of the
-# checkout you are running in — the BASE (pre-PR) corpus. That is the set you want: it carries
-# every live ADR the new one could contradict, and it excludes the new ADR itself, so the subject
-# can never rank against its own file. Only the subject is read from the PR head.
-# Exit 0 means the mechanical sweep found nothing left to open; non-zero means there is a
-# shortlist to clear, or that the sweep was INDETERMINATE and proved nothing.
-SUBJECT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/review-doc-adr-subject.XXXXXX")"   # §SP rule-4 carve-out: allocated AND consumed in this one call
-git show "$PR_REF:.decisions/NNNN-slug.md" > "$SUBJECT_DIR/NNNN-slug.md"
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
-  --new "$SUBJECT_DIR/NNNN-slug.md"
-SWEEP=$?; rm -rf "$SUBJECT_DIR"   # keep the sweep's status: it, not the cleanup, is the outcome
+# $PR_REF is bound by Step 2's materialize; if that ran in an EARLIER Bash call the variable is gone,
+# so re-derive it via head-env.sh first — never re-run the materialize just to rebind it.
+. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/adr-sweep.sh "$PR_REF" .decisions/NNNN-slug.md
+SWEEP=$?
 ```
+
+**The exit status is the answer**: 0 means the mechanical sweep found nothing left to open; non-zero
+means there is a shortlist to clear, **or** that the sweep was INDETERMINATE and proved nothing — the
+script's own guards (no subject dir, an unreadable ADR at the head) exit non-zero for exactly that
+reason. It runs on Step 2's DEFAULT ref-only path — no `--worktree`, no materialized tree, because
+`--new` takes "a path to the ADR file" (any real file, anywhere) and a `git show` off `$PR_REF` is
+all the "real file on disk" the sweep needs.
 
 Two things worth being explicit about, because a reader will otherwise assume them wrong. **The
 swept corpus is the base `.decisions/` of the checkout you run in**, not a PR-head tree — the new
@@ -899,7 +844,7 @@ verdict not bound to the PR's current head (ADR
 [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258).
 
 ```bash
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/current-head.sh "$PR")"   # the head you reviewed
 ```
 
 ### Pass path — non-blocking PR (the binding signal)
@@ -937,15 +882,16 @@ the post. This is the single-source rule in
 Resolve the tool once — in-repo first, published fallback (ADR 0062/0064; epic #994) — and pass
 your composed verdict body by file:
 
-```bash
-# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
-# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here
-# (#3653; ADR 0062/0064; epic #994)
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+All three Step-5 branches — non-blocking PASS, §CP advisory, FAIL — post through the **one**
+[`scripts/verdict-post.sh`](scripts/verdict-post.sh), which takes the composed body on **stdin**. The
+three fences differed only in the body they told you to compose; the mechanism was identical, so
+there is one script and not three. Stdin also retires the scratch file, which removes the #2683 /
+#3718 class by construction: with no path on disk there is nothing for a concurrent review of the
+same PR to clobber, and no `mktemp` path that can bleed into the marker's `@ <sha>` field.
 
-VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
-# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-doc: PASS @ <HEAD_SHA> — merge-ready)
-$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"   # upsert (PATCH own prior marker, else POST)
+```bash
+# $BODY is your composed PASS verdict; first line: review-doc: PASS @ <HEAD_SHA> — merge-ready.
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh "$PR"   # upsert (PATCH own prior marker, else POST)
 ```
 
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
@@ -1059,12 +1005,10 @@ blocking-set path is comment-only too, exactly like the PASS and FAIL paths (ADR
 rule 4). Upsert it the same way, on the §VERDICT key — (PR, gate-namespace, head, run):
 
 ```bash
-# $VERDICT resolved above (in-repo-first, published-fallback; ADR 0062/0064). The advisory line
-# opens with `review-doc:` too, so `verdict post`'s namespace guard accepts it and upserts it on
-# the same (PR, gate-namespace, head, run) key — replacing only this head+run's own record.
-VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
-# write your composed advisory verdict into "$VERDICT_FILE" (first line: review-doc: advisory — blocking-set PR (§CP — approval-gated))
-$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"
+# The advisory line opens with `review-doc:` too, so `verdict post`'s namespace guard accepts it and
+# upserts it on the same (PR, gate-namespace, head, run) key — replacing only this head+run's own
+# record. $BODY's first line: review-doc: advisory — blocking-set PR (§CP — approval-gated).
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh "$PR"
 ```
 
 Do **not** emit the `review-doc: PASS @ <sha> — merge-ready` marker for a blocking PR — that marker is a
@@ -1088,10 +1032,9 @@ overwrites another's record (ADR 0058 rule 2, refined by ADR 0213). Never hand-r
 
 ```bash
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
-VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
-# write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-doc: FAIL @ <HEAD_SHA> — changes-requested)
-# $VERDICT resolved above (ADR 0062/0064) — same (PR, gate-namespace, head, run) upsert as the PASS path.
-$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"
+# $BODY is your composed FAIL verdict; first line: review-doc: FAIL @ <HEAD_SHA> — changes-requested.
+# Same (PR, gate-namespace, head, run) upsert as the PASS path.
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh "$PR"
 ```
 
 Verdict body shape:
@@ -1153,7 +1096,7 @@ landed, on **every** post path —
 # UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
 # + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
 # the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.
-verdict_post_verify "$PR" review-doc "$HEAD_SHA" || exit 1
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-readback.sh "$PR" "$HEAD_SHA" || exit 1
 ```
 
 The wrapper's single **fatal** exit — on nothing-landed *and* on a malformed/leaking marker resolved

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/adr-sweep.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/adr-sweep.sh
@@ -1,17 +1,40 @@
+#!/usr/bin/env bash
+# Step 4a — the citation-independent ADR contradiction sweep. Extracted from review-doc/SKILL.md
+# (#4453, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+#
+# THE EXIT STATUS IS THE ANSWER, and the cleanup must not eat it: exit 0 means the mechanical sweep
+# found nothing left to open; non-zero means there is a shortlist to clear, or that the sweep was
+# INDETERMINATE and proved nothing. The `SWEEP=$?` capture before the `rm -rf` is what preserves
+# that, and it is also why this script installs no `EXIT` trap — under bash 3.2 a cleanup trap's
+# last command becomes the script's status, which would report the cleanup instead of the sweep.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: adr-sweep.sh <pr-ref> <.decisions/NNNN-slug.md>" >&2; exit 2; }
+PR_REF="$1"; ADR_PATH="$2"
+PCLI="$(kp_pcli)" || exit 127
+
 # Runs on Step 2's DEFAULT ref-only path — no `--worktree`, no materialized tree. `--new` takes
 # "a path to the ADR file" (any real file, anywhere), so a `git show` off $PR_REF is all the
 # "real file on disk" the sweep needs. $PR_REF is bound by Step 2's `review-head materialize`;
-# if that ran in an EARLIER Bash call the variable is gone, so re-source Step 2's `head.env` here
-# (`pipeline-cli scratchpad file --slug "review-doc-$PR" --name head.env`) — never re-run the
-# materialize just to rebind it, and never carry the path in a variable across the reset.
+# if that ran in an EARLIER Bash call the variable is gone, so re-derive it from Step 2's `head.env`
+# via head-env.sh — never re-run the materialize just to rebind it.
 # CORPUS: `--dir` is deliberately unset, so the sweep reads the repo-root `.decisions/` of the
 # checkout you are running in — the BASE (pre-PR) corpus. That is the set you want: it carries
 # every live ADR the new one could contradict, and it excludes the new ADR itself, so the subject
 # can never rank against its own file. Only the subject is read from the PR head.
-# Exit 0 means the mechanical sweep found nothing left to open; non-zero means there is a
-# shortlist to clear, or that the sweep was INDETERMINATE and proved nothing.
 SUBJECT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/review-doc-adr-subject.XXXXXX")"   # §SP rule-4 carve-out: allocated AND consumed in this one call
-git show "$PR_REF:.decisions/NNNN-slug.md" > "$SUBJECT_DIR/NNNN-slug.md"
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
-  --new "$SUBJECT_DIR/NNNN-slug.md"
+if [ -z "$SUBJECT_DIR" ] || [ ! -d "$SUBJECT_DIR" ]; then
+  echo "adr-sweep.sh: mktemp -d produced no subject dir — the sweep did NOT run (UNKNOWN, never 'nothing to open')." >&2
+  exit 1
+fi
+if ! git show "$PR_REF:$ADR_PATH" > "$SUBJECT_DIR/$(basename "$ADR_PATH")"; then
+  echo "adr-sweep.sh: could not read $ADR_PATH at $PR_REF — the sweep did NOT run (UNKNOWN, never 'nothing to open')." >&2
+  rm -rf "$SUBJECT_DIR"
+  exit 1
+fi
+"$PCLI" adr-sweep shortlist --new "$SUBJECT_DIR/$(basename "$ADR_PATH")"
 SWEEP=$?; rm -rf "$SUBJECT_DIR"   # keep the sweep's status: it, not the cleanup, is the outcome
+exit "$SWEEP"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/adr-sweep.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/adr-sweep.sh
@@ -1,0 +1,17 @@
+# Runs on Step 2's DEFAULT ref-only path — no `--worktree`, no materialized tree. `--new` takes
+# "a path to the ADR file" (any real file, anywhere), so a `git show` off $PR_REF is all the
+# "real file on disk" the sweep needs. $PR_REF is bound by Step 2's `review-head materialize`;
+# if that ran in an EARLIER Bash call the variable is gone, so re-source Step 2's `head.env` here
+# (`pipeline-cli scratchpad file --slug "review-doc-$PR" --name head.env`) — never re-run the
+# materialize just to rebind it, and never carry the path in a variable across the reset.
+# CORPUS: `--dir` is deliberately unset, so the sweep reads the repo-root `.decisions/` of the
+# checkout you are running in — the BASE (pre-PR) corpus. That is the set you want: it carries
+# every live ADR the new one could contradict, and it excludes the new ADR itself, so the subject
+# can never rank against its own file. Only the subject is read from the PR head.
+# Exit 0 means the mechanical sweep found nothing left to open; non-zero means there is a
+# shortlist to clear, or that the sweep was INDETERMINATE and proved nothing.
+SUBJECT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/review-doc-adr-subject.XXXXXX")"   # §SP rule-4 carve-out: allocated AND consumed in this one call
+git show "$PR_REF:.decisions/NNNN-slug.md" > "$SUBJECT_DIR/NNNN-slug.md"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" adr-sweep shortlist \
+  --new "$SUBJECT_DIR/NNNN-slug.md"
+SWEEP=$?; rm -rf "$SUBJECT_DIR"   # keep the sweep's status: it, not the cleanup, is the outcome

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/base-groundtruth.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/base-groundtruth.sh
@@ -1,6 +1,37 @@
-BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
-git fetch origin "$BASE_REF"                                  # refresh the merge target
+#!/usr/bin/env bash
+# Step 2 — refresh the merge target, then read a path off it for an "is it shipped on main?"
+# ground-truth check. Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# The fetch is the point: a stale local `main` is what false-FAILed PR #305, whose consumers had
+# merged minutes earlier. Freshness is structural here — a fetch this script runs, not a property of
+# whoever's checkout the gate happens to run in. It never reads the working tree.
+#
+# Three modes, because the fence carried three steps: `fetch` refreshes the base and prints the ref
+# it refreshed; `exists` is the `git cat-file -e` presence probe (exit status IS the answer, no
+# stdout); `show` prints the shipped content.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
+[ "$#" -ge 2 ] || { echo "usage: base-groundtruth.sh fetch <pr> | base-groundtruth.sh <exists|show> <base-ref> <path>" >&2; exit 2; }
+MODE="$1"
+
+if [ "$MODE" = "fetch" ]; then
+  PR="$2"
+  REPO="$(kp_repo)" || exit 1
+  BASE_REF="$(gh api repos/"$REPO"/pulls/"$PR" --jq '.base.ref')"   # normally main
+  [ -n "$BASE_REF" ] || { echo "base-groundtruth.sh: could not resolve the PR's base ref — no ground truth to check against." >&2; exit 1; }
+  git fetch origin "$BASE_REF" >&2                                  # refresh the merge target
+  printf '%s\n' "$BASE_REF"
+  exit 0
+fi
+
+[ "$#" -ge 3 ] || { echo "usage: base-groundtruth.sh <exists|show> <base-ref> <path>" >&2; exit 2; }
+BASE_REF="$2"; TARGET="$3"
 # Verify shipped-state against the FETCHED remote ref, not the working tree / local main:
-git cat-file -e "origin/$BASE_REF:<path>"          # does this path exist on fresh main?
-git show "origin/$BASE_REF:<path>"                 # read its shipped content to confirm
+case "$MODE" in
+  exists) git cat-file -e "origin/$BASE_REF:$TARGET" ;;   # does this path exist on fresh main?
+  show)   git show "origin/$BASE_REF:$TARGET" ;;          # read its shipped content to confirm
+  *) echo "base-groundtruth.sh: mode must be 'fetch', 'exists' or 'show'." >&2; exit 2 ;;
+esac

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/base-groundtruth.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/base-groundtruth.sh
@@ -1,0 +1,6 @@
+BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
+git fetch origin "$BASE_REF"                                  # refresh the merge target
+
+# Verify shipped-state against the FETCHED remote ref, not the working tree / local main:
+git cat-file -e "origin/$BASE_REF:<path>"          # does this path exist on fresh main?
+git show "origin/$BASE_REF:<path>"                 # read its shipped content to confirm

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh
@@ -1,73 +1,130 @@
-PR=<pr number>
+#!/usr/bin/env bash
+# Step 0 — the §CP blocking flag: the path clause (CONTROL_PLANE_RE, re-resolved from origin/main)
+# and the ADR-0164 content clause (guard-touching `.decisions/**`). Extracted from
+# review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts. The *why* for each clause stays in that step's prose.
+#
+# STDOUT IS A MACHINE CHANNEL: the only stdout line is the run-state handle carrying
+# CONTROL_PLANE_TOUCHED / GUARD_TOUCHING / CP_FILES_N / ADR_N, so Step 0 can
+# `. "$(classify-control-plane.sh "$PR")"` and branch on the two flags. Scope + diagnostic lines go
+# to stderr, per `.patterns/skill-script-io-contract.md`.
+#
+# EVERY failure path WRITES THE HANDLE WITH THE §CP SENTINEL FIRST, then exits non-zero. That is the
+# whole reason this script exists in this shape: an empty `$CONTROL_PLANE_TOUCHED` is what the step
+# reads as "non-blocking", so a classifier that could not run must never reach the caller as an
+# unset/empty flag. An absent or empty result is UNKNOWN, and UNKNOWN is never "no §CP path touched"
+# (§ZS / ADR 0092; #4216, #4231, #4010, #4219). If even the handle cannot be written, stdout stays
+# EMPTY and the caller's `.` fails loudly — hold the PR as §CP.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# §CPREAD's `cp_changed_files` + `cp_head_sha`, sourced from their canonical home — no skill-local
+# copy to drift (#4489 extracted them out of ../../gh-issue-intake-formats.md, which is why the moved
+# comments below no longer say "copy them verbatim"). They write on stderr only, so no call site
+# redirects (`.patterns/skill-script-io-contract.md`, #4510).
+# shellcheck source=../../shared/scripts/cp-read.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
+
+SENTINEL="<§CP classifier could not run — §CP UNKNOWN, held as control-plane>"
+HANDLE=""
+# emit_and_exit <status> <control-plane-touched> <guard-touching> <cp-files-n> <adr-n>
+emit_and_exit() {
+  if [ -n "$HANDLE" ]; then
+    {
+      printf 'CONTROL_PLANE_TOUCHED=%q\n' "$2"
+      printf 'GUARD_TOUCHING=%q\n' "$3"
+      printf 'CP_FILES_N=%s\n' "$4"
+      printf 'ADR_N=%s\n' "$5"
+    } > "$HANDLE"
+    printf '%s\n' "$HANDLE"
+  else
+    echo "classify-control-plane.sh: could not open the per-run handle — no §CP answer was produced. Hold the PR as CONTROL PLANE." >&2
+  fi
+  exit "$1"
+}
+
+# Open the handle BEFORE the argument check, so even a usage error reaches the caller as the §CP
+# sentinel IN THE HANDLE rather than as 0 bytes on stdout.
+HANDLE="$(kp_scratch_open review-doc-cp)/cp.env" || HANDLE=""
+[ "$#" -ge 1 ] || { echo "usage: classify-control-plane.sh <pr>" >&2; emit_and_exit 2 "$SENTINEL" "$SENTINEL" 0 0; }
+PR="$1"
+# Top-level assignment, never `local` — `local REPO="$(kp_repo)"` masks the substitution's status,
+# and this guard's whole job is to catch it.
+REPO="$(kp_repo)" || emit_and_exit 1 "$SENTINEL" "$SENTINEL" 0 0
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="$(kp_pcli)" || PCLI=""
+
+# The changed-file list, for the record. --paginate + streaming --jq: full set past file #100 (the
+# API caps per_page at 100; #725).
 gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[] | "\(.status)\t\(.filename)"'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
-  # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
-  # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981).
-  # §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
-  # run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
-  # (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
-  CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
-  # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
-  # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
-  # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
-  CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
-  if [ -n "$CP_LIVE" ]; then
-    CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the advisory flag tracks origin/main, not the snapshot's age (AC1/AC2)
-  else
-    CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
-  fi
-  # The changed-file list is a fallible READ, and a failed one used to resolve to "no control-plane
-  # path touched" (#4216). `cp_changed_files` (and `cp_head_sha`, used by the content clause below)
-  # is §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim from there (single source), and
-  # read the why there, not here.
-  CP_READ_FAILED=
-  if ! cp_changed_files "$REPO" "$PR"; then
-    CP_READ_FAILED=1   # carried into the CONTENT clause below — one read, both clauses
-    CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"   # FAIL CLOSED
-  else
-    # grep aggregates the §CP matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER
-    # PAGE. `|| true` now means ONLY what it says: no match is grep exit 1 over a list PROVEN to
-    # arrive, not a swallowed read failure (#725 + #4216).
-    CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
-  fi
-  # non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
-  # Probe each touched .decisions/** ADR's CONTENT at head with the shared verb (single source of the
-  # ADR-0164 guard vocabulary; #3645). Assert on the probe's STATE WORD, never on its exit status —
-  # the exit code discriminates the two verdicts only once the verb has RUN, so the old
-  # `>/dev/null && …` shape accumulated NOTHING when it never ran (bad flag / nested-cwd
-  # module-not-found / missing shim) and read an unprobed ADR as ordinary. The `*)` arm keeps
-  # could-not-determine a HOLD, exactly as an unreadable body is (#4219).
-  # Same §CPREAD input as the path clause above — a blinded file-list read blinds the CONTENT clause
-  # too, and for a `.decisions/**`-only PR the content clause is the ONLY §CP signal there is (#4216).
-  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-  GUARD_TOUCHING=""
-  if [ -n "$CP_READ_FAILED" ]; then
-    GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
-  else
-    # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
-    # (copy it verbatim from there). It DISCARDS gh's payload on failure, which is what makes the
-    # `[ -n ]` test below a live guard rather than a dead one.
-    cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
-    [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"
-    ADR_N=0
-    while IFS= read -r adr; do
-      [ -z "$adr" ] && continue
-      [ -n "$HEAD_SHA" ] || break
-      ADR_N=$((ADR_N + 1))
-      # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
-      adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
-      if [ -z "$adr_body" ]; then
-        GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
-      else
-        GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
-        case "$GC_STATE" in
-          not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
-          guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
-          *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
-        esac
-      fi
-    done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
-    echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092)
-  fi
-  # non-empty $GUARD_TOUCHING → blocking: §CP-advisory, same as a control-plane path above (ADR 0164/0135)
+  --jq '.[] | "\(.status)\t\(.filename)"' >&2
+# §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
+# is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981).
+# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
+# Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
+# PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
+# freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
+CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+if [ -n "$CP_LIVE" ]; then
+  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the advisory flag tracks origin/main, not the snapshot's age (AC1/AC2)
+else
+  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
+fi
+# The changed-file list is a fallible READ, and a failed one used to resolve to "no control-plane
+# path touched" (#4216). `cp_changed_files` (and `cp_head_sha`, used by the content clause below)
+# is §CPREAD, sourced above from ../../shared/scripts/cp-read.sh (single source), and the why lives
+# in ../../gh-issue-intake-formats.md, not here.
+CP_READ_FAILED=
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_READ_FAILED=1   # carried into the CONTENT clause below — one read, both clauses
+  CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"   # FAIL CLOSED
+else
+  # grep aggregates the §CP matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER
+  # PAGE. `|| true` now means ONLY what it says: no match is grep exit 1 over a list PROVEN to
+  # arrive, not a swallowed read failure (#725 + #4216).
+  CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
+fi
+# non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
+# Probe each touched .decisions/** ADR's CONTENT at head with the shared verb (single source of the
+# ADR-0164 guard vocabulary; #3645). Assert on the probe's STATE WORD, never on its exit status —
+# the exit code discriminates the two verdicts only once the verb has RUN, so the old
+# `>/dev/null && …` shape accumulated NOTHING when it never ran (bad flag / nested-cwd
+# module-not-found / missing shim) and read an unprobed ADR as ordinary. The `*)` arm keeps
+# could-not-determine a HOLD, exactly as an unreadable body is (#4219).
+# Same §CPREAD input as the path clause above — a blinded file-list read blinds the CONTENT clause
+# too, and for a `.decisions/**`-only PR the content clause is the ONLY §CP signal there is (#4216).
+GUARD_TOUCHING=""
+ADR_N=0
+if [ -n "$CP_READ_FAILED" ]; then
+  GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  emit_and_exit 1 "$CONTROL_PLANE_TOUCHED" "$GUARD_TOUCHING" "${CP_FILES_N:-0}" 0
+else
+  # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
+  # (sourced above from ../../shared/scripts/cp-read.sh). It DISCARDS gh's payload on failure, which
+  # is what makes the `[ -n ]` test below a live guard rather than a dead one.
+  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"
+  while IFS= read -r adr; do
+    [ -z "$adr" ] && continue
+    [ -n "$HEAD_SHA" ] || break
+    ADR_N=$((ADR_N + 1))
+    # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
+    adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+    if [ -z "$adr_body" ]; then
+      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
+    else
+      GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+      case "$GC_STATE" in
+        not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+        guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
+        *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
+      esac
+    fi
+  done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
+  echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed" >&2   # §ZS #1 (ADR 0092)
+fi
+# non-empty $GUARD_TOUCHING → blocking: §CP-advisory, same as a control-plane path above (ADR 0164/0135)
+emit_and_exit 0 "$CONTROL_PLANE_TOUCHED" "$GUARD_TOUCHING" "$CP_FILES_N" "$ADR_N"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh
@@ -1,0 +1,73 @@
+PR=<pr number>
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+  --jq '.[] | "\(.status)\t\(.filename)"'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
+  # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
+  # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981).
+  # §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+  # run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+  # (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+  CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
+  # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
+  # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
+  # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
+  CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+  if [ -n "$CP_LIVE" ]; then
+    CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the advisory flag tracks origin/main, not the snapshot's age (AC1/AC2)
+  else
+    CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
+  fi
+  # The changed-file list is a fallible READ, and a failed one used to resolve to "no control-plane
+  # path touched" (#4216). `cp_changed_files` (and `cp_head_sha`, used by the content clause below)
+  # is §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim from there (single source), and
+  # read the why there, not here.
+  CP_READ_FAILED=
+  if ! cp_changed_files "$REPO" "$PR"; then
+    CP_READ_FAILED=1   # carried into the CONTENT clause below — one read, both clauses
+    CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"   # FAIL CLOSED
+  else
+    # grep aggregates the §CP matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER
+    # PAGE. `|| true` now means ONLY what it says: no match is grep exit 1 over a list PROVEN to
+    # arrive, not a swallowed read failure (#725 + #4216).
+    CONTROL_PLANE_TOUCHED="$(printf '%s\n' "$CP_FILES" | grep -E "$CONTROL_PLANE_RE" || true)"
+  fi
+  # non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
+  # Probe each touched .decisions/** ADR's CONTENT at head with the shared verb (single source of the
+  # ADR-0164 guard vocabulary; #3645). Assert on the probe's STATE WORD, never on its exit status —
+  # the exit code discriminates the two verdicts only once the verb has RUN, so the old
+  # `>/dev/null && …` shape accumulated NOTHING when it never ran (bad flag / nested-cwd
+  # module-not-found / missing shim) and read an unprobed ADR as ordinary. The `*)` arm keeps
+  # could-not-determine a HOLD, exactly as an unreadable body is (#4219).
+  # Same §CPREAD input as the path clause above — a blinded file-list read blinds the CONTENT clause
+  # too, and for a `.decisions/**`-only PR the content clause is the ONLY §CP signal there is (#4216).
+  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+  GUARD_TOUCHING=""
+  if [ -n "$CP_READ_FAILED" ]; then
+    GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  else
+    # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
+    # (copy it verbatim from there). It DISCARDS gh's payload on failure, which is what makes the
+    # `[ -n ]` test below a live guard rather than a dead one.
+    cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+    [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"
+    ADR_N=0
+    while IFS= read -r adr; do
+      [ -z "$adr" ] && continue
+      [ -n "$HEAD_SHA" ] || break
+      ADR_N=$((ADR_N + 1))
+      # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
+      adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+      if [ -z "$adr_body" ]; then
+        GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
+      else
+        GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+        case "$GC_STATE" in
+          not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+          guard-touching) GUARD_TOUCHING="$GUARD_TOUCHING $adr" ;;
+          *) GUARD_TOUCHING="$GUARD_TOUCHING $adr(undetermined:'$GC_STATE')" ;;
+        esac
+      fi
+    done < <(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)
+    echo "§CP scope: $CP_FILES_N file(s) scanned, $ADR_N .decisions/** ADR(s) content-probed"   # §ZS #1 (ADR 0092)
+  fi
+  # non-empty $GUARD_TOUCHING → blocking: §CP-advisory, same as a control-plane path above (ADR 0164/0135)

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-issueless.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-issueless.sh
@@ -1,0 +1,7 @@
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# doc/vocab-surface-only? exit 0 = yes (issueless is legitimate), non-zero = no (hard-stop below).
+# Predicate single-sourced in §CLASS (DOC_VOCAB_EXCLUDE_RE / DOC_VOCAB_SURFACE_RE); fails closed to
+# "no" on an unreadable source or zero input (ADR 0092) — it can only ever REFUSE the allowance.
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
+  | "$PCLI" class-probe doc-vocab-surface-only

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-issueless.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-issueless.sh
@@ -1,7 +1,22 @@
+#!/usr/bin/env bash
+# Step 1 — is the diff doc/vocab-surface-only, i.e. is a missing `Fixes #N` legitimate (ADR 0075 /
+# 0184)? Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# THE EXIT STATUS IS THE ANSWER: 0 = doc/vocab-surface-only (issueless is legitimate), non-zero = no
+# (hard-stop). The predicate is single-sourced in §CLASS (DOC_VOCAB_EXCLUDE_RE /
+# DOC_VOCAB_SURFACE_RE) and fails closed to "no" on an unreadable source or zero input (ADR 0092) —
+# it can only ever REFUSE the allowance, never grant one it could not prove. This script keeps that
+# direction: every guard below exits non-zero, so a could-not-run is a refusal, never a carve-out.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: classify-issueless.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# doc/vocab-surface-only? exit 0 = yes (issueless is legitimate), non-zero = no (hard-stop below).
-# Predicate single-sourced in §CLASS (DOC_VOCAB_EXCLUDE_RE / DOC_VOCAB_SURFACE_RE); fails closed to
-# "no" on an unreadable source or zero input (ADR 0092) — it can only ever REFUSE the allowance.
+PCLI="$(kp_pcli)" || exit 127
+
 gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
   | "$PCLI" class-probe doc-vocab-surface-only

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/current-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/current-head.sh
@@ -1,1 +1,24 @@
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
+#!/usr/bin/env bash
+# Step 5 — the head SHA you actually reviewed, resolved ONCE before composing the verdict, so the SHA
+# the marker carries and every later use are one single-sourced read rather than two independent
+# resolutions that could straddle a head move. Extracted from review-doc/SKILL.md (#4453, epic
+# #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# Prints a bare 40-hex SHA or NOTHING. Shape-asserted, because gh writes its error document to
+# STDOUT on failure: an unshape-checked capture would put that document into the marker's `@ <sha>`
+# field, and `verdict post`'s emissionDefect gate would then refuse the whole verdict (#2683).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: current-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+HEAD_SHA="$(gh api repos/"$REPO"/pulls/"$PR" --jq .head.sha)" || {
+  echo "current-head.sh: head SHA read FAILED (payload discarded) — no SHA to bind a verdict to." >&2; exit 1; }
+case "$HEAD_SHA" in
+  *[!0-9a-f]*|"") echo "current-head.sh: head SHA is not bare hex — discarded (never let gh's error body reach the marker's @ <sha>; #2683)." >&2; exit 1 ;;
+esac
+[ "${#HEAD_SHA}" -eq 40 ] || { echo "current-head.sh: head SHA is not a 40-char ref — discarded." >&2; exit 1; }
+printf '%s\n' "$HEAD_SHA"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/current-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/current-head.sh
@@ -1,0 +1,1 @@
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
@@ -1,5 +1,23 @@
+#!/usr/bin/env bash
+# Print the absolute path of the run-state handle `materialize-head.sh` wrote (PR_REF / HEAD_SHA,
+# and REVIEW_WT if `--worktree` was used), so any later step re-derives it with
+# `. "$(head-env.sh "$PR")"` after the harness resets the shell between Bash calls. Extracted from
+# review-doc/SKILL.md's repeated re-source line (#4453, epic #4435 phase 1). Extraction contract:
+# ../SKILL.md § The extracted scripts.
+#
+# `scratchpad file` REFUSES when the namespace was never opened in this run, so a lost handle fails
+# loud instead of silently reading an empty directory — and this script exits non-zero with EMPTY
+# stdout on that path, so a caller's `.` fails loudly rather than falling back to the launched
+# checkout's working copy (§HEAD, #793).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: head-env.sh <pr>" >&2; exit 2; }
+PR="$1"
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+PCLI="$(kp_pcli)" || exit 127
+
 HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
 [ -s "$HEAD_ENV" ] || { echo "review-doc: §SP — head.env absent/empty; re-run the materialize step in THIS session." >&2; exit 1; }
-. "$HEAD_ENV"                        # $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)
+printf '%s\n' "$HEAD_ENV"   # source it for $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
@@ -1,0 +1,5 @@
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
+[ -s "$HEAD_ENV" ] || { echo "review-doc: §SP — head.env absent/empty; re-run the materialize step in THIS session." >&2; exit 1; }
+. "$HEAD_ENV"                        # $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/issue-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/issue-context.sh
@@ -1,3 +1,14 @@
-ISSUE=<N>
-gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
+#!/usr/bin/env bash
+# Step 1 — the linked issue (its `### Acceptance criteria` lives in the body) plus the progress trail
+# write-code left. Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: issue-context.sh <issue>" >&2; exit 2; }
+ISSUE="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh api repos/"$REPO"/issues/"$ISSUE" --jq '{number, state, assignee: .assignee.login, body}'
 gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/issue-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/issue-context.sh
@@ -1,0 +1,3 @@
+ISSUE=<N>
+gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
+gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/leak-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/leak-scan.sh
@@ -1,5 +1,22 @@
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-   # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
-   # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
-   gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment
+#!/usr/bin/env bash
+# Step 4 hygiene check 4 — the machine-local-path scan over the diff's added lines, through the
+# SHARED matcher. Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# The exit status IS the answer here (0 clean / 2 leak / anything else UNRESOLVED), so this script
+# propagates `leak-guard scan-comment`'s status untouched and adds no stdout of its own. Deliberately
+# no pattern set lives here: it is single-sourced in
+# `packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts`, and a restated token would land in a
+# verdict comment that `leak-guard scan-pr` then reads back as a real leak (#4220).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: leak-scan.sh <pr>" >&2; exit 2; }
+PR="$1"
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="$(kp_pcli)" || exit 127
+
+# added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+# any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
+gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/leak-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/leak-scan.sh
@@ -1,0 +1,5 @@
+   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+   # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+   # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
+   gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/linked-issue-timeline.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/linked-issue-timeline.sh
@@ -1,3 +1,15 @@
+#!/usr/bin/env bash
+# Step 1 — cross-check the linked issue off the PR's timeline when `Fixes #N` is not obvious in the
+# body. Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: linked-issue-timeline.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
 # --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
 # invisible without it on a long-lived PR's timeline (#4193)
 gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/linked-issue-timeline.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/linked-issue-timeline.sh
@@ -1,0 +1,4 @@
+# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
+# invisible without it on a long-lived PR's timeline (#4193)
+gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
+  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh
@@ -1,5 +1,23 @@
+#!/usr/bin/env bash
+# Step 2 — §HEAD materialization: land the PR head in a per-run ref (default) or additionally in a
+# throwaway detached worktree (`--worktree`), and record the handles in this run's §SP namespace.
+# Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# STDOUT IS A MACHINE CHANNEL: the ONLY stdout line is the absolute path of the run-state handle
+# carrying PR_REF / HEAD_SHA (and REVIEW_WT under `--worktree`), so the caller can
+# `. "$(materialize-head.sh "$PR")"`. Diagnostics go to stderr. On ANY failure path stdout stays
+# EMPTY and the exit is non-zero — the caller's `.` then fails loudly rather than sourcing a
+# half-written handle and reviewing the launched checkout's BASE tree (#793, the false-PASS hazard).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: materialize-head.sh <pr> [--worktree]" >&2; exit 2; }
+PR="$1"; MODE="${2:-}"
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+PCLI="$(kp_pcli)" || exit 127
+
 # §SP FIRST — allocate this run's scratch namespace, and land the head handles in a file inside it.
 # $PR_REF / $HEAD_SHA (and $REVIEW_WT below) are needed by LATER Bash calls — Step 4a's ADR sweep
 # reads `git show "$PR_REF:…"` — and a shell variable does not survive the harness's between-call
@@ -7,9 +25,9 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # function of this run's session id and is therefore RE-DERIVABLE in any later call. A `mktemp`
 # path is not: by the next call the handle itself is a lost shell variable with no way back to it
 # (#4041). §SP rules 2+3 apply here, NOT the rule-4 carve-out — that one is for a temp allocated
-# AND consumed inside one call, like `VERDICT_FILE` below. `scratchpad` is the allocator (§SP rule
-# 2 of ../gh-issue-intake-formats.md); it refuses with a reason on stderr rather than falling back
-# to a shared path, and §SP's one-liner is the same namespace for a run with no CLI on PATH.
+# AND consumed inside one call, like the ADR sweep's subject dir. `scratchpad` is the allocator (§SP
+# rule 2 of ../gh-issue-intake-formats.md); it refuses with a reason on stderr rather than falling
+# back to a shared path, and §SP's one-liner is the same namespace for a run with no CLI on PATH.
 "$PCLI" scratchpad open --slug "review-doc-$PR" >/dev/null || exit 1   # ONCE, at the start of the run
 HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
 
@@ -19,18 +37,21 @@ HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" ||
 # WITHOUT touching the working tree, and asserts the fetched ref IS that head. It never runs
 # `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the shared PRIMARY
 # the harness resets this cwd to and detach the human's `main` — #2270/#1103; §RO). It emits the
-# head + ref as JSON:
-"$PCLI" review-head materialize --pr "$PR" \
-  | jq -r '"PR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
+# head + ref as JSON.
+if [ "$MODE" = "--worktree" ]; then
+  "$PCLI" review-head materialize --pr "$PR" --worktree \
+    | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
+else
+  "$PCLI" review-head materialize --pr "$PR" \
+    | jq -r '"PR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
+fi
+# shellcheck disable=SC1090  # the run-unique handle this script just wrote
 . "$HEAD_ENV"
+[ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
+  echo "FATAL: review-head materialize did not yield a head ref — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
+if [ "$MODE" = "--worktree" ] && [ -z "${REVIEW_WT:-}" ]; then
+  echo "FATAL: --worktree was asked for but no worktree came back — aborting (§HEAD)." >&2; exit 1
+fi
 
-# Read the head's files off the ref — read-only, no checkout:
-git show "$PR_REF:<path>"            # the file's content at the PR head
-git grep -n "<pattern>" "$PR_REF"    # search the head tree without checking it out
-
-git update-ref -d "$PR_REF"          # drop the throwaway ref when done
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-"$PCLI" review-head materialize --pr "$PR" --worktree \
-  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
-. "$HEAD_ENV"
+# The handle path — the ONLY stdout line, so the caller can `. "$(materialize-head.sh "$PR")"`.
+printf '%s\n' "$HEAD_ENV"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh
@@ -1,0 +1,36 @@
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# §SP FIRST — allocate this run's scratch namespace, and land the head handles in a file inside it.
+# $PR_REF / $HEAD_SHA (and $REVIEW_WT below) are needed by LATER Bash calls — Step 4a's ADR sweep
+# reads `git show "$PR_REF:…"` — and a shell variable does not survive the harness's between-call
+# reset. So they go in `head.env` under the per-run namespace, whose path is a deterministic
+# function of this run's session id and is therefore RE-DERIVABLE in any later call. A `mktemp`
+# path is not: by the next call the handle itself is a lost shell variable with no way back to it
+# (#4041). §SP rules 2+3 apply here, NOT the rule-4 carve-out — that one is for a temp allocated
+# AND consumed inside one call, like `VERDICT_FILE` below. `scratchpad` is the allocator (§SP rule
+# 2 of ../gh-issue-intake-formats.md); it refuses with a reason on stderr rather than falling back
+# to a shared path, and §SP's one-liner is the same namespace for a run with no CLI on PATH.
+"$PCLI" scratchpad open --slug "review-doc-$PR" >/dev/null || exit 1   # ONCE, at the start of the run
+HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
+
+# Land the head in a per-run ref via the shared `pipeline-cli review-head materialize` verb
+# (#3690 / #793 / #1807) — cite it, don't re-derive it. Ref-only mode (no `--worktree`): it
+# resolves the live head SHA (REST), fetches `pull/<pr>/head` into a nonce-uniqued per-run ref
+# WITHOUT touching the working tree, and asserts the fetched ref IS that head. It never runs
+# `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the shared PRIMARY
+# the harness resets this cwd to and detach the human's `main` — #2270/#1103; §RO). It emits the
+# head + ref as JSON:
+"$PCLI" review-head materialize --pr "$PR" \
+  | jq -r '"PR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
+. "$HEAD_ENV"
+
+# Read the head's files off the ref — read-only, no checkout:
+git show "$PR_REF:<path>"            # the file's content at the PR head
+git grep -n "<pattern>" "$PR_REF"    # search the head tree without checking it out
+
+git update-ref -d "$PR_REF"          # drop the throwaway ref when done
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+"$PCLI" review-head materialize --pr "$PR" --worktree \
+  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$HEAD_ENV"
+. "$HEAD_ENV"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-context.sh
@@ -1,2 +1,14 @@
-gh api repos/$REPO/pulls/$PR \
+#!/usr/bin/env bash
+# Step 1 — the PR's shape (state, draft, merged, head/base refs, body). Extracted from
+# review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pr-context.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh api repos/"$REPO"/pulls/"$PR" \
   --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-context.sh
@@ -1,0 +1,2 @@
+gh api repos/$REPO/pulls/$PR \
+  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-diff.sh
@@ -1,2 +1,13 @@
-gh pr diff $PR \
-  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
+#!/usr/bin/env bash
+# Step 2 — the change under review. Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1).
+# Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pr-diff.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh pr diff "$PR" \
+  || gh api repos/"$REPO"/pulls/"$PR" -H "Accept: application/vnd.github.v3.diff"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/pr-diff.sh
@@ -1,0 +1,2 @@
+gh pr diff $PR \
+  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/resolve-repo.sh
@@ -1,0 +1,1 @@
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/resolve-repo.sh
@@ -1,1 +1,12 @@
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+#!/usr/bin/env bash
+# Print the target repo as `owner/name`. Extracted from review-doc/SKILL.md (#4453, epic #4435
+# phase 1). Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# Top-level assignment, never `local` — `local REPO="$(kp_repo)"` takes `local`'s own status and
+# masks the substitution's, so an unresolvable repo would sail through as the empty string and
+# address `gh api repos//…`.
+REPO="$(kp_repo)" || exit 1
+printf '%s\n' "$REPO"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
@@ -1,0 +1,3 @@
+# Register teardown as a trap so a mid-block error still tears the throwaway tree down:
+trap 'rm -rf "$REVIEW_WT"; git worktree prune' EXIT
+rm -rf "$REVIEW_WT" && git worktree prune   # tear it down on EVERY exit path — PASS or FAIL

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
@@ -1,3 +1,37 @@
-# Register teardown as a trap so a mid-block error still tears the throwaway tree down:
-trap 'rm -rf "$REVIEW_WT"; git worktree prune' EXIT
-rm -rf "$REVIEW_WT" && git worktree prune   # tear it down on EVERY exit path — PASS or FAIL
+#!/usr/bin/env bash
+# Step 2 — tear the throwaway head worktree + per-run ref down. Extracted from review-doc/SKILL.md
+# (#4453, epic #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# It is its OWN script because the prose requires it on EVERY exit path (PASS, FAIL, mid-run error),
+# not just after a clean read — a leaked `review-doc-head-*` tree accumulates on the shared primary
+# otherwise (#2785). Safe by construction: what it removes is a detached, already-pushed throwaway
+# this gate materialized itself, holding no branch and no unpushed work. Idempotent — a namespace
+# that was never opened is a clean no-op, so it may be run after an aborted materialization.
+#
+# It installs no `EXIT` trap of its own: under bash 3.2 a cleanup trap's last command becomes the
+# script's exit status, laundering a `set -u` abort into exit 0 (#4476, class #4479). The trap
+# belongs to the CALLER's shell — `trap '…/scripts/teardown-head.sh "$PR"' EXIT`.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: teardown-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+
+# shellcheck disable=SC1007
+HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
+  echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
+  exit 0
+}
+# shellcheck disable=SC1090
+. "$HANDLE"
+[ -n "${PR_REF:-}" ] || {
+  echo "teardown-head.sh: handle carries no PR_REF — refusing to guess what to remove (no-op)." >&2
+  exit 0
+}
+
+# The worktree exists only under Step 2's rare `--worktree` mode; the ref always does.
+if [ -n "${REVIEW_WT:-}" ]; then
+  rm -rf "$REVIEW_WT" && git worktree prune
+fi
+git update-ref -d "$PR_REF"          # drop the throwaway ref when done

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh
@@ -1,0 +1,8 @@
+# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
+# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here
+# (#3653; ADR 0062/0064; epic #994)
+VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+
+VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
+# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-doc: PASS @ <HEAD_SHA> — merge-ready)
+$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"   # upsert (PATCH own prior marker, else POST)

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-post.sh
@@ -1,8 +1,34 @@
+#!/usr/bin/env bash
+# Step 5 — the guarded `review-doc` verdict upsert, on the §VERDICT (PR, gate-namespace, head, run)
+# key. Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# ONE script for all THREE Step-5 branches — non-blocking PASS, §CP advisory, FAIL. The fences
+# differed only in the body they told the reviewer to compose; the mechanism was identical
+# (`mktemp` a file, write the body into it, `verdict post --gate doc --body-file`). Collapsing them
+# removes two copies of the same upsert rather than preserving a distinction the shell never had.
+#
+# THE BODY ARRIVES ON STDIN — the declared seam. The fences said "write your composed verdict into
+# $VERDICT_FILE", so the body is authored by the reviewing agent and a script can only receive it.
+# Stdin also retires the scratch file entirely, which removes the #2683 / #3718 class by
+# construction: with no path on disk there is nothing for a concurrent review of the same PR to
+# clobber, and no mktemp path that could bleed into the marker's `@ <sha>` field.
+#
+# The upsert itself stays `pipeline-cli verdict post` — the MANDATED emit choke point. A bare
+# `gh api …/comments` hand-post of a marker is FORBIDDEN: it skips `emissionDefect` and the
+# §READBACK re-scan (§READBACK of ../../shared/gate-verdict-contract.md; #2789 / #2816 / #2818).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: printf '%s' \"\$BODY\" | verdict-post.sh <pr>" >&2; exit 2; }
+PR="$1"
 # resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
 # else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here
 # (#3653; ADR 0062/0064; epic #994)
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+PCLI="$(kp_pcli)" || exit 127
 
-VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
-# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-doc: PASS @ <HEAD_SHA> — merge-ready)
-$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"   # upsert (PATCH own prior marker, else POST)
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "verdict-post.sh: EMPTY body on stdin — refusing to post an empty verdict; the PR would read as UNGATED." >&2; exit 1; }
+
+printf '%s' "$BODY" | "$PCLI" verdict post --pr "$PR" --gate doc   # upsert (PATCH own prior marker, else POST)

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-readback.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-readback.sh
@@ -1,0 +1,4 @@
+# UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
+# + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
+# the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.
+verdict_post_verify "$PR" review-doc "$HEAD_SHA" || exit 1

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-readback.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/verdict-readback.sh
@@ -1,3 +1,28 @@
+#!/usr/bin/env bash
+# Step 5b — the UNCONDITIONAL post-verify: prove a clean, current-head `review-doc:` verdict is
+# actually on the PR. Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract: ../SKILL.md § The extracted scripts.
+#
+# `verdict_post_verify` itself is SOURCED from its canonical home,
+# ../../shared/scripts/verdict-readback.sh (#4489 extracted it out of
+# ../../gh-issue-intake-formats.md) — there is no skill-local copy to drift. It re-derives the landed
+# verdict from live PR state, never from a carried comment id: `$MINE` was set only on one posting
+# branch, which is exactly how the #2264 recurrence slipped a broken/leaking marker through.
+#
+# PROPAGATE THE NON-ZERO. This wrapper's single FATAL exit is what makes verdict-posting an ENFORCED
+# gate rather than a hopeful one — never report the gate done over an ungated PR.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: verdict-readback.sh <pr> <head-sha>" >&2; exit 2; }
+PR="$1"; HEAD_SHA="$2"
+# $REPO is what the sourced guard addresses `gh api` at, exactly as the fence did.
+REPO="$(kp_repo)" || exit 1
+export REPO
+# shellcheck source=../../shared/scripts/verdict-readback.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/verdict-readback.sh"
+
 # UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
 # + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
 # the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -769,7 +769,7 @@ head leaves the prior head's verdict standing and a concurrent run never overwri
 record (ADR 0058 rule 2, refined by ADR 0213). Never hand-roll the `PATCH`:
 
 ```bash
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/current-head.sh "$PR")"   # the head you reviewed
 # $BODY is your composed FAIL verdict; first line: review-skill: FAIL @ <HEAD_SHA> — changes-requested.
 # Upsert through the guarded tool on the (PR, gate-namespace, head, run) key — namespace-anchored,
 # so a fresh FAIL replaces this head+run's own prior review-skill record (an advisory included) and

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -67,50 +67,34 @@ reviewing (below), read all skill text from the head, and re-check the live head
 (§HEAD #4); the verdict (§VERDICT) binds to the SHA whose files you actually read and asserts it.
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main — your trusted config
-git fetch origin "$BASE_REF"
+# Prints ONE line — the absolute path of this run's handle, carrying REVIEW_WT / PR_REF / HEAD_SHA /
+# BASE_REF. Every FATAL line goes to stderr; on any failure stdout is EMPTY, so this `.` fails loudly
+# rather than sourcing a half-written handle and reviewing the base tree (#793).
+. "$(bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh "$PR")"
+```
 
-# §HEAD steps 1–3 (resolve the live head SHA via REST, fetch pull/$PR/head into a nonce-uniqued
-# per-run ref WITHOUT touching the session tree, assert the fetched ref IS that head, add a
-# throwaway DETACHED head worktree) are the shared `pipeline-cli review-head materialize` verb
-# (#3690 / #793 / #1807) — cite it, don't re-derive it. `pull/<pr>/head` resolves same-repo AND
-# cross-fork; the verb never runs `gh pr checkout` / `git checkout` / `git switch` (which would land
-# the head in the shared PRIMARY the harness resets this cwd to and detach the human's `main` —
-# #2270/#1103; §RO), and it internally aborts on a fetched-ref ≠ resolved-head mismatch (§HEAD #2)
-# so you never review a different SHA than the verdict claims. Persist its emitted head/ref/worktree
-# to a per-run mktemp handle so they survive the harness cwd/shell reset between Bash calls (a shell
-# var is lost across calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive
-# from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and
-# reads the wrong head's skill text — the #1807 collision). This is the §SP per-run scratchpad
-# namespace (gh-issue-intake-formats.md): a PR number is not unique, and a clobbered file reads
-# back cleanly with the other run's content (#3718). WT_FILE is a CROSS-CALL carrier — a later
-# step re-sources it — so §SP rules 2+3 apply, NOT the rule-4 single-file `mktemp` carve-out
-# (that one is for allocate-and-consume inside one call, like VERDICT_FILE below): the path is
-# derived deterministically from the session id, so each later step recomputes this same line
-# rather than inheriting a lost `$WT_FILE` variable.
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR"
-mkdir -p "$RUN_SCRATCH" || { echo "review-skill: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
-WT_FILE="$RUN_SCRATCH/wt.env"
-"$PCLI" review-head materialize --pr "$PR" --worktree \
-  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
-. "$WT_FILE"
-[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
-  echo "FATAL: review-head materialize did not yield a head worktree — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
+The script fetches the trusted base, drives §HEAD steps 1–3 through the shared
+`pipeline-cli review-head materialize` verb, and then enforces + asserts the instruction denylist.
+Two properties of it are load-bearing and stated here rather than left to the file:
 
-# Enforce the instruction denylist EXPLICITLY (a full checkout lands the head's root CLAUDE.md
-# + .claude/.decisions/.patterns): remove them, then ASSERT absent — the load-bearing isolation
-# check. The head's skills/** are present as text to READ; the instruction surfaces are not.
-git -C "$REVIEW_WT" rm -r -q --cached --ignore-unmatch \
-  CLAUDE.md .claude .decisions .patterns
-rm -rf "$REVIEW_WT/CLAUDE.md" "$REVIEW_WT/.claude" "$REVIEW_WT/.decisions" "$REVIEW_WT/.patterns"
-for p in CLAUDE.md .claude .decisions .patterns; do
-  if [ -e "$REVIEW_WT/$p" ]; then
-    echo "FATAL: denied instruction surface '$p' present in review worktree — isolation broken; aborting" >&2
-    exit 1
-  fi
-done
+- **§HEAD steps 1–3 are the shared verb, not re-derived** (#3690 / #793 / #1807). `pull/<pr>/head`
+  resolves same-repo AND cross-fork; the verb never runs `gh pr checkout` / `git checkout` /
+  `git switch` (which would land the head in the shared PRIMARY the harness resets this cwd to and
+  detach the human's `main` — #2270/#1103; §RO), and it internally aborts on a fetched-ref ≠
+  resolved-head mismatch (§HEAD #2) so you never review a different SHA than the verdict claims.
+- **The handle is the §SP per-run scratchpad namespace, not a `mktemp`** (#3718). A shell variable is
+  lost across the harness's between-call reset, so each later step re-derives the handle with
+  [`scripts/head-env.sh`](scripts/head-env.sh) — **never** from a shared leaf name, which under a
+  parallel fan-out matches a SIBLING reviewer's tree and reads the wrong head's skill text (#1807).
+  §SP rules 2+3 apply because the handle is a CROSS-CALL carrier, not the rule-4 allocate-and-consume
+  carve-out; the path is a deterministic function of this run's session id, which is what makes it
+  re-derivable at all.
+
+The denylist half — remove the head's `CLAUDE.md` / `.claude` / `.decisions` / `.patterns`, then
+**assert them absent** — is the load-bearing isolation check, and it aborts rather than proceed:
+
+```text
+FATAL: denied instruction surface '<p>' present in review worktree — isolation broken; aborting
 ```
 
 **A subtlety for this gate.** `skills/` is a real directory the head ships, and `.claude/skills`
@@ -156,8 +140,43 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/resolve-repo.sh
 ```
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/) and every fenced `bash` block below is an
+**invocation** of one, run by literal path with its results on stdout — never sourced (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)).
+The prose keeps the *why*; the scripts hold the *how* (epic #4435 phase 1 — the shell moved as-is,
+and turning its `gh`/`jq` glue into tested `pipeline-cli` verbs is #1929, ADR 0228: a script may
+RELAY a verb's answer, never DERIVE the decision). Four properties are load-bearing when you read or
+edit them:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control flow
+  through the guards written into it — a state-word assertion instead of an exit-status test (§CP), a
+  `grep` whose empty result is an answer. `errexit` would abort those paths before they print their
+  fail-closed line, converting fail-closed into fail-**open**
+  ([`.patterns/skill-script-shell-shape.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-shell-shape.md)).
+- **No script installs an `EXIT` trap.** Under bash 3.2 a cleanup trap's last command becomes the
+  script's exit status, which launders a `set -u` abort into exit 0 (#4476, class #4479).
+- **A script whose stdout answers a safety question makes every failure path speak (the
+  error-channel rule).** Moving glue behind a script boundary invents a channel the inline block
+  never had: a non-zero exit with **0 bytes on stdout**. Where a caller reads the *absence* of a
+  fail-closed line as a *positive* answer — the `BLOCKING (…)` lines of
+  [`scripts/classify-control-plane.sh`](scripts/classify-control-plane.sh) are exactly that shape —
+  a silent guard exit is indistinguishable from "proven ordinary". So each such script prints its
+  **own** fail-closed line on stdout before every early `exit`, **and** exits non-zero, and the prose
+  reads the **status before the stdout**. An absent or empty result is UNKNOWN, and UNKNOWN is never
+  "no" (§ZS / ADR
+  [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md);
+  [`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md)).
+- **The shared-contract helpers are SOURCED from their canonical home — there is no skill-local
+  copy.** §CPREAD's `cp_changed_files` / `cp_head_sha` and the `verdict_post_verify` read-back live
+  in [`../shared/scripts/`](../shared/scripts/) (#4489 extracted them out of
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)), and this skill's scripts source
+  them directly. With no second copy there is nothing to keep in step and no byte-identity claim to
+  make about one.
 
 ## Read-only on git working state
 
@@ -202,61 +221,19 @@ the path list here (that fourth copy is exactly the #375 drift class §CP closes
 from the copy embedded in this skill body** (this advisory flag is informational, but the
 embedded copy travels in the *injected snapshot*, which can lag `origin/main` even when the
 on-disk file is current, so a pre-amendment snapshot once mis-flagged a now-control-plane PR;
-#981). The bash below reads §CP freshly from `origin/main` and **fails closed** (treats every
+#981). The script below reads §CP freshly from `origin/main` and **fails closed** (treats every
 path as control-plane → advisory not-auto-mergeable) if that read can't be made.
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 PR=<pr number>
-# The shared §CP classification entry point — one verb all the gates cite (#4161, formats §CP). It
-# re-resolves CONTROL_PLANE_RE from origin/main itself (§CP travels in the INJECTED skill snapshot,
-# which can lag origin/main even when the on-disk file is current — a pre-amendment snapshot once
-# mis-flagged a now-control-plane PR as auto-mergeable, #981) AND covers the second §CP source: a
-# guard-touching `.decisions/**` ADR is §CP BY CONTENT (ADR 0164) with zero path matches, so the old
-# path-only grep here flagged it non-blocking — the fail-open this verb removes.
-# Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
-# Assert on the STATE WORD, never on the exit status — the exit code discriminates the four states
-# only once the verb has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing
-# binary (127). The `else` below is the catch-all that makes that safe (formats §CP; #4161).
-# The verb's INPUT is a fallible read, so it comes from §CPREAD's `cp_changed_files` (copy it and
-# `cp_head_sha` verbatim from ../gh-issue-intake-formats.md) — never a bare `gh api … |` pipe: with
-# pipefail off, a failed read pipes gh's stdout ERROR BODY into the verb, which matches no §CP clause
-# and answers `not-control-plane` (#4216).
-if ! cp_changed_files "$REPO" "$PR"; then
-  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ held as §CP by the catch-all below
-else
-  CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
-fi
-# `content-undetermined` is an OBLIGATION, not an answer: probe each touched ADR at head with the
-# SAME ADR-0164 verb ship-it Step 0 and review-code/review-doc run. Any BLOCKING line ⇒ §CP.
-if [ "$CP_STATE" = "content-undetermined" ]; then
-  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
-  [ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable — ADR content unprobeable ⇒ §CP, fail-closed)"
-  [ -z "$HEAD_SHA" ] || printf '%s\n' "$CP_FILES" \
-    | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-        # Capture and CHECK, never a straight pipe — gh writes its error document to STDOUT, so a
-        # pipe hands the probe an ERROR BODY as the ADR body (§CPREAD #2).
-        adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
-        if [ -z "$adr_body" ]; then echo "BLOCKING ($adr — body unreadable at head ⇒ §CP, fail-closed)"
-        else
-          # Same rule as the cp-classify call above: assert on the probe's STATE WORD, never on its
-          # exit status — an invocation that never ran would otherwise read as proven ordinary (#4219).
-          GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
-          case "$GC_STATE" in
-            not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
-            guard-touching) echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)" ;;
-            *) echo "BLOCKING ($adr — probe UNDETERMINED (state '$GC_STATE') ⇒ §CP, fail-closed)" ;;
-          esac
-        fi
-      done
-elif [ "$CP_STATE" != "not-control-plane" ]; then
-  # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed
-  # invocation yields included. Only a positive `not-control-plane` may skip the hold.
-  echo "BLOCKING (§CP state '$CP_STATE')"
-fi
-# blocking → advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
+CP_HOLD="$(bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh "$PR")"; RC=$?
 ```
+
+Read its **exit status before its stdout**: a non-zero `$RC` holds the PR as §CP regardless of what
+stdout says, because the classification could not be made. On `$RC = 0`, each `BLOCKING (…)` line in
+`$CP_HOLD` is a §CP hold and its reason; **no** `BLOCKING (…)` line is the one positive
+`not-control-plane` answer. Blocking → advisory only; a control-plane approval @head → `ship-it`
+enqueues (ADR 0135; §CP set 0053/0065/0073).
 
 - **`control-plane`**, **`unknown`** (the classification could not be made — fail closed), or a
   `content-undetermined` the ADR probe resolved to BLOCKING (a guard-touching ADR, ADR 0164) — as
@@ -315,18 +292,14 @@ namespace is discovered.
 ## Step 1 — Resolve the PR and its linked issue
 
 ```bash
-gh api repos/$REPO/pulls/$PR \
-  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-context.sh "$PR"
 ```
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code`
 writes). Cross-check via the timeline if it's not obvious:
 
 ```bash
-# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
-# invisible without it on a long-lived PR's timeline (#4193)
-gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
-  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/linked-issue-timeline.sh "$PR"
 ```
 
 The `issues/$PR/timeline` endpoint accepts the PR number, and the
@@ -340,8 +313,7 @@ Now pull the issue and its acceptance criteria:
 
 ```bash
 ISSUE=<N>
-gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
-gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/issue-context.sh "$ISSUE"
 ```
 
 Extract the `### Acceptance criteria` checklist from the issue body. That list — every box —
@@ -357,8 +329,7 @@ here** — a skill is an instruction, not running code; the artifact *is* the pr
 so you read it. Pull the change:
 
 ```bash
-gh pr diff $PR \
-  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-diff.sh "$PR"
 ```
 
 For checks that need the file in context (a trigger phrase, a cross-skill reference, the full
@@ -372,9 +343,7 @@ variable by then, so recompute its path from the same §SP recipe first — that
 the namespace is session-derived rather than `mktemp`-allocated:
 
 ```bash
-WT_FILE="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR/wt.env"
-[ -s "$WT_FILE" ] || { echo "review-skill: §SP — $WT_FILE missing; re-run the head-materialization step in THIS session." >&2; exit 1; }
-. "$WT_FILE"
+. "$(bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh "$PR")"
 ```
 
 ### Fetch the base fresh before any "is-it-shipped on main" check
@@ -386,8 +355,8 @@ contract section it cites is present." Verify those against a **freshly fetched*
 or a local `main`, which may be stale:
 
 ```bash
-git cat-file -e "origin/$BASE_REF:.decisions/0073-review-skill-gate.md"   # does the ADR exist on fresh main?
-git show "origin/$BASE_REF:skills/gh-issue-intake-formats.md"             # read shipped contract content
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/base-groundtruth.sh exists "$BASE_REF" .decisions/0073-review-skill-gate.md
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/base-groundtruth.sh show   "$BASE_REF" skills/gh-issue-intake-formats.md
 ```
 
 You're reading, not building — no `pnpm install`, no typecheck, no test suite. The diff, the
@@ -398,14 +367,16 @@ Tear the throwaway tree + ref down on **every** exit path — PASS, FAIL, or a m
 not only when you finish reading clean:
 
 ```bash
-rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh "$PR"
 ```
 
 Run this even when the review is exiting `FAIL` or aborting mid-run, so no `review-skill-head-*`
 tree leaks onto the shared primary (#2785); the `rm -rf` of the review's own detached, already-
-pushed throwaway is safe (no branch/unpushed work). To catch a mid-block error, register it as a
-trap right after `git worktree add`:
-`trap 'rm -rf "$REVIEW_WT"; git worktree prune; git update-ref -d "$PR_REF"' EXIT`. The standing
+pushed throwaway is safe (no branch/unpushed work). To catch a mid-block error, register the same
+script as a trap right after materialization — `trap '…/scripts/teardown-head.sh "$PR"' EXIT` — and
+note the trap belongs to **your** shell, not to the script (an extracted script installs no `EXIT`
+trap of its own: under bash 3.2 a cleanup trap's last command becomes the exit status, which
+launders a `set -u` abort into exit 0). The standing
 net for a session-end abort between Bash calls (no in-shell trap reaches it) is `pipeline-cli
 worktree-sweep --execute` (#2785): it reclaims a leaked `review-skill-head-*` tree only when
 clean + idle + unlocked, **without** `--force` (dirty / active / locked is KEPT — the #2240
@@ -623,7 +594,7 @@ verdict not bound to the PR's current head (ADR
 [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258).
 
 ```bash
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/current-head.sh "$PR")"   # the head you reviewed
 ```
 
 `review-skill` lands its verdict **only as the SHA-bound comment, never a native review** (ADR
@@ -647,11 +618,12 @@ the body **MUST** first pass `pipeline-cli leak-guard scan-comment` (the #2823 p
 the post. This is the single-source rule in
 [the gate-verdict contract §READBACK](../shared/gate-verdict-contract.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
 
-```bash
-# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
-# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653).
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
-```
+All three Step-5 branches — non-blocking PASS, §CP advisory, FAIL — post through the **one**
+[`scripts/verdict-post.sh`](scripts/verdict-post.sh), which takes the composed body on **stdin**.
+The three fences differed only in the body they told you to compose; the mechanism was identical, so
+there is one script and not three. Stdin also retires the scratch file, which removes the #2683 /
+#3718 class by construction: with no path on disk there is nothing for a concurrent review of the
+same PR to clobber, and no `mktemp` path that can bleed into the marker's `@ <sha>` field.
 
 ### Pass path — non-blocking PR (the binding signal)
 
@@ -660,13 +632,12 @@ Every criterion and every rigor check passed, and Step 0 classified the PR **non
 merge on it.
 
 ```bash
-VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
-# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-skill: PASS @ <HEAD_SHA> — merge-ready)
-# Upsert through the guarded tool on the (PR, gate-namespace, head, run) key: it replaces this
-# head+run's own review-skill record (namespace-anchored, so a blocking↔non-blocking flip replaces
-# a prior advisory at the same key too) and appends against any other key, and it
-# fail-closes on a malformed/cross-namespace body — the mktemp-path `@ <sha>` leak (#2683) never lands.
-$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
+# $BODY is your composed PASS verdict; first line: review-skill: PASS @ <HEAD_SHA> — merge-ready.
+# The script upserts through the guarded tool on the (PR, gate-namespace, head, run) key: it replaces
+# this head+run's own review-skill record (namespace-anchored, so a blocking↔non-blocking flip
+# replaces a prior advisory at the same key too) and appends against any other key, and it
+# fail-closes on a malformed/cross-namespace body.
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-post.sh "$PR"
 ```
 
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
@@ -775,11 +746,10 @@ to blocking replaces this run's own binding verdict at this head with the adviso
 canonical `Reviewed-head: @ <HEAD_SHA>` line (ADR 0151), which `ship-it`'s §CP enqueue reads.
 
 ```bash
-VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
-# write your composed advisory verdict into "$VERDICT_FILE" (first line: review-skill: advisory — blocking-set PR (§CP — approval-gated))
-# The guarded tool also validates the §CP advisory's `Reviewed-head: @ <sha>` anchor line is a clean
-# full 40-hex head SHA — the exact field the #2680 mktemp path leaked into (#2683).
-$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
+# $BODY is your composed advisory verdict; first line: review-skill: advisory — blocking-set PR
+# (§CP — approval-gated). The guarded tool also validates the §CP advisory's `Reviewed-head: @ <sha>`
+# anchor line is a clean full 40-hex head SHA — the exact field the #2680 mktemp path leaked into (#2683).
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-post.sh "$PR"
 ```
 
 Post it **as a comment, never a native review** (ADR 0058 rule 4). Do **not** emit the
@@ -800,12 +770,11 @@ record (ADR 0058 rule 2, refined by ADR 0213). Never hand-roll the `PATCH`:
 
 ```bash
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
-VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
-# write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-skill: FAIL @ <HEAD_SHA> — changes-requested)
+# $BODY is your composed FAIL verdict; first line: review-skill: FAIL @ <HEAD_SHA> — changes-requested.
 # Upsert through the guarded tool on the (PR, gate-namespace, head, run) key — namespace-anchored,
 # so a fresh FAIL replaces this head+run's own prior review-skill record (an advisory included) and
 # appends against any other key — fail-closed on a malformed marker (#2683).
-$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-post.sh "$PR"
 ```
 
 Verdict body shape:
@@ -865,7 +834,7 @@ landed, on **every** post path —
 # UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
 # + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
 # the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.
-verdict_post_verify "$PR" review-skill "$HEAD_SHA" || exit 1
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-readback.sh "$PR" "$HEAD_SHA" || exit 1
 ```
 
 The wrapper's single **fatal** exit — on nothing-landed *and* on a malformed/leaking marker resolved

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/base-groundtruth.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/base-groundtruth.sh
@@ -1,0 +1,2 @@
+git cat-file -e "origin/$BASE_REF:.decisions/0073-review-skill-gate.md"   # does the ADR exist on fresh main?
+git show "origin/$BASE_REF:skills/gh-issue-intake-formats.md"             # read shipped contract content

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/base-groundtruth.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/base-groundtruth.sh
@@ -1,2 +1,23 @@
-git cat-file -e "origin/$BASE_REF:.decisions/0073-review-skill-gate.md"   # does the ADR exist on fresh main?
-git show "origin/$BASE_REF:skills/gh-issue-intake-formats.md"             # read shipped contract content
+#!/usr/bin/env bash
+# Step 2 — read a path off the FRESHLY FETCHED merge target, for an "is it shipped on main?"
+# ground-truth check. Extracted from review-skill/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# It reads `origin/$BASE_REF` — never the working tree and never a local `main`, either of which may
+# be stale in a long-lived checkout and would ground the check against an old merge target.
+# `materialize-head.sh` already ran the fetch and recorded BASE_REF in the run handle; pass it in.
+#
+# Two modes, because the fence carried both: `exists` is the `git cat-file -e` presence probe (exit
+# status IS the answer, no stdout), `show` prints the shipped content.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 3 ] || { echo "usage: base-groundtruth.sh <exists|show> <base-ref> <path>" >&2; exit 2; }
+MODE="$1"; BASE_REF="$2"; TARGET="$3"
+
+case "$MODE" in
+  exists) git cat-file -e "origin/$BASE_REF:$TARGET" ;;   # does the path exist on fresh main?
+  show)   git show "origin/$BASE_REF:$TARGET" ;;          # read shipped content
+  *) echo "base-groundtruth.sh: mode must be 'exists' or 'show'." >&2; exit 2 ;;
+esac

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh
@@ -1,6 +1,35 @@
+#!/usr/bin/env bash
+# Step 0 — blocking vs non-blocking, via the shared §CP entry point plus the ADR-0164 content probe.
+# Extracted from review-skill/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts. The *why* for each clause stays in
+# that step's prose.
+#
+# STDOUT IS THE ANSWER, AND ITS EMPTY STATE IS THE PERMISSIVE ONE: a `BLOCKING (…)` line means hold
+# the PR as §CP, and NO line means proven-ordinary. So every could-not-run path prints its own
+# `BLOCKING (…)` line BEFORE exiting, and exits non-zero — a classifier that never ran must never
+# reach the caller as silence, which the caller reads as "auto-mergeable" (§ZS / ADR 0092,
+# `.patterns/skill-script-io-contract.md`; #4216, #4161, #4219). Read the STATUS before the STDOUT:
+# a non-zero exit holds the PR as §CP whatever stdout says.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# §CPREAD's `cp_changed_files` + `cp_head_sha`, sourced from their canonical home — no skill-local
+# copy to drift (#4489 extracted them out of ../../gh-issue-intake-formats.md, which is why the moved
+# comment below no longer says "copy them verbatim"). They write on stderr only, so no call site
+# redirects (`.patterns/skill-script-io-contract.md`, #4510).
+# shellcheck source=../../shared/scripts/cp-read.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
+
+[ "$#" -ge 1 ] || {
+  echo "BLOCKING (classify-control-plane.sh ran with no <pr> argument — nothing was classified ⇒ §CP, fail-closed)"
+  echo "usage: classify-control-plane.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || {
+  echo "BLOCKING (target repo unresolvable — §CP unclassifiable ⇒ §CP, fail-closed)"; exit 1; }
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-PR=<pr number>
+PCLI="$(kp_pcli)" || {
+  echo "BLOCKING (pipeline-cli UNRESOLVED — cp-classify never ran ⇒ §CP, fail-closed)"; exit 127; }
+
 # The shared §CP classification entry point — one verb all the gates cite (#4161, formats §CP). It
 # re-resolves CONTROL_PLANE_RE from origin/main itself (§CP travels in the INJECTED skill snapshot,
 # which can lag origin/main even when the on-disk file is current — a pre-amendment snapshot once
@@ -11,8 +40,8 @@ PR=<pr number>
 # Assert on the STATE WORD, never on the exit status — the exit code discriminates the four states
 # only once the verb has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing
 # binary (127). The `else` below is the catch-all that makes that safe (formats §CP; #4161).
-# The verb's INPUT is a fallible read, so it comes from §CPREAD's `cp_changed_files` (copy it and
-# `cp_head_sha` verbatim from ../gh-issue-intake-formats.md) — never a bare `gh api … |` pipe: with
+# The verb's INPUT is a fallible read, so it comes from §CPREAD's `cp_changed_files` (sourced above
+# from ../../shared/scripts/cp-read.sh) — never a bare `gh api … |` pipe: with
 # pipefail off, a failed read pipes gh's stdout ERROR BODY into the verb, which matches no §CP clause
 # and answers `not-control-plane` (#4216).
 if ! cp_changed_files "$REPO" "$PR"; then

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh
@@ -28,7 +28,7 @@ REPO="$(kp_repo)" || {
   echo "BLOCKING (target repo unresolvable — §CP unclassifiable ⇒ §CP, fail-closed)"; exit 1; }
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="$(kp_pcli)" || {
-  echo "BLOCKING (pipeline-cli UNRESOLVED — cp-classify never ran ⇒ §CP, fail-closed)"; exit 127; }
+  echo "BLOCKING (the CLI shim is UNRESOLVED — cp-classify never ran ⇒ §CP, fail-closed)"; exit 127; }
 
 # The shared §CP classification entry point — one verb all the gates cite (#4161, formats §CP). It
 # re-resolves CONTROL_PLANE_RE from origin/main itself (§CP travels in the INJECTED skill snapshot,

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh
@@ -1,0 +1,50 @@
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+PR=<pr number>
+# The shared §CP classification entry point — one verb all the gates cite (#4161, formats §CP). It
+# re-resolves CONTROL_PLANE_RE from origin/main itself (§CP travels in the INJECTED skill snapshot,
+# which can lag origin/main even when the on-disk file is current — a pre-amendment snapshot once
+# mis-flagged a now-control-plane PR as auto-mergeable, #981) AND covers the second §CP source: a
+# guard-touching `.decisions/**` ADR is §CP BY CONTENT (ADR 0164) with zero path matches, so the old
+# path-only grep here flagged it non-blocking — the fail-open this verb removes.
+# Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
+# Assert on the STATE WORD, never on the exit status — the exit code discriminates the four states
+# only once the verb has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing
+# binary (127). The `else` below is the catch-all that makes that safe (formats §CP; #4161).
+# The verb's INPUT is a fallible read, so it comes from §CPREAD's `cp_changed_files` (copy it and
+# `cp_head_sha` verbatim from ../gh-issue-intake-formats.md) — never a bare `gh api … |` pipe: with
+# pipefail off, a failed read pipes gh's stdout ERROR BODY into the verb, which matches no §CP clause
+# and answers `not-control-plane` (#4216).
+if ! cp_changed_files "$REPO" "$PR"; then
+  CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ held as §CP by the catch-all below
+else
+  CP_STATE="$(printf '%s\n' "$CP_FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
+fi
+# `content-undetermined` is an OBLIGATION, not an answer: probe each touched ADR at head with the
+# SAME ADR-0164 verb ship-it Step 0 and review-code/review-doc run. Any BLOCKING line ⇒ §CP.
+if [ "$CP_STATE" = "content-undetermined" ]; then
+  cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
+  [ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable — ADR content unprobeable ⇒ §CP, fail-closed)"
+  [ -z "$HEAD_SHA" ] || printf '%s\n' "$CP_FILES" \
+    | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+        # Capture and CHECK, never a straight pipe — gh writes its error document to STDOUT, so a
+        # pipe hands the probe an ERROR BODY as the ADR body (§CPREAD #2).
+        adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+        if [ -z "$adr_body" ]; then echo "BLOCKING ($adr — body unreadable at head ⇒ §CP, fail-closed)"
+        else
+          # Same rule as the cp-classify call above: assert on the probe's STATE WORD, never on its
+          # exit status — an invocation that never ran would otherwise read as proven ordinary (#4219).
+          GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+          case "$GC_STATE" in
+            not-guard-touching) : ;;   # proven ordinary — the ONLY value that may skip the §CP hold
+            guard-touching) echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)" ;;
+            *) echo "BLOCKING ($adr — probe UNDETERMINED (state '$GC_STATE') ⇒ §CP, fail-closed)" ;;
+          esac
+        fi
+      done
+elif [ "$CP_STATE" != "not-control-plane" ]; then
+  # The catch-all: control-plane, unknown, AND anything unenumerated — the empty string a failed
+  # invocation yields included. Only a positive `not-control-plane` may skip the hold.
+  echo "BLOCKING (§CP state '$CP_STATE')"
+fi
+# blocking → advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/current-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/current-head.sh
@@ -1,0 +1,1 @@
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/current-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/current-head.sh
@@ -1,1 +1,24 @@
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
+#!/usr/bin/env bash
+# Step 5 — the head SHA you actually reviewed, resolved ONCE before composing the verdict, so the SHA
+# the marker carries and every later use are one single-sourced read rather than two independent
+# resolutions that could straddle a head move. Extracted from review-skill/SKILL.md (#4453, epic
+# #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# Prints a bare 40-hex SHA or NOTHING. Shape-asserted, because gh writes its error document to
+# STDOUT on failure: an unshape-checked capture would put that document into the marker's `@ <sha>`
+# field, and `verdict post`'s emissionDefect gate would then refuse the whole verdict (#2683).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: current-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+HEAD_SHA="$(gh api repos/"$REPO"/pulls/"$PR" --jq .head.sha)" || {
+  echo "current-head.sh: head SHA read FAILED (payload discarded) — no SHA to bind a verdict to." >&2; exit 1; }
+case "$HEAD_SHA" in
+  *[!0-9a-f]*|"") echo "current-head.sh: head SHA is not bare hex — discarded (never let gh's error body reach the marker's @ <sha>; #2683)." >&2; exit 1 ;;
+esac
+[ "${#HEAD_SHA}" -eq 40 ] || { echo "current-head.sh: head SHA is not a 40-char ref — discarded." >&2; exit 1; }
+printf '%s\n' "$HEAD_SHA"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
@@ -1,3 +1,24 @@
-WT_FILE="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR/wt.env"
-[ -s "$WT_FILE" ] || { echo "review-skill: §SP — $WT_FILE missing; re-run the head-materialization step in THIS session." >&2; exit 1; }
-. "$WT_FILE"
+#!/usr/bin/env bash
+# Print the absolute path of the run-state handle `materialize-head.sh` wrote (REVIEW_WT / PR_REF /
+# HEAD_SHA / BASE_REF), so any later step re-derives it with `. "$(head-env.sh "$PR")"` after the
+# harness resets the shell between Bash calls. Extracted from review-skill/SKILL.md's repeated
+# re-source line (#4453, epic #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# The namespace is per-run and per-session (§SP, #3718), which is what keeps a SIBLING reviewer's
+# tree out of reach — the failure a `git worktree list` re-derivation on the shared
+# `review-skill-head-${PR}` leaf walks straight into, pinning the wrong head's skill text (#1807).
+# Exits non-zero with EMPTY stdout when the namespace was never opened, so a caller's `.` fails
+# loudly instead of silently reading the base tree.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: head-env.sh <pr>" >&2; exit 2; }
+PR="$1"
+
+DIR="$(kp_scratch_path "review-skill-head-$PR")" || exit 1
+[ -s "$DIR/wt.env" ] || {
+  echo "review-skill: §SP — $DIR/wt.env missing; re-run the head-materialization step in THIS session. NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
+  exit 1
+}
+printf '%s\n' "$DIR/wt.env"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
@@ -1,0 +1,3 @@
+WT_FILE="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR/wt.env"
+[ -s "$WT_FILE" ] || { echo "review-skill: §SP — $WT_FILE missing; re-run the head-materialization step in THIS session." >&2; exit 1; }
+. "$WT_FILE"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/issue-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/issue-context.sh
@@ -1,0 +1,3 @@
+ISSUE=<N>
+gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
+gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/issue-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/issue-context.sh
@@ -1,3 +1,14 @@
-ISSUE=<N>
-gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
+#!/usr/bin/env bash
+# Step 1 — the linked issue (its `### Acceptance criteria` lives in the body) plus the progress trail
+# write-code left. Extracted from review-skill/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: issue-context.sh <issue>" >&2; exit 2; }
+ISSUE="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh api repos/"$REPO"/issues/"$ISSUE" --jq '{number, state, assignee: .assignee.login, body}'
 gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/linked-issue-timeline.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/linked-issue-timeline.sh
@@ -1,3 +1,15 @@
+#!/usr/bin/env bash
+# Step 1 — cross-check the linked issue off the PR's timeline when `Fixes #N` is not obvious in the
+# body. Extracted from review-skill/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: linked-issue-timeline.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
 # --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
 # invisible without it on a long-lived PR's timeline (#4193)
 gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/linked-issue-timeline.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/linked-issue-timeline.sh
@@ -1,0 +1,4 @@
+# --paginate + a STREAMING --jq: per_page caps at 100, so a link event past event 100 is
+# invisible without it on a long-lived PR's timeline (#4193)
+gh api --paginate "repos/$REPO/issues/$PR/timeline?per_page=100" \
+  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh
@@ -1,7 +1,28 @@
+#!/usr/bin/env bash
+# Config-pin / §HEAD materialization — the fresh base fetch, the head worktree, and the ADR-0052
+# instruction-denylist removal + absence assert. Extracted from review-skill/SKILL.md (#4453, epic
+# #4435 phase 1). Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+# The *why* for every step stays in that step's prose.
+#
+# STDOUT IS A MACHINE CHANNEL: the ONLY thing this writes to stdout is the absolute path of the
+# run-state handle carrying REVIEW_WT / PR_REF / HEAD_SHA / BASE_REF, so the caller can
+# `. "$(materialize-head.sh "$PR")"`. Every progress and FATAL line goes to stderr. On ANY failure
+# path stdout stays EMPTY and the exit is non-zero — the caller's `.` then fails loudly rather than
+# sourcing a half-written handle. A materialization that could not run is UNKNOWN, and reviewing the
+# BASE tree is the #793 false-PASS hazard (§ZS / ADR 0092).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: materialize-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main — your trusted config
-git fetch origin "$BASE_REF"
+PCLI="$(kp_pcli)" || exit 127
+
+BASE_REF="$(gh api repos/"$REPO"/pulls/"$PR" --jq '.base.ref')"   # normally main — your trusted config
+[ -n "$BASE_REF" ] || { echo "FATAL: could not resolve the PR's base ref — aborting (the base is half of verification; §HEAD)." >&2; exit 1; }
+git fetch origin "$BASE_REF" >&2
 
 # §HEAD steps 1–3 (resolve the live head SHA via REST, fetch pull/$PR/head into a nonce-uniqued
 # per-run ref WITHOUT touching the session tree, assert the fetched ref IS that head, add a
@@ -11,21 +32,20 @@ git fetch origin "$BASE_REF"
 # the head in the shared PRIMARY the harness resets this cwd to and detach the human's `main` —
 # #2270/#1103; §RO), and it internally aborts on a fetched-ref ≠ resolved-head mismatch (§HEAD #2)
 # so you never review a different SHA than the verdict claims. Persist its emitted head/ref/worktree
-# to a per-run mktemp handle so they survive the harness cwd/shell reset between Bash calls (a shell
-# var is lost across calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive
-# from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and
-# reads the wrong head's skill text — the #1807 collision). This is the §SP per-run scratchpad
-# namespace (gh-issue-intake-formats.md): a PR number is not unique, and a clobbered file reads
-# back cleanly with the other run's content (#3718). WT_FILE is a CROSS-CALL carrier — a later
-# step re-sources it — so §SP rules 2+3 apply, NOT the rule-4 single-file `mktemp` carve-out
-# (that one is for allocate-and-consume inside one call, like VERDICT_FILE below): the path is
-# derived deterministically from the session id, so each later step recomputes this same line
-# rather than inheriting a lost `$WT_FILE` variable.
-RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR"
-mkdir -p "$RUN_SCRATCH" || { echo "review-skill: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
-WT_FILE="$RUN_SCRATCH/wt.env"
+# to the per-run handle so they survive the harness cwd/shell reset between Bash calls (a shell
+# var is lost across calls); re-derive them with `. "$(head-env.sh "$PR")"` at each later step —
+# NEVER from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's
+# tree and reads the wrong head's skill text — the #1807 collision). This is the §SP per-run
+# scratchpad namespace (gh-issue-intake-formats.md): a PR number is not unique, and a clobbered file
+# reads back cleanly with the other run's content (#3718). The handle is a CROSS-CALL carrier — a
+# later step re-derives it — so §SP rules 2+3 apply, NOT the rule-4 single-file `mktemp` carve-out
+# (that one is for allocate-and-consume inside one call, like the verdict body): the path is a
+# deterministic function of this run's session id, which is what makes it re-derivable at all.
+WT_FILE="$(kp_scratch_open "review-skill-head-$PR")/wt.env" || exit 1
 "$PCLI" review-head materialize --pr "$PR" --worktree \
   | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
+printf 'BASE_REF=%s\n' "$BASE_REF" >> "$WT_FILE"
+# shellcheck disable=SC1090  # the run-unique handle this script just wrote
 . "$WT_FILE"
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
   echo "FATAL: review-head materialize did not yield a head worktree — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
@@ -34,7 +54,7 @@ WT_FILE="$RUN_SCRATCH/wt.env"
 # + .claude/.decisions/.patterns): remove them, then ASSERT absent — the load-bearing isolation
 # check. The head's skills/** are present as text to READ; the instruction surfaces are not.
 git -C "$REVIEW_WT" rm -r -q --cached --ignore-unmatch \
-  CLAUDE.md .claude .decisions .patterns
+  CLAUDE.md .claude .decisions .patterns >&2
 rm -rf "$REVIEW_WT/CLAUDE.md" "$REVIEW_WT/.claude" "$REVIEW_WT/.decisions" "$REVIEW_WT/.patterns"
 for p in CLAUDE.md .claude .decisions .patterns; do
   if [ -e "$REVIEW_WT/$p" ]; then
@@ -42,3 +62,6 @@ for p in CLAUDE.md .claude .decisions .patterns; do
     exit 1
   fi
 done
+
+# The handle path — the ONLY stdout line, so the caller can `. "$(materialize-head.sh "$PR")"`.
+printf '%s\n' "$WT_FILE"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh
@@ -1,0 +1,44 @@
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main — your trusted config
+git fetch origin "$BASE_REF"
+
+# §HEAD steps 1–3 (resolve the live head SHA via REST, fetch pull/$PR/head into a nonce-uniqued
+# per-run ref WITHOUT touching the session tree, assert the fetched ref IS that head, add a
+# throwaway DETACHED head worktree) are the shared `pipeline-cli review-head materialize` verb
+# (#3690 / #793 / #1807) — cite it, don't re-derive it. `pull/<pr>/head` resolves same-repo AND
+# cross-fork; the verb never runs `gh pr checkout` / `git checkout` / `git switch` (which would land
+# the head in the shared PRIMARY the harness resets this cwd to and detach the human's `main` —
+# #2270/#1103; §RO), and it internally aborts on a fetched-ref ≠ resolved-head mismatch (§HEAD #2)
+# so you never review a different SHA than the verdict claims. Persist its emitted head/ref/worktree
+# to a per-run mktemp handle so they survive the harness cwd/shell reset between Bash calls (a shell
+# var is lost across calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive
+# from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and
+# reads the wrong head's skill text — the #1807 collision). This is the §SP per-run scratchpad
+# namespace (gh-issue-intake-formats.md): a PR number is not unique, and a clobbered file reads
+# back cleanly with the other run's content (#3718). WT_FILE is a CROSS-CALL carrier — a later
+# step re-sources it — so §SP rules 2+3 apply, NOT the rule-4 single-file `mktemp` carve-out
+# (that one is for allocate-and-consume inside one call, like VERDICT_FILE below): the path is
+# derived deterministically from the session id, so each later step recomputes this same line
+# rather than inheriting a lost `$WT_FILE` variable.
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR"
+mkdir -p "$RUN_SCRATCH" || { echo "review-skill: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
+WT_FILE="$RUN_SCRATCH/wt.env"
+"$PCLI" review-head materialize --pr "$PR" --worktree \
+  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
+. "$WT_FILE"
+[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
+  echo "FATAL: review-head materialize did not yield a head worktree — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
+
+# Enforce the instruction denylist EXPLICITLY (a full checkout lands the head's root CLAUDE.md
+# + .claude/.decisions/.patterns): remove them, then ASSERT absent — the load-bearing isolation
+# check. The head's skills/** are present as text to READ; the instruction surfaces are not.
+git -C "$REVIEW_WT" rm -r -q --cached --ignore-unmatch \
+  CLAUDE.md .claude .decisions .patterns
+rm -rf "$REVIEW_WT/CLAUDE.md" "$REVIEW_WT/.claude" "$REVIEW_WT/.decisions" "$REVIEW_WT/.patterns"
+for p in CLAUDE.md .claude .decisions .patterns; do
+  if [ -e "$REVIEW_WT/$p" ]; then
+    echo "FATAL: denied instruction surface '$p' present in review worktree — isolation broken; aborting" >&2
+    exit 1
+  fi
+done

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-context.sh
@@ -1,2 +1,14 @@
-gh api repos/$REPO/pulls/$PR \
+#!/usr/bin/env bash
+# Step 1 — the PR's shape (state, draft, merged, head/base refs, body). Extracted from
+# review-skill/SKILL.md (#4453, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pr-context.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh api repos/"$REPO"/pulls/"$PR" \
   --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-context.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-context.sh
@@ -1,0 +1,2 @@
+gh api repos/$REPO/pulls/$PR \
+  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-diff.sh
@@ -1,0 +1,2 @@
+gh pr diff $PR \
+  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-diff.sh
@@ -1,2 +1,13 @@
-gh pr diff $PR \
-  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
+#!/usr/bin/env bash
+# Step 2 — the change under review. Extracted from review-skill/SKILL.md (#4453, epic #4435 phase 1).
+# Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: pr-diff.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
+gh pr diff "$PR" \
+  || gh api repos/"$REPO"/pulls/"$PR" -H "Accept: application/vnd.github.v3.diff"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/resolve-repo.sh
@@ -1,0 +1,1 @@
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/resolve-repo.sh
@@ -1,1 +1,12 @@
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+#!/usr/bin/env bash
+# Print the target repo as `owner/name`. Extracted from review-skill/SKILL.md (#4453, epic #4435
+# phase 1). Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# Top-level assignment, never `local` — `local REPO="$(kp_repo)"` takes `local`'s own status and
+# masks the substitution's, so an unresolvable repo would sail through as the empty string and
+# address `gh api repos//…`.
+REPO="$(kp_repo)" || exit 1
+printf '%s\n' "$REPO"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
@@ -1,0 +1,1 @@
+rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
@@ -1,1 +1,29 @@
+#!/usr/bin/env bash
+# Step 2 — tear the throwaway head worktree + per-run ref down. Extracted from review-skill/SKILL.md
+# (#4453, epic #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# It is its OWN script because the prose requires it on EVERY exit path (PASS, FAIL, mid-run error),
+# not just after a clean read — a leaked `review-skill-head-*` tree accumulates on the shared primary
+# otherwise (#2785). Safe by construction: the tree it removes is a detached, already-pushed
+# throwaway this gate materialized itself, holding no branch and no unpushed work. Idempotent — a
+# namespace that was never opened is a clean no-op, so it may be run after an aborted materialization.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: teardown-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+
+# shellcheck disable=SC1007
+HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
+  echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
+  exit 0
+}
+# shellcheck disable=SC1090
+. "$HANDLE"
+[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] || {
+  echo "teardown-head.sh: handle carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\` (no-op)." >&2
+  exit 0
+}
+
 rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-post.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-post.sh
@@ -1,0 +1,10 @@
+# resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
+# else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653).
+VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
+VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
+# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-skill: PASS @ <HEAD_SHA> — merge-ready)
+# Upsert through the guarded tool on the (PR, gate-namespace, head, run) key: it replaces this
+# head+run's own review-skill record (namespace-anchored, so a blocking↔non-blocking flip replaces
+# a prior advisory at the same key too) and appends against any other key, and it
+# fail-closes on a malformed/cross-namespace body — the mktemp-path `@ <sha>` leak (#2683) never lands.
+$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-post.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-post.sh
@@ -1,10 +1,37 @@
+#!/usr/bin/env bash
+# Step 5 — the guarded `review-skill` verdict upsert, on the §VERDICT (PR, gate-namespace, head, run)
+# key. Extracted from review-skill/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# ONE script for all THREE Step-5 branches — non-blocking PASS, §CP advisory, FAIL. The fences
+# differed only in the body they told the reviewer to compose; the mechanism was identical
+# (`mktemp` a file, write the body into it, `verdict post --gate skill --body-file`). Collapsing them
+# removes two copies of the same upsert rather than preserving a distinction the shell never had.
+#
+# THE BODY ARRIVES ON STDIN — the declared seam. The fences said "write your composed verdict into
+# $VERDICT_FILE", so the body is authored by the reviewing agent and a script can only receive it.
+# Stdin also retires the scratch file entirely, which removes the #2683 / #3718 class by
+# construction: with no path on disk there is nothing for a concurrent review of the same PR to
+# clobber, and no mktemp path that could bleed into the marker's `@ <sha>` field.
+#
+# The upsert itself stays `pipeline-cli verdict post` — the MANDATED emit choke point. A bare
+# `gh api …/comments` hand-post of a marker is FORBIDDEN: it skips `emissionDefect` and the
+# §READBACK re-scan (§READBACK of ../../shared/gate-verdict-contract.md; #2789 / #2816 / #2818).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: printf '%s' \"\$BODY\" | verdict-post.sh <pr>" >&2; exit 2; }
+PR="$1"
 # resolve the verdict CLI via the `bin/pipeline-cli` shim — in-repo bin, else the installed bin,
 # else the pinned `pnpm dlx` fallback reading the one pin (hooks/pin.sh); no version pinned here (#3653).
-VERDICT="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli verdict"
-VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
-# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-skill: PASS @ <HEAD_SHA> — merge-ready)
+PCLI="$(kp_pcli)" || exit 127
+
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "verdict-post.sh: EMPTY body on stdin — refusing to post an empty verdict; the PR would read as UNGATED." >&2; exit 1; }
+
 # Upsert through the guarded tool on the (PR, gate-namespace, head, run) key: it replaces this
 # head+run's own review-skill record (namespace-anchored, so a blocking↔non-blocking flip replaces
 # a prior advisory at the same key too) and appends against any other key, and it
 # fail-closes on a malformed/cross-namespace body — the mktemp-path `@ <sha>` leak (#2683) never lands.
-$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
+printf '%s' "$BODY" | "$PCLI" verdict post --pr "$PR" --gate skill

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-readback.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-readback.sh
@@ -1,0 +1,4 @@
+# UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
+# + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
+# the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.
+verdict_post_verify "$PR" review-skill "$HEAD_SHA" || exit 1

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-readback.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/verdict-readback.sh
@@ -1,3 +1,28 @@
+#!/usr/bin/env bash
+# Step 5b — the UNCONDITIONAL post-verify: prove a clean, current-head `review-skill:` verdict is
+# actually on the PR. Extracted from review-skill/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract: ../SKILL.md § The extracted scripts.
+#
+# `verdict_post_verify` itself is SOURCED from its canonical home,
+# ../../shared/scripts/verdict-readback.sh (#4489 extracted it out of
+# ../../gh-issue-intake-formats.md) — there is no skill-local copy to drift. It re-derives the landed
+# verdict from live PR state, never from a carried comment id: `$MINE` was set only on one posting
+# branch, which is exactly how the #2264 recurrence slipped a broken/leaking marker through.
+#
+# PROPAGATE THE NON-ZERO. This wrapper's single FATAL exit is what makes verdict-posting an ENFORCED
+# gate rather than a hopeful one — never report the gate done over an ungated PR.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: verdict-readback.sh <pr> <head-sha>" >&2; exit 2; }
+PR="$1"; HEAD_SHA="$2"
+# $REPO is what the sourced guard addresses `gh api` at, exactly as the fence did.
+REPO="$(kp_repo)" || exit 1
+export REPO
+# shellcheck source=../../shared/scripts/verdict-readback.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/verdict-readback.sh"
+
 # UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
 # + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
 # the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -47,8 +47,39 @@ queries; every read and write goes through `gh api`. Resolve the target repo onc
 ADR 0062 §1):
 
 ```bash
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+bash ./claude-plugins/kampus-pipeline/skills/review-trivial/scripts/resolve-repo.sh
 ```
+
+## The extracted scripts
+
+This skill's shell lives in [`scripts/`](scripts/) and every fenced `bash` block below is an
+**invocation** of one, run by literal path with its results on stdout — never sourced (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)).
+The prose keeps the *why*; the scripts hold the *how* (epic #4435 phase 1 — the shell moved as-is,
+and turning its `gh`/`jq` glue into tested `pipeline-cli` verbs is #1929, ADR 0228: a script may
+RELAY a verb's answer, never DERIVE the decision). Four properties are load-bearing:
+
+- **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control
+  flow through the guards written into it — a state-word assertion instead of an exit-status test
+  (§CP), a `grep` whose empty result is an answer. `errexit` would abort those paths before they
+  print their fail-closed line, converting fail-closed into fail-**open**
+  ([`.patterns/skill-script-shell-shape.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-shell-shape.md)).
+- **No script installs an `EXIT` trap.** Under bash 3.2 a cleanup trap's last command becomes the
+  script's exit status, which launders a `set -u` abort into exit 0 (#4476, class #4479).
+- **This gate's permissive answer is EMPTY STDOUT, so every failure path speaks.**
+  [`scripts/step0-triviality.sh`](scripts/step0-triviality.sh) answers "route to the full path" with
+  a `review-trivial: not-trivial — …` line and answers "the premise holds" with **silence**. That
+  inversion makes a silent guard exit indistinguishable from "proven trivial" — at the gate that
+  routes to the *lighter* path, so a fail-open here **under-gates**. Every could-not-run path
+  therefore prints its own `not-trivial` line **before** exiting, **and** exits non-zero. An absent
+  or empty result is UNKNOWN, and UNKNOWN is never "no" (§ZS / ADR
+  [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md);
+  [`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md)).
+- **The shared-contract helpers are SOURCED from their canonical home — there is no skill-local
+  copy.** §CPREAD's `cp_changed_files` / `cp_head_sha` and §RO-iso's `iso_preflight` live in
+  [`../shared/scripts/`](../shared/scripts/) (#4489 extracted them out of
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)), and this skill's scripts source
+  them directly. With no second copy there is nothing to keep in step.
 
 ## Read-only on git working state
 
@@ -90,23 +121,16 @@ path, so a path-only test here would ride it straight onto the lighter gate (#41
 don't re-hard-code the list:
 
 ```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 PR=<pr number>
-# The changed-file list is a fallible READ, and an unchecked capture resolved a failed one to "no §CP
-# path touched" (#4216) — at the gate that routes to the LIGHTER path, so a fail-open here UNDER-gates.
-# `cp_changed_files` / `cp_head_sha` are §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim
-# from there (single source; the why lives there, not here).
-if ! cp_changed_files "$REPO" "$PR"; then
-  echo "review-trivial: not-trivial — changed-file list unreadable (§CP UNKNOWN, never 'no §CP path'); route to full path"; exit 0
-fi
-FILES="$CP_FILES"; NFILES="$CP_FILES_N"   # proven-arrived; scope already emitted per §ZS #1 (ADR 0092)
-ADD=$(gh api repos/$REPO/pulls/$PR --jq '.additions'); DEL=$(gh api repos/$REPO/pulls/$PR --jq '.deletions')
-
-# Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
-# Only `not-control-plane` is a proven-ordinary answer; every other state is a HOLD.
-CP_STATE="$(printf '%s\n' "$FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
+HOLD="$(bash ./claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh "$PR")"; RC=$?
 ```
+
+**Read the exit status before the stdout, and read `$HOLD` as a hold, never as a summary.** A
+non-zero `$RC` means the classification **could not be made** — hold and route to the full path
+whatever `$HOLD` says. On `$RC = 0`, a **non-empty** `$HOLD` is the refusal and its reason; an
+**empty** `$HOLD` is the one positive answer: the §CP axis and the §DEV premise both cleared, so the
+lighter checklist's bound holds. The script's scope line (file count, `+add/-del`) lands on stderr —
+it feeds the verdict's triviality-re-affirm evidence row.
 
 **Refuse the lighter gate (FAIL → full path) on any of:**
 
@@ -146,70 +170,8 @@ CP_STATE="$(printf '%s\n' "$FILES" | "$PCLI" cp-classify classify --repo "$REPO"
 On any refusal, emit a `review-trivial: not-trivial — route to full path` note (a plain note,
 **not** a verdict marker — you are declining to be this PR's gate) and stop. The executor's
 fail-closed fallback (#1559) re-routes it to the full `review-code` / `review-doc` fan-out;
-the worst case of a miss is paying the full (correct) cost, never an under-gated merge.
-
-```bash
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-# Fail-closed on EVERY value but the proven-ordinary one. The test is a positive match on the
-# STATE WORD, not on the exit status: the exit code discriminates the four states only once the
-# verb has RUN, so a bad flag (exit 1) or a missing binary (exit 127) would fail OPEN through
-# `… || ordinary`. Here they leave CP_STATE empty, which this test routes to the full path (#4161).
-if [ "$CP_STATE" != "not-control-plane" ]; then
-  # Resolve the one state that is an obligation rather than a verdict (ADR 0164, #4161).
-  if [ "$CP_STATE" = "content-undetermined" ]; then
-    cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
-    if [ -z "$HEAD_SHA" ]; then
-      echo "review-trivial: not-trivial — head SHA unreadable, ADR content unprobeable (§CP UNKNOWN); route to full path"; exit 0
-    fi
-    # Assert on the probe's STATE WORD, never on its exit status: the exit code discriminates the
-    # two verdicts only once the verb has RUN, so `>/dev/null && echo "$adr"` collected NOTHING when
-    # it never ran and read an unprobed ADR as ordinary. Only `not-guard-touching` clears (#4219).
-    GUARD_TOUCHING="$(printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-        # Capture and CHECK, never a straight pipe: gh writes its error document to STDOUT, so a pipe
-        # hands the probe an ERROR BODY as the ADR body (§CPREAD #2). Unreadable ⇒ §CP, fail-closed.
-        adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
-        if [ -z "$adr_body" ]; then echo "$adr(body-unreadable⇒§CP)"
-        else
-          GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
-          case "$GC_STATE" in
-            not-guard-touching) : ;;
-            guard-touching) echo "$adr" ;;
-            *) echo "$adr(undetermined:'$GC_STATE')" ;;
-          esac
-        fi
-      done)"
-    if [ -z "$GUARD_TOUCHING" ]; then
-      : # every touched ADR probed not-guard-touching ⇒ the content axis is resolved, carry on
-    else
-      echo "review-trivial: not-trivial — ADR not proven ordinary by content (guard-touching, or the probe could not determine; ADR 0164): $GUARD_TOUCHING; route to full path"; exit 0
-    fi
-  else
-    echo "review-trivial: not-trivial — §CP state '$CP_STATE'; route to full path (ADR 0053/0065; #4161)"; exit 0
-  fi
-fi
-
-# §DEV: the disclosure section decides triviality too — a disclosed deviation, or a missing heading,
-# routes to the full path. Read the section's body (heading → next heading or EOF) and compare.
-BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
-# `IGNORECASE` is a gawk extension BSD/macOS awk ignores SILENTLY, so a lowercase `## deviations`
-# heading yielded an empty DEV_BODY here while the case-insensitive `grep -i` below still saw the
-# heading — the two halves disagreed about case. Spell the case-insensitivity into the pattern
-# instead (POSIX, portable) so both halves read the same heading.
-DEV_BODY="$(printf '%s\n' "$BODY" \
-  | awk '/^[[:space:]]*###?[[:space:]]*[Dd][Ee][Vv][Ii][Aa][Tt][Ii][Oo][Nn][Ss][[:space:]]*$/{f=1;next} /^[[:space:]]*##?#?[[:space:]]/{f=0} f' \
-  | grep -Ev '^[[:space:]]*$')"
-if ! printf '%s\n' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$'; then
-  echo "review-trivial: not-trivial — no ## Deviations section, so no None. claim to stand on (§DEV); route to full path, which decides owed-vs-not"; exit 0
-elif [ "$(printf '%s\n' "$DEV_BODY" | grep -c .)" = 1 ] && printf '%s\n' "$DEV_BODY" | grep -Eiqx '[[:space:]]*none\.?[[:space:]]*'; then
-  : # exactly one non-blank line, and it is `None.` — the triviality premise holds, continue Step 0
-else
-  # anything else — a disclosed deviation, OR an empty section (which is not the `None.` claim §DEV
-  # requires) — is outside the lighter gate's bound. Default-deny, exactly like the unreadable
-  # CONTROL_PLANE_RE above: you cannot prove the premise, so you must not treat the diff as trivial.
-  echo "review-trivial: not-trivial — the body discloses a deviation, or its ## Deviations section is empty (§DEV); route to full path"; exit 0
-fi
-```
+the worst case of a miss is paying the full (correct) cost, never an under-gated merge. The
+`$HOLD` line the script printed **is** that note's text — quote it, don't paraphrase it.
 
 ---
 
@@ -227,26 +189,16 @@ split holds too (ADR 0052): the **head is the diff under test**, your **config/i
 come from the trusted base** — never load the head's `.claude/**` / `CLAUDE.md` / hooks.
 
 ```bash
-# Isolation preflight FIRST, before the head fetch below. If this review-trivial spawn expected
-# worktree isolation (reviewer agent-type) but the #2440 harness no-op dropped it onto the shared
-# PRIMARY checkout ($WORKTREE_ROOT unset), fetching the head here is the #2452/#2453
-# primary-checkout-detach surface — fail closed LOUD and route up. Single-sourced in
-# gh-issue-intake-formats.md §RO-iso (ADR 0172; the write-code wt_preflight sibling). A genuine
-# standalone run on the owner's checkout still proceeds (the head read is via `git show`, checkout-free).
-iso_preflight review-trivial || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
-
-HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
-PR_REF="refs/review-trivial/$PR"
-git fetch --no-tags origin "pull/$PR/head:$PR_REF" >/dev/null 2>&1 || git fetch origin "$HEAD_SHA" >/dev/null 2>&1
-# read a head file WITHOUT a checkout:  git show "$PR_REF:<path>"   (or "$HEAD_SHA:<path>")
-# NEVER `git checkout` / `git switch` to inspect the head — the harness resets this cwd to the
-# shared PRIMARY between Bash calls, so a checkout lands there and detaches the human's `main`
-# (#2270/#1103); §RO in gh-issue-intake-formats.md forbids switching any working tree outright.
-
-# the PR body carries Fixes #N; pin the linked issue and its acceptance criteria
-ISSUE=$(gh api repos/$REPO/pulls/$PR --jq '.body' | grep -ioE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' | head -n1)
-gh api repos/$REPO/issues/$ISSUE --jq '.body'   # the ### Acceptance criteria you verify against
+# Prints HEAD_SHA= / PR_REF= / ISSUE= on stdout; the linked issue's body (its ### Acceptance
+# criteria) goes to stderr. `eval` the three, or read them off the run log.
+eval "$(bash ./claude-plugins/kampus-pipeline/skills/review-trivial/scripts/materialize-head.sh "$PR")" || exit 1
 ```
+
+The script runs §RO-iso's `iso_preflight` **first**, before any fetch, and shape-asserts the head SHA
+before it can reach a `git fetch` argument. Read `$PR_REF` afterwards, not the working copy: a head
+file is `git show "$PR_REF:<path>"`, and you **never** `git checkout` / `git switch` to inspect it —
+the harness resets this cwd to the shared PRIMARY between Bash calls, so a checkout lands there and
+detaches the human's `main` (#2270/#1103); §RO forbids switching any working tree outright.
 
 If you genuinely can't find a linked issue, that's a FAIL you can't even start (the `Fixes #N`
 seam is missing) — note it and stop; there's nothing to gate against without the criteria. (A
@@ -286,7 +238,7 @@ Verify **all** of the following over the head diff. Each is conjunctive; **one m
    for a pasted secret. Scan the added hunks:
 
    ```bash
-   git show "$PR_REF" | grep -nE '^\+' | grep -niE 'api[_-]?key|secret|token|password|passwd|BEGIN [A-Z ]*PRIVATE KEY|AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z]{30,}|xox[baprs]-|-----BEGIN' || echo "no secret-shaped added lines"
+   bash ./claude-plugins/kampus-pipeline/skills/review-trivial/scripts/secret-scan.sh "$PR_REF"
    ```
    Treat any hit as a finding to confirm by eye (a variable *named* `token` referencing a binding
    is fine; a literal secret value is a **FAIL**).
@@ -304,11 +256,9 @@ Verify **all** of the following over the head diff. Each is conjunctive; **one m
    on a clean PR (#4220):
 
    ```bash
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
    # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
    # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
-   git show "$PR_REF" | grep '^+' | "$PCLI" leak-guard scan-comment
+   bash ./claude-plugins/kampus-pipeline/skills/review-trivial/scripts/leak-scan.sh "$PR_REF"
    ```
    A repo-relative path (`apps/web/…`, `.decisions/…`) is fine; a hit is a **FAIL** — cite it by
    the class the scan names, never by quoting the matched token. A hit you suspect is a documented
@@ -360,17 +310,12 @@ and run-blind — which is exactly the ADR-0213 concurrent-reviewer clobber, and
 `emissionDefect` plus the §READBACK re-scan that §VERDICT makes mandatory:
 
 ```bash
-NS=code   # or doc / skill, per the class above — the gate namespace is `review-$NS`
-HEAD_NOW="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
-[ "$HEAD_NOW" = "$HEAD_SHA" ] || { echo "head moved under the verdict — re-review the new head or abort (ADR 0058)"; exit 1; }
-
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-VERDICT_FILE="$(mktemp /tmp/review-trivial-verdict.XXXXXX)"
-# write your composed verdict into "$VERDICT_FILE"; first line is the bare SHA-bound marker:
-#   review-<NS>: PASS @ <HEAD_SHA> — merge-ready          (every check passed)
-#   review-<NS>: FAIL @ <HEAD_SHA> — not merge-ready       (any check failed)
-"$PCLI" verdict post --pr "$PR" --gate "$NS" --body-file "$VERDICT_FILE"
+# NS is `code` / `doc` / `skill` per the artifact class above — no default, so a mis-routed
+# namespace can never be emitted silently. $BODY is the verdict you composed; its first line is the
+# bare SHA-bound marker (`review-<NS>: PASS @ <HEAD_SHA> — merge-ready`, or `FAIL … — not
+# merge-ready`). Passing $HEAD_SHA makes the script re-check the live head first and refuse if it
+# moved (§HEAD #4 / ADR 0058).
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-trivial/scripts/verdict-post.sh "$PR" "$NS" "$HEAD_SHA"
 ```
 
 ### Verdict body shape

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/leak-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/leak-scan.sh
@@ -1,5 +1,24 @@
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-   # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
-   # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
-   git show "$PR_REF" | grep '^+' | "$PCLI" leak-guard scan-comment
+#!/usr/bin/env bash
+# Step 2 check 3 — the machine-local-path scan over the head diff's added lines, through the SHARED
+# matcher. Extracted from review-trivial/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
+# shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# The exit status IS the answer here (0 clean / 2 leak / anything else UNRESOLVED), so this script
+# propagates `leak-guard scan-comment`'s status untouched and adds no stdout of its own. Deliberately
+# no pattern set lives here: it is single-sourced in
+# `packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts`, and a restated token would land in a
+# verdict comment that `leak-guard scan-pr` then reads back as a real leak (#4220).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: leak-scan.sh <pr-ref>   # the ref materialize-head.sh printed" >&2; exit 2; }
+PR_REF="$1"
+git rev-parse --verify --quiet "$PR_REF^{commit}" >/dev/null || {
+  echo "leak-scan.sh: '$PR_REF' is not a readable ref — the scan did NOT run; UNKNOWN, never 'clean'." >&2; exit 1; }
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="$(kp_pcli)" || exit 127
+
+# added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+# any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
+git show "$PR_REF" | grep '^+' | "$PCLI" leak-guard scan-comment

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/leak-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/leak-scan.sh
@@ -1,0 +1,5 @@
+   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+   # added lines only ('+'), scanned by the shared matcher: exit 0 = clean, 2 = leak found
+   # any OTHER non-zero (4 = the fail-closed stdin read, #4010) is an UNRESOLVED scan, never a pass
+   git show "$PR_REF" | grep '^+' | "$PCLI" leak-guard scan-comment

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/materialize-head.sh
@@ -1,0 +1,19 @@
+# Isolation preflight FIRST, before the head fetch below. If this review-trivial spawn expected
+# worktree isolation (reviewer agent-type) but the #2440 harness no-op dropped it onto the shared
+# PRIMARY checkout ($WORKTREE_ROOT unset), fetching the head here is the #2452/#2453
+# primary-checkout-detach surface — fail closed LOUD and route up. Single-sourced in
+# gh-issue-intake-formats.md §RO-iso (ADR 0172; the write-code wt_preflight sibling). A genuine
+# standalone run on the owner's checkout still proceeds (the head read is via `git show`, checkout-free).
+iso_preflight review-trivial || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
+
+HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
+PR_REF="refs/review-trivial/$PR"
+git fetch --no-tags origin "pull/$PR/head:$PR_REF" >/dev/null 2>&1 || git fetch origin "$HEAD_SHA" >/dev/null 2>&1
+# read a head file WITHOUT a checkout:  git show "$PR_REF:<path>"   (or "$HEAD_SHA:<path>")
+# NEVER `git checkout` / `git switch` to inspect the head — the harness resets this cwd to the
+# shared PRIMARY between Bash calls, so a checkout lands there and detaches the human's `main`
+# (#2270/#1103); §RO in gh-issue-intake-formats.md forbids switching any working tree outright.
+
+# the PR body carries Fixes #N; pin the linked issue and its acceptance criteria
+ISSUE=$(gh api repos/$REPO/pulls/$PR --jq '.body' | grep -ioE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' | head -n1)
+gh api repos/$REPO/issues/$ISSUE --jq '.body'   # the ### Acceptance criteria you verify against

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/materialize-head.sh
@@ -1,19 +1,51 @@
+#!/usr/bin/env bash
+# Step 1 — §RO-iso preflight, then land the PR head in a per-run ref (no checkout) and resolve the
+# linked issue. Extracted from review-trivial/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# STDOUT IS A MACHINE CHANNEL: the only stdout lines are the `HEAD_SHA=` / `PR_REF=` / `ISSUE=`
+# answer, so the caller can `eval` or read them. The issue body the fence printed goes to stderr —
+# the caller reads it from the run log, or re-reads it off the printed `ISSUE=`. On ANY failure path
+# stdout stays EMPTY and the exit is non-zero: a materialization that could not run is UNKNOWN, and
+# reviewing the launched checkout's base tree is the #793 false-PASS hazard.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# §RO-iso's `iso_preflight`, sourced from its canonical home rather than re-copied (#4489 extracted
+# it out of ../../gh-issue-intake-formats.md).
+# shellcheck source=../../shared/scripts/iso-preflight.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/iso-preflight.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: materialize-head.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || exit 1
+
 # Isolation preflight FIRST, before the head fetch below. If this review-trivial spawn expected
 # worktree isolation (reviewer agent-type) but the #2440 harness no-op dropped it onto the shared
 # PRIMARY checkout ($WORKTREE_ROOT unset), fetching the head here is the #2452/#2453
 # primary-checkout-detach surface — fail closed LOUD and route up. Single-sourced in
 # gh-issue-intake-formats.md §RO-iso (ADR 0172; the write-code wt_preflight sibling). A genuine
 # standalone run on the owner's checkout still proceeds (the head read is via `git show`, checkout-free).
-iso_preflight review-trivial || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
+iso_preflight review-trivial >&2 || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
 
 HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
+# Shape-assert before the SHA can reach a `git fetch` argument or the caller's `@ <sha>` field: gh
+# writes its error document to STDOUT on failure, so an unchecked capture is non-empty garbage.
+case "$HEAD_SHA" in
+  *[!0-9a-f]*|"") echo "materialize-head.sh: head SHA is not bare hex — discarded; NO head was materialized (§HEAD)." >&2; exit 1 ;;
+esac
+[ "${#HEAD_SHA}" -eq 40 ] || { echo "materialize-head.sh: head SHA is not a 40-char ref — discarded." >&2; exit 1; }
 PR_REF="refs/review-trivial/$PR"
 git fetch --no-tags origin "pull/$PR/head:$PR_REF" >/dev/null 2>&1 || git fetch origin "$HEAD_SHA" >/dev/null 2>&1
 # read a head file WITHOUT a checkout:  git show "$PR_REF:<path>"   (or "$HEAD_SHA:<path>")
 # NEVER `git checkout` / `git switch` to inspect the head — the harness resets this cwd to the
 # shared PRIMARY between Bash calls, so a checkout lands there and detaches the human's `main`
 # (#2270/#1103); §RO in gh-issue-intake-formats.md forbids switching any working tree outright.
+git rev-parse --verify --quiet "$PR_REF^{commit}" >/dev/null || {
+  echo "materialize-head.sh: neither fetch landed $PR_REF — the head is NOT readable, so nothing may be reviewed (§HEAD)." >&2; exit 1; }
 
 # the PR body carries Fixes #N; pin the linked issue and its acceptance criteria
-ISSUE=$(gh api repos/$REPO/pulls/$PR --jq '.body' | grep -ioE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' | head -n1)
-gh api repos/$REPO/issues/$ISSUE --jq '.body'   # the ### Acceptance criteria you verify against
+ISSUE=$(gh api repos/"$REPO"/pulls/"$PR" --jq '.body' | grep -ioE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' | head -n1)
+gh api repos/"$REPO"/issues/"$ISSUE" --jq '.body' >&2   # the ### Acceptance criteria you verify against
+
+printf 'HEAD_SHA=%s\nPR_REF=%s\nISSUE=%s\n' "$HEAD_SHA" "$PR_REF" "${ISSUE:-}"

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/resolve-repo.sh
@@ -1,0 +1,1 @@
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/resolve-repo.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/resolve-repo.sh
@@ -1,1 +1,12 @@
-REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+#!/usr/bin/env bash
+# Print the target repo as `owner/name`. Extracted from review-trivial/SKILL.md (#4453, epic #4435
+# phase 1). Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# Top-level assignment, never `local` — `local REPO="$(kp_repo)"` takes `local`'s own status and
+# masks the substitution's, so an unresolvable repo would sail through as the empty string and
+# address `gh api repos//…`.
+REPO="$(kp_repo)" || exit 1
+printf '%s\n' "$REPO"

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/secret-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/secret-scan.sh
@@ -1,0 +1,1 @@
+   git show "$PR_REF" | grep -nE '^\+' | grep -niE 'api[_-]?key|secret|token|password|passwd|BEGIN [A-Z ]*PRIVATE KEY|AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z]{30,}|xox[baprs]-|-----BEGIN' || echo "no secret-shaped added lines"

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/secret-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/secret-scan.sh
@@ -1,1 +1,18 @@
-   git show "$PR_REF" | grep -nE '^\+' | grep -niE 'api[_-]?key|secret|token|password|passwd|BEGIN [A-Z ]*PRIVATE KEY|AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z]{30,}|xox[baprs]-|-----BEGIN' || echo "no secret-shaped added lines"
+#!/usr/bin/env bash
+# Step 2 check 2 — the secret-shaped-added-line scan over the head diff. Extracted from
+# review-trivial/SKILL.md (#4453, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+#
+# The moved line's own `|| echo "no secret-shaped added lines"` is the clean answer, so an EMPTY
+# stdout can only mean the scan did not run — which the caller must never read as clean. Hence the
+# ref guard below: no readable ref ⇒ a loud line + non-zero, never silence (§ZS / ADR 0092).
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 1 ] || { echo "usage: secret-scan.sh <pr-ref>   # the ref materialize-head.sh printed" >&2; exit 2; }
+PR_REF="$1"
+git rev-parse --verify --quiet "$PR_REF^{commit}" >/dev/null || {
+  echo "secret-scan.sh: '$PR_REF' is not a readable ref — the scan did NOT run; this is UNKNOWN, never 'clean'." >&2; exit 1; }
+
+git show "$PR_REF" | grep -nE '^\+' | grep -niE 'api[_-]?key|secret|token|password|passwd|BEGIN [A-Z ]*PRIVATE KEY|AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z]{30,}|xox[baprs]-|-----BEGIN' || echo "no secret-shaped added lines"

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh
@@ -10,6 +10,15 @@
 # BEFORE exiting, and exits non-zero: a classifier that never ran must never reach the caller as
 # silence, which the caller would read as "proven trivial" and under-gate (§ZS / ADR 0092,
 # `.patterns/skill-script-io-contract.md`; #4216, #4161, #4219). Scope + diagnostics go to stderr.
+#
+# BASH 3.2 NOTE, load-bearing: the ADR-0164 probe loop below sits inside a `$( … )`, and bash 3.2
+# balances parens across the WHOLE substitution body — including inside comments, where a lone `(`
+# or `)` is counted as if it were syntax. Two consequences, both measured on 3.2.57(1)-release:
+# every `case` pattern in there carries the POSIX leading `(` (otherwise the pattern's closing `)`
+# ends the substitution early), and no comment in there may carry an unbalanced paren. Neither
+# hazard was reachable while this block lived inline in the markdown and never ran, and CI's bash 5
+# parses both shapes — so CI cannot catch either. The local interpreter every agent run gets is the
+# one that decides (`.patterns/skill-script-shell-shape.md`).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -29,7 +38,7 @@ REPO="$(kp_repo)" || {
   exit 1; }
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="$(kp_pcli)" || {
-  echo "review-trivial: not-trivial — pipeline-cli UNRESOLVED, so cp-classify never ran (UNKNOWN, never 'ordinary'); route to full path"
+  echo "review-trivial: not-trivial — the CLI shim is UNRESOLVED, so cp-classify never ran (UNKNOWN, never 'ordinary'); route to full path"
   exit 127; }
 
 # The changed-file list is a fallible READ, and an unchecked capture resolved a failed one to "no §CP
@@ -70,10 +79,11 @@ if [ "$CP_STATE" != "not-control-plane" ]; then
         if [ -z "$adr_body" ]; then echo "$adr(body-unreadable⇒§CP)"
         else
           GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+          # The pattern prefixes below are REQUIRED — see the header note on bash 3.2.
           case "$GC_STATE" in
-            not-guard-touching) : ;;
-            guard-touching) echo "$adr" ;;
-            *) echo "$adr(undetermined:'$GC_STATE')" ;;
+            (not-guard-touching) : ;;
+            (guard-touching) echo "$adr" ;;
+            (*) echo "$adr(undetermined:'$GC_STATE')" ;;
           esac
         fi
       done)"

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh
@@ -1,0 +1,76 @@
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+PR=<pr number>
+# The changed-file list is a fallible READ, and an unchecked capture resolved a failed one to "no §CP
+# path touched" (#4216) — at the gate that routes to the LIGHTER path, so a fail-open here UNDER-gates.
+# `cp_changed_files` / `cp_head_sha` are §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim
+# from there (single source; the why lives there, not here).
+if ! cp_changed_files "$REPO" "$PR"; then
+  echo "review-trivial: not-trivial — changed-file list unreadable (§CP UNKNOWN, never 'no §CP path'); route to full path"; exit 0
+fi
+FILES="$CP_FILES"; NFILES="$CP_FILES_N"   # proven-arrived; scope already emitted per §ZS #1 (ADR 0092)
+ADD=$(gh api repos/$REPO/pulls/$PR --jq '.additions'); DEL=$(gh api repos/$REPO/pulls/$PR --jq '.deletions')
+
+# Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
+# Only `not-control-plane` is a proven-ordinary answer; every other state is a HOLD.
+CP_STATE="$(printf '%s\n' "$FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# Fail-closed on EVERY value but the proven-ordinary one. The test is a positive match on the
+# STATE WORD, not on the exit status: the exit code discriminates the four states only once the
+# verb has RUN, so a bad flag (exit 1) or a missing binary (exit 127) would fail OPEN through
+# `… || ordinary`. Here they leave CP_STATE empty, which this test routes to the full path (#4161).
+if [ "$CP_STATE" != "not-control-plane" ]; then
+  # Resolve the one state that is an obligation rather than a verdict (ADR 0164, #4161).
+  if [ "$CP_STATE" = "content-undetermined" ]; then
+    cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
+    if [ -z "$HEAD_SHA" ]; then
+      echo "review-trivial: not-trivial — head SHA unreadable, ADR content unprobeable (§CP UNKNOWN); route to full path"; exit 0
+    fi
+    # Assert on the probe's STATE WORD, never on its exit status: the exit code discriminates the
+    # two verdicts only once the verb has RUN, so `>/dev/null && echo "$adr"` collected NOTHING when
+    # it never ran and read an unprobed ADR as ordinary. Only `not-guard-touching` clears (#4219).
+    GUARD_TOUCHING="$(printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+        # Capture and CHECK, never a straight pipe: gh writes its error document to STDOUT, so a pipe
+        # hands the probe an ERROR BODY as the ADR body (§CPREAD #2). Unreadable ⇒ §CP, fail-closed.
+        adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
+        if [ -z "$adr_body" ]; then echo "$adr(body-unreadable⇒§CP)"
+        else
+          GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
+          case "$GC_STATE" in
+            not-guard-touching) : ;;
+            guard-touching) echo "$adr" ;;
+            *) echo "$adr(undetermined:'$GC_STATE')" ;;
+          esac
+        fi
+      done)"
+    if [ -z "$GUARD_TOUCHING" ]; then
+      : # every touched ADR probed not-guard-touching ⇒ the content axis is resolved, carry on
+    else
+      echo "review-trivial: not-trivial — ADR not proven ordinary by content (guard-touching, or the probe could not determine; ADR 0164): $GUARD_TOUCHING; route to full path"; exit 0
+    fi
+  else
+    echo "review-trivial: not-trivial — §CP state '$CP_STATE'; route to full path (ADR 0053/0065; #4161)"; exit 0
+  fi
+fi
+
+# §DEV: the disclosure section decides triviality too — a disclosed deviation, or a missing heading,
+# routes to the full path. Read the section's body (heading → next heading or EOF) and compare.
+BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
+# `IGNORECASE` is a gawk extension BSD/macOS awk ignores SILENTLY, so a lowercase `## deviations`
+# heading yielded an empty DEV_BODY here while the case-insensitive `grep -i` below still saw the
+# heading — the two halves disagreed about case. Spell the case-insensitivity into the pattern
+# instead (POSIX, portable) so both halves read the same heading.
+DEV_BODY="$(printf '%s\n' "$BODY" \
+  | awk '/^[[:space:]]*###?[[:space:]]*[Dd][Ee][Vv][Ii][Aa][Tt][Ii][Oo][Nn][Ss][[:space:]]*$/{f=1;next} /^[[:space:]]*##?#?[[:space:]]/{f=0} f' \
+  | grep -Ev '^[[:space:]]*$')"
+if ! printf '%s\n' "$BODY" | grep -Eiq '^[[:space:]]*#{2,3}[[:space:]]*Deviations[[:space:]]*$'; then
+  echo "review-trivial: not-trivial — no ## Deviations section, so no None. claim to stand on (§DEV); route to full path, which decides owed-vs-not"; exit 0
+elif [ "$(printf '%s\n' "$DEV_BODY" | grep -c .)" = 1 ] && printf '%s\n' "$DEV_BODY" | grep -Eiqx '[[:space:]]*none\.?[[:space:]]*'; then
+  : # exactly one non-blank line, and it is `None.` — the triviality premise holds, continue Step 0
+else
+  # anything else — a disclosed deviation, OR an empty section (which is not the `None.` claim §DEV
+  # requires) — is outside the lighter gate's bound. Default-deny, exactly like the unreadable
+  # CONTROL_PLANE_RE above: you cannot prove the premise, so you must not treat the diff as trivial.
+  echo "review-trivial: not-trivial — the body discloses a deviation, or its ## Deviations section is empty (§DEV); route to full path"; exit 0
+fi

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh
@@ -1,21 +1,54 @@
+#!/usr/bin/env bash
+# Step 0 — the fail-closed triviality re-affirm: the §CP path/content classification and the §DEV
+# disclosure premise. Extracted from review-trivial/SKILL.md (#4453, epic #4435 phase 1). Extraction
+# contract + shell-option rationale: ../SKILL.md § The extracted scripts. The *why* for each clause
+# stays in that step's prose.
+#
+# STDOUT IS THE ANSWER, AND ITS EMPTY STATE IS THE PERMISSIVE ONE. Any `review-trivial: not-trivial
+# — …` line on stdout means "route to the full path"; EMPTY stdout with exit 0 means the triviality
+# premise held. That inversion is why every could-not-run path here PRINTS a `not-trivial` line
+# BEFORE exiting, and exits non-zero: a classifier that never ran must never reach the caller as
+# silence, which the caller would read as "proven trivial" and under-gate (§ZS / ADR 0092,
+# `.patterns/skill-script-io-contract.md`; #4216, #4161, #4219). Scope + diagnostics go to stderr.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# §CPREAD's `cp_changed_files` + `cp_head_sha`, sourced from their canonical home — no skill-local
+# copy to drift (#4489 extracted them out of ../../gh-issue-intake-formats.md, which is why the moved
+# comment below no longer says "copy them verbatim"). They write on stderr only, so no call site
+# redirects (`.patterns/skill-script-io-contract.md`, #4510).
+# shellcheck source=../../shared/scripts/cp-read.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
+
+[ "$#" -ge 1 ] || {
+  echo "review-trivial: not-trivial — step0-triviality.sh ran with no <pr> argument, so nothing was classified; route to full path"
+  echo "usage: step0-triviality.sh <pr>" >&2; exit 2; }
+PR="$1"
+REPO="$(kp_repo)" || {
+  echo "review-trivial: not-trivial — target repo unresolvable, so §CP could not be classified (UNKNOWN, never 'ordinary'); route to full path"
+  exit 1; }
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-PR=<pr number>
+PCLI="$(kp_pcli)" || {
+  echo "review-trivial: not-trivial — pipeline-cli UNRESOLVED, so cp-classify never ran (UNKNOWN, never 'ordinary'); route to full path"
+  exit 127; }
+
 # The changed-file list is a fallible READ, and an unchecked capture resolved a failed one to "no §CP
 # path touched" (#4216) — at the gate that routes to the LIGHTER path, so a fail-open here UNDER-gates.
-# `cp_changed_files` / `cp_head_sha` are §CPREAD of ../gh-issue-intake-formats.md — copy them verbatim
-# from there (single source; the why lives there, not here).
+# `cp_changed_files` / `cp_head_sha` are §CPREAD, sourced above from ../../shared/scripts/cp-read.sh
+# (single source; the why lives in ../../gh-issue-intake-formats.md, not here).
 if ! cp_changed_files "$REPO" "$PR"; then
-  echo "review-trivial: not-trivial — changed-file list unreadable (§CP UNKNOWN, never 'no §CP path'); route to full path"; exit 0
+  echo "review-trivial: not-trivial — changed-file list unreadable (§CP UNKNOWN, never 'no §CP path'); route to full path"; exit 1
 fi
 FILES="$CP_FILES"; NFILES="$CP_FILES_N"   # proven-arrived; scope already emitted per §ZS #1 (ADR 0092)
-ADD=$(gh api repos/$REPO/pulls/$PR --jq '.additions'); DEL=$(gh api repos/$REPO/pulls/$PR --jq '.deletions')
+ADD=$(gh api repos/"$REPO"/pulls/"$PR" --jq '.additions'); DEL=$(gh api repos/"$REPO"/pulls/"$PR" --jq '.deletions')
+# The size facts feed the verdict's triviality-re-affirm evidence row. They go to STDERR because
+# stdout is the not-trivial channel and an extra line there would read as a hold (the seam the
+# fenced block did not have: it left $NFILES/$ADD/$DEL in the caller's shell, retired by ADR 0232).
+echo "review-trivial scope: $NFILES file(s), +${ADD:-?}/-${DEL:-?}" >&2
 
 # Four states on stdout: control-plane / content-undetermined / not-control-plane / unknown.
 # Only `not-control-plane` is a proven-ordinary answer; every other state is a HOLD.
 CP_STATE="$(printf '%s\n' "$FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
-# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Fail-closed on EVERY value but the proven-ordinary one. The test is a positive match on the
 # STATE WORD, not on the exit status: the exit code discriminates the four states only once the
 # verb has RUN, so a bad flag (exit 1) or a missing binary (exit 127) would fail OPEN through
@@ -25,7 +58,7 @@ if [ "$CP_STATE" != "not-control-plane" ]; then
   if [ "$CP_STATE" = "content-undetermined" ]; then
     cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"   # EMPTY on failure (payload discarded) — §CPREAD
     if [ -z "$HEAD_SHA" ]; then
-      echo "review-trivial: not-trivial — head SHA unreadable, ADR content unprobeable (§CP UNKNOWN); route to full path"; exit 0
+      echo "review-trivial: not-trivial — head SHA unreadable, ADR content unprobeable (§CP UNKNOWN); route to full path"; exit 1
     fi
     # Assert on the probe's STATE WORD, never on its exit status: the exit code discriminates the
     # two verdicts only once the verb has RUN, so `>/dev/null && echo "$adr"` collected NOTHING when
@@ -56,7 +89,8 @@ fi
 
 # §DEV: the disclosure section decides triviality too — a disclosed deviation, or a missing heading,
 # routes to the full path. Read the section's body (heading → next heading or EOF) and compare.
-BODY="$(gh api repos/$REPO/pulls/$PR --jq '.body')"
+BODY="$(gh api repos/"$REPO"/pulls/"$PR" --jq '.body')" || {
+  echo "review-trivial: not-trivial — PR body unreadable, so the §DEV None. premise is unprovable; route to full path"; exit 1; }
 # `IGNORECASE` is a gawk extension BSD/macOS awk ignores SILENTLY, so a lowercase `## deviations`
 # heading yielded an empty DEV_BODY here while the case-insensitive `grep -i` below still saw the
 # heading — the two halves disagreed about case. Spell the case-insensitivity into the pattern

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/verdict-post.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/verdict-post.sh
@@ -1,0 +1,11 @@
+NS=code   # or doc / skill, per the class above — the gate namespace is `review-$NS`
+HEAD_NOW="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
+[ "$HEAD_NOW" = "$HEAD_SHA" ] || { echo "head moved under the verdict — re-review the new head or abort (ADR 0058)"; exit 1; }
+
+# §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+VERDICT_FILE="$(mktemp /tmp/review-trivial-verdict.XXXXXX)"
+# write your composed verdict into "$VERDICT_FILE"; first line is the bare SHA-bound marker:
+#   review-<NS>: PASS @ <HEAD_SHA> — merge-ready          (every check passed)
+#   review-<NS>: FAIL @ <HEAD_SHA> — not merge-ready       (any check failed)
+"$PCLI" verdict post --pr "$PR" --gate "$NS" --body-file "$VERDICT_FILE"

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/verdict-post.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/scripts/verdict-post.sh
@@ -1,11 +1,40 @@
-NS=code   # or doc / skill, per the class above — the gate namespace is `review-$NS`
-HEAD_NOW="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
-[ "$HEAD_NOW" = "$HEAD_SHA" ] || { echo "head moved under the verdict — re-review the new head or abort (ADR 0058)"; exit 1; }
+#!/usr/bin/env bash
+# Step 3 — the §HEAD #4 live-head re-check, then the guarded verdict upsert. Extracted from
+# review-trivial/SKILL.md (#4453, epic #4435 phase 1). Extraction contract + shell-option rationale:
+# ../SKILL.md § The extracted scripts.
+#
+# THE BODY ARRIVES ON STDIN — the declared seam. The fence told the reviewer to "write your composed
+# verdict into $VERDICT_FILE", so the body is authored by the agent and a script can only receive it.
+# Stdin also retires the scratch file entirely, which removes the #2683 class by construction: with
+# no path on disk there is nothing to leak into the marker's `@ <sha>` field.
+#
+# THE NAMESPACE IS AN ARGUMENT, NOT A DEFAULT. The fence's `NS=code` was a placeholder the reviewer
+# had to overwrite per Step 3's artifact-class routing; a default here would silently emit the wrong
+# gate's marker on a doc or skill diff, which is the namespace collapse the skill forbids.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
+[ "$#" -ge 2 ] || { echo "usage: printf '%s' \"\$BODY\" | verdict-post.sh <pr> <code|doc|skill> [reviewed-head-sha]" >&2; exit 2; }
+PR="$1"; NS="$2"; HEAD_SHA="${3:-}"
+case "$NS" in
+  code|doc|skill) ;;
+  *) echo "verdict-post.sh: '$NS' is not a gate namespace — refusing to guess (Step 3 routes by artifact class)." >&2; exit 2 ;;
+esac
+REPO="$(kp_repo)" || exit 1
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
-VERDICT_FILE="$(mktemp /tmp/review-trivial-verdict.XXXXXX)"
-# write your composed verdict into "$VERDICT_FILE"; first line is the bare SHA-bound marker:
+PCLI="$(kp_pcli)" || exit 127
+
+BODY="$(cat)"
+[ -n "$BODY" ] || { echo "verdict-post.sh: EMPTY body on stdin — refusing to post an empty verdict; the PR would read as UNGATED." >&2; exit 1; }
+
+if [ -n "$HEAD_SHA" ]; then
+  HEAD_NOW="$(gh api repos/"$REPO"/pulls/"$PR" --jq .head.sha)" || {
+    echo "verdict-post.sh: live head unreadable — cannot prove the head did not move; refusing to post (ADR 0058)." >&2; exit 1; }
+  [ "$HEAD_NOW" = "$HEAD_SHA" ] || { echo "head moved under the verdict — re-review the new head or abort (ADR 0058)" >&2; exit 1; }
+fi
+
+# The first line of $BODY is the bare SHA-bound marker:
 #   review-<NS>: PASS @ <HEAD_SHA> — merge-ready          (every check passed)
 #   review-<NS>: FAIL @ <HEAD_SHA> — not merge-ready       (any check failed)
-"$PCLI" verdict post --pr "$PR" --gate "$NS" --body-file "$VERDICT_FILE"
+printf '%s' "$BODY" | "$PCLI" verdict post --pr "$PR" --gate "$NS"


### PR DESCRIPTION
Closes #4453

Byte-moves the review-gate tail's fenced shell — `review-skill`, `review-doc`, `review-trivial`
(and re-measures `review-design`, already drained) — into per-skill `scripts/` in ADR 0232's
**executed** shape: literal-path `bash ./claude-plugins/…` invocation, results on stdout,
`set -uo pipefail` (never `-e`), no cleanup `EXIT` trap, shared lib and the shared §CPREAD /
`iso_preflight` / read-back helpers sourced in-script through ADR 0230's canonical column-0
`BASH_SOURCE` idiom.

Split by commit on purpose, so byte-identity is checkable independently of the seams:

| commit | what |
|---|---|
| `09b2c9ae` | the **verbatim** relocation — all 35 new files are byte-identical to the fenced spans they replaced. Not runnable at this commit (no shebang, no options, no arg handling), which is the point |
| `4bd2eadf` | `review-trivial` + `review-skill` seams — every line that had to change |
| `fd569f53` | `review-doc` seams, plus a bash-3.2 parse defect the extraction **exposed** (below) |

## The re-count, against the issue's estimate

The issue estimated **51 blocks / ~471 lines** across four files. Re-counted at base `f66bc054`
with the matcher below, and `review-design` turns out to have been fully drained already by
PR #4485 (which this issue's own progress trail records), so the real payload is the other three:

| file | issue estimate | at base `f66bc054` | at this head |
|---|---|---|---|
| `review-skill/SKILL.md` | 16 / ~137 | 16 / **139** | 15 / **37** |
| `review-doc/SKILL.md` | 17 / ~113 | 20 / **188** | 18 / **58** |
| `review-trivial/SKILL.md` | 5 / ~116 | 7 / **113** | 6 / **16** |
| `review-design/SKILL.md` | 13 / ~105 | 12 / **19** — already drained | 12 / 19 (untouched) |
| **total** | **51 / ~471** | **55 / 459** | **51 / 130** |

Every cell above is a fresh run of the matcher below, per file, at each commit (an earlier round of
this body carried 138 / 53 / 20 / 126 from a differently-tallied pass; the base total was unaffected
because the two ±1s cancelled).

So the estimate was close on **count** and close on **total lines**, but mis-attributed: it
carried ~105 lines for `review-design` that no longer exist, and under-counted `review-doc` by
~75. The **329** payload lines this PR removes (440 → 111 across the three un-drained files) are
the whole of the remaining multi-line glue in those files. The 130 that remain corpus-wide — 111
here plus `review-design`'s untouched 19 — are invocations and their explanatory comments; the
residue audit below enumerates every block the checker still flags.

## The fence matcher (verbatim)

A column-0 `grep '^```'` misses blocks **indented inside list items or blockquotes** (live in this
diff: `review-doc/SKILL.md`'s leak-scan block sits three spaces deep inside a numbered list item),
so the matcher strips a leading `[ \t>]*` before testing the fence. Paste this at the repo root:

The program is inlined here (not written to a file), so the recipe cites no path but repo-relative
ones. Paste it whole at the repo root:

```bash
K=claude-plugins/kampus-pipeline/skills
awk '
{ line = $0; sub(/^[ \t>]*/, "", line) }
line ~ /^```/ {
  if (!inb) {
    lang = line; sub(/^```[ \t]*/, "", lang); sub(/[ \t]*$/, "", lang)
    inb = 1; start = FNR; nlines = 0; curlang = lang
    next
  } else {
    inb = 0
    if (curlang ~ /^(bash|sh|shell|console)$/) {
      printf "%s\t%d\t%d\t%d\t%s\n", FILENAME, start, FNR, nlines, curlang
      tb++; tl += nlines
    }
    next
  }
}
inb { nlines++ }
END { printf "TOTAL_SHELL_BLOCKS=%d TOTAL_SHELL_LINES=%d\n", tb, tl }
' "$K"/review-skill/SKILL.md "$K"/review-doc/SKILL.md \
  "$K"/review-trivial/SKILL.md "$K"/review-design/SKILL.md
```

Columns are `file, open-line, close-line, payload-lines, language`. It counts **every** fenced
shell block, not only multi-line ones; the fourth column is the payload size, so a block with
payload > 1 is the multi-line class. At `f66bc054` it prints `TOTAL_SHELL_BLOCKS=55
TOTAL_SHELL_LINES=459`; at this head, `TOTAL_SHELL_BLOCKS=51 TOTAL_SHELL_LINES=130`.

## Byte-move proof (reviewer-runnable)

Each row hashes the source span **at the base** against the extracted file **at the byte-move
commit**. All 35 match; nothing in `09b2c9ae` differs from the markdown it came out of.

```bash
BASE=f66bc054; MOVE=09b2c9ae; K=claude-plugins/kampus-pipeline/skills
# one example row; the full table is below — <ranges> is the sed expression from the table
git show "$BASE:$K/review-doc/SKILL.md" | sed -n '151,153p;175,204p;220,259p' | shasum -a 256
git show "$MOVE:$K/review-doc/scripts/classify-control-plane.sh"              | shasum -a 256
```

| script | source span at `f66bc054` | span sha256 | file sha256 at `09b2c9ae` | |
|---|---|---|---|---|
| `review-trivial/resolve-repo.sh` | `50p` | `68b527e741c14b24` | `68b527e741c14b24` | OK |
| `review-trivial/step0-triviality.sh` | `93,108p;152,211p` | `e59a2672b6bcc95b` | `e59a2672b6bcc95b` | OK |
| `review-trivial/materialize-head.sh` | `230,248p` | `dfdbc47e45fa6c7e` | `dfdbc47e45fa6c7e` | OK |
| `review-trivial/secret-scan.sh` | `289p` | `9cf2d75a36c0fa51` | `9cf2d75a36c0fa51` | OK |
| `review-trivial/leak-scan.sh` | `307,311p` | `e6680cc9bfdb7c5b` | `e6680cc9bfdb7c5b` | OK |
| `review-trivial/verdict-post.sh` | `363,373p` | `9b7a89e6a89fe7b9` | `9b7a89e6a89fe7b9` | OK |
| `review-skill/materialize-head.sh` | `70,113p` | `d41fcdc767056b74` | `d41fcdc767056b74` | OK |
| `review-skill/resolve-repo.sh` | `159p` | `68b527e741c14b24` | `68b527e741c14b24` | OK |
| `review-skill/classify-control-plane.sh` | `209,258p` | `daeebf944f75a105` | `daeebf944f75a105` | OK |
| `review-skill/pr-context.sh` | `318,319p` | `8aea53eac2ba0b18` | `8aea53eac2ba0b18` | OK |
| `review-skill/linked-issue-timeline.sh` | `326,329p` | `09f8cd47a9e475fc` | `09f8cd47a9e475fc` | OK |
| `review-skill/issue-context.sh` | `342,344p` | `0ee137b991b8336a` | `0ee137b991b8336a` | OK |
| `review-skill/pr-diff.sh` | `360,361p` | `a4756b6db697d64e` | `a4756b6db697d64e` | OK |
| `review-skill/head-env.sh` | `375,377p` | `09205914a579e962` | `09205914a579e962` | OK |
| `review-skill/base-groundtruth.sh` | `389,390p` | `b82ca63535e25ab0` | `b82ca63535e25ab0` | OK |
| `review-skill/teardown-head.sh` | `401p` | `7e0266fcd8e7dcbc` | `7e0266fcd8e7dcbc` | OK |
| `review-skill/current-head.sh` | `626p` | `28474f28d2b1fc2d` | `28474f28d2b1fc2d` | OK |
| `review-skill/verdict-post.sh` | `651,653p;663,669p` | `f69f97b3bf58ad36` | `f69f97b3bf58ad36` | OK |
| `review-skill/verdict-readback.sh` | `865,868p` | `088829e9095da25b` | `088829e9095da25b` | OK |
| `review-doc/resolve-repo.sh` | `110p` | `68b527e741c14b24` | `68b527e741c14b24` | OK |
| `review-doc/classify-control-plane.sh` | `151,153p;175,204p;220,259p` | `cbcc129d2cc2c2e7` | `cbcc129d2cc2c2e7` | OK |
| `review-doc/pr-context.sh` | `323,324p` | `8aea53eac2ba0b18` | `8aea53eac2ba0b18` | OK |
| `review-doc/linked-issue-timeline.sh` | `331,334p` | `09f8cd47a9e475fc` | `09f8cd47a9e475fc` | OK |
| `review-doc/classify-issueless.sh` | `354,360p` | `f15f4204ac0b1aa8` | `f15f4204ac0b1aa8` | OK |
| `review-doc/issue-context.sh` | `387,389p` | `0ee137b991b8336a` | `0ee137b991b8336a` | OK |
| `review-doc/pr-diff.sh` | `420,421p` | `a4756b6db697d64e` | `a4756b6db697d64e` | OK |
| `review-doc/materialize-head.sh` | `431,461p;484,488p` | `d9a98edb7c905b32` | `d9a98edb7c905b32` | OK |
| `review-doc/head-env.sh` | `470,474p` | `e70e76e45154f266` | `e70e76e45154f266` | OK |
| `review-doc/teardown-head.sh` | `489,491p` | `1ddfd95b22586624` | `1ddfd95b22586624` | OK |
| `review-doc/base-groundtruth.sh` | `519,524p` | `773d6a54bda1e38b` | `773d6a54bda1e38b` | OK |
| `review-doc/leak-scan.sh` | `607,611p` | `37ae2b7a48a39ad4` | `37ae2b7a48a39ad4` | OK |
| `review-doc/adr-sweep.sh` | `699,715p` | `5330599429f8602e` | `5330599429f8602e` | OK |
| `review-doc/current-head.sh` | `902p` | `28474f28d2b1fc2d` | `28474f28d2b1fc2d` | OK |
| `review-doc/verdict-post.sh` | `941,948p` | `c502dbf469550938` | `c502dbf469550938` | OK |
| `review-doc/verdict-readback.sh` | `1153,1156p` | `34ab541678879616` | `34ab541678879616` | OK |

Six identical hashes across skills are real, not a bug: `resolve-repo` / `pr-context` /
`linked-issue-timeline` / `issue-context` / `pr-diff` / `current-head` were byte-identical fences
in `review-skill` and `review-doc` to begin with.

The seams, isolated:

```bash
git diff 09b2c9ae 4bd2eadf    # review-trivial + review-skill
git diff 4bd2eadf fd569f53    # review-doc + the bash-3.2 fix
```

## The bash-3.2 defect this EXPOSED (not introduced)

`review-trivial`'s ADR-0164 probe loop lives inside a `GUARD_TOUCHING="$( … )"`. Bash 3.2
balances parens across the **whole substitution body**, including inside comments, so a `case`
pattern's closing `)` terminated the substitution early:

```
step0-triviality.sh: line 76: syntax error near unexpected token `('
```

Reproduced standalone on `GNU bash 3.2.57(1)-release`:

```bash
bash -c 'X="$(printf "a\n" | while read -r r; do case "$r" in *) echo "$r" ;; esac; done)"'
# syntax error near unexpected token `('
bash -c 'X="$(printf "a\n" | while read -r r; do case "$r" in (*) echo "$r" ;; esac; done)"'
# clean
```

Inline in the markdown the block never ran, so this never showed. **CI cannot catch it** — the
runners are bash 5, which parses both shapes; the local interpreter every agent run gets is the
one that decides. Every pattern in that `case` now carries the POSIX leading `(`, the rule is
recorded in the script's header, and all 48 scripts across the four surfaces `bash -n` clean on
3.2.57 (0 failures).

## ADR 0230 source-edge resolution

Every in-script source uses the literal column-0 `BASH_SOURCE` idiom with **no interpolated
directory** — the shape the resolver can see. Measured with `kp_skill_source_edges`, not with CI
(`validate-cycle-absence`'s scope is a hardcoded four-skill array that covers none of these four,
so a green CI would prove nothing here):

| skill | rc | edges resolved |
|---|---|---|
| `review-skill` | 0 | `lib/common.sh`, `shared/scripts/cp-read.sh`, `shared/scripts/verdict-readback.sh` |
| `review-doc` | 0 | `lib/common.sh`, `shared/scripts/cp-read.sh`, `shared/scripts/verdict-readback.sh` |
| `review-trivial` | 0 | `lib/common.sh`, `shared/scripts/iso-preflight.sh`, `shared/scripts/cp-read.sh` |
| `review-design` | 0 | `lib/common.sh`, `shared/scripts/cp-read.sh`, `shared/scripts/verdict-readback.sh` |

**Corpus sweep: 31 skills scanned, 37 edge lines, 0 UNRESOLVED.**

## Runtime smoke (read-only, network reads only)

```bash
bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/resolve-repo.sh
# kamp-us/phoenix   exit 0
bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/current-head.sh 4589
# <this PR's live head, a bare 40-hex sha>   exit 0
bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/classify-control-plane.sh 4589
# BLOCKING (§CP state 'control-plane')   exit 0
bash ./claude-plugins/kampus-pipeline/skills/review-trivial/scripts/step0-triviality.sh 4589
# review-trivial: not-trivial — §CP state 'control-plane'; route to full path   exit 0
```

Each classifier's scope line lands on **stderr** and its answer on **stdout**, per
`.patterns/skill-script-io-contract.md`.

## Residue audit — what check 1 still reds, block by block

**`verify-extraction.sh` check 1 does not count comments.** Its scanner drops them outright —
`if (line == "" || line ~ /^#/) next   # comments and blanks are not glue` — so a red there is
*never* "an invocation plus a comment". It always means the block carries a **second executable
line** beside the invocation the checker recognized. Seven blocks do at this head, and here is
each one, re-derived by running the checker rather than reasoned about:

| block (at this head) | the second executable line | why it stays |
|---|---|---|
| `review-skill:227` | `PR=<pr number>` | operator fill-in — the value the agent substitutes before invoking |
| `review-skill:314` | `ISSUE=<N>` | operator fill-in |
| `review-doc:191` | `PR=<pr number>` | operator fill-in |
| `review-doc:353` | `ISSUE=<N>` | operator fill-in |
| `review-trivial:123` | `PR=<pr number>` | operator fill-in |
| `review-doc:395` | `git show "$PR_REF:<path>"` **and** `git grep -n "<pattern>" "$PR_REF"` | the read-only §HEAD reading idiom the step teaches — placeholder-bearing demo lines, not runnable glue |
| `review-doc:648` | `SWEEP=$?` | captures the preceding invocation's exit code, which *is* the ADR sweep's answer |

Scripting a `PR=<pr number>` placeholder away would remove the seam, not the glue; the two `git`
demo lines and `SWEEP=$?` are each one line of caller-side reading. Whether check 1 should
recognize those three shapes is a question for the checker (#4593's lane), not a reason to rewrite
these blocks. Line numbers drift — re-derive them:

```bash
bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh review-skill review-doc review-trivial
```

## Deviations

1. **The move is 3 commits, not 1** (deliberate, per the byte-move discipline): `09b2c9ae` is
   byte-identical, `4bd2eadf` + `fd569f53` carry every line that had to change. The scripts are
   not runnable at the intermediate commit — no shebang, no options — which is the point of
   splitting them.
2. **Seam: path resolution.** Every `${CLAUDE_PLUGIN_ROOT:-…}/bin/pipeline-cli` interpolation
   becomes `kp_pcli`, and every `${CLAUDE_PIPELINE_REPO:-$(gh repo view …)}` becomes `kp_repo`,
   both from the shared lib. The interpolated fence idiom is retired by ADR 0232.
3. **Seam: inputs.** `$PR` / `$ISSUE` / `$REPO` / `$PR_REF` / `$BASE_REF` used to arrive from the
   agent's shell. Each script now takes what it needs as an argument and resolves the repo through
   `kp_repo`. `PR=<pr number>` and `ISSUE=<N>` placeholder lines stay in the markdown as the
   operator's fill-in.
4. **Seam: the answer channel.** Leave-state-in-the-caller's-shell is retired (ADR 0232), so:
   `review-skill`/`review-doc`'s materialize prints a **run-state handle path** for `. "$( … )"`
   (mirroring the shipped `review-code/scripts/materialize-head.sh`); `review-doc`'s §CP classifier
   prints a handle carrying `CONTROL_PLANE_TOUCHED`/`GUARD_TOUCHING`/`CP_FILES_N`/`ADR_N`;
   `review-trivial`'s Step-0 keeps its **stdout-is-the-hold** contract and routes its size facts
   (`$NFILES`/`$ADD`/`$DEL`) to stderr, because an extra stdout line there would read as a hold.
5. **Two blocks collapsed into one script, twice.** `review-trivial`'s two Step-0 fences shared
   `$CP_STATE`/`$FILES` across a shell that no longer persists, so they became one
   `step0-triviality.sh`; `review-doc`'s two Step-0 fences shared `$CP_READ_FAILED` the same way
   and became one `classify-control-plane.sh`. Each half is still hashed separately in the table
   above, so byte-identity stays checkable per span.
6. **Three verdict-post fences collapsed into one script, in each of `review-skill` and
   `review-doc`.** The PASS / advisory / FAIL fences differed only in the body they told the
   reviewer to compose; the mechanism was identical. The body now arrives on **stdin**, which also
   retires the `mktemp` verdict file — removing the #2683 / #3718 class by construction (no path on
   disk to leak into `@ <sha>`, nothing for a concurrent review to clobber). Matches the shipped
   `review-code/scripts/verdict-emit-*.sh` shape.
7. **Behavioural hardening at four seams, disclosed rather than hidden.** (a)
   `review-trivial/materialize-head.sh` shape-asserts the head SHA before it reaches a `git fetch`
   argument and verifies the ref actually landed — the fence captured `gh pr view` unchecked, and gh
   writes its error document to stdout. (b) `review-trivial/secret-scan.sh` and `leak-scan.sh`
   refuse on an unreadable `$PR_REF` rather than scanning nothing and printing "clean". (c)
   `review-doc/adr-sweep.sh` refuses when `mktemp -d` or the `git show` of the subject fails,
   instead of running the sweep against an empty file. (d) `review-doc/teardown-head.sh` now drops
   the throwaway **ref** as well as the tree — the fence's `git update-ref -d` sat in a different
   block from its `rm -rf` and was easy to skip. All four move a silent-permissive path to a loud
   refusal; none relaxes anything.
8. **`verify-extraction.sh` is red for four reasons, none of them this PR's — do not green them
   mechanically.** (i) **check 1** counts payload lines against recognized invocations, and it
   **excludes comments and blanks** (`if (line == "" || line ~ /^#/) next`) — so a red always means
   a block carries a genuine *second executable line*. An earlier round of this body claimed the
   reds were "an invocation plus one comment"; that premise is false and is withdrawn. The seven
   remaining reds are five `PR=<pr number>` / `ISSUE=<N>` operator fill-ins, `review-doc`'s two-line
   read-only `git show` / `git grep` §HEAD demo, and `review-doc`'s `SWEEP=$?` — enumerated block by
   block in the residue audit above. Check 1 also reds `review-design:308`, a file this PR does not
   touch (#4587, and PR #4585 Deviation 13 routed the AC question to epic #4435). The two check-1
   reds that **were** this PR's — the FAIL-path `HEAD_SHA="$(gh api …)"` left raw in `review-skill`
   and `review-doc` while their PASS-path twins were converted — are fixed in repair round 1 below.
   (ii) **check 9's zero-stdout-on-usage-error rule** contradicts
   the error-channel rule this corpus is built on: these classifiers' *permissive* answer is empty
   stdout, so a usage error MUST print its fail-closed line there; greening it would disarm a live
   gate (#4584). It reds `review-design/scripts/classify-ui-surface.sh` identically — again
   untouched here. (iii) the **`kp_pcli` without `|| exit 127`** rows are the same #4584 class: these
   sites use `|| { echo <fail-closed line>; exit 127; }`, which is strictly stronger, or `|| PCLI=""`
   copied verbatim from the shipped `review-code/scripts/classify-control-plane.sh` (where an empty
   `$PCLI` makes the probe fail and the `*)` arm hold as §CP). (iv) two `review-design` scripts do
   not source `lib/common.sh` — pre-existing, not touched. The **one** row that *was* this PR's was
   fixed: two new diagnostic strings contained a bare `pipeline-cli` token, now reworded; that check
   is green.
9. **Pre-existing defects left alone, as instructed:** `review-design/scripts/classify-control-plane.sh`'s
   `|| CP_STATE=""` (#4582) and the `|| true` in its `classify-ui-surface.sh` (#4493). No file under
   `review-design/` is modified by this PR.
10. **Indentation of the moved lines is preserved as-is** rather than re-tabbed to the sibling
    scripts' style — several spans came out of fences indented inside list items, and re-indenting
    would have broken byte-identity for no behavioural gain.
11. **(repair round 1)** **Rebased onto `origin/main`** before applying the round's fixes, per the
    repair contract's freshen-the-base step. The one intervening commit (`32e66f24`, `heal-ci` only)
    does not overlap this diff, so the replay was clean — but it moves the head, so the push is a
    `--force-with-lease` and every SHA cited above for the three original commits is its pre-rebase
    id. Byte-identity is unaffected (`git range-diff` shows content-identical patches).
12. **(repair round 1)** **The re-count table was corrected against a fresh per-file run of the
    pasted matcher**: base `review-skill` 138 → **139**, base `review-design` 20 → **19** (those two
    cancel, so the base total is still 459), head `review-doc` 53 → **58**, head total 126 → **130**,
    and "the 333 payload lines this PR removes" → **329**. Nothing in the acceptance criteria turns
    on the ±1s; they are corrected because a wrong number in a re-measurement section is what makes
    the next audit re-derive everything.
13. **(repair round 1)** **The resubmit was pushed with an explicit refspec, not
    `pipeline-cli verified-push`.** The PR's head branch was still checked out in the *previous*
    lane's worktree, so this run could not check it out under its own name; `verified-push` can only
    push the branch checked out in `--cwd`, which would have created a second, unrelated remote
    branch. The round therefore pushed `<local branch>:refs/heads/<PR head branch>` with
    `--force-with-lease=<PR head branch>:<the pre-push remote sha>`, then discharged the property
    `verified-push` exists for — *confirm the remote actually moved* — on **two** independent
    surfaces: `git ls-remote` and `GET /repos/{repo}/pulls/4589`, both reading the new head.
    Removing the sibling lane's worktree to route around this was rejected as out of scope.

## Lanes respected

Nothing under `skills/review-code/**` (#4549), `skills/write-code/**` (#4578), `skills/heal-ci/**`
(#4585), `lib/common.sh` or `skills/shared/**` is touched. The diff is exactly
`review-skill/**`, `review-doc/**`, `review-trivial/**` — and **not** `review-design/**`, which
needed no change.

## Checks run locally

`shellcheck -x` (48 scripts, exit 0) · `bash -n` on 48 scripts under bash 3.2.57 (0 failures) ·
`validate-skills.sh` (30 skills) · `validate-gate-path-drift.sh` (34 checks) ·
`validate-cycle-absence.sh` (14 checks) · `validate-cycle-presence.sh` (18 checks) ·
`lib/common-test.sh` · `trap-status-guard check` at CI scope (327 files, clean) ·
`cli-invocation-guard check` at CI scope (327 files, clean) · `adoption-lint check` at CI scope
(clean) · `leak-guard scan` over the changed set (38 files, clean) · `readme-guard check` ·
`kp_skill_source_edges` per skill + a 31-skill corpus sweep (0 unresolved).

Re-run after the repair round, at the current head: `validate-gate-path-drift.sh` (OK — 34 checks) ·
`validate-skills.sh` (OK — 30 skills) · `cli-invocation-guard check` at CI scope (328 files, clean) ·
`trap-status-guard check` at CI scope (328 files, clean) · `leak-guard scan` over the two changed
files (clean) · `bash -n` under `GNU bash 3.2.57(1)-release` on all 35 extracted scripts (0
failures) · `verify-extraction.sh review-skill review-doc review-trivial` — **check 1's flagged
blocks drop 9 → 7**, the two that closed being exactly the two the gate charged. The harness's
top-line count stays `9 error(s)`, because check 1 emits **one row per file** (both files still have
other flagged blocks) and the remaining six rows are the three `kp_pcli`-shape rows and the three
check-9 rows — #4584's lane, deliberately not greened here.

§CP — every file is `claude-plugins/kampus-pipeline/skills/**`, so this banks for a
`@kamp-us/control-plane` approval at head. Not self-approved, not merged by its author.

