### PR TITLE
fix(fabrika-cli): refuse to delegate when the invoked copy is in another checkout (#4956)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -40,7 +40,7 @@ copy of `@kampus/fabrika-cli` that root has installed, and hands the invocation 
 shape [turbo](https://turborepo.com) ships (`crates/turborepo-shim/`), reimplemented here in
 TypeScript ([#4784](https://github.com/kamp-us/phoenix/issues/4784)).
 
-There are exactly three outcomes, and **only one of them is silent**:
+**No outcome is both silent and wrong**:
 
 | Where you are | What runs | Warning |
 | --- | --- | --- |
@@ -48,11 +48,21 @@ There are exactly three outcomes, and **only one of them is silent**:
 | In a consumer repo that installed it | that repo's pinned version | — |
 | In a consumer repo that did **not** install it | the global | **yes**, naming both versions |
 | In no repo at all | the global | no — deliberately |
+| Running a **different checkout's** copy by path | nothing — it refuses, exit `2` | **yes**, naming both checkouts |
 
-The last two are the whole design. Running the global outside any repo is a normal, correct
-invocation, so it stays quiet. Running the global *inside a repo that asked for a specific version*
-is the quietly-wrong case, so it says so out loud and names the global's version beside the one the
-root manifest declared. Set `FABRIKA_GLOBAL_WARNING_DISABLED=1` to silence it.
+Rows three and four are the original design. Running the global outside any repo is a normal,
+correct invocation, so it stays quiet. Running the global *inside a repo that asked for a specific
+version* is the quietly-wrong case, so it says so out loud and names the global's version beside the
+one the root manifest declared. Set `FABRIKA_GLOBAL_WARNING_DISABLED=1` to silence it.
+
+The last row closes the one case that used to be quietly wrong ([#4956](https://github.com/kamp-us/phoenix/issues/4956)).
+`node <other-checkout>/packages/fabrika-cli/src/bin.ts` run from a cwd inside *this* checkout looked
+exactly like a global install on `PATH`, so it delegated — and answered from the checkout you did
+not name, with no warning at all. It is a live hazard for anyone reviewing from a worktree: the CLI
+reports the state of `main` while you are reading a branch. The two are separated by asking which
+checkout the *invoked copy* belongs to; an installed copy (anything under `node_modules`) belongs to
+none, which is what keeps the global-install delegation exactly as it was. Either run it from inside
+its own checkout, or pass `--skip-infer` to make the copy you named serve the invocation.
 
 The property this buys is a **repo-pinned version**. phoenix carries `@kampus/fabrika-cli` in its
 root `devDependencies`, so a bare `fabrika` anywhere in a phoenix checkout runs the version this

--- a/packages/fabrika-cli/src/delegate/entry.ts
+++ b/packages/fabrika-cli/src/delegate/entry.ts
@@ -13,6 +13,7 @@ import {VERSION} from "../version.ts";
 import {declaredVersion, probeLocalInstall} from "./local.ts";
 import {
 	DEBUG_ENV,
+	foreignCheckoutRefusal,
 	GLOBAL_WARNING_DISABLED_ENV,
 	globalWarning,
 	resolve,
@@ -21,7 +22,7 @@ import {
 	spawnDelegate,
 	traceLine,
 } from "./resolve.ts";
-import {discoverRepoRoot} from "./root.ts";
+import {discoverRepoRoot, originOf} from "./root.ts";
 
 /** The running copy's own root could not be canonicalized — fatal, never a fallback. */
 export class RealPathFailed extends Schema.TaggedErrorClass<RealPathFailed>()(
@@ -62,13 +63,21 @@ const program = Effect.gen(function* () {
 				(cause) => new RealPathFailed({path: own, reason: cause.message}),
 			),
 		);
+	// Both walks stay on the `E` channel, so an ancestor that cannot be probed ends the run with the
+	// diagnostic below. An unreadable origin must never soften into "no checkout", which reads as the
+	// global install and re-opens the branch #4956 closed.
+	const selfOrigin = yield* originOf(selfPackageRoot);
 	const invocationDir = process.cwd();
 	const repoRoot = yield* discoverRepoRoot(invocationDir);
 	const local = repoRoot === undefined ? undefined : yield* probeLocalInstall(repoRoot);
-	const resolution = resolve({selfPackageRoot, repoRoot, local});
+	const resolution = resolve({selfPackageRoot, selfOrigin, repoRoot, local});
 
 	if (process.env[DEBUG_ENV] !== undefined) console.error(traceLine(selfPackageRoot, resolution));
 
+	if (resolution._tag === "refuse-foreign-checkout") {
+		console.error(foreignCheckoutRefusal(resolution));
+		return {_tag: "exited", status: 2} as const;
+	}
 	if (resolution._tag === "run-here") return undefined;
 	if (resolution._tag === "warn-and-run-here") {
 		if (process.env[GLOBAL_WARNING_DISABLED_ENV] === undefined) {
@@ -132,7 +141,7 @@ export const delegateOrRunHere = async (): Promise<void> => {
 	}
 	console.error(
 		`fabrika: could not resolve which copy to run.\n` +
-			`  looked for a repo root above: ${process.cwd()}\n` +
+			`  looked for a repo root above your cwd (${process.cwd()}) and above the invoked copy (${packageRootUrl.href})\n` +
 			`  stopped at: ${outcome.failed}\n` +
 			`  cause: ${outcome.reason}`,
 	);

--- a/packages/fabrika-cli/src/delegate/foreign-checkout.cli.test.ts
+++ b/packages/fabrika-cli/src/delegate/foreign-checkout.cli.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The end-to-end half of the foreign-checkout refusal: a real process, invoked exactly the way the
+ * defect was met (#4956).
+ *
+ * A reviewer gating a PR runs from an isolated worktree and invokes the head's `bin.ts` **by path**.
+ * The cwd then sits in a different checkout, whose own install answers instead — silently, with a
+ * plausible result. The unit tests decide the branch; only a spawn proves the copy on disk obeys it,
+ * because the delegation's whole failure mode is that both copies print the same bytes.
+ */
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+
+/** Spawning under a loaded machine outruns vitest's 5s default (the #4014 false red). */
+const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+/** What the other checkout's install prints if it is ever allowed to answer. */
+const IMPOSTER = "answered-from-the-cwd-checkout";
+
+let consumer: string;
+
+beforeAll(() => {
+	consumer = mkdtempSync(join(tmpdir(), "fabrika-foreign-"));
+	const installed = join(consumer, "node_modules", "@kampus", "fabrika-cli");
+	mkdirSync(installed, {recursive: true});
+	writeFileSync(join(consumer, "package.json"), '{"name":"consumer","version":"0.0.0"}\n');
+	writeFileSync(join(installed, "bin.js"), `console.log(${JSON.stringify(IMPOSTER)});\n`);
+	writeFileSync(
+		join(installed, "package.json"),
+		'{"name":"@kampus/fabrika-cli","version":"9.9.9","bin":{"fabrika":"./bin.js"}}\n',
+	);
+});
+
+afterAll(() => rmSync(consumer, {recursive: true, force: true}));
+
+const invokeFromConsumer = (...args: ReadonlyArray<string>) => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			cwd: consumer,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("invoking this checkout's bin from a cwd in another checkout", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+	// The bin's own delegation is what is under test, so the guard that pins an invocation to this
+	// copy has to stay unset — and vitest inherits the parent env.
+	skip: process.env.FABRIKA_SKIP_INFER !== undefined,
+}, () => {
+	it("refuses instead of answering, and never lets the cwd's install speak", () => {
+		const run = invokeFromConsumer("--version");
+		expect(run.stdout).not.toContain(IMPOSTER);
+		expect(run.code).toBe(2);
+		expect(run.stderr).toContain("different checkouts");
+	});
+
+	it("names both checkouts in the refusal, so the caller can see which copy it declined", () => {
+		const run = invokeFromConsumer("--version");
+		expect(run.stderr).toContain(consumer);
+		expect(run.stderr).toContain(
+			fileURLToPath(new URL("../../", import.meta.url)).replace(/\/$/, ""),
+		);
+	});
+
+	it("still serves the invocation itself under --skip-infer — the refusal has a way out", () => {
+		const run = invokeFromConsumer("--skip-infer", "--version");
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("fabrika v");
+		expect(run.stdout).not.toContain(IMPOSTER);
+	});
+});

--- a/packages/fabrika-cli/src/delegate/resolve.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.ts
@@ -1,19 +1,22 @@
 /**
  * Decide, and then act on, which copy of `fabrika` serves this invocation.
  *
- * The decision is a pure function of four facts — where the running copy lives, whether there is a
- * repo root, what the root's install probe said, and what the root manifest declares — so every
+ * The decision is a pure function of four facts — where the running copy lives, *which checkout it
+ * belongs to*, whether the cwd has a repo root, and what that root's install probe said — so every
  * branch is testable without a filesystem.
  *
- * **Every branch ends in a working CLI, and only one of them is silent.** No repo root at all runs
- * the global with no warning, deliberately, so global-only invocations still work. A repo root whose
- * local install is missing or corrupt runs the global too, but *says so loudly* — that pairing is
- * the whole design: tiers that can only be right or loudly absent are fine; tiers that can be
- * quietly wrong are the defect (#4784).
+ * **No branch is both silent and wrong.** No repo root at all runs the global with no warning,
+ * deliberately, so global-only invocations still work. A repo root whose local install is missing or
+ * corrupt runs the global too, but *says so loudly* — that pairing is the whole design: tiers that
+ * can only be right or loudly absent are fine; tiers that can be quietly wrong are the defect
+ * (#4784). One tier used to be quietly wrong against that rule and is now a refusal: a copy invoked
+ * out of a *different checkout* is not a global install, and delegating it answered from a tree the
+ * caller never named (#4956).
  */
 import {Effect} from "effect";
 import {ChildProcess, type ChildProcessSpawner} from "effect/unstable/process";
 import type {LocalInstall, LocalProbe} from "./local.ts";
+import type {SelfOrigin} from "./root.ts";
 
 /**
  * The child's recursion guard, passed as a **flag** rather than an environment variable so it is
@@ -38,26 +41,79 @@ export type Resolution =
 			readonly _tag: "warn-and-run-here";
 			readonly repoRoot: string;
 			readonly reason: string;
+	  }
+	| {
+			readonly _tag: "refuse-foreign-checkout";
+			readonly selfPackageRoot: string;
+			/** The checkout the invoked copy belongs to — never equal to {@link repoRoot}. */
+			readonly selfCheckout: string;
+			readonly repoRoot: string;
+			/** The install the cwd's repo would have answered from, named so the refusal is checkable. */
+			readonly wouldHaveRun: LocalInstall;
 	  };
 
 export interface ResolveInput {
 	/** The real path of the package root the running bin belongs to. */
 	readonly selfPackageRoot: string;
+	/** Which checkout, if any, {@link selfPackageRoot} belongs to. */
+	readonly selfOrigin: SelfOrigin;
 	/** `undefined` when the cwd is in no repo at all — the one silent branch. */
 	readonly repoRoot: string | undefined;
 	readonly local: LocalProbe | undefined;
 }
 
-/** Which copy serves this invocation. Total over the four states; there is no fallthrough. */
-export const resolve = ({selfPackageRoot, repoRoot, local}: ResolveInput): Resolution => {
+/** Which copy serves this invocation. Total over the five states; there is no fallthrough. */
+export const resolve = ({
+	selfPackageRoot,
+	selfOrigin,
+	repoRoot,
+	local,
+}: ResolveInput): Resolution => {
 	if (repoRoot === undefined) return {_tag: "run-here", why: "the cwd is not inside a repo"};
 	if (local === undefined || local._tag === "absent")
 		return {_tag: "warn-and-run-here", repoRoot, reason: "it has no local install"};
 	if (local._tag === "corrupt") return {_tag: "warn-and-run-here", repoRoot, reason: local.reason};
 	if (local.install.packageRoot === selfPackageRoot)
 		return {_tag: "run-here", why: "the repo-local install is this copy"};
+	// Only a copy that belongs to NO checkout is the global install this delegation was designed for.
+	// A copy from another checkout reaches the same comparison and used to be indistinguishable from
+	// it (#4956) — the refusal is placed here, on the delegate branch alone, so the two loud branches
+	// above keep their behaviour and their text exactly.
+	if (selfOrigin._tag === "checkout" && selfOrigin.root !== repoRoot)
+		return {
+			_tag: "refuse-foreign-checkout",
+			selfPackageRoot,
+			selfCheckout: selfOrigin.root,
+			repoRoot,
+			wouldHaveRun: local.install,
+		};
 	return {_tag: "delegate", to: local.install};
 };
+
+/**
+ * The refusal's text: both checkouts, the answer it declined to give, and the two ways out.
+ *
+ * Naming the install it *would* have run is what makes the refusal auditable rather than a bare
+ * "no" — a reader who expected the delegation can see precisely which copy the cwd resolved to.
+ */
+export const foreignCheckoutRefusal = ({
+	selfPackageRoot,
+	selfCheckout,
+	repoRoot,
+	wouldHaveRun,
+}: {
+	readonly selfPackageRoot: string;
+	readonly selfCheckout: string;
+	readonly repoRoot: string;
+	readonly wouldHaveRun: LocalInstall;
+}): string =>
+	[
+		"fabrika: refusing to run — the copy you invoked and your cwd are in different checkouts.",
+		`  invoked copy: ${selfPackageRoot} (checkout ${selfCheckout})`,
+		`  cwd checkout: ${repoRoot}, which resolves ${wouldHaveRun.binPath} (v${wouldHaveRun.version})`,
+		"  Delegating would have answered from a checkout you did not name.",
+		`  Re-run with the cwd inside ${selfCheckout}, or pass ${SKIP_INFER_FLAG} to make the copy you named serve this invocation.`,
+	].join("\n");
 
 export interface WarningInput {
 	readonly repoRoot: string;
@@ -95,6 +151,8 @@ export const traceLine = (selfPackageRoot: string, resolution: Resolution): stri
 			return `fabrika: global at ${selfPackageRoot} — delegating to the repo-local install at ${resolution.to.packageRoot} (${resolution.to.binPath}, v${resolution.to.version})`;
 		case "warn-and-run-here":
 			return `fabrika: running here, at ${selfPackageRoot} — repo root ${resolution.repoRoot}, but ${resolution.reason}`;
+		case "refuse-foreign-checkout":
+			return `fabrika: refusing — ${selfPackageRoot} is in checkout ${resolution.selfCheckout}, the cwd is in ${resolution.repoRoot}`;
 		case "run-here":
 			return `fabrika: running here, at ${selfPackageRoot} — ${resolution.why}`;
 	}

--- a/packages/fabrika-cli/src/delegate/resolve.unit.test.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.unit.test.ts
@@ -7,13 +7,16 @@ import {describe, expect, it} from "vitest";
 import {faultingShell, signalledExitError, signalledShell} from "../fakes.test-support.ts";
 import type {LocalInstall} from "./local.ts";
 import {
+	foreignCheckoutRefusal,
 	GLOBAL_WARNING_DISABLED_ENV,
 	globalWarning,
 	resolve,
+	SKIP_INFER_FLAG,
 	signalFromError,
 	spawnDelegate,
 	traceLine,
 } from "./resolve.ts";
+import type {SelfOrigin} from "./root.ts";
 
 const install: LocalInstall = {
 	packageRoot: "/repo/packages/fabrika-cli",
@@ -24,21 +27,39 @@ const install: LocalInstall = {
 
 const GLOBAL = "/usr/local/pnpm/global/5/node_modules/@kampus/fabrika-cli";
 
+/** A copy on `PATH`: it belongs to no checkout, which is what makes delegating from it correct. */
+const INSTALLED: SelfOrigin = {_tag: "no-checkout"};
+
+/** The reviewer's shape — a second checkout of the same repo, invoked by path from elsewhere. */
+const OTHER_CHECKOUT = "/repo/.claude/worktrees/agent-1";
+const otherCopy = `${OTHER_CHECKOUT}/packages/fabrika-cli`;
+
 describe("resolve", () => {
 	it("delegates to the repo-local install — the pinned version wins over the global", () => {
 		expect(
-			resolve({selfPackageRoot: GLOBAL, repoRoot: "/repo", local: {_tag: "found", install}}),
+			resolve({
+				selfPackageRoot: GLOBAL,
+				selfOrigin: INSTALLED,
+				repoRoot: "/repo",
+				local: {_tag: "found", install},
+			}),
 		).toEqual({_tag: "delegate", to: install});
 	});
 
 	it("runs here SILENTLY outside any repo — a global-only invocation is not a defect", () => {
-		const resolution = resolve({selfPackageRoot: GLOBAL, repoRoot: undefined, local: undefined});
+		const resolution = resolve({
+			selfPackageRoot: GLOBAL,
+			selfOrigin: INSTALLED,
+			repoRoot: undefined,
+			local: undefined,
+		});
 		expect(resolution._tag).toBe("run-here");
 	});
 
 	it("WARNS when a repo root exists but nothing is installed — the quietly-wrong case", () => {
 		const resolution = resolve({
 			selfPackageRoot: GLOBAL,
+			selfOrigin: INSTALLED,
 			repoRoot: "/repo",
 			local: {_tag: "absent"},
 		});
@@ -48,6 +69,7 @@ describe("resolve", () => {
 	it("warns rather than throws on a corrupt local — the worst outcome is running the global", () => {
 		const resolution = resolve({
 			selfPackageRoot: GLOBAL,
+			selfOrigin: INSTALLED,
 			repoRoot: "/repo",
 			local: {_tag: "corrupt", reason: "manifest declares no version"},
 		});
@@ -61,10 +83,69 @@ describe("resolve", () => {
 	it("runs here when the install it found IS this copy, rather than spawning itself", () => {
 		const resolution = resolve({
 			selfPackageRoot: install.packageRoot,
+			selfOrigin: {_tag: "checkout", root: "/repo"},
 			repoRoot: "/repo",
 			local: {_tag: "found", install},
 		});
 		expect(resolution._tag).toBe("run-here");
+	});
+});
+
+/**
+ * The two cases #4956 fused. Both reach the delegate comparison with `selfPackageRoot` outside the
+ * cwd's repo root, so `selfOrigin` is the only fact separating them — and these two assertions
+ * disagree on the outcome, which is what makes a future edit that drops the field fail rather than
+ * quietly restore the wrong answer.
+ */
+describe("resolve — a global install and a foreign checkout are NOT the same input", () => {
+	const input = {repoRoot: "/repo", local: {_tag: "found", install}} as const;
+
+	it("REFUSES a copy invoked out of a different checkout, naming both roots", () => {
+		const resolution = resolve({
+			...input,
+			selfPackageRoot: otherCopy,
+			selfOrigin: {_tag: "checkout", root: OTHER_CHECKOUT},
+		});
+		expect(resolution).toEqual({
+			_tag: "refuse-foreign-checkout",
+			selfPackageRoot: otherCopy,
+			selfCheckout: OTHER_CHECKOUT,
+			repoRoot: "/repo",
+			wouldHaveRun: install,
+		});
+	});
+
+	it("still delegates SILENTLY from an install that belongs to no checkout — same comparison, opposite answer", () => {
+		expect(resolve({...input, selfPackageRoot: GLOBAL, selfOrigin: INSTALLED})).toEqual({
+			_tag: "delegate",
+			to: install,
+		});
+	});
+
+	it("delegates within ONE checkout — the pinned install may differ from the copy you ran", () => {
+		expect(
+			resolve({
+				...input,
+				selfPackageRoot: "/repo/vendor/fabrika-cli",
+				selfOrigin: {_tag: "checkout", root: "/repo"},
+			}),
+		).toEqual({_tag: "delegate", to: install});
+	});
+});
+
+describe("foreignCheckoutRefusal", () => {
+	it("names both checkouts, the answer it declined to give, and both ways out", () => {
+		const text = foreignCheckoutRefusal({
+			selfPackageRoot: otherCopy,
+			selfCheckout: OTHER_CHECKOUT,
+			repoRoot: "/repo",
+			wouldHaveRun: install,
+		});
+		expect(text).toContain(otherCopy);
+		expect(text).toContain(OTHER_CHECKOUT);
+		expect(text).toContain("/repo");
+		expect(text).toContain(install.binPath);
+		expect(text).toContain(SKIP_INFER_FLAG);
 	});
 });
 
@@ -96,7 +177,12 @@ describe("traceLine", () => {
 	it("names both copies on a delegation, so the hop is checkable from outside", () => {
 		const line = traceLine(
 			GLOBAL,
-			resolve({selfPackageRoot: GLOBAL, repoRoot: "/repo", local: {_tag: "found", install}}),
+			resolve({
+				selfPackageRoot: GLOBAL,
+				selfOrigin: INSTALLED,
+				repoRoot: "/repo",
+				local: {_tag: "found", install},
+			}),
 		);
 		expect(line).toContain(GLOBAL);
 		expect(line).toContain(install.packageRoot);
@@ -106,7 +192,12 @@ describe("traceLine", () => {
 	it("says why it stayed put, not merely that it did", () => {
 		const line = traceLine(
 			GLOBAL,
-			resolve({selfPackageRoot: GLOBAL, repoRoot: undefined, local: undefined}),
+			resolve({
+				selfPackageRoot: GLOBAL,
+				selfOrigin: INSTALLED,
+				repoRoot: undefined,
+				local: undefined,
+			}),
 		);
 		expect(line).toContain("not inside a repo");
 	});

--- a/packages/fabrika-cli/src/delegate/root.ts
+++ b/packages/fabrika-cli/src/delegate/root.ts
@@ -163,3 +163,42 @@ export const discoverRepoRoot = (
 		}
 		return chooseRoot(path, candidates);
 	});
+
+/**
+ * Where the *running* copy lives — the second root the delegation has to know about.
+ *
+ * A tagged union rather than `string | undefined` on purpose: `undefined` would be readable as "not
+ * looked up", and never looking it up is exactly the defect (#4956). This type has no state that
+ * means "undecided", so a caller either has an answer or is holding an `Effect` that failed.
+ */
+export type SelfOrigin =
+	| {readonly _tag: "no-checkout"}
+	| {readonly _tag: "checkout"; readonly root: string};
+
+const NODE_MODULES = "node_modules";
+
+/**
+ * The checkout the copy at `packageRoot` belongs to, or `no-checkout` for an installed artifact.
+ *
+ * Two narrowings against {@link discoverRepoRoot} keep the designed global-install delegation intact,
+ * and both are load-bearing rather than defensive. The walk starts at the package root's **parent**,
+ * because a package root always holds its own `package.json` and would otherwise be its own repo
+ * root. And a path with a `node_modules` segment answers `no-checkout` outright, because an installed
+ * copy is an artifact of some tree, not a checkout of one — `pnpm add --global` writes a
+ * `package.json` beside the global `node_modules`, so a plain ancestor walk would report every global
+ * install as a checkout and turn the one branch that is *meant* to delegate into a refusal.
+ */
+export const originOf = (
+	packageRoot: string,
+): Effect.Effect<SelfOrigin, ReadFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const resolved = path.resolve(packageRoot);
+		if (resolved.split(path.sep).includes(NODE_MODULES)) return {_tag: "no-checkout"} as const;
+		const parent = path.dirname(resolved);
+		if (parent === resolved) return {_tag: "no-checkout"} as const;
+		const root = yield* discoverRepoRoot(parent);
+		return root === undefined
+			? ({_tag: "no-checkout"} as const)
+			: ({_tag: "checkout", root} as const);
+	});

--- a/packages/fabrika-cli/src/delegate/root.unit.test.ts
+++ b/packages/fabrika-cli/src/delegate/root.unit.test.ts
@@ -7,6 +7,7 @@ import {
 	globToRegExp,
 	manifestWorkspaceGlobs,
 	matchesWorkspaceGlobs,
+	originOf,
 	pnpmWorkspaceGlobs,
 } from "./root.ts";
 
@@ -148,5 +149,53 @@ describe("discoverRepoRoot", () => {
 		});
 		const root = await run(discoverRepoRoot("/consumer/src").pipe(Effect.provide(fs.layer)));
 		expect(root).toBe("/consumer");
+	});
+});
+
+describe("originOf", () => {
+	const checkout = (root: string) => ({
+		[`${root}/package.json`]: '{"name":"phoenix"}',
+		[`${root}/pnpm-workspace.yaml`]: "packages:\n  - packages/*\n",
+		[`${root}/packages/fabrika-cli/package.json`]: '{"name":"@kampus/fabrika-cli"}',
+	});
+
+	it("names the checkout a source copy belongs to", async () => {
+		const fs = fakeFs({files: checkout("/repo")});
+		const origin = await run(originOf("/repo/packages/fabrika-cli").pipe(Effect.provide(fs.layer)));
+		expect(origin).toEqual({_tag: "checkout", root: "/repo"});
+	});
+
+	it("never reports a package as its OWN checkout — the walk starts above it", async () => {
+		const fs = fakeFs({files: {"/loose/thing/package.json": '{"name":"thing"}'}});
+		const origin = await run(originOf("/loose/thing").pipe(Effect.provide(fs.layer)));
+		expect(origin).toEqual({_tag: "no-checkout"});
+	});
+
+	/**
+	 * `pnpm add --global` writes a `package.json` beside the global `node_modules`, so a plain
+	 * ancestor walk answers "checkout" here and the refusal would swallow the delegation the whole
+	 * feature exists for.
+	 */
+	it("answers no-checkout for an install under node_modules, manifest above it or not", async () => {
+		const fs = fakeFs({
+			files: {
+				"/usr/local/pnpm/global/5/package.json": '{"name":"global"}',
+				"/usr/local/pnpm/global/5/node_modules/@kampus/fabrika-cli/package.json": "{}",
+			},
+		});
+		const origin = await run(
+			originOf("/usr/local/pnpm/global/5/node_modules/@kampus/fabrika-cli").pipe(
+				Effect.provide(fs.layer),
+			),
+		);
+		expect(origin).toEqual({_tag: "no-checkout"});
+	});
+
+	it("FAILS rather than answering no-checkout when an ancestor cannot be probed", async () => {
+		const fs = fakeFs({files: {}, unprobeable: ["/repo/packages/package.json"]});
+		const outcome = await run(
+			originOf("/repo/packages/fabrika-cli").pipe(Effect.provide(fs.layer), Effect.result),
+		);
+		expect(outcome._tag).toBe("Failure");
 	});
 });


### PR DESCRIPTION
Running `fabrika` from a directory that belongs to a different checkout than the copy you invoked used to hand the work to whichever copy the *directory's* repo pins, silently — so a reviewer gating a branch from an isolated worktree got answers computed against `main` while reading the branch, with nothing on screen to say so. This makes that case refuse instead: it stops, names both checkouts, and tells you the two ways to get the copy you meant. Running a globally-installed `fabrika` inside a repo still delegates exactly as before.

## What changed

The delegation compared the running copy's package root against the install the cwd's repo pins, and never asked **which checkout the running copy belongs to**. Both "a global install on `PATH`" and "a copy from another checkout" reach that comparison as unequal, so the second was indistinguishable from the first — and only the first is meant to delegate.

`originOf` (in `packages/fabrika-cli/src/delegate/root.ts`) answers that missing question, and `resolve` (in `packages/fabrika-cli/src/delegate/resolve.ts`) gains a fourth outcome, `refuse-foreign-checkout`. The bootstrap prints the refusal and exits `2` — this package's reserved "could not resolve an implementation" code.

**The fork the issue left open: cwd-resolution is kept, and the divergence refuses.** Resolving the root from the invoked script's own location — the other option — would delete the feature: a global install's own location is inside no repo, so root discovery from it finds nothing and the delegation never fires. Cwd-resolution is load-bearing and stays.

**Refusal, not a warning.** The reported damage is a *false FAIL carrying plausible evidence* — a wrong row count read off stdout. A warning still emits that answer, and a pipeline capturing stdout never sees the stderr line. Withholding the answer is the only shape that removes the misleading evidence, and it has a named way out (`--skip-infer`, or run it from inside its own checkout), so nothing becomes unreachable.

**The global-install path is untouched, and that is what `originOf` is careful about.** An installed copy — any path with a `node_modules` segment — belongs to no checkout, and the walk starts *above* the package root. Both narrowings are load-bearing: `pnpm add --global` writes a `package.json` beside the global `node_modules`, and every package root holds its own manifest, so a naive ancestor walk would call every installed copy a checkout and turn the one branch that *should* delegate into a refusal. The refusal is also placed on the `delegate` branch alone, so `warn-and-run-here` and the no-repo-root branch keep their behaviour and their exact text.

`SelfOrigin` is a tagged union rather than `string | undefined` on purpose: `undefined` reads as "not looked up", and never looking it up is precisely this bug. An unreadable ancestor stays on the `E` channel and ends the run with a diagnostic — it never softens into "no checkout", which would read as a global install and re-open the branch this closes.

## Live repro, before and after

Same command, from the primary checkout, against a worktree's bin. Before — the worktree copy is called "global" and `main`'s copy answers, printing nothing at all without `FABRIKA_DEBUG`:

```
fabrika: global at <worktree>/packages/fabrika-cli — delegating to the repo-local install at <primary>/packages/fabrika-cli (…/src/bin.ts, v0.1.0)
fabrika v0.1.0
```

After: exit `2`, both checkouts named, no answer. The intake note called the mechanism a source read rather than a live repro — it reproduces, and `packages/fabrika-cli/src/delegate/foreign-checkout.cli.test.ts` is that repro as a test.

## The test that keeps the two cases apart

`resolve.unit.test.ts` carries a `describe` block holding two assertions over the *same* delegate comparison, differing only in `selfOrigin`: a foreign checkout must refuse, an install that belongs to no checkout must delegate. An edit that re-fuses them cannot satisfy both. `root.unit.test.ts` pins `originOf`'s four outcomes, including the global-install shape and the unreadable-ancestor failure. `foreign-checkout.cli.test.ts` spawns the real bin from a synthetic consumer checkout whose installed copy prints a marker, and asserts that marker never reaches stdout.

Fixes #4956

## Deviations

- **Scope narrowed, deliberately (class: narrowed a suggested fix-shape).** Said: the issue offered two fix shapes. Did: took cwd-resolution + refusal, and rejected script-location resolution. Why: script-location resolution deletes the global-install delegation outright, as argued above. Disposition: no action needed — the issue named this as the implementer's choice and asked it be stated in the PR.
- **One error string edited outside the new branch (class: changed something the issue did not name).** Said: keep the other branches' text. Did: the bootstrap's `could not resolve which copy to run` diagnostic now names both walk origins instead of only the cwd. Why: a second walk now feeds that same catch, so the old wording would misattribute a self-walk failure to the cwd. This is the fatal-diagnostic path, not one of the three resolution branches whose text the acceptance criteria pin. Disposition: no action needed.
- **No `.patterns/` doc added (class: declined an adjacent piece of work).** Said: add a pattern doc for a load-bearing pattern not yet documented. Did: left `.patterns/` alone. Why: the shape here is local to this module's own decision function, not a repeatable shape other phoenix code follows; the *why* lives in the module docblocks and in #4956 / #4784. Disposition: for the reviewer to judge.
- **Past gate verdicts not audited (class: left a sibling concern to its owner).** Said: #4961 owns whether any recorded verdict was reached through this defect. Did: nothing on that axis, and nothing touched on #4942 / #4943 / #4953 / #4955. Disposition: owned by #4961.
- **The positive global-install branch has no spawn-level test (class: a test left unwritten).** Said: prove the branches end to end. Did: covered the global-install case in unit tests only. Why: synthesizing a real global install means copying the package outside every checkout, where its `catalog:` dependencies no longer resolve — the spawn would fail for reasons unrelated to the branch under test. Disposition: for the reviewer to judge.
