### PR TITLE
feat(fabrika-cli): the three /report verbs — dedup, file, note (#4748)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1,8 +1,9 @@
 # @kampus/fabrika-cli
 
 The deterministic verb package [fabrika](../../claude-plugins/fabrika/) skills call.
-`fabrika-cli <group> <verb> …` dispatches to a registered verb group; the first group is
-`adr`, which implements the six verbs the `/adr` skill's derived contract specifies.
+`fabrika-cli <group> <verb> …` dispatches to a registered verb group. Two groups are
+registered: `adr`, the six verbs the `/adr` skill's derived contract specifies, and
+`report`, the three the `/report` contract specifies.
 
 ## Who it's for
 
@@ -84,6 +85,40 @@ Three behaviours are worth knowing before you call them:
   decision text is immutable, so a rewrite that would touch any line but `status:` aborts
   with exit 6 and writes nothing.
 
+## The `report` group
+
+The contract these three implement is
+[`claude-plugins/fabrika/skills/report/contract.md`](../../claude-plugins/fabrika/skills/report/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `report dedup` | ranks the open issues that may already cover an observation — `candidates` / `none` / `indeterminate`, all three at exit 0 |
+| `report file` | composes the intake issue from the six sections on stdin, guards it, creates it, and reads back what landed |
+| `report note` | adds a note to an existing issue over the same guarded path, and reads the comment back |
+
+Four behaviours are worth knowing before you call them:
+
+- **The body is a value, never a path.** The two writing verbs take it on **stdin only** —
+  no `--body`, no `--body-file`, no temp file. A flag that accepts a path turns the body
+  into a string the verb could post verbatim, which is exactly how a machine-local path
+  reached a public artifact while the poster read success. A shell redirect is fine: the
+  *shell* reads the file, so what reaches the verb is already the bytes.
+- **An empty stdin is a refusal, not an empty body.** A read that failed exits `1` (the body
+  is UNKNOWN) and a pipe that was read and held nothing exits `3` (a proven refusal). They
+  are never the same answer.
+- **A missing `--label` is a refusal on `dedup` too, not a `none`.** `GET /issues?labels=…`
+  answers HTTP 200 with `[]` for a label that does not exist, so an unchecked `dedup` would
+  print a proven negative over a scope of zero — the fail-open ADR 0092 forbids. Both
+  writing and reading verbs check the label first and exit `7` when it is absent
+  ([#4752](https://github.com/kamp-us/phoenix/issues/4752)).
+- **The write is not finished until it is read back.** A create call's own response is the
+  server echoing the request; exit `9` is the landed artifact failing to match what was
+  composed.
+
+Intake applies **no type and no priority**, and that is defended mechanically rather than in
+prose: exit `10` refuses a `--label` or a title prefix that resolves to the target repo's own
+type/priority vocabulary.
+
 ## Development
 
 ```bash
@@ -94,7 +129,7 @@ pnpm --filter @kampus/fabrika-cli build       # tsc -p tsconfig.build.json
 
 A verb is a **pure function of its dependencies** — the `*-verb.ts` modules compute a
 `VerbOutcome` (exit code, stdout, stderr) and never write a stream or exit. The Effect CLI
-layer in [`src/adr/command.ts`](./src/adr/command.ts) does both. That split is what makes
+layer in each group's `command.ts` does both. That split is what makes
 each refusal as deterministically testable as each answer, which is why the tests can drive
 an unreadable directory, a `gh` that exits 0 with the wrong bytes, and a base ref that
 cannot be fetched — inputs a real tree cannot be asked to produce on demand.
@@ -108,3 +143,9 @@ satisfied by the one `NodeServices.layer` [`src/run.ts`](./src/run.ts) provides.
 substitutes those same services rather than a hand-rolled double, so the seam under test is
 the seam production uses. A read that could not be performed fails on the `E` channel — it
 never resolves to an empty value a caller could forget to distinguish from a real one.
+
+The one exception is **fd 0**, which stays a raw `node:fs` read at the boundary in
+[`src/io/stdin.ts`](./src/io/stdin.ts) — the standing ruling in the same pattern doc, where
+`Stdio.stdin` is a considered-and-declined stream swap rather than a missing service. The
+verbs take the read as an injected effect, so the `EAGAIN` and TTY paths stay testable
+without a real descriptor.

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -1,0 +1,262 @@
+/**
+ * The GitHub surface the `report` verbs read and write: the intake queue, the search index, the
+ * repository's label set, and the issue/comment writes plus their read-backs.
+ *
+ * Everything goes through `gh api` REST and **never GraphQL** — the org's Projects-classic
+ * integration errors out GraphQL issue queries — and **every list read pages**: an unpaginated
+ * first page is a silently short answer, which for a duplicate check is a false `none`.
+ *
+ * Two disciplines this module exists to make unavoidable:
+ *
+ * - **Absent and unreadable are different outcomes.** `gh` reports a 404 and a 502 the same way —
+ *   a non-zero exit — so {@link Existence} splits them on the `(HTTP <n>)` status `gh` prints. A
+ *   caller may only seat a proven "does not exist" refusal on `Absent`; `Unknown` refuses on its
+ *   own code with nothing on stdout.
+ * - **A shape that is not what was asked for is a failure, never an empty result.** Every parser
+ *   validates before anything interprets, because `gh` can exit 0 having printed something else.
+ */
+import {Effect} from "effect";
+import {execCapture} from "./exec.ts";
+import {type Attempt, fail, ok, originRepo, type Shell} from "./git.ts";
+import {isRecord, parseJson} from "./json.ts";
+
+/** A three-way probe: proven present, proven absent, or unreadable — never two of those fused. */
+export type Existence<A> =
+	| {readonly _tag: "Present"; readonly value: A}
+	| {readonly _tag: "Absent"}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+export const present = <A>(value: A): Existence<A> => ({_tag: "Present", value});
+export const absent = <A>(): Existence<A> => ({_tag: "Absent"});
+export const unknown = <A>(reason: string): Existence<A> => ({_tag: "Unknown", reason});
+
+/** The HTTP status `gh` names in `gh: Not Found (HTTP 404)`, or `null` when it named none. */
+export const httpStatusOf = (reason: string): number | null => {
+	const m = /\(HTTP (\d{3})\)/.exec(reason);
+	return m?.[1] === undefined ? null : Number.parseInt(m[1], 10);
+};
+
+/** One issue as the dedup ranking sees it. */
+export interface IssueRow {
+	readonly number: number;
+	readonly title: string;
+}
+
+/** `<number>\t<title>` rows, or `null` when a row is not that shape. */
+export const parseIssueRows = (stdout: string): ReadonlyArray<IssueRow> | null => {
+	const rows: IssueRow[] = [];
+	for (const line of stdout.split("\n")) {
+		if (line === "") continue;
+		const tab = line.indexOf("\t");
+		if (tab <= 0) return null;
+		const number = line.slice(0, tab);
+		if (!/^\d+$/.test(number)) return null;
+		rows.push({number: Number.parseInt(number, 10), title: line.slice(tab + 1)});
+	}
+	return rows;
+};
+
+/**
+ * The target repository, in the precedence the contract states: `--repo`, then
+ * `$CLAUDE_PIPELINE_REPO`, then `$GITHUB_REPOSITORY`, then the `origin` remote. With none
+ * resolvable the caller exits 1 rather than guessing which repo to touch.
+ */
+export const resolveRepo = (
+	explicit: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const named = explicit ?? env.CLAUDE_PIPELINE_REPO ?? env.GITHUB_REPOSITORY ?? "";
+		if (named.trim() !== "") return ok(named.trim());
+		return yield* originRepo;
+	});
+
+/** The current branch ref, or `null` when git cannot say or the head is detached. */
+export const currentBranch: Shell<string | null> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+	const name = r.stdout.trim();
+	return r.ok && name !== "" && name !== "HEAD" ? name : null;
+});
+
+/** Every label name defined in `repo`, paged. Doubles as the type/priority vocabulary source. */
+export const listLabels = (repo: string): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/labels?per_page=100`,
+			"--jq",
+			".[].name",
+		]);
+		if (!r.ok) return fail(r.reason);
+		const names = r.stdout
+			.split("\n")
+			.map((l) => l.trim())
+			.filter((l) => l !== "");
+		return ok(names);
+	});
+
+/** Open issues carrying `label`, paged, with pull requests filtered out. */
+export const openIssuesWithLabel = (
+	repo: string,
+	label: string,
+): Shell<Attempt<ReadonlyArray<IssueRow>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues?state=open&labels=${encodeURIComponent(label)}&per_page=100`,
+			"--jq",
+			'.[] | select(.pull_request | not) | "\\(.number)\t\\(.title)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseIssueRows(r.stdout);
+		return rows === null
+			? fail("`gh api` exited 0 but its output is not a list of issue rows")
+			: ok(rows);
+	});
+
+/**
+ * The search index's open issues for `tokens`.
+ *
+ * GitHub AND-joins search terms, which is why the caller caps the token list — an over-long query
+ * matches nothing and would read back as a clean `none`.
+ */
+export const searchOpenIssues = (
+	repo: string,
+	tokens: ReadonlyArray<string>,
+): Shell<Attempt<ReadonlyArray<IssueRow>>> =>
+	Effect.gen(function* () {
+		const q = `repo:${repo} is:issue is:open ${tokens.join(" ")}`;
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`search/issues?q=${encodeURIComponent(q)}&per_page=100`,
+			"--jq",
+			'.items[] | "\\(.number)\t\\(.title)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseIssueRows(r.stdout);
+		return rows === null
+			? fail("`gh api` exited 0 but its output is not a list of issue rows")
+			: ok(rows);
+	});
+
+export interface IssueRecord {
+	readonly number: number;
+	readonly title: string;
+	readonly body: string;
+	readonly state: string;
+	readonly labels: ReadonlyArray<string>;
+	readonly url: string;
+}
+
+const toIssueRecord = (value: unknown): IssueRecord | null => {
+	if (!isRecord(value)) return null;
+	const {number, title, body, state, labels, html_url: url} = value;
+	if (typeof number !== "number" || typeof title !== "string" || typeof url !== "string") {
+		return null;
+	}
+	const names = Array.isArray(labels)
+		? labels.map((l) => (isRecord(l) && typeof l.name === "string" ? l.name : null))
+		: null;
+	if (names === null || names.includes(null)) return null;
+	return {
+		number,
+		title,
+		body: typeof body === "string" ? body : "",
+		state: typeof state === "string" ? state : "",
+		labels: names as ReadonlyArray<string>,
+		url,
+	};
+};
+
+/** One issue, probed three ways — the 404 that seats a proven refusal is split from a 5xx. */
+export const getIssue = (repo: string, issue: number): Shell<Existence<IssueRecord>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/issues/${issue}`]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404
+				? absent<IssueRecord>()
+				: unknown<IssueRecord>(r.reason);
+		}
+		const record = toIssueRecord(parseJson(r.stdout));
+		return record === null
+			? unknown<IssueRecord>("`gh api` exited 0 but its output is not an issue")
+			: present(record);
+	});
+
+export interface CreatedIssue {
+	readonly number: number;
+	readonly url: string;
+}
+
+/** Create the intake issue carrying exactly one label. */
+export const createIssue = (
+	repo: string,
+	title: string,
+	body: string,
+	label: string,
+): Shell<Attempt<CreatedIssue>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues`,
+			"-f",
+			`title=${title}`,
+			"-f",
+			`body=${body}`,
+			"-f",
+			`labels[]=${label}`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		if (
+			!isRecord(parsed) ||
+			typeof parsed.number !== "number" ||
+			typeof parsed.html_url !== "string"
+		) {
+			return fail("`gh api` exited 0 but its output is not a created issue");
+		}
+		return ok({number: parsed.number, url: parsed.html_url});
+	});
+
+export interface CreatedComment {
+	readonly id: number;
+	readonly url: string;
+}
+
+export const createComment = (
+	repo: string,
+	issue: number,
+	body: string,
+): Shell<Attempt<CreatedComment>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues/${issue}/comments`,
+			"-f",
+			`body=${body}`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		if (!isRecord(parsed) || typeof parsed.id !== "number" || typeof parsed.html_url !== "string") {
+			return fail("`gh api` exited 0 but its output is not a created comment");
+		}
+		return ok({id: parsed.id, url: parsed.html_url});
+	});
+
+/** One comment's body, re-read from the API — the create call's own echo is not evidence. */
+export const getComment = (repo: string, id: number): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/issues/comments/${id}`]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		return isRecord(parsed) && typeof parsed.body === "string"
+			? ok(parsed.body)
+			: fail("`gh api` exited 0 but its output is not a comment");
+	});

--- a/packages/fabrika-cli/src/io/json.ts
+++ b/packages/fabrika-cli/src/io/json.ts
@@ -1,0 +1,20 @@
+/**
+ * The JSON boundary for `gh api` responses.
+ *
+ * **No `effect` import here on purpose.** Parsing an untrusted string needs a native `try/catch`,
+ * and the repo bans that inside Effect control flow (#2736) — so this is the boundary half, and the
+ * Effect seams in `issues.ts` wrap it. A parse that fails resolves to `null`, which every caller
+ * turns into a typed refusal rather than into an empty result.
+ */
+
+/** The parsed value, or `null` when the bytes were not JSON at all. */
+export const parseJson = (text: string): unknown => {
+	try {
+		return JSON.parse(text) as unknown;
+	} catch {
+		return null;
+	}
+};
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/fabrika-cli/src/io/stdin.ts
+++ b/packages/fabrika-cli/src/io/stdin.ts
@@ -1,0 +1,133 @@
+/**
+ * The fd-0 boundary — a body arrives as bytes, and a pipe that could not be read is never empty.
+ *
+ * The read is a raw `node:fs` `readSync` on purpose, which is the standing ruling in
+ * [.patterns/effect-platform-access.md](../../../../.patterns/effect-platform-access.md)
+ * (§"The bright line" — fd 0 stays a raw read at the boundary; `Stdio.stdin` is a
+ * considered-and-declined stream swap, not a missing service). **No `effect` import here**, for the
+ * same reason: the retry loop needs a native `try/catch` around each `readSync`, which is banned
+ * inside Effect control flow (#2736). The CLI adapter lifts {@link readStdin} into an effect, and
+ * the verbs take that effect as an option — so a test drives the `EAGAIN` and TTY paths without a
+ * real descriptor.
+ *
+ * **`Text("")` and `Failed` are different answers and must never collapse.** A non-blocking pipe
+ * throws `EAGAIN` before its producer writes, and swallowing that to `""` makes an unread pipe
+ * byte-identical to an empty one — the caller then decides over evidence it never saw (#3924, and
+ * ADR 0092's zero-scope fail-open). Reimplemented here rather than reused: ADR 0238 bans calling
+ * v1, so its scar is duplicated as behaviour, not as a dependency.
+ */
+import {readSync} from "node:fs";
+
+export type StdinRead =
+	/** Bytes arrived and decoded. `text` may be `""` — a genuinely empty pipe stays an answer. */
+	| {readonly _tag: "Text"; readonly text: string}
+	/** fd 0 carried nothing to read at all: a TTY, or a descriptor that is not attached. */
+	| {readonly _tag: "NoStdin"; readonly reason: string}
+	/** The read itself failed. The body is UNKNOWN. */
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+/** The process-level reads the loop needs, injected so the retry path is testable. */
+export interface StdinIo {
+	readonly isTTY: boolean;
+	/** Read up to `into.length` bytes; returns the byte count, `0` at EOF. Throws an errno error. */
+	readonly read: (into: Uint8Array) => number;
+	readonly sleep: (ms: number) => void;
+	readonly now: () => number;
+}
+
+export interface StdinOptions {
+	/**
+	 * How long the reader tolerates making no progress before giving up loudly. It resets on every
+	 * byte, so a slow producer is fine and only a stalled pipe trips it — which is what keeps
+	 * "retry until it drains" from becoming an unbounded hang.
+	 */
+	readonly idleTimeoutMs?: number;
+	readonly pollMs?: number;
+	readonly chunkBytes?: number;
+}
+
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_MS = 5;
+const DEFAULT_CHUNK_BYTES = 64 * 1024;
+
+/** Errno codes meaning "no data yet", not "this read failed". */
+const RETRYABLE = new Set(["EAGAIN", "EWOULDBLOCK", "EINTR"]);
+/** Errno codes meaning fd 0 is not attached — an absent pipe, not an unread one. */
+const UNATTACHED = new Set(["EBADF", "ENXIO", "ENOTCONN"]);
+
+const errnoOf = (error: unknown): string =>
+	typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+		? error.code
+		: "";
+
+const messageOf = (error: unknown): string =>
+	error instanceof Error ? error.message : String(error);
+
+/** Read fd 0 to EOF. Terminates in every direction: a TTY returns first, EOF ends it, a stall trips. */
+export const readStdinWith = (io: StdinIo, options: StdinOptions = {}): StdinRead => {
+	const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+	const pollMs = options.pollMs ?? DEFAULT_POLL_MS;
+	const chunkBytes = options.chunkBytes ?? DEFAULT_CHUNK_BYTES;
+
+	// A check rather than a deadline: on a TTY the read blocks on keystrokes, which no timeout can
+	// tell apart from a slow producer.
+	if (io.isTTY) return {_tag: "NoStdin", reason: "fd 0 is a TTY — nothing was piped in"};
+
+	const chunks: Uint8Array[] = [];
+	let bytesRead = 0;
+	let lastProgress = io.now();
+
+	for (;;) {
+		const buffer = new Uint8Array(chunkBytes);
+		let n: number;
+		try {
+			n = io.read(buffer);
+		} catch (error) {
+			const code = errnoOf(error);
+			if (RETRYABLE.has(code)) {
+				if (io.now() - lastProgress >= idleTimeoutMs) {
+					return {
+						_tag: "Failed",
+						reason: `fd 0 is a non-blocking pipe that returned ${code} with no data for ${idleTimeoutMs}ms (${bytesRead} bytes so far)`,
+					};
+				}
+				io.sleep(pollMs);
+				continue;
+			}
+			if (UNATTACHED.has(code) && bytesRead === 0) {
+				return {_tag: "NoStdin", reason: `fd 0 is not readable (${code}) — nothing was piped in`};
+			}
+			return {
+				_tag: "Failed",
+				reason: `${code === "" ? "" : `${code}: `}${messageOf(error)} (${bytesRead} bytes so far)`,
+			};
+		}
+		if (n === 0) break;
+		chunks.push(buffer.subarray(0, n));
+		bytesRead += n;
+		lastProgress = io.now();
+	}
+
+	// Decode once over the joined bytes: a multi-byte character split across two reads would be
+	// mangled by per-chunk decoding.
+	const joined = new Uint8Array(bytesRead);
+	let at = 0;
+	for (const chunk of chunks) {
+		joined.set(chunk, at);
+		at += chunk.length;
+	}
+	return {_tag: "Text", text: new TextDecoder("utf-8").decode(joined)};
+};
+
+const sleepSync = (ms: number): void => {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+};
+
+/** {@link readStdinWith} bound to the real process — the one place fd 0 is named. */
+export const readStdin = (): StdinRead =>
+	readStdinWith({
+		isTTY: process.stdin.isTTY === true,
+		read: (into) => readSync(0, into, 0, into.length, null),
+		sleep: sleepSync,
+		now: () => Date.now(),
+	});

--- a/packages/fabrika-cli/src/io/stdin.unit.test.ts
+++ b/packages/fabrika-cli/src/io/stdin.unit.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from "vitest";
+import {readStdinWith, type StdinIo} from "./stdin.ts";
+
+const errno = (code: string): Error => Object.assign(new Error(code), {code});
+
+/** A scripted fd 0: each entry is either bytes to hand back or an errno to throw. */
+const io = (
+	script: ReadonlyArray<string | Uint8Array | Error>,
+	overrides: Partial<StdinIo> = {},
+): StdinIo & {clock: {now: number}} => {
+	const encoder = new TextEncoder();
+	const queue = [...script];
+	const clock = {now: 0};
+	return {
+		clock,
+		isTTY: false,
+		read: (into) => {
+			const next = queue.shift();
+			if (next === undefined) return 0;
+			if (next instanceof Error) throw next;
+			const bytes = typeof next === "string" ? encoder.encode(next) : next;
+			into.set(bytes, 0);
+			return bytes.length;
+		},
+		sleep: (ms) => {
+			clock.now += ms;
+		},
+		now: () => clock.now,
+		...overrides,
+	};
+};
+
+describe("readStdinWith", () => {
+	it("reads a pipe to EOF", () => {
+		expect(readStdinWith(io(["hello "]))).toEqual({_tag: "Text", text: "hello "});
+	});
+
+	it('returns Text("") for a pipe that genuinely carried nothing', () => {
+		expect(readStdinWith(io([]))).toEqual({_tag: "Text", text: ""});
+	});
+
+	it("retries EAGAIN instead of swallowing it to empty (#3924)", () => {
+		const read = readStdinWith(io([errno("EAGAIN"), errno("EAGAIN"), "late bytes"]));
+		expect(read).toEqual({_tag: "Text", text: "late bytes"});
+	});
+
+	it('gives up LOUDLY on a stalled pipe — Failed, never Text("")', () => {
+		const read = readStdinWith(io([errno("EAGAIN"), errno("EAGAIN")]), {
+			idleTimeoutMs: 10,
+			pollMs: 20,
+		});
+		expect(read._tag).toBe("Failed");
+		expect(read._tag === "Failed" && read.reason).toContain("EAGAIN");
+	});
+
+	it("returns before the first read on a TTY, so an interactive run never hangs", () => {
+		const read = readStdinWith(io(["never reached"], {isTTY: true}));
+		expect(read).toEqual({_tag: "NoStdin", reason: "fd 0 is a TTY — nothing was piped in"});
+	});
+
+	it("separates an unattached descriptor from a failed read", () => {
+		expect(readStdinWith(io([errno("EBADF")]))._tag).toBe("NoStdin");
+		expect(readStdinWith(io([errno("EIO")]))._tag).toBe("Failed");
+	});
+
+	it("decodes once over the joined bytes, so a split multi-byte character survives", () => {
+		const bytes = new TextEncoder().encode("sözlük");
+		// `ö` is two bytes at offset 1; splitting between them is what per-chunk decoding mangles.
+		const read = readStdinWith(io([bytes.subarray(0, 2), bytes.subarray(2)]));
+		expect(read).toEqual({_tag: "Text", text: "sözlük"});
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -16,9 +16,10 @@
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
 import {adrCommand} from "./adr/command.ts";
+import {reportCommand} from "./report/command.ts";
 
 /** A registered verb group: a top-level `Command` whose name is the `fabrika-cli <name>` selector. */
 export type VerbGroup = Command.Command<any, any, object, unknown, NodeServices.NodeServices>;
 
 /** The registered groups, in the order they list under `--help`. */
-export const registeredGroups: ReadonlyArray<VerbGroup> = [adrCommand];
+export const registeredGroups: ReadonlyArray<VerbGroup> = [adrCommand, reportCommand];

--- a/packages/fabrika-cli/src/report/codes.ts
+++ b/packages/fabrika-cli/src/report/codes.ts
@@ -1,0 +1,45 @@
+/**
+ * The one exit table `report file` and `report note` allocate from, so a code means the same thing
+ * whichever verb produced it. A verb that cannot reach a code leaves it unused rather than
+ * compacting the range — a gap is cheaper than a collision.
+ *
+ * `0`, `1` and `127` are the interface convention's reserved codes (see `../verb.ts`); everything
+ * here is `3` and up, the band a verb owns for outcomes it PROVED.
+ */
+
+/** Stdin was read and held nothing. Distinct from a read that failed, which is `1`. */
+export const EMPTY_STDIN = 3;
+/** A required section is missing, out of order, or empty. `report file` only. */
+export const BAD_SECTIONS = 4;
+/** The body carries a machine-local path and `--redact` was not given. */
+export const LEAKED_PATH = 5;
+/**
+ * The body is a bare `@` path reference — **not** redactable.
+ *
+ * Separate from {@link LEAKED_PATH} because the fixes are opposite: the caller's loop on a path
+ * refusal is *re-run with `--redact`*, and on a body that IS a path that loop never terminates.
+ */
+export const BARE_AT_PATH = 6;
+/** The write target does not exist: `--label` in the repo, or `--issue`. */
+export const NO_TARGET = 7;
+/**
+ * The write itself failed, so the outcome is **UNKNOWN** — deliberately not `1`.
+ *
+ * A create or comment call that times out may or may not have landed. Seating that on `1` would
+ * make "GitHub refused the write" indistinguishable from "the binary is broken", which is the
+ * verdict-versus-invocation collision the reserved range exists to prevent (#4208, #4219).
+ */
+export const WRITE_UNKNOWN = 8;
+/** The write landed but the read-back does not match. The artifact exists and needs a human. */
+export const READBACK_MISMATCH = 9;
+/** The title or `--label` carries a type or priority classification. `report file` only. */
+export const CLASSIFIED = 10;
+/**
+ * A precondition read failed, so nothing was written and no outcome is proven.
+ *
+ * Not in the contract's table, and allocated here rather than folded into an existing code
+ * (#4752's class): the label-set read is what makes {@link NO_TARGET} and {@link CLASSIFIED}
+ * *proven*, so a failed read of it can be neither. It is not `8` — nothing was attempted — and not
+ * `1`, which would fuse an unreachable GitHub with a bad flag.
+ */
+export const PRECONDITION_UNKNOWN = 11;

--- a/packages/fabrika-cli/src/report/command.ts
+++ b/packages/fabrika-cli/src/report/command.ts
@@ -1,0 +1,154 @@
+/**
+ * The `report` verb group — `fabrika-cli report <dedup|file|note>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives
+ * in the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning
+ * a process.
+ *
+ * **The body is a value, never a path.** There is deliberately no `--body` flag, no `--body-file`
+ * and no temp file: a flag that accepts a path turns the body into a string the verb could post
+ * verbatim, which is how #3086 and #3945 happened. A shell redirect is fine and expected — the
+ * *shell* reads the file, so what reaches the verb is already the bytes.
+ */
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {DEFAULT_LIMIT} from "./dedup.ts";
+import {runDedup} from "./dedup-verb.ts";
+import {runFile} from "./file-verb.ts";
+import {runNote} from "./note-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const DEFAULT_LABEL = "status:needs-triage";
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
+);
+
+const redactFlag = Flag.boolean("redact").pipe(
+	Flag.withDescription(
+		"mask each machine-local path down to its class root and post the masked body, instead of refusing",
+	),
+);
+
+const dedup = Command.make(
+	"dedup",
+	{
+		query: Flag.string("query").pipe(
+			Flag.withDescription("the observation text to check for an already-open issue"),
+		),
+		label: Flag.string("label").pipe(
+			Flag.withDefault(DEFAULT_LABEL),
+			Flag.withDescription(
+				`the intake-queue label whose open issues are read (default: ${DEFAULT_LABEL})`,
+			),
+		),
+		limit: Flag.integer("limit").pipe(
+			Flag.withDefault(DEFAULT_LIMIT),
+			Flag.withDescription(`the maximum number of candidates to print (default: ${DEFAULT_LIMIT})`),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({query, label, limit, repo, json}) {
+		yield* emit(
+			yield* runDedup({
+				query,
+				label,
+				limit,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Rank the open issues that may already cover an observation. First stdout line is the outcome token — candidates | none | indeterminate — and ALL THREE exit 0; a candidates list adds one `<number>\\t<source>\\t<score>\\t<title>` line per entry. Exits 3 (queue unreadable), 4 (search index unreadable), 7 (--label does not exist, so the queue half would scan nothing). Example: fabrika-cli report dedup --query "retry helper swallows the abort reason"',
+	),
+);
+
+const fileCmd = Command.make(
+	"file",
+	{
+		title: Flag.string("title").pipe(
+			Flag.withDescription("the issue title: a short, specific, type-neutral summary"),
+		),
+		label: Flag.string("label").pipe(
+			Flag.withDefault(DEFAULT_LABEL),
+			Flag.withDescription(
+				`the single intake-queue label the new issue carries (default: ${DEFAULT_LABEL})`,
+			),
+		),
+		redact: redactFlag,
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({title, label, redact, repo, json}) {
+		yield* emit(
+			yield* runFile({
+				title,
+				label,
+				redact,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Compose the intake issue from the six sections on STDIN, guard it, create it, and read back what landed. Prints `<number>\\t<url>`. Exits 3 (empty stdin), 4 (bad sections), 5 (machine-local path), 6 (bare @ reference), 7 (no such label), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 10 (title or label classifies), 11 (label set unreadable). Example: fabrika-cli report file --title "Retry helper swallows the abort reason" < body.md',
+	),
+);
+
+const note = Command.make(
+	"note",
+	{
+		issue: Flag.integer("issue").pipe(Flag.withDescription("the issue number to add the note to")),
+		redact: redactFlag,
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, redact, repo, json}) {
+		yield* emit(
+			yield* runNote({
+				issue,
+				redact,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Add a note from STDIN to an existing issue over the same guarded path, then read the comment back. Prints `<comment-id>\\t<url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue), 8 (post failed — UNKNOWN), 9 (read-back mismatch), 11 (issue unreadable). Example: fabrika-cli report note --issue 4312 < note.md",
+	),
+);
+
+export const reportCommand = Command.make("report").pipe(
+	Command.withSubcommands([dedup, fileCmd, note]),
+	Command.withDescription(
+		"File one follow-up observation into the intake queue: check for a duplicate, then compose and post it over a guarded path that refuses a leak, an empty body, or a hand-applied classification",
+	),
+);

--- a/packages/fabrika-cli/src/report/compose.ts
+++ b/packages/fabrika-cli/src/report/compose.ts
@@ -1,0 +1,183 @@
+/**
+ * `report file`'s composition half, pure: the six-section check, the footer, and the
+ * classification refusal.
+ *
+ * **This module owns the validated spelling and order of the sections.** The skill necessarily
+ * names the same six headings — a model cannot author under a section it cannot name — so the two
+ * are a guarded duplicate rather than a single source, and the section refusal is the mechanism
+ * that catches the skill drifting from the verb.
+ */
+
+export const REQUIRED_SECTIONS: ReadonlyArray<string> = [
+	"## Summary",
+	"## What I was doing",
+	"## What I observed",
+	"## Why it matters",
+	"## Pointers",
+	"## Suggested next step (non-binding)",
+];
+
+/** A blank guess beats a misleading one, so the last section alone may carry nothing. */
+const MAY_BE_EMPTY = "## Suggested next step (non-binding)";
+
+export type SectionProblem =
+	| {readonly _tag: "Missing"; readonly heading: string}
+	| {readonly _tag: "Empty"; readonly heading: string}
+	| {readonly _tag: "OutOfOrder"; readonly heading: string; readonly after: string};
+
+interface Seen {
+	readonly heading: string;
+	readonly content: string;
+}
+
+/** The `##` sections of a markdown body, in the order they appear, with their content. */
+const sectionsOf = (body: string): ReadonlyArray<Seen> => {
+	const lines = body.split("\n");
+	const seen: {heading: string; content: string[]}[] = [];
+	for (const line of lines) {
+		const m = /^##\s+(.*?)\s*$/.exec(line);
+		if (m?.[1] !== undefined) seen.push({heading: `## ${m[1]}`, content: []});
+		else seen.at(-1)?.content.push(line);
+	}
+	return seen.map((s) => ({heading: s.heading, content: s.content.join("\n")}));
+};
+
+/**
+ * The first thing wrong with the six sections, or `null`.
+ *
+ * One problem at a time, and in this precedence — missing, then order, then empty — because every
+ * refusal in this skill names exactly one correctable thing, so a second attempt is a correction
+ * rather than a rewrite.
+ */
+export const checkSections = (body: string): SectionProblem | null => {
+	const seen = sectionsOf(body);
+	const headings = seen.map((s) => s.heading);
+
+	for (const required of REQUIRED_SECTIONS) {
+		if (!headings.includes(required)) return {_tag: "Missing", heading: required};
+	}
+
+	const ordered = headings.filter((h) => REQUIRED_SECTIONS.includes(h));
+	for (let i = 1; i < ordered.length; i += 1) {
+		const previous = ordered[i - 1];
+		const current = ordered[i];
+		if (previous === undefined || current === undefined) continue;
+		if (REQUIRED_SECTIONS.indexOf(current) < REQUIRED_SECTIONS.indexOf(previous)) {
+			return {_tag: "OutOfOrder", heading: current, after: previous};
+		}
+	}
+
+	for (const required of REQUIRED_SECTIONS) {
+		if (required === MAY_BE_EMPTY) continue;
+		const section = seen.find((s) => s.heading === required);
+		if (section === undefined || section.content.trim() === "") {
+			return {_tag: "Empty", heading: required};
+		}
+	}
+	return null;
+};
+
+export interface FooterFields {
+	readonly session: string | null;
+	readonly model: string | null;
+	/** A ref, never a path — the only repo-shaped field, and detached HEAD resolves to `null`. */
+	readonly branch: string | null;
+	readonly timestamp: string;
+}
+
+/**
+ * The footer, joined with ` · ` over the **present fields only** — a dropped field takes its
+ * separator with it. There is no placeholder, no `unknown`, and no dangling label.
+ *
+ * `Filed by an agent` is never omitted: it is ADR 0159's never-auto-close signal, and GitHub
+ * authorship cannot serve it because every pipeline-filed issue goes through one shared login.
+ * Privacy is this verb's precondition, not the caller's — no email, no author name, no path.
+ */
+export const renderFooter = (fields: FooterFields): string => {
+	const parts = [
+		"Filed by an agent",
+		fields.session === null ? null : `session \`${fields.session}\``,
+		fields.model === null ? null : `model \`${fields.model}\``,
+		fields.branch === null ? null : `branch \`${fields.branch}\``,
+		fields.timestamp,
+	].filter((p): p is string => p !== null);
+	return `---\n<sub>${parts.join(" · ")}</sub>`;
+};
+
+/** The sections plus the footer, after a blank line. */
+export const composeBody = (sections: string, footer: string): string =>
+	`${sections.replace(/\s+$/, "")}\n\n${footer}\n`;
+
+export interface Vocabulary {
+	readonly typeLabels: ReadonlySet<string>;
+	readonly priorityLabels: ReadonlySet<string>;
+	/** Lowercased bare words a classifying title prefix is matched against. */
+	readonly words: ReadonlyMap<string, "type" | "priority">;
+}
+
+/**
+ * The type and priority vocabulary, **derived from the target repo's own label set** rather than a
+ * hardcoded list that rots.
+ *
+ * Which names count is a shape rule, because the contract does not give one: `type:*` is a type
+ * label, and `priority:*` **or** a bare `p<digits>` is a priority label — the second spelling is
+ * what this repo actually uses (`p0`/`p1`/`p2`), and a rule that only read `priority:` would derive
+ * an empty priority vocabulary here and wave `P0: …` straight through.
+ */
+export const deriveVocabulary = (labels: ReadonlyArray<string>): Vocabulary => {
+	const typeLabels = new Set<string>();
+	const priorityLabels = new Set<string>();
+	const words = new Map<string, "type" | "priority">();
+	for (const label of labels) {
+		const lower = label.toLowerCase();
+		if (lower.startsWith("type:")) {
+			typeLabels.add(label);
+			words.set(lower.slice("type:".length), "type");
+		} else if (lower.startsWith("priority:")) {
+			priorityLabels.add(label);
+			words.set(lower.slice("priority:".length), "priority");
+		} else if (/^p\d+$/.test(lower)) {
+			priorityLabels.add(label);
+			words.set(lower, "priority");
+		}
+	}
+	return {typeLabels, priorityLabels, words};
+};
+
+export const labelKind = (label: string, vocabulary: Vocabulary): "type" | "priority" | null => {
+	if (vocabulary.typeLabels.has(label)) return "type";
+	if (vocabulary.priorityLabels.has(label)) return "priority";
+	return null;
+};
+
+/**
+ * The classifying prefix a title leads with, or `null`.
+ *
+ * The refusal needs **both** conditions: the leading token has a `WORD:` or `[WORD]` shape, and
+ * that word resolves to the repo's vocabulary. Both together, so `BUG: fix retry` refuses while
+ * `Bug reports from the sozluk form are lost` files cleanly — the shape alone would reject a
+ * legitimate title whose first word happens to be a vocabulary term.
+ */
+export const classifyingPrefix = (title: string, vocabulary: Vocabulary): string | null => {
+	const m = /^\s*(?:([A-Za-z][\w-]*):|\[([A-Za-z][\w-]*)\])/.exec(title);
+	const word = m?.[1] ?? m?.[2];
+	if (m === null || word === undefined) return null;
+	return vocabulary.words.has(word.toLowerCase()) ? m[0].trim() : null;
+};
+
+/**
+ * The comparison the read-back asserts on.
+ *
+ * Byte-identity is the intent, but this package does **not** assert that the GitHub issue
+ * round-trip preserves bytes exactly — that would be an unverified claim about a dependency, and
+ * if it is false the read-back refusal fires on every clean filing. Line endings are normalised
+ * to `\n` and per-line trailing whitespace is stripped; tighten to byte-identity only against
+ * evidence from the real API.
+ */
+export const normalizeForReadback = (text: string): string =>
+	text
+		.replace(/\r\n/g, "\n")
+		.split("\n")
+		.map((line) => line.replace(/[ \t]+$/, ""))
+		.join("\n")
+		.replace(/\n+$/, "");

--- a/packages/fabrika-cli/src/report/compose.unit.test.ts
+++ b/packages/fabrika-cli/src/report/compose.unit.test.ts
@@ -1,0 +1,146 @@
+import {describe, expect, it} from "vitest";
+import {
+	checkSections,
+	classifyingPrefix,
+	composeBody,
+	deriveVocabulary,
+	labelKind,
+	normalizeForReadback,
+	REQUIRED_SECTIONS,
+	renderFooter,
+} from "./compose.ts";
+
+const sections = (overrides: Partial<Record<string, string>> = {}): string =>
+	REQUIRED_SECTIONS.map((h) => `${h}\n${overrides[h] ?? "content"}`).join("\n\n");
+
+describe("checkSections", () => {
+	it("accepts the six sections in order", () => {
+		expect(checkSections(sections())).toBeNull();
+	});
+
+	it("accepts an empty suggested-next-step — a blank guess beats a misleading one", () => {
+		expect(checkSections(sections({"## Suggested next step (non-binding)": ""}))).toBeNull();
+	});
+
+	it("names the one missing heading", () => {
+		const body = sections().replace("## Pointers\ncontent", "");
+		expect(checkSections(body)).toEqual({_tag: "Missing", heading: "## Pointers"});
+	});
+
+	it("catches a misspelled heading as the canonical one missing", () => {
+		const body = sections().replace("## What I observed", "## What I Observed");
+		expect(checkSections(body)).toEqual({_tag: "Missing", heading: "## What I observed"});
+	});
+
+	it("names both sides of an ordering violation", () => {
+		const body = [
+			"## Summary\ncontent",
+			"## What I observed\ncontent",
+			"## What I was doing\ncontent",
+			"## Why it matters\ncontent",
+			"## Pointers\ncontent",
+			"## Suggested next step (non-binding)\n",
+		].join("\n\n");
+		expect(checkSections(body)).toEqual({
+			_tag: "OutOfOrder",
+			heading: "## What I was doing",
+			after: "## What I observed",
+		});
+	});
+
+	it("names an empty required section", () => {
+		expect(checkSections(sections({"## Why it matters": "   "}))).toEqual({
+			_tag: "Empty",
+			heading: "## Why it matters",
+		});
+	});
+
+	it("ignores extra sections the reporter added", () => {
+		expect(checkSections(`${sections()}\n\n## Extra\nmore`)).toBeNull();
+	});
+});
+
+describe("renderFooter", () => {
+	it("renders every present field, separated by ` · `", () => {
+		expect(
+			renderFooter({
+				session: "a0bd6818-7dda-4f64-8a1c-56e55c725214",
+				model: "claude-opus-5",
+				branch: "umut/fabrika-report-skill",
+				timestamp: "2026-08-01T14:22:07Z",
+			}),
+		).toBe(
+			"---\n<sub>Filed by an agent · session `a0bd6818-7dda-4f64-8a1c-56e55c725214` · model `claude-opus-5` · branch `umut/fabrika-report-skill` · 2026-08-01T14:22:07Z</sub>",
+		);
+	});
+
+	it("takes each dropped field's separator with it — no placeholder, no dangling label", () => {
+		expect(
+			renderFooter({
+				session: null,
+				model: null,
+				branch: "umut/fabrika-report-skill",
+				timestamp: "2026-08-01T14:22:07Z",
+			}),
+		).toBe(
+			"---\n<sub>Filed by an agent · branch `umut/fabrika-report-skill` · 2026-08-01T14:22:07Z</sub>",
+		);
+	});
+
+	it("never drops the `Filed by an agent` marker — it is ADR 0159's never-auto-close signal", () => {
+		expect(
+			renderFooter({session: null, model: null, branch: null, timestamp: "2026-08-01T14:22:07Z"}),
+		).toBe("---\n<sub>Filed by an agent · 2026-08-01T14:22:07Z</sub>");
+	});
+});
+
+describe("composeBody", () => {
+	it("puts the footer after the sections and a blank line", () => {
+		expect(composeBody("## Summary\nx\n\n\n", "---\n<sub>f</sub>")).toBe(
+			"## Summary\nx\n\n---\n<sub>f</sub>\n",
+		);
+	});
+});
+
+describe("deriveVocabulary", () => {
+	const vocabulary = deriveVocabulary([
+		"type:bug",
+		"type:feature",
+		"p0",
+		"p2",
+		"status:needs-triage",
+		"area:pipeline",
+	]);
+
+	it("derives type and priority from the repo's own labels, not a hardcoded list", () => {
+		expect(labelKind("type:bug", vocabulary)).toBe("type");
+		expect(labelKind("p0", vocabulary)).toBe("priority");
+		expect(labelKind("status:needs-triage", vocabulary)).toBeNull();
+		expect(labelKind("area:pipeline", vocabulary)).toBeNull();
+	});
+
+	it("refuses a title that BOTH has the prefix shape AND resolves to the vocabulary", () => {
+		expect(classifyingPrefix("BUG: fix retry", vocabulary)).toBe("BUG:");
+		expect(classifyingPrefix("[p0] fix retry", vocabulary)).toBe("[p0]");
+	});
+
+	it("files a legitimate title whose first word merely happens to be a vocabulary term", () => {
+		expect(classifyingPrefix("Bug reports from the sozluk form are lost", vocabulary)).toBeNull();
+		expect(classifyingPrefix("Retry helper swallows the abort reason", vocabulary)).toBeNull();
+	});
+
+	it("leaves a prefix shape that names nothing in the vocabulary alone", () => {
+		expect(classifyingPrefix("sozluk: definition editor loses focus", vocabulary)).toBeNull();
+	});
+});
+
+describe("normalizeForReadback", () => {
+	it("normalises line endings and per-line trailing whitespace, and nothing else", () => {
+		expect(normalizeForReadback("a  \r\nb\t\n\n")).toBe("a\nb");
+		expect(normalizeForReadback("a\nb")).toBe("a\nb");
+	});
+
+	it("still separates a body that genuinely differs", () => {
+		expect(normalizeForReadback("a\nb")).not.toBe(normalizeForReadback("a\nc"));
+	});
+});

--- a/packages/fabrika-cli/src/report/dedup-verb.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.ts
@@ -1,0 +1,146 @@
+/**
+ * `report dedup` — rank the open issues that may already cover an observation.
+ *
+ * The verb **supplies an input; it does not judge**, which is why all three outcomes exit 0: the
+ * check is advisory, never a gate on filing (ADR 0181). A duplicate is cheap for triage to close
+ * and a lost observation is gone, so the skill files on ambiguity.
+ *
+ * The two halves are read for different reasons. The **label queue** is read-after-write consistent
+ * and catches an issue filed seconds ago; the **search index** is eventually consistent — it lags
+ * fresh issues but reaches older open issues that have already left the queue.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {listLabels, openIssuesWithLabel, resolveRepo, searchOpenIssues} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {NO_TARGET} from "./codes.ts";
+import {rank, renderCandidate, tokenize} from "./dedup.ts";
+
+/** The intake queue could not be read, so the outcome is UNKNOWN. */
+export const QUEUE_UNREADABLE = 3;
+/** The search index could not be read, so the outcome is UNKNOWN. */
+export const SEARCH_UNREADABLE = 4;
+/**
+ * `--label` does not exist in `--repo`, so the queue half has **no scope** — and a scope of zero
+ * cannot produce a proven negative.
+ *
+ * Not in the contract's exit table, and reported as a spec defect on #4752: a missing label is not
+ * a transport error, so `GET /issues?labels=<missing>` answers HTTP 200 with `[]` and never reaches
+ * {@link QUEUE_UNREADABLE}. It lands on the success path, where an empty queue is read as a fact,
+ * and the verb prints `none` — a proven negative over nothing scanned, which ADR 0092 forbids. The
+ * code is `7` rather than a fresh number so it means what it already means on `report file`: *the
+ * target named by `--label` does not exist in `--repo`*.
+ */
+export {NO_TARGET as LABEL_ABSENT};
+
+export interface DedupOptions {
+	readonly query: string;
+	readonly label: string;
+	readonly limit: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runDedup = (
+	options: DedupOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {label, limit, json} = options;
+
+		if (options.query.trim() === "") return refuse(FAILED, "report dedup: --query is empty.");
+		if (limit < 0) return refuse(FAILED, `report dedup: --limit ${limit} is negative.`);
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"report dedup: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		// The label precondition runs BEFORE either source read, because it is what makes the queue
+		// half's scope non-zero. Reading it here also means an unreadable label set refuses as UNKNOWN
+		// rather than resolving to "the label is missing".
+		const labels = yield* listLabels(repo);
+		if (labels._tag === "Failure") {
+			return refuse(
+				QUEUE_UNREADABLE,
+				`report dedup: cannot read the label set of ${repo}: ${labels.reason} — whether the ${label} queue exists is UNKNOWN, and so is the outcome.`,
+			);
+		}
+		if (!labels.value.includes(label)) {
+			return refuse(
+				NO_TARGET,
+				`report dedup: ${repo} has no "${label}" label — the queue half would scan nothing, so the outcome is UNKNOWN, never "none". Create the label, or pass the one this repo uses.`,
+			);
+		}
+
+		const tokens = tokenize(options.query);
+		if (tokens.length < 2) {
+			const result = rank({tokens, queue: [], search: [], limit, label});
+			const scope = `report dedup: ${repo}, tokens: ${tokens.join(", ") || "(none)"} — neither source was read, because the query cannot discriminate.`;
+			const diagnostics = [scope, `report dedup: ${result.reason}.`];
+			return json
+				? answer(
+						JSON.stringify({
+							outcome: result.outcome,
+							candidates: [],
+							reason: result.reason,
+							tokens,
+							truncated: false,
+							queueCount: 0,
+							searchCount: 0,
+						}),
+						diagnostics,
+					)
+				: answer(result.outcome, diagnostics);
+		}
+
+		const queue = yield* openIssuesWithLabel(repo, label);
+		const search = yield* searchOpenIssues(repo, tokens);
+
+		// The queue is the load-bearing half — it is the one that catches an issue filed seconds ago —
+		// so when both fail its code is the one reported, and the reason names both failures so
+		// neither is hidden by the precedence.
+		if (queue._tag === "Failure") {
+			const also =
+				search._tag === "Failure" ? ` (the search index also failed: ${search.reason})` : "";
+			return refuse(
+				QUEUE_UNREADABLE,
+				`report dedup: cannot read the ${label} queue in ${repo}: ${queue.reason}${also} — the outcome is UNKNOWN, never "none".`,
+			);
+		}
+		if (search._tag === "Failure") {
+			return refuse(
+				SEARCH_UNREADABLE,
+				`report dedup: cannot read the search index for ${repo}: ${search.reason} — the outcome is UNKNOWN, never "none".`,
+			);
+		}
+
+		const result = rank({tokens, queue: queue.value, search: search.value, limit, label});
+		const scope = `report dedup: ${repo}, ${queue.value.length} open issue(s) in the ${label} queue, ${search.value.length} search hit(s); tokens: ${tokens.join(", ")}${result.truncated ? `; list TRUNCATED to --limit ${limit}` : ""}.`;
+		const diagnostics =
+			result.reason === null ? [scope] : [scope, `report dedup: ${result.reason}.`];
+
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome: result.outcome,
+					candidates: result.candidates,
+					reason: result.reason,
+					tokens,
+					truncated: result.truncated,
+					queueCount: queue.value.length,
+					searchCount: search.value.length,
+				}),
+				diagnostics,
+			);
+		}
+		return answer(
+			[result.outcome, ...result.candidates.map(renderCandidate)].join("\n"),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
@@ -1,0 +1,142 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {NO_TARGET} from "./codes.ts";
+import {QUEUE_UNREADABLE, runDedup, SEARCH_UNREADABLE} from "./dedup-verb.ts";
+
+const LABELS = /repos\/o\/r\/labels/;
+const QUEUE = /repos\/o\/r\/issues\?state=open/;
+const SEARCH = /search\/issues/;
+
+const options = {
+	query: "retry helper swallows the abort reason",
+	label: "status:needs-triage",
+	limit: 20,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runDedup({...options, ...overrides}), fakeShell(script).layer));
+
+const labelsOk = [LABELS, okOut("status:needs-triage\ntype:bug\np0")] as const;
+
+describe("runDedup", () => {
+	it("exits 0 with a ranked candidates list", async () => {
+		const out = await run([
+			labelsOk,
+			[QUEUE, okOut("4312\tAbort reason lost when the retry helper re-wraps the request")],
+			[SEARCH, okOut("4088\thttp worker retries do not propagate cancellation")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("candidates");
+		expect(out.stdout).toContain("4312\tqueue\t");
+		expect(out.stdout).toContain("4088\tsearch\t");
+	});
+
+	it("exits 0 on a PROVEN none, printing the token rather than empty stdout", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut("")], [SEARCH, okOut("")]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("none\n");
+		expect(out.stderr.join("\n")).toContain("both sources were read");
+	});
+
+	it("exits 0 on indeterminate below the two-token floor", async () => {
+		const out = await run([labelsOk], {query: "the thing"});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("indeterminate\n");
+		expect(out.stderr.join("\n")).toContain("below the floor of 2");
+	});
+
+	it("REFUSES a --label that does not exist rather than printing `none` over zero scope (#4752)", async () => {
+		const out = await run([[LABELS, okOut("type:bug\np0")]]);
+		expect(out.code).toBe(NO_TARGET);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never "none"');
+	});
+
+	it("never reads either source once the label is proven absent", async () => {
+		const shell = fakeShell([[LABELS, okOut("type:bug")]]);
+		await Effect.runPromise(Effect.provide(runDedup(options), shell.layer));
+		expect(shell.calls.some((c) => QUEUE.test(c) || SEARCH.test(c))).toBe(false);
+	});
+
+	it("refuses an UNREADABLE label set as UNKNOWN — never as `the label is missing`", async () => {
+		const out = await run([[LABELS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(QUEUE_UNREADABLE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("UNKNOWN");
+	});
+
+	it("refuses an unreadable queue — UNKNOWN, never `none`", async () => {
+		const out = await run([
+			labelsOk,
+			[QUEUE, errOut("gh: Not Found (HTTP 404)")],
+			[SEARCH, okOut("")],
+		]);
+		expect(out.code).toBe(QUEUE_UNREADABLE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never "none"');
+	});
+
+	it("refuses an unreadable search index on its own code", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut("")], [SEARCH, errOut("rate limited")]]);
+		expect(out.code).toBe(SEARCH_UNREADABLE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("reports the QUEUE's code when both fail, and names both failures", async () => {
+		const out = await run([
+			labelsOk,
+			[QUEUE, errOut("queue down")],
+			[SEARCH, errOut("search down")],
+		]);
+		expect(out.code).toBe(QUEUE_UNREADABLE);
+		expect(out.stderr.at(-1)).toContain("queue down");
+		expect(out.stderr.at(-1)).toContain("search down");
+	});
+
+	it("refuses a `gh` that exited 0 with output that is not issue rows", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut("not a row")], [SEARCH, okOut("")]]);
+		expect(out.code).toBe(QUEUE_UNREADABLE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("puts the --json payload on STDOUT, with both source counts", async () => {
+		const out = await run(
+			[labelsOk, [QUEUE, okOut("4312\tretry helper abort reason")], [SEARCH, okOut("")]],
+			{json: true},
+		);
+		const payload = JSON.parse(out.stdout);
+		expect(payload.outcome).toBe("candidates");
+		expect(payload.queueCount).toBe(1);
+		expect(payload.searchCount).toBe(0);
+		expect(payload.tokens).toContain("retry");
+		expect(out.stderr.join("")).not.toContain('"outcome"');
+	});
+
+	it("says on stderr when the cap truncated the list", async () => {
+		const rows = Array.from({length: 4}, (_, i) => `${i + 1}\tretry helper abort reason`).join(
+			"\n",
+		);
+		const out = await run([labelsOk, [QUEUE, okOut(rows)], [SEARCH, okOut("")]], {limit: 2});
+		expect(out.stdout.split("\n").filter((l) => l !== "")).toHaveLength(3);
+		expect(out.stderr[0]).toContain("TRUNCATED");
+	});
+
+	it("refuses an empty --query as a usage error", async () => {
+		const out = await run([labelsOk], {query: "   "});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses when no target repo resolves", async () => {
+		const out = await run([[/git remote get-url/, errOut("no origin")]], {env: {}});
+		expect(out.code).toBe(1);
+		expect(out.stderr.at(-1)).toContain("CLAUDE_PIPELINE_REPO");
+	});
+});

--- a/packages/fabrika-cli/src/report/dedup.ts
+++ b/packages/fabrika-cli/src/report/dedup.ts
@@ -1,0 +1,172 @@
+/**
+ * `report dedup`'s tokenizer and ranking, pure and native to fabrika (ADR 0238).
+ *
+ * **All three outcomes are answers and all three exit 0.** `none` is a printed token rather than
+ * empty stdout, because empty stdout is byte-identical to a verb that never ran — which is exactly
+ * how v1's `intake-dedup check` reports finding no duplicate.
+ *
+ * `indeterminate` fires **below a floor of two surviving tokens**, not only at zero. A query that
+ * tokenizes to nothing was never compared; a query that tokenizes to one generic term is AND-joined
+ * into a match on everything or nothing, and neither carries information about *this* observation.
+ * Reporting either as `none` is the degenerate-silence trap this token exists to close.
+ */
+
+/** Beneath this many surviving tokens a run carries no information about the query. */
+export const TOKEN_FLOOR = 2;
+/** GitHub AND-joins search terms, so an over-long query matches nothing. */
+export const MAX_TOKENS = 12;
+export const DEFAULT_LIMIT = 20;
+/** What a shared prefix must reach to count as a match. */
+const PREFIX = 5;
+
+/**
+ * Stopwords in **both** repo languages. Turkish is a product-copy language here, so an
+ * English-only list leaves `bir`/`için`/`ile` as "distinctive" terms and lets a generic Turkish
+ * query clear the floor while discriminating nothing.
+ */
+const STOPWORDS = new Set(
+	`about after again all also and any are because been before being both but can cannot could
+	did does doing done down during each either else even ever every for from further had has have
+	having here how however into its itself just less like made make many may might more most much
+	must never new not now off once one only other our out over own per rather same shall should
+	since some still such than that the their them then there these they this those though through
+	thus too under until upon use used uses using very was way well were what when where whether
+	which while who whom whose why will with within without would yet you your
+	ama ancak bana bazı belki ben bende beni benim bir biri birkaç birşey biz bize bizi bizim bu
+	buna bunda bundan bunu bunun burada çok çünkü da daha de defa değil diğer diye eğer en gibi
+	hem hep hepsi her hiç için ile ise kez ki kim mı mi mu mü nasıl ne neden nerde nerede nereye
+	niçin niye o olan olarak oldu olduğu olsa olsun onlar onları onların onu ise şey şeyden şeyi
+	şeyler şu şuna şunda şundan şunu tüm ve veya ya yani`.split(/\s+/),
+);
+
+/**
+ * Lowercase, split on any run of non-letter non-number characters over the **full Unicode letter
+ * class**, drop short tokens and stopwords, dedupe first-seen.
+ *
+ * The Unicode split is #3255: an ASCII-only tokenizer shreds a Turkish stem into sub-threshold
+ * fragments and drops it, so the search half silently runs on fewer keywords than the caller
+ * supplied.
+ */
+export const tokenize = (text: string, cap = MAX_TOKENS): ReadonlyArray<string> => {
+	const out: string[] = [];
+	for (const raw of text.toLowerCase().split(/[^\p{L}\p{N}]+/u)) {
+		if (raw.length < 3 || STOPWORDS.has(raw) || out.includes(raw)) continue;
+		out.push(raw);
+		if (out.length >= cap) break;
+	}
+	return out;
+};
+
+/**
+ * Whether a query token matches a title token: an exact hit, or a shared prefix of at least five
+ * characters — which is what lets an agglutinative Turkish inflection match a bare stem without a
+ * morphological analyzer while staying off short English derivational overlaps.
+ */
+export const tokensMatch = (query: string, title: string): boolean =>
+	query === title ||
+	(query.length >= PREFIX &&
+		title.length >= PREFIX &&
+		query.slice(0, PREFIX) === title.slice(0, PREFIX));
+
+export type Source = "queue" | "search" | "both";
+export type Outcome = "candidates" | "none" | "indeterminate";
+
+export interface Row {
+	readonly number: number;
+	readonly title: string;
+}
+
+export interface Candidate {
+	readonly number: number;
+	readonly source: Source;
+	readonly score: number;
+	readonly title: string;
+}
+
+export interface RankResult {
+	readonly outcome: Outcome;
+	readonly candidates: ReadonlyArray<Candidate>;
+	readonly reason: string | null;
+	readonly truncated: boolean;
+}
+
+/** How many of the query's tokens the title carries. */
+export const scoreTitle = (tokens: ReadonlyArray<string>, title: string): number => {
+	const titleTokens = tokenize(title, Number.POSITIVE_INFINITY);
+	return tokens.filter((q) => titleTokens.some((t) => tokensMatch(q, t))).length;
+};
+
+export interface RankInput {
+	readonly tokens: ReadonlyArray<string>;
+	readonly queue: ReadonlyArray<Row>;
+	readonly search: ReadonlyArray<Row>;
+	readonly limit: number;
+	readonly label: string;
+}
+
+/**
+ * Rank the two sources into one list.
+ *
+ * The halves are kept for different reasons and so are filtered differently: a queue row is kept
+ * only when its title overlaps, while a **search row already matched server-side on title *or*
+ * body**, so it is kept regardless of its title score. `both` is the strongest duplicate signal.
+ */
+export const rank = (input: RankInput): RankResult => {
+	const {tokens, queue, search, limit, label} = input;
+
+	if (tokens.length < TOKEN_FLOOR) {
+		return {
+			outcome: "indeterminate",
+			candidates: [],
+			reason: `the query yielded ${tokens.length} distinctive token(s), below the floor of ${TOKEN_FLOOR} — an AND-joined query of that shape matches everything or nothing, so nothing about this observation was compared`,
+			truncated: false,
+		};
+	}
+
+	const merged = new Map<number, {title: string; score: number; queue: boolean; search: boolean}>();
+	for (const row of queue) {
+		const score = scoreTitle(tokens, row.title);
+		if (score > 0) merged.set(row.number, {title: row.title, score, queue: true, search: false});
+	}
+	for (const row of search) {
+		const existing = merged.get(row.number);
+		if (existing === undefined) {
+			merged.set(row.number, {
+				title: row.title,
+				score: scoreTitle(tokens, row.title),
+				queue: false,
+				search: true,
+			});
+		} else {
+			merged.set(row.number, {...existing, search: true});
+		}
+	}
+
+	const ranked = [...merged.entries()]
+		.map(([number, entry]): Candidate => {
+			const source: Source =
+				entry.queue && entry.search ? "both" : entry.queue ? "queue" : "search";
+			return {number, source, score: entry.score, title: entry.title};
+		})
+		.sort((a, b) => (b.score !== a.score ? b.score - a.score : b.number - a.number));
+
+	if (ranked.length === 0) {
+		return {
+			outcome: "none",
+			candidates: [],
+			reason: `both sources were read — ${queue.length} open issue(s) in the ${label} queue and ${search.length} search hit(s) — and none matched`,
+			truncated: false,
+		};
+	}
+
+	return {
+		outcome: "candidates",
+		candidates: ranked.slice(0, Math.max(limit, 0)),
+		reason: null,
+		truncated: ranked.length > Math.max(limit, 0),
+	};
+};
+
+/** The line grammar for one candidate: `<number>\t<source>\t<score>\t<title>`. */
+export const renderCandidate = (candidate: Candidate): string =>
+	`${candidate.number}\t${candidate.source}\t${candidate.score}\t${candidate.title}`;

--- a/packages/fabrika-cli/src/report/dedup.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup.unit.test.ts
@@ -1,0 +1,162 @@
+import {describe, expect, it} from "vitest";
+import {MAX_TOKENS, rank, renderCandidate, scoreTitle, tokenize, tokensMatch} from "./dedup.ts";
+
+describe("tokenize", () => {
+	it("lowercases, drops short tokens and English stopwords, and dedupes first-seen", () => {
+		expect(tokenize("The retry helper and the RETRY budget in a worker")).toEqual([
+			"retry",
+			"helper",
+			"budget",
+			"worker",
+		]);
+	});
+
+	it("splits over the full Unicode letter class, so a Turkish stem survives (#3255)", () => {
+		expect(tokenize("sözlük tanımı düzenleyici odağı kaybediyor")).toEqual([
+			"sözlük",
+			"tanımı",
+			"düzenleyici",
+			"odağı",
+			"kaybediyor",
+		]);
+	});
+
+	it("drops Turkish stopwords too — an English-only list leaves them looking distinctive", () => {
+		expect(tokenize("sözlük için bir tanım ve çok şey")).toEqual(["sözlük", "tanım"]);
+	});
+
+	it("caps at 12 tokens, because GitHub AND-joins and an over-long query matches nothing", () => {
+		const query = Array.from({length: 30}, (_, i) => `token${i}`).join(" ");
+		expect(tokenize(query)).toHaveLength(MAX_TOKENS);
+	});
+});
+
+describe("tokensMatch", () => {
+	it("matches on an exact hit", () => {
+		expect(tokensMatch("retry", "retry")).toBe(true);
+	});
+
+	it("matches an agglutinative inflection against a bare stem on a 5-char shared prefix", () => {
+		expect(tokensMatch("tanımı", "tanımlar")).toBe(true);
+	});
+
+	it("stays off a short English derivational overlap", () => {
+		expect(tokensMatch("read", "reader")).toBe(false);
+		expect(tokensMatch("abort", "above")).toBe(false);
+	});
+});
+
+describe("scoreTitle", () => {
+	it("counts how many of the query's tokens the title carries", () => {
+		expect(scoreTitle(["retry", "helper", "abort"], "Abort reason lost in the retry helper")).toBe(
+			3,
+		);
+		expect(scoreTitle(["retry", "helper", "abort"], "Unrelated sozluk focus bug")).toBe(0);
+	});
+});
+
+const tokens = ["retry", "helper", "abort", "reason"];
+
+describe("rank", () => {
+	it("marks a row seen in both sources `both` — the strongest duplicate signal", () => {
+		const result = rank({
+			tokens,
+			queue: [{number: 4312, title: "Abort reason lost when the retry helper re-wraps"}],
+			search: [{number: 4312, title: "Abort reason lost when the retry helper re-wraps"}],
+			limit: 20,
+			label: "status:needs-triage",
+		});
+		expect(result.outcome).toBe("candidates");
+		expect(result.candidates[0]?.source).toBe("both");
+	});
+
+	it("keeps a search row whose TITLE does not overlap — it already matched server-side on the body", () => {
+		const result = rank({
+			tokens,
+			queue: [],
+			search: [{number: 4088, title: "Cancellation is not propagated"}],
+			limit: 20,
+			label: "status:needs-triage",
+		});
+		expect(result.outcome).toBe("candidates");
+		expect(result.candidates).toEqual([
+			{number: 4088, source: "search", score: 0, title: "Cancellation is not propagated"},
+		]);
+	});
+
+	it("drops a queue row whose title does not overlap", () => {
+		const result = rank({
+			tokens,
+			queue: [{number: 4001, title: "Sozluk editor loses focus"}],
+			search: [],
+			limit: 20,
+			label: "status:needs-triage",
+		});
+		expect(result.outcome).toBe("none");
+		expect(result.candidates).toEqual([]);
+	});
+
+	it("ranks by score descending, then by number descending", () => {
+		const result = rank({
+			tokens,
+			queue: [
+				{number: 100, title: "retry helper"},
+				{number: 200, title: "retry helper"},
+				{number: 300, title: "retry helper abort reason"},
+			],
+			search: [],
+			limit: 20,
+			label: "status:needs-triage",
+		});
+		expect(result.candidates.map((c) => c.number)).toEqual([300, 200, 100]);
+	});
+
+	it("caps at --limit and says the list was truncated", () => {
+		const queue = Array.from({length: 5}, (_, i) => ({number: i + 1, title: "retry helper"}));
+		const result = rank({tokens, queue, search: [], limit: 2, label: "status:needs-triage"});
+		expect(result.candidates).toHaveLength(2);
+		expect(result.truncated).toBe(true);
+	});
+
+	it("reports `none` as a PROVEN negative, with both source counts in the reason", () => {
+		const result = rank({
+			tokens,
+			queue: [],
+			search: [],
+			limit: 20,
+			label: "status:needs-triage",
+		});
+		expect(result.outcome).toBe("none");
+		expect(result.reason).toContain("both sources were read");
+		expect(result.truncated).toBe(false);
+	});
+
+	it("reports `indeterminate` below the two-token floor, not only at zero", () => {
+		const one = rank({tokens: ["thing"], queue: [], search: [], limit: 20, label: "l"});
+		expect(one.outcome).toBe("indeterminate");
+		expect(one.reason).toContain("below the floor of 2");
+
+		const none = rank({tokens: [], queue: [], search: [], limit: 20, label: "l"});
+		expect(none.outcome).toBe("indeterminate");
+	});
+
+	it("never reports a degenerate query as `none`, even when candidates exist", () => {
+		const result = rank({
+			tokens: ["thing"],
+			queue: [{number: 1, title: "the thing"}],
+			search: [],
+			limit: 20,
+			label: "l",
+		});
+		expect(result.outcome).toBe("indeterminate");
+		expect(result.candidates).toEqual([]);
+	});
+});
+
+describe("renderCandidate", () => {
+	it("is tab-separated with a bare number, so `cut -f1` needs no stripping", () => {
+		expect(renderCandidate({number: 4312, source: "both", score: 4, title: "Abort reason"})).toBe(
+			"4312\tboth\t4\tAbort reason",
+		);
+	});
+});

--- a/packages/fabrika-cli/src/report/file-verb.ts
+++ b/packages/fabrika-cli/src/report/file-verb.ts
@@ -1,0 +1,240 @@
+/**
+ * `report file` — compose the intake issue, guard it, create it, and read back what landed.
+ *
+ * **One transaction.** Every step is a precondition or a postcondition of *this observation is now
+ * an issue in the intake queue*, and splitting them would hand a caller the chance to skip one.
+ *
+ * The check order is local-first: everything decidable from the bytes on stdin runs before any
+ * network read, so a refusable body costs no API call and a refusal always names the cheapest
+ * correctable thing first.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	createIssue,
+	currentBranch,
+	type Existence,
+	getIssue,
+	type IssueRecord,
+	listLabels,
+	resolveRepo,
+} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	CLASSIFIED,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	checkSections,
+	classifyingPrefix,
+	composeBody,
+	deriveVocabulary,
+	labelKind,
+	normalizeForReadback,
+	REQUIRED_SECTIONS,
+	renderFooter,
+} from "./compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "./leaks.ts";
+
+export interface FileOptions {
+	readonly title: string;
+	readonly label: string;
+	readonly redact: boolean;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The fd-0 read, injected so the failed-read and TTY paths are testable without a descriptor. */
+	readonly stdin: Effect.Effect<StdinRead>;
+	/** The footer's timestamp, injected so a filing is byte-reproducible in a test. */
+	readonly now: () => Date;
+}
+
+const utc = (date: Date): string => `${date.toISOString().slice(0, 19)}Z`;
+
+/**
+ * What the read-back found wrong, or `null` when the issue landed as composed.
+ *
+ * Four assertions, in the order a failure is most likely to explain the rest: it exists; it carries
+ * `--label` and only that label; its body carries the never-dropped marker and all six headings;
+ * and its body matches what was composed under the normalised comparison.
+ */
+export const readbackMismatch = (
+	landed: Existence<IssueRecord>,
+	label: string,
+	composed: string,
+): string | null => {
+	if (landed._tag === "Absent") return "the issue is not readable after the create";
+	if (landed._tag === "Unknown") return `the read-back itself failed: ${landed.reason}`;
+	const issue = landed.value;
+	if (issue.labels.length !== 1 || issue.labels[0] !== label) {
+		return `it carries labels [${issue.labels.join(", ")}] rather than exactly "${label}"`;
+	}
+	if (!issue.body.includes("Filed by an agent")) {
+		return "the body is missing the `Filed by an agent` marker";
+	}
+	const missing = REQUIRED_SECTIONS.find((heading) => !issue.body.includes(heading));
+	if (missing !== undefined) return `the body is missing section "${missing}"`;
+	return normalizeForReadback(issue.body) === normalizeForReadback(composed)
+		? null
+		: "the landed body differs from what was composed";
+};
+
+export const runFile = (
+	options: FileOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {label, json, title} = options;
+
+		if (title.trim() === "") {
+			return refuse(FAILED, "report file: --title is empty — refusing to file an untitled report.");
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"report file: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`report file: could not read stdin: ${read.reason} — the body is UNKNOWN, never empty.`,
+			);
+		}
+		// A TTY with nothing piped in never reached a read, but the caller's correction is identical
+		// to an empty pipe's — send the body — and nothing was proven UNKNOWN, so it seats here rather
+		// than on the failed-read code.
+		const sections = read._tag === "NoStdin" ? "" : read.text;
+		const bytesIn = new TextEncoder().encode(sections).length;
+		if (sections.trim() === "") {
+			return refuse(
+				EMPTY_STDIN,
+				bytesIn === 0
+					? "report file: stdin was read and held 0 bytes — refusing to file a bodyless issue."
+					: `report file: stdin was read and held ${bytesIn} bytes of whitespace — refusing to file a bodyless issue.`,
+			);
+		}
+
+		if (isBareAtReference(sections)) {
+			return refuse(
+				BARE_AT_PATH,
+				'report file: the body is a bare "@" path reference — the composed body never arrived. Send it on stdin; --redact does not apply.',
+			);
+		}
+
+		const problem = checkSections(sections);
+		if (problem !== null) {
+			return refuse(
+				BAD_SECTIONS,
+				problem._tag === "Missing"
+					? `report file: section "${problem.heading}" is missing.`
+					: problem._tag === "Empty"
+						? `report file: section "${problem.heading}" is empty.`
+						: `report file: sections are out of order — "${problem.heading}" follows "${problem.after}".`,
+			);
+		}
+
+		const footer = renderFooter({
+			session: options.env.CLAUDE_CODE_SESSION_ID ?? null,
+			model: options.env.ANTHROPIC_MODEL ?? options.env.CLAUDE_MODEL ?? null,
+			branch: yield* currentBranch,
+			timestamp: utc(options.now()),
+		});
+		// Scanned after composition, so nothing the verb itself appends can escape the predicate.
+		const composed = composeBody(sections, footer);
+		const scan = scanBody(composed);
+		if (scan.leaks.length > 0 && !options.redact) {
+			return refuse(
+				LEAKED_PATH,
+				`report file: the body carries ${scan.leaks.length} machine-local path(s) — refusing to post them to a public issue.`,
+				renderLeaks(scan.leaks),
+			);
+		}
+		const body = options.redact ? scan.redacted : composed;
+		const redactions = options.redact
+			? scan.leaks.map((leak) => ({line: leak.line, class: leak.class}))
+			: [];
+		const redactionNotes = redactions.map(
+			(r) => `report file: redacted a machine-local path — line ${r.line}, ${r.class}`,
+		);
+
+		const labels = yield* listLabels(repo);
+		if (labels._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`report file: cannot read the label set of ${repo}: ${labels.reason} — whether "${label}" exists is UNKNOWN, so nothing was filed.`,
+			);
+		}
+		if (!labels.value.includes(label)) {
+			return refuse(
+				NO_TARGET,
+				`report file: ${repo} has no "${label}" label — the issue would be filed outside the intake queue. Create the label, then re-run.`,
+			);
+		}
+
+		const vocabulary = deriveVocabulary(labels.value);
+		const kind = labelKind(label, vocabulary);
+		if (kind !== null) {
+			return refuse(
+				CLASSIFIED,
+				`report file: --label "${label}" is a ${kind} label — intake applies neither. Triage classifies; this verb files.`,
+			);
+		}
+		const prefix = classifyingPrefix(title, vocabulary);
+		if (prefix !== null) {
+			return refuse(
+				CLASSIFIED,
+				`report file: the title leads with the classification prefix "${prefix}" — intake files type-neutral titles. Drop the prefix.`,
+			);
+		}
+
+		const bodyBytes = new TextEncoder().encode(body).length;
+		const scope = `report file: ${repo}, ${bytesIn} byte(s) read, ${REQUIRED_SECTIONS.length} section(s) seen, label "${label}" checked against ${labels.value.length} label(s), ${vocabulary.words.size} classification term(s) derived.`;
+
+		const created = yield* createIssue(repo, title, body, label);
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`report file: could not create the issue in ${repo}: ${created.reason} — the filing is UNKNOWN. Re-run \`report dedup\` before re-filing; the create may have landed.`,
+				[scope, ...redactionNotes],
+			);
+		}
+
+		// A create call's own response is the server echoing the request; a fresh read is the only
+		// evidence the issue is in the queue (#3173).
+		const mismatch = readbackMismatch(yield* getIssue(repo, created.value.number), label, body);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`report file: created #${created.value.number} but the read-back is wrong: ${mismatch}. The issue exists and needs fixing by hand.`,
+				[scope, ...redactionNotes],
+			);
+		}
+
+		const diagnostics = [scope, ...redactionNotes];
+		return json
+			? answer(
+					JSON.stringify({
+						number: created.value.number,
+						url: created.value.url,
+						label,
+						redactions,
+						bodyBytes,
+					}),
+					diagnostics,
+				)
+			: answer(`${created.value.number}\t${created.value.url}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/report/file-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/file-verb.unit.test.ts
@@ -1,0 +1,253 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	CLASSIFIED,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {composeBody, REQUIRED_SECTIONS, renderFooter} from "./compose.ts";
+import {runFile} from "./file-verb.ts";
+
+const READBACK = /^gh api repos\/o\/r\/issues\/\d+$/;
+const CREATE = /--method POST repos\/o\/r\/issues -f/;
+const LABELS = /repos\/o\/r\/labels/;
+const BRANCH = /git rev-parse/;
+
+const NOW = new Date("2026-08-01T14:22:07.000Z");
+
+const sections = REQUIRED_SECTIONS.map((h) =>
+	h === "## Suggested next step (non-binding)" ? `${h}\n` : `${h}\ncontent for ${h}`,
+).join("\n\n");
+
+/** What the verb composes for these inputs: no session, no model, detached branch, fixed clock. */
+const composed = composeBody(
+	sections,
+	renderFooter({session: null, model: null, branch: null, timestamp: "2026-08-01T14:22:07Z"}),
+);
+
+const created = okOut(JSON.stringify({number: 4732, html_url: "https://example.test/issues/4732"}));
+
+const landed = (body: string, labels: ReadonlyArray<string> = ["status:needs-triage"]) =>
+	okOut(
+		JSON.stringify({
+			number: 4732,
+			title: "t",
+			body,
+			state: "open",
+			labels: labels.map((name) => ({name})),
+			html_url: "https://example.test/issues/4732",
+		}),
+	);
+
+const options = {
+	title: "Retry helper in the http worker swallows the abort reason",
+	label: "status:needs-triage",
+	redact: false,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: sections}),
+	now: () => NOW,
+};
+
+const labelsOk = [LABELS, okOut("status:needs-triage\ntype:bug\np0")] as const;
+const branchDetached = [BRANCH, errOut("detached")] as const;
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[READBACK, landed(composed)],
+	[CREATE, created],
+	labelsOk,
+	branchDetached,
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runFile({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runFile", () => {
+	it("files, reads back, and prints a bare tab-separated number and url", async () => {
+		const out = await run(happy);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("4732\thttps://example.test/issues/4732\n");
+	});
+
+	it("emits the full filing record on STDOUT with --json", async () => {
+		const out = await run(happy, {json: true});
+		const payload = JSON.parse(out.stdout);
+		expect(payload).toMatchObject({
+			number: 4732,
+			url: "https://example.test/issues/4732",
+			label: "status:needs-triage",
+			redactions: [],
+		});
+		expect(payload.bodyBytes).toBeGreaterThan(0);
+	});
+
+	it("appends the footer itself, with the never-dropped marker", async () => {
+		const shell = fakeShell(happy);
+		await Effect.runPromise(Effect.provide(runFile(options), shell.layer));
+		const create = shell.calls.find((c) => CREATE.test(c)) ?? "";
+		expect(create).toContain("Filed by an agent");
+		expect(create).toContain("2026-08-01T14:22:07Z");
+	});
+
+	it("refuses a FAILED stdin read as UNKNOWN, never as an empty body (#3924)", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses an empty-but-READ stdin on its own, different code", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({_tag: "Text", text: ""} satisfies StdinRead),
+		});
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stderr.at(-1)).toContain("0 bytes");
+	});
+
+	it("treats a TTY with nothing piped in as a bodyless filing, not a broken verb", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({_tag: "NoStdin", reason: "fd 0 is a TTY"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a bare @ path body on its own code — --redact must not apply", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({_tag: "Text", text: "@/tmp/body.md\n"} satisfies StdinRead),
+			redact: true,
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+		expect(out.stderr.at(-1)).toContain("--redact does not apply");
+	});
+
+	it("names the one section that is wrong", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: sections.replace("## Pointers\ncontent for ## Pointers", ""),
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toBe('report file: section "## Pointers" is missing.');
+	});
+
+	it("refuses a machine-local path with one indented hit per line", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: sections.replace("content for ## Pointers", "/tmp/session/body.md"),
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stderr[0]).toMatch(/^ {2}line \d+, temp root$/);
+	});
+
+	it("files the masked body under --redact, and says what it masked", async () => {
+		const text = sections.replace("content for ## Pointers", "/tmp/session/body.md");
+		const masked = composeBody(
+			text.replace("/tmp/session/body.md", "/tmp/<redacted>"),
+			renderFooter({session: null, model: null, branch: null, timestamp: "2026-08-01T14:22:07Z"}),
+		);
+		const out = await run(
+			[[READBACK, landed(masked)], [CREATE, created], labelsOk, branchDetached],
+			{stdin: Effect.succeed({_tag: "Text", text} satisfies StdinRead), redact: true},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stderr.join("\n")).toContain("redacted a machine-local path");
+	});
+
+	it("refuses a label that does not exist in the repo", async () => {
+		const out = await run(happy, {label: "status:needs-triageee"});
+		expect(out.code).toBe(NO_TARGET);
+		expect(out.stderr.at(-1)).toContain("outside the intake queue");
+	});
+
+	it("refuses an UNREADABLE label set as UNKNOWN, and files nothing", async () => {
+		const shell = fakeShell([
+			[READBACK, landed(composed)],
+			[CREATE, created],
+			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+			branchDetached,
+		]);
+		const out = await Effect.runPromise(Effect.provide(runFile(options), shell.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(shell.calls.some((c) => CREATE.test(c))).toBe(false);
+	});
+
+	it("refuses a --label that classifies", async () => {
+		const out = await run(happy, {label: "type:bug"});
+		expect(out.code).toBe(CLASSIFIED);
+		expect(out.stderr.at(-1)).toContain("Triage classifies; this verb files.");
+	});
+
+	it("refuses a title that leads with a classification prefix", async () => {
+		const out = await run(happy, {title: "BUG: retry helper swallows the abort reason"});
+		expect(out.code).toBe(CLASSIFIED);
+		expect(out.stderr.at(-1)).toContain('"BUG:"');
+	});
+
+	it("reports a failed create as UNKNOWN, with the re-run-dedup recovery", async () => {
+		const out = await run([
+			[READBACK, landed(composed)],
+			[CREATE, errOut("gh: Service unavailable (HTTP 503)")],
+			labelsOk,
+			branchDetached,
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("Re-run `report dedup`");
+	});
+
+	it("refuses when the read-back carries a label the verb did not apply", async () => {
+		const out = await run([
+			[READBACK, landed(composed, ["status:needs-triage", "type:bug"])],
+			[CREATE, created],
+			labelsOk,
+			branchDetached,
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("needs fixing by hand");
+	});
+
+	it("refuses when the landed body is not what was composed (#3173)", async () => {
+		const out = await run([
+			[READBACK, landed(composed.replace("content for ## Summary", "something else"))],
+			[CREATE, created],
+			labelsOk,
+			branchDetached,
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("tolerates the round-trip's line-ending and trailing-whitespace normalisation", async () => {
+		const out = await run([
+			[READBACK, landed(`${composed.replace(/\n/g, "\r\n")}   \r\n`)],
+			[CREATE, created],
+			labelsOk,
+			branchDetached,
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses an empty --title", async () => {
+		const out = await run(happy, {title: "  "});
+		expect(out.code).toBe(1);
+		expect(out.stderr.at(-1)).toContain("untitled");
+	});
+});

--- a/packages/fabrika-cli/src/report/leaks.ts
+++ b/packages/fabrika-cli/src/report/leaks.ts
@@ -1,0 +1,105 @@
+/**
+ * The body-surface leak predicate, shared by `report file` and `report note`.
+ *
+ * A machine-local path in a body posted to a public issue is a leak, and no merge gate covers it —
+ * the repo's committed-file leak gate decides whether a *file in a diff* carries one, and a runtime
+ * issue body is never in a diff. This is the ungated surface, not a second verdict on a gated one.
+ *
+ * **Three generic shapes and no name list.** Every shape is structural, so a new operator, a
+ * renamed tool directory or a different machine needs no edit here.
+ */
+
+export type LeakClass = "home-relative" | "absolute home root" | "temp root";
+
+export interface Leak {
+	/** 1-based line number in the scanned body — what the refusal prints. */
+	readonly line: number;
+	readonly class: LeakClass;
+	readonly text: string;
+}
+
+export interface Scan {
+	readonly leaks: ReadonlyArray<Leak>;
+	/** The body with every match masked to its class root. Equal to the input when there are none. */
+	readonly redacted: string;
+}
+
+/**
+ * The claude CLI's public config leaves these two files, byte-identical on every machine and
+ * naming nothing operator-specific. Each carve-out pins the **exact** leaf, so a deeper descent or
+ * a longer name still matches.
+ */
+const CARVE_OUTS = new Set(["~/.claude.json", "~/.claude/settings.json"]);
+
+/** One path segment: anything up to a separator or a character that ends a run in prose/markdown. */
+const SEG = String.raw`[^\s\x60'"<>)\]}/]+`;
+
+/**
+ * The roots, **longest first** so an overlapping pair cannot corrupt each other: `/private/tmp`
+ * must win over `/tmp`, and `/private/var` over a bare `/var`. A single left-to-right pass over
+ * this alternation is what gives "longer matches are replaced before shorter ones".
+ *
+ * Every alternative requires at least one following segment, so the word `/tmp` in prose is not a
+ * path and a bare `~` is not a home reference.
+ */
+const PATH_RE = new RegExp(
+	`(?:/private/tmp|/private/var|/var/folders|/tmp|/Users|/home|~)(?:/${SEG})+`,
+	"g",
+);
+
+/** Trailing sentence punctuation is prose, not part of the path. */
+const trimPunctuation = (match: string): string => match.replace(/[.,;:!?]+$/, "");
+
+const ROOTS: ReadonlyArray<{prefix: string; cls: LeakClass; mask: string}> = [
+	{prefix: "/private/tmp", cls: "temp root", mask: "/private/tmp/<redacted>"},
+	{prefix: "/private/var", cls: "temp root", mask: "/private/var/<redacted>"},
+	{prefix: "/var/folders", cls: "temp root", mask: "/var/folders/<redacted>"},
+	{prefix: "/tmp", cls: "temp root", mask: "/tmp/<redacted>"},
+	{prefix: "/Users", cls: "absolute home root", mask: "/Users/<redacted>"},
+	{prefix: "/home", cls: "absolute home root", mask: "/home/<redacted>"},
+	{prefix: "~", cls: "home-relative", mask: "~/<redacted>"},
+];
+
+const rootOf = (path: string): {cls: LeakClass; mask: string} =>
+	ROOTS.find((r) => path.startsWith(r.prefix)) ?? {cls: "temp root", mask: "/tmp/<redacted>"};
+
+/**
+ * Scan a body for machine-local paths, and produce the masked body alongside.
+ *
+ * The mask keeps the class root — `/var/folders/<redacted>`, not one collapsed marker — because
+ * *which* root a path came from is itself the evidence. The leaf filename does not survive, and
+ * that is deliberate: a filename can identify a person or a machine, and a reader who needs it can
+ * ask the reporter.
+ */
+export const scanBody = (body: string): Scan => {
+	const leaks: Leak[] = [];
+	const lines = body.split("\n").map((line, index) => {
+		PATH_RE.lastIndex = 0;
+		return line.replace(PATH_RE, (raw) => {
+			const path = trimPunctuation(raw);
+			const tail = raw.slice(path.length);
+			if (CARVE_OUTS.has(path)) return raw;
+			const {cls, mask} = rootOf(path);
+			leaks.push({line: index + 1, class: cls, text: path});
+			return mask + tail;
+		});
+	});
+	return {leaks, redacted: leaks.length === 0 ? body : lines.join("\n")};
+};
+
+/**
+ * Whether the body's first non-whitespace run is an `@`-prefixed path.
+ *
+ * That is the composed body having never arrived at all — #3086's exact byte pattern, where a
+ * posting flag that does not expand `@` shipped the literal path into a public artifact and left
+ * the description empty. It refuses on its own code because the fix is to send the body, not to
+ * mask a placeholder.
+ */
+export const isBareAtReference = (body: string): boolean => {
+	const first = body.trim().split(/\s/)[0] ?? "";
+	return first.startsWith("@") && first.includes("/");
+};
+
+/** The stderr detail lines a refusal prints under its message: one `line <n>, <class>` per hit. */
+export const renderLeaks = (leaks: ReadonlyArray<Leak>): ReadonlyArray<string> =>
+	leaks.map((leak) => `  line ${leak.line}, ${leak.class}`);

--- a/packages/fabrika-cli/src/report/leaks.unit.test.ts
+++ b/packages/fabrika-cli/src/report/leaks.unit.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from "vitest";
+import {isBareAtReference, renderLeaks, scanBody} from "./leaks.ts";
+
+describe("scanBody", () => {
+	it("classifies the three shapes and keeps the class root in the mask", () => {
+		const body = ["~/notes/todo.md", "/Users/someone/code/x.ts", "/var/folders/ab/cd/T/y"].join(
+			"\n",
+		);
+		const scan = scanBody(body);
+		expect(scan.leaks.map((l) => l.class)).toEqual([
+			"home-relative",
+			"absolute home root",
+			"temp root",
+		]);
+		expect(scan.redacted.split("\n")).toEqual([
+			"~/<redacted>",
+			"/Users/<redacted>",
+			"/var/folders/<redacted>",
+		]);
+	});
+
+	it("does not fold the temp roots together — which root it came from IS the evidence", () => {
+		const scan = scanBody("/tmp/a /private/tmp/b /private/var/c /var/folders/d/e");
+		expect(scan.redacted).toBe(
+			"/tmp/<redacted> /private/tmp/<redacted> /private/var/<redacted> /var/folders/<redacted>",
+		);
+	});
+
+	it("replaces the LONGER root first, so /private/tmp never degrades to /tmp", () => {
+		const scan = scanBody("see /private/tmp/session/body.md");
+		expect(scan.leaks).toHaveLength(1);
+		expect(scan.redacted).toBe("see /private/tmp/<redacted>");
+	});
+
+	it("drops the leaf filename — a filename can itself identify a person or a machine", () => {
+		expect(scanBody("/Users/someone/Desktop/invoice-someone.pdf").redacted).toBe(
+			"/Users/<redacted>",
+		);
+	});
+
+	it("carves out the two machine-agnostic claude config leaves, by exact leaf", () => {
+		const scan = scanBody("~/.claude.json and ~/.claude/settings.json");
+		expect(scan.leaks).toEqual([]);
+		expect(scan.redacted).toBe("~/.claude.json and ~/.claude/settings.json");
+	});
+
+	it("still matches a deeper descent or a longer name under the carved-out leaf", () => {
+		const scan = scanBody("~/.claude/settings.local.json ~/.claude/projects/x");
+		expect(scan.leaks).toHaveLength(2);
+		expect(scan.redacted).toBe("~/<redacted> ~/<redacted>");
+	});
+
+	it("reports the 1-based line of each hit", () => {
+		const scan = scanBody(["clean", "clean", "/tmp/x/y"].join("\n"));
+		expect(scan.leaks).toEqual([{line: 3, class: "temp root", text: "/tmp/x/y"}]);
+		expect(renderLeaks(scan.leaks)).toEqual(["  line 3, temp root"]);
+	});
+
+	it("leaves prose alone: a bare root with no segment is not a path", () => {
+		const scan = scanBody("the /tmp directory, a ~ in a table, and /home on its own");
+		expect(scan.leaks).toEqual([]);
+		expect(scan.redacted).toBe("the /tmp directory, a ~ in a table, and /home on its own");
+	});
+
+	it("does not swallow the sentence punctuation that follows a path", () => {
+		expect(scanBody("it lives at /tmp/session/body.md.").redacted).toBe(
+			"it lives at /tmp/<redacted>.",
+		);
+	});
+
+	it("leaves a repo-relative path untouched — the Pointers section is repo-relative by contract", () => {
+		const body = "packages/fabrika-cli/src/report/leaks.ts and apps/web/worker/http/retry.ts";
+		expect(scanBody(body)).toEqual({leaks: [], redacted: body});
+	});
+});
+
+describe("isBareAtReference", () => {
+	it("catches the composed body having never arrived (#3086)", () => {
+		expect(isBareAtReference("@/tmp/body.md")).toBe(true);
+		expect(isBareAtReference("  \n@~/notes/body.md\n")).toBe(true);
+	});
+
+	it("is not fooled by an @mention or an email in prose", () => {
+		expect(isBareAtReference("@usirin said the retry helper drops the reason")).toBe(false);
+		expect(isBareAtReference("## Summary\nsee @/tmp/x later")).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/report/note-verb.ts
+++ b/packages/fabrika-cli/src/report/note-verb.ts
@@ -1,0 +1,154 @@
+/**
+ * `report note` — add a note to an existing issue over the same guarded path.
+ *
+ * **This verb exists because the skill tells its caller to comment on a duplicate rather than file
+ * a twin.** A skill that says that without providing a guarded path sends the caller to a
+ * hand-rolled posting call — which is the exact call #3945 and #3173 each made, and both of those
+ * incidents were comment posts, not issue creates.
+ *
+ * A note is free prose: no section template applies and no footer is appended. Stated in code as
+ * well as in the contract because the sibling verb does both.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getComment, getIssue, resolveRepo} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {normalizeForReadback} from "./compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "./leaks.ts";
+
+export interface NoteOptions {
+	readonly issue: number;
+	readonly redact: boolean;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runNote = (
+	options: NoteOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, json} = options;
+
+		if (!Number.isInteger(issue) || issue <= 0) {
+			return refuse(FAILED, `report note: --issue ${issue} is not an issue number.`);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"report note: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`report note: could not read stdin: ${read.reason} — the note is UNKNOWN, never empty.`,
+			);
+		}
+		const note = read._tag === "NoStdin" ? "" : read.text;
+		const bytesIn = new TextEncoder().encode(note).length;
+		if (note.trim() === "") {
+			return refuse(
+				EMPTY_STDIN,
+				bytesIn === 0
+					? "report note: stdin was read and held 0 bytes — refusing to post an empty note."
+					: `report note: stdin was read and held ${bytesIn} bytes of whitespace — refusing to post an empty note.`,
+			);
+		}
+
+		if (isBareAtReference(note)) {
+			return refuse(
+				BARE_AT_PATH,
+				'report note: the note is a bare "@" path reference — the composed note never arrived. Send it on stdin; --redact does not apply.',
+			);
+		}
+
+		const scan = scanBody(note);
+		if (scan.leaks.length > 0 && !options.redact) {
+			return refuse(
+				LEAKED_PATH,
+				`report note: the note carries ${scan.leaks.length} machine-local path(s) — refusing to post them to a public issue.`,
+				renderLeaks(scan.leaks),
+			);
+		}
+		const body = options.redact ? scan.redacted : note;
+		const redactions = options.redact
+			? scan.leaks.map((leak) => ({line: leak.line, class: leak.class}))
+			: [];
+		const redactionNotes = redactions.map(
+			(r) => `report note: redacted a machine-local path — line ${r.line}, ${r.class}`,
+		);
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(NO_TARGET, `report note: ${repo} has no issue #${issue}.`);
+		}
+		if (target._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`report note: cannot read #${issue} in ${repo}: ${target.reason} — whether the issue exists is UNKNOWN, so nothing was posted.`,
+			);
+		}
+
+		const scope = `report note: ${repo}#${issue}, ${bytesIn} byte(s) read.`;
+		// A closed issue is not a refusal — a note on one is sometimes exactly right — but the caller
+		// is never left surprised by where the note landed.
+		const closed = target.value.state === "closed" ? [`report note: #${issue} is closed.`] : [];
+		const diagnostics = [scope, ...closed, ...redactionNotes];
+
+		const posted = yield* createComment(repo, issue, body);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`report note: could not post the comment on #${issue}: ${posted.reason} — the note is UNKNOWN. Re-read the issue before re-posting; the comment may have landed.`,
+				diagnostics,
+			);
+		}
+
+		// #3173 is precisely a posted comment whose landed body was not what the poster believed it
+		// had sent, reported upward as a success — so a post that is not verified is not finished.
+		const landed = yield* getComment(repo, posted.value.id);
+		const mismatch =
+			landed._tag === "Failure"
+				? `the read-back itself failed: ${landed.reason}`
+				: normalizeForReadback(landed.value) === normalizeForReadback(body)
+					? null
+					: "the landed body differs from what was sent";
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`report note: posted comment ${posted.value.id} on #${issue} but the read-back is wrong: ${mismatch}. The comment exists and needs fixing by hand.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({
+						id: posted.value.id,
+						url: posted.value.url,
+						issue,
+						redactions,
+						bodyBytes: new TextEncoder().encode(body).length,
+					}),
+					diagnostics,
+				)
+			: answer(`${posted.value.id}\t${posted.value.url}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/report/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/note-verb.unit.test.ts
@@ -1,0 +1,217 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {runNote} from "./note-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const POST = /repos\/o\/r\/issues\/4312\/comments -f/;
+const COMMENT = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+
+const NOTE = "Also reproduces on the streaming path, not just the buffered one.";
+
+const issueOpen = okOut(
+	JSON.stringify({
+		number: 4312,
+		title: "t",
+		body: "b",
+		state: "open",
+		labels: [],
+		html_url: "https://example.test/issues/4312",
+	}),
+);
+
+const issueClosed = okOut(
+	JSON.stringify({
+		number: 4312,
+		title: "t",
+		body: "b",
+		state: "closed",
+		labels: [],
+		html_url: "https://example.test/issues/4312",
+	}),
+);
+
+const posted = okOut(
+	JSON.stringify({
+		id: 5154891644,
+		html_url: "https://example.test/issues/4312#issuecomment-5154891644",
+	}),
+);
+
+const options = {
+	issue: 4312,
+	redact: false,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: NOTE}),
+};
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[COMMENT, okOut(JSON.stringify({body: NOTE}))],
+	[ISSUE, issueOpen],
+	[POST, posted],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runNote", () => {
+	it("posts, reads back, and prints a bare tab-separated id and url", async () => {
+		const out = await run(happy);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			"5154891644\thttps://example.test/issues/4312#issuecomment-5154891644\n",
+		);
+	});
+
+	it("emits the note record on STDOUT with --json", async () => {
+		const out = await run(happy, {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			id: 5154891644,
+			issue: 4312,
+			redactions: [],
+		});
+	});
+
+	it("validates nothing about the note's structure — a note is free prose", async () => {
+		const out = await run(
+			[
+				[COMMENT, okOut(JSON.stringify({body: "one line, no headings"}))],
+				[ISSUE, issueOpen],
+				[POST, posted],
+			],
+			{stdin: Effect.succeed({_tag: "Text", text: "one line, no headings"} satisfies StdinRead)},
+		);
+		expect(out.code).toBe(0);
+	});
+
+	it("appends no footer — the note lands byte-for-byte as sent", async () => {
+		const shell = fakeShell(happy);
+		await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		const post = shell.calls.find((c) => POST.test(c)) ?? "";
+		expect(post).toContain(`body=${NOTE}`);
+		expect(post).not.toContain("Filed by an agent");
+	});
+
+	it("posts on a CLOSED issue but says so — never a surprise about where it landed", async () => {
+		const out = await run([
+			[COMMENT, okOut(JSON.stringify({body: NOTE}))],
+			[ISSUE, issueClosed],
+			[POST, posted],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stderr.join("\n")).toContain("#4312 is closed.");
+	});
+
+	it("refuses a FAILED stdin read as UNKNOWN, never as an empty note", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses an empty-but-READ stdin on its own, different code", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({_tag: "Text", text: ""} satisfies StdinRead),
+		});
+		expect(out.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a bare @ path note on its own code", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({_tag: "Text", text: "@/tmp/note.md"} satisfies StdinRead),
+			redact: true,
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path in the note", async () => {
+		const out = await run(happy, {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: "reproduced from /Users/someone/scratch/case.md",
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stderr[0]).toBe("  line 1, absolute home root");
+	});
+
+	it("posts the masked note under --redact", async () => {
+		const masked = "reproduced from /Users/<redacted>";
+		const out = await run(
+			[
+				[COMMENT, okOut(JSON.stringify({body: masked}))],
+				[ISSUE, issueOpen],
+				[POST, posted],
+			],
+			{
+				stdin: Effect.succeed({
+					_tag: "Text",
+					text: "reproduced from /Users/someone/scratch/case.md",
+				} satisfies StdinRead),
+				redact: true,
+			},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stderr.join("\n")).toContain("redacted a machine-local path");
+	});
+
+	it("refuses an issue that does not exist", async () => {
+		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(NO_TARGET);
+		expect(out.stderr.at(-1)).toBe("report note: o/r has no issue #4312.");
+	});
+
+	it("separates an UNREADABLE issue from an absent one, and posts nothing", async () => {
+		const shell = fakeShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(shell.calls.some((c) => POST.test(c))).toBe(false);
+	});
+
+	it("reports a failed post as UNKNOWN, with the re-read recovery", async () => {
+		const out = await run([
+			[ISSUE, issueOpen],
+			[POST, errOut("gh: timeout")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("may have landed");
+	});
+
+	it("refuses when the landed comment is not what was sent (#3173)", async () => {
+		const out = await run([
+			[COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+			[ISSUE, issueOpen],
+			[POST, posted],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("needs fixing by hand");
+	});
+
+	it("refuses when the read-back itself fails — a post that is not verified is not finished", async () => {
+		const out = await run([
+			[COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, issueOpen],
+			[POST, posted],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+});


### PR DESCRIPTION
`/report` is how an observation leaves an agent session, and the skill for it has been on `main` since #4741 calling three CLI verbs that did not exist. This PR builds them, so the skill can actually run: check whether the thing is already filed, file it, or add a note to the issue that already covered it. Each verb refuses loudly rather than guessing — an unread pipe is not an empty body, a machine-local path never reaches a public issue, and a write is not finished until it has been read back.

Fixes #4748

## What changed

`packages/fabrika-cli/src/report/` — three verbs implementing `claude-plugins/fabrika/skills/report/contract.md`, registered as a `report` group in `src/registry.ts` so they list under `--help`. The shape follows the sibling `adr/` group exactly: a pure core per concern with a `*.unit.test.ts` beside it, a thin Effect CLI adapter in `command.ts`, and the `io/` seam for every read and write.

- `report dedup` — ranks the open issues that may already cover an observation. `candidates` / `none` / `indeterminate`, all three at exit 0.
- `report file` — composes the intake issue from the six sections on stdin, guards it, creates it, reads back what landed.
- `report note` — the same guarded path for a comment on an existing issue.

New `io/` modules: `issues.ts` (the `gh api` REST surface — REST only, never GraphQL, `--paginate` on every list read), `stdin.ts` (the fail-closed fd-0 read), `json.ts` (the JSON boundary).

## `report dedup` deviates from the contract, on purpose — see #4752

The contract gives `dedup` no exit code for a `--label` that does not exist. `GET /issues?labels=<missing>` answers **HTTP 200 with an empty array**, so a typo'd label — or an adopter repo with no `status:needs-triage` — never reaches the "queue unreadable" path. It lands on the success path, where the Scope section reads an empty queue as a fact, and the verb prints `none`: a proven negative over a scope of zero, which ADR 0092 forbids.

So `dedup` here checks the label first and refuses on **exit 7**, reusing `report file`'s existing meaning for that code (*the target named by `--label` does not exist in `--repo`*) rather than minting a new number. `contract.md` is **not** patched — the gap is reported on #4752 instead.

## The disciplines the code is built to make unavoidable

- **Unreadable is never empty.** Every read that could not happen is a typed failure with its own exit code and nothing on stdout: a failed stdin read is `1` and an empty-but-read pipe is `3`; an unreadable label set is `11` (nothing was written) and a proven-missing label is `7`; a failed write is `8` (UNKNOWN) and a landed-but-wrong write is `9`. Each verb carries a test proving the pair does not collapse.
- **The body is a value, never a path.** No `--body`, no `--body-file`, no temp file — stdin only, so no path ever exists inside the process to be posted verbatim.
- **Absent and unreadable are split at the transport.** `gh` reports a 404 and a 502 identically, so `io/issues.ts` reads the `(HTTP <n>)` status: only a real 404 may seat a proven "does not exist" refusal.

## Verification

- `pnpm typecheck` (whole workspace) and `pnpm lint:worktree` clean.
- 240 tests in the package, 91 of them new.
- Live smoke against this repo, read-only: `dedup` produced `candidates` (with #4752 ranked `both`), `none`, `indeterminate`, and the exit-7 refusal on a typo'd label; the `file` / `note` refusal paths (3, 5, 6, 7, 10) were exercised end to end without any write landing.

## Deviations

**1. Under-determined contract detail — the type/priority vocabulary rule.** *Said:* the vocabulary is "derived from the target repo's label set". *Did:* `type:*` is a type label; `priority:*` **or** a bare `p<digits>` is a priority label. *Why:* this repo spells priority `p0`/`p1`/`p2`, so a rule reading only `priority:` would derive an empty priority vocabulary here and wave `P0: …` straight through. *Disposition:* recorded in the contract-sufficiency comment on #4748, for the reviewer to judge.

**2. An exit code the contract does not have — `11`.** *Said:* the shared table stops at `10`. *Did:* added `11` = a precondition read failed, so nothing was written and no outcome is proven. *Why:* the label-set read is what makes `7` and `10` provable, so a failed read of it can be neither; `8` means a write was attempted and `1` would fuse an unreachable GitHub with a bad flag. *Disposition:* reported on #4752 alongside the `dedup` gap.

**3. The read-back comparison was not tightened to byte-identity.** *Said:* "the implementer verifies the round-trip against the real API and tightens the comparison to byte-identity if it holds, recording what was found." *Did:* kept the normalised comparison; did not verify. *Why:* verifying requires creating a real issue in a public repo, which is not something this lane should do as a side effect. *Disposition:* recorded here and on #4748; the normalisation is the contract's own stated concession, so nothing regresses.

**4. AC "every fence in `SKILL.md` resolves and runs" is met only for the half this ticket owns.** *Said:* every fence resolves and runs. *Did:* all three verbs now resolve and run — no invocation returns an unknown-verb refusal. The fences invoke `fabrika-cli` as a **bare name**, which is not on `PATH` where agents spawn. *Why:* that is the resolution mechanism #4650 owns, and `contract.md` already records it as a tracked blocker rather than an assumption. *Disposition:* no action here; #4650 is the home.

**5. Branched off the fetched `origin/main` tip rather than the dispatched `ff6e75ef`.** *Said:* branch at `ff6e75ef`. *Did:* branched off `FETCH_HEAD`, per the skill's Step-4 stale-base rule. *Why:* branching off a possibly-stale ref is the #1920 class. *Disposition:* no action needed.

**6. One shared-file edit outside `src/report/`.** `src/registry.ts` gains two lines (the import and the array entry). `src/adr/**` is untouched, so this should not conflict with the #4736 lane beyond that one file.