### PR TITLE
fix(review-code): make glossary-freshness detector (3) able to fire, and loud when it cannot (#4700)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,6 +629,16 @@ jobs:
       # Same script runs locally: `bash .claude/skills/plan-epic/scripts/verify-roundtrip-diff.sh`.
       - run: bash .claude/skills/plan-epic/scripts/verify-roundtrip-diff.sh
 
+      # Positive pin for review-code's glossary-freshness detector (3) — a new public export on an
+      # existing package entry point (#4700). It shipped born-dead: the awk regex would not compile,
+      # its exit status was never tested, and the gate printed a clean `not applicable` skip for six
+      # weeks. A born-dead detector is invisible to any suite that only asserts the happy skip, so
+      # this harness asserts a MATCH, and carries five mutants — one per claim the fix rests on — so
+      # an assertion that stopped having teeth reds here rather than passing quietly. Hermetic: gh,
+      # git and the CLI shim are stubbed, no network.
+      # Same script runs locally: `bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh`.
+      - run: bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh
+
       # Gate-path drift guard (issue #720): assert the five CONTROL_PLANE_RE= copies
       # in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats are
       # byte-identical to the §CP canonical line, and that .claude/skills resolves to

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -826,7 +826,14 @@ The chain is the tail of the same
 probe LEADS it, EXECUTED, never asserted in prose, so the detector-blind `UNVERIFIABLE` branch is
 structurally unreachable when the glossary is absent. A fifth line,
 `glossary-freshness: CANNOT-EVALUATE (…)` at a non-zero exit, is the extraction's own fail-closed
-sentinel: fold it as `[UNVERIFIABLE]`, never as a not-applicable skip.
+sentinel: fold it as `[UNVERIFIABLE]`, never as a not-applicable skip. **A detector that could not
+RUN reaches that sentinel too**, and the reason it has to is that its silence is indistinguishable
+from a negative: detector (3) shipped with a regex awk refused to compile, exited 2 into a status
+nothing tested, and the gate printed its confident `not applicable` skip on 16 export-changing PRs
+over six weeks (#4700). So each detector's exit status is tested, and an unrun one is UNKNOWN. That
+the detectors can fire *at all* is pinned executably by
+[`scripts/verify-glossary-detector-fires.sh`](scripts/verify-glossary-detector-fires.sh) — a
+positive fixture, because a born-dead detector passes every test that only asserts the happy skip.
 
 Fold the result into the per-criterion table as one line, exactly like Step 3b's flag-gating facet —
 so the conjunctive verdict (Step 3) accounts for it like any other criterion:

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
@@ -29,6 +29,8 @@ REPO="$(kp_repo)" || cannot "target repo unresolved"
 # --paginate + streaming --jq so the full set past file #100 is seen (the API caps per_page at 100; #725)
 FILES_STATUS="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '.[] | "\(.status)\t\(.filename)"')"
+FILES_RC=$?
+[ "$FILES_RC" -eq 0 ] || cannot "the PR file list could not be read (gh api exited $FILES_RC) — detectors (1) and (2) would then scan an EMPTY file set and report no new surface"
 ADDED="$(printf '%s\n' "$FILES_STATUS" | awk -F'\t' '$1=="added"{print $2}')"
 
 # (1) a NEW feature folder: an added file under apps/web/worker/features/<dir>/... whose <dir>
@@ -52,9 +54,30 @@ done
 # CHANGES to expose a new name. This one is read from the diff hunk, not a path-status test:
 # inspect the diff of any touched public entry for an added `export …` line. Treat a public-entry
 # file with an added export as a new surface for this gate.
-PUBLIC_ENTRY_EXPORT_ADDED="$(gh pr diff "$PR" \
-  | awk '/^\+\+\+ b\/packages\/[^/]+\/src\/index\.(ts|tsx)$/{e=1;next}
-         /^\+\+\+ /{e=0} e && /^\+[^+].*\bexport\b/{print}')"
+#
+# Both patterns are awk STRINGS matched with `~`, never `/…/` regex literals, so the `/` inside a
+# bracket expression can never close the literal that contains it. The literal form is what left
+# this detector born-dead from the day it shipped: awk refused to compile `[^/]` inside `/…/`, exited
+# 2 into a status nobody tested, and the gate printed its clean skip for six weeks (#4700). `\b` is
+# gone for a second, independent reason found while fixing that one — one-true-awk (the macOS `awk
+# version 20200816` this gate runs on) does not implement it, so `\bexport\b` matched nothing even
+# with the class repaired; the explicit non-word-character alternation is the boundary instead.
+# SC2016 is declared, not waved off: this is LITERAL awk text, and shell-expanding its `$0` would
+# destroy the program. It is re-expanded nowhere — `awk "$DETECTOR3_AWK"` expands the variable, not
+# the `$0` inside its value.
+# shellcheck disable=SC2016
+DETECTOR3_AWK='
+BEGIN {
+  entry = "^\\+\\+\\+ b/packages/[^/]+/src/index\\.(ts|tsx)$"
+  expre = "(^|[^A-Za-z0-9_$])export([^A-Za-z0-9_$]|$)"
+}
+$0 ~ entry { in_entry = 1; next }
+/^\+\+\+ / { in_entry = 0; next }
+in_entry && /^\+/ && $0 ~ expre { print }
+'
+PUBLIC_ENTRY_EXPORT_ADDED="$(gh pr diff "$PR" | awk "$DETECTOR3_AWK")"
+DETECTOR3_RC=$?
+[ "$DETECTOR3_RC" -eq 0 ] || cannot "detector (3), the new-public-export scan, could not run — 'gh pr diff | awk' exited $DETECTOR3_RC; an unrun detector is UNKNOWN, never 'this PR added no export'"
 
 # the union: is there ANY new surface?
 NEW_SURFACE="$(printf '%s %s %s' "$NEW_FEATURE_DIRS" "$NEW_PACKAGES" "$PUBLIC_ENTRY_EXPORT_ADDED" | tr -s ' ')"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC2016
+# SC2016 is declared, not waved off: the mutant generators' sed programs are LITERAL awk text —
+# expanding their `$0` / `$` here would rewrite the mutants into something else.
+# Reviewer-runnable proof that glossary-freshness's detector (3) CAN FIRE, and that a detector which
+# could not run reaches CANNOT-EVALUATE rather than the clean skip (#4700).
+#
+# Detector (3) — a new public export added to an EXISTING package's entry point — shipped born-dead
+# on 2026-06-20 and stayed that way for six weeks. Every sighting of it was of the SKIP path, which
+# is the whole problem: a detector that can never match is invisible to any suite that only asserts
+# the happy `not applicable` line. So the property under test is POSITIVE — feed it a diff that does
+# add a public export and require a match — plus the loudness contract on the other side: an unrun
+# detector must be CANNOT-EVALUATE, never a plausible empty answer.
+#
+# Falsifiability is asserted, not assumed. The harness generates five MUTANTS, each reverting one
+# claim this fix rests on, and requires the assertions to go red under each:
+#   M1  the awk regex literal comes back        → positive fixture must go LOUD, not green
+#   M2  the detector status test is deleted     → an unrun detector must fall through to the skip
+#   M3  M1 + M2, i.e. the code as filed         → reproduces #4700 verbatim: a clean skip
+#   M4  `\b` comes back as the word boundary    → one-true-awk does not implement it, so no match
+#   M5  the added-line test and the export test fuse back into one `^\+[^+].*export` regex, where
+#       the `[^+]` eats the `e` of an unindented `+export` before `.*export` can match
+# M4 and M5 pin two further deaths found while fixing the filed one: with the character class
+# repaired and nothing else changed, this detector STILL matched nothing. M5 is also why the added-
+# line test and the export test are two separate patterns rather than one — split, `[^+]` is
+# harmless; fused, it silently drops the commonest shape of the surface the detector exists to see.
+#
+# Hermetic: `gh`, `git` and the CLI shim are stubbed, so this needs no auth, no network, and reads
+# no real PR.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, and no
+# `EXIT` trap — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this
+# harness's whole contract is its exit status.
+set -uo pipefail
+
+# PHYSICAL resolution (`cd -P` / `pwd -P`), unlike the sibling verify scripts: CI invokes this
+# through the `.claude/skills` symlink, and the `$DIR/../..` hop below has to land on the plugin
+# root. Resolved logically, `..` is folded textually and that hop lands on `.claude/`, where there
+# is no `lib/` — the mutants then all die at repo resolution, which is a CANNOT-EVALUATE too and so
+# scores as "mutant caught" while testing nothing.
+DIR="$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd -P)"
+SUT="$DIR/glossary-freshness.sh"
+fail=0
+
+if [ ! -f "$SUT" ]; then
+	echo "FAIL: zero scope — $SUT does not exist (ADR 0092)"
+	exit 1
+fi
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+BIN="$TMP/bin"
+PLUGIN="$TMP/plugin/bin"
+HEAD="$TMP/head"
+mkdir -p "$BIN" "$PLUGIN" "$HEAD" || { echo "FAIL: cannot create the stub dirs under $TMP"; exit 1; }
+printf 'BASE_REF=main\nHEAD_SHA=%s\n' "0000000000000000000000000000000000000000" > "$HEAD/head.env"
+
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "pr diff")        [ "$STUB_DIFF"  = FAIL ] && exit 1; cat "$STUB_DIFF";  exit 0 ;;
+  "api --paginate") [ "$STUB_FILES" = FAIL ] && exit 1; cat "$STUB_FILES"; exit 0 ;;
+esac
+exit 0
+STUB
+
+# Every path EXISTS on base except when the case says otherwise, so detectors (1) and (2) stay mute
+# and detector (3) is the only one that can speak — which is what isolates it under test.
+cat > "$BIN/git" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  cat-file) exit 0 ;;
+  ls-tree)  if [ "$2" = "-r" ]; then printf 'kit/package.json\nui/package.json\n'
+            else printf 'sozluk\npano\n'; fi
+            exit 0 ;;
+esac
+exit 0
+STUB
+
+cat > "$PLUGIN/pipeline-cli" <<'STUB'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "scratchpad path") printf '%s\n' "$STUB_HEAD_DIR" ;;
+esac
+exit 0
+STUB
+chmod +x "$BIN/gh" "$BIN/git" "$PLUGIN/pipeline-cli"
+
+# --- the fixtures ---------------------------------------------------------------------------------
+# POSITIVE: an existing package's entry point gains a public export. Unindented on purpose — that is
+# the shape M5's `[^+]` guard silently drops.
+cat > "$TMP/diff-export-added" <<'EOF'
+diff --git a/packages/kit/src/index.ts b/packages/kit/src/index.ts
+--- a/packages/kit/src/index.ts
++++ b/packages/kit/src/index.ts
+@@ -1,1 +1,2 @@
+ export const existing = 1;
++export const freshlyExposed = 2;
+EOF
+
+# NEGATIVE: the same entry point is touched, but nothing public is exposed.
+cat > "$TMP/diff-no-export" <<'EOF'
+diff --git a/packages/kit/src/index.ts b/packages/kit/src/index.ts
+--- a/packages/kit/src/index.ts
++++ b/packages/kit/src/index.ts
+@@ -1,1 +1,2 @@
+ export const existing = 1;
++const internalHelper = 2;
+EOF
+
+# NEGATIVE: an export is added, but not on a public entry point — the detector's scope, not its blindness.
+cat > "$TMP/diff-export-off-entry" <<'EOF'
+diff --git a/packages/kit/src/internal.ts b/packages/kit/src/internal.ts
+--- a/packages/kit/src/internal.ts
++++ b/packages/kit/src/internal.ts
+@@ -1,0 +1,1 @@
++export const notAnEntryPoint = 1;
+EOF
+
+printf 'modified\tpackages/kit/src/index.ts\n' > "$TMP/files-plain"
+printf 'modified\tpackages/kit/src/index.ts\nmodified\t.glossary/TERMS.md\n' > "$TMP/files-glossary-touched"
+
+# One case = one run of the script under one PR shape. `$OUT` is its stdout, `$RC` its exit status.
+run_case() {   # $1 = script, $2 = diff fixture (or FAIL), $3 = files fixture (or FAIL)
+	OUT="$(STUB_DIFF="$2" STUB_FILES="$3" STUB_HEAD_DIR="$HEAD" \
+		CLAUDE_PIPELINE_REPO=owner/repo CLAUDE_PLUGIN_ROOT="$TMP/plugin" \
+		PATH="$BIN:$PATH" bash "$1" 1 2>"$TMP/err")"
+	RC=$?
+}
+
+check() {   # $1 = label, $2 = expected stdout substring, $3 = zero|nonzero
+	if ! printf '%s' "$OUT" | grep -q "$2"; then
+		printf 'BAD   %-38s stdout missing %-34s got: %s\n' "$1" "$2" "${OUT:-<empty>}"
+		fail=1
+		return
+	fi
+	if [ "$3" = nonzero ] && [ "$RC" -eq 0 ]; then
+		printf 'BAD   %-38s CANNOT-EVALUATE must exit non-zero, exited 0\n' "$1"
+		fail=1
+		return
+	fi
+	if [ "$3" = zero ] && [ "$RC" -ne 0 ]; then
+		printf 'BAD   %-38s expected exit 0, exited %s\n' "$1" "$RC"
+		fail=1
+		return
+	fi
+	printf 'OK    %-38s %s\n' "$1" "$2"
+}
+
+echo "scope: $SUT, driven under 6 PR shapes + 5 mutants"
+
+# --- the POSITIVE fixture: detector (3) fires, and the gate reaches the new-surface branch ---------
+run_case "$SUT" "$TMP/diff-export-added" "$TMP/files-plain"
+check "added export ⇒ new surface" "scanned new surfaces" zero
+check "added export ⇒ FAIL, no TERMS touch" "FAIL — new surface added" zero
+run_case "$SUT" "$TMP/diff-export-added" "$TMP/files-glossary-touched"
+check "added export + TERMS touch ⇒ PASS" "PASS — new surface ships with" zero
+
+# --- the NEGATIVE fixtures: the skip is still reached when nothing public was added ----------------
+run_case "$SUT" "$TMP/diff-no-export" "$TMP/files-plain"
+check "no export added ⇒ skip" "not applicable — no new feature folder" zero
+run_case "$SUT" "$TMP/diff-export-off-entry" "$TMP/files-plain"
+check "export off the entry point ⇒ skip" "not applicable — no new feature folder" zero
+
+# --- could-not-run is LOUD, and is not the skip ---------------------------------------------------
+run_case "$SUT" FAIL "$TMP/files-plain"
+check "diff unreadable ⇒ CANNOT-EVALUATE" "CANNOT-EVALUATE (detector (3)" nonzero
+run_case "$SUT" "$TMP/diff-export-added" FAIL
+check "file list unreadable ⇒ CANNOT-EVAL" "CANNOT-EVALUATE (the PR file list" nonzero
+
+# --- falsifiability: every claim above must go red under a mutant that reverts it ------------------
+#
+# A mutant must live at the SAME depth as the original: the script resolves its shared lib and its
+# head handle through `../../../lib` and its own directory, so a mutant dropped in a flat temp dir
+# dies at repo resolution — which is a CANNOT-EVALUATE too, and would let a loose assertion score
+# the mutant as caught for entirely the wrong reason. Hence a mirrored tree, and hence every
+# expectation below naming its outcome precisely rather than matching CANNOT-EVALUATE at large.
+PLUGIN_SRC="$(CDPATH= cd -- "$DIR/../../.." && pwd)"
+MUT_DIR="$TMP/tree/skills/review-code/scripts"
+mkdir -p "$MUT_DIR" || { echo "FAIL: cannot create the mutant tree under $TMP"; exit 1; }
+ln -s "$PLUGIN_SRC/lib" "$TMP/tree/lib" || { echo "FAIL: cannot mirror the shared lib"; exit 1; }
+ln -s "$DIR/head-env.sh" "$MUT_DIR/head-env.sh" || { echo "FAIL: cannot mirror head-env.sh"; exit 1; }
+
+LITERAL='/^\+\+\+ b\/packages\/[^/]+\/src\/index\.(ts|tsx)$/ { in_entry = 1; next }'
+mutate() {   # $1 = name, $2… = sed programs
+	local name="$1"; shift
+	MUTANT="$MUT_DIR/mutant-$name.sh"
+	cp "$SUT" "$MUTANT"
+	for prog in "$@"; do
+		sed "$prog" "$MUTANT" > "$MUTANT.tmp" && mv "$MUTANT.tmp" "$MUTANT"
+	done
+	if cmp -s "$SUT" "$MUTANT"; then
+		printf 'BAD   %-38s the mutant is byte-identical to the original — it reverts nothing\n' "$name"
+		fail=1
+		return 1
+	fi
+	return 0
+}
+
+expect_mutant() {   # $1 = name, $2 = substring the BROKEN behaviour prints, $3 = why it has teeth
+	if printf '%s' "$OUT" | grep -q "$2"; then
+		printf 'OK    %-38s %s\n' "$1" "$3"
+	else
+		printf 'BAD   %-38s expected the reverted behaviour %s, got: %s\n' "$1" "$2" "${OUT:-<empty>}"
+		fail=1
+	fi
+}
+
+if mutate regex "s%^\$0 ~ entry.*%$LITERAL%"; then
+	run_case "$MUTANT" "$TMP/diff-export-added" "$TMP/files-plain"
+	expect_mutant "M1 regex literal returns" "CANNOT-EVALUATE (detector (3)" "the born-dead regex now goes LOUD, not green"
+fi
+
+if mutate status '/DETECTOR3_RC/d'; then
+	run_case "$MUTANT" FAIL "$TMP/files-plain"
+	expect_mutant "M2 status test deleted" "not applicable" "without the status test an unrun detector reads as a clean skip"
+fi
+
+if mutate asfiled "s%^\$0 ~ entry.*%$LITERAL%" '/DETECTOR3_RC/d'; then
+	run_case "$MUTANT" "$TMP/diff-export-added" "$TMP/files-plain"
+	expect_mutant "M3 the code as filed (#4700)" "not applicable" "reproduces the filed defect: a clean skip over a real new export"
+fi
+
+if mutate wordboundary 's%^  expre = .*%  expre = "\\\\bexport\\\\b"%'; then
+	run_case "$MUTANT" "$TMP/diff-export-added" "$TMP/files-plain"
+	expect_mutant "M4 \\b as the boundary" "not applicable" "one-true-awk has no \\b, so the detector matches nothing"
+fi
+
+if mutate addedline 's%^in_entry .*%in_entry \&\& /^\\+[^+].*export/ { print }%'; then
+	run_case "$MUTANT" "$TMP/diff-export-added" "$TMP/files-plain"
+	expect_mutant "M5 one combined added-line regex" "not applicable" "[^+] eats the e of an unindented +export before .*export can match"
+fi
+
+rm -rf "$TMP"
+if [ "$fail" -ne 0 ]; then
+	echo "FAIL: glossary-freshness detector (3) does not fire, or a could-not-run reads as a skip"
+	exit 1
+fi
+echo "PASS: detector (3) fires on an added public export, skips when none, and goes CANNOT-EVALUATE when it cannot run"


### PR DESCRIPTION
Fixes #4700

`review-code`'s Step-3c glossary-freshness detector (3) — *a new public export added to an existing package's entry point* — has never once matched, on any PR, since it shipped on 2026-06-20. Its awk regex closed its own `/…/` literal on the `/` inside `[^/]`, so awk exited **2 at parse time**; nothing tested that status, and the gate fell through to its confident `not applicable` skip. 16 export-changing PRs got a green verdict for a surface the gate was structurally unable to see.

This is the "a check that cannot see what it is looking for returns a plausible value instead of an error" shape. Fixing the regex is necessary and **not** sufficient, so this PR does three things: makes the delimiter collision unrepresentable, makes could-not-run a loud outcome, and pins the detector's ability to fire with a positive fixture backed by mutants.

## Re-derived, not taken on trust — and the filing was incomplete

Every premise was re-run first-hand on `awk version 20200816` (the one-true-awk that ships with macOS; `gawk`/`mawk`/`busybox` are absent on the reviewer host). The filed defect reproduced exactly — `awk: nonterminated character class`, **exit 2**, nothing on stdout.

But **repairing the character class alone would not have revived the detector.** Two further deaths were sitting behind the first, and only building the positive fixture surfaced them:

| # | Defect | Evidence |
|---|---|---|
| 1 | `[^/]` inside a `/…/` literal — awk will not compile the program | exit 2, `nonterminated character class` (the filed one) |
| 2 | `\bexport\b` — one-true-awk does not implement `\b` | with the class repaired, `+  export function f(){}` still matched nothing, rc 0 |
| 3 | `^\+[^+].*\bexport\b` — `[^+]` consumes the `e` of an unindented `+export`, leaving `.*export` nothing to match | `+export const x = 1;` matched nothing even with 1 and 2 both repaired |

Defect 3 is the sharpest: an unindented `+export …` is the *commonest* shape of the very surface the detector exists to catch. Had this PR fixed only what was filed, the gate would have stayed dead and looked repaired.

## The fix

**`claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh`**

- Both patterns are now awk **strings** matched with `~`, never `/…/` literals — the delimiter can no longer close a bracket expression, so defect 1 is unrepresentable rather than merely corrected.
- The word boundary is an explicit non-word-character alternation instead of `\b`.
- The added-line test and the export test are **two separate patterns**. Split, `[^+]` would be harmless; fused, it reintroduces defect 3. Mutant M5 pins exactly this, so the split cannot be "simplified" back.
- **Detector (3)'s exit status is tested.** A non-zero exit reaches the existing `cannot()` helper — `glossary-freshness: CANNOT-EVALUATE (…)`, non-zero exit, folded by the caller as `[UNVERIFIABLE]`. It can no longer reach a `not applicable` line.
- **The PR file-list read is tested too.** It is one line from the same silent skip: a failed `gh api` leaves detectors (1) and (2) scanning an empty file set and reporting no new surface. Slightly beyond the letter of AC 2, deliberately — leaving the sibling fail-open in place while fixing its twin would be the same defect with a different line number.

**`claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`** — the *why* lives in the prose per this skill's own extraction contract, so Step 3c now states that a detector which could not **run** reaches the CANNOT-EVALUATE sentinel, and points at the proof.

## Mutation testing — the counterexample is compiled

`claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh`, wired into CI's `validate skill frontmatter` job. Hermetic — `gh`, `git` and the CLI shim are stubbed, no auth, no network, no real PR read.

It asserts a **match**, not an absence. That is the whole point: this detector is *born-dead*, not drifted-dead, so every plausible existing test — all of which assert the happy skip — would pass against a detector that can never fire. All three field sightings of this bug were of the skip path.

Then it proves the assertions have teeth. Five mutants, one per claim the fix rests on; each must go red:

```
scope: …/glossary-freshness.sh, driven under 6 PR shapes + 5 mutants
OK    added export ⇒ new surface           scanned new surfaces
OK    added export ⇒ FAIL, no TERMS touch  FAIL — new surface added
OK    added export + TERMS touch ⇒ PASS    PASS — new surface ships with
OK    no export added ⇒ skip               not applicable — no new feature folder
OK    export off the entry point ⇒ skip    not applicable — no new feature folder
OK    diff unreadable ⇒ CANNOT-EVALUATE    CANNOT-EVALUATE (detector (3)
OK    file list unreadable ⇒ CANNOT-EVAL   CANNOT-EVALUATE (the PR file list
OK    M1 regex literal returns               the born-dead regex now goes LOUD, not green
OK    M2 status test deleted                 without the status test an unrun detector reads as a clean skip
OK    M3 the code as filed (#4700)           reproduces the filed defect: a clean skip over a real new export
OK    M4 \b as the boundary                  one-true-awk has no \b, so the detector matches nothing
OK    M5 one combined added-line regex       [^+] eats the e of an unindented +export before .*export can match
PASS: detector (3) fires on an added public export, skips when none, and goes CANNOT-EVALUATE when it cannot run
```

**M3 is the filed bug, reproduced under the harness**: with both halves reverted, a PR that genuinely adds a public export gets `not applicable` and exit 0. That is the counterexample, compiled and watched going red.

Two things the harness caught about *itself* while being built, both worth knowing because both are the same defect class as the bug under repair:

- M1's assertion first matched bare `CANNOT-EVALUATE`, which the mutants were also producing for an unrelated reason (they died at repo resolution, having been dropped in a flat temp dir where `../../../lib` does not resolve). Every mutant scored as *caught* while testing nothing. Fixed by mirroring the directory depth and by naming each expected outcome precisely.
- Run through the `.claude/skills` symlink — the exact path CI uses — logical `..` folding sent the plugin-root hop to `.claude/`, resurrecting the same false pass. The harness resolves physically now, and it is verified green **through the CI path**, not just the real one.

## Verification run

- `verify-glossary-detector-fires.sh` — PASS via both the real path and the `.claude/skills` CI path
- `pnpm typecheck` — 30/30 successful · `pnpm lint:worktree` — clean
- `shellcheck` — clean on both scripts (SC2016 declared at its raising site with its reason, never blanket-suppressed)
- `trap-status-guard check` — clean over the full 362-file corpus, as CI invokes it
- `gh-phoenix lint-skills` — clean · `validate-skills.sh` — 30 skills valid
- `workflow-contract`, `change-detect-guard`, `leak-guard` — clean

## §CP — human approval required at head

`pipeline-cli cp-classify classify` returns `control-plane [path-match]`, **BLOCKING (human merge)**. Not auto-shippable.

## Acceptance criteria

- [x] The awk detector compiles under `awk version 20200816`, verified by running it and showing the exit status — and, beyond the criterion, two further reasons it could not have matched are fixed and pinned (M4, M5)
- [x] The detector's exit status is tested; a non-zero awk exit emits `CANNOT-EVALUATE (…)` via `cannot()` and exits non-zero, never falling through to `not applicable` (M2 proves it, and the same test now covers the file-list read feeding detectors 1 and 2)
- [x] A positive fixture proves the detector fires: an added export on an existing `packages/<pkg>/src/index.ts` yields a non-empty `PUBLIC_ENTRY_EXPORT_ADDED` and reaches the new-surface branch
- [x] A negative fixture confirms the skip is still reached — two of them: no export added, and an export added off the entry point
- [ ] Treated as §CP and merged only with human approval at head — classified and routed; the merge is not mine
