### PR TITLE
feat(fabrika): the triage split verb — create-once on (back-reference AND title)

### DIFF
--- a/packages/fabrika-cli/src/triage/authored.ts
+++ b/packages/fabrika-cli/src/triage/authored.ts
@@ -1,0 +1,94 @@
+/**
+ * The guard over **authored** text — the bytes the caller just wrote — shared by `triage split`,
+ * `triage enrich`, `triage park` and `triage kill`.
+ *
+ * All four take their text on stdin only and refuse the same three ways: an unread pipe is UNKNOWN,
+ * a read-but-empty one is `3`, a body that IS a path is `6`, and a machine-local path in it is `5`.
+ * Only the nouns differ, so the nouns are the parameter and the decisions are here — a second copy
+ * per verb is four chances for the refusals to drift apart.
+ *
+ * **The asymmetry this module encodes:** authored text is *refusable* because its author can fix it.
+ * Foreign content a verb copies forward is redacted instead, because refusing it would strand the
+ * operation on somebody else's mistake. Redaction is therefore deliberately absent here.
+ *
+ * The predicate itself is imported from `../report/leaks.ts` rather than re-derived: a second leak
+ * predicate that drifts from the first is worse than either alone.
+ */
+
+import type {StdinRead} from "../io/stdin.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {BARE_AT_PATH, EMPTY_STDIN, LEAKED_PATH} from "./codes.ts";
+
+/** What one verb calls the text it is guarding, so the refusals read as that verb's own. */
+export interface AuthoredSurface {
+	/** The verb's full name, e.g. `triage split` — every message leads with it. */
+	readonly verb: string;
+	/** The noun a refusal names, e.g. `the child body`. */
+	readonly noun: string;
+	/** The correction an empty read gets, e.g. `pipe the child body in.` */
+	readonly emptyHint: string;
+}
+
+export type Authored =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	/** The authored text, and the byte count a scope line reports. */
+	| {readonly _tag: "Text"; readonly text: string; readonly bytes: number};
+
+/**
+ * Resolve stdin into authored text, or the refusal that stops the verb.
+ *
+ * A **failed** read seats on `1` rather than on {@link EMPTY_STDIN}: an unread pipe is byte-identical
+ * to an empty one only if the reader is willing to say so, and a verb that creates issues must not be
+ * (#3924). A TTY with nothing piped never reached a read, but its correction is the same as an empty
+ * pipe's — send the body — so it joins the empty case.
+ */
+export const readAuthored = (surface: AuthoredSurface, read: StdinRead): Authored => {
+	if (read._tag === "Failed") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				FAILED,
+				`${surface.verb}: could not read stdin: ${read.reason} — ${surface.noun} is UNKNOWN, never empty.`,
+			),
+		};
+	}
+	const text = read._tag === "NoStdin" ? "" : read.text;
+	const bytes = new TextEncoder().encode(text).length;
+	if (text.trim() === "") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(EMPTY_STDIN, `${surface.verb}: no body on stdin — ${surface.emptyHint}`, [
+				`${surface.verb}: stdin was read and held ${bytes} byte(s).`,
+			]),
+		};
+	}
+	if (isBareAtReference(text)) {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				BARE_AT_PATH,
+				`${surface.verb}: ${surface.noun} is a bare "@" path reference — the body never arrived. Send it on stdin.`,
+			),
+		};
+	}
+	return {_tag: "Text", text, bytes};
+};
+
+/**
+ * The leak refusal for `body`, or `null` when it carries no machine-local path.
+ *
+ * Callers run this over the **composed** body rather than over raw stdin, so nothing a verb itself
+ * appends can escape the predicate — the same ordering `report file` uses. The message names the
+ * first hit because a refusal names one correctable thing; every hit is listed above it.
+ */
+export const leakRefusal = (surface: AuthoredSurface, body: string): VerbOutcome | null => {
+	const scan = scanBody(body);
+	const first = scan.leaks[0];
+	if (first === undefined) return null;
+	return refuse(
+		LEAKED_PATH,
+		`${surface.verb}: ${surface.noun} carries a machine-local path at line ${first.line} (${first.class}) — rewrite it repo-relative.`,
+		renderLeaks(scan.leaks),
+	);
+};

--- a/packages/fabrika-cli/src/triage/authored.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/authored.unit.test.ts
@@ -1,0 +1,94 @@
+import {describe, expect, it} from "vitest";
+import type {StdinRead} from "../io/stdin.ts";
+import {FAILED} from "../verb.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
+import {BARE_AT_PATH, EMPTY_STDIN, LEAKED_PATH} from "./codes.ts";
+
+const SURFACE: AuthoredSurface = {
+	verb: "triage split",
+	noun: "the child body",
+	emptyHint: "pipe the child body in.",
+};
+
+const read = (r: StdinRead) => readAuthored(SURFACE, r);
+
+describe("readAuthored", () => {
+	it("passes authored text through with its byte count", () => {
+		const out = read({_tag: "Text", text: "iki ünite"});
+		expect(out).toMatchObject({_tag: "Text", text: "iki ünite"});
+		// The count is bytes, not characters — `ü` is two.
+		expect(out._tag === "Text" && out.bytes).toBe(10);
+	});
+
+	it("seats a FAILED read on 1, never on the empty code — an unread pipe is UNKNOWN", () => {
+		const out = read({_tag: "Failed", reason: "EAGAIN"});
+		expect(out._tag === "Refused" && out.outcome.code).toBe(FAILED);
+		expect(out._tag === "Refused" && out.outcome.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses a read-but-empty pipe on its own code, and says what it read", () => {
+		const out = read({_tag: "Text", text: ""});
+		expect(out._tag === "Refused" && out.outcome.code).toBe(EMPTY_STDIN);
+		expect(out._tag === "Refused" && out.outcome.stderr.at(-1)).toBe(
+			"triage split: no body on stdin — pipe the child body in.",
+		);
+		expect(out._tag === "Refused" && out.outcome.stderr[0]).toContain("0 byte(s)");
+	});
+
+	it("treats whitespace-only text as empty", () => {
+		expect(read({_tag: "Text", text: "  \n\t"})._tag).toBe("Refused");
+	});
+
+	it("treats a TTY as the same correctable state as an empty pipe", () => {
+		const out = read({_tag: "NoStdin", reason: "fd 0 is a TTY"});
+		expect(out._tag === "Refused" && out.outcome.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a bare @ reference on its own code — masking it would never terminate", () => {
+		const out = read({_tag: "Text", text: "@/tmp/child.md"});
+		expect(out._tag === "Refused" && out.outcome.code).toBe(BARE_AT_PATH);
+		expect(out._tag === "Refused" && out.outcome.stderr.at(-1)).toContain("the body never arrived");
+	});
+
+	it("does not mistake an @mention for a path reference", () => {
+		expect(read({_tag: "Text", text: "@usirin asked for this"})._tag).toBe("Text");
+	});
+
+	it("emits nothing on stdout on every refusal", () => {
+		for (const r of [
+			{_tag: "Failed", reason: "EAGAIN"},
+			{_tag: "Text", text: ""},
+			{_tag: "Text", text: "@/tmp/x.md"},
+		] satisfies ReadonlyArray<StdinRead>) {
+			const out = read(r);
+			expect(out._tag === "Refused" && out.outcome.stdout).toBe("");
+		}
+	});
+});
+
+describe("leakRefusal", () => {
+	it("passes a body carrying no machine-local path", () => {
+		expect(leakRefusal(SURFACE, "see packages/fabrika-cli/src/triage/split.ts")).toBeNull();
+	});
+
+	it("refuses a machine-local path, naming the first hit's line and class", () => {
+		const out = leakRefusal(SURFACE, "context\nreproduced from /Users/someone/scratch/case.md");
+		expect(out?.code).toBe(LEAKED_PATH);
+		expect(out?.stderr.at(-1)).toBe(
+			"triage split: the child body carries a machine-local path at line 2 (absolute home root) — rewrite it repo-relative.",
+		);
+	});
+
+	it("lists every hit above the message, not just the one it names", () => {
+		const out = leakRefusal(SURFACE, "/tmp/a/b\n~/c/d");
+		expect(out?.stderr).toEqual([
+			"  line 1, temp root",
+			"  line 2, home-relative",
+			expect.stringContaining("line 1 (temp root)"),
+		]);
+	});
+
+	it("offers no redaction — authored text is the author's to fix", () => {
+		expect(leakRefusal(SURFACE, "/Users/someone/x")?.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -14,11 +14,13 @@
  * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
  * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
  */
-import {Effect} from "effect";
-import {Command, Flag} from "effect/unstable/cli";
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {runCodes} from "./codes-verb.ts";
+import {runSplit} from "./split-verb.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
 const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
@@ -58,11 +60,49 @@ const codes = leafCommand(
 	),
 );
 
+/**
+ * The child body arrives on **stdin only**. There is deliberately no `--body` and no `--body-file`: a
+ * flag that takes a path turns the body into a string the verb could post verbatim, which is how a
+ * machine-local path reaches a public issue while the poster reads success. A shell redirect is
+ * expected — the *shell* reads the file, so what reaches the verb is already bytes.
+ */
+const split = leafCommand(
+	"split",
+	{
+		parent: Argument.integer("parent").pipe(
+			Argument.withDescription("the parent issue this unit is split from"),
+		),
+		title: Flag.string("title").pipe(
+			Flag.withDescription("the child's single-unit title; also half the create-once key"),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({parent, title, repo, json}) {
+		yield* emit(
+			yield* runSplit({
+				parent,
+				title,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Create one child of a bundled report from the body on STDIN, exactly once, and cross-link the parent. Prints `<created|reused>\\t<number>\\t<url>`; both outcomes exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (parent absent, or the queue label does not exist), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed — never a silent create). Example: fabrika triage split 4312 --title "Editor loses focus after save" < child.md',
+	),
+);
+
 export const triageCommand = Command.make("triage").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
 		// editing one. The comment is what keeps the formatter from collapsing the list back.
 		codes,
+		split,
 	]),
 	Command.withDescription(
 		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",

--- a/packages/fabrika-cli/src/triage/split-verb.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.ts
@@ -1,0 +1,294 @@
+/**
+ * `triage split` — create one child of a bundled report, **once**, and cross-link the parent.
+ *
+ * One transaction: the label precondition, the two reads that decide `created` vs `reused`, the
+ * create, its read-back, and the parent comment. Splitting them would hand a caller the chance to
+ * skip one, and the one most worth skipping is the read that prevents a twin.
+ *
+ * **Where the guarantee lives.** Read 1 — the `status:needs-triage` queue — is the create-once read:
+ * it is the read-after-write-consistent source, and every child this verb makes carries that label by
+ * construction, so the read can see its own output. Read 2 — the parent's timeline — is
+ * supplementary: it reaches children already triaged out of the queue, and it lags by an observed
+ * 30–60 minutes (#4057), which is why it widens the net and carries nothing.
+ *
+ * **A read that cannot see is never an answer.** Every unreadable precondition — the parent, the
+ * label set, the queue, the timeline, or any candidate's body — exits `11`. Falling through an
+ * `Unknown` to "no match, therefore create" is exactly how one split becomes two issues on a public
+ * board, and it is the defect the predecessor shipped: its guard printed a number or nothing, so an
+ * auth failure read as a proven "safe to create".
+ */
+
+import {Effect} from "effect";
+import {
+	createComment,
+	createIssue,
+	currentBranch,
+	type Existence,
+	getIssue,
+	type IssueRecord,
+	issueTimeline,
+	listLabels,
+	openIssuesWithLabel,
+	resolveRepo,
+} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback, renderFooter} from "../report/compose.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {scannedLine} from "./scope.ts";
+import {
+	type Candidate,
+	composeChildBody,
+	crossLinkComment,
+	isExistingChild,
+	normalizeTitle,
+} from "./split.ts";
+
+const VERB = "triage split";
+const QUEUE_LABEL = "status:needs-triage";
+
+const SURFACE: AuthoredSurface = {
+	verb: VERB,
+	noun: "the child body",
+	emptyHint: "pipe the child body in.",
+};
+
+export interface SplitOptions {
+	/** The parent issue this unit is split from. */
+	readonly parent: number;
+	readonly title: string;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The fd-0 read, injected so the failed-read and TTY paths are testable without a descriptor. */
+	readonly stdin: Effect.Effect<StdinRead>;
+	/** The footer's timestamp, injected so a child body is byte-reproducible in a test. */
+	readonly now: () => Date;
+}
+
+const utc = (date: Date): string => `${date.toISOString().slice(0, 19)}Z`;
+
+/** The one `11` message, so every unreadable precondition refuses in the same words. */
+const unreadable = (
+	what: string,
+	repo: string,
+	reason: string,
+	diagnostics: ReadonlyArray<string>,
+): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`${VERB}: cannot read ${what} in ${repo}: ${reason} — UNKNOWN whether a child already exists; refusing to create a possible twin.`,
+		diagnostics,
+	);
+
+const asCandidate = (issue: IssueRecord): Candidate => ({
+	number: issue.number,
+	title: issue.title,
+	body: issue.body,
+	url: issue.url,
+});
+
+/**
+ * The reuse answer.
+ *
+ * `crossLinked` is `false` on every reuse and that is a fact, not a failure: a reuse stops before the
+ * cross-link, because the parent was linked when the child was first created. The existing child's
+ * body is **not** updated from stdin either — a reuse is an idempotency answer, not an edit, and
+ * rewriting a child someone may have already triaged would lose their work.
+ */
+const reused = (
+	child: Candidate,
+	json: boolean,
+	diagnostics: ReadonlyArray<string>,
+): VerbOutcome =>
+	json
+		? answer(
+				JSON.stringify({
+					outcome: "reused",
+					number: child.number,
+					url: child.url,
+					matchedOn: "back-reference+title",
+					crossLinked: false,
+				}),
+				diagnostics,
+			)
+		: answer(`reused\t${child.number}\t${child.url}`, diagnostics);
+
+/** What the read-back found wrong, or `null` when the child landed as composed. */
+export const readbackMismatch = (
+	landed: Existence<IssueRecord>,
+	composed: string,
+): string | null => {
+	if (landed._tag === "Absent") return "the child is not readable after the create";
+	if (landed._tag === "Unknown") return `the read-back itself failed: ${landed.reason}`;
+	return normalizeForReadback(landed.value.body) === normalizeForReadback(composed)
+		? null
+		: "the landed body differs from what was composed";
+};
+
+/**
+ * The verb, as one `Effect.fn` generator rather than a function returning `Effect.gen` — effect-smol
+ * `LLMS.md` §"Using Effect.fn" ("Avoid creating functions that return an Effect.gen").
+ */
+export const runSplit = Effect.fn(function* (options: SplitOptions) {
+	const {parent, title, json} = options;
+
+	if (!Number.isInteger(parent) || parent <= 0) {
+		return refuse(FAILED, `${VERB}: ${parent} is not an issue number.`);
+	}
+	if (title.trim() === "") {
+		return refuse(FAILED, `${VERB}: --title is empty — refusing to create an untitled child.`);
+	}
+
+	const repoAttempt = yield* resolveRepo(options.repo, options.env);
+	if (repoAttempt._tag === "Failure") {
+		return refuse(
+			FAILED,
+			`${VERB}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+		);
+	}
+	const repo = repoAttempt.value;
+
+	const authored = readAuthored(SURFACE, yield* options.stdin);
+	if (authored._tag === "Refused") return authored.outcome;
+
+	const footer = renderFooter({
+		session: options.env.CLAUDE_CODE_SESSION_ID ?? null,
+		model: options.env.ANTHROPIC_MODEL ?? options.env.CLAUDE_MODEL ?? null,
+		branch: yield* currentBranch,
+		timestamp: utc(options.now()),
+	});
+	const composed = composeChildBody(authored.text, parent, footer);
+	const leaked = leakRefusal(SURFACE, composed);
+	if (leaked !== null) return leaked;
+
+	const parentIssue = yield* getIssue(repo, parent);
+	if (parentIssue._tag === "Absent") {
+		return refuse(ZERO_SCOPE, `${VERB}: parent #${parent} not found in ${repo}.`);
+	}
+	if (parentIssue._tag === "Unknown") {
+		return unreadable(`parent #${parent}`, repo, parentIssue.reason, []);
+	}
+
+	// Read 1's label is a hardcoded literal while --repo is generic, so a renamed label or a
+	// scope-limited token returns HTTP 200 with `[]` — not a read failure, and therefore not 11. The
+	// verb would fall through to `created` and mint a twin, which makes the one verb built to be
+	// fail-closed the ADR 0092 fail-open.
+	const labels = yield* listLabels(repo);
+	if (labels._tag === "Failure") {
+		return unreadable("the label set", repo, labels.reason, []);
+	}
+	if (!labels.value.includes(QUEUE_LABEL)) {
+		return refuse(
+			ZERO_SCOPE,
+			`${VERB}: label ${QUEUE_LABEL} does not exist in ${repo} — refusing to create a child over a queue that would scan nothing (ADR 0092).`,
+		);
+	}
+
+	const queue = yield* openIssuesWithLabel(repo, QUEUE_LABEL);
+	if (queue._tag === "Failure") {
+		return unreadable(`the ${QUEUE_LABEL} queue`, repo, queue.reason, []);
+	}
+	const wanted = normalizeTitle(title);
+	// The list read carries titles and no bodies, so the match runs in two stages: narrow on the title
+	// the transport did return, then fetch only the survivors. Narrowing first is what keeps the N+1
+	// at roughly one.
+	const survivors = queue.value.filter((row) => normalizeTitle(row.title) === wanted);
+	const diagnostics = [
+		scannedLine(
+			VERB,
+			repo,
+			queue.value.length,
+			`open ${QUEUE_LABEL} issue`,
+			`${survivors.length} title match(es)`,
+		),
+	];
+
+	const seen = new Set<number>();
+	for (const row of survivors) {
+		seen.add(row.number);
+		const candidate = yield* getIssue(repo, row.number);
+		// An Unknown survivor might BE the child, and creating over an unread candidate is exactly the
+		// twin this verb exists to prevent.
+		if (candidate._tag === "Unknown") {
+			return unreadable(`candidate #${row.number}`, repo, candidate.reason, diagnostics);
+		}
+		if (candidate._tag === "Absent") continue;
+		if (isExistingChild(asCandidate(candidate.value), parent, title)) {
+			return reused(asCandidate(candidate.value), json, diagnostics);
+		}
+	}
+
+	const timeline = yield* issueTimeline(repo, parent);
+	if (timeline._tag === "Failure") {
+		return unreadable(`the timeline of #${parent}`, repo, timeline.reason, diagnostics);
+	}
+	const references = timeline.value.filter((ref) => !ref.isPullRequest && !seen.has(ref.number));
+	diagnostics.push(
+		scannedLine(
+			VERB,
+			repo,
+			timeline.value.length,
+			"timeline cross-reference",
+			`${references.length} issue candidate(s)`,
+		),
+	);
+	for (const ref of references) {
+		const candidate = yield* getIssue(repo, ref.number);
+		if (candidate._tag === "Unknown") {
+			return unreadable(`candidate #${ref.number}`, repo, candidate.reason, diagnostics);
+		}
+		if (candidate._tag === "Absent") continue;
+		if (isExistingChild(asCandidate(candidate.value), parent, title)) {
+			return reused(asCandidate(candidate.value), json, diagnostics);
+		}
+	}
+
+	const created = yield* createIssue(repo, title, composed, QUEUE_LABEL);
+	if (created._tag === "Failure") {
+		return refuse(
+			WRITE_UNKNOWN,
+			`${VERB}: create failed: ${created.reason} — UNKNOWN whether a child landed; re-run this verb, which will reuse it if it did.`,
+			diagnostics,
+		);
+	}
+
+	// A create call's own response is the server echoing the request; a fresh read is the only
+	// evidence the child carries the back-reference the next run keys on.
+	const landed = yield* getIssue(repo, created.value.number);
+	const mismatch = readbackMismatch(landed, composed);
+	if (mismatch !== null) {
+		return refuse(
+			READBACK_MISMATCH,
+			`${VERB}: child #${created.value.number} created but its body read back changed — inspect before splitting further.`,
+			[...diagnostics, `${VERB}: ${mismatch}`],
+		);
+	}
+
+	// Step 5 is best-effort and never changes the exit status: the child demonstrably exists, so
+	// mapping a failed comment onto the create-unknown code would be a lie. The durable trace is the
+	// child's own back-reference; this comment is for human readers.
+	const linked = yield* createComment(repo, parent, crossLinkComment(created.value.number));
+	const notices =
+		linked._tag === "Failure"
+			? [
+					`${VERB}: could not cross-link parent #${parent} to child #${created.value.number}: ${linked.reason} — the child exists; add the comment by hand.`,
+				]
+			: [];
+	const crossLinked = linked._tag === "Ok";
+
+	const out = [...diagnostics, ...notices];
+	return json
+		? answer(
+				JSON.stringify({
+					outcome: "created",
+					number: created.value.number,
+					url: created.value.url,
+					matchedOn: null,
+					crossLinked,
+				}),
+				out,
+			)
+		: answer(`created\t${created.value.number}\t${created.value.url}`, out);
+});

--- a/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
@@ -1,0 +1,303 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {renderFooter} from "../report/compose.ts";
+import {
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {composeChildBody} from "./split.ts";
+import {runSplit} from "./split-verb.ts";
+
+const BRANCH = /^git rev-parse/;
+const PARENT = /^gh api repos\/o\/r\/issues\/4312$/;
+const LABELS = /repos\/o\/r\/labels/;
+const QUEUE = /repos\/o\/r\/issues\?state=open/;
+const TIMELINE = /repos\/o\/r\/issues\/4312\/timeline/;
+const CREATE = /--method POST repos\/o\/r\/issues -f/;
+const CROSSLINK = /--method POST repos\/o\/r\/issues\/4312\/comments/;
+const issueRead = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
+
+const TITLE = "Editor loses focus after save";
+const BODY = "The editor drops focus once the save round-trips.";
+
+const COMPOSED = composeChildBody(
+	BODY,
+	4312,
+	renderFooter({
+		session: null,
+		model: null,
+		branch: "umut/x",
+		timestamp: "2026-01-01T00:00:00Z",
+	}),
+);
+
+const issue = (over: Record<string, unknown>) =>
+	okOut(
+		JSON.stringify({
+			number: 4321,
+			title: TITLE,
+			body: COMPOSED,
+			state: "open",
+			labels: [{name: "status:needs-triage"}],
+			html_url: "https://example.test/issues/4321",
+			...over,
+		}),
+	);
+
+const parentIssue = issue({number: 4312, title: "Two unrelated bugs", body: "a\nb"});
+const created = okOut(JSON.stringify({number: 4321, html_url: "https://example.test/issues/4321"}));
+const posted = okOut(JSON.stringify({id: 7, html_url: "https://example.test/c/7"}));
+
+const options = {
+	parent: 4312,
+	title: TITLE,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: BODY}),
+	now: () => new Date("2026-01-01T00:00:00.000Z"),
+};
+
+/** The base script: parent present, label present, nothing already split, create + cross-link fine. */
+const base: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[BRANCH, okOut("umut/x\n")],
+	[PARENT, parentIssue],
+	[LABELS, okOut("status:needs-triage\ntype:bug")],
+	[QUEUE, okOut("")],
+	[TIMELINE, okOut("")],
+	[CREATE, created],
+	[CROSSLINK, posted],
+	[issueRead(4321), issue({})],
+];
+
+const script = (
+	...overrides: ReadonlyArray<readonly [RegExp, ExecResult]>
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [...overrides, ...base];
+
+const run = (
+	steps: ReadonlyArray<readonly [RegExp, ExecResult]> = base,
+	over: Partial<typeof options> = {},
+) => {
+	const shell = fakeShell(steps);
+	return Effect.runPromise(Effect.provide(runSplit({...options, ...over}), shell.layer)).then(
+		(outcome) => ({outcome, calls: shell.calls}),
+	);
+};
+
+describe("runSplit — the created path", () => {
+	it("prints the outcome token, the number and the url, tab-separated", async () => {
+		const {outcome} = await run();
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("created\t4321\thttps://example.test/issues/4321\n");
+	});
+
+	it("creates the child carrying the back-reference and the queue label", async () => {
+		const {calls} = await run();
+		const create = calls.find((c) => CREATE.test(c)) ?? "";
+		expect(create).toContain("split from #4312");
+		expect(create).toContain("Filed by an agent");
+		expect(create).toContain("labels[]=status:needs-triage");
+	});
+
+	it("cross-links the parent as part of the same operation", async () => {
+		const {calls} = await run();
+		expect(calls.some((c) => CROSSLINK.test(c) && c.includes("split into #4321"))).toBe(true);
+	});
+
+	it("reports the object with --json", async () => {
+		const {outcome} = await run(base, {json: true});
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "created",
+			number: 4321,
+			url: "https://example.test/issues/4321",
+			matchedOn: null,
+			crossLinked: true,
+		});
+	});
+
+	it("reports the scanned count of both list reads", async () => {
+		const {outcome} = await run();
+		const stderr = outcome.stderr.join("\n");
+		expect(stderr).toContain("scanned 0 open status:needs-triage issues in o/r");
+		expect(stderr).toContain("scanned 0 timeline cross-references in o/r");
+	});
+
+	it("still exits 0 when the cross-link fails — the child demonstrably exists", async () => {
+		const {outcome} = await run(script([CROSSLINK, errOut("gh: timeout")]), {json: true});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).crossLinked).toBe(false);
+		expect(outcome.stderr.join("\n")).toContain("add the comment by hand");
+	});
+});
+
+describe("runSplit — the create-once key", () => {
+	const sibling = issue({number: 4400, title: "Autosave drops the draft"});
+	const foreign = issue({number: 4400, body: "unrelated\n\nsplit from #9999\n"});
+
+	it("reuses a child matching BOTH halves of the key, and writes nothing", async () => {
+		const {outcome, calls} = await run(
+			script([QUEUE, okOut(`4321\t${TITLE}\n`)], [issueRead(4321), issue({})]),
+		);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("reused\t4321\thttps://example.test/issues/4321\n");
+		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+		expect(calls.some((c) => CROSSLINK.test(c))).toBe(false);
+	});
+
+	it("names the key it matched on, and never claims a cross-link it did not make", async () => {
+		const {outcome} = await run(
+			script([QUEUE, okOut(`4321\t${TITLE}\n`)], [issueRead(4321), issue({})]),
+			{json: true},
+		);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			outcome: "reused",
+			matchedOn: "back-reference+title",
+			crossLinked: false,
+		});
+	});
+
+	it("does NOT reuse on the title alone — a same-titled child of another parent is not this child", async () => {
+		const {outcome} = await run(
+			script([QUEUE, okOut(`4400\t${TITLE}\n`)], [issueRead(4400), foreign]),
+		);
+		expect(outcome.stdout).toBe("created\t4321\thttps://example.test/issues/4321\n");
+	});
+
+	// Routed through the TIMELINE deliberately: that read carries no titles, so every cross-reference
+	// is fetched and tested, and the AND is the only thing standing between this sibling and a false
+	// reuse. Through the queue the title narrowing would reject it before the key ran at all.
+	it("does NOT reuse on the back-reference alone — a sibling split is not this child", async () => {
+		const {outcome} = await run(
+			script([TIMELINE, okOut("4400\tfalse\n")], [issueRead(4400), sibling]),
+		);
+		expect(outcome.stdout).toBe("created\t4321\thttps://example.test/issues/4321\n");
+	});
+
+	it("reaches a child already triaged out of the queue, through the timeline", async () => {
+		const {outcome} = await run(
+			script([TIMELINE, okOut("4321\tfalse\n")], [issueRead(4321), issue({})]),
+		);
+		expect(outcome.stdout).toBe("reused\t4321\thttps://example.test/issues/4321\n");
+	});
+
+	it("ignores pull requests in the timeline", async () => {
+		const {outcome, calls} = await run(script([TIMELINE, okOut("9001\ttrue\n")]));
+		expect(outcome.stdout).toBe("created\t4321\thttps://example.test/issues/4321\n");
+		expect(calls.some((c) => issueRead(9001).test(c))).toBe(false);
+	});
+
+	it("narrows on the title before fetching, so an unrelated queue row costs no read", async () => {
+		const {calls} = await run(script([QUEUE, okOut("4400\tSomething else entirely\n")]));
+		expect(calls.some((c) => issueRead(4400).test(c))).toBe(false);
+	});
+});
+
+describe("runSplit — a read that cannot see is never an answer", () => {
+	it("exits 11 on an UNKNOWN candidate body, and creates nothing", async () => {
+		const {outcome, calls} = await run(
+			script(
+				[QUEUE, okOut(`4400\t${TITLE}\n`)],
+				[issueRead(4400), errOut("gh: Bad gateway (HTTP 502)")],
+			),
+		);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("refusing to create a possible twin");
+		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+	});
+
+	it("exits 11 on an unreadable queue, never on a silent create", async () => {
+		const {outcome, calls} = await run(script([QUEUE, errOut("gh: Bad gateway (HTTP 502)")]));
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+	});
+
+	it("exits 11 on an unreadable timeline", async () => {
+		const {outcome, calls} = await run(script([TIMELINE, errOut("gh: Bad gateway (HTTP 502)")]));
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+	});
+
+	it("exits 11 on an unreadable parent, and 7 on one proven absent", async () => {
+		const unreadable = await run(script([PARENT, errOut("gh: Bad gateway (HTTP 502)")]));
+		expect(unreadable.outcome.code).toBe(PRECONDITION_UNKNOWN);
+		const absent = await run(script([PARENT, errOut("gh: Not Found (HTTP 404)")]));
+		expect(absent.outcome.code).toBe(ZERO_SCOPE);
+		expect(absent.outcome.stderr.at(-1)).toBe("triage split: parent #4312 not found in o/r.");
+	});
+
+	it("exits 11 on an unreadable label set", async () => {
+		const {outcome} = await run(script([LABELS, errOut("gh: Bad gateway (HTTP 502)")]));
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("exits 7 when the queue label does not exist — a 200 over [] is not a proven negative", async () => {
+		const {outcome, calls} = await run(script([LABELS, okOut("type:bug\np0")]));
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.at(-1)).toContain("(ADR 0092)");
+		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+	});
+});
+
+describe("runSplit — the write and its read-back", () => {
+	it("exits 8 with the re-run recovery when the create fails", async () => {
+		const {outcome} = await run(script([CREATE, errOut("gh: timeout")]));
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("which will reuse it if it did");
+	});
+
+	it("exits 9 when the landed child is not what was composed", async () => {
+		const {outcome} = await run(script([issueRead(4321), issue({body: "something else"})]));
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toBe(
+			"triage split: child #4321 created but its body read back changed — inspect before splitting further.",
+		);
+	});
+
+	it("exits 9 when the read-back itself fails", async () => {
+		const {outcome} = await run(script([issueRead(4321), errOut("gh: Bad gateway (HTTP 502)")]));
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("tolerates a trailing-newline difference — the normalised comparison owns that", async () => {
+		const {outcome} = await run(
+			script([issueRead(4321), issue({body: `${COMPOSED.trimEnd()}\n\n\n`})]),
+		);
+		expect(outcome.code).toBe(0);
+	});
+});
+
+describe("runSplit — the authored-text guard", () => {
+	it("refuses an empty body before any network read", async () => {
+		const {outcome, calls} = await run(base, {
+			stdin: Effect.succeed({_tag: "Text", text: ""} satisfies StdinRead),
+		});
+		expect(outcome.code).toBe(EMPTY_STDIN);
+		expect(calls.some((c) => c.startsWith("gh"))).toBe(false);
+	});
+
+	it("scans the COMPOSED body, so nothing the verb appends can escape the predicate", async () => {
+		const {outcome, calls} = await run(base, {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: "reproduced from /Users/someone/scratch/case.md",
+			} satisfies StdinRead),
+		});
+		expect(outcome.code).toBe(LEAKED_PATH);
+		expect(calls.some((c) => c.startsWith("gh"))).toBe(false);
+	});
+
+	it("refuses a non-issue-number parent without touching the network", async () => {
+		const {outcome, calls} = await run(base, {parent: 0});
+		expect(outcome.code).toBe(1);
+		expect(calls).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
@@ -213,6 +213,20 @@ describe("runSplit — a read that cannot see is never an answer", () => {
 		expect(calls.some((c) => CREATE.test(c))).toBe(false);
 	});
 
+	// The same refusal on the second loop. The timeline read carries no titles, so it fetches every
+	// cross-reference — an UNKNOWN one there is just as likely to BE the child as an UNKNOWN queue row.
+	it("exits 11 on an UNKNOWN timeline candidate too, not only a queue one", async () => {
+		const {outcome, calls} = await run(
+			script(
+				[TIMELINE, okOut("4400\tfalse\n")],
+				[issueRead(4400), errOut("gh: Bad gateway (HTTP 502)")],
+			),
+		);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(calls.some((c) => CREATE.test(c))).toBe(false);
+	});
+
 	it("exits 11 on an unreadable queue, never on a silent create", async () => {
 		const {outcome, calls} = await run(script([QUEUE, errOut("gh: Bad gateway (HTTP 502)")]));
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);

--- a/packages/fabrika-cli/src/triage/split.ts
+++ b/packages/fabrika-cli/src/triage/split.ts
@@ -1,0 +1,72 @@
+/**
+ * `triage split`'s create-once key and the child body that carries it, pure.
+ *
+ * **The key is one the verb wrote, not one a caller remembered.** The child body carries
+ * `split from #<parent>`, so a re-run reads back the same evidence it planted. The predecessor
+ * called that back-reference load-bearing and then never checked the body carried it, so a child
+ * filed without it was permanently invisible to the guard and every re-run fired a fresh twin
+ * (#3462/#3463).
+ *
+ * **Both halves, never one.** A candidate matches on `(back-reference AND normalized title)`. The
+ * back-reference alone collapses every sibling of one parent into the first child ever split from it;
+ * the title alone collapses same-titled children of unrelated parents. Each half alone is a silent
+ * lost split, which is the direction this verb is least allowed to fail in.
+ */
+
+import {composeBody} from "../report/compose.ts";
+
+/**
+ * The title, reduced to the form the key compares — **Unicode-aware**, not ASCII.
+ *
+ * `\p{L}\p{N}` is the load-bearing part. An ASCII class shreds a Turkish title into a handful of
+ * fragments, so two genuinely different Turkish-titled siblings of one parent collapse to the same
+ * key and the second is falsely *reused* — a split silently lost, against a corpus whose product
+ * titles are Turkish by repo law (`.glossary/LANGUAGE.md`). NFC folds canonically-equivalent
+ * spellings of one title together, which can only remove twins, never merge distinct titles.
+ */
+export const normalizeTitle = (title: string): string =>
+	title
+		.normalize("NFC")
+		.toLowerCase()
+		.split(/[^\p{L}\p{N}]+/u)
+		.filter((token) => token !== "")
+		.join(" ");
+
+/** The line the child body carries, and the thing a later run greps for. */
+export const backReference = (parent: number): string => `split from #${parent}`;
+
+/**
+ * Whether `body` carries the back-reference to `parent`.
+ *
+ * The trailing-digit guard is what keeps `split from #431` from answering for `#43` — a false match
+ * there reuses an unrelated child and drops the split.
+ */
+export const hasBackReference = (body: string, parent: number): boolean =>
+	new RegExp(`split from #${parent}(?!\\d)`, "i").test(body);
+
+/** One issue as the create-once match reads it. */
+export interface Candidate {
+	readonly number: number;
+	readonly title: string;
+	readonly body: string;
+	readonly url: string;
+}
+
+/** Whether `candidate` is already this split's child — both halves of the key, AND-ed. */
+export const isExistingChild = (candidate: Candidate, parent: number, title: string): boolean =>
+	hasBackReference(candidate.body, parent) &&
+	normalizeTitle(candidate.title) === normalizeTitle(title);
+
+/**
+ * The child body: the caller's bytes, the back-reference, then the agent footer.
+ *
+ * The footer is not decoration. Without it `triage provenance` answers `human` and `triage kill`
+ * refuses the child forever on `12` — a split child could never be killed, not even as a duplicate
+ * of its own sibling (ADR 0159). `composeBody` owns the spacing so this shape stays identical to
+ * `report file`'s.
+ */
+export const composeChildBody = (stdin: string, parent: number, footer: string): string =>
+	composeBody(`${stdin.replace(/\s+$/, "")}\n\n${backReference(parent)}`, footer);
+
+/** The comment the parent gets, so the provenance trace is part of the operation, not the model's. */
+export const crossLinkComment = (child: number): string => `split into #${child}`;

--- a/packages/fabrika-cli/src/triage/split.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/split.unit.test.ts
@@ -1,0 +1,116 @@
+import {describe, expect, it} from "vitest";
+import {renderFooter} from "../report/compose.ts";
+import {
+	backReference,
+	composeChildBody,
+	crossLinkComment,
+	hasBackReference,
+	isExistingChild,
+	normalizeTitle,
+} from "./split.ts";
+
+/** The predecessor's key, reproduced so the Turkish collapse is asserted rather than asserted about. */
+const asciiNormalize = (title: string): string =>
+	title
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((t) => t !== "")
+		.join(" ");
+
+const child = (over: Partial<Parameters<typeof isExistingChild>[0]> = {}) => ({
+	number: 4321,
+	title: "Editor loses focus after save",
+	body: "The editor drops focus.\n\nsplit from #4312\n",
+	url: "https://example.test/issues/4321",
+	...over,
+});
+
+describe("normalizeTitle", () => {
+	it("is case- and punctuation-insensitive", () => {
+		expect(normalizeTitle("Editor loses focus — after save!")).toBe(
+			normalizeTitle("editor loses focus after save"),
+		);
+	});
+
+	it("keeps two Turkish titles distinct where an ASCII key collapses them", () => {
+		const a = "Başlık düşüyor";
+		const b = "Başlık döşüyor";
+		// The hazard, proven: the ASCII key cannot tell these apart, so the second would be falsely
+		// REUSED — a split silently lost.
+		expect(asciiNormalize(a)).toBe(asciiNormalize(b));
+		expect(normalizeTitle(a)).not.toBe(normalizeTitle(b));
+	});
+
+	it("keeps Turkish letters instead of dropping them", () => {
+		expect(normalizeTitle("Sözlük tanımı")).toBe("sözlük tanımı");
+	});
+
+	it("folds canonically-equivalent spellings of one title together", () => {
+		expect(normalizeTitle("Sözlük")).toBe(normalizeTitle("Sözlük".normalize("NFD")));
+	});
+});
+
+describe("hasBackReference", () => {
+	it("finds the reference the verb itself writes", () => {
+		expect(hasBackReference(`x\n\n${backReference(4312)}\n`, 4312)).toBe(true);
+	});
+
+	it("does not let #431 answer for #43 — a longer number is a different parent", () => {
+		expect(hasBackReference("split from #431", 43)).toBe(false);
+	});
+
+	it("is absent when the body never carried one", () => {
+		expect(hasBackReference("a body with no provenance at all", 4312)).toBe(false);
+	});
+});
+
+describe("isExistingChild", () => {
+	it("matches on both halves of the key", () => {
+		expect(isExistingChild(child(), 4312, "Editor loses focus after save")).toBe(true);
+	});
+
+	it("refuses a title-only match — a same-titled child of ANOTHER parent is not this child", () => {
+		expect(
+			isExistingChild(child({body: "split from #9999"}), 4312, "Editor loses focus after save"),
+		).toBe(false);
+	});
+
+	it("refuses a back-reference-only match — a sibling split from the same parent is not this child", () => {
+		expect(
+			isExistingChild(
+				child({title: "Autosave drops the draft"}),
+				4312,
+				"Editor loses focus after save",
+			),
+		).toBe(false);
+	});
+});
+
+describe("composeChildBody", () => {
+	const footer = renderFooter({
+		session: "s",
+		model: null,
+		branch: null,
+		timestamp: "2026-01-01T00:00:00Z",
+	});
+
+	it("puts the caller's bytes first, then the back-reference, then the footer", () => {
+		expect(composeChildBody("The editor drops focus.", 4312, footer)).toBe(
+			"The editor drops focus.\n\nsplit from #4312\n\n---\n<sub>Filed by an agent · session `s` · 2026-01-01T00:00:00Z</sub>\n",
+		);
+	});
+
+	it("carries the agent footer, without which the child could never be killed (ADR 0159)", () => {
+		expect(composeChildBody("x", 4312, footer)).toContain("Filed by an agent");
+	});
+
+	it("writes a back-reference its own matcher reads back", () => {
+		expect(hasBackReference(composeChildBody("x", 4312, footer), 4312)).toBe(true);
+	});
+});
+
+describe("crossLinkComment", () => {
+	it("names the child", () => {
+		expect(crossLinkComment(4321)).toBe("split into #4321");
+	});
+});


### PR DESCRIPTION
Part of #4831 — slice 3 of the nine `triage` verbs. Deliberately **not** `Fixes`: six verbs and the
`report dedup --exclude` flag are still outstanding, so this must not close the issue.

## What this adds

`fabrika triage split <parent> --title "…" < child.md` — create one child of a bundled report,
**once**, and cross-link the parent. Three new modules plus the group registration:

| File | What it is |
|---|---|
| `packages/fabrika-cli/src/triage/split.ts` | the create-once key and the child body that carries it, pure |
| `packages/fabrika-cli/src/triage/split-verb.ts` | the one transaction — precondition, the two reads, the create, its read-back, the parent comment |
| `packages/fabrika-cli/src/triage/authored.ts` | the shared authored-text guard (empty `3`, leak `5`, bare `@` `6`), which slices 4–6 import rather than re-derive |
| `packages/fabrika-cli/src/triage/command.ts` | `split` registered in the `triage` group |

## The two things worth reviewing

**The create-once key is `(back-reference AND normalized title)`.** The child body carries
`split from #<parent>`, so a re-run matches on evidence the verb itself planted — the predecessor
called that back-reference load-bearing and then never checked the body carried it (#3462/#3463).
Each half **alone** is a silent lost split: the back-reference alone collapses every sibling of one
parent into the first child ever split from it; the title alone collapses same-titled children of
unrelated parents. `normalizeTitle` is Unicode-aware (`\p{L}\p{N}`, NFC) rather than ASCII, because
an ASCII class shreds a Turkish title and falsely *reuses* a genuinely different sibling — against a
corpus whose product titles are Turkish by repo law.

**A read that cannot see is never an answer.** Every unreadable precondition — the parent, the label
set, the queue, the timeline, or any candidate's body — exits `11`, never falls through to a create.
The absent-label case is separately `7`: the queue label is a hardcoded literal while `--repo` is
generic, so a renamed label or a scope-limited token returns HTTP 200 over `[]`, which is not a read
failure and would otherwise mint a twin (ADR 0092).

Read 1 (the `status:needs-triage` queue) carries the guarantee — it is read-after-write consistent
and every child gets that label by construction, so the read can see its own output. Read 2 (the
parent timeline) only widens the net to children already triaged out of the queue; it lags 30–60
minutes (#4057), so it carries nothing on its own.

## Mutation verification

Every load-bearing behaviour was reverted, proven to turn a test RED, and restored to GREEN. Ten
mutants, ten killed:

| # | Mutant | Killed by |
|---|---|---|
| 1 | create-once key: drop the back-reference half (title-only match) | `refuses a title-only match…`, `does NOT reuse on the title alone…` |
| 2 | create-once key: drop the title half (back-reference-only match) | `refuses a back-reference-only match…`, `does NOT reuse on the back-reference alone…` |
| 3 | `normalizeTitle`: Unicode class → ASCII class | `keeps two Turkish titles distinct where an ASCII key collapses them`, `keeps Turkish letters instead of dropping them` |
| 4 | `hasBackReference`: drop the trailing-digit guard | `does not let #431 answer for #43` |
| 5 | queue loop: an UNKNOWN candidate falls through instead of exiting 11 | `exits 11 on an UNKNOWN candidate body, and creates nothing` |
| 6 | timeline loop: an UNKNOWN candidate falls through instead of exiting 11 | `exits 11 on an UNKNOWN timeline candidate too, not only a queue one` |
| 7 | label vocabulary: drop the absent-label zero-scope refusal | `exits 7 when the queue label does not exist` |
| 8 | read-back: byte equality instead of the normalised comparison | `tolerates a trailing-newline difference` |
| 9 | timeline: stop filtering out pull requests | `ignores pull requests in the timeline` |
| 10 | authored guard: seat a FAILED stdin read on the empty code (the #3924 regression) | `seats a FAILED read on 1, never on the empty code` |

Mutant 6 **survived the first pass** — the timeline loop's `return unreadable(...)` could be turned
into a `continue` with every test still green, so the second loop's fall-through to a create was
unguarded even though the queue loop's identical branch was covered. The covering test is the second
commit; the mutant is red now.

## Verification

- `pnpm exec vitest run` in `packages/fabrika-cli` — 48 files, 658 tests, all passing
- `pnpm typecheck` — 30/30 tasks green
- `pnpm lint:worktree` — clean
- `fabrika triage split --help` resolves and prints the contract's exit table

## Out of scope

The remaining six verbs (`queue` and `claim` and `provenance` and `homes` land in their own slices;
`enrich`, `apply`, `park`, `kill` follow), and `report dedup --exclude`. The name collision (#4829),
the routing pin (#4761) and the spec-to-build seam (#4749) are untouched.
