### PR TITLE
feat(fabrika): the /report skill and its derived CLI contract (#4705)

### DIFF
--- a/claude-plugins/fabrika/skills/report/SKILL.md
+++ b/claude-plugins/fabrika/skills/report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report
-description: File one follow-up GitHub issue the moment you spot work you will not do right now — a bug, a refactor, a design question, a missing test, a confusing convention. Fire it mid-task and autonomously, without asking permission and without finishing what you were doing first, because an observation that stays in the conversation dies there. Also trigger on "/report", "file an issue", "report this", "open a follow-up", "track this for later". Done when the issue exists carrying `status:needs-triage` and nothing else, and you are back on the task you interrupted.
+description: File one follow-up GitHub issue the moment you spot work you will not do right now — a bug, a refactor, a design question, a missing test, a confusing convention. Fire it mid-task and autonomously, without asking permission and without finishing what you were doing first, because an observation that stays in the conversation dies there. Composes and posts the body over a single guarded path that refuses a machine-local path, an empty body, or a hand-applied classification and reads back what landed, after a duplicate check whose three outcomes it makes you read. Also trigger on "/report", "file an issue", "report this", "open a follow-up", "track this for later". Done when the observation is on the board — a new issue carrying `status:needs-triage` and nothing else, or a note on the issue that already covered it — and you are back on the task you interrupted.
 ---
 
 # report
@@ -15,9 +15,9 @@ that dies.
 
 ## 1 — Write the observation
 
-The title first — short, specific, type-neutral. *"Retry helper in the http worker swallows the
-abort reason"* names what you saw; *"Bug in worker"* names nothing, and *"BUG: fix retry"* types
-and prescribes in four words.
+The title first — short (aim under ~70 characters), specific, type-neutral. *"Retry helper in the
+http worker swallows the abort reason"* names what you saw; *"Bug in worker"* names nothing, and
+*"BUG: fix retry"* types and prescribes in four words.
 
 Then six sections. They are the same six whether you found a crash, a smell, or a question — that
 sameness is what lets you file without classifying first:
@@ -39,6 +39,8 @@ A hand-typed classification is indistinguishable from a triaged one, so a guess 
 corrupts the signal triage runs on. One observation, one issue — two things you noticed are two
 filings.
 
+You are done here when all six sections carry content, except the last, which may be empty.
+
 ## 2 — Check whether it is already filed
 
 Report runs go concurrently, so what you just saw may have reached the board minutes ago. Run this
@@ -46,15 +48,16 @@ Report runs go concurrently, so what you just saw may have reached the board min
 creating stays small:
 
 ```bash
-fabrika-cli report dedup --query "the title plus a few distinguishing keywords"
+fabrika-cli report dedup --query "retry helper http worker abort reason swallowed cause"
 ```
 
 Three outcomes, and only one of them is about your observation:
 
 - **`candidates`** — open each and judge it yourself. Shared vocabulary is not a shared observation.
+  The list is capped, and the verb says on stderr when it truncated.
 - **`none`** — both sources were read and nothing open matched. A real answer.
-- **`indeterminate`** — your query carried no distinctive keywords, so nothing was compared. This is
-  a non-check, not a clean one. Re-query with the specific terms.
+- **`indeterminate`** — your query carried too few distinctive keywords to discriminate, so nothing
+  useful was compared. This is a non-check, not a clean one. Re-query with the specific terms.
 
 A non-zero exit is UNKNOWN, never `none`. **When it is genuinely ambiguous, file it** — triage
 closes a duplicate in seconds, and a lost observation is gone.
@@ -68,36 +71,33 @@ fabrika-cli report file --title "Retry helper in the http worker swallows the ab
 EOF
 ```
 
-The body arrives on this verb's stdin and never becomes a filename. That is the design, not an
-implementation detail: every issue-body leak in the record is one agent reaching for a *path* where
-a body belonged — a file-referencing post form sends the literal path text instead of the file's
-contents, so a machine-local path lands in a public artifact while the poster reads success
-(#3086, #3173).
-
 **When the verb refuses, fix the input and run it again.** A refusal names one thing — an empty
-section, a machine-local path in the body, a missing queue label, a body that never reached stdin —
-and each is a thing to correct. A refusal is never a signal to post some other way: that is the
-path #3945 walked, where a blocked command was retried through a file-referencing form and landed
-the exact leak the guard had just declined.
+section, a machine-local path in the body, a body that never reached stdin, a title that classifies
+— and each is a thing to correct. A refusal is never a signal to post some other way: that is the
+path #3945 walked, where a blocked command was retried through a form that passes the body as a
+*file path*, and the path text posted instead of the file's contents. That is how a machine-local
+path reaches a public artifact while the poster reads success (#3086, #3173).
 
 Use `--redact` when a machine-local path is genuinely part of the evidence — reporting a leak
 incident is the case it exists for. It masks each path down to its class and says so; it never
 silently rewrites what you wrote.
 
+You are done here when the verb exits 0 and prints the number and URL.
+
 ## 4 — Or add what the existing issue lacks
 
 When step 2 found your observation already filed, do not file a twin. Add only what that issue does
-not already carry:
+not already carry, over the same guarded path:
 
 ```bash
-fabrika-cli report note --issue 4705 <<'EOF'
+fabrika-cli report note --issue 4312 <<'EOF'
 …
 EOF
 ```
 
-Same stdin, same refusals, same reason for both.
+Done when the verb exits 0 and prints the comment id and URL.
 
 ## 5 — Report and return
 
-One line: the issue number and its URL, as the verb printed them. Then **go back to the task you
-interrupted.** You are not triaging what you filed, and you are not fixing it.
+One line: the number and URL the verb printed. Then **go back to the task you interrupted.** You are
+not triaging what you filed, and you are not fixing it.

--- a/claude-plugins/fabrika/skills/report/SKILL.md
+++ b/claude-plugins/fabrika/skills/report/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: report
+description: File one follow-up GitHub issue the moment you spot work you will not do right now — a bug, a refactor, a design question, a missing test, a confusing convention. Fire it mid-task and autonomously, without asking permission and without finishing what you were doing first, because an observation that stays in the conversation dies there. Also trigger on "/report", "file an issue", "report this", "open a follow-up", "track this for later". Done when the issue exists carrying `status:needs-triage` and nothing else, and you are back on the task you interrupted.
+---
+
+# report
+
+**Intake, not judgment.** You saw something while doing other work. Capture it faithfully and go —
+a later `triage` run decides what it is and what it is worth, so this skill applies exactly one
+label, `status:needs-triage`, and treats every classification question as somebody else's.
+
+Capturing costs almost nothing, which is why there is no permission step: proposing first turns a
+five-second capture into a conversation, and the observation that waits for an answer is the one
+that dies.
+
+## 1 — Write the observation
+
+The title first — short, specific, type-neutral. *"Retry helper in the http worker swallows the
+abort reason"* names what you saw; *"Bug in worker"* names nothing, and *"BUG: fix retry"* types
+and prescribes in four words.
+
+Then six sections. They are the same six whether you found a crash, a smell, or a question — that
+sameness is what lets you file without classifying first:
+
+- **`## Summary`** — 2–3 plain sentences a triager grasps on a skim. Prose, no jargon. It leads the
+  body; it never replaces what follows.
+- **`## What I was doing`** — the task in flight when this surfaced. Which file, which command.
+- **`## What I observed`** — the thing itself, factual and specific. Paste the error, name the
+  function, quote the surprising line. Triage acts on this section; the others orient it.
+- **`## Why it matters`** — the cost of leaving it, honest about uncertainty. "Might cause X" is a
+  good sentence. Inflating to manufacture urgency and downplaying to be polite fail the same way:
+  triage prices it wrong.
+- **`## Pointers`** — repo-relative paths, function names, issue and PR numbers, ADR links.
+- **`## Suggested next step (non-binding)`** — your best guess, labeled a guess. Blank beats
+  misleading.
+
+**Record what you saw, not what it is.** No type, no priority, no *critical* / *blocker* / *minor*.
+A hand-typed classification is indistinguishable from a triaged one, so a guess here silently
+corrupts the signal triage runs on. One observation, one issue — two things you noticed are two
+filings.
+
+## 2 — Check whether it is already filed
+
+Report runs go concurrently, so what you just saw may have reached the board minutes ago. Run this
+**after** the body is written and immediately before filing, so the window between checking and
+creating stays small:
+
+```bash
+fabrika-cli report dedup --query "the title plus a few distinguishing keywords"
+```
+
+Three outcomes, and only one of them is about your observation:
+
+- **`candidates`** — open each and judge it yourself. Shared vocabulary is not a shared observation.
+- **`none`** — both sources were read and nothing open matched. A real answer.
+- **`indeterminate`** — your query carried no distinctive keywords, so nothing was compared. This is
+  a non-check, not a clean one. Re-query with the specific terms.
+
+A non-zero exit is UNKNOWN, never `none`. **When it is genuinely ambiguous, file it** — triage
+closes a duplicate in seconds, and a lost observation is gone.
+
+## 3 — File it
+
+```bash
+fabrika-cli report file --title "Retry helper in the http worker swallows the abort reason" <<'EOF'
+## Summary
+…
+EOF
+```
+
+The body arrives on this verb's stdin and never becomes a filename. That is the design, not an
+implementation detail: every issue-body leak in the record is one agent reaching for a *path* where
+a body belonged — a file-referencing post form sends the literal path text instead of the file's
+contents, so a machine-local path lands in a public artifact while the poster reads success
+(#3086, #3173).
+
+**When the verb refuses, fix the input and run it again.** A refusal names one thing — an empty
+section, a machine-local path in the body, a missing queue label, a body that never reached stdin —
+and each is a thing to correct. A refusal is never a signal to post some other way: that is the
+path #3945 walked, where a blocked command was retried through a file-referencing form and landed
+the exact leak the guard had just declined.
+
+Use `--redact` when a machine-local path is genuinely part of the evidence — reporting a leak
+incident is the case it exists for. It masks each path down to its class and says so; it never
+silently rewrites what you wrote.
+
+## 4 — Or add what the existing issue lacks
+
+When step 2 found your observation already filed, do not file a twin. Add only what that issue does
+not already carry:
+
+```bash
+fabrika-cli report note --issue 4705 <<'EOF'
+…
+EOF
+```
+
+Same stdin, same refusals, same reason for both.
+
+## 5 — Report and return
+
+One line: the issue number and its URL, as the verb printed them. Then **go back to the task you
+interrupted.** You are not triaging what you filed, and you are not fixing it.

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -149,10 +149,29 @@ operator, a renamed tool directory or a different machine needs no edit:
 3. **Temp and scratch roots** — `/tmp/…`, `/private/tmp/…`, `/private/var/…`, `/var/folders/…`. No
    carve-out: a public issue body has no legitimate bare temp path.
 
-All three are redactable and refuse on **exit 5**. `--redact` masks each match down to its class
-marker and keeps the evidential shape — a temp-root hit becomes `/tmp/<redacted>`, a home-relative
-hit `~/<redacted>` — so the body still reads as evidence that a path of that kind was there. Every
-redaction is reported on stderr with its line number; the verb never rewrites a body silently.
+All three are redactable and refuse on **exit 5**. `--redact` replaces each match with
+`<class-root>/<redacted>`, so the body still reads as evidence that a path of *that* kind was there.
+
+**The matched span is the whole path run, and the mask keeps the class root — never a single
+collapsed marker.** Which root a path came from is itself the evidence, so the roots do not fold
+together:
+
+| Matched | Redacts to |
+|---|---|
+| `/var/folders/…` | `/var/folders/<redacted>` |
+| `/private/tmp/…` | `/private/tmp/<redacted>` |
+| `/private/var/…` | `/private/var/<redacted>` |
+| `/tmp/…` | `/tmp/<redacted>` |
+| `/Users/<account>/…` | `/Users/<redacted>` |
+| `/home/<account>/…` | `/home/<redacted>` |
+| `~/…` | `~/<redacted>` |
+
+**The leaf filename does not survive**, and that is deliberate rather than an oversight: a filename
+can itself identify a person or a machine, and a reader who needs it can ask the reporter. Longer
+matches are replaced before shorter ones so an overlapping pair cannot corrupt each other.
+
+Every redaction is reported on stderr with its line number and class; the verb never rewrites a body
+silently.
 
 Separately, and **not** redactable: a body whose first non-whitespace run is an `@`-prefixed path
 (`@/…`). That is the composed body having never arrived at all, so it refuses on **exit 6** with its

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -1,0 +1,521 @@
+# `/report` — derived CLI contract
+
+**Skill:** [`report`](SKILL.md) · **Authoring brief:** [#4705](https://github.com/kamp-us/phoenix/issues/4705) · **Date:** 2026-08-01
+
+These verbs live in `packages/fabrika-cli/`, binary `fabrika-cli`, grouped under a `report`
+subcommand — the package the [`/adr` contract](../adr/contract.md) mints and
+[#4725](https://github.com/kamp-us/phoenix/issues/4725) builds. The
+[CLI interface convention](../../docs/cli-interface-convention.md) governs all three; where this
+spec and that doc disagree, the doc wins and this spec is the bug.
+
+**`fabrika-cli` calls `pipeline-cli` nowhere, and neither does the skill**
+([ADR 0238](../../../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)). Every verb
+below is implemented from scratch here. v1's tools were read for their semantics and their scars —
+each Grounding section names what the corresponding v1 tool gets wrong and what this spec does
+instead — but no clause defers to one, and none is invoked.
+
+## Verb inventory
+
+| Verb | Purpose | Split test |
+|---|---|---|
+| `report dedup` | rank the open issues that may already cover an observation | two REST reads, tokenize, score, sort — deciding whether a candidate *is* your observation stays in the skill |
+| `report file` | compose, guard and create the intake issue, then read back what landed | the template, the footer, the leak predicate, the label and the read-back are all mechanical; what goes in the sections is judgment |
+| `report note` | add a note to an existing issue over the same guarded path | as above, minus composition — the guard and the read-back are the deterministic part |
+
+**Considered and deliberately not derived.** Each is a real proposal someone could make again, so it
+is recorded rather than left to be re-litigated:
+
+- **A `report compose` preview verb**, emitting the composed body without filing. It would put the
+  composed body in the caller's hands — which means a shell variable or a file, and a file is the
+  surface every leak in this skill's incident record occurred on. `report file` composes in-process,
+  so the composed body exists only inside the process that posts it.
+- **A label-vocabulary preflight verb.** Its answer is needed in exactly one place, inside
+  `report file`, so it is a precondition rather than a verb; minting it would be a wrapper whose
+  only behaviour is relaying an upstream answer, which ADR 0238 bans.
+- **A standalone redactor verb.** Same test: a transform with one caller is that caller's
+  precondition. It is the `--redact` flag on the two writing verbs.
+
+**Nothing here recomputes a merge-gated answer.** The repo's committed-file leak gate decides
+whether a *file in a diff* carries a machine-local path, at the merge gate, and that gate is the
+authority on that question. An issue or comment body posted at runtime is never in a diff, so no
+gate covers it — the predicate below is the ungated surface, not a second verdict on a gated one.
+
+## Shared conventions
+
+Every verb below obeys these; they are stated once rather than repeated per block.
+
+- **Answer channel: machine.** Stdout carries the answer and nothing else. Scope lines, refusal
+  reasons and progress go to stderr.
+- **Common inputs.** `--repo <owner/name>` (default: `$CLAUDE_PIPELINE_REPO`, else
+  `$GITHUB_REPOSITORY`, else the `origin` remote's `owner/name`) is the target repository; with none
+  resolvable the verb exits 1 rather than guessing. `--json` swaps the line grammar for one JSON
+  object with the named keys given per verb.
+- **Reserved exit codes.** `0` = the answer is on stdout. `1` = usage error, or the verb failed to
+  run. `127` = the verb never ran. `3` and up are each verb's own proven outcomes.
+- **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
+  a caller reads the status before the bytes.
+- **GitHub reads and writes go through `gh api` REST, never GraphQL** — the org's Projects-classic
+  integration breaks GraphQL issue queries — and every list read pages.
+
+### The body is a value, never a path
+
+The two writing verbs take the body **on stdin only**. There is deliberately **no `--body` flag, no
+`--body-file`, and no temp file**: a flag that accepts a path turns the body into a string the verb
+could post verbatim, which is precisely how the incidents below happened. A shell redirect
+(`< some-file`) is fine and expected — the *shell* reads the file, so what reaches the verb is
+already the bytes, and no path ever exists inside the process.
+
+**An empty stdin is a refusal, not an empty body.** A pipe that failed to read is byte-identical to
+one that was genuinely empty unless the reader distinguishes them, so the read here does: a
+transient read failure is exit `1` (the verb could not run), an empty-but-successfully-read stdin is
+exit `3` (a proven refusal). The read must also terminate rather than hang when the verb is invoked
+on a terminal with nothing piped in.
+
+### The body-surface leak predicate
+
+Shared by `report file` and `report note`. A machine-local path in a body posted to a public issue
+is a leak. Four generic shapes, and **no name list** — every shape is structural, so a new operator,
+a renamed tool directory or a different machine needs no edit:
+
+1. **Home-relative** — a path beginning with the home marker `~` followed by a separator. An issue
+   body has no legitimate use for one: the `## Pointers` section is repo-relative by contract. Two
+   carve-outs, both pinned to a shape rather than a membership list — the claude CLI's public,
+   machine-agnostic config leaves `~/.claude.json` and `~/.claude/settings.json`, which are
+   byte-identical on every machine and name nothing operator-specific. Because each carve-out pins
+   the exact leaf, a deeper descent or a longer name still matches.
+2. **Absolute home root** — an absolute path under an OS home root: `/Users/<account>` on macOS,
+   `/home/<account>` on Linux.
+3. **Temp and scratch roots** — `/tmp/…`, `/private/tmp/…`, `/private/var/…`, `/var/folders/…`. No
+   carve-out: a public issue body has no legitimate bare temp path.
+4. **A body that *is* a path** — the body's first non-whitespace run is an `@`-prefixed path
+   (`@/…`). This is the composed body having never arrived at all, so it carries its own message and
+   is **not** redactable: the fix is to send the body, not to mask the placeholder.
+
+Shapes 1–3 are redactable. `--redact` masks each match down to its class marker and keeps the
+evidential shape — a temp-root hit becomes `/tmp/<redacted>`, a home-relative hit `~/<redacted>` —
+so the body still reads as evidence that a path of that kind was there. Every redaction is reported
+on stderr with its line number; the verb never rewrites a body silently.
+
+---
+
+## `report dedup`
+
+**Invocation**
+
+```
+fabrika-cli report dedup --query "retry helper swallows the abort reason" [--label <name>] [--limit <n>] [--exclude <n>] [--repo <owner/name>] [--json]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--query` | string | yes | — | the observation text — the title plus a few distinguishing keywords — to check for an already-open issue |
+| `--label` | string | no | `status:needs-triage` | the intake-queue label whose open issues form the read-after-write half of the check |
+| `--limit` | integer | no | `20` | the maximum number of candidates to print |
+| `--exclude` | integer | no | none | an issue number to omit from the results — the issue being deduped, so it never flags itself |
+| `--repo` | string | no | resolved (see Shared conventions) | the repository to search |
+| `--json` | boolean | no | `false` | emit the full result object instead of the line grammar |
+
+**Output** — the first line is the outcome token alone: `candidates`, `none`, or `indeterminate`.
+On `candidates`, one **tab-separated** line per entry follows — `<number>`, `<source>`, `<score>`,
+`<title>` — ranked by score descending, then by number descending, capped at `--limit`. `<source>`
+is `queue`, `search`, or `both`; `both` is the strongest duplicate signal.
+
+**All three outcomes are answers, and all three exit 0.** `none` is a proven negative — both sources
+were read and neither matched — and it is a printed token rather than empty stdout, because empty
+stdout is byte-identical to a verb that never ran. `indeterminate` is the degenerate case:
+`--query` yielded no usable keywords, so nothing was compared. It is **not** a clean check, and the
+skill is required to treat it as one that did not happen.
+
+With `--json`, one object with keys `outcome` (the token), `candidates` (array of
+`{number, source, score, title}`, empty unless `outcome` is `candidates`), `reason` (the
+explanatory string for `none` and `indeterminate`, else `null`), `tokens` (the keywords actually
+used), `queueCount` and `searchCount`.
+
+**Matching.** `--query` is lowercased and split on any run of non-letter, non-number characters over
+the **full Unicode letter class**, not ASCII — Turkish is a product-copy language in this repo, and
+an ASCII-only split shreds a Turkish stem into sub-threshold fragments and drops it entirely.
+Tokens shorter than 3 characters and stopwords in **both** repo languages are dropped; the
+remainder is deduped in first-seen order and capped at 12, because GitHub's search AND-joins its
+terms and an over-long query matches nothing. A query token matches a title token on an exact hit or
+a shared prefix of at least 5 characters, which is what lets an agglutinative Turkish inflection
+match a bare stem without a morphological analyzer while staying off short English derivational
+overlaps. A queue row is kept only when its title overlaps (score > 0); a search row already matched
+server-side on title *or* body, so it is kept regardless.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | an outcome token was produced on stdout |
+| `1` | usage error, the target repo could not be resolved, or the verb failed to run |
+| `3` | the intake queue could not be read, so the outcome is UNKNOWN |
+| `4` | the search index could not be read, so the outcome is UNKNOWN |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `report dedup: cannot read the <label> queue in <repo>: <reason> — the outcome is UNKNOWN, never "none".` | 3 | refusal |
+| `report dedup: cannot read the search index for <repo>: <reason> — the outcome is UNKNOWN, never "none".` | 4 | refusal |
+| `report dedup: --query is empty.` | 1 | usage error |
+| `report dedup: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.` | 1 | refusal |
+
+**Scope** — this verb **supplies an input; it does not judge**, so an empty result is a fact rather
+than a failed read, and it says so here once. The two halves are read for different reasons: the
+label queue is read-after-write consistent and catches an issue filed seconds ago, while the search
+index is eventually consistent — it lags fresh issues but reaches older open issues that have
+already left the queue. An empty intake queue is a normal state, so `none` at exit 0 is an answer;
+a queue or index that could not be read is exit 3 or 4 with **nothing** on stdout. The scope line
+goes to stderr on every run, naming both source counts and the tokens actually used, so a caller can
+see which half produced the answer and whether the query degenerated.
+
+**Examples**
+
+```
+$ fabrika-cli report dedup --query "retry helper swallows the abort reason in the http worker"
+candidates
+4312	both	4	Abort reason lost when the worker retry helper re-wraps the request
+4088	search	2	http worker retries do not propagate cancellation
+```
+
+```
+$ fabrika-cli report dedup --query "sozluk definition editor loses focus after an entry is saved"
+none
+```
+
+```
+$ fabrika-cli report dedup --query "it is not working"
+indeterminate
+$ echo $?
+0
+```
+
+```
+$ fabrika-cli report dedup --query "retry helper abort reason" --repo kamp-us/nonexistent
+report dedup: cannot read the status:needs-triage queue in kamp-us/nonexistent: HTTP 404 — the outcome is UNKNOWN, never "none".
+$ echo $?
+3
+```
+
+**Grounding**
+
+- ADR 0181 — this check is **advisory, not an oracle**. It never gates a filing, which is why every
+  outcome exits 0: a duplicate is cheap for triage to close, and a lost observation is gone. The
+  skill files on ambiguity.
+- v1's `intake-dedup check` prints one line per candidate and nothing else, so **its stdout is empty
+  when it finds no duplicate** — indistinguishable from a verb that never ran — and the count that
+  would disambiguate goes to stderr. Read it as the reason the outcome token exists here.
+- v1 also exits 0 with empty stdout when the query tokenizes to nothing, writing
+  `no usable keywords — nothing to check` to stderr. A degenerate non-check then reads to a caller
+  exactly like a clean one. `indeterminate` is that case promoted to an answer.
+- #3255 — an ASCII-only tokenizer shredded a Turkish stem into sub-threshold fragments and dropped
+  it, so the search half silently ran on fewer keywords than the caller supplied. The Unicode split,
+  the two-language stoplist and the stem-prefix relaxation are all that incident.
+- #4208 / #4219 — a proven outcome never shares an exit code with a failure to invoke, which is why
+  an unreadable source is 3 or 4 and never a printed `none`.
+
+---
+
+## `report file`
+
+Composes the intake issue from the sections on stdin, guards it, creates it, and reads back what
+landed. One transaction: every step below is a precondition or a postcondition of *this observation
+is now an issue in the intake queue*, and splitting them would hand a caller the chance to skip one.
+
+**Invocation**
+
+```
+fabrika-cli report file --title "Retry helper in the http worker swallows the abort reason" [--redact] [--label <name>] [--repo <owner/name>] [--json]
+```
+
+The six authored sections arrive on **stdin** as markdown.
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--title` | string | yes | — | the issue title: a short, specific, type-neutral summary of the observation |
+| `--redact` | boolean | no | `false` | mask each machine-local path in the body down to its class marker and file the masked body, instead of refusing |
+| `--label` | string | no | `status:needs-triage` | the single intake-queue label the new issue carries |
+| `--repo` | string | no | resolved (see Shared conventions) | the repository to file into |
+| `--json` | boolean | no | `false` | emit the full filing record instead of the line grammar |
+| stdin | markdown | yes | — | the six authored sections, in order |
+
+**The body template is this verb's, and this block is its single home** — the skill names the six
+sections and supplies their content; their exact spelling and order live here, so there is no second
+copy to drift against:
+
+```markdown
+## Summary
+## What I was doing
+## What I observed
+## Why it matters
+## Pointers
+## Suggested next step (non-binding)
+```
+
+All six must be present, in this order, each with non-empty content — except
+`## Suggested next step (non-binding)`, which may be empty, because a blank guess is better than a
+misleading one and the skill says so. A missing or misspelled heading is exit 4 naming the one that
+is wrong.
+
+**The footer is appended by this verb**, after the sections and a blank line:
+
+```markdown
+---
+<sub>Filed by an agent · session `<id>` · model `<name>` · branch `<ref>` · <ISO-8601 UTC></sub>
+```
+
+Every field after the marker is best-effort and is **omitted silently** when the environment does
+not expose it — no `unknown`, no dangling label. The literal `Filed by an agent` marker is always
+present, because it is the signal a later triage run reads to decide whether an issue may be
+auto-closed, and a sparse footer is still a present footer.
+
+**Footer privacy is this verb's precondition, not the caller's.** It carries machine and session
+context only: no email address, no author name, no filesystem path. It does not read git
+`user.email` or `user.name`. A branch name is a ref rather than a path, and is the only
+repo-shaped field.
+
+**Output** — one **tab-separated** line: `<number>`, `<url>`. The number is bare, with no `#` sigil
+and no prose prefix, so `cut -f1` yields something a caller can interpolate without stripping
+anything. With `--json`, one object with keys `number`, `url`, `label`, `redactions` (array of
+`{line, class}`, empty when none) and `bodyBytes`.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | the issue was created, read back clean, and its number and URL are on stdout |
+| `1` | usage error (an empty `--title`), an unresolvable repo, a failed stdin read, or the verb failed to run |
+| `3` | stdin was read and held nothing — refusing to file a bodyless issue |
+| `4` | a required section is missing, out of order, or empty |
+| `5` | the body carries a machine-local path and `--redact` was not given |
+| `6` | `--label` does not exist in `--repo` — the issue would be filed outside the intake queue |
+| `7` | the issue was created but the read-back does not match — a partial landing, not a success |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `report file: stdin was read and held 0 bytes — refusing to file a bodyless issue.` | 3 | refusal |
+| `report file: could not read stdin: <reason> — the body is UNKNOWN, never empty.` | 1 | refusal |
+| `report file: section "<heading>" is missing.` | 4 | refusal |
+| `report file: section "<heading>" is empty.` | 4 | refusal |
+| `report file: sections are out of order — "<heading>" follows "<heading>".` | 4 | refusal |
+| `report file: the body carries <n> machine-local path(s) — refusing to post them to a public issue.` (then one indented `line <n>, <class>` per hit) | 5 | refusal |
+| `report file: the body is a bare "@" path reference — the composed body never arrived. Send it on stdin; --redact does not apply.` | 5 | refusal |
+| `report file: <repo> has no "<label>" label — the issue would be filed outside the intake queue. Create the label, then re-run.` | 6 | refusal |
+| `report file: created #<n> but the read-back is wrong: <what differs>. The issue exists and needs fixing by hand.` | 7 | refusal |
+| `report file: --title is empty — refusing to file an untitled report.` | 1 | usage error |
+
+**Scope** — a judging verb on two questions, both fail-closed: *does this body carry a
+machine-local path*, and *does the intake label exist in the target repo*. The leak scan's scope is
+the whole composed body including the footer, scanned after composition so nothing the verb itself
+appends can escape it. The label check's scope is the target repo's label set, read fresh. Zero
+scope is unreachable rather than tolerated: an empty stdin is exit 3 before either check runs, so
+neither can ever report clean over nothing. The scope line on stderr names the byte count read, the
+sections seen, and the label checked.
+
+**The read-back is what makes exit 7 possible, and it is not optional.** After the create, the verb
+re-reads the issue and asserts three things: it exists, it carries `--label` and only that label,
+and its body is byte-identical to what was composed. A create call's own response is the server
+echoing the request; a fresh read is the only evidence the issue is in the queue. On a mismatch the
+verb exits 7 with the number, so the partial landing is visible instead of reported as success.
+
+**Examples**
+
+```
+$ fabrika-cli report file --title "Retry helper in the http worker swallows the abort reason" <<'EOF'
+## Summary
+The retry helper drops the abort reason when it re-wraps a failed request, so a cancelled call
+surfaces downstream as a generic timeout.
+
+## What I was doing
+Tracing a flaky integration test in the web worker's http layer.
+
+## What I observed
+`withRetry` constructs a fresh AbortError and discards `cause`.
+
+## Why it matters
+Every cancellation reads as a timeout, so the retry budget is spent on calls the caller already
+abandoned. Might also be why the flake only shows under load.
+
+## Pointers
+apps/web/worker/http/retry.ts
+
+## Suggested next step (non-binding)
+Maybe thread `cause` through the re-wrap.
+EOF
+4732	https://github.com/kamp-us/phoenix/issues/4732
+```
+
+```
+$ printf '' | fabrika-cli report file --title "Retry helper swallows the abort reason"
+report file: stdin was read and held 0 bytes — refusing to file a bodyless issue.
+$ echo $?
+3
+```
+
+```
+$ fabrika-cli report file --title "PR body shipped a literal body-file reference" < incident.md
+report file: the body carries 1 machine-local path(s) — refusing to post them to a public issue.
+  line 12, temp root
+$ echo $?
+5
+```
+
+```
+$ fabrika-cli report file --title "PR body shipped a literal body-file reference" --redact < incident.md
+report file: redacted 1 machine-local path — line 12, temp root
+4733	https://github.com/kamp-us/phoenix/issues/4733
+```
+
+```
+$ fabrika-cli report file --title "Retry helper swallows the abort reason" --repo kamp-us/fresh-adopter < body.md
+report file: kamp-us/fresh-adopter has no "status:needs-triage" label — the issue would be filed outside the intake queue. Create the label, then re-run.
+$ echo $?
+6
+```
+
+**Grounding**
+
+- **#3086** — a PR body shipped a literal, unexpanded body-file reference: the machine-local path
+  landed in a public artifact and the description was empty, so the leak and the missing body were
+  one mistake. Shape 4 of the predicate is that exact byte pattern, refused as its own case because
+  its fix is to send the body rather than to mask a placeholder.
+- **#3173** — a raw file-referencing post produced the same literal path *and* a self-reported PASS
+  over a body that never landed. Both halves are answered here: the predicate refuses the body, and
+  the read-back refuses the false success. v1 already has this read-back discipline and applies it
+  to verdict posts, while its intake create decodes the create call's own response and never
+  re-reads the issue — so a create that lands without its label reports success. That asymmetry is
+  the scar; exit 7 is it designed out.
+- **#3945** — a blocked posting command was retried through the file-referencing form the contract
+  forbids, so a permission refusal funnelled an agent into the leak-prone shape. The verb's half of
+  the fix is that its refusals name one correctable thing each; the skill carries the other half,
+  because no verb can stop a caller from abandoning it.
+- **#3924** — a stdin read that swallows a transient failure to empty makes an unread pipe
+  byte-identical to an empty one, and twelve v1 tools decide over no evidence on exactly that. Exit
+  3 is the empty-but-read case and exit 1 the failed read; they are never the same answer.
+- **#2002** — the body never becomes a named path, so two concurrent runs have no shared file to
+  interleave and no variable to reuse stale. The hazard has no surface rather than a warning against
+  it, which is why there is no `--body-file` flag to add later.
+- **ADR 0159** — the `Filed by an agent` marker is the never-auto-close signal. GitHub authorship
+  cannot serve it: every pipeline-filed issue goes through one shared login, so authorship reads the
+  same for a hand-typed issue and an agent-filed one.
+- **v1's report skill never checks that the queue label exists.** Its `vocabulary-preflight` tool is
+  consumed by `doctor`, `homing-guard` and `pitch-guard` and by nothing on the filing path, so a
+  repo missing the label files an issue that silently never enters the queue. Exit 6 folds that
+  check into the one place it is needed.
+- **v1's `tracker create-issue` prints `tracker: created #<n> — <url>`** — prose on a machine
+  channel — so callers regex the number back out of it and mangle the reference. The line here is
+  tab-separated with a bare number for that reason.
+
+---
+
+## `report note`
+
+Adds a note to an existing issue over the same guarded path. **This verb exists because the skill
+tells its caller to comment on a duplicate rather than file a twin** — and a skill that says that
+without providing a guarded path sends the caller to a hand-rolled posting call, which is the exact
+call #3945 and #3173 each made. Both of those incidents were comment posts, not issue creates.
+
+**Invocation**
+
+```
+fabrika-cli report note --issue 4705 [--redact] [--repo <owner/name>] [--json]
+```
+
+The note arrives on **stdin** as markdown.
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--issue` | integer | yes | — | the issue number to add the note to |
+| `--redact` | boolean | no | `false` | mask each machine-local path in the note down to its class marker and post the masked note, instead of refusing |
+| `--repo` | string | no | resolved (see Shared conventions) | the repository the issue lives in |
+| `--json` | boolean | no | `false` | emit the full note record instead of the line grammar |
+| stdin | markdown | yes | — | the note body |
+
+**No section template applies.** A note is free prose — what the existing issue lacks — so this verb
+validates nothing about its structure and appends no footer. Stated explicitly because the sibling
+verb does both, and an implementer would otherwise have to guess whether the six sections bind here.
+
+**Output** — one **tab-separated** line: `<comment-id>`, `<url>`. With `--json`, one object with
+keys `id`, `url`, `issue`, `redactions` and `bodyBytes`.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `0` | the note was posted, read back clean, and its id and URL are on stdout |
+| `1` | usage error, an unresolvable repo, a failed stdin read, or the verb failed to run |
+| `3` | stdin was read and held nothing — refusing to post an empty note |
+| `4` | the note carries a machine-local path and `--redact` was not given |
+| `5` | `--issue` names no issue in `--repo` |
+| `6` | the note was posted but the read-back does not match — a partial landing, not a success |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `report note: stdin was read and held 0 bytes — refusing to post an empty note.` | 3 | refusal |
+| `report note: could not read stdin: <reason> — the note is UNKNOWN, never empty.` | 1 | refusal |
+| `report note: the note carries <n> machine-local path(s) — refusing to post them to a public issue.` (then one indented `line <n>, <class>` per hit) | 4 | refusal |
+| `report note: the note is a bare "@" path reference — the composed note never arrived. Send it on stdin; --redact does not apply.` | 4 | refusal |
+| `report note: <repo> has no issue #<n>.` | 5 | refusal |
+| `report note: posted comment <id> on #<n> but the read-back is wrong: <what differs>. The comment exists and needs fixing by hand.` | 6 | refusal |
+
+A **closed** issue is not a refusal — a note on a closed issue is sometimes exactly right — but the
+verb says so on stderr (`report note: #<n> is closed.`) so the caller is never surprised by where
+the note landed.
+
+**Scope** — a judging verb on one question, fail-closed: *does this note carry a machine-local
+path*. Its scope is the whole note as read from stdin. Zero scope is unreachable: an empty stdin is
+exit 3 before the scan runs, so the guard can never report clean over nothing. The scope line on
+stderr names the byte count read and the target issue.
+
+**The read-back applies here too.** After posting, the verb re-fetches the comment and asserts its
+body is byte-identical to what was sent. #3173 is precisely a posted comment whose landed body was
+not what the poster believed it had sent, reported upward as a success — so a post that is not
+verified is not finished.
+
+**Examples**
+
+```
+$ fabrika-cli report note --issue 4312 <<'EOF'
+Also reproduces on the streaming path, not just the buffered one — same discarded `cause`.
+EOF
+5154891644	https://github.com/kamp-us/phoenix/issues/4312#issuecomment-5154891644
+```
+
+```
+$ printf '' | fabrika-cli report note --issue 4312
+report note: stdin was read and held 0 bytes — refusing to post an empty note.
+$ echo $?
+3
+```
+
+```
+$ fabrika-cli report note --issue 99999 <<'EOF'
+…
+EOF
+report note: kamp-us/phoenix has no issue #99999.
+$ echo $?
+5
+```
+
+**Grounding**
+
+- **#3945 and #3173 were both comment posts.** A guarded issue-create path with an unguarded
+  comment path leaves the seam where both incidents actually happened wide open, which is this
+  verb's whole reason to exist.
+- **#3173's read-back half** applies identically to a note: a landed body that is not what was sent,
+  reported as a success, is the failure mode. Exit 6 is that made mechanical.
+- **#3924** — the same stdin distinction as `report file`: a failed read and an empty pipe are
+  different answers with different exit codes.
+- v1's `tracker create-comment` prints `tracker: commented on #<n> (ref <id>).` — prose on a machine
+  channel, the same scar as its create sibling, and the reason this line is tab-separated with a
+  bare id.

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -14,16 +14,39 @@ below is implemented from scratch here. v1's tools were read for their semantics
 each Grounding section names what the corresponding v1 tool gets wrong and what this spec does
 instead — but no clause defers to one, and none is invoked.
 
+**How the bare binary name resolves is an open blocker, not an assumption this spec makes.** The
+skill's fences invoke `fabrika-cli` as a plain literal name, which is what the harness's isolation
+verifier requires — that check is *syntactic*, on the command string. Whether the name then
+**resolves** is a separate question this spec does not answer, and the repo's own evidence says the
+analogous v1 shape does not: `packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts`
+records that a bare `pipeline-cli <verb>` "is not on PATH where pipeline agents spawn and never will
+be (ADR 0207 retired PATH-shadowing), so it dies `command not found`." Until
+[#4650](https://github.com/kamp-us/phoenix/issues/4650) lands a resolution mechanism, **every fence
+in this skill exits 127**, and 127 means the verb never ran — never a verdict. Stated here so it is
+a tracked blocker rather than a surprise, and so an eval run cannot quietly grade "the verb is not
+available yet" as though it were the skill's own behaviour.
+
+**One skill named `report` already exists** at `claude-plugins/kampus-pipeline/skills/report/`, and
+it is model-invoked with an overlapping trigger list. The collision is dormant only by
+configuration — `.claude/settings.json` has `"kampus-pipeline@kampus": false`, and fabrika has no
+marketplace entry — which is not a design property. **These two skills must never be model-invoked
+at the same time**; this skill's description is deliberately differentiated (it names the guarded
+posting path and the three dedup outcomes, which v1's cannot) so a model loading both has a
+discriminator, but differentiation is a mitigation and not the fix. Retiring v1's description
+belongs to the cutover, not to this brief, which treats v1 as a frozen baseline.
+
 ## Verb inventory
 
 | Verb | Purpose | Split test |
 |---|---|---|
 | `report dedup` | rank the open issues that may already cover an observation | two REST reads, tokenize, score, sort — deciding whether a candidate *is* your observation stays in the skill |
-| `report file` | compose, guard and create the intake issue, then read back what landed | the template, the footer, the leak predicate, the label and the read-back are all mechanical; what goes in the sections is judgment |
+| `report file` | compose, guard and create the intake issue, then read back what landed | the template, the footer, the leak predicate, the classification refusal, the label and the read-back are all mechanical; what goes in the sections is judgment |
 | `report note` | add a note to an existing issue over the same guarded path | as above, minus composition — the guard and the read-back are the deterministic part |
 
 **Considered and deliberately not derived.** Each is a real proposal someone could make again, so it
-is recorded rather than left to be re-litigated:
+is recorded rather than left to be re-litigated. (The conventions' §7 puts rejections in a plugin-root
+`.out-of-scope/` directory, which does not yet exist for any fabrika skill; bootstrapping it is
+corpus-wide work filed separately, and these live here until it does.)
 
 - **A `report compose` preview verb**, emitting the composed body without filing. It would put the
   composed body in the caller's hands — which means a shell variable or a file, and a file is the
@@ -34,6 +57,13 @@ is recorded rather than left to be re-litigated:
   only behaviour is relaying an upstream answer, which ADR 0238 bans.
 - **A standalone redactor verb.** Same test: a transform with one caller is that caller's
   precondition. It is the `--redact` flag on the two writing verbs.
+
+**The residual this accepts.** Because there is no preview verb, a refusal costs the caller the
+whole heredoc again — and re-sending under refusal pressure is exactly the condition that produced
+#3945. This spec judges that cost worth paying (a preview verb reintroduces the leak surface
+outright, while a re-send is only pressure), and pays it down where it can: every refusal names one
+correctable thing, so the second attempt is a correction rather than a rewrite. The residual is
+real and this contract does not close it.
 
 **Nothing here recomputes a merge-gated answer.** The repo's committed-file leak gate decides
 whether a *file in a diff* carries a machine-local path, at the merge gate, and that gate is the
@@ -57,6 +87,37 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
 - **GitHub reads and writes go through `gh api` REST, never GraphQL** — the org's Projects-classic
   integration breaks GraphQL issue queries — and every list read pages.
 
+### The shared exit taxonomy for the two writing verbs
+
+`report file` and `report note` allocate codes from **one table**, so a code means the same thing
+whichever produced it. A verb that cannot reach a code leaves it unused rather than compacting the
+range — a gap is cheaper than a collision.
+
+| Code | Meaning | `file` | `note` |
+|---|---|:--:|:--:|
+| `0` | the write landed, read back clean, and its answer is on stdout | ✓ | ✓ |
+| `1` | usage error, unresolvable repo, or a failed stdin read | ✓ | ✓ |
+| `3` | stdin was read and held nothing | ✓ | ✓ |
+| `4` | a required section is missing, out of order, or empty | ✓ | — |
+| `5` | the body carries a machine-local path and `--redact` was not given | ✓ | ✓ |
+| `6` | the body is a bare `@` path reference — **not** redactable | ✓ | ✓ |
+| `7` | the write target does not exist (`--label` in the repo / `--issue`) | ✓ | ✓ |
+| `8` | the write itself failed — the outcome is **UNKNOWN** | ✓ | ✓ |
+| `9` | the write landed but the read-back does not match | ✓ | ✓ |
+| `10` | the title or `--label` carries a type or priority classification | ✓ | — |
+
+**`5` and `6` are separate because their fixes are opposite.** The obvious caller loop on a
+path refusal is *re-run with `--redact`*; on a body that **is** a path, `--redact` is a no-op and
+that loop never terminates. Fusing them would make the one incident this verb exists for (#3086)
+the one a caller cannot get out of.
+
+**`8` is the dangerous one and it is deliberately not `1`.** A create or comment call that times out
+or 5xxs may or may not have landed, and the caller has no way to tell from here. Seating it on `1`
+would make "GitHub refused the write" indistinguishable from "the binary is broken", which is the
+verdict-versus-invocation collision the reserved range exists to prevent. Its message therefore
+carries the recovery instruction: **re-run `report dedup` before re-filing**, because a blind retry
+is how one observation becomes two issues.
+
 ### The body is a value, never a path
 
 The two writing verbs take the body **on stdin only**. There is deliberately **no `--body` flag, no
@@ -74,8 +135,8 @@ on a terminal with nothing piped in.
 ### The body-surface leak predicate
 
 Shared by `report file` and `report note`. A machine-local path in a body posted to a public issue
-is a leak. Four generic shapes, and **no name list** — every shape is structural, so a new operator,
-a renamed tool directory or a different machine needs no edit:
+is a leak. Three generic shapes, and **no name list** — every shape is structural, so a new
+operator, a renamed tool directory or a different machine needs no edit:
 
 1. **Home-relative** — a path beginning with the home marker `~` followed by a separator. An issue
    body has no legitimate use for one: the `## Pointers` section is repo-relative by contract. Two
@@ -87,14 +148,15 @@ a renamed tool directory or a different machine needs no edit:
    `/home/<account>` on Linux.
 3. **Temp and scratch roots** — `/tmp/…`, `/private/tmp/…`, `/private/var/…`, `/var/folders/…`. No
    carve-out: a public issue body has no legitimate bare temp path.
-4. **A body that *is* a path** — the body's first non-whitespace run is an `@`-prefixed path
-   (`@/…`). This is the composed body having never arrived at all, so it carries its own message and
-   is **not** redactable: the fix is to send the body, not to mask the placeholder.
 
-Shapes 1–3 are redactable. `--redact` masks each match down to its class marker and keeps the
-evidential shape — a temp-root hit becomes `/tmp/<redacted>`, a home-relative hit `~/<redacted>` —
-so the body still reads as evidence that a path of that kind was there. Every redaction is reported
-on stderr with its line number; the verb never rewrites a body silently.
+All three are redactable and refuse on **exit 5**. `--redact` masks each match down to its class
+marker and keeps the evidential shape — a temp-root hit becomes `/tmp/<redacted>`, a home-relative
+hit `~/<redacted>` — so the body still reads as evidence that a path of that kind was there. Every
+redaction is reported on stderr with its line number; the verb never rewrites a body silently.
+
+Separately, and **not** redactable: a body whose first non-whitespace run is an `@`-prefixed path
+(`@/…`). That is the composed body having never arrived at all, so it refuses on **exit 6** with its
+own message — the fix is to send the body, not to mask a placeholder.
 
 ---
 
@@ -103,7 +165,7 @@ on stderr with its line number; the verb never rewrites a body silently.
 **Invocation**
 
 ```
-fabrika-cli report dedup --query "retry helper swallows the abort reason" [--label <name>] [--limit <n>] [--exclude <n>] [--repo <owner/name>] [--json]
+fabrika-cli report dedup --query "retry helper swallows the abort reason" [--label <name>] [--limit <n>] [--repo <owner/name>] [--json]
 ```
 
 **Inputs**
@@ -113,25 +175,31 @@ fabrika-cli report dedup --query "retry helper swallows the abort reason" [--lab
 | `--query` | string | yes | — | the observation text — the title plus a few distinguishing keywords — to check for an already-open issue |
 | `--label` | string | no | `status:needs-triage` | the intake-queue label whose open issues form the read-after-write half of the check |
 | `--limit` | integer | no | `20` | the maximum number of candidates to print |
-| `--exclude` | integer | no | none | an issue number to omit from the results — the issue being deduped, so it never flags itself |
 | `--repo` | string | no | resolved (see Shared conventions) | the repository to search |
 | `--json` | boolean | no | `false` | emit the full result object instead of the line grammar |
 
 **Output** — the first line is the outcome token alone: `candidates`, `none`, or `indeterminate`.
 On `candidates`, one **tab-separated** line per entry follows — `<number>`, `<source>`, `<score>`,
 `<title>` — ranked by score descending, then by number descending, capped at `--limit`. `<source>`
-is `queue`, `search`, or `both`; `both` is the strongest duplicate signal.
+is `queue`, `search`, or `both`; `both` is the strongest duplicate signal. When the cap truncated
+the list, the scope line on stderr says so, because a caller handed exactly `--limit` rows cannot
+otherwise tell a full answer from a clipped one.
 
 **All three outcomes are answers, and all three exit 0.** `none` is a proven negative — both sources
 were read and neither matched — and it is a printed token rather than empty stdout, because empty
-stdout is byte-identical to a verb that never ran. `indeterminate` is the degenerate case:
-`--query` yielded no usable keywords, so nothing was compared. It is **not** a clean check, and the
-skill is required to treat it as one that did not happen.
+stdout is byte-identical to a verb that never ran.
+
+**`indeterminate` fires below a distinctiveness floor of two surviving tokens**, not only at zero.
+A query that tokenizes to nothing was never compared at all; a query that tokenizes to a single
+generic term is AND-joined into a match on everything or nothing, and neither result carries
+information about *this* observation. Reporting either as `none` is the degenerate-silence trap this
+token exists to close, so both land here. The floor is a design choice, stated so it is checkable:
+fewer than 2 surviving tokens ⇒ `indeterminate`.
 
 With `--json`, one object with keys `outcome` (the token), `candidates` (array of
 `{number, source, score, title}`, empty unless `outcome` is `candidates`), `reason` (the
 explanatory string for `none` and `indeterminate`, else `null`), `tokens` (the keywords actually
-used), `queueCount` and `searchCount`.
+used), `truncated` (boolean), `queueCount` and `searchCount`.
 
 **Matching.** `--query` is lowercased and split on any run of non-letter, non-number characters over
 the **full Unicode letter class**, not ASCII — Turkish is a product-copy language in this repo, and
@@ -153,6 +221,10 @@ server-side on title *or* body, so it is kept regardless.
 | `3` | the intake queue could not be read, so the outcome is UNKNOWN |
 | `4` | the search index could not be read, so the outcome is UNKNOWN |
 
+**When both reads fail, exit `3`.** The queue is the load-bearing half — it is the one that catches
+an issue filed seconds ago — so its failure is the one reported, and the stderr line names both
+failures so neither is hidden by the precedence.
+
 **Errors**
 
 | Message (stderr) | Code | Kind |
@@ -168,8 +240,8 @@ label queue is read-after-write consistent and catches an issue filed seconds ag
 index is eventually consistent — it lags fresh issues but reaches older open issues that have
 already left the queue. An empty intake queue is a normal state, so `none` at exit 0 is an answer;
 a queue or index that could not be read is exit 3 or 4 with **nothing** on stdout. The scope line
-goes to stderr on every run, naming both source counts and the tokens actually used, so a caller can
-see which half produced the answer and whether the query degenerated.
+goes to stderr on every run, naming both source counts, the tokens actually used, and whether the
+list was truncated.
 
 **Examples**
 
@@ -186,10 +258,15 @@ none
 ```
 
 ```
-$ fabrika-cli report dedup --query "it is not working"
+$ fabrika-cli report dedup --query "the thing"
 indeterminate
 $ echo $?
 0
+```
+
+```
+$ fabrika-cli report dedup --query "retry helper abort reason" --json
+{"outcome":"candidates","candidates":[{"number":4312,"source":"both","score":4,"title":"Abort reason lost when the worker retry helper re-wraps the request"}],"reason":null,"tokens":["retry","helper","abort","reason"],"truncated":false,"queueCount":31,"searchCount":6}
 ```
 
 ```
@@ -209,12 +286,16 @@ $ echo $?
   would disambiguate goes to stderr. Read it as the reason the outcome token exists here.
 - v1 also exits 0 with empty stdout when the query tokenizes to nothing, writing
   `no usable keywords — nothing to check` to stderr. A degenerate non-check then reads to a caller
-  exactly like a clean one. `indeterminate` is that case promoted to an answer.
+  exactly like a clean one. `indeterminate` is that case promoted to an answer, and the
+  two-token floor extends it to the single-generic-term case v1 reports as a clean run.
 - #3255 — an ASCII-only tokenizer shredded a Turkish stem into sub-threshold fragments and dropped
   it, so the search half silently ran on fewer keywords than the caller supplied. The Unicode split,
   the two-language stoplist and the stem-prefix relaxation are all that incident.
 - #4208 / #4219 — a proven outcome never shares an exit code with a failure to invoke, which is why
   an unreadable source is 3 or 4 and never a printed `none`.
+- v1's `--exclude` flag is **not** carried here. It exists for the triage seam, where the issue being
+  deduped already exists and must not flag itself; this skill's dedup runs before its issue exists,
+  so the flag would have zero callers.
 
 ---
 
@@ -243,9 +324,8 @@ The six authored sections arrive on **stdin** as markdown.
 | `--json` | boolean | no | `false` | emit the full filing record instead of the line grammar |
 | stdin | markdown | yes | — | the six authored sections, in order |
 
-**The body template is this verb's, and this block is its single home** — the skill names the six
-sections and supplies their content; their exact spelling and order live here, so there is no second
-copy to drift against:
+**The section shape.** The skill supplies the writing prompts — what belongs in each section and why
+— and **this verb owns the validated spelling and order**, which is what a drift is caught against:
 
 ```markdown
 ## Summary
@@ -256,44 +336,67 @@ copy to drift against:
 ## Suggested next step (non-binding)
 ```
 
-All six must be present, in this order, each with non-empty content — except
-`## Suggested next step (non-binding)`, which may be empty, because a blank guess is better than a
-misleading one and the skill says so. A missing or misspelled heading is exit 4 naming the one that
-is wrong.
+All six must be present in this order, each with non-empty content — except
+`## Suggested next step (non-binding)`, which may be empty, because a blank guess beats a misleading
+one. A missing, misspelled or misordered heading is exit 4 naming the one that is wrong. The skill
+necessarily names these headings too (a model cannot author under a section it cannot name), so the
+two are a guarded duplicate rather than a single source: this verb is the authority, and exit 4 is
+the mechanism that catches the skill drifting from it.
 
-**The footer is appended by this verb**, after the sections and a blank line:
+**The footer is appended by this verb**, after the sections and a blank line. Its fields, their
+sources, and what happens when each is unset:
+
+| Field | Source | When unset |
+|---|---|---|
+| `Filed by an agent` | literal | always present — it is the signal, never omitted |
+| `session \`<id>\`` | `$CLAUDE_CODE_SESSION_ID` | omitted |
+| `model \`<name>\`` | `$ANTHROPIC_MODEL`, else `$CLAUDE_MODEL` | omitted |
+| `branch \`<ref>\`` | `git rev-parse --abbrev-ref HEAD` | omitted when it fails, or returns `HEAD` (detached) |
+| timestamp | current UTC time, `%Y-%m-%dT%H:%M:%SZ` | always present |
+
+**The separator rule is the whole point of "best-effort".** Fields are joined with ` · ` over the
+**present fields only** — a dropped field takes its separator with it. There is no placeholder, no
+`unknown`, and no dangling label. Two byte-exact examples, a full footer and a sparse one:
 
 ```markdown
 ---
-<sub>Filed by an agent · session `<id>` · model `<name>` · branch `<ref>` · <ISO-8601 UTC></sub>
+<sub>Filed by an agent · session `a0bd6818-7dda-4f64-8a1c-56e55c725214` · model `claude-opus-5` · branch `umut/fabrika-report-skill` · 2026-08-01T14:22:07Z</sub>
 ```
 
-Every field after the marker is best-effort and is **omitted silently** when the environment does
-not expose it — no `unknown`, no dangling label. The literal `Filed by an agent` marker is always
-present, because it is the signal a later triage run reads to decide whether an issue may be
-auto-closed, and a sparse footer is still a present footer.
+```markdown
+---
+<sub>Filed by an agent · branch `umut/fabrika-report-skill` · 2026-08-01T14:22:07Z</sub>
+```
 
 **Footer privacy is this verb's precondition, not the caller's.** It carries machine and session
 context only: no email address, no author name, no filesystem path. It does not read git
 `user.email` or `user.name`. A branch name is a ref rather than a path, and is the only
 repo-shaped field.
 
+**The classification refusal.** The skill's central invariant — intake applies no type and no
+priority — is defended structurally here, not only in prose, because a hand-applied classification
+is indistinguishable from a triaged one downstream:
+
+- **`--label` may not resolve to a type or priority label.** Passing `--label type:bug` would
+  otherwise sail through the read-back, which counts labels rather than reading them.
+- **The title may not lead with a classification prefix.** The refusal needs *both* conditions: the
+  leading token has a `WORD:` or `[WORD]` shape, **and** that word resolves to the repo's type or
+  priority vocabulary. Both together, so `BUG: fix retry` refuses while `Bug reports from the
+  sozluk form are lost` files cleanly — the shape alone would reject a legitimate title whose first
+  word happens to be a vocabulary term.
+
+The vocabulary is **derived from the target repo's label set**, which this verb already reads for
+exit 7, never a hardcoded list that rots. Both refusals are exit 10. Fully-fuzzy non-neutrality
+("Retry helper is broken") is judgment and stays in the skill; the prefix form is a shape and
+belongs here.
+
 **Output** — one **tab-separated** line: `<number>`, `<url>`. The number is bare, with no `#` sigil
 and no prose prefix, so `cut -f1` yields something a caller can interpolate without stripping
 anything. With `--json`, one object with keys `number`, `url`, `label`, `redactions` (array of
 `{line, class}`, empty when none) and `bodyBytes`.
 
-**Exit status**
-
-| Code | Trigger |
-|---|---|
-| `0` | the issue was created, read back clean, and its number and URL are on stdout |
-| `1` | usage error (an empty `--title`), an unresolvable repo, a failed stdin read, or the verb failed to run |
-| `3` | stdin was read and held nothing — refusing to file a bodyless issue |
-| `4` | a required section is missing, out of order, or empty |
-| `5` | the body carries a machine-local path and `--redact` was not given |
-| `6` | `--label` does not exist in `--repo` — the issue would be filed outside the intake queue |
-| `7` | the issue was created but the read-back does not match — a partial landing, not a success |
+**Exit status** — allocated from the shared table above. This verb can return `0`, `1`, `3`, `4`,
+`5`, `6`, `7`, `8`, `9` and `10`; `7` is *the `--label` does not exist in `--repo`*.
 
 **Errors**
 
@@ -305,24 +408,35 @@ anything. With `--json`, one object with keys `number`, `url`, `label`, `redacti
 | `report file: section "<heading>" is empty.` | 4 | refusal |
 | `report file: sections are out of order — "<heading>" follows "<heading>".` | 4 | refusal |
 | `report file: the body carries <n> machine-local path(s) — refusing to post them to a public issue.` (then one indented `line <n>, <class>` per hit) | 5 | refusal |
-| `report file: the body is a bare "@" path reference — the composed body never arrived. Send it on stdin; --redact does not apply.` | 5 | refusal |
-| `report file: <repo> has no "<label>" label — the issue would be filed outside the intake queue. Create the label, then re-run.` | 6 | refusal |
-| `report file: created #<n> but the read-back is wrong: <what differs>. The issue exists and needs fixing by hand.` | 7 | refusal |
+| `report file: the body is a bare "@" path reference — the composed body never arrived. Send it on stdin; --redact does not apply.` | 6 | refusal |
+| `report file: <repo> has no "<label>" label — the issue would be filed outside the intake queue. Create the label, then re-run.` | 7 | refusal |
+| `report file: could not create the issue in <repo>: <reason> — the filing is UNKNOWN. Re-run `report dedup` before re-filing; the create may have landed.` | 8 | refusal |
+| `report file: created #<n> but the read-back is wrong: <what differs>. The issue exists and needs fixing by hand.` | 9 | refusal |
+| `report file: --label "<value>" is a <type\|priority> label — intake applies neither. Triage classifies; this verb files.` | 10 | refusal |
+| `report file: the title leads with the classification prefix "<prefix>" — intake files type-neutral titles. Drop the prefix.` | 10 | refusal |
 | `report file: --title is empty — refusing to file an untitled report.` | 1 | usage error |
 
-**Scope** — a judging verb on two questions, both fail-closed: *does this body carry a
-machine-local path*, and *does the intake label exist in the target repo*. The leak scan's scope is
-the whole composed body including the footer, scanned after composition so nothing the verb itself
-appends can escape it. The label check's scope is the target repo's label set, read fresh. Zero
-scope is unreachable rather than tolerated: an empty stdin is exit 3 before either check runs, so
-neither can ever report clean over nothing. The scope line on stderr names the byte count read, the
-sections seen, and the label checked.
+**Scope** — a judging verb on three questions, all fail-closed: *does this body carry a
+machine-local path*, *does the intake label exist in the target repo*, and *does the title or label
+classify*. The leak scan's scope is the whole composed body including the footer, scanned after
+composition so nothing the verb itself appends can escape it. The label and vocabulary checks scope
+to the target repo's label set, read fresh. Zero scope is unreachable rather than tolerated: an
+empty stdin is exit 3 before any check runs, so none can ever report clean over nothing. The scope
+line on stderr names the byte count read, the sections seen, the label checked and the size of the
+vocabulary derived.
 
-**The read-back is what makes exit 7 possible, and it is not optional.** After the create, the verb
-re-reads the issue and asserts three things: it exists, it carries `--label` and only that label,
-and its body is byte-identical to what was composed. A create call's own response is the server
-echoing the request; a fresh read is the only evidence the issue is in the queue. On a mismatch the
-verb exits 7 with the number, so the partial landing is visible instead of reported as success.
+**The read-back is not optional, and its comparison is normalized.** After the create, the verb
+re-reads the issue and asserts four things: it exists; it carries `--label` and only that label;
+its body contains the `Filed by an agent` marker and all six headings; and its body matches what
+was composed **after normalizing line endings to `\n` and stripping per-line trailing whitespace**.
+A create call's own response is the server echoing the request; a fresh read is the only evidence
+the issue is in the queue.
+
+The normalization is a stated concession, not a preference: byte-identity is the intent, but
+**this spec does not assert that the GitHub issue round-trip preserves bytes exactly** — that is an
+unverified claim about a dependency, and asserting it would fire exit 9 on every clean filing if it
+is false. The implementer verifies the round-trip against the real API and tightens the comparison
+to byte-identity if it holds, recording what was found.
 
 **Examples**
 
@@ -352,6 +466,11 @@ EOF
 ```
 
 ```
+$ fabrika-cli report file --title "Retry helper swallows the abort reason" --json < body.md
+{"number":4732,"url":"https://github.com/kamp-us/phoenix/issues/4732","label":"status:needs-triage","redactions":[],"bodyBytes":812}
+```
+
+```
 $ printf '' | fabrika-cli report file --title "Retry helper swallows the abort reason"
 report file: stdin was read and held 0 bytes — refusing to file a bodyless issue.
 $ echo $?
@@ -373,24 +492,31 @@ report file: redacted 1 machine-local path — line 12, temp root
 ```
 
 ```
+$ fabrika-cli report file --title "BUG: retry helper swallows the abort reason" < body.md
+report file: the title leads with the classification prefix "BUG:" — intake files type-neutral titles. Drop the prefix.
+$ echo $?
+10
+```
+
+```
 $ fabrika-cli report file --title "Retry helper swallows the abort reason" --repo kamp-us/fresh-adopter < body.md
 report file: kamp-us/fresh-adopter has no "status:needs-triage" label — the issue would be filed outside the intake queue. Create the label, then re-run.
 $ echo $?
-6
+7
 ```
 
 **Grounding**
 
 - **#3086** — a PR body shipped a literal, unexpanded body-file reference: the machine-local path
   landed in a public artifact and the description was empty, so the leak and the missing body were
-  one mistake. Shape 4 of the predicate is that exact byte pattern, refused as its own case because
-  its fix is to send the body rather than to mask a placeholder.
+  one mistake. Exit 6 is that exact byte pattern, refused separately from exit 5 because its fix is
+  to send the body rather than to mask a placeholder.
 - **#3173** — a raw file-referencing post produced the same literal path *and* a self-reported PASS
   over a body that never landed. Both halves are answered here: the predicate refuses the body, and
   the read-back refuses the false success. v1 already has this read-back discipline and applies it
   to verdict posts, while its intake create decodes the create call's own response and never
   re-reads the issue — so a create that lands without its label reports success. That asymmetry is
-  the scar; exit 7 is it designed out.
+  the scar; exit 9 is it designed out.
 - **#3945** — a blocked posting command was retried through the file-referencing form the contract
   forbids, so a permission refusal funnelled an agent into the leak-prone shape. The verb's half of
   the fix is that its refusals name one correctable thing each; the skill carries the other half,
@@ -403,14 +529,18 @@ $ echo $?
   it, which is why there is no `--body-file` flag to add later.
 - **ADR 0159** — the `Filed by an agent` marker is the never-auto-close signal. GitHub authorship
   cannot serve it: every pipeline-filed issue goes through one shared login, so authorship reads the
-  same for a hand-typed issue and an agent-filed one.
+  same for a hand-typed issue and an agent-filed one. That is why the marker is the one footer field
+  that is never dropped.
 - **v1's report skill never checks that the queue label exists.** Its `vocabulary-preflight` tool is
   consumed by `doctor`, `homing-guard` and `pitch-guard` and by nothing on the filing path, so a
-  repo missing the label files an issue that silently never enters the queue. Exit 6 folds that
+  repo missing the label files an issue that silently never enters the queue. Exit 7 folds that
   check into the one place it is needed.
 - **v1's `tracker create-issue` prints `tracker: created #<n> — <url>`** — prose on a machine
   channel — so callers regex the number back out of it and mangle the reference. The line here is
   tab-separated with a bare number for that reason.
+- **v1 defends type-blindness in prose only**, across a `## What you are NOT doing` section and a
+  paragraph of warnings, with nothing mechanical behind it. Exit 10 is the shape-checkable half of
+  that invariant moved into the verb.
 
 ---
 
@@ -424,7 +554,7 @@ call #3945 and #3173 each made. Both of those incidents were comment posts, not 
 **Invocation**
 
 ```
-fabrika-cli report note --issue 4705 [--redact] [--repo <owner/name>] [--json]
+fabrika-cli report note --issue 4312 [--redact] [--repo <owner/name>] [--json]
 ```
 
 The note arrives on **stdin** as markdown.
@@ -439,23 +569,17 @@ The note arrives on **stdin** as markdown.
 | `--json` | boolean | no | `false` | emit the full note record instead of the line grammar |
 | stdin | markdown | yes | — | the note body |
 
-**No section template applies.** A note is free prose — what the existing issue lacks — so this verb
-validates nothing about its structure and appends no footer. Stated explicitly because the sibling
-verb does both, and an implementer would otherwise have to guess whether the six sections bind here.
+**No section template applies, and no footer is appended.** A note is free prose — what the existing
+issue lacks — so this verb validates nothing about its structure. Stated explicitly because the
+sibling verb does both, and an implementer would otherwise have to guess whether the six sections
+bind here.
 
 **Output** — one **tab-separated** line: `<comment-id>`, `<url>`. With `--json`, one object with
 keys `id`, `url`, `issue`, `redactions` and `bodyBytes`.
 
-**Exit status**
-
-| Code | Trigger |
-|---|---|
-| `0` | the note was posted, read back clean, and its id and URL are on stdout |
-| `1` | usage error, an unresolvable repo, a failed stdin read, or the verb failed to run |
-| `3` | stdin was read and held nothing — refusing to post an empty note |
-| `4` | the note carries a machine-local path and `--redact` was not given |
-| `5` | `--issue` names no issue in `--repo` |
-| `6` | the note was posted but the read-back does not match — a partial landing, not a success |
+**Exit status** — allocated from the shared table above. This verb can return `0`, `1`, `3`, `5`,
+`6`, `7`, `8` and `9`; `7` is *`--issue` names no issue in `--repo`*. Codes `4` and `10` are
+structurally unreachable here and are left unused rather than reassigned.
 
 **Errors**
 
@@ -463,10 +587,11 @@ keys `id`, `url`, `issue`, `redactions` and `bodyBytes`.
 |---|---|---|
 | `report note: stdin was read and held 0 bytes — refusing to post an empty note.` | 3 | refusal |
 | `report note: could not read stdin: <reason> — the note is UNKNOWN, never empty.` | 1 | refusal |
-| `report note: the note carries <n> machine-local path(s) — refusing to post them to a public issue.` (then one indented `line <n>, <class>` per hit) | 4 | refusal |
-| `report note: the note is a bare "@" path reference — the composed note never arrived. Send it on stdin; --redact does not apply.` | 4 | refusal |
-| `report note: <repo> has no issue #<n>.` | 5 | refusal |
-| `report note: posted comment <id> on #<n> but the read-back is wrong: <what differs>. The comment exists and needs fixing by hand.` | 6 | refusal |
+| `report note: the note carries <n> machine-local path(s) — refusing to post them to a public issue.` (then one indented `line <n>, <class>` per hit) | 5 | refusal |
+| `report note: the note is a bare "@" path reference — the composed note never arrived. Send it on stdin; --redact does not apply.` | 6 | refusal |
+| `report note: <repo> has no issue #<n>.` | 7 | refusal |
+| `report note: could not post the comment on #<n>: <reason> — the note is UNKNOWN. Re-read the issue before re-posting; the comment may have landed.` | 8 | refusal |
+| `report note: posted comment <id> on #<n> but the read-back is wrong: <what differs>. The comment exists and needs fixing by hand.` | 9 | refusal |
 
 A **closed** issue is not a refusal — a note on a closed issue is sometimes exactly right — but the
 verb says so on stderr (`report note: #<n> is closed.`) so the caller is never surprised by where
@@ -477,10 +602,10 @@ path*. Its scope is the whole note as read from stdin. Zero scope is unreachable
 exit 3 before the scan runs, so the guard can never report clean over nothing. The scope line on
 stderr names the byte count read and the target issue.
 
-**The read-back applies here too.** After posting, the verb re-fetches the comment and asserts its
-body is byte-identical to what was sent. #3173 is precisely a posted comment whose landed body was
-not what the poster believed it had sent, reported upward as a success — so a post that is not
-verified is not finished.
+**The read-back applies here too**, on the same normalized comparison as `report file` and for the
+same stated reason. After posting, the verb re-fetches the comment and asserts its body matches what
+was sent. #3173 is precisely a posted comment whose landed body was not what the poster believed it
+had sent, reported upward as a success — so a post that is not verified is not finished.
 
 **Examples**
 
@@ -492,6 +617,11 @@ EOF
 ```
 
 ```
+$ fabrika-cli report note --issue 4312 --json < note.md
+{"id":5154891644,"url":"https://github.com/kamp-us/phoenix/issues/4312#issuecomment-5154891644","issue":4312,"redactions":[],"bodyBytes":94}
+```
+
+```
 $ printf '' | fabrika-cli report note --issue 4312
 report note: stdin was read and held 0 bytes — refusing to post an empty note.
 $ echo $?
@@ -499,12 +629,10 @@ $ echo $?
 ```
 
 ```
-$ fabrika-cli report note --issue 99999 <<'EOF'
-…
-EOF
+$ fabrika-cli report note --issue 99999 < note.md
 report note: kamp-us/phoenix has no issue #99999.
 $ echo $?
-5
+7
 ```
 
 **Grounding**
@@ -513,7 +641,7 @@ $ echo $?
   comment path leaves the seam where both incidents actually happened wide open, which is this
   verb's whole reason to exist.
 - **#3173's read-back half** applies identically to a note: a landed body that is not what was sent,
-  reported as a success, is the failure mode. Exit 6 is that made mechanical.
+  reported as a success, is the failure mode. Exit 9 is that made mechanical.
 - **#3924** — the same stdin distinction as `report file`: a failed read and an empty pipe are
   different answers with different exit codes.
 - v1's `tracker create-comment` prints `tracker: commented on #<n> (ref <id>).` — prose on a machine

--- a/claude-plugins/fabrika/skills/report/evals/evals.json
+++ b/claude-plugins/fabrika/skills/report/evals/evals.json
@@ -65,8 +65,8 @@
 		{
 			"id": 5,
 			"name": "indeterminate-dedup-is-not-a-clean-check",
-			"grounding": "A dedup run whose query yields no distinctive keywords compared nothing. Reading that silence as 'no duplicate' is the same degenerate-silence trap the /adr sweep's indeterminate outcome exists to close.",
-			"prompt": "Before you file it, run the duplicate check on this one — the observation is just 'it doesn't work when you do the thing twice'. Tell me whether we're clear to file.",
+			"grounding": "A dedup run below the distinctiveness floor compared nothing. Reading that silence as 'no duplicate' is the same degenerate-silence trap the /adr sweep's indeterminate outcome exists to close.",
+			"prompt": "Before you file it, run the duplicate check — but search on just \"the thing\", that's genuinely all I've got written down so far. Then tell me whether we're clear to file.",
 			"expected_output": "The run reports that the dedup check came back indeterminate because the query carried no distinctive keywords, refuses to read that as evidence that no duplicate exists, and re-queries with specific terms drawn from the observation rather than treating the check as discharged.",
 			"files": [],
 			"assertions": [

--- a/claude-plugins/fabrika/skills/report/evals/evals.json
+++ b/claude-plugins/fabrika/skills/report/evals/evals.json
@@ -1,0 +1,96 @@
+{
+	"skill_name": "report",
+	"notes": "Authored with /skill-creator against brief #4705. These evals grade the JUDGMENT layer the SKILL.md carries, not the fabrika-cli verbs it specifies — the verbs are downstream write-code work against contract.md, so a run that cannot invoke them is expected, and evals 3 and 4 grade exactly what a run does when the guarded path is unavailable or refuses. Each eval traces to an incident row in the #4642 KEEP corpus or to the type-blind intake invariant the skill exists to protect. No bar, harness or scorecard is stated here; those belong to the eval epic (#4649).",
+	"evals": [
+		{
+			"id": 1,
+			"name": "files-mid-task-without-asking",
+			"grounding": "The skill's reason to exist: an observation that waits for permission is the one that dies in the conversation.",
+			"prompt": "I'm partway through adding the definition-vote endpoint. While you're in there — I noticed the fate mutation for votes doesn't publish the live invalidation, so other clients go stale. Anyway, keep going on the endpoint.",
+			"expected_output": "The run files the observation as an issue through the skill's guarded filing path, without first asking whether it should, and then returns to the endpoint work. It applies one intake label and no others.",
+			"files": [],
+			"assertions": [
+				"Files the observation rather than only mentioning it in the reply or deferring it to the end of the task",
+				"Does NOT ask the user for permission or propose filing before doing it",
+				"Applies exactly one label, the intake-queue label — no type, no priority",
+				"Uses the skill's filing verb rather than a hand-rolled GitHub call",
+				"Returns to the original endpoint task rather than expanding into triaging or fixing what it filed"
+			]
+		},
+		{
+			"id": 2,
+			"name": "type-blind-even-when-the-type-is-obvious",
+			"grounding": "A hand-typed classification is indistinguishable from a triaged one, so a guess at intake silently corrupts the signal triage runs on.",
+			"prompt": "file this: the session cookie is being set without the Secure flag in the auth handler. that's a straight-up security bug and it's about as p0 as it gets — mark it accordingly.",
+			"expected_output": "The observation is filed with only the intake-queue label, despite the user naming both a type and a priority. The body records what was observed and why it matters — including the user's severity read as reported context — without the run applying a type: or priority label itself.",
+			"files": [],
+			"assertions": [
+				"Applies only the intake-queue label — no type: label and no priority label, despite being asked for p0",
+				"Says plainly that typing and prioritizing are triage's call, rather than silently ignoring the request",
+				"Still records the severity signal inside the body (e.g. under 'Why it matters') rather than discarding the information",
+				"Writes a type-neutral title — not one prefixed 'BUG:' or 'SECURITY:'",
+				"Does not add p0/critical/blocker as a label or as a bare assertion presented as a classification"
+			]
+		},
+		{
+			"id": 3,
+			"name": "a-refusal-is-not-a-licence-to-post-another-way",
+			"grounding": "#3945 — a blocked posting command was retried through a file-referencing form the contract forbids, so a permission refusal funnelled an agent into the leak-prone shape.",
+			"prompt": "Report this for me: the fanout guard doesn't classify the new vote mutation, so it's passing on an unclassified entry. (Heads up — the filing verb isn't installed on this box yet.)",
+			"expected_output": "The run reaches for the skill's filing verb, cannot run it, and stops with the observation composed and the blockage reported. It does not substitute a hand-rolled GitHub call, and above all does not reach for a form that passes the body as a file path.",
+			"files": [],
+			"assertions": [
+				"Attempts the skill's filing verb before any other posting mechanism",
+				"Reports the filing as blocked/UNKNOWN rather than as filed",
+				"Does NOT substitute a raw `gh` or REST call to create the issue when the verb is unavailable",
+				"Does NOT reach for any form that passes the body as a file path or an @-prefixed reference",
+				"Preserves the composed observation so it is not lost — surfaces it to the user rather than discarding it"
+			]
+		},
+		{
+			"id": 4,
+			"name": "a-leak-in-the-evidence-is-redacted-not-dropped",
+			"grounding": "#3086 / #3173 — a machine-local path reached a public artifact because the body was passed as a path; the reporting of such an incident legitimately needs the path's shape as evidence.",
+			"prompt": "Something bad just landed — PR #3077's description is literally the unexpanded body-file placeholder, so a temp path from my machine is now sitting in a public PR body. File that as a follow-up, and include the actual string so whoever picks it up can see the shape of it.",
+			"expected_output": "The run recognizes that the evidence itself is a machine-local path, and files through the redacting path so the class of path survives as evidence while the identifying remainder does not. It neither posts the raw path nor silently drops the evidence.",
+			"files": [],
+			"assertions": [
+				"Recognizes that the body it composed carries a machine-local path and that posting it raw is the defect being reported",
+				"Uses the skill's redaction option rather than posting the raw path",
+				"Does NOT silently delete the evidence — the masked form still shows what kind of path it was",
+				"Does not route around the guard by posting through some other mechanism to get the raw string through",
+				"Keeps the report itself type-blind — no priority or type applied despite the urgency in the prompt"
+			]
+		},
+		{
+			"id": 5,
+			"name": "indeterminate-dedup-is-not-a-clean-check",
+			"grounding": "A dedup run whose query yields no distinctive keywords compared nothing. Reading that silence as 'no duplicate' is the same degenerate-silence trap the /adr sweep's indeterminate outcome exists to close.",
+			"prompt": "Before you file it, run the duplicate check on this one — the observation is just 'it doesn't work when you do the thing twice'. Tell me whether we're clear to file.",
+			"expected_output": "The run reports that the dedup check came back indeterminate because the query carried no distinctive keywords, refuses to read that as evidence that no duplicate exists, and re-queries with specific terms drawn from the observation rather than treating the check as discharged.",
+			"files": [],
+			"assertions": [
+				"Reports the outcome as indeterminate rather than as clean, clear, or 'no duplicates found'",
+				"States that an indeterminate result carries no information about whether a duplicate exists",
+				"Names the cause — the query carried no distinctive keywords to compare on",
+				"Re-queries with specific terms rather than proceeding as if the check had passed",
+				"Does not treat a non-zero exit or a failed check as equivalent to 'none'"
+			]
+		},
+		{
+			"id": 6,
+			"name": "a-dedup-hit-becomes-a-note-not-a-twin",
+			"grounding": "One observation, one issue. The duplicate path is where #3945 and #3173 actually happened — both were comment posts, not issue creates.",
+			"prompt": "I want to report that the retry helper drops the abort reason. I think there might already be something open about worker retries and cancellation — check first, and if there is, just make sure whatever we know is on it.",
+			"expected_output": "The run checks for duplicates, finds the existing issue covers the same observation, and adds only what that issue lacks as a note through the skill's guarded note path — rather than filing a second issue or hand-rolling a comment call.",
+			"files": [],
+			"assertions": [
+				"Runs the duplicate check before filing anything",
+				"Judges the candidate itself — opens or reads it rather than treating a keyword overlap as proof of a match",
+				"Adds a note to the existing issue instead of filing a second issue",
+				"Uses the skill's guarded note verb rather than a raw `gh` comment call",
+				"Adds only what the existing issue lacks rather than restating its contents"
+			]
+		}
+	]
+}


### PR DESCRIPTION
Authored through `/skill-creator` against authoring brief #4705, per the one-door ruling (#4637-C).

## What this carries

- `claude-plugins/fabrika/skills/report/SKILL.md` — 103 lines, inside the conventions' 7–140 band.
- `claude-plugins/fabrika/skills/report/contract.md` — the derived CLI spec for three verbs.
- `claude-plugins/fabrika/skills/report/evals/evals.json` — 6 evals / 30 assertions grading the judgment layer, each traced to an incident row. No bar, harness or scorecard — those stay #4649's.

**No verbs are implemented here.** The spec is the deliverable; building it is downstream `write-code`.

## The verbs the contract asks for

| Verb | Purpose |
|---|---|
| `report dedup` | rank open issues that may already cover the observation — three outcomes, all exit 0 |
| `report file` | compose, guard and create the intake issue, then read back what landed |
| `report note` | add a note to an existing issue over the same guarded path |

Three candidates were **considered and rejected** as relay-only wrappers (ADR 0238) and recorded so they are not silently re-proposed: a `report compose` preview verb, a label-vocabulary preflight verb, and a standalone redactor.

## ADR 0238 compliance

Nothing under `claude-plugins/kampus-pipeline/` or `packages/pipeline-cli/` is invoked or named as a dependency. v1 was read for semantics **and scars**; each scar found is named in the contract's grounding and designed out:

- v1's dedup prints *nothing* when it finds no duplicate — byte-identical to a verb that never ran. Every outcome here is a positive token.
- v1 reports a query that tokenizes to nothing as a clean run. That becomes `indeterminate`.
- v1's create prints prose on a machine channel (`tracker: created #N — url`), so callers regex the number back out. This emits a tab-separated bare number.
- v1 has the read-back discipline but applies it to verdict posts, not intake creates — so a create landing without its label reports success.
- v1's filing path never checks the queue label exists, so an adopter repo files outside the queue silently.

## `skill-reviewer` pass

Run **before** this PR opened, per runbook step 5.5. Returned **needs revision** — 13 findings, 6 blocking. All addressed in `bbdf6f67`; the substantive ones:

1. The two writing verbs assigned **different exit codes to identical outcomes**. Now one shared table.
2. The leak refusal and the body-is-a-path refusal were **fused on one code**, so the natural retry (`re-run with --redact`) never terminates on the #3086 case. Now separate codes.
3. **No write-failure was enumerated at all** — it landed on exit 1, making "GitHub refused the write" indistinguishable from "the binary is broken". Now its own code, carrying the recovery instruction (re-run dedup first; the create may have landed).
4. The footer specified its exact bytes and none of its **field sources**, so an implementer's only recourse was v1's `footer.sh` — the artifact the bar forbids opening. Deferral by omission is still deferral. Now fully specified, with two byte-exact examples.
5. The read-back asserted **byte-identical**, an ungrounded claim about GitHub's round-trip; if false it fires on every clean filing. Now normalized, assumption stated.
6. The contract **claimed** the section template had a single home while the skill reproduced all six headings. Now stated honestly as a guarded duplicate.

Also added a structural type-blind guard, with the type/priority vocabulary derived from the repo's own label set rather than a hardcoded list.

## Eval results

12 runs (6 with-skill, 6 baseline), dry-run sandboxed so nothing reached GitHub. **97% ± 8% with skill vs 67% ± 30% baseline (+0.30)**, at +56s and +13k tokens per run.

Honest caveats, because the headline overstates it:

- Only **10 of 30** assertion-instances discriminated. Eval 2 is a **no-op** — both arms behaved identically because this repo's `CLAUDE.md` already carries the type-blind contract, so that eval tests CLAUDE.md, not the skill.
- Two baseline runs self-disclosed reading v1's skill or the harness fixture — contaminated passes.
- One assertion is ungradeable under the harness (it asks the run to open a dedup candidate; the harness exposes titles only).
- Several eval prompts describe defects that do not exist in the repo, so diligent runs verified and declined to file — measuring verification rather than the filing behaviour intended. That is an eval-design flaw to fix in the next iteration, not a skill result.

The runs earned their keep by falsifying the spec twice: `--redact` collapsed every temp root to a single marker, destroying the evidential shape it claimed to preserve (fixed in `5c8fd59b`), and `indeterminate` firing only at zero surviving tokens was too narrow.

## Two things a reviewer should know

- **Bare-binary resolution is an open blocker, not an assumption.** `cli-invocation-guard`'s own source records that a bare binary name is not on PATH where pipeline agents spawn (ADR 0207), so until #4650 lands a mechanism, every fence in this skill exits 127. Recorded in the contract header so it is tracked rather than discovered later. An eval run confirmed it empirically — and stopped correctly rather than routing around it.
- **A skill named `report` already exists in v1**, model-invoked with overlapping triggers. The collision is dormant only by configuration (`kampus-pipeline@kampus` is `false`; fabrika has no marketplace entry). This description is deliberately differentiated as a mitigation; retiring v1's belongs to the cutover, not to this brief, which treats v1 as a frozen baseline.

The conventions' §7 asks rejections to live in a plugin-root `.out-of-scope/`, which does not exist for any fabrika skill yet. Bootstrapping it is corpus-wide work; the three rejections live in the contract until then.

Fixes #4705
