### PR TITLE
feat(fabrika-cli): publish the ruled KEEP corpus as an enumeration (#4823)

### DIFF
--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -1,14 +1,15 @@
 /**
- * The `eval` verb group — `fabrika eval check|report|cases|run`.
+ * The `eval` verb group — `fabrika eval check|report|cases|run|keeps`.
  *
  * The graded-corpus apparatus for adjudicating a stochastic model swap per stage (epic
- * #1842), plus the ingestion of `/skill-creator`-authored eval sets (epic #4649). Four live
+ * #1842), plus the ingestion of `/skill-creator`-authored eval sets (epic #4649). Five live
  * surfaces:
  *
  *   fabrika eval check <manifest>   # decode a corpus manifest; exit non-zero on a bad one
  *   fabrika eval report <rows>      # the graded two-axis scorecard over runner rows
  *   fabrika eval cases <path>       # decode an authored eval set; exit non-zero on a bad one
  *   fabrika eval run <path>         # execute an eval set unattended, emit the capture manifest
+ *   fabrika eval keeps <path>       # print the ruled KEEP corpus and what already pins each row
  *
  * `check` (issue #1848) validates the on-disk corpus format. `report` (issue #1853) is the
  * top of the vertical slice: it reads the runner's graded `{entry, grade, spend}` rows and
@@ -16,15 +17,18 @@
  * cost — as a human table (default) or stable JSON (`--json`), the evidence the model-tiering
  * decision (#1576) consumes. It presents measurement, never a recommendation. `cases` (issue
  * #4674) validates a `/skill-creator` `evals/evals.json` and prints the tier each case derives to.
+ * `keeps` (issue #4823) prints the ruled KEEP corpus — the enumeration that replaced the
+ * two-artifact join every consumer used to re-run by hand.
  *
  * Thin IO shell over the pure cores (the `token-spend` / `readme-guard` idiom): read the file,
  * decode, render. An unreadable path and a malformed/mismatched input both exit non-zero.
  */
-import {Console, Crypto, Effect, FileSystem, Result} from "effect";
+import {Console, Crypto, Effect, FileSystem, Path, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import {decodeManifest, STAGES} from "./corpus.ts";
+import {decodeIncidentProvenance} from "./incident-provenance.ts";
 import {
 	type BaselineKey,
 	buildScorecard,
@@ -32,6 +36,13 @@ import {
 	renderTable,
 	toJson,
 } from "./report.ts";
+import {
+	decodeRuledKeeps,
+	keepsToJson,
+	renderKeeps,
+	ruledKeepsViolations,
+	withCoverage,
+} from "./ruled-keeps.ts";
 import {decodeSkillEvalSet, tierCounts} from "./skill-eval-set.ts";
 import {
 	buildClaudeArgs,
@@ -435,9 +446,96 @@ const runCommand = leafCommand(
 	),
 );
 
-export const evalCommand = Command.make("eval").pipe(
-	Command.withSubcommands([check, report, cases, runCommand]),
+// A named enumeration/ledger path that could not be read — a hard error (exit 1), not a skip.
+class KeepsUnreadable extends Schema.TaggedErrorClass<KeepsUnreadable>()("KeepsUnreadable", {
+	path: Schema.String,
+}) {}
+
+const keepsArg = Argument.string("path").pipe(
+	Argument.withDescription(
+		"path to the ruled-KEEP enumeration (incident-corpus/ruled-keeps.json) — the committed membership list",
+	),
+);
+
+const provenanceFlag = Flag.string("provenance").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"path to the provenance ledger the coverage column is joined from (default: provenance.json beside the enumeration)",
+	),
+);
+
+/**
+ * `keeps` — print the ruled KEEP corpus (#4823).
+ *
+ * Membership was ruled in #4642 and never written down, so every consumer re-ran a two-artifact
+ * join by hand. This verb is the read that replaces it. Coverage is joined live from the
+ * provenance ledger rather than stored, so the two can never disagree.
+ */
+const keeps = Command.make(
+	"keeps",
+	{path: keepsArg, provenance: provenanceFlag, json: jsonFlag},
+	Effect.fn(function* (opts) {
+		const run = Effect.gen(function* () {
+			const fs = yield* FileSystem.FileSystem;
+			const path = yield* Path.Path;
+			const text = yield* Effect.mapError(
+				fs.readFileString(opts.path),
+				() => new KeepsUnreadable({path: opts.path}),
+			);
+			const decoded = decodeRuledKeeps(text);
+			if (Result.isFailure(decoded)) {
+				yield* Console.error(
+					`fabrika eval: ${opts.path} is not a valid ruled-KEEP enumeration (${decoded.failure.reason}): ${decoded.failure.message}`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+			const violations = ruledKeepsViolations(decoded.success);
+			if (violations.length > 0) {
+				yield* Console.error(
+					`fabrika eval: ${opts.path} decodes but breaks its own integrity rules:\n${violations.map((v) => `  - ${v}`).join("\n")}`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+
+			const ledgerPath =
+				opts.provenance._tag === "Some"
+					? opts.provenance.value
+					: path.join(path.dirname(opts.path), "provenance.json");
+			const ledgerText = yield* Effect.mapError(
+				fs.readFileString(ledgerPath),
+				() => new KeepsUnreadable({path: ledgerPath}),
+			);
+			const ledger = decodeIncidentProvenance(ledgerText);
+			if (Result.isFailure(ledger)) {
+				yield* Console.error(
+					`fabrika eval: ${ledgerPath} is not a valid provenance ledger (${ledger.failure.reason}): ${ledger.failure.message}`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+
+			const covered = withCoverage(decoded.success, ledger.success);
+			yield* Console.log(
+				opts.json ? keepsToJson(decoded.success, covered) : renderKeeps(decoded.success, covered),
+			);
+		});
+		yield* run.pipe(
+			Effect.catchTag("KeepsUnreadable", (e) =>
+				Effect.gen(function* () {
+					yield* Console.error(`fabrika eval: cannot read ${e.path}`);
+					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				}),
+			),
+		);
+	}),
+).pipe(
 	Command.withDescription(
-		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner (#1848, #1853, #4674, #4676)",
+		"Print the ruled KEEP corpus — the committed enumeration of the fabrika eval feedstock, with each row's derivation and the eval cases that pin it (#4823)",
+	),
+);
+
+export const evalCommand = Command.make("eval").pipe(
+	Command.withSubcommands([check, report, cases, runCommand, keeps]),
+	Command.withDescription(
+		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner + the ruled KEEP enumeration (#1848, #1853, #4674, #4676, #4823)",
 	),
 );

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -471,7 +471,7 @@ const provenanceFlag = Flag.string("provenance").pipe(
  * join by hand. This verb is the read that replaces it. Coverage is joined live from the
  * provenance ledger rather than stored, so the two can never disagree.
  */
-const keeps = Command.make(
+const keeps = leafCommand(
 	"keeps",
 	{path: keepsArg, provenance: provenanceFlag, json: jsonFlag},
 	Effect.fn(function* (opts) {

--- a/packages/fabrika-cli/src/eval/incident-corpus/README.md
+++ b/packages/fabrika-cli/src/eval/incident-corpus/README.md
@@ -7,12 +7,14 @@ must pass, always — and the founder's ruling on
 becomes a case within days. This page is how you do that, so the floor grows by rule rather than
 by whoever remembers.
 
-Two files hold the corpus:
+Three files hold the corpus:
 
 - `evals.json` — the cases, in the `/skill-creator` authoring format, decoded by
   [`../skill-eval-set.ts`](../skill-eval-set.ts). No field is added to that format here.
 - `provenance.json` — the sidecar that binds each case to the artifact it pins, decoded by
   [`../incident-provenance.ts`](../incident-provenance.ts).
+- `ruled-keeps.json` — the enumeration of the incidents ruled into the feedstock, decoded by
+  [`../ruled-keeps.ts`](../ruled-keeps.ts) and printed by `fabrika eval keeps`.
 
 ## What makes an incident a case
 
@@ -39,11 +41,19 @@ sharpest the moment it lands, and a case written a week later is written from th
 than from the failure. The ruled expectation is **days, not sprints**: an incident closed today
 should carry its case before the week is out.
 
-If the incident is one of the 74 KEEP issues, verify membership **two ways**, because no
-enumeration of the 74 exists to read: a `KEEP-AS-EVAL` row on the
-[#4634](https://github.com/kamp-us/phoenix/issues/4634) verdict table, **and** absence from the
-153-issue kill list in the [#4642](https://github.com/kamp-us/phoenix/issues/4642) ruling. Record
-both in the case's `verification`.
+If the incident is one of the ruled KEEP issues, **read `ruled-keeps.json`** — or run
+`fabrika eval keeps incident-corpus/ruled-keeps.json`, which prints each row with the eval cases
+that already pin it. Membership is **66**, plus one pending row
+([#4180](https://github.com/kamp-us/phoenix/issues/4180), whose sweep verdict the
+[#4642](https://github.com/kamp-us/phoenix/issues/4642) ruling retracted and never replaced). Cite
+the enumeration in the case's `verification`.
+
+Do **not** re-run the two-artifact join by hand. That join — a `KEEP-AS-EVAL` row on the
+[#4634](https://github.com/kamp-us/phoenix/issues/4634) verdict table **and** absence from the
+153-issue kill list in the #4642 ruling — is now recorded once, as `ruled-keeps.json`'s
+`derivation`, which is also where the arithmetic behind the corrected figure lives. #4642 published
+the size as 74; that double-counts the 7 borderline items, which carry `KEEP-AS-EVAL` rows and were
+never outside the set. The enumerated figure is 66 ([#4823](https://github.com/kamp-us/phoenix/issues/4823)).
 
 ## Adding a case
 

--- a/packages/fabrika-cli/src/eval/incident-corpus/ruled-keeps.json
+++ b/packages/fabrika-cli/src/eval/incident-corpus/ruled-keeps.json
@@ -1,0 +1,959 @@
+{
+	"corpus": "fabrika eval feedstock — the ruled KEEP corpus of #4642",
+	"derivedAt": "2026-08-03",
+	"derivation": {
+		"recipe": "A row is a member iff it carries a KEEP-AS-EVAL verdict on the #4634 sweep table AND its number is absent from the 153-issue kill list in the #4642 ruling comment. Applied mechanically over both artifacts.",
+		"sources": [
+			"#4634 comment 5149946878 — the sweep table, 222 rows of `#NNNN | VERDICT | reason` (80 KEEP-AS-EVAL, 138 KILL-CANDIDATE, 4 UNSURE)",
+			"#4642 comment 5150090125 — the ruling, whose `The full kill list (153)` line is the exclusion set",
+			"#4642 comment 5149968683 — the crew-layer scope delta naming the 14 re-buckets and the 7 borderline"
+		],
+		"arithmetic": [
+			"Derivation A (the recipe): 80 KEEP-AS-EVAL rows minus the 14 that appear in the 153-issue kill list = 66.",
+			"Derivation B (independent): 80 KEEP-AS-EVAL rows minus the 14 crew-layer re-buckets named in the scope delta = 66. All 14 re-buckets are in the kill list, so A and B are the same 66 issues.",
+			"The sweep's stated per-chunk KEEP total is 81 against 80 enumerated rows; the one-row gap is #4180, carried as a pending row rather than resolved either way.",
+			"#4642 publishes the corpus size as 74 ('the 67 pipeline-incident KEEPs plus the 7 borderline folded in'). That double-counts: all 7 borderline (#4338 #3330 #4285 #4163 #4145 #3945 #3709) carry KEEP-AS-EVAL rows and none is among the 14 re-buckets, so they were inside the KEEP set already and were added a second time. 67 was itself computed from the stated 81 rather than the 80 rows that exist. The enumerable figure is 66, plus 1 pending."
+		]
+	},
+	"rows": [
+		{
+			"issue": 2118,
+			"title": "Should deployed-worker system smokes be fail-closed merge gates? (ci-required coupling)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "non-hermetic deployed-worker smoke drift evicted 4 unrelated approved §CP PRs",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 2617,
+			"title": "ADR 0164 guard-ADR probe false-positives on DESIGN-law ADRs (gate/guard/containment used visually)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "design-law ADR 0176 false-positived §CP by guard-vocab regex, blocked shipping",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 2666,
+			"title": "Fresh self-provisioned coder worktree started dirty with an unauthored uncommitted hunk",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "fresh self-provisioned worktree started dirty with an unauthored uncommitted hunk",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 2923,
+			"title": "Worktree provisioning fails 3/3 — bootstrap-deps (~11s pnpm install) exceeds harness provisioning timeout, whole build lane down",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "worktree provisioning failed 3/3 in-session, whole build lane down (timeout race)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 2997,
+			"title": "Primary-checkout index recurred with 251 staged deletions (#2778 mass-staged-deletion class)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "251 control-plane deletions staged into primary index, actor unpinnable (recurrence of #2778)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 3086,
+			"title": "PR-create leaked a literal @/tmp body-file reference into a PR body (local-path leak)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "PR #3077 body shipped literal @/tmp path leak",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 3148,
+			"title": "phoenix-reactions was live at on@100% despite being a 'default-off dark-ship' flag with an unsettled decision — release-drift governance gap",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "dark-ship flag silently drifted to on@100%, decision unsettled (#2408)",
+			"sweepSection": "M39 Flag Lifecycle",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Flag Lifecycle campaign — graduation mechanism + retirement tail"
+			}
+		},
+		{
+			"issue": 3170,
+			"title": "§CP mixed code+skill PR fails-closed at ship unless both review namespaces are filled",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "reviewer filled one namespace on mixed diff; ship refused, wasted round-trip",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 3173,
+			"title": "Reviewer verdict emit-bypass recurs: raw `gh api -f body=@file` posts a literal @path (empty namespace + local-path leak) vs `pipeline-cli verdict post`",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "reviewer's raw gh api emit posted literal path, self-reported false PASS",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 3330,
+			"title": "Pipeline: triage/plan-epic baseline scan runs against stale local checkout, spawning phantom no-op children",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "stale local checkout inflated baseline, spawned phantom no-op children",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": true,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 3369,
+			"title": "CodeQL code-scanning merge gate is unsatisfiable in the merge queue — needs merge_group trigger (advanced setup) to be re-armable",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "arming code_scanning wedged queue: default CodeQL never runs on merge_group",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 3377,
+			"title": "Re-arm the ADR-0158 unresolved-thread gate as a required check the correct way (job-name context + rebase in-flight PRs) so it doesn't re-wedge the queue",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "required check armed with workflow-name context; wedged entire merge queue",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 3416,
+			"title": "Guard-touching ADRs mis-classified NON-§CP by path-regex alone — ADR 0164 content clause not applied at review gate or driver",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "guard-touching ADR PR #3415 misclassified non-§CP by gate and driver",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 3594,
+			"title": "isolation:worktree coders wrote initial Write/Edit to primary checkout paths (2/2 near-miss)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "2/2 coders addressed initial Write/Edit to primary-checkout absolute paths",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 3607,
+			"title": "review-code verdict-file /tmp collision contaminated a PR marker with another PR's body (#1465 recurrence)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "/tmp collision posted PR #3592's verdict onto PR #3603",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 3709,
+			"title": "Parallel verb-extraction lanes all conflict on registry.ts + adoption-lint manifest",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "N parallel lanes all merge-conflicted on registry.ts central lists",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": true,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 3720,
+			"title": "Integration/e2e stages serve flags at IaC defaults, not prod serving state",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "CI served flag-OFF world; retirement PR #3707 broke 61 tests",
+			"sweepSection": "M39 Flag Lifecycle",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Flag Lifecycle campaign — graduation mechanism + retirement tail"
+			}
+		},
+		{
+			"issue": 3744,
+			"title": "Worktree creation can silently not happen for an agent spawned with isolation:worktree — the first layer, before any guard",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "unprovisioned isolation:worktree agent wrote 78 lines straight into main, no guard fired",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 3769,
+			"title": "A patch-identical force-push rebase RE-BINDS an existing approval to the new head",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "force-push kept stale approval live; dismiss_stale didn't fire (#3713)",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 3779,
+			"title": "Nothing catches a cross-PR ADR number collision — two concurrent lanes both minted ADR 0198",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "two concurrent lanes both minted ADR 0198, both PRs green (recurrence: 0114, 0123)",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 3785,
+			"title": "leak-guard scan-pr flags counter-example paths quoted in review prose",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "leak-guard blocked PR #3733's own review prose (fence clause incoherent)",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 3837,
+			"title": "Agent worktree reverts tracked-file edits on every Bash-call boundary — silent-divergence trap for coder spawns",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "tracked edits reverted at Bash boundary while Read overlay served stale content (2 lanes)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 3887,
+			"title": "Worktree provisioning degrading under ~200-orphan pileup — coder spawns no-op'ing repeatedly (acute; remediation banked as PR #3881)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "4 consecutive coder spawns silently unprovisioned under ~200-orphan pileup",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 3925,
+			"title": "Nothing mechanically forces a design-capture upload failure into a review-design verdict",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "review-design PASSed on 100% upload failure for months (#3738)",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 3929,
+			"title": "No repair path for 'PR already PASSED/approved, defect found later' — moves only by hand-dispatch",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "two PASSed/approved PRs carried fail-open guard defects; only hand-dispatch moved them",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 3943,
+			"title": "Worktree reaper removes worktrees belonging to LIVE agents mid-run (2 instances)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "reaper deleted LIVE shippers' worktrees mid-run, twice (PRs #3913/#3923)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 3945,
+			"title": "Classifier blocks the stdin body form the no-shared-file rule mandates",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "classifier refusal forced contract-forbidden `-F body=@file` posting form",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": true,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 3954,
+			"title": "worktree-guard bash pin refuses compound commands, so ship-it's SKILL body isn't runnable verbatim",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "isolation verifier refused ship-it's own SKILL bash; two runs improvised divergent workarounds",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 3993,
+			"title": "PR #3986 merged with two \"discharge before control-plane approval\" findings undischarged",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "PR #3986 merged with two discharge-before-approval findings undischarged",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4000,
+			"title": "Record the ADR amending 0115 §5: proven-death claim supersession shipped in skill text with no authorizing ADR",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "PR #3986 shipped invariant-narrowing; reviewer-required ADR never filed",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 4017,
+			"title": "review-head worktree paths carry no session segment, so the #2785 review-head-idle reclaim can never match and every review-head-* tree is kept forever",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "review-head-idle reclaim unreachable — every review-head tree kept forever (source-proven)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4060,
+			"title": "`class-probe classify` reads 0 files under parallel invocation, silently defaulting to has-code",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "class-probe read 0 files, silently classified has-code exit 0",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4103,
+			"title": "Board bank signal can't tell a reviewed-ready PR from a FAIL'd one",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "FAIL'd PR #3955 presented on board identically to banked-ready #4076",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4105,
+			"title": "A §CP advisory hides its polarity from `verdict read --expect FAIL`, so a repair agent sees `none` while `[FAIL]` rows sit in the body",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "repair agent read \"none\" while FAIL rows sat in advisory",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4106,
+			"title": "`pnpm typecheck` reported a green from another worktree's turbo cache — establish whether a cross-worktree cache hit can return a false green",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "turbo returned another worktree's cached typecheck green (3x one session; shared cache verified)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4110,
+			"title": "Ratify (or reject) the unrunnable-guard rule that ran all session without a founder ruling: stop, never reimplement a guard from source and hand-discharge it",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "shipper hand-discharged cp-cardinality/leak-guard from source during outage",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4111,
+			"title": "Agent self-reports of \"restored to match main\" were false twice, silently destroying the coverage they claimed to preserve — caught only by counterfactual injection",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "agent falsely claimed \"restored to match main,\" destroyed test coverage (PR #4050 confirmed)",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4131,
+			"title": "investigate: pre-push `unit-changed` ran the full apps/web unit project for a packages-only diff",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "`--changed` ran 286 apps/web specs for a packages-only diff",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4133,
+			"title": "Dispatch briefs should tell the agent to ground the contract, not trust the dispatcher",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "wrong-premise briefs thrice; only source-grounding survived (#4124/#4045/#4073)",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 4136,
+			"title": "A slow pre-push hook kills the push it guards: git opens the SSH connection before the hook runs, GitHub closes it mid-hook",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "9-min pre-push hook outlived SSH connection; push died SIGPIPE twice",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4145,
+			"title": "write-code releasing the delegated claim at terminus leaves a mid-repair lane unclaimed, so the next repair dispatch refuses at the claim guard",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "terminus release leaves mid-repair lane unclaimed; repair guard refuses (deterministic on delegated path)",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": true,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 4153,
+			"title": "write-code misclassified a §CP PR as non-§CP by arguing from an ADR",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "write-code wrote false §CP-negative into PR #4152 body",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4162,
+			"title": "A guarded agent whose worktree vanishes keeps running in the primary checkout — the Bash cd-pin never checks that $WORKTREE_ROOT still exists",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "agent whose worktree vanished kept running in primary checkout, zero signal",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4163,
+			"title": "A stale working tree fails toward \"does not exist\" — recurrence of #308 across 4 seats",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "review gate declared merged ADR nonexistent; 4 seats, one session",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": true,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 4180,
+			"title": "Worktree owner stamps are never written on the live harness path — 0 of 256 trees stamped",
+			"sweepVerdict": "KILL-CANDIDATE",
+			"sweepReason": "error-attribution polish sliver; the incident evidence is folded into #3943/#4162",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "pending",
+			"pendingReason": "#4642 ruling, EXCLUDED / HELD: “**#4180** — **table correction**: chunk E returned 31 verdicts by count (18 KEEP / 13 KILL) but its #4180 row was dropped in transit, and the merged table above wrongly reconstructed it as KILL; arithmetic implies it was the 18th KEEP. Held for one direct read at execution time; the merged table's #4180 row is hereby retracted.” The retracted row is reproduced above as sweepVerdict/sweepReason so the retraction is auditable; it is not a membership verdict. The owed read is #4180's to discharge.",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4185,
+			"title": "pipeline-cli self-heal's pnpm install failure kills read-only verbs that need no linked deps",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "self-heal `pnpm install` killed a live merge-queue-classify reconcile poll",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4199,
+			"title": "write-code SKILL.md teaches the pre-ADR-0135 §CP hand-merge model",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "stale hand-merge prose confirmed leaking into §CP PR bodies",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4211,
+			"title": "WorktreeCreate hook never fires — #3621 + ADR 0178 inert since merge",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "WorktreeCreate hook never invoked despite live registration (experiment-proven; two merged fixes inert)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4221,
+			"title": "No gate catches a green-on-branch / red-in-batch semantic merge conflict before enqueue",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "PR #4202 green-on-head, red-in-batch (import-sort semantic merge conflict)",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4227,
+			"title": "triage asserted §CP scope for a path the contract deliberately excludes (#4108), and the false routing note propagated",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "triage asserted false §CP scope; falsehood propagated into build",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4238,
+			"title": "A newly-merged CI guard has a blind window: an open PR with an older base can land a violation fully green",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "cli-invocation-guard violation landed fully green; `main` red 15 minutes",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4285,
+			"title": "tracker apply-triage does not validate --p: a bare `1` is applied as a literal label, reported as success",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "bare `1` applied as literal label on #4282, reported success",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": true,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 4296,
+			"title": "Merge ordering between #4293 and #4286 is real but unenforced — held only by memory",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "PR #4293 cited unlanded ADR 0219; every gate green on dead citation",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4336,
+			"title": "[BLOCKED until #4327 merges] Implement ADR 0220 — declare the §CP surface at stand-up; a missing declaration fails the stand-up preflight",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "live adopter repo merges nothing: §CP sentinel `'.'` matches everything",
+			"sweepSection": "M35 Pipeline Anywhere",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Pipeline Anywhere campaign"
+			}
+		},
+		{
+			"issue": 4338,
+			"title": "Agents execute skills from the working tree, so a stale checkout silently applies withdrawn doctrine",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "stale checkout applied withdrawn ADR 86 min post-merge (#4330)",
+			"sweepSection": "M29 deterministic-crew-mechanics",
+			"borderline": true,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "closed",
+				"milestone": "deterministic-crew-mechanics"
+			}
+		},
+		{
+			"issue": 4386,
+			"title": "§CP-by-content (ADR 0164) has no platform enforcement — only §CP-by-path is hard-gated",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "guard-touching ADR merged to main with zero approvals",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4500,
+			"title": "write-code: wt_preflight refuses for every lane of a multi-subagent session — the lane stamp is session-keyed, not worktree-keyed",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "8 worktrees same lane stamp; wt_preflight refused every lane of multi-subagent session",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "closed",
+				"milestone": "fabrika campaign"
+			}
+		},
+		{
+			"issue": 4516,
+			"title": "Per-run scratch namespace's session key is shared across lanes and roles",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "shared session-id key collapsed §SP run isolation across lanes/roles (observed 3-role collision)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4520,
+			"title": "verdict gate: a repeated --require flag keeps only ONE namespace, reports enqueueable past a live FAIL",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "repeated `--require` dropped a namespace; gate said enqueueable past live FAIL (reproduced)",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "closed",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4521,
+			"title": "Guard landing blinds every in-flight lane whose base predates it — needs a rebase-sweep trigger",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "guard landed mid-flight; stale-base PR ejected, §CP approval destroyed (3x one night)",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4540,
+			"title": "Abandoned pipeline worktrees hold branch refs and block the verified-push path — repair lanes forced onto force-push-with-lease",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "dead worktrees pinned PR branches; 3 repair lanes forced off verified-push in one drain",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4544,
+			"title": "Gate skills still write fixed-name scratchpad intermediates, bypassing the shipped allocator",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "concurrent gates clobbered fixed-name scratch files; file grew mid-run (2 hits, 2026-07-30)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4555,
+			"title": "Repair mode has no modeled entry for non-FAIL drivers — all of §CP by construction",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "§CP PR #4543 needed repair; no modeled entry existed",
+			"sweepSection": "M38 CP Verdict Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "CP Verdict Integrity campaign"
+			}
+		},
+		{
+			"issue": 4557,
+			"title": "ship-it reconcile terminal-classification defects survive #4550, stranded on closed #4547",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "batched-wave reconcile: false UNRESOLVED; healthy KEPT path exits 1 (D1/D3/D4 verified)",
+			"sweepSection": "M36 Merge-Gate Reliability",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Merge-Gate Reliability campaign"
+			}
+		},
+		{
+			"issue": 4591,
+			"title": "iso_preflight aborts under a `set -u` caller before its guard can answer (undefaulted $CLAUDE_CODE_AGENT / $WORKTREE_ROOT)",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "set -u caller aborts iso_preflight on unset vars (triage-reproduced, both paths)",
+			"sweepSection": "M37 Worktree-Isolation Integrity",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Worktree-Isolation Integrity campaign"
+			}
+		},
+		{
+			"issue": 4605,
+			"title": "The isolation verifier refuses ALL unresolvable expansions, not just the CLAUDE_PLUGIN_ROOT idiom — ~41 gh api $REPO fences are outside every ADR 0232 lane",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "isolation verifier refuses all `$REPO` fences — 18-trial matrix (#4595)",
+			"sweepSection": "M43 Skill Harness Audit",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "closed",
+				"milestone": "Skill Harness Audit"
+			}
+		},
+		{
+			"issue": 4618,
+			"title": "Reconcile verify-extraction check 9 to ADR 0234's declared sentinel",
+			"sweepVerdict": "KEEP-AS-EVAL",
+			"sweepReason": "check 9 permanently reds a compliant declared-sentinel script (containment-marker.sh)",
+			"sweepSection": "M43 Skill Harness Audit",
+			"borderline": false,
+			"status": "member",
+			"snapshot": {
+				"at": "2026-08-03",
+				"state": "open",
+				"milestone": "Skill Harness Audit"
+			}
+		}
+	]
+}

--- a/packages/fabrika-cli/src/eval/ruled-keeps.data.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/ruled-keeps.data.unit.test.ts
@@ -1,0 +1,127 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import {decodeIncidentProvenance} from "./incident-provenance.ts";
+import {
+	decodeRuledKeeps,
+	KEEP_VERDICT,
+	ruledKeepsViolations,
+	summarize,
+	withCoverage,
+} from "./ruled-keeps.ts";
+
+const read = (leaf: string) =>
+	readFileSync(fileURLToPath(new URL(`./incident-corpus/${leaf}`, import.meta.url)), "utf8");
+
+const keeps = () => {
+	const result = decodeRuledKeeps(read("ruled-keeps.json"));
+	assert.isTrue(Result.isSuccess(result), "incident-corpus/ruled-keeps.json must decode to Ok");
+	if (!Result.isSuccess(result)) throw new Error("unreachable");
+	return result.success;
+};
+
+const provenance = () => {
+	const result = decodeIncidentProvenance(read("provenance.json"));
+	assert.isTrue(Result.isSuccess(result), "incident-corpus/provenance.json must decode to Ok");
+	if (!Result.isSuccess(result)) throw new Error("unreachable");
+	return result.success;
+};
+
+// The 7 the #4642 scope delta named borderline, and the 14 it re-bucketed to kill-scope.
+const BORDERLINE = [4338, 3330, 4285, 4163, 4145, 3945, 3709];
+const REBUCKETED = [
+	4617, 4480, 4409, 4360, 4290, 4222, 4141, 4118, 4077, 4075, 4055, 3990, 3938, 3766,
+];
+
+describe("ruled KEEP corpus — the enumeration is the artifact, not a join to re-run", () => {
+	it("decodes and holds its own integrity rules", () => {
+		assert.deepStrictEqual(ruledKeepsViolations(keeps()), []);
+	});
+
+	it("enumerates the 66 ruled members, not the published 74", () => {
+		const summary = summarize(withCoverage(keeps(), provenance()));
+		assert.strictEqual(summary.members, 66);
+		assert.strictEqual(summary.pending, 1);
+	});
+
+	it("every member carries the KEEP-AS-EVAL verdict the recipe requires", () => {
+		for (const row of keeps().rows) {
+			if (row.status !== "member") continue;
+			assert.strictEqual(row.sweepVerdict, KEEP_VERDICT, `#${row.issue}`);
+		}
+	});
+
+	it("all 7 borderline are inside the member set — the double-count #4642 published", () => {
+		const members = new Set(
+			keeps()
+				.rows.filter((r) => r.status === "member")
+				.map((r) => r.issue),
+		);
+		for (const issue of BORDERLINE) assert.isTrue(members.has(issue), `#${issue} must be a member`);
+		const flagged = keeps()
+			.rows.filter((r) => r.borderline)
+			.map((r) => r.issue)
+			.sort((a, b) => a - b);
+		assert.deepStrictEqual(
+			flagged,
+			[...BORDERLINE].sort((a, b) => a - b),
+		);
+	});
+
+	it("none of the 14 crew-layer re-buckets survived into the corpus", () => {
+		const enumerated = new Set(keeps().rows.map((r) => r.issue));
+		for (const issue of REBUCKETED) assert.isFalse(enumerated.has(issue), `#${issue}`);
+	});
+});
+
+describe("ruled KEEP corpus — #4180 is pending, neither included nor dropped", () => {
+	it("carries #4180 as a pending row quoting the #4642 retraction", () => {
+		const row = keeps().rows.find((r) => r.issue === 4180);
+		assert.isDefined(row, "#4180 must appear in the enumeration");
+		assert.strictEqual(row?.status, "pending");
+		assert.include(row?.status === "pending" ? row.pendingReason : "", "hereby retracted");
+	});
+
+	it("#4180 is the only pending row", () => {
+		const pending = keeps().rows.filter((r) => r.status === "pending");
+		assert.deepStrictEqual(
+			pending.map((r) => r.issue),
+			[4180],
+		);
+	});
+});
+
+describe("ruled KEEP corpus — coverage is derived from the ledger, never stored", () => {
+	it("reports exactly the members the provenance ledger already cites", () => {
+		const covered = withCoverage(keeps(), provenance())
+			.filter((c) => c.pinnedBy.length > 0)
+			.map((c) => c.row.issue)
+			.sort((a, b) => a - b);
+		const cited = new Set(provenance().cases.flatMap((c) => c.incidents));
+		const expected = keeps()
+			.rows.map((r) => r.issue)
+			.filter((issue) => cited.has(`#${issue}`))
+			.sort((a, b) => a - b);
+		assert.deepStrictEqual(covered, expected);
+		assert.isAbove(covered.length, 0, "the join must find the cases the ledger really cites");
+	});
+});
+
+describe("ruled KEEP corpus — the corpus README points at the enumeration", () => {
+	const readme = () => read("README.md");
+
+	it("no longer instructs a case author to run the two-artifact join by hand", () => {
+		assert.notInclude(readme(), "verify membership **two ways**");
+		assert.notInclude(readme(), "no enumeration of the 74 exists to read");
+	});
+
+	it("no longer publishes 74 as the corpus size", () => {
+		assert.notInclude(readme(), "74 KEEP");
+	});
+
+	it("names the committed enumeration and the corrected figure", () => {
+		assert.include(readme(), "ruled-keeps.json");
+		assert.include(readme(), "66");
+	});
+});

--- a/packages/fabrika-cli/src/eval/ruled-keeps.ts
+++ b/packages/fabrika-cli/src/eval/ruled-keeps.ts
@@ -1,0 +1,232 @@
+/**
+ * `eval` ruled-KEEP-corpus core — the committed enumeration of the fabrika eval feedstock
+ * (issue #4823, epic #4649).
+ *
+ * The corpus's membership was ruled in #4642 but never written down, so every consumer re-ran a
+ * two-artifact join by hand and the size that was published (74) matched no derivation. This module
+ * decodes the enumeration that replaces that join, and re-checks the claims a well-shaped file can
+ * still make falsely.
+ *
+ * Three shapes carry the weight:
+ *
+ * 1. **A row is a discriminated union on `status`**, so a `pending` row without a written reason is
+ *    unrepresentable. #4180 is the one pending row — the ruling retracted its sweep verdict and
+ *    never replaced it — and the union is what stops a future editor from resolving it by deleting
+ *    a field.
+ * 2. **Coverage is derived, never stored.** Whether a case in `provenance.json` already pins an
+ *    issue is computed by joining the two files at read time (`withCoverage`). A committed copy of
+ *    that flag would be a second source of truth that drifts silently from the ledger — which is
+ *    the defect class this whole enumeration exists to remove (#4482).
+ * 3. **The derivation travels with the data.** `derivation` records the recipe, the source
+ *    artifacts and the arithmetic, so the list is auditable rather than asserted.
+ *
+ * `decodeRuledKeeps` is total in the same way `decodeIncidentProvenance` is — a typed `Result`
+ * failure on malformed JSON or a schema mismatch, never a throw.
+ */
+import {Result} from "effect";
+import * as Schema from "effect/Schema";
+import type {IncidentProvenance} from "./incident-provenance.ts";
+
+/**
+ * A point-in-time read of an issue's board state. Named `snapshot` and dated because it is the one
+ * part of a row that rots: milestone and state move under the file, and a reader who mistakes a
+ * stale field for a live one is back to trusting a plausible value.
+ */
+const Snapshot = Schema.Struct({
+	at: Schema.String,
+	state: Schema.Literals(["open", "closed"]),
+	milestone: Schema.NullOr(Schema.String),
+});
+
+const RowFields = {
+	issue: Schema.Int,
+	title: Schema.String,
+	sweepVerdict: Schema.String,
+	sweepReason: Schema.String,
+	sweepSection: Schema.String,
+	borderline: Schema.Boolean,
+	snapshot: Snapshot,
+};
+
+/** An issue the recipe admits to the corpus. */
+const MemberRow = Schema.Struct({status: Schema.Literal("member"), ...RowFields});
+
+/** An issue whose membership the ruling left open. `pendingReason` is required: it quotes what is owed. */
+const PendingRow = Schema.Struct({
+	status: Schema.Literal("pending"),
+	pendingReason: Schema.String,
+	...RowFields,
+});
+
+const KeepRow = Schema.Union([MemberRow, PendingRow]);
+
+/** How the enumeration was produced — the recipe, the artifacts it read, and the arithmetic. */
+const Derivation = Schema.Struct({
+	recipe: Schema.String,
+	sources: Schema.Array(Schema.String),
+	arithmetic: Schema.Array(Schema.String),
+});
+
+/** The wire shape of `incident-corpus/ruled-keeps.json`. */
+export const RuledKeepsFile = Schema.Struct({
+	corpus: Schema.String,
+	derivedAt: Schema.String,
+	derivation: Derivation,
+	rows: Schema.Array(KeepRow),
+});
+
+export type KeepRow = typeof KeepRow.Type;
+export type RuledKeeps = typeof RuledKeepsFile.Type;
+
+/** The verdict text a member row must carry on the #4634 sweep table. */
+export const KEEP_VERDICT = "KEEP-AS-EVAL";
+
+/** A typed enumeration decode failure — malformed JSON, or a shape that doesn't match the schema. */
+export class RuledKeepsDecodeError extends Schema.TaggedErrorClass<RuledKeepsDecodeError>()(
+	"RuledKeepsDecodeError",
+	{
+		reason: Schema.Literals(["malformed-json", "schema-mismatch"]),
+		message: Schema.String,
+	},
+) {}
+
+const decodeUnknownRuledKeeps = Schema.decodeUnknownResult(RuledKeepsFile);
+
+const parseJson = (text: string): Result.Result<unknown, RuledKeepsDecodeError> =>
+	Result.try({
+		try: (): unknown => JSON.parse(text),
+		catch: (cause) =>
+			new RuledKeepsDecodeError({
+				reason: "malformed-json",
+				message: cause instanceof Error ? cause.message : String(cause),
+			}),
+	});
+
+/** Decode the enumeration from the text of `incident-corpus/ruled-keeps.json`. Total. */
+export const decodeRuledKeeps = (text: string): Result.Result<RuledKeeps, RuledKeepsDecodeError> =>
+	parseJson(text).pipe(
+		Result.flatMap((parsed) =>
+			decodeUnknownRuledKeeps(parsed).pipe(
+				Result.mapError(
+					(error) => new RuledKeepsDecodeError({reason: "schema-mismatch", message: error.message}),
+				),
+			),
+		),
+	);
+
+/**
+ * The enumeration's own integrity rules, as reasons rather than a boolean. An empty array means the
+ * list holds; each string names one rule a specific row broke.
+ *
+ * These are not the schema's job: the schema makes a malformed *shape* unrepresentable, while these
+ * are the claims a well-shaped file can still make falsely — a member row that never carried the
+ * KEEP-AS-EVAL verdict the recipe requires, a pending row whose reason is blank, an enumeration that
+ * records no derivation, or an empty list reporting green over nothing (ADR 0092).
+ */
+export const ruledKeepsViolations = (keeps: RuledKeeps): ReadonlyArray<string> => {
+	const violations: string[] = [];
+	if (keeps.rows.length === 0) violations.push("enumeration is empty — zero scope reds (ADR 0092)");
+	if (keeps.derivation.recipe.trim() === "") violations.push("derivation records no recipe");
+	if (keeps.derivation.sources.length === 0) violations.push("derivation cites no source artifact");
+	if (keeps.derivation.arithmetic.length === 0) {
+		violations.push("derivation shows no arithmetic");
+	}
+	const seen = new Set<number>();
+	for (const row of keeps.rows) {
+		if (seen.has(row.issue)) violations.push(`#${row.issue}: duplicate row`);
+		seen.add(row.issue);
+		if (row.status === "member" && row.sweepVerdict !== KEEP_VERDICT) {
+			violations.push(
+				`#${row.issue}: member row carries sweep verdict '${row.sweepVerdict}', not ${KEEP_VERDICT}`,
+			);
+		}
+		if (row.status === "pending" && row.pendingReason.trim() === "") {
+			violations.push(`#${row.issue}: pending row records no reason`);
+		}
+		if (row.sweepReason.trim() === "") violations.push(`#${row.issue}: no sweep reason recorded`);
+	}
+	return violations;
+};
+
+/** A row joined with the corpus coverage the provenance ledger reports for it. */
+export interface CoveredRow {
+	readonly row: KeepRow;
+	readonly pinnedBy: ReadonlyArray<number>;
+}
+
+/**
+ * Join the enumeration against the provenance ledger: for each row, the ids of the committed eval
+ * cases that cite it. Derived at read time so the flag cannot drift from the ledger.
+ */
+export const withCoverage = (
+	keeps: RuledKeeps,
+	provenance: IncidentProvenance,
+): ReadonlyArray<CoveredRow> =>
+	keeps.rows.map((row) => ({
+		row,
+		pinnedBy: provenance.cases
+			.filter((entry) => entry.incidents.includes(`#${row.issue}`))
+			.map((entry) => entry.id),
+	}));
+
+/** The counts the `keeps` verb prints: members, pending rows, borderline, and how many are covered. */
+export interface KeepsSummary {
+	readonly members: number;
+	readonly pending: number;
+	readonly borderline: number;
+	readonly covered: number;
+	readonly uncovered: number;
+}
+
+export const summarize = (covered: ReadonlyArray<CoveredRow>): KeepsSummary => {
+	const members = covered.filter((c) => c.row.status === "member");
+	return {
+		members: members.length,
+		pending: covered.length - members.length,
+		borderline: covered.filter((c) => c.row.borderline).length,
+		covered: members.filter((c) => c.pinnedBy.length > 0).length,
+		uncovered: members.filter((c) => c.pinnedBy.length === 0).length,
+	};
+};
+
+const renderRow = ({row, pinnedBy}: CoveredRow): string => {
+	const flags = [
+		row.status === "pending" ? "PENDING" : null,
+		row.borderline ? "borderline" : null,
+		pinnedBy.length > 0 ? `pinned by case ${pinnedBy.join(", ")}` : "no case",
+	].filter((f): f is string => f !== null);
+	const head = `  #${row.issue} [${flags.join(" · ")}] ${row.sweepVerdict} — ${row.sweepReason}`;
+	// A pending row that printed like a member would re-create the silence this list removes.
+	return row.status === "pending" ? `${head}\n      pending: ${row.pendingReason}` : head;
+};
+
+/** The human table — the enumeration as something you read rather than a join you run. */
+export const renderKeeps = (keeps: RuledKeeps, covered: ReadonlyArray<CoveredRow>): string => {
+	const s = summarize(covered);
+	const lines = [
+		`${keeps.corpus} — ${s.members} member(s) plus ${s.pending} pending, derived ${keeps.derivedAt}.`,
+		`  ${s.borderline} borderline · ${s.covered} pinned by a committed case · ${s.uncovered} uncovered.`,
+		"",
+		...covered.map(renderRow),
+		"",
+		"Derivation:",
+		`  ${keeps.derivation.recipe}`,
+		...keeps.derivation.sources.map((source) => `  source: ${source}`),
+		...keeps.derivation.arithmetic.map((line) => `  ${line}`),
+	];
+	return lines.join("\n");
+};
+
+/** The stable machine-readable form — the same rows, plus the derived coverage. */
+export const keepsToJson = (keeps: RuledKeeps, covered: ReadonlyArray<CoveredRow>): string =>
+	JSON.stringify(
+		{
+			corpus: keeps.corpus,
+			derivedAt: keeps.derivedAt,
+			derivation: keeps.derivation,
+			summary: summarize(covered),
+			rows: covered.map(({row, pinnedBy}) => ({...row, pinnedBy})),
+		},
+		null,
+		2,
+	);

--- a/packages/fabrika-cli/src/eval/ruled-keeps.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/ruled-keeps.unit.test.ts
@@ -1,0 +1,178 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import type {IncidentProvenance} from "./incident-provenance.ts";
+import {
+	decodeRuledKeeps,
+	type RuledKeeps,
+	renderKeeps,
+	ruledKeepsViolations,
+	summarize,
+	withCoverage,
+} from "./ruled-keeps.ts";
+
+const snapshot = {at: "2026-08-03", state: "open" as const, milestone: "M37"};
+
+const member = (issue: number, over: Record<string, unknown> = {}) => ({
+	issue,
+	title: `issue ${issue}`,
+	sweepVerdict: "KEEP-AS-EVAL",
+	sweepReason: "an observed incident",
+	sweepSection: "M37 Worktree-Isolation Integrity",
+	borderline: false,
+	status: "member",
+	snapshot,
+	...over,
+});
+
+const file = (rows: ReadonlyArray<unknown>) => ({
+	corpus: "test corpus",
+	derivedAt: "2026-08-03",
+	derivation: {recipe: "a recipe", sources: ["#4634"], arithmetic: ["1 + 1 = 2"]},
+	rows,
+});
+
+const decode = (value: unknown): RuledKeeps => {
+	const result = decodeRuledKeeps(JSON.stringify(value));
+	assert.isTrue(Result.isSuccess(result), "fixture must decode");
+	if (!Result.isSuccess(result)) throw new Error("unreachable");
+	return result.success;
+};
+
+describe("decodeRuledKeeps", () => {
+	it("is total on malformed JSON", () => {
+		const result = decodeRuledKeeps("{not json");
+		assert.isTrue(Result.isFailure(result));
+		if (Result.isFailure(result)) assert.strictEqual(result.failure.reason, "malformed-json");
+	});
+
+	it("refuses a pending row with no reason — the union makes it unrepresentable", () => {
+		const result = decodeRuledKeeps(JSON.stringify(file([{...member(4180), status: "pending"}])));
+		assert.isTrue(Result.isFailure(result));
+		if (Result.isFailure(result)) assert.strictEqual(result.failure.reason, "schema-mismatch");
+	});
+
+	it("refuses a snapshot state outside open/closed", () => {
+		const result = decodeRuledKeeps(
+			JSON.stringify(file([member(1, {snapshot: {...snapshot, state: "merged"}})])),
+		);
+		assert.isTrue(Result.isFailure(result));
+	});
+});
+
+describe("ruledKeepsViolations", () => {
+	it("holds on a well-formed enumeration", () => {
+		assert.deepStrictEqual(ruledKeepsViolations(decode(file([member(1)]))), []);
+	});
+
+	it("names a member row that never carried the KEEP-AS-EVAL verdict", () => {
+		const violations = ruledKeepsViolations(
+			decode(file([member(7, {sweepVerdict: "KILL-CANDIDATE"})])),
+		);
+		assert.deepStrictEqual(violations, [
+			"#7: member row carries sweep verdict 'KILL-CANDIDATE', not KEEP-AS-EVAL",
+		]);
+	});
+
+	it("names a duplicated issue", () => {
+		const violations = ruledKeepsViolations(decode(file([member(1), member(1)])));
+		assert.include(violations, "#1: duplicate row");
+	});
+
+	it("names a pending row whose reason is blank", () => {
+		const violations = ruledKeepsViolations(
+			decode(file([{...member(4180), status: "pending", pendingReason: "   "}])),
+		);
+		assert.include(violations, "#4180: pending row records no reason");
+	});
+
+	it("reds on an empty enumeration rather than reporting green over nothing", () => {
+		assert.include(
+			ruledKeepsViolations(decode(file([]))),
+			"enumeration is empty — zero scope reds (ADR 0092)",
+		);
+	});
+
+	it("reds when the derivation cites nothing, so the list cannot be asserted unaudited", () => {
+		const bare = {...file([member(1)]), derivation: {recipe: "", sources: [], arithmetic: []}};
+		const violations = ruledKeepsViolations(decode(bare));
+		assert.deepStrictEqual(violations, [
+			"derivation records no recipe",
+			"derivation cites no source artifact",
+			"derivation shows no arithmetic",
+		]);
+	});
+});
+
+const ledger = (
+	cases: ReadonlyArray<{id: number; incidents: ReadonlyArray<string>}>,
+): IncidentProvenance => ({
+	corpus: "test",
+	cases: cases.map((c) => ({
+		tier: "deterministic",
+		id: c.id,
+		title: `case ${c.id}`,
+		incidents: c.incidents,
+		verification: ["verified"],
+		corrections: [],
+	})),
+	declined: [],
+});
+
+describe("withCoverage", () => {
+	it("joins each row to the cases that cite it", () => {
+		const covered = withCoverage(
+			decode(file([member(10), member(20)])),
+			ledger([
+				{id: 1, incidents: ["#10", "#99"]},
+				{id: 2, incidents: ["#10"]},
+			]),
+		);
+		assert.deepStrictEqual(
+			covered.map((c) => [c.row.issue, c.pinnedBy]),
+			[
+				[10, [1, 2]],
+				[20, []],
+			],
+		);
+	});
+
+	it("does not match a prefix — #10 is not pinned by a case citing #100", () => {
+		const covered = withCoverage(
+			decode(file([member(10)])),
+			ledger([{id: 1, incidents: ["#100"]}]),
+		);
+		assert.deepStrictEqual(covered[0]?.pinnedBy, []);
+	});
+});
+
+describe("summarize", () => {
+	it("counts members, pending, borderline and coverage separately", () => {
+		const keeps = decode(
+			file([
+				member(1),
+				member(2, {borderline: true}),
+				{...member(3), status: "pending", pendingReason: "retracted"},
+			]),
+		);
+		assert.deepStrictEqual(summarize(withCoverage(keeps, ledger([{id: 1, incidents: ["#1"]}]))), {
+			members: 2,
+			pending: 1,
+			borderline: 1,
+			covered: 1,
+			uncovered: 1,
+		});
+	});
+});
+
+describe("renderKeeps", () => {
+	it("marks a pending row and names the case that pins a covered one", () => {
+		const keeps = decode(
+			file([member(1), {...member(4180), status: "pending", pendingReason: "retracted"}]),
+		);
+		const text = renderKeeps(keeps, withCoverage(keeps, ledger([{id: 9, incidents: ["#1"]}])));
+		assert.include(text, "#1 [pinned by case 9]");
+		assert.include(text, "#4180 [PENDING · no case]");
+		assert.include(text, "pending: retracted");
+		assert.include(text, "1 member(s) plus 1 pending");
+	});
+});


### PR DESCRIPTION
The list of incidents that make up fabrika's eval feedstock was ruled in #4642 but never written down, so anyone who needed it re-ran a two-artifact join by hand — and the size that got published, 74, matched no derivation anyone could reproduce. This PR commits the list next to the corpus it feeds, along with the derivation that produced it, and adds `fabrika eval keeps` to read it.

The corrected figure is **66 members plus one pending row**. #4180 is that pending row: the #4642 ruling retracted its sweep verdict and never replaced it, so it is carried explicitly rather than silently included or dropped.

Part of #4823.

## What changed

- **`packages/fabrika-cli/src/eval/incident-corpus/ruled-keeps.json`** — the enumeration. Each row carries the issue number and title, its `#NNNN | VERDICT | reason` row from the #4634 sweep table, which sweep section it came from, whether it is one of the 7 borderline items, and a **dated snapshot** of its board state. A `derivation` block records the recipe, the three source comments, and the arithmetic.
- **`packages/fabrika-cli/src/eval/ruled-keeps.ts`** — the decoder + integrity rules + the coverage join.
- **`packages/fabrika-cli/src/eval/command.ts`** — `fabrika eval keeps <path> [--provenance <path>] [--json]`.
- **`packages/fabrika-cli/src/eval/incident-corpus/README.md`** — points a case author at the enumeration instead of the hand-run join, and publishes 66 instead of 74.
- Two test files: `ruled-keeps.unit.test.ts` (the pure core) and `ruled-keeps.data.unit.test.ts` (the committed data + the README).

## Two design calls worth flagging

**Coverage is derived, never stored.** The ticket asks each row to carry "whether a case in `provenance.json` already pins it". That is computed at read time by `withCoverage`, joining the two files — there is no committed `pinned` field. A stored copy would be a second source of truth that drifts silently from the ledger, which is exactly the defect class (#4482) the enumeration exists to remove. The emitted enumeration carries the column; the file does not store it.

**Board state is a dated snapshot, not a claim of currency.** Milestone and state move under a committed file. The field is named `snapshot`, carries its own `at` date, and the README does not ask anyone to trust it as live.

Both are disclosed as class-1 departures under [`## Deviations`](#deviations) below.

## How the 66 was derived

Both derivations were run mechanically over the two artifacts and land on the same 66 issues:

| Step | Figure |
|---|---|
| #4634 sweep rows | 222 (80 `KEEP-AS-EVAL`, 138 `KILL-CANDIDATE`, 4 `UNSURE`) |
| Derivation A — 80 KEEP rows minus the 14 that appear in the 153-issue kill list | **66** |
| Derivation B — 80 KEEP rows minus the 14 crew-layer re-buckets | **66** |
| A and B name the same issue set | yes |

74 double-counts: the 7 borderline (#4338 #3330 #4285 #4163 #4145 #3945 #3709) all carry `KEEP-AS-EVAL` rows and none is among the 14 re-buckets, so they were inside the KEEP set already and were added a second time. The 67 they were added to was itself computed from the sweep's stated 81 rather than the 80 rows that exist.

## Observed output

```
$ fabrika eval keeps src/eval/incident-corpus/ruled-keeps.json
fabrika eval feedstock — the ruled KEEP corpus of #4642 — 66 member(s) plus 1 pending, derived 2026-08-03.
  7 borderline · 7 pinned by a committed case · 59 uncovered.

  #2118 [no case] KEEP-AS-EVAL — non-hermetic deployed-worker smoke drift evicted 4 unrelated approved §CP PRs
  ...
  #3594 [pinned by case 12] KEEP-AS-EVAL — 2/2 coders addressed initial Write/Edit to primary-checkout absolute paths
  ...
  #4180 [PENDING · no case] KILL-CANDIDATE — error-attribution polish sliver; the incident evidence is folded into #3943/#4162
      pending: #4642 ruling, EXCLUDED / HELD: “**#4180** — **table correction**: chunk E returned 31 verdicts by count (18 KEEP / 13 KILL) but its #4180 row was dropped in transit, and the merged table above wrongly reconstructed it as KILL; arithmetic implies it was the 18th KEEP. Held for one direct read at execution time; the merged table's #4180 row is hereby retracted.” …
  ...
EXIT=0
```

`--json` emits the same rows with a `summary` block (`members: 66, pending: 1, borderline: 7, covered: 7, uncovered: 59`) and each row's `pinnedBy` case ids. A missing path exits 1 with a named reason.

## Acceptance criteria

- [x] The 66 are enumerated in a committed artifact adjacent to the corpus, each row carrying issue number, sweep verdict text, borderline flag, and provenance coverage (derived — see above).
- [x] The artifact's provenance records the derivation that produced it.
- [x] #4180 appears as an explicitly pending row with the #4642 retraction quoted as its reason.
- [x] The README no longer instructs the hand-run join and no longer publishes 74; it points at the enumeration and states 66 plus 1 pending.
- [x] **A correction comment on #4642** — **discharged.** Comment `5162555158` on #4642 (2026-08-03T05:13:36Z) is the amendment, opening "**Appended, not edited.**" and carrying the same 81/80/-14 = 66 arithmetic.
- [x] No open issue's milestone is changed by this PR.

### AC5 — deferred by this lane, then discharged off-lane

This lane could not post the #4642 comment itself. The mis-attribution guard refused the write, and a guard refusal is not overridable by reasoning:

```
$ step3_5-claim-is-mine.sh 4642
{"issue":4642,"mine":false,"reason":"no-winner","winner":null,"superseded":[]}
claim: #4642: no authorized claim resolves — NOT mine, back off (default-deny, never a false win).
GUARD-EXIT=1
```

This lane's dispatch pre-authorized #4823 only; #4642 was never named, so the refusal was correct and the dispatch was at fault. The arithmetic the comment owed was committed here in `ruled-keeps.json`'s `derivation.arithmetic` regardless.

**The comment has since been posted:** `5162555158` on #4642 at 2026-08-03T05:13:36Z, appended not edited, with the same arithmetic. The follow-up that tracked the deferral, #4836, was consequently closed `not_planned` — it was filed 78 minutes *after* the work it described had already landed. **Nothing about AC5 is outstanding, and #4836 is not an open follow-up.**

`Part of #4823` rather than `Fixes` still stands, for a different reason: triage separately filed **#4838** for three stale "74-issue KEEP corpus" strings in `provenance.json` that this diff does not touch and #4823's ACs never named. #4823 must stay open past this merge until #4838 lands.

<a id="deviations"></a>

## Deviations

- **Scope narrowing** — **Said:** #4823 is this PR's linked issue and its acceptance criteria are the contract; the default token is `Fixes #N`. **Did:** the body says `Part of #4823`, so merging this PR does not close the issue. **Why:** triage filed #4838 for three stale "74-issue KEEP corpus" strings in `provenance.json` — a surface this diff does not touch and #4823's ACs never named — so #4823 is not fully discharged by this merge and must stay open until #4838 lands. Claiming otherwise would auto-close an issue with real work left. **Disposition:** follow-up #4838 filed; no ADR needed.
- **Scope narrowing** — **Said:** #4823's AC1 asks each enumerated row to carry "whether a case in `provenance.json` already pins it". **Did:** no coverage field is committed to `ruled-keeps.json`; coverage is derived at read time by `withCoverage` joining the ledger, and emitted on each row as `pinnedBy`. **Why:** a stored flag would be a second source of truth that drifts silently from the ledger as cases are added — precisely the #4482 class this enumeration exists to remove. AC1's "whether a case already pins it" is satisfied at the artifact's read surface, which is where a consumer actually meets it. **Disposition:** no action needed — the `review-code` gate at `aa30e00c` judged this correct and the stronger design.
- **Scope narrowing** — **Said:** #4823's Scope prose asks each row to carry "its current milestone and state". **Did:** each row carries a `snapshot` object with its own `at` date (uniformly `2026-08-03`) instead of an implied-live currency claim. **Why:** a committed file physically cannot hold a "current" value — the moment it merges, any such field is a past reading, and an unlabelled one is exactly the plausible-value-that-never-errors defect this ticket exists to remove. Labelling the staleness is the only honest shape a static artifact can take, and AC1 never lists milestone/state at all, so the field sits above the AC floor rather than below it. **Disposition:** no action needed — the `review-code` gate at `aa30e00c` judged this an acceptable deviation, not a miss.
- **(repair round 1) Post-review change** — **Said:** the diff the `review-code` gate PASSed at `aa30e00c` is the reviewed tree. **Did:** rebased the branch onto current `main` and changed one line in `packages/fabrika-cli/src/eval/command.ts` — `eval keeps` now declares through `leafCommand` instead of a bare `Command.make`. **Why:** a semantic conflict, not a review defect. PR #4839 merged to `main` at 07:05:05Z (`89195133`) adding `packages/fabrika-cli/src/excess-operand.unit.test.ts`, a guard asserting every registered leaf verb declares the excess-operand catch-all; this PR's head CI ran at 06:32:04Z, before that guard existed, and `eval keeps` binds its trailing operand as `path` where the guard requires `excess`. Green alone, red combined with `main` — the merge queue ejected the PR twice on `AssertionError: expected 'path' to be 'excess'` while `mergeable_state` stayed `clean` (there was no textual conflict). The verb was made to conform to the landed guard; the guard was not weakened, skipped, or special-cased. **Disposition:** `excess-operand.unit.test.ts` green (17/17, including the `fabrika eval keeps` binds-its-trailing-operands row); `fabrika eval keeps <path>` output unchanged (66 plus 1 pending; `--json` summary `{"members":66,"pending":1,"borderline":7,"covered":7,"uncovered":59}`); `fabrika eval keeps <path> bogus` now refuses with exit 1, empty stdout, and the refusal on stderr; full `packages/fabrika-cli` suite green (41 files, 561 tests). The rebase moved the head, so the `aa30e00c` PASS is staleness-invalidated (ADR 0058) and a fresh current-head re-review is required before ship.

## Verification

- `pnpm vitest run` in `packages/fabrika-cli` — 39 files, 532 tests, all passing.
- `pnpm typecheck` — 30/30 tasks successful.
- `pnpm lint:worktree` — clean.
- `pipeline-cli cp-classify classify` — `not-control-plane [path-clear-no-content-source] … Proven ordinary.`

The README assertions were written before the README was changed and observed failing against it (3 failures: the two-ways instruction, the `74 KEEP` string, the missing `ruled-keeps.json` pointer). The member-verdict integrity rule was temporarily removed from `ruledKeepsViolations` to confirm its test reds rather than passing vacuously.

## Not touched

`packages/fabrika-cli/package.json` is unchanged — `@kampus/fabrika-cli@0.1.0` is published and PR #4833 already proposes `0.1.1`. No collision with the release train.

This PR does not touch PR #4832 (`/triage` skill) or anything under its surface; the two diffs are disjoint.

