### PR TITLE
fix(fabrika-cli): provenance.json publishes 66, not the discredited 74 (#4838)

### DIFF
--- a/packages/fabrika-cli/src/eval/incident-corpus/provenance.json
+++ b/packages/fabrika-cli/src/eval/incident-corpus/provenance.json
@@ -166,7 +166,7 @@
 			"incidents": ["#4285"],
 			"verification": [
 				"KEEP-AS-EVAL row on the #4634 verdict table: bare 1 applied as a literal label on #4282, reported success.",
-				"Absent from the 153-issue kill list on #4642, and named in that ruling's fold into the 74-issue KEEP corpus."
+				"Absent from the 153-issue kill list on #4642, and named among the 7 borderline items that ruling folded into the KEEP corpus. The fold double-counts them — each already carries a KEEP-AS-EVAL row — so the enumerated corpus is 66, not the 74 the ruling published (ruled-keeps.json, #4823)."
 			],
 			"corrections": []
 		},
@@ -177,7 +177,7 @@
 			"incidents": ["#4163"],
 			"verification": [
 				"KEEP-AS-EVAL row on the #4634 verdict table: review gate declared a merged ADR nonexistent, four seats in one session.",
-				"Absent from the 153-issue kill list on #4642, and named in that ruling's fold into the 74-issue KEEP corpus."
+				"Absent from the 153-issue kill list on #4642, and named among the 7 borderline items that ruling folded into the KEEP corpus. The fold double-counts them — each already carries a KEEP-AS-EVAL row — so the enumerated corpus is 66, not the 74 the ruling published (ruled-keeps.json, #4823)."
 			],
 			"corrections": []
 		},
@@ -188,7 +188,7 @@
 			"incidents": ["#4338"],
 			"verification": [
 				"KEEP-AS-EVAL row on the #4634 verdict table: stale checkout applied a withdrawn ADR 86 minutes after the withdrawal merged.",
-				"Absent from the 153-issue kill list on #4642, and named in that ruling's fold into the 74-issue KEEP corpus."
+				"Absent from the 153-issue kill list on #4642, and named among the 7 borderline items that ruling folded into the KEEP corpus. The fold double-counts them — each already carries a KEEP-AS-EVAL row — so the enumerated corpus is 66, not the 74 the ruling published (ruled-keeps.json, #4823)."
 			],
 			"corrections": []
 		}


### PR DESCRIPTION
The incident corpus keeps a ledger, `provenance.json`, that records how each eval case was verified. Three of its entries still said the ruled KEEP corpus has 74 members — a figure that was corrected to 66 everywhere else, including the README sitting next to it. This PR fixes those three entries, so someone auditing corpus membership no longer reads two different sizes from two files in the same directory.

It is not a find-and-replace of a digit. The old sentence described #4642's fold of the 7 borderline items into the corpus, and that fold *is* the double-count, so swapping 74 for 66 would have left a sentence that was arithmetically right and narratively false. The claim is restated instead.

Fixes #4838
Part of #4823

## What changed

`packages/fabrika-cli/src/eval/incident-corpus/provenance.json` — cases 15, 16 and 17 (pinning #4285, #4163, #4338). Each carried the identical string:

> Absent from the 153-issue kill list on #4642, and named in that ruling's fold into the 74-issue KEEP corpus.

Now:

> Absent from the 153-issue kill list on #4642, and named among the 7 borderline items that ruling folded into the KEEP corpus. The fold double-counts them — each already carries a KEEP-AS-EVAL row — so the enumerated corpus is 66, not the 74 the ruling published (ruled-keeps.json, #4823).

All three cases pin borderline issues, so "named among the 7 borderline items" is true of each. The surviving `74` is now a dated citation of what #4642 published, not an assertion of the corpus size.

## The 66 was re-derived, not taken on trust

Mechanically, against the two source artifacts, before any edit:

- #4634 comment 5149946878 (the sweep table) enumerates **80** `KEEP-AS-EVAL` rows. Its stated per-chunk total is 81; the one-row gap is #4180, which carries a `KILL-CANDIDATE` row that #4642 retracted and never replaced.
- #4642 comment 5150090125's kill list parses to exactly **153** unique numbers.
- 80 KEEP rows minus the 14 that appear in the kill list = **66**.
- All 14 crew-layer re-buckets (4617 4480 4409 4360 4290 4222 4141 4118 4077 4075 4055 3990 3938 3766) are **in** the kill list — 14/14.
- All 7 borderline (#4338 #3330 #4285 #4163 #4145 #3945 #3709) are **absent** from the kill list — 0/7 present — and each carries a `KEEP-AS-EVAL` row — 7/7.

So the borderline items were inside the KEEP set already, and `67 + 7 = 74` counts them twice. This matches `ruled-keeps.json`'s own `derivation` block and its 66 member rows + 1 pending row, arrived at independently.

## Sweep for other stale figures

`grep -n 74` over the whole file returns only the three corrected lines. No other stale cardinality is published in `provenance.json`; the issue's enumeration of three was complete.

## Checks

- `pnpm vitest run src/eval/incident-corpus.data.unit.test.ts src/eval/ruled-keeps.data.unit.test.ts` — 19 passed
- `pnpm typecheck` — 30/30 tasks
- `pnpm lint:worktree` — clean

## Deviations

**Class: narrowed the suggested fix-shape.**
- Said: #4838 suggested the replacement wording *"named in that ruling's fold into the KEEP corpus (published there as 74; the corrected cardinality is 66 — see the amendment on #4642)"*.
- Did: used a variant that names the 7 borderline items and states *why* the fold double-counts, and cites `ruled-keeps.json` + #4823 rather than the #4642 amendment.
- Why: the suggested string still leaves the reader to work out how 74 became 66; the derivation now lives in `ruled-keeps.json`'s `derivation` block, which is the durable in-repo home the README also points at. Citing the sibling file keeps the ledger self-contained.
- Disposition: no action needed — same figure, same claim, for the reviewer to judge on wording.

**Class: left a sibling item for its own ticket.**
- Said: #4838 suggested folding this into PR #4837 while it was open.
- Did: opened a standalone PR.
- Why: #4837 merged as c84046e3 before this lane started, which is the issue's own stated fallback.
- Disposition: no action needed.

**Class: declined to close a related issue.**
- Said: #4838 is the remaining half of #4823's scope.
- Did: emitted `Part of #4823` (non-closing) and no closing keyword for it.
- Why: #4823's own disposition is not this lane's to decide; the dispatch was explicit that it stays open until this lands.
- Disposition: for whoever owns #4823 to close.