### PR TITLE
fix(write-code): sanction a repair path past a worktree-pinned head branch (#4826)

### DIFF
--- a/claude-plugins/kampus-pipeline/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/lib/common-test.sh
@@ -492,6 +492,137 @@ else
 	ok "wt_preflight with no session id: non-zero, empty stdout (fail-closed)"
 fi
 
+# ---------------------------------------------------------------------------------------------
+# #4826 — the pinned head branch. Real worktrees, because the condition IS a second checkout of one
+# branch and no fixture can fake git's own refusal of it.
+# ---------------------------------------------------------------------------------------------
+
+mkdir -p "$tmp/pin"
+pin_sid="kp-test-lane-pin"
+if ! git -C "$tmp/pin" init -q --template='' >/dev/null 2>&1 ||
+	! git -C "$tmp/pin" -c user.name=kp-test -c user.email=kp-test@invalid commit -q --allow-empty -m c1 >/dev/null 2>&1 ||
+	! git -C "$tmp/pin" worktree add -q -b kp-lane "$tmp/pin-lane" >/dev/null 2>&1 ||
+	! git -C "$tmp/pin" worktree add -q -b kp-feat "$tmp/pin-left" >/dev/null 2>&1 ||
+	! git -C "$tmp/pin" -c user.name=kp-test -c user.email=kp-test@invalid commit -q --allow-empty -m c2 >/dev/null 2>&1; then
+	fail "fixture did not take: could not build the pinned-branch fixture — cases 26–31 were NOT exercised"
+else
+	pin_base="$(git -C "$tmp/pin" symbolic-ref --short HEAD)"
+	pin_lane="$(cd "$tmp/pin-lane" && pwd -P)"
+	pin_left="$(cd "$tmp/pin-left" && pwd -P)"
+	# Real uncommitted work in the leftover lane's tree. It must still be there at the end: eating a
+	# dirty tree is strictly worse than the bug this fix closes.
+	printf 'precious uncommitted work\n' > "$pin_left/UNCOMMITTED.txt"
+
+	# 26. The classifier separates the four states. A boolean "is it pinned" cannot, and the states
+	# have opposite handling — `other` co-checks-out, `primary` and `live-lane` refuse.
+	printf '%s\n' "$pin_sid" > "$tmp/pin/.git/worktrees/pin-left/kampus-lane"
+	out_live="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-feat)"
+	rm -f "$tmp/pin/.git/worktrees/pin-left/kampus-lane"
+	out_other="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-feat)"
+	out_mine="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-lane)"
+	out_free="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-no-such-branch)"
+	out_primary="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" "$pin_base")"
+	if [ "$out_live" != "PIN=live-lane
+PINROOT=$pin_left" ]; then
+		fail "kp_branch_pin: a pinning tree stamped with MY lane must read live-lane: [$out_live]"
+	elif [ "$out_other" != "PIN=other
+PINROOT=$pin_left" ]; then
+		fail "kp_branch_pin: an unstamped pinning tree must read other: [$out_other]"
+	elif [ "$out_mine" != "PIN=mine
+PINROOT=$pin_lane" ]; then
+		fail "kp_branch_pin: my own branch must read mine: [$out_mine]"
+	elif [ "$out_free" != "PIN=free
+PINROOT=" ]; then
+		fail "kp_branch_pin: an unheld branch must read free: [$out_free]"
+	elif [ "$out_primary" != "PIN=primary
+PINROOT=$(cd "$tmp/pin" && pwd -P)" ]; then
+		fail "kp_branch_pin: a branch held by the primary checkout must read primary: [$out_primary]"
+	else
+		ok "kp_branch_pin separates free / mine / primary / live-lane / other"
+	fi
+
+	# 27. THE FALSIFICATION. The bare `git switch` the step used to run REFUSES here — that refusal is
+	# the whole defect — while the sanctioned path puts this lane on the branch, still attached.
+	bare_err="$(git -C "$pin_lane" switch kp-feat 2>&1)"; bare_rc=$?
+	if [ "$bare_rc" -eq 0 ]; then
+		fail "fixture did not take: a bare \`git switch\` onto a branch another worktree holds SUCCEEDED — the pinned-branch condition was NOT reproduced"
+	elif ! grep -qF 'already checked out' <<<"$bare_err"; then
+		fail "the bare switch failed for some other reason than the pin: [$bare_err]"
+	else
+		err="$tmp/stderr"
+		CLAUDE_CODE_SESSION_ID="$pin_sid" kp_switch_head_branch "$pin_lane" kp-feat 2>"$err"; rc=$?
+		diag="$(cat "$err")"
+		head_ref="$(git -C "$pin_lane" symbolic-ref -q HEAD)"
+		if [ "$rc" -ne 0 ]; then
+			fail "the sanctioned path refused the routine leftover-tree case (rc=$rc): [$diag]"
+		elif [ "$head_ref" != "refs/heads/kp-feat" ]; then
+			fail "the sanctioned path left HEAD at [$head_ref] — a DETACHED head is what makes verified-push resolve UNKNOWN (#4826)"
+		elif ! grep -qF 'SANCTIONED' <<<"$diag"; then
+			fail "the sanctioned co-checkout narrated nothing naming itself sanctioned: [$diag]"
+		else
+			ok "pinned head branch: the bare switch refuses, the sanctioned co-checkout attaches this lane to the branch"
+		fi
+	fi
+
+	# 28. The freshen-the-base guarantee survives the sanctioned switch — the guarantee the detached
+	# improvisation dropped. The rebase must land, on a branch ref, not a detached head.
+	if ! git -C "$pin_lane" -c user.name=kp-test -c user.email=kp-test@invalid rebase "$pin_base" >/dev/null 2>&1; then
+		fail "rebase onto $pin_base failed after the sanctioned switch — the freshen-the-base step is not reachable"
+	elif [ "$(git -C "$pin_lane" symbolic-ref -q HEAD)" != "refs/heads/kp-feat" ]; then
+		fail "the rebase left HEAD detached — verified-push would resolve UNKNOWN and push nothing"
+	elif ! git -C "$pin_lane" merge-base --is-ancestor "$pin_base" HEAD; then
+		fail "kp-feat is not on top of $pin_base after the rebase — the base was never freshened"
+	else
+		ok "the rebase onto the latest base still happens on the sanctioned path, on an attached branch"
+	fi
+
+	# 29. THE SAFETY PIN. The leftover tree is still registered and its uncommitted work is still
+	# there: the sanctioned path removes no worktree, so there is no `--force` to eat a dirty tree.
+	if [ ! -f "$pin_left/UNCOMMITTED.txt" ]; then
+		fail "the leftover worktree's uncommitted file is GONE — a removal was introduced (#4826 hard constraint)"
+	elif [ "$(cat "$pin_left/UNCOMMITTED.txt")" != "precious uncommitted work" ]; then
+		fail "the leftover worktree's uncommitted file was modified"
+	elif ! git -C "$tmp/pin" worktree list --porcelain | grep -qF "worktree $pin_left"; then
+		fail "the leftover worktree was UNREGISTERED — the sanctioned path must remove nothing"
+	else
+		ok "the leftover worktree and its dirty, uncommitted work are untouched (nothing removed)"
+	fi
+
+	# 30. The primary checkout is never co-checked-out: its branch ref would move under the shared
+	# tree. Refusal names the remedy, and this lane's HEAD does not move.
+	err="$tmp/stderr"
+	CLAUDE_CODE_SESSION_ID="$pin_sid" kp_switch_head_branch "$pin_lane" "$pin_base" 2>"$err"; rc=$?
+	diag="$(cat "$err")"
+	if [ "$rc" -eq 0 ]; then
+		fail "the sanctioned path co-checked-out a branch held by the PRIMARY checkout — the #2270 class"
+	elif [ "$(git -C "$pin_lane" symbolic-ref -q HEAD)" != "refs/heads/kp-feat" ]; then
+		fail "the primary refusal moved this lane's HEAD — a refusal must change nothing"
+	elif ! grep -qF 'REMEDY:' <<<"$diag"; then
+		fail "the primary refusal names no remedy: [$diag] — a refusal with no way forward is what gets improvised past"
+	else
+		ok "a branch held by the primary checkout: refused, HEAD unmoved, remedy named"
+	fi
+
+	# 31. A pinning tree stamped with THIS session is a sibling lane that may still be building on the
+	# branch; the rebase would move its HEAD mid-flight. Refuse, name the remedy, remove nothing.
+	if ! git -C "$tmp/pin" worktree add -q -b kp-sib "$tmp/pin-sib" >/dev/null 2>&1; then
+		fail "fixture did not take: could not add the sibling-lane worktree — case 31 was NOT exercised"
+	else
+		printf '%s\n' "$pin_sid" > "$tmp/pin/.git/worktrees/pin-sib/kampus-lane"
+		CLAUDE_CODE_SESSION_ID="$pin_sid" kp_switch_head_branch "$pin_lane" kp-sib 2>"$err"; rc=$?
+		diag="$(cat "$err")"
+		if [ "$rc" -eq 0 ]; then
+			fail "the sanctioned path co-checked-out a branch held by a LIVE sibling lane of this session"
+		elif ! grep -qF 'REMEDY:' <<<"$diag"; then
+			fail "the live-lane refusal names no remedy: [$diag]"
+		elif ! git -C "$tmp/pin" worktree list --porcelain | grep -qF "worktree $(cd "$tmp/pin-sib" && pwd -P)"; then
+			fail "the live-lane refusal removed the sibling worktree"
+		else
+			ok "a branch held by a same-session sibling lane: refused, remedy named, nothing removed"
+		fi
+	fi
+fi
+
 cleanup
 if [ "$failures" -ne 0 ]; then
 	printf '\ncommon-test: %d failure(s)\n' "$failures"

--- a/claude-plugins/kampus-pipeline/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/lib/common-test.sh
@@ -546,8 +546,12 @@ PINROOT=$(cd "$tmp/pin" && pwd -P)" ]; then
 	bare_err="$(git -C "$pin_lane" switch kp-feat 2>&1)"; bare_rc=$?
 	if [ "$bare_rc" -eq 0 ]; then
 		fail "fixture did not take: a bare \`git switch\` onto a branch another worktree holds SUCCEEDED — the pinned-branch condition was NOT reproduced"
-	elif ! grep -qF 'already checked out' <<<"$bare_err"; then
-		fail "the bare switch failed for some other reason than the pin: [$bare_err]"
+	# Assert on the PINNING TREE'S PATH, not on git's wording: 2.40 says "already checked out at
+	# '<path>'" and 2.54 says "already used by worktree at '<path>'", and only the pin refusal names
+	# that path at all. Grepping the wording passed locally and red on CI's newer git, leaving the
+	# sanctioned co-checkout below — this fix's whole point — unexercised there.
+	elif ! grep -qF "$pin_left" <<<"$bare_err"; then
+		fail "the bare switch failed for some other reason than the pin (its error does not name the pinning tree $pin_left): [$bare_err]"
 	else
 		err="$tmp/stderr"
 		CLAUDE_CODE_SESSION_ID="$pin_sid" kp_switch_head_branch "$pin_lane" kp-feat 2>"$err"; rc=$?

--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -415,6 +415,160 @@ kp__scratch() {
 	printf '%s\n' "$dir"
 }
 
+kp__phys() { # <path> — its physical form, or the path itself when the directory is gone (a prunable
+	# worktree registration outlives its directory, and it still pins the branch).
+	cd -P "$1" 2>/dev/null && pwd -P && return 0
+	printf '%s\n' "$1"
+}
+
+# WHICH worktree holds <branch> checked out right now — the classifier repair R2 routes on when a
+# leftover build lane still pins the PR's head branch (#4826). Prints exactly two lines:
+#
+#   PIN=free|mine|primary|live-lane|other
+#   PINROOT=<absolute worktree root>          (empty only for `free`)
+#
+# The four non-free states are NOT interchangeable, which is the whole reason this is a classifier
+# and not a boolean: co-checking-out a branch (`git switch --ignore-other-worktrees`) leaves the
+# pinning tree's FILES untouched but lets a later rebase move the branch ref under its HEAD. That is
+# harmless for a finished lane's leftover tree (`other`), and it is exactly the #2270
+# primary-checkout-corruption class for the shared primary tree (`primary`) or a lane that may still
+# be building on it (`live-lane`).
+#
+# `live-lane` is keyed on the ONLY liveness evidence available here: the pinning tree's own
+# `kampus-lane` stamp equalling THIS session's id, i.e. a sibling lane of the very session now
+# repairing. A foreign session's stamp proves nothing either way and resolves `other` — stated
+# plainly rather than dressed up as a liveness check, because the mitigation for it is that the
+# co-checkout removes nothing and writes nothing into that tree.
+#
+# A read it cannot complete is UNKNOWN and returns non-zero with nothing on stdout — never `free`,
+# which is the permissive branch (§ZS, ADR 0092).
+kp_branch_pin() {
+	local mine="$1" branch="$2"
+	local common list line cur primary="" hits="" mine_p hit_p state gd r stamp
+	local NL='
+'
+	if [ -z "$mine" ] || [ -z "$branch" ]; then
+		printf 'kp_branch_pin: need <my-worktree-root> <branch> — the pin state is UNKNOWN, never free.\n' >&2
+		return 1
+	fi
+	if ! common="$(git -C "$mine" rev-parse --git-common-dir 2>/dev/null)"; then
+		printf 'kp_branch_pin: %s is not inside a git repository — the pin state is UNKNOWN, never free.\n' "$mine" >&2
+		return 1
+	fi
+	case "$common" in /*) ;; *) common="$mine/$common" ;; esac
+	if ! common="$(cd "$common" 2>/dev/null && pwd -P)"; then
+		printf 'kp_branch_pin: could not resolve the common git dir of %s — UNKNOWN, never free.\n' "$mine" >&2
+		return 1
+	fi
+	if ! list="$(git -C "$mine" worktree list --porcelain 2>/dev/null)"; then
+		printf 'kp_branch_pin: `git worktree list` failed under %s — UNKNOWN, never free.\n' "$mine" >&2
+		return 1
+	fi
+	# git lists the MAIN worktree first, so the first record names the primary checkout; a detached
+	# worktree emits no `branch` line and therefore pins nothing.
+	while IFS= read -r line; do
+		case "$line" in
+		"worktree "*)
+			cur="${line#worktree }"
+			[ -n "$primary" ] || primary="$cur"
+			;;
+		"branch refs/heads/$branch") hits="$hits$cur$NL" ;;
+		esac
+	done <<EOF
+$list
+EOF
+	if [ -z "$hits" ]; then
+		printf 'PIN=free\nPINROOT=\n'
+		return 0
+	fi
+	mine_p="$(kp__phys "$mine")"
+	# SEVERAL trees can legitimately hold one branch — that is precisely the state the sanctioned
+	# co-checkout leaves behind — and MINE wins the read, so re-running the step after a co-checkout
+	# resolves `mine` and is a clean no-op rather than a repeat refusal.
+	hit_p=""
+	while IFS= read -r line; do
+		[ -n "$line" ] || continue
+		r="$(kp__phys "$line")"
+		if [ "$r" = "$mine_p" ]; then
+			hit_p="$mine_p"
+			break
+		fi
+		[ -n "$hit_p" ] || hit_p="$r"
+	done <<EOF
+$hits
+EOF
+	if [ "$hit_p" = "$mine_p" ]; then
+		state="mine"
+	elif [ "$hit_p" = "$(kp__phys "$primary")" ] || [ "$hit_p" = "$(kp__phys "${common%/.git}")" ]; then
+		state="primary"
+	else
+		state="other"
+		for gd in "$common"/worktrees/*/gitdir; do
+			[ -f "$gd" ] || continue
+			r="$(cat "$gd")"
+			[ "$(kp__phys "${r%/.git}")" = "$hit_p" ] || continue
+			stamp="$(cat "${gd%/gitdir}/kampus-lane" 2>/dev/null)"
+			if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && [ "$stamp" = "$CLAUDE_CODE_SESSION_ID" ]; then
+				state="live-lane"
+			fi
+			break
+		done
+	fi
+	printf 'PIN=%s\nPINROOT=%s\n' "$state" "$hit_p"
+}
+
+# Put MY lane's HEAD on <branch> whatever pins it — the SANCTIONED path repair R2 takes, so no repair
+# agent has to invent one (#4826). Narration and every refusal go to stderr; stdout stays empty
+# because this is an effect, not an answer.
+#
+# It removes NO worktree, on any branch — not even a prunable registration, and never with `--force`.
+# A build lane's tree can hold real uncommitted work, so eating one is strictly worse than the bug
+# this closes; the co-checkout needs no removal at all, which is why that is the shape chosen.
+#
+# Every refusal names its remedy in the refusal line. A fail-closed stop with no stated way forward
+# is what produced the improvisations in the first place, one of which silently dropped the rebase
+# onto latest `main` and the `verified-push` verification.
+kp_switch_head_branch() {
+	local wt="$1" branch="$2" pin state root
+	if ! pin="$(kp_branch_pin "$wt" "$branch")"; then
+		printf 'kp_switch_head_branch: the pin state of %s is UNKNOWN (see above), so the sanctioned path cannot be chosen. REMEDY: re-run from your own lane once `git worktree list` reads cleanly. NOTHING was switched.\n' "$branch" >&2
+		return 1
+	fi
+	state="$(printf '%s\n' "$pin" | sed -n 's/^PIN=//p')"
+	root="$(printf '%s\n' "$pin" | sed -n 's/^PINROOT=//p')"
+	case "$state" in
+	mine)
+		printf 'kp_switch_head_branch: %s already holds %s — nothing to switch.\n' "$wt" "$branch" >&2
+		;;
+	free)
+		if ! git -C "$wt" switch "$branch" >&2; then
+			printf 'kp_switch_head_branch: `git switch %s` failed in %s, and NO worktree holds that branch — so this is NOT the pinned-branch case and its remedy does not apply. REMEDY: read git'\''s error above; a local change blocking the switch is committed or stashed IN %s, an unknown branch needs `git fetch origin` first. NOTHING was switched.\n' "$branch" "$wt" "$wt" >&2
+			return 1
+		fi
+		;;
+	other)
+		printf 'kp_switch_head_branch: %s is pinned by worktree %s — not this lane, not the primary checkout. Taking the SANCTIONED co-checkout in MY lane (%s): `git switch --ignore-other-worktrees`. That tree is left in place and its files are untouched; no worktree is removed. Its HEAD will follow the branch ref once this repair rebases.\n' "$branch" "$root" "$wt" >&2
+		if ! git -C "$wt" switch --ignore-other-worktrees "$branch" >&2; then
+			printf 'kp_switch_head_branch: the sanctioned co-checkout of %s into %s failed (git'\''s error is above) — the pin is NOT what blocked it. REMEDY: resolve what git named in %s and re-run this step. Do NOT detach HEAD to work around it: a detached repair skips the rebase onto origin/main and `verified-push` resolves a detached HEAD to UNKNOWN and pushes nothing. NOTHING was switched.\n' "$branch" "$wt" "$wt" >&2
+			return 1
+		fi
+		;;
+	primary)
+		printf 'kp_switch_head_branch REFUSED (fail-closed): %s is checked out in the PRIMARY checkout %s. Co-checking it out here would let this repair'\''s rebase move the branch ref under the shared primary tree (the #2270 primary-corruption class). REMEDY: release %s in that checkout (`git switch <some other branch>`), then re-run this step. Do NOT remove any worktree. NOTHING was switched.\n' "$branch" "$root" "$branch" >&2
+		return 1
+		;;
+	live-lane)
+		printf 'kp_switch_head_branch REFUSED (fail-closed): %s is checked out in %s, a worktree stamped with THIS session'\''s lane id (%s) — a sibling lane that may still be building on it. The rebase would move its HEAD mid-flight. REMEDY: run this repair from that lane'\''s worktree, or wait for it to finish and re-run. Do NOT remove that worktree — it can hold uncommitted work. NOTHING was switched.\n' "$branch" "$root" "${CLAUDE_CODE_SESSION_ID:-<unset>}" >&2
+		return 1
+		;;
+	*)
+		printf 'kp_switch_head_branch REFUSED (fail-closed): the pin classifier returned no state for %s — UNKNOWN, never free. REMEDY: run `git worktree list --porcelain` from %s and report what it shows. NOTHING was switched.\n' "$branch" "$wt" >&2
+		return 1
+		;;
+	esac
+	return 0
+}
+
 # The per-mutation worktree guard and the lane resolver under it. They live HERE, in the file every
 # pipeline shell script already sources, because they have TWO classes of caller: the EXECUTED
 # `write-code/scripts/step4-wt-preflight.sh`, which runs `wt_preflight` in a subprocess and prints

--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -417,8 +417,9 @@ kp__scratch() {
 
 kp__phys() { # <path> — its physical form, or the path itself when the directory is gone (a prunable
 	# worktree registration outlives its directory, and it still pins the branch).
-	cd -P "$1" 2>/dev/null && pwd -P && return 0
-	printf '%s\n' "$1"
+	# The `cd` runs in a subshell so this can never move the CALLER's cwd — every call site wraps it
+	# in `$( … )` today, but a bare call would otherwise relocate the shell that sourced this lib.
+	(cd -P "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"
 }
 
 # WHICH worktree holds <branch> checked out right now — the classifier repair R2 routes on when a

--- a/claude-plugins/kampus-pipeline/skills/write-code/repair.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/repair.md
@@ -244,6 +244,36 @@ Repair mode runs in a worktree too, so re-run the Step-4 opening preflight (and 
 before this switch, then gate every later `git commit`/`git push` on `step4-wt-preflight.sh` exactly
 as the initial build does.
 
+#### The head branch is usually pinned by the build lane's leftover worktree — the sanctioned path
+
+A build lane's worktree is not released when its lane finishes, so by the time you repair, the PR's
+head branch is normally **still checked out there** and git refuses a second checkout of it
+(`fatal: '<branch>' is already checked out at …`). **This is the routine case, not an edge case**, and
+the step above already handles it — **do not improvise past it.** Two lanes that improvised on the
+same night took different routes, and one committed on a **detached checkout**, which silently cost
+both the rebase onto latest `origin/main` *and* `verified-push` (which resolves a detached HEAD to
+`UNKNOWN` and pushes nothing, so that lane hand-rolled its own refspec push and `ls-remote` check —
+#4826).
+
+`stepR2-branch-rebase.sh` classifies what holds the branch and routes on it, inside **your own**
+`wt_preflight`-resolved worktree, and **removes no worktree in any case**:
+
+| What holds the head branch | What the step does |
+| --- | --- |
+| Nothing | plain `git switch` |
+| **Your own lane** already | nothing to switch — a re-run after a co-checkout is a clean no-op |
+| **Another lane's leftover tree** | the sanctioned **co-checkout**: `git switch --ignore-other-worktrees` in your lane. That tree keeps its files, including uncommitted work; only the branch ref moves when you rebase |
+| The **primary checkout** | **REFUSES** — rebasing would move a branch ref under the shared primary tree (the #2270 class). Remedy in the refusal: release the branch there, then re-run |
+| A worktree stamped with **this session's** lane id | **REFUSES** — a sibling lane may still be building on it, and the rebase would move its HEAD mid-flight. Remedy: run the repair from that lane, or wait and re-run |
+
+Two rules hold across all five rows, and neither is negotiable. **Never remove a worktree to free a
+branch** — a build lane's tree can hold real uncommitted work, so eating one is strictly worse than
+the bug; the co-checkout needs no removal at all, which is why it is the shape chosen. (Reaping the
+accumulated leftover trees is a separate, undecided policy question — #4806 — and is deliberately not
+solved here.) And **never detach HEAD to get past a refusal**: a detached repair skips the rebase and
+leaves `verified-push` with no branch to verify. Every refusal above names its remedy on the refusal
+line; if you hit one, take *that* remedy or stop and report — do not invent a sixth route.
+
 **Freshen the base onto latest `origin/main` before you fix — surface a textual conflict at
 code-time, not merge-time.** The repair branch still carries its **dispatch-time base**; if
 `main` moved while the PR sat in the gate (other PRs merged) and touched the same lines, the

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-branch-rebase.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/stepR2-branch-rebase.sh
@@ -34,7 +34,12 @@ git -C "$WT" fetch origin || { echo "write-code Step R2: 'git fetch origin' fail
 # In orchestrated repair the original claim token is threaded as MY_CLAIM (ADR 0115 §3 delegated own).
 bash "$HERE/step3_5-claim-is-mine.sh" "$N" >&2 \
 	|| { echo "refusing to repair PR #$PR — its linked issue #$N is not my claim (Step 3.5)" >&2; exit 1; }
-git -C "$WT" switch "$HEAD_BRANCH" || { echo "write-code Step R2: could not switch to '$HEAD_BRANCH' — NOTHING was rebased." >&2; exit 1; }
+# The head branch is USUALLY still checked out in the original build lane's leftover worktree, so a
+# bare `git switch` refuses and the step used to stop there with no route onward — which is what each
+# repair agent then invented for itself (#4826). `kp_switch_head_branch` is that route: it classifies
+# what pins the branch and either co-checks-it-out inside THIS lane or refuses with a named remedy.
+kp_switch_head_branch "$WT" "$HEAD_BRANCH" \
+	|| { echo "write-code Step R2: could not put $WT on '$HEAD_BRANCH' (the remedy is named above) — NOTHING was rebased." >&2; exit 1; }
 # freshen the dispatch-time base FIRST — surface a textual conflict now, in-context (see repair.md).
 # A CONFLICT is an expected outcome here, not a defect: the rebase stops mid-flight, so this exits
 # non-zero WITHOUT printing `WT=`, and the fix is to resolve in-context and re-run — never `--abort`


### PR DESCRIPTION
A build lane's worktree is never released when its lane finishes, so by the time a repair runs the PR's head branch is normally still checked out there and the repair step's bare `git switch` refuses. That refusal was correct and had nothing after it, so three repair lanes in one night each invented their own way past it — and one committed on a **detached checkout**, which silently skipped the rebase onto latest `origin/main` and bypassed `verified-push` (a detached HEAD resolves `UNKNOWN` and pushes nothing, so that lane hand-rolled a refspec push plus its own `ls-remote`). This gives the step a sanctioned path: classify what holds the branch, co-check-it-out inside the lane's own worktree when that is safe, and otherwise refuse with the remedy named on the refusal line. No worktree is removed on any path.

Fixes #4826

## What changed

- **`lib/common.sh` — `kp_branch_pin`**: which worktree holds `<branch>` right now, as five states, not a boolean: `free` / `mine` / `primary` / `live-lane` / `other`. An unreadable `git worktree list` is UNKNOWN (non-zero, empty stdout), never `free`.
- **`lib/common.sh` — `kp_switch_head_branch`**: the sanctioned switch. `other` (a leftover build lane's tree) takes `git switch --ignore-other-worktrees` inside the lane's own `wt_preflight`-resolved worktree; `primary` and `live-lane` refuse; every refusal names its remedy.
- **`scripts/stepR2-branch-rebase.sh`**: line 37's bare `git switch` becomes one call to that function. Everything else — the `wt_preflight` gate, the Step-3.5 claim guard, the `git rebase origin/main` — is untouched.
- **`repair.md`**: a table of the five cases plus the two rules that hold across all of them (never remove a worktree to free a branch; never detach HEAD to get past a refusal).
- **`lib/common-test.sh`**: six falsifiable cases (26–31) on real `git worktree` fixtures.

## Why this direction

The issue listed three non-binding candidates. Chosen: **`--ignore-other-worktrees`, plus a classifier in front of it, plus named remedies on every refusal** — the first and third candidates together.

- **Not "release the build lane's worktree when its lane completes."** That is a removal, and removal is where the hard constraint bites; it is also #4806's undecided reaping policy. The co-checkout needs no removal at all, so it sits entirely upstream of that ruling and stays correct whichever way #4806 goes. Cross-referenced, not folded in.
- **Not a bare `--ignore-other-worktrees`.** The flag is right for the routine case and wrong in two others, which a boolean "is it pinned" cannot tell apart. The rebase moves the branch ref, so the pinning tree's HEAD follows it. That is harmless for a finished lane's leftover tree, and it is the #2270 primary-corruption class when the pinning tree is the shared primary checkout, or a lane that may still be building on the branch. Hence five states.
- **`live-lane` is keyed on the only liveness evidence available here** — the pinning tree's own `kampus-lane` stamp equalling this session's id, i.e. a sibling lane of the very session now repairing. A foreign session's stamp proves nothing either way and resolves `other`; that is stated plainly in the code rather than dressed up as a liveness check, and the mitigation for it is that the co-checkout removes nothing and writes nothing into that tree.
- **A `mine` state exists so a re-run is a clean no-op.** After a co-checkout two trees legitimately hold the branch; `mine` wins the read, so re-running the step resolves `mine` rather than refusing again.

## Proof (observed, on real worktrees)

`bash claude-plugins/kampus-pipeline/lib/common-test.sh` — the pinned-branch cases build a real repo with a lane worktree and a leftover worktree holding the head branch, with uncommitted work in the leftover tree:

```
ok: kp_branch_pin separates free / mine / primary / live-lane / other
ok: pinned head branch: the bare switch refuses, the sanctioned co-checkout attaches this lane to the branch
ok: the rebase onto the latest base still happens on the sanctioned path, on an attached branch
ok: the leftover worktree and its dirty, uncommitted work are untouched (nothing removed)
ok: a branch held by the primary checkout: refused, HEAD unmoved, remedy named
ok: a branch held by a same-session sibling lane: refused, remedy named, nothing removed

common-test: all checks passed
```

These are red before the fix, not green-both-ways. Against `HEAD`'s `lib/common.sh` the suite refuses to run at all:

```
FAIL: kp_branch_pin is not defined by <lib>/common.sh — the cases below would resolve 127 and read as fail-closed passes. Refusing to run them.
FAIL: kp_switch_head_branch is not defined by <lib>/common.sh — the cases below would resolve 127 and read as fail-closed passes. Refusing to run them.
```

Case 27 reproduces the defect inside the fixture before exercising the fix — it asserts the bare `git switch` **fails** with `already checked out`, and reds if the fixture ever stops reproducing it. An end-to-end transcript over the same fixture (temp paths elided):

```
=== BEFORE (what stepR2 line 37 used to do: a bare git switch) ===
fatal: 'feat/head' is already checked out at '<tmp>/leftover'
  exit=128

=== AFTER (the sanctioned path) ===
kp_switch_head_branch: feat/head is pinned by worktree <tmp>/leftover — not this lane, not the
primary checkout. Taking the SANCTIONED co-checkout in MY lane (<tmp>/lane):
`git switch --ignore-other-worktrees`. That tree is left in place and its files are untouched;
no worktree is removed. Its HEAD will follow the branch ref once this repair rebases.
Switched to branch 'feat/head'
  exit=0
Successfully rebased and updated refs/heads/feat/head.
  HEAD in my lane: refs/heads/feat/head  (attached => verified-push has a branch)
  feat/head on top of main: yes
  leftover tree still registered: 1
  leftover dirty file: precious uncommitted work
  leftover git status: ?? WIP.txt
```

And the failure modes, loud rather than silent:

```
=== REFUSAL 1: the branch is held by the PRIMARY checkout ===
kp_switch_head_branch REFUSED (fail-closed): main is checked out in the PRIMARY checkout <tmp>/repo.
Co-checking it out here would let this repair's rebase move the branch ref under the shared primary
tree (the #2270 primary-corruption class). REMEDY: release main in that checkout
(`git switch <some other branch>`), then re-run this step. Do NOT remove any worktree.
NOTHING was switched.
  exit=1

=== REFUSAL 2: the branch is held by a live sibling lane of this session ===
kp_switch_head_branch REFUSED (fail-closed): sib is checked out in <tmp>/sib, a worktree stamped
with THIS session's lane id (demo-lane) — a sibling lane that may still be building on it. The
rebase would move its HEAD mid-flight. REMEDY: run this repair from that lane's worktree, or wait
for it to finish and re-run. Do NOT remove that worktree — it can hold uncommitted work.
NOTHING was switched.
  exit=1
  sibling worktree still registered: 1

=== IDEMPOTENT: re-running after the co-checkout ===
kp_switch_head_branch: <tmp>/lane already holds feat/head — nothing to switch.
  exit=0
```

The dirty-tree case is the safety pin: the leftover tree's uncommitted `WIP.txt` is still there, still untracked, and the tree is still registered — the fix contains no `git worktree remove` at all, with or without `--force`, so there is nothing that could eat it.

## Guards run

- `bash claude-plugins/kampus-pipeline/lib/common-test.sh` — all checks passed
- `bash .claude/skills/validate-skills.sh` — 30 skills valid
- `pipeline-cli trap-status-guard check` over the plugin corpus — clean (351 files)
- `pipeline-cli gh-phoenix lint-skills` over the plugin corpus — clean
- `bash …/write-code/scripts/verify-executed-contract.sh` and `verify-fail-closed.sh` — OK
- `shellcheck -x` on the three changed shell files — no new findings (the one SC1007 on `common.sh` line 368 is pre-existing and unchanged)
- `pipeline-cli cp-classify classify` → **`control-plane [path-match]` — BLOCKING (human merge).** This PR stops at reviewed-ready; it is not auto-mergeable and must not be self-approved.

## Deviations

- **Class: implementation shape narrower than the issue's framing.** Said: the acceptance criteria name `stepR2-branch-rebase.sh` as the file that must carry the sanctioned path. Did: the step carries the *call*; the decision and the effect live in `kp_branch_pin` / `kp_switch_head_branch` in `lib/common.sh`. Why: the lib is where the sibling worktree guards (`wt_preflight`, `lane_worktree`) already live and is the only surface `lib/common-test.sh` can exercise directly, so hosting it there is what let the behaviour be proven end to end on real worktrees instead of asserted. Disposition: no action needed — `stepR2-branch-rebase.sh` is still the only caller and still the file the AC points a reader at.
- **Class: a guard introduced that the issue did not ask for.** Said: the issue asks for a sanctioned path plus loud refusals. Did: also refuses on `primary` and on a same-session `live-lane` pin, two cases neither observed incident hit. Why: the co-checkout's cost is that the pinning tree's HEAD follows the rebased branch ref, which is exactly the #2270 class against the shared primary tree and a mid-flight HEAD move against a live sibling; shipping the flag without those two states would sanction the hazard along with the fix. Disposition: for the reviewer to judge — the `live-lane` line is the debatable one, since a same-session sibling stamp is suggestive of liveness rather than proof of it.
- **(repair round 1) Class: declined an optional reviewer suggestion.** Said: `review-code`'s non-blocking observation 2 — the `case "$line" in "branch refs/heads/$branch")` arm interpolates the branch into a glob, so a name containing `[`, `*` or `?` would misresolve. Did: left the `case` arm exactly as it was. Why: git itself makes that state unrepresentable — `git check-ref-format` **rejects** `refs/heads/kp-f[e]at`, `refs/heads/kp-f*at` and `refs/heads/kp-f?at` (run at this head on git 2.40.1; the rule is git's own refname format, not a local policy), so no branch reachable by this code can carry a glob metacharacter. A rewrite guarding an unreachable state cannot be pinned by a test and only widens a §CP diff. Disposition: no action needed; the grounding is recorded here rather than as an unfalsifiable code comment.
