### PR TITLE
fix(fabrika-cli): cut the excess-operand CLI suite to 5 spawns and take the network out of it

### DIFF
--- a/packages/fabrika-cli/src/excess-operand.cli.test.ts
+++ b/packages/fabrika-cli/src/excess-operand.cli.test.ts
@@ -4,16 +4,33 @@
  * The defect this covers produced a successful-looking result — exit 0 with the id `adr next` would
  * have printed anyway (#4828) — so a test asserting on stdout *content* is exactly the test that
  * passes against the bug. Every case below asserts the exit code and stderr instead.
+ *
+ * **Five spawns, and none of them touch the network (#4847).** Each `it` costs one cold node+TS load
+ * of `bin.ts` — about 2.3s on a CI runner — so spawn count *is* this file's cost, and the matrix it
+ * used to walk twelve times is covered in 19ms by `excess-operand.unit.test.ts`. What only a
+ * subprocess can prove is the exit status, which needs a handful of representative invocations, not
+ * one per phrasing.
+ *
+ * The variadic case additionally ran `adr resolve` **inside this repo**, where the verb fetches
+ * `origin/main` before reading it: a real network fetch, 15.4s green and 41.3s under merge-queue
+ * contention, which timed out and ejected PR #4835. It now runs from a scratch directory that is not
+ * a git repository, so that read refuses in milliseconds — which changes nothing it asserts, because
+ * the excess-operand check runs at parse time, before the verb ever reaches git.
  */
 import {execFileSync} from "node:child_process";
-import {mkdtempSync} from "node:fs";
+import {mkdtempSync, readdirSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
+import {BASE_UNFETCHABLE} from "./adr/resolve-verb.ts";
 
-/** Spawning under a loaded machine outruns vitest's 5s default (the #4014 false red). */
-const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+/**
+ * One spawn costs ~2.3s on a CI runner. The contention factor measured between two runs of this file
+ * 24 minutes apart was **2.69×** (#4847), so a ceiling is only a margin if it clears that band: 20s
+ * is ~8× the per-spawn baseline, while still failing a genuinely wedged spawn well inside the job.
+ */
+const SUBPROCESS_TEST_TIMEOUT_MS = 20_000;
 
 const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
 
@@ -27,9 +44,10 @@ interface Run {
  * `FABRIKA_SKIP_INFER` pins the invocation to *this* copy: the delegation would otherwise resolve
  * whichever install the enclosing repo root pins, which is not the tree under test.
  */
-const fabrika = (...args: ReadonlyArray<string>): Run => {
+const fabrika = (args: ReadonlyArray<string>, cwd: string = process.cwd()): Run => {
 	try {
 		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			cwd,
 			encoding: "utf8",
 			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
 			stdio: ["ignore", "pipe", "pipe"],
@@ -53,70 +71,54 @@ const USAGE_ERROR = 1;
 describe("an operand no leaf verb declares is refused", {
 	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
 }, () => {
-	it("refuses one excess operand on a verb that declares none", () => {
-		const run = fabrika("adr", "next", "extratoken");
+	it("refuses an excess operand, naming both the token and the verb path", () => {
+		const run = fabrika(["adr", "next", "extratoken"]);
 		expect(run.code).toBe(USAGE_ERROR);
 		expect(run.stderr).toContain('unexpected operand "extratoken"');
+		expect(run.stderr).toContain('for "fabrika adr next"');
 		expect(run.stdout).toBe("");
 	});
 
-	it("refuses more than one excess operand, naming each", () => {
-		const run = fabrika("adr", "next", "a", "b");
-		expect(run.code).toBe(USAGE_ERROR);
-		expect(run.stderr).toContain('unexpected operands "a", "b"');
-		expect(run.stdout).toBe("");
-	});
-
-	it("refuses an excess operand that follows a flag", () => {
-		const run = fabrika("adr", "next", "--json", "extratoken");
-		expect(run.code).toBe(USAGE_ERROR);
-		expect(run.stderr).toContain('unexpected operand "extratoken"');
-		expect(run.stdout).toBe("");
-	});
-
-	it("refuses an operand beyond a fixed arity, and writes nothing", () => {
+	// The operand trails a flag *and* a satisfied arity, which is the shape a pre-runner argv walk
+	// gets wrong: only the parser knows `extra` is a positional rather than another `--dir` value.
+	it("refuses an operand past a fixed arity that follows a flag, and writes nothing", () => {
 		const dir = scratchDir();
-		const run = fabrika("adr", "new", "0240", "some-slug", "extra", "--dir", dir);
+		const run = fabrika(["adr", "new", "0240", "some-slug", "--dir", dir, "extra"]);
 		expect(run.code).toBe(USAGE_ERROR);
 		expect(run.stderr).toContain('unexpected operand "extra"');
 		expect(run.stdout).toBe("");
-	});
-
-	it("refuses in a group other than adr, so the guard is not one verb's", () => {
-		const run = fabrika("eval", "check", "some-manifest.json", "extra");
-		expect(run.code).toBe(USAGE_ERROR);
-		expect(run.stderr).toContain('unexpected operand "extra"');
-	});
-
-	it("names the full verb path, not just the token", () => {
-		expect(fabrika("adr", "next", "extratoken").stderr).toContain('for "fabrika adr next"');
+		expect(readdirSync(dir)).toEqual([]);
 	});
 });
 
 describe("what already worked still works", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	/**
+	 * `adr resolve` is the one variadic leaf, so it is the one verb whose own arguments must swallow
+	 * the operands before the catch-all sees them. Run from a non-repo cwd it refuses at its first
+	 * git read — `--repo` is what seats that refusal on `BASE_UNFETCHABLE` rather than the `1` the
+	 * origin-remote lookup would return, so the code alone distinguishes "ran and could not fetch"
+	 * from "refused the operands".
+	 */
 	it("a variadic verb absorbs its operands rather than refusing them", () => {
-		const run = fabrika("adr", "resolve", "0164", "0023", "--dir", scratchDir());
+		const run = fabrika(["adr", "resolve", "0164", "0023", "--repo", "owner/name"], scratchDir());
 		expect(run.stderr).not.toContain("unexpected operand");
+		expect(run.code).toBe(BASE_UNFETCHABLE);
 	});
 
 	it("a fixed-arity verb at its declared arity still succeeds", () => {
-		const run = fabrika("adr", "new", "0240", "some-slug", "--dir", scratchDir());
+		const run = fabrika(["adr", "new", "0240", "some-slug", "--dir", scratchDir()]);
 		expect(run.code).toBe(0);
 		expect(run.stdout).not.toBe("");
 	});
 
-	it.each([
-		["the root index", ["--help"]],
-		["a group's verbs", ["adr", "--help"]],
-		["a verb's flags", ["adr", "next", "--help"]],
-	])("%s still exits 0 with help on stdout and an empty stderr", (_label, args) => {
-		const run = fabrika(...args);
+	// That help at every depth still exits 0 with USAGE is asserted four ways in
+	// `unknown-subcommand.cli.test.ts`; the half only this file owns is that the hidden catch-all
+	// stays out of it — help is the interface, and it must not offer an argument that does not exist.
+	it("a verb's help exits 0 and never advertises the catch-all", () => {
+		const run = fabrika(["adr", "next", "--help"]);
 		expect(run.code).toBe(0);
 		expect(run.stdout).toContain("USAGE");
 		expect(run.stderr).toBe("");
-	});
-
-	it("the catch-all stays out of the help a caller reads — help is the interface", () => {
-		expect(fabrika("adr", "next", "--help").stdout).not.toContain("excess");
+		expect(run.stdout).not.toContain("excess");
 	});
 });

--- a/packages/fabrika-cli/src/excess-operand.cli.test.ts
+++ b/packages/fabrika-cli/src/excess-operand.cli.test.ts
@@ -9,13 +9,8 @@
  * of `bin.ts` — about 2.3s on a CI runner — so spawn count *is* this file's cost, and the matrix it
  * used to walk twelve times is covered in 19ms by `excess-operand.unit.test.ts`. What only a
  * subprocess can prove is the exit status, which needs a handful of representative invocations, not
- * one per phrasing.
- *
- * The variadic case additionally ran `adr resolve` **inside this repo**, where the verb fetches
- * `origin/main` before reading it: a real network fetch, 15.4s green and 41.3s under merge-queue
- * contention, which timed out and ejected PR #4835. It now runs from a scratch directory that is not
- * a git repository, so that read refuses in milliseconds — which changes nothing it asserts, because
- * the excess-operand check runs at parse time, before the verb ever reaches git.
+ * one per phrasing. Twelve spawns plus one that fetched `origin/main` for real is what timed out and
+ * ejected PR #4835 from the merge queue; the cwd that removes that fetch is explained at its case.
  */
 import {execFileSync} from "node:child_process";
 import {mkdtempSync, readdirSync} from "node:fs";
@@ -94,10 +89,13 @@ describe("an operand no leaf verb declares is refused", {
 describe("what already worked still works", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
 	/**
 	 * `adr resolve` is the one variadic leaf, so it is the one verb whose own arguments must swallow
-	 * the operands before the catch-all sees them. Run from a non-repo cwd it refuses at its first
-	 * git read — `--repo` is what seats that refusal on `BASE_UNFETCHABLE` rather than the `1` the
-	 * origin-remote lookup would return, so the code alone distinguishes "ran and could not fetch"
-	 * from "refused the operands".
+	 * the operands before the catch-all sees them. It is also the one verb here that does real work:
+	 * inside this repo it fetches `origin/main` before reading it, which cost 15.4s green and 41.3s
+	 * under merge-queue contention. From a cwd that is not a git repository it refuses at that first
+	 * git read instead, and the assertion is unweakened — the excess-operand check runs at parse
+	 * time, before the verb reaches git, so a regressed catch-all still seats `USAGE_ERROR` here.
+	 * `--repo` is what keeps the refusal on `BASE_UNFETCHABLE` rather than the ambiguous `1` the
+	 * origin-remote lookup would return, so the code alone separates "ran" from "refused".
 	 */
 	it("a variadic verb absorbs its operands rather than refusing them", () => {
 		const run = fabrika(["adr", "resolve", "0164", "0023", "--repo", "owner/name"], scratchDir());


### PR DESCRIPTION
A test in `packages/fabrika-cli` was spawning twelve real subprocesses to check one guard, and one of those subprocesses fetched from GitHub every time it ran. That fetch took 15 seconds on a quiet runner and 41 seconds under merge-queue load, where it blew a 30-second ceiling and ejected an unrelated docs-only PR from the queue. This cuts the file to five spawns, none of which touch the network, and re-sizes the ceiling against what the job actually costs.

**PR #4835 is blocked on this landing.** It is a docs-only diff that has now been ejected from the merge queue twice by this test, and nothing in its own diff touches `packages/fabrika-cli`.

## The diagnosis, and why the fix is not a bigger number

The issue title frames this as "~15s against a 30s ceiling" — a headroom problem. It is not, and I checked before touching the constant.

`fabrika adr resolve` — the invocation in the timing-out case — calls `loadMerged`, which calls `fetchAndResolve`, which runs a real `git fetch --quiet origin main` against this repository before it reads anything (`packages/fabrika-cli/src/io/git.ts`, `packages/fabrika-cli/src/adr/base-ref.ts`). Measured on one machine:

| invocation | wall clock |
|---|---|
| `adr next extratoken` (no git) | 0.71s |
| `adr resolve 0164 0023` (fetches `origin/main`) | 3.29s |
| `adr resolve …` from a non-repo cwd | 0.38s |

That is a network round-trip inside a unit-tier test. It is the part with unbounded variance, it is why one test cost 15.4s of the file's 40.9s green baseline, and it is why the same test cost 41.3s under contention. Raising `SUBPROCESS_TEST_TIMEOUT_MS` would have left the fetch in place and moved the threshold — the partial mitigation the repo's standing rule says not to ship.

## What changed

**The variadic case no longer reaches the network.** It runs from a scratch directory that is not a git repository, so `adr resolve` refuses at its first git read. The assertion is not weakened — it is strengthened. The excess-operand check runs at parse time, inside `leafCommand`'s handler wrapper, *before* the verb reaches git, so a regressed catch-all still prints `unexpected operand` and seats exit `1` here. The case now also asserts `BASE_UNFETCHABLE` (3), which positively proves the verb *ran* rather than merely proving a string was absent; `--repo owner/name` is what keeps the refusal on 3 instead of the ambiguous 1 the origin-remote lookup returns.

**Twelve spawns become five.** Each spawn is a cold node+TS load of `bin.ts`, ~2.3s on CI, so spawn count is the file's cost. Dropped, and where the coverage still lives:

| dropped case | still covered by |
|---|---|
| multi-token refusal wording | `excess-operand.unit.test.ts` — `excessRefusal(…, ["a","b"])` |
| naming the full verb path | folded into the first refusal case (same spawn), plus the unit tier |
| refusal in a group other than `adr` | `excess-operand.unit.test.ts` — its coverage guard walks *every* registered leaf |
| excess operand following a flag | folded into the fixed-arity case, which now passes `--dir <dir> extra` |
| root `--help` and `adr --help` exit 0 | `unknown-subcommand.cli.test.ts` — asserts this at four depths already |

Kept, because only a process proves them: the #4828 repro (exit 1, empty stdout, token and path named), refusal past a fixed arity with nothing written to the scratch dir, variadic absorption, a fixed-arity verb succeeding at its declared arity, and the hidden catch-all staying out of `--help`.

**`SUBPROCESS_TEST_TIMEOUT_MS`: 30s to 20s**, with a comment stating what it is sized for — about 8x the ~2.3s per-spawn CI baseline, against the 2.69x contention factor the issue measured between two runs 24 minutes apart.

## Evidence

Local, same machine, before and after:

| | before | after |
|---|---|---|
| file test time | 5.66s (12 tests) | 1.72s (5 tests) |
| variadic case | 1922ms | 349ms |

The improvement on that case is larger on CI than locally, because the fetch here hits a warm local git over a fast link — 15.4s on the runner versus 1.9s here.

**Falsifiability re-proven in both directions**, by injecting regressions into `excess-operand.ts` and reverting:

- Catch-all spread *first* instead of last, so it absorbs a variadic verb's own operands: the variadic case reds (`code 1`, not 3), as do the fixed-arity cases. 3 of 5 fail.
- The `excess.length === 0` guard disarmed, restoring the #4828 defect exactly: both refusal cases red. 2 of 5 fail.

Neither injected defect can pass this file. `pnpm --filter './packages/**' --filter @kampus/infra run test` exits 0 (fabrika-cli: 41 files, 554 tests). `pnpm typecheck` and `pnpm lint:worktree` clean.

## Acceptance criteria

- Matrix reduced to a representative set, unit-tier-covered cases dropped rather than duplicated — done, 12 to 5.
- Duration materially below the 40.9s green baseline, evidenced by a run log — local before/after above; this PR's own `packages unit tests` run is the CI evidence, and its measured file duration gets appended to this body once it reports.
- Ceiling re-set against the new baseline with headroom exceeding 2.69x, carrying its sizing factor — done, 20s / ~8x, comment cites the factor.
- The job stays in the merge-queue-gating set and every asserted behaviour is still covered in `packages/fabrika-cli/` — done, no workflow change; see the mapping table.
- `pnpm --filter './packages/**' --filter @kampus/infra run test` green — done, exit 0.

Fixes #4847

## Deviations

**1. Declined the in-passing `ci.yml` comment correction (deferred sibling defect).**
- Said: the issue's Pointers call the stale `packages-tests` header ("fast (~7s, ~500 tests)") "worth correcting in passing, not a separate unit".
- Did: left `.github/workflows/ci.yml` untouched.
- Why: `.github/**` is control-plane (ADR 0053), so touching it moves this PR out of the autonomous merge lane and onto a human merge. This PR exists to unblock PR #4835 from the merge queue now; a one-line comment fix is not worth that latency.
- Disposition: follow-up #4856 filed, carrying the measurements and the reason it was deferred.

**2. Narrowed the fix to the one file the issue scopes (sibling left for follow-up).**
- Said: the issue scopes explicitly to `excess-operand.cli.test.ts`.
- Did: left `unknown-subcommand.cli.test.ts` alone, which has the same 12-spawn / fixed-30s shape in the same gating job.
- Why: honoring the stated scope; widening it would also grow the diff a reviewer must verify under time pressure.
- Disposition: follow-up #4855 filed.

**3. Lowered the ceiling rather than raising it.**
- Said: the AC asks for the ceiling to be re-set against the *new* baseline with headroom exceeding the 2.69x factor. A reader primed by the issue title might expect a raise.
- Did: 30s to 20s.
- Why: with the network gone, the worst case is a single ~2.3s spawn. 20s is ~8x that, well clear of 2.69x, and a lower ceiling makes a genuinely wedged spawn fail inside the job rather than near its budget.
- Disposition: no action needed; the constant's comment records the sizing.

**4. Strengthened the timing-out test's assertion while shrinking the file.**
- Said: the issue asks only that behaviour stay covered.
- Did: added `expect(run.code).toBe(BASE_UNFETCHABLE)` to the variadic case, which previously asserted only that a string was absent.
- Why: a bare `not.toContain` also passes if the process dies for an unrelated reason. Binding the exit code to the source constant makes "the verb ran and absorbed its operands" the thing actually proven.
- Disposition: for the reviewer to judge.


---

## Update 2026-08-03 — the CI run log AC 2 asks for

This PR's own `packages unit tests` job (check run `91636514592`, head `a77e817`) reports:

```
✓ src/excess-operand.cli.test.ts (5 tests) 13427ms
  Test Files  41 passed (41)
       Tests  554 passed (554)
```

Against the 40,890ms green baseline recorded in the issue, on the same job: **40.9s -> 13.4s, a 3.05x reduction**, with the network fetch gone. That works out to ~2.7s per spawn, which is the figure the new 20s ceiling was sized against — about 7.4x headroom on the slowest single case, clear of the 2.69x contention factor.
