### PR TITLE
feat(fabrika): triage kill — close an agent-filed issue not-planned over four gated writes (slice 6 of #4831)

### DIFF
--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -22,6 +22,7 @@ import type {VerbOutcome} from "../verb.ts";
 import {runApply} from "./apply-verb.ts";
 import {runCodes} from "./codes-verb.ts";
 import {AUDIENCES, PRIORITIES, STANDING_LANES, TYPES} from "./facets.ts";
+import {runKill} from "./kill-verb.ts";
 import {runPark} from "./park-verb.ts";
 import {runSplit} from "./split-verb.ts";
 
@@ -60,6 +61,48 @@ const codes = leafCommand(
 ).pipe(
 	Command.withDescription(
 		"Print the exit taxonomy every verb in this group allocates from, one `<code>\\t<meaning>` line per code. Reads nothing and always exits 0. Example: fabrika triage codes",
+	),
+);
+
+const kill = leafCommand(
+	"kill",
+	{
+		issue: Argument.integer("issue").pipe(
+			Argument.withDescription("the issue to close not-planned"),
+		),
+		// Optional at the parser and refused at the verb, deliberately: a parser-required flag's
+		// absence is a usage error indistinguishable from a typo, and ADR 0159's confirmation is a
+		// decision whose absence must be a proven refusal (exit 13).
+		confirm: Flag.boolean("confirm").pipe(
+			Flag.withDescription(
+				"assert that salvage was attempted and this filing is genuinely unsalvageable (ADR 0159); its absence is a refusal on 13, not a usage error",
+			),
+		),
+		duplicateOf: Flag.integer("duplicate-of").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the surviving issue; this issue's body is folded into it, leak-redacted, before the close",
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, confirm, duplicateOf, repo, json}) {
+		yield* emit(
+			yield* runKill({
+				issue,
+				confirm,
+				duplicateOf: Option.getOrNull(duplicateOf),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Close an agent-filed issue not-planned over four gated writes — the optional redacted duplicate fold, the reason from STDIN, the closed-by-triage label, then the close — and read back that it says not_planned. Prints `killed\\t<number>\\t<foldedInto|none>`. Exits 3 (empty stdin), 5 (machine-local path in the reason), 6 (bare @ reference), 7 (issue absent or closed, duplicate absent or closed, or no closed-by-triage label), 8 (a write failed — UNKNOWN), 9 (read-back is not a not-planned close), 11 (a precondition read failed), 12 (human-filed), 13 (unconfirmed). Example: fabrika triage kill 4312 --confirm --duplicate-of 4290 < reason.md",
 	),
 );
 
@@ -182,6 +225,7 @@ export const triageCommand = Command.make("triage").pipe(
 		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
 		// editing one. The comment is what keeps the formatter from collapsing the list back.
 		codes,
+		kill,
 		split,
 		apply,
 		park,

--- a/packages/fabrika-cli/src/triage/kill-verb.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.ts
@@ -1,0 +1,284 @@
+/**
+ * `triage kill` — close an agent-filed issue not-planned, auditably.
+ *
+ * This is the group's only irreversible act on a public board, which shapes every decision below:
+ * no precondition resolves to a plausible value, and no write runs before all of them are proven.
+ *
+ * **Two guards, and they are different guards (ADR 0159).** A missing footer means the issue is
+ * human-owned and the verb refuses outright; a present footer makes it *eligible*, not closeable — a
+ * human-invoked `/report` emits the same footer, so `--confirm` is the confirmation step made
+ * structural. That is why `--confirm` is optional at the parser and refused at the verb: a
+ * parser-required flag's absence is a usage error, indistinguishable from a typo, while ADR 0159's
+ * confirmation is a decision whose absence must be a proven refusal a caller can read as one.
+ *
+ * **Write order is the auditability guarantee.** Fold the duplicate content, post the reason, apply
+ * `closed-by-triage`, then close — and each step gates the next, so a failure before the close
+ * leaves the issue OPEN, which is the recoverable direction. The three unguarded sequential writes
+ * this replaces landed a closed, unexplained, unlabelled issue whenever the middle one failed.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	addLabels,
+	closeNotPlanned,
+	createComment,
+	getIssue,
+	type IssueRecord,
+	listLabels,
+	resolveRepo,
+} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	HUMAN_FILED,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	UNCONFIRMED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {provenanceOf} from "./provenance.ts";
+import {scannedLine} from "./scope.ts";
+
+/** The label a kill is audited by. Its absence in the repo is a zero-scope refusal, not a create. */
+export const KILL_LABEL = "closed-by-triage";
+
+export interface KillOptions {
+	readonly issue: number;
+	/** ADR 0159's confirmation. Absent ⇒ a proven refusal on `13`, never a usage error. */
+	readonly confirm: boolean;
+	readonly duplicateOf: number | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+const isIssueNumber = (n: number): boolean => Number.isInteger(n) && n > 0;
+
+export const runKill = (
+	options: KillOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, duplicateOf, json} = options;
+
+		if (!isIssueNumber(issue)) {
+			return refuse(FAILED, `triage kill: ${issue} is not an issue number.`);
+		}
+		if (duplicateOf !== null && !isIssueNumber(duplicateOf)) {
+			return refuse(FAILED, `triage kill: --duplicate-of ${duplicateOf} is not an issue number.`);
+		}
+		if (duplicateOf === issue) {
+			return refuse(
+				FAILED,
+				`triage kill: --duplicate-of #${issue} is the issue being killed — refusing to fold it into itself.`,
+			);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"triage kill: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`triage kill: could not read stdin: ${read.reason} — the reason is UNKNOWN, never empty.`,
+			);
+		}
+		const reason = read._tag === "NoStdin" ? "" : read.text;
+		if (reason.trim() === "") {
+			return refuse(EMPTY_STDIN, "triage kill: no reason on stdin — refusing an unauditable kill.");
+		}
+
+		if (isBareAtReference(reason)) {
+			return refuse(
+				BARE_AT_PATH,
+				'triage kill: the reason is a bare "@" path reference — it never arrived. Send it on stdin.',
+			);
+		}
+
+		// The reason is authored text, so a leak in it is refusable — the author can fix it. The
+		// duplicate's body below is foreign content being preserved, so it is redacted instead. That
+		// asymmetry is the whole of the leak design (`../report/leaks.ts`).
+		const reasonScan = scanBody(reason);
+		const firstLeak = reasonScan.leaks[0];
+		if (firstLeak !== undefined) {
+			return refuse(
+				LEAKED_PATH,
+				`triage kill: the reason carries a machine-local path at line ${firstLeak.line} (${firstLeak.class}) — rewrite it repo-relative.`,
+				renderLeaks(reasonScan.leaks),
+			);
+		}
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `triage kill: issue #${issue} not found in ${repo}.`);
+		}
+		if (target._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`triage kill: cannot read #${issue} in ${repo}: ${target.reason} — the provenance test has no evidence; refusing to close on a body that was never read.`,
+			);
+		}
+		if (target.value.state === "closed") {
+			return refuse(ZERO_SCOPE, `triage kill: issue #${issue} is already closed.`);
+		}
+
+		const emptyBodyNotice =
+			target.value.body.trim() === ""
+				? [
+						`triage kill: #${issue} has an empty body — reading its provenance as human (fail-closed).`,
+					]
+				: [];
+
+		const provenance = provenanceOf(target.value.body);
+		if (provenance === "human") {
+			return refuse(
+				HUMAN_FILED,
+				`triage kill: #${issue} is human-filed — refusing to close it. Park it with questions instead.`,
+				emptyBodyNotice,
+			);
+		}
+
+		if (!options.confirm) {
+			return refuse(
+				UNCONFIRMED,
+				`triage kill: #${issue} is agent-filed and close-eligible, but ADR 0159 makes the confirmation the guard — pass --confirm once salvage has genuinely been attempted.`,
+			);
+		}
+
+		let duplicate: IssueRecord | null = null;
+		if (duplicateOf !== null) {
+			const found = yield* getIssue(repo, duplicateOf);
+			if (found._tag === "Absent") {
+				return refuse(
+					ZERO_SCOPE,
+					`triage kill: --duplicate-of #${duplicateOf} not found in ${repo}.`,
+				);
+			}
+			if (found._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`triage kill: cannot read --duplicate-of #${duplicateOf} in ${repo}: ${found.reason} — no kill was attempted.`,
+				);
+			}
+			if (found.value.state === "closed") {
+				return refuse(
+					ZERO_SCOPE,
+					`triage kill: --duplicate-of #${duplicateOf} is closed — refusing to fold this issue's content into a closed issue where nobody will read it.`,
+				);
+			}
+			duplicate = found.value;
+		}
+
+		const labels = yield* listLabels(repo);
+		if (labels._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`triage kill: cannot read the label set of ${repo}: ${labels.reason} — no kill was attempted.`,
+			);
+		}
+		const scope = scannedLine("triage kill", repo, labels.value.length, "label");
+		if (!labels.value.includes(KILL_LABEL)) {
+			return refuse(
+				ZERO_SCOPE,
+				`triage kill: label ${KILL_LABEL} does not exist in ${repo} — refusing a kill that would be invisible to the audit.`,
+				[scope, ...emptyBodyNotice],
+			);
+		}
+
+		const foldScan = scanBody(target.value.body);
+		const redactions = duplicate === null ? 0 : foldScan.leaks.length;
+		const redactionNotice =
+			redactions === 0
+				? []
+				: [
+						`triage kill: redacted ${redactions} machine-local path(s) from the folded duplicate body.`,
+					];
+		const diagnostics = [scope, ...emptyBodyNotice, ...redactionNotice];
+
+		// Each write gates the next, and each `8` names what landed, what did not, and the recovery —
+		// because "nothing happened, re-run" and "three comments are live, re-running duplicates them"
+		// are opposite instructions.
+		if (duplicate !== null) {
+			const foldBody = `Folded from #${issue} (closed not-planned as a duplicate of this issue).\n\n${foldScan.redacted}`;
+			const folded = yield* createComment(repo, duplicate.number, foldBody);
+			if (folded._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`triage kill: the fold comment on #${duplicate.number} failed: ${folded.reason} — #${issue} is NOT closed, carries no reason and no label; nothing was lost. Re-run.`,
+					diagnostics,
+				);
+			}
+		}
+
+		const reasonComment = yield* createComment(repo, issue, reason);
+		if (reasonComment._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				duplicate === null
+					? `triage kill: the reason comment on #${issue} failed: ${reasonComment.reason} — #${issue} is NOT closed and carries no label; nothing landed and nothing was lost. Re-run.`
+					: `triage kill: the reason comment on #${issue} failed: ${reasonComment.reason} — #${issue} is NOT closed and carries no label, but the fold on #${duplicate.number} DID land; delete that comment before re-running, or the fold posts twice.`,
+				diagnostics,
+			);
+		}
+
+		const labelled = yield* addLabels(repo, issue, [KILL_LABEL]);
+		if (labelled._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`triage kill: applying ${KILL_LABEL} to #${issue} failed: ${labelled.reason} — the fold and the reason comment landed; #${issue} is still OPEN and invisible to the kill audit. Apply the label by hand, or delete the landed comments and re-run.`,
+				diagnostics,
+			);
+		}
+
+		const closed = yield* closeNotPlanned(repo, issue);
+		if (closed._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`triage kill: closing #${issue} failed: ${closed.reason} — the fold, the reason and ${KILL_LABEL} all landed; #${issue} is still OPEN and fully annotated. Close it by hand with state_reason=not_planned, or delete the landed comments and re-run.`,
+				diagnostics,
+			);
+		}
+
+		// A plain `closed` reads as "done", not "killed", so the read-back asserts BOTH fields. An
+		// unreadable read-back is not a proven close either: the writes landed and the outcome is
+		// unverified, which is exactly what `9` says.
+		const after = yield* getIssue(repo, issue);
+		if (after._tag !== "Present") {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage kill: the writes on #${issue} landed but the read-back itself failed: ${
+					after._tag === "Absent" ? "the issue is now absent" : after.reason
+				} — the close is unverified.`,
+				diagnostics,
+			);
+		}
+		if (after.value.state !== "closed" || after.value.stateReason !== "not_planned") {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage kill: closed, but the read-back shows state=${after.value.state} state_reason=${
+					after.value.stateReason ?? "none"
+				}, not not_planned — #${issue} reads as done rather than killed.`,
+				diagnostics,
+			);
+		}
+
+		const foldedInto = duplicate === null ? null : duplicate.number;
+		return json
+			? answer(
+					JSON.stringify({outcome: "killed", number: issue, foldedInto, redactions, provenance}),
+					diagnostics,
+				)
+			: answer(`killed\t${issue}\t${foldedInto ?? "none"}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
@@ -1,0 +1,493 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	HUMAN_FILED,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	UNCONFIRMED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {KILL_LABEL, runKill} from "./kill-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const DUPLICATE = /^gh api repos\/o\/r\/issues\/4290$/;
+const LABELS = /labels\?per_page=100/;
+const REASON_COMMENT = /repos\/o\/r\/issues\/4312\/comments -f/;
+const FOLD_COMMENT = /repos\/o\/r\/issues\/4290\/comments -f/;
+const APPLY_LABEL = /repos\/o\/r\/issues\/4312\/labels/;
+const CLOSE = /--method PATCH repos\/o\/r\/issues\/4312 -f state=closed/;
+
+/**
+ * A pattern that matches once and then never again.
+ *
+ * A kill makes the *same* `gh api repos/o/r/issues/<n>` call twice — the precondition read and the
+ * read-back — and `fakeShell` resolves a line against the first pattern that matches, so scripting
+ * the two to different answers needs a pattern that retires itself. It is a real `RegExp` subclass
+ * rather than a cast object because the package forbids type assertions.
+ */
+class FirstCallOnly extends RegExp {
+	private used = false;
+	override test(line: string): boolean {
+		if (this.used || !super.test(line)) return false;
+		this.used = true;
+		return true;
+	}
+}
+
+const firstCallOnly = (re: RegExp): RegExp => new FirstCallOnly(re.source, re.flags);
+
+const FOOTER = "---\n<sub>Filed by an agent · 2026-01-01T00:00:00Z</sub>";
+
+const issue = (over: Record<string, unknown> = {}) =>
+	okOut(
+		JSON.stringify({
+			number: 4312,
+			title: "t",
+			body: `## Summary\n\nsomething\n\n${FOOTER}`,
+			state: "open",
+			labels: [],
+			html_url: "https://example.test/issues/4312",
+			...over,
+		}),
+	);
+
+const duplicate = (over: Record<string, unknown> = {}) =>
+	okOut(
+		JSON.stringify({
+			number: 4290,
+			title: "survivor",
+			body: "the surviving issue",
+			state: "open",
+			labels: [],
+			html_url: "https://example.test/issues/4290",
+			...over,
+		}),
+	);
+
+const killed = okOut(
+	JSON.stringify({
+		number: 4312,
+		title: "t",
+		body: `## Summary\n\nsomething\n\n${FOOTER}`,
+		state: "closed",
+		state_reason: "not_planned",
+		labels: [{name: KILL_LABEL}],
+		html_url: "https://example.test/issues/4312",
+	}),
+);
+
+const comment = okOut(
+	JSON.stringify({id: 99, html_url: "https://example.test/issues/4312#issuecomment-99"}),
+);
+
+const labelSet = okOut([KILL_LABEL, "status:needs-triage", "p1"].join("\n"));
+
+const REASON = "Superseded by the merged contract; nothing here moves forward.";
+
+const options = {
+	issue: 4312,
+	confirm: true,
+	duplicateOf: null as number | null,
+	repo: null as string | null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: REASON}),
+};
+
+/** The whole sequence green: precondition read, label set, three writes, a not-planned read-back. */
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[firstCallOnly(ISSUE), issue()],
+	[ISSUE, killed],
+	[LABELS, labelSet],
+	[REASON_COMMENT, comment],
+	[APPLY_LABEL, okOut("[]")],
+	[CLOSE, okOut("{}")],
+];
+
+const runWith = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(Effect.provide(runKill({...options, ...overrides}), shell.layer)).then(
+		(out) => ({out, calls: shell.calls}),
+	);
+};
+
+describe("runKill", () => {
+	it("closes not-planned and prints the outcome line", async () => {
+		const {out, calls} = await runWith(happy());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("killed\t4312\tnone\n");
+		expect(calls.filter((c) => CLOSE.test(c))).toHaveLength(1);
+	});
+
+	it("writes in the order that keeps a failure recoverable: reason, label, close", async () => {
+		const {calls} = await runWith(happy());
+		const at = (re: RegExp) => calls.findIndex((c) => re.test(c));
+		expect(at(REASON_COMMENT)).toBeLessThan(at(APPLY_LABEL));
+		expect(at(APPLY_LABEL)).toBeLessThan(at(CLOSE));
+	});
+
+	it("reports the label count it scanned", async () => {
+		const {out} = await runWith(happy());
+		expect(out.stderr.join("\n")).toContain("triage kill: scanned 3 labels in o/r.");
+	});
+
+	it("emits the result object with --json", async () => {
+		const {out} = await runWith(happy(), {json: true});
+		expect(JSON.parse(out.stdout)).toEqual({
+			outcome: "killed",
+			number: 4312,
+			foldedInto: null,
+			redactions: 0,
+			provenance: "agent",
+		});
+	});
+
+	// --- the provenance guard ------------------------------------------------------------------
+
+	it("refuses a human-filed issue on 12 and writes nothing", async () => {
+		const {out, calls} = await runWith([
+			[firstCallOnly(ISSUE), issue({body: "I typed this myself."})],
+			...happy().slice(1),
+		]);
+		expect(out.code).toBe(HUMAN_FILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("Park it with questions instead.");
+		expect(calls.some((c) => CLOSE.test(c) || REASON_COMMENT.test(c))).toBe(false);
+	});
+
+	it("refuses a body that merely QUOTES the footer — an unanchored match would close it", async () => {
+		const {out, calls} = await runWith([
+			[
+				firstCallOnly(ISSUE),
+				issue({body: 'The footer text "Filed by an agent" renders wrong on mobile.'}),
+			],
+			...happy().slice(1),
+		]);
+		expect(out.code).toBe(HUMAN_FILED);
+		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+	});
+
+	it("refuses an empty body as human, and says the answer was defaulted", async () => {
+		const {out} = await runWith([[firstCallOnly(ISSUE), issue({body: ""})], ...happy().slice(1)]);
+		expect(out.code).toBe(HUMAN_FILED);
+		expect(out.stderr.join("\n")).toContain("fail-closed");
+	});
+
+	it("refuses an UNREADABLE body on 11, never as a human verdict", async () => {
+		const {out, calls} = await runWith([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("a body that was never read");
+		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+	});
+
+	// --- the confirmation guard ----------------------------------------------------------------
+
+	it("refuses an agent-filed issue without --confirm on 13, and writes nothing", async () => {
+		const {out, calls} = await runWith(happy(), {confirm: false});
+		expect(out.code).toBe(UNCONFIRMED);
+		expect(out.stderr.at(-1)).toContain("ADR 0159");
+		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+	});
+
+	it("checks provenance BEFORE confirmation — a human-filed issue refuses on 12 either way", async () => {
+		const {out} = await runWith(
+			[[firstCallOnly(ISSUE), issue({body: "hand-typed"})], ...happy().slice(1)],
+			{confirm: false},
+		);
+		expect(out.code).toBe(HUMAN_FILED);
+	});
+
+	// --- preconditions -------------------------------------------------------------------------
+
+	it("refuses an absent issue on 7", async () => {
+		const {out} = await runWith([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("triage kill: issue #4312 not found in o/r.");
+	});
+
+	it("refuses an already-closed issue on 7", async () => {
+		const {out} = await runWith([
+			[firstCallOnly(ISSUE), issue({state: "closed"})],
+			...happy().slice(1),
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("triage kill: issue #4312 is already closed.");
+	});
+
+	it("refuses when closed-by-triage is absent from the repo — the kill would be unauditable", async () => {
+		const {out, calls} = await runWith([
+			[firstCallOnly(ISSUE), issue()],
+			[ISSUE, killed],
+			[LABELS, okOut("p1\nstatus:needs-triage")],
+			...happy().slice(3),
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("invisible to the audit");
+		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+	});
+
+	it("refuses an unreadable label set on 11, not on 7", async () => {
+		const {out} = await runWith([
+			[firstCallOnly(ISSUE), issue()],
+			[ISSUE, killed],
+			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+			...happy().slice(3),
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a closed --duplicate-of on 7 — nobody would read the fold", async () => {
+		const {out, calls} = await runWith(
+			[
+				[firstCallOnly(ISSUE), issue()],
+				[ISSUE, killed],
+				[DUPLICATE, duplicate({state: "closed"})],
+				...happy().slice(2),
+			],
+			{duplicateOf: 4290},
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(calls.some((c) => FOLD_COMMENT.test(c))).toBe(false);
+	});
+
+	it("refuses an absent --duplicate-of on 7", async () => {
+		const {out} = await runWith(
+			[
+				[firstCallOnly(ISSUE), issue()],
+				[ISSUE, killed],
+				[DUPLICATE, errOut("gh: Not Found (HTTP 404)")],
+				...happy().slice(2),
+			],
+			{duplicateOf: 4290},
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an unreadable --duplicate-of on 11", async () => {
+		const {out} = await runWith(
+			[
+				[firstCallOnly(ISSUE), issue()],
+				[ISSUE, killed],
+				[DUPLICATE, errOut("gh: Bad gateway (HTTP 502)")],
+				...happy().slice(2),
+			],
+			{duplicateOf: 4290},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	// --- the authored reason -------------------------------------------------------------------
+
+	it("refuses an empty-but-read stdin on 3 — an unauditable kill", async () => {
+		const {out} = await runWith(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "   "} satisfies StdinRead),
+		});
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stderr.at(-1)).toBe(
+			"triage kill: no reason on stdin — refusing an unauditable kill.",
+		);
+	});
+
+	it("refuses a FAILED stdin read as UNKNOWN, never as an empty reason", async () => {
+		const {out} = await runWith(happy(), {
+			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(1);
+		expect(out.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses a bare @ reason on 6 — masking a placeholder never terminates", async () => {
+		const {out} = await runWith(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "@/tmp/reason.md"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path in the authored reason on 5", async () => {
+		const {out, calls} = await runWith(happy(), {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: "see /Users/someone/notes/why.md",
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stderr.at(-1)).toContain("at line 1 (absolute home root)");
+		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+	});
+
+	// --- the duplicate fold --------------------------------------------------------------------
+
+	it("folds the redacted body into the survivor and names it on stdout", async () => {
+		const {out, calls} = await runWith(
+			[
+				[firstCallOnly(ISSUE), issue({body: `repro at /Users/someone/x.md\n\n${FOOTER}`})],
+				[ISSUE, killed],
+				[DUPLICATE, duplicate()],
+				[LABELS, labelSet],
+				[FOLD_COMMENT, comment],
+				[REASON_COMMENT, comment],
+				[APPLY_LABEL, okOut("[]")],
+				[CLOSE, okOut("{}")],
+			],
+			{duplicateOf: 4290},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("killed\t4312\t4290\n");
+		const fold = calls.find((c) => FOLD_COMMENT.test(c)) ?? "";
+		expect(fold).toContain("/Users/<redacted>");
+		expect(fold).not.toContain("/Users/someone/x.md");
+		expect(out.stderr.join("\n")).toContain("redacted 1 machine-local path(s)");
+	});
+
+	it("folds before it comments, and comments before it closes", async () => {
+		const {calls} = await runWith(
+			[
+				[firstCallOnly(ISSUE), issue()],
+				[ISSUE, killed],
+				[DUPLICATE, duplicate()],
+				[LABELS, labelSet],
+				[FOLD_COMMENT, comment],
+				[REASON_COMMENT, comment],
+				[APPLY_LABEL, okOut("[]")],
+				[CLOSE, okOut("{}")],
+			],
+			{duplicateOf: 4290},
+		);
+		const at = (re: RegExp) => calls.findIndex((c) => re.test(c));
+		expect(at(FOLD_COMMENT)).toBeLessThan(at(REASON_COMMENT));
+		expect(at(REASON_COMMENT)).toBeLessThan(at(CLOSE));
+	});
+
+	// --- the four gated writes -----------------------------------------------------------------
+
+	it("stops at a failed fold: nothing else is attempted and nothing was lost", async () => {
+		const {out, calls} = await runWith(
+			[
+				[firstCallOnly(ISSUE), issue()],
+				[ISSUE, killed],
+				[DUPLICATE, duplicate()],
+				[LABELS, labelSet],
+				[FOLD_COMMENT, errOut("gh: timeout")],
+				...happy().slice(3),
+			],
+			{duplicateOf: 4290},
+		);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("nothing was lost. Re-run.");
+		expect(calls.some((c) => REASON_COMMENT.test(c) || CLOSE.test(c))).toBe(false);
+	});
+
+	it("names the landed fold when the reason comment fails — a blind re-run would double-post", async () => {
+		const {out} = await runWith(
+			[
+				[firstCallOnly(ISSUE), issue()],
+				[ISSUE, killed],
+				[DUPLICATE, duplicate()],
+				[LABELS, labelSet],
+				[FOLD_COMMENT, comment],
+				[REASON_COMMENT, errOut("gh: timeout")],
+				[APPLY_LABEL, okOut("[]")],
+				[CLOSE, okOut("{}")],
+			],
+			{duplicateOf: 4290},
+		);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the fold on #4290 DID land");
+	});
+
+	it("stops at a failed reason comment: the issue stays open and unlabelled", async () => {
+		const {out, calls} = await runWith([
+			[firstCallOnly(ISSUE), issue()],
+			[ISSUE, killed],
+			[LABELS, labelSet],
+			[REASON_COMMENT, errOut("gh: timeout")],
+			[APPLY_LABEL, okOut("[]")],
+			[CLOSE, okOut("{}")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("is NOT closed");
+		expect(calls.some((c) => APPLY_LABEL.test(c) || CLOSE.test(c))).toBe(false);
+	});
+
+	it("stops at a failed label: the issue stays OPEN rather than closed and unauditable", async () => {
+		const {out, calls} = await runWith([
+			[firstCallOnly(ISSUE), issue()],
+			[ISSUE, killed],
+			[LABELS, labelSet],
+			[REASON_COMMENT, comment],
+			[APPLY_LABEL, errOut("gh: timeout")],
+			[CLOSE, okOut("{}")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("still OPEN and invisible to the kill audit");
+		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
+	});
+
+	it("reports a failed close as UNKNOWN with the by-hand recovery", async () => {
+		const {out} = await runWith([
+			[firstCallOnly(ISSUE), issue()],
+			[ISSUE, killed],
+			[LABELS, labelSet],
+			[REASON_COMMENT, comment],
+			[APPLY_LABEL, okOut("[]")],
+			[CLOSE, errOut("gh: timeout")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("state_reason=not_planned");
+	});
+
+	// --- the read-back -------------------------------------------------------------------------
+
+	it("refuses a close that reads back as completed — done is not killed", async () => {
+		const {out} = await runWith([
+			[firstCallOnly(ISSUE), issue()],
+			[
+				ISSUE,
+				okOut(
+					JSON.stringify({
+						...JSON.parse(issue().stdout),
+						state: "closed",
+						state_reason: "completed",
+					}),
+				),
+			],
+			[LABELS, labelSet],
+			[REASON_COMMENT, comment],
+			[APPLY_LABEL, okOut("[]")],
+			[CLOSE, okOut("{}")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("reads as done rather than killed");
+	});
+
+	it("refuses when the read-back itself fails — the writes landed but the close is unproven", async () => {
+		const {out} = await runWith([
+			[firstCallOnly(ISSUE), issue()],
+			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, labelSet],
+			[REASON_COMMENT, comment],
+			[APPLY_LABEL, okOut("[]")],
+			[CLOSE, okOut("{}")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("the close is unverified");
+	});
+
+	// --- usage ---------------------------------------------------------------------------------
+
+	it("refuses folding an issue into itself", async () => {
+		const {out} = await runWith(happy(), {duplicateOf: 4312});
+		expect(out.code).toBe(1);
+		expect(out.stderr.at(-1)).toContain("into itself");
+	});
+});

--- a/packages/fabrika-cli/src/triage/provenance.ts
+++ b/packages/fabrika-cli/src/triage/provenance.ts
@@ -1,0 +1,40 @@
+/**
+ * The filing-provenance predicate: was this issue body emitted by `report file`, or typed by a human?
+ *
+ * The signal is the agent footer, not the author — every report-filed issue shows the same account,
+ * so authorship carries no information (ADR 0159).
+ *
+ * **This file is the group's single definition of that predicate.** `triage kill` re-runs the test
+ * itself rather than trusting a caller to have run `triage provenance` first, which makes the guard
+ * structural instead of a caller's discipline. When the `triage provenance` verb lands it imports
+ * this module too; neither may re-derive the match.
+ */
+
+/**
+ * Whether a body carries the agent footer, matched **anchored at line-begin**.
+ *
+ * `renderFooter` (`../report/compose.ts`) emits `` `---\n<sub>` `` then the present fields joined
+ * with ` · `, and the literal `Filed by an agent` is always the first of them — so the emitted line
+ * begins with `<sub>Filed by an agent` whatever else the footer carries. Three of the five fields
+ * are droppable and take their separator with them, so the match may require none of them.
+ *
+ * **The anchor deliberately diverges from `../report/file-verb.ts`'s bare
+ * `body.includes("Filed by an agent")` — do not "fix" the two back into agreement.** That check is
+ * correct there: it is a read-back over a body the same process just composed, so nothing else can
+ * be in it. Here the body is foreign, and a bare substring fails **open toward `agent`** — an issue
+ * that merely quotes the phrase (a bug report about the footer, a pasted body, a discussion of ADR
+ * 0159) would answer `agent`, which is the close-eligible direction. Anchoring makes the failure
+ * land on `human`, the protected one.
+ *
+ * An empty body has no footer and so answers `false` ⇒ human, which is the fail-closed default. An
+ * *unreadable* body never reaches here: that is a precondition failure the caller seats on `11`,
+ * because a verdict manufactured from a failed read is not a measurement.
+ */
+export const hasAgentFooter = (body: string): boolean =>
+	/^<sub>Filed by an agent/m.test(body.replace(/\r\n/g, "\n"));
+
+/** `agent` or `human` — the word the answer channel prints. */
+export type Provenance = "agent" | "human";
+
+export const provenanceOf = (body: string): Provenance =>
+	hasAgentFooter(body) ? "agent" : "human";

--- a/packages/fabrika-cli/src/triage/provenance.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/provenance.unit.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from "vitest";
+import {renderFooter} from "../report/compose.ts";
+import {hasAgentFooter, provenanceOf} from "./provenance.ts";
+
+const footer = (extra: Partial<Parameters<typeof renderFooter>[0]> = {}) =>
+	renderFooter({
+		session: null,
+		model: null,
+		branch: null,
+		timestamp: "2026-08-03T18:00:00Z",
+		...extra,
+	});
+
+describe("hasAgentFooter", () => {
+	it("matches the footer the emitter really produces, sparse or full", () => {
+		expect(hasAgentFooter(`## Summary\n\nsomething\n\n${footer()}`)).toBe(true);
+		expect(
+			hasAgentFooter(`body\n\n${footer({session: "abc", model: "opus", branch: "usirin/x"})}`),
+		).toBe(true);
+	});
+
+	it("matches across CRLF line endings", () => {
+		expect(hasAgentFooter(`body\r\n\r\n${footer().replace(/\n/g, "\r\n")}`)).toBe(true);
+	});
+
+	it("answers human on a body that merely QUOTES the phrase — the anchor is the point", () => {
+		expect(
+			hasAgentFooter("The footer reads `<sub>Filed by an agent · …</sub>` and is wrong."),
+		).toBe(false);
+		expect(hasAgentFooter("A discussion of ADR 0159: Filed by an agent is the signal.")).toBe(
+			false,
+		);
+		expect(hasAgentFooter("> <sub>Filed by an agent · 2026-01-01</sub>")).toBe(false);
+	});
+
+	it("answers human on an empty body — the fail-closed default", () => {
+		expect(provenanceOf("")).toBe("human");
+	});
+
+	it("answers agent on the footer alone", () => {
+		expect(provenanceOf(footer())).toBe("agent");
+	});
+});


### PR DESCRIPTION
Part of #4831 — slice 6 of nine. This adds `triage kill` only; the remaining verbs land in their own slices, so this PR deliberately does **not** close the issue.

## What this adds

`fabrika triage kill <issue> --confirm [--duplicate-of <n>] [--repo] [--json]`, reading the kill reason from **stdin**.

- `packages/fabrika-cli/src/triage/kill-verb.ts` — the verb.
- `packages/fabrika-cli/src/triage/provenance.ts` — the group's single definition of the filing-provenance predicate (`triage provenance` will import this module, not re-derive the match).
- `packages/fabrika-cli/src/triage/command.ts` — the `kill` leaf, declared with `leafCommand` so the excess-operand guard covers it.
- Unit tests beside each, in the package's existing idiom.

**Four gated writes, in the order that keeps a failure recoverable:** the optional redacted duplicate fold → the reason comment → the `closed-by-triage` label → the close. Each step gates the next, so any failure before the close leaves the issue **OPEN** — the recoverable direction — and every `8` message names what landed, what did not, and the specific recovery, because "nothing happened, re-run" and "three comments are live, re-running duplicates them" are opposite instructions.

**Two guards, and they are different guards (ADR 0159).** A missing agent footer means the issue is human-filed and the verb refuses outright. A *present* footer makes it eligible, not closeable — a human-invoked `/report` emits the same footer — so `--confirm` is the confirmation step made structural. `--confirm` is therefore optional at the parser and refused at the verb: a parser-required flag's absence is a usage error indistinguishable from a typo, while ADR 0159's confirmation is a decision whose absence must be a refusal a caller can read as one.

**The footer match is anchored** (`/^<sub>Filed by an agent/m`), deliberately diverging from `report/file-verb.ts`'s bare `body.includes(...)`. That check is correct there — it reads back a body the same process just composed. Here the body is foreign, and a bare substring fails **open toward `agent`**: an issue that merely quotes the phrase (a bug report about the footer, a pasted body, a discussion of ADR 0159) would answer `agent`, the close-eligible direction. Anchoring makes the failure land on `human`, the protected one.

**Leak handling follows the asymmetry already in `report/leaks.ts`:** the authored reason is *refused* on `5` (the author can fix it); the duplicate's body is foreign content being preserved, so it is *redacted* into the fold instead.

**The read-back asserts both fields.** A plain `closed` reads as "done", not "killed", so the verb requires `state=closed` **and** `state_reason=not_planned`; an unreadable read-back is not a proven close either, and lands on `9`.

---

## ⚠️ This diverges from the issue's stated acceptance criteria — deliberately, and here is why

**#4831's AC says:**

> `triage kill` exits `11` on a human-filed issue and `12` on an agent-filed issue without `--confirm`

**This PR ships `12` and `13`.** The AC is stale relative to the merged contract, and following it silently would reintroduce a collision the contract already resolved.

The contract (`claude-plugins/fabrika/skills/triage/contract.md`) is the spec the same issue names as authoritative ("The contract is the spec — read it there, not from this issue, which does not restate it"), and it pins `12`/`13` in three places — the shared exit matrix (lines 152–153), the verb's own exit table (1557–1558) and its message table (1572–1573) — with the rationale stated outright at line 189:

> An earlier revision of this spec used `11` for the human-filed refusal, colliding with the shipped meaning; those refusals moved to `12` and `13`.

`11` is already taken: `packages/fabrika-cli/src/report/codes.ts` ships `PRECONDITION_UNKNOWN = 11`, and this group aligns to `report` code-for-code so a caller driving both in one sweep reads one meaning. Seating the human-filed refusal on `11` would make "the issue is human-filed" indistinguishable from "the precondition read failed" — and those are opposite facts: one is a measurement, the other is the absence of one. `triage kill` genuinely produces both (an unreadable target body seats on `11`; a read body with no footer seats on `12`), so the collision is reachable, not theoretical.

**This slice *consumes* that decision — it does not introduce it.** `packages/fabrika-cli/src/triage/codes.ts` is **already on `main`**, carrying `HUMAN_FILED = 12` and `UNCONFIRMED = 13` with the divergence from the AC documented at the constant; an earlier slice landed it. `codes.unit.test.ts` — also already on `main` — asserts the alignment **against the shipped `report` constants** rather than copied literals, because a test over `expect(LEAKED_PATH).toBe(5)` would stay green while the two tables drifted, which is the only failure the alignment exists to prevent. What *this* PR does is seat `triage kill`'s two refusals on those pre-existing constants; the numbering was chosen upstream of this diff.

The AC's `11`/`12` is the pre-move numbering. `12`/`13` is the merged contract's, and it is what the issue's own non-goal ("Do not re-litigate the contract") points at.

**No action needed from a reviewer beyond agreeing.** If the AC is preferred over the contract, that is a contract change, and it should land as an amendment on #4831 plus a contract edit — not as a divergent implementation here.

---

## Verification

`packages/fabrika-cli`: **641 tests / 47 files green**; `pnpm typecheck` and `pnpm lint` clean.

**Mutation verification** — each load-bearing behaviour was reverted, proven to turn a test RED, then restored and proven GREEN. All eight mutants were killed; the tree was byte-identical to the commit afterwards.

| # | Mutant (behaviour reverted) | Test(s) that went RED |
|---|---|---|
| 1 | Anchored footer match → bare `includes("Filed by an agent")` | `answers human on a body that merely QUOTES the phrase`; `refuses a body that merely QUOTES the footer` |
| 2 | Provenance no longer checked **before** `--confirm` | `checks provenance BEFORE confirmation — a human-filed issue refuses on 12 either way` |
| 3 | Read-back drops the `state_reason` half (accepts a plain `closed`) | `refuses a close that reads back as completed — done is not killed` |
| 4 | A failed reason comment no longer short-circuits the remaining writes | `stops at a failed reason comment: the issue stays open and unlabelled`; `names the landed fold when the reason comment fails` |
| 5 | A missing `closed-by-triage` label no longer refuses | `refuses when closed-by-triage is absent from the repo — the kill would be unauditable` |
| 6 | An unreadable target read seated on `7` instead of `11` | `refuses an UNREADABLE body on 11, never as a human verdict` |
| 7 | The duplicate body folded raw instead of leak-redacted | `folds the redacted body into the survivor and names it on stdout` |
| 8 | `HUMAN_FILED` moved onto `report`'s shipped `11` | `seats the human-filed refusal clear of report's shipped 11`; `carries every allocated code exactly once`; `states each exported constant's meaning at its own number` |

## Out of scope for this slice

The other eight verbs and `report dedup --exclude`; the live name collision (#4829); the routing pin (#4761).

## Deviations

- **Class 1 — scope narrowing (the `Part of #4831` partial split).** **Said:** #4831 specifies the whole `triage` verb group. **Did:** this slice ships `triage kill` alone, plus the provenance predicate it needs, and leaves #4831 open. **Why:** the group is planned as a sequence of reviewable slices; one PR carrying nine verbs is not reviewable, and each verb's refusal semantics need their own mutation evidence. **Disposition:** no action needed — `Part of #4831` is deliberate per §9, the remaining verbs land in their own slices, and the issue closes when the last one does.

- **Class 1 / class 2 — acceptance-criterion departure: `12`/`13`, not the AC's `11`/`12`.** **Said:** #4831's AC states `triage kill` exits `11` on a human-filed issue and `12` on an agent-filed issue without `--confirm`. **Did:** the verb refuses on `12` (human-filed) and `13` (unconfirmed), seating both on the constants already shipped in `packages/fabrika-cli/src/triage/codes.ts`. **Why:** the merged contract pins `12`/`13` at three sites and records why the refusals moved off `11` — `report/codes.ts` ships `PRECONDITION_UNKNOWN = 11`, and `triage kill` reachably produces both facts, so the collision would fuse a measurement with the absence of one. The AC is the pre-move numbering, and the issue names the contract as the spec. Full reasoning in the section above. **Disposition:** for the reviewer to judge — no ADR needed; if the AC is preferred over the contract, that is a contract edit plus an amendment on #4831, not a divergent implementation here.

- **Class 3 — known defects left unfixed.** **Said:** nothing in #4831 asks for them. **Did:** the live name collision and the routing pin were both seen while working in this group and deliberately not touched here. **Why:** each is a separate surface with its own blast radius; folding either into a verb slice would mix an unrelated risk into this diff. **Disposition:** both are already filed — #4829 and #4761 — and named under `## Out of scope for this slice`.

Walking the remaining classes explicitly, none fired: **class 4** (declined guidance) — no reviewer suggestion, reviewer-appended AC, or triage instruction was declined; **class 5** (guard or gate bypassed) — no `--no-verify`, no skipped hook, and the diff adds no `biome-ignore`, `@ts-expect-error`, `.skip(` or `.only(`; **class 6** (pre-existing test or fixture changed) — no existing assertion was modified, weakened, or deleted, and the only removed lines in the diff are two `import` statements that the widened imports replace; **class 7** (out-of-scope change) — every changed path is under `packages/fabrika-cli/src/triage/`, which is exactly what the slice implies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
