### PR TITLE
refactor(pipeline): convert the shared script family to ADR 0232 executed/stdout invocation (#4571)

### DIFF
--- a/.patterns/skill-script-shell-shape.md
+++ b/.patterns/skill-script-shell-shape.md
@@ -84,6 +84,38 @@ them as history, not as a choice on offer:
   [ADR 0230](../.decisions/0230-cycle-validators-follow-the-source-edge.md) follow that source edge
   as before.
 
+## The dual-mode shape — an executed entry over a preserved source edge
+
+A shared script under `skills/shared/scripts/` is reached two ways at once, and ADR 0232 retires only
+one of them. An **agent** invokes it as a top-level command, which must be literal-path execution
+with results on stdout. Another **script** sources it in-chain for the functions or variables it
+defines — the edge ADR 0232 explicitly keeps sanctioned, [ADR 0230](../.decisions/0230-cycle-validators-follow-the-source-edge.md)'s
+validators follow, and `verify-extraction.sh` check 5 requires. Converting such a file to a
+source-hostile executed script orphans its in-script consumers at `rc 127`, which no CI check sees.
+
+So the converted shape is **both**: the file's existing top-level body and function definitions stay
+exactly as they were, and an **executed entry** is added that runs them and prints their results.
+Three rules make it hold:
+
+1. **Two literal guards, `[ "${BASH_SOURCE[0]}" = "$0" ]`** — one near the top applying the shell
+   options, one at the bottom holding the entry. The condition is written out at both sites rather
+   than hidden behind a helper function, because a helper is itself state the sourcing caller
+   inherits.
+2. **`set -uo pipefail` fires in executed mode only.** `set` in a sourced file runs in the *caller's*
+   shell, and several in-chain consumers (`ship-it/scripts/step0-*.sh`) deliberately set no options —
+   applying the options unconditionally would silently change their guards' behaviour, which is
+   exactly the not-a-relay change ADRs [0228](../.decisions/0228-scripts-relay-never-derive.md)/[0229](../.decisions/0229-mechanical-combination-is-relay.md)
+   forbid.
+3. **The in-script `.` line does not move and does not indent.** `kp_skill_source_edges` matches the
+   sourcing idiom anchored at **column 0**; wrapping one in an `if` makes the edge invisible, which
+   narrows a cycle validator's surface in silence, and re-writing one with an interpolated directory
+   makes the whole edge list UNRESOLVED and reds the skill.
+
+The executed entry prints one `NAME=value` line per value the sourced form used to leave in the
+shell (a multi-valued one repeats a singular key — `CP_FILE=<path>` alongside `CP_FILES_N=<n>`), so
+the two modes' answers correspond line for line. It adds no decision logic: it relays what the
+sourced body already computed.
+
 ## Why: the measured matrix
 
 Measured on `GNU bash 3.2.57(1)-release (arm64-apple-darwin23)`. Each script assigns a temp dir,

--- a/.patterns/skill-script-shell-shape.md
+++ b/.patterns/skill-script-shell-shape.md
@@ -95,7 +95,7 @@ source-hostile executed script orphans its in-script consumers at `rc 127`, whic
 
 So the converted shape is **both**: the file's existing top-level body and function definitions stay
 exactly as they were, and an **executed entry** is added that runs them and prints their results.
-Three rules make it hold:
+Four rules make it hold:
 
 1. **Two literal guards, `[ "${BASH_SOURCE[0]}" = "$0" ]`** — one near the top applying the shell
    options, one at the bottom holding the entry. The condition is written out at both sites rather
@@ -110,11 +110,35 @@ Three rules make it hold:
    sourcing idiom anchored at **column 0**; wrapping one in an `if` makes the edge invisible, which
    narrows a cycle validator's surface in silence, and re-writing one with an interpolated directory
    makes the whole edge list UNRESOLVED and reds the skill.
+4. **The entry's exit status is `could I answer`, never `did I find something` — and no `grep` or
+   `while` may set it by accident.** The stdout rule below says what an entry must *print*; this says
+   what it must *return*, and the two are equally load-bearing, because the intake contract's §SHARED
+   tells every reader to *read the exit status first* and treat any non-zero as UNKNOWN. So an entry
+   whose ordinary answer is *nothing found* must still return **0** — and under rule 2's `pipefail`
+   two ordinary shapes silently return 1 instead:
+   - a **filter left inside the pipeline** (`… | grep <pattern> | while …`) leaks `grep`'s no-match
+     exit 1 as the pipeline's status. Capture the filter's output into a variable first, with an
+     explicit `|| true`, then loop over the variable.
+   - an **`&&` loop body** (`while read -r x; do [ -n "$x" ] && printf …; done`) over an *empty*
+     variable makes the failing `[ -n "" ]` the loop's last executed command, so the `while` — and
+     the script — returns 1. Use an `if … fi` body, whose status is 0 when no branch runs.
+
+   Both mis-fire only on the **empty/clean** input, which is exactly the class a
+   populated-input-only recipe cannot see: `cp-guard-adr.sh`, `dev-tier-m.sh` and `cp-read.sh
+   team-roster` each shipped this defect and each returned 1 on its clean answer (#4571). Prove the
+   entry's status against the **empty** input as well as the populated one, or the rule is untested.
 
 The executed entry prints one `NAME=value` line per value the sourced form used to leave in the
 shell (a multi-valued one repeats a singular key — `CP_FILE=<path>` alongside `CP_FILES_N=<n>`), so
 the two modes' answers correspond line for line. It adds no decision logic: it relays what the
 sourced body already computed.
+
+Rule 4's *empty means 0* is not the same as *empty means fine*: whether an empty result is a fact or
+a failed read is the **script's** call, made in its body, and the entry only relays it. `cp-read.sh`
+carries both answers — `changed-files` treats zero files as a failed read (non-zero, nothing on
+stdout) because a PR always changes at least one file, while `team-roster` prints `CP_MEMBERS_N=0` at
+exit 0 because an empty team is a real answer (the ADR-0175 N==0 STOP). The failure rule 4 removes is
+the entry *inventing* a non-zero the body never decided.
 
 ## Why: the measured matrix
 

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -404,16 +404,15 @@ sidestep it — ADR 0072, **never GraphQL**). Every skill that reads, writes, or
   share).
 
 All five are in [`shared/scripts/milestone-rest.sh`](shared/scripts/milestone-rest.sh) (§SHARED),
-one function each:
+
+one subcommand each. Each relays the `gh api` answer straight to stdout:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/milestone-rest.sh"
-kp_milestone_read <N>          # none ⇒ the well-formed default, never a defect to repair
-kp_milestone_catalog           # the existing open milestones — the ONLY legal assignment targets
-kp_milestone_assign <N> <m>    # numeric milestone id, never the title
-kp_milestone_clear <N>         # rare; assignment is the common write
-kp_milestone_issues <m>        # the drain-this-milestone query
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh "$REPO" read <N>          # stdout: the milestone number, or `none` — the well-formed default, never a defect to repair
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh "$REPO" catalog           # stdout: one `#<n>\t<title>` per open milestone — the ONLY legal assignment targets
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh "$REPO" assign <N> <m>    # numeric milestone id, never the title
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh "$REPO" clear <N>         # rare; assignment is the common write
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh "$REPO" issues <m>        # the drain-this-milestone query
 ```
 
 ---
@@ -452,8 +451,8 @@ Every consumer cites **this one canonical probe** — a content read against `$R
 branch (no second copy in any skill):
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cycle-doc-probe.sh"   # §SHARED: leaves $CYCLE_DOC = present | absent
+# stdout: exactly one line, `CYCLE_DOC=present` or `CYCLE_DOC=absent`.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cycle-doc-probe.sh "$REPO"
 ```
 
 A skill operating on a **local working tree** rather than the GitHub API (e.g. an offline
@@ -1250,9 +1249,11 @@ The probe itself lives in [`shared/scripts/cp-guard-adr.sh`](shared/scripts/cp-g
 prints one `BLOCKING (…)` line per guard-touching or unreadable ADR:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cp-read.sh"; cp_changed_files "$REPO" "$PR" || CP_STATE=unknown   # §CPREAD owns the input
-. "$KP_SHARED/cp-guard-adr.sh"                                                 # ADR-0164 content clause
+# stdout: `GUARD_ADR_RE=…` and `HEAD_SHA=…`, then one `BLOCKING (…)` line per finding. Those two
+# NAME= lines are the evidence the probe ran, since its ordinary answer is the ABSENCE of a BLOCKING
+# line — never read empty stdout as "no guard-touching ADR". It makes the §CPREAD changed-file read
+# itself, so a failed read prints BLOCKING and exits non-zero rather than probing nothing.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-guard-adr.sh "$REPO" "$PR"
 ```
 
 A guard-touching ADR classifies **§CP for merge-authority** exactly like a path-§CP file:
@@ -1303,13 +1304,13 @@ site in this file and in every skill that cites it — not merely the ones below
 
 `cp_changed_files` (the file list, setting `CP_FILES` + `CP_FILES_N`) and `cp_head_sha` (the ref, setting
 `CP_HEAD_SHA`) both live in [`shared/scripts/cp-read.sh`](shared/scripts/cp-read.sh) (§SHARED), with the
-`--paginate` + streaming-`--jq` and dead-guard rationale carried in the script's own comments. Consumers
-source it and branch on the **return status**, resolving a failure toward §CP:
+`--paginate` + streaming-`--jq` and dead-guard rationale carried in the script's own comments. Run it
+and branch on the **exit status**, resolving a failure toward §CP:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cp-read.sh"
-if ! cp_changed_files "$REPO" "$PR"; then
+# stdout: `CP_FILES_N=<n>` then one `CP_FILE=<path>` per file. A read that could not execute prints
+# NOTHING on stdout and exits non-zero — so read the status, never the emptiness.
+if ! bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh "$REPO" changed-files "$PR"; then
   CP_STATE=unknown   # the input never arrived ⇒ UNKNOWN ⇒ hold as §CP (never `not-control-plane`)
 fi
 ```
@@ -1344,11 +1345,12 @@ two above in [`shared/scripts/cp-read.sh`](shared/scripts/cp-read.sh) (§SHARED)
 shape-assert rationale in-script:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cp-read.sh"
-cp_team_roster "$ORG"          || CP_ROSTER_STATE=unknown   # NEVER a cardinality, never "the team is empty"
-cp_pr_author "$REPO" "$PR"     || CP_AUTHOR_STATE=unknown   # un-skipping the author would count a self-approval
-cp_team_membership "$ORG" "$L" || CP_MEMBER_STATE=unknown   # 404 is definite; anything else is UNKNOWN
+CPREAD=./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh
+# stdout: `CP_MEMBERS_N=<n>` then one `CP_MEMBER=<login>` per member. `CP_MEMBERS_N=0` at exit 0 is a
+# real answer here — an empty team is a FACT (the ADR-0175 N==0 STOP), unlike an empty file list.
+bash "$CPREAD" "$ORG"  team-roster              || CP_ROSTER_STATE=unknown   # NEVER a cardinality, never "the team is empty"
+bash "$CPREAD" "$REPO" pr-author       "$PR"    || CP_AUTHOR_STATE=unknown   # stdout `CP_PR_AUTHOR=<login>`; un-skipping the author would count a self-approval
+bash "$CPREAD" "$ORG"  team-membership "$L"     || CP_MEMBER_STATE=unknown   # stdout `CP_MEMBERSHIP=<state>|absent`; 404 is definite, anything else is UNKNOWN
 ```
 
 Consumers of these three resolve a failure to **UNKNOWN and stop under a reason line that names the
@@ -1369,12 +1371,14 @@ rather than erroring.
 runs the shared entry point, which cannot hand back a fail-open no:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cp-classify-entry.sh"   # §SHARED: §CPREAD input → cp-classify → $CP_STATE, held on anything but not-control-plane
+# stdout, in order: the §CP scope line, `CP_STATE=<state>`, then `BLOCKING (…)` on every state but
+# `not-control-plane`. Assert on the CP_STATE word — an exit code discriminates outcomes only once
+# the script has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing binary (127).
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-entry.sh "$REPO" "$PR"
 ```
 
-[`shared/scripts/cp-classify-entry.sh`](shared/scripts/cp-classify-entry.sh) leaves `$CP_STATE` in the
-caller's shell and prints `BLOCKING (§CP state '…')` on every value except the one proven-ordinary
+[`shared/scripts/cp-classify-entry.sh`](shared/scripts/cp-classify-entry.sh) prints `CP_STATE=…` and
+`BLOCKING (§CP state '…')` on every value except the one proven-ordinary
 `not-control-plane` — including the empty string a failed invocation yields. It takes its input from
 §CPREAD's `cp_changed_files`, never a bare `gh api … |` pipe: with `pipefail` off, a failed read pipes
 its stdout **error body** into the verb, which sees one non-`.decisions/` "path", matches no §CP clause,
@@ -1563,8 +1567,9 @@ and every path falls through to the doc test). This is the same stance as §CP's
 `CONTROL_PLANE_RE='.'` and `UI_RE`'s fail-closed `has-ui`:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/class-probe-resolve.sh"   # §SHARED: leaves the four live HAS_*_RE in this shell
+# stdout: four lines — HAS_CODE_RE=…, HAS_SKILLS_RE=…, HAS_DOCS_EXCLUDE_RE=…, HAS_DOCS_RE=… — each
+# already carrying the fail-closed default when its live read was unusable.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/class-probe-resolve.sh "$REPO"
 ```
 
 [`shared/scripts/class-probe-resolve.sh`](shared/scripts/class-probe-resolve.sh) makes the single
@@ -1734,13 +1739,13 @@ Step-4 `wt_preflight` (ADR [0172](https://github.com/kamp-us/phoenix/blob/main/.
 #2443/#2446): the **same** `git-dir == common-dir` primary-checkout detection and the **same**
 isolation-expected fork, defined **once here** so the three head-materializing gates
 (`review-code`, `review-trivial`, `ship-it`) share one contract rather than drifting three
-copies apart. Each gate runs it — `iso_preflight <surface> || exit 1` — **before** its first
-head fetch / `git worktree add`:
+copies apart. Each gate runs it **before** its first head fetch / `git worktree add`:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/iso-preflight.sh"        # §SHARED: read-only, git rev-parse only, safe to re-run
-iso_preflight review-code || exit 1    # BEFORE the first head fetch / `git worktree add`
+# Read-only (git rev-parse only), safe to re-run. stdout: the scope line, then `ISO_PREFLIGHT=OK`
+# only when the tree is safe to materialize into; a refusal names itself on stderr and exits 1.
+# The EXIT STATUS is this guard's whole contract — never proceed past a non-zero.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh review-code || exit 1
 ```
 
 [`shared/scripts/iso-preflight.sh`](shared/scripts/iso-preflight.sh) carries the detection and its
@@ -1762,9 +1767,9 @@ documented specialization of this same contract, not a fourth drifting copy.
 
 ---
 
-## SHARED. The extracted shared scripts — one resolution, sourced not pasted (epic #4435)
+## SHARED. The extracted shared scripts — executed by literal path, answers on stdout (epic #4435)
 
-This contract's recipes are **sourced scripts**, not fenced prose an agent re-types. They live under
+This contract's recipes are **scripts you run**, not fenced prose an agent re-types. They live under
 [`shared/scripts/`](shared/scripts/) — inside the skills tree, which `CONTROL_PLANE_RE` and the
 `/claude-plugins/kampus-pipeline/skills/` CODEOWNERS row gate whole, at any depth and any extension,
 so a change to one needs a human approval (#4446, #4458). The cross-script state lib they source,
@@ -1772,25 +1777,39 @@ so a change to one needs a human approval (#4446, #4458). The cross-script state
 skill — and carries its own `^claude-plugins/kampus-pipeline/lib/` branch and CODEOWNERS row, added
 in the same commit as the move (#4484).
 
-**Why sourced rather than fenced.** Each agent shell invocation is a fresh process, so a variable set
+**Why a script rather than a fence.** Each agent shell invocation is a fresh process, so a variable set
 in one fenced block is gone by the next — every recipe that produced `$CP_FILES`, `$GUARD_ADR_RE` or
 `$RUN_SCRATCH` for a *later* block was un-runnable as written, and each agent hand-stitched around it
 differently. A script also runs as **one** permitted command, so the worktree guard never parses its
 internals (#4427). The prose keeps the *why*; the script carries the shell (founder ruling on #4435).
 
-**The one resolution — re-run it per block, exactly like §CLI's `PCLI`.** `$KP_SHARED` is a shell
-variable, so it does not survive between an agent's separate Bash calls; never cache it to a file (§SP):
+**How you invoke one — literal path, results on stdout (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)).**
 
 ```bash
-# §SHARED — resolve the extracted-script dir. Same two tiers as §CLI's shim: $CLAUDE_PLUGIN_ROOT
-# covers a foreign consumer install, the git-toplevel fallback covers this repo from ANY cwd, in the
-# primary checkout AND in an agent worktree.
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/<name>.sh <args…>
 ```
 
-Then `. "$KP_SHARED/<name>.sh"` to get its functions/variables into your shell, or
-`bash "$KP_SHARED/<name>.sh" …` when you only need its stdout. Each script's header states which of the
-two it is and which caller variables it reads.
+Two constraints make that the only shape, and both are the harness's, not this contract's: its
+isolation verifier refuses a `.`/`source` at an agent's top-level command **by any path form**, and it
+refuses the interpolated `"${CLAUDE_PLUGIN_ROOT:-…}/…"` idiom as too complex to verify. So the path is
+written out literally, which hardcodes the in-repo plugin location — the ADR
+[0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-as-config-plugin.md)
+portability trade ADR 0232 accepts and records.
+
+**Read the answer off stdout, and read the exit status first.** Exit 0 means the script produced its
+answer on stdout; any non-zero means it could not, which is UNKNOWN and never the permissive answer
+(§ZS / ADR 0092). Each block below names the lines its script prints. Every value the sourced form
+used to leave in your shell now arrives as a `NAME=value` line, a multi-valued one as a repeated
+singular key (`CP_FILE=<path>` alongside `CP_FILES_N=<n>`); a script whose answer is prose prints its
+§ZS scope line first, so "ran and found nothing" never looks like "never ran".
+
+**In-script sourcing is untouched.** A script sourcing the shared lib or another shared script
+in-chain is unaffected — the verifier judges only *your* top-level command, and ADR
+[0230](https://github.com/kamp-us/phoenix/blob/main/.decisions/0230-cycle-validators-follow-the-source-edge.md)'s
+validators keep following that edge. The shape both modes are written in is
+[`.patterns/skill-script-shell-shape.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-shell-shape.md)
+§ The dual-mode shape.
 
 **What did NOT move, and why.** The nine column-0 boundary canonicals stay in *this* file, at column 0,
 exactly once each: `validate-gate-path-drift.sh` asserts that, and the live gates re-resolve them from
@@ -1867,8 +1886,10 @@ classification — make the refusal explicit, so an unresolved CLI can never be 
 verdict:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/cli-require.sh"   # §SHARED: refuses (127) unless $PCLI resolved — UNKNOWN, never a verdict
+# Pass the shim path the §CLI preamble resolved — an executed child cannot see your unexported $PCLI.
+# stdout: `PCLI=<path>` only when the shim is executable; otherwise nothing on stdout, the three
+# refusal lines on stderr, and exit 127 — UNKNOWN, never a verdict.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cli-require.sh "$PCLI" || exit 127
 ```
 
 This section owns the **call-site resolution** half only. Two adjacent seams own the rest and
@@ -1961,9 +1982,8 @@ Bash call goes in the namespace below, never in that directory.
 Allocation is owned by one tested verb, so a caller **cites it instead of hand-rolling a path**
 (#3718). It prints the absolute directory on stdout and nothing else:
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/scratchpad.sh"                        # §SHARED: the verb path and the no-CLI fallback
-kp_sp_verb "review-doc-$PR" verdict.md || exit 1    # open, then re-derive; $RUN_SCRATCH + $VERDICT
+# open, then re-derive. stdout: `RUN_SCRATCH=<dir>` and `VERDICT=<file>`; nothing on a refusal.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/scratchpad.sh verb "review-doc-$PR" verdict.md || exit 1
 ```
 
 [`shared/scripts/scratchpad.sh`](shared/scripts/scratchpad.sh) keeps the two calls apart because the
@@ -1998,17 +2018,16 @@ signal available, the same run — never one run silently reading another's stat
 The verb ships with `pipeline-cli`. Where it isn't installed (a foreign install, ADR 0062), the
 equivalent recipe below is the fallback. It used to be **inlined at each site** rather than made a
 shell helper, because a helper is itself shell state that does not survive between Bash calls — a
-*sourced script* is a file on disk, not shell state, so the fallback is now a function alongside the
-verb path in the same script (§SHARED, epic #4435). The recipe is unchanged.
+*script* is a file on disk, not shell state, so the fallback is now a subcommand alongside the verb
+path in the same script (§SHARED, epic #4435). The recipe is unchanged.
 
 **Open the run once, re-derive freely afterwards.** The distinction is load-bearing — getting
 it backwards re-creates the empty-directory bug it exists to prevent:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/scratchpad.sh"                          # §SHARED
-kp_sp_open_fallback <slug> || exit 1                  # the run's FIRST write of state — clears leftovers
-kp_sp_path_fallback <slug> <file> || exit 1           # every LATER Bash call — asserts, never creates
+SP=./claude-plugins/kampus-pipeline/skills/shared/scripts/scratchpad.sh   # both print `RUN_SCRATCH=<dir>`
+bash "$SP" open-fallback <slug> || exit 1             # the run's FIRST write of state — clears leftovers
+bash "$SP" path-fallback <slug> <file> || exit 1      # every LATER Bash call — asserts, never creates
 ```
 
 Both fail closed on a missing `$CLAUDE_CODE_SESSION_ID` rather than falling back to a shared path,
@@ -2094,9 +2113,10 @@ form [`lefthook.yml`](https://github.com/kamp-us/phoenix/blob/main/lefthook.yml)
 section is its pipeline-side statement — don't restate the rationale at each call site, point here:
 
 ```sh
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/wl-empty-output.sh"                     # §SHARED
-if kp_wl_all_onclass; then …                          # $FILES non-empty AND the inverted match empty
+# The path list arrives on STDIN. stdout: `WL_ALL_ONCLASS=yes` only when the set is NON-EMPTY and the
+# inverted match captured NOTHING; `WL_ALL_ONCLASS=no` (exit 1) otherwise. Read the printed word —
+# the emptiness of the captured output is the condition, never the exit status of a `grep -v`.
+printf '%s\n' "$FILES" | bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/wl-empty-output.sh
 ```
 
 ---
@@ -2351,10 +2371,9 @@ after the win, before it hands the lane on.**
 The write goes through **one verb** — never a hand-rolled `gh api … /assignees`:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/claim-verbs.sh"   # §SHARED
-kp_claim_assign <N>             # layer one under our own session
-kp_claim_assign <N> <token>     # …or under the threaded delegated token
+CV=./claude-plugins/kampus-pipeline/skills/shared/scripts/claim-verbs.sh   # stdout + exit status are the verb's own
+bash "$CV" assign <N>             # layer one under our own session
+bash "$CV" assign <N> <token>     # …or under the threaded delegated token
 ```
 
 The verb is the enforcement, not the prose: it resolves ownership through the same **default-deny**
@@ -2417,9 +2436,8 @@ A claim is **held for the duration of the work it protects, and given up when th
 done**. The owner performs that release itself:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/claim-verbs.sh"   # §SHARED
-kp_claim_release <N>            # retract our own marker; pass the token as $2 to release a delegated claim
+# retract our own marker; pass the delegated token as the third argument to release a delegated claim
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/claim-verbs.sh release <N>
 ```
 
 **Who calls it, and when.** The run that holds the claim, at its terminus: `write-code` Step 8
@@ -2473,9 +2491,9 @@ be invisible; stranded lanes accumulated silently until a dispatch read `lost` a
 read-only inventory is the surface:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/claim-verbs.sh"   # §SHARED
-kp_claim_status <N>             # every marker: author, authorization, liveness, and the resolved owner
+# stdout: the verb's inventory — every marker with its author, authorization, liveness, and the
+# resolved owner.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/claim-verbs.sh status <N>
 ```
 
 Read it before concluding a lane is stuck. A row with `liveness: dead` is already superseded and
@@ -2544,11 +2562,10 @@ by an audited cleanup, not by a resolution rule — the rules above are untouche
 claim is never a candidate whatever its age:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/claim-verbs.sh"   # §SHARED
-kp_claim_audit                  # every open lane held by an unstamped marker, and which are retirable
-kp_claim_audit <N>              # the cheap single-lane read when a stall is already known
-kp_claim_audit --execute        # retire the retirable ones through `claim release`
+CV=./claude-plugins/kampus-pipeline/skills/shared/scripts/claim-verbs.sh   # stdout is the verb's own report
+bash "$CV" audit                  # every open lane held by an unstamped marker, and which are retirable
+bash "$CV" audit <N>              # the cheap single-lane read when a stall is already known
+bash "$CV" audit --execute        # retire the retirable ones through `claim release`
 ```
 
 Retirement runs through **`claim release` under the marker's own token** — the one retraction
@@ -2863,8 +2880,9 @@ check; it never decides it. Emit the scanned scope (§ZS #1) so a drift that sil
 shows in the run log instead of reading green:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/dev-tier-m.sh"   # §SHARED: leaves $DEV_SUPPRESS + $DEV_TESTCUTS and echoes the scope
+# stdout: the two `deviation-disclosure:` scope lines, then one `DEV_SUPPRESS_LINE=<text>` per
+# class-5 hit and one `DEV_TESTCUT_LINE=<text>` per class-6 hit.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh "$REPO" "$PR"
 ```
 
 [`shared/scripts/dev-tier-m.sh`](shared/scripts/dev-tier-m.sh) carries the section-presence pattern

--- a/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
+++ b/claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md
@@ -360,9 +360,9 @@ on any miss — never a silent pass. This is the single source; each review skil
 prevent):
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/verdict-readback.sh"                                  # §SHARED: both guards, one source
-verdict_readback_guard "$CID" review-code "$HEAD_SHA" || …          # <gate> ∈ review-{code,doc,skill,design}
+# stdout: the `verdict_readback_guard OK: …` line, and nothing at all on a miss — which names its
+# cause on stderr and exits non-zero. <gate> ∈ review-{code,doc,skill,design}.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/verdict-readback.sh "$REPO" guard "$CID" review-code "$HEAD_SHA" || …
 ```
 
 [`scripts/verdict-readback.sh`](scripts/verdict-readback.sh) carries the four checks and
@@ -414,9 +414,9 @@ actually landed for the head, and **hard-fails (non-zero)** on absent / broken /
 or path-leaking marker is a **fatal** error the gate cannot silently pass:
 
 ```bash
-KP_SHARED="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/shared/scripts"
-. "$KP_SHARED/verdict-readback.sh"                                  # §SHARED: the wrapper and the guard it calls
-verdict_post_verify "$PR" review-code "$HEAD_SHA" || exit 1         # UNCONDITIONAL, after ANY post/upsert
+# UNCONDITIONAL, after ANY post/upsert. stdout: the resolution line then `verdict_post_verify OK: …`;
+# a fatal miss prints nothing there, names itself on stderr, and exits non-zero.
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/verdict-readback.sh "$REPO" post-verify "$PR" review-code "$HEAD_SHA" || exit 1
 ```
 
 It resolves the landed verdict from live PR state — **(A)** my SHA-bound or advisory marker comment,

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/claim-verbs.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/claim-verbs.sh
@@ -10,10 +10,17 @@
 # `<token>` -> "$2"). These ARE the verbs, so there is nothing for phase 2 (#1929) to verbify — ADR
 # 0228 keeps them relays: the script passes the verb's answer through, it never re-derives it.
 #
-# Sourced, never executed: it defines functions and sets no shell options, so the caller keeps its own
-# `set -euo pipefail`. No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the
-# script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479). The verbs are
-# default-deny, so their EXIT STATUS is the whole contract: never swallow it.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/claim-verbs.sh \
+#                   <assign|release|status|audit> [<issue>] [<token>|--execute]
+#              stdout ⇒ the verb's own stdout, relayed byte-for-byte; the verb's EXIT STATUS is
+#              relayed too, because these verbs are default-deny and the status is the whole
+#              contract (never swallow it).
+#   SOURCED:   no in-script consumer today; the four functions stay for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
@@ -55,3 +62,13 @@ case "${1:-}" in
 ;;
 esac
 }
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  case "${1-}" in
+    assign)  kp_claim_assign  "${2:?claim-verbs.sh assign: no issue number}" "${3-}" ;;
+    release) kp_claim_release "${2:?claim-verbs.sh release: no issue number}" "${3-}" ;;
+    status)  kp_claim_status  "${2:?claim-verbs.sh status: no issue number}" ;;
+    audit)   kp_claim_audit   "${2-}" ;;
+    *) echo "usage: claim-verbs.sh <assign|release|status|audit> [<issue>] [<token>|--execute]" >&2; exit 2 ;;
+  esac
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/class-probe-resolve.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/class-probe-resolve.sh
@@ -8,14 +8,19 @@
 # so a reviewer can diff it against the deleted block directly. Verbification is phase 2 (#1929,
 # ADR 0228). Do not "improve" it here.
 #
-# SOURCE it (`. class-probe-resolve.sh`) with REPO set: the point is the four HAS_*_RE values it
-# leaves in the caller's shell. It sets no shell options and installs no EXIT trap — under bash 3.2 a
-# cleanup trap's last command becomes the script's status, laundering a `set -u` abort into exit 0
-# (#4476, class #4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/class-probe-resolve.sh <REPO>
+#              stdout ⇒ four lines, `HAS_CODE_RE=…`, `HAS_SKILLS_RE=…`, `HAS_DOCS_EXCLUDE_RE=…`,
+#              `HAS_DOCS_RE=…` — the same four values the sourced form left in the caller's shell.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
 #
 # The canonical HAS_*_RE lines it reads are, and stay, column-0 assignments in the contract itself:
 # `validate-gate-path-drift.sh` asserts each appears there exactly once at column 0, and every live
 # consumer resolves them with `grep '^NAME='` off `origin/main`.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 REPO="${REPO:-${1:?class-probe-resolve.sh: REPO unset and no \$1 — refusing to resolve a boundary from an unnamed repo}}"
 
@@ -44,3 +49,10 @@ HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"
 HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
 HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed: exclude NOTHING ⇒ every path reaches the doc test
 HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed: every path is a doc
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'HAS_CODE_RE=%s\n' "$HAS_CODE_RE"
+  printf 'HAS_SKILLS_RE=%s\n' "$HAS_SKILLS_RE"
+  printf 'HAS_DOCS_EXCLUDE_RE=%s\n' "$HAS_DOCS_EXCLUDE_RE"
+  printf 'HAS_DOCS_RE=%s\n' "$HAS_DOCS_RE"
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cli-require.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cli-require.sh
@@ -7,13 +7,22 @@
 # MECHANICAL MOVE. The moved lines are byte-identical to the fence they came from and sit at column 0.
 # Verbification is phase 2 (#1929, ADR 0228). Do not "improve" it here.
 #
-# SOURCE it (`. cli-require.sh`) from a gate-critical block, after §CLI's `PCLI=` preamble has run —
-# the fence's `exit 127` becomes a `return 127` when sourced, so the caller decides whether an
-# unresolved CLI ends the run or is routed up; either way it is UNKNOWN, never a verdict. Sets no
-# shell options and installs no EXIT trap: under bash 3.2 a cleanup trap's last command becomes the
-# script's exit status, which would launder this very refusal into exit 0 (#4476, class #4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cli-require.sh <pcli-path>
+#              stdout ⇒ one line, `PCLI=<path>`, ONLY when the shim is executable; otherwise nothing
+#              on stdout, the three refusal lines on stderr, and exit 127. The path is an ARGUMENT
+#              because an executed child cannot see a caller's unexported `$PCLI` — a silent empty
+#              read there would refuse every run, which is the wrong kind of fail-closed.
+#   SOURCED:   after §CLI's `PCLI=` preamble; the `exit 127` becomes `return 127`, so the caller
+#              decides whether an unresolved CLI ends the run or is routed up. Either way it is
+#              UNKNOWN, never a verdict.
+# No EXIT trap: under bash 3.2 a cleanup trap's last command becomes the script's exit status,
+# which would launder this very refusal into exit 0 (#4476, class #4479).
 
-: "${PCLI?cli-require.sh: \$PCLI unset — run the §CLI preamble first; an unresolved shim is UNKNOWN, never a verdict}"
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
+
+PCLI="${PCLI-${1-}}"
+: "${PCLI?cli-require.sh: \$PCLI unset and no \$1 — run the §CLI preamble first, or pass the shim path; an unresolved shim is UNKNOWN, never a verdict}"
 
 [ -x "$PCLI" ] || {
   echo "pipeline-cli: UNRESOLVED at '$PCLI' — the CLI never ran, so this gate has NO result." >&2
@@ -21,3 +30,7 @@
   echo "  This is a resolution gap, NOT worktree teardown (teardown = exit 1 ENOENT on a tracked file, then exit 126)." >&2
   return 127 2>/dev/null || exit 127
 }
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'PCLI=%s\n' "$PCLI"
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-entry.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-entry.sh
@@ -9,14 +9,23 @@
 # sourcing seam in this header block, and the §ZS scope line below (#4510). Verbification is phase 2
 # (#1929, ADR 0228). Do not otherwise "improve" it here.
 #
-# SOURCE it (`. cp-classify-entry.sh`) with REPO and PR set: the point of the recipe is the $CP_STATE
-# it leaves in the caller's shell. It sets no shell options and installs no EXIT trap — under bash
-# 3.2 a cleanup trap's last command becomes the script's exit status, laundering a `set -u` abort
-# into exit 0 (#4476, class #4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-entry.sh <REPO> <PR>
+#              stdout is a PROSE answer channel: the §CP scope line, then `CP_STATE=<state>`, then a
+#              `BLOCKING (…)` line on every state but `not-control-plane`. Read the scope line as the
+#              evidence the run happened — the ordinary answer here is the ABSENCE of a BLOCKING
+#              line, so emptiness must never be read as "ordinary".
+#   SOURCED:   no in-script consumer today; the $CP_STATE the body leaves in the caller's shell stays
+#              available for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's exit status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 REPO="${REPO:-${1:?cp-classify-entry.sh: REPO unset and no \$1 — refusing to classify an unnamed repo}}"
 PR="${PR:-${2:?cp-classify-entry.sh: PR unset and no \$2 — refusing to classify an unnamed PR}}"
 # §CPREAD owns cp_changed_files; the fence assumed the reader had already pasted it into the shell.
+# shellcheck source=cp-read.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/cp-read.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
@@ -38,6 +47,7 @@ fi
 # stderr now, so without it stdout would be 0 bytes on the ordinary path
 # (`.patterns/skill-script-io-contract.md`, #4510).
 echo "§CP scope: PR #$PR — ${CP_FILES_N:-0} file(s) scanned, state '$CP_STATE'"
+printf 'CP_STATE=%s\n' "$CP_STATE"   # the positive token, so the executed reader never infers the state from an absence
 if [ "$CP_STATE" = "not-control-plane" ]; then
   : # proven ordinary — the ONLY branch that may skip the §CP hold
 else

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-guard-adr.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-guard-adr.sh
@@ -69,13 +69,22 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   printf 'HEAD_SHA=%s\n' "$HEAD_SHA"
 fi
 [ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable — ADR content unprobeable ⇒ §CP, fail-closed)"
-printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-  [ -z "$adr" ] && continue
-  [ -n "$HEAD_SHA" ] || break
-  # Capture and CHECK, never `|| true`: gh writes its error document to STDOUT, so `|| true` would
-  # leave that JSON in $body, skip the fail-closed branch below, and grep an ERROR DOC for guard
-  # vocabulary (§CPREAD property 2).
-  body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || body=""
-  if [ -z "$body" ]; then echo "BLOCKING ($adr — unreadable at head ⇒ §CP, fail-closed)"
-  elif printf '%s' "$body" | grep -Eiq "$GUARD_ADR_RE"; then echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
+# The probe's ORDINARY answer is a PR that touches no ADR at all — i.e. this filter matching
+# NOTHING. Left inside the pipeline, that no-match exit 1 becomes the pipeline's status under
+# executed mode's `pipefail`, and therefore the script's: §SHARED tells its reader to read the exit
+# status first and treat any non-zero as UNKNOWN, so every clean §CP guard-ADR probe would resolve
+# UNKNOWN. Capture the filter's output first (`|| true`) so no filter status can reach the entry's,
+# and keep the loop body an `if … fi` so an EMPTY list still leaves the loop's status 0
+# (`.patterns/skill-script-shell-shape.md` § The dual-mode shape rule 4). The exit status answers
+# "could I probe", never "did I find something" — the findings are the BLOCKING lines on stdout.
+TOUCHED_ADRS="$(printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' || true)"
+printf '%s\n' "$TOUCHED_ADRS" | while IFS= read -r adr; do
+  if [ -n "$adr" ] && [ -n "$HEAD_SHA" ]; then
+    # Capture and CHECK, never `|| true`: gh writes its error document to STDOUT, so `|| true` would
+    # leave that JSON in $body, skip the fail-closed branch below, and grep an ERROR DOC for guard
+    # vocabulary (§CPREAD property 2).
+    body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || body=""
+    if [ -z "$body" ]; then echo "BLOCKING ($adr — unreadable at head ⇒ §CP, fail-closed)"
+    elif printf '%s' "$body" | grep -Eiq "$GUARD_ADR_RE"; then echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
+  fi
 done

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-guard-adr.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-guard-adr.sh
@@ -8,13 +8,22 @@
 # argument + sourcing seam in this header block. Replacing the glue with `pipeline-cli` verbs is
 # phase 2 (#1929, ADR 0228). Do not "improve" it here.
 #
-# Prints one `BLOCKING (…)` line per §CP finding on stdout, exactly as the fence did; a caller that
-# needs no variables back may run it (`bash cp-guard-adr.sh "$REPO" "$PR"`), and a caller that wants
-# $GUARD_ADR_RE / $HEAD_SHA in its own shell sources it after exporting REPO and PR.
-#
-# NO shell options and NO EXIT trap on purpose: `set -u` plus a cleanup EXIT trap makes the trap's
-# last command the script's status under bash 3.2, converting an unbound-variable abort into exit 0
-# (#4476, class #4479). Failure here is signalled the way the fence signalled it — on stdout.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-guard-adr.sh <REPO> <PR>
+#              stdout is a PROSE answer channel: `GUARD_ADR_RE=…` and `HEAD_SHA=…`, then one
+#              `BLOCKING (…)` line per §CP finding — exactly the lines the fence printed. The two
+#              NAME= lines are the positive evidence the probe ran, since its ordinary answer is the
+#              ABSENCE of a BLOCKING line.
+#              In executed mode the §CPREAD file list cannot be inherited, so this script makes that
+#              read ITSELF via `cp_changed_files` when $CP_FILES is unset. The fail-closed direction
+#              is the sourced one's, unchanged: an unread list is UNKNOWN, so a failed read prints
+#              BLOCKING and exits non-zero rather than probing nothing and finding nothing.
+#   SOURCED:   with REPO, PR and a §CPREAD-populated $CP_FILES already in the caller's shell; that
+#              path still refuses outright on an unset $CP_FILES.
+# NO EXIT trap on purpose: `set -u` plus a cleanup EXIT trap makes the trap's last command the
+# script's status under bash 3.2, converting an unbound-variable abort into exit 0 (#4476, #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 REPO="${REPO:-${1:?cp-guard-adr.sh: REPO unset and no \$1 — refusing to probe an unnamed repo}}"
 PR="${PR:-${2:?cp-guard-adr.sh: PR unset and no \$2 — refusing to probe an unnamed PR}}"
@@ -22,7 +31,11 @@ PR="${PR:-${2:?cp-guard-adr.sh: PR unset and no \$2 — refusing to probe an unn
 # first; sourcing makes that dependency explicit instead of latent — the cross-block defect the
 # extraction exists to fix. $CP_FILES is likewise the caller's, from cp_changed_files: an unset one is
 # an unread list, which is UNKNOWN and must never read as "no §CP path touched" (#4216).
+# shellcheck source=cp-read.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/cp-read.sh"
+if [ "${BASH_SOURCE[0]}" = "$0" ] && [ -z "${CP_FILES+set}" ]; then
+  cp_changed_files "$REPO" "$PR" || { echo "BLOCKING (PR #$PR changed-file list unreadable — the §CP input is UNKNOWN, never 'no §CP path touched')"; exit 1; }
+fi
 : "${CP_FILES?cp-guard-adr.sh: CP_FILES unset — run cp_changed_files (§CPREAD) first; an unread list is UNKNOWN, never 'no §CP path touched'}"
 
 # §CP content clause (ADR 0164): a touched .decisions/** ADR whose CONTENT matches GUARD_ADR_RE is
@@ -51,6 +64,10 @@ if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(accept_re GUARD_ADR_RE "$(printf '%s'
 # The ref and the file list are fallible reads too — both come from §CPREAD (below), so an
 # unreadable head SHA leaves HEAD_SHA EMPTY (payload discarded) rather than holding gh's error body.
 cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'GUARD_ADR_RE=%s\n' "$GUARD_ADR_RE"
+  printf 'HEAD_SHA=%s\n' "$HEAD_SHA"
+fi
 [ -n "$HEAD_SHA" ] || echo "BLOCKING (head SHA unreadable — ADR content unprobeable ⇒ §CP, fail-closed)"
 printf '%s\n' "$CP_FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
   [ -z "$adr" ] && continue

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh
@@ -7,9 +7,26 @@
 # below — replacing glue with `pipeline-cli` verbs is phase 2 (#1929, ADR 0228: a script may RELAY a
 # verb's answer, never DERIVE the decision). Do not otherwise "improve" it here.
 #
-# Sourced, never executed: it defines functions and sets no shell options, so the sourcing caller
-# keeps its own `set -euo pipefail`. No EXIT trap — under bash 3.2 a cleanup trap's last command
-# becomes the script's status, which converts a `set -u` abort into exit 0 (#4476/#4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh <REPO|ORG> \
+#                   <changed-files|head-sha|team-roster|pr-author|team-membership> <PR|login>
+#              stdout ⇒ one `NAME=value` line per value the matching function sets, the multi-valued
+#              ones as a repeated singular key:
+#                changed-files    CP_FILES_N=<n>  then one CP_FILE=<path> per file
+#                head-sha         CP_HEAD_SHA=<40-hex>
+#                team-roster      CP_MEMBERS_N=<n>  then one CP_MEMBER=<login> per member
+#                pr-author        CP_PR_AUTHOR=<login>
+#                team-membership  CP_MEMBERSHIP=<state>|absent
+#              A read that could not execute prints NOTHING on stdout and exits non-zero — UNKNOWN,
+#              never "no control-plane path touched".
+#   SOURCED:   the sanctioned in-script edge, and the reason the functions below are untouched. Six
+#              scripts source this file for them: review-code/ and review-design/
+#              scripts/classify-control-plane.sh, ship-it/scripts/step0-classify.sh and
+#              step0-cp-approval.sh, and this directory's cp-classify-entry.sh and cp-guard-adr.sh.
+#              The three ship-it ones set NO shell options by design, which is why the options above
+#              are applied in executed mode only.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status, which
+# converts a `set -u` abort into exit 0 (#4476/#4479).
 #
 # OUTPUT CHANNEL — every function here writes on STDERR ONLY. The rule and its why are
 # `.patterns/skill-script-io-contract.md`; the instance is that these are sourced helpers whose
@@ -17,6 +34,8 @@
 # the caller wants and a line printed there can only corrupt the caller's own answer. It did: the
 # §ZS scope line used to land on stdout, and a consumer whose stdout is a machine channel sourced
 # that sentence as a path (#4510). No call site needs a `>&2` — if one appears, the helper is wrong.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 # §CPREAD — the ONE hardened read of a PR's changed-file list, the input to BOTH §CP clauses.
 # Sets CP_FILES (the list) + CP_FILES_N (the scanned count); returns NON-ZERO on a read that could
@@ -122,3 +141,43 @@ cp_team_membership() {   # $1 = ORG, $2 = login; sets CP_MEMBERSHIP = <state>|ab
       return 1 ;;
   esac
 }
+
+# The ADR-0232 executed entry. It RELAYS each function's result onto stdout and its status onto the
+# exit code; it adds no branch of its own, so the executed and sourced answers cannot diverge.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  _target="${1:?cp-read.sh: no <REPO|ORG> argument — refusing to read against an unnamed target}"
+  case "${2-}" in
+    changed-files)
+      cp_changed_files "$_target" "${3:?cp-read.sh changed-files: no PR number}" || exit 1
+      printf 'CP_FILES_N=%s\n' "$CP_FILES_N"
+      printf '%s\n' "$CP_FILES" | while IFS= read -r _f; do
+        [ -n "$_f" ] && printf 'CP_FILE=%s\n' "$_f"
+      done
+      ;;
+    head-sha)
+      cp_head_sha "$_target" "${3:?cp-read.sh head-sha: no PR number}" || exit 1
+      printf 'CP_HEAD_SHA=%s\n' "$CP_HEAD_SHA"
+      ;;
+    team-roster)
+      # Zero members is a FACT here, not a failed read (the ADR-0175 N==0 STOP), so this branch
+      # legitimately prints `CP_MEMBERS_N=0` and no CP_MEMBER lines at exit 0 — the asymmetry with
+      # changed-files above is deliberate (`.patterns/skill-script-io-contract.md`).
+      cp_team_roster "$_target" || exit 1
+      printf 'CP_MEMBERS_N=%s\n' "$CP_MEMBERS_N"
+      printf '%s\n' "$CP_MEMBERS" | while IFS= read -r _m; do
+        [ -n "$_m" ] && printf 'CP_MEMBER=%s\n' "$_m"
+      done
+      ;;
+    pr-author)
+      cp_pr_author "$_target" "${3:?cp-read.sh pr-author: no PR number}" || exit 1
+      printf 'CP_PR_AUTHOR=%s\n' "$CP_PR_AUTHOR"
+      ;;
+    team-membership)
+      cp_team_membership "$_target" "${3:?cp-read.sh team-membership: no login}" || exit 1
+      printf 'CP_MEMBERSHIP=%s\n' "$CP_MEMBERSHIP"
+      ;;
+    *)
+      echo "usage: cp-read.sh <REPO|ORG> <changed-files|head-sha|team-roster|pr-author|team-membership> <PR|login>" >&2
+      exit 2 ;;
+  esac
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh
@@ -19,12 +19,12 @@
 #                team-membership  CP_MEMBERSHIP=<state>|absent
 #              A read that could not execute prints NOTHING on stdout and exits non-zero — UNKNOWN,
 #              never "no control-plane path touched".
-#   SOURCED:   the sanctioned in-script edge, and the reason the functions below are untouched. Six
+#   SOURCED:   the sanctioned in-script edge, and the reason the functions below are untouched. SEVEN
 #              scripts source this file for them: review-code/ and review-design/
 #              scripts/classify-control-plane.sh, ship-it/scripts/step0-classify.sh and
-#              step0-cp-approval.sh, and this directory's cp-classify-entry.sh and cp-guard-adr.sh.
-#              The three ship-it ones set NO shell options by design, which is why the options above
-#              are applied in executed mode only.
+#              step0-cp-approval.sh, heal-ci/scripts/active-repair.sh, and this directory's
+#              cp-classify-entry.sh and cp-guard-adr.sh. The three ship-it ones set NO shell options
+#              by design, which is why the options above are applied in executed mode only.
 # No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status, which
 # converts a `set -u` abort into exit 0 (#4476/#4479).
 #
@@ -144,6 +144,12 @@ cp_team_membership() {   # $1 = ORG, $2 = login; sets CP_MEMBERSHIP = <state>|ab
 
 # The ADR-0232 executed entry. It RELAYS each function's result onto stdout and its status onto the
 # exit code; it adds no branch of its own, so the executed and sourced answers cannot diverge.
+#
+# EVERY relay loop below uses an `if … fi` body rather than `[ -n "$x" ] && printf …`. That is a
+# correctness requirement, not a style call: with an EMPTY variable the `[ -n "" ]` test is the
+# loop's last executed command, so the `while` — and the script — returns 1 on the very answer the
+# read succeeded at, and §SHARED's "read the exit status first, non-zero is UNKNOWN" rule then makes
+# a clean read unreadable. `.patterns/skill-script-shell-shape.md` § The dual-mode shape rule 4.
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   _target="${1:?cp-read.sh: no <REPO|ORG> argument — refusing to read against an unnamed target}"
   case "${2-}" in
@@ -151,7 +157,7 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
       cp_changed_files "$_target" "${3:?cp-read.sh changed-files: no PR number}" || exit 1
       printf 'CP_FILES_N=%s\n' "$CP_FILES_N"
       printf '%s\n' "$CP_FILES" | while IFS= read -r _f; do
-        [ -n "$_f" ] && printf 'CP_FILE=%s\n' "$_f"
+        if [ -n "$_f" ]; then printf 'CP_FILE=%s\n' "$_f"; fi
       done
       ;;
     head-sha)
@@ -161,11 +167,13 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
     team-roster)
       # Zero members is a FACT here, not a failed read (the ADR-0175 N==0 STOP), so this branch
       # legitimately prints `CP_MEMBERS_N=0` and no CP_MEMBER lines at exit 0 — the asymmetry with
-      # changed-files above is deliberate (`.patterns/skill-script-io-contract.md`).
+      # changed-files above is deliberate (`.patterns/skill-script-io-contract.md`). That asymmetry
+      # is exactly what the `if … fi` loop body preserves: an `&&` body would return 1 at N==0 and
+      # collapse this branch back onto the failed-read one it is defined against (#4571 repair r1).
       cp_team_roster "$_target" || exit 1
       printf 'CP_MEMBERS_N=%s\n' "$CP_MEMBERS_N"
       printf '%s\n' "$CP_MEMBERS" | while IFS= read -r _m; do
-        [ -n "$_m" ] && printf 'CP_MEMBER=%s\n' "$_m"
+        if [ -n "$_m" ]; then printf 'CP_MEMBER=%s\n' "$_m"; fi
       done
       ;;
     pr-author)

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/cycle-doc-probe.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/cycle-doc-probe.sh
@@ -7,11 +7,18 @@
 # MECHANICAL MOVE. Every moved line is byte-identical to the fence it came from and sits at column 0.
 # Verbification is phase 2 (#1929, ADR 0228). Do not "improve" it here.
 #
-# SOURCE it (`. cycle-doc-probe.sh`) with REPO set: the point is the $CYCLE_DOC it leaves in the
-# caller's shell. Sets no shell options and installs no EXIT trap (#4476, class #4479).
+# DUAL-MODE (ADR 0232) — `.patterns/skill-script-shell-shape.md` § The dual-mode shape carries the
+# why for the whole family; only this file's two contracts are restated here.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cycle-doc-probe.sh <REPO>
+#              stdout ⇒ exactly one line, `CYCLE_DOC=present` or `CYCLE_DOC=absent`.
+#   SOURCED:   the sanctioned in-script edge — `plan-epic/scripts/cycle-doc-probe.sh` sources this
+#              file for the $CYCLE_DOC it leaves in that script's shell. Unchanged.
+# No EXIT trap (#4476, class #4479).
 #
 # A skill operating on a LOCAL WORKING TREE rather than the API may substitute the equivalent
 # `test -f product-development-cycle.md` at the repo root; both must treat absent ⇒ no-op.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 REPO="${REPO:-${1:?cycle-doc-probe.sh: REPO unset and no \$1 — refusing to probe an unnamed repo}}"
 
@@ -20,4 +27,8 @@ if gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev
   CYCLE_DOC=present   # consult it for the containment policy
 else
   CYCLE_DOC=absent    # no-op: no marker, no dark-ship, no release queue
+fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'CYCLE_DOC=%s\n' "$CYCLE_DOC"
 fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh
@@ -49,11 +49,17 @@ DEV_TESTCUTS="$(gh pr diff "$PR" | awk '
   t && /^-[^-]/ && /expect\(|assert|toBe|toEqual|toThrow/ { print }')"
 echo "deviation-disclosure: Tier-M scan — $(printf '%s' "$DEV_SUPPRESS" | grep -c .) suppression/skip line(s), $(printf '%s' "$DEV_TESTCUTS" | grep -c .) removed-assertion line(s)"
 
+# A CLEAN scan — zero suppression and zero removed-assertion hits — is this scan's ORDINARY answer,
+# and it must arrive at exit 0: §SHARED tells its reader to read the exit status first and treat any
+# non-zero as UNKNOWN, so a clean scan returning 1 makes every green PR unreadable. Hence the
+# `if … fi` bodies: with both variables empty the `[ -n "" ]` of an `&&` body would be each loop's
+# last command, and the second loop's status is the script's
+# (`.patterns/skill-script-shell-shape.md` § The dual-mode shape rule 4).
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   printf '%s\n' "$DEV_SUPPRESS" | while IFS= read -r _l; do
-    [ -n "$_l" ] && printf 'DEV_SUPPRESS_LINE=%s\n' "$_l"
+    if [ -n "$_l" ]; then printf 'DEV_SUPPRESS_LINE=%s\n' "$_l"; fi
   done
   printf '%s\n' "$DEV_TESTCUTS" | while IFS= read -r _l; do
-    [ -n "$_l" ] && printf 'DEV_TESTCUT_LINE=%s\n' "$_l"
+    if [ -n "$_l" ]; then printf 'DEV_TESTCUT_LINE=%s\n' "$_l"; fi
   done
 fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh
@@ -7,10 +7,18 @@
 # MECHANICAL MOVE. Every moved line is byte-identical to the fence it came from and sits at column 0.
 # Verbification is phase 2 (#1929, ADR 0228). Do not "improve" it here.
 #
-# SOURCE it (`. dev-tier-m.sh`) with REPO and PR set: the point is $DEV_SUPPRESS / $DEV_TESTCUTS in the
-# caller's shell, plus the two scope lines it echoes (§ZS #1 — emit the scanned scope so a drift that
-# silently stops matching shows in the run log instead of reading green). Sets no shell options and
-# installs no EXIT trap (#4476, class #4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh <REPO> <PR>
+#              stdout ⇒ the two scope lines the body already echoes (§ZS #1 — emit the scanned scope
+#              so a drift that silently stops matching shows in the run log instead of reading
+#              green), then one `DEV_SUPPRESS_LINE=<text>` per class-5 hit and one
+#              `DEV_TESTCUT_LINE=<text>` per class-6 hit — the contents of the two variables the
+#              sourced form left in the caller's shell. This scan ARMS the check and never decides
+#              it: a hit is a line to judge against the disclosure, not a FAIL.
+#   SOURCED:   no in-script consumer today; $DEV_SUPPRESS / $DEV_TESTCUTS stay available for one.
+# No EXIT trap (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 REPO="${REPO:-${1:?dev-tier-m.sh: REPO unset and no \$1 — refusing to scan an unnamed repo}}"
 PR="${PR:-${2:?dev-tier-m.sh: PR unset and no \$2 — refusing to scan an unnamed PR}}"
@@ -40,3 +48,12 @@ DEV_TESTCUTS="$(gh pr diff "$PR" | awk '
   /^\+\+\+ / { t = ((($0 ~ /^\+\+\+ b\//) ? $0 : p) ~ /(\.|\/)(test|spec)\.[a-z]+$|\/(__tests__|test|tests)\//) ; next }
   t && /^-[^-]/ && /expect\(|assert|toBe|toEqual|toThrow/ { print }')"
 echo "deviation-disclosure: Tier-M scan — $(printf '%s' "$DEV_SUPPRESS" | grep -c .) suppression/skip line(s), $(printf '%s' "$DEV_TESTCUTS" | grep -c .) removed-assertion line(s)"
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf '%s\n' "$DEV_SUPPRESS" | while IFS= read -r _l; do
+    [ -n "$_l" ] && printf 'DEV_SUPPRESS_LINE=%s\n' "$_l"
+  done
+  printf '%s\n' "$DEV_TESTCUTS" | while IFS= read -r _l; do
+    [ -n "$_l" ] && printf 'DEV_TESTCUT_LINE=%s\n' "$_l"
+  done
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh
@@ -8,10 +8,18 @@
 # so a reviewer can diff it against the deleted block directly. Verbification is phase 2 (#1929,
 # ADR 0228). Do not "improve" it here.
 #
-# Sourced, never executed: it defines one function and sets no shell options, so the caller keeps its
-# own `set -euo pipefail`. No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the
-# script's status, laundering a `set -u` abort into exit 0 (#4476, class #4479); this guard's whole
-# contract is its EXIT STATUS, so that laundering would silently disarm it.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh <surface>
+#              stdout ⇒ the function's own scope line, then `ISO_PREFLIGHT=OK`; on a refusal the
+#              LOUD ROUTED BLOCKER lines go to stderr, stdout carries no `ISO_PREFLIGHT=OK`, and the
+#              exit status is 1. This guard's whole contract is that status — read it first.
+#   SOURCED:   the sanctioned in-script edge — `review-code/scripts/materialize-head.sh` and
+#              `ship-it/scripts/step0-preflight.sh` source this file for `iso_preflight`. Unchanged,
+#              including which stream each of its lines lands on.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479), which would silently disarm it.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 # iso_preflight <surface>: the shared primary-checkout fail-closed guard every head-materializing
 # gate runs BEFORE its first head fetch / `git worktree add` (§RO). Reviewer/shipper sibling of
@@ -57,3 +65,15 @@ iso_preflight() {
     echo "$surface iso_preflight: standalone run on the primary checkout — proceeding read-only via the §RO throwaway-worktree / per-run-ref materialization (the launched tree is never mutated)." >&2
   fi
 }
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  # The function reads $CLAUDE_CODE_AGENT and $WORKTREE_ROOT UNDEFAULTED, so under this mode's
+  # `set -u` an unset one aborts before the guard can answer at all. Bind each to its own current
+  # value — empty when unset — so the executed form evaluates exactly the branches a no-options
+  # sourced caller gets. The body stays untouched: the undefaulted reads under a sourced `set -u`
+  # caller are a separate pre-existing defect, filed rather than fixed from here.
+  CLAUDE_CODE_AGENT="${CLAUDE_CODE_AGENT-}"
+  WORKTREE_ROOT="${WORKTREE_ROOT-}"
+  iso_preflight "${1:?iso-preflight.sh: no <surface> argument — refusing to run an unnamed preflight}" || exit 1
+  echo "ISO_PREFLIGHT=OK"
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh
@@ -9,9 +9,18 @@
 # milestone argument) — the one seam a non-runnable placeholder recipe needs to become runnable.
 # Verbification is phase 2 (#1929, ADR 0228). Do not "improve" it here.
 #
-# Sourced, never executed: it defines functions and sets no shell options, so the caller keeps its own
-# `set -euo pipefail`. Reads $REPO from the caller. No EXIT trap — under bash 3.2 a cleanup trap's
-# last command becomes the script's status, laundering a `set -u` abort into exit 0 (#4476, #4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/milestone-rest.sh \
+#                   <REPO> <read|catalog|assign|clear|issues> [<issue>] [<milestone>]
+#              stdout ⇒ the `gh api` answer, relayed byte-for-byte (a bare milestone number or the
+#              literal `none` for `read`; the `#<n>\t<title>` catalog rows; the raw REST payload for
+#              `assign`/`clear`/`issues`), and the same exit status.
+#   SOURCED:   no in-script consumer today; the five functions stay for one, reading $REPO from the
+#              caller exactly as before.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 # read an issue's milestone (none ⇒ the well-formed default, never a defect to repair)
 kp_milestone_read() {   # $1 = issue number
@@ -33,3 +42,15 @@ gh api -X PATCH repos/$REPO/issues/"$1" -F milestone=null
 kp_milestone_issues() {   # $1 = milestone number
 gh api "repos/$REPO/issues?state=open&milestone=$1&per_page=100"
 }
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  REPO="${REPO:-${1:?milestone-rest.sh: REPO unset and no \$1 — refusing to read milestones from an unnamed repo}}"
+  case "${2-}" in
+    read)    kp_milestone_read    "${3:?milestone-rest.sh read: no issue number}" ;;
+    catalog) kp_milestone_catalog ;;
+    assign)  kp_milestone_assign  "${3:?milestone-rest.sh assign: no issue number}" "${4:?milestone-rest.sh assign: no milestone number}" ;;
+    clear)   kp_milestone_clear   "${3:?milestone-rest.sh clear: no issue number}" ;;
+    issues)  kp_milestone_issues  "${3:?milestone-rest.sh issues: no milestone number}" ;;
+    *) echo "usage: milestone-rest.sh <REPO> <read|catalog|assign|clear|issues> [<issue>] [<milestone>]" >&2; exit 2 ;;
+  esac
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/scratchpad.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/scratchpad.sh
@@ -8,8 +8,13 @@
 # metavariables bound to positional parameters in the no-CLI fallback (`<slug>` -> "$1",
 # `<file>` -> "$2"). Verbification is phase 2 (#1929, ADR 0228). Do not "improve" it here.
 #
-# SOURCE it (`. scratchpad.sh`) — the point is the $RUN_SCRATCH it leaves in the caller's shell. Sets
-# no shell options and installs no EXIT trap: under bash 3.2 a cleanup trap's last command becomes the
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/scratchpad.sh \
+#                   <verb|open-fallback|path-fallback> <slug> [<leaf-file>]
+#              stdout ⇒ `RUN_SCRATCH=<dir>`, plus `VERDICT=<file>` for the `verb` form — the same
+#              values the sourced form left in the caller's shell. Nothing on stdout on failure.
+#   SOURCED:   no in-script consumer today; the three functions stay for one.
+# No EXIT trap: under bash 3.2 a cleanup trap's last command becomes the
 # script's status, which would launder a `set -u` abort — or the fail-closed session-id refusal below
 # — into exit 0 (#4476, class #4479).
 #
@@ -18,6 +23,8 @@
 # shell state that doesn't survive between Bash calls." A SOURCED script is not shell state — it is a
 # file on disk — so the fallback is a function here. That is the extraction's whole point (#4435), not
 # a change to the recipe, which is byte-identical below.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 # --- The verb: allocation is owned by one tested verb, so a caller cites it ------------------------
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
@@ -55,3 +62,22 @@ kp_sp_path_fallback() {   # $1 = slug, $2 = leaf file name whose survival is ass
 RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/$1"
 [ -s "$RUN_SCRATCH/$2" ] || { echo "§SP: $RUN_SCRATCH/$2 did not survive — re-run the opening step in THIS session." >&2; return 1; }
 }
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  case "${1-}" in
+    verb)
+      kp_sp_verb "${2:?scratchpad.sh verb: no slug}" "${3:?scratchpad.sh verb: no leaf file name}" || exit 1
+      printf 'RUN_SCRATCH=%s\n' "$RUN_SCRATCH"
+      printf 'VERDICT=%s\n' "$VERDICT"
+      ;;
+    open-fallback)
+      kp_sp_open_fallback "${2:?scratchpad.sh open-fallback: no slug}" || exit 1
+      printf 'RUN_SCRATCH=%s\n' "$RUN_SCRATCH"
+      ;;
+    path-fallback)
+      kp_sp_path_fallback "${2:?scratchpad.sh path-fallback: no slug}" "${3:?scratchpad.sh path-fallback: no leaf file name}" || exit 1
+      printf 'RUN_SCRATCH=%s\n' "$RUN_SCRATCH"
+      ;;
+    *) echo "usage: scratchpad.sh <verb|open-fallback|path-fallback> <slug> [<leaf-file>]" >&2; exit 2 ;;
+  esac
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/verdict-readback.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/verdict-readback.sh
@@ -9,13 +9,24 @@
 # so a reviewer can diff it against the deleted blocks directly. Verbification is phase 2 (#1929,
 # ADR 0228: a script may RELAY a verb's answer, never DERIVE the decision). Do not "improve" it here.
 #
-# Sourced, never executed: it defines two functions and sets no shell options, so the caller keeps its
-# own `set -euo pipefail`. No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the
-# script's status, which launders a `set -u` abort into exit 0 (#4476, class #4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/verdict-readback.sh \
+#                   <REPO> guard <comment-id> <gate> <head-sha>
+#                   <REPO> post-verify <PR> <gate> <head-sha>
+#              stdout ⇒ the chosen guard's own lines, relayed unchanged — the `… OK: …` line on a
+#              proven-clean verdict, nothing on a refusal (which names itself on stderr). The EXIT
+#              STATUS is the verdict: 0 only for a landed, well-formed, leak-free marker.
+#   SOURCED:   the sanctioned in-script edge — `review-code/scripts/verdict-readback.sh` and
+#              `review-design/scripts/verdict-readback.sh` source this file for the two functions,
+#              which read $REPO from their caller exactly as the fences did. Unchanged.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status, which
+# launders a `set -u` abort into exit 0 (#4476, class #4479).
 #
-# Reads $REPO from the caller, exactly as the fences did. The local-path patterns in checks (3)/(E)
+# The local-path patterns in checks (3)/(E)
 # are PLACEHOLDERS the guard matches against a comment body — never real paths, so this file, like the
 # contract it came from, stays leak-clean.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 # verdict_readback_guard <comment-id> <gate> <head-sha>: re-read the just-posted verdict comment
 # and PROVE it is a well-formed, leak-free, current-head-bound marker. FAIL LOUD (non-zero) on any
@@ -135,3 +146,18 @@ verdict_post_verify() {
 
   echo "verdict_post_verify OK: ${gate} verdict @ ${sha:0:7} landed clean on PR #$PR (comment=${cid:-none} native-approve=${approved:-0}) — present, well-formed, leak-free."
 }
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  REPO="${REPO:-${1:?verdict-readback.sh: REPO unset and no \$1 — refusing to re-read a verdict from an unnamed repo}}"
+  case "${2-}" in
+    guard)
+      verdict_readback_guard "${3:?verdict-readback.sh guard: no comment id}" \
+                             "${4:?verdict-readback.sh guard: no gate}" \
+                             "${5:?verdict-readback.sh guard: no head sha}" ;;
+    post-verify)
+      verdict_post_verify "${3:?verdict-readback.sh post-verify: no PR number}" \
+                          "${4:?verdict-readback.sh post-verify: no gate}" \
+                          "${5:?verdict-readback.sh post-verify: no head sha}" ;;
+    *) echo "usage: verdict-readback.sh <REPO> <guard <comment-id>|post-verify <PR>> <gate> <head-sha>" >&2; exit 2 ;;
+  esac
+fi

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/wl-empty-output.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/wl-empty-output.sh
@@ -10,9 +10,17 @@
 # predicate is a runnable, shellcheck-able function instead of a syntactically incomplete fragment.
 # Verbification is phase 2 (#1929, ADR 0228). Do not "improve" it here.
 #
-# Sourced, never executed: it defines one function and sets no shell options, so the caller keeps its
-# own `set -euo pipefail`. No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the
-# script's status, and this predicate's whole contract is its exit status (#4476, class #4479).
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  <path-list> | bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/wl-empty-output.sh
+#              The changed-path list arrives on STDIN, because an executed child cannot see the
+#              caller's unexported $FILES. stdout ⇒ one line, `WL_ALL_ONCLASS=yes` or
+#              `WL_ALL_ONCLASS=no`; the exit status matches (0 / 1), so a caller may read either.
+#   SOURCED:   the sanctioned in-script edge — `review-code/scripts/classify-skills-only.sh` sources
+#              this file for `kp_wl_all_onclass`, which reads that script's own $FILES. Unchanged.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status, and this
+# predicate's whole contract is its exit status (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 
 # "every changed path is under skills/ or agents/" — the empty-output form. Reads $FILES; returns 0
 # only when the set is NON-EMPTY and the inverted match captured NOTHING. Emptiness of the captured
@@ -23,3 +31,8 @@ OFFCLASS=$(grep -vE '^claude-plugins/kampus-pipeline/(skills|agents)/' <<<"$FILE
 if [ -n "$FILES" ] && [ -z "$OFFCLASS" ]; then return 0; fi
 return 1
 }
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  FILES="$(cat)"
+  if kp_wl_all_onclass; then echo "WL_ALL_ONCLASS=yes"; else echo "WL_ALL_ONCLASS=no"; exit 1; fi
+fi


### PR DESCRIPTION
Closes #4571

Converts the 13 shared scripts under `claude-plugins/kampus-pipeline/skills/shared/scripts/` to ADR 0232's executed/stdout convention, and the 21 invoking fences (19 in `gh-issue-intake-formats.md`, 2 in `shared/gate-verdict-contract.md`) to the literal-path form.

## The shape, and why it is dual-mode

**A source-hostile rewrite would have orphaned 13 in-script consumers at `rc 127`, and no CI check can see that.** ADR 0232 bans sourcing at an *agent's top-level command* and explicitly keeps **in-script** sourcing sanctioned; `verify-extraction.sh` check 5 requires it and ADR 0230's cycle validators follow it. Seven scripts source `cp-read.sh` in-chain, two source `iso-preflight.sh`, two source `verdict-readback.sh`, one sources `wl-empty-output.sh`, one sources `cycle-doc-probe.sh` — most of them in `review-code`/`review-design`/`ship-it`/`heal-ci`, which this issue puts out of scope.

So every function body, every top-level statement and every column-0 `.` line is **untouched**, and each script gains an executed entry that runs them and prints their results:

```bash
if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # near the top: options in executed mode only
...
if [ "${BASH_SOURCE[0]}" = "$0" ]; then                        # at the bottom: the entry
  ...
fi
```

Four properties a reviewer should check:

1. **`set -uo pipefail` fires in executed mode only.** `set` in a sourced file runs in the *caller's* shell, and `ship-it/scripts/step0-{classify,cp-approval,preflight}.sh` set **no** options by design. Applying the options unconditionally would silently change three §CP guards' behaviour — the not-a-relay change ADR 0228/0229 forbid.
2. **No `.` line moved or indented.** `kp_skill_source_edges` matches the sourcing idiom anchored at **column 0**; indenting one makes the edge invisible and narrows a cycle validator's surface in silence, and an interpolated directory makes the whole edge list UNRESOLVED.
3. **The entry adds no decision logic.** It relays what the body already computed, so the executed and sourced answers cannot diverge.
4. **The entry's exit status is `could I answer`, never `did I find something`.** A clean/empty answer returns **0**; only a read that could not execute returns non-zero. Under rule 1's `pipefail` two ordinary shapes break this on the *empty* input, and both were live in the first round — see the repair note below.

The shape is recorded in `.patterns/skill-script-shell-shape.md` § The dual-mode shape, so the sibling conversion lanes (#4572–#4576) copy one idiom rather than four.

## The stdout contract, and the exit-status contract beside it

Every value the sourced form left in the caller's shell arrives as a `NAME=value` line; a multi-valued one repeats a singular key (`CP_FILE=<path>` alongside `CP_FILES_N=<n>`). A script that could not produce an answer prints **nothing** on stdout and exits non-zero.

The mirror rule matters just as much, because §SHARED tells every reader to *read the exit status first and treat any non-zero as UNKNOWN*: an entry whose ordinary answer is *nothing found* must still exit **0**. Two shapes silently violate that under executed mode's `pipefail`, and only on the empty input:

- a **filter left inside the pipeline** (`… | grep <pat> | while …`) leaks `grep`'s no-match exit 1 as the pipeline's status. Fix: capture the filter's output into a variable first with an explicit `|| true`, then loop over the variable.
- an **`&&` loop body** (`while read -r x; do [ -n "$x" ] && printf …; done`) over an *empty* variable makes the failing `[ -n "" ]` the loop's last executed command, so the `while` — and the script — returns 1. Fix: an `if … fi` body, whose status is 0 when no branch runs.

The two empty-case semantics stay **genuinely distinct**, per `.patterns/skill-script-io-contract.md`: `cp-read.sh changed-files` treats zero files as a **failed read** (a PR always changes at least one file) and exits non-zero with nothing on stdout, while `cp-read.sh team-roster` prints `CP_MEMBERS_N=0` at exit 0 because an empty team is a **fact** (the ADR-0175 N==0 STOP). Both halves are measured below, not asserted.

## Proof 1 — rc parity across BOTH input classes (populated AND empty)

The round-1 recipe only ever exercised the *populated* case, so the input class that breaks was structurally unmeasurable. This harness measures both, hermetically (a `gh` stub — no network, no live-roster dependency) under **`/bin/bash` 3.2.57**, the real target. For each entry it runs the **sourced** form and the **executed** form on the same input and compares exit codes.

```bash
S=./claude-plugins/kampus-pipeline/skills/shared/scripts
T="$(mktemp -d)"; mkdir -p "$T/bin"
cat > "$T/bin/gh" <<'STUB'
#!/bin/bash
args="$*"
case "$args" in
  *"pr diff"*)                     printf '%s' "$FIXTURE_DIFF";    [ -n "$FIXTURE_DIFF" ] && echo; exit 0 ;;
  *"/files"*)                      printf '%s' "$FIXTURE_FILES";   [ -n "$FIXTURE_FILES" ] && echo; exit 0 ;;
  *"teams/control-plane/members"*) printf '%s' "$FIXTURE_MEMBERS"; [ -n "$FIXTURE_MEMBERS" ] && echo; exit 0 ;;
  *"gh-issue-intake-formats.md"*)  echo "GUARD_ADR_RE='guardword'"; exit 0 ;;
  *"contents/"*)                   printf '%s\n' "$FIXTURE_ADR_BODY"; exit 0 ;;
  *".body"*)                       printf '%s\n' "$FIXTURE_BODY"; exit 0 ;;
  *"/pulls/"*)                     echo "0123456789abcdef0123456789abcdef01234567"; exit 0 ;;
esac
exit 1
STUB
chmod +x "$T/bin/gh"; PATH="$T/bin:$PATH"

# cp-read.sh team-roster — EMPTY roster (a successful read of an empty team)
FIXTURE_MEMBERS="" /bin/bash -c ". $S/cp-read.sh; cp_team_roster kamp-us >/dev/null 2>&1; echo sourced-rc=\$?"
FIXTURE_MEMBERS="" /bin/bash "$S/cp-read.sh" kamp-us team-roster; echo "executed-rc=$?"

# dev-tier-m.sh — CLEAN scan (no suppression, no removed assertion)
D='+++ b/src/a.ts
+const x = 1'
FIXTURE_DIFF="$D" FIXTURE_BODY='## Deviations' REPO=kamp-us/phoenix PR=1 \
  /bin/bash -c ". $S/dev-tier-m.sh >/dev/null 2>&1; echo sourced-rc=\$?"
FIXTURE_DIFF="$D" FIXTURE_BODY='## Deviations' /bin/bash "$S/dev-tier-m.sh" kamp-us/phoenix 1 >/dev/null; echo "executed-rc=$?"

# cp-guard-adr.sh — a PR touching ZERO .decisions/** files
F='apps/web/src/x.tsx'
FIXTURE_FILES="$F" REPO=kamp-us/phoenix PR=1 CP_FILES="$F" \
  /bin/bash -c ". $S/cp-guard-adr.sh >/dev/null 2>&1; echo sourced-rc=\$?"
FIXTURE_FILES="$F" /bin/bash "$S/cp-guard-adr.sh" kamp-us/phoenix 1 >/dev/null; echo "executed-rc=$?"
```

Measured at this head, per script, per input class:

| script / entry | input | sourced rc | executed rc | parity |
|---|---|---|---|---|
| `cp-read.sh team-roster` | populated (2 members) | 0 | 0 | OK |
| `cp-read.sh team-roster` | **empty** (0 members) | 0 | **0** | OK |
| `cp-read.sh changed-files` | populated (2 files) | 0 | 0 | OK |
| `cp-read.sh changed-files` | **empty** (0 files) | 1 | **1** | OK — a failed read, by design |
| `dev-tier-m.sh` | populated (1 suppression + 1 removed assertion) | 0 | 0 | OK |
| `dev-tier-m.sh` | **empty** (clean scan) | 0 | **0** | OK |
| `cp-guard-adr.sh` | populated (1 guard-touching ADR) | 0 | 0 | OK |
| `cp-guard-adr.sh` | **empty** (zero `.decisions/**`) | 0 | **0** | OK |

The same harness run against the round-1 head reproduces the three FAILs independently (`team-roster` empty 0→1, `dev-tier-m` empty 0→1, `cp-guard-adr` empty 0→1), so it is a real discriminator and not a test that passes by construction.

The remaining nine entries have no status-leaking terminal construct to measure: `class-probe-resolve`, `cli-require`, `cycle-doc-probe`, `iso-preflight` and `wl-empty-output` end in a `printf`/`echo`/explicit `exit`; `claim-verbs`, `milestone-rest`, `scratchpad` and `verdict-readback` end in a `case` that relays a verb's own status; `cp-classify-entry` ends in an `if … else … fi` whose both arms succeed. Every executed entry's tail is a single-command status by construction.

## Proof 2 — the two empty-case semantics stay apart

Same stub, plus a second `gh` that *fails* (exit 1 with an error document on stdout — the read-could-not-execute class):

| call | outcome | rc | stdout |
|---|---|---|---|
| `changed-files`, zero files | FAILED READ | 1 | 0 bytes |
| `team-roster`, zero members | FACT (ADR-0175 N==0 STOP) | **0** | `CP_MEMBERS_N=0` |
| `team-roster`, 2 members | fact | 0 | `CP_MEMBERS_N=2 CP_MEMBER=alice CP_MEMBER=bob` |
| `team-roster`, `gh` exits non-zero | FAILED READ | 1 | 0 bytes |

So `CP_MEMBERS_N=0 at exit 0` — stated in the PR body, the script header and the §CPREAD fence — is now **measured**, and a failed roster read is still distinguishable from an empty one.

## Proof 3 — live runs at this head

```
bash $S/cp-guard-adr.sh kamp-us/phoenix 4590   → GUARD_ADR_RE=…, HEAD_SHA=…, no BLOCKING   rc=0
bash $S/dev-tier-m.sh   kamp-us/phoenix 4590   → 2 scope lines, 0 hits                     rc=0
bash $S/cp-read.sh      kamp-us team-roster    → CP_MEMBERS_N=4 + 4 CP_MEMBER lines        rc=0
```

## Reviewer-runnable relay recipe (populated, live)

Run from the repo root; `REPO=kamp-us/phoenix`, `PR=4577` are just an example pair. Each block runs the **sourced** form (capturing the shell state) and the **executed** form (capturing stdout), so the correspondence is visible line for line. This covers the *populated* class only — the empty class is proof 1 above.

```bash
S=./claude-plugins/kampus-pipeline/skills/shared/scripts
R=kamp-us/phoenix; PR=4577

# cycle-doc-probe — sourced $CYCLE_DOC  <->  executed CYCLE_DOC=
( REPO=$R; . $S/cycle-doc-probe.sh; echo "sourced:  CYCLE_DOC=$CYCLE_DOC" )
bash $S/cycle-doc-probe.sh $R | sed 's/^/executed: /'

# class-probe-resolve — sourced four HAS_*_RE  <->  executed four NAME= lines
( REPO=$R; . $S/class-probe-resolve.sh; echo "sourced:  HAS_CODE_RE=$HAS_CODE_RE" )
bash $S/class-probe-resolve.sh $R | sed 's/^/executed: /'

# cp-read changed-files — sourced $CP_FILES/$CP_FILES_N  <->  executed CP_FILES_N= + CP_FILE= per file
( . $S/cp-read.sh; cp_changed_files $R $PR 2>/dev/null; echo "sourced:  CP_FILES_N=$CP_FILES_N"; printf '%s\n' "$CP_FILES" | sed 's/^/sourced:  CP_FILE=/' )
bash $S/cp-read.sh $R changed-files $PR 2>/dev/null | sed 's/^/executed: /'

# cp-read head-sha / pr-author / team-roster
( . $S/cp-read.sh; cp_head_sha $R $PR 2>/dev/null; echo "sourced:  CP_HEAD_SHA=$CP_HEAD_SHA" )
bash $S/cp-read.sh $R head-sha $PR 2>/dev/null       | sed 's/^/executed: /'
bash $S/cp-read.sh $R pr-author $PR 2>/dev/null      | sed 's/^/executed: /'
bash $S/cp-read.sh kamp-us team-roster 2>/dev/null   | sed 's/^/executed: /'

# wl-empty-output — sourced predicate exit status  <->  executed WL_ALL_ONCLASS= (+ matching status)
( FILES="$(printf 'claude-plugins/kampus-pipeline/skills/a.md\nclaude-plugins/kampus-pipeline/agents/b.md')"; . $S/wl-empty-output.sh; kp_wl_all_onclass && echo "sourced:  rc=0" )
printf 'claude-plugins/kampus-pipeline/skills/a.md\n' | bash $S/wl-empty-output.sh | sed 's/^/executed: /'
printf 'apps/web/src/x.tsx\n'                          | bash $S/wl-empty-output.sh | sed 's/^/executed: /'   # exits 1

# the rest, executed
bash $S/cli-require.sh ./claude-plugins/kampus-pipeline/bin/pipeline-cli   # PCLI=<path>
bash $S/cli-require.sh /nope/pipeline-cli; echo "exit=$?"                  # 127, empty stdout
bash $S/iso-preflight.sh smoke                                            # scope line + ISO_PREFLIGHT=OK
bash $S/milestone-rest.sh $R catalog | head -3                            # relayed gh api answer
bash $S/cp-classify-entry.sh $R $PR                                       # scope line, CP_STATE=, BLOCKING
bash $S/cp-guard-adr.sh $R $PR                                            # GUARD_ADR_RE=, HEAD_SHA=, BLOCKING
bash $S/dev-tier-m.sh $R $PR                                              # two scope lines + DEV_*_LINE=
bash $S/claim-verbs.sh status 4571                                        # relayed verb answer + status
bash $S/scratchpad.sh open-fallback smoke-4571                            # RUN_SCRATCH=<dir>
bash $S/verdict-readback.sh $R bogus; echo "exit=$?"                      # 2, usage on stderr
```

Observed on this branch: on the populated inputs every sourced/executed pair matched — `CYCLE_DOC=present`; the four `HAS_*_RE` values identical; `CP_FILES_N=8` with the same eight paths in the same order; `CP_HEAD_SHA` and `CP_PR_AUTHOR` identical; the `wl-empty-output` predicate's `rc=0` corresponding to `WL_ALL_ONCLASS=yes` and its `rc=1` to `WL_ALL_ONCLASS=no`.

## Consumer enumeration — every in-script caller still resolves

**13 source edges across 13 distinct consumer files**, enumerated by `grep -rn --include='*.sh' -E '^[[:space:]]*(\.|source) .*<name>\.sh' claude-plugins/` per converted script (round 1 listed 12 edges and omitted `heal-ci/scripts/active-repair.sh`):

| Converted script | In-script consumers (all still source it) | Edges |
|---|---|---|
| `cp-read.sh` | `heal-ci/scripts/active-repair.sh`, `review-code/scripts/classify-control-plane.sh`, `review-design/scripts/classify-control-plane.sh`, `ship-it/scripts/step0-classify.sh`, `ship-it/scripts/step0-cp-approval.sh`, `shared/scripts/cp-classify-entry.sh`, `shared/scripts/cp-guard-adr.sh` | 7 |
| `iso-preflight.sh` | `review-code/scripts/materialize-head.sh`, `ship-it/scripts/step0-preflight.sh` | 2 |
| `verdict-readback.sh` | `review-code/scripts/verdict-readback.sh`, `review-design/scripts/verdict-readback.sh` | 2 |
| `wl-empty-output.sh` | `review-code/scripts/classify-skills-only.sh` | 1 |
| `cycle-doc-probe.sh` | `plan-epic/scripts/cycle-doc-probe.sh` | 1 |
| `claim-verbs.sh`, `class-probe-resolve.sh`, `cli-require.sh`, `cp-classify-entry.sh`, `cp-guard-adr.sh`, `dev-tier-m.sh`, `milestone-rest.sh`, `scratchpad.sh` | none — invoked only from the fences converted here | 0 |

All 13 consumers parse clean under `/bin/bash -n` **3.2.57** (run per file — `xargs` flattens exit codes 1–125 into one value, so a per-file loop is the only honest count), and `kp_skill_source_edges` credits every edge: `cp-read.sh` to **review-code** and **ship-it**, `iso-preflight.sh` to both, `verdict-readback.sh` to review-code, `wl-empty-output.sh` to review-code, `cycle-doc-probe.sh` to plan-epic. Zero unresolved.

Doc-fence callers **outside** these two files (`write-code/SKILL.md`, `write-code/repair.md`, `heal-ci/SKILL.md`, and the `review-code`/`review-design`/`ship-it`/`plan-epic` SKILL.mds) still source or reference these scripts and **still work unchanged**, because the source edge is preserved. They convert in their own sibling children per the issue's scope.

## Verification

```
/bin/bash 3.2.57 -n, 13 scripts + 13 in-script consumers   parse clean (per file, no xargs)
shellcheck -x -S warning, all 13 scripts (per file)        clean
kp_skill_source_edges over all 31 skill dirs               zero unresolved
lib/common-test.sh                                         all checks passed
validate-gate-path-drift.sh                                OK — 34 checks
validate-cycle-presence.sh                                 OK — 18 checks
validate-cycle-absence.sh                                  OK — 14 checks
validate-skills.sh                                         OK — 30 skills valid
trap-status-guard (CI's exact find | xargs invocation)     clean
gh-phoenix lint-skills (CI's exact invocation)             clean
plan-epic verify-extraction.sh                             OK — 11 checks
pnpm typecheck + unit suite (pre-push hook)                287 files, 2420 tests passed
pnpm lint:worktree                                         no biome-handled changed files
```

AC3's byte-untouched requirement, re-checked: each of the nine column-0 canonicals (`CONTROL_PLANE_RE`, `GUARD_ADR_RE`, `HAS_CODE_RE`, `HAS_SKILLS_RE`, `HAS_DOCS_EXCLUDE_RE`, `HAS_DOCS_RE`, `DOC_VOCAB_EXCLUDE_RE`, `DOC_VOCAB_SURFACE_RE`, `CLAIM_RE`) still appears exactly once at column 0 in the intake contract; `UI_RE`/`UI_EXCLUDE_RE` live in `ship-it/SKILL.md`, which this PR does not touch. AC2, re-checked: zero `KP_SHARED` occurrences and zero top-level `.`/`source` lines remain in either file.

## Contract note for #4549 (the review-code cycle-doc-probe collapse)

`shared/scripts/cycle-doc-probe.sh`'s **sourced** contract is unchanged: source it with `REPO` set and it leaves `$CYCLE_DOC` = `present`|`absent`, exactly as `plan-epic/scripts/cycle-doc-probe.sh` consumes it today. So #4549 can collapse `review-code/scripts/cycle-doc-probe.sh` onto it with the ordinary column-0 idiom and no adaptation:

```bash
# shellcheck source=../../shared/scripts/cycle-doc-probe.sh disable=SC1007,SC1091
. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cycle-doc-probe.sh"
```

What is **new**, and only additive: the file now also runs standalone as `bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cycle-doc-probe.sh <REPO>`, printing `CYCLE_DOC=present|absent`. The probe literal `contents/product-development-cycle.md` stays in executable code, so the ADR-0230 edge grep still finds it through the collapse.

## Deviations

- **AC1 says each script "opens with `set -uo pipefail`"; here the options are applied under a `[ "${BASH_SOURCE[0]}" = "$0" ]` guard at the top instead.** Unconditional options would run in the caller's shell for the 13 sanctioned in-script source edges, and three of those callers (`ship-it/scripts/step0-*.sh`) set no options by design — turning on `-u` and `pipefail` inside their §CP guards is a behaviour change AC4 forbids. The guard is the smallest construction that satisfies both ACs; it is written out literally at both sites rather than hidden behind a helper, because a helper is itself state a sourcing caller inherits.
- **`iso-preflight.sh`'s executed entry binds `CLAUDE_CODE_AGENT` and `WORKTREE_ROOT` to their own values before calling the guard.** The function reads both undefaulted, so under the executed mode's `set -u` an unset one aborts before the guard can answer at all (measured: `WORKTREE_ROOT` is unset in a live agent run). The binding is scoped to the executed entry; the function body is untouched, and no decision changes — it evaluates exactly the branches a no-options sourced caller gets. **The same undefaulted reads abort `review-code/scripts/materialize-head.sh`, which sources this file under its own `set -uo pipefail` — a pre-existing defect in a file this issue puts out of scope, filed rather than fixed here.**
- **Two `# shellcheck source=cp-read.sh disable=SC1007,SC1091` directives added** to `cp-classify-entry.sh` and `cp-guard-adr.sh`. Both files raised a pre-existing `SC1007` on their column-0 source line at the base commit; AC3 requires `shellcheck -x` to pass on the converted scripts, and the directive is the idiom every sibling consumer already uses. No behaviour change.
- **`cp-guard-adr.sh` makes the §CPREAD changed-file read itself in executed mode**, when `$CP_FILES` is not already in the environment — an executed child cannot inherit it. The sourced path still refuses outright on an unset `$CP_FILES`, and the executed path's failure direction is identical: an unreadable list prints `BLOCKING (…)` and exits non-zero, never "no §CP path touched".
- **The §CLI `PCLI=` preamble in `gh-issue-intake-formats.md` keeps its interpolated `CLAUDE_PLUGIN_ROOT` form.** It resolves a *binary* through ADR 0207's three-tier ladder, not a skill script, and every skill in the corpus pastes it — converting it is a corpus-wide change well outside this issue's scope. AC2's operative clause, "every script **invocation** is the literal-path form", holds, and ADR 0232's binding constraint is scoped to invocation for the same reason. **No open child owns this**: round 1 forwarded it to #4575, which is wrong — #4575 explicitly scopes *out* the intake contract. The gap is real and unowned; it is being filed separately rather than claimed here.
- **`.patterns/skill-script-shell-shape.md` gains a § The dual-mode shape section.** Not named in the issue's scope, but CLAUDE.md requires a load-bearing pattern to be documented, and the sibling lanes are about to copy this shape.
- **(repair round 1) Three converted scripts are no longer a byte-identical move of their fence.** `cp-guard-adr.sh`, `dev-tier-m.sh` and `cp-read.sh` each had their final relay construct rewritten — the `grep` lifted out of the pipeline behind `|| true`, and `[ -n "$x" ] && printf …` loop bodies turned into `if … fi`. That departs from the "every moved line is byte-identical" property the headers claim for the *moved* lines, and it is deliberate: the byte-identical form returns 1 on the clean answer under executed mode's `pipefail`, which is the AC4 break the gate caught. The sourced behaviour is unchanged (measured 0 before and after on both input classes); only the executed status is corrected. The scripts' `MECHANICAL MOVE` headers still describe the *function bodies*, which remain untouched.
- **(repair round 1) `.patterns/skill-script-shell-shape.md` § The dual-mode shape goes from three rules to four.** The added rule 4 is the exit-status rule, which the round-1 section omitted even though the §SHARED prose in this same PR leans on it. Same disclosure as the section itself: not in the issue's named scope, required because four sibling lanes copy this file.
- **(repair round 1) The round-1 body's claim "every sourced/executed pair matched exactly" was false**, and `CP_MEMBERS_N=0 at exit 0` was asserted rather than measured, because the recipe only exercised the populated inputs. Both are corrected above and both classes are now measured; the consumer table's edge count is corrected from 12 to 13 (`heal-ci/scripts/active-repair.sh` was missing).

## §CP

Touches `claude-plugins/kampus-pipeline/skills/**` — control-plane by path (CODEOWNERS + `CONTROL_PLANE_RE`). Costs one human §CP approval round. Do not merge on a gate PASS alone.
