### PR TITLE
feat(fabrika-cli): the eight review verbs the /review contract specifies

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1,12 +1,12 @@
 # @kampus/fabrika-cli
 
 The deterministic verb package [fabrika](../../claude-plugins/fabrika/) skills call.
-`fabrika <group> <verb> …` dispatches to a registered verb group. Five groups are
+`fabrika <group> <verb> …` dispatches to a registered verb group. Six groups are
 registered: `adr`, the six verbs the `/adr` skill's derived contract specifies; `report`,
 the three the `/report` contract specifies; `triage`, the intake-queue group the `/triage`
-contract specifies; `eval`, the graded-corpus harness the fabrika eval layer measures
-itself with; and `wire`, which owns the byte-level formats two skills meet through on a
-GitHub artifact.
+contract specifies; `review`, the eight the `/review` contract specifies; `eval`, the
+graded-corpus harness the fabrika eval layer measures itself with; and `wire`, which owns
+the byte-level formats two skills meet through on a GitHub artifact.
 
 ## Who it's for
 
@@ -233,6 +233,40 @@ Three properties of that substrate are worth knowing before the verbs arrive:
   ([`src/triage/scope.ts`](./src/triage/scope.ts)). A verdict driven by a silently truncated
   read is a verdict over unknown scope; pagination fixes the reach, and printing what was
   scanned is what makes the reach checkable from outside the process.
+
+## The `review` group
+
+Everything a text review needs off one pull request, plus the one sanctioned way to write a
+verdict back. The group implements
+[`claude-plugins/fabrika/skills/review/contract.md`](../../claude-plugins/fabrika/skills/review/contract.md).
+
+| Verb | What it answers |
+|---|---|
+| `review scope` | head SHA, linked issue, the code / doc / skill partition of the changed files, and the `self` / `harness` flags |
+| `review diff` | the diff bytes, with truncation refused rather than passed through |
+| `review criteria` | the linked issue's acceptance-criteria block, through the registered wire format |
+| `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration |
+| `review verdicts` | every verdict marker on the PR, each with its `current` / `stale` / `unbindable` binding |
+| `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan over the diff |
+| `review post` | the single sanctioned verdict emit — compose, bind, one comment per namespace, read back |
+| `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences |
+
+- **A check that cannot see what it is looking for does not return a plausible value.** An
+  unreadable response, a provably short read and a non-conforming payload each resolve to
+  their own loud refusal — `11`, `13` and `7` — and never to a clean pass. That is the whole
+  reason `13` exists beside the other two ([`src/review/codes.ts`](./src/review/codes.ts)).
+- **The overlapping exit codes are imported, not restated** — `3`, `5`, `6`, `7`, `8`, `9`,
+  `10` and `11` come from `../report/codes.ts` and `../triage/codes.ts` by re-export, so they
+  cannot drift from the shipped values.
+- **`current` / `stale` / `unbindable` stay three outcomes.** `review verdicts` is the first
+  consumer of [`verdict-marker.ts`](./src/wire/verdict-marker.ts)'s `bindToHead`, and folding
+  any two of them together is how a stale PASS reads as a current one.
+- **Four modules are imported rather than re-derived**: the AC parser, the verdict-marker
+  parser, `normalizeForReadback`, and the machine-local-path predicate.
+- **Every guard is demonstrated failing.**
+  [`src/review/mutation.unit.test.ts`](./src/review/mutation.unit.test.ts) plants a
+  counterexample per guard, breaks exactly that guard, and asserts the verb returns the
+  specific wrong answer instead — a guard that cannot be shown failing is not demonstrated.
 
 ## The `wire` group
 

--- a/packages/fabrika-cli/src/io/pulls.ts
+++ b/packages/fabrika-cli/src/io/pulls.ts
@@ -1,0 +1,225 @@
+/**
+ * The pull-request surface the `review` verbs read and write: one PR's metadata, its changed-file
+ * list, its diff bytes, the check runs at a commit, the invoking token's identity and repository
+ * permission, and the comment edit an upsert needs.
+ *
+ * The `issues.ts` disciplines hold here unchanged — `gh api` REST and never GraphQL, every list read
+ * paged, absent split from unreadable through {@link Existence}, and a shape that is not what was
+ * asked for treated as a failure rather than an empty result.
+ *
+ * **Every list read returns what it received alongside what the platform declared.** A review whose
+ * scope was silently truncated is a review over unknown scope, and the only way a caller can refuse
+ * that is to be handed both numbers. The reads below never narrow to the received list alone.
+ */
+import {Effect} from "effect";
+import {execCapture} from "./exec.ts";
+import {type Attempt, fail, ok, type Shell} from "./git.ts";
+import {absent, type Existence, httpStatusOf, present, splitJsonArrays, unknown} from "./issues.ts";
+import {isRecord, parseJson} from "./json.ts";
+
+export interface PullRecord {
+	readonly number: number;
+	readonly state: string;
+	readonly headSha: string;
+	readonly body: string;
+	/** What the platform says the PR changes — the denominator every completeness proof divides by. */
+	readonly changedFiles: number;
+	/** Issue comments on the PR, as the platform counts them. The verdict sweep's denominator. */
+	readonly comments: number;
+}
+
+const toPullRecord = (value: unknown): PullRecord | null => {
+	if (!isRecord(value)) return null;
+	const {number, state, head, body, changed_files: changedFiles, comments} = value;
+	const headSha = isRecord(head) && typeof head.sha === "string" ? head.sha : null;
+	if (typeof number !== "number" || typeof state !== "string" || headSha === null) return null;
+	if (typeof changedFiles !== "number") return null;
+	return {
+		number,
+		state,
+		headSha,
+		body: typeof body === "string" ? body : "",
+		changedFiles,
+		comments: typeof comments === "number" ? comments : 0,
+	};
+};
+
+/** One pull request, probed three ways — the 404 that seats a proven refusal is split from a 5xx. */
+export const getPullRequest = (repo: string, pr: number): Shell<Existence<PullRecord>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/pulls/${pr}`]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404 ? absent<PullRecord>() : unknown<PullRecord>(r.reason);
+		}
+		const record = toPullRecord(parseJson(r.stdout));
+		return record === null
+			? unknown<PullRecord>("`gh api` exited 0 but its output is not a pull request")
+			: present(record);
+	});
+
+/**
+ * Every changed path on the PR, paged.
+ *
+ * Read as typed JSON rather than through `--jq .filename`: the count of entries is the completeness
+ * proof, and a `jq` filter that errors mid-stream on one odd entry would shorten the list silently —
+ * which is the truncation the caller is trying to detect.
+ */
+export const listPullFiles = (repo: string, pr: number): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/pulls/${pr}/files?per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const files: string[] = [];
+		for (const page of splitJsonArrays(r.stdout)) {
+			const parsed = parseJson(page);
+			if (!Array.isArray(parsed)) {
+				return fail("`gh api` exited 0 but its output is not a list of changed files");
+			}
+			for (const value of parsed) {
+				if (!isRecord(value) || typeof value.filename !== "string") {
+					return fail("`gh api` exited 0 but one entry is not a changed file");
+				}
+				files.push(value.filename);
+			}
+		}
+		return ok(files);
+	});
+
+/** The unified diff bytes, served by the platform's diff media type. */
+export const getPullDiff = (repo: string, pr: number): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"-H",
+			"Accept: application/vnd.github.diff",
+			`repos/${repo}/pulls/${pr}`,
+		]);
+		return r.ok ? ok(r.stdout) : fail(r.reason);
+	});
+
+/** One check run at a commit. `conclusion` is `null` until `status` reaches `completed`. */
+export interface CheckRun {
+	readonly name: string;
+	readonly status: string;
+	readonly conclusion: string | null;
+}
+
+export interface CheckRunPage {
+	/** What the platform declared at this commit — the denominator the `13` refusal compares against. */
+	readonly declared: number;
+	readonly runs: ReadonlyArray<CheckRun>;
+}
+
+/**
+ * The check runs at one commit, paged, carrying the platform's own `total_count` beside them.
+ *
+ * `--paginate` concatenates one `{total_count, check_runs}` object per page, so the runs accumulate
+ * across pages while the declared total is read from the first — a later page's total is the same
+ * number, and taking the first keeps a zero-run trailing page from lowering it.
+ */
+export const listCheckRuns = (repo: string, sha: string): Shell<Attempt<CheckRunPage>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/commits/${sha}/check-runs?per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const runs: CheckRun[] = [];
+		let declared: number | null = null;
+		for (const page of splitJsonArrays(r.stdout)) {
+			const parsed = parseJson(page);
+			if (!isRecord(parsed) || !Array.isArray(parsed.check_runs)) {
+				return fail("`gh api` exited 0 but its output is not a check-run rollup");
+			}
+			if (declared === null) {
+				if (typeof parsed.total_count !== "number") {
+					return fail("`gh api` exited 0 but the check-run rollup declares no total_count");
+				}
+				declared = parsed.total_count;
+			}
+			for (const value of parsed.check_runs) {
+				if (
+					!isRecord(value) ||
+					typeof value.name !== "string" ||
+					typeof value.status !== "string"
+				) {
+					return fail("`gh api` exited 0 but one entry is not a check run");
+				}
+				runs.push({
+					name: value.name,
+					status: value.status,
+					conclusion: typeof value.conclusion === "string" ? value.conclusion : null,
+				});
+			}
+		}
+		return declared === null
+			? fail("`gh api` exited 0 and printed no check-run rollup at all")
+			: ok({declared, runs});
+	});
+
+/** Whether a commit exists in the repository — the proven-absent half of `review ci`'s `7`. */
+export const commitExists = (repo: string, sha: string): Shell<Existence<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/commits/${sha}`, "--jq", ".sha"]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404 ? absent<string>() : unknown<string>(r.reason);
+		}
+		const resolved = r.stdout.trim();
+		return resolved === ""
+			? unknown<string>("`gh api` exited 0 but named no commit")
+			: present(resolved);
+	});
+
+/** The login the invoking token authenticates as — half of the ACL lookup, and the upsert's key. */
+export const viewerLogin: Shell<Attempt<string>> = Effect.gen(function* () {
+	const r = yield* execCapture("gh", ["api", "user", "--jq", ".login"]);
+	if (!r.ok) return fail(r.reason);
+	const login = r.stdout.trim();
+	return login === "" ? fail("`gh api` exited 0 but named no login") : ok(login);
+});
+
+/**
+ * One collaborator's repository permission — `admin` / `maintain` / `write` / `triage` / `read`.
+ *
+ * A 404 is a **proven** answer here (the login is not a collaborator, so it holds no permission) and
+ * is deliberately not folded into the unreadable arm: the fence above it refuses either way, but the
+ * two refusals say different true things.
+ */
+export const permissionFor = (repo: string, login: string): Shell<Existence<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			`repos/${repo}/collaborators/${login}/permission`,
+			"--jq",
+			".permission",
+		]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404 ? absent<string>() : unknown<string>(r.reason);
+		}
+		const permission = r.stdout.trim();
+		return permission === ""
+			? unknown<string>("`gh api` exited 0 but named no permission")
+			: present(permission);
+	});
+
+/** Replace one issue comment's body — the edit half of the one-comment-per-namespace upsert. */
+export const patchComment = (repo: string, id: number, body: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/issues/comments/${id}`,
+			"-f",
+			`body=${body}`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		return isRecord(parsed) && typeof parsed.html_url === "string"
+			? ok(parsed.html_url)
+			: fail("`gh api` exited 0 but its output is not an edited comment");
+	});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -18,6 +18,7 @@ import type {Command} from "effect/unstable/cli";
 import {adrCommand} from "./adr/command.ts";
 import {evalCommand} from "./eval/command.ts";
 import {reportCommand} from "./report/command.ts";
+import {reviewCommand} from "./review/command.ts";
 import {triageCommand} from "./triage/command.ts";
 import {wireCommand} from "./wire/command.ts";
 
@@ -29,6 +30,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	adrCommand,
 	evalCommand,
 	reportCommand,
+	reviewCommand,
 	triageCommand,
 	wireCommand,
 ];

--- a/packages/fabrika-cli/src/review/advisory.ts
+++ b/packages/fabrika-cli/src/review/advisory.ts
@@ -1,0 +1,45 @@
+/**
+ * The §CP advisory carrier: a first line that withholds the SHA, and a canonical body line that
+ * carries it.
+ *
+ * The shape is ADR 0151's, reimplemented here rather than called (ADR 0238). Its whole point is that
+ * the two tokens are **distinct**: the first line stays SHA-less so an advisory can never be read as
+ * an auto-mergeable `PASS @ <sha>` marker (ADR 0111 preserved), while `Reviewed-head: @ <sha>` in the
+ * body records the head that was actually inspected. ADR 0226 makes the carrier PASS-only — a §CP
+ * FAIL posts the ordinary FAIL marker — which `review post` enforces on `10`.
+ */
+import {CLAUSE_SEPARATOR, type HeadSha, headSha} from "../wire/verdict-marker.ts";
+
+/** The advisory first line: the namespace, the fixed `advisory` token, and the human clause. */
+export const emitAdvisory = (namespace: string, clause: string): string =>
+	`${namespace}: advisory ${CLAUSE_SEPARATOR} ${clause}\n`;
+
+/** The canonical body line ADR 0151 pins. Emitted verbatim; a drifted prefix is not this line. */
+export const reviewedHeadLine = (sha: string): string => `Reviewed-head: @ ${sha}`;
+
+const FIRST_LINE = /^\s*\*{0,2}\s*(review(?:-[a-z0-9]+)*)\s*:\s*\*{0,2}\s*advisory\b/i;
+/** ADR 0151's anchored matcher — the `Reviewed-head:` prefix, hyphen and all, at a line's start. */
+const REVIEWED_HEAD = /^[ \t]*Reviewed-head:[ \t]*@?[ \t]*([0-9a-f]{7,40})\b/im;
+
+export interface AdvisoryCarrier {
+	readonly namespace: string;
+	readonly sha: HeadSha;
+}
+
+const firstNonBlankLine = (body: string): string =>
+	body.split("\n").find((line) => line.trim() !== "") ?? "";
+
+/**
+ * The advisory carrier a comment body holds, or `null`.
+ *
+ * Both halves are required: an advisory first line with no `Reviewed-head:` records no head, and a
+ * `Reviewed-head:` under an ordinary marker is not an advisory. Returning `null` for either is what
+ * keeps a half-formed advisory reaching the caller as a `malformed` row rather than as a verdict.
+ */
+export const readAdvisory = (body: string): AdvisoryCarrier | null => {
+	const first = FIRST_LINE.exec(firstNonBlankLine(body));
+	if (first?.[1] === undefined) return null;
+	const bound = REVIEWED_HEAD.exec(body);
+	const sha = bound?.[1] === undefined ? null : headSha(bound[1]);
+	return sha === null ? null : {namespace: first[1].toLowerCase(), sha};
+};

--- a/packages/fabrika-cli/src/review/append-criterion-verb.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.ts
@@ -1,0 +1,209 @@
+/**
+ * `review append-criterion` — append one reviewer-authored acceptance criterion under ADR 0079's
+ * four fences.
+ *
+ * The fences run in this order and each is a refusal, never a warning:
+ *
+ * 1. **ACL-gated, fail-closed** (ADR 0055) — below `write`, or *any* ACL lookup failure, refuses on
+ *    `14`. Authority comes from the ACL check, never from the text being plausible.
+ * 2. **Append-only** — the new body is the old plus exactly one row, proven by a diff guard before
+ *    the PATCH is sent (`./append.ts`).
+ * 3. **Frozen at round K = 3** — at or past the freeze the verb posts the escalation comment and
+ *    appends nothing. Append-rate stays bounded by fix-rate; a finding raised at the freeze routes
+ *    to a human.
+ * 4. **In-scope-only is the caller's** — the trace-to-stated-goal test is judgment. What this verb
+ *    contributes is the provenance tag, which is what makes a routed row auditable afterwards.
+ *
+ * v1's `reviewer-append-ac.sh` was mandated at four call sites and called at none — a first-class
+ * verb is the difference between a fence and a fence description.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getIssue, patchIssueBody} from "../io/issues.ts";
+import {permissionFor, viewerLogin} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {read as readCriteria} from "../wire/acceptance-criteria.ts";
+import {appendOnly, criterionRow, insertAfterLastCheckbox} from "./append.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
+import {
+	ACL_DENIED,
+	APPEND_ONLY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {badNumber, resolveTargetRepo} from "./target.ts";
+
+const VERB = "review append-criterion";
+
+/** The round at which the fence closes. ADR 0079 sets K = N = 3. */
+export const FREEZE_ROUND = 3;
+
+/** The permissions that resolve at or above `write`. Anything else, or a failed lookup, refuses. */
+const WRITE_OR_ABOVE = new Set(["admin", "maintain", "write"]);
+
+const SURFACE: AuthoredSurface = {
+	verb: VERB,
+	noun: "the criterion",
+	emptyMessage: `${VERB}: no criterion on stdin.`,
+	bareAtMessage: `${VERB}: the criterion is a bare "@" path reference — the text never arrived. Send it on stdin.`,
+	leakCorrection: "rewrite it repo-relative.",
+};
+
+export interface AppendCriterionOptions {
+	readonly issue: number;
+	readonly pr: number;
+	readonly round: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+const unreadable = (what: string, reason: string): VerbOutcome =>
+	refuse(PRECONDITION_UNKNOWN, `${VERB}: cannot read ${what}: ${reason} — nothing was written.`);
+
+const aclRefusal = (repo: string): VerbOutcome =>
+	refuse(
+		ACL_DENIED,
+		`${VERB}: token resolves below write on ${repo}, or the ACL could not be read — refusing the append (ADR 0055, fail-closed).`,
+	);
+
+export const runAppendCriterion = (
+	options: AppendCriterionOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, pr, round, json} = options;
+		const badIssue = badNumber(VERB, "an issue number", issue);
+		if (badIssue !== null) return badIssue;
+		const badPr = badNumber(VERB, "a pull-request number", pr);
+		if (badPr !== null) return badPr;
+		const badRound = badNumber(VERB, "a review round", round);
+		if (badRound !== null) return badRound;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+		const leaked = leakRefusal(SURFACE, authored.text);
+		if (leaked !== null) return leaked;
+
+		// Fence 1 — the ACL, fail-closed. A failed lookup is a denial, not a pass.
+		const me = yield* viewerLogin;
+		if (me._tag === "Failure") return aclRefusal(repo);
+		const permission = yield* permissionFor(repo, me.value);
+		if (permission._tag !== "Present" || !WRITE_OR_ABOVE.has(permission.value)) {
+			return aclRefusal(repo);
+		}
+		const diagnostics = [`${VERB}: ${me.value} resolves ${permission.value} on ${repo}.`];
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `${VERB}: issue #${issue} not found in ${repo}.`, diagnostics);
+		}
+		if (target._tag === "Unknown") {
+			return unreadable(`issue #${issue} in ${repo}`, target.reason);
+		}
+		if (target.value.state !== "open") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: issue #${issue} is closed — an appended row there enters no cycle; file the finding instead.`,
+				diagnostics,
+			);
+		}
+
+		const block = readCriteria(target.value.body);
+		if (block._tag !== "Found") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${issue} carries no conforming acceptance-criteria block (${
+					block._tag === "Absent" ? "absent" : "malformed"
+				}: ${block.reason}) — nothing to append under.`,
+				diagnostics,
+			);
+		}
+		const before = block.value;
+
+		// Fence 3 — frozen at K = 3. The escalation lands and the AC does not; both are proven exit-0
+		// answers, discriminated by the stdout token.
+		if (round >= FREEZE_ROUND) {
+			const escalated = yield* createComment(
+				repo,
+				issue,
+				`review append-criterion: a finding from PR #${pr}'s round ${round} was NOT appended — the acceptance-criteria fence is frozen at round ${FREEZE_ROUND} (ADR 0079). Routing it to a human instead.\n\n${authored.text}`,
+			);
+			if (escalated._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: the escalation comment failed: ${escalated.reason} — UNKNOWN whether it landed; nothing was appended either way. Re-run.`,
+					diagnostics,
+				);
+			}
+			return json
+				? answer(
+						JSON.stringify({
+							outcome: "escalated-frozen",
+							issue,
+							rows: before.length,
+							round,
+							acl: permission.value,
+						}),
+						diagnostics,
+					)
+				: answer(`escalated-frozen\t${issue}\t${round}`, diagnostics);
+		}
+
+		// Fence 2 — append-only, proven against the old bytes before anything is sent.
+		const row = criterionRow(authored.text, pr, round);
+		const composed = insertAfterLastCheckbox(target.value.body, row);
+		if (composed === null || appendOnly(target.value.body, composed)._tag === "Violates") {
+			return refuse(
+				APPEND_ONLY,
+				`${VERB}: the append would drop or mutate an existing row — refusing (append-only fence).`,
+				diagnostics,
+			);
+		}
+
+		const written = yield* patchIssueBody(repo, issue, composed);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: PATCH failed: ${written.reason} — UNKNOWN whether the row landed; re-read #${issue} before retrying.`,
+				diagnostics,
+			);
+		}
+
+		// The read-back re-reads the block through the same format and compares row by row.
+		const back = yield* getIssue(repo, issue);
+		const reread = back._tag === "Present" ? readCriteria(back.value.body) : null;
+		const after = reread !== null && reread._tag === "Found" ? reread.value : null;
+		const grew =
+			after !== null &&
+			after.length === before.length + 1 &&
+			before.every((criterion, index) => after[index]?.text === criterion.text) &&
+			after[before.length]?.text.includes(authored.text.trim()) === true;
+		if (!grew) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: read-back does not show the prior rows plus this one — inspect #${issue}.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "appended",
+						issue,
+						rows: after.length,
+						round,
+						acl: permission.value,
+					}),
+					diagnostics,
+				)
+			: answer(`appended\t${issue}\t${after.length}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/review/append-criterion-verb.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.ts
@@ -24,7 +24,7 @@ import {permissionFor, viewerLogin} from "../io/pulls.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {read as readCriteria} from "../wire/acceptance-criteria.ts";
-import {appendOnly, criterionRow, insertAfterLastCheckbox} from "./append.ts";
+import {appendOnly, criterionRow, grewByOne, insertAfterLastCriterion} from "./append.ts";
 import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
 import {
 	ACL_DENIED,
@@ -157,10 +157,22 @@ export const runAppendCriterion = (
 				: answer(`escalated-frozen\t${issue}\t${round}`, diagnostics);
 		}
 
-		// Fence 2 — append-only, proven against the old bytes before anything is sent.
+		// Fence 2 — append-only, proven twice before anything is sent: against the old bytes, and
+		// against what the registered format reads back out of the composed body.
 		const row = criterionRow(authored.text, pr, round);
-		const composed = insertAfterLastCheckbox(target.value.body, row);
-		if (composed === null || appendOnly(target.value.body, composed)._tag === "Violates") {
+		const last = before[before.length - 1]?.text ?? "";
+		const composed = insertAfterLastCriterion(target.value.body, last, row);
+		const composedBlock = composed === null ? null : readCriteria(composed);
+		const wouldGrow = grewByOne(
+			before,
+			composedBlock !== null && composedBlock._tag === "Found" ? composedBlock.value : null,
+			authored.text,
+		);
+		if (
+			composed === null ||
+			appendOnly(target.value.body, composed)._tag === "Violates" ||
+			!wouldGrow
+		) {
 			return refuse(
 				APPEND_ONLY,
 				`${VERB}: the append would drop or mutate an existing row — refusing (append-only fence).`,
@@ -181,12 +193,7 @@ export const runAppendCriterion = (
 		const back = yield* getIssue(repo, issue);
 		const reread = back._tag === "Present" ? readCriteria(back.value.body) : null;
 		const after = reread !== null && reread._tag === "Found" ? reread.value : null;
-		const grew =
-			after !== null &&
-			after.length === before.length + 1 &&
-			before.every((criterion, index) => after[index]?.text === criterion.text) &&
-			after[before.length]?.text.includes(authored.text.trim()) === true;
-		if (!grew) {
+		if (!grewByOne(before, after, authored.text) || after === null) {
 			return refuse(
 				READBACK_MISMATCH,
 				`${VERB}: read-back does not show the prior rows plus this one — inspect #${issue}.`,

--- a/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.unit.test.ts
@@ -1,0 +1,324 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {runAppendCriterion} from "./append-criterion-verb.ts";
+import {
+	ACL_DENIED,
+	APPEND_ONLY,
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {issue} from "./fixtures.test-support.ts";
+
+const USER = /^gh api user --jq \.login$/;
+const PERMISSION = /^gh api repos\/o\/r\/collaborators\/kampus-bot\/permission --jq \.permission$/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4287 -f body=/;
+const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/4287\/comments /;
+
+const TEXT = "a regression test covers qty > 1";
+const ROW = `- [ ] ${TEXT} <!-- ac:review pr:#4321 round:1 -->`;
+
+const APPENDED = `Build the thing.
+
+### Acceptance criteria
+
+- [ ] the first retry delay equals \`base\`
+- [x] the retry guide documents the delay table
+${ROW}
+`;
+
+const options = {
+	issue: 4287,
+	pr: 4321,
+	round: 1,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: TEXT}),
+};
+
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[USER, okOut("kampus-bot")],
+	[PERMISSION, okOut("write")],
+	[once(ISSUE), issue()],
+	[ISSUE, issue(APPENDED)],
+	[PATCH, okOut("{}")],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runAppendCriterion({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+describe("runAppendCriterion", () => {
+	it("appends the row and prints the row count after", async () => {
+		const out = await run(happy());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("appended\t4287\t3\n");
+	});
+
+	it("writes exactly one row, tagged with its provenance", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
+		const write = shell.calls.find((call) => PATCH.test(call)) ?? "";
+		expect(write).toContain(ROW);
+	});
+
+	// Fence 1 — the ACL, fail-closed.
+	it("refuses a token below write on 14, and writes nothing", async () => {
+		const shell = fakeShell([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("read")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
+		expect(out.code).toBe(ACL_DENIED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review append-criterion: token resolves below write on o/r, or the ACL could not be read — refusing the append (ADR 0055, fail-closed).",
+		);
+		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+	});
+
+	it("refuses a FAILED ACL lookup on 14 too — authority never comes from a failed read", async () => {
+		const lookupFailed = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(lookupFailed.code).toBe(ACL_DENIED);
+
+		const noIdentity = await run([[USER, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(noIdentity.code).toBe(ACL_DENIED);
+	});
+
+	it("admits admin and maintain, which resolve above write", async () => {
+		for (const permission of ["admin", "maintain", "write"]) {
+			const out = await run([
+				[USER, okOut("kampus-bot")],
+				[PERMISSION, okOut(permission)],
+				[once(ISSUE), issue()],
+				[ISSUE, issue(APPENDED)],
+				[PATCH, okOut("{}")],
+			]);
+			expect(out.code).toBe(0);
+		}
+		const triage = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("triage")],
+		]);
+		expect(triage.code).toBe(ACL_DENIED);
+	});
+
+	// Fence 2 — append-only, proven before the PATCH is sent.
+	it("puts the row INSIDE the block even when a later section carries checkboxes of its own", async () => {
+		const withLaterList = `### Acceptance criteria
+
+- [ ] the only criterion
+
+## Notes
+
+- [ ] a checkbox that is not a criterion
+`;
+		const shell = fakeShell([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[once(ISSUE), issue(withLaterList)],
+			[
+				ISSUE,
+				issue(
+					withLaterList.replace("- [ ] the only criterion", `- [ ] the only criterion\n${ROW}`),
+				),
+			],
+			[PATCH, okOut("{}")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
+		expect(out.code).toBe(0);
+		const write = shell.calls.find((call) => PATCH.test(call)) ?? "";
+		expect(write.indexOf(ROW)).toBeLessThan(write.indexOf("## Notes"));
+	});
+
+	/**
+	 * Exit 15 is unreachable from any input this verb accepts, and that is the fence working rather
+	 * than a gap: the composition is built to satisfy it, so no PR body can drive it. It is therefore
+	 * demonstrated by **mutation** — `./mutation.unit.test.ts` plants a composition that appends past
+	 * the block and asserts this verb reds on 15 with this message and sends no PATCH. Asserting it
+	 * loosely here (`code is 15 or 0`) would score a guard that never ran as caught, which is the
+	 * failure mode a sibling lane hit; the constant's distinctness is pinned in `./codes.unit.test.ts`.
+	 */
+	it("keeps 15 distinct from every other refusal this verb can reach", async () => {
+		const reachable = await Promise.all([
+			run([
+				[USER, okOut("kampus-bot")],
+				[PERMISSION, okOut("read")],
+			]),
+			run([
+				[USER, okOut("kampus-bot")],
+				[PERMISSION, okOut("write")],
+				[ISSUE, errOut("gh: Not Found (HTTP 404)")],
+			]),
+			run(happy(), {stdin: Effect.succeed({_tag: "Text", text: ""})}),
+		]);
+		expect(reachable.map((out) => out.code)).not.toContain(APPEND_ONLY);
+	});
+
+	// Fence 3 — frozen at round 3.
+	it("escalates instead of appending at the freeze, and appends NOTHING", async () => {
+		const shell = fakeShell([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[ISSUE, issue()],
+			[COMMENT, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runAppendCriterion({...options, round: 3}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("escalated-frozen\t4287\t3\n");
+		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+		expect(shell.calls.some((call) => COMMENT.test(call))).toBe(true);
+	});
+
+	it("reports a failed escalation comment as 8, naming which write it was", async () => {
+		const out = await run(
+			[
+				[USER, okOut("kampus-bot")],
+				[PERMISSION, okOut("write")],
+				[ISSUE, issue()],
+				[COMMENT, errOut("gh: timeout")],
+			],
+			{round: 3},
+		);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the escalation comment failed");
+		expect(out.stderr.at(-1)).toContain("nothing was appended either way");
+	});
+
+	// The target's own preconditions.
+	it("refuses an absent issue on 7 and a CLOSED one on 7 — a row there enters no cycle", async () => {
+		const absent = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[ISSUE, errOut("gh: Not Found (HTTP 404)")],
+		]);
+		expect(absent.code).toBe(ZERO_SCOPE);
+
+		const closed = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[ISSUE, issue(undefined, "closed")],
+		]);
+		expect(closed.code).toBe(ZERO_SCOPE);
+		expect(closed.stderr.at(-1)).toContain("file the finding instead");
+	});
+
+	it("refuses an issue with no conforming block on 7, naming absent vs malformed", async () => {
+		const out = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[ISSUE, issue("nothing to append under")],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("(absent:");
+		expect(out.stderr.at(-1)).toContain("nothing to append under.");
+	});
+
+	it("refuses an unreadable issue on 11 — nothing was written", async () => {
+		const out = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("nothing was written");
+	});
+
+	it("reports a failed PATCH as 8 — UNKNOWN whether the row landed", async () => {
+		const out = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[ISSUE, issue()],
+			[PATCH, errOut("gh: timeout")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("re-read #4287 before retrying");
+	});
+
+	it("refuses on 9 when the read-back does not show the prior rows plus this one", async () => {
+		const out = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[once(ISSUE), issue()],
+			[ISSUE, issue()],
+			[PATCH, okOut("{}")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("inspect #4287");
+	});
+
+	it("refuses a read-back that MUTATED a prior row, even at the right length", async () => {
+		const mutated = `### Acceptance criteria
+
+- [ ] a totally different first row
+- [x] the retry guide documents the delay table
+${ROW}
+`;
+		const out = await run([
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[once(ISSUE), issue()],
+			[ISSUE, issue(mutated)],
+			[PATCH, okOut("{}")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+
+	// The stdin guard.
+	it("refuses empty stdin on 3, a bare @ on 6, and a machine-local path on 5", async () => {
+		const empty = await run(happy(), {stdin: Effect.succeed({_tag: "Text", text: " \n"})});
+		expect(empty.code).toBe(EMPTY_STDIN);
+		expect(empty.stderr.at(-1)).toBe("review append-criterion: no criterion on stdin.");
+
+		const bare = await run(happy(), {stdin: Effect.succeed({_tag: "Text", text: "@notes/ac.md"})});
+		expect(bare.code).toBe(BARE_AT_PATH);
+
+		const leaked = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "cover /Users/someone/scratch/case.md"}),
+		});
+		expect(leaked.code).toBe(LEAKED_PATH);
+		expect(leaked.stderr.at(-1)).toContain("rewrite it repo-relative.");
+	});
+
+	it("writes nothing at all on a stdin refusal — not even the ACL lookup", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(
+			Effect.provide(
+				runAppendCriterion({...options, stdin: Effect.succeed({_tag: "Text", text: ""})}),
+				shell.layer,
+			),
+		);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("emits the record with --json, naming the ACL it resolved", async () => {
+		const out = await run(happy(), {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "appended",
+			issue: 4287,
+			rows: 3,
+			round: 1,
+			acl: "write",
+		});
+	});
+});

--- a/packages/fabrika-cli/src/review/append.ts
+++ b/packages/fabrika-cli/src/review/append.ts
@@ -1,0 +1,70 @@
+/**
+ * The append-only composition: where the new row goes, and the diff guard that proves nothing else
+ * moved.
+ *
+ * The guard is the fence, not a formality. ADR 0079's whole point is that a reviewer-authored
+ * criterion **adds** to the contract and never rewrites it — v1's `reviewer-append-ac.sh` was
+ * mandated at four call sites and called at none, so the fence existed only as a description. Here
+ * the composed body is compared line-for-line against the old one before it is sent, and any drop or
+ * mutation refuses.
+ */
+
+const CHECKBOX = /^[ \t]*[-*][ \t]+\[[ xX]\]/;
+
+/** The provenance tag ADR 0079 requires — what makes a routed row auditable after the fact. */
+export const provenanceTag = (pr: number, round: number): string =>
+	`<!-- ac:review pr:#${pr} round:${round} -->`;
+
+export const criterionRow = (text: string, pr: number, round: number): string =>
+	`- [ ] ${text.trim()} ${provenanceTag(pr, round)}`;
+
+/**
+ * `body` with `row` inserted after the last checkbox line, or `null` when there is none to follow.
+ *
+ * "After the last checkbox" rather than "at the end of the section" keeps the row inside the block a
+ * later read parses, even when the section trails prose.
+ */
+export const insertAfterLastCheckbox = (body: string, row: string): string | null => {
+	const lines = body.split("\n");
+	let last = -1;
+	for (const [index, line] of lines.entries()) {
+		if (CHECKBOX.test(line)) last = index;
+	}
+	if (last < 0) return null;
+	return [...lines.slice(0, last + 1), row, ...lines.slice(last + 1)].join("\n");
+};
+
+export type AppendGuard =
+	| {readonly _tag: "AppendOnly"}
+	| {readonly _tag: "Violates"; readonly reason: string};
+
+/**
+ * Whether `next` is `previous` plus exactly one line and nothing else.
+ *
+ * Both halves are asserted: exactly one added line, and every original line still present in its
+ * original order. Checking only the length would wave through a body that swapped one line for
+ * another and added a third.
+ */
+export const appendOnly = (previous: string, next: string): AppendGuard => {
+	const before = previous.split("\n");
+	const after = next.split("\n");
+	if (after.length !== before.length + 1) {
+		return {
+			_tag: "Violates",
+			reason: `the composed body has ${after.length} lines, expected ${before.length + 1}`,
+		};
+	}
+	let inserted = 0;
+	let at = 0;
+	for (const line of after) {
+		if (at < before.length && before[at] === line) {
+			at += 1;
+			continue;
+		}
+		inserted += 1;
+		if (inserted > 1) return {_tag: "Violates", reason: "more than one line differs"};
+	}
+	return at === before.length
+		? {_tag: "AppendOnly"}
+		: {_tag: "Violates", reason: "an original line was dropped or mutated"};
+};

--- a/packages/fabrika-cli/src/review/append.ts
+++ b/packages/fabrika-cli/src/review/append.ts
@@ -1,15 +1,19 @@
 /**
- * The append-only composition: where the new row goes, and the diff guard that proves nothing else
+ * The append-only composition: where the new row goes, and the two guards that prove nothing else
  * moved.
  *
- * The guard is the fence, not a formality. ADR 0079's whole point is that a reviewer-authored
+ * The guards are the fence, not a formality. ADR 0079's whole point is that a reviewer-authored
  * criterion **adds** to the contract and never rewrites it — v1's `reviewer-append-ac.sh` was
  * mandated at four call sites and called at none, so the fence existed only as a description. Here
- * the composed body is compared line-for-line against the old one before it is sent, and any drop or
- * mutation refuses.
+ * the composed body is checked twice before it is sent, and the two checks read it through
+ * *different* eyes on purpose: one compares lines against the old bytes, the other re-parses the
+ * composed body through the **registered wire format** and asserts the block grew by exactly one row.
+ * A composition that inserted the row somewhere the parser does not see it passes the first and reds
+ * on the second, which is the whole reason both exist.
  */
+import type {AcceptanceCriterion} from "../wire/acceptance-criteria.ts";
 
-const CHECKBOX = /^[ \t]*[-*][ \t]+\[[ xX]\]/;
+const CHECKBOX = /^([ \t]*[-*][ \t]+\[[ xX]\][ \t]*)(.*)$/;
 
 /** The provenance tag ADR 0079 requires — what makes a routed row auditable after the fact. */
 export const provenanceTag = (pr: number, round: number): string =>
@@ -19,19 +23,27 @@ export const criterionRow = (text: string, pr: number, round: number): string =>
 	`- [ ] ${text.trim()} ${provenanceTag(pr, round)}`;
 
 /**
- * `body` with `row` inserted after the last checkbox line, or `null` when there is none to follow.
+ * `body` with `row` inserted directly after the block's **last criterion**, or `null` when that
+ * criterion's line cannot be located.
  *
- * "After the last checkbox" rather than "at the end of the section" keeps the row inside the block a
- * later read parses, even when the section trails prose.
+ * The anchor is the parser's own answer — the text of the last row `acceptance-criteria.ts` read —
+ * rather than "the last checkbox in the body". Those differ whenever a later section carries
+ * checkboxes of its own, and appending to the wrong one puts the row outside the block every future
+ * read parses. Locating it this way needs no second heading parser.
  */
-export const insertAfterLastCheckbox = (body: string, row: string): string | null => {
+export const insertAfterLastCriterion = (
+	body: string,
+	lastCriterion: string,
+	row: string,
+): string | null => {
 	const lines = body.split("\n");
-	let last = -1;
+	let at = -1;
 	for (const [index, line] of lines.entries()) {
-		if (CHECKBOX.test(line)) last = index;
+		const matched = CHECKBOX.exec(line);
+		if (matched !== null && (matched[2] ?? "").trim() === lastCriterion.trim()) at = index;
 	}
-	if (last < 0) return null;
-	return [...lines.slice(0, last + 1), row, ...lines.slice(last + 1)].join("\n");
+	if (at < 0) return null;
+	return [...lines.slice(0, at + 1), row, ...lines.slice(at + 1)].join("\n");
 };
 
 export type AppendGuard =
@@ -68,3 +80,26 @@ export const appendOnly = (previous: string, next: string): AppendGuard => {
 		? {_tag: "AppendOnly"}
 		: {_tag: "Violates", reason: "an original line was dropped or mutated"};
 };
+
+/**
+ * Whether the block the parser reads back is the old rows plus exactly this one.
+ *
+ * This is the half {@link appendOnly} cannot see: a row inserted where the format does not parse it
+ * leaves the old bytes perfectly intact, so a line-level guard passes while the criterion the caller
+ * wrote enters no contract at all. Shared by the pre-write fence and the post-write read-back, so
+ * both assert the same thing.
+ */
+export const grewByOne = (
+	before: ReadonlyArray<AcceptanceCriterion>,
+	after: ReadonlyArray<AcceptanceCriterion> | null,
+	added: string,
+): boolean =>
+	after !== null &&
+	after.length === before.length + 1 &&
+	// Both fields, because a flipped checkbox is a mutation of an existing row even though its text
+	// is untouched — and the read-back is the only place that mutation would otherwise be invisible.
+	before.every(
+		(criterion, index) =>
+			after[index]?.text === criterion.text && after[index]?.checked === criterion.checked,
+	) &&
+	(after[before.length]?.text ?? "").includes(added.trim());

--- a/packages/fabrika-cli/src/review/append.unit.test.ts
+++ b/packages/fabrika-cli/src/review/append.unit.test.ts
@@ -1,0 +1,132 @@
+import {describe, expect, it} from "vitest";
+import {read as readCriteria} from "../wire/acceptance-criteria.ts";
+import {
+	appendOnly,
+	criterionRow,
+	grewByOne,
+	insertAfterLastCriterion,
+	provenanceTag,
+} from "./append.ts";
+
+/** The criteria the registered format reads out of a body — the operand `grewByOne` compares. */
+const criteriaOf = (body: string) => {
+	const block = readCriteria(body);
+	return block._tag === "Found" ? block.value : null;
+};
+
+const BODY = `### Acceptance criteria
+
+- [x] the first thing
+- [ ] the second thing
+
+Some trailing prose.`;
+
+describe("criterionRow", () => {
+	it("carries the provenance tag that makes a routed row auditable", () => {
+		expect(criterionRow("a regression test covers qty > 1", 4321, 1)).toBe(
+			"- [ ] a regression test covers qty > 1 <!-- ac:review pr:#4321 round:1 -->",
+		);
+		expect(provenanceTag(4321, 2)).toBe("<!-- ac:review pr:#4321 round:2 -->");
+	});
+});
+
+describe("insertAfterLastCriterion", () => {
+	it("puts the row inside the block a later read parses, not after the trailing prose", () => {
+		const composed = insertAfterLastCriterion(BODY, "the second thing", "- [ ] a third thing");
+		expect(composed).toBe(`### Acceptance criteria
+
+- [x] the first thing
+- [ ] the second thing
+- [ ] a third thing
+
+Some trailing prose.`);
+	});
+
+	it("anchors on the block's last criterion, not on the last checkbox anywhere in the body", () => {
+		const withLaterList = `### Acceptance criteria
+
+- [ ] the only criterion
+
+## Notes
+
+- [ ] a checkbox that is not a criterion`;
+		const composed =
+			insertAfterLastCriterion(withLaterList, "the only criterion", "- [ ] added") ?? "";
+		expect(composed.indexOf("- [ ] added")).toBeLessThan(composed.indexOf("## Notes"));
+	});
+
+	it("answers null when the criterion's line cannot be located", () => {
+		expect(insertAfterLastCriterion(BODY, "a row that is not there", "- [ ] x")).toBeNull();
+	});
+});
+
+describe("grewByOne", () => {
+	it("passes the block the parser reads back as the old rows plus this one", () => {
+		const composed =
+			insertAfterLastCriterion(BODY, "the second thing", "- [ ] a third thing") ?? "";
+		expect(grewByOne(criteriaOf(BODY) ?? [], criteriaOf(composed), "a third thing")).toBe(true);
+	});
+
+	it("reds on a row inserted where the FORMAT cannot see it, which appendOnly cannot catch", () => {
+		// The old bytes are untouched and exactly one line was added, so the line-level guard passes —
+		// and the criterion enters no contract at all, because it landed under the next heading. This
+		// is the half the second guard exists for.
+		const withLaterSection = `${BODY}\n\n## Notes\n\nnothing yet.`;
+		const past = `${withLaterSection}\n- [ ] a third thing`;
+		expect(appendOnly(withLaterSection, past)._tag).toBe("AppendOnly");
+		expect(grewByOne(criteriaOf(withLaterSection) ?? [], criteriaOf(past), "a third thing")).toBe(
+			false,
+		);
+	});
+
+	it("reds when a prior row changed, and when the added row is not the text that was written", () => {
+		const mutated = criteriaOf(`### Acceptance criteria
+
+- [x] the first thing
+- [x] the second thing
+- [ ] a third thing`);
+		expect(grewByOne(criteriaOf(BODY) ?? [], mutated, "a third thing")).toBe(false);
+		const composed =
+			insertAfterLastCriterion(BODY, "the second thing", "- [ ] something else") ?? "";
+		expect(grewByOne(criteriaOf(BODY) ?? [], criteriaOf(composed), "a third thing")).toBe(false);
+	});
+});
+
+describe("appendOnly", () => {
+	it("passes exactly one inserted line", () => {
+		const composed =
+			insertAfterLastCriterion(BODY, "the second thing", "- [ ] a third thing") ?? "";
+		expect(appendOnly(BODY, composed)._tag).toBe("AppendOnly");
+	});
+
+	it("refuses a body that dropped a prior row, even at the right length", () => {
+		const mutilated = `### Acceptance criteria
+
+- [x] the first thing
+- [ ] a third thing
+- [ ] a fourth thing
+
+Some trailing prose.`;
+		expect(appendOnly(BODY, mutilated)._tag).toBe("Violates");
+	});
+
+	it("refuses a body that MUTATED a prior row while adding one", () => {
+		const mutated = `### Acceptance criteria
+
+- [x] the first thing
+- [x] the second thing
+- [ ] a third thing
+
+Some trailing prose.`;
+		expect(appendOnly(BODY, mutated)._tag).toBe("Violates");
+	});
+
+	it("refuses two added lines — the fence is exactly one row", () => {
+		const two = `${BODY}\n- [ ] a\n- [ ] b`;
+		expect(appendOnly(BODY, two)._tag).toBe("Violates");
+	});
+
+	it("refuses a shorter body outright", () => {
+		expect(appendOnly(BODY, "### Acceptance criteria")._tag).toBe("Violates");
+	});
+});

--- a/packages/fabrika-cli/src/review/authored.ts
+++ b/packages/fabrika-cli/src/review/authored.ts
@@ -1,0 +1,82 @@
+/**
+ * The guard over **authored** text — the bytes the caller just wrote — for `review post` and
+ * `review append-criterion`.
+ *
+ * Four outcomes, and the first two must never collapse: an **unread** pipe is UNKNOWN and seats on
+ * `1`, a **read-but-empty** one is a proven `3`. Swallowing the first to the second makes an unread
+ * pipe byte-identical to an empty one, and the caller then decides over evidence it never saw
+ * (#3924). A body that IS a path is `6` rather than `5` because the fixes are opposite — the loop on
+ * a leak is *rewrite and resend*, and on a body that is a path that loop never terminates.
+ *
+ * **The predicates are the shipped `report/leaks.ts` ones, imported.** Only the message text is this
+ * group's, because each refusal names one correctable thing in this verb's own words — a verdict body
+ * that must *cite* a leak found in the diff cites it by class root or repo-relative form, while an
+ * appended criterion is simply rewritten (#3785). A second leak predicate that drifts from the first
+ * is worse than either alone.
+ */
+
+import type {StdinRead} from "../io/stdin.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {BARE_AT_PATH, EMPTY_STDIN, LEAKED_PATH} from "./codes.ts";
+
+/** What one verb calls the text it is guarding, so each refusal reads as that verb's own. */
+export interface AuthoredSurface {
+	readonly verb: string;
+	/** The noun a `1` and a `5` refusal name, e.g. `the assembled comment`. */
+	readonly noun: string;
+	/** The whole `3` message — the contract states it per verb, so it is not composed here. */
+	readonly emptyMessage: string;
+	/** The whole `6` message, for the same reason. */
+	readonly bareAtMessage: string;
+	/** The correction a leak refusal ends with, e.g. `cite it repo-relative or by class root.` */
+	readonly leakCorrection: string;
+}
+
+export type Authored =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Text"; readonly text: string; readonly bytes: number};
+
+export const readAuthored = (surface: AuthoredSurface, read: StdinRead): Authored => {
+	if (read._tag === "Failed") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				FAILED,
+				`${surface.verb}: could not read stdin: ${read.reason} — ${surface.noun} is UNKNOWN, never empty.`,
+			),
+		};
+	}
+	const text = read._tag === "NoStdin" ? "" : read.text;
+	const bytes = new TextEncoder().encode(text).length;
+	if (text.trim() === "") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(EMPTY_STDIN, surface.emptyMessage, [
+				`${surface.verb}: stdin was read and held ${bytes} byte(s).`,
+			]),
+		};
+	}
+	if (isBareAtReference(text)) {
+		return {_tag: "Refused", outcome: refuse(BARE_AT_PATH, surface.bareAtMessage)};
+	}
+	return {_tag: "Text", text, bytes};
+};
+
+/**
+ * The leak refusal for `body`, or `null` when it carries no machine-local path.
+ *
+ * Run over the **composed** artifact rather than over raw stdin, so nothing a verb itself appends can
+ * escape the predicate. The message names the first hit because a refusal names one correctable
+ * thing; every hit is listed above it, so one round clears them all.
+ */
+export const leakRefusal = (surface: AuthoredSurface, body: string): VerbOutcome | null => {
+	const scan = scanBody(body);
+	const first = scan.leaks[0];
+	if (first === undefined) return null;
+	return refuse(
+		LEAKED_PATH,
+		`${surface.verb}: ${surface.noun} carries a machine-local path at line ${first.line} (${first.class}) — ${surface.leakCorrection}`,
+		renderLeaks(scan.leaks),
+	);
+};

--- a/packages/fabrika-cli/src/review/ci-verb.ts
+++ b/packages/fabrika-cli/src/review/ci-verb.ts
@@ -1,0 +1,116 @@
+/**
+ * `review ci` — the live check-run rollup at a head, fail-closed on incomplete enumeration.
+ *
+ * v1's CI-at-head read was dispatch-prompt-dependent: a gate ruled on a live RED check as a prose
+ * question because one sentence was omitted (#4552). This verb is that read made structural, and its
+ * two refusals are what keep it honest — zero declared runs is a vacuous green (ADR 0092), and an
+ * enumeration short of `total_count` is never read as "no red checks" (#3999).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {commitExists, listCheckRuns} from "../io/pulls.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {rollupOf, statusOf} from "./rollup.ts";
+import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "review ci";
+
+export interface CiOptions {
+	readonly pr: number;
+	readonly sha: string | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
+
+export const runCi = (
+	options: CiOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {requireOpen: false, requireFiles: false});
+		if (target._tag === "Refused") return target.outcome;
+		const live = target.pull.headSha;
+
+		const asked = options.sha?.trim() ?? "";
+		const diagnostics: string[] = [];
+		let sha = live;
+		if (asked !== "") {
+			const at = yield* commitExists(repo, asked);
+			if (at._tag === "Absent") {
+				return refuse(ZERO_SCOPE, `${VERB}: no commit ${asked} on PR #${pr} in ${repo}.`);
+			}
+			if (at._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot enumerate check runs at ${asked}: ${at.reason} — CI state is UNKNOWN, never green.`,
+				);
+			}
+			sha = asked;
+			// A read at a moved-past head is a fact worth seeing, not a refusal: the `12` stale seat
+			// belongs to `review post`, the write seam.
+			if (!prefixMatch(live, asked)) {
+				diagnostics.push(
+					`${VERB}: the live head is ${live}, you are enumerating at ${asked} — the head moved; a verdict still binds only what was inspected.`,
+				);
+			}
+		}
+
+		const enumerated = yield* listCheckRuns(repo, sha);
+		if (enumerated._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot enumerate check runs at ${sha}: ${enumerated.reason} — CI state is UNKNOWN, never green.`,
+				diagnostics,
+			);
+		}
+		const {declared, runs} = enumerated.value;
+		diagnostics.push(scannedLine(VERB, runs.length, "check run", `${declared} declared`));
+		if (declared === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: zero check runs declared at ${sha} — refusing to report green over an empty enumeration (ADR 0092).`,
+				diagnostics,
+			);
+		}
+		if (runs.length < declared) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: received ${runs.length} of ${declared} declared check runs at ${sha} — refusing the partial enumeration (#3999).`,
+				diagnostics,
+			);
+		}
+
+		const rollup = rollupOf(runs);
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "ci",
+						sha,
+						rollup,
+						checks: runs.map((run) => ({name: run.name, status: statusOf(run)})),
+						scanned: runs.length,
+						declared,
+					}),
+					diagnostics,
+				)
+			: answer(
+					[
+						`ci\t${sha}\t${rollup}`,
+						`check\t${runs.length}`,
+						...runs.map((run) => `${run.name}\t${statusOf(run)}`),
+					].join("\n"),
+					diagnostics,
+				);
+	});

--- a/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/ci-verb.unit.test.ts
@@ -1,0 +1,131 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {runCi} from "./ci-verb.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {checkRuns, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const COMMIT = (sha: string) => new RegExp(`^gh api repos/o/r/commits/${sha} --jq \\.sha$`);
+const RUNS = /^gh api --paginate repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
+
+const GREEN = checkRuns(3, [
+	{name: "lint / format / typecheck", status: "completed", conclusion: "success"},
+	{name: "unit tests", status: "completed", conclusion: "success"},
+	{name: "leak-guard", status: "completed", conclusion: "success"},
+]);
+
+const options = {
+	pr: 4321,
+	sha: null as string | null,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => Effect.runPromise(Effect.provide(runCi({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runCi", () => {
+	it("prints the rollup, the count of lines that follow, and one line per run", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RUNS, GREEN],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				`ci\t${HEAD}\tgreen`,
+				"check\t3",
+				"lint / format / typecheck\tsuccess",
+				"unit tests\tsuccess",
+				"leak-guard\tsuccess",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("names a red check by name, not as a rollup boolean", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[
+				RUNS,
+				checkRuns(2, [
+					{name: "unit tests", status: "completed", conclusion: "failure"},
+					{name: "leak-guard", status: "completed", conclusion: "success"},
+				]),
+			],
+		]);
+		expect(out.stdout).toContain("\tred\n");
+		expect(out.stdout).toContain("unit tests\tfailure");
+	});
+
+	it("enumerates at --sha and notices when the live head has moved past it", async () => {
+		const out = await run(
+			[
+				[PULL, pull({head: HEAD})],
+				[COMMIT(OLD_HEAD), okOut(OLD_HEAD)],
+				[RUNS, GREEN],
+			],
+			{sha: OLD_HEAD},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe(`ci\t${OLD_HEAD}\tgreen`);
+		expect(out.stderr[0]).toContain("the head moved");
+	});
+
+	it("refuses a --sha proven absent on 7", async () => {
+		const out = await run(
+			[
+				[PULL, pull()],
+				[COMMIT(OLD_HEAD), errOut("gh: Not Found (HTTP 404)")],
+			],
+			{sha: OLD_HEAD},
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe(`review ci: no commit ${OLD_HEAD} on PR #4321 in o/r.`);
+	});
+
+	it("refuses zero declared check runs on 7 — a vacuous green is the ADR 0092 fail-open", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RUNS, checkRuns(0, [])],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("refusing to report green over an empty enumeration");
+	});
+
+	it("refuses a short enumeration on 13 — never read as `no red checks`", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RUNS, checkRuns(9, [{name: "unit tests", status: "completed", conclusion: "success"}])],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`review ci: received 1 of 9 declared check runs at ${HEAD} — refusing the partial enumeration (#3999).`,
+		);
+	});
+
+	it("refuses an unreadable enumeration on 11 — CI state is UNKNOWN, never green", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RUNS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("CI state is UNKNOWN, never green");
+	});
+
+	it("reports what it scanned against what was declared", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RUNS, GREEN],
+		]);
+		expect(out.stderr).toContain("review ci: scanned 3 check runs; 3 declared.");
+	});
+});

--- a/packages/fabrika-cli/src/review/classes.ts
+++ b/packages/fabrika-cli/src/review/classes.ts
@@ -1,0 +1,95 @@
+/**
+ * The artifact-class partition of a PR's changed files, and the two flags derived beside it.
+ *
+ * The map is a **fixed path partition** so two runs cannot disagree, and it is **total**: a file the
+ * map cannot place is `code`, never dropped. An unclassified file silently excluded from every
+ * rubric is a review that never saw it (#4060).
+ */
+
+/** The three artifact classes, in the fixed order the line grammar prints them. */
+export const CLASS_NAMES = ["code", "doc", "skill"] as const;
+export type ClassName = (typeof CLASS_NAMES)[number];
+
+/** The namespace a present class derives. `review post` refuses any namespace outside this image. */
+export const namespaceOf = (name: ClassName): string => `review-${name}`;
+
+/** True when the path is `SKILL.md` itself, wherever it sits. */
+const isSkillFile = (path: string): boolean => path === "SKILL.md" || path.endsWith("/SKILL.md");
+
+/**
+ * The class one path belongs to.
+ *
+ * The last two `skill` rows — `skills/**` and any `SKILL.md` anywhere — are what keep the map honest
+ * on a repo that homes its skills elsewhere; without them a foreign repo's
+ * `skills/deploy-notes/SKILL.md` partitions to `doc` and is graded by the wrong rubric.
+ */
+export const classOf = (path: string): ClassName => {
+	if (
+		path.startsWith("claude-plugins/") ||
+		path.startsWith(".claude/") ||
+		path.startsWith("skills/") ||
+		isSkillFile(path)
+	) {
+		return "skill";
+	}
+	return path.endsWith(".md") ? "doc" : "code";
+};
+
+/** The `self` flag: this diff edits the `review` skill's own text (ADR 0052's BASE-revision fence). */
+const SELF_ROOT = "claude-plugins/fabrika/skills/review/";
+
+/**
+ * The `harness` flag's closed three-root list — *this* repo's governance surface.
+ *
+ * The class map's two portability rows deliberately do not set it: they classify a foreign repo's
+ * skill text for the rubric, while `harness` marks this harness. What governance does with the flag
+ * is the `governance` skill's decision; the flag only makes the seam mechanical.
+ */
+const HARNESS_ROOTS = [".claude/", ".github/", "claude-plugins/"];
+
+export interface ClassTally {
+	readonly name: ClassName;
+	readonly files: number;
+}
+
+export interface Partition {
+	/** Only the classes actually present, in {@link CLASS_NAMES} order. */
+	readonly classes: ReadonlyArray<ClassTally>;
+	readonly self: boolean;
+	readonly harness: boolean;
+	readonly scanned: number;
+}
+
+export const partition = (files: ReadonlyArray<string>): Partition => {
+	const counts = new Map<ClassName, number>();
+	for (const file of files) {
+		const name = classOf(file);
+		counts.set(name, (counts.get(name) ?? 0) + 1);
+	}
+	return {
+		classes: CLASS_NAMES.filter((name) => (counts.get(name) ?? 0) > 0).map((name) => ({
+			name,
+			files: counts.get(name) ?? 0,
+		})),
+		self: files.some((file) => file.startsWith(SELF_ROOT)),
+		harness: files.some((file) => HARNESS_ROOTS.some((root) => file.startsWith(root))),
+		scanned: files.length,
+	};
+};
+
+export const namespacesOf = (result: Partition): ReadonlyArray<string> =>
+	result.classes.map((entry) => namespaceOf(entry.name));
+
+/**
+ * The linked issue, from the PR body's first closing keyword.
+ *
+ * Every inflection of the three keywords is admitted — GitHub auto-closes on all of them, and a body
+ * that says `Fixed #4287` links exactly as hard as one that says `Fixes #4287`. What an issueless PR
+ * *means* is the skill's decision; this only reports it.
+ */
+const CLOSING_KEYWORD = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[ \t]*:?[ \t]*#(\d+)/i;
+
+export const linkedIssueOf = (body: string): number | null => {
+	const matched = CLOSING_KEYWORD.exec(body);
+	return matched?.[1] === undefined ? null : Number.parseInt(matched[1], 10);
+};

--- a/packages/fabrika-cli/src/review/classes.unit.test.ts
+++ b/packages/fabrika-cli/src/review/classes.unit.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, it} from "vitest";
+import {classOf, linkedIssueOf, namespacesOf, partition} from "./classes.ts";
+
+describe("classOf", () => {
+	it("puts every claude-plugins and .claude path in skill", () => {
+		expect(classOf("claude-plugins/fabrika/skills/review/SKILL.md")).toBe("skill");
+		expect(classOf("claude-plugins/fabrika/docs/cli-interface-convention.md")).toBe("skill");
+		expect(classOf(".claude/agents/coder.md")).toBe("skill");
+	});
+
+	it("keeps the two portability rows honest on a repo that homes skills elsewhere", () => {
+		// Found live by an eval run: under the first two rows alone this partitions to `doc`.
+		expect(classOf("skills/deploy-notes/SKILL.md")).toBe("skill");
+		expect(classOf("some/other/place/SKILL.md")).toBe("skill");
+	});
+
+	it("puts markdown outside claude-plugins in doc", () => {
+		expect(classOf(".decisions/0238-fabrika.md")).toBe("doc");
+		expect(classOf("README.md")).toBe("doc");
+		expect(classOf(".patterns/index.md")).toBe("doc");
+	});
+
+	it("makes code the residual — a file the map cannot place is never dropped", () => {
+		expect(classOf("packages/fabrika-cli/src/review/codes.ts")).toBe("code");
+		expect(classOf(".github/workflows/ci.yml")).toBe("code");
+		expect(classOf("LICENSE")).toBe("code");
+		expect(classOf("weird-file-with-no-extension")).toBe("code");
+	});
+});
+
+describe("partition", () => {
+	it("counts each present class and omits the absent ones", () => {
+		const result = partition(["src/a.ts", "src/b.ts", "README.md"]);
+		expect(result.classes).toEqual([
+			{name: "code", files: 2},
+			{name: "doc", files: 1},
+		]);
+		expect(result.scanned).toBe(3);
+	});
+
+	it("is total — every file lands in exactly one class", () => {
+		const files = ["a.ts", "b.md", "claude-plugins/x/SKILL.md", "no-extension"];
+		const result = partition(files);
+		expect(result.classes.reduce((sum, entry) => sum + entry.files, 0)).toBe(files.length);
+	});
+
+	it("sets self only for the review skill's own text", () => {
+		expect(partition(["claude-plugins/fabrika/skills/review/SKILL.md"]).self).toBe(true);
+		expect(partition(["claude-plugins/fabrika/skills/triage/SKILL.md"]).self).toBe(false);
+	});
+
+	it("sets harness on the closed three-root list, and not on the portability rows", () => {
+		expect(partition([".github/workflows/ci.yml"]).harness).toBe(true);
+		expect(partition([".claude/settings.json"]).harness).toBe(true);
+		expect(partition(["claude-plugins/fabrika/x.md"]).harness).toBe(true);
+		// A foreign repo's skill text is classified for the rubric but marks no harness of ours.
+		expect(partition(["skills/deploy-notes/SKILL.md"]).harness).toBe(false);
+	});
+
+	it("derives one namespace per present class, as a set the caller cannot forget", () => {
+		expect(namespacesOf(partition(["a.ts", "b.md"]))).toEqual(["review-code", "review-doc"]);
+		expect(namespacesOf(partition(["b.md"]))).toEqual(["review-doc"]);
+	});
+});
+
+describe("linkedIssueOf", () => {
+	it("takes the first closing keyword's issue", () => {
+		expect(linkedIssueOf("does things\n\nFixes #4287\n")).toBe(4287);
+		expect(linkedIssueOf("Closes #12\nFixes #99")).toBe(12);
+		expect(linkedIssueOf("Resolved #7")).toBe(7);
+	});
+
+	it("answers null when the body carries no closing keyword", () => {
+		expect(linkedIssueOf("relates to #4287")).toBeNull();
+		expect(linkedIssueOf("Part of #4287")).toBeNull();
+		expect(linkedIssueOf("")).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/review/codes.ts
+++ b/packages/fabrika-cli/src/review/codes.ts
@@ -1,0 +1,72 @@
+/**
+ * The one exit table all eight `review` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it.
+ *
+ * **The overlap with `report` and `triage` is re-exported, never re-typed.** Where this group's
+ * codes meet the shipped writing verbs' — `3`, `5`, `6`, `7`, `8`, `9`, `10`, `11` — the values are
+ * *imported* from `../report/codes.ts` and `../triage/codes.ts` rather than restated as numerals
+ * here. A restated numeral is a second source that can drift silently; an import cannot, and the
+ * checked-in `/report` contract already sits behind its own binary on `7` and `11` (#4752), which is
+ * why the shipped package is the authority and no prose copy is.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ * `4` stays a deliberate gap — it is `report file`'s body-section seat, and no verb here performs
+ * one; a row for it would be a meaning this group does not have.
+ */
+
+import {
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+import {OFF_VOCABULARY as TRIAGE_OFF_VOCABULARY} from "../triage/codes.ts";
+
+/** Stdin was read and held nothing. Distinct from a read that failed, which is `1`. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/** The **authored** text carries a machine-local path. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The **authored** text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/**
+ * Zero scope: the target is **proven absent (404)** or closed, the PR has zero changed files or zero
+ * declared check runs, or a required block is proven absent or malformed (ADR 0092).
+ *
+ * *Proven* is the operative word. A 404 is a fact about the repository; an unreachable GitHub is not
+ * a fact about anything and lands on {@link PRECONDITION_UNKNOWN}.
+ */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** The write itself failed — the outcome is **UNKNOWN**, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed but the read-back does not match. The artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** A supplied classification value is off the closed vocabulary — namespace, polarity or carrier. */
+export const OFF_VOCABULARY = TRIAGE_OFF_VOCABULARY;
+/** A precondition read failed — nothing was written and the outcome is UNKNOWN. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/**
+ * Refused: the live head moved past the inspected `--sha`.
+ *
+ * The one code whose absence would let a verdict formed over one tree land on another — `bindToHead`'s
+ * `Stale` arm applied at the write seam (#3769 / #4338's class, ADR 0058).
+ */
+export const STALE_HEAD = 12;
+/**
+ * Refused: the read completed and its scope is **provably incomplete**.
+ *
+ * Neither {@link PRECONDITION_UNKNOWN} (nothing failed) nor {@link ZERO_SCOPE} (scope exists; it just
+ * was not all seen). Folding it into either renders a half-seen PR as a fully-judged one — the class
+ * of #3925 and #4060.
+ */
+export const INCOMPLETE_SCAN = 13;
+/** Refused: the invoking token resolves below `write`, or the ACL lookup failed (ADR 0055). */
+export const ACL_DENIED = 14;
+/** Refused: the write would drop or mutate an existing row — the append-only fence. */
+export const APPEND_ONLY = 15;
+
+/** The unallocated code — see the gap note at the top of this file. */
+export const DELIBERATE_GAP = 4;

--- a/packages/fabrika-cli/src/review/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/review/codes.unit.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from "vitest";
+import * as report from "../report/codes.ts";
+import * as triage from "../triage/codes.ts";
+import * as review from "./codes.ts";
+
+/**
+ * The parity assertion the acceptance criterion names: where this group's codes overlap the shipped
+ * writing verbs', they match **code for code**, read from the shipped package and never from a
+ * contract.md (#4752).
+ *
+ * The test is not redundant with the re-export in `./codes.ts`. It pins the *claim* — that these
+ * particular meanings are the ones aligned — so a future edit that swaps a re-export for a numeral
+ * reds here instead of drifting silently.
+ */
+describe("the review exit table", () => {
+	it("matches report's writing codes, code for code", () => {
+		expect(review.EMPTY_STDIN).toBe(report.EMPTY_STDIN);
+		expect(review.LEAKED_PATH).toBe(report.LEAKED_PATH);
+		expect(review.BARE_AT_PATH).toBe(report.BARE_AT_PATH);
+		expect(review.ZERO_SCOPE).toBe(report.NO_TARGET);
+		expect(review.WRITE_UNKNOWN).toBe(report.WRITE_UNKNOWN);
+		expect(review.READBACK_MISMATCH).toBe(report.READBACK_MISMATCH);
+		expect(review.PRECONDITION_UNKNOWN).toBe(report.PRECONDITION_UNKNOWN);
+	});
+
+	it("matches triage's overlapping codes too, so one sweep reads one meaning", () => {
+		expect(review.EMPTY_STDIN).toBe(triage.EMPTY_STDIN);
+		expect(review.LEAKED_PATH).toBe(triage.LEAKED_PATH);
+		expect(review.BARE_AT_PATH).toBe(triage.BARE_AT_PATH);
+		expect(review.ZERO_SCOPE).toBe(triage.ZERO_SCOPE);
+		expect(review.WRITE_UNKNOWN).toBe(triage.WRITE_UNKNOWN);
+		expect(review.READBACK_MISMATCH).toBe(triage.READBACK_MISMATCH);
+		expect(review.OFF_VOCABULARY).toBe(triage.OFF_VOCABULARY);
+		expect(review.PRECONDITION_UNKNOWN).toBe(triage.PRECONDITION_UNKNOWN);
+	});
+
+	it("seats the contract's matrix on the numbers it states", () => {
+		expect([
+			review.EMPTY_STDIN,
+			review.LEAKED_PATH,
+			review.BARE_AT_PATH,
+			review.ZERO_SCOPE,
+			review.WRITE_UNKNOWN,
+			review.READBACK_MISMATCH,
+			review.OFF_VOCABULARY,
+			review.PRECONDITION_UNKNOWN,
+			review.STALE_HEAD,
+			review.INCOMPLETE_SCAN,
+			review.ACL_DENIED,
+			review.APPEND_ONLY,
+		]).toEqual([3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+	});
+
+	it("leaves 4 a gap, and collides no two meanings on one code", () => {
+		expect(review.DELIBERATE_GAP).toBe(4);
+		const allocated = [
+			review.EMPTY_STDIN,
+			review.LEAKED_PATH,
+			review.BARE_AT_PATH,
+			review.ZERO_SCOPE,
+			review.WRITE_UNKNOWN,
+			review.READBACK_MISMATCH,
+			review.OFF_VOCABULARY,
+			review.PRECONDITION_UNKNOWN,
+			review.STALE_HEAD,
+			review.INCOMPLETE_SCAN,
+			review.ACL_DENIED,
+			review.APPEND_ONLY,
+		];
+		expect(new Set(allocated).size).toBe(allocated.length);
+		expect(allocated).not.toContain(review.DELIBERATE_GAP);
+	});
+});

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -1,0 +1,261 @@
+/**
+ * The `review` verb group — `fabrika review <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives in
+ * the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a
+ * process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ */
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runAppendCriterion} from "./append-criterion-verb.ts";
+import {runCi} from "./ci-verb.ts";
+import {runCriteria} from "./criteria-verb.ts";
+import {runDeviations} from "./deviations-verb.ts";
+import {runDiff} from "./diff-verb.ts";
+import {runPost} from "./post-verb.ts";
+import {runScope} from "./scope-verb.ts";
+import {runVerdicts} from "./verdicts-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+/**
+ * The two flags every verb in this group shares, declared once here.
+ *
+ * They are not imported from a sibling group's adapter: that would couple two groups' `--help` text
+ * together. The wording is shared because the contract states it, not because the declaration is.
+ */
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
+);
+
+const prArg = Argument.integer("pr").pipe(
+	Argument.withDescription("the pull-request number to read"),
+);
+
+const scope = leafCommand(
+	"scope",
+	{pr: prArg, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, repo, json}) {
+		yield* emit(yield* runScope({pr, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Partition a PR's changed files into the code / doc / skill artifact classes and report its head SHA, linked issue and self / harness flags. First stdout line is `scoped\\t<head-sha>\\t<issue>`, then one `class\\t<name>\\t<files>` line per present class and the two flag lines; the scanned count is on stderr. Exits 7 (PR absent, closed, or zero changed files — ADR 0092, #4060), 11 (the PR or its file list could not be read — the scope is UNKNOWN), 13 (the file list is provably short of the declared count). Example: fabrika review scope 4321",
+	),
+);
+
+const diff = leafCommand(
+	"diff",
+	{pr: prArg, repo: repoFlag},
+	Effect.fn(function* ({pr, repo}) {
+		yield* emit(yield* runDiff({pr, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Serve a PR's unified diff bytes on stdout, refusing a truncated one rather than passing it through as the whole. No --json: the diff is the object. Exits 7 (PR absent, closed, or zero changed files), 11 (the diff could not be read — UNKNOWN), 13 (the served diff carries fewer files than the PR declares — #3925's class). Example: fabrika review diff 4321",
+	),
+);
+
+const criteria = leafCommand(
+	"criteria",
+	{
+		issue: Argument.integer("issue").pipe(
+			Argument.withDescription("the issue carrying the acceptance-criteria block"),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, repo, json}) {
+		yield* emit(yield* runCriteria({issue, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Read an issue's acceptance-criteria block through the registered `acceptance-criteria` wire format — no second parser. First stdout line is `criteria\\t<count>`, then one `<checked|open>\\t<text>` line per criterion. A closed issue is read anyway, with a notice on stderr. Exits 7 (issue absent, or the block is proven absent or malformed — the two are distinguished on stderr, never invented around), 11 (the issue could not be read — whether a block exists is UNKNOWN). Example: fabrika review criteria 4287",
+	),
+);
+
+const ci = leafCommand(
+	"ci",
+	{
+		pr: prArg,
+		sha: Flag.string("sha").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the head to enumerate check runs at (default: the PR's live head); give the inspected head so the answer binds to what is being judged",
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({pr, sha, repo, json}) {
+		yield* emit(
+			yield* runCi({
+				pr,
+				sha: Option.getOrNull(sha),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Enumerate the live check runs at a head and roll them up green / red / pending, fail-closed on the ambiguous rows — a cancelled or unrecognised conclusion is red, never green. First stdout line is `ci\\t<sha>\\t<rollup>`, then `check\\t<count>` and one `<name>\\t<status>` line per run. Exits 7 (PR or --sha proven absent, or zero check runs declared — ADR 0092), 11 (the enumeration failed — CI state is UNKNOWN, never green), 13 (received fewer runs than declared — #3999). Example: fabrika review ci 4321 --sha 03135b91",
+	),
+);
+
+const verdicts = leafCommand(
+	"verdicts",
+	{pr: prArg, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, repo, json}) {
+		yield* emit(yield* runVerdicts({pr, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Sweep every verdict marker on a PR and bind each to the live head as one of three outcomes — current / stale / unbindable, never folded (ADR 0058). First stdout line is `verdicts\\t<live-head>\\t<count>`; a count of 0 is a proven answer. Then one `<namespace>\\t<polarity>\\t<sha>\\t<binding>\\t<comment-id>` line per marker, newest first; a marker that fails the format prints as a `malformed` row rather than being dropped. An unresolvable head prints unbindable on every row. Exits 7 (PR proven absent), 11 (the comment list could not be read — never zero), 13 (the sweep is provably short). Example: fabrika review verdicts 4321",
+	),
+);
+
+const deviations = leafCommand(
+	"deviations",
+	{pr: prArg, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, repo, json}) {
+		yield* emit(yield* runDeviations({pr, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Report the PR body's `## Deviations` state — found | none-declared | absent | malformed, three distinct facts — with its entries and the Tier-M token scan over the head diff. First stdout line is `deviations\\t<state>`, then one `entry\\t<class-label-or-->\\t<first-line-of-Said>` line per entry and one `tier-m\\t<kind>\\t<file>:<line>\\t<token>` line per hit. Exits 7 (PR proven absent), 11 (the body or diff could not be read — the disclosure state is UNKNOWN, never `none`), 13 (a partial diff must not print a partial scan beside a disclosure claim). Example: fabrika review deviations 4321",
+	),
+);
+
+/**
+ * The verdict body arrives on **stdin only** — no `--body`, no `--body-file`. A flag that takes a
+ * path turns the body into a string the verb could post verbatim, which is how a machine-local path
+ * reaches a public surface while the poster reads success.
+ */
+const post = leafCommand(
+	"post",
+	{
+		pr: Argument.integer("pr").pipe(
+			Argument.withDescription("the pull request the verdict is posted on"),
+		),
+		namespace: Flag.string("namespace").pipe(
+			Flag.withDescription(
+				"the namespace this verdict fills; must be one this PR's own diff derived",
+			),
+		),
+		polarity: Flag.string("polarity").pipe(
+			Flag.withDescription("PASS or FAIL — a third token is not a polarity"),
+		),
+		sha: Flag.string("sha").pipe(
+			Flag.withDescription("the head the reviewer actually inspected (7–40 lowercase hex)"),
+		),
+		clause: Flag.string("clause").pipe(
+			Flag.withDescription("the human clause the marker ends with; blank is not a clause"),
+		),
+		carrier: Flag.string("carrier").pipe(
+			Flag.withDefault("marker"),
+			Flag.withDescription(
+				"marker (first-line SHA-bound marker) or advisory (§CP: advisory first line, `Reviewed-head: @ <sha>` in the body); advisory is a PASS path only (default: marker)",
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({pr, namespace, polarity, sha, clause, carrier, repo, json}) {
+		yield* emit(
+			yield* runPost({
+				pr,
+				namespace,
+				polarity,
+				sha,
+				clause,
+				carrier,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Post the verdict on STDIN as ONE comment for this namespace — recompute the class set, re-resolve the live head, compose the first line through the `verdict-marker` wire format, leak-scan the assembled comment, upsert, and read it back from live state. Prints `posted\\t<namespace>\\t<polarity>\\t<sha>\\t<created|edited>\\t<comment-url>`. Exits 3 (empty stdin — an empty verdict reads as UNGATED), 5 (machine-local path in the assembled comment), 6 (bare @ reference), 7 (PR absent or closed), 8 (the create/edit failed — UNKNOWN), 9 (read-back does not yield this marker), 10 (namespace this diff did not derive, bad polarity, or advisory with FAIL), 11 (a precondition read failed — nothing was posted), 12 (the live head moved past --sha — re-review, never re-bind). Example: fabrika review post 4321 --namespace review-doc --polarity PASS --sha 03135b91 --clause "guide matches shipped behavior" < verdict.md',
+	),
+);
+
+/** The criterion text arrives on **stdin**, for the same reason `post`'s body does. */
+const appendCriterion = leafCommand(
+	"append-criterion",
+	{
+		issue: Argument.integer("issue").pipe(
+			Argument.withDescription("the linked issue receiving the criterion"),
+		),
+		pr: Flag.integer("pr").pipe(
+			Flag.withDescription(
+				"the PR whose review round produced the finding — half the provenance tag",
+			),
+		),
+		round: Flag.integer("round").pipe(
+			Flag.withDescription(
+				"this review round's number; at or past the freeze (3) the verb escalates instead of appending",
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, pr, round, repo, json}) {
+		yield* emit(
+			yield* runAppendCriterion({
+				issue,
+				pr,
+				round,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Append one reviewer-authored acceptance criterion from STDIN under ADR 0079's four fences — ACL-gated fail-closed, append-only, provenance-tagged, frozen at round 3. Prints `appended\\t<issue>\\t<rows-after>`, or `escalated-frozen\\t<issue>\\t<round>` at the freeze; both are proven answers at exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (issue absent or closed, or no conforming acceptance-criteria block), 8 (the PATCH or the escalation comment failed — UNKNOWN), 9 (read-back does not show the prior rows plus this one), 11 (a precondition read failed), 14 (token below write or the ACL lookup failed — ADR 0055), 15 (the write would drop or mutate an existing row). Example: printf 'a regression test covers qty > 1' | fabrika review append-criterion 4287 --pr 4321 --round 1",
+	),
+);
+
+export const reviewCommand = Command.make("review").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
+		scope,
+		diff,
+		criteria,
+		ci,
+		verdicts,
+		deviations,
+		post,
+		appendCriterion,
+	]),
+	Command.withDescription(
+		"Read everything a text review needs off one pull request — scope, diff, criteria, CI, verdicts, deviations — and emit the verdict or a reviewer-authored criterion through the one sanctioned write path",
+	),
+);

--- a/packages/fabrika-cli/src/review/criteria-verb.ts
+++ b/packages/fabrika-cli/src/review/criteria-verb.ts
@@ -1,0 +1,90 @@
+/**
+ * `review criteria` — the linked issue's acceptance-criteria block, read through the registered
+ * `acceptance-criteria` wire format.
+ *
+ * The verb fetches the body and hands it to the format's own `read`; there is **no second parser**
+ * (`../wire/acceptance-criteria.ts`, imported). A drifted heading therefore reds as `Malformed`
+ * rather than reading as "there were none" — the wire module's discrimination carried to the fetch
+ * seam.
+ *
+ * An issue's open/closed state is deliberately not a precondition, asymmetric with
+ * `review append-criterion`: reading the contract off a closed issue is a legitimate re-review case,
+ * while writing to one buries the row where nobody looks.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {read as readCriteria, renderCriteria} from "../wire/acceptance-criteria.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {badNumber, resolveTargetRepo} from "./target.ts";
+
+const VERB = "review criteria";
+
+export interface CriteriaOptions {
+	readonly issue: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runCriteria = (
+	options: CriteriaOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue, json} = options;
+		const bad = badNumber(VERB, "an issue number", issue);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const found = yield* getIssue(repo, issue);
+		if (found._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `${VERB}: issue #${issue} not found in ${repo}.`);
+		}
+		if (found._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue} in ${repo}: ${found.reason} — whether a block exists is UNKNOWN.`,
+			);
+		}
+
+		const diagnostics =
+			found.value.state === "open"
+				? []
+				: [`${VERB}: #${issue} is ${found.value.state} — reading its contract anyway.`];
+
+		const block = readCriteria(found.value.body);
+		if (block._tag === "Absent") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${issue} carries no acceptance-criteria block — absent: ${block.reason}. Grade nothing; the contract is missing.`,
+				diagnostics,
+			);
+		}
+		if (block._tag === "Malformed") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${issue}'s acceptance-criteria block is malformed: ${block.reason} — a drifted heading is a defect to report, not "there were none".`,
+				diagnostics,
+			);
+		}
+
+		const criteria = block.value;
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "criteria",
+						issue,
+						count: criteria.length,
+						criteria: criteria.map(({text, checked}) => ({text, checked})),
+					}),
+					diagnostics,
+				)
+			: answer(
+					[`criteria\t${criteria.length}`, ...renderCriteria(criteria)].join("\n"),
+					diagnostics,
+				);
+	});

--- a/packages/fabrika-cli/src/review/criteria-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/criteria-verb.unit.test.ts
@@ -1,0 +1,84 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runCriteria} from "./criteria-verb.ts";
+import {issue} from "./fixtures.test-support.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
+
+const options = {
+	issue: 4287,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runCriteria({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+describe("runCriteria", () => {
+	it("prints the count and one line per criterion, in the wire format's own grammar", async () => {
+		const out = await run([[ISSUE, issue()]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				"criteria\t2",
+				"open\tthe first retry delay equals `base`",
+				"checked\tthe retry guide documents the delay table",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("emits the record with --json", async () => {
+		const out = await run([[ISSUE, issue()]], {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "criteria", issue: 4287, count: 2});
+	});
+
+	it("reads a CLOSED issue's contract anyway, with a notice — a re-review is legitimate", async () => {
+		const out = await run([[ISSUE, issue(undefined, "closed")]]);
+		expect(out.code).toBe(0);
+		expect(out.stderr[0]).toContain("#4287 is closed");
+	});
+
+	it("refuses an issue proven absent on 7", async () => {
+		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("review criteria: issue #4287 not found in o/r.");
+	});
+
+	it("refuses an ABSENT block on 7, naming the wire reason", async () => {
+		const out = await run([[ISSUE, issue("no contract here")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("carries no acceptance-criteria block — absent:");
+		expect(out.stderr.at(-1)).toContain("Grade nothing; the contract is missing.");
+	});
+
+	it("reds a DRIFTED heading as malformed — never as `there were none`", async () => {
+		const out = await run([[ISSUE, issue("## Acceptance Criteria\n\n- [ ] a thing\n")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("is malformed:");
+		expect(out.stderr.at(-1)).toContain('not "there were none"');
+	});
+
+	it("gives absent and malformed the same code and never the same message", async () => {
+		const absent = await run([[ISSUE, issue("nothing")]]);
+		const malformed = await run([[ISSUE, issue("## Acceptance Criteria\n\n- [ ] x\n")]]);
+		expect(absent.code).toBe(malformed.code);
+		expect(absent.stderr.at(-1)).not.toBe(malformed.stderr.at(-1));
+	});
+
+	it("refuses an unreadable issue on 11 — whether a block exists is UNKNOWN", async () => {
+		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("whether a block exists is UNKNOWN");
+	});
+});

--- a/packages/fabrika-cli/src/review/deviations-verb.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.ts
@@ -1,0 +1,90 @@
+/**
+ * `review deviations` — the PR body's `## Deviations` state, its entries, and the Tier-M token scan
+ * over the head diff.
+ *
+ * The verb reports states and facts, never the §DEV verdict row: whether the PR *owes* the section,
+ * and whether an entry's substance covers a finding, are Tier R — the judgment layer's. What this
+ * makes mechanical is the one thing a grep can hold an author to: a `None.` printed beside a
+ * non-empty Tier-M list is a falsified disclosure the caller sees in one read.
+ *
+ * The scan inherits `review diff`'s completeness proof, so a truncated diff reds here too — an
+ * under-reported hit list beside a `None.` reads as a checked-clean disclosure that was never
+ * checked.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getPullDiff} from "../io/pulls.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {readDeviations} from "./deviations.ts";
+import {filesInDiff, tierMHits} from "./diff.ts";
+import {NULL_TOKEN} from "./scope-verb.ts";
+import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "review deviations";
+
+export interface DeviationsOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const unreadable = (pr: number, reason: string): string =>
+	`${VERB}: cannot read #${pr}'s body or diff: ${reason} — the disclosure state is UNKNOWN, never "none".`;
+
+export const runDeviations = (
+	options: DeviationsOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: false,
+			requireFiles: false,
+			unknownMessage: (reason) => unreadable(pr, reason),
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const pull = target.pull;
+
+		const served = yield* getPullDiff(repo, pr);
+		if (served._tag === "Failure") {
+			return refuse(PRECONDITION_UNKNOWN, unreadable(pr, served.reason));
+		}
+		const diff = served.value;
+		const seen = filesInDiff(diff);
+		const diagnostics = [scannedLine(VERB, seen, "file", `${pull.changedFiles} declared`)];
+		if (seen < pull.changedFiles) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: the diff for #${pr} is truncated (${seen} of ${pull.changedFiles} files) — refusing a partial Tier-M scan beside a disclosure claim.`,
+				diagnostics,
+			);
+		}
+
+		const section = readDeviations(pull.body);
+		const hits = tierMHits(diff);
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: section.state,
+						entries: section.entries.map((entry) => ({label: entry.label, said: entry.said})),
+						tierM: hits,
+					}),
+					diagnostics,
+				)
+			: answer(
+					[
+						`deviations\t${section.state}`,
+						...section.entries.map((entry) => `entry\t${entry.label ?? NULL_TOKEN}\t${entry.said}`),
+						...hits.map((hit) => `tier-m\t${hit.kind}\t${hit.file}:${hit.line}\t${hit.token}`),
+					].join("\n"),
+					diagnostics,
+				);
+	});

--- a/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
@@ -1,0 +1,118 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runDeviations} from "./deviations-verb.ts";
+import {DIFF, pull} from "./fixtures.test-support.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
+
+const SUPPRESSING_DIFF = `diff --git a/src/cart.ts b/src/cart.ts
+--- a/src/cart.ts
++++ b/src/cart.ts
+@@ -10,1 +10,2 @@
+ const items = read();
++// @ts-expect-error the types are wrong
+diff --git a/src/cart.test.ts b/src/cart.test.ts
+--- a/src/cart.test.ts
++++ b/src/cart.test.ts
+@@ -12,2 +12,1 @@
+ it("renders", () => {
+-		expect(renderTotal(10)).toBe("10.00");
+`;
+
+const options = {
+	pr: 4321,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runDeviations({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+describe("runDeviations", () => {
+	it("prints none-declared for a `None.` body with a clean diff", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RAW, okOut(DIFF)],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("deviations\tnone-declared\n");
+	});
+
+	it("makes a falsified `None.` visible in one read — the claim beside the hits", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RAW, okOut(SUPPRESSING_DIFF)],
+		]);
+		expect(out.stdout).toBe(
+			[
+				"deviations\tnone-declared",
+				"tier-m\tsuppression\tsrc/cart.ts:11\t@ts-expect-error",
+				'tier-m\tremoved-assertion\tsrc/cart.test.ts:13\texpect(renderTotal(10)).toBe("10.00");',
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("prints an entry's label and the first line of its Said", async () => {
+		const body =
+			"## Deviations\n\n- **Pre-existing test or fixture changed** — **Said:** replaced the two-decimal rendering assertion. **Did:** dropped it.";
+		const out = await run([
+			[PULL, pull({body})],
+			[RAW, okOut(DIFF)],
+		]);
+		expect(out.stdout).toBe(
+			["deviations\tfound", "entry\t6\treplaced the two-decimal rendering assertion.", ""].join(
+				"\n",
+			),
+		);
+	});
+
+	it("keeps absent distinct from none-declared — the skill's verdict depends on it", async () => {
+		const out = await run([
+			[PULL, pull({body: "Fixes #4287\n"})],
+			[RAW, okOut(DIFF)],
+		]);
+		expect(out.stdout).toBe("deviations\tabsent\n");
+	});
+
+	it("refuses a truncated diff on 13 — a partial scan must not print beside a claim", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 9})],
+			[RAW, okOut(DIFF)],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("refusing a partial Tier-M scan beside a disclosure claim");
+	});
+
+	it("refuses a PR proven absent on 7", async () => {
+		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("review deviations: PR #4321 not found in o/r.");
+	});
+
+	it("refuses an unreadable body or diff on 11, and never answers `none`", async () => {
+		for (const script of [
+			[[PULL, errOut("gh: Bad gateway (HTTP 502)")]] as const,
+			[
+				[PULL, pull()],
+				[RAW, errOut("gh: Bad gateway (HTTP 502)")],
+			] as const,
+		]) {
+			const out = await run(script as ReadonlyArray<readonly [RegExp, ExecResult]>);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stdout).toBe("");
+			expect(out.stderr.at(-1)).toContain('the disclosure state is UNKNOWN, never "none"');
+		}
+	});
+});

--- a/packages/fabrika-cli/src/review/deviations.ts
+++ b/packages/fabrika-cli/src/review/deviations.ts
@@ -1,0 +1,126 @@
+/**
+ * The PR body's `## Deviations` section: which of four states it is in, and what it discloses.
+ *
+ * The four states stay distinct on the wire because the skill's verdict vocabulary depends on the
+ * distinction — absent-on-owing fails closed, `None.` is a *checked* claim, and this reader is what
+ * makes the claim checkable. Collapsing `absent` into `none-declared` is how "never considered it"
+ * comes to read as "nothing to disclose".
+ *
+ * v1's §DEV supplied the semantics — the four fields, the seven classes, the M/R/D tiers — and was
+ * read as prior art, never called (ADR 0238). Its heading detection is triplicated in awk across
+ * three surfaces; this is one reader.
+ */
+
+export type DeviationsState = "found" | "none-declared" | "absent" | "malformed";
+
+export interface DeviationEntry {
+	/** The class label `1`–`7`, or `null` when the entry carries none this reader recognises. */
+	readonly label: string | null;
+	/** The first line of the entry's **Said** field — what the spec asked. */
+	readonly said: string;
+}
+
+export interface DeviationsRead {
+	readonly state: DeviationsState;
+	readonly entries: ReadonlyArray<DeviationEntry>;
+}
+
+/**
+ * The seven classes, keyed by their canonical names normalised to letters.
+ *
+ * The vocabulary is **this contract's, enumerated closed** — never a pointer into v1's prose. The
+ * label is a routing hint, not the disclosure: a gate matches an entry's substance, never its label,
+ * so an unrecognised label costs a `-` and nothing else.
+ */
+const CLASSES: ReadonlyArray<readonly [string, string]> = [
+	["1", "scopenarrowing"],
+	["2", "governingadrdeparture"],
+	["3", "knowndefectleftunfixed"],
+	["4", "declinedguidance"],
+	["5", "guardorgatebypassed"],
+	["6", "preexistingtestorfixturechanged"],
+	["7", "outofscopechange"],
+];
+
+const HEADING = /^ {0,3}##[ \t]+(.*?)[ \t]*#*[ \t]*$/;
+const ANY_HEADING = /^ {0,3}#{1,6}[ \t]+/;
+const FENCE = /^ {0,3}(?:```|~~~)/;
+const normalize = (text: string): string => text.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/** The lines under the `## Deviations` heading, or `null` when the body carries no such heading. */
+const sectionOf = (body: string): ReadonlyArray<string> | null => {
+	const lines = body.split("\n");
+	let start = -1;
+	let fenced = false;
+	for (const [index, line] of lines.entries()) {
+		if (FENCE.test(line)) {
+			fenced = !fenced;
+			continue;
+		}
+		if (fenced) continue;
+		if (start >= 0) {
+			if (ANY_HEADING.test(line)) return lines.slice(start, index);
+			continue;
+		}
+		const heading = HEADING.exec(line);
+		if (heading !== null && normalize(heading[1] ?? "") === "deviations") start = index + 1;
+	}
+	return start >= 0 ? lines.slice(start) : null;
+};
+
+const labelOf = (lead: string): string | null => {
+	const key = normalize(lead);
+	const named = CLASSES.find(([, name]) => key.startsWith(name));
+	if (named !== undefined) return named[0];
+	const numeric = /^([1-7])\b/.exec(lead.trim());
+	return numeric?.[1] ?? null;
+};
+
+/** The `**Said:**` field's first line, or `null` when the bullet carries no `Said` at all. */
+const saidOf = (text: string): string | null => {
+	const at = /\*{0,2}said\*{0,2}\s*:/i.exec(text);
+	if (at === null) return null;
+	const rest = text.slice(at.index + at[0].length);
+	const end = /\*{0,2}(?:did|why|disposition)\*{0,2}\s*:/i.exec(rest);
+	const value = (end === null ? rest : rest.slice(0, end.index)).trim();
+	return value.split("\n")[0]?.trim() ?? "";
+};
+
+/**
+ * Each top-level `- ` bullet in the section, joined with its continuation lines.
+ *
+ * An entry spans several lines in practice — the four fields wrap — so a per-line read would report
+ * one entry as four and lose every `Said` that started on the second line.
+ */
+const bulletsOf = (section: ReadonlyArray<string>): ReadonlyArray<string> => {
+	const bullets: string[] = [];
+	for (const line of section) {
+		if (/^[ \t]{0,3}[-*][ \t]+/.test(line)) bullets.push(line.replace(/^[ \t]{0,3}[-*][ \t]+/, ""));
+		else if (bullets.length > 0 && line.trim() !== "") bullets[bullets.length - 1] += `\n${line}`;
+	}
+	return bullets;
+};
+
+/** The bold or plain lead of a bullet — `**Scope narrowing**` — before the first field. */
+const leadOf = (bullet: string): string => {
+	const bold = /^\s*\*\*(.+?)\*\*/.exec(bullet);
+	if (bold?.[1] !== undefined) return bold[1];
+	return bullet.split(/[—–:]/)[0] ?? "";
+};
+
+export const readDeviations = (body: string): DeviationsRead => {
+	const section = sectionOf(body);
+	if (section === null) return {state: "absent", entries: []};
+
+	const text = section.join("\n").trim();
+	if (text === "") return {state: "malformed", entries: []};
+	if (/^none\.?$/i.test(text)) return {state: "none-declared", entries: []};
+
+	const entries: DeviationEntry[] = [];
+	for (const bullet of bulletsOf(section)) {
+		const said = saidOf(bullet);
+		if (said === null) continue;
+		entries.push({label: labelOf(leadOf(bullet)), said});
+	}
+	return entries.length === 0 ? {state: "malformed", entries: []} : {state: "found", entries};
+};

--- a/packages/fabrika-cli/src/review/deviations.ts
+++ b/packages/fabrika-cli/src/review/deviations.ts
@@ -76,9 +76,15 @@ const labelOf = (lead: string): string | null => {
 	return numeric?.[1] ?? null;
 };
 
-/** The `**Said:**` field's first line, or `null` when the bullet carries no `Said` at all. */
+/**
+ * The `**Said:**` field's first line, or `null` when the bullet carries no `Said` at all.
+ *
+ * The emphasis is admitted on both sides of the colon: the canonical §DEV entry writes `**Said:**`,
+ * closing the bold *after* the punctuation, so a pattern anchored only on `**Said**:` would leave the
+ * closer at the head of every value it read.
+ */
 const saidOf = (text: string): string | null => {
-	const at = /\*{0,2}said\*{0,2}\s*:/i.exec(text);
+	const at = /\*{0,2}said\*{0,2}\s*:\s*\*{0,2}/i.exec(text);
 	if (at === null) return null;
 	const rest = text.slice(at.index + at[0].length);
 	const end = /\*{0,2}(?:did|why|disposition)\*{0,2}\s*:/i.exec(rest);

--- a/packages/fabrika-cli/src/review/deviations.unit.test.ts
+++ b/packages/fabrika-cli/src/review/deviations.unit.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from "vitest";
+import {readDeviations} from "./deviations.ts";
+
+const ENTRY =
+	"- **Scope narrowing** — **Said:** the AC asks for four gates. **Did:** three plus a bounce. **Why:** the fourth emits a trivial verdict. **Disposition:** stated in the PR body.";
+
+describe("readDeviations", () => {
+	it("reads absent when the body carries no `## Deviations` heading at all", () => {
+		expect(readDeviations("Fixes #1\n\n## Summary\n\nstuff")).toEqual({
+			state: "absent",
+			entries: [],
+		});
+	});
+
+	it("reads none-declared for the literal `None.`, which is a CHECKED claim", () => {
+		expect(readDeviations("## Deviations\n\nNone.\n")).toEqual({
+			state: "none-declared",
+			entries: [],
+		});
+	});
+
+	it("never folds absent into none-declared — the two are different facts", () => {
+		expect(readDeviations("no heading here").state).not.toBe(
+			readDeviations("## Deviations\n\nNone.").state,
+		);
+	});
+
+	it("reads an entry's class label and the first line of its Said", () => {
+		expect(readDeviations(`## Deviations\n\n${ENTRY}\n`)).toEqual({
+			state: "found",
+			entries: [{label: "1", said: "the AC asks for four gates."}],
+		});
+	});
+
+	it("prints `-` for an entry whose label this reader does not recognise", () => {
+		const body = "## Deviations\n\n- **Something else** — **Said:** a thing. **Did:** another.";
+		expect(readDeviations(body).entries[0]?.label).toBeNull();
+	});
+
+	it("accepts a bare numeric label too — the label is a routing hint, not the disclosure", () => {
+		const body = "## Deviations\n\n- **6** — **Said:** the fixture asserted the defect.";
+		expect(readDeviations(body).entries[0]?.label).toBe("6");
+	});
+
+	it("joins an entry's continuation lines, so one wrapped entry is one entry", () => {
+		const body = `## Deviations\n\n- **Declined guidance**\n  **Said:** take the reviewer's shape.\n  **Did:** kept mine.\n`;
+		const result = readDeviations(body);
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0]).toEqual({label: "4", said: "take the reviewer's shape."});
+	});
+
+	it("reads a heading whose section fits neither shape as malformed", () => {
+		expect(readDeviations("## Deviations\n\nprobably nothing?\n").state).toBe("malformed");
+		expect(readDeviations("## Deviations\n\n").state).toBe("malformed");
+	});
+
+	it("stops at the next heading, so a later section is not read as an entry", () => {
+		const body = `## Deviations\n\nNone.\n\n## Notes\n\n- **Said:** unrelated bullet.`;
+		expect(readDeviations(body).state).toBe("none-declared");
+	});
+
+	it("ignores a `## Deviations` heading inside a fenced block", () => {
+		const body = "before\n\n```\n## Deviations\n\nNone.\n```\n\nafter";
+		expect(readDeviations(body).state).toBe("absent");
+	});
+});

--- a/packages/fabrika-cli/src/review/diff-verb.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.ts
@@ -1,0 +1,69 @@
+/**
+ * `review diff` — the PR's diff bytes, with truncation refused rather than silently passed through.
+ *
+ * This verb is not a relay, and the completeness proof is why: GitHub truncates large diffs at the
+ * API tier, so a gate that judged the visible prefix as the whole PR is the #3925 blind-PASS class
+ * one layer down. v1's `pr-diff.sh` was the relay, and nothing checked what it served.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getPullDiff} from "../io/pulls.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {filesInDiff} from "./diff.ts";
+import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "review diff";
+
+export interface DiffOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runDiff = (
+	options: DiffOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			requireFiles: true,
+			emptyReason: "refusing to serve an empty diff as a reviewable one (ADR 0092).",
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const pull = target.pull;
+
+		const served = yield* getPullDiff(repo, pr);
+		if (served._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the diff for #${pr}: ${served.reason} — UNKNOWN.`,
+			);
+		}
+		const diff = served.value;
+		const seen = filesInDiff(diff);
+		const diagnostics = [
+			scannedLine(
+				VERB,
+				seen,
+				"file",
+				`${pull.changedFiles} declared, ${new TextEncoder().encode(diff).length} bytes`,
+			),
+		];
+		if (seen < pull.changedFiles) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: the diff for #${pr} is truncated (${seen} of ${pull.changedFiles} files) — refusing to serve a partial diff as the whole (#3925's class).`,
+				diagnostics,
+			);
+		}
+		return answer(diff, diagnostics);
+	});

--- a/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
@@ -1,0 +1,73 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runDiff} from "./diff-verb.ts";
+import {DIFF, pull} from "./fixtures.test-support.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
+
+const options = {
+	pr: 4321,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runDiff({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runDiff", () => {
+	it("serves the diff bytes exactly as the platform did", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RAW, okOut(DIFF)],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(DIFF);
+	});
+
+	it("reports the file and byte counts it proved the diff against", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[RAW, okOut(DIFF)],
+		]);
+		expect(out.stderr[0]).toContain("scanned 2 files; 2 declared");
+		expect(out.stderr[0]).toContain("bytes");
+	});
+
+	it("refuses a truncated diff on 13 rather than serving the prefix as the whole", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 7})],
+			[RAW, okOut(DIFF)],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review diff: the diff for #4321 is truncated (2 of 7 files) — refusing to serve a partial diff as the whole (#3925's class).",
+		);
+	});
+
+	it("makes the same zero-file refusal `review scope` does, so neither serves a review over nothing", async () => {
+		const out = await run([[PULL, pull({changedFiles: 0})]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain(
+			"refusing to serve an empty diff as a reviewable one (ADR 0092).",
+		);
+	});
+
+	it("refuses an absent PR on 7 and an unreadable diff on 11", async () => {
+		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		const unreadable = await run([
+			[PULL, pull()],
+			[RAW, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(unreadable.code).toBe(PRECONDITION_UNKNOWN);
+		expect(unreadable.stdout).toBe("");
+		expect(unreadable.stderr.at(-1)).toContain("UNKNOWN");
+	});
+});

--- a/packages/fabrika-cli/src/review/diff.ts
+++ b/packages/fabrika-cli/src/review/diff.ts
@@ -1,0 +1,114 @@
+/**
+ * The unified-diff walk: how many files the served diff actually carries, and where each added or
+ * removed line sits.
+ *
+ * **The completeness proof is the file count, and only the file count.** GitHub truncates large
+ * diffs at the API tier, and a gate that judged the visible prefix as the whole PR is the #3925
+ * blind-PASS class one layer down — so the served diff's `diff --git` header count is compared
+ * against the PR's declared `changed_files` and a short one is refused. It is deliberately not
+ * compared against a literal truncation marker: the exact bytes GitHub emits for a truncated diff
+ * are not verifiable from this repo, and an unverified marker string is a check that silently stops
+ * matching (CLAUDE.md's grounding rule). The count is derivable from what the platform already
+ * declares, so it is the proof this module makes.
+ */
+
+const FILE_HEADER = /^diff --git a\/(.*) b\/(.*)$/;
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/** How many files the served diff carries — the numerator of the completeness proof. */
+export const filesInDiff = (diff: string): number =>
+	diff.split("\n").filter((line) => FILE_HEADER.test(line)).length;
+
+/** One added or removed line, resolved to the file and line number a human can open. */
+export interface DiffLine {
+	readonly file: string;
+	readonly line: number;
+	readonly kind: "added" | "removed";
+	readonly text: string;
+}
+
+/**
+ * Every added and removed line in the diff, with its file and line number.
+ *
+ * An added line is numbered in the **new** file and a removed line in the **old** one, because those
+ * are the numbers that resolve: a deleted assertion does not exist at any new-file line. The file
+ * name is the `b/` path, falling back to `a/` for a deletion, so a rename reports where the line now
+ * lives.
+ */
+export const changedLines = (diff: string): ReadonlyArray<DiffLine> => {
+	const out: DiffLine[] = [];
+	let file = "";
+	let oldLine = 0;
+	let newLine = 0;
+	for (const raw of diff.split("\n")) {
+		const header = FILE_HEADER.exec(raw);
+		if (header !== null) {
+			const before = header[1] ?? "";
+			const after = header[2] ?? "";
+			file = after === "/dev/null" || after === "" ? before : after;
+			oldLine = 0;
+			newLine = 0;
+			continue;
+		}
+		const hunk = HUNK_HEADER.exec(raw);
+		if (hunk !== null) {
+			oldLine = Number.parseInt(hunk[1] ?? "0", 10);
+			newLine = Number.parseInt(hunk[2] ?? "0", 10);
+			continue;
+		}
+		// Everything above the first hunk — the `index`, `---` and `+++` lines — carries no line
+		// number, so it is skipped rather than read as a change.
+		if (newLine === 0 && oldLine === 0) continue;
+		if (raw.startsWith("+")) {
+			out.push({file, line: newLine, kind: "added", text: raw.slice(1)});
+			newLine += 1;
+		} else if (raw.startsWith("-")) {
+			out.push({file, line: oldLine, kind: "removed", text: raw.slice(1)});
+			oldLine += 1;
+		} else if (raw.startsWith(" ") || raw === "") {
+			oldLine += 1;
+			newLine += 1;
+		}
+	}
+	return out;
+};
+
+/** The two mechanically-detectable §DEV classes. */
+export type TierMKind = "suppression" | "removed-assertion";
+
+export interface TierMHit {
+	readonly kind: TierMKind;
+	readonly file: string;
+	readonly line: number;
+	readonly token: string;
+}
+
+/** Class 5's in-diff suppressions. The four tokens the contract enumerates, and no more. */
+const SUPPRESSIONS = ["biome-ignore", "@ts-expect-error", "test.skip", ".only"];
+
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
+/** What counts as an assertion for class 6. Both spellings the repo's two runners use. */
+const ASSERTION = /\b(?:expect|assert)\s*\(/;
+
+/**
+ * The Tier-M scan: the §DEV classes a gate can see in the diff itself.
+ *
+ * These are facts, never the verdict. Whether a disclosed entry's substance covers a hit is Tier R —
+ * the judgment layer's — and this scan only makes a `None.` beside a non-empty list visible in one
+ * read.
+ */
+export const tierMHits = (diff: string): ReadonlyArray<TierMHit> => {
+	const hits: TierMHit[] = [];
+	for (const {file, line, kind, text} of changedLines(diff)) {
+		if (kind === "added") {
+			for (const token of SUPPRESSIONS) {
+				if (text.includes(token)) hits.push({kind: "suppression", file, line, token});
+			}
+			continue;
+		}
+		if (TEST_FILE.test(file) && ASSERTION.test(text)) {
+			hits.push({kind: "removed-assertion", file, line, token: text.trim()});
+		}
+	}
+	return hits;
+};

--- a/packages/fabrika-cli/src/review/diff.unit.test.ts
+++ b/packages/fabrika-cli/src/review/diff.unit.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, it} from "vitest";
+import {changedLines, filesInDiff, tierMHits} from "./diff.ts";
+
+const DIFF = `diff --git a/src/cart.ts b/src/cart.ts
+index 0b1c2d3..a1b2c3d 100644
+--- a/src/cart.ts
++++ b/src/cart.ts
+@@ -10,3 +10,4 @@ export const total = () => {
+ 	const items = read();
++	// biome-ignore lint/suspicious/noExplicitAny: not now
+ 	return items.length;
+ };
+diff --git a/src/cart.test.ts b/src/cart.test.ts
+index 1111111..2222222 100644
+--- a/src/cart.test.ts
++++ b/src/cart.test.ts
+@@ -12,4 +12,3 @@ describe("cart", () => {
+ 	it("renders", () => {
+-		expect(renderTotal(10)).toBe("10.00");
+ 	});
+ });
+`;
+
+describe("filesInDiff", () => {
+	it("counts one per `diff --git` header — the numerator of the completeness proof", () => {
+		expect(filesInDiff(DIFF)).toBe(2);
+		expect(filesInDiff("")).toBe(0);
+	});
+});
+
+describe("changedLines", () => {
+	it("numbers an added line in the new file and a removed one in the old", () => {
+		const lines = changedLines(DIFF);
+		expect(lines).toContainEqual({
+			file: "src/cart.ts",
+			line: 11,
+			kind: "added",
+			text: "	// biome-ignore lint/suspicious/noExplicitAny: not now",
+		});
+		expect(lines).toContainEqual({
+			file: "src/cart.test.ts",
+			line: 13,
+			kind: "removed",
+			text: '		expect(renderTotal(10)).toBe("10.00");',
+		});
+	});
+
+	it("reads nothing above the first hunk — the `---`/`+++` lines carry no line number", () => {
+		expect(changedLines(DIFF).some((line) => line.text.startsWith("+ b/"))).toBe(false);
+		expect(changedLines(DIFF).filter((line) => line.file === "").length).toBe(0);
+	});
+
+	it("reports a deletion under the path it had", () => {
+		const deleted = `diff --git a/gone.test.ts b/dev/null
+--- a/gone.test.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-expect(1).toBe(1);
+-const x = 1;
+`;
+		expect(changedLines(deleted)[0]?.file).toBe("dev/null");
+	});
+});
+
+describe("tierMHits", () => {
+	it("finds an added suppression and a removed assertion in a test file", () => {
+		expect(tierMHits(DIFF)).toEqual([
+			{
+				kind: "suppression",
+				file: "src/cart.ts",
+				line: 11,
+				token: "biome-ignore",
+			},
+			{
+				kind: "removed-assertion",
+				file: "src/cart.test.ts",
+				line: 13,
+				token: 'expect(renderTotal(10)).toBe("10.00");',
+			},
+		]);
+	});
+
+	it("finds each of the four suppression tokens the contract enumerates", () => {
+		const suppressions = ["biome-ignore", "@ts-expect-error", "test.skip", ".only"];
+		for (const token of suppressions) {
+			const diff = `diff --git a/a.ts b/a.ts\n@@ -1,1 +1,2 @@\n a\n+${token} here\n`;
+			expect(tierMHits(diff).map((hit) => hit.token)).toContain(token);
+		}
+	});
+
+	it("does not report a removed assertion outside a test file", () => {
+		const diff = `diff --git a/src/app.ts b/src/app.ts\n@@ -1,2 +1,1 @@\n a\n-expect(x).toBe(1);\n`;
+		expect(tierMHits(diff)).toEqual([]);
+	});
+
+	it("does not report a suppression that was REMOVED — only what the diff adds", () => {
+		const diff = `diff --git a/a.ts b/a.ts\n@@ -1,2 +1,1 @@\n a\n-// biome-ignore lint: gone\n`;
+		expect(tierMHits(diff)).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/review/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/review/fixtures.test-support.ts
@@ -1,0 +1,89 @@
+/**
+ * The canned GitHub payloads the `review` verb tests script their spawner with.
+ *
+ * They live in one module because every verb in the group reads the same PR shape, and a per-test
+ * literal is how two tests come to disagree about what the platform returns.
+ */
+import {okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+
+export const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+export const OLD_HEAD = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
+
+export interface PullShape {
+	readonly state?: string;
+	readonly head?: string;
+	readonly body?: string;
+	readonly changedFiles?: number;
+	readonly comments?: number;
+}
+
+export const pull = (shape: PullShape = {}): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4321,
+			state: shape.state ?? "open",
+			head: {sha: shape.head ?? HEAD},
+			body: shape.body ?? "does a thing\n\nFixes #4287\n\n## Deviations\n\nNone.\n",
+			changed_files: shape.changedFiles ?? 2,
+			comments: shape.comments ?? 0,
+		}),
+	);
+
+export const files = (...names: ReadonlyArray<string>): ExecResult =>
+	okOut(JSON.stringify(names.map((filename) => ({filename}))));
+
+export const checkRuns = (
+	declared: number,
+	runs: ReadonlyArray<{name: string; status: string; conclusion: string | null}>,
+): ExecResult => okOut(JSON.stringify({total_count: declared, check_runs: runs}));
+
+export const comments = (
+	...rows: ReadonlyArray<{id: number; body: string; author?: string}>
+): ExecResult =>
+	okOut(
+		JSON.stringify(
+			rows.map((row) => ({
+				id: row.id,
+				user: {login: row.author ?? "kampus-bot"},
+				created_at: "2026-08-08T00:00:00Z",
+				body: row.body,
+			})),
+		),
+	);
+
+/** A two-file unified diff whose header count matches `pull()`'s declared `changed_files`. */
+export const DIFF = `diff --git a/src/cart.ts b/src/cart.ts
+--- a/src/cart.ts
++++ b/src/cart.ts
+@@ -10,2 +10,3 @@
+ const items = read();
++const extra = 1;
+diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1,1 +1,2 @@
+ # phoenix
++a line
+`;
+
+export const ISSUE_BODY = `Build the thing.
+
+### Acceptance criteria
+
+- [ ] the first retry delay equals \`base\`
+- [x] the retry guide documents the delay table
+`;
+
+export const issue = (body: string = ISSUE_BODY, state = "open"): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4287,
+			title: "t",
+			body,
+			state,
+			labels: [],
+			html_url: "https://example.test/issues/4287",
+			milestone: null,
+		}),
+	);

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -1,0 +1,370 @@
+/**
+ * The mutation harness: for each load-bearing guard, plant a counterexample the guard must catch,
+ * then break exactly that guard and prove the verb answers **wrongly** instead.
+ *
+ * A guard you cannot demonstrate failing is not demonstrated. An ordinary unit test shows the guard
+ * refusing; only the mutant shows that the refusal is *load-bearing* — that without it the verb
+ * returns a plausible value over evidence it never had.
+ *
+ * **Every mutant is asserted to die for its INTENDED reason.** Each case pins the exact wrong answer
+ * the mutant produces (a `green` rollup, a `current` binding, an exit 0 where a refusal belongs), not
+ * merely that something differed. A sibling lane's harness scored every mutant "caught" while they
+ * were all dying of an unrelated path-resolution error, so a loose `expect(mutant).not.toEqual(real)`
+ * is exactly the assertion this file may not make.
+ *
+ * The mutants are injected by module substitution rather than by editing files on disk: each case
+ * resets the module registry, overrides **one** export of **one** module over the real one, and
+ * re-imports the verb. The specifiers below are byte-identical to the ones the verbs themselves
+ * import, so no path is re-derived and nothing resolves through a symlink.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {APPEND_ONLY, INCOMPLETE_SCAN, LEAKED_PATH, READBACK_MISMATCH} from "./codes.ts";
+import {
+	checkRuns,
+	comments,
+	DIFF,
+	files,
+	HEAD,
+	issue,
+	OLD_HEAD,
+	pull,
+} from "./fixtures.test-support.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
+const RUNS = /^gh api --paginate repos\/o\/r\/commits\/[0-9a-f]+\/check-runs/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
+const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+const USER = /^gh api user --jq \.login$/;
+const PERMISSION = /^gh api repos\/o\/r\/collaborators\/kampus-bot\/permission --jq \.permission$/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4287 -f body=/;
+
+const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;
+
+const withShell = <A>(
+	effect: Effect.Effect<A, never, ChildProcessSpawner.ChildProcessSpawner>,
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+): Promise<A> => Effect.runPromise(Effect.provide(effect, fakeShell(script).layer));
+
+afterEach(() => {
+	vi.resetModules();
+	vi.doUnmock("./rollup.ts");
+	vi.doUnmock("./diff.ts");
+	vi.doUnmock("./append.ts");
+	vi.doUnmock("../wire/verdict-marker.ts");
+	vi.doUnmock("../report/leaks.ts");
+	vi.doUnmock("../report/compose.ts");
+});
+
+/** Replace one export of one module, keeping every other export real. */
+const mutate = async <M extends Record<string, unknown>>(
+	specifier: string,
+	patch: (actual: M) => Partial<M>,
+): Promise<void> => {
+	vi.resetModules();
+	const actual = (await vi.importActual(specifier)) as M;
+	vi.doMock(specifier, () => ({...actual, ...patch(actual)}));
+};
+
+describe("the CI rollup's fail-closed buckets", () => {
+	const CANCELLED = checkRuns(1, [
+		{name: "unit tests", status: "completed", conclusion: "cancelled"},
+	]);
+	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull()],
+		[RUNS, CANCELLED],
+	];
+
+	it("reds a cancelled check — a check that proved nothing must not read green", async () => {
+		const {runCi} = await import("./ci-verb.ts");
+		const out = await withShell(
+			runCi({pr: 4321, sha: null, repo: null, json: false, env: ENV}),
+			script,
+		);
+		expect(out.stdout.split("\n")[0]).toBe(`ci\t${HEAD}\tred`);
+	});
+
+	it("MUTANT: dropping `cancelled` from the red set makes the same PR report GREEN", async () => {
+		await mutate<typeof import("./rollup.ts")>("./rollup.ts", (actual) => ({
+			rollupOf: (runs) => actual.rollupOf(runs.filter((run) => run.conclusion !== "cancelled")),
+		}));
+		const {runCi} = await import("./ci-verb.ts");
+		const out = await withShell(
+			runCi({pr: 4321, sha: null, repo: null, json: false, env: ENV}),
+			script,
+		);
+		// The intended death, named exactly: the answer flips to the permissive token, at exit 0.
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe(`ci\t${HEAD}\tgreen`);
+	});
+});
+
+describe("the three-outcome binding", () => {
+	const STALE = `review-code: PASS @ ${OLD_HEAD} — merge-ready`;
+	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({comments: 1})],
+		[COMMENTS, comments({id: 1, body: STALE})],
+	];
+
+	it("prints a stale PASS as stale", async () => {
+		const {runVerdicts} = await import("./verdicts-verb.ts");
+		const out = await withShell(runVerdicts({pr: 4321, repo: null, json: false, env: ENV}), script);
+		expect(out.stdout).toContain("\tstale\t");
+	});
+
+	it("MUTANT: folding Stale into Current makes a stale PASS read as a CURRENT one (ADR 0058)", async () => {
+		await mutate<typeof import("../wire/verdict-marker.ts")>(
+			"../wire/verdict-marker.ts",
+			(actual) => ({
+				bindToHead: (marker, head) => {
+					const binding = actual.bindToHead(marker, head);
+					return binding._tag === "Stale" ? {_tag: "Current", sha: marker.sha} : binding;
+				},
+			}),
+		);
+		const {runVerdicts} = await import("./verdicts-verb.ts");
+		const out = await withShell(runVerdicts({pr: 4321, repo: null, json: false, env: ENV}), script);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tcurrent\t");
+		expect(out.stdout).not.toContain("\tstale\t");
+	});
+});
+
+describe("the diff completeness proof", () => {
+	// The PR declares seven files; the platform served two. Anything but a refusal judges 2/7.
+	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({changedFiles: 7})],
+		[RAW, okOut(DIFF)],
+	];
+
+	it("refuses a truncated diff on 13", async () => {
+		const {runDiff} = await import("./diff-verb.ts");
+		const out = await withShell(runDiff({pr: 4321, repo: null, env: ENV}), script);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("MUTANT: a file count that always matches serves the partial diff as the whole (#3925)", async () => {
+		await mutate<typeof import("./diff.ts")>("./diff.ts", () => ({filesInDiff: () => 7}));
+		const {runDiff} = await import("./diff-verb.ts");
+		const out = await withShell(runDiff({pr: 4321, repo: null, env: ENV}), script);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(DIFF);
+	});
+});
+
+describe("the leak predicate over the assembled verdict", () => {
+	const LEAKY = "the failure is at /Users/someone/scratch/case.md";
+	const options = {
+		pr: 4321,
+		namespace: "review-doc",
+		polarity: "PASS",
+		sha: HEAD,
+		clause: "guide matches shipped behavior",
+		carrier: "marker",
+		repo: null,
+		json: false,
+		env: ENV,
+		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: LEAKY}),
+	};
+	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull()],
+		[FILES, files("src/cart.ts", "README.md")],
+		[USER, okOut("kampus-bot")],
+		[COMMENTS, comments()],
+		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		[
+			READBACK,
+			okOut(
+				JSON.stringify({
+					body: `review-doc: PASS @ ${HEAD} — guide matches shipped behavior\n\n${LEAKY}`,
+				}),
+			),
+		],
+	];
+
+	it("refuses a machine-local path in the verdict body on 5, posting nothing", async () => {
+		const {runPost} = await import("./post-verb.ts");
+		const shell = fakeShell(script);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("MUTANT: a predicate that finds nothing posts the machine-local path to the PR (#3173)", async () => {
+		await mutate<typeof import("../report/leaks.ts")>("../report/leaks.ts", () => ({
+			scanBody: (body: string) => ({leaks: [], redacted: body}),
+		}));
+		const {runPost} = await import("./post-verb.ts");
+		const shell = fakeShell(script);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls.some((call) => call.includes("/Users/someone/scratch/case.md"))).toBe(true);
+	});
+});
+
+describe("normalizeForReadback's trailing-newline step", () => {
+	// The contract's explicit warning: a re-derivation that drops the third step fires exit 9 on a
+	// clean run. The counterexample is a comment GitHub echoed back with a trailing newline.
+	const options = {
+		pr: 4321,
+		namespace: "review-doc",
+		polarity: "PASS",
+		sha: HEAD,
+		clause: "guide matches shipped behavior",
+		carrier: "marker",
+		repo: null,
+		json: false,
+		env: ENV,
+		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "the table\n"}),
+	};
+	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull()],
+		[FILES, files("src/cart.ts", "README.md")],
+		[USER, okOut("kampus-bot")],
+		[COMMENTS, comments()],
+		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		[
+			READBACK,
+			okOut(
+				JSON.stringify({
+					body: `review-doc: PASS @ ${HEAD} — guide matches shipped behavior   \n\nthe table\n\n\n`,
+				}),
+			),
+		],
+	];
+
+	it("accepts a read-back that differs only in trailing whitespace", async () => {
+		const {runPost} = await import("./post-verb.ts");
+		const out = await withShell(runPost(options), script);
+		expect(out.code).toBe(0);
+	});
+
+	it("MUTANT: dropping the trailing-newline step fires exit 9 on a CLEAN run", async () => {
+		await mutate<typeof import("../report/compose.ts")>("../report/compose.ts", () => ({
+			normalizeForReadback: (text: string) => text,
+		}));
+		const {runPost} = await import("./post-verb.ts");
+		const out = await withShell(runPost(options), script);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("the comment's bytes are not the ones that were sent");
+	});
+});
+
+describe("the append-only fence", () => {
+	const TEXT = "a regression test covers qty > 1";
+	const options = {
+		issue: 4287,
+		pr: 4321,
+		round: 1,
+		repo: null,
+		json: false,
+		env: ENV,
+		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: TEXT}),
+	};
+	const WITH_LATER_SECTION = `### Acceptance criteria
+
+- [ ] the only criterion
+
+## Notes
+
+nothing yet.
+`;
+	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[USER, okOut("kampus-bot")],
+		[PERMISSION, okOut("write")],
+		[ISSUE, issue(WITH_LATER_SECTION)],
+		[PATCH, okOut("{}")],
+	];
+
+	it("MUTANT: a composition that appends PAST the block reds on 15, before any PATCH", async () => {
+		await mutate<typeof import("./append.ts")>("./append.ts", () => ({
+			insertAfterLastCriterion: (body: string, _last: string, row: string) => `${body}\n${row}`,
+		}));
+		const {runAppendCriterion} = await import("./append-criterion-verb.ts");
+		const shell = fakeShell(script);
+		const out = await Effect.runPromise(Effect.provide(runAppendCriterion(options), shell.layer));
+		expect(out.code).toBe(APPEND_ONLY);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review append-criterion: the append would drop or mutate an existing row — refusing (append-only fence).",
+		);
+		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+	});
+
+	it("MUTANT: a growth check that always passes lets an unchanged read-back exit 0", async () => {
+		await mutate<typeof import("./append.ts")>("./append.ts", () => ({
+			grewByOne: () => true,
+		}));
+		const {runAppendCriterion} = await import("./append-criterion-verb.ts");
+		const unchanged: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[once(ISSUE), issue()],
+			[ISSUE, issue()],
+			[PATCH, okOut("{}")],
+		];
+		const out = await withShell(runAppendCriterion(options), unchanged);
+		expect(out.code).toBe(0);
+	});
+
+	it("without the mutant, that same unchanged read-back reds on 9", async () => {
+		const {runAppendCriterion} = await import("./append-criterion-verb.ts");
+		const unchanged: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+			[USER, okOut("kampus-bot")],
+			[PERMISSION, okOut("write")],
+			[once(ISSUE), issue()],
+			[ISSUE, issue()],
+			[PATCH, okOut("{}")],
+		];
+		const out = await withShell(runAppendCriterion(options), unchanged);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+});
+
+describe("the short-read refusal on the changed-file list", () => {
+	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({changedFiles: 9})],
+		[FILES, files("src/cart.ts", "README.md")],
+	];
+
+	it("refuses a partition over a truncated read on 13", async () => {
+		const {runScope} = await import("./scope-verb.ts");
+		const out = await withShell(runScope({pr: 4321, repo: null, json: false, env: ENV}), script);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+	});
+
+	it("MUTANT: a file list that reports the declared count partitions 2 of 9 files as the whole", async () => {
+		await mutate<typeof import("../io/pulls.ts")>("../io/pulls.ts", (actual) => ({
+			listPullFiles: (repo: string, pr: number) =>
+				Effect.map(actual.listPullFiles(repo, pr), (attempt) =>
+					attempt._tag === "Ok"
+						? {
+								_tag: "Ok" as const,
+								value: [...attempt.value, ...Array.from({length: 7}, (_, i) => `pad-${i}.ts`)],
+							}
+						: attempt,
+				),
+		}));
+		const {runScope} = await import("./scope-verb.ts");
+		const out = await withShell(runScope({pr: 4321, repo: null, json: false, env: ENV}), script);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("scoped\t");
+	});
+
+	it("proves the harness itself is live — an unscripted call still fails loudly", async () => {
+		const {runScope} = await import("./scope-verb.ts");
+		const out = await withShell(runScope({pr: 4321, repo: null, json: false, env: ENV}), [
+			[PULL, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).not.toBe(0);
+	});
+});

--- a/packages/fabrika-cli/src/review/post-verb.ts
+++ b/packages/fabrika-cli/src/review/post-verb.ts
@@ -77,23 +77,41 @@ const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.star
 /**
  * Why the read-back does not show what was posted, or `null` when it does.
  *
- * The marker carrier is checked through the format's own `read`, which is the contract's step 6. The
- * **advisory** carrier cannot be: its first line deliberately withholds the SHA, so the format reads
- * it as `Malformed` by design (ADR 0111). It is verified through its own two anchors instead — the
- * advisory first line and the canonical `Reviewed-head:` body line — which is the same unconditional
- * live-state assertion applied to the shape that was actually written.
+ * Two assertions, and both are needed. The **marker** is checked through the format's own `read`,
+ * which is the contract's step 6 — the four fields have to be the four that were composed. The
+ * **whole comment** is then compared against the bytes that were sent, through `normalizeForReadback`
+ * from `report/compose.ts`: a marker that parses proves nothing about the body under it, and the body
+ * is the verdict. The normalizer is what makes that comparison survivable — its trailing-newline step
+ * is the one a re-derivation drops, which fires this refusal on every clean run.
+ *
+ * The **advisory** carrier cannot go through the format: its first line deliberately withholds the
+ * SHA, so `read` calls it `Malformed` by design (ADR 0111). It is verified through its own two
+ * anchors instead — the advisory first line and the canonical `Reviewed-head:` body line — and then
+ * through the same whole-comment comparison.
  */
-const mismatchOf = (body: string, posted: Posted, carrier: Carrier): string | null => {
+const mismatchOf = (
+	body: string,
+	posted: Posted,
+	carrier: Carrier,
+	composed: string,
+): string | null => {
 	const normalized = normalizeForReadback(body);
+	// The field checks run first because they name WHICH field drifted; the whole-comment comparison
+	// below is the broader net and would otherwise mask that with one generic reason.
+	const bytes =
+		normalized === normalizeForReadback(composed)
+			? null
+			: "the comment's bytes are not the ones that were sent";
 	if (carrier === "advisory") {
 		const advisory = readAdvisory(normalized);
 		if (advisory === null) return "the advisory first line or its Reviewed-head: line is not there";
 		if (advisory.namespace !== posted.namespace) {
 			return `namespace ${advisory.namespace}, expected ${posted.namespace}`;
 		}
-		return advisory.sha === posted.sha
-			? null
-			: `Reviewed-head ${advisory.sha}, expected ${posted.sha}`;
+		if (advisory.sha !== posted.sha) {
+			return `Reviewed-head ${advisory.sha}, expected ${posted.sha}`;
+		}
+		return bytes;
 	}
 	const parsed = readMarker(normalized);
 	if (parsed._tag !== "Found") return parsed.reason;
@@ -105,9 +123,10 @@ const mismatchOf = (body: string, posted: Posted, carrier: Carrier): string | nu
 		return `polarity ${marker.polarity}, expected ${posted.polarity}`;
 	}
 	if (marker.sha !== posted.sha) return `sha ${marker.sha}, expected ${posted.sha}`;
-	return normalizeForReadback(marker.clause) === normalizeForReadback(posted.clause)
-		? null
-		: `clause "${marker.clause}", expected "${posted.clause}"`;
+	if (marker.clause !== posted.clause) {
+		return `clause "${marker.clause}", expected "${posted.clause}"`;
+	}
+	return bytes;
 };
 
 /** Steps 1, 2 and 5's reads failing is `11`: nothing was written, so the outcome is known-unwritten. */
@@ -248,7 +267,7 @@ export const runPost = (
 		const mismatch =
 			back._tag === "Failure"
 				? back.reason
-				: mismatchOf(back.value, {namespace, polarity, sha: inspected, clause}, carrier);
+				: mismatchOf(back.value, {namespace, polarity, sha: inspected, clause}, carrier, composed);
 		if (mismatch !== null) {
 			return refuse(
 				READBACK_MISMATCH,

--- a/packages/fabrika-cli/src/review/post-verb.ts
+++ b/packages/fabrika-cli/src/review/post-verb.ts
@@ -1,0 +1,277 @@
+/**
+ * `review post` — the single sanctioned verdict emit.
+ *
+ * Six steps, each gating the next: recompute the class set, re-resolve the live head, compose the
+ * first line through the wire format's `emit`, leak-scan the assembled comment, upsert **one comment
+ * per namespace**, and read it back unconditionally from live PR state.
+ *
+ * Every one of those is a scar. #3173's hand-rolled `gh api` emit posted a literal path and
+ * self-reported a false PASS, which is why the read-back re-fetches instead of trusting a carried
+ * variable. The namespace set is recomputed rather than trusted because v1 got "a gate never emits
+ * another gate's marker" free from one-skill-per-namespace and this owner does not. The `12` refusal
+ * is `bindToHead`'s `Stale` arm applied at the write seam, where its absence costs the most. And the
+ * marker is the comment's **literal first line** — a second marker stacked on line 2 is un-anchored,
+ * resolves its namespace empty, and fail-closes a substantively-passing PR (the PR #2456 stall).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getComment, listComments} from "../io/issues.ts";
+import {listPullFiles, patchComment, viewerLogin} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	emit as emitMarker,
+	headSha,
+	type Polarity,
+	read as readMarker,
+	clause as toClause,
+} from "../wire/verdict-marker.ts";
+import {emitAdvisory, readAdvisory, reviewedHeadLine} from "./advisory.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
+import {namespacesOf, partition} from "./classes.ts";
+import {
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "review post";
+
+const SURFACE: AuthoredSurface = {
+	verb: VERB,
+	noun: "the assembled comment",
+	emptyMessage: `${VERB}: no body on stdin — an empty verdict reads as UNGATED; pipe the verdict body in.`,
+	bareAtMessage: `${VERB}: the body is a bare "@" path reference — the body never arrived. Send its bytes on stdin.`,
+	leakCorrection: "cite it repo-relative or by class root.",
+};
+
+export type Carrier = "marker" | "advisory";
+
+export interface PostOptions {
+	readonly pr: number;
+	readonly namespace: string;
+	readonly polarity: string;
+	readonly sha: string;
+	readonly clause: string;
+	readonly carrier: string;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+interface Posted {
+	readonly namespace: string;
+	readonly polarity: string;
+	readonly sha: string;
+	readonly clause: string;
+}
+
+/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
+
+/**
+ * Why the read-back does not show what was posted, or `null` when it does.
+ *
+ * The marker carrier is checked through the format's own `read`, which is the contract's step 6. The
+ * **advisory** carrier cannot be: its first line deliberately withholds the SHA, so the format reads
+ * it as `Malformed` by design (ADR 0111). It is verified through its own two anchors instead — the
+ * advisory first line and the canonical `Reviewed-head:` body line — which is the same unconditional
+ * live-state assertion applied to the shape that was actually written.
+ */
+const mismatchOf = (body: string, posted: Posted, carrier: Carrier): string | null => {
+	const normalized = normalizeForReadback(body);
+	if (carrier === "advisory") {
+		const advisory = readAdvisory(normalized);
+		if (advisory === null) return "the advisory first line or its Reviewed-head: line is not there";
+		if (advisory.namespace !== posted.namespace) {
+			return `namespace ${advisory.namespace}, expected ${posted.namespace}`;
+		}
+		return advisory.sha === posted.sha
+			? null
+			: `Reviewed-head ${advisory.sha}, expected ${posted.sha}`;
+	}
+	const parsed = readMarker(normalized);
+	if (parsed._tag !== "Found") return parsed.reason;
+	const marker = parsed.value;
+	if (marker.namespace !== posted.namespace) {
+		return `namespace ${marker.namespace}, expected ${posted.namespace}`;
+	}
+	if (marker.polarity !== posted.polarity) {
+		return `polarity ${marker.polarity}, expected ${posted.polarity}`;
+	}
+	if (marker.sha !== posted.sha) return `sha ${marker.sha}, expected ${posted.sha}`;
+	return normalizeForReadback(marker.clause) === normalizeForReadback(posted.clause)
+		? null
+		: `clause "${marker.clause}", expected "${posted.clause}"`;
+};
+
+/** Steps 1, 2 and 5's reads failing is `11`: nothing was written, so the outcome is known-unwritten. */
+const unreadableMessage = (what: string, pr: number, reason: string): string =>
+	`${VERB}: cannot read ${what} for #${pr}: ${reason} — nothing was posted.`;
+
+const unreadable = (what: string, pr: number, reason: string): VerbOutcome =>
+	refuse(PRECONDITION_UNKNOWN, unreadableMessage(what, pr, reason));
+
+export const runPost = (
+	options: PostOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const polarity = options.polarity.toUpperCase();
+		if (polarity !== "PASS" && polarity !== "FAIL") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --polarity must be PASS or FAIL — got "${options.polarity}". A third token is not a polarity.`,
+			);
+		}
+		const carrier = options.carrier.toLowerCase();
+		if (carrier !== "marker" && carrier !== "advisory") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --carrier must be marker or advisory — got "${options.carrier}".`,
+			);
+		}
+		if (carrier === "advisory" && polarity === "FAIL") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --carrier advisory is a PASS path only (ADR 0226) — post the FAIL marker instead.`,
+			);
+		}
+		const inspected = headSha(options.sha);
+		if (inspected === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --sha "${options.sha}" is not a head SHA — expected 7–40 hex characters.`,
+			);
+		}
+		const clause = toClause(options.clause);
+		if (clause === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --clause is blank — a verdict with no clause says nothing to a human.`,
+			);
+		}
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "a verdict on a closed PR gates nothing.",
+			requireFiles: false,
+			unknownMessage: (reason) => unreadableMessage("the PR", pr, reason),
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const live = target.pull.headSha;
+
+		// Step 1 — recompute the class set this run derived, and refuse a namespace outside it.
+		const listed = yield* listPullFiles(repo, pr);
+		if (listed._tag === "Failure") return unreadable("the changed-file list", pr, listed.reason);
+		const derived = namespacesOf(partition(listed.value));
+		const diagnostics = [scannedLine(VERB, listed.value.length, "changed file")];
+		const namespace = options.namespace.trim().toLowerCase();
+		if (!derived.includes(namespace)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --namespace ${namespace} is not derived by #${pr}'s diff (present: ${derived.join(", ")}) — a gate never emits a namespace it did not judge.`,
+				diagnostics,
+			);
+		}
+
+		// Step 2 — the verdict binds the tree it was formed over, or it is re-reviewed, never re-bound.
+		if (!prefixMatch(live, inspected)) {
+			return refuse(
+				STALE_HEAD,
+				`${VERB}: the live head is ${live}, not ${inspected} — the tree you judged is gone; re-review at ${live} (ADR 0058).`,
+				diagnostics,
+			);
+		}
+
+		// Step 3 — compose through the wire format, or through the ADR 0151 advisory shape.
+		const firstLine =
+			carrier === "advisory"
+				? emitAdvisory(namespace, clause)
+				: emitMarker({namespace, polarity: polarity as Polarity, sha: inspected, clause});
+		const below =
+			carrier === "advisory" ? `${reviewedHeadLine(inspected)}\n\n${authored.text}` : authored.text;
+		const composed = `${firstLine}\n${below}`;
+
+		// Step 4 — the scan runs over the ASSEMBLED comment, so nothing this verb appended escapes it.
+		const leaked = leakRefusal(SURFACE, composed);
+		if (leaked !== null) return leaked;
+
+		// Step 5 — one namespace, one comment: edit this namespace's own comment, else create one.
+		const me = yield* viewerLogin;
+		if (me._tag === "Failure") return unreadable("the authenticated user", pr, me.reason);
+		const comments = yield* listComments(repo, pr);
+		if (comments._tag === "Failure") return unreadable("the comments", pr, comments.reason);
+		const mine = comments.value.find((comment) => {
+			if (comment.author !== me.value) return false;
+			const parsed = readMarker(comment.body);
+			return parsed._tag === "Found" && parsed.value.namespace === namespace;
+		});
+
+		let landed: {readonly id: number; readonly url: string} | null = null;
+		let failure: string | null = null;
+		if (mine === undefined) {
+			const created = yield* createComment(repo, pr, composed);
+			if (created._tag === "Failure") failure = created.reason;
+			else landed = {id: created.value.id, url: created.value.url};
+		} else {
+			const edited = yield* patchComment(repo, mine.id, composed);
+			if (edited._tag === "Failure") failure = edited.reason;
+			else landed = {id: mine.id, url: edited.value};
+		}
+		if (landed === null) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: create/edit failed: ${failure ?? "unknown"} — UNKNOWN whether the verdict landed; run \`fabrika review verdicts ${pr}\` before retrying.`,
+				diagnostics,
+			);
+		}
+		const upsert = mine === undefined ? "created" : "edited";
+
+		// Step 6 — read it back from live state. The write call's own echo is not evidence (#3173).
+		const back = yield* getComment(repo, landed.id);
+		const mismatch =
+			back._tag === "Failure"
+				? back.reason
+				: mismatchOf(back.value, {namespace, polarity, sha: inspected, clause}, carrier);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: posted, but the read-back does not yield this marker (${mismatch}) — the PR may carry a garbled verdict; inspect comment ${landed.id}.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "posted",
+						namespace,
+						polarity,
+						sha: inspected,
+						upsert,
+						carrier,
+						commentUrl: landed.url,
+					}),
+					diagnostics,
+				)
+			: answer(
+					`posted\t${namespace}\t${polarity}\t${inspected}\t${upsert}\t${landed.url}`,
+					diagnostics,
+				);
+	});

--- a/packages/fabrika-cli/src/review/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/post-verb.unit.test.ts
@@ -1,0 +1,300 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {comments, files, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+import {runPost} from "./post-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+const USER = /^gh api user --jq \.login$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/\d+ /;
+const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+
+const BODY = "| criterion | verdict |\n|---|---|\n| the first thing | PASS |\n";
+const URL = "https://example.test/pull/4321#issuecomment-5154902211";
+const MARKER = `review-doc: PASS @ ${HEAD} — guide matches shipped behavior`;
+
+const created = okOut(JSON.stringify({id: 5154902211, html_url: URL}));
+const commentBody = (body: string): ExecResult => okOut(JSON.stringify({body}));
+
+const options = {
+	pr: 4321,
+	namespace: "review-doc",
+	polarity: "PASS",
+	sha: HEAD,
+	clause: "guide matches shipped behavior",
+	carrier: "marker",
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: BODY}),
+};
+
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull()],
+	[FILES, files("src/cart.ts", "README.md")],
+	[USER, okOut("kampus-bot")],
+	[COMMENTS, comments()],
+	[CREATE, created],
+	[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runPost({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runPost", () => {
+	it("posts the verdict and says whether it created or edited", async () => {
+		const out = await run(happy());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`posted\treview-doc\tPASS\t${HEAD}\tcreated\t${URL}\n`);
+	});
+
+	it("puts the marker on the comment's LITERAL first line, never stacked on line 2", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
+		const body = write.slice(write.indexOf("body=") + "body=".length);
+		expect(body.split("\n")[0]).toBe(MARKER);
+		expect(body.split("\n").filter((line) => line.startsWith("review-doc:"))).toHaveLength(1);
+	});
+
+	it("edits this namespace's existing comment instead of stacking a second one", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 1})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[
+				COMMENTS,
+				comments({
+					id: 42,
+					body: `review-doc: PASS @ ${OLD_HEAD} — older round`,
+					author: "kampus-bot",
+				}),
+			],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tedited\t");
+		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("does not edit another author's comment in the same namespace", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 1})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments({id: 42, body: MARKER, author: "someone-else"})],
+			[CREATE, created],
+			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.stdout).toContain("\tcreated\t");
+	});
+
+	it("refuses a namespace this PR's own diff did not derive, on 10", async () => {
+		const out = await run(happy(), {namespace: "review-skill"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review post: --namespace review-skill is not derived by #4321's diff (present: review-code, review-doc) — a gate never emits a namespace it did not judge.",
+		);
+	});
+
+	it("refuses a third polarity token, and advisory+FAIL, on 10", async () => {
+		const bad = await run(happy(), {polarity: "MAYBE"});
+		expect(bad.code).toBe(OFF_VOCABULARY);
+		expect(bad.stderr.at(-1)).toContain("A third token is not a polarity");
+
+		const advisoryFail = await run(happy(), {polarity: "FAIL", carrier: "advisory"});
+		expect(advisoryFail.code).toBe(OFF_VOCABULARY);
+		expect(advisoryFail.stderr.at(-1)).toBe(
+			"review post: --carrier advisory is a PASS path only (ADR 0226) — post the FAIL marker instead.",
+		);
+	});
+
+	it("refuses a moved-past head on 12 and writes nothing — re-review, never re-bind", async () => {
+		const shell = fakeShell(happy());
+		const out = await Effect.runPromise(
+			Effect.provide(runPost({...options, sha: OLD_HEAD}), shell.layer),
+		);
+		expect(out.code).toBe(STALE_HEAD);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`review post: the live head is ${HEAD}, not ${OLD_HEAD} — the tree you judged is gone; re-review at ${HEAD} (ADR 0058).`,
+		);
+		expect(shell.calls.some((call) => CREATE.test(call) || PATCH.test(call))).toBe(false);
+	});
+
+	it("refuses an empty verdict body on 3 — an empty verdict reads as UNGATED", async () => {
+		const out = await run(happy(), {stdin: Effect.succeed({_tag: "Text", text: "  \n"})});
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stderr.at(-1)).toBe(
+			"review post: no body on stdin — an empty verdict reads as UNGATED; pipe the verdict body in.",
+		);
+	});
+
+	it("keeps an UNREAD pipe on 1, never on the read-but-empty code", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"}),
+		});
+		expect(out.code).toBe(1);
+		expect(out.code).not.toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a bare @ body on 6 and a machine-local path on 5", async () => {
+		const bare = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "@notes/verdict.md"}),
+		});
+		expect(bare.code).toBe(BARE_AT_PATH);
+
+		const leaked = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "see /Users/someone/scratch/notes.md"}),
+		});
+		expect(leaked.code).toBe(LEAKED_PATH);
+		expect(leaked.stderr.at(-1)).toContain("cite it repo-relative or by class root.");
+	});
+
+	it("scans the ASSEMBLED comment, so a leak in the clause cannot escape the predicate", async () => {
+		const out = await run(happy(), {clause: "see /Users/someone/scratch/notes.md"});
+		expect(out.code).toBe(LEAKED_PATH);
+	});
+
+	it("refuses an absent PR on 7 and a closed one on 7 with its own reason", async () => {
+		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		const closed = await run([[PULL, pull({state: "closed"})]]);
+		expect(closed.code).toBe(ZERO_SCOPE);
+		expect(closed.stderr.at(-1)).toBe(
+			"review post: PR #4321 is closed — a verdict on a closed PR gates nothing.",
+		);
+	});
+
+	it("refuses a failed precondition read on 11, with nothing posted", async () => {
+		const shell = fakeShell([
+			[PULL, pull()],
+			[FILES, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("nothing was posted");
+		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("reports a failed write as 8 — UNKNOWN whether the verdict landed", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, errOut("gh: timeout")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("UNKNOWN whether the verdict landed");
+		expect(out.stderr.at(-1)).toContain("fabrika review verdicts 4321");
+	});
+
+	it("refuses on 9 when the read-back does not yield this marker (#3173)", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[READBACK, commentBody("something else entirely")],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("inspect comment 5154902211");
+	});
+
+	it("reads back from LIVE state — a garbled SHA on the PR reds even though the write returned ok", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[READBACK, commentBody(`review-doc: PASS @ ${OLD_HEAD} — guide matches shipped behavior`)],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain(`sha ${OLD_HEAD}`);
+	});
+
+	it("composes the advisory carrier with a SHA-less first line and a Reviewed-head body line", async () => {
+		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD}\n\n${BODY}`;
+		const shell = fakeShell([
+			[PULL, pull()],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[READBACK, commentBody(advisory)],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runPost({...options, carrier: "advisory", clause: "blocking-set PR (manual merge)"}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
+		expect(write).toContain("review-doc: advisory");
+		expect(write).toContain(`Reviewed-head: @ ${HEAD}`);
+		expect(write).not.toContain(`advisory — ... @ ${HEAD}`);
+	});
+
+	it("emits the record with --json", async () => {
+		const out = await run(happy(), {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "posted",
+			namespace: "review-doc",
+			polarity: "PASS",
+			sha: HEAD,
+			upsert: "created",
+			carrier: "marker",
+		});
+	});
+
+	it("refuses a blank clause and a non-SHA --sha on 10, before any read", async () => {
+		const shell = fakeShell(happy());
+		const blank = await Effect.runPromise(
+			Effect.provide(runPost({...options, clause: "  "}), shell.layer),
+		);
+		expect(blank.code).toBe(OFF_VOCABULARY);
+		expect((await run(happy(), {sha: "nothex"})).code).toBe(OFF_VOCABULARY);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("uses `once` to prove the read-back is a SECOND fetch, not the write's echo", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[once(READBACK), commentBody(`${MARKER}\n\n${BODY}`)],
+			[READBACK, errOut("never reached")],
+		]);
+		expect(out.code).toBe(0);
+	});
+});

--- a/packages/fabrika-cli/src/review/rollup.ts
+++ b/packages/fabrika-cli/src/review/rollup.ts
@@ -1,0 +1,35 @@
+/**
+ * The check-run rollup — total over the status vocabulary, fail-closed on the ambiguous rows.
+ *
+ * `cancelled` is bucketed **red** on purpose: a cancelled check proved nothing, and "proved nothing"
+ * must not read green. An unrecognised conclusion string is red for the same reason — a conclusion
+ * this module has never seen is the one case where a permissive default is guaranteed wrong (#4552).
+ */
+import type {CheckRun} from "../io/pulls.ts";
+
+export type Rollup = "green" | "red" | "pending";
+
+/** The two conclusions GitHub defines as non-blocking, plus the passing one. Every other is red. */
+const PASSING = new Set(["success", "neutral", "skipped"]);
+
+/**
+ * The status token one run prints: its conclusion once completed, else its in-flight status.
+ *
+ * A completed run carrying no conclusion prints `unknown` rather than a vocabulary word — it is red
+ * in the rollup, and naming it with a token a caller could read as passing would hide that.
+ */
+export const statusOf = (run: CheckRun): string =>
+	run.status === "completed" ? (run.conclusion ?? "unknown") : run.status;
+
+/**
+ * `red` on any completed run outside {@link PASSING}; `pending` when none red and any run is still in
+ * flight; `green` only when every run completed and each concluded passing.
+ */
+export const rollupOf = (runs: ReadonlyArray<CheckRun>): Rollup => {
+	let inFlight = false;
+	for (const run of runs) {
+		if (run.status !== "completed") inFlight = true;
+		else if (!PASSING.has(run.conclusion ?? "")) return "red";
+	}
+	return inFlight ? "pending" : "green";
+};

--- a/packages/fabrika-cli/src/review/rollup.unit.test.ts
+++ b/packages/fabrika-cli/src/review/rollup.unit.test.ts
@@ -1,0 +1,57 @@
+import {describe, expect, it} from "vitest";
+import type {CheckRun} from "../io/pulls.ts";
+import {rollupOf, statusOf} from "./rollup.ts";
+
+const done = (name: string, conclusion: string): CheckRun => ({
+	name,
+	status: "completed",
+	conclusion,
+});
+const running = (name: string, status = "in_progress"): CheckRun => ({
+	name,
+	status,
+	conclusion: null,
+});
+
+describe("rollupOf", () => {
+	it("is green only when every run completed and each concluded non-blocking", () => {
+		expect(rollupOf([done("a", "success"), done("b", "neutral"), done("c", "skipped")])).toBe(
+			"green",
+		);
+	});
+
+	it("reds on failure, timed_out and action_required", () => {
+		for (const conclusion of ["failure", "timed_out", "action_required"]) {
+			expect(rollupOf([done("a", "success"), done("b", conclusion)])).toBe("red");
+		}
+	});
+
+	it("reds on cancelled — a cancelled check proved nothing, and that must not read green", () => {
+		expect(rollupOf([done("a", "cancelled")])).toBe("red");
+	});
+
+	it("reds on a conclusion the vocabulary has never seen, never drops it silently", () => {
+		expect(rollupOf([done("a", "success"), done("b", "some_future_conclusion")])).toBe("red");
+		expect(rollupOf([{name: "a", status: "completed", conclusion: null}])).toBe("red");
+	});
+
+	it("is pending when nothing is red and something is still in flight", () => {
+		expect(rollupOf([done("a", "success"), running("b")])).toBe("pending");
+		expect(rollupOf([running("b", "queued")])).toBe("pending");
+	});
+
+	it("lets red win over pending — a red beside a running check is not pending", () => {
+		expect(rollupOf([done("a", "failure"), running("b")])).toBe("red");
+	});
+});
+
+describe("statusOf", () => {
+	it("prints the conclusion once completed and the status while in flight", () => {
+		expect(statusOf(done("a", "success"))).toBe("success");
+		expect(statusOf(running("b", "queued"))).toBe("queued");
+	});
+
+	it("prints `unknown` for a completed run with no conclusion, never a passing token", () => {
+		expect(statusOf({name: "a", status: "completed", conclusion: null})).toBe("unknown");
+	});
+});

--- a/packages/fabrika-cli/src/review/scope-verb.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.ts
@@ -1,0 +1,91 @@
+/**
+ * `review scope` — the head SHA, the linked issue, the artifact-class partition of the PR's changed
+ * files, and the `self` / `harness` flags.
+ *
+ * The refusals are the point: the partition is total over **what was read**, so the verb exists to
+ * make sure it is never run over less than everything. A zero-file PR reds (v1's `class-probe` read
+ * 0 files and classified `has-code` exit 0 — #4060), and a file list short of the declared count reds
+ * rather than partitioning a truncated read (#3999).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {listPullFiles} from "../io/pulls.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {linkedIssueOf, namespacesOf, partition} from "./classes.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "review scope";
+
+/** The null token this group prints for a field with no value. One token, every verb. */
+export const NULL_TOKEN = "-";
+
+export interface ScopeOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runScope = (
+	options: ScopeOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {requireOpen: true, requireFiles: true});
+		if (target._tag === "Refused") return target.outcome;
+		const pull = target.pull;
+
+		const listed = yield* listPullFiles(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read PR #${pr} in ${repo}: ${listed.reason} — the scope is UNKNOWN.`,
+			);
+		}
+		const files = listed.value;
+		const diagnostics = [
+			scannedLine(VERB, files.length, "changed file", `${pull.changedFiles} declared`),
+		];
+		if (files.length < pull.changedFiles) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: file list shows ${files.length} of ${pull.changedFiles} declared files — refusing to partition a truncated read (#3999).`,
+				diagnostics,
+			);
+		}
+
+		const result = partition(files);
+		const issue = linkedIssueOf(pull.body);
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome: "scoped",
+					head: pull.headSha,
+					issue,
+					classes: result.classes,
+					self: result.self,
+					harness: result.harness,
+					scanned: result.scanned,
+					namespaces: namespacesOf(result),
+				}),
+				diagnostics,
+			);
+		}
+		return answer(
+			[
+				`scoped\t${pull.headSha}\t${issue ?? NULL_TOKEN}`,
+				...result.classes.map((entry) => `class\t${entry.name}\t${entry.files}`),
+				`self\t${result.self}`,
+				`harness\t${result.harness}`,
+			].join("\n"),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
@@ -1,0 +1,126 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {files, HEAD, pull} from "./fixtures.test-support.ts";
+import {runScope} from "./scope-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+
+const options = {
+	pr: 4321,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runScope({...options, ...overrides}), fakeShell(script).layer));
+
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull()],
+	[FILES, files("src/cart.ts", "README.md")],
+];
+
+describe("runScope", () => {
+	it("prints the head, the linked issue, the present classes and the two flags", async () => {
+		const out = await run(happy());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				`scoped\t${HEAD}\t4287`,
+				"class\tcode\t1",
+				"class\tdoc\t1",
+				"self\tfalse",
+				"harness\tfalse",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("emits the record with --json, including the derived namespace set", async () => {
+		const out = await run(happy(), {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "scoped",
+			head: HEAD,
+			issue: 4287,
+			scanned: 2,
+			namespaces: ["review-code", "review-doc"],
+		});
+	});
+
+	it("prints `-` for a PR with no closing keyword, never a fabricated issue", async () => {
+		const out = await run([
+			[PULL, pull({body: "relates to #4287"})],
+			[FILES, files("a.ts", "b.ts")],
+		]);
+		expect(out.stdout.split("\n")[0]).toBe(`scoped\t${HEAD}\t-`);
+	});
+
+	it("reports what it scanned against what was declared", async () => {
+		const out = await run(happy());
+		expect(out.stderr[0]).toBe("review scope: scanned 2 changed files; 2 declared.");
+	});
+
+	it("refuses a PR proven absent on 7", async () => {
+		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe("review scope: PR #4321 not found in o/r.");
+	});
+
+	it("refuses a closed PR on 7 — nothing to review", async () => {
+		const out = await run([[PULL, pull({state: "closed"})]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("review scope: PR #4321 is closed — nothing to review.");
+	});
+
+	it("refuses a zero-file PR on 7 rather than classifying an empty review (#4060)", async () => {
+		const out = await run([[PULL, pull({changedFiles: 0})]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("has zero changed files");
+	});
+
+	it("separates an UNREADABLE PR from an absent one — 11, never 7", async () => {
+		const out = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.code).not.toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("the scope is UNKNOWN");
+	});
+
+	it("refuses an unreadable file list on 11 — the partition would be over unknown scope", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a provably short file list on 13, distinct from 11 and 7", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 9})],
+			[FILES, files("a.ts", "b.md")],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.code).not.toBe(PRECONDITION_UNKNOWN);
+		expect(out.code).not.toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review scope: file list shows 2 of 9 declared files — refusing to partition a truncated read (#3999).",
+		);
+	});
+
+	it("refuses a non-PR number, and an unresolvable repo, on 1", async () => {
+		expect((await run(happy(), {pr: 0})).code).toBe(1);
+		const out = await Effect.runPromise(
+			Effect.provide(runScope({...options, env: {}}), fakeShell([]).layer),
+		);
+		expect(out.code).toBe(1);
+	});
+});

--- a/packages/fabrika-cli/src/review/target.ts
+++ b/packages/fabrika-cli/src/review/target.ts
@@ -54,6 +54,14 @@ export interface TargetOptions {
 	readonly requireFiles: boolean;
 	/** The tail of the zero-changed-files refusal, which each verb phrases in its own terms. */
 	readonly emptyReason?: string;
+	/**
+	 * The whole `11` message, when this verb names something other than "the scope" as UNKNOWN.
+	 *
+	 * The wording is the verb's because the refusal has to say what is unknown *to it* — for
+	 * `review deviations` that is the disclosure state, and "the scope is UNKNOWN" would leave the
+	 * caller free to read `none`.
+	 */
+	readonly unknownMessage?: (reason: string) => string;
 }
 
 export type Target =
@@ -79,7 +87,8 @@ export const openPull = (
 				_tag: "Refused" as const,
 				outcome: refuse(
 					PRECONDITION_UNKNOWN,
-					`${verb}: cannot read PR #${pr} in ${repo}: ${found.reason} — the scope is UNKNOWN.`,
+					options.unknownMessage?.(found.reason) ??
+						`${verb}: cannot read PR #${pr} in ${repo}: ${found.reason} — the scope is UNKNOWN.`,
 				),
 			};
 		}

--- a/packages/fabrika-cli/src/review/target.ts
+++ b/packages/fabrika-cli/src/review/target.ts
@@ -1,0 +1,111 @@
+/**
+ * The precondition every `review` verb runs before it judges anything: resolve the repo, resolve the
+ * PR, and split *proven absent* from *unreadable*.
+ *
+ * It lives here rather than in each verb because the split is the group's whole fail-closed posture
+ * and six copies of it are six chances to fold the two outcomes together — a 404 is a fact about the
+ * repository, an unreachable GitHub is not a fact about anything.
+ *
+ * The scanned-count line is here for the same reason: this group's convention is that every list
+ * read reports what it saw on stderr, and a verdict driven by a silently truncated read is a verdict
+ * over unknown scope (#3999).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {resolveRepo} from "../io/issues.ts";
+import {getPullRequest, type PullRecord} from "../io/pulls.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+
+/** `<verb>: scanned <n> <noun>(s) [in <repo>][; <note>].` — the count first, on every run. */
+export const scannedLine = (verb: string, scanned: number, noun: string, note?: string): string =>
+	`${verb}: scanned ${scanned} ${noun}${scanned === 1 ? "" : "s"}${
+		note === undefined ? "" : `; ${note}`
+	}.`;
+
+export type Resolved =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Repo"; readonly repo: string};
+
+export const resolveTargetRepo = (
+	verb: string,
+	explicit: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Resolved, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const attempt = yield* resolveRepo(explicit, env);
+		return attempt._tag === "Failure"
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						FAILED,
+						`${verb}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+					),
+				}
+			: {_tag: "Repo" as const, repo: attempt.value};
+	});
+
+export interface TargetOptions {
+	/** Refuse a closed PR on `7` — true for the verbs whose answer would gate nothing. */
+	readonly requireOpen: boolean;
+	/** The tail of the closed-PR refusal, which each verb phrases in its own terms. */
+	readonly closedReason?: string;
+	/** Refuse a PR with zero changed files on `7` — a review over nothing (ADR 0092, #4060). */
+	readonly requireFiles: boolean;
+	/** The tail of the zero-changed-files refusal, which each verb phrases in its own terms. */
+	readonly emptyReason?: string;
+}
+
+export type Target =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Pull"; readonly pull: PullRecord};
+
+export const openPull = (
+	verb: string,
+	repo: string,
+	pr: number,
+	options: TargetOptions,
+): Effect.Effect<Target, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const found = yield* getPullRequest(repo, pr);
+		if (found._tag === "Absent") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(ZERO_SCOPE, `${verb}: PR #${pr} not found in ${repo}.`),
+			};
+		}
+		if (found._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read PR #${pr} in ${repo}: ${found.reason} — the scope is UNKNOWN.`,
+				),
+			};
+		}
+		if (options.requireOpen && found.value.state !== "open") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					ZERO_SCOPE,
+					`${verb}: PR #${pr} is closed — ${options.closedReason ?? "nothing to review."}`,
+				),
+			};
+		}
+		if (options.requireFiles && found.value.changedFiles === 0) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					ZERO_SCOPE,
+					`${verb}: PR #${pr} has zero changed files — ${
+						options.emptyReason ?? "refusing to derive an empty review (ADR 0092, #4060)."
+					}`,
+				),
+			};
+		}
+		return {_tag: "Pull" as const, pull: found.value};
+	});
+
+/** A positive integer, or the usage refusal — every verb's first check. */
+export const badNumber = (verb: string, noun: string, value: number): VerbOutcome | null =>
+	Number.isInteger(value) && value > 0 ? null : refuse(FAILED, `${verb}: ${value} is not ${noun}.`);

--- a/packages/fabrika-cli/src/review/verdicts-verb.ts
+++ b/packages/fabrika-cli/src/review/verdicts-verb.ts
@@ -1,0 +1,200 @@
+/**
+ * `review verdicts` — every verdict marker on the PR, per namespace, each with its
+ * `Current` / `Stale` / `Unbindable` binding against the live head.
+ *
+ * This is `bindToHead`'s first consumer surface. That module's `Binding` type has three arms and no
+ * non-test caller today; the three reach stdout here as **three tokens**, because folding any two of
+ * them together is how a stale PASS reads as a current one (ADR 0058, #3769 / #4338).
+ *
+ * A head this verb cannot resolve prints `unbindable` on **every** row — never `current`, never
+ * `stale`. A comparison that could not be made is not a negative result, so the live-head read's
+ * failure is that answer rather than an exit: the markers themselves were seen and are reportable
+ * facts.
+ *
+ * A marker that reaches for the format and fails it prints as a `malformed` row with the wire reason
+ * on stderr. It is never dropped from the sweep — a dropped row is how a FAIL'd PR reads as
+ * unreviewed (#4103 / #4105, #4520).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type CommentRecord, listComments} from "../io/issues.ts";
+import {getPullRequest} from "../io/pulls.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	bindToHead,
+	type HeadSha,
+	read as readMarker,
+	clause as toClause,
+	type VerdictMarker,
+} from "../wire/verdict-marker.ts";
+import {readAdvisory} from "./advisory.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {NULL_TOKEN} from "./scope-verb.ts";
+import {badNumber, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "review verdicts";
+
+export interface VerdictsOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+interface MarkerRow {
+	readonly namespace: string;
+	readonly polarity: string;
+	readonly sha: string;
+	readonly binding: "current" | "stale" | "unbindable";
+	readonly commentId: number;
+}
+
+interface MalformedRow {
+	readonly commentId: number;
+	readonly reason: string;
+}
+
+/**
+ * The binding token for one marker against a head this run may not have been able to resolve.
+ *
+ * The three arms map to three tokens and nothing folds: an unresolved head is `unbindable` before
+ * `bindToHead` is even asked, because the comparison could not be made.
+ */
+const bindingOf = (marker: VerdictMarker, head: string | null): MarkerRow["binding"] => {
+	if (head === null) return "unbindable";
+	const binding = bindToHead(marker, head);
+	return binding._tag === "Current" ? "current" : binding._tag === "Stale" ? "stale" : "unbindable";
+};
+
+/** An advisory carrier binds by its body SHA, so it is bound through a marker built from that SHA. */
+const advisoryMarker = (namespace: string, sha: HeadSha): VerdictMarker => ({
+	namespace,
+	polarity: "PASS",
+	sha,
+	clause: toClause("advisory") ?? ("advisory" as VerdictMarker["clause"]),
+});
+
+const sweep = (
+	comments: ReadonlyArray<CommentRecord>,
+	head: string | null,
+): {markers: MarkerRow[]; malformed: MalformedRow[]} => {
+	const markers: MarkerRow[] = [];
+	const malformed: MalformedRow[] = [];
+	// Newest first: the sweep's own order, so a caller reading top-down sees the latest round first.
+	for (const comment of [...comments].reverse()) {
+		const parsed = readMarker(comment.body);
+		if (parsed._tag === "Found") {
+			markers.push({
+				namespace: parsed.value.namespace,
+				polarity: parsed.value.polarity,
+				sha: parsed.value.sha,
+				binding: bindingOf(parsed.value, head),
+				commentId: comment.id,
+			});
+			continue;
+		}
+		const advisory = readAdvisory(comment.body);
+		if (advisory !== null) {
+			markers.push({
+				namespace: advisory.namespace,
+				polarity: "ADVISORY",
+				sha: advisory.sha,
+				binding: bindingOf(advisoryMarker(advisory.namespace, advisory.sha), head),
+				commentId: comment.id,
+			});
+			continue;
+		}
+		if (parsed._tag === "Malformed") {
+			malformed.push({commentId: comment.id, reason: parsed.reason});
+		}
+	}
+	return {markers, malformed};
+};
+
+export const runVerdicts = (
+	options: VerdictsOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const found = yield* getPullRequest(repo, pr);
+		if (found._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `${VERB}: PR #${pr} not found in ${repo}.`);
+		}
+		const head = found._tag === "Present" ? found.value.headSha : null;
+		const declared = found._tag === "Present" ? found.value.comments : null;
+		const diagnostics: string[] =
+			head === null
+				? [
+						`${VERB}: the live head could not be resolved (${
+							found._tag === "Unknown" ? found.reason : "unreadable"
+						}) — every row prints unbindable, never current and never stale.`,
+					]
+				: [];
+
+		// The PR may be readable as an issue even when the pulls read failed, so the comment sweep is
+		// attempted regardless: its own failure is the `11`, and the head's is the unbindable answer.
+		const listed = yield* listComments(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${pr}'s comments: ${listed.reason} — whether verdicts exist is UNKNOWN, never zero.`,
+				diagnostics,
+			);
+		}
+		const comments = listed.value;
+		diagnostics.push(
+			scannedLine(
+				VERB,
+				comments.length,
+				"comment",
+				declared === null ? "no declared count" : `${declared} declared`,
+			),
+		);
+		if (declared !== null && comments.length < declared) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: received ${comments.length} of ${declared} comments — refusing the partial sweep.`,
+				diagnostics,
+			);
+		}
+
+		const {markers, malformed} = sweep(comments, head);
+		for (const row of malformed) {
+			diagnostics.push(
+				`${VERB}: comment ${row.commentId} reaches for a marker and fails the format: ${row.reason}.`,
+			);
+		}
+
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome: "verdicts",
+					head,
+					markers,
+					malformed,
+					scanned: comments.length,
+				}),
+				diagnostics,
+			);
+		}
+		return answer(
+			[
+				`verdicts\t${head ?? NULL_TOKEN}\t${markers.length + malformed.length}`,
+				...markers.map(
+					(row) =>
+						`${row.namespace}\t${row.polarity}\t${row.sha}\t${row.binding}\t${row.commentId}`,
+				),
+				...malformed.map(
+					(row) => `malformed\t${NULL_TOKEN}\t${NULL_TOKEN}\t${NULL_TOKEN}\t${row.commentId}`,
+				),
+			].join("\n"),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/review/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/verdicts-verb.unit.test.ts
@@ -1,0 +1,138 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {comments, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+import {runVerdicts} from "./verdicts-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+
+const CURRENT = `review-doc: PASS @ ${HEAD} — guide matches shipped behavior`;
+const STALE = `review-code: PASS @ ${OLD_HEAD} — merge-ready`;
+const ADVISORY = `review-skill: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD}\n`;
+
+const options = {
+	pr: 4321,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runVerdicts({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+describe("runVerdicts", () => {
+	it("prints the three bindings as THREE distinct tokens, newest first", async () => {
+		const out = await run([
+			[PULL, pull({comments: 2})],
+			[COMMENTS, comments({id: 5154891644, body: STALE}, {id: 5154902211, body: CURRENT})],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				`verdicts\t${HEAD}\t2`,
+				`review-doc\tPASS\t${HEAD}\tcurrent\t5154902211`,
+				`review-code\tPASS\t${OLD_HEAD}\tstale\t5154891644`,
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("never lets a stale PASS print as a current one", async () => {
+		const out = await run([
+			[PULL, pull({comments: 1})],
+			[COMMENTS, comments({id: 1, body: STALE})],
+		]);
+		expect(out.stdout).toContain("\tstale\t");
+		expect(out.stdout).not.toContain("\tcurrent\t");
+	});
+
+	it("prints unbindable on EVERY row when the live head could not be resolved", async () => {
+		const out = await run([
+			[PULL, errOut("gh: Bad gateway (HTTP 502)")],
+			[COMMENTS, comments({id: 1, body: CURRENT}, {id: 2, body: STALE})],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("verdicts\t-\t2");
+		expect(out.stdout).not.toContain("\tcurrent\t");
+		expect(out.stdout).not.toContain("\tstale\t");
+		expect(out.stdout.match(/\tunbindable\t/g)).toHaveLength(2);
+		expect(out.stderr[0]).toContain("every row prints unbindable");
+	});
+
+	it("counts 0 as a proven answer — the PR carries no verdict", async () => {
+		const out = await run([
+			[PULL, pull({comments: 1})],
+			[COMMENTS, comments({id: 1, body: "just a normal comment"})],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`verdicts\t${HEAD}\t0\n`);
+	});
+
+	it("surfaces a drifted marker as a malformed ROW, never drops it from the sweep", async () => {
+		const out = await run([
+			[PULL, pull({comments: 1})],
+			[COMMENTS, comments({id: 77, body: "review-code: PASS — merge-ready"})],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("malformed\t-\t-\t-\t77");
+		expect(out.stderr.at(-1)).toContain("comment 77 reaches for a marker and fails the format");
+	});
+
+	it("reads an advisory carrier as ADVISORY, bound by its Reviewed-head line", async () => {
+		const out = await run([
+			[PULL, pull({comments: 1})],
+			[COMMENTS, comments({id: 9, body: ADVISORY})],
+		]);
+		expect(out.stdout).toBe(`verdicts\t${HEAD}\t1\nreview-skill\tADVISORY\t${HEAD}\tcurrent\t9\n`);
+	});
+
+	it("refuses a PR proven absent on 7", async () => {
+		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("review verdicts: PR #4321 not found in o/r.");
+	});
+
+	it("refuses an unreadable comment list on 11 — never zero", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("whether verdicts exist is UNKNOWN, never zero");
+	});
+
+	it("refuses a provably short sweep on 13 rather than narrowing", async () => {
+		const out = await run([
+			[PULL, pull({comments: 12})],
+			[COMMENTS, comments({id: 1, body: CURRENT})],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review verdicts: received 1 of 12 comments — refusing the partial sweep.",
+		);
+	});
+
+	it("emits the record with --json, keeping malformed rows in their own array", async () => {
+		const out = await run(
+			[
+				[PULL, pull({comments: 2})],
+				[COMMENTS, comments({id: 1, body: CURRENT}, {id: 2, body: "review-code: nope"})],
+			],
+			{json: true},
+		);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.markers).toHaveLength(1);
+		expect(parsed.malformed).toHaveLength(1);
+		expect(parsed.head).toBe(HEAD);
+	});
+});


### PR DESCRIPTION
The `/review` skill merged as a document: it names eight `fabrika review …` commands and none of them existed, so every step of the skill was simulation. This PR builds all eight against the contract that shipped beside the skill, and registers the group so it appears in `fabrika --help`. The verbs read what a text review needs off one pull request — its scope, its diff, its acceptance criteria, its CI, its verdicts, its disclosed deviations — and write a verdict or a reviewer-authored criterion back through the one sanctioned path.

The bar the whole group is built to: **a check that cannot see what it is looking for must not return a plausible value.** An unreadable response, a provably short read, and a non-conforming payload each resolve to their own loud refusal and never to a clean pass.

Fixes #4965

## What landed

`packages/fabrika-cli/src/review/` — eight verbs, one shared exit table, five pure cores, and `reviewCommand` registered in `src/registry.ts` beside the five existing groups. `packages/fabrika-cli/src/io/pulls.ts` adds the pull-request reads (metadata, changed files, diff, check runs, viewer identity, collaborator permission, comment edit), following `io/issues.ts`'s disciplines unchanged: `gh api` REST only, every list read paged, absent split from unreadable.

| Verb | Answers |
|---|---|
| `review scope` | head SHA, linked issue, the code / doc / skill partition, `self` / `harness` |
| `review diff` | the diff bytes, truncation refused |
| `review criteria` | the AC block, through the registered wire format |
| `review ci` | the check-run rollup at a head, fail-closed on the ambiguous rows |
| `review verdicts` | every marker with its `current` / `stale` / `unbindable` binding |
| `review deviations` | the `## Deviations` state, its entries, the Tier-M scan |
| `review post` | the single sanctioned verdict emit |
| `review append-criterion` | one criterion under ADR 0079's four fences |

## The things that were easy to get subtly wrong

- **Exit-code parity is an import, not a numeral.** `src/review/codes.ts` re-exports `3`, `5`, `6`, `7`, `8`, `9`, `10` and `11` from the shipped `report/codes.ts` and `triage/codes.ts` rather than restating them, so they cannot drift. `12`–`15` are this group's own. `codes.unit.test.ts` pins the parity claim and asserts no two meanings share a code.
- **`Current` / `Stale` / `Unbindable` stay three outcomes.** `review verdicts` is `bindToHead`'s first consumer surface; the three arms map to three stdout tokens, and an unresolvable head prints `unbindable` on every row before `bindToHead` is even asked.
- **One comment per namespace.** `review post` upserts by (this bot, this namespace) and puts the marker on the comment's literal first line; a test asserts exactly one `review-doc:` line in the written body and that a foreign author's comment is never edited.
- **The four append-criterion fences run in order** — ACL fail-closed (a *failed lookup* denies, same as a low permission), append-only, provenance tag, round-3 freeze that escalates and appends nothing.
- **Pagination plus refuse-on-short-read.** Changed files, check runs and comments are each read paged and compared against what the platform declared; short reds on `13`, which is neither `11` (nothing failed) nor `7` (scope exists, it just was not all seen).
- **Import, don't re-derive.** The AC parser, the verdict-marker parser, `normalizeForReadback` and the leak predicate are imported from the shipped modules. There is no second implementation of any of the four.

## Every guard is demonstrated failing

`src/review/mutation.unit.test.ts` plants a counterexample per guard, breaks **exactly that guard** by substituting one export of one module, and asserts the verb returns a specific wrong answer. Each mutant is asserted to die for its **intended** reason — the exact wrong token or code, never a loose "it differed":

| Guard mutated | Counterexample | The mutant's asserted wrong answer |
|---|---|---|
| `rollupOf` drops `cancelled` from red | a PR whose only check was cancelled | `ci <sha> green` at exit 0 (real: `red`) |
| `bindToHead` folds `Stale` into `Current` | a PASS bound to an old head | row prints `current`, no `stale` row at all |
| `filesInDiff` always reports the declared count | 2 files served, 7 declared | exit 0 serving the partial diff (real: `13`) |
| `scanBody` finds no leaks | a verdict body citing a machine-local path | exit 0, and the path reaches the `gh api` write (real: `5`, nothing posted) |
| `normalizeForReadback` becomes identity | a comment echoed back with trailing whitespace | exit `9` on a clean run — the contract's own warning |
| `insertAfterLastCriterion` appends past the block | an issue with a `## Notes` section below the ACs | exit `15`, no PATCH sent |
| `grewByOne` always passes | a read-back showing the body unchanged | exit 0 (real: `9`) |
| the file-list short-read comparison | 2 files received, 9 declared | exit 0 partitioning 2 of 9 as the whole (real: `13`) |

The harness also carries a liveness case: an unscripted `gh` call still fails loudly, so a mutant cannot be scored "caught" because the harness itself broke. That is the failure mode a sibling lane hit today — its mutants all died of an unrelated path-resolution error while a loose assertion scored them green.

Two defects in my own first draft were found by this harness and fixed rather than papered over:

1. The `normalizeForReadback` mutant **survived**, which meant I had applied the normalizer where it could not matter (the clause, which the marker parser already trims). The read-back now also compares the whole comment against the bytes that were sent, which is what the normalizer's trailing-newline step actually protects.
2. Building the exit-`15` mutant showed the composition anchored on the last checkbox **anywhere in the body**, so a PR body with a later checkbox list would have put the row outside the block every future read parses. It now anchors on the text of the block's last criterion — the registered parser's own answer — and a second guard re-parses the composed body before the PATCH is sent.

`pnpm typecheck` and `pnpm lint:worktree` are clean; the package's 1254 tests pass, 156 of them new.

## Deviations

- **1 — scope narrowing.** **Said:** `review diff`'s `13` trigger is "the platform's truncation markers are present, **or** the file count in the diff is short of the PR's declared count". **Did:** implemented the file-count half only; the marker half is not implemented. **Why:** the exact bytes GitHub emits for a truncated diff are not verifiable from this repo, and CLAUDE.md forbids grounding a falsifiable platform claim in intuition — an unverified marker string is a check that silently stops matching. The file-count proof is derivable from what the platform already declares, and the trigger is a disjunction, so `13` still fires on the truncation case the contract cares about. **Disposition:** stated here and in `src/review/diff.ts`'s header; no action needed, and a grounded marker check can be added later against real API evidence.
- **2 — governing-ADR departure (a gap in the spec, not a departure from it).** **Said:** `review post` step 6 reads the posted comment back "through the format's `read`, requiring `Found`". **Did:** the `--carrier advisory` path is read back through its own two anchors — the advisory first line and the canonical `Reviewed-head: @ <sha>` line — instead. **Why:** an advisory first line deliberately withholds the SHA (ADR 0111 / 0151), so the format reads it as `Malformed` **by design**; applying step 6 literally would make every advisory post exit `9` and the carrier unusable. **Disposition:** for the reviewer to judge — the read-back stays unconditional and live-state, only its shape follows what was actually written.
- **1 — scope narrowing.** **Said:** the advisory first line is "the fixed advisory line". **Did:** composed it as `<namespace>: advisory — <clause>`, carrying the caller's required `--clause` rather than a hardcoded sentence. **Why:** `--clause` is a required input the verb may not discard, and the SHA-less shape ADR 0111 protects is preserved either way. **Disposition:** no action needed.
- **3 — known defect left unfixed.** **Said:** nothing; this is a property of the fence. **Did:** exit `15` is unreachable from any input the verb accepts, because the composition is built to satisfy it. **Why:** that is the fence working, not a gap — but it means no ordinary unit test can drive it. **Disposition:** demonstrated by mutation instead (row 6 of the table above), and `append-criterion-verb.unit.test.ts` says so explicitly rather than asserting it loosely.
