### PR TITLE
fix(fabrika-cli): adr next/resolve seat an unreadable --dir on its own proven exit code (#4736)

### DIFF
--- a/packages/fabrika-cli/src/adr/next-verb.ts
+++ b/packages/fabrika-cli/src/adr/next-verb.ts
@@ -19,6 +19,15 @@ export const BASE_UNFETCHABLE = 3;
 export const IN_FLIGHT_UNKNOWN = 4;
 /** `--dir` was read and held zero records — zero scope (ADR 0092). */
 export const ZERO_SCOPE = 5;
+/**
+ * `--dir` could not be read at the fetched base ref, so the merged set is UNKNOWN.
+ *
+ * This is a proven outcome, so it takes a `3`+ code and not `1`: a caller that saw a refusal share
+ * the failure-to-invoke code could not tell "the directory is not there at that ref" from "the verb
+ * never ran" (#4208, #4219, #4736). `6` is the lowest code this verb's table had free — `3`, `4` and
+ * `5` already carry other proven outcomes — and `resolve` seats the same state on the same number.
+ */
+export const DIR_UNREADABLE = 6;
 
 export interface NextOptions {
 	readonly dir: string;
@@ -53,7 +62,10 @@ export const runNext = (options: NextOptions): Shell<VerbOutcome> =>
 				);
 			}
 			if (e._tag === "DirUnreadable") {
-				return refuse(FAILED, `adr next: cannot read ${dir} at ${base}: ${e.reason}`);
+				return refuse(
+					DIR_UNREADABLE,
+					`adr next: cannot read ${dir} at ${base}: ${e.reason} — the merged set is UNKNOWN, never "0 records".`,
+				);
 			}
 			if (e._tag === "UnparseableId") {
 				return refuse(FAILED, `adr next: ${dir} holds a record with an unparseable id: ${e.file}`);

--- a/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
@@ -1,7 +1,13 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, tree} from "../fakes.test-support.ts";
-import {BASE_UNFETCHABLE, IN_FLIGHT_UNKNOWN, runNext, ZERO_SCOPE} from "./next-verb.ts";
+import {
+	BASE_UNFETCHABLE,
+	DIR_UNREADABLE,
+	IN_FLIGHT_UNKNOWN,
+	runNext,
+	ZERO_SCOPE,
+} from "./next-verb.ts";
 
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
 
@@ -84,6 +90,25 @@ describe("runNext", () => {
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("ADR 0092");
+	});
+
+	// The two states below are both non-zero and must stay on different codes: an unreadable
+	// directory is a PROVEN refusal, so it may not share `1` with a verb that failed to run
+	// (#4208, #4219, #4736), and it may not be confused with the empty directory that answers 5.
+	it("refuses an unreadable --dir on its own proven code, not on 1", async () => {
+		const out = await run([[/^git ls-tree/, errOut("fatal: not a tree object")]]);
+		expect(out.code).toBe(DIR_UNREADABLE);
+		expect(out.code).not.toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			'adr next: cannot read .decisions at origin/main: fatal: not a tree object — the merged set is UNKNOWN, never "0 records".',
+		);
+	});
+
+	it("keeps an unreadable --dir distinguishable from an empty one", async () => {
+		const unreadable = await run([[/^git ls-tree/, errOut("fatal: not a tree object")]]);
+		const empty = await run([[/^git ls-tree/, okOut("")]]);
+		expect(unreadable.code).not.toBe(empty.code);
 	});
 
 	it("refuses a record whose id cannot be parsed", async () => {

--- a/packages/fabrika-cli/src/adr/resolve-verb.ts
+++ b/packages/fabrika-cli/src/adr/resolve-verb.ts
@@ -29,6 +29,8 @@ export const BASE_UNFETCHABLE = 3;
 export const IN_FLIGHT_UNKNOWN = 4;
 /** `--dir` was read and held zero records — zero scope (ADR 0092). */
 export const ZERO_SCOPE = 5;
+/** `--dir` could not be read at the fetched base ref, so every state is UNKNOWN. See `next-verb.ts`'s `DIR_UNREADABLE` for why this is a `3`+ code and not `1`. */
+export const DIR_UNREADABLE = 6;
 
 export interface ResolveOptions {
 	readonly ids: ReadonlyArray<string>;
@@ -70,7 +72,10 @@ export const runResolve = (options: ResolveOptions): Shell<VerbOutcome> =>
 				);
 			}
 			if (e._tag === "DirUnreadable") {
-				return refuse(FAILED, `adr resolve: cannot read ${dir} at ${base}: ${e.reason}`);
+				return refuse(
+					DIR_UNREADABLE,
+					`adr resolve: cannot read ${dir} at ${base}: ${e.reason} — every state is UNKNOWN, never "absent".`,
+				);
 			}
 			if (e._tag === "UnparseableId") {
 				return refuse(

--- a/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
@@ -1,7 +1,13 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, record, tree} from "../fakes.test-support.ts";
-import {BASE_UNFETCHABLE, IN_FLIGHT_UNKNOWN, runResolve, ZERO_SCOPE} from "./resolve-verb.ts";
+import {
+	BASE_UNFETCHABLE,
+	DIR_UNREADABLE,
+	IN_FLIGHT_UNKNOWN,
+	runResolve,
+	ZERO_SCOPE,
+} from "./resolve-verb.ts";
 
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
 const AMEND_LIST =
@@ -104,6 +110,22 @@ describe("runResolve", () => {
 		const out = await run([[/^git ls-tree/, okOut("")]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unreadable --dir on its own proven code, not on 1", async () => {
+		const out = await run([[/^git ls-tree/, errOut("fatal: not a tree object")]]);
+		expect(out.code).toBe(DIR_UNREADABLE);
+		expect(out.code).not.toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			'adr resolve: cannot read .decisions at origin/main: fatal: not a tree object — every state is UNKNOWN, never "absent".',
+		);
+	});
+
+	it("keeps an unreadable --dir distinguishable from an empty one", async () => {
+		const unreadable = await run([[/^git ls-tree/, errOut("fatal: not a tree object")]]);
+		const empty = await run([[/^git ls-tree/, okOut("")]]);
+		expect(unreadable.code).not.toBe(empty.code);
 	});
 
 	it("refuses an id that is not four zero-padded digits", async () => {


### PR DESCRIPTION
When `fabrika-cli adr next` or `adr resolve` could not read its `--dir` at the fetched base ref, it exited 1 — the code reserved for "you passed a bad flag" or "the verb never started". A caller checking the exit status could not tell a directory that genuinely is not there from a module that failed to load, even though those call for opposite responses. Both verbs now refuse on their own code, 6, so a proven refusal reads as proof.

Part of #4736

## What changed

- `packages/fabrika-cli/src/adr/next-verb.ts` — new `DIR_UNREADABLE = 6`; the `DirUnreadable` branch refuses on it instead of `FAILED`, with the merged set named UNKNOWN in the message.
- `packages/fabrika-cli/src/adr/resolve-verb.ts` — the same, with every state named UNKNOWN.
- One test per verb drives the unreadable-directory path and asserts the proven code, `not.toBe(1)`, and `stdout === ""`; a second per verb asserts unreadable and empty do not share a code.

## Why 6

The interface convention reserves `0` for the answer, `1` for a usage error or a failure to invoke, `127` for a verb that never ran, and `3`+ for each verb's own proven outcomes. "The directory could not be read at the base ref" is a proven outcome, so it needs a `3`+ code (#4208 / #4219 — the distinction this restores).

`adr sweep` already seats its unreadable-corpus refusal on the lowest code free in its own table (3). `next` and `resolve` cannot copy that number: they both spend `3` on an unfetchable base, `4` on an unenumerable in-flight set, and `5` on zero scope. `6` is the lowest free code in each, and both verbs take the same one so the sibling verbs agree. Exit codes are per-verb, so this does not collide with `adr supersede`'s `6`.

## Deviations

- **Class: scope narrowed against the issue's acceptance criteria.** Said: the ACs ask for the code to be assigned in `claude-plugins/fabrika/skills/adr/contract.md` (both exit-status tables plus matching Errors rows) *and* for `packages/fabrika-cli/` to stop returning 1. Did: only the code half. Why: the dispatch binds this lane to `packages/fabrika-cli/` and states the contract is the spec, to be reported against rather than patched by an implementer — which is also the issue's own argument for why the number should not be minted unilaterally. Disposition: `Part of #4736` rather than `Fixes`, so the issue stays open for the spec-owning lane; the chosen codes and byte-for-byte message text are reported on #4736 so the contract can be amended to match.
- **Class: adjacent defect left unfixed.** Said: nothing. Did: left `adr next`'s `UnparseableId` refusal on exit 1. Why: it is the same defect class — a proven refusal on the failure-to-invoke code — but the contract explicitly assigns it `1` today, so changing it would be an implementer overriding the spec, which is the thing this issue objects to. Disposition: reported on #4736 alongside the spec gap, for the contract lane to rule on.
- **Class: message text chosen by the implementer.** Said: the ACs want byte-for-byte message text in the spec. Did: chose the two strings, mirroring `sweep`'s "the outcome is UNKNOWN, never …" shape. Why: the guard cannot ship without a message. Disposition: both strings are quoted verbatim on #4736 so the contract can adopt or overrule them; the tests assert them exactly, so a spec change will red here rather than drift silently.