### PR TITLE
fix(plan-epic): splice-body round-trips a clean deps-last block (#4596)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,6 +611,15 @@ jobs:
       # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh`.
       - run: bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh
 
+      # Executable pin for plan-epic's round-trip race detector (#4596): a CLEAN splice whose
+      # `## Dependencies` block is the body's last section — the standard first-time layout —
+      # must exit 0, while ANY in-block difference must still exit 1 with the racer verdict. The
+      # pre-fix diff reported "a racer clobbered it" on every clean deps-last write, so both
+      # directions are pinned; greening the false alarm by loosening the block-level byte-exactness
+      # would trade it for a silent miss. Hermetic: gh is stubbed, no network.
+      # Same script runs locally: `bash .claude/skills/plan-epic/scripts/verify-roundtrip-diff.sh`.
+      - run: bash .claude/skills/plan-epic/scripts/verify-roundtrip-diff.sh
+
       # Gate-path drift guard (issue #720): assert the five CONTROL_PLANE_RE= copies
       # in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats are
       # byte-identical to the §CP canonical line, and that .claude/skills resolves to

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/splice-body.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/splice-body.sh
@@ -16,13 +16,44 @@
 #
 # Exit 0 iff the block LANDED (the round-trip confirmed); every other terminal path — an aborted
 # guard, an exhausted loop, a racer's clobber — exits non-zero with its verdict on stdout, so
-# "could not land" can never be read as "pinned".
+# "could not land" can never be read as "pinned". Both directions of that claim are pinned by
+# `verify-roundtrip-diff.sh`, which drives THIS script against a stubbed `gh`.
 #
 # Extracted from plan-epic/SKILL.md (#4452, epic #4435 phase 1). Extraction contract +
 # shell-option rationale: ../SKILL.md § The extracted scripts.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# The ONE extraction surface both sides of step 6's round-trip diff go through: `## Dependencies` →
+# EOF, with trailing blank lines dropped and everything else — interior blanks, whitespace-only
+# lines, trailing spaces on a content line — preserved byte-for-byte. Two properties, both
+# load-bearing (#4596):
+#
+#   ONE FUNCTION, BOTH SIDES. The asymmetry it removes was structural, not a typo: the expected side
+#   was extracted from the FILE `body.md` while the bytes actually PATCHed are `$BODY`, which
+#   `$(cat)` had already stripped of every trailing newline. Deriving the expectation from a surface
+#   that is never stored is the same shape as a check blind to what it seeks; step 5 below now
+#   extracts from `$BODY` itself, and both sides call THIS function, so the two cannot drift apart
+#   again by a one-sided edit.
+#
+#   TRAILING BLANK LINES ONLY. `deps.md` carries the trailing blank line ../SKILL.md instructs, and a
+#   first-time plan appends the block to EOF — so deps-last-with-trailing-blank is the STANDARD
+#   layout, and the pre-fix diff reported "a racer clobbered it" and exited 1 on every one of them.
+#   Normalizing any further would trade that false alarm for a silent miss, which is strictly worse:
+#   the exit status is contractually "0 iff the block LANDED", so an in-block difference of ANY kind
+#   must still red. `verify-roundtrip-diff.sh` pins both directions.
+#
+# The `$0`/`$b` in the awk program are awk's, not the shell's — SC2016 is declared, not waved off.
+# shellcheck disable=SC2016
+deps_block() {   # stdin: a body; stdout: its `## Dependencies` block, trailing blank lines dropped
+	awk '
+		/^## Dependencies[[:space:]]*$/ { f = 1 }
+		!f { next }
+		/^[[:space:]]*$/ { held = held $0 "\n"; next }
+		{ printf "%s%s\n", held, $0; held = "" }
+	'
+}
 
 [ "$#" -ge 1 ] || { echo "usage: splice-body.sh <EPIC> [--replan]" >&2; exit 2; }
 EPIC="$1"; shift
@@ -127,21 +158,21 @@ for attempt in 1 2 3; do
   fi
   BODY="$(cat "$RUN_SCRATCH/body.md")"
 
-  # 5. extract THIS run's whole `## Dependencies` block (heading → EOF) from the body we're about
-  #    to write — that exact multi-line block is what we'll confirm round-tripped, so a racer who
-  #    happens to share a child number can't satisfy the check with one matching `- #` line.
-  awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' "$RUN_SCRATCH/body.md" \
-    > "$RUN_SCRATCH/deps-expected.md"
+  # 5. extract THIS run's whole `## Dependencies` block (heading → EOF) from `$BODY` — the bytes we
+  #    are ACTUALLY about to PATCH, not the pre-strip `body.md` file they came from (#4596). That
+  #    exact multi-line block is what we'll confirm round-tripped, so a racer who happens to share a
+  #    child number can't satisfy the check with one matching `- #` line.
+  printf '%s\n' "$BODY" | deps_block > "$RUN_SCRATCH/deps-expected.md"
 
   # 6. write, then re-confirm OUR WHOLE BLOCK landed — extract `## Dependencies`→EOF from the live
   #    post-write body and diff it against the block we just wrote. A racer's clobber differs
   #    somewhere in the block (different topology/labels/ordering), so an exact block match — not a
   #    heading or a single child line — is what tells our section from theirs. The residual window
   #    (below) means the PATCH is still last-write-wins; this is the honest after-the-fact check
-  #    that retries the loser.
+  #    that retries the loser. Both sides go through `deps_block` — same extraction, same trailing-
+  #    blank normalization — so the only thing this diff can report is an in-block difference.
   gh api -X PATCH "repos/$REPO/issues/$EPIC" -f body="$BODY" >/dev/null; patched=1
-  gh api "repos/$REPO/issues/$EPIC" --jq '.body' \
-    | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > "$RUN_SCRATCH/deps-live.md"
+  gh api "repos/$REPO/issues/$EPIC" --jq '.body' | deps_block > "$RUN_SCRATCH/deps-live.md"
   if diff -q "$RUN_SCRATCH/deps-expected.md" "$RUN_SCRATCH/deps-live.md" >/dev/null; then
     echo "epic body updated, our whole ## Dependencies block round-tripped"; landed=1; break
   else

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091
+# Reviewer-runnable proof for `splice-body.sh`'s round-trip check (#4596), driving the REAL script
+# against a stubbed `gh` — never a re-implementation of its awk, which would be blind to exactly the
+# defect it is here to pin (the expected side was derived from a surface that is never stored).
+#
+# Four cases, and the negative ones are the point: a check that only proves the happy path has
+# replaced a false alarm with a silent miss, which is strictly worse.
+#
+#   A. CLEAN, deps-last, `deps.md` carrying the instructed trailing blank line → exit 0, "round-tripped".
+#      This is the #4596 false positive: it FAILS on the pre-fix script.
+#   B. CLOBBERED topology — the stored body's block gains a child line → exit 1, racer verdict.
+#   C. CLOBBERED whitespace INSIDE the block — trailing spaces on a content line → exit 1. The
+#      normalization is trailing-blank-LINES only; anything inside the block stays byte-exact.
+#   D. CLOBBERED heading-adjacent blank — an interior blank line deleted → exit 1. Pins that the
+#      normalization did not degrade into "strip all blank lines".
+#
+# B/C/D are the anti-weakening clamp. Falsify this harness by deleting the `deps_block` normalization
+# from splice-body.sh: A must go red. Falsify it the other way by widening `deps_block` to strip all
+# whitespace: C and D must go red.
+#
+# Hermetic: `gh` is stubbed on PATH, so this needs no auth and touches no live issue. The
+# `pipeline-cli` shim IS the real one — `epic-splice apply` and `scratchpad` are offline local
+# transforms, and stubbing them would take the transform under test out of the loop.
+#
+# usage: bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, and no
+# `EXIT` trap — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this
+# harness's whole contract is its exit status.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="$DIR/splice-body.sh"
+[ -f "$UNDER_TEST" ] || { echo "FAIL: zero scope — no splice-body.sh at $UNDER_TEST (ADR 0092)"; exit 1; }
+
+# A number no live epic uses: the stub `gh` is the only thing that ever answers for it, and the
+# scratch namespace it keys is this harness's own.
+EPIC=999000
+export CLAUDE_PIPELINE_REPO="kampus-verify/roundtrip"
+# The harness must be runnable outside an agent session (CI has no session id), and §SP keys the
+# scratch namespace on it. A per-process fallback keeps the namespace this run's own.
+export CLAUDE_CODE_SESSION_ID="${CLAUDE_CODE_SESSION_ID:-verify-roundtrip-$$}"
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+BIN="$TMP/bin"
+mkdir -p "$BIN" || { echo "FAIL: cannot create the stub dir under $TMP"; exit 1; }
+
+# The stub server. `body` is the stored body, byte-for-byte what the PATCH handed it — modelling
+# GitHub as a verbatim store on purpose, so case A's mismatch can only come from the CLIENT-side
+# `$(cat)` strip and not from a normalization this harness invented. $CLOBBER, when set, is a sed
+# program applied to the stored body right after the write: that IS the racer.
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+BODY_F="$GH_STATE/body"
+AT_F="$GH_STATE/updated-at"
+patch=0
+val=""
+for a in "$@"; do
+	case "$a" in
+	PATCH) patch=1 ;;
+	body=*) val="${a#body=}" ;;
+	esac
+done
+if [ "$patch" = 1 ]; then
+	printf '%s' "$val" > "$BODY_F"
+	if [ -n "${CLOBBER:-}" ]; then
+		sed "$CLOBBER" "$BODY_F" > "$BODY_F.new" && mv "$BODY_F.new" "$BODY_F"
+	fi
+	printf '{"ok":true}\n'
+	exit 0
+fi
+for a in "$@"; do
+	case "$a" in
+	'.body') jq -rn --rawfile b "$BODY_F" '$b'; exit 0 ;;
+	'{body,updated_at}') jq -n --rawfile b "$BODY_F" --arg u "$(cat "$AT_F")" '{body:$b,updated_at:$u}'; exit 0 ;;
+	esac
+done
+jq -n --rawfile b "$BODY_F" --arg u "$(cat "$AT_F")" '{body:$b,updated_at:$u}'
+STUB
+chmod +x "$BIN/gh"
+
+BASE_BODY='## Brief
+
+A worked epic body whose LAST section is the dependency topology — the standard
+first-time-plan layout, because a first-time plan APPENDS the block to EOF.
+
+## Plan (plan-epic)
+
+### Phase 1
+
+- build the thing
+'
+# The trailing blank line is the one SKILL.md instructs ("Give each block a trailing blank line so
+# the next spliced heading stays separated"). It is what the pre-fix round-trip choked on.
+DEPS_BLOCK='## Dependencies
+
+### Phase 1: #900001, #900002
+
+- #900001 — first child
+- #900002 — second child (requires: #900001)
+
+'
+
+fail=0
+run_case() {   # $1 = case name, $2 = expected exit (0|1), $3 = sed clobber program (may be empty)
+	local name="$1" want="$2" clobber="$3" scratch rc out
+	scratch="$(kp_scratch_open "plan-epic-$EPIC")" || { echo "BAD   $name: could not open the scratch namespace"; fail=1; return; }
+	mkdir -p "$TMP/state" || { echo "BAD   $name: could not create the stub state dir"; fail=1; return; }
+	printf '%s' "$BASE_BODY" > "$TMP/state/body"
+	printf '%s' "2026-07-31T00:00:00Z" > "$TMP/state/updated-at"
+	printf '%s' "$BASE_BODY" > "$scratch/current.md"
+	printf '%s' "2026-07-31T00:00:00Z" > "$scratch/updated-at.txt"
+	printf '%s' "$DEPS_BLOCK" > "$scratch/deps.md"
+	# The freshness guard compares mtimes; back-date the base rather than sleeping, so the guard is
+	# satisfied deterministically instead of by however coarse this filesystem's clock is.
+	touch -t 202001010000 "$scratch/current.md" "$scratch/updated-at.txt"
+	out="$(PATH="$BIN:$PATH" GH_STATE="$TMP/state" CLOBBER="$clobber" bash "$UNDER_TEST" "$EPIC" 2>&1)"
+	rc=$?
+	if [ "$rc" = "$want" ]; then
+		printf 'OK    %-34s exit=%s (want %s)\n' "$name" "$rc" "$want"
+	else
+		printf 'BAD   %-34s exit=%s (want %s)\n' "$name" "$rc" "$want"
+		printf '%s\n' "$out" | sed 's/^/      /'
+		fail=1
+	fi
+	printf '%s' "$out" > "$TMP/last-out"
+}
+
+echo "scope: $UNDER_TEST driven against a stubbed gh, 4 cases"
+
+run_case "A clean deps-last round-trip" 0 ""
+grep -q 'round-tripped' "$TMP/last-out" || { echo "BAD   A: exit 0 without the landed verdict on stdout"; fail=1; }
+
+run_case "B clobbered topology" 1 's/second child/second child AND A THIRD/'
+grep -q 'a racer clobbered it' "$TMP/last-out" || { echo "BAD   B: exit 1 without the racer verdict on stdout"; fail=1; }
+
+run_case "C trailing spaces on a content line" 1 's/first child$/first child   /'
+grep -q 'a racer clobbered it' "$TMP/last-out" || { echo "BAD   C: exit 1 without the racer verdict on stdout"; fail=1; }
+
+run_case "D interior blank line whitespaced" 1 's/^$/ /'
+grep -q 'a racer clobbered it' "$TMP/last-out" || { echo "BAD   D: exit 1 without the racer verdict on stdout"; fail=1; }
+
+rm -rf "$TMP"
+if [ "$fail" -ne 0 ]; then
+	echo "FAIL: splice-body.sh's round-trip check does not hold both directions (#4596)"
+	exit 1
+fi
+echo "PASS: a clean deps-last splice round-trips, and every in-block difference still reds (#4596)"

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh
@@ -4,7 +4,7 @@
 # against a stubbed `gh` — never a re-implementation of its awk, which would be blind to exactly the
 # defect it is here to pin (the expected side was derived from a surface that is never stored).
 #
-# Four cases, and the negative ones are the point: a check that only proves the happy path has
+# Five cases, and the negative ones are the point: a check that only proves the happy path has
 # replaced a false alarm with a silent miss, which is strictly worse.
 #
 #   A. CLEAN, deps-last, `deps.md` carrying the instructed trailing blank line → exit 0, "round-tripped".
@@ -14,10 +14,26 @@
 #      normalization is trailing-blank-LINES only; anything inside the block stays byte-exact.
 #   D. CLOBBERED heading-adjacent blank — an interior blank line deleted → exit 1. Pins that the
 #      normalization did not degrade into "strip all blank lines".
+#   E. CLEAN, but `deps.md` ends in a WHITESPACE-ONLY line against a store that strips trailing
+#      whitespace → exit 0. `$(cat)` strips newlines only, so `$BODY` reaches the PATCH still ending
+#      in that line while the store does not keep it — the one case the trailing-blank drop guards.
 #
-# B/C/D are the anti-weakening clamp. Falsify this harness by deleting the `deps_block` normalization
-# from splice-body.sh: A must go red. Falsify it the other way by widening `deps_block` to strip all
-# whitespace: C and D must go red.
+# Falsify this harness three ways. WHICH case reds is the claim — run the mutation before trusting
+# the mapping, because the obvious one is wrong (#4598 review):
+#
+#   - Full pre-fix — step 5 back to the FILE `body.md` AND `deps_block` back to a plain `{ print }`:
+#     A goes red, the #4596 false positive.
+#   - Drop `held` only (print every blank, keep the `$BODY` source): E goes red, A does NOT. Under a
+#     verbatim store both sides of A's diff are byte-identical with or without the normalization, so
+#     A can never pin that clause on its own; E is what pins it.
+#   - Widen `deps_block` to strip all whitespace: C and D go red. B/C/D are the anti-weakening clamp.
+#
+# What NO case reds, stated plainly rather than left to be discovered: the FILE→`$BODY` source change
+# alone, with the normalization left standing. It cannot — `body.md` and `$BODY` differ only in
+# trailing newlines, which `deps_block` drops, so the two sources are block-equivalent by
+# construction. The two halves of the fix each independently close #4596; the one-surface property is
+# pinned STRUCTURALLY (one `deps_block()`, both call sites through it) and is not a behavior a
+# black-box case can reach.
 #
 # Hermetic: `gh` is stubbed on PATH, so this needs no auth and touches no live issue. The
 # `pipeline-cli` shim IS the real one — `epic-splice apply` and `scratchpad` are offline local
@@ -55,7 +71,8 @@ mkdir -p "$BIN" || { echo "FAIL: cannot create the stub dir under $TMP"; exit 1;
 # The stub server. `body` is the stored body, byte-for-byte what the PATCH handed it — modelling
 # GitHub as a verbatim store on purpose, so case A's mismatch can only come from the CLIENT-side
 # `$(cat)` strip and not from a normalization this harness invented. $CLOBBER, when set, is a sed
-# program applied to the stored body right after the write: that IS the racer.
+# program applied to the stored body right after the write — the racer in B/C/D, and in E a store
+# that normalizes trailing whitespace rather than a second writer.
 cat > "$BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -108,17 +125,21 @@ DEPS_BLOCK='## Dependencies
 - #900002 — second child (requires: #900001)
 
 '
+# Case E's block: the same one, plus a trailing WHITESPACE-ONLY line. Built with `$'   \n'` rather
+# than written literally, so no formatter or editor can silently strip the trailing spaces that are
+# the whole fixture.
+DEPS_BLOCK_TRAILING_WS="$DEPS_BLOCK"$'   \n'
 
 fail=0
-run_case() {   # $1 = case name, $2 = expected exit (0|1), $3 = sed clobber program (may be empty)
-	local name="$1" want="$2" clobber="$3" scratch rc out
+run_case() {   # $1 = case name, $2 = expected exit (0|1), $3 = sed clobber program (may be empty), $4 = deps block (default: $DEPS_BLOCK)
+	local name="$1" want="$2" clobber="$3" deps="${4:-$DEPS_BLOCK}" scratch rc out
 	scratch="$(kp_scratch_open "plan-epic-$EPIC")" || { echo "BAD   $name: could not open the scratch namespace"; fail=1; return; }
 	mkdir -p "$TMP/state" || { echo "BAD   $name: could not create the stub state dir"; fail=1; return; }
 	printf '%s' "$BASE_BODY" > "$TMP/state/body"
 	printf '%s' "2026-07-31T00:00:00Z" > "$TMP/state/updated-at"
 	printf '%s' "$BASE_BODY" > "$scratch/current.md"
 	printf '%s' "2026-07-31T00:00:00Z" > "$scratch/updated-at.txt"
-	printf '%s' "$DEPS_BLOCK" > "$scratch/deps.md"
+	printf '%s' "$deps" > "$scratch/deps.md"
 	# The freshness guard compares mtimes; back-date the base rather than sleeping, so the guard is
 	# satisfied deterministically instead of by however coarse this filesystem's clock is.
 	touch -t 202001010000 "$scratch/current.md" "$scratch/updated-at.txt"
@@ -134,7 +155,7 @@ run_case() {   # $1 = case name, $2 = expected exit (0|1), $3 = sed clobber prog
 	printf '%s' "$out" > "$TMP/last-out"
 }
 
-echo "scope: $UNDER_TEST driven against a stubbed gh, 4 cases"
+echo "scope: $UNDER_TEST driven against a stubbed gh, 5 cases"
 
 run_case "A clean deps-last round-trip" 0 ""
 grep -q 'round-tripped' "$TMP/last-out" || { echo "BAD   A: exit 0 without the landed verdict on stdout"; fail=1; }
@@ -148,9 +169,15 @@ grep -q 'a racer clobbered it' "$TMP/last-out" || { echo "BAD   C: exit 1 withou
 run_case "D interior blank line whitespaced" 1 's/^$/ /'
 grep -q 'a racer clobbered it' "$TMP/last-out" || { echo "BAD   D: exit 1 without the racer verdict on stdout"; fail=1; }
 
+# The store keeps the bytes but not the trailing whitespace — `s/[[:space:]]*$//` touches only the
+# whitespace-only line this case adds (no other fixture line ends in whitespace). This is the ONLY
+# case that reds when the trailing-blank hold-and-flush is deleted from `deps_block`.
+run_case "E trailing whitespace-only line" 0 's/[[:space:]]*$//' "$DEPS_BLOCK_TRAILING_WS"
+grep -q 'round-tripped' "$TMP/last-out" || { echo "BAD   E: exit 0 without the landed verdict on stdout"; fail=1; }
+
 rm -rf "$TMP"
 if [ "$fail" -ne 0 ]; then
 	echo "FAIL: splice-body.sh's round-trip check does not hold both directions (#4596)"
 	exit 1
 fi
-echo "PASS: a clean deps-last splice round-trips, and every in-block difference still reds (#4596)"
+echo "PASS: a clean deps-last splice round-trips, the trailing-blank drop is pinned, and every in-block difference still reds (#4596)"


### PR DESCRIPTION
Fixes #4596

## The reproduction, before the fix

`verify-roundtrip-diff.sh` case A drives the **real** `splice-body.sh` against a stubbed `gh` with **no racer at all** (`CLOBBER=""`), on the standard first-time layout: `## Dependencies` last, `deps.md` carrying the trailing blank line `plan-epic/SKILL.md` instructs. On the pre-fix script:

```
attempt 1
epic-splice: appended the section(s)
our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it.
plan-epic: could NOT land the ## Dependencies block — STOP and inspect, do not proceed.
  (A PATCH was issued but our block didn't round-trip — a racer clobbered it. …)
rc=1
--- diff deps-expected.md deps-live.md ---
4d3
<
```

The sole difference is the final empty line, on a write that landed byte-clean.

## Mechanism, re-verified from source

1. `deps-expected.md` was `awk`-extracted from the **file** `$RUN_SCRATCH/body.md`, which keeps the trailing blank line when the block is last.
2. `BODY="$(cat "$RUN_SCRATCH/body.md")"` — command substitution strips **all** trailing newlines. The blank is lost **client-side**, before the PATCH. (The stub `gh` in the harness stores the PATCH body verbatim, so case A's mismatch can only come from this strip — it does not depend on any server-side normalization, which stays unverified and is not needed to explain the bug.)
3. `deps-live.md` was extracted from the post-PATCH re-read, ending at the last content line.
4. `diff -q` failed on exactly that line → false racer verdict, exit 1.

## The fix — one surface, and which one (AC3)

Both sides now go through **one function**, `deps_block`, and the expected side is extracted from **`$BODY` — the bytes actually PATCHed** — not the pre-strip file.

**Why the post-strip surface.** The defect's shape is a check derived from a surface that is *never stored*; deriving the expectation from `body.md` reproduces exactly that. Extracting from `$BODY` puts the expectation on the surface the write actually put on the wire. `deps_block` additionally drops trailing blank lines on **both** sides, which is what keeps a whitespace-only trailing line — which `$(cat)` does **not** strip — from reading as a racer. One function called from both sites is the structural part: the asymmetry cannot re-enter through a one-sided edit.

**AC2 — the anti-weakening clamp.** `deps_block` drops trailing blank *lines* and nothing else. Interior blanks, whitespace-only lines and trailing spaces on a content line are all preserved byte-for-byte, so **any** in-block difference still fails the diff and exits 1 with the racer verdict.

## Both directions are pinned, and the pin is mutation-proven

`claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh` (new, hermetic, wired into the `skills` CI job) drives the real script:

| case | fixture / clobber | want |
|---|---|---|
| A clean deps-last round-trip | none | exit 0, "round-tripped" |
| B clobbered topology | a child line rewritten | exit 1, racer verdict |
| C trailing spaces on a content line | `s/first child$/first child   /` | exit 1, racer verdict |
| D interior blank line whitespaced | `s/^$/ /` | exit 1, racer verdict |
| E `deps.md` ends in a whitespace-only line, against a store that strips trailing whitespace | `s/[[:space:]]*$//` | exit 0, "round-tripped" |

A test that only proves the happy path can pass vacuously, so the mapping below was **measured by running each mutation**, not asserted. **Which case reds is the claim, and the obvious mapping is wrong** — the mutation table this PR shipped in round 0 said case A pins the trailing-blank clause, and it does not:

| mutation | measured result | what it pins |
|---|---|---|
| full pre-fix — step 5 back to the FILE `body.md` **and** `deps_block` back to a plain `{ print }` | **A reds** (E too) | the #4596 regression, AC1 |
| drop `held` only — print every blank, keep the `$BODY` source | **E reds; A, B, C, D stay green** | the trailing-blank drop, AC2 |
| widen `deps_block` to strip all whitespace | **C and D red** | the anti-weakening clamp, AC2 |
| `deps_block` → heading-only extraction | B, C, D red | block-level exactness |
| replace the round-trip `diff -q` with `true` | B, C, D red | the round-trip diff itself |

**What no case reds, stated plainly rather than left to be discovered:** the FILE→`$BODY` source change *alone*, with the normalization left standing. It cannot — `body.md` and `$BODY` differ only in trailing newlines, which `deps_block` drops, so the two sources are block-equivalent by construction. AC3's one-surface property is pinned **structurally** (one `deps_block()`, both call sites through it), not behaviorally; that is a property of the code's shape, not a behavior a black-box case can reach. The script header carries this same measured map, so a maintainer following it gets the truth.

## Checks run locally

- `bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh` → PASS (5/5) under `/bin/bash` 3.2.57, also via the `.claude/skills/…` symlink path CI uses
- each of the three falsification mutations above applied to a **throwaway worktree** at this head (the PR's own files never touched) and re-run — the measured column is those runs
- `bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh plan-epic` → OK, 10 checks over 18 scripts (shellcheck `-x` clean, sources the shared lib, no `EXIT` trap, no bare `pipeline-cli`, no user-local paths)
- `/bin/bash -n` under **bash 3.2.57** on both changed scripts — CI's bash 5 structurally cannot catch a 3.2-only parse defect (#4592)
- `trap-status-guard check` over the full `claude-plugins` corpus exactly as its workflow invokes it → clean (294 files, 321 fences, 214 shell units)
- `validate-skills.sh`, `validate-cycle-presence.sh`, `validate-cycle-absence.sh` → OK
- `actionlint .github/workflows/ci.yml` → OK

## TypeScript side — checked, no parallel defect, one adjacent observation

`packages/pipeline-cli/src/tools/epic-splice/` is a **pure text transform** (`spliceEpicBody`) with **no round-trip check at all** — the comparison lives only in the shell, so there is no second copy of this asymmetry to fix and no TS change here. The shell script is the authoritative surface for the round trip.

Adjacent, **not** fixed here and flagged rather than silently absorbed: `command.ts`'s docblock says it prints "raw bytes, no trailing newline added, so the caller's PATCH round-trips byte-for-byte". The tool holds up its end — `> body.md` is byte-exact — but the caller's `$(cat)` capture then drops the trailing newline, so that byte-for-byte promise is not true end-to-end. This fix makes the *check* agree with what is written rather than changing what is written; moving the PATCH onto the file bytes is a separate, riskier call. Disclosed as a deviation below.

## §CP

`cp-classify` → `control-plane` (`claude-plugins/kampus-pipeline/skills/**`). `mergeable_state=blocked` is expected: the human approval requirement, not a defect.

## Scope

Three files, no sibling surface touched: `verify-extraction.sh` and `check1-invocation.awk` (PR #4593) were **run, never edited**; `skills/shared/**`, `gh-issue-intake-formats.md`, `skills/write-code/**`, `skills/review-code/**` and the review-gate tails are untouched. The changed-file set was derived twice — REST `pulls/4598/files` and `git diff --name-only` against merge base `32e66f24` — and the two agree exactly on the same three files (#4544 guard).

## Deviations

- **Known defect left unfixed** — **Said:** #4596 asks that the round-trip check stop false-alarming on the standard deps-last layout. **Did:** fixed the *check*; left `epic-splice`'s `command.ts` docblock promise ("the caller's PATCH round-trips byte-for-byte") untrue end-to-end, because the caller's `$(cat)` still strips the trailing newline. **Why:** moving the PATCH onto the file bytes changes what is *written*, not what is *checked* — a wider, riskier change than this issue scopes. **Disposition:** for the reviewer to judge; no follow-up filed, the observation is recorded in the TypeScript section above.

- **(repair round 1) Scope narrowing** — **Said:** the round-0 body and the script header both claimed the harness behaviorally falsifies on deleting the `deps_block` normalization. **Did:** case E now earns the trailing-blank half, and the map states that **no** case reds on the FILE→`$BODY` source change alone; AC3's one-surface property is pinned structurally, not behaviorally. **Why:** the two sources are block-equivalent by construction once the normalization stands, so no black-box case can reach that property — asserting one would be the same vacuous-claim defect this PR exists to remove. **Disposition:** stated here and in the script header; AC3 is verified by reading the two call sites, which the `review-code` verdict did at `splice-body.sh:165`/`:175`.

- **(repair round 1) Declined guidance** — **Said:** the `review-code` FAIL offered remedy (a) *correct the claims* **or** (b) *earn the claim with a fifth case*. **Did:** both — case E was added **and** both claims were rewritten to the measured mapping. **Why:** (b) alone would have left the round-0 body's other false rows standing; (a) alone would have left the trailing-blank clause pinned by nothing. **Disposition:** no action needed.

- **(repair round 1) Guard or gate bypassed — none, but the mechanism deviated** — **Said:** `write-code` repair mode runs its steps by sourcing the skill's `scripts/step*.sh`. **Did:** ran the equivalent checks as plain, separate commands with explicit `git -C <worktree>` targeting, because this run's worktree-isolation harness refuses compound/multi-statement shell invocations. **Why:** the sourced step scripts are multi-statement and were refused verbatim. **Disposition:** no guard was skipped — the Step-4 worktree preflight (git-dir ≠ common-dir) and the Step-3.5 claim guard (`claim is-mine --issue 4596` → `mine: true, reason: won`) both ran and passed, and no `--no-verify` push was made. Recorded so the substitution is visible rather than inferred.
