### PR TITLE
feat(fabrika): the /adr skill and its derived CLI contract — wave-0 pilot (#4704)

### DIFF
--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -52,6 +52,6 @@ nothing else at the `skills/` root.
 
 - **No marketplace entry.** fabrika is not listed in the root marketplace manifest
   (`.claude-plugin/`), so nothing here reaches the pinned external channel (#4643).
-- **No skills yet.** They arrive one authoring session at a time through `/skill-creator`.
-- **No CLI.** fabrika's verbs will live in their own workspace package; `pipeline-cli` stays the
-  v1-era substrate fabrika may call but never grows into.
+- **No dependency on v1.** fabrika calls `pipeline-cli` nowhere — not from a skill, not from a verb.
+  Its own verbs live in `packages/fabrika-cli/`. v1 is a reference to read, never a runtime to call,
+  because a fabrika that calls the old tree can never be the thing that replaces it.

--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -30,9 +30,8 @@ not hand-dropped into `skills/`, not ported from v1, not copied from a sibling p
 fabrika skill is authored through `/skill-creator`, against the [fabrika skill
 conventions](docs/skill-conventions.md), and enters as that session's output.
 
-This posture is the whole reason `skills/` is empty right now. An empty directory is the correct
-state until the first authoring session lands its skill through the door; a skill that appears
-here by any other route is a defect, not a shortcut.
+This posture is why `skills/` fills one authoring session at a time rather than by porting. A skill
+that appears here by any other route is a defect, not a shortcut — the door is the only door.
 
 ## Layout
 
@@ -41,12 +40,12 @@ claude-plugins/fabrika/
 ├── .claude-plugin/plugin.json   the plugin manifest (no version — ADR 0110, continuous ship)
 ├── README.md                    this file: the mission, the only-door posture, the layout
 ├── docs/                        the canonical convention + contract docs (see docs/README.md)
-└── skills/                      one dir per skill, each authored by /skill-creator — empty today
+└── skills/                      one dir per skill, each authored by /skill-creator
 ```
 
-`skills/` holds a `.gitkeep` so the directory survives a clone while it is empty. It carries no
-`README` and no loose files: the fabrika layout law is `SKILL.md` under a per-skill directory and
-nothing else at the `skills/` root.
+`skills/` carries no `README` and no loose files: the fabrika layout law is `SKILL.md` under a
+per-skill directory and nothing else at the `skills/` root. A `.gitkeep` remains from when the
+directory was empty; it is harmless and can go with any later change.
 
 ## What is deliberately absent
 

--- a/claude-plugins/fabrika/docs/authoring-brief-contract.md
+++ b/claude-plugins/fabrika/docs/authoring-brief-contract.md
@@ -71,17 +71,25 @@ Two rules keep the field honest:
 - **A skill with no corpus rows says so explicitly.** An empty list and an unwritten list read the
   same on the page and mean opposite things.
 
-### 4. Assumable verbs — the deterministic layer that already exists
+### 4. Prior art — the deterministic layer that already exists, to read and not to call
 
-The existing verbs this skill may call, named. The inventory is the
+The existing v1 verbs that already solve some part of this skill's problem, named — as **prior art
+to read, never as a runtime to call**. fabrika calls `pipeline-cli` nowhere (CLI interface
+convention, rule 6): where v1 already does the work, the session reads its source for the semantics
+and the scars it carries, then specifies fabrika's own. The inventory is the
 [#4635](https://github.com/kamp-us/phoenix/issues/4635) gap analysis of `packages/pipeline-cli`
-(76 tools, verified 2026-08-01); `pipeline-cli commands compact` renders the live one-line-per-tool
-map on demand, so a brief's list is checkable rather than remembered.
+(76 tools, verified 2026-08-01).
 
-`pipeline-cli` is the v1-era substrate **fabrika may call but never grows into** (the
-[README](../README.md)'s own line). Naming what already exists is what stops a session from
-deriving a contract for work that is already deterministic and already tested — the derived contract
-is for what is *missing*, per the CLI interface convention's Part 2.
+Naming it is still what stops a session from re-deriving a solved problem from zero — it just changes
+what the session does with the answer. Two things a brief should say per entry: what v1's verb
+computes, and what it gets *wrong*, because a scar recorded in the old implementation is the cheapest
+thing a rebuild can inherit. The pilot found two worth carrying: `adr-sweep` exits non-zero on its
+own informative case, and its `--json` payload goes to stderr (#4723). Both were designed out rather
+than reproduced.
+
+**Not every entry becomes a verb.** Where the thing is already *enforced* elsewhere — a CI gate, a
+merge check — fabrika does not compute a second answer to it. Ask whether the skill needs the answer
+or only needs to expect it.
 
 ### 5. Conventions — the two pointers, not their content
 
@@ -180,7 +188,7 @@ point: a session can tell an unbootable brief from a bootable one before it star
 1. The skill name and its destination directory are both stated.
 2. The v1 baseline is a real repo-relative path, or an explicit **none**.
 3. Every incident is a number **and** a one-line behavior; an empty list is written as empty.
-4. Every assumable verb is named as a literal command string.
+4. Every prior-art verb is named, with what it computes and — where known — what it gets wrong.
 5. Both convention docs are linked, and neither is summarised.
 6. The output contract is stated in the brief, not assumed.
 
@@ -228,7 +236,8 @@ The last three are one class read from three angles: **ADR state was resolved ag
 was not current**, and the wrong answer was indistinguishable from a right one. #3779 is the
 allocation race the v1 skill's reservation lock narrows but does not close.
 
-**Assumable verbs** (#4635 inventory — `pipeline-cli commands compact` renders the live map):
+**Prior art to read, not to call** (#4635 inventory; fabrika calls `pipeline-cli` nowhere — CLI
+interface convention rule 6):
 
 - `pipeline-cli decisions-index next` — the next id, `max(id) + 1` zero-padded, parsed from
   `.decisions/` frontmatter.
@@ -236,7 +245,8 @@ allocation race the v1 skill's reservation lock narrows but does not close.
 - `pipeline-cli decisions-index validate` — reds on a duplicate id or a filename/frontmatter
   mismatch; this is the CI backstop the number lock relies on.
 
-Assume these; derive a contract only for deterministic work they do not already cover.
+Read these for semantics and scars; specify fabrika's own. Derive nothing for work that is already
+*enforced* somewhere else — a second answer to a gated question is worse than no answer.
 
 **Conventions:** `claude-plugins/fabrika/docs/skill-conventions.md` ·
 `claude-plugins/fabrika/docs/cli-interface-convention.md`

--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -121,6 +121,35 @@ usable at an agent's top-level command.
   (a session id, a target repo), and each such variable is named in `--help` with its default and
   what happens when it is unset.
 
+### 6. fabrika calls nothing outside fabrika
+
+Source: founder ruling, in-session 2026-08-01, on the wave-0 pilot's derived contract
+([#4704](https://github.com/kamp-us/phoenix/issues/4704) / [#4724](https://github.com/kamp-us/phoenix/pull/4724)).
+
+**No fabrika skill and no fabrika verb invokes `pipeline-cli`, or anything else under
+`claude-plugins/kampus-pipeline/`.** Every deterministic step a skill needs is implemented in
+fabrika's own verb package. Where v1 already solves the same problem, read its source to learn the
+semantics and the scars, then implement fabrika's own — duplication is the accepted cost.
+
+The reason is the **deletion test**: a fabrika that calls v1 can never be the thing that replaces it,
+because every call is a tether keeping the old tree alive. Duplication costs a second implementation
+during the transition. A tether costs the ability to ever delete anything.
+
+Two consequences worth stating, because both were live questions on the pilot:
+
+- **This supersedes "fabrika may call `pipeline-cli` but never grows into it."** That earlier posture
+  produced wrapper verbs whose only job was relaying an upstream answer — seven verbs for one skill,
+  two of them pure pass-throughs. Extrapolated across the skill corpus it rebuilds `pipeline-cli` by
+  accretion, which is the outcome the posture existed to prevent.
+- **Not every v1 call becomes a fabrika verb; some become nothing.** Where the thing being computed
+  is already *enforced* elsewhere — a CI gate, a merge check — fabrika does not compute a second
+  answer to it. The pilot's `adr classify` was dropped for exactly this: `cp-classify` decides
+  control-plane membership at the merge gate, and a fabrika copy could contradict the gate on a
+  merge-gating question. Ask whether the skill needs the answer, or only needs to expect it.
+
+An authoring brief's "assumable verbs" field is therefore a list of **prior art to read**, not a list
+of things to call.
+
 ### Enforcement
 
 There is no mechanical conformance guard yet, and that absence is deliberate: with zero fabrika verbs

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: adr
+description: Record one architecture decision as a `.decisions/NNNN-slug.md` file. Trigger on "/adr", "save this as an ADR", "record this decision", "ADR for X" — and reach for it too whenever a technical preference, convention, or invariant gets settled in conversation that future agents must respect, even when nobody asks for an ADR, because an unrecorded ruling is one the next session re-decides differently. Done when the file exists, the sweep landed on hits-resolved or read-by-hand, every ADR reference in it resolves as live, and the vocabulary impact is a named term or an explicit none.
+---
+
+# adr
+
+One decision per file; the pull request adds nothing but that file plus the status-line edits it
+implies, because discovery is the CLAUDE.md contract and there is no index. Examples run id `0240`.
+
+## 1 — Claim the number
+
+```bash
+fabrika-cli adr next
+```
+
+Unions the freshly fetched merged set with the ids open ADR PRs already claim, so a checkout sitting
+at `0150` while origin is at `0151` cannot mint a duplicate.
+
+**A non-zero exit is UNKNOWN, never "nothing reserved."** Re-run it. Falling back to the highest id
+on disk is what minted ADR 0198 from two lanes at once, and 0114 and 0123 before it (#3779).
+
+## 2 — Write the decision
+
+```bash
+fabrika-cli adr new 0240 only-landed-adrs-may-be-cited
+```
+
+Scaffolds the frontmatter and section skeleton; the slug is kebab-case, at most 5 words.
+
+**The `title` carries the decision, not the topic** — `Every gate fails closed on zero scope`, never
+`Gate scope handling`. One clause, long enough to carry the discriminating half when the ruling has
+one (`X, never Y`); the corpus median is 14 words, a shape rather than a cap. It renders verbatim as
+this ADR's compact-map row, and the `# NNNN — <Title>` H1 repeats it character for character. The
+`**What this decides:**` line beneath is the plain-language gloss a non-author reads.
+
+`## Decision` opens with one bolded declarative sentence, ahead of any mechanics. Where this ADR
+constrains future work, close it with an austere `**Binding constraints.**` or `**Banned.**` list.
+
+## 3 — Sweep the live ADRs this one might contradict
+
+Two live `accepted` ADRs deciding opposite things on one question are worse than an open question:
+each reads as authoritative, neither hints the other exists. Write down what this ADR settles **as
+questions** — *"may an open issue exist without a milestone?"* — not as a summary; you cannot sweep
+for a question you cannot phrase. Then rank the uncited live-accepted ADRs your domain touches:
+
+```bash
+fabrika-cli adr sweep --new 0240
+```
+
+None of its three outcomes is a clearance:
+
+- **`shortlist`** — open the entries and judge each once. It ranks lexical adjacency, caps at 8, and
+  **re-ranks as you add citations**, so the tail refills and chasing a clean result is the trap.
+- **`no-overlap`** — nothing mechanically adjacent was left to open, **never** that there is no
+  contradiction: an ADR disagreeing with yours about what a label *means*, sharing no distinctive
+  vocabulary, never appears at all. Read the domain by hand.
+- **`indeterminate`** — the run carries no information: your draft yielded no distinctive terms, or
+  the corpus is too small to rank rarity against. Say which, and read by hand regardless.
+
+Resolve each real hit in step 4 — supersede where this ADR replaces it outright, amend-in-part where
+the rest still stands. Where you only refine your own earlier ADR's mechanics and its ruling holds,
+append a dated `- **#NNNN — <what changed> (YYYY-MM-DD).**` line under its `## Amendments` instead.
+
+## 4 — Resolve every reference, then edit the status lines
+
+```bash
+fabrika-cli adr resolve 0164 0023 0126
+```
+
+Answers against a freshly fetched base ref, printing `live`, `landed`, `in-flight` or `absent` with
+the real filename. Pass every citation, supersede link and amend target in one call.
+
+**Cite only `live`.** `landed` means present but `proposed`, `superseded` or `retired` — 36 of the
+234 ADRs on `main` — and citing one as settled law is how a withdrawn ADR gets applied 86 minutes
+after its withdrawal (#4338). `in-flight` may never merge: that is how PR #4293 cited ADR 0219 and
+every gate passed on a dead citation (#4296). **A non-zero exit is UNKNOWN, never `absent`** (#4163).
+**Use the filename it prints** — 0048 is `ship-it-merge-actor`, not `single-merge-authority`.
+
+```bash
+fabrika-cli adr supersede 0126 --by 0240
+```
+
+Where the rest of that ADR still stands, `fabrika-cli adr amend-in-part 0023 --by 0240` instead.
+Either verb touches the `status:` line and nothing else — an accepted ADR's decision text is
+immutable, so name the relationship in your own `## Context` rather than editing theirs.
+
+## 5 — Record the vocabulary impact
+
+An ADR is a primary coining site — 0126's "ambient discovery" was coined here and drifted silently.
+Land on **exactly one** outcome; the explicit "none" separates *considered it* from *forgot to*:
+
+- **A term is coined or redefined** → name it and route it to `.glossary/TERMS.md`: the row in this
+  PR when the definition is short and unambiguous, otherwise `/glossary`.
+- **Nothing is coined** → add a terminal `## Records` section and write `no vocabulary impact`.
+
+## 6 — Check, classify, report
+
+```bash
+fabrika-cli adr resolve 0240
+```
+
+Your own id, one last time: `absent` means nobody claimed it while you wrote; `in-flight` means
+another lane opened its PR first, so renumber now.
+
+```bash
+fabrika-cli adr classify 0240
+```
+
+Prints `guard-touching` or `not-guard-touching`. No `.decisions/**` path matches the control-plane
+pattern, so a guard-governing ADR is §CP by content alone (ADR 0164), and one routed as ordinary
+reaches `main` with zero approvals (#4386, #3416). Anything but `not-guard-touching` — a verb that
+never ran included — needs a control-plane approval at head.
+
+**Never reword to change that verdict.** The probe fires on words — `gate`, `guard`, `control-plane`
+— so 84% of the corpus classifies §CP; a false §CP costs one approval, a false ordinary is #4386.
+Say it misfired on the PR (#2617).
+
+Report the path, the verdict and the vocabulary outcome; do not summarize the body.

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -95,7 +95,7 @@ Land on **exactly one** outcome; the explicit "none" separates *considered it* f
   PR when the definition is short and unambiguous, otherwise `/glossary`.
 - **Nothing is coined** → add a terminal `## Records` section and write `no vocabulary impact`.
 
-## 6 — Check, classify, report
+## 6 — Check, then report
 
 ```bash
 fabrika-cli adr resolve 0240
@@ -104,17 +104,10 @@ fabrika-cli adr resolve 0240
 Your own id, one last time: `absent` means nobody claimed it while you wrote; `in-flight` means
 another lane opened its PR first, so renumber now.
 
-```bash
-fabrika-cli adr classify 0240
-```
+**Expect this PR to route as control plane.** No `.decisions/**` path matches the control-plane
+pattern, so `cp-classify` decides it on content at the gate — and 84% of the corpus comes back
+guard-touching. **That gate is the authority; do not predict it and never reword the ADR to change
+its verdict.** A false §CP costs one approval, a false ordinary reaches `main` with none (#4386,
+#3416). If you think it misfired, say so on the PR (#2617).
 
-Prints `guard-touching` or `not-guard-touching`. No `.decisions/**` path matches the control-plane
-pattern, so a guard-governing ADR is §CP by content alone — what `cp-classify` enforces on the merge
-path — and one routed as ordinary reaches `main` with zero approvals (#4386, #3416). Anything but
-`not-guard-touching`, a verb that never ran included, needs approval at head.
-
-**Never reword to change that verdict.** The probe fires on words — `gate`, `guard`, `control-plane`
-— so 84% of the corpus classifies §CP; a false §CP costs one approval, a false ordinary is #4386.
-Say it misfired on the PR (#2617).
-
-Report the path, the verdict and the vocabulary outcome; do not summarize the body.
+Report the path and the vocabulary outcome; do not summarize the body.

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -29,10 +29,11 @@ fabrika-cli adr new 0240 only-landed-adrs-may-be-cited
 Scaffolds the frontmatter and section skeleton; the slug is kebab-case, at most 5 words.
 
 **The `title` carries the decision, not the topic** — `Every gate fails closed on zero scope`, never
-`Gate scope handling`. One clause, long enough to carry the discriminating half when the ruling has
-one (`X, never Y`); the corpus median is 14 words, a shape rather than a cap. It renders verbatim as
-this ADR's compact-map row, and the `# NNNN — <Title>` H1 repeats it character for character. The
-`**What this decides:**` line beneath is the plain-language gloss a non-author reads.
+`Gate scope handling`. **One clause**: where the ruling has a discriminating half, it belongs inside
+that clause (`X, never Y`), never appended as a second clause after an em-dash. The corpus median is
+14 words, a shape rather than a cap. It renders verbatim as this ADR's compact-map row, and the
+`# NNNN — <Title>` H1 repeats it character for character. The `**What this decides:**` line beneath
+is the plain-language gloss a non-author reads.
 
 `## Decision` opens with one bolded declarative sentence, ahead of any mechanics. Where this ADR
 constrains future work, close it with an austere `**Binding constraints.**` or `**Banned.**` list.

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -72,7 +72,7 @@ Answers against a freshly fetched base ref, printing `live`, `landed`, `in-fligh
 the real filename. Pass every citation, supersede link and amend target in one call.
 
 **Cite only `live`.** `landed` means present but `proposed`, `superseded` or `retired` — 36 of the
-234 ADRs on `main` — and citing one as settled law is how a withdrawn ADR gets applied 86 minutes
+233 ADRs on `main` — and citing one as settled law is how a withdrawn ADR gets applied 86 minutes
 after its withdrawal (#4338). `in-flight` may never merge: that is how PR #4293 cited ADR 0219 and
 every gate passed on a dead citation (#4296). **A non-zero exit is UNKNOWN, never `absent`** (#4163).
 **Use the filename it prints** — 0048 is `ship-it-merge-actor`, not `single-merge-authority`.
@@ -108,9 +108,9 @@ fabrika-cli adr classify 0240
 ```
 
 Prints `guard-touching` or `not-guard-touching`. No `.decisions/**` path matches the control-plane
-pattern, so a guard-governing ADR is §CP by content alone (ADR 0164), and one routed as ordinary
-reaches `main` with zero approvals (#4386, #3416). Anything but `not-guard-touching` — a verb that
-never ran included — needs a control-plane approval at head.
+pattern, so a guard-governing ADR is §CP by content alone — the rule `cp-classify` enforces today,
+still `proposed` in ADR 0164 — and one routed as ordinary reaches `main` with zero approvals (#4386,
+#3416). Anything but `not-guard-touching`, a verb that never ran included, needs approval at head.
 
 **Never reword to change that verdict.** The probe fires on words — `gate`, `guard`, `control-plane`
 — so 84% of the corpus classifies §CP; a false §CP costs one approval, a false ordinary is #4386.

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -108,9 +108,9 @@ fabrika-cli adr classify 0240
 ```
 
 Prints `guard-touching` or `not-guard-touching`. No `.decisions/**` path matches the control-plane
-pattern, so a guard-governing ADR is §CP by content alone — the rule `cp-classify` enforces today,
-still `proposed` in ADR 0164 — and one routed as ordinary reaches `main` with zero approvals (#4386,
-#3416). Anything but `not-guard-touching`, a verb that never ran included, needs approval at head.
+pattern, so a guard-governing ADR is §CP by content alone — what `cp-classify` enforces on the merge
+path — and one routed as ordinary reaches `main` with zero approvals (#4386, #3416). Anything but
+`not-guard-touching`, a verb that never ran included, needs approval at head.
 
 **Never reword to change that verdict.** The probe fires on words — `gate`, `guard`, `control-plane`
 — so 84% of the corpus classifies §CP; a false §CP costs one approval, a false ordinary is #4386.

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -617,11 +617,13 @@ not-guard-touching
 
 **Grounding**
 
-- ADR 0164 (**`proposed`**, not accepted) — `.decisions/**` matches no control-plane *path*, so a
-  guard-governing ADR is §CP by content alone. The behaviour is live regardless: `cp-classify` and
-  `guard-content-probe` enforce it and stamp `(§CP, ADR 0164)` into their output. Cite the
-  enforcement rather than the decision until 0164 lands — this spec's own `live`/`landed` rule
-  forbids leaning on a `proposed` ADR as settled law, and it binds the spec too.
+- ADR 0164 — `.decisions/**` matches no control-plane *path*, so a guard-governing ADR is §CP by
+  content alone. **The binding fact is the enforcement, not the ADR's status field:** `cp-classify`
+  and `guard-content-probe` implement this today and stamp `(§CP, ADR 0164)` into their output, while
+  0164 itself has read `proposed` throughout — the mismatch is #4388, which carries a founder ruling
+  to accept it that has not landed. Neither this spec nor the skill asserts 0164's status, because a
+  status claim about another record is exactly the thing that rots; `adr resolve` is how a caller
+  learns it at the moment of citing.
 - #4386 / #3416 — a guard-touching ADR routed as ordinary reaches `main` with zero approvals.
 - Upstream's exit codes are inverted — `0` is guard-touching, `3` is not-guard-touching — and its own
   README says to read the stdout word and never the status. The inversion must not leak through this

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -1,0 +1,627 @@
+# `/adr` — derived CLI contract
+
+**Skill:** [`adr`](SKILL.md) · **Authoring brief:** [#4704](https://github.com/kamp-us/phoenix/issues/4704) · **Date:** 2026-08-01
+
+**The seed package.** These are fabrika's first derived verbs, so this spec is where the verb package
+lands — [#4648](https://github.com/kamp-us/phoenix/issues/4648) Resolved question 2 defers the
+decision to the first derived contract, which is this one. The package is `packages/fabrika-cli/`,
+its binary is `fabrika-cli`, and this skill's verbs sit under an `adr` subcommand group. The
+[CLI interface convention](../../docs/cli-interface-convention.md) governs all five; where this spec
+and that doc disagree, the doc wins and this spec is the bug.
+
+**`fabrika-cli` delegates to `pipeline-cli`; it does not absorb it.** `adr sweep` and `adr classify`
+shell out to `pipeline-cli adr-sweep shortlist` and `pipeline-cli guard-content-probe classify` and
+relay their answers. fabrika may call that substrate and never grows into it — neither verb
+reimplements the ranking or the vocabulary match, and a second implementation of either would be
+strictly worse, because two adjacency rankers drifting apart is a failure nobody would notice.
+
+The delegation is a wrapper rather than a raw call in the skill for two reasons, and both are
+mechanical rather than stylistic:
+
+- **There is no legal way for a fabrika skill to invoke `pipeline-cli` directly.** The harness's
+  isolation verifier refuses a `$VAR`-rooted invocation (skill conventions §4), and
+  `cli-invocation-guard` reds a bare `pipeline-cli` inside a runnable fence anywhere under
+  `claude-plugins/`. The canonical `PCLI="…"` form that satisfies the guard is exactly what §4 bans.
+- **Both upstream verbs carry exit contracts a caller gets wrong.** `adr-sweep shortlist` exits `1`
+  whenever it *has* a shortlist — its normal, informative case. `guard-content-probe classify` exits
+  `0` on the §CP hold and `3` on proven-ordinary, inverted from intuition, and its own README says to
+  read the stdout word and never the status. Normalising both onto this contract's uniform "`0` means
+  the answer is on stdout" is the wrapper's whole job, and it is testable in one place instead of
+  remembered at every call site.
+
+## Verb inventory
+
+| Verb | Purpose | Split test |
+|---|---|---|
+| `adr next` | the next unused ADR id, against a fetched base ref unioned with open ADR PRs | fetch, parse ids, take the max, add one — no judgment anywhere in it |
+| `adr new` | scaffold `.decisions/NNNN-slug.md` from the canonical template | the file's *shape* is fixed text with substitutions; only its content is judgment |
+| `adr resolve` | resolve an id to its real filename and state against a fetched base ref | a lookup with a defined answer; whether the result may be cited stays in the skill |
+| `adr supersede` | rewrite an older ADR's `status:` line to `superseded by [NNNN](…)` | *deciding* to supersede is judgment; the one-line edit and its link are mechanical |
+| `adr amend-in-part` | append this ADR to an older one's `amended-in-part by` list | as above, plus the list-append and refusal rules an author gets wrong by hand |
+| `adr sweep` | rank the uncited live-accepted ADRs this one may contradict | the ranking is upstream and deterministic; only *judging* the hits is the skill's, and this verb normalises an exit contract the caller misreads |
+| `adr classify` | answer whether this ADR is control-plane by content | a fixed vocabulary match with an inverted exit code; the judgment left over is whether to dispute it, not how to compute it |
+
+**Considered and not derived.** A verb for step 3's dated `## Amendments` note. It is mechanical, but
+the note's *content* is judgment and its shape is one line the skill already carries, so a verb would
+move one line and add a block. Recorded here so it is not silently re-proposed as a gap.
+
+## Shared conventions
+
+Every verb below obeys these; they are stated once rather than repeated per block.
+
+- **Answer channel: machine.** Stdout carries the answer and nothing else. Scope lines, refusal
+  reasons and progress go to stderr.
+- **Common inputs.** `--dir <path>` (default `.decisions`) is the record directory. `--base <ref>`
+  (default `origin/main`) is the base ref, **fetched before it is read** — reading a stale local ref
+  is the whole defect class this contract exists to close. `--repo <owner/name>` (default: resolved
+  from the `origin` remote) is the repository whose open pull requests form the in-flight set.
+  `--json` swaps the line grammar for one JSON object with the named keys given per verb.
+- **Reserved exit codes.** `0` = the answer is on stdout. `1` = usage error, or the verb failed to
+  run. `127` = the verb never ran. `3` and up are each verb's own proven outcomes.
+- **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
+  a caller reads the status before the bytes.
+- **GitHub reads go through `gh api` REST, never GraphQL** — the org's Projects-classic integration
+  breaks GraphQL — and every list read pages. A pull request that adds its `.decisions/` file past
+  file #100 still claims its number (#725).
+
+---
+
+## `adr next`
+
+**Invocation**
+
+```
+fabrika-cli adr next [--dir <path>] [--base <ref>] [--repo <owner/name>] [--json]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--dir` | string | no | `.decisions` | the directory of `NNNN-slug.md` decision records to scan |
+| `--base` | string | no | `origin/main` | the base ref to fetch and read the merged set from |
+| `--repo` | string | no | the `origin` remote's `owner/name` | the repository whose open pull requests form the in-flight set |
+| `--json` | boolean | no | `false` | emit the full allocation record instead of the bare id |
+
+**Output** — one line, the zero-padded four-digit id, newline-terminated. With `--json`, one object
+with keys `id`, `mergedMax`, `inFlight` (array of ids, ascending), `baseRef`, `baseSha`. There is no
+empty answer: see Scope.
+
+**The id is the maximum of the union, plus one — never the first free number in it.** A gap below
+the maximum is a number some pull request claimed and never merged, and re-issuing it points every
+citation of the abandoned ADR at a different decision. The worked example below is chosen to
+discriminate the two rules: `mergedMax 0236` with `inFlight [0237, 0239]` answers `0240`, where
+first-free would answer `0238`.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | the id was produced on stdout |
+| `1` | usage error, or the verb failed to run |
+| `3` | `--base` could not be fetched, so the merged set is UNKNOWN |
+| `4` | the open pull requests could not be enumerated, so the in-flight set is UNKNOWN |
+| `5` | `--dir` was read and held zero `NNNN-slug.md` records — zero scope |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `adr next: cannot fetch <ref>: <reason> — the merged set is UNKNOWN. Re-run; do not answer from the local tree.` | 3 | refusal |
+| `adr next: cannot enumerate open pull requests in <repo>: <reason> — the in-flight set is UNKNOWN, never "nothing reserved". Re-run; do not fall back to the on-disk id.` | 4 | refusal |
+| `adr next: cannot read PR #<n>'s file list: <reason> — the in-flight set is INCOMPLETE, so it is UNKNOWN.` | 4 | refusal |
+| `adr next: scanned <dir> at <ref>, 0 decision records — refusing to answer (ADR 0092).` | 5 | refusal |
+| `adr next: <dir> holds a record with an unparseable id: <name>` | 1 | refusal |
+
+**Scope** — every `NNNN-slug.md` under `--dir` **as of the fetched `--base`**, plus every open pull
+request in `--repo` that *adds* a `.decisions/NNNN-*.md` file. The scope line goes to stderr on every
+run, naming the base SHA, the record count and the in-flight count, so a caller can audit which half
+produced the answer.
+
+The two halves fail differently, and the difference is load-bearing:
+
+- **Zero records is a failed read, not an answer.** This repo always has decision records, so an
+  empty scan means the wrong directory or a broken read, and answering `0001` would collide with
+  every existing record.
+- **An empty in-flight set is a fact — but only on exit 0.** No open ADR pull request is a normal
+  state. An in-flight set that could not be read is exit 4 and prints nothing on stdout, because a
+  caller that reads an empty set as "nothing reserved" silently falls back to the on-disk id, which
+  is exactly the collision this verb removes.
+
+**Examples**
+
+```
+$ fabrika-cli adr next
+0240
+```
+
+```
+$ fabrika-cli adr next --json
+{"id":"0240","mergedMax":"0236","inFlight":["0237","0239"],"baseRef":"origin/main","baseSha":"49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82"}
+```
+
+```
+$ fabrika-cli adr next --repo kamp-us/nonexistent
+adr next: cannot enumerate open pull requests in kamp-us/nonexistent: HTTP 404 — the in-flight set is UNKNOWN, never "nothing reserved". Re-run; do not fall back to the on-disk id.
+$ echo $?
+4
+```
+
+**Grounding**
+
+- #3779 — two lanes both minted ADR 0198 and both PRs went green; 0114 and 0123 were the same
+  collision earlier. The fetched base ref closes the stale-local-tree half.
+- ADR 0074 — the in-flight reservation lock: an open PR adding `.decisions/NNNN-*.md` *is* the
+  reservation for `NNNN`. **This verb follows 0074's union and departs from its allocation rule.**
+  0074's Decision says "reserve the first integer free in the union"; every implementation since —
+  `decisions-index next` in code, help text and unit tests, and the v1 skill's own Step 1 — computes
+  `max(union) + 1`. This spec follows the implementations, because #4296 (a citation to an ADR that
+  never landed) postdates 0074 and makes re-issuing an abandoned number strictly worse than leaving
+  a gap. Measured 2026-08-01, the two rules are 75 apart: first-free answers `0163` — an id absent
+  from `main`, absent from every open pull request, and never added in any commit in history — while
+  `max(union) + 1` answers `0238`. **The divergence is real and needs an ADR that amends 0074 rather
+  than a spec that quietly outvotes it** — an implementer should not resolve this alone. Tracked on
+  #3779.
+- ADR 0092 — zero scope reds; an empty record scan is a refusal, not `0001`.
+- **The residual race is real and this verb does not close it.** Two authors between the same pair of
+  invocations still collide. `pipeline-cli decisions-index validate` reds the second-to-merge PR in
+  CI, and the skill's step 6 re-check catches it for the caller's own id before the PR opens. A verb
+  that claimed to close it would be lying; state the residual in `--help`.
+- #4208 / #4219 — a proven refusal never shares an exit code with a failure to invoke.
+
+---
+
+## `adr new`
+
+**Invocation**
+
+```
+fabrika-cli adr new 0240 only-landed-adrs-may-be-cited [--dir <path>] [--status <text>] [--date <YYYY-MM-DD>] [--title <text>] [--tags <a,b>]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<id>` | positional string | yes | — | the four-digit zero-padded id this ADR claims |
+| `<slug>` | positional string | yes | — | the kebab-case slug, at most 5 words |
+| `--dir` | string | no | `.decisions` | the directory to write the record into |
+| `--status` | string | no | `accepted` | the frontmatter `status:` value |
+| `--date` | string | no | today, `YYYY-MM-DD` | the frontmatter `date:` value |
+| `--title` | string | no | the slug, de-hyphenated | the frontmatter `title:` value and the H1 |
+| `--tags` | string | no | empty | comma-separated frontmatter tags |
+
+**Output** — one line, the path written, newline-terminated. With `--json`, one object with keys
+`path`, `id`, `slug`.
+
+The file's bytes are the canonical template, and **this block is that template's single home** — the
+skill does not carry a copy to drift against:
+
+```markdown
+---
+id: NNNN
+title: <one decision-carrying clause, ≤ ~12 words — this is the compact-map row>
+status: accepted
+date: YYYY-MM-DD
+tags: []
+---
+
+# NNNN — <Title, verbatim from the frontmatter title>
+
+**What this decides:** <one plain sentence a non-author parses cold.>
+
+## Context
+
+<Why this came up — situation, constraint, prior pain. Name any ADR this supersedes or amends.>
+
+## Decision
+
+**<One bolded declarative sentence.>**
+
+<Then the mechanics, declarative. No hedging.>
+
+## Consequences
+
+<What this makes easier / harder. Any migration cost.>
+```
+
+Two terminal sections are **not** scaffolded, because an empty one invites filler: `## Records` for
+merge-time bookkeeping (`Closes #N`, blocks cleared, the vocabulary-impact outcome) and
+`## Amendments` for dated forward notes. The skill adds them when it has content for them.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | the file was written and its path is on stdout |
+| `1` | usage error, or the verb failed to run |
+| `3` | the target path already exists — refused, never overwritten |
+| `4` | `<id>` is not four digits, or `<slug>` is not kebab-case |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `adr new: <path> already exists — refusing to overwrite.` | 3 | refusal |
+| `adr new: id "<id>" is not four zero-padded digits.` | 4 | usage error |
+| `adr new: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 4 | usage error |
+| `adr new: cannot write <path>: <reason>` | 1 | refusal |
+
+**Scope** — not a judging verb. It writes exactly one file and never edits another. It does not check
+whether the id is claimed; that is `adr next` and `adr resolve`.
+
+**Examples**
+
+```
+$ fabrika-cli adr new 0240 only-landed-adrs-may-be-cited
+.decisions/0240-only-landed-adrs-may-be-cited.md
+```
+
+```
+$ fabrika-cli adr new 0126 ambient-adr-discovery
+adr new: .decisions/0126-ambient-adr-discovery.md already exists — refusing to overwrite.
+$ echo $?
+3
+```
+
+**Grounding**
+
+- The template is the v1 skill's, trimmed. It lives here rather than in `SKILL.md` because a template
+  in two places is a template that drifts, and the skill's job is the judgment the template cannot
+  carry.
+- The `**What this decides:**` line is required on every ADR: the founder ratifies ADRs (ADR 0078)
+  and reads that line, not the dense agent-facing prose beneath it.
+
+---
+
+## `adr resolve`
+
+**Invocation**
+
+```
+fabrika-cli adr resolve 0164 [--dir <path>] [--base <ref>] [--repo <owner/name>] [--json]
+```
+
+One or more ids may be given; each produces one line, in argument order. One fetch serves them all.
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<id>...` | positional string, repeatable | yes | — | the four-digit ids to resolve |
+| `--dir` | string | no | `.decisions` | the directory of decision records to resolve against |
+| `--base` | string | no | `origin/main` | the base ref to fetch and resolve against |
+| `--repo` | string | no | the `origin` remote's `owner/name` | the repository whose open pull requests form the in-flight set |
+| `--json` | boolean | no | `false` | emit one object per id instead of the line grammar |
+
+**Output** — one **tab-separated** line per id: `<state>`, `<file>`, `<detail>`.
+
+| `state` | `file` | `detail` |
+|---|---|---|
+| `live` | the record's filename under `--dir`, at `--base` | the frontmatter `status:` value, verbatim |
+| `landed` | the record's filename — present on the base ref, but not live | the frontmatter `status:` value, verbatim |
+| `in-flight` | the filename the open pull request adds | `PR #<n>` |
+| `absent` | `-` | `-` |
+
+**`live` and `landed` split presence from authority, and the split is the point.** Presence alone is
+what a caller wrongly reads as "citable": 36 of the 234 records on `main` today are present and
+*not* live — 20 `superseded`, 9 `proposed`, 2 `superseded-in-part`, plus `retired`, `moot` and
+`reference`. A verb that answered `landed` for all 234 would license citing every one of them.
+
+The predicate is `isLiveAccepted`, already implemented and named in
+[`adr-sweep`](../../../../packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.ts) — reuse that
+notion rather than minting a second one, because two definitions of "live" drifting apart is worse
+than either definition being wrong. `accepted` is live; so is `amended-in-part`, whose unamended
+remainder still stands. `proposed` is not yet live and `superseded` is no longer.
+
+With `--json`, one object per id with keys `id`, `state`, `file`, `detail`, `baseRef`, `baseSha`.
+
+**All four states are answers, and each is a positive token.** `absent` on exit 0 means *proven
+absent against a current tree*: the fetch succeeded, the records were read, the open pull requests
+were enumerated, and no one holds this id. It is never what a failed read prints.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | a state line was produced for every id given |
+| `1` | usage error, or the verb failed to run |
+| `3` | `--base` could not be fetched, so every state is UNKNOWN |
+| `4` | the open pull requests could not be enumerated, so `absent` cannot be distinguished from `in-flight` |
+| `5` | `--dir` was read and held zero `NNNN-slug.md` records — zero scope |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `adr resolve: cannot fetch <ref>: <reason> — every state is UNKNOWN, never "absent".` | 3 | refusal |
+| `adr resolve: cannot enumerate open pull requests in <repo>: <reason> — "absent" is indistinguishable from "in-flight", so it is UNKNOWN.` | 4 | refusal |
+| `adr resolve: scanned <dir> at <ref>, 0 decision records — refusing to answer (ADR 0092).` | 5 | refusal |
+| `adr resolve: id "<id>" is not four zero-padded digits.` | 1 | usage error |
+| `adr resolve: <dir> at <ref> holds two records for id <id>: <a>, <b>` | 1 | refusal |
+
+**Scope** — every `NNNN-slug.md` under `--dir` at the fetched `--base`, plus every open pull request
+in `--repo` that adds a `.decisions/NNNN-*.md` file. Zero records is a failed read and reds, for the
+same reason it does in `adr next`. The scope line goes to stderr, naming the base SHA and both counts.
+
+**Examples**
+
+```
+$ fabrika-cli adr resolve 0164
+landed	0164-guard-relaxing-adr-cp-gate.md	proposed
+```
+
+```
+$ fabrika-cli adr resolve 0023 0240
+live	0023-live-views-sse-livedo.md	amended-in-part by [0025](0025-split-livedo-connection-topic.md), [0028](0028-effect-durable-object-model.md), [0037](0037-unified-void-aligned-live-do.md)
+absent	-	-
+```
+
+```
+$ fabrika-cli adr resolve 0239
+in-flight	0239-campaign-milestones-close-with-their-arc.md	PR #4711
+```
+
+```
+$ fabrika-cli adr resolve 0164 --base origin/nonexistent
+adr resolve: cannot fetch origin/nonexistent: couldn't find remote ref — every state is UNKNOWN, never "absent".
+$ echo $?
+3
+```
+
+**Grounding**
+
+- #4296 — PR #4293 cited unlanded ADR 0219 and every gate passed on the dead citation. `in-flight` is
+  a distinct state precisely so a caller can refuse to cite it.
+- #4163 — a review gate declared a merged ADR nonexistent. A stale tree must exit 3, never print
+  `absent`.
+- #4338 — a stale checkout applied a withdrawn ADR 86 minutes after the withdrawal landed. The
+  `detail` field carries the frontmatter `status:` verbatim, so a withdrawn or superseded ADR reads
+  as such at the moment of citation.
+- #1777 — a guessed slug is a dead link. A slug is not derivable from a title (0048 is
+  `ship-it-merge-actor`, not `single-merge-authority`), so this verb prints the real filename and the
+  caller uses it verbatim.
+- ADR 0092 — zero scope reds.
+
+---
+
+## `adr supersede` and `adr amend-in-part`
+
+One mechanic, two relationships. Both rewrite the **frontmatter `status:` line of the older ADR and
+nothing else**.
+
+**Invocation**
+
+```
+fabrika-cli adr supersede 0126 --by 0240 [--dir <path>]
+```
+
+```
+fabrika-cli adr amend-in-part 0023 --by 0240 [--dir <path>]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<id>` | positional string | yes | — | the four-digit id of the older ADR whose status line changes |
+| `--by` | string | yes | — | the four-digit id of the ADR doing the superseding or amending |
+| `--dir` | string | no | `.decisions` | the directory both records live in |
+| `--json` | boolean | no | `false` | emit the edit record instead of the line grammar |
+
+**Output** — one **tab-separated** line: the path edited, then the new `status:` value. With
+`--json`, one object with keys `path`, `id`, `by`, `statusBefore`, `statusAfter`.
+
+The written value resolves `--by`'s slug **off disk**, never from its title:
+
+- `supersede` → `superseded by [NNNN](NNNN-slug.md)`, replacing whatever was there.
+- `amend-in-part` → `amended-in-part by [NNNN](NNNN-slug.md)`. When the target already carries an
+  `amended-in-part by` list, the new link is **appended** to it, comma-separated, in id order; a
+  duplicate link is a no-op edit that still exits 0. ADR 0023 carries three such links today, and a
+  verb that overwrote instead of appending would silently drop two live relationships.
+
+**The one-line invariant, enforced in code.** The verb reads the file, rewrites exactly the
+`status:` line, and asserts before writing that the resulting text differs from the original on that
+line alone. A diff of any other line is a bug and aborts the write with exit 6. An accepted ADR's
+decision text is immutable; the relationship is named in the *newer* ADR's `## Context`, which this
+verb never touches. This assertion is the deterministic test the implementation owes.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | the status line was rewritten and the result is on stdout |
+| `1` | usage error, or the verb failed to run |
+| `3` | `<id>` has no record under `--dir` |
+| `4` | `--by` has no record under `--dir` — the link would be dead on arrival |
+| `5` | `<id>`'s frontmatter has no single rewritable `status:` line |
+| `6` | the rewrite would have changed a line other than `status:` — aborted before writing |
+| `7` | `<id>` is already `superseded by …`, so it is not amendable or re-supersedable |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `adr supersede: no record for id <id> under <dir>.` | 3 | refusal |
+| `adr supersede: no record for --by id <by> under <dir> — refusing to write a dead link.` | 4 | refusal |
+| `adr supersede: <path> has no single frontmatter status: line to rewrite.` | 5 | refusal |
+| `adr supersede: rewrite would have changed <n> line(s) beyond status: — aborted, nothing written.` | 6 | refusal |
+| `adr amend-in-part: <path> is already "superseded by …" — a superseded ADR is not amendable.` | 7 | refusal |
+
+Each message is prefixed with the invoked verb name, so `adr amend-in-part` says `adr amend-in-part`.
+
+**Scope** — not a judging verb. It reads and writes exactly one file, the record for `<id>`, and
+reads one more, the record for `--by`, to resolve its slug.
+
+**Examples**
+
+```
+$ fabrika-cli adr supersede 0126 --by 0240
+.decisions/0126-ambient-adr-discovery.md	superseded by [0240](0240-only-landed-adrs-may-be-cited.md)
+```
+
+```
+$ fabrika-cli adr amend-in-part 0023 --by 0240
+.decisions/0023-live-views-sse-livedo.md	amended-in-part by [0025](0025-split-livedo-connection-topic.md), [0028](0028-effect-durable-object-model.md), [0037](0037-unified-void-aligned-live-do.md), [0240](0240-only-landed-adrs-may-be-cited.md)
+```
+
+```
+$ fabrika-cli adr supersede 0126 --by 9999
+adr supersede: no record for --by id 9999 under .decisions — refusing to write a dead link.
+$ echo $?
+4
+```
+
+**Grounding**
+
+- #1777 — the recurring dead-link FAIL. Resolving `--by`'s slug off disk, and refusing when it has no
+  record, is why exit 4 exists.
+- ADR 0023's live status line — three appended `amended-in-part by` links prove the list is real and
+  the append is not hypothetical.
+- The immutability rule: never edit an accepted ADR's decision text; supersede it, or amend it in
+  part on the status line alone. Exit 6 is that rule made mechanical rather than remembered.
+
+---
+
+## `adr sweep`
+
+Delegates to `pipeline-cli adr-sweep shortlist` and relays its answer on this contract's exit terms.
+It reimplements no ranking.
+
+**Invocation**
+
+```
+fabrika-cli adr sweep --new 0240 [--dir <path>] [--limit <n>] [--json]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--new` | string | yes | — | the ADR to sweep: a four-digit id already in `--dir`, or a path to the draft file |
+| `--dir` | string | no | `.decisions` | the corpus to sweep against |
+| `--limit` | integer | no | `8` | how many shortlist entries to emit |
+| `--json` | boolean | no | `false` | emit the sweep result as one JSON object on **stdout** |
+
+**Output** — the first line is the outcome token alone: `shortlist`, `no-overlap` or `indeterminate`.
+On `shortlist`, one tab-separated line per entry follows — `<id>`, `<score>`, `<file>`, `<title>`.
+The reason for a `no-overlap` or `indeterminate`, and the scope line, go to stderr.
+
+**All three outcomes are answers, and all three exit 0.** Upstream exits `1` on a shortlist, which is
+its normal informative case; relaying that status would make every caller read its own results as a
+failed run. Nothing else is transformed — the outcome token is upstream's, verbatim.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | an outcome token was produced on stdout |
+| `1` | usage error, or the verb failed to run |
+| `3` | the underlying sweep could not run, so the outcome is UNKNOWN |
+| `4` | `--new` names an id or path with no readable ADR |
+| `5` | `--dir` was read and held zero `NNNN-slug.md` records — zero scope |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `adr sweep: the underlying sweep failed: <reason> — the outcome is UNKNOWN, never "no-overlap".` | 3 | refusal |
+| `adr sweep: no readable ADR for --new <value>.` | 4 | refusal |
+| `adr sweep: scanned <dir>, 0 decision records — refusing to answer (ADR 0092).` | 5 | refusal |
+
+**Scope** — every live-accepted record under `--dir` that `--new` does not already cite. The scope
+line goes to stderr naming the corpus size and the in-scope count, because the outcome is only
+readable against them: `indeterminate` fires when the live-accepted corpus is below the rarity floor
+of 10, and a caller that cannot see the count cannot tell that from a clean sweep.
+
+**Examples**
+
+```
+$ fabrika-cli adr sweep --new 0240
+shortlist
+0233	15.11	0233-decision-shell-enforcement-review-skill-criterion.md	New decision-computing shell is caught by a review-skill criterion row
+0160	13.46	0160-ref-transaction-guard-refuses-diverging-primary-main.md	A git reference-transaction guard refuses a diverging refs/heads/main ref-move
+$ echo $?
+0
+```
+
+```
+$ fabrika-cli adr sweep --new 0240 --dir claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus
+indeterminate
+$ echo $?
+0
+```
+
+**Grounding**
+
+- `adr-sweep shortlist` exits `1` whenever it has a shortlist — exit 0 only on `no-overlap`. Relaying
+  that status makes the informative case byte-indistinguishable from a failure.
+- ADR 0092 — zero scope reds.
+- #4723 — upstream's `--json` payload currently goes to **stderr**, leaving stdout empty. This verb's
+  `--json` puts it on stdout per rule 2, so the wrapper must move it until #4723 lands.
+
+---
+
+## `adr classify`
+
+Delegates to `pipeline-cli guard-content-probe classify` and relays its verdict on this contract's
+exit terms. It reimplements no vocabulary match.
+
+**Invocation**
+
+```
+fabrika-cli adr classify 0240 [--dir <path>]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<id>` | positional string | yes | — | the four-digit id of the ADR to classify, resolved under `--dir` |
+| `--dir` | string | no | `.decisions` | the directory holding the record |
+
+**Output** — one line, `guard-touching` or `not-guard-touching`, newline-terminated. The human reason
+naming the matched vocabulary goes to stderr.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | a verdict was produced on stdout |
+| `1` | usage error, or the verb failed to run |
+| `3` | the probe could not run, so the verdict is UNKNOWN |
+| `4` | `<id>` has no record under `--dir` |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `adr classify: the probe failed: <reason> — the verdict is UNKNOWN. Treat this ADR as control plane.` | 3 | refusal |
+| `adr classify: no record for id <id> under <dir>.` | 4 | refusal |
+
+**Scope** — one record, so ADR 0092's zero-scope clause does not apply. The fail-closed direction
+here is the *verdict*, not the scope: any non-zero exit obliges the caller to treat the ADR as §CP,
+because a false §CP costs one approval while a false ordinary is #4386.
+
+**Examples**
+
+```
+$ fabrika-cli adr classify 0092
+guard-touching
+```
+
+```
+$ fabrika-cli adr classify 0023
+not-guard-touching
+```
+
+**Grounding**
+
+- ADR 0164 — `.decisions/**` matches no control-plane *path*, so a guard-governing ADR is §CP by
+  content alone.
+- #4386 / #3416 — a guard-touching ADR routed as ordinary reaches `main` with zero approvals.
+- Upstream's exit codes are inverted — `0` is guard-touching, `3` is not-guard-touching — and its own
+  README says to read the stdout word and never the status. The inversion must not leak through this
+  wrapper; normalising it is half the reason the wrapper exists.
+- #2617 — 196 of 233 ADRs currently classify `guard-touching`, an 84% rate. This verb relays that
+  calibration rather than correcting it; re-tuning the vocabulary is #2617's call, not this spec's.

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -304,9 +304,9 @@ One or more ids may be given; each produces one line, in argument order. One fet
 | `absent` | `-` | `-` |
 
 **`live` and `landed` split presence from authority, and the split is the point.** Presence alone is
-what a caller wrongly reads as "citable": 36 of the 234 records on `main` today are present and
+what a caller wrongly reads as "citable": 36 of the 233 records on `main` today are present and
 *not* live — 20 `superseded`, 9 `proposed`, 2 `superseded-in-part`, plus `retired`, `moot` and
-`reference`. A verb that answered `landed` for all 234 would license citing every one of them.
+`reference`. A verb that answered `landed` for all 233 would license citing every one of them.
 
 The predicate is `isLiveAccepted`, already implemented and named in
 [`adr-sweep`](../../../../packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.ts) — reuse that
@@ -617,8 +617,11 @@ not-guard-touching
 
 **Grounding**
 
-- ADR 0164 — `.decisions/**` matches no control-plane *path*, so a guard-governing ADR is §CP by
-  content alone.
+- ADR 0164 (**`proposed`**, not accepted) — `.decisions/**` matches no control-plane *path*, so a
+  guard-governing ADR is §CP by content alone. The behaviour is live regardless: `cp-classify` and
+  `guard-content-probe` enforce it and stamp `(§CP, ADR 0164)` into their output. Cite the
+  enforcement rather than the decision until 0164 lands — this spec's own `live`/`landed` rule
+  forbids leaning on a `proposed` ADR as settled law, and it binds the spec too.
 - #4386 / #3416 — a guard-touching ADR routed as ordinary reaches `main` with zero approvals.
 - Upstream's exit codes are inverted — `0` is guard-touching, `3` is not-guard-touching — and its own
   README says to read the stdout word and never the status. The inversion must not leak through this

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -6,28 +6,25 @@
 lands — [#4648](https://github.com/kamp-us/phoenix/issues/4648) Resolved question 2 defers the
 decision to the first derived contract, which is this one. The package is `packages/fabrika-cli/`,
 its binary is `fabrika-cli`, and this skill's verbs sit under an `adr` subcommand group. The
-[CLI interface convention](../../docs/cli-interface-convention.md) governs all five; where this spec
+[CLI interface convention](../../docs/cli-interface-convention.md) governs all six; where this spec
 and that doc disagree, the doc wins and this spec is the bug.
 
-**`fabrika-cli` delegates to `pipeline-cli`; it does not absorb it.** `adr sweep` and `adr classify`
-shell out to `pipeline-cli adr-sweep shortlist` and `pipeline-cli guard-content-probe classify` and
-relay their answers. fabrika may call that substrate and never grows into it — neither verb
-reimplements the ranking or the vocabulary match, and a second implementation of either would be
-strictly worse, because two adjacency rankers drifting apart is a failure nobody would notice.
+**`fabrika-cli` calls `pipeline-cli` nowhere, and neither does the skill.** fabrika is self-contained
+by construction: every verb this skill needs is implemented in `packages/fabrika-cli/`, and no fence
+in `SKILL.md` invokes anything else. That is the [isolation rule](../../docs/cli-interface-convention.md);
+it is a hard constraint on every fabrika skill, not a preference of this one.
 
-The delegation is a wrapper rather than a raw call in the skill for two reasons, and both are
-mechanical rather than stylistic:
+The reason is the deletion test. A fabrika that calls `pipeline-cli` can never be the thing that
+replaces it — every call is a tether that keeps the old tree alive. Isolation costs a duplicated
+ranking during the transition; a tether costs the ability to ever delete anything.
 
-- **There is no legal way for a fabrika skill to invoke `pipeline-cli` directly.** The harness's
-  isolation verifier refuses a `$VAR`-rooted invocation (skill conventions §4), and
-  `cli-invocation-guard` reds a bare `pipeline-cli` inside a runnable fence anywhere under
-  `claude-plugins/`. The canonical `PCLI="…"` form that satisfies the guard is exactly what §4 bans.
-- **Both upstream verbs carry exit contracts a caller gets wrong.** `adr-sweep shortlist` exits `1`
-  whenever it *has* a shortlist — its normal, informative case. `guard-content-probe classify` exits
-  `0` on the §CP hold and `3` on proven-ordinary, inverted from intuition, and its own README says to
-  read the stdout word and never the status. Normalising both onto this contract's uniform "`0` means
-  the answer is on stdout" is the wrapper's whole job, and it is testable in one place instead of
-  remembered at every call site.
+**`adr classify` was considered and deliberately not derived.** Classifying an ADR as control-plane
+by content is what `cp-classify` already does at the merge gate, and that gate is the authority. A
+fabrika copy of the guard vocabulary could tell an author "ordinary" while the gate says
+"control-plane" — two answers to a merge-gating question, which is worse than either a tether or a
+drifted ranking. The skill instead states the expectation (assume §CP, never reword to dodge the
+gate) and leaves the verdict where it is enforced. The incidents behind it, #4386 and #3416, were the
+*gate* misclassifying, so an author-side predictor would not have caught them anyway.
 
 ## Verb inventory
 
@@ -38,8 +35,7 @@ mechanical rather than stylistic:
 | `adr resolve` | resolve an id to its real filename and state against a fetched base ref | a lookup with a defined answer; whether the result may be cited stays in the skill |
 | `adr supersede` | rewrite an older ADR's `status:` line to `superseded by [NNNN](…)` | *deciding* to supersede is judgment; the one-line edit and its link are mechanical |
 | `adr amend-in-part` | append this ADR to an older one's `amended-in-part by` list | as above, plus the list-append and refusal rules an author gets wrong by hand |
-| `adr sweep` | rank the uncited live-accepted ADRs this one may contradict | the ranking is upstream and deterministic; only *judging* the hits is the skill's, and this verb normalises an exit contract the caller misreads |
-| `adr classify` | answer whether this ADR is control-plane by content | a fixed vocabulary match with an inverted exit code; the judgment left over is whether to dispute it, not how to compute it |
+| `adr sweep` | rank the uncited live-accepted ADRs this one may contradict | ranking is deterministic — scan, score, sort; only *judging* the hits is the skill's |
 
 **Considered and not derived.** A verb for step 3's dated `## Amendments` note. It is mechanical, but
 the note's *content* is judgment and its shape is one line the skill already carries, so a verb would
@@ -164,7 +160,7 @@ $ echo $?
   #3779.
 - ADR 0092 — zero scope reds; an empty record scan is a refusal, not `0001`.
 - **The residual race is real and this verb does not close it.** Two authors between the same pair of
-  invocations still collide. `pipeline-cli decisions-index validate` reds the second-to-merge PR in
+  invocations still collide. CI's `decisions-index validate` job reds the second-to-merge PR in
   CI, and the skill's step 6 re-check catches it for the caller's own id before the PR opens. A verb
   that claimed to close it would be lying; state the residual in `--help`.
 - #4208 / #4219 — a proven refusal never shares an exit code with a failure to invoke.
@@ -308,11 +304,10 @@ what a caller wrongly reads as "citable": 36 of the 233 records on `main` today 
 *not* live — 20 `superseded`, 9 `proposed`, 2 `superseded-in-part`, plus `retired`, `moot` and
 `reference`. A verb that answered `landed` for all 233 would license citing every one of them.
 
-The predicate is `isLiveAccepted`, already implemented and named in
-[`adr-sweep`](../../../../packages/pipeline-cli/src/tools/adr-sweep/adr-sweep.ts) — reuse that
-notion rather than minting a second one, because two definitions of "live" drifting apart is worse
-than either definition being wrong. `accepted` is live; so is `amended-in-part`, whose unamended
-remainder still stands. `proposed` is not yet live and `superseded` is no longer.
+fabrika owns this predicate; it does not import one. The semantics: `accepted` is live, and so is
+`amended-in-part`, whose unamended remainder still stands. `proposed` is not yet live and
+`superseded` is no longer. v1's `isLiveAccepted` is a **reference for what the words mean**, never a
+dependency — read it to check the semantics agree, then implement fabrika's own.
 
 With `--json`, one object per id with keys `id`, `state`, `file`, `detail`, `baseRef`, `baseSha`.
 
@@ -485,8 +480,8 @@ $ echo $?
 
 ## `adr sweep`
 
-Delegates to `pipeline-cli adr-sweep shortlist` and relays its answer on this contract's exit terms.
-It reimplements no ranking.
+Ranks the uncited live-accepted ADRs whose decision domain the subject touches. **Implemented in
+`fabrika-cli`, calling nothing** — the lexical/rarity ranking is fabrika's own.
 
 **Invocation**
 
@@ -554,79 +549,13 @@ $ echo $?
 
 **Grounding**
 
-- `adr-sweep shortlist` exits `1` whenever it has a shortlist — exit 0 only on `no-overlap`. Relaying
-  that status makes the informative case byte-indistinguishable from a failure.
 - ADR 0092 — zero scope reds.
-- #4723 — upstream's `--json` payload currently goes to **stderr**, leaving stdout empty. This verb's
-  `--json` puts it on stdout per rule 2, so the wrapper must move it until #4723 lands.
-
----
-
-## `adr classify`
-
-Delegates to `pipeline-cli guard-content-probe classify` and relays its verdict on this contract's
-exit terms. It reimplements no vocabulary match.
-
-**Invocation**
-
-```
-fabrika-cli adr classify 0240 [--dir <path>]
-```
-
-**Inputs**
-
-| Flag | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `<id>` | positional string | yes | — | the four-digit id of the ADR to classify, resolved under `--dir` |
-| `--dir` | string | no | `.decisions` | the directory holding the record |
-
-**Output** — one line, `guard-touching` or `not-guard-touching`, newline-terminated. The human reason
-naming the matched vocabulary goes to stderr.
-
-**Exit status**
-
-| Code | Trigger |
-|---|---|
-| `0` | a verdict was produced on stdout |
-| `1` | usage error, or the verb failed to run |
-| `3` | the probe could not run, so the verdict is UNKNOWN |
-| `4` | `<id>` has no record under `--dir` |
-
-**Errors**
-
-| Message (stderr) | Code | Kind |
-|---|---|---|
-| `adr classify: the probe failed: <reason> — the verdict is UNKNOWN. Treat this ADR as control plane.` | 3 | refusal |
-| `adr classify: no record for id <id> under <dir>.` | 4 | refusal |
-
-**Scope** — one record, so ADR 0092's zero-scope clause does not apply. The fail-closed direction
-here is the *verdict*, not the scope: any non-zero exit obliges the caller to treat the ADR as §CP,
-because a false §CP costs one approval while a false ordinary is #4386.
-
-**Examples**
-
-```
-$ fabrika-cli adr classify 0092
-guard-touching
-```
-
-```
-$ fabrika-cli adr classify 0023
-not-guard-touching
-```
-
-**Grounding**
-
-- ADR 0164 — `.decisions/**` matches no control-plane *path*, so a guard-governing ADR is §CP by
-  content alone. **The binding fact is the enforcement, not the ADR's status field:** `cp-classify`
-  and `guard-content-probe` implement this today and stamp `(§CP, ADR 0164)` into their output, while
-  0164 itself has read `proposed` throughout — the mismatch is #4388, which carries a founder ruling
-  to accept it that has not landed. Neither this spec nor the skill asserts 0164's status, because a
-  status claim about another record is exactly the thing that rots; `adr resolve` is how a caller
-  learns it at the moment of citing.
-- #4386 / #3416 — a guard-touching ADR routed as ordinary reaches `main` with zero approvals.
-- Upstream's exit codes are inverted — `0` is guard-touching, `3` is not-guard-touching — and its own
-  README says to read the stdout word and never the status. The inversion must not leak through this
-  wrapper; normalising it is half the reason the wrapper exists.
-- #2617 — 196 of 233 ADRs currently classify `guard-touching`, an 84% rate. This verb relays that
-  calibration rather than correcting it; re-tuning the vocabulary is #2617's call, not this spec's.
+- v1's `adr-sweep` is worth reading before implementing this, for two scars it already carries: it
+  exits `1` whenever it *has* a shortlist (so a caller reads its informative case as a failure), and
+  its `--json` payload goes to stderr leaving stdout empty (#4723). fabrika repeats neither — all
+  three outcomes exit `0` here, and `--json` goes to stdout per rule 2. Read it as a list of mistakes
+  already made, not as an implementation to copy.
+- The ranking is a lexical/rarity score over decision-bearing text, capped at 8, excluding the
+  subject's own citations. `indeterminate` fires when the subject yields no distinctive terms or the
+  live-accepted corpus is below the rarity floor of 10 — a small corpus makes every term look common,
+  so silence there is degenerate rather than clean.

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -172,7 +172,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika-cli adr new 0240 only-landed-adrs-may-be-cited [--dir <path>] [--status <text>] [--date <YYYY-MM-DD>] [--title <text>] [--tags <a,b>]
+fabrika-cli adr new 0240 only-landed-adrs-may-be-cited [--dir <path>] [--status <text>] [--date <YYYY-MM-DD>] [--title <text>] [--tags <a,b>] [--json]
 ```
 
 **Inputs**
@@ -309,7 +309,9 @@ fabrika owns this predicate; it does not import one. The semantics: `accepted` i
 `superseded` is no longer. v1's `isLiveAccepted` is a **reference for what the words mean**, never a
 dependency — read it to check the semantics agree, then implement fabrika's own.
 
-With `--json`, one object per id with keys `id`, `state`, `file`, `detail`, `baseRef`, `baseSha`.
+With `--json`, a **JSON array** — one object per id, in argument order, with keys `id`, `state`,
+`file`, `detail`, `baseRef`, `baseSha`. An array rather than JSON-lines, so a single id and many ids
+parse identically and a caller never has to branch on the count.
 
 **All four states are answers, and each is a positive token.** `absent` on exit 0 means *proven
 absent against a current tree*: the fetch succeeded, the records were read, the open pull requests

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -502,9 +502,13 @@ fabrika-cli adr sweep --new 0240 [--dir <path>] [--limit <n>] [--json]
 On `shortlist`, one tab-separated line per entry follows — `<id>`, `<score>`, `<file>`, `<title>`.
 The reason for a `no-overlap` or `indeterminate`, and the scope line, go to stderr.
 
-**All three outcomes are answers, and all three exit 0.** Upstream exits `1` on a shortlist, which is
-its normal informative case; relaying that status would make every caller read its own results as a
-failed run. Nothing else is transformed — the outcome token is upstream's, verbatim.
+**All three outcomes are answers, and all three exit 0.** The outcome is this verb's own verdict, and
+a caller must never read its own shortlist as a failed run — which is precisely the mistake v1's
+`adr-sweep` makes by exiting `1` on the one case it was asked to produce.
+
+With `--json`, one object on stdout with keys `outcome` (the token), `entries` (an array of
+`{id, score, file, title}`, empty unless `outcome` is `shortlist`), `reason` (the explanatory string
+for `no-overlap` and `indeterminate`, else `null`), `scanned`, `inScope` and `cited`.
 
 **Exit status**
 
@@ -512,7 +516,7 @@ failed run. Nothing else is transformed — the outcome token is upstream's, ver
 |---|---|
 | `0` | an outcome token was produced on stdout |
 | `1` | usage error, or the verb failed to run |
-| `3` | the underlying sweep could not run, so the outcome is UNKNOWN |
+| `3` | the corpus could not be read, so the outcome is UNKNOWN |
 | `4` | `--new` names an id or path with no readable ADR |
 | `5` | `--dir` was read and held zero `NNNN-slug.md` records — zero scope |
 
@@ -520,7 +524,7 @@ failed run. Nothing else is transformed — the outcome token is upstream's, ver
 
 | Message (stderr) | Code | Kind |
 |---|---|---|
-| `adr sweep: the underlying sweep failed: <reason> — the outcome is UNKNOWN, never "no-overlap".` | 3 | refusal |
+| `adr sweep: cannot read <dir>: <reason> — the outcome is UNKNOWN, never "no-overlap".` | 3 | refusal |
 | `adr sweep: no readable ADR for --new <value>.` | 4 | refusal |
 | `adr sweep: scanned <dir>, 0 decision records — refusing to answer (ADR 0092).` | 5 | refusal |
 

--- a/claude-plugins/fabrika/skills/adr/evals/evals.json
+++ b/claude-plugins/fabrika/skills/adr/evals/evals.json
@@ -42,7 +42,7 @@
 				"Enumerates what the draft ADR decides as explicit questions, not as a summary",
 				"Runs the contradiction sweep against the draft",
 				"Explicitly states that a 'no-overlap' result does not establish that there is no contradiction",
-				"Does not treat the sweep's non-zero exit status as a failed run",
+				"Treats a shortlist as the sweep working, not as a failed run",
 				"Opens or reads the shortlisted ADRs rather than reporting only their scores",
 				"States that clearing the shortlist would not prove absence of contradiction"
 			]

--- a/claude-plugins/fabrika/skills/adr/evals/evals.json
+++ b/claude-plugins/fabrika/skills/adr/evals/evals.json
@@ -1,0 +1,80 @@
+{
+	"skill_name": "adr",
+	"notes": "Authored with /skill-creator against brief #4704. These evals grade the JUDGMENT layer the SKILL.md carries, not the fabrika-cli verbs it specifies \u2014 the verbs are downstream write-code work against contract.md, so a run that cannot invoke them is expected and eval 1 grades exactly that failure mode. Each eval traces to an incident row in the #4642 KEEP corpus.",
+	"evals": [
+		{
+			"id": 1,
+			"name": "fail-closed-when-the-allocator-is-unavailable",
+			"grounding": "#3779 \u2014 two lanes both minted ADR 0198; 0114 and 0123 were the same collision earlier.",
+			"prompt": "we just settled this in the design review \u2014 from now on every worker route that writes to D1 goes through the repository layer, no raw prepared statements in handlers. write that up as an ADR so the next agent doesn't quietly undo it",
+			"expected_output": "The run reaches for the skill's allocator before choosing a number. The allocator is unavailable in this environment, so the run reports the id as UNKNOWN and stops rather than picking one. It must not substitute a number derived from the .decisions/ filenames on disk.",
+			"files": [],
+			"assertions": [
+				"Attempts to allocate the ADR number with the skill's allocator verb before choosing any number",
+				"Does NOT choose an id by listing .decisions/ and taking the highest filename plus one",
+				"Reports the number as UNKNOWN, unresolved, or blocked when the allocator does not run \u2014 never as 'nothing is reserved'",
+				"Does not stamp an ADR file with an id the allocator did not issue"
+			]
+		},
+		{
+			"id": 2,
+			"name": "title-carries-the-decision-not-the-topic",
+			"grounding": "The compact map renders the frontmatter title verbatim, so a topic-shaped title costs every future reader the decision.",
+			"prompt": "record a decision for me: we're not doing server-side rendering for the sozluk pages. they stay client-rendered, because the live view holds an SSE connection anyway so SSR buys us nothing but a second render path to keep in sync",
+			"expected_output": "An ADR draft whose frontmatter title is a single decision-carrying clause, whose H1 repeats that title verbatim, and which carries a plain-language '**What this decides:**' line directly beneath the H1 that is a gloss for a non-author rather than a restatement of the title.",
+			"files": [],
+			"assertions": [
+				"The frontmatter title states the decision (e.g. 'Sozluk pages stay client-rendered'), not the topic (e.g. 'Sozluk rendering strategy')",
+				"The frontmatter title is a single clause, not two sentences or a clause plus a trailing aside",
+				"The '# NNNN \u2014 <Title>' H1 repeats the frontmatter title verbatim",
+				"A '**What this decides:**' line sits directly beneath the H1 and reads as plain language for a non-author, not as a restatement of the title",
+				"The '## Decision' section opens with one bolded declarative sentence before any mechanics"
+			]
+		},
+		{
+			"id": 3,
+			"name": "no-overlap-is-not-no-contradiction",
+			"grounding": "A shortlist detects lexical adjacency only; treating a clean result as proof of no contradiction is how two live accepted ADRs end up ruling opposite ways on one question.",
+			"prompt": "I've got a draft ADR sitting at claude-plugins/fabrika/skills/adr/evals/fixtures/0240-only-landed-adrs-may-be-cited.md \u2014 haven't moved it into .decisions/ yet. Run the contradiction sweep against it and tell me whether I'm clear to open the PR.",
+			"files": ["fixtures/0240-only-landed-adrs-may-be-cited.md"],
+			"expected_output": "The run enumerates what the draft decides as questions, runs the sweep, and refuses to read a clean or indeterminate sweep result as proof that no live ADR contradicts the draft. It opens the shortlist entries rather than reporting their scores.",
+			"assertions": [
+				"Enumerates what the draft ADR decides as explicit questions, not as a summary",
+				"Runs the contradiction sweep against the draft",
+				"Explicitly states that a 'no-overlap' result does not establish that there is no contradiction",
+				"Does not treat the sweep's non-zero exit status as a failed run",
+				"Opens or reads the shortlisted ADRs rather than reporting only their scores",
+				"States that clearing the shortlist would not prove absence of contradiction"
+			]
+		},
+		{
+			"id": 4,
+			"name": "vocabulary-impact-lands-on-one-of-two-outcomes",
+			"grounding": "An ADR is a primary coining site; 0126's 'ambient discovery' was coined in an ADR and drifted silently.",
+			"prompt": "write this up as a decision \u2014 we're calling the line that decides whether a PR needs a human approval the 'gate boundary'. anything inside it is machine-mergeable, anything crossing it needs a human on it.",
+			"expected_output": "An ADR draft that names 'gate boundary' as a coined term and routes it to the repo glossary, either by adding the row in the same change or by handing it to the glossary skill. The vocabulary-impact outcome is stated explicitly, never left unaddressed.",
+			"files": [],
+			"assertions": [
+				"Names 'gate boundary' explicitly as a term this ADR coins",
+				"Routes the term to .glossary/TERMS.md, either by adding the row or by handing it to the glossary skill",
+				"States the vocabulary-impact outcome explicitly rather than leaving it unaddressed",
+				"Does not silently skip the vocabulary question"
+			]
+		},
+		{
+			"id": 5,
+			"name": "indeterminate-carries-no-information",
+			"grounding": "The sweep reports indeterminate when it had nothing to key on \u2014 a degenerate silence. Reading it as a clean sweep is how a young or thin corpus launders a non-result into a clearance.",
+			"prompt": "Before I move this repo onto our ADR flow, sanity-check it: run the contradiction sweep for the draft 0240 against claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus and tell me if it's clear.",
+			"files": ["fixtures/small-corpus/"],
+			"expected_output": "The run reports the sweep came back INDETERMINATE, names why (only 3 live-accepted ADRs, below the rarity floor of 10), refuses to read that as a clearance, and reads the small corpus by hand instead.",
+			"assertions": [
+				"Runs the contradiction sweep against the given directory rather than the repo's own .decisions/",
+				"Reports the outcome as indeterminate rather than as a clean, clear or passing sweep",
+				"States that an indeterminate result carries no information about whether a contradiction exists",
+				"Names the cause \u2014 the corpus is below the minimum size for rarity scoring",
+				"Reads the corpus by hand rather than treating the sweep as having discharged the check"
+			]
+		}
+	]
+}

--- a/claude-plugins/fabrika/skills/adr/evals/evals.json
+++ b/claude-plugins/fabrika/skills/adr/evals/evals.json
@@ -12,7 +12,7 @@
 			"assertions": [
 				"Attempts to allocate the ADR number with the skill's allocator verb before choosing any number",
 				"Does NOT choose an id by listing .decisions/ and taking the highest filename plus one",
-				"Reports the number as UNKNOWN, unresolved, or blocked when the allocator does not run \u2014 never as 'nothing is reserved'",
+				"Reports the number as UNKNOWN, unresolved, or blocked when the allocator does not run \u2014 never as 'nothing is reserved' \u2014 and leaves the id unstamped in the artifact itself",
 				"Does not stamp an ADR file with an id the allocator did not issue"
 			]
 		},
@@ -56,7 +56,7 @@
 			"files": [],
 			"assertions": [
 				"Names 'gate boundary' explicitly as a term this ADR coins",
-				"Routes the term to .glossary/TERMS.md, either by adding the row or by handing it to the glossary skill",
+				"Produces the actual .glossary/TERMS.md row text and names its insertion point, rather than only asserting the term should be routed there",
 				"States the vocabulary-impact outcome explicitly rather than leaving it unaddressed",
 				"Does not silently skip the vocabulary question"
 			]

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/0240-only-landed-adrs-may-be-cited.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/0240-only-landed-adrs-may-be-cited.md
@@ -1,0 +1,42 @@
+---
+id: 0240
+title: An ADR may cite only an ADR that has landed on the base ref
+status: proposed
+date: 2026-08-01
+tags: [decisions, gates, pipeline]
+---
+
+# 0240 — An ADR may cite only an ADR that has landed on the base ref
+
+**What this decides:** When one ADR references another, the referenced ADR has to already be merged
+on the base branch. Citing an ADR that only exists inside somebody's open pull request is not
+allowed, because that pull request may never merge and the citation would point at nothing.
+
+## Context
+
+A citation to an unmerged ADR reads exactly like a citation to a merged one. Nothing in the file
+records which it is, so every downstream reader inherits the author's assumption that the target
+exists. When the target's pull request is later closed instead of merged, the citation survives as a
+pointer to a decision the repository never made.
+
+The failure is invisible at review time: the reviewer resolves the reference against whatever tree
+they happen to hold, and a tree that already contains the target — the author's own branch, say —
+makes a dead citation look live.
+
+## Decision
+
+**An ADR cites only ADRs that are present on the base ref at the time the citing ADR's pull request
+opens; an ADR that exists solely in an open pull request may not be cited.**
+
+An author who needs to reference an in-flight decision has two options and no third: wait for it to
+land, or restate the constraint in their own ADR without the citation. The relationship can be
+recorded after the fact as a dated amendment note once the target lands.
+
+**Binding constraints.**
+- Every ADR reference resolves against the fetched base ref, never the local working tree.
+- A reference that resolves to an open pull request blocks the citing ADR's pull request.
+
+## Consequences
+
+Authors of paired ADRs must sequence them, which costs a round trip when two decisions are drafted
+together. In exchange, a reference in a merged ADR is a reference a reader can follow.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0001-hand-authored-flat-migrations.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0001-hand-authored-flat-migrations.md
@@ -1,0 +1,20 @@
+---
+id: 0001
+title: Migrations stay hand-authored in one flat directory
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0001 — Migrations stay hand-authored in one flat directory
+
+**What this decides:** Migrations stay hand-authored in one flat directory.
+
+## Context
+An early-stage repo with few decisions recorded so far.
+
+## Decision
+**Migrations stay hand-authored in one flat directory.**
+
+## Consequences
+Cheap now; revisit as the corpus grows.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0002-one-worker-per-app.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0002-one-worker-per-app.md
@@ -1,0 +1,20 @@
+---
+id: 0002
+title: Each app ships as its own worker with its own stack
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0002 — Each app ships as its own worker with its own stack
+
+**What this decides:** Each app ships as its own worker with its own stack.
+
+## Context
+An early-stage repo with few decisions recorded so far.
+
+## Decision
+**Each app ships as its own worker with its own stack.**
+
+## Consequences
+Cheap now; revisit as the corpus grows.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0003-no-default-exports.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0003-no-default-exports.md
@@ -1,0 +1,20 @@
+---
+id: 0003
+title: Modules use named exports only
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0003 — Modules use named exports only
+
+**What this decides:** Modules use named exports only.
+
+## Context
+An early-stage repo with few decisions recorded so far.
+
+## Decision
+**Modules use named exports only.**
+
+## Consequences
+Cheap now; revisit as the corpus grows.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0240-only-landed-adrs-may-be-cited.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus/0240-only-landed-adrs-may-be-cited.md
@@ -1,0 +1,42 @@
+---
+id: 0240
+title: An ADR may cite only an ADR that has landed on the base ref
+status: proposed
+date: 2026-08-01
+tags: [decisions, gates, pipeline]
+---
+
+# 0240 — An ADR may cite only an ADR that has landed on the base ref
+
+**What this decides:** When one ADR references another, the referenced ADR has to already be merged
+on the base branch. Citing an ADR that only exists inside somebody's open pull request is not
+allowed, because that pull request may never merge and the citation would point at nothing.
+
+## Context
+
+A citation to an unmerged ADR reads exactly like a citation to a merged one. Nothing in the file
+records which it is, so every downstream reader inherits the author's assumption that the target
+exists. When the target's pull request is later closed instead of merged, the citation survives as a
+pointer to a decision the repository never made.
+
+The failure is invisible at review time: the reviewer resolves the reference against whatever tree
+they happen to hold, and a tree that already contains the target — the author's own branch, say —
+makes a dead citation look live.
+
+## Decision
+
+**An ADR cites only ADRs that are present on the base ref at the time the citing ADR's pull request
+opens; an ADR that exists solely in an open pull request may not be cited.**
+
+An author who needs to reference an in-flight decision has two options and no third: wait for it to
+land, or restate the constraint in their own ADR without the citation. The relationship can be
+recorded after the fact as a dated amendment note once the target lands.
+
+**Binding constraints.**
+- Every ADR reference resolves against the fetched base ref, never the local working tree.
+- A reference that resolves to an open pull request blocks the citing ADR's pull request.
+
+## Consequences
+
+Authors of paired ADRs must sequence them, which costs a round trip when two decisions are drafted
+together. In exchange, a reference in a merged ADR is a reference a reader can follow.


### PR DESCRIPTION
Fixes #4704

The fabrika wave-0 pilot: `/adr`, authored through `/skill-creator` against the brief, plus the CLI contract its verbs are specified by, plus a graded eval set.

## What landed

- **`claude-plugins/fabrika/skills/adr/SKILL.md`** — **113 lines**, inside the brief's 80–120 target, against v1's 182. Six steps, **six fences**, each exactly one plain-literal invocation.
- **`claude-plugins/fabrika/skills/adr/contract.md`** — **six verbs**, fully specified. It also claims the seed package (`packages/fabrika-cli/`), which [#4648](https://github.com/kamp-us/phoenix/issues/4648) Resolved question 2 defers to the first derived contract.
- **`claude-plugins/fabrika/skills/adr/evals/`** — five graded cases with fixtures.
- **Three fabrika docs updated** to carry the isolation rule (below).

**No verbs are implemented here** — building them is #4725. **No v1 script is ported** and no clause defers to one (#4638): `grep` for `kampus-pipeline`, `.sh` or `scripts/` in either file returns nothing.

## fabrika calls `pipeline-cli` nowhere

Founder ruling in-session, recorded as **ADR 0238** in companion PR #4728. The deletion test decides it: a fabrika that calls v1 can never be the thing that replaces it, because every call keeps the old tree alive.

For this skill that means **six verbs, not seven**. `adr sweep` is a native implementation — v1's `adr-sweep` is cited as a list of mistakes already made (it exits `1` on its own informative case; its `--json` goes to stderr, #4723), never as something to call. **`adr classify` was dropped rather than duplicated**: `cp-classify` decides control-plane membership at the merge gate and that gate is the authority, so a fabrika copy of the guard vocabulary could contradict it on a merge-gating question. #4386 and #3416 were the *gate* misclassifying, so an author-side predictor would not have caught them anyway.

Encoded for the sessions that follow: rule 6 of the CLI interface convention, the README's absent-list, and field 4 of the authoring-brief contract — which becomes prior-art-to-read rather than verbs-to-call. The 18 unfired briefs (#4705–#4722) were amended to match.

## The derivation the brief did not pre-specify

`adr resolve`. The brief grouped #4296, #4338 and #4163 as one class — *ADR state resolved against a tree that was not current, with the wrong answer indistinguishable from a right one*. One verb answers all three, and absorbs v1's "never guess a slug from a title" rule as a fourth.

Its **`live` / `landed`** split separates presence from authority. **36 of the 233 ADRs on `main` are landed but `proposed`, `superseded` or `retired`** — ADR 0164 is landed *and* `proposed`. "Cite only `landed`" would not have closed #4338; "cite only `live`" does.

## Gates run before this PR

**`skill-reviewer`** (runbook step 5.5) ran pre-PR and returned Needs Major Revision with 28 findings; all blocking ones are fixed. Three of its claims I verified myself before acting, because they changed the architecture — all three held. One claim of **mine** did not: I asserted the template's `**Banned.**` labels trip the §CP probe. Tested in isolation they do not — the trigger is `gate`/`guard` in ordinary prose.

**`review-skill` + `review-code`** then FAILed the first submission for real cause: the `adr sweep` block still carried delegation language after the isolation rule was adopted, so a coder building from that paragraph alone would have written a `pipeline-cli` wrapper. Fixed in `a1a8ab4a`, along with the missing `--json` payload shape.

## Deviation from the pre-derived carry-list

The brief's pre-derived material said to keep a trimmed ADR template in the wrapper. **I cut it entirely** — it is now the specified output of `adr new`, so it has one home. The brief instructs flagging rather than following when it pre-decides the split, so: flagged. `skill-reviewer` agreed on the principle (~90%) while catching three seam defects the removal created; all fixed.

## Evals

Iteration 1: **95% with the skill, 40% without**, 18 assertions over 4 cases. The sharpest result is eval 2 — the baseline shipped an ADR stamped `0237`, a number open PR #4703 already holds; the skill's arm refused to claim one at all.

Iteration 2 re-ran the three cases still valid after the rewrite: **12/13**. The one regression was mine — dropping the 12-word title cap invited an em-dash aside, fixed so the contrast sits inside the clause.

Caveats stated rather than buried: n=1 per cell, so a one-assertion swing is noise. Both graders found defects in the eval design itself (one vacuous assertion, one unreachable branch); both are fixed and a fifth case now covers the `indeterminate` branch. Evals 3 and 5 cannot execute until `fabrika-cli` exists.

## Filed along the way

[#4723](https://github.com/kamp-us/phoenix/issues/4723) · [#4725](https://github.com/kamp-us/phoenix/issues/4725) · [#4726](https://github.com/kamp-us/phoenix/issues/4726) · [#4727](https://github.com/kamp-us/phoenix/issues/4727), plus folded findings on [#3779](https://github.com/kamp-us/phoenix/issues/3779) (the live allocator collision) and [#2617](https://github.com/kamp-us/phoenix/issues/2617) (the §CP probe's false-positive rate, measured for the first time at 84%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
