### PR TITLE
fix(pipeline): track .claude/.pipeline in git, and leave a breadcrumb when the hook fails (#4818)

### DIFF
--- a/.claude/.pipeline
+++ b/.claude/.pipeline
@@ -1,0 +1,1 @@
+../claude-plugins/kampus-pipeline

--- a/.gitignore
+++ b/.gitignore
@@ -54,12 +54,6 @@ apps/web/tests/e2e/.auth
 # Per-machine, never committed — mirrors the plugin's ${CLAUDE_PLUGIN_DATA}.
 /.claude/.pipeline-cli-data/
 
-# The symlink the SessionStart / WorktreeCreate hooks plant at the live plugin install, so a skill
-# fence can name the pipeline by a literal relative path that resolves in ANY consuming repo (#4605).
-# Hook-planted per tree, per machine — never committed; a committed link would pin one machine's
-# install path into every clone.
-/.claude/.pipeline
-
 # @kampus/pipeline-crew-mcp writes each crew pane a distinct, git-valid launch cwd here so its
 # ~/.claude.json local-scope entry is isolated (issue #3444). Per-machine, launcher-owned, swept by
 # stand-down + the start-of-stand-up reaper — never committed.

--- a/claude-plugins/kampus-pipeline/hooks/plant-link-pretooluse.sh
+++ b/claude-plugins/kampus-pipeline/hooks/plant-link-pretooluse.sh
@@ -17,7 +17,8 @@
 # Contract: reads the PreToolUse JSON payload on stdin for `cwd`. ALWAYS exits 0 — a PreToolUse hook
 # that exits 0 with no stdout is an implicit allow, so this can never block a tool call, and a
 # planting failure is left to surface where it is actionable (the fence's own 127, which the corpus
-# treats as UNKNOWN and never as a negative answer).
+# treats as UNKNOWN and never as a negative answer). A failure also leaves ONE breadcrumb; see the
+# stamp below.
 set -uo pipefail
 
 HOOKS_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
@@ -37,6 +38,13 @@ if [ -n "$payload" ]; then
 	fi
 fi
 
+# The one breadcrumb a planting failure leaves (#4818) — until now both streams were discarded under
+# an unconditional exit 0, so a failure was diagnosable only by archaeology on symlink mtimes.
+# It lives OUTSIDE every working tree on purpose: a breadcrumb written into the tree would show up in
+# `git status`, and the worktree sweep KEEPS a dirty tree forever (#3943), so the failure report
+# would leak the very worktree it reported on.
+PLANT_LOG="${TMPDIR:-/tmp}/kampus-pipeline-plant-failures.log"
+
 # Both trees, because they differ exactly when it matters: an isolated subagent's `cwd` is its
 # worktree while `CLAUDE_PROJECT_DIR` stays the primary checkout, and each needs its own link (a
 # worktree is a separate working tree with its own `.claude/`). When they coincide the second call is
@@ -44,7 +52,11 @@ fi
 for tree in "$cwd" "${CLAUDE_PROJECT_DIR:-}"; do
 	[ -n "$tree" ] || continue
 	[ -d "$tree" ] || continue
-	bash "$HOOKS_DIR/plant-pipeline-link.sh" "$tree" >/dev/null 2>/dev/null || true
+	if ! why="$(bash "$HOOKS_DIR/plant-pipeline-link.sh" "$tree" 2>&1 >/dev/null)"; then
+		printf '%s\tplant-link-pretooluse\t%s\t%s\n' \
+			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$tree" "${why:-no diagnostic}" \
+			>>"$PLANT_LOG" 2>/dev/null || true
+	fi
 done
 
 exit 0


### PR DESCRIPTION
Fixes #4818

Implements the [FOUNDER RULING of 2026-08-03](https://github.com/kamp-us/phoenix/issues/4818#issuecomment-5162507057) exactly: **track the link, add one breadcrumb, defer the intermittency.** The design fork is settled; this PR does not reopen it.

## What changed — three files, nothing else

| File | Change |
| --- | --- |
| `.gitignore` | Removed `/.claude/.pipeline` (and its now-false comment block). `/.claude/.pipeline-cli-data/` is a **different** path and is untouched. |
| `.claude/.pipeline` | **New tracked symlink**, mode `120000`, target `../claude-plugins/kampus-pipeline` — the same shape as its two siblings `.claude/agents` and `.claude/skills`. |
| `claude-plugins/kampus-pipeline/hooks/plant-link-pretooluse.sh` | One observable breadcrumb on the failure path. The hook is **not** removed and its command path is **not** changed. |

### Why tracking is the fix, in one line

`.claude/agents` and `.claude/skills` survive into every worktree because git materializes tracked symlinks on checkout — no hook, no provisioning step. `.pipeline` was the one untracked sibling, so it depended on an intermittent runtime plant (5 of ~198 worktrees carried it), and its absence lands on the *first* fence a coder runs as exit 127 with empty stdout — the state the corpus defines as UNKNOWN.

### The breadcrumb

```bash
PLANT_LOG="${TMPDIR:-/tmp}/kampus-pipeline-plant-failures.log"

for tree in "$cwd" "${CLAUDE_PROJECT_DIR:-}"; do
	[ -n "$tree" ] || continue
	[ -d "$tree" ] || continue
	if ! why="$(bash "$HOOKS_DIR/plant-pipeline-link.sh" "$tree" 2>&1 >/dev/null)"; then
		printf '%s\tplant-link-pretooluse\t%s\t%s\n' \
			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$tree" "${why:-no diagnostic}" \
			>>"$PLANT_LOG" 2>/dev/null || true
	fi
done
```

`2>&1 >/dev/null` keeps the planter's own diagnostic — the *reason*, not just the fact — while still discarding its stdout. The stamp lives **outside every working tree** on purpose: a breadcrumb written into the tree would show up in `git status`, and the worktree sweep keeps a dirty tree forever (#3943), so the failure report would leak the very worktree it reported on. `TMPDIR` is also the one location that still exists when the failure is *"that tree is not a repo at all"*.

## Evidence — observed, not asserted

Absolute roots below are replaced with `<fresh-worktree>` / `<scratch>` placeholders (no local paths in artifacts); nothing else is edited.

**1. The defect reproduces in this build's own worktree, then the fence recovers.**

```
$ ls -la <this-worktree>/.claude/
agents -> ../claude-plugins/kampus-pipeline/agents
settings.json
skills -> ../claude-plugins/kampus-pipeline/skills
workflows/
            (no .pipeline)

$ bash ./.claude/.pipeline/skills/write-code/scripts/step4-preflight.sh
bash: ./.claude/.pipeline/skills/write-code/scripts/step4-preflight.sh: No such file or directory
EXIT=127
```

**2. The link is genuinely in the index (a passing `git add` is not proof).** It needed `-f`, because after `.gitignore` was cleaned the per-clone `.git/info/exclude` line the planter appends still matched:

```
$ git check-ignore -v .claude/.pipeline
.git/info/exclude:19:/.claude/.pipeline	.claude/.pipeline

$ git ls-files -s .claude/.pipeline .claude/agents .claude/skills
120000 3f74fc204ae1f0e0c9578de5519550a85f3317c5 0	.claude/.pipeline
120000 17cacdc4316ca520c72895ad10b11088fbbad310 0	.claude/agents
120000 434df3af245652ab0a8273b0eb02ebf786f7bfd9 0	.claude/skills

$ git cat-file -p 3f74fc20
../claude-plugins/kampus-pipeline
```

An `info/exclude` entry has no effect on a **tracked** path, so the planter may keep appending it harmlessly. Commit summary line: `create mode 120000 .claude/.pipeline`.

**3. A freshly-created worktree carries a resolving link with no hook involvement.** `git worktree add` at this branch's head, then `ls` before any tool call has ever run with that cwd:

```
$ ls -la <fresh-worktree>/.claude/
lrwxr-xr-x  .pipeline -> ../claude-plugins/kampus-pipeline
lrwxr-xr-x  agents    -> ../claude-plugins/kampus-pipeline/agents
-rw-r--r--  settings.json
lrwxr-xr-x  skills    -> ../claude-plugins/kampus-pipeline/skills
drwxr-xr-x  workflows

$ cd <fresh-worktree> && bash ./.claude/.pipeline/skills/write-code/scripts/step4-preflight.sh
exit=0  (was 127 before this change)
```

The probe worktree was torn down with `git worktree remove` (never `--force`); `teardown exit=0`.

**4. The breadcrumb fires on failure, stays silent on success, and never blocks.** Driven with a synthetic unplantable tree (mode `500`, so the planter's `mkdir` fails):

```
=== FAILURE PATH ===
HOOK_EXIT=0                     # never-block contract intact; nothing on stdout
--- contents of the stamp ---
2026-08-03T05:11:51Z	plant-link-pretooluse	<scratch>/readonly-tree	plant-pipeline-link: cannot create '<scratch>/readonly-tree/.claude' — refusing (fail-closed).

=== SUCCESS PATH (a plantable tree) ===
HOOK_EXIT=0
1                               # still one line — success adds nothing
```

**5. Guards.**

```
$ bash -n claude-plugins/kampus-pipeline/hooks/plant-link-pretooluse.sh   →  exit 0
$ shellcheck -s bash claude-plugins/kampus-pipeline/hooks/plant-link-pretooluse.sh   →  clean
$ find claude-plugins -type f \( -name '*.md' -o -name '*.sh' \) -print0 | sort -z | xargs -0 pipeline-cli trap-status-guard check
trap-status-guard: scanned 351 file(s), 327 runnable bash/sh fence(s) in markdown, 257 shell file(s) as implicit units
trap-status-guard: clean — no runnable shell unit pairs `errexit` with an `EXIT` trap.
$ pnpm lint:worktree   →  no biome-handled changed files vs origin/main
$ pnpm typecheck       →  30 successful, 30 total
```

The hook keeps `set -uo pipefail` (never `-e`) and no `EXIT` trap. It uses no arrays, so the defaulted-expansion / emptiness-test rules have no site here.

## The honest weak leg — the consumer path is UNTESTED

The founder ruling flags this as the one MEDIUM-confidence leg, and it is still MEDIUM after this PR. **Nobody has installed the plugin into a real non-vendoring consumer repo and verified it.** I did not test one either. Stating that plainly rather than reporting it as verified.

What the claim rests on is a reading of `plant-pipeline-link.sh`'s own branch:

```bash
TARGET="$PLUGIN_ROOT"
if [ -d "$TREE_ABS/claude-plugins/kampus-pipeline/skills" ]; then
	TARGET="../claude-plugins/kampus-pipeline"
fi
```

A repo that **vendors** the plugin — phoenix, and every phoenix worktree — takes the second branch and gets the relative target, which is byte-identical to the symlink now in the index. Every other consumer takes the first branch and gets the absolute install path. A consumer does not clone phoenix; they install the plugin into *their* tree, so a symlink in phoenix's index never reaches them.

**Why that is acceptable to ship on:** the change is additive and phoenix-local. Tracking adds a path to phoenix's index and removes a line from phoenix's `.gitignore` — neither is a thing a consumer's install reads. The hook, which *is* the consumer mechanism, is unchanged in path, registration, and target-selection logic; the only edit to it makes a previously-silent failure observable, which strictly improves the consumer's diagnosability. The residual risk is bounded to "a consumer install has some other, pre-existing problem this PR neither causes nor fixes" — and the breadcrumb is precisely what will now surface it.

## Acceptance criteria — the ruling's list

- [x] `/.claude/.pipeline` removed from the root `.gitignore`; `.claude/.pipeline` in the index at mode `120000` with target `../claude-plugins/kampus-pipeline`. — evidence 2
- [x] A freshly-created worktree carries a resolving `.claude/.pipeline` with no hook involvement, by pasted transcript. — evidence 3
- [x] The hook's failure path emits one observable artifact; never-block preserved (exit 0, no stdout). — evidence 4
- [x] The consumer path is **stated as untested**, with why that is acceptable — not reported as verified. — the section above
- [x] The hook is not removed and its path is not changed; the intermittency remains open. — the diff touches only the hook's failure-reporting; `.claude/settings.json` is untouched

## Acceptance criteria — the issue's original list

- [x] A freshly-provisioned worktree carries a resolvable `.claude/.pipeline`, demonstrated by an actual spawn, not by a registration being present. — evidence 3
- [x] The demonstration names the runtime in use. — the mechanism is now `git`, not the harness: the link is materialized by checkout, so the property is a git property (`git version 2.40.1` on this host, and tracked symlinks are not version-sensitive), not a harness-build property. That is the substance of the ruling — phoenix stops depending on which harness build fires which hook.
- [x] The Step-4 preflight fence runs in that tree and reaches its own logic instead of exiting 127. — evidence 3, `exit=0`
- [x] The remedy states how it composes with `plant-pipeline-link.sh` and what a non-vendoring consumer gets. — the planter is idempotent against a correct link (`readlink == TARGET` → return early, no churn), and the tracked link *is* that correct link, so the planter is a no-op in phoenix from now on. The consumer gets the unchanged absolute-target hook path. See the untested-leg section.
- [x] A missing or dangling `.claude/.pipeline` becomes a named failure rather than a bare 127. — two halves, per the ruling: in phoenix the missing case is eliminated at the source (the link is checked out, so there is no window in which it is absent), and for the consumer path the previously-silent planting failure now names itself in the stamp with the planter's own fail-closed diagnostic.
- [x] The relationship to #4211 is honored rather than re-derived. — no parallel investigation opened; the intermittency is deferred per the ruling, and any mechanism finding belongs on #4211.
- [x] No artifact recommends a hand-typed symlink as the escape hatch. — nothing in this diff or this body documents one. The one place this build needed a link before it could run its own fences, it got it by **invoking the checked `plant-pipeline-link.sh`**, which derives its own target, verifies the destination has `skills/`, and proves the link resolves.

## Deviations

- **Scope narrowing** — **Said:** the issue's original AC 5 asks for *"a guard that reds when a provisioned worktree is missing any of the three links"*, turning a bare 127 into a named failure. **Did:** shipped no such guard; the missing case is eliminated at the source in phoenix (the link is checked out) and named for consumers only through the hook's new stamp. **Why:** the founder ruling enumerates three deliverables — track, one breadcrumb, defer — and its own AC list omits a link guard; adding one would be scope the ruling did not authorize. **Disposition:** for the reviewer to judge; if a standing three-link guard is still wanted it is a separate issue, not this one.
- **Known defect left unfixed** — **Said:** the intermittency that leaves ~193 of ~198 worktrees unlinked. **Did:** not investigated, not fixed. **Why:** explicitly deferred by the ruling ("not abandoned — deferred until the breadcrumb produces evidence"); #4211 owns the mechanism. **Disposition:** no action needed here; the breadcrumb is what will feed #4211.
- **Known defect left unfixed** — **Said:** nothing; this one I found while building. **Did:** left `plant-pipeline-link.sh` appending `/.claude/.pipeline` to every clone's `.git/info/exclude`, which is now inert (an exclude entry has no effect on a tracked path) but misleading — it is what forced the `git add -f` below, and it will confuse the next person who tries to stage the link. **Why:** the ruling says do not change the hook's path or mechanism, and the exclude write is part of the planter's consumer-facing behavior where it is still correct. **Disposition:** for the reviewer to judge whether the planter should skip the exclude write when the link is already tracked.
- **Guard or gate bypassed** — **Said:** nothing explicit. **Did:** staged the symlink with `git add -f`. **Why:** the root `.gitignore` line was removed as the ruling requires, but this clone's `.git/info/exclude:19` still carried `/.claude/.pipeline` from a prior plant, and a plain `git add` refuses on it. Verified afterwards that the path is genuinely in the index at mode `120000` rather than trusting the `add` (evidence 2). **Disposition:** no action needed — `info/exclude` is per-clone and never committed, and a fresh clone has no such line before the file is already tracked.

## §CP

Both surfaces (`/.claude/` and `claude-plugins/kampus-pipeline/hooks/`) are `@kamp-us/control-plane`. This stops at reviewed-ready for a control-plane approval — a merge gate, not an authorship gate. Not self-approved, not merged.
