### PR TITLE
fix(pipeline): a banked §CP PR with no ticking approval-watcher now reds (#4754)

### DIFF
--- a/.github/workflows/cp-bank-guard.yml
+++ b/.github/workflows/cp-bank-guard.yml
@@ -1,0 +1,64 @@
+name: cp-bank-guard
+
+# The reader that makes an UNARMED §CP approval-watcher visible (#4754).
+#
+# Banking a control-plane PR and arming the watcher that notices its approval were two
+# independent acts, and the board state after a bank-without-arm was identical to a
+# bank-with-arm. PR #4742 sat approved-and-unenqueued for 8h34m and nothing anywhere went red;
+# a human on a routine pass caught it. The approval-watcher writes a durable tick ledger, but
+# nothing read it — and a surface that only ever writes its own trace can never notice that it
+# stopped writing.
+#
+# So this job is the OUTSIDE reader: `pipeline-cli cp-bank check` derives the banked §CP set
+# from the board and reds when that set is non-empty with no ledger tick inside the window. It
+# is a schedule, not a `pull_request` gate, because the failure it detects has nothing to do
+# with any PR's diff — it is a state of the board that appears between PRs.
+on:
+  schedule:
+    # Hourly at :41 — off the top of the hour (the GitHub scheduler congests on-the-hour crons).
+    # With the 2h default window a strand surfaces within ~3h instead of the 8h34m it took a
+    # human to notice.
+    - cron: "41 * * * *"
+  workflow_dispatch:
+    inputs:
+      window-hours:
+        description: "How stale the newest approval-watcher tick may be before a non-empty banked set reds"
+        type: string
+        default: "2"
+
+concurrency:
+  group: cp-bank-guard
+  cancel-in-progress: false
+
+permissions:
+  contents: read # checkout
+  issues: read # read the approval-watcher tick ledger + the repo label universe
+  pull-requests: read # derive the banked set off the board
+
+jobs:
+  check:
+    name: banked control-plane PRs have a ticking approval-watcher
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 0 = green, 1 = RED (banked work with a missing or stale tick), 2 = UNKNOWN (the
+      # label does not exist in this repo, or an instant would not parse). Both non-zero states
+      # fail the job — an unanswered question is never a pass — and the report says which.
+      - name: Check every banked control-plane PR has a live approval-watcher
+        env:
+          # The CLI resolves the repo from GITHUB_REPOSITORY (auto-set) and reads via `gh api`;
+          # GH_TOKEN is what gh authenticates with.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node packages/pipeline-cli/src/bin.ts cp-bank check \
+            --window-hours "${{ inputs.window-hours || '2' }}"

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -198,9 +198,19 @@ merge model from human-hand-merge to **approve-then-pipeline-enqueue** — the h
 dead end at reviewed-ready; it carries **one extra gate** — the current-head approval — before the
 same shipper that ships a non-§CP PR enqueues it:
 
-- Drive the lane through coder → reviewer to **reviewed-ready**, then **bank it on the board**:
-  assign the PR to the approver and label it banked. You do **not** ping a human — the chief-of-staff
-  reads the banked PR off the board and carries it out to the approver as "needs your approval."
+- Drive the lane through coder → reviewer to **reviewed-ready**, then **bank it on the board** —
+  through the one verb that performs the whole act and proves it landed, never a hand-rolled trio of
+  `gh api` calls:
+
+  ```bash
+  "$PCLI" cp-bank apply --pr "$PR" --approver "$CP_APPROVER"
+  ```
+
+  It applies the banked label (`status:cp-banked`, provisioning it if the repo lacks it), assigns the
+  approver, requests their review, and reads the PR back — so a bank cannot half-land in the one way
+  that matters: **the label the watch set below is derived from is always written** (#4754). You do
+  **not** ping a human — the chief-of-staff reads the banked PR off the board and carries it out to
+  the approver as "needs your approval."
 - **Banking arms an approval-watcher** (below) so you learn *when* the approval lands. Once that
   watcher wakes you on a control-plane team approval at the PR's **current head** (machine gates still
   green), spawn the approval-aware `shipper` on that approved head. The shipper is itself
@@ -221,12 +231,20 @@ never waits on a human re-nudging the crew. The poll-vs-push shape is a self-pol
 it adds no engine→engine and no human-facing edge.
 
 - **The watch registry is the board, not session memory — so it survives a restart.** The set you
-  watch is *your banked §CP PRs*, and that set is already durable on the board: a §CP PR you banked is
-  assigned to the approver and carries the banked label. Arming the watcher *is* the bank — each loop
-  tick you re-derive the watch set from the board (`gh api` — open §CP PRs you banked, still awaiting
-  approval), never from an in-memory list a restarted engine would lose. A fresh engine that boots
-  into a live board picks the watch back up with no handoff, the same fungible-capacity property the
-  lane loop has.
+  watch is *your banked §CP PRs*, and that set is durable on the board: `cp-bank apply` labelled each
+  one `status:cp-banked` and assigned it to the approver. Each loop tick you re-derive the set from
+  the board through the **shipped** derivation — `"$PCLI" cp-bank set`, which prints the open banked
+  PRs as a JSON array — never from an in-memory list a restarted engine would lose, and never from a
+  derivation you write yourself here. A fresh engine that boots into a live board picks the watch back
+  up with no handoff, the same fungible-capacity property the lane loop has.
+- **Arming is a loop, so banking cannot *be* the arming — the absence of a tick is what reds.**
+  Banking writes board state once; the watcher keeps ticking, and no single act can guarantee a loop
+  keeps running. So the coupling is on the read side: `pipeline-cli cp-bank check` correlates the
+  board-derived banked set against the tick ledger and **reds when a non-empty banked set has no tick
+  inside a bounded window**. It runs hourly in CI (`.github/workflows/cp-bank-guard.yml`), so an
+  engine that banks and never arms is now loud within hours instead of invisible until a human
+  happens to look — the 8h34m strand of #4754. If you are holding banked §CP PRs, your loop ticking
+  is what keeps that guard green.
 - **Every tick leaves a durable record — the trace the transcript cannot be.** A tick's log lines go
   to *your* transcript, which is session-local, so from outside a loop that never ticked and a loop
   that ticked and found nothing were the same observation: silence. Worse, the asymmetry ran the wrong
@@ -382,7 +400,7 @@ it adds no engine→engine and no human-facing edge.
   #    board from a read that never executed, which is #3715's collapse one level up from the guards
   #    that prevent it. `--watch-unresolved` is the set-level `unknown:`: it names the failed read
   #    instead of asserting an empty board.
-  BANKED_JSON="$(banked_cp_prs_awaiting_approval_json)" \
+  BANKED_JSON="$("$PCLI" cp-bank set)" \
     && printf '%s' "$BANKED_JSON" | all_pages_are_arrays \
     || { "$PCLI" approval-watcher record --watch "" --watch-unresolved "board: unreadable payload"
          echo "approval-watcher: board read FAILED — UNKNOWN watch set, re-arming; NOT 'no banked §CP PR'"

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -107,6 +107,9 @@ export const registeredTools: ReadonlyArray<ToolRegistration> = [
 	tool("approval-watcher", () =>
 		import("./tools/approval-watcher/command.ts").then((m) => m.approvalWatcherCommand),
 	),
+	// #4754 — banking a §CP PR is one act that writes the label the watch set is derived from, and
+	// `check` is the outside reader that reds when that set is banked with no watcher ticking.
+	tool("cp-bank", () => import("./tools/cp-bank/command.ts").then((m) => m.cpBankCommand)),
 	tool("token-spend", () =>
 		import("./tools/token-spend/command.ts").then((m) => m.tokenSpendCommand),
 	),

--- a/packages/pipeline-cli/src/tools/approval-watcher/github.ts
+++ b/packages/pipeline-cli/src/tools/approval-watcher/github.ts
@@ -95,12 +95,11 @@ const createLedgerArgs = (repo: string): ReadonlyArray<string> => [
 ];
 
 /**
- * Resolve the ledger issue: an explicit number wins, then `$PIPELINE_APPROVAL_WATCHER_LEDGER`,
- * then the label search, and only then provisioning. Auto-provisioning is deliberate and bounded
- * to one issue ever — the alternative is a first tick that has nowhere to write and therefore
- * silently records nothing, which is the defect this tool exists to remove.
+ * Locate the ledger issue WITHOUT creating one: an explicit number wins, then
+ * `$PIPELINE_APPROVAL_WATCHER_LEDGER`, then the label search — and `null` when none exists.
+ * The read path stops here (a guard must not mint board state); only `resolveLedger` provisions.
  */
-const resolveLedger = Effect.fn("ApprovalWatcher.resolveLedger")(function* (
+const findLedger = Effect.fn("ApprovalWatcher.findLedger")(function* (
 	repo: string,
 	explicit: number | null,
 ) {
@@ -108,8 +107,20 @@ const resolveLedger = Effect.fn("ApprovalWatcher.resolveLedger")(function* (
 	const fromEnv = Number(process.env.PIPELINE_APPROVAL_WATCHER_LEDGER ?? "");
 	if (Number.isInteger(fromEnv) && fromEnv > 0) return fromEnv;
 	const found = yield* decodeIssues(yield* json(searchLedgerArgs(repo)));
-	const first = found[0];
-	if (first !== undefined) return first.number;
+	return found[0]?.number ?? null;
+});
+
+/**
+ * Resolve the ledger issue, provisioning one if none exists. Auto-provisioning is deliberate and
+ * bounded to one issue ever — the alternative is a first tick that has nowhere to write and
+ * therefore silently records nothing, which is the defect this tool exists to remove.
+ */
+const resolveLedger = Effect.fn("ApprovalWatcher.resolveLedger")(function* (
+	repo: string,
+	explicit: number | null,
+) {
+	const existing = yield* findLedger(repo, explicit);
+	if (existing !== null) return existing;
 	// The label may or may not exist; a 422 here is "already exists", which is not a failure.
 	yield* runGh(createLabelArgs(repo)).pipe(
 		Effect.catchTag("@kampus/gh-io/GhCommandError", () => Effect.void),
@@ -179,6 +190,39 @@ const ticks = Effect.fn("ApprovalWatcher.ticks")(function* (
 	return {ledger, records} satisfies TicksResult;
 });
 
+/**
+ * The ledger's liveness as an OUTSIDE reader sees it — the single-sourced answer to "has the
+ * watcher ticked, and when?" (#4754). Both non-`ticked` arms are a proven absence, not an
+ * unknown: the ledger auto-provisions on the first `record`, so no ledger and a ledger with no
+ * record both establish that no tick has ever run.
+ */
+export type LedgerLiveness =
+	| {readonly _tag: "no-ledger"}
+	| {readonly _tag: "no-record"; readonly ledger: number}
+	| {readonly _tag: "ticked"; readonly ledger: number; readonly lastAt: string};
+
+/**
+ * The newest tick instant across the ledger, NOT the last comment's — coalescing patches an
+ * older comment and bumps its `lastAt`, so recency lives in the max, never in comment order.
+ */
+const liveness = Effect.fn("ApprovalWatcher.liveness")(function* (
+	repo: string,
+	explicitLedger: number | null,
+) {
+	const ledger = yield* findLedger(repo, explicitLedger);
+	if (ledger === null) return {_tag: "no-ledger"} satisfies LedgerLiveness;
+	const records = (yield* ledgerComments(repo, ledger))
+		.map((c) => parseTick(c.body))
+		.filter((r): r is TickRecord => r !== null);
+	let lastAt: string | null = null;
+	for (const record of records) {
+		if (lastAt === null || record.lastAt > lastAt) lastAt = record.lastAt;
+	}
+	return (
+		lastAt === null ? {_tag: "no-record", ledger} : {_tag: "ticked", ledger, lastAt}
+	) satisfies LedgerLiveness;
+});
+
 type Fault = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
 
 /**
@@ -190,6 +234,7 @@ export class ApprovalWatcher extends Context.Service<
 	{
 		readonly record: (ledger: number | null, tick: TickInput) => Effect.Effect<RecordResult, Fault>;
 		readonly ticks: (ledger: number | null, limit: number) => Effect.Effect<TicksResult, Fault>;
+		readonly liveness: (ledger: number | null) => Effect.Effect<LedgerLiveness, Fault>;
 	}
 >()("@kampus/approval-watcher/ApprovalWatcher") {}
 
@@ -209,6 +254,8 @@ export const ApprovalWatcherLive: Layer.Layer<
 				repo.pipe(Effect.flatMap((r) => withSpawner(record(r, ledger, tick)))),
 			ticks: (ledger: number | null, limit: number) =>
 				repo.pipe(Effect.flatMap((r) => withSpawner(ticks(r, ledger, limit)))),
+			liveness: (ledger: number | null) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(liveness(r, ledger)))),
 		};
 	}),
 );

--- a/packages/pipeline-cli/src/tools/cp-bank/README.md
+++ b/packages/pipeline-cli/src/tools/cp-bank/README.md
@@ -1,0 +1,67 @@
+# cp-bank
+
+Banking a control-plane (§CP) PR, and the reader that notices when a banked PR has nobody
+watching it.
+
+## Why it exists
+
+Under [ADR 0135](../../../../../.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
+a §CP PR needs a human approval at its current head, and the pipeline owns the enqueue that
+follows. The engine *banks* the PR (hands it to the approver on the board) and *arms* an
+approval-watcher loop that notices the approval and spawns the shipper.
+
+Those were two independent acts with nothing coupling them. A bank-without-arm looked exactly
+like a bank-with-arm — same board state, no error, no red check, no missing artifact — so an
+approved §CP PR could sit unenqueued indefinitely and emit nothing. PR #4742 did, for 8h34m
+([#4754](https://github.com/kamp-us/phoenix/issues/4754)). Worse, the watch set the loop was
+supposed to re-derive from the board had no shipped implementation at all: the engine definition
+called a helper by name that was defined nowhere.
+
+## The three verbs
+
+```bash
+pipeline-cli cp-bank apply --pr 4742 --approver <login>
+pipeline-cli cp-bank set
+pipeline-cli cp-bank check --window-hours 2
+```
+
+- **`apply`** is the whole banking act as one call: provision the `status:cp-banked` label if the
+  repo lacks it, apply it, assign the approver, request their review — then **read the PR back**
+  and fail if the label or the assignment did not land. Banking cannot half-happen in the way
+  that mattered: the label the watch set is derived from is always written.
+- **`set`** prints the banked §CP watch set derived from the board, as a JSON array. This is the
+  shipped derivation the approval-watcher tick loop reads; it replaces a helper name with no
+  definition. An empty **array** is a derived-empty set; a non-zero exit with no stdout is a read
+  that never ran, which is never "nothing is banked".
+- **`check`** is the reader. It correlates the board-derived banked set against the
+  approval-watcher's own ledger (through `approval-watcher`'s `liveness`, never a second copy of
+  the ledger's shape) and reds when banked work exists with no tick inside the window.
+
+## `check`'s exit codes
+
+| exit | meaning |
+| --- | --- |
+| `0` | GREEN — nothing banked, or the watcher ticked inside the window |
+| `1` | RED — banked work exists and the newest tick is missing or older than the window |
+| `2` | UNKNOWN — the question was not answered (the `status:cp-banked` label does not exist in the repo, or an instant would not parse) |
+
+`2` is separate on purpose. A check that cannot see what it is looking for must not share an exit
+code with one that looked and disliked what it saw — a repo that never adopted the label would
+otherwise derive an empty set and pass vacuously, which is the same silent no-op
+[ADR 0092](../../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md) exists to kill.
+
+## Where it runs
+
+`.github/workflows/cp-bank-guard.yml` runs `check` hourly. That is the point of AC 3 on #4754:
+something **other than the approval-watcher itself** consumes the ledger, so an unarmed watcher
+surfaces without a human running `approval-watcher ticks` by hand. A surface that only ever writes
+its own trace can never notice that it stopped writing.
+
+## What it deliberately does not do
+
+It says nothing about the *quality* of a tick once the watcher is ticking — coverage, cadence
+jitter, disposition fidelity. That is a different defect
+([#4790](https://github.com/kamp-us/phoenix/issues/4790)), and #4754 is explicit that improving a
+watcher that is already ticking does not close it. `check` keys on tick **recency** only; set
+membership follows from the derivation being board-sourced, so any engine ticking against the same
+board picks up every banked PR.

--- a/packages/pipeline-cli/src/tools/cp-bank/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-bank/command.ts
@@ -1,0 +1,107 @@
+/**
+ * The `cp-bank` tool — `pipeline-cli cp-bank apply|set|check`.
+ *
+ *   apply --pr N --approver LOGIN   bank a §CP PR: one act (label + assign + review request)
+ *   set                             the board-derived banked §CP watch set, as JSON
+ *   check [--window-hours H]        RED when banked work exists and the watcher is not ticking
+ *
+ * `apply` and `set` are two ends of one fact: banking writes the label the derivation reads, so
+ * the watch set the approval-watcher rides can no longer be a helper name with no definition
+ * (#4754). `check` is the outside reader that makes a bank-without-arm loud.
+ *
+ * Exit codes on `check`: **0 = proven green, 1 = proven RED, 2 = UNKNOWN.** The unknown code is
+ * separate on purpose — a check that could not see what it was looking for must not share an exit
+ * with one that looked and disliked what it saw (the `exit-codes.ts` rule). Any other non-zero is
+ * a run that never happened, never a verdict.
+ */
+import {Console, Effect, Layer} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {onCheckFailed} from "../../gate-fail.ts";
+import {ApprovalWatcherLive} from "../approval-watcher/github.ts";
+import {RepoLabelsLive} from "../vocabulary-preflight/github.ts";
+import {checkArming} from "./gate.ts";
+import {BankBoard, BankBoardLive} from "./github.ts";
+
+const UNKNOWN_EXIT_CODE = 2;
+
+const prFlag = Flag.integer("pr").pipe(Flag.withDescription("the §CP pull request to bank"));
+
+const approverFlag = Flag.string("approver").pipe(
+	Flag.withDescription("the control-plane approver's GitHub login to bank the PR against"),
+);
+
+const ledgerFlag = Flag.integer("ledger").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the approval-watcher ledger issue to read (default: the tool's own resolution — never provisioned by this read)",
+	),
+);
+
+const windowFlag = Flag.integer("window-hours").pipe(
+	Flag.withDefault(2),
+	Flag.withDescription(
+		"how stale the newest approval-watcher tick may be before a non-empty banked set reds",
+	),
+);
+
+const apply = Command.make(
+	"apply",
+	{pr: prFlag, approver: approverFlag},
+	Effect.fn(function* ({pr, approver}) {
+		const result = yield* (yield* BankBoard).bank(pr, approver);
+		yield* Console.log(JSON.stringify(result));
+		process.stderr.write(
+			`cp-bank: #${pr} banked to ${approver} — labelled + assigned, confirmed by read-back. ` +
+				"It is now in the board-derived watch set `cp-bank set` returns.\n",
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Bank a control-plane PR as one act — apply the banked label, assign the approver, request their review — and prove it landed",
+	),
+);
+
+const set = Command.make(
+	"set",
+	{},
+	Effect.fn(function* () {
+		const banked = yield* (yield* BankBoard).set();
+		yield* Console.log(JSON.stringify(banked));
+		process.stderr.write(
+			`cp-bank: ${banked.length} banked §CP PR(s) derived from the board. An empty ARRAY is a ` +
+				"derived-empty set; a non-zero exit with no stdout is a read that never ran.\n",
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Print the banked control-plane watch set derived from the board, as a JSON array — the shipped derivation the approval-watcher tick reads",
+	),
+);
+
+const check = Command.make(
+	"check",
+	{ledger: ledgerFlag, windowHours: windowFlag},
+	Effect.fn(function* ({ledger, windowHours}) {
+		yield* checkArming(ledger, windowHours).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+			Effect.catchTag("CheckUnknown", (e) =>
+				Effect.sync(() => {
+					process.stderr.write(`${e.reason}\n`);
+					process.exit(UNKNOWN_EXIT_CODE);
+				}),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail when a non-empty banked control-plane set has no approval-watcher tick inside the window — the reader that makes an unarmed watcher visible",
+	),
+);
+
+export const cpBankCommand = Command.make("cp-bank").pipe(
+	Command.withSubcommands([apply, set, check]),
+	Command.withDescription(
+		"Bank a control-plane PR on the board, derive the banked watch set from it, and red when that set is banked with no approval-watcher ticking (#4754)",
+	),
+	Command.provide(Layer.mergeAll(BankBoardLive, RepoLabelsLive, ApprovalWatcherLive)),
+);

--- a/packages/pipeline-cli/src/tools/cp-bank/cp-bank.ts
+++ b/packages/pipeline-cli/src/tools/cp-bank/cp-bank.ts
@@ -1,0 +1,170 @@
+/**
+ * `cp-bank` pure core — the banking label, the board-derived watch set's shape, and the one
+ * decision that makes an UN-ARMED approval-watcher observably different from an armed-and-quiet
+ * one (#4754).
+ *
+ * Banking a §CP PR and arming the watcher were two independent acts, and the board state after
+ * a bank-without-arm was byte-identical to a bank-with-arm: no error, no red check, no missing
+ * artifact. PR #4742 stranded approved-and-unenqueued for 8h34m and emitted nothing. This core
+ * breaks that identity from the other side — it does not try to weld the two acts together (the
+ * watcher is a *loop*, so a one-shot "armed" flag would just move the same silence one level up),
+ * it makes the **absence of a tick reportable**: a non-empty banked set with no ledger tick inside
+ * a bounded window is a RED.
+ *
+ * Three-state on purpose, and the third state is the whole point. A check that cannot see what it
+ * is looking for must not return a plausible value — so when the scoping label does not exist in
+ * the repo at all, the empty banked set it would derive is UNKNOWN, never "nothing is banked"
+ * (ADR 0092's zero-scope fail-closed; the #4272 vacuous-pass shape).
+ *
+ * IO-free and total; `github.ts` supplies the `gh api` REST shell and `gate.ts` the wiring.
+ */
+import type {VocabularyPresence} from "../vocabulary-preflight/presence.ts";
+
+/**
+ * The label that makes the banked set derivable from the board. The watch registry the design
+ * rests on *is* the board, so the derivation has to key on something banking durably writes —
+ * `cp-bank apply` applies this label, `cp-bank set` derives the set from it, and the
+ * `vocabulary-preflight` required set asserts the adopting repo actually carries it.
+ */
+export const BANKED_LABEL = "status:cp-banked";
+
+/** One banked §CP PR as the board reports it. */
+export interface BankedPr {
+	readonly number: number;
+	readonly title: string;
+}
+
+/**
+ * What the approval-watcher ledger says about the loop's liveness. `no-record` is a PROVEN
+ * absence — the ledger auto-provisions on the first `record`, so a repo with no ledger, and a
+ * ledger with no tick record, are the same established fact: no tick has ever run.
+ */
+export type Liveness =
+	| {readonly _tag: "ticked"; readonly lastAt: string}
+	| {readonly _tag: "no-record"};
+
+/** Everything the verdict is a function of — no clock, no IO, so the decision is testable. */
+export interface ArmingInput {
+	readonly vocabulary: VocabularyPresence;
+	readonly banked: ReadonlyArray<BankedPr>;
+	readonly liveness: Liveness;
+	readonly now: string;
+	readonly windowHours: number;
+}
+
+/**
+ * `unknown` is not a soft red: it says the question was never answered. Keeping it distinct is
+ * what stops a repo that never adopted the label — or an unparseable timestamp — from reading as
+ * a healthy "nothing banked".
+ */
+export type ArmingVerdict =
+	| {readonly _tag: "green"; readonly detail: string; readonly banked: ReadonlyArray<BankedPr>}
+	| {
+			readonly _tag: "red";
+			readonly detail: string;
+			readonly banked: ReadonlyArray<BankedPr>;
+			readonly liveness: Liveness;
+			readonly windowHours: number;
+	  }
+	| {readonly _tag: "unknown"; readonly detail: string};
+
+const hoursBetween = (fromIso: string, toIso: string): number | null => {
+	const from = Date.parse(fromIso);
+	const to = Date.parse(toIso);
+	if (Number.isNaN(from) || Number.isNaN(to)) return null;
+	return (to - from) / 3_600_000;
+};
+
+const plural = (n: number, one: string): string => `${n} ${one}${n === 1 ? "" : "s"}`;
+
+/**
+ * The verdict, in the order the states have to be resolved: prove the scope exists, prove the
+ * clock is readable, and only then read an empty set as "nothing banked".
+ */
+export const judge = (input: ArmingInput): ArmingVerdict => {
+	const {vocabulary, banked, liveness, now, windowHours} = input;
+	if (vocabulary._tag === "absent") {
+		return {
+			_tag: "unknown",
+			detail:
+				`the scoping label(s) ${vocabulary.missing.join(", ")} do not exist in this repo, so the ` +
+				"banked set could not be derived — this is UNKNOWN, NOT an empty board. Create the label " +
+				`(\`gh api -X POST repos/<owner>/<repo>/labels -f name=${BANKED_LABEL}\`) or bank through ` +
+				"`pipeline-cli cp-bank apply`, which provisions it.",
+		};
+	}
+	if (!Number.isFinite(windowHours) || windowHours <= 0) {
+		return {
+			_tag: "unknown",
+			detail: `window must be a positive number of hours, got ${windowHours}`,
+		};
+	}
+	if (Number.isNaN(Date.parse(now))) {
+		return {_tag: "unknown", detail: `could not read the current instant (${JSON.stringify(now)})`};
+	}
+	if (banked.length === 0) {
+		return {
+			_tag: "green",
+			detail: `no open PR carries \`${BANKED_LABEL}\` — nothing is banked, so nothing is owed a tick`,
+			banked,
+		};
+	}
+	if (liveness._tag === "no-record") {
+		return {
+			_tag: "red",
+			detail:
+				`${plural(banked.length, "PR")} banked awaiting a control-plane approval, and the ` +
+				"approval-watcher ledger carries NO tick record at all — the watcher was never armed. " +
+				"An approved §CP PR here strands with nothing to enqueue it.",
+			banked,
+			liveness,
+			windowHours,
+		};
+	}
+	const age = hoursBetween(liveness.lastAt, now);
+	if (age === null) {
+		return {
+			_tag: "unknown",
+			detail: `the newest tick record carries an unreadable instant (${JSON.stringify(liveness.lastAt)})`,
+		};
+	}
+	if (age > windowHours) {
+		return {
+			_tag: "red",
+			detail:
+				`${plural(banked.length, "PR")} banked awaiting a control-plane approval, and the newest ` +
+				`approval-watcher tick is ${age.toFixed(1)}h old (window ${windowHours}h) — the watcher is ` +
+				"not ticking, so an approval that lands now is not enqueued by anything.",
+			banked,
+			liveness,
+			windowHours,
+		};
+	}
+	return {
+		_tag: "green",
+		detail:
+			`${plural(banked.length, "PR")} banked, and the approval-watcher ticked ${age.toFixed(1)}h ` +
+			`ago (window ${windowHours}h) — the loop is live over this set`,
+		banked,
+	};
+};
+
+const bankedRows = (banked: ReadonlyArray<BankedPr>): ReadonlyArray<string> =>
+	banked.map((pr) => `  #${pr.number} ${pr.title}`);
+
+export const renderReport = (verdict: ArmingVerdict): string => {
+	switch (verdict._tag) {
+		case "green":
+			return [`cp-bank: GREEN — ${verdict.detail}`, ...bankedRows(verdict.banked)].join("\n");
+		case "red":
+			return [
+				`cp-bank: RED — ${verdict.detail}`,
+				...bankedRows(verdict.banked),
+				"",
+				"Arm the approval-watcher on the engine's self-drain loop (`pipeline-cli approval-watcher",
+				"record` per tick), or unbank a PR that no longer needs an approval.",
+			].join("\n");
+		case "unknown":
+			return `cp-bank: UNKNOWN — ${verdict.detail}`;
+	}
+};

--- a/packages/pipeline-cli/src/tools/cp-bank/cp-bank.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/cp-bank/cp-bank.unit.test.ts
@@ -1,0 +1,96 @@
+import {describe, expect, it} from "vitest";
+import {PRESENT} from "../vocabulary-preflight/presence.ts";
+import {type ArmingInput, BANKED_LABEL, judge, renderReport} from "./cp-bank.ts";
+
+const NOW = "2026-08-02T18:10:00Z";
+const PR_4742 = {number: 4742, title: "fix(ship-it): merge authorization"};
+
+const input = (over: Partial<ArmingInput>): ArmingInput => ({
+	vocabulary: PRESENT,
+	banked: [PR_4742],
+	liveness: {_tag: "ticked", lastAt: "2026-08-02T18:00:00Z"},
+	now: NOW,
+	windowHours: 2,
+	...over,
+});
+
+/**
+ * The #4754 regression: before this tool, a §CP PR banked WITH an armed watcher and one banked
+ * WITHOUT were the same observation from outside. These two cases are that pair, and they must
+ * not agree.
+ */
+describe("bank-with-arm vs bank-without-arm are no longer the same state", () => {
+	const bankWithArm = judge(input({}));
+	const bankWithoutArm = judge(input({liveness: {_tag: "no-record"}}));
+
+	it("bank-with-arm is green", () => {
+		expect(bankWithArm._tag).toBe("green");
+	});
+
+	it("bank-without-arm is red", () => {
+		expect(bankWithoutArm._tag).toBe("red");
+	});
+
+	it("the two verdicts differ — the identity in the incident is broken", () => {
+		expect(bankWithoutArm._tag).not.toBe(bankWithArm._tag);
+		expect(renderReport(bankWithoutArm)).not.toBe(renderReport(bankWithArm));
+	});
+
+	it("the red names the stranded PR, so the report is actionable", () => {
+		expect(renderReport(bankWithoutArm)).toContain("#4742");
+	});
+});
+
+describe("staleness is measured against the window, not against 'a tick exists'", () => {
+	it("a tick inside the window is green", () => {
+		expect(judge(input({liveness: {_tag: "ticked", lastAt: "2026-08-02T16:30:00Z"}}))._tag).toBe(
+			"green",
+		);
+	});
+
+	it("a tick older than the window is red — the 8h34m strand", () => {
+		const verdict = judge(input({liveness: {_tag: "ticked", lastAt: "2026-08-02T09:36:00Z"}}));
+		expect(verdict._tag).toBe("red");
+		expect(renderReport(verdict)).toContain("8.6h old");
+	});
+
+	it("a tick exactly at the window boundary is still green", () => {
+		expect(judge(input({liveness: {_tag: "ticked", lastAt: "2026-08-02T16:10:00Z"}}))._tag).toBe(
+			"green",
+		);
+	});
+});
+
+describe("an empty banked set is a green, and only when it was PROVEN empty", () => {
+	it("nothing banked and no tick ever is green — nothing is owed a tick", () => {
+		expect(judge(input({banked: [], liveness: {_tag: "no-record"}}))._tag).toBe("green");
+	});
+
+	it("an absent scoping label is UNKNOWN, never the empty set it would derive", () => {
+		const verdict = judge(
+			input({banked: [], vocabulary: {_tag: "absent", missing: [BANKED_LABEL]}}),
+		);
+		expect(verdict._tag).toBe("unknown");
+		expect(renderReport(verdict)).toContain(BANKED_LABEL);
+	});
+
+	it("an absent label is UNKNOWN even when the board read returned banked PRs", () => {
+		expect(judge(input({vocabulary: {_tag: "absent", missing: [BANKED_LABEL]}}))._tag).toBe(
+			"unknown",
+		);
+	});
+});
+
+describe("an unreadable input never resolves to a verdict", () => {
+	it("an unparseable tick instant is UNKNOWN, not a stale-tick red", () => {
+		expect(judge(input({liveness: {_tag: "ticked", lastAt: "whenever"}}))._tag).toBe("unknown");
+	});
+
+	it("an unparseable now is UNKNOWN", () => {
+		expect(judge(input({now: ""}))._tag).toBe("unknown");
+	});
+
+	it("a non-positive window is UNKNOWN, not an instantly-red gate", () => {
+		expect(judge(input({windowHours: 0}))._tag).toBe("unknown");
+	});
+});

--- a/packages/pipeline-cli/src/tools/cp-bank/gate.ts
+++ b/packages/pipeline-cli/src/tools/cp-bank/gate.ts
@@ -1,0 +1,68 @@
+/**
+ * The `cp-bank check` gate — the READER that closes #4754's finding 2 ("nothing reads the ledger").
+ *
+ * It is deliberately a different tool from `approval-watcher`: the watcher writes the ledger, and
+ * a surface that only ever writes its own trace can never notice that it stopped writing. This
+ * gate consumes that trace from outside, correlating it against the board-derived banked set, and
+ * it runs on a schedule (`.github/workflows/cp-bank-guard.yml`) so the correlation happens without
+ * a human remembering to run `approval-watcher ticks` by hand.
+ *
+ * The ledger read is `ApprovalWatcher.liveness` — the tool that owns the ledger — never a second
+ * copy of the ledger's shape here.
+ */
+import {Console, Effect, Option} from "effect";
+import * as Schema from "effect/Schema";
+import {ApprovalWatcher} from "../approval-watcher/github.ts";
+import type {RepoLabelsError} from "../vocabulary-preflight/github.ts";
+import {RepoLabels} from "../vocabulary-preflight/github.ts";
+import {type ArmingVerdict, BANKED_LABEL, judge, type Liveness, renderReport} from "./cp-bank.ts";
+import type {BankBoardError} from "./github.ts";
+import {BankBoard} from "./github.ts";
+
+/** A proven RED: banked work is on the board and the watcher is not ticking over it. */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+/** Proven UNKNOWN — kept off `CheckFailed` so a red and an unanswered question never share a code. */
+export class CheckUnknown extends Schema.TaggedErrorClass<CheckUnknown>()("CheckUnknown", {
+	reason: Schema.String,
+}) {}
+
+export const checkArming = (
+	ledger: Option.Option<number>,
+	windowHours: number,
+): Effect.Effect<
+	void,
+	CheckFailed | CheckUnknown | BankBoardError | RepoLabelsError,
+	BankBoard | RepoLabels | ApprovalWatcher
+> =>
+	Effect.gen(function* () {
+		const board = yield* BankBoard;
+		const labels = yield* RepoLabels;
+		const watcher = yield* ApprovalWatcher;
+		const [banked, vocabulary, ledgerLiveness] = yield* Effect.all(
+			[board.set(), labels.presence([BANKED_LABEL]), watcher.liveness(Option.getOrNull(ledger))],
+			{concurrency: "unbounded"},
+		);
+		const liveness: Liveness =
+			ledgerLiveness._tag === "ticked"
+				? {_tag: "ticked", lastAt: ledgerLiveness.lastAt}
+				: {_tag: "no-record"};
+		const verdict: ArmingVerdict = judge({
+			vocabulary,
+			banked,
+			liveness,
+			now: new Date().toISOString(),
+			windowHours,
+		});
+		const report = renderReport(verdict);
+		switch (verdict._tag) {
+			case "green":
+				return yield* Console.log(report);
+			case "red":
+				return yield* Effect.fail(new CheckFailed({reason: report}));
+			case "unknown":
+				return yield* Effect.fail(new CheckUnknown({reason: report}));
+		}
+	});

--- a/packages/pipeline-cli/src/tools/cp-bank/github.ts
+++ b/packages/pipeline-cli/src/tools/cp-bank/github.ts
@@ -1,0 +1,188 @@
+/**
+ * The `gh api` REST shell behind `cp-bank` — the board write that banks a §CP PR, and the board
+ * read that derives the banked set back off it (#4754).
+ *
+ * The read is the shipped implementation of the watch-set derivation the engine def used to call
+ * by name only (`banked_cp_prs_awaiting_approval_json`, no definition anywhere in the tree). The
+ * write exists so the two can never disagree: banking goes through one verb that applies the very
+ * label the derivation keys on, provisioning it if the adopting repo lacks it.
+ *
+ * Same `Context.Service`-on-`ChildProcessSpawner` shape as `approval-watcher/github.ts`, over the
+ * shared `tracker/gh-io.ts` seam: REST only (GraphQL is broken on the kamp-us org), every infra
+ * failure a typed error in the `E` channel, untrusted REST JSON Schema-decoded at the boundary.
+ */
+import {Context, Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	type GhCommandError,
+	type GhParseError,
+	json,
+	type RepoResolutionError,
+	resolveRepo,
+	runGh,
+} from "../tracker/gh-io.ts";
+import {BANKED_LABEL, type BankedPr} from "./cp-bank.ts";
+
+const createLabelArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/labels`,
+	"-f",
+	`name=${BANKED_LABEL}`,
+	"-f",
+	"color=5319e7",
+	"-f",
+	"description=Control-plane PR banked on the board, awaiting a control-plane approval",
+];
+
+// `--slurp` because bare `--paginate` concatenates one JSON array per page, unparseable as a
+// whole once the set passes 100 (#3762).
+const bankedArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/issues`,
+	"-f",
+	"state=open",
+	"-f",
+	`labels=${BANKED_LABEL}`,
+	"-f",
+	"per_page=100",
+	"--paginate",
+	"--slurp",
+];
+
+const addLabelArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${pr}/labels`,
+	"-f",
+	`labels[]=${BANKED_LABEL}`,
+];
+
+const assignArgs = (repo: string, pr: number, login: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${pr}/assignees`,
+	"-f",
+	`assignees[]=${login}`,
+];
+
+const requestReviewArgs = (repo: string, pr: number, login: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/pulls/${pr}/requested_reviewers`,
+	"-f",
+	`reviewers[]=${login}`,
+];
+
+const readBackArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${pr}`,
+];
+
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	labels: Schema.Array(Schema.Struct({name: Schema.String})),
+	assignees: Schema.Array(Schema.Struct({login: Schema.String})),
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+
+const decodePages = Schema.decodeUnknownEffect(Schema.Array(Schema.Array(RawIssue)));
+const decodeIssue = Schema.decodeUnknownEffect(RawIssue);
+
+/** The label lives on PRs; the issues endpoint returns both, so plain issues are filtered out. */
+const listBanked = Effect.fn("BankBoard.listBanked")(function* (repo: string) {
+	const pages = yield* decodePages(yield* json(bankedArgs(repo)));
+	return pages
+		.flat()
+		.filter((raw) => raw.pull_request !== undefined)
+		.map((raw): BankedPr => ({number: raw.number, title: raw.title}));
+});
+
+/** What a bank landed, read back off the board rather than inferred from four 2xx responses. */
+export interface BankResult {
+	readonly pr: number;
+	readonly approver: string;
+	readonly labelled: boolean;
+	readonly assigned: boolean;
+}
+
+/** The bank failed its read-back: the mutations returned 2xx but the board does not carry them. */
+export class BankNotLanded extends Schema.TaggedErrorClass<BankNotLanded>()(
+	"@kampus/cp-bank/BankNotLanded",
+	{pr: Schema.Number, detail: Schema.String},
+) {}
+
+const bank = Effect.fn("BankBoard.bank")(function* (repo: string, pr: number, approver: string) {
+	// A 422 here is "the label already exists", which is the common case, not a failure.
+	yield* runGh(createLabelArgs(repo)).pipe(
+		Effect.catchTag("@kampus/gh-io/GhCommandError", () => Effect.void),
+	);
+	yield* runGh(addLabelArgs(repo, pr));
+	yield* runGh(assignArgs(repo, pr, approver));
+	// A review request on a PR the approver already reviewed 422s; the assignment + label are what
+	// the derivation reads, so this leg is best-effort rather than the whole bank's failure.
+	yield* runGh(requestReviewArgs(repo, pr, approver)).pipe(
+		Effect.catchTag("@kampus/gh-io/GhCommandError", () => Effect.void),
+	);
+	const landed = yield* decodeIssue(yield* json(readBackArgs(repo, pr)));
+	const result: BankResult = {
+		pr,
+		approver,
+		labelled: landed.labels.some((l) => l.name === BANKED_LABEL),
+		assigned: landed.assignees.some((a) => a.login === approver),
+	};
+	if (!result.labelled || !result.assigned) {
+		return yield* new BankNotLanded({
+			pr,
+			detail:
+				`read-back says labelled=${result.labelled} assigned=${result.assigned} — the bank did ` +
+				"not land, so the watch set would not carry this PR",
+		});
+	}
+	return result;
+});
+
+export type BankBoardError =
+	| RepoResolutionError
+	| GhCommandError
+	| GhParseError
+	| Schema.SchemaError;
+
+/**
+ * `BankBoard` — the board side of banking. `set` derives the banked §CP watch set; `bank` performs
+ * the whole banking act as one call and proves it landed.
+ */
+export class BankBoard extends Context.Service<
+	BankBoard,
+	{
+		readonly set: () => Effect.Effect<ReadonlyArray<BankedPr>, BankBoardError>;
+		readonly bank: (
+			pr: number,
+			approver: string,
+		) => Effect.Effect<BankResult, BankBoardError | BankNotLanded>;
+	}
+>()("@kampus/cp-bank/BankBoard") {}
+
+export const BankBoardLive: Layer.Layer<BankBoard, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(BankBoard)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				set: () => repo.pipe(Effect.flatMap((r) => withSpawner(listBanked(r)))),
+				bank: (pr: number, approver: string) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(bank(r, pr, approver)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
+++ b/packages/pipeline-cli/src/tools/vocabulary-preflight/vocabulary.ts
@@ -16,6 +16,7 @@
  * IO-free and total — the `gh api` label read and the `ROADMAP.md` read live in
  * `github.ts`/`gate.ts`.
  */
+import {BANKED_LABEL} from "../cp-bank/cp-bank.ts";
 import {ISSUE_TYPE_LABELS} from "../drive-issue-flow/type-route.ts";
 import {EXEMPT_LABELS, TRIAGED_LABEL} from "../homing-guard/homing-guard.ts";
 import {PLATFORM_LABELS} from "../lane/lane.ts";
@@ -42,6 +43,7 @@ export const LABEL_GROUPS: ReadonlyArray<LabelGroup> = [
 	{name: "issue types", labels: ISSUE_TYPE_LABELS},
 	{name: "standing lanes", labels: EXEMPT_LABELS},
 	{name: "platform discriminator", labels: PLATFORM_LABELS},
+	{name: "control-plane banking", labels: [BANKED_LABEL]},
 ];
 
 /** Every label the tools scope on, deduped, in group order. */


### PR DESCRIPTION
Fixes #4754

## The shape taken, and why

The issue offers two shapes. **This PR takes the second — make the absence of a tick reportable — and it does not take the first.**

Arming is not an act; it is a **loop**. Banking writes board state once, but the watcher has to keep ticking, and no single act at bank time can guarantee that a loop is still running an hour later. A "banking also writes an `armed` record" fix would produce exactly the defect it was meant to close, one level up: an `armed` record with no ticks after it is again indistinguishable from an armed-and-quiet watcher. So the coupling has to live on the **read** side.

What is now true: banking is one verb that always writes the label the watch set is derived from, and a **non-empty banked set with no ledger tick inside a bounded window is a RED that fires on a schedule**, with no human running anything by hand.

## The new tool — `pipeline-cli cp-bank`

```
cp-bank apply --pr N --approver LOGIN   bank a §CP PR as ONE act, proven by read-back
cp-bank set                             the board-derived banked watch set, as JSON
cp-bank check [--window-hours H]        RED when banked work has no ticking watcher
```

- **`apply`** provisions the `status:cp-banked` label if the repo lacks it, applies it, assigns the approver, requests their review, then **re-reads the PR** and fails if the label or assignment did not land. Four 2xx responses are not evidence the board carries the state; the read-back is.
- **`set`** is the shipped implementation of the derivation the engine definition called by name only. `banked_cp_prs_awaiting_approval_json` appeared exactly once repo-wide, at its call site, with no definition anywhere — each engine session was expected to invent it. It now prints the open PRs carrying the banked label as a JSON array, in the exact shape the existing tick frame already consumes (`all_pages_are_arrays`, then `jq -r '.[].number'`).
- **`check`** correlates that board-derived set against the approval-watcher's tick ledger and reds when the set is non-empty and the newest tick is missing or older than the window (default 2h).

## The reader (AC 3)

`.github/workflows/cp-bank-guard.yml` runs `cp-bank check` **hourly**. This is a schedule, not a `pull_request` gate, because the failure has nothing to do with any diff — it is a state of the board that appears *between* PRs.

`cp-bank` is deliberately a **different tool** from `approval-watcher`. The watcher writes the ledger, and a surface that only ever writes its own trace can never notice that it stopped writing. The ledger read itself is not re-derived here: `approval-watcher` grew a `liveness` method (the newest tick instant across the ledger, taken as a **max** rather than off the last comment, because coalescing patches an older comment and bumps its `lastAt`), and `cp-bank` consumes that. That read resolves the ledger **without provisioning** one — a guard must not mint board state, so `findLedger` was split out of `resolveLedger` and only the write path still creates.

Nothing in the §CP discharge predicate was touched. `cp-cardinality` remains the single source of the approve-then-enqueue decision; this PR is about whether the loop that consults it is running at all.

## The three-state contract, and why the third state is the point

`check` exits **0 = proven GREEN, 1 = proven RED, 2 = UNKNOWN**.

The defect class here is "a check that cannot see what it is looking for returns a plausible value instead of an error." A repo whose label set lacks `status:cp-banked` would derive an empty banked set and pass — vacuously, forever, exactly the shape #4272 fixed for the triage guards. So the scoping label's presence is proven **first**, against the live label universe (`RepoLabels.presence`, the existing seam), and its absence resolves UNKNOWN, never "nothing is banked". An unparseable tick instant, an unparseable clock, and a non-positive window resolve UNKNOWN too. `1` and `2` both fail the job; keeping them apart is what makes the report say *which* happened.

Adoption is asserted rather than assumed: `status:cp-banked` is added to the `vocabulary-preflight` required label set, so a repo that adopts the pipeline without the label reds at the preflight instead of silently getting a guard that can never fire. The label has been created on this repo.

## Live evidence, run against the real board

Before the label existed:

```
cp-bank: UNKNOWN — the scoping label(s) status:cp-banked do not exist in this repo, so the banked
set could not be derived — this is UNKNOWN, NOT an empty board. …
EXIT=2
```

After creating it:

```
cp-bank: GREEN — no open PR carries `status:cp-banked` — nothing is banked, so nothing is owed a tick
EXIT=0
```

`vocabulary-preflight check` → `prerequisites met — all 17 required labels exist`.

## The regression exercise (AC 4)

`packages/pipeline-cli/src/tools/cp-bank/cp-bank.unit.test.ts` pins the identity finding 1 established, and asserts it is broken. The same board — one banked §CP PR — judged twice:

| ledger state | verdict |
| --- | --- |
| a tick 10 minutes ago (bank **with** arm) | GREEN |
| no tick record at all (bank **without** arm) | RED, naming the stranded PR |

with an explicit assertion that the two verdicts differ. The staleness cases replay the incident's own numbers (a tick 8.6h stale reds); the fail-closed cases cover the absent label, the unreadable instants, and the non-positive window. 13 tests; the full pipeline-cli suite is 3031 passing.

## Explicitly out of scope (AC 5)

Nothing here improves a watcher that is already ticking. `check` keys on tick **recency** only — not coverage, cadence jitter, or disposition fidelity. Set membership follows from the derivation being board-sourced: any engine ticking against the same board derives every banked PR, so recency is the right signal for "is anything watching at all". Tick quality once armed is #4790, which the founder deliberately left in milestone #38.

## §CP status

This PR **is** control-plane, confirmed with `pipeline-cli cp-classify classify` → `control-plane [path-match]` (`packages/pipeline-cli/src/registry.ts`, plus `.github/workflows/`). It needs a control-plane approval at its current head. The triage note anticipated this: the reader has to live where it can run on a schedule, and that is inside §CP.
