### PR TITLE
test(epic-splice): pin the ruled position-independent --epic anchors (#4850)

### DIFF
--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -1074,6 +1074,16 @@ against the implementation rather than inherited: `epic-splice` cuts only on `##
 `## Plan (plan-epic)` (`epic-splice.ts:48-51`), so `## Pitch` and `## Epic — awaiting plan` are bytes
 it can never touch, and they survive every plan and re-plan.
 
+**That survival is pinned executably, not only argued.** `epic-splice`'s unit tests
+(`packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts`, the *fabrika `--epic`
+envelope survives the splice* block) run a real envelope through a first-time plan and a re-plan and
+assert that the `<details>` block stops being terminal, that the three anchors still hold, that the
+wrapped original survives byte-for-byte, and that the summary line never doubles. Three negatives pin
+the quote-protection to the same anchors: a body that quotes an envelope below its own framing prose,
+a pitch that quotes the summary line above the header, and a pitched body carrying no header are each
+rejected. Change an anchor and those tests go red, which is what keeps this section from drifting back
+into an assumption.
+
 **The residual case, stated rather than assumed away:** a body whose *first* bytes are a raw paste of
 a complete epic envelope is byte-indistinguishable from an enriched epic and will be read as one.
 Terminality did not cover that case either — a paste that ends the body is terminal — so this trades

--- a/packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts
@@ -175,6 +175,28 @@ describe("the fabrika `--epic` envelope survives the splice — #4850's position
 		expect(readsAsEnrichedByAnchors(out)).toBe(true);
 	});
 
+	// The quote-protection AC4 requires to survive the move off terminality: each negative pins ONE of
+	// the three anchors, so a detector that drops any of them goes red here rather than silently
+	// widening into "replace everything above the opening `<details>`" on somebody's pasted envelope.
+	it("rejects a body that merely QUOTES an envelope below the reporter's own framing prose", () => {
+		const quoting = `## What I saw\n\nA report about this very format. The body it pasted:\n\n${EPIC_ENVELOPE}`;
+		expect(quoting).toContain(SUMMARY_LINE);
+		expect(readsAsEnrichedByAnchors(quoting)).toBe(false);
+	});
+
+	it("rejects a pitch that quotes the summary line ABOVE the header", () => {
+		const quotingPitch = `## Pitch\n\nThe wrapper it writes opens \`${SUMMARY_LINE}\`.\n\n${EPIC_HEADER_BLOCK}`;
+		expect(quotingPitch.startsWith("## Pitch\n")).toBe(true);
+		expect(readsAsEnrichedByAnchors(quotingPitch)).toBe(false);
+	});
+
+	it("rejects a pitched body carrying no `## Epic — awaiting plan` heading", () => {
+		const headerless = EPIC_PITCH + EPIC_DETAILS;
+		expect(headerless.startsWith("## Pitch\n")).toBe(true);
+		expect(headerless).toContain(SUMMARY_LINE);
+		expect(readsAsEnrichedByAnchors(headerless)).toBe(false);
+	});
+
 	it("never cuts on `## Pitch` or `## Epic — awaiting plan` — they are not splice anchors", () => {
 		const body = beforeFirstPlan + epicDeps;
 		const freshDeps = "## Dependencies\n\n### Phase 1\n- #12 — z\n";

--- a/packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts
@@ -92,6 +92,98 @@ describe("re-plan of both sections — splice plan AND deps in place", () => {
 	});
 });
 
+/**
+ * The `--epic` enrichment envelope, byte for byte per the `## triage enrich` section of
+ * `claude-plugins/fabrika/skills/triage/contract.md`. `fabrika triage enrich --epic` writes it;
+ * `plan-epic` then splices around it, which is what these fixtures exercise.
+ */
+const EPIC_ORIGINAL = "## Summary\n\nThe reporter's own brief.  \nA `code` span and a — dash.\n";
+const EPIC_DETAILS = `<details>\n<summary>Original brief (verbatim)</summary>\n\n${EPIC_ORIGINAL}\n</details>\n`;
+const EPIC_PITCH =
+	"## Pitch\n\n**Problem:** who has it, and what stalls.\n**Arc:** fabrika campaign\n" +
+	"**Appetite:** 1 cycles\n**Rabbit-holes:** none named.\n**No-gos:** none named.\n\n";
+const EPIC_HEADER_BLOCK =
+	"## Epic — awaiting plan\n\n`plan-epic` appends its plan and dependency topology below.\n\n";
+const EPIC_ENVELOPE = EPIC_PITCH + EPIC_HEADER_BLOCK + EPIC_DETAILS;
+
+const SUMMARY_LINE = "<summary>Original brief (verbatim)</summary>";
+const EPIC_HEADER_RE = /^## Epic — awaiting plan[^\S\n]*$/m;
+
+/**
+ * The RETIRED terminality rule: a body read as already-enriched only when the `<details>` block was
+ * the last block and closed at end-of-body. Kept here as the falsified predicate — #4850's whole
+ * defect is that `spliceEpicBody` makes this false on every planned epic, at which point the old
+ * "first enrichment ⇒ wrap" branch re-wrapped pitch, header, plan and topology inside a fresh
+ * `Original brief (verbatim)` block, compounding per run.
+ */
+const readsAsEnrichedByTerminality = (body: string): boolean =>
+	body.includes(SUMMARY_LINE) && /<\/details>[^\S\n]*\n?$/.test(body);
+
+/**
+ * The ruled position-independent detector (option (a), founder ruling on #4850): all three anchors
+ * must hold, and where the `<details>` block sits relative to end-of-body is not tested at all.
+ */
+const readsAsEnrichedByAnchors = (body: string): boolean => {
+	const headerAt = body.search(EPIC_HEADER_RE);
+	const summaryAt = body.indexOf(SUMMARY_LINE);
+	return body.startsWith("## Pitch\n") && headerAt !== -1 && summaryAt > headerAt;
+};
+
+const occurrences = (body: string, needle: string): number => body.split(needle).length - 1;
+
+describe("the fabrika `--epic` envelope survives the splice — #4850's position-independent anchors", () => {
+	const epicPlan = "## Plan (plan-epic)\n\n### Product layer\n\nthe authored plan.\n\n";
+	const epicDeps = "## Dependencies\n\n### Phase 1\n- #10 — x\n";
+	// What `plan-epic` Step 2 leaves: the plan written below the untouched envelope, no topology yet.
+	const beforeFirstPlan = EPIC_ENVELOPE + epicPlan;
+
+	it("the envelope alone reads as enriched under BOTH the retired and the ruled detector", () => {
+		expect(readsAsEnrichedByTerminality(EPIC_ENVELOPE)).toBe(true);
+		expect(readsAsEnrichedByAnchors(EPIC_ENVELOPE)).toBe(true);
+	});
+
+	it("a first-time plan appends below the wrap, which falsifies terminality (the #4850 root cause)", () => {
+		const out = spliced(spliceEpicBody({body: beforeFirstPlan, deps: epicDeps, plan: null}));
+		expect(out).toBe(beforeFirstPlan + epicDeps);
+		expect(readsAsEnrichedByTerminality(out)).toBe(false);
+	});
+
+	it("but the three ruled anchors all still hold on that same planned body", () => {
+		const out = spliced(spliceEpicBody({body: beforeFirstPlan, deps: epicDeps, plan: null}));
+		expect(out.startsWith("## Pitch\n")).toBe(true);
+		expect(out.search(EPIC_HEADER_RE)).toBe(EPIC_PITCH.length);
+		expect(out.indexOf(SUMMARY_LINE)).toBeGreaterThan(out.search(EPIC_HEADER_RE));
+		expect(readsAsEnrichedByAnchors(out)).toBe(true);
+	});
+
+	it("preserves the wrapped original byte-for-byte through a first-time plan", () => {
+		const out = spliced(spliceEpicBody({body: beforeFirstPlan, deps: epicDeps, plan: null}));
+		expect(out).toContain(EPIC_DETAILS);
+		expect(occurrences(out, SUMMARY_LINE)).toBe(1);
+	});
+
+	it("keeps every anchor and the wrap intact through a re-plan of BOTH sections", () => {
+		const body = beforeFirstPlan + epicDeps;
+		const freshPlan = "## Plan (plan-epic)\n\n### Product layer\n\nre-planned prose.\n\n";
+		const freshDeps = "## Dependencies\n\n### Phase 1\n- #11 — y\n";
+		const out = spliced(spliceEpicBody({body, deps: freshDeps, plan: freshPlan}));
+		expect(out).toBe(EPIC_ENVELOPE + freshPlan + freshDeps);
+		expect(out.startsWith("## Pitch\n")).toBe(true);
+		expect(out.search(EPIC_HEADER_RE)).toBe(EPIC_PITCH.length);
+		expect(out).toContain(EPIC_DETAILS);
+		expect(occurrences(out, SUMMARY_LINE)).toBe(1);
+		expect(readsAsEnrichedByAnchors(out)).toBe(true);
+	});
+
+	it("never cuts on `## Pitch` or `## Epic — awaiting plan` — they are not splice anchors", () => {
+		const body = beforeFirstPlan + epicDeps;
+		const freshDeps = "## Dependencies\n\n### Phase 1\n- #12 — z\n";
+		const out = spliced(spliceEpicBody({body, deps: freshDeps, plan: null}));
+		// Everything above the pinned `## Dependencies` heading is verbatim live bytes, envelope included.
+		expect(out).toBe(EPIC_ENVELOPE + epicPlan + freshDeps);
+	});
+});
+
 describe("corrupt-heading guards — refuse rather than orphan or double a section", () => {
 	it("refuses a body with more than one `## Dependencies` heading", () => {
 		const body = `${BRIEF}${DEPS}\n${DEPS}`;


### PR DESCRIPTION
Re-running `triage enrich --epic` on an epic that had already been planned used to wrap the whole
body — pitch, plan, dependency topology and the previous wrapper — inside a fresh "original brief"
block, once per run. The founder ruled the fix is a detector that keys on the envelope's own headers
instead of on the wrapper sitting last in the body, and that corrected rule is already on `main`.
What was missing is proof: the rule leans on the claim that `plan-epic`'s splicer can never touch
`## Pitch` or `## Epic — awaiting plan`, and that claim was argued in prose and never run. This PR
runs it — a real envelope goes through a first-time plan and a re-plan, and the tests assert what
survives — and points the contract at those tests.

Part of #4850

## What changed

- `packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts` — a new block,
  *the fabrika `--epic` envelope survives the splice*, with seven cases:
  - a first-time plan appends below the wrap, which **falsifies terminality** — the exact condition
    that turned the next `enrich --epic` into a fresh wrap;
  - the three ruled anchors still hold on that same planned body, and again after a re-plan of both
    sections;
  - the wrapped original survives byte-for-byte and the summary line never doubles;
  - three negatives pin the quote-protection to those anchors: a body that quotes an envelope below
    its own framing prose, a pitch that quotes the summary line above the header, and a pitched body
    with no `## Epic — awaiting plan` heading are each rejected;
  - `## Pitch` and `## Epic — awaiting plan` are never splice anchors, proven by exact-equality on
    the spliced body.
- `claude-plugins/fabrika/skills/triage/contract.md` — the `## triage enrich` section now cites those
  tests as the executable pin for its anchor claim, so AC4's *stated, not assumed* has something a
  reader can run.

## Where the other acceptance criteria stand

ACs 1–4 were **already delivered on `main`**, in the merged contract (`cc04ff60`, PR #4832): the
`--epic` detector there is position-independent, the nesting claim is qualified against a planned
epic, `enrich` states an idempotency requirement in the same shape as `claim` / `split` / `apply` /
`park`, and the "adds no exit code" sentence is reconciled. Each was re-read against the merged text
before this diff was written, not assumed from the issue. This PR adds the runnable half AC4 asked
for.

**AC5 is not delivered here, which is why this is `Part of` and not `Fixes`.** It requires updating
#4831's acceptance criteria for `enrich --epic` and recording the revision they were derived from —
a write to an issue this run did not open. The text is drafted and ready; the write was **blocked by
the auto-mode cross-issue-write classifier** because the dispatch carried no pre-authorization clause
for #4831. Surfacing that rather than dropping it: whoever re-dispatches should name #4831 in the
pre-authorization, or post the drafted amendment themselves. #4850 stays open and owns that
criterion.

## Mutation verification

Every assertion was proven to fail on a reverted behaviour, then restored to green (21 passed).

| # | Mutant | Result |
|---|---|---|
| M1 | `DEPS_HEADING` widened to also match `## Epic — awaiting plan` | **RED** — 5 failed |
| M2 | first-time append reversed: `deps + working` instead of `working + deps` | **RED** — 4 failed |
| M3 | `NEXT_H2` loosened from `/^## /` to `/^#{2,6} /` | **RED** — 4 failed |
| M4 | detector drops the byte-0 `## Pitch` condition | **RED** — the quoting-body negative |
| M5 | detector's `summaryAt > headerAt` weakened to `summaryAt !== -1` | **RED** — the quoted-summary-above-header negative |
| M6 | detector drops the `headerAt !== -1` condition | **RED** — the headerless-body negative |

M4–M6 exist because the positive cases alone could not kill them: a test that only asserts a detector
returns `true` is satisfied by any weakening of it. The three negatives are what make each anchor
load-bearing.

## Observation on #4866, deliberately not absorbed

The position-independent detector does **not** settle #4866. That defect is cross-mode — a default
(non-`--epic`) `enrich` over an `--epic`-enriched body looks for
`<summary>Original report (verbatim)</summary>`, the epic envelope carries
`<summary>Original brief (verbatim)</summary>`, so the default-mode detector reads it as un-enriched
and wraps everything. No anchor in the `--epic` rule is consulted on that path. See #4866, which
remains open on its own fork; nothing here arms a close directive against it.

## Deviations

- **Class: narrowed the suggested fix-shape.** *Said:* the dispatch briefed this as a root-cause code
  fix with a test that reproduces the double-wrap and fails against current code. *Did:* delivered an
  executable pin plus a contract citation, and no failing-then-fixed test. *Why:* the defect is in a
  **specification**, and the corrected specification already merged (`cc04ff60`) — the issue itself
  says so and the founder ruling scopes the remedy to "one text edit … on PR #4832 before it merges".
  The verb `triage enrich` does not exist in `packages/fabrika-cli/src/triage/` (only `codes`, `scope`
  and the group command are there), so no test can execute the double-wrap without implementing the
  verb, which #4831 owns and #4850 explicitly rules out as "not a parallel implementation lane".
  *Disposition:* for the reviewer to judge; the mutation table above is what stands in for a
  before/after red.
- **Class: an acceptance criterion left undelivered.** *Said:* AC5 updates #4831 and records the
  revision. *Did:* drafted it, was blocked writing to #4831, used `Part of #4850`. *Why:* no
  cross-issue write pre-authorization in the dispatch. *Disposition:* #4850 stays open and owns AC5;
  named above so it is re-dispatchable rather than lost.
- **Class: a sibling defect left for a follow-up.** *Said:* nothing. *Did:* noticed that
  `spliceEpicBody` counts `## Dependencies` headings across the **whole** body, including bytes
  inside the preserved `<details>` brief — so an epic whose original report contains a single
  `## Dependencies` heading makes a *first-time* plan take the in-place **replace** branch and
  truncate the body from inside the wrap. *Why:* out of #4850's scope (its anchors are unaffected —
  `## Pitch` and `## Epic — awaiting plan` sit above the cut either way). *Disposition:* measured
  against the real function and filed as #4879; not fixed here.
