### PR TITLE
fix(fabrika): plant the fabrika-cli shim the bare invocation resolves to (#4784)

### DIFF
--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -47,8 +47,20 @@ claude-plugins/fabrika/
 `bin/` is on `PATH` for an enabled plugin, which is what makes the bare literal invocation the
 [CLI interface convention](docs/cli-interface-convention.md) mandates resolve. The shim finds
 `packages/fabrika-cli/src/bin.ts` from its own path and runs it under `node` — no build step, and no
-cwd dependence, since an agent's working directory resets between calls. Outside a phoenix checkout
-it resolves nothing and says so on stderr with exit `2`; #4775 owns that consumer-side install path.
+cwd dependence, since an agent's working directory resets between calls.
+
+It selects that tier on **runnability, not file presence**: a marketplace install is a depth-1 clone
+of the whole tree, so the source file is on disk in a consumer while its imports cannot resolve
+there, and a `-f` test would pick a tier that cannot run. The registry tier behind it
+(`@kampus/fabrika-cli` at a pinned version) is **empty today** — the package is unpublished and
+[#4786](https://github.com/kamp-us/phoenix/issues/4786) owns the publish path — so it rejects itself
+by name rather than resolving to nothing.
+
+**So fabrika works inside a phoenix checkout and does not work outside one yet.** In a consumer every
+fence exits `2` with nothing on stdout and, on stderr, each tier and why it was rejected. That is a
+well-worded failure, not a working fabrika; the "works outside phoenix" criterion
+([#4776](https://github.com/kamp-us/phoenix/issues/4776)) is discharged by the publish path, not
+here.
 
 `skills/` carries no `README` and no loose files: the fabrika layout law is `SKILL.md` under a
 per-skill directory and nothing else at the `skills/` root. A `.gitkeep` remains from when the

--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -39,9 +39,16 @@ that appears here by any other route is a defect, not a shortcut — the door is
 claude-plugins/fabrika/
 ├── .claude-plugin/plugin.json   the plugin manifest (no version — ADR 0110, continuous ship)
 ├── README.md                    this file: the mission, the only-door posture, the layout
+├── bin/fabrika-cli              what the bare `fabrika-cli` in every skill resolves to (#4784)
 ├── docs/                        the canonical convention + contract docs (see docs/README.md)
 └── skills/                      one dir per skill, each authored by /skill-creator
 ```
+
+`bin/` is on `PATH` for an enabled plugin, which is what makes the bare literal invocation the
+[CLI interface convention](docs/cli-interface-convention.md) mandates resolve. The shim finds
+`packages/fabrika-cli/src/bin.ts` from its own path and runs it under `node` — no build step, and no
+cwd dependence, since an agent's working directory resets between calls. Outside a phoenix checkout
+it resolves nothing and says so on stderr with exit `2`; #4775 owns that consumer-side install path.
 
 `skills/` carries no `README` and no loose files: the fabrika layout law is `SKILL.md` under a
 per-skill directory and nothing else at the `skills/` root. A `.gitkeep` remains from when the

--- a/claude-plugins/fabrika/bin/fabrika-cli
+++ b/claude-plugins/fabrika/bin/fabrika-cli
@@ -7,25 +7,39 @@
 # syntactic check on the command string, so a variable-rooted `"$SOMETHING"/fabrika-cli` is
 # unusable by construction (#4641, ADR 0232).
 #
-# Resolution — one tier, then a loud refusal:
-#   1. the in-repo TypeScript entry point, located from THIS FILE's own path
-#      (bin -> fabrika -> claude-plugins -> repo root). Self-path resolution is load-bearing: an
-#      agent's working directory resets between Bash calls, so anything keyed on the caller's cwd
-#      is broken by construction. Node runs the `.ts` directly, so a fresh checkout works with no
-#      build step and an absent `dist/` can never resurface as a resolution failure.
-#   2. there is no second tier. `@kampus/fabrika-cli` is unpublished (verified 404 against the live
-#      registry), so a registry fallback would resolve to nothing while looking like a safety net.
-#      A failure to resolve prints what was looked for and where, and exits 2.
+# Three tiers, tried in order, then a refusal that names each tier and why it was rejected:
 #
-# Exit 2 is reserved for "the shim ran but could not resolve the implementation" — deliberately
-# neither 127 (which is what an unresolved binary produces, silently, and is the state this file
-# exists to make impossible to reach) nor 1 (a verb's own usage error), so "never ran" and "ran and
-# said no" stay distinguishable (#4666). The reserved-code table lives in
-# ../docs/cli-interface-convention.md rule 3.
+#   1. the in-repo TypeScript source, located from THIS FILE's own path (bin -> fabrika ->
+#      claude-plugins -> repo root). Self-path resolution is load-bearing: an agent's working
+#      directory resets between Bash calls, so anything keyed on the caller's cwd is broken by
+#      construction. Node runs the `.ts` directly, so a fresh checkout needs no build step.
+#
+#      Selected on RUNNABILITY, never on file presence. A marketplace install is a depth-1 clone
+#      of the WHOLE tree, so `packages/fabrika-cli/src/bin.ts` is on disk in a consumer while node
+#      cannot resolve its imports there — an `-f` test would confidently select a tier that cannot
+#      run. That was measured on a live install, and it is why the #4784 ruling was amended.
+#
+#   2. a registry fetch of the pinned `@kampus/fabrika-cli`. EMPTY TODAY: the package is a verified
+#      npm 404 and nothing publishes it yet (#4786 owns the publish path), so the pin below is
+#      deliberately unset and this tier rejects itself out loud. An unset pin is never interpolated
+#      into a fetch — `<pkg>@` resolves to whatever `latest` happens to be, and resolving to
+#      something-other-than-the-pin is the failure mode this tier must not have.
+#
+#   3. loud, legible refusal: nothing on stdout, every tier and its rejection reason on stderr.
+#
+# Exit 2 is reserved for "the shim ran but could not resolve an implementation" — deliberately
+# neither 127 (what an unresolved binary produces, silently, and the state this file exists to make
+# unreachable) nor 1 (a verb's own usage error), so "never ran" and "ran and said no" stay
+# distinguishable (#4666). `packages/fabrika-cli/src/bin.ts` exits the same 2 when a dependency
+# fails to load past this shim's probe, so the code holds on every resolution path. The
+# reserved-code table lives in ../docs/cli-interface-convention.md rule 3.
 #
 # fabrika calls nothing under claude-plugins/kampus-pipeline/ (ADR 0238, rule 6). v1's
 # `pipeline-cli` shim was read for its shape and its scars; it is never invoked.
 set -uo pipefail
+
+FABRIKA_CLI_PKG="@kampus/fabrika-cli"
+FABRIKA_CLI_PIN="" # unset until #4786 publishes; see tier 2 above.
 
 SHIM_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 if [ -z "${SHIM_DIR:-}" ] || [ ! -d "$SHIM_DIR" ]; then
@@ -33,18 +47,22 @@ if [ -z "${SHIM_DIR:-}" ] || [ ! -d "$SHIM_DIR" ]; then
 	exit 2
 fi
 
-REPO_SRC="$SHIM_DIR/../../../packages/fabrika-cli/src/bin.ts"
+REPO_PKG_DIR="$SHIM_DIR/../../../packages/fabrika-cli"
+REPO_SRC="$REPO_PKG_DIR/src/bin.ts"
 
-if [ -f "$REPO_SRC" ]; then
-	if ! command -v node >/dev/null 2>&1; then
-		{
-			echo "fabrika-cli: found the verb package at"
-			echo "    $REPO_SRC"
-			echo "  but no \`node\` is on PATH to run it — refusing to run."
-			echo "  Install Node (the package pins 26.2.0 via volta) and re-run."
-		} >&2
-		exit 2
-	fi
+TIER1_REJECT=""
+TIER2_REJECT=""
+
+if [ ! -f "$REPO_SRC" ]; then
+	TIER1_REJECT="no in-repo verb package — nothing at $REPO_SRC"
+elif ! command -v node >/dev/null 2>&1; then
+	TIER1_REJECT="the verb package is at $REPO_SRC, but no \`node\` is on PATH to run it (the package pins 26.2.0 via volta)"
+elif ! (
+	cd -- "$REPO_PKG_DIR" &&
+		node --input-type=module -e 'import.meta.resolve("effect");import.meta.resolve("@effect/platform-node")'
+) >/dev/null 2>&1; then
+	TIER1_REJECT="the verb package is present at $REPO_SRC but is NOT runnable — node's own resolver, run from $REPO_PKG_DIR, cannot resolve the two runtime dependencies that package declares (effect, @effect/platform-node), so its imports would not load"
+else
 	# bash 3.2 aborts on "$@" under `set -u` when there are no positional parameters, so the
 	# no-argument case gets its own expansion-free exec.
 	if [ "$#" -gt 0 ]; then
@@ -53,18 +71,35 @@ if [ -f "$REPO_SRC" ]; then
 	exec node "$REPO_SRC"
 fi
 
+if [ -z "$FABRIKA_CLI_PIN" ]; then
+	TIER2_REJECT="no pinned version to fetch — $FABRIKA_CLI_PKG is unpublished (a verified npm 404) and nothing publishes it yet; #4786 owns the publish path"
+elif ! command -v pnpm >/dev/null 2>&1; then
+	TIER2_REJECT="pinned at $FABRIKA_CLI_PKG@$FABRIKA_CLI_PIN, but no \`pnpm\` is on PATH to fetch it"
+else
+	if [ "$#" -gt 0 ]; then
+		exec pnpm dlx "$FABRIKA_CLI_PKG@$FABRIKA_CLI_PIN" "$@"
+	fi
+	exec pnpm dlx "$FABRIKA_CLI_PKG@$FABRIKA_CLI_PIN"
+fi
+
 {
-	echo "fabrika-cli: cannot resolve the fabrika verb package — refusing to run."
-	echo "  looked for the in-repo TypeScript entry point at:"
-	echo "    $REPO_SRC"
+	echo "fabrika-cli: no tier resolved a fabrika implementation — refusing to run."
+	echo
+	echo "  tier 1 — in-repo TypeScript source, selected on runnability — REJECTED:"
+	echo "      $TIER1_REJECT"
+	echo "  tier 2 — registry fetch at a pinned version — REJECTED:"
+	echo "      $TIER2_REJECT"
+	echo "  tier 3 — this message."
+	echo
 	echo "  resolved from this shim at:"
-	echo "    $SHIM_DIR"
+	echo "      $SHIM_DIR"
 	echo "  (resolution is keyed on the shim's own path, never on the caller's working directory)"
 	echo
-	echo "  This is what a fabrika plugin installed OUTSIDE a phoenix checkout looks like: the"
-	echo "  plugin ships the skills and this shim, but not packages/fabrika-cli. #4775 owns that"
-	echo "  consumer-side install path; nothing here silently falls back to a registry, because"
-	echo "  @kampus/fabrika-cli is unpublished."
+	echo "  If this tree is your own phoenix checkout, run \`pnpm install\` at its root and re-run."
+	echo "  If it is a marketplace-managed plugin clone, do NOT install into it — that directory is"
+	echo "  owned and re-synced by the harness. Outside a phoenix checkout fabrika has no working"
+	echo "  implementation until $FABRIKA_CLI_PKG is published (#4786); this refusal is the honest"
+	echo "  answer, not a fallback."
 	echo
 	echo "  Exit 2 means the verb never ran. It is NOT a verdict, and it is NOT 127."
 } >&2

--- a/claude-plugins/fabrika/bin/fabrika-cli
+++ b/claude-plugins/fabrika/bin/fabrika-cli
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# `fabrika-cli` — the executable the bare name in every fabrika skill resolves to (#4784).
+#
+# An enabled plugin's `<plugin-root>/bin` is appended to PATH, so planting this file is what makes
+# the bare literal invocation rule 5 of ../docs/cli-interface-convention.md mandates actually run.
+# The bare form is the whole point and is not negotiable: the harness's isolation verifier is a
+# syntactic check on the command string, so a variable-rooted `"$SOMETHING"/fabrika-cli` is
+# unusable by construction (#4641, ADR 0232).
+#
+# Resolution — one tier, then a loud refusal:
+#   1. the in-repo TypeScript entry point, located from THIS FILE's own path
+#      (bin -> fabrika -> claude-plugins -> repo root). Self-path resolution is load-bearing: an
+#      agent's working directory resets between Bash calls, so anything keyed on the caller's cwd
+#      is broken by construction. Node runs the `.ts` directly, so a fresh checkout works with no
+#      build step and an absent `dist/` can never resurface as a resolution failure.
+#   2. there is no second tier. `@kampus/fabrika-cli` is unpublished (verified 404 against the live
+#      registry), so a registry fallback would resolve to nothing while looking like a safety net.
+#      A failure to resolve prints what was looked for and where, and exits 2.
+#
+# Exit 2 is reserved for "the shim ran but could not resolve the implementation" — deliberately
+# neither 127 (which is what an unresolved binary produces, silently, and is the state this file
+# exists to make impossible to reach) nor 1 (a verb's own usage error), so "never ran" and "ran and
+# said no" stay distinguishable (#4666). The reserved-code table lives in
+# ../docs/cli-interface-convention.md rule 3.
+#
+# fabrika calls nothing under claude-plugins/kampus-pipeline/ (ADR 0238, rule 6). v1's
+# `pipeline-cli` shim was read for its shape and its scars; it is never invoked.
+set -uo pipefail
+
+SHIM_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if [ -z "${SHIM_DIR:-}" ] || [ ! -d "$SHIM_DIR" ]; then
+	echo "fabrika-cli: could not resolve this shim's own directory — refusing to run." >&2
+	exit 2
+fi
+
+REPO_SRC="$SHIM_DIR/../../../packages/fabrika-cli/src/bin.ts"
+
+if [ -f "$REPO_SRC" ]; then
+	if ! command -v node >/dev/null 2>&1; then
+		{
+			echo "fabrika-cli: found the verb package at"
+			echo "    $REPO_SRC"
+			echo "  but no \`node\` is on PATH to run it — refusing to run."
+			echo "  Install Node (the package pins 26.2.0 via volta) and re-run."
+		} >&2
+		exit 2
+	fi
+	# bash 3.2 aborts on "$@" under `set -u` when there are no positional parameters, so the
+	# no-argument case gets its own expansion-free exec.
+	if [ "$#" -gt 0 ]; then
+		exec node "$REPO_SRC" "$@"
+	fi
+	exec node "$REPO_SRC"
+fi
+
+{
+	echo "fabrika-cli: cannot resolve the fabrika verb package — refusing to run."
+	echo "  looked for the in-repo TypeScript entry point at:"
+	echo "    $REPO_SRC"
+	echo "  resolved from this shim at:"
+	echo "    $SHIM_DIR"
+	echo "  (resolution is keyed on the shim's own path, never on the caller's working directory)"
+	echo
+	echo "  This is what a fabrika plugin installed OUTSIDE a phoenix checkout looks like: the"
+	echo "  plugin ships the skills and this shim, but not packages/fabrika-cli. #4775 owns that"
+	echo "  consumer-side install path; nothing here silently falls back to a registry, because"
+	echo "  @kampus/fabrika-cli is unpublished."
+	echo
+	echo "  Exit 2 means the verb never ran. It is NOT a verdict, and it is NOT 127."
+} >&2
+exit 2

--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -76,8 +76,14 @@ exit taxonomy, and the verdict-vs-invocation rule proven in v1 at
   |---|---|
   | `0` | the answer was produced on stdout |
   | `1` | usage error, or the verb failed to run |
+  | `2` | the `fabrika-cli` shim ran but resolved no implementation to hand the verb to (rule 5) |
   | `127` | the verb never ran at all (unresolved binary) |
   | `3`+ | the verb's own proven outcomes, each enumerated in `--help` |
+
+  `2` is reserved for the shim, so **no verb may return it**. It exists because `127` and empty
+  output are what an unresolvable binary produces on its own — the one failure that is
+  byte-identical to a verb that ran and refused. The shim never lets a caller land there silently:
+  it prints what it looked for and where, and exits `2`.
 
 - A verb whose result crosses a pipe keeps its exit code binary (`0` / non-zero) and puts the
   discriminator in a stdout state word: a meaningful code does not survive `xargs`.
@@ -109,12 +115,19 @@ usable at an agent's top-level command.
 
 - A fabrika verb is invoked as a plain literal command string — written `fabrika-cli <verb> …`
   throughout this doc. No `$VAR`, no `${VAR:-default}`, no command substitution, no `source`.
-  **The binary name is illustrative and not fixed here.** Where fabrika's verbs live — and so what
-  they are invoked as — is deferred to [#4650](https://github.com/kamp-us/phoenix/issues/4650) (epic
-  [#4648](https://github.com/kamp-us/phoenix/issues/4648), Resolved question 2: the seed package
-  rides with the first derived contract, because minting one earlier would invert
-  contract-before-implementation). This rule constrains the **form** of an invocation, never its
-  name; substitute whatever name #4650 lands.
+- **The literal is `fabrika-cli`.** The name was deferred to
+  [#4650](https://github.com/kamp-us/phoenix/issues/4650) while the seed package was still being
+  derived; [#4784](https://github.com/kamp-us/phoenix/issues/4784) closes that deferral by planting
+  the executable, so the name is now fixed rather than illustrative. Every skill, every `--help`
+  example and every contract spec writes exactly `fabrika-cli`.
+
+  What the name resolves to is [`../bin/fabrika-cli`](../bin/fabrika-cli), a committed shim in the
+  plugin's own `bin/` — the directory an enabled plugin contributes to `PATH`. The shim locates the
+  verb package from **its own path**, never from the caller's working directory, because an agent's
+  working directory resets between Bash calls. It runs the TypeScript source directly, so a fresh
+  checkout needs no build step and a missing build artifact cannot resurface as an unresolved
+  binary. When it resolves nothing it says what it looked for and where, and exits `2` (rule 3) —
+  never `127`, never silence.
 - **Examples in `--help` and in a contract spec are held to the same rule.** An example an agent
   cannot paste verbatim is not an example.
 - A verb never requires an env var to *locate* itself. Configuration may still arrive by env
@@ -215,9 +228,8 @@ point: an implementer can tell an unfinished spec from a finished one before sta
 
 Illustration only. It is not a commissioned verb, and it does not pre-commit the `/adr` contract —
 that one is derived by its own authoring session as the wave-0 pilot in
-[#4650](https://github.com/kamp-us/phoenix/issues/4650). The `fabrika-cli` binary name it invokes is
-illustrative on the same terms (rule 5): an example needs a name to be readable, and #4650 owns the
-real one. It is here to show a complete block at the level of detail the completeness test demands.
+[#4650](https://github.com/kamp-us/phoenix/issues/4650). It is here to show a complete block at the
+level of detail the completeness test demands.
 
 ---
 

--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -76,14 +76,16 @@ exit taxonomy, and the verdict-vs-invocation rule proven in v1 at
   |---|---|
   | `0` | the answer was produced on stdout |
   | `1` | usage error, or the verb failed to run |
-  | `2` | the `fabrika-cli` shim ran but resolved no implementation to hand the verb to (rule 5) |
+  | `2` | no implementation was resolved, so no verb was reached (rule 5) |
   | `127` | the verb never ran at all (unresolved binary) |
   | `3`+ | the verb's own proven outcomes, each enumerated in `--help` |
 
-  `2` is reserved for the shim, so **no verb may return it**. It exists because `127` and empty
+  `2` is reserved for resolution, so **no verb may return it**. It exists because `127` and empty
   output are what an unresolvable binary produces on its own — the one failure that is
-  byte-identical to a verb that ran and refused. The shim never lets a caller land there silently:
-  it prints what it looked for and where, and exits `2`.
+  byte-identical to a verb that ran and refused. It is emitted by whichever layer discovers the
+  failure — the shim when no tier is runnable, or the verb package's bootstrap when a dependency
+  fails to load past the shim's probe — and either way the caller can tell "never ran" from "ran and
+  said no" without reading the text.
 
 - A verb whose result crosses a pipe keeps its exit code binary (`0` / non-zero) and puts the
   discriminator in a stdout state word: a meaningful code does not survive `xargs`.
@@ -126,8 +128,19 @@ usable at an agent's top-level command.
   verb package from **its own path**, never from the caller's working directory, because an agent's
   working directory resets between Bash calls. It runs the TypeScript source directly, so a fresh
   checkout needs no build step and a missing build artifact cannot resurface as an unresolved
-  binary. When it resolves nothing it says what it looked for and where, and exits `2` (rule 3) —
-  never `127`, never silence.
+  binary.
+
+  It picks that tier on **runnability, not file presence**. A marketplace install is a depth-1 clone
+  of the whole repository, so the source file exists in a consumer while its imports cannot resolve
+  there — an `-f` test would select a tier that cannot run, and would keep doing so after the
+  registry tier lands. The registry tier (`@kampus/fabrika-cli` at a pinned version) is **empty
+  today**: the package is unpublished, so the pin is unset and the tier rejects itself by name
+  rather than fetching whatever `latest` happens to be
+  ([#4786](https://github.com/kamp-us/phoenix/issues/4786) owns the publish path).
+
+  **In a phoenix checkout the fences run; outside one, none of them do — yet.** When no tier
+  resolves, the shim names each tier it tried and why it was rejected, and exits `2` (rule 3) with
+  nothing on stdout — never `127`, never silence.
 - **Examples in `--help` and in a contract spec are held to the same rule.** An example an agent
   cannot paste verbatim is not an example.
 - A verb never requires an env var to *locate* itself. Configuration may still arrive by env

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -53,7 +53,7 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
   from the `origin` remote) is the repository whose open pull requests form the in-flight set.
   `--json` swaps the line grammar for one JSON object with the named keys given per verb.
 - **Reserved exit codes.** `0` = the answer is on stdout. `1` = usage error, or the verb failed to
-  run. `2` = the `fabrika-cli` shim resolved no implementation, so no verb may return it. `127` =
+  run. `2` = no implementation was resolved, so no verb was reached — no verb may return it. `127` =
   the verb never ran. `3` and up are each verb's own proven outcomes.
 - **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
   a caller reads the status before the bytes.

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -53,7 +53,8 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
   from the `origin` remote) is the repository whose open pull requests form the in-flight set.
   `--json` swaps the line grammar for one JSON object with the named keys given per verb.
 - **Reserved exit codes.** `0` = the answer is on stdout. `1` = usage error, or the verb failed to
-  run. `127` = the verb never ran. `3` and up are each verb's own proven outcomes.
+  run. `2` = the `fabrika-cli` shim resolved no implementation, so no verb may return it. `127` =
+  the verb never ran. `3` and up are each verb's own proven outcomes.
 - **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
   a caller reads the status before the bytes.
 - **GitHub reads go through `gh api` REST, never GraphQL** — the org's Projects-classic integration

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -14,17 +14,14 @@ below is implemented from scratch here. v1's tools were read for their semantics
 each Grounding section names what the corresponding v1 tool gets wrong and what this spec does
 instead — but no clause defers to one, and none is invoked.
 
-**How the bare binary name resolves is an open blocker, not an assumption this spec makes.** The
-skill's fences invoke `fabrika-cli` as a plain literal name, which is what the harness's isolation
-verifier requires — that check is *syntactic*, on the command string. Whether the name then
-**resolves** is a separate question this spec does not answer, and the repo's own evidence says the
-analogous v1 shape does not: `packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts`
-records that a bare `pipeline-cli <verb>` "is not on PATH where pipeline agents spawn and never will
-be (ADR 0207 retired PATH-shadowing), so it dies `command not found`." Until
-[#4650](https://github.com/kamp-us/phoenix/issues/4650) lands a resolution mechanism, **every fence
-in this skill exits 127**, and 127 means the verb never ran — never a verdict. Stated here so it is
-a tracked blocker rather than a surprise, and so an eval run cannot quietly grade "the verb is not
-available yet" as though it were the skill's own behaviour.
+**The bare binary name resolves; this was a tracked blocker and is now closed.** The skill's fences
+invoke `fabrika-cli` as a plain literal name, which is what the harness's isolation verifier
+requires — that check is *syntactic*, on the command string. Whether the name then **resolved** was
+an open question this spec deliberately refused to assume, and the answer was no: every fence exited
+`127`. [#4784](https://github.com/kamp-us/phoenix/issues/4784) plants the executable at
+`claude-plugins/fabrika/bin/fabrika-cli`, the directory an enabled plugin contributes to `PATH`, so
+the fences below now run. A resolution failure there prints what it looked for and exits `2`, never
+`127` — so an eval run can still tell "the verb is not available" from the skill's own behaviour.
 
 **One skill named `report` already exists** at `claude-plugins/kampus-pipeline/skills/report/`, and
 it is model-invoked with an overlapping trigger list. The collision is dormant only by
@@ -81,7 +78,8 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
   resolvable the verb exits 1 rather than guessing. `--json` swaps the line grammar for one JSON
   object with the named keys given per verb.
 - **Reserved exit codes.** `0` = the answer is on stdout. `1` = usage error, or the verb failed to
-  run. `127` = the verb never ran. `3` and up are each verb's own proven outcomes.
+  run. `2` = the `fabrika-cli` shim resolved no implementation, so no verb may return it. `127` =
+  the verb never ran. `3` and up are each verb's own proven outcomes.
 - **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
   a caller reads the status before the bytes.
 - **GitHub reads and writes go through `gh api` REST, never GraphQL** — the org's Projects-classic

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -14,14 +14,18 @@ below is implemented from scratch here. v1's tools were read for their semantics
 each Grounding section names what the corresponding v1 tool gets wrong and what this spec does
 instead — but no clause defers to one, and none is invoked.
 
-**The bare binary name resolves; this was a tracked blocker and is now closed.** The skill's fences
-invoke `fabrika-cli` as a plain literal name, which is what the harness's isolation verifier
-requires — that check is *syntactic*, on the command string. Whether the name then **resolved** was
-an open question this spec deliberately refused to assume, and the answer was no: every fence exited
-`127`. [#4784](https://github.com/kamp-us/phoenix/issues/4784) plants the executable at
-`claude-plugins/fabrika/bin/fabrika-cli`, the directory an enabled plugin contributes to `PATH`, so
-the fences below now run. A resolution failure there prints what it looked for and exits `2`, never
-`127` — so an eval run can still tell "the verb is not available" from the skill's own behaviour.
+**The bare binary name resolves inside a phoenix checkout; outside one it does not, and says so.**
+The skill's fences invoke `fabrika-cli` as a plain literal name, which is what the harness's
+isolation verifier requires — that check is *syntactic*, on the command string. Whether the name then
+**resolved** was an open question this spec deliberately refused to assume, and the answer was no:
+every fence exited `127`. [#4784](https://github.com/kamp-us/phoenix/issues/4784) plants the
+executable at `claude-plugins/fabrika/bin/fabrika-cli`, the directory an enabled plugin contributes
+to `PATH`, so the fences below run **in a phoenix checkout**. In a plugin installed anywhere else
+they do not: the in-repo tier is present but unrunnable there and the registry tier is empty until
+`@kampus/fabrika-cli` is published ([#4786](https://github.com/kamp-us/phoenix/issues/4786)). What
+changed is that this now fails legibly instead of silently — the shim names each tier it tried and
+why, and exits `2`, never `127` — so an eval run can still tell "the verb is not available" from the
+skill's own behaviour.
 
 **One skill named `report` already exists** at `claude-plugins/kampus-pipeline/skills/report/`, and
 it is model-invoked with an overlapping trigger list. The collision is dormant only by
@@ -78,7 +82,7 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
   resolvable the verb exits 1 rather than guessing. `--json` swaps the line grammar for one JSON
   object with the named keys given per verb.
 - **Reserved exit codes.** `0` = the answer is on stdout. `1` = usage error, or the verb failed to
-  run. `2` = the `fabrika-cli` shim resolved no implementation, so no verb may return it. `127` =
+  run. `2` = no implementation was resolved, so no verb was reached — no verb may return it. `127` =
   the verb never ran. `3` and up are each verb's own proven outcomes.
 - **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
   a caller reads the status before the bytes.

--- a/packages/fabrika-cli/src/bin.ts
+++ b/packages/fabrika-cli/src/bin.ts
@@ -23,11 +23,18 @@ try {
 } catch (err) {
 	const message = err instanceof Error ? err.message : String(err);
 	if (message.includes("ERR_MODULE_NOT_FOUND") || message.includes("Cannot find package")) {
+		// Exit 2, not 1: this is "could not resolve an implementation", the same reserved code the
+		// shim uses, so a resolution failure never reads as a verb's own usage error (#4666). The
+		// remedy is stated conditionally on purpose — `pnpm install` is right for your own checkout
+		// and wrong for a marketplace-managed plugin clone, which the harness owns and re-syncs.
 		console.error(
 			`fabrika-cli: a dependency is not linked (${message}).\n` +
-				"Run `pnpm install` at the repo root, then re-run.",
+				"If this is your own phoenix checkout, run `pnpm install` at its root and re-run.\n" +
+				"If it is a marketplace-managed plugin clone, do not install into it — fabrika has no\n" +
+				"working implementation outside a phoenix checkout until @kampus/fabrika-cli is\n" +
+				"published (#4786).",
 		);
-		process.exit(1);
+		process.exit(2);
 	}
 	throw err;
 }


### PR DESCRIPTION
Every fabrika skill's first command was dead. The skills invoke `fabrika-cli <verb>` by bare name — which is the form the harness requires — but nothing had ever been planted at that name, so every fence exited 127 and no fabrika skill could complete a step. This adds the missing executable: a small committed shim in the plugin's own `bin/`, the directory an enabled plugin contributes to `PATH`.

The shim finds the verb package from **its own path**, never from the caller's working directory, and runs the TypeScript source directly so a fresh checkout needs no build. It selects that tier on **runnability, not file presence**. When no tier resolves it names each tier it tried and why it was rejected, and exits `2` — never a silent 127.

Fixes #4784

## Scope — what this does and does not discharge

**#4784 does not discharge the #4776 "works outside phoenix" release criterion. It discharges the dev case, and a consumer gets a well-worded failure, not a working fabrika.** In a phoenix checkout every fence runs. In a plugin installed anywhere else, the in-repo tier is present but unrunnable and the registry tier is empty until `@kampus/fabrika-cli` is published, so every fence exits `2` with a legible enumeration of what was tried. #4786 owns the publish path and is a hard dependency of the consumer case.

## What changed

| Path | Change |
|---|---|
| `claude-plugins/fabrika/bin/fabrika-cli` | new, mode `100755` — the shim, three tiers, tier 1 gated on runnability |
| `packages/fabrika-cli/src/bin.ts` | its dependency-load catch exits `2`, not `1`, and drops the install-into-a-managed-clone remedy |
| `claude-plugins/fabrika/docs/cli-interface-convention.md` | rule 5 names the literal (closes the #4650 deferral) and states the tier rule; rule 3's table reserves `2` for resolution |
| `claude-plugins/fabrika/skills/report/contract.md` | the tracked "every fence exits 127" blocker is closed, scoped to where the fences actually run |
| `claude-plugins/fabrika/skills/adr/contract.md` | reserved-exit-code line carries `2` |
| `claude-plugins/fabrika/README.md` | layout gains `bin/`, with the tier rule and the non-discharge stated plainly |

No fabrika skill's invocation style is touched. The bare literal form stays exactly as rule 5 mandates — the fix is entirely on the executable-planting end.

## Design calls

**Tier 1 is gated on runnability, and the probe is node's own resolver.** A marketplace install is a depth-1 clone of the **whole** repository, so `packages/fabrika-cli/src/bin.ts` is on disk in a consumer while its imports cannot resolve there. An `-f` test therefore selects a tier that cannot run — and would keep selecting it after the registry tier lands, making the follow-up unit unreachable. The probe is:

```
( cd -- "$REPO_PKG_DIR" && node --input-type=module \
    -e 'import.meta.resolve("effect");import.meta.resolve("@effect/platform-node")' )
```

**Why it is reliable, stated so it can be checked:** it does not model resolution, it *asks the resolver*. `import.meta.resolve` is node's own ESM resolution algorithm — the same one `node src/bin.ts` runs — and it is invoked from the verb package's own directory, so the `node_modules` walk-up is the identical chain the real run would take. The specifiers are the two runtime dependencies `packages/fabrika-cli/package.json` declares, read off that file rather than guessed. A missing interpreter is caught separately and named separately, because `command -v node` tests the interpreter, not resolution.

**Its residual, and why no path can read a resolution failure as an answer.** Resolving the two direct dependencies does not prove the whole module graph loads — a broken *transitive* link would pass the probe and fail the run. That gap is closed on the other side rather than papered over: `packages/fabrika-cli/src/bin.ts` catches an `ERR_MODULE_NOT_FOUND` past the probe and now exits the same reserved `2` (it exited `1` before, which is the code for a verb's own usage error). So every resolution failure, at either layer, exits `2`, and "never ran" stays distinguishable from "ran and said no" (#4666).

**Cost, measured rather than assumed:** the resolve probe costs **39 ms**; actually importing both packages costs **311 ms**. The probe runs on every invocation, and the ruling itself weighted hot-path latency heavily, so the 8×-cheaper probe plus the bootstrap's exit-`2` backstop is the better pair. Both numbers measured on this machine at this head.

**Tier 2 is a registry fetch at a pinned version, and it is empty today.** Per the founder overrule, tier 2 is a registry fetch of `@kampus/fabrika-cli` — not a committed bundle and not an install into the plugin clone. It lands structurally: the package name and pin are constants, and the tier `exec`s `pnpm dlx "<pkg>@<pin>"` when both are usable. **The pin is deliberately unset**, because the package is a verified npm 404 and nothing publishes it (#4786). An unset pin is never interpolated into a fetch: `<pkg>@` resolves to whatever `latest` happens to be, and resolving to something-other-than-the-pin is exactly the resolve-to-nothing this tier must not do. So today the tier rejects itself, by name, with the reason and the owning issue.

**Self-path resolution, not cwd.** v1's `claude-plugins/kampus-pipeline/bin/pipeline-cli` was read for its shape and its scars; its tier 1 resolves from the shim's own path, and that is the load-bearing property here too. An agent's working directory resets between Bash calls, so anything keyed on `pwd` is broken by construction. Read for shape only: the shim invokes nothing under `packages/pipeline-cli/` or `claude-plugins/kampus-pipeline/` (ADR 0238, convention rule 6). The only commands it can execute are `node` and, once a pin exists, `pnpm dlx`.

**Run the TypeScript source; require no build artifact.** `packages/fabrika-cli/package.json` declares `"bin": {"fabrika-cli": "./dist/bin.js"}`, an artifact absent in a fresh checkout. Depending on it would reintroduce exactly the defect class this issue exists to kill — a missing artifact surfacing as a 127 rather than as a legible error. Node runs `src/bin.ts` directly (the package's own `cli` script already does), so the shim always gets the fresh tree.

**Bash 3.2 shape.** `set -uo pipefail`, never `-e`, no cleanup `EXIT` trap (`.patterns/skill-script-shell-shape.md`). Each `exec` site gets its own expansion-free no-argument form because bash 3.2 aborts on `"$@"` under `set -u` with no positional parameters. `shellcheck --shell=bash` on the shim: clean, zero findings.

## Verification

Re-measured at this head by running, not asserting. Each case ran the bare literal `fabrika-cli` with the relevant `bin/` on `PATH`; stdout and stderr were captured to files and byte-counted.

| Case | Exit | stdout bytes |
|---|---|---|
| Dev checkout, `--help`, from `cwd=/` | `0` | 1134 |
| Dev checkout, `adr next`, from a linked worktree | `0` | 5 (`0239`) |
| **Consumer-unrunnable** — source present, no `node_modules`, from `cwd=/` | **`2`** | **0** |
| **Orphaned shim** — no verb package at all, from `cwd=/` | **`2`** | **0** |
| Verb package's own bootstrap, invoked directly past the shim in the unrunnable tree | **`2`** | **0** |

The consumer case is the marketplace shape reproduced: `claude-plugins/fabrika/bin/fabrika-cli` plus `packages/fabrika-cli/{src,package.json}`, with `node_modules` absent. Its stderr:

```
fabrika-cli: no tier resolved a fabrika implementation — refusing to run.

  tier 1 — in-repo TypeScript source, selected on runnability — REJECTED:
      the verb package is present at <sim>/packages/fabrika-cli/src/bin.ts but is NOT
      runnable — node's own resolver, run from <sim>/packages/fabrika-cli, cannot resolve
      the two runtime dependencies that package declares (effect, @effect/platform-node),
      so its imports would not load
  tier 2 — registry fetch at a pinned version — REJECTED:
      no pinned version to fetch — @kampus/fabrika-cli is unpublished (a verified npm 404)
      and nothing publishes it yet; #4786 owns the publish path
  tier 3 — this message.

  resolved from this shim at:
      <sim>/claude-plugins/fabrika/bin
  (resolution is keyed on the shim's own path, never on the caller's working directory)

  If this tree is your own phoenix checkout, run `pnpm install` at its root and re-run.
  If it is a marketplace-managed plugin clone, do NOT install into it — that directory is
  owned and re-synced by the harness. Outside a phoenix checkout fabrika has no working
  implementation until @kampus/fabrika-cli is published (#4786); this refusal is the honest
  answer, not a fallback.

  Exit 2 means the verb never ran. It is NOT a verdict, and it is NOT 127.
```

The orphaned-shim case differs only in tier 1's reason (`no in-repo verb package — nothing at <path>`), which is the point of enumerating per tier.

**Nothing under `kampus-pipeline` is invoked.** Non-comment lines naming `pipeline-cli` or `kampus-pipeline`: 0. The only executables named anywhere in the file are `node` and `pnpm`.

**Committed mode:**

```
$ git ls-files -s claude-plugins/fabrika/bin/fabrika-cli
100755 c5d8019af9436ce64ae60de90f19199fd8ee36a0 0	claude-plugins/fabrika/bin/fabrika-cli
```

`pnpm typecheck` green (30/30), `pnpm lint:worktree` clean, `packages/fabrika-cli` tests 244/244 passing, `shellcheck` clean on the shim.

## Deviations

**1. The bare-form demonstration prepends the plugin's `bin/` to `PATH` explicitly, rather than relying on this session's ambient PATH.**
*Said:* demonstrate a bare `fabrika-cli --help` "run from an agent Bash tool with the fabrika plugin enabled".
*Did:* ran the bare literal from an agent Bash tool with the plugin's `bin/` directory on `PATH`, set explicitly for the run.
*Why:* this session's `PATH` was computed before fabrika was enabled (PR #4771 merged mid-session), so it carries no fabrika entry — nothing in this diff can retroactively change that. The PATH-append mechanism itself is already proven and unchanged: `claude-plugins/pipeline-crew/bin` is on this session's `PATH` as a repo path, and check 14 on the issue re-proved an enabled plugin's `<plugin-root>/bin` is appended whether or not it exists. What was untestable before and is tested here is the half this diff owns — that the executable is there and resolves.
*Disposition:* for the reviewer to judge; a session started after this merges gets the ambient path for free.

**2. Foreign-consumer behaviour is scoped out, not delivered.**
*Said:* the behaviour against a fabrika installed outside phoenix is "either demonstrated or explicitly scoped out with the follow-up named".
*Did:* scoped out, and the behaviour is *defined* rather than left undefined — a foreign install gets the legible exit-`2` refusal shown above, naming what was missing. It does not run verbs there.
*Why:* the verb package lives in `packages/fabrika-cli/`, which a plugin install does not carry, and `@kampus/fabrika-cli` is unpublished (verified 404), so no fallback tier exists to write. Inventing a vendored-`dist` tier would be speculative design ahead of the delivery decision.
*Disposition:* #4775 already owns the consumer-side install path; named in the shim's diagnostic and in the plugin README rather than filed as a duplicate.

**3. #4763 is reconciled by this change, but no comment was posted to it.**
*Said:* "#4763 is reconciled in the same change rather than left as a parallel lane."
*Did:* delivered #4763's second work item — the `claude-plugins/fabrika/bin/` shim the PATH entry points at — as this single change, so there is no parallel build lane.
*Why:* this run's write authority was scoped to #4784 and its PR, so the tracker-side follow-ups on #4763 (posting this result, and its re-type off `type:decision`, which triage owns) could not be performed. Surfaced rather than silently dropped.
*Disposition:* for whoever holds write authority on #4763 — this addresses #4763's shim item; nothing here re-litigates its retracted original premise.

**4. `bin/fabrika-cli` is a shell shim, not an Effect TS CLI.**
*Said:* CLAUDE.md prefers Node over ad-hoc scripts, and fabrika verbs are Effect TS CLIs.
*Did:* the resolver itself is bash.
*Why:* it is a bootstrap that must run *before* any Node module can be located — it cannot be written in the thing it exists to find. v1's `pipeline-cli` shim is the same shape for the same reason. All actual logic stays in `packages/fabrika-cli`.
*Disposition:* no action needed.

**5. (repair round 1) The repair edits `packages/fabrika-cli/src/bin.ts`, a file outside the original diff.**
*Said:* the round's findings are about the shim and three documents.
*Did:* also changed the verb package's bootstrap catch to exit `2` instead of `1`, and reworded its remedy.
*Why:* the finding is that the reserved `2` is lost on a real resolution failure. Fixing only the shim leaves one path — a transitive dependency that resolves past the probe and fails at load — still exiting `1`, i.e. the discriminator holds *almost* everywhere, which is the shape of the defect rather than its fix. The exit code is the contract three documents in this diff state, so making the contract true required this line.
*Disposition:* for the reviewer to judge; it is one `process.exit` and one message, inside the same reserved-code contract.

**6. (repair round 1) Deviation 2 above is superseded in part and left standing.**
*Said:* the §DEV log is the PR's whole-life record and is never rewritten.
*Did:* left Deviation 2 exactly as written, though its "no fallback tier exists to write" reasoning was overtaken by the founder overrule that made tier 2 a registry fetch.
*Why:* the round-0 entry records what was decided with what was known then; overwriting it would erase the trail. The current position is the Scope section and the tier-2 design call above.
*Disposition:* no action needed.

**7. (repair round 1) The branch was rebased onto `origin/main` before the fix.**
*Said:* nothing about the base.
*Did:* `git rebase origin/main` (clean, no conflicts) ahead of the repair, so the round-1 push is a force-with-lease.
*Why:* the R2 freshen-the-base step — `main` had moved one commit while the PR sat in the gate.
*Disposition:* the head moved, so the prior verdicts are staleness-invalidated by design; the fresh gate re-binds to this head.
