### PR TITLE
fix(scratchpad): publish the owner stamp atomically so a lost claim race is exit 4, not exit 6

### DIFF
--- a/packages/pipeline-cli/src/tools/scratchpad/command.concurrency.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/command.concurrency.test.ts
@@ -26,6 +26,12 @@ const RACERS = 8;
 interface RunResult {
 	readonly code: number;
 	readonly stdout: string;
+	/**
+	 * Captured because the exit code alone cannot say WHICH refusal fired: four branches map to
+	 * `NamespaceUnavailable` (exit 6) and only one of them names an unreadable owner stamp. A run
+	 * that discarded stderr proved *a* exit-6 refusal and left the diagnosis to guesswork (#4864).
+	 */
+	readonly stderr: string;
 }
 
 let root: string;
@@ -44,12 +50,12 @@ const open = (pid: string): Promise<RunResult> =>
 			"node",
 			[BIN, "scratchpad", "open", "--slug", SLUG, "--session", SESSION],
 			{env: {...process.env, TMPDIR: root, CLAUDE_PID: pid}},
-			(error, stdout) => {
+			(error, stdout, stderr) => {
 				const code =
 					error && typeof (error as {code?: unknown}).code === "number"
 						? (error as {code: number}).code
 						: 0;
-				resolve({code, stdout: stdout.trim()});
+				resolve({code, stdout: stdout.trim(), stderr: stderr.trim()});
 			},
 		);
 	});
@@ -66,8 +72,18 @@ describe("scratchpad open — concurrent claims on one namespace", {
 			1,
 			`expected a single winner, got exit codes [${results.map((r) => r.code).join(" ")}]`,
 		);
-		for (const loser of results.filter((result) => result.code !== 0))
-			assert.strictEqual(loser.code, 4, "a loser must be refused as ForeignNamespace, not 0 or 6");
+		for (const loser of results.filter((result) => result.code !== 0)) {
+			assert.strictEqual(
+				loser.code,
+				4,
+				`a loser must be refused as ForeignNamespace, not 0 or 6 — refusal was: ${loser.stderr || "<no stderr captured>"}`,
+			);
+			assert.include(
+				loser.stderr,
+				"scratchpad: ForeignNamespace",
+				"the refusal must name itself on stderr, so an exit code is never diagnosed by guesswork",
+			);
+		}
 
 		// The winner owns what it was handed: the surviving stamp names it, and no loser
 		// printed a path it could have written into.

--- a/packages/pipeline-cli/src/tools/scratchpad/store.claim-atomicity.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/store.claim-atomicity.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The claim window (#4864): a run that loses the race to a peer STILL PUBLISHING its owner
+ * stamp must be refused `ForeignNamespace` (exit 4) — someone else owns this — and never
+ * `NamespaceUnavailable` (exit 6), which says the namespace is broken and is not a condition
+ * a caller can retry on.
+ *
+ * These are deterministic because the mock below reproduces the platform behaviour the defect
+ * rests on rather than approximating it. `writeFileSync(path, <utf8 string>)` takes Node's C++
+ * fast path (`lib/fs.js`) into `WriteFileUtf8` (`src/node_file.cc`), which is a `uv_fs_open`
+ * followed by a SEPARATE `uv_fs_write` loop — so the mock is an `openSync`, a hook, then the
+ * write. The hook IS the ordinary preemption point between those two syscalls, held open long
+ * enough for a peer's whole `openNamespace` to run inside it; a loaded batch runner widens the
+ * same window by descheduling the writer, which is why the failure showed up in a merge-queue
+ * batch and not on an idle machine. Load is the trigger, not the defect.
+ */
+import {existsSync, mkdtempSync, readFileSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
+import {vi} from "vitest";
+import {OWNER_FILE, parseOwner, type Resolved} from "./scratchpad.ts";
+import {openNamespace} from "./store.ts";
+
+const hooks = vi.hoisted(() => ({atOpenWriteBoundary: null as (() => void) | null}));
+
+vi.mock("node:fs", async () => {
+	const real = await vi.importActual<typeof import("node:fs")>("node:fs");
+	return {
+		...real,
+		writeFileSync: (
+			file: Parameters<typeof real.writeFileSync>[0],
+			data: Parameters<typeof real.writeFileSync>[1],
+			options?: Parameters<typeof real.writeFileSync>[2],
+		) => {
+			const flag =
+				typeof options === "object" && options !== null && typeof options.flag === "string"
+					? options.flag
+					: "w";
+			const fd = real.openSync(file as string, flag);
+			try {
+				// Fires ONCE: the peer that runs inside the boundary must not re-enter it on its
+				// own writes, or the two runs would recurse into each other instead of racing.
+				const hook = hooks.atOpenWriteBoundary;
+				hooks.atOpenWriteBoundary = null;
+				hook?.();
+				real.writeFileSync(fd, data);
+			} finally {
+				real.closeSync(fd);
+			}
+		},
+	};
+});
+
+// Synthetic run identities — never a real machine/session value in a fixture (#4018).
+const SESSION = "cccccccc-0000-4000-8000-00000000000c";
+const SLUG = "review-doc-3951";
+
+let root: string;
+
+beforeEach(() => {
+	hooks.atOpenWriteBoundary = null;
+	root = mkdtempSync(join(tmpdir(), "scratchpad-claim-"));
+});
+
+afterEach(() => {
+	hooks.atOpenWriteBoundary = null;
+	rmSync(root, {recursive: true, force: true});
+});
+
+// Two concurrent runs of ONE session on ONE slug, told apart only by pid — the exact shape
+// the eight-way process race takes, held at the single interleaving that matters.
+const input = (pid: string) => ({tmpdir: root, session: SESSION, pid, slug: SLUG});
+
+const ownerFile = () => join(root, "kampus-run", SESSION, SLUG, OWNER_FILE);
+
+const tagOf = (resolved: Resolved<unknown>): string => (resolved.ok ? "ok" : resolved.error._tag);
+
+describe("openNamespace — a peer racing the claim (#4864)", () => {
+	it("refuses the loser as ForeignNamespace, not NamespaceUnavailable", () => {
+		const outcomes: Resolved<unknown>[] = [];
+		hooks.atOpenWriteBoundary = () => {
+			outcomes.push(openNamespace(input("pid-peer")));
+		};
+
+		outcomes.push(openNamespace(input("pid-first")));
+		assert.strictEqual(
+			outcomes.length,
+			2,
+			"the peer must have raced inside the claim's open/write window",
+		);
+		assert.strictEqual(
+			outcomes.filter((outcome) => outcome.ok).length,
+			1,
+			`exactly one racer may win, got [${outcomes.map(tagOf).join(" ")}]`,
+		);
+		const loser = outcomes.find((outcome) => !outcome.ok);
+		assert.strictEqual(
+			loser === undefined ? "none" : tagOf(loser),
+			"ForeignNamespace",
+			"a run that lost to a peer mid-claim owns exit 4 (someone else holds it), not exit 6 (the namespace is broken)",
+		);
+	});
+
+	it("never lets the owner stamp be observed in a partial state", () => {
+		// The property underneath the exit code: at ANY moment a peer can look, the stamp is
+		// either absent or complete. A present-but-unparseable stamp is what made a routine lost
+		// race read as an unreadable claim.
+		let observed: "absent" | "complete" | "partial" = "absent";
+		hooks.atOpenWriteBoundary = () => {
+			if (!existsSync(ownerFile())) return;
+			observed = parseOwner(readFileSync(ownerFile(), "utf8")) === null ? "partial" : "complete";
+		};
+
+		openNamespace(input("pid-first"));
+		assert.notStrictEqual(
+			observed,
+			"partial",
+			"the stamp name must never exist without its content",
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/scratchpad/store.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/store.ts
@@ -7,7 +7,17 @@
  * Every function returns a `Resolved` — a refusal is a value here, never a throw and
  * never a fallback to a shared path.
  */
-import {existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {randomUUID} from "node:crypto";
+import {
+	existsSync,
+	linkSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import {dirname} from "node:path";
 import {
 	classifyOwnership,
 	fail,
@@ -56,16 +66,46 @@ const clearLeftovers = (namespace: Namespace): void => {
 };
 
 /**
+ * Publish the owner stamp so the name never exists holding partial content: write the whole
+ * stamp to a private temp file, then `link()` it into place. `link` is BOTH atomic and
+ * exclusive — it raises `EEXIST` when a peer already claimed — so the kernel-picks-the-winner
+ * property survives while the mid-write window closes. (A plain `rename` is atomic but not
+ * exclusive: it would silently clobber the peer's claim, so it is not a substitute.)
+ *
+ * `wx` alone was not enough, and this is the #4864 defect: `writeFileSync(path, <utf8 string>)`
+ * takes Node's C++ fast path (`lib/fs.js`) into `WriteFileUtf8` (`src/node_file.cc`), which is
+ * a `uv_fs_open` followed by a SEPARATE `uv_fs_write` loop. `O_CREAT | O_EXCL` makes the
+ * *create* exclusive; it does not make the content appear atomically, so a loser could hit
+ * `EEXIST`, read the file at size 0, parse nothing, and be refused `NamespaceUnavailable`
+ * (exit 6) where it was owed `ForeignNamespace` (exit 4) — a transient lost race reported as
+ * a permanent breakage.
+ *
+ * The temp file is a DOT-PREFIXED sibling of the namespace directory, and both halves of that
+ * matter: a sibling escapes `clearLeftovers`, which the winner runs over the namespace and
+ * would otherwise delete a concurrent peer's in-flight temp; and `SLUG_RE` forbids a leading
+ * dot, so the name can never collide with some other run's namespace.
+ */
+const publishOwnerStamp = (namespace: Namespace, stamp: string): void => {
+	const temp = `${dirname(namespace.path)}/.claim-${randomUUID()}.tmp`;
+	writeFileSync(temp, stamp);
+	try {
+		linkSync(temp, namespace.ownerFile);
+	} finally {
+		rmSync(temp, {force: true});
+	}
+};
+
+/**
  * OPEN — the run's first write of scratch state. Claims the namespace and stamps it as ours.
  *
- * The claim is ONE exclusive create: the stamp is written with `wx` (`O_CREAT | O_EXCL`), so
- * the kernel — not a preceding existence check — picks the single winner among concurrent
- * opens, and the `EEXIST` it raises IS the refusal. This is the shape Node's own `fs` docs
- * prescribe (the "write (RECOMMENDED)" example), against the check-then-act they name as a
- * race. The earlier `existsSync` → classify → `rmSync` + write sequence had a real window
- * between the check and the act: eight concurrent opens on one session and slug each
- * concluded they owned it, five reporting success, which put #3718's silent cross-run read
- * back in reach on precisely the case the stamp was added to close.
+ * The claim is ONE exclusive, atomic publish (`publishOwnerStamp`), so the kernel — not a
+ * preceding existence check — picks the single winner among concurrent opens, and the
+ * `EEXIST` it raises IS the refusal. This is the shape Node's own `fs` docs prescribe (the
+ * "write (RECOMMENDED)" example), against the check-then-act they name as a race. The earlier
+ * `existsSync` → classify → `rmSync` + write sequence had a real window between the check and
+ * the act: eight concurrent opens on one session and slug each concluded they owned it, five
+ * reporting success, which put #3718's silent cross-run read back in reach on precisely the
+ * case the stamp was added to close.
  */
 export const openNamespace = (
 	input: NamespaceInput,
@@ -80,12 +120,12 @@ export const openNamespace = (
 		return unavailable(namespace, cause);
 	}
 	try {
-		writeFileSync(namespace.ownerFile, formatOwner(namespace.identity, now().toISOString()), {
-			flag: "wx",
-		});
+		publishOwnerStamp(namespace, formatOwner(namespace.identity, now().toISOString()));
 	} catch (cause) {
 		if (!isEexist(cause)) return unavailable(namespace, cause);
-		// The claim is already held. Whose?
+		// The claim is already held. Whose? An unreadable stamp is UNKNOWN, never "ours" — and
+		// now that the stamp is published atomically it can no longer be a peer mid-write, so
+		// this branch means genuine corruption and stays a refusal.
 		const owner = readOwner(namespace);
 		if (owner === null)
 			return fail({

--- a/packages/pipeline-cli/src/tools/scratchpad/store.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/scratchpad/store.unit.test.ts
@@ -88,6 +88,18 @@ describe("openNamespace", () => {
 		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "NamespaceUnavailable");
 	});
 
+	it("refuses a zero-length stamp too — an empty claim is corrupt, never an invitation", () => {
+		// The claim is published atomically (#4864), so the stamp can no longer be empty because a
+		// peer is mid-write. An empty one is therefore real residue, and reading it as "unowned"
+		// would turn the fix for a wrong exit code into a fail-open.
+		const claimed = join(root, "kampus-run", REVIEWER_A.session, "review-doc-3951");
+		mkdirSync(claimed, {recursive: true});
+		writeFileSync(join(claimed, ".kampus-run-owner"), "");
+		const resolved = openNamespace(input(REVIEWER_A, "review-doc-3951"));
+		assert.isFalse(resolved.ok);
+		if (!resolved.ok) assert.strictEqual(resolved.error._tag, "NamespaceUnavailable");
+	});
+
 	it("refuses with MissingSessionId rather than allocating a shared path", () => {
 		const resolved = openNamespace({
 			tmpdir: root,


### PR DESCRIPTION
`scratchpad open` picks one winner among concurrent runs and refuses everyone else. Under load a loser could get the wrong refusal: exit 6 ("this namespace is broken") instead of exit 4 ("someone else owns it"). The claim's exclusive create only made the *filename* exclusive — the JSON inside it landed in a second syscall, so a peer could catch the file existing but still empty and conclude the claim was unreadable. That is a transient lost race reported as a permanent breakage, and it is what ejected PR #4853 from the merge queue.

The claim now writes the whole stamp to a private temp file and `link()`s it into place. `link` is both atomic and exclusive, so the kernel still picks exactly one winner while the owner file never exists holding partial content.

Fixes #4864

## What changed

- `packages/pipeline-cli/src/tools/scratchpad/store.ts` — `publishOwnerStamp`: write the stamp to a dot-prefixed sibling temp file, then `linkSync` it onto the owner path. The temp is a *sibling* of the namespace directory so the winner's `clearLeftovers` cannot delete a concurrent peer's in-flight temp, and dot-prefixed so it can never collide with a slug (`SLUG_RE` forbids a leading dot). A plain `rename` was rejected: atomic but not exclusive, so it would silently clobber a peer's claim.
- The unreadable-stamp branch stays a `NamespaceUnavailable` refusal. With the publish atomic, an unparseable stamp can no longer be a peer mid-write, so it means real corruption — an unreadable stamp is UNKNOWN, never "assume it is ours".
- `store.claim-atomicity.test.ts` (new) — the deterministic reproduction. It mocks `node:fs`'s `writeFileSync` as the `open` / `write` pair Node actually performs (`lib/fs.js` fast path into `WriteFileUtf8` in `src/node_file.cc`) and runs a peer's whole `openNamespace` at that boundary. Two tests: the loser is `ForeignNamespace`, and the owner stamp is never observable in a partial state.
- `command.concurrency.test.ts` — the eight-way process race now captures each child's **stderr** and asserts a loser's refusal names itself, so an exit code is never diagnosed by guesswork. Four branches map to exit 6 and the failing CI run could not say which one fired.
- `store.unit.test.ts` — a zero-length stamp still fails closed, pinning the fix away from becoming a fail-open.

## Mutation verification

Every load-bearing behaviour was reverted, proved RED, restored, proved GREEN. The tree was byte-identical to the committed state afterwards (`git status` clean).

| # | Mutant | Result |
|---|---|---|
| 1 | `publishOwnerStamp` reverted to `writeFileSync(ownerFile, stamp, {flag: "wx"})` — the pre-fix claim | RED, 2 tests: `expected 'NamespaceUnavailable' to equal 'ForeignNamespace'` (the exact reported bug) and `expected 'partial' to not equal 'partial'` |
| 2 | `linkSync` → `renameSync` — atomic but not exclusive | RED, 7 tests, incl. `expected a single winner, got exit codes [0 0 0 0 0 0 0 0]` |
| 3 | unreadable-stamp refusal → `return ok(namespace)` — the fail-open | RED, 2 tests (`refuses a claim whose stamp cannot be read`, `refuses a zero-length stamp too`) |
| 4 | concurrency test's `stderr` capture discarded | RED, 1 test: `expected '' to include 'scratchpad: ForeignNamespace'` |

Restored: `pipeline-cli` full suite 3009 passed (180 files); `pnpm typecheck` and `pnpm lint:worktree` clean.

## Deviations

- **Narrowed a suggested fix-shape.** Said: triage surfaced three remedies (atomic publish, bounded retry on an unparseable stamp, widen the test). Did: took the atomic publish only. Why: it removes the window rather than tolerating it, and it keeps the corrupt-stamp guard fail-closed — a retry would still have to give up somewhere, and widening the test would ship the wrong refusal code. Disposition: no action needed; the ACs accept either of the first two.
- **The reproduction races at a mocked syscall boundary, not across real processes.** Said: "a test that genuinely reproduces the race". Did: mocked `node:fs`'s `writeFileSync` into the `open` → hook → `write` sequence Node itself performs, and ran the peer inside that window. Why: a real multi-process race on a ~90-byte stamp is microseconds wide and would be flaky in exactly the way this issue is about; the mock reproduces the platform behaviour the issue verified against Node's source rather than approximating it, and fails RED on the pre-fix code. The real eight-way process race is still exercised by `command.concurrency.test.ts`. Disposition: for the reviewer to judge.
- **No `.patterns/` doc added for the link-publish technique.** Said: CLAUDE.md asks for a pattern doc when you rely on an undocumented pattern. Did: kept the rationale in the function's docblock. Why: `.patterns/index.md` sets the bar at 2+ call sites, and this is one. Disposition: no action needed; revisit if a second claim primitive needs it.
- **Did not touch PR #4853.** Its head-pinned control-plane approval would be dismissed on push, per the issue's scope note. Disposition: no action needed.