### PR TITLE
fix(pipeline): resolve the lane from the tree you stand in, not a session-wide stamp search (#4500)

### DIFF
--- a/claude-plugins/kampus-pipeline/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/lib/common-test.sh
@@ -417,7 +417,71 @@ else
 	fi
 fi
 
-# 22. `wt_preflight` with no lane identity at all refuses before it looks at any tree — the
+# The multi-lane fixture (#4500): TWO REAL linked worktrees of ONE session, both stamped with the
+# same id — the exact live condition, since sibling subagents share $CLAUDE_CODE_SESSION_ID. Real
+# `git worktree add` trees, not hand-built ones, because cases 22–24 resolve from INSIDE a worktree
+# and so need `git rev-parse --absolute-git-dir` to answer there.
+mkdir -p "$tmp/ml"
+if ! git -C "$tmp/ml" init -q --template='' >/dev/null 2>&1 ||
+	! git -C "$tmp/ml" -c user.name=kp-test -c user.email=kp-test@invalid commit -q --allow-empty -m init >/dev/null 2>&1 ||
+	! git -C "$tmp/ml" worktree add -q -b lane-a "$tmp/ml-a" >/dev/null 2>&1 ||
+	! git -C "$tmp/ml" worktree add -q -b lane-b "$tmp/ml-b" >/dev/null 2>&1; then
+	fail "fixture did not take: could not build the two-worktree fixture — cases 22–24 were NOT exercised"
+else
+	ml_sid="kp-test-lane-multi"
+	printf '%s\n' "$ml_sid" > "$tmp/ml/.git/worktrees/ml-a/kampus-lane"
+	printf '%s\n' "$ml_sid" > "$tmp/ml/.git/worktrees/ml-b/kampus-lane"
+	ml_a="$(cd "$tmp/ml-a" && pwd -P)"
+	ml_b="$(cd "$tmp/ml-b" && pwd -P)"
+
+	# 22. THE DEFECT (#4500). Two live lanes of one session: each resolves ITS OWN tree. Before the
+	# fix both refused, because the session-wide search found two stamps and `-eq 1` cannot hold for
+	# a value that is shared by construction — a hard cap of one concurrent lane on the whole factory.
+	out="$(cd "$tmp/ml-a" && CLAUDE_CODE_SESSION_ID="$ml_sid" lane_worktree)"; rc=$?
+	if [ "$rc" -eq 0 ] && [ "$out" = "$ml_a" ]; then
+		ok "lane_worktree in lane A resolves A while a same-session sibling is stamped (#4500)"
+	else
+		fail "lane_worktree multi-lane A: rc=$rc out=[$out] expected [$ml_a]"
+	fi
+	out="$(cd "$tmp/ml-b" && CLAUDE_CODE_SESSION_ID="$ml_sid" lane_worktree)"; rc=$?
+	if [ "$rc" -eq 0 ] && [ "$out" = "$ml_b" ]; then
+		ok "lane_worktree in lane B resolves B while a same-session sibling is stamped (#4500)"
+	else
+		fail "lane_worktree multi-lane B: rc=$rc out=[$out] expected [$ml_b]"
+	fi
+
+	# 23. The two refusals are DISTINGUISHABLE, by exit code and by message. They have opposite
+	# remedies, and emitting only the zero-case explanation for both is what kept #4500 misdiagnosed
+	# across five reproductions. Read from the fixture's PRIMARY checkout, which is where the
+	# session-wide search — and therefore genuine ambiguity — still lives.
+	err_many="$(cd "$tmp/ml" && CLAUDE_CODE_SESSION_ID="$ml_sid" wt_preflight 2>&1 >/dev/null)"; rc_many=$?
+	rm -f "$tmp/ml/.git/worktrees/ml-a/kampus-lane" "$tmp/ml/.git/worktrees/ml-b/kampus-lane"
+	err_none="$(cd "$tmp/ml" && CLAUDE_CODE_SESSION_ID="$ml_sid" wt_preflight 2>&1 >/dev/null)"; rc_none=$?
+	if [ "$rc_many" -eq 0 ] || [ "$rc_none" -eq 0 ]; then
+		fail "wt_preflight returned 0 from the primary checkout (many=$rc_many none=$rc_none) — both states must refuse"
+	elif ! grep -qF 'AMBIGUOUS' <<<"$err_many"; then
+		fail "wt_preflight's several-stamps refusal does not name ambiguity: [$err_many]"
+	elif grep -qF 'AMBIGUOUS' <<<"$err_none"; then
+		fail "wt_preflight's zero-stamp refusal claims ambiguity: [$err_none]"
+	elif ! grep -qF 'its tree is gone' <<<"$err_none"; then
+		fail "wt_preflight's zero-stamp refusal does not name a missing/torn-down tree: [$err_none]"
+	else
+		ok "wt_preflight names the actual cause: ambiguity vs missing tree are different messages (#4500)"
+	fi
+
+	# 24. A RETIRED stamp is `kampus-lane.retired`, which the `*/kampus-lane` glob does not match and
+	# the ambient read does not open — so operator-retired stamps leave a lane unresolvable rather
+	# than silently resolving a dead one. Pinned because the retire-by-rename sweep is live on hosts.
+	printf '%s\n' "$ml_sid" > "$tmp/ml/.git/worktrees/ml-a/kampus-lane.retired"
+	out="$(cd "$tmp/ml-a" && CLAUDE_CODE_SESSION_ID="$ml_sid" lane_worktree 2>/dev/null)"; rc=$?
+	if [ "$rc" -eq 0 ] || [ -n "$out" ]; then
+		fail "lane_worktree resolved [$out] from a RETIRED stamp (rc=$rc) — a retired lane must not resolve"
+	else
+		ok "lane_worktree ignores retired stamps (kampus-lane.retired), ambient and search alike"
+	fi
+fi
+
+# 25. `wt_preflight` with no lane identity at all refuses before it looks at any tree — the
 # `${CLAUDE_CODE_SESSION_ID:?}` floor. Run in a subshell because that expansion aborts the shell.
 out="$(CLAUDE_CODE_SESSION_ID='' wt_preflight 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ]; then

--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -426,29 +426,68 @@ kp__scratch() {
 # names stay unprefixed, against this file's `kp_` convention, because they ARE the names those
 # callers and write-code/SKILL.md refer to.
 #
-# The block below is VERBATIM from write-code/SKILL.md's per-mutation-preflight blockquote (epic
-# #4435 phase 1, #4449) — two-space indent included. Byte fidelity is the extraction's contract, so
-# it is not reindented to this file's tabs.
+# The block below was extracted from write-code/SKILL.md's per-mutation-preflight blockquote (epic
+# #4435 phase 1, #4449) and keeps that blockquote's two-space indent rather than this file's tabs;
+# SKILL.md now carries prose only, so the lib is the single source and reindenting it would be pure
+# diff noise.
 
 # Resolve MY worktree by IDENTITY, never from cwd (#4398). `git rev-parse --show-toplevel` answers
 # "where is the cwd" — which a between-calls reset makes a different question from "which tree is
 # mine". Deriving $WT from it and then re-deriving the toplevel to compare against is one answer
 # checked against itself: always equal, so its failure branch could never print. The stamp is
 # CONTENT written once when $WT was trustworthy, so these two operands can genuinely differ.
-lane_worktree() {   # print the absolute root of the worktree stamped with THIS lane's session id
-  common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+#
+# THE SESSION ID NAMES A SESSION, NOT A WORKTREE (#4500). Every sibling subagent of one dispatching
+# session shares $CLAUDE_CODE_SESSION_ID, so each lane's opening preflight stamps its own tree with
+# the SAME value and a session-wide search finds N of them — making the `-eq 1` assertion below
+# unsatisfiable for every lane after the first, and capping the factory at one concurrent lane.
+# Nothing in the process env distinguishes sibling lanes (measured on the harness: every CLAUDE_*
+# identifier, $CLAUDE_PID included, is session-scoped), so no per-worktree stamp VALUE could be
+# searched for either — a per-worktree key is only ever readable from the tree you are standing in.
+# Hence the two-path resolution: read the ambient tree's own stamp first, and fall back to the
+# session-wide search only when the cwd is the primary checkout (the harness's between-calls reset),
+# where the lane is genuinely unknowable if the session owns more than one tree. The `-eq 1`
+# assertion is therefore KEPT, unrelaxed — it now guards only the case where ambiguity is real.
+#
+# Exit codes are the cause: 0 ⇒ root on stdout; 2 ⇒ NO tree carries this lane's stamp; 3 ⇒ SEVERAL
+# do. 2 and 3 have opposite remedies and only 2's was ever printed, which is why this survived five
+# reproductions — every debugger was told its worktree was gone (#4661 fold-in).
+lane_worktree() {   # print the absolute root of THIS lane's worktree
+  common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 2
   case "$common" in /*) ;; *) common="$(pwd -P)/$common" ;; esac
-  common="$(cd "$common" && pwd -P)" || return 1   # -P: git answers in PHYSICAL paths, so must we
+  common="$(cd "$common" && pwd -P)" || return 2   # -P: git answers in PHYSICAL paths, so must we
+  # AMBIENT-FIRST. The operands stay independent (#4398): the stamp is durable CONTENT written when
+  # the tree was proven, matched against the process env, and the root comes from the durable
+  # `worktrees/<name>/gitdir` file — never from `--show-toplevel`, so nothing is compared to its own
+  # derivation. A linked tree carrying MY session's stamp is a tree my own opening preflight proved.
+  amb="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+  [ -n "$amb" ] && amb="$(cd "$amb" && pwd -P)"
+  if [ -n "$amb" ] && [ "$amb" != "$common" ] && [ -f "$amb/kampus-lane" ] &&
+     [ "$(cat "$amb/kampus-lane")" = "$CLAUDE_CODE_SESSION_ID" ] && [ -f "$amb/gitdir" ]; then
+    gd="$(cat "$amb/gitdir")" || return 2                 # "<worktree-root>/.git"
+    root="$(cd "${gd%/.git}" 2>/dev/null && pwd -P)" || return 2
+    [ -n "$root" ] || return 2
+    printf '%s\n' "$root"
+    return 0
+  fi
   hits=""
-  for st in "$common"/worktrees/*/kampus-lane; do
+  for st in "$common"/worktrees/*/kampus-lane; do   # a retired stamp is `kampus-lane.retired`: no match
     [ -f "$st" ] || continue
     [ "$(cat "$st")" = "$CLAUDE_CODE_SESSION_ID" ] || continue
-    gd="$(cat "${st%/kampus-lane}/gitdir")" || return 1   # "<worktree-root>/.git"
+    gd="$(cat "${st%/kampus-lane}/gitdir")" || return 2   # "<worktree-root>/.git"
     hits="$hits $(cd "${gd%/.git}" && pwd -P)"
   done
   set -- $hits
-  [ "$#" -eq 1 ] || return 1   # 0 ⇒ no tree is mine; >1 ⇒ ambiguous. Both REFUSE (fail-closed).
-  printf '%s\n' "$1"
+  if [ "$#" -eq 1 ]; then   # unchanged: exactly one, or REFUSE (fail-closed)
+    printf '%s\n' "$1"
+    return 0
+  fi
+  if [ "$#" -eq 0 ]; then
+    echo "lane_worktree: ZERO worktrees carry this lane's stamp ($CLAUDE_CODE_SESSION_ID) under $common/worktrees/." >&2
+    return 2
+  fi
+  echo "lane_worktree: AMBIGUOUS — $# worktrees carry this lane's stamp ($CLAUDE_CODE_SESSION_ID): $*" >&2
+  return 3
 }
 wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-closed, re-correcting cwd
   : "${CLAUDE_CODE_SESSION_ID:?wt_preflight FAILED (fail-closed): no session id — no lane identity to verify a worktree against}"
@@ -473,9 +512,19 @@ wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-cl
     return 1
   fi
   # cwd is my own tree or the PRIMARY checkout (the between-calls reset). Resolve my lane by
-  # identity and cd there — the correction. A miss REFUSES: no tree is mine (unprovisioned, torn
-  # down, or a foreign session), or several are (ambiguous).
-  WT="$(lane_worktree)" || { echo "wt_preflight FAILED (fail-closed): no single worktree carries this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2; return 1; }
+  # identity and cd there — the correction. A miss REFUSES, and the two misses get DIFFERENT
+  # messages because they have opposite remedies: rc 2 means re-establish a worktree, rc 3 means
+  # the cwd was reset to the primary checkout and only the lane itself can say which tree it is.
+  # One shared message that explained only rc 2 is what routed five debuggers to the wrong (and
+  # dangerous — self-provision, blanket worktree removal) remedy (#4500 AC4).
+  WT="$(lane_worktree)"
+  case "$?" in
+    0) ;;
+    3) echo "wt_preflight FAILED (fail-closed): AMBIGUOUS — SEVERAL worktrees carry this lane's stamp ($CLAUDE_CODE_SESSION_ID), listed above. Your worktree is NOT missing: sibling lanes of this same session are stamped too, and from the PRIMARY checkout the lane is unknowable. Re-run the mutation from your own lane's worktree (the root the opening preflight CONFIRMED) instead of re-running the opening preflight, self-provisioning, or removing worktrees. Refusing to mutate." >&2
+       return 1 ;;
+    *) echo "wt_preflight FAILED (fail-closed): ZERO worktrees carry this lane's stamp ($CLAUDE_CODE_SESSION_ID) — the opening preflight never ran, or its tree is gone. Refusing to mutate." >&2
+       return 1 ;;
+  esac
   cd "$WT" || { echo "wt_preflight FAILED: cannot cd to worktree root $WT" >&2; return 1; }
   # DEFENCE IN DEPTH — the resolved lane must not BE the primary checkout. This sits after the
   # `cd` and is still a genuine assertion, because its operands do not come from the cwd: it


### PR DESCRIPTION
Fixes #4500

## What was broken

`lane_worktree` (`claude-plugins/kampus-pipeline/lib/common.sh`) resolved "which worktree is mine" by
globbing every linked worktree's `kampus-lane` stamp, keeping those whose **content** equalled
`$CLAUDE_CODE_SESSION_ID`, and requiring **exactly one** hit.

That id names a **session**, not a worktree. Every sibling subagent of one dispatching session shares
it, so each lane's opening preflight stamps its own tree with the byte-identical value — making the
`-eq 1` assertion unsatisfiable for every lane after the first, and refusing every branch/commit/push
behind it. First-hand corroboration on this host: **17 stamp files, one identical value** (16 already
retired by hand, plus this lane's live one).

## What changed, and what deliberately did not

**The exactly-one assertion is kept, unrelaxed.** If two trees genuinely share a lane id, refusing is
correct — picking one would be the corruption the guard exists to prevent. What changed is that the
**spurious** ambiguity is no longer reached.

Resolution is now **ambient-first**: a linked worktree carrying *my* session's stamp is a tree my own
opening preflight proved, so it resolves directly. The session-wide search survives only as the
fallback for a cwd reset to the primary checkout — where, if the session owns several trees, the lane
is genuinely unknowable and the untouched `-eq 1` test refuses.

### A per-worktree stamp *value* was considered and does not work — the spec's premise needs correcting

The issue's fix-shape guidance was to make ambiguity unrepresentable by keying the stamp per
worktree. That is right in spirit but not implementable as a **search key**, and the reason is
measurable rather than a matter of taste:

- `lane_worktree` must *find* its stamp using only what the process knows.
- Every identifier the harness exposes is **session-scoped**, not lane-scoped. `$CLAUDE_CODE_SESSION_ID`
  is shared by construction, and `$CLAUDE_PID` is too — this lane's `CLAUDE_PID` is byte-identical to
  the pid in the **presence stamp of the claim comment written before this lane was spawned**, which
  is direct evidence it names the dispatching session's process, not the lane's.
- So no per-worktree value could be searched *for*. A per-worktree key is only ever readable **from
  the tree you are standing in** — and reading the ambient tree's own stamp is exactly what
  ambient-first resolution is. It is the same fix, arrived at from the side that is actually
  reachable.

The upside of this shape: **case 21's fixture and premise survive verbatim**, rather than being
re-expressed. See below.

### AC2 — the independent-operands property holds

The ambient path compares **durable stamp content**, written at opening-preflight time when `$WT` was
trustworthy, against the **process env** — the same pair #4398 established. The resolved root is read
from the durable `worktrees/<name>/gitdir` file, **never** from `git rev-parse --show-toplevel`, so
nothing is compared against its own derivation. `wt_preflight`'s post-resolution primary-checkout
assertion (two different plumbing queries that coincide only on the primary) is untouched and still
fires.

### AC4 — the two refusals are now distinguishable

`lane_worktree` exits **2** for zero stamps and **3** for several, and names the cause on stderr
(count + the matching roots). `wt_preflight` maps those to different messages:

- **zero** — `ZERO worktrees carry this lane's stamp (<id>) — the opening preflight never ran, or its
  tree is gone. Refusing to mutate.`
- **several** — `AMBIGUOUS — SEVERAL worktrees carry this lane's stamp (<id>), listed above. Your
  worktree is NOT missing: sibling lanes of this same session are stamped too, and from the PRIMARY
  checkout the lane is unknowable. Re-run the mutation from your own lane's worktree (the root the
  opening preflight CONFIRMED) instead of re-running the opening preflight, self-provisioning, or
  removing worktrees. Refusing to mutate.`

This is not cosmetic. The single shared message explained only the zero case, so five reproductions
were told their worktree had vanished and were routed toward remedies that are actively dangerous
(self-provision — forbidden by ADR 0172 for an isolation-expected run — or a blanket worktree removal
that would destroy other lanes' uncommitted work).

## Tests

**Cases 18–21 are untouched, fixtures included** — including case 21's two-trees-one-lane ambiguity
refusal. Its premise survives intact because it reads from the fixture's **primary checkout**, which
is exactly where the session-wide search, and therefore genuine ambiguity, still lives.

Added (`common-test.sh`), on a fixture of **two real linked worktrees of one session, both stamped
with the same id** — the live condition:

- **22** — each lane resolves **its own** root while a same-session sibling is stamped (AC1).
- **23** — the two refusals differ: the several-stamps message names ambiguity, the zero-stamp message
  does not and names a missing/torn-down tree (AC4), asserted at `wt_preflight`'s own surface.
- **24** — retired `kampus-lane.retired` stamps match neither the glob nor the ambient read, so an
  operator-retired lane refuses instead of silently resolving a dead one (verified rather than
  assumed, since the retire-by-rename sweep is live on hosts).

**Falsification** — case 22 pins the defect, not the fix: the pre-fix `lane_worktree` body, extracted
verbatim and run against the same two-worktree scenario, returns `rc=1` with empty stdout.

**Suite: 28/28 green** (`bash claude-plugins/kampus-pipeline/lib/common-test.sh`). Also green:
`trap-status-guard check` over the full plugin corpus (336 files, 318 fences, 256 shell units),
`verify-fail-closed.sh`, `verify-executed-contract.sh`, and shellcheck (the only finding is a
pre-existing SC1007 on an untouched line).

## Deviations

- **Class 1 — a different fix-shape from the issue's suggested direction.** **Said:** #4500's
  *Suggested direction* (explicitly non-binding) asks that the `kampus-lane` stamp be keyed per
  **worktree** — write the worktree's git-dir basename alongside the session id and match the pair,
  or have the opening preflight record its resolved root and have the guard verify that path.
  **Did:** kept the stamp session-keyed and byte-identical, and changed **resolution** instead:
  `lane_worktree` is now ambient-first — it reads the ambient linked tree's own stamp before it falls
  back to the session-wide search. **Why:** a per-worktree stamp *value* is not a worse shape, it is
  **unimplementable as a search key**. `lane_worktree` has to *find* its stamp using only what the
  process knows, and every identifier the harness exposes is **session**-scoped:
  `$CLAUDE_CODE_SESSION_ID` is shared across sibling subagents by construction, and `$CLAUDE_PID` is
  too — this lane's `CLAUDE_PID` is byte-identical to the pid in the presence stamp of a claim
  comment written **before this lane was spawned**, which is direct evidence it names the dispatching
  session's process, not the lane's. With no per-lane discriminator to search *by*, a per-worktree key
  is only ever readable **from the tree you are standing in** — which is exactly what ambient-first
  does, arrived at from the side that is reachable. The other half of the guidance (split the 0-hit
  and >1-hit refusals) is implemented as asked. **Disposition:** no ADR needed — the guidance is
  non-binding and this corrects its premise rather than contradicting a decision; the long form is
  under *"A per-worktree stamp value was considered and does not work"* above.

- **Class 1 — a real behavior change against an acceptance criterion's enumeration, disclosed rather
  than left to be found.** **Said:** AC3 requires that all existing fail-closed refusals still fire,
  naming *"a sibling lane's tree as ambient cwd"* among them. **Did:** ambient-first **changes** that
  behavior in one case — standing inside a **same-session** sibling lane's worktree, `lane_worktree`
  now resolves *that* tree (rc=0) where the pre-fix body refused. **Why:** (a) the *named* sibling
  refusal lives in `wt_preflight`, keys on a stamp **MISMATCH**, is **byte-unchanged** by this diff,
  and still runs **before** `lane_worktree` is ever called — so cross-**session** bleed (#832,
  #3458/#3580) stays fully blocked; (b) the same-session case was never caught by a refusal written
  for it — it was caught only collaterally by the `-eq 1` ambiguity assertion, i.e. **by the outage
  #4500 is filed against**, which refused every mutation in every lane; and (c) because stamping is
  session-scoped, "I am in my own tree" and "I am in a same-session sibling's tree" are the **same
  observable state** — no information exists that separates them — so AC3 cannot be read to demand a
  refusal that AC1's required pass makes unsatisfiable. **Disposition:** for the reviewer to judge;
  stated plainly here so the trade is visible at the head that ships it, not reconstructed later.

- **Class 2 / 7 — an in-prose contract rewritten in a header the issue never asked me to touch.**
  **Said:** `lib/common.sh`'s own header declared the guard block *"VERBATIM from
  write-code/SKILL.md's per-mutation-preflight blockquote (epic #4435 phase 1, #4449) — two-space
  indent included. Byte fidelity is the extraction's contract, so it is not reindented."* Nothing in
  #4500 asks to revisit that. **Did:** rewrote that paragraph — the block is no longer byte-identical
  to any SKILL.md fence, and the header now states that the lib is the single source and keeps the
  two-space indent only because reindenting would be diff noise. **Why:** the fix necessarily edits
  the block, so leaving a "VERBATIM / byte fidelity is the contract" claim standing would have left a
  **false invariant** on the page for the next reader to trust; and the claim was already stale —
  SKILL.md's per-mutation-preflight section carries prose plus a script invocation at this head, not
  the guard body. **Disposition:** no ADR needed (the claim lived in a file comment, never in an
  ADR), but flagged for the reviewer as a prose-invariant edit — the #3986 class this section exists
  for.

**Classes walked that did not fire.** 3 — no adjacent defect on this surface was seen and left
unfixed. 5 — no guard or gate bypassed: no `--no-verify`, no skipped or disabled hook, no
`biome-ignore` / `@ts-expect-error` / skipped test, no widened allowlist (the single shellcheck
finding, SC1007, is pre-existing on an untouched line and is not newly suppressed). 6 — no
pre-existing test or fixture assertion modified, weakened or deleted: cases 18–21 are
**byte-unchanged**, case 21's two-trees-one-lane ambiguity fixture and premise included, because the
fix removes the **upstream cause** of *spurious* ambiguity rather than relaxing the `-eq 1`
assertion, which is kept unrelaxed. The only edit to an existing test line is the old case `22`
renumbered to `25` in its comment.

## §CP

`cp-classify classify` ⇒ **control-plane** [path-match] on
`claude-plugins/kampus-pipeline/lib/common.sh` — **BLOCKING (human merge)**. Needs a
`@kamp-us/control-plane` approval at head; not enqueued, not self-approved.

