### PR TITLE
refactor(ship-it): convert the 18 sourced scripts + SKILL.md fences to ADR-0232 executed/stdout (#4572)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -89,12 +89,33 @@ behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
 REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
-# This skill's steps are SOURCED scripts under `scripts/` (epic #4435 phase 1, #4448) — resolved the
-# same way §CLI resolves the `pipeline-cli` shim, because neither is on PATH. Source each step's
-# script where the step says to; sourcing (not executing) is what keeps a step's variables and
-# functions visible to the steps after it, exactly as the inline fenced blocks did.
-SHIPIT_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/skills/ship-it/scripts"
 ```
+
+**Run each step's script by literal path and read its answer off stdout (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)).**
+This skill's steps are scripts under `scripts/`, and you **run** them:
+
+```bash
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/<name>.sh <args…>
+```
+
+Two constraints make that the only shape, and both are the harness's: its isolation verifier refuses
+a `.`/`source` at an agent's top-level command **by any path form**, and it refuses the interpolated
+`"${CLAUDE_PLUGIN_ROOT:-…}/…"` idiom as too complex to verify. So the path is written out literally,
+which hardcodes the in-repo plugin location — the ADR
+[0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-as-config-plugin.md)
+portability trade ADR 0232 accepts and records.
+
+**Read the exit status first, then the stdout.** Exit 0 means the script produced its answer on
+stdout; a non-zero means it could not, which is UNKNOWN and never the permissive branch (§ZS / ADR
+0092). Two of this skill's conventions sharpen that, and both are stated at each step below:
+
+- **A refusal is not a failure to run.** Most of ship-it's stop paths are *successful declines* —
+  they print their `refused — …` / `unverified (…)` line and exit **0**, exactly as the fenced blocks
+  did. Where a step works that way, read the **terminal word** on stdout, not the status.
+- **Every value a step used to leave in your shell now arrives as a `NAME=value` line**, and you
+  re-pass it as the next step's argument. Nothing survives between your Bash calls, so a step that
+  needs `$PR`, `$CP_FLAG`, `$CURRENT_HEAD` or the run-evidence handles is *handed* them.
 
 ## The hard guards
 
@@ -160,8 +181,14 @@ The enqueue primitive is unchanged (`gh pr merge --auto`, Step 4). What is added
 rule with **four mandated sites** — run start, every stop/refusal, an ejection, and after the
 bounded reconcile:
 
+The primitive lives in
+[`scripts/disarm-intent.sh`](scripts/disarm-intent.sh). Every step script that has a stop path
+sources it in-chain for `disarm_intent`, so you never invoke it yourself on the ordinary paths —
+each of those steps prints `INTENT_UNCLEARED=<0|1>` and that is what your outcome line carries. Run
+it directly only to clear an intent outside a step (stdout is the same one line):
+
 ```bash
-. "$SHIPIT_SCRIPTS/disarm-intent.sh"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/disarm-intent.sh "$REPO" <pr> <preflight|refuse|post-enqueue|ejected>
 ```
 
 **Site 1 is Step 0's `disarm_intent preflight || exit 1`, and it is the one that catches the
@@ -253,7 +280,10 @@ it. The fix round-trip is `write-code`'s (code) / the doc author's job, not your
 Before anything else, read the PR's changed files and split them by class. This is one read:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step0-preflight.sh" <pr number>   # $PR for the whole run — every later step reads it back
+# stdout: `PR=<n>` — the run's PR, which you re-pass as every later step's second argument — then one
+# changed-file path per line. A refusal (the §RO-iso stop, or a guard-6 Site-1 disarm that failed)
+# prints NO `PR=` line, names itself on stderr, and exits non-zero: read the status first.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh "$REPO" <pr number>
 ```
 
 Classify each path. The classification is **derived by the shared verb `pipeline-cli cp-classify`**,
@@ -330,7 +360,12 @@ UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
 ```
 
 ```bash
-. "$SHIPIT_SCRIPTS/step0-classify.sh"
+# stdout, in order: `CP_STATE=<state>`, then one `BLOCKING (…)` line per §CP finding, then one class
+# word per class present (`has-skills` / `has-code` / `has-docs`) and `has-ui` when the diff renders a
+# surface. The ordinary §CP answer is the ABSENCE of a BLOCKING line, so read `CP_STATE=` as the
+# evidence the derivation ran — never emptiness. A classification that could not be made prints
+# `STOP: …` and exits 1; that is UNKNOWN, never "no gates required".
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh "$REPO" "$PR"
 ```
 
 **Routing:**
@@ -346,14 +381,13 @@ UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
   [§CP approval gate](#step-0-cp-approval-gate) below, ADR 0175):
   - **discharge** → the human-judgment gate is satisfied; **set the Step-2 §CP seam**, then **carry
     on** into Step 2's normal machine
-    gates (matching-gate SHA-bound PASS, CI green, run-evidence). The seam is one assignment in this
-    same shell, and this is its **only** sanctioned site — a §CP PR's pass path is the SHA-less
-    advisory, which `verdict gate` counts only under `--cp` (Step 2), and the discharge is exactly
-    the condition that licenses it:
-
-    ```bash
-    CP_FLAG=--cp   # §CP classified AND approval discharged — the ONLY state that sets this (#4547)
-    ```
+    gates (matching-gate SHA-bound PASS, CI green, run-evidence). The seam is the literal token
+    `--cp`, **printed by the approval gate's discharge branch as `CP_FLAG=--cp`**, and that branch is
+    its **only** source — a §CP PR's pass path is the SHA-less advisory, which `verdict gate` counts
+    only under `--cp` (Step 2), and the discharge is exactly the condition that licenses it. Carry
+    that token forward as the **third argument** to Step 2's gate and its native-review fold. Read no
+    `CP_FLAG=` line ⇒ pass nothing, which is the stricter branch: an omitted seam can only refuse a
+    §CP PR, never pass one (#4547).
 
     Once those pass, ENQUEUE exactly
     like a non-§CP PR (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method;
@@ -411,7 +445,10 @@ UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
   Each failure branch stops under a message that names the read that failed.
 
   ```bash
-  . "$SHIPIT_SCRIPTS/step0-cp-approval.sh"
+  # stdout: exactly one `§CP approval: …` line, plus `CP_FLAG=--cp` on the discharge branch only —
+  # that token is the Step-2 seam, and this is its only source. A branch that could not answer names
+  # the failed read on stderr and exits 1: UNKNOWN, never `awaiting control-plane approval`.
+  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh "$REPO" "$PR"
   ```
 
   This is **only** the §CP unblock — it does not weaken any other guard. The SHA-bound gate verdict
@@ -628,15 +665,19 @@ The required set is **derived, never eyeballed** — the same `class-probe` outp
 dispatches off, so `dispatched-gate == required-gate` holds by construction:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step2-verdict-gate.sh"   # reads $CP_FLAG from this shell — set ONLY by Step 0's §CP discharge
+# stdout: one `ship-it guard 1: …` line naming the required namespaces. The EXIT STATUS is the gate —
+# 0 only when `verdict gate` passed every required namespace; every refusal names itself on stderr
+# and exits 1. Pass `--cp` as the THIRD argument only when Step 0's approval gate printed it.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh "$REPO" "$PR" [--cp]
 ```
 
-**The one input this step takes is `$CP_FLAG`, and it is already set (or deliberately unset) by the
-time you get here.** Step 0's §CP discharge branch is its only writer; every other path leaves it
-unset, which the script reads as the non-§CP branch. So this source line takes no argument and needs
-no hand-substituted value — run it as written. Setting `CP_FLAG` here, from your own reading of the
-diff, is the [defect this seam replaced](https://github.com/kamp-us/phoenix/issues/4547): it puts the
-§CP decision back where an eyeball makes it, next to the verb that is supposed to be handed it.
+**The one input this step takes beyond the PR is the §CP seam, and Step 0 already decided it.** Step
+0's §CP discharge branch is its only source — it prints `CP_FLAG=--cp` — and every other path prints
+nothing, which the script reads as the non-§CP branch. So pass the token **iff you read it off that
+branch's stdout**, verbatim, and otherwise omit the argument entirely. Deciding `--cp` here, from your
+own reading of the diff, is the [defect this seam replaced](https://github.com/kamp-us/phoenix/issues/4547):
+it puts the §CP decision back where an eyeball makes it, next to the verb that is supposed to be
+handed it.
 
 **Why a verb and not a careful read.** The rule below was already correct in prose ("docs present
 but the review-doc namespace is empty → `unverified (no review-doc PASS)`"), but nothing *computed*
@@ -751,7 +792,11 @@ The native decisive review folds into the code namespace separately (the verb re
 not reviews), and that fold applies the ADR-0058 staleness test inline, at the fold itself:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step2-native-review-fold.sh"
+# stdout: `CURRENT_HEAD=<40-hex>`, `CODE_PASS=<0|1>`, `CODE_FAIL=<0|1>` — the folded code-namespace
+# verdict. Carry `CURRENT_HEAD` forward: Step 3's settle wait compares against it to catch a head
+# that moved mid-poll. The exit status answers "could I resolve them", never "is it a PASS" — a
+# folded FAIL is `CODE_FAIL=1` at exit 0. Pass the same `--cp` token Step 2's gate got, or omit it.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh "$REPO" "$PR" [--cp]
 ```
 
 Now resolve **per namespace** (the marker verdict from the verb above, the native review + §CP
@@ -1007,7 +1052,11 @@ verb also owns the running/wedged split and the latest-per-context reduction —
 re-derive the query (#3762).
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3-rollup-bindings.sh"
+# stdout: `CONTEXTS=<n>`, `RUNNING=<names>`, `WEDGED=<names>`, `GATING_RED=<names>` — the classifier
+# input the branches below read. An empty RUNNING/WEDGED/GATING_RED is the all-green answer, so the
+# lines are always printed; an unreadable head instead prints `refused — head CI unreadable …` plus
+# `INTENT_UNCLEARED=<0|1>` and exits 0 (a successful decline). Read for `CONTEXTS=`, not the status.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh "$REPO" "$PR"
 ```
 
 **Parser-held — keep that source line inside this section.** The script's `jq` rollup bindings
@@ -1061,7 +1110,9 @@ the workflow runs GitHub actually recorded for the head SHA — **both reads fai
 absence):
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3-empty-checkset-probe.sh"
+# stdout: `HEAD_SHA=<40-hex>`, `NWF=<n>`, `NRUNS=<n>`. Both counts already carry their fail-safe
+# substitute when the lookup itself failed, so the printed number is the one to branch on.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-empty-checkset-probe.sh "$REPO" "$PR"
 ```
 
 Classify in this order (a `skipped` / `cancelled` conclusion is non-blocking — neither a failure
@@ -1149,7 +1200,12 @@ is why a later-empty pending set inside the loop is a genuine green, not the dro
 false-green Step 3z guards (that state is branch 3, never reached from here):
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3-ci-settle-wait.sh"
+# Hand it the head Step 2 verified (`CURRENT_HEAD=` from the native-review fold) — the mid-settle
+# head-move guard compares against it, so a guessed value re-opens the TOCTOU window it closes.
+# stdout: a progress line per poll, then ONE terminal line — `gating checks settled green after …`
+# (proceed to Step 3.5), `routed to heal-ci …`, or a `refused — …` — plus `INTENT_UNCLEARED=<0|1>`.
+# Every disposition is a successful decline and exits 0: read the TERMINAL WORD, not the status.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-ci-settle-wait.sh "$REPO" "$PR" "$CURRENT_HEAD"
 ```
 
 The three returns are the **whole guarantee**: `0` reaches the enqueue, `2` routes a mid-wait red
@@ -1222,7 +1278,11 @@ statelessly against the PR's own reopened-event history so a genuinely-stuck pro
 loop:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3z-dropped-trigger.sh"
+# Hand it the `HEAD_SHA=` the empty-checkset probe printed — the nudge counts `reopened` events since
+# THAT commit, so a guessed head would mis-count them and re-nudge a head already nudged once.
+# stdout: one terminal line — `nudged (close→reopen) …` or `unverified (no runs fired …)` — plus
+# `INTENT_UNCLEARED=<0|1>`. Both are successful declines and exit 0; read the terminal word.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh "$REPO" "$PR" "$HEAD_SHA"
 ```
 
 The nudge **never bypasses verification** — it only restores the *missing runs*. A nudged PR
@@ -1258,7 +1318,9 @@ is never an error." This is a producer-presence test, **not** a per-PR escape: a
 below (that's a real gap, not portability).
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3_5-producer-preflight.sh"
+# stdout: `HAS_PRODUCER=<n>`, plus the `guard 2 N/A …` line at 0. The NUMBER is the answer, and a 0
+# is reached only on a CONFIRMED-empty lookup — an unread one degrades to the strict path, never here.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-producer-preflight.sh "$REPO"
 ```
 
 When a producer **is** present (the phoenix home repo, or any adopter that ships the
@@ -1273,7 +1335,12 @@ control-plane skills at the seam — minor duplication is the cheaper trade now;
 helper later if a third consumer appears.
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3_5-fetch-artifact.sh"
+# stdout: `HEAD_SHA=`, `RUN_ID=`, `ART_ID=`, `MANIFEST=`, `ART_FETCH_STATUS=`, `ART_FETCH_ERR=` — the
+# six inputs the assertion below takes as arguments. `RUN_ID` / `ART_ID` are legitimately EMPTY on a
+# genuine absence (that IS assertion 1b's input), so every line is printed unconditionally: an absent
+# line would mean the fetch never ran. The bundle itself stays on disk under the per-run `mktemp -d`
+# that `MANIFEST=` points into — the one piece of cross-step state a process boundary does not lose.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-fetch-artifact.sh "$REPO" "$PR"
 ```
 
 Now assert the bundle, **failing closed** on each check — an unreachable upstream, a missing
@@ -1283,7 +1350,15 @@ failure (assertion 1a) is reported as unverified-transient and **must be checked
 genuine-absence case (1b), since a transport failure leaves the bundle fields empty:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3_5-assert-bundle.sh"
+# Hand it the six values the fetch printed, VERBATIM and in this order. They are positional because
+# the fetch and the assertion are separate processes now, and an input that silently defaulted to
+# empty here would read as "genuine absence" (assertion 1b) for a bundle that fetched fine — so each
+# refuses when absent, except `ART_FETCH_ERR`, which is the transient cause text and may be empty.
+# stdout: NOTHING when all four assertions hold — guard 2 cleared; otherwise the ONE `unverified (…)`
+# / `run-evidence checks failed (…)` line plus `INTENT_UNCLEARED=<0|1>`, at exit 0 (a successful
+# decline). Read the line, not the status.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-assert-bundle.sh \
+  "$REPO" "$PR" "$ART_FETCH_STATUS" "$RUN_ID" "$ART_ID" "$MANIFEST" "$HEAD_SHA" "$ART_FETCH_ERR"
 ```
 
 The five refusal reasons are **distinct and load-bearing** — each names *why* the bundle
@@ -1421,7 +1496,11 @@ Discrimination is live-verified on this org: `github-advanced-security` and
 `copilot-pull-request-reviewer` return `Bot`, a human login returns `User` (#4408).
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3_6-threads-read.sh"
+# stdout: one compact JSON object per UNRESOLVED thread (`{id, path, line, author, class, body}`).
+# ZERO objects at exit 0 is the ordinary clean answer — no unresolved threads. A read that could not
+# execute prints its two `STOP:` / refusal lines plus `INTENT_UNCLEARED=<0|1>` and exits 1, so the
+# status is what tells "no threads" from "no answer": never read emptiness as clean.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_6-threads-read.sh "$REPO" "$PR"
 ```
 
 ### Disposition — class first, then (bot only) substantive-vs-nit
@@ -1488,7 +1567,10 @@ boundary. Reuse the shared `findCommentLeaks` detector via the pipeline-cli verb
 matcher `redact-leaks` and `verdict post` already consume — one detector, not a re-invented one):
 
 ```bash
-. "$SHIPIT_SCRIPTS/step3_7-leak-scan.sh"
+# stdout: `LEAK_SCAN=clean` when guard 4 clears — a positive token, because this guard's clean answer
+# is otherwise silence and silence is also what a scan that never ran looks like. A leak, or an
+# unresolved shim, names itself on stderr, prints `INTENT_UNCLEARED=<0|1>`, and exits 1.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_7-leak-scan.sh "$REPO" "$PR"
 ```
 
 Refuse **fail-closed**, exactly like the other pre-enqueue guards: a non-zero `scan-pr` (a live leak)
@@ -1552,7 +1634,10 @@ is the **`already queued to merge`** message the enqueue prints and/or the PR's 
 field, which gh 2.62.0 rejects, #1930). See ADR 0132 addendum §3.
 
 ```bash
-. "$SHIPIT_SCRIPTS/step5-confirm-enqueued.sh"
+# stdout: the two PR-state objects, then `QUEUE_STATE=<merged|queued|pending|ejected>` — that last
+# line is the answer. An unresolved shim prints no `QUEUE_STATE=` line, names itself, and exits 1:
+# could-not-run is UNKNOWN, never a queue outcome.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5-confirm-enqueued.sh "$REPO" "$PR"
 ```
 
 **Why the verb and not a `gh api …/timeline` one-liner here.** This confirmation used to
@@ -1645,7 +1730,11 @@ yet), which is **never** an ejection. The classification is a **pure, unit-teste
 reconcile shells out to it per poll and branches on the printed outcome word:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step5_5-reconcile.sh"
+# stdout: `MERGE_OUTCOME=<merged|queued|pending|ejected>`, `RECONCILE_HORIZON=<secs>`,
+# `INTENT_UNCLEARED=<0|1>`, then `MERGE_DISPOSITION=<text>` last (it is the only multi-word value, so
+# take the rest of that line verbatim into the ledger's `merge:` line). An unresolved shim prints
+# none of them and exits 1 — a reconcile that never ran is UNKNOWN, not `pending`.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh "$REPO" "$PR"
 ```
 
 **Parser-held — keep that source line inside this section.** The script's `RECONCILE_TRIES` /
@@ -1855,7 +1944,10 @@ issue's inherited stamp (exactly the #1211/#1212/#1213 foundation shape, address
 behavior is exactly as it was before this dimension existed:
 
 ```bash
-. "$SHIPIT_SCRIPTS/step5b-release-queue.sh"
+# Hand it the linked issue Step 1 resolved. stdout: one line, `RELEASE_QUEUE=queued (awaiting human
+# flip)` or `RELEASE_QUEUE=n/a (not a dark ship)` — the ledger value. No linked issue ⇒ nothing to
+# queue ⇒ the `n/a` no-op, unchanged.
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5b-release-queue.sh "$REPO" "$PR" "$ISSUE"
 ```
 
 The `status:awaiting-release` label is **orthogonal to the `status:*` pickability spine** — it

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -188,7 +188,7 @@ each of those steps prints `INTENT_UNCLEARED=<0|1>` and that is what your outcom
 it directly only to clear an intent outside a step (stdout is the same one line):
 
 ```bash
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/disarm-intent.sh "$REPO" <pr> <preflight|refuse|post-enqueue|ejected>
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/disarm-intent.sh <owner/repo> <pr> <preflight|refuse|post-enqueue|ejected>
 ```
 
 **Site 1 is Step 0's `disarm_intent preflight || exit 1`, and it is the one that catches the
@@ -283,7 +283,7 @@ Before anything else, read the PR's changed files and split them by class. This 
 # stdout: `PR=<n>` — the run's PR, which you re-pass as every later step's second argument — then one
 # changed-file path per line. A refusal (the §RO-iso stop, or a guard-6 Site-1 disarm that failed)
 # prints NO `PR=` line, names itself on stderr, and exits non-zero: read the status first.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh "$REPO" <pr number>
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh <owner/repo> <pr number>
 ```
 
 Classify each path. The classification is **derived by the shared verb `pipeline-cli cp-classify`**,
@@ -365,7 +365,7 @@ UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
 # surface. The ordinary §CP answer is the ABSENCE of a BLOCKING line, so read `CP_STATE=` as the
 # evidence the derivation ran — never emptiness. A classification that could not be made prints
 # `STOP: …` and exits 1; that is UNKNOWN, never "no gates required".
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh <owner/repo> <pr number>
 ```
 
 **Routing:**
@@ -448,7 +448,7 @@ bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh "
   # stdout: exactly one `§CP approval: …` line, plus `CP_FLAG=--cp` on the discharge branch only —
   # that token is the Step-2 seam, and this is its only source. A branch that could not answer names
   # the failed read on stderr and exits 1: UNKNOWN, never `awaiting control-plane approval`.
-  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh "$REPO" "$PR"
+  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh <owner/repo> <pr number>
   ```
 
   This is **only** the §CP unblock — it does not weaken any other guard. The SHA-bound gate verdict
@@ -668,7 +668,7 @@ dispatches off, so `dispatched-gate == required-gate` holds by construction:
 # stdout: one `ship-it guard 1: …` line naming the required namespaces. The EXIT STATUS is the gate —
 # 0 only when `verdict gate` passed every required namespace; every refusal names itself on stderr
 # and exits 1. Pass `--cp` as the THIRD argument only when Step 0's approval gate printed it.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh "$REPO" "$PR" [--cp]
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh <owner/repo> <pr number> [--cp]
 ```
 
 **The one input this step takes beyond the PR is the §CP seam, and Step 0 already decided it.** Step
@@ -796,7 +796,7 @@ not reviews), and that fold applies the ADR-0058 staleness test inline, at the f
 # verdict. Carry `CURRENT_HEAD` forward: Step 3's settle wait compares against it to catch a head
 # that moved mid-poll. The exit status answers "could I resolve them", never "is it a PASS" — a
 # folded FAIL is `CODE_FAIL=1` at exit 0. Pass the same `--cp` token Step 2's gate got, or omit it.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh "$REPO" "$PR" [--cp]
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh <owner/repo> <pr number> [--cp]
 ```
 
 Now resolve **per namespace** (the marker verdict from the verb above, the native review + §CP
@@ -1056,7 +1056,7 @@ re-derive the query (#3762).
 # input the branches below read. An empty RUNNING/WEDGED/GATING_RED is the all-green answer, so the
 # lines are always printed; an unreadable head instead prints `refused — head CI unreadable …` plus
 # `INTENT_UNCLEARED=<0|1>` and exits 0 (a successful decline). Read for `CONTEXTS=`, not the status.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh <owner/repo> <pr number>
 ```
 
 **Parser-held — keep that source line inside this section.** The script's `jq` rollup bindings
@@ -1112,7 +1112,7 @@ absence):
 ```bash
 # stdout: `HEAD_SHA=<40-hex>`, `NWF=<n>`, `NRUNS=<n>`. Both counts already carry their fail-safe
 # substitute when the lookup itself failed, so the printed number is the one to branch on.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-empty-checkset-probe.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-empty-checkset-probe.sh <owner/repo> <pr number>
 ```
 
 Classify in this order (a `skipped` / `cancelled` conclusion is non-blocking — neither a failure
@@ -1205,7 +1205,7 @@ false-green Step 3z guards (that state is branch 3, never reached from here):
 # stdout: a progress line per poll, then ONE terminal line — `gating checks settled green after …`
 # (proceed to Step 3.5), `routed to heal-ci …`, or a `refused — …` — plus `INTENT_UNCLEARED=<0|1>`.
 # Every disposition is a successful decline and exits 0: read the TERMINAL WORD, not the status.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-ci-settle-wait.sh "$REPO" "$PR" "$CURRENT_HEAD"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-ci-settle-wait.sh <owner/repo> <pr number> <CURRENT_HEAD>
 ```
 
 The three returns are the **whole guarantee**: `0` reaches the enqueue, `2` routes a mid-wait red
@@ -1282,7 +1282,7 @@ loop:
 # THAT commit, so a guessed head would mis-count them and re-nudge a head already nudged once.
 # stdout: one terminal line — `nudged (close→reopen) …` or `unverified (no runs fired …)` — plus
 # `INTENT_UNCLEARED=<0|1>`. Both are successful declines and exit 0; read the terminal word.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh "$REPO" "$PR" "$HEAD_SHA"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh <owner/repo> <pr number> <HEAD_SHA>
 ```
 
 The nudge **never bypasses verification** — it only restores the *missing runs*. A nudged PR
@@ -1320,7 +1320,7 @@ below (that's a real gap, not portability).
 ```bash
 # stdout: `HAS_PRODUCER=<n>`, plus the `guard 2 N/A …` line at 0. The NUMBER is the answer, and a 0
 # is reached only on a CONFIRMED-empty lookup — an unread one degrades to the strict path, never here.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-producer-preflight.sh "$REPO"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-producer-preflight.sh <owner/repo>
 ```
 
 When a producer **is** present (the phoenix home repo, or any adopter that ships the
@@ -1340,7 +1340,7 @@ helper later if a third consumer appears.
 # genuine absence (that IS assertion 1b's input), so every line is printed unconditionally: an absent
 # line would mean the fetch never ran. The bundle itself stays on disk under the per-run `mktemp -d`
 # that `MANIFEST=` points into — the one piece of cross-step state a process boundary does not lose.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-fetch-artifact.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-fetch-artifact.sh <owner/repo> <pr number>
 ```
 
 Now assert the bundle, **failing closed** on each check — an unreachable upstream, a missing
@@ -1358,7 +1358,7 @@ genuine-absence case (1b), since a transport failure leaves the bundle fields em
 # / `run-evidence checks failed (…)` line plus `INTENT_UNCLEARED=<0|1>`, at exit 0 (a successful
 # decline). Read the line, not the status.
 bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-assert-bundle.sh \
-  "$REPO" "$PR" "$ART_FETCH_STATUS" "$RUN_ID" "$ART_ID" "$MANIFEST" "$HEAD_SHA" "$ART_FETCH_ERR"
+  <owner/repo> <pr number> <ART_FETCH_STATUS> <RUN_ID> <ART_ID> <MANIFEST> <HEAD_SHA> <ART_FETCH_ERR>
 ```
 
 The five refusal reasons are **distinct and load-bearing** — each names *why* the bundle
@@ -1500,7 +1500,7 @@ Discrimination is live-verified on this org: `github-advanced-security` and
 # ZERO objects at exit 0 is the ordinary clean answer — no unresolved threads. A read that could not
 # execute prints its two `STOP:` / refusal lines plus `INTENT_UNCLEARED=<0|1>` and exits 1, so the
 # status is what tells "no threads" from "no answer": never read emptiness as clean.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_6-threads-read.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_6-threads-read.sh <owner/repo> <pr number>
 ```
 
 ### Disposition — class first, then (bot only) substantive-vs-nit
@@ -1570,7 +1570,7 @@ matcher `redact-leaks` and `verdict post` already consume — one detector, not 
 # stdout: `LEAK_SCAN=clean` when guard 4 clears — a positive token, because this guard's clean answer
 # is otherwise silence and silence is also what a scan that never ran looks like. A leak, or an
 # unresolved shim, names itself on stderr, prints `INTENT_UNCLEARED=<0|1>`, and exits 1.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_7-leak-scan.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_7-leak-scan.sh <owner/repo> <pr number>
 ```
 
 Refuse **fail-closed**, exactly like the other pre-enqueue guards: a non-zero `scan-pr` (a live leak)
@@ -1637,7 +1637,7 @@ field, which gh 2.62.0 rejects, #1930). See ADR 0132 addendum §3.
 # stdout: the two PR-state objects, then `QUEUE_STATE=<merged|queued|pending|ejected>` — that last
 # line is the answer. An unresolved shim prints no `QUEUE_STATE=` line, names itself, and exits 1:
 # could-not-run is UNKNOWN, never a queue outcome.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5-confirm-enqueued.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5-confirm-enqueued.sh <owner/repo> <pr number>
 ```
 
 **Why the verb and not a `gh api …/timeline` one-liner here.** This confirmation used to
@@ -1734,7 +1734,7 @@ reconcile shells out to it per poll and branches on the printed outcome word:
 # `INTENT_UNCLEARED=<0|1>`, then `MERGE_DISPOSITION=<text>` last (it is the only multi-word value, so
 # take the rest of that line verbatim into the ledger's `merge:` line). An unresolved shim prints
 # none of them and exits 1 — a reconcile that never ran is UNKNOWN, not `pending`.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh "$REPO" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh <owner/repo> <pr number>
 ```
 
 **Parser-held — keep that source line inside this section.** The script's `RECONCILE_TRIES` /
@@ -1947,7 +1947,7 @@ behavior is exactly as it was before this dimension existed:
 # Hand it the linked issue Step 1 resolved. stdout: one line, `RELEASE_QUEUE=queued (awaiting human
 # flip)` or `RELEASE_QUEUE=n/a (not a dark ship)` — the ledger value. No linked issue ⇒ nothing to
 # queue ⇒ the `n/a` no-op, unchanged.
-bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5b-release-queue.sh "$REPO" "$PR" "$ISSUE"
+bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5b-release-queue.sh <owner/repo> <pr number> <linked issue>
 ```
 
 The `status:awaiting-release` label is **orthogonal to the `status:*` pickability spine** — it

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/disarm-intent.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/disarm-intent.sh
@@ -5,10 +5,22 @@
 # Extracted VERBATIM from ship-it/SKILL.md's The no-parked-merge-intent invariant fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/disarm-intent.sh \
+#                   <REPO> <PR> <preflight|refuse|post-enqueue|ejected>
+#              stdout ⇒ one line, `INTENT_UNCLEARED=0` (the intent is provably clear) or
+#              `INTENT_UNCLEARED=1` (it may STILL be armed — the run's outcome line MUST carry it).
+#              The exit status matches, so a caller may read either. `INTENT_UNCLEARED` is the one
+#              value the sourced form left in the caller's shell that no longer crosses a process
+#              boundary, so it is relayed on stdout instead.
+#   SOURCED:   the sanctioned in-script edge, and why the function below is untouched. Nine ship-it
+#              step scripts source this file for `disarm_intent`, which the SKILL.md preamble used to
+#              leave in the agent's shell for the whole chain; a process cannot inherit a function,
+#              so each caller now pulls it in itself. `verify-chain-resolves.sh` sources it too.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
@@ -19,7 +31,11 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # `auto_merge` — never trust
 # `--disable-auto`'s exit code, which is non-zero both when the disable failed and when nothing
 # was armed. Exit 1 = the intent may STILL be armed: surface it, never report a clean stop over it.
-INTENT_UNCLEARED=0   # set by any failed disarm; the run's outcome line MUST carry it (see Running it)
+# `:-0` rather than a bare `0`: nine step scripts now source this file in-chain, so the assignment
+# runs more than once per run. A bare `0` would reset a 1 an earlier disarm had already recorded, and
+# the run would report a clean stop over an intent that may still be armed — the exact failure the
+# variable exists to surface. A fresh shell still starts at 0.
+INTENT_UNCLEARED="${INTENT_UNCLEARED:-0}"   # set by any failed disarm; the run's outcome line MUST carry it (see Running it)
 disarm_intent() {   # $1 = preflight | refuse | post-enqueue | ejected
   "$PCLI" merge-intent disarm --pr "$PR" --repo "$REPO" --site "$1" || {
     echo "ship-it: FAILED to clear the merge intent on #$PR (site $1) — a later approval could enqueue it ungated (ADR 0198). Disable auto-merge by hand before this PR is approved again." >&2
@@ -29,4 +45,18 @@ disarm_intent() {   # $1 = preflight | refuse | post-enqueue | ejected
 
 # Site 1 — run start. This function is DEFINED here; the call itself is WIRED at Step 0, on the
 # line after `PR=` — the first point at which both $PR and $REPO exist (see "Step 0 — Classify the
-# diff"). Do not call it here: this block is preamble and runs before Step 0 resolves $PR.
+# diff"). Do not call it here in SOURCED mode: that path is preamble and runs before Step 0
+# resolves $PR. The executed entry below is a different caller — it is handed both.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  REPO="${REPO:-${1:?disarm-intent.sh: no <REPO> argument — refusing to disarm an intent on an unnamed repo}}"
+  PR="${PR:-${2:?disarm-intent.sh: no <PR> argument — refusing to disarm an intent on an unnamed PR}}"
+  # The status answers "could I clear it", and the printed line carries the same fact for the ledger
+  # (`.patterns/skill-script-shell-shape.md` § The dual-mode shape rule 4). A failed disarm is a
+  # 1 to REPORT, never a reason to print nothing.
+  if disarm_intent "${3:?disarm-intent.sh: no <site> argument — refusing to disarm at an unnamed site}"; then
+    echo "INTENT_UNCLEARED=0"
+  else
+    echo "INTENT_UNCLEARED=1"; exit 1
+  fi
+fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
@@ -5,16 +5,29 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 0 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh <REPO> <PR>
+#              stdout is a PROSE answer channel, exactly as the fence's was: `CP_STATE=<state>`, then
+#              one `BLOCKING (…)` line per §CP finding, then one class word per class present
+#              (`has-skills` / `has-code` / `has-docs`) and `has-ui` when the diff renders a surface.
+#              The ordinary §CP answer is the ABSENCE of a BLOCKING line, so read `CP_STATE=` as the
+#              evidence the derivation ran — never emptiness. A classification that could not be made
+#              prints `STOP: …` and exits 1.
+#   SOURCED:   `verify-chain-resolves.sh` check 2 stands this file up against a stubbed `gh` /
+#              `pipeline-cli`, reading $REPO and $PR out of its own driver shell. Untouched.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 # §CPREAD's `cp_changed_files` / `cp_head_sha`, sourced IN-CHAIN from their canonical home — the
 # extraction dropped this line and left both calls below command-not-found (#4547). Same idiom as
 # review-code's `classify-control-plane.sh`; never a re-copy of the helpers.
 # shellcheck source=../../shared/scripts/cp-read.sh
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
+
+REPO="${REPO:-${1:?step0-classify.sh: REPO unset and no \$1 — refusing to classify a diff in an unnamed repo}}"
+PR="${PR:-${2:?step0-classify.sh: PR unset and no \$2 — refusing to classify an unnamed PR}}"
 
 # The changed-file list is a fallible network READ, and EVERY probe in this step — §CP, the ADR
 # content clause, has-code/has-docs/has-skills, has-ui — is a `grep` over it. So a failed read used
@@ -54,6 +67,9 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # the why. Four states on stdout, only `not-control-plane` an answer: assert on the STATE WORD, never
 # the exit status (formats §CP; #4161/#4219).
 CP_STATE="$(printf '%s\n' "$FILES" | "$PCLI" cp-classify classify --repo "$REPO")"
+# The positive token, so the executed reader never infers the state from an absence — the ordinary
+# answer below is the ABSENCE of a BLOCKING line (`.patterns/skill-script-io-contract.md`, #4510).
+printf 'CP_STATE=%s\n' "$CP_STATE"
 if [ "$CP_STATE" = "control-plane" ]; then
   echo "BLOCKING"   # a path matched the live boundary: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100/0103); other skills/** auto-merge on a review-skill PASS (ADR 0073)
 elif [ "$CP_STATE" = "content-undetermined" ]; then
@@ -68,8 +84,14 @@ elif [ "$CP_STATE" = "content-undetermined" ]; then
   if [ -z "$HEAD_SHA" ]; then
     echo "BLOCKING (head SHA unreadable ⇒ no ref to probe ADR content at ⇒ §CP UNKNOWN, held)"   # fail closed: an unprobeable content clause is not an absent one
   else
-    printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
-      [ -z "$adr" ] && continue
+    # The ordinary answer here is a diff that touches NO ADR — i.e. this filter matching nothing.
+    # Left inside the pipeline, that no-match exit 1 becomes the pipeline's status under executed
+    # mode's `pipefail`. Capture the filter first (`|| true`) and give the loop an `if … fi` body, so
+    # neither the filter's nor an empty loop's status can reach this script's
+    # (`.patterns/skill-script-shell-shape.md` § The dual-mode shape rule 4).
+    TOUCHED_ADRS="$(printf '%s\n' "$FILES" | grep -E '^\.decisions/.*\.md$' || true)"
+    printf '%s\n' "$TOUCHED_ADRS" | while IFS= read -r adr; do
+      if [ -n "$adr" ]; then
       # Capture and CHECK before classifying, never a straight pipe — gh writes its error document to
       # STDOUT, so a pipe would hand the probe an ERROR BODY as the ADR body (§CPREAD #2, #4216).
       adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
@@ -89,6 +111,7 @@ elif [ "$CP_STATE" = "content-undetermined" ]; then
           guard-touching) echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)" ;;
           *) echo "BLOCKING ($adr — probe UNDETERMINED (state '$GC_STATE') ⇒ §CP, fail-closed)" ;;
         esac
+      fi
       fi
     done
   fi
@@ -116,9 +139,13 @@ HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"
 HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
 HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed: exclude NOTHING ⇒ every path reaches the doc test
 HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed: every path is a doc
-echo "$FILES" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills"   # → review-skill (ADR 0073/0150); §CP-blocking for merge via the cp-classify derivation above
-echo "$FILES" | grep -Eq "$HAS_CODE_RE" && echo "has-code"       # → review-code; the has-code roots agree with the docs-exclusion below in lockstep (§CLASS/§DOC, #663/#919/#1987)
-echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs"   # → review-doc; carve out code roots/skills/.glossary first, then test for a doc path (§DOC contract)
+# `if … then … fi`, not `… && echo`: a class the diff does NOT carry is this probe's ORDINARY answer,
+# and with `&& echo` the failing `grep` is the last command executed — so a docs-only PR would leave
+# this script's exit status at 1 and §SHARED's "read the status first, non-zero is UNKNOWN" rule
+# would make a perfectly good classification unreadable (rule 4). The predicates are byte-unchanged.
+if echo "$FILES" | grep -Eq "$HAS_SKILLS_RE"; then echo "has-skills"; fi   # → review-skill (ADR 0073/0150); §CP-blocking for merge via the cp-classify derivation above
+if echo "$FILES" | grep -Eq "$HAS_CODE_RE"; then echo "has-code"; fi       # → review-code; the has-code roots agree with the docs-exclusion below in lockstep (§CLASS/§DOC, #663/#919/#1987)
+if echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE"; then echo "has-docs"; fi   # → review-doc; carve out code roots/skills/.glossary first, then test for a doc path (§DOC contract)
 # No-class fail-closed (#2765): a NON-EMPTY diff whose files match NONE of the three classes above
 # — root tooling outside the code roots (biome-plugins/**, biome.jsonc, turbo.json) — must NOT ship
 # un-gated. `pipeline-cli class-probe classify` (the live decision source above) folds this in: any
@@ -159,4 +186,4 @@ UI_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_RE=' | head -n1 || true)"
 UX_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_EXCLUDE_RE=' | head -n1 || true)"
 if [ -n "$UI_LIVE" ]; then UI_RE="$(accept_re UI_RE "$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")" '.')"; else UI_RE='.'; fi   # FAIL CLOSED: can't read origin/main's UI_RE — or it resolves TRIVIAL — ⇒ '.' ⇒ every path UI-affecting ⇒ REQUIRE review-design, never silently skip (#2341/#4401)
 if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(accept_re UI_EXCLUDE_RE "$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")" '$^')"; else UI_EXCLUDE_RE='$^'; fi   # FAIL CLOSED: unreadable or trivial ⇒ '$^' never-match ⇒ carve out NOTHING ⇒ every apps/web/src path (incl. tests) gates review-design
-echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"   # carve test/spec first, THEN require review-design ALONGSIDE the class gate(s)
+if echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE"; then echo "has-ui"; fi   # carve test/spec first, THEN require review-design ALONGSIDE the class gate(s)

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh
@@ -5,10 +5,20 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 0's §CP approval gate fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh <REPO> <PR>
+#              stdout ⇒ exactly one `§CP approval: …` line, and — on the discharge branch only —
+#              `CP_FLAG=--cp`. That token is the Step-2 seam: it used to be an assignment the agent
+#              made in its own shell, and a process cannot inherit one, so the discharge branch PRINTS
+#              it and the shipper re-passes it as Step 2's third argument. A branch that could not
+#              answer names the failed read on stderr and exits 1 — read the status first, and never
+#              read a missing `CP_FLAG=` line as a discharge.
+#   SOURCED:   `verify-chain-resolves.sh` check 2 stands this file up against a stubbed `gh` /
+#              `pipeline-cli`, reading $REPO and $PR out of its own driver shell. Untouched.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 # §CPREAD + §CPREAD-APPROVAL's `cp_team_roster` / `cp_pr_author` / `cp_head_sha` /
 # `cp_team_membership`, sourced IN-CHAIN. SKILL.md documents a verbatim-paste precondition ahead of
@@ -19,6 +29,8 @@
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+REPO="${REPO:-${1:?step0-cp-approval.sh: REPO unset and no \$1 — refusing to discharge §CP on an unnamed repo}}"
+PR="${PR:-${2:?step0-cp-approval.sh: PR unset and no \$2 — refusing to discharge §CP on an unnamed PR}}"
 # ADR 0175: DETERMINISTIC §CP discharge keyed on control-plane team cardinality, not judgment.
 ORG="${REPO%%/*}"                                            # owner half of owner/repo
 # The one non-firing exit that is NOT a definite answer: it names the read that could not execute,
@@ -114,6 +126,11 @@ if printf '%s\n' "$MEMBERS" | "$PCLI" cp-cardinality decide \
      $([ "$NON_AUTHOR_APPROVAL_AT_HEAD" = true ] && printf -- '--non-author-approval-at-head') \
      $([ "$SELF_APPROVAL_AT_HEAD" = true ] && printf -- '--self-approval-at-head'); then
   echo "§CP approval: discharged deterministically (ADR 0175) → carry on to machine gates"
+  # THE SEAM (#4547), now a printed token rather than a caller-shell assignment (ADR 0232). This is
+  # still its ONLY sanctioned site: `--cp` licenses the SHA-less advisory at Step 2, and the
+  # discharge is exactly the condition that licenses it. A shipper that reads no `CP_FLAG=` line
+  # passes nothing, which is the STRICTER branch — an omitted seam can only refuse a §CP PR.
+  echo "CP_FLAG=--cp"
 else
   # Reachable ONLY with every input proven readable, so this message states a fact: the branch's
   # required human signal is genuinely absent.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh
@@ -1,15 +1,33 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007,SC1091,SC2016
+# shellcheck shell=bash disable=SC1007,SC1091,SC2016,SC2317
+# SC2317 is on the `return 1 2>/dev/null || exit 1` line: shellcheck reads the file as a script, so
+# the `exit` after a top-level `return` looks unreachable. It is exactly reachable in EXECUTED mode,
+# where the `return` is the no-op-with-an-error and the `exit` is what stops the run — the whole
+# point of the idiom (the same one `shared/scripts/cli-require.sh` uses).
 # Step 0's preflight: the §RO-iso isolation assert, guard 6 Site 1, and the changed-file read.
 #
 # Extracted VERBATIM from ship-it/SKILL.md's Step 0 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh <REPO> <PR>
+#              stdout ⇒ `PR=<n>` (the run's PR, the one value every later step is re-handed as an
+#              argument now that shell state cannot cross a process boundary), then one changed-file
+#              path per line. A refusal — the §RO-iso stop or a failed guard-6 Site-1 disarm — prints
+#              NO `PR=` line, names itself on stderr, and exits non-zero. Read the status first.
+#   SOURCED:   `verify-chain-resolves.sh` check 2 stands this file up against a stubbed `gh`, reading
+#              $REPO and $PR out of its own driver shell. That path is untouched, options and all.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479), and this preflight's contract is its
+# EXIT STATUS.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN from its canonical home. The SKILL.md
+# preamble used to source it once and leave the function in the agent's shell for the whole chain; a
+# process inherits no functions, so every caller pulls it in itself (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
 # §RO-iso's `iso_preflight`, sourced IN-CHAIN from its canonical home — the extraction dropped this
 # line and left the call below command-not-found (#4547). Same idiom as review-code's
 # `materialize-head.sh`; never a re-copy of the function.
@@ -17,13 +35,24 @@
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/iso-preflight.sh"
 
 # The one seam this move needed: the block's `PR=<pr number>` placeholder was filled by whoever ran
-# the step, so the sourcing site passes it instead — `. "$SHIPIT_SCRIPTS/step0-preflight.sh" <pr number>`.
-# Fail closed on an absent one: an empty $PR addresses `repos/$REPO/pulls/` and reads as a clean miss.
-PR="${1:-}"
-if [ -z "$PR" ]; then
-	printf 'ship-it Step 0: no PR number — source this as `. "$SHIPIT_SCRIPTS/step0-preflight.sh" <pr number>`.\n' >&2
-	return 1
+# the step, so the invocation passes it instead. Fail closed on an absent one: an empty $PR addresses
+# `repos/$REPO/pulls/` and reads as a clean miss.
+REPO="${REPO:-${1:-}}"
+PR="${PR:-${2:-}}"
+if [ -z "$REPO" ] || [ -z "$PR" ]; then
+	printf 'ship-it Step 0: no repo and/or PR number — run this as `bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-preflight.sh <REPO> <PR>`.\n' >&2
+	# `return` outside a function is a no-op-with-an-error in an EXECUTED script, and the run would
+	# carry straight on into the reads below with an empty $PR. The cli-require.sh idiom keeps the
+	# sourced path's `return` and gives the executed path the `exit` it needs (ADR 0232).
+	return 1 2>/dev/null || exit 1
 fi
+# `iso_preflight` reads $CLAUDE_CODE_AGENT and $WORKTREE_ROOT UNDEFAULTED, so under executed mode's
+# `set -u` an unset one aborts before the guard can answer at all. Bind each to its own current value
+# — empty when unset — so the executed form evaluates exactly the branches the no-options sourced
+# caller got. The shared function's body stays untouched (the same binding #4571 added at
+# `shared/scripts/iso-preflight.sh`'s own entry).
+CLAUDE_CODE_AGENT="${CLAUDE_CODE_AGENT-}"
+WORKTREE_ROOT="${WORKTREE_ROOT-}"
 # Isolation preflight FIRST. ship-it is §RO — it ships entirely over `gh api` / `gh pr merge`
 # (server-side) and materializes NO head via local git — so it should never touch the primary
 # checkout's git state. This is the defense-in-depth belt: if this ship-it spawn expected worktree
@@ -45,4 +74,8 @@ iso_preflight ship-it || exit 1   # ../gh-issue-intake-formats.md §RO-iso — d
 # intent state cannot honor the invariant at any later site.
 disarm_intent preflight || exit 1
 
+# The run's PR, echoed as the positive token every later step is re-handed as an argument. It is the
+# evidence this preflight RAN: the file list below can legitimately be short, so its length proves
+# nothing, whereas an absent `PR=` line is the refusal (rule 4 / §ZS).
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'PR=%s\n' "$PR"; fi
 gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh
@@ -5,11 +5,25 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 2 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-native-review-fold.sh \
+#                   <REPO> <PR> [--cp]
+#              stdout ⇒ three lines — `CURRENT_HEAD=<40-hex>`, `CODE_PASS=<0|1>`, `CODE_FAIL=<0|1>`
+#              — the three values the sourced form left in the caller's shell. `CURRENT_HEAD` is
+#              re-passed to Step 3's settle wait, which compares against it to catch a head that
+#              moved mid-poll. The exit status answers "could I resolve them", never "is it a PASS":
+#              a folded FAIL is `CODE_FAIL=1` at exit 0 (rule 4).
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+REPO="${REPO:-${1:?step2-native-review-fold.sh: REPO unset and no \$1 — refusing to fold a review in an unnamed repo}}"
+PR="${PR:-${2:?step2-native-review-fold.sh: PR unset and no \$2 — refusing to fold a review on an unnamed PR}}"
+# The same seam Step 2's gate reads, re-passed as the third argument (see step0-cp-approval.sh).
+CP_FLAG="${CP_FLAG:-${3-}}"
 
 # the PR's CURRENT head SHA — the head every verdict must be bound to (ADR 0058)
 CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
@@ -74,3 +88,9 @@ if [ -n "$RSHA" ]; then case "$CURRENT_HEAD" in "$RSHA"*)
     esac
   fi   # else the marker is newer and already stands — leave CODE_PASS/CODE_FAIL as the verb resolved them
 ;; esac; fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'CURRENT_HEAD=%s\n' "$CURRENT_HEAD"
+  printf 'CODE_PASS=%s\n' "$CODE_PASS"
+  printf 'CODE_FAIL=%s\n' "$CODE_FAIL"
+fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh
@@ -5,14 +5,34 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 2 gate fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step2-verdict-gate.sh \
+#                   <REPO> <PR> [--cp]
+#              stdout ⇒ one `ship-it guard 1: …` line naming the required namespaces. The EXIT STATUS
+#              is the gate: 0 only when `verdict gate` passed every required namespace. Every refusal
+#              names itself on stderr and exits 1 — read the status first, never the stdout's shape.
+#   SOURCED:   `verify-chain-resolves.sh` check 3 sources this file to prove the §CP seam reaches
+#              `verdict gate`, reading $REPO / $PR / $CP_FLAG out of its own driver shell. Untouched.
+#
+# THIS FILE IS THE `pipefail`-OFF EXEMPLAR `.patterns/skill-script-shell-shape.md` names, so the
+# option is not simply switched on: the ONE guard that read a pipeline's status — `PROBE_RC` below —
+# is re-derived as capture-then-match so it still answers with `class-probe`'s own status and nothing
+# else. See its comment. Every other pipeline here either cannot fail in its producer stage
+# (`printf`) or has its status discarded, so `pipefail` is inert over them.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN — a process inherits no functions, so the
+# SKILL.md preamble can no longer leave it in the shell for this step (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+REPO="${REPO:-${1:?step2-verdict-gate.sh: REPO unset and no \$1 — refusing to gate a PR in an unnamed repo}}"
+PR="${PR:-${2:?step2-verdict-gate.sh: PR unset and no \$2 — refusing to gate an unnamed PR}}"
 # the required namespaces for THIS diff — one per artifact class present, plus review-design when
 # the diff is UI-affecting. `.glossary/**` rides has-code, so an ADR + a glossary row requires BOTH
 # review-doc AND review-code; satisfying one is not enough.
@@ -22,8 +42,16 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
 # unobservable: `pipefail` is OFF here (#4146), so paste's 0 was the pipeline's status (#4231). Join
 # the ALREADY-CAPTURED value instead. The `verdict gate` zero-scope refusal downstream is untouched —
 # this removes the masking in front of it, it does not relocate the backstop.
-REQUIRED_NS="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
-  | "$PCLI" class-probe classify --namespaces)"; PROBE_RC=$?
+# CAPTURE-THEN-MATCH, and the capture is what preserves the guard under executed mode's `pipefail`.
+# `PROBE_RC` must be `class-probe`'s OWN status — that is what discriminates its exit-4 refusal from
+# a classification. Left as one pipeline, `pipefail` would fold `gh`'s status into it too, so a
+# transport failure would report itself as a class-probe refusal. Splitting the stages restores the
+# original operand exactly: `printf` cannot fail, so the pipeline's status IS the probe's. `gh`'s own
+# status is deliberately left unread HERE, exactly as the pipe left it unread — its stdout (an error
+# document included) reaches the probe byte-for-byte as before, and the probe's #4010 fail-closed
+# stdin read is what judges it. This is a relay of the same decision, not a new guard (ADR 0228).
+PROBE_IN="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')"
+REQUIRED_NS="$(printf '%s\n' "$PROBE_IN" | "$PCLI" class-probe classify --namespaces)"; PROBE_RC=$?
 if [ "$PROBE_RC" -ne 0 ]; then
   disarm_intent refuse || INTENT_UNCLEARED=1
   echo "ship-it: refused at guard 1 — class-probe REFUSED (exit $PROBE_RC); the required-namespace set is UNKNOWN, not empty. NOT enqueued." >&2; exit 1
@@ -47,7 +75,11 @@ echo "ship-it guard 1: PR $PR requires $(printf '%s\n' "$REQUIRED_NS" | grep -c 
 # source site as something the shipper types by hand — the hand-substitution this seam removes.
 # Unset ⇒ empty ⇒ the non-§CP branch, which is the STRICTER one (the SHA-less advisory does not
 # count), so an omitted seam can only refuse a §CP PR, never pass one.
-CP_FLAG="${CP_FLAG:-}"
+# Under ADR 0232 the seam arrives as the THIRD ARGUMENT, printed by `step0-cp-approval.sh`'s
+# discharge branch and re-passed by the shipper; a sourced caller's own $CP_FLAG still wins, so
+# `verify-chain-resolves.sh` check 3 exercises the same seam it always did. Absent ⇒ empty ⇒ the
+# non-§CP branch, which is the STRICTER one.
+CP_FLAG="${CP_FLAG:-${3-}}"
 case "$CP_FLAG" in
   ""|"--cp") ;;
   # A third value is not a classification. It would reach `verdict gate` as an unrecognized flag —

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-ci-settle-wait.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-ci-settle-wait.sh
@@ -5,11 +5,36 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-ci-settle-wait.sh \
+#                   <REPO> <PR> <CURRENT_HEAD>
+#              stdout ⇒ one progress line per poll, then exactly one terminal line: `gating checks
+#              settled green after …` (proceed to Step 3.5), `routed to heal-ci …`, or one of the
+#              `refused — …` lines. Every terminus also prints `INTENT_UNCLEARED=<0|1>`. Read the
+#              TERMINAL WORD, not the exit status: like the fenced block, every disposition here is a
+#              successful decline and exits 0 — only a refusal to run at all exits non-zero.
+#              `<CURRENT_HEAD>` is the head Step 2 verified, printed by `step2-native-review-fold.sh`;
+#              the mid-settle head-move guard compares against it, so passing it is load-bearing.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+REPO="${REPO:-${1:?step3-ci-settle-wait.sh: REPO unset and no \$1 — refusing to poll CI in an unnamed repo}}"
+PR="${PR:-${2:?step3-ci-settle-wait.sh: PR unset and no \$2 — refusing to poll CI on an unnamed PR}}"
+# The head Step 2 verified. Fail closed on an absent one: the mid-settle head-move guard below
+# compares against it, and an empty value would make every head "unchanged" and re-open the TOCTOU
+# window the guard exists to close.
+CURRENT_HEAD="${CURRENT_HEAD:-${3:?step3-ci-settle-wait.sh: CURRENT_HEAD unset and no \$3 — refusing to poll without the verified head to compare against}}"
+# `read_head_ci` (and, through it, `disarm_intent`), sourced IN-CHAIN. The poll re-reads the head
+# through the SAME function Step 3's rollup used, and a process inherits no functions, so this file
+# pulls the definition in itself rather than carrying a second copy that could drift (ADR 0232/0228).
+# The cost is one extra `checks read` at source time — the same read this loop makes on its first
+# pass anyway, with the same refusal disposition on an unreadable head.
+# shellcheck source=step3-rollup-bindings.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/step3-rollup-bindings.sh"
 
 SETTLE_BUDGET_SECS="${SHIP_IT_SETTLE_BUDGET_SECS:-600}"    # total in-process wait ceiling — BOUNDED, never unbounded
 SETTLE_INTERVAL_SECS="${SHIP_IT_SETTLE_INTERVAL_SECS:-30}" # cadence; each pass emits progress so a no-progress watchdog never fires
@@ -79,6 +104,9 @@ Re-dispatch ship-it once the re-run settles — idempotent, a re-ship on the now
 }
 
 ci_settle_wait; SETTLE_RC=$?
+# Every terminus below is a successful decline or a proceed, so the ledger's intent state has to ride
+# stdout — it is the one value the sourced form left in the caller's shell that no process inherits.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
 case "$SETTLE_RC" in
   0) : ;;         # settled green → fall through to Step 3.5 → Step 4 (enqueue)
   2)              # gating red mid-wait → route to /heal-ci (Step 3 branch 1's disposition), then STOP — never enqueue.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-empty-checkset-probe.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-empty-checkset-probe.sh
@@ -5,11 +5,21 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-empty-checkset-probe.sh <REPO> <PR>
+#              stdout ⇒ three lines — `HEAD_SHA=<40-hex>`, `NWF=<n>`, `NRUNS=<n>` — the values the
+#              sourced form left in the caller's shell. Both counts already carry their fail-safe
+#              substitute when the lookup itself failed, so the printed number is always the number
+#              the Step-3z branch is meant to read.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+REPO="${REPO:-${1:?step3-empty-checkset-probe.sh: REPO unset and no \$1 — refusing to probe an unnamed repo}}"
+PR="${PR:-${2:?step3-empty-checkset-probe.sh: PR unset and no \$2 — refusing to probe an unnamed PR}}"
 
 HEAD_SHA=$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')
 # (a) Does this repo run Actions at all? A CI-less / foreign repo's empty check set is genuine,
@@ -21,5 +31,15 @@ NRUNS=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
 # An empty capture = the lookup itself failed (network/auth/rate-limit), NOT a confirmed zero —
 # never nudge on an unconfirmed absence: assume "runs exist" / "no Actions", fall through, and
 # let the Step 3.5 backstop guard the merge.
-[ -z "$NRUNS" ] && NRUNS=1
-[ -z "$NWF" ]   && NWF=0
+# `if … fi`, not `[ … ] && VAR=…`: the ORDINARY case is a lookup that succeeded, which makes the
+# `[ -z … ]` test FALSE — and as the last command of the script that would leave the exit status at
+# 1 on the very reads that worked (`.patterns/skill-script-shell-shape.md` § The dual-mode shape
+# rule 4). The substitutions themselves are unchanged.
+if [ -z "$NRUNS" ]; then NRUNS=1; fi
+if [ -z "$NWF" ]; then NWF=0; fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'HEAD_SHA=%s\n' "$HEAD_SHA"
+  printf 'NWF=%s\n' "$NWF"
+  printf 'NRUNS=%s\n' "$NRUNS"
+fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh
@@ -6,17 +6,30 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3 fenced block (epic #4435 phase 1, #4448/#4498).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them. The bare `exit 0` on an unreadable head is therefore the SHIPPER's exit,
-# which is the intended disposition: an unreadable head is never enqueued.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh <REPO> <PR>
+#              stdout ⇒ four lines — `CONTEXTS=<n>`, `RUNNING=<names>`, `WEDGED=<names>`,
+#              `GATING_RED=<names>` — the classifier input the sourced form left in the caller's
+#              shell. An unreadable head prints NONE of them and instead prints the `refused — head
+#              CI unreadable …` line plus `INTENT_UNCLEARED=<0|1>`; that is a successful DECLINE, so
+#              it exits 0 exactly as the fenced block did. Read the presence of `CONTEXTS=`, never
+#              the exit status, to tell an answer from a decline here.
+#   SOURCED:   the sanctioned in-script edge — `step3-ci-settle-wait.sh` sources this file for
+#              `read_head_ci`, which no longer reaches it through the agent's shell (ADR 0232).
 #
 # PARSER-HELD (#4498): `checks/step3-contract.ts` reads the `VAR=$(jq -r '.field …)` bindings below
 # out of Step 3's surface to derive the branch-2 pending predicate. It reaches them by following
-# SKILL.md's source line into this file, so keep the bindings at column 0 and keep that source line
-# inside the `## Step 3 — ` section.
+# SKILL.md's INVOCATION line into this file, so keep the bindings at column 0 and keep that
+# invocation inside the `## Step 3 — ` section. (`sourcedScriptNames` learned the ADR-0232
+# literal-path form alongside the old `$SHIPIT_SCRIPTS/` one, so the follow still resolves.)
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN — a process inherits no functions (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
+
+REPO="${REPO:-${1:?step3-rollup-bindings.sh: REPO unset and no \$1 — refusing to read CI in an unnamed repo}}"
+PR="${PR:-${2:?step3-rollup-bindings.sh: PR unset and no \$2 — refusing to read CI on an unnamed PR}}"
 
 CHECKS="${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli checks"
 
@@ -36,7 +49,9 @@ read_head_ci() {
 CI_JSON="$(read_head_ci)" || {
   disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: this stop does not enqueue — park nothing
   gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — head CI **unreadable** (the check-runs read returned no interpretable state) — **not enqueued**. An unreadable head is not a green head; re-dispatch ship-it once the API is answering — idempotent (#3999)." >/dev/null
-  echo "refused — head CI unreadable (typed unknown) — not enqueued"; exit 0
+  echo "refused — head CI unreadable (typed unknown) — not enqueued"
+  printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"   # the ledger must name a decline that left the intent armed
+  exit 0
 }
 
 # The aggregate `.conclusion` is deliberately NOT bound here: it is a colour in which red wins over
@@ -47,3 +62,12 @@ WEDGED=$(jq -r   '.wedged  | join(", ")' <<<"$CI_JSON")   # queued, never starte
 # The known-informational carve-out, applied to the failing set (names below).
 GATING_RED=$(jq -r '[.failing[]
   | select(. != "deploy (web)" and (startswith("cleanup (web,") | not))] | join(", ")' <<<"$CI_JSON")
+
+# An EMPTY $RUNNING / $WEDGED / $GATING_RED is the ordinary all-green answer, so each line is printed
+# unconditionally — an absent line would be indistinguishable from a decline (rule 4 / §ZS).
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'CONTEXTS=%s\n' "$CONTEXTS"
+  printf 'RUNNING=%s\n' "$RUNNING"
+  printf 'WEDGED=%s\n' "$WEDGED"
+  printf 'GATING_RED=%s\n' "$GATING_RED"
+fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-assert-bundle.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-assert-bundle.sh
@@ -5,15 +5,48 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3.5 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-assert-bundle.sh \
+#                   <REPO> <PR> <ART_FETCH_STATUS> <RUN_ID> <ART_ID> <MANIFEST> <HEAD_SHA> [<ART_FETCH_ERR>]
+#              The six inputs after <PR> are the values `step3_5-fetch-artifact.sh` printed. They are
+#              POSITIONAL rather than inherited because the fetch and the assertion are now separate
+#              processes: an executed child sees none of its parent's shell, and an input silently
+#              defaulting to empty here would read as "genuine absence" — assertion 1b — for a bundle
+#              that was fetched fine. So every one of them refuses when absent (§ZS: an unread input
+#              is UNKNOWN, never a finding). The one exception is <ART_FETCH_ERR>, which is the
+#              transient CAUSE TEXT and is legitimately empty.
+#              stdout ⇒ nothing at all when all four assertions hold — guard 2 cleared; otherwise the
+#              ONE `unverified (…)` / `run-evidence checks failed (…)` refusal line plus
+#              `INTENT_UNCLEARED=<0|1>`. Each refusal is a successful decline and exits 0, as the
+#              fenced block did, so read the LINE, not the status.
+#   SOURCED:   no in-script consumer today; a caller that has all six in its own shell may still
+#              source it, and its values win over the positionals.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN — a process inherits no functions (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
+
+REPO="${REPO:-${1:?step3_5-assert-bundle.sh: REPO unset and no \$1 — refusing to assert a bundle in an unnamed repo}}"
+PR="${PR:-${2:?step3_5-assert-bundle.sh: PR unset and no \$2 — refusing to assert a bundle for an unnamed PR}}"
+ART_FETCH_STATUS="${ART_FETCH_STATUS:-${3:?step3_5-assert-bundle.sh: ART_FETCH_STATUS unset and no \$3 — an unknown fetch outcome is UNKNOWN, never 'absent'}}"
+RUN_ID="${RUN_ID-${4-}}"     # legitimately EMPTY on a genuine absence — assertion 1b's own input
+ART_ID="${ART_ID-${5-}}"     # likewise
+MANIFEST="${MANIFEST:-${6:?step3_5-assert-bundle.sh: MANIFEST unset and no \$6 — refusing to assert against an unnamed manifest path}}"
+HEAD_SHA="${HEAD_SHA:-${7:?step3_5-assert-bundle.sh: HEAD_SHA unset and no \$7 — with no head to compare, assertion 3 could not tell a stale bundle from a current one}}"
+ART_FETCH_ERR="${ART_FETCH_ERR-${8-}}"   # the transient cause text; legitimately empty
 
 # Each refusal below (transient, absent, schema, stale, checks-failed) is a stop path, so each
 # clears the merge intent before it reports (guard 6 / ADR 0198) — one wrapper, not N hand-copied disarms.
-refuse_ship() { disarm_intent refuse || INTENT_UNCLEARED=1; echo "$1"; exit 0; }
+refuse_ship() {
+  disarm_intent refuse || INTENT_UNCLEARED=1
+  echo "$1"
+  if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
+  exit 0
+}
 
 # 1a. TRANSIENT / upstream-unavailable (the #3716 fix — this MUST precede 1b). A read 5xx'd, or the
 #     listed artifact would not download as a valid zip after retry+backoff — a TRANSPORT failure,

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-fetch-artifact.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-fetch-artifact.sh
@@ -5,11 +5,26 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3.5 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-fetch-artifact.sh <REPO> <PR>
+#              stdout ⇒ six lines — `HEAD_SHA=`, `RUN_ID=`, `ART_ID=`, `MANIFEST=`,
+#              `ART_FETCH_STATUS=`, `ART_FETCH_ERR=` — the values the sourced form left in the
+#              caller's shell, and exactly the inputs `step3_5-assert-bundle.sh` now takes as
+#              arguments. `RUN_ID` / `ART_ID` are legitimately EMPTY on a genuinely absent bundle,
+#              which is assertion 1b's input, so each line is printed unconditionally: an absent line
+#              would be indistinguishable from a fetch that never ran (rule 4 / §ZS). The BUNDLE
+#              itself stays on disk under the per-run `mktemp -d` that `MANIFEST=` points into — the
+#              one piece of cross-step state that is a FILE, so a process boundary does not lose it.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479). It also must not delete $BUNDLE_DIR:
+# the next step reads the manifest out of it.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+REPO="${REPO:-${1:?step3_5-fetch-artifact.sh: REPO unset and no \$1 — refusing to fetch evidence from an unnamed repo}}"
+PR="${PR:-${2:?step3_5-fetch-artifact.sh: PR unset and no \$2 — refusing to fetch evidence for an unnamed PR}}"
 
 HEAD_SHA=$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')
 
@@ -71,14 +86,17 @@ ART_FETCH_STATUS=absent
 # the run-evidence workflow run for THIS exact head SHA (not a stale earlier push)
 RUN_ID=$(gh_read_retry "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
   '[.workflow_runs[] | select(.name=="run-evidence")] | sort_by(.created_at) | last | .id // empty')
-[ $? -ne 0 ] && ART_FETCH_STATUS=transient
+# `if … fi` bodies below (rule 4): the ORDINARY case is a read that SUCCEEDED, which makes
+# `[ $? -ne 0 ]` false — as an `&&` body that failing test would be the last command executed on the
+# clean path and would leak a 1 into this script's status. `$?` is still read first, unchanged.
+if [ $? -ne 0 ]; then ART_FETCH_STATUS=transient; fi
 
 # the run-evidence artifact id (retry-aware — a 5xx here is UNKNOWN, not an absent artifact)
 ART_ID=""
 if [ "$ART_FETCH_STATUS" != transient ] && [ -n "$RUN_ID" ]; then
   ART_ID=$(gh_read_retry "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
     '.artifacts[] | select(.name=="run-evidence") | .id')
-  [ $? -ne 0 ] && ART_FETCH_STATUS=transient
+  if [ $? -ne 0 ]; then ART_FETCH_STATUS=transient; fi   # `if … fi`, same rule-4 reason as above
 fi
 
 # per-run bundle dir (mktemp -d), NOT a fixed /tmp/ship-it-bundle — the §SP per-run scratchpad
@@ -98,4 +116,13 @@ if [ "$ART_FETCH_STATUS" != transient ] && [ -n "$RUN_ID" ] && [ -n "$ART_ID" ];
   else
     ART_FETCH_STATUS=transient        # a listed artifact that will not download as a valid zip = UNKNOWN
   fi
+fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'HEAD_SHA=%s\n' "$HEAD_SHA"
+  printf 'RUN_ID=%s\n' "$RUN_ID"
+  printf 'ART_ID=%s\n' "$ART_ID"
+  printf 'MANIFEST=%s\n' "$MANIFEST"
+  printf 'ART_FETCH_STATUS=%s\n' "$ART_FETCH_STATUS"
+  printf 'ART_FETCH_ERR=%s\n' "$ART_FETCH_ERR"
 fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-producer-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-producer-preflight.sh
@@ -5,11 +5,19 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3.5 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_5-producer-preflight.sh <REPO>
+#              stdout ⇒ `HAS_PRODUCER=<n>`, plus the `guard 2 N/A …` line when the count is 0. The
+#              NUMBER is the answer — a `0` here means guard 2 degrades to checks-green, and it is
+#              reached only on a CONFIRMED-empty lookup, so it can never be an unread one.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+REPO="${REPO:-${1:?step3_5-producer-preflight.sh: REPO unset and no \$1 — refusing to probe an unnamed repo}}"
 
 # Does THIS repo produce run-evidence at all? (a workflow named "run-evidence" defined on the
 # default branch). Absent → foreign repo → guard 2 N/A, gated on Step 3. Present → strict path.
@@ -23,9 +31,14 @@
 # and the `-eq 0` test). per_page=100 fits any realistic repo's workflow set in one page.
 HAS_PRODUCER=$(gh api "repos/$REPO/actions/workflows?per_page=100" \
   --jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null)
-[ -z "$HAS_PRODUCER" ] && HAS_PRODUCER=1   # lookup failed (empty) → can't confirm absence → strict
+# `if … fi`: with a successful lookup the `[ -z … ]` test is FALSE, and an `&& HAS_PRODUCER=1` would
+# make that failing test the last command before the branch below — rule 4 of
+# `.patterns/skill-script-shell-shape.md` § The dual-mode shape. The substitution is unchanged.
+if [ -z "$HAS_PRODUCER" ]; then HAS_PRODUCER=1; fi   # lookup failed (empty) → can't confirm absence → strict
 if [ "$HAS_PRODUCER" -eq 0 ]; then
   echo "guard 2 N/A (no run-evidence producer in this repo) — gated on checks (Step 3)"
   # Degraded: guard 2 clears here. Skip the bundle fetch + the four assertions below and
   # proceed to Step 4 on the strength of Step 2 (PASS) + Step 3 (gating checks green).
 fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'HAS_PRODUCER=%s\n' "$HAS_PRODUCER"; fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_6-threads-read.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_6-threads-read.sh
@@ -5,12 +5,24 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3.6 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
-. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_6-threads-read.sh <REPO> <PR>
+#              stdout ⇒ one compact JSON object per UNRESOLVED thread (`{id, path, line, author,
+#              class, body}`). ZERO objects at exit 0 is the ordinary clean answer — a PR with no
+#              unresolved threads — and it is distinguishable from a failed read because THAT prints
+#              its two `STOP:` / refusal lines and exits 1. Read the status first (rule 4 / §ZS).
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
 
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN — a process inherits no functions (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
+
+REPO="${REPO:-${1:?step3_6-threads-read.sh: REPO unset and no \$1 — refusing to read threads in an unnamed repo}}"
+PR="${PR:-${2:?step3_6-threads-read.sh: PR unset and no \$2 — refusing to read threads on an unnamed PR}}"
 ORG="${REPO%%/*}"; NAME="${REPO#*/}"
 # The ONE GraphQL read in ship-it (ADR 0158): REST exposes no isResolved. Read every thread's
 # resolution state, its first author's login AND __typename (the ADR-0224 class), and the text the
@@ -48,6 +60,7 @@ if [ $? -ne 0 ] || [ -z "$THREADS" ]; then
   disarm_intent refuse || INTENT_UNCLEARED=1
   echo "STOP: review-thread read UNREADABLE or non-conforming — author class is UNKNOWN for every thread, and UNKNOWN is human (ADR 0224 rule 3)."
   echo "unresolved review threads unreadable (author class UNKNOWN ⇒ human) — refusing to enqueue"
+  if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
   exit 1
 fi
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_7-leak-scan.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_7-leak-scan.sh
@@ -5,19 +5,32 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3.7 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3_7-leak-scan.sh <REPO> <PR>
+#              stdout ⇒ `LEAK_SCAN=clean` when guard 4 clears — the positive token, because this
+#              guard's clean answer is otherwise SILENCE and silence is also what a run that never
+#              happened looks like (§ZS). A leak, or an unresolved shim, names itself on stderr,
+#              prints `INTENT_UNCLEARED=<0|1>`, and exits 1. The EXIT STATUS is the gate.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479), which would silently disarm guard 4.
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN — a process inherits no functions (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+REPO="${REPO:-${1:?step3_7-leak-scan.sh: REPO unset and no \$1 — refusing to scan an unnamed repo}}"
+PR="${PR:-${2:?step3_7-leak-scan.sh: PR unset and no \$2 — refusing to scan an unnamed PR}}"
 # …and prove it resolved BEFORE the guard runs. Without this the `||` below fires on a 127 too,
 # and reports "a landed comment carries a machine-local path" for a CLI that never ran (#3314).
 [ -x "$PCLI" ] || {
   disarm_intent refuse || INTENT_UNCLEARED=1
   echo "ship-it: REFUSING to enqueue #$PR — leak-guard is UNRESOLVED at '$PCLI', so the leak scan has NO result (§CLI: could-not-run is UNKNOWN, never clean)." >&2
+  if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
   exit 1
 }
 # guard 4 — refuse the enqueue on ANY live leak in a landed comment (exit 2 = a leak; ADR 0092 fail-closed)
@@ -28,5 +41,9 @@ PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-
   echo '  1. redact each flagged comment body — `$PCLI redact-leaks` (the merged #3021 tool) preserves evidential shape;' >&2
   echo '  2. re-post the redacted body (a verdict via `$PCLI verdict post`, which now self-verifies the landed comment, #3019);' >&2
   echo "  3. the underlying issue is a bypassed emit path — route the PR back to repair so the leaking comment is re-emitted through the mandated choke point." >&2
+  if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
   exit 1
 }
+# The positive clean token — guard 4's ordinary answer is otherwise no output at all, and §SHARED's
+# reader must never have to infer "clean" from an absence (rule 4 / §ZS).
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then echo "LEAK_SCAN=clean"; fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh
@@ -5,11 +5,27 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 3z fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh \
+#                   <REPO> <PR> <HEAD_SHA>
+#              stdout ⇒ one terminal line — `nudged (close→reopen) …` or `unverified (no runs fired
+#              …)` — plus `INTENT_UNCLEARED=<0|1>`. Both are successful declines and exit 0, exactly
+#              as the fenced block did; read the terminal word, not the status.
+#              `<HEAD_SHA>` is the head `step3-empty-checkset-probe.sh` printed — the nudge counts
+#              `reopened` events since THAT commit, so a guessed head would mis-count them.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN — a process inherits no functions (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
+
+REPO="${REPO:-${1:?step3z-dropped-trigger.sh: REPO unset and no \$1 — refusing to nudge an unnamed repo}}"
+PR="${PR:-${2:?step3z-dropped-trigger.sh: PR unset and no \$2 — refusing to nudge an unnamed PR}}"
+HEAD_SHA="${HEAD_SHA:-${3:?step3z-dropped-trigger.sh: HEAD_SHA unset and no \$3 — refusing to count nudges against an unnamed head}}"
 
 # Have we ALREADY nudged this exact head? A nudge leaves a `reopened` event; count the ones
 # that landed AFTER this head SHA was pushed (its committer date is the proxy for "since this
@@ -25,7 +41,9 @@ if [ "${NUDGES:-0}" -ge 1 ]; then
   # Nudge exhausted → refuse and hand to a human, but leave a durable PR-visible signal (#1928):
   # never a silent stop even on this dead-end path.
   gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: unverified (no runs fired — nudge exhausted, producer may be stuck) — **not enqueued**. This head was already close→reopened once and CI still fired zero runs; handing to a human (#1928)." >/dev/null
-  echo "unverified (no runs fired — nudge exhausted, producer may be stuck)"; exit 0   # refuse, hand to human
+  echo "unverified (no runs fired — nudge exhausted, producer may be stuck)"   # refuse, hand to human
+  if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
+  exit 0
 fi
 
 # First (and only) nudge for this head: close then reopen over REST (never `gh pr close/reopen`
@@ -35,4 +53,6 @@ gh api -X PATCH "repos/$REPO/pulls/$PR" -f state=closed >/dev/null
 gh api -X PATCH "repos/$REPO/pulls/$PR" -f state=open   >/dev/null
 # Durable, PR-visible outcome so the park is observable (#1928): a re-dispatch after CI settles resumes the ship.
 gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: nudged (close→reopen) — CI re-triggered, **not enqueued** yet. The head SHA had zero workflow runs (dropped trigger); ship-it close→reopened it once to re-emit the trigger. Re-dispatch ship-it once CI settles — idempotent (#1928)." >/dev/null
-echo "nudged (close→reopen) — CI re-triggered, not yet merge-ready"; exit 0   # stop; re-dispatch after CI settles resumes the ship
+echo "nudged (close→reopen) — CI re-triggered, not yet merge-ready"   # stop; re-dispatch after CI settles resumes the ship
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
+exit 0

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5-confirm-enqueued.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5-confirm-enqueued.sh
@@ -5,14 +5,23 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 5 fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5-confirm-enqueued.sh <REPO> <PR>
+#              stdout ⇒ the two REST/porcelain state objects, then `QUEUE_STATE=<merged|queued|
+#              pending|ejected>`. That last line is the answer; an unresolved shim prints no
+#              `QUEUE_STATE=` line at all, names itself on stderr, and exits 1 — could-not-run is
+#              UNKNOWN, never a queue outcome.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+REPO="${REPO:-${1:?step5-confirm-enqueued.sh: REPO unset and no \$1 — refusing to confirm an enqueue in an unnamed repo}}"
+PR="${PR:-${2:?step5-confirm-enqueued.sh: PR unset and no \$2 — refusing to confirm an enqueue for an unnamed PR}}"
 # The QUEUED signal is the success condition. `already queued to merge` from Step 4's --auto
 # and/or an `enqueued`/QUEUED mergeStateStatus confirm it — NOT a non-null auto_merge, which
 # under the queue stays null on a clean enqueue (ADR 0132 §3).
@@ -24,3 +33,4 @@ gh pr view $PR --json mergeStateStatus --jq '{mergeStateStatus}'
 # branch on it (§CLI: could-not-run is UNKNOWN, never a queue outcome; #3314).
 [ -x "$PCLI" ] || { echo "ship-it: merge-queue-classify is UNRESOLVED at '$PCLI' — queue membership is UNKNOWN, not confirmed." >&2; exit 1; }
 QUEUE_STATE=$("$PCLI" merge-queue-classify classify --pr "$PR" --repo "$REPO")
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'QUEUE_STATE=%s\n' "$QUEUE_STATE"; fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh
@@ -6,19 +6,32 @@
 # #4448/#4498). A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is
 # phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the ledger still sees
-# $MERGE_OUTCOME / $MERGE_DISPOSITION / $RECONCILE_HORIZON / $INTENT_UNCLEARED.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh <REPO> <PR>
+#              stdout ⇒ `MERGE_OUTCOME=<merged|queued|pending|ejected>`, `RECONCILE_HORIZON=<secs>`,
+#              `INTENT_UNCLEARED=<0|1>`, and `MERGE_DISPOSITION=<text>` — the four values the ledger
+#              renders, which the sourced form left in the caller's shell. `MERGE_DISPOSITION` is
+#              printed LAST because it is the only multi-word one, so a reader can take the rest of
+#              the line verbatim. An unresolved shim prints NONE of them and exits 1: a reconcile
+#              that never ran is UNKNOWN, not `pending`.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
 #
 # PARSER-HELD (#4498): `merge-queue-classify/step55-contract.ts` reads the RECONCILE_TRIES /
 # RECONCILE_SLEEP defaults, the between-polls sleep guard, and the MERGE_DISPOSITION case arms out
 # of Step 5.5's surface. It reaches them by following SKILL.md's source line into this file, so keep
-# those bindings at column 0 and keep that source line inside the `### Step 5.5 — ` section.
+# those bindings at column 0 and keep that INVOCATION inside the `### Step 5.5 — ` section.
+# (`sourcedScriptNames` learned the ADR-0232 literal-path form alongside the old `$SHIPIT_SCRIPTS/`
+# one, so the follow still resolves.)
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+# `disarm_intent` (guard 6 / ADR 0198), sourced IN-CHAIN — a process inherits no functions (ADR 0232).
+# shellcheck source=disarm-intent.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/." && pwd)/disarm-intent.sh"
 
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+REPO="${REPO:-${1:?step5_5-reconcile.sh: REPO unset and no \$1 — refusing to reconcile in an unnamed repo}}"
+PR="${PR:-${2:?step5_5-reconcile.sh: PR unset and no \$2 — refusing to reconcile an unnamed PR}}"
 # …and prove it resolved before polling. An unresolved CLI prints nothing, so every poll would
 # read as neither `merged` nor `ejected`, the budget would exhaust, and the run would report a
 # well-formed `pending` for a classifier that never ran — a could-not-run posing as an answer
@@ -94,6 +107,18 @@ if [ "$MERGE_OUTCOME" = ejected ]; then
   disarm_intent ejected || INTENT_UNCLEARED=1
 else
   INTENT_ACTION=$("$PCLI" merge-intent disarm --pr "$PR" --repo "$REPO" --site post-enqueue) || INTENT_UNCLEARED=1
-  [ "$INTENT_ACTION" = disarmed ] && \
+  # `if … fi`: the ORDINARY outcome is an intent that was NOT a parked arm — i.e. this test being
+  # FALSE — and as the branch's last command that failing test became the script's exit status, so
+  # every clean reconcile would report itself UNKNOWN under §SHARED's read-the-status-first rule
+  # (`.patterns/skill-script-shell-shape.md` § The dual-mode shape rule 4). The predicate is unchanged.
+  if [ "$INTENT_ACTION" = disarmed ]; then
     echo "refused — the enqueue did not take effect at this head; the parked intent was cleared. Re-dispatch ship-it to re-assert the gates and enqueue (idempotent)."
+  fi
+fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'MERGE_OUTCOME=%s\n' "$MERGE_OUTCOME"
+  printf 'RECONCILE_HORIZON=%s\n' "$RECONCILE_HORIZON"
+  printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"
+  printf 'MERGE_DISPOSITION=%s\n' "$MERGE_DISPOSITION"
 fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5b-release-queue.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5b-release-queue.sh
@@ -5,11 +5,28 @@
 # Extracted VERBATIM from ship-it/SKILL.md's Step 5b fenced block (epic #4435 phase 1, #4448).
 # A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
 #
-# SOURCED, never executed. The fenced block it replaces ran inline in the agent's shell, so this
-# file deliberately sets NO shell options — several guards here depend on `pipefail` being OFF —
-# and leaves its variables and functions in the sourcing shell, which is how the step's later
-# blocks still see them.
+# DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
+#   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5b-release-queue.sh \
+#                   <REPO> <PR> [<ISSUE>]
+#              stdout ⇒ one line, `RELEASE_QUEUE=queued (awaiting human flip)` or
+#              `RELEASE_QUEUE=n/a (not a dark ship)` — the ledger value the sourced form left in the
+#              caller's shell. <ISSUE> is the linked issue Step 1 resolved; an ABSENT one keeps the
+#              fenced block's own behaviour — no linked issue means nothing to queue, so the step
+#              no-ops and reports `n/a`.
+#   SOURCED:   no in-script consumer today; the edge stays open for one.
+#
+# `pipefail` (executed mode) changes what a PIPELINE's status is, and two detector captures below
+# read one, so each is re-derived as capture-then-match. See their comments — the predicates
+# themselves are byte-unchanged (ADR 0228/0229).
+# No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
+# laundering a `set -u` abort into exit 0 (#4476, class #4479).
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode only (ADR 0232)
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+REPO="${REPO:-${1:?step5b-release-queue.sh: REPO unset and no \$1 — refusing to queue a release in an unnamed repo}}"
+PR="${PR:-${2:?step5b-release-queue.sh: PR unset and no \$2 — refusing to read the dark-ship signals off an unnamed PR}}"
+ISSUE="${ISSUE-${3-}}"   # legitimately empty: no linked issue ⇒ nothing to queue ⇒ the `n/a` no-op
 
 RELEASE_QUEUE="n/a (not a dark ship)"   # default: the no-op state
 
@@ -22,8 +39,14 @@ if [ -n "$ISSUE" ] && gh api "repos/$REPO/contents/product-development-cycle.md"
   #     `+` patch lines are additions; an added `FlagshipFlag(` factory call or a `defaultVariation:`
   #     flag-config line is a real default-off flag THIS PR introduced (write-code Step 4b mints it,
   #     review-code Step 3b verifies it).
-  FLAG_IN_DIFF=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-    --jq '.[] | select(.filename | test("features/flagship/resources\\.ts$")) | .patch // ""' \
+  #     CAPTURE-THEN-MATCH: the detector's decision is the GREPS' verdict, and only theirs. Left as
+  #     one pipeline under executed mode's `pipefail`, a non-zero `gh` would fold into the status and
+  #     answer `no` — a transport failure posing as "this PR ships no flag", which silently skips the
+  #     release queue. Capturing the read first restores the original operand exactly; the two greps
+  #     and their patterns are untouched.
+  FLAG_PATCHES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+    --jq '.[] | select(.filename | test("features/flagship/resources\\.ts$")) | .patch // ""')
+  FLAG_IN_DIFF=$(printf '%s\n' "$FLAG_PATCHES" \
     | grep -E '^\+' | grep -Eq 'FlagshipFlag\(|defaultVariation:' && echo yes || echo no)
 
   # (b) the PR BODY declares the dark-ship flag key explicitly (a `Flag:`/`Flag key:` line naming a
@@ -32,7 +55,10 @@ if [ -n "$ISSUE" ] && gh api "repos/$REPO/contents/product-development-cycle.md"
   #     ATX header (`#{1,6}`, so `## Flag:` / `### Flag key:` match, #1293), and `**` bold — while the
   #     key grammar `[a-z0-9]+(-[a-z0-9]+)+` is untouched, so prose containing "flag" and a non-kebab
   #     key still miss.
-  FLAG_IN_BODY=$(gh api repos/$REPO/pulls/$PR --jq '.body // ""' \
+  #     Same capture-then-match as (a), same reason: the grep's verdict is the detector, `gh`'s
+  #     status is not part of it.
+  BODY_RAW=$(gh api repos/$REPO/pulls/$PR --jq '.body // ""')
+  FLAG_IN_BODY=$(printf '%s\n' "$BODY_RAW" \
     | grep -Eiq '^[[:space:]]*(#{1,6}[[:space:]]*)?\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+' && echo yes || echo no)
 
   # (c) the PR BODY names an ALREADY-DECLARED flag key in a GATING-DECLARATION line (the reused-flag
@@ -89,7 +115,7 @@ if [ -n "$ISSUE" ] && gh api "repos/$REPO/contents/product-development-cycle.md"
       [ -z "$K" ] && continue
       # whole-token match: the declared key bounded by non-[a-z0-9-] on each side, so a longer key
       # containing this one as a substring (e.g. phoenix-bildirim-x) is NOT matched by phoenix-bildirim
-      printf '%s' "$GATING_PROSE" | grep -Eq "(^|[^a-z0-9-])$K([^a-z0-9-]|\$)" && { FLAG_IN_PROSE=yes; break; }
+      if printf '%s' "$GATING_PROSE" | grep -Eq "(^|[^a-z0-9-])$K([^a-z0-9-]|\$)"; then FLAG_IN_PROSE=yes; break; fi
     done <<EOF
 $DECLARED_KEYS
 EOF
@@ -102,3 +128,5 @@ EOF
   fi
   # no signal ⇒ the PR shipped ungated (the inherited-stamp false positive #1257 closes) ⇒ no-op, no label
 fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'RELEASE_QUEUE=%s\n' "$RELEASE_QUEUE"; fi

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-chain-resolves.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-chain-resolves.sh
@@ -94,8 +94,15 @@ sourced_by() {
 # functions in the agent's shell by the time a later step runs. This is what makes
 # `disarm_intent` — defined in disarm-intent.sh, sourced in SKILL.md's preamble — legitimately
 # reachable from every step without any step sourcing it.
-skill_md_line_of() {   # $1 = script basename; prints the line number of its SKILL.md source, or 0
-	grep -n "SHIPIT_SCRIPTS/$1\"" "$SKILL_MD" 2>/dev/null | head -n1 | cut -d: -f1
+skill_md_line_of() {   # $1 = script basename; prints the line number of its SKILL.md invocation, or 0
+	# ADR 0232 replaced `. "$SHIPIT_SCRIPTS/<name>.sh"` with the literal-path executed form, so the
+	# chain order is now read off `…/ship-it/scripts/<name>.sh`. Matching only the old form would make
+	# every `mine` resolve to 0, the predecessor loop would `continue` for every script, and the
+	# reachable set would silently lose everything SKILL.md's order used to contribute — the audit
+	# would then report BAD for calls that resolve fine, or (worse, in the other direction) stop
+	# covering the ordering property entirely. Both spellings are matched so the check survives a
+	# corpus that converts skill by skill.
+	grep -nE "(SHIPIT_SCRIPTS/|/ship-it/scripts/)$1(\"|\$|[[:space:]])" "$SKILL_MD" 2>/dev/null | head -n1 | cut -d: -f1
 }
 
 for s in $SCRIPTS; do

--- a/packages/pipeline-cli/src/skill-shell-surface.ts
+++ b/packages/pipeline-cli/src/skill-shell-surface.ts
@@ -48,13 +48,23 @@ export interface ResolvedSection {
 export const ZERO_SCOPE: ResolvedSection = {section: "", scanned: [], unresolved: []};
 
 /**
- * The `scripts/*.sh` a stretch of skill text sources (`. "$<SKILL>_SCRIPTS/<name>.sh"`), in first
- * appearance order, deduplicated. Deliberately the SAME matcher `adoption-lint`'s claim pins use
- * (#4449) — three consumers answering "which script does this text source?" three ways would be its
- * own defect.
+ * The `scripts/*.sh` a stretch of skill text reaches, in first appearance order, deduplicated.
+ * Deliberately the SAME matcher `adoption-lint`'s claim pins use (#4449) — three consumers answering
+ * "which script does this text run?" three ways would be its own defect.
+ *
+ * TWO forms, because ADR 0232 replaced one with the other and the corpus converts skill by skill:
+ * the original `. "$<SKILL>_SCRIPTS/<name>.sh"`, and the literal-path `bash
+ * ./claude-plugins/<plugin>/skills/<skill>/scripts/<name>.sh` an isolated agent must use instead.
+ * Recognizing only the first is not a lint miss but a SILENT NARROWING: a converted section resolves
+ * to the markdown alone, and every constant this module exists to follow into the script — Step 3's
+ * rollup bindings, Step 5.5's reconcile defaults — reads back absent. The consumers turn absent into
+ * their own fail-closed constant, so the failure surfaces as a red guard rather than a wrong answer;
+ * matching both forms is what keeps it from surfacing at all.
  */
 export const sourcedScriptNames = (text: string): ReadonlyArray<string> => [
-	...new Set([...text.matchAll(/_SCRIPTS\}?\/([\w.-]+\.sh)/g)].flatMap((m) => m[1] ?? [])),
+	...new Set(
+		[...text.matchAll(/(?:_SCRIPTS\}?|\/scripts)\/([\w.-]+\.sh)/g)].flatMap((m) => m[1] ?? []),
+	),
 ];
 
 /** Resolve one heading-sliced section into its full shell surface. */

--- a/packages/pipeline-cli/src/skill-shell-surface.unit.test.ts
+++ b/packages/pipeline-cli/src/skill-shell-surface.unit.test.ts
@@ -32,8 +32,29 @@ describe("sourcedScriptNames", () => {
 		]);
 	});
 
+	it("names every ADR-0232 literal-path `bash ./…/scripts/<file>.sh` invocation too", () => {
+		// The whole point of matching this form: a converted section that resolved to the markdown
+		// alone would read back with ZERO bindings, and every constant the parsers follow into the
+		// script would look absent rather than unfollowed (#4572).
+		const text = [
+			"bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh $REPO $PR",
+			'bash "./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step5_5-reconcile.sh"',
+			"bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3-rollup-bindings.sh $REPO $PR",
+		].join("\n");
+		assert.deepStrictEqual(sourcedScriptNames(text), [
+			"step3-rollup-bindings.sh",
+			"step5_5-reconcile.sh",
+		]);
+	});
+
 	it("names nothing for text that sources nothing — the un-extracted corpus", () => {
 		assert.deepStrictEqual(sourcedScriptNames(`RECONCILE_TRIES=${brace("X:-16")}\n`), []);
+	});
+
+	// The falsification: drop the `/scripts` alternative from the matcher and this reds. Without it
+	// the literal-path case above would return [] and the parsers would silently narrow.
+	it("does not match a bare `.sh` mention that is not a scripts/ path", () => {
+		assert.deepStrictEqual(sourcedScriptNames("see verify-chain-resolves.sh for the proof"), []);
 	});
 });
 


### PR DESCRIPTION
ship-it is the pipeline's single merge authority, and until now every one of its steps was invoked by
sourcing a script — a form the worktree harness refuses outright, so every shipper tonight had to
improvise its way around eighteen refusals. This PR converts ship-it to the convention ADR 0232
settled: you run each step by literal path and read its answer off stdout. Nothing about what a step
decides changes; what changes is how you invoke it and how its answer reaches you.

Fixes #4572

## What changed

- **18 scripts + `verify-chain-resolves.sh`** gain the dual-mode shape #4590 established: the existing
  body and function definitions are byte-untouched, `set -uo pipefail` fires in executed mode only
  (`[ "${BASH_SOURCE[0]}" = "$0" ]`), and an entry relays what the body already computed. No cleanup
  `EXIT` trap anywhere.
- **17 sourcing fences + the `$SHIPIT_SCRIPTS` preamble** in `SKILL.md` become
  `bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/<name>.sh <args>`, each with prose
  naming the lines to read off stdout and whether the exit status or the terminal word is the answer.
  Fence arguments are angle-bracket placeholders, so no fence keeps a variable it does not bind.
- **Cross-step state** moves to stdout and back in as an argument: the run PR, the §CP seam, the
  verified head, the rollup bindings, the run-evidence handles, and `INTENT_UNCLEARED`.
- **`sourcedScriptNames`** (`packages/pipeline-cli/src/skill-shell-surface.ts`) learns the literal-path
  form alongside `$<SKILL>_SCRIPTS/`. This is not optional polish: Step 3's rollup bindings and Step
  5.5's reconcile defaults are parser-held *through this matcher*, and recognizing only the retired
  spelling would have left both parses reading the markdown alone — a silent narrowing that surfaces
  as a red guard rather than a wrong answer, but surfaces late.

## Per-script note: how each guard that depended on `pipefail`-off or caller-shell state still refuses

`step2-verdict-gate.sh` is the exemplar `.patterns/skill-script-shell-shape.md` names, so `pipefail`
was not simply switched on.

| script | what it depended on | how the executed form reproduces it |
|---|---|---|
| `step2-verdict-gate.sh` | `PROBE_RC` had to be **class-probe's own** status (its exit 4 is a refusal, not a classification). Under `pipefail` a `gh` failure would fold in and report itself as a probe refusal. | Capture-then-match: `PROBE_IN="$(gh api …)"` then `printf … \| class-probe`. `printf` cannot fail, so the pipeline's status **is** the probe's — the original operand exactly. `gh`'s status stays unread here, as the pipe left it unread, and its stdout still reaches the probe byte-for-byte. |
| `step2-verdict-gate.sh` | `$CP_FLAG` from the caller's shell | third argument; a sourced caller's own `$CP_FLAG` still wins, so `verify-chain-resolves.sh` check 3 exercises the same seam. Absent ⇒ empty ⇒ the stricter non-§CP branch. |
| `step0-cp-approval.sh` | wrote `CP_FLAG=--cp` into the agent's shell | the discharge branch **prints** `CP_FLAG=--cp`; it is still that branch's only source. No line read ⇒ nothing passed ⇒ the stricter branch. |
| `step0-classify.sh` | `echo \| grep -q && echo <class>` as the script's last commands | `if … fi` bodies. The predicates are byte-identical; without this a non-UI diff left the failing `grep` as the last command and the whole classification returned 1. Falsified: with `&& echo` restored, a docs-only diff exits **1**; with `if … fi`, **0**. |
| `step0-classify.sh` | `\| grep '^\.decisions/…' \| while` | capture-then-loop with `\|\| true` + an `if … fi` body, so neither a no-match filter nor an empty loop can set the script's status (#4571 rule 4). |
| `step5b-release-queue.sh` | two `gh … \| grep … && echo yes \|\| echo no` detectors | each `gh` read is captured first. Under `pipefail` a non-zero `gh` would have folded in and answered `no` — a transport failure posing as "this PR ships no flag", silently skipping the release queue. |
| `step3-empty-checkset-probe.sh` | `[ -z "$NRUNS" ] && NRUNS=1` as the last commands | `if … fi`. The substitutions are unchanged; the successful-lookup case no longer returns 1. |
| `step3_5-producer-preflight.sh` | `[ -z "$HAS_PRODUCER" ] && HAS_PRODUCER=1` | `if … fi`, same reason. |
| `step3_5-fetch-artifact.sh` | `[ $? -ne 0 ] && ART_FETCH_STATUS=transient` ×2 | `if … fi`; `$?` is still read first, unchanged. |
| `step5_5-reconcile.sh` | `[ "$INTENT_ACTION" = disarmed ] && echo …` | `if … fi`. |
| `step3_5-assert-bundle.sh` | six values from `step3_5-fetch-artifact.sh`'s shell | positional arguments. Each refuses when absent, because a silently-empty input would read as assertion 1b's "genuine absence" for a bundle that fetched fine. `RUN_ID`/`ART_ID` are the deliberate exception — empty **is** 1b's input — and `ART_FETCH_ERR` is cause text. The bundle stays on disk under its per-run `mktemp -d`, so the file half of the state survives the process boundary untouched. |
| `step3-ci-settle-wait.sh` | `read_head_ci` + `$CURRENT_HEAD` from the chain | sources `step3-rollup-bindings.sh` in-chain for the function (a process inherits none) rather than carrying a second copy that could drift; `CURRENT_HEAD` is a required argument, because an empty one would make every head "unchanged" and re-open the TOCTOU window the guard closes. |
| nine step scripts | `disarm_intent` from the SKILL.md preamble | each sources `disarm-intent.sh` in-chain at column 0. Its `INTENT_UNCLEARED=0` becomes `${INTENT_UNCLEARED:-0}` so a second source cannot reset a 1 an earlier disarm recorded — the one behaviour change, and it is in the fail-closed direction. |
| every stop path | `INTENT_UNCLEARED` for the outcome line | printed as `INTENT_UNCLEARED=<0\|1>` at each terminus. |

## Verification

- **rc parity, sourced vs executed, on populated AND empty input, per entry** — a hermetic harness
  (stubbed `gh` + `pipeline-cli`) ran every script both ways in both modes: **19/19 OK, 0 mismatches**.
  Three scripts returned 1 on their clean answer *before* the `if … fi` fixes; all now return 0.
- **The check has teeth.** Reverting `step0-classify.sh`'s `has-ui` probe to `&& echo` makes a
  docs-only diff exit 1; restoring `if … fi` returns 0. The mutation reds.
- **A second, independent surface.** `checks/step3-contract` and `merge-queue-classify/step55-contract`
  parse the **live** `SKILL.md` from disk through `sourcedScriptNames` and follow it into the scripts;
  both suites pass, which is what proves the literal-path fences are still followed.
- `verify-chain-resolves.sh` PASS (18 scripts, 44 helper names; checks 1/2/3 green — the sourced Step-0
  chain and the §CP seam are unchanged). `validate-gate-path-drift.sh` OK, 34 checks, `UI_RE` and
  `UI_EXCLUDE_RE` byte-identical at column 0. `trap-status-guard check` clean over 20 files / 29 fences
  / 19 shell units. Both cycle validators rc=0. `shellcheck -x` clean, run **per file** (`xargs`
  flattens 1–125 into one value on BSD). `pnpm typecheck` and `pnpm lint:worktree` clean.

## Deviations

- **Class 1 (narrowed fix-shape) — `packages/pipeline-cli/src/skill-shell-surface.ts` is outside the
  issue's stated scope.** Said: scope is `skills/ship-it/**`. Did: also extended `sourcedScriptNames`
  + its unit test. Why: converting the fence without it leaves Step 3's and Step 5.5's parser-held
  constants resolving against the markdown alone. Disposition: no action needed — the change is
  additive (both spellings match) and carries a falsifying test.
- **Class 1 — `verify-chain-resolves.sh` was not in the issue's list of 18.** Said: 18 scripts. Did:
  also converted it and re-keyed `skill_md_line_of` onto both spellings. Why: it is in `ship-it/**`,
  runs in CI, and its chain-order read is by definition on the fence that moved. Disposition: no
  action needed.
- **Class 4 (a note left for the reviewer) — the `REPO=` fence keeps `${CLAUDE_PIPELINE_REPO:-$(gh …)}`.**
  Said: AC2 bans a fence that resolves *a path* through `${…:-…}`/`$(…)`. Did: left the repo-name
  resolution intact. Why: it resolves a repo NAME, not a path, and it is the ADR-0062 target-repo
  contract every skill pastes — the same reading the #4590 gate applied to the `PCLI=` preamble.
  Disposition: for the reviewer to judge; #4595 is the open lane that settles the assignment-form
  question programme-wide.
- **Class 6 (an incident during the build) — this run's edits first landed in the PRIMARY checkout.**
  Said: anchor every edit under `$WT`. Did: the first ~40 edits used primary-checkout absolute paths
  (the #3458 raw-write class, which no git guard covers), then I banked them, restored every touched
  primary file to its committed content, and re-landed the work in the worktree. Why it is disclosed:
  it is a real near-miss, and the reviewer should know the diff was assembled through a repair rather
  than authored in place. Disposition: verified — all 22 touched paths in the primary checkout now
  compare byte-identical to `32e66f24`, checked file by file.
- **Class 4 — one behaviour I could not verify against the real platform.**
  `step3-ci-settle-wait.sh` now sources `step3-rollup-bindings.sh`, which costs one extra
  `pipeline-cli checks read` at source time. Its refusal disposition on an unreadable head matches the
  poll's own first-pass disposition, but I exercised that only against a stub, never a live wedged PR.
  Disposition: for the reviewer to judge.
