### PR TITLE
docs(epic-splice): the docblock stops promising a byte-exact PATCH round-trip (#4599)

### DIFF
--- a/packages/pipeline-cli/src/tools/epic-splice/command.ts
+++ b/packages/pipeline-cli/src/tools/epic-splice/command.ts
@@ -8,11 +8,14 @@
  * first-time APPEND or a re-plan in-place REPLACE — with the anchor-count guards. `--plan-file`
  * present ⇒ re-plan mode; absent ⇒ first-time (or a deps-only re-splice).
  *
- * Exit 0 = a clean splice printed to stdout (raw bytes, no trailing newline added, so the caller's
- * PATCH round-trips byte-for-byte). Exit 1 = a corrupt-heading refusal (the reason on stderr) — the
- * caller must inspect by hand rather than blind-write. Pure text transform: no `gh` boundary, so it
- * needs no `Github` layer — the optimistic `updated_at` recheck + PATCH orchestration stay in the
- * skill prose (#3689 scope).
+ * Exit 0 = a clean splice printed to stdout as raw bytes, with no trailing newline added. That is
+ * the tool's half only, and it is not an end-to-end byte-exactness guarantee: the sole executing
+ * caller — `plan-epic`'s `splice-body.sh` — captures stdout with `BODY="$(cat …)"`, and command
+ * substitution strips every trailing newline before the PATCH, so what GitHub stores is
+ * trailing-newline-normalized rather than the emitted bytes (#4599). Exit 1 = a corrupt-heading
+ * refusal (the reason on stderr) — the caller must inspect by hand rather than blind-write. Pure
+ * text transform: no `gh` boundary, so it needs no `Github` layer — the optimistic `updated_at`
+ * recheck + PATCH orchestration stay in the skill prose (#3689 scope).
  */
 import {readFileSync} from "node:fs";
 import {Effect, Option} from "effect";
@@ -54,7 +57,8 @@ const apply = Command.make(
 			process.stderr.write(`epic-splice: ${outcome.reason}\n`);
 			return yield* Effect.sync(() => process.exit(CORRUPT_EXIT_CODE));
 		}
-		// Raw bytes, no trailing newline added — the caller PATCHes this verbatim (byte-preservation).
+		// Raw bytes, no trailing newline added. What the caller then writes is not these exact bytes —
+		// see the docblock (#4599).
 		yield* Effect.sync(() => process.stdout.write(outcome.body));
 		process.stderr.write(
 			`epic-splice: ${outcome.mode === "append" ? "appended" : "spliced"} the section(s)\n`,


### PR DESCRIPTION
A comment in the `epic-splice` tool told readers that the epic-body bytes it prints get written to GitHub unchanged. They don't. The tool prints its bytes cleanly, but the one script that calls it captures the output in a way that quietly drops trailing newlines before sending it, so what GitHub stores is close to — but not exactly — what the tool emitted. This PR rewrites the two comments that made the wrong promise so they describe what actually happens. Nothing about how the tool behaves changes.

Fixes #4599

## What changed

One file, comments only: `packages/pipeline-cli/src/tools/epic-splice/command.ts`.

**The docblock (was lines 11–15).** Before:

```
 * Exit 0 = a clean splice printed to stdout (raw bytes, no trailing newline added, so the caller's
 * PATCH round-trips byte-for-byte). Exit 1 = a corrupt-heading refusal (the reason on stderr) — the
 * caller must inspect by hand rather than blind-write. …
```

After:

```
 * Exit 0 = a clean splice printed to stdout as raw bytes, with no trailing newline added. That is
 * the tool's half only, and it is not an end-to-end byte-exactness guarantee: the sole executing
 * caller — `plan-epic`'s `splice-body.sh` — captures stdout with `BODY="$(cat …)"`, and command
 * substitution strips every trailing newline before the PATCH, so what GitHub stores is
 * trailing-newline-normalized rather than the emitted bytes (#4599). Exit 1 = a corrupt-heading
 * refusal (the reason on stderr) — the caller must inspect by hand rather than blind-write. …
```

**The inline restatement (was line 57).** Before:

```
		// Raw bytes, no trailing newline added — the caller PATCHes this verbatim (byte-preservation).
```

After:

```
		// Raw bytes, no trailing newline added. What the caller then writes is not these exact bytes —
		// see the docblock (#4599).
```

The emit-site comment keeps the local invariant it sits on (this write adds no newline) and points at the docblock for the *why*, rather than restating it — CLAUDE.md's state-a-why-once rule.

## Acceptance criteria

- [x] The docblock no longer claims the caller's PATCH round-trips byte-for-byte; it states the tool emits raw bytes with no added trailing newline, and that `splice-body.sh` strips trailing newlines via its `$(cat)` capture before the PATCH.
- [x] The inline restatement is reconciled to the same truth — no surface in `command.ts` still asserts end-to-end byte-preservation.
- [x] No behavior change. `process.stdout.write(outcome.body)` is untouched, and `splice-body.sh` is not in this diff.
- [x] Consistent with #4598's `deps_block` design: the new wording says the *stored* body is the post-strip form, which is exactly the side #4598 derives both of its diff operands from — true whether or not #4598 has merged.

## Verification

- `pnpm typecheck` — clean (29/29).
- `pnpm lint:worktree` — clean (1 file checked).
- `pnpm vitest run src/tools/epic-splice` — 12/12 pass (unchanged; comments only).
- `pipeline-cli cp-classify classify` on the changed-file set — `not-control-plane [path-clear-no-content-source]`, exit 3.

## Deviations

**Class: narrowed scope on a judgment call.**

- *Said:* sweep the whole `epic-splice/` directory (and its tests) for any other statement of the same guarantee, by meaning rather than by phrase, on the assumption a third surface might exist.
- *Did:* swept the directory and then all of `packages/pipeline-cli/src` for `byte-for-byte`, `verbatim`, `byte-preservation`, `round-trip`, `trailing newline`, and `PATCH`. Found further hits in `epic-splice.ts` (lines 14–15) and `epic-splice.unit.test.ts` (lines 5, 40, 58, 81) and **left them alone**.
- *Why:* those state a different claim, and it is true. They describe the pure transform's invariant — every byte *outside* the replaced section survives, because the splice slices on the heading boundary instead of reconstructing. That is a property of `spliceEpicBody`, has nothing to do with what the shell caller later PATCHes, and is what the tests actually assert. Editing it would have made a correct guarantee read as doubtful. Only the two `command.ts` surfaces made the end-to-end claim.
- *Disposition:* no action needed — for the reviewer to confirm the meaning-level split is right.

**Class: an option deliberately not taken.** Making the PATCH byte-exact was considered and rejected in triage (recorded on #4599): #4598's `deps_block` normalization is designed around the strip existing, and whether GitHub's issues PATCH preserves a trailing `body` newline is unverified in this repo, so that direction starts with an experiment. This PR does not attempt it and does not touch `splice-body.sh`. *Disposition:* out of scope by the recorded triage call; a future caller that genuinely needs byte-exactness is a new issue.
