### PR TITLE
docs(fabrika): single-source the REST-never-GraphQL rule into skill-conventions §11 (#4929)

### DIFF
--- a/claude-plugins/fabrika/docs/README.md
+++ b/claude-plugins/fabrika/docs/README.md
@@ -13,7 +13,7 @@ This directory is the home; the docs themselves land as the foundation epic's la
 
 | Doc | What it fixes | Child |
 |---|---|---|
-| [skill conventions](skill-conventions.md) | the writing discipline every fabrika skill meets — the two-layer split, wrapper sizing, invocation-axis economics, the quality vocabulary and failure-mode taxonomy, checkable completion criteria, the scope law, the literal-invocation rule, the ship gate | #4653 |
+| [skill conventions](skill-conventions.md) | the writing discipline every fabrika skill meets — the two-layer split, wrapper sizing, invocation-axis economics, the quality vocabulary and failure-mode taxonomy, checkable completion criteria, the scope law, the literal-invocation rule, the ship gate, trust and ingestion, the leaf rule, and the REST-never-GraphQL GitHub-access rule | #4653 |
 | [CLI interface convention + contract-spec format](cli-interface-convention.md) | what every fabrika verb owes its caller (`--help` discoverability, uniform output contracts, usage examples) and the shape of the contract a skill derives for the verbs it needs | #4654 |
 | [authoring-brief contract](authoring-brief-contract.md) | the boot document a stateless `/skill-creator` session works from | #4655 |
 | [wire formats](wire-formats.md) | the index of the byte-level agreements two skills meet through — format → owner module → producers/consumers, with the protocol narrative and none of the shape | #4945 |

--- a/claude-plugins/fabrika/docs/skill-conventions.md
+++ b/claude-plugins/fabrika/docs/skill-conventions.md
@@ -285,6 +285,37 @@ evals.
 > [#4891](https://github.com/kamp-us/phoenix/issues/4891) (2026-08-08, in-session), the leaf rule
 > and the eval-enumeration obligation recorded with it.
 
+## 11. GitHub access is REST, never GraphQL
+
+**Every GitHub read and write a fabrika skill or verb makes goes through `gh api` REST, and every
+list read paginates.** This section is where that rule lives; a skill contract cites it and does not
+restate it.
+
+The forcing reason is the org, not taste: kamp-us runs a legacy Projects-classic integration, and
+GraphQL issue and pull-request queries break against it. That rules out the porcelain that silently
+takes the GraphQL path — the projects noun, the `pr`/`issue` edit verbs, the explicit GraphQL
+transport — in favour of the REST form (`gh api repos/…`, `gh api -X PATCH repos/…`). Pagination is
+a **separate** scar riding along: an unpaginated list read returns a plausible first page instead of
+an error, so a verb that reads one page and reports a count reports a wrong one with nothing marking
+it wrong.
+
+**It is single-sourced here because it is a platform fact with an expiry.** The integration is not
+permanent. Stated once, its retirement is one paragraph edited; stated per contract, it is a rule
+every copy can drift from while each author assumes some other copy is authoritative.
+
+**Where it is enforced today — stated so nobody assumes coverage it does not have.** The
+`skill-gh-lint` job ([`.github/workflows/skill-gh-lint.yml`](../../../.github/workflows/skill-gh-lint.yml),
+matchers in [`lint.ts`](../../../packages/pipeline-cli/src/tools/gh-phoenix/lint.ts)) reds on a
+GraphQL-path `gh` invocation anywhere in the corpus it walks and fails closed on zero scope
+([ADR 0092](../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)). That walk is rooted at
+`claude-plugins/kampus-pipeline/`, so **fabrika's own corpus is outside its scope** — here the rule
+is prose held by review, not machine-checked. Extending the walk is its own change; this doc does
+not assume it.
+
+> Source: the org's Projects-classic constraint, carried through v1 as a per-skill standing
+> invariant. Five fabrika contracts each restated it before this section existed
+> ([#4929](https://github.com/kamp-us/phoenix/issues/4929)); they now cite it.
+
 ## What these conventions deliberately do not cover
 
 - **What a verb owes its caller** — `--help` discoverability, output contracts, usage examples —

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -60,9 +60,10 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
   run. `127` = the verb never ran. `3` and up are each verb's own proven outcomes.
 - **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
   a caller reads the status before the bytes.
-- **GitHub reads go through `gh api` REST, never GraphQL** — the org's Projects-classic integration
-  breaks GraphQL — and every list read pages. A pull request that adds its `.decisions/` file past
-  file #100 still claims its number (#725).
+- **GitHub access follows [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql)**
+  — REST, paginated. The reason lives there, not here. What is local to this group: a pull request
+  that adds its `.decisions/` file past file #100 still claims its number (#725), so the paginate
+  half is load-bearing for `adr next`.
 
 ---
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -78,9 +78,9 @@ Every verb obeys these; stated once.
   beside a failure invites reading the bytes without the status.
 - **Common inputs.** `--repo <owner/name>` (default: resolved from the `origin` remote). `--json`
   is the default and only output mode where a shape is JSON; line-grammar verbs say so. GitHub
-  reads go through `gh api` REST, never GraphQL (the org's Projects-classic integration breaks
-  GraphQL), and **every list read paginates** — a truncated page is the un-paginated scar this
-  group exists to close (#4926; v1's `per_page=100` comment reads in `stepR1-verdicts.sh`).
+  access per [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql)
+  — the paginate half is what this group most depends on: a truncated page is the un-paginated scar
+  it exists to close (#4926; v1's `per_page=100` comment reads in `stepR1-verdicts.sh`).
 - **The content gate.** Every externally-authorable byte a verb returns — issue bodies, comments,
   PR bodies, review text — passes through one shared module,
   `packages/fabrika-cli/src/build/content-gate.ts`, before it reaches stdout. Today the gate is

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -84,8 +84,8 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
   run. `127` = the verb never ran. `3` and up are each verb's own proven outcomes.
 - **A non-zero exit is UNKNOWN.** No verb prints a partial or permissive answer on a non-zero exit;
   a caller reads the status before the bytes.
-- **GitHub reads and writes go through `gh api` REST, never GraphQL** — the org's Projects-classic
-  integration breaks GraphQL issue queries — and every list read pages.
+- **GitHub access follows [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql)**
+  — REST, paginated, reads and writes alike. The reason lives there, not here.
 
 ### The shared exit taxonomy for the two writing verbs
 

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -14,9 +14,9 @@ their semantics and their scars — each Grounding section names what the v1 cou
 and what this spec does instead — but no clause defers to one, and none is invoked.
 
 **Substrate.** Effect CLI verbs on the `@effect/platform-node` seam the sibling groups use;
-GitHub access through the same `gh api` REST shape, never GraphQL (the org's Projects-classic
-integration breaks GraphQL issue queries). Named because a spec that leaves the substrate open
-makes the implementer guess (#4734).
+GitHub access per
+[skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql).
+Named because a spec that leaves the substrate open makes the implementer guess (#4734).
 
 ## Verb inventory
 

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -14,10 +14,10 @@ their scars — each Grounding section names what the v1 counterpart gets wrong 
 instead — but no clause defers to one, and none is invoked.
 
 **Substrate.** These verbs are Effect CLI verbs on the `@effect/platform-node` seam already used by
-the sibling groups; GitHub access goes through the same `gh api` REST shape, never GraphQL (the org's
-Projects-classic integration breaks GraphQL issue queries). Named here because
-`cli-interface-convention.md` states no substrate and a spec that leaves it open makes the
-implementer guess ([#4734](https://github.com/kamp-us/phoenix/issues/4734)).
+the sibling groups; GitHub access per
+[skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql).
+Named here because `cli-interface-convention.md` states no substrate and a spec that leaves it open
+makes the implementer guess ([#4734](https://github.com/kamp-us/phoenix/issues/4734)).
 
 ## Verb inventory
 


### PR DESCRIPTION
Fixes #4929

## What changed

`claude-plugins/fabrika/docs/skill-conventions.md` **§11 now owns** the REST-never-GraphQL rule: the constraint, its forcing reason (the org's legacy Projects-classic integration breaks GraphQL issue/PR queries), the paginate-every-list-read corollary, and a named statement of where the rule is machine-checked today.

Five landed skill contracts cite §11 instead of restating it:

| Contract | Was | Now |
|---|---|---|
| `skills/adr/contract.md` | full restatement + the `.decisions/` file-#100 scar | cites §11; keeps only the scar, which is local to `adr next` |
| `skills/build/contract.md` | full restatement + the un-paginated `stepR1-verdicts.sh` scar | cites §11; keeps only the scar |
| `skills/report/contract.md` | full restatement | cites §11 |
| `skills/review/contract.md` | full restatement | cites §11 |
| `skills/triage/contract.md` | full restatement | cites §11 |

The issue named three restatements; the corpus grew to **five** between filing and build (`review` and `build` contracts landed since). All five are converted — the acceptance criterion is written over `claude-plugins/fabrika/skills/**/contract.md`, so it covers them.

`docs/README.md`'s index row for `skill-conventions.md` gains the new topic (that row had also gone stale on §9 and §10).

## Why a fourth prose copy would have been the wrong fix

Three copies look like triple coverage and provide none. No copy is authoritative, so each author assumes some other one is — and any copy can drift silently. This is the documentation twin of a check that cannot see what it is looking for and returns a plausible value instead of an error. §11 says explicitly that it is the owner; the contracts point at it.

## The enforcement gap, stated rather than papered over

A CI job already lints for this: `skill-gh-lint` (`.github/workflows/skill-gh-lint.yml`, matchers in `packages/pipeline-cli/src/tools/gh-phoenix/lint.ts`) reds on a GraphQL-path `gh` invocation and fails closed on zero scope (ADR 0092).

**Its walk is rooted at `claude-plugins/kampus-pipeline`** — so `claude-plugins/fabrika/**` is **outside its scope**. In fabrika the rule is prose held by review, not machine-checked.

§11 states that gap in the doc rather than implying coverage it does not have. **This PR deliberately does not widen the guard's scope**: that is not in #4929's acceptance criteria, and it is a real behavior change to a fail-closed CI gate over a corpus with different self-exemption needs (fabrika contracts must be able to *name* the forbidden forms to explain them, and today only `kampus-pipeline` paths appear in `SELF_EXEMPT_SUFFIXES`). Surfacing it here so it can be triaged as its own item.

Defensive detail while that gap is open: §11 describes the offending porcelain ("the projects noun, the `pr`/`issue` edit verbs, the explicit GraphQL transport") rather than spelling the literal command strings, so the doc cannot itself trip the lint if the walk is ever widened to cover fabrika.

## Acceptance criteria

- [x] `skill-conventions.md` states the constraint once, with its forcing reason and the paginate corollary
- [x] the fabrika skill contracts cite that section; `grep GraphQL claude-plugins/fabrika/skills/**/contract.md` returns only citations (the link text `skill conventions §11 — REST, never GraphQL`), no restatements
- [x] no other section of `skill-conventions.md` is rewritten — the diff there is one appended `## 11` section, nothing else touched
- [x] lands after #4915 (closed 2026-08-08), branched off current `main`, no overlap with its three additions
- [x] no absolute, home-rooted, machine-local or sibling-repo path, no operator name or handle (`leak-guard` clean at commit)

`pipeline-cli cp-classify classify` → `not-control-plane [path-clear-no-content-source]`.

Rabbit hole named in the issue and honored: no general de-duplication sweep across the contracts. One constraint, one section, five citations.
