### PR TITLE
fix(plan-epic): widen verify-extraction check 1 to the ledger's sanctioned shapes (#4587)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/check1-invocation.awk
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/check1-invocation.awk
@@ -60,7 +60,11 @@ function classify(l,   c, t, u) {
 	# as shell composition (campaign's FOUNDER guard carries a `;` inside its refusal message)
 	gsub(/\$\{[^}]*\}/, "$V", t)
 	if (t ~ /^[A-Za-z_][A-Za-z0-9_]*=.*bin\/pipeline-cli['"]?$/) return 1   # the shim resolution itself
-	if (t ~ /^[A-Za-z_][A-Za-z0-9_]*=/ && !computed(t)) return 1            # NAME=<placeholder>, operator-filled
+	# reads the UNMASKED `c` for the substitution, because the mask above deletes a `$( … )` NESTED
+	# INSIDE an expansion — so `computed(t)` alone accepted `NUMS="${X:-$(gh api … | sort | head -5)}"`,
+	# the wrapper rather than the pipeline deciding (#4587 repair round 1). Pinned by
+	# `expansion-default-with-substitution` in check 1a.
+	if (t ~ /^[A-Za-z_][A-Za-z0-9_]*=/ && !computed(t) && index(c, "$(") == 0 && index(c, "`") == 0) return 1
 	return 0
 }
 

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/check1-invocation.awk
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/check1-invocation.awk
@@ -13,9 +13,13 @@
 # every verb in a one-line script, hide the operator placeholders) removes zero glue and reduces
 # legibility, which is what the epic exists to undo.
 #
-# Every shape is clamped by composes(): a recognized command that PIPES, CHAINS or `eval`s is glue
-# again, whatever it invokes. That clamp is what keeps the widening from greening everything (#4587
-# AC3) — without it a `gh … | grep … | "$PCLI" leak-guard scan-comment` scores as a verb call.
+# EVERY accept clause in classify() is clamped by composes() — read on the UNMASKED line, and via
+# computed() for the bare-assignment clause: a recognized command that PIPES, CHAINS or `eval`s is
+# glue again, whatever it invokes. That clamp is what keeps the widening from greening everything
+# (#4587 AC3) — without it a `gh … | grep … | "$PCLI" leak-guard scan-comment` scores as a verb call
+# and a `PCLI="$(gh … | sort | head -1)/bin/pipeline-cli"` scores as a shim resolution. check 1a pins
+# BOTH directions of every clause, because an accept side pinned alone is how the shim-resolution
+# clause shipped unclamped through two review rounds (#4587 repair round 2).
 
 # a trailing ` # …` comment is prose. Strip it before matching so a mention of `$PCLI` or of a
 # `skills/**.sh` path inside a comment cannot classify the CODE on that line. The strip needs
@@ -59,7 +63,11 @@ function classify(l,   c, t, u) {
 	# mask ${...} expansions: their :?/:- message text is prose, and its punctuation must not read
 	# as shell composition (campaign's FOUNDER guard carries a `;` inside its refusal message)
 	gsub(/\$\{[^}]*\}/, "$V", t)
-	if (t ~ /^[A-Za-z_][A-Za-z0-9_]*=.*bin\/pipeline-cli['"]?$/) return 1   # the shim resolution itself
+	# the shim resolution itself. The clamp reads the UNMASKED `c`: the mask above exists to hide an
+	# expansion's prose punctuation, so composing it would let a `PCLI="$(gh … | sort | head -1)/bin/
+	# pipeline-cli"` pipeline hide behind the wrapper (#4587 repair round 2). `!computed(c)` would be
+	# wrong here — a real shim resolution legitimately carries `$(git rev-parse …)`.
+	if (!composes(c) && t ~ /^[A-Za-z_][A-Za-z0-9_]*=.*bin\/pipeline-cli['"]?$/) return 1
 	# reads the UNMASKED `c` for the substitution, because the mask above deletes a `$( … )` NESTED
 	# INSIDE an expansion — so `computed(t)` alone accepted `NUMS="${X:-$(gh api … | sort | head -5)}"`,
 	# the wrapper rather than the pipeline deciding (#4587 repair round 1). Pinned by

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/check1-invocation.awk
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/check1-invocation.awk
@@ -1,0 +1,102 @@
+# verify-extraction.sh check 1's invocation recognizer, in its own file so check 1 (the corpus scan)
+# and check 1a (the recognizer self-test) run the SAME program — a self-test that certifies a copy
+# certifies nothing.
+#
+# Reads one SKILL.md; prints one line per fenced bash/sh block that carries something other than a
+# sanctioned non-glue shape, followed by the unrecognized lines. Silence means every block is clean.
+# `-v skill=<name>` names the file in the output.
+#
+# The sanctioned shapes are epic #4435 / child #4454's AC4 list as recorded in the epic ledger, not a
+# narrower guess: a skill-local script executed by path, a pipeline-cli verb call, the shim-resolution
+# assignment that supplies one, an operator placeholder assignment, and a heredoc body fed to a
+# recognized invocation. Widening the recognizer is the whole point of #4587 — the alternative (wrap
+# every verb in a one-line script, hide the operator placeholders) removes zero glue and reduces
+# legibility, which is what the epic exists to undo.
+#
+# Every shape is clamped by composes(): a recognized command that PIPES, CHAINS or `eval`s is glue
+# again, whatever it invokes. That clamp is what keeps the widening from greening everything (#4587
+# AC3) — without it a `gh … | grep … | "$PCLI" leak-guard scan-comment` scores as a verb call.
+
+# a trailing ` # …` comment is prose. Strip it before matching so a mention of `$PCLI` or of a
+# `skills/**.sh` path inside a comment cannot classify the CODE on that line. The strip needs
+# whitespace on both sides of the `#`, so a `#` inside a ref/format string (`refs/#`, `"#$p"`)
+# survives — the naive first-`#` strip the other checks use would eat those.
+function decomment(l,   t) {
+	t = l
+	sub(/[[:space:]]#[[:space:]].*$/, "", t)
+	return t
+}
+
+# true composition — two commands joined into a pipeline/chain — as opposed to a fail-closed `||`
+# trailer on ONE command, which is a trimming every skill uses and which composes nothing.
+function composes(l,   t) {
+	t = l
+	gsub(/\|\|/, "", t)
+	return (index(t, "|") > 0 || index(t, "&&") > 0 || index(t, ";") > 0 || t ~ /(^|[[:space:]])eval([[:space:]]|$)/)
+}
+
+# does the line COMPOSE or SUBSTITUTE? the stricter clamp, for a bare assignment: an operator
+# placeholder never needs a command to produce its value.
+function computed(t) {
+	return (composes(t) || index(t, "$(") > 0 || index(t, "`") > 0)
+}
+
+function classify(l,   c, t, u) {
+	c = decomment(l)
+	u = c
+	gsub(/['"]/, "", u)
+	# a skill-local script executed by path — anywhere under skills/<skill>/, not only scripts/
+	# (report/footer.sh is a real helper, not glue, and the old regex could not see it)
+	if (c ~ /skills\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.\/-]*\.sh/ && !composes(c)) return 1
+	# a pipeline-cli verb call: the path-resolved shim, literal or through a resolved $PCLI, and
+	# either run directly or captured. The skills MANDATE this shape (ADR 0207 — the shim is not on
+	# PATH), so it can never be glue. Anchored: a verb name must follow the shim at the START of the
+	# command, so a shim path buried mid-pipeline stays unrecognized.
+	if (!composes(c) && (u ~ /^\$\{?PCLI\}?[[:space:]]+[a-z][a-z0-9-]*/ ||
+	                     u ~ /^[^[:space:]]*bin\/pipeline-cli[[:space:]]+[a-z][a-z0-9-]*/ ||
+	                     u ~ /^[A-Za-z_][A-Za-z0-9_]*=\$\([^)]*(\$\{?PCLI\}?|bin\/pipeline-cli)[[:space:]]+[a-z][a-z0-9-]*/)) return 1
+	t = c
+	# mask ${...} expansions: their :?/:- message text is prose, and its punctuation must not read
+	# as shell composition (campaign's FOUNDER guard carries a `;` inside its refusal message)
+	gsub(/\$\{[^}]*\}/, "$V", t)
+	if (t ~ /^[A-Za-z_][A-Za-z0-9_]*=.*bin\/pipeline-cli['"]?$/) return 1   # the shim resolution itself
+	if (t ~ /^[A-Za-z_][A-Za-z0-9_]*=/ && !computed(t)) return 1            # NAME=<placeholder>, operator-filled
+	return 0
+}
+
+function scanhd(l,   d) {   # arm heredoc-body skipping when this line opens one
+	if (!match(l, /<<-?[[:space:]]*['"]?[A-Za-z_][A-Za-z0-9_]*['"]?/)) return
+	if (RSTART > 1 && substr(l, RSTART - 1, 1) == "<") return   # a <<< herestring, not a heredoc
+	d = substr(l, RSTART, RLENGTH)
+	sub(/^<<-?[[:space:]]*/, "", d)
+	gsub(/['"]/, "", d)
+	hd = d
+}
+
+/^[[:space:]]*```(bash|sh)[[:space:]]*$/ { inb=1; start=NR; n=0; unc=0; solo_blocked=0; hd=""; cont=0; next }
+
+inb && /^[[:space:]]*```[[:space:]]*$/ {
+	# A block whose whole payload is ONE self-contained, uncomposed command composes nothing, so it
+	# is not multi-line glue — the same `payload > 1` threshold AC4's pinned census uses (the
+	# ADR-discovery `ls .decisions/NNNN-*.md` is the corpus instance). It is a threshold, not a
+	# hole: a line that pipes/chains/substitutes still reds, and so does one that CONTINUES over a
+	# `\`, which is a multi-line command wearing a single payload line's clothes.
+	if (n == 0 || (unc > 0 && !(n == 1 && solo_blocked == 0))) {
+		printf "%s:%d (payload lines=%d, unrecognized=%d)\n", skill, start, n, unc
+		for (i = 1; i <= unc; i++) printf "    -> %s\n", offend[i]
+	}
+	inb=0; next
+}
+
+inb {
+	line=$0
+	sub(/^[[:space:]]+/, "", line)
+	sub(/[[:space:]]+$/, "", line)
+	if (hd != "") { if (line == hd) hd=""; next }   # heredoc body: an authored template, not shell
+	if (line == "" || line ~ /^#/) next             # comments and blanks are not glue
+	if (cont) { scanhd(line); cont = (line ~ /\\$/); next }   # a continuation of the counted line
+	n++
+	if (!classify(line)) { unc++; offend[unc]=line; if (computed(decomment(line)) || line ~ /\\$/) solo_blocked=1 }
+	scanhd(line)
+	cont = (line ~ /\\$/)
+}

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
@@ -10,9 +10,19 @@
 # (ADR 0092): a run that resolved no SKILL.md or no scripts is a FAIL, never a silent pass. This
 # harness excludes ITSELF from the extracted-script set — it is the verifier, not moved shell.
 #
-#   1. INVOCATION-ONLY — every fenced bash/sh block left in each SKILL.md contains nothing but
-#      script invocations (comments, blanks and trailing `\` continuations allowed); no multi-line
-#      glue remains.
+#   1. INVOCATION-ONLY — every fenced bash/sh block left in each SKILL.md carries only sanctioned
+#      non-glue lines (comments, blanks and trailing `\` continuations allowed); no multi-line glue
+#      remains. The sanctioned shapes are epic #4435 / child #4454's AC4 list as recorded in the
+#      epic ledger — a skill-local script executed by path (anywhere under `skills/<skill>/`, not
+#      only `scripts/`), a `pipeline-cli` verb call (the path-resolved shim, literal or via a
+#      resolved `"$PCLI"`), the shim-resolution assignment, an operator placeholder assignment
+#      (`NAME=<placeholder>`) that supplies one, and a heredoc body fed to a recognized invocation.
+#      The recognizer lives in `check1-invocation.awk`; #4587 is why it is that wide, and why the
+#      fix belongs here and never in the corpus it judges.
+#   1a. RECOGNIZER SELF-TEST — check 1's classifier, run over fixture blocks that pin BOTH
+#      directions: every sanctioned shape is accepted, AND a multi-line gh/jq pipeline still reds.
+#      A widening that greens everything is a failure, so the harness re-proves it didn't on every
+#      run rather than asserting it in prose (#4587 AC3).
 #   2. NO BARE `pipeline-cli` — the extracted scripts reach the shim only through `kp_pcli`, so a
 #      PATH-resolved `pipeline-cli` (not on PATH, ADR 0207) cannot re-enter the corpus.
 #   3. NO USER-LOCAL PATHS — no /Users/<name> or /home/<name> absolute path. This is the check
@@ -46,7 +56,9 @@ set -uo pipefail
 # shellcheck disable=SC1007  # `CDPATH= cd` is the corpus idiom: an empty CDPATH for this one command
 SKILLS_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck disable=SC1007
-SELF="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/$(basename -- "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SELF="$SCRIPT_DIR/$(basename -- "${BASH_SOURCE[0]}")"
+CHECK1_AWK="$SCRIPT_DIR/check1-invocation.awk"
 SKILLS=(plan-epic review-plan)
 [ "$#" -gt 0 ] && SKILLS=("$@")
 
@@ -65,6 +77,128 @@ code_lines() {
 	done
 }
 
+# 1a. the recognizer self-test — the SAME awk check 1 runs, over fixtures that pin both directions
+[ -f "$CHECK1_AWK" ] || {
+	fail "check 1's recognizer is missing at $CHECK1_AWK — refusing to report a pass over nothing (ADR 0092)"
+	echo "verify-extraction: FAILED — $errors error(s)"
+	exit 1
+}
+c1_cases=0
+c1_bad=0
+c1_case() {   # <name> <ok|red>; the fixture's fenced block arrives on stdin
+	local name="$1" expect="$2" tmp out verdict
+	tmp="$(mktemp)" || { fail "check 1 self-test '$name': could not allocate a fixture"; c1_bad=1; return; }
+	cat > "$tmp"
+	out="$(awk -v skill="$name" -f "$CHECK1_AWK" "$tmp")"
+	rm -f "$tmp"
+	verdict=ok
+	[ -n "$out" ] && verdict=red
+	c1_cases=$((c1_cases + 1))
+	[ "$verdict" = "$expect" ] && return
+	fail "check 1 self-test '$name': recognizer said $verdict, expected $expect"
+	[ -n "$out" ] && printf '%s\n' "$out"
+	c1_bad=1
+}
+
+c1_case script-invocation ok <<'FIXTURE'
+```bash
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup.sh" "$N"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/label.sh" "$N"
+```
+FIXTURE
+
+c1_case skill-local-script-outside-scripts ok <<'FIXTURE'
+```bash
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/footer.sh"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/footer.sh" --short
+```
+FIXTURE
+
+c1_case resolved-pcli-verb-call ok <<'FIXTURE'
+```bash
+PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+EXISTING=$("$PCLI" split-guard check \
+  --parent <original #N> --title "<the split-child title>")
+```
+FIXTURE
+
+c1_case literal-shim-verb-call ok <<'FIXTURE'
+```bash
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" decisions-index compact
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" commands compact
+```
+FIXTURE
+
+c1_case operator-placeholder-assignment ok <<'FIXTURE'
+```bash
+RUN=<run id>     # the failed run
+PR=<n>           # the PR, if this is a PR run (else leave unset)
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/failed-logs.sh" "$RUN"
+```
+FIXTURE
+
+c1_case heredoc-body-template ok <<'FIXTURE'
+```bash
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/file-report.sh" \
+  "<title>" <<'EOF'
+## Summary
+A body line that merely LOOKS like glue: gh api repos/o/r/issues | jq -r '.[].number'
+EOF
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/footer.sh"
+```
+FIXTURE
+
+c1_case solo-uncomposed-command ok <<'FIXTURE'
+```bash
+ls .decisions/NNNN-*.md   # -> .decisions/NNNN-real-slug.md, use exactly this filename
+```
+FIXTURE
+
+c1_case multi-line-gh-jq-pipeline red <<'FIXTURE'
+```bash
+gh api "repos/$REPO/issues?state=open&per_page=100" \
+  --jq '.[] | select(.assignee == null) | .number' | while read -r n; do
+  gh api "repos/$REPO/issues/$n" --jq .title
+done
+```
+FIXTURE
+
+c1_case captured-gh-jq-assignment red <<'FIXTURE'
+```bash
+PRS=$(gh api "repos/$REPO/pulls?state=open" --jq '.[].number')
+for p in $PRS; do echo "#$p"; done
+```
+FIXTURE
+
+c1_case solo-composed-glue red <<'FIXTURE'
+```bash
+gh api "repos/$REPO/labels" --jq '.[].name' | sort
+```
+FIXTURE
+
+c1_case verb-call-inside-a-pipeline red <<'FIXTURE'
+```bash
+PCLI="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+gh pr diff "$PR" | grep '^+' | "$PCLI" leak-guard scan-comment
+```
+FIXTURE
+
+c1_case solo-continued-command red <<'FIXTURE'
+```bash
+gh api "repos/$REPO/pulls?state=open&per_page=100" \
+  --jq '.[] | select(.draft | not) | .number'
+```
+FIXTURE
+
+c1_case empty-block red <<'FIXTURE'
+```bash
+```
+FIXTURE
+
+if [ "$c1_bad" = 0 ]; then
+	ok "check 1 recognizer self-test: $c1_cases fixture block(s) — every sanctioned shape accepted, glue still red"
+fi
+
 SCRIPT_PATHS=()
 for skill in "${SKILLS[@]}"; do
 	md="$SKILLS_DIR/$skill/SKILL.md"
@@ -79,28 +213,13 @@ for skill in "${SKILLS[@]}"; do
 		scanned_sh=$((scanned_sh + 1))
 	done < <(find "$dir" -type f -name '*.sh' | LC_ALL=C sort)
 
-	# 1. every remaining fenced bash/sh block contains only script invocations
-	bad="$(awk -v skill="$skill" '
-		/^[[:space:]]*```(bash|sh)[[:space:]]*$/ { inb=1; start=NR; n=0; inv=0; cont=0; next }
-		inb && /^[[:space:]]*```[[:space:]]*$/ {
-			if (n == 0 || inv != n) printf "%s:%d (payload lines=%d, invocations=%d)\n", skill, start, n, inv
-			inb=0; next
-		}
-		inb {
-			line=$0
-			sub(/^[[:space:]]+/, "", line)
-			if (line == "" || line ~ /^#/) next          # comments and blanks are not glue
-			if (cont) { cont = (line ~ /\\$/); next }    # a continuation of the counted line
-			n++
-			if (line ~ /skills\/[a-z-]+\/scripts\/[a-z0-9_-]+\.sh/) inv++
-			cont = (line ~ /\\$/)
-		}
-	' "$md")"
+	# 1. every remaining fenced bash/sh block carries only sanctioned non-glue lines
+	bad="$(awk -v skill="$skill" -f "$CHECK1_AWK" "$md")"
 	if [ -n "$bad" ]; then
-		fail "$skill/SKILL.md: fenced block(s) carry something other than script invocations:"
-		printf '  %s\n' "$bad"
+		fail "$skill/SKILL.md: fenced block(s) carry something other than a sanctioned invocation shape:"
+		printf '%s\n' "$bad"
 	else
-		ok "$skill/SKILL.md: every fenced bash/sh block carries only scripts/*.sh invocations"
+		ok "$skill/SKILL.md: every fenced bash/sh block carries only sanctioned invocation shapes"
 	fi
 done
 

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
@@ -190,9 +190,44 @@ gh api "repos/$REPO/pulls?state=open&per_page=100" \
 ```
 FIXTURE
 
-# The second payload line of each of these three is a SANCTIONED invocation, so the block's verdict
-# turns on the first line alone — a glue partner would red the block for the wrong reason and the
-# fixture would pass with its clamp disabled (the trap the first draft of this fixture fell into).
+# THE CLAMP GROUP — one fixture per accept clause's clamp, in classify() order, each pinning the
+# REJECT side its clause's accept fixture cannot. Two rounds of review found a clause whose accept
+# side alone was pinned (#4587 repair rounds 1 and 2), so the coverage rule is: mutate each clamp
+# individually, and exactly one fixture here must flip.
+#
+# The second payload line of each is a SANCTIONED invocation, so the block's verdict turns on the
+# first line alone — a glue partner would red the block for the wrong reason and the fixture would
+# pass with its clamp disabled (the trap the first draft of these fixtures fell into).
+c1_case script-invocation-heading-a-pipeline red <<'FIXTURE'
+```bash
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup.sh" "$N" | jq -r '.[]'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/label.sh" "$N"
+```
+FIXTURE
+
+# `verb-call-inside-a-pipeline` above pins the ANCHORING (a shim path buried mid-pipeline never
+# matches at all), not this clamp — a verb call that HEADS the pipeline is what reaches it.
+c1_case verb-call-heading-a-pipeline red <<'FIXTURE'
+```bash
+"$PCLI" verdict read --pr "$PR" --gate code | jq -r '._tag'
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup.sh" "$N"
+```
+FIXTURE
+
+c1_case shim-resolution-with-pipeline red <<'FIXTURE'
+```bash
+PCLI="$(gh api "repos/$REPO/issues" --jq '.[].number' | sort -n | head -1)/bin/pipeline-cli"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup.sh" "$N"
+```
+FIXTURE
+
+c1_case placeholder-assignment-then-chain red <<'FIXTURE'
+```bash
+RUN=<run id> && gh run view "$RUN" --log-failed
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/failed-logs.sh" "$RUN"
+```
+FIXTURE
+
 c1_case expansion-default-with-substitution red <<'FIXTURE'
 ```bash
 NUMS="${CACHED_NUMS:-$(gh api "repos/$REPO/issues?state=open" --jq ".[].number" | sort -n | head -5)}"
@@ -207,6 +242,9 @@ NUMS="${CACHED_NUMS:-`gh api "repos/$REPO/issues?state=open" --jq ".[].number"`}
 ```
 FIXTURE
 
+# The one fixture with NO sanctioned partner — both its lines are the offending class, because the
+# defect IS that a trailing comment classifies the code. Still non-vacuous: it flips alone when
+# decomment()'s strip is deleted.
 c1_case comment-cannot-classify-the-code red <<'FIXTURE'
 ```bash
 mkdir -p .decisions                                # per skills/adr/scripts/next-number.sh

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
@@ -190,6 +190,30 @@ gh api "repos/$REPO/pulls?state=open&per_page=100" \
 ```
 FIXTURE
 
+# The second payload line of each of these three is a SANCTIONED invocation, so the block's verdict
+# turns on the first line alone — a glue partner would red the block for the wrong reason and the
+# fixture would pass with its clamp disabled (the trap the first draft of this fixture fell into).
+c1_case expansion-default-with-substitution red <<'FIXTURE'
+```bash
+NUMS="${CACHED_NUMS:-$(gh api "repos/$REPO/issues?state=open" --jq ".[].number" | sort -n | head -5)}"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup.sh" "$NUMS"
+```
+FIXTURE
+
+c1_case expansion-default-with-backtick red <<'FIXTURE'
+```bash
+NUMS="${CACHED_NUMS:-`gh api "repos/$REPO/issues?state=open" --jq ".[].number"`}"
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup.sh" "$NUMS"
+```
+FIXTURE
+
+c1_case comment-cannot-classify-the-code red <<'FIXTURE'
+```bash
+mkdir -p .decisions                                # per skills/adr/scripts/next-number.sh
+cp .decisions/0000-template.md .decisions/NNNN.md  # per skills/adr/scripts/next-number.sh
+```
+FIXTURE
+
 c1_case empty-block red <<'FIXTURE'
 ```bash
 ```


### PR DESCRIPTION
Fixes #4587

## Route taken: (a) — widen the recognizer

The ticket offered two routes and told the implementer to pick one against the epic ledger's
**current** AC4, not the triage note's (self-flagged unverified) description of it. Read off
`#4454`'s live body — the version amended by plan-epic on 2026-07-31, which landed tonight in
PR #4585 (squash `32e66f24`) — AC4 now reads:

> … every surviving multi-line fenced bash/sh block classifies as a sanctioned non-glue shape —
> an ADR 0232 executed script invocation (`bash ./claude-plugins/kampus-pipeline/skills/<skill>/scripts/<script>.sh …`)
> **plus its comment lines and operator placeholder assignments**, a **sanctioned `pipeline-cli`
> verb invocation with the same trimmings**, or a **heredoc body template fed to such an
> invocation** — and the PR records that classification … A surviving block that fits none of
> those shapes is glue and fails this criterion.

That definition **enumerates the very shapes check 1 was reddening**. Route (b) — scoping check 1
to `plan-epic`/`review-plan` and disowning the corpus-wide proof — would put the check *out* of
alignment with a ledger criterion that already names those shapes as sanctioned. So route (a).
The amendment's own note ("the open decision tickets #4584 and #4587 may later refine the
sanctioned-shape list") reads this as the intended refinement seam.

## What changed

Two files, both in `claude-plugins/kampus-pipeline/skills/plan-epic/scripts/`:

| file | delta |
| --- | --- |
| `check1-invocation.awk` | **new** — the recognizer, extracted so check 1 and its self-test run the *same* program |
| `verify-extraction.sh` | header rewritten, check 1 now delegates to the awk, new check 1a |

**No skill file is touched.** The ticket's named anti-goal — wrapping a `pipeline-cli` verb in a
one-line `scripts/*.sh` and hiding the `RUN=<run id>` operator placeholder — removes zero glue and
reduces legibility, so the fix lives entirely in the recognizer.

### The recognizer

A payload line is sanctioned when it is one of:

1. a **skill-local script executed by path** — anywhere under `skills/<skill>/`, not only
   `scripts/` (this is what `report/footer.sh` needed);
2. a **`pipeline-cli` verb call** — the path-resolved shim literally, or through a resolved
   `"$PCLI"`, run directly or captured (`NAME=$("$PCLI" verb …)`). ADR 0207 *mandates* this shape,
   so it can never be glue;
3. the **shim-resolution assignment** itself (`PCLI="${CLAUDE_PLUGIN_ROOT:-…}/bin/pipeline-cli"`);
4. an **operator placeholder assignment** (`RUN=<run id>`, `FLAG_KEY="<the kebab-case flag key>"`)
   that supplies an invocation's argument.

A **heredoc body** fed to a recognized invocation is an authored template and is not payload at
all — including when the `<<'EOF'` sits on a `\` continuation line (`wayfinder`,
`architecture-audit`), which is why those two blocks previously counted their markdown bodies as
shell.

### Why the widening does not green everything (AC3)

**Every accept clause is clamped, and every clamp is pinned in BOTH directions.** That sentence is
the AC, and two review rounds each found it false of one clause — round 1 the `${…}` mask, round 2
the shim-resolution clause, which carried **no** composition clamp at all and tested the *masked*
line, so `PCLI="$(gh api … | sort -n | head -1)/bin/pipeline-cli"` scored as a sanctioned
invocation. Rather than patch the one clause a reviewer found, repair round 2 **swept every clause**
(table below): three more clamps turned out to be pinned by nothing, and all four now have a
dedicated red fixture.

| # | accept clause (`classify()`) | its clamp | accept side pinned by | reject side pinned by |
| --- | --- | --- | --- | --- |
| 1 | skill-local script executed by path | `!composes(c)`, unmasked | `script-invocation`, `skill-local-script-outside-scripts`, `operator-placeholder-assignment`, `heredoc-body-template` | `script-invocation-heading-a-pipeline` **(new)** |
| 2 | `pipeline-cli` verb call (`"$PCLI" verb`, literal shim, `NAME=$(… verb …)`) | `!composes(c)`, unmasked — **plus** the `^` anchoring | `resolved-pcli-verb-call`, `literal-shim-verb-call` | clamp: `verb-call-heading-a-pipeline` **(new)** · anchoring: `verb-call-inside-a-pipeline` |
| 3 | the shim-resolution assignment | `!composes(c)`, unmasked **(added this round)** | `resolved-pcli-verb-call` | `shim-resolution-with-pipeline` **(new)** |
| 4 | operator placeholder assignment | `!computed(t)`, **plus** the unmasked `$(` and backtick tests | `operator-placeholder-assignment` | clamp: `placeholder-assignment-then-chain` **(new)** · unmasked tests: `expansion-default-with-substitution`, `expansion-default-with-backtick` |
| — | `decomment()` — a pre-pass over every clause | — | (implicit in every accept fixture) | `comment-cannot-classify-the-code` |
| — | the block-level `payload > 1` threshold | `solo_blocked` | `solo-uncomposed-command` | `solo-composed-glue`, `solo-continued-command` |

Two notes the table cannot carry:

- **Clause 2 has two independent rejection mechanisms, and only one was pinned.**
  `verb-call-inside-a-pipeline` (a shim path buried mid-pipeline) is rejected by the `^`
  **anchoring**, not by `!composes(c)` — removing the clamp leaves that fixture green. A verb call
  that *heads* a pipeline is the shape that reaches the clamp, hence the new fixture.
- **The clamp on clause 3 must read the UNMASKED line.** The `${…}` mask exists to hide an
  expansion's prose punctuation from the composition test, so composing *it* would let the pipeline
  hide behind the wrapper again. `!computed(c)` would be **wrong** here — a real shim resolution
  legitimately carries `$(git rev-parse …)`.

### Check 1a — the negative case is committed, not asserted

`verify-extraction.sh` runs check 1's classifier over **20 fixture blocks** before it scans the
corpus, pinning both directions: 7 sanctioned shapes must pass, and 13 glue shapes must red.
It uses the same `-f check1-invocation.awk`, so the self-test cannot certify a copy.

The **six fixtures of the clamp group** — one per clamp — each pair their offending line with a
**sanctioned** invocation, so the block's verdict turns on that line alone; a glue partner would red
the block for the wrong reason and the fixture would still pass with its clamp disabled (the trap the
first draft of the `${…}` fixture fell into). `verb-call-inside-a-pipeline` is paired too (its first
line is a real shim resolution). The remaining six are deliberately unpaired and that is stated, not
glossed: `multi-line-gh-jq-pipeline`, `captured-gh-jq-assignment`, `solo-composed-glue` and
`solo-continued-command` are glue end to end by construction; `empty-block` has no lines at all; and
`comment-cannot-classify-the-code` has **no** sanctioned partner because both its lines are the
offending class — the defect *is* that a trailing comment classifies the code. All six are still
non-vacuous: each flips under its own mutation (table below).

## Reviewer-runnable verification

```bash
# 1. the harness on its own scope — 20 self-test cases + both planning skills
bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh

# 2. the corpus-wide check-1 run from the report (checks 5/8/9 FAILs are pre-existing, see below)
bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh \
  triage heal-ci release report wayfinder what-shipped architecture-audit campaign canon adr author-skill doctor glossary
```

### Corpus-wide check-1 false FAILs: 15 → 0

Re-derived at this head by running the **base** harness (`32e66f24`) and this one over the same
13-argument scope. At base the second command reds check-1 on **15** blocks across 8 SKILL.md:
`triage:247,272` · `heal-ci:94,108,347` · `release:89,154` · `report:60,143` · `wayfinder:510` ·
`architecture-audit:241` · `campaign:41,82` · `adr:40,172`. At this head **all twelve SKILL.md
report `ok`** — zero check-1 blocks, zero file-level check-1 FAILs. Total harness errors 25 → 17,
a delta of exactly the 8 file-level check-1 FAILs, so no pre-existing FAIL was silently greened.
Re-measured at this head after the round-2 clamp: still **0** check-1 blocks, still **17** errors.

### Mutation proof — every clamp, one at a time

Each clause and each clamp disabled **individually** in a `cp -R` sandbox copy of the plugin (these
files were never edited), then the harness re-run over the same 13-skill scope. The rule the sweep
enforces: **exactly one fixture must flip per clamp.** It now does, for all of them.

| mutation | corpus check-1 blocks | self-test fixtures red |
| --- | --- | --- |
| clause 1 disabled | 40 | `script-invocation`, `skill-local-script-outside-scripts`, `operator-placeholder-assignment`, `heredoc-body-template` |
| clause 2 disabled | 4 | `resolved-pcli-verb-call`, `literal-shim-verb-call` |
| clause 3 disabled | 3 | `resolved-pcli-verb-call` |
| clause 4 disabled | 8 | `operator-placeholder-assignment` |
| clause 1's `!composes(c)` removed | 0 (silently green) | `script-invocation-heading-a-pipeline` |
| clause 2's `!composes(c)` removed | 0 (silently green) | `verb-call-heading-a-pipeline` |
| clause 3's `!composes(c)` removed | 0 (silently green) | `shim-resolution-with-pipeline` |
| clause 4's `!computed(t)` removed | 0 (silently green) | `placeholder-assignment-then-chain` |
| clause 4's unmasked `$(` test removed | 0 (silently green) | `expansion-default-with-substitution` |
| clause 4's unmasked backtick test removed | 0 (silently green) | `expansion-default-with-backtick` |
| `classify()` accepts everything (final `return 0` → `return 1`) | 0 (silently green) | **12** — every red fixture except `empty-block`, which reds on `n == 0` independently of `classify()` |
| `decomment()` strip deleted | 1 (`triage:705`) | `comment-cannot-classify-the-code` |
| the `payload > 1` threshold removed | 2 | `solo-uncomposed-command` |

Eight of the thirteen mutations leave the corpus scan **silently green**, so check 1a is the only
surface that sees them. (Round 1's body reported the `classify()` row as 7 fixtures; the reviewer
measured 8 at that head, and it is **12** at this one — the four new red fixtures each flip under it
too.)

### Second, independent surface

The corpus scan is an aggregate, and an aggregate hides an over-wide accept. So every payload line
inside every fenced `bash`/`sh` block across **all** of `claude-plugins/kampus-pipeline/skills/`
(449 unique lines by the round-1 extractor, including the not-yet-drained review/ship skills) was
re-emitted as its own two-line block paired with a known-good invocation and fed back through the
**real** awk, once per recognizer build:

- pre-repair head: 184 accept / 265 reject
- round-1 head (`976f32b6`): 180 accept / 269 reject
- **newly accepted at round 1: none.** Newly rejected: exactly four lines, all the same shape — a
  command substitution nested in a `${…}` default (`REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view …)}"`,
  `SHIPIT_SCRIPTS=`, `WRITECODE_SCRIPTS=`, `KP_SHARED=`).

**Round 2 re-ran the same probe against `976f32b6` and this head, and the recognizer's behavior over
the whole corpus is unchanged: 267 rejected → 267 rejected, 0 newly accepted, 0 newly rejected.**
Independently, the awk's *block-level* output over every SKILL.md in the plugin (30 files, 56 blocks)
is **byte-identical** between the two heads (`diff` empty). The round-2 clamp is reachable only by a
shape the corpus does not contain — which is precisely why it needed a fixture rather than a corpus
line.

### Expected consequence: five blocks in NOT-YET-DRAINED skills newly red

The round-1 `${…}` clamp is correct and it has a footprint outside the scanned scope. These five
blocks were silently green at the pre-repair head and are red now — **this is the intended behavior,
not a regression**; the eleven already-drained skills extract that very `REPO=` line into
`scripts/resolve-repo.sh`, so the corpus convention already treats it as extraction-worthy. Naming
them so the remaining drain lanes do not read them as new damage. **The awk reports the
FENCE-OPEN line, and the offending payload sits one line BELOW it** — `ship-it/SKILL.md:90` is the
` ```bash `, and `:91` is the `REPO=` line; likewise `review-skill:158`/`:159`. (Round 1's body had
this direction inverted; the numbers themselves were and remain correct.)

| block (fence-open line) | the line, one below it |
| --- | --- |
| `ship-it/SKILL.md:90` | `REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view …)}"` + `SHIPIT_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse …)}/skills/ship-it/scripts"` |
| `write-code/SKILL.md:46` | `REPO=…` + `WRITECODE_SCRIPTS=…`, same two shapes |
| `review-doc/SKILL.md:109` | `REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view …)}"` |
| `review-skill/SKILL.md:158` | same `REPO=` line |
| `review-trivial/SKILL.md:49` | same `REPO=` line |

Also `write-code/SKILL.md:1104`, an already-red block, goes from 1 to 2 unrecognized lines
(`KP_SHARED=`). None of these files is touched by this PR.

## Not in scope

- **Check 9** (`FAIL: … with no args: exit=2, stdout bytes=N`) — that is sibling #4584, explicitly
  "do not fold the two". Untouched, and greening it here would disarm a live dark-ship gate.
- **Check 5** (14 scripts under `heal-ci`/`release`/`what-shipped`/`architecture-audit`/`canon`/`glossary`
  that do not source `lib/common.sh`), **check 8** (`heal-ci/scripts/resolve-failing-run.sh` calling
  `kp_pcli` without `|| exit 127`) and `doctor: no scripts/ dir` — all present identically at base
  `32e66f24`; not regressions and not this ticket.
- **Clause 1's unanchored `.sh` path match** — round 2's review noted that
  `cp skills/adr/scripts/next-number.sh elsewhere.sh` (a command that merely *mentions* a script)
  is accepted, and did not charge it: no corpus line exploits it and no collateral-free remedy was
  found (anchoring would reach `bash ./…` and `. "$KP_SHARED/…"`). Left as reported. It is a
  question about *what counts as an invocation*, which belongs in #4454's AC4 list.

## Deviations

- **Scope narrowing / out-of-scope shape** — **Said:** #4587's Pointers describe check 1's
  recognizer as "the single line to widen (or the header to scope)". **Did:** retired the one-line
  regex entirely and extracted a standalone `check1-invocation.awk`, then added check 1a on top.
  **Why:** the widened definition is four clamped shapes, not a regex, and a self-test that re-implements
  the recognizer certifies a copy — extracting it is what makes check 1 and check 1a the same program.
  **Disposition:** no action needed; the AC is about behavior, and the file count stays at two.
- **(repair round 1) Governing-behavior narrowing** — **Said:** the round-0 `${…}` mask comment
  claims "an operator placeholder never needs a command to produce its value". **Did:** the mask
  deleted a `$( … )` nested inside the expansion before that test ran, so the claim did not hold and
  a `gh … | sort | head` pipeline wrapped in `${VAR:-…}` was accepted. **Why:** the mask was applied
  indiscriminately for a narrow reason (`:?`/`:-` message punctuation). **Disposition:** fixed —
  the clause now reads the unmasked line for `$(` and for a backtick, and two fixtures pin it.
- **(repair round 1) Known consequence left unfixed** — **Said:** nothing; AC5 scopes the corpus
  proof to the drained skills. **Did:** the clamp reds five blocks in the five NOT-yet-drained
  skills (table above), and I did **not** widen the recognizer to re-sanction them. **Why:** whether
  `REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view …)}"` is *meant* to be a sanctioned shape cannot be
  settled from the ledger — #4454's AC4 does not list it, and the base recognizer redded it. Widening
  to make it green would be resolving that ambiguity unilaterally, in the same clause that just
  proved to be too wide. **Disposition:** for the ledger to judge — if that shape should be
  sanctioned, it belongs in AC4's list (and then in the recognizer), not decided here.
- **(repair round 1) Overstated claim corrected** — **Said:** the round-0 body claimed all three
  clamps were "covered by a fixture". **Did:** the reviewer mutated each and found `decomment()`
  was covered by **no** self-test (it only redded `triage:705` in the corpus). **Why:** the fixture
  set had no case where the comment strip was the deciding clamp. **Disposition:** fixed — the
  `comment-cannot-classify-the-code` fixture pins it, and the mutation table above is re-derived
  per clamp rather than asserted.
- **(repair round 1) Local branch name** — **Said:** repair mode fixes "on the PR's existing head
  branch". **Did:** the head branch was still checked out in the round-0 lane's worktree, so this
  round committed on a local branch at the same commit and pushed it to the PR's remote head ref.
  **Why:** git refuses to check the same branch out twice, and force-removing a sibling lane's
  worktree is never sanctioned. **Disposition:** no action needed — the PR's branch, history and
  gate trail are unchanged; only the local ref name differs. Tracked as #4468.
- **(repair round 2) Fixed WIDER than the verdict prescribed** — **Said:** the FAIL named one
  remedy — add `!composes(c)` to the shim-resolution clause plus one fixture. **Did:** that, and
  then swept **every** accept clause's clamp individually, which surfaced three further unpinned
  reject sides (clause 1's `!composes(c)`, clause 2's `!composes(c)`, clause 4's `!computed(t)`) and
  added three more red fixtures. **Why:** four instances of "a clause blind to composition" had been
  found in this one file by four different readers; fixing only the fourth would leave the same
  class live. **Disposition:** no action needed — the extra fixtures are self-test only; the
  recognizer's behavior over the corpus is byte-identical (see Second surface).
- **(repair round 2) Corrected claims in this body** — **Said:** round 1 claimed "7 fixtures red"
  under the `classify()`-accepts-everything mutation, that "each of the three" new red fixtures
  pairs with a sanctioned invocation, and described the five newly-red blocks as fence-line "one
  below the payload line". **Did:** re-measured (**12** at this head, 8 at round 1's),
  restated the pairing accurately (`comment-cannot-classify-the-code` has no sanctioned partner),
  and inverted the fence/payload prose to the correct direction. **Why:** all three were relayed or
  reasoned rather than re-derived. **Disposition:** fixed in this body; the in-file comment that
  carried the same inaccurate "each of these three" claim is corrected too.
- **(repair round 2) Lane claim NOT released** — **Said:** repair mode releases the lane's claim
  before stopping (#3780). **Did:** left the `claim:` marker on #4587 standing. **Why:** this repair
  was dispatched with a delegated token whose session is the **still-live** dispatching engine's own
  session, not a finished coder run — retracting it would evict a live claimant mid-drive, which is
  the hazard the claim protocol exists to prevent. **Disposition:** the dispatcher owns the release;
  flagged here so it is not read as a dropped step.

## Gates run

`shellcheck -x` on the harness · `bash -n` under the real target (GNU bash 3.2.57, not CI's bash 5) ·
`awk -f` parse on the recognizer · `pipeline-cli trap-status-guard check` over the whole
`claude-plugins` corpus (293 files, clean) · `pipeline-cli leak-guard scan` on both files (clean) ·
`pnpm lint:worktree`. No TypeScript changed, so `pnpm typecheck` has no scope here.

This is §CP (ADR 0227) — `claude-plugins/kampus-pipeline/skills/**` is control-plane by directory,
so `mergeable_state=blocked` pending human approval is expected, not a defect.
