### PR TITLE
docs(fabrika): record the ruled §CP classification model where the corpus can cite it (#4932)

### DIFF
--- a/claude-plugins/fabrika/docs/README.md
+++ b/claude-plugins/fabrika/docs/README.md
@@ -17,3 +17,4 @@ This directory is the home; the docs themselves land as the foundation epic's la
 | [CLI interface convention + contract-spec format](cli-interface-convention.md) | what every fabrika verb owes its caller (`--help` discoverability, uniform output contracts, usage examples) and the shape of the contract a skill derives for the verbs it needs | #4654 |
 | [authoring-brief contract](authoring-brief-contract.md) | the boot document a stateless `/skill-creator` session works from | #4655 |
 | [wire formats](wire-formats.md) | the index of the byte-level agreements two skills meet through — format → owner module → producers/consumers, with the protocol narrative and none of the shape | #4945 |
+| [§CP classification](control-plane-classification.md) | the ruled control-plane model every §CP-computing verb implements and every §CP-mentioning skill is held to — CODEOWNERS as single source, three-valued, `UNKNOWN` fails closed, no semantic detection | #4932 |

--- a/claude-plugins/fabrika/docs/control-plane-classification.md
+++ b/claude-plugins/fabrika/docs/control-plane-classification.md
@@ -1,0 +1,90 @@
+# fabrika §CP classification — CODEOWNERS is the single source of truth
+
+The rule a fabrika verb answers "is this change control plane?" by, and the rule every fabrika skill
+that *mentions* §CP is held to. Founder ruling, 2026-08-08, recorded first-hand on
+[#4927](https://github.com/kamp-us/phoenix/issues/4927) and transcribed here so a brief, a contract
+spec or a verb implementer can cite a file instead of a comment
+([#4932](https://github.com/kamp-us/phoenix/issues/4932)).
+
+## The model
+
+1. **CODEOWNERS is the single source of truth.** A change is control-plane **iff** it touches paths
+   owned by the control-plane team in [`.github/CODEOWNERS`](../../../.github/CODEOWNERS). There is
+   no second source.
+2. **A verb computes it, from two inputs and nothing else** — the CODEOWNERS file and the diff's
+   changed paths. **No agent judgement, and no content regex.** A skill may state the expectation;
+   it never asserts the answer.
+3. **The output is three-valued**, and the third value is not a "no":
+
+   | value | means |
+   |---|---|
+   | `§CP` | a changed path is owned by the control-plane team |
+   | `not-§CP` | CODEOWNERS was read, and no changed path is owned |
+   | `UNKNOWN` | the classification could not be made — unreadable/unparseable CODEOWNERS, empty path set |
+
+4. **`UNKNOWN` is treated as §CP — fail closed.** A read that failed and a change that is genuinely
+   ordinary are different facts, and collapsing them is this repo's dominant defect class (a check
+   that cannot see its subject answering confidently instead of erroring). A false §CP costs one
+   approval; a false ordinary reaches `main` with none.
+5. **Enforcement is GitHub's, not the verb's.** The block is the native code-owner review
+   requirement on the `main` ruleset (ADR
+   [0135](../../../.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md),
+   ADR [0053](../../../.decisions/0053-control-plane-boundary.md)). The verb *routes*; CODEOWNERS
+   *gates*. A verb answer is never the gate, so a wrong answer cannot open one.
+
+## No semantic detection exists — path-set completeness is a maintenance obligation
+
+**Stated explicitly, because it is the model's one load-bearing assumption:** nothing in fabrika
+inspects what a change *says*. A guard-relaxing edit in a file no CODEOWNERS row owns classifies
+`not-§CP`, correctly per this model and by design.
+
+That makes **coverage of the owned-path set the whole protection**, and therefore an obligation
+somebody owns rather than a property that holds by itself:
+
+> **Obligation.** When a surface becomes governance-bearing, its path is added to CODEOWNERS in the
+> same change that creates it. **Owner: the `@kamp-us/control-plane` team** — CODEOWNERS lives under
+> `/.github/`, which that team already owns, so every edit to the boundary is itself a §CP change
+> reviewed by the people accountable for it.
+
+ADR [0164](../../../.decisions/0164-guard-relaxing-adr-cp-gate.md)'s "§CP by what it says" case
+resolves **here**, by path completeness — not by a probe. Where 0164 wanted a content signal, the
+answer is a CODEOWNERS row.
+
+### The one surface deliberately left uncovered: `.decisions/`
+
+Later the same day (2026-08-08, on the same thread) the founder ruled the ADR case specifically, and
+that ruling supersedes any reading of the above that would put `.decisions/` in CODEOWNERS:
+
+- `.decisions/` does **not** become team-owned; ADRs get **no** code-owner review. This declines a
+  widening — `.decisions/` has no CODEOWNERS row today — rather than removing a protection.
+- The guard that stays is machine-run: the citation-independent ADR contradiction sweep
+  ([`../../kampus-pipeline/skills/review-doc/SKILL.md`](../../kampus-pipeline/skills/review-doc/SKILL.md),
+  its `Step 4a`).
+- **The condition attached to the ruling, and not droppable:** the gate is replaced by a periodic,
+  non-blocking **readout** of landed ADRs, ranked for consequence and tension by the
+  governance-corpus-integrity skill and surfaced on the front door. Without it, "supersede later" is
+  fiction.
+
+So an ADR classifies `not-§CP` under this model, and that is the ruled outcome, not a gap.
+
+## What this changes relative to v1
+
+v1's [`pipeline-cli cp-classify`](../../../packages/pipeline-cli/src/tools/cp-classify/README.md)
+answers a **different** question and is not wrong at what it does: it has two independent sources —
+the `CONTROL_PLANE_RE` path regex *and* an ADR-0164 content probe over touched `.decisions/**` files
+— and four states, including `content-undetermined`, which is an obligation to probe rather than a
+verdict. fabrika's verb is CODEOWNERS-only and three-valued.
+
+Per ADR [0238](../../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md), fabrika does not
+call v1 and does not patch it. v1's model is described here only so a reader who meets both knows
+which one governs a fabrika artifact.
+
+## Who reads this
+
+- **Authoring sessions and briefs** naming `cp-classify`, `control-plane-paths`, `cp-cardinality` or
+  `codeowners-cp` — this is the contract those verbs implement; the interface they meet is
+  [the CLI interface convention](cli-interface-convention.md).
+- **Skills that mention §CP.** The rule is: state the expectation, never compute a second answer to
+  a merge-gating question ([#4227](https://github.com/kamp-us/phoenix/issues/4227) is the cost of
+  the second opinion — a routing note contradicted a settled ruling and a lane was planned around an
+  approval that never fires).

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -104,10 +104,14 @@ fabrika adr resolve 0240
 Your own id, one last time: `absent` means nobody claimed it while you wrote; `in-flight` means
 another lane opened its PR first, so renumber now.
 
-**Expect this PR to route as control plane.** No `.decisions/**` path matches the control-plane
-pattern, so `cp-classify` decides it on content at the gate — and 84% of the corpus comes back
-guard-touching. **That gate is the authority; do not predict it and never reword the ADR to change
-its verdict.** A false §CP costs one approval, a false ordinary reaches `main` with none (#4386,
-#3416). If you think it misfired, say so on the PR (#2617).
+**How this PR routes depends on which model is live, so expect either.** v1's gate decides it on
+content: no `.decisions/**` path matches its control-plane pattern, so `cp-classify` falls to its
+ADR-0164 content probe, and 84% of the corpus comes back guard-touching — expect control plane.
+fabrika's ruled model is CODEOWNERS-only with no semantic detection at all, and `.decisions/`
+deliberately carries no row, so under it an ADR is not control plane
+([§CP classification](../../docs/control-plane-classification.md)). **Whichever answers, that gate is
+the authority; do not predict it and never reword the ADR to change its verdict.** A false §CP costs
+one approval, a false ordinary reaches `main` with none (#4386, #3416). If you think it misfired, say
+so on the PR (#2617).
 
 Report the path and the vocabulary outcome; do not summarize the body.

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -18,13 +18,17 @@ The reason is the deletion test. A fabrika that calls `pipeline-cli` can never b
 replaces it — every call is a tether that keeps the old tree alive. Isolation costs a duplicated
 ranking during the transition; a tether costs the ability to ever delete anything.
 
-**`adr classify` was considered and deliberately not derived.** Classifying an ADR as control-plane
-by content is what `cp-classify` already does at the merge gate, and that gate is the authority. A
-fabrika copy of the guard vocabulary could tell an author "ordinary" while the gate says
-"control-plane" — two answers to a merge-gating question, which is worse than either a tether or a
-drifted ranking. The skill instead states the expectation (assume §CP, never reword to dodge the
-gate) and leaves the verdict where it is enforced. The incidents behind it, #4386 and #3416, were the
-*gate* misclassifying, so an author-side predictor would not have caught them anyway.
+**`adr classify` was considered and deliberately not derived.** The control-plane question is settled
+at the merge gate, and that gate is the authority. A fabrika copy of it could tell an author
+"ordinary" while the gate says "control-plane" — two answers to a merge-gating question, which is
+worse than either a tether or a drifted ranking. That reasoning holds under either model, and the two
+differ: v1's `cp-classify` classifies an ADR **by content** (its ADR-0164 probe, reached because no
+`.decisions/**` path matches its path pattern), while fabrika's ruled model is CODEOWNERS-only,
+three-valued, and has **no semantic detection**, so under it an ADR is not control plane — see
+[§CP classification](../../docs/control-plane-classification.md). Either way the skill states the
+expectation, never rewords to dodge the gate, and leaves the verdict where it is enforced. The
+incidents behind it, #4386 and #3416, were the *gate* misclassifying, so an author-side predictor
+would not have caught them anyway.
 
 ## Verb inventory
 


### PR DESCRIPTION
The founder's §CP classification ruling existed only as a comment on #4927, while fourteen authoring briefs are being written against it right now — and a brief cannot cite a comment. This writes the ruling into `claude-plugins/fabrika/docs/control-plane-classification.md`, where a brief, a contract spec or a verb implementer can point at a file.

The new doc states all four ruled properties (CODEOWNERS as the single source of truth; three-valued §CP / not-§CP / UNKNOWN; unreadable CODEOWNERS ⇒ UNKNOWN ⇒ treated §CP, fail-closed; no agent judgement and no content regex), that enforcement rides GitHub's native code-owner review, and — explicitly, because it is the model's one load-bearing assumption — that **no semantic detection exists**, which makes owned-path-set completeness a named maintenance obligation owned by the `@kamp-us/control-plane` team rather than a silent assumption.

This is a **reconciliation, not a bug fix.** Two landed statements in `skills/adr/` describe v1's `pipeline-cli cp-classify` — which genuinely has two independent sources (`CONTROL_PLANE_RE` plus an ADR-0164 content probe) and four states — and are accurate about v1 today. They become stale only once fabrika's model is the corpus's model, so both are reworded as "v1's gate does X; fabrika's verb does Y, per the ruling" rather than as corrections. Nothing under `packages/pipeline-cli/` is touched.

**Where the contract lives, and why there.** `claude-plugins/fabrika/docs/` is fabrika's stated home for reference — "one doc per source of truth: an authoring session, a reviewer, or a verb implementer reads the doc, never a transcript and never another skill's prose" (`docs/README.md`). The ruling is exactly that: the rule an artifact is held to. It is not an ADR because it is reference rather than a repo-wide *why*, and because the same ruling puts `.decisions/` outside CODEOWNERS — recording it as an ADR would put the contract inside the one surface it deliberately leaves uncovered.

**Landed statements checked and left alone**, as #4932 asks: `claude-plugins/fabrika/skills/triage/SKILL.md` (L117) and `skills/triage/contract.md` (L63) both already say the skill must not assert §CP and that CODEOWNERS enforces it at merge. Confirmed at this head; untouched.

**§CP re-derived on both axes for this PR, not assumed.** Changed paths are all `claude-plugins/fabrika/**`, which matches no branch of the live `CONTROL_PLANE_RE` (its `claude-plugins/` branches are all `kampus-pipeline/`) and no row of `.github/CODEOWNERS`. No `.decisions/**` file is touched, so v1's ADR-0164 content clause has nothing to decide. Ordinary PR on both axes; the gate is still the authority.

Fixes #4932

## Deviations

- **Out-of-scope change** — **Said:** #4932's transcription of the ruling gives "the owned-path set must cover the semantic surfaces (e.g. the decisions dir)". **Did:** the doc records path completeness as the general obligation but states that `.decisions/` is deliberately **excluded** from CODEOWNERS, with the machine-run ADR contradiction sweep plus the non-blocking ADR readout in its place. **Why:** verifying the ruling at its source found a *later* founder comment on the same #4927 thread (2026-08-08, ~19:21 UTC — after #4932 was filed at ~19:11) that rules the ADR case specifically: `.decisions/` does not enter CODEOWNERS, ADRs get no code-owner review, and v1's content branch retires with nothing human replacing it. Recording only the earlier example would have written a superseded instruction into the corpus this issue exists to make citable. This is transcription of the source's latest state, not re-litigation. **Disposition:** for the reviewer to judge; both the general obligation and the carve-out are stated, in order, so the refinement reads as a decision rather than a contradiction.
- **Out-of-scope change** — **Said:** #4932 asks for the model to be written into a citable fabrika surface. **Did:** also added the doc's row to `claude-plugins/fabrika/docs/README.md`. **Why:** that README is the index every other fabrika doc is discovered through; an unindexed doc is citable only by someone who already knows it exists, which defeats the issue's purpose. **Disposition:** no action needed.
- **Known defect left unfixed** — **Said:** nothing in #4932 about it. **Did:** left `claude-plugins/fabrika/docs/cli-interface-convention.md` (~L210) saying `cp-classify` "decides control-plane membership at the merge gate". **Why:** it is true under both models and makes no content claim, and #4954 owns the sweep of §CP prose that has drifted from the live boundary. **Disposition:** left deliberately; #4954 is the home.
