### PR TITLE
docs(roadmap): the fabrika campaign row + the regenerated diagram (supersedes #4669)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,7 @@ flowchart TD
 		camp_agentic_design_system_coverage["Agentic design-system coverage"]:::done
 		camp_flag_retirement_adr_0136["Flag Retirement (ADR 0136)"]:::active
 		camp_writing_craft_import["Writing-Craft Import"]:::done
+		camp_fabrika_kampus_pipeline_v2["fabrika — kampus-pipeline v2"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -94,6 +95,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Agentic design-system coverage | #33 | done |
 | Flag Retirement (ADR 0136) | #34 | active |
 | Writing-Craft Import | #30 | done |
+| fabrika — kampus-pipeline v2 | #44 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Adds the `fabrika — kampus-pipeline v2` campaign to `ROADMAP.md` — **both halves in one commit**: the `## Campaigns` row *and* the regenerated `## Dependency graph` block.

## Supersedes #4669

#4669 carried only the first half — it added the campaigns row but never regenerated the diagram, which is what its `review-doc: FAIL` named. That PR is an ADR-0075 issueless doc PR and therefore carries no closing keyword by design, so the repair path cannot resolve a linked issue for it; rebuilding the complete change as one clean PR is the reachable route. Close #4669 in favour of this one.

## What changed

`ROADMAP.md`, two added lines, nothing else:

- **The campaigns row**, appended last to the `## Campaigns` table:
  `| fabrika — kampus-pipeline v2 | #44 | active |` — grammar per the table's own pinned contract (`Campaign | Milestone | State`, milestone by number, `State ∈ {active, done}`). `fabrika` is lowercase: a brand noun under the Turkish-for-product law.
- **The regenerated diagram**, per the instruction in the `## Dependencies` section ("Regenerate the diagram after editing any table with `pipeline-cli roadmap diagram`"). The delta is exactly one node, last in the `campaigns` subgraph:
  `camp_fabrika_kampus_pipeline_v2["fabrika — kampus-pipeline v2"]:::active`

The committed block was verified byte-identical to `pipeline-cli roadmap diagram` output — no reordering, reflow, or renaming.

## Context

Milestone [#44](https://github.com/kamp-us/phoenix/milestone/44) ("fabrika campaign") is open and was minted without a roadmap row, so the roadmap and its operational milestone projection had drifted. This claims it.

## Verification

`pipeline-cli roadmap-guard check`: **6 → 5** violations. The resolved one is exactly:

```
[I3] open milestone #44 ("fabrika campaign") is not claimed by any arc or campaign row
```

The five survivors are unchanged line for line (the `#43` I3, plus the four pre-existing I5 active-row/closed-milestone rows) — no substitution. The new row adds no violation of its own: `active` against an open milestone satisfies I5.

`pipeline-cli cp-classify classify` on the changed-file set: `not-control-plane [path-clear-no-content-source]`.
`pnpm lint:worktree`: clean skip (no biome-handled files).

Issueless under ADR [0075](.decisions/0075-issueless-doc-pr-merge-seam.md) — the absence of a `Fixes`/`Closes` line is intentional.
