### PR TITLE
fix(triage): apply-triage.sh forwards every argument, or refuses loudly (#4936)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,16 @@ jobs:
       # Same script runs locally: `bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh`.
       - run: bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh
 
+      # Executable pin for triage's apply-triage wrapper (#4936): every argument it is given reaches
+      # the verb, or it refuses non-zero having spawned the verb zero times. The wrapper took `-ge 3`
+      # and forwarded only `$1 $2 $3`, so the documented `--status needs-info` was accepted, dropped,
+      # and exited 0 having stamped `status:triaged` — the pickable label — on an issue a triager was
+      # deliberately holding. The assertions are on the verb's ARGV, not on a clean exit, because a
+      # clean exit is what the defect already produced; five mutants keep them from going toothless.
+      # Hermetic: the verb is a stub, no network, no issue mutated.
+      # Same script runs locally: `bash .claude/skills/triage/scripts/verify-apply-triage-args.sh`.
+      - run: bash .claude/skills/triage/scripts/verify-apply-triage-args.sh
+
       # Gate-path drift guard (issue #720): assert the five CONTROL_PLANE_RE= copies
       # in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats are
       # byte-identical to the §CP canonical line, and that .claude/skills resolves to

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -732,9 +732,25 @@ The verb adds the `type:` / priority / `status:triaged` labels and drops the que
 in one envelope (ADR 0190; `packages/pipeline-cli/src/tools/tracker/`). Dropping the queue
 label is idempotent: a `404 "Label does not exist"` when the issue never carried
 `status:needs-triage` (a pre-bootstrap issue predating the label) is tolerated, since the
-goal — issue out of the queue — is met either way. Pass `--status <stage>` to target a
-different lifecycle stage (e.g. `needs-info`); it defaults to `triaged`. Don't hand-roll
+goal — issue out of the queue — is met either way. Don't hand-roll
 the REST label calls — that inline envelope is exactly what the adoption lint (#3254) flags.
+
+`--status <stage>` targets a different lifecycle stage; it defaults to `triaged`. Which
+positionals go with it is the stage's own contract, not a free choice — the
+park stage `needs-info` ([Step 5](#step-5--the-human-vs-agent-judgment-who-never-gets-auto-closed))
+carries **no** type and **no** priority, so it takes the bare-`<N>` form:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/apply-triage.sh" <N> --status needs-info
+"${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/apply-triage.sh" <N> <type> <priority> --status <classified-stage>
+```
+
+**Every argument you pass reaches the verb, or the script refuses (exit 2) — there is no
+partial application.** An unrecognized flag, a `--status` with no stage, a fourth positional,
+and a `--status needs-info` alongside a type and a priority are all fatal, loudly, before any
+label is written. That refusal is the point: the earlier wrapper took the documented
+`--status` and silently dropped it, stamping `status:triaged` — the *pickable* label — on an
+issue a triager was deliberately trying to hold (#4936).
 
 `status:triaged` is an explicit signature only *you* apply — it tells write-code the
 issue was actually reviewed. Never let a type label alone stand in for it; a

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/apply-triage.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/apply-triage.sh
@@ -2,7 +2,17 @@
 # Apply the triage verdict to #N: the type + priority labels and the status transition, through the
 # one verb that owns that label write.
 #
-# usage: apply-triage.sh <N> <type> <priority>
+# usage: apply-triage.sh <N> <type> <priority> [--status <stage>]
+#        apply-triage.sh <N> --status <stage>            # the un-classified park (e.g. needs-info)
+#
+# EVERY argument reaches the verb, or the script refuses. The shape it replaced took `-ge 3` and
+# forwarded `$1 $2 $3`, so `apply-triage.sh <N> <type> <priority> --status needs-info` — the exact
+# invocation ../SKILL.md § Apply the labels tells a triager to use — was accepted, dropped on the
+# floor, and exited 0 having stamped `status:triaged` instead. That drop fails OPEN: `status:triaged`
+# + unassigned is precisely what write-code's picker selects on, so an issue someone deliberately
+# tried to hold landed pickable with no signal to anyone (#4936). Hence the parse below: an
+# unrecognized flag, a `--status` with no stage, and an off-contract positional count are all fatal,
+# and a partial application is unreachable.
 #
 # Extracted from triage/SKILL.md (#4454, epic #4435 phase 1). Extraction contract +
 # shell-option rationale: ../SKILL.md § The extracted scripts.
@@ -10,7 +20,73 @@ set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
-[ "$#" -ge 3 ] || { echo "usage: apply-triage.sh <N> <type> <priority>" >&2; exit 2; }
+usage() {
+	cat >&2 <<'EOF'
+usage: apply-triage.sh <N> <type> <priority> [--status <stage>]
+       apply-triage.sh <N> --status <stage>            # the un-classified park (e.g. needs-info)
+EOF
+}
+
+refuse() {
+	printf 'apply-triage.sh: %s\n' "$1" >&2
+	usage
+	exit 2
+}
+
+STATUS="triaged"
+STATUS_SEEN=0
+POSITIONAL=()
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--status)
+			[ "$STATUS_SEEN" -eq 0 ] || refuse "--status given more than once"
+			[ "$#" -ge 2 ] || refuse "--status needs a stage (e.g. --status needs-info)"
+			STATUS="$2"
+			STATUS_SEEN=1
+			shift 2
+			;;
+		--status=*)
+			[ "$STATUS_SEEN" -eq 0 ] || refuse "--status given more than once"
+			STATUS="${1#--status=}"
+			[ -n "$STATUS" ] || refuse "--status needs a stage (e.g. --status needs-info)"
+			STATUS_SEEN=1
+			shift
+			;;
+		-*)
+			refuse "unrecognized flag '$1' — this wrapper forwards --status only"
+			;;
+		*)
+			POSITIONAL+=("$1")
+			shift
+			;;
+	esac
+done
+
+# The positional contract is exact, never `-ge`: an extra bare word is as silently dropped as an
+# extra flag was, so `<N> <type> <priority> extra` is refused on the same footing.
+case "${#POSITIONAL[@]}" in
+	3) ;;
+	1) [ "$STATUS_SEEN" -eq 1 ] || refuse "a bare <N> applies nothing — give <type> <priority>, or --status <stage> to park it" ;;
+	*) refuse "expected 3 positionals (<N> <type> <priority>) or 1 (<N>) with --status, got ${#POSITIONAL[@]}" ;;
+esac
+
+TARGET="${POSITIONAL[0]}"
+case "$TARGET" in
+	'' | *[!0-9]*) refuse "<N> must be an issue number, got '$TARGET'" ;;
+esac
+
 PCLI="$(kp_pcli)" || exit 127
 
-"$PCLI" tracker apply-triage "$1" --type "$2" --p "$3"
+# `--status` is always forwarded, never left implicit: the verb's own default is `triaged`, so
+# passing the resolved value changes nothing about the 3-argument path while making "the stage the
+# caller asked for is the stage the verb is told" true by construction rather than by defaulting.
+if [ "${#POSITIONAL[@]}" -eq 3 ]; then
+	"$PCLI" tracker apply-triage "$TARGET" \
+		--type "${POSITIONAL[1]}" --p "${POSITIONAL[2]}" --status "$STATUS"
+else
+	# The park: type and priority are deliberately absent. Whether the stage tolerates that is the
+	# domain's call (`classify`), and it refuses loudly before any write — this wrapper never
+	# invents a filler classification to fill the gap.
+	"$PCLI" tracker apply-triage "$TARGET" --status "$STATUS"
+fi

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC2016
+# SC2016 is declared, not waved off: the mutant generators' sed programs are LITERAL text —
+# expanding their `$#` / `$1` here would rewrite the mutants into something else.
+#
+# Reviewer-runnable proof that apply-triage.sh forwards every argument it is given, and refuses —
+# loudly, non-zero, before any write — when it cannot.
+#
+# The defect (#4936): the wrapper took `-ge 3` and forwarded `$1 $2 $3`, so a trailing
+# `--status needs-info` was accepted, discarded, and the run exited 0 having applied
+# `status:triaged`. That direction is what makes it worse than an ordinary dropped argument —
+# `status:triaged` + unassigned is exactly write-code's pick predicate, so the hold a triager
+# thought they had applied landed PICKABLE, with nothing in the exit status or on stdout to say so.
+#
+# So the property under test is two-sided, and neither side alone is the fix:
+#   (1) POSITIVE — a well-formed invocation reaches the verb with EVERY argument intact. Asserted on
+#       the verb's actual argv, not on a clean exit: an exit 0 is what the defect already produced.
+#   (2) LOUD — an invocation the wrapper cannot forward in full exits non-zero with a diagnostic and
+#       spawns the verb ZERO times. A partial application is the failing case, not a lesser pass.
+#
+# Falsifiability is asserted, not assumed: five MUTANTS each revert one claim the fix rests on, and
+# each is required to reproduce its OWN failure — matched on the specific wrong argv or the specific
+# wrong exit, never on "something went red", which a mutant that merely fails to start also does.
+#
+# Hermetic: the verb is a stub that records its argv, so this needs no auth, no network, and mutates
+# no issue.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, and no
+# `EXIT` trap — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this
+# harness's whole contract is its exit status.
+set -uo pipefail
+
+# PHYSICAL resolution (`cd -P` / `pwd -P`): CI and agents reach this through the `.claude/skills`
+# symlink, where a logically-folded `..` lands on `.claude/` — which has no `lib/`, so every mutant
+# would die at lib resolution and score as "caught" while testing nothing.
+DIR="$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd -P)"
+SUT="$DIR/apply-triage.sh"
+fail=0
+
+if [ ! -f "$SUT" ]; then
+	echo "FAIL: zero scope — $SUT does not exist (ADR 0092)"
+	exit 1
+fi
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+PLUGIN="$TMP/plugin"
+mkdir -p "$PLUGIN/bin" || { echo "FAIL: cannot create the stub plugin root under $TMP"; exit 1; }
+
+# The verb stub records one line per spawn: the full argv it was handed, tab-separated. Its absence
+# is therefore evidence the wrapper refused before spawning anything — which is what "no partial
+# application" means operationally.
+cat > "$PLUGIN/bin/pipeline-cli" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\t' "$@" >> "$PCLI_LOG"
+printf '\n' >> "$PCLI_LOG"
+exit 0
+STUB
+chmod +x "$PLUGIN/bin/pipeline-cli" || { echo "FAIL: cannot chmod the verb stub"; exit 1; }
+
+LOG="$TMP/argv.log"
+
+run_case() {   # $1 = script under test, $2… = the invocation's arguments
+	local script="$1"
+	shift
+	: > "$LOG"
+	ERR="$TMP/err"
+	OUT="$(PCLI_LOG="$LOG" CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$script" "$@" 2>"$ERR")"
+	RC=$?
+	ARGV="$(cat "$LOG")"
+	ERRTEXT="$(cat "$ERR")"
+	SPAWNS="$(grep -c . "$LOG")"
+}
+
+# A forwarded invocation: the verb ran exactly once and its argv is EXACTLY the expected line. An
+# argv substring match would let a dropped trailing flag pass, which is the defect itself.
+check_forwarded() {   # $1 = label, $2 = expected tab-joined argv
+	if [ "$RC" -ne 0 ]; then
+		printf 'BAD   %-44s expected exit 0, exited %s (%s)\n' "$1" "$RC" "${ERRTEXT:-<no stderr>}"
+		fail=1
+		return
+	fi
+	if [ "$SPAWNS" -ne 1 ]; then
+		printf 'BAD   %-44s expected exactly 1 verb spawn, saw %s\n' "$1" "$SPAWNS"
+		fail=1
+		return
+	fi
+	if [ "$ARGV" != "$2	" ]; then
+		printf 'BAD   %-44s argv mismatch\n        want: %s\n        got:  %s\n' "$1" "$2" "$ARGV"
+		fail=1
+		return
+	fi
+	printf 'OK    %-44s forwarded: %s\n' "$1" "$2"
+}
+
+# A refused invocation: non-zero, a diagnostic naming the reason, and — the load-bearing half — ZERO
+# verb spawns, so nothing was partially applied on the way to the refusal.
+check_refused() {   # $1 = label, $2 = substring the stderr diagnostic must carry
+	if [ "$RC" -eq 0 ]; then
+		printf 'BAD   %-44s must refuse, exited 0 (argv: %s)\n' "$1" "${ARGV:-<none>}"
+		fail=1
+		return
+	fi
+	if [ "$SPAWNS" -ne 0 ]; then
+		printf 'BAD   %-44s refused but still spawned the verb %s time(s): %s\n' "$1" "$SPAWNS" "$ARGV"
+		fail=1
+		return
+	fi
+	if ! printf '%s' "$ERRTEXT" | grep -q "$2"; then
+		printf 'BAD   %-44s stderr missing %-30s got: %s\n' "$1" "$2" "${ERRTEXT:-<empty>}"
+		fail=1
+		return
+	fi
+	printf 'OK    %-44s refused (%s), no write\n' "$1" "$2"
+}
+
+echo "scope: $SUT, driven under 11 invocations + 5 mutants"
+
+# --- POSITIVE: every argument reaches the verb ----------------------------------------------------
+run_case "$SUT" 4936 bug p1
+check_forwarded "3-arg path (unchanged)" "tracker	apply-triage	4936	--type	bug	--p	p1	--status	triaged"
+
+run_case "$SUT" 4936 bug p1 --status planned
+check_forwarded "trailing --status is APPLIED" "tracker	apply-triage	4936	--type	bug	--p	p1	--status	planned"
+
+run_case "$SUT" 4936 --status needs-info
+check_forwarded "the park (no type, no priority)" "tracker	apply-triage	4936	--status	needs-info"
+
+run_case "$SUT" 4936 --status=needs-info
+check_forwarded "--status=<stage> joined form" "tracker	apply-triage	4936	--status	needs-info"
+
+run_case "$SUT" --status planned 4936 chore p2
+check_forwarded "leading --status, positionals after" "tracker	apply-triage	4936	--type	chore	--p	p2	--status	planned"
+
+# --- LOUD: what cannot be forwarded in full is fatal, and applies NOTHING --------------------------
+run_case "$SUT" 4936 bug p1 extra
+check_refused "4th bare positional (the arity half)" "expected 3 positionals"
+
+run_case "$SUT" 4936 bug p1 --status
+check_refused "--status with no stage" "needs a stage"
+
+run_case "$SUT" 4936 bug p1 --sttaus needs-info
+check_refused "misspelled/unknown flag" "unrecognized flag"
+
+run_case "$SUT" 4936 bug p1 --status a --status b
+check_refused "--status given twice" "more than once"
+
+run_case "$SUT" 4936
+check_refused "bare <N>, no stage and no facets" "applies nothing"
+
+run_case "$SUT" bug p1 4936
+check_refused "non-numeric <N> (transposed args)" "must be an issue number"
+
+# --- falsifiability: every claim above must go red under a mutant that reverts it ------------------
+#
+# A mutant must live at the SAME depth as the original: apply-triage.sh sources the shared lib
+# through `../../../lib`, so a mutant dropped in a flat temp dir dies at lib resolution — a non-zero
+# exit that a loose "it refused" assertion would score as caught for entirely the wrong reason.
+# Hence a mirrored tree, and hence every expectation below naming its own outcome precisely.
+PLUGIN_SRC="$(CDPATH= cd -P -- "$DIR/../../.." && pwd -P)"
+MUT_DIR="$TMP/tree/skills/triage/scripts"
+mkdir -p "$MUT_DIR" || { echo "FAIL: cannot create the mutant tree under $TMP"; exit 1; }
+ln -s "$PLUGIN_SRC/lib" "$TMP/tree/lib" || { echo "FAIL: cannot mirror the shared lib"; exit 1; }
+
+mutate() {   # $1 = name, $2… = sed programs
+	local name="$1"
+	shift
+	MUTANT="$MUT_DIR/mutant-$name.sh"
+	cp "$SUT" "$MUTANT" || return 1
+	local prog
+	for prog in "$@"; do
+		sed "$prog" "$MUTANT" > "$MUTANT.tmp" && mv "$MUTANT.tmp" "$MUTANT"
+	done
+	if cmp -s "$SUT" "$MUTANT"; then
+		printf 'BAD   %-44s the mutant is byte-identical to the original — it reverts nothing\n' "$name"
+		fail=1
+		return 1
+	fi
+	return 0
+}
+
+# The reverted behaviour is asserted on the ARGV the verb saw (or on its absence), never on a bare
+# non-zero: a mutant that fails to start is also non-zero, and scoring that as "caught" is how a
+# mutation suite passes while testing nothing.
+expect_argv() {   # $1 = name, $2 = the argv line the BROKEN wrapper forwards, $3 = why it has teeth
+	if [ "$ARGV" = "$2	" ]; then
+		printf 'OK    %-44s %s\n' "$1" "$3"
+	else
+		printf 'BAD   %-44s expected the reverted argv\n        want: %s\n        got:  %s\n' "$1" "$2" "${ARGV:-<no spawn>}"
+		fail=1
+	fi
+}
+
+# M1 — the filed defect verbatim: `-ge 3` arity + forward only $1 $2 $3. The trailing `--status
+# needs-info` is swallowed and `status:triaged` is what lands.
+if mutate asfiled '/^while \[ "\$#" -gt 0 \]; do$/,/^fi$/d'; then
+	cat >> "$MUTANT" <<'ASFILED'
+[ "$#" -ge 3 ] || { echo "usage: apply-triage.sh <N> <type> <priority>" >&2; exit 2; }
+PCLI="$(kp_pcli)" || exit 127
+"$PCLI" tracker apply-triage "$1" --type "$2" --p "$3"
+ASFILED
+	run_case "$MUTANT" 4936 bug p1 --status needs-info
+	expect_argv "M1 the code as filed (#4936)" "tracker	apply-triage	4936	--type	bug	--p	p1" \
+		"reproduces the drop: the hold is discarded and status:triaged lands"
+fi
+
+# M2 — the `-*` catch-all refuses nothing and just steps over the flag and its value, which is how
+# an unrecognized flag gets swallowed instead of surfaced.
+if mutate noflagguard 's%^			refuse "unrecognized flag.*%			shift 2%'; then
+	run_case "$MUTANT" 4936 bug p1 --sttaus needs-info
+	expect_argv "M2 unknown-flag refusal deleted" "tracker	apply-triage	4936	--type	bug	--p	p1	--status	triaged" \
+		"a typo'd flag is absorbed instead of refused"
+fi
+
+# M3 — the exact positional count goes back to `-ge`-style tolerance, so a 4th bare word is dropped.
+# The flag-shaped refusal that #4854 will land corpus-wide does NOT catch this one: `extra` has no
+# leading dash.
+if mutate arityloose \
+	's%^	\*) refuse "expected 3 positionals.*$%	*) : ;;%' \
+	's%-eq 3 \]; then$%-ge 3 ]; then%'; then
+	run_case "$MUTANT" 4936 bug p1 extra
+	expect_argv "M3 exact arity relaxed" "tracker	apply-triage	4936	--type	bug	--p	p1	--status	triaged" \
+		"the arity half is independent of flag shape — 'extra' is dropped in silence"
+fi
+
+# M4 — `--status` is parsed but never forwarded (the defect's shape, one layer in): the wrapper
+# consumes the flag and the verb still applies its default.
+if mutate notforwarded 's%^		--type "\${POSITIONAL\[1\]}" --p "\${POSITIONAL\[2\]}" --status "\$STATUS"$%		--type "${POSITIONAL[1]}" --p "${POSITIONAL[2]}"%'; then
+	run_case "$MUTANT" 4936 bug p1 --status planned
+	expect_argv "M4 --status parsed, not forwarded" "tracker	apply-triage	4936	--type	bug	--p	p1" \
+		"consuming the flag without forwarding it is the same silent drop"
+fi
+
+# M5 — the numeric-<N> guard is dropped, so a transposed invocation addresses the verb with a word
+# where the issue number belongs instead of refusing.
+if mutate nonnumeric "/must be an issue number/d"; then
+	run_case "$MUTANT" bug p1 4936
+	expect_argv "M5 numeric <N> guard deleted" "tracker	apply-triage	bug	--type	p1	--p	4936	--status	triaged" \
+		"a transposed argv reaches the verb addressed at a non-issue"
+fi
+
+rm -rf "$TMP"
+if [ "$fail" -ne 0 ]; then
+	echo "FAIL: apply-triage.sh drops an argument, or a refusal is not loud and write-free"
+	exit 1
+fi
+echo "PASS: every argument reaches the verb, and what cannot be forwarded refuses non-zero with no write"

--- a/claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh
+++ b/claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh
@@ -71,7 +71,9 @@ run_case() {   # $1 = script under test, $2… = the invocation's arguments
 	shift
 	: > "$LOG"
 	ERR="$TMP/err"
-	OUT="$(PCLI_LOG="$LOG" CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$script" "$@" 2>"$ERR")"
+	# The wrapper's own stdout is the verb's, which the stub does not print — the recorded argv is
+	# the observation, so stdout is parked in a file rather than captured.
+	PCLI_LOG="$LOG" CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$script" "$@" >"$TMP/out" 2>"$ERR"
 	RC=$?
 	ARGV="$(cat "$LOG")"
 	ERRTEXT="$(cat "$ERR")"


### PR DESCRIPTION
Triage's `apply-triage.sh` used to accept arguments it never passed on. Ask it to park an issue with `--status needs-info` and it would take the flag, throw it away, exit 0, and stamp `status:triaged` instead — the label that makes an issue *pickable*. So the hold you thought you applied left the issue open for the next coder to grab, and nothing anywhere said so. This PR makes the wrapper forward every argument it is given, or refuse loudly and write nothing.

Fixes #4936

## Which fork this took, and why

The issue named two candidate forks — **refuse extras** or **thread `--status` through**. This PR does **both**, because either alone leaves a hole:

- **Thread `--status` through.** Refusal alone would leave `triage/SKILL.md`'s own Step-6 instruction ("Pass `--status <stage>` to target a different lifecycle stage") unusable, forcing a prose retraction of a capability the underlying `tracker apply-triage` verb has supported since #4042. The flag is now parsed and forwarded.
- **Refuse what cannot be forwarded.** Threading alone leaves the arity half open: `apply-triage.sh <N> <type> <priority> extra` has no leading dash, so the flag-shaped refusal #4854 will land corpus-wide never sees it. The positional count is now exact, not `-ge`.

This stays the single call site. The corpus-wide leading-dash sweep is **#4854's**, unchanged and not pre-empted — this PR adds no shared helper and touches no sibling script.

## What changed

`claude-plugins/kampus-pipeline/skills/triage/scripts/apply-triage.sh` — an explicit parse replaces the positional grab:

| invocation | before | now |
|---|---|---|
| `<N> <type> <priority>` | applies type/priority/`triaged` | unchanged, byte-for-byte in the verb's argv |
| `<N> <type> <priority> --status <stage>` | **flag dropped, `triaged` applied, exit 0** | `--status` forwarded |
| `<N> --status needs-info` (the park) | usage error — inexpressible | forwarded, no type, no priority |
| `<N> <type> <priority> extra` | **`extra` dropped, exit 0** | refused, exit 2 |
| an unknown flag / `--status` with no stage / `--status` twice / non-numeric `<N>` | absorbed or dropped | refused, exit 2 |

The park form is new capability, not scope creep: `needs-info` is defined as un-classified, so the CLI's `classify` refuses it alongside a type or a priority. Without a bare-`<N>` shape, the exact invocation the SKILL documents could not be expressed through the wrapper at all.

`claude-plugins/kampus-pipeline/skills/triage/SKILL.md` — Step 6 now shows both shapes and states the no-partial-application contract, so a triager following it literally issues something that works.

## Demonstration

The issue's repro, run against the real verb. It no longer silently succeeds — the flag reaches the domain, which refuses the combination before any label write:

```
$ apply-triage.sh 4936 bug p1 --status needs-info
tracker: status:needs-info parks an entity with no type and no priority, but this judgment
supplies type bug and p1 — drop them, or target a classified stage
exit=1
```

`#4936`'s labels were re-read after that run and are unchanged (`type:bug`, `status:triaged`, `p1`, `axis:pipeline-hardening`) — the refusal is pre-write, so nothing partial landed.

The other malformed shape, and the two well-formed ones (verb stubbed, so the forwarded argv is visible):

```
$ apply-triage.sh 4936 bug p1 extra
apply-triage.sh: expected 3 positionals (<N> <type> <priority>) or 1 (<N>) with --status, got 4
usage: apply-triage.sh <N> <type> <priority> [--status <stage>]
       apply-triage.sh <N> --status <stage>            # the un-classified park (e.g. needs-info)
exit=2

$ apply-triage.sh 4936 --status needs-info
verb argv: tracker apply-triage 4936 --status needs-info
exit=0

$ apply-triage.sh 4936 bug p1
verb argv: tracker apply-triage 4936 --type bug --p p1 --status triaged
exit=0
```

## The harness, and why its assertions have teeth

`claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh` — 11 invocations + 5 mutants, wired into CI's `skills` job beside the sibling executable pins. Two design points, both aimed at the fail-open-harness class:

- **Assertions are on the verb's argv, never on a clean exit.** A clean exit is exactly what the defect produced, so "it exited 0" proves nothing. A forwarded case requires the argv to equal the expected line — not contain it, since a substring match would wave a dropped trailing flag through. A refused case requires non-zero **and zero verb spawns**, which is what "no partial application" means operationally.
- **Each mutant must die for its own named reason.** Every `expect_argv` matches the specific wrong argv the reverted claim produces, never a bare non-zero — a mutant that merely fails to start is also non-zero, and scoring that as "caught" is how a mutation suite passes while testing nothing. Mutants live in a mirrored tree at the same depth as the original so they resolve the shared lib rather than dying at lib resolution, and `mutate` reds if a sed program was a no-op and left the mutant byte-identical. Paths resolve physically (`cd -P` / `pwd -P`) because CI reaches this through the `.claude/skills` symlink, where a folded `..` lands on `.claude/` and every mutant would die for the wrong reason.

The mutants: **M1** the code as filed (`-ge 3` + forward `$1 $2 $3`) — reproduces the drop verbatim; **M2** the unknown-flag arm steps over the flag instead of refusing; **M3** the exact arity relaxed — `extra` dropped, with no leading dash for a flag-shaped guard to catch; **M4** `--status` parsed but not forwarded; **M5** the numeric-`<N>` guard deleted.

Run it: `bash claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh` — 16 OK, exit 0. Pointed at the pre-fix script from `origin/main` it reds on all 11 invocations and all 5 mutants (the byte-identical guard fires, since the sed programs match nothing there).

## Zero scope and unreadable input

The harness refuses on a missing SUT and on a `mktemp -d` that produced no root, each with an ADR-0092 line and exit 1. The wrapper itself has no scan and no zero-scope surface — its "could not run" is `kp_pcli`'s exit 127, which it propagates rather than laundering.

## Deviations

- **Class: narrowed/widened the suggested fix-shape.** Said: pick refuse-extras *or* thread `--status`. Did: both, plus a numeric-`<N>` guard and an unknown-flag refusal the issue did not ask for. Why: the two forks cover disjoint halves of the defect (flag-shaped vs bare-word excess), and the issue's own AC 2 requires the arity half explicitly. Disposition: no action needed — stated above so it is auditable against #4854's later corpus remedy.
- **Class: touched a surface outside the issue's named files.** Said: the wrapper and the SKILL prose. Did: also added one step to `.github/workflows/ci.yml`. Why: an unwired harness is a harness nobody runs, which is the same rot class this ticket is about. Disposition: for the reviewer to judge — it is one `- run:` line beside four sibling pins, and it makes this PR §CP-by-path twice over rather than once.
- **Class: added a capability not in the ACs.** Said: make `--status` apply or fail. Did: also made the bare-`<N>` park form expressible. Why: `classify` forbids type/priority on `needs-info`, so the SKILL's documented example is unreachable without it — threading the flag alone would have produced a loud failure on the one invocation the ticket exists to make work. Disposition: no action needed.
- **Class: left a sibling defect for a follow-up.** Said (in triage's scope ruling): the corpus sweep is #4854's. Did: nothing corpus-wide — no helper in `lib/common.sh`, no sibling script touched. Why: #4854 owns it and this PR must not pre-empt its shape. Disposition: `#4854` owns it, still open.
- **Class: no test asserted the defect.** No existing test covered this wrapper, so none was changed or weakened.
