### PR TITLE
feat(fabrika): the triage group's shared substrate (slice 1a of #4831)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1,10 +1,11 @@
 # @kampus/fabrika-cli
 
 The deterministic verb package [fabrika](../../claude-plugins/fabrika/) skills call.
-`fabrika <group> <verb> …` dispatches to a registered verb group. Three groups are
+`fabrika <group> <verb> …` dispatches to a registered verb group. Four groups are
 registered: `adr`, the six verbs the `/adr` skill's derived contract specifies; `report`,
-the three the `/report` contract specifies; and `eval`, the graded-corpus harness the
-fabrika eval layer measures itself with.
+the three the `/report` contract specifies; `triage`, the intake-queue group the `/triage`
+contract specifies; and `eval`, the graded-corpus harness the fabrika eval layer measures
+itself with.
 
 ## Who it's for
 
@@ -191,6 +192,36 @@ Four behaviours are worth knowing before you call them:
 Intake applies **no type and no priority**, and that is defended mechanically rather than in
 prose: exit `10` refuses a `--label` or a title prefix that resolves to the target repo's own
 type/priority vocabulary.
+
+## The `triage` group
+
+The contract is
+[`claude-plugins/fabrika/skills/triage/contract.md`](../../claude-plugins/fabrika/skills/triage/contract.md).
+**Only the shared substrate is built so far** — the group's nine verbs (`queue`, `claim`,
+`provenance`, `homes`, `split`, `enrich`, `apply`, `park`, `kill`) land in later slices of
+[#4831](https://github.com/kamp-us/phoenix/issues/4831), and the one registered verb today
+prints the table they will all allocate from.
+
+| Verb | Answers |
+|---|---|
+| `triage codes` | the exit taxonomy every verb in the group allocates from, one `<code>\t<meaning>` line per code |
+
+Three properties of that substrate are worth knowing before the verbs arrive:
+
+- **All nine verbs allocate from one table** ([`src/triage/codes.ts`](./src/triage/codes.ts)),
+  so a code means one thing across this group. Where it overlaps the two `report` writing
+  verbs — `3`, `5`, `6`, `7`, `8`, `9`, `10`, `11` — the meanings match **code for code**, so
+  a caller driving both groups in one sweep reads one meaning. That alignment does not extend
+  repo-wide: `adr` allocates per verb, and `report dedup`'s own `3`/`4` mean something else
+  again.
+- **`4` is a deliberate gap.** It once fused "the target issue is proven absent" with "the
+  target issue could not be read". `7` and `11` took the halves, and the slot is left
+  unallocated rather than compacted — a gap is cheaper than a collision, and it keeps the
+  alignment with `report file`, where `4` is a body-section failure no verb here performs.
+- **Every list read pages and reports its scanned count** on stderr
+  ([`src/triage/scope.ts`](./src/triage/scope.ts)). A verdict driven by a silently truncated
+  read is a verdict over unknown scope; pagination fixes the reach, and printing what was
+  scanned is what makes the reach checkable from outside the process.
 
 ## The `eval` group
 

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -1,6 +1,7 @@
 /**
- * The GitHub surface the `report` verbs read and write: the intake queue, the search index, the
- * repository's label set, and the issue/comment writes plus their read-backs.
+ * The GitHub surface the `report` and `triage` verbs read and write: the intake queue, the search
+ * index, the repository's label set and open milestones, and the issue/comment writes plus their
+ * read-backs.
  *
  * Everything goes through `gh api` REST and **never GraphQL** — the org's Projects-classic
  * integration errors out GraphQL issue queries — and **every list read pages**: an unpaginated
@@ -149,11 +150,20 @@ export interface IssueRecord {
 	readonly state: string;
 	readonly labels: ReadonlyArray<string>;
 	readonly url: string;
+	/**
+	 * The assigned milestone's number, or `null` for an unhomed issue.
+	 *
+	 * A home write cannot be proven from the labels, so a read-back that does not carry this field
+	 * cannot tell "homed where I asked" from "not homed at all".
+	 */
+	readonly milestone: number | null;
+	/** `completed` / `not_planned` on a closed issue, `null` otherwise. A kill's read-back reads it. */
+	readonly stateReason: string | null;
 }
 
 const toIssueRecord = (value: unknown): IssueRecord | null => {
 	if (!isRecord(value)) return null;
-	const {number, title, body, state, labels, html_url: url} = value;
+	const {number, title, body, state, labels, html_url: url, milestone, state_reason} = value;
 	if (typeof number !== "number" || typeof title !== "string" || typeof url !== "string") {
 		return null;
 	}
@@ -168,6 +178,9 @@ const toIssueRecord = (value: unknown): IssueRecord | null => {
 		state: typeof state === "string" ? state : "",
 		labels: names as ReadonlyArray<string>,
 		url,
+		milestone:
+			isRecord(milestone) && typeof milestone.number === "number" ? milestone.number : null,
+		stateReason: typeof state_reason === "string" ? state_reason : null,
 	};
 };
 
@@ -259,4 +272,313 @@ export const getComment = (repo: string, id: number): Shell<Attempt<string>> =>
 		return isRecord(parsed) && typeof parsed.body === "string"
 			? ok(parsed.body)
 			: fail("`gh api` exited 0 but its output is not a comment");
+	});
+
+// ---------------------------------------------------------------------------------------------
+// The `triage` group's reads and writes, appended as one block so later verb slices extend the
+// file here without colliding with the `report` half above.
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Split `stdout` into rows of exactly `columns` tab-separated fields, or `null` when any line is not
+ * that shape.
+ *
+ * The wider sibling of {@link parseIssueRows}: same discipline, any column count. A shape that is
+ * not what was asked for is a failure, never an empty result — `gh` can exit 0 having printed a `jq`
+ * error, and interpreting those bytes positionally is how a malformed read answers a plausible
+ * value.
+ */
+export const parseTabRows = (
+	stdout: string,
+	columns: number,
+): ReadonlyArray<ReadonlyArray<string>> | null => {
+	const rows: ReadonlyArray<string>[] = [];
+	for (const line of stdout.split("\n")) {
+		if (line === "") continue;
+		const fields = line.split("\t");
+		if (fields.length !== columns) return null;
+		rows.push(fields);
+	}
+	return rows;
+};
+
+/** The leading field of every tab row as a non-negative integer — `null` if any is not one. */
+const leadingNumbers = (
+	rows: ReadonlyArray<ReadonlyArray<string>>,
+): ReadonlyArray<number> | null => {
+	const out: number[] = [];
+	for (const row of rows) {
+		const first = row[0];
+		if (first === undefined || !/^\d+$/.test(first)) return null;
+		out.push(Number.parseInt(first, 10));
+	}
+	return out;
+};
+
+/** One open milestone, as a home candidate. */
+export interface Milestone {
+	readonly number: number;
+	readonly title: string;
+}
+
+/**
+ * Every **open** milestone in `repo`, paged.
+ *
+ * The pagination is load-bearing rather than defensive: an unpaginated read caps candidates at
+ * GitHub's default page of 30 with no truncation signal, and "no home fits" is a conclusion that
+ * routes work toward a park or a close.
+ */
+export const listOpenMilestones = (repo: string): Shell<Attempt<ReadonlyArray<Milestone>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/milestones?state=open&per_page=100`,
+			"--jq",
+			'.[] | "\\(.number)\t\\(.title)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseTabRows(r.stdout, 2);
+		if (rows === null) return fail("`gh api` exited 0 but its output is not a list of milestones");
+		const numbers = leadingNumbers(rows);
+		if (numbers === null) {
+			return fail("`gh api` exited 0 but a milestone row does not start with a number");
+		}
+		return ok(rows.map((row, i) => ({number: numbers[i] as number, title: row[1] ?? ""})));
+	});
+
+/**
+ * Split `gh api --paginate`'s concatenated top-level JSON values back into one string per page.
+ *
+ * `--paginate` emits `[…][…]` with no separator, which `JSON.parse` rejects outright — so a
+ * single-parse read would fail on exactly the responses pagination exists to reach. Bracket depth is
+ * counted outside string literals only, so a `[` inside a comment body cannot split a page.
+ */
+export const splitJsonArrays = (stdout: string): ReadonlyArray<string> => {
+	const pages: string[] = [];
+	let depth = 0;
+	let start = -1;
+	let inString = false;
+	let escaped = false;
+	for (let i = 0; i < stdout.length; i++) {
+		const c = stdout[i];
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (c === "\\") escaped = true;
+			else if (c === '"') inString = false;
+			continue;
+		}
+		if (c === '"') inString = true;
+		else if (c === "[" || c === "{") {
+			if (depth === 0) start = i;
+			depth++;
+		} else if (c === "]" || c === "}") {
+			depth--;
+			if (depth === 0 && start >= 0) {
+				pages.push(stdout.slice(start, i + 1));
+				start = -1;
+			}
+		}
+	}
+	return pages;
+};
+
+/** One issue comment, as a claim scan reads it. */
+export interface CommentRecord {
+	readonly id: number;
+	readonly author: string;
+	readonly createdAt: string;
+	readonly body: string;
+}
+
+/**
+ * Every comment on `issue`, paged, oldest first.
+ *
+ * The bodies arrive as typed JSON rather than through `--jq .body`: a body carrying an unescaped
+ * control character makes `jq -r` error mid-stream, which inside a loop reads back as an empty
+ * comment rather than as a failure.
+ */
+export const listComments = (
+	repo: string,
+	issue: number,
+): Shell<Attempt<ReadonlyArray<CommentRecord>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues/${issue}/comments?per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const out: CommentRecord[] = [];
+		for (const page of splitJsonArrays(r.stdout)) {
+			const parsed = parseJson(page);
+			if (!Array.isArray(parsed)) {
+				return fail("`gh api` exited 0 but its output is not a list of comments");
+			}
+			for (const value of parsed) {
+				if (!isRecord(value) || typeof value.id !== "number") {
+					return fail("`gh api` exited 0 but one entry is not a comment");
+				}
+				const user = value.user;
+				out.push({
+					id: value.id,
+					author: isRecord(user) && typeof user.login === "string" ? user.login : "",
+					createdAt: typeof value.created_at === "string" ? value.created_at : "",
+					body: typeof value.body === "string" ? value.body : "",
+				});
+			}
+		}
+		return ok(out);
+	});
+
+/** Delete one issue comment — how a claim is retracted. */
+export const deleteComment = (repo: string, id: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"DELETE",
+			`repos/${repo}/issues/comments/${id}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** Replace an issue's body. The caller re-reads and compares; this call's echo is not evidence. */
+export const patchIssueBody = (repo: string, issue: number, body: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/issues/${issue}`,
+			"-f",
+			`body=${body}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** Add labels to an issue, leaving every label already on it in place. */
+export const addLabels = (
+	repo: string,
+	issue: number,
+	labels: ReadonlyArray<string>,
+): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		if (labels.length === 0) return ok(undefined);
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues/${issue}/labels`,
+			...labels.flatMap((l) => ["-f", `labels[]=${l}`]),
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/**
+ * Remove one label from an issue. `true` = it was removed, `false` = it was already absent.
+ *
+ * The 404 folds into the success channel deliberately: removal is idempotent, so a label that was
+ * not on the issue leaves the caller in exactly the state it asked for. Every other failure stays a
+ * failure — "I could not remove it" and "it is gone" are opposite facts.
+ */
+export const removeLabel = (repo: string, issue: number, label: string): Shell<Attempt<boolean>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"DELETE",
+			`repos/${repo}/issues/${issue}/labels/${encodeURIComponent(label)}`,
+		]);
+		if (r.ok) return ok(true);
+		return httpStatusOf(r.reason) === 404 ? ok(false) : fail(r.reason);
+	});
+
+/** Home an issue on a milestone by number. */
+export const setMilestone = (
+	repo: string,
+	issue: number,
+	milestone: number,
+): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/issues/${issue}`,
+			"-F",
+			`milestone=${milestone}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/**
+ * Clear an issue's milestone.
+ *
+ * `-F` is what sends a JSON `null`; the `-f` form would send the four-character string `"null"`,
+ * which the API rejects rather than reading as a clear.
+ */
+export const clearMilestone = (repo: string, issue: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/issues/${issue}`,
+			"-F",
+			"milestone=null",
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** Close an issue as `not_planned` — the only close spelling a kill may use. */
+export const closeNotPlanned = (repo: string, issue: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/issues/${issue}`,
+			"-f",
+			"state=closed",
+			"-f",
+			"state_reason=not_planned",
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** An issue or pull request that references this one, from the timeline. */
+export interface CrossReference {
+	readonly number: number;
+	readonly isPullRequest: boolean;
+}
+
+/**
+ * The `cross-referenced` entries of an issue's timeline, paged — what already points at this issue.
+ *
+ * A split child is keyed on its parent back-reference, so this read is what makes creating one
+ * idempotent: an existing cross-reference is the evidence the child is already there.
+ */
+export const issueTimeline = (
+	repo: string,
+	issue: number,
+): Shell<Attempt<ReadonlyArray<CrossReference>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues/${issue}/timeline?per_page=100`,
+			"--jq",
+			'.[] | select(.event == "cross-referenced") | "\\(.source.issue.number)\t\\(.source.issue.pull_request != null)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseTabRows(r.stdout, 2);
+		if (rows === null) return fail("`gh api` exited 0 but its output is not a timeline");
+		const numbers = leadingNumbers(rows);
+		if (numbers === null) {
+			return fail("`gh api` exited 0 but a timeline row does not start with an issue number");
+		}
+		return ok(
+			rows.map((row, i) => ({number: numbers[i] as number, isPullRequest: row[1] === "true"})),
+		);
 	});

--- a/packages/fabrika-cli/src/io/issues.unit.test.ts
+++ b/packages/fabrika-cli/src/io/issues.unit.test.ts
@@ -1,0 +1,262 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {
+	addLabels,
+	clearMilestone,
+	closeNotPlanned,
+	deleteComment,
+	getIssue,
+	issueTimeline,
+	listComments,
+	listOpenMilestones,
+	parseTabRows,
+	patchIssueBody,
+	removeLabel,
+	setMilestone,
+	splitJsonArrays,
+} from "./issues.ts";
+
+const run = <A>(effect: Effect.Effect<A, never, never>) => Effect.runPromise(effect);
+
+describe("parseTabRows — shape before interpretation", () => {
+	it("reads rows of exactly the asked-for column count", () => {
+		expect(parseTabRows("1\ta\n2\tb\n", 2)).toEqual([
+			["1", "a"],
+			["2", "b"],
+		]);
+	});
+
+	it("reads no rows as an empty FACT, not a failure", () => {
+		expect(parseTabRows("", 2)).toEqual([]);
+	});
+
+	it("returns null when a row has the wrong number of fields — either way", () => {
+		expect(parseTabRows("1\ta\tb\n", 2)).toBeNull();
+		expect(parseTabRows("1\n", 2)).toBeNull();
+	});
+});
+
+describe("splitJsonArrays", () => {
+	it("splits the concatenated pages `--paginate` emits, which JSON.parse rejects whole", () => {
+		expect(() => JSON.parse("[1][2]")).toThrow();
+		expect(splitJsonArrays("[1][2]")).toEqual(["[1]", "[2]"]);
+	});
+
+	it("does not split on a bracket inside a string — a body may contain one", () => {
+		expect(splitJsonArrays('[{"body":"see [1] and ]"}]')).toEqual(['[{"body":"see [1] and ]"}]']);
+	});
+
+	it("does not split on an escaped quote inside a string", () => {
+		expect(splitJsonArrays('[{"body":"a \\" ] b"}]')).toEqual(['[{"body":"a \\" ] b"}]']);
+	});
+});
+
+describe("getIssue carries the two facets a read-back cannot prove from labels", () => {
+	it("reads the milestone number and the state reason", async () => {
+		const body = JSON.stringify({
+			number: 7,
+			title: "t",
+			html_url: "u",
+			state: "closed",
+			state_reason: "not_planned",
+			labels: [],
+			milestone: {number: 44, title: "fabrika campaign"},
+		});
+		const result = await run(
+			Effect.provide(getIssue("kamp-us/phoenix", 7), fakeShell([[/gh api/, okOut(body)]]).layer),
+		);
+		expect(result).toMatchObject({
+			_tag: "Present",
+			value: {milestone: 44, stateReason: "not_planned"},
+		});
+	});
+
+	it("reads an unhomed, open issue as null on both — absence, not a guess", async () => {
+		const body = JSON.stringify({
+			number: 7,
+			title: "t",
+			html_url: "u",
+			state: "open",
+			state_reason: null,
+			labels: [],
+			milestone: null,
+		});
+		const result = await run(
+			Effect.provide(getIssue("kamp-us/phoenix", 7), fakeShell([[/gh api/, okOut(body)]]).layer),
+		);
+		expect(result).toMatchObject({_tag: "Present", value: {milestone: null, stateReason: null}});
+	});
+});
+
+describe("listOpenMilestones", () => {
+	it("pages, and asks only for open milestones", async () => {
+		const shell = fakeShell([[/gh api/, okOut("24\tGeçit\n44\tfabrika campaign\n")]]);
+		const result = await run(Effect.provide(listOpenMilestones("kamp-us/phoenix"), shell.layer));
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [
+				{number: 24, title: "Geçit"},
+				{number: 44, title: "fabrika campaign"},
+			],
+		});
+		expect(shell.calls[0]).toContain("--paginate");
+		expect(shell.calls[0]).toContain("per_page=100");
+		expect(shell.calls[0]).toContain("state=open");
+	});
+
+	it("refuses rather than returning a short list when the read fails", async () => {
+		const result = await run(
+			Effect.provide(
+				listOpenMilestones("kamp-us/phoenix"),
+				fakeShell([[/gh api/, errOut("gh: Bad gateway (HTTP 502)")]]).layer,
+			),
+		);
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("refuses on a 0 exit whose bytes are not milestone rows", async () => {
+		const result = await run(
+			Effect.provide(
+				listOpenMilestones("kamp-us/phoenix"),
+				fakeShell([[/gh api/, okOut("not-a-number\ttitle\n")]]).layer,
+			),
+		);
+		expect(result._tag).toBe("Failure");
+	});
+});
+
+describe("listComments", () => {
+	const comment = (id: number, login: string, body: string) =>
+		JSON.stringify({id, user: {login}, created_at: "2026-08-03T09:28:41Z", body});
+
+	it("reads every page, in order", async () => {
+		const shell = fakeShell([
+			[/gh api/, okOut(`[${comment(1, "usirin", "first")}][${comment(2, "cansirin", "second")}]`)],
+		]);
+		const result = await run(Effect.provide(listComments("kamp-us/phoenix", 4831), shell.layer));
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [
+				{id: 1, author: "usirin", createdAt: "2026-08-03T09:28:41Z", body: "first"},
+				{id: 2, author: "cansirin", createdAt: "2026-08-03T09:28:41Z", body: "second"},
+			],
+		});
+		expect(shell.calls[0]).toContain("--paginate");
+	});
+
+	it("carries a body holding a control character, which `--jq -r` cannot", async () => {
+		const shell = fakeShell([[/gh api/, okOut(`[${comment(1, "usirin", "a\nb")}]`)]]);
+		const result = await run(Effect.provide(listComments("kamp-us/phoenix", 1), shell.layer));
+		expect(result).toMatchObject({_tag: "Ok", value: [{body: "a\nb"}]});
+		expect(shell.calls[0]).not.toContain("--jq");
+	});
+
+	it("refuses on an entry that is not a comment", async () => {
+		const result = await run(
+			Effect.provide(
+				listComments("kamp-us/phoenix", 1),
+				fakeShell([[/gh api/, okOut('[{"message":"Not Found"}]')]]).layer,
+			),
+		);
+		expect(result._tag).toBe("Failure");
+	});
+});
+
+describe("removeLabel splits `it is gone` from `I could not remove it`", () => {
+	it("reports false — not a failure — when the label was already absent", async () => {
+		const result = await run(
+			Effect.provide(
+				removeLabel("kamp-us/phoenix", 1, "status:needs-triage"),
+				fakeShell([[/gh api/, errOut("gh: Label does not exist (HTTP 404)")]]).layer,
+			),
+		);
+		expect(result).toEqual({_tag: "Ok", value: false});
+	});
+
+	it("fails on any other error — an unreachable GitHub is not a removal", async () => {
+		const result = await run(
+			Effect.provide(
+				removeLabel("kamp-us/phoenix", 1, "status:needs-triage"),
+				fakeShell([[/gh api/, errOut("gh: Bad gateway (HTTP 502)")]]).layer,
+			),
+		);
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("escapes the label name into the path", async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(Effect.provide(removeLabel("kamp-us/phoenix", 1, "type:bug"), shell.layer));
+		expect(shell.calls[0]).toContain("labels/type%3Abug");
+	});
+});
+
+describe("the writes send the fields the API needs, in the form it accepts", () => {
+	it("addLabels adds rather than replaces, and spawns nothing for an empty list", async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(Effect.provide(addLabels("kamp-us/phoenix", 1, ["type:bug", "p1"]), shell.layer));
+		expect(shell.calls[0]).toContain("--method POST");
+		expect(shell.calls[0]).toContain("labels[]=type:bug");
+		expect(shell.calls[0]).toContain("labels[]=p1");
+
+		const empty = fakeShell([[/gh api/, okOut("")]]);
+		const result = await run(Effect.provide(addLabels("kamp-us/phoenix", 1, []), empty.layer));
+		expect(result._tag).toBe("Ok");
+		expect(empty.calls).toEqual([]);
+	});
+
+	it("setMilestone sends the number as a typed field", async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(Effect.provide(setMilestone("kamp-us/phoenix", 1, 44), shell.layer));
+		expect(shell.calls[0]).toContain("--method PATCH");
+		expect(shell.calls[0]).toContain("-F milestone=44");
+	});
+
+	it('clearMilestone sends a JSON null, not the string "null"', async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(Effect.provide(clearMilestone("kamp-us/phoenix", 1), shell.layer));
+		expect(shell.calls[0]).toContain("-F milestone=null");
+		expect(shell.calls[0]).not.toContain("-f milestone=null");
+	});
+
+	it("closeNotPlanned states the reason — a bare close reads as completed", async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(Effect.provide(closeNotPlanned("kamp-us/phoenix", 1), shell.layer));
+		expect(shell.calls[0]).toContain("state=closed");
+		expect(shell.calls[0]).toContain("state_reason=not_planned");
+	});
+
+	it("patchIssueBody and deleteComment surface the failure rather than swallowing it", async () => {
+		const failing = fakeShell([[/gh api/, errOut("gh: Bad gateway (HTTP 502)")]]).layer;
+		expect((await run(Effect.provide(patchIssueBody("r/r", 1, "b"), failing)))._tag).toBe(
+			"Failure",
+		);
+		expect((await run(Effect.provide(deleteComment("r/r", 9), failing)))._tag).toBe("Failure");
+	});
+});
+
+describe("issueTimeline", () => {
+	it("pages, and tells a referencing PR from a referencing issue", async () => {
+		const shell = fakeShell([[/gh api/, okOut("4832\ttrue\n4706\tfalse\n")]]);
+		const result = await run(Effect.provide(issueTimeline("kamp-us/phoenix", 4831), shell.layer));
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [
+				{number: 4832, isPullRequest: true},
+				{number: 4706, isPullRequest: false},
+			],
+		});
+		expect(shell.calls[0]).toContain("--paginate");
+		expect(shell.calls[0]).toContain("cross-referenced");
+	});
+
+	it("refuses on a read that failed — an empty timeline would read as `no twin exists`", async () => {
+		const result = await run(
+			Effect.provide(
+				issueTimeline("kamp-us/phoenix", 1),
+				fakeShell([[/gh api/, errOut("gh: Bad gateway (HTTP 502)")]]).layer,
+			),
+		);
+		expect(result._tag).toBe("Failure");
+	});
+});

--- a/packages/fabrika-cli/src/io/issues.unit.test.ts
+++ b/packages/fabrika-cli/src/io/issues.unit.test.ts
@@ -226,6 +226,24 @@ describe("the writes send the fields the API needs, in the form it accepts", () 
 		expect(shell.calls[0]).toContain("state_reason=not_planned");
 	});
 
+	it("patchIssueBody writes the body field — a `title=` here would overwrite the title", async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(
+			Effect.provide(patchIssueBody("kamp-us/phoenix", 7, "enriched-body-text"), shell.layer),
+		);
+		expect(shell.calls[0]).toContain("--method PATCH");
+		expect(shell.calls[0]).toContain("repos/kamp-us/phoenix/issues/7");
+		expect(shell.calls[0]).toContain("-f body=enriched-body-text");
+		expect(shell.calls[0]).not.toContain("title=");
+	});
+
+	it("deleteComment targets the id it was given — an off-by-one deletes someone else's", async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(Effect.provide(deleteComment("kamp-us/phoenix", 5170139674), shell.layer));
+		expect(shell.calls[0]).toContain("--method DELETE");
+		expect(shell.calls[0]).toContain("repos/kamp-us/phoenix/issues/comments/5170139674");
+	});
+
 	it("patchIssueBody and deleteComment surface the failure rather than swallowing it", async () => {
 		const failing = fakeShell([[/gh api/, errOut("gh: Bad gateway (HTTP 502)")]]).layer;
 		expect((await run(Effect.provide(patchIssueBody("r/r", 1, "b"), failing)))._tag).toBe(

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -18,9 +18,15 @@ import type {Command} from "effect/unstable/cli";
 import {adrCommand} from "./adr/command.ts";
 import {evalCommand} from "./eval/command.ts";
 import {reportCommand} from "./report/command.ts";
+import {triageCommand} from "./triage/command.ts";
 
 /** A registered verb group: a top-level `Command` whose name is the `fabrika <name>` selector. */
 export type VerbGroup = Command.Command<any, any, object, unknown, NodeServices.NodeServices>;
 
 /** The registered groups, in the order they list under `--help`. */
-export const registeredGroups: ReadonlyArray<VerbGroup> = [adrCommand, evalCommand, reportCommand];
+export const registeredGroups: ReadonlyArray<VerbGroup> = [
+	adrCommand,
+	evalCommand,
+	reportCommand,
+	triageCommand,
+];

--- a/packages/fabrika-cli/src/triage/codes-verb.ts
+++ b/packages/fabrika-cli/src/triage/codes-verb.ts
@@ -1,0 +1,26 @@
+/**
+ * `triage codes` — print the group's shared exit taxonomy.
+ *
+ * The group allocates from one table, which means a caller driving several verbs has to know
+ * thirteen numbers that no single `--help` page states: each verb's own help enumerates only the
+ * codes *it* can reach. This verb prints the table itself, so the shipped meanings are readable at
+ * runtime from the binary that owns them rather than from a document that can drift out of step with
+ * it.
+ *
+ * It touches no repository and performs no read, which is why it takes no `--repo`.
+ */
+import {answer, type VerbOutcome} from "../verb.ts";
+import {DELIBERATE_GAP, TRIAGE_EXIT_TABLE} from "./codes.ts";
+
+export interface CodesInput {
+	readonly json: boolean;
+}
+
+const GAP_NOTE = `triage codes: ${DELIBERATE_GAP} is unallocated — it once fused "proven absent" with "unreadable", which 7 and 11 now split.`;
+
+export const runCodes = ({json}: CodesInput): VerbOutcome => {
+	const stdout = json
+		? `${JSON.stringify({gap: DELIBERATE_GAP, codes: TRIAGE_EXIT_TABLE})}\n`
+		: `${TRIAGE_EXIT_TABLE.map((row) => `${row.code}\t${row.meaning}`).join("\n")}\n`;
+	return answer(stdout, [GAP_NOTE]);
+};

--- a/packages/fabrika-cli/src/triage/codes-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/codes-verb.unit.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from "vitest";
+import {ANSWER} from "../verb.ts";
+import {DELIBERATE_GAP, TRIAGE_EXIT_TABLE} from "./codes.ts";
+import {runCodes} from "./codes-verb.ts";
+
+describe("runCodes", () => {
+	it("prints one `<code>\\t<meaning>` line per allocated code", () => {
+		const outcome = runCodes({json: false});
+		const lines = outcome.stdout.trimEnd().split("\n");
+		expect(lines).toHaveLength(TRIAGE_EXIT_TABLE.length);
+		expect(lines[0]).toBe("0\tthe answer is on stdout");
+		expect(lines.at(-1)).toBe("127\tthe verb never ran (unresolved binary)");
+	});
+
+	it("emits the table on stdout and the gap note on stderr — the answer channel is machine-only", () => {
+		const outcome = runCodes({json: false});
+		expect(outcome.stdout).not.toContain("unallocated");
+		expect(outcome.stderr.join("\n")).toContain(`${DELIBERATE_GAP} is unallocated`);
+	});
+
+	it("swaps the line grammar for one JSON object under --json", () => {
+		const outcome = runCodes({json: true});
+		expect(outcome.stdout).not.toContain("\t");
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			gap: DELIBERATE_GAP,
+			codes: TRIAGE_EXIT_TABLE,
+		});
+	});
+
+	it("always exits 0 — it reads nothing that could refuse", () => {
+		expect(runCodes({json: false}).code).toBe(ANSWER);
+		expect(runCodes({json: true}).code).toBe(ANSWER);
+	});
+});

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -1,0 +1,125 @@
+/**
+ * The one exit table all nine `triage` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (see `../verb.ts` and the exit-2
+ * bootstrap in `../bin.ts`); everything else here is `3` and up, the band a verb owns for outcomes
+ * it PROVED.
+ *
+ * **The alignment with `report` is deliberate and code-for-code.** Where this table overlaps
+ * `report`'s two writing verbs — `3`, `5`, `6`, `7`, `8`, `9`, `10`, `11` — the meanings match
+ * `../report/codes.ts` exactly, so a caller driving `report` and `triage` in one sweep reads one
+ * meaning. That alignment does **not** extend repo-wide: `adr` allocates per verb, and `report
+ * dedup`'s own `3`/`4` are *queue unreadable* / *search index unreadable*.
+ *
+ * **`4` is a deliberate gap, not a free slot.** It once held "the target issue does not exist, or is
+ * not readable" — a proven fact and an unknown fused into one code. {@link ZERO_SCOPE} and
+ * {@link PRECONDITION_UNKNOWN} took the halves; leaving `4` unallocated keeps the alignment with
+ * `report file`, where it is a body-section failure no verb here performs.
+ */
+
+/** The answer is on stdout. Restated here because {@link TRIAGE_EXIT_TABLE} spans the whole matrix. */
+const ANSWER = 0;
+/** Usage error, an unresolvable repo, or the verb failed to run. */
+const FAILED = 1;
+/** No implementation could be resolved — the dependency graph never loaded (`../bin.ts`). */
+const NO_IMPLEMENTATION = 2;
+
+/** Stdin was read and held nothing. Distinct from a read that failed, which is `1`. */
+export const EMPTY_STDIN = 3;
+/** The **authored** text carries a machine-local path and it was not redacted. */
+export const LEAKED_PATH = 5;
+/**
+ * The **authored** text is a bare `@` path reference — **not** redactable.
+ *
+ * Separate from {@link LEAKED_PATH} because the fixes are opposite: the caller's loop on a path
+ * refusal is *redact and re-send*, and on a body that IS a path that loop never terminates.
+ */
+export const BARE_AT_PATH = 6;
+/**
+ * Zero scope: a read that succeeded over nothing, an absent label vocabulary, or a target issue
+ * **proven absent (404)** or closed — a fail-closed refusal (ADR 0092).
+ *
+ * *Proven* is the operative word. A 404 is a fact about the repository; an unreachable GitHub is not
+ * a fact about anything, and lands on {@link PRECONDITION_UNKNOWN} instead.
+ */
+export const ZERO_SCOPE = 7;
+/**
+ * The write itself failed, so the outcome is **UNKNOWN** — deliberately not `1`.
+ *
+ * A create or PATCH that times out may or may not have landed. Seating that on `1` would make
+ * "GitHub refused the write" indistinguishable from "the binary is broken", which is the
+ * verdict-versus-invocation collision the reserved range exists to prevent (#4208, #4219). Each
+ * message carries its recovery instruction, because a blind retry is how one split becomes two
+ * children.
+ */
+export const WRITE_UNKNOWN = 8;
+/** The write landed but the read-back does not match. The artifact exists and needs a human. */
+export const READBACK_MISMATCH = 9;
+/**
+ * The supplied classification value is not permitted in this position — off a closed enum, or a
+ * `--home` naming a milestone that is not open.
+ *
+ * The superset that keeps `report`'s reading true: there `10` is a title or `--label` carrying a
+ * type or priority. A closed milestone is an off-vocabulary home, so it belongs with the enum
+ * refusals rather than with the shape errors.
+ */
+export const OFF_VOCABULARY = 10;
+/** A precondition read failed — nothing was written and no outcome is proven. `report`'s `11`. */
+export const PRECONDITION_UNKNOWN = 11;
+/**
+ * Refused: the issue is human-filed.
+ *
+ * `12`, not `11`, because `11` already means `PRECONDITION_UNKNOWN` in the shipped `report` table
+ * this group aligns to. Issue #4831's acceptance criteria state `11`/`12` for this pair; the merged
+ * contract's `12`/`13` wins, and the divergence is disclosed rather than silently resolved.
+ */
+export const HUMAN_FILED = 12;
+/** Refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159). */
+export const UNCONFIRMED = 13;
+
+/** The verb never ran (unresolved binary). The shell's, not this process's — no constant owns it. */
+const NEVER_RAN = 127;
+
+/** One row of the shared matrix: a code and the single meaning it carries across the group. */
+export interface ExitCodeRow {
+	readonly code: number;
+	readonly meaning: string;
+}
+
+/**
+ * The whole matrix in ascending order — the machine-readable form of the contract's table.
+ *
+ * The reserved rows sit here beside the allocated ones because the matrix owns what a code *means*
+ * while each verb's `--help` owns what *triggers* it. `4` is absent: it is unallocated, and a row
+ * for it would be a meaning.
+ */
+export const TRIAGE_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
+	{code: ANSWER, meaning: "the answer is on stdout"},
+	{code: FAILED, meaning: "usage error, unresolvable repo, or the verb failed to run"},
+	{code: NO_IMPLEMENTATION, meaning: "no implementation could be resolved"},
+	{code: EMPTY_STDIN, meaning: "stdin was read and held nothing"},
+	{code: LEAKED_PATH, meaning: "the authored text carries a machine-local path"},
+	{code: BARE_AT_PATH, meaning: "the authored text is a bare @ path reference — not redactable"},
+	{
+		code: ZERO_SCOPE,
+		meaning:
+			"zero scope: a read that succeeded over nothing, an absent label vocabulary, or a target issue proven absent (404) or closed",
+	},
+	{code: WRITE_UNKNOWN, meaning: "the write itself failed — the outcome is UNKNOWN"},
+	{code: READBACK_MISMATCH, meaning: "the write landed but the read-back does not match"},
+	{code: OFF_VOCABULARY, meaning: "the supplied classification value is not permitted here"},
+	{
+		code: PRECONDITION_UNKNOWN,
+		meaning: "a precondition read failed — nothing was written and the outcome is UNKNOWN",
+	},
+	{code: HUMAN_FILED, meaning: "refused: the issue is human-filed"},
+	{
+		code: UNCONFIRMED,
+		meaning: "refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159)",
+	},
+	{code: NEVER_RAN, meaning: "the verb never ran (unresolved binary)"},
+];
+
+/** The unallocated code, named so the gap is legible rather than looking like an oversight. */
+export const DELIBERATE_GAP = 4;

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -121,5 +121,5 @@ export const TRIAGE_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
 	{code: NEVER_RAN, meaning: "the verb never ran (unresolved binary)"},
 ];
 
-/** The unallocated code, named so the gap is legible rather than looking like an oversight. */
+/** The unallocated code — see the gap note at the top of this file. */
 export const DELIBERATE_GAP = 4;

--- a/packages/fabrika-cli/src/triage/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/codes.unit.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from "vitest";
+import * as report from "../report/codes.ts";
+import {
+	BARE_AT_PATH,
+	DELIBERATE_GAP,
+	EMPTY_STDIN,
+	HUMAN_FILED,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TRIAGE_EXIT_TABLE,
+	UNCONFIRMED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+
+/**
+ * The alignment is asserted against the shipped `report` constants, not against copied literals — a
+ * test over `expect(LEAKED_PATH).toBe(5)` would stay green while the two tables drifted apart, which
+ * is the only failure this alignment exists to prevent.
+ */
+describe("the overlap with `report`'s writing verbs is code-for-code", () => {
+	it.each([
+		["EMPTY_STDIN", EMPTY_STDIN, report.EMPTY_STDIN],
+		["LEAKED_PATH", LEAKED_PATH, report.LEAKED_PATH],
+		["BARE_AT_PATH", BARE_AT_PATH, report.BARE_AT_PATH],
+		["ZERO_SCOPE / NO_TARGET", ZERO_SCOPE, report.NO_TARGET],
+		["WRITE_UNKNOWN", WRITE_UNKNOWN, report.WRITE_UNKNOWN],
+		["READBACK_MISMATCH", READBACK_MISMATCH, report.READBACK_MISMATCH],
+		["OFF_VOCABULARY / CLASSIFIED", OFF_VOCABULARY, report.CLASSIFIED],
+		["PRECONDITION_UNKNOWN", PRECONDITION_UNKNOWN, report.PRECONDITION_UNKNOWN],
+	])("`%s` sits on the same number in both groups", (_name, triage, shipped) => {
+		expect(triage).toBe(shipped);
+	});
+});
+
+describe("the two codes this group adds", () => {
+	it("seats the human-filed refusal clear of `report`'s shipped 11", () => {
+		expect(HUMAN_FILED).toBe(12);
+		expect(HUMAN_FILED).not.toBe(report.PRECONDITION_UNKNOWN);
+	});
+
+	it("seats the unconfirmed-kill refusal on its own code", () => {
+		expect(UNCONFIRMED).toBe(13);
+		expect(UNCONFIRMED).not.toBe(HUMAN_FILED);
+	});
+});
+
+describe("TRIAGE_EXIT_TABLE", () => {
+	const codes = TRIAGE_EXIT_TABLE.map((row) => row.code);
+
+	it("leaves 4 unallocated — a gap is cheaper than a collision", () => {
+		expect(DELIBERATE_GAP).toBe(4);
+		expect(codes).not.toContain(DELIBERATE_GAP);
+	});
+
+	it("carries every allocated code exactly once", () => {
+		expect(codes).toEqual([0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 127]);
+	});
+
+	it("gives every code a non-empty meaning", () => {
+		for (const row of TRIAGE_EXIT_TABLE) expect(row.meaning.length).toBeGreaterThan(0);
+	});
+
+	it("states each exported constant's meaning at its own number", () => {
+		const meaningOf = (code: number) => TRIAGE_EXIT_TABLE.find((row) => row.code === code)?.meaning;
+		expect(meaningOf(ZERO_SCOPE)).toContain("proven absent");
+		expect(meaningOf(PRECONDITION_UNKNOWN)).toContain("precondition read failed");
+		expect(meaningOf(HUMAN_FILED)).toContain("human-filed");
+		expect(meaningOf(UNCONFIRMED)).toContain("unconfirmed");
+	});
+});

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -1,0 +1,66 @@
+/**
+ * The `triage` verb group — `fabrika triage <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives
+ * in the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a
+ * process.
+ *
+ * This is the group's foundation slice: the shared exit table (`codes.ts`), the scanned-count
+ * convention (`scope.ts`) and the GitHub reads and writes in `../io/issues.ts` land here, ahead of
+ * the verbs that consume them. Later slices append their leaves below and extend the
+ * `withSubcommands` list at the end of the file, so two slices in flight touch different regions.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
+ * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ */
+import {Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runCodes} from "./codes-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+/**
+ * The two flags every verb in this group shares, declared once here.
+ *
+ * They are not imported from `../report/command.ts`: that module is an adapter, and a group reaching
+ * into a sibling group's adapter for a flag couples their `--help` text together. The wording is
+ * shared because the contract states it, not because the declaration is.
+ */
+export const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+export const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
+);
+
+const codes = leafCommand(
+	"codes",
+	{json: jsonFlag},
+	Effect.fn(function* ({json}) {
+		yield* emit(runCodes({json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Print the exit taxonomy every verb in this group allocates from, one `<code>\\t<meaning>` line per code. Reads nothing and always exits 0. Example: fabrika triage codes",
+	),
+);
+
+export const triageCommand = Command.make("triage").pipe(
+	Command.withSubcommands([codes]),
+	Command.withDescription(
+		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",
+	),
+);

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -8,8 +8,8 @@
  *
  * This is the group's foundation slice: the shared exit table (`codes.ts`), the scanned-count
  * convention (`scope.ts`) and the GitHub reads and writes in `../io/issues.ts` land here, ahead of
- * the verbs that consume them. Later slices append their leaves below and extend the
- * `withSubcommands` list at the end of the file, so two slices in flight touch different regions.
+ * the verbs that consume them. Later slices append their leaves below and add one line each to the
+ * `withSubcommands` list at the end of the file, which is why that list is one entry per line.
  *
  * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
  * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
@@ -59,7 +59,11 @@ const codes = leafCommand(
 );
 
 export const triageCommand = Command.make("triage").pipe(
-	Command.withSubcommands([codes]),
+	Command.withSubcommands([
+		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
+		// editing one. The comment is what keeps the formatter from collapsing the list back.
+		codes,
+	]),
 	Command.withDescription(
 		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",
 	),

--- a/packages/fabrika-cli/src/triage/scope.ts
+++ b/packages/fabrika-cli/src/triage/scope.ts
@@ -1,0 +1,28 @@
+/**
+ * The scanned-count line every `triage` verb that reads a list puts on stderr.
+ *
+ * The convention exists because a verdict driven by a silently truncated read is a verdict over
+ * unknown scope: the reads this group replaces lost home candidates past GitHub's default page of 30
+ * and truncated the queue at 100 with no signal at all. Pagination fixes the reach; **printing what
+ * was scanned is what makes the reach checkable from outside the process.**
+ *
+ * It lives here rather than in `../report/` because it is this group's convention — the `report`
+ * verbs compose their own scope lines and emit no scanned count.
+ */
+
+/**
+ * `<verb>: scanned <n> <noun>(s) in <repo>[; <note>].`
+ *
+ * The count comes first because it is the fact a caller greps for, and it is printed on **every**
+ * run — including the zero-scope refusals, where "what did you look at" is the whole question.
+ */
+export const scannedLine = (
+	verb: string,
+	repo: string,
+	scanned: number,
+	noun: string,
+	note?: string,
+): string =>
+	`${verb}: scanned ${scanned} ${noun}${scanned === 1 ? "" : "s"} in ${repo}${
+		note === undefined ? "" : `; ${note}`
+	}.`;

--- a/packages/fabrika-cli/src/triage/scope.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/scope.unit.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from "vitest";
+import {scannedLine} from "./scope.ts";
+
+describe("scannedLine", () => {
+	it("names the verb, the count, the noun and the repo", () => {
+		expect(scannedLine("queue", "kamp-us/phoenix", 12, "issue")).toBe(
+			"queue: scanned 12 issues in kamp-us/phoenix.",
+		);
+	});
+
+	it("prints a zero count rather than staying silent — the refusal is where scope matters most", () => {
+		expect(scannedLine("homes", "kamp-us/phoenix", 0, "milestone")).toBe(
+			"homes: scanned 0 milestones in kamp-us/phoenix.",
+		);
+	});
+
+	it("singularizes a count of one", () => {
+		expect(scannedLine("homes", "kamp-us/phoenix", 1, "milestone")).toBe(
+			"homes: scanned 1 milestone in kamp-us/phoenix.",
+		);
+	});
+
+	it("appends a note when one is given, and nothing when it is not", () => {
+		expect(scannedLine("queue", "kamp-us/phoenix", 3, "issue", "2 already claimed")).toBe(
+			"queue: scanned 3 issues in kamp-us/phoenix; 2 already claimed.",
+		);
+		expect(scannedLine("queue", "kamp-us/phoenix", 3, "issue")).not.toContain(";");
+	});
+});

--- a/packages/fabrika-cli/src/unknown-subcommand.cli.test.ts
+++ b/packages/fabrika-cli/src/unknown-subcommand.cli.test.ts
@@ -4,6 +4,9 @@
  * The unit tests cover the resolution; only a real process proves the code, and the code is the part
  * that carried the lie — `fabrika triage --help` exited 0 (#4822). An assertion on stdout alone would
  * have passed against the defect, because the defect printed help.
+ *
+ * The fixture token is no longer `triage`: that group is registered now, so reusing the reported
+ * token would assert the guard against a name that resolves.
  */
 import {execFileSync} from "node:child_process";
 import {fileURLToPath} from "node:url";
@@ -46,9 +49,9 @@ describe("an unresolvable path is refused, at every depth", {
 	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
 }, () => {
 	it.each([
-		["an unknown group", ["triage"]],
-		["an unknown group probed with --help", ["triage", "--help"]],
-		["an unknown group probed with -h", ["triage", "-h"]],
+		["an unknown group", ["nosuchgroup"]],
+		["an unknown group probed with --help", ["nosuchgroup", "--help"]],
+		["an unknown group probed with -h", ["nosuchgroup", "-h"]],
 		["an unknown verb in a known group", ["adr", "bogus"]],
 		["an unknown verb probed with --help", ["adr", "bogus", "--help"]],
 		["a multi-token invalid tail probed with --help", ["adr", "bogus", "deeper", "--help"]],

--- a/packages/fabrika-cli/src/unknown-subcommand.unit.test.ts
+++ b/packages/fabrika-cli/src/unknown-subcommand.unit.test.ts
@@ -102,9 +102,11 @@ describe("against the real fabrika command tree", () => {
 		expect(registeredGroups.length).toBeGreaterThan(0);
 	});
 
+	// The token used to be `triage`, which #4822 was reported against; registering that group turned
+	// this fixture green for the wrong reason, so it moved to a name no slice will ever claim.
 	it("refuses an unregistered group", () => {
-		expect(findUnknownSubcommand(fabrikaCommand, ["triage", "--help"])).toEqual({
-			token: "triage",
+		expect(findUnknownSubcommand(fabrikaCommand, ["nosuchgroup", "--help"])).toEqual({
+			token: "nosuchgroup",
 			path: ["fabrika"],
 			known: registeredGroups.map((group) => group.name),
 		});


### PR DESCRIPTION
The `/triage` skill needs nine CLI verbs, and all nine sit on the same handful of pieces: one exit-code table, one pagination convention, and a set of GitHub reads and writes that do not exist yet. This PR builds only those pieces, plus the `triage` group they hang off, so the verb slices that follow can be written and reviewed one at a time instead of as one 3,000-line drop. Nothing user-facing changes: `fabrika --help` gains a `triage` row, and the group's single registered verb prints the exit table.

This is **slice 1a** of #4831's six-slice build plan (see the build-plan comment on #4831). Slice 1b carries `queue`, `provenance`, `homes` and the `report dedup --exclude` rider; the remaining verbs follow in later slices.

Part of #4831

## What landed

- **`packages/fabrika-cli/src/triage/codes.ts`** — the one exit table all nine verbs allocate from. It matches `src/report/codes.ts` **code for code** on the eight they share (`3`, `5`, `6`, `7`, `8`, `9`, `10`, `11`), adds `12` (human-filed) and `13` (unconfirmed kill), and leaves `4` unallocated. `TRIAGE_EXIT_TABLE` is the machine-readable form of the contract's matrix.
- **`packages/fabrika-cli/src/triage/scope.ts`** — the `scanned <n> <noun>s in <repo>` stderr line the contract requires of every list read. The `report` verbs do not emit one; this is the `triage` group's convention.
- **`packages/fabrika-cli/src/io/issues.ts`** — the reads and writes later slices need, appended as one block at end-of-file: `listComments` (paged), `deleteComment`, `listOpenMilestones` (paged), `patchIssueBody`, `addLabels` / `removeLabel`, `setMilestone` / `clearMilestone`, `closeNotPlanned`, `issueTimeline` (paged, `cross-referenced`), plus the shared `parseTabRows` / `splitJsonArrays` helpers. `IssueRecord` gains `milestone` and `stateReason` — the two facets an `apply` / `park` / `kill` read-back cannot prove from labels.
- **`packages/fabrika-cli/src/triage/command.ts` + the registry row** — the group, with one leaf (`triage codes`) declared through `leafCommand`, and the `--repo` / `--json` flags later verbs share.

Every claim about platform behaviour here was checked against the live API, not assumed: the `timeline` endpoint's `cross-referenced` event shape, `milestones?state=open`, and `state_reason` on a closed issue were each read off `kamp-us/phoenix` before the parser was written.

## Deviations

**1. The contract's `kill` exit codes win over this issue's acceptance criteria — deliberately, and the AC checkbox reads as failed.**
Said: the AC states `triage kill` exits `11` on a human-filed issue and `12` on an unconfirmed one. Did: encoded `12` = human-filed and `13` = unconfirmed, leaving `11` as `PRECONDITION_UNKNOWN`. Why: `11` is the *shipped* meaning in `src/report/codes.ts` (`PRECONDITION_UNKNOWN`), and the merged contract says so explicitly — an earlier revision of the spec used `11` for the human-filed refusal, collided with the shipped table, and moved the pair to `12`/`13`. Taking the AC's numbering would fuse "a precondition read failed" with "this issue is human-filed" in the one group that exists to keep proven refusals separable. Disposition: contract encoded, conflict disclosed here rather than silently resolved. This is an open founder fork (Fork B on #4831); that AC checkbox failing is the expected reading, not a defect to repair.

**2. A tenth verb, `triage codes`, that the contract does not list.**
Said: the contract derives exactly nine verbs and records its rejected ones. Did: registered a tenth, `triage codes`, which prints the shared exit table and reads nothing. Why: a group registered with zero subcommands is read as a *leaf* by the shipped excess-operand coverage test (`src/excess-operand.unit.test.ts`), which then reds because a group declares no catch-all argument — so the group cannot register empty, and none of the nine is small enough to belong in a foundation slice. `codes` is the smallest verb that exercises registry → group → `leafCommand` → verb → emit end to end, and it answers a question no single `--help` page can (each verb's help lists only the codes *it* reaches). Disposition: for the reviewer to judge — if a tenth verb is unwanted, it can be dropped once slice 1b lands a real leaf.

**3. Two existing tests changed, because they used `triage` as a stand-in for an unregistered group.**
Said: nothing in the issue about touching `unknown-subcommand.unit.test.ts` / `.cli.test.ts`. Did: moved their fixture token from `triage` to `nosuchgroup` and noted why in each file. Why: those tests assert the unknown-subcommand guard refuses an unregistered group, and registering `triage` would have turned them green for the wrong reason (the token now resolves). The historical `#4822` citation is preserved. Disposition: no action needed — the guard's coverage is unchanged, only the fixture name moved.

**4. Two spec problems encoded as stated, not fixed.**
(a) The contract puts `triage claim`'s unset-session refusal on exit `1`, which shares a code with a failure to invoke — the very collision this group's reserved-range rule exists to prevent. Not resolvable here (no `claim` verb in this slice); flagged for the slice that builds it. (b) The matrix carries `2` and `127`, neither of which is a constant: `2` is emitted by `src/bin.ts`, and `127` is the shell's, so nothing in-process can produce it. Both appear as rows in `TRIAGE_EXIT_TABLE` (the matrix owns what a code *means*) and **no constant was invented for `127`**. Disposition: for the reviewer to judge.

**5. Most of #4831's acceptance criteria are unmet by this diff, by design.**
Said: eleven ACs, nine of them about the verbs. Did: delivered the substrate and one trivial verb. Why: two prior full-scope attempts on this issue died mid-run without pushing anything — one to a no-progress watchdog, one to a connection error — so the work was re-sliced deliberately smaller. Disposition: `Part of #4831` rather than `Fixes`, so the issue stays open; slices 1b onward carry the rest, tracked in the build-plan comment on #4831.

**6. Code carried over from the second (dead) attempt's uncommitted worktree.**
Said: nothing. Did: reused the shape of `codes.ts`, `scope.ts` and most of the `io/issues.ts` block from work a prior lane left uncommitted, after re-verifying each line against the merged contract and dropping what belongs to slice 1b (`openQueueIssues`). Why: it saved real time on an issue that has already burned two runs. Disposition: no action needed — everything kept is covered by tests in this PR and is owned here.

**7. (repair round 1) The multi-line `withSubcommands` list needs a comment inside the array to survive the formatter.**
Said: the gate's non-blocking note asked for "a multi-line array with trailing comma — the exact shape this PR already applied to `src/registry.ts`". Did: that, plus a two-line comment inside the array. Why: `registry.ts` stays multi-line only because its four entries exceed 100 columns; a one-element `[codes]` fits, and Biome collapses it straight back (verified — `biome check` printed the collapse diff). A comment inside the array is what holds the shape until the list grows. Disposition: no action needed; the comment can go once the list is long enough to break on its own. Related honest caveat, recorded rather than oversold: while the list is this short, two lanes still insert at the same point and still conflict — the shape starts paying off once entries land at distinct positions.

## Checks

- `pnpm typecheck` — 30/30 tasks pass.
- `pnpm lint:worktree` — clean.
- `pnpm vitest run` in `packages/fabrika-cli` — 604 tests, 45 files, all pass (602 before repair round 1).
- Repair round 1 mutation re-runs, both **RED**: `patchIssueBody` sending `title=` instead of `body=`; `deleteComment` targeting `${id + 1}`.
- Falsifiability spot-check: reverting `clearMilestone`'s `-F` to `-f` reds `clearMilestone sends a JSON null, not the string "null"`.
