### PR TITLE
refactor(review-code): convert the env-file sourcing fences to ADR 0232 executed/stdout invocation (#4574)

### DIFF
--- a/.patterns/skill-script-io-contract.md
+++ b/.patterns/skill-script-io-contract.md
@@ -123,9 +123,13 @@ its stdout instead ([#4487](https://github.com/kamp-us/phoenix/issues/4487)).
 - [`claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh`](../claude-plugins/kampus-pipeline/skills/shared/scripts/cp-read.sh) —
   the sourced §CPREAD helpers: no stdout at all, results in `CP_*` variables, every scope and
   failure line on stderr.
-- `skills/review-code/scripts/classify-control-plane.sh` — a **machine** answer channel (the
-  run-state handle path), which is why every failure path writes the handle with a §CP sentinel
-  before exiting non-zero rather than leaving stdout empty.
+- `skills/review-code/scripts/classify-control-plane.sh` — a **machine** answer channel of
+  `KEY=value` lines, which is why every failure path prints the flags as a §CP sentinel before
+  exiting non-zero rather than leaving stdout empty. Its `%q`-quoted flags are the positive-token
+  rule applied literally: the ordinary not-§CP answer is `''`, not an absence. Its siblings
+  `materialize-head.sh` and `run-evidence-read.sh` are the same shape — each once returned a path to
+  a §SP handle for the caller to source, and ADR 0232 moved the answer onto stdout while the handle
+  stayed behind purely for the *later scripts of the same skill* to re-source in-process (#4574).
 - `skills/review-design/scripts/classify-control-plane.sh` and
   `skills/shared/scripts/cp-classify-entry.sh` — **prose** answer channels, each printing its own
   §CP scope line ahead of the `BLOCKING (…)` lines.

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -44,7 +44,7 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/resolve-repo.sh"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/resolve-repo.sh
 ```
 
 Every script below resolves the repo the same way, through the shared lib's `kp_repo` — so the
@@ -56,8 +56,18 @@ fenced block does not (each agent shell invocation is a fresh process).
 This skill's shell lives in [`scripts/`](scripts/) and every fenced `bash` block below is an
 **invocation** of one. The prose keeps the *why*; the scripts hold the *how* (epic #4435 phase 1 —
 the shell moved as-is, and turning its `gh`/`jq` glue into tested `pipeline-cli` verbs is #1929, ADR
-0228: a script may RELAY a verb's answer, never DERIVE the decision). Four properties are
+0228: a script may RELAY a verb's answer, never DERIVE the decision). Five properties are
 load-bearing when you read or edit them:
+
+- **Every one is EXECUTED by literal path, and stdout is its answer** — `bash
+  ./claude-plugins/kampus-pipeline/skills/review-code/scripts/<script>.sh …`, never `.`/`source` at
+  your top-level command and never the old interpolated plugin-root idiom (a `${…:-…}`-defaulted
+  variable standing in for the plugin directory), both of which the isolation verifier refuses (ADR
+  [0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)).
+  Each fence below names what to read off stdout. A script *internally* sourcing a sibling or a
+  shared helper is untouched by that ban — the verifier judges only your top-level command — which is
+  why [`scripts/head-env.sh`](scripts/head-env.sh) and the shared-lib sources below still read as
+  they always did.
 
 - **They set `set -uo pipefail`, deliberately not `-e`.** The moved glue decides its own control flow
   through the guards written into it — `|| true` on a read that may legitimately match nothing, a
@@ -143,7 +153,7 @@ You're given a PR number (or you're told to review the PR for issue #N). Bind `P
 number, then establish the PR ↔ issue pairing — the issue is where the acceptance criteria live.
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/pr-context.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/pr-context.sh "$PR"
 ```
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam
@@ -151,7 +161,7 @@ Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam
 timeline if it's not obvious:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/linked-issue-timeline.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/linked-issue-timeline.sh "$PR"
 ```
 
 Pin down `ISSUE=<N>`. If there is **no** linked issue, the rule is **class-aware** — this is
@@ -164,7 +174,7 @@ signal, **not** a second taxonomy; the ADR 0075 discipline `review-doc` follows 
 Step-0 class):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/classify-issueless.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-issueless.sh "$PR"
 ```
 
 Read the script's **exit status before its stdout**, and note the carve-out line is the *permissive*
@@ -198,7 +208,7 @@ When `ISSUE` **is** set, honor it as today — bind `ISSUE` to that number and p
 and its acceptance criteria:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/issue-context.sh" "$ISSUE"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/issue-context.sh "$ISSUE"
 ```
 
 Extract the `### Acceptance criteria` checklist from the issue body. That list — every
@@ -229,7 +239,7 @@ Verification is grounded in the diff, the tests, and — where it matters — th
 not in the PR's self-description. Pull the change:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/pr-diff.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/pr-diff.sh "$PR"
 ```
 
 This same loaded diff (and the review worktree below) is what the **specialist fan-out** runs
@@ -249,7 +259,7 @@ to `review-doc`'s skills-only / pure-code routes and `review-skill`'s "not a ski
 each gate hands a mis-classed PR to the gate that owns its class:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/classify-skills-only.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-skills-only.sh "$PR"
 ```
 
 Three outcomes, and the **exit status is read before the stdout**: a non-zero exit is UNKNOWN and
@@ -329,16 +339,23 @@ make the isolation hold *by construction*, not by your remembering to behave:
 Your own session stays in *this* worktree (the trusted base config you were launched under).
 
 ```bash
-. "$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/materialize-head.sh" "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh "$PR" || exit 1
 ```
 
-The script's **only stdout line is the run-state handle** carrying `REVIEW_WT` / `PR_REF` /
-`HEAD_SHA` / `BASE_REF`, so sourcing its output puts those four in your shell; every progress, scope
-and FATAL line goes to stderr. On any failure path stdout is empty and the exit is non-zero, so the
-`.` itself fails loudly — **never** fall back to reading the launched checkout's working copy (that
-is the #793 false-PASS: reviewing the base tree while binding the verdict to the head SHA). Later
-steps re-derive the same four values with
-[`scripts/head-env.sh`](scripts/head-env.sh) after the harness resets the shell between calls.
+**Executed, not sourced, and stdout is the answer** (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md),
+[`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md)).
+It prints four `KEY=value` lines — `REVIEW_WT`, `PR_REF`, `HEAD_SHA`, `BASE_REF` — and every
+progress, scope and FATAL line goes to stderr. **Read those four values off stdout and carry them
+forward yourself**; every `$REVIEW_WT` / `$PR_REF` / `$HEAD_SHA` / `$BASE_REF` below names the value
+you read here, not a variable that survives into the next Bash call (the harness resets the shell
+between calls, which is why leaving state in the caller's shell was retired as a design property).
+**Read the exit status before the stdout:** on any failure path stdout is empty and the exit is
+non-zero, and that is UNKNOWN — **never** fall back to reading the launched checkout's working copy
+(the #793 false-PASS: reviewing the base tree while binding the verdict to the head SHA). The four
+values also persist to a per-run §SP handle that this skill's *own later scripts* re-source
+in-process via [`scripts/head-env.sh`](scripts/head-env.sh) — in-script sourcing of a sibling script
+stays sanctioned; only the `.` at your top-level command is banned.
 
 The cross-fork case needs no special branch: `pull/$PR/head` is the GitHub-provided ref for
 the PR head whether it lives on this repo or a fork, so the single `git fetch` above covers
@@ -350,7 +367,7 @@ an output), run the repo's commands **inside the review worktree** — behavior 
 running beats behavior inferred from a diff:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/worktree-checks.sh"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-checks.sh
 ```
 
 Scoping a test to the criterion is fine when the SHA-bound run-evidence bundle (Step 2) corroborates
@@ -362,7 +379,7 @@ degrade block below: run the FULL unit project, never a subset.
 just the happy path:**
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/teardown-head.sh"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh
 ```
 
 It is the review's own `rm -rf` of a detached, already-pushed throwaway
@@ -370,10 +387,10 @@ it materialized itself (safe — it holds no branch and no unpushed work), so ru
 the review is exiting `FAIL` or aborting after a typecheck/lint error; a leaked `review-head-*`
 tree accumulates on the shared primary otherwise (#2785). To catch a mid-block error inside a
 single Bash call, register the script as a trap right after materialization:
-`trap '…/scripts/teardown-head.sh' EXIT` — and note the trap belongs to **your** shell, not to any
-extracted script: none of them installs an `EXIT` trap, because under bash 3.2 the trap's last
-command becomes the script's exit status and would launder a `set -u` abort into exit 0 (#4476,
-class #4479). And the
+`trap 'bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh' EXIT` —
+and note the trap belongs to **your** shell, not to any extracted script: none of them installs an
+`EXIT` trap, because under bash 3.2 the trap's last command becomes the script's exit status and
+would launder a `set -u` abort into exit 0 (#4476, class #4479). And the
 standing net for the un-catchable case — a session-end abort *between* Bash calls, which no
 in-shell trap can reach — is `pipeline-cli worktree-sweep --execute` (#2785): it reclaims any
 leaked `review-head-*` tree that is clean + idle + unlocked, **without** `--force` (a dirty /
@@ -386,7 +403,7 @@ the full build inputs, so the typecheck bootstrap is whole — run it and treat 
 the typecheck signal:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/worktree-typecheck.sh"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh
 ```
 
 CI and the SHA-bound run-evidence bundle (below) are now **corroboration**, not the sole
@@ -419,19 +436,23 @@ you received an archive and not a 503 error body; `schemaVersion` and
 load-bearing**: a bundle from a stale earlier push is not evidence for this commit.
 
 ```bash
-. "$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/run-evidence-read.sh" "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-read.sh "$PR" || exit 1
 ```
 
-Sourcing its one stdout line puts `HEAD_SHA`, `BUNDLE_STATE` (`present` | `pending` | `absent` |
-`unknown`) and `BUNDLE_LINE` in your shell. **Read the state word, never the exit alone** — the verb
-exits 0 only on `present`, and the other three are different facts, not one "absent".
+**Executed, not sourced, and stdout is the answer** (ADR 0232). It prints four `KEY=value` lines —
+`HEAD_SHA`, `BUNDLE_STATE` (`present` | `pending` | `absent` | `unknown`), `BUNDLE_JSON` (the
+downloaded manifest's path) and `BUNDLE_LINE` (last, printed raw, so you can lift it verbatim).
+**Read the state word, never the exit alone** — the four states are different facts, not one
+"absent". A `BUNDLE_STATE` outside that enumerated set is not a fifth state: the script prints
+nothing, names the diagnostic on stderr and exits non-zero, so **a non-zero exit here is UNKNOWN**
+— report it as such and never as `absent`.
 
 When the state is `present`, `.manifest` carries the structured results (ADR 0054 §2 fields):
 `checks[]` is each gate step (`{name, status: pass|fail}`), `tests` is the folded JUnit summary
 (`{total, passed, failed, skipped, failingSuites[]}`).
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/run-evidence-manifest.sh"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-manifest.sh
 ```
 
 Cite those numbers as the evidence for any criterion they speak to — "lint/typecheck/unit
@@ -483,7 +504,7 @@ gate exists to prevent. On the degrade path therefore:
   past a degraded verification.
 
   ```bash
-  "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/full-unit-project.sh"
+  bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/full-unit-project.sh
   ```
 
 - **If — and only if — the full unit project genuinely cannot run** (an environment fault
@@ -539,16 +560,19 @@ than carrying a copy of, so there is nothing to keep in step (#4489). It holds �
 return:
 
 ```bash
-. "$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/classify-control-plane.sh" "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh "$PR"
 ```
 
-Sourcing its one stdout line puts `CONTROL_PLANE_TOUCHED` and `GUARD_TOUCHING` in your shell — the
-two flags Step 4a branches on — plus the `CP_FILES_N` / `ADR_N` scope counts. **A non-empty either
-flag ⇒ §CP-advisory** (ADR 0053/0065/0073 for the path clause; ADR 0164/0135 for the content clause).
-Every failure path writes the flags as a non-empty `§CP UNKNOWN, held as control-plane` sentinel
-*before* exiting non-zero, because an empty flag is exactly what Step 4a reads as auto-mergeable —
-and if even the handle could not be written, stdout is empty, the `.` fails loudly, and the PR is
-held as control plane.
+**Executed, not sourced, and stdout is the answer** (ADR 0232). It prints four `KEY=value` lines —
+`CONTROL_PLANE_TOUCHED` and `GUARD_TOUCHING`, the two flags Step 4a branches on, plus the
+`CP_FILES_N` / `ADR_N` scope counts. The two flag values are `printf '%q'`-quoted, so each is a
+single line and the **empty** (not-§CP) answer arrives as the positive token `''` rather than as an
+absence you have to infer. **A non-empty either flag ⇒ §CP-advisory** (ADR 0053/0065/0073 for the
+path clause; ADR 0164/0135 for the content clause). Every failure path prints the flags as a
+non-empty `§CP UNKNOWN, held as control-plane` sentinel *before* exiting non-zero, because an empty
+flag is exactly what Step 4a reads as auto-mergeable. **Read the exit status before the stdout**: a
+non-zero exit is a hold whatever the flags say, and stdout carrying no `CONTROL_PLANE_TOUCHED=` line
+at all means the classifier never ran — UNKNOWN, so hold the PR as control plane.
 
 ---
 
@@ -634,7 +658,7 @@ per the formats §Reading stance — a `**Containment:**` line, with a leading b
 in the body:
 
 ```bash
-CONTAINMENT="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/containment-marker.sh" "$ISSUE")"
+CONTAINMENT="$(bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/containment-marker.sh "$ISSUE")"
 ```
 
 The script prints exactly one of `flag` | `exempt` | `none`. `none` is the *skip* answer, so on a
@@ -684,7 +708,7 @@ FAIL — there is no dark feature here to gate (it is **not** a graceful skip; t
 surface and the surface came back empty):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/userfacing-scope.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/userfacing-scope.sh "$PR"
 ```
 
 The matched-paths emit is **load-bearing, not narration** (§ZS #1): the verdict states the exact
@@ -756,7 +780,7 @@ the same change that ships the surface.
 folder is *new* only when its marker path is absent on fresh base.
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/glossary-freshness.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh "$PR"
 ```
 
 The three detectors, the positive-evidence-of-scope probe and the four-outcome verdict chain live in
@@ -871,7 +895,7 @@ relevant-but-zero-match** case, and express a no-comment diff as an **explicit n
 skip** — distinct from a FAIL.
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/comment-scan.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/comment-scan.sh "$PR"
 ```
 
 It prints the §ZS scope line, then the scanned lines themselves — the fence left those in a shell
@@ -924,7 +948,7 @@ lint's self-exempt array, the shape [#4491](https://github.com/kamp-us/phoenix/p
 query is one file's licence, not the directory's.
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/unresolved-threads-read.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/unresolved-threads-read.sh "$PR"
 ```
 
 Read the script's **exit status before its stdout**: an unreadable `reviewThreads` response prints
@@ -984,7 +1008,7 @@ Detect it off the diff Step 2 already loaded — emit the scanned scope (§ZS #1
 that silently stops matching is visible in the run output rather than reading green:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/session-caching-scan.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/session-caching-scan.sh "$PR"
 ```
 
 It prints the §ZS scope line, then the candidate lines themselves, so you can judge each against the
@@ -1125,7 +1149,7 @@ any verdict not bound to the PR's current head (ADR
 verdict-body shape at the end of this step.
 
 ```bash
-HEAD_SHA="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/current-head.sh" "$PR")"   # the head you reviewed
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/current-head.sh "$PR")"   # the head you reviewed
 ```
 
 The script shape-asserts the SHA (bare 40-hex) and prints **nothing** on a failed read, so gh's error
@@ -1163,7 +1187,7 @@ genuinely unavoidable, the body **MUST** first pass `pipeline-cli leak-guard sca
 [the gate-verdict contract §READBACK](../shared/gate-verdict-contract.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
 
 ```bash
-printf '%s' "$BODY" | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-emit-pass.sh" "$PR" "$HEAD_SHA"
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-emit-pass.sh "$PR" "$HEAD_SHA"
 ```
 
 `$BODY` is the verdict body **you** compose — its canonical shape is the markdown block at the end of
@@ -1345,8 +1369,8 @@ any later use are one single-sourced read, never two independent resolutions tha
 straddle a head move:
 
 ```bash
-HEAD_SHA="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/current-head.sh" "$PR")"   # resolve ONCE, before composing (mirror the PASS path)
-printf '%s' "$BODY" | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-emit-fail.sh" "$PR" "$HEAD_SHA"
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/current-head.sh "$PR")"   # resolve ONCE, before composing (mirror the PASS path)
+printf '%s' "$BODY" | bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-emit-fail.sh "$PR" "$HEAD_SHA"
 ```
 
 Same stdin seam as the PASS path, for the same reason — no fixed or `${PR}`-keyed scratch name a
@@ -1441,7 +1465,7 @@ state (never a carried variable) and runs the read-back on whatever landed, on *
 [the gate-verdict contract §READBACK — Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../shared/gate-verdict-contract.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-code/scripts/verdict-readback.sh" "$PR" "$HEAD_SHA" || exit 1
+bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/verdict-readback.sh "$PR" "$HEAD_SHA" || exit 1
 ```
 
 The script **sources** `verdict_post_verify` from

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
@@ -4,19 +4,25 @@
 # review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract + shell-option rationale:
 # ../SKILL.md § The extracted scripts. The *why* for each clause stays in that step's prose.
 #
-# STDOUT IS A MACHINE CHANNEL: the only stdout line is the run-state handle carrying
-# CONTROL_PLANE_TOUCHED / GUARD_TOUCHING / CP_FILES_N / ADR_N, so Step 4a can
-# `. "$(classify-control-plane.sh "$PR")"` and branch on the two flags. Scope + diagnostic lines go
-# to stderr, per `.patterns/skill-script-io-contract.md`. The §CPREAD helpers keep stdout clean
-# themselves now, so no call site below redirects — an un-redirected `cp_changed_files` is what put
-# a scope sentence ahead of the handle path and got it sourced as one (#4510).
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh <pr>
 #
-# EVERY failure path WRITES THE HANDLE WITH THE §CP SENTINEL FIRST, then exits non-zero. That is the
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — four `KEY=value` lines:
+#   CONTROL_PLANE_TOUCHED / GUARD_TOUCHING   the two flags Step 4a branches on, `printf '%q'`-quoted
+#   CP_FILES_N / ADR_N                       the §ZS scope counts
+# The two flags are %q-quoted for two reasons: a multi-file match stays ONE line, and the ordinary
+# not-§CP answer arrives as the positive token `''` rather than as an absence Step 4a has to infer
+# (.patterns/skill-script-io-contract.md, "the positive answer must be a positive token"). Scope +
+# diagnostic lines go to stderr; the §CPREAD helpers keep stdout clean themselves, so no call site
+# below redirects — an un-redirected `cp_changed_files` is what put a scope sentence ahead of the
+# answer and got it read as one (#4510).
+#
+# EVERY failure path PRINTS THE FLAGS AS THE §CP SENTINEL FIRST, then exits non-zero. That is the
 # whole reason this script exists in this shape: an empty `$CONTROL_PLANE_TOUCHED` is what Step 4a
 # reads as "auto-mergeable", so a classifier that could not run must never reach the caller as an
 # unset/empty flag. An absent or empty result is UNKNOWN, and UNKNOWN is never "no §CP path touched"
-# (§ZS / ADR 0092; #4216, #4231, #4010, #4219). If even the handle cannot be written, stdout stays
-# EMPTY and the caller's `.` fails loudly — hold the PR as §CP.
+# (§ZS / ADR 0092; #4216, #4231, #4010, #4219). Under ADR 0232 stdout carries the answer directly, so
+# there is no run-state handle left to fail to open — the sentinel now reaches the caller on EVERY
+# path, including the one where the §SP namespace itself is unavailable.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -26,29 +32,22 @@ set -uo pipefail
 # shellcheck source=../../shared/scripts/cp-read.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
 
-SENTINEL="<§CP classifier could not run — §CP UNKNOWN, held as control-plane>"
-HANDLE=""
+# ASCII punctuation in every EMITTED string below, deliberately: bash 3.2's `printf %q` escapes a
+# 3-byte UTF-8 sequence half-raw (`—` becomes a raw 0xE2 then `\200\224`), which round-trips through
+# a `.` but renders as mojibake on the stdout an agent now READS. `§` is 2-byte and survives, so the
+# canonical §CP term stays; the em-dashes and `⇒` do not. Measured on bash 3.2.57, macOS.
+SENTINEL="<§CP classifier could not run - §CP UNKNOWN, held as control-plane>"
 # emit_and_exit <status> <control-plane-touched> <guard-touching> <cp-files-n> <adr-n>
+# The ONLY writer of this script's stdout, so every exit — success, usage error, blinded read —
+# leaves the caller a readable flag pair rather than 0 bytes it would have to interpret.
 emit_and_exit() {
-  if [ -n "$HANDLE" ]; then
-    {
-      printf 'CONTROL_PLANE_TOUCHED=%q\n' "$2"
-      printf 'GUARD_TOUCHING=%q\n' "$3"
-      printf 'CP_FILES_N=%s\n' "$4"
-      printf 'ADR_N=%s\n' "$5"
-    } > "$HANDLE"
-    printf '%s\n' "$HANDLE"
-  else
-    echo "classify-control-plane.sh: could not open the per-run handle — no §CP answer was produced. Hold the PR as CONTROL PLANE." >&2
-  fi
+  printf 'CONTROL_PLANE_TOUCHED=%q\n' "$2"
+  printf 'GUARD_TOUCHING=%q\n' "$3"
+  printf 'CP_FILES_N=%s\n' "$4"
+  printf 'ADR_N=%s\n' "$5"
   exit "$1"
 }
 
-# Open the handle BEFORE the argument check, so even a usage error reaches the caller as the §CP
-# sentinel IN THE HANDLE rather than as 0 bytes on stdout. Measured: with the checks the other way
-# round the usage path exited 2 with an empty stdout, which is still fail-closed (the caller's `.`
-# fails loudly) but hands it no readable flag.
-HANDLE="$(kp_scratch_open review-code-cp)/cp.env" || HANDLE=""
 [ "$#" -ge 1 ] || { echo "usage: classify-control-plane.sh <pr>" >&2; emit_and_exit 2 "$SENTINEL" "$SENTINEL" 0 0; }
 PR="$1"
 # Top-level assignment, never `local` — `local REPO="$(kp_repo)"` masks the substitution's status,
@@ -80,8 +79,8 @@ if ! cp_changed_files "$REPO" "$PR"; then
   # FAIL CLOSED (#4216): a blinded read blinds BOTH clauses at once — the path regex AND the ADR-0164
   # content probe, which is the only §CP signal a `.decisions/**`-only PR can produce. So resolve BOTH
   # toward §CP; the sentinel is non-empty, which is exactly what Step 4a branches on.
-  CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
-  GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  CONTROL_PLANE_TOUCHED="<changed-file list unreadable - §CP UNKNOWN, held as control-plane>"
+  GUARD_TOUCHING="<changed-file list unreadable - §CP UNKNOWN, held as control-plane>"
   emit_and_exit 1 "$CONTROL_PLANE_TOUCHED" "$GUARD_TOUCHING" "${CP_FILES_N:-0}" 0
 else
   # grep aggregates the §CP matches ACROSS the concatenated pages — a jq `[ … ]` aggregate would
@@ -103,7 +102,7 @@ else
   # never ran (bad flag / nested-cwd module-not-found / missing shim) and read an unprobed ADR as
   # ordinary. The `*)` arm keeps could-not-determine a HOLD, exactly as an unreadable body is (#4219).
   GUARD_TOUCHING=""
-  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"   # fail closed: no ref ⇒ no probe ⇒ UNKNOWN
+  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable - ADR content unprobeable, held as control-plane>"   # fail closed: no ref ⇒ no probe ⇒ UNKNOWN
   ADR_N=0
   while IFS= read -r adr; do
     [ -z "$adr" ] && continue
@@ -112,7 +111,7 @@ else
     # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
     adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
     if [ -z "$adr_body" ]; then
-      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # fail closed: never auto-ship an ADR that could not be read and proven guard-free
+      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable=>§CP)"   # fail closed: never auto-ship an ADR that could not be read and proven guard-free
     else
       GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
       case "$GC_STATE" in

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # Print the absolute path of the run-state handle `materialize-head.sh` wrote (REVIEW_WT / PR_REF /
-# HEAD_SHA / BASE_REF), so any later step re-derives it with `. "$(head-env.sh)"` after the harness
-# resets the shell between Bash calls. Extracted from review-code/SKILL.md's repeated
-# `. "$WT_FILE"` re-source line (#4451, epic #4435 phase 1). Extraction contract:
-# ../SKILL.md § The extracted scripts.
+# HEAD_SHA / BASE_REF), so a later step re-derives those four after the harness resets the shell
+# between Bash calls. Extracted from review-code/SKILL.md's repeated `. "$WT_FILE"` re-source line
+# (#4451, epic #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# ITS CALLERS ARE THIS SKILL'S OWN SCRIPTS, never the agent's top-level command. They read it as
+# `. "$(head-env.sh)"` from inside their own process, which ADR 0232 leaves sanctioned — the ban is
+# on an AGENT sourcing at its top-level command, which the isolation verifier refuses. The agent
+# reads the same four values off `materialize-head.sh`'s stdout instead.
 #
 # The namespace is per-run and per-session (§SP, #3718), which is what keeps a SIBLING reviewer's
 # tree out of reach — the failure a `git worktree list` re-derivation on a shared leaf name walks

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh
@@ -4,12 +4,18 @@
 # review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract + shell-option rationale:
 # ../SKILL.md § The extracted scripts. The *why* for every step stays in that step's prose.
 #
-# STDOUT IS A MACHINE CHANNEL: the ONLY thing this script writes to stdout is the absolute path of
-# the run-state handle carrying REVIEW_WT / PR_REF / HEAD_SHA / BASE_REF. Every progress, scope and
-# FATAL line goes to stderr, so the caller can `. "$(materialize-head.sh "$PR")"` and have the four
-# values in its own shell. On ANY failure path stdout stays EMPTY and the exit is non-zero — the
-# caller's `.` then fails loudly rather than sourcing a half-written handle (§ZS: a materialization
-# that could not run is UNKNOWN, and reviewing the BASE tree is the #793 false-PASS hazard).
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh <pr>
+#
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — four `KEY=value` lines:
+#   REVIEW_WT / PR_REF / HEAD_SHA / BASE_REF
+# Every progress, scope and FATAL line goes to stderr, so the four lines are the whole stdout. On ANY
+# failure path stdout stays EMPTY and the exit is non-zero (§ZS: a materialization that could not run
+# is UNKNOWN, and reviewing the BASE tree is the #793 false-PASS hazard).
+#
+# The same four values ALSO persist to a per-run §SP handle. That is not a second answer channel: the
+# harness resets the agent's shell between Bash calls, so the LATER scripts of this skill re-source
+# the handle in-process via head-env.sh. In-script sourcing stays sanctioned under ADR 0232 — only
+# the `.` at an agent's top-level command is banned.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -95,5 +101,7 @@ for p in CLAUDE.md .claude .decisions .patterns; do
   fi
 done
 
-# The handle path — the ONLY stdout line, so the caller can `. "$(materialize-head.sh "$PR")"`.
-printf '%s\n' "$WT_FILE"
+# THE ANSWER — the four resolved values, one KEY=value line each, and the only stdout this script
+# writes. Printed from the variables the handle read back above, so what the caller sees and what the
+# later steps re-source through head-env.sh are the same four values by construction.
+printf 'REVIEW_WT=%s\nPR_REF=%s\nHEAD_SHA=%s\nBASE_REF=%s\n' "$REVIEW_WT" "$PR_REF" "$HEAD_SHA" "$BASE_REF"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-read.sh
@@ -3,12 +3,20 @@
 # Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
 # ../SKILL.md § The extracted scripts.
 #
-# STDOUT IS A MACHINE CHANNEL: the ONLY thing this writes to stdout is the run-state handle carrying
-# BUNDLE / BUNDLE_STATE / BUNDLE_LINE, so the caller can `. "$(run-evidence-read.sh "$PR")"`. Four
-# states come back on BUNDLE_STATE and they are DIFFERENT FACTS — `present` | `pending` | `absent` |
-# `unknown`; read the state word, never the exit alone, and never report `pending`/`unknown` as
-# `absent` (that invents a CI gap — PR #3913). An UNRESOLVED shim exits 127 with EMPTY stdout, so the
-# caller's `.` fails loudly: "could not run" is not a bundle state.
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/run-evidence-read.sh <pr>
+#
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — four `KEY=value` lines:
+#   HEAD_SHA / BUNDLE_STATE / BUNDLE_JSON / BUNDLE_LINE
+# BUNDLE_LINE is printed LAST and RAW (never %q-quoted) because the caller pastes it verbatim into
+# the verdict; the §SP handle keeps its own %q-quoted copy, which is what `run-evidence-manifest.sh`
+# re-sources in-process (sanctioned under ADR 0232 — only an agent's top-level `.` is banned).
+#
+# Four states come back on BUNDLE_STATE and they are DIFFERENT FACTS — `present` | `pending` |
+# `absent` | `unknown`; read the state word, never the exit alone, and never report `pending`/
+# `unknown` as `absent` (that invents a CI gap — PR #3913). The set is ENUMERATED, not interpolated:
+# anything else is UNKNOWN, so stdout stays EMPTY, a named diagnostic goes to stderr and the exit is
+# non-zero (§ZS, ADR 0092). An UNRESOLVED shim exits 127 with EMPTY stdout the same way: "could not
+# run" is not a bundle state, and a non-zero exit here is never `absent`.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -25,12 +33,29 @@ BUNDLE="$("$PCLI" run-evidence read --pr "$PR")" || true
 BUNDLE_STATE="$(jq -r '.state' <<<"$BUNDLE")"     # present | pending | absent | unknown
 BUNDLE_LINE="$(jq -r '.reportLine' <<<"$BUNDLE")" # the verdict line, evidence already in it
 
+# Assert the state word BEFORE writing anything. `jq` on an empty/non-JSON $BUNDLE leaves
+# BUNDLE_STATE empty, and an empty state word is UNKNOWN — it must never reach the caller as a fifth,
+# unnamed state it has to interpret, nor as the permissive `absent`.
+case "$BUNDLE_STATE" in
+  present|pending|absent|unknown) ;;
+  *)
+    echo "run-evidence-read.sh: \`run-evidence read\` yielded state '${BUNDLE_STATE:-<empty>}', outside the enumerated present|pending|absent|unknown — UNKNOWN, never 'absent'. No answer produced." >&2
+    exit 1
+    ;;
+esac
+
 OUT="$(kp_scratch_open review-code-bundle)/bundle.env" || exit 1
+BUNDLE_JSON="$(dirname "$OUT")/bundle.json"
 {
   printf 'HEAD_SHA=%s\n' "$HEAD_SHA"
   printf 'BUNDLE_STATE=%s\n' "$BUNDLE_STATE"
   printf 'BUNDLE_LINE=%s\n' "$(printf '%q' "$BUNDLE_LINE")"
+  printf 'BUNDLE_JSON=%s\n' "$BUNDLE_JSON"
 } > "$OUT"
-printf '%s\n' "$BUNDLE" > "$(dirname "$OUT")/bundle.json"
-printf 'BUNDLE_JSON=%s\n' "$(dirname "$OUT")/bundle.json" >> "$OUT"
-printf '%s\n' "$OUT"
+printf '%s\n' "$BUNDLE" > "$BUNDLE_JSON"
+
+# THE ANSWER. BUNDLE_LINE goes last and unquoted so the caller can lift it verbatim into the verdict.
+printf 'HEAD_SHA=%s\n' "$HEAD_SHA"
+printf 'BUNDLE_STATE=%s\n' "$BUNDLE_STATE"
+printf 'BUNDLE_JSON=%s\n' "$BUNDLE_JSON"
+printf 'BUNDLE_LINE=%s\n' "$BUNDLE_LINE"


### PR DESCRIPTION
Fixes #4574

Converts `review-code` to ADR [0232](.decisions/0232-agents-execute-skill-scripts-never-source-them.md)'s executed/stdout invocation convention. Control-plane by path — one human §CP approval round.

## What changed

**AC1 — no top-level source, no interpolated plugin-root.** All 26 script invocations in `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md` are now `bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/<name>.sh …`. `grep -c CLAUDE_PLUGIN_ROOT` on the file is **0**; `grep -nE '^\s*(\.|source)\s'` returns nothing. Each converted fence's prose names what to read off stdout, and a new bullet in *The extracted scripts* states the convention once for the whole file.

**AC2 — the probe was already discharged by #4549.** `scripts/cycle-doc-probe.sh` on this base already opens with `set -uo pipefail`, installs no `EXIT` trap, and prints `CYCLE_DOC=` / `CYCLE_GATING=` on stdout, with its SKILL fence already in the executed form. This PR inherits it and does not touch it — see the #4549 boundary note below.

**AC3 — the three env-file fences now return their values on stdout.** Each emitting script printed a path to an env file that the agent then sourced at its top level; each now prints `KEY=value` lines directly:

| script | stdout |
|---|---|
| `materialize-head.sh` | `REVIEW_WT` / `PR_REF` / `HEAD_SHA` / `BASE_REF` |
| `run-evidence-read.sh` | `HEAD_SHA` / `BUNDLE_STATE` / `BUNDLE_JSON` / `BUNDLE_LINE` (last, raw, so it can be lifted verbatim) |
| `classify-control-plane.sh` | `CONTROL_PLANE_TOUCHED` / `GUARD_TOUCHING` (`%q`-quoted) / `CP_FILES_N` / `ADR_N` |

Cross-step state keeps riding the §SP scratch namespace, but only where a real consumer exists: the head handle (`head.env`) and the bundle handle (`bundle.env`) stay on disk because `head-env.sh`, `worktree-checks.sh`, `worktree-typecheck.sh`, `full-unit-project.sh`, `teardown-head.sh`, `glossary-freshness.sh` and `run-evidence-manifest.sh` re-source them **in-process** — sourcing ADR 0232 explicitly leaves sanctioned. `classify-control-plane.sh` had no such consumer, so its `cp.env` handle is deleted outright; stdout is now the only channel, which removes the one path where the §CP sentinel could fail to reach the caller at all.

**SHA-binding (ADR 0058) is unchanged.** `current-head.sh`, `verdict-emit-pass.sh`, `verdict-emit-fail.sh` and `verdict-readback.sh` are byte-identical; only their fences' invocation form moved.

## Two fail-closed clamps strengthened, deliberately

Both are named here rather than buried, because each is a *behaviour* change, not a form change:

1. **`run-evidence-read.sh` enumerates the four bundle states before writing anything.** Previously a `jq` over an empty or non-JSON verb answer left `BUNDLE_STATE` empty, and that empty word reached the caller as a fifth, unnamed state. It now prints nothing, names the diagnostic on stderr and exits non-zero (§ZS, ADR 0092) — the same shape `cycle-doc-probe.sh` uses. Nothing is derived: an unreadable answer is refused, never normalised into `absent`.
2. **`classify-control-plane.sh`'s `emit_and_exit` is the sole stdout writer.** Every exit — success, usage error, blinded read — leaves a readable flag pair. The old shape could reach the `HANDLE=""` branch and produce no flag at all.

## Mutation-test matrix

Every clamp broken specifically, and shown to go red with the intended message.

| # | clamp | mutation | result |
|---|---|---|---|
| M1 | `run-evidence-read.sh` state enumeration | delete the `case "$BUNDLE_STATE"` block | **green when it should be red** — a forced `{"state":"expired"}` sails through as `BUNDLE_STATE=expired`, `rc=0`. Unmutated: `rc=1`, 0 bytes stdout, `…yielded state 'expired', outside the enumerated present\|pending\|absent\|unknown — UNKNOWN, never 'absent'`. **Has teeth.** |
| M2 | same, empty-answer path | force the verb to return `''` and a non-JSON `<html>503…` body | `rc=1`, 0 bytes stdout, `…yielded state '<empty>'…`. **Fires.** |
| M3 | `classify-control-plane.sh` sentinel print | replace `printf 'CONTROL_PLANE_TOUCHED=%q\n' "$2"` with `:` | the `CONTROL_PLANE_TOUCHED=` line vanishes from stdout while `rc=2` is unchanged — exactly the discriminator the step prose now names ("stdout carrying no `CONTROL_PLANE_TOUCHED=` line at all means the classifier never ran"). **Observable, but see the honest caveat below.** |
| M4 | ADR 0230 source edge in `cycle-doc-probe.sh` | replace the literal column-0 `BASH_SOURCE` idiom with an interpolated `"$SOMEDIR/cycle-doc-probe.sh"` | `validate-cycle-presence.sh` goes **FAILED — 1 error(s)**, `FAIL: review-code: does not cite the canonical cycle-doc probe … in executable shell or via a source edge`, and `shared/scripts/cycle-doc-probe.sh (edge:review-code)` **disappears from the emitted `scanned scope`**. The green is therefore *not* vacuous — the edge is genuinely resolved. |
| M5 | accept side, all four states | force `present` / `pending` / `absent` / `unknown` | each yields `rc=0` and the four `KEY=value` lines, and `run-evidence-manifest.sh` still reads the handle end to end (prints the manifest on `present`, the state diagnostic otherwise). |

**Honest caveat on M3:** the "`CONTROL_PLANE_TOUCHED=` line must be present" check is a *caller-side contract read by the reviewing agent*, not a CI guard. The mutation makes the line vanish, so it is not decorative — but nothing in CI reds on it. That gap is pre-existing (the old handle contract had the same property) and is out of this child's ACs; it is called out rather than glossed.

Accept and reject sides were both exercised through the real script's control flow with only the two fallible external reads (`gh api`, the `pipeline-cli` shim) stubbed — no clamp is pinned by a fixture on one side only.

## bash 3.2 evidence

Target is `/bin/bash` **3.2.57(1)-release (arm64-apple-darwin23)**, not CI's bash 5.

- `bash -n` parses all four changed scripts clean, and — per the standing warning that `bash -n` is necessary but not sufficient — every emit path above was **executed** under that same 3.2 binary, not just parsed.
- **Measured defect, and the reason for a punctuation change in this diff:** bash 3.2's `printf %q` escapes a 3-byte UTF-8 sequence *half-raw* — `printf '%q' "a — b"` emits a raw `0xE2` followed by literal `\200\224`. It round-trips losslessly through a `.` (verified by hexdump of a source-and-reprint), which is why it never mattered while the value lived in a sourced handle; on the stdout an agent now *reads*, it renders as mojibake. Every **emitted** sentinel in `classify-control-plane.sh` therefore drops its em-dashes and `⇒` for ASCII. Two-byte `§` survives `%q` verbatim, so the canonical `§CP` term stays. The *why* is stated once, at the `SENTINEL` definition.
- `printf '%q' ""` → `''` under 3.2, which is what makes the empty not-§CP answer a positive token rather than an absence.
- No `pipefail` was introduced by this PR — all three scripts already carried `set -uo pipefail`, so the "pipefail arms a latent `diff | grep -q && abort`" hazard has no surface here. The one inherited pipeline in scope (`gh api … | grep '^CONTROL_PLANE_RE=' | head -n1 || true`) is untouched and its `|| true` is correct under `pipefail`.

## File set, derived from two independent surfaces

- **Surface A** — script names reached from `SKILL.md`: **26**.
- **Surface B** — `ls review-code/scripts/`: **27**.
- **A minus B** is empty. **B minus A** = `head-env.sh`, which is deliberately script-only (its callers are this skill's own scripts, in-process). The two surfaces agree.
- **Surface C** (corroboration) — the cycle validators' emitted `scanned scope` lists all 27 plus four resolved edges for `review-code`, including `shared/scripts/cycle-doc-probe.sh (edge:review-code)`.

## Verification run

- `shellcheck -x` clean on all four changed scripts.
- `pipeline-cli trap-status-guard check` over the full corpus: 332 files, 317 markdown fences, 252 shell units — clean.
- `pipeline-cli cli-invocation-guard check` at CI scope: clean.
- `pipeline-cli adoption-lint check` at exact CI scope (corpus + the declared `drive-issue.js` mirror): clean.
- `validate-skills.sh`: 30 skills valid. `validate-cycle-presence.sh`: 18 checks OK. `validate-cycle-absence.sh`: 14 checks OK. `validate-gate-path-drift.sh`: 34 checks OK.
- `pipeline-cli pointer-guard check`, `leak-guard sweep`: clean.
- `pnpm lint`, `pnpm typecheck`: clean.

## Scope boundaries, stated rather than assumed

- **#4549 boundary (AC4).** This PR converted **invocation form only**. It did not duplicate, pre-empt or re-do the probe-dedup work: `scripts/cycle-doc-probe.sh` is untouched by this diff, and its collapse onto the shared source edge landed with #4549. AC2's three properties are inherited from that child, exactly as #4574's body anticipated.
- **#4595 boundary.** No bare interpolated *assignment* preamble was converted. #4574's ACs name the sourced probe fence, the env-file sourcing fences, and the interpolated plugin-root **invocations**; `review-code/SKILL.md` carries no `PCLI=` / `KP_SHARED=`-style assignment preamble at all, so the question does not arise here and nothing was pre-empted.
- **Out of scope, found and left.** `packages/pipeline-cli/src/skill-shell-surface.ts` still exports `sourcedScriptNames` with the matcher `/_SCRIPTS\}?\/([\w.-]+\.sh)/` on this base — there is no `reachedScriptNames` in the tree. That resolver's only consumers are `checks/step3-contract.ts` and `merge-queue-classify/step55-contract.ts`, both of which slice `ship-it/SKILL.md`; `review-code` is not a consumer. The matcher already failed to see review-code's invocations *before* this PR (the interpolated form contains no `_SCRIPTS` either), so this conversion regresses nothing — but if the executed literal-path form is meant to be visible to that resolver, the widening is a separate change and is not made here.


## Deviations

Walked all seven §DEV classes against this diff. Classes 4 (declined guidance) and 5 (guard/gate
bypassed) did not fire — no reviewer or triage instruction was declined, and the canonical Tier-M
scan reports **0 suppression/skip lines**. Class 6 did not fire either: **0 removed-assertion
lines**, and no test or fixture file is in the changed set at all. The six entries below are
classes 1, 3 and 7.

- **Out-of-scope logic change (class 7, also class 1)** — **Said:** #4574's `### What to build`
  scopes the already-executed scripts under `review-code/scripts/` to "change only their
  emitted-env contract where (2) requires it; **their logic is untouched** (ADR 0228/0229 relay)."
  **Did:** `run-evidence-read.sh` gains a new `case "$BUNDLE_STATE"` block that enumerates
  `present|pending|absent|unknown` and, on anything else, prints nothing, names the diagnostic on
  stderr and exits non-zero. That is added logic, not a changed emission contract. **Why:** moving
  the answer from a sourced handle onto stdout changes what an unenumerated state *costs*. Under
  the handle contract a `jq` over an empty or non-JSON verb answer left `BUNDLE_STATE` empty and
  the caller's `.` still succeeded, so the empty word reached the agent as a fifth, unnamed state;
  on the stdout the agent now reads directly there is no `.` left to fail loudly, so without the
  clamp the conversion would have *weakened* §ZS. It relays the verb's answer and refuses outside
  the enumeration — it never normalises an unreadable answer into `absent`, so it is an ADR 0228
  relay and not an ADR 0229 derive. **Disposition:** no action needed; for the reviewer to judge
  against AC3's "fail-closed semantics preserved", which this strengthens rather than merely
  preserves.

- **Out-of-scope logic change (class 7, also class 1)** — **Said:** same clause as above. **Did:**
  `classify-control-plane.sh`'s `emit_and_exit` becomes the sole writer of stdout: the
  `kp_scratch_open`/`cp.env` handle open is deleted, and with it the `HANDLE=""` else-branch that
  emitted no flag at all. **Why:** the deleted branch was the one path on which the §CP sentinel
  could fail to reach the caller, and it was reachable exactly when the §SP namespace was
  unavailable. Keeping it under the stdout contract would have left a hole that the handle
  contract's loud `.` failure used to cover. No consumer re-sources `cp.env` in-process (unlike
  `head.env` and `bundle.env`, which keep theirs), so deleting the handle costs nothing.
  **Disposition:** no action needed; described in prose under *Two fail-closed clamps strengthened*
  and now disclosed under this heading.

- **Out-of-scope content change (class 7)** — **Said:** #4574 scopes the change to invocation form
  plus the emitted-env contract. **Did:** every **emitted** string in `classify-control-plane.sh`
  is rewritten from `—` / `⇒` to ASCII `-` / `=>` — the `SENTINEL`, both `changed-file list
  unreadable` strings, the `head SHA unreadable` string, and the `body-unreadable` marker. **Why:**
  measured on `/bin/bash` 3.2.57, `printf '%q'` escapes a 3-byte UTF-8 sequence half-raw (a raw
  `0xE2` then the literal text `\200\224`). That round-tripped losslessly through a `.`, which is
  why it never mattered while the value lived in a sourced handle; on the stdout an agent now reads
  it renders as mojibake. Two-byte `§` survives `%q` verbatim, so the canonical `§CP` term is kept
  and only the em-dash and double-arrow are cut. **Disposition:** no action needed; the *why* is
  stated once at the `SENTINEL` definition rather than repeated per string.

- **Out-of-scope surface touched (class 7)** — **Said:** #4574's `### What to build` names
  `review-code/SKILL.md` and `review-code/scripts/**`; it names no doc surface. **Did:** one bullet
  in `.patterns/skill-script-io-contract.md` is rewritten. **Why:** that pattern doc is the
  repo-level catalogue of exactly this contract, and the bullet described
  `classify-control-plane.sh` as a run-state-handle path — a statement this diff makes false. Under
  CLAUDE.md's "when the docs and the source disagree, the source is authoritative — fix the doc",
  leaving it would have shipped a knowingly stale pattern entry. `.patterns/index.md`'s row for the
  doc stays accurate after the edit, so no index change was owed. **Disposition:** no action needed.

- **Known defect left unfixed (class 3)** — **Said:** AC3 asks that fail-closed semantics be
  preserved. **Did:** they are, but the `CONTROL_PLANE_TOUCHED=` output contract has **no CI
  teeth** — mutation M3 makes the line vanish from stdout with `shellcheck`, `validate-skills.sh`,
  `validate-gate-path-drift.sh`, `trap-status-guard check` and `cli-invocation-guard check` all
  still green, and no unit test names the script. The contract is enforced by the reading agent
  only. This was seen and deliberately not fixed. **Why:** the gap is pre-existing — the base
  handle contract had the identical property, so AC3's "preserved" is met and the head is strictly
  better on this axis (the zero-flag `HANDLE=""` path is gone). Building a scanner here is also the
  shape ADR 0233 has just rejected on the adjacent axis. **Disposition:** out of this child's ACs;
  left for a separate lane rather than glossed.

- **Known defect left unfixed (class 3)** — **Said:** nothing in #4574 names it. **Did:**
  `packages/pipeline-cli/src/skill-shell-surface.ts` still exports `sourcedScriptNames` with the
  narrow `_SCRIPTS`-anchored matcher, and this PR does not widen it. **Why:** `review-code/SKILL.md`
  contains `_SCRIPTS` **0 times at head and 0 times at base**, so that matcher saw nothing in this
  file before the conversion and sees nothing after — no regression, and no dependency on any
  unmerged widening. Its only consumers slice `ship-it/SKILL.md`. **Disposition:** if the executed
  literal-path form is meant to be visible to that resolver, the widening is a separate change; not
  made here.