### PR TITLE
feat(publish): resolve the release tag to a published package (#4801)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,20 @@
-# Publishes the single consolidated `@kampus/pipeline-cli` package to npm on a
-# human-cut GitHub Release (ADR 0103). The whole agent pipeline — skills, CLIs,
-# guards, CI primitives — folds into this one package, so there is exactly one
-# thing to publish and no "which package" to derive (that derivation, and the
-# `publish-guard` gate that enforced it, are retired with this consolidation).
+# Publishes one `@kampus/*` package to npm on a human-cut GitHub Release. A `release`
+# event carries exactly one tag, so this is a single resolved job, not a fan-out: the
+# tag's prefix names which workspace member publishes, and per-package independent
+# versions/tags are preserved.
 #
-# Release tag grammar: `pipeline-cli-v<version>` (e.g. `pipeline-cli-v0.1.0`),
-# where `<version>` exactly equals packages/pipeline-cli/package.json `version`.
-# A guard fails the run if they disagree, so a mistagged release never publishes.
+# Release tag grammar: `<unscoped-name>-v<version>` (e.g. `pipeline-cli-v0.1.0`,
+# `fabrika-cli-v0.1.0`), where `<version>` exactly equals that package's package.json
+# `version`. The resolve step below fails the run before any publish step when the
+# prefix maps to no published package or the versions disagree, so a mistagged or
+# unknown release never publishes.
+#
+# The resolve step's tag-match arms are the SINGLE source of truth for the published set:
+# `pipeline-cli publish-isolation-guard check` parses THIS file's tag-grammar regex
+# anchors to derive which packages publish (ADR 0201 §4), so adding an arm widens the
+# guard's scope automatically and dropping one narrows it. Keep the arms as literal
+# anchored regexes — moving the grammar behind a variable or an external file zeroes
+# that gate, which then fails closed (ADR 0092) rather than passing vacuously.
 #
 # Auth is OIDC Trusted Publishing — no NPM_TOKEN secret: `id-token: write` mints a
 # short-lived per-run credential, and provenance is generated automatically.
@@ -14,13 +22,16 @@
 # Publish is `pnpm publish` (not `npm publish`): pnpm has native OIDC
 # trusted-publishing support and resolves `catalog:`/`workspace:` specifiers into
 # the tarball at pack time, so the source package.json keeps the pnpm catalog as
-# the single source of truth.
+# the single source of truth. Every dep in this repo is `catalog:`, so `npm publish`
+# would ship a literal `"catalog:"` string and produce an uninstallable tarball.
 #
-# ── One-time HUMAN setup (until done, the workflow fails closed — that's correct) ─
-#   Register THIS repo + this workflow file (`publish.yml`) as a Trusted Publisher
-#   for `@kampus/pipeline-cli` on npmjs.com (Settings → Publishing). npm Trusted
-#   Publishing binds to the exact workflow FILENAME; the OIDC credential is
-#   mintable only after this registration — before it, `pnpm publish` 403s.
+# ── One-time HUMAN setup, PER PACKAGE (until done, the run fails closed — correct) ─
+#   Register THIS repo + this workflow file (`publish.yml`) as a Trusted Publisher for
+#   each published package on npmjs.com (Settings → Publishing). npm Trusted Publishing
+#   binds to the exact workflow FILENAME — that is why this file keeps its name and why
+#   no second publish workflow is added: a rename or a new file silently invalidates an
+#   existing registration. The OIDC credential is mintable only after registration;
+#   before it, `pnpm publish` 403s.
 # ──────────────────────────────────────────────────────────────────────────────
 name: publish
 
@@ -34,9 +45,14 @@ permissions:
 
 jobs:
   publish:
-    name: publish @kampus/pipeline-cli to npm
+    name: publish the tagged @kampus package to npm
     runs-on: ubuntu-latest
     steps:
+      # A bare checkout is the TAGGED tree, not a moving branch head: GitHub's
+      # events-that-trigger-workflows reference gives the `release` event GITHUB_SHA
+      # "Last commit in the tagged release" and GITHUB_REF `refs/tags/<tag_name>`. That
+      # matters because npm versions are immutable (ADR 0076) — a publish from a stale
+      # ref bakes its error in permanently.
       - uses: actions/checkout@v4.2.2
 
       # pnpm derives from the root `packageManager` field (pnpm@10.27.0) — pnpm 11
@@ -50,39 +66,51 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
-      # The release event carries no tag filter, so the grammar gate lives here:
-      # a tag that isn't `pipeline-cli-v<version>` fails the run before any publish.
-      - name: Guard — release tag must be pipeline-cli-v<version> matching package.json
+      # The release event carries no tag filter, so the grammar gate lives here.
+      - name: Resolve the release tag to a published package
+        # The tag reaches the script through the environment, never string-interpolated
+        # into it — a `${{ }}` splice of an attacker-shaped tag name would execute.
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-          if [[ ! "$TAG" =~ ^pipeline-cli-v([0-9].*)$ ]]; then
-            echo "::error::release tag '$TAG' does not match the pipeline-cli-v<version> grammar — refusing to publish"
+          set -uo pipefail
+          if [[ "$TAG" =~ ^pipeline-cli-v([0-9].*)$ ]]; then
+            PKG_DIR="packages/pipeline-cli"
+            TAG_VERSION="${BASH_REMATCH[1]}"
+          elif [[ "$TAG" =~ ^fabrika-cli-v([0-9].*)$ ]]; then
+            PKG_DIR="packages/fabrika-cli"
+            TAG_VERSION="${BASH_REMATCH[1]}"
+          else
+            echo "::error::release tag '$TAG' matches no published package's <name>-v<version> grammar — refusing to publish"
             exit 1
           fi
-          TAG_VERSION="${BASH_REMATCH[1]}"
-          PKG_VERSION="$(node -p "require('./packages/pipeline-cli/package.json').version")"
+          PKG_NAME="$(node -p "require('./$PKG_DIR/package.json').name")"
+          PKG_VERSION="$(node -p "require('./$PKG_DIR/package.json').version")"
+          echo "resolved package:     $PKG_NAME"
+          echo "resolved directory:   $PKG_DIR"
           echo "tag version:          $TAG_VERSION"
           echo "package.json version: $PKG_VERSION"
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::release tag ($TAG_VERSION) does not match packages/pipeline-cli/package.json version ($PKG_VERSION) — refusing to publish"
+            echo "::error::release tag ($TAG_VERSION) does not match $PKG_DIR/package.json version ($PKG_VERSION) — refusing to publish"
             exit 1
           fi
+          {
+            echo "PKG_DIR=$PKG_DIR"
+            echo "PKG_NAME=$PKG_NAME"
+          } >> "$GITHUB_ENV"
 
       - run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        run: pnpm --filter @kampus/pipeline-cli typecheck
+        run: pnpm --filter "$PKG_NAME" typecheck
 
-      # The package ships compiled ESM JS (bin/exports point at dist/, files: [dist]),
+      # The packages ship compiled ESM JS (bin/exports point at dist/, files: [dist]),
       # never raw .ts — Node refuses to strip types under node_modules, so a source-only
       # tarball is dead-on-arrival for any consumer (issue #405). Build dist/ before
       # publish; prepublishOnly also runs it, but an explicit step makes the gate visible.
       - name: Build (compile src/ → dist/)
-        run: pnpm --filter @kampus/pipeline-cli build
+        run: pnpm --filter "$PKG_NAME" build
 
-      # No NPM_TOKEN — pnpm's native OIDC trusted publishing supplies the credential
-      # per run and generates provenance automatically. pnpm resolves catalog:/
-      # workspace: specifiers into the tarball at pack time.
       - name: Publish to npm (pnpm OIDC trusted publishing + automatic provenance)
-        working-directory: packages/pipeline-cli
+        working-directory: ${{ env.PKG_DIR }}
         run: pnpm publish --access public --no-git-checks

--- a/packages/pipeline-cli/src/tools/publish-isolation-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/publish-isolation-guard/gate.unit.test.ts
@@ -6,13 +6,14 @@
  * prefix-with-no-member drift, and a zero-scope publish.yml all `CheckFailed`) from
  * observable outcomes — never by spawning the bin.
  */
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
-import {join} from "node:path";
+import {dirname, join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
 import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkPublishIsolation} from "./gate.ts";
+import {parsePublishedTagPrefixes} from "./publish-isolation-guard.ts";
 
 let root: string;
 beforeEach(() => {
@@ -122,5 +123,66 @@ describe("checkPublishIsolation — the CI exit-code gate over a fake repo dir",
 		mkPackage("pipeline-cli", {name: "@kampus/pipeline-cli", dependencies: {effect: "catalog:"}});
 		const exit = await run(checkPublishIsolation(root));
 		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("SUCCEEDS over a TWO-prefix publish.yml — both published members are in scope", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli", "fabrika-cli"]);
+		mkPackage("pipeline-cli", {name: "@kampus/pipeline-cli", dependencies: {effect: "catalog:"}});
+		mkPackage("fabrika-cli", {
+			name: "@kampus/fabrika-cli",
+			dependencies: {effect: "catalog:", "@effect/platform-node": "catalog:"},
+		});
+		const exit = await run(checkPublishIsolation(root));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("FAILS over a TWO-prefix publish.yml when the SECOND package links a workspace:* dep", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli", "fabrika-cli"]);
+		mkPackage("pipeline-cli", {name: "@kampus/pipeline-cli", dependencies: {effect: "catalog:"}});
+		mkPackage("fabrika-cli", {
+			name: "@kampus/fabrika-cli",
+			dependencies: {"@kampus/pipeline-crew-mcp": "workspace:*"},
+		});
+		const exit = await run(checkPublishIsolation(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (fail-closed, drift) when ONE of two prefixes maps to no workspace member", async () => {
+		writeWorkspace();
+		writePublishWorkflow(["pipeline-cli", "fabrika-cli"]);
+		mkPackage("pipeline-cli", {name: "@kampus/pipeline-cli", dependencies: {effect: "catalog:"}});
+		const exit = await run(checkPublishIsolation(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+});
+
+/**
+ * The fixtures above prove the gate's behavior; this pins its SCOPE to the real release
+ * pipeline. The published set is derived by parsing `publish.yml`'s tag-grammar anchors,
+ * so an edit that drops an arm — or moves the grammar behind a variable and unparses it —
+ * silently narrows or zeroes the guard. Reading the shipped file is what makes that edit
+ * red here instead of passing vacuously.
+ */
+describe("the repo's own publish.yml — derived published set", () => {
+	const repoRoot = (): string => {
+		let dir = import.meta.dirname;
+		while (!existsSync(join(dir, "pnpm-workspace.yaml"))) {
+			const up = dirname(dir);
+			if (up === dir) throw new Error("could not locate the repo root from the test file");
+			dir = up;
+		}
+		return dir;
+	};
+
+	it("derives BOTH published packages (fabrika-cli, pipeline-cli) from the shipped workflow", () => {
+		const yaml = readFileSync(join(repoRoot(), ".github", "workflows", "publish.yml"), "utf8");
+		expect(parsePublishedTagPrefixes(yaml)).toEqual(["fabrika-cli", "pipeline-cli"]);
+	});
+
+	it("PASSES the live gate over the real repo — both packages link no private @kampus deps", async () => {
+		const exit = await run(checkPublishIsolation(repoRoot()));
+		expect(Exit.isSuccess(exit)).toBe(true);
 	});
 });


### PR DESCRIPTION
The release workflow used to publish one hardcoded package. Now it reads the release tag, works out which package that tag belongs to, and publishes that one — so `@kampus/fabrika-cli` and `@kampus/pipeline-cli` both release from the same file, each with its own version and its own tag.

The file keeps its name and no second publish workflow is added, on purpose. npm Trusted Publishing binds to the exact workflow filename, so a rename or a new file silently invalidates a registration; and `publish-isolation-guard` derives which packages publish by parsing *this* file, so a package published from anywhere else would ship with no isolation checking at all.

Fixes #4801

## What changed

- `.github/workflows/publish.yml` — a resolve step maps the tag prefix to a workspace member (`pipeline-cli-v<version>` → `packages/pipeline-cli`, `fabrika-cli-v<version>` → `packages/fabrika-cli`), guards the tag version against that package's `package.json`, and exports `PKG_DIR`/`PKG_NAME` for the typecheck / build / publish steps. An unknown prefix or a version mismatch fails the run before any publish step. The tag reaches the script through `env:`, not a `${{ }}` splice.
- `packages/pipeline-cli/src/tools/publish-isolation-guard/gate.unit.test.ts` — five new tests: the two-prefix derivation passing, a second-package violation failing, fail-closed drift when one of two prefixes maps to no member, and two that pin the guard's scope to the *shipped* `publish.yml`.

Deliberately unchanged: the workflow filename, `pnpm/action-setup@v4.1.0` with **no** `version:` input (pnpm still derives from the root `packageManager`, and the pnpm#11513 comment survives), and `pnpm publish --access public` as the publish verb.

## Evidence

### AC1 + AC2 + AC6 — tag resolution, demonstrated

The resolve step's `run:` body was extracted **verbatim** from the committed `.github/workflows/publish.yml` and executed with a fake `TAG` under `bash -e` (Actions' default `run:` shell). This is the workflow's own code, not a paraphrase:

```
set -uo pipefail
if [[ "$TAG" =~ ^pipeline-cli-v([0-9].*)$ ]]; then
  PKG_DIR="packages/pipeline-cli"
  TAG_VERSION="${BASH_REMATCH[1]}"
elif [[ "$TAG" =~ ^fabrika-cli-v([0-9].*)$ ]]; then
  PKG_DIR="packages/fabrika-cli"
  TAG_VERSION="${BASH_REMATCH[1]}"
else
  echo "::error::release tag '$TAG' matches no published package's <name>-v<version> grammar — refusing to publish"
  exit 1
fi
PKG_NAME="$(node -p "require('./$PKG_DIR/package.json').name")"
PKG_VERSION="$(node -p "require('./$PKG_DIR/package.json').version")"
echo "resolved package:     $PKG_NAME"
echo "resolved directory:   $PKG_DIR"
echo "tag version:          $TAG_VERSION"
echo "package.json version: $PKG_VERSION"
if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
  echo "::error::release tag ($TAG_VERSION) does not match $PKG_DIR/package.json version ($PKG_VERSION) — refusing to publish"
  exit 1
fi
{
  echo "PKG_DIR=$PKG_DIR"
  echo "PKG_NAME=$PKG_NAME"
} >> "$GITHUB_ENV"
```

Observed output across five tags:

```
=== TAG=pipeline-cli-v0.2.1 ===
resolved package:     @kampus/pipeline-cli
resolved directory:   packages/pipeline-cli
tag version:          0.2.1
package.json version: 0.2.1
-- exit: 0
-- $GITHUB_ENV written:
PKG_DIR=packages/pipeline-cli
PKG_NAME=@kampus/pipeline-cli

=== TAG=fabrika-cli-v0.1.0 ===
resolved package:     @kampus/fabrika-cli
resolved directory:   packages/fabrika-cli
tag version:          0.1.0
package.json version: 0.1.0
-- exit: 0
-- $GITHUB_ENV written:
PKG_DIR=packages/fabrika-cli
PKG_NAME=@kampus/fabrika-cli

=== TAG=depo-v1.0.0 ===
::error::release tag 'depo-v1.0.0' matches no published package's <name>-v<version> grammar — refusing to publish
-- exit: 1
-- $GITHUB_ENV written:

=== TAG=v0.1.0 ===
::error::release tag 'v0.1.0' matches no published package's <name>-v<version> grammar — refusing to publish
-- exit: 1
-- $GITHUB_ENV written:

=== TAG=fabrika-cli-v9.9.9 ===
resolved package:     @kampus/fabrika-cli
resolved directory:   packages/fabrika-cli
tag version:          9.9.9
package.json version: 0.1.0
::error::release tag (9.9.9) does not match packages/fabrika-cli/package.json version (0.1.0) — refusing to publish
-- exit: 1
-- $GITHUB_ENV written:
```

The two failing prefixes and the version mismatch all exit non-zero from the resolve step, which sits **before** `pnpm install`, the build, and the publish — nothing downstream runs. `$GITHUB_ENV` is empty in every refusal, so no later step can pick up a half-resolved package.

### AC3 — filename, pnpm pin, publish verb

```
$ git diff --name-status origin/main...HEAD
M       .github/workflows/publish.yml
M       packages/pipeline-cli/src/tools/publish-isolation-guard/gate.unit.test.ts

$ ls .github/workflows/ | grep publish
publish-isolation-guard.yml
publish.yml
```

`M`, not `R` — the file is edited in place, and the only other `publish*` workflow is the pre-existing guard job. No second publish workflow.

Parsed straight out of the committed YAML:

```
workflow name: publish
job name: publish the tagged @kampus package to npm
steps: actions/checkout@v4.2.2 | pnpm/action-setup@v4.1.0 | actions/setup-node@v4.4.0 | Resolve the release tag to a published package |  | Typecheck | Build (compile src/ → dist/) | Publish to npm (pnpm OIDC trusted publishing + automatic provenance)
publish step working-directory: ${{ env.PKG_DIR }}
pnpm/action-setup step: {"uses":"pnpm/action-setup@v4.1.0"}
publish run: pnpm publish --access public --no-git-checks
```

`pnpm/action-setup` carries **no** `with:` block at all, so no `version:` input was added — pnpm still derives from the root `packageManager` (`pnpm@10.27.0`). The pnpm#11513 comment survives verbatim above that step. The publish verb is still `pnpm publish --access public`, never `npm publish`: every dep here is `catalog:`, and npm would ship the literal string (ADR 0076 §2).

### AC4 — the isolation guard derives BOTH packages and still fails closed

```
$ node packages/pipeline-cli/src/bin.ts publish-isolation-guard check
publish-isolation-guard: 2 published packages (@kampus/fabrika-cli, @kampus/pipeline-cli) link no private/unpublished @kampus deps
GUARD_EXIT=0
```

The scope widened with the workflow because the guard parses the workflow's tag-grammar anchors — it was not touched to make this happen. Full suite, verbose:

```
 ✓ SUCCEEDS when the published package's runtime deps are all public/catalog 6ms
 ✓ IGNORES a private, non-published member's dirty graph — only the published set is in scope 2ms
 ✓ FAILS (CheckFailed) when the published package links a workspace:* dep (the #3802 class) 2ms
 ✓ FAILS (CheckFailed) when the published package links a private @kampus dep by version 1ms
 ✓ FAILS (fail-closed) when a publish.yml tag prefix maps to no workspace member (drift) 1ms
 ✓ FAILS (fail-closed, zero-scope) when publish.yml declares no release-tag grammar 1ms
 ✓ SUCCEEDS over a TWO-prefix publish.yml — both published members are in scope 3ms
 ✓ FAILS over a TWO-prefix publish.yml when the SECOND package links a workspace:* dep 2ms
 ✓ FAILS (fail-closed, drift) when ONE of two prefixes maps to no workspace member 2ms
 ✓ the repo's own publish.yml — derives BOTH published packages (fabrika-cli, pipeline-cli) from the shipped workflow 0ms
 ✓ the repo's own publish.yml — PASSES the live gate over the real repo — both packages link no private @kampus deps 3ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

The zero-scope and drift refusals are intact at the widened scope, and the drift case is now also exercised with *one of two* prefixes unresolvable — the shape that would otherwise silently narrow the guard to the surviving package. The last two tests read the shipped `publish.yml` rather than a fixture, so an edit that drops an arm or moves the grammar behind a variable reds here instead of quietly zeroing the gate.

### AC5 — the fabrika tarball contains the file its `bin` points at

Verified against the shape live on `main` today (PR #4792 merged at 2026-08-03T03:57:28Z, so `publishConfig` already rewrites the entry points):

```
$ node -p "JSON.stringify(require('./package.json').publishConfig.bin)"
{"fabrika":"./dist/bin.js"}

$ pnpm run build && pnpm pack
…
Tarball Details
kampus-fabrika-cli-0.1.0.tgz
```

Listing (excerpt — the effective `bin` target, plus the manifest):

```
package/LICENSE
package/README.md
package/dist/bin.d.ts
package/dist/bin.d.ts.map
package/dist/bin.js
package/dist/bin.js.map
package/dist/index.js
package/dist/registry.js
package/dist/run.js
…
package/package.json
```

`package/dist/bin.js` is present — the effective `bin` (`./dist/bin.js`) resolves inside the tarball. The packed manifest confirms both the `publishConfig` rewrite and the `catalog:` resolution `pnpm publish` performs at pack time:

```json
{
  "bin": {"fabrika": "./dist/bin.js"},
  "main": "./dist/index.js",
  "types": "./dist/index.d.ts",
  "exports": {
    ".": {"types": "./dist/index.d.ts", "import": "./dist/index.js"},
    "./package.json": "./package.json"
  },
  "dependencies": {
    "@effect/platform-node": "4.0.0-beta.92",
    "effect": "4.0.0-beta.92"
  }
}
```

Those two deps are `"catalog:"` in the source `package.json` and concrete versions in the tarball. That is exactly what `npm publish` cannot do, and why the verb stays `pnpm publish` (ADR 0076 §2).

### Gates

```
$ pnpm typecheck
 Tasks:    30 successful, 30 total

$ pnpm lint:worktree
Checked 1 file in 13ms. No fixes applied.
```

## Reviewer notes

- **§CP.** This touches `.github/workflows/**`, so it is control-plane per ADR 0053: it stops at reviewed-ready and needs a human `@kamp-us/control-plane` approval at its current head. Not auto-merged. See #4754 — banking a control-plane PR does not arm the approval-watcher, so an approved PR can strand silently.
- **The workflow filename is unchanged**, so the Trusted Publisher registration being set up in #4800 stays valid. `@kampus/fabrika-cli` still needs its **own** Trusted Publisher registration against this same file before a `fabrika-cli-v*` release can publish; until then the OIDC step 403s, which is the correct fail-closed state.
- **Publishing from a stale ref is not reachable here.** A bare `actions/checkout` on a `release` event checks out the tagged commit — GitHub's events-that-trigger-workflows reference gives the `release` row `GITHUB_SHA` = "Last commit in the tagged release" and `GITHUB_REF` = `refs/tags/<tag_name>`. Combined with the tag-version-vs-`package.json` guard, a release can only publish the tree it was cut from. npm versions are immutable (ADR 0076), so this property is the one that matters most.
- **ADR 0103** said "simplify `publish.yml` to publish the single package" when the pipeline consolidated to one package. That premise no longer holds now that `@kampus/fabrika-cli` is live on the registry; #4801 rules the generalization and explicitly forbids the per-package `publish-<name>.yml` convention ADR 0076 §3 used. Flagging it so the ADR trail can be reconciled — no ADR is authored in this PR.
