### PR TITLE
feat(fabrika-cli): triage claim — a race protocol where `won` requires positive proof (#4831)

### DIFF
--- a/packages/fabrika-cli/src/triage/claim-verb.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.ts
@@ -1,0 +1,225 @@
+/**
+ * `triage claim` — take a session-scoped claim on one issue, proven by read-back.
+ *
+ * Post this session's marker, re-read every marker on the issue, discard the ones older than the
+ * TTL, and let the earliest survivor win. `won` and `lost` are both **proven answers** and both exit
+ * 0, with the discriminator in the state word: a losing claim is something this verb *determined*,
+ * so seating it on a non-zero code would make "another sweep holds it" indistinguishable from "the
+ * verb is broken".
+ *
+ * Everything a marker set could fail to say is a refusal instead. An unreadable comment list, a
+ * shape that is not a list of comments, a marker whose ordering key will not parse — none of them
+ * resolve to "no competing claim", which is the fail-open shape this verb exists to design out (see
+ * `claim.ts`). The resolution itself is pure and lives there; this module is the IO and the exit
+ * codes.
+ *
+ * The `Attempt`/`Existence` results the IO returns are **values, not the `E` channel**: a 404 and a
+ * 502 are outcomes this verb maps onto its own codes, not exceptions (effect-smol `LLMS.md`
+ * §"Error handling" — the typed error channel is for faults a caller recovers from, and `io/exec.ts`
+ * already folds the spawn fault in).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, deleteComment, getIssue, listComments, resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	expiryOf,
+	isStampableSession,
+	markerBody,
+	markersOf,
+	myMarker,
+	resolveClaim,
+} from "./claim.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {scannedLine} from "./scope.ts";
+
+export const DEFAULT_TTL_MINUTES = 60;
+
+export interface ClaimOptions {
+	readonly issue: number;
+	readonly ttlMinutes: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly now: () => Date;
+}
+
+const VERB = "triage claim";
+
+/**
+ * The session id, or a refusal.
+ *
+ * The unset case is seated on `1` because the merged contract's errors table puts it there. That
+ * sits against the group's own rule that a proven refusal never shares a code with a failure to
+ * invoke — the tension is real and disclosed rather than renumbered here, and it is defensible: an
+ * unstamped environment is a precondition of *invoking* the verb, not a verdict it reached.
+ */
+const sessionFrom = (
+	env: Readonly<Record<string, string | undefined>>,
+): {readonly session: string} | {readonly refusal: VerbOutcome} => {
+	const raw = env.CLAUDE_CODE_SESSION_ID ?? "";
+	if (raw.trim() === "") {
+		return {
+			refusal: refuse(
+				FAILED,
+				`${VERB}: CLAUDE_CODE_SESSION_ID is unset — refusing to post an unattributable claim.`,
+			),
+		};
+	}
+	const session = raw.trim();
+	if (!isStampableSession(session)) {
+		return {
+			refusal: refuse(
+				FAILED,
+				`${VERB}: CLAUDE_CODE_SESSION_ID is not a single token — a marker stamped with it would not read back as this session.`,
+			),
+		};
+	}
+	return {session};
+};
+
+export const runClaim = (
+	options: ClaimOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, ttlMinutes, json} = options;
+
+		if (!Number.isInteger(issue) || issue <= 0) {
+			return refuse(FAILED, `${VERB}: ${issue} is not an issue number.`);
+		}
+		if (!Number.isInteger(ttlMinutes) || ttlMinutes <= 0) {
+			return refuse(FAILED, `${VERB}: --ttl-minutes ${ttlMinutes} is not a positive integer.`);
+		}
+
+		const stamped = sessionFrom(options.env);
+		if ("refusal" in stamped) return stamped.refusal;
+		const {session} = stamped;
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				`${VERB}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `${VERB}: issue #${issue} not found in ${repo}.`);
+		}
+		if (target._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue} or its comments in ${repo}: ${target.reason} — no claim was resolved; never "won".`,
+			);
+		}
+		if (target.value.state === "closed") {
+			return refuse(ZERO_SCOPE, `${VERB}: issue #${issue} is closed — nothing to triage.`);
+		}
+
+		const before = yield* listComments(repo, issue);
+		if (before._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue} or its comments in ${repo}: ${before.reason} — no claim was resolved; never "won".`,
+			);
+		}
+
+		const now = options.now().getTime();
+		// Re-running inside one session is idempotent: a second marker is strictly later than the
+		// first, so it can win nothing the first did not and only adds litter to clean up.
+		const alreadyHeld = myMarker(
+			resolveClaim({markers: markersOf(before.value), session, now, ttlMinutes}),
+		);
+
+		let postedId: number | null = null;
+		if (alreadyHeld === null) {
+			const posted = yield* createComment(repo, issue, markerBody(session));
+			if (posted._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: marker POST failed: ${posted.reason} — UNKNOWN whether it landed; re-run before mutating #${issue}.`,
+				);
+			}
+			postedId = posted.value.id;
+		}
+
+		const after = alreadyHeld === null ? yield* listComments(repo, issue) : before;
+		if (after._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue} or its comments in ${repo}: ${after.reason} — no claim was resolved; never "won".`,
+				postedId === null
+					? []
+					: [
+							`${VERB}: this session's marker ${postedId} is live on #${issue} and was not read back — delete it by hand if this session stops here.`,
+						],
+			);
+		}
+		const scope = scannedLine(VERB, repo, after.value.length, "comment");
+		const resolution = resolveClaim({
+			markers: markersOf(after.value),
+			session,
+			now,
+			ttlMinutes,
+		});
+
+		if (resolution._tag === "Unresolvable") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue} or its comments in ${repo}: ${resolution.reason} — no claim was resolved; never "won".`,
+				[scope],
+			);
+		}
+
+		if (resolution._tag === "MineAbsent") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: marker posted but absent on read-back — treating the claim as lost.`,
+				[scope],
+			);
+		}
+
+		if (resolution._tag === "Won") {
+			return json
+				? answer(
+						JSON.stringify({
+							outcome: "won",
+							session,
+							holder: null,
+							markers: resolution.live,
+							expired: resolution.expired,
+						}),
+						[scope],
+					)
+				: answer("won", [scope]);
+		}
+
+		// A losing claim deletes the marker it just posted, before it says so. Litter survives the
+		// full TTL and its created_at is older than every marker posted after it, so a session that
+		// already conceded would beat a rightful winner on a later run.
+		const deleted = yield* deleteComment(repo, resolution.mine.id);
+		if (deleted._tag === "Failure") {
+			const expiry = expiryOf(resolution.mine.createdAt, ttlMinutes) ?? "an unknown time";
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: lost #${issue}, but this session's marker ${resolution.mine.id} could not be deleted: ${deleted.reason} — a stale claim is live on the issue until ${expiry}; delete it by hand.`,
+				[scope],
+			);
+		}
+
+		const notice = `${VERB}: #${issue} is held by session ${resolution.holder.session} since ${resolution.holder.createdAt} — backing off.`;
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "lost",
+						session,
+						holder: resolution.holder.session,
+						markers: resolution.live,
+						expired: resolution.expired,
+					}),
+					[scope, notice],
+				)
+			: answer(`lost\t${resolution.holder.session}`, [scope, notice]);
+	});

--- a/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
@@ -1,0 +1,322 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {markerBody} from "./claim.ts";
+import {runClaim} from "./claim-verb.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+
+const MINE = "b2e1-4c07-4a99-9f30-55da1e6b7c02";
+const THEIRS = "7f3c-9a20-4b11-8e05-1d77c2a4f9be";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const LIST = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const POST = /--method POST repos\/o\/r\/issues\/4312\/comments/;
+const DELETE = /--method DELETE repos\/o\/r\/issues\/comments\//;
+
+/**
+ * A pattern that matches at most once, so the two identical comment-list reads of one run can be
+ * scripted with different answers.
+ *
+ * The whole protocol lives in the difference between the list read before the marker is posted and
+ * the read after it, so a fake that cannot tell those two calls apart cannot exercise it at all.
+ */
+const once = (pattern: RegExp): RegExp => {
+	const re = new RegExp(pattern.source);
+	let fired = false;
+	re.test = (input: string) => {
+		if (fired || !RegExp.prototype.test.call(re, input)) return false;
+		fired = true;
+		return true;
+	};
+	return re;
+};
+
+const issue = (state: string) =>
+	okOut(
+		JSON.stringify({
+			number: 4312,
+			title: "t",
+			body: "b",
+			state,
+			labels: [],
+			html_url: "https://example.test/issues/4312",
+		}),
+	);
+
+const comment = (id: number, body: string, createdAt: string) => ({
+	id,
+	user: {login: "usirin"},
+	created_at: createdAt,
+	body,
+});
+
+const comments = (...entries: ReadonlyArray<ReturnType<typeof comment>>) =>
+	okOut(JSON.stringify(entries));
+
+const posted = (id: number) =>
+	okOut(JSON.stringify({id, html_url: `https://example.test/issues/4312#issuecomment-${id}`}));
+
+const NOW = new Date("2026-08-02T10:00:00Z");
+const MY_MARKER = comment(5001, markerBody(MINE), "2026-08-02T09:50:00Z");
+const THEIR_MARKER = comment(4002, markerBody(THEIRS), "2026-08-02T09:14:02Z");
+
+const options = {
+	issue: 4312,
+	ttlMinutes: 60,
+	repo: null,
+	json: false,
+	env: {
+		CLAUDE_PIPELINE_REPO: "o/r",
+		CLAUDE_CODE_SESSION_ID: MINE,
+	} as Record<string, string | undefined>,
+	now: () => NOW,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(Effect.provide(runClaim({...options, ...overrides}), shell.layer)).then(
+		(outcome) => ({outcome, calls: shell.calls}),
+	);
+};
+
+/** before: nobody. post lands. after: only mine. */
+const winning = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[ISSUE, issue("open")],
+	[POST, posted(5001)],
+	[once(LIST), comments()],
+	[LIST, comments(MY_MARKER)],
+];
+
+/** before: theirs is already there. post lands. after: both. */
+const losing = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[ISSUE, issue("open")],
+	[POST, posted(5001)],
+	[once(LIST), comments(THEIR_MARKER)],
+	[LIST, comments(THEIR_MARKER, MY_MARKER)],
+];
+
+describe("runClaim — winning", () => {
+	it("posts the exact marker literal and prints the state word `won`", async () => {
+		const {outcome, calls} = await run(winning());
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("won\n");
+		expect(calls.find((c) => POST.test(c))).toContain(`body=${markerBody(MINE)}`);
+	});
+
+	it("reports the scanned comment count on stderr — a verdict names its scope", async () => {
+		const {outcome} = await run(winning());
+		expect(outcome.stderr.join("\n")).toContain("triage claim: scanned 1 comment in o/r.");
+	});
+
+	it("emits the result object under --json", async () => {
+		const {outcome} = await run(winning(), {json: true});
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "won",
+			session: MINE,
+			holder: null,
+			markers: 1,
+			expired: 0,
+		});
+	});
+
+	it("wins over a marker the TTL has aged out, and counts it as expired", async () => {
+		const stale = comment(4002, markerBody(THEIRS), "2026-08-02T08:00:00Z");
+		const {outcome} = await run(
+			[
+				[ISSUE, issue("open")],
+				[POST, posted(5001)],
+				[once(LIST), comments(stale)],
+				[LIST, comments(stale, MY_MARKER)],
+			],
+			{json: true},
+		);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({outcome: "won", markers: 1, expired: 1});
+	});
+
+	it("re-resolves rather than posting a second marker when this session already holds one", async () => {
+		const {outcome, calls} = await run([
+			[ISSUE, issue("open")],
+			[LIST, comments(MY_MARKER)],
+		]);
+		expect(outcome.stdout).toBe("won\n");
+		expect(calls.filter((c) => POST.test(c))).toHaveLength(0);
+		expect(calls.filter((c) => LIST.test(c))).toHaveLength(1);
+	});
+});
+
+describe("runClaim — losing", () => {
+	it("prints `lost\\t<holder>` at exit 0 and names the holder in full", async () => {
+		const {outcome} = await run([...losing(), [DELETE, okOut("")]]);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(`lost\t${THEIRS}\n`);
+		expect(outcome.stderr.join("\n")).toContain(
+			`#4312 is held by session ${THEIRS} since 2026-08-02T09:14:02Z — backing off.`,
+		);
+	});
+
+	it("deletes its OWN marker and only that one", async () => {
+		const {calls} = await run([...losing(), [DELETE, okOut("")]]);
+		const deletes = calls.filter((c) => DELETE.test(c));
+		expect(deletes).toHaveLength(1);
+		expect(deletes[0]).toContain("issues/comments/5001");
+	});
+
+	it("refuses at 9 when the conceded marker cannot be deleted — a live stale claim is not an aside", async () => {
+		const {outcome} = await run([...losing(), [DELETE, errOut("gh: Forbidden (HTTP 403)")]]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain(
+			"a stale claim is live on the issue until 2026-08-02T10:50:00.000Z; delete it by hand.",
+		);
+	});
+});
+
+describe("runClaim — `won` requires positive proof", () => {
+	it("refuses at 11 when the comment list read fails — never `no competing claim`", async () => {
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments()],
+			[LIST, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain('no claim was resolved; never "won"');
+	});
+
+	it("refuses at 11 when the comment payload is not a list, even though gh exited 0", async () => {
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments()],
+			[LIST, okOut(JSON.stringify({message: "Not Found"}))],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses at 11 when an entry is not a comment — a shape mismatch is never an empty field", async () => {
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments()],
+			[LIST, okOut(JSON.stringify([{note: "no id here"}]))],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses at 11 when a marker's ordering key will not parse", async () => {
+		const undated = {...THEIR_MARKER, created_at: ""};
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments()],
+			[LIST, comments(undated, MY_MARKER)],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses at 9 when the posted marker is absent from the read-back", async () => {
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments()],
+			[LIST, comments()],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.join("\n")).toContain("absent on read-back");
+	});
+
+	it("loses to a malformed marker rather than ignoring it", async () => {
+		const malformed = comment(
+			4002,
+			"<!-- fabrika-triage-claim session= -->",
+			"2026-08-02T09:14:02Z",
+		);
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments(malformed)],
+			[LIST, comments(malformed, MY_MARKER)],
+			[DELETE, okOut("")],
+		]);
+		expect(outcome.stdout).toBe("lost\t\n");
+	});
+});
+
+describe("runClaim — preconditions", () => {
+	it("refuses at 1 with an unset session id, and touches the network for nothing", async () => {
+		const {outcome, calls} = await run([], {
+			env: {CLAUDE_PIPELINE_REPO: "o/r"},
+		});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.join("\n")).toContain(
+			"CLAUDE_CODE_SESSION_ID is unset — refusing to post an unattributable claim.",
+		);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("refuses at 1 on a session id that would not read back as itself", async () => {
+		const {outcome} = await run([], {
+			env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "two tokens"},
+		});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.join("\n")).toContain("not a single token");
+	});
+
+	it("refuses at 7 on a proven-absent issue", async () => {
+		const {outcome} = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.join("\n")).toContain("issue #4312 not found in o/r.");
+	});
+
+	it("refuses at 7 on a closed issue — nothing to triage", async () => {
+		const {outcome, calls} = await run([[ISSUE, issue("closed")]]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(calls.filter((c) => POST.test(c))).toHaveLength(0);
+	});
+
+	it("refuses at 11 on an unreadable issue — a 502 is not a fact about anything", async () => {
+		const {outcome} = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("posts nothing when the FIRST comment read fails", async () => {
+		const {outcome, calls} = await run([
+			[ISSUE, issue("open")],
+			[LIST, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(calls.filter((c) => POST.test(c))).toHaveLength(0);
+	});
+
+	it("refuses at 8 when the marker POST itself fails — UNKNOWN whether it landed", async () => {
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[LIST, comments()],
+			[POST, errOut("gh: Service unavailable (HTTP 503)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("re-run before mutating #4312.");
+	});
+
+	it("names its own live marker when the post-write read fails", async () => {
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments()],
+			[LIST, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.stderr.join("\n")).toContain("this session's marker 5001 is live on #4312");
+	});
+
+	it("refuses at 1 on a non-positive ttl and on a non-issue number", async () => {
+		expect((await run([], {ttlMinutes: 0})).outcome.code).toBe(1);
+		expect((await run([], {issue: 0})).outcome.code).toBe(1);
+	});
+});

--- a/packages/fabrika-cli/src/triage/claim.ts
+++ b/packages/fabrika-cli/src/triage/claim.ts
@@ -1,0 +1,162 @@
+/**
+ * The `triage claim` race protocol, as a pure function of the comments that were read.
+ *
+ * The whole verb is one rule: **`won` requires positive proof that the earliest surviving marker is
+ * this session's.** Nothing else may produce it — not an empty comment list, not a marker whose
+ * ordering key is unreadable, not a set the caller could not fetch. v1's claim printed `won` and
+ * exited 0 when its own identity read came back empty, because every comparison against an empty
+ * string succeeded; that is a fail-open claim on a token that cannot write. Here the absence of
+ * evidence resolves to {@link Unresolvable} or to `lost`, never to `won`.
+ *
+ * Keeping the resolution here rather than in the verb is what makes the losing and the ambiguous
+ * branches testable without a network: the verb supplies markers, a clock and a session id, and
+ * this module decides.
+ */
+
+/** The exact one-line body a claim marker carries, up to the session id. */
+export const MARKER_PREFIX = "<!-- fabrika-triage-claim session=";
+const MARKER_SUFFIX = " -->";
+
+/** The marker literal for `session`. One line, no surrounding prose — matched back by prefix. */
+export const markerBody = (session: string): string => `${MARKER_PREFIX}${session}${MARKER_SUFFIX}`;
+
+/**
+ * A session id fit to stamp a marker with: one whitespace-free token that cannot close the comment
+ * early.
+ *
+ * An id carrying a space would post a marker this module reads back as a *different* session, so the
+ * claim it proves would not be the claim it made. Refusing up front is the only reading that keeps
+ * `won` a proof.
+ */
+export const isStampableSession = (session: string): boolean =>
+	/^\S+$/.test(session) && !session.includes("-->");
+
+/**
+ * The session id stamped on `body`, or `null` when it is not a marker at all.
+ *
+ * Matched by the exact prefix the contract fixes, never by parsing prose. A body that carries the
+ * prefix but no readable id yields `""` rather than `null`: it *is* a marker — some session posted
+ * it — and dropping it would let a malformed competitor be silently ignored, which is the one
+ * direction this protocol may not fail.
+ */
+export const sessionOf = (body: string): string | null => {
+	const trimmed = body.trim();
+	if (!trimmed.startsWith(MARKER_PREFIX)) return null;
+	const rest = trimmed.slice(MARKER_PREFIX.length);
+	const token = rest.split(/\s/, 1)[0] ?? "";
+	return token;
+};
+
+/** One claim marker, as the resolution orders it. */
+export interface Marker {
+	readonly id: number;
+	readonly session: string;
+	/** GitHub's `created_at` — the ordering key, never a timestamp from the caller-supplied body. */
+	readonly createdAt: string;
+}
+
+/** The markers among `comments`, in the order they were read. */
+export const markersOf = (
+	comments: ReadonlyArray<{readonly id: number; readonly createdAt: string; readonly body: string}>,
+): ReadonlyArray<Marker> => {
+	const out: Marker[] = [];
+	for (const comment of comments) {
+		const session = sessionOf(comment.body);
+		if (session !== null) out.push({id: comment.id, session, createdAt: comment.createdAt});
+	}
+	return out;
+};
+
+/** Epoch milliseconds for an ISO timestamp, or `null` when it is not one. */
+export const instantOf = (iso: string): number | null => {
+	const ms = Date.parse(iso);
+	return Number.isNaN(ms) ? null : ms;
+};
+
+export type ClaimResolution =
+	| {readonly _tag: "Won"; readonly marker: Marker; readonly live: number; readonly expired: number}
+	| {
+			readonly _tag: "Lost";
+			readonly holder: Marker;
+			/** Non-null by construction: a set holding no marker of this session is {@link MineAbsent}. */
+			readonly mine: Marker;
+			readonly live: number;
+			readonly expired: number;
+	  }
+	/** No marker of this session survives — whatever was posted is not on the issue. */
+	| {readonly _tag: "MineAbsent"; readonly live: number; readonly expired: number}
+	/** The ordering key itself could not be read, so no claim was resolved. */
+	| {readonly _tag: "Unresolvable"; readonly reason: string};
+
+export interface ResolveInput {
+	readonly markers: ReadonlyArray<Marker>;
+	readonly session: string;
+	/** Epoch milliseconds — the clock the TTL is measured against. */
+	readonly now: number;
+	readonly ttlMinutes: number;
+}
+
+/**
+ * Discard the markers older than the TTL, then let the earliest survivor win.
+ *
+ * A marker whose `created_at` will not parse is **not** dropped as expired and **not** ordered
+ * against: it can neither be aged out nor placed, so the race has no answer and this refuses. The
+ * tempting alternatives both break the invariant — treating it as expired discards a possibly-live
+ * competitor, and treating it as newest lets an unreadable marker lose a race it was never placed
+ * in.
+ */
+export const resolveClaim = ({
+	markers,
+	session,
+	now,
+	ttlMinutes,
+}: ResolveInput): ClaimResolution => {
+	const ttlMs = ttlMinutes * 60_000;
+	const live: Marker[] = [];
+	let expired = 0;
+	for (const marker of markers) {
+		const at = instantOf(marker.createdAt);
+		if (at === null) {
+			return {
+				_tag: "Unresolvable",
+				reason: `comment ${marker.id} carries no readable created_at, so the markers cannot be ordered`,
+			};
+		}
+		if (now - at > ttlMs) expired++;
+		else live.push(marker);
+	}
+
+	const ordered = [...live].sort((a, b) => {
+		const at = instantOf(a.createdAt) ?? 0;
+		const bt = instantOf(b.createdAt) ?? 0;
+		return at === bt ? a.id - b.id : at - bt;
+	});
+
+	const mine = ordered.find((m) => m.session === session) ?? null;
+	const earliest = ordered[0];
+	if (earliest === undefined || mine === null) {
+		return {_tag: "MineAbsent", live: live.length, expired};
+	}
+	return earliest.session === session
+		? {_tag: "Won", marker: earliest, live: live.length, expired}
+		: {_tag: "Lost", holder: earliest, mine, live: live.length, expired};
+};
+
+/**
+ * This session's surviving marker, on either resolved outcome — `null` when it holds none.
+ *
+ * What "do I already hold a live marker here?" and "which marker do I retract on a loss?" both ask,
+ * so both ask it once.
+ */
+export const myMarker = (resolution: ClaimResolution): Marker | null =>
+	resolution._tag === "Won"
+		? resolution.marker
+		: resolution._tag === "Lost"
+			? resolution.mine
+			: null;
+
+/** When a marker created at `createdAt` stops binding, as an ISO instant. */
+export const expiryOf = (createdAt: string, ttlMinutes: number): string | null => {
+	const at = instantOf(createdAt);
+	return at === null ? null : new Date(at + ttlMinutes * 60_000).toISOString();
+};

--- a/packages/fabrika-cli/src/triage/claim.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim.unit.test.ts
@@ -1,0 +1,179 @@
+import {describe, expect, it} from "vitest";
+import {
+	expiryOf,
+	MARKER_PREFIX,
+	markerBody,
+	markersOf,
+	myMarker,
+	resolveClaim,
+	sessionOf,
+} from "./claim.ts";
+
+const MINE = "b2e1-4c07-4a99-9f30-55da1e6b7c02";
+const THEIRS = "7f3c-9a20-4b11-8e05-1d77c2a4f9be";
+
+const at = (iso: string) => Date.parse(iso);
+
+const marker = (id: number, session: string, createdAt: string) => ({
+	id,
+	session,
+	createdAt,
+});
+
+describe("markerBody / sessionOf", () => {
+	it("round-trips the exact one-line literal", () => {
+		expect(markerBody(MINE)).toBe(`${MARKER_PREFIX}${MINE} -->`);
+		expect(sessionOf(markerBody(MINE))).toBe(MINE);
+	});
+
+	it("ignores any comment that does not carry the prefix", () => {
+		expect(sessionOf("I am triaging this one, hands off")).toBeNull();
+		expect(sessionOf(`prose then ${markerBody(MINE)}`)).toBeNull();
+	});
+
+	it("reads a malformed marker as a foreign claim, never as absent", () => {
+		// Some session posted it. Dropping it would silently ignore a live competitor, which is the
+		// one direction the protocol may not fail.
+		expect(sessionOf(`${MARKER_PREFIX} -->`)).toBe("");
+		expect(sessionOf(`${MARKER_PREFIX}${MINE}`)).toBe(MINE);
+	});
+});
+
+describe("markersOf", () => {
+	it("keeps only the marker comments, in read order", () => {
+		expect(
+			markersOf([
+				{id: 1, createdAt: "2026-08-02T09:00:00Z", body: "a human comment"},
+				{id: 2, createdAt: "2026-08-02T09:14:02Z", body: markerBody(THEIRS)},
+				{id: 3, createdAt: "2026-08-02T09:15:00Z", body: markerBody(MINE)},
+			]),
+		).toEqual([
+			{id: 2, session: THEIRS, createdAt: "2026-08-02T09:14:02Z"},
+			{id: 3, session: MINE, createdAt: "2026-08-02T09:15:00Z"},
+		]);
+	});
+});
+
+describe("resolveClaim", () => {
+	const now = at("2026-08-02T10:00:00Z");
+
+	it("wins only when the earliest surviving marker is this session's", () => {
+		const out = resolveClaim({
+			markers: [marker(3, MINE, "2026-08-02T09:50:00Z")],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		expect(out).toMatchObject({_tag: "Won", live: 1, expired: 0});
+	});
+
+	it("loses to an earlier live marker and names the holder", () => {
+		const out = resolveClaim({
+			markers: [marker(3, MINE, "2026-08-02T09:50:00Z"), marker(2, THEIRS, "2026-08-02T09:14:02Z")],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		expect(out).toMatchObject({_tag: "Lost"});
+		if (out._tag !== "Lost") throw new Error("unreachable");
+		expect(out.holder.session).toBe(THEIRS);
+		expect(out.mine.id).toBe(3);
+	});
+
+	it("breaks a created_at tie on the lower comment id", () => {
+		const same = "2026-08-02T09:50:00Z";
+		const out = resolveClaim({
+			markers: [marker(9, MINE, same), marker(4, THEIRS, same)],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		expect(out._tag).toBe("Lost");
+	});
+
+	it("discards a marker older than the TTL and counts it", () => {
+		const out = resolveClaim({
+			markers: [marker(2, THEIRS, "2026-08-02T08:00:00Z"), marker(3, MINE, "2026-08-02T09:50:00Z")],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		expect(out).toMatchObject({_tag: "Won", live: 1, expired: 1});
+	});
+
+	it("keeps a marker exactly at the TTL boundary binding", () => {
+		const out = resolveClaim({
+			markers: [marker(2, THEIRS, "2026-08-02T09:00:00Z"), marker(3, MINE, "2026-08-02T09:50:00Z")],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		expect(out._tag).toBe("Lost");
+	});
+
+	it("REFUSES rather than answering when an ordering key will not parse — `won` needs proof", () => {
+		const out = resolveClaim({
+			markers: [marker(2, THEIRS, "not-a-timestamp"), marker(3, MINE, "2026-08-02T09:50:00Z")],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		expect(out._tag).toBe("Unresolvable");
+	});
+
+	it("reports MineAbsent — never Won — when no marker of this session survives", () => {
+		expect(resolveClaim({markers: [], session: MINE, now, ttlMinutes: 60})._tag).toBe("MineAbsent");
+		expect(
+			resolveClaim({
+				markers: [marker(2, THEIRS, "2026-08-02T09:14:02Z")],
+				session: MINE,
+				now,
+				ttlMinutes: 60,
+			})._tag,
+		).toBe("MineAbsent");
+	});
+
+	it("never resolves Won for a session that is not the caller's, whatever the marker set", () => {
+		// The fail-open shape v1 shipped: an empty identity compared equal to everything. Here an
+		// empty session matches only a marker that literally carries none.
+		const out = resolveClaim({
+			markers: [marker(2, THEIRS, "2026-08-02T09:14:02Z")],
+			session: "",
+			now,
+			ttlMinutes: 60,
+		});
+		expect(out._tag).not.toBe("Won");
+	});
+});
+
+describe("myMarker", () => {
+	it("finds this session's marker on both resolved outcomes and nowhere else", () => {
+		const now = at("2026-08-02T10:00:00Z");
+		const won = resolveClaim({
+			markers: [marker(3, MINE, "2026-08-02T09:50:00Z")],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		const lost = resolveClaim({
+			markers: [marker(3, MINE, "2026-08-02T09:50:00Z"), marker(2, THEIRS, "2026-08-02T09:14:02Z")],
+			session: MINE,
+			now,
+			ttlMinutes: 60,
+		});
+		expect(myMarker(won)?.id).toBe(3);
+		expect(myMarker(lost)?.id).toBe(3);
+		expect(myMarker({_tag: "Unresolvable", reason: "r"})).toBeNull();
+		expect(myMarker({_tag: "MineAbsent", live: 0, expired: 0})).toBeNull();
+	});
+});
+
+describe("expiryOf", () => {
+	it("adds the TTL to the comment's own created_at", () => {
+		expect(expiryOf("2026-08-02T09:14:02Z", 60)).toBe("2026-08-02T10:14:02.000Z");
+	});
+
+	it("is null when the created_at will not parse", () => {
+		expect(expiryOf("nope", 60)).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/triage/claim.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim.unit.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 import {
 	expiryOf,
+	isStampableSession,
 	MARKER_PREFIX,
 	markerBody,
 	markersOf,
@@ -36,6 +37,29 @@ describe("markerBody / sessionOf", () => {
 		// one direction the protocol may not fail.
 		expect(sessionOf(`${MARKER_PREFIX} -->`)).toBe("");
 		expect(sessionOf(`${MARKER_PREFIX}${MINE}`)).toBe(MINE);
+	});
+});
+
+describe("isStampableSession", () => {
+	it("accepts a single whitespace-free token", () => {
+		expect(isStampableSession(MINE)).toBe(true);
+	});
+
+	it("rejects an id carrying whitespace — it would read back as a different session", () => {
+		expect(isStampableSession("two tokens")).toBe(false);
+		expect(isStampableSession("")).toBe(false);
+	});
+
+	it("rejects an id carrying `-->` — it would close the comment and escape as body text", () => {
+		// Both halves of the guard are load-bearing, and only the whitespace half fails loudly. An id
+		// containing `-->` is a single token, so it passes the first half; what it produces is
+		// `<!-- fabrika-triage-claim session=-->@here -->`, whose comment ends at the FIRST `-->` and
+		// renders `@here -->` as visible markdown in the comment this verb posts.
+		expect(isStampableSession("-->x")).toBe(false);
+		expect(isStampableSession("-->@here")).toBe(false);
+		// the escape itself, so the guard is pinned to the thing it prevents rather than to a literal
+		const escaped = markerBody("-->@here");
+		expect(escaped.indexOf("-->")).toBeLessThan(escaped.length - "-->".length);
 	});
 });
 

--- a/packages/fabrika-cli/src/triage/claim.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim.unit.test.ts
@@ -143,6 +143,17 @@ describe("resolveClaim", () => {
 			ttlMinutes: 60,
 		});
 		expect(out._tag).not.toBe("Won");
+
+		// With a marker of its own present the MineAbsent branch no longer short-circuits, so the
+		// winner comparison itself runs — which is where the empty identity would compare equal. This
+		// case, not the one above, is what pins it.
+		const holdingOne = resolveClaim({
+			markers: [marker(2, THEIRS, "2026-08-02T09:14:02Z"), marker(3, "", "2026-08-02T09:50:00Z")],
+			session: "",
+			now,
+			ttlMinutes: 60,
+		});
+		expect(holdingOne._tag).toBe("Lost");
 	});
 });
 

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -20,6 +20,7 @@ import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {runApply} from "./apply-verb.ts";
+import {DEFAULT_TTL_MINUTES, runClaim} from "./claim-verb.ts";
 import {runCodes} from "./codes-verb.ts";
 import {AUDIENCES, PRIORITIES, STANDING_LANES, TYPES} from "./facets.ts";
 import {runKill} from "./kill-verb.ts";
@@ -220,6 +221,37 @@ const park = leafCommand(
 	),
 );
 
+const claim = leafCommand(
+	"claim",
+	{
+		issue: Argument.integer("issue").pipe(Argument.withDescription("the issue number to claim")),
+		ttlMinutes: Flag.integer("ttl-minutes").pipe(
+			Flag.withDefault(DEFAULT_TTL_MINUTES),
+			Flag.withDescription(
+				`how long an existing claim marker stays binding before it is treated as abandoned (default: ${DEFAULT_TTL_MINUTES})`,
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, ttlMinutes, repo, json}) {
+		yield* emit(
+			yield* runClaim({
+				issue,
+				ttlMinutes,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Take a session-scoped claim on one issue, proven by re-reading the markers back. Prints `won` or `lost\\t<holder-session-id>` — both are proven answers and both exit 0. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 7 (no such issue, or it is closed), 8 (marker POST failed — UNKNOWN), 9 (marker absent on read-back, or a conceded marker could not be deleted), 11 (the issue or its comments could not be read — never "won"). Example: fabrika triage claim 4312',
+	),
+);
+
 export const triageCommand = Command.make("triage").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
@@ -229,6 +261,7 @@ export const triageCommand = Command.make("triage").pipe(
 		split,
 		apply,
 		park,
+		claim,
 	]),
 	Command.withDescription(
 		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",


### PR DESCRIPTION
Part of #4831 — slice 2 of the nine-verb `triage` group. **Not `Fixes`:** the other seven verbs and
the `report dedup --exclude` extension are still outstanding, so this must not close the issue.

## What this is

`triage claim` — take a session-scoped claim on one issue, proven by re-reading the markers back.
The whole verb is one rule: **`won` requires positive proof that the earliest surviving marker is
this session's.** Post the session-stamped marker, re-read every marker on the issue, discard the
ones older than the TTL, and let the earliest survivor win.

`won` and `lost` are **both proven answers** and both exit 0, discriminated by the state word on
stdout — seating a loss on a non-zero code would make "another sweep holds it" indistinguishable
from "the verb is broken". Every state that *cannot* be proven refuses instead: an unreadable
comment list, a payload that is not a list of comments, an entry that is not a comment, and a marker
whose `created_at` will not parse all land on `11` with nothing on stdout. v1's claim printed `won`
on exactly that kind of absence, because an empty identity compared equal to everything.

## Files

- `packages/fabrika-cli/src/triage/claim.ts` — the marker literal, the parse, and the pure resolution
- `packages/fabrika-cli/src/triage/claim-verb.ts` — the IO, the concede-and-delete, the exit codes
- `packages/fabrika-cli/src/triage/command.ts` — the leaf, appended to the group's one-per-line list
- `claim.unit.test.ts` / `claim-verb.unit.test.ts` — the package's existing test idiom

## Contract conformance (this verb's slice of the acceptance criteria)

- Allocates only from the shared exit table: `1` (unset/invalid session, bad operands), `7` (no such
  issue, or closed), `8` (marker POST failed — UNKNOWN whether it landed), `9` (marker absent on
  read-back, or a conceded marker could not be deleted), `11` (issue or comments unreadable).
- No non-zero exit prints a partial or permissive answer — every refusal path asserts empty stdout.
- Every "nothing found" case is a state word on stdout (`won` / `lost\t<holder>`), never an absence.
- The comment read paginates and reports its scanned count on stderr.

## Mutation verification

Ten load-bearing behaviours were each reverted, proven to turn a test RED, restored, and proven
GREEN again. Full suite after the repair round: **646 passing across 47 files**; `typecheck` and
`lint:worktree` green.

| # | Behaviour reverted | Result |
|---|---|---|
| M1 | `won` needs a real session-identity match — an empty identity may not compare equal to every marker | RED (killed) |
| M2 | a surviving set holding no marker of mine resolves `MineAbsent`, never an ordered outcome | RED (killed) |
| M3 | an unparseable `created_at` REFUSES (`Unresolvable`) rather than being aged out as expired | RED (killed) |
| M4 | the TTL actually discards an aged-out marker instead of letting it keep binding | RED (killed) |
| M5 | a prefix-only (malformed) marker reads as a foreign claim, never as absent | RED (killed) |
| M6 | a losing claim deletes the marker it just posted (concede-and-delete) | RED (killed) |
| M7 | an unreadable comment list refuses at `11` — never "no competing claim" | RED (killed) |
| M8 | re-running inside one session is idempotent — it posts no second marker | RED (killed) |
| M9 | a failed marker POST is seated on `8` (write UNKNOWN), distinct from `1` | RED (killed) |
| M10 | `isStampableSession` rejects an id containing `-->`, which would close the marker comment early | RED (killed) |

**M1 survived the first pass**, and the fix is the second commit here. The mutant was v1's exact
fail-open — `earliest.session === session || session === ""` — and the whole suite stayed green
under it. The existing case fed session `""` a marker set holding none of its own, so it resolved
`MineAbsent` and returned *before* the winner comparison ever ran; its assertion was
`not.toBe("Won")`, which the mutant satisfies. Giving the empty session a marker of its own is what
makes the branch reachable, and only then does the real comparison keep the answer `Lost`. The
module's central claim was documented but unpinned.

**M10 is the same shape, found by the gate rather than by me, and fixed in repair round 1.** Only
the whitespace half of `isStampableSession` had a case; deleting `&& !session.includes("-->")` left
60/60 green. `markerBody("-->@here")` yields `<!-- fabrika-triage-claim session=-->@here -->`, whose
HTML comment ends at the *first* `-->`, so `@here -->` renders as visible markdown in the comment
the verb posts. Stated straight: this is **not** a fail-open on the claim verdict — `sessionOf`
still round-trips such an id and `CLAUDE_CODE_SESSION_ID` is harness-supplied — it is
defence-in-depth whose regression would be silent, which is the bar this PR set for itself.

## Notes for review

- Read-back normalization is not exercised here: `claim` compares marker *identity*, not body text,
  so the contract's normalized-comparison requirement lands on the write verbs in later slices.
- The one disclosed contract tension is the class-2 entry below, not repeated here.

## Deviations

- **Scope narrowing** — **Said:** #4831's acceptance criteria cover all nine `triage` verbs plus the
  `report dedup --exclude` extension. **Did:** this PR delivers `claim` only — slice 2 of nine —
  linked `Part of #4831` rather than `Fixes`. **Why:** nine verbs in one diff is not reviewable
  against a per-verb exit-code contract, and the group is being landed slice by slice so each verb's
  refusal paths get their own mutation pass. **Disposition:** no action needed — #4831 stays open and
  tracks the remaining slices; §9's partial-split token is the mechanism, and this entry is the
  reasoning it must not stand in for.
- **Governing-contract departure** — **Said:** the group's rule, stated in `verb.ts`'s own docblock
  (#4208 / #4219), is that a proven refusal never shares an exit code with a failure to invoke.
  **Did:** an unset `CLAUDE_CODE_SESSION_ID` is seated on `1`, the same code as bad operands.
  **Why:** the merged contract's errors table puts it there, and an unstamped environment is
  arguably a precondition of *invoking* the verb rather than a verdict the verb reached — but that
  reading is not obviously the right one. **Disposition:** for the reviewer to judge. It is a
  contract question, not an implementation one; renumbering it here would fork the errors table
  against every other verb in the group.
