### PR TITLE
fix(pipeline): fence 1 diffs newline-symmetric bodies, so a real AC append can land (#4600)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac-fence1-proof.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac-fence1-proof.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC2016
+# Reviewer-runnable four-case proof that `reviewer-append-ac.sh`'s fence 1 (append-only) is BOTH
+# correct and non-vacuous. It runs the real script — no re-implementation of the fence — against an
+# offline `gh` stub on PATH, so the whole proof is deterministic and touches no repo.
+#
+#   clean append   a real-shape body with NO trailing newline appends and PATCHes byte-for-byte
+#   mutated line   a tampered rebuild that ALTERS a pre-existing line still aborts (exit 1)
+#   dropped line   a tampered rebuild that DROPS a pre-existing line still aborts (exit 1)
+#   control        the same dropped-line tamper with the guard neutered PATCHes the lossy body,
+#                  which is what proves the two reds above come from the guard and not from the
+#                  tamper failing to take effect
+#
+# The tampers are injected into a COPY of the script (one extra line after its `UPDATED=` rebuild),
+# never into the shipped file: fence 1 guards against a rebuild that loses a line, and the shipped
+# rebuild cannot produce one, so a negative direction is only observable by simulating the failure
+# the fence exists for. Background: #4600 (both diff operands now share one normalizer).
+#
+# Runs under the bash the target actually has — `/bin/bash`, 3.2.57 on macOS — not the caller's.
+# Override with KP_PROOF_BASH for a second interpreter.
+set -uo pipefail
+
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/reviewer-append-ac.sh"
+BASH_BIN="${KP_PROOF_BASH:-/bin/bash}"
+
+if [ ! -f "$SCRIPT" ]; then
+	echo "fence1-proof: $SCRIPT not found — NO case was run." >&2
+	exit 1
+fi
+if [ ! -x "$BASH_BIN" ]; then
+	echo "fence1-proof: interpreter $BASH_BIN not executable — NO case was run." >&2
+	exit 1
+fi
+
+WORK="$(mktemp -d)"
+if [ -z "$WORK" ] || [ ! -d "$WORK" ]; then
+	echo "fence1-proof: mktemp -d produced no directory — NO case was run." >&2
+	exit 1
+fi
+BIN="$WORK/bin"
+# The variants live at the same depth under a mirror plugin root, because the script resolves the
+# shared lib by a relative `../../../lib` hop — a copy at any other depth dies before fence 1.
+VARIANTS="$WORK/plugin/skills/shared/scripts"
+mkdir -p "$BIN" "$VARIANTS" || exit 1
+ln -s "$HERE/../../../lib" "$WORK/plugin/lib" || exit 1
+export KP_PROOF_BODY_FILE="$WORK/body.txt"
+export KP_PROOF_PATCH_FILE="$WORK/patched.txt"
+export CLAUDE_PIPELINE_REPO="kamp-us/fence1-proof-fixture"
+
+# The fixture body is the real shape — an `### Acceptance criteria` list — delivered exactly as
+# `gh api … --jq .body` delivers it: with NO trailing newline. That is the shape #4600 aborted on.
+printf '%s' '## What to build
+
+Something observable.
+
+### Acceptance criteria
+
+- [ ] a pre-existing criterion
+- [ ] another pre-existing criterion' > "$KP_PROOF_BODY_FILE"
+
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+# Offline stand-in for `gh`, answering only the four calls reviewer-append-ac.sh makes.
+set -uo pipefail
+case "$*" in
+	"api user --jq .login") printf 'fixture-reviewer\n'; exit 0 ;;
+	*permission*) printf 'write\n'; exit 0 ;;
+esac
+is_patch=0
+for a in "$@"; do
+	if [ "$a" = "PATCH" ]; then is_patch=1; fi
+done
+if [ "$is_patch" = 1 ]; then
+	for a in "$@"; do
+		case "$a" in
+			(body=*) printf '%s' "${a#body=}" > "$KP_PROOF_PATCH_FILE" ;;
+		esac
+	done
+	exit 0
+fi
+cat "$KP_PROOF_BODY_FILE"
+STUB
+chmod +x "$BIN/gh" || exit 1
+
+NEW_ROW='- [ ] a newly appended criterion <!-- ac:review-code pr:#701 round:1 -->'
+{ cat "$KP_PROOF_BODY_FILE"; printf '\n%s' "$NEW_ROW"; } > "$WORK/expected.txt"
+
+# A copy of the script with one shell line injected after its `UPDATED=` rebuild (empty = verbatim),
+# optionally with the fence-1 abort neutered — the control.
+variant() { # <inject-line> <neuter-guard:0|1> <outfile>
+	awk -v inj="$1" -v neuter="$2" '
+		{ line = $0 }
+		neuter == 1 && line ~ /^if printf .*grep -qE .*then$/ { line = "if false; then" }
+		{ print line }
+		!seen && $0 ~ /^UPDATED=/ { if (inj != "") print inj; seen = 1 }
+	' "$SCRIPT" > "$3"
+}
+
+RUN_OUT=""
+RUN_RC=0
+run_case() { # <script-path>
+	rm -f "$KP_PROOF_PATCH_FILE"
+	RUN_OUT="$(PATH="$BIN:$PATH" "$BASH_BIN" "$1" 700 701 1 review-code "a newly appended criterion" "an in-scope finding" 2>&1)"
+	RUN_RC=$?
+}
+
+CASES=0
+FAILS=0
+ok() { # <label> <condition-description> <0|1 result>
+	CASES=$((CASES + 1))
+	if [ "$3" = 1 ]; then
+		printf 'PASS  %-14s %s\n' "$1" "$2"
+	else
+		printf 'FAIL  %-14s %s\n' "$1" "$2"
+		printf '      rc=%s output:\n%s\n' "$RUN_RC" "$RUN_OUT"
+		FAILS=$((FAILS + 1))
+	fi
+}
+
+printf 'fence1-proof: interpreter %s — %s\n' "$BASH_BIN" "$("$BASH_BIN" --version | head -1)"
+printf 'fence1-proof: script under proof %s\n\n' "$SCRIPT"
+
+# ── 1. clean append ────────────────────────────────────────────────────────────────────────
+variant "" 0 "$VARIANTS/clean.sh"
+run_case "$VARIANTS/clean.sh"
+r=0
+if [ "$RUN_RC" = 0 ] && printf '%s\n' "$RUN_OUT" | grep -q 'APPEND-STATE: appended' && cmp -s "$KP_PROOF_PATCH_FILE" "$WORK/expected.txt"; then r=1; fi
+ok "clean-append" "no abort on a body with no trailing newline; PATCHed body is byte-for-byte prior + one row" "$r"
+
+# ── 2. mutated pre-existing line ───────────────────────────────────────────────────────────
+# No backslash survives `awk -v`, so the tamper patterns carry none — they key on the fixture's
+# criterion TEXT rather than on its `- [ ]` prefix, whose brackets would otherwise need escaping.
+variant 'UPDATED="$(printf '"'"'%s'"'"' "$UPDATED" | sed '"'"'s/another pre-existing criterion/another pre-existing criterion MUTATED/'"'"')"' 0 "$VARIANTS/mutated.sh"
+run_case "$VARIANTS/mutated.sh"
+r=0
+if [ "$RUN_RC" = 1 ] && printf '%s\n' "$RUN_OUT" | grep -q 'append-only violation' && [ ! -f "$KP_PROOF_PATCH_FILE" ]; then r=1; fi
+ok "mutated-line" "aborts (exit 1, 'append-only violation') and PATCHes nothing" "$r"
+
+# ── 3. dropped pre-existing line ───────────────────────────────────────────────────────────
+DROP_TAMPER='UPDATED="$(printf '"'"'%s'"'"' "$UPDATED" | grep -v '"'"'another pre-existing criterion'"'"')"'
+variant "$DROP_TAMPER" 0 "$VARIANTS/dropped.sh"
+run_case "$VARIANTS/dropped.sh"
+r=0
+if [ "$RUN_RC" = 1 ] && printf '%s\n' "$RUN_OUT" | grep -q 'append-only violation' && [ ! -f "$KP_PROOF_PATCH_FILE" ]; then r=1; fi
+ok "dropped-line" "aborts (exit 1, 'append-only violation') and PATCHes nothing" "$r"
+
+# ── 4. control: same drop, guard neutered ──────────────────────────────────────────────────
+variant "$DROP_TAMPER" 1 "$VARIANTS/control.sh"
+run_case "$VARIANTS/control.sh"
+r=0
+if [ "$RUN_RC" = 0 ] && printf '%s\n' "$RUN_OUT" | grep -q 'APPEND-STATE: appended' && [ -f "$KP_PROOF_PATCH_FILE" ] && ! grep -q 'another pre-existing criterion' "$KP_PROOF_PATCH_FILE"; then r=1; fi
+ok "guard-disabled" "with the guard neutered the same drop PATCHes a lossy body — the red above is the guard's" "$r"
+
+rm -rf "$WORK"
+
+printf '\nfence1-proof: %s case(s), %s failure(s)\n' "$CASES" "$FAILS"
+if [ "$CASES" -ne 4 ]; then
+	echo "fence1-proof: expected 4 cases, ran $CASES — the proof did not cover its own scope." >&2
+	exit 1
+fi
+[ "$FAILS" -eq 0 ]

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac.sh
@@ -141,8 +141,12 @@ UPDATED="$(printf '%s\n%s\n' "$BODY" "$NEW_AC")"
 # catastrophe fence 1 forbids). The diff is captured BEFORE it is matched on purpose: with
 # `pipefail` on, `diff … | grep -qE '^< '` returns diff's own 1-on-difference even when grep
 # matched, so the guard's `&&` would never fire and the abort would be silently disabled.
-# Its over-strictness on a body with no trailing newline is preserved as-is — see #4600.
-DIFF_OUT="$(diff <(printf '%s' "$BODY") <(printf '%s' "$UPDATED"))"
+# BOTH operands go through ONE normalizer, and that symmetry IS the guard's correctness: `gh api …
+# --jq .body` strips every trailing newline, while the rebuilt body re-emits that same last line
+# WITH one — so an unnormalized diff read the last pre-existing line as CHANGED and aborted every
+# non-empty append. Normalizing a single side would move the asymmetry, not remove it (#4600).
+newline_terminated() { printf '%s\n' "$1"; }
+DIFF_OUT="$(diff <(newline_terminated "$BODY") <(newline_terminated "$UPDATED"))"
 if printf '%s\n' "$DIFF_OUT" | grep -qE '^< '; then
 	echo "append-only violation: a pre-existing line would change — ABORT, do not write" >&2
 	exit 1

--- a/claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
+++ b/claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md
@@ -127,16 +127,16 @@ is never blocked by this step and still posts its normal verdict.
 
 A non-zero exit is the fence-1 abort (a pre-existing line would have changed) or an input the
 script could not resolve: nothing on stdout, a named diagnostic on stderr. Treat it as a hold —
-the issue body was **not** written. **Known standing condition:** an issue body read back through
-`gh api … --jq .body` never ends in a newline, which `diff` reports as its last line *changing*,
-so fence 1 aborts on every non-empty body. That over-strictness is inherited verbatim from the
-procedure this script was extracted from and is out of scope to relax here — it errs toward
-refusing a write, never toward losing a criterion ([#4600](https://github.com/kamp-us/phoenix/issues/4600)).
+the issue body was **not** written.
 
 The append is **append-only by construction** (fence 1): the body is rebuilt from the existing
 one with a single row added, and a `diff` guard refuses any write that would drop or mutate a
 prior line — so a reviewer flow *cannot* edit or remove an existing AC (the catastrophe
-`review-skill`'s gate-invariant check exists to catch). It is **in-scope-only** (fence 2): only
+`review-skill`'s gate-invariant check exists to catch). That the guard is both correct and
+non-vacuous is re-derived rather than asserted:
+[`scripts/reviewer-append-ac-fence1-proof.sh`](scripts/reviewer-append-ac-fence1-proof.sh) runs
+the real script offline over four cases — clean append, mutated prior line, dropped prior line,
+and the same drop with the guard neutered as the control. It is **in-scope-only** (fence 2): only
 a finding that passed the trace-to-stated-goal test (Route, don't grade) reaches this step; a
 tangential one was routed to `report` and never arrives. It is **ACL-gated and fails closed**
 (fence 3): a below-`write+` author — or any ACL lookup failure — skips the append entirely, so


### PR DESCRIPTION
Fixes #4600

## What changed

The ADR-0079 fence-1 append-only guard compared two newline-asymmetric operands. `BODY` comes
from `BODY="$(gh api … --jq .body)"`, and command substitution strips **every** trailing newline;
`UPDATED="$(printf '%s\n%s\n' "$BODY" "$NEW_AC")"` re-emits that same last pre-existing line
**with** one. `diff <(printf '%s' "$BODY") <(printf '%s' "$UPDATED")` therefore reported the last
pre-existing line as *changed*, emitted a `< ` line, and the abort arm fired on every non-empty
body — a fail-closed always-abort whose positive path had likely never run.

Both operands now go through **one** normalizer, so the asymmetry cannot re-enter on a single
side (normalizing one side would move it, not remove it — the same property #4598 adopted for
`splice-body.sh`):

```bash
newline_terminated() { printf '%s\n' "$1"; }
DIFF_OUT="$(diff <(newline_terminated "$BODY") <(newline_terminated "$UPDATED"))"
```

Everything else about the fence is untouched: the `DIFF_OUT` capture-before-`grep` shape stays
(under `pipefail` a `diff … | grep -qE '^< '` returns diff's own 1-on-difference and would
silently disable the abort), the rebuild is unchanged, and the PATCHed body is byte-identical to
what the pre-fix construction produced.

Files:

- `claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac.sh` — the fix. The
  in-source `see #4600` preserved-as-is marker is **removed**; this PR is its resolution, and the
  four lines that replace it state the newline asymmetry once, at the enforcement site.
- `claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac-fence1-proof.sh` — new,
  reviewer-runnable, offline.
- `claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md` — the "Known standing
  condition" paragraph is retired (it documented exactly this defect), and the fence-1 prose now
  points at the proof.

The file set was derived from two independent surfaces — the issue's own pointers and a repo-wide
grep for `4600` / `append-only violation` — which agree on exactly these two pre-existing files.

## Proof — both directions, non-vacuous

`reviewer-append-ac-fence1-proof.sh` runs the **real** script (no re-implementation of the fence)
against an offline `gh` stub on `PATH`, over the four cases the issue asks for. The tampers are
injected into a *copy* of the script, one line after its `UPDATED=` rebuild: fence 1 guards
against a rebuild that loses a line, and the shipped rebuild cannot produce one, so the negative
direction is only observable by simulating the failure the fence exists for.

```
$ /bin/bash claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac-fence1-proof.sh
fence1-proof: interpreter /bin/bash — GNU bash, version 3.2.57(1)-release (arm64-apple-darwin23)
fence1-proof: script under proof …/skills/shared/scripts/reviewer-append-ac.sh

PASS  clean-append   no abort on a body with no trailing newline; PATCHed body is byte-for-byte prior + one row
PASS  mutated-line   aborts (exit 1, 'append-only violation') and PATCHes nothing
PASS  dropped-line   aborts (exit 1, 'append-only violation') and PATCHes nothing
PASS  guard-disabled with the guard neutered the same drop PATCHes a lossy body — the red above is the guard's

fence1-proof: 4 case(s), 0 failure(s)
```

- **Positive** — `clean-append`: the fixture body is the real shape (an `### Acceptance criteria`
  list) with **no** trailing newline, exactly as `gh api … --jq .body` delivers it. It appends,
  prints `APPEND-STATE: appended`, and the PATCHed body `cmp`s byte-for-byte against
  `<prior body>\n<new row>`. This path has never run before this PR.
- **Negative** — `mutated-line` / `dropped-line`: a tampered rebuild that alters, and one that
  drops, a pre-existing line both still exit 1 with `append-only violation: a pre-existing line
  would change — ABORT, do not write`, and PATCH nothing. The fix did not turn a fail-closed bug
  into a fail-open one.
- **Control** — `guard-disabled`: the same drop with the abort neutered (`if false; then`) PATCHes
  a body that is missing the dropped criterion. That is what proves the two reds above come from
  the guard and not from a tamper that failed to take effect.

**Regression evidence.** The same proof run against the **pre-fix** script (`origin/main`'s copy,
checked out to a scratch mirror) reproduces #4600 precisely — one red, and it is the positive
path:

```
FAIL  clean-append   no abort on a body with no trailing newline; …
      rc=1 output:
      reviewer-append-ac scope: repo … · issue #700 · pr #701 · round 1 · gate review-code
      append-only violation: a pre-existing line would change — ABORT, do not write
PASS  mutated-line   …
PASS  dropped-line   …
PASS  guard-disabled …
fence1-proof: 4 case(s), 1 failure(s)
```

## bash 3.2 evidence

Every case above executed under `/bin/bash` — `GNU bash, version 3.2.57(1)-release
(arm64-apple-darwin23)`, the target interpreter, not CI's bash 5 — because `bash -n` is necessary
and not sufficient (a heredoc inside `$( … )` parses clean under 3.2 and truncates at runtime; the
same script's fence-4 escalation already composes its heredoc through a file for that reason). The
proof's interpreter is `KP_PROOF_BASH`-overridable for a second one. `bash -n` is clean on both
scripts as well.

## Guards run locally

`trap-status-guard check` clean (3 files, no `errexit` + `EXIT` trap pairing — the proof uses
`set -uo pipefail` and installs no trap) · `leak-guard scan` clean · `shellcheck` clean on both
scripts · `gh-phoenix lint-skills` clean over the whole corpus · `adoption-lint check` clean over
the CI scope · `cli-invocation-guard check` clean.

## Deviations

- **Scope narrowing / different shape** — **Said:** #4600's AC3 asks that "the reference fenced
  block in `claude-plugins/kampus-pipeline/skills/shared/specialist-fan-out.md` is updated to match
  the script". **Did:** no fenced block was updated. At this PR's base that file carries no copy of
  the fence-1 comparison — its only `bash` fence is the script's six-argument invocation, which this
  PR does not touch. What changed is the surrounding prose: the "Known standing condition" paragraph
  is retired and the fence-1 paragraph now points at the committed proof instead of restating the
  comparison inline. **Why:** AC3 was written against the pre-#4601 shape, when the reference still
  carried the `diff <(printf '%s' "$BODY") …` block inline; #4601 moved that code into the script, so
  by this base there was no block left to sync. Re-inlining one would recreate exactly the
  duplicate-of-the-script that extraction removed, and it would drift again the next time fence 1
  changes. AC3's other two limbs are met literally — the paragraph is retired, and the in-source
  `see #4600` preserved-as-is marker is removed. **Disposition:** for the reviewer to judge; no ADR
  and no follow-up needed.
- **Out-of-scope change** — **Said:** #4600's AC2 asks that the four-case proof "is run and recorded
  on the PR". **Did:** also committed the harness as a permanent file,
  `claude-plugins/kampus-pipeline/skills/shared/scripts/reviewer-append-ac-fence1-proof.sh` (162
  lines, control-plane), and linked it from the reference. **Why:** a transcript in a PR body records
  the run but is not re-runnable after merge — the next change to fence 1 would have nothing to
  re-derive against. The committed harness runs the *real* script offline over both directions plus
  the control, and it is what makes the reference's new pointer resolve. The AC is satisfied by the
  recorded run either way; the committed file is surplus to it. **Disposition:** no action needed.
- **Guard or gate bypassed (lint suppression)** — **Said:** nothing in #4600 asks for a lint
  suppression. **Did:** the new proof script carries
  `# shellcheck shell=bash disable=SC1007,SC2016`. **Why:** both codes are false positives, measured
  rather than assumed — with the directive stripped, `shellcheck` raises SC1007 on the standard
  `CDPATH= cd --` prefix-assignment idiom (the sibling scripts in this same directory use and declare
  it identically) and SC2016 on three single-quoted strings that are shell source injected verbatim
  into a tamper variant, where expansion is precisely what must not happen. The directive is
  per-file and names its two codes — the convention this script directory already follows — never a
  blanket suppression. **Disposition:** no action needed; disclosed because §DEV class 5 covers a
  suppressed lint whether or not the Tier-M scan pattern matches it (it does not match `shellcheck`
  directives).

## §CP

Control-plane: the diff is entirely under `claude-plugins/kampus-pipeline/skills/`, so it needs a
`@kamp-us/control-plane` human approval before it can merge.

