### PR TITLE
fix(pipeline): check 9 verifies a usage-miss against the declared restrictive sentinel (#4618)

### DIFF
--- a/.patterns/skill-script-io-contract.md
+++ b/.patterns/skill-script-io-contract.md
@@ -55,7 +55,7 @@ UNKNOWN, never the permissive answer** ([ADR 0092](../.decisions/0092-gates-fail
 | Exit | Meaning | stdout | stderr |
 |---|---|---|---|
 | `0` | The answer was produced | the answer (possibly a legitimately empty set, see below) | nothing, or progress |
-| non-zero | The unit could not run, or its input was UNKNOWN | **nothing** | a named diagnostic |
+| non-zero | The unit could not run, or its input was UNKNOWN | **nothing**, or exactly the unit's declared restrictive sentinel (below) | a named diagnostic |
 | `127` | The unit never ran at all (unresolved shim/binary — §CLI, [ADR 0207](../.decisions/0207-gh-path-shim-retired.md)) | **nothing** | a named diagnostic |
 
 Two consequences that are easy to get backwards:
@@ -95,6 +95,39 @@ So the contract has a second half:
 - **Assert on a state word, never on an exit status alone**, when a unit has more than two outcomes.
   An exit code discriminates outcomes only once the unit has *run*, so `… || ordinary` fail-opens on
   a usage error (`1`) or a missing binary (`127`).
+
+## The declared restrictive sentinel — the one thing a failure path may print
+
+A unit whose stdout a call site reads as a **safety value** cannot obey "print nothing when you
+fail". Where the caller gates on the value, silence resolves to whatever the empty string means
+there, and for `containment-marker.sh` that is `none` — the *skip* answer. Printing nothing would
+disarm a live dark-ship gate while every downstream gate reported green.
+
+So the taxonomy above has one exception, and it is narrow enough to be mechanical
+([ADR 0234](../.decisions/0234-usage-miss-declared-restrictive-sentinel.md)). A failing unit prints
+on stdout either **nothing** (the silent class, the default) or **exactly the one restrictive
+sentinel it declares, and nothing else** (the safety-answer class) — never a third thing, and never
+the permissive value. The restrictive sentinel is the answer that holds the guard armed.
+
+The declaration is what makes this checkable instead of a per-review judgment call. A safety-answer
+script declares its sentinel in a contiguous pragma block, one line per expected stdout line, in
+order, immediately above the guard that emits it:
+
+```sh
+# usage-miss-sentinel: flag
+[ "$#" -ge 1 ] || { echo flag; echo "usage: containment-marker.sh <issue>" >&2; exit 2; }
+```
+
+`# usage-miss-sentinel: <silent>` is the reserved counter-declaration: *this* unit's failure stdout
+is deliberately empty, asserted rather than assumed. A unit whose call site captures its stdout into
+a variable must carry one or the other.
+
+`verify-extraction.sh` check 9 probes each argument-taking script with no arguments and compares the
+captured stdout against that declaration. The point of declaring rather than judging is what it
+makes impossible: deleting the emission to satisfy a "must be silent" check now contradicts the
+script's own declaration and reds, so the fail-open edit — quietly dropping a value-sensitive
+sentinel — is a check failure by construction. That edit is banned outright by ADR 0234; the
+declaration is what stops it from also being *easy*.
 
 ## A meaningful exit code does not survive a pipeline
 

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh
@@ -42,9 +42,21 @@
 #      bogus CLAUDE_PLUGIN_ROOT), asserting BOTH the captured exit code and the captured stdout byte
 #      count; plus every script that reaches a verb resolves it as `PCLI="$(kp_pcli)" || exit 127`,
 #      so a could-not-run can never surface as an answer. Network-free.
-#   9. USAGE MISS IS NON-ZERO WITH EMPTY STDOUT — every script that takes arguments, run with none,
-#      asserted on BOTH the captured exit code and the captured stdout byte count. Network-free
-#      (the usage guard precedes every `gh` call).
+#   9. USAGE MISS IS NON-ZERO, AND ITS STDOUT IS EMPTY OR EXACTLY THE DECLARED SENTINEL — every
+#      script that takes arguments, run with none, asserted on BOTH the captured exit code and the
+#      captured stdout. Network-free (the usage guard precedes every `gh` call). Per ADR 0234 a
+#      usage-miss prints nothing (the silent class) or exactly the script's declared restrictive
+#      sentinel (the safety-answer class), so this check reads each script's own declaration — a
+#      contiguous `# usage-miss-sentinel: <line>` block, one pragma line per expected stdout line, in
+#      order — rather than demanding silence from a script whose stdout a call site reads as a safety
+#      value. Deleting the emission while the declaration stands is a FAIL, which is what keeps the
+#      check from being satisfiable by the fail-open edit ADR 0234 bans. Two corroborating legs make
+#      the declaration itself hard to drop: a script whose SKILL.md call site CAPTURES its stdout
+#      into a variable must declare EITHER a sentinel or the reserved `<silent>` (evidence outside
+#      the file a greening edit would touch — `containment-marker.sh`'s dark-ship gate is that
+#      case), and an undeclared script must still be silent. So a captured script cannot be
+#      de-declared quietly; the silent claim has to be written down. A prose-channel sentinel that
+#      no call site captures rests on its declaration alone; that gap is stated, not papered over.
 #
 # Checks 2, 6 and 7 match against a COMMENT-STRIPPED copy of each script (everything from the first
 # `#` on a line is dropped) so the skills can keep *writing about* a bare shim, a cleanup trap, or an
@@ -374,24 +386,58 @@ for f in "${SCRIPT_PATHS[@]}"; do
 done
 [ "$pcli_bad" = 0 ] && ok "every script that reaches a verb resolves it as PCLI=\"\$(kp_pcli)\" || exit 127"
 
-# 9. a usage miss is non-zero with EMPTY stdout — asserted on BOTH operands, network-free
+# 9. a usage miss is non-zero, and its stdout is EMPTY or EXACTLY the declared restrictive sentinel
+#    (ADR 0234) — asserted on BOTH operands, network-free
 probed=0
+declaring=0
 usage_bad=0
+# The one reserved declaration value: "my usage miss is silent, deliberately". A captured script must
+# say which class it is, so dropping a sentinel is never a silent de-declaration — it has to be
+# written down as a claim a reviewer can weigh.
+SILENT_DECL='<silent>'
 for f in "${SCRIPT_PATHS[@]}"; do
 	grep -qE '^\[ "\$#" -ge [0-9]+ \] \|\|' "$f" || continue
 	probed=$((probed + 1))
+	base="$(basename "$f")"
+	declared="$(sed -n -e 's/^# usage-miss-sentinel: //p' "$f")"
 	out="$(bash "$f" 2>/dev/null)"
 	rc=$?
 	bytes=$(printf '%s' "$out" | wc -c | tr -d ' ')
-	if [ "$rc" = 0 ] || [ "$bytes" != 0 ]; then
-		fail "$(basename "$f") with no args: exit=$rc, stdout bytes=$bytes (want non-zero exit, 0 bytes)"
+	# script-external evidence that this script's stdout is read as a VALUE: its own skill's SKILL.md
+	# captures it into a variable. A fail-open edit to the script cannot remove this, so it is what
+	# makes dropping the declaration itself a FAIL for the captured class.
+	md="$(dirname "$(dirname "$f")")/SKILL.md"
+	captured=0
+	[ -f "$md" ] && grep -qE '=[[:space:]]*"?\$\([^)]*'"$base" "$md" && captured=1
+	if [ "$rc" = 0 ]; then
+		fail "$base with no args: exit=$rc — a usage miss must exit non-zero (ADR 0234)"
+		usage_bad=1
+	elif [ "$declared" = "$SILENT_DECL" ]; then
+		if [ "$bytes" != 0 ]; then
+			fail "$base declares the silent class ($SILENT_DECL) but printed $bytes byte(s) on a usage miss (ADR 0234)"
+			usage_bad=1
+		fi
+	elif [ -n "$declared" ]; then
+		declaring=$((declaring + 1))
+		if [ "$out" != "$declared" ]; then
+			fail "$base with no args: stdout is not its declared restrictive sentinel (ADR 0234) — deleting or weakening a declared sentinel is a FAIL, never a way to green this check. Declared:"
+			printf '  %s\n' "$declared"
+			echo "  observed ($bytes byte(s)):"
+			printf '  %s\n' "$out"
+			usage_bad=1
+		fi
+	elif [ "$captured" = 1 ]; then
+		fail "$base declares no \`# usage-miss-sentinel:\` yet $(basename "$md") captures its stdout as a value — declare its restrictive sentinel, or \`$SILENT_DECL\` if an empty capture is genuinely not the permissive answer there (ADR 0234)"
+		usage_bad=1
+	elif [ "$bytes" != 0 ]; then
+		fail "$base with no args: exit=$rc, stdout bytes=$bytes — an undeclared script must be silent; declare the sentinel with \`# usage-miss-sentinel:\` if its stdout answers a safety question (ADR 0234)"
 		usage_bad=1
 	fi
 done
 if [ "$probed" -eq 0 ]; then
 	fail "zero scope: no argument-taking script was probed for its usage refusal (ADR 0092)"
 elif [ "$usage_bad" = 0 ]; then
-	ok "all $probed argument-taking script(s) refuse a no-args call with a non-zero exit AND 0 bytes of stdout"
+	ok "all $probed argument-taking script(s) refuse a no-args call with a non-zero exit AND stdout that is empty or exactly the declared restrictive sentinel ($declaring declaring one — ADR 0234)"
 fi
 
 echo "scanned scope: ${scanned_md} SKILL.md, ${scanned_sh} extracted script(s) across [${SKILLS[*]}]"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-control-plane.sh
@@ -48,6 +48,12 @@ emit_and_exit() {
   exit "$1"
 }
 
+# The declared lines carry bash 3.2.57's `%q` escaping (the platform measured above); bash 5 quotes
+# the same string differently, so a mismatch here on another bash is the escaping, not a lost sentinel.
+# usage-miss-sentinel: CONTROL_PLANE_TOUCHED=\<§CP\ classifier\ could\ not\ run\ -\ §CP\ UNKNOWN\,\ held\ as\ control-plane\>
+# usage-miss-sentinel: GUARD_TOUCHING=\<§CP\ classifier\ could\ not\ run\ -\ §CP\ UNKNOWN\,\ held\ as\ control-plane\>
+# usage-miss-sentinel: CP_FILES_N=0
+# usage-miss-sentinel: ADR_N=0
 [ "$#" -ge 1 ] || { echo "usage: classify-control-plane.sh <pr>" >&2; emit_and_exit 2 "$SENTINEL" "$SENTINEL" 0 0; }
 PR="$1"
 # Top-level assignment, never `local` — `local REPO="$(kp_repo)"` masks the substitution's status,

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-issueless.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-issueless.sh
@@ -15,6 +15,7 @@ set -uo pipefail
 
 HARD_STOP="no linked issue on a PR carrying behavioral code — broken seam: hard-stop (dangling-code guard, ADR 0184)"
 
+# usage-miss-sentinel: no linked issue on a PR carrying behavioral code — broken seam: hard-stop (dangling-code guard, ADR 0184)
 [ "$#" -ge 1 ] || {
 	echo "$HARD_STOP"
 	echo "usage: classify-issueless.sh <pr>" >&2

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-skills-only.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/classify-skills-only.sh
@@ -21,6 +21,7 @@ set -uo pipefail
 # shellcheck source=../../shared/scripts/wl-empty-output.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../shared/scripts" && pwd)/wl-empty-output.sh"
 
+# usage-miss-sentinel: CANNOT-CLASSIFY (no <pr> argument — artifact class UNKNOWN, never an off-ramp)
 [ "$#" -ge 1 ] || {
 	echo "CANNOT-CLASSIFY (no <pr> argument — artifact class UNKNOWN, never an off-ramp)"
 	echo "usage: classify-skills-only.sh <pr>" >&2

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/containment-marker.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/containment-marker.sh
@@ -14,6 +14,7 @@ set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
+# usage-miss-sentinel: flag
 [ "$#" -ge 1 ] || { echo flag; echo "usage: containment-marker.sh <issue>" >&2; exit 2; }
 ISSUE="$1"
 REPO="$(kp_repo)" || { echo flag; echo "containment-marker.sh: target repo unresolved — marker UNKNOWN, held ARMED (flag)." >&2; exit 1; }

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/current-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/current-head.sh
@@ -11,6 +11,7 @@ set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
+# usage-miss-sentinel: <silent>
 [ "$#" -ge 1 ] || { echo "usage: current-head.sh <pr>" >&2; exit 2; }
 PR="$1"
 REPO="$(kp_repo)" || exit 1

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 
 cannot() { echo "glossary-freshness: CANNOT-EVALUATE ($1) — fold as [UNVERIFIABLE], never as a not-applicable skip (§ZS, #4299)"; exit "${2:-1}"; }
 
+# usage-miss-sentinel: glossary-freshness: CANNOT-EVALUATE (no <pr> argument) — fold as [UNVERIFIABLE], never as a not-applicable skip (§ZS, #4299)
 [ "$#" -ge 1 ] || { echo "usage: glossary-freshness.sh <pr>" >&2; cannot "no <pr> argument" 2; }
 PR="$1"
 REPO="$(kp_repo)" || cannot "target repo unresolved"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/userfacing-scope.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/userfacing-scope.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 # shellcheck disable=SC2016  # the `**Containment:** flag` / `apps/web/src/**` text is literal verdict prose, not an expansion
 ZERO_ROW='- [FAIL] flag-gating (default-off) — `**Containment:** flag` marks a dark-shipped feature, but the diff touches NO user-facing surface (apps/web/src/**/*.{tsx,css}, new apps/web/worker/** resolver/route/mutation): empty scope on a flag-marked PR is a FAIL (ADR 0092 §ZS), not a pass — there is no user-facing path to gate.'
 
+# usage-miss-sentinel: - [FAIL] flag-gating (default-off) — `**Containment:** flag` marks a dark-shipped feature, but the diff touches NO user-facing surface (apps/web/src/**/*.{tsx,css}, new apps/web/worker/** resolver/route/mutation): empty scope on a flag-marked PR is a FAIL (ADR 0092 §ZS), not a pass — there is no user-facing path to gate.
 [ "$#" -ge 1 ] || { printf '%s\n' "$ZERO_ROW"; echo "usage: userfacing-scope.sh <pr>" >&2; exit 2; }
 PR="$1"
 REPO="$(kp_repo)" || { printf '%s\n' "$ZERO_ROW"; echo "userfacing-scope.sh: target repo unresolved — scope UNKNOWN, failing closed." >&2; exit 1; }


### PR DESCRIPTION
Six of `review-code`'s scripts print a short safety answer on stdout when they cannot run — `containment-marker.sh`, for instance, prints `flag` so a dark-ship containment gate stays armed rather than silently skipped. The extraction verifier's check 9 demanded that every script be *silent* when it fails, so those six sat permanently red, and the only way to green them was to delete the very sentinel that keeps the gate armed. This PR teaches check 9 to read each script's own declaration of what its sentinel is, so a compliant script passes and deleting a sentinel now *fails* the check instead of satisfying it.

Fixes #4618

## What changed

**1. `verify-extraction.sh` check 9 verifies against the declaration** (`claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-extraction.sh`). A usage-miss must still exit non-zero; its stdout must now be **either** empty **or** exactly the script's declared restrictive sentinel, per ADR 0234. The declaration is a contiguous `# usage-miss-sentinel: <line>` pragma block sitting immediately above the guard that emits it, one pragma line per expected stdout line, in order.

Three outcomes, and the fail-open edit is unreachable in all of them:

- **Declared, stdout matches** → ok.
- **Declared, stdout differs (including empty)** → FAIL. This is the ban made mechanical: deleting or weakening the emission now contradicts the script's own declaration.
- **Undeclared** → the existing empty-stdout assertion, unchanged.

Two legs keep the *declaration* from being dropped as quietly as the emission was:

- A script whose `SKILL.md` call site **captures its stdout into a variable** must declare either a sentinel or the reserved `# usage-miss-sentinel: <silent>`. That capture lives in a different file from the one a greening edit would touch, so `containment-marker.sh` — the live dark-ship gate ADR 0234 names — cannot be de-declared without also editing `review-code/SKILL.md`.
- `<silent>` is a counter-declaration, not an escape hatch: it asserts the empty stdout is deliberate, and check 9 then verifies the stdout really is empty. Claiming the silent class on a value-sensitive script is now a written claim a reviewer can weigh, not an absence nobody sees.

The honest limit, stated rather than implied: the five prose-channel scripts are read by an agent, not captured into a variable, so no grep can corroborate their value-sensitivity from the call site. Their declaration is the only anchor. The capture leg covers the class where the stakes are highest.

**2. `.patterns/skill-script-io-contract.md` amended in place.** The exit taxonomy's non-zero row read "stdout: **nothing**" unconditionally; it now reads "nothing, or exactly the unit's declared restrictive sentinel", and a new section states the two classes, the pragma shape, the reserved `<silent>` value, and why declaring beats judging. No supersession mechanics — it is a pattern doc, corrected in place, as ADR 0234 directs.

**3. The seven declarations.** The six audited scripts declare their sentinel verbatim; `current-head.sh` declares `<silent>` (its stdout is captured, and an empty capture there is genuinely not the permissive answer — a missing SHA blocks the verdict rather than waving it through).

## The six-site audit

Run **before** any script change and recorded on #4618 (https://github.com/kamp-us/phoenix/issues/4618#issuecomment-5149755545), as ADR 0234's first binding constraint requires. Finding: **all six are value-sensitive**, so none was silenced — which is why the check, not the corpus, is what changed.

## Verification, as observed

- `verify-extraction.sh review-code` — the six check-9 FAILs are gone: `ok: all 19 argument-taking script(s) refuse a no-args call with a non-zero exit AND stdout that is empty or exactly the declared restrictive sentinel (6 declaring one — ADR 0234)`. Two **pre-existing** FAILs remain, outside this issue's scope (see Deviations).
- `verify-extraction.sh` (default `plan-epic review-plan` scope) — `OK — 12 checks over 23 script(s) in 2 skill(s)`, no regression.
- **Mutation proof** — the fail-open edit does not green check 9. Applied to `containment-marker.sh`, each reverted after:
  - delete the emission, declaration standing → `FAIL: containment-marker.sh with no args: stdout is not its declared restrictive sentinel (ADR 0234)`
  - delete the emission **and** the declaration → `FAIL: containment-marker.sh declares no \`# usage-miss-sentinel:\` yet SKILL.md captures its stdout as a value`
  - weaken `flag` (ARMED) → `none` (the SKIP answer) → `FAIL: … stdout is not its declared restrictive sentinel`
  - restored → `ok: all 19 argument-taking script(s) …`
- `containment-marker.sh` with no args, after the change: `exit=2`, stdout `flag` — still ARMED at its call site.
- `verify-fail-closed.sh` — `OK: both properties hold.`
- `verify-executed-contract.sh` — `OK: write-code follows the ADR-0232 executed/stdout convention.`
- `trap-status-guard check` over the CI job's exact corpus scan — `scanned 334 file(s), 318 runnable bash/sh fence(s) in markdown, 254 shell file(s); clean — no runnable shell unit pairs errexit with an EXIT trap.`
- `shellcheck -x` on all eight touched scripts — `rc=0`.
- `/bin/bash -n` under **3.2.57(1)-release** on all eight — parse ok; each touched `review-code` script also **executed** with no args to confirm exit code and stdout bytes at runtime, not just parse.
- `pnpm typecheck` — 29/29 successful (full turbo cache; this diff adds no TypeScript surface).
- `pnpm lint:worktree` — no biome-handled changed files.
- `leak-guard sweep` — clean.

## Deviations

- **Class: scope narrowing/widening.** *Said:* the issue names six scripts. *Did:* an eighth file, `current-head.sh`, gained a `# usage-miss-sentinel: <silent>` declaration. *Why:* the new capture-site corroboration leg correctly flagged it — its stdout is captured into `HEAD_SHA` — and it is a genuine silent-class script, so it declares that rather than being exempted. *Disposition:* no action needed; it is a declaration, not a behavior change, and its runtime output is unchanged (`exit=2`, 0 bytes).
- **Class: narrowing a suggested fix-shape.** *Said:* the issue suggested "a header pragma the verifier greps, a sidecar manifest". *Did:* the pragma, plus the capture-site leg and the reserved `<silent>` value. *Why:* a pragma alone makes deleting the *emission* a FAIL but leaves "delete the emission and the pragma together" open; the capture leg closes that for the value-gating class using evidence outside the edited file. *Disposition:* for the reviewer to judge — the residual for prose-channel scripts is stated above rather than papered over.
- **Class: leaving a sibling defect for a follow-up.** *Said:* the AC is "no longer reports the six check-9 FAILs". *Did:* `verify-extraction.sh review-code` still reports two FAILs, both **pre-existing and unrelated** — check 1 on two `printf … | bash …` fenced blocks in `review-code/SKILL.md`, and check 8 on `classify-control-plane.sh`'s deliberate `PCLI="$(kp_pcli)" || PCLI=""` fallback. *Why:* neither is a check-9 defect, and both are `review-code` conversion residue owned by the #4435 programme. *Disposition:* named in the audit comment and here so they are not read as regressions; not fixed under this ticket.
- **Class: pushed past a tooling refusal.** *Said:* gate every git mutation on `step4-wt-preflight.sh`. *Did:* the preflight refused with "no single worktree carries this lane's stamp" — the known sibling-worktree **ambiguity** defect (#4500), not absence. Worktree identity was re-established from git plumbing (per-tree git-dir under `worktrees/` ≠ the common dir), and every git op addressed the worktree explicitly with `git -C`. *Disposition:* no action needed here; #4500 is the standing ticket.
- **Class: a mistake made and corrected.** *Said:* anchor every edit under `$WT`. *Did:* one edit to `.patterns/skill-script-io-contract.md` was applied to the **primary checkout** path before the mistake was caught. *Why:* an absolute path from earlier session context, the exact #3458 edit-bleed class. *Disposition:* reverted byte-for-byte and verified identical to the primary's committed content before any commit; the primary checkout is untouched and this diff carries only the worktree edit.
