### PR TITLE
chore(marketplace): register fabrika and enable it in-repo — ship channel == dogfood channel (#4670)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,6 +55,11 @@
 				"claude-channel",
 				"repo-agnostic"
 			]
+		},
+		{
+			"name": "fabrika",
+			"source": "./claude-plugins/fabrika",
+			"description": "The kamp.us agent pipeline rebuilt from first principles. Authoritative description: claude-plugins/fabrika/.claude-plugin/plugin.json."
 		}
 	]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
 	"enabledPlugins": {
+		"fabrika@kampus": true,
 		"kampus-pipeline@kampus": false
 	},
 	"hooks": {


### PR DESCRIPTION
Phoenix ships the pipeline as a marketplace plugin but has never installed one that way — it reads its own skills through a symlink, so the path an outside user takes has no one walking it. That divergence is what broke an external consumer on 2026-08-01. This PR registers fabrika in the marketplace and turns it on in this repo, so from here the channel we ship on is the channel we use.

Two files, both control plane:

- `.claude-plugin/marketplace.json` gains the fabrika entry — `source: ./claude-plugins/fabrika`, the per-plugin subdir shape from ADR 0087.
- `.claude/settings.json` gains `"fabrika@kampus": true`.

Part of #4670

## §CP classification — run on this PR's actual changed-file set

```
$ git diff --name-only origin/main...HEAD
.claude-plugin/marketplace.json
.claude/settings.json

$ pipeline-cli cp-classify classify --files-file <that list>
cp-classify: control-plane [path-match] — .claude-plugin/marketplace.json matches the live CONTROL_PLANE_RE. BLOCKING (human merge).
control-plane
```

Four-state result: **`control-plane`**, by path-match, BLOCKING. `.claude/settings.json` is §CP too (the `^(\.claude|\.github)/` branch); `.claude-plugin/marketplace.json` is §CP under ADR 0212's own branch. This banks for a human control-plane merge. I have not merged and have not self-approved.

## Why the entry is three fields and not seven

The sibling entries each restate the plugin's author, license, keywords and full description — a second copy of what `claude-plugins/<name>/.claude-plugin/plugin.json` already says, free to drift from it. AC1 asks for an "un-driftable one-liner description", so fabrika's entry carries only what the marketplace schema requires (`name`, `source`) plus a one-liner that **points at** the plugin manifest instead of restating it:

```json
{
  "name": "fabrika",
  "source": "./claude-plugins/fabrika",
  "description": "The kamp.us agent pipeline rebuilt from first principles. Authoritative description: claude-plugins/fabrika/.claude-plugin/plugin.json."
}
```

## Two placement decisions that are load-bearing, not stylistic

**The entry is appended last in `plugins[]`.** `claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` Invariant 2 resolves the `.claude/skills` symlink against `grep '"source"' … | head -n1` — the **first** `source` in the file. Inserting fabrika ahead of `kampus-pipeline` would silently re-point that invariant at the fabrika tree and red the check. Verified after the edit: `validate-gate-path-drift: OK — 34 checks`, with `.claude/skills symlink agrees with marketplace source (./claude-plugins/kampus-pipeline + /skills)`.

**`"fabrika@kampus"` is placed *before* `"kampus-pipeline@kampus"` in `enabledPlugins`.** AC6 asks for the kampus-pipeline settings entry byte-untouched. JSON needs a comma between the two, so whichever entry comes first absorbs it — putting fabrika first leaves the `"kampus-pipeline@kampus": false` line byte-identical. (It is also alphabetical.)

## Acceptance criteria

- [x] **Root marketplace manifest carries the fabrika entry** — `source: ./claude-plugins/fabrika`, one-liner description. Landing via §CP approval is the merge act, not this diff.
- [x] **`.claude/settings.json` carries `fabrika@kampus: true`.** Same §CP note.
- [x] **At flip time `claude-plugins/fabrika/skills/` contains at least one authored skill.** Two on `main` today: `skills/adr/` and `skills/report/`, each with a `SKILL.md` + `contract.md`. Not an empty plugin.
- [ ] **The external-consumer confirmation gate (#4605 comment 5152608258) has landed.** **UNMET — see below.**
- [x] **fabrika is consumed through the root-marketplace entry, no symlink into `claude-plugins/fabrika/`.** The only two symlinks in `.claude/` are `agents` and `skills`, both pointing into `claude-plugins/kampus-pipeline/`; this PR adds none. fabrika's sole consumption path is the marketplace entry + the enable flag.
- [x] **`claude-plugins/kampus-pipeline/` and its settings entry are byte-untouched.** The diff is two files, neither under that tree; the settings line is unchanged byte-for-byte.

## The unmet criterion — this is a MERGE PRECONDITION, and I could not verify it

AC4 is not something a diff can satisfy: it is a real-world confirmation that the external consumer has the landed symlink remedy (#4645) present on their side. The founder ruling states the gate explicitly — *"the chief-of-staff's confirmation ask is out and its gate stands (no victory declared until the link is observed present on their side)"* — and the exit-(a) ruling re-states it as still open at 2026-08-01T18:26Z.

What I searched, so the next reader does not repeat it:

- Every comment on #4605 — the last is the kill-batch unfreeze at 2026-08-01T18:26Z; nothing after records a confirmation.
- Every comment on epic #4648, including the 2026-08-02T19:15Z engine checkpoint.
- `search/issues` with `in:comments` for `Binclusive`, `symlink remedy`, `confirmation gate`, and `external consumer confirmation` — four issues total mention Binclusive (#4377, #4380, #4605, #4648), none with a post-ruling confirmation.
- `reports/`, `.decisions/` — no record.

**Absence of a record is not proof the confirmation did not happen** — it lives outside this repo, and the person who knows is the one who sent the ask. So this is surfaced rather than assumed: the §CP approver holds the fact, and their approval is the natural place to discharge it. **Do not merge this PR until AC4 is affirmatively confirmed.** That is why this body links #4670 with a `Part of` marker rather than a closing keyword — #4670 stays open on merge, and closing it is correct only once the gate is confirmed landed.

No follow-up issue was filed for the deferred AC: it is a precondition on this same PR's merge, not a separable unit of work, so a new ticket would only fragment it away from the merge decision that owns it.

## Related, deliberately not folded in

- **#4763** (`p0`) — every fabrika skill invokes a bare `fabrika-cli`, which resolves to nothing. That ticket's own analysis says it *"blocks dogfooding, not the flip. #4670 can land first; nothing breaks. Nothing works either."* So enabling fabrika here is safe and inert; the skills become usable when #4763 lands.
- **#4761 / #4762** — `CLAUDE.md` and the crew agent-defs reach skills by filesystem path, so routing still names v1 after this flip. A comment on #4670 (5159645294) asked the flip to carry the `CLAUDE.md` re-point; triage has since re-homed that work to #4761 (which recommends folding into #4762), and #4761's triage note explicitly states the registration "is already owned by #4670 and is not folded in here." Keeping them separate matches that split, and keeps this §CP diff to two files.

## Deviations

**Class: narrowed a suggested shape.**
- *Said:* AC1 asks for the fabrika entry with a "one-liner description", by analogy to three sibling entries that each carry `author` / `license` / `keywords` as well.
- *Did:* Emitted `name` + `source` + `description` only.
- *Why:* The same AC names the drift class it is defending against — `plugin.json` is the authoritative description. Every field copied into the marketplace entry is a second copy that can drift; the schema requires only `name` and `source`. Adding the other four would have meant inventing values the issue does not specify and re-creating the drift surface in the same edit.
- *Disposition:* For the reviewer to judge. If entry-shape consistency across `plugins[]` is worth more than the drift reduction, the four fields are a one-line-each addition.

**Class: left a sibling concern for a follow-up.**
- *Said:* Comment 5159645294 on #4670 adds two items to "the flip's checklist" — re-point `CLAUDE.md`'s path-pinned skill links, and disambiguate `/adr` now that two skills answer to the name.
- *Did:* Did not touch `CLAUDE.md`.
- *Why:* #4761 and #4762 were filed after that comment and now own exactly that work; #4761's triage note draws the boundary the other way too, leaving the marketplace registration to this issue.
- *Disposition:* No action needed — #4761 / #4762 own it.

**Class: judgment call the issue did not specify (entry ordering).**
- *Said:* Nothing about where in `plugins[]` or `enabledPlugins` the new entries go.
- *Did:* Appended the manifest entry last; placed the settings entry first.
- *Why:* Both positions are forced by checks that read position — `validate-gate-path-drift.sh` Invariant 2 reads the first `"source"`, and AC6's byte-untouched requirement is only literally true if the new settings line absorbs the comma.
- *Disposition:* No action needed; both are stated above so a later editor does not "tidy" the order and break a check.


---

## Note for the control-plane approver (added by the execution engine)

**This flip does not deliver dogfooding, and must not be read as discharging the dogfood ruling.**

Enabling registers the plugin and breaks nothing — the skills load and become addressable. But every fabrika skill's first command invokes a bare `fabrika-cli`, which resolves to nothing and exits 127 (#4763, `p0`, `type:decision`). Until the invocation form is ruled, this flip makes fabrika *present*, not *working*.

That is not an argument against merging — #4763's own analysis is that it blocks dogfooding, not the flip. It is stated here so the approval is spent on what this change actually is.

**Merge precondition still outstanding:** AC4 requires the external-consumer confirmation gate to have landed before the manifest entry does, and no record of it exists anywhere in this repo (searched #4605's and #4648's comments, `search/issues` across comments, `reports/`, `.decisions/`). Absence is not proof — that fact lives outside this repo. **Do not merge until it is affirmatively confirmed.** If it already landed and simply was not written down, recording it on #4605 unblocks this with no code change.

Filed by an agent
