### PR TITLE
feat(pipeline): a held child is born assigned, and the plan gate verifies the barrier it cannot flip away (#4693)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ build
 # Generated
 __generated__
 schema.graphql.generated
+# Mutation-proof staging: a throwaway copy a verify script plants counterexamples in. It has to
+# live under src/ to be collected by vitest's include, and it is removed on a clean run.
+__mutation__
 # fate Vite plugin codegen output (build-time; never committed)
 .fate
 

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -533,6 +533,29 @@ relocation *is* the #754 guard) and prints the created `{number,id}`:
   <EPIC> "<sharp single-unit title>" type:feature p2 "<path/to/child-spec.json>"
 ```
 
+#### A child a human picks up is born held (the optional 6th argument)
+
+Most children are agent work and want no assignee — `write-code` picking them up *is* the plan
+working. A few are not: a **fabrika authoring brief** is authored by a human session through
+`/skill-creator`, and a coder that picks one up implements the skill through a door founder ruling
+[#4637-C](https://github.com/kamp-us/phoenix/issues/4637) closed. For those, pass the login of the
+human it is held for as a 6th argument:
+
+```bash
+# a held child: assigned AND `ready-for:human`, both inside the same atomic create
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/plan-epic/scripts/create-child.sh" \
+  <EPIC> "Authoring brief: <skill>" type:feature p1 "<path/to/child-spec.json>" <login>
+```
+
+**Why the barrier is the assignee and not a label** ([#4693](https://github.com/kamp-us/phoenix/issues/4693)):
+`review-plan` flips **every** `status:planned` child to `status:triaged`, so no label the planner
+withholds survives that gate. The assignee does — it is the one child attribute the flip never
+touches, and it is what `write-code`'s picker selects on (`.assignee == null`). The `ready-for:human`
+label rides along not as a second barrier but to make the first one **checkable**: the plan gate
+reds `HELD_CHILD_UNASSIGNED` on a `ready-for:human` child with an empty assignee slot, so a held
+child that lost its assignee blocks the flip for the whole epic instead of quietly joining the pool.
+One argument sets both, so a planner cannot apply half of it.
+
 Capture both `number` and `id` from the create — Step 4 links by the `id`, so you won't need
 to re-fetch it. **Link the child as a native sub-issue (Step 4) immediately after this create** —
 the sooner the epic registers the child, the narrower the window a re-dispatch has to reconcile.

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/create-child.sh
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/scripts/create-child.sh
@@ -4,7 +4,17 @@
 # composer owns the format, why the labels go on AT create, and why the spec lives in the §SP
 # namespace rather than a fixed /tmp path (#754) — stays in ../SKILL.md § Emit idempotently.
 #
-# usage: create-child.sh <EPIC> <title> <type-label> <priority-label> <spec-file>
+# usage: create-child.sh <EPIC> <title> <type-label> <priority-label> <spec-file> [held-for-login]
+#
+# The optional 6th argument is the login of the human a child is HELD FOR — a fabrika authoring
+# brief being the case that forced it (#4693 / #4637-C). It lands two things in the same atomic
+# create: the `assignees[]` entry and the `ready-for:human` label. They go together on purpose.
+# The assignee is the barrier `write-code`'s picker honours (`step1-candidate-pool.sh` selects
+# `.assignee == null`) and the only child attribute `review-plan`'s flip does not touch; the label
+# is what makes that barrier CHECKABLE, and the plan gate reds on a `ready-for:human` child whose
+# assignee slot is empty (`HELD_CHILD_UNASSIGNED`). Applying them from one argument in one write
+# is what makes the half-applied state unreachable — there is no ordering in which the child is
+# briefly labelled-but-unassigned, and no run in which a planner sets one and forgets the other.
 #
 # The spec arrives as a FILE, not an argument: it is multi-line JSON carrying the child's
 # `whatToBuild` prose and acceptance criteria, which an argv string mangles. This script relocates
@@ -18,8 +28,8 @@ set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
-[ "$#" -ge 5 ] || { echo "usage: create-child.sh <EPIC> <title> <type-label> <priority-label> <spec-file>" >&2; exit 2; }
-EPIC="$1"; TITLE="$2"; TYPE_LABEL="$3"; PRIORITY_LABEL="$4"; SPEC_IN="$5"
+[ "$#" -ge 5 ] || { echo "usage: create-child.sh <EPIC> <title> <type-label> <priority-label> <spec-file> [held-for-login]" >&2; exit 2; }
+EPIC="$1"; TITLE="$2"; TYPE_LABEL="$3"; PRIORITY_LABEL="$4"; SPEC_IN="$5"; HELD_FOR="${6:-}"
 [ -s "$SPEC_IN" ] || { echo "create-child: spec file '$SPEC_IN' is missing/empty — refusing to file a specless child." >&2; exit 2; }
 REPO="$(kp_repo)" || exit 1
 PCLI="$(kp_pcli)" || exit 127
@@ -32,10 +42,16 @@ cat "$SPEC_IN" > "$CHILD_SPEC_FILE" || exit 1
 # hand-re-derived `### What to build` / `### Acceptance criteria`, no `-f body=@file` leak.
 BODY="$("$PCLI" intake-compose sub-issue --spec "$CHILD_SPEC_FILE")" || exit 1
 # ATOMIC create — body AND its type/priority/status:planned labels in ONE REST write. `POST /issues`
-# accepts `labels` inline, so an interrupted run can never leave a label-less child: the create
-# either lands the issue WITH its labels or creates nothing.
-gh api "repos/$REPO/issues" \
-  -f title="$TITLE" \
-  -f body="$BODY" \
-  -f "labels[]=$TYPE_LABEL" -f "labels[]=$PRIORITY_LABEL" -f "labels[]=status:planned" \
-  --jq '{number,id}'
+# accepts `labels` and `assignees` inline, so an interrupted run can never leave a label-less or
+# (for a held child) momentarily pool-visible issue: the create either lands the issue WITH every
+# birth attribute or creates nothing.
+CREATE_ARGS=(api "repos/$REPO/issues"
+  -f "title=$TITLE"
+  -f "body=$BODY"
+  -f "labels[]=$TYPE_LABEL" -f "labels[]=$PRIORITY_LABEL" -f "labels[]=status:planned")
+if [ -n "$HELD_FOR" ]; then
+  CREATE_ARGS=("${CREATE_ARGS[@]}" -f "assignees[]=$HELD_FOR" -f "labels[]=ready-for:human")
+fi
+CREATE_ARGS=("${CREATE_ARGS[@]}" --jq '{number,id}')
+[ "${#CREATE_ARGS[@]}" -gt 0 ] || { echo "create-child: empty gh argument list — refusing to run gh against nothing." >&2; exit 1; }
+gh "${CREATE_ARGS[@]}"

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -256,8 +256,14 @@ yourself — the validator is the single source of truth, and re-judging it in p
 reintroduces exactly the non-determinism this gate removes. The action's verdict *is* the
 gate's verdict.
 
-- **`pass`** → every `status:planned` child is now `status:triaged` (pickable), and a PASS
+- **`pass`** → every `status:planned` child is now `status:triaged`, and a PASS
   verdict comment is on the epic. Go to Step 2 (the soft-advisor) to *annotate* that pass.
+  **Triaged is not the same as pickable.** `write-code`'s picker also requires
+  `.assignee == null`, so a child the planner **held for a human** — a fabrika authoring brief,
+  born assigned and `ready-for:human` — is flipped like any other and still stays out of the
+  pool. That barrier is the assignee precisely because your flip does not touch it; what the
+  floor adds is the *check* that it is really there (`HELD_CHILD_UNASSIGNED`, and
+  `UNVERIFIABLE_ASSIGNEE` when the slot could not be read at all — #4693).
 - **`fail`** → a FAIL verdict listing each defect is on the epic; **no child was flipped**.
   Skip Step 2 (the soft-advisor only annotates a PASS — there's nothing to annotate on a
   FAIL) and go to [the convergence loop](#the-re-plan-convergence-loop).

--- a/packages/pipeline-cli/scripts/verify-pool-barrier-fires.sh
+++ b/packages/pipeline-cli/scripts/verify-pool-barrier-fires.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Mutation proof for the write-code pool barrier (#4693): each mutant must make a NAMED test red.
+#
+# A guard you cannot demonstrate failing is not demonstrated. This plants three counterexamples in a
+# throwaway copy of `src/tools/epic-ledger/`, runs the suite against the copy, and asserts the mutant
+# died for its INTENDED reason — the specific test title has to appear in a FAIL line, not merely
+# "something went red". A harness that scores any redness as a kill passes even when its mutants are
+# dying of a typo.
+#
+# Nothing under `src/tools/epic-ledger/` is ever edited: the mutants live in a copy, so there is no
+# restore step whose failure could leave a sabotaged validator in the working tree.
+#
+# usage: bash packages/pipeline-cli/scripts/verify-pool-barrier-fires.sh
+# shellcheck disable=SC1007,SC2016
+set -uo pipefail
+
+HERE="$(CDPATH= cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+if [ -z "$HERE" ] || [ ! -d "$HERE/src/tools/epic-ledger" ]; then
+	echo "FAIL: could not resolve packages/pipeline-cli from this script's own location — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+SRC="$HERE/src/tools/epic-ledger"
+RUN="$HERE/src/__mutation__"
+# vitest's include is `src/**/*.test.ts`, so the copy has to live under src/ to be collected at all.
+REL="src/__mutation__/epic-ledger"
+
+# One row per mutant, TAB-separated: <label> <file> <find> <replace> <test title that MUST go red>.
+# The find/replace are LITERAL — the planter is a string splice, not a regex, so an anchor reads
+# exactly as it does in the source.
+MUTANTS=(
+	"$(printf 'M1 an unread assignee slot laundered into an empty one\tgithub.ts\tassignees?.map((a) => a.login)\t(assignees ?? []).map((a) => a.login)\tan absent or null `assignees` key decodes to UNOBSERVED, never to unassigned')"
+	"$(printf 'M2 the held-child barrier check disabled\tvalidate.ts\t} else if (child.labels.includes(HELD_FOR_HUMAN_LABEL) && child.assignees.length === 0) {\t} else if (false) {\tmutant 1 — drop the assignee: HELD_CHILD_UNASSIGNED, and nothing else')"
+	"$(printf 'M3 the unverifiable-slot check disabled\tvalidate.ts\tif (child.assignees === undefined) {\tif (child.assignees === undefined && Array.isArray(child.assignees)) {\tmutant 3 — unobserve the slot on an agent-audience child: still UNVERIFIABLE, never a skip')"
+)
+
+if [ "${#MUTANTS[@]}" -eq 0 ]; then
+	echo "FAIL: zero mutants — a proof that plants nothing proves nothing (ADR 0092)"
+	exit 1
+fi
+
+# Literal splice, in node so no shell metacharacter survives into an anchor. Exit 3 means the anchor
+# is not in the file any more, which is a drifted proof rather than a surviving mutant.
+splice() { # <file> <find> <replace>
+	node -e '
+		const fs = require("node:fs");
+		const [file, find, replace] = process.argv.slice(1);
+		const before = fs.readFileSync(file, "utf8");
+		if (!before.includes(find)) process.exit(3);
+		fs.writeFileSync(file, before.split(find).join(replace));
+	' "$1" "$2" "$3"
+}
+
+stage() {
+	rm -rf "$RUN"
+	mkdir -p "$RUN" || return 1
+	cp -R "$SRC" "$RUN/epic-ledger" || return 1
+}
+
+run_suite() {
+	(cd "$HERE" && npx vitest run "$REL" 2>&1)
+}
+
+FAILURES=0
+CHECKS=0
+
+echo "== baseline: the unmutated copy must be GREEN =="
+CHECKS=$((CHECKS + 1))
+if ! stage; then
+	echo "FAIL: could not stage the baseline copy"
+	exit 1
+fi
+BASE_OUT="$(run_suite)"
+BASE_STATUS=$?
+if [ "$BASE_STATUS" -ne 0 ]; then
+	echo "FAIL: the unmutated copy is already red, so no mutant death below is attributable"
+	echo "$BASE_OUT" | tail -20
+	FAILURES=$((FAILURES + 1))
+else
+	echo "ok — baseline green, so every death below is attributable to its mutant"
+fi
+
+for row in "${MUTANTS[@]-}"; do
+	CHECKS=$((CHECKS + 1))
+	label="$(printf '%s' "$row" | cut -f1)"
+	file="$(printf '%s' "$row" | cut -f2)"
+	find="$(printf '%s' "$row" | cut -f3)"
+	replace="$(printf '%s' "$row" | cut -f4)"
+	expect="$(printf '%s' "$row" | cut -f5)"
+	echo
+	echo "== $label =="
+
+	if ! stage; then
+		echo "FAIL: could not stage a copy for $label"
+		FAILURES=$((FAILURES + 1))
+		continue
+	fi
+	splice "$RUN/epic-ledger/$file" "$find" "$replace"
+	SPLICE_STATUS=$?
+	case "$SPLICE_STATUS" in
+		0) ;;
+		3)
+			echo "FAIL: the anchor for $label is no longer in $file — the proof has drifted, so a green run would be meaningless"
+			FAILURES=$((FAILURES + 1))
+			continue
+			;;
+		*)
+			echo "FAIL: could not plant $label"
+			FAILURES=$((FAILURES + 1))
+			continue
+			;;
+	esac
+
+	OUT="$(run_suite)"
+	OUT_STATUS=$?
+	if [ "$OUT_STATUS" -eq 0 ]; then
+		echo "FAIL: $label SURVIVED — the guard did not fire on its own counterexample"
+		FAILURES=$((FAILURES + 1))
+		continue
+	fi
+	if printf '%s\n' "$OUT" | grep -F "FAIL" | grep -qF "$expect"; then
+		echo "ok — died for its intended reason: \"$expect\""
+	else
+		echo "FAIL: $label went red, but NOT on \"$expect\" — a mutant that dies of something else is not evidence"
+		printf '%s\n' "$OUT" | grep -F "FAIL" | head -10
+		FAILURES=$((FAILURES + 1))
+	fi
+done
+
+rm -rf "$RUN"
+
+echo
+if [ "$FAILURES" -ne 0 ]; then
+	echo "POOL-BARRIER MUTATION PROOF: FAIL ($FAILURES of $CHECKS checks)"
+	exit 1
+fi
+echo "POOL-BARRIER MUTATION PROOF: PASS (${#MUTANTS[@]} mutants, each red on its own named test; baseline green)"

--- a/packages/pipeline-cli/src/tools/epic-ledger/Defect.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/Defect.ts
@@ -32,6 +32,16 @@ import * as Schema from "effect/Schema";
  * repo that has a cycle doc (ADR 0091, formats §2). It sits in the child-content
  * cluster next to its marker-shaped sibling `MISSING_LABEL`, after the
  * story-coverage defects.
+ *
+ * The last two are the pool-barrier pair (#4693). `HELD_CHILD_UNASSIGNED` is the
+ * barrier itself: a `ready-for:human` child whose assignee slot is empty enters
+ * `write-code`'s candidate pool the moment the gate flips it. `UNVERIFIABLE_ASSIGNEE`
+ * is the case where the barrier could not be *checked* — the ledger carries no
+ * observation of the child's assignee slot at all — and it is deliberately a defect
+ * rather than a skip: an unread field is UNKNOWN, never "this child is fine"
+ * (ADR 0092 §ZS). They trail the list because they are the newest widening; the
+ * unverifiable one precedes the substantive one, so when both could fire the root
+ * cause reads first.
  */
 export const DEFECT_TYPES = [
 	"ZERO_SCOPE",
@@ -46,6 +56,8 @@ export const DEFECT_TYPES = [
 	"MISSING_LABEL",
 	"MISSING_CONTAINMENT",
 	"NEEDS_TRIAGE_LABEL",
+	"UNVERIFIABLE_ASSIGNEE",
+	"HELD_CHILD_UNASSIGNED",
 ] as const;
 
 export const DefectType = Schema.Literals(DEFECT_TYPES);

--- a/packages/pipeline-cli/src/tools/epic-ledger/Ledger.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/Ledger.ts
@@ -62,6 +62,14 @@ export type Containment = (typeof Containment)["Type"];
  * tolerant-read rule; `validateLedger` flags a `type:feature` child whose marker
  * is `"none"`/`undefined` as `MISSING_CONTAINMENT`, but only when the repo has a
  * cycle doc (ADR 0091).
+ *
+ * `assignees` is the child's assignee slot — the one attribute the gate's label
+ * flip does not touch, and therefore the only barrier that survives it (#4693).
+ * It is a **three-state** field on purpose: a list of logins is an observed,
+ * assigned child; `[]` is an observed, unassigned one; and `undefined` is
+ * **unobserved** — the REST payload carried no `assignees` key, so the ledger has
+ * no fact to check. `undefined` is never read as "unassigned" or as "fine": it is
+ * `UNVERIFIABLE_ASSIGNEE`.
  */
 export const ChildIssue = Schema.Struct({
 	number: Schema.Number,
@@ -70,6 +78,7 @@ export const ChildIssue = Schema.Struct({
 	acceptanceCriteriaCount: Schema.Number,
 	stories: Schema.optional(Schema.Array(Schema.Number)),
 	containment: Schema.optional(Containment),
+	assignees: Schema.optional(Schema.Array(Schema.String)),
 });
 export type ChildIssue = (typeof ChildIssue)["Type"];
 

--- a/packages/pipeline-cli/src/tools/epic-ledger/fixtures.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/fixtures.ts
@@ -14,6 +14,9 @@ export const child = (number: number, overrides: Partial<ChildIssue> = {}): Chil
 	// MISSING_CONTAINMENT under the default `cycleDocPresent: true`; tests that want
 	// a missing/`none` marker set `containment` (or override to `undefined`) explicitly.
 	containment: "exempt",
+	// Observed-and-unassigned by default: the ordinary agent-audience child. A test that
+	// wants the unobserved slot (`UNVERIFIABLE_ASSIGNEE`) overrides to `undefined`.
+	assignees: [],
 	...overrides,
 });
 

--- a/packages/pipeline-cli/src/tools/epic-ledger/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/gate.unit.test.ts
@@ -155,4 +155,71 @@ describe("runGate — the deterministic review-plan gate action (#164)", () => {
 			assert.match(r.comments[0]?.body ?? "", /Scanned scope: 0 child\(ren\) — —/);
 		}),
 	);
+
+	// The pool barrier (#4693). The flip stays unconditional — the gate still flips EVERY
+	// planned child on a clean ledger — so what carries the information is the ledger being
+	// clean in the first place. A child held for a human with an empty assignee slot is a
+	// hard defect, so the whole flip does not happen, and the sibling child stays planned
+	// too: the barrier can never be half-applied.
+	it.effect("a `ready-for:human` child with no assignee blocks the flip for the whole epic", () =>
+		Effect.gen(function* () {
+			const held = ledger({
+				epic: epic({
+					number: 500,
+					stories: [1],
+					dependencies: {present: true, nodes: [501, 502], edges: []},
+				}),
+				children: [
+					child(501, {labels: ["type:feature", "p1", "status:planned"], stories: [1]}),
+					child(502, {
+						labels: ["type:feature", "p1", "status:planned", "ready-for:human"],
+						stories: [1],
+						assignees: [],
+					}),
+				],
+			});
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(500).pipe(Effect.provide(fakeGithub(held, rec)));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "fail");
+			if (verdict._tag === "fail") {
+				assert.deepStrictEqual(
+					verdict.defects.map((d) => d.type),
+					["HELD_CHILD_UNASSIGNED"],
+				);
+				assert.deepStrictEqual(verdict.defects[0]?.refs, [502]);
+			}
+			assert.deepStrictEqual(r.flips, []);
+			assert.match(r.comments[0]?.body ?? "", /HELD_CHILD_UNASSIGNED/);
+		}),
+	);
+
+	it.effect("the same epic PASSES and flips both children once the held child is assigned", () =>
+		Effect.gen(function* () {
+			const assigned = ledger({
+				epic: epic({
+					number: 500,
+					stories: [1],
+					dependencies: {present: true, nodes: [501, 502], edges: []},
+				}),
+				children: [
+					child(501, {labels: ["type:feature", "p1", "status:planned"], stories: [1]}),
+					child(502, {
+						labels: ["type:feature", "p1", "status:planned", "ready-for:human"],
+						stories: [1],
+						assignees: ["a-human"],
+					}),
+				],
+			});
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(500).pipe(Effect.provide(fakeGithub(assigned, rec)));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "pass");
+			// the flip is UNCHANGED: still every planned child, held one included — the assignee
+			// it now carries is what keeps it out of the pool, not a skipped flip.
+			assert.deepStrictEqual(r.flips, [501, 502]);
+		}),
+	);
 });

--- a/packages/pipeline-cli/src/tools/epic-ledger/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/github-service.unit.test.ts
@@ -84,12 +84,14 @@ const provide = <A, E>(
 ): Effect.Effect<A, E | RepoResolutionError> =>
 	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
 
-const issue = (number: number, body: string, labels: string[]) =>
+const issue = (number: number, body: string, labels: string[], assignees: string[] = []) =>
 	JSON.stringify({
 		number,
 		title: `#${number}`,
 		labels: labels.map((name) => ({name})),
 		body,
+		// present-and-empty, as REST returns for an unassigned issue (#4693)
+		assignees: assignees.map((login) => ({login})),
 	});
 
 const EPIC_BODY = [

--- a/packages/pipeline-cli/src/tools/epic-ledger/github.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/github.ts
@@ -42,12 +42,27 @@ const GithubLabel = Schema.Struct({
 /** A null/absent issue body normalizes to the empty string before parsing. */
 const GithubBody = Schema.optionalKey(Schema.NullOr(Schema.String));
 
+/** A GitHub assignee as REST returns it (`{login, ...}`); only `login` is read. */
+const GithubAssignee = Schema.Struct({
+	login: Schema.String,
+});
+
+/**
+ * The assignee slot, decoded so an **absent** key stays distinguishable from an
+ * empty one. `repos/{repo}/issues/{n}` always returns `assignees`, so the absent
+ * case means the payload was narrowed (a `--jq` projection, a fixture, a future
+ * refactor) — and the check downstream must say UNKNOWN rather than read the
+ * silence as "unassigned" (#4693).
+ */
+const GithubAssignees = Schema.optionalKey(Schema.NullOr(Schema.Array(GithubAssignee)));
+
 /** The raw GitHub issue fields the ledger needs, lenient on everything else. */
 const GithubIssue = Schema.Struct({
 	number: Schema.Number,
 	title: Schema.String,
 	body: GithubBody,
 	labels: Schema.Array(GithubLabel),
+	assignees: GithubAssignees,
 });
 
 /** The untrusted input: the epic issue plus its linked sub-issues' JSON. */
@@ -64,6 +79,10 @@ const bodyOf = (body: string | null | undefined): string => body ?? "";
 const labelNames = (labels: ReadonlyArray<{readonly name: string}>): ReadonlyArray<string> =>
 	labels.map((l) => l.name);
 
+const assigneeLogins = (
+	assignees: ReadonlyArray<{readonly login: string}> | null | undefined,
+): ReadonlyArray<string> | undefined => assignees?.map((a) => a.login);
+
 const toLedger = (input: GithubEpicInput): EpicLedger => ({
 	epic: {
 		number: input.epic.number,
@@ -79,6 +98,7 @@ const toLedger = (input: GithubEpicInput): EpicLedger => ({
 		acceptanceCriteriaCount: countAcceptanceCriteria(bodyOf(child.body)),
 		stories: parseChildStories(bodyOf(child.body)),
 		containment: parseChildContainment(bodyOf(child.body)),
+		assignees: assigneeLogins(child.assignees),
 	})),
 	// Pure decode cannot probe GitHub, so cross-epic refs and the cycle-doc presence
 	// are left unresolved here; the IO boundary (`loadEpicLedger`) resolves and

--- a/packages/pipeline-cli/src/tools/epic-ledger/github.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/github.unit.test.ts
@@ -19,11 +19,15 @@ const epicJson = {
 	].join("\n"),
 };
 
-const childJson = (number: number, body: string, labels: string[]) => ({
+// `assignees: []` is what REST actually returns for an unassigned issue — the key is
+// always present. A fixture that omitted it would be decoding a payload GitHub does not
+// send, and would quietly exercise the unobserved-slot path instead of the real one.
+const childJson = (number: number, body: string, labels: string[], assignees: string[] = []) => ({
 	number,
 	title: `child #${number}`,
 	labels: labels.map((name) => ({name})),
 	body,
+	assignees: assignees.map((login) => ({login})),
 });
 
 describe("decodeEpicLedger — the GitHub trust boundary", () => {
@@ -69,6 +73,43 @@ describe("decodeEpicLedger — the GitHub trust boundary", () => {
 			assert.deepStrictEqual(ledger.epic.stories, []);
 			assert.strictEqual(ledger.children[0]?.acceptanceCriteriaCount, 0);
 			assert.strictEqual(ledger.children[0]?.stories, undefined);
+		}),
+	);
+
+	// The three states of the assignee slot (#4693). The decode is where "unassigned" and
+	// "never read" stop being the same value, so it is where they get separate tests.
+	it.effect("an assigned child decodes its logins; an unassigned one decodes an empty list", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: epicJson,
+				children: [
+					childJson(101, "**Stories:** 1\n- [ ] ac", ["type:feature"], ["a-human"]),
+					childJson(102, "**Stories:** 2\n- [ ] ac", ["type:feature"]),
+				],
+			});
+			assert.deepStrictEqual(ledger.children[0]?.assignees, ["a-human"]);
+			assert.deepStrictEqual(ledger.children[1]?.assignees, []);
+		}),
+	);
+
+	it.effect("an absent or null `assignees` key decodes to UNOBSERVED, never to unassigned", () =>
+		Effect.gen(function* () {
+			const {assignees: _absent, ...noKey} = childJson(101, "**Stories:** 1\n- [ ] ac", [
+				"type:feature",
+			]);
+			const ledger = yield* decodeEpicLedger({
+				epic: epicJson,
+				children: [noKey, {...childJson(102, "**Stories:** 2\n- [ ] ac", []), assignees: null}],
+			});
+			assert.strictEqual(ledger.children[0]?.assignees, undefined);
+			assert.strictEqual(ledger.children[1]?.assignees, undefined);
+			// and the floor says so out loud rather than passing the narrowed payload
+			assert.deepStrictEqual(
+				validateLedger(ledger)
+					.filter((d) => d.type === "UNVERIFIABLE_ASSIGNEE")
+					.map((d) => d.refs[0]),
+				[101, 102],
+			);
 		}),
 	);
 

--- a/packages/pipeline-cli/src/tools/epic-ledger/validate.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/validate.ts
@@ -29,6 +29,14 @@ const PRIORITY_LABELS = ["p0", "p1", "p2"] as const;
 const NEEDS_TRIAGE_LABEL = "status:needs-triage";
 const FEATURE_LABEL = "type:feature";
 
+/**
+ * The audience label a child carries when a *human* picks it up — a fabrika authoring
+ * brief being the case that forced it (#4693, founder ruling #4780). Its counterpart
+ * `ready-for:agent` needs no check: an agent-audience child is *supposed* to reach the
+ * pool.
+ */
+const HELD_FOR_HUMAN_LABEL = "ready-for:human";
+
 const hasPrefixedLabel = (labels: ReadonlyArray<string>, prefix: string): boolean =>
 	labels.some((l) => l.startsWith(prefix));
 
@@ -175,6 +183,28 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 			defects.push({
 				type: "MISSING_CONTAINMENT",
 				message: `Child #${child.number} is \`type:feature\` but carries no \`**Containment:**\` marker; every feature child must declare \`flag (default-off)\` or \`exempt (<reason>)\` (ADR 0091).`,
+				refs: [child.number],
+			});
+		}
+
+		// The pool barrier (#4693). The flip below this gate is unconditional by design and
+		// stays that way: it makes every `status:planned` child `status:triaged`. So the only
+		// attribute that can keep a child out of `write-code`'s candidate pool is the one the
+		// flip never touches — the assignee (`step1-candidate-pool.sh` selects
+		// `.assignee == null`). Checking it here is what makes a PASS carry information: the
+		// gate exposes a child only after verifying its board state matches its declared
+		// audience. The scope is every child in the ledger, so it is non-empty on the first
+		// run and on every run (zero children already returned `ZERO_SCOPE` above).
+		if (child.assignees === undefined) {
+			defects.push({
+				type: "UNVERIFIABLE_ASSIGNEE",
+				message: `Child #${child.number} carries no observation of its assignee slot, so the pool barrier could not be checked; an unread field is UNKNOWN, never "unassigned is fine" (ADR 0092).`,
+				refs: [child.number],
+			});
+		} else if (child.labels.includes(HELD_FOR_HUMAN_LABEL) && child.assignees.length === 0) {
+			defects.push({
+				type: "HELD_CHILD_UNASSIGNED",
+				message: `Child #${child.number} is \`${HELD_FOR_HUMAN_LABEL}\` but has no assignee; the flip would put it in \`write-code\`'s candidate pool, which selects \`.assignee == null\` (#4693).`,
 				refs: [child.number],
 			});
 		}

--- a/packages/pipeline-cli/src/tools/epic-ledger/validate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/validate.unit.test.ts
@@ -302,6 +302,30 @@ describe("validateLedger — each defect type", () => {
 		// a childless epic produces the zero-scope=fail self-assertion (ADR 0092)
 		for (const t of typesOf(ledger({epic: epic({stories: []}), children: []}))) produced.add(t);
 
+		// the pool-barrier pair (#4693): an unobserved assignee slot, and a `ready-for:human`
+		// child whose slot is observed and empty
+		for (const t of typesOf(
+			ledger({
+				epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+				children: [child(101, {assignees: undefined})],
+			}),
+		)) {
+			produced.add(t);
+		}
+		for (const t of typesOf(
+			ledger({
+				epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+				children: [
+					child(101, {
+						labels: ["type:feature", "p1", "status:planned", "ready-for:human"],
+						assignees: [],
+					}),
+				],
+			}),
+		)) {
+			produced.add(t);
+		}
+
 		for (const t of DEFECT_TYPES) {
 			assert.isTrue(produced.has(t), `expected defect type ${t} to be producible`);
 		}
@@ -491,5 +515,92 @@ describe("validateLedger — zero-scope=fail self-assertion (ADR 0092)", () => {
 		const types = validateLedger(l).map((d) => d.type);
 		assert.notInclude(types, "ZERO_SCOPE");
 		assert.include(types, "ZERO_AC");
+	});
+});
+
+/**
+ * The pool barrier (#4693), tested as single-field mutants off one clean baseline.
+ *
+ * Each case changes exactly one field of `heldBaseline()` and asserts the WHOLE defect
+ * list — not `include` — so a mutant that died for some unrelated reason fails the
+ * assertion instead of scoring as caught. The baseline's own zero-defect assertion is
+ * what makes that reading valid.
+ */
+const HELD_LABELS = ["type:feature", "p1", "status:planned", "ready-for:human"];
+
+const heldLedger = (assignees: ReadonlyArray<string> | undefined): EpicLedger =>
+	ledger({
+		epic: epic({stories: [1], dependencies: graph({nodes: [101], edges: []})}),
+		children: [child(101, {labels: HELD_LABELS, assignees})],
+	});
+
+const heldBaseline = (): EpicLedger => heldLedger(["a-human"]);
+
+describe("validateLedger — the write-code pool barrier (#4693)", () => {
+	it("baseline: a `ready-for:human` child that IS assigned is clean", () => {
+		assert.deepStrictEqual(validateLedger(heldBaseline()), []);
+	});
+
+	it("mutant 1 — drop the assignee: HELD_CHILD_UNASSIGNED, and nothing else", () => {
+		assert.deepStrictEqual(validateLedger(heldLedger([])), [
+			{
+				type: "HELD_CHILD_UNASSIGNED",
+				message:
+					"Child #101 is `ready-for:human` but has no assignee; the flip would put it in `write-code`'s candidate pool, which selects `.assignee == null` (#4693).",
+				refs: [101],
+			},
+		]);
+	});
+
+	it("mutant 2 — unobserve the assignee slot: UNVERIFIABLE_ASSIGNEE, and nothing else", () => {
+		assert.deepStrictEqual(validateLedger(heldLedger(undefined)), [
+			{
+				type: "UNVERIFIABLE_ASSIGNEE",
+				message:
+					'Child #101 carries no observation of its assignee slot, so the pool barrier could not be checked; an unread field is UNKNOWN, never "unassigned is fine" (ADR 0092).',
+				refs: [101],
+			},
+		]);
+	});
+
+	it("mutant 3 — unobserve the slot on an agent-audience child: still UNVERIFIABLE, never a skip", () => {
+		// The defect class this closes: a check that cannot see what it is looking for must not
+		// return a plausible value. Absence of `ready-for:human` is NOT a licence to stop looking,
+		// because the label itself is part of what went unread on a narrowed payload.
+		const mutant = ledger({
+			epic: epic({stories: [1], dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {assignees: undefined})],
+		});
+		assert.deepStrictEqual(
+			validateLedger(mutant).map((d) => d.type),
+			["UNVERIFIABLE_ASSIGNEE"],
+		);
+	});
+
+	it("no false positive: an unassigned agent-audience child is clean (it is meant to be picked)", () => {
+		const l = ledger({
+			epic: epic({stories: [1], dependencies: graph({nodes: [101], edges: []})}),
+			children: [
+				child(101, {
+					labels: ["type:feature", "p1", "status:planned", "ready-for:agent"],
+					assignees: [],
+				}),
+			],
+		});
+		assert.deepStrictEqual(validateLedger(l), []);
+	});
+
+	it("the barrier has scope on every ledger: it is checked per child, not per brief", () => {
+		// AC3's scope predicate. A guard scoped to "find the brief issues" would have zero scope
+		// until briefs exist and would red on itself (ADR 0092); this one's scope is the ledger's
+		// children, which `ZERO_SCOPE` already guarantees is non-empty whenever the floor runs.
+		const l = ledger({
+			epic: epic({stories: [1], dependencies: graph({nodes: [101, 102], edges: []})}),
+			children: [child(101, {assignees: undefined}), child(102, {assignees: undefined})],
+		});
+		assert.deepStrictEqual(
+			validateLedger(l).map((d) => d.refs[0]),
+			[101, 102],
+		);
 	});
 });


### PR DESCRIPTION
Fixes #4693

## What this is

A fabrika authoring brief must never reach `write-code`'s candidate pool — a coder that picks one up implements the skill directly, through the door founder ruling #4637-C closed. The contract states that rule; nothing enforced it. This builds the enforcement, on **both** halves (shape 3 of the three the issue offered).

**Enforcement shape chosen: planner-applies **and** plan-gate-verifies.** Recorded with its reasoning on #4693.

## The barrier, and why the flip is untouched

`review-plan`'s flip is unconditional and **stays** unconditional (AC4): it makes every `status:planned` child `status:triaged`. So no label the planner withholds survives it. The assignee does survive — it is the one child attribute the flip never touches, and it is what the picker actually selects on (`step1-candidate-pool.sh`: `.assignee == null`).

So the barrier is the assignee, and what this PR adds is the **check that it is really there**. Nothing about the flip changed; what changed is that a PASS now attests something. Before, the gate flipped whether or not the thing it implies (these children are ready to be picked up) held.

- **Planner** (`plan-epic/scripts/create-child.sh`) takes an optional 6th argument, the login the child is **held for**, and folds *two* attributes into the same atomic `POST /issues` as the labels: `assignees[]` and `ready-for:human`. One argument sets both, so there is no ordering in which the child is briefly labelled-but-unassigned, and no run where a planner sets one and forgets the other.
- **Plan gate** (`epic-ledger`) reds `HELD_CHILD_UNASSIGNED` on a `ready-for:human` child with an empty assignee slot. Being a hard defect, it blocks the flip for the **whole** epic, so the barrier can never be half-applied across a decomposition.

`ready-for:human` is not a new mechanism: it is the label founder ruling #4780 established as the audience dimension, and both `ready-for:*` labels already exist in the repo. No new `status:*` was minted (an explicit rabbit-hole on the issue).

## The defect class this sits in

**The ledger could not see the field at all.** `GithubIssue` decoded `number`, `title`, `body`, `labels` — no `assignees`. A check written against that data would have had to infer "unassigned" from a field it never read.

So the slot is decoded **three-state**, not two: a list of logins (assigned), `[]` (observed, unassigned), and `undefined` (**unobserved** — the payload carried no key). `undefined` is `UNVERIFIABLE_ASSIGNEE`, a hard defect. An unread field is UNKNOWN, never "unassigned is fine" (ADR 0092) — the same idiom as `glossary-freshness.sh`'s `cannot()` route.

This is the honest part: `repos/{repo}/issues/{n}` always returns `assignees`, so today the unobserved case is unreachable in production. It is a defect rather than a skip precisely so that the *next* narrowing of that payload — a `--jq` projection, a refactor, a fixture that drifts from the real REST shape — surfaces as a loud FAIL instead of a plausible green. It already caught two in-repo fixtures that omitted the key.

**Zero scope was the sub-question, and the predicate answers it (AC3).** A guard scoped to "find the brief issues" has zero scope until briefs exist and reds on itself. This one's scope is **every child of the ledger**, which `ZERO_SCOPE` already guarantees is non-empty whenever the floor runs at all. It has scope on its first run and on every run.

## Mutation proof — the guard demonstrably fails

`packages/pipeline-cli/scripts/verify-pool-barrier-fires.sh` plants three counterexamples in a throwaway copy of `src/tools/epic-ledger/` (nothing in the working tree is ever edited, so there is no restore step whose failure leaves a sabotaged validator behind) and asserts each mutant dies **for its intended reason** — the specific test title must appear in a FAIL line. A harness that scores any redness as a kill passes even when its mutants die of a typo.

```
== baseline: the unmutated copy must be GREEN ==
ok — baseline green, so every death below is attributable to its mutant

== M1 an unread assignee slot laundered into an empty one ==
ok — died for its intended reason: "an absent or null `assignees` key decodes to UNOBSERVED, never to unassigned"

== M2 the held-child barrier check disabled ==
ok — died for its intended reason: "mutant 1 — drop the assignee: HELD_CHILD_UNASSIGNED, and nothing else"

== M3 the unverifiable-slot check disabled ==
ok — died for its intended reason: "mutant 3 — unobserve the slot on an agent-audience child: still UNVERIFIABLE, never a skip"

POOL-BARRIER MUTATION PROOF: PASS (3 mutants, each red on its own named test; baseline green)
```

**Negative control, run on a scratch copy of the harness:** with M2's expected test title replaced by one that does not exist, the run reports `FAIL: M2 … went red, but NOT on "a test title that does not exist"` and exits 1. The intended-reason assertion is not vacuous.

The unit tests are written the same way: each is a single-field mutation off one baseline that is asserted clean, and the assertion is the **whole** defect list, not `include` — so a mutant that died of something unrelated fails the assertion instead of scoring as caught.

## Live evidence the barrier works (AC5)

Run against real board state rather than a dry run. `step1-candidate-pool.sh` returned **224** candidates; all **13** currently-open authoring briefs — #4707, #4710, #4711, #4712, #4717, #4718, #4719, #4721, #4941, #4948, #4949, #4950, #4952 — are open, `status:triaged`, priority-labelled, and **absent from every row**. They are stepped over on the assignee alone, exactly as the design claims, with the `status:triaged` label already on them.

## Two premises worth a reviewer's eye

1. **The issue was `Held — needs a founder reconcile` (comment of 2026-08-02)** over ruling #4780, which says the assignee is "a shared availability slot, not an ownership signal". That ruling is about *ownership* — one shared login cannot say *which agent* holds a lane. This design does not use it for ownership: the audience is declared by `ready-for:human` (#4780's own vocabulary), and the assignee is used only as the mechanical availability gate the picker already reads. The founder's live practice matches: the 13 open briefs are all born-assigned, and #4914's acceptance criteria say "created ASSIGNED … in the create call". Flagging it rather than deciding it — see the note on #4693.
2. **"v1 is the frozen baseline"** (ADR 0238) is about fabrika never *calling* v1 code, and about v1 being deletable — not a ban on hardening it; `main` is taking v1 fixes continuously. Also flagged on the issue rather than assumed away.

## §CP

`pipeline-cli cp-classify classify` → **`control-plane [path-match]`** (`claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md` matches the live `CONTROL_PLANE_RE`). This banks for human control-plane approval at head; it does not auto-ship.

## Verification

- `pnpm typecheck` (pipeline-cli) — clean
- `pnpm vitest run src/tools/epic-ledger` — 108 passed
- `shellcheck` on both touched shell scripts — clean
- `create-child.sh` argv proved end-to-end against a stub `gh`: the held path emits `assignees[]=<login>` and `labels[]=ready-for:human` inside the single create call; the default path emits neither.

## Deviations

Walked §DEV's seven classes against this diff. Four entries follow. The first three were already written out — two under "Two premises worth a reviewer's eye" above, one in the #4693 progress comment under "Not done here, surfaced rather than dropped" — and are restated here under the heading a gate can read, unchanged in substance.

- **Governing-ADR / ruling departure (class 2)** — **Said:** founder ruling #4780 says the GitHub assignee is "a shared availability slot, not an ownership signal." **Did:** used the assignee as the enforced barrier the picker selects on, with `ready-for:human` declaring the audience. **Why:** #4780's statement is about *ownership* — one shared login cannot say which agent holds a lane — and nothing here reads it as ownership; the assignee is used only as the mechanical availability gate `step1-candidate-pool.sh` already reads. **Disposition:** settled, not open — the founder ruling recorded on #4693 (2026-08-09) is **COMPOSE**: the `ready-for:<x>` label is the routing signal, born-assignment is the enforced hold, both required, neither substitutes. Applying both is the ruled design.

- **Governing-ADR departure (class 2)** — **Said:** ADR 0238 / #4631 record that v1 is "the frozen baseline — deliberately untouched." **Did:** hardened v1 code (`packages/pipeline-cli/src/tools/epic-ledger/`, `claude-plugins/kampus-pipeline/skills/plan-epic/`) rather than requesting a freeze exception. **Why:** read at ADR 0238 itself, the freeze is about fabrika never *calling* v1 and about keeping v1 deletable — not a ban on fixing it; `main` takes v1 fixes continuously. **Disposition:** flagged for the reviewer to judge, stated on #4693 at authoring time rather than assumed away. If the reading is wrong, the planner half is the part to pull; the `epic-ledger` half stands on its own.

- **Known gap left unfixed (class 3)** — **Said:** #4693 asks that a fabrika authoring brief never reach `write-code`'s candidate pool. **Did:** built the barrier (planner applies, plan gate verifies) but did **not** teach `plan-epic`'s prompt to pass the held-for argument for the fabrika waves, so the gate catches an omission only once a child already carries `ready-for:human`. **Why:** closing that last inch means teaching the planner to recognise a brief by shape, which the issue's own rabbit-holes warn against. **Disposition:** surfaced, not dropped — recorded on #4693; no follow-up filed, because the shape of the fix is exactly what the issue ruled out of scope.

- **Out-of-scope change (class 7)** — **Said:** #4693 asks for the pool barrier; it says nothing about repo ignore rules. **Did:** added one `.gitignore` entry, `__mutation__`. **Why:** the mutation harness that supplies the AC's evidence stages its throwaway copy under `src/` (it has to, to be collected by vitest's `include`), so the entry is what keeps a crashed run from leaving staged files trackable. **Disposition:** no action needed — one line, in service of the evidence the ACs require.

Classes 1, 4, 5 and 6 did not fire, and the two the Tier-M scan can see are worth stating against the scan's own output:

- **Class 5 (guard or gate bypassed) — nothing bypassed.** No `biome-ignore`, `@ts-expect-error`, `eslint-disable`, `.skip(` / `.only(`, `--no-verify` or disabled hook is in the diff. `dev-tier-m.sh` reports one suppression/skip line — `if (!before.includes(find)) process.exit(3);` in `packages/pipeline-cli/scripts/verify-pool-barrier-fires.sh`. That is the scan's `xit\(` pattern matching inside `exit(`, not a skipped test; the line is the harness refusing to plant a mutant whose anchor text is absent, i.e. a fail-closed check, not a relaxed one.
- **Class 6 (pre-existing test or fixture changed) — additive only.** `dev-tier-m.sh` reports zero removed-assertion lines. The two fixture edits (`fixtures.ts`, `github-service.unit.test.ts`) **add** the `assignees` key the new three-state decode requires; no existing assertion was modified, weakened, or deleted.
- **Class 1 (scope narrowing)** — none. All five acceptance criteria are delivered in the shape they asked for; the one thing not built is disclosed as the class-3 entry above, which is a gap the issue's rabbit-holes put out of scope rather than a narrowing of an AC.
