### PR TITLE
feat(fabrika-cli): the wire verb group + the acceptance-criteria schema module (#4942)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1,11 +1,12 @@
 # @kampus/fabrika-cli
 
 The deterministic verb package [fabrika](../../claude-plugins/fabrika/) skills call.
-`fabrika <group> <verb> …` dispatches to a registered verb group. Four groups are
+`fabrika <group> <verb> …` dispatches to a registered verb group. Five groups are
 registered: `adr`, the six verbs the `/adr` skill's derived contract specifies; `report`,
 the three the `/report` contract specifies; `triage`, the intake-queue group the `/triage`
-contract specifies; and `eval`, the graded-corpus harness the fabrika eval layer measures
-itself with.
+contract specifies; `eval`, the graded-corpus harness the fabrika eval layer measures
+itself with; and `wire`, which owns the byte-level formats two skills meet through on a
+GitHub artifact.
 
 ## Who it's for
 
@@ -222,6 +223,45 @@ Three properties of that substrate are worth knowing before the verbs arrive:
   ([`src/triage/scope.ts`](./src/triage/scope.ts)). A verdict driven by a silently truncated
   read is a verdict over unknown scope; pagination fixes the reach, and printing what was
   scanned is what makes the reach checkable from outside the process.
+
+## The `wire` group
+
+A **wire format** is the byte-level agreement two skills meet through on a GitHub artifact —
+the acceptance-criteria block on a sub-issue body, the verdict marker on a PR. Each one is
+owned by a typed schema module under [`src/wire/`](./src/wire/) with an `emit` and a
+`read`, registered as one row in [`src/wire/registry.ts`](./src/wire/registry.ts). The
+formats used to live as prose in a skill body, which is why fabrika could not pin one: the
+`### Acceptance criteria` heading was named in no code at all.
+
+| Verb | Answers |
+|---|---|
+| `wire formats` | the registered formats, derived from the registry — key, purpose, producers, consumers |
+| `wire codes` | the exit taxonomy every verb in the group allocates from |
+| `wire emit` | the format's bytes, composed from the fields on stdin |
+| `wire read` | the format's fields, read out of the artifact on stdin |
+| `wire check` | whether the artifact on stdin carries a conforming block, without the fields |
+
+Three properties are worth knowing before you call them:
+
+- **`read` is total, and `found` is its only answer.** The return type is
+  `Found | Absent | Malformed` and nothing else, with `Found` carrying a non-empty list by
+  construction. A heading that drifted — a different spelling, a different level, a section
+  with no checkbox items — is `Malformed`, never a `Found` holding nothing. That is the whole
+  point: the prose-owned era's failure was not a crash, it was a *plausible* empty answer, and
+  a grader reading it passed over nothing without an error.
+- **Absent, malformed and never-seen are three different exit codes.** `3` is a proven
+  negative over an artifact that was read in full; `4` is a proven defect; `6` means fd 0
+  carried nothing readable, so nothing is proven at all. Fusing any pair is what lets an
+  unread artifact pass for a clean one.
+- **The artifact arrives on stdin only.** No `--body`, no `--body-file` — the same reason the
+  `report` and `triage` writing verbs take theirs there: a flag that accepts a path turns the
+  artifact into a string the verb could echo back onto a public surface.
+
+```bash
+printf 'the read is total\n[x] the registry is the seam\n' \
+  | node src/bin.ts wire emit --format acceptance-criteria \
+  | node src/bin.ts wire check --format acceptance-criteria
+```
 
 ## The `eval` group
 

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {adrCommand} from "./adr/command.ts";
 import {evalCommand} from "./eval/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {triageCommand} from "./triage/command.ts";
+import {wireCommand} from "./wire/command.ts";
 
 /** A registered verb group: a top-level `Command` whose name is the `fabrika <name>` selector. */
 export type VerbGroup = Command.Command<any, any, object, unknown, NodeServices.NodeServices>;
@@ -29,4 +30,5 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	evalCommand,
 	reportCommand,
 	triageCommand,
+	wireCommand,
 ];

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.ts
@@ -1,0 +1,278 @@
+/**
+ * The acceptance-criteria block — the founding wire format.
+ *
+ * An issue body carries the contract a gate grades a PR against as a `### Acceptance criteria`
+ * heading over a list of checkbox items. Every grader in the pipeline reads it, and until this
+ * module nothing in fabrika pinned it: the shape lived in prose, so a heading that drifted by one
+ * character read back as an empty list and a grader passed over nothing.
+ *
+ * `read` is total and its three answers are the whole design (see `./format.ts`). The
+ * discrimination that carries the weight is **Absent vs Malformed**: a body with no acceptance
+ * criteria at all is a fact worth reporting, while a body whose heading drifted is a *defect* — and
+ * the defect must never be reported as the fact. So a heading that is recognisably *reaching for*
+ * this block, and misses, is `Malformed`; only a body where nothing reaches for it at all is
+ * `Absent`. Neither is an answer on stdout: the adapter seats them on distinct non-zero codes
+ * (`./codes.ts`).
+ *
+ * v1's `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §2 is where the semantics
+ * come from — read as prior art, never called (ADR 0238). Its reviewer-append provenance tag
+ * (`<!-- ac:review-code … -->`) is deliberately not carried here.
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+
+/** One criterion and whether it is checked off. The field type of this format. */
+export interface AcceptanceCriterion {
+	readonly text: string;
+	readonly checked: boolean;
+}
+
+export type AcceptanceCriteriaRead = WireRead<NonEmptyReadonlyArray<AcceptanceCriterion>>;
+
+/** The one conforming heading. Level and spelling are both part of it. */
+export const HEADING_LEVEL = 3;
+export const HEADING_TEXT = "Acceptance criteria";
+
+/** The heading text with case and punctuation removed — what a near-miss is measured against. */
+const HEADING_KEY = "acceptancecriteria";
+
+/**
+ * How far a normalised heading may sit from {@link HEADING_KEY} and still count as reaching for
+ * this block. Three edits covers the drifts seen in the wild — a dropped letter, a transposition, a
+ * singular/plural swap — without swallowing an unrelated heading, which would misreport `Absent` as
+ * `Malformed`. Both are refusals, so the cost of being wrong here is a worse message, never a
+ * plausible answer.
+ */
+const NEAR_MISS_EDITS = 3;
+
+const ATX_HEADING = /^ {0,3}(#{1,6})[ \t]+(.*?)[ \t]*#*[ \t]*$/;
+const FENCE = /^ {0,3}(```|~~~)/;
+const CHECKBOX_ITEM = /^[ \t]*[-*][ \t]+\[([ xX])\][ \t]*(.*)$/;
+
+interface Heading {
+	readonly level: number;
+	readonly text: string;
+	/** 1-based, so a refusal can point at a line a human can find. */
+	readonly line: number;
+}
+
+const normalize = (text: string): string => text.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/** Levenshtein distance, capped: anything past `limit` is reported as `limit + 1`. */
+const editDistance = (a: string, b: string, limit: number): number => {
+	if (Math.abs(a.length - b.length) > limit) return limit + 1;
+	let previous = Array.from({length: b.length + 1}, (_, i) => i);
+	for (let i = 1; i <= a.length; i++) {
+		const current = [i, ...Array.from<number>({length: b.length}).fill(0)];
+		for (let j = 1; j <= b.length; j++) {
+			const substitution = (previous[j - 1] ?? 0) + (a[i - 1] === b[j - 1] ? 0 : 1);
+			const deletion = (previous[j] ?? 0) + 1;
+			const insertion = (current[j - 1] ?? 0) + 1;
+			current[j] = Math.min(substitution, deletion, insertion);
+		}
+		previous = current;
+	}
+	return previous[b.length] ?? limit + 1;
+};
+
+/**
+ * Does this heading reach for the acceptance-criteria block?
+ *
+ * Deliberately wider than the conforming form: every heading this admits and then rejects becomes a
+ * `Malformed` naming the drift, and every one it turns away becomes an `Absent`. Erring wide is
+ * what keeps a drifted heading from being reported as "there were none".
+ */
+const reachesForBlock = (headingText: string): boolean => {
+	const key = normalize(headingText);
+	return (
+		key.includes("acceptance") ||
+		key.includes("criteri") ||
+		editDistance(key, HEADING_KEY, NEAR_MISS_EDITS) <= NEAR_MISS_EDITS
+	);
+};
+
+/** Every ATX heading outside a fenced code block — a fenced example must not pass for the real one. */
+const scanHeadings = (lines: ReadonlyArray<string>): ReadonlyArray<Heading> => {
+	const headings: Heading[] = [];
+	let openFence: string | null = null;
+	for (const [index, line] of lines.entries()) {
+		const fence = FENCE.exec(line);
+		if (fence !== null) {
+			const marker = fence[1] ?? "";
+			if (openFence === null) openFence = marker;
+			else if (openFence === marker) openFence = null;
+			continue;
+		}
+		if (openFence !== null) continue;
+		const heading = ATX_HEADING.exec(line);
+		if (heading === null) continue;
+		headings.push({
+			level: (heading[1] ?? "").length,
+			text: heading[2] ?? "",
+			line: index + 1,
+		});
+	}
+	return headings;
+};
+
+const conforms = (heading: Heading): boolean =>
+	heading.level === HEADING_LEVEL && heading.text === HEADING_TEXT;
+
+const quote = (heading: Heading): string =>
+	`line ${heading.line}: "${"#".repeat(heading.level)} ${heading.text}"`;
+
+const driftReason = (heading: Heading): string => {
+	const levelWrong = heading.level !== HEADING_LEVEL;
+	const textWrong = heading.text !== HEADING_TEXT;
+	const parts = [
+		levelWrong ? `heading level ${heading.level}, expected ${HEADING_LEVEL}` : null,
+		textWrong ? `heading text "${heading.text}", expected "${HEADING_TEXT}"` : null,
+	].filter((part): part is string => part !== null);
+	return `the acceptance-criteria heading has drifted — ${parts.join("; ")}`;
+};
+
+/** The lines under `heading`, up to the next heading outside a fence, or the end of the body. */
+const sectionOf = (lines: ReadonlyArray<string>, heading: Heading): ReadonlyArray<string> => {
+	const body: string[] = [];
+	let openFence: string | null = null;
+	for (const line of lines.slice(heading.line)) {
+		const fence = FENCE.exec(line);
+		if (fence !== null) {
+			const marker = fence[1] ?? "";
+			if (openFence === null) openFence = marker;
+			else if (openFence === marker) openFence = null;
+			body.push(line);
+			continue;
+		}
+		if (openFence === null && ATX_HEADING.test(line)) break;
+		body.push(line);
+	}
+	return body;
+};
+
+const malformed = (reason: string, evidence: string): AcceptanceCriteriaRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+/**
+ * Read the acceptance-criteria block out of an issue body. Total: `Found` | `Absent` | `Malformed`.
+ *
+ * `Found` is unreachable with zero criteria — the only `return` that produces it is guarded by the
+ * emptiness check below and the type would reject it regardless.
+ */
+export const read = (body: string): AcceptanceCriteriaRead => {
+	const lines = body.split("\n");
+	const candidates = scanHeadings(lines).filter((heading) => reachesForBlock(heading.text));
+	if (candidates.length === 0) {
+		return {
+			_tag: "Absent",
+			reason: `no heading in the body reaches for "${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}"`,
+		};
+	}
+
+	const conforming = candidates.filter(conforms);
+	const first = candidates[0];
+	if (conforming.length === 0 && first !== undefined) {
+		return malformed(driftReason(first), quote(first));
+	}
+	if (conforming.length > 1) {
+		return malformed(
+			`the body carries ${conforming.length} acceptance-criteria headings — which one is the contract is undecidable`,
+			conforming.map(quote).join(" | "),
+		);
+	}
+
+	const heading = conforming[0];
+	if (heading === undefined) {
+		return malformed("the acceptance-criteria heading could not be resolved", "");
+	}
+
+	const criteria: AcceptanceCriterion[] = [];
+	for (const [offset, line] of sectionOf(lines, heading).entries()) {
+		const item = CHECKBOX_ITEM.exec(line);
+		if (item === null) continue;
+		const text = (item[2] ?? "").trim();
+		if (text === "") {
+			return malformed(
+				"a checkbox item under the acceptance-criteria heading carries no text",
+				`line ${heading.line + offset + 1}: "${line}"`,
+			);
+		}
+		criteria.push({text, checked: (item[1] ?? " ").toLowerCase() === "x"});
+	}
+
+	const [head, ...rest] = criteria;
+	if (head === undefined) {
+		return malformed(
+			`"${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}" is present and its section holds no "- [ ]" checkbox item — every sub-issue carries at least one`,
+			`line ${heading.line}`,
+		);
+	}
+	return {_tag: "Found", value: [head, ...rest]};
+};
+
+/** Compose criteria into the block's bytes. Round-trips through {@link read}. */
+export const emit = (criteria: NonEmptyReadonlyArray<AcceptanceCriterion>): string => {
+	const items = criteria.map(({checked, text}) => `- [${checked ? "x" : " "}] ${text}`);
+	return `${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}\n\n${items.join("\n")}\n`;
+};
+
+export type AcceptanceFields =
+	| {readonly _tag: "Fields"; readonly criteria: NonEmptyReadonlyArray<AcceptanceCriterion>}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+const FIELD_LINE = /^(?:[-*][ \t]+)?(?:\[([ xX])\][ \t]*)?(.*)$/;
+
+/**
+ * Parse `emit`'s stdin into criteria: one per non-blank line, `[x]` / `[ ]` setting the state.
+ *
+ * A line that carries a state marker and no text is a refusal rather than a dropped line — silently
+ * skipping it is how a caller composes a block with fewer criteria than it wrote.
+ */
+export const parseFields = (fields: string): AcceptanceFields => {
+	const criteria: AcceptanceCriterion[] = [];
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const match = FIELD_LINE.exec(line);
+		const text = (match?.[2] ?? "").trim();
+		if (text === "") {
+			return {
+				_tag: "Unusable",
+				reason: `line ${index + 1} carries a checkbox marker and no criterion text: "${line}"`,
+			};
+		}
+		criteria.push({text, checked: (match?.[1] ?? " ").toLowerCase() === "x"});
+	}
+	const [head, ...rest] = criteria;
+	if (head === undefined) {
+		return {_tag: "Unusable", reason: "no criterion lines — a block with no criteria is malformed"};
+	}
+	return {_tag: "Fields", criteria: [head, ...rest]};
+};
+
+/** One `<state>\t<text>` line per criterion — the `wire read` answer for this format. */
+export const renderCriteria = (
+	criteria: NonEmptyReadonlyArray<AcceptanceCriterion>,
+): NonEmptyReadonlyArray<string> => {
+	const [head, ...rest] = criteria;
+	const line = ({checked, text}: AcceptanceCriterion): string =>
+		`${checked ? "checked" : "open"}\t${text}`;
+	return [line(head), ...rest.map(line)];
+};
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.criteria)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderCriteria(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The schema module's own tier: `emit`, and the three answers `read` may give.
+ *
+ * The assertions that carry the design are the drift cases. Each of them feeds a body a naive
+ * reader would answer "no acceptance criteria" for, and asserts `Malformed` — because the failure
+ * this module exists to remove is not a crash, it is a *plausible* answer. `expect(...).toBe(
+ * "Malformed")` is the whole point; a test that only asserted "criteria is empty" would pass
+ * against the defect.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	type AcceptanceCriterion,
+	emit,
+	HEADING_TEXT,
+	parseFields,
+	read,
+	renderCriteria,
+} from "./acceptance-criteria.ts";
+
+const body = (...lines: ReadonlyArray<string>): string => lines.join("\n");
+
+const found = (source: string): ReadonlyArray<AcceptanceCriterion> => {
+	const result = read(source);
+	if (result._tag !== "Found") throw new Error(`expected Found, got ${result._tag}`);
+	return result.value;
+};
+
+const CONFORMING = body(
+	"**Stories:** 1, 2",
+	"",
+	"### What to build",
+	"Stand up the group.",
+	"",
+	"### Acceptance criteria",
+	"- [ ] the read is total",
+	"- [x] the registry is the only place a format is registered",
+	"",
+	"### Notes",
+	"Nothing else.",
+);
+
+describe("emit", () => {
+	it("composes the heading and one checkbox line per criterion", () => {
+		expect(
+			emit([
+				{text: "the read is total", checked: false},
+				{text: "the registry is the seam", checked: true},
+			]),
+		).toBe("### Acceptance criteria\n\n- [ ] the read is total\n- [x] the registry is the seam\n");
+	});
+
+	it("round-trips: what it composes is what `read` finds", () => {
+		const criteria: AcceptanceCriterion[] = [
+			{text: "first", checked: true},
+			{text: "second", checked: false},
+			{text: "third with `backticks` and a #4942 ref", checked: false},
+		];
+		expect(found(emit([criteria[0]!, ...criteria.slice(1)]))).toEqual(criteria);
+	});
+});
+
+describe("read — Found", () => {
+	it("finds every criterion with its checked state, from a full sub-issue body", () => {
+		expect(found(CONFORMING)).toEqual([
+			{text: "the read is total", checked: false},
+			{text: "the registry is the only place a format is registered", checked: true},
+		]);
+	});
+
+	it("stops at the next heading rather than swallowing a later list", () => {
+		expect(
+			found(
+				body("### Acceptance criteria", "- [ ] mine", "", "### Out of scope", "- [ ] not mine"),
+			),
+		).toEqual([{text: "mine", checked: false}]);
+	});
+
+	it("reads an uppercase [X] as checked — a tolerant read of a real drift that changes no meaning", () => {
+		expect(found(body("### Acceptance criteria", "- [X] done"))).toEqual([
+			{text: "done", checked: true},
+		]);
+	});
+});
+
+describe("read — Absent", () => {
+	it("answers Absent for a body where nothing reaches for the block", () => {
+		const result = read(body("### What to build", "Stand up the group.", "", "Some prose."));
+		expect(result._tag).toBe("Absent");
+	});
+
+	it("answers Absent for a body that is only prose", () => {
+		expect(read("Just a paragraph, no headings at all.")._tag).toBe("Absent");
+	});
+});
+
+describe("read — Malformed: the drifts a naive reader answers `empty` for", () => {
+	it("a drifted heading SPELLING is Malformed, never Found-with-nothing", () => {
+		const result = read(body("### Acceptance Criteria:", "- [ ] one", "- [ ] two"));
+		expect(result._tag).toBe("Malformed");
+		if (result._tag !== "Malformed") return;
+		expect(result.reason).toContain(HEADING_TEXT);
+		expect(result.evidence).toContain("Acceptance Criteria:");
+	});
+
+	it("a typo inside the word is Malformed", () => {
+		expect(read(body("### Acceptance critera", "- [ ] one"))._tag).toBe("Malformed");
+	});
+
+	it("a heading at the WRONG LEVEL is Malformed, and the reason names the level", () => {
+		const result = read(body("## Acceptance criteria", "- [ ] one"));
+		expect(result._tag).toBe("Malformed");
+		if (result._tag !== "Malformed") return;
+		expect(result.reason).toContain("heading level 2");
+	});
+
+	it("a level-4 heading is Malformed too — drift is drift in both directions", () => {
+		expect(read(body("#### Acceptance criteria", "- [ ] one"))._tag).toBe("Malformed");
+	});
+
+	it("the conforming heading with NO checkbox item is Malformed, not an empty Found", () => {
+		const result = read(
+			body("### Acceptance criteria", "", "It should basically work.", "", "### Notes"),
+		);
+		expect(result._tag).toBe("Malformed");
+		if (result._tag !== "Malformed") return;
+		expect(result.reason).toContain("no");
+	});
+
+	it("a checkbox item with no text is Malformed rather than a silently dropped criterion", () => {
+		const result = read(body("### Acceptance criteria", "- [ ] first", "- [ ]"));
+		expect(result._tag).toBe("Malformed");
+	});
+
+	it("two conforming headings are Malformed — which one is the contract is undecidable", () => {
+		const result = read(
+			body("### Acceptance criteria", "- [ ] one", "", "### Acceptance criteria", "- [ ] two"),
+		);
+		expect(result._tag).toBe("Malformed");
+		if (result._tag !== "Malformed") return;
+		expect(result.reason).toContain("2");
+	});
+
+	it("no drift answer is ever Found, so no caller can read a drift as a zero-criteria contract", () => {
+		const drifts = [
+			body("### Acceptance Criteria", "- [ ] one"),
+			body("## Acceptance criteria", "- [ ] one"),
+			body("#### Acceptance criteria", "- [ ] one"),
+			body("### Acceptance criterion", "- [ ] one"),
+			body("### Acceptance criteria", "just prose"),
+		];
+		for (const drift of drifts) expect(read(drift)._tag).toBe("Malformed");
+	});
+});
+
+describe("read — a fenced example is not the real block", () => {
+	it("ignores a heading inside a code fence", () => {
+		const result = read(
+			body(
+				"Here is the shape:",
+				"",
+				"```markdown",
+				"### Acceptance criteria",
+				"- [ ] an example, not the contract",
+				"```",
+				"",
+				"That is all.",
+			),
+		);
+		expect(result._tag).toBe("Absent");
+	});
+
+	it("reads the real block when a fenced example sits above it", () => {
+		expect(
+			found(
+				body(
+					"```markdown",
+					"### Acceptance criteria",
+					"- [ ] the example",
+					"```",
+					"",
+					"### Acceptance criteria",
+					"- [ ] the contract",
+				),
+			),
+		).toEqual([{text: "the contract", checked: false}]);
+	});
+});
+
+describe("parseFields", () => {
+	it("takes one criterion per line, with the state marker optional", () => {
+		expect(parseFields("first\n[x] second\n- [ ] third\n")).toEqual({
+			_tag: "Fields",
+			criteria: [
+				{text: "first", checked: false},
+				{text: "second", checked: true},
+				{text: "third", checked: false},
+			],
+		});
+	});
+
+	it("refuses fields that hold no criterion — `emit` cannot compose an empty block", () => {
+		expect(parseFields("\n   \n\n")._tag).toBe("Unusable");
+	});
+
+	it("refuses a state marker with no text rather than dropping the line", () => {
+		const parsed = parseFields("first\n[x]\n");
+		expect(parsed._tag).toBe("Unusable");
+		if (parsed._tag !== "Unusable") return;
+		expect(parsed.reason).toContain("line 2");
+	});
+});
+
+describe("renderCriteria", () => {
+	it("renders one `<state>\\t<text>` line per criterion", () => {
+		expect(
+			renderCriteria([
+				{text: "a", checked: false},
+				{text: "b", checked: true},
+			]),
+		).toEqual(["open\ta", "checked\tb"]);
+	});
+});

--- a/packages/fabrika-cli/src/wire/artifact.ts
+++ b/packages/fabrika-cli/src/wire/artifact.ts
@@ -1,0 +1,53 @@
+/**
+ * The artifact-on-stdin boundary: three inputs a reader must never fuse into one.
+ *
+ * `../io/stdin.ts` already keeps "the pipe held nothing" apart from "the pipe could not be read".
+ * This module carries that distinction the rest of the way into an exit code, because for *this*
+ * group the negative answer is the expected one — a body with no acceptance criteria is ordinary —
+ * and an expected negative is the least-questioned place for an unseen input to hide.
+ */
+import type {StdinRead} from "../io/stdin.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {ARTIFACT_UNKNOWN, EMPTY_ARTIFACT} from "./codes.ts";
+
+export type Artifact =
+	/** Bytes that can be judged. Never blank — a blank artifact refuses instead. */
+	| {readonly _tag: "Bytes"; readonly text: string}
+	/** Nothing to judge, seated on a proven refusal rather than on a negative answer. */
+	| {readonly _tag: "Refusal"; readonly outcome: VerbOutcome};
+
+/**
+ * Classify what arrived on fd 0.
+ *
+ * A blank artifact refuses on {@link EMPTY_ARTIFACT} rather than answering `Absent`: a redirect that
+ * fed nothing is far more likely than an issue body that is genuinely zero bytes, and the two are
+ * byte-identical here. Refusing costs a caller one re-run; answering costs a proven-looking negative
+ * over an artifact nobody ever saw.
+ */
+export const classifyArtifact = (verb: string, read: StdinRead): Artifact => {
+	if (read._tag === "NoStdin" || read._tag === "Failed") {
+		return {
+			_tag: "Refusal",
+			outcome: refuse(
+				ARTIFACT_UNKNOWN,
+				`${verb}: the artifact could not be read (${read.reason}) — UNKNOWN, never absent. Redirect the artifact in: ${verb} < body.md`,
+			),
+		};
+	}
+	if (read.text.trim() === "") {
+		return {
+			_tag: "Refusal",
+			outcome: refuse(
+				EMPTY_ARTIFACT,
+				`${verb}: stdin was read and held nothing — an empty artifact is not an artifact to judge`,
+			),
+		};
+	}
+	return {_tag: "Bytes", text: read.text};
+};
+
+/** `<verb>: judged <n> lines (<b> bytes) against format <key>.` — printed on answers and refusals alike. */
+export const judgedLine = (verb: string, key: string, artifact: string): string => {
+	const lines = artifact.split("\n").length;
+	return `${verb}: judged ${lines} line${lines === 1 ? "" : "s"} (${artifact.length} bytes) against format ${key}.`;
+};

--- a/packages/fabrika-cli/src/wire/check-verb.ts
+++ b/packages/fabrika-cli/src/wire/check-verb.ts
@@ -1,0 +1,47 @@
+/**
+ * `wire check` — does the artifact on stdin carry a conforming block for this format?
+ *
+ * `read` without the payload: the same three-way total read, answered as a verdict token rather
+ * than as fields, for a caller that only needs the yes/no. It shares `read`'s codes so one meaning
+ * covers both, and it prints the scope it judged on **every** path — a verdict whose scope is
+ * unstated cannot be told from a verdict over nothing (ADR 0092).
+ */
+import {Effect} from "effect";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {classifyArtifact, judgedLine} from "./artifact.ts";
+import {ABSENT, MALFORMED} from "./codes.ts";
+import {resolveFormat} from "./resolve-format.ts";
+
+const VERB = "wire check";
+
+export interface CheckOptions {
+	readonly format: string;
+	readonly json: boolean;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runCheck = ({format, json, stdin}: CheckOptions): Effect.Effect<VerbOutcome> =>
+	Effect.map(stdin, (piped) => {
+		const lookup = resolveFormat(VERB, format);
+		if (lookup._tag === "Refusal") return lookup.outcome;
+
+		const artifact = classifyArtifact(VERB, piped);
+		if (artifact._tag === "Refusal") return artifact.outcome;
+
+		const scope = judgedLine(VERB, format, artifact.text);
+		const result = lookup.format.read(artifact.text);
+		if (result._tag === "Absent") {
+			return refuse(ABSENT, `${VERB}: absent — ${result.reason}`, [scope]);
+		}
+		if (result._tag === "Malformed") {
+			return refuse(MALFORMED, `${VERB}: malformed — ${result.reason}`, [
+				scope,
+				`${VERB}: ${result.evidence}`,
+			]);
+		}
+		const stdout = json
+			? `${JSON.stringify({format, outcome: "conforms", fields: result.value.length})}\n`
+			: `conforms\t${format}\t${result.value.length}\n`;
+		return answer(stdout, [scope]);
+	});

--- a/packages/fabrika-cli/src/wire/codes-verb.ts
+++ b/packages/fabrika-cli/src/wire/codes-verb.ts
@@ -1,0 +1,21 @@
+/**
+ * `wire codes` — print the group's exit taxonomy.
+ *
+ * Each verb's `--help` enumerates only the codes *it* can reach, so the table itself has no other
+ * runtime home. It touches no repository and performs no read, which is why it takes no `--repo`.
+ */
+import {answer, type VerbOutcome} from "../verb.ts";
+import {ABSENT, ARTIFACT_UNKNOWN, WIRE_EXIT_TABLE} from "./codes.ts";
+
+export interface CodesInput {
+	readonly json: boolean;
+}
+
+const SPLIT_NOTE = `wire codes: ${ABSENT} (proven absent) and ${ARTIFACT_UNKNOWN} (never seen) are deliberately different codes — fusing them is what lets an unread artifact pass for one with no block.`;
+
+export const runCodes = ({json}: CodesInput): VerbOutcome => {
+	const stdout = json
+		? `${JSON.stringify({codes: WIRE_EXIT_TABLE})}\n`
+		: `${WIRE_EXIT_TABLE.map((row) => `${row.code}\t${row.meaning}`).join("\n")}\n`;
+	return answer(stdout, [SPLIT_NOTE]);
+};

--- a/packages/fabrika-cli/src/wire/codes.ts
+++ b/packages/fabrika-cli/src/wire/codes.ts
@@ -1,0 +1,84 @@
+/**
+ * The one exit table every `wire` verb allocates from, so a code means one thing across the group.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`); everything else
+ * is `3` and up, the band a verb owns for outcomes it PROVED.
+ *
+ * **The split that is the whole point of this group.** Three different things can go wrong while
+ * looking for a format in an artifact, and collapsing any two of them is what blinds a reader:
+ *
+ *   - {@link ABSENT} — the artifact was read in full and the block is provably not in it.
+ *   - {@link MALFORMED} — something in the artifact means to be the block and does not conform.
+ *   - {@link ARTIFACT_UNKNOWN} — the artifact was never seen. Nothing is proven about it.
+ *
+ * Only the first two are answers about an artifact. A reader that seats an unseen artifact on
+ * {@link ABSENT} reports a proven negative over evidence it never had — the silent green
+ * `../eval/spawn.ts` documents (a skill that never resolved exiting 0 with `num_turns: 0`), in the
+ * one place where the negative is the *expected* result and so the least likely to be questioned.
+ */
+
+/** The answer is on stdout. Restated here because {@link WIRE_EXIT_TABLE} spans the whole matrix. */
+const ANSWER = 0;
+/** Usage error, or the verb failed to run. */
+const FAILED = 1;
+/** No implementation could be resolved — the dependency graph never loaded (`../bin.ts`). */
+const NO_IMPLEMENTATION = 2;
+
+/** The artifact was read and the format's block is provably not in it. A proven negative. */
+export const ABSENT = 3;
+/** The block is present and does not conform. A proven negative, distinct from {@link ABSENT}. */
+export const MALFORMED = 4;
+/** Stdin was read and held nothing. An empty artifact is not an artifact to judge. */
+export const EMPTY_ARTIFACT = 5;
+/**
+ * fd 0 carried nothing readable, or the read failed. The artifact is **UNKNOWN**.
+ *
+ * Deliberately not {@link ABSENT}: "I could not see it" and "it is not there" are the two the
+ * group exists to keep apart. Deliberately not `1` either — `1` is also what a bad flag and a
+ * failed module load return, so a proven outcome seated there is unreadable as proof (#4208).
+ */
+export const ARTIFACT_UNKNOWN = 6;
+/**
+ * Zero scope: `--format` names no registered format, or the registry holds no rows at all
+ * (ADR 0092).
+ *
+ * A checker asked for a format it does not have must red, not pass — a `check` that judged
+ * nothing and exited 0 is a vacuous pass, the exact fail-open shape ADR 0092 forbids.
+ */
+export const ZERO_SCOPE = 7;
+/** The fields on stdin hold nothing this format can compose a block from. */
+export const UNUSABLE_FIELDS = 8;
+
+/** The verb never ran (unresolved binary). The shell's, not this process's — no constant owns it. */
+const NEVER_RAN = 127;
+
+/** One row of the shared matrix: a code and the single meaning it carries across the group. */
+export interface ExitCodeRow {
+	readonly code: number;
+	readonly meaning: string;
+}
+
+/**
+ * The whole matrix in ascending order — the machine-readable form of the group's exit contract.
+ *
+ * The reserved rows sit beside the allocated ones because the matrix owns what a code *means*
+ * while each verb's `--help` owns what *triggers* it.
+ */
+export const WIRE_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
+	{code: ANSWER, meaning: "the answer is on stdout"},
+	{code: FAILED, meaning: "usage error, or the verb failed to run"},
+	{code: NO_IMPLEMENTATION, meaning: "no implementation could be resolved"},
+	{code: ABSENT, meaning: "the artifact was read and the format's block is proven absent"},
+	{code: MALFORMED, meaning: "the block is present and does not conform"},
+	{code: EMPTY_ARTIFACT, meaning: "stdin was read and held nothing"},
+	{
+		code: ARTIFACT_UNKNOWN,
+		meaning: "the artifact could not be read — UNKNOWN, never absent",
+	},
+	{
+		code: ZERO_SCOPE,
+		meaning: "zero scope: --format names no registered format, or the registry is empty",
+	},
+	{code: UNUSABLE_FIELDS, meaning: "the fields on stdin hold nothing this format can compose"},
+	{code: NEVER_RAN, meaning: "the verb never ran (unresolved binary)"},
+];

--- a/packages/fabrika-cli/src/wire/command.ts
+++ b/packages/fabrika-cli/src/wire/command.ts
@@ -1,0 +1,120 @@
+/**
+ * The `wire` verb group — `fabrika wire <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags, runs the pure verb, and emits its outcome.
+ * Every decision lives in the `*-verb.ts` modules beside it, which is what makes each refusal
+ * testable without spawning a process.
+ *
+ * The leaves are **flat** — `emit` / `read` / `check` select their format with `--format`, never
+ * with a `wire ac emit` sub-group. Every other group is group→leaf, and the `--help` path guard and
+ * the excess-operand catch-all are only exercised at that depth.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
+ * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ */
+import {Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runCheck} from "./check-verb.ts";
+import {runCodes} from "./codes-verb.ts";
+import {runEmit} from "./emit-verb.ts";
+import {runFormats} from "./formats-verb.ts";
+import {runRead} from "./read-verb.ts";
+import {registeredKeys} from "./registry.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emitOutcome = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
+);
+
+/**
+ * The registered keys are interpolated into the description rather than restated, so `--help` can
+ * never advertise a format the registry does not hold.
+ */
+const formatFlag = Flag.string("format").pipe(
+	Flag.withDescription(`the wire format to act on: one of ${registeredKeys().join(", ")}`),
+);
+
+const codes = leafCommand(
+	"codes",
+	{json: jsonFlag},
+	Effect.fn(function* ({json}) {
+		yield* emitOutcome(runCodes({json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Print the exit taxonomy every verb in this group allocates from. Stdout is one `<code>\\t<meaning>` line per code. Reads nothing and always exits 0. Example: fabrika wire codes",
+	),
+);
+
+const formats = leafCommand(
+	"formats",
+	{json: jsonFlag},
+	Effect.fn(function* ({json}) {
+		yield* emitOutcome(runFormats({json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"List the registered wire formats, derived from the registry rather than from a hand-written list. First stdout line is `formats\\t<n>`, then one `<key>\\t<purpose>\\t<producers>\\t<consumers>` line per format. Exits 7 (no format is registered — a listing over zero rows is not an answer). Example: fabrika wire formats",
+	),
+);
+
+const emit = leafCommand(
+	"emit",
+	{format: formatFlag, json: jsonFlag},
+	Effect.fn(function* ({format, json}) {
+		yield* emitOutcome(yield* runEmit({format, json, stdin: Effect.sync(readStdin)}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Compose a format's bytes from the fields on STDIN — for acceptance-criteria, one criterion per line, optionally prefixed `[x]` or `[ ]`. The composed block is the stdout answer and round-trips through `wire read`. Exits 5 (stdin was read and held nothing), 6 (stdin could not be read — UNKNOWN), 7 (--format names no registered format), 8 (the fields hold no usable criterion). Example: fabrika wire emit --format acceptance-criteria < criteria.txt",
+	),
+);
+
+const read = leafCommand(
+	"read",
+	{format: formatFlag, json: jsonFlag},
+	Effect.fn(function* ({format, json}) {
+		yield* emitOutcome(yield* runRead({format, json, stdin: Effect.sync(readStdin)}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Read a format's block out of the artifact on STDIN and print its fields. The read is total: `found` is the only outcome on stdout, and it never carries zero fields. First stdout line is `found\\t<format>\\t<count>`, then one field line each. Exits 3 (proven absent — nothing in the artifact reaches for the block), 4 (present and malformed — the reason and the offending bytes are on stderr), 5 (stdin was read and held nothing), 6 (the artifact could not be read — UNKNOWN, never absent), 7 (--format names no registered format). Example: fabrika wire read --format acceptance-criteria < issue-body.md",
+	),
+);
+
+const check = leafCommand(
+	"check",
+	{format: formatFlag, json: jsonFlag},
+	Effect.fn(function* ({format, json}) {
+		yield* emitOutcome(yield* runCheck({format, json, stdin: Effect.sync(readStdin)}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Say whether the artifact on STDIN carries a conforming block for this format, without printing its fields. The scope judged — lines, bytes and format — is on stderr on every path, so a verdict is never reported over unstated scope. Stdout is the single line `conforms\\t<format>\\t<count>`. Exits 3 (proven absent), 4 (present and malformed), 5 (stdin was read and held nothing), 6 (the artifact could not be read — UNKNOWN), 7 (--format names no registered format — zero scope, never a vacuous pass). Example: fabrika wire check --format acceptance-criteria < issue-body.md",
+	),
+);
+
+export const wireCommand = Command.make("wire").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing
+		// one. The comment is what keeps the formatter from collapsing the list back.
+		codes,
+		formats,
+		emit,
+		read,
+		check,
+	]),
+	Command.withDescription(
+		"Own the byte-level formats two skills meet through on a GitHub artifact — compose them, read them back totally (found / absent / malformed), and check one without reading its fields",
+	),
+);

--- a/packages/fabrika-cli/src/wire/emit-verb.ts
+++ b/packages/fabrika-cli/src/wire/emit-verb.ts
@@ -1,0 +1,37 @@
+/**
+ * `wire emit` — compose a format's bytes from the fields on stdin.
+ *
+ * The fields arrive on **stdin only**, for the reason `triage split`'s body does: a flag that takes
+ * a path turns the artifact into a string the verb could echo back, and that is how a machine-local
+ * path reaches a public surface. A shell redirect is expected — the *shell* reads the file, so what
+ * reaches the verb is already bytes.
+ */
+import {Effect} from "effect";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {classifyArtifact} from "./artifact.ts";
+import {UNUSABLE_FIELDS} from "./codes.ts";
+import {resolveFormat} from "./resolve-format.ts";
+
+const VERB = "wire emit";
+
+export interface EmitOptions {
+	readonly format: string;
+	readonly json: boolean;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runEmit = ({format, json, stdin}: EmitOptions): Effect.Effect<VerbOutcome> =>
+	Effect.map(stdin, (piped) => {
+		const lookup = resolveFormat(VERB, format);
+		if (lookup._tag === "Refusal") return lookup.outcome;
+
+		const fields = classifyArtifact(VERB, piped);
+		if (fields._tag === "Refusal") return fields.outcome;
+
+		const composed = lookup.format.emit(fields.text);
+		if (composed._tag === "Unusable") {
+			return refuse(UNUSABLE_FIELDS, `${VERB}: unusable fields — ${composed.reason}`);
+		}
+		return answer(json ? `${JSON.stringify({format, bytes: composed.bytes})}\n` : composed.bytes);
+	});

--- a/packages/fabrika-cli/src/wire/format.ts
+++ b/packages/fabrika-cli/src/wire/format.ts
@@ -1,0 +1,81 @@
+/**
+ * What a wire format is, as a type — the shape every schema module fills and the registry lists.
+ *
+ * A wire format is the byte-level agreement two skills meet through on a GitHub artifact. Its
+ * schema module owns the bytes and nothing else: composing them ({@link WireFormat.emit}) and
+ * reading them back ({@link WireFormat.read}). Which deviation class a finding belongs to, when a
+ * criterion is worth writing — those judgements stay in the skills.
+ *
+ * **`read` is total, and its three answers are the reason this type exists.** A reader whose
+ * failure mode is "return the well-formed empty value" is indistinguishable, at the call site, from
+ * one that genuinely found nothing — so a heading that drifted by one character reads back as "this
+ * issue has no acceptance criteria" and a grader passes over nothing. {@link WireRead} admits no
+ * such value: `Found` carries a {@link NonEmptyReadonlyArray} by construction, so "found, but
+ * empty" is not a representable state, and every non-conforming input lands on `Absent` or
+ * `Malformed` with a reason attached.
+ */
+
+/** An array the type system knows holds at least one element. */
+export type NonEmptyReadonlyArray<A> = readonly [A, ...ReadonlyArray<A>];
+
+/** The artifact was read in full and the block is provably not in it. */
+export interface WireAbsent {
+	readonly _tag: "Absent";
+	readonly reason: string;
+}
+
+/** Something in the artifact means to be the block and does not conform. */
+export interface WireMalformed {
+	readonly _tag: "Malformed";
+	readonly reason: string;
+	/** The offending bytes, quoted back so the caller can see what was judged. */
+	readonly evidence: string;
+}
+
+/** The block is present and conforms. `value` is non-empty wherever the format's value is a list. */
+export interface WireFound<A> {
+	readonly _tag: "Found";
+	readonly value: A;
+}
+
+/** Exactly three answers. A fourth would have to be added here, in the open. */
+export type WireRead<A> = WireFound<A> | WireAbsent | WireMalformed;
+
+/** Fields composed into the format's bytes. */
+export interface WireComposed {
+	readonly _tag: "Composed";
+	readonly bytes: string;
+}
+
+/** The fields hold nothing this format can compose a conforming block from. */
+export interface WireUnusable {
+	readonly _tag: "Unusable";
+	readonly reason: string;
+}
+
+export type WireEmit = WireComposed | WireUnusable;
+
+/** {@link WireRead} with the format's value already rendered to the adapter's stdout lines. */
+export type WireReadLines = WireRead<NonEmptyReadonlyArray<string>>;
+
+/**
+ * A registered format: its identity, its wiring, and its bytes.
+ *
+ * The `emit`/`read` pair is stated over **bytes in, bytes out** so one array can hold formats whose
+ * values have nothing in common. Each schema module keeps its own typed core — the field type, the
+ * typed read — and the row adapts it; the typing is not lost, it is bound at the row.
+ */
+export interface WireFormat {
+	/** The `--format` selector. Kebab-case, and the row's identity. */
+	readonly key: string;
+	/** One line: what agreement this format encodes. */
+	readonly purpose: string;
+	/** Who writes these bytes. */
+	readonly producers: ReadonlyArray<string>;
+	/** Who reads them. */
+	readonly consumers: ReadonlyArray<string>;
+	/** Fields (as bytes) → the format's bytes. */
+	readonly emit: (fields: string) => WireEmit;
+	/** An artifact's bytes → the total read, with `Found` rendered to stdout lines. */
+	readonly read: (artifact: string) => WireReadLines;
+}

--- a/packages/fabrika-cli/src/wire/formats-verb.ts
+++ b/packages/fabrika-cli/src/wire/formats-verb.ts
@@ -1,0 +1,38 @@
+/**
+ * `wire formats` — the registered formats, derived from `./registry.ts`.
+ *
+ * The listing is a projection of the array, never a second copy of it, which is what makes "is this
+ * format registered?" answerable from the binary that dispatches rather than from a document that
+ * can drift. An empty registry refuses (ADR 0092): printing an empty list would be a proven
+ * negative from a verb that resolved nothing.
+ */
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {ZERO_SCOPE} from "./codes.ts";
+import {registeredFormats} from "./registry.ts";
+
+const VERB = "wire formats";
+
+export interface FormatsInput {
+	readonly json: boolean;
+}
+
+export const runFormats = ({json}: FormatsInput): VerbOutcome => {
+	if (registeredFormats.length === 0) {
+		return refuse(ZERO_SCOPE, `${VERB}: no wire format is registered — the registry holds no rows`);
+	}
+	const rows = registeredFormats.map(({key, purpose, producers, consumers}) => ({
+		key,
+		purpose,
+		producers,
+		consumers,
+	}));
+	const stdout = json
+		? `${JSON.stringify({formats: rows})}\n`
+		: `formats\t${rows.length}\n${rows
+				.map(
+					(row) =>
+						`${row.key}\t${row.purpose}\t${row.producers.join(",")}\t${row.consumers.join(",")}`,
+				)
+				.join("\n")}\n`;
+	return answer(stdout, [`${VERB}: derived from the registry — ${rows.length} registered.`]);
+};

--- a/packages/fabrika-cli/src/wire/help.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/help.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `--help` is the interface (`claude-plugins/fabrika/docs/cli-interface-convention.md` §1), so what
+ * it must state is asserted rather than trusted: what the verb answers, the shape of its stdout,
+ * the codes it can exit on, and one literal invocation a caller can paste.
+ *
+ * It reads the description and the declared flags off the `Command`'s runtime shape, the same
+ * deliberately-confined idiom `../excess-operand.unit.test.ts` uses — a plain widening assignment,
+ * never a cast, so a rename upstream reds here at build time rather than leaving the assertions
+ * silently vacuous.
+ */
+import {describe, expect, it} from "vitest";
+import type {CommandNode} from "../unknown-subcommand.ts";
+import {wireCommand} from "./command.ts";
+import {registeredKeys} from "./registry.ts";
+
+/** A flag as this test reads it: a combinator chain over a `Single` carrying the help text. */
+interface FlagNode {
+	readonly description?: string | undefined;
+	readonly param?: FlagNode | undefined;
+}
+
+interface DescribedCommand extends Omit<CommandNode, "subcommands"> {
+	readonly description: string | undefined;
+	readonly config?: {readonly flags?: ReadonlyArray<FlagNode>} | undefined;
+	readonly subcommands: ReadonlyArray<{readonly commands: ReadonlyArray<DescribedCommand>}>;
+}
+
+const group: DescribedCommand = wireCommand;
+const leaves = group.subcommands.flatMap((set) => set.commands);
+const LEAF_NAMES = ["codes", "formats", "emit", "read", "check"];
+
+const describedBy = (name: string): string =>
+	leaves.find((leaf) => leaf.name === name)?.description ?? "";
+
+/** Every help string on a flag, following the combinator chain down to the `Single` that holds it. */
+const flagHelp = (name: string): string => {
+	const text = (node: FlagNode | undefined): string =>
+		node === undefined ? "" : `${node.description ?? ""} ${text(node.param)}`;
+	const leaf = leaves.find((candidate) => candidate.name === name);
+	return (leaf?.config?.flags ?? []).map(text).join(" ");
+};
+
+describe("the wire group's help", () => {
+	it("registers the five flat leaves and no sub-group", () => {
+		expect(leaves.map((leaf) => leaf.name)).toEqual(LEAF_NAMES);
+		for (const leaf of leaves) expect(leaf.subcommands.flatMap((set) => set.commands)).toEqual([]);
+	});
+
+	it("gives the group itself a one-line description, so `fabrika --help` lists it", () => {
+		expect(group.description ?? "").not.toBe("");
+	});
+
+	it.each(LEAF_NAMES)("%s states its exit codes and a literal example invocation", (name) => {
+		const description = describedBy(name);
+		expect(description).not.toBe("");
+		expect(description).toMatch(/[Ee]xits? \d|always exits 0/);
+		expect(description).toContain(`Example: fabrika wire ${name}`);
+	});
+
+	it("states the stdout shape for every verb that prints one", () => {
+		for (const name of ["codes", "formats", "read", "check"]) {
+			expect(describedBy(name)).toMatch(/stdout/i);
+		}
+	});
+
+	it("advertises the --format vocabulary from the registry, never from a literal", () => {
+		for (const name of ["emit", "read", "check"]) {
+			const advertised = flagHelp(name);
+			expect(advertised).not.toBe("");
+			for (const key of registeredKeys()) expect(advertised).toContain(key);
+		}
+	});
+});

--- a/packages/fabrika-cli/src/wire/read-verb.ts
+++ b/packages/fabrika-cli/src/wire/read-verb.ts
@@ -1,0 +1,48 @@
+/**
+ * `wire read` — read a format's block out of an artifact on stdin.
+ *
+ * The one verb whose *negative* answers are the point. `Found` is the only outcome that reaches
+ * stdout; `Absent` and `Malformed` are proven refusals on distinct codes, and an artifact that was
+ * never seen is a third code again (`./codes.ts`). Nothing here can produce a well-formed empty
+ * answer.
+ */
+import {Effect} from "effect";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {classifyArtifact, judgedLine} from "./artifact.ts";
+import {ABSENT, MALFORMED} from "./codes.ts";
+import {resolveFormat} from "./resolve-format.ts";
+
+const VERB = "wire read";
+
+export interface ReadOptions {
+	readonly format: string;
+	readonly json: boolean;
+	/** The fd-0 read, injected so the failed-read and TTY paths are testable without a descriptor. */
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runRead = ({format, json, stdin}: ReadOptions): Effect.Effect<VerbOutcome> =>
+	Effect.map(stdin, (piped) => {
+		const lookup = resolveFormat(VERB, format);
+		if (lookup._tag === "Refusal") return lookup.outcome;
+
+		const artifact = classifyArtifact(VERB, piped);
+		if (artifact._tag === "Refusal") return artifact.outcome;
+
+		const scope = judgedLine(VERB, format, artifact.text);
+		const result = lookup.format.read(artifact.text);
+		if (result._tag === "Absent") {
+			return refuse(ABSENT, `${VERB}: absent — ${result.reason}`, [scope]);
+		}
+		if (result._tag === "Malformed") {
+			return refuse(MALFORMED, `${VERB}: malformed — ${result.reason}`, [
+				scope,
+				`${VERB}: ${result.evidence}`,
+			]);
+		}
+		const stdout = json
+			? `${JSON.stringify({format, outcome: "found", fields: result.value})}\n`
+			: `found\t${format}\t${result.value.length}\n${result.value.join("\n")}\n`;
+		return answer(stdout, [scope]);
+	});

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -1,0 +1,35 @@
+/**
+ * The wire-format registry — the extension seam.
+ *
+ * One row per format: its `--format` key, its purpose, who writes the bytes, who reads them, and
+ * the schema module that owns them. `fabrika wire formats` derives its listing from this array, and
+ * `emit` / `read` / `check` resolve `--format` against it, so a format exists by being registered
+ * here and nowhere else. That is the same discipline `../registry.ts` holds for verb groups, for
+ * the same reason: a hand-maintained parallel list is a second source of truth that drifts, and the
+ * drift is silent.
+ *
+ * A new format lands as a sibling schema module plus one row here — never as a branch inside a
+ * verb.
+ */
+import {emitFromFields, readToLines} from "./acceptance-criteria.ts";
+import type {WireFormat} from "./format.ts";
+
+export const registeredFormats: ReadonlyArray<WireFormat> = [
+	{
+		key: "acceptance-criteria",
+		purpose:
+			"the checkbox contract a gate grades a PR against, carried on a sub-issue body under `### Acceptance criteria`",
+		producers: ["triage", "build-epic"],
+		consumers: ["build", "review"],
+		emit: emitFromFields,
+		read: readToLines,
+	},
+];
+
+/** The registered key for `--format`, resolved against the array above. `undefined` is zero scope. */
+export const findFormat = (key: string): WireFormat | undefined =>
+	registeredFormats.find((format) => format.key === key);
+
+/** Every registered key, for a refusal that names what *is* available. */
+export const registeredKeys = (): ReadonlyArray<string> =>
+	registeredFormats.map((format) => format.key);

--- a/packages/fabrika-cli/src/wire/resolve-format.ts
+++ b/packages/fabrika-cli/src/wire/resolve-format.ts
@@ -1,0 +1,39 @@
+/**
+ * `--format` → a registered row, or a zero-scope refusal.
+ *
+ * Shared by the three verbs that take `--format` so an unregistered key refuses in one voice. The
+ * refusal is {@link ZERO_SCOPE}, not a usage error: a verb asked to judge a format it does not have
+ * judged nothing, and a check over nothing that exits 0 is the vacuous pass ADR 0092 forbids.
+ */
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {ZERO_SCOPE} from "./codes.ts";
+import type {WireFormat} from "./format.ts";
+import {findFormat, registeredKeys} from "./registry.ts";
+
+export type FormatLookup =
+	| {readonly _tag: "Format"; readonly format: WireFormat}
+	| {readonly _tag: "Refusal"; readonly outcome: VerbOutcome};
+
+export const resolveFormat = (verb: string, key: string): FormatLookup => {
+	const keys = registeredKeys();
+	if (keys.length === 0) {
+		return {
+			_tag: "Refusal",
+			outcome: refuse(
+				ZERO_SCOPE,
+				`${verb}: no wire format is registered — there is nothing to judge`,
+			),
+		};
+	}
+	const format = findFormat(key);
+	if (format === undefined) {
+		return {
+			_tag: "Refusal",
+			outcome: refuse(
+				ZERO_SCOPE,
+				`${verb}: no format is registered under "${key}" — registered: ${keys.join(", ")}`,
+			),
+		};
+	}
+	return {_tag: "Format", format};
+};

--- a/packages/fabrika-cli/src/wire/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/verbs.unit.test.ts
@@ -1,0 +1,219 @@
+/**
+ * The adapter tier: which exit code each outcome is seated on, and — the assertion this group
+ * exists for — that an artifact the verb could not see is **distinguishable** from one it read and
+ * found nothing in.
+ *
+ * Three inputs are driven through `read` and `check` below: a real body with no block, a fd 0 that
+ * could not be read, and a fd 0 that carried nothing. A reader that fused any two of them would
+ * still pass a test asserting only "it refused"; every case here asserts the *code*, and the last
+ * test asserts the three codes are pairwise distinct, which is the property a future edit could
+ * quietly lose.
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import type {StdinRead} from "../io/stdin.ts";
+import {ANSWER} from "../verb.ts";
+import {runCheck} from "./check-verb.ts";
+import {
+	ABSENT,
+	ARTIFACT_UNKNOWN,
+	EMPTY_ARTIFACT,
+	MALFORMED,
+	UNUSABLE_FIELDS,
+	WIRE_EXIT_TABLE,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {runCodes} from "./codes-verb.ts";
+import {runEmit} from "./emit-verb.ts";
+import {runFormats} from "./formats-verb.ts";
+import {runRead} from "./read-verb.ts";
+import {registeredFormats} from "./registry.ts";
+
+const KEY = "acceptance-criteria";
+
+const piped = (text: string): Effect.Effect<StdinRead> => Effect.succeed({_tag: "Text", text});
+const noStdin: Effect.Effect<StdinRead> = Effect.succeed({
+	_tag: "NoStdin",
+	reason: "fd 0 is a TTY — nothing was piped in",
+});
+const readFailed: Effect.Effect<StdinRead> = Effect.succeed({
+	_tag: "Failed",
+	reason: "EAGAIN with no data for 30000ms",
+});
+
+const CONFORMING = "### Acceptance criteria\n- [ ] one\n- [x] two\n";
+const NO_BLOCK = "### What to build\n\nStand up the group. No criteria section here.\n";
+const DRIFTED = "### Acceptance Criteria\n- [ ] one\n";
+
+const read = (stdin: Effect.Effect<StdinRead>, format = KEY, json = false) =>
+	Effect.runPromise(runRead({format, json, stdin}));
+const check = (stdin: Effect.Effect<StdinRead>, format = KEY, json = false) =>
+	Effect.runPromise(runCheck({format, json, stdin}));
+const emit = (stdin: Effect.Effect<StdinRead>, format = KEY, json = false) =>
+	Effect.runPromise(runEmit({format, json, stdin}));
+
+describe("wire read", () => {
+	it("prints the criteria on stdout with a positive token, exit 0", async () => {
+		const out = await read(piped(CONFORMING));
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe(`found\t${KEY}\t2\nopen\tone\nchecked\ttwo\n`);
+	});
+
+	it("states the scope it judged on stderr, never on the answer channel", async () => {
+		const out = await read(piped(CONFORMING));
+		expect(out.stderr.join("\n")).toContain(`judged 4 lines (${CONFORMING.length} bytes)`);
+		expect(out.stdout).not.toContain("judged");
+	});
+
+	it("seats a PROVEN absent on 3 with nothing on stdout", async () => {
+		const out = await read(piped(NO_BLOCK));
+		expect(out.code).toBe(ABSENT);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("absent");
+	});
+
+	it("seats a PROVEN malformed on 4, naming the drift and quoting the bytes", async () => {
+		const out = await read(piped(DRIFTED));
+		expect(out.code).toBe(MALFORMED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("Acceptance Criteria");
+	});
+
+	it("REFUSES an artifact it never saw as UNKNOWN — not as absent", async () => {
+		for (const stdin of [noStdin, readFailed]) {
+			const out = await read(stdin);
+			expect(out.code).toBe(ARTIFACT_UNKNOWN);
+			expect(out.stdout).toBe("");
+			expect(out.stderr.join("\n")).toContain("UNKNOWN");
+		}
+	});
+
+	it("refuses an empty artifact on its own code — an empty pipe is not a body with no block", async () => {
+		const out = await read(piped("   \n\n"));
+		expect(out.code).toBe(EMPTY_ARTIFACT);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unregistered --format as zero scope, naming what IS registered", async () => {
+		const out = await read(piped(CONFORMING), "no-such-format");
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain(KEY);
+	});
+
+	it("emits one JSON object under --json", async () => {
+		const out = await read(piped(CONFORMING), KEY, true);
+		expect(JSON.parse(out.stdout)).toEqual({
+			format: KEY,
+			outcome: "found",
+			fields: ["open\tone", "checked\ttwo"],
+		});
+	});
+
+	/**
+	 * The property, asserted directly rather than left implied by the cases above: a caller that
+	 * branches on the exit code can always tell the three apart. Collapsing any pair is what turns an
+	 * unread artifact into a clean-looking negative.
+	 */
+	it("keeps proven-absent, malformed and never-seen on three DIFFERENT codes", async () => {
+		const codes = [
+			(await read(piped(NO_BLOCK))).code,
+			(await read(piped(DRIFTED))).code,
+			(await read(noStdin)).code,
+			(await read(piped(""))).code,
+		];
+		expect(new Set(codes).size).toBe(codes.length);
+		expect(codes).not.toContain(0);
+		expect(codes).not.toContain(1);
+		expect(codes).not.toContain(127);
+	});
+});
+
+describe("wire check", () => {
+	it("answers a verdict token without the fields, exit 0", async () => {
+		const out = await check(piped(CONFORMING));
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe(`conforms\t${KEY}\t2\n`);
+		expect(out.stdout).not.toContain("one");
+	});
+
+	it("states the scope it judged on EVERY path, including the refusals", async () => {
+		for (const artifact of [CONFORMING, NO_BLOCK, DRIFTED]) {
+			const out = await check(piped(artifact));
+			expect(out.stderr.join("\n")).toContain(`against format ${KEY}`);
+		}
+	});
+
+	it("reds on zero scope rather than passing vacuously (ADR 0092)", async () => {
+		const out = await check(piped(CONFORMING), "no-such-format");
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("seats absent on 3 and malformed on 4, matching `read`", async () => {
+		expect((await check(piped(NO_BLOCK))).code).toBe(ABSENT);
+		expect((await check(piped(DRIFTED))).code).toBe(MALFORMED);
+	});
+
+	it("refuses an unseen artifact as UNKNOWN", async () => {
+		expect((await check(readFailed)).code).toBe(ARTIFACT_UNKNOWN);
+	});
+});
+
+describe("wire emit", () => {
+	it("composes the block from the fields and round-trips through `read`", async () => {
+		const out = await emit(piped("first\n[x] second\n"));
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("### Acceptance criteria\n\n- [ ] first\n- [x] second\n");
+
+		const back = await read(piped(out.stdout));
+		expect(back.code).toBe(ANSWER);
+		expect(back.stdout).toBe(`found\t${KEY}\t2\nopen\tfirst\nchecked\tsecond\n`);
+	});
+
+	it("refuses fields that compose nothing, rather than emitting an empty block", async () => {
+		const out = await emit(piped("[x]\n"));
+		expect(out.code).toBe(UNUSABLE_FIELDS);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unseen fd 0 as UNKNOWN and an empty one on its own code", async () => {
+		expect((await emit(noStdin)).code).toBe(ARTIFACT_UNKNOWN);
+		expect((await emit(piped("\n")))?.code).toBe(EMPTY_ARTIFACT);
+	});
+});
+
+describe("wire formats", () => {
+	it("derives one row per registered format — no parallel hand-written list", () => {
+		const out = runFormats({json: false});
+		const lines = out.stdout.trimEnd().split("\n");
+		expect(lines[0]).toBe(`formats\t${registeredFormats.length}`);
+		expect(lines).toHaveLength(registeredFormats.length + 1);
+		for (const [index, format] of registeredFormats.entries()) {
+			expect(lines[index + 1]?.startsWith(`${format.key}\t`)).toBe(true);
+		}
+	});
+
+	it("lists the founding format with its producers and consumers", () => {
+		const out = runFormats({json: true});
+		expect(JSON.parse(out.stdout).formats).toContainEqual({
+			key: KEY,
+			purpose: expect.any(String),
+			producers: expect.arrayContaining(["triage"]),
+			consumers: expect.arrayContaining(["review"]),
+		});
+	});
+});
+
+describe("wire codes", () => {
+	it("prints one `<code>\\t<meaning>` line per row and always exits 0", () => {
+		const out = runCodes({json: false});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout.trimEnd().split("\n")).toHaveLength(WIRE_EXIT_TABLE.length);
+	});
+
+	it("allocates no code twice — a shared code is a fused meaning", () => {
+		const codes = WIRE_EXIT_TABLE.map((row) => row.code);
+		expect(new Set(codes).size).toBe(codes.length);
+	});
+});

--- a/packages/fabrika-cli/src/wire/wire.cli.test.ts
+++ b/packages/fabrika-cli/src/wire/wire.cli.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The end-to-end half: the **exit status and the exact stdout bytes** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Two spawns: one answer and one
+ * refusal, which is the pair that cannot be established in-process. Everything else about these
+ * verbs is covered in-process by `./verbs.unit.test.ts`.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {ABSENT} from "./codes.ts";
+
+/** One spawn costs ~2.3s on a CI runner; 20s clears the measured 2.69× contention band (#4847). */
+const SUBPROCESS_TEST_TIMEOUT_MS = 20_000;
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
+const fabrika = (args: ReadonlyArray<string>, stdin: string): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			input: stdin,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika wire, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("answers a conforming artifact with the exact stdout bytes, exit 0", () => {
+		const run = fabrika(
+			["wire", "read", "--format", "acceptance-criteria"],
+			"### Acceptance criteria\n- [ ] the read is total\n- [x] the registry is the seam\n",
+		);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toBe(
+			"found\tacceptance-criteria\t2\nopen\tthe read is total\nchecked\tthe registry is the seam\n",
+		);
+	});
+
+	it("refuses a body with no block on the absent code, with NOTHING on stdout", () => {
+		const run = fabrika(
+			["wire", "read", "--format", "acceptance-criteria"],
+			"### What to build\n\nStand up the group.\n",
+		);
+		expect(run.code).toBe(ABSENT);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("absent");
+	});
+});


### PR DESCRIPTION
Two fabrika skills that have to meet on a GitHub issue had nothing to meet *on*: the acceptance-criteria block lived as prose, so a heading that drifted by one character read back as "this issue has no acceptance criteria" and a grader passed over nothing without an error. This PR gives that format a real owner — a typed schema module in `fabrika-cli` whose read has exactly three answers and cannot return a well-formed empty one — plus the `wire` verb group and the registry seam every later format lands on.

Fixes #4942

## What changed

- **`packages/fabrika-cli/src/wire/acceptance-criteria.ts`** — the founding schema module. A criterion field type (`text` + `checked`), an `emit` that composes criteria into the block's bytes, and a **total** `read` returning `Found | Absent | Malformed`. `Found` carries a `NonEmptyReadonlyArray`, so "found, but empty" is not a representable value. A heading that *reaches for* the block and misses — a drifted spelling, a wrong level, a conforming heading over a section with no checkbox items, a checkbox item with no text, two conforming headings — is `Malformed`; only a body where nothing reaches for it is `Absent`. A heading inside a code fence is an example, not the contract.
- **`packages/fabrika-cli/src/wire/format.ts`** — what a wire format is as a type: `WireRead`'s three cases, and the row shape stated over bytes in / bytes out so one array holds formats whose values have nothing in common.
- **`packages/fabrika-cli/src/wire/registry.ts`** — the extension seam. One row per format (key, purpose, producers, consumers, its schema module's `emit`/`read`). `wire formats` projects this array and `--format` resolves against it, so a format exists by being registered here and nowhere else.
- **`packages/fabrika-cli/src/wire/command.ts`** — the adapter and nothing else. Five **flat** leaves — `emit`, `read`, `check`, `formats`, `codes` — each declared with `leafCommand`, each selecting its format with `--format`. No `wire ac emit` sub-group: every other group is group→leaf, and the `--help` path guard and the excess-operand catch-all are only exercised at that depth. Each `--help` states what the verb answers, its stdout shape, its exit codes and a literal example.
- **`packages/fabrika-cli/src/wire/codes.ts`, `artifact.ts`, `resolve-format.ts`, the five `*-verb.ts`** — the group's exit table and the pure verbs. The artifact arrives on **stdin only** (no `--body`, no `--body-file`), for the reason `triage split`'s body does.
- **`packages/fabrika-cli/src/registry.ts`** — registers `wireCommand` as the fifth verb group, so `fabrika --help` lists it.
- **`packages/fabrika-cli/README.md`** — a `wire` group section: the verb table and the three properties a caller needs before calling them.

## How an unseen artifact stays distinguishable from a genuine negative

The defect class this campaign keeps hitting is a check that cannot see what it is looking for returning a plausible value. Here the negative answer is the *expected* one — plenty of issues have no acceptance criteria — which makes it the least-questioned place for an unseen input to hide. So the three states get three different exit codes, and the only outcome that reaches stdout is `found`:

| Input | Exit | stdout |
|---|---|---|
| a conforming block | `0` | `found\t<format>\t<n>` + one field line each |
| a body read in full with no block | `3` | *(nothing)* — a proven negative |
| a block present and drifted | `4` | *(nothing)* — the reason and the offending bytes on stderr |
| stdin read and held nothing | `5` | *(nothing)* — an empty artifact is not an artifact to judge |
| fd 0 carried nothing readable, or the read failed | `6` | *(nothing)* — UNKNOWN, never absent |

Proved by test, not asserted by comment: `packages/fabrika-cli/src/wire/verbs.unit.test.ts` drives each of those inputs and asserts the code, and one test asserts the property directly — the four refusal codes are **pairwise distinct** and none of them is `0`, `1` or `127`. A future edit that fused any pair reds there. On the schema side, `packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts` feeds five drifts a naive reader answers "empty" for and asserts each is `Malformed`, never a `Found` with zero criteria.

`packages/fabrika-cli/src/wire/wire.cli.test.ts` pins the end-to-end half in two spawns — the exact stdout bytes at exit `0` for an answer, and empty stdout at exit `3` for a refusal.

## Deviations

- **Class: narrowed a suggested shape.** *Said:* the issue calls for `read` to return `Found | Absent | Malformed`. *Did:* also made a **blank** artifact (exit `5`) and an **unreadable** one (exit `6`) refusals in the adapter, rather than mapping either onto `Absent`. *Why:* an empty pipe is far more often a redirect mistake than a genuinely zero-byte issue body, and the two are byte-identical at fd 0 — answering `Absent` there is exactly the proven-looking negative over unseen evidence this epic exists to remove. *Disposition:* no action needed; the schema module's `read` is unchanged and still exactly three-way.
- **Class: declined an adjacent change.** *Said:* nothing about `.patterns/`. *Did:* added no pattern doc. *Why:* the shapes this diff relies on are already documented — the pure-core-plus-thin-adapter verb shape and the derived-registry seam in `claude-plugins/fabrika/docs/cli-interface-convention.md` and `packages/fabrika-cli/README.md`, and the spawn budget in `.patterns/subprocess-test-budget.md`. The *law* this establishes (wire formats are owned by typed schema modules) is #4946's ADR, explicitly out of scope here. *Disposition:* for the reviewer to judge; #4946 owns the durable record.
- **Class: a judgment call the issue did not specify.** *Said:* read v1's formats contract as prior art only. *Did:* `acceptance-criteria.ts`'s docblock **cites** `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §2 as where the semantics came from. *Why:* ADR 0238 bans a dependency, not a citation, and naming the source is provenance a later reader needs. *Disposition:* no action needed — it is a prose reference, not an import, call, or shell-out. Flagged because a mechanical grep for that string would hit it.
- **Class: a scope call inside the issue.** *Said:* at least three distinct malformed drifts. *Did:* six — the three named, plus a checkbox item with no text, two conforming headings, and a fenced example that must not pass for the real block. *Why:* each is a body shape that reaches this code today; leaving one unhandled would let it fall through to a `Found` or an `Absent`. *Disposition:* no action needed.
