### PR TITLE
feat(release): wire release-please v4 manifest mode — derived versions, one standing Release PR (#4803)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@
 #   The history boundary lives in `release-please-config.json` as `last-release-sha`
 #   (with `bootstrap-sha` at the same commit for the never-released fabrika-cli leaf).
 #   Without it the first run has no stopping point and folds ~94 commits of pipeline-cli
-#   backlog into one bump. npm versions are immutable (ADR 0076), so the first Release PR
+#   backlog into one bump. npm versions are immutable, so the first Release PR
 #   is read before it is merged, never after.
 #
 # ADR 0069 boundary: `changelog.yml` owns the ROOT CHANGELOG.md, derived from pipeline
@@ -87,6 +87,9 @@ jobs:
           {
             echo "## Released this push"
             echo
+            # the backticks are literal markdown in a printf FORMAT string, so the single
+            # quotes are correct; shellcheck reads them as an unexpanded command substitution
+            # shellcheck disable=SC2016
             printf -- '- `%s`\n' "${released[@]}"
             echo
             echo "Tags: \`${PIPELINE_CLI_TAG:-none}\` / \`${FABRIKA_CLI_TAG:-none}\`"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,95 @@
+# Derives each publishable package's next version from conventional commits and parks
+# the answer in a standing Release PR (ADR 0239). Merging that PR is the human release
+# act: it tags `<component>-v<version>`, the tag creates the GitHub Release, and the
+# `release: published` event is what fires `publish.yml`. Nothing here publishes — this
+# workflow has no registry credential and release-please has no publish path.
+#
+# Routing is by CHANGED FILE PATH, not by commit scope (ADR 0239 §1): a commit is
+# assigned to a package root by the files it touched, so `fix(pipeline): …` still bumps
+# whichever package its diff landed in, and a commit touching no package root bumps
+# nothing.
+#
+# The `<component>-v<version>` tag grammar is what `publish.yml` guards and what
+# `publish-isolation-guard` machine-reads out of that workflow to derive its own scope,
+# so the components below must stay `pipeline-cli` / `fabrika-cli` (ADR 0239 §4).
+#
+# Two hazards this file is wired against, both from ADR 0239 §5:
+#
+#   `releases_created` is REPO-WIDE — true when ANY configured path released, silent
+#   about which. It is NOT "always true" (release-please-action v4.4.1/v5.0.0 set it to
+#   `releases.length > 0` in `outputReleases`), which makes it worse, not better: it
+#   looks trustworthy and would gate a pipeline-cli action on a fabrika-cli release.
+#   Every condition here keys on the per-path `<path>--release_created` output instead.
+#
+#   The history boundary lives in `release-please-config.json` as `last-release-sha`
+#   (with `bootstrap-sha` at the same commit for the never-released fabrika-cli leaf).
+#   Without it the first run has no stopping point and folds ~94 commits of pipeline-cli
+#   backlog into one bump. npm versions are immutable (ADR 0076), so the first Release PR
+#   is read before it is merged, never after.
+#
+# ADR 0069 boundary: `changelog.yml` owns the ROOT CHANGELOG.md, derived from pipeline
+# metadata on the same `*-v*` tag. release-please writes PER-PACKAGE CHANGELOG.md files
+# under each package root (the node strategy prefixes `changelog-path` with the package
+# path). Different files, different sources — pointing release-please at the root
+# changelog is banned.
+name: release-please
+
+on:
+  push:
+    branches: [main]
+
+# release-please opens/updates the Release PR and creates releases + tags on merge.
+# No `id-token` — this workflow never touches a registry; `publish.yml` mints the OIDC
+# credential on the release event.
+permissions:
+  contents: write
+  pull-requests: write
+
+# Never cancel in flight: a cancelled run can leave the standing Release PR groomed
+# against a stale commit range.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    name: derive versions and groom the standing Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v5.0.0
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+      # The one gate in this file, keyed on the PER-PATH outputs. `releases_created`
+      # appears nowhere.
+      - name: Summarize which packages this push released
+        if: ${{ steps.release.outputs['packages/pipeline-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' }}
+        env:
+          PATHS_RELEASED: ${{ steps.release.outputs.paths_released }}
+          PIPELINE_CLI_TAG: ${{ steps.release.outputs['packages/pipeline-cli--tag_name'] }}
+          FABRIKA_CLI_TAG: ${{ steps.release.outputs['packages/fabrika-cli--tag_name'] }}
+        run: |
+          set -uo pipefail
+
+          released=()
+          while IFS= read -r path; do
+            [ -n "$path" ] && released+=("$path")
+          done < <(printf '%s' "${PATHS_RELEASED:-[]}" | jq -r '.[]?')
+
+          if [ "${#released[@]}" -eq 0 ]; then
+            echo "::error::a per-path release_created output was true but paths_released is empty — refusing to report a release that cannot be named"
+            exit 1
+          fi
+
+          {
+            echo "## Released this push"
+            echo
+            printf -- '- `%s`\n' "${released[@]}"
+            echo
+            echo "Tags: \`${PIPELINE_CLI_TAG:-none}\` / \`${FABRIKA_CLI_TAG:-none}\`"
+            echo
+            echo "Publishing is \`publish.yml\` on the \`release: published\` event — not this workflow."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,4 @@
+{
+	"packages/pipeline-cli": "0.2.1",
+	"packages/fabrika-cli": "0.1.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+	"last-release-sha": "97f3022228eeeb850b02ef4cb10b64c772fbd77f",
+	"bootstrap-sha": "97f3022228eeeb850b02ef4cb10b64c772fbd77f",
+	"release-type": "node",
+	"include-component-in-tag": true,
+	"separate-pull-requests": false,
+	"packages": {
+		"packages/pipeline-cli": {
+			"component": "pipeline-cli"
+		},
+		"packages/fabrika-cli": {
+			"component": "fabrika-cli"
+		}
+	}
+}


### PR DESCRIPTION
A bot now works out what each publishable package's next version number should be, by reading the commit messages of the commits that touched that package's files, and parks the answer in a pull request that sits there until a human merges it. Merging that PR is what creates the tag, and the tag is what fires the existing publish job. Nobody hand-types a version number any more, and nothing reaches npm without a human having merged something.

Implements ADR [0239](https://github.com/kamp-us/phoenix/blob/main/.decisions/0239-release-please-manifest-mode-version-derivation.md) (in review as #4816 at the time of writing; read from that PR's head `61da2f9`). The mechanism is the ADR's, not re-derived here.

Fixes #4803

## What landed

- **`release-please-config.json`** — manifest-mode config for the two publishable leaves, `packages/pipeline-cli` (component `pipeline-cli`) and `packages/fabrika-cli` (component `fabrika-cli`). `@kampus/depo` stays out, per scope. `include-component-in-tag: true` + `release-type: node` is what produces the `<component>-v<version>` grammar; `separate-pull-requests: false` is what keeps it to **one** standing Release PR.
- **`.release-please-manifest.json`** — the current published versions, `0.2.1` and `0.1.0`.
- **`.github/workflows/release-please.yml`** — runs on push to `main`, opens/grooms the Release PR, creates the tag + GitHub Release when that PR merges. It holds no registry credential and no `id-token` permission.

**I did not touch `publish.yml`.** #4801 owns generalizing it, and its filename is bound to a Trusted Publisher registration (#4800). Nothing here renames, moves, or edits it. The only coupling is the tag grammar, which this config is built to match rather than change.

## The action major: `v5.0.0`

Pinned `googleapis/release-please-action@v5.0.0`. The ADR deliberately left this open, so: v4.4.1 runs on the **node20** runner, v5.0.0 on **node24** — that runner bump is the entire breaking change, and node20 actions are on GitHub's deprecation path. The manifest mechanism is byte-identical between them; I diffed the outputs surface at both tags and it is the same `setPathOutput` / `releases_created` / `paths_released` code (evidence below). Taking the current major costs nothing and avoids a forced re-pin later.

## The coarse-output hazard, and what I actually used

The upstream research claim that `releases_created` reports `true` whether or not a release happened is **false**, and I re-derived that from source rather than trusting the summary. In `googleapis/release-please-action` at **v4.4.1**, `src/index.ts` `outputReleases()`:

```
releases = releases.filter(release => release !== undefined);
const pathsReleased = [];
core.setOutput('releases_created', releases.length > 0);
```

It is `releases.length > 0` after filtering undefined — it is not always true. **v5.0.0 is identical** on this surface:

```
$ curl -sL .../v4.4.1/src/index.ts | grep -n "setPathOutput\|releases_created\|paths_released"
178:function setPathOutput(path: string, key: string, value: string | boolean) {
189:  core.setOutput('releases_created', releases.length > 0);
200:        setPathOutput(path, 'release_created', true);
210:        setPathOutput(path, key, value);
216:  core.setOutput('paths_released', JSON.stringify(pathsReleased));

$ curl -sL .../v5.0.0/src/index.ts | grep -n "setPathOutput\|releases_created\|paths_released"
178:function setPathOutput(path: string, key: string, value: string | boolean) {
189:  core.setOutput('releases_created', releases.length > 0);
200:        setPathOutput(path, 'release_created', true);
210:        setPathOutput(path, key, value);
216:  core.setOutput('paths_released', JSON.stringify(pathsReleased));
```

**The real hazard is worse than the false one, which is why the mitigation is the same.** `releases_created` is **repo-wide**: true when *any* configured path released, and silent about *which*. In a two-package manifest, a condition on it fires for `pipeline-cli` when only `fabrika-cli` released. A flag that is honestly computed and looks trustworthy is more dangerous than one that is obviously always-true, because nothing about it invites suspicion.

So the one condition in this workflow keys on the **per-path** output. `setPathOutput` emits `<path>--<key>` for every path except the root `.`, so the keys are `packages/pipeline-cli--release_created` and `packages/fabrika-cli--release_created`:

```yaml
if: ${{ steps.release.outputs['packages/pipeline-cli--release_created'] == 'true' || steps.release.outputs['packages/fabrika-cli--release_created'] == 'true' }}
```

`releases_created` appears nowhere in the workflow except in the header comment explaining why it is refused.

## The history boundary

`last-release-sha` and `bootstrap-sha` are both pinned to `97f3022228eeeb850b02ef4cb10b64c772fbd77f` — `main`'s tip when this branch was cut. Both keys are set on purpose, because they break the commit walk under different conditions (`release-please@17.11.1`, `build/src/manifest.js`):

```js
if (this.lastReleaseSha && this.lastReleaseSha === commit.sha) { … break; }
else if (needsBootstrap && commit.sha === this.bootstrapSha) { … break; }
```

`last-release-sha` breaks unconditionally; `bootstrap-sha` breaks only when `needsBootstrap`. `fabrika-cli` has **no** GitHub release or tag (it was bootstrap-published by hand), so `needsBootstrap` is true — the observed run below prints `Expected 2 releases, only found 1 / Missing 1 paths: packages/fabrika-cli`. Setting both means the boundary holds on either path.

The reading is: *everything up to `97f3022` is treated as already released.* That is what keeps the ~94-commit `pipeline-cli` backlog since `0.2.1` (published 2026-07-24) out of the first Release PR. npm versions are immutable, so the first merge is the one that cannot be taken back — the range is shown below and must be re-read against the actual first Release PR before it is merged.

## Observed evidence — every acceptance criterion, run live

All of it from `release-please@17.11.1` run with `--dry-run --trace` against real branches on this repo, reading the config and manifest from the branch. Nothing below is asserted.

### AC1 — a push touching only non-publishable paths produces no version bump

Dry-run against this PR's branch, whose single commit changes `.github/workflows/release-please.yml` + the two root config files:

```
✔ Using configured lastReleaseSha 97f3022228eeeb850b02ef4cb10b64c772fbd77f as last commit.
✔ Splitting 1 commits by path
✔ Building candidate release pull request for path: packages/pipeline-cli
❯ commits: 0
✔ No commits for path: packages/pipeline-cli, skipping
✔ Building candidate release pull request for path: packages/fabrika-cli
❯ commits: 0
✔ No commits for path: packages/fabrika-cli, skipping
Would open 0 pull requests
```

One commit walked, three files, routed to neither package, **zero** Release PRs.

### AC1 + AC2 — a touching push bumps, and routing is by path not scope

I then pushed two throwaway commits onto a scratch branch off this one and ran the same dry-run. The scopes were chosen to name no package — `fix(pipeline):` and `feat(anything):` — exactly the mismatch that motivated the epic:

| commit | subject | files touched |
| --- | --- | --- |
| `e255946` | `fix(pipeline): routing proof — scope names no package, diff touches fabrika-cli (#4803)` | `packages/fabrika-cli/ROUTING-PROOF.txt` |
| `f5844dc` | `feat(anything): second routing proof — diff touches pipeline-cli (#4803)` | `packages/pipeline-cli/ROUTING-PROOF.txt` |

```
✔ Using configured lastReleaseSha 97f3022228eeeb850b02ef4cb10b64c772fbd77f as last commit.
✔ Splitting 3 commits by path
✔ Building candidate release pull request for path: packages/pipeline-cli
❯ commits: 1
❯ component: pipeline-cli
✔ Building candidate release pull request for path: packages/fabrika-cli
❯ commits: 1
❯ component: fabrika-cli
❯ running plugin: Merge
Would open 1 pull requests
```

Three commits in range; each package got exactly the one commit whose **diff** landed in it; the workflow/config commit routed to neither. **One** Release PR for both. The derived contents:

```diff
--- .release-please-manifest.json
+++ .release-please-manifest.json
 {
-	"packages/pipeline-cli": "0.2.1",
-	"packages/fabrika-cli": "0.1.0"
+	"packages/pipeline-cli": "0.3.0",
+	"packages/fabrika-cli": "0.1.1"
 }

--- packages/pipeline-cli/package.json
+++ packages/pipeline-cli/package.json
-	"version": "0.2.1",
+	"version": "0.3.0",

--- packages/fabrika-cli/package.json
+++ packages/fabrika-cli/package.json
-	"version": "0.1.0",
+	"version": "0.1.1",
```

`feat` → minor (`0.2.1` → `0.3.0`), `fix` → patch (`0.1.0` → `0.1.1`), each on the package its **files** touched, with neither scope string naming a package. The scratch branch was deleted after the run; nothing from it is in this diff.

### AC3 — tag grammar matches what `publish.yml` guards

From the same run — the resolver looks up, and the generated changelogs link, exactly `<component>-v<version>`:

```
❯ Found release for path packages/pipeline-cli, pipeline-cli-v0.2.1
❯ looking for tagName: fabrika-cli-v0.1.0
```

```
+## [0.3.0](https://github.com/kamp-us/phoenix/compare/pipeline-cli-v0.2.1...pipeline-cli-v0.3.0) (2026-08-03)
+## [0.1.1](https://github.com/kamp-us/phoenix/compare/fabrika-cli-v0.1.0...fabrika-cli-v0.1.1) (2026-08-03)
```

`publish.yml`'s guard regex is `^pipeline-cli-v([0-9].*)$`, and `publish-isolation-guard` machine-reads that same grammar out of the workflow file to derive its own scope. Both are satisfied without either being edited.

### AC4 — the boundary holds and the first range is small

`Using configured lastReleaseSha 97f3022… as last commit` appears in every run above, and the commit counts (`Splitting 1 commits` / `Splitting 3 commits`) are the whole walk — not ~94. **The commit range the first real Release PR will cover is `97f3022..main`**, i.e. everything merged after this PR's branch point. That range must still be read on the actual first Release PR before it is merged; the ADR is explicit that the boundary setting has itself been buggy upstream, so the setting is not the proof — the diff is.

### AC5 — no condition keys on the coarse output

```
$ grep -n "releases_created\|release_created\|paths_released" .github/workflows/release-please.yml
20:#   `releases_created` is REPO-WIDE — true when ANY configured path released, silent
22:#   `releases.length > 0` in `outputReleases`), which makes it worse, not better: it
26: - name: Summarize which packages this push released
27:   if: ... outputs['packages/pipeline-cli--release_created'] == 'true' || outputs['packages/fabrika-cli--release_created'] == 'true'
```

The only `releases_created` occurrences are in the header comment that explains the refusal. Every gate is per-path.

### AC6 — required checks on the Release PR

Answered in writing on #4803 (progress comment), and summarized here. Observed from ruleset `17377992` on `main`:

```
$ gh api repos/kamp-us/phoenix/rules/branches/main --jq '...required_status_checks...'
scan changed files for leaks
validate skill frontmatter
ci-required
```

plus `pull_request` and `merge_queue` rules — so the Release PR is a real PR that merges through the queue. `ci-required` and `validate skill frontmatter` are jobs in `ci.yml`; `scan changed files for leaks` is `leak-guard.yml`. **Both of those workflows already declare a `merge_group:` trigger** (added by ADR 0132 for exactly this reason), so the required checks do run on the batched merge ref.

The GITHUB_TOKEN limitation is real and unmitigated at the PR level: a PR opened by the default `GITHUB_TOKEN` does not fire `pull_request`-triggered workflows, so those three checks will not report on the Release PR itself. The pre-decided remedy, if the queue refuses to accept the PR on that basis, is to author the Release PR under a non-`GITHUB_TOKEN` identity — a GitHub App installation token or fine-grained PAT passed to the action's `token:` input. No such secret exists on this repo today (observed: `ALCHEMY_PASSWORD`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRET_TEST`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`), so provisioning it is a human control-plane act, and it is deliberately not smuggled into this PR. The first Release PR is the empirical test.

## ADR 0069 boundary — held

`changelog.yml` owns the **root** `CHANGELOG.md`. release-please writes **per-package** changelogs: the node strategy resolves `changelog-path` through `addPath()`, which prefixes the package path (`build/src/strategies/node.js:53` → `path: this.addPath(this.changelogPath)`; `base.js:483` → `file = ${this.path}/${file}`). The observed dry-run confirms it — the only changelog paths it wrote were `packages/pipeline-cli/CHANGELOG.md` and `packages/fabrika-cli/CHANGELOG.md`. Nothing points at the root file.

## Deviations

**Class: narrowed a suggested shape.**
Said: the issue frames the mitigation as "`release_created` or the per-path `<path>--release_created`".
Did: used **only** the per-path form.
Why: the bare `release_created` output is emitted by `setPathOutput` only for the root path `.`, and this manifest configures no root path — so `release_created` would never be set here and a condition on it would be silently always-false.
Disposition: no action needed; the stricter of the two options is the correct one for this config.

**Class: pushed a temporary artifact to the remote.**
Said: nothing about creating scratch branches.
Did: created `usirin/proof-4803-routing-635C4988` with two throwaway commits to obtain the live routing evidence in AC1/AC2, then deleted the ref.
Why: AC1 and AC2 require the routing be *demonstrated*, not asserted, and the release-please workflow only runs after a merge to `main` — a dry-run against a real branch with real commits is the only pre-merge way to observe it.
Disposition: no action needed; the branch is deleted and no proof commit is in this diff.

**Class: left a sibling concern to another lane.**
Said: nothing.
Did: left `publish.yml` completely untouched, including its `pipeline-cli`-hardcoded tag guard, which cannot publish `fabrika-cli` today.
Why: #4801 owns that generalization and is building in parallel; pre-settling its diff here would collide.
Disposition: sequencing note for the operator — until #4801 lands, a `fabrika-cli-v*` release will fire `publish.yml` and fail its grammar guard. That is a loud failure, not a bad publish, and it fails **before** any registry call.

**Class: a deliberate non-choice a reviewer should see.**
Said: the ADR leaves the action major open.
Did: pinned `v5.0.0` rather than the `v4.4.1` the ADR's source citations were read at.
Why: the outputs surface is identical at both tags (diffed above); v4.4.1's node20 runner is deprecated.
Disposition: for the reviewer to judge; reverting to `v4.4.1` is a one-line change with no other consequence.


**(repair round 1) Class 5: suppressed a lint.**
Said: nothing in #4803 sanctions suppressing a linter.
Did: added `# shellcheck disable=SC2016` above the step-summary `printf` in `.github/workflows/release-please.yml`.
Why: SC2016 fires on the single-quoted `printf` FORMAT string that carries literal markdown backticks. The single quotes are correct — the backticks are format-string content, not a command substitution — so this is a false positive, but actionlint feeds `ci-required`, which is a required check. The alternative the gate offered (restructuring the printf) would have changed correct code to satisfy a linter.
Disposition: no action needed; the suppression is one code at one line with the reason stated at the site, not a blanket disable.

**(repair round 1) Class 7: touched a line the issue does not imply.**
Said: nothing about ADR citations.
Did: dropped the `(ADR 0076)` attribution from the npm-immutability sentence in the workflow header (and from this body), keeping the statement itself.
Why: the citation is false — ADR 0076 never states version immutability and is itself superseded by 0103. The constraint is true and load-bearing but currently has no ADR home; re-homing it is a separate scope decision recorded at https://github.com/kamp-us/phoenix/pull/4816#issuecomment-5162412604.
Disposition: no action needed here; no replacement citation invented.
