### PR TITLE
fix(ci): run the Step 0 class-parity harness, and make it able to fail (#4744)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,6 +611,15 @@ jobs:
       # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh`.
       - run: bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh
 
+      # Executable pin for Step 0's class parity (#4744): the printed class set must EQUAL
+      # `class-probe classify`'s. The harness landed with #4730's fix and then ran nowhere for a
+      # week — read by four static-lint corpora, executed by none — so it read as coverage while
+      # being unable to fail. Its own falsifiability is asserted in-file (three mutants, each
+      # required to red for its intended reason) and its scope is counted, so a deleted case reds
+      # rather than printing a vacuous OK. Hermetic: gh is stubbed, no network.
+      # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-step0-class-parity.sh`.
+      - run: bash .claude/skills/ship-it/scripts/verify-step0-class-parity.sh
+
       # Executable pin for Step 3z's precondition (#4830): the one ship-it step that mutates a live
       # PR — close→reopen — must fire ONLY in the dropped-trigger state and refuse without touching
       # the PR otherwise, including on an unreadable count. The precondition used to live in the

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
@@ -153,4 +153,4 @@ if [ -z "$CLASS_OUT" ]; then
 fi
 # One class word per line, `has-ui` last when the diff renders a surface — the probe's own emission
 # order, passed through unaltered. Carry THIS set into Step 2 (which re-derives it from the same verb).
-printf '%s\n' "$CLASS_OUT"
+printf '%s\n' "$CLASS_OUT" | grep -v '^has-code$'

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/step0-classify.sh
@@ -153,4 +153,4 @@ if [ -z "$CLASS_OUT" ]; then
 fi
 # One class word per line, `has-ui` last when the diff renders a surface — the probe's own emission
 # order, passed through unaltered. Carry THIS set into Step 2 (which re-derives it from the same verb).
-printf '%s\n' "$CLASS_OUT" | grep -v '^has-code$'
+printf '%s\n' "$CLASS_OUT"

--- a/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash disable=SC1007
+# shellcheck shell=bash disable=SC1007,SC2016
+# SC2016 is declared, not waved off: the mutant generators' sed programs are LITERAL shell text —
+# expanding their `$CLASS_OUT` / `$` here would rewrite the mutants into something else.
 # Reviewer-runnable proof that ship-it Step 0's printed class set EQUALS `class-probe classify`'s —
 # the property #4730 found false, where the step printed a strict SUBSET and nothing noticed.
 #
@@ -12,24 +14,53 @@
 # any plugin home carrying docs beside its skills reproduces it. Case 2 is a diff where every file
 # classifies, so a harness that passed both would still be distinguishing something real.
 #
+# Falsifiability is asserted, not assumed (#4744). The harness generates three MUTANTS of the step,
+# each breaking the parity this file exists to pin, and requires the compare to go red under each —
+# and to go red for the RIGHT reason, which is why each mutant asserts on the printed class sets and
+# not merely on a non-zero exit:
+#   M1  the subtractive copy returns — `has-code` is dropped from the emitted set, reproducing #4730
+#       on case 1: the step prints `has-skills` where the probe prints `has-code has-skills`
+#   M2  a SUPERSET instead of a subtraction — `has-ui` is appended unconditionally, so the compare is
+#       pinned in both directions rather than as a one-way subset test
+#   M3  the step emits NO class set at all (the probe call is stubbed empty, so Step 0 takes its
+#       no-class STOP path) — an unrun step must read as disagreement, never as agreement-by-silence
+#
+# ZERO SCOPE IS A FAILURE, NOT A PASS (ADR 0092). The cases and mutants below are counted as they
+# run, and the final verdict refuses unless both counts equal the declared totals — so a case or a
+# mutant deleted, renamed, or aborted mid-run reds here instead of printing a vacuous `OK` over an
+# empty scope. The count is the scope statement, not the sentence at the bottom.
+#
 # Hermetic: `gh` is stubbed to serve the fixture as the PR's changed-file list, so this needs no auth
 # and touches no repo state. `pipeline-cli` is REAL — the point is to compare the shipped verb's
 # answer against the step's, and a stubbed probe would compare a stub to itself.
 #
 # Usage:  bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
+#         CI runs the same script through the `.claude/skills` symlink (ci.yml, the `skills` job).
 #
 # Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, and no
 # `EXIT` trap — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this
 # harness's whole contract is its exit status.
 set -uo pipefail
 
-DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+# PHYSICAL resolution (`cd -P` / `pwd -P`): CI invokes this through the `.claude/skills` symlink, and
+# the step under test resolves its own sourced chain through `../../../lib`. Left logical, that hop is
+# folded textually against the symlink and lands on `.claude/lib`, which does not exist — the step
+# then dies at its source line and prints no class set, which this harness would score as a caught
+# disagreement while testing nothing. Resolving here physically is what keeps the `..` hops real.
+DIR="$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd -P)"
+SUT="$DIR/step0-classify.sh"
+if [ ! -f "$SUT" ]; then
+	echo "FAIL: zero scope — $SUT does not exist, so there is no Step 0 to compare against (ADR 0092)"
+	exit 1
+fi
+
 ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null)"
 if [ -z "$ROOT" ]; then
 	echo "FAIL: could not resolve the repo root from $DIR — refusing to verify against nothing (ADR 0092)"
 	exit 1
 fi
-PCLI="$ROOT/claude-plugins/kampus-pipeline/bin/pipeline-cli"
+PLUGIN="$ROOT/claude-plugins/kampus-pipeline"
+PCLI="$PLUGIN/bin/pipeline-cli"
 if [ ! -x "$PCLI" ]; then
 	echo "FAIL: the CLI shim is missing or not executable at claude-plugins/kampus-pipeline/bin/pipeline-cli — restore it (chmod +x); without it the parity compare has no reference answer"
 	exit 1
@@ -63,8 +94,8 @@ exit 0
 STUB
 chmod +x "$BIN/gh" || { echo "FAIL: cannot chmod the gh stub"; exit 1; }
 
-FORMATS_SRC="$ROOT/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md"
-SHIPIT_SRC="$ROOT/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md"
+FORMATS_SRC="$PLUGIN/skills/gh-issue-intake-formats.md"
+SHIPIT_SRC="$PLUGIN/skills/ship-it/SKILL.md"
 for f in "$FORMATS_SRC" "$SHIPIT_SRC"; do
 	if [ ! -f "$f" ]; then
 		echo "FAIL: $f is missing — the stub cannot serve the boundary sources, so a subtractive step would be masked by fail-closed sentinels"
@@ -74,33 +105,51 @@ done
 export FORMATS_SRC SHIPIT_SRC
 
 fail=0
+CASES_RUN=0
+MUTANTS_RUN=0
+EXPECTED_CASES=2
+EXPECTED_MUTANTS=3
 
-# One case: write the fixture, run the step under the stub, and compare its class words against the
-# real probe's answer over the identical list. The two answers come from different processes reading
-# the same input — that is what makes the compare able to fail.
-check() {   # $1=name, $2=expected class words (newline-joined, in probe emission order)
-	name="$1"; expected="$2"
-	got_step="$(PATH="$BIN:$PATH" FIXTURE="$FIXTURE" bash "$DIR/step0-classify.sh" kamp-us/phoenix 4724 2>/dev/null \
+# Run one step script over one fixture and print the class words it emitted, `<empty>` when it
+# emitted none. `<empty>` is a distinct token on purpose: a step that STOPPED and a step that printed
+# a smaller set are different defects, and a blank field in the failure text hides which one fired.
+step_classes() {   # $1 = step script, $2 = fixture
+	out="$(PATH="$BIN:$PATH" FIXTURE="$2" bash "$1" kamp-us/phoenix 4724 2>/dev/null \
 		| grep -E '^(has-code|has-docs|has-skills|has-ui)$' || true)"
-	got_probe="$("$PCLI" class-probe classify --files-from "$FIXTURE" --root "$ROOT" 2>/dev/null || true)"
+	printf '%s' "$out"
+}
+
+fmt() {   # newline-joined class set → one space-joined line, `<empty>` when there is none
+	if [ -z "$1" ]; then printf '<empty>'; else printf '%s' "$1" | tr '\n' ' '; fi
+}
+
+# The compare, shared by the real cases and the mutants: the two answers come from different
+# processes reading the same input, which is what makes it able to fail. Prints one verdict line and
+# returns 0 iff parity holds AND the agreed set is the expected one.
+compare() {   # $1 = step script, $2 = name, $3 = fixture, $4 = expected class words (newline-joined)
+	got_step="$(step_classes "$1" "$3")"
+	got_probe="$("$PCLI" class-probe classify --files-from "$3" --root "$ROOT" 2>/dev/null || true)"
 	if [ -z "$got_probe" ]; then
-		printf 'BAD   %-34s the reference probe produced NO class set — the compare would be vacuous\n' "$name"
-		fail=1
-		return
+		printf 'BAD   %-34s the reference probe produced NO class set — the compare would be vacuous\n' "$2"
+		return 1
 	fi
 	if [ "$got_step" != "$got_probe" ]; then
-		printf 'BAD   %-34s step 0 and class-probe DISAGREE\n  step0:      %s\n  class-probe: %s\n' \
-			"$name" "$(printf '%s' "$got_step" | tr '\n' ' ')" "$(printf '%s' "$got_probe" | tr '\n' ' ')"
-		fail=1
-		return
+		printf 'BAD   %-34s step 0 and class-probe DISAGREE\n  step0:       %s\n  class-probe: %s\n' \
+			"$2" "$(fmt "$got_step")" "$(fmt "$got_probe")"
+		return 1
 	fi
-	if [ "$got_step" != "$expected" ]; then
+	if [ "$got_step" != "$4" ]; then
 		printf 'BAD   %-34s parity holds but the set is not the expected one\n  got:      %s\n  expected: %s\n' \
-			"$name" "$(printf '%s' "$got_step" | tr '\n' ' ')" "$(printf '%s' "$expected" | tr '\n' ' ')"
-		fail=1
-		return
+			"$2" "$(fmt "$got_step")" "$(fmt "$4")"
+		return 1
 	fi
-	printf 'ok    %-34s %s\n' "$name" "$(printf '%s' "$got_step" | tr '\n' ' ')"
+	printf 'ok    %-34s %s\n' "$2" "$(fmt "$got_step")"
+	return 0
+}
+
+check() {   # $1 = name, $2 = expected class words — run against the REAL step
+	CASES_RUN=$((CASES_RUN + 1))
+	compare "$SUT" "$1" "$FIXTURE" "$2" || fail=1
 }
 
 # 1. THE REGRESSION CASE — plugin docs beside plugin skills. The first two files classify as NOTHING
@@ -113,6 +162,7 @@ claude-plugins/fabrika/docs/authoring-brief-contract.md
 claude-plugins/fabrika/docs/cli-interface-convention.md
 claude-plugins/fabrika/skills/adr/SKILL.md
 FILES
+REGRESSION_FIXTURE="$FIXTURE"
 check "plugin docs beside skills (#4730)" "$(printf 'has-code\nhas-skills')"
 
 # 2. THE CONTROL — every file classifies on its own, so this case passed even BEFORE the fix. Keeping
@@ -124,8 +174,91 @@ packages/pipeline-cli/src/tools/verdict/command.ts
 FILES
 check "every file classifies (control)" "$(printf 'has-code\nhas-docs')"
 
+# --- falsifiability: the compare must go red under a step that breaks parity -----------------------
+#
+# A mutant must live at the SAME depth as the original: the step resolves its shared lib through
+# `../../../lib` and cp-read through `../../shared/scripts`, so a mutant dropped in a flat temp dir
+# would die at its own source lines and print no class set — which reads as a disagreement and would
+# score the mutant caught for entirely the wrong reason. Hence a mirrored tree whose `lib`, `bin` and
+# `skills/shared` are symlinks back to the real plugin, and hence every mutant asserts on the class
+# sets in the failure text rather than on a bare non-zero exit.
+MUT="$TMP/mut"
+mkdir -p "$MUT/skills/ship-it/scripts" || { echo "FAIL: cannot create the mutant tree under $TMP"; exit 1; }
+ln -s "$PLUGIN/lib" "$MUT/lib" || { echo "FAIL: cannot link the plugin lib into the mutant tree"; exit 1; }
+ln -s "$PLUGIN/bin" "$MUT/bin" || { echo "FAIL: cannot link the plugin bin into the mutant tree"; exit 1; }
+ln -s "$PLUGIN/skills/shared" "$MUT/skills/shared" || { echo "FAIL: cannot link skills/shared into the mutant tree"; exit 1; }
+MUTANT="$MUT/skills/ship-it/scripts/step0-classify.sh"
+
+mutate() {   # $1 = name, $2… = sed programs applied in order
+	name="$1"; shift
+	cp "$SUT" "$MUTANT" || { printf 'BAD   %-34s cannot copy the step into the mutant tree\n' "$name"; fail=1; return 1; }
+	for prog in "$@"; do
+		sed "$prog" "$MUTANT" > "$MUTANT.tmp" && mv "$MUTANT.tmp" "$MUTANT"
+	done
+	if cmp -s "$SUT" "$MUTANT"; then
+		printf 'BAD   %-34s the mutant is byte-identical to the original — it reverts nothing\n' "$name"
+		fail=1
+		return 1
+	fi
+	return 0
+}
+
+# A mutant is caught only when the compare goes red AND its failure text names the class sets the
+# mutation was meant to produce. Asserting on the exit status alone would score a mutant that died of
+# a broken source line — the #4700 lesson — as a mutant the parity check caught.
+expect_mutant() {   # $1 = name, $2 = fixture, $3… = substrings the failure text MUST carry
+	name="$1"; fx="$2"; shift 2
+	MUTANTS_RUN=$((MUTANTS_RUN + 1))
+	out="$(compare "$MUTANT" "$name" "$fx" "$(printf 'has-code\nhas-skills')" 2>&1)"
+	rc=$?
+	if [ "$rc" -eq 0 ]; then
+		printf 'BAD   %-34s the compare stayed GREEN under a mutant that breaks parity\n' "$name"
+		fail=1
+		return
+	fi
+	for want in "$@"; do
+		case "$out" in
+			*"$want"*) : ;;
+			*)
+				printf 'BAD   %-34s the compare went red for the WRONG reason — expected the text to carry %s, got: %s\n' \
+					"$name" "$want" "$out"
+				fail=1
+				return
+				;;
+		esac
+	done
+	printf 'ok    %-34s mutant caught (%s)\n' "$name" "$(printf '%s' "$out" | head -1 | sed 's/^BAD  *//')"
+}
+
+# M1 — the subtractive copy returns: `has-code` never reaches stdout, exactly #4730's shape.
+if mutate "M1 has-code subtracted" 's|^printf .%s\\n. "\$CLASS_OUT"$|printf "%s\\n" "$CLASS_OUT" \| grep -v "^has-code$"|'; then
+	expect_mutant "M1 has-code subtracted" "$REGRESSION_FIXTURE" "DISAGREE" "step0:       has-skills" "class-probe: has-code has-skills"
+fi
+
+# M2 — a SUPERSET, not a subtraction: the compare is an equality, so an ADDED class must red too.
+if mutate "M2 has-ui added" 's|^printf .%s\\n. "\$CLASS_OUT"$|printf "%s\\n" "$CLASS_OUT"; echo has-ui|'; then
+	expect_mutant "M2 has-ui added" "$REGRESSION_FIXTURE" "DISAGREE" "step0:       has-code has-skills has-ui" "class-probe: has-code has-skills"
+fi
+
+# M3 — the step prints NO class set (its own no-class STOP path). Agreement-by-silence is the exact
+# reading this harness must never make, so the `<empty>` token is asserted rather than a blank field.
+if mutate "M3 step emits nothing" 's|^CLASS_OUT="\$(printf .*$|CLASS_OUT=""|'; then
+	expect_mutant "M3 step emits nothing" "$REGRESSION_FIXTURE" "DISAGREE" "step0:       <empty>" "class-probe: has-code has-skills"
+fi
+
+# ZERO-SCOPE FAIL-CLOSED (ADR 0092): the counters are the scope statement. A deleted case, a mutant
+# whose generator aborted, or a `check` that never ran leaves a count short — and a short count is
+# never a pass, because "nothing disagreed" over an empty scope is the vacuous green this whole file
+# exists to make impossible.
+if [ "$CASES_RUN" -ne "$EXPECTED_CASES" ] || [ "$MUTANTS_RUN" -ne "$EXPECTED_MUTANTS" ]; then
+	printf 'FAIL: zero/short scope — ran %s of %s parity case(s) and %s of %s mutant(s); refusing to report a verdict over a scope that is not the declared one (ADR 0092)\n' \
+		"$CASES_RUN" "$EXPECTED_CASES" "$MUTANTS_RUN" "$EXPECTED_MUTANTS"
+	exit 1
+fi
+
 if [ "$fail" -ne 0 ]; then
 	echo "verify-step0-class-parity: FAILED — Step 0's class set is not class-probe's (#4730)"
 	exit 1
 fi
-echo "verify-step0-class-parity: OK — 2 case(s); Step 0 prints class-probe's answer, including on a diff whose files classify as nothing"
+printf 'verify-step0-class-parity: OK — %s parity case(s) + %s mutant(s); Step 0 prints class-probe answer, including on a diff whose files classify as nothing\n' \
+	"$CASES_RUN" "$MUTANTS_RUN"


### PR DESCRIPTION
There is a check in this repo that verifies the ship-it merge path classifies a diff the same way the shared class probe does. It has never run. It landed with the fix it was written to protect, no CI job ever invoked it, and four static-lint jobs read the file without executing it — so it looked like coverage while being unable to fail. This PR runs it, and hardens it so a green run actually means something.

Fixes #4744

## What changed

**`.github/workflows/ci.yml`** — a step in the `skills` job runs the harness, in the same shape and with the same `# Same script runs locally:` comment as its wired siblings (`verify-chain-resolves.sh`, `verify-step3z-precondition.sh`, `verify-glossary-detector-fires.sh`).

**`claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh`** — three changes, each closing a way the harness could have passed without testing anything:

1. **Physical path resolution** (`cd -P` / `pwd -P`). CI invokes the harness through the `.claude/skills` symlink, and the step under test resolves its own sourced chain through `../../../lib`. Left logical, that hop folds textually against the symlink onto `.claude/lib`, which does not exist — the step would die at its source line and print no class set, which the compare would score as a caught disagreement while testing nothing. This is the exact false pass `verify-glossary-detector-fires.sh` documents.
2. **Three mutants of the step, each asserted to red for its intended reason.** M1 subtracts `has-code` from the emitted set (#4730's shape). M2 appends `has-ui`, pinning the compare as an equality rather than a one-way subset test. M3 makes the step print no class set at all, so agreement-by-silence is impossible. A mutant that merely exits non-zero is not evidence, so each one asserts on the class sets printed in the failure text.
3. **The scope is counted, and a short count fails closed** (ADR 0092). The old file printed a hardcoded `OK — 2 case(s)` regardless of how many cases ran, so deleting a case would have left a clean green over an empty scope. Cases and mutants are now counted as they run and compared against declared totals.

## Why the step blocks

`ci-required`'s `needs:` list does **not** include the `skills` job, so the acceptance criterion's stated mechanism ("feeds the required `ci-required` gate") is not how any of these verify steps block. They block because the `skills` job's display name, `validate skill frontmatter`, is itself one of three required status-check contexts on the `main` ruleset (alongside `scan changed files for leaks` and `ci-required`). A non-zero exit from any step in that job fails the job, and a failed required context blocks the merge. The criterion's intent — a failure must block, not merely annotate — holds; its stated route does not. Flagged in Deviations rather than silently marked satisfied.

## Demonstration

Green baseline:

```
ok    plugin docs beside skills (#4730)  has-code has-skills
ok    every file classifies (control)    has-code has-docs
ok    M1 has-code subtracted             mutant caught (... step 0 and class-probe DISAGREE)
ok    M2 has-ui added                    mutant caught (... step 0 and class-probe DISAGREE)
ok    M3 step emits nothing              mutant caught (... step 0 and class-probe DISAGREE)
verify-step0-class-parity: OK — 2 parity case(s) + 3 mutant(s); ...
```

Each new guard was proven able to fire by breaking it, watching it red, then restoring it:

- **Short scope** — declared 3 cases, ran 2: `FAIL: zero/short scope — ran 2 of 3 parity case(s) and 3 of 3 mutant(s); refusing to report a verdict over a scope that is not the declared one (ADR 0092)`, exit 1.
- **Wrong reason** — M1's expected class set changed to one the mutation cannot produce: `BAD M1 has-code subtracted — the compare went red for the WRONG reason — expected the text to carry step0: has-docs, got: ... step0: has-skills`, exit 1. A mutant dying for an unrelated reason cannot score as caught.
- **No-op mutation** — M2's sed program pointed at a line that does not exist: `BAD M2 has-ui added — the mutant is byte-identical to the original — it reverts nothing`, followed by the short-mutant-count refusal, exit 1.

### Red → green on real CI

A real parity violation was planted in `step0-classify.sh` (drop `has-code` from the emitted set — #4730's exact defect), pushed, observed, and reverted. Three heads on this branch:

| head | `validate skill frontmatter` | run |
| --- | --- | --- |
| `379c79c` wiring + hardening | success | [31291371041](https://github.com/kamp-us/phoenix/actions/runs/31291371041/job/93189013128) |
| `22bd85a` planted violation | **failure** | [31291537733](https://github.com/kamp-us/phoenix/actions/runs/31291537733/job/93189515339) |
| `5ca716f` violation reverted | success | [31291652310](https://github.com/kamp-us/phoenix/actions/runs/31291652310/job/93189803677) |

On the red run the new step is the **only** failing step in the job, and its output names the disagreement:

```
BAD   plugin docs beside skills (#4730)  step 0 and class-probe DISAGREE
  step0:       has-skills
  class-probe: has-code has-skills
FAIL: zero/short scope — ran 2 of 2 parity case(s) and 1 of 3 mutant(s); ...
```

Two things that run shows beyond "the wiring works". First, every other step in that job passed on the same violation — including `verify-chain-resolves.sh`, which sources `step0-classify.sh` — so nothing else in CI could see this defect. Second, the mutant generators correctly reported `the mutant is byte-identical to the original — it reverts nothing` (the planted change had already turned M1's target line into M1), and the short-mutant-count guard turned that into a refusal rather than a partial pass.

## §CP

`cp-classify classify` returns `control-plane [path-match]` on `.github/workflows/ci.yml`. This PR needs a human merge; I am not merging or enqueueing it.

## Deviations

**1 · Narrowed a stated acceptance criterion's mechanism (class: scope).**
- *Said:* the step must feed the required `ci-required` gate, "exactly as its sibling verify steps do".
- *Did:* wired the step into the `skills` job, which is directly a required status check; it does not feed `ci-required`, and neither do the siblings — `ci-required`'s `needs:` list omits `skills`.
- *Why:* the criterion's premise about the wiring was inaccurate. Making `ci-required` depend on `skills` would change the aggregator's contract for every job in it, which is out of scope here and a control-plane change of its own.
- *Disposition:* no action needed — the criterion's intent (a failure blocks) is met by the existing required context; for the reviewer to judge.

**2 · Widened the diff beyond the literal one-line fix (class: scope).**
- *Said:* triage measured the harness green, hermetic and fail-closed, and suggested wiring it as roughly one line.
- *Did:* also hardened the harness — physical resolution, three mutants, counted scope.
- *Why:* the issue's own framing is that a check which cannot fail reads as coverage. Wiring an unfalsifiable harness would reproduce that defect one layer up: the harness had no proof it could fail, and a hardcoded case count that survived case deletion.
- *Disposition:* no action needed.

**3 · Pushed two extra commits deliberately, one of them red (class: process).**
- *Said:* nothing — this is not something the issue asked about.
- *Did:* pushed a temporary commit planting a real parity violation so CI could be observed failing, then reverted it in the next commit. The branch's net diff is the two intended files.
- *Why:* a guard that has never been seen to fail is exactly the defect this issue is about; a red run on the real required check is the only evidence that settles it.
- *Disposition:* no action needed — reverted; both commits are on the branch for audit. Squash-merge collapses them.

**4 · Left a sibling gap unfixed (class: deferred work).**
- *Said:* the issue's closing question — whether anything systematically detects scripts that are defined but never invoked — was explicitly scoped out by triage.
- *Did:* did not build such a detector.
- *Why:* triage ruled it a separate unit of work with its own design question.
- *Disposition:* still unowned; someone should file it if it is wanted.