### PR TITLE
feat(fabrika-cli): triage apply + park over one owned-facet reconcile (#4831)

### DIFF
--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -192,6 +192,26 @@ export const signalledShell = (
 		),
 	);
 
+/**
+ * A pattern that matches at most once, so a script can answer the *same* command line differently on
+ * successive calls.
+ *
+ * {@link fakeShell} resolves each call by the first entry whose pattern matches, which cannot express
+ * a seam that is read twice on purpose — a reconcile reads the issue, writes, then re-reads the very
+ * same endpoint. Without this, the observed state and the read-back are forced to be identical, and
+ * every read-back test would be asserting against the input it already knew.
+ */
+export const once = (source: RegExp): RegExp => {
+	const pattern = new RegExp(source.source, source.flags);
+	let spent = false;
+	pattern.test = (line: string): boolean => {
+		if (spent) return false;
+		spent = RegExp.prototype.test.call(pattern, line);
+		return spent;
+	};
+	return pattern;
+};
+
 export const okOut = (stdout: string): ExecResult => ({ok: true, stdout, reason: ""});
 
 export const errOut = (reason: string): ExecResult => ({ok: false, stdout: "", reason});

--- a/packages/fabrika-cli/src/triage/apply-verb.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.ts
@@ -1,0 +1,206 @@
+/**
+ * `triage apply` — the whole triaged transition as one owned-facet reconcile, read back positively.
+ *
+ * Type, priority, audience, status and the home land together or not at all, and what the verb
+ * reports is what it re-read, never what it requested. v1's read-back did `landed ?? requested`, so a
+ * read that found no status label reported the *asked-for* one as landed; a read-back that falls back
+ * to the request is not a read-back.
+ *
+ * The reconcile itself — which labels are owned, what is removed, what is preserved, and the shape
+ * the read-back asserts — lives in `./facets.ts` and is shared with `triage park`.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue, listLabels, listOpenMilestones, resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {applyChanges} from "./facet-writes.ts";
+import {
+	AUDIENCES,
+	decodeMember,
+	PRIORITIES,
+	planReconcile,
+	renderShape,
+	STANDING_LANES,
+	type StandingLane,
+	shapeViolations,
+	TYPES,
+	triagedFacets,
+} from "./facets.ts";
+import {scannedLine} from "./scope.ts";
+
+export interface ApplyOptions {
+	readonly issue: number;
+	readonly type: string;
+	readonly priority: string;
+	readonly readyFor: string;
+	readonly home: number | null;
+	readonly lane: string | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const unreadable = (what: string, repo: string, reason: string): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`triage apply: cannot read ${what} in ${repo}: ${reason} — nothing was written; the transition is UNKNOWN.`,
+	);
+
+export const runApply = (
+	options: ApplyOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, json} = options;
+
+		if (!Number.isInteger(issue) || issue <= 0) {
+			return refuse(FAILED, `triage apply: ${issue} is not an issue number.`);
+		}
+		if ((options.home === null) === (options.lane === null)) {
+			return refuse(
+				FAILED,
+				"triage apply: give exactly one of --home or --lane; an issue cannot be both homed and lane-exempt.",
+			);
+		}
+
+		const type = decodeMember(TYPES, options.type);
+		if (type === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`triage apply: --type must be one of ${TYPES.join(", ")} — got "${options.type}".`,
+			);
+		}
+		const priority = decodeMember(PRIORITIES, options.priority);
+		if (priority === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`triage apply: --priority must be one of ${PRIORITIES.join(", ")} — got "${options.priority}". Refusing to apply it as a label.`,
+			);
+		}
+		const readyFor = decodeMember(AUDIENCES, options.readyFor);
+		if (readyFor === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`triage apply: --ready-for must be human or agent — got "${options.readyFor}".`,
+			);
+		}
+		let lane: StandingLane | null = null;
+		if (options.lane !== null) {
+			lane = decodeMember(STANDING_LANES, options.lane);
+			if (lane === null) {
+				return refuse(
+					OFF_VOCABULARY,
+					`triage apply: --lane must be ${STANDING_LANES.join(" or ")} — got "${options.lane}".`,
+				);
+			}
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"triage apply: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `triage apply: issue #${issue} not found in ${repo}.`);
+		}
+		if (target._tag === "Unknown") {
+			return unreadable(`issue #${issue}`, repo, target.reason);
+		}
+
+		const vocabulary = yield* listLabels(repo);
+		if (vocabulary._tag === "Failure") return unreadable("the label set", repo, vocabulary.reason);
+		const diagnostics = [scannedLine("triage apply", repo, vocabulary.value.length, "label")];
+
+		// Only the labels THIS invocation writes, not the whole vocabulary: checking all six types
+		// would refuse a good `--type bug` in a repo that merely lacks `type:investigation`.
+		const facets = triagedFacets({type, priority, readyFor, lane});
+		const willWrite = facets.flatMap((facet) => facet.keep);
+		const missing = willWrite.find((label) => !vocabulary.value.includes(label));
+		if (missing !== undefined) {
+			return refuse(
+				ZERO_SCOPE,
+				`triage apply: label ${missing} does not exist in ${repo} — refusing to write, because the API would create it (#4285).`,
+				diagnostics,
+			);
+		}
+
+		if (options.home !== null) {
+			const open = yield* listOpenMilestones(repo);
+			if (open._tag === "Failure") return unreadable("the milestone set", repo, open.reason);
+			diagnostics.push(scannedLine("triage apply", repo, open.value.length, "open milestone"));
+			if (!open.value.some((m) => m.number === options.home)) {
+				return refuse(
+					OFF_VOCABULARY,
+					`triage apply: milestone ${options.home} is not an open milestone in ${repo}.`,
+					diagnostics,
+				);
+			}
+		}
+
+		const home = options.home;
+		const plan = planReconcile(
+			{labels: target.value.labels, milestone: target.value.milestone},
+			facets,
+			home,
+		);
+
+		const written = yield* applyChanges(repo, issue, plan.changes);
+		if (written._tag === "Failed") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`triage apply: write failed after ${written.applied} of ${plan.changes.length} changes: ${written.reason} — #${issue} may be partially labelled; re-run this verb, which is idempotent.`,
+				diagnostics,
+			);
+		}
+
+		const expected = `expected exactly one type, one priority, status:triaged, one ready-for, and ${
+			home === null ? "no milestone" : `milestone ${home}`
+		}`;
+		const back = yield* getIssue(repo, issue);
+		if (back._tag !== "Present") {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage apply: read-back shows nothing — the issue could not be re-read after the write (${
+					back._tag === "Absent" ? "it is gone" : back.reason
+				}) — ${expected}.`,
+				diagnostics,
+			);
+		}
+		const observed = {labels: back.value.labels, milestone: back.value.milestone};
+		const violations = shapeViolations(observed, facets, home);
+		if (violations.length > 0) {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage apply: read-back shows ${renderShape(observed, facets)} — ${expected}.`,
+				diagnostics,
+			);
+		}
+
+		const homeColumn = home === null ? (lane as string) : String(home);
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "triaged",
+						number: issue,
+						type,
+						priority,
+						readyFor,
+						home: home === null ? lane : home,
+						removed: plan.removed,
+						readBack: {labels: observed.labels, milestone: observed.milestone},
+					}),
+					diagnostics,
+				)
+			: answer(`triaged\t${issue}\t${type}\t${priority}\t${readyFor}\t${homeColumn}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
@@ -1,0 +1,329 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {runApply} from "./apply-verb.ts";
+import {
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
+const MILESTONES = /^gh api --paginate repos\/o\/r\/milestones/;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4312 -F milestone=/;
+const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4312\/labels\//;
+const ADD = /^gh api --method POST repos\/o\/r\/issues\/4312\/labels /;
+
+const issue = (labels: ReadonlyArray<string>, milestone: number | null): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4312,
+			title: "t",
+			body: "b",
+			state: "open",
+			labels: labels.map((name) => ({name})),
+			html_url: "https://example.test/issues/4312",
+			milestone: milestone === null ? null : {number: milestone},
+		}),
+	);
+
+const VOCABULARY = okOut(
+	[
+		"type:bug",
+		"type:chore",
+		"p1",
+		"p2",
+		"status:needs-triage",
+		"status:triaged",
+		"ready-for:agent",
+		"ready-for:human",
+		"wayfinder:backlog",
+		"axis:pipeline-hardening",
+	].join("\n"),
+);
+
+const OPEN_MILESTONES = okOut("47\tfabrika campaign\n44\twayfinder");
+
+const options = {
+	issue: 4312,
+	type: "bug",
+	priority: "p2",
+	readyFor: "agent",
+	home: 47 as number | null,
+	lane: null as string | null,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+/** Observed: needs-triage on `p1` and unhomed. Read back: the whole triaged shape. */
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[once(ISSUE), issue(["status:needs-triage", "p1"], null)],
+	[ISSUE, issue(["type:bug", "p2", "status:triaged", "ready-for:agent"], 47)],
+	[LABELS, VOCABULARY],
+	[MILESTONES, OPEN_MILESTONES],
+	[PATCH, okOut("{}")],
+	[REMOVE, okOut("[]")],
+	[ADD, okOut("[]")],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runApply({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runApply", () => {
+	it("stamps the whole transition and prints the tab-separated triaged line", async () => {
+		const out = await run(happy());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("triaged\t4312\tbug\tp2\tagent\t47\n");
+	});
+
+	it("emits the record on STDOUT with --json, carrying what it read BACK", async () => {
+		const out = await run(happy(), {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "triaged",
+			number: 4312,
+			type: "bug",
+			priority: "p2",
+			readyFor: "agent",
+			home: 47,
+			removed: ["status:needs-triage", "p1"],
+			readBack: {labels: ["type:bug", "p2", "status:triaged", "ready-for:agent"], milestone: 47},
+		});
+	});
+
+	it("reports what it scanned on stderr", async () => {
+		const out = await run(happy());
+		expect(out.stderr[0]).toBe("triage apply: scanned 10 labels in o/r.");
+		expect(out.stderr[1]).toBe("triage apply: scanned 2 open milestones in o/r.");
+	});
+
+	it("homes BEFORE it labels, so the homing guard never sees a triaged un-homed issue", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
+		const writes = shell.calls.filter((c) => PATCH.test(c) || REMOVE.test(c) || ADD.test(c));
+		expect(writes[0]).toBe("gh api --method PATCH repos/o/r/issues/4312 -F milestone=47");
+		expect(writes.at(-1)).toContain("--method POST");
+	});
+
+	it("removes the superseded priority and never the applied one (#4285)", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
+		const removes = shell.calls.filter((c) => REMOVE.test(c));
+		expect(removes).toEqual([
+			"gh api --method DELETE repos/o/r/issues/4312/labels/status%3Aneeds-triage",
+			"gh api --method DELETE repos/o/r/issues/4312/labels/p1",
+		]);
+		expect(shell.calls.find((c) => ADD.test(c))).toContain("labels[]=p2");
+	});
+
+	it("leaves a label no facet owns entirely alone", async () => {
+		const shell = fakeShell([
+			[once(ISSUE), issue(["area:pipeline", "p1"], 47)],
+			[ISSUE, issue(["area:pipeline", "type:bug", "p2", "status:triaged", "ready-for:agent"], 47)],
+			[LABELS, VOCABULARY],
+			[MILESTONES, OPEN_MILESTONES],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls.some((c) => c.includes("area%3Apipeline"))).toBe(false);
+	});
+
+	it("clears the milestone under --lane, because a lane-exempt issue is not homed (ADR 0208)", async () => {
+		const shell = fakeShell([
+			[once(ISSUE), issue(["status:needs-triage"], 47)],
+			[
+				ISSUE,
+				issue(["type:bug", "p2", "status:triaged", "ready-for:agent", "wayfinder:backlog"], null),
+			],
+			[LABELS, VOCABULARY],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runApply({...options, home: null, lane: "wayfinder:backlog"}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("triaged\t4312\tbug\tp2\tagent\twayfinder:backlog\n");
+		expect(shell.calls).toContain("gh api --method PATCH repos/o/r/issues/4312 -F milestone=null");
+		expect(shell.calls.some((c) => MILESTONES.test(c))).toBe(false);
+	});
+
+	it("refuses both --home and --lane", async () => {
+		const out = await run(happy(), {lane: "wayfinder:backlog"});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("exactly one of --home or --lane");
+	});
+
+	it("refuses neither --home nor --lane", async () => {
+		const out = await run(happy(), {home: null});
+		expect(out.code).toBe(1);
+	});
+
+	it("refuses a non-issue number", async () => {
+		const out = await run(happy(), {issue: 0});
+		expect(out.code).toBe(1);
+	});
+
+	it.each([
+		["type", {type: "task"}],
+		["priority", {priority: "1"}],
+		["ready-for", {readyFor: "robot"}],
+		["lane", {home: null, lane: "axis:whatever"}],
+	])("refuses an off-vocabulary --%s on 10, before any read", async (_flag, override) => {
+		const shell = fakeShell(happy());
+		const out = await Effect.runPromise(
+			Effect.provide(runApply({...options, ...override}), shell.layer),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a milestone that is not open, on the same code", async () => {
+		const out = await run(happy(), {home: 99});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("not an open milestone");
+	});
+
+	it("refuses to write a label the repo does not define — the API would mint it (#4285)", async () => {
+		const shell = fakeShell([
+			[once(ISSUE), issue(["status:needs-triage"], null)],
+			[ISSUE, issue([], null)],
+			[LABELS, okOut(["type:bug", "p2", "status:triaged"].join("\n"))],
+			[MILESTONES, OPEN_MILESTONES],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("label ready-for:agent does not exist");
+		expect(shell.calls.some((c) => ADD.test(c) || PATCH.test(c))).toBe(false);
+	});
+
+	it("checks only the labels THIS run writes, not the whole vocabulary", async () => {
+		// A repo missing `type:investigation` must not refuse a good `--type bug`.
+		const out = await run([
+			[once(ISSUE), issue(["status:needs-triage", "p1"], null)],
+			[ISSUE, issue(["type:bug", "p2", "status:triaged", "ready-for:agent"], 47)],
+			[LABELS, okOut(["type:bug", "p1", "p2", "status:triaged", "ready-for:agent"].join("\n"))],
+			[MILESTONES, OPEN_MILESTONES],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses an issue proven absent on 7", async () => {
+		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("triage apply: issue #4312 not found in o/r.");
+	});
+
+	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {
+		const shell = fakeShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("nothing was written");
+		expect(shell.calls.some((c) => PATCH.test(c) || ADD.test(c))).toBe(false);
+	});
+
+	it("refuses an unreadable label set as UNKNOWN, never as an empty vocabulary", async () => {
+		const out = await run([
+			[ISSUE, issue(["status:needs-triage"], null)],
+			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("cannot read the label set");
+	});
+
+	it("refuses an unreadable milestone set as UNKNOWN, never as a closed home", async () => {
+		const out = await run([
+			[ISSUE, issue(["status:needs-triage"], null)],
+			[LABELS, VOCABULARY],
+			[MILESTONES, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("cannot read the milestone set");
+	});
+
+	it("reports a failed write as UNKNOWN, counting how many changes had landed", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["status:needs-triage", "p1"], null)],
+			[ISSUE, issue([], null)],
+			[LABELS, VOCABULARY],
+			[MILESTONES, OPEN_MILESTONES],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, errOut("gh: timeout")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("write failed after 3 of 4 changes");
+		expect(out.stderr.at(-1)).toContain("which is idempotent");
+	});
+
+	it("refuses when the read-back does not show the shape, reporting what it SAW", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["status:needs-triage", "p1"], null)],
+			[ISSUE, issue(["type:bug", "p2", "ready-for:agent"], 47)],
+			[LABELS, VOCABULARY],
+			[MILESTONES, OPEN_MILESTONES],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("status=[]");
+		expect(out.stderr.at(-1)).toContain("expected exactly one type");
+	});
+
+	it("refuses a read-back that lost the home, even with every label right", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["status:needs-triage"], null)],
+			[ISSUE, issue(["type:bug", "p2", "status:triaged", "ready-for:agent"], null)],
+			[LABELS, VOCABULARY],
+			[MILESTONES, OPEN_MILESTONES],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("milestone=none");
+	});
+
+	it("refuses when the read-back itself fails — a write that is not verified is not finished", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["status:needs-triage"], null)],
+			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, VOCABULARY],
+			[MILESTONES, OPEN_MILESTONES],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("read-back shows nothing");
+	});
+
+	it("refuses an unresolvable repo rather than guessing one", async () => {
+		const out = await Effect.runPromise(
+			Effect.provide(runApply({...options, env: {}}), fakeShell([]).layer),
+		);
+		expect(out.code).toBe(1);
+		expect(out.stderr.at(-1)).toContain("cannot resolve a target repo");
+	});
+});

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -19,7 +19,10 @@ import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
 import type {VerbOutcome} from "../verb.ts";
+import {runApply} from "./apply-verb.ts";
 import {runCodes} from "./codes-verb.ts";
+import {AUDIENCES, PRIORITIES, STANDING_LANES, TYPES} from "./facets.ts";
+import {runPark} from "./park-verb.ts";
 import {runSplit} from "./split-verb.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
@@ -97,12 +100,91 @@ const split = leafCommand(
 	),
 );
 
+/**
+ * The classification flags are declared as free strings, not as CLI-level enums, so an off-vocabulary
+ * value reaches the verb and is refused there on `10` with the message the contract states. A
+ * parser-level rejection would seat it on `1`, fusing "you named a priority that does not exist" with
+ * "the binary is broken".
+ */
+const issueArg = Argument.integer("issue").pipe(
+	Argument.withDescription("the issue number to stamp"),
+);
+
+const apply = leafCommand(
+	"apply",
+	{
+		issue: issueArg,
+		type: Flag.string("type").pipe(
+			Flag.withDescription(`the issue's type: one of ${TYPES.join(", ")}`),
+		),
+		priority: Flag.string("priority").pipe(
+			Flag.withDescription(`the priority bucket: one of ${PRIORITIES.join(", ")}`),
+		),
+		readyFor: Flag.string("ready-for").pipe(
+			Flag.withDescription(`who picks it up: ${AUDIENCES.join(" or ")}`),
+		),
+		home: Flag.integer("home").pipe(
+			Flag.optional,
+			Flag.withDescription("the number of an open milestone to home the issue in"),
+		),
+		lane: Flag.string("lane").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				`a standing lane instead of a milestone: ${STANDING_LANES.join(" or ")}`,
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, type, priority, readyFor, home, lane, repo, json}) {
+		yield* emit(
+			yield* runApply({
+				issue,
+				type,
+				priority,
+				readyFor,
+				home: Option.getOrNull(home),
+				lane: Option.getOrNull(lane),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Stamp the whole triaged transition — type, priority, audience, status and home — as ONE owned-facet reconcile, then read the end state back positively. Exactly one of --home / --lane. Prints `triaged\\t<n>\\t<type>\\t<priority>\\t<ready-for>\\t<home>`. Exits 7 (no such issue, or a label this run would write does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 10 (off-vocabulary value, or a non-open milestone), 11 (a precondition read failed). Example: fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47",
+	),
+);
+
+const park = leafCommand(
+	"park",
+	{issue: issueArg, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({issue, repo, json}) {
+		yield* emit(
+			yield* runPark({
+				issue,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Demote an issue to status:needs-info with the questions on STDIN, clearing every priced facet — type, priority, audience, lane and milestone. The comment is posted BEFORE the labels move. Prints `parked\\t<n>\\t<comment-url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue, or status:needs-info does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed). Example: fabrika triage park 4290 < questions.md",
+	),
+);
+
 export const triageCommand = Command.make("triage").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
 		// editing one. The comment is what keeps the formatter from collapsing the list back.
 		codes,
 		split,
+		apply,
+		park,
 	]),
 	Command.withDescription(
 		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",

--- a/packages/fabrika-cli/src/triage/facet-writes.ts
+++ b/packages/fabrika-cli/src/triage/facet-writes.ts
@@ -1,0 +1,49 @@
+/**
+ * Issue a reconcile plan's changes in order, counting how many landed before one failed.
+ *
+ * The count is the point. Exit `8` reports "write failed after `<k>` of `<m>` changes", and a caller
+ * told only that *something* failed cannot tell an issue that was never touched from one left half
+ * labelled — so the changes are decomposed into individually-observable add/remove calls rather than
+ * collapsed into a single replace-set `PUT`, and the applier reports the index it stopped at.
+ *
+ * The adds go through `POST .../labels`, which **creates an unknown label rather than rejecting it**
+ * — so the caller's vocabulary precondition is not optional politeness, it is the only thing between
+ * a typo and a repo-wide grey label (#4285).
+ */
+import {Effect} from "effect";
+import type {Attempt, Shell} from "../io/git.ts";
+import {addLabels, clearMilestone, removeLabel, setMilestone} from "../io/issues.ts";
+import type {Change} from "./facets.ts";
+
+export type WriteOutcome =
+	| {readonly _tag: "Applied"; readonly count: number}
+	| {readonly _tag: "Failed"; readonly applied: number; readonly reason: string};
+
+const runChange = (repo: string, issue: number, change: Change): Shell<Attempt<unknown>> => {
+	switch (change._tag) {
+		case "SetMilestone":
+			return setMilestone(repo, issue, change.milestone);
+		case "ClearMilestone":
+			return clearMilestone(repo, issue);
+		case "RemoveLabel":
+			return removeLabel(repo, issue, change.label);
+		case "AddLabels":
+			return addLabels(repo, issue, change.labels);
+	}
+};
+
+export const applyChanges = (
+	repo: string,
+	issue: number,
+	changes: ReadonlyArray<Change>,
+): Shell<WriteOutcome> =>
+	Effect.gen(function* () {
+		let applied = 0;
+		for (const change of changes) {
+			const result = yield* runChange(repo, issue, change);
+			if (result._tag === "Failure")
+				return {_tag: "Failed" as const, applied, reason: result.reason};
+			applied += 1;
+		}
+		return {_tag: "Applied" as const, count: applied};
+	});

--- a/packages/fabrika-cli/src/triage/facets.ts
+++ b/packages/fabrika-cli/src/triage/facets.ts
@@ -1,0 +1,196 @@
+/**
+ * The owned-facet reconcile that `triage apply` and `triage park` both write through, and the closed
+ * vocabularies that feed it.
+ *
+ * A facet owns a pattern of labels and names the ones it keeps. **Every label the pattern matches and
+ * the keep set does not is removed; every label no facet's pattern matches is preserved untouched.**
+ * The milestone obeys the same rule — it is not a label, so it plans as its own change, but it is a
+ * facet, which is what stops `--lane` from landing the milestone-on-a-standing-lane state ADR 0208
+ * bans while a labels-only read-back certifies it.
+ *
+ * **One engine, two verbs, deliberately.** #4285's mechanism was a *delete*, not a write: the
+ * priority facet owned `/^p\d+$/`, the applied `p2` was not in the keep set, and a well-formed run
+ * stripped the issue's only priority while printing a success line indistinguishable from a correct
+ * one. Two independently-written reconciles are two chances to re-derive that, so the reconcile, the
+ * change plan and the read-back assertion live here once and the verbs differ only in the facet table
+ * they pass in.
+ */
+
+/**
+ * The two standing lanes, taking their values from the contract's `triage homes` table — the one
+ * place in that spec that enumerates them.
+ *
+ * They live here only until `triage homes` lands and exports them; this list then moves to that
+ * module and every reader re-points at it. It is defined in exactly one place even so: the contract's
+ * own `park` facet table re-enumerates the same two labels as a regex, and a second copy is precisely
+ * the drift a shared engine exists to prevent.
+ */
+export const STANDING_LANES = ["wayfinder:backlog", "axis:pipeline-hardening"] as const;
+
+export type StandingLane = (typeof STANDING_LANES)[number];
+
+export const isStandingLane = (label: string): label is StandingLane =>
+	(STANDING_LANES as ReadonlyArray<string>).includes(label);
+
+/** The closed `--type` vocabulary. A value off it is refused before any write, never applied. */
+export const TYPES = ["bug", "feature", "chore", "decision", "investigation", "epic"] as const;
+export type TriageType = (typeof TYPES)[number];
+
+/** The closed `--priority` vocabulary — the enum whose absence made `--p 1` mint a label `1`. */
+export const PRIORITIES = ["p0", "p1", "p2"] as const;
+export type TriagePriority = (typeof PRIORITIES)[number];
+
+/** The closed `--ready-for` vocabulary: who picks the issue up (#4780). */
+export const AUDIENCES = ["human", "agent"] as const;
+export type TriageAudience = (typeof AUDIENCES)[number];
+
+export const decodeMember = <A extends string>(
+	vocabulary: ReadonlyArray<A>,
+	value: string,
+): A | null => (vocabulary.includes(value as A) ? (value as A) : null);
+
+/** One facet: what it owns, and the labels it keeps of what it owns. */
+export interface Facet {
+	readonly name: string;
+	readonly owns: (label: string) => boolean;
+	readonly keep: ReadonlyArray<string>;
+}
+
+const ownsType = (label: string): boolean => label.startsWith("type:");
+const ownsPriority = (label: string): boolean => /^p\d+$/.test(label);
+const ownsStatus = (label: string): boolean =>
+	/^status:(needs-triage|triaged|needs-info)$/.test(label);
+const ownsAudience = (label: string): boolean => label.startsWith("ready-for:");
+
+/**
+ * The facet table for the triaged transition.
+ *
+ * The containment invariant, stated where a future editor adding a facet will read it: **the set of
+ * values an input can produce must be a subset of what its facet owns.** `PRIORITIES` ⊂ `/^p\d+$/`,
+ * `TYPES` ⊂ `type:*`, `AUDIENCES` ⊂ `ready-for:*`, `STANDING_LANES` ⊂ itself. Widening a pattern past
+ * its input — which is what v1 did — is what makes a correct value look superseded.
+ * `facets.unit.test.ts` re-derives the containment rather than trusting this note.
+ */
+export const triagedFacets = (input: {
+	readonly type: TriageType;
+	readonly priority: TriagePriority;
+	readonly readyFor: TriageAudience;
+	readonly lane: StandingLane | null;
+}): ReadonlyArray<Facet> => [
+	{name: "type", owns: ownsType, keep: [`type:${input.type}`]},
+	{name: "priority", owns: ownsPriority, keep: [input.priority]},
+	{name: "status", owns: ownsStatus, keep: ["status:triaged"]},
+	{name: "audience", owns: ownsAudience, keep: [`ready-for:${input.readyFor}`]},
+	{name: "lane", owns: isStandingLane, keep: input.lane === null ? [] : [input.lane]},
+];
+
+/**
+ * The facet table for a park: the same five facets, every keep set empty but the status.
+ *
+ * A parked issue carries no type, no priority, no audience, no lane and no home — and a re-park, or a
+ * park after an earlier `apply`, arrives already priced. Asserting the end state over only the two
+ * labels the verb wrote would certify an issue reading both `status:triaged` and `status:needs-info`,
+ * which corrupts every queue read downstream.
+ */
+export const parkedFacets = (): ReadonlyArray<Facet> => [
+	{name: "type", owns: ownsType, keep: []},
+	{name: "priority", owns: ownsPriority, keep: []},
+	{name: "status", owns: ownsStatus, keep: ["status:needs-info"]},
+	{name: "audience", owns: ownsAudience, keep: []},
+	{name: "lane", owns: isStandingLane, keep: []},
+];
+
+/** One atomic write the plan will issue. `AddLabels` is one change because it is one API call. */
+export type Change =
+	| {readonly _tag: "SetMilestone"; readonly milestone: number}
+	| {readonly _tag: "ClearMilestone"}
+	| {readonly _tag: "RemoveLabel"; readonly label: string}
+	| {readonly _tag: "AddLabels"; readonly labels: ReadonlyArray<string>};
+
+/** An issue's facet-bearing state, as read and as read back. */
+export interface Shape {
+	readonly labels: ReadonlyArray<string>;
+	readonly milestone: number | null;
+}
+
+export interface Plan {
+	readonly changes: ReadonlyArray<Change>;
+	readonly removed: ReadonlyArray<string>;
+	readonly added: ReadonlyArray<string>;
+	/** Every label no facet owns. Named so a test can bind to it: these must never be written. */
+	readonly preserved: ReadonlyArray<string>;
+}
+
+/**
+ * Plan the reconcile from the observed shape to the one the facets and `home` describe.
+ *
+ * The **milestone change comes first**, before the labels. The homing guard fires on the label event,
+ * so stamping `status:triaged` ahead of the home opens a real window in which the issue is triaged
+ * and un-homed and the guard reds on the happy path — and a guard that reds on correct work is one
+ * people learn to ignore. Removals precede the single add batch for the same reason: a superseded
+ * status label must not be readable alongside its replacement.
+ */
+export const planReconcile = (
+	observed: Shape,
+	facets: ReadonlyArray<Facet>,
+	home: number | null,
+): Plan => {
+	const keep = new Set(facets.flatMap((facet) => facet.keep));
+	const owned = (label: string): boolean => facets.some((facet) => facet.owns(label));
+
+	const removed = observed.labels.filter((label) => owned(label) && !keep.has(label));
+	const added = [...keep].filter((label) => !observed.labels.includes(label));
+	const preserved = observed.labels.filter((label) => !owned(label));
+
+	const milestone: ReadonlyArray<Change> =
+		home === observed.milestone
+			? []
+			: home === null
+				? [{_tag: "ClearMilestone"}]
+				: [{_tag: "SetMilestone", milestone: home}];
+
+	return {
+		changes: [
+			...milestone,
+			...removed.map((label): Change => ({_tag: "RemoveLabel", label})),
+			...(added.length === 0 ? [] : [{_tag: "AddLabels", labels: added} as const]),
+		],
+		removed,
+		added,
+		preserved,
+	};
+};
+
+/**
+ * The facets whose observed labels are not exactly their keep set, plus `"milestone"` when the home
+ * does not match — the read-back's **positive** proof, in the one shape both verbs assert.
+ *
+ * An empty array means every facet was observed to hold exactly what it should, which is a different
+ * claim from "no contradiction was seen": a read that cannot see the new state fails this, because
+ * the required labels are then observably absent rather than merely unrefuted.
+ */
+export const shapeViolations = (
+	observed: Shape,
+	facets: ReadonlyArray<Facet>,
+	home: number | null,
+): ReadonlyArray<string> => {
+	const wrong = facets
+		.filter((facet) => {
+			const seen = observed.labels.filter(facet.owns).slice().sort();
+			const want = facet.keep.slice().sort();
+			return seen.length !== want.length || seen.some((label, i) => label !== want[i]);
+		})
+		.map((facet) => facet.name);
+	return observed.milestone === home ? wrong : [...wrong, "milestone"];
+};
+
+/** What the read-back actually saw, facet by facet — the `<observed>` of the exit-`9` message. */
+export const renderShape = (observed: Shape, facets: ReadonlyArray<Facet>): string => {
+	const perFacet = facets.map(
+		(facet) => `${facet.name}=[${observed.labels.filter(facet.owns).join(", ")}]`,
+	);
+	return [
+		...perFacet,
+		`milestone=${observed.milestone === null ? "none" : observed.milestone}`,
+	].join(", ");
+};

--- a/packages/fabrika-cli/src/triage/facets.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/facets.unit.test.ts
@@ -1,0 +1,309 @@
+import {describe, expect, it} from "vitest";
+import {
+	AUDIENCES,
+	type Change,
+	decodeMember,
+	isStandingLane,
+	PRIORITIES,
+	parkedFacets,
+	planReconcile,
+	renderShape,
+	STANDING_LANES,
+	shapeViolations,
+	TYPES,
+	triagedFacets,
+} from "./facets.ts";
+
+const triaged = triagedFacets({
+	type: "bug",
+	priority: "p2",
+	readyFor: "agent",
+	lane: null,
+});
+
+const removedLabels = (changes: ReadonlyArray<Change>): ReadonlyArray<string> =>
+	changes.flatMap((c) => (c._tag === "RemoveLabel" ? [c.label] : []));
+
+const addedLabels = (changes: ReadonlyArray<Change>): ReadonlyArray<string> =>
+	changes.flatMap((c) => (c._tag === "AddLabels" ? [...c.labels] : []));
+
+describe("the containment invariant", () => {
+	// #4285's mechanism was a facet owning MORE than its input can produce, so a correct value read
+	// as superseded. Every case below re-derives that the pattern and the vocabulary line up, rather
+	// than trusting the note in facets.ts that says so.
+	it.each(TYPES)("keeps type:%s under the facet that owns type:*", (type) => {
+		const facets = triagedFacets({type, priority: "p2", readyFor: "agent", lane: null});
+		const facet = facets.find((f) => f.name === "type");
+		expect(facet?.keep).toEqual([`type:${type}`]);
+		expect(facet?.owns(`type:${type}`)).toBe(true);
+	});
+
+	it.each(PRIORITIES)("keeps %s under the facet that owns /^p\\d+$/", (priority) => {
+		const facets = triagedFacets({type: "bug", priority, readyFor: "agent", lane: null});
+		const facet = facets.find((f) => f.name === "priority");
+		expect(facet?.keep).toEqual([priority]);
+		expect(facet?.owns(priority)).toBe(true);
+	});
+
+	it.each(AUDIENCES)("keeps ready-for:%s under the facet that owns ready-for:*", (readyFor) => {
+		const facets = triagedFacets({type: "bug", priority: "p2", readyFor, lane: null});
+		const facet = facets.find((f) => f.name === "audience");
+		expect(facet?.keep).toEqual([`ready-for:${readyFor}`]);
+		expect(facet?.owns(`ready-for:${readyFor}`)).toBe(true);
+	});
+
+	it.each(STANDING_LANES)("keeps %s under the facet that owns the standing lanes", (lane) => {
+		const facets = triagedFacets({type: "bug", priority: "p2", readyFor: "agent", lane});
+		const facet = facets.find((f) => f.name === "lane");
+		expect(facet?.keep).toEqual([lane]);
+		expect(facet?.owns(lane)).toBe(true);
+	});
+
+	it("holds for every keep label of every facet, in both tables", () => {
+		const tables = [
+			triagedFacets({type: "epic", priority: "p0", readyFor: "human", lane: "wayfinder:backlog"}),
+			parkedFacets(),
+		];
+		for (const table of tables) {
+			for (const facet of table) {
+				for (const label of facet.keep) expect(facet.owns(label)).toBe(true);
+			}
+		}
+	});
+
+	it("owns status:needs-info as a status, so a park and a triage contradict rather than coexist", () => {
+		const status = triaged.find((f) => f.name === "status");
+		expect(status?.owns("status:needs-info")).toBe(true);
+		expect(status?.owns("status:needs-triage")).toBe(true);
+		expect(status?.keep).toEqual(["status:triaged"]);
+	});
+});
+
+describe("decodeMember", () => {
+	it("returns the value when it is on the vocabulary", () => {
+		expect(decodeMember(PRIORITIES, "p1")).toBe("p1");
+	});
+
+	it("returns null for a value off it — never the raw string", () => {
+		expect(decodeMember(PRIORITIES, "1")).toBeNull();
+		expect(decodeMember(TYPES, "type:bug")).toBeNull();
+		expect(decodeMember(AUDIENCES, "")).toBeNull();
+	});
+
+	it("recognises exactly the two standing lanes", () => {
+		expect(isStandingLane("wayfinder:backlog")).toBe(true);
+		expect(isStandingLane("axis:pipeline-hardening")).toBe(true);
+		expect(isStandingLane("wayfinder:backlog ")).toBe(false);
+	});
+});
+
+describe("planReconcile — the #4285 removal mechanism", () => {
+	it("removes a superseded priority and adds the applied one", () => {
+		const plan = planReconcile(
+			{labels: ["p1", "status:needs-triage"], milestone: null},
+			triaged,
+			47,
+		);
+		expect(plan.removed).toEqual(["p1", "status:needs-triage"]);
+		expect(plan.added).toEqual(["type:bug", "p2", "status:triaged", "ready-for:agent"]);
+	});
+
+	it("NEVER removes the label it is applying, even when the facet's pattern matches it", () => {
+		// The exact #4285 delete: `p2` matches /^p\d+$/, so a keep set the removal does not consult
+		// strips the priority the run just asked for while still printing a success line.
+		const plan = planReconcile({labels: ["p2", "type:bug"], milestone: 47}, triaged, 47);
+		expect(plan.removed).not.toContain("p2");
+		expect(plan.removed).not.toContain("type:bug");
+		expect(removedLabels(plan.changes)).toEqual([]);
+	});
+
+	it("preserves every label no facet owns, and issues no write for it", () => {
+		const plan = planReconcile(
+			{labels: ["area:pipeline", "good first issue", "p1"], milestone: 47},
+			triaged,
+			47,
+		);
+		expect(plan.preserved).toEqual(["area:pipeline", "good first issue"]);
+		expect(removedLabels(plan.changes)).toEqual(["p1"]);
+		expect(addedLabels(plan.changes)).not.toContain("area:pipeline");
+	});
+
+	it("plans the milestone FIRST, so the homing guard never sees a triaged un-homed issue", () => {
+		const plan = planReconcile({labels: ["status:needs-triage"], milestone: null}, triaged, 47);
+		expect(plan.changes[0]).toEqual({_tag: "SetMilestone", milestone: 47});
+	});
+
+	it("plans every removal before the single add batch", () => {
+		const plan = planReconcile({labels: ["p1", "status:needs-triage"], milestone: 47}, triaged, 47);
+		const lastRemoval = plan.changes.findLastIndex((c) => c._tag === "RemoveLabel");
+		const add = plan.changes.findIndex((c) => c._tag === "AddLabels");
+		expect(lastRemoval).toBeGreaterThanOrEqual(0);
+		expect(add).toBeGreaterThan(lastRemoval);
+	});
+
+	it("batches the adds into one change, because it is one API call", () => {
+		const plan = planReconcile({labels: [], milestone: 47}, triaged, 47);
+		expect(plan.changes.filter((c) => c._tag === "AddLabels")).toHaveLength(1);
+	});
+
+	it("plans nothing at all when the issue already holds the target shape", () => {
+		const plan = planReconcile(
+			{labels: ["type:bug", "p2", "status:triaged", "ready-for:agent"], milestone: 47},
+			triaged,
+			47,
+		);
+		expect(plan.changes).toEqual([]);
+	});
+
+	it("clears the milestone when the home is a standing lane (ADR 0208)", () => {
+		const facets = triagedFacets({
+			type: "chore",
+			priority: "p2",
+			readyFor: "agent",
+			lane: "axis:pipeline-hardening",
+		});
+		const plan = planReconcile({labels: [], milestone: 47}, facets, null);
+		expect(plan.changes[0]).toEqual({_tag: "ClearMilestone"});
+		expect(plan.added).toContain("axis:pipeline-hardening");
+	});
+
+	it("touches the milestone not at all when the home already matches", () => {
+		const plan = planReconcile({labels: [], milestone: 47}, triaged, 47);
+		expect(plan.changes.some((c) => c._tag === "SetMilestone" || c._tag === "ClearMilestone")).toBe(
+			false,
+		);
+	});
+
+	it("swaps the other standing lane out rather than letting both stand", () => {
+		const facets = triagedFacets({
+			type: "chore",
+			priority: "p2",
+			readyFor: "agent",
+			lane: "axis:pipeline-hardening",
+		});
+		const plan = planReconcile({labels: ["wayfinder:backlog"], milestone: null}, facets, null);
+		expect(plan.removed).toEqual(["wayfinder:backlog"]);
+		expect(plan.added).toContain("axis:pipeline-hardening");
+	});
+});
+
+describe("planReconcile — a park", () => {
+	const parked = parkedFacets();
+
+	it("strips every priced facet and leaves only the parked status", () => {
+		const plan = planReconcile(
+			{
+				labels: ["type:bug", "p1", "status:triaged", "ready-for:agent", "wayfinder:backlog"],
+				milestone: 47,
+			},
+			parked,
+			null,
+		);
+		expect(plan.removed).toEqual([
+			"type:bug",
+			"p1",
+			"status:triaged",
+			"ready-for:agent",
+			"wayfinder:backlog",
+		]);
+		expect(plan.added).toEqual(["status:needs-info"]);
+		expect(plan.changes[0]).toEqual({_tag: "ClearMilestone"});
+	});
+
+	it("preserves an unowned label across a park", () => {
+		const plan = planReconcile({labels: ["area:pipeline"], milestone: null}, parked, null);
+		expect(plan.preserved).toEqual(["area:pipeline"]);
+		expect(removedLabels(plan.changes)).toEqual([]);
+	});
+
+	it("is idempotent on an already-parked issue", () => {
+		const plan = planReconcile({labels: ["status:needs-info"], milestone: null}, parked, null);
+		expect(plan.changes).toEqual([]);
+	});
+});
+
+describe("shapeViolations — the read-back's positive proof", () => {
+	it("names nothing when every facet holds exactly its keep set", () => {
+		const observed = {
+			labels: ["type:bug", "p2", "status:triaged", "ready-for:agent", "area:pipeline"],
+			milestone: 47,
+		};
+		expect(shapeViolations(observed, triaged, 47)).toEqual([]);
+	});
+
+	it("fails a read that sees NOTHING — absence is not a matching shape", () => {
+		expect(shapeViolations({labels: [], milestone: null}, triaged, 47)).toEqual([
+			"type",
+			"priority",
+			"status",
+			"audience",
+			"milestone",
+		]);
+	});
+
+	it("fails an issue reading both status labels at once", () => {
+		const observed = {
+			labels: ["type:bug", "p2", "status:triaged", "status:needs-info", "ready-for:agent"],
+			milestone: 47,
+		};
+		expect(shapeViolations(observed, triaged, 47)).toEqual(["status"]);
+	});
+
+	it("fails a second priority alongside the applied one", () => {
+		const observed = {
+			labels: ["type:bug", "p2", "p0", "status:triaged", "ready-for:agent"],
+			milestone: 47,
+		};
+		expect(shapeViolations(observed, triaged, 47)).toEqual(["priority"]);
+	});
+
+	it("names the milestone when the home did not land", () => {
+		const observed = {
+			labels: ["type:bug", "p2", "status:triaged", "ready-for:agent"],
+			milestone: null,
+		};
+		expect(shapeViolations(observed, triaged, 47)).toEqual(["milestone"]);
+	});
+
+	it("names the milestone when a lane-exempt issue is still homed (ADR 0208)", () => {
+		const facets = triagedFacets({
+			type: "chore",
+			priority: "p2",
+			readyFor: "agent",
+			lane: "wayfinder:backlog",
+		});
+		const observed = {
+			labels: ["type:chore", "p2", "status:triaged", "ready-for:agent", "wayfinder:backlog"],
+			milestone: 47,
+		};
+		expect(shapeViolations(observed, facets, null)).toEqual(["milestone"]);
+	});
+
+	it("fails a park whose read-back still carries a priced facet", () => {
+		const parked = parkedFacets();
+		expect(
+			shapeViolations({labels: ["status:needs-info", "p1"], milestone: null}, parked, null),
+		).toEqual(["priority"]);
+	});
+
+	it("ignores unowned labels entirely", () => {
+		const observed = {
+			labels: ["type:bug", "p2", "status:triaged", "ready-for:agent", "good first issue"],
+			milestone: 47,
+		};
+		expect(shapeViolations(observed, triaged, 47)).toEqual([]);
+	});
+});
+
+describe("renderShape", () => {
+	it("reports what was seen facet by facet, including the milestone", () => {
+		const observed = {labels: ["type:bug", "p1", "p2", "area:x"], milestone: 47};
+		expect(renderShape(observed, triaged)).toBe(
+			"type=[type:bug], priority=[p1, p2], status=[], audience=[], lane=[], milestone=47",
+		);
+	});
+
+	it("says none for an unhomed issue rather than printing nothing", () => {
+		expect(renderShape({labels: [], milestone: null}, triaged)).toContain("milestone=none");
+	});
+});

--- a/packages/fabrika-cli/src/triage/park-verb.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.ts
@@ -1,0 +1,172 @@
+/**
+ * `triage park` — demote an issue to `status:needs-info` with the questions that would unblock it.
+ *
+ * A separate verb rather than `apply --status needs-info`, because a parked issue carries no type, no
+ * priority, no audience and no home; folding it into `apply` would make four required flags
+ * conditionally required, which is the shape that let v1 emit a fully-triaged-looking issue with a
+ * facet missing.
+ *
+ * **The comment is written first, by design.** An issue must never sit on `status:needs-info` with no
+ * statement of what would unblock it, so a comment failure leaves nothing labelled at all — which is
+ * also why the two exit-`8` messages differ: only the second can leave a partial label state.
+ *
+ * The demotion itself runs through the reconcile in `./facets.ts`, shared with `triage apply`.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getIssue, listLabels, resolveRepo} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {isBareAtReference, scanBody} from "../report/leaks.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {applyChanges} from "./facet-writes.ts";
+import {parkedFacets, planReconcile, renderShape, shapeViolations} from "./facets.ts";
+import {scannedLine} from "./scope.ts";
+
+/** The one label a park writes. Its absence is a `7`, because the API would otherwise mint it. */
+const NEEDS_INFO = "status:needs-info";
+
+export interface ParkOptions {
+	readonly issue: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+const unreadable = (what: string, repo: string, reason: string): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`triage park: cannot read ${what} in ${repo}: ${reason} — nothing was written; the park is UNKNOWN.`,
+	);
+
+export const runPark = (
+	options: ParkOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, json} = options;
+
+		if (!Number.isInteger(issue) || issue <= 0) {
+			return refuse(FAILED, `triage park: ${issue} is not an issue number.`);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"triage park: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`triage park: could not read stdin: ${read.reason} — the questions are UNKNOWN, never empty.`,
+			);
+		}
+		const questions = read._tag === "NoStdin" ? "" : read.text;
+		if (questions.trim() === "") {
+			return refuse(
+				EMPTY_STDIN,
+				"triage park: no questions on stdin — a parked issue must say what would unblock it.",
+			);
+		}
+		if (isBareAtReference(questions)) {
+			return refuse(
+				BARE_AT_PATH,
+				'triage park: the questions are a bare "@" path reference — they never arrived. Send them on stdin.',
+			);
+		}
+		// Authored text, so a leak is refusable rather than redactable: the caller can fix it, and
+		// the loop on a refusal is redact-and-re-send.
+		const leak = scanBody(questions).leaks[0];
+		if (leak !== undefined) {
+			return refuse(
+				LEAKED_PATH,
+				`triage park: the questions carry a machine-local path at line ${leak.line} (${leak.class}) — rewrite it repo-relative.`,
+			);
+		}
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `triage park: issue #${issue} not found in ${repo}.`);
+		}
+		if (target._tag === "Unknown") return unreadable(`issue #${issue}`, repo, target.reason);
+
+		const vocabulary = yield* listLabels(repo);
+		if (vocabulary._tag === "Failure") return unreadable("the label set", repo, vocabulary.reason);
+		const diagnostics = [scannedLine("triage park", repo, vocabulary.value.length, "label")];
+		if (!vocabulary.value.includes(NEEDS_INFO)) {
+			return refuse(
+				ZERO_SCOPE,
+				`triage park: label ${NEEDS_INFO} does not exist in ${repo} — refusing to write, because the API would create it (#4285).`,
+				diagnostics,
+			);
+		}
+
+		const posted = yield* createComment(repo, issue, questions);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`triage park: the questions comment on #${issue} failed: ${posted.reason} — nothing was labelled and #${issue} is unchanged. Re-run.`,
+				diagnostics,
+			);
+		}
+
+		const facets = parkedFacets();
+		const plan = planReconcile(
+			{labels: target.value.labels, milestone: target.value.milestone},
+			facets,
+			null,
+		);
+		const written = yield* applyChanges(repo, issue, plan.changes);
+		if (written._tag === "Failed") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`triage park: the questions landed but the label swap failed: ${written.reason} — #${issue} carries the questions and may be partially labelled; re-run this verb, which is idempotent.`,
+				diagnostics,
+			);
+		}
+
+		const expected = `expected ${NEEDS_INFO} present and status:needs-triage absent`;
+		const back = yield* getIssue(repo, issue);
+		if (back._tag !== "Present") {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage park: read-back shows nothing — the issue could not be re-read after the write (${
+					back._tag === "Absent" ? "it is gone" : back.reason
+				}) — ${expected}.`,
+				diagnostics,
+			);
+		}
+		const observed = {labels: back.value.labels, milestone: back.value.milestone};
+		if (shapeViolations(observed, facets, null).length > 0) {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage park: read-back shows ${renderShape(observed, facets)} — ${expected}.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "parked",
+						number: issue,
+						commentUrl: posted.value.url,
+						removed: plan.removed,
+					}),
+					diagnostics,
+				)
+			: answer(`parked\t${issue}\t${posted.value.url}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
@@ -1,0 +1,309 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {runPark} from "./park-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4290$/;
+const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
+const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/4290\/comments /;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4290 -F milestone=/;
+const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4290\/labels\//;
+const ADD = /^gh api --method POST repos\/o\/r\/issues\/4290\/labels /;
+
+const QUESTIONS = "Which of the two sozluk surfaces does this cover?";
+
+const issue = (labels: ReadonlyArray<string>, milestone: number | null): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4290,
+			title: "t",
+			body: "b",
+			state: "open",
+			labels: labels.map((name) => ({name})),
+			html_url: "https://example.test/issues/4290",
+			milestone: milestone === null ? null : {number: milestone},
+		}),
+	);
+
+const VOCABULARY = okOut(
+	["type:bug", "p1", "status:needs-triage", "status:needs-info", "ready-for:agent"].join("\n"),
+);
+
+const POSTED = okOut(
+	JSON.stringify({
+		id: 5170421888,
+		html_url: "https://example.test/issues/4290#issuecomment-5170421888",
+	}),
+);
+
+const options = {
+	issue: 4290,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: QUESTIONS}),
+};
+
+/** Observed: a fully priced issue. Read back: nothing but the parked status. */
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[once(ISSUE), issue(["type:bug", "p1", "status:triaged", "ready-for:agent"], 47)],
+	[ISSUE, issue(["status:needs-info"], null)],
+	[LABELS, VOCABULARY],
+	[COMMENT, POSTED],
+	[PATCH, okOut("{}")],
+	[REMOVE, okOut("[]")],
+	[ADD, okOut("[]")],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runPark({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runPark", () => {
+	it("parks the issue and prints the tab-separated parked line", async () => {
+		const out = await run(happy());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			"parked\t4290\thttps://example.test/issues/4290#issuecomment-5170421888\n",
+		);
+	});
+
+	it("emits the record on STDOUT with --json", async () => {
+		const out = await run(happy(), {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "parked",
+			number: 4290,
+			commentUrl: "https://example.test/issues/4290#issuecomment-5170421888",
+			removed: ["type:bug", "p1", "status:triaged", "ready-for:agent"],
+		});
+	});
+
+	it("reports what it scanned on stderr", async () => {
+		const out = await run(happy());
+		expect(out.stderr[0]).toBe("triage park: scanned 5 labels in o/r.");
+	});
+
+	it("posts the questions BEFORE it touches a label", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
+		const writes = shell.calls.filter(
+			(c) => COMMENT.test(c) || PATCH.test(c) || REMOVE.test(c) || ADD.test(c),
+		);
+		expect(writes[0]).toContain("/comments");
+		expect(writes[0]).toContain(`body=${QUESTIONS}`);
+	});
+
+	it("clears every priced facet, milestone included", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
+		expect(shell.calls).toContain("gh api --method PATCH repos/o/r/issues/4290 -F milestone=null");
+		expect(shell.calls.filter((c) => REMOVE.test(c))).toEqual([
+			"gh api --method DELETE repos/o/r/issues/4290/labels/type%3Abug",
+			"gh api --method DELETE repos/o/r/issues/4290/labels/p1",
+			"gh api --method DELETE repos/o/r/issues/4290/labels/status%3Atriaged",
+			"gh api --method DELETE repos/o/r/issues/4290/labels/ready-for%3Aagent",
+		]);
+		expect(shell.calls.find((c) => ADD.test(c))).toContain("labels[]=status:needs-info");
+	});
+
+	it("leaves a label no facet owns alone across a park", async () => {
+		const shell = fakeShell([
+			[once(ISSUE), issue(["area:pipeline", "status:needs-triage"], null)],
+			[ISSUE, issue(["area:pipeline", "status:needs-info"], null)],
+			[LABELS, VOCABULARY],
+			[COMMENT, POSTED],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls.some((c) => c.includes("area%3Apipeline"))).toBe(false);
+	});
+
+	it("refuses a FAILED stdin read as UNKNOWN, never as empty questions", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses empty-but-READ questions on their own code", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "   \n"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a bare @ path — the questions never arrived", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "@notes/questions.md"} satisfies StdinRead),
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path in the authored questions", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: "which of /Users/someone/scratch/case.md did you mean?",
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stderr.at(-1)).toContain("rewrite it repo-relative");
+	});
+
+	it("writes nothing at all on any stdin refusal", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(
+			Effect.provide(
+				runPark({
+					...options,
+					stdin: Effect.succeed({_tag: "Text", text: ""} satisfies StdinRead),
+				}),
+				shell.layer,
+			),
+		);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses an issue proven absent on 7", async () => {
+		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("triage park: issue #4290 not found in o/r.");
+	});
+
+	it("separates an UNREADABLE issue from an absent one, and posts nothing", async () => {
+		const shell = fakeShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const out = await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(shell.calls.some((c) => COMMENT.test(c))).toBe(false);
+	});
+
+	it("refuses to write status:needs-info when the repo does not define it (#4285)", async () => {
+		const shell = fakeShell([
+			[ISSUE, issue(["status:needs-triage"], null)],
+			[LABELS, okOut(["type:bug", "status:needs-triage"].join("\n"))],
+			[COMMENT, POSTED],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("label status:needs-info does not exist");
+		expect(shell.calls.some((c) => COMMENT.test(c))).toBe(false);
+	});
+
+	it("refuses an unreadable label set as UNKNOWN, never as an empty vocabulary", async () => {
+		const out = await run([
+			[ISSUE, issue(["status:needs-triage"], null)],
+			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("cannot read the label set");
+	});
+
+	it("reports a failed comment as UNKNOWN, and says nothing was labelled", async () => {
+		const shell = fakeShell([
+			[ISSUE, issue(["status:needs-triage"], null)],
+			[LABELS, VOCABULARY],
+			[COMMENT, errOut("gh: timeout")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("nothing was labelled");
+		expect(shell.calls.some((c) => REMOVE.test(c) || ADD.test(c))).toBe(false);
+	});
+
+	it("distinguishes a failed label swap — the questions landed, the labels may be partial", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["type:bug", "status:triaged"], null)],
+			[ISSUE, issue([], null)],
+			[LABELS, VOCABULARY],
+			[COMMENT, POSTED],
+			[REMOVE, errOut("gh: timeout")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the questions landed but the label swap failed");
+	});
+
+	it("refuses a read-back that still carries a priced facet (#4285's other half)", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["type:bug", "p1", "status:triaged"], null)],
+			[ISSUE, issue(["status:needs-info", "p1"], null)],
+			[LABELS, VOCABULARY],
+			[COMMENT, POSTED],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("priority=[p1]");
+	});
+
+	it("refuses a read-back showing both status labels at once", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["status:triaged"], null)],
+			[ISSUE, issue(["status:needs-info", "status:triaged"], null)],
+			[LABELS, VOCABULARY],
+			[COMMENT, POSTED],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses a read-back that still shows a milestone", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["status:triaged"], 47)],
+			[ISSUE, issue(["status:needs-info"], 47)],
+			[LABELS, VOCABULARY],
+			[COMMENT, POSTED],
+			[PATCH, okOut("{}")],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("milestone=47");
+	});
+
+	it("refuses when the read-back itself fails", async () => {
+		const out = await run([
+			[once(ISSUE), issue(["status:triaged"], null)],
+			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+			[LABELS, VOCABULARY],
+			[COMMENT, POSTED],
+			[REMOVE, okOut("[]")],
+			[ADD, okOut("[]")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("read-back shows nothing");
+	});
+
+	it("refuses a non-issue number", async () => {
+		const out = await run(happy(), {issue: -1});
+		expect(out.code).toBe(1);
+	});
+
+	it("refuses an unresolvable repo rather than guessing one", async () => {
+		const out = await Effect.runPromise(
+			Effect.provide(runPark({...options, env: {}}), fakeShell([]).layer),
+		);
+		expect(out.code).toBe(1);
+		expect(out.stderr.at(-1)).toContain("cannot resolve a target repo");
+	});
+});


### PR DESCRIPTION
Part of #4831 — slice 4 of the nine `triage` verbs. Deliberately **not** `Fixes`: `queue`,
`claim`, `provenance`, `homes`, `split`, `enrich` and `kill` are still outstanding, and the issue
must stay open until they land.

## What this adds

`fabrika triage apply` and `fabrika triage park`, over **one** owned-facet reconcile shared by both.

| File | What it is |
|---|---|
| `packages/fabrika-cli/src/triage/facets.ts` | the facet table, the reconcile planner, and the read-back's shape assertion |
| `packages/fabrika-cli/src/triage/facet-writes.ts` | issues a plan's changes in order, counting how many landed before one failed |
| `packages/fabrika-cli/src/triage/apply-verb.ts` | the whole triaged transition — type, priority, audience, status, home |
| `packages/fabrika-cli/src/triage/park-verb.ts` | the demotion to `status:needs-info` with the questions that would unblock it |
| `packages/fabrika-cli/src/triage/command.ts` | the two leaves, registered in the group |
| `…/facets.unit.test.ts`, `…/apply-verb.unit.test.ts`, `…/park-verb.unit.test.ts` | 112 tests over the group |
| `packages/fabrika-cli/src/fakes.test-support.ts` | one addition: a `once()` pattern (below) |

### One engine, two verbs

#4285's mechanism was a **delete**, not a bad write: the priority facet owned `/^p\d+$/`, the
applied `p2` was not in the keep set, and a well-formed run stripped the issue's only priority
while printing a success line indistinguishable from a correct one. Two independently-written
reconciles are two chances to re-derive that, so the reconcile, the change plan and the read-back
assertion live in `facets.ts` once and the verbs differ only in the facet table they pass in.

Three properties the planner encodes, each with a test bound to it:

- **The milestone change is planned first.** The homing guard fires on the label event, so
  stamping `status:triaged` ahead of the home opens a real window where the issue is triaged and
  un-homed and the guard reds on the happy path.
- **Removals precede the single add batch**, so a superseded status label is never readable
  alongside its replacement.
- **Every label no facet owns is preserved untouched** — it is never in a change.

The milestone is a facet too, which is what stops `--lane` from landing the
milestone-on-a-standing-lane state ADR 0208 bans while a labels-only read-back certifies it.

### The read-back is a read-back

v1's did `landed ?? requested`, so a read that found no status label reported the *asked-for* one
as landed. `shapeViolations` is **positive** proof: an empty result means every facet was observed
to hold exactly its keep set, which is a different claim from "no contradiction was seen" — a read
that cannot see the new state fails it, because the required labels are then observably absent
rather than merely unrefuted.

### The `once()` test-support addition

`fakeShell` resolves each call by the first entry whose pattern matches, which cannot express a
seam read twice on purpose — a reconcile reads the issue, writes, then re-reads that same endpoint.
Without `once()`, the observed state and the read-back are forced to be identical and every
read-back test would be asserting the verb echoed its own input.

## Verification

- `pnpm test` in `packages/fabrika-cli`: **48 files, 696 tests, all passing** (112 in `src/triage/`).
- `pnpm typecheck` (full workspace, 30 tasks): clean, no cache.
- `pnpm lint:worktree`: clean.

### Mutation verification — 18 mutants, 0 survivors

Each load-bearing behaviour was reverted in place, the suite run, then restored and re-run. Every
mutant was killed; the tree was verified GREEN before and after the sweep.

| # | Behaviour reverted | Verdict | A test that went RED |
|---|---|---|---|
| M1 | the removal set consults the keep set (the #4285 delete) | KILLED (3) | `NEVER removes the label it is applying, even when the facet's pattern matches it` |
| M2 | removals are confined to what a facet OWNS | KILLED (4) | `preserves every label no facet owns, and issues no write for it` |
| M3 | the milestone change is planned FIRST | KILLED (5) | `homes BEFORE it labels, so the homing guard never sees a triaged un-homed issue` |
| M4 | every removal precedes the single add batch | KILLED (3) | `plans every removal before the single add batch` |
| M5 | `shapeViolations` is positive proof, not absence-of-contradiction | KILLED (2) | `fails a read that sees NOTHING — absence is not a matching shape` |
| M6 | the read-back asserts the milestone too | KILLED (5) | `refuses a read-back that lost the home, even with every label right` |
| M7 | `parkedFacets` clears EVERY priced facet, not just the status | KILLED (5) | `refuses a read-back that still carries a priced facet (#4285's other half)` |
| M8 | `applyChanges` stops at the first failure and counts what landed | KILLED (2) | `reports a failed write as UNKNOWN, counting how many changes had landed` |
| M9 | the read-back re-reads — never `landed ?? requested` | KILLED (2) | `refuses when the read-back does not show the shape, reporting what it SAW` |
| M10 | a label absent from the vocabulary refuses (the API would mint it) | KILLED (1) | `refuses to write a label the repo does not define — the API would mint it (#4285)` |
| M11 | the precondition checks only the labels THIS run writes | KILLED (15) | `stamps the whole transition and prints the tab-separated triaged line` |
| M12 | exactly one of `--home` / `--lane` | KILLED (2) | `refuses both --home and --lane` |
| M13 | an off-vocabulary `--priority` is seated on `10`, not `1` | KILLED (1) | `refuses an off-vocabulary --priority on 10, before any read` |
| M14 | `--home` must name an OPEN milestone | KILLED (1) | `refuses a milestone that is not open, on the same code` |
| M15 | an unreadable issue is `11`, never folded into the proven `7` | KILLED (1) | `separates an UNREADABLE issue from an absent one, and writes nothing` |
| M16 | the questions are posted BEFORE any label moves | KILLED (7) | `posts the questions BEFORE it touches a label` |
| M17 | authored questions carrying a machine-local path are refused | KILLED (1) | `refuses a machine-local path in the authored questions` |
| M18 | `status:needs-info` absent from the vocabulary refuses | KILLED (1) | `refuses to write status:needs-info when the repo does not define it (#4285)` |

## Acceptance criteria this slice discharges

- Every "nothing found" answer is a state word on stdout; both verbs print nothing on stdout on a
  non-zero exit (`refuse` enforces it, and each refusal test asserts `stdout === ""`).
- `triage apply` validates its inputs against closed enums, fails closed when a required label is
  absent from the repo vocabulary, and **its owned-facet removal set is unit-tested against the
  #4285 removal mechanism** — M1/M2 above, not only against a malformed write.
- `park` imports the leak predicate from `packages/fabrika-cli/src/report/leaks.ts` rather than
  defining a second one; authored text is refused (`5`), and a bare `@` reference is refused
  separately (`6`) because the redact-and-re-send loop never terminates on it.
- Every list read paginates (`--paginate` in `io/issues.ts`) and reports its scanned count on
  stderr.
- `pnpm typecheck` and `pnpm lint` pass.

## Disclosed divergence from the issue text

The issue's acceptance criteria state `11`/`12` for `triage kill`'s two refusals; the merged
`contract.md` states `12`/`13`, because `11` is already `PRECONDITION_UNKNOWN` in the shipped
`report` table this group aligns to. **The contract wins** (the issue's own non-goal: do not
re-litigate it), and `codes.ts` records the divergence at the constant rather than resolving it
silently. `kill` itself is not in this slice.

## Out of scope

The other seven verbs and `report dedup --exclude`. The live name collision (#4829), the routing
pin (#4761) and the spec-to-build seam (#4749) are untouched, per the issue's non-goals.

## Note on the branch name

An earlier run of this lane was killed mid-verification; its worktree still holds
`usirin/triage-apply-park-4831-9EB3F3AE` checked out, so this lane cut its branch at the same
commit under a distinct name rather than disturbing that tree. No PR was ever bound to the old
name; its remote ref is a strict ancestor of this one.
