### PR TITLE
fix(ship-it): Step 3z asserts its own zero-runs precondition before it nudges (#4830)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,6 +611,15 @@ jobs:
       # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh`.
       - run: bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh
 
+      # Executable pin for Step 3z's precondition (#4830): the one ship-it step that mutates a live
+      # PR — close→reopen — must fire ONLY in the dropped-trigger state and refuse without touching
+      # the PR otherwise, including on an unreadable count. The precondition used to live in the
+      # caller's prose, and a mis-read branch close→reopened a green PR (#4816). The harness carries
+      # its own mutant, so an assertion that stopped having teeth reds here rather than passing
+      # quietly. Hermetic: gh and the CLI shim are stubbed, no network.
+      # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-step3z-precondition.sh`.
+      - run: bash .claude/skills/ship-it/scripts/verify-step3z-precondition.sh
+
       # Executable pin for plan-epic's round-trip race detector (#4596): a CLEAN splice whose
       # `## Dependencies` block is the body's last section — the standard first-time layout —
       # must exit 0, while ANY in-block difference must still exit 1 with the racer verdict. The

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1280,18 +1280,31 @@ loop:
 ```bash
 # Hand it the `HEAD_SHA=` the empty-checkset probe printed — the nudge counts `reopened` events since
 # THAT commit, so a guessed head would mis-count them and re-nudge a head already nudged once.
-# stdout: one terminal line — `nudged (close→reopen) …` or `unverified (no runs fired …)` — plus
-# `INTENT_UNCLEARED=<0|1>`. Both are successful declines and exit 0; read the terminal word.
+# stdout: one terminal line — `nudged (close→reopen) …`, `unverified (no runs fired …)`, or
+# `refused (not the dropped-trigger state: …) — no nudge` — plus `INTENT_UNCLEARED=<0|1>`. All three
+# are successful declines and exit 0; read the terminal word.
 bash ./.claude/.pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh <owner/repo> <pr number> <HEAD_SHA>
 ```
+
+**The script asserts this branch itself, and a third terminal outcome is its refusal (#4830).** The
+classification above is *prose*: it happens in your head, and if you reach Step 3z from any other
+state the remedy would close→reopen a live PR and leave a durable comment claiming a dropped trigger
+that never happened (PR #4816 — a head with 45 contexts and 33 runs, nudged anyway). So the script
+re-derives `CONTEXTS` / `NWF` / `NRUNS` at the head instead of trusting the branch that called it,
+and prints `refused (not the dropped-trigger state: CONTEXTS=<n> NWF=<n> NRUNS=<n>) — no nudge`
+**without touching the PR** — no close→reopen, no comment — whenever the state does not hold. An
+**unreadable** number refuses on the same line (`…=unreadable`): an unknown is never a confirmed
+zero, which is the whole of the class this closes (#4482). A refusal here means the *dispatch* was
+wrong, not the PR: re-read Step 3's branch list against the numbers the refusal names.
 
 The nudge **never bypasses verification** — it only restores the *missing runs*. A nudged PR
 is handed back to the normal gate on the next invocation; the merge still requires a
 current-head PASS (Step 2), green gating checks (Step 3), **and** a commit-bound, all-`pass`
 run-evidence bundle (Step 3.5, guard 2). The close→reopen re-triggers CI; it does not advance
-the merge by itself. Like Step 3's red and Step 2's FAIL, both Step 3z outcomes —
-`nudged (close→reopen) …` and `unverified (no runs fired — nudge exhausted …)` — are a
-**successful run that declines to merge**, not an error.
+the merge by itself. Like Step 3's red and Step 2's FAIL, all three Step 3z outcomes —
+`nudged (close→reopen) …`, `unverified (no runs fired — nudge exhausted …)` and
+`refused (not the dropped-trigger state: …) — no nudge` — are a **successful run that declines to
+merge**, not an error.
 
 ---
 
@@ -2030,9 +2043,12 @@ check-runs read returned nothing interpretable; an unreadable head is never a gr
 the dropped-trigger outcomes (Step 3z):
 `nudged (close→reopen) — CI re-triggered, not yet merge-ready` (the head SHA had zero workflow
 runs; ship-it close→reopened it once to re-emit the trigger, posted a durable PR outcome comment,
-and stopped — re-dispatch after CI settles) or `unverified (no runs fired — nudge exhausted,
+and stopped — re-dispatch after CI settles), `unverified (no runs fired — nudge exhausted,
 producer may be stuck)` (already nudged once and still zero runs → handed to a human, with a
-durable PR outcome comment), `no linked issue`, or a run-evidence refusal (Step 3.5):
+durable PR outcome comment) or `refused (not the dropped-trigger state: CONTEXTS=<n> NWF=<n>
+NRUNS=<n>) — no nudge` (the remedy was reached from a head that is not in the state it remedies, or
+one of those numbers was unreadable — the PR is left untouched, #4830), `no linked issue`, or a
+run-evidence refusal (Step 3.5):
 `unverified (run-evidence artifact unreachable — transient upstream error, …)`,
 `unverified (no run-evidence bundle)`, `unverified (unsupported bundle schemaVersion: <v>)`,
 `unverified (stale run-evidence bundle: …)`, or `run-evidence checks failed (<names>)`. A

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh
@@ -8,8 +8,9 @@
 # DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
 #   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh \
 #                   <REPO> <PR> <HEAD_SHA>
-#              stdout ⇒ one terminal line — `nudged (close→reopen) …` or `unverified (no runs fired
-#              …)` — plus `INTENT_UNCLEARED=<0|1>`. Both are successful declines and exit 0, exactly
+#              stdout ⇒ one terminal line — `nudged (close→reopen) …`, `unverified (no runs fired
+#              …)`, or `refused (not the dropped-trigger state: …) — no nudge` — plus
+#              `INTENT_UNCLEARED=<0|1>`. All three are successful declines and exit 0, exactly
 #              as the fenced block did; read the terminal word, not the status.
 #              `<HEAD_SHA>` is the head `step3-empty-checkset-probe.sh` printed — the nudge counts
 #              `reopened` events since THAT commit, so a guessed head would mis-count them.
@@ -27,6 +28,47 @@ REPO="${REPO:-${1:?step3z-dropped-trigger.sh: REPO unset and no \$1 — refusing
 PR="${PR:-${2:?step3z-dropped-trigger.sh: PR unset and no \$2 — refusing to nudge an unnamed PR}}"
 HEAD_SHA="${HEAD_SHA:-${3:?step3z-dropped-trigger.sh: HEAD_SHA unset and no \$3 — refusing to count nudges against an unnamed head}}"
 
+# This script's OWN evidence that the head is in the state its remedy is for (#4830). The branch
+# that selects Step 3z lives in the agent's prose classification, so before this the only thing
+# between a mis-read branch and a close→reopen of a live PR was the agent having read correctly —
+# and on PR #4816 it had not: a fully-green head (CONTEXTS=45, NRUNS=33) was close→reopened and
+# given a durable comment asserting zero workflow runs. Re-derive the three numbers that DEFINE the
+# state instead of trusting the caller for them, and read every unreadable one as a REFUSAL: an
+# unknown is never a confirmed zero (class #4482).
+CHECKS_CLI="$(kp_pcli)" || CHECKS_CLI=""   # its own name: `$PCLI` belongs to disarm-intent.sh, sourced above
+# `.contexts` is relayed from `checks read`, the single head-CI rollup reader (ADR 0228) — never a
+# second rollup derived here. NWF/NRUNS are the same two REST reads step3-empty-checkset-probe.sh
+# makes, in the opposite fail direction: the probe substitutes "runs exist" to fall through, this
+# one keeps the lookup failure visible so it can refuse on it.
+CONTEXTS=""
+if [ -n "$CHECKS_CLI" ]; then
+  CONTEXTS=$("$CHECKS_CLI" checks read --sha "$HEAD_SHA" 2>/dev/null | jq -r '.contexts? // empty' 2>/dev/null)
+fi
+NWF=$(gh api "repos/$REPO/actions/workflows?per_page=100" --jq '.workflows | length' 2>/dev/null)
+NRUNS=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+  --jq '.workflow_runs | length' 2>/dev/null)
+# A non-numeric capture is a lookup that FAILED, not a count; name it so the refusal line can say so.
+case "$CONTEXTS" in ''|*[!0-9]*) CONTEXTS=unreadable ;; esac
+case "$NWF"      in ''|*[!0-9]*) NWF=unreadable ;; esac
+case "$NRUNS"    in ''|*[!0-9]*) NRUNS=unreadable ;; esac
+# The dropped-trigger state, exactly as SKILL.md Step 3 branch 3 defines it: no check context
+# reported, the repo does run Actions, and zero runs fired for this head. Anything else — including
+# any unreadable — is not it.
+DROPPED=1
+case "$CONTEXTS" in 0) ;; *) DROPPED=0 ;; esac
+case "$NRUNS"    in 0) ;; *) DROPPED=0 ;; esac
+case "$NWF"      in unreadable|0) DROPPED=0 ;; esac
+
+disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: ALL exits below stop without enqueuing — park nothing (ADR 0198)
+
+if [ "$DROPPED" -ne 1 ]; then
+  # No PATCH and no comment: the PR is not this run's to mutate, and a "dropped trigger" comment
+  # here would be the same false claim #4816 left behind. The refusal is stdout-only by design.
+  echo "refused (not the dropped-trigger state: CONTEXTS=$CONTEXTS NWF=$NWF NRUNS=$NRUNS) — no nudge"
+  if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
+  exit 0
+fi
+
 # Have we ALREADY nudged this exact head? A nudge leaves a `reopened` event; count the ones
 # that landed AFTER this head SHA was pushed (its committer date is the proxy for "since this
 # commit"). >=1 ⇒ we already close→reopened this head and runs STILL didn't fire ⇒ the producer
@@ -34,8 +76,6 @@ HEAD_SHA="${HEAD_SHA:-${3:?step3z-dropped-trigger.sh: HEAD_SHA unset and no \$3 
 HEAD_PUSHED=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date')
 NUDGES=$(gh api "repos/$REPO/issues/$PR/events?per_page=100" \
   --jq "[.[] | select(.event==\"reopened\") | .created_at | select(. > \"$HEAD_PUSHED\")] | length")
-
-disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: BOTH exits below stop without enqueuing — park nothing (ADR 0198)
 
 if [ "${NUDGES:-0}" -ge 1 ]; then
   # Nudge exhausted → refuse and hand to a human, but leave a durable PR-visible signal (#1928):

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step3z-dropped-trigger.sh
@@ -29,11 +29,8 @@ PR="${PR:-${2:?step3z-dropped-trigger.sh: PR unset and no \$2 — refusing to nu
 HEAD_SHA="${HEAD_SHA:-${3:?step3z-dropped-trigger.sh: HEAD_SHA unset and no \$3 — refusing to count nudges against an unnamed head}}"
 
 # This script's OWN evidence that the head is in the state its remedy is for (#4830). The branch
-# that selects Step 3z lives in the agent's prose classification, so before this the only thing
-# between a mis-read branch and a close→reopen of a live PR was the agent having read correctly —
-# and on PR #4816 it had not: a fully-green head (CONTEXTS=45, NRUNS=33) was close→reopened and
-# given a durable comment asserting zero workflow runs. Re-derive the three numbers that DEFINE the
-# state instead of trusting the caller for them, and read every unreadable one as a REFUSAL: an
+# that selects Step 3z is agent-side prose, and on PR #4816 a mis-read close→reopened a live green
+# head and left a false zero-runs comment on it. Every unreadable number below refuses too — an
 # unknown is never a confirmed zero (class #4482).
 CHECKS_CLI="$(kp_pcli)" || CHECKS_CLI=""   # its own name: `$PCLI` belongs to disarm-intent.sh, sourced above
 # `.contexts` is relayed from `checks read`, the single head-CI rollup reader (ADR 0228) — never a
@@ -62,8 +59,7 @@ case "$NWF"      in unreadable|0) DROPPED=0 ;; esac
 disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: ALL exits below stop without enqueuing — park nothing (ADR 0198)
 
 if [ "$DROPPED" -ne 1 ]; then
-  # No PATCH and no comment: the PR is not this run's to mutate, and a "dropped trigger" comment
-  # here would be the same false claim #4816 left behind. The refusal is stdout-only by design.
+  # Stdout-only on purpose: a comment here would be the same false claim #4816 left behind.
   echo "refused (not the dropped-trigger state: CONTEXTS=$CONTEXTS NWF=$NWF NRUNS=$NRUNS) — no nudge"
   if [ "${BASH_SOURCE[0]}" = "$0" ]; then printf 'INTENT_UNCLEARED=%s\n' "$INTENT_UNCLEARED"; fi
   exit 0

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step3z-precondition.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step3z-precondition.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC2016,SC2086
+# SC2016 is declared, not waved off: the mutant generator's sed program matches the LITERAL text
+# `$DROPPED` in the script under test, so expanding it here would delete nothing.
+# Reviewer-runnable proof that Step 3z's close→reopen fires ONLY in the dropped-trigger state (#4830).
+#
+# Step 3z is the one ship-it step that takes a destructive server-side action on a live PR, and its
+# precondition used to live entirely in the caller's prose classification: on PR #4816 a fully-green
+# head was close→reopened and given a durable comment claiming zero workflow runs. So the property
+# under test is not "the script runs" but "the script REFUSES to mutate a PR whose head is not in
+# the state the remedy is for", in every direction the numbers can fail — including unreadable.
+#
+# Falsifiability is asserted, not assumed: the harness generates a MUTANT with the precondition
+# block deleted and requires the not-dropped case to nudge under it. An assertion that passes on the
+# mutant too would be testing nothing.
+#
+# Hermetic: `gh` and `pipeline-cli` are stubbed, so this needs no auth and touches no PR.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step3z-precondition.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, and no
+# `EXIT` trap — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this
+# harness's whole contract is its exit status.
+set -uo pipefail
+
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SUT="$DIR/step3z-dropped-trigger.sh"
+fail=0
+
+if [ ! -f "$SUT" ]; then
+	echo "FAIL: zero scope — $SUT does not exist (ADR 0092)"
+	exit 1
+fi
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+BIN="$TMP/bin"
+PLUGIN="$TMP/plugin/bin"
+mkdir -p "$BIN" "$PLUGIN" || { echo "FAIL: cannot create the stub dirs under $TMP"; exit 1; }
+
+# The stubs answer each read with the number the CASE sets, and RECORD every call — the mutation
+# assertions read that log, never the script's own narration of what it did.
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_CALLS"
+for a in "$@"; do
+  case "$a" in
+    */actions/workflows*)  [ "$STUB_NWF"   = FAIL ] && exit 1; printf '%s\n' "$STUB_NWF"; exit 0 ;;
+    */actions/runs*)       [ "$STUB_NRUNS" = FAIL ] && exit 1; printf '%s\n' "$STUB_NRUNS"; exit 0 ;;
+    */commits/*)           printf '2026-01-01T00:00:00Z\n'; exit 0 ;;
+    */events*)             printf '%s\n' "$STUB_NUDGES"; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+
+cat > "$PLUGIN/pipeline-cli" <<'STUB'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "checks read")        [ "$STUB_CONTEXTS" = FAIL ] && exit 1
+                        printf '{"conclusion":"green","contexts":%s,"running":[],"wedged":[],"failing":[]}\n' "$STUB_CONTEXTS" ;;
+  "merge-intent disarm") ;;
+esac
+exit 0
+STUB
+chmod +x "$BIN/gh" "$PLUGIN/pipeline-cli"
+
+# One case = one run of the script under one head state. `$OUT` is its stdout, `$CALLS` every gh
+# call it made.
+run_case() {   # $1 = script, $2 = CONTEXTS, $3 = NWF, $4 = NRUNS, $5 = prior nudges
+	CALLS="$TMP/calls"
+	: > "$CALLS"
+	OUT="$(GH_CALLS="$CALLS" STUB_CONTEXTS="$2" STUB_NWF="$3" STUB_NRUNS="$4" STUB_NUDGES="$5" \
+		PATH="$BIN:$PATH" CLAUDE_PLUGIN_ROOT="$TMP/plugin" \
+		bash "$1" owner/repo 1 deadbeefdeadbeefdeadbeefdeadbeefdeadbeef 2>"$TMP/err")"
+}
+
+mutated() { grep -q 'PATCH' "$CALLS" || grep -q 'comments' "$CALLS"; }
+
+# `no-mutate` is the refusal contract: no close→reopen AND no comment — a comment here would be the
+# false dropped-trigger claim. `no-patch` is the pre-existing exhausted outcome, which deliberately
+# leaves its durable #1928 comment; only the close→reopen is forbidden there.
+check() {   # $1 = label, $2 = expected terminal substring, $3 = mutate|no-patch|no-mutate
+	if ! printf '%s' "$OUT" | grep -q "$2"; then
+		printf 'BAD   %-34s stdout missing %-46s got: %s\n' "$1" "$2" "${OUT:-<empty>}"
+		fail=1
+		return
+	fi
+	if [ "$3" = no-mutate ] && mutated; then
+		printf 'BAD   %-34s REFUSED but still mutated the PR:\n' "$1"
+		sed 's/^/      /' "$CALLS"
+		fail=1
+		return
+	fi
+	if [ "$3" = no-patch ] && grep -q 'PATCH' "$CALLS"; then
+		printf 'BAD   %-34s close→reopened the PR anyway:\n' "$1"
+		sed 's/^/      /' "$CALLS"
+		fail=1
+		return
+	fi
+	if [ "$3" = mutate ] && ! grep -q 'state=closed' "$CALLS"; then
+		printf 'BAD   %-34s expected the close→reopen nudge, none recorded\n' "$1"
+		fail=1
+		return
+	fi
+	printf 'OK    %-34s %s\n' "$1" "$2"
+}
+
+echo "scope: $SUT, driven under 6 head states + 1 mutant"
+
+# --- the two PRE-EXISTING terminal outcomes, preserved -------------------------------------------
+run_case "$SUT" 0 45 0 0
+check "genuine dropped trigger" "nudged (close→reopen)" mutate
+run_case "$SUT" 0 45 0 1
+check "nudge exhausted" "unverified (no runs fired" no-patch
+
+# --- the refusal, in every direction the precondition can fail ------------------------------------
+# The #4816 shape: a fully-green head handed to the remedy by a mis-read branch.
+run_case "$SUT" 45 45 33 0
+check "green head (#4816 shape)" "refused (not the dropped-trigger state" no-mutate
+run_case "$SUT" 0 45 FAIL 0
+check "NRUNS unreadable" "NRUNS=unreadable" no-mutate
+run_case "$SUT" FAIL 45 0 0
+check "CONTEXTS unreadable" "CONTEXTS=unreadable" no-mutate
+# A repo that runs no Actions has a genuinely empty check set — not a dropped trigger.
+run_case "$SUT" 0 0 0 0
+check "repo runs no Actions" "refused (not the dropped-trigger state" no-mutate
+
+# --- falsifiability: the assertions must FAIL on a mutant that drops the precondition --------------
+MUTANT="$TMP/mutant.sh"
+sed '/^if \[ "\$DROPPED" -ne 1 \]; then$/,/^fi$/d' "$SUT" > "$MUTANT"
+if ! cmp -s "$SUT" "$MUTANT"; then
+	run_case "$MUTANT" 45 45 33 0
+	if mutated; then
+		printf 'OK    %-34s the mutant nudges the green head — the refusal assertions have teeth\n' "mutant reverts the fix"
+	else
+		printf 'BAD   %-34s the mutant did NOT nudge; the refusal assertions would pass without the fix\n' "mutant reverts the fix"
+		fail=1
+	fi
+else
+	printf 'BAD   %-34s found no precondition block to delete — the mutant is the original\n' "mutant reverts the fix"
+	fail=1
+fi
+
+rm -rf "$TMP"
+if [ "$fail" -ne 0 ]; then
+	echo "FAIL: Step 3z can close→reopen a PR outside the dropped-trigger state"
+	exit 1
+fi
+echo "PASS: Step 3z nudges only in the dropped-trigger state, and refuses without mutating otherwise"


### PR DESCRIPTION
ship-it's Step 3z is the one step that close→reopens a live PR to re-fire dropped CI, and until now it took that action purely on the caller's word — the numbers that define the dropped-trigger state never reached the script, so the only thing between an agent mis-reading Step 3's branch list and a real PR being close→reopened was the agent reading correctly. On PR #4816 it did not: a head with 45 check contexts and 33 workflow runs was close→reopened and given a durable comment claiming it had zero runs.

The script now establishes that state itself before it touches the PR, and refuses with a named third outcome when it cannot — including when a lookup fails, since an unreadable count is never a confirmed zero.

Fixes #4830

## What changed

- **`step3z-dropped-trigger.sh` asserts its own precondition.** It re-derives the three numbers at the head — `CONTEXTS` relayed from `pipeline-cli checks read` (ADR 0228: relay the one head-CI rollup reader, never derive a second rollup here), plus the `actions/workflows` and `actions/runs?head_sha=` counts the sibling probe reads — and only nudges when the state SKILL.md Step 3 branch 3 defines actually holds: zero contexts, the repo runs Actions, zero runs for this head.
- **A third terminal outcome, and it mutates nothing.** `refused (not the dropped-trigger state: CONTEXTS=<n> NWF=<n> NRUNS=<n>) — no nudge` — no `state=closed` / `state=open`, and no comment (a comment here would be the same false claim #4816 left behind). An unreadable count prints on the same line as `…=unreadable` and refuses, which is the whole point of the class in #4482.
- **Everything else is preserved.** Both existing terminal outcomes, the once-per-head exhaustion bound (still leaving its durable #1928 comment), guard 6's `disarm_intent refuse` on every exit, and the dual-mode / no-`EXIT`-trap shell shape (`.patterns/skill-script-shell-shape.md`, ADR 0232).
- **`verify-step3z-precondition.sh`** drives the script over six head states against stubbed `gh` / `pipeline-cli` and asserts, from the recorded call log rather than the script's own narration, that no refusal touched the PR. It generates its own mutant — the precondition block deleted — and **requires** that mutant to nudge the green head, so an assertion that stops having teeth reds instead of passing quietly. Wired into the `skills` CI job beside `verify-chain-resolves.sh`.

## Verification

- `verify-step3z-precondition.sh` — PASS, 6 states + the mutant.
- `verify-chain-resolves.sh` — PASS (the chain still runs as written).
- `shellcheck` clean on both scripts; `trap-status-guard`, `cli-invocation-guard`, `gh-phoenix lint-skills`, `adoption-lint`, `leak-guard` clean; `actionlint` clean on `ci.yml`.

## Deviations

**Class: narrowed the suggested fix-shape.**
- Said: the issue offered "either by taking `CONTEXTS` / `NRUNS` as arguments, or by re-deriving them at the head."
- Did: re-derive at the head only, and asserted a third number, `NWF`, alongside them.
- Why: arguments would keep the trust in the caller (and a test asserting a refusal the caller never supplies would prove nothing). `NWF` is part of the same branch-3 predicate — without it a repo that runs no Actions has `NRUNS == 0` by definition and would be nudged, which is the fail-open direction branch 3 exists to close.
- Disposition: no action needed.

**Class: scope judgment on where the derivation lives.**
- Said: ADR 0228 bounds these scripts to relaying a `pipeline-cli` verb's answer.
- Did: relayed `.contexts` from `checks read`, but read `NWF` / `NRUNS` over REST inline, because no verb exposes a head's workflow-run count (`checks read` reads check-runs, `run-evidence read` reads the bundle).
- Why: this mirrors `step3-empty-checkset-probe.sh`, which makes the same two reads; folding this glue into verbs is the phase-2 rewrite the issue puts out of scope (#1929).
- Disposition: for the reviewer to judge.

**Class: a stop-path behaviour the ACs did not specify.**
- Said: "refuses without mutating the PR."
- Did: the refusal still runs `disarm_intent refuse` before it prints, like the two existing exits.
- Why: guard 6 (ADR 0198) requires every non-enqueuing stop to leave no armed merge intent; disarming is the fail-safe direction and skipping it here would let a refused run leave `--auto` parked.
- Disposition: no action needed.
