### PR TITLE
fix(fabrika-cli): refuse an unresolvable command path instead of answering it with help (#4822)

### DIFF
--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -38,6 +38,16 @@ per-tool help documents subcommands and exit codes inline.
   without a description is mechanically detectable
   ([`packages/pipeline-cli/src/tools/commands/commands.ts`](../../../packages/pipeline-cli/src/tools/commands/commands.ts)).
   A parallel hand-written list rots; that is the defect the derived index replaced.
+- **A `--help` that resolves is proof the path exists — up to the last node that takes subcommands.**
+  `fabrika <unknown> …` is refused before the CLI runner sees it: the reason on stderr, nothing on
+  stdout, exit `1`. That holds at the group level and inside a group, with or without `--help`, and
+  however many invalid tokens follow. It has to be a fabrika-side guard because the runner answers the
+  probe otherwise — `effect`'s `Command.runWith` processes action flags before it inspects parse
+  errors, and `--help` is an action flag, so it printed the deepest valid prefix's help and exited `0`
+  while discarding the whole invalid tail ([#4822](https://github.com/kamp-us/phoenix/issues/4822)).
+  **The residual caveat:** the guarantee covers the command *path*, not a verb's operands. A leaf verb
+  takes arguments, not subcommands, so its extra tokens are its own business —
+  `fabrika adr next bogus` still runs `adr next`.
 
 ### 2. Results by value on stdout; the shape is documented, not guessed
 

--- a/packages/fabrika-cli/src/root-command.ts
+++ b/packages/fabrika-cli/src/root-command.ts
@@ -1,0 +1,17 @@
+/**
+ * The root `fabrika` command — the definition, separated from the wiring that runs it.
+ *
+ * `run.ts` executes on import, so anything that needs the command *object* (the unknown-subcommand
+ * guard, and the tests that resolve argv against the real tree) cannot get it from there. This module
+ * is importable without starting a CLI, which is what lets a test walk the same tree the runner
+ * parses instead of a parallel copy of it.
+ */
+import {Command} from "effect/unstable/cli";
+import {registeredGroups} from "./registry.ts";
+
+export const fabrikaCommand = Command.make("fabrika").pipe(
+	Command.withSubcommands(registeredGroups),
+	Command.withDescription(
+		"fabrika's deterministic verb package — `fabrika <group> <verb> …`. Stdout is the answer; scope lines and refusals go to stderr; a non-zero exit is UNKNOWN, never a partial answer.",
+	),
+);

--- a/packages/fabrika-cli/src/run.ts
+++ b/packages/fabrika-cli/src/run.ts
@@ -5,20 +5,29 @@
  * `ERR_MODULE_NOT_FOUND` the bin can explain, rather than a raw static-load throw.
  *
  * Wired per effect-smol's CLI guidance: `effect/unstable/cli` for the typed subcommands, the Node
- * platform over `NodeServices.layer`, run via `NodeRuntime.runMain`. The subcommand set comes
- * straight off `registry.ts`, so `--help` lists exactly what is registered.
+ * platform over `NodeServices.layer`, run via `NodeRuntime.runMain`. The command itself lives in
+ * `root-command.ts`; the subcommand set comes straight off `registry.ts`, so `--help` lists exactly
+ * what is registered.
+ *
+ * The one thing that happens before the runner is the unknown-subcommand guard, which the runner
+ * cannot do for itself — see `unknown-subcommand.ts` for why (#4822).
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Effect} from "effect";
 import {Command} from "effect/unstable/cli";
-import {registeredGroups} from "./registry.ts";
+import {fabrikaCommand} from "./root-command.ts";
+import {findUnknownSubcommand, refusal} from "./unknown-subcommand.ts";
+import {FAILED} from "./verb.ts";
 import {VERSION} from "./version.ts";
 
-const cli = Command.make("fabrika").pipe(
-	Command.withSubcommands(registeredGroups),
-	Command.withDescription(
-		"fabrika's deterministic verb package — `fabrika <group> <verb> …`. Stdout is the answer; scope lines and refusals go to stderr; a non-zero exit is UNKNOWN, never a partial answer.",
-	),
-);
+const unknown = findUnknownSubcommand(fabrikaCommand, process.argv.slice(2));
+if (unknown !== undefined) {
+	console.error(refusal(unknown));
+	process.exit(FAILED);
+}
 
-cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);
+fabrikaCommand.pipe(
+	Command.run({version: VERSION}),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/fabrika-cli/src/unknown-subcommand.cli.test.ts
+++ b/packages/fabrika-cli/src/unknown-subcommand.cli.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The end-to-end half of the unknown-subcommand guard: the **exit status** a caller actually reads.
+ *
+ * The unit tests cover the resolution; only a real process proves the code, and the code is the part
+ * that carried the lie — `fabrika triage --help` exited 0 (#4822). An assertion on stdout alone would
+ * have passed against the defect, because the defect printed help.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+/** Spawning under a loaded machine outruns vitest's 5s default (the #4014 false red). */
+const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/**
+ * `FABRIKA_SKIP_INFER` pins the invocation to *this* copy: the delegation would otherwise resolve
+ * whichever install the enclosing repo root pins, which is not the tree under test.
+ */
+const fabrika = (...args: ReadonlyArray<string>): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {
+			code: failure.status ?? -1,
+			stdout: failure.stdout ?? "",
+			stderr: failure.stderr ?? "",
+		};
+	}
+};
+
+describe("an unresolvable path is refused, at every depth", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it.each([
+		["an unknown group", ["triage"]],
+		["an unknown group probed with --help", ["triage", "--help"]],
+		["an unknown group probed with -h", ["triage", "-h"]],
+		["an unknown verb in a known group", ["adr", "bogus"]],
+		["an unknown verb probed with --help", ["adr", "bogus", "--help"]],
+		["a multi-token invalid tail probed with --help", ["adr", "bogus", "deeper", "--help"]],
+	])("%s exits non-zero with the refusal on stderr and nothing on stdout", (_label, args) => {
+		const run = fabrika(...args);
+		expect(run.code).not.toBe(0);
+		expect(run.stderr).toMatch(/Unknown subcommand/);
+		expect(run.stdout).toBe("");
+	});
+
+	it("names the group a bad verb sat under, not just the root", () => {
+		expect(fabrika("adr", "bogus", "deeper", "--help").stderr).toContain('for "fabrika adr"');
+	});
+
+	it("reports the first invalid token, not a later one", () => {
+		expect(fabrika("adr", "bogus", "deeper", "--help").stderr).toContain('"bogus"');
+	});
+});
+
+describe("the discovery path is unchanged", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it.each([
+		["the root index", ["--help"]],
+		["a group's verbs", ["adr", "--help"]],
+		["a verb's flags", ["adr", "next", "--help"]],
+		["a verb's flags behind another flag", ["adr", "next", "--dir", ".decisions", "--help"]],
+	])("%s still exits 0 with help on stdout and an empty stderr", (_label, args) => {
+		const run = fabrika(...args);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("USAGE");
+		expect(run.stderr).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/unknown-subcommand.ts
+++ b/packages/fabrika-cli/src/unknown-subcommand.ts
@@ -1,0 +1,111 @@
+/**
+ * Resolve `fabrika <token> …` against the command tree before the Effect CLI runner sees it, so an
+ * unresolvable path is refused instead of answered (#4822).
+ *
+ * The runner cannot do this itself. `Command.runWith` processes **action flags** (step 5) before it
+ * inspects accumulated **parse errors** (step 6), and `--help` is an action flag — so a `--help`
+ * anywhere in argv runs the help action and returns, discarding the `UnknownSubcommand` error the
+ * parser already put in `parsedArgs.errors`. Verified in the installed dependency,
+ * `effect@4.0.0-beta.92`, `src/unstable/cli/Command.ts`: line 2327 `// 5. Process action flags —
+ * first present action wins, then exit`, line 2341 `// 6. Handle parsing errors`. Without `--help`
+ * step 6 raises `ShowHelp` carrying the errors and the process exits 1; with it, exit 0 and the
+ * deepest valid prefix's help — at any depth, discarding any number of invalid tail tokens.
+ *
+ * That matters because `--help` is fabrika's designated discovery probe
+ * (`claude-plugins/fabrika/docs/cli-interface-convention.md` §1): the one probe meant to answer
+ * "does this path exist?" answered yes for paths that do not.
+ *
+ * The guard runs on every invocation, not only ones carrying `--help`, so one refusal shape covers
+ * both — and it seats that refusal the way §2/§3 of the convention require: the reason on stderr,
+ * nothing on stdout, a non-zero exit.
+ */
+
+/**
+ * The shape this module needs of a command — satisfied by `effect/unstable/cli`'s `Command`, so the
+ * guard walks the *same object* the runner parses and cannot drift from the registry.
+ */
+export interface CommandNode {
+	readonly name: string;
+	readonly alias: string | undefined;
+	readonly hidden: boolean;
+	readonly subcommands: ReadonlyArray<{readonly commands: ReadonlyArray<CommandNode>}>;
+}
+
+/** A token that named no subcommand of the node it sat under. */
+export interface UnknownSubcommand {
+	/** The offending token. */
+	readonly token: string;
+	/** The command path it sat under, root first — e.g. `["fabrika", "adr"]`. */
+	readonly path: ReadonlyArray<string>;
+	/** What that node does accept, in declaration order. */
+	readonly known: ReadonlyArray<string>;
+}
+
+/**
+ * Name → subcommand, plus each alias, mirroring the parser's own `buildSubcommandIndex`
+ * (`effect/unstable/cli/internal/parser.ts`). Hidden subcommands are indexed: the parser resolves
+ * them by exact name too, and only excludes them from what it *offers*.
+ */
+const subcommandIndex = (node: CommandNode): ReadonlyMap<string, CommandNode> => {
+	const index = new Map<string, CommandNode>();
+	for (const group of node.subcommands) {
+		for (const sub of group.commands) {
+			index.set(sub.name, sub);
+			if (sub.alias !== undefined && sub.alias !== sub.name) index.set(sub.alias, sub);
+		}
+	}
+	return index;
+};
+
+/** What a node offers: hidden subcommands are withheld so a typo cannot reveal one (same parser). */
+const offered = (node: CommandNode): ReadonlyArray<string> =>
+	node.subcommands.flatMap((group) =>
+		group.commands.filter((sub) => !sub.hidden).map((sub) => sub.name),
+	);
+
+/**
+ * Walk `argv` down the tree and return the first token that names no subcommand of the node it sits
+ * under, or `undefined` when the path resolves.
+ *
+ * Two stopping rules, both of which can only *miss* an unknown path and never invent one — the
+ * fail-safe direction for a guard whose output is a refusal:
+ *
+ * - **A leaf ends the walk.** A node with no subcommands takes arguments, so its tokens are its own.
+ * - **A flag ends the walk.** A later bare token may be that flag's value (`--log-level debug`), and
+ *   reading a flag value as a subcommand would refuse a valid invocation.
+ *
+ * One divergence from the parser: it suppresses `UnknownSubcommand` when the node *also* declares
+ * positional arguments (`resolveFirstValue`'s `expectsArgs` branch), which the public `Command`
+ * surface does not expose. No fabrika node has both — every node carrying subcommands is a bare
+ * `Command.make(name)` router — and `unknown-subcommand.unit.test.ts` re-proves that against the
+ * real tree by running the parser itself at each such node.
+ */
+export const findUnknownSubcommand = (
+	root: CommandNode,
+	argv: ReadonlyArray<string>,
+): UnknownSubcommand | undefined => {
+	let node = root;
+	const path: Array<string> = [root.name];
+	for (const token of argv) {
+		if (token.startsWith("-")) return undefined;
+		const index = subcommandIndex(node);
+		if (index.size === 0) return undefined;
+		const next = index.get(token);
+		if (next === undefined) return {token, path: [...path], known: offered(node)};
+		node = next;
+		path.push(next.name);
+	}
+	return undefined;
+};
+
+/**
+ * The stderr line for a refusal.
+ *
+ * It keeps the runner's own `Unknown subcommand "x" for "y"` wording — that phrasing is what callers
+ * already match on — and appends what the node does accept, which is more use to a caller than the
+ * help body this refusal replaces on stdout.
+ */
+export const refusal = (unknown: UnknownSubcommand): string =>
+	`fabrika: Unknown subcommand "${unknown.token}" for "${unknown.path.join(" ")}" — known subcommands: ${
+		unknown.known.join(", ") || "(none)"
+	}`;

--- a/packages/fabrika-cli/src/unknown-subcommand.unit.test.ts
+++ b/packages/fabrika-cli/src/unknown-subcommand.unit.test.ts
@@ -1,0 +1,163 @@
+import {NodeServices} from "@effect/platform-node";
+import {Cause, Effect, Exit, Option} from "effect";
+import {CliError, Command} from "effect/unstable/cli";
+import {describe, expect, it} from "vitest";
+import {registeredGroups} from "./registry.ts";
+import {fabrikaCommand} from "./root-command.ts";
+import {type CommandNode, findUnknownSubcommand, refusal} from "./unknown-subcommand.ts";
+
+const node = (
+	name: string,
+	subs: ReadonlyArray<CommandNode> = [],
+	extra: {alias?: string; hidden?: boolean} = {},
+): CommandNode => ({
+	name,
+	alias: extra.alias,
+	hidden: extra.hidden ?? false,
+	subcommands: subs.length === 0 ? [] : [{commands: subs}],
+});
+
+describe("findUnknownSubcommand", () => {
+	const leaf = node("leaf");
+	const group = node("group", [node("verb", [], {alias: "v"}), node("secret", [], {hidden: true})]);
+	const root = node("root", [group, leaf]);
+
+	it("resolves a known path to no refusal", () => {
+		expect(findUnknownSubcommand(root, ["group", "verb"])).toBeUndefined();
+	});
+
+	it("resolves an alias the parser would resolve", () => {
+		expect(findUnknownSubcommand(root, ["group", "v"])).toBeUndefined();
+	});
+
+	it("resolves a hidden subcommand by exact name, as the parser does", () => {
+		expect(findUnknownSubcommand(root, ["group", "secret"])).toBeUndefined();
+	});
+
+	it("refuses an unknown token at the root, naming the path and what root offers", () => {
+		expect(findUnknownSubcommand(root, ["nope"])).toEqual({
+			token: "nope",
+			path: ["root"],
+			known: ["group", "leaf"],
+		});
+	});
+
+	it("refuses an unknown token one level down, naming the group's path", () => {
+		expect(findUnknownSubcommand(root, ["group", "nope"])).toEqual({
+			token: "nope",
+			path: ["root", "group"],
+			known: ["verb"],
+		});
+	});
+
+	it("withholds hidden subcommands from what it offers, so a typo cannot reveal one", () => {
+		expect(findUnknownSubcommand(root, ["group", "nope"])?.known).not.toContain("secret");
+	});
+
+	it("reports the FIRST unknown token, not the last, however long the invalid tail", () => {
+		expect(findUnknownSubcommand(root, ["group", "nope", "deeper", "deepest"])?.token).toBe("nope");
+	});
+
+	it("stops at a leaf — its tokens are its own arguments, not subcommands", () => {
+		expect(findUnknownSubcommand(root, ["leaf", "whatever"])).toBeUndefined();
+	});
+
+	it("stops at a flag — a later bare token may be that flag's value", () => {
+		expect(findUnknownSubcommand(root, ["--log-level", "debug"])).toBeUndefined();
+	});
+
+	it("treats empty argv as resolved (the bare-root help case)", () => {
+		expect(findUnknownSubcommand(root, [])).toBeUndefined();
+	});
+
+	it("refuses before a trailing help flag, whichever spelling", () => {
+		for (const help of ["--help", "-h"]) {
+			expect(findUnknownSubcommand(root, ["nope", help])?.token).toBe("nope");
+		}
+	});
+});
+
+describe("refusal", () => {
+	it("keeps the runner's own wording and appends what the node accepts", () => {
+		expect(refusal({token: "bogus", path: ["fabrika", "adr"], known: ["next", "new"]})).toBe(
+			'fabrika: Unknown subcommand "bogus" for "fabrika adr" — known subcommands: next, new',
+		);
+	});
+
+	it("says so rather than trailing off when a node offers nothing", () => {
+		expect(refusal({token: "bogus", path: ["fabrika"], known: []})).toContain(
+			"known subcommands: (none)",
+		);
+	});
+});
+
+describe("against the real fabrika command tree", () => {
+	it("resolves every registered group", () => {
+		for (const group of registeredGroups) {
+			expect(findUnknownSubcommand(fabrikaCommand, [group.name])).toBeUndefined();
+		}
+	});
+
+	it("finds groups at all — fail closed on zero scope (ADR 0092)", () => {
+		expect(registeredGroups.length).toBeGreaterThan(0);
+	});
+
+	it("refuses an unregistered group", () => {
+		expect(findUnknownSubcommand(fabrikaCommand, ["triage", "--help"])).toEqual({
+			token: "triage",
+			path: ["fabrika"],
+			known: registeredGroups.map((group) => group.name),
+		});
+	});
+
+	it("refuses an unregistered verb inside a registered group", () => {
+		expect(
+			findUnknownSubcommand(fabrikaCommand, ["adr", "bogus", "deeper", "--help"])?.path,
+		).toEqual(["fabrika", "adr"]);
+	});
+});
+
+/**
+ * Closes the one divergence `findUnknownSubcommand` documents: if a future group ever declared both
+ * subcommands and positional arguments, the parser would read an unknown token as an argument while
+ * the guard refused it. This reds there instead.
+ *
+ * `Command.runWith` drives a command over an explicit argument array (`effect/unstable/cli/Command.ts`,
+ * `runWith`'s "Test help display" example) and bypasses `run.ts` — so the runner answers here, never
+ * the guard.
+ */
+describe("the parser refuses an unknown token at every node that carries subcommands", () => {
+	const routerPaths = (
+		command: CommandNode,
+		prefix: ReadonlyArray<string> = [],
+	): ReadonlyArray<ReadonlyArray<string>> => {
+		const children = command.subcommands.flatMap((group) => group.commands);
+		if (children.length === 0) return [];
+		return [prefix, ...children.flatMap((child) => routerPaths(child, [...prefix, child.name]))];
+	};
+
+	const paths = routerPaths(fabrikaCommand);
+
+	it("finds router nodes at all — fail closed on zero scope (ADR 0092)", () => {
+		expect(paths.length).toBeGreaterThan(0);
+	});
+
+	it.each(
+		paths.map((path) => [path.join(" ") || "(root)", path] as const),
+	)("refuses at `fabrika %s`", async (_label, path) => {
+		const exit = await Effect.runPromiseExit(
+			Command.runWith(fabrikaCommand, {version: "test"})([...path, "__no_such_token__"]).pipe(
+				Effect.provide(NodeServices.layer),
+			),
+		);
+		expect(Exit.isFailure(exit)).toBe(true);
+		const failure = Exit.isFailure(exit)
+			? Option.getOrUndefined(Cause.findErrorOption(exit.cause))
+			: undefined;
+		expect(
+			CliError.isCliError(failure) &&
+				failure._tag === "ShowHelp" &&
+				failure.errors.some((error) => error._tag === "UnknownSubcommand"),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
Typing `fabrika something-that-does-not-exist --help` used to print help and exit 0, so the probe a session uses to find out whether a verb exists happily confirmed verbs that were never registered. It now refuses: a reason on stderr, nothing on stdout, exit 1 — at the group level, inside a group, and however many junk tokens follow. Valid `--help` invocations are untouched.

Fixes #4822

## What the immunity read found (the refinement's first ask)

The refinement on the issue asked, before anything else, why `pipeline-cli`'s top level is immune while fabrika's is not, and flagged that as unverified. Read: **the immunity is incidental, not a containment pattern.**

`packages/pipeline-cli/src/run.ts` resolves argv **before** it constructs the Effect CLI, because tool modules are loaded lazily — only the selected tool is imported (#4008). `resolveSubcommands()` runs the pure `dispatch()` from `router.ts` on `argv[0]`, and an unregistered token hits `exitWith(...)` → `console.error` + `process.exit(1)`, so the runner never sees the invocation at all. The stderr bytes corroborate it: the message is `UnknownToolError.message` verbatim, not the Effect CLI's `Unknown subcommand` wording.

```
$ pipeline-cli bogusgroup --help
exit 1, stdout 0b, stderr 1180b
unknown tool "bogusgroup" — known tools: version, epic-ledger, epic-lock, …
```

So the top level is guarded by a **module-loading optimisation**, and the guard stops exactly where the optimisation stops: once the selector resolves, the rest of argv goes to `Command.withSubcommands`, which is why `pipeline-cli cp-classify bogusverb --help` still exits 0.

Two consequences, both of which shaped this PR:

- The **shape** is copyable — resolve argv before the runner — and this PR copies it. Its **coverage is not**: a top-level-only pre-check would leave AC #2 (unknown verb inside a known group) unmet. This guard walks the whole tree instead.
- The dep-patch case is weaker than the issue's original framing. It is **not** an identical lie, so this PR does not use that argument. See the `pipeline-cli` note at the bottom.

## Root cause, grounded in the installed dependency

Read at `effect@4.0.0-beta.92`, `src/unstable/cli/Command.ts` (the resolved install carries `patch_hash=…`, so this is the patched copy the repo actually runs):

- **line 2327** — `// 5. Process action flags — first present action wins, then exit`. The loop runs the matching action and `return`s.
- **line 2341** — `// 6. Handle parsing errors` — `if (parsedArgs.errors && parsedArgs.errors.length > 0) { return yield* new CliError.ShowHelp({ commandPath, errors: parsedArgs.errors }) }`

`GlobalFlag.Help` is an `Action` flag, and the parser has already pushed `UnknownSubcommand` into `parsedArgs.errors` at step 3 (`internal/parser.ts`, `resolveFirstValue`). Step 5 returns before step 6 ever looks, so the errors are dropped and the process exits 0. There is no hook to reorder this from outside: `Command.run`'s config is `{version}` and nothing else, and effect-smol's `LLMS.md` §"Building CLI applications" documents no pre-parse validation seam — so the documented idiom does not conflict with a fabrika-side pre-check, there simply isn't one to conflict with.

## The fix — Q2 answered as fabrika-local containment

Triage's lean, taken. `packages/fabrika-cli/src/unknown-subcommand.ts` resolves argv against the command tree before `Command.run`, and refuses on the first token that names no subcommand of the node it sits under.

Three things make it not a re-implementation of the parser:

- **It walks the same object the runner parses.** The root command moved to `root-command.ts` (importable without starting a CLI) and the guard takes that `Command` directly — name and alias resolution mirrors the parser's own `buildSubcommandIndex`, and hidden subcommands resolve by exact name but are withheld from what the refusal offers, exactly as `resolveFirstValue` does. It cannot drift from `registry.ts` because it never reads a second list.
- **Both stopping rules can only miss, never over-refuse.** A leaf ends the walk (its tokens are its own arguments); a flag ends the walk (a later bare token may be that flag's value, e.g. `--log-level debug`). For a guard whose output is a refusal, that is the fail-safe direction.
- **The one divergence is tested, not assumed.** The parser also suppresses `UnknownSubcommand` at a node that declares positional arguments, and the public `Command` surface does not expose that. `unknown-subcommand.unit.test.ts` drives `Command.runWith` — the documented explicit-argv entry point — at every node in the real tree that carries subcommands and asserts the **runner itself** refuses there. If a future group ever declares both, that test reds instead of the guard silently over-refusing.

The guard runs on every invocation, not only ones carrying `--help`, so both paths give one answer.

## Observed behaviour — before and after

Exit codes captured by redirecting stdout/stderr to files; a pipe would report the pipe's status.

**Before** (commit before this branch's change):

| command | exit | stdout | stderr |
|---|---|---|---|
| `fabrika --help` | 0 | 1257b | 0b |
| `fabrika --version` | 0 | 15b | 0b |
| `fabrika adr --help` | 0 | 2443b | 0b |
| `fabrika adr next --help` | 0 | 1201b | 0b |
| `fabrika triage` | 1 | 1257b | 51b |
| `fabrika triage --help` | **0** | 1257b | **0b** |
| `fabrika adr bogus` | 1 | 2443b | 54b |
| `fabrika adr bogus --help` | **0** | 2443b | **0b** |
| `fabrika adr bogus deeper --help` | **0** | 2443b | **0b** |
| `fabrika adr bogus -h` | **0** | 2443b | **0b** |

**After:**

| command | exit | stdout | stderr |
|---|---|---|---|
| `fabrika --help` | 0 | 1257b | 0b |
| `fabrika --version` | 0 | 15b | 0b |
| `fabrika adr --help` | 0 | 2443b | 0b |
| `fabrika adr next --help` | 0 | 1201b | 0b |
| `fabrika adr next --dir .decisions --help` | 0 | 1201b | 0b |
| `fabrika triage` | **1** | **0b** | 92b |
| `fabrika triage --help` | **1** | **0b** | 92b |
| `fabrika adr bogus` | **1** | **0b** | 129b |
| `fabrika adr bogus --help` | **1** | **0b** | 129b |
| `fabrika adr bogus deeper --help` | **1** | **0b** | 129b |
| `fabrika adr bogus -h` | **1** | **0b** | 129b |

The stderr bytes, verbatim:

```
fabrika: Unknown subcommand "triage" for "fabrika" — known subcommands: adr, eval, report
fabrika: Unknown subcommand "bogus" for "fabrika adr" — known subcommands: next, new, resolve, supersede, amend-in-part, sweep
```

## The new tests fail against the old code

`unknown-subcommand.cli.test.ts` run with the guard removed from `run.ts` and everything else identical:

```
 × an unknown group exits non-zero with the refusal on stderr and nothing on stdout
 × an unknown group probed with --help exits non-zero with the refusal on stderr and nothing on stdout
 × an unknown group probed with -h exits non-zero with the refusal on stderr and nothing on stdout
 × an unknown verb in a known group exits non-zero with the refusal on stderr and nothing on stdout
 × an unknown verb probed with --help exits non-zero with the refusal on stderr and nothing on stdout
 × a multi-token invalid tail probed with --help exits non-zero with the refusal on stderr and nothing on stdout
 × names the group a bad verb sat under, not just the root
 × reports the first invalid token, not a later one

 Test Files  1 failed (1)
      Tests  8 failed | 4 passed (12)
```

The sharpest assertion, and the reason a stdout-only test would have proved nothing — the defect *printed help*, so only the status caught it:

```
AssertionError: expected +0 not to be +0 // Object.is equality
 ❯ src/unknown-subcommand.cli.test.ts:55:24
     54|   const run = fabrika(...args);
     55|   expect(run.code).not.toBe(0);
       |                        ^
```

The 4 that passed are the "the discovery path is unchanged" suite — correct, those paths were already right and this PR must not move them.

After the fix, the same file:

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Whole package, including the 22 unit tests:

```
 Test Files  37 passed (37)
      Tests  508 passed (508)
```

`pnpm typecheck` — `Tasks: 30 successful, 30 total`. `pnpm lint:worktree` — `Checked 5 files in 12ms. No fixes applied.`

## Acceptance criteria

- [x] `fabrika <unknown-group> --help` exits non-zero with an `Unknown subcommand` refusal on stderr — rows above.
- [x] `fabrika <known-group> <unknown-verb> --help` behaves the same, and `fabrika adr bogus deeper --help` is not silently discarded — rows above.
- [x] `fabrika <known-group> --help` and `fabrika --help` unchanged: exit 0, help on stdout, empty stderr — rows above, byte-identical before and after.
- [x] Tests assert the **exit status**, not just stdout — `unknown-subcommand.cli.test.ts` spawns a real process and asserts the code; the red above is on that assertion.
- [x] `cli-interface-convention.md` §1 records the guarantee **and** the residual caveat (Q3) — a `--help` that resolves proves the command *path* exists, up to the last node that takes subcommands; a leaf verb's operands are not checked, so `fabrika adr next bogus` still runs `adr next`.
- [x] The `pnpm patch` route was **not** taken, so the AC conditioned on it does not apply. Why it was not, below.

## Why not the `pnpm patch` on `effect` — and what `pipeline-cli` keeps

Not taken, and deliberately **not** argued on "it fixes `pipeline-cli`'s identical lie too". The refinement measured that the lie is not identical: `pipeline-cli` is immune at the group level a discoverer probes first, and exposed only at the nested verb level. The shared-fix rationale is therefore smaller than the issue's original framing assumed.

What is left is the plain cost/benefit. A patch to step 5/6 ordering changes argument parsing for **every** Effect CLI in the repo — `pipeline-cli` and the 29 other workspace packages — to fix a defect that today has one observed victim, and adds drift to re-apply across each `effect` beta bump. Containment is bounded to fabrika, unit-testable without spawning, and carries no upgrade tax.

**Stated rather than left implied, as the refinement asked:** `pipeline-cli cp-classify <unknown-verb> --help` still exits 0 with `cp-classify`'s help and an empty stderr. This PR does not change it. No twin issue is filed — under the founder focus ruling that arrival would be out of lane, and filing one manufactures a deferred ticket.

## Deviations

- **Class: narrowed the fix shape.** Said: triage left Q2 open with a lean toward fabrika-local containment. Did: took containment, and placed the pre-check in `run.ts` over the whole command tree rather than in `bin.ts` over the first token as the original report suggested. Why: `bin.ts` is a pre-runtime bootstrap that imports nothing from `effect`, and a first-token check only covers the root — it would leave AC #2 unmet. Disposition: no action needed.

- **Class: behaviour changed beyond the acceptance criteria.** Said: the ACs only constrain the `--help` variants. Did: the guard also changes the non-`--help` unknown-path case — `fabrika adr bogus` went from `exit 1` with 2443b of help on stdout to `exit 1` with 0b on stdout and a richer stderr line. Why: a guard that fires only when `--help` is present leaves two different answers for one question, and dumping help on a non-zero exit contradicts `verb.ts`'s stated contract and §3 of the interface convention ("a non-zero exit is UNKNOWN, never a partial answer"). The refusal names the known subcommands, which is more use than the help body it replaces. Disposition: for the reviewer to judge — the exit code is unchanged for this case, only the channel content moved.

- **Class: a defect left for a follow-up.** Said: nothing. Did: found a sibling instance while measuring and did not fix it — `fabrika adr next bogus` exits **0**, running `adr next` and silently discarding `bogus`. It is the same "silently discard what you could not resolve" family, but at the *argument* layer, not the subcommand layer, and outside every AC here. Why: fixing operand validation is a different change to a different seam. Disposition: recorded as the residual caveat in `cli-interface-convention.md` §1 so no reader infers a guarantee this does not give; filed as #4828 rather than folded in.

- **Class: added a file the issue did not ask for.** Said: fix the defect. Did: also split the root command out of `run.ts` into `root-command.ts`. Why: `run.ts` executes on import, so neither the guard nor a test could get the command object from it; the split is what lets the guard and the parser-agreement test walk the same tree the runner parses instead of a parallel copy. Disposition: no action needed.
