### PR TITLE
test(fabrika-cli): registry-level wire conformance — every format inherits the totality law (#4944)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -272,6 +272,12 @@ Three properties are worth knowing before you call them:
   [`verdict-marker.ts`](./src/wire/verdict-marker.ts)'s `bindToHead` — three answers again
   (`Current` / `Stale` / `Unbindable`), because a head the caller could not resolve is not a
   comparison anyone made.
+- **A registered format is a conforming format.** A registry row carries the fixtures its laws
+  are driven from and the brands its value is built from, and both are required by the row
+  type — so adding a format means filling them in, and
+  [`conformance.ts`](./src/wire/conformance.ts) then holds it to the same laws as every other
+  row without naming it. Weakening one of those brands to a bare `string` stops the *row* from
+  compiling, which is how the type-level half is inherited rather than re-written per format.
 
 ```bash
 printf 'the read is total\n[x] the registry is the seam\n' \

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.ts
@@ -21,9 +21,25 @@
 
 import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
 
+declare const CRITERION_TEXT: unique symbol;
+
+/**
+ * What a criterion says, trimmed and non-blank.
+ *
+ * Branded for the same reason `HeadSha` is: a checkbox with nothing after it is not a criterion, and
+ * a `Found` carrying one would be a well-formed answer that grades a PR against nothing. The read
+ * refused it before; the brand is what makes the refusal the only way to build one.
+ */
+export type CriterionText = string & {readonly [CRITERION_TEXT]: true};
+
+export const criterionText = (raw: string): CriterionText | null => {
+	const value = raw.trim();
+	return value === "" ? null : (value as CriterionText);
+};
+
 /** One criterion and whether it is checked off. The field type of this format. */
 export interface AcceptanceCriterion {
-	readonly text: string;
+	readonly text: CriterionText;
 	readonly checked: boolean;
 }
 
@@ -193,8 +209,8 @@ export const read = (body: string): AcceptanceCriteriaRead => {
 	for (const [offset, line] of sectionOf(lines, heading).entries()) {
 		const item = CHECKBOX_ITEM.exec(line);
 		if (item === null) continue;
-		const text = (item[2] ?? "").trim();
-		if (text === "") {
+		const text = criterionText(item[2] ?? "");
+		if (text === null) {
 			return malformed(
 				"a checkbox item under the acceptance-criteria heading carries no text",
 				`line ${heading.line + offset + 1}: "${line}"`,
@@ -237,8 +253,8 @@ export const parseFields = (fields: string): AcceptanceFields => {
 		const line = raw.trim();
 		if (line === "") continue;
 		const match = FIELD_LINE.exec(line);
-		const text = (match?.[2] ?? "").trim();
-		if (text === "") {
+		const text = criterionText(match?.[2] ?? "");
+		if (text === null) {
 			return {
 				_tag: "Unusable",
 				reason: `line ${index + 1} carries a checkbox marker and no criterion text: "${line}"`,

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
@@ -10,6 +10,7 @@
 import {describe, expect, it} from "vitest";
 import {
 	type AcceptanceCriterion,
+	criterionText,
 	emit,
 	HEADING_TEXT,
 	parseFields,
@@ -18,6 +19,13 @@ import {
 } from "./acceptance-criteria.ts";
 
 const body = (...lines: ReadonlyArray<string>): string => lines.join("\n");
+
+/** A criterion, through the smart constructor the brand leaves as the only way in. */
+const criterion = (text: string, checked: boolean): AcceptanceCriterion => {
+	const value = criterionText(text);
+	if (value === null) throw new Error(`"${text}" is not criterion text`);
+	return {text: value, checked};
+};
 
 const found = (source: string): ReadonlyArray<AcceptanceCriterion> => {
 	const result = read(source);
@@ -42,18 +50,15 @@ const CONFORMING = body(
 describe("emit", () => {
 	it("composes the heading and one checkbox line per criterion", () => {
 		expect(
-			emit([
-				{text: "the read is total", checked: false},
-				{text: "the registry is the seam", checked: true},
-			]),
+			emit([criterion("the read is total", false), criterion("the registry is the seam", true)]),
 		).toBe("### Acceptance criteria\n\n- [ ] the read is total\n- [x] the registry is the seam\n");
 	});
 
 	it("round-trips: what it composes is what `read` finds", () => {
 		const criteria: AcceptanceCriterion[] = [
-			{text: "first", checked: true},
-			{text: "second", checked: false},
-			{text: "third with `backticks` and a #4942 ref", checked: false},
+			criterion("first", true),
+			criterion("second", false),
+			criterion("third with `backticks` and a #4942 ref", false),
 		];
 		expect(found(emit([criteria[0]!, ...criteria.slice(1)]))).toEqual(criteria);
 	});
@@ -62,8 +67,8 @@ describe("emit", () => {
 describe("read — Found", () => {
 	it("finds every criterion with its checked state, from a full sub-issue body", () => {
 		expect(found(CONFORMING)).toEqual([
-			{text: "the read is total", checked: false},
-			{text: "the registry is the only place a format is registered", checked: true},
+			criterion("the read is total", false),
+			criterion("the registry is the only place a format is registered", true),
 		]);
 	});
 
@@ -72,13 +77,11 @@ describe("read — Found", () => {
 			found(
 				body("### Acceptance criteria", "- [ ] mine", "", "### Out of scope", "- [ ] not mine"),
 			),
-		).toEqual([{text: "mine", checked: false}]);
+		).toEqual([criterion("mine", false)]);
 	});
 
 	it("reads an uppercase [X] as checked — a tolerant read of a real drift that changes no meaning", () => {
-		expect(found(body("### Acceptance criteria", "- [X] done"))).toEqual([
-			{text: "done", checked: true},
-		]);
+		expect(found(body("### Acceptance criteria", "- [X] done"))).toEqual([criterion("done", true)]);
 	});
 });
 
@@ -182,7 +185,7 @@ describe("read — a fenced example is not the real block", () => {
 					"- [ ] the contract",
 				),
 			),
-		).toEqual([{text: "the contract", checked: false}]);
+		).toEqual([criterion("the contract", false)]);
 	});
 });
 
@@ -190,11 +193,7 @@ describe("parseFields", () => {
 	it("takes one criterion per line, with the state marker optional", () => {
 		expect(parseFields("first\n[x] second\n- [ ] third\n")).toEqual({
 			_tag: "Fields",
-			criteria: [
-				{text: "first", checked: false},
-				{text: "second", checked: true},
-				{text: "third", checked: false},
-			],
+			criteria: [criterion("first", false), criterion("second", true), criterion("third", false)],
 		});
 	});
 
@@ -212,11 +211,9 @@ describe("parseFields", () => {
 
 describe("renderCriteria", () => {
 	it("renders one `<state>\\t<text>` line per criterion", () => {
-		expect(
-			renderCriteria([
-				{text: "a", checked: false},
-				{text: "b", checked: true},
-			]),
-		).toEqual(["open\ta", "checked\tb"]);
+		expect(renderCriteria([criterion("a", false), criterion("b", true)])).toEqual([
+			"open\ta",
+			"checked\tb",
+		]);
 	});
 });

--- a/packages/fabrika-cli/src/wire/conformance.ts
+++ b/packages/fabrika-cli/src/wire/conformance.ts
@@ -1,0 +1,126 @@
+/**
+ * The conformance laws, applied to every registered format by iterating the registry.
+ *
+ * The totality law is worth exactly as much as the diligence of whoever lands the next format, and
+ * per-format tests are diligence. So the laws live here, over `WireFormat` and nothing narrower —
+ * this module never learns a format's name, never branches on one, and holds no skip list. A row is
+ * checked because it is in the array, and the samples the laws are driven from ride on the row
+ * itself (`WireFixtures`), which the type makes required: a row added without them does not compile,
+ * so coverage cannot quietly shrink to the formats whose author remembered to write tests.
+ *
+ * The compile-time half of the same idea is `format.ts`'s `brandWitness`, whose signature collapses
+ * to `never` when a brand is weakened to `string`. The two halves are complementary: what a type can
+ * refuse it refuses here at build time, and what it cannot — that `read` answers `Malformed` rather
+ * than `Absent` for a drift — the findings below refuse at test time.
+ *
+ * Zero scope is a refusal, not a pass (ADR 0092): a suite that iterated an empty registry would run
+ * no assertions and report green, which is the vacuous pass the law exists to forbid.
+ */
+import type {WireFormat, WireReadLines} from "./format.ts";
+
+/** One broken law, named against the row that broke it. */
+export interface ConformanceFinding {
+	readonly format: string;
+	readonly law: string;
+	readonly detail: string;
+}
+
+export type ConformanceReport =
+	| {readonly _tag: "ZeroScope"; readonly scanned: 0; readonly reason: string}
+	| {
+			readonly _tag: "Scanned";
+			readonly scanned: number;
+			readonly findings: ReadonlyArray<ConformanceFinding>;
+	  };
+
+/** The law names, so a finding and this module's prose cannot drift apart. */
+export const LAWS = {
+	emits: "emit composes the round-trip fixture",
+	roundTrip: "read(emit(fields)) is Found",
+	recovers: "the Found answer carries every field value it was given",
+	emptyIsAbsent: "empty bytes read Absent — never Found",
+	absentIsAbsent: "the declared absent fixture reads Absent — never Found, never Malformed",
+	driftIsMalformed: "each declared drift fixture reads Malformed — never Found, never Absent",
+	brandsNamed: "the row's brand witnesses name distinct, non-blank fields",
+	keysUnique: "each registered key appears once",
+} as const;
+
+const answerOf = (read: WireReadLines): string =>
+	read._tag === "Found" ? read.value.join("\n") : "";
+
+export const conformFormat = (format: WireFormat): ReadonlyArray<ConformanceFinding> => {
+	const findings: ConformanceFinding[] = [];
+	const fail = (law: string, detail: string): void => {
+		findings.push({format: format.key, law, detail});
+	};
+
+	const {roundTrip, absent, malformed} = format.fixtures;
+	const composed = format.emit(roundTrip.fields);
+	if (composed._tag !== "Composed") {
+		fail(LAWS.emits, `emit answered Unusable: ${composed.reason}`);
+	} else {
+		const read = format.read(composed.bytes);
+		if (read._tag !== "Found") {
+			fail(LAWS.roundTrip, `its own emitted bytes read back ${read._tag}: ${read.reason}`);
+		} else {
+			const answer = answerOf(read);
+			const dropped = roundTrip.values.filter((value) => !answer.includes(value));
+			if (dropped.length > 0) {
+				fail(LAWS.recovers, `the answer dropped ${dropped.map((v) => `"${v}"`).join(", ")}`);
+			}
+		}
+	}
+
+	const empty = format.read("");
+	if (empty._tag !== "Absent") {
+		fail(LAWS.emptyIsAbsent, `empty bytes read ${empty._tag}`);
+	}
+
+	const declaredAbsent = format.read(absent);
+	if (declaredAbsent._tag !== "Absent") {
+		fail(LAWS.absentIsAbsent, `the absent fixture read ${declaredAbsent._tag}`);
+	}
+
+	for (const fixture of malformed) {
+		const drifted = format.read(fixture.artifact);
+		if (drifted._tag !== "Malformed") {
+			fail(LAWS.driftIsMalformed, `"${fixture.drift}" read ${drifted._tag}`);
+		}
+	}
+
+	const fields = format.brands.map((witness) => witness.field.trim());
+	if (fields.some((field) => field === "")) {
+		fail(LAWS.brandsNamed, "a brand witness names no field");
+	}
+	if (new Set(fields).size !== fields.length) {
+		fail(LAWS.brandsNamed, `the same field is witnessed twice: ${fields.join(", ")}`);
+	}
+
+	return findings;
+};
+
+export const conformRegistry = (formats: ReadonlyArray<WireFormat>): ConformanceReport => {
+	if (formats.length === 0) {
+		return {
+			_tag: "ZeroScope",
+			scanned: 0,
+			reason:
+				"wire conformance scanned 0 formats — an empty registry proves nothing about the totality law (ADR 0092)",
+		};
+	}
+
+	const findings = formats.flatMap(conformFormat);
+	const keys = formats.map((format) => format.key);
+	const duplicates = keys.filter((key, index) => keys.indexOf(key) !== index);
+	const keyFindings: ReadonlyArray<ConformanceFinding> = [...new Set(duplicates)].map((key) => ({
+		format: key,
+		law: LAWS.keysUnique,
+		detail: `"${key}" is registered more than once — which row --format resolves to is undecidable`,
+	}));
+
+	return {_tag: "Scanned", scanned: formats.length, findings: [...findings, ...keyFindings]};
+};
+
+/** One line per finding, for an assertion message a reader can act on without opening the row. */
+export const describeFindings = (findings: ReadonlyArray<ConformanceFinding>): string =>
+	findings.map(({format, law, detail}) => `${format}: ${law} — ${detail}`).join("\n");

--- a/packages/fabrika-cli/src/wire/conformance.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/conformance.unit.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The registry-level tier: the laws of `./conformance.ts`, run over whatever `./registry.ts` holds.
+ *
+ * Two halves, and the second is what makes the first worth anything. The first drives every
+ * registered row through the laws without naming one. The second drives *deliberately broken*
+ * synthetic rows through the same laws and asserts each one is caught — because a conformance suite
+ * that cannot fail reports green over a registry that has stopped conforming, which is precisely the
+ * plausible-negative failure the wire group exists to remove.
+ */
+import {describe, expect, it} from "vitest";
+import {conformFormat, conformRegistry, describeFindings, LAWS} from "./conformance.ts";
+import {brandWitness, type WireFormat, type WireReadLines} from "./format.ts";
+import {registeredFormats} from "./registry.ts";
+
+describe("the registry conforms", () => {
+	// `it.each` over an emptied registry would run zero assertions and report green, so scope is
+	// asserted here, once, before any per-row case.
+	it("scans every registered format and finds no broken law", () => {
+		const report = conformRegistry(registeredFormats);
+		expect(report._tag, `scanned ${report.scanned} formats`).toBe("Scanned");
+		if (report._tag !== "Scanned") return;
+		expect(report.scanned).toBe(registeredFormats.length);
+		expect(describeFindings(report.findings)).toBe("");
+	});
+
+	it("reds on an empty registry, stating the count it scanned, rather than passing over nothing", () => {
+		const report = conformRegistry([]);
+		expect(report._tag).toBe("ZeroScope");
+		if (report._tag !== "ZeroScope") return;
+		expect(report.scanned).toBe(0);
+		expect(report.reason).toContain("scanned 0 formats");
+	});
+
+	it.each(
+		registeredFormats.map((format) => [format.key, format] as const),
+	)("%s satisfies every law", (_key, format) => {
+		expect(describeFindings(conformFormat(format))).toBe("");
+	});
+});
+
+/**
+ * A minimal conforming format, so the mutations below break exactly one law each.
+ *
+ * It is synthetic on purpose: mutating a real row would test that row's module, while the subject
+ * here is the checker.
+ */
+declare const TOY: unique symbol;
+type ToyValue = string & {readonly [TOY]: true};
+
+const toyRead = (artifact: string): WireReadLines => {
+	const line = artifact.trim();
+	if (line === "") return {_tag: "Absent", reason: "nothing to judge"};
+	if (line.startsWith("toy: ")) return {_tag: "Found", value: [`value\t${line.slice(5)}`]};
+	if (line.startsWith("toy")) return {_tag: "Malformed", reason: "drifted", evidence: line};
+	return {_tag: "Absent", reason: "no marker of this format"};
+};
+
+const TOY_FORMAT: WireFormat = {
+	key: "toy",
+	purpose: "a conforming format that exists only to be broken",
+	producers: ["nobody"],
+	consumers: ["nobody"],
+	emit: (fields) => ({_tag: "Composed", bytes: `toy: ${fields.trim()}\n`}),
+	read: toyRead,
+	fixtures: {
+		roundTrip: {fields: "alpha", values: ["alpha"]},
+		absent: "prose that reaches for nothing\n",
+		malformed: [{drift: "the key drifted", artifact: "toyish: alpha\n"}],
+	},
+	brands: [brandWitness<ToyValue>("value")],
+};
+
+const broken = (mutation: Partial<WireFormat>): WireFormat => ({...TOY_FORMAT, ...mutation});
+
+const lawsBrokenBy = (format: WireFormat): ReadonlyArray<string> =>
+	conformFormat(format).map((finding) => finding.law);
+
+describe("the laws bite — each mutation is caught", () => {
+	it("the baseline conforms, so every case below fails for its own reason", () => {
+		expect(describeFindings(conformFormat(TOY_FORMAT))).toBe("");
+	});
+
+	it("catches an emit that cannot compose its own fixture", () => {
+		const format = broken({emit: () => ({_tag: "Unusable", reason: "no fields"})});
+		expect(lawsBrokenBy(format)).toContain(LAWS.emits);
+	});
+
+	it("catches a read that does not find its own emitted bytes", () => {
+		const format = broken({read: () => ({_tag: "Absent", reason: "never finds anything"})});
+		expect(lawsBrokenBy(format)).toContain(LAWS.roundTrip);
+	});
+
+	it("catches a read that finds the block but drops a field", () => {
+		const format = broken({read: () => ({_tag: "Found", value: ["value\t"]})});
+		expect(lawsBrokenBy(format)).toContain(LAWS.recovers);
+	});
+
+	it("catches empty bytes answered as Found — the plausible empty value itself", () => {
+		const format = broken({
+			read: (artifact) =>
+				artifact.trim() === "" ? {_tag: "Found", value: ["value\t"]} : toyRead(artifact),
+		});
+		expect(lawsBrokenBy(format)).toContain(LAWS.emptyIsAbsent);
+	});
+
+	it("catches an absent artifact answered as Malformed", () => {
+		const format = broken({
+			read: (artifact) =>
+				artifact.startsWith("prose")
+					? {_tag: "Malformed", reason: "over-eager", evidence: artifact}
+					: toyRead(artifact),
+		});
+		expect(lawsBrokenBy(format)).toContain(LAWS.absentIsAbsent);
+	});
+
+	it("catches a drift answered as Absent — the collapse this group exists to forbid", () => {
+		const format = broken({
+			read: (artifact) =>
+				artifact.startsWith("toyish")
+					? {_tag: "Absent", reason: "read it as nothing"}
+					: toyRead(artifact),
+		});
+		expect(lawsBrokenBy(format)).toContain(LAWS.driftIsMalformed);
+	});
+
+	it("catches a drift answered as Found", () => {
+		const format = broken({
+			read: (artifact) =>
+				artifact.startsWith("toyish")
+					? {_tag: "Found", value: ["value\talpha"]}
+					: toyRead(artifact),
+		});
+		expect(lawsBrokenBy(format)).toContain(LAWS.driftIsMalformed);
+	});
+
+	it("catches a padded brand declaration", () => {
+		const format = broken({brands: [{field: "value"}, {field: "value"}]});
+		expect(lawsBrokenBy(format)).toContain(LAWS.brandsNamed);
+	});
+
+	it("catches two rows registered under one key", () => {
+		const report = conformRegistry([TOY_FORMAT, broken({purpose: "the shadowing row"})]);
+		expect(report._tag).toBe("Scanned");
+		if (report._tag !== "Scanned") return;
+		expect(report.findings.map((finding) => finding.law)).toContain(LAWS.keysUnique);
+	});
+});
+
+describe("brand weakening is caught at compile time, not here", () => {
+	it("declares a brand witness for every registered format", () => {
+		for (const format of registeredFormats) {
+			expect(format.brands.length, `${format.key} declares no brand`).toBeGreaterThan(0);
+		}
+	});
+
+	it("refuses a witness for a field typed as bare string", () => {
+		// @ts-expect-error — `string extends string`, so the parameter collapses to `never`. This is
+		// the counterexample every brand inherits by being declared on a row (`format.ts`).
+		const weakened = brandWitness<string>("clause");
+		expect(weakened.field).toBe("clause");
+	});
+});

--- a/packages/fabrika-cli/src/wire/format.ts
+++ b/packages/fabrika-cli/src/wire/format.ts
@@ -59,6 +59,62 @@ export type WireEmit = WireComposed | WireUnusable;
 export type WireReadLines = WireRead<NonEmptyReadonlyArray<string>>;
 
 /**
+ * The fields a round-trip is driven from, plus what surviving the round-trip means.
+ *
+ * `values` is the non-tautological half: it lists the field *values* `fields` carries, and the
+ * conformance law is that every one of them is still in `read`'s answer. A format that drops a
+ * field on the way out composes and reads back perfectly well — the answer is just quietly smaller
+ * than what was written, which is the same plausible-value failure the whole group exists to remove.
+ */
+export interface WireRoundTripFixture {
+	/** The fields exactly as {@link WireFormat.emit} takes them. */
+	readonly fields: string;
+	/** Every field value `fields` carries. Each must survive into the read's answer. */
+	readonly values: NonEmptyReadonlyArray<string>;
+}
+
+/** An artifact that reaches for the format's block and misses. */
+export interface WireMalformedFixture {
+	/** What drifted, so a broken law names the case rather than an index. */
+	readonly drift: string;
+	readonly artifact: string;
+}
+
+/**
+ * The samples the conformance suite drives a row through, carried by the row itself.
+ *
+ * Fixtures live on the registry rather than in the suite so the suite never learns a format's name:
+ * a new format inherits the laws by filling these in, and — because every field here is required —
+ * a row added without them does not compile, rather than silently reducing coverage to the formats
+ * whose author remembered to write tests.
+ */
+export interface WireFixtures {
+	readonly roundTrip: WireRoundTripFixture;
+	/** An artifact that genuinely carries no block: `Absent`, never `Malformed`. */
+	readonly absent: string;
+	/** At least one drift: `Malformed`, never `Found` and never `Absent`. */
+	readonly malformed: NonEmptyReadonlyArray<WireMalformedFixture>;
+}
+
+/** A field of the format's value whose type is a brand rather than a bare `string`. */
+export interface WireBrandWitness {
+	readonly field: string;
+}
+
+/**
+ * Declare that `field` carries the brand `A` — and make weakening `A` a compile error.
+ *
+ * A brand is a proper subtype of `string`, so `string extends A` is false for it and the parameter
+ * is an ordinary `string`. Weaken the brand to bare `string` and the parameter becomes `never`, so
+ * the row itself stops compiling (`TS2345`). That is the whole mechanism: the counterexample is not
+ * a hand-written `@ts-expect-error` per brand — which is why `Clause` had none while `HeadSha` did
+ * — it is the registry row every format must fill.
+ */
+export const brandWitness = <A extends string>(
+	field: string extends A ? never : string,
+): WireBrandWitness => ({field});
+
+/**
  * A registered format: its identity, its wiring, and its bytes.
  *
  * The `emit`/`read` pair is stated over **bytes in, bytes out** so one array can hold formats whose
@@ -78,4 +134,8 @@ export interface WireFormat {
 	readonly emit: (fields: string) => WireEmit;
 	/** An artifact's bytes → the total read, with `Found` rendered to stdout lines. */
 	readonly read: (artifact: string) => WireReadLines;
+	/** The samples `./conformance.ts` drives this row's laws from. Required — see {@link WireFixtures}. */
+	readonly fixtures: WireFixtures;
+	/** The brands this format's value is built from. Non-empty, so the check has scope (ADR 0092). */
+	readonly brands: NonEmptyReadonlyArray<WireBrandWitness>;
 }

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -10,9 +10,13 @@
  *
  * A new format lands as a sibling schema module plus one row here — never as a branch inside a
  * verb.
+ *
+ * A row also carries what `./conformance.ts` judges it by: the fixtures its laws are driven from and
+ * the brands its value is built from. Both are required by {@link WireFormat}, so a format cannot be
+ * registered without them — which is what makes the totality law inherited rather than re-written.
  */
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
-import type {WireFormat} from "./format.ts";
+import {brandWitness, type WireFormat} from "./format.ts";
 import * as verdictMarker from "./verdict-marker.ts";
 
 export const registeredFormats: ReadonlyArray<WireFormat> = [
@@ -24,6 +28,28 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 		consumers: ["build", "review"],
 		emit: acceptanceCriteria.emitFromFields,
 		read: acceptanceCriteria.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields: "- [ ] the read is total\n- [x] the registry is the seam\n",
+				values: ["the read is total", "the registry is the seam"],
+			},
+			absent: "### What to build\n\nStand up the group. Nothing here reaches for the block.\n",
+			malformed: [
+				{
+					drift: "the heading spelling drifted",
+					artifact: "### Acceptance Criteria\n- [ ] one\n- [ ] two\n",
+				},
+				{
+					drift: "the heading level drifted",
+					artifact: "#### Acceptance criteria\n- [ ] one\n",
+				},
+				{
+					drift: "the conforming heading is present over prose instead of checkbox items",
+					artifact: "### Acceptance criteria\n\nEvery box is implied.\n",
+				},
+			],
+		},
+		brands: [brandWitness<acceptanceCriteria.CriterionText>("text")],
 	},
 	{
 		key: "verdict-marker",
@@ -33,6 +59,32 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 		consumers: ["build", "ship"],
 		emit: verdictMarker.emitFromFields,
 		read: verdictMarker.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields: "namespace: review-code\npolarity: PASS\nsha: 03135b91\nclause: merge-ready\n",
+				values: ["review-code", "PASS", "03135b91", "merge-ready"],
+			},
+			absent: "Thanks — this reads well to me, no notes.\n",
+			malformed: [
+				{
+					drift: "the namespace is not kebab-case",
+					artifact: "review_code: PASS @ 03135b91 — merge-ready\n",
+				},
+				{
+					drift: "the marker is bound to no head SHA",
+					artifact: "review-code: PASS — merge-ready\n",
+				},
+				{
+					drift: "the polarity is not PASS or FAIL",
+					artifact: "review-code: APPROVED @ 03135b91 — merge-ready\n",
+				},
+			],
+		},
+		brands: [
+			brandWitness<verdictMarker.HeadSha>("sha"),
+			brandWitness<verdictMarker.Clause>("clause"),
+			brandWitness<verdictMarker.Polarity>("polarity"),
+		],
 	},
 ];
 


### PR DESCRIPTION
Until now, a wire format's totality law — that a drifted heading reads `Malformed` rather than as a plausible "there were none" — held only as far as whoever landed the format remembered to write the tests for it. This PR moves the law off the author and onto the registry: the checks are stated once over `WireFormat` and run against every registered row, and the samples they run on are carried by the row itself, as fields the type refuses to let you leave out. A third format inherits the whole suite by being registered; a row that skips its fixtures does not compile.

Fixes #4944

## What changed

- **`packages/fabrika-cli/src/wire/conformance.ts`** — the laws as a pure core over any `WireFormat`. Per row: `read(emit(fields))` is `Found` and drops none of the field values it was given; empty bytes and the row's declared absent fixture read `Absent`; every declared drift fixture reads `Malformed`. Registry-wide: each key appears once. The module names no format and holds no skip list, and an empty registry answers `ZeroScope` with the count it scanned rather than a vacuous pass (ADR 0092).
- **`packages/fabrika-cli/src/wire/format.ts`** — `WireFormat` gains required `fixtures` (round-trip / absent / at-least-one-malformed) and a required non-empty `brands`. Both are non-optional, so a row added without them fails `pnpm typecheck` rather than silently reducing coverage.
- **`brandWitness<A>`** — a row declares the brands its value is built from. The parameter type is `string extends A ? never : string`, so weakening any brand to bare `string` stops the *registry row* compiling. That closes the `Clause` gap uniformly (the PR #4955 gate's recorded candidate) instead of a hand-written `@ts-expect-error` per brand — which is exactly why `HeadSha` had one and `Clause` did not.
- **`AcceptanceCriterion.text` is branded `CriterionText`** — the read already refused a checkbox with no text at runtime; the brand makes the refusal the only way to construct one, and gives the acceptance-criteria format the brand witness its row now requires.
- **`packages/fabrika-cli/src/wire/conformance.unit.test.ts`** — runs the laws over the live registry (plus a readable per-row case), then drives *deliberately broken synthetic rows* through the same laws, asserting each violation is caught. A suite that stopped biting reds on itself.

## Proof it bites

Each guard was broken on purpose and the red observed, then reverted:

| Mutation | Reds with |
|---|---|
| `Clause` → `string` | `registry.ts(85,39): error TS2345: Argument of type '"clause"' is not assignable to parameter of type 'never'` |
| `CriterionText` → `string` | `registry.ts(52,59): error TS2345` — same shape, other format |
| drop `fixtures` from the acceptance-criteria row | `registry.ts(23,2): error TS2741: Property 'fixtures' is missing … but required in type 'WireFormat'` |
| acceptance-criteria answers `Absent` for a drifted heading | 2 tests fail — `"the heading spelling drifted" read Absent`, `"the heading level drifted" read Absent` |
| verdict-marker answers `Absent` for an unknown polarity | 2 tests fail — `"the polarity is not PASS or FAIL" read Absent` |
| `registeredFormats = []` | `AssertionError: scanned 0 formats: expected 'ZeroScope' to be 'Scanned'` |

`pnpm typecheck` (30/30 tasks), `pnpm lint:worktree`, and the package's 1089 tests are green on the pushed head.

## Deviations

- **Class: scope widened beyond the issue.** Said: #4944's acceptance criteria ask only that the fixtures be required. Did: also made brand-weakening compile-caught, via a required non-empty `brands` field on every row. Why: the dispatch flagged `Clause` having no compile-time counterexample as the concrete gap this suite should close, and a per-brand `@ts-expect-error` is the same per-author diligence the issue exists to replace. Disposition: for the reviewer to judge — the fixture half alone satisfies #4944, and the brand half is separable.
- **Class: touched a module the issue did not name.** Said: the suite lives in `src/wire/` and changes no format's bytes. Did: branded `AcceptanceCriterion.text` as `CriterionText` in `acceptance-criteria.ts`, and routed that module's unit-test literals through a smart-constructor helper. Why: requiring a non-empty `brands` list means every format needs at least one brand, and acceptance-criteria had none; branding the criterion text is the invariant its `read` already enforced at runtime. No emitted or accepted bytes change — `emit`/`read` behaviour is identical and every pre-existing assertion still holds. Disposition: no action needed.
- **Class: added a check the issue did not list.** Said: the issue enumerates round-trip, absent and malformed. Did: also added a registry-wide key-uniqueness law. Why: `findFormat` resolves `--format` by first match, so a duplicated key silently shadows a row — a registry-level property only a registry-level suite can see. Disposition: no action needed.
- **Class: a pattern relied on but not documented.** Said: CLAUDE.md asks for a `.patterns/` doc when a load-bearing pattern is undocumented. Did: did not add one for the `brandWitness` device. Why: `.patterns/index.md`'s bar is "used in 2+ places", and this is one mechanism inside one registry; the rationale is stated at its single load-bearing site (`format.ts`). Disposition: for the reviewer to judge — worth a pattern doc once a second registry adopts it.
- **Class: v1.** No new citation of `packages/pipeline-cli/**` was added. The pre-existing inert prose citations in the two format modules' docblocks (ADR 0238 prior art) are untouched, and nothing here invokes, imports, or wraps v1.
- **Class: concurrent lane.** `claude-plugins/fabrika/docs/wire-formats.md` (#4945) was neither created nor edited. The README bullet added here describes only `packages/fabrika-cli/src/wire/`.
