### PR TITLE
refactor(fabrika-cli): triage kill and park read authored text through the shared authored.ts

### DIFF
--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -1459,10 +1459,10 @@ it.
 
 | Message (stderr) | Code | Kind |
 |---|---|---|
-| `triage park: no questions on stdin — a parked issue must say what would unblock it.` | 3 | refusal |
+| `triage park: no body on stdin — a parked issue must say what would unblock it: pipe the questions in.` | 3 | refusal |
 | `triage park: issue #<n> not found in <repo>.` | 7 | refusal |
-| `triage park: the questions carry a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
-| `triage park: the questions are a bare "@" path reference — they never arrived. Send them on stdin.` | 6 | refusal |
+| `triage park: the questions text carries a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
+| `triage park: the questions text is a bare "@" path reference — the body never arrived. Send it on stdin.` | 6 | refusal |
 | `triage park: label status:needs-info does not exist in <repo> — refusing to write, because the API would create it (#4285).` | 7 | refusal |
 | `triage park: cannot read <what> in <repo>: <reason> — nothing was written; the park is UNKNOWN.` | 11 | refusal |
 | `triage park: the questions comment on #<n> failed: <reason> — nothing was labelled and #<n> is unchanged. Re-run.` | 8 | refusal |
@@ -1571,12 +1571,12 @@ location, with the leak matcher literally named for comments.
 
 | Message (stderr) | Code | Kind |
 |---|---|---|
-| `triage kill: no reason on stdin — refusing an unauditable kill.` | 3 | refusal |
+| `triage kill: no body on stdin — refusing an unauditable kill: pipe the reason in.` | 3 | refusal |
 | `triage kill: issue #<n> not found in <repo>.` | 7 | refusal |
 | `triage kill: issue #<n> is already closed.` | 7 | refusal |
 | `triage kill: --duplicate-of #<m> is closed — refusing to fold this issue's content into a closed issue where nobody will read it.` | 7 | refusal |
 | `triage kill: the reason carries a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
-| `triage kill: the reason is a bare "@" path reference — it never arrived. Send it on stdin.` | 6 | refusal |
+| `triage kill: the reason is a bare "@" path reference — the body never arrived. Send it on stdin.` | 6 | refusal |
 | `triage kill: label closed-by-triage does not exist in <repo> — refusing a kill that would be invisible to the audit.` | 7 | refusal |
 | `triage kill: cannot read #<n> in <repo>: <reason> — the provenance test has no evidence; refusing to close on a body that was never read.` | 11 | refusal |
 | `triage kill: #<n> is human-filed — refusing to close it. Park it with questions instead.` | 12 | refusal |

--- a/packages/fabrika-cli/src/triage/kill-verb.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.ts
@@ -28,13 +28,11 @@ import {
 	resolveRepo,
 } from "../io/issues.ts";
 import type {StdinRead} from "../io/stdin.ts";
-import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {scanBody} from "../report/leaks.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
 import {
-	BARE_AT_PATH,
-	EMPTY_STDIN,
 	HUMAN_FILED,
-	LEAKED_PATH,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	UNCONFIRMED,
@@ -46,6 +44,12 @@ import {scannedLine} from "./scope.ts";
 
 /** The label a kill is audited by. Its absence in the repo is a zero-scope refusal, not a create. */
 export const KILL_LABEL = "closed-by-triage";
+
+const SURFACE: AuthoredSurface = {
+	verb: "triage kill",
+	noun: "the reason",
+	emptyHint: "refusing an unauditable kill: pipe the reason in.",
+};
 
 export interface KillOptions {
 	readonly issue: number;
@@ -88,37 +92,13 @@ export const runKill = (
 		}
 		const repo = repoAttempt.value;
 
-		const read = yield* options.stdin;
-		if (read._tag === "Failed") {
-			return refuse(
-				FAILED,
-				`triage kill: could not read stdin: ${read.reason} — the reason is UNKNOWN, never empty.`,
-			);
-		}
-		const reason = read._tag === "NoStdin" ? "" : read.text;
-		if (reason.trim() === "") {
-			return refuse(EMPTY_STDIN, "triage kill: no reason on stdin — refusing an unauditable kill.");
-		}
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+		const reason = authored.text;
 
-		if (isBareAtReference(reason)) {
-			return refuse(
-				BARE_AT_PATH,
-				'triage kill: the reason is a bare "@" path reference — it never arrived. Send it on stdin.',
-			);
-		}
-
-		// The reason is authored text, so a leak in it is refusable — the author can fix it. The
-		// duplicate's body below is foreign content being preserved, so it is redacted instead. That
-		// asymmetry is the whole of the leak design (`../report/leaks.ts`).
-		const reasonScan = scanBody(reason);
-		const firstLeak = reasonScan.leaks[0];
-		if (firstLeak !== undefined) {
-			return refuse(
-				LEAKED_PATH,
-				`triage kill: the reason carries a machine-local path at line ${firstLeak.line} (${firstLeak.class}) — rewrite it repo-relative.`,
-				renderLeaks(reasonScan.leaks),
-			);
-		}
+		// The reason is posted verbatim, so scanning it here is scanning the composed body.
+		const leaked = leakRefusal(SURFACE, reason);
+		if (leaked !== null) return leaked;
 
 		const target = yield* getIssue(repo, issue);
 		if (target._tag === "Absent") {
@@ -197,6 +177,8 @@ export const runKill = (
 			);
 		}
 
+		// The duplicate's body is foreign content being preserved, so it is redacted rather than
+		// refused — the asymmetry `./authored.ts` states.
 		const foldScan = scanBody(target.value.body);
 		const redactions = duplicate === null ? 0 : foldScan.leaks.length;
 		const redactionNotice =

--- a/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
@@ -288,22 +288,27 @@ describe("runKill", () => {
 
 	// --- the authored reason -------------------------------------------------------------------
 
-	it("refuses an empty-but-read stdin on 3 — an unauditable kill", async () => {
+	it("refuses an empty-but-read stdin on 3, and says how many bytes it read", async () => {
 		const {out} = await runWith(happy(), {
 			stdin: Effect.succeed({_tag: "Text", text: "   "} satisfies StdinRead),
 		});
 		expect(out.code).toBe(EMPTY_STDIN);
 		expect(out.stderr.at(-1)).toBe(
-			"triage kill: no reason on stdin — refusing an unauditable kill.",
+			"triage kill: no body on stdin — refusing an unauditable kill: pipe the reason in.",
 		);
+		// The byte count is what tells a read-but-empty pipe (3) from an unread one (1).
+		expect(out.stderr[0]).toBe("triage kill: stdin was read and held 3 byte(s).");
 	});
 
-	it("refuses a FAILED stdin read as UNKNOWN, never as an empty reason", async () => {
+	it("refuses a FAILED stdin read on 1, never on the empty code", async () => {
 		const {out} = await runWith(happy(), {
 			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"} satisfies StdinRead),
 		});
 		expect(out.code).toBe(1);
-		expect(out.stderr.at(-1)).toContain("never empty");
+		expect(out.code).not.toBe(EMPTY_STDIN);
+		expect(out.stderr.at(-1)).toBe(
+			"triage kill: could not read stdin: EAGAIN — the reason is UNKNOWN, never empty.",
+		);
 	});
 
 	it("refuses a bare @ reason on 6 — masking a placeholder never terminates", async () => {
@@ -311,17 +316,37 @@ describe("runKill", () => {
 			stdin: Effect.succeed({_tag: "Text", text: "@/tmp/reason.md"} satisfies StdinRead),
 		});
 		expect(out.code).toBe(BARE_AT_PATH);
+		expect(out.stderr.at(-1)).toBe(
+			'triage kill: the reason is a bare "@" path reference — the body never arrived. Send it on stdin.',
+		);
 	});
 
-	it("refuses a machine-local path in the authored reason on 5", async () => {
+	it("seats a reason that is BOTH a bare @ and a leak on 6 — the bare @ is tested first", async () => {
+		const {out} = await runWith(happy(), {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: "@/Users/someone/notes/why.md",
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+		expect(out.code).not.toBe(LEAKED_PATH);
+	});
+
+	it("refuses a machine-local path in the authored reason on 5, listing every hit", async () => {
 		const {out, calls} = await runWith(happy(), {
 			stdin: Effect.succeed({
 				_tag: "Text",
-				text: "see /Users/someone/notes/why.md",
+				text: "see /Users/someone/notes/why.md\nand /Users/someone/notes/how.md",
 			} satisfies StdinRead),
 		});
 		expect(out.code).toBe(LEAKED_PATH);
-		expect(out.stderr.at(-1)).toContain("at line 1 (absolute home root)");
+		expect(out.stderr.at(-1)).toBe(
+			"triage kill: the reason carries a machine-local path at line 1 (absolute home root) — rewrite it repo-relative.",
+		);
+		expect(out.stderr.slice(0, -1)).toEqual([
+			"  line 1, absolute home root",
+			"  line 2, absolute home root",
+		]);
 		expect(calls.some((c) => CLOSE.test(c))).toBe(false);
 	});
 

--- a/packages/fabrika-cli/src/triage/park-verb.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.ts
@@ -16,23 +16,21 @@ import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {createComment, getIssue, listLabels, resolveRepo} from "../io/issues.ts";
 import type {StdinRead} from "../io/stdin.ts";
-import {isBareAtReference, scanBody} from "../report/leaks.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
-import {
-	BARE_AT_PATH,
-	EMPTY_STDIN,
-	LEAKED_PATH,
-	PRECONDITION_UNKNOWN,
-	READBACK_MISMATCH,
-	WRITE_UNKNOWN,
-	ZERO_SCOPE,
-} from "./codes.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {applyChanges} from "./facet-writes.ts";
 import {parkedFacets, planReconcile, renderShape, shapeViolations} from "./facets.ts";
 import {scannedLine} from "./scope.ts";
 
 /** The one label a park writes. Its absence is a `7`, because the API would otherwise mint it. */
 const NEEDS_INFO = "status:needs-info";
+
+const SURFACE: AuthoredSurface = {
+	verb: "triage park",
+	noun: "the questions text",
+	emptyHint: "a parked issue must say what would unblock it: pipe the questions in.",
+};
 
 export interface ParkOptions {
 	readonly issue: number;
@@ -67,35 +65,13 @@ export const runPark = (
 		}
 		const repo = repoAttempt.value;
 
-		const read = yield* options.stdin;
-		if (read._tag === "Failed") {
-			return refuse(
-				FAILED,
-				`triage park: could not read stdin: ${read.reason} — the questions are UNKNOWN, never empty.`,
-			);
-		}
-		const questions = read._tag === "NoStdin" ? "" : read.text;
-		if (questions.trim() === "") {
-			return refuse(
-				EMPTY_STDIN,
-				"triage park: no questions on stdin — a parked issue must say what would unblock it.",
-			);
-		}
-		if (isBareAtReference(questions)) {
-			return refuse(
-				BARE_AT_PATH,
-				'triage park: the questions are a bare "@" path reference — they never arrived. Send them on stdin.',
-			);
-		}
-		// Authored text, so a leak is refusable rather than redactable: the caller can fix it, and
-		// the loop on a refusal is redact-and-re-send.
-		const leak = scanBody(questions).leaks[0];
-		if (leak !== undefined) {
-			return refuse(
-				LEAKED_PATH,
-				`triage park: the questions carry a machine-local path at line ${leak.line} (${leak.class}) — rewrite it repo-relative.`,
-			);
-		}
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+		const questions = authored.text;
+
+		// The questions are posted verbatim, so scanning them here is scanning the composed body.
+		const leaked = leakRefusal(SURFACE, questions);
+		if (leaked !== null) return leaked;
 
 		const target = yield* getIssue(repo, issue);
 		if (target._tag === "Absent") {

--- a/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
@@ -133,20 +133,28 @@ describe("runPark", () => {
 		expect(shell.calls.some((c) => c.includes("area%3Apipeline"))).toBe(false);
 	});
 
-	it("refuses a FAILED stdin read as UNKNOWN, never as empty questions", async () => {
+	it("refuses a FAILED stdin read on 1, never on the empty code", async () => {
 		const out = await run(happy(), {
 			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"} satisfies StdinRead),
 		});
 		expect(out.code).toBe(1);
+		expect(out.code).not.toBe(EMPTY_STDIN);
 		expect(out.stdout).toBe("");
-		expect(out.stderr.at(-1)).toContain("never empty");
+		expect(out.stderr.at(-1)).toBe(
+			"triage park: could not read stdin: EAGAIN — the questions text is UNKNOWN, never empty.",
+		);
 	});
 
-	it("refuses empty-but-READ questions on their own code", async () => {
+	it("refuses empty-but-READ questions on 3, and says how many bytes it read", async () => {
 		const out = await run(happy(), {
 			stdin: Effect.succeed({_tag: "Text", text: "   \n"} satisfies StdinRead),
 		});
 		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stderr.at(-1)).toBe(
+			"triage park: no body on stdin — a parked issue must say what would unblock it: pipe the questions in.",
+		);
+		// The byte count is what tells a read-but-empty pipe (3) from an unread one (1).
+		expect(out.stderr[0]).toBe("triage park: stdin was read and held 4 byte(s).");
 	});
 
 	it("refuses a bare @ path — the questions never arrived", async () => {
@@ -154,9 +162,23 @@ describe("runPark", () => {
 			stdin: Effect.succeed({_tag: "Text", text: "@notes/questions.md"} satisfies StdinRead),
 		});
 		expect(out.code).toBe(BARE_AT_PATH);
+		expect(out.stderr.at(-1)).toBe(
+			'triage park: the questions text is a bare "@" path reference — the body never arrived. Send it on stdin.',
+		);
 	});
 
-	it("refuses a machine-local path in the authored questions", async () => {
+	it("seats questions that are BOTH a bare @ and a leak on 6 — the bare @ is tested first", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: "@/Users/someone/scratch/case.md",
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+		expect(out.code).not.toBe(LEAKED_PATH);
+	});
+
+	it("refuses a machine-local path in the authored questions on 5", async () => {
 		const out = await run(happy(), {
 			stdin: Effect.succeed({
 				_tag: "Text",
@@ -164,7 +186,24 @@ describe("runPark", () => {
 			} satisfies StdinRead),
 		});
 		expect(out.code).toBe(LEAKED_PATH);
-		expect(out.stderr.at(-1)).toContain("rewrite it repo-relative");
+		expect(out.stderr.at(-1)).toBe(
+			"triage park: the questions text carries a machine-local path at line 1 (absolute home root) — rewrite it repo-relative.",
+		);
+	});
+
+	it("lists EVERY leak, not just the one the message names — one refusal, one round", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: "/Users/someone/a.md\nthen /Users/someone/b.md\nand /Users/someone/c.md",
+			} satisfies StdinRead),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stderr.slice(0, -1)).toEqual([
+			"  line 1, absolute home root",
+			"  line 2, absolute home root",
+			"  line 3, absolute home root",
+		]);
 	});
 
 	it("writes nothing at all on any stdin refusal", async () => {


### PR DESCRIPTION
`triage kill` and `triage park` each carried their own hand-written copy of the same stdin guard — refuse an unread pipe, refuse a read-but-empty one, refuse a body that is really a path, refuse a body carrying a machine-local path. `triage split` already got all four decisions from one shared module. This PR points the other two at that module too, so there is one implementation of the refusal sequence instead of three.

Nothing about which refusal fires, or in what order, changes. What does change is that both verbs now emit the diagnostics the shared module always emitted: `kill` and `park` gain the byte count that tells a read-but-empty pipe apart from an unread one, `park` gains the full listing of every leaked path instead of only the one its message names, and the wording of several refusal messages converges on the shared templates. The `triage` contract doc is updated to match.

Fixes #4886

## What changed

- `packages/fabrika-cli/src/triage/kill-verb.ts` — `runKill` takes its reason through `readAuthored` and its leak refusal through `leakRefusal`, behind a `triage kill` `AuthoredSurface`. The inline block is gone; `scanBody` stays only for the duplicate-fold redaction, which is the *other* half of the refuse-vs-redact asymmetry.
- `packages/fabrika-cli/src/triage/park-verb.ts` — the same, behind a `triage park` `AuthoredSurface`. Its `LEAKED_PATH` refusal no longer drops the `renderLeaks` listing.
- `packages/fabrika-cli/src/triage/kill-verb.unit.test.ts`, `packages/fabrika-cli/src/triage/park-verb.unit.test.ts` — every refusal path re-asserted at its exact code, with the gained diagnostics, plus a new both-a-bare-`@`-and-a-leak case per verb that pins the ordering and a multi-leak `park` case that pins the full listing.
- `claude-plugins/fabrika/skills/triage/contract.md` — the documented refusal rows whose text the convergence changed.

## Acceptance criteria

- [x] `runKill` obtains its reason through `readAuthored` and its leak refusal through `leakRefusal`; no refusal constructed inline in that file.
- [x] `triage park` does the same, and no longer drops the `renderLeaks` listing on `5`.
- [x] `packages/fabrika-cli/src/triage/authored.ts` is the only production source under `packages/fabrika-cli/src/triage/` that seats `EMPTY_STDIN` / `BARE_AT_PATH` / `LEAKED_PATH` (with `codes.ts`, which defines them). See the Deviations entry on the test files.
- [x] Exit codes and refusal ordering unchanged for both verbs — proven by the code assertions still passing, and by the mutation-verification below.
- [x] Both unit test files updated for the two gained diagnostics; `park` asserts a multi-leak body lists every hit.
- [x] The leak predicates are still imported from `packages/fabrika-cli/src/report/leaks.ts`, never re-derived — `authored.ts` is their only importer under `src/triage/` now.
- [x] Typecheck and lint pass.

## Verification

`pnpm exec tsgo -p tsconfig.json` clean in `packages/fabrika-cli` (run directly, not through turbo — #4887). `pnpm run lint:worktree` clean. Full package suite: 59 files, 903 tests, all passing.

**Mutation-verified.** Each load-bearing behaviour was reverted, the suite re-run, and the resulting RED tests recorded; every mutant was killed and the tree restored green (69 tests across the three affected files at baseline and after restore).

| # | Mutant | Result |
|---|---|---|
| M1 | failed read seats on `3` instead of `1` | RED — 3 tests, incl. both verbs' "on 1, never on the empty code" |
| M2 | empty-read refusal removed | RED — 7 tests |
| M3 | byte-count diagnostic dropped | RED — 3 tests (the two gained assertions + the shared module's) |
| M4 | bare-`@` refusal removed | RED — 6 tests, incl. both ordering cases |
| M5 | leak refusal always returns null | RED — 6 tests |
| M6 | leak listing truncated to the first hit | RED — 3 tests, incl. `park`'s new multi-leak case |
| M7 | `kill` drops its `leakRefusal` call | RED — 1 test |
| M8 | `park` drops its `leakRefusal` call | RED — 2 tests |

M3 and M6 are the two gained diagnostics; both are asserted by exact equality on the specific stderr line, not by `toContain`, so a mutant cannot satisfy them by emitting something else. M1 and M4 are the ordering invariants — M4 in particular is killed by the new both-a-bare-`@`-and-a-leak cases, which would otherwise pass on `5`.

## Third copies — reported, not fixed

Nothing else under `packages/fabrika-cli/src/triage/` inlines the sequence: `kill`, `park` and `split` are the only `options.stdin` consumers there, and all three now go through `authored.ts`. `triage enrich` does not exist on `main` yet, so it carries no copy.

Two copies remain in the **`report`** group — `packages/fabrika-cli/src/report/file-verb.ts` and `packages/fabrika-cli/src/report/note-verb.ts`. Both are named as an explicit non-goal on #4886 (different verb group, own `codes.ts`, predate `authored.ts`), so they are left alone here.

## Deviations

- **Scope narrowing (class 1) — the greppability criterion holds for production sources, not test files.** **Said:** the third acceptance criterion asks that "no file under that directory other than `authored.ts` and `codes.ts` references those three constants." **Did:** the three constants are still imported by `kill-verb.unit.test.ts`, `park-verb.unit.test.ts`, `split-verb.unit.test.ts`, `authored.unit.test.ts` and `codes.unit.test.ts`. **Why:** those are exit-code assertions — a test that pins a refusal to `EMPTY_STDIN` by name is stronger than one pinning it to the literal `3`, and `split-verb.unit.test.ts` already did this before this PR, so the criterion as literally written was unmeetable without weakening the tests. The criterion's intent — one *seat* for the refusal — is met: `authored.ts` is the only production file under `src/triage/` that constructs one. **Disposition:** for the reviewer to judge; no test was weakened to satisfy the letter of the criterion.

- **Governing-spec departure (class 2) — several refusal messages changed text, against the issue's "do not change message text" non-goal.** **Said:** the Non-goals say "Do not change any exit code, message text, or refusal ordering," and the issue body claims "Exit codes, ordering and message text are unchanged." **Did:** exit codes and ordering are unchanged, but the message text is not — the shared templates render differently from the two hand-written copies. Exactly:

  | Verb | Code | Before | After |
  |---|---|---|---|
  | `kill` | 3 | `no reason on stdin — refusing an unauditable kill.` | `no body on stdin — refusing an unauditable kill: pipe the reason in.` |
  | `kill` | 6 | `the reason is a bare "@" path reference — it never arrived. …` | `the reason is a bare "@" path reference — the body never arrived. …` |
  | `park` | 1 | `the questions are UNKNOWN, never empty.` | `the questions text is UNKNOWN, never empty.` |
  | `park` | 3 | `no questions on stdin — a parked issue must say what would unblock it.` | `no body on stdin — a parked issue must say what would unblock it: pipe the questions in.` |
  | `park` | 5 | `the questions carry a machine-local path …` | `the questions text carries a machine-local path …` |
  | `park` | 6 | `the questions are a bare "@" path reference — they never arrived. Send them on stdin.` | `the questions text is a bare "@" path reference — the body never arrived. Send it on stdin.` |

  `kill`'s `1` and `5` messages are byte-identical before and after, with `noun: "the reason"`.

  **Why:** the non-goal and the collapse are not jointly satisfiable. `AuthoredSurface` parameterises the *nouns* (`verb`, `noun`, `emptyHint`) and nothing else, by design — its docblock says the decisions live in the module. `kill`'s "no **reason** on stdin" and `park`'s plural agreement (`are` / `carry` / `they` / `them`) are not reachable from those three fields; preserving them byte-for-byte would mean adding message-template fields, or a singular/plural conjugation switch used in four places, which rebuilds the per-verb divergence the module exists to remove. `park`'s noun is `the questions text` rather than `the questions` precisely so the shared singular templates stay grammatical. I checked the contract before deciding rather than assuming the shared version wins: `claude-plugins/fabrika/skills/triage/contract.md` specifies these strings per verb, so this is a departure from a written spec and not only from the code — which is why the documented rows are updated in this PR rather than left to drift. **Disposition:** for the reviewer to judge. If byte-exact message preservation outranks the collapse, the honest fix is to keep the two copies and close #4886 as not-doable, not to grow `AuthoredSurface` into a message bag.

- **Pre-existing tests changed (class 6).** **Said:** the fourth acceptance criterion expects the existing unit tests to still pass "on the code assertions, with only the diagnostic expectations updated." **Did:** six existing assertions were rewritten, not only the diagnostic ones — `kill`'s empty-refusal exact string, `kill`'s failed-read and bare-`@` messages, `park`'s failed-read, bare-`@` and leak messages. **Why:** they asserted the exact text of the messages the entry above changed. Where the old assertion was a loose `toContain("never empty")` or `toContain("rewrite it repo-relative")` I replaced it with an exact `toBe` on the full line, so the assertion is anchored rather than satisfiable by any message mentioning the phrase. No assertion was weakened or deleted; every code assertion is unchanged. **Disposition:** no action needed — the change is the disclosed consequence of the entry above.

- **Out-of-scope change (class 7) — `claude-plugins/fabrika/skills/triage/contract.md`.** **Said:** #4886 scopes the work to `packages/fabrika-cli/src/triage/` and lists no doc surface. **Did:** four refusal rows in the `triage` contract doc are updated. **Why:** that doc is the written spec for these messages; leaving it would land a diff whose behaviour contradicts a committed contract in the same repo. It is not a control-plane path (`CONTROL_PLANE_RE` covers `claude-plugins/kampus-pipeline/skills/`, not `claude-plugins/fabrika/`), so it does not change how this PR merges. **Disposition:** no action needed. Note the byte-count and leak-listing diagnostics gained here are *not* added to the contract — it documents no diagnostics for any verb, including `split`, and inventing a new documentation convention is not this chore's call.

- **Known defect left unfixed (class 3) — two more inline copies in the `report` group, and the duplicated exit-code tables.** **Said:** the Non-goals name both: `report/file-verb.ts` and `report/note-verb.ts` inline the same sequence, and `triage/codes.ts` and `report/codes.ts` independently define the same three values, with "file it, don't fold it in here." **Did:** neither is touched, and I did not open a separate issue for the codes-table duplication. **Why:** the collapse is a cross-group call that `authored.ts`'s own docblock scopes itself out of, and the codes-table observation is already recorded in #4886's triage note. **Disposition:** for the reviewer to judge whether the codes-table observation needs its own issue before #4886 closes and buries the note.

- **Not fired:** class 4 (declined guidance) — no reviewer or triage instruction was declined. Class 5 (guard or gate bypassed) — no `--no-verify`, no skipped or disabled hook, no suppressed lint or type error, no skipped or `.only` test, no widened allowlist; the one pre-commit biome failure was fixed by formatting, not bypassed.
