### PR TITLE
feat(fabrika-cli): triage enrich — the verb-written marker settles re-enrichment (slice 5 of #4831)

### DIFF
--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -1082,13 +1082,39 @@ preserved region, so a marker carried *inside* preserved content — a quoted en
 that was wrapped — is always the later one and can never be mistaken for the boundary.
 
 **Legacy is a self-healing migration, and is meant to be deleted.** On meeting a **pre-marker**
-wrapped body the verb recognises the two v1 envelope shapes above — default mode's terminality test,
+wrapped body the verb recognises the two v1 envelope shapes below — default mode's terminality test,
 and `--epic`'s three anchors — **does not double-wrap**, and **stamps the marker in passing**. Every
 body that branch can match therefore converts on its next enrichment and never returns to it. It is
 one-time code that retires with v1-backlog absorption (founder mandate, map #4891); an implementation
 keeps it separable so retiring it is a delete rather than an excavation. The shapes are used **only**
 for a body carrying no marker at all — a body whose marker binds *another* issue short-circuits ahead
 of them, so the legacy door cannot re-admit the impersonation the binding exists to refuse.
+
+### The two v1 envelope shapes — legacy recognisers only, never the detector
+
+Restated here **only** as what the legacy branch recognises, so the clause above resolves against a
+specification rather than a label, and so the retirement has something to delete. These are **not**
+the detector: detection is marker presence, and it is mode-independent. They decide nothing about a
+marker-bearing body — a body whose marker binds *another* issue short-circuits ahead of them
+(`detect`, `enrich.ts:95-107`) — and they are consulted **only** for a body carrying no marker at
+all. Their whole purpose is that a **pre-marker** body is preserved rather than double-wrapped. Both
+live in exactly one place, `packages/fabrika-cli/src/triage/enrich-legacy.ts`, whose retirement is a
+whole-file delete plus the injected `legacyPreserved` argument at `detect`'s call sites.
+
+**v1 default mode — terminality plus the report literal.** All three conditions hold: the body
+carries a line that is exactly `<summary>Original report (verbatim)</summary>`; that line's
+`<details>` opener sits immediately above it, blank lines aside; and the body's **last non-blank
+line** is `</details>`, so the block closes at end of body. The preserved region is that opener line
+onward, to end of body.
+
+**v1 `--epic` mode — three anchors, position-independent** (#4850's ruled option (a)). All three
+conditions hold: the body's **first** line is exactly `## Pitch`; the body carries the exact line
+`## Epic — awaiting plan`; and the first `<summary>Original brief (verbatim)</summary>` line sits
+**below** that header. The preserved region is that summary's `<details>` opener line onward, to end
+of body.
+
+Every line test above compares the line with trailing whitespace stripped, and each anchor resolves
+to its **first** occurrence in the body.
 
 **The quote-protection is preserved, and it moved onto the binding.** The strict form is required for
 the same reason `triage provenance` pins its footer match, but the failure direction is worse:

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -938,6 +938,7 @@ original:
 
 ---
 
+<!-- fabrika:enriched issue=<N> mode=rewrite -->
 <details>
 <summary>Original report (verbatim)</summary>
 
@@ -958,6 +959,7 @@ original, where `<PITCH>` is stdin verbatim:
 
 `plan-epic` appends its plan and dependency topology below.
 
+<!-- fabrika:enriched issue=<N> mode=wrap -->
 <details>
 <summary>Original brief (verbatim)</summary>
 
@@ -965,6 +967,10 @@ original, where `<PITCH>` is stdin verbatim:
 
 </details>
 ```
+
+**The `<!-- fabrika:enriched … -->` line is the re-enrich marker**, described in full under the
+detector below. It renders as nothing, it is the boundary between the region this verb owns and the
+bytes it must never touch, and it carries the issue number it was written on.
 
 An epic's original is consumed verbatim by the downstream planning step, so a **rewrite** above it
 would fork the brief — which is why this mode never takes one. **A pitch is not a rewrite**: it is
@@ -981,7 +987,7 @@ verbatim (`packages/pipeline-cli/src/tools/epic-splice/epic-splice.ts:48-51`), s
 above is an anchor it can cut on, and the wrapped original is untouched bytes either way. What
 `plan-epic` *does* change is where the wrap sits: `## Plan (plan-epic)` and `## Dependencies` both
 land **below** it, so this mode's envelope stops being terminal the moment the epic is planned. The
-re-enrich detector below is position-independent in this mode for exactly that reason; a re-enrich
+re-enrich detector below tests position nowhere, in either mode, for exactly that reason; a re-enrich
 replaces the pitch and the header from fresh stdin and preserves the wrap — and everything under it —
 unchanged, exactly as the default mode replaces a rewrite.
 
@@ -1029,75 +1035,109 @@ This verb refuses only what it can refuse about text the caller just wrote — e
 machine-local path (`5`), a bare `@` reference (`6`) — and **adds no exit code**: `--epic` reaching
 those three is the removal of a restriction, not a new outcome.
 
-**The re-enrich detector matches the envelope's shape, not the summary line alone — and the shape
-differs by mode.** Default mode's wrap is terminal and stays terminal, so that mode keys on
-terminality: a body counts as already-enriched only when the `<details>` block whose summary is the
-literal `<summary>Original report (verbatim)</summary>` is the **last** block in the body and closes
-at end-of-body. A body that carries that summary line anywhere else is treated as a **first**
-enrichment and wrapped, never replaced. Nothing downstream disturbs that shape — `epic-splice` is
-`plan-epic`'s and runs only on epics.
+**The re-enrich detector is the marker this verb writes — one rule, mode-independent** (founder
+ruling on [#4866](https://github.com/kamp-us/phoenix/issues/4866), 2026-08-08, option (b)). A body
+counts as already-enriched **when, and only when, it carries a marker line bound to this issue**:
 
-**`--epic` mode's detector is position-independent, because terminality is false there by design.**
-Once `plan-epic` runs, `## Plan (plan-epic)` and `## Dependencies` sit *below* the wrap
-(`epic-splice.ts:128-130` appends the first-time deps block at end-of-body under `depsCount === 0`;
-`plan-epic` Step 2 writes the plan "below the untouched brief"). A terminality test would therefore
-stop matching on **every planned epic**, and the "first enrichment ⇒ wrap" rule would then re-wrap
-the pitch, the header, the plan, the topology and the previous envelope inside a fresh
-`Original brief (verbatim)` block — compounding per run, and labelling the authored plan as the
-reporter's own text, which is the provenance boundary this envelope exists to keep sharp. So this
-mode keys on the envelope's own headers instead. A body counts as already-enriched only when **all
-three** hold:
+```
+<!-- fabrika:enriched issue=<N> mode=<rewrite|wrap> -->
+```
 
-- it opens at byte 0 with the exact heading `## Pitch`;
-- it carries the exact top-level heading `## Epic — awaiting plan`;
-- the first `<summary>Original brief (verbatim)</summary>` line in the body sits **below** that
-  heading.
+matched **anchored to a whole line**, never as a substring — a filing that *mentions* the marker in
+prose is an ordinary filing here, and reading its prose as a marker would overwrite the reporter's
+own text above the mention.
 
-Where the `<details>` block sits relative to end-of-body is not tested at all.
+**This supersedes the two shape-based detectors this section specified before the ruling** — default
+mode's terminality-plus-`Original report (verbatim)` test, and `--epic`'s three envelope anchors. The
+reasoning that produced them is not withdrawn: each was correct about its own mode, and the
+`--epic` rule's position-independence was itself the ruled fix to a real compounding bug
+([#4850](https://github.com/kamp-us/phoenix/issues/4850)) — once `plan-epic` runs,
+`## Plan (plan-epic)` and `## Dependencies` sit *below* the wrap
+(`epic-splice.ts:128-130`; `plan-epic` Step 2 writes the plan "below the untouched brief"), so a
+terminality test stops matching on every planned epic. What the ruling settles is that **both** were
+mode-scoped and keyed on disjoint literals, so neither could recognise the other mode's envelope. A
+re-run in the other mode therefore fell through to "first enrichment ⇒ wrap" and nested the whole
+existing envelope — pitch, header, plan, topology and the previous provenance boundary — inside a
+fresh block, compounding per run and labelling authored content as the reporter's own text. That path
+is ordinary rather than exotic: `triage apply`'s owned-facet table owns `^type:`, so re-classifying an
+enriched issue to `type:epic` and re-enriching with `--epic` is a supported sequence with no guard
+between its steps.
 
-**On a match this mode replaces the authored region only — byte 0 up to the opening `<details>` — and
-preserves that block *and every byte below it* verbatim.** Preserving the block alone would be the
-same destruction by a shorter route: it would delete the plan and the dependency topology
-`plan-epic` wrote underneath. Default mode's match is the same rule where "everything below" is
-empty.
+A marker is written by this verb and by nothing else, so presence *is* the answer, whichever mode
+wrote it and whichever mode is re-running. The class dies for every marker-bearing body rather than
+for one axis of it.
 
-**The quote-protection is preserved; it moved from terminality onto the authored prefix.** The strict
-form is required for the same reason `triage provenance` pins its footer match, but the failure
-direction is worse: provenance fails *open* toward a wrong verdict, while a loose re-enrich detector
-fails *destructively* — "replace everything above the opening `<details>`" applied to an issue that
-merely **quotes** an enrichment envelope (a bug report about this very format, a pasted body)
-silently deletes every line above the paste, on a public issue, irreversibly. In this repo an issue
-pasting a fabrika envelope is an ordinary filing, not an exotic one. Both anchors hold that line: a
-quoting body carries the reporter's own framing prose above the paste, so it fails default mode's
-terminality test *and* fails `--epic`'s byte-0 `## Pitch` test. The `--epic` anchors were checked
-against the implementation rather than inherited: `epic-splice` cuts only on `## Dependencies` and
+**The marker is also the boundary.** It sits on its own line immediately above the opening
+`<details>`, so "is this enriched?" and "where does the authored region end?" are the same read.
+Nothing has to locate a `<details>` opener or a summary literal — which is precisely what made the
+retired detectors mode-scoped. **On a match the verb replaces the authored region only — byte 0 up to
+the marker — and preserves the marker's line onward, the block *and every byte below it*, verbatim**
+(it re-emits a fresh marker carrying the mode that just wrote the region). Preserving the block alone
+would be the same destruction by a shorter route: it would delete the plan and the dependency
+topology `plan-epic` wrote underneath. Default mode's match is the same rule where "everything below"
+is empty.
+
+**The split is on the FIRST marker in the body.** The verb always writes its own marker *above* the
+preserved region, so a marker carried *inside* preserved content — a quoted envelope, a foreign paste
+that was wrapped — is always the later one and can never be mistaken for the boundary.
+
+**Legacy is a self-healing migration, and is meant to be deleted.** On meeting a **pre-marker**
+wrapped body the verb recognises the two v1 envelope shapes above — default mode's terminality test,
+and `--epic`'s three anchors — **does not double-wrap**, and **stamps the marker in passing**. Every
+body that branch can match therefore converts on its next enrichment and never returns to it. It is
+one-time code that retires with v1-backlog absorption (founder mandate, map #4891); an implementation
+keeps it separable so retiring it is a delete rather than an excavation. The shapes are used **only**
+for a body carrying no marker at all — a body whose marker binds *another* issue short-circuits ahead
+of them, so the legacy door cannot re-admit the impersonation the binding exists to refuse.
+
+**The quote-protection is preserved, and it moved onto the binding.** The strict form is required for
+the same reason `triage provenance` pins its footer match, but the failure direction is worse:
+provenance fails *open* toward a wrong verdict, while a loose re-enrich detector fails
+*destructively* — "replace everything above the boundary" applied to an issue that merely **quotes**
+an enrichment envelope (a bug report about this very format, a pasted body) silently deletes every
+line above the paste, on a public issue, irreversibly. In this repo an issue pasting a fabrika
+envelope is an ordinary filing, not an exotic one.
+
+**The issue number bound into the marker is what holds that line, and it holds a strictly wider one
+than the anchors did.** A pasted envelope carries the marker of the issue it was written on, so on
+*any other* issue it reads as **fresh** and is wrapped rather than partially overwritten — whatever
+the paste's shape, and wherever in the body it sits. That covers both the quote-impersonation case
+the retired anchors defended against **and** the residual the section previously had to state as
+uncovered: a body whose *first* bytes are a raw paste of a complete envelope. That case was
+byte-indistinguishable from an enriched body under any content-derived test, and terminality did not
+cover it either (a paste that ends the body is terminal). The section named the answer at the time —
+*"if it ever bites the answer is a marker the verb writes and a paste does not, never a weaker
+anchor"* — and this is that answer.
+
+The `--epic` anchors, which the legacy branch still uses as recognisers, were checked against the
+implementation rather than inherited: `epic-splice` cuts only on `## Dependencies` and
 `## Plan (plan-epic)` (`epic-splice.ts:48-51`), so `## Pitch` and `## Epic — awaiting plan` are bytes
-it can never touch, and they survive every plan and re-plan.
+it can never touch, and they survive every plan and re-plan. The same holds of the marker: it is
+neither of those two headings, so `epic-splice` preserves it verbatim through every plan and re-plan.
 
 **That survival is pinned executably, not only argued.** `epic-splice`'s unit tests
 (`packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts`, the *fabrika `--epic`
 envelope survives the splice* block) run a real envelope through a first-time plan and a re-plan and
-assert that the `<details>` block stops being terminal, that the three anchors still hold, that the
-wrapped original survives byte-for-byte, and that the summary line never doubles. Three negatives pin
-the quote-protection to the same anchors: a body that quotes an envelope below its own framing prose,
-a pitch that quotes the summary line above the header, and a pitched body carrying no header are each
-rejected. Change an anchor and those tests go red, which is what keeps this section from drifting back
-into an assumption.
+assert that the `<details>` block stops being terminal, that the anchors still hold, that the wrapped
+original survives byte-for-byte, and that the summary line never doubles. The marker rule is pinned
+the same way on the verb's own side, in `packages/fabrika-cli/src/triage/enrich.unit.test.ts`, which
+reproduces the **retired** detectors in-test as controls: the cross-mode re-run they miss is asserted
+to be recognised here, a pasted envelope bound to another issue is asserted to read as fresh, and a
+legacy body is asserted to be recognised, preserved and stamped. Change the rule and those tests go
+red, which is what keeps this section from drifting back into an assumption.
 
-**The residual case, stated rather than assumed away:** a body whose *first* bytes are a raw paste of
-a complete epic envelope is byte-indistinguishable from an enriched epic and will be read as one.
-Terminality did not cover that case either — a paste that ends the body is terminal — so this trades
-no protection away; it is the limit of any content-derived test, and if it ever bites the answer is a
-marker the verb writes and a paste does not, never a weaker anchor.
-
-**Idempotency, stated as the other write verbs state theirs.** Re-running `enrich` on an
-already-enriched issue **converges**: it replaces the authored region from fresh stdin and leaves the
-preserved original — and, under `--epic`, every byte below it — unchanged, so a second pass produces
-the same body as the first, nesting never accumulates, and "the innermost original" is not a case
-that arises. This holds for a **planned** epic body, which is the case the position-independent
-detector exists for. No branch here refuses, so the exit-status and error tables are unchanged and
-the **adds no exit code** statement above stands. This is the rule's only statement in this spec; the
-Scope section below states the scope and does not restate it.
+**Idempotency, stated as the other write verbs state theirs — and now unconditional.** Re-running
+`enrich` on an already-enriched issue **converges**: it replaces the authored region from fresh stdin
+and leaves the marker's line onward — the preserved original and every byte below it — unchanged, so
+a second pass produces the same body as the first, nesting never accumulates, and "the innermost
+original" is not a case that arises. This holds over a **planned** epic body (the position axis,
+#4850) and it holds when the re-run's mode **differs** from the mode that wrote the envelope (the
+mode axis, #4866) — the two qualifications the sentence previously needed. The one case it does not
+claim is a body carrying no marker and matching neither v1 shape, which is a *first* enrichment by
+definition rather than a re-run. No branch here refuses, so the exit-status and error tables are
+unchanged and the **adds no exit code** statement above stands: the marker is a body-composition
+change, not a refusal branch. This is the rule's only statement in this spec; the Scope section below
+states the scope and does not restate it.
 
 **Redaction is asymmetric and deliberate.** The **preserved original** is foreign content: any
 machine-local path in it is masked to its class root, counted, and reported on stderr with its line
@@ -1112,7 +1152,7 @@ else's leak, and preserving it unredacted re-commits that leak into a public iss
 | `3` | stdin was read and held nothing — the rewrite, or the pitch with `--epic` |
 | `5` | the **authored** text carries a machine-local path — the rewrite, or the pitch with `--epic` |
 | `6` | the **authored** text is a bare `@` path reference — the rewrite, or the pitch with `--epic` |
-| `7` | the issue is proven absent (404) |
+| `7` | the issue is proven absent (404), or it was read and its body is empty — a read that succeeded over nothing |
 | `8` | the `PATCH` failed — UNKNOWN whether the body changed |
 | `9` | the body was written but the read-back does not match |
 | `11` | the issue body could not be read — there is no original to preserve |
@@ -1123,6 +1163,7 @@ else's leak, and preserving it unredacted re-commits that leak into a public iss
 |---|---|---|
 | `triage enrich: no body on stdin — pipe the rewritten body in (with --epic, the pitch's five fields).` | 3 | refusal |
 | `triage enrich: issue #<n> not found in <repo>.` | 7 | refusal |
+| `triage enrich: #<n> has an empty body — there is no original to preserve, and an empty one must never be preserved as though it were the record.` | 7 | refusal |
 | `triage enrich: cannot read #<n> in <repo>: <reason> — refusing to write an envelope over an original that was never read.` | 11 | refusal |
 | `triage enrich: the text you sent on stdin carries a machine-local path at line <k> (<class>) — rewrite it repo-relative. The preserved original is redacted automatically; this refusal is about the text you wrote.` | 5 | refusal |
 | `triage enrich: stdin is a bare "@" path reference — the text never arrived. Send its bytes, not its path.` | 6 | refusal |
@@ -1131,7 +1172,8 @@ else's leak, and preserving it unredacted re-commits that leak into a public iss
 | `triage enrich: body written but the read-back does not match — inspect #<n> before continuing.` | 9 | refusal |
 
 **Scope** — one issue body, plus the caller's stdin: the rewrite, or the pitch with `--epic`. An
-issue proven absent is `7`; a body that could not be read is `11`. Neither ever degrades to an empty
+issue proven absent is `7`; a body that could not be read is `11`; a body that *was* read and is
+empty is `7`, a read that succeeded over nothing. None of the three ever degrades to an empty
 original preserved as though it were the record — which is the failure that would quietly delete a
 report while printing `enriched`. Re-enrichment is covered above, under the detector.
 
@@ -1171,6 +1213,12 @@ $ fabrika triage enrich 4312 --json < enriched.md
   hit `ARG_MAX` on a large enrichment. Stdin and an in-process envelope remove both.
 - v1's `PATCH` had no read-back, while the skill's own Step 0 names last-write-wins body clobbering
   as the reason its claim exists.
+- Founder ruling #4866 (2026-08-08), option (b) — the re-enrich detector is a verb-written marker
+  rather than envelope-shape inspection, with the issue number bound into it and a self-healing
+  legacy migration. It supersedes the two shape-based detectors this section carried, on evidence
+  from investigation #4896 (map #4891). The wrap-last unification (option (c)) stays on the table as
+  within-brief design for fabrika's `plan-epic` (#4712); if it is adopted later the marker becomes
+  redundant insurance, and nothing here has to be undone.
 - Founder ruling #3909 / §PITCH — lane-entering work becomes pickable only carrying a pitch, and
   `pitch-guard` scopes **every** triaged `type:epic`. This verb is the group's only body-writing
   verb, so `--epic` reading the pitch on stdin is the epic's one path to that section; an earlier

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -22,6 +22,7 @@ import type {VerbOutcome} from "../verb.ts";
 import {runApply} from "./apply-verb.ts";
 import {DEFAULT_TTL_MINUTES, runClaim} from "./claim-verb.ts";
 import {runCodes} from "./codes-verb.ts";
+import {runEnrich} from "./enrich-verb.ts";
 import {AUDIENCES, PRIORITIES, STANDING_LANES, TYPES} from "./facets.ts";
 import {DEFAULT_ROADMAP, runHomes} from "./homes-verb.ts";
 import {runKill} from "./kill-verb.ts";
@@ -328,6 +329,41 @@ const homes = leafCommand(
 	),
 );
 
+/**
+ * The rewrite — or, with `--epic`, the pitch — arrives on **stdin only**, for `split`'s reason above.
+ * `--epic` is a mode on this verb rather than a second verb because both compose the same envelope
+ * around the same preserved original; only the authored region above the marker differs.
+ */
+const enrich = leafCommand(
+	"enrich",
+	{
+		issue: Argument.integer("issue").pipe(Argument.withDescription("the issue to enrich")),
+		epic: Flag.boolean("epic").pipe(
+			Flag.withDescription(
+				"wrap the original under a fixed header and head a pitch above it; stdin carries the pitch's five field lines, not a rewrite",
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, epic, repo, json}) {
+		yield* emit(
+			yield* runEnrich({
+				issue,
+				epic,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Replace an issue body with the rewrite on STDIN above the preserved, leak-redacted original — or with --epic, a pitch above the original under a fixed header. A prior enrichment is recognised by the marker this verb writes, bound to this issue number, so a re-run in EITHER mode replaces the authored region instead of nesting a second envelope. Prints `enriched\\t<number>\\t<redactions>`. Exits 3 (empty stdin), 5 (machine-local path in the authored text), 6 (bare @ reference), 7 (issue absent, or its body is empty — no original to preserve), 8 (the PATCH failed — UNKNOWN), 9 (read-back mismatch), 11 (the issue could not be read). Example: fabrika triage enrich 4312 < enriched.md",
+	),
+);
+
 export const triageCommand = Command.make("triage").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so five in-flight slices append at five distinct lines rather than all
@@ -341,6 +377,7 @@ export const triageCommand = Command.make("triage").pipe(
 		queue,
 		provenance,
 		homes,
+		enrich,
 	]),
 	Command.withDescription(
 		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",

--- a/packages/fabrika-cli/src/triage/enrich-legacy.ts
+++ b/packages/fabrika-cli/src/triage/enrich-legacy.ts
@@ -1,0 +1,73 @@
+/**
+ * Recognise a **pre-marker** enrichment envelope, so a body written before the marker existed is
+ * migrated rather than double-wrapped.
+ *
+ * **This module is one-time migration code and is meant to be deleted.** The founder ruling on #4866
+ * makes the migration self-healing: a legacy body is recognised once, its preserved block is kept,
+ * and the marker is stamped in passing — so every body this module can match converts on its next
+ * enrichment and never returns here. The branch retires with v1-backlog absorption, and retiring it
+ * is a delete of this file plus the `legacyPreserved` argument at `detect`'s two call sites. Nothing
+ * else imports it, and no other module encodes a v1 envelope shape.
+ *
+ * The two shapes below are the two detectors `contract.md` specified before the ruling, kept here
+ * *only* as recognisers. They are never used to decide a body written after the marker landed: a
+ * marker binding another issue short-circuits ahead of them (`./enrich.ts`), which is what keeps a
+ * pasted envelope from impersonating an enrichment through the legacy door.
+ */
+
+import {SUMMARY_LINE} from "./enrich.ts";
+
+const DETAILS_OPEN = "<details>";
+const DETAILS_CLOSE = "</details>";
+const PITCH_HEADING = "## Pitch";
+const EPIC_HEADER = "## Epic — awaiting plan";
+
+/** The block's opening `<details>` line, walking back from its summary line. `null` if there is none. */
+const openerAbove = (lines: ReadonlyArray<string>, summaryAt: number): number | null => {
+	for (let i = summaryAt - 1; i >= 0; i--) {
+		const line = lines[i]?.trimEnd() ?? "";
+		if (line === DETAILS_OPEN) return i;
+		if (line !== "") return null;
+	}
+	return null;
+};
+
+const firstIndexOf = (lines: ReadonlyArray<string>, wanted: string): number =>
+	lines.findIndex((line) => line.trimEnd() === wanted);
+
+/** Whether the body's last non-blank line closes a `<details>` block — v1 default mode's terminality. */
+const closesAtEndOfBody = (lines: ReadonlyArray<string>): boolean => {
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i]?.trimEnd() ?? "";
+		if (line === "") continue;
+		return line === DETAILS_CLOSE;
+	}
+	return false;
+};
+
+/**
+ * The preserved region of a pre-marker envelope — the opening `<details>` line to end of body — or
+ * `null` when the body matches neither v1 shape.
+ */
+export const legacyPreserved = (body: string): string | null => {
+	const lines = body.split("\n");
+
+	// v1 default mode: keyed on terminality plus the `Original report (verbatim)` literal.
+	const reportAt = firstIndexOf(lines, SUMMARY_LINE.rewrite);
+	if (reportAt !== -1 && closesAtEndOfBody(lines)) {
+		const opener = openerAbove(lines, reportAt);
+		if (opener !== null) return lines.slice(opener).join("\n");
+	}
+
+	// v1 `--epic` mode: keyed on three anchors, position-independent (#4850's ruled option (a)).
+	const briefAt = firstIndexOf(lines, SUMMARY_LINE.wrap);
+	const headerAt = firstIndexOf(lines, EPIC_HEADER);
+	// `briefAt > headerAt` carries "the brief is below the header" AND "both are present": a `-1`
+	// header makes it false for any real index, and a `-1` brief is below nothing.
+	if ((lines[0]?.trimEnd() ?? "") === PITCH_HEADING && headerAt !== -1 && briefAt > headerAt) {
+		const opener = openerAbove(lines, briefAt);
+		if (opener !== null) return lines.slice(opener).join("\n");
+	}
+
+	return null;
+};

--- a/packages/fabrika-cli/src/triage/enrich-verb.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.ts
@@ -1,0 +1,155 @@
+/**
+ * `triage enrich` — write a rewrite (or, with `--epic`, a pitch) above the preserved original.
+ *
+ * This is the group's only body-writing verb, so it is the only one that can destroy a filing. Two
+ * decisions carry that weight, and both live in `./enrich.ts`: a prior enrichment is recognised by
+ * the **marker the verb itself wrote**, and the marker is also the boundary between the region this
+ * verb owns and the bytes it must never touch.
+ *
+ * **The leak asymmetry is the reason the guard runs over stdin rather than the composed body.**
+ * `readAuthored`'s callers usually scan what they composed, so nothing a verb appends can escape the
+ * predicate. Here the composed body *contains foreign content by design* — the preserved original —
+ * and that content is redacted, not refused, because refusing it would strand the enrichment on
+ * somebody else's leak while preserving it unredacted would re-commit that leak to a public issue.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue, patchIssueBody, resolveRepo} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {renderLeaks, scanBody} from "../report/leaks.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {leakRefusal, readAuthored} from "./authored.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {composeBody, detect, type EnrichMode, wrapOriginal} from "./enrich.ts";
+import {legacyPreserved} from "./enrich-legacy.ts";
+
+export interface EnrichOptions {
+	readonly issue: number;
+	/** `--epic`: stdin carries the pitch, and the original is wrapped under a fixed header. */
+	readonly epic: boolean;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runEnrich = (
+	options: EnrichOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, json} = options;
+		const mode: EnrichMode = options.epic ? "wrap" : "rewrite";
+		const surface = {
+			verb: "triage enrich",
+			noun: options.epic ? "the pitch" : "the rewrite",
+			emptyHint: options.epic
+				? "pipe the pitch's five field lines in."
+				: "pipe the rewritten body in.",
+		};
+
+		if (!Number.isInteger(issue) || issue <= 0) {
+			return refuse(FAILED, `triage enrich: ${issue} is not an issue number.`);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				"triage enrich: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.",
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const authored = readAuthored(surface, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+		const leak = leakRefusal(surface, authored.text);
+		if (leak !== null) return leak;
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `triage enrich: issue #${issue} not found in ${repo}.`);
+		}
+		if (target._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`triage enrich: cannot read #${issue} in ${repo}: ${target.reason} — refusing to write an envelope over an original that was never read.`,
+			);
+		}
+
+		const before = target.value.body;
+		const detection = detect(before, issue, legacyPreserved);
+
+		// A first enrichment redacts the original it is about to bury; a re-enrichment preserves bytes
+		// that were already redacted when they were buried, so re-scanning them would only re-report a
+		// count nobody can act on.
+		let preserved: string;
+		let redactions: number;
+		const diagnostics: string[] = [];
+
+		if (detection._tag === "Enriched") {
+			preserved = detection.preserved;
+			redactions = 0;
+			diagnostics.push(
+				detection.via === "marker"
+					? `triage enrich: #${issue} carries this issue's enrichment marker (mode=${detection.markedMode}) — replacing the authored region and preserving ${preserved.length} byte(s) below it.`
+					: `triage enrich: #${issue} carries a pre-marker v1 envelope — preserving it, stamping the marker in passing, and never wrapping it a second time.`,
+			);
+		} else {
+			if (before.trim() === "") {
+				return refuse(
+					ZERO_SCOPE,
+					`triage enrich: #${issue} has an empty body — there is no original to preserve, and an empty one must never be preserved as though it were the record.`,
+				);
+			}
+			const scan = scanBody(before);
+			preserved = wrapOriginal(mode, scan.redacted);
+			redactions = scan.leaks.length;
+			diagnostics.push(
+				detection.reason === "marker binds another issue"
+					? `triage enrich: #${issue} carries an enrichment marker bound to #${detection.boundTo}, not #${issue} — reading it as a pasted body and wrapping it as a first enrichment.`
+					: `triage enrich: #${issue} carries no enrichment marker — wrapping its body as a first enrichment.`,
+			);
+			if (redactions > 0) {
+				diagnostics.push(
+					`triage enrich: redacted ${redactions} machine-local path(s) from the preserved original (lines ${scan.leaks
+						.map((hit) => hit.line)
+						.join(", ")}).`,
+					...renderLeaks(scan.leaks),
+				);
+			}
+		}
+
+		const composed = composeBody({mode, issue, authored: authored.text, preserved});
+
+		const written = yield* patchIssueBody(repo, issue, composed);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`triage enrich: PATCH failed: ${written.reason} — UNKNOWN whether the body changed; re-read #${issue} before retrying.`,
+				diagnostics,
+			);
+		}
+
+		const back = yield* getIssue(repo, issue);
+		if (back._tag !== "Present") {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage enrich: body written but it could not be read back (${
+					back._tag === "Absent" ? "the issue is now absent" : back.reason
+				}) — inspect #${issue} before continuing.`,
+				diagnostics,
+			);
+		}
+		if (normalizeForReadback(back.value.body) !== normalizeForReadback(composed)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`triage enrich: body written but the read-back does not match — inspect #${issue} before continuing.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(JSON.stringify({outcome: "enriched", number: issue, redactions, mode}), diagnostics)
+			: answer(`enriched\t${issue}\t${redactions}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
@@ -1,0 +1,387 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {MARKER_RE, renderMarker, SUMMARY_LINE} from "./enrich.ts";
+import {runEnrich} from "./enrich-verb.ts";
+
+const READ = /^gh api repos\/o\/r\/issues\/4312$/;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4312 -f body=/;
+
+const ORIGINAL = "## Summary\n\nThe editor loses focus after a save.";
+const REWRITE = "## What to build\n\nKeep focus on the editor across a save.";
+const PITCH =
+	"**Problem:** yazars lose their place\n**Arc:** fabrika campaign\n**Appetite:** 2 cycles\n**Rabbit-holes:** none\n**No-gos:** no rewrite";
+
+const issue = (body: string): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4312,
+			title: "t",
+			body,
+			state: "open",
+			labels: [],
+			html_url: "https://example.test/issues/4312",
+			milestone: null,
+		}),
+	);
+
+const options = {
+	issue: 4312,
+	epic: false,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: REWRITE}),
+};
+
+/** The body the PATCH carried, or `null` when the verb wrote nothing. */
+const written = (calls: ReadonlyArray<string>): string | null => {
+	const call = calls.find((line) => PATCH.test(line));
+	return call === undefined ? null : call.slice(call.indexOf(" -f body=") + " -f body=".length);
+};
+
+/**
+ * Run the verb against a body, echoing whatever it PATCHes back on the read-back.
+ *
+ * A live GitHub round-trip returns what was written, so a fake that returned a fixed body would
+ * make every read-back assertion a statement about the fixture rather than about the verb.
+ */
+const run = async (before: string, overrides: Partial<typeof options> = {}) => {
+	const shell = fakeShell([
+		[once(READ), issue(before)],
+		[PATCH, okOut("{}")],
+	]);
+	// Two passes: the first to learn what the verb writes, the second to feed it back as the read-back.
+	const probe = await Effect.runPromise(
+		Effect.provide(runEnrich({...options, ...overrides}), shell.layer),
+	);
+	const patched = written(shell.calls);
+	if (patched === null) return {outcome: probe, body: null, calls: shell.calls};
+	const echoing = fakeShell([
+		[once(READ), issue(before)],
+		[PATCH, okOut("{}")],
+		[READ, issue(patched)],
+	]);
+	const outcome = await Effect.runPromise(
+		Effect.provide(runEnrich({...options, ...overrides}), echoing.layer),
+	);
+	return {outcome, body: patched, calls: echoing.calls};
+};
+
+const runScripted = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runEnrich({...options, ...overrides}), fakeShell(script).layer));
+
+const summaryLines = (body: string): ReadonlyArray<string> =>
+	body.split("\n").filter((line) => line === SUMMARY_LINE.rewrite || line === SUMMARY_LINE.wrap);
+
+const markerLines = (body: string): ReadonlyArray<string> =>
+	body.split("\n").filter((line) => MARKER_RE.test(line));
+
+describe("runEnrich — a first enrichment", () => {
+	it("writes the rewrite above the preserved original and prints the enriched line", async () => {
+		const {outcome, body} = await run(ORIGINAL);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("enriched\t4312\t0\n");
+		expect(body).toBe(
+			`${REWRITE}\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`,
+		);
+	});
+
+	it("heads a pitch under the two headings with --epic, and never writes a rewrite there", async () => {
+		const {outcome, body} = await run(ORIGINAL, {
+			epic: true,
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: PITCH}),
+		});
+		expect(outcome.code).toBe(0);
+		expect(body).toBe(
+			`## Pitch\n\n${PITCH}\n\n## Epic — awaiting plan\n\n\`plan-epic\` appends its plan and dependency topology below.\n\n${renderMarker(4312, "wrap")}\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n`,
+		);
+	});
+
+	it("emits the record on STDOUT with --json", async () => {
+		const {outcome} = await run(ORIGINAL, {json: true});
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "enriched",
+			number: 4312,
+			redactions: 0,
+			mode: "rewrite",
+		});
+	});
+
+	it("redacts machine-local paths out of the PRESERVED original and counts them", async () => {
+		const leaky = `Repro at /Users/someone/scratch/case.md and /tmp/kampus/out.log.`;
+		const {outcome, body} = await run(leaky);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe("enriched\t4312\t2\n");
+		expect(body).toContain("/Users/<redacted>");
+		expect(body).toContain("/tmp/<redacted>");
+		expect(body).not.toContain("scratch/case.md");
+		expect(outcome.stderr.some((line) => line.includes("redacted 2 machine-local path(s)"))).toBe(
+			true,
+		);
+	});
+
+	it("says on stderr that it found no marker and is wrapping a first enrichment", async () => {
+		const {outcome} = await run(ORIGINAL);
+		expect(outcome.stderr[0]).toBe(
+			"triage enrich: #4312 carries no enrichment marker — wrapping its body as a first enrichment.",
+		);
+	});
+});
+
+describe("runEnrich — re-enrichment is recognised by the marker, in EITHER mode (#4866)", () => {
+	const enriched = `${REWRITE}\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`;
+
+	it("replaces the authored region on a same-mode re-run, leaving one envelope", async () => {
+		const {outcome, body} = await run(enriched, {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "## A sharper rewrite"}),
+		});
+		expect(outcome.code).toBe(0);
+		expect(body).toBe(
+			`## A sharper rewrite\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`,
+		);
+		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.rewrite]);
+	});
+
+	it("does NOT double-wrap a default-mode envelope re-run under --epic — the cross-mode class", async () => {
+		const {outcome, body} = await run(enriched, {
+			epic: true,
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: PITCH}),
+		});
+		expect(outcome.code).toBe(0);
+		// One envelope, still the default-mode one, and the original was never re-wrapped as a "brief".
+		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.rewrite]);
+		expect(markerLines(body ?? "")).toEqual([renderMarker(4312, "wrap")]);
+		expect(body).toContain(`<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>`);
+		expect(body).toContain("## Epic — awaiting plan");
+	});
+
+	it("does NOT double-wrap an --epic envelope re-run in default mode either", async () => {
+		const epicBody = `## Pitch\n\n${PITCH}\n\n## Epic — awaiting plan\n\n${renderMarker(4312, "wrap")}\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n`;
+		const {body} = await run(epicBody);
+		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.wrap]);
+		expect(body).not.toContain("## Pitch");
+	});
+
+	it("preserves the plan and dependency topology plan-epic wrote BELOW the wrap", async () => {
+		const planned = `## Pitch\n\nstale\n\n## Epic — awaiting plan\n\n${renderMarker(4312, "wrap")}\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n\n## Plan (plan-epic)\n\nPhase 1: #4400\n\n## Dependencies\n\n#4400 requires: none\n`;
+		const {body} = await run(planned, {
+			epic: true,
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: PITCH}),
+		});
+		expect(body).toContain("## Plan (plan-epic)\n\nPhase 1: #4400");
+		expect(body).toContain("## Dependencies\n\n#4400 requires: none");
+		expect(body).toContain(PITCH);
+		expect(body).not.toContain("stale");
+		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.wrap]);
+	});
+
+	it("re-reports zero redactions on a re-enrich — the preserved bytes are not rescanned", async () => {
+		const already = `${REWRITE}\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\nRepro at /Users/<redacted> and one raw /tmp/kampus/out.log.\n\n</details>\n`;
+		const {outcome, body} = await run(already);
+		expect(outcome.stdout).toBe("enriched\t4312\t0\n");
+		// Verbatim means verbatim: the preserved region is not re-redacted behind the caller's back.
+		expect(body).toContain("/tmp/kampus/out.log");
+	});
+});
+
+describe("runEnrich — the marker binds THIS issue, so a paste reads as fresh", () => {
+	it("wraps an enriched body pasted in from another issue instead of overwriting above it", async () => {
+		const pasted = `Someone else's rewrite\n\n---\n\n${renderMarker(4290, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`;
+		const {outcome, body} = await run(pasted);
+		expect(outcome.code).toBe(0);
+		// The whole paste — foreign marker included — is preserved as the original, under OUR marker.
+		expect(body).toBe(
+			`${REWRITE}\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${pasted.trim()}\n\n</details>\n`,
+		);
+		expect(body?.startsWith(REWRITE)).toBe(true);
+		expect(body).toContain("Someone else's rewrite");
+	});
+
+	it("says on stderr which issue the foreign marker bound", async () => {
+		const pasted = `x\n\n${renderMarker(4290, "wrap")}\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n`;
+		const {outcome} = await run(pasted);
+		expect(outcome.stderr[0]).toBe(
+			"triage enrich: #4312 carries an enrichment marker bound to #4290, not #4312 — reading it as a pasted body and wrapping it as a first enrichment.",
+		);
+	});
+
+	it("converges on the SECOND pass, because our own marker now leads the body", async () => {
+		const pasted = `Someone else's rewrite\n\n---\n\n${renderMarker(4290, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`;
+		const first = await run(pasted);
+		const second = await run(first.body ?? "");
+		expect(second.body).toBe(first.body);
+		expect(markerLines(second.body ?? "")).toEqual([
+			renderMarker(4312, "rewrite"),
+			renderMarker(4290, "rewrite"),
+		]);
+	});
+});
+
+describe("runEnrich — legacy migration", () => {
+	const legacy = `${REWRITE}\n\n---\n\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`;
+
+	it("recognises a pre-marker envelope, keeps it, and stamps the marker in passing", async () => {
+		const {outcome, body} = await run(legacy, {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "## A sharper rewrite"}),
+		});
+		expect(outcome.code).toBe(0);
+		expect(body).toBe(
+			`## A sharper rewrite\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`,
+		);
+		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.rewrite]);
+		expect(outcome.stderr[0]).toContain("pre-marker v1 envelope");
+	});
+
+	it("migrates a legacy body across a mode switch without nesting it", async () => {
+		const {body} = await run(legacy, {
+			epic: true,
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: PITCH}),
+		});
+		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.rewrite]);
+		expect(markerLines(body ?? "")).toEqual([renderMarker(4312, "wrap")]);
+	});
+
+	it("wraps a body that merely QUOTES an envelope rather than overwriting the reporter's framing", async () => {
+		const quoting = `I think this format is wrong:\n\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n\nWhat should it be?\n`;
+		const {body} = await run(quoting);
+		expect(body).toContain("I think this format is wrong:");
+		expect(body).toContain("What should it be?");
+		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.rewrite, SUMMARY_LINE.wrap]);
+	});
+});
+
+describe("runEnrich — refusals", () => {
+	it("refuses a FAILED stdin read as UNKNOWN, never as empty", async () => {
+		const outcome = await runScripted([[READ, issue(ORIGINAL)]], {
+			stdin: Effect.succeed<StdinRead>({_tag: "Failed", reason: "EAGAIN"}),
+		});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses empty-but-READ stdin on 3, and writes nothing", async () => {
+		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runEnrich({...options, stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "  \n"})}),
+				shell.layer,
+			),
+		);
+		expect(outcome.code).toBe(EMPTY_STDIN);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a bare @ reference on 6", async () => {
+		const outcome = await runScripted([[READ, issue(ORIGINAL)]], {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "@notes/rewrite.md"}),
+		});
+		expect(outcome.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path in the AUTHORED rewrite on 5, while redacting the original", async () => {
+		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runEnrich({
+					...options,
+					stdin: Effect.succeed<StdinRead>({
+						_tag: "Text",
+						text: "see /Users/someone/scratch/case.md",
+					}),
+				}),
+				shell.layer,
+			),
+		);
+		expect(outcome.code).toBe(LEAKED_PATH);
+		expect(outcome.stderr.at(-1)).toContain("rewrite it repo-relative");
+		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("refuses an issue proven absent on 7", async () => {
+		const outcome = await runScripted([[READ, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.at(-1)).toBe("triage enrich: issue #4312 not found in o/r.");
+	});
+
+	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {
+		const shell = fakeShell([[READ, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const outcome = await Effect.runPromise(Effect.provide(runEnrich(options), shell.layer));
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("an original that was never read");
+		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("refuses an EMPTY body rather than preserving nothing as though it were the record", async () => {
+		const shell = fakeShell([[READ, issue("   \n")]]);
+		const outcome = await Effect.runPromise(Effect.provide(runEnrich(options), shell.layer));
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.at(-1)).toContain("there is no original to preserve");
+		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("reports a failed PATCH as UNKNOWN on 8, never as a failure to write", async () => {
+		const outcome = await runScripted([
+			[READ, issue(ORIGINAL)],
+			[PATCH, errOut("gh: timeout")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("UNKNOWN whether the body changed");
+	});
+
+	it("refuses on 9 when the read-back does not match what was written", async () => {
+		const outcome = await runScripted([
+			[once(READ), issue(ORIGINAL)],
+			[PATCH, okOut("{}")],
+			[READ, issue("something else entirely")],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("read-back does not match");
+	});
+
+	it("refuses on 9 when the read-back itself fails", async () => {
+		const outcome = await runScripted([
+			[once(READ), issue(ORIGINAL)],
+			[PATCH, okOut("{}")],
+			[READ, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toContain("could not be read back");
+	});
+
+	it("tolerates the round-trip's line-ending and trailing-whitespace normalisation", async () => {
+		const composed = `${REWRITE}\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`;
+		const outcome = await runScripted([
+			[once(READ), issue(ORIGINAL)],
+			[PATCH, okOut("{}")],
+			[READ, issue(`${composed.replace(/\n/g, "\r\n")}\r\n\r\n`)],
+		]);
+		expect(outcome.code).toBe(0);
+	});
+
+	it("refuses a non-issue number, and an unresolvable repo, before reading anything", async () => {
+		expect((await runScripted([], {issue: -1})).code).toBe(1);
+		const shell = fakeShell([]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(runEnrich({...options, env: {}}), shell.layer),
+		);
+		expect(outcome.code).toBe(1);
+		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/triage/enrich.ts
+++ b/packages/fabrika-cli/src/triage/enrich.ts
@@ -1,0 +1,135 @@
+/**
+ * The `triage enrich` envelope: how a body is composed, and how a prior enrichment is recognised.
+ *
+ * **Detection is a marker the verb writes, not a shape it infers** (founder ruling on #4866,
+ * 2026-08-08, option (b)). The two shape-based detectors that preceded it were mode-scoped and keyed
+ * on disjoint literals, so a re-run in the *other* mode matched neither, fell through to "first
+ * enrichment ⇒ wrap", and nested the whole existing envelope — provenance boundary included — inside
+ * a fresh block, compounding per run. A marker is one rule and is mode-independent, so that class
+ * dies for every marker-bearing body rather than for one axis of it.
+ *
+ * **The marker is also the boundary.** It sits on its own line immediately above the preserved
+ * `<details>` block, so "is this enriched?" and "where does the authored region end?" are the same
+ * read. Nothing has to locate a `<details>` opener or a summary literal, which is what made the old
+ * detectors mode-scoped in the first place.
+ *
+ * **The issue number is bound into the marker**, so an enriched body pasted into a *different* issue
+ * reads as fresh and is wrapped rather than partially overwritten. That covers both the
+ * quote-impersonation case the retired terminality test defended against and the
+ * paste-that-ends-the-body residual it could not — the case `contract.md` named as the limit of any
+ * content-derived test.
+ *
+ * Pre-marker bodies are recognised by `./enrich-legacy.ts`, which is one-time migration code.
+ */
+
+/** Which authored region the verb last wrote: a rewrite (default mode) or a pitch (`--epic`). */
+export type EnrichMode = "rewrite" | "wrap";
+
+/** The summary line each mode's preserved block carries. Pinned by the contract, byte for byte. */
+export const SUMMARY_LINE: Readonly<Record<EnrichMode, string>> = {
+	rewrite: "<summary>Original report (verbatim)</summary>",
+	wrap: "<summary>Original brief (verbatim)</summary>",
+};
+
+/**
+ * The marker, anchored to a whole line.
+ *
+ * Anchored, never a substring test: a body that *quotes* the marker inside a fenced block or mid-line
+ * — a bug report about this very format is an ordinary filing here — must not be read as carrying
+ * one. The number and the mode are captured because the number is the binding this ruling turns on.
+ */
+export const MARKER_RE = /^<!-- fabrika:enriched issue=(\d+) mode=(rewrite|wrap) -->$/m;
+
+export const renderMarker = (issue: number, mode: EnrichMode): string =>
+	`<!-- fabrika:enriched issue=${issue} mode=${mode} -->`;
+
+export type Detection =
+	/** No enrichment of *this* issue is present, so the whole body is the original to preserve. */
+	| {
+			readonly _tag: "Fresh";
+			readonly reason: "no marker" | "marker binds another issue" | "no v1 envelope";
+			/** The issue the foreign marker binds, when that is why this body reads as fresh. */
+			readonly boundTo: number | null;
+	  }
+	/** Enriched already: replace everything above `preserved`, and keep `preserved` byte for byte. */
+	| {
+			readonly _tag: "Enriched";
+			readonly via: "marker" | "legacy";
+			/** The mode the marker records, or `null` for a legacy body that carries no marker. */
+			readonly markedMode: EnrichMode | null;
+			readonly preserved: string;
+	  };
+
+/**
+ * Split a marker-bearing body at its **first** marker line.
+ *
+ * First, not last, and that ordering is load-bearing: the verb always emits its own marker *above*
+ * the preserved block, so a marker carried inside preserved content — a quoted envelope, a foreign
+ * paste that was wrapped — is always the later one and can never be mistaken for the boundary.
+ */
+const splitAtMarker = (
+	body: string,
+): {readonly issue: number; readonly mode: EnrichMode; readonly preserved: string} | null => {
+	const match = MARKER_RE.exec(body);
+	if (match === null || match.index === undefined) return null;
+	const after = match.index + match[0].length;
+	return {
+		issue: Number(match[1]),
+		mode: match[2] as EnrichMode,
+		// Drop the single newline that terminates the marker line; everything below is verbatim.
+		preserved: body.slice(body.startsWith("\n", after) ? after + 1 : after),
+	};
+};
+
+/**
+ * Classify a body against the issue it lives on.
+ *
+ * `legacyPreserved` is injected rather than imported so the migration branch is one argument and one
+ * module to delete when the v1 backlog is absorbed — see `./enrich-legacy.ts`.
+ */
+export const detect = (
+	body: string,
+	issue: number,
+	legacyPreserved: (body: string) => string | null,
+): Detection => {
+	const marked = splitAtMarker(body);
+	if (marked !== null) {
+		return marked.issue === issue
+			? {_tag: "Enriched", via: "marker", markedMode: marked.mode, preserved: marked.preserved}
+			: {_tag: "Fresh", reason: "marker binds another issue", boundTo: marked.issue};
+	}
+	// The legacy shapes are only consulted for a body carrying NO marker at all. A body whose marker
+	// binds another issue returned above: it is a paste, and running a shape test over a paste is
+	// exactly the impersonation the binding exists to refuse.
+	const legacy = legacyPreserved(body);
+	return legacy === null
+		? {_tag: "Fresh", reason: "no marker", boundTo: null}
+		: {_tag: "Enriched", via: "legacy", markedMode: null, preserved: legacy};
+};
+
+const EPIC_HEADER = "## Epic — awaiting plan";
+
+/** The authored region — everything above the marker — for one mode and one caller's stdin. */
+const authoredRegion = (mode: EnrichMode, text: string): string =>
+	mode === "rewrite"
+		? `${text.trim()}\n\n---\n\n`
+		: `## Pitch\n\n${text.trim()}\n\n${EPIC_HEADER}\n\n\`plan-epic\` appends its plan and dependency topology below.\n\n`;
+
+/** The preserved block a **first** enrichment builds around the redacted original. */
+export const wrapOriginal = (mode: EnrichMode, original: string): string =>
+	`<details>\n${SUMMARY_LINE[mode]}\n\n${original.trim()}\n\n</details>\n`;
+
+/**
+ * The whole new body: a fresh authored region, the marker, then `preserved` verbatim.
+ *
+ * `preserved` is the block **and every byte below it** on a re-enrich — `plan-epic` writes its plan
+ * and dependency topology under the wrap, and preserving the block alone would delete them, which is
+ * the same destruction by a shorter route.
+ */
+export const composeBody = (options: {
+	readonly mode: EnrichMode;
+	readonly issue: number;
+	readonly authored: string;
+	readonly preserved: string;
+}): string =>
+	`${authoredRegion(options.mode, options.authored)}${renderMarker(options.issue, options.mode)}\n${options.preserved}`;

--- a/packages/fabrika-cli/src/triage/enrich.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich.unit.test.ts
@@ -90,6 +90,13 @@ describe("detect — the marker is the whole rule, and it is mode-independent (#
 		expect(detection).toMatchObject({_tag: "Fresh", reason: "no marker"});
 	});
 
+	it("reads a body that MENTIONS the marker mid-line as fresh, never as enriched", () => {
+		// A bug report about this very format is an ordinary filing here. Treating its prose as a
+		// marker would overwrite the reporter's own text above the mention.
+		const talking = `The verb writes <!-- fabrika:enriched issue=4312 mode=rewrite --> above the block.\n\n${ORIGINAL}`;
+		expect(detect(talking, ISSUE, legacyPreserved)).toMatchObject({_tag: "Fresh"});
+	});
+
 	it("recognises this issue's own default-mode envelope", () => {
 		const detection = detect(enrichedDefault(), ISSUE, legacyPreserved);
 		expect(detection).toMatchObject({_tag: "Enriched", via: "marker", markedMode: "rewrite"});
@@ -207,6 +214,13 @@ describe("legacy migration — recognise once, stamp in passing, never wrap twic
 
 	it("refuses a pitch that quotes the summary line ABOVE the epic header", () => {
 		const quoting = `## Pitch\n\n${PITCH}\n\n${SUMMARY_LINE.wrap}\n\n## Epic — awaiting plan\n`;
+		expect(legacyPreserved(quoting)).toBeNull();
+	});
+
+	it("refuses an otherwise-perfect epic envelope that does not OPEN at byte 0 with ## Pitch", () => {
+		// Only the byte-0 anchor separates this from a real v1 epic envelope: the reporter's framing
+		// prose sits above it, which is what a quoting filing looks like.
+		const quoting = `Here is what our epics look like:\n\n## Pitch\n\n${PITCH}\n\n## Epic — awaiting plan\n\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n`;
 		expect(legacyPreserved(quoting)).toBeNull();
 	});
 

--- a/packages/fabrika-cli/src/triage/enrich.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich.unit.test.ts
@@ -1,0 +1,273 @@
+import {describe, expect, it} from "vitest";
+import {
+	composeBody,
+	detect,
+	MARKER_RE,
+	renderMarker,
+	SUMMARY_LINE,
+	wrapOriginal,
+} from "./enrich.ts";
+import {legacyPreserved} from "./enrich-legacy.ts";
+
+const ISSUE = 4312;
+const OTHER = 4290;
+
+const ORIGINAL = "## Summary\n\nThe editor loses focus after a save.";
+const REWRITE = "## What to build\n\nKeep focus on the editor across a save.";
+const PITCH =
+	"**Problem:** yazars lose their place\n**Arc:** fabrika campaign\n**Appetite:** 2 cycles\n**Rabbit-holes:** none\n**No-gos:** no rewrite";
+
+/** A first enrichment in default mode, exactly as the verb composes it. */
+const enrichedDefault = (issue = ISSUE): string =>
+	composeBody({
+		mode: "rewrite",
+		issue,
+		authored: REWRITE,
+		preserved: wrapOriginal("rewrite", ORIGINAL),
+	});
+
+/** A first enrichment in `--epic` mode. */
+const enrichedEpic = (issue = ISSUE): string =>
+	composeBody({mode: "wrap", issue, authored: PITCH, preserved: wrapOriginal("wrap", ORIGINAL)});
+
+/**
+ * The RETIRED `--epic` shape detector, reproduced here as the control.
+ *
+ * It is what `contract.md` specified before the #4866 ruling, and reproducing it is the only way a
+ * test can show the cross-mode failure is a property of shape inspection rather than of one buggy
+ * line — under it the cross-mode re-run below returns `false` and the verb wraps a second time.
+ */
+const retiredEpicAnchors = (body: string): boolean => {
+	const lines = body.split("\n");
+	const headerAt = lines.indexOf("## Epic — awaiting plan");
+	const briefAt = lines.indexOf(SUMMARY_LINE.wrap);
+	return lines[0] === "## Pitch" && headerAt !== -1 && briefAt > headerAt;
+};
+
+/** The RETIRED default-mode detector: the summary line's block closes at end of body. */
+const retiredTerminality = (body: string): boolean => {
+	const lines = body.split("\n").filter((line) => line.trim() !== "");
+	return lines.includes(SUMMARY_LINE.rewrite) && lines.at(-1) === "</details>";
+};
+
+const summaryLines = (body: string): ReadonlyArray<string> =>
+	body.split("\n").filter((line) => line === SUMMARY_LINE.rewrite || line === SUMMARY_LINE.wrap);
+
+const markerLines = (body: string): ReadonlyArray<string> =>
+	body.split("\n").filter((line) => MARKER_RE.test(line));
+
+describe("the composed envelope", () => {
+	it("writes the marker on its own line, directly above the preserved block", () => {
+		expect(enrichedDefault()).toBe(
+			`${REWRITE}\n\n---\n\n<!-- fabrika:enriched issue=4312 mode=rewrite -->\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`,
+		);
+	});
+
+	it("heads the pitch under the two headings pitch-guard anchors on, in --epic mode", () => {
+		expect(enrichedEpic()).toBe(
+			`## Pitch\n\n${PITCH}\n\n## Epic — awaiting plan\n\n\`plan-epic\` appends its plan and dependency topology below.\n\n<!-- fabrika:enriched issue=4312 mode=wrap -->\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n`,
+		);
+	});
+
+	it("binds the issue number and the mode into the marker", () => {
+		expect(renderMarker(4312, "rewrite")).toBe("<!-- fabrika:enriched issue=4312 mode=rewrite -->");
+		expect(renderMarker(4290, "wrap")).toBe("<!-- fabrika:enriched issue=4290 mode=wrap -->");
+	});
+
+	it("matches the marker anchored to a whole line, never as a substring", () => {
+		expect(MARKER_RE.test("<!-- fabrika:enriched issue=4312 mode=rewrite -->")).toBe(true);
+		expect(
+			MARKER_RE.test("the body carried <!-- fabrika:enriched issue=4312 mode=rewrite --> inline"),
+		).toBe(false);
+		expect(MARKER_RE.test("<!-- fabrika:enriched issue=abc mode=rewrite -->")).toBe(false);
+		expect(MARKER_RE.test("<!-- fabrika:enriched issue=4312 -->")).toBe(false);
+	});
+});
+
+describe("detect — the marker is the whole rule, and it is mode-independent (#4866)", () => {
+	it("reads a fresh, never-enriched body as Fresh", () => {
+		const detection = detect(ORIGINAL, ISSUE, legacyPreserved);
+		expect(detection).toMatchObject({_tag: "Fresh", reason: "no marker"});
+	});
+
+	it("recognises this issue's own default-mode envelope", () => {
+		const detection = detect(enrichedDefault(), ISSUE, legacyPreserved);
+		expect(detection).toMatchObject({_tag: "Enriched", via: "marker", markedMode: "rewrite"});
+	});
+
+	it("recognises a DEFAULT-mode envelope that the retired --epic shape detector could not (#4866)", () => {
+		const body = enrichedDefault();
+		// The control: shape inspection misses it, which is exactly how the verb came to wrap a second
+		// time and nest the previous provenance boundary inside a fresh block.
+		expect(retiredEpicAnchors(body)).toBe(false);
+		expect(detect(body, ISSUE, legacyPreserved)).toMatchObject({_tag: "Enriched", via: "marker"});
+	});
+
+	it("recognises an --epic envelope that the retired terminality test could not (#4866, reverse direction)", () => {
+		const planned = `${enrichedEpic()}\n## Plan (plan-epic)\n\nPhase 1: #4400\n`;
+		expect(retiredTerminality(planned)).toBe(false);
+		expect(detect(planned, ISSUE, legacyPreserved)).toMatchObject({
+			_tag: "Enriched",
+			via: "marker",
+			markedMode: "wrap",
+		});
+	});
+
+	it("preserves the block AND every byte below it, so a plan is never deleted", () => {
+		const tail = `<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n\n## Plan (plan-epic)\n\nPhase 1: #4400\n\n## Dependencies\n\n#4400 requires: none\n`;
+		const planned = composeBody({mode: "wrap", issue: ISSUE, authored: PITCH, preserved: tail});
+		const detection = detect(planned, ISSUE, legacyPreserved);
+		expect(detection).toMatchObject({_tag: "Enriched"});
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		expect(detection.preserved).toBe(tail);
+	});
+});
+
+describe("the marker binds the issue number — a paste reads as FRESH", () => {
+	it("reads another issue's enriched body, pasted here, as a first enrichment", () => {
+		const detection = detect(enrichedDefault(OTHER), ISSUE, legacyPreserved);
+		expect(detection).toMatchObject({
+			_tag: "Fresh",
+			reason: "marker binds another issue",
+			boundTo: OTHER,
+		});
+	});
+
+	it("reads a pasted --epic envelope as fresh even though its shape is a perfect match", () => {
+		const pasted = enrichedEpic(OTHER);
+		// The shape detector the ruling retired would have accepted this and overwritten the reporter's
+		// text above it. The binding is what refuses it.
+		expect(retiredEpicAnchors(pasted)).toBe(true);
+		expect(detect(pasted, ISSUE, legacyPreserved)).toMatchObject({_tag: "Fresh"});
+	});
+
+	it("never consults the legacy shapes for a foreign-marker body, however v1-shaped it is", () => {
+		// A paste that is BOTH marker-bearing (bound elsewhere) and a perfect v1 default envelope: the
+		// short-circuit is what stops the legacy door from re-admitting the impersonation.
+		const pasted = `${REWRITE}\n\n---\n\n${renderMarker(OTHER, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>`;
+		expect(legacyPreserved(pasted)).not.toBeNull();
+		expect(detect(pasted, ISSUE, legacyPreserved)).toMatchObject({
+			_tag: "Fresh",
+			boundTo: OTHER,
+		});
+	});
+
+	it("splits on the FIRST marker, so a marker buried in preserved content is never the boundary", () => {
+		const buried = wrapOriginal("rewrite", `${renderMarker(OTHER, "wrap")}\n${ORIGINAL}`);
+		const body = composeBody({mode: "rewrite", issue: ISSUE, authored: REWRITE, preserved: buried});
+		const detection = detect(body, ISSUE, legacyPreserved);
+		expect(detection).toMatchObject({_tag: "Enriched", markedMode: "rewrite"});
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		expect(detection.preserved).toBe(buried);
+	});
+});
+
+describe("legacy migration — recognise once, stamp in passing, never wrap twice", () => {
+	const legacyDefault = `${REWRITE}\n\n---\n\n<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`;
+	const legacyEpic = `## Pitch\n\n${PITCH}\n\n## Epic — awaiting plan\n\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n\n## Plan (plan-epic)\n\nPhase 1: #4400\n`;
+
+	it("recognises a v1 default envelope and hands back the block as the preserved region", () => {
+		const detection = detect(legacyDefault, ISSUE, legacyPreserved);
+		expect(detection).toMatchObject({_tag: "Enriched", via: "legacy", markedMode: null});
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		expect(detection.preserved).toBe(
+			`<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>\n`,
+		);
+	});
+
+	it("recognises a v1 --epic envelope even once plan-epic has appended below it", () => {
+		const detection = detect(legacyEpic, ISSUE, legacyPreserved);
+		expect(detection).toMatchObject({_tag: "Enriched", via: "legacy"});
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		expect(detection.preserved).toBe(
+			`<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n\n## Plan (plan-epic)\n\nPhase 1: #4400\n`,
+		);
+	});
+
+	it("converts a legacy body to a marked one in one pass, with no second envelope", () => {
+		const detection = detect(legacyDefault, ISSUE, legacyPreserved);
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		const migrated = composeBody({
+			mode: "rewrite",
+			issue: ISSUE,
+			authored: REWRITE,
+			preserved: detection.preserved,
+		});
+		expect(summaryLines(migrated)).toEqual([SUMMARY_LINE.rewrite]);
+		expect(markerLines(migrated)).toEqual([renderMarker(ISSUE, "rewrite")]);
+		// And the migration is one-way: the second pass goes through the marker, never the legacy door.
+		expect(detect(migrated, ISSUE, legacyPreserved)).toMatchObject({via: "marker"});
+	});
+
+	it("refuses a body that merely QUOTES an envelope below the reporter's own framing", () => {
+		const quoting = `I filed this because the format below looks wrong to me:\n\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n\nWhat should it be?\n`;
+		expect(legacyPreserved(quoting)).toBeNull();
+		expect(detect(quoting, ISSUE, legacyPreserved)).toMatchObject({_tag: "Fresh"});
+	});
+
+	it("refuses a pitch that quotes the summary line ABOVE the epic header", () => {
+		const quoting = `## Pitch\n\n${PITCH}\n\n${SUMMARY_LINE.wrap}\n\n## Epic — awaiting plan\n`;
+		expect(legacyPreserved(quoting)).toBeNull();
+	});
+
+	it("refuses a pitched body carrying no epic header", () => {
+		const headerless = `## Pitch\n\n${PITCH}\n\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n`;
+		expect(legacyPreserved(headerless)).toBeNull();
+	});
+
+	it("refuses a v1 default envelope whose block does not close at end of body", () => {
+		expect(legacyPreserved(`${legacyDefault}\nA trailing paragraph.\n`)).toBeNull();
+	});
+
+	it("refuses a summary line with no <details> opener above it", () => {
+		expect(legacyPreserved(`${REWRITE}\n\n${SUMMARY_LINE.rewrite}\n\n</details>\n`)).toBeNull();
+	});
+});
+
+describe("idempotency — a second pass converges, in either mode", () => {
+	it("produces the same body twice in default mode", () => {
+		const first = enrichedDefault();
+		const detection = detect(first, ISSUE, legacyPreserved);
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		const second = composeBody({
+			mode: "rewrite",
+			issue: ISSUE,
+			authored: REWRITE,
+			preserved: detection.preserved,
+		});
+		expect(second).toBe(first);
+	});
+
+	it("converges over a PLANNED epic body, and never accumulates a level", () => {
+		const planned = `${enrichedEpic()}\n## Plan (plan-epic)\n\nPhase 1: #4400\n`;
+		let body = planned;
+		for (let pass = 0; pass < 3; pass++) {
+			const detection = detect(body, ISSUE, legacyPreserved);
+			if (detection._tag !== "Enriched") throw new Error(`pass ${pass} read as fresh`);
+			body = composeBody({
+				mode: "wrap",
+				issue: ISSUE,
+				authored: PITCH,
+				preserved: detection.preserved,
+			});
+		}
+		expect(body).toBe(planned);
+		expect(summaryLines(body)).toEqual([SUMMARY_LINE.wrap]);
+		expect(markerLines(body)).toHaveLength(1);
+	});
+
+	it("converges across a MODE SWITCH — the class #4866 tracks", () => {
+		const detection = detect(enrichedDefault(), ISSUE, legacyPreserved);
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		const converted = composeBody({
+			mode: "wrap",
+			issue: ISSUE,
+			authored: PITCH,
+			preserved: detection.preserved,
+		});
+		// One envelope, and it is still the DEFAULT-mode one: the preserved original was never re-wrapped.
+		expect(summaryLines(converted)).toEqual([SUMMARY_LINE.rewrite]);
+		expect(markerLines(converted)).toEqual([renderMarker(ISSUE, "wrap")]);
+		expect(converted).toContain(`<details>\n${SUMMARY_LINE.rewrite}\n\n${ORIGINAL}\n\n</details>`);
+	});
+});


### PR DESCRIPTION
Part of #4831 — slice 5, the `triage enrich` verb. This is the last of the nine fabrika triage
verbs; the other eight are on `main` and wired. Deliberately **not** `Fixes`: #4831 closes by hand
once all nine are verified on `main`.

Implements the founder ruling on #4866 (2026-08-08), **option (b): the verb-written marker**.

## What this builds

Three source modules, one leaf, and one contract reconciliation.

| File | What it is |
|---|---|
| `packages/fabrika-cli/src/triage/enrich.ts` | the marker, the detector, and the envelope composition |
| `packages/fabrika-cli/src/triage/enrich-legacy.ts` | the two v1 envelope recognisers — one-time migration code, separable by design |
| `packages/fabrika-cli/src/triage/enrich-verb.ts` | the verb: stdin guard, redaction, PATCH, read-back |
| `packages/fabrika-cli/src/triage/command.ts` | one leaf appended, one line, nothing reordered — ten leaves now |
| `claude-plugins/fabrika/skills/triage/contract.md` | the `## triage enrich` section, reconciled to the ruling |

### The rule, as ruled

A body is already-enriched **when, and only when, it carries a marker line bound to this issue**:

```
<!-- fabrika:enriched issue=<N> mode=<rewrite|wrap> -->
```

- **Detection is marker presence, not envelope shape. One rule, mode-independent.** The two
  shape-based detectors the contract carried were mode-scoped and keyed on disjoint literals, so a
  re-run in the other mode matched neither and nested the whole existing envelope inside a fresh
  block. Presence of a marker only this verb writes settles it for either mode, so the cross-mode
  class (#4866) dies for every marker-bearing body.
- **The marker is also the boundary.** It sits on its own line immediately above the opening
  `<details>`, so "is this enriched?" and "where does the authored region end?" are one read. A
  re-enrich replaces byte 0 up to the marker and preserves the marker's line onward — the block
  **and every byte below it** — verbatim, so a planned epic's `## Plan (plan-epic)` and
  `## Dependencies` survive.
- **The issue number is bound in.** An enriched body pasted into a *different* issue reads as
  **fresh** and is wrapped rather than partially overwritten. That covers both the
  quote-impersonation case the retired terminality test defended against **and** the
  paste-that-ends-the-body residual it could not — the case the contract itself named as the limit
  of any content-derived test, with the marker as the stated answer.
- **Legacy is a self-healing migration.** A pre-marker body is recognised by the two v1 shapes, is
  **not** double-wrapped, and gets the marker **stamped in passing** — so every body that branch can
  match converts on its next enrichment and never returns to it. It lives in its own module
  (`enrich-legacy.ts`), injected into `detect` as one argument, so retiring it with v1-backlog
  absorption is a file delete plus one parameter, not an excavation. The contract says so too.
- **The wrap-last unification (option c) is not foreclosed.** Nothing here needs undoing if
  fabrika's `plan-epic` (#4712) adopts it later; the marker simply becomes redundant insurance.
- **No exit code is added or changed.** `3` / `5` / `6` / `7` / `8` / `9` / `11` only, all already
  seated in the group's shared table.

### Reuse, not re-derivation

`authored.ts` (the authored-text guard), `codes.ts` (the shared exit table), `verb.ts`
(`answer`/`refuse`), `../report/leaks.ts` (the leak predicate, through `authored.ts`) and
`../report/compose.ts`'s `normalizeForReadback`. No third copy of any shared predicate was
introduced — #4886 stays exactly as bad as it was, no worse.

`packages/pipeline-cli/` is **untouched**. Nothing calls or patches `epic-splice`.

## Tests — 54 new, and every load-bearing behaviour mutation-verified

`enrich.unit.test.ts` (26) and `enrich-verb.unit.test.ts` (28). Full package suite: 955 passing.

The cross-mode reproduction is not asserted by assertion alone: **both retired detectors are
reproduced in-test as controls**, so the test states the failure is a property of shape inspection
rather than of one buggy line — `retiredEpicAnchors(defaultEnrichedBody)` is asserted `false` (which
is what made the verb wrap a second time) on the same body `detect` is asserted to recognise.

### Mutation-verification — 14 mutants, 14 RED, restored tree GREEN

Each was applied to the shipped source, the suite run, then restored and re-run green.

| # | Mutant (behaviour reverted) | Verdict — first tests that went red |
|---|---|---|
| M1 | the marker's issue number is not compared | RED — *wraps an enriched body pasted in from another issue…*, *reads another issue's enriched body… as a first enrichment*, *says on stderr which issue the foreign marker bound* |
| M2 | split at the LAST marker instead of the first | RED — *splits on the FIRST marker…*, *converges on the SECOND pass…* |
| M3 | the marker matches as a substring, not a whole line | RED — *reads a body that MENTIONS the marker mid-line as fresh*, *matches the marker anchored to a whole line* |
| M4 | consult the v1 shapes BEFORE the marker | RED — *never consults the legacy shapes for a foreign-marker body*, *recognises this issue's own default-mode envelope*, +2 |
| M5 | preserve the `<details>` block ALONE | RED — *preserves the block AND every byte below it*, *preserves the plan and dependency topology plan-epic wrote BELOW the wrap*, +2 |
| M6 | no pre-marker envelope is ever recognised | RED — *recognises a v1 default envelope…*, *recognises a v1 --epic envelope even once plan-epic has appended below it*, +2 |
| M7 | the v1 default shape drops its terminality test | RED — *refuses a v1 default envelope whose block does not close at end of body* |
| M8 | the v1 epic shape drops its byte-0 `## Pitch` anchor | RED — *refuses an otherwise-perfect epic envelope that does not OPEN at byte 0 with ## Pitch* |
| M9 | an empty body is wrapped as though it were the record | RED — *refuses an EMPTY body rather than preserving nothing…* |
| M10 | the read-back is never compared to what was written | RED — *refuses on 9 when the read-back does not match what was written* |
| M11 | a machine-local path in the authored rewrite is not refused | RED — *refuses a machine-local path in the AUTHORED rewrite on 5…* |
| M12 | the preserved original is wrapped unredacted | RED — *redacts machine-local paths out of the PRESERVED original and counts them* |
| M13 | a failed PATCH seats on `1` instead of `8` | RED — *reports a failed PATCH as UNKNOWN on 8, never as a failure to write* |
| M14 | a re-enrich re-scans and re-reports the preserved bytes | RED — *re-reports zero redactions on a re-enrich…* |

Two mutants (M3, M8) exist because the first pass had **no** behaviour test that isolated them —
M3's only witness was a direct regex assertion (a mutant can satisfy that without the verb behaving
right), and M8's byte-0 anchor was masked by the header anchor in every existing negative. Both got a
dedicated test before the campaign was re-run.

Assertion strength: every primary path asserts the **whole composed body** with `toBe`, and the
envelope-count assertions are exact arrays (`summaryLines(...)` / `markerLines(...)` with `toEqual`),
not `toContain`. The read-back fake **echoes what the verb PATCHed** rather than a fixture, so a
read-back assertion is a statement about the verb, not about the test.

## Gates run

- `pnpm exec tsgo -p tsconfig.json` in `packages/fabrika-cli` — clean. Run **directly**, never
  through turbo (#4887).
- `pnpm run lint:worktree` — clean (never a bare biome call, #4889).
- `pnpm exec vitest run` in `packages/fabrika-cli` — 61 files, 955 tests, all passing.
- `fabrika triage --help` lists `enrich` as the tenth leaf.

## Deviations

**Fired.**

1. **The contract's `## triage enrich` detector text is changed, not just implemented.**
   - *Said:* `contract.md` specifies the anchor-based detector — three `--epic` anchors, and a
     default-mode terminality plus `Original report (verbatim)` literal test.
   - *Did:* replaced both with the marker rule, kept the reasoning that produced them (including
     #4850's position-independence result) rather than deleting it, and recorded the ruling and its
     supersession in the section and in `**Grounding**`.
   - *Why:* the founder ruling on #4866 supersedes that text. Shipping an implementation that
     contradicts the merged contract, silently, is the worse failure — and the section itself
     anticipated this exact answer: *"if it ever bites the answer is a marker the verb writes and a
     paste does not, never a weaker anchor."*
   - *Disposition:* intended, disclosed, and the dispatch briefed it explicitly.

2. **The envelope's pinned bytes gain a line.**
   - *Said:* the contract pins both envelopes "byte for byte".
   - *Did:* added the marker line immediately above the opening `<details>` in both, and updated both
     fenced blocks in the contract to match.
   - *Why:* a verb-written marker cannot exist without occupying bytes. It is an HTML comment, so it
     renders as nothing, and `epic-splice` cuts only on `## Dependencies` / `## Plan (plan-epic)`, so
     it survives every plan and re-plan.
   - *Disposition:* intended, and entailed by the ruling.

3. **The empty-body case is seated on `7`, and the contract's exit table now says so.**
   - *Said:* the contract's Scope states that neither refusal "ever degrades to an empty original
     preserved as though it were the record", but names no code for a body that *was* read and is
     empty. `7` was "the issue is proven absent (404)"; `11` is "could not be read".
   - *Did:* refused an empty-but-read body on `7`, and extended the `7` row plus the Errors table.
   - *Why:* `codes.ts` already defines `7` as *"a read that succeeded over nothing"*, which is
     precisely this. `11` would claim a read failed when it did not, and inventing a code would
     violate the section's "adds no exit code".
   - *Disposition:* intended; the smallest reading consistent with the shared table. Flagged here
     because it is an interpretation of a gap, not a restatement.

4. **`leakRefusal` runs over stdin, not over the composed body.**
   - *Said:* `authored.ts`'s docblock says callers run it over the **composed** body, so nothing a
     verb appends can escape the predicate.
   - *Did:* ran it over the authored stdin text only.
   - *Why:* this verb's composed body contains foreign content **by design** — the preserved original
     — and the contract's whole leak design is that foreign content is *redacted*, not refused.
     Running the refusal over the composed body would refuse every enrichment of a leaky report,
     which is the "stranded on somebody else's leak" failure the contract names. The preserved half
     is redacted through the same predicate, so nothing escapes it; only the *disposition* differs.
   - *Disposition:* intended, and stated at the module docblock so a reader does not read it as an
     oversight.

**Not fired — stated explicitly.**

- **No `packages/pipeline-cli/` change of any kind.** `epic-splice` is neither called nor patched;
  fabrika is a clean cut and never uses v1.
- **No second copy of a shared predicate.** The leak predicate, the exit table, the outcome
  constructors and the read-back normalisation are all imported. #4886 is not made worse.
- **No new or changed exit code.** The verb's Exit-status and Errors tables gain one *row* for an
  already-allocated code (`7`) and lose nothing.
- **No re-litigation of the ruling.** Option (b) is implemented as ruled; option (c) is left open and
  nothing built here would need undoing if it lands.
- **No change to the skill's judgment layer or its eval set**, no ship-channel or plugin toggle, and
  no touch to the other eight verbs or `report dedup`.
- **No home / local / absolute / sibling-repo path** in any committed file, commit message, or in
  this body.
- **No self-review.** No `review-*` verdict was posted and nothing was merged.
