### PR TITLE
fix(pipeline-cli): the subprocess-budget guard scans every workspace member, not just its own package (#4858)

### DIFF
--- a/.patterns/subprocess-test-budget.md
+++ b/.patterns/subprocess-test-budget.md
@@ -1,7 +1,8 @@
 # The subprocess test tier — one budget, declared at the suite
 
-How a pipeline-cli test that spawns a **real** child process is budgeted, and why the budget is
-never the global vitest default.
+How a test that spawns a **real** child process is budgeted, and why the budget is never the global
+vitest default. The tier covers every workspace member the merge-queue-gating `packages unit tests`
+job runs — everything under `packages/` plus `infra/` — not one package.
 
 ## The shape
 
@@ -15,13 +16,17 @@ agent can't tell "my diff broke something" from "the box was busy."
 
 ## The rule
 
-- One shared constant, [`packages/pipeline-cli/src/test-budget.ts`](../packages/pipeline-cli/src/test-budget.ts)
-  (`SUBPROCESS_TEST_TIMEOUT_MS`), holds the budget and states the *why* once.
+- One constant per package, in that package's `src/test-budget.ts` (`SUBPROCESS_TEST_TIMEOUT_MS`),
+  all on the same 60s ceiling. [`packages/pipeline-cli/src/test-budget.ts`](../packages/pipeline-cli/src/test-budget.ts)
+  is the canonical one and states the *why* once; the others point at it. It is one module per
+  package rather than one for the workspace because these members have no dependency edge between
+  them — a test importing another package's source would invent one. The guard below makes the
+  copies provably identical: a package whose module drifts off the canonical value reds.
 - Declare it **at the suite**, as vitest's third-argument options object — it covers every `it` in
   the file, including ones added later:
 
   ```ts
-  import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts";
+  import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts"; // your own package's
 
   describe("worktree-sweep --execute — against a REAL git repo", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
   	it("removes a clean, idle, unlocked orphan", async () => { … }); // no per-test timeout
@@ -41,10 +46,23 @@ still fails decisively on a genuinely hung child while leaving a >60x margin for
 ## The guard
 
 [`packages/pipeline-cli/src/subprocess-budget.test.ts`](../packages/pipeline-cli/src/subprocess-budget.test.ts)
-scans every `src/**/*.test.ts`, treats an **import of `node:child_process`** as tier membership,
-and reds if any such file has a `describe` without the budget — fail-closed on zero scope
-([ADR 0092](../.decisions/0092-gates-fail-closed-on-zero-scope.md)). So a new spawning suite joins
-the tier by being written, not by being remembered.
+derives its scope from the workspace members declared in `pnpm-workspace.yaml`, keeps the members
+the `packages unit tests` job actually runs, walks every `*.test.ts` in them, treats an **import of
+`node:child_process`** as tier membership, and reds on a suite without the budget, a per-test
+timeout literal, a locally re-declared constant, or a package budget off the canonical value. So a
+new spawning suite joins the tier by being written, not by being remembered — in any package, not
+just its own.
+
+It fails closed on an empty scope and on a **collapsed** one
+([ADR 0092](../.decisions/0092-gates-fail-closed-on-zero-scope.md)). Both matter, because the guard
+spent its first life rooted at its own package directory: it ran, it passed, and it had never looked
+outside `packages/pipeline-cli/`, where three suites elsewhere had no budget at all (#4858). A guard
+that passes because its scope is empty reads exactly like one that passes because the code is clean,
+so "the tier spans more than one member" and "every guarded root contributed members" are asserted
+directly rather than left implied.
+
+`apps/*` is out of tier by construction, not by omission: the only `apps/web` project whose tests
+spawn is `integration`, and `apps/web/vitest.config.ts` sets its `testTimeout` at the project level.
 
 ## See also
 

--- a/packages/fabrika-cli/src/delegate/foreign-checkout.cli.test.ts
+++ b/packages/fabrika-cli/src/delegate/foreign-checkout.cli.test.ts
@@ -13,9 +13,7 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
-
-/** Spawning under a loaded machine outruns vitest's 5s default (the #4014 false red). */
-const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 
 const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
 

--- a/packages/fabrika-cli/src/eval/deterministic-shell-observer.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/deterministic-shell-observer.unit.test.ts
@@ -4,6 +4,7 @@ import {join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 import {observeShellCommand} from "./deterministic-shell-observer.ts";
 import {
 	type DeterministicCommand,
@@ -11,14 +12,6 @@ import {
 	summarizeEvalRows,
 	type TieredEvalCase,
 } from "./deterministic-tier.ts";
-
-/**
- * These suites spawn real children, and a spawn costs far more than vitest's 5s default budget
- * under this repo's normal operating condition (many worktree agents at once). A generous upper
- * bound still fails decisively on a genuinely hung child; raising the global default instead would
- * blunt the 5s budget the pure suites are correctly held to.
- */
-const SUBPROCESS_TEST_TIMEOUT_MS = 60_000;
 
 /** Run an effect against the real Node platform — these suites are about the real OS boundary. */
 const live = <A>(effect: Effect.Effect<A, never, NodeServices.NodeServices>): Promise<A> =>

--- a/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
@@ -13,9 +13,7 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
-
-/** Spawning under a loaded machine outruns vitest's 5s default (the #4014 false red). */
-const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 
 const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
 const EVAL_SET = fileURLToPath(new URL("./fixtures/skill-creator/evals.json", import.meta.url));

--- a/packages/fabrika-cli/src/excess-operand.cli.test.ts
+++ b/packages/fabrika-cli/src/excess-operand.cli.test.ts
@@ -19,13 +19,7 @@ import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {BASE_UNFETCHABLE} from "./adr/resolve-verb.ts";
-
-/**
- * One spawn costs ~2.3s on a CI runner. The contention factor measured between two runs of this file
- * 24 minutes apart was **2.69×** (#4847), so a ceiling is only a margin if it clears that band: 20s
- * is ~8× the per-spawn baseline, while still failing a genuinely wedged spawn well inside the job.
- */
-const SUBPROCESS_TEST_TIMEOUT_MS = 20_000;
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "./test-budget.ts";
 
 const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
 

--- a/packages/fabrika-cli/src/test-budget.ts
+++ b/packages/fabrika-cli/src/test-budget.ts
@@ -1,0 +1,17 @@
+/**
+ * The per-suite timeout every test in this package that spawns a REAL subprocess runs under.
+ *
+ * The rationale, the profiling and the tier rule live once in
+ * [`.patterns/subprocess-test-budget.md`](../../../.patterns/subprocess-test-budget.md) and in
+ * `packages/pipeline-cli/src/test-budget.ts` (#4014); this is the same ceiling, declared here
+ * because workspace members have no source-level dependency edge to import it across.
+ *
+ * This collapses five per-file copies that had drifted to three different numbers (20s / 30s / 60s).
+ * A timeout is an upper bound, not a delay, so landing on the highest of them cannot introduce a
+ * false red; what actually made `excess-operand.cli.test.ts` fast is #4857 taking the network out of
+ * it and cutting twelve spawns to five, and that is untouched here.
+ *
+ * `packages/pipeline-cli/src/subprocess-budget.test.ts` fails closed if this file drifts off that
+ * canonical value, or if a spawning suite in this package does not carry it (#4858).
+ */
+export const SUBPROCESS_TEST_TIMEOUT_MS = 60_000;

--- a/packages/fabrika-cli/src/unknown-subcommand.cli.test.ts
+++ b/packages/fabrika-cli/src/unknown-subcommand.cli.test.ts
@@ -11,9 +11,7 @@
 import {execFileSync} from "node:child_process";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
-
-/** Spawning under a loaded machine outruns vitest's 5s default (the #4014 false red). */
-const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "./test-budget.ts";
 
 const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
 

--- a/packages/fabrika-cli/src/wire/wire.cli.test.ts
+++ b/packages/fabrika-cli/src/wire/wire.cli.test.ts
@@ -9,10 +9,8 @@
 import {execFileSync} from "node:child_process";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 import {ABSENT} from "./codes.ts";
-
-/** One spawn costs ~2.3s on a CI runner; 20s clears the measured 2.69× contention band (#4847). */
-const SUBPROCESS_TEST_TIMEOUT_MS = 20_000;
 
 const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
 

--- a/packages/pipeline-cli/src/subprocess-budget.test.ts
+++ b/packages/pipeline-cli/src/subprocess-budget.test.ts
@@ -1,19 +1,89 @@
 /**
- * The subprocess test tier stays complete: every pipeline-cli test file that spawns a real child
- * process runs its suites under `SUBPROCESS_TEST_TIMEOUT_MS`, never vitest's 5s default (#4014).
+ * The subprocess test tier stays complete across the WHOLE workspace: every test file in a guarded
+ * workspace member that spawns a real child process runs its suites under a named
+ * `SUBPROCESS_TEST_TIMEOUT_MS`, never vitest's 5s default (#4014).
  *
- * Without this the tier is a convention three files happened to follow, and the next spawning suite
- * re-earns the false red under load that #4014 was filed for.
+ * This guard used to root its scan at its own package directory, so it enforced the tier inside
+ * `packages/pipeline-cli/` and reported nothing about anywhere else — it ran, it passed, and it had
+ * never looked (#4858). A guard that passes because its scope is empty is indistinguishable from one
+ * that passes because the code is clean, so the scope is now DERIVED from the declared workspace
+ * members and the scan fails closed on an empty or collapsed one (ADR 0092).
  */
-import {readdirSync, readFileSync} from "node:fs";
-import {join} from "node:path";
+import {existsSync, readdirSync, readFileSync, realpathSync, statSync} from "node:fs";
+import {dirname, join, sep} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "./test-budget.ts";
+import {parseWorkspacePackageGlobs} from "./tools/publish-isolation-guard/publish-isolation-guard.ts";
 
-const SRC = fileURLToPath(new URL(".", import.meta.url));
+/**
+ * The workspace roots this guard covers, mirroring what the `packages unit tests` job actually runs
+ * (`pnpm --filter './packages/**' --filter @kampus/infra run test` in `.github/workflows/ci.yml`) —
+ * that job is the blocking route, via `ci-required`'s `needs:`, so guarding a member the job never
+ * runs would be an assertion with no teeth. `apps/*` is out of tier by construction, not by
+ * omission: `apps/web/vitest.config.ts` sets a project-level `testTimeout` on the only project whose
+ * tests spawn.
+ */
+const GUARDED_WORKSPACE_ROOTS = ["packages", "infra"] as const;
 
-const testFiles = (): readonly string[] =>
-	(readdirSync(SRC, {recursive: true}) as string[]).filter((p) => p.endsWith(".test.ts"));
+/** Physical resolution — the `.claude/skills` symlink's `..` folding can otherwise walk past the root. */
+const repoRoot = (): string => {
+	let dir = realpathSync(dirname(fileURLToPath(import.meta.url)));
+	for (;;) {
+		if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+		const up = dirname(dir);
+		if (up === dir) throw new Error("subprocess-budget: no pnpm-workspace.yaml above this file");
+		dir = up;
+	}
+};
+
+const ROOT = repoRoot();
+
+/** `packages/*` → every child dir of `packages/` carrying a `package.json`. */
+const membersUnder = (glob: string): readonly string[] => {
+	const m = /^(.+)\/\*$/.exec(glob);
+	if (m?.[1] === undefined) return existsSync(join(ROOT, glob, "package.json")) ? [glob] : [];
+	const parent = m[1];
+	const abs = join(ROOT, parent);
+	if (!existsSync(abs)) return [];
+	return readdirSync(abs)
+		.map((name) => `${parent}/${name}`)
+		.filter((rel) => existsSync(join(ROOT, rel, "package.json")));
+};
+
+interface Scope {
+	readonly members: readonly string[];
+	/** Per guarded root, the members it contributed — an empty list is a scope regression, not a pass. */
+	readonly byRoot: ReadonlyMap<string, readonly string[]>;
+}
+
+const workspaceScope = (): Scope => {
+	const globs = parseWorkspacePackageGlobs(readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8"));
+	const byRoot = new Map<string, readonly string[]>();
+	for (const root of GUARDED_WORKSPACE_ROOTS) {
+		const hits = globs.filter((g) => g === root || g.startsWith(`${root}/`)).flatMap(membersUnder);
+		byRoot.set(root, hits);
+	}
+	return {members: [...byRoot.values()].flat().sort(), byRoot};
+};
+
+const SKIP_DIRS = new Set(["node_modules", "dist", ".turbo", "coverage"]);
+
+const testFilesIn = (memberRel: string): readonly string[] => {
+	const out: string[] = [];
+	const walk = (rel: string): void => {
+		const abs = join(ROOT, rel);
+		for (const entry of readdirSync(abs, {withFileTypes: true})) {
+			if (entry.isDirectory()) {
+				if (!SKIP_DIRS.has(entry.name)) walk(join(rel, entry.name));
+			} else if (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.tsx")) {
+				out.push(join(rel, entry.name));
+			}
+		}
+	};
+	if (statSync(join(ROOT, memberRel)).isDirectory()) walk(memberRel);
+	return out;
+};
 
 /**
  * A file that IMPORTS `node:child_process` spawns for real — that import statement is the tier
@@ -23,9 +93,12 @@ const testFiles = (): readonly string[] =>
 const CHILD_PROCESS_IMPORT = /^import\s[^;]*\sfrom\s"node:child_process";$/m;
 
 const spawningTestFiles = (): ReadonlyArray<readonly [string, string]> =>
-	testFiles()
-		.map((rel) => [rel, readFileSync(join(SRC, rel), "utf8")] as const)
+	workspaceScope()
+		.members.flatMap(testFilesIn)
+		.map((rel) => [rel, readFileSync(join(ROOT, rel), "utf8")] as const)
 		.filter(([, src]) => CHILD_PROCESS_IMPORT.test(src));
+
+const packageOf = (rel: string): string => rel.split(sep).slice(0, 2).join("/");
 
 /**
  * Each `describe(` head, sliced up to its factory arrow — the window the `{timeout}` option must
@@ -42,9 +115,34 @@ const describeHeads = (src: string): readonly string[] => {
 	return heads;
 };
 
-describe("every subprocess-spawning test suite carries the subprocess timeout budget (#4014)", () => {
+const DECLARES_BUDGET = /^\s*(?:export\s+)?const\s+SUBPROCESS_TEST_TIMEOUT_MS\s*=\s*([0-9_]+)/m;
+
+/** Every `src/test-budget.ts` in scope — the one place per package the number may be written. */
+const budgetModules = (): ReadonlyArray<readonly [string, string]> =>
+	workspaceScope()
+		.members.map((m) => join(m, "src", "test-budget.ts"))
+		.filter((rel) => existsSync(join(ROOT, rel)))
+		.map((rel) => [rel, readFileSync(join(ROOT, rel), "utf8")] as const);
+
+describe("every subprocess-spawning test suite carries the subprocess timeout budget (#4014, #4858)", () => {
+	it("derives a non-empty workspace scope, and every guarded root contributes (ADR 0092)", () => {
+		const {members, byRoot} = workspaceScope();
+		expect(members.length).toBeGreaterThan(0);
+		expect([...byRoot].filter(([, hits]) => hits.length === 0).map(([root]) => root)).toEqual([]);
+	});
+
 	it("finds subprocess-spawning test files at all — fail closed on zero scope (ADR 0092)", () => {
 		expect(spawningTestFiles().map(([rel]) => rel).length).toBeGreaterThan(0);
+	});
+
+	/**
+	 * The #4858 regression detector. Re-narrowing the scan root to one package leaves every other
+	 * assertion here green — the tier is complete *within* pipeline-cli — so "the tier spans more
+	 * than one workspace member" is the property that has to be asserted directly.
+	 */
+	it("scans beyond its own package — a scope collapsed back to one member reds (#4858)", () => {
+		const packages = new Set(spawningTestFiles().map(([rel]) => packageOf(rel)));
+		expect([...packages].sort().length).toBeGreaterThan(1);
 	});
 
 	it("declares a `{timeout: SUBPROCESS_TEST_TIMEOUT_MS}` on every describe in every such file", () => {
@@ -55,6 +153,42 @@ describe("every subprocess-spawning test suite carries the subprocess timeout bu
 				.filter((head) => !head.includes("SUBPROCESS_TEST_TIMEOUT_MS"))
 				.map((head) => `${rel}: ${head.split("\n")[0]?.trim()}`);
 		});
+		expect(offenders).toEqual([]);
+	});
+
+	/**
+	 * A trailing `}, 30_000)` on an `it` overrides the suite budget, usually downward, which is how
+	 * the tier scattered its number in the first place (`.patterns/subprocess-test-budget.md`). The
+	 * shape is what identifies it — a numeric argument following the callback's closing brace, which
+	 * biome always puts at the start of a line — so neither a number inside a fixture object nor a
+	 * `setInterval(() => {}, 1000)` in a spawned child's inline source is mistaken for a ceiling.
+	 */
+	it("writes no per-test timeout literal — the suite budget is the only ceiling", () => {
+		const offenders = spawningTestFiles().flatMap(([rel, src]) =>
+			(src.match(/^[\t ]*\},\s*\d[\d_]*\s*,?\s*\)/gm) ?? []).map(
+				(hit) => `${rel}: ${hit.replace(/\s+/g, " ")}`,
+			),
+		);
+		expect(offenders).toEqual([]);
+	});
+
+	it("imports the budget instead of re-declaring it — no per-file copies of the number", () => {
+		const offenders = spawningTestFiles()
+			.filter(([, src]) => DECLARES_BUDGET.test(src))
+			.map(
+				([rel]) =>
+					`${rel}: declares SUBPROCESS_TEST_TIMEOUT_MS locally; import it from test-budget.ts`,
+			);
+		expect(offenders).toEqual([]);
+	});
+
+	it("keeps every package's test-budget.ts on the one canonical ceiling", () => {
+		const modules = budgetModules();
+		expect(modules.map(([rel]) => rel).length).toBeGreaterThan(0);
+		const offenders = modules
+			.map(([rel, src]) => [rel, DECLARES_BUDGET.exec(src)?.[1]?.replace(/_/g, "")] as const)
+			.filter(([, value]) => value !== String(SUBPROCESS_TEST_TIMEOUT_MS))
+			.map(([rel, value]) => `${rel}: exports ${value ?? "no SUBPROCESS_TEST_TIMEOUT_MS"}`);
 		expect(offenders).toEqual([]);
 	});
 });

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -313,7 +313,7 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		assert.isFalse(existsSync(deadOwnedWt), "the dead-owner control must still be reclaimed");
 		assert.include(stdout, "live-session");
 		assert.include(stdout, "owner-unknown");
-	}, 30_000);
+	});
 
 	// The #4001 regression, end to end: LIVE_SID stands in for a crew pane that is STILL RUNNING and
 	// has spawned many trees. A tree it launched, whose occupant finished long ago, must become
@@ -344,7 +344,7 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		assert.include(stdout, "launcher-alive");
 
 		git(mainRepo, "worktree", "remove", freshWt);
-	}, 30_000);
+	});
 
 	// The fail-closed half of the presence gate: with no readable registry there is no way to prove
 	// any owner dead, so the sweep must remove NOTHING — not fall back to the age signal.
@@ -364,7 +364,7 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		assert.include(stdout, "registry UNRESOLVED");
 
 		git(mainRepo, "worktree", "remove", wt);
-	}, 30_000);
+	});
 
 	// #3654: a tree whose working dir was cleaned out from under it (a dead session's temp root)
 	// leaves stale `.git/worktrees/<id>` metadata that `git worktree list` keeps surfacing. The

--- a/packages/pipeline-crew-mcp/src/bin.test.ts
+++ b/packages/pipeline-crew-mcp/src/bin.test.ts
@@ -8,6 +8,7 @@
 import {execFile} from "node:child_process";
 import {fileURLToPath} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "./test-budget.ts";
 
 const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
 
@@ -28,7 +29,9 @@ const run = (...args: readonly string[]): Promise<RunResult> =>
 		});
 	});
 
-describe("bin.ts — the session subcommand declares --instance (#3445)", () => {
+describe("bin.ts — the session subcommand declares --instance (#3445)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it("session --help lists --instance, so the flag bind.ts bakes parses instead of aborting", async () => {
 		const {code, stdout} = await run("session", "--help");
 		assert.strictEqual(code, 0, "session --help exits 0");
@@ -40,5 +43,5 @@ describe("bin.ts — the session subcommand declares --instance (#3445)", () => 
 		// the pre-existing flags still render — the additive change didn't drop them.
 		assert.match(stdout, /--role/, "the --role flag is still declared");
 		assert.match(stdout, /--project-root/, "the --project-root flag is still declared");
-	}, 30_000);
+	});
 });

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
@@ -21,6 +21,7 @@ import {Effect, Exit, Layer, Ref} from "effect";
 import {type ChannelNotificationPayload, ChannelSink} from "../edge/index.ts";
 import {Dialer, type InboxEnvelope} from "../peer/index.ts";
 import {stampFromMillis} from "../protocol/index.ts";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 import {
 	crewSocketDialerLayer,
 	inboxServerSocketLayer,
@@ -57,7 +58,9 @@ const leaveStaleSocket = (socketPath: string): Effect.Effect<void> =>
 		});
 	});
 
-describe("crew/channel-server — REAL unix-socket inbox transport", () => {
+describe("crew/channel-server — REAL unix-socket inbox transport", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it.live(
 		"a valid IntakePing crosses the socket, returns an InboxAck, and wakes the recipient",
 		() =>

--- a/packages/pipeline-crew-mcp/src/crew/tracker.rendezvous.socket.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.rendezvous.socket.test.ts
@@ -17,13 +17,16 @@ import {join} from "node:path";
 import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Context, Effect, Layer} from "effect";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 import {resolveRendezvous} from "../tracker/index.ts";
 import {CrewTracker, crewTrackerHostOrDialLayer} from "./tracker.ts";
 
 const hostOrDial = (socketPath: string) =>
 	crewTrackerHostOrDialLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
 
-describe("crew rendezvous — two cwds of one repo, one live registry", () => {
+describe("crew rendezvous — two cwds of one repo, one live registry", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it.live("a peer announced from the repo root is discovered from a nested subdir", () =>
 		Effect.gen(function* () {
 			const root = realpathSync(mkdtempSync(join(tmpdir(), "rendezvous-e2e-")));

--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
@@ -13,6 +13,7 @@ import {NodeFileSystem, NodeSocket} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 import {rendezvousSocketPathFor, TrackerRegistry, trackerServerLayer} from "../tracker/index.ts";
 import {ensureTrackerRunning, tryBecomeTracker} from "./ensure-tracker.ts";
 
@@ -36,7 +37,7 @@ const clientLayer = (socketPath: string) =>
 const reap = (pid: number | undefined) =>
 	pid === undefined ? Effect.void : Effect.try(() => process.kill(pid)).pipe(Effect.ignore);
 
-describe("tryBecomeTracker — the bind-outcome core", () => {
+describe("tryBecomeTracker — the bind-outcome core", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
 	it.effect("start-if-absent: an unbound socket is won ('started') and served afterward", () => {
 		const socketPath = freshSocketPath();
 		return Effect.gen(function* () {
@@ -68,7 +69,9 @@ describe("tryBecomeTracker — the bind-outcome core", () => {
 	);
 });
 
-describe("ensureTrackerRunning — the detached standing process", () => {
+describe("ensureTrackerRunning — the detached standing process", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	// `it.live`, not `it.effect`: this spawns a real detached node process and polls the socket with
 	// real-time `Effect.sleep` — the default TestClock would freeze that poll (sleep never elapses).
 	it.live(
@@ -107,6 +110,5 @@ describe("ensureTrackerRunning — the detached standing process", () => {
 				Effect.ensuring(Effect.sync(() => rmSync(projectDir, {recursive: true, force: true}))),
 			);
 		},
-		30_000,
 	); // two real detached node child spawns (each ~1-3s of node + TS + Effect startup)
 });

--- a/packages/pipeline-crew-mcp/src/test-budget.ts
+++ b/packages/pipeline-crew-mcp/src/test-budget.ts
@@ -1,0 +1,12 @@
+/**
+ * The per-suite timeout every test in this package that spawns a REAL subprocess runs under.
+ *
+ * The rationale, the profiling and the tier rule live once in
+ * [`.patterns/subprocess-test-budget.md`](../../../.patterns/subprocess-test-budget.md) and in
+ * `packages/pipeline-cli/src/test-budget.ts` (#4014); this is the same ceiling, declared here
+ * because workspace members have no source-level dependency edge to import it across.
+ *
+ * `packages/pipeline-cli/src/subprocess-budget.test.ts` fails closed if this file drifts off that
+ * canonical value, or if a spawning suite in this package does not carry it (#4858).
+ */
+export const SUBPROCESS_TEST_TIMEOUT_MS = 60_000;

--- a/packages/pipeline-crew-mcp/src/tracker/rendezvous.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/rendezvous.test.ts
@@ -15,6 +15,7 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 import {
 	canonicalizeGitCommonDir,
 	RendezvousResolutionError,
@@ -35,7 +36,9 @@ const makeRepo = (label: string): string => {
 	return root;
 };
 
-describe("canonicalizeGitCommonDir — the relative-to-cwd trap (ADR 0197)", () => {
+describe("canonicalizeGitCommonDir — the relative-to-cwd trap (ADR 0197)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it("resolves the bare `.git` reading against the main checkout it was read from", () => {
 		assert.strictEqual(canonicalizeGitCommonDir(".git", "/repo"), "/repo/.git");
 	});
@@ -47,7 +50,9 @@ describe("canonicalizeGitCommonDir — the relative-to-cwd trap (ADR 0197)", () 
 	});
 });
 
-describe("resolveRendezvous — one repo, one rendezvous", () => {
+describe("resolveRendezvous — one repo, one rendezvous", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it.effect("converges from the repo root, a nested subdir, and a linked worktree", () =>
 		Effect.gen(function* () {
 			const root = makeRepo("converge");
@@ -107,7 +112,9 @@ describe("resolveRendezvous — one repo, one rendezvous", () => {
 	);
 });
 
-describe("rendezvousSocketPathFor — the key is the only input", () => {
+describe("rendezvousSocketPathFor — the key is the only input", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it("honors XDG_RUNTIME_DIR when set", () => {
 		const previous = process.env.XDG_RUNTIME_DIR;
 		process.env.XDG_RUNTIME_DIR = "/run/user/501";

--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -13,6 +13,7 @@ import {NodeFileSystem, NodeSocket} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
 import {TrackerRegistry} from "./group.ts";
 import {rendezvousSocketPathFor} from "./rendezvous.ts";
 import {isTrackerAddressInUse, trackerServerLayer} from "./server.ts";
@@ -22,7 +23,9 @@ import {isTrackerAddressInUse, trackerServerLayer} from "./server.ts";
 const hostedTracker = (socketPath: string) =>
 	trackerServerLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
 
-describe("tracker socket path — derived from the canonical repo key", () => {
+describe("tracker socket path — derived from the canonical repo key", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it("is deterministic in the repo key", () => {
 		assert.strictEqual(
 			rendezvousSocketPathFor("/repo/.git"),
@@ -35,7 +38,9 @@ describe("tracker socket path — derived from the canonical repo key", () => {
 	});
 });
 
-describe("tracker served surface — control-plane only", () => {
+describe("tracker served surface — control-plane only", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it("serves exactly the six registry kinds and no message-relay kind", () => {
 		assert.deepStrictEqual([...TrackerRegistry.requests.keys()].sort(), [
 			"AnnouncePresence",
@@ -59,7 +64,9 @@ const socketClientLayer = (socketPath: string) =>
 		Layer.provide([NodeSocket.layerNet({path: socketPath}), RpcSerialization.layerNdjson]),
 	);
 
-describe("tracker over a unix socket — RpcServer round-trip", () => {
+describe("tracker over a unix socket — RpcServer round-trip", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	it.effect("announce then lookup round-trips over layerProtocolSocketServer", () => {
 		const socketPath = join(tmpdir(), `crew-test-${randomUUID().slice(0, 8)}.sock`);
 		return Effect.gen(function* () {
@@ -99,37 +106,35 @@ const leaveStaleSocket = (socketPath: string): Effect.Effect<void> =>
 		});
 	});
 
-describe("tracker stale-socket crash recovery (#3280)", () => {
+describe("tracker stale-socket crash recovery (#3280)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
 	// `it.live`: spawns a real child + SIGKILLs it, so it needs real time, not the frozen TestClock.
-	it.live(
-		"reclaims a crashed host's stale socket and re-hosts the tracker",
-		() => {
-			const socketPath = join(tmpdir(), `crew-stale-${randomUUID().slice(0, 8)}.sock`);
-			return Effect.gen(function* () {
-				// Strand the stale socket BEFORE the tracker layer is built — the layer runs reclaim at
-				// build time, so building it must observe the crashed host's orphaned file, not a clean path.
-				yield* leaveStaleSocket(socketPath);
-				assert.isTrue(
-					existsSync(socketPath),
-					"expected a stale socket file after the simulated crash",
-				);
-				// Build the server FIRST so it reclaims the stale file and is listening, THEN dial a client
-				// (the production sequencing: `crewTrackerHostOrDialLayer` provides the client onto the
-				// hosted server). A successful round-trip proves the reclaim re-hosted the tracker.
-				yield* Layer.build(hostedTracker(socketPath));
-				const result = yield* Effect.gen(function* () {
-					const client = yield* RpcClient.make(TrackerRegistry);
-					yield* client.AnnouncePresence({
-						peer: "inbox://peer-a",
-						role: "builder",
-					});
-					return yield* client.LookupRole({role: "builder"});
-				}).pipe(Effect.provide(socketClientLayer(socketPath)));
-				assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
-			}).pipe(Effect.scoped);
-		},
-		20_000,
-	); // a real node child spawn + SIGKILL + rebind (node + TS + Effect startup)
+	it.live("reclaims a crashed host's stale socket and re-hosts the tracker", () => {
+		const socketPath = join(tmpdir(), `crew-stale-${randomUUID().slice(0, 8)}.sock`);
+		return Effect.gen(function* () {
+			// Strand the stale socket BEFORE the tracker layer is built — the layer runs reclaim at
+			// build time, so building it must observe the crashed host's orphaned file, not a clean path.
+			yield* leaveStaleSocket(socketPath);
+			assert.isTrue(
+				existsSync(socketPath),
+				"expected a stale socket file after the simulated crash",
+			);
+			// Build the server FIRST so it reclaims the stale file and is listening, THEN dial a client
+			// (the production sequencing: `crewTrackerHostOrDialLayer` provides the client onto the
+			// hosted server). A successful round-trip proves the reclaim re-hosted the tracker.
+			yield* Layer.build(hostedTracker(socketPath));
+			const result = yield* Effect.gen(function* () {
+				const client = yield* RpcClient.make(TrackerRegistry);
+				yield* client.AnnouncePresence({
+					peer: "inbox://peer-a",
+					role: "builder",
+				});
+				return yield* client.LookupRole({role: "builder"});
+			}).pipe(Effect.provide(socketClientLayer(socketPath)));
+			assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
+		}).pipe(Effect.scoped);
+	}); // a real node child spawn + SIGKILL + rebind (node + TS + Effect startup)
 
 	it.effect(
 		"leaves a LIVE socket intact — a second bind still gets EADDRINUSE (dial, not reclaim)",


### PR DESCRIPTION
The guard that keeps subprocess-spawning tests off vitest's 5-second default only ever looked inside its own package. It ran on every PR, it passed every time, and it had never read a line of the other 28 workspace packages — where six suites were spawning real child processes with no budget at all, on the job whose timeouts eject a PR from the merge queue instead of just reddening it. This widens the guard's scan to the whole workspace, budgets those six suites, and collapses five scattered copies of the timeout constant down to one per package.

Fixes #4858

## What changed

**The guard now derives its scope instead of assuming it.** `packages/pipeline-cli/src/subprocess-budget.test.ts` used to compute `SRC` from `import.meta.url`, which pinned it to `packages/pipeline-cli/src/`. It now walks up to `pnpm-workspace.yaml`, expands the declared `packages:` globs through the existing `parseWorkspacePackageGlobs` seam, and keeps the members the `packages unit tests` job actually runs (`pnpm --filter './packages/**' --filter @kampus/infra run test`). Scope follows the workspace declaration, so a new package cannot fall outside it by being forgotten.

**Three assertions make an empty or collapsed scope red, per ADR 0092:**

- the derived member list is non-empty;
- every guarded root contributed at least one member (a renamed glob reds instead of silently emptying);
- the tier spans **more than one** workspace member. This last one is the #4858 regression detector specifically. Re-narrowing the scan back to `packages/pipeline-cli` leaves every other assertion in the file green — the tier really is complete in there — so "we are looking past our own package" has to be asserted directly, not inferred.

**Six `packages/pipeline-crew-mcp` suites joined the tier.** The issue listed three; a full-tree scan found six files / 14 `describe`s with no budget:

| file | describes |
|---|---|
| `packages/pipeline-crew-mcp/src/bin.test.ts` | 1 |
| `packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts` | 1 |
| `packages/pipeline-crew-mcp/src/crew/tracker.rendezvous.socket.test.ts` | 1 |
| `packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts` | 2 |
| `packages/pipeline-crew-mcp/src/tracker/rendezvous.test.ts` | 3 |
| `packages/pipeline-crew-mcp/src/tracker/server.test.ts` | 4 |

**One constant per package, not five per-file copies.** `packages/fabrika-cli/src/` carried five local re-declarations at three different numbers (20s / 30s / 60s), and `packages/pipeline-crew-mcp/` had none. Both packages now have a `src/test-budget.ts` on the same 60s ceiling as `packages/pipeline-cli/src/test-budget.ts`, and the guard asserts they agree — so the copies are provably identical rather than merely intended to be. It is one module per package because these members have no dependency edge between them; a test importing another package's source would invent one. `.patterns/subprocess-test-budget.md` records that reasoning.

**Four per-test timeout literals removed.** A trailing `}, 30_000)` on an `it` overrides the suite budget downward, which the pattern doc already bans and nothing enforced. Three sat in `packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts` (30s under a 60s suite) and one in `packages/pipeline-crew-mcp/src/bin.test.ts`; two more multi-line forms were in the crew-mcp suites above. A new assertion keeps them out.

## Mutation evidence

Every mutant was checked for **which** assertion killed it, not merely that something went red. Restored to green between each.

| # | mutation | result | assertion that fired |
|---|---|---|---|
| 1 | drop `{timeout}` from `ensure-tracker.test.ts`'s second describe | 1 failed / 5 passed | `declares a {timeout: SUBPROCESS_TEST_TIMEOUT_MS} on every describe` — named `packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts`, which is the proof the scan leaves its own package |
| 2 | re-declare the constant locally in `wire.cli.test.ts` | 1 failed / 5 passed | `imports the budget instead of re-declaring it` — `packages/fabrika-cli/src/wire/wire.cli.test.ts: declares SUBPROCESS_TEST_TIMEOUT_MS locally` |
| 3 | drift `pipeline-crew-mcp/src/test-budget.ts` to `30_000` | 1 failed / 5 passed | `keeps every package's test-budget.ts on the one canonical ceiling` — `exports 30000` |
| 4a | **empty scope** — `GUARDED_WORKSPACE_ROOTS = []` | 4 failed / 2 passed | `derives a non-empty workspace scope` (`expected 0 to be greater than 0`), plus the zero-tier-files, span, and budget-module asserts |
| 4b | a guarded root that matches no member (`"tools"`) | 1 failed / 5 passed | `every guarded root contributes` — `expected [ 'tools' ] to deeply equal []` |
| 5 | **scope collapsed back to `packages/pipeline-cli` only** (the #4858 regression) | 1 failed / 5 passed | `scans beyond its own package` — `expected 1 to be greater than 1`. Note the other five stayed green: this is the mutant the pre-#4858 guard could not detect |
| 6 | plant `}, 30_000);` on an `it` in `bin.test.ts` | 1 failed / 6 passed | `writes no per-test timeout literal` |

Two false positives were caught while writing assertion 6 and fixed rather than tolerated: a first draft flagged `total_tokens: 31_000` in a spawn-guard fixture, and a second flagged `setInterval(() => {}, 1000)` inside a spawned child's inline source. The shipped pattern keys on a numeric argument after a callback's closing brace at the start of a line, which biome's formatting guarantees for a real per-test override.

Scope resolution is physical (`realpathSync` before the walk up to `pnpm-workspace.yaml`), so a symlinked entry point cannot fold `..` past the repo root into a false pass.

## The blocking route, checked rather than assumed

No CI change was needed, and I verified that rather than assuming it:

- `.github/workflows/ci.yml` — `ci-required` declares `needs: [changes, check, unit, packages-tests, actionlint, integration, e2e]`, so `packages-tests` is a genuine predecessor.
- `ci-required` is one of three required status-check contexts on the `main` ruleset (`17377992`), alongside `scan changed files for leaks` and `validate skill frontmatter`.
- `packages-tests` runs when `packages_required` is true, which this diff sets, and unconditionally on `merge_group`.

That is also why the guard's scope stops at `packages/` + `infra/`: guarding a member this job never runs would be an assertion with no teeth. `apps/*` is out of tier for a separate reason recorded in the pattern doc — the only `apps/web` project whose tests spawn is `integration`, and `apps/web/vitest.config.ts` sets its `testTimeout` at the project level.

## Verification

- `pnpm --filter './packages/**' --filter @kampus/infra run test` (the job's exact command): green — pipeline-cli 3036, fabrika-cli 1254, pipeline-crew-mcp 469, all other packages green.
- `pnpm typecheck`: 30/30 tasks green.
- `pnpm lint:worktree`: clean.

## §CP

`pipeline-cli cp-classify classify` returns `control-plane [path-match]` — `packages/pipeline-cli/src/subprocess-budget.test.ts` matches the live `CONTROL_PLANE_RE`. This banks for a human merge rather than auto-shipping.

## Deviations

**Class: narrowed or changed a prior decision.**
- *Said:* AC 3 asks the `packages/fabrika-cli/src/` re-declarations to either import a shared constant or have the pattern doc justify a package-local budget — "one source, not three copies."
- *Did:* Gave the package one `src/test-budget.ts` at `60_000`. That **raises** the `20_000` ceiling PR #4857 measured for `excess-operand.cli.test.ts`, and the same for `wire.cli.test.ts`.
- *Why:* Five copies at three numbers cannot collapse without picking one, and only the maximum is safe — a timeout is an upper bound, so raising it cannot introduce a false red, while lowering `deterministic-shell-observer.unit.test.ts` from 60s could. #4857's actual fix was removing a `git fetch` from a unit test and cutting twelve spawns to five; neither is touched here, and its file still runs in 1.7s locally.
- *Disposition:* For the reviewer to judge. If the measured 20s sizing should govern the package, the one-line change is the value in `packages/fabrika-cli/src/test-budget.ts` — the guard then holds all five files to it.

**Class: fixed more than the issue named.**
- *Said:* Three unbudgeted `pipeline-crew-mcp` files, and the `fabrika-cli` re-declarations.
- *Did:* Six unbudgeted files (triage flagged its list as a floor from code search, not a full-tree grep — the grep finds six), plus four per-test timeout literals, three of which are inside `packages/pipeline-cli` and were invisible to the old guard.
- *Why:* The widened guard reds on all of them, so leaving any would have shipped a red gate.
- *Disposition:* No action needed.

**Class: declined a plausible wider fix.**
- *Said:* Nothing in the issue about `apps/**`.
- *Did:* Left `apps/*` out of the guard's scope.
- *Why:* Its two spawning files are in the `integration` project, which already carries a project-level 120s `testTimeout`, and that project runs in a different job than the one this guard blocks through.
- *Disposition:* Recorded in `.patterns/subprocess-test-budget.md` as out-of-tier by construction, so a later reader does not read it as an oversight.

**Class: chose not to add a CI surface.**
- *Said:* Nothing explicit.
- *Did:* Added no workflow job and did not touch `.github/workflows/` or `packages/pipeline-cli/src/registry.ts`.
- *Why:* The guard already blocks through `packages unit tests` → `ci-required`, verified above. A second surface would be ceremony over an existing route.
- *Disposition:* No action needed.


**(repair round 1) Class: fixed more than the issue named.**
- *Said:* The five `fabrika-cli` re-declarations that existed when this PR was authored.
- *Did:* Collapsed a sixth — `packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts`, which landed on `main` from #5032 while this PR sat in review and declared its own `SUBPROCESS_TEST_TIMEOUT_MS = 30_000`. It now imports from `packages/fabrika-cli/src/test-budget.ts` like the other five.
- *Why:* The merge queue ejected this PR on exactly that file: the widened guard scanned it and red. The guard is correct — the new file is the drift it exists to catch — so the fix is the file, not the guard. No guard assertion was weakened; all seven still pass.
- *Disposition:* No action needed.
