### PR TITLE
fix(pipeline): the required review set can no longer shrink in silence (#4520, #4730)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash disable=SC1007,SC1091
-# Classify the diff: the §CP derivation, the artifact-class probes, and the additive UI probe.
+# Classify the diff: the §CP derivation, then the artifact-class + UI answer, both from shared verbs.
 #
 # Extracted VERBATIM from ship-it/SKILL.md's Step 0 fenced block (epic #4435 phase 1, #4448).
-# A byte-move, not a rewrite: replacing this glue with `pipeline-cli` verbs is phase 2 (#1929).
+# The class/UI half is no longer that byte-move: it delegates to `pipeline-cli class-probe classify`
+# rather than re-deriving a second, smaller answer beside it (#4730 — see the block below).
 #
 # DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
 #   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh <REPO> <PR>
@@ -46,18 +47,9 @@ if ! cp_changed_files "$REPO" "$PR"; then
   exit 1
 fi
 FILES="$CP_FILES"   # proven-arrived, scope already emitted ($CP_FILES_N files) per §ZS #1
-# NON-TRIVIALITY ASSERT (#4401) — single-sourced in §CLASS of gh-issue-intake-formats.md; copied
-# here verbatim because Step 0 runs as one shell block. EVERY boundary this step strips out of a
-# network read goes through it before anything gates on it: an empty or prefix-carrying value still
-# COMPILES, and `grep -E ""` matches every path while `grep -Ev ""` matches none, both at exit 0.
-accept_re() {   # $1=name, $2=resolved value, $3=fail-closed default
-  case "$2" in
-    *"$1='"*) : ;;   # the assignment prefix survived the strip ⇒ not a pattern, a whole line
-    *) if [ "${#2}" -ge 4 ]; then printf '%s' "$2"; return 0; fi ;;
-  esac
-  printf 'TRIVIAL-GATE-BOUNDARY: %s did not resolve to a usable pattern — failing closed.\n' "$1" >&2
-  printf '%s' "$3"
-}
+# §CLASS's NON-TRIVIALITY ASSERT used to live here, guarding the gate boundaries this step stripped
+# out of a network read itself. It went with them: this step no longer resolves a boundary regex —
+# the shared verbs below do, each behind its own copy of that assert.
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)/claude-plugins/kampus-pipeline}/bin/pipeline-cli"
 # Could-not-run is UNKNOWN, never a discharge (§CLI, #3314). The catch-all below would hold an
@@ -118,72 +110,47 @@ elif [ "$CP_STATE" = "content-undetermined" ]; then
 elif [ "$CP_STATE" != "not-control-plane" ]; then
   echo "BLOCKING (§CP state '$CP_STATE' ⇒ not proven ordinary, held)"   # `unknown`, anything unenumerated, and the EMPTY STRING a failed invocation yields
 fi
-# The has-code/has-docs/has-skills probes are single-sourced as canonical HAS_*_RE= lines in
-# gh-issue-intake-formats.md §CLASS and re-resolved from origin/main here (the #981 idiom, same as
-# UI_RE below and as the §CP boundary cp-classify re-resolves internally) so this snapshot can't
-# mis-classify — and so the reviewer (which consumes the SAME
-# lines) fans across every present class in lockstep with what ship-it requires (#2383). The reviewer
-# and this step both run `pipeline-cli class-probe classify` (which parses these SAME §CLASS lines —
-# no third copy) as the deterministic class set, so `required == dispatched` can't diverge by an
-# eyeball miss the way `.glossary/**` did on PR #2430 (#2434). FAIL CLOSED: an unreadable source ⇒
-# dispatch/require the gate. The literals below are the fail-closed reference, NOT the live decision
-# source — §CLASS is the source:
-#   gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' | pipeline-cli class-probe classify
-HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'
-HAS_SKILLS_RE='^claude-plugins/[^/]+/(skills|agents)/|^\.claude-plugin/'
-HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'
-HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'
-CLASS_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
-reresolve_re() { live="$(printf '%s\n' "$CLASS_RAW" | grep "^$1=" | head -n1 || true)"; if [ -z "$live" ]; then printf '%s' "$2"; else accept_re "$1" "$(printf '%s' "$live" | sed "s/^$1='//; s/'\$//")" "$2"; fi; }
-HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"
-HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
-HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed: exclude NOTHING ⇒ every path reaches the doc test
-HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed: every path is a doc
-# `if … then … fi`, not `… && echo`: a class the diff does NOT carry is this probe's ORDINARY answer,
-# and with `&& echo` the failing `grep` is the last command executed — so a docs-only PR would leave
-# this script's exit status at 1 and §SHARED's "read the status first, non-zero is UNKNOWN" rule
-# would make a perfectly good classification unreadable (rule 4). The predicates are byte-unchanged.
-if echo "$FILES" | grep -Eq "$HAS_SKILLS_RE"; then echo "has-skills"; fi   # → review-skill (ADR 0073/0150); §CP-blocking for merge via the cp-classify derivation above
-if echo "$FILES" | grep -Eq "$HAS_CODE_RE"; then echo "has-code"; fi       # → review-code; the has-code roots agree with the docs-exclusion below in lockstep (§CLASS/§DOC, #663/#919/#1987)
-if echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE"; then echo "has-docs"; fi   # → review-doc; carve out code roots/skills/.glossary first, then test for a doc path (§DOC contract)
-# No-class fail-closed (#2765): a NON-EMPTY diff whose files match NONE of the three classes above
-# — root tooling outside the code roots (biome-plugins/**, biome.jsonc, turbo.json) — must NOT ship
-# un-gated. `pipeline-cli class-probe classify` (the live decision source above) folds this in: any
-# unclassified changed file rides has-code → review-code, so a non-empty diff never requires zero
-# gates. This is the §CLASS "no-class fail-closed" rule, NOT a widened HAS_CODE_RE (that is #2761).
-# UI probe → review-design (ADDITIVE, not a class): a changed path under apps/web/src — the
-# rendered frontend surface (React components, styles, tokens, routes). `pipeline-cli class-probe
-# classify` above ALSO emits `has-ui` (it parses this same UI_RE from its single source,
-# ship-it/SKILL.md) — so the reviewer fan dispatches review-design off the SAME deterministic probe
-# it fans the class gates from, rather than eyeballing the files and skipping it (the #2483 deadlock;
-# #2485). Like the §CP boundary and GUARD_ADR_RE (both re-resolved inside their shared verbs above),
-# the literal below is the fail-closed REFERENCE + the validate-gate-path-drift lockstep target, NOT
-# the live decision source: it is re-resolved from
-# origin/main right after, so an injected skill snapshot that predates the review-design gate can't
-# silently DROP the UI probe and slip a UI PR past the gate (#2341 — the #981 idiom, previously only
-# on §CP/GUARD, now extended to UI_RE). ship-it/SKILL.md@main's `UI_RE=` line is the ONE live source;
-# reviewer.md, class-probe, AND review-design's Step 0 off-ramp all re-resolve the SAME line from the
-# same ref, so required-gate == dispatched-gate == satisfiable-gate holds by construction — all sides
-# read live main, not independently-aging snapshots. When a second app worker is added, generalize
-# this one live UI_RE to apps/**/src and every side tracks it.
-# SCOPE (#2470): UI_RE is `^apps/web/src/` ONLY — a `.tsx`/`.css` OUTSIDE apps/web/src (a Hono
-# server-JSX file, a `.tsx` test fixture, a non-web `.css`) has no rendered surface, so it is NOT
-# design-gate work and must NOT mint a required review-design. The earlier `|\.tsx$|\.css$` branches
-# made the *require* predicate a superset of review-design's own dispatch/off-ramp predicate
-# (`^apps/web/src/`): a non-web `.tsx` was required-but-unroutable — the dispatched review-design run
-# off-ramped with no marker and ship-it deadlocked on a review-design PASS no run could produce.
-# IN-SRC TEST CARVE-OUT (#3071): a change whose apps/web/src paths are ALL test/spec files renders no
-# surface, so it must NOT mint a required review-design either — the src-colocated `*.test.tsx` next to
-# a component (the established sibling-colocation convention) stalled #3046/#3047 at ship on a gate no
-# run could satisfy. ERE (grep -E) has no negative lookahead, so a single UI_RE can't express "under
-# src, but not a test" — mirror §CLASS's has-docs carve-then-test: strip test/spec files FIRST, THEN
-# test for a UI path. A real component (apps/web/src/**/*.tsx non-test) or a mixed component+test diff
-# survives the carve and STILL gates; only an all-test/spec src diff is exempted.
-UI_RE='^apps/web/src/'
-UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
-UI_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
-UI_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_RE=' | head -n1 || true)"
-UX_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_EXCLUDE_RE=' | head -n1 || true)"
-if [ -n "$UI_LIVE" ]; then UI_RE="$(accept_re UI_RE "$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")" '.')"; else UI_RE='.'; fi   # FAIL CLOSED: can't read origin/main's UI_RE — or it resolves TRIVIAL — ⇒ '.' ⇒ every path UI-affecting ⇒ REQUIRE review-design, never silently skip (#2341/#4401)
-if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(accept_re UI_EXCLUDE_RE "$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")" '$^')"; else UI_EXCLUDE_RE='$^'; fi   # FAIL CLOSED: unreadable or trivial ⇒ '$^' never-match ⇒ carve out NOTHING ⇒ every apps/web/src path (incl. tests) gates review-design
-if echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE"; then echo "has-ui"; fi   # carve test/spec first, THEN require review-design ALONGSIDE the class gate(s)
+# THE CLASS SET IS `class-probe`'s ANSWER, PRINTED — one derivation, not two (#4730, finishing #2765).
+#
+# This step used to re-implement the §CLASS probes here: four re-resolved HAS_*_RE literals plus a
+# re-resolved UI_RE, three `grep -Eq` class tests and one UI test. That copy answered a STRICT SUBSET
+# of `class-probe`'s, in one direction only — its failure mode on a file matching none of the three
+# predicates was SILENCE, and silence subtracts a class. `class-probe` does the opposite in code
+# (`files.some(isCode) || files.some((f) => !isClassified(f))`), so an unclassified file rides
+# has-code there and vanished here. On PR #4724 the copy printed `has-skills` alone where the probe
+# printed `has-code, has-skills` — the three `claude-plugins/fabrika/{README.md,docs/**}` files are
+# under no code root, under no `skills/`|`agents/` segment, and carved out of the doc test, so they
+# classified nowhere. Any plugin home carrying docs beside its skills reproduces it.
+#
+# The rule was never dropped here — it was never written here. The commit closing #2765 added it to
+# this step as five comment lines and zero executable lines, i.e. BORN DEAD, and stated the design
+# intent in the same breath: the rule "lives once in the shared class-probe core that ship-it Step 0
+# and the reviewer fan both run". Printing the probe's output is therefore #2765 finished, not a
+# redesign — and it is the same verb Step 2 re-derives the required set from, so Step 0's printed set
+# and Step 2's enforced set are now identical BY CONSTRUCTION rather than by matched maintenance.
+#
+# The HAS_*_RE / UI_RE literals are gone from this file along with the derivation they served. That
+# does NOT remove drift detection: `validate-gate-path-drift.sh` locks each boundary's CANONICAL
+# (invariants 1b/1d, in gh-issue-intake-formats.md §CLASS and ship-it/SKILL.md) against the typed
+# const in packages/pipeline-cli/src/gate-boundaries.ts, and 1c value-locks whatever copies exist.
+# A copy that no longer exists cannot drift; the anchor it was checked against is untouched.
+CLASS_OUT="$(printf '%s\n' "$FILES" | "$PCLI" class-probe classify)" || {
+  echo "BLOCKING (class-probe could not classify ⇒ required-gate set UNKNOWN, held — ADR 0092 §ZS)"
+  echo "STOP: classification unresolved — refuse to enqueue and report the failed probe; do NOT read this as 'no gates required'."
+  exit 1
+}
+# NO-CLASS FAIL-CLOSED (#2765) — as EXECUTABLE CODE, which is the whole point. Its operands come from
+# two different origins, which is what makes it able to fire: the file COUNT is §CPREAD's ($CP_FILES_N,
+# already proven ≥ 1 — `cp_changed_files` fails closed on a zero-length list), the class SET is
+# class-probe's stdout. A non-empty diff that spans zero classes would require zero gates, i.e. a
+# vacuous conjunction — an un-gated merge reported as a clean one. `class-probe` folds the rule in
+# (an unclassified file rides has-code), so reaching this branch means the probe itself answered
+# emptily; that is UNKNOWN, and UNKNOWN is never "no gates required".
+if [ -z "$CLASS_OUT" ]; then
+  echo "BLOCKING ($CP_FILES_N changed file(s) but the class set came back EMPTY ⇒ zero required gates would be a vacuous conjunction, held — §CLASS no-class fail-closed, #2765/#4730)"
+  echo "STOP: classification unresolved — refuse to enqueue; do NOT read this as 'no gates required'."
+  exit 1
+fi
+# One class word per line, `has-ui` last when the diff renders a surface — the probe's own emission
+# order, passed through unaltered. Carry THIS set into Step 2 (which re-derives it from the same verb).
+printf '%s\n' "$CLASS_OUT"

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
@@ -31,7 +31,7 @@ if [ -z "$ROOT" ]; then
 fi
 PCLI="$ROOT/claude-plugins/kampus-pipeline/bin/pipeline-cli"
 if [ ! -x "$PCLI" ]; then
-	echo "FAIL: pipeline-cli shim not executable at claude-plugins/kampus-pipeline/bin/pipeline-cli — the parity compare has no reference answer"
+	echo "FAIL: the CLI shim is missing or not executable at claude-plugins/kampus-pipeline/bin/pipeline-cli — restore it (chmod +x); without it the parity compare has no reference answer"
 	exit 1
 fi
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007
+# Reviewer-runnable proof that ship-it Step 0's printed class set EQUALS `class-probe classify`'s —
+# the property #4730 found false, where the step printed a strict SUBSET and nothing noticed.
+#
+# The fixture is the load-bearing part. The old divergence was invisible to any test whose diff
+# classified as *something*, because the failure mode was SILENCE on an unclassified file and silence
+# subtracts a class — a smaller answer is still well-formed, still exit 0. So case 1 below is a diff
+# containing files that classify as NOTHING under the three §CLASS predicates (a plugin home's
+# `README.md` + `docs/**`, beside its `skills/**`): not under a code root, not under a
+# `skills/`|`agents/` segment, and carved out of the doc test. That is PR #4724's exact shape, and
+# any plugin home carrying docs beside its skills reproduces it. Case 2 is a diff where every file
+# classifies, so a harness that passed both would still be distinguishing something real.
+#
+# Hermetic: `gh` is stubbed to serve the fixture as the PR's changed-file list, so this needs no auth
+# and touches no repo state. `pipeline-cli` is REAL — the point is to compare the shipped verb's
+# answer against the step's, and a stubbed probe would compare a stub to itself.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, and no
+# `EXIT` trap — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this
+# harness's whole contract is its exit status.
+set -uo pipefail
+
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$ROOT" ]; then
+	echo "FAIL: could not resolve the repo root from $DIR — refusing to verify against nothing (ADR 0092)"
+	exit 1
+fi
+PCLI="$ROOT/claude-plugins/kampus-pipeline/bin/pipeline-cli"
+if [ ! -x "$PCLI" ]; then
+	echo "FAIL: pipeline-cli shim not executable at claude-plugins/kampus-pipeline/bin/pipeline-cli — the parity compare has no reference answer"
+	exit 1
+fi
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+BIN="$TMP/bin"
+mkdir -p "$BIN" || { echo "FAIL: cannot create the stub dir under $TMP"; exit 1; }
+
+# The hermetic `gh`: serve $FIXTURE for the changed-files endpoint and the REAL working-tree bytes
+# for the two `contents/` reads a §CLASS/UI re-resolution would make, an empty success otherwise.
+# Serving those two for real is what keeps this harness able to fail: a step that re-derived the
+# class set would resolve the genuine boundary regexes and print its genuine (smaller) answer, rather
+# than falling back to the `.`-matches-everything sentinel an empty stub would hand it — which
+# over-dispatches and would mask the very subtraction under test. Both paths travel in the
+# environment because the stub is a separate process.
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    */pulls/*/files*) cat "$FIXTURE"; exit 0 ;;
+    *contents/*gh-issue-intake-formats.md*) cat "$FORMATS_SRC"; exit 0 ;;
+    *contents/*ship-it/SKILL.md*) cat "$SHIPIT_SRC"; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+chmod +x "$BIN/gh" || { echo "FAIL: cannot chmod the gh stub"; exit 1; }
+
+FORMATS_SRC="$ROOT/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md"
+SHIPIT_SRC="$ROOT/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md"
+for f in "$FORMATS_SRC" "$SHIPIT_SRC"; do
+	if [ ! -f "$f" ]; then
+		echo "FAIL: $f is missing — the stub cannot serve the boundary sources, so a subtractive step would be masked by fail-closed sentinels"
+		exit 1
+	fi
+done
+export FORMATS_SRC SHIPIT_SRC
+
+fail=0
+
+# One case: write the fixture, run the step under the stub, and compare its class words against the
+# real probe's answer over the identical list. The two answers come from different processes reading
+# the same input — that is what makes the compare able to fail.
+check() {   # $1=name, $2=expected class words (newline-joined, in probe emission order)
+	name="$1"; expected="$2"
+	got_step="$(PATH="$BIN:$PATH" FIXTURE="$FIXTURE" bash "$DIR/step0-classify.sh" kamp-us/phoenix 4724 2>/dev/null \
+		| grep -E '^(has-code|has-docs|has-skills|has-ui)$' || true)"
+	got_probe="$("$PCLI" class-probe classify --files-from "$FIXTURE" --root "$ROOT" 2>/dev/null || true)"
+	if [ -z "$got_probe" ]; then
+		printf 'BAD   %-34s the reference probe produced NO class set — the compare would be vacuous\n' "$name"
+		fail=1
+		return
+	fi
+	if [ "$got_step" != "$got_probe" ]; then
+		printf 'BAD   %-34s step 0 and class-probe DISAGREE\n  step0:      %s\n  class-probe: %s\n' \
+			"$name" "$(printf '%s' "$got_step" | tr '\n' ' ')" "$(printf '%s' "$got_probe" | tr '\n' ' ')"
+		fail=1
+		return
+	fi
+	if [ "$got_step" != "$expected" ]; then
+		printf 'BAD   %-34s parity holds but the set is not the expected one\n  got:      %s\n  expected: %s\n' \
+			"$name" "$(printf '%s' "$got_step" | tr '\n' ' ')" "$(printf '%s' "$expected" | tr '\n' ' ')"
+		fail=1
+		return
+	fi
+	printf 'ok    %-34s %s\n' "$name" "$(printf '%s' "$got_step" | tr '\n' ' ')"
+}
+
+# 1. THE REGRESSION CASE — plugin docs beside plugin skills. The first two files classify as NOTHING
+#    under the §CLASS predicates and ride has-code only because `class-probe` folds the #2765
+#    no-class rule in. A step that derived its own answer printed `has-skills` alone here.
+FIXTURE="$TMP/plugin-docs.txt"
+cat > "$FIXTURE" <<'FILES'
+claude-plugins/fabrika/README.md
+claude-plugins/fabrika/docs/authoring-brief-contract.md
+claude-plugins/fabrika/docs/cli-interface-convention.md
+claude-plugins/fabrika/skills/adr/SKILL.md
+FILES
+check "plugin docs beside skills (#4730)" "$(printf 'has-code\nhas-skills')"
+
+# 2. THE CONTROL — every file classifies on its own, so this case passed even BEFORE the fix. Keeping
+#    it is what shows case 1 is discriminating rather than the harness being green on everything.
+FIXTURE="$TMP/classified.txt"
+cat > "$FIXTURE" <<'FILES'
+packages/pipeline-cli/src/tools/verdict/command.ts
+.patterns/index.md
+FILES
+check "every file classifies (control)" "$(printf 'has-code\nhas-docs')"
+
+if [ "$fail" -ne 0 ]; then
+	echo "verify-step0-class-parity: FAILED — Step 0's class set is not class-probe's (#4730)"
+	exit 1
+fi
+echo "verify-step0-class-parity: OK — 2 case(s); Step 0 prints class-probe's answer, including on a diff whose files classify as nothing"

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -52,6 +52,7 @@
 import {Console, Effect, FileSystem, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {readStdinTextOrExit} from "../../read-stdin.ts";
+import {coverageDefect, parseRequiredGates} from "./gate-decision.ts";
 import {Github, GithubLive} from "./github.ts";
 import {
 	emissionDefect,
@@ -156,35 +157,28 @@ const read = Command.make(
  * and a piped set that arrives empty (a dropped/undelivered stdin) is indistinguishable from "this
  * PR needs no gates" — the #3786 zero-input class. An explicit flag makes the omission a usage
  * error instead, and an explicitly-empty value still refuses on zero scope below.
+ *
+ * REPEATABLE (`Flag.atLeast(1)` — at least one occurrence, all of them collected), because the
+ * single-valued `Flag.string` this replaces kept only the FIRST `--require` and dropped the rest in
+ * silence: `--require review-code --require review-doc` gated on review-code alone and still printed
+ * `enqueueable: true`, while the byte-identical requirement spelled `--require review-code,review-doc`
+ * correctly refused. Repeated occurrences now UNION into one set, so the two spellings cannot give
+ * opposite answers, and a later occurrence's bogus token reaches the unrecognized-token refusal
+ * instead of vanishing upstream of it (#4520).
  */
 const requireFlag = Flag.string("require").pipe(
 	Flag.withDescription(
-		"the required review namespaces, comma/space separated (`review-code,review-doc` or `code,doc`) — derive with `pipeline-cli class-probe classify --namespaces`",
+		"the required review namespaces — repeatable, and comma/space separated within one occurrence (`--require review-code,review-doc` ≡ `--require review-code --require review-doc`); derive with `pipeline-cli class-probe classify --namespaces`",
 	),
+	Flag.atLeast(1),
 );
 
-/**
- * Parse the required-namespace set, tolerating both shapes the producer emits: the
- * `class-probe classify --namespaces` output (`review-code`) and a bare gate name (`code`). An
- * unrecognized token is a hard input error, never a silently-dropped requirement — dropping one
- * would shrink the conjunction, the exact fail-open this verb exists to prevent.
- */
-const parseRequired = (raw: string): Effect.Effect<ReadonlyArray<VerdictGate>, never> => {
-	const tokens = raw
-		.split(/[\s,]+/)
-		.map((t) => t.trim().toLowerCase())
-		.filter((t) => t.length > 0);
-	const gates: VerdictGate[] = [];
-	for (const token of tokens) {
-		const name = token.startsWith("review-") ? token.slice("review-".length) : token;
-		if (!(GATES as ReadonlyArray<string>).includes(name)) {
-			return fail(
-				`unrecognized required namespace '${token}' — expected review-<gate> or <gate>, one of ${GATES.join(" | ")}. Refusing to drop it from the required set (that would shrink the gate conjunction).`,
-			);
-		}
-		gates.push(name as VerdictGate);
-	}
-	return Effect.succeed(gates);
+/** The pure parse (`gate-decision.ts`) lifted into this verb's fail-closed exit convention. */
+const parseRequired = (
+	occurrences: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<VerdictGate>, never> => {
+	const parsed = parseRequiredGates(occurrences);
+	return parsed._tag === "ok" ? Effect.succeed(parsed.gates) : fail(parsed.reason);
 };
 
 /**
@@ -196,7 +190,9 @@ const parseRequired = (raw: string): Effect.Effect<ReadonlyArray<VerdictGate>, n
  * This is deliberately not expressible as N × `verdict read`: absence is a property of the required
  * SET, so it can only be decided where the set is known. `--require` takes the same set
  * `class-probe classify --namespaces` derives, so a PR spanning an ADR plus a `.glossary/**` row
- * (which rides has-code) needs BOTH review-doc and review-code, not either.
+ * (which rides has-code) needs BOTH review-doc and review-code, not either. It is **repeatable** and
+ * every occurrence unions in, and an affirmative answer is checked to cover the whole distinct set
+ * before it is believed — the two halves of #4520.
  */
 const gate = Command.make(
 	"gate",
@@ -212,6 +208,11 @@ const gate = Command.make(
 		// The full per-namespace decision goes to stdout as JSON (a caller may want to name which
 		// namespace blocked); the single named outcome line goes to stderr, mirroring `read`.
 		yield* Console.log(JSON.stringify(decision));
+		// The coverage assertion, run BEFORE the clearance is believed: the answer must be about as
+		// many distinct namespaces as argv asked about. Union-or-error fixes the one spelling #4520
+		// found; this refuses any path that answers about fewer things than it was asked.
+		const coverage = coverageDefect(requiredGates, decision);
+		if (decision.enqueueable && coverage !== null) return yield* fail(coverage);
 		if (decision.enqueueable) {
 			process.stderr.write(`verdict gate: ${decision.reason}\n`);
 			return;

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.ts
@@ -24,6 +24,7 @@ import {
 	boundHead,
 	compareWriteRecency,
 	GATE_KEYWORD,
+	GATES,
 	isBoundToHead,
 	outcomeCommentId,
 	outcomeSha,
@@ -318,4 +319,73 @@ export const decideGate = (input: GateDecisionInput): GateDecision => {
 			.map((d) => `${d.namespace} (${d.form})`)
 			.join(" + ")} @ ${input.headSha}`,
 	};
+};
+
+/** What `parseRequiredGates` resolved: the union of every occurrence, or the input error that refuses. */
+export type RequiredParse =
+	| {readonly _tag: "ok"; readonly gates: ReadonlyArray<VerdictGate>}
+	| {readonly _tag: "error"; readonly reason: string};
+
+/**
+ * Parse the required-namespace set out of EVERY `--require` occurrence, tolerating both shapes the
+ * producer emits: `class-probe classify --namespaces` output (`review-code`) and a bare gate name
+ * (`code`). The occurrences are UNIONED, so `--require a --require b` and `--require a,b` are the
+ * same required set — the flag-shape parity #4520 found broken.
+ *
+ * Taking `ReadonlyArray<string>` rather than `string` is the whole fix, and it is a type-level one:
+ * the single-valued `Flag.string("require")` handed this function ONE occurrence, so every later
+ * `--require` was dropped by the flag layer, upstream of the unrecognized-token refusal below —
+ * which meant a guard whose stated purpose is "never shrink the gate conjunction" was structurally
+ * unreachable for occurrence 2..n, born dead rather than drifted. With the flag now repeatable
+ * (`Flag.atLeast(1)`), every occurrence reaches this parse and a bogus token in ANY of them refuses.
+ */
+export const parseRequiredGates = (occurrences: ReadonlyArray<string>): RequiredParse => {
+	const tokens = occurrences
+		.flatMap((raw) => raw.split(/[\s,]+/))
+		.map((t) => t.trim().toLowerCase())
+		.filter((t) => t.length > 0);
+	const gates: VerdictGate[] = [];
+	for (const token of tokens) {
+		const name = token.startsWith("review-") ? token.slice("review-".length) : token;
+		if (!(GATES as ReadonlyArray<string>).includes(name)) {
+			return {
+				_tag: "error",
+				reason: `unrecognized required namespace '${token}' — expected review-<gate> or <gate>, one of ${GATES.join(" | ")}. Refusing to drop it from the required set (that would shrink the gate conjunction).`,
+			};
+		}
+		gates.push(name as VerdictGate);
+	}
+	return {_tag: "ok", gates};
+};
+
+/**
+ * The coverage assertion: an AFFIRMATIVE gate answer must be about exactly the namespaces it was
+ * asked about — `decisions` must be one per DISTINCT requested gate, no more and no fewer.
+ *
+ * This is the general form of #4520, and it is the part that outlives the specific spelling.
+ * Repeatable `--require` fixes the one path where a namespace went missing; this refuses ANY future
+ * path that answers about fewer things than it was asked, because the defect's signature is a
+ * *plausible value* rather than an error — the answer runs, exits clean, and is well-formed, just
+ * smaller. The natural guards (did it run? did it exit 0? did it return a set?) are all satisfied by
+ * the wrong answer, so only an explicit count can see it.
+ *
+ * The operands come from two different origins on purpose (`.patterns/skill-script-shell-shape.md`'s
+ * rule, same idea): the requested set is the CLI's own parse of argv, the answered set comes back
+ * over the `Github` service boundary. An assertion that re-derived `decisions` from `requiredGates`
+ * inside `decideGate` would be true by construction and could never fire.
+ *
+ * Applied to a pass only: a refusal already refuses, and its own reason is the more useful one.
+ */
+export const coverageDefect = (
+	requested: ReadonlyArray<VerdictGate>,
+	decision: GateDecision,
+): string | null => {
+	const distinct = new Set(requested);
+	const answered = new Set(decision.decisions.map((d) => d.gate));
+	const missing = [...distinct].filter((g) => !answered.has(g));
+	const extra = [...answered].filter((g) => !distinct.has(g));
+	if (missing.length === 0 && extra.length === 0 && decision.decisions.length === distinct.size) {
+		return null;
+	}
+	return `refused (fail-closed, coverage): the gate answered about ${decision.decisions.length} namespace(s) [${[...answered].join(", ") || "none"}] but was asked about ${distinct.size} [${[...distinct].join(", ") || "none"}]${missing.length > 0 ? ` — NEVER decided: ${missing.join(", ")}` : ""}${extra.length > 0 ? ` — decided unasked: ${extra.join(", ")}` : ""}. A pass that covers fewer namespaces than were required is an un-gated merge reported as a clean one (#4520).`;
 };

--- a/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/gate-decision.unit.test.ts
@@ -1,5 +1,11 @@
 import {assert, describe, it} from "@effect/vitest";
-import {decideGate, decideNamespace, type GateDecisionInput} from "./gate-decision.ts";
+import {
+	coverageDefect,
+	decideGate,
+	decideNamespace,
+	type GateDecisionInput,
+	parseRequiredGates,
+} from "./gate-decision.ts";
 import {isReviewed, type VerdictComment, type VerdictGate} from "./verdict-match.ts";
 
 const HEAD = "15ae9df658ce6225b8b71f22d214cfcabb6b1c9a";
@@ -22,6 +28,16 @@ const decide = (over: Partial<GateDecisionInput>) =>
 		controlPlane: false,
 		...over,
 	});
+
+/**
+ * The parse's gates, with the ok-branch ASSERTED rather than defaulted — a `?? []` here would let a
+ * refusing parse silently gate on zero namespaces, which is the shape of the bug under test.
+ */
+const requiredOf = (occurrences: ReadonlyArray<string>): ReadonlyArray<VerdictGate> => {
+	const parse = parseRequiredGates(occurrences);
+	assert.strictEqual(parse._tag, "ok");
+	return parse._tag === "ok" ? parse.gates : [];
+};
 
 /** The §CP advisory shape ship-it Step 2.§CP resolves: SHA-less line 1, head bound in the body. */
 const advisory = (gate: VerdictGate, sha: string, checkbox = "[PASS]") =>
@@ -689,4 +705,98 @@ describe("`verdict read` and `verdict gate` resolve ONE in-force verdict (#4049)
 			assert.strictEqual(gateResult.decisions[0]?.commentId, decision.commentId);
 		});
 	}
+});
+
+describe("parseRequiredGates — flag-shape parity (#4520)", () => {
+	it("repeated occurrences and one comma-separated occurrence are the SAME set", () => {
+		assert.deepStrictEqual(
+			requiredOf(["review-code", "review-doc"]),
+			requiredOf(["review-code,review-doc"]),
+		);
+	});
+
+	it("the union is order-blind and covers every occurrence, not just the first", () => {
+		assert.deepStrictEqual(requiredOf(["review-code", "review-doc"]), ["code", "doc"]);
+		assert.deepStrictEqual(requiredOf(["skill", "review-code", "doc"]), ["skill", "code", "doc"]);
+	});
+
+	it("a bogus token in a LATER occurrence reaches the token guard (it used to vanish upstream)", () => {
+		const parse = parseRequiredGates(["review-code", "bogus"]);
+		assert.strictEqual(parse._tag, "error");
+		if (parse._tag === "error") assert.include(parse.reason, "shrink the gate conjunction");
+	});
+
+	it("a bogus token in the FIRST occurrence still refuses (the shape that already worked)", () => {
+		assert.strictEqual(parseRequiredGates(["bogus", "review-code"])._tag, "error");
+	});
+
+	it("an explicitly-empty value yields zero gates, which decideGate refuses on zero scope", () => {
+		assert.deepStrictEqual(requiredOf([""]), []);
+		assert.isFalse(decide({requiredGates: []}).enqueueable);
+	});
+});
+
+describe("the repeated --require shape gates on EVERY namespace (#4520 acceptance)", () => {
+	// The live repro: review-code PASSes at head, review-doc has no verdict at all. The old
+	// single-valued flag dropped review-doc and cleared the enqueue; the union must refuse.
+	const codePass = comment({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`});
+
+	it("an absent verdict in the LATER-occurrence namespace refuses", () => {
+		const result = decide({
+			comments: [codePass],
+			requiredGates: requiredOf(["review-code", "review-doc"]),
+		});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "no review-doc PASS");
+	});
+
+	it("a live FAIL in the LATER-occurrence namespace refuses", () => {
+		const result = decide({
+			comments: [
+				codePass,
+				comment({id: 2, body: `review-doc: FAIL @ ${HEAD} — changes-requested`}),
+			],
+			requiredGates: requiredOf(["review-code", "review-doc"]),
+		});
+		assert.isFalse(result.enqueueable);
+		assert.include(result.reason, "latest verdict is FAIL (review-doc)");
+	});
+
+	it("both spellings of the same requirement decide identically", () => {
+		const comments = [codePass];
+		const repeated = decide({
+			comments,
+			requiredGates: requiredOf(["review-code", "review-doc"]),
+		});
+		const commaJoined = decide({
+			comments,
+			requiredGates: requiredOf(["review-code,review-doc"]),
+		});
+		assert.strictEqual(repeated.enqueueable, commaJoined.enqueueable);
+		assert.strictEqual(repeated.reason, commaJoined.reason);
+	});
+});
+
+describe("coverageDefect — an affirmative answer must cover every namespace asked (#4520)", () => {
+	const passing = decide({
+		comments: [comment({id: 1, body: `review-doc: PASS @ ${HEAD} — merge-ready`})],
+	});
+
+	it("no defect when the answer covers exactly the distinct requested set", () => {
+		assert.isNull(coverageDefect(["doc"], passing));
+	});
+
+	it("duplicates in the request are not a defect — the core dedups the set", () => {
+		assert.isNull(coverageDefect(["doc", "doc"], passing));
+	});
+
+	it("a pass that decided FEWER namespaces than were asked is refused, and names the missing one", () => {
+		const defect = coverageDefect(["doc", "code"], passing);
+		assert.isNotNull(defect);
+		assert.include(defect ?? "", "NEVER decided: code");
+	});
+
+	it("a pass that decided a namespace nobody asked for is refused too", () => {
+		assert.include(coverageDefect([], passing) ?? "", "decided unasked: doc");
+	});
 });


### PR DESCRIPTION
Fixes #4520
Fixes #4730

**#4729 is a duplicate of #4520** and is NOT closed by this PR — see *Loose end* at the bottom.

Two ends of one too-small required-review set, on the merge-authorization path. They land
together because neither half is the whole hazard.

---

## Part A — `verdict gate` dropped a namespace on a repeated `--require` (#4520)

`--require` was declared `Flag.string("require")` — **single-valued**. A repeated flag kept the
first occurrence and discarded the rest in silence, and the gate still answered
`enqueueable: true`, exit 0.

Reproduced against PR #4724 at its merged head, where `review-doc` has no verdict at all:

| invocation | answer |
|---|---|
| `--require review-code --require review-doc` | `enqueueable: true`, exit 0 — `review-doc` never mentioned |
| `--require review-code,review-doc` | `enqueueable: false`, exit 1 — refuses on the absent `review-doc` |

The identical required set, opposite answers, decided by spelling alone. Both prior reports
happened to test with every named namespace passing, which is why it stayed invisible.

**The guard that should have caught it was already there and was structurally unreachable.**
`parseRequired` refuses an unrecognized token with *"Refusing to drop it from the required set
(that would shrink the gate conjunction)"* — its docblock names shrinking the conjunction as the
exact fail-open this verb exists to prevent. It only ever received **one** occurrence's string,
so for occurrence 2..n it never ran. Born dead, not drifted. So this is not "add a guard".

### The fix: UNION, via `Flag.atLeast(1)`

Grounded in the flag API, not memory — `effect/unstable/cli`'s `Flag` exposes `atLeast` /
`atMost` / `between` under `@category repetition`, and `atLeast(1)` turns `Flag<string>` into
`Flag<ReadonlyArray<string>>` collecting every occurrence while keeping the flag mandatory
(`packages/pipeline-cli` pins `effect@4.0.0-beta.92`; the combinator delegates to
`Param.atLeast`).

Union over usage-error because union is the shape that makes the two spellings **the same
input** rather than one legal and one rejected — the caller's intent is unambiguous, and a usage
error would break every existing correct repeated-flag caller for no safety gain. A later
occurrence's bogus token now reaches the existing token guard instead of vanishing upstream of
it, which is the property that guard was written for.

Verified live on this branch, both spellings against PR #4724:

```
--require review-code --require review-doc   → enqueueable:false, exit 1, [required: review-code + review-doc]
--require review-code,review-doc             → enqueueable:false, exit 1, [required: review-code + review-doc]
--require review-code --require bogus        → refused: unrecognized required namespace 'bogus' …
```

### The independent check — `coverageDefect`

An affirmative gate answer must be about as many **distinct** namespaces as argv asked about; if
`decisions.length` and the parsed distinct set disagree, the pass is refused and the reason names
what was never decided.

This is the part that outlives the spelling. Union-or-error fixes *this* path; the assertion
refuses **any** future path that answers about fewer things than it was asked — the general form
of a defect whose signature is a *plausible value* rather than an error: it runs, exits clean,
returns a well-formed set, just a smaller one, so every natural guard (did it run? exit 0? return
a set?) is satisfied by the wrong answer.

Its operands come from two different origins deliberately: the **CLI's own parse of argv**
against the decision returned over the `Github` service boundary. An assertion that re-derived
`decisions` from `requiredGates` inside `decideGate` would be true by construction and could
never fire. It is applied to a **pass** only — a refusal already refuses, and its own reason is
the more useful one.

---

## Part B — ship-it Step 0 under-reported the class set (#4730)

`step0-classify.sh` carried a hand-rolled reimplementation of the §CLASS probes: three
`grep -Eq` class tests plus a UI test, over four re-resolved boundary regexes. A changed file
matching none of the three produced **no output at all**, and `class-probe` does the opposite in
code — an unclassified file rides `has-code`. So the shell could only ever answer a **strict
subset**, never a superset. The #2765 no-class rule sat in that file as five comment lines and
zero executable ones.

**Step 0 now prints `class-probe classify`'s output.** That is not a redesign — the commit that
closed #2765 states the rule "lives once in the shared class-probe core that ship-it Step 0 and
the reviewer fan both run", i.e. Step 0 was always meant to delegate. It is also the verb Step 2
already re-derives the required set from, so Step 0's printed set and Step 2's enforced set are
now identical **by construction** instead of by matched maintenance. Two implementations of a
merge-gating question is worse than either bug.

**The no-class rule landed as executable code, not a second comment.** It is a real guard, not a
restatement: it compares the §CPREAD **file count** (`$CP_FILES_N`, already proven ≥ 1 —
`cp_changed_files` fails closed on a zero-length list) against **`class-probe`'s stdout**. Two
origins, so it can fire. A non-empty diff whose class set comes back empty prints `BLOCKING` +
`STOP` and exits 1 — UNKNOWN, never "no gates required".

### The regression harness, and why its fixture is the point

`claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh` — hermetic,
reviewer-runnable, asserts Step 0's printed class words **equal** the real `class-probe`'s over
the same list.

The failure mode is silence and silence subtracts, so a fixture that always classifies as
*something* proves nothing. Case 1 is therefore the plugin-docs-beside-skills shape — a plugin
home's `README.md` + `docs/**` beside its `skills/**`, files that classify as **nothing** under
all three predicates. Case 2 is a diff where every file classifies, kept so a green case 1 is
visibly discriminating rather than the harness being green on everything.

The stub serves the **real** `gh-issue-intake-formats.md` / `ship-it/SKILL.md` bytes for the two
`contents/` reads, not an empty body — an empty body would hand a re-deriving step the
`.`-matches-everything fail-closed sentinel, which over-dispatches and would mask the very
subtraction under test.

**Falsifiability, measured rather than argued.** The pre-fix script run under this harness's stub
on case 1's fixture prints `has-skills` alone, against `class-probe`'s `has-code, has-skills` —
the harness fails on it. Post-fix it prints `has-code`, `has-skills`, matching #4730's AC2 (a
live run against PR #4724's 11-file list gives the same).

### The drift anchor is intact

Removing the `HAS_*_RE` / `UI_RE` literals from this script does not remove drift detection.
`validate-gate-path-drift.sh` locks each boundary's **canonical** (invariants 1b/1d, in
`gh-issue-intake-formats.md` §CLASS and `ship-it/SKILL.md`) against the typed const in
`packages/pipeline-cli/src/gate-boundaries.ts`; 1c value-locks whatever copies exist. A copy that
no longer exists cannot drift, and the anchor it was checked against is untouched. The guard runs
green on this branch — 34 checks, including `UI_RE` / `UI_EXCLUDE_RE` canonical-appears-once in
`ship-it/SKILL.md`, which this PR does not touch.

---

## What this PR does NOT claim

**The executed gate was not weakened by the Step-0 half alone.** ship-it Step 2 re-derives the
required set from the CLI rather than trusting the carried one, and no executable consumer of
`step0-classify` exists. The exposure was the **prose contract** telling an agent to carry the
class set forward, and turning it live needed a second deviation — which is Part A.

So **the pair is the urgency; neither half alone demonstrates an un-gated merge end to end.**
That is why #4730 priced `p1` and #4520 `p0`. This PR does not claim either half "would have
merged a FAIL" on its own.

The reading contract in `ship-it/SKILL.md` ("carry the class set into Step 2") is left unchanged
and is now correct as written, because Step 0 prints the same verb's answer Step 2 re-derives
from. That also keeps this PR inside the freeze exception's scope.

---

## Scope, freeze exception, and §CP

- **v1 freeze exception.** The in-place edit to `claude-plugins/kampus-pipeline/skills/ship-it/`
  runs under the founder's explicit #4650 No-go exception recorded on #4730, **scoped to this
  defect only** — not a general licence to edit v1. Nothing outside the Step-0 classifier and its
  new sibling harness is touched in that tree.
- **CONTROL-PLANE — human approval required at head.** Verified, not assumed:
  `pipeline-cli cp-classify classify --files-file <this PR's file list>` returns
  **`control-plane [path-match]` — BLOCKING (human merge)**, on
  `claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh` matching the live
  `CONTROL_PLANE_RE`. This PR needs a `@kamp-us/control-plane` approval at head and cannot
  auto-merge on a review PASS.

## Verification run on this branch

- `pipeline-cli` suite: **3180 tests / 191 files pass**, including the new cases (flag-shape
  parity, the repeated-shape acceptance set, `coverageDefect`).
- `typecheck` clean; `biome check` clean; `shellcheck -x` clean on both scripts.
- `verify-step0-class-parity.sh`: OK, 2 cases.
- `verify-chain-resolves.sh`: PASS (static, executable, and the `$CP_FLAG` seam).
- `validate-gate-path-drift.sh`: OK, 34 checks.
- `trap-status-guard check` over the plugin corpus: clean (349 files).
- `gh-phoenix lint-skills` over the corpus: clean.
- Live `verdict gate` runs against PR #4724 in both spellings, as tabled above.

## Loose end for the dispatcher — #4729 not closed

#4729 (duplicate of #4520) is still **open**. Closing it is a number-targeting mutation and the
write-code claim guard refused it, verbatim:

```
{"issue":4729,"mine":false,"reason":"no-winner","winner":null,"superseded":[]}
claim: #4729: no authorized claim resolves — NOT mine, back off (default-deny, never a false win).
```

I stopped rather than reasoning past a fail-closed refusal. It needs closing as a duplicate with
a pointer to #4520 by whoever holds that lane. It is deliberately **not** linked with a `Fixes`
keyword here, so nothing closes it silently on merge.

---

## Deviations

This section was owed at PR-open (§DEV) and was not written — round 1 rendered no such row, so this
is a skipped step, not a prior `[N/A]`. It is added in a body-only repair round; the head has not
moved, so every entry below describes the round-1 diff as it stands.

- **Class 3 — known defect left unfixed: #4729 not closed by this PR.** **Said:** #4729 is a
  duplicate of #4520, so the lane should end with it closed. **Did:** this PR left it open, and
  disclosed that only as free prose (*Loose end*, above) rather than here. **Why:** closing it is a
  number-targeting mutation and the write-code claim guard refused it —
  `{"issue":4729,"mine":false,"reason":"no-winner"}` — and a fail-closed refusal is not overridable
  by reasoning. **Disposition:** resolved. The dispatching engine has since closed #4729 as a
  duplicate of #4520. Nothing is outstanding on it; the *Loose end* paragraph is the round-1 record
  and is stale on that point.

- **Class 3 — `coverageDefect` cannot fire against any input reachable today.** **Said:** Part A's
  independent check is presented as the assertion that outlives the spelling fix. **Did:**
  `Github.gate` passes `requiredGates` straight through, and `decideGate` builds `decisions` from a
  `Set` over that same array, so the postcondition is identically `null` for every input reachable
  through the wired call path. **Why:** it constrains an **interface**, not a single call frame —
  implementations of `Github` (test doubles, a future short-circuiting refactor) can violate it.
  That is what separates it from the born-dead shape Part A fixes: the old `parseRequired` guard was
  unreachable *within one call frame*, because `Flag.string` could never hand it a second
  occurrence. This is an ordinary unfired postcondition, and it can only **refuse**, so it carries
  zero false-pass risk. **Disposition:** kept as written, and the genuine gap is named rather than
  argued away — **nothing in this PR stands the wired call site up against a `Github` double**, so
  only the pure predicate is pinned by tests. Coverage of the wired path is not delivered here.

- **Class 2 — the `coverageDefect` docblock cites a rule that does not exist.** **Said:** the
  docblock attributes a "two different origins" rule to `.patterns/skill-script-shell-shape.md`.
  **Did:** no such rule is written there, or anywhere else in the repo — the gate grepped
  `.patterns/` and `.decisions/` for "two different origins" and "two origins" and found **zero**
  hits, twice, in two separate review rounds. The citation is wrong, not merely loose.
  **Disposition:** disclosed, not fixed here. Correcting the docblock is a code change; it would
  move a head that is fully green and carries two head-bound §CP advisory markers, invalidating both
  under ADR 0058 for a comment. A follow-up must either write that rule down as a real pattern or
  drop the citation — as it stands the comment points a reader at a document that will not confirm
  it. **Filed as #4745.**

- **Class 3 — the coverage-refusal path still prints `"enqueueable":true` under exit 1.** **Said:**
  a gate that refuses should not also emit an affirmative answer. **Did:** on the `coverageDefect`
  refusal path stdout still carries `"enqueueable":true` while the process exits 1. **Why:** the
  refusal was added around the existing answer-emitting path instead of restructuring it.
  **Disposition:** left as-is and disclosed with the uncomfortable framing stated plainly — no live
  consumer is affected (ship-it Step 2 reads exit status only), but this is **this PR's own subject
  shape**, a well-formed affirmative value that is not the real answer, appearing inside the fix for
  it. **Filed as #4746.**

- **Class 3 / class 1 — `ship-it/SKILL.md` deliberately untouched, with a known stale line left in
  it.** **Said:** the founder's #4650 No-go exception recorded on #4730 is scoped to **this defect
  only**. **Did:** nothing in `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` was edited —
  including a line this PR makes stale: the `UI_RE` fence describes "the classification shell that
  consumes them", and after this change that shell no longer consumes them. **Why:** editing it
  would spend a narrowly-scoped freeze exception on something outside the defect it was granted for.
  **Disposition:** knowingly left alone; it needs its own ticket, under its own exception or after
  the freeze lifts. **Filed as #4747.**

- **Class 3 — known defect left unfixed: merge-boundary class resolution reads the local file, not
  `origin/main` (#4743).** **Said:** the docblock in `packages/pipeline-cli/src/gate-boundaries.ts`
  states the class regexes are re-resolved from `origin/main`, so a boundary-editing PR is classified
  against MAIN's rules rather than its own — the #981 anti-self-authorization read. **Did:**
  `class-probe` parses §CLASS from the **local file**, and this PR routes Step 0 through
  `class-probe`, so the verb this PR now delegates to is the one carrying that read; the docblock
  still asserts the older behaviour. **Why:** the shift is **pre-existing on `main`**, not introduced
  here. Whether the remedy is restoring the `origin/main` read or correcting the docblock to match
  turns on whether #981's threat model is still live — a decision, and outside this defect's scope.
  **Disposition:** filed as **#4743**, left to triage. Surfaced by this PR's review, durably homed,
  non-blocking.

- **Class 3 — known defect left unfixed: `verify-step0-class-parity.sh` is wired into nothing
  (#4744).** **Said:** the new harness is described above as hermetic and reviewer-runnable, which it
  is. **Did:** nothing invokes it — no CI job runs it, and its filename appears nowhere in the repo
  outside the script itself, while its sibling `verify-chain-resolves.sh` *is* a step in
  `.github/workflows/ci.yml`. A harness nothing runs cannot fail, so it rots silently while reading
  as coverage. **Why:** wiring a CI job is outside the founder's #4650 freeze exception, which is
  scoped to this defect only. **Disposition:** filed as **#4744**, left to triage —
  reviewer-runnable in the meantime, non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


