### PR TITLE
refactor(skills): literal-path sweep across the remaining skill surfaces (ADR 0232) (#4575)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -28,7 +28,7 @@ rather than printing nothing, and an empty listing is only "nothing reserved" on
    - **In-flight set** — the `NNNN` **claimed by open ADR PRs**. An open PR that adds a `.decisions/NNNN-*.md` file *is* the reservation for `NNNN` (no separate artifact, exactly as ADR 0059's `status:planning` label *is* the epic lock — opening the PR reserves, merging/closing releases). Enumerate via **`gh api` REST, never GraphQL** (the org's Projects-classic integration breaks GraphQL):
      ```bash
      # every NNNN claimed by an open PR that ADDS a .decisions/NNNN-*.md file, one per line
-     "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/adr/scripts/claimed-numbers.sh" || exit 1
+     bash ./claude-plugins/kampus-pipeline/skills/adr/scripts/claimed-numbers.sh || exit 1
      ```
      (The script resolves `$REPO` itself, the same way write-code does.) **Fail closed** (ADR 0074, ADR 0059's fail-closed acquire): if the in-flight query errors it exits non-zero — **surface it and re-run**, and never silently fall back to the on-disk-only number. That stale-on-disk fall-back is the bug this step removes, so an empty listing is only "nothing reserved" on **exit 0**.
 
@@ -41,7 +41,9 @@ rather than printing nothing, and an empty listing is only "nothing reserved" on
    # OPTIONAL local render of the on-demand compact map — nothing to `git add` (no committed index).
    # The `bin/pipeline-cli` shim resolves the bin (in-repo, else installed, else pinned dlx reading
    # the ONE pin in hooks/pin.sh) — no version pinned here (#3653).
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" decisions-index compact
+   # §CLI — bind the shim by LITERAL assignment, run from the repo root.
+   PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
+   "$PCLI" decisions-index compact
    ```
    The published CLI operates on the local `.decisions/` filesystem (no GitHub target), so there is no `$REPO`/`$CLAUDE_PIPELINE_REPO` resolution here — it is purely the in-repo-vs-published invocation swap.
 6. **Record the ADR's vocabulary impact (required — a named term or an explicit "none").** An ADR is a primary *coining site*: it is where a concept most often enters the repo vocabulary — a new term, or a redefinition of an existing one (ADR 0126's "ambient discovery" was coined here and drifted silently). So before you tell the user the path, run the point-of-coining glossary catch defined in [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source). This is a **coining-time authoring hook, not the `review-code` gate** — it lives in this skill (prong (c) of ADR [0128](https://github.com/kamp-us/phoenix/blob/main/.decisions/0128-glossary-concept-trigger-off-the-gate.md), Fixes #1737); it never touches `review-code`'s fail-closed Step 3c. **You must land on one of two explicit outcomes — a named term routed to the glossary, or a recorded "no vocabulary impact"; silently skipping it is not an option.**
@@ -65,7 +67,7 @@ live-accepted ADRs whose decision domain yours touches and which you do **not** 
 
 ```bash
 # Exit 0 = nothing left to open. Non-zero = a shortlist to clear, or an INDETERMINATE run.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/adr/scripts/sweep-shortlist.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/adr/scripts/sweep-shortlist.sh \
   .decisions/NNNN-slug.md
 ```
 
@@ -178,4 +180,4 @@ On a **PR**, `.github/workflows/decisions-index.yml` runs `decisions-index valid
 - Never edit an accepted ADR's decision text after the fact — supersede instead, or amend in part (below).
 - **Amending in part: the status line only.** When your ADR changes part of a live `accepted` ADR while the rest still stands, set `status: amended-in-part by [NNNN](NNNN-slug.md)` on that older file and change **nothing else in it** — its decision text is immutable. Name the relationship in your own `## Context`. Precedents: 0023, 0028, 0031, 0035. Finding the ADRs that need this is the [§Contradiction sweep](#contradiction-sweep--never-decide-against-a-live-adr-silently), which is required on every ADR.
 - **Always resolve the vocabulary-impact outcome** (Step 6 / [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source)): every ADR ends with *either* a term surfaced to `.glossary/TERMS.md` *or* an explicit recorded "no vocabulary impact." Never leave it unstated — the explicit "none" is a real outcome, not a skip.
-- Your PR adds only the ADR file (plus the status-line edit on a file it supersedes or amends-in-part); there is no committed index. Optional local render of the on-demand compact map (nothing to stage): `"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/bin/pipeline-cli" decisions-index compact` (the shim resolves the bin — in-repo, else installed, else pinned dlx reading the one pin in hooks/pin.sh; #3653).
+- Your PR adds only the ADR file (plus the status-line edit on a file it supersedes or amends-in-part); there is no committed index. Optional local render of the on-demand compact map (nothing to stage): `./claude-plugins/kampus-pipeline/bin/pipeline-cli decisions-index compact` (the shim resolves the bin — in-repo, else installed, else pinned dlx reading the one pin in hooks/pin.sh; #3653).

--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
@@ -37,7 +37,7 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/resolve-repo.sh)" || exit 1
 ```
 
 ## The extracted scripts
@@ -72,7 +72,7 @@ Read both before walking code:
 
 ```bash
 # the committed architecture + domain vocabulary the audit speaks in
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/read-glossary.sh"
+bash ./claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/read-glossary.sh
 ```
 
 If a glossary file is genuinely absent (a foreign install that hasn't adopted the glossary
@@ -106,7 +106,7 @@ carries `id`/`title`/`status`:
 
 ```bash
 # the `NNNN-slug.md` filenames (the map), then the compact id · title · status index
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/decisions-map.sh"
+bash ./claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/decisions-map.sh
 ```
 
 Treat a recorded decision as decided ground: don't surface a finding that contradicts a
@@ -203,7 +203,7 @@ report agents exist, so the same friction may already be filed:
 
 ```bash
 # (a) the live needs-triage queue, then (b) the search index; the script joins keywords with +
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/architecture-audit/scripts/dedup-search.sh" "<keywords>"
+bash ./claude-plugins/kampus-pipeline/skills/architecture-audit/scripts/dedup-search.sh "<keywords>"
 ```
 
 Both commands guard different failure modes — don't drop either: (a) is read-after-write
@@ -239,7 +239,7 @@ and hands the stream to the `tracker create-issue` verb, which owns this intake-
 collide on, which is what retires the old `/tmp/arch-audit-body.XXXXXX` shared-`/tmp` hazard (§SP):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/file-report.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/report/scripts/file-report.sh \
   "<short, type-neutral finding summary (≤ ~70 chars)>" <<'EOF'
 <the five sections>
 EOF

--- a/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
@@ -133,7 +133,7 @@ auto-shippable. **Re-check the final path** against the live control-plane regex
 opening the PR:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/author-skill/scripts/control-plane-paths.sh"
+bash ./claude-plugins/kampus-pipeline/skills/author-skill/scripts/control-plane-paths.sh
 ```
 
 A skill flips to §CP (human-merge, never auto-shipped) when its path falls under a gate skill

--- a/claude-plugins/kampus-pipeline/skills/campaign/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/campaign/SKILL.md
@@ -46,7 +46,7 @@ Resolve `$REPO` the repo-agnostic way the rest of the pipeline does (ADR
 [0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-agnostic-pipeline.md)):
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/resolve-repo.sh)" || exit 1
 ```
 
 All GitHub reads/writes below go through **`gh api` REST** — never GraphQL (the org's
@@ -83,7 +83,7 @@ You need three inputs before the ritual:
    WAVE_LABEL="<the shared wave label>"
    # one `#<n>\t<state>\t<title>` line per member. Exit 4 = the label names ZERO issues (no wave);
    # exit 1 = the read never landed, which is UNKNOWN and never an empty cluster.
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/list-wave.sh" "$WAVE_LABEL"
+   bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/list-wave.sh "$WAVE_LABEL"
    ```
 
 2. **The lifecycle direction — `active` (create) or `done` (complete).** Default is `active`
@@ -105,7 +105,7 @@ every other input (absent, malformed, non-founder author, zero scope) exits non-
 [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/verify-trace.sh" "$WAVE_LABEL" "$FOUNDER" || exit 1
+bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/verify-trace.sh "$WAVE_LABEL" "$FOUNDER" || exit 1
 ```
 
 The trace the verifier requires is a **founder-authored comment**, on any issue carrying the wave
@@ -132,7 +132,7 @@ product arc:
   milestone for this wave, attach to it. List open milestones and match by title/description:
 
   ```bash
-  "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/list-milestones.sh"
+  bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/list-milestones.sh
   ```
 
 - **Otherwise provision the campaign's own milestone** — the roadmap act the founder approval
@@ -140,7 +140,7 @@ product arc:
   milestone):
 
   ```bash
-  MILESTONE_NUMBER="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/create-milestone.sh" \
+  MILESTONE_NUMBER="$(bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/create-milestone.sh \
     "<Campaign name> campaign" \
     "<one-line campaign scope> (bounded, platform-lane drained).")" || exit 1
   ```
@@ -149,7 +149,7 @@ Then **stamp the milestone on every wave-labeled issue** so the milestone projec
 cluster (the milestone is set per-issue via the issue-edit endpoint):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/home-wave.sh" "$WAVE_LABEL" "$MILESTONE_NUMBER"
+bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/home-wave.sh "$WAVE_LABEL" "$MILESTONE_NUMBER"
 ```
 
 **Assignments.** Record who owns the campaign's drain if the founder named owners (assign the wave
@@ -167,7 +167,7 @@ campaign runs alongside whichever arc is active). Swap any existing `p0`/`p2` fo
 wave issue:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/normalize-priority.sh" "$WAVE_LABEL"
+bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/normalize-priority.sh "$WAVE_LABEL"
 ```
 
 Only open issues need re-pricing — a closed wave issue has already drained and its priority is
@@ -205,7 +205,7 @@ Open the PR against the wave's tracking issue so it closes on merge:
 3. Open the PR:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/open-roadmap-pr.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/open-roadmap-pr.sh \
   "<Campaign name>" "<active|done>" "<branch>" "$WAVE_LABEL" "<MILESTONE_NUMBER>" "<tracking-issue>"
 ```
 
@@ -234,7 +234,7 @@ run the **same gate** (Step 1), so completing a campaign is exactly as guarded a
   2. **Close the milestone** — the operational projection of a finished campaign:
 
      ```bash
-     "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/campaign/scripts/close-milestone.sh" \
+     bash ./claude-plugins/kampus-pipeline/skills/campaign/scripts/close-milestone.sh \
        "$MILESTONE_NUMBER" || exit 1
      ```
   3. **Flip the ROADMAP row to `done`** in a Campaigns-row PR (Step 4, `done` variant) — the row's

--- a/claude-plugins/kampus-pipeline/skills/canon/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/canon/SKILL.md
@@ -45,7 +45,7 @@ it once, at the top of your run, per the shared contract's **Target repo resolut
 ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)):
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/canon/scripts/resolve-repo.sh)" || exit 1
 ```
 
 ## The extracted scripts
@@ -149,7 +149,7 @@ Run it when there's no doc worth preserving for a pattern that clears the index 
 
    ```bash
    # exit 4 = there is no pattern-doc library (or it is empty) — a fact to confirm, not a listing
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/list-pattern-docs.sh"
+   bash ./claude-plugins/kampus-pipeline/skills/canon/scripts/list-pattern-docs.sh
    ```
 
 2. **Read the source for the concern, in layers.** Stop as soon as you can name the decision
@@ -196,7 +196,7 @@ change. Surgical — touch the drifted parts, preserve everything else.
    ```bash
    # the source surfaces that changed since the doc last moved. Exit 4 = the doc has never been
    # committed, which is the BOOTSTRAP case below and not an empty drift.
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/pattern-doc-drift.sh" \
+   bash ./claude-plugins/kampus-pipeline/skills/canon/scripts/pattern-doc-drift.sh \
      "<name>" <source-dirs>
    ```
 
@@ -254,7 +254,7 @@ Run mechanically — don't self-assess, actually check:
 
 ```bash
 # all four checks over .patterns/<name>.md — cross-refs, leaks, stale markers, the index row
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/canon/scripts/verify-pattern-doc.sh" "<name>"
+bash ./claude-plugins/kampus-pipeline/skills/canon/scripts/verify-pattern-doc.sh "<name>"
 ```
 
 Then, by judgment: for the doc — **name the specific mistake an agent makes without it**;

--- a/claude-plugins/kampus-pipeline/skills/glossary/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/glossary/SKILL.md
@@ -46,7 +46,7 @@ term's disambiguation note), resolve it once, at the top of your run, per the sh
 **Target repo resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)):
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/glossary/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/glossary/scripts/resolve-repo.sh)" || exit 1
 ```
 
 In phoenix this defaults to `kamp-us/phoenix` with no config, so the behavior is unchanged
@@ -121,7 +121,7 @@ The first-run seed. Run it when there's no glossary worth preserving.
    ```bash
    # feature/domain folders + package names. Exit 4 = this repo has NO such surfaces, which is a fact
    # to confirm rather than an empty listing to read past.
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/glossary/scripts/list-surfaces.sh"
+   bash ./claude-plugins/kampus-pipeline/skills/glossary/scripts/list-surfaces.sh
    ```
 
 2. **Harvest the nouns.** For each surface, read enough to name its domain nouns: the product
@@ -153,7 +153,7 @@ the change. The discipline is surgical — touch the affected rows, preserve eve
 
    ```bash
    # the code surfaces that changed since the glossary last moved (feature folders, exports, renames)
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/glossary/scripts/glossary-drift.sh"
+   bash ./claude-plugins/kampus-pipeline/skills/glossary/scripts/glossary-drift.sh
    ```
 
    Exit 4 means the file has never been committed (you're staging a fresh seed) — that's the

--- a/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/heal-ci/SKILL.md
@@ -35,7 +35,7 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/resolve-repo.sh)" || exit 1
 ```
 
 ## The extracted scripts
@@ -95,7 +95,7 @@ once, up front, then use the vars in every command below:
 RUN=<run id>     # the failed run
 PR=<n>           # the PR, if this is a PR run (else leave unset)
 # the failed logs, then the job/step rollup that names which job died (and its databaseId)
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/failed-logs.sh" "$RUN"
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/failed-logs.sh "$RUN"
 ```
 
 If `--log-failed` returns nothing (it sometimes does — e.g. a bare `exit 1` with no
@@ -107,7 +107,7 @@ emptiness**: a non-zero exit means the read never landed, which is not "no annot
 
 ```bash
 JOB=<failed job databaseId from the rollup above>
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/job-log.sh" "$JOB"
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/job-log.sh "$JOB"
 ```
 
 ### Entering from a PR — resolve the failing run over REST
@@ -120,7 +120,7 @@ the head is genuinely red; exit 2 means it was **unreadable**, which is not "not
 ```bash
 # prints `CONTEXT=<name> JOB=<id> RUN=<id>` on exit 0. Exit 3 green · 4 pending · 5 not-an-Actions-check
 # · 1 unreadable. READ THE STATUS BEFORE THE STDOUT — an unreadable head is not a green one.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/resolve-failing-run.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/resolve-failing-run.sh "$PR"
 ```
 
 One script, because the three fences this replaces shared a `$CI_JSON` that **never survived**: each
@@ -151,7 +151,7 @@ but the run/PR state itself remembers a prior rerun). Read two facts:
 ```bash
 # prints `attempt=<n> rerun-markers=<n>`. A non-zero exit means a read did not land — UNKNOWN, and
 # UNKNOWN is never "not yet rerun". READ THE STATUS BEFORE THE NUMBERS.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/already-rerun.sh" "$RUN" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/already-rerun.sh "$RUN" "$PR"
 ```
 
 **The one-rerun rule (canonical statement — every later step points here).** A flake gets
@@ -225,7 +225,7 @@ manual rerun can also bump):
 ```bash
 # reruns the failed jobs, then — on a PR run — writes the marker Step 1's detector queries. Omit the
 # PR argument on a non-PR run. A failed rerun writes NO marker.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/rerun-once.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/rerun-once.sh \
   "$RUN" "<signature>" "$PR"
 ```
 
@@ -314,7 +314,7 @@ with the `Filed #N` comment the no-repair path posts, but routed to the in-fligh
 of a fresh issue — and stop. That comment *is* your one routed action for this invocation:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/comment-active-repair.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/comment-active-repair.sh \
   "$PR" "<signature>" "<run url>"
 ```
 
@@ -347,7 +347,7 @@ that real number — never post the `Filed #<N>` line with an unresolved `<N>` p
 ```bash
 N=<the .number report returned>
 # refuses a non-numeric N, so the `Filed #<N>` line can never post with an unresolved placeholder
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/heal-ci/scripts/comment-filed.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/heal-ci/scripts/comment-filed.sh \
   "$PR" "$N" "<signature>"
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -47,7 +47,7 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/resolve-repo.sh)" || exit 1
 ```
 
 Every script under [`scripts/`](scripts/) resolves the repo the same way through the shared lib's
@@ -183,7 +183,7 @@ re-implementing ~50 lines of `jq` inline. Resolve the tool in-repo first, publis
 # exit 0 = lock WON (prints `epic-lock: won #<EPIC>`) → mutate, then RELEASE on every exit path.
 # 3 = backed off (held lock / setup gap / lost race — not a plan-epic failure, re-run later);
 # 127 = the shim never ran (UNKNOWN). NEVER mutate on a non-zero.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/epic-lock-acquire.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-lock-acquire.sh <EPIC>
 ```
 
 **Release is an explicit agent step, not a shell `trap … EXIT`.** The acquire above runs in
@@ -198,7 +198,7 @@ or a failure/abort mid-mutation):
 ```bash
 # A non-zero exit means the release did NOT complete — the lock is LEAKED and the epic is wedged.
 # Surface it loudly; never swallow it.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/epic-lock-release.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-lock-release.sh <EPIC>
 ```
 
 The release fires on **every** terminal path on purpose: you drive this as an LLM agent across
@@ -265,13 +265,13 @@ after which every later script **re-derives** the same directory through the sha
 ```bash
 # OPEN the namespace — run this ONCE per plan; it prints the directory and clears a previous run of
 # this same epic in this same session. Every later script re-derives it and never clears it.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/scratch-open.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/scratch-open.sh <EPIC>
 ```
 
 ```bash
 # the epic + its labels + child summary on stdout, and the body/updated_at snapshot written into the
 # namespace for Step 5 to read back
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/epic-read.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/epic-read.sh <EPIC>
 ```
 
 If the epic already has sub-issues or a plan section, you're **re-planning** — jump to
@@ -475,7 +475,7 @@ later; #1968 and #2099 the same verdict-resolver work in two places).
 
 ```bash
 # writes existing-children.txt (set 1) and open-backlog.txt (set 2) into the §SP namespace
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/idempotency-sets.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/idempotency-sets.sh <EPIC>
 ```
 
 **Then classify each proposed child before you create it:**
@@ -529,7 +529,7 @@ relocation *is* the #754 guard) and prints the created `{number,id}`:
 
 ```bash
 # type + priority are yours to choose per the paragraph below; status:planned is fixed by the script.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/create-child.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/create-child.sh \
   <EPIC> "<sharp single-unit title>" type:feature p2 "<path/to/child-spec.json>"
 ```
 
@@ -561,7 +561,7 @@ adjust labels on an **already-existing** child:
 ```bash
 # amend-only — append/adjust labels on an EXISTING child. Fresh children are labeled AT CREATE (above),
 # so this never runs on the create path; using it there would reopen the label-less-orphan window.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/amend-child-labels.sh" <CHILD> type:feature p2
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/amend-child-labels.sh <CHILD> type:feature p2
 ```
 
 (Type and priority are your call as planner, the same authority triage has — you're
@@ -583,7 +583,7 @@ Read the epic's milestone once, and **only if it has one** PATCH each created ch
 
 ```bash
 # a no-op (reported on stdout) when the epic has no milestone — inheritance copies, never invents
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/inherit-milestone.sh" <EPIC> <CHILD>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/inherit-milestone.sh <EPIC> <CHILD>
 ```
 
 **If the epic has no milestone, children stay unmilestoned** — inheritance *copies* the
@@ -614,7 +614,7 @@ whole step no-ops (graceful absence, ADR
 # prints `present` or `absent`; it sources the ONE shared implementation of the formats-contract
 # canonical probe (`../shared/scripts/cycle-doc-probe.sh`), never a second copy.
 # absent ⇒ no marker stamped (children carry `none`)
-CYCLE_DOC="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/cycle-doc-probe.sh")" || exit 1
+CYCLE_DOC="$(bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/cycle-doc-probe.sh)" || exit 1
 ```
 
 - **Cycle doc present.** For each child, consult the cycle's policy and decide the child's
@@ -685,13 +685,13 @@ The endpoint takes the child's **database id** (`.id`), *not* its issue number:
 
 ```bash
 # the script resolves the child's database id itself and POSTs the link (`-F`, so the id is a number)
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/link-child.sh" <EPIC> <CHILD>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/link-child.sh <EPIC> <CHILD>
 ```
 
 Confirm the link landed:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/confirm-links.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/confirm-links.sh <EPIC>
 ```
 
 The exact-equality check holds on the fresh-plan path, where every linked child is
@@ -705,7 +705,7 @@ endpoint is **singular** `sub_issue` (not `sub_issues`), and the id goes in the 
 body via `--input` — `-X DELETE … -F` does **not** work here:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/unlink-child.sh" <EPIC> <CHILD>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/unlink-child.sh <EPIC> <CHILD>
 ```
 
 Unlinking does not close the child; it just removes the parent/child edge. Closing is
@@ -795,7 +795,7 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 # exit 0 = our whole ## Dependencies block round-tripped (the topology is pinned). Any non-zero is
 # a hard STOP: a guard aborted, every attempt raced, or a racer clobbered the write — the script
 # names which on stdout, and re-derive is YOUR next action.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/splice-body.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/splice-body.sh <EPIC>
 ```
 
 **Keep the brief byte-for-byte.** With the `epic-splice` verb's surgical splice/append this is
@@ -845,7 +845,7 @@ close each source it names — but only a genuine `type:investigation` source, i
 ```bash
 # a no-op when the brief names no `resolved investigation #N`; each named source is closed only
 # if it is an OPEN type:investigation, so a re-plan run is idempotent
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/close-graduated-sources.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/close-graduated-sources.sh <EPIC>
 ```
 
 Only the *source* that graduated is closed; the epic and every downstream artifact it links stay
@@ -888,7 +888,7 @@ Every supersede is auditable. Before closing a superseded child, post a comment 
 ```bash
 # posts the journal note FIRST, then unlinks and closes not-planned — the trail exists even if a
 # later leg fails. Only ever on an OPEN child; a closed-done child is history.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/supersede-child.sh" <EPIC> <CHILD> \
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/supersede-child.sh <EPIC> <CHILD> \
   "<specific reason — e.g. 'scope merged into #<NEW>' or 'dropped, the brief no longer asks for X'>"
 ```
 
@@ -933,7 +933,7 @@ unmistakably test debris.
 ```bash
 # THROWAWAY EPICS ONLY — it closes exactly the numbers you name, and no script can tell test
 # debris from the real backlog
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/teardown-scratch-epic.sh" <EPIC> <CHILD> [<CHILD> …]
+bash ./claude-plugins/kampus-pipeline/skills/plan-epic/scripts/teardown-scratch-epic.sh <EPIC> <CHILD> [<CHILD> …]
 ```
 
 (If you have repo-admin and the GraphQL `deleteIssue` mutation is available to you,

--- a/claude-plugins/kampus-pipeline/skills/release/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/release/SKILL.md
@@ -71,7 +71,7 @@ You need two things before the ritual:
 
    ```bash
    # reports where each credential resolves from and whether it authenticates
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/auth-status.sh"
+   bash ./claude-plugins/kampus-pipeline/skills/release/scripts/auth-status.sh
    ```
 
    **Read its exit status before its output.** A non-zero exit means the pre-flight never ran, which is
@@ -94,7 +94,7 @@ You need two things before the ritual:
 Resolve `$REPO` the same way the rest of the pipeline does (it is repo-agnostic; ADR 0062):
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/release/scripts/resolve-repo.sh)" || exit 1
 ```
 
 All GitHub reads/writes below go through **`gh api` REST** — never GraphQL (the org's
@@ -131,7 +131,7 @@ anything. `flag get` reports it in the canonical form (`off (default)` for an un
 `on@100% (split)` for a released one, `on@N% (ramping)` for a partial):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-get.sh" "$FLAG_KEY" "$ENV"
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/flag-get.sh "$FLAG_KEY" "$ENV"
 ```
 
 - **Currently `off (default)` (dark) →** this is a release you can perform: proceed to Step 2.
@@ -153,7 +153,7 @@ whose closing PR dark-shipped **this** flag key:
 
 ```bash
 # prints one `match: issue #<I> ← PR #<P> declares Flag: <key>` line per match
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/find-linked-issue.sh" "$FLAG_KEY"
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/find-linked-issue.sh "$FLAG_KEY"
 # LINKED_ISSUE is the awaiting-release issue whose closing PR body carried `Flag: $FLAG_KEY`.
 LINKED_ISSUE="<that issue number>"
 ```
@@ -187,7 +187,7 @@ missing. Run it for the resolved key **before the dry-run flip**:
 # HARD-REFUSE the flip on a non-zero exit — the script relays the guard's report (on stderr), which
 # names which assertion failed, then prints the refusal. The flag stays dark; do NOT proceed to
 # Step 2.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/reachability-gate.sh" "$FLAG_KEY" || exit 1
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/reachability-gate.sh "$FLAG_KEY" || exit 1
 ```
 
 - **Non-zero exit → hard-refuse the flip.** This is the identical fail-closed refusal shape as
@@ -223,19 +223,19 @@ live state:
 
 ```bash
 # Full release (100% — the default release act). DRY-RUN: prints current → target, writes nothing.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-dryrun.sh" "$FLAG_KEY" "$ENV"
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-dryrun.sh "$FLAG_KEY" "$ENV"
 
 # Ramped release (serve `on` to N% of traffic; the remainder falls to the safe default). DRY-RUN.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-dryrun.sh" "$FLAG_KEY" "$ENV" "$N"
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-dryrun.sh "$FLAG_KEY" "$ENV" "$N"
 ```
 
 Once the dry-run diff is exactly the release you intend, **execute it** by re-running the same
 command with `--execute`:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-execute.sh" "$FLAG_KEY" "$ENV"        # APPLY the full release
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-execute.sh "$FLAG_KEY" "$ENV"        # APPLY the full release
 # or, for a ramp:
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-open-execute.sh" "$FLAG_KEY" "$ENV" "$N"
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/flag-open-execute.sh "$FLAG_KEY" "$ENV" "$N"
 ```
 
 **`--percent <n>` — the ramped-release form.** `/release <flag-key> --percent 50` runs the
@@ -260,7 +260,7 @@ it now reports the live state — the dark → live transition actually landed:
 
 ```bash
 # expect: on@100% (split)  — or  on@N% (ramping) for a ramp
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/flag-get.sh" "$FLAG_KEY" "$ENV"
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/flag-get.sh "$FLAG_KEY" "$ENV"
 ```
 
 Assert the transition:
@@ -289,7 +289,7 @@ hand-cleared the night this skill was proposed):
 
 ```bash
 # remove the release-queue label from the (closed) linked issue — the consume half of #602
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/clear-queue-label.sh" "$LINKED_ISSUE"
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/clear-queue-label.sh "$LINKED_ISSUE"
 ```
 
 The label lives on a **closed** issue (the dark ship's PR closed it on merge); removing a label
@@ -309,7 +309,7 @@ linked issue so it is durable and discoverable next to the work it releases (and
 text to the human running the command):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/release/scripts/post-release-note.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/release/scripts/post-release-note.sh \
   "$LINKED_ISSUE" "$FLAG_KEY" "$ENV" "$SERVING_NOW" "<human releaser>"
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -58,7 +58,7 @@ Below the five sections, append a footer carrying the machine context of the ses
 Gather the context with the helper, which reads it from the environment and git:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/footer.sh"
+bash ./claude-plugins/kampus-pipeline/skills/report/footer.sh
 ```
 
 It prints a ready-to-append markdown block. Which fields appear varies by run — the helper includes only what the environment actually exposes and silently drops the rest, so a real footer might look like this (here `session` and `model` weren't available, so they're omitted — no dangling labels, no "unknown"):
@@ -86,7 +86,7 @@ All GitHub operations go through `gh api` REST. **Never GraphQL** — the kamp-u
 **Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api` call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared contract's **Target repo resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO` if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/report/scripts/resolve-repo.sh)" || exit 1
 ```
 
 ## The extracted scripts
@@ -115,7 +115,7 @@ into tested `pipeline-cli` verbs is #1929). Two properties are load-bearing:
    fed your title plus a few keywords:
 
    ```bash
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/dedup-check.sh" \
+   bash ./claude-plugins/kampus-pipeline/skills/report/scripts/dedup-check.sh \
      "<the title + a few distinguishing keywords>"
    ```
 
@@ -141,7 +141,7 @@ intact), and the script appends the blank line + the `footer.sh` block and strea
 into the create verb. Everything below the invocation line is your authored body, not glue:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/file-report.sh" "<title>" <<'EOF'
+bash ./claude-plugins/kampus-pipeline/skills/report/scripts/file-report.sh "<title>" <<'EOF'
 ## Summary
 …
 

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -205,7 +205,7 @@ repo-agnostic — every `gh api` call targets `$REPO`, not a hardcoded repo) per
 0062 §1); in phoenix this defaults to `kamp-us/phoenix` with no config.
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/resolve-repo.sh"
+bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/resolve-repo.sh
 ```
 
 Every script below resolves the repo the same way, through the shared lib's `kp_repo` — so the
@@ -307,7 +307,7 @@ never silently off-ramp, which is the failure that mints the phantom gate.
 
 ```bash
 PR=<pr number>
-UI_TOUCHED="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/classify-ui-surface.sh" "$PR")"
+UI_TOUCHED="$(bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/classify-ui-surface.sh "$PR")"
 ```
 
 Read **three** outcomes off the script, never two — and read its **exit status before its stdout**:
@@ -337,7 +337,7 @@ with zero path matches, so a path-only test here would classify it non-blocking 
 this verb removes (#4161, formats §CP):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/classify-control-plane.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/classify-control-plane.sh "$PR"
 ```
 
 Read its **exit status before its stdout**, exactly as the off-ramp above does: a **non-zero exit**
@@ -369,7 +369,7 @@ so a bad flag or an unresolved CLI leaves an empty `CP_STATE` that the catch-all
 ## Step 1 — Resolve the PR, its head SHA, the preview URL, and the changed surfaces
 
 ```bash
-HEAD_SHA="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/resolve-head.sh" "$PR")"
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/resolve-head.sh "$PR")"
 ```
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code` writes) —
@@ -377,7 +377,7 @@ cross-check via the timeline if it's not obvious — for context on *what* the U
 surfaces it targets. The script prints the PR summary first, then the numbers its timeline links:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/pr-context.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/pr-context.sh "$PR"
 ```
 
 ### Resolve the preview URL from the sticky preview-deploy comment
@@ -389,7 +389,7 @@ CI posts a **sticky comment keyed by `<!-- preview-deploy -->`**, with a per-app
 your own app server**:
 
 ```bash
-PREVIEW_URL="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/resolve-preview-url.sh" "$PR")"
+PREVIEW_URL="$(bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/resolve-preview-url.sh "$PR")"
 ```
 
 If **no preview URL** can be resolved (the preview-deploy comment is absent or the deploy failed),
@@ -403,7 +403,7 @@ Derive the **routes/surfaces** the diff affects from the changed frontend files 
 maps to the page(s) that render it. Read the diff for surface selection:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/pr-diff.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/pr-diff.sh "$PR"
 ```
 
 Map each changed `apps/web/src/**` surface to the route(s) that render it (a changed
@@ -422,7 +422,7 @@ render-exception still apply to it). The pointer is the committed source of trut
 surface-ids are the same `<route>[:state]` capture spec:
 
 ```bash
-BLESSED_SURFACES="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/blessed-surfaces.sh")"
+BLESSED_SURFACES="$(bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/blessed-surfaces.sh)"
 ```
 
 The changed BLESSED surfaces are the capture surface-ids (Step 1) ∩ `$BLESSED_SURFACES`. An empty
@@ -459,7 +459,7 @@ implementation legs land to match):
 ```bash
 # one <route>[:state] argument per surface; CAPTURES is the helper's stdout JSON array of
 # { surface, route, state, localPath, hostedUrl, uploadError, pageErrors }
-CAPTURES="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/capture-surfaces.sh" "$PREVIEW_URL" "<route>[:state]" ...)"
+CAPTURES="$(bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/capture-surfaces.sh "$PREVIEW_URL" "<route>[:state]" ...)"
 ```
 
 **Now judge the LOCAL bytes.** For each captured surface, **read the local PNG** (`localPath`) as
@@ -475,8 +475,8 @@ hard-FAILs the gate regardless of how its screenshot looks; a bare `console.erro
 
 ```bash
 # uncaught exceptions → hard-FAIL rows (surface + message); console.error → advisory
-RENDER_CRASHES="$(printf '%s' "$CAPTURES" | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/render-errors.sh" pageerror)"
-RENDER_ADVISORIES="$(printf '%s' "$CAPTURES" | "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/render-errors.sh" console.error)"
+RENDER_CRASHES="$(printf '%s' "$CAPTURES" | bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/render-errors.sh pageerror)"
+RENDER_ADVISORIES="$(printf '%s' "$CAPTURES" | bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/render-errors.sh console.error)"
 ```
 
 A non-empty `RENDER_CRASHES` is a **FAIL** (Step 3), naming each thrown error + its surface so a
@@ -623,7 +623,7 @@ new head before posting (never bind a verdict to a head whose UI you didn't see)
 
 ```bash
 # prints the CURRENT head; warns on stderr when it moved off the head you reviewed
-HEAD_SHA="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/current-head.sh" "$PR" "$HEAD_SHA")"
+HEAD_SHA="$(bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/current-head.sh "$PR" "$HEAD_SHA")"
 ```
 
 Write the verdict to a per-run temp file so multi-line markdown + backticks survive the shell, then
@@ -799,8 +799,8 @@ it from [`../shared/scripts/verdict-readback.sh`](../shared/scripts/verdict-read
 implementation of it:
 
 ```bash
-CID="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/verdict-upsert.sh" "$PR" "$VERDICT_FILE")"
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-design/scripts/verdict-readback.sh" "$CID" "$HEAD_SHA"
+CID="$(bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/verdict-upsert.sh "$PR" "$VERDICT_FILE")"
+bash ./claude-plugins/kampus-pipeline/skills/review-design/scripts/verdict-readback.sh "$CID" "$HEAD_SHA"
 ```
 
 A non-zero exit is the read-back failing: re-post the real verdict and re-assert; if it still can't

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -186,17 +186,25 @@ check is satisfied by what the diff actually shows, not by the author asserting 
 
 Pull the file list first; the classification gates everything after it. One script runs **both** §CP
 clauses — the path clause and the ADR-0164 content clause — off **one** hardened read of the changed
-files, and leaves their two flags in your shell through the run-state handle it prints:
+files, and prints their two flags:
 
 ```bash
 PR=<pr number>
-# Prints ONE line — the handle carrying CONTROL_PLANE_TOUCHED / GUARD_TOUCHING / CP_FILES_N / ADR_N.
-# The changed-file list and the §ZS scope line go to stderr. On any failure the handle is written
-# with the §CP SENTINEL first, so a classifier that could not run reaches you as a HOLD, never as an
-# empty (= non-blocking) flag; if even the handle cannot be written, stdout is empty and this `.`
-# fails loudly. Read the STATUS before the flags.
-. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh "$PR"
 ```
+
+**Executed, not sourced, and stdout is the answer** (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md),
+[`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md)).
+It prints four `KEY=value` lines — `CONTROL_PLANE_TOUCHED` and `GUARD_TOUCHING`, the two flags this
+step branches on, plus the `CP_FILES_N` / `ADR_N` scope counts. The two flag values are
+`printf '%q'`-quoted, so each is a single line and the **empty** (not-§CP) answer arrives as the
+positive token `''` rather than as an absence you have to infer. The changed-file list and the §ZS
+scope line go to stderr. Every failure path prints the flags as a non-empty §CP sentinel *before*
+exiting non-zero, because an empty flag is exactly what this step reads as non-blocking. **Read the
+exit status before the stdout**: a non-zero exit is a hold whatever the flags say, and stdout
+carrying no `CONTROL_PLANE_TOUCHED=` line at all means the classifier never ran — UNKNOWN, so hold
+the PR as control plane.
 
 - **Any control-plane path** — the **canonical §CP set** in
   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md): `.claude/**`, `.github/**`,
@@ -393,14 +401,20 @@ the hunk alone — and read it **read-only**, without ever switching the checkou
 **Read-only on git working state** below). Fetch the head into a ref and read off that ref:
 
 ```bash
-# Prints ONE line — the handle carrying PR_REF / HEAD_SHA. On any failure stdout is EMPTY, so this
-# `.` fails loudly rather than leaving you reading the launched checkout's base tree (#793).
-. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh "$PR" || exit 1
 
 # Read the head's files off the ref — read-only, no checkout:
 git show "$PR_REF:<path>"            # the file's content at the PR head
 git grep -n "<pattern>" "$PR_REF"    # search the head tree without checking it out
 ```
+
+**Executed, not sourced, and stdout is the answer** (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md)).
+It prints one `KEY=value` line per resolved value — `PR_REF` and `HEAD_SHA` — and every progress and
+FATAL line goes to stderr. Read those values off stdout; every `$PR_REF` / `$HEAD_SHA` below names
+the value you read here, not a variable that survives into the next Bash call. **Read the exit
+status before the stdout:** on any failure path stdout is empty and the exit is non-zero, and that
+is UNKNOWN — **never** fall back to reading the launched checkout's base tree (the #793 false-PASS).
 
 The script drives §HEAD's fetch-into-a-ref through the shared `pipeline-cli review-head materialize`
 verb (#3690 / #793 / #1807) — cite it, don't re-derive it. Ref-only mode resolves the live head SHA
@@ -420,13 +434,13 @@ dir. `scratchpad` is the allocator (§SP rule 2 of
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)); it refuses with a reason on stderr
 rather than falling back to a shared path.
 
-**Every later Bash call re-derives `$HEAD_ENV`; it never inherits it.** Run
-[`scripts/head-env.sh`](scripts/head-env.sh) — same session, same slug, same path — then re-source.
-It **refuses** when the namespace was never opened in this run, so a lost handle fails loud instead
-of silently reading an empty directory:
+**Every later Bash call re-derives the head values; it never inherits them.** Run
+[`scripts/head-env.sh`](scripts/head-env.sh) — same session, same slug, same path — and read the
+same `KEY=value` lines off its stdout. It **refuses** (non-zero, empty stdout) when the namespace was
+never opened in this run, so a lost handle fails loud instead of silently reading an empty directory:
 
 ```bash
-. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh "$PR")"   # $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh "$PR" || exit 1   # PR_REF / HEAD_SHA (and REVIEW_WT, if --worktree was used)
 ```
 
 If a check genuinely needs a materialized tree (rare for a doc PR), pass `--worktree` to the
@@ -437,7 +451,7 @@ reviewer's tree and pins the wrong head (the #1807 collision). Tear it down with
 [`scripts/teardown-head.sh`](scripts/teardown-head.sh), which also drops the throwaway ref:
 
 ```bash
-. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh "$PR" --worktree)"
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh "$PR" --worktree || exit 1   # adds a REVIEW_WT= line
 # Register teardown as a trap so a mid-block error still tears the throwaway tree down. The trap is
 # YOURS, not the script's — an extracted script installs no EXIT trap of its own (#4476/#4479).
 trap 'bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh "$PR"' EXIT
@@ -645,10 +659,17 @@ a question you cannot sweep for.
 citations.** The mechanical shortlist is one command — it ranks the live-accepted ADRs whose
 decision domain the new one touches **and which it does not cite**:
 
+`PR_REF` is the value Step 2's materialize printed; if that ran in an EARLIER Bash call the variable
+is gone, so re-read it off `head-env.sh`'s stdout — never re-run the materialize just to rebind it:
+
 ```bash
-# $PR_REF is bound by Step 2's materialize; if that ran in an EARLIER Bash call the variable is gone,
-# so re-derive it via head-env.sh first — never re-run the materialize just to rebind it.
-. "$(bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh "$PR" || exit 1
+```
+
+Then bind it by literal assignment in the block that uses it:
+
+```bash
+PR_REF="<the refs/pr/… value head-env.sh printed>"
 bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/adr-sweep.sh "$PR_REF" .decisions/NNNN-slug.md
 SWEEP=$?
 ```

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh
@@ -4,17 +4,22 @@
 # review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract + shell-option rationale:
 # ../SKILL.md § The extracted scripts. The *why* for each clause stays in that step's prose.
 #
-# STDOUT IS A MACHINE CHANNEL: the only stdout line is the run-state handle carrying
-# CONTROL_PLANE_TOUCHED / GUARD_TOUCHING / CP_FILES_N / ADR_N, so Step 0 can
-# `. "$(classify-control-plane.sh "$PR")"` and branch on the two flags. Scope + diagnostic lines go
-# to stderr, per `.patterns/skill-script-io-contract.md`.
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/classify-control-plane.sh <pr>
 #
-# EVERY failure path WRITES THE HANDLE WITH THE §CP SENTINEL FIRST, then exits non-zero. That is the
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — four `KEY=value` lines:
+#   CONTROL_PLANE_TOUCHED / GUARD_TOUCHING   the two flags Step 0 branches on, `printf '%q'`-quoted
+#   CP_FILES_N / ADR_N                       the §ZS scope counts
+# The two flags are %q-quoted so a multi-file match stays ONE line and the ordinary not-§CP answer
+# arrives as the positive token `''` rather than as an absence Step 0 has to infer. Scope +
+# diagnostic lines go to stderr.
+#
+# EVERY failure path PRINTS THE FLAGS AS THE §CP SENTINEL FIRST, then exits non-zero. That is the
 # whole reason this script exists in this shape: an empty `$CONTROL_PLANE_TOUCHED` is what the step
 # reads as "non-blocking", so a classifier that could not run must never reach the caller as an
 # unset/empty flag. An absent or empty result is UNKNOWN, and UNKNOWN is never "no §CP path touched"
-# (§ZS / ADR 0092; #4216, #4231, #4010, #4219). If even the handle cannot be written, stdout stays
-# EMPTY and the caller's `.` fails loudly — hold the PR as §CP.
+# (§ZS / ADR 0092; #4216, #4231, #4010, #4219). Under ADR 0232 stdout carries the answer directly, so
+# there is no run-state handle left to fail to open — the sentinel now reaches the caller on EVERY
+# path, including the one where the §SP namespace itself is unavailable.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -25,27 +30,21 @@ set -uo pipefail
 # shellcheck source=../../shared/scripts/cp-read.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/cp-read.sh"
 
-SENTINEL="<§CP classifier could not run — §CP UNKNOWN, held as control-plane>"
-HANDLE=""
+# ASCII punctuation in every EMITTED string below, deliberately: bash 3.2's `printf %q` escapes a
+# 3-byte UTF-8 sequence half-raw, which round-tripped through a `.` but renders as mojibake on the
+# stdout an agent now READS. `§` is 2-byte and survives, so the canonical §CP term stays.
+SENTINEL="<§CP classifier could not run - §CP UNKNOWN, held as control-plane>"
 # emit_and_exit <status> <control-plane-touched> <guard-touching> <cp-files-n> <adr-n>
+# The ONLY writer of this script's stdout, so every exit — success, usage error, blinded read —
+# leaves the caller a readable flag pair rather than 0 bytes it would have to interpret.
 emit_and_exit() {
-  if [ -n "$HANDLE" ]; then
-    {
-      printf 'CONTROL_PLANE_TOUCHED=%q\n' "$2"
-      printf 'GUARD_TOUCHING=%q\n' "$3"
-      printf 'CP_FILES_N=%s\n' "$4"
-      printf 'ADR_N=%s\n' "$5"
-    } > "$HANDLE"
-    printf '%s\n' "$HANDLE"
-  else
-    echo "classify-control-plane.sh: could not open the per-run handle — no §CP answer was produced. Hold the PR as CONTROL PLANE." >&2
-  fi
+  printf 'CONTROL_PLANE_TOUCHED=%q\n' "$2"
+  printf 'GUARD_TOUCHING=%q\n' "$3"
+  printf 'CP_FILES_N=%s\n' "$4"
+  printf 'ADR_N=%s\n' "$5"
   exit "$1"
 }
 
-# Open the handle BEFORE the argument check, so even a usage error reaches the caller as the §CP
-# sentinel IN THE HANDLE rather than as 0 bytes on stdout.
-HANDLE="$(kp_scratch_open review-doc-cp)/cp.env" || HANDLE=""
 [ "$#" -ge 1 ] || { echo "usage: classify-control-plane.sh <pr>" >&2; emit_and_exit 2 "$SENTINEL" "$SENTINEL" 0 0; }
 PR="$1"
 # Top-level assignment, never `local` — `local REPO="$(kp_repo)"` masks the substitution's status,
@@ -80,7 +79,7 @@ fi
 CP_READ_FAILED=
 if ! cp_changed_files "$REPO" "$PR"; then
   CP_READ_FAILED=1   # carried into the CONTENT clause below — one read, both clauses
-  CONTROL_PLANE_TOUCHED="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"   # FAIL CLOSED
+  CONTROL_PLANE_TOUCHED="<changed-file list unreadable - §CP UNKNOWN, held as control-plane>"   # FAIL CLOSED
 else
   # grep aggregates the §CP matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER
   # PAGE. `|| true` now means ONLY what it says: no match is grep exit 1 over a list PROVEN to
@@ -99,14 +98,14 @@ fi
 GUARD_TOUCHING=""
 ADR_N=0
 if [ -n "$CP_READ_FAILED" ]; then
-  GUARD_TOUCHING="<changed-file list unreadable — §CP UNKNOWN, held as control-plane>"
+  GUARD_TOUCHING="<changed-file list unreadable - §CP UNKNOWN, held as control-plane>"
   emit_and_exit 1 "$CONTROL_PLANE_TOUCHED" "$GUARD_TOUCHING" "${CP_FILES_N:-0}" 0
 else
   # The ref is a fallible read too — `cp_head_sha` is §CPREAD's companion to `cp_changed_files`
   # (sourced above from ../../shared/scripts/cp-read.sh). It DISCARDS gh's payload on failure, which
   # is what makes the `[ -n ]` test below a live guard rather than a dead one.
   cp_head_sha "$REPO" "$PR"; HEAD_SHA="$CP_HEAD_SHA"
-  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable — ADR content unprobeable, held as control-plane>"
+  [ -n "$HEAD_SHA" ] || GUARD_TOUCHING="<head SHA unreadable - ADR content unprobeable, held as control-plane>"
   while IFS= read -r adr; do
     [ -z "$adr" ] && continue
     [ -n "$HEAD_SHA" ] || break
@@ -114,7 +113,7 @@ else
     # Capture and CHECK before classifying, never a straight pipe — §CPREAD #2.
     adr_body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null)" || adr_body=""
     if [ -z "$adr_body" ]; then
-      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable⇒§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
+      GUARD_TOUCHING="$GUARD_TOUCHING $adr(body-unreadable=>§CP)"   # never auto-ship an ADR that couldn't be read and proven guard-free
     else
       GC_STATE="$(printf '%s' "$adr_body" | "$PCLI" guard-content-probe classify --path "$adr" 2>/dev/null)"
       case "$GC_STATE" in

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# Print the absolute path of the run-state handle `materialize-head.sh` wrote (PR_REF / HEAD_SHA,
-# and REVIEW_WT if `--worktree` was used), so any later step re-derives it with
-# `. "$(head-env.sh "$PR")"` after the harness resets the shell between Bash calls. Extracted from
-# review-doc/SKILL.md's repeated re-source line (#4453, epic #4435 phase 1). Extraction contract:
-# ../SKILL.md § The extracted scripts.
+# Re-emit the head values `materialize-head.sh` resolved (PR_REF / HEAD_SHA, and REVIEW_WT if
+# `--worktree` was used), so any later step recovers them after the harness resets the shell between
+# Bash calls. Extracted from review-doc/SKILL.md's repeated re-source line (#4453, epic #4435 phase
+# 1). Extraction contract: ../SKILL.md § The extracted scripts.
 #
-# `scratchpad file` REFUSES when the namespace was never opened in this run, so a lost handle fails
-# loud instead of silently reading an empty directory — and this script exits non-zero with EMPTY
-# stdout on that path, so a caller's `.` fails loudly rather than falling back to the launched
-# checkout's working copy (§HEAD, #793).
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh <pr>
+#
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — the same `KEY=value`
+# lines materialize-head.sh printed, read back from this run's §SP handle. `scratchpad file` REFUSES
+# when the namespace was never opened in this run, and an empty handle is refused too, so a lost
+# handle exits non-zero with EMPTY stdout. Read the exit status BEFORE the stdout: no answer is
+# UNKNOWN, never a licence to fall back to the launched checkout's working copy (§HEAD, #793).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -20,4 +22,4 @@ PCLI="$(kp_pcli)" || exit 127
 
 HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
 [ -s "$HEAD_ENV" ] || { echo "review-doc: §SP — head.env absent/empty; re-run the materialize step in THIS session." >&2; exit 1; }
-printf '%s\n' "$HEAD_ENV"   # source it for $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)
+cat "$HEAD_ENV"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh
@@ -4,11 +4,17 @@
 # Extracted from review-doc/SKILL.md (#4453, epic #4435 phase 1). Extraction contract +
 # shell-option rationale: ../SKILL.md § The extracted scripts.
 #
-# STDOUT IS A MACHINE CHANNEL: the ONLY stdout line is the absolute path of the run-state handle
-# carrying PR_REF / HEAD_SHA (and REVIEW_WT under `--worktree`), so the caller can
-# `. "$(materialize-head.sh "$PR")"`. Diagnostics go to stderr. On ANY failure path stdout stays
-# EMPTY and the exit is non-zero — the caller's `.` then fails loudly rather than sourcing a
-# half-written handle and reviewing the launched checkout's BASE tree (#793, the false-PASS hazard).
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-doc/scripts/materialize-head.sh <pr> [--worktree]
+#
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — one `KEY=value` line per
+# resolved value: PR_REF / HEAD_SHA, plus REVIEW_WT under `--worktree`. Diagnostics go to stderr. On
+# ANY failure path stdout stays EMPTY and the exit is non-zero — read the exit status BEFORE the
+# stdout, because a materialization that could not run is UNKNOWN and must never fall back to the
+# launched checkout's BASE tree (#793, the false-PASS hazard).
+#
+# The same values also persist to this run's §SP handle, which this skill's OWN later scripts
+# re-source in-process via head-env.sh. In-script sourcing stays sanctioned under ADR 0232; only the
+# `.` at an agent's top-level command is banned.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -53,5 +59,8 @@ if [ "$MODE" = "--worktree" ] && [ -z "${REVIEW_WT:-}" ]; then
   echo "FATAL: --worktree was asked for but no worktree came back — aborting (§HEAD)." >&2; exit 1
 fi
 
-# The handle path — the ONLY stdout line, so the caller can `. "$(materialize-head.sh "$PR")"`.
-printf '%s\n' "$HEAD_ENV"
+# THE ANSWER — the resolved values, one KEY=value line each, and the only stdout this script writes.
+# Printed from the variables the handle read back above, so what the caller reads and what the later
+# steps re-source through head-env.sh are the same values by construction.
+[ -n "${REVIEW_WT:-}" ] && printf 'REVIEW_WT=%s\n' "$REVIEW_WT"
+printf 'PR_REF=%s\nHEAD_SHA=%s\n' "$PR_REF" "$HEAD_SHA"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
@@ -18,13 +18,15 @@ set -uo pipefail
 [ "$#" -ge 1 ] || { echo "usage: teardown-head.sh <pr>" >&2; exit 2; }
 PR="$1"
 
+# head-env.sh's STDOUT is the answer (ADR 0232) — the same KEY=value lines the agent reads — so bind
+# them here rather than sourcing a handle path. Capture and CHECK first: `eval` of an empty capture
+# returns 0, which would read a lost handle as a successful bind.
 # shellcheck disable=SC1007
-HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
+HEAD_ENV_LINES="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
   echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
   exit 0
 }
-# shellcheck disable=SC1090
-. "$HANDLE"
+eval "$HEAD_ENV_LINES"
 [ -n "${PR_REF:-}" ] || {
   echo "teardown-head.sh: handle carries no PR_REF — refusing to guess what to remove (no-op)." >&2
   exit 0

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -59,7 +59,7 @@ if set, else the current repository. In phoenix this defaults to `kamp-us/phoeni
 behavior is unchanged with no config (ADR 0062 §1).
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/review-plan/scripts/resolve-repo.sh)" || exit 1
 ```
 
 Every script under [`scripts/`](scripts/) resolves the repo the same way through the shared lib's
@@ -157,7 +157,7 @@ in-repo first, published fallback (ADR 0064) — then branch on its exit status:
 # exit 0 = lock WON (prints `epic-lock: won #<EPIC>`) → gate/loop, then RELEASE on every exit path.
 # 3 = backed off (held lock / setup gap / lost race — not a review-plan failure, re-run later);
 # 127 = the shim never ran (UNKNOWN). NEVER flip or loop on a non-zero.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/epic-lock-acquire.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/review-plan/scripts/epic-lock-acquire.sh <EPIC>
 ```
 
 **Release is an explicit agent step, not a shell `trap … EXIT`.** The acquire above runs in
@@ -171,7 +171,7 @@ you reach **any** terminal state (PASS-and-flipped, parked, or a fault mid-fligh
 ```bash
 # A non-zero exit means the release did NOT complete — the lock is LEAKED and the epic is wedged.
 # Surface it loudly; never swallow it.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/epic-lock-release.sh" <EPIC>
+bash ./claude-plugins/kampus-pipeline/skills/review-plan/scripts/epic-lock-release.sh <EPIC>
 ```
 
 The release fires on **every** terminal path on purpose: the gate and the convergence loop can
@@ -232,7 +232,7 @@ once into a `$GATE` command and use it everywhere below, so there is exactly one
 ```bash
 # for your own ad-hoc `$GATE …` reads; `run-gate.sh` resolves the shim through the same one
 # primitive, so there is still exactly one resolution mechanism. Exit 127 ⇒ no gate command at all.
-GATE="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/resolve-gate.sh")" || exit 127
+GATE="$(bash ./claude-plugins/kampus-pipeline/skills/review-plan/scripts/resolve-gate.sh)" || exit 127
 ```
 
 The shim yields a runnable `$GATE`, so a foreign install **runs** the gate rather than
@@ -242,8 +242,8 @@ Then run the gate:
 
 ```bash
 # from the repo root. Exit status + stdout are the gate's own, relayed; 127 = no verdict at all.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/run-gate.sh" <EPIC>            # the live gate — flips + comments
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/review-plan/scripts/run-gate.sh" <EPIC> --dry-run  # read-only: validate + print, no mutation
+bash ./claude-plugins/kampus-pipeline/skills/review-plan/scripts/run-gate.sh <EPIC>            # the live gate — flips + comments
+bash ./claude-plugins/kampus-pipeline/skills/review-plan/scripts/run-gate.sh <EPIC> --dry-run  # read-only: validate + print, no mutation
 ```
 
 `runGate(<EPIC>)` is the underlying action the CLI calls (`epic-ledger`'s `runGate`,

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -67,11 +67,18 @@ reviewing (below), read all skill text from the head, and re-check the live head
 (§HEAD #4); the verdict (§VERDICT) binds to the SHA whose files you actually read and asserts it.
 
 ```bash
-# Prints ONE line — the absolute path of this run's handle, carrying REVIEW_WT / PR_REF / HEAD_SHA /
-# BASE_REF. Every FATAL line goes to stderr; on any failure stdout is EMPTY, so this `.` fails loudly
-# rather than sourcing a half-written handle and reviewing the base tree (#793).
-. "$(bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh "$PR" || exit 1
 ```
+
+**Executed, not sourced, and stdout is the answer** (ADR
+[0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md),
+[`.patterns/skill-script-io-contract.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/skill-script-io-contract.md)).
+It prints four `KEY=value` lines — `REVIEW_WT`, `PR_REF`, `HEAD_SHA`, `BASE_REF` — and every FATAL
+line goes to stderr. **Read those four values off stdout and carry them forward yourself**; every
+`$REVIEW_WT` / `$PR_REF` / `$HEAD_SHA` / `$BASE_REF` below names the value you read here, not a
+variable that survives into the next Bash call. **Read the exit status before the stdout:** on any
+failure path stdout is empty and the exit is non-zero, and that is UNKNOWN — never fall back to
+reviewing the base tree (#793).
 
 The script fetches the trusted base, drives §HEAD steps 1–3 through the shared
 `pipeline-cli review-head materialize` verb, and then enforces + asserts the instruction denylist.
@@ -83,8 +90,8 @@ Two properties of it are load-bearing and stated here rather than left to the fi
   detach the human's `main` — #2270/#1103; §RO), and it internally aborts on a fetched-ref ≠
   resolved-head mismatch (§HEAD #2) so you never review a different SHA than the verdict claims.
 - **The handle is the §SP per-run scratchpad namespace, not a `mktemp`** (#3718). A shell variable is
-  lost across the harness's between-call reset, so each later step re-derives the handle with
-  [`scripts/head-env.sh`](scripts/head-env.sh) — **never** from a shared leaf name, which under a
+  lost across the harness's between-call reset, so each later step re-reads the four values by
+  running [`scripts/head-env.sh`](scripts/head-env.sh) — **never** from a shared leaf name, which under a
   parallel fan-out matches a SIBLING reviewer's tree and reads the wrong head's skill text (#1807).
   §SP rules 2+3 apply because the handle is a CROSS-CALL carrier, not the rule-4 allocate-and-consume
   carve-out; the path is a deterministic function of this run's session id, which is what makes it
@@ -335,16 +342,20 @@ bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/pr-diff.sh "$P
 For checks that need the file in context (a trigger phrase, a cross-skill reference, the full
 shape of a step you're judging), read the changed skill at the PR head **from the isolated
 review worktree** (`$REVIEW_WT/skills/...`) the config-pin step set up — never by checking the
-head out into your session tree. Because the harness resets the shell between Bash calls,
-re-source the run-unique handle at the start of any later step that references `$REVIEW_WT`,
-never re-deriving it from the shared `review-skill-head-${PR}` leaf — under a parallel fan-out
-that leaf name also matches a sibling's worktree (#1807). `$WT_FILE` is itself a lost shell
-variable by then, so recompute its path from the same §SP recipe first — that is exactly why
-the namespace is session-derived rather than `mktemp`-allocated:
+head out into your session tree. Because the harness resets the shell between Bash calls, re-read
+the run-unique values at the start of any later step that references `$REVIEW_WT`, never
+re-deriving them from the shared `review-skill-head-${PR}` leaf — under a parallel fan-out that
+leaf name also matches a sibling's worktree (#1807). The script recomputes the namespace path from
+the same §SP recipe and prints the four `KEY=value` lines on stdout; that is exactly why the
+namespace is session-derived rather than `mktemp`-allocated:
 
 ```bash
-. "$(bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh "$PR")"
+bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh "$PR" || exit 1
 ```
+
+A non-zero exit with empty stdout is UNKNOWN — re-run the materialize step in this session rather
+than reading the base tree. Bind any value you need in a later block by **literal assignment inside
+that block** (`REVIEW_WT="<the path head-env.sh printed>"`), never by sourcing.
 
 ### Fetch the base fresh before any "is-it-shipped on main" check
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
-# Print the absolute path of the run-state handle `materialize-head.sh` wrote (REVIEW_WT / PR_REF /
-# HEAD_SHA / BASE_REF), so any later step re-derives it with `. "$(head-env.sh "$PR")"` after the
-# harness resets the shell between Bash calls. Extracted from review-skill/SKILL.md's repeated
-# re-source line (#4453, epic #4435 phase 1). Extraction contract: ../SKILL.md § The extracted scripts.
+# Re-emit the four head values `materialize-head.sh` resolved (REVIEW_WT / PR_REF / HEAD_SHA /
+# BASE_REF), so any later step recovers them after the harness resets the shell between Bash calls.
+# Extracted from review-skill/SKILL.md's repeated re-source line (#4453, epic #4435 phase 1).
+# Extraction contract: ../SKILL.md § The extracted scripts.
+#
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh <pr>
+#
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — the same `KEY=value`
+# lines materialize-head.sh printed, read back from this run's §SP handle.
 #
 # The namespace is per-run and per-session (§SP, #3718), which is what keeps a SIBLING reviewer's
 # tree out of reach — the failure a `git worktree list` re-derivation on the shared
 # `review-skill-head-${PR}` leaf walks straight into, pinning the wrong head's skill text (#1807).
-# Exits non-zero with EMPTY stdout when the namespace was never opened, so a caller's `.` fails
-# loudly instead of silently reading the base tree.
+# Exits non-zero with EMPTY stdout when the namespace was never opened: read the exit status BEFORE
+# the stdout, because no answer is UNKNOWN, never a licence to read the base tree.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -21,4 +26,4 @@ DIR="$(kp_scratch_path "review-skill-head-$PR")" || exit 1
   echo "review-skill: §SP — $DIR/wt.env missing; re-run the head-materialization step in THIS session. NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
   exit 1
 }
-printf '%s\n' "$DIR/wt.env"
+cat "$DIR/wt.env"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh
@@ -4,12 +4,17 @@
 # #4435 phase 1). Extraction contract + shell-option rationale: ../SKILL.md § The extracted scripts.
 # The *why* for every step stays in that step's prose.
 #
-# STDOUT IS A MACHINE CHANNEL: the ONLY thing this writes to stdout is the absolute path of the
-# run-state handle carrying REVIEW_WT / PR_REF / HEAD_SHA / BASE_REF, so the caller can
-# `. "$(materialize-head.sh "$PR")"`. Every progress and FATAL line goes to stderr. On ANY failure
-# path stdout stays EMPTY and the exit is non-zero — the caller's `.` then fails loudly rather than
-# sourcing a half-written handle. A materialization that could not run is UNKNOWN, and reviewing the
-# BASE tree is the #793 false-PASS hazard (§ZS / ADR 0092).
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-skill/scripts/materialize-head.sh <pr>
+#
+# STDOUT IS THE ANSWER (ADR 0232, .patterns/skill-script-io-contract.md) — four `KEY=value` lines:
+# REVIEW_WT / PR_REF / HEAD_SHA / BASE_REF. Every progress and FATAL line goes to stderr. On ANY
+# failure path stdout stays EMPTY and the exit is non-zero — read the exit status BEFORE the stdout,
+# because a materialization that could not run is UNKNOWN, and reviewing the BASE tree is the #793
+# false-PASS hazard (§ZS / ADR 0092).
+#
+# The same four values also persist to this run's §SP handle, which this skill's OWN later scripts
+# re-source in-process via head-env.sh. In-script sourcing stays sanctioned under ADR 0232; only the
+# `.` at an agent's top-level command is banned.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -33,7 +38,7 @@ git fetch origin "$BASE_REF" >&2
 # #2270/#1103; §RO), and it internally aborts on a fetched-ref ≠ resolved-head mismatch (§HEAD #2)
 # so you never review a different SHA than the verdict claims. Persist its emitted head/ref/worktree
 # to the per-run handle so they survive the harness cwd/shell reset between Bash calls (a shell
-# var is lost across calls); re-derive them with `. "$(head-env.sh "$PR")"` at each later step —
+# var is lost across calls); re-derive them by RUNNING head-env.sh at each later step —
 # NEVER from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's
 # tree and reads the wrong head's skill text — the #1807 collision). This is the §SP per-run
 # scratchpad namespace (gh-issue-intake-formats.md): a PR number is not unique, and a clobbered file
@@ -63,5 +68,7 @@ for p in CLAUDE.md .claude .decisions .patterns; do
   fi
 done
 
-# The handle path — the ONLY stdout line, so the caller can `. "$(materialize-head.sh "$PR")"`.
-printf '%s\n' "$WT_FILE"
+# THE ANSWER — the four resolved values, one KEY=value line each, and the only stdout this script
+# writes. Printed from the variables the handle read back above, so what the caller reads and what
+# the later steps re-source through head-env.sh are the same four values by construction.
+printf 'REVIEW_WT=%s\nPR_REF=%s\nHEAD_SHA=%s\nBASE_REF=%s\n' "$REVIEW_WT" "$PR_REF" "$HEAD_SHA" "$BASE_REF"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
@@ -14,13 +14,15 @@ set -uo pipefail
 [ "$#" -ge 1 ] || { echo "usage: teardown-head.sh <pr>" >&2; exit 2; }
 PR="$1"
 
+# head-env.sh's STDOUT is the answer (ADR 0232) — the same KEY=value lines the agent reads — so bind
+# them here rather than sourcing a handle path. Capture and CHECK first: `eval` of an empty capture
+# returns 0, which would read a lost handle as a successful bind.
 # shellcheck disable=SC1007
-HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
+HEAD_ENV_LINES="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
   echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
   exit 0
 }
-# shellcheck disable=SC1090
-. "$HANDLE"
+eval "$HEAD_ENV_LINES"
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] || {
   echo "teardown-head.sh: handle carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\` (no-op)." >&2
   exit 0

--- a/claude-plugins/kampus-pipeline/skills/taste-library-conventions.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-library-conventions.md
@@ -82,7 +82,7 @@ raise it as a scope decision. Verify before opening the PR:
 
 ```bash
 # proven-ordinary ⇒ exit 3. control-plane ⇒ exit 0 ⇒ something under your diff is owned; find it.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/shared/scripts/cp-classify-working-diff.sh"
+bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/cp-classify-working-diff.sh
 ```
 
 ## 4. The SKILL.md / STANDARDS.md split

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -44,7 +44,7 @@ resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), 
 defaulting to `kamp-us/phoenix` with no config:
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/resolve-repo.sh)" || exit 1
 ```
 
 Every script under [`scripts/`](scripts/) resolves the repo the same way through the shared lib's
@@ -54,7 +54,7 @@ reads.
 List the queue:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/list-queue.sh"
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/list-queue.sh
 ```
 
 ## The extracted scripts
@@ -110,7 +110,7 @@ lock; the protocol below is detect-and-tiebreak, **not** mutual exclusion. Run i
 # exit 0 = claim WON and confirmed → triage #N, then release in Step 6.
 # non-zero = backed off (3: already claimed, or lost the tiebreak) or could not run (1) —
 # either way, do NOT triage #N. The script's own header states the full exit-code contract.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/claim-issue.sh" <N> || continue
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/claim-issue.sh <N> || continue
 ```
 
 **You MUST release the claim when you finish triaging** (Step 6) — triage's claim is a
@@ -142,7 +142,7 @@ point** for the human path: a UI/hand-filed issue never ran `report`'s pre-file 
 keywords, excluding itself so it never flags itself:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/dedup-check.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/dedup-check.sh \
   "<this issue's title + a few distinguishing keywords>" <N>
 ```
 
@@ -245,8 +245,8 @@ How to split:
    new unit's title + keywords:
 
    ```bash
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+   # §CLI — bind the shim by LITERAL assignment, run from the repo root (ADR 0207; #3314).
+   PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
    "$PCLI" intake-dedup check \
      --query "<the new unit's title + a few distinguishing keywords>"
    ```
@@ -270,8 +270,8 @@ How to split:
    body byte-equality, so a twin re-emitted with a slightly different body is still caught:
 
    ```bash
-   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
-   PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
+   # §CLI — bind the shim by LITERAL assignment, run from the repo root (ADR 0207; #3314).
+   PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
    EXISTING=$("$PCLI" split-guard check \
      --parent <original #N> --title "<the split-child title>")
    ```
@@ -304,7 +304,7 @@ How to split:
 # The script runs the create-once guard first and only files when no child covers the unit; the
 # body arrives as a FILE because it is multi-line markdown and MUST carry `split from #<N>`, the
 # guard's create-once key. Cross-link via a comment on the original afterwards (Step 6).
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/split-child.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/split-child.sh \
   <N> "<single-unit title>" "<path/to/child-body.md>"
 ```
 
@@ -390,7 +390,7 @@ body**, so triage would silently preserve the wrong original inside `<details>` 
 ```bash
 # Prints the §SP scratch dir; writes original.md and original.redacted.md into it. Assemble the
 # <details> block from the REDACTED original, never the raw one.
-RUN_SCRATCH="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/fetch-original.sh" <N>)" || exit 1
+RUN_SCRATCH="$(bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/fetch-original.sh <N>)" || exit 1
 ```
 
 Assemble the new body in a temp file — under `$RUN_SCRATCH` for the same reason — and read it
@@ -398,7 +398,7 @@ into `$BODY` so multi-line markdown, backticks, and the nested fences survive th
 
 ```bash
 # Re-derives the SAME §SP namespace (non-resetting) and refuses on a missing/empty body.md.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/patch-body.sh" <N>
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/patch-body.sh <N>
 ```
 
 **Epics are the exception — wrap-in-place, never rewrite-on-top.** An epic's original
@@ -612,9 +612,9 @@ the numbers you may assign to:
 
 ```bash
 # the home candidates: the arc/campaign rows and the open milestones they pin to
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/list-open-milestones.sh"
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/list-open-milestones.sh
 # assign — one single-field, last-write-wins PATCH (benign, #91); by NUMBER, never title
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/assign-milestone.sh" <N> <n>
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/assign-milestone.sh <N> <n>
 ```
 
 - **Existing open milestones only — triage NEVER creates one.** Match against the set that
@@ -703,7 +703,7 @@ approval "on his behalf," and do not treat your own draft as approved.
 issue you just drafted, so a red names *this* issue rather than the whole backlog:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/pitch-guard.sh" <N>   # out-of-scope issues pass; a red is this draft
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/pitch-guard.sh <N>   # out-of-scope issues pass; a red is this draft
 ```
 
 An **unapproved** pitch is a legitimate, expected state for a freshly-triaged issue — the guard
@@ -725,7 +725,7 @@ queue (its `status:needs-triage` removed). Apply the whole transition with the `
 verb — the classification is the parameter, the label plumbing is the verb's:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/apply-triage.sh" <N> <type> <priority>
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/apply-triage.sh <N> <type> <priority>
 ```
 
 The verb adds the `type:` / priority / `status:triaged` labels and drops the queue label
@@ -747,8 +747,8 @@ this confirms the pair landed rather than racing it; the invariant is enforced a
 not re-swept by hand later:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/homing-guard.sh" <N>   # the issue you just triaged
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/homing-guard.sh"       # the whole open triaged backlog
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/homing-guard.sh <N>   # the issue you just triaged
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/homing-guard.sh       # the whole open triaged backlog
 ```
 
 ### Close not-planned (kill, agent issues only)
@@ -774,7 +774,7 @@ consistency: a parked `needs-info` issue or a closed one should carry no stray t
 claim. The DELETE is idempotent — a 404 means it was already unassigned, which is fine.
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/release-claim.sh" <N>
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/release-claim.sh <N>
 ```
 
 (A `closed-by-triage` issue is closed *and* unassigned; a needs-info issue is parked with
@@ -835,7 +835,7 @@ three applies is out of triage's scope (ADR
 
 ```bash
 # open milestones at 100% — 0 open issues, at least one closed (an empty milestone is not "done")
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/completed-milestones.sh"
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/completed-milestones.sh
 ```
 
 Surface the matches in the sweep ledger (Step 5's report-back) as a **flag to the EA** — one

--- a/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
@@ -32,11 +32,11 @@ Every kill is auditable and reversible. Always:
 # step 1 only when closing as a duplicate of #M. Both scripts resolve the SAME §SP per-run scratch
 # namespace through the shared lib's kp_scratch_* seam — an issue number is NOT unique, and a
 # clobbered file reads back cleanly as another run's body, preserving the WRONG original (#3718).
-RUN_SCRATCH="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/fetch-duplicate-body.sh" <N>)" || exit 1
+RUN_SCRATCH="$(bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/fetch-duplicate-body.sh <N>)" || exit 1
 # then wrap $RUN_SCRATCH/dup.md in <details> as $RUN_SCRATCH/dup-comment.md, and:
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/post-duplicate-comment.sh" <N> <M>
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/post-duplicate-comment.sh <N> <M>
 # steps 2-4, every kill:
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/close-not-planned.sh" <N> "<specific reason>."
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/close-not-planned.sh <N> "<specific reason>."
 ```
 
 The scripts live in [`scripts/`](scripts/) alongside the rest of this skill's extracted shell; the
@@ -47,5 +47,5 @@ The maintainer audits all kills with one query, so over-closing is caught and re
 cheaply:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/audit-kills.sh"
+bash ./claude-plugins/kampus-pipeline/skills/triage/scripts/audit-kills.sh
 ```

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -202,7 +202,7 @@ plan-don't-do line, so it enters the pipeline only via emission, never as fog.
    # new map (REST only — the org bans GraphQL for issue ops); prints the map's issue number.
    # The four-section body arrives on stdin from a per-run (§SP) file, because it is multi-line
    # authored markdown; an EMPTY stdin is refused rather than filed as a bodyless map.
-   MAP="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/wayfinder/scripts/create-map.sh" \
+   MAP="$(bash ./claude-plugins/kampus-pipeline/skills/wayfinder/scripts/create-map.sh \
      "<destination, as a short noun phrase>" < "<path/to/map-body.md>")" || exit 1
    ```
 
@@ -242,7 +242,7 @@ plan-don't-do line, so it enters the pipeline only via emission, never as fog.
    ```bash
    # files the ticket and links it under $MAP in one act; prints the child's issue number. The body
    # (what's unknown, and what an answer would unblock) arrives on stdin; an empty stdin is refused.
-   "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/wayfinder/scripts/add-frontier-ticket.sh" \
+   bash ./claude-plugins/kampus-pipeline/skills/wayfinder/scripts/add-frontier-ticket.sh \
      "$MAP" "Investigation: <the open question>" type:investigation < "<path/to/ticket-body.md>"
    ```
 
@@ -508,7 +508,7 @@ the SAME `status:needs-triage` entry `report` uses — literally the same script
 drift from the report skill's:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/report/scripts/file-report.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/report/scripts/file-report.sh \
   "<the epic, as one concrete deliverable>" <<'EOF'
 ## Destination
 <the epic's end-state, from the map's ## Destination>
@@ -557,7 +557,7 @@ Make the ideation→execution handoff traceable from both ends, then close:
 ```bash
 # Name every artifact the map graduated into (epics and/or ADR and/or roadmap), then close it
 # IFF the destination is FULLY graduated. A partial graduation is annotated but stays open.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/wayfinder/scripts/graduate-map.sh" "$MAP" \
+bash ./claude-plugins/kampus-pipeline/skills/wayfinder/scripts/graduate-map.sh "$MAP" \
   "#$E1, #$E2 → triage → plan-epic → write-code; ADR 0176; ROADMAP.md v1" \
   "Frontier cleared — closing this map as the durable record of how the plan was discovered."
 ```

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
@@ -30,7 +30,7 @@ targets `$REPO`), per the shared contract's target-repo rule
 ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), ADR 0062):
 
 ```bash
-REPO="$("${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/resolve-repo.sh")" || exit 1
+REPO="$(bash ./claude-plugins/kampus-pipeline/skills/what-shipped/scripts/resolve-repo.sh)" || exit 1
 ```
 
 ## The extracted scripts
@@ -61,7 +61,7 @@ dates the digest heading reports over:
 
 ```bash
 # prints `<since> <until>`; $SINCE / $UNTIL in the environment override either end
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/window.sh"
+bash ./claude-plugins/kampus-pipeline/skills/what-shipped/scripts/window.sh
 ```
 
 Read the two dates off that output and pass them explicitly to the calls below. No shell variable
@@ -82,7 +82,7 @@ Read merged PRs via `gh api` REST (never GraphQL). The `search/issues` endpoint 
 
 ```bash
 # merged PRs in the window — REST search, never GraphQL. `is:merged` + `merged:<since>..<until>`.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/merged-prs.sh" "$SINCE" "$UNTIL"
+bash ./claude-plugins/kampus-pipeline/skills/what-shipped/scripts/merged-prs.sh "$SINCE" "$UNTIL"
 ```
 
 If you prefer to anchor on the merge commits rather than trust the search index, cross-check with
@@ -95,7 +95,7 @@ For each merged PR number, read the fields the entry needs:
 ```bash
 # per merged PR: title, its `area:*` label (join-free product/infra signal, #1598), and the
 # linked issue via the `Fixes #N` / `Closes #N` in the PR body.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/pr-context.sh" "$PR"
+bash ./claude-plugins/kampus-pipeline/skills/what-shipped/scripts/pr-context.sh "$PR"
 ```
 
 - **`title`** → the entry's `title` (prefer the linked-issue title once resolved in Step 2).
@@ -113,7 +113,7 @@ issue, then read that issue's metadata:
 
 ```bash
 # the linked issue's title, milestone, and type:* — the entry's title (preferred), milestone, and type.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/issue-context.sh" "$ISSUE"
+bash ./claude-plugins/kampus-pipeline/skills/what-shipped/scripts/issue-context.sh "$ISSUE"
 ```
 
 Populate each entry from the join:
@@ -150,7 +150,7 @@ serving is truthful — a split-released flag's `defaultVariation` stays `off` f
 ```bash
 # authoritative Flagship state — every flag × env with its enabled/default value (ADR 0081/0123).
 # in-repo-first, published-fallback.
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/flag-list.sh"
+bash ./claude-plugins/kampus-pipeline/skills/what-shipped/scripts/flag-list.sh
 ```
 
 Assign each merged entry a **`releaseState`** — one of `live` / `awaiting-release` / `dark` /
@@ -206,7 +206,7 @@ artifact), then invoke:
 
 ```bash
 # … having written the gathered array to a per-run JSON file (§SP) …
-"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/what-shipped/scripts/derive-digest.sh" \
+bash ./claude-plugins/kampus-pipeline/skills/what-shipped/scripts/derive-digest.sh \
   "<entries.json>" "$SINCE" "$UNTIL"
 ```
 


### PR DESCRIPTION
Pipeline skills used to name their helper scripts through an interpolated `CLAUDE_PLUGIN_ROOT` variable, and a few steps still pulled results into the agent's shell by sourcing a generated env file. The harness refuses both shapes at an agent's top-level command, so those steps could not run as written. This sweeps the remaining 17 skill markdown files onto the literal-path form ADR 0232 mandates, and converts the last sourcing fences so their scripts print results on stdout instead.

One idiom in, one idiom out. The diff is large in line count and uniform in shape: 120 mechanical replacements plus seven script files whose emit contract changed.

Fixes #4575

## What changed

**1. The interpolated idiom → the literal path (120 occurrences, 17 files).**

`"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/…/x.sh"` becomes `bash ./claude-plugins/kampus-pipeline/skills/…/x.sh`. The two `PCLI=` **assignment** fences in `triage/SKILL.md` and the two `bin/pipeline-cli` sites in `adr/SKILL.md` are in scope too — AC1 is position-blind, so assignment and sourcing count, not merely invocation form (#4595). Each is now the §CLI canonical preamble, a literal assignment inside the same block:

```bash
# §CLI — bind the shim by LITERAL assignment, run from the repo root.
PCLI="./claude-plugins/kampus-pipeline/bin/pipeline-cli"
```

Per file: `triage/SKILL.md` 17, `plan-epic/SKILL.md` 17, `review-design/SKILL.md` 14, `release/SKILL.md` 12, `campaign/SKILL.md` 9, `heal-ci/SKILL.md` 8, `what-shipped/SKILL.md` 7, `review-plan/SKILL.md` 6, `architecture-audit/SKILL.md` 5, `wayfinder/SKILL.md` 4, `triage/close-not-planned.md` 4, `report/SKILL.md` 4, `canon/SKILL.md` 4, `adr/SKILL.md` 4, `glossary/SKILL.md` 3, `taste-library-conventions.md` 1, `author-skill/SKILL.md` 1.

**2. The last top-level sourcing fences → executed, stdout is the answer.**

Five fences in `review-doc/SKILL.md` and two in `review-skill/SKILL.md` sourced a script whose stdout was a *path* to a generated env file. Their emitting scripts now print the `KEY=value` lines directly, in the shape the already-converted `review-code` sibling uses:

- `review-doc/scripts/classify-control-plane.sh` — prints `CONTROL_PLANE_TOUCHED` / `GUARD_TOUCHING` (`printf '%q'`-quoted) plus `CP_FILES_N` / `ADR_N`.
- `review-doc/scripts/materialize-head.sh` — prints `PR_REF` / `HEAD_SHA`, plus `REVIEW_WT` under `--worktree`.
- `review-doc/scripts/head-env.sh`, `review-skill/scripts/head-env.sh` — re-emit the same lines from this run's §SP handle.
- `review-skill/scripts/materialize-head.sh` — prints `REVIEW_WT` / `PR_REF` / `HEAD_SHA` / `BASE_REF`.
- Both `teardown-head.sh` — the in-script consumers, now binding `head-env.sh`'s stdout instead of sourcing a handle path.

**Fail-closed semantics are preserved, and in one place strengthened.** Every failure path still exits non-zero with empty stdout, and every prose block still says *read the exit status before the stdout* — an absent answer is UNKNOWN, never the permissive branch (§ZS / ADR 0092). `classify-control-plane.sh` keeps its rule that every exit prints the §CP sentinel *first*, so a classifier that could not run reaches the caller as a hold rather than as an empty (= non-blocking) flag. That property is now **stronger**: with the answer on stdout there is no run-state handle left to fail to open, so the sentinel reaches the caller even when the §SP namespace itself is unavailable — previously that path emitted 0 bytes. `teardown-head.sh` captures and checks before `eval`, because `eval` of an empty capture returns 0 and would read a lost handle as a successful bind.

The §SP handle files are still written; this skill's own scripts source them in-process, which ADR 0232 leaves sanctioned — only the `.` at an agent's top-level command is banned.

## Verification (observed, at head `9b494a5`)

**Position-blind grep, before and after.** Across the 17 swept markdown files:

```bash
grep -rn "CLAUDE_PLUGIN_ROOT" claude-plugins/kampus-pipeline/skills --include="*.md" -c | sort -t: -k2 -rn
```

Before: 120 occurrences across 17 files. After: **0** in every swept file. The only remaining occurrences in the corpus are the four out-of-scope sibling-lane surfaces (`write-code/SKILL.md` 1, `write-code/repair.md` 2, `ship-it/SKILL.md` 1, `gh-issue-intake-formats.md` 1). No fence in a swept file resolves a path through `${…:-…}` or `$(…)`.

**AC3 — every literal-path target resolves (reviewer-runnable, from the repo root).** "Runnable" is what `bash ./x.sh` actually needs: the target must exist, be readable, and parse under bash. The exec bit is not consulted on that path, so it is reported as information, never as a pass condition.

```bash
set -uo pipefail
TARGETS="$(grep -rhoE 'bash \./claude-plugins/[A-Za-z0-9._/-]+\.sh' \
  claude-plugins/kampus-pipeline/skills --include='*.md' \
  | sed 's|^bash \./||' | sort -u)"
[ -n "$TARGETS" ] || { echo "ZERO scope — refusing."; exit 3; }
N=0; BAD=0; NOEXEC=0
while IFS= read -r p; do
  [ -z "$p" ] && continue
  N=$((N + 1))
  if [ ! -f "$p" ] || [ ! -r "$p" ]; then echo "MISSING   $p"; BAD=$((BAD + 1)); continue; fi
  if ! /bin/bash -n "$p" 2>/dev/null; then echo "PARSEFAIL $p"; BAD=$((BAD + 1)); continue; fi
  [ -x "$p" ] || NOEXEC=$((NOEXEC + 1))
done <<EOF
$TARGETS
EOF
echo "resolve-check: $N target(s) named; $BAD unresolved-or-unparseable; $NOEXEC lack the (unused) exec bit"
[ "$BAD" -eq 0 ] || exit 1
```

Observed: `resolve-check: 205 target(s) named; 0 unresolved-or-unparseable; 69 lack the (unused) exec bit` — exit 0.

**`shellcheck -x` on the seven scripts whose emit contract changed** — exit 0, no findings.

**`/bin/bash -n` on the same seven under bash 3.2.57 (macOS `/bin/bash`), not CI's bash 5** — all parse.

**Validators, as observed:**

- `validate-skills.sh` → `OK — 30 skills valid`
- `validate-cycle-absence.sh` → `OK — 14 checks; cycle-aware skills no-op gracefully with no product-development-cycle.md`
- `validate-cycle-presence.sh` → `OK — 18 checks; phoenix's present cycle-doc path is real`
- `validate-gate-path-drift.sh` → `OK — 34 checks; CONTROL_PLANE_RE copies and symlink agree with §CP / marketplace`
- `trap-status-guard check` (full corpus, as the workflow invokes it) → `scanned 334 file(s), 318 runnable bash/sh fence(s) in markdown, 254 shell file(s) as implicit units` / `clean`
- `gh-phoenix lint-skills` (full corpus) → `clean — no GraphQL-path gh calls, no bare git push in an executable block, and all frontmatter parses as strict YAML`
- `pnpm lint:worktree` → `no biome-handled changed files vs origin/main — nothing to do` (markdown/shell-only diff)

## Deviations

**1. AC3's "executable file" is proven as existence + parse, not as the exec bit.** *Said:* every `bash ./claude-plugins/...` target resolves to an executable file. *Did:* the proof asserts the target exists, is readable, and parses under `/bin/bash -n`, and reports the exec bit separately as information. *Why:* `bash ./x.sh` reads the file and never consults the exec bit, so parse-clean existence is the property the invocation form actually requires. 69 of the 205 targets lack `+x` — all of them pre-existing, in files this lane does not own (`ship-it`, `review-trivial`, `shared/`, `write-code`, and the `review-doc`/`review-skill` script dirs), and none introduced here. *Disposition:* no action needed; chmod-ing files across four sibling lanes' surfaces would be exactly the opportunistic widening this lane is supposed to avoid. For the reviewer to judge whether a separate follow-up should normalize the bit corpus-wide.

**2. Three files in the issue's 20-file scope had already been swept.** *Said:* `heal-ci/SKILL.md` 12 occurrences including its `cp-read.sh` sourcing fence, `review-doc/SKILL.md` 8, `review-skill/SKILL.md` 3, `review-trivial/SKILL.md` 4. *Did:* at branch-cut those counts were 8, 0, 0, 0 — `heal-ci`'s `cp-read` fence and `review-trivial` were already fully converted by the prerequisite lanes (#4571 / the #4453–#4454 extraction remainder), and the `review-doc`/`review-skill` `CLAUDE_PLUGIN_ROOT` occurrences had moved into their extracted scripts. Their remaining sourcing fences were still open and are converted here. *Why:* the enumerated counts were measured at planning time, ahead of the prerequisite lanes closing. *Disposition:* no action needed — the scope is discharged; the census below the counts (zero `CLAUDE_PLUGIN_ROOT`, zero top-level sourcing in every named file) is the real acceptance test.

**3. `adr/SKILL.md`'s prose mention drops its quotes.** *Said:* nothing about prose. *Did:* the inline-code CLI mention in the Rules section became `./claude-plugins/kampus-pipeline/bin/pipeline-cli decisions-index compact` rather than a quoted path, so the prose reads as a command a human can paste. *Why:* the mechanical rewrite left `"./…" decisions-index compact`, which is valid but reads oddly in a sentence. *Disposition:* no action needed.

**4. `review-doc`'s ADR-sweep block splits in two.** *Said:* doc-only fence rewriting with zero behavior change outside the named scripts. *Did:* the Step 4a block that sourced `head-env.sh` and then passed `$PR_REF` to `adr-sweep.sh` in the same fence is now two fences — read the value, then bind it by literal assignment in the block that uses it. *Why:* under ADR 0232 the value arrives on stdout, so a single fence could no longer have `$PR_REF` bound; the row-16 safe shape is a literal assignment inside the same block. *Disposition:* no action needed — the procedure is unchanged, only its fencing.

**5. Emitted sentinel strings in `review-doc/scripts/classify-control-plane.sh` are ASCII-punctuated.** *Said:* the script edits are the stdout conversion. *Did:* the em-dashes and `⇒` inside the four `printf '%q'`-emitted sentinel strings became `-` and `=>`. *Why:* bash 3.2's `printf %q` escapes a 3-byte UTF-8 sequence half-raw, which round-tripped through a `.` but renders as mojibake on the stdout an agent now reads — the same fix the `review-code` sibling already carries, and it only becomes load-bearing once the string is read rather than sourced. `§` is 2-byte and survives, so the canonical §CP term is untouched. *Disposition:* no action needed.

## §CP

Control-plane by path (`claude-plugins/kampus-pipeline/**`, ADR 0227). Advisory review only — this banks for one `@kamp-us/control-plane` approval round. Do not merge or enqueue on a gate PASS alone.
