### PR TITLE
chore(pipeline): extract the ADR-0079 reviewer-append procedure into an executed script (#4566)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC1091,SC2086
+# Perform the ADR-0079 reviewer AC append with all four §2 fences enforced at this site.
+#
+# usage: reviewer-append-ac.sh <ISSUE> <PR> <ROUND_K> <GATE> "<criterion>" "<finding>"
+#   ISSUE     the issue whose `### Acceptance criteria` list the row lands on (for review-plan,
+#             the CHILD issue — that gate has no PR)
+#   PR        the PR number the provenance tag records (for review-plan, the child again)
+#   ROUND_K   the §5/Bounding round-cluster index for THIS PR; 1-based, a first review is round 1
+#   GATE      the appending gate's namespace — one of review-code / review-doc / review-skill /
+#             review-plan, the four call sites `../specialist-fan-out.md` names
+#   criterion the AC row text (observable, checkable from the outside)
+#   finding   the in-scope defect, named in the fence-4 escalation comment
+#
+# Three outcomes, each announced by an `APPEND-STATE:` token on stdout, all exit 0 — the gate is
+# never blocked by this step, it still posts its normal verdict:
+#   skipped-below-write-floor   fence 3 refused (not write+, or the ACL lookup failed)
+#   escalated-frozen-round-K    fence 4 froze the append and escalated to a human
+#   appended                    the one new row was written back
+# Exit 1 is the fence-1 abort (a pre-existing line would change) or an input/repo resolution that
+# could not be produced: nothing on stdout, a named diagnostic on stderr (ADR 0232, #4510).
+#
+# Extracted from `../specialist-fan-out.md`'s "Performing the append" fenced block (#4566, epic
+# #4435). The four fences are RELAYED, not re-derived (ADR 0228/0229): every decision below is the
+# one the fence made, at the same exit status. The *why* — what each fence is and why it exists —
+# stays in that file's prose and in `../gh-issue-intake-formats.md` §2, which is the single source.
+set -uo pipefail
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+if [ "$#" -ne 6 ]; then
+	echo "reviewer-append-ac: needs 6 arguments — NO append and NO escalation happened." >&2
+	echo "usage: reviewer-append-ac.sh <ISSUE> <PR> <ROUND_K> <GATE> \"<criterion>\" \"<finding>\"" >&2
+	exit 2
+fi
+ISSUE="$1"
+PR="$2"
+ROUND_K="$3"
+GATE="$4"
+CRITERION="$5"
+FINDING="$6"
+
+# Argument shape is checked before any fence runs: the fence-4 branch is `[ "$ROUND_K" -ge 3 ]`, and
+# a non-numeric ROUND_K makes `test` error out to a FALSE, which would slide a frozen round into the
+# append path. Refusing here keeps that branch's fail-closed direction intact.
+for _n in "$ISSUE" "$PR" "$ROUND_K"; do
+	case "$_n" in
+		(''|*[!0-9]*)
+			echo "reviewer-append-ac: ISSUE/PR/ROUND_K must be numbers, got '$_n' — NO append and NO escalation happened." >&2
+			exit 2
+			;;
+	esac
+done
+# The gate namespace is an argument because one script serves the four call sites that cite the
+# reference; the tag it composes is §2's, per-gate.
+case "$GATE" in
+	(review-code|review-doc|review-skill|review-plan) : ;;
+	(*)
+		echo "reviewer-append-ac: GATE must be review-code|review-doc|review-skill|review-plan, got '$GATE' — NO append and NO escalation happened." >&2
+		exit 2
+		;;
+esac
+REPO="$(kp_repo)" || {
+	echo "reviewer-append-ac: target repo unresolved — NO append and NO escalation happened." >&2
+	exit 1
+}
+echo "reviewer-append-ac scope: repo $REPO · issue #$ISSUE · pr #$PR · round $ROUND_K · gate $GATE"
+
+# the §2 in-scope-only fence (fence 2) gates whether you may append AT ALL:
+# only an in-scope finding (traces to the issue's stated goal — Route, don't grade above)
+# reaches here. A finding that fails the trace test was already routed to `report`; it must
+# NOT arrive at this append step. If it did, route it to `report` and stop — never append it.
+
+# ── Fence 3: ACL-gated, FAILS CLOSED ──────────────────────────────────────────────────────
+# resolve your OWN authority at the GitHub ACL — the same write+ floor ADR 0055 applies to
+# verdict-marker authority — BEFORE writing anything. No checked-in allowlist; the repo ACL is
+# the trust root. Any non-write+/lookup-failure result fails closed: skip the append, route the
+# finding to `report` instead (the PR is not blocked — it still gets your normal verdict).
+ME="$(gh api user --jq .login)"
+PERM="$(gh api "repos/$REPO/collaborators/$ME/permission" --jq .permission 2>/dev/null)"
+case "$PERM" in
+	(admin|maintain|write) : ;;                      # authorized — proceed
+	(*)
+		echo "below write+ floor (or ACL lookup failed) — fail closed: do NOT append, route to report"
+		echo "APPEND-STATE: skipped-below-write-floor"
+		exit 0
+		;;
+esac
+
+# ── Fence 4: frozen-after-round-K (K = N = 3) ─────────────────────────────────────────────
+# the round K this append would be tagged with arrives as an argument — the §5/Bounding
+# round-cluster index for THIS PR (the same count write-code's cap uses). An append in/after the
+# final repair round has no round left to drain-and-re-verify it within the bound, so it
+# ESCALATES to a human instead of appending-and-looping (the append-side of write-code's
+# drain-side freeze — §2 fence 4).
+if [ "$ROUND_K" -ge 3 ]; then
+	# frozen: append-rate must not outrun fix-rate. Escalate, never append — name the finding,
+	# hand the PR to a human, surface for re-triage (mirrors write-code's N=3 escalation path).
+	# The heredoc is composed through a FILE, not inline in `$(cat <<EOF … EOF)` as the reference's
+	# block wrote it: on bash 3.2 that inline form silently truncates this body at the `)` of
+	# "(accept as-is, …, or drop it)" and appends a literal `EOF )` — measured, not theorised. Same
+	# authored text, a parse the interpreter can actually deliver.
+	ESC_FILE="$(mktemp)"
+	if [ -z "$ESC_FILE" ] || [ ! -f "$ESC_FILE" ]; then
+		echo "reviewer-append-ac: mktemp produced no file — NO escalation comment was posted, NO label applied." >&2
+		exit 1
+	fi
+	cat > "$ESC_FILE" <<EOF
+### Append escalation — in-scope finding raised at/after the final repair round (round $ROUND_K)
+
+A reviewer specialist surfaced an in-scope finding, but it arrives in/after \`write-code\`'s
+final repair round (K = N = 3), so there is no round left to drain-and-re-verify a fresh AC
+within the bound. Per ADR 0079 §2 fence 4 the append is **frozen** — escalating to a human
+instead of appending-and-looping:
+
+- $FINDING
+
+Needs a human decision (accept as-is, extend the AC's life by a fresh triage, or drop it).
+EOF
+	ESCALATION="$(cat "$ESC_FILE")"
+	rm -f "$ESC_FILE"
+	gh api repos/$REPO/issues/$ISSUE/comments -f body="$ESCALATION" >/dev/null
+	gh api -X POST repos/$REPO/issues/$ISSUE/labels -f "labels[]=status:needs-triage" >/dev/null
+	echo "APPEND-STATE: escalated-frozen-round-$ROUND_K"
+	exit 0   # frozen → escalated, NOT appended
+fi
+
+# ── Fence 1: append-only — add the one new row, never edit/remove a pre-existing one ───────
+# read the CURRENT body, append exactly one §2-shaped row (provenance-tagged), write it back.
+# Reconstructing the body this way makes removal/edit unrepresentable: every pre-existing line
+# is carried through byte-for-byte; only a trailing criterion is added.
+BODY="$(gh api repos/$REPO/issues/$ISSUE --jq .body)"
+NEW_AC="- [ ] $CRITERION <!-- ac:$GATE pr:#$PR round:$ROUND_K -->"
+# The insertion point is the naive one the reference's block carried (marked `# illustrative`
+# there): the row lands at the END of the body, not under the `### Acceptance criteria` heading.
+# Making it heading-aware is new behaviour, not this conversion's to invent — fence 1 holds either
+# way, since every prior line survives verbatim.
+UPDATED="$(printf '%s\n%s\n' "$BODY" "$NEW_AC")"
+# fail-closed integrity guard: refuse to write back a body that DROPPED or ALTERED any prior
+# line — append-only means every prior line survives verbatim in the new body. If a pre-existing
+# line would change, abort (never write a body that lost a criterion — the gate-weakening
+# catastrophe fence 1 forbids). The diff is captured BEFORE it is matched on purpose: with
+# `pipefail` on, `diff … | grep -qE '^< '` returns diff's own 1-on-difference even when grep
+# matched, so the guard's `&&` would never fire and the abort would be silently disabled.
+# Its over-strictness on a body with no trailing newline is preserved as-is — see #4600.
+DIFF_OUT="$(diff <(printf '%s' "$BODY") <(printf '%s' "$UPDATED"))"
+if printf '%s\n' "$DIFF_OUT" | grep -qE '^< '; then
+	echo "append-only violation: a pre-existing line would change — ABORT, do not write" >&2
+	exit 1
+fi
+gh api -X PATCH repos/$REPO/issues/$ISSUE -f body="$UPDATED" >/dev/null
+echo "APPEND-STATE: appended"

--- a/claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
+++ b/claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
@@ -87,70 +87,51 @@ or weaken it.** The append is the route's *output*, not a new gate:
 
 §2 **defines** the four fences; this is where they are **enforced**, so an invalid append is
 unrepresentable rather than merely discouraged. §2 stays the single source of *what* each fence
-is — cite it, don't restate the definitions; the steps below are *how* the append step obeys
-them. The other three gates run **this same procedure** (one logic, four call sites). Append by
+is — cite it, don't restate the definitions; the script below is *how* the append step obeys
+them. The other three gates run **this same procedure** (one logic, four call sites). It appends by
 **reconstructing the issue body** — read it, gate, append the one new row, write it back — never
-by a blind edit:
+by a blind edit.
+
+Fence 2 gates whether you may reach this step at all: only an in-scope finding — one that
+traces to the issue's stated goal (Route, don't grade above) — arrives here. A finding that
+failed the trace test was already routed to `report`; if one reaches you anyway, route it to
+`report` and stop. The other three fences are enforced *inside* one executed script, which all
+four gates run:
 
 ```bash
-# the §2 in-scope-only fence (fence 2) gates whether you may append AT ALL:
-# only an in-scope finding (traces to the issue's stated goal — Route, don't grade above)
-# reaches here. A finding that fails the trace test was already routed to `report`; it must
-# NOT arrive at this append step. If it did, route it to `report` and stop — never append it.
-
-# ── Fence 3: ACL-gated, FAILS CLOSED ──────────────────────────────────────────────────────
-# resolve your OWN authority at the GitHub ACL — the same write+ floor ADR 0055 applies to
-# verdict-marker authority — BEFORE writing anything. No checked-in allowlist; the repo ACL is
-# the trust root. Any non-write+/lookup-failure result fails closed: skip the append, route the
-# finding to `report` instead (the PR is not blocked — it still gets your normal verdict).
-ME="$(gh api user --jq .login)"
-PERM="$(gh api "repos/$REPO/collaborators/$ME/permission" --jq .permission 2>/dev/null)"
-case "$PERM" in
-  admin|maintain|write) : ;;                       # authorized — proceed
-  *) echo "below write+ floor (or ACL lookup failed) — fail closed: do NOT append, route to report"; exit 0 ;;
-esac
-
-# ── Fence 4: frozen-after-round-K (K = N = 3) ─────────────────────────────────────────────
-# resolve the round K you would tag this append with — the §5/Bounding round-cluster index for
-# THIS PR (the same count write-code's cap uses). An append in/after the final repair round has
-# no round left to drain-and-re-verify it within the bound, so it ESCALATES to a human instead
-# of appending-and-looping (the append-side of write-code's drain-side freeze — §2 fence 4).
-ROUND_K=<the §5/Bounding round-cluster index for this PR>   # 1-based; a first review is round 1
-if [ "$ROUND_K" -ge 3 ]; then
-  # frozen: append-rate must not outrun fix-rate. Escalate, never append — name the finding,
-  # hand the PR to a human, surface for re-triage (mirrors write-code's N=3 escalation path).
-  gh api repos/$REPO/issues/$ISSUE/comments -f body="$(cat <<EOF
-### Append escalation — in-scope finding raised at/after the final repair round (round $ROUND_K)
-
-A reviewer specialist surfaced an in-scope finding, but it arrives in/after \`write-code\`'s
-final repair round (K = N = 3), so there is no round left to drain-and-re-verify a fresh AC
-within the bound. Per ADR 0079 §2 fence 4 the append is **frozen** — escalating to a human
-instead of appending-and-looping:
-
-- <finding> — <the in-scope defect; what an AC would have required>
-
-Needs a human decision (accept as-is, extend the AC's life by a fresh triage, or drop it).
-EOF
-)"
-  gh api -X POST repos/$REPO/issues/$ISSUE/labels -f "labels[]=status:needs-triage"
-  exit 0   # frozen → escalated, NOT appended
-fi
-
-# ── Fence 1: append-only — add the one new row, never edit/remove a pre-existing one ───────
-# read the CURRENT body, append exactly one §2-shaped row (provenance-tagged), write it back.
-# Reconstructing the body this way makes removal/edit unrepresentable: every pre-existing line
-# is carried through byte-for-byte; only a trailing criterion is added.
-BODY="$(gh api repos/$REPO/issues/$ISSUE --jq .body)"
-NEW_AC="- [ ] <criterion — observable, checkable from the outside> <!-- ac:review-code pr:#$PR round:$ROUND_K -->"
-# append the row under the ### Acceptance criteria list; do not touch any existing row
-UPDATED="$(printf '%s\n%s\n' "$BODY" "$NEW_AC")"   # illustrative — insert under the AC heading, preserving every prior line
-# fail-closed integrity guard: refuse to write back a body that DROPPED or ALTERED any prior
-# line — append-only means every prior line survives verbatim in the new body. If a pre-existing
-# line would change, abort (never write a body that lost a criterion — the gate-weakening
-# catastrophe fence 1 forbids):
-diff <(printf '%s' "$BODY") <(printf '%s' "$UPDATED") | grep -qE '^< ' && { echo "append-only violation: a pre-existing line would change — ABORT, do not write"; exit 1; }
-gh api -X PATCH repos/$REPO/issues/$ISSUE -f body="$UPDATED"
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac.sh \
+  <ISSUE> <PR> <ROUND_K> <review-code|review-doc|review-skill|review-plan> \
+  "<criterion — observable, checkable from the outside>" \
+  "<finding — the in-scope defect; what an AC would have required>"
 ```
+
+- **`ISSUE` / `PR`** — the issue whose `### Acceptance criteria` list the row lands on, and the
+  PR the provenance tag records. `review-plan` has no PR, so it passes the **child** issue for
+  both (its own §2 tag reads `pr:#<child>`).
+- **`ROUND_K`** — the §5/Bounding round-cluster index for this PR; 1-based, a first review is
+  round 1. It arrives as an argument because the round count is the gate's to resolve, not the
+  append's.
+- **`GATE`** — your own namespace, so the row carries §2's per-gate provenance tag
+  (`ac:review-code` / `ac:review-doc` / `ac:review-skill` / `ac:review-plan`).
+
+Read the result off **stdout** (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)):
+one `APPEND-STATE:` token names which of three outcomes happened, all of them exit 0 — the gate
+is never blocked by this step and still posts its normal verdict.
+
+| `APPEND-STATE:` | fence | what happened |
+|---|---|---|
+| `skipped-below-write-floor` | 3 | your ACL is below `write+`, or the lookup failed — nothing was written; route the finding to `report` |
+| `escalated-frozen-round-K` | 4 | the round is at/after K = N = 3 — the escalation comment and `status:needs-triage` landed, the AC did **not** |
+| `appended` | 1 | the one new row was written back |
+
+A non-zero exit is the fence-1 abort (a pre-existing line would have changed) or an input the
+script could not resolve: nothing on stdout, a named diagnostic on stderr. Treat it as a hold —
+the issue body was **not** written. **Known standing condition:** an issue body read back through
+`gh api … --jq .body` never ends in a newline, which `diff` reports as its last line *changing*,
+so fence 1 aborts on every non-empty body. That over-strictness is inherited verbatim from the
+procedure this script was extracted from and is out of scope to relax here — it errs toward
+refusing a write, never toward losing a criterion ([#4600](https://github.com/kamp-us/phoenix/issues/4600)).
 
 The append is **append-only by construction** (fence 1): the body is rebuilt from the existing
 one with a single row added, and a `diff` guard refuses any write that would drop or mutate a


### PR DESCRIPTION
The shared fan-out reference carried a 58-line block of inline `gh`/`jq` shell that four review
gates run as their acceptance-criterion append procedure. This moves that shell into one script the
gates execute by path and read the answer off stdout, leaving the reference to say what the script
does and when to run it. Nothing about what the procedure decides changes — the same four fences
make the same calls at the same exit statuses; only how it is invoked and how its result comes back
are new.

Fixes #4566

## What changed

- **New:** `claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac.sh` — the ADR-0079
  append procedure as one executed script (`set -uo pipefail`, no `EXIT` trap, sources
  `lib/common.sh` through the column-0 `BASH_SOURCE` idiom of ADR 0230).
- **Changed:** `claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md` — the fence
  (lines 95–153 on the merge base, 59 lines inclusive of both fences) becomes the literal-path
  invocation plus the argument contract, the `APPEND-STATE:` outcome table, and the non-zero
  contract. The `### Performing the append …` heading is byte-unchanged, so the four gates'
  deep-links to it still resolve.

The disposition was ruled EXTRACT at the epic ledger
(https://github.com/kamp-us/phoenix/issues/4566#issuecomment-5147227463); this PR is the build half
of that ruling and relitigates nothing.

## Per-fence behaviour-preservation proof

Run against `GNU bash 3.2.57(1)-release (arm64-apple-darwin23)` — the interpreter a local agent run
gets — with `gh` replaced by a recording stub, so every decision and exit status below is measured,
not asserted.

| fence | input | decision | exit | sourced vs executed |
|---|---|---|---|---|
| 3 | `permission` = `read` | prints the block's own `below write+ floor …` line, no writes | 0 | identical |
| 3 | ACL lookup fails (non-zero `gh`) | same fail-closed skip | 0 | identical |
| 4 | `ROUND_K` = 3 | escalation comment + `status:needs-triage`, no append | 0 | identical decision; comment text corrected, see Deviations |
| 4 | `ROUND_K` = 1 or 2 | falls through to fence 1 | — | identical |
| 1 | body with a prior line dropped | `append-only violation … ABORT`, no PATCH | 1 | identical |
| 1 | body with a prior line mutated | `append-only violation … ABORT`, no PATCH | 1 | identical |
| 1 | clean append | PATCH with body + one row | 0 | identical |
| — | no arguments | usage refusal, **empty stdout** | 2 | new (the block took no arguments) |

**The empty-input exit status.** The clean/empty answer is exit **0**, not 1: an empty issue body
appends normally (`APPEND-STATE: appended`, rc 0), and a below-`write+` ACL — the "I found nothing
to do" shape — is also rc 0, because this script's status answers *could I answer*, never *did I
find something*. The only non-zero paths are the fence-1 abort and an input the script could not
resolve, and both print nothing on stdout.

**The fence-1 guard is not vacuous.** With the guard disabled, the dropped-line and mutated-line
cases both reach `WOULD PATCH`; re-enabled, both abort. The red comes from the guard.

**Why fence 1 could not stay a pipeline.** Measured, all three in one run:

| form | `pipefail` | a prior line DROPPED |
|---|---|---|
| `diff … \| grep -qE '^< ' && { abort; }` (the block's) | off | ABORT, rc 1 |
| same | **on** (the mandated executed shape) | **WOULD PATCH, rc 0 — guard silently disabled** |
| capture the diff, then match (this PR's) | on | ABORT, rc 1 |

Under `pipefail`, `diff`'s own 1-on-difference becomes the pipeline's status even when `grep`
matched, so the `&&` never fires. Capturing the diff before matching is what preserves the abort.

**The bash 3.2 `case` check.** `/bin/bash -n` (3.2.57) parses the script clean, and both `case`
statements use POSIX leading `(` on their patterns. Parse-clean was not sufficient on its own: the
fence-4 heredoc composed inline as `$(cat <<EOF … EOF)` **parsed** fine and then **truncated at
runtime** under 3.2, cutting the body at the `)` of "(accept as-is, …, or drop it)" and appending a
literal `EOF )`. That is the live instance of the 3.2 balancing defect, caught by running the script
rather than only linting it.

## Verification surfaces

- `pipeline-cli trap-status-guard check` — clean over the two changed files, and clean corpus-wide
  (294 files, 321 markdown fences, 214 shell units).
- `pipeline-cli cli-invocation-guard check` — clean.
- `pipeline-cli gh-phoenix lint-skills` — clean over the **whole** corpus, run exactly as
  `skill-gh-lint.yml` runs it.
- `shellcheck -x` — clean.
- `kp_skill_source_edges` resolves this script's source line to `lib/common.sh` (ADR 0230 edge is
  visible, not suppressed), and `kp_skill_shell_surfaces` lists the new file.
- `validate-cycle-presence.sh` / `validate-cycle-absence.sh` — both OK. **Stated as a non-proof:**
  they only cover four hardcoded skills and never scan `skills/shared/*.md`, so their green says
  nothing about this diff.
- `pnpm typecheck` clean; `pnpm lint:worktree` reports no biome-handled changed files (shell +
  markdown only).
- `extraction-coverage-proof.sh` on the two files: SCOPE ok on all three guards, TEETH ok on all
  three, and one `FAIL lint-skills clean over the handed set`. That row is the harness's own
  zero-scope artifact — `lint-skills`' frontmatter leg sees no `SKILL.md` in a 2-file set and fails
  closed. Control: the same row FAILs on `cp-read.sh` + `gh-issue-intake-formats.md`, two files this
  PR does not touch.

## The four gate call sites

`review-code`, `review-doc`, `review-skill` and `review-plan` each cite this reference by deep-link
to the `### Performing the append — the four fences, enforced at this site (ADR 0079)` heading and
name their own `ac:review-*` provenance tag; none of them inlined the block. The heading text is
unchanged, so all four links still resolve and **no gate file needed a change** — which is also why
none was touched (four sibling PRs are banked or live over those trees).

## Deviations

- **Scope narrowing / out-of-scope shape** — **Said:** the ledger ruling's shape note names three
  arguments (ISSUE, PR, ROUND_K; repo via the shared lib). **Did:** the script takes six — those
  three plus GATE, CRITERION and FINDING. **Why:** the block's tag literal is `ac:review-code`, but
  the ruling also requires one script to serve four callers, and §2 gives each gate its own
  `ac:review-*` tag — so the namespace has to be an argument or three of the four callers would
  write the wrong provenance. CRITERION and FINDING are the block's two remaining placeholders; left
  as literals the script would post `<criterion — observable, checkable from the outside>` to a real
  issue. GATE is validated against the four namespaces the reference itself enumerates, so the
  generalisation is fail-closed, and for the `review-code` call site the composed row is
  byte-identical to the block's. **Disposition:** no action needed; stated here per §DEV.
- **Governing-ADR-adjacent restructure (fence 4)** — **Said:** relay the fences, never re-derive
  them. **Did:** the fence-4 escalation heredoc is composed through a temp file instead of inline in
  `$(cat <<EOF … EOF)`. **Why:** measured on bash 3.2, the inline form truncates the comment body
  mid-sentence and appends a literal `EOF )`. The authored text is unchanged; only the parse path
  is. Same decision, same exit status, same label POST. **Disposition:** no action needed.
- **Governing-ADR-adjacent restructure (fence 1)** — **Said:** same. **Did:** the `diff` output is
  captured into a variable and matched in a second statement instead of piped straight into `grep`.
  **Why:** the executed shape mandates `pipefail`, under which the original pipeline never aborts
  (table above). Restructuring is what keeps the fail-closed branch fail-closed. **Disposition:** no
  action needed.
- **Known defect left unfixed** — **Said:** fence 1 refuses a write that would drop or alter a prior
  line. **Did:** left verbatim the fact that it aborts on **every** non-empty body, because
  `gh api … --jq .body` strips the trailing newline and `diff` then reports the last line as
  changed. **Why:** relaxing it would change what the fence decides on a whole input class, which
  the ruling forbids; the failure direction is safe (refuse the write, never lose a criterion).
  **Disposition:** follow-up #4600 filed, and the reference records it as a known standing
  condition.
- **Known defect left unfixed** — **Said:** nothing. **Did:** the three `gh` mutation calls
  (escalation comment, label POST, body PATCH) still have their exit statuses unchecked, exactly as
  the block left them. **Why:** checking them would change the script's exit status on a new input
  class; that is glue→verb work, #1929's. **Disposition:** for the reviewer to judge.
- **Scope narrowing** — **Said:** the block's `# illustrative` line marks the insertion point as
  "insert under the AC heading". **Did:** kept the naive `printf '%s\n%s\n'`, which appends the row
  at the end of the body. **Why:** heading-aware insertion is new behaviour, not a conversion; fence
  1 holds either way. **Disposition:** no action needed; the script's comment says so at the site.
- **Result-channel change (sanctioned by ADR 0232 / #4510)** — **Said:** conversion changes the
  invocation and the result channel. **Did:** added a §ZS scope line and one `APPEND-STATE:` token
  per outcome on stdout, moved the fence-1 abort diagnostic to stderr, and suppressed the three
  `gh` mutations' JSON so stdout carries only the answer. **Why:** the io contract requires a
  positive token rather than an absence, and a non-zero exit with empty stdout. No decision or exit
  status moved. **Disposition:** no action needed.
- **Out-of-scope change** — **Said:** edit no surface but the reference. **Did:** added one
  paragraph to the reference recording the #4600 standing condition. **Why:** without it a gate
  hitting the abort reads it as its own mistake. **Disposition:** for the reviewer to judge.

Not disclosed because they did not happen: no guard or gate bypassed (no `--no-verify`, no
suppressed lint, no skipped test), no pre-existing test or fixture changed, no reviewer or triage
guidance declined.
