### PR TITLE
feat(fabrika): triage queue/provenance/homes + report dedup --exclude (slice 1b of #4831)

### DIFF
--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -547,6 +547,51 @@ export const closeNotPlanned = (repo: string, issue: number): Shell<Attempt<void
 		return r.ok ? ok(undefined) : fail(r.reason);
 	});
 
+/** One intake-queue row. `IssueRow` omits `created_at`, and the age is half of what a queue prints. */
+export interface QueueIssue {
+	readonly number: number;
+	readonly createdAt: string;
+	readonly title: string;
+}
+
+/**
+ * Open issues carrying `label` with their filing time, paged, pull requests filtered out.
+ *
+ * The rows are cut at the **first two** tabs rather than through {@link parseTabRows}, because a
+ * title may itself contain a tab: a strict three-field split would turn one odd title into a failed
+ * read of the whole queue, and a queue that cannot be read is a sweep that cannot terminate.
+ */
+export const openQueueIssues = (
+	repo: string,
+	label: string,
+): Shell<Attempt<ReadonlyArray<QueueIssue>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues?state=open&labels=${encodeURIComponent(label)}&per_page=100`,
+			"--jq",
+			'.[] | select(.pull_request | not) | "\\(.number)\t\\(.created_at)\t\\(.title)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows: QueueIssue[] = [];
+		for (const line of r.stdout.split("\n")) {
+			if (line === "") continue;
+			const first = line.indexOf("\t");
+			const second = line.indexOf("\t", first + 1);
+			if (first <= 0 || second <= first) {
+				return fail("`gh api` exited 0 but its output is not a list of queue rows");
+			}
+			const number = line.slice(0, first);
+			const createdAt = line.slice(first + 1, second);
+			if (!/^\d+$/.test(number) || Number.isNaN(Date.parse(createdAt))) {
+				return fail("`gh api` exited 0 but a queue row carries no issue number and filing time");
+			}
+			rows.push({number: Number.parseInt(number, 10), createdAt, title: line.slice(second + 1)});
+		}
+		return ok(rows);
+	});
+
 /** An issue or pull request that references this one, from the timeline. */
 export interface CrossReference {
 	readonly number: number;

--- a/packages/fabrika-cli/src/io/issues.unit.test.ts
+++ b/packages/fabrika-cli/src/io/issues.unit.test.ts
@@ -10,6 +10,7 @@ import {
 	issueTimeline,
 	listComments,
 	listOpenMilestones,
+	openQueueIssues,
 	parseTabRows,
 	patchIssueBody,
 	removeLabel,
@@ -250,6 +251,96 @@ describe("the writes send the fields the API needs, in the form it accepts", () 
 			"Failure",
 		);
 		expect((await run(Effect.provide(deleteComment("r/r", 9), failing)))._tag).toBe("Failure");
+	});
+});
+
+describe("openQueueIssues", () => {
+	it("pages, filters pull requests out, and carries the filing time the age is computed from", async () => {
+		const shell = fakeShell([
+			[
+				/gh api/,
+				okOut(
+					"4312\t2026-08-01T00:00:00Z\tAbort reason lost\n4088\t2026-07-01T00:00:00Z\tCancellation\n",
+				),
+			],
+		]);
+		const result = await run(
+			Effect.provide(openQueueIssues("kamp-us/phoenix", "status:needs-triage"), shell.layer),
+		);
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [
+				{number: 4312, createdAt: "2026-08-01T00:00:00Z", title: "Abort reason lost"},
+				{number: 4088, createdAt: "2026-07-01T00:00:00Z", title: "Cancellation"},
+			],
+		});
+		expect(shell.calls[0]).toContain("--paginate");
+		expect(shell.calls[0]).toContain("per_page=100");
+		expect(shell.calls[0]).toContain("pull_request | not");
+	});
+
+	it("cuts at the FIRST TWO tabs, so a title containing a tab does not fail the whole queue", async () => {
+		const result = await run(
+			Effect.provide(
+				openQueueIssues("o/r", "l"),
+				fakeShell([[/gh api/, okOut("7\t2026-08-01T00:00:00Z\ta\tb\tc\n")]]).layer,
+			),
+		);
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [{number: 7, createdAt: "2026-08-01T00:00:00Z", title: "a\tb\tc"}],
+		});
+	});
+
+	it("escapes the label into the query string", async () => {
+		const shell = fakeShell([[/gh api/, okOut("")]]);
+		await run(Effect.provide(openQueueIssues("o/r", "status:needs-triage"), shell.layer));
+		expect(shell.calls[0]).toContain("labels=status%3Aneeds-triage");
+	});
+
+	it("reads no rows as an empty FACT — the caller turns that into the `empty` state word", async () => {
+		const result = await run(
+			Effect.provide(openQueueIssues("o/r", "l"), fakeShell([[/gh api/, okOut("")]]).layer),
+		);
+		expect(result).toEqual({_tag: "Ok", value: []});
+	});
+
+	it("refuses a 0 exit whose bytes are not queue rows, rather than reading them positionally", async () => {
+		const tooFewFields = await run(
+			Effect.provide(
+				openQueueIssues("o/r", "l"),
+				fakeShell([[/gh api/, okOut("7\ttitle\n")]]).layer,
+			),
+		);
+		expect(tooFewFields._tag).toBe("Failure");
+
+		const notANumber = await run(
+			Effect.provide(
+				openQueueIssues("o/r", "l"),
+				fakeShell([[/gh api/, okOut("jq: error\t2026-08-01T00:00:00Z\tt\n")]]).layer,
+			),
+		);
+		expect(notANumber._tag).toBe("Failure");
+	});
+
+	it("refuses a row whose second field is not a filing time — an unparseable age is not 0", async () => {
+		const result = await run(
+			Effect.provide(
+				openQueueIssues("o/r", "l"),
+				fakeShell([[/gh api/, okOut("7\tnot-a-date\tt\n")]]).layer,
+			),
+		);
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("refuses rather than returning a short list when the read fails", async () => {
+		const result = await run(
+			Effect.provide(
+				openQueueIssues("o/r", "l"),
+				fakeShell([[/gh api/, errOut("gh: Bad gateway (HTTP 502)")]]).layer,
+			),
+		);
+		expect(result._tag).toBe("Failure");
 	});
 });
 

--- a/packages/fabrika-cli/src/report/command.ts
+++ b/packages/fabrika-cli/src/report/command.ts
@@ -64,15 +64,22 @@ const dedup = leafCommand(
 			Flag.withDefault(DEFAULT_LIMIT),
 			Flag.withDescription(`the maximum number of candidates to print (default: ${DEFAULT_LIMIT})`),
 		),
+		exclude: Flag.integer("exclude").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"an issue number to omit from both sources — the issue being deduped, so it never flags itself",
+			),
+		),
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({query, label, limit, repo, json}) {
+	Effect.fn(function* ({query, label, limit, exclude, repo, json}) {
 		yield* emit(
 			yield* runDedup({
 				query,
 				label,
 				limit,
+				exclude: Option.getOrNull(exclude),
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,
@@ -81,7 +88,7 @@ const dedup = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		'Rank the open issues that may already cover an observation. First stdout line is the outcome token — candidates | none | indeterminate — and ALL THREE exit 0; a candidates list adds one `<number>\\t<source>\\t<score>\\t<title>` line per entry. Exits 3 (queue unreadable), 4 (search index unreadable), 7 (--label does not exist, so the queue half would scan nothing). Example: fabrika report dedup --query "retry helper swallows the abort reason"',
+		'Rank the open issues that may already cover an observation. First stdout line is the outcome token — candidates | none | indeterminate — and ALL THREE exit 0; a candidates list adds one `<number>\\t<source>\\t<score>\\t<title>` line per entry. Exits 3 (queue unreadable), 4 (search index unreadable), 7 (--label does not exist, so the queue half would scan nothing). Example: fabrika report dedup --query "retry helper swallows the abort reason" --exclude 4312',
 	),
 );
 

--- a/packages/fabrika-cli/src/report/dedup-verb.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.ts
@@ -41,13 +41,15 @@ export interface DedupOptions {
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The issue being deduped, filtered from both sources so it never flags itself. */
+	readonly exclude: number | null;
 }
 
 export const runDedup = (
 	options: DedupOptions,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
-		const {label, limit, json} = options;
+		const {label, limit, json, exclude} = options;
 
 		if (options.query.trim() === "") return refuse(FAILED, "report dedup: --query is empty.");
 		if (limit < 0) return refuse(FAILED, `report dedup: --limit ${limit} is negative.`);
@@ -80,7 +82,7 @@ export const runDedup = (
 
 		const tokens = tokenize(options.query);
 		if (tokens.length < 2) {
-			const result = rank({tokens, queue: [], search: [], limit, label});
+			const result = rank({tokens, queue: [], search: [], limit, label, exclude});
 			const scope = `report dedup: ${repo}, tokens: ${tokens.join(", ") || "(none)"} — neither source was read, because the query cannot discriminate.`;
 			const diagnostics = [scope, `report dedup: ${result.reason}.`];
 			return json
@@ -120,8 +122,9 @@ export const runDedup = (
 			);
 		}
 
-		const result = rank({tokens, queue: queue.value, search: search.value, limit, label});
-		const scope = `report dedup: ${repo}, ${queue.value.length} open issue(s) in the ${label} queue, ${search.value.length} search hit(s); tokens: ${tokens.join(", ")}${result.truncated ? `; list TRUNCATED to --limit ${limit}` : ""}.`;
+		const result = rank({tokens, queue: queue.value, search: search.value, limit, label, exclude});
+		const excluded = exclude === null ? "" : `; #${exclude} excluded from both sources`;
+		const scope = `report dedup: ${repo}, ${queue.value.length} open issue(s) in the ${label} queue, ${search.value.length} search hit(s)${excluded}; tokens: ${tokens.join(", ")}${result.truncated ? `; list TRUNCATED to --limit ${limit}` : ""}.`;
 		const diagnostics =
 			result.reason === null ? [scope] : [scope, `report dedup: ${result.reason}.`];
 

--- a/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
@@ -39,6 +39,22 @@ describe("runDedup", () => {
 		expect(out.stdout).toContain("4088\tsearch\t");
 	});
 
+	it("--exclude drops the issue being deduped from both sources, so it cannot flag itself", async () => {
+		const title = "Abort reason lost when the retry helper re-wraps the request";
+		const out = await run(
+			[labelsOk, [QUEUE, okOut(`4312\t${title}`)], [SEARCH, okOut(`4312\t${title}`)]],
+			{exclude: 4312},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("none\n");
+		expect(out.stderr.join("\n")).toContain("#4312 excluded from both sources");
+	});
+
+	it("says nothing about exclusion on the scope line when --exclude was not given", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut("")], [SEARCH, okOut("")]]);
+		expect(out.stderr.join("\n")).not.toContain("excluded from both sources");
+	});
+
 	it("exits 0 on a PROVEN none, printing the token rather than empty stdout", async () => {
 		const out = await run([labelsOk, [QUEUE, okOut("")], [SEARCH, okOut("")]]);
 		expect(out.code).toBe(0);

--- a/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
@@ -14,6 +14,7 @@ const options = {
 	limit: 20,
 	repo: null,
 	json: false,
+	exclude: null as number | null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 

--- a/packages/fabrika-cli/src/report/dedup.ts
+++ b/packages/fabrika-cli/src/report/dedup.ts
@@ -102,6 +102,16 @@ export interface RankInput {
 	readonly search: ReadonlyArray<Row>;
 	readonly limit: number;
 	readonly label: string;
+	/**
+	 * An issue number to omit from **both** sources — the issue being deduped, so it never flags
+	 * itself. Absent filters nothing.
+	 *
+	 * The filter runs here, after retrieval and **before scoring and the cap**, so excluding an issue
+	 * never changes the rank order of the rest and never lets a truncated row take the excluded
+	 * issue's place. A number matching nothing is not an error: the caller's intent — "not this one"
+	 * — is satisfied either way.
+	 */
+	readonly exclude?: number | null;
 }
 
 /**
@@ -112,7 +122,12 @@ export interface RankInput {
  * body**, so it is kept regardless of its title score. `both` is the strongest duplicate signal.
  */
 export const rank = (input: RankInput): RankResult => {
-	const {tokens, queue, search, limit, label} = input;
+	const {tokens, limit, label} = input;
+	const excluded = input.exclude ?? null;
+	const keep = (rows: ReadonlyArray<Row>) =>
+		excluded === null ? rows : rows.filter((row) => row.number !== excluded);
+	const queue = keep(input.queue);
+	const search = keep(input.search);
 
 	if (tokens.length < TOKEN_FLOOR) {
 		return {

--- a/packages/fabrika-cli/src/report/dedup.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup.unit.test.ts
@@ -140,6 +140,58 @@ describe("rank", () => {
 		expect(none.outcome).toBe("indeterminate");
 	});
 
+	it("omits --exclude from BOTH sources, so an issue can no longer flag itself", () => {
+		const self = {number: 4312, title: "Abort reason lost in the retry helper"};
+		const other = {number: 4088, title: "Abort reason lost in the retry helper"};
+		const result = rank({
+			tokens,
+			queue: [self, other],
+			search: [self],
+			limit: 20,
+			label: "status:needs-triage",
+			exclude: 4312,
+		});
+		expect(result.candidates.map((c) => c.number)).toEqual([4088]);
+		// `search` was the only other source carrying 4312, so the survivor is a plain queue hit —
+		// proof the filter ran on the search half too, not just the queue half.
+		expect(result.candidates[0]?.source).toBe("queue");
+	});
+
+	it("filters BEFORE the cap, so an excluded row never gives up its slot to a truncated one", () => {
+		const queue = Array.from({length: 3}, (_, i) => ({number: i + 1, title: "retry helper"}));
+		const result = rank({tokens, queue, search: [], limit: 2, label: "l", exclude: 3});
+		expect(result.candidates.map((c) => c.number)).toEqual([2, 1]);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("reports `none` — the proven negative — when the only match was the excluded issue", () => {
+		const result = rank({
+			tokens,
+			queue: [{number: 4312, title: "Abort reason lost in the retry helper"}],
+			search: [],
+			limit: 20,
+			label: "status:needs-triage",
+			exclude: 4312,
+		});
+		expect(result.outcome).toBe("none");
+		expect(result.candidates).toEqual([]);
+	});
+
+	it("treats an --exclude matching nothing as satisfied, not as an error", () => {
+		const queue = [{number: 4088, title: "Abort reason lost in the retry helper"}];
+		const excluded = rank({tokens, queue, search: [], limit: 20, label: "l", exclude: 999});
+		const plain = rank({tokens, queue, search: [], limit: 20, label: "l"});
+		expect(excluded).toEqual(plain);
+	});
+
+	it("filters nothing when --exclude is absent or null", () => {
+		const queue = [{number: 4312, title: "Abort reason lost in the retry helper"}];
+		expect(rank({tokens, queue, search: [], limit: 20, label: "l"}).candidates).toHaveLength(1);
+		expect(
+			rank({tokens, queue, search: [], limit: 20, label: "l", exclude: null}).candidates,
+		).toHaveLength(1);
+	});
+
 	it("never reports a degenerate query as `none`, even when candidates exist", () => {
 		const result = rank({
 			tokens: ["thing"],

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -23,8 +23,11 @@ import {runApply} from "./apply-verb.ts";
 import {DEFAULT_TTL_MINUTES, runClaim} from "./claim-verb.ts";
 import {runCodes} from "./codes-verb.ts";
 import {AUDIENCES, PRIORITIES, STANDING_LANES, TYPES} from "./facets.ts";
+import {DEFAULT_ROADMAP, runHomes} from "./homes-verb.ts";
 import {runKill} from "./kill-verb.ts";
 import {runPark} from "./park-verb.ts";
+import {runProvenance} from "./provenance-verb.ts";
+import {DEFAULT_QUEUE_LABEL, DEFAULT_QUEUE_LIMIT, runQueue} from "./queue-verb.ts";
 import {runSplit} from "./split-verb.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
@@ -252,6 +255,79 @@ const claim = leafCommand(
 	),
 );
 
+const queue = leafCommand(
+	"queue",
+	{
+		label: Flag.string("label").pipe(
+			Flag.withDefault(DEFAULT_QUEUE_LABEL),
+			Flag.withDescription(
+				`the intake-queue label whose open issues form the queue (default: ${DEFAULT_QUEUE_LABEL})`,
+			),
+		),
+		limit: Flag.integer("limit").pipe(
+			Flag.withDefault(DEFAULT_QUEUE_LIMIT),
+			Flag.withDescription(`the maximum number of rows to print (default: ${DEFAULT_QUEUE_LIMIT})`),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({label, limit, repo, json}) {
+		yield* emit(
+			yield* runQueue({
+				label,
+				limit,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"List the claimable intake queue, oldest first. First stdout line is the outcome token — queued | empty — and a queued list adds one `<number>\\t<age-days>\\t<title>` line per issue; the scanned count is on stderr. Exits 7 (--label does not exist, so the queue would scan nothing), 11 (the queue read failed — UNKNOWN, never `empty`). Example: fabrika triage queue --limit 20",
+	),
+);
+
+const provenance = leafCommand(
+	"provenance",
+	{
+		issue: Argument.integer("issue").pipe(Argument.withDescription("the issue number to inspect")),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, repo, json}) {
+		yield* emit(
+			yield* runProvenance({issue, repo: Option.getOrNull(repo), json, env: process.env}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Say whether an issue was filed by an agent or typed by a human, from the agent footer rather than the author — every report-filed issue shows the same account (ADR 0159). Prints `agent` or `human`; an empty body answers `human` fail-closed, an unreadable one refuses. Exits 7 (issue proven absent), 11 (unreadable — the provenance is UNKNOWN, never `human`). Example: fabrika triage provenance 4312",
+	),
+);
+
+const homes = leafCommand(
+	"homes",
+	{
+		roadmap: Flag.string("roadmap").pipe(
+			Flag.withDefault(DEFAULT_ROADMAP),
+			Flag.withDescription(
+				`the roadmap file whose ## Arcs and ## Campaigns tables the open milestones join to (default: ${DEFAULT_ROADMAP})`,
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({roadmap, repo, json}) {
+		yield* emit(yield* runHomes({roadmap, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"List the assignable homes: every OPEN milestone joined to its roadmap arc/campaign row by `#<number>`, plus the two standing lanes. First stdout line is `homes`, then one `<kind>\\t<key>\\t<label>` line per candidate. Exits 7 (zero open milestones, or the roadmap parsed to 0 arc rows), 11 (the milestone list or the roadmap could not be read). Example: fabrika triage homes",
+	),
+);
+
 export const triageCommand = Command.make("triage").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
@@ -262,6 +338,9 @@ export const triageCommand = Command.make("triage").pipe(
 		apply,
 		park,
 		claim,
+		queue,
+		provenance,
+		homes,
 	]),
 	Command.withDescription(
 		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",

--- a/packages/fabrika-cli/src/triage/homes-verb.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.ts
@@ -1,0 +1,133 @@
+/**
+ * `triage homes` — the assignable homes: every **open** milestone joined to its roadmap arc or
+ * campaign row, plus the two standing lanes.
+ *
+ * **Zero open milestones is a refusal, not an answer.** An empty candidate list routes the caller
+ * toward a standing lane or a close, and a close driven by a failed read is irreversible — so both
+ * "I read nothing" cases red on {@link ZERO_SCOPE} and both "I could not look" cases on
+ * {@link PRECONDITION_UNKNOWN}, never on `1`, which would fuse an unreachable GitHub with a
+ * mistyped flag.
+ *
+ * Curating the milestone set is a human roadmap act (ADR 0072 §3), so this verb creates none. It
+ * offers only open, roadmap-joined milestones, which designs out the mismatch where a closed
+ * milestone reports as a valid home.
+ */
+import {Effect, Result} from "effect";
+import {readFile} from "../io/fs.ts";
+import {listOpenMilestones, resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {parseRoadmap, roadmapRowFor} from "./roadmap.ts";
+import {scannedLine} from "./scope.ts";
+
+export const DEFAULT_ROADMAP = "ROADMAP.md";
+
+/** One standing lane: a label that is a home in its own right, and what routing to it means. */
+export interface StandingLane {
+	readonly label: string;
+	readonly meaning: string;
+}
+
+/**
+ * The two standing lanes, and **the only place in this package that enumerates them.**
+ *
+ * `triage apply --lane` takes its vocabulary from here rather than restating it, so the pair cannot
+ * drift into two lists a reader has to reconcile. The meanings are constants rather than the repo's
+ * live label descriptions, so a description edit cannot change a machine-channel answer. There is no
+ * third lane, and this verb never invents one.
+ */
+export const STANDING_LANES: ReadonlyArray<StandingLane> = [
+	{label: "wayfinder:backlog", meaning: "fog — uncharted work upstream of any arc"},
+	{label: "axis:pipeline-hardening", meaning: "the standing pipeline and reliability lane"},
+];
+
+export interface HomesOptions {
+	readonly roadmap: string;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** The lane rows, on stderr — a `7` refusal withholds stdout entirely, so they go where they fit. */
+const laneNotice = STANDING_LANES.map(
+	(lane) => `triage homes: standing lane ${lane.label} — ${lane.meaning}`,
+);
+
+export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) {
+	const {roadmap, json} = options;
+
+	const repoAttempt = yield* resolveRepo(options.repo, options.env);
+	if (repoAttempt._tag === "Failure") {
+		return refuse(
+			FAILED,
+			"triage homes: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+		);
+	}
+	const repo = repoAttempt.value;
+
+	const milestones = yield* listOpenMilestones(repo);
+	if (milestones._tag === "Failure") {
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`triage homes: cannot read milestones in ${repo}: ${milestones.reason} — the home list is UNKNOWN, never empty.`,
+		);
+	}
+
+	const scope = scannedLine("triage homes", repo, milestones.value.length, "open milestone");
+	if (milestones.value.length === 0) {
+		return refuse(
+			ZERO_SCOPE,
+			`triage homes: ${repo} has 0 open milestones — refusing to answer, since "no home exists" routes to a kill (ADR 0092).`,
+			[scope, ...laneNotice],
+		);
+	}
+
+	const read = yield* Effect.result(readFile(roadmap));
+	if (Result.isFailure(read)) {
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`triage homes: cannot read the roadmap at ${roadmap}: ${read.failure.reason} — the home list is UNKNOWN, never empty.`,
+			[scope],
+		);
+	}
+
+	const rows = parseRoadmap(read.success);
+	// Zero ARC rows is a failed parse, not a repo with no arcs: the table grammar belongs to the
+	// roadmap, so a grammar change silently empties the join. Zero CAMPAIGN rows is a legitimate
+	// state and passes.
+	if (rows.arcs.length === 0) {
+		return refuse(
+			ZERO_SCOPE,
+			`triage homes: the roadmap at ${roadmap} parsed to 0 arc rows — the table grammar changed or the file is truncated; refusing to answer over an unjoinable roadmap.`,
+			[scope, ...laneNotice],
+		);
+	}
+
+	const homes = [...milestones.value]
+		.sort((a, b) => a.number - b.number)
+		.map((milestone) => ({
+			number: milestone.number,
+			title: milestone.title,
+			roadmapRow: roadmapRowFor(rows, milestone.number),
+		}));
+
+	if (json) {
+		return answer(
+			JSON.stringify({
+				outcome: "homes",
+				milestones: homes,
+				lanes: STANDING_LANES,
+				scanned: milestones.value.length,
+			}),
+			[scope],
+		);
+	}
+	return answer(
+		[
+			"homes",
+			...homes.map((home) => `milestone\t${home.number}\t${home.title}`),
+			...STANDING_LANES.map((lane) => `lane\t${lane.label}\t${lane.meaning}`),
+		].join("\n"),
+		[scope],
+	);
+});

--- a/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
@@ -1,0 +1,174 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import {ANSWER, FAILED} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runHomes, STANDING_LANES} from "./homes-verb.ts";
+
+const MILESTONES = /repos\/o\/r\/milestones/;
+
+const ROADMAP = `## Arcs
+
+| Arc | Milestone | State |
+|-----|-----------|-------|
+| Geçit | #24 | active |
+
+## Campaigns
+
+| Campaign | Milestone | State |
+|----------|-----------|-------|
+| fabrika campaign | #44 | active |
+`;
+
+const options = {
+	roadmap: "ROADMAP.md",
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	files: Record<string, string | null> = {"ROADMAP.md": ROADMAP},
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runHomes({...options, ...overrides}),
+			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+		),
+	);
+
+const twoMilestones = [
+	MILESTONES,
+	okOut("24\tSözlük — search and discovery\n44\tfabrika"),
+] as const;
+
+describe("runHomes", () => {
+	it("prints `homes` then the open milestones and the standing lanes", async () => {
+		const out = await run([twoMilestones]);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout.trimEnd().split("\n")).toEqual([
+			"homes",
+			"milestone\t24\tSözlük — search and discovery",
+			"milestone\t44\tfabrika",
+			"lane\twayfinder:backlog\tfog — uncharted work upstream of any arc",
+			"lane\taxis:pipeline-hardening\tthe standing pipeline and reliability lane",
+		]);
+	});
+
+	it("joins a milestone to its roadmap row by NUMBER — the two titles share no substring", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": ROADMAP}, {json: true});
+		const payload = JSON.parse(out.stdout);
+		expect(payload.milestones).toEqual([
+			{number: 24, title: "Sözlük — search and discovery", roadmapRow: "Geçit"},
+			{number: 44, title: "fabrika", roadmapRow: "fabrika campaign"},
+		]);
+	});
+
+	it("reports an open milestone no roadmap row pins as null rather than hiding it", async () => {
+		const out = await run(
+			[[MILESTONES, okOut("99\toff-roadmap")]],
+			{"ROADMAP.md": ROADMAP},
+			{
+				json: true,
+			},
+		);
+		expect(JSON.parse(out.stdout).milestones).toEqual([
+			{number: 99, title: "off-roadmap", roadmapRow: null},
+		]);
+	});
+
+	it("carries the standing lanes into the --json payload from the one enumeration", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": ROADMAP}, {json: true});
+		expect(JSON.parse(out.stdout).lanes).toEqual(STANDING_LANES);
+	});
+
+	it("reports the scanned milestone count on stderr", async () => {
+		const out = await run([twoMilestones]);
+		expect(out.stderr.join("\n")).toContain("scanned 2 open milestones in o/r");
+	});
+
+	it("REFUSES zero open milestones — `no home exists` routes to an irreversible close", async () => {
+		const out = await run([[MILESTONES, okOut("")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("0 open milestones");
+	});
+
+	it("still names the standing lanes on stderr when it refuses over zero milestones", async () => {
+		const out = await run([[MILESTONES, okOut("")]]);
+		expect(out.stderr.join("\n")).toContain("wayfinder:backlog");
+		expect(out.stderr.join("\n")).toContain("axis:pipeline-hardening");
+	});
+
+	it("refuses an unreadable milestone list as UNKNOWN — never as `no homes`", async () => {
+		const out = await run([[MILESTONES, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses an unreadable roadmap as UNKNOWN rather than answering unjoined", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": null});
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("REFUSES a roadmap that parsed to 0 arc rows — a grammar change empties the join silently", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": "# Roadmap\n\nNo tables.\n"});
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("0 arc rows");
+	});
+
+	it("passes a roadmap with arcs but ZERO campaigns — that is a legitimate state", async () => {
+		const arcsOnly = "## Arcs\n\n| Arc | Milestone |\n|---|---|\n| Geçit | #24 |\n";
+		const out = await run([twoMilestones], {"ROADMAP.md": arcsOnly});
+		expect(out.code).toBe(ANSWER);
+	});
+
+	it("pages the milestone read and asks only for open ones", async () => {
+		const shell = fakeShell([twoMilestones]);
+		await Effect.runPromise(
+			Effect.provide(
+				runHomes(options),
+				Layer.merge(shell.layer, fakeFs({files: {"ROADMAP.md": ROADMAP}}).layer),
+			),
+		);
+		expect(shell.calls[0]).toContain("--paginate");
+		expect(shell.calls[0]).toContain("state=open");
+	});
+
+	it("reads the roadmap the --roadmap flag names", async () => {
+		const out = await run(
+			[twoMilestones],
+			{"docs/ROADMAP.md": ROADMAP},
+			{
+				roadmap: "docs/ROADMAP.md",
+			},
+		);
+		expect(out.code).toBe(ANSWER);
+	});
+
+	it("refuses when no target repo resolves", async () => {
+		const out = await run(
+			[[/git remote get-url/, errOut("no origin")]],
+			{"ROADMAP.md": ROADMAP},
+			{
+				env: {},
+			},
+		);
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.at(-1)).toContain("CLAUDE_PIPELINE_REPO");
+	});
+});
+
+describe("STANDING_LANES", () => {
+	it("is the only enumeration of the lanes — two of them, and no third", () => {
+		expect(STANDING_LANES.map((l) => l.label)).toEqual([
+			"wayfinder:backlog",
+			"axis:pipeline-hardening",
+		]);
+	});
+});

--- a/packages/fabrika-cli/src/triage/provenance-verb.ts
+++ b/packages/fabrika-cli/src/triage/provenance-verb.ts
@@ -1,0 +1,72 @@
+/**
+ * `triage provenance` — was this issue filed by an agent or typed by a human?
+ *
+ * The predicate itself lives in `./provenance.ts`, exported because `triage kill` re-checks it
+ * rather than trusting a caller to have run this verb.
+ *
+ * **A present-but-empty body answers `human`; an unreadable one refuses.** Those are different
+ * facts and this verb keeps them apart. An empty body is a measurement — the body is there, it
+ * carries no footer, and the protective reading of "no footer" is `human`, because the only
+ * irreversible act downstream is a kill. An unreadable body is not a measurement at all, and
+ * answering `human` over it would be a verdict manufactured from a failed read.
+ */
+import {Effect} from "effect";
+import {getIssue, resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {hasAgentFooter} from "./provenance.ts";
+
+export interface ProvenanceOptions {
+	readonly issue: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const AGENT_REASON = "the 'Filed by an agent' marker is present in the body";
+const HUMAN_REASON = "no line begins '<sub>Filed by an agent' — the body carries no agent footer";
+const EMPTY_REASON = "the body is empty, so it carries no footer — answering human (fail-closed)";
+
+const render = (
+	json: boolean,
+	outcome: "agent" | "human",
+	marker: boolean,
+	reason: string,
+	stderr: ReadonlyArray<string>,
+): VerbOutcome =>
+	json ? answer(JSON.stringify({outcome, marker, reason}), stderr) : answer(outcome, stderr);
+
+export const runProvenance = Effect.fn("runProvenance")(function* (options: ProvenanceOptions) {
+	const {issue, json} = options;
+
+	const repoAttempt = yield* resolveRepo(options.repo, options.env);
+	if (repoAttempt._tag === "Failure") {
+		return refuse(
+			FAILED,
+			"triage provenance: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+		);
+	}
+	const repo = repoAttempt.value;
+
+	const record = yield* getIssue(repo, issue);
+	if (record._tag === "Absent") {
+		return refuse(ZERO_SCOPE, `triage provenance: issue #${issue} not found in ${repo}.`);
+	}
+	if (record._tag === "Unknown") {
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`triage provenance: cannot read #${issue} in ${repo}: ${record.reason} — the provenance is UNKNOWN; refusing to default it.`,
+		);
+	}
+
+	const body = record.value.body;
+	if (body.trim() === "") {
+		return render(json, "human", false, EMPTY_REASON, [
+			`triage provenance: #${issue} has an empty body — answering human (fail-closed).`,
+		]);
+	}
+	const marker = hasAgentFooter(body);
+	return render(json, marker ? "agent" : "human", marker, marker ? AGENT_REASON : HUMAN_REASON, [
+		`triage provenance: read the body of #${issue} in ${repo} — ${marker ? AGENT_REASON : HUMAN_REASON}.`,
+	]);
+});

--- a/packages/fabrika-cli/src/triage/provenance-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/provenance-verb.unit.test.ts
@@ -1,0 +1,74 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {ANSWER, FAILED} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runProvenance} from "./provenance-verb.ts";
+
+const ISSUE = /repos\/o\/r\/issues\/4312/;
+
+const options = {
+	issue: 4312,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const issueJson = (body: string) =>
+	JSON.stringify({number: 4312, title: "t", html_url: "u", state: "open", labels: [], body});
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runProvenance({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+const AGENT_BODY = "What I observed.\n\n---\n<sub>Filed by an agent · 2026-08-03T05:47:38Z</sub>\n";
+
+describe("runProvenance", () => {
+	it("answers `agent` on the footer, on stdout, exit 0", async () => {
+		const out = await run([[ISSUE, okOut(issueJson(AGENT_BODY))]]);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("agent\n");
+	});
+
+	it("answers `human` for a hand-typed body", async () => {
+		const out = await run([[ISSUE, okOut(issueJson("I hit a bug in the retry helper.\n"))]]);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("human\n");
+	});
+
+	it("answers `human` for a PRESENT-but-empty body — a measurement, fail-closed", async () => {
+		const out = await run([[ISSUE, okOut(issueJson("   \n"))]]);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("human\n");
+		expect(out.stderr.join("\n")).toContain("empty body");
+	});
+
+	it("REFUSES an unreadable issue as UNKNOWN — never `human`, which a kill acts on", async () => {
+		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("UNKNOWN");
+	});
+
+	it("refuses a PROVEN-absent issue on the zero-scope code, apart from the unknown one", async () => {
+		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("puts the --json payload on stdout with the marker and the reason", async () => {
+		const out = await run([[ISSUE, okOut(issueJson(AGENT_BODY))]], {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "agent", marker: true});
+		expect(out.stderr.join("")).not.toContain('"outcome"');
+	});
+
+	it("refuses when no target repo resolves", async () => {
+		const out = await run([[/git remote get-url/, errOut("no origin")]], {env: {}});
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.at(-1)).toContain("CLAUDE_PIPELINE_REPO");
+	});
+});

--- a/packages/fabrika-cli/src/triage/provenance.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/provenance.unit.test.ts
@@ -33,6 +33,10 @@ describe("hasAgentFooter", () => {
 		expect(hasAgentFooter("> <sub>Filed by an agent · 2026-01-01</sub>")).toBe(false);
 	});
 
+	it("answers human on a hand-typed body that never mentions the footer at all", () => {
+		expect(hasAgentFooter("I hit a bug in the retry helper.\n")).toBe(false);
+	});
+
 	it("answers human on an empty body — the fail-closed default", () => {
 		expect(provenanceOf("")).toBe("human");
 	});

--- a/packages/fabrika-cli/src/triage/queue-verb.ts
+++ b/packages/fabrika-cli/src/triage/queue-verb.ts
@@ -1,0 +1,131 @@
+/**
+ * `triage queue` — the claimable intake queue, oldest first, with the count it scanned.
+ *
+ * **`empty` and a failed read are different answers and never share a channel or a code.** The skill
+ * uses this verb as a sweep's termination test, and a renamed label or a scope-limited token answers
+ * HTTP 200 with `[]` — so the label's existence is checked against the repository's label set and a
+ * typo reds on {@link ZERO_SCOPE} rather than reporting the queue drained.
+ *
+ * The filer login the read this replaces printed on every row is deliberately absent: every
+ * report-filed issue shows the same account, so it carries no information (ADR 0159). `triage
+ * provenance` answers the question that field pretends to.
+ */
+import {Effect} from "effect";
+import {listLabels, openQueueIssues, type QueueIssue, resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {scannedLine} from "./scope.ts";
+
+export const DEFAULT_QUEUE_LABEL = "status:needs-triage";
+export const DEFAULT_QUEUE_LIMIT = 100;
+
+const DAY_MS = 86_400_000;
+
+export interface QueueOptions {
+	readonly label: string;
+	readonly limit: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly now: () => Date;
+}
+
+export interface QueueRow {
+	readonly number: number;
+	readonly ageDays: number;
+	readonly title: string;
+}
+
+/** Whole days from `createdAt` to `now`, floored. A clock skew that runs the age negative reads 0. */
+export const ageDays = (createdAt: string, now: Date): number =>
+	Math.max(0, Math.floor((now.getTime() - Date.parse(createdAt)) / DAY_MS));
+
+/** Oldest first — ISO-8601 UTC sorts chronologically as text, so the compare needs no parse. */
+export const toRows = (
+	issues: ReadonlyArray<QueueIssue>,
+	now: Date,
+	limit: number,
+): ReadonlyArray<QueueRow> =>
+	[...issues]
+		.sort((a, b) =>
+			a.createdAt === b.createdAt ? a.number - b.number : a.createdAt < b.createdAt ? -1 : 1,
+		)
+		.slice(0, limit)
+		.map((issue) => ({
+			number: issue.number,
+			ageDays: ageDays(issue.createdAt, now),
+			title: issue.title,
+		}));
+
+export const runQueue = Effect.fn("runQueue")(function* (options: QueueOptions) {
+	const {label, limit, json} = options;
+
+	if (limit < 1) return refuse(FAILED, "triage queue: --limit must be 1 or greater.");
+
+	const repoAttempt = yield* resolveRepo(options.repo, options.env);
+	if (repoAttempt._tag === "Failure") {
+		return refuse(
+			FAILED,
+			"triage queue: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+		);
+	}
+	const repo = repoAttempt.value;
+
+	// The label precondition runs BEFORE the queue read, because it is what makes the queue's scope
+	// non-zero. Reading it here also means an unreadable label set refuses as UNKNOWN rather than
+	// resolving to "the label is missing".
+	const labels = yield* listLabels(repo);
+	if (labels._tag === "Failure") {
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`triage queue: cannot read the label set of ${repo}: ${labels.reason} — whether the ${label} queue exists is UNKNOWN, and so is the outcome.`,
+		);
+	}
+	if (!labels.value.includes(label)) {
+		return refuse(
+			ZERO_SCOPE,
+			`triage queue: label ${label} does not exist in ${repo} — refusing to report an empty queue over zero scope (ADR 0092).`,
+			[scannedLine("triage queue", repo, labels.value.length, "label", `none of them is ${label}`)],
+		);
+	}
+
+	const queue = yield* openQueueIssues(repo, label);
+	if (queue._tag === "Failure") {
+		// No scanned count accompanies this refusal on purpose: a count is a measurement, and a read
+		// that failed produced none. Printing `scanned 0` here would be the very fusion of "nothing
+		// is there" with "I could not look" that the 7/11 split exists to prevent.
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`triage queue: cannot read the ${label} queue in ${repo}: ${queue.reason} — the outcome is UNKNOWN, never "empty".`,
+		);
+	}
+
+	const scanned = queue.value.length;
+	const rows = toRows(queue.value, options.now(), limit);
+	const truncated = scanned > limit;
+	const scope = scannedLine(
+		"triage queue",
+		repo,
+		scanned,
+		`open ${label} issue`,
+		truncated ? `list TRUNCATED to --limit ${limit}` : undefined,
+	);
+
+	if (json) {
+		return answer(
+			JSON.stringify({
+				outcome: scanned === 0 ? "empty" : "queued",
+				issues: rows,
+				scanned,
+				truncated,
+			}),
+			[scope],
+		);
+	}
+	return scanned === 0
+		? answer("empty", [scope])
+		: answer(
+				["queued", ...rows.map((row) => `${row.number}\t${row.ageDays}\t${row.title}`)].join("\n"),
+				[scope],
+			);
+});

--- a/packages/fabrika-cli/src/triage/queue-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/queue-verb.unit.test.ts
@@ -1,0 +1,181 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {ANSWER, FAILED} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {ageDays, runQueue, toRows} from "./queue-verb.ts";
+
+const LABELS = /repos\/o\/r\/labels/;
+const QUEUE = /repos\/o\/r\/issues\?state=open/;
+
+const NOW = new Date("2026-08-03T00:00:00Z");
+
+const options = {
+	label: "status:needs-triage",
+	limit: 100,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	now: () => NOW,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runQueue({...options, ...overrides}), fakeShell(script).layer));
+
+const labelsOk = [LABELS, okOut("status:needs-triage\ntype:bug\np0")] as const;
+
+const row = (n: number, createdAt: string, title: string) => `${n}\t${createdAt}\t${title}`;
+
+describe("ageDays", () => {
+	it("floors to whole days", () => {
+		expect(ageDays("2026-08-01T23:00:00Z", NOW)).toBe(1);
+		expect(ageDays("2026-08-02T23:59:59Z", NOW)).toBe(0);
+	});
+
+	it("reads a clock skew that runs the age negative as 0, never as a negative age", () => {
+		expect(ageDays("2026-08-10T00:00:00Z", NOW)).toBe(0);
+	});
+});
+
+describe("toRows", () => {
+	const issues = [
+		{number: 3, createdAt: "2026-07-30T00:00:00Z", title: "newest"},
+		{number: 1, createdAt: "2026-07-01T00:00:00Z", title: "oldest"},
+		{number: 2, createdAt: "2026-07-15T00:00:00Z", title: "middle"},
+	];
+
+	it("orders OLDEST first — the claimable end of the queue", () => {
+		expect(toRows(issues, NOW, 100).map((r) => r.number)).toEqual([1, 2, 3]);
+	});
+
+	it("breaks a tie on the issue number, so the order is total and stable", () => {
+		const tied = [
+			{number: 9, createdAt: "2026-07-01T00:00:00Z", title: "b"},
+			{number: 4, createdAt: "2026-07-01T00:00:00Z", title: "a"},
+		];
+		expect(toRows(tied, NOW, 100).map((r) => r.number)).toEqual([4, 9]);
+	});
+
+	it("caps at the limit AFTER ordering, so the cap keeps the oldest", () => {
+		expect(toRows(issues, NOW, 2).map((r) => r.number)).toEqual([1, 2]);
+	});
+
+	it("does not mutate its input", () => {
+		const input = [...issues];
+		toRows(input, NOW, 100);
+		expect(input.map((i) => i.number)).toEqual([3, 1, 2]);
+	});
+});
+
+describe("runQueue", () => {
+	it("prints `queued` then one `<number>\\t<age-days>\\t<title>` line per issue", async () => {
+		const out = await run([
+			labelsOk,
+			[QUEUE, okOut(row(4312, "2026-08-01T00:00:00Z", "Abort reason lost"))],
+		]);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("queued\n4312\t2\tAbort reason lost\n");
+	});
+
+	it("prints the STATE WORD `empty` — never empty stdout, which a sweep cannot read", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut("")]]);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("empty\n");
+	});
+
+	it("reports the scanned count on stderr", async () => {
+		const out = await run([
+			labelsOk,
+			[
+				QUEUE,
+				okOut(
+					[row(1, "2026-08-01T00:00:00Z", "a"), row(2, "2026-08-01T00:00:00Z", "b")].join("\n"),
+				),
+			],
+		]);
+		expect(out.stderr.join("\n")).toContain("scanned 2 open status:needs-triage issues in o/r");
+	});
+
+	it("says on stderr when --limit truncated the list", async () => {
+		const rows = Array.from({length: 4}, (_, i) => row(i + 1, "2026-08-01T00:00:00Z", "t")).join(
+			"\n",
+		);
+		const out = await run([labelsOk, [QUEUE, okOut(rows)]], {limit: 2});
+		expect(out.stdout.trimEnd().split("\n")).toHaveLength(3);
+		expect(out.stderr.join("\n")).toContain("TRUNCATED");
+	});
+
+	it("REFUSES a --label that does not exist rather than reporting the queue drained", async () => {
+		const out = await run([[LABELS, okOut("type:bug\np0")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("never reads the queue once the label is proven absent", async () => {
+		const shell = fakeShell([[LABELS, okOut("type:bug")]]);
+		await Effect.runPromise(Effect.provide(runQueue(options), shell.layer));
+		expect(shell.calls.some((c) => QUEUE.test(c))).toBe(false);
+	});
+
+	it("refuses an UNREADABLE label set as UNKNOWN — never as `the label is missing`", async () => {
+		const out = await run([[LABELS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unreadable queue as UNKNOWN — never `empty`, which terminates a sweep", async () => {
+		const out = await run([labelsOk, [QUEUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never "empty"');
+	});
+
+	it("prints NO scanned count beside a failed read — a count is a measurement", async () => {
+		const out = await run([labelsOk, [QUEUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.stderr.join("\n")).not.toContain("scanned");
+	});
+
+	it("refuses a `gh` that exited 0 with bytes that are not queue rows", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut("not a row")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("pages the queue read — an unpaginated read truncates at GitHub's default page", async () => {
+		const shell = fakeShell([labelsOk, [QUEUE, okOut("")]]);
+		await Effect.runPromise(Effect.provide(runQueue(options), shell.layer));
+		expect(shell.calls.find((c) => QUEUE.test(c))).toContain("--paginate");
+	});
+
+	it("puts the --json payload on stdout, carrying the outcome word and the scanned count", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut(row(4312, "2026-08-01T00:00:00Z", "t"))]], {
+			json: true,
+		});
+		expect(JSON.parse(out.stdout)).toEqual({
+			outcome: "queued",
+			issues: [{number: 4312, ageDays: 2, title: "t"}],
+			scanned: 1,
+			truncated: false,
+		});
+	});
+
+	it("carries the `empty` outcome word into the --json payload too", async () => {
+		const out = await run([labelsOk, [QUEUE, okOut("")]], {json: true});
+		expect(JSON.parse(out.stdout).outcome).toBe("empty");
+	});
+
+	it("refuses a --limit below 1 as a usage error", async () => {
+		const out = await run([labelsOk], {limit: 0});
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses when no target repo resolves", async () => {
+		const out = await run([[/git remote get-url/, errOut("no origin")]], {env: {}});
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.at(-1)).toContain("CLAUDE_PIPELINE_REPO");
+	});
+});

--- a/packages/fabrika-cli/src/triage/roadmap.ts
+++ b/packages/fabrika-cli/src/triage/roadmap.ts
@@ -1,0 +1,73 @@
+/**
+ * The `ROADMAP.md` half of `triage homes`: the `## Arcs` and `## Campaigns` tables, parsed to
+ * `<name> → <milestone number>` rows.
+ *
+ * **The join key is the `#<number>` cell, never the title** — the same row-to-milestone binding
+ * `roadmap-guard` enforces. Matching on the title is the obvious shortcut and it is wrong: an arc
+ * named `Geçit` pins a milestone titled `Sözlük — search and discovery`, and the two share no
+ * substring.
+ *
+ * The `State` column is deliberately not read. This reports what exists; whether an arc is active is
+ * a question for the caller, not a filter here.
+ */
+
+/** One roadmap row: the first column, and the milestone its second column pins. */
+export interface RoadmapRow {
+	readonly name: string;
+	readonly milestone: number;
+}
+
+export interface RoadmapRows {
+	readonly arcs: ReadonlyArray<RoadmapRow>;
+	readonly campaigns: ReadonlyArray<RoadmapRow>;
+}
+
+/** The cells of a markdown table row, or `null` for a line that is not one. */
+const cells = (line: string): ReadonlyArray<string> | null => {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("|")) return null;
+	return trimmed
+		.replace(/^\|/, "")
+		.replace(/\|$/, "")
+		.split("|")
+		.map((cell) => cell.trim());
+};
+
+/**
+ * The rows of the table under `## <heading>`, up to the next `## ` heading.
+ *
+ * A row counts only when its second cell is `#<number>`, which drops the header and the `|---|`
+ * separator without matching on their text — so a header rename cannot silently admit a row.
+ */
+const sectionRows = (text: string, heading: string): ReadonlyArray<RoadmapRow> => {
+	const rows: RoadmapRow[] = [];
+	let inSection = false;
+	for (const line of text.split("\n")) {
+		if (line.startsWith("## ")) {
+			if (inSection) break;
+			inSection = line.trim() === `## ${heading}`;
+			continue;
+		}
+		if (!inSection) continue;
+		const fields = cells(line);
+		const pinned = fields?.[1] === undefined ? null : /^#(\d+)$/.exec(fields[1]);
+		const name = fields?.[0];
+		if (pinned?.[1] === undefined || name === undefined || name === "") continue;
+		rows.push({name, milestone: Number.parseInt(pinned[1], 10)});
+	}
+	return rows;
+};
+
+export const parseRoadmap = (text: string): RoadmapRows => ({
+	arcs: sectionRows(text, "Arcs"),
+	campaigns: sectionRows(text, "Campaigns"),
+});
+
+/**
+ * The name of the first row pinning `milestone`, arcs before campaigns, or `null` when no row does.
+ *
+ * `null` is a signal worth seeing rather than a row to hide: an open milestone no roadmap row pins
+ * is a home that exists off the roadmap.
+ */
+export const roadmapRowFor = (rows: RoadmapRows, milestone: number): string | null =>
+	[...rows.arcs, ...rows.campaigns].find((row) => row.milestone === milestone)?.name ?? null;

--- a/packages/fabrika-cli/src/triage/roadmap.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/roadmap.unit.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, it} from "vitest";
+import {parseRoadmap, roadmapRowFor} from "./roadmap.ts";
+
+/** The shape of the real `ROADMAP.md`, cut to the two tables this module reads. */
+const ROADMAP = `# Roadmap
+
+## Arcs
+
+| Arc | Milestone | State |
+|-----|-----------|-------|
+| Four Pillars | #17 | done |
+| Geçit | #24 | active |
+| Mecmua v2 | #25 | queued |
+
+## Campaigns
+
+Campaigns are bounded, milestone-backed pushes.
+
+| Campaign | Milestone | State |
+|----------|-----------|-------|
+| Mentor Audit | #27 | active |
+| fabrika campaign | #44 | active |
+
+## Something else
+
+| Not a table we read | #99 | ignored |
+`;
+
+describe("parseRoadmap", () => {
+	it("reads the ## Arcs and ## Campaigns rows as name → milestone pairs", () => {
+		const rows = parseRoadmap(ROADMAP);
+		expect(rows.arcs).toEqual([
+			{name: "Four Pillars", milestone: 17},
+			{name: "Geçit", milestone: 24},
+			{name: "Mecmua v2", milestone: 25},
+		]);
+		expect(rows.campaigns).toEqual([
+			{name: "Mentor Audit", milestone: 27},
+			{name: "fabrika campaign", milestone: 44},
+		]);
+	});
+
+	it("stops at the next `## ` heading — a later table is not another arc", () => {
+		expect(parseRoadmap(ROADMAP).arcs.map((r) => r.milestone)).not.toContain(99);
+	});
+
+	it("drops the header and `|---|` separator rows without matching on their text", () => {
+		expect(parseRoadmap(ROADMAP).arcs.map((r) => r.name)).not.toContain("Arc");
+		expect(parseRoadmap(ROADMAP).arcs.some((r) => r.name.startsWith("---"))).toBe(false);
+	});
+
+	it("requires the second cell to be exactly `#<number>`, so a prose cell admits no row", () => {
+		const rows = parseRoadmap(`## Arcs
+
+| Arc | Milestone | State |
+|-----|-----------|-------|
+| Unpinned | TBD | queued |
+| Almost | see #24 | queued |
+`);
+		expect(rows.arcs).toEqual([]);
+	});
+
+	it("reads an absent section as no rows, not as a failure", () => {
+		expect(parseRoadmap("# Roadmap\n\nNo tables here.\n")).toEqual({arcs: [], campaigns: []});
+	});
+});
+
+describe("roadmapRowFor", () => {
+	const rows = parseRoadmap(ROADMAP);
+
+	it("joins on the `#<number>` cell, NOT the title — the two share no substring", () => {
+		// `Geçit` pins milestone #24, whose GitHub title is `Sözlük — search and discovery`.
+		expect(roadmapRowFor(rows, 24)).toBe("Geçit");
+	});
+
+	it("finds a campaign row too", () => {
+		expect(roadmapRowFor(rows, 44)).toBe("fabrika campaign");
+	});
+
+	it("prefers an arc over a campaign pinning the same milestone", () => {
+		const both = parseRoadmap(`## Arcs
+
+| Arc | Milestone |
+|-----|-----------|
+| The arc | #5 |
+
+## Campaigns
+
+| Campaign | Milestone |
+|----------|-----------|
+| The campaign | #5 |
+`);
+		expect(roadmapRowFor(both, 5)).toBe("The arc");
+	});
+
+	it("answers null for an open milestone no row pins — a home that exists off the roadmap", () => {
+		expect(roadmapRowFor(rows, 4831)).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/triage/roadmap.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/roadmap.unit.test.ts
@@ -44,6 +44,26 @@ describe("parseRoadmap", () => {
 		expect(parseRoadmap(ROADMAP).arcs.map((r) => r.milestone)).not.toContain(99);
 	});
 
+	it("stops after the FIRST matching section, so a repeated heading appends nothing", () => {
+		// The `## ` break is only observable here: a second `## Arcs` further down — a stray heading, a
+		// quoted table, an archive block — would otherwise silently merge its rows into the live arcs.
+		const rows = parseRoadmap(`## Arcs
+
+| Arc | Milestone |
+|-----|-----------|
+| Live | #1 |
+
+## Archive
+
+## Arcs
+
+| Arc | Milestone |
+|-----|-----------|
+| Retired | #2 |
+`);
+		expect(rows.arcs).toEqual([{name: "Live", milestone: 1}]);
+	});
+
 	it("drops the header and `|---|` separator rows without matching on their text", () => {
 		expect(parseRoadmap(ROADMAP).arcs.map((r) => r.name)).not.toContain("Arc");
 		expect(parseRoadmap(ROADMAP).arcs.some((r) => r.name.startsWith("---"))).toBe(false);


### PR DESCRIPTION
Part of #4831 — slice 1b of nine. **This does not close the issue**; six verbs (`claim`, `split`, `enrich`, `apply`, `park`, `kill`) are still outstanding.

## What lands

Three read-only `triage` verbs on the substrate slice 1a shipped, plus the one flag on an existing verb the `/report` contract deferred to this seam by name:

| Verb | Answer | Refusals |
|---|---|---|
| `triage queue` | `queued` + `<number>\t<age-days>\t<title>` rows, oldest first, or the state word `empty` | `7` (the `--label` does not exist in the repo, so the queue would scan nothing), `11` (the label set or the queue could not be read) |
| `triage provenance <issue>` | `agent` / `human` | `7` (issue proven absent, 404), `11` (unreadable — the provenance is UNKNOWN) |
| `triage homes` | `homes` + one `<kind>\t<key>\t<label>` line per open milestone and per standing lane | `7` (zero open milestones, or the roadmap parsed to 0 arc rows), `11` (the milestone list or the roadmap could not be read) |
| `report dedup --exclude <n>` | unchanged | unchanged |

Supporting modules: `src/triage/provenance.ts` (the footer predicate `triage kill` will re-check for itself), `src/triage/roadmap.ts` (the `## Arcs` / `## Campaigns` tables), and four reads appended to `src/io/issues.ts`.

## Four decisions worth a reviewer's eye

- **`--exclude` extends the shipped ranking rather than adding a second dedup.** The filter runs inside `rank`, after retrieval and **before scoring and the cap**, so excluding an issue never reorders the rest and never lets a truncated row take the excluded issue's slot.
- **The agent-footer predicate is anchored to the emitted line shape** (`^<sub>Filed by an agent`, multiline), deliberately diverging from `src/report/file-verb.ts`'s bare substring. There the body is one the same process just composed; here it is foreign, and a bare substring fails **open toward `agent`** — the close-eligible direction — for any issue that merely quotes the phrase. The divergence is documented at the definition; it is not a drift to reconcile.
- **`triage homes` joins on the `#<number>` cell, never the title.** The arc `Geçit` pins a milestone titled `Sözlük — search and discovery`; the two share no substring, so a title join silently returns nothing.
- **Zero open milestones and a roadmap that parsed to zero arc rows both refuse (`7`) rather than answering an empty list.** "No home exists" routes a caller toward a close, which is irreversible.

## Testing

`pnpm test` in `packages/fabrika-cli`: **50 files, 678 tests, all passing** (baseline before this branch's tests: 45 files, 607). `pnpm typecheck` and `biome check` clean.

**Mutation-verified.** Each load-bearing behaviour was reverted, the suite re-run to prove a test goes RED, then restored to prove GREEN. The mutants and their results are in a comment on this PR.

## Not in this slice

`triage claim`, `split`, `enrich`, `apply`, `park`, `kill` — and therefore the write-side read-back normalization the issue asks to confirm against the live API, which belongs with the first verb that writes.

## Deviations

- **Class 1 — scope narrowing (the `Part of #4831` partial split).** **Said:** #4831 specifies the whole nine-verb `triage` group plus `report dedup --exclude`, and its acceptance criteria are written against all nine. **Did:** this slice ships the three read verbs (`queue`, `provenance`, `homes`) with the modules they need, plus `--exclude`; the six write-side verbs are untouched and #4831 stays open. **Why:** the group is planned as a sequence of reviewable slices — one pull request carrying nine verbs is not reviewable, and each verb's refusal semantics need their own mutation evidence. The read verbs are independently useful and carry no write-side read-back seam, which makes them a clean first cut. **Disposition:** no action needed — `Part of #4831` is deliberate; the remaining verbs land in their own slices and the issue closes when the last one does.

- **Class 1 — acceptance-criterion departure: `triage homes` refuses over zero milestones instead of printing a state word.** **Said:** #4831's AC states *"Every 'nothing found' case prints a state word on stdout; no verb signals a negative by empty stdout."* **Did:** `queue` and `provenance` follow that literally (`empty`, and `human` on a present-but-empty body), but `triage homes` **refuses on `7`** — with empty stdout — over zero open milestones and over a roadmap that parsed to zero arc rows. **Why:** `contract.md` pins exactly this, at the verb's own refusal table (`<repo> has 0 open milestones — refusing to answer, since "no home exists" routes to a kill`), and #4831 names the contract as the spec over its own restatement. A state word here would answer *"no home exists"*, which routes a caller toward an irreversible close; a readable roadmap yielding zero arc rows is a failed parse, not a repo with no arcs. **Disposition:** no action needed — the implementation follows the contract, and the departure is from the issue's summary of it. It is documented at the definition, not only here.

- **Class 1 / class 3 — the source commit is inherited and was untested; the entire test tier is author-written on top of it.** **Said:** the AC asks for each verb *"with unit tests beside it in the package's existing test idiom"*, which reads as one author writing verb and test together. **Did:** the branch's first commit, `b7c67e51`, is a predecessor lane's and carries the source only — five new modules and four `io` reads, with no assertions at all; its single test-file touch adds one `exclude: null` field to an existing options fixture. Every assertion in this PR was written in this lane on top of that commit (`40499e73`, `5ceb939d`): five new `*.unit.test.ts` files plus additions to three existing ones. **Why:** the source commit was already pushed and reachable, and rewriting it to interleave tests would have destroyed the history a reviewer can diff; writing the tier against `contract.md` and #4831's criteria rather than against the inherited implementation was the safer direction. **Disposition:** for the reviewer to judge — it is why the tests deserve to be read as spec-binding rather than code-restating, and it is the reason this PR's mutation evidence is stated in full rather than summarised.

- **Class 1 — the branch was cut fresh rather than continuing the original lane's.** **Said:** the slice was started on `usirin/triage-read-verbs-4831-56121DD8`, and the ordinary shape is to keep pushing that branch. **Did:** work resumed on a new branch, `usirin/triage-read-verbs-4831-resume`, cut at the original's tip commit `b7c67e51`, and this PR is opened from it. **Why:** the original lane died with its worktree still holding that branch checked out, so it could not be reused from a fresh worktree. **Disposition:** no action needed — the new branch is a strict continuation: `b7c67e51` is the first of the three commits and is reachable from the head, so no work was orphaned or silently re-written.

- **(repair round 1) Class 3 / class 4 — one uncovered clause left uncovered.** **Said:** the `review-code` verdict at `5ceb939d` recorded, explicitly **non-blocking**, that deleting the `name === ""` guard in `sectionRows` (`src/triage/roadmap.ts`) leaves all 679 tests green — the behaviour is correct, the coverage is thin. **Did:** no test was added and no source line changed in this repair round. **Why:** the round's only blocking finding is this section's own absence, which is a body edit; adding a test would move the head and invalidate a verdict that otherwise re-binds to the same SHA, and the gate marked the note as not counting against the verdict. **Disposition:** for the reviewer to judge — the guard is correct today, and the test belongs with the next slice that touches `roadmap.ts`; it is recorded here so the observation does not die with the round.

Walking the remaining classes explicitly, none fired. **Class 2** (governing-ADR departure) — no accepted ADR is contradicted, narrowed or widened: the zero-scope refusals implement ADR 0092's posture as written and cite it at their definitions, and no ADR is amended in this diff. **Class 5** (guard or gate bypassed) — the canonical Tier-M scan at this head reports **0 suppression/skip lines**: no `--no-verify` push, no skipped or disabled hook, and the diff adds no `biome-ignore`, `@ts-expect-error`, `.skip(` or `.only(`; `pnpm typecheck` and `biome check` pass unsuppressed. **Class 6** (pre-existing test or fixture changed) — the same scan reports **0 removed-assertion lines**, and every touched test file is additions-only (`-0` deletions across all eight); the one pre-existing test-file change is the `exclude: null` fixture field the widened option type requires, which modifies no assertion. **Class 7** (out-of-scope change) — every changed path is `src/triage/**` (the new group), `src/io/issues.ts` (the reads it needs, appended not rewritten), or the three `src/report/` files the `--exclude` extension the issue names by file necessarily touches.
