### PR TITLE
refactor(write-code): convert the last three inline shell sites to executed-class scripts (#4502)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -298,11 +298,7 @@ Milestone shapes the pick in two modes:
   filter and pick from it by the **same** priority-then-age order:
 
   ```bash
-  # explicit milestone drain: same priority spine, scoped to milestone N (REST, never GraphQL)
-  for P in p0 p1 p2; do
-    gh api "repos/$REPO/issues?state=open&milestone=$N&labels=status:triaged,$P&sort=created&direction=asc&per_page=100" \
-      --jq '.[] | select(.assignee == null and (.pull_request | not)) | "#\(.number)\t\(.created_at)\t\(.title)"'
-  done
+  bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-milestone-pool.sh <milestone-number> || exit 1   # stdout IS the milestone-scoped pool — silence is UNKNOWN, never "drained"
   ```
 
   Even here the priority spine wins **inside** the milestone (p0s in the milestone before
@@ -818,8 +814,7 @@ freshly-fetched `FETCH_HEAD` is the only flow that works — don't "fix" it back
 >
 > ```bash
 > WT="$(bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-wt-preflight.sh)" || exit 1
-> BRANCH="$(git -C "$WT" branch --show-current)"   # live from the worktree — the source of truth, re-read at each git op
-> : "${BRANCH:?could not re-derive branch from worktree $WT — refusing to push to a guessed/cached ref}"
+> BRANCH="$(bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-live-branch.sh "$WT")" || exit 1   # stdout IS the branch, live from the worktree — an empty one is a refusal, never a ref to push to
 > ```
 >
 > This is exactly the recovery the reported incident used to self-heal, promoted to the
@@ -1778,8 +1773,7 @@ a **diagnosis** and the *routing* of its findings, not a feature branch:
    # so a mis-attributed number never closes another agent's live issue (the #1404 class).
    bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step3_5-claim-is-mine.sh "<N>" \
      || { echo "refusing to close #<N> — not my claim (Step 3.5)"; exit 1; }
-   gh api repos/$REPO/issues/<N>/comments -f body="$DIAGNOSIS"
-   gh api -X PATCH repos/$REPO/issues/<N> -f state=closed -f state_reason=completed
+   bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/type-investigation-close.sh "<N>" "$DIAGNOSIS" || exit 1
    ```
 
    (`completed`, not `not_planned` — the investigation *did its job*. Reserve

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-milestone-pool.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-milestone-pool.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Step 1's explicit `work milestone N` drain: the candidate pool scoped to one milestone.
+#
+# usage: step1-milestone-pool.sh <milestone-number>
+#
+# stdout IS the pool, one `#N<TAB>created_at<TAB>title` row per candidate, p0 bucket first; an empty
+# pool means the milestone holds no unassigned triaged issue. An absent milestone number or an
+# unresolved repo refuses with NOTHING on stdout (§ZS / ADR 0092) — silence plus a non-zero exit is
+# UNKNOWN, never "this milestone is drained".
+#
+# Executed, never sourced (ADR 0232). `$REPO` and the milestone `$N` used to arrive from the agent's
+# own shell, which does not survive between Bash calls: the repo resolves here through `kp_repo` and
+# the milestone arrives as the one seam. The per-bucket read keeps the moved block's own behaviour (a
+# failed bucket prints nothing and the loop continues) — hardening that into a §ZS refusal is the
+# sibling pool's open follow-up (#4501), not this conversion's (ADR 0228: relay, never derive).
+# shellcheck disable=SC1007,SC1091,SC2016,SC2086
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+N="${1:-}"
+if [ -z "$N" ]; then
+	printf 'write-code Step 1 (milestone drain): no milestone number — run this as `bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-milestone-pool.sh <milestone-number>`. NO pool was listed (UNKNOWN, never an empty pool).\n' >&2
+	exit 1
+fi
+REPO="$(kp_repo)" || {
+	echo "write-code Step 1 (milestone drain): target repo unresolved — NO candidate pool was listed (UNKNOWN, never an empty pool)." >&2
+	exit 1
+}
+
+# explicit milestone drain: same priority spine, scoped to milestone N (REST, never GraphQL)
+for P in p0 p1 p2; do
+	gh api "repos/$REPO/issues?state=open&milestone=$N&labels=status:triaged,$P&sort=created&direction=asc&per_page=100" \
+		--jq '.[] | select(.assignee == null and (.pull_request | not)) | "#\(.number)\t\(.created_at)\t\(.title)"'
+done

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-live-branch.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-live-branch.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# The live branch re-derivation every git op after the Step-4 branch cut runs on.
+#
+# usage: step4-live-branch.sh <worktree-root>     (the root `step4-wt-preflight.sh` just resolved)
+#
+# stdout IS the branch checked out in <worktree-root> — the source of truth, re-read at each git op.
+# An absent root, a root that is not a worktree, or a HEAD that names no branch (detached) refuses
+# with NOTHING on stdout and a non-zero exit: the caller must never push to a guessed or cached ref,
+# so silence here is a refusal, never "no branch" (§ZS / ADR 0092).
+#
+# Executed, never sourced (ADR 0232). This is the enforcement site of the never-carry-the-branch rule
+# — the name is created once at the branch cut and re-derived live from the worktree at every later
+# git op, never persisted to a scratchpad file a concurrent lane can clobber (#2038).
+# shellcheck disable=SC1007,SC2016
+set -uo pipefail
+
+WT="${1:-}"
+if [ -z "$WT" ]; then
+	printf 'write-code: no worktree root — run this as `bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-live-branch.sh "$WT"`, passing the root `step4-wt-preflight.sh` resolved. NO branch was derived; refusing to push to a guessed/cached ref.\n' >&2
+	exit 1
+fi
+BRANCH="$(git -C "$WT" branch --show-current)"
+: "${BRANCH:?could not re-derive branch from worktree $WT — refusing to push to a guessed/cached ref}"
+printf '%s\n' "$BRANCH"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/type-investigation-close.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/type-investigation-close.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# The `type:investigation` residue path's close: post the diagnosis as the closing comment, then
+# close the issue `completed`.
+#
+# usage: type-investigation-close.sh <N> <diagnosis-body>
+#
+# `completed`, not `not_planned` — the investigation DID its job. Reserve `not_planned` for work that
+# won't be done.
+#
+# Both writes are number-targeting mutations, and the Step-3.5 mis-attribution guard stays a separate
+# visible line at the CALL SITE rather than folding in here: a reader of SKILL.md must still see the
+# guard the step mandates, and hiding it inside this script would make the mandate unauditable from
+# the doc. This script therefore assumes an already-green `step3_5-claim-is-mine.sh <N>`.
+#
+# An absent number, an empty diagnosis, or an unresolved repo refuses with NOTHING on stdout and a
+# non-zero exit (§ZS / ADR 0092) — a close with no diagnosis is indistinguishable from a completed
+# investigation, which is exactly the state that must never be reachable by accident.
+#
+# Executed, never sourced (ADR 0232). `$REPO` used to arrive from the agent's own shell and `<N>` was
+# hand-substituted into the fence; both are explicit seams here. The comment POST is deliberately not
+# `|| exit`-gated: that is the moved block's own sequencing, and turning it into a fail-closed gate is
+# a behaviour change this conversion does not own (ADR 0228: relay, never derive).
+# shellcheck disable=SC1007,SC1091,SC2016,SC2086
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+N="${1:-}"
+DIAGNOSIS="${2:-}"
+if [ -z "$N" ] || [ -z "$DIAGNOSIS" ]; then
+	printf 'write-code (type:investigation): need BOTH an issue number and a diagnosis body — run this as `bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/type-investigation-close.sh <N> "$DIAGNOSIS"`. NOTHING was posted and NOTHING was closed.\n' >&2
+	exit 1
+fi
+REPO="$(kp_repo)" || {
+	echo "write-code (type:investigation): target repo unresolved — NOTHING was posted and the issue was NOT closed." >&2
+	exit 1
+}
+
+gh api repos/$REPO/issues/$N/comments -f body="$DIAGNOSIS"
+gh api -X PATCH repos/$REPO/issues/$N -f state=closed -f state_reason=completed

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/verify-fail-closed.sh
@@ -35,12 +35,13 @@ echo "=== 1. §ZS: every seam refuses with a NON-ZERO exit and ZERO stdout bytes
 # its namespace argument is defaulted: the property under test is that a no-argument RUN produces no
 # answer, and it holds there too (its PR seam is required), so excluding it would leave the harness
 # claiming less than its own scope (#4503 review).
-SEAMED="step1-parent-resolve.sh step2-epic-read.sh step3-delegated-claim.sh step3-direct-claim.sh
-        step3_5-claim-is-mine.sh step4-branch.sh step4b-containment.sh step5-acceptance-criteria.sh
+SEAMED="step1-milestone-pool.sh step1-parent-resolve.sh step2-epic-read.sh step3-delegated-claim.sh
+        step3-direct-claim.sh step3_5-claim-is-mine.sh step4-branch.sh step4-live-branch.sh
+        step4b-containment.sh step5-acceptance-criteria.sh
         step5-push.sh step5-seam-checks.sh step6-progress-comment.sh step7-epic-handoff.sh
         step8-claim-release.sh stepR1-verdicts.sh stepR-frozen-ac.sh stepR-round-count.sh
         stepR2-branch-rebase.sh stepR2-fail-body.sh stepR2-inline-comments.sh stepR2-linked-issue.sh
-        stepR3-push-and-note.sh stepR3-thread-reply.sh"
+        stepR3-push-and-note.sh stepR3-thread-reply.sh type-investigation-close.sh"
 for s in $SEAMED; do
   bash "$DIR/$s" > "$TMP/out" 2> "$TMP/err"
   rc=$?


### PR DESCRIPTION
Fixes #4502

**§CP by path** — this PR touches `claude-plugins/kampus-pipeline/**` (ADR 0227), so it banks for one `@kamp-us/control-plane` approval. Not to be merged, approved, or enqueued by the author.

## What this is

The post-#4594 residue. The ADR-0232 conversion already extracted the column-0 and blockquoted bulk of `write-code`'s inline shell — including the 61-line `wt_preflight` guard, which now lives plugin-shared in `claude-plugins/kampus-pipeline/lib/common.sh`. Three sites survived it. All three carry **live expansions**, so none of them is the "static illustration beside an extracted invocation" the leave-inline clause exists for: they are operative glue the agent is expected to run. All three are extracted here.

| `SKILL.md` site | before | after | new script |
| --- | --- | --- | --- |
| Step 1 explicit `work milestone N` drain | fence 300–306, 5 body lines, list-indented | fence 300–302, one invocation | `scripts/step1-milestone-pool.sh` |
| Step 4 live branch re-derivation | fence 819–823, 2 residual body lines, blockquoted | fence 815–818 | `scripts/step4-live-branch.sh` |
| `type:investigation` residue-path close | fence 1776–1783, 2 residual body lines, list-indented | fence 1771–1777 | `scripts/type-investigation-close.sh` |

(Before-numbers are against `614b4fe1`, this PR's base; after-numbers against the head.)

The fourth non-column-0 fence in the file — the `step4-wt-preflight.sh` invocation, 707–710 at base / 703–706 at head — is already the extracted form and is untouched. `repair.md` carries no non-column-0 fence and is untouched.

## Executed-class, not sourced

The original ticket's "extract into **sourced** scripts" wording is superseded: ADR [0232](https://github.com/kamp-us/phoenix/blob/main/.decisions/0232-agents-execute-skill-scripts-never-source-them.md) mandates executed-class — invoked by literal path, answer read off **stdout**, never sourced. All three follow the shape the 29 existing scripts use:

```
bash ./claude-plugins/kampus-pipeline/skills/write-code/scripts/<script>.sh <args>
```

`set -uo pipefail`, never `-e`; no `EXIT` trap; `# shellcheck` codes declared per file; the repo resolved through `kp_repo` (shell state does not cross an agent's Bash calls, which is why `$REPO` could not simply be inherited); every other value an explicit seam that refuses fail-closed when absent.

## Behavior is preserved — this is a move, not a rewrite

Two places where the "obvious improvement" was deliberately **not** taken, per ADR 0228 (relay, never derive):

- `step1-milestone-pool.sh` keeps the moved loop's own per-bucket behaviour — a failed bucket prints nothing and the loop continues. Hardening that into a §ZS refusal is the sibling pool's open follow-up (#4501), not this conversion's.
- `type-investigation-close.sh` keeps the moved block's un-gated comment-then-close sequencing (no `|| exit 1` between the POST and the PATCH). Making the close conditional on a landed diagnosis is a real behaviour change and is not this PR's to make.

The Step-3.5 mis-attribution guard stays a **separate visible line at the call site** rather than folding into the close script: a reader of `SKILL.md` must still see the guard the step mandates, and hiding it inside the script would make the mandate unauditable from the doc.

## Verification (observed output)

`verify-executed-contract.sh`:

```
scope: 32 script(s) under claude-plugins/kampus-pipeline/skills/write-code/scripts, plus SKILL.md and repair.md
=== 1. shell shape: `set -uo pipefail`, never `-e`, and no cleanup EXIT trap
OK    every script opens `set -uo pipefail`, none enables -e, none installs an EXIT trap
=== 2. the retired sourced-class header must be gone
OK    no script still declares itself SOURCED, never executed
=== 3. no fenced block in SKILL.md / repair.md sources at the TOP LEVEL, and none interpolates CLAUDE_PLUGIN_ROOT into an invocation
OK    both docs invoke scripts only by literal path
=== 4. every literal-path invocation in the docs names a script that EXISTS
      scope: 32 distinct literal-path invocation target(s)
OK: write-code follows the ADR-0232 executed/stdout convention.
```

`verify-fail-closed.sh` — all three new scripts added to its `SEAMED` list, so the §ZS property is proven for them rather than assumed:

```
=== 1. §ZS: every seam refuses with a NON-ZERO exit and ZERO stdout bytes
OK    step1-milestone-pool.sh            rc=1   stdout-bytes=0 (stderr-bytes=234)
OK    step4-live-branch.sh               rc=1   stdout-bytes=0 (stderr-bytes=255)
OK    type-investigation-close.sh        rc=1   stdout-bytes=0 (stderr-bytes=251)
      … 22 pre-existing seams, all OK …
=== 2. zero-coverage-delta greps over the converted scripts
      scope: 32 converted script(s) under claude-plugins/kampus-pipeline/skills/write-code/scripts
OK    zero bare `pipeline-cli` invocations outside a comment
OK    zero hits — all nine leak-guard path arms
OK: both properties hold.
```

**Shell shape.** `/bin/bash -n` (3.2.57) parses all three clean. Parse is necessary, not sufficient, so each was also **run**: `step4-live-branch.sh` prints this PR's own branch when handed the worktree root and refuses (rc=1, empty stdout, the `${BRANCH:?…}` message on stderr) on a bad root; `step1-milestone-pool.sh` returns a 90-row pool for milestone 29 and an empty-but-exit-0 pool for a milestone with no unassigned triaged issues; `type-investigation-close.sh` refuses with empty stdout on a missing diagnosis. No heredoc inside a `$(…)` anywhere, so the 3.2 truncation class does not apply.

`pnpm typecheck`: 29/29 tasks successful.

## Guard coverage follows the move (explicit AC)

This is the #4470/#4473 follow-into-`scripts/*.sh` check, verified by **running each guard**, not by reading its source alone:

- **`gh-phoenix lint-skills`** (the `skill-gh-lint.yml` job) — its corpus is `find claude-plugins/kampus-pipeline -type f \( -name '*.md' -o -name '*.sh' \)`, so the new scripts enter scope automatically. Its bare-push scan treats a `.sh` as **one implicit whole-file fence** (`scanBarePush`'s `inFence = isShell`), which is the exact counterpart of the `stripQuotePrefix` handling that kept these blocks in scope as markdown — so there is no window where the lines are in neither surface. Run over the full corpus: `clean — no GraphQL-path gh calls, no bare git push in an executable block, and all frontmatter parses as strict YAML`, with all three new files listed as `push-scanned`.
- **`cli-invocation-guard`** — `scanned 337 file(s), 318 runnable bash/sh fence(s) in markdown, 257 shell file(s) as implicit fences … clean`.
- **`trap-status-guard`** — `scanned 337 file(s) … 257 shell file(s) as implicit units … clean — no runnable shell unit pairs errexit with an EXIT trap`.
- **`adoption-lint`** — over the CI corpus (plugin `.md`/`.sh` plus the declared orchestrator mirror): `clean — no un-cited re-derivations of a tool-owned decision`.
- **`leak-guard scan`** over the three new scripts plus `SKILL.md`: `scope — 4 file(s) handed: 1 doc surface, 3 shell surface … clean`. `.sh` is a first-class leak-guard surface since #4507.

Net: every guard that read these lines while they were markdown reads them as `.sh`, and the shell-surface scopes are non-empty, so none of them silently degrades to zero scope.

## Deviations

- **`verify-fail-closed.sh` is edited, not just added to.** Its `SEAMED` list is hand-maintained, so a new seamed script is invisible to it until listed. Leaving the three off would have let the harness pass while claiming less than its own scope — the same defect its `stepR2-fail-body.sh` note records from the #4503 review. That the list is hand-maintained at all is a latent gap; it is out of this ticket's ~10-line scope and is not fixed here.
- **`wt_preflight` refused throughout this run** — `no single worktree carries this lane's stamp`, the known sibling-worktree ambiguity defect (#4500), not an absence. Worktree identity was instead established from git plumbing (`step4-preflight.sh` CONFIRMED: per-tree git-dir under `worktrees/<id>` ≠ the common dir) and every git op was addressed explicitly with `git -C <worktree>`. The primary checkout was not touched.
- **The comment-post in `type-investigation-close.sh` is not `|| exit`-gated** and the milestone loop swallows a failed bucket — both deliberate behaviour preservation, reasoned above rather than silently carried.
- **Naming.** The investigation-close script is `type-investigation-close.sh`, not a `stepN-` name: the site is a branch of the type-routing section, not a numbered step, and inventing a step number for it would misdescribe the flow.
