### PR TITLE
chore(pipeline): convert the 4 orphaned interpolated PCLI fences to literal assignment (#4607)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -149,8 +149,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   unit-tested probe (it parses the **same** §CLASS `HAS_*_RE` lines `ship-it` Step 0 reads — no
   third copy) and dispatch a gate for **exactly** each namespace it prints:
   ```bash
-  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+  # §CLI — bind the shim by LITERAL assignment, from the repo root; not on PATH, and a fence
+  # may not interpolate a path in any position (ADR 0207/0232; the why is §CLI's, not restated here).
+  PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
   # <a id="probe-status-note"></a>READ THE PROBE'S EXIT STATUS — an empty set is UNKNOWN, never "no gates"
   # (#4231). class-probe's stdin branch REFUSES with exit 4 on a failed read (#4010) and prints NOTHING,
   # so stdout alone cannot tell a refusal from a legitimate result — capture the probe as the LAST stage
@@ -253,8 +254,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   required namespace empty" unrepresentable from the reviewer's side; it does **not** touch ship-it's
   fail-closed per-namespace PASS gate (the merge authority), which stays the terminal check, untouched.
   ```bash
-  # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-  PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+  # §CLI — bind the shim by LITERAL assignment, from the repo root; not on PATH, and a fence
+  # may not interpolate a path in any position (ADR 0207/0232; the why is §CLI's, not restated here).
+  PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
   HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
   # the required set — same class-probe output the fan dispatches on (folds in review-design when has-ui),
   # read under the same status contract (see the fan invariant's [probe-status note](#probe-status-note)):

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1792,7 +1792,15 @@ bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/<name>.sh <args…>
 
 Two constraints make that the only shape, and both are the harness's, not this contract's: its
 isolation verifier refuses a `.`/`source` at an agent's top-level command **by any path form**, and it
-refuses the interpolated `"${CLAUDE_PLUGIN_ROOT:-…}/…"` idiom as too complex to verify. So the path is
+refuses a path it cannot resolve statically. The second refusal is **position-blind**, which an
+18-trial reproduction pinned ([#4595](https://github.com/kamp-us/phoenix/issues/4595)): three
+triggers each fire on their own — the `${VAR:-default}` syntax itself (refused even when the
+variable is already set), any expansion the verifier cannot resolve, and `$(…)` command
+substitution. That means "assignments are safe, only invocations are refused" is not a real
+distinction, and the rule is constructive rather than positional: **a fence may bind a variable only
+by literal assignment inside the same block.**
+
+So the path is
 written out literally, which hardcodes the in-repo plugin location — the ADR
 [0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-as-config-plugin.md)
 portability trade ADR 0232 accepts and records.
@@ -1850,16 +1858,24 @@ the gate silently never fires (#4236). Use `"$PCLI"`.
 ### The canonical preamble — paste it once per bash block that invokes the CLI
 
 ```bash
-# §CLI — resolve the shim. `$CLAUDE_PLUGIN_ROOT` covers a foreign consumer install; the
-# git-toplevel fallback covers this repo from ANY cwd, in the primary checkout AND in an
-# agent worktree (both trees carry the shim, and a worktree's toplevel is its own root).
-PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+# §CLI — bind the shim by LITERAL assignment, run from the repo root.
+PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
 ```
 
 Then call it as `"$PCLI" <verb> …`. That is the **one** documented form; do not re-derive a
 second. `$PCLI` is a shell variable, so — like `$BRANCH` and `$WT` — it does **not** survive
 between an agent's separate Bash calls: re-run the preamble in each block, never cache the path
 to a file (§SP).
+
+**Why a literal, and what it costs.** The preamble used to resolve `$CLAUDE_PLUGIN_ROOT` with a
+git-toplevel fallback, so it worked from any cwd and in a foreign consumer install. The harness
+refuses that whole shape at an agent's top-level command — see the §SHARED constraint above — so
+the assignment is written out literally instead. The trade is the same one §SHARED records: the
+in-repo plugin location is hardcoded and the block must be pasted from the repo root, which is the
+ADR [0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-as-config-plugin.md)
+portability cost ADR [0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)
+accepts. A script may still resolve its own paths however it likes — the verifier judges only the
+command *you* run, not a script's body.
 
 ### The exit-code taxonomy — "could not run" is never a verdict
 
@@ -2149,8 +2165,8 @@ assert it did:**
    **asserts the fetched ref resolves to exactly that SHA before you review** — aborting on a moved
    head rather than binding a stale verdict. Two modes, same core:
    ```bash
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+   # §CLI — bind the shim by LITERAL assignment, from the repo root (the preamble above).
+   PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
    # ref-only (review-doc reads via `git show "$PR_REF:<path>"`):
    eval "$("$PCLI" review-head materialize --pr "$PR" | jq -r '"PR_REF=\(.prRef); HEAD_SHA=\(.headSha)"')"
    # full detached head worktree (review-code / review-skill), emitted as `.worktreeDir`:


### PR DESCRIPTION
Four `bash` blocks in the pipeline docs told an agent to build the `pipeline-cli` path by interpolating `${CLAUDE_PLUGIN_ROOT:-...}`. The sandbox an agent runs in refuses to execute a command shaped like that, so every one of those blocks was unpasteable — an agent that followed the doc literally got a refusal, not a shim path. This replaces the four with a plain literal assignment, which the same sandbox accepts. Docs only; no behavior is added or re-derived.

Fixes #4607

## What changed

Four fences, two files, one line each (plus its comment). Before, all four were byte-identical:

```
PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
```

After, all four are:

```
PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
```

| File | Line at base `2c5defd2` | Block |
|---|---|---|
| `claude-plugins/kampus-pipeline/agents/reviewer.md` | 153 | the `class_reresolve` fan invariant |
| `claude-plugins/kampus-pipeline/agents/reviewer.md` | 257 | the `coverage_selfcheck` invariant |
| `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` | 1856 | §CLI, the canonical preamble |
| `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` | 2153 | §HEAD, `review-head materialize` |

The line numbers were verified at the branch base and had not drifted from the issue.

These four were owned by no open conversion child: `agents/**` sits outside #4575's `skills/**/*.md` glob, and the two intake-contract preambles were correctly outside #4571's satisfied AC (its PR #4590 merged), so reopening it would have been wrong.

The §CLI section also gains a short **Why a literal, and what it costs** paragraph — the single home for the rationale, so the three other sites carry a pointer instead of a restated *why* (CLAUDE.md comment discipline).

## Why the literal shape, and not a narrower fix

The refusal is **position-blind**, which the #4595 reproduction pinned over 18 trials. Three triggers each fire on their own:

1. the `${VAR:-default}` syntax itself — refused **even when the variable is already set**;
2. expansion of any variable the verifier cannot resolve;
3. `$(…)` command substitution — refused with no interpolation present at all.

So the "assignments are safe, only invocations are refused" distinction the earlier ACs encoded does not exist. The rule these fences now follow is constructive: **a fence may bind a variable only by literal assignment inside the same block.** The §SHARED prose that states the harness constraint is corrected to say this; at base it named interpolation only.

## Verification (reviewer-runnable, from the repo root)

**AC1 — no fenced block in either file resolves the plugin root by interpolation.**

```bash
awk '/^[[:space:]]*```/{f=!f; next} f && /CLAUDE_PLUGIN_ROOT/{print FILENAME":"FNR": "$0} END{print "fence-state-at-eof="f}' \
  claude-plugins/kampus-pipeline/agents/reviewer.md \
  claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
grep -n 'kampus-pipeline}' claude-plugins/kampus-pipeline/agents/reviewer.md claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
```

At head the awk prints no hits and `fence-state-at-eof=0` — the fence toggle pairs, so the scan really did cover every block rather than falling out of sync. The grep exits 1 with no output. Two prose mentions of the variable remain (`reviewer.md:66` and the new §CLI paragraph); both sit outside any fence, both are backticked, neither is runnable.

**The scan is non-vacuous.** The same awk against the base prints exactly the five in-fence lines it is meant to catch:

```bash
git show 2c5defd2:claude-plugins/kampus-pipeline/agents/reviewer.md \
  | awk '/^[[:space:]]*```/{f=!f; next} f && /CLAUDE_PLUGIN_ROOT/{print FNR": "$0}'
# → 153, 257
git show 2c5defd2:claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md \
  | awk '/^[[:space:]]*```/{f=!f; next} f && /CLAUDE_PLUGIN_ROOT/{print FNR": "$0}'
# → 1853 (the comment in the same fence), 1856, 2153
```

**AC2 — each converted fence actually runs under worktree isolation.** Demonstrated, not asserted: every converted block was pasted verbatim as a top-level command in this lane's isolated worktree, with its comment lines and its original indentation.

- §CLI canonical preamble + `"$PCLI" decisions-index compact` — accepted; printed the ADR index.
- `reviewer.md`'s form (two-space list indentation) + `"$PCLI" cp-classify --help` — accepted, exit 0.
- `reviewer.md`'s form + `"$PCLI" verdict read --pr 4601 --gate skill --expect PASS` — accepted; returned the verb's own `{"_tag":"none",…}` and exit 1.
- §HEAD's form (three-space indentation) + `"$PCLI" review-head resolve --pr 4601` — accepted; resolved the head SHA.

Paired negative control: the **pre-conversion** block, pasted verbatim into the same shell, was **refused** — `this command is too complex to verify that it stays inside the worktree`. So the conversion is load-bearing, not cosmetic.

**AC3 — the column-0 boundary canonicals are untouched.**

```bash
bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
git diff -U0 origin/main -- claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md \
  | grep -E '^[-+](CONTROL_PLANE_RE|GUARD_ADR_RE|HAS_|DOC_VOCAB_|CLAIM_RE|UI_)'
```

Validator: `validate-gate-path-drift: OK — 34 checks`. The grep exits 1 — not one canonical line appears on either side of the diff.

**Other guards, all green:** `pipeline-cli cli-invocation-guard check` over the full `claude-plugins/**` corpus exactly as CI invokes it (332 files, 317 markdown fences, 252 shell files — clean), `pipeline-cli gh-phoenix lint-skills` on both files, `validate-skills.sh` (30 skills valid), `pnpm lint:worktree` (no biome-handled changed files — markdown-only diff).

## Deviations

- **Scope wider than the four fences.** Said: convert four fences, doc-only. Did: also rewrote the one §SHARED paragraph that states *why* a fence must be literal, and added the §CLI rationale paragraph. Why: the base prose said the verifier "refuses the interpolated `${CLAUDE_PLUGIN_ROOT:-…}/…` idiom as too complex to verify" — which #4595 falsified, and a reader converting a fence off that sentence would not know a bare `$(…)` is refused too. Without it the §CLI conversion has no stated rationale at all. Disposition: for the reviewer to judge; same two files, no fence semantics changed.
- **AC1 read more narrowly than its literal text.** Said: "No fenced block … contains `${CLAUDE_PLUGIN_ROOT` … or resolves a path through `${...:-...}` or `$(...)`". Did: enforced the first clause absolutely, and the second only for **plugin-path** resolution. Why: read literally, the second clause covers every `$(gh api …)` / `$(printf …)` in both files — dozens of fences that resolve no path — and the one remaining `${...:-...}` per file is the `REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view …)}"` preamble, which the issue's own scoping parks at decision issue #4605. Disposition: no action needed; the `$REPO` class stays #4605's.
- **Sibling defect left for a follow-up.** Said: nothing. Did: left §SHARED's "The nine column-0 boundary canonicals" uncorrected — `validate-gate-path-drift.sh` locks eleven since #4401, and two of them are canonical in `ship-it/SKILL.md` rather than in the intake contract. Why: prose in an adjacent section, not a fence, and amending a stated invariant's count is a triage call. Disposition: follow-up #4610 filed.
