### PR TITLE
feat(eval-harness): spawn-and-collect — the unattended eval runner feeding the existing oracle (#4676)

### DIFF
--- a/.decisions/0236-eval-harness-gains-a-spawning-shell.md
+++ b/.decisions/0236-eval-harness-gains-a-spawning-shell.md
@@ -1,0 +1,106 @@
+---
+id: 0236
+title: The eval-harness gains a spawning IO shell — its pure cores stay spawn-free, and no CI job ever spawns a model
+status: accepted
+date: 2026-08-01
+tags: [pipeline, eval-harness, tooling, fabrika, cost]
+---
+
+# 0236 — The eval-harness gains a spawning IO shell — its pure cores stay spawn-free, and no CI job ever spawns a model
+
+**What this decides:** `packages/pipeline-cli/src/tools/eval-harness/` may now start a process. The
+spawning is confined to one IO file (`spawn-io.ts`), every core it feeds stays pure and
+offline-replayable, and the spawning verb's supported invocation sites are an operator's shell and a
+`review-skill` review-stage spawn — never a CI job.
+
+## Context
+
+The module was built (epic #1842, ADR [0112](0112-token-measurement-no-quality-compromise-methodology.md)) as a
+**collector over runs that already happened**. Both its README and `runner.ts`'s header state the
+property explicitly: *"it does NOT spawn stage agents (spawning is the operator's act)"*. That was a
+real design property, not an omission — it is what makes the offline replay path reproducible.
+
+Fabrika's eval system (epic [#4649](https://github.com/kamp-us/phoenix/issues/4649)) needs the
+half that was deliberately absent. Its story 2 is *"run my skill's whole eval set unattended with
+one command"*; there is no way to reach that without something starting a process. The epic resolved
+where it lives — the existing module, extended, because a second module would fork the token meter
+and break apples-to-apples against every prior cost measurement (ADR 0112 §2) — and the
+[#4673 spike](https://github.com/kamp-us/phoenix/issues/4673) established, against the real tool,
+that `claude -p "/<skill>" --output-format json --session-id <uuid>` is the invocation and that the
+existing spend reconstruction reads its transcript unchanged. The spike explicitly deferred this
+ADR to the landing that causes the reversal, so the *why* attaches to the diff.
+
+Two further constraints arrived from outside the module:
+
+1. **The founder ruling on #4649 (comment 5153280445): no model-in-the-loop execution runs in CI.**
+   The stated reason is **cost** — there are no credits to spend on model runs inside the CI
+   provider. It is recorded as a cost constraint rather than a principle so a future reader knows
+   what would have to change to revisit it. The graded axis therefore rides the review stage, which
+   already pays for a model.
+2. **`spawn-guard` is a `PreToolUse` hook on `Task|Workflow`** and denies on `tool_input.model`. A
+   `claude -p --model <x>` subprocess is not a `Task` tool call, so the two surfaces are disjoint —
+   measured on the spike. Which surface the runner uses is therefore load-bearing, not incidental.
+
+## Decision
+
+**1. The reversal is scoped to one file.** `spawn-io.ts` is the only place in the module that
+imports `node:child_process`. `spawn.ts` plans the invocations, decodes the result payload and
+classifies each run; `runner.ts`, `oracle.ts`, `report.ts` and `repair-churn.ts` are untouched in
+their purity. The offline replay path and its tests keep passing unchanged, which is the property
+worth preserving — a reproducible re-analysis must not need a model.
+
+**2. The runner spawns as a CLI subprocess, never as an in-session `Task`.** Beyond keeping the
+spawn out of the agent's tool surface, this is what makes #4680's model-churn re-run contract
+satisfiable at all: a named-model re-run through `Task` is a hard deny under `spawn-guard`'s
+allowlist, while the same run as a subprocess is unimpeded. Re-implementing this as a `Task` spawn
+would silently break that contract.
+
+**3. A run that never reached a model is a typed failure, never a free pass.** This is the finding
+that shapes the whole design and it is the module's own failure class staring back. `claude -p
+"/not-a-skill"` exits **0** with `is_error: false`, `subtype: "success"`, `num_turns: 0`,
+`total_cost_usd: 0`, `modelUsage: {}` — and `pipeline-cli token-spend` reconstructs its transcript to
+well-formed **zeros, also at exit 0**. (Measured on `claude` 2.1.220 during the spike and reproduced
+independently while landing this.) Nothing in the platform reports the failure, so a with-skill arm
+whose plugin failed to load **silently degrades into a without-skill arm and scores as a legitimate
+free run**. The runner therefore synthesizes the missing signal: `num_turns === 0`, a
+`^Unknown command:` result, an empty `modelUsage`, a requested-but-absent `structured_output`, or a
+transcript reconstructing to zero billed assistant turns each make the run a counted `NoModelTurns`
+failure, and only a run that survives all five becomes a `CaptureRun`.
+
+**4. `RunSpend` gains a third arm, `NoBilledTurns`.** The union existed to stop a fabricated zero
+from being read as a genuinely free run, and it had exactly two arms — `Reconstructed` and
+`TranscriptMissing`. A zero-turn run defeats both: its transcript *is* present and *does* parse, and
+reconstructs to a real zero. Folding it into `Reconstructed` would put the fabricated zero back.
+
+**5. No CI workflow invokes the model-spawning verb, and that is asserted rather than described.**
+The runner ships with no workflow, and a unit test reds if any `.github/workflows/*` file calls
+`eval-harness run` (failing closed on zero scope per ADR
+[0092](0092-gates-fail-closed-on-zero-scope.md)). CI's own eval work — the deterministic regression
+floor (#4677) and the presence/head-binding/bar check over recorded results (#4681) — is
+string-and-number comparison with no model and no credential.
+
+## Consequences
+
+- The module's stated "does not spawn" property is now **false for the module and true for its
+  cores**, and the README says so in those words rather than being quietly edited.
+- An operator can run a whole eval set with one command; `review-skill` can invoke the same verb;
+  neither path is reachable from CI without tripping (5).
+- The runner's exit code reports **executability only** — whether every planned case ran. Whether
+  cases *passed* stays the oracle's answer, read off the capture manifest downstream. Bundling the
+  two would make a legitimately-failing eval indistinguishable from a harness malfunction, which is
+  the distinction this whole epic exists to draw.
+- Dollars are recorded opportunistically (`total_cost_usd` exists only at the headless site), but the
+  cost axis stays **token-grounded** per ADR 0112 §2. There is no second meter.
+
+## Alternatives considered
+
+- **A separate module for execution.** Rejected upstream by the epic: it forks the token meter and
+  breaks comparability with every prior measurement.
+- **Trusting the CLI's exit code / `is_error` / `subtype`.** Rejected on measurement — all three
+  report success on a run that never reached a model.
+- **`--disable-slash-commands` as the with/without arm toggle.** Rejected on measurement: against a
+  loaded plugin it short-circuits to zero turns and `$0`, so both arms would be un-run. The toggle is
+  the presence of `--plugin-dir`.
+- **Re-deriving the transcript's `<cwd-slug>` directory instead of scanning.** Rejected: the slug is
+  a lossy separator flattening, so a re-derivation answers "no transcript" for runs that produced
+  one.

--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -66,13 +66,18 @@ of those rows is the raw material the report slice ([#1853](https://github.com/k
 aggregates into pass-rate + churn cost.
 
 The runner is a deterministic, side-effect-light **collector over runs that already happened** — it
-does **not** spawn stage agents. Spawning is the operator's act, and the fleet's model is pinned by
-`spawn-guard`; keeping the runner spawn-free is what makes the harness reproducible.
+spawns nothing itself, which is what makes it reproducible offline. That property still holds for
+`runner.ts` and for every other core here, but it is **no longer true of the module**: `run` (below)
+starts processes from `spawn-io.ts`. The reversal and its bounds are [ADR
+0236](../../../../../.decisions/0236-eval-harness-gains-a-spawning-shell.md).
 
-`RunRow` is `{entry, grade, spend}` where `spend` is a `RunSpend` union — either
-`{_tag: "Reconstructed", spend}` (the `token-spend` `StageSpend`) or `{_tag: "TranscriptMissing"}`.
-The missing case is a distinct, counted outcome rather than a fabricated zero the report could
-mistake for a genuinely free run — a **missing transcript is graded and counted, never a crash**.
+`RunRow` is `{entry, grade, spend}` where `spend` is a **three-arm** `RunSpend` union:
+`{_tag: "Reconstructed", spend}` (the `token-spend` `StageSpend`), `{_tag: "NoBilledTurns"}`, or
+`{_tag: "TranscriptMissing"}`. None of the three can be mistaken for a genuinely free run — a
+**missing transcript is graded and counted, never a crash**, and a transcript that is present and
+well-formed but carries **zero billed assistant turns** gets its own arm rather than a zero-valued
+`Reconstructed`: that is exactly what a run whose skill failed to resolve writes, and folding it in
+would restore the fabricated zero this union exists to prevent.
 
 Two modes, story-split:
 
@@ -82,9 +87,12 @@ Two modes, story-split:
   total (a malformed artifact grades `fail` via the oracle) and spend reconstruction is fail-open (a
   malformed transcript undercounts, never throws) — so a whole corpus resolves without a crash.
 - **Capture-manifest (story 7)** — `CaptureManifest` is the documented shape naming, per run, the
-  transcript path (`<parent-session-id>/subagents/agent-<id>.jsonl`, ADR 0112 §2) + the recorded
-  artifact, keyed by `(stage, inputRef)` so a fresh live run (spawned by the **operator**, not this
-  tool) folds into the corpus deterministically. `decodeCaptureManifest(text)` is total (typed
+  transcript path + the recorded artifact, keyed by `(stage, inputRef)` so a fresh live run folds
+  into the corpus deterministically. The path takes either of the two real shapes: a **Task-spawned
+  sub-agent**'s `<parent-session-id>/subagents/agent-<id>.jsonl` (ADR 0112 §2), or a **headless
+  `claude -p` run**'s `<claude-data-root>/projects/<cwd-slug>/<session-id>.jsonl` — the latter is a
+  top-level session, so it is not under `subagents/`. Both reconstruct through the same
+  `token-spend` core, verified against the run's own `result.usage`. `decodeCaptureManifest(text)` is total (typed
   `Result` failure on malformed JSON or a schema mismatch). `collectFromCapture({stage, corpus,
   capture, loadTranscript})` joins each capture run to its corpus entry (for the ground-truth label),
   loads transcripts through the caller-supplied `TranscriptLoader` (keeping the core pure — the
@@ -377,8 +385,88 @@ An unedited authoring-session output shape is committed under
 [`fixtures/skill-creator/`](./fixtures/skill-creator) and is what the unit tests decode, so "decodes
 with no edits" is checked against the real shape rather than asserted.
 
+## `eval-harness run` — executing an eval set unattended (#4676)
+
+```bash
+pipeline-cli eval-harness run <evals.json> \
+  --stage <triage|write-code|review-code|review-doc|ship-it> \
+  --plugin-dir <the candidate skill's plugin dir> \
+  --model <model> \
+  [--arms with-skill,without-skill] [--json-schema <schema.json>] \
+  [--timeout-ms 900000] [--out ledger.json] [--capture-out capture.json] [--dry-run]
+```
+
+One command runs a skill's whole eval set with nobody watching. Per (case × arm) it invokes
+`claude -p "<case prompt>" --output-format json --session-id <uuid> --model <m> [--plugin-dir …]`,
+locates the pinned session's transcript, classifies the run, and folds the collectable ones into the
+**capture manifest** `collectFromCapture` already consumes. Grading, spend reconstruction and the
+scorecard are all pre-existing code paths — this verb adds no oracle, no meter and no renderer.
+
+**The two arms are `--plugin-dir` present or absent.** That is the whole difference in the argv, and
+it is the arm variable the /skill-creator methodology means by with-skill vs without-skill. Two flags
+are deliberately never emitted: `--no-session-persistence` (it suppresses the transcript this path
+exists to collect) and `--disable-slash-commands` (measured: against a loaded plugin it
+short-circuits to zero turns and `$0`, so it is not a usable arm toggle).
+
+**A `/<skill>` case prompt makes the without-skill arm structurally unrunnable** — with no plugin
+loaded there is no such command, so that arm reports `NoModelTurns:unknown-command` rather than a
+score. That is the runner telling the truth, not a defect: a case meant to be run on both arms is
+written as plain task text, and only a with-skill-only case names the slash command.
+
+### The failure mode this verb exists to catch
+
+**An unresolvable skill is a silent green.** Measured on `claude` 2.1.220:
+`claude -p "/not-a-skill"` exits **0** with `is_error: false`, `subtype: "success"`,
+`num_turns: 0`, `total_cost_usd: 0`, `modelUsage: {}` — and `pipeline-cli token-spend` reconstructs
+its transcript to well-formed **zeros, also at exit 0**. Nothing errors. A with-skill arm whose
+plugin failed to load therefore degrades into a without-skill arm and scores as a legitimate free
+run, which is precisely the class of silent pass this whole epic exists to end.
+
+So the runner **synthesizes the signal the platform does not give it**. A run is a counted
+`NoModelTurns` failure — never a pass, never a graded fail — when any of these hold:
+
+| signal | what it caught |
+|---|---|
+| `unknown-command` | the result text starts `Unknown command:` — the skill did not resolve |
+| `zero-turns` | `num_turns === 0` |
+| `empty-model-usage` | `modelUsage` is `{}` |
+| `zero-assistant-turns` | the transcript reconstructs to zero billed assistant turns |
+| `missing-structured-output` | a `--json-schema` was requested and no `structured_output` came back |
+
+Alongside these, a run that never started (`SpawnFailed`), one past its stated bound (`TimedOut`),
+unreadable stdout (`UndecodableResult`), a run the CLI itself flagged (`ReportedError`), and a
+healthy run whose transcript cannot be found (`TranscriptNotFound`) are all typed, counted outcomes.
+**The suite always completes** — a dying case is classified and the next one runs.
+
+The **exit code reports executability only**: zero when every planned run was collected, non-zero
+when any died *or* when the set planned nothing (zero scope reds, [ADR
+0092](../../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)). Whether the cases
+*passed* is the oracle's answer, read off the capture manifest downstream.
+
+### Where it may be invoked — and where it may not
+
+Its supported sites are **an operator's shell** and a **`review-skill` review-stage spawn**.
+**Model-in-the-loop execution never runs in CI**, per the founder ruling on epic
+[#4649](https://github.com/kamp-us/phoenix/issues/4649) (comment 5153280445). The stated reason is
+**cost** — there are no credits for model runs inside the CI provider — and it is recorded as a cost
+constraint, *not a principle*, so a future reader knows what would have to change to revisit it. No
+workflow ships with this verb, and a unit test reds if any `.github/workflows/*` file ever calls it.
+CI's own eval legs (#4677's deterministic tier, #4681's presence/head-binding/bar check) run no
+model at all.
+
+### Shape
+
+`spawn.ts` is pure — planning, argv, result decode, classification, the capture fold — and is what
+the unit tier drives through a **stubbed executor**, so no unit test spends a cent. `spawn-io.ts` is
+the only file in the module that imports `node:child_process`. The reversal that lands here (this
+module could previously not spawn anything) and its bounds are recorded in [ADR
+0236](../../../../../.decisions/0236-eval-harness-gains-a-spawning-shell.md).
+
 ## Out of scope
 
-Running any stage (collecting the transcripts) is the operator's act, not this tool.
 **Making the tiering call** is [#1576](https://github.com/kamp-us/phoenix/issues/1576), a
 separate `type:decision` — the harness supplies the graded evidence, the human decides.
+
+**The tier protocols.** `run` executes and collects; it does not implement the deterministic tier's
+mechanical checks (#4677) or the graded tier's 5-run median (#4678), and it renders no scorecard
+series (#4680).

--- a/packages/pipeline-cli/src/tools/eval-harness/command.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/command.ts
@@ -19,6 +19,7 @@
  * Thin IO shell over the pure cores (the `token-spend` / `readme-guard` idiom): read the file,
  * decode, render. An unreadable path and a malformed/mismatched input both exit non-zero.
  */
+import {randomUUID} from "node:crypto";
 import {Console, Effect, FileSystem, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
@@ -31,6 +32,20 @@ import {
 	toJson,
 } from "./report.ts";
 import {decodeSkillEvalSet, tierCounts} from "./skill-eval-set.ts";
+import {
+	buildClaudeArgs,
+	buildLedger,
+	captureToJson,
+	EVAL_ARMS,
+	executeRuns,
+	isStageName,
+	ledgerToJson,
+	parseArms,
+	planEvalRuns,
+	renderLedger,
+	suiteExecuted,
+} from "./spawn.ts";
+import {claudeExecutor, claudeVersion, locateTranscript, readTranscript} from "./spawn-io.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 
@@ -231,9 +246,194 @@ const cases = Command.make(
 	),
 );
 
-export const evalHarnessCommand = Command.make("eval-harness").pipe(
-	Command.withSubcommands([check, report, cases]),
+const stageFlag = Flag.string("stage").pipe(
+	Flag.withDescription(
+		`the pipeline stage this skill's eval set exercises — the capture manifest's join key (one of: ${STAGES.join(", ")})`,
+	),
+);
+
+const pluginDirFlag = Flag.string("plugin-dir").pipe(
+	Flag.withDescription(
+		"the candidate skill's plugin directory — loaded for the with-skill arm only, which is what makes the two arms differ",
+	),
+);
+
+const modelFlag = Flag.string("model").pipe(
+	Flag.withDescription(
+		"the model every run is pinned to — required, because a scorecard is only comparable when it names one",
+	),
+);
+
+const armsFlag = Flag.string("arms").pipe(
+	Flag.withDefault("with-skill,without-skill"),
+	Flag.withDescription(`comma-separated arms to run (${EVAL_ARMS.join(", ")})`),
+);
+
+const jsonSchemaFlag = Flag.string("json-schema").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"path to a JSON schema for the decision artifact; its text is passed to --json-schema and the validated object becomes the capture run's artifact",
+	),
+);
+
+const timeoutFlag = Flag.integer("timeout-ms").pipe(
+	Flag.withDefault(900_000),
+	Flag.withDescription(
+		"the stated wall-clock bound per run; a run past it is a typed TimedOut case",
+	),
+);
+
+const ledgerOutFlag = Flag.string("out").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"write the full run ledger (every run's typed outcome + the capture manifest) here",
+	),
+);
+
+const captureOutFlag = Flag.string("capture-out").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"write the bare capture manifest here — the file `eval-harness report` and collectFromCapture consume unchanged",
+	),
+);
+
+const dryRunFlag = Flag.boolean("dry-run").pipe(
+	Flag.withDescription("print the argv of every planned run and spawn nothing"),
+);
+
+/**
+ * `run` — execute an eval set unattended and emit the capture manifest the existing collector reads.
+ *
+ * Its supported invocation sites are an operator's shell and a `review-skill` review-stage spawn.
+ * **No CI workflow invokes this path**, and none is shipped with it: the founder ruling on epic #4649
+ * (comment 5153280445) removed model-in-the-loop execution from CI on a **cost** constraint — there
+ * are no credits for model runs inside the CI provider. That is a cost constraint, not a principle,
+ * recorded so a future reader knows what would have to change to revisit it. #4681's deterministic
+ * regression-floor leg is the separate, model-free thing CI does run.
+ */
+const runCommand = Command.make(
+	"run",
+	{
+		path: evalSetArg,
+		stage: stageFlag,
+		pluginDir: pluginDirFlag,
+		model: modelFlag,
+		arms: armsFlag,
+		jsonSchema: jsonSchemaFlag,
+		timeoutMs: timeoutFlag,
+		out: ledgerOutFlag,
+		captureOut: captureOutFlag,
+		dryRun: dryRunFlag,
+	},
+	Effect.fn(function* (opts) {
+		const run = Effect.gen(function* () {
+			const fs = yield* FileSystem.FileSystem;
+			const text = yield* Effect.mapError(
+				fs.readFileString(opts.path),
+				() => new EvalSetUnreadable({path: opts.path}),
+			);
+			const decoded = decodeSkillEvalSet(text);
+			if (Result.isFailure(decoded)) {
+				yield* Console.error(
+					`eval-harness: ${opts.path} is not a valid skill eval set (${decoded.failure.reason}): ${decoded.failure.message}`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+			const set = decoded.success;
+			if (set.cases.length === 0) {
+				yield* Console.error(
+					`eval-harness: ${opts.path} carries zero eval cases — refusing to report a green suite that ran nothing (ADR 0092)`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+			if (!isStageName(opts.stage)) {
+				yield* Console.error(
+					`eval-harness: --stage '${opts.stage}' is not a known stage (${STAGES.join(", ")})`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+			const arms = parseArms(opts.arms);
+			if (arms === null) {
+				yield* Console.error(
+					`eval-harness: --arms '${opts.arms}' names something that is not an arm (${EVAL_ARMS.join(", ")})`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+
+			let jsonSchema: string | null = null;
+			if (opts.jsonSchema._tag === "Some") {
+				const schemaPath = opts.jsonSchema.value;
+				jsonSchema = yield* Effect.mapError(
+					fs.readFileString(schemaPath),
+					() => new EvalSetUnreadable({path: schemaPath}),
+				);
+			}
+
+			const plans = planEvalRuns({
+				cases: set.cases,
+				arms,
+				model: opts.model,
+				pluginDir: opts.pluginDir,
+				jsonSchema,
+				sessionId: () => randomUUID(),
+			});
+
+			if (opts.dryRun) {
+				for (const plan of plans) {
+					yield* Console.log(
+						`case ${plan.caseId} [${plan.arm}] claude ${buildClaudeArgs(plan).join(" ")}`,
+					);
+				}
+				return;
+			}
+
+			const outcomes = executeRuns({
+				plans,
+				executor: claudeExecutor({timeoutMs: opts.timeoutMs}),
+				locateTranscript: (sessionId) => locateTranscript(sessionId),
+				loadTranscript: readTranscript,
+			});
+			const ledger = buildLedger({
+				skillName: set.skillName,
+				stage: opts.stage,
+				model: opts.model,
+				cliVersion: claudeVersion(),
+				outcomes,
+			});
+
+			if (opts.out._tag === "Some") yield* fs.writeFileString(opts.out.value, ledgerToJson(ledger));
+			if (opts.captureOut._tag === "Some") {
+				yield* fs.writeFileString(opts.captureOut.value, captureToJson(ledger.capture));
+			}
+			yield* Console.log(renderLedger(ledger));
+
+			// The suite always completes; the exit code reports only whether every case EXECUTED.
+			// Whether they passed is the oracle's answer, read off the capture manifest downstream.
+			if (!suiteExecuted(ledger.summary)) {
+				yield* Console.error(
+					`eval-harness: ${ledger.summary.failed} of ${ledger.summary.planned} run(s) did not execute — ${JSON.stringify(ledger.summary.byFailure)}`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+		});
+		yield* run.pipe(
+			Effect.catchTag("EvalSetUnreadable", (e) =>
+				Effect.gen(function* () {
+					yield* Console.error(`eval-harness: cannot read ${e.path}`);
+					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				}),
+			),
+		);
+	}),
+).pipe(
 	Command.withDescription(
-		"Graded per-stage corpus + scorecard + authored-eval-set ingestion: the labeled ground-truth format, the model-tiering evidence report, and the /skill-creator eval-set decode (#1848, #1853, #4674)",
+		"Execute a skill's eval set unattended (both arms) and emit the capture manifest the existing collector consumes — for an operator's shell or a review-skill spawn, never a CI job (#4676)",
+	),
+);
+
+export const evalHarnessCommand = Command.make("eval-harness").pipe(
+	Command.withSubcommands([check, report, cases, runCommand]),
+	Command.withDescription(
+		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner (#1848, #1853, #4674, #4676)",
 	),
 );

--- a/packages/pipeline-cli/src/tools/eval-harness/report.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/report.ts
@@ -139,6 +139,9 @@ const bucketize = (rows: ReadonlyArray<RunRow>): ReadonlyArray<Bucket> => {
 			bucket.billedSum += row.spend.spend.billed;
 			bucket.exCacheReadSum += row.spend.spend.exCacheRead;
 		} else {
+			// Both no-measurement arms (`TranscriptMissing`, `NoBilledTurns`) land here: neither
+			// contributes to the per-run averages, which is what keeps a fabricated zero out of the
+			// spend axis. Giving `NoBilledTurns` its own scorecard column belongs to #4680.
 			bucket.transcriptMissing += 1;
 		}
 	}
@@ -348,6 +351,7 @@ const StageSpendSchema = Schema.Struct({
 
 const RunSpendSchema = Schema.Union([
 	Schema.Struct({_tag: Schema.Literal("Reconstructed"), spend: StageSpendSchema}),
+	Schema.Struct({_tag: Schema.Literal("NoBilledTurns")}),
 	Schema.Struct({_tag: Schema.Literal("TranscriptMissing")}),
 ]);
 

--- a/packages/pipeline-cli/src/tools/eval-harness/runner.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/runner.ts
@@ -8,9 +8,10 @@
  * core, ADR 0112 §2), yielding a `{entry, grade, spend}` row. A per-(stage × model) collection
  * of those rows is the raw material the report slice aggregates into pass-rate + churn cost.
  *
- * This runner is a deterministic, side-effect-light COLLECTOR over runs that already happened —
- * it does NOT spawn stage agents (spawning is the operator's act; the fleet model is pinned by
- * spawn-guard). Two modes, story-split:
+ * This runner is a deterministic, side-effect-light COLLECTOR over runs that already happened — it
+ * spawns nothing, which is what keeps the offline replay reproducible. That is still true of this
+ * file, but no longer of the module: `spawn.ts`/`spawn-io.ts` execute an eval set (ADR 0236).
+ * Two modes, story-split:
  *  - Offline/replay (story 6): `collectRuns` over already-loaded transcripts + recorded
  *    artifacts — reproducible, no spawn. The primary path.
  *  - Capture-manifest (story 7): `CaptureManifest` documents, per run, the transcript path +
@@ -28,12 +29,19 @@ import {type CorpusEntry, type CorpusManifest, STAGES} from "./corpus.ts";
 import {type Grade, gradeEntry} from "./oracle.ts";
 
 /**
- * One run's token spend: reconstructed from its transcript, or explicitly missing. Modelled as a
- * union (not a nullable `StageSpend`) so a not-found transcript is a distinct, counted outcome —
- * never a fabricated zero the report could mistake for a genuinely free run.
+ * One run's token spend, as one of three distinct outcomes — never a nullable `StageSpend`, so a
+ * zero can never be fabricated where a measurement is missing.
+ *
+ * `NoBilledTurns` is the third: a transcript that exists and parses cleanly but carries **zero**
+ * billed assistant turns, which reconstructs to a genuine, well-formed zero indistinguishable from a
+ * free run. That is not hypothetical — a `claude -p` run whose skill failed to resolve writes
+ * exactly such a transcript, and `token-spend` reports all-zeros at exit 0 (measured on 2.1.220,
+ * #4673 §6). Folding it into `Reconstructed` would put the fabricated zero back that this union
+ * exists to keep out.
  */
 export type RunSpend =
 	| {readonly _tag: "Reconstructed"; readonly spend: StageSpend}
+	| {readonly _tag: "NoBilledTurns"}
 	| {readonly _tag: "TranscriptMissing"};
 
 /** One graded run row: the corpus entry, its grade against the label, and its token spend. */
@@ -62,11 +70,15 @@ export interface RunInput {
 export const collectRun = (input: RunInput): RunRow => ({
 	entry: input.entry,
 	grade: gradeEntry(input.entry, input.artifact),
-	spend:
-		input.transcript === null
-			? {_tag: "TranscriptMissing"}
-			: {_tag: "Reconstructed", spend: reconstructSpend(input.transcript)},
+	spend: classifyRunSpend(input.transcript),
 });
+
+/** Resolve a transcript to one of the three `RunSpend` outcomes. Pure + total. */
+export const classifyRunSpend = (transcript: string | null): RunSpend => {
+	if (transcript === null) return {_tag: "TranscriptMissing"};
+	const spend = reconstructSpend(transcript);
+	return spend.assistantTurns === 0 ? {_tag: "NoBilledTurns"} : {_tag: "Reconstructed", spend};
+};
 
 /**
  * Offline/replay entry point (story 6): collect a graded `{entry, grade, spend}` row per supplied
@@ -79,9 +91,12 @@ export const collectRuns = (inputs: ReadonlyArray<RunInput>): ReadonlyArray<RunR
 /**
  * A capture-manifest run (story 7): names, for one corpus run, WHERE its transcript lives and WHAT
  * artifact it produced, keyed by (stage, inputRef) so it joins to a `CorpusEntry`'s ground-truth
- * label. `transcriptPath` is the sub-agent transcript at `<parent-session-id>/subagents/agent-<id>.jsonl`
- * (ADR 0112 §2); `artifact` is the recorded decision artifact graded as-is. This is the documented
- * shape a fresh live run (spawned by the operator, not this tool) folds into the corpus deterministically.
+ * label. `artifact` is the recorded decision artifact graded as-is.
+ *
+ * `transcriptPath` takes either of the two real shapes: a Task-spawned sub-agent's
+ * `<parent-session-id>/subagents/agent-<id>.jsonl` (ADR 0112 §2), or a headless `claude -p` run's
+ * `<claude-data-root>/projects/<cwd-slug>/<session-id>.jsonl` — a top-level session, so NOT under
+ * `subagents/`. Both reconstruct through the same `token-spend` core.
  */
 export const CaptureRun = Schema.Struct({
 	stage: Schema.Literals([...STAGES]),

--- a/packages/pipeline-cli/src/tools/eval-harness/spawn-io.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/spawn-io.ts
@@ -1,0 +1,112 @@
+/**
+ * The OS boundary for the eval runner: the one place in `eval-harness` that starts a process
+ * (issue #4676, ADR 0236). Every decision lives in `spawn.ts`; this file only performs.
+ *
+ * Deliberately synchronous and outside the Effect `E` channel, matching `epic-lock/presence-io.ts`:
+ * every failure here is already modelled as a value the pure classifier reads fail-closed (a
+ * `SpawnFailed` / `TimedOut` executor result, a `null` transcript path), so lowering it into a typed
+ * error would add a channel no caller can act on.
+ *
+ * A `claude -p` **subprocess is not a `Task` tool call**, so it is outside `spawn-guard`'s
+ * `PreToolUse` surface entirely (measured, #4673 §5). That is what lets a run name any model — and
+ * it is also why this must never be re-implemented as an in-session Task spawn, which would hard-deny
+ * every model outside the guard's allowlist.
+ */
+import {spawnSync} from "node:child_process";
+import {readdirSync, readFileSync} from "node:fs";
+import {homedir} from "node:os";
+import {join} from "node:path";
+import {buildClaudeArgs, type Executor, type ExecutorResult, type PlannedRun} from "./spawn.ts";
+
+/**
+ * Where `claude` keeps its per-session transcripts. `CLAUDE_CONFIG_DIR` overrides the default
+ * per-user config dir (the 2.1.220 binary reads it in 27 places, #4673 §2).
+ */
+export const claudeDataRoot = (
+	env: Readonly<Record<string, string | undefined>> = process.env,
+	home: string = homedir(),
+): string => {
+	const configured = env.CLAUDE_CONFIG_DIR;
+	return configured !== undefined && configured !== "" ? configured : join(home, ".claude");
+};
+
+/**
+ * Find a pinned session's transcript, or `null`.
+ *
+ * The file is `<data-root>/projects/<cwd-slug>/<session-id>.jsonl`, and the search is a scan of the
+ * project dirs rather than a re-derivation of `<cwd-slug>` on purpose: the slug is a lossy
+ * flattening of the working directory's separators, so re-deriving it breaks on any path the
+ * flattening collapses, and would answer "no transcript" for a run that produced one (#4673 §7).
+ */
+export const locateTranscript = (sessionId: string, dataRoot = claudeDataRoot()): string | null => {
+	const projects = join(dataRoot, "projects");
+	let dirs: ReadonlyArray<string>;
+	try {
+		dirs = readdirSync(projects);
+	} catch {
+		return null;
+	}
+	const file = `${sessionId}.jsonl`;
+	for (const dir of dirs) {
+		const candidate = join(projects, dir, file);
+		try {
+			readFileSync(candidate, "utf8");
+			return candidate;
+		} catch {}
+	}
+	return null;
+};
+
+/** A transcript's raw text, or `null` when absent/unreadable — the `TranscriptLoader` `runner.ts` takes. */
+export const readTranscript = (path: string): string | null => {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return null;
+	}
+};
+
+/** The CLI version a scorecard is pinned to (#4680), or `null` when it cannot be read. */
+export const claudeVersion = (executable = "claude"): string | null => {
+	const result = spawnSync(executable, ["--version"], {encoding: "utf8", timeout: 10_000});
+	return result.status === 0 ? result.stdout.trim() : null;
+};
+
+/**
+ * The real executor: run one planned invocation to completion under a stated wall-clock bound.
+ *
+ * `spawnSync` rather than `execFileSync` because its three outcomes are *return values*, not
+ * exceptions — measured on node: a timeout yields `error.code === "ETIMEDOUT"` with `status: null`
+ * after SIGTERM, an unresolvable executable yields `ENOENT`, and a normal finish yields a numeric
+ * `status`. Mapping them here keeps the classifier total.
+ */
+export const claudeExecutor = (opts: {
+	readonly timeoutMs: number;
+	readonly cwd?: string;
+	readonly executable?: string;
+}): Executor => {
+	const executable = opts.executable ?? "claude";
+	return (plan: PlannedRun): ExecutorResult => {
+		const result = spawnSync(executable, [...buildClaudeArgs(plan)], {
+			encoding: "utf8",
+			timeout: opts.timeoutMs,
+			maxBuffer: 64 * 1024 * 1024,
+			...(opts.cwd === undefined ? {} : {cwd: opts.cwd}),
+		});
+		if (result.error !== undefined) {
+			const code = (result.error as NodeJS.ErrnoException).code;
+			return code === "ETIMEDOUT"
+				? {_tag: "TimedOut", boundMs: opts.timeoutMs}
+				: {_tag: "SpawnFailed", detail: `${code ?? "unknown"}: ${result.error.message}`};
+		}
+		if (result.status === null) {
+			return {_tag: "SpawnFailed", detail: `killed by signal ${result.signal ?? "unknown"}`};
+		}
+		return {
+			_tag: "Exited",
+			code: result.status,
+			stdout: result.stdout ?? "",
+			stderr: result.stderr ?? "",
+		};
+	};
+};

--- a/packages/pipeline-cli/src/tools/eval-harness/spawn.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/spawn.ts
@@ -1,0 +1,516 @@
+/**
+ * `eval-harness` spawn-and-collect core — planning an unattended eval run and classifying what came
+ * back (issue #4676, epic #4649).
+ *
+ * This is the **pure** half of the execution layer: it plans the invocations, builds their argv,
+ * decodes the headless result payload, and classifies each run into a typed outcome. It imports no
+ * `node:child_process` and touches no filesystem — the spawning lives in `spawn-io.ts`, so the
+ * module's offline replay path (`runner.ts`) stays reproducible and this core stays unit-testable
+ * against a stubbed executor. See ADR 0236 for why the module gained a spawning shell at all.
+ *
+ * The invocation contract below is **measured, not inferred** — every flag comes from the #4673
+ * spike's evidence log (comment 5153355534 on that issue), re-verified here against `claude`
+ * 2.1.220.
+ *
+ * The one thing that shapes everything else: **an unresolvable skill is a silent green.**
+ * `claude -p "/not-a-skill"` exits 0 with `is_error: false`, `subtype: "success"`, `num_turns: 0`,
+ * `total_cost_usd: 0`, `modelUsage: {}` — and `token-spend` reconstructs its transcript to
+ * well-formed zeros, also at exit 0. Nothing in the platform reports the failure, so a with-skill
+ * arm whose plugin failed to load degrades into a without-skill arm and scores as a legitimate free
+ * run. `classifyRun` therefore synthesizes the missing signal (`NO_MODEL_TURNS_SIGNALS`), and its
+ * verdict is the one place a run is allowed to become a `CaptureRun`.
+ */
+import {reconstructSpend} from "../token-spend/token-spend.ts";
+import {STAGES} from "./corpus.ts";
+import type {CaptureManifest, CaptureRun, TranscriptLoader} from "./runner.ts";
+import type {EvalTier} from "./skill-eval-set.ts";
+
+/**
+ * The with/without methodology's arm variable is **skill availability**, and `--plugin-dir` is the
+ * toggle: it loads the skill under test for that session only. `--disable-slash-commands` is NOT a
+ * usable toggle — measured against a loaded plugin it short-circuits to `num_turns: 0`, `$0`,
+ * `"Unknown command: …"` and never reaches the model (#4673 §4).
+ */
+export const EVAL_ARMS = ["with-skill", "without-skill"] as const;
+
+export type EvalArm = (typeof EVAL_ARMS)[number];
+
+/**
+ * The minimum a case must offer to be run. Declared structurally rather than imported as
+ * `SkillEvalCase` so the executor never depends on the authored format's other fields — a decoded
+ * `SkillEvalCase` satisfies it, and so does a synthetic case in a test.
+ */
+export interface RunnableCase {
+	readonly id: number;
+	readonly prompt: string;
+	readonly tier: EvalTier;
+}
+
+/** One planned invocation: exactly one (case × arm), with the session id its transcript will land under. */
+export interface PlannedRun {
+	readonly caseId: number;
+	readonly tier: EvalTier;
+	readonly arm: EvalArm;
+	readonly sessionId: string;
+	readonly prompt: string;
+	readonly model: string;
+	/** The candidate skill's plugin dir on the with-skill arm; `null` is what makes the other arm the other arm. */
+	readonly pluginDir: string | null;
+	/** The JSON schema text requested for the decision artifact, or `null` when none was asked for. */
+	readonly jsonSchema: string | null;
+}
+
+/**
+ * Plan one invocation per (case × arm). `sessionId` is supplied by the caller (the IO shell mints
+ * UUIDs) because pinning it is what makes the transcript locatable afterwards — the result payload
+ * carries `session_id` but never the transcript path (#4673 §7).
+ */
+export const planEvalRuns = (args: {
+	readonly cases: ReadonlyArray<RunnableCase>;
+	readonly arms: ReadonlyArray<EvalArm>;
+	readonly model: string;
+	readonly pluginDir: string;
+	readonly jsonSchema: string | null;
+	readonly sessionId: (caseId: number, arm: EvalArm) => string;
+}): ReadonlyArray<PlannedRun> =>
+	args.cases.flatMap((evalCase) =>
+		args.arms.map(
+			(arm): PlannedRun => ({
+				caseId: evalCase.id,
+				tier: evalCase.tier,
+				arm,
+				sessionId: args.sessionId(evalCase.id, arm),
+				prompt: evalCase.prompt,
+				model: args.model,
+				pluginDir: arm === "with-skill" ? args.pluginDir : null,
+				jsonSchema: args.jsonSchema,
+			}),
+		),
+	);
+
+/**
+ * The argv for one planned run, minus the executable.
+ *
+ * Two flags are deliberately absent and must stay absent. `--no-session-persistence` would suppress
+ * the transcript this whole path is built to collect, and `--disable-slash-commands` silently
+ * short-circuits a `/<skill>` prompt (both #4673 §4/§7).
+ */
+export const buildClaudeArgs = (plan: PlannedRun): ReadonlyArray<string> => [
+	"-p",
+	plan.prompt,
+	"--output-format",
+	"json",
+	"--session-id",
+	plan.sessionId,
+	"--model",
+	plan.model,
+	...(plan.pluginDir === null ? [] : ["--plugin-dir", plan.pluginDir]),
+	...(plan.jsonSchema === null ? [] : ["--json-schema", plan.jsonSchema]),
+];
+
+/** What the executor observed. Total: a dead or wedged child is a value here, never an exception. */
+export type ExecutorResult =
+	| {
+			readonly _tag: "Exited";
+			readonly code: number;
+			readonly stdout: string;
+			readonly stderr: string;
+	  }
+	| {readonly _tag: "TimedOut"; readonly boundMs: number}
+	| {readonly _tag: "SpawnFailed"; readonly detail: string};
+
+/** The seam the unit tier stubs: a planned run in, an observation out. No model call in a unit test. */
+export type Executor = (plan: PlannedRun) => ExecutorResult;
+
+/** The fields of the headless `result` message this runner reads. Everything else in it is ignored. */
+export interface HeadlessResult {
+	readonly isError: boolean;
+	readonly subtype: string;
+	readonly numTurns: number;
+	readonly text: string;
+	readonly sessionId: string;
+	readonly modelUsageKeys: ReadonlyArray<string>;
+	readonly totalCostUsd: number | null;
+	readonly hasStructuredOutput: boolean;
+	readonly structuredOutput: unknown;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Find the `result` message in a headless run's stdout.
+ *
+ * `--output-format json` emits a **JSON array of stream messages** (`system/init`, `assistant`,
+ * `result`) on 2.1.220 — measured, and a correction to the spike, which described the top level as
+ * the result object itself. Both shapes are read: the last `type: "result"` element of an array, or
+ * a bare object that already is one. Reading only one of them would make the runner version-brittle
+ * in the direction that matters least safely — a missed result reads as a dead run.
+ */
+const findResultMessage = (parsed: unknown): Record<string, unknown> | null => {
+	if (Array.isArray(parsed)) {
+		for (let i = parsed.length - 1; i >= 0; i -= 1) {
+			const message: unknown = parsed[i];
+			if (isRecord(message) && message.type === "result") return message;
+		}
+		return null;
+	}
+	if (isRecord(parsed) && (parsed.type === "result" || parsed.type === undefined)) {
+		return parsed;
+	}
+	return null;
+};
+
+const asNumber = (value: unknown): number | null => (typeof value === "number" ? value : null);
+
+/**
+ * Decode a headless run's stdout into the fields the guard needs, or `null` when it holds no
+ * readable result message.
+ *
+ * Hand-read rather than schema-decoded on purpose: the payload carries a dozen fields that vary by
+ * CLI version, and a strict decode would turn a harmless new key into a dead run. Every field is
+ * read defensively and a missing one degrades to the value that makes `classifyRun` *stricter*
+ * (zero turns, no model usage, no structured output), never to a pass.
+ */
+export const decodeHeadlessResult = (stdout: string): HeadlessResult | null => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return null;
+	}
+	const message = findResultMessage(parsed);
+	if (message === null) return null;
+	const modelUsage = message.modelUsage;
+	return {
+		isError: message.is_error === true,
+		subtype: typeof message.subtype === "string" ? message.subtype : "",
+		numTurns: asNumber(message.num_turns) ?? 0,
+		text: typeof message.result === "string" ? message.result : "",
+		sessionId: typeof message.session_id === "string" ? message.session_id : "",
+		modelUsageKeys: isRecord(modelUsage) ? Object.keys(modelUsage) : [],
+		totalCostUsd: asNumber(message.total_cost_usd),
+		hasStructuredOutput: message.structured_output !== undefined,
+		structuredOutput: message.structured_output,
+	};
+};
+
+/**
+ * The five ways a run can report success while never having reached a model. Each is an independent
+ * observation of the same hazard, kept separate so a ledger names *which* one fired — "the plugin
+ * did not load" and "the schema was ignored" are different repairs.
+ */
+export const NO_MODEL_TURNS_SIGNALS = [
+	"unknown-command",
+	"zero-turns",
+	"empty-model-usage",
+	"zero-assistant-turns",
+	"missing-structured-output",
+] as const;
+
+export type NoModelTurnsSignal = (typeof NO_MODEL_TURNS_SIGNALS)[number];
+
+/** Why a run is not collectable. Every arm is counted; none is ever scored as a pass. */
+export type RunFailure =
+	| {readonly _tag: "SpawnFailed"; readonly detail: string}
+	| {readonly _tag: "TimedOut"; readonly boundMs: number}
+	| {readonly _tag: "UndecodableResult"; readonly detail: string}
+	| {readonly _tag: "ReportedError"; readonly detail: string}
+	| {readonly _tag: "NoModelTurns"; readonly signal: NoModelTurnsSignal; readonly detail: string}
+	| {readonly _tag: "TranscriptNotFound"; readonly sessionId: string};
+
+/** One executed run: collectable, or a typed counted failure. There is no third state. */
+export type RunOutcome =
+	| {
+			readonly _tag: "Completed";
+			readonly caseId: number;
+			readonly tier: EvalTier;
+			readonly arm: EvalArm;
+			readonly sessionId: string;
+			readonly transcriptPath: string;
+			readonly artifact: unknown;
+			readonly numTurns: number;
+			readonly totalCostUsd: number | null;
+	  }
+	| {
+			readonly _tag: "Failed";
+			readonly caseId: number;
+			readonly tier: EvalTier;
+			readonly arm: EvalArm;
+			readonly sessionId: string;
+			readonly failure: RunFailure;
+	  };
+
+const failed = (plan: PlannedRun, failure: RunFailure): RunOutcome => ({
+	_tag: "Failed",
+	caseId: plan.caseId,
+	tier: plan.tier,
+	arm: plan.arm,
+	sessionId: plan.sessionId,
+	failure,
+});
+
+/**
+ * Detect a run that reported success without reaching a model. Order is by specificity: the
+ * `Unknown command:` prefix names the actual cause, so it is reported ahead of the `num_turns === 0`
+ * that always accompanies it.
+ *
+ * `assistantTurns` is the transcript's own reconstruction (`reconstructSpend`), passed in rather
+ * than computed here so this stays pure; `null` means no transcript was read yet, which is not
+ * itself a signal — `TranscriptNotFound` covers that separately.
+ */
+const noModelTurns = (args: {
+	readonly result: HeadlessResult;
+	readonly schemaRequested: boolean;
+	readonly assistantTurns: number | null;
+}): {readonly signal: NoModelTurnsSignal; readonly detail: string} | null => {
+	const {result} = args;
+	if (/^Unknown command:/.test(result.text)) {
+		return {signal: "unknown-command", detail: result.text};
+	}
+	if (result.numTurns === 0) {
+		return {signal: "zero-turns", detail: "the run reported num_turns: 0"};
+	}
+	if (result.modelUsageKeys.length === 0) {
+		return {signal: "empty-model-usage", detail: "the run reported an empty modelUsage"};
+	}
+	if (args.assistantTurns === 0) {
+		return {
+			signal: "zero-assistant-turns",
+			detail: "the transcript reconstructs to zero billed assistant turns",
+		};
+	}
+	if (args.schemaRequested && !result.hasStructuredOutput) {
+		return {
+			signal: "missing-structured-output",
+			detail: "a --json-schema was requested but the result carried no structured_output",
+		};
+	}
+	return null;
+};
+
+/**
+ * Classify one executed run. This is the fail-closed seam: only a run that survives every check
+ * becomes `Completed`, and only a `Completed` run reaches the capture manifest.
+ */
+export const classifyRun = (args: {
+	readonly plan: PlannedRun;
+	readonly exec: ExecutorResult;
+	readonly transcriptPath: string | null;
+	readonly assistantTurns: number | null;
+}): RunOutcome => {
+	const {plan, exec} = args;
+	if (exec._tag === "SpawnFailed") return failed(plan, {_tag: "SpawnFailed", detail: exec.detail});
+	if (exec._tag === "TimedOut") return failed(plan, {_tag: "TimedOut", boundMs: exec.boundMs});
+
+	const result = decodeHeadlessResult(exec.stdout);
+	if (result === null) {
+		return failed(plan, {
+			_tag: "UndecodableResult",
+			detail: `exit ${exec.code}: stdout carried no readable result message`,
+		});
+	}
+	if (result.isError) {
+		return failed(plan, {_tag: "ReportedError", detail: result.text || result.subtype});
+	}
+
+	const silentGreen = noModelTurns({
+		result,
+		schemaRequested: plan.jsonSchema !== null,
+		assistantTurns: args.assistantTurns,
+	});
+	if (silentGreen !== null) {
+		return failed(plan, {_tag: "NoModelTurns", ...silentGreen});
+	}
+	if (args.transcriptPath === null) {
+		return failed(plan, {_tag: "TranscriptNotFound", sessionId: plan.sessionId});
+	}
+
+	return {
+		_tag: "Completed",
+		caseId: plan.caseId,
+		tier: plan.tier,
+		arm: plan.arm,
+		sessionId: plan.sessionId,
+		transcriptPath: args.transcriptPath,
+		// `null`, never `undefined`, when no schema was requested: `JSON.stringify` drops an
+		// undefined value entirely, and the written manifest would then fail the existing
+		// `decodeCaptureManifest` on a missing required key.
+		artifact: result.hasStructuredOutput ? result.structuredOutput : null,
+		numTurns: result.numTurns,
+		totalCostUsd: result.totalCostUsd,
+	};
+};
+
+/**
+ * Execute a planned suite and classify every run.
+ *
+ * Pure in the sense that matters: the three effects it needs are parameters, so the unit tier drives
+ * it with a stubbed executor and no model call. It is also the "the suite still completes" guarantee
+ * — a case that dies is classified and the loop continues to the next one, never aborting the run.
+ */
+export const executeRuns = (args: {
+	readonly plans: ReadonlyArray<PlannedRun>;
+	readonly executor: Executor;
+	readonly locateTranscript: (sessionId: string) => string | null;
+	readonly loadTranscript: TranscriptLoader;
+}): ReadonlyArray<RunOutcome> =>
+	args.plans.map((plan) => {
+		const exec = args.executor(plan);
+		const transcriptPath = args.locateTranscript(plan.sessionId);
+		const transcript = transcriptPath === null ? null : args.loadTranscript(transcriptPath);
+		return classifyRun({
+			plan,
+			exec,
+			transcriptPath,
+			assistantTurns: transcript === null ? null : reconstructSpend(transcript).assistantTurns,
+		});
+	});
+
+/**
+ * Fold the completed runs into the capture-manifest shape `collectFromCapture` already consumes —
+ * the whole point of the runner's output (#4676 AC2). `stage` is named by the operator (a skill's
+ * eval set exercises one pipeline stage) and `inputRef` is the case id, which is what joins a run
+ * to its corpus ground truth. A `Failed` run contributes nothing: an uncollected run cannot be
+ * graded, and grading it would be the fabricated pass this whole guard exists to prevent.
+ */
+export const toCaptureManifest = (
+	stage: CaptureRun["stage"],
+	outcomes: ReadonlyArray<RunOutcome>,
+): CaptureManifest => ({
+	version: 1,
+	runs: outcomes.flatMap((outcome) =>
+		outcome._tag === "Completed"
+			? [
+					{
+						stage,
+						inputRef: outcome.caseId,
+						transcriptPath: outcome.transcriptPath,
+						artifact: outcome.artifact,
+					},
+				]
+			: [],
+	),
+});
+
+/** The counted shape of a suite: how many ran, how many died, and of what. */
+export interface RunSummary {
+	readonly planned: number;
+	readonly completed: number;
+	readonly failed: number;
+	readonly byFailure: Readonly<Record<string, number>>;
+	readonly byArm: Readonly<Record<EvalArm, {readonly completed: number; readonly failed: number}>>;
+}
+
+export const summarizeRuns = (outcomes: ReadonlyArray<RunOutcome>): RunSummary => {
+	const byFailure: Record<string, number> = {};
+	const byArm: Record<EvalArm, {completed: number; failed: number}> = {
+		"with-skill": {completed: 0, failed: 0},
+		"without-skill": {completed: 0, failed: 0},
+	};
+	let completed = 0;
+	for (const outcome of outcomes) {
+		if (outcome._tag === "Completed") {
+			completed += 1;
+			byArm[outcome.arm].completed += 1;
+			continue;
+		}
+		byArm[outcome.arm].failed += 1;
+		const key =
+			outcome.failure._tag === "NoModelTurns"
+				? `NoModelTurns:${outcome.failure.signal}`
+				: outcome.failure._tag;
+		byFailure[key] = (byFailure[key] ?? 0) + 1;
+	}
+	return {
+		planned: outcomes.length,
+		completed,
+		failed: outcomes.length - completed,
+		byFailure,
+		byArm,
+	};
+};
+
+/**
+ * Whether the suite executed. Fail-closed in both directions ADR 0092 names: a suite that planned
+ * nothing reports red (a zero-case run that exits green is the zero-scope pass the epic exists to
+ * end), and so does one where any case died. This says nothing about whether the cases *passed* —
+ * grading is `oracle.ts`'s, and the tier verbs' (#4677/#4678), never this verb's.
+ */
+export const suiteExecuted = (summary: RunSummary): boolean =>
+	summary.planned > 0 && summary.failed === 0;
+
+/**
+ * The runner's on-disk output: the ledger of every planned run's typed outcome, plus the capture
+ * manifest folded out of the collectable ones. Both arms are in `runs`, each naming its own, so
+ * with-skill and without-skill stay distinguishable after collection — `CaptureRun` has no arm
+ * field and gains none.
+ */
+export interface RunLedger {
+	readonly version: 1;
+	readonly skillName: string;
+	readonly stage: CaptureRun["stage"];
+	readonly model: string;
+	readonly cliVersion: string | null;
+	readonly runs: ReadonlyArray<RunOutcome>;
+	readonly capture: CaptureManifest;
+	readonly summary: RunSummary;
+}
+
+export const buildLedger = (args: {
+	readonly skillName: string;
+	readonly stage: CaptureRun["stage"];
+	readonly model: string;
+	readonly cliVersion: string | null;
+	readonly outcomes: ReadonlyArray<RunOutcome>;
+}): RunLedger => ({
+	version: 1,
+	skillName: args.skillName,
+	stage: args.stage,
+	model: args.model,
+	cliVersion: args.cliVersion,
+	runs: args.outcomes,
+	capture: toCaptureManifest(args.stage, args.outcomes),
+	summary: summarizeRuns(args.outcomes),
+});
+
+/** The stage names a `--stage` flag accepts — re-exported so the shell needn't reach into `runner.ts`. */
+export const isStageName = (value: string): value is CaptureRun["stage"] =>
+	(STAGES as ReadonlyArray<string>).includes(value);
+
+/** Parse a comma-separated `--arms` value; `null` when it names anything that is not an arm. */
+export const parseArms = (value: string): ReadonlyArray<EvalArm> | null => {
+	const parts = value
+		.split(",")
+		.map((part) => part.trim())
+		.filter((part) => part !== "");
+	if (parts.length === 0) return null;
+	const arms: Array<EvalArm> = [];
+	for (const part of parts) {
+		if (!(EVAL_ARMS as ReadonlyArray<string>).includes(part)) return null;
+		if (!arms.includes(part as EvalArm)) arms.push(part as EvalArm);
+	}
+	return arms;
+};
+
+/** The ledger's stable JSON form — sorted keys are not needed, but a trailing newline is. */
+export const ledgerToJson = (ledger: RunLedger): string => `${JSON.stringify(ledger, null, 2)}\n`;
+
+export const captureToJson = (capture: CaptureManifest): string =>
+	`${JSON.stringify(capture, null, 2)}\n`;
+
+/** A one-line-per-run human rendering, so an operator sees which arm died of what without a jq. */
+export const renderLedger = (ledger: RunLedger): string => {
+	const lines = [
+		`eval-harness run: ${ledger.skillName} · stage ${ledger.stage} · model ${ledger.model}`,
+		...ledger.runs.map((outcome) =>
+			outcome._tag === "Completed"
+				? `  case ${outcome.caseId} [${outcome.arm}] ok — ${outcome.numTurns} turns, transcript ${outcome.transcriptPath}`
+				: `  case ${outcome.caseId} [${outcome.arm}] FAILED — ${outcome.failure._tag}${
+						outcome.failure._tag === "NoModelTurns" ? `:${outcome.failure.signal}` : ""
+					}`,
+		),
+		`  planned ${ledger.summary.planned} · collected ${ledger.summary.completed} · failed ${ledger.summary.failed}`,
+	];
+	return lines.join("\n");
+};

--- a/packages/pipeline-cli/src/tools/eval-harness/spawn.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/spawn.unit.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Unit tier for the spawn-and-collect core (#4676). No model call and no subprocess: the executor
+ * is a stub, which is the seam the design exists to expose.
+ *
+ * The silent-green fixtures below are **captured output**, not invented shapes — the payload in
+ * `SILENT_GREEN_STDOUT` is what `claude -p "/definitely-not-a-skill…" --output-format json` actually
+ * returned on 2.1.220 while building this. If a future CLI stops behaving that way these tests go
+ * green for the wrong reason, so they are paired with the argv contract tests, which pin the flags
+ * that produce it.
+ */
+import {readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import type {CorpusManifest} from "./corpus.ts";
+import {classifyRunSpend, collectFromCapture, decodeCaptureManifest} from "./runner.ts";
+import {
+	buildClaudeArgs,
+	buildLedger,
+	captureToJson,
+	classifyRun,
+	decodeHeadlessResult,
+	type EvalArm,
+	type Executor,
+	type ExecutorResult,
+	executeRuns,
+	isStageName,
+	type PlannedRun,
+	parseArms,
+	planEvalRuns,
+	type RunnableCase,
+	type RunOutcome,
+	suiteExecuted,
+	summarizeRuns,
+	toCaptureManifest,
+} from "./spawn.ts";
+
+const CASES: ReadonlyArray<RunnableCase> = [
+	{id: 1, prompt: "/probe alpha", tier: "graded"},
+	{id: 2, prompt: "/probe beta", tier: "deterministic"},
+];
+
+const BOTH_ARMS: ReadonlyArray<EvalArm> = ["with-skill", "without-skill"];
+
+const plan = (over: Partial<PlannedRun> = {}): PlannedRun => ({
+	caseId: 1,
+	tier: "graded",
+	arm: "with-skill",
+	sessionId: "11111111-2222-4333-8444-555555555555",
+	prompt: "/probe alpha",
+	model: "sonnet",
+	pluginDir: "/candidate/plugin",
+	jsonSchema: null,
+	...over,
+});
+
+/** A well-formed result message: the array-of-stream-messages form the CLI actually emits. */
+const resultStdout = (over: Record<string, unknown> = {}): string =>
+	JSON.stringify([
+		{type: "system", subtype: "init", session_id: "s"},
+		{type: "assistant", message: {role: "assistant"}},
+		{
+			type: "result",
+			subtype: "success",
+			is_error: false,
+			num_turns: 3,
+			result: "done",
+			session_id: "11111111-2222-4333-8444-555555555555",
+			total_cost_usd: 0.19,
+			modelUsage: {"claude-sonnet-5": {costUSD: 0.19}},
+			...over,
+		},
+	]);
+
+/** Captured verbatim: the unresolvable-skill run that exits 0 and reports success (#4673 §6). */
+const SILENT_GREEN_STDOUT = JSON.stringify([
+	{type: "system", subtype: "init", session_id: "s"},
+	{type: "assistant", message: {role: "assistant"}},
+	{
+		type: "result",
+		subtype: "success",
+		is_error: false,
+		num_turns: 0,
+		result: "Unknown command: /definitely-not-a-skill-4676-probe",
+		session_id: "11111111-2222-4333-8444-555555555555",
+		total_cost_usd: 0,
+		modelUsage: {},
+	},
+]);
+
+const exited = (stdout: string, code = 0): ExecutorResult => ({
+	_tag: "Exited",
+	code,
+	stdout,
+	stderr: "",
+});
+
+const billedTranscript = JSON.stringify({
+	message: {
+		role: "assistant",
+		model: "claude-sonnet-5",
+		usage: {
+			input_tokens: 2,
+			cache_creation_input_tokens: 32_122,
+			cache_read_input_tokens: 0,
+			output_tokens: 19,
+		},
+	},
+});
+
+const completedRun = (over: Partial<Parameters<typeof classifyRun>[0]> = {}): RunOutcome =>
+	classifyRun({
+		plan: plan(),
+		exec: exited(resultStdout()),
+		transcriptPath: "/data/projects/x/s.jsonl",
+		assistantTurns: 3,
+		...over,
+	});
+
+describe("planEvalRuns — one invocation per (case × arm)", () => {
+	it("plans every case on every requested arm", () => {
+		const plans = planEvalRuns({
+			cases: CASES,
+			arms: BOTH_ARMS,
+			model: "sonnet",
+			pluginDir: "/candidate",
+			jsonSchema: null,
+			sessionId: (id, arm) => `${id}-${arm}`,
+		});
+		assert.strictEqual(plans.length, 4);
+		assert.deepStrictEqual(
+			plans.map((p) => `${p.caseId}:${p.arm}`),
+			["1:with-skill", "1:without-skill", "2:with-skill", "2:without-skill"],
+		);
+	});
+
+	it("the arm variable is skill availability: with-skill carries the plugin dir, without-skill carries none", () => {
+		const plans = planEvalRuns({
+			cases: [CASES[0] as RunnableCase],
+			arms: BOTH_ARMS,
+			model: "sonnet",
+			pluginDir: "/candidate",
+			jsonSchema: null,
+			sessionId: (id, arm) => `${id}-${arm}`,
+		});
+		assert.strictEqual(plans[0]?.pluginDir, "/candidate");
+		assert.strictEqual(plans[1]?.pluginDir, null);
+	});
+
+	it("carries each case's derived tier through, so a downstream tier verb needn't re-read the set", () => {
+		const plans = planEvalRuns({
+			cases: CASES,
+			arms: ["with-skill"],
+			model: "sonnet",
+			pluginDir: "/candidate",
+			jsonSchema: null,
+			sessionId: (id) => `${id}`,
+		});
+		assert.deepStrictEqual(
+			plans.map((p) => p.tier),
+			["graded", "deterministic"],
+		);
+	});
+});
+
+describe("buildClaudeArgs — the measured invocation contract (#4673 §1)", () => {
+	it("pins the session id, the output format and the model, and passes the prompt to -p", () => {
+		assert.deepStrictEqual(
+			[...buildClaudeArgs(plan({pluginDir: null}))],
+			[
+				"-p",
+				"/probe alpha",
+				"--output-format",
+				"json",
+				"--session-id",
+				"11111111-2222-4333-8444-555555555555",
+				"--model",
+				"sonnet",
+			],
+		);
+	});
+
+	it("the two arms' argv differ by exactly --plugin-dir", () => {
+		const withSkill = [...buildClaudeArgs(plan({arm: "with-skill", pluginDir: "/candidate"}))];
+		const without = [...buildClaudeArgs(plan({arm: "without-skill", pluginDir: null}))];
+		assert.deepStrictEqual(
+			withSkill.filter((a) => !["--plugin-dir", "/candidate"].includes(a)),
+			without,
+		);
+	});
+
+	it("requests the decision artifact via --json-schema when one was asked for", () => {
+		const args = [...buildClaudeArgs(plan({jsonSchema: '{"type":"object"}'}))];
+		assert.include(args, "--json-schema");
+		assert.include(args, '{"type":"object"}');
+	});
+
+	it("never emits --no-session-persistence (it would suppress the transcript) or --disable-slash-commands (it short-circuits a /skill prompt)", () => {
+		for (const p of [plan(), plan({pluginDir: null}), plan({jsonSchema: "{}"})]) {
+			const args = [...buildClaudeArgs(p)];
+			assert.notInclude(args, "--no-session-persistence");
+			assert.notInclude(args, "--disable-slash-commands");
+		}
+	});
+});
+
+describe("decodeHeadlessResult — tolerant of both observed stdout shapes", () => {
+	it("reads the result message out of the stream array the CLI emits", () => {
+		const decoded = decodeHeadlessResult(resultStdout());
+		assert.strictEqual(decoded?.numTurns, 3);
+		assert.deepStrictEqual(decoded?.modelUsageKeys, ["claude-sonnet-5"]);
+		assert.strictEqual(decoded?.totalCostUsd, 0.19);
+	});
+
+	it("reads a bare result object too", () => {
+		const decoded = decodeHeadlessResult(
+			JSON.stringify({type: "result", is_error: false, num_turns: 2, modelUsage: {m: {}}}),
+		);
+		assert.strictEqual(decoded?.numTurns, 2);
+	});
+
+	it("a non-JSON body and a stream with no result message both decode to null, never to a pass", () => {
+		assert.strictEqual(decodeHeadlessResult("not json at all"), null);
+		assert.strictEqual(decodeHeadlessResult(JSON.stringify([{type: "system"}])), null);
+	});
+
+	it("a missing field degrades toward stricter, never toward a pass", () => {
+		const decoded = decodeHeadlessResult(JSON.stringify({type: "result"}));
+		assert.strictEqual(decoded?.numTurns, 0);
+		assert.deepStrictEqual(decoded?.modelUsageKeys, []);
+		assert.strictEqual(decoded?.hasStructuredOutput, false);
+	});
+
+	it("captures structured_output as the artifact when the run produced one", () => {
+		const decoded = decodeHeadlessResult(
+			resultStdout({structured_output: {verdict: "ok", token: "T"}}),
+		);
+		assert.deepStrictEqual(decoded?.structuredOutput, {verdict: "ok", token: "T"});
+	});
+});
+
+describe("classifyRun — the synthesized failure signal for a silent green (#4673 §6)", () => {
+	it("the captured unresolvable-skill run is a typed failure, not a free pass", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: exited(SILENT_GREEN_STDOUT, 0),
+			transcriptPath: "/data/projects/x/s.jsonl",
+			assistantTurns: 0,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed") return;
+		assert.strictEqual(outcome.failure._tag, "NoModelTurns");
+		if (outcome.failure._tag !== "NoModelTurns") return;
+		assert.strictEqual(outcome.failure.signal, "unknown-command");
+	});
+
+	it("num_turns: 0 alone is enough — a run that never reached a model cannot be collected", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: exited(resultStdout({num_turns: 0, result: "ok"})),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 4,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+	});
+
+	it("an empty modelUsage is its own signal", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: exited(resultStdout({modelUsage: {}})),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 4,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed" || outcome.failure._tag !== "NoModelTurns") return;
+		assert.strictEqual(outcome.failure.signal, "empty-model-usage");
+	});
+
+	it("a transcript that reconstructs to zero billed turns is a failure even when the result looks healthy", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: exited(resultStdout()),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 0,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed" || outcome.failure._tag !== "NoModelTurns") return;
+		assert.strictEqual(outcome.failure.signal, "zero-assistant-turns");
+	});
+
+	it("a requested --json-schema that produced no structured_output is a failure", () => {
+		const outcome = classifyRun({
+			plan: plan({jsonSchema: '{"type":"object"}'}),
+			exec: exited(resultStdout()),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 4,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed" || outcome.failure._tag !== "NoModelTurns") return;
+		assert.strictEqual(outcome.failure.signal, "missing-structured-output");
+	});
+
+	it("the same run WITH a structured_output completes and carries it as the artifact", () => {
+		const outcome = classifyRun({
+			plan: plan({jsonSchema: '{"type":"object"}'}),
+			exec: exited(resultStdout({structured_output: {verdict: "ok"}})),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 4,
+		});
+		assert.strictEqual(outcome._tag, "Completed");
+		if (outcome._tag !== "Completed") return;
+		assert.deepStrictEqual(outcome.artifact, {verdict: "ok"});
+	});
+});
+
+describe("classifyRun — a dying run is a typed counted outcome, never a crash", () => {
+	it("a spawn that never started", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: {_tag: "SpawnFailed", detail: "ENOENT: claude not found"},
+			transcriptPath: null,
+			assistantTurns: null,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed") return;
+		assert.strictEqual(outcome.failure._tag, "SpawnFailed");
+	});
+
+	it("a run past its stated bound", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: {_tag: "TimedOut", boundMs: 900_000},
+			transcriptPath: null,
+			assistantTurns: null,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed" || outcome.failure._tag !== "TimedOut") return;
+		assert.strictEqual(outcome.failure.boundMs, 900_000);
+	});
+
+	it("stdout that carries no readable result message", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: exited("<html>gateway error</html>", 1),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 4,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed") return;
+		assert.strictEqual(outcome.failure._tag, "UndecodableResult");
+	});
+
+	it("a run the CLI itself flags as an error", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: exited(resultStdout({is_error: true, subtype: "error_during_execution"})),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 4,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed") return;
+		assert.strictEqual(outcome.failure._tag, "ReportedError");
+	});
+
+	it("a healthy run whose transcript cannot be found", () => {
+		const outcome = classifyRun({
+			plan: plan(),
+			exec: exited(resultStdout()),
+			transcriptPath: null,
+			assistantTurns: null,
+		});
+		assert.strictEqual(outcome._tag, "Failed");
+		if (outcome._tag !== "Failed") return;
+		assert.strictEqual(outcome.failure._tag, "TranscriptNotFound");
+	});
+});
+
+describe("executeRuns — the suite completes, against a stubbed executor", () => {
+	const stub =
+		(byArm: Readonly<Record<EvalArm, ExecutorResult>>): Executor =>
+		(p) =>
+			byArm[p.arm];
+
+	it("one dead arm does not abort the suite; every planned run is accounted for", () => {
+		const plans = planEvalRuns({
+			cases: CASES,
+			arms: BOTH_ARMS,
+			model: "sonnet",
+			pluginDir: "/candidate",
+			jsonSchema: null,
+			sessionId: (id, arm) => `${id}-${arm}`,
+		});
+		const outcomes = executeRuns({
+			plans,
+			executor: stub({
+				"with-skill": exited(SILENT_GREEN_STDOUT),
+				"without-skill": exited(resultStdout()),
+			}),
+			locateTranscript: (sessionId) => `/data/${sessionId}.jsonl`,
+			loadTranscript: () => billedTranscript,
+		});
+		assert.strictEqual(outcomes.length, 4);
+		const summary = summarizeRuns(outcomes);
+		assert.strictEqual(summary.planned, 4);
+		assert.strictEqual(summary.completed, 2);
+		assert.strictEqual(summary.failed, 2);
+		assert.strictEqual(summary.byFailure["NoModelTurns:unknown-command"], 2);
+	});
+
+	it("both arms stay distinguishable in the collected output", () => {
+		const plans = planEvalRuns({
+			cases: [CASES[0] as RunnableCase],
+			arms: BOTH_ARMS,
+			model: "sonnet",
+			pluginDir: "/candidate",
+			jsonSchema: null,
+			sessionId: (id, arm) => `${id}-${arm}`,
+		});
+		const outcomes = executeRuns({
+			plans,
+			executor: () => exited(resultStdout()),
+			locateTranscript: (sessionId) => `/data/${sessionId}.jsonl`,
+			loadTranscript: () => billedTranscript,
+		});
+		assert.deepStrictEqual(
+			outcomes.map((o) => o.arm),
+			["with-skill", "without-skill"],
+		);
+		const ledger = buildLedger({
+			skillName: "probe",
+			stage: "triage",
+			model: "sonnet",
+			cliVersion: "2.1.220",
+			outcomes,
+		});
+		assert.strictEqual(ledger.summary.byArm["with-skill"].completed, 1);
+		assert.strictEqual(ledger.summary.byArm["without-skill"].completed, 1);
+	});
+
+	it("a transcript the loader cannot read yields TranscriptNotFound, not a fabricated zero", () => {
+		const plans = planEvalRuns({
+			cases: [CASES[0] as RunnableCase],
+			arms: ["with-skill"],
+			model: "sonnet",
+			pluginDir: "/candidate",
+			jsonSchema: null,
+			sessionId: () => "s",
+		});
+		const outcomes = executeRuns({
+			plans,
+			executor: () => exited(resultStdout()),
+			locateTranscript: () => null,
+			loadTranscript: () => null,
+		});
+		assert.strictEqual(outcomes[0]?._tag, "Failed");
+	});
+});
+
+describe("toCaptureManifest — the existing collector consumes it unchanged", () => {
+	it("only collectable runs enter the manifest; a failed run is never handed to the oracle", () => {
+		const outcomes: ReadonlyArray<RunOutcome> = [
+			completedRun(),
+			classifyRun({
+				plan: plan({caseId: 2}),
+				exec: exited(SILENT_GREEN_STDOUT),
+				transcriptPath: "/t.jsonl",
+				assistantTurns: 0,
+			}),
+		];
+		const capture = toCaptureManifest("triage", outcomes);
+		assert.strictEqual(capture.runs.length, 1);
+		assert.strictEqual(capture.runs[0]?.inputRef, 1);
+	});
+
+	it("what it writes round-trips through the existing decodeCaptureManifest", () => {
+		const capture = toCaptureManifest("triage", [completedRun()]);
+		const decoded = decodeCaptureManifest(captureToJson(capture));
+		assert.isTrue(Result.isSuccess(decoded));
+	});
+
+	it("collectFromCapture folds it against the corpus with no change to the collector", () => {
+		const corpus: CorpusManifest = {
+			version: 1,
+			stages: {
+				triage: [
+					{stage: "triage", inputRef: 1, label: {type: "bug", priority: "p0", status: "triaged"}},
+				],
+				"write-code": [],
+				"review-code": [],
+				"review-doc": [],
+				"ship-it": [],
+			},
+		};
+		const outcome = classifyRun({
+			plan: plan({jsonSchema: "{}"}),
+			exec: exited(
+				resultStdout({structured_output: {type: "bug", priority: "p0", status: "triaged"}}),
+			),
+			transcriptPath: "/t.jsonl",
+			assistantTurns: 3,
+		});
+		const rows = collectFromCapture({
+			stage: "triage",
+			corpus,
+			capture: toCaptureManifest("triage", [outcome]),
+			loadTranscript: () => billedTranscript,
+		});
+		assert.strictEqual(rows.length, 1);
+		assert.strictEqual(rows[0]?.grade.status, "pass");
+	});
+});
+
+describe("suiteExecuted — fails closed on zero scope and on any dead run (ADR 0092)", () => {
+	it("a suite that planned nothing is red, never a green that checked nothing", () => {
+		assert.isFalse(suiteExecuted(summarizeRuns([])));
+	});
+
+	it("one dead run reds the suite", () => {
+		const outcomes: ReadonlyArray<RunOutcome> = [
+			completedRun(),
+			classifyRun({
+				plan: plan({caseId: 2}),
+				exec: {_tag: "TimedOut", boundMs: 1},
+				transcriptPath: null,
+				assistantTurns: null,
+			}),
+		];
+		assert.isFalse(suiteExecuted(summarizeRuns(outcomes)));
+	});
+
+	it("an all-collected suite is green", () => {
+		assert.isTrue(suiteExecuted(summarizeRuns([completedRun()])));
+	});
+});
+
+describe("RunSpend's third arm — a well-formed zero is not a free run", () => {
+	it("a transcript with billed turns reconstructs", () => {
+		assert.strictEqual(classifyRunSpend(billedTranscript)._tag, "Reconstructed");
+	});
+
+	it("a transcript with zero billed assistant turns is NoBilledTurns, not a zero-valued Reconstructed", () => {
+		assert.strictEqual(classifyRunSpend('{"type":"summary"}')._tag, "NoBilledTurns");
+	});
+
+	it("an absent transcript stays TranscriptMissing", () => {
+		assert.strictEqual(classifyRunSpend(null)._tag, "TranscriptMissing");
+	});
+});
+
+describe("flag parsing", () => {
+	it("accepts the known arms, de-duplicated, and rejects anything else", () => {
+		assert.deepStrictEqual(parseArms("with-skill, without-skill"), ["with-skill", "without-skill"]);
+		assert.deepStrictEqual(parseArms("with-skill,with-skill"), ["with-skill"]);
+		assert.strictEqual(parseArms("with-skil"), null);
+		assert.strictEqual(parseArms(""), null);
+	});
+
+	it("accepts only real stage names", () => {
+		assert.isTrue(isStageName("review-code"));
+		assert.isFalse(isStageName("review-skill"));
+	});
+});
+
+/**
+ * The founder ruling on epic #4649 (comment 5153280445) removes model-in-the-loop execution from CI
+ * on a cost constraint. Asserting it here rather than in prose is the difference between a rule and
+ * a note: the runner's model-spawning verb cannot be wired into a workflow without this reddening.
+ */
+describe("no CI workflow invokes the model-spawning runner (#4649 ruling)", () => {
+	const workflows = fileURLToPath(new URL("../../../../../.github/workflows", import.meta.url));
+
+	it("finds workflow files at all — fail closed on zero scope (ADR 0092)", () => {
+		assert.isAbove(readdirSync(workflows).filter((f) => f.endsWith(".yml")).length, 0);
+	});
+
+	it("no workflow calls `eval-harness run`", () => {
+		const offenders = readdirSync(workflows)
+			.filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+			.filter((f) => /eval-harness\s+run\b/.test(readFileSync(join(workflows, f), "utf8")));
+		assert.deepStrictEqual(offenders, []);
+	});
+});


### PR DESCRIPTION
> **Stacked on #4691 — do not merge before it.** This PR's base is `usirin/eval-case-ingestion-4674-A7151CE6`, the branch of #4691 (`Fixes #4674`), because `#4676 requires: #4674` in the epic topology and that dependency is genuinely unmet on `main`: the `run` verb decodes its eval set with `decodeSkillEvalSet`, which lands in #4691. Basing on `main` would have forced a second decoder for the authored format — the epic's hardest boundary. GitHub retargets this PR to `main` automatically when #4691 merges. **The diff below is this PR's alone**; #4691's seven files are in the base, not here.

Fixes #4676

`pipeline-cli eval-harness run <evals.json>` executes a skill's whole eval set with nobody watching and hands the results to machinery that already exists. No second oracle, no second meter, no second scorecard renderer.

## The two board artifacts this was built against, not the ticket alone

- **The founder ruling on #4649 (comment 5153280445).** No model-in-the-loop execution runs in CI — a **cost** constraint (no credits for model runs in the CI provider), recorded as a constraint rather than a principle. The runner's honest consumers are an operator's shell and a `review-skill` review-stage spawn. It ships with **no workflow**, and a unit test reds if any `.github/workflows/*` file ever calls `eval-harness run` (fail-closed on zero scope, ADR 0092). Asserting it is the difference between a rule and a note.
- **The #4673 spike findings (comment 5153355534).** The invocation, the transcript location, the artifact capture and the arm toggle are all taken from measured evidence, not intuition, and re-verified here.

## The finding that shaped the design — validated independently, not taken on faith

**An unresolvable skill is a silent green.** I reproduced it before designing around it, on `claude` 2.1.220:

```
claude -p "/definitely-not-a-skill-4676-probe" --output-format json --session-id <uuid> --model sonnet
EXITCODE=0
```

and in the result message: `is_error: false`, `subtype: "success"`, `num_turns: 0`, `total_cost_usd: 0`, `modelUsage: {}`, `result: "Unknown command: …"`. A transcript **is** written, and `pipeline-cli token-spend` on it reports **all zeros with exit 0**. So a with-skill arm whose plugin failed to load silently becomes a without-skill arm and scores as a legitimate free run.

The runner therefore **synthesizes its own failure signal**. A run is a counted `NoModelTurns` failure — never a pass, never a graded fail — on any of: `^Unknown command:`, `num_turns === 0`, an empty `modelUsage`, a reconstructed `assistantTurns === 0`, or a requested-but-absent `structured_output`. Alongside it: `SpawnFailed`, `TimedOut`, `UndecodableResult`, `ReportedError`, `TranscriptNotFound`. The suite always completes; only a run that survives every check becomes a `CaptureRun`.

**One correction to the spike, measured.** `--output-format json` emits a **JSON array of stream messages** (`system/init`, `assistant`, `result`) on 2.1.220 — not the bare result object the spike described. `decodeHeadlessResult` reads both shapes; a runner that only read the bare form would have found no result and classified every healthy run as dead.

**`RunSpend` gains its third arm.** `Reconstructed | NoBilledTurns | TranscriptMissing`. A zero-turn run defeats the original two: its transcript is present *and* parses *and* reconstructs to a genuine zero. Folding it into `Reconstructed` would restore the fabricated zero the union exists to prevent.

## Verified live, end to end

A throwaway one-skill plugin and a one-case eval set in scratch, both arms, nothing committed:

```
eval-harness run: fabrika-probe-4676 · stage triage · model sonnet
  case 1 [with-skill] ok — 1 turns, transcript <projects>/<slug>/fbc21ab8-….jsonl
  case 1 [without-skill] FAILED — NoModelTurns:unknown-command
  planned 2 · collected 1 · failed 1
eval-harness: 1 of 2 run(s) did not execute — {"NoModelTurns:unknown-command":1}
EXITCODE=1
```

The with-skill arm resolved, its transcript was located by the pinned session id, and `pipeline-cli token-spend` read it unchanged (`claude-sonnet-5 · billed 63,981 · 1 turn`). The without-skill arm hit the silent green and was **caught** rather than scored. The written `capture.json` is the bare capture-manifest shape; the ledger carries both arms, the per-arm counts, and `cliVersion: "2.1.220 (Claude Code)"` for #4680's pinning.

Worth knowing for #4678: a `/<skill>` case prompt makes the without-skill arm structurally unrunnable, since with no plugin loaded there is no such command. That is the runner telling the truth — a two-arm case is written as plain task text. Documented in the README.

## What changed

- **`spawn.ts`** (new, pure) — `planEvalRuns` (one invocation per case × arm), `buildClaudeArgs` (the measured contract; `--no-session-persistence` and `--disable-slash-commands` are deliberately never emitted), `decodeHeadlessResult`, `classifyRun` (the silent-green battery), `executeRuns`, `toCaptureManifest`, `summarizeRuns`, `suiteExecuted`, `buildLedger`. Imports no `node:child_process` and touches no filesystem.
- **`spawn-io.ts`** (new) — the only file in the module that spawns. `claudeExecutor` uses `spawnSync` because its three outcomes are return values rather than exceptions (grounded on node: timeout → `ETIMEDOUT` + SIGTERM + `status: null`; unresolvable executable → `ENOENT`; normal finish → numeric `status`). `locateTranscript` **scans** the project dirs rather than re-deriving the `<cwd-slug>`, which is a lossy separator flattening.
- **`runner.ts`** — the `NoBilledTurns` arm and `classifyRunSpend`; the `transcriptPath` docblock narrowed to name both real shapes (a Task sub-agent's `subagents/agent-<id>.jsonl` and a headless run's top-level `projects/<slug>/<session-id>.jsonl`).
- **`report.ts`** — `NoBilledTurns` added to `RunSpendSchema`. The aggregation is otherwise untouched: both no-measurement arms stay out of the per-run averages, which is the property that matters. A distinct scorecard column belongs to #4680.
- **`command.ts`** — the `run` verb.
- **`spawn.unit.test.ts`** — 39 tests against a stubbed executor: no model call, no subprocess.
- **ADR 0236** — the module's documented no-spawn property is partially reversed, and this is the diff that causes it.
- **README** — the `run` section, the silent-green table, the invocation-site rule with its cost reason, and the corrected `transcriptPath` prose.

## Acceptance criteria

| AC | Where |
|---|---|
| runs every case unattended; non-zero when the suite could not be executed | `run` verb; `suiteExecuted` reds on any dead run **and** on zero scope |
| output consumed by the existing `collectFromCapture` / `gradeEntry` / `report` path unchanged | `toCaptureManifest`; a test round-trips through `decodeCaptureManifest` and folds through `collectFromCapture` to a `pass` |
| both arms runnable and distinguishable in the collected output | `--arms`; the ledger's per-run `arm` + `summary.byArm` |
| a crashed / hung / transcript-less case is typed, counted, never a pass | `RunFailure`'s six arms; `executeRuns` never aborts the loop |
| pure cores stay spawn-free; existing offline replay tests pass unchanged | `spawn.ts` imports no `node:child_process`; 3110 tests pass, 187 files |
| unit tests cover collection/adaptation against a stubbed executor, no live model call | `spawn.unit.test.ts` |
| **(amended)** no CI workflow invokes the model-spawning path; README states the reason as a cost constraint | asserted by a unit test over `.github/workflows/`; README "Where it may be invoked" |

## Verification

- `pnpm typecheck` — clean (29/29).
- `pnpm lint` — clean.
- `pipeline-cli` unit suite — **3110 passed / 187 files** (3071 on the base; the 39 new ones are mine, and every pre-existing test passes unchanged).
- The live two-arm run above, plus a free `--dry-run` showing the exact argv of both arms.

## Deviations

- **Base is #4691's branch, not `main`.** **Said:** open a PR against `main`. **Did:** based on `usirin/eval-case-ingestion-4674-A7151CE6`. **Why:** `#4676 requires: #4674`, and #4674 is open — its decoder is the eval set's only decoder. A `main`-based PR could only satisfy AC1 by writing a second decoder for the authored format, which the epic names its hardest boundary. **Disposition:** for the reviewer/merge authority to judge — the concrete hazard is that a shipper merging on a PASS would merge **into the sibling branch**, so this must not ship before #4691 does. GitHub retargets the base to `main` on #4691's merge.
- **The base branch moved under this PR once already.** **Said:** stack on #4691's branch. **Did:** #4691 was re-pushed between my fork and this PR's open, so the first diff showed 13 files (its 7 plus my 8); I rebased onto its new tip and force-pushed, and the diff is now my 8. **Why:** flagged rather than silently corrected because it is the standing cost of the stack — every #4691 repair round will re-orphan this base until it merges. **Disposition:** for the reviewer to judge — re-check `changed_files` is 8 before trusting the diff, and note that a rebase here invalidates any prior SHA-bound verdict (ADR 0058).
- **Departure — `--model` is required, with no default.** **Said:** nothing about a default. **Did:** made it mandatory. **Why:** a scorecard is only comparable when it names the model it was measured at (#4680), and a silent default would drift under a fleet change without anyone noticing. **Disposition:** no action needed.
- **Judgment call — `--stage` is a required flag.** **Said:** AC2 wants the output consumed by `collectFromCapture` unchanged. **Did:** `CaptureRun.stage` is a closed literal set with no fabrika-skill member, so the operator names which pipeline stage the eval set exercises, and the case id becomes `inputRef`. **Why:** the alternative was widening `CaptureRun`'s schema, which is the "unchanged collector" the AC forbids touching. **Disposition:** for the reviewer to judge — if a fabrika skill ever exercises something outside the five stages, that is a schema conversation, not a flag one.
- **Judgment call — the exit code reports executability, not pass/fail.** **Said:** "exits non-zero when the suite could not be executed." **Did:** non-zero on any dead run and on zero scope; a *graded* failure is not this verb's exit code. **Why:** bundling them makes a legitimately-failing eval indistinguishable from a harness malfunction, which is the distinction the whole epic draws. **Disposition:** no action needed; the ledger names every cause.
- **Scope held — `report.ts` does not gain a `NoBilledTurns` column.** **Said:** `RunSpend` needs a third arm. **Did:** added the arm and the schema; left the scorecard's `transcriptMissingRuns` counter as the single no-measurement bucket, with a comment. **Why:** renaming a field in the public JSON scorecard is #4680's, and the load-bearing property (no fabricated zero enters the averages) already holds. **Disposition:** for the reviewer to judge.
- **Known defect worked around — #4687.** **Said:** `write-code` mandates `./.claude/.pipeline/skills/write-code/scripts/<script>.sh`. **Did:** invoked the identical scripts via their in-repo `./claude-plugins/kampus-pipeline/…` path. **Why:** the `.claude/.pipeline` symlink does not exist inside a linked worktree, so the mandated literal exits 127 with empty stdout — UNKNOWN, never an answer. No guard was skipped: the delegated-claim check, the opening preflight, a `wt_preflight` before every mutation, the Step-3.5 mis-attribution guard and `pipeline-cli verified-push` (`PUSH-VERDICT: MOVED`) all ran and passed. **Disposition:** surfaced to the dispatching operator; the symlink is harness scope.
- **Spent real money.** **Said:** ground claims in real runs. **Did:** two live `claude -p` runs (~$0.25 total) plus one free zero-turn probe. **Why:** the ticket's central hazard is a silent green, and a guard nobody has watched fire is a guard nobody knows works. **Disposition:** no action needed; all probe artifacts were throwaway scratch and nothing is committed.


- **(repair round 1) Rebased onto `main` after #4691 squash-merged.** **Said:** stack on `usirin/eval-case-ingestion-4674-A7151CE6`. **Did:** #4691 landed as a **squash** (`a1adb783`), so GitHub retargeted this PR's base to `main` while the branch's original commits no longer matched main's single squash commit — the diff reappeared as 13 files. Rebased with `git rebase --onto origin/main 785adfb6`, dropping the commit whose content the squash already carries, and force-pushed with lease. **Why:** rebase-only; no content changed. Proof it is content-neutral: `git diff --stat 785adfb6 origin/main` is **empty** (the old stacked base and current `main` have identical trees), the head commit message hash is byte-identical before and after the rebase, and `git diff --name-status origin/main...HEAD` is exactly this PR's own 8 files — `skill-eval-set.ts`, its unit test, the `fixtures/skill-creator/**` files and `.glossary/TERMS.md` are **inherited from `main`**, not re-added. ADR `0236` re-checked against current `main` (highest there is `0234`) and kept. **Disposition:** for the reviewer to judge — the rebase moved the head, so any prior SHA-bound verdict is invalidated (ADR 0058) and the gate re-runs at the new head. Worked from a fresh worktree because a predecessor worktree still holds the branch; that tree was left untouched (`git switch --ignore-other-worktrees`).
