### PR TITLE
feat(eval-harness): the deterministic tier — one run, no model, and a flake is a defect (#4677)

### DIFF
--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -175,6 +175,87 @@ total: a malformed body or a shape mismatch exits non-zero with a typed reason, 
 The shape is stable: field names + nesting are the contract, and `toJson` is a thin projection of
 the in-memory `Scorecard` so the JSON and the type never drift.
 
+## The deterministic tier ([#4677](https://github.com/kamp-us/phoenix/issues/4677))
+
+The no-model half of the fabrika eval layer (epic
+[#4649](https://github.com/kamp-us/phoenix/issues/4649)). A case whose assertions are all
+mechanically checkable never needs a model: it runs its CLI-layer command **once**, and its
+assertions are read straight off what that run produced. This is the tier that keeps a
+100%-and-growing regression floor cheap enough to sit on every change, and it is where
+incident-derived cases are pushed by default (founder ruling 4 on
+[#4637](https://github.com/kamp-us/phoenix/issues/4637)); the graded path is the justified
+exception, and it is the review stage's, not CI's (the ruling on
+[#4649](https://github.com/kamp-us/phoenix/issues/4649#issuecomment-5153280445)).
+
+`deterministic-tier.ts` is the **pure core** — it imports nothing, so it can reach nothing
+spawnable, and a unit test reads its import list to keep it that way.
+`deterministic-shell-observer.ts` is the **one IO leg**: it spawns a *process*, never a model.
+
+### The one-run protocol, and the flake stance as a mechanism
+
+- `runDeterministicTier({cases, resolveCommand, observe, deferGraded})` routes each decoded case
+  by its derived `tier` and executes the deterministic half **exactly once**. `deferGraded` is the
+  handoff to the graded tier ([#4678](https://github.com/kamp-us/phoenix/issues/4678)) and the only
+  seam here through which a model could ever be reached — it is never called for a deterministic
+  case, which is what a caller (or a test) asserts against.
+- Nothing in this module re-executes a case to obtain a pass. `reconcileRerun(first, rerun)` exists
+  for the opposite purpose: an **agreeing** re-run returns the first row untouched (`runs` stays 1
+  — the verdict came from one execution), and a **disagreeing** one returns a `flake` row plus a
+  `FlakeDefect` to file through the normal `report` path. A deterministic case that does not
+  reproduce is a bug in the case or in the CLI it exercises — surfaced, never quarantined, never
+  retried into green.
+
+### Everything unreadable is a case defect, never a pass
+
+`readExpectation` reads a mechanical assertion's prose into a concrete expectation (an expected
+exit code, a quoted output substring and its stream, a quoted file path, a quoted tool) with a
+deliberately narrow literal reader. Every shape it cannot read becomes `Unreadable`, which reds
+the case as `uncheckable`. The direction is the point: a permissive reader that *guessed* an
+expectation would report a green nobody earned, whereas an `Unreadable` costs a one-line edit to
+the case. The same rule covers a case with no assertions, a case declaring no command, an unknown
+cue, and a `tool-invocation` assertion under the shell observer (which cannot see tool invocations
+and says so, rather than answering "not invoked").
+
+**Did-not-run is UNKNOWN, not a negative answer.** A command that never started (no binary, a bad
+cwd) reports `notRun` and the case reds `uncheckable`; a command that started and was killed
+reports `exitStatus: null` with `notRun: null` and genuinely fails. An `exit 127` from a shell that
+*did* run is an ordinary answered status, distinct from both.
+
+### One row shape, one aggregation path
+
+Both tiers emit `EvalRow` — `{caseId, tier, outcome, runs, assertions, detail}`, where each
+`AssertionOutcome` is the flat `{text, cue, status, detail}` (a judged assertion carries
+`cue: null`). `summarizeEvalRows(rows)` is **the** aggregator: graded rows fold in here rather than
+through a second path. Its verdict is green only when every row passed, and **zero rows is red**,
+never a vacuous green over a corpus the suite could not see (ADR
+[0092](../../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)).
+
+```ts
+import {runDeterministicTier, reconcileRerun, summarizeEvalRows} from "./deterministic-tier.ts";
+import {observeShellCommand} from "./deterministic-shell-observer.ts";
+```
+
+### Measured cost
+
+**20 deterministic cases, two mechanical assertions each, real subprocess per case: 55–58 ms
+(~2.8 ms/case)** — measured on macOS 14 / Node 26 over three consecutive runs. That is well inside
+"sits on an ordinary change": the whole tier costs less than a single `tsc` file. The subprocess is
+the only cost that matters; the pure judging is free.
+
+Re-measure with the end-to-end suite, which prints the figure:
+
+```bash
+pnpm --filter @kampus/pipeline-cli exec vitest run \
+  src/tools/eval-harness/deterministic-shell-observer.unit.test.ts --reporter=verbose
+```
+
+The suite asserts the observable outcome — a green over cases that hold, a **red** over one that
+genuinely fails — and never a wall-clock threshold: a timing assertion is precisely the flaky test
+the ruling this tier implements calls a bug. The figure above is measured over a 20-case
+corpus-shaped stand-in, because the fabrika incident corpus
+([#4675](https://github.com/kamp-us/phoenix/issues/4675)) has not landed yet; re-run the command
+above against it once it does and update this number.
+
 ## Why it exists
 
 ADR 0112's apparatus grades **one** frozen input per stage with a **binary** oracle —

--- a/packages/pipeline-cli/src/tools/eval-harness/deterministic-shell-observer.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/deterministic-shell-observer.ts
@@ -1,0 +1,75 @@
+/**
+ * The deterministic tier's shell observer — the one IO leg of issue #4677.
+ *
+ * `deterministic-tier.ts` is pure and never spawns; this file is where a case's CLI-layer command
+ * actually runs. It spawns a **process**, never a model — that separation is the point, and it is
+ * why the two live in different files: the tier's purity is checkable by reading its imports.
+ *
+ * Sync `spawnSync` matches this package's existing subprocess idiom (`main-sync`, `verified-push`)
+ * and keeps the observer a plain function the pure core can call.
+ */
+import {spawnSync} from "node:child_process";
+import {existsSync} from "node:fs";
+import {isAbsolute, resolve} from "node:path";
+import type {
+	CaseObserver,
+	CliObservation,
+	DeterministicCommand,
+	TieredEvalCase,
+} from "./deterministic-tier.ts";
+import {namedArtifactPaths} from "./deterministic-tier.ts";
+
+/** A CLI-layer eval case that outruns this is a case defect, not a slow machine. */
+export const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+/** Well above the 1 MB default: exceeding `maxBuffer` kills the child and forges a failure. */
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Run one case's command and report what it produced.
+ *
+ * The `notRun` / killed distinction is the §ZS rule in code. A command that never started (no
+ * binary, a bad cwd) yields `notRun`, which the tier reads as UNKNOWN — never as "the assertion
+ * failed". A command that started and was then killed (timeout, signal) reports `exitStatus: null`
+ * with `notRun: null`: it *did* run and did not answer, which is a genuine failure of the case.
+ *
+ * `toolInvocations` is `null` because a plain subprocess cannot see which tools a run used. That
+ * is an honest "cannot observe", so a `tool-invocation` assertion reds as a case defect here
+ * rather than silently failing — a transcript-backed observer (#4676) is what can answer it.
+ */
+export const observeShellCommand: CaseObserver = (
+	evalCase: TieredEvalCase,
+	command: DeterministicCommand,
+): CliObservation => {
+	const cwd = command.cwd ?? process.cwd();
+	const run = spawnSync(command.command, [...command.args], {
+		cwd,
+		encoding: "utf8",
+		timeout: command.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+		maxBuffer: MAX_OUTPUT_BYTES,
+	});
+
+	// `error` with no signal means the child never started at all — ENOENT, EACCES, a bad cwd.
+	// A timeout also sets `error`, but with a signal, and that child DID run.
+	if (run.error !== undefined && run.signal === null) {
+		return {
+			exitStatus: null,
+			stdout: "",
+			stderr: "",
+			artifacts: [],
+			toolInvocations: null,
+			notRun: run.error.message,
+		};
+	}
+
+	return {
+		exitStatus: run.status,
+		stdout: run.stdout ?? "",
+		stderr: run.stderr ?? "",
+		artifacts: namedArtifactPaths(evalCase).filter((path) =>
+			existsSync(isAbsolute(path) ? path : resolve(cwd, path)),
+		),
+		toolInvocations: null,
+		notRun: null,
+	};
+};

--- a/packages/pipeline-cli/src/tools/eval-harness/deterministic-shell-observer.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/deterministic-shell-observer.unit.test.ts
@@ -1,0 +1,142 @@
+import {mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts";
+import {observeShellCommand} from "./deterministic-shell-observer.ts";
+import {
+	type DeterministicCommand,
+	runDeterministicTier,
+	summarizeEvalRows,
+	type TieredEvalCase,
+} from "./deterministic-tier.ts";
+
+const mechanical = (text: string, cue: string) => ({kind: "mechanical", text, cue}) as const;
+
+const evalCase = (id: number, assertions: TieredEvalCase["assertions"]): TieredEvalCase => ({
+	id,
+	tier: "deterministic",
+	assertions,
+});
+
+const sh = (script: string, cwd: string | null = null): DeterministicCommand => ({
+	command: "bash",
+	args: ["-c", script],
+	cwd,
+	timeoutMs: 10_000,
+});
+
+describe("observeShellCommand — a real process, never a model", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("reports the exit status and both streams of a run that answered", () => {
+		const observation = observeShellCommand(
+			evalCase(1, []),
+			sh("printf out; printf err >&2; exit 3"),
+		);
+		assert.strictEqual(observation.exitStatus, 3);
+		assert.strictEqual(observation.stdout, "out");
+		assert.strictEqual(observation.stderr, "err");
+		assert.strictEqual(observation.notRun, null);
+	});
+
+	it("reports a command that never started as notRun, not as a failing status (§ZS)", () => {
+		const observation = observeShellCommand(evalCase(1, []), {
+			command: "kampus-no-such-binary-4677",
+			args: [],
+			cwd: null,
+			timeoutMs: 5_000,
+		});
+		assert.strictEqual(observation.notRun !== null, true);
+		assert.strictEqual(observation.exitStatus, null);
+	});
+
+	it("distinguishes an exit 127 (ran, answered) from a did-not-run", () => {
+		const observation = observeShellCommand(evalCase(1, []), sh("kampus-no-such-binary-4677"));
+		assert.strictEqual(observation.exitStatus, 127);
+		assert.strictEqual(observation.notRun, null);
+	});
+
+	it("probes only the artifact paths the case's assertions name", () => {
+		const dir = mkdtempSync(join(tmpdir(), "eval-artifacts-"));
+		try {
+			writeFileSync(join(dir, "made.txt"), "x");
+			const observation = observeShellCommand(
+				evalCase(1, [
+					mechanical("a file named `made.txt` exists", "file-artifact"),
+					mechanical("a file named `absent.txt` exists", "file-artifact"),
+				]),
+				sh("true", dir),
+			);
+			assert.deepStrictEqual(observation.artifacts, ["made.txt"]);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	});
+
+	it("cannot see tool invocations, and says so rather than answering no", () => {
+		const observation = observeShellCommand(evalCase(1, []), sh("true"));
+		assert.strictEqual(observation.toolInvocations, null);
+	});
+});
+
+/**
+ * The measurement AC4 asks for. Deliberately a real end-to-end pass — process spawn included —
+ * because the subprocess is the only cost that matters at this tier; the pure judging is free.
+ *
+ * It asserts the observable outcome (a green suite over cases that hold, a red over one that
+ * doesn't), never a wall-clock threshold: a timing assertion is exactly the flaky test the
+ * ruling this tier implements calls a bug. The measured figure is recorded in the README, and
+ * this suite is the command that re-measures it.
+ */
+describe("the deterministic tier end to end over a corpus-shaped set", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	const CASES = 20;
+
+	const corpusShaped = (): ReadonlyArray<TieredEvalCase> =>
+		Array.from({length: CASES}, (_, i) =>
+			evalCase(i + 1, [
+				mechanical("exits 0", "exit-status"),
+				mechanical(`stdout contains 'case-${i + 1}'`, "output-content"),
+			]),
+		);
+
+	it(`runs ${CASES} cases green, one run each`, () => {
+		const started = Date.now();
+		const run = runDeterministicTier({
+			cases: corpusShaped(),
+			resolveCommand: (c) => sh(`printf 'case-%s' ${c.id}`),
+			observe: observeShellCommand,
+			deferGraded: () => {
+				throw new Error("a model was spawned for a deterministic case");
+			},
+		});
+		const elapsedMs = Date.now() - started;
+		const summary = summarizeEvalRows(run.rows);
+
+		assert.strictEqual(summary.verdict, "green");
+		assert.strictEqual(summary.total.cases, CASES);
+		assert.deepStrictEqual(
+			run.rows.map((r) => r.runs),
+			Array.from({length: CASES}, () => 1),
+		);
+		// The figure the README records; printed so a re-measure is a read, not a rerun-and-time.
+		console.log(`deterministic tier: ${CASES} cases in ${elapsedMs}ms`);
+	});
+
+	it("goes red on a case that genuinely fails — the tier is observed red, not assumed", () => {
+		const run = runDeterministicTier({
+			cases: [
+				evalCase(1, [mechanical("exits 0", "exit-status")]),
+				evalCase(2, [mechanical("exits 0", "exit-status")]),
+			],
+			resolveCommand: (c) => sh(c.id === 2 ? "exit 4" : "true"),
+			observe: observeShellCommand,
+		});
+		const summary = summarizeEvalRows(run.rows);
+		assert.strictEqual(summary.verdict, "red");
+		assert.strictEqual(summary.total.failed, 1);
+		assert.strictEqual(run.rows[1]?.detail, "exit status was 4, expected 0");
+	});
+});

--- a/packages/pipeline-cli/src/tools/eval-harness/deterministic-tier.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/deterministic-tier.ts
@@ -1,0 +1,489 @@
+/**
+ * eval-harness deterministic tier — the no-model half of the fabrika eval layer (issue #4677,
+ * epic #4649).
+ *
+ * A case whose assertions are all mechanically checkable never needs a model: it runs its
+ * CLI-layer command **once**, and its assertions are read straight off what that run produced.
+ * This module owns that judgement, the one-run protocol (`reconcileRerun`), and `EvalRow` — the
+ * row shape the graded tier (#4678) reports in too, so one aggregator serves both.
+ *
+ * The tier is pure: `resolveCommand` and `observe` are supplied by the caller, so the only IO is
+ * the caller's. That is what makes "no model in the loop" *checkable* rather than asserted — this
+ * file imports nothing, so it can reach nothing spawnable, and `deferGraded` is its only handoff
+ * toward a model-bearing path.
+ *
+ * The case shape it consumes is #4674's decoded `SkillEvalCase` (`skill-eval-set.ts`), read
+ * structurally so this tier re-derives no parser and adds no field to the authored format.
+ */
+
+/**
+ * The two tiers a decoded case routes to. Same two values #4674's derived `EvalTier` yields;
+ * named separately here so the row shape does not depend on the ingestion module's type.
+ */
+export type EvalRowTier = "deterministic" | "graded";
+
+/**
+ * A decoded assertion, read structurally: #4674's `SkillEvalAssertion` satisfies this, and `cue`
+ * is widened to `string` so this tier never restates that module's cue lexicon.
+ */
+export type TieredAssertion =
+	| {readonly kind: "mechanical"; readonly text: string; readonly cue: string}
+	| {readonly kind: "judgment"; readonly text: string};
+
+/** A decoded eval case, read structurally — the fields this tier actually reads, and no more. */
+export interface TieredEvalCase {
+	readonly id: number;
+	readonly tier: EvalRowTier;
+	readonly assertions: ReadonlyArray<TieredAssertion>;
+}
+
+/** The CLI-layer command one deterministic case runs. Not part of the authored eval format. */
+export interface DeterministicCommand {
+	readonly command: string;
+	readonly args: ReadonlyArray<string>;
+	readonly cwd: string | null;
+	readonly timeoutMs: number | null;
+}
+
+/** What one CLI-layer run produced — the only thing a mechanical assertion is ever read against. */
+export interface CliObservation {
+	/** The exit status the run reported, or `null` when it was killed before reporting one. */
+	readonly exitStatus: number | null;
+	readonly stdout: string;
+	readonly stderr: string;
+	/** Of the paths the case's `file-artifact` assertions name, the ones present after the run. */
+	readonly artifacts: ReadonlyArray<string>;
+	/** Tools the run was seen to invoke, or `null` when this observer cannot see them at all. */
+	readonly toolInvocations: ReadonlyArray<string> | null;
+	/**
+	 * Why the command never started, or `null` when it ran. A did-not-run is UNKNOWN, so it must
+	 * be distinguishable from a run that answered — never collapsed into a failing exit status.
+	 */
+	readonly notRun: string | null;
+}
+
+/**
+ * One assertion's outcome. Deliberately flat and tier-agnostic: the graded tier (#4678) reports
+ * judged assertions in this same shape with `cue: null`, so there is one row model, not two.
+ */
+export interface AssertionOutcome {
+	readonly text: string;
+	/** The mechanical cue checked, or `null` for a judged assertion. */
+	readonly cue: string | null;
+	readonly status: "pass" | "fail" | "uncheckable";
+	/** Why it is not a pass — `null` on a pass. */
+	readonly detail: string | null;
+}
+
+/**
+ * A case's outcome. Everything that is not `pass` is a failure of the suite: `uncheckable` and
+ * `flake` are defects *of the case* (or of the CLI it exercises) and are reported as such, but
+ * neither is ever tolerated into green.
+ */
+export type EvalRowOutcome = "pass" | "fail" | "uncheckable" | "flake";
+
+/**
+ * One eval case's result — the single row shape **both** tiers emit, so the report path
+ * aggregates them through one aggregation function (`summarizeEvalRows`) rather than two.
+ */
+export interface EvalRow {
+	readonly caseId: number;
+	readonly tier: EvalRowTier;
+	readonly outcome: EvalRowOutcome;
+	/** Executions behind this row. Deterministic is always `1` — the tier never retries. */
+	readonly runs: number;
+	readonly assertions: ReadonlyArray<AssertionOutcome>;
+	/** Why the row is not a pass — `null` on a pass. */
+	readonly detail: string | null;
+}
+
+/** What a mechanical assertion's prose was read to mean, or why it could not be read. */
+export type Expectation =
+	| {readonly _tag: "ExitStatus"; readonly code: number}
+	| {readonly _tag: "ExitNonZero"}
+	| {
+			readonly _tag: "Substring";
+			readonly stream: "stdout" | "stderr" | "any";
+			readonly needle: string;
+	  }
+	| {readonly _tag: "FileExists"; readonly path: string}
+	| {readonly _tag: "ToolInvoked"; readonly tool: string}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+/**
+ * The first quoted run in an assertion's text — the literal the assertion is about. Backticks,
+ * straight quotes and typographic quotes all count, because assertions are authored as prose by
+ * a human and a smart-quoted path is the same path.
+ */
+const QUOTED = /[`"'‘“]([^`"'’”]+)[`"'’”]/;
+
+const quoted = (text: string): string | null => QUOTED.exec(text)?.[1]?.trim() || null;
+
+const EXIT_NON_ZERO = /\bnon-?zero\b/i;
+const EXIT_CODE = /\bexit(?:s|ed)?(?:\s+(?:code|status))?\s*(?:is|of|was|=|==|:)?\s*(\d+)\b/i;
+
+/**
+ * Read one mechanical assertion's prose into a concrete expectation.
+ *
+ * Deliberately literal and narrow rather than a general parser: every shape it cannot read
+ * becomes `Unreadable`, which reds the case as a defect. That direction is the whole point —
+ * a permissive reader that guessed an expectation would report a green nobody earned, whereas
+ * an `Unreadable` costs a one-line edit to the case.
+ */
+export const readExpectation = (assertion: TieredAssertion): Expectation => {
+	if (assertion.kind === "judgment") {
+		return {
+			_tag: "Unreadable",
+			reason: "judgment assertion on a deterministic case — it belongs on the graded tier",
+		};
+	}
+	const text = assertion.text;
+	switch (assertion.cue) {
+		case "exit-status": {
+			if (EXIT_NON_ZERO.test(text)) return {_tag: "ExitNonZero"};
+			const code = EXIT_CODE.exec(text)?.[1];
+			return code === undefined
+				? {_tag: "Unreadable", reason: "names no expected exit code"}
+				: {_tag: "ExitStatus", code: Number(code)};
+		}
+		case "output-content": {
+			const needle = quoted(text);
+			if (needle === null) return {_tag: "Unreadable", reason: "names no quoted expected output"};
+			const lowered = text.toLowerCase();
+			const stream = lowered.includes("stderr")
+				? ("stderr" as const)
+				: lowered.includes("stdout")
+					? ("stdout" as const)
+					: ("any" as const);
+			return {_tag: "Substring", stream, needle};
+		}
+		case "file-artifact": {
+			const path = quoted(text);
+			return path === null
+				? {_tag: "Unreadable", reason: "names no quoted file path"}
+				: {_tag: "FileExists", path};
+		}
+		case "tool-invocation": {
+			const tool = quoted(text);
+			return tool === null
+				? {_tag: "Unreadable", reason: "names no quoted tool"}
+				: {_tag: "ToolInvoked", tool};
+		}
+		default:
+			return {_tag: "Unreadable", reason: `unknown cue '${assertion.cue}'`};
+	}
+};
+
+/** The file paths a case's `file-artifact` assertions name — what an observer must probe for. */
+export const namedArtifactPaths = (evalCase: TieredEvalCase): ReadonlyArray<string> => {
+	const paths: Array<string> = [];
+	for (const assertion of evalCase.assertions) {
+		const expectation = readExpectation(assertion);
+		if (expectation._tag === "FileExists") paths.push(expectation.path);
+	}
+	return paths;
+};
+
+const pass = (assertion: TieredAssertion, cue: string | null): AssertionOutcome => ({
+	text: assertion.text,
+	cue,
+	status: "pass",
+	detail: null,
+});
+
+const fail = (
+	assertion: TieredAssertion,
+	cue: string | null,
+	detail: string,
+): AssertionOutcome => ({
+	text: assertion.text,
+	cue,
+	status: "fail",
+	detail,
+});
+
+const uncheckable = (
+	assertion: TieredAssertion,
+	cue: string | null,
+	detail: string,
+): AssertionOutcome => ({text: assertion.text, cue, status: "uncheckable", detail});
+
+/** Check one mechanical assertion against a run's observation. Total — never throws. */
+export const checkAssertion = (
+	assertion: TieredAssertion,
+	observation: CliObservation,
+): AssertionOutcome => {
+	const cue = assertion.kind === "mechanical" ? assertion.cue : null;
+	const expectation = readExpectation(assertion);
+	switch (expectation._tag) {
+		case "Unreadable":
+			return uncheckable(assertion, cue, expectation.reason);
+		case "ExitStatus":
+			if (observation.exitStatus === null) {
+				return fail(assertion, cue, "the run was killed before it reported an exit status");
+			}
+			return observation.exitStatus === expectation.code
+				? pass(assertion, cue)
+				: fail(
+						assertion,
+						cue,
+						`exit status was ${observation.exitStatus}, expected ${expectation.code}`,
+					);
+		case "ExitNonZero":
+			if (observation.exitStatus === null) {
+				return fail(assertion, cue, "the run was killed before it reported an exit status");
+			}
+			return observation.exitStatus !== 0
+				? pass(assertion, cue)
+				: fail(assertion, cue, "exit status was 0, expected non-zero");
+		case "Substring": {
+			const haystack =
+				expectation.stream === "stdout"
+					? observation.stdout
+					: expectation.stream === "stderr"
+						? observation.stderr
+						: `${observation.stdout}\n${observation.stderr}`;
+			return haystack.includes(expectation.needle)
+				? pass(assertion, cue)
+				: fail(assertion, cue, `${expectation.stream} does not contain '${expectation.needle}'`);
+		}
+		case "FileExists":
+			return observation.artifacts.includes(expectation.path)
+				? pass(assertion, cue)
+				: fail(assertion, cue, `no file at '${expectation.path}' after the run`);
+		case "ToolInvoked":
+			// An observer that cannot see tool invocations at all has not answered "it wasn't
+			// invoked" — that is UNKNOWN, so the case reds as a defect rather than a false fail.
+			if (observation.toolInvocations === null) {
+				return uncheckable(
+					assertion,
+					cue,
+					"this observer cannot see tool invocations — the case needs a transcript-backed one",
+				);
+			}
+			return observation.toolInvocations.includes(expectation.tool)
+				? pass(assertion, cue)
+				: fail(assertion, cue, `the run did not invoke '${expectation.tool}'`);
+	}
+};
+
+const rowOutcome = (assertions: ReadonlyArray<AssertionOutcome>): EvalRowOutcome => {
+	if (assertions.some((a) => a.status === "uncheckable")) return "uncheckable";
+	return assertions.some((a) => a.status === "fail") ? "fail" : "pass";
+};
+
+const firstDetail = (
+	assertions: ReadonlyArray<AssertionOutcome>,
+	status: AssertionOutcome["status"],
+): string | null => assertions.find((a) => a.status === status)?.detail ?? null;
+
+/**
+ * Judge one deterministic case from a single run's observation. Pure and total: this is the whole
+ * verdict for the case, and it is reached in exactly one execution.
+ */
+export const judgeDeterministicCase = (
+	evalCase: TieredEvalCase,
+	observation: CliObservation,
+): EvalRow => {
+	const base = {caseId: evalCase.id, tier: "deterministic" as const, runs: 1};
+	if (observation.notRun !== null) {
+		return {
+			...base,
+			outcome: "uncheckable",
+			assertions: [],
+			detail: `the case's command never ran (${observation.notRun})`,
+		};
+	}
+	if (evalCase.assertions.length === 0) {
+		return {
+			...base,
+			outcome: "uncheckable",
+			assertions: [],
+			detail: "the case carries no assertions — there is nothing to check",
+		};
+	}
+	const assertions = evalCase.assertions.map((a) => checkAssertion(a, observation));
+	const outcome = rowOutcome(assertions);
+	return {
+		...base,
+		outcome,
+		assertions,
+		detail:
+			outcome === "pass"
+				? null
+				: firstDetail(assertions, outcome === "fail" ? "fail" : "uncheckable"),
+	};
+};
+
+/** Resolves the CLI-layer command a case runs, or `null` when the case declares none. */
+export type CommandResolver = (evalCase: TieredEvalCase) => DeterministicCommand | null;
+
+/** Runs one case's command and reports what it produced. The caller's only IO seam. */
+export type CaseObserver = (
+	evalCase: TieredEvalCase,
+	command: DeterministicCommand,
+) => CliObservation;
+
+/** What one pass over a set produced: a row per deterministic case, and the graded ids it routed away. */
+export interface DeterministicTierRun {
+	readonly rows: ReadonlyArray<EvalRow>;
+	readonly deferredToGraded: ReadonlyArray<number>;
+}
+
+/**
+ * Route a decoded set by tier and execute the deterministic half — each case exactly once.
+ *
+ * `deferGraded` is the handoff to #4678's model-bearing path and is the only seam in this module
+ * through which a model could ever be reached. It is called for graded cases and **never** for a
+ * deterministic one, which is what a caller (or a test) asserts against to prove no model entered
+ * the loop.
+ */
+export const runDeterministicTier = (args: {
+	readonly cases: ReadonlyArray<TieredEvalCase>;
+	readonly resolveCommand: CommandResolver;
+	readonly observe: CaseObserver;
+	readonly deferGraded?: (evalCase: TieredEvalCase) => void;
+}): DeterministicTierRun => {
+	const rows: Array<EvalRow> = [];
+	const deferredToGraded: Array<number> = [];
+	for (const evalCase of args.cases) {
+		if (evalCase.tier !== "deterministic") {
+			deferredToGraded.push(evalCase.id);
+			args.deferGraded?.(evalCase);
+			continue;
+		}
+		const command = args.resolveCommand(evalCase);
+		if (command === null) {
+			rows.push({
+				caseId: evalCase.id,
+				tier: "deterministic",
+				outcome: "uncheckable",
+				runs: 0,
+				assertions: [],
+				detail: "the case declares no CLI-layer command to run",
+			});
+			continue;
+		}
+		rows.push(judgeDeterministicCase(evalCase, args.observe(evalCase, command)));
+	}
+	return {rows, deferredToGraded};
+};
+
+/** A deterministic case that did not reproduce — a defect of the case, routed like any other bug. */
+export interface FlakeDefect {
+	readonly caseId: number;
+	readonly firstOutcome: EvalRowOutcome;
+	readonly rerunOutcome: EvalRowOutcome;
+	/** A one-line body for the `report` path — the flake stance as a mechanism, not a slogan. */
+	readonly summary: string;
+}
+
+const assertionShape = (row: EvalRow): string =>
+	row.assertions.map((a) => `${a.cue ?? "judged"}:${a.status}`).join("|");
+
+/**
+ * Reconcile a deliberate re-run against the first run.
+ *
+ * This is **not** a retry and can never turn a fail into a pass: an agreeing re-run returns the
+ * first row untouched (`runs` stays 1 — the verdict came from one execution), and a disagreeing
+ * one returns a `flake` row plus a defect to file. Non-reproduction is a bug in the case or in the
+ * CLI it exercises, so it is surfaced, never quarantined and never retried into green.
+ */
+export const reconcileRerun = (
+	first: EvalRow,
+	rerun: EvalRow,
+): {readonly row: EvalRow; readonly defect: FlakeDefect | null} => {
+	const agrees = first.outcome === rerun.outcome && assertionShape(first) === assertionShape(rerun);
+	if (agrees) return {row: first, defect: null};
+	const summary =
+		`deterministic eval case ${first.caseId} did not reproduce: the first run was ` +
+		`'${first.outcome}', an identical re-run was '${rerun.outcome}'. A deterministic case that ` +
+		"does not reproduce is a defect of the case or of the CLI it exercises — file it, never retry it.";
+	return {
+		row: {
+			caseId: first.caseId,
+			tier: first.tier,
+			outcome: "flake",
+			runs: 2,
+			assertions: first.assertions,
+			detail: summary,
+		},
+		defect: {
+			caseId: first.caseId,
+			firstOutcome: first.outcome,
+			rerunOutcome: rerun.outcome,
+			summary,
+		},
+	};
+};
+
+/** Per-tier tallies over eval rows. */
+export interface TierCounts {
+	readonly cases: number;
+	readonly passed: number;
+	readonly failed: number;
+	readonly uncheckable: number;
+	readonly flaked: number;
+}
+
+/** The aggregate over a suite's rows — one shape, both tiers. */
+export interface EvalSuiteSummary {
+	readonly total: TierCounts;
+	readonly byTier: Record<EvalRowTier, TierCounts>;
+	readonly passRate: number;
+	readonly verdict: "green" | "red";
+	/** Why the suite is red — `null` on green. */
+	readonly redReason: string | null;
+}
+
+const emptyCounts = (): TierCounts => ({cases: 0, passed: 0, failed: 0, uncheckable: 0, flaked: 0});
+
+const tally = (counts: TierCounts, outcome: EvalRowOutcome): TierCounts => ({
+	cases: counts.cases + 1,
+	passed: counts.passed + (outcome === "pass" ? 1 : 0),
+	failed: counts.failed + (outcome === "fail" ? 1 : 0),
+	uncheckable: counts.uncheckable + (outcome === "uncheckable" ? 1 : 0),
+	flaked: counts.flaked + (outcome === "flake" ? 1 : 0),
+});
+
+/**
+ * Aggregate eval rows into a suite verdict. **The one aggregation path** — the graded tier's rows
+ * are the same shape, so they fold in here rather than through a second aggregator.
+ *
+ * Zero rows is RED, not a vacuous green (ADR 0092): a suite that could not see its own corpus has
+ * proven nothing, and this repo has repeatedly shipped guards that passed because of exactly that.
+ */
+export const summarizeEvalRows = (rows: ReadonlyArray<EvalRow>): EvalSuiteSummary => {
+	let total = emptyCounts();
+	const byTier: Record<EvalRowTier, TierCounts> = {
+		deterministic: emptyCounts(),
+		graded: emptyCounts(),
+	};
+	for (const row of rows) {
+		total = tally(total, row.outcome);
+		byTier[row.tier] = tally(byTier[row.tier], row.outcome);
+	}
+	if (total.cases === 0) {
+		return {
+			total,
+			byTier,
+			passRate: 0,
+			verdict: "red",
+			redReason:
+				"zero scope: no eval rows — a suite that checked nothing is never green (ADR 0092)",
+		};
+	}
+	const passRate = total.passed / total.cases;
+	const notPassed = total.cases - total.passed;
+	return {
+		total,
+		byTier,
+		passRate,
+		verdict: notPassed === 0 ? "green" : "red",
+		redReason:
+			notPassed === 0
+				? null
+				: `${notPassed} of ${total.cases} cases did not pass ` +
+					`(${total.failed} failed, ${total.uncheckable} uncheckable, ${total.flaked} flaked)`,
+	};
+};

--- a/packages/pipeline-cli/src/tools/eval-harness/deterministic-tier.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/deterministic-tier.unit.test.ts
@@ -1,0 +1,373 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type CliObservation,
+	checkAssertion,
+	type DeterministicCommand,
+	judgeDeterministicCase,
+	namedArtifactPaths,
+	readExpectation,
+	reconcileRerun,
+	runDeterministicTier,
+	summarizeEvalRows,
+	type TieredEvalCase,
+} from "./deterministic-tier.ts";
+
+const ran = (over: Partial<CliObservation> = {}): CliObservation => ({
+	exitStatus: 0,
+	stdout: "",
+	stderr: "",
+	artifacts: [],
+	toolInvocations: null,
+	notRun: null,
+	...over,
+});
+
+const mechanical = (text: string, cue: string) => ({kind: "mechanical", text, cue}) as const;
+
+const deterministicCase = (
+	id: number,
+	assertions: TieredEvalCase["assertions"],
+): TieredEvalCase => ({
+	id,
+	tier: "deterministic",
+	assertions,
+});
+
+const gradedCase = (id: number): TieredEvalCase => ({
+	id,
+	tier: "graded",
+	assertions: [{kind: "judgment", text: "the answer reads well"}],
+});
+
+const command: DeterministicCommand = {command: "true", args: [], cwd: null, timeoutMs: null};
+
+const resolveCommand = () => command;
+
+describe("readExpectation — literal, and unreadable rather than guessed", () => {
+	it("reads an expected exit code", () => {
+		assert.deepStrictEqual(readExpectation(mechanical("exits 0", "exit-status")), {
+			_tag: "ExitStatus",
+			code: 0,
+		});
+		assert.deepStrictEqual(readExpectation(mechanical("exit code is 3", "exit-status")), {
+			_tag: "ExitStatus",
+			code: 3,
+		});
+	});
+
+	it("reads a non-zero exit expectation", () => {
+		assert.deepStrictEqual(readExpectation(mechanical("exits non-zero", "exit-status")), {
+			_tag: "ExitNonZero",
+		});
+	});
+
+	it("reads the stream and needle of an output-content assertion", () => {
+		assert.deepStrictEqual(
+			readExpectation(mechanical("stderr contains 'refusing to push'", "output-content")),
+			{_tag: "Substring", stream: "stderr", needle: "refusing to push"},
+		);
+		assert.deepStrictEqual(
+			readExpectation(mechanical("output includes `PASS`", "output-content")),
+			{_tag: "Substring", stream: "any", needle: "PASS"},
+		);
+	});
+
+	it("reads a quoted file path and a quoted tool", () => {
+		assert.deepStrictEqual(
+			readExpectation(mechanical("a file named `out/report.json` exists", "file-artifact")),
+			{_tag: "FileExists", path: "out/report.json"},
+		);
+		assert.deepStrictEqual(
+			readExpectation(mechanical("uses script `verified-push`", "tool-invocation")),
+			{_tag: "ToolInvoked", tool: "verified-push"},
+		);
+	});
+
+	it("is unreadable — never a guess — when the prose names no concrete expectation", () => {
+		for (const assertion of [
+			mechanical("the exit status looks right", "exit-status"),
+			mechanical("output contains the summary", "output-content"),
+			mechanical("a file exists somewhere", "file-artifact"),
+			mechanical("it ran the script", "tool-invocation"),
+			mechanical("exits 0", "some-future-cue"),
+		]) {
+			assert.strictEqual(readExpectation(assertion)._tag, "Unreadable");
+		}
+	});
+
+	it("routes a judgment assertion away rather than pretending to check it", () => {
+		const expectation = readExpectation({kind: "judgment", text: "the tone is right"});
+		assert.strictEqual(expectation._tag, "Unreadable");
+	});
+
+	it("collects the artifact paths an observer must probe for", () => {
+		const evalCase = deterministicCase(1, [
+			mechanical("a file named `a.txt` exists", "file-artifact"),
+			mechanical("exits 0", "exit-status"),
+			mechanical("creates a file `b/c.json`", "file-artifact"),
+		]);
+		assert.deepStrictEqual(namedArtifactPaths(evalCase), ["a.txt", "b/c.json"]);
+	});
+});
+
+describe("checkAssertion — total, and never a silent skip", () => {
+	it("passes and fails an exit-status assertion on the observed status", () => {
+		const assertion = mechanical("exits 0", "exit-status");
+		assert.strictEqual(checkAssertion(assertion, ran()).status, "pass");
+		const failed = checkAssertion(assertion, ran({exitStatus: 1}));
+		assert.strictEqual(failed.status, "fail");
+		assert.strictEqual(failed.detail, "exit status was 1, expected 0");
+	});
+
+	it("fails — does not skip — a run killed before it reported a status", () => {
+		const outcome = checkAssertion(mechanical("exits 0", "exit-status"), ran({exitStatus: null}));
+		assert.strictEqual(outcome.status, "fail");
+	});
+
+	it("checks output content against the named stream only", () => {
+		const observation = ran({stdout: "hello", stderr: "boom"});
+		assert.strictEqual(
+			checkAssertion(mechanical("stdout contains 'hello'", "output-content"), observation).status,
+			"pass",
+		);
+		assert.strictEqual(
+			checkAssertion(mechanical("stdout contains 'boom'", "output-content"), observation).status,
+			"fail",
+		);
+		assert.strictEqual(
+			checkAssertion(mechanical("output contains 'boom'", "output-content"), observation).status,
+			"pass",
+		);
+	});
+
+	it("checks a named file against what the observer found", () => {
+		const assertion = mechanical("a file named `out.json` exists", "file-artifact");
+		assert.strictEqual(checkAssertion(assertion, ran({artifacts: ["out.json"]})).status, "pass");
+		assert.strictEqual(checkAssertion(assertion, ran()).status, "fail");
+	});
+
+	it("is uncheckable — not a fail — when the observer cannot see tool invocations at all", () => {
+		const assertion = mechanical("used script `push`", "tool-invocation");
+		assert.strictEqual(checkAssertion(assertion, ran()).status, "uncheckable");
+		assert.strictEqual(checkAssertion(assertion, ran({toolInvocations: ["push"]})).status, "pass");
+		assert.strictEqual(checkAssertion(assertion, ran({toolInvocations: []})).status, "fail");
+	});
+});
+
+describe("judgeDeterministicCase — the whole verdict, from exactly one run", () => {
+	it("passes a case whose every assertion holds, in one run", () => {
+		const row = judgeDeterministicCase(
+			deterministicCase(1, [
+				mechanical("exits 0", "exit-status"),
+				mechanical("stdout contains 'ok'", "output-content"),
+			]),
+			ran({stdout: "ok"}),
+		);
+		assert.strictEqual(row.outcome, "pass");
+		assert.strictEqual(row.runs, 1);
+		assert.strictEqual(row.detail, null);
+	});
+
+	it("fails a case with a failing assertion and names why", () => {
+		const row = judgeDeterministicCase(
+			deterministicCase(2, [mechanical("exits 0", "exit-status")]),
+			ran({exitStatus: 2}),
+		);
+		assert.strictEqual(row.outcome, "fail");
+		assert.strictEqual(row.detail, "exit status was 2, expected 0");
+	});
+
+	it("reds an uncheckable assertion ahead of a merely failing one", () => {
+		const row = judgeDeterministicCase(
+			deterministicCase(3, [
+				mechanical("exits 0", "exit-status"),
+				mechanical("output contains the right thing", "output-content"),
+			]),
+			ran({exitStatus: 9}),
+		);
+		assert.strictEqual(row.outcome, "uncheckable");
+	});
+
+	it("reds a case with no assertions rather than passing it vacuously", () => {
+		const row = judgeDeterministicCase(deterministicCase(4, []), ran());
+		assert.strictEqual(row.outcome, "uncheckable");
+	});
+
+	it("reads a did-not-run as UNKNOWN, never as a failing assertion (§ZS)", () => {
+		const row = judgeDeterministicCase(
+			deterministicCase(5, [mechanical("exits non-zero", "exit-status")]),
+			ran({exitStatus: null, notRun: "spawn nope ENOENT"}),
+		);
+		assert.strictEqual(row.outcome, "uncheckable");
+		assert.include(row.detail ?? "", "never ran");
+	});
+});
+
+describe("runDeterministicTier — routing, with no model in the loop", () => {
+	it("routes each case by its derived tier", () => {
+		const run = runDeterministicTier({
+			cases: [deterministicCase(1, [mechanical("exits 0", "exit-status")]), gradedCase(2)],
+			resolveCommand,
+			observe: () => ran(),
+		});
+		assert.deepStrictEqual(
+			run.rows.map((r) => r.caseId),
+			[1],
+		);
+		assert.deepStrictEqual(run.deferredToGraded, [2]);
+	});
+
+	it("never reaches the model-bearing seam for a deterministic case", () => {
+		const run = runDeterministicTier({
+			cases: [
+				deterministicCase(1, [mechanical("exits 0", "exit-status")]),
+				deterministicCase(2, [mechanical("exits non-zero", "exit-status")]),
+			],
+			resolveCommand,
+			observe: () => ran(),
+			deferGraded: () => {
+				throw new Error("a model was spawned for a deterministic case");
+			},
+		});
+		assert.strictEqual(run.rows.length, 2);
+		assert.deepStrictEqual(run.deferredToGraded, []);
+	});
+
+	it("hands a graded case to that seam instead of executing it", () => {
+		const handed: Array<number> = [];
+		const observed: Array<number> = [];
+		runDeterministicTier({
+			cases: [gradedCase(7)],
+			resolveCommand,
+			observe: (evalCase) => {
+				observed.push(evalCase.id);
+				return ran();
+			},
+			deferGraded: (evalCase) => handed.push(evalCase.id),
+		});
+		assert.deepStrictEqual(handed, [7]);
+		assert.deepStrictEqual(observed, []);
+	});
+
+	it("executes each deterministic case exactly once", () => {
+		const executions: Array<number> = [];
+		runDeterministicTier({
+			cases: [
+				deterministicCase(1, [mechanical("exits 0", "exit-status")]),
+				deterministicCase(2, [mechanical("exits 0", "exit-status")]),
+			],
+			resolveCommand,
+			observe: (evalCase) => {
+				executions.push(evalCase.id);
+				return ran({exitStatus: 1});
+			},
+		});
+		assert.deepStrictEqual(executions, [1, 2]);
+	});
+
+	it("reds a case that declares no command instead of skipping it", () => {
+		const run = runDeterministicTier({
+			cases: [deterministicCase(1, [mechanical("exits 0", "exit-status")])],
+			resolveCommand: () => null,
+			observe: () => ran(),
+		});
+		assert.strictEqual(run.rows[0]?.outcome, "uncheckable");
+		assert.strictEqual(run.rows[0]?.runs, 0);
+	});
+
+	// AC1's "no model invocation, verifiable by the absence of any spawn" is a property of the
+	// module, not of one code path: a behavioral test can only prove the paths it exercises. The
+	// tier can reach nothing spawnable if it imports nothing spawnable, and that is readable.
+	it("imports no runtime or observer module that could spawn anything", () => {
+		const source = readFileSync(
+			fileURLToPath(new URL("./deterministic-tier.ts", import.meta.url)),
+			"utf8",
+		);
+		const specifiers = [...source.matchAll(/^import\s[\s\S]*?from\s"([^"]+)";$/gm)].map(
+			(m) => m[1] ?? "",
+		);
+		assert.deepStrictEqual(
+			specifiers.filter((s) => s.startsWith("node:") || s.includes("observer")),
+			[],
+		);
+	});
+});
+
+describe("reconcileRerun — a flake is surfaced, never retried into green", () => {
+	const failing = judgeDeterministicCase(
+		deterministicCase(1, [mechanical("exits 0", "exit-status")]),
+		ran({exitStatus: 1}),
+	);
+	const passing = judgeDeterministicCase(
+		deterministicCase(1, [mechanical("exits 0", "exit-status")]),
+		ran(),
+	);
+
+	it("leaves an agreeing re-run's verdict at the first run's, still one run", () => {
+		const {row, defect} = reconcileRerun(failing, failing);
+		assert.strictEqual(row.outcome, "fail");
+		assert.strictEqual(row.runs, 1);
+		assert.strictEqual(defect, null);
+	});
+
+	it("cannot turn a fail into a pass — a disagreeing re-run is a flake, not a win", () => {
+		const {row, defect} = reconcileRerun(failing, passing);
+		assert.strictEqual(row.outcome, "flake");
+		assert.strictEqual(row.runs, 2);
+		assert.strictEqual(defect?.firstOutcome, "fail");
+		assert.strictEqual(defect?.rerunOutcome, "pass");
+		assert.include(defect?.summary ?? "", "did not reproduce");
+	});
+
+	it("surfaces the reverse direction too — a pass that later fails is the same defect", () => {
+		const {row, defect} = reconcileRerun(passing, failing);
+		assert.strictEqual(row.outcome, "flake");
+		assert.notStrictEqual(defect, null);
+	});
+
+	it("makes the suite red on a flake", () => {
+		const {row} = reconcileRerun(failing, passing);
+		const summary = summarizeEvalRows([row]);
+		assert.strictEqual(summary.verdict, "red");
+		assert.strictEqual(summary.total.flaked, 1);
+	});
+});
+
+describe("summarizeEvalRows — one aggregation path for both tiers", () => {
+	const row = (caseId: number, tier: "deterministic" | "graded", outcome: "pass" | "fail") => ({
+		caseId,
+		tier,
+		outcome,
+		runs: tier === "deterministic" ? 1 : 5,
+		assertions: [],
+		detail: outcome === "pass" ? null : "nope",
+	});
+
+	it("folds deterministic and graded rows through the same function", () => {
+		const summary = summarizeEvalRows([
+			row(1, "deterministic", "pass"),
+			row(2, "deterministic", "fail"),
+			row(3, "graded", "pass"),
+		]);
+		assert.strictEqual(summary.total.cases, 3);
+		assert.strictEqual(summary.byTier.deterministic.cases, 2);
+		assert.strictEqual(summary.byTier.graded.cases, 1);
+		assert.strictEqual(summary.passRate, 2 / 3);
+		assert.strictEqual(summary.verdict, "red");
+	});
+
+	it("is green only when every row passed", () => {
+		const summary = summarizeEvalRows([row(1, "deterministic", "pass")]);
+		assert.strictEqual(summary.verdict, "green");
+		assert.strictEqual(summary.redReason, null);
+	});
+
+	it("reds on zero scope rather than passing an empty suite (ADR 0092)", () => {
+		const summary = summarizeEvalRows([]);
+		assert.strictEqual(summary.verdict, "red");
+		assert.include(summary.redReason ?? "", "zero scope");
+		assert.strictEqual(summary.passRate, 0);
+	});
+});


### PR DESCRIPTION
A skill's eval cases now split into two lanes, and this PR builds the cheap one. A case whose assertions are all mechanically checkable — an exit code, a string in stdout, a file that must exist — runs its command once, with no model anywhere in the loop, and reports pass or fail. That is what lets a growing regression corpus sit on every change instead of being something a human runs occasionally.

The flake stance ships as a mechanism rather than a slogan: nothing here can re-run a case to obtain a pass. A deterministic case that does not reproduce is a defect of the case, surfaced as one.

Fixes #4677

## What's in it

- **`deterministic-tier.ts`** — the pure core. It imports **nothing**, so it can reach nothing spawnable; a unit test reads its import list to keep that true. It owns tier routing, the one-run judgement, the flake reconciliation, and `EvalRow`.
- **`deterministic-shell-observer.ts`** — the one IO leg. It spawns a *process*, never a model. The two live in separate files precisely so the core's purity is checkable by reading it.
- **`deterministic-tier.unit.test.ts` / `deterministic-shell-observer.unit.test.ts`** — 37 tests, including a real end-to-end pass over 20 cases with a real subprocess each.
- **README** — a new `## The deterministic tier` section, with the measured figure and the command that re-measures it.

## The three properties that are enforced rather than documented

**One run, never a retry** (founder ruling 4 on #4637). `runDeterministicTier` executes each deterministic case exactly once. `reconcileRerun(first, rerun)` exists for the opposite purpose from a retry: an *agreeing* re-run returns the first row untouched (`runs` stays 1 — the verdict came from one execution), and a *disagreeing* one returns a `flake` row plus a `FlakeDefect` to file through the normal report path. It is structurally incapable of turning a fail into a pass, and a test asserts that in both directions.

**Everything unreadable reds as a case defect, never a pass.** `readExpectation` is a deliberately narrow literal reader; every shape it cannot read becomes `Unreadable`, which reds the case `uncheckable`. So do: a case with no assertions, a case declaring no command, an unknown cue, a judgment assertion that reached this tier, and a `tool-invocation` assertion under an observer that cannot see tool invocations. The direction is the point — a permissive reader that *guessed* an expectation would report a green nobody earned.

**Did-not-run is UNKNOWN, not a negative answer.** A command that never started reports `notRun` and reds `uncheckable`; a command that started and was killed reports `exitStatus: null` and genuinely fails; an `exit 127` from a shell that *did* run is an ordinary answered status. All three are separately tested against real processes.

And zero rows is red, not a vacuous green (ADR 0092) — `summarizeEvalRows([])` reds with a named `zero scope` reason.

## One row shape, one aggregation path

Both tiers emit `EvalRow` — `{caseId, tier, outcome, runs, assertions, detail}` — where each `AssertionOutcome` is the flat `{text, cue, status, detail}` and a judged assertion carries `cue: null`. `summarizeEvalRows` is the single aggregator; the graded tier's rows fold in there rather than through a second path. It is tested with a mixed deterministic + graded row set.

## Measured

20 cases, two mechanical assertions each, a real subprocess per case: **55–58 ms** across three consecutive runs (~2.8 ms/case), on macOS 14 / Node 26. The suite that produces the number prints it and is named in the README. It asserts the observable outcome — green over cases that hold, **red** over one that genuinely fails — and never a wall-clock threshold, because a timing assertion is exactly the flaky test the ruling this tier implements calls a bug.

Both negative paths were observed red before the tier was trusted: the end-to-end suite includes a deliberately failing case (`exit 4` against an `exits 0` assertion) and asserts the suite verdict is red with the named detail.

## Scope held

Nothing here spawns anything unattended (#4676), grades anything (#4678), or wires a CI job (#4681). `deferGraded` is the handoff *seam* toward #4678 and is never implemented here — it is a caller-supplied callback, and its only role in this PR is being the thing a test proves is never called for a deterministic case.

## Verification

- `pnpm typecheck` — clean (29/29).
- `pnpm lint:worktree` — clean.
- `pipeline-cli` unit suite — 3084 passed (3047 before, 37 new).
- The wall-clock figure was measured three times; the numbers in the README are the observed ones.

## Deviations

- **Departure — built against #4674's decoded shape structurally, not by type import.** **Said:** the epic makes #4677 depend on #4674 (eval-case ingestion), and the dispatch brief says to consume its decoded shape rather than re-derive a parser. **Did:** #4674's PR #4691 is open and unmerged, so `skill-eval-set.ts` is not on `main` and a type import would not compile. This tier declares `TieredEvalCase` / `TieredAssertion` — the exact fields it reads, with `cue` widened to `string` — which #4691's `SkillEvalCase` / `SkillEvalAssertion` satisfy structurally with no adapter. **Why:** it re-derives no parser and no cue lexicon (the widened `cue` is what avoids restating #4691's `MechanicalCue` literals), it does not stack this PR on an unmerged branch, and it keeps both PRs independently reviewable and mergeable in either order. **Disposition:** for the reviewer to judge — once #4674 lands, `TieredEvalCase` can collapse to `import type {SkillEvalCase}` in a one-line follow-up, or stay as the tier's narrower structural contract.

- **Departure — this tier was built while its `requires: #4674` is still open.** **Said:** the epic's `## Dependencies` puts #4677 in Phase 2 requiring #4674, and write-code's Step 2 derivation would skip a child whose `requires:` is open. **Did:** built it, on an explicit dispatch that named the sibling PR and instructed composition against it. **Why:** the dependency is a shape dependency, and the shape is settled and readable on #4691. **Disposition:** for the reviewer to judge — flagged so the eligibility derivation is not silently bypassed.

- **Departure — no CLI verb, so the #4685 exit-code divergence is untouched, not re-decided.** **Said:** the dispatch brief asks me either to follow the tool's existing `1` seating or argue for re-seating on `3`, and to log whichever I choose. **Did:** neither — this PR adds **no** CLI verb, so it seats no exit code and introduces no third convention. **Why:** none of the five ACs asks for one, and a verb that reads an eval set would need #4674's decoder, which is not on `main`. The natural home for a `deterministic` verb is the runner (#4676), which will already own reading a set off disk; whoever ships it inherits the open divergence unchanged. **Disposition:** no action needed here; the divergence stays #4691's flag and a follow-up that re-seats the whole tool at once, as that PR proposes.

- **Departure — AC4's figure is measured over a stand-in, not the incident corpus.** **Said:** AC4 asks for the wall-clock of "the committed incident corpus deterministic cases" recorded in the module README. **Did:** measured a 20-case corpus-shaped set with a real subprocess per case, recorded the figure and the re-measure command, and stated in the README that the corpus is a stand-in. **Why:** the fabrika incident corpus is #4675 and has not landed; there is nothing else to measure. The per-case cost is the transferable number and scales linearly. **Disposition:** follow-up #4695 filed to re-take the figure against the real corpus once #4675 lands. If the reviewer reads AC4 as binding literally to #4675's corpus, downgrade this PR to a partial link — the deferred half already has a home.

- **Judgment call — the CLI-layer command comes from a caller-supplied resolver, not from the authored format.** **Said:** the epic forbids adding any required field to the authored eval format. **Did:** `runDeterministicTier` takes a `resolveCommand(evalCase) => DeterministicCommand | null`, and a `null` reds the case `uncheckable`. **Why:** the `/skill-creator` format carries a prompt and assertions but nothing naming a command to run, and a deterministic CLI-layer case needs one. Making it a caller seam adds no field, invents no sidecar format here, and leaves the question of *where* a command is declared to the runner (#4676) or the corpus (#4675), whichever ends up owning it. **Disposition:** for the reviewer to judge — flag if the command declaration should be specified in this PR rather than deferred to its consumer.

- **Judgment call — `tool-invocation` assertions are `uncheckable` under the shell observer.** **Said:** #4674 derives four mechanical cues, all of which a deterministic case may carry. **Did:** the shell observer reports `toolInvocations: null` ("I cannot see this"), and the checker reds such an assertion as a case defect rather than failing it. **Why:** a plain subprocess genuinely cannot observe which tools a run used, and answering "not invoked" from an inability to look is the false-negative this tier exists to avoid. A transcript-backed observer (#4676) can answer it, and the seam is already the right shape for one. **Disposition:** no action needed; the reason is named in the outcome so a case author knows what to do.

- **Known defect left unfixed — #4687.** **Said:** `write-code` mandates invoking its scripts by the literal path `./.claude/.pipeline/skills/write-code/scripts/<script>.sh`. **Did:** invoked the identical scripts through their in-repo `./claude-plugins/kampus-pipeline/…` path. **Why:** the `.claude/.pipeline` symlink does not exist inside a linked worktree, so the mandated literal exits 127 with empty stdout — UNKNOWN, not an answer. No guard was skipped: the delegated-claim confirmation, the opening preflight, a `wt_preflight` before the branch and the commit, the mis-attribution guard before PR-open, and `verified-push` (`PUSH-VERDICT: MOVED`) all ran and passed. **Disposition:** surfaced to the dispatching operator; the symlink's provisioning is harness scope.
