### PR TITLE
docs(roadmap): add the fabrika campaign row (milestone #44)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,6 +94,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Agentic design-system coverage | #33 | done |
 | Flag Retirement (ADR 0136) | #34 | active |
 | Writing-Craft Import | #30 | done |
+| fabrika — kampus-pipeline v2 | #44 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Completes the `fabrika` campaign mint. The board half already landed — GitHub milestone #44 (`fabrika campaign`) exists and is stamped on all 11 fabrika issues — but the `ROADMAP.md` half was never written, leaving the mint half-executed: an open milestone with no founder-voice row claiming it. Campaign mint context: #4648.

## What changed

One row appended to `ROADMAP.md`'s `## Campaigns` table, as its last row:

```
| fabrika — kampus-pipeline v2 | #44 | active |
```

Nothing else in the file is touched — the diff is exactly one added line.

## Grammar conformance

The table is a **parsed contract** (stated in `ROADMAP.md` immediately below it): it is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the row is written to the pinned grammar rather than eyeballed:

- **Columns** `Campaign | Milestone | State`, in that order.
- **`Milestone` pins by number** — `#44`, verified live against the GitHub milestone titled `fabrika campaign` (open).
- **`State ∈ {active, done}`** — there is no `queued` for a campaign; a campaign opens `active` and ends `done`. This one opens `active`, matching its open milestone.
- **`fabrika` is lowercase** — a founder-sealed brand noun under the Turkish-for-product law (`.glossary/LANGUAGE.md`). Deliberately not title-cased.

## Issueless under ADR 0075

This is a docs-only PR with **no `Fixes #N`**, which ADR [0075](.decisions/0075-issueless-doc-pr-merge-seam.md) makes a legitimate state: `ship-it` Step 1's `no linked issue` hard stop is scoped to diffs carrying a code artifact class, and a docs-only diff ships on its `review-doc: PASS` alone. No tracking issue was minted to manufacture a link — minting one purely to satisfy the guard is explicitly banned by that ADR. The campaign mint on #4648 is the context reference, not a closing seam.

## Verification

- `cp-classify classify` on the changed-file list (`ROADMAP.md`) → **not-control-plane** `[path-clear-no-content-source]` — no path matched the live `CONTROL_PLANE_RE` and no `.decisions/**` file is present, so the ADR-0164 content clause has nothing to decide. Ordinary lane.
- `git diff --stat` → `ROADMAP.md | 1 +`, 1 file changed, 1 insertion(+), 0 deletions.
- `roadmap-guard check` → **6 violations on the base, 5 with this change.** The row resolves exactly one of them: `[I3] open milestone #44 ("fabrika campaign") is not claimed by any arc or campaign row`. The remaining 5 are pre-existing on the base commit and untouched here (an unclaimed milestone #43, and four `[I5]` active-row/closed-milestone mismatches).

## Deviations

- **The mermaid dependency graph was not regenerated.** `ROADMAP.md`'s diagram block is generated from the two tables (`pipeline-cli roadmap diagram`) and now lacks a `fabrika` node. This was left out deliberately to keep the diff to the single contracted row; no guard enforces diagram freshness (`roadmap-guard` does not read the diagram, and there is no diagram-drift CI job), so this is cosmetic staleness, not a red gate. Flagging it for the reviewer to rule rather than silently widening the diff.
