### PR TITLE
chore(fabrika-cli): tie the exit-code tables together — import the shared seats, check the private ones (#4924)

### DIFF
--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -1,0 +1,165 @@
+/**
+ * Which exit tables in this package must agree, what "agree" means, and the derivation that decides
+ * it — read from the shipped modules' own exports, never from a copied list of numbers.
+ *
+ * `report/codes.ts` is the **base**: the table the writing verbs shipped first, so every other group
+ * seats itself against it rather than the other way round. An aligning group owes the base two
+ * things, and they are different obligations that need different machinery:
+ *
+ *   - **The shared seats carry the same number.** Handled by identity, not by assertion: an aligning
+ *     group *imports* the base's constant (`review/codes.ts` already does; `triage/codes.ts` now does
+ *     too), so a drift is unrepresentable rather than merely detectable. {@link SHARED_SEATS} records
+ *     which meanings are claimed shared, so swapping an import back to a numeral reds instead of
+ *     drifting quietly.
+ *   - **The codes the group adds on its own account clear the base's whole table.** This one cannot
+ *     be an import — the group's private codes are its own — so it is a check, and the check derives
+ *     the base's occupied seats from `report`'s exports. That is the direction that bit: `triage`'s
+ *     `HUMAN_FILED` had to be re-seated `12` because `11` was already `PRECONDITION_UNKNOWN`
+ *     upstream, and it was a human reading both files side by side who caught it (#4924).
+ *
+ * Not every group aligns. `wire` allocates `3`-`6` for entirely different facts and is right to —
+ * see {@link UNALIGNED_GROUPS}, which lists it rather than omitting it, because an omission is
+ * indistinguishable from a group nobody registered.
+ */
+
+import {existsSync, readdirSync, realpathSync} from "node:fs";
+import {join} from "node:path";
+
+/** The group whose table every aligning group seats itself against. */
+export const ALIGNMENT_BASE = "report";
+
+/**
+ * The seats an aligning group shares with the base, as `<group export> → <base export>`.
+ *
+ * The names differ where the group's reading is a documented superset (`triage`'s `ZERO_SCOPE` over
+ * `report`'s `NO_TARGET`), which is why this is a map of names and not a set of numbers: the claim
+ * is that these two meanings sit on one code, and a number cannot say that.
+ */
+export type SharedSeats = Readonly<Record<string, string>>;
+
+/**
+ * The seats `triage` and `review` share with `report`. Both groups claim the same eight, so the map
+ * is written once.
+ */
+export const SHARED_SEATS: SharedSeats = {
+	EMPTY_STDIN: "EMPTY_STDIN",
+	LEAKED_PATH: "LEAKED_PATH",
+	BARE_AT_PATH: "BARE_AT_PATH",
+	ZERO_SCOPE: "NO_TARGET",
+	WRITE_UNKNOWN: "WRITE_UNKNOWN",
+	READBACK_MISMATCH: "READBACK_MISMATCH",
+	OFF_VOCABULARY: "CLASSIFIED",
+	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
+};
+
+/** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
+export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
+	triage: SHARED_SEATS,
+	review: SHARED_SEATS,
+};
+
+/**
+ * The groups that deliberately do **not** align, and the reason each is exempt. A group listed here
+ * is a decision; a group listed nowhere is drift, which is what
+ * {@link codeTableGroupsIn} exists to surface.
+ */
+export const UNALIGNED_GROUPS: Readonly<Record<string, string>> = {
+	wire: "3-6 are ABSENT / MALFORMED / EMPTY_ARTIFACT / ARTIFACT_UNKNOWN — a different vocabulary about artifacts, not about writes",
+};
+
+/**
+ * The export every aligned table uses for the code it deliberately leaves empty. Excluded from a
+ * table's allocations: reading a gap as an allocation reports a collision on a seat nobody sits in.
+ */
+export const GAP_EXPORT = "DELIBERATE_GAP";
+
+/** A code table as its module namespace — every numeric export is a code the group speaks. */
+export type CodeTable = object;
+
+/** `code → the exports that name it`, so a table that seats two meanings on one code shows up too. */
+export const allocatedCodes = (table: CodeTable): ReadonlyMap<number, readonly string[]> => {
+	const byCode = new Map<number, string[]>();
+	for (const [name, value] of Object.entries(table)) {
+		if (name === GAP_EXPORT || typeof value !== "number") continue;
+		const names = byCode.get(value);
+		if (names === undefined) byCode.set(value, [name]);
+		else names.push(name);
+	}
+	return byCode;
+};
+
+/** The codes a group allocates on its own account: everything outside the seats it shares. */
+export const privateCodes = (
+	table: CodeTable,
+	seats: SharedSeats,
+): ReadonlyMap<number, readonly string[]> => {
+	const shared = new Set(Object.keys(seats));
+	const own = new Map<number, readonly string[]>();
+	for (const [code, names] of allocatedCodes(table)) {
+		const ownNames = names.filter((name) => !shared.has(name));
+		if (ownNames.length > 0) own.set(code, ownNames);
+	}
+	return own;
+};
+
+/** A shared seat whose two constants no longer sit on one code. */
+export interface SeatDrift {
+	readonly groupExport: string;
+	readonly baseExport: string;
+	readonly groupCode: unknown;
+	readonly baseCode: unknown;
+}
+
+/** A code a group added on its own account that the base already spoke for. */
+export interface Collision {
+	readonly code: number;
+	readonly groupExports: readonly string[];
+	readonly baseExports: readonly string[];
+}
+
+/** Both obligations, evaluated over the live modules. Empty arrays are the aligned state. */
+export interface AlignmentReport {
+	readonly drifted: readonly SeatDrift[];
+	readonly collisions: readonly Collision[];
+}
+
+export const checkAlignment = (
+	base: CodeTable,
+	group: CodeTable,
+	seats: SharedSeats,
+): AlignmentReport => {
+	const baseValues = base as Readonly<Record<string, unknown>>;
+	const groupValues = group as Readonly<Record<string, unknown>>;
+
+	const drifted: SeatDrift[] = [];
+	for (const [groupExport, baseExport] of Object.entries(seats)) {
+		const groupCode = groupValues[groupExport];
+		const baseCode = baseValues[baseExport];
+		if (groupCode !== baseCode || typeof groupCode !== "number") {
+			drifted.push({groupExport, baseExport, groupCode, baseCode});
+		}
+	}
+
+	const occupied = allocatedCodes(base);
+	const collisions: Collision[] = [];
+	for (const [code, groupExports] of privateCodes(group, seats)) {
+		const baseExports = occupied.get(code);
+		if (baseExports !== undefined) collisions.push({code, groupExports, baseExports});
+	}
+
+	return {drifted, collisions};
+};
+
+/**
+ * The `<group>/codes.ts` tables that actually exist on disk, so a new group is a registry failure
+ * rather than an unchecked table. Paths resolve physically — a `..` folded across the repo's
+ * `.claude/skills` symlink resolves somewhere else entirely.
+ */
+export const codeTableGroupsIn = (srcDir: string): readonly string[] => {
+	const root = realpathSync(srcDir);
+	return readdirSync(root, {withFileTypes: true})
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.filter((name) => existsSync(join(root, name, "codes.ts")))
+		.sort();
+};

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -1,0 +1,77 @@
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {
+	ALIGNED_GROUPS,
+	ALIGNMENT_BASE,
+	type CodeTable,
+	checkAlignment,
+	codeTableGroupsIn,
+	UNALIGNED_GROUPS,
+} from "./exit-code-alignment.ts";
+import * as report from "./report/codes.ts";
+import * as review from "./review/codes.ts";
+import * as triage from "./triage/codes.ts";
+import * as wire from "./wire/codes.ts";
+
+const SRC_DIR = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * The registry above names groups; this names the modules. Keeping the two apart is the point: the
+ * coverage test below compares this hand-written set against what is on disk, so a group whose table
+ * nobody registered reds here instead of shipping unchecked.
+ */
+const TABLES: Readonly<Record<string, CodeTable>> = {
+	report,
+	review,
+	triage,
+	wire,
+};
+
+describe("every `<group>/codes.ts` in this package is accounted for", () => {
+	const onDisk = codeTableGroupsIn(SRC_DIR);
+
+	it("finds tables at all — a scan over nothing is a failure, not a pass (ADR 0092)", () => {
+		expect(onDisk.length).toBeGreaterThan(0);
+	});
+
+	it("classifies each one as the base, aligned, or deliberately unaligned", () => {
+		const registered = new Set([
+			ALIGNMENT_BASE,
+			...Object.keys(ALIGNED_GROUPS),
+			...Object.keys(UNALIGNED_GROUPS),
+		]);
+		expect([...onDisk].sort()).toEqual([...registered].sort());
+	});
+
+	it("holds a module for each, so no registered group is checked against nothing", () => {
+		expect(Object.keys(TABLES).sort()).toEqual([...onDisk].sort());
+	});
+});
+
+describe.each(Object.entries(ALIGNED_GROUPS))("`%s` against `report`", (group, seats) => {
+	const table = TABLES[group];
+
+	it("has a module to check", () => {
+		expect(table).toBeDefined();
+	});
+
+	it("seats every shared meaning on the base's number", () => {
+		expect(checkAlignment(report, table as CodeTable, seats).drifted).toEqual([]);
+	});
+
+	it("adds no code the base already spoke for", () => {
+		expect(checkAlignment(report, table as CodeTable, seats).collisions).toEqual([]);
+	});
+});
+
+/**
+ * `wire` is the control: it is registered as unaligned, and it would fail the alignment check it is
+ * exempt from. Without this, "unaligned" could quietly come to mean "aligned anyway" and the
+ * exemption would stop carrying information.
+ */
+describe("the unaligned groups are genuinely unaligned", () => {
+	it("`wire` does not share the base's seats", () => {
+		const {drifted} = checkAlignment(report, wire, ALIGNED_GROUPS.triage ?? {});
+		expect(drifted.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -6,17 +6,31 @@
  * bootstrap in `../bin.ts`); everything else here is `3` and up, the band a verb owns for outcomes
  * it PROVED.
  *
- * **The alignment with `report` is deliberate and code-for-code.** Where this table overlaps
- * `report`'s two writing verbs — `3`, `5`, `6`, `7`, `8`, `9`, `10`, `11` — the meanings match
- * `../report/codes.ts` exactly, so a caller driving `report` and `triage` in one sweep reads one
- * meaning. That alignment does **not** extend repo-wide: `adr` allocates per verb, and `report
- * dedup`'s own `3`/`4` are *queue unreadable* / *search index unreadable*.
+ * **The alignment with `report` is deliberate, code-for-code, and re-exported rather than
+ * re-typed.** Where this table overlaps `report`'s two writing verbs — `3`, `5`, `6`, `7`, `8`, `9`,
+ * `10`, `11` — the values are *imported* from `../report/codes.ts`, so a caller driving `report` and
+ * `triage` in one sweep reads one meaning and a drift between the two is unrepresentable rather than
+ * merely detectable (`../review/codes.ts` set the precedent; `../exit-code-alignment.ts` owns the
+ * policy and checks the direction an import cannot cover — that the codes added below clear
+ * `report`'s whole table). That alignment does **not** extend repo-wide: `adr` allocates per verb,
+ * and `report dedup`'s own `3`/`4` are *queue unreadable* / *search index unreadable*.
  *
  * **`4` is a deliberate gap, not a free slot.** It once held "the target issue does not exist, or is
  * not readable" — a proven fact and an unknown fused into one code. {@link ZERO_SCOPE} and
  * {@link PRECONDITION_UNKNOWN} took the halves; leaving `4` unallocated keeps the alignment with
  * `report file`, where it is a body-section failure no verb here performs.
  */
+
+import {
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
 
 /** The answer is on stdout. Restated here because {@link TRIAGE_EXIT_TABLE} spans the whole matrix. */
 const ANSWER = 0;
@@ -26,16 +40,16 @@ const FAILED = 1;
 const NO_IMPLEMENTATION = 2;
 
 /** Stdin was read and held nothing. Distinct from a read that failed, which is `1`. */
-export const EMPTY_STDIN = 3;
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
 /** The **authored** text carries a machine-local path and it was not redacted. */
-export const LEAKED_PATH = 5;
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
 /**
  * The **authored** text is a bare `@` path reference — **not** redactable.
  *
  * Separate from {@link LEAKED_PATH} because the fixes are opposite: the caller's loop on a path
  * refusal is *redact and re-send*, and on a body that IS a path that loop never terminates.
  */
-export const BARE_AT_PATH = 6;
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
 /**
  * Zero scope: a read that succeeded over nothing, an absent label vocabulary, or a target issue
  * **proven absent (404)** or closed — a fail-closed refusal (ADR 0092).
@@ -43,7 +57,7 @@ export const BARE_AT_PATH = 6;
  * *Proven* is the operative word. A 404 is a fact about the repository; an unreachable GitHub is not
  * a fact about anything, and lands on {@link PRECONDITION_UNKNOWN} instead.
  */
-export const ZERO_SCOPE = 7;
+export const ZERO_SCOPE = REPORT_NO_TARGET;
 /**
  * The write itself failed, so the outcome is **UNKNOWN** — deliberately not `1`.
  *
@@ -53,9 +67,9 @@ export const ZERO_SCOPE = 7;
  * message carries its recovery instruction, because a blind retry is how one split becomes two
  * children.
  */
-export const WRITE_UNKNOWN = 8;
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
 /** The write landed but the read-back does not match. The artifact exists and needs a human. */
-export const READBACK_MISMATCH = 9;
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
 /**
  * The supplied classification value is not permitted in this position — off a closed enum, or a
  * `--home` naming a milestone that is not open.
@@ -64,15 +78,17 @@ export const READBACK_MISMATCH = 9;
  * type or priority. A closed milestone is an off-vocabulary home, so it belongs with the enum
  * refusals rather than with the shape errors.
  */
-export const OFF_VOCABULARY = 10;
+export const OFF_VOCABULARY = REPORT_CLASSIFIED;
 /** A precondition read failed — nothing was written and no outcome is proven. `report`'s `11`. */
-export const PRECONDITION_UNKNOWN = 11;
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
 /**
  * Refused: the issue is human-filed.
  *
  * `12`, not `11`, because `11` already means `PRECONDITION_UNKNOWN` in the shipped `report` table
  * this group aligns to. Issue #4831's acceptance criteria state `11`/`12` for this pair; the merged
- * contract's `12`/`13` wins, and the divergence is disclosed rather than silently resolved.
+ * contract's `12`/`13` wins, and the divergence is disclosed rather than silently resolved. That
+ * clearance is now checked both ways — `../exit-code-alignment.ts` reds if either table moves into
+ * the other's seat.
  */
 export const HUMAN_FILED = 12;
 /** Refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159). */

--- a/packages/fabrika-cli/src/triage/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/codes.unit.test.ts
@@ -1,5 +1,7 @@
 import {describe, expect, it} from "vitest";
+import {checkAlignment, SHARED_SEATS} from "../exit-code-alignment.ts";
 import * as report from "../report/codes.ts";
+import * as codes from "./codes.ts";
 import {
 	BARE_AT_PATH,
 	DELIBERATE_GAP,
@@ -44,6 +46,16 @@ describe("the two codes this group adds", () => {
 	it("seats the unconfirmed-kill refusal on its own code", () => {
 		expect(UNCONFIRMED).toBe(13);
 		expect(UNCONFIRMED).not.toBe(HUMAN_FILED);
+	});
+
+	/**
+	 * The pairwise checks above name one `report` constant each, so a *new* code added upstream at
+	 * `12` or `13` would land on top of this group and every one of them would stay green. This reads
+	 * the base's occupied seats off its exports instead, which is the only form that covers a code
+	 * nobody has written yet (#4924).
+	 */
+	it("clears every seat `report` occupies, read from its exports and not a list", () => {
+		expect(checkAlignment(report, codes, SHARED_SEATS).collisions).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
The fabrika CLI has several exit-code tables that are supposed to agree, and until now nothing made
them. This PR ties them together two ways: the numbers a group shares with `report` are now
*imported* from `report` instead of retyped, so they cannot drift apart; and a new module owns the
one thing an import cannot cover — that the codes a group adds on its own account do not land on a
seat `report` already uses. A new `<group>/codes.ts` that nobody registers now turns the suite red
instead of shipping unchecked.

Fixes #4924

## The file set is larger than the issue assumed

The issue was written when there were two `codes.ts`. There are now **four**:

| File | Role |
|---|---|
| `packages/fabrika-cli/src/report/codes.ts` | the base — the table shipped first, that the others seat against |
| `packages/fabrika-cli/src/triage/codes.ts` | aligns to the base on eight seats |
| `packages/fabrika-cli/src/review/codes.ts` | aligns to the base on the same eight (landed in PR #4989, after the issue was filed) |
| `packages/fabrika-cli/src/wire/codes.ts` | deliberately does **not** align — `3`-`6` are `ABSENT` / `MALFORMED` / `EMPTY_ARTIFACT` / `ARTIFACT_UNKNOWN`, a vocabulary about artifacts rather than writes |

So the tie has to cover three tables, and it has to know that the fourth is exempt on purpose. A
registry that simply omitted `wire` would be indistinguishable from a registry that forgot it, so
`wire` is listed with its reason and a control test asserts it would in fact fail the check it is
exempt from.

## Which shape this took, and why

**Both shapes, on the two directions they each fit.** The issue's triage note ruled out merging the
tables — the groups legitimately carry different meanings on shared numbers (`7` is `NO_TARGET` in
`report` and the documented superset `ZERO_SCOPE` in `triage`), and `4` is a gap in one and
`BAD_SECTIONS` in the other. So:

- **The shared seats: made unrepresentable, not asserted.** `triage/codes.ts` now imports its eight
  overlapping values from `report/codes.ts` rather than restating `3`, `5`, `6`, `7`, `8`, `9`, `10`,
  `11` as numerals. This is the shape `review/codes.ts` already used and the repo's standing
  import-don't-re-derive rule. No value and no meaning changed — the numbers are identical, only
  their source is.
- **The private codes: an executable check, because no import can express it.** A group's own codes
  (`triage`'s `HUMAN_FILED = 12`, `review`'s `STALE_HEAD = 12`…) are its own by definition; the
  obligation is that they clear the base's *whole* table, including seats nobody has allocated yet.
  `packages/fabrika-cli/src/exit-code-alignment.ts` derives the base's occupied seats from its
  exports and reds on any group code that lands on one. This is the direction that actually bit —
  `triage`'s `12`/`13` were re-seated by hand because `11` was already taken.
- **Zero scope reds.** The check discovers `<group>/codes.ts` on disk (paths resolved with
  `realpathSync`, so a folded `..` cannot resurrect a false pass) and fails if it finds none, if a
  discovered group is unregistered, or if a registered group has no module behind it — ADR 0092's
  posture, not a vacuous pass.

## Proof by mutation

Four mutants, each run against the full `packages/fabrika-cli` suite, each checked for the
**intended** failing test by name rather than by exit code alone. All four died for their intended
reason; the suite is green before and after.

| Mutant | Intended death |
|---|---|
| `report/codes.ts` allocates a new code at `12` | `triage … clears every seat report occupies`, and `adds no code the base already spoke for` for **both** `triage` and `review` |
| `triage/codes.ts` swaps an imported value back to a numeral (`EMPTY_STDIN = 33`) | the existing by-reference row `EMPTY_STDIN sits on the same number in both groups`, and `seats every shared meaning on the base's number` |
| a new `src/spend/codes.ts` lands unregistered | `classifies each one as the base, aligned, or deliberately unaligned`, and `holds a module for each …` |
| discovery returns nothing (a blinded `codeTableGroupsIn`) | `finds tables at all — a scan over nothing is a failure, not a pass (ADR 0092)` |

The first mutant is the exact scenario the issue names: a new `report` code at `12` used to leave
every assertion green.

## The blocking route is real, and it is an existing one

No CI step was added. The check is vitest, and `packages/fabrika-cli` already declares a `test`
script, so it runs under the discovery-based `packages-tests` job in `.github/workflows/ci.yml`.
That job is in `ci-required`'s `needs:` list and its result is read as `PACKAGES_RESULT`, and the
`packages` path filter covers `packages/**`. A red assertion here reds `ci-required`. Verified by
reading the workflow, not assumed.

## Acceptance criteria

- [x] `triage/codes.unit.test.ts` asserts every code `triage` allocates outside the documented
      overlap is disjoint from every value exported by `report/codes.ts`, derived from the module's
      exports. Adding a `report` code at `12` or `13` turns the suite red (mutant 1).
- [x] The existing eight by-reference overlap assertions are preserved unchanged.
- [x] The tables are not merged and no meaning changed: `7` and `10` keep their superset readings on
      the `triage` side, `4` stays a gap there and `BAD_SECTIONS` in `report`.
- [x] Proven by mutation, restored to green.
- [x] `pnpm typecheck` and `pnpm lint:worktree` clean; the `packages/fabrika-cli` suite green
      (1265 tests, 84 files).

## Deviations

**Class: narrowed/widened the fix shape.**
- *Said:* the issue scopes the deliverable to a test-only change in `triage/codes.unit.test.ts`
  ("the deliverable is a test-only change with no observable behaviour delta").
- *Did:* also changed `triage/codes.ts` to import its eight shared values from `report/codes.ts`, and
  added a new module `packages/fabrika-cli/src/exit-code-alignment.ts` plus its test.
- *Why:* the repo's rule is to prefer making drift unrepresentable over asserting it, and
  `review/codes.ts` was held to exactly that in PR #4989 — leaving `triage` as the one group that
  retypes numerals would have kept a source of drift the AC's check cannot see. The values are
  byte-identical; there is still no behaviour delta.
- *Disposition:* for the reviewer to judge — the AC's own assertion is present and independently
  proven, so this is additive.

**Class: found a sibling defect and did not fix it.**
- *Said:* nothing; the issue predates `review/codes.ts`.
- *Did:* found that `review` seats `STALE_HEAD = 12` / `INCOMPLETE_SCAN = 13` on the same numbers
  `triage` uses for `HUMAN_FILED` / `UNCONFIRMED`, and left both as they are.
- *Why:* whether a group's private band must clear only the base or every sibling group is an
  unrecorded decision, and renumbering a shipped exit code is not a coder's call. The policy I
  encoded is the one the issue states — clear the base — so this stays green deliberately, not by
  oversight.
- *Disposition:* follow-up #5005 filed with both readings and what each implies.
