### PR TITLE
feat(fabrika-cli): the verdict-marker wire format, on the registry seam (#4943)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -256,6 +256,12 @@ Three properties are worth knowing before you call them:
 - **The artifact arrives on stdin only.** No `--body`, no `--body-file` — the same reason the
   `report` and `triage` writing verbs take theirs there: a flag that accepts a path turns the
   artifact into a string the verb could echo back onto a public surface.
+- **A `found` verdict marker is well-formed, not current.** `verdict-marker` carries the head
+  SHA the reviewer inspected, and a marker bound to a head that has since moved is *stale*, not
+  passing. Whether a marker binds the head you hold is
+  [`verdict-marker.ts`](./src/wire/verdict-marker.ts)'s `bindToHead` — three answers again
+  (`Current` / `Stale` / `Unbindable`), because a head the caller could not resolve is not a
+  comparison anyone made.
 
 ```bash
 printf 'the read is total\n[x] the registry is the seam\n' \

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -11,8 +11,9 @@
  * A new format lands as a sibling schema module plus one row here — never as a branch inside a
  * verb.
  */
-import {emitFromFields, readToLines} from "./acceptance-criteria.ts";
+import * as acceptanceCriteria from "./acceptance-criteria.ts";
 import type {WireFormat} from "./format.ts";
+import * as verdictMarker from "./verdict-marker.ts";
 
 export const registeredFormats: ReadonlyArray<WireFormat> = [
 	{
@@ -21,8 +22,17 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			"the checkbox contract a gate grades a PR against, carried on a sub-issue body under `### Acceptance criteria`",
 		producers: ["triage", "build-epic"],
 		consumers: ["build", "review"],
-		emit: emitFromFields,
-		read: readToLines,
+		emit: acceptanceCriteria.emitFromFields,
+		read: acceptanceCriteria.readToLines,
+	},
+	{
+		key: "verdict-marker",
+		purpose:
+			"the SHA-bound first line of a gate's verdict comment on a PR — namespace, polarity, the head the reviewer inspected, and the human clause",
+		producers: ["review"],
+		consumers: ["build", "ship"],
+		emit: verdictMarker.emitFromFields,
+		read: verdictMarker.readToLines,
 	},
 ];
 

--- a/packages/fabrika-cli/src/wire/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/verbs.unit.test.ts
@@ -30,6 +30,7 @@ import {runRead} from "./read-verb.ts";
 import {registeredFormats} from "./registry.ts";
 
 const KEY = "acceptance-criteria";
+const VERDICT = "verdict-marker";
 
 const piped = (text: string): Effect.Effect<StdinRead> => Effect.succeed({_tag: "Text", text});
 const noStdin: Effect.Effect<StdinRead> = Effect.succeed({
@@ -202,6 +203,66 @@ describe("wire formats", () => {
 			producers: expect.arrayContaining(["triage"]),
 			consumers: expect.arrayContaining(["review"]),
 		});
+	});
+
+	it("lists the verdict marker with its owner module's producers and consumers", () => {
+		const out = runFormats({json: true});
+		expect(JSON.parse(out.stdout).formats).toContainEqual({
+			key: VERDICT,
+			purpose: expect.any(String),
+			producers: expect.arrayContaining(["review"]),
+			consumers: expect.arrayContaining(["ship"]),
+		});
+	});
+});
+
+/**
+ * The seam's own test: a second format reaches every verb through its registry row alone.
+ *
+ * If any assertion here needed a branch in `read-verb.ts` / `check-verb.ts` / `emit-verb.ts` to
+ * pass, the registry would not be the landing surface it claims to be — so these cases are as much
+ * about the adapter as about the marker.
+ */
+describe("a second format on the same seam", () => {
+	const HEAD = "03135b91e7d4a2c6f1b8093a5c4d2e1f6a7b8c9d";
+	const MARKER = `review-code: PASS @ ${HEAD} — merge-ready\n`;
+
+	it("answers a conforming marker through the SAME read verb, exit 0", async () => {
+		const out = await read(piped(MARKER), VERDICT);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe(
+			`found\t${VERDICT}\t4\nnamespace\treview-code\npolarity\tPASS\nsha\t${HEAD}\nclause\tmerge-ready\n`,
+		);
+	});
+
+	it("seats a comment with no marker on ABSENT and a drifted marker on MALFORMED", async () => {
+		expect((await read(piped("looks good to me\n"), VERDICT)).code).toBe(ABSENT);
+		expect((await read(piped("review-code: PASS — merge-ready\n"), VERDICT)).code).toBe(MALFORMED);
+	});
+
+	it("refuses an artifact it never saw as UNKNOWN rather than as an unreviewed PR", async () => {
+		expect((await read(readFailed, VERDICT)).code).toBe(ARTIFACT_UNKNOWN);
+		expect((await read(piped("  \n"), VERDICT)).code).toBe(EMPTY_ARTIFACT);
+	});
+
+	it("checks and emits on the same taxonomy, and `emit` round-trips through `read`", async () => {
+		expect((await check(piped(MARKER), VERDICT)).code).toBe(ANSWER);
+		const composed = await emit(
+			piped(`namespace: review-code\npolarity: PASS\nsha: ${HEAD}\nclause: merge-ready\n`),
+			VERDICT,
+		);
+		expect(composed.code).toBe(ANSWER);
+		expect(composed.stdout).toBe(MARKER);
+		expect((await read(piped(composed.stdout), VERDICT)).code).toBe(ANSWER);
+	});
+
+	it("refuses fields that compose no bound marker, on the shared UNUSABLE_FIELDS code", async () => {
+		const out = await emit(
+			piped("namespace: review-code\npolarity: PASS\nclause: merge-ready\n"),
+			VERDICT,
+		);
+		expect(out.code).toBe(UNUSABLE_FIELDS);
+		expect(out.stdout).toBe("");
 	});
 });
 

--- a/packages/fabrika-cli/src/wire/verdict-marker.ts
+++ b/packages/fabrika-cli/src/wire/verdict-marker.ts
@@ -1,0 +1,316 @@
+/**
+ * The verdict marker — the recognizable first line of a gate's verdict comment on a PR.
+ *
+ *     review-code: PASS @ 03135b91 — merge-ready
+ *
+ * Four fields: the gate **namespace**, the **polarity**, the **head SHA the reviewer inspected**,
+ * and the trailing human clause. The SHA is the load-bearing one. A verdict attests the exact tree
+ * it was formed over, so a marker bound to a head that has since moved is *stale*, not passing — and
+ * a marker carrying no SHA at all is malformed, not passing either. Both are refusals here rather
+ * than values a caller could mistake for a current PASS: {@link read} never yields a `Found` with an
+ * empty SHA (the type forbids it — {@link HeadSha} has no empty inhabitant), and {@link bindToHead}
+ * answers the staleness question as its own third outcome instead of folding it into the read.
+ *
+ * `read` is total and its three answers are the design (see `./format.ts`). The discrimination that
+ * carries the weight is **Absent vs Malformed**: bytes carrying no marker of this format at all are
+ * `Absent`; bytes carrying something recognisably *reaching* for one — the namespace is there but
+ * the polarity is unknown, the SHA is missing or not hex, the clause is gone — are `Malformed`. A
+ * gate whose marker drifted must never read as a PR nobody reviewed.
+ *
+ * v1's `claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md` §VERDICT and
+ * `packages/pipeline-cli/src/tools/verdict/verdict-match.ts` are where the semantics and the scars
+ * come from — read as prior art, never called (ADR 0238). v1's upsert keying, its advisory line and
+ * its read-back guard are deliberately not carried here.
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+
+declare const HEAD_SHA: unique symbol;
+declare const CLAUSE: unique symbol;
+
+/**
+ * A git object name the marker is bound to: 7–40 hex characters, lowercased.
+ *
+ * Branded so a `Found` cannot carry `""`. The abbreviation floor is 7 because that is what git
+ * itself abbreviates to and what v1's scanner accepted; shorter is ambiguous across a real
+ * repository, and an ambiguous binding is not a binding.
+ */
+export type HeadSha = string & {readonly [HEAD_SHA]: true};
+
+/** The trailing human clause. Branded for the same reason: a blank clause is not a clause. */
+export type Clause = string & {readonly [CLAUSE]: true};
+
+/** The reviewer's go/no-go. A third token is not a polarity — it is a drift. */
+export type Polarity = "PASS" | "FAIL";
+
+export interface VerdictMarker {
+	/** The gate that formed the verdict: `review`, or `review-<gate>`. */
+	readonly namespace: string;
+	readonly polarity: Polarity;
+	readonly sha: HeadSha;
+	readonly clause: Clause;
+}
+
+export type VerdictMarkerRead = WireRead<VerdictMarker>;
+
+const SHA_MIN = 7;
+const SHA_MAX = 40;
+
+const NAMESPACE = /^review(-[a-z0-9]+)*$/;
+const HEX = /^[0-9a-f]+$/;
+
+/** The conforming separator between the SHA and the clause; the ASCII dashes are read tolerantly. */
+export const CLAUSE_SEPARATOR = "—";
+const SEPARATOR = /^(?:—|–|--|-)\s*/;
+
+/**
+ * The emphasis a skill's bolding adds, and the `<namespace>:` prefix.
+ *
+ * The namespace class is deliberately wider than {@link NAMESPACE}: a token this admits and
+ * {@link NAMESPACE} rejects becomes a `Malformed` naming the drift, one this turns away becomes an
+ * `Absent`. Erring wide is what keeps `review_code:` from being reported as "no verdict here".
+ */
+const MARKER_LINE = /^\s*(\*{0,2})\s*([A-Za-z0-9_-]+)\s*:\s*(.*)$/;
+
+export const headSha = (raw: string): HeadSha | null => {
+	const value = raw.trim().toLowerCase();
+	if (value.length < SHA_MIN || value.length > SHA_MAX || !HEX.test(value)) return null;
+	return value as HeadSha;
+};
+
+export const clause = (raw: string): Clause | null => {
+	const value = raw.trim();
+	return value === "" ? null : (value as Clause);
+};
+
+const polarityOf = (token: string): Polarity | null => {
+	const value = token.toUpperCase();
+	return value === "PASS" || value === "FAIL" ? value : null;
+};
+
+const malformed = (reason: string, evidence: string): VerdictMarkerRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+/** The marker is the artifact's first non-blank line — a marker merely quoted further down is not one. */
+const firstNonBlankLine = (artifact: string): string | null =>
+	artifact.split("\n").find((line) => line.trim() !== "") ?? null;
+
+const takeToken = (rest: string): {readonly token: string; readonly after: string} => {
+	const trimmed = rest.trimStart();
+	const end = trimmed.search(/\s/);
+	return end === -1
+		? {token: trimmed, after: ""}
+		: {token: trimmed.slice(0, end), after: trimmed.slice(end)};
+};
+
+/**
+ * Read the verdict marker out of a comment body. Total: `Found` | `Absent` | `Malformed`.
+ *
+ * The walk is stepwise rather than one regex so each refusal can name *which* field drifted; a
+ * single alternation would collapse "no SHA" and "unknown polarity" into one unhelpful non-match,
+ * and telling a reviewer which half of its own marker is wrong is the whole value of the refusal.
+ */
+export const read = (artifact: string): VerdictMarkerRead => {
+	const line = firstNonBlankLine(artifact);
+	if (line === null) {
+		return {_tag: "Absent", reason: "the artifact holds no non-blank line to carry a marker"};
+	}
+
+	const matched = MARKER_LINE.exec(line);
+	const namespace = matched?.[2]?.toLowerCase() ?? "";
+	if (matched === undefined || matched === null || !namespace.startsWith("review")) {
+		return {
+			_tag: "Absent",
+			reason: 'the first line does not open with a "review…:" namespace — no marker of this format',
+		};
+	}
+	const evidence = `first line: "${line.trim()}"`;
+	if (!NAMESPACE.test(namespace)) {
+		return malformed(
+			`the gate namespace "${namespace}" is not kebab-case "review" or "review-<gate>"`,
+			evidence,
+		);
+	}
+
+	const emphasis = matched[1] ?? "";
+	const rest = matched[3] ?? "";
+	const {token: polarityToken, after: afterPolarity} = takeToken(rest);
+	if (polarityToken === "") {
+		return malformed(`"${namespace}:" carries no polarity — expected PASS or FAIL`, evidence);
+	}
+	const polarity = polarityOf(polarityToken);
+	if (polarity === null) {
+		return malformed(`"${polarityToken}" is not a polarity — expected PASS or FAIL`, evidence);
+	}
+
+	const bound = afterPolarity.trimStart();
+	if (!bound.startsWith("@")) {
+		return malformed(
+			`the ${polarity} marker is bound to no head SHA — a verdict with no "@ <sha>" attests no tree`,
+			evidence,
+		);
+	}
+	const {token: shaToken, after: afterSha} = takeToken(bound.slice(1));
+	if (shaToken === "") {
+		return malformed(
+			`the ${polarity} marker's "@" is followed by no SHA — a verdict with no head attests no tree`,
+			evidence,
+		);
+	}
+	const sha = headSha(shaToken);
+	if (sha === null) {
+		return malformed(
+			`"${shaToken}" is not a head SHA — expected ${SHA_MIN}–${SHA_MAX} hex characters`,
+			evidence,
+		);
+	}
+
+	// A skill that bolds the whole marker closes it after the clause, so that closer belongs to the
+	// emphasis rather than to the human's sentence. Stripped only when the line opened with one.
+	const tail = afterSha.trim();
+	const unemphasized =
+		emphasis !== "" && tail.endsWith(emphasis) ? tail.slice(0, -emphasis.length) : tail;
+	const text = clause(unemphasized.replace(SEPARATOR, ""));
+	if (text === null) {
+		return malformed(
+			"the marker carries no trailing clause — the one field that says what the verdict means to a human",
+			evidence,
+		);
+	}
+
+	return {_tag: "Found", value: {namespace, polarity, sha, clause: text}};
+};
+
+/** Compose the marker's first line. Round-trips through {@link read}. */
+export const emit = ({namespace, polarity, sha, clause: text}: VerdictMarker): string =>
+	`${namespace}: ${polarity} @ ${sha} ${CLAUSE_SEPARATOR} ${text}\n`;
+
+/**
+ * Whether a marker is bound to the head a caller holds — the question the SHA field exists for.
+ *
+ * Deliberately **not** an outcome of {@link read}: staleness is not a property of the bytes, it is a
+ * relation between the marker and a head only the caller knows. Equally deliberately three answers
+ * rather than a boolean — a caller handed a head it could not resolve gets `Unbindable`, never
+ * `Stale` and never `Current`, because a comparison that could not be made is not a negative result.
+ * Fold any two of these together and a stale PASS reads as a current one (ADR 0058).
+ */
+export type Binding =
+	| {readonly _tag: "Current"; readonly sha: HeadSha}
+	| {readonly _tag: "Stale"; readonly markerSha: HeadSha; readonly head: HeadSha}
+	| {readonly _tag: "Unbindable"; readonly reason: string};
+
+/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+export const bindToHead = (marker: VerdictMarker, head: string): Binding => {
+	const resolved = headSha(head);
+	if (resolved === null) {
+		return {
+			_tag: "Unbindable",
+			reason: `"${head.trim()}" is not a head SHA — the marker's binding cannot be judged`,
+		};
+	}
+	const current = marker.sha.startsWith(resolved) || resolved.startsWith(marker.sha);
+	return current
+		? {_tag: "Current", sha: marker.sha}
+		: {_tag: "Stale", markerSha: marker.sha, head: resolved};
+};
+
+export type VerdictMarkerFields =
+	| {readonly _tag: "Fields"; readonly marker: VerdictMarker}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+/** `<key>: <value>` or `<key><TAB><value>`, so `wire read`'s own output pipes back into `wire emit`. */
+const FIELD_LINE = /^([A-Za-z-]+)[ \t]*[:\t][ \t]*(.*)$/;
+const KEYS = ["namespace", "polarity", "sha", "clause"] as const;
+type FieldKey = (typeof KEYS)[number];
+
+const isFieldKey = (key: string): key is FieldKey => (KEYS as ReadonlyArray<string>).includes(key);
+
+/**
+ * Parse `emit`'s stdin into a marker: one `<key>: <value>` per line, in any order.
+ *
+ * Every rejection here is a refusal rather than a default. A missing `sha` that silently composed
+ * an unbound marker, or an unknown key silently dropped, is how a caller emits a verdict weaker than
+ * the one it wrote — and the emitted bytes would look perfectly well-formed.
+ */
+export const parseFields = (fields: string): VerdictMarkerFields => {
+	const seen = new Map<FieldKey, string>();
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const matched = FIELD_LINE.exec(line);
+		const key = matched?.[1]?.toLowerCase() ?? "";
+		if (matched === null || !isFieldKey(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `line ${index + 1} is not a "<field>: <value>" line over ${KEYS.join(", ")}: "${line}"`,
+			};
+		}
+		if (seen.has(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `"${key}" is given twice — which one is the field is undecidable`,
+			};
+		}
+		seen.set(key, matched[2] ?? "");
+	}
+
+	const missing = KEYS.filter((key) => (seen.get(key) ?? "").trim() === "");
+	if (missing.length > 0) {
+		return {
+			_tag: "Unusable",
+			reason: `no value for ${missing.join(", ")} — every field is required`,
+		};
+	}
+
+	const namespace = (seen.get("namespace") ?? "").trim().toLowerCase();
+	if (!NAMESPACE.test(namespace)) {
+		return {
+			_tag: "Unusable",
+			reason: `"${namespace}" is not a "review" or "review-<gate>" namespace`,
+		};
+	}
+	const polarity = polarityOf((seen.get("polarity") ?? "").trim());
+	if (polarity === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("polarity")}" is not a polarity — expected PASS or FAIL`,
+		};
+	}
+	const sha = headSha(seen.get("sha") ?? "");
+	if (sha === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("sha")}" is not a head SHA — expected ${SHA_MIN}–${SHA_MAX} hex characters`,
+		};
+	}
+	const text = clause(seen.get("clause") ?? "");
+	if (text === null) {
+		return {_tag: "Unusable", reason: "the trailing clause is blank"};
+	}
+	return {_tag: "Fields", marker: {namespace, polarity, sha, clause: text}};
+};
+
+/** One `<field>\t<value>` line per field — the `wire read` answer for this format. */
+export const renderMarker = (marker: VerdictMarker): NonEmptyReadonlyArray<string> => [
+	`namespace\t${marker.namespace}`,
+	`polarity\t${marker.polarity}`,
+	`sha\t${marker.sha}`,
+	`clause\t${marker.clause}`,
+];
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.marker)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderMarker(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/verdict-marker.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/verdict-marker.unit.test.ts
@@ -1,0 +1,292 @@
+/**
+ * The schema module's own tier: `emit`, the three answers `read` may give, and the binding.
+ *
+ * The assertions that carry the design are the drift cases and the staleness cases. Each drift feeds
+ * a line a lenient reader would answer "PASS" for — the SHA missing, the SHA truncated, the polarity
+ * a word nobody defined — and asserts `Malformed`, because the failure this module removes is not a
+ * crash, it is a *plausible* verdict. The binding cases assert the same thing one level up: a marker
+ * bound to a head that moved is `Stale`, and a head that cannot be resolved is `Unbindable`, so
+ * neither can be read as a current PASS.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	bindToHead,
+	clause,
+	emit,
+	emitFromFields,
+	headSha,
+	parseFields,
+	read,
+	readToLines,
+	renderMarker,
+	type VerdictMarker,
+} from "./verdict-marker.ts";
+
+const sha = (raw: string) => {
+	const value = headSha(raw);
+	if (value === null) throw new Error(`fixture is not a head SHA: ${raw}`);
+	return value;
+};
+const text = (raw: string) => {
+	const value = clause(raw);
+	if (value === null) throw new Error("fixture clause is blank");
+	return value;
+};
+
+const HEAD = "03135b91e7d4a2c6f1b8093a5c4d2e1f6a7b8c9d";
+
+const MARKER: VerdictMarker = {
+	namespace: "review-code",
+	polarity: "PASS",
+	sha: sha(HEAD),
+	clause: text("merge-ready"),
+};
+
+const found = (artifact: string): VerdictMarker => {
+	const result = read(artifact);
+	if (result._tag !== "Found") throw new Error(`expected Found, got ${result._tag}`);
+	return result.value;
+};
+
+const drift = (name: string, line: string) => ({name, line});
+
+describe("emit", () => {
+	it("composes the one recognizable first line", () => {
+		expect(emit(MARKER)).toBe(`review-code: PASS @ ${HEAD} — merge-ready\n`);
+	});
+
+	it("round-trips: every field emitted is a field `read` recovers", () => {
+		const markers: ReadonlyArray<VerdictMarker> = [
+			MARKER,
+			{
+				namespace: "review",
+				polarity: "FAIL",
+				sha: sha("03135b9"),
+				clause: text("changes-requested — 2 criteria unmet, see the table below"),
+			},
+		];
+		for (const marker of markers) expect(found(emit(marker))).toEqual(marker);
+	});
+});
+
+describe("read — Found", () => {
+	it("recovers namespace, polarity, SHA and clause from a real verdict comment", () => {
+		expect(
+			found(`**review-code: FAIL @ ${HEAD} — not merge-ready**\n\n| criterion | verdict |\n`),
+		).toEqual({
+			namespace: "review-code",
+			polarity: "FAIL",
+			sha: sha(HEAD),
+			clause: text("not merge-ready"),
+		});
+	});
+
+	it("accepts a full 40-hex SHA and an abbreviated 7-hex SHA alike", () => {
+		expect(found(`review: PASS @ ${HEAD} — ok`).sha).toBe(HEAD);
+		expect(found("review: PASS @ 03135b9 — ok").sha).toBe("03135b9");
+	});
+
+	it("lowercases an upper-case SHA and an upper-case namespace rather than refusing them", () => {
+		const marker = found("REVIEW-CODE: pass @ 03135B9 — ok");
+		expect(marker.sha).toBe("03135b9");
+		expect(marker.namespace).toBe("review-code");
+		expect(marker.polarity).toBe("PASS");
+	});
+});
+
+describe("read — Absent", () => {
+	it("answers Absent for a comment that carries no marker of this format", () => {
+		const result = read("Nice work — one nit on the naming, otherwise this reads well.\n");
+		expect(result._tag).toBe("Absent");
+	});
+
+	it("answers Absent for a marker merely QUOTED further down, never Found", () => {
+		const result = read(
+			`The convention is:\n\n> review-code: PASS @ ${HEAD} — merge-ready\n\nnot what I posted.\n`,
+		);
+		expect(result._tag).toBe("Absent");
+	});
+
+	it("answers Absent for an empty artifact rather than inventing a malformed one", () => {
+		expect(read("\n   \n")._tag).toBe("Absent");
+	});
+});
+
+describe("read — Malformed: the drifts a lenient reader answers `PASS` for", () => {
+	const DRIFTS = [
+		drift("no SHA at all", "review-code: PASS — merge-ready"),
+		drift("an @ with nothing after it", "review-code: PASS @ — merge-ready"),
+		drift("a SHA one character under the floor", "review-code: PASS @ 03135b — merge-ready"),
+		drift("a SHA carrying a non-hex character", "review-code: PASS @ 03135bz — merge-ready"),
+		drift("a SHA longer than a git object name", `review-code: PASS @ ${HEAD}00 — merge-ready`),
+		drift("a polarity nobody defined", `review-code: APPROVED @ ${HEAD} — merge-ready`),
+		drift("a polarity that is only a near-miss", `review-code: PASSED @ ${HEAD} — merge-ready`),
+		drift("no polarity at all", `review-code: @ ${HEAD} — merge-ready`),
+		drift("a namespace that lost its hyphen", `reviewcode: PASS @ ${HEAD} — merge-ready`),
+		drift("a namespace in snake_case", `review_code: PASS @ ${HEAD} — merge-ready`),
+		drift("no trailing clause", `review-code: PASS @ ${HEAD}`),
+		drift("a separator with no clause after it", `review-code: PASS @ ${HEAD} —`),
+	];
+
+	for (const {name, line} of DRIFTS) {
+		it(`${name} is Malformed — never Found, never Absent`, () => {
+			const result = read(`${line}\n`);
+			expect(result._tag).toBe("Malformed");
+			if (result._tag !== "Malformed") return;
+			expect(result.evidence).toContain(line.trim());
+			expect(result.reason).not.toBe("");
+		});
+	}
+
+	it("names the missing SHA specifically, so a reviewer learns WHICH half drifted", () => {
+		const result = read("review-code: PASS — merge-ready\n");
+		if (result._tag !== "Malformed") throw new Error("expected Malformed");
+		expect(result.reason).toContain("head SHA");
+	});
+
+	it("names the unrecognized polarity token specifically", () => {
+		const result = read(`review-code: APPROVED @ ${HEAD} — merge-ready\n`);
+		if (result._tag !== "Malformed") throw new Error("expected Malformed");
+		expect(result.reason).toContain("APPROVED");
+	});
+});
+
+describe("read — Absent and Malformed are two answers, not one collapsed negative", () => {
+	it("keeps a body with no marker apart from a body whose marker drifted", () => {
+		const noMarker = read("Looks good to me, shipping it.\n");
+		const drifted = read("review-code: PASS — merge-ready\n");
+		expect(noMarker._tag).toBe("Absent");
+		expect(drifted._tag).toBe("Malformed");
+		expect(noMarker._tag).not.toBe(drifted._tag);
+	});
+
+	it("never answers Found for either, so no caller reads a drift as an unreviewed PR", () => {
+		for (const artifact of [
+			"chatter with no marker",
+			"review: PASS — no sha",
+			"review: OK @ 03135b9 — x",
+		]) {
+			expect(read(artifact)._tag).not.toBe("Found");
+		}
+	});
+});
+
+describe("bindToHead — stale is its own outcome, never a PASS and never an absence", () => {
+	it("answers Current when the marker's SHA is the head", () => {
+		expect(bindToHead(MARKER, HEAD)).toEqual({_tag: "Current", sha: HEAD});
+	});
+
+	it("answers Current across an abbreviation, in either direction", () => {
+		expect(bindToHead(MARKER, "03135b9")._tag).toBe("Current");
+		expect(bindToHead({...MARKER, sha: sha("03135b9")}, HEAD)._tag).toBe("Current");
+	});
+
+	it("answers Stale for a head that moved under the verdict — the PASS does not survive it", () => {
+		const binding = bindToHead(MARKER, "7d588903c1a2b3d4e5f60718293a4b5c6d7e8f90");
+		expect(binding._tag).toBe("Stale");
+		if (binding._tag !== "Stale") return;
+		expect(binding.markerSha).toBe(HEAD);
+	});
+
+	it("answers Unbindable for a head it cannot resolve — a comparison it could not make is not a negative", () => {
+		for (const head of ["", "HEAD", "not-a-sha", "03135b"]) {
+			expect(bindToHead(MARKER, head)._tag).toBe("Unbindable");
+		}
+	});
+
+	it("keeps Current, Stale and Unbindable pairwise distinct", () => {
+		const tags = [
+			bindToHead(MARKER, HEAD)._tag,
+			bindToHead(MARKER, "7d588903")._tag,
+			bindToHead(MARKER, "HEAD")._tag,
+		];
+		expect(new Set(tags).size).toBe(tags.length);
+	});
+});
+
+describe("parseFields", () => {
+	it("takes the four fields in any order, as `<key>: <value>` or `<key><TAB><value>`", () => {
+		expect(
+			parseFields(`clause: merge-ready\nsha\t${HEAD}\npolarity: PASS\nnamespace: review-code\n`),
+		).toEqual({_tag: "Fields", marker: MARKER});
+	});
+
+	it("refuses a missing field rather than composing a weaker marker than the caller wrote", () => {
+		const parsed = parseFields("namespace: review-code\npolarity: PASS\nclause: merge-ready\n");
+		expect(parsed._tag).toBe("Unusable");
+		if (parsed._tag !== "Unusable") return;
+		expect(parsed.reason).toContain("sha");
+	});
+
+	it("refuses a SHA the marker could not be bound by", () => {
+		expect(parseFields("namespace: review\npolarity: PASS\nsha: 03135b\nclause: ok\n")._tag).toBe(
+			"Unusable",
+		);
+	});
+
+	it("refuses an unknown polarity", () => {
+		expect(parseFields(`namespace: review\npolarity: MAYBE\nsha: ${HEAD}\nclause: ok\n`)._tag).toBe(
+			"Unusable",
+		);
+	});
+
+	it("refuses a duplicated field instead of letting one silently win", () => {
+		const parsed = parseFields(
+			`namespace: review\nnamespace: review-code\npolarity: PASS\nsha: ${HEAD}\nclause: ok\n`,
+		);
+		expect(parsed._tag).toBe("Unusable");
+		if (parsed._tag !== "Unusable") return;
+		expect(parsed.reason).toContain("twice");
+	});
+
+	it("refuses an unknown key rather than dropping the line", () => {
+		expect(
+			parseFields(`namespace: review\npolarity: PASS\nsha: ${HEAD}\nclause: ok\nrun: 42\n`)._tag,
+		).toBe("Unusable");
+	});
+});
+
+describe("the registry row's byte-level pair", () => {
+	it("renders one `<field>\\t<value>` line per field", () => {
+		expect(renderMarker(MARKER)).toEqual([
+			"namespace\treview-code",
+			"polarity\tPASS",
+			`sha\t${HEAD}`,
+			"clause\tmerge-ready",
+		]);
+	});
+
+	it("round-trips fields → bytes → lines through the pair the registry binds", () => {
+		const composed = emitFromFields(
+			`namespace: review\npolarity: FAIL\nsha: ${HEAD}\nclause: two unmet\n`,
+		);
+		expect(composed._tag).toBe("Composed");
+		if (composed._tag !== "Composed") return;
+		expect(readToLines(composed.bytes)).toEqual({
+			_tag: "Found",
+			value: ["namespace\treview", "polarity\tFAIL", `sha\t${HEAD}`, "clause\ttwo unmet"],
+		});
+	});
+});
+
+describe("the type forbids the values a lenient reader would invent", () => {
+	it("does not admit a Found carrying an empty SHA", () => {
+		const counterexample = {
+			_tag: "Found",
+			// @ts-expect-error — `""` is not a HeadSha, so "found with no binding" is unrepresentable
+			value: {namespace: "review", polarity: "PASS", sha: "", clause: text("ok")},
+		} satisfies {_tag: "Found"; value: VerdictMarker};
+		expect(counterexample._tag).toBe("Found");
+	});
+
+	it("does not admit a polarity outside PASS / FAIL", () => {
+		const counterexample = {
+			// @ts-expect-error — "APPROVED" is not a Polarity
+			polarity: "APPROVED",
+			namespace: "review",
+			sha: sha(HEAD),
+			clause: text("ok"),
+		} satisfies VerdictMarker;
+		expect(counterexample.namespace).toBe("review");
+	});
+});


### PR DESCRIPTION
This adds the second wire format to fabrika's CLI: the verdict marker, the recognizable first line of a gate's verdict comment on a PR (`review-code: PASS @ <sha> — merge-ready`). It lands as a new schema module plus exactly one row in the format registry — no verb gained a branch to serve it, which is the property this child exists to test. The format matters now because the `review` skill authoring brief (#4907) is blocked until both the acceptance-criteria block and this marker exist for it to cite; with this merged, that gate is clear.

The load-bearing part is the head SHA. A verdict attests the exact tree the reviewer looked at, so a marker bound to a head that has since moved is stale, not passing — and a marker with no SHA at all is malformed, not passing either. Both are refusals rather than values a caller could mistake for a current PASS.

Fixes #4943

## What changed

- **`packages/fabrika-cli/src/wire/verdict-marker.ts`** — the schema module. Four fields (gate namespace, polarity, head SHA, trailing clause), an `emit`, and a total `read` returning the same `Found | Absent | Malformed` union the founding format uses.
- **`packages/fabrika-cli/src/wire/registry.ts`** — one row: `verdict-marker`, producers `review`, consumers `build`/`ship`. Nothing else changed in the adapter; the `--format` help text already interpolates the registered keys, so `wire formats`, `wire --help`, `emit`, `read` and `check` pick the row up derived.
- **`packages/fabrika-cli/src/wire/verdict-marker.unit.test.ts`** — the module tier: the round-trip, twelve named drift fixtures, the Absent-vs-Malformed distinctness assertion, the binding cases, and two compile-time counterexamples.
- **`packages/fabrika-cli/src/wire/verbs.unit.test.ts`** — the adapter tier for the second format: the exit taxonomy answered through the same verbs, and the `formats` row.
- **`packages/fabrika-cli/README.md`** — one bullet on the marker's SHA binding.

## How the invariant is held

Stage 1's law is *a check that cannot see what it is looking for must never return a plausible value*. This module inherits it at three levels rather than restating it:

- **At the type level.** `HeadSha` and `Clause` are branded string types with no empty inhabitant, so `{_tag: "Found", value: {…, sha: ""}}` does not typecheck — the same shape `NonEmptyReadonlyArray` gives the founding format. Two `@ts-expect-error` counterexamples in the test file assert this compiles as an error, and `pnpm typecheck` fails if either stops erroring.
- **At the read.** A comment carrying no marker is `Absent`; a line reaching for the namespace and missing — no SHA, a short or non-hex SHA, an unknown polarity, a broken namespace, a missing clause — is `Malformed`. The namespace matcher is deliberately wider than the conforming grammar so a drift lands on `Malformed` rather than being reported as "no verdict here".
- **At the binding.** Staleness is modelled as its own outcome, not folded into the read: `bindToHead(marker, head)` answers `Current` / `Stale` / `Unbindable`. A head the caller could not resolve is `Unbindable` — a comparison nobody made is not a negative result. A test asserts the three tags are pairwise distinct, which is the property a future edit could quietly lose.

`pnpm typecheck`, `pnpm lint:worktree` and the full `fabrika-cli` suite (1062 tests) are green.

## Deviations

**1. Phase-2 eligibility — Phase 1 is not fully closed.**
*Said:* the epic's `## Dependencies` puts #4943 in Phase 2, and a Phase-2 child with no `requires:` waits on all of Phase 1.
*Did:* implemented it with #4942 closed but #4946 (the ADR recording the ownership law) still open.
*Why:* the dispatch handed me #4943 explicitly with a delegated claim token, and the epic's own plan states #4946 "is independent of all of it — it records a ruling already made — so it runs in parallel from the start." No artifact in this diff depends on the ADR.
*Disposition:* for the reviewer to judge — the code dependency (#4942) is satisfied; the topology edge to #4946 is not.

**2. The trailing clause is required, which is stricter than v1.**
*Said:* the issue lists the trailing human clause as one of the marker's fields and does not say what a missing one means.
*Did:* a marker with no clause reads `Malformed`, and `emit` refuses a blank one.
*Why:* the alternative is a `Found` carrying `clause: ""` — precisely the plausible-empty value this epic exists to remove. v1's scanner ignores everything after the SHA, so this is a deliberate tightening rather than a port.
*Disposition:* for the reviewer to judge; reversing it means giving the clause an explicit present/absent tag, never an empty string.

**3. `bindToHead` is beyond the issue's literal acceptance criteria.**
*Said:* the ACs cover the field type, `emit`, `read`, the registry row and the CLI taxonomy.
*Did:* also exported a total `bindToHead` returning `Current` / `Stale` / `Unbindable`.
*Why:* the SHA field is only load-bearing if something can ask the staleness question, and leaving it to each consumer is how a stale PASS gets read as current. It is pure, tested, and adds no verb.
*Disposition:* no action needed — additive and covered.

**4. v1 paths cited in a docblock.**
*Said:* ADR 0238 permits reading v1 and bans invoking or wrapping it.
*Did:* the module's header names `claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md` §VERDICT and `packages/pipeline-cli/src/tools/verdict/verdict-match.ts` as the prior art the semantics came from.
*Why:* inert prose only — no import, no exec, no build edge, matching the founding module's own header. A grep of the changed files finds these two comment lines and nothing else.
*Disposition:* no action needed.

**5. The registry row names skills that do not exist yet.**
*Said:* the row carries producers and consumers.
*Did:* `producers: ["review"]`, `consumers: ["build", "ship"]` — none of which is an authored fabrika skill today.
*Why:* the founding row does the same (`build-epic`, `build`, `review`); the field records the seam's intended ends, and #4907 is the dated first producer.
*Disposition:* no action needed.

**6. No new subprocess test.**
*Said:* the package's `.cli.test.ts` proves exit status and exact stdout bytes end to end.
*Did:* covered the new format at the in-process adapter tier (`verbs.unit.test.ts`) and added no spawn.
*Why:* `.patterns/subprocess-test-budget.md` — each spawn costs a cold load, and the existing two spawns already prove the adapter's status/stdout wiring; a second format exercises the same code path through a registry row. Verified by hand that `wire read`, `wire check` and `wire formats` answer correctly from the real binary.
*Disposition:* for the reviewer to judge.

**7. One README bullet no AC asked for.**
*Said:* keep the README truthful.
*Did:* added a bullet on the marker's SHA binding and `bindToHead` to the `wire` group section.
*Why:* the section already promised "the verdict marker on a PR"; a caller reading `found` as "current" is the mistake worth naming there.
*Disposition:* no action needed.