### PR TITLE
feat(marketplace): pin the kampus-pipeline channel to a known-good commit (#4643)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,13 @@
 	"plugins": [
 		{
 			"name": "kampus-pipeline",
-			"source": "./claude-plugins/kampus-pipeline",
+			"source": {
+				"source": "git-subdir",
+				"url": "https://github.com/kamp-us/phoenix.git",
+				"path": "claude-plugins/kampus-pipeline",
+				"ref": "main",
+				"sha": "f66bc0547772eabb0b0aa0bbe02e5afea1b429a6"
+			},
 			"description": "The kamp.us agent pipeline: report → triage → plan-epic → write-code → review → ship-it, with artifact-class review gates (code/doc/skill/plan) plus adr, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
 			"author": {
 				"name": "kamp-us",

--- a/claude-plugins/kampus-pipeline/README.md
+++ b/claude-plugins/kampus-pipeline/README.md
@@ -115,6 +115,32 @@ Claude Code:
 `kampus-pipeline` from the `kampus` marketplace. After install, the 14 skills are
 available in the picker (e.g. `triage`, `write-code`, `ship-it`).
 
+### The channel is pinned — you get a fixed commit, not `main`
+
+The marketplace serves `kampus-pipeline` from a **pinned commit**, not from the tip of the
+default branch. The plugin entry in [`.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json)
+uses a `git-subdir` source carrying an explicit `sha`, and per the marketplace contract the
+`sha` is the effective pin: Claude Code checks out that exact commit. With no `version` field
+anywhere, the resolved version *is* that SHA — so it never changes, and both `/plugin update`
+and background auto-update skip the plugin. **An install with `autoUpdate: true` therefore
+stops tracking `main`.** That is the intent: the pipeline is being rewritten, and an external
+install should not ride the rewrite.
+
+**To move an installed copy forward**, do nothing on your side — we bump the pin, you refresh:
+
+```
+/plugin marketplace update kampus
+/plugin update kampus-pipeline@kampus
+```
+
+The first command re-fetches the catalog (picking up the new `sha`); the second re-resolves
+the plugin against it. Nothing in your settings changes, and skipping both leaves you exactly
+where you are — which is the point of a pin.
+
+**To cut a new pin** (maintainer side), edit the one `sha` field in the marketplace entry to a
+newer `main` commit and merge it. That file is control-plane, so the change lands only through
+the human-approval gate.
+
 ## Configuration — point the pipeline at your repo
 
 The pipeline is **zero-config for the common case**. Every skill resolves its target
@@ -164,6 +190,8 @@ the gap surfaces before any work is done; it **prints** the fix and never applie
 ## Design notes — versioning and spec conformance
 
 The plugin carries **no per-plugin `version`** (neither in the marketplace plugin entry nor in [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)): Claude Code then content-addresses the install by git commit SHA, so every commit is a new "version" and skill additions/edits reach already-installed users on the normal update path — a fixed semver pin froze the cache and silently served stale content (#945). This omission is **deliberate, not a defect — do not add a `version`**; the decision record (why + history) is [ADR 0110](https://github.com/kamp-us/phoenix/blob/main/.decisions/0110-plugin-carries-no-version-continuous-ship.md).
+
+The **continuous-ship half of that is currently suspended for marketplace consumers**, by founder ruling on [#4639](https://github.com/kamp-us/phoenix/issues/4639): the marketplace entry pins a `sha` (see [The channel is pinned](#the-channel-is-pinned--you-get-a-fixed-commit-not-main)), so external installs sit on a fixed commit for the duration of the pipeline rewrite and move forward only by an explicit update. The `version` omission is what *makes* the pin work — with no `version`, the resolved version is the pinned SHA, so pinning content and stopping auto-update are the same field — which is why 0110's "do not add a `version`" still holds unchanged. Contributors working **in this repo** are unaffected: local runs resolve the skills through the in-tree `.claude/skills` symlink and the `.claude/.pipeline` link, never through the marketplace.
 
 The whole plugin surface was audited against the official Claude Code plugin spec ([plugins reference](https://docs.claude.com/en/docs/claude-code/plugins-reference), [marketplaces](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)); the conformance record — the corrected manifest `$schema` URL plus every deliberate deviation (no `version`, the root-level `hooks.json`, the absent `commands/`, the `.claude/skills` discovery symlink) and its forcing constraint — is [ADR 0171](https://github.com/kamp-us/phoenix/blob/main/.decisions/0171-kampus-pipeline-plugin-spec-conformance.md). A future audit that re-flags any of those reads the disposition there: documented-intentional, not an open defect.
 
@@ -284,7 +312,7 @@ phoenix/
 ├── .claude-plugin/
 │   └── marketplace.json                 # catalog — lists each plugin + its source
 ├── claude-plugins/                      # marketplace container (one subdir per plugin)
-│   └── kampus-pipeline/                 # this plugin — source: "./claude-plugins/kampus-pipeline"
+│   └── kampus-pipeline/                 # this plugin — the git-subdir source's pinned `path`
 │       ├── .claude-plugin/
 │       │   └── plugin.json
 │       ├── README.md                    # this file — the plugin's front-door entry point

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -182,11 +182,15 @@ EOF
 	ok "$name copies across the corpus match the single-source const"
 done
 
-# Invariant 2: .claude/skills symlink agrees with marketplace source.
+# Invariant 2: .claude/skills symlink agrees with the marketplace's plugin root.
 #
 # .claude/skills -> ../claude-plugins/kampus-pipeline/skills
-# marketplace.json source -> ./claude-plugins/kampus-pipeline
-# Invariant: resolved(.claude/skills) == resolved(marketplace source)/skills
+# marketplace plugin root -> claude-plugins/kampus-pipeline
+# Invariant: resolved(.claude/skills) == resolved(plugin root)/skills
+#
+# "Plugin root" is whichever field the entry's `source` union uses to name it: the bare
+# relative-path string, or a pinned `git-subdir` object's `path` (#4643). Both spell the same
+# in-repo directory, so the invariant is unchanged — only the field it reads moved.
 SYMLINK="$repo_root/.claude/skills"
 MARKETPLACE="$repo_root/.claude-plugin/marketplace.json"
 
@@ -201,23 +205,34 @@ else
 	if [ ! -f "$MARKETPLACE" ]; then
 		fail ".claude-plugin/marketplace.json not found — cannot verify symlink ↔ marketplace agreement"
 	else
-		# Extract source field (bash 3.2: grep + sed, no python/jq required)
-		MP_SOURCE=$(grep '"source"' "$MARKETPLACE" | head -n1 \
-			| sed 's/.*"source"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)   # || true: no-match → empty → fail below, not a set -e abort
+		# Parse the plugin root out of the NAMED entry. The old grep+sed took the file's first
+		# `"source"` line, which only worked while every entry was a bare string and kampus-pipeline
+		# happened to be listed first; against a `git-subdir` object it matched the opening brace and
+		# silently yielded a path that resolves to nothing. Node already gates this script (the
+		# boundary consts above are read through it), so parsing the JSON adds no dependency.
+		MP_SOURCE=$(node -e '
+			const m = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+			const entry = (m.plugins || []).find((p) => p.name === "kampus-pipeline");
+			if (!entry) process.exit(1);
+			const s = entry.source;
+			const root = typeof s === "string" ? s : s && s.source === "git-subdir" ? s.path : null;
+			if (!root) process.exit(1);
+			process.stdout.write(root);
+		' "$MARKETPLACE" 2>/dev/null || true)   # || true: a parse/shape failure yields empty → fail below, not a set -e abort
 		if [ -z "$MP_SOURCE" ]; then
-			fail "marketplace.json: no \"source\" field found in plugins entry"
+			fail "marketplace.json: could not resolve the kampus-pipeline entry's plugin root (expected a relative-path \"source\" string or a \"git-subdir\" source with a \"path\")"
 		else
-			# Resolve marketplace source to absolute path, then append /skills
+			# Resolve the plugin root to an absolute path, then append /skills
 			if ! MP_SOURCE_RESOLVED=$(cd "$repo_root" && cd "$MP_SOURCE" && pwd) 2>/dev/null; then
-				fail "marketplace.json source \"$MP_SOURCE\" does not resolve to a directory"
+				fail "marketplace.json plugin root \"$MP_SOURCE\" does not resolve to a directory"
 			else
 				EXPECTED_SYMLINK="$MP_SOURCE_RESOLVED/skills"
 				if [ "$SYMLINK_RESOLVED" = "$EXPECTED_SYMLINK" ]; then
-					ok ".claude/skills symlink agrees with marketplace source ($MP_SOURCE + /skills)"
+					ok ".claude/skills symlink agrees with the marketplace plugin root ($MP_SOURCE + /skills)"
 				else
-					fail ".claude/skills symlink has drifted from marketplace source
+					fail ".claude/skills symlink has drifted from the marketplace plugin root
   symlink resolves to: $SYMLINK_RESOLVED
-  marketplace expects: $EXPECTED_SYMLINK (source=\"$MP_SOURCE\" + /skills)"
+  marketplace expects: $EXPECTED_SYMLINK (plugin root \"$MP_SOURCE\" + /skills)"
 				fi
 			fi
 		fi


### PR DESCRIPTION
The marketplace hands out `kampus-pipeline` from a path into the working tree, which has no way to say "serve this version" — so every merge to `main` was what an external install's next auto-update fetched, mid-rewrite. This PR pins the channel to one fixed commit: an install with `autoUpdate: true` stops tracking `main` and moves forward only when we deliberately cut a new pin. Nothing changes for anyone working inside this repo.

Fixes #4643

## What changed

- **`.claude-plugin/marketplace.json`** — the `kampus-pipeline` entry's `source` goes from the bare relative path to a `git-subdir` object carrying `path`, `ref: main`, and `sha: f66bc0547772eabb0b0aa0bbe02e5afea1b429a6`.
- **`claude-plugins/kampus-pipeline/README.md`** — a new *The channel is pinned* section under Install (what a consumer gets, the two commands that move them forward, how a maintainer cuts a new pin), plus an amendment to the versioning design note, which claimed continuous ship to installed users and is now only true for in-repo contributors.
- **`claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh`** — invariant 2 read the plugin root by grepping the file's *first* `"source"` line. Against an object source that line is `"source": {`, the `sed` falls through unchanged, and the resulting path resolves to nothing — CI reds. It now parses the named entry and accepts either shape.

## The lever, grounded (AC 2)

Verified first-hand against two authoritative sources, not inferred from the manifest's shape.

**The declared schema** (`https://json.schemastore.org/claude-code-marketplace.json`, the `$schema` the manifest itself names). `source` is a union. The relative-path form we used is a bare `string` with **no fields at all** — there is nothing on it to pin. The three git forms (`github`, `url`, `git-subdir`) each carry optional `ref` and `sha`, `sha` being *"Specific commit SHA to use"*, constrained to `^[a-f0-9]{40}$`.

**The official marketplace documentation.** Three statements settle it:

- *"Plugin source: where to fetch an individual plugin listed in the marketplace... Supports both `ref` (branch/tag) and `sha` (exact commit)."*
- *"When both `ref` and `sha` are set on any of them, the `sha` is the effective pin. Claude Code fetches and checks out the pinned commit directly."*
- *"Plugin versions determine cache paths and update detection: if the resolved version matches what a user already has, `/plugin update` and auto-update skip the plugin"*, over a resolution order of `plugin.json` version → marketplace-entry version → *the git commit SHA of the plugin's source*.

The plugin declares no `version` anywhere (deliberate, ADR 0110), so the resolved version **is** the source SHA. Fix the SHA and the version is constant, so auto-update skips. One field does both jobs — pinning content and closing auto-update are not two mechanisms here.

**The plausible-and-wrong lever, killed against source.** The obvious candidate is to set `version` on the entry. It does not work: per the resolution order above, `version` governs cache paths and update detection — it pins the plugin's *identity*, not the *content* it resolves to. Layered over a relative-path source the content still resolves against the marketplace clone, i.e. `main`, so it cannot deliver a pre-conversion tree. Recording this because it is exactly the answer that looks right.

`git-subdir` rather than `github`/`url` because the plugin lives in a monorepo subdirectory; the other two treat the repo root as the plugin root, and `plugin.json` is not there. `ref` is kept beside `sha` as the documented graceful fallback for hosts that cannot fetch a bare commit.

## Why `f66bc054`, and a premise in the issue that is wrong

The issue names #4608 "the first literal-path conversion merge" and offers its parent as a serviceable pin. **That premise does not hold.** Counting non-portable `bash ./claude-plugins/...` fences across the skill corpus at every `main` commit since ADR 0232 landed: the first such fence entered at `32e66f24` (#4585, 2026-07-31T19:14:13Z), five merges earlier, and `main` already carried 27 of them when #4608 merged (#4608 took the count 27 → 48, the largest single jump, which is likely why it was fingered as the first).

So pinning to #4608's parent would satisfy the criterion's letter while shipping 27 already-broken fences — a pin that does not pin what it claims to. `f66bc0547772eabb0b0aa0bbe02e5afea1b429a6` (2026-07-31T18:55:16Z) is the last `main` commit measuring **zero** non-portable fences. It predates #4608, so it meets the criterion as written *and* delivers its intent.

## Containment, not a cure

Say this plainly so "pinned" is not read as "fixed": the pinned tree predates the portability remedy, so its fences use the sourced `${CLAUDE_PLUGIN_ROOT:-...}` form. That form is correct for a plain external install, and it is *refused by the isolation verifier* when a skill runs under worktree isolation. The genuinely-correct corpus is today's `main`. The pin stops the channel from widening the exposure; it does not repair the tree it serves. The forward move is the documented update path plus a later pin bump to a post-#4645 commit once the rewrite settles.

## Blast radius

- **In-repo contributors: unaffected.** Local runs resolve skills through the in-tree `.claude/skills` symlink and the `.claude/.pipeline` link, never through the marketplace.
- **The sparse clone is safe.** `git-subdir` materializes only the plugin subdirectory, and `bin/pipeline-cli`'s tier-1 in-repo path (`../../../packages/pipeline-cli/src/bin.ts`) would not be materialized — but that tier is a phoenix-checkout convenience with a documented fall-through to the session-installed bin and then a pinned `pnpm dlx`. The docs are explicit that plugins are copied to a cache and cannot reference files outside their own directory, so an external install never had that path anyway.
- **Only `kampus-pipeline` is pinned.** The whole non-portable-fence exposure is inside it; the other two entries carry none, and `pipeline-crew-mcp` resolves its server through a path a sparse source would break outright. Pinning all three would be both scope creep and a regression.

## §CP

`.claude-plugin/marketplace.json` is control-plane by path (ADR 0212) — confirmed with `pipeline-cli cp-classify classify`, which returns `control-plane [path-match] — BLOCKING (human merge)`. This PR banks for a `@kamp-us/control-plane` approval at head; it does not ship.

## Verification run

- `validate-gate-path-drift.sh` — 34 checks, OK. Negative-tested by pointing the pinned `path` at another plugin: it fails with the drift message, so invariant 2 can still fire.
- `gh-phoenix lint-skills` over the full corpus (as CI invokes it) — clean.
- `trap-status-guard check` over `claude-plugins/**` (as CI invokes it) — clean, 336 files.
- `pnpm typecheck`, `pnpm lint:worktree` — clean. `leak-guard` clean at commit.
- Manifest re-parsed: the entry's `sha` matches `^[a-f0-9]{40}$` and no `version` field was introduced.

## Deviations

- **Scope — a file the issue did not name.** *Said:* pin the channel and document the update path. *Did:* also rewrote invariant 2 of `validate-gate-path-drift.sh`. *Why:* it parses `source` as a bare string, so the pin alone reds the `lint / format / typecheck` job — the pin is unshippable without it. The rewrite is confined to how the plugin root is read; the invariant itself is unchanged, and I proved it can still fail. *Disposition:* no action needed.
- **Corrected a premise in the issue.** *Said:* pin to the state predating #4608. *Did:* pinned `f66bc054`, which predates #4608 by five merges. *Why:* #4608 was not the first conversion; its parent already carried 27 broken fences, so the literal reading defeats the stated intent. *Disposition:* stated in full above; the issue text should be read against this correction.
- **A standing decision's consequence is suspended without a new ADR.** *Said:* nothing about ADR 0110. *Did:* the pin suspends 0110's continuous-ship property for marketplace consumers, and I amended the README design note rather than writing an ADR. *Why:* 0110's actual decision ("carry no `version`") is untouched and is in fact what makes the pin work; the suspension is a founder ruling on #4639, which is the deciding authority, and an ADR is outside this issue's one-cycle appetite. *Disposition:* for the reviewer to judge — if a decision record is wanted, it is a follow-up, not a blocker.
- **Ran a provisioning hook the harness had not.** *Said:* nothing. *Did:* ran `claude-plugins/kampus-pipeline/hooks/plant-pipeline-link.sh` against this worktree, because `.claude/.pipeline` was absent and every skill fence exited 127. *Why:* it is the plugin's own sanctioned planting script and the link is gitignored — no route-around of a guard, and nothing committed. *Disposition:* no action needed; noted because it is a run condition a successor will hit in any fresh worktree.