### PR TITLE
chore(fabrika-cli): re-key the eval harness's `write-code` stage to `build` (#4978)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -18,12 +18,25 @@ slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) shipped the corp
   decision artifact. It is a **discriminated union keyed on `stage`**, so a label whose
   shape doesn't match its stage is unrepresentable (make-invalid-states-unrepresentable):
   - `triage` → `{ type, priority, status }`
-  - `write-code` → `{ fixesRef, ciGreen, reviewVerdict }`
+  - `build` → `{ fixesRef, ciGreen, reviewVerdict }`
   - `review-code` → `{ verdict, acFindings }`
   - `review-doc` → `{ verdict, findings }`
   - `ship-it` → `{ merged, mergeSha }`
-- `CorpusManifest` — the frozen ground truth: entries grouped under per-stage keys, each
+- `CorpusManifest` — the frozen ground truth: entries grouped under **live** stage keys, each
   key admitting only that stage's entry (the second half of the unrepresentable guarantee).
+
+### Live stage key vs recorded provenance
+
+`STAGES` is the **live** vocabulary — what `--stage` accepts and what a manifest groups under.
+An entry's own `stage` is **provenance**: the stage that actually produced that row. The two
+coincide for anything measured from now on and differ for the rows the v1 pipeline recorded.
+
+The founder ruling on [#4977](https://github.com/kamp-us/phoenix/issues/4977) fixes what happens
+to those rows: they keep their original key, because re-keying them would republish a v1
+measurement as a fabrika one. So `build` is the live stage, `write-code` is not a stage any more,
+and the three rows in `corpus/build.json` are still keyed `write-code` — the decoder accepts that
+key on an already-recorded row and nowhere else. Read a record's stage key as *what was run*,
+never as a pointer into `STAGES`; joins (the runner, the scorecard) key on the live stage.
 - `decodeManifest(text)` — total: returns a typed `Result` failure (`malformed-json` or
   `schema-mismatch`) on bad input, never throws. `encodeManifest(manifest)` round-trips it.
 
@@ -40,7 +53,7 @@ a stage or call `gh` (that is the runner slice, #1851).
 An entry passes iff the observed `artifact` reproduces its known-good `label`, per stage (ADR 0112 §3):
 
 - `triage` — actual `{type, priority, status}` equals the label.
-- `write-code` — the PR carries the labeled `Fixes #N` + CI green + an independent `review-code: PASS`
+- `build` — the PR carries the labeled `Fixes #N` + CI green + an independent `review-code: PASS`
   (actual `{fixesRef, ciGreen, reviewVerdict}` equals the label).
 - `review-code` — actual verdict + AC-finding **set** match the label (findings compared order- and
   duplicate-insensitively).
@@ -142,7 +155,7 @@ fabrika eval report <rows.json>
 fabrika eval report <rows.json> --json
 
 # price net saving against a baseline (stage × model)
-fabrika eval report <rows.json> --baseline-stage write-code --baseline-model opus-4.8
+fabrika eval report <rows.json> --baseline-stage build --baseline-model opus-4.8
 ```
 
 `<rows.json>` is a serialized `RunRow[]` — the array `collectRuns` emits. `decodeReportInput` is
@@ -154,10 +167,10 @@ total: a malformed body or a shape mismatch exits non-zero with a typed reason, 
 {
   "decisionRef": 1576,                       // the decision this evidence feeds — never made here
   "framing": "This scorecard is measurement feeding the model-tiering decision (#1576); …",
-  "baseline": { "stage": "write-code", "model": "opus-4.8" } | null,
+  "baseline": { "stage": "build", "model": "opus-4.8" } | null,
   "cells": [
     {
-      "stage": "write-code",
+      "stage": "build",
       "model": "opus-4.8" | null,            // reconstructed from the transcript; null when unattributable
       "gradedRuns": 3,                        // pass-rate denominator (includes transcript-missing runs)
       "passedRuns": 2,
@@ -341,7 +354,7 @@ The frozen ground truth lives beside this module as one manifest per stage under
 [`corpus/`](./corpus) (issue [#1854](https://github.com/kamp-us/phoenix/issues/1854)):
 
 - [`corpus/triage.json`](./corpus/triage.json) — triage classifications
-- [`corpus/write-code.json`](./corpus/write-code.json) — write-code outcomes
+- [`corpus/build.json`](./corpus/build.json) — build outcomes (rows recorded by v1 `write-code`)
 - [`corpus/review-code.json`](./corpus/review-code.json) — review-code verdicts
 
 Each file is a `CorpusManifest` whose non-target stage arrays are empty, so it decodes
@@ -367,7 +380,7 @@ The corpus is governed by the **representative-task-set discipline** of ADR
 - **Selection — representative, stable, reproducible-from-id.** An entry is a real
   pipeline input chosen to be small and stable, pinned by its issue/PR **identifier** (never
   "a recent issue"). Each stage seeds the ADR 0112 §1 recorded input (triage
-  [#1227](https://github.com/kamp-us/phoenix/issues/1227), write-code
+  [#1227](https://github.com/kamp-us/phoenix/issues/1227), build
   [#1223](https://github.com/kamp-us/phoenix/issues/1223) →
   [#1224](https://github.com/kamp-us/phoenix/pull/1224), review-code
   [#1199](https://github.com/kamp-us/phoenix/pull/1199)) and adds entries spanning the
@@ -470,7 +483,7 @@ with no edits" is checked against the real shape rather than asserted.
 
 ```bash
 fabrika eval run <evals.json> \
-  --stage <triage|write-code|review-code|review-doc|ship-it> \
+  --stage <triage|build|review-code|review-doc|ship-it> \
   --plugin-dir <the candidate skill's plugin dir> \
   --model <model> \
   [--arms with-skill,without-skill] [--json-schema <schema.json>] \

--- a/packages/fabrika-cli/src/eval/corpus.data.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/corpus.data.unit.test.ts
@@ -16,7 +16,7 @@ const decodeFile = (name: string) =>
 
 describe("committed corpus — every manifest decodes clean (a malformed corpus cannot land)", () => {
 	it("finds the three per-stage manifests on disk", () => {
-		assert.deepStrictEqual(manifestFiles, ["review-code.json", "triage.json", "write-code.json"]);
+		assert.deepStrictEqual(manifestFiles, ["build.json", "review-code.json", "triage.json"]);
 	});
 
 	for (const name of manifestFiles) {
@@ -31,7 +31,7 @@ describe("committed corpus — meaningful pass-rate, not n=1 (seed + ≥2 per st
 	// AC1: each stage manifest seeds the ADR 0112 §1 recorded input plus ≥2 more entries.
 	const expected = [
 		{file: "triage.json", stage: "triage", seed: 1227, min: 3},
-		{file: "write-code.json", stage: "write-code", seed: 1223, min: 3},
+		{file: "build.json", stage: "build", seed: 1223, min: 3},
 		{file: "review-code.json", stage: "review-code", seed: 1199, min: 3},
 	] as const;
 
@@ -49,4 +49,19 @@ describe("committed corpus — meaningful pass-rate, not n=1 (seed + ≥2 per st
 			}
 		});
 	}
+});
+
+describe("committed corpus — the recorded v1 rows keep their provenance (#4977 ruling)", () => {
+	it("build.json's rows are still keyed write-code, not relabelled as fabrika baselines", () => {
+		const result = decodeFile("build.json");
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			const rows = result.success.stages.build;
+			assert.isAtLeast(rows.length, 3);
+			assert.deepStrictEqual(
+				rows.map((row) => row.stage),
+				["write-code", "write-code", "write-code"],
+			);
+		}
+	});
 });

--- a/packages/fabrika-cli/src/eval/corpus.ts
+++ b/packages/fabrika-cli/src/eval/corpus.ts
@@ -9,11 +9,16 @@
  * into a version-controlled ground truth. See ADR 0112.
  *
  * The one non-obvious shape: a corpus entry is a **discriminated union keyed on `stage`**,
- * so a label whose shape doesn't match its stage is *unrepresentable* — the write-code
+ * so a label whose shape doesn't match its stage is *unrepresentable* — the build
  * label `{fixesRef, ciGreen, reviewVerdict}` cannot sit under `stage: "triage"`, whose
  * only admissible label is `{type, priority, status}` (make-invalid-states-unrepresentable).
  * The manifest doubles the guarantee: it groups entries under per-stage keys whose value
  * schema is that stage's entry alone, so a mismatched entry can't even be filed.
+ *
+ * The second non-obvious shape: an entry's `stage` is **recorded provenance** — what actually
+ * produced the row — while a manifest's group key is the **live stage**. The two are the same
+ * for anything measured from now on and differ for the v1 rows the harness already carries.
+ * See the founder ruling on #4977.
  *
  * `decodeManifest` is total — it returns a typed `Result` failure on malformed JSON or a
  * schema mismatch, never a throw.
@@ -21,8 +26,11 @@
 import {Result} from "effect";
 import * as Schema from "effect/Schema";
 
-/** The five graded pipeline stages a corpus entry can label. */
-export const STAGES = ["triage", "write-code", "review-code", "review-doc", "ship-it"] as const;
+/** The live stage vocabulary: what `--stage` accepts and what a manifest groups entries under. */
+export const STAGES = ["triage", "build", "review-code", "review-doc", "ship-it"] as const;
+
+/** One live stage key. Distinct from an entry's `stage`, which may be a recorded v1 name. */
+export type LiveStage = (typeof STAGES)[number];
 
 /** A reproducible input identifier — an issue/PR number (ADR 0112 §1: pinned by identifier). */
 const InputRef = Schema.Int;
@@ -44,15 +52,30 @@ const TriageEntry = Schema.Struct({
 	}),
 });
 
-/** write-code's oracle: the issue it fixes, a green CI, and the review verdict its PR earned. */
-const WriteCodeEntry = Schema.Struct({
+/** build's oracle: the issue it fixes, a green CI, and the review verdict its PR earned. */
+const BuildLabel = Schema.Struct({
+	fixesRef: InputRef,
+	ciGreen: Schema.Boolean,
+	reviewVerdict: Verdict,
+});
+
+const BuildEntry = Schema.Struct({
+	stage: Schema.Literal("build"),
+	inputRef: InputRef,
+	label: BuildLabel,
+});
+
+/**
+ * A row the v1 `write-code` stage recorded, under the same label shape `build` now records.
+ * Its key stays `write-code` because that is what ran — a recorded stage key is provenance, not
+ * a pointer into the live vocabulary, and re-keying it would republish a v1 measurement as a
+ * fabrika one. See the founder ruling on #4977. Nothing new may be filed under it; the live key
+ * `build` is what a manifest groups both under.
+ */
+const RecordedWriteCodeEntry = Schema.Struct({
 	stage: Schema.Literal("write-code"),
 	inputRef: InputRef,
-	label: Schema.Struct({
-		fixesRef: InputRef,
-		ciGreen: Schema.Boolean,
-		reviewVerdict: Verdict,
-	}),
+	label: BuildLabel,
 });
 
 /** review-code's oracle: the verdict plus the acceptance-criteria findings it surfaced. */
@@ -91,7 +114,8 @@ const ShipItEntry = Schema.Struct({
  */
 export const CorpusEntry = Schema.Union([
 	TriageEntry,
-	WriteCodeEntry,
+	BuildEntry,
+	RecordedWriteCodeEntry,
 	ReviewCodeEntry,
 	ReviewDocEntry,
 	ShipItEntry,
@@ -100,15 +124,17 @@ export const CorpusEntry = Schema.Union([
 export type CorpusEntry = typeof CorpusEntry.Type;
 
 /**
- * The frozen, version-controlled ground truth: entries grouped under per-stage keys. Each
+ * The frozen, version-controlled ground truth: entries grouped under LIVE stage keys. Each
  * group's value schema is that stage's entry alone, so a mismatched entry cannot be filed
- * under the wrong stage — the second half of the unrepresentable-invalid guarantee.
+ * under the wrong stage — the second half of the unrepresentable-invalid guarantee. `build`
+ * additionally admits the recorded `write-code` rows, which share its label shape and keep their
+ * own provenance key.
  */
 export const CorpusManifest = Schema.Struct({
 	version: Schema.Int,
 	stages: Schema.Struct({
 		triage: Schema.Array(TriageEntry),
-		"write-code": Schema.Array(WriteCodeEntry),
+		build: Schema.Array(Schema.Union([BuildEntry, RecordedWriteCodeEntry])),
 		"review-code": Schema.Array(ReviewCodeEntry),
 		"review-doc": Schema.Array(ReviewDocEntry),
 		"ship-it": Schema.Array(ShipItEntry),

--- a/packages/fabrika-cli/src/eval/corpus.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/corpus.unit.test.ts
@@ -18,9 +18,9 @@ const validManifest = {
 		triage: [
 			{stage: "triage", inputRef: 1848, label: {type: "chore", priority: "p1", status: "triaged"}},
 		],
-		"write-code": [
+		build: [
 			{
-				stage: "write-code",
+				stage: "build",
 				inputRef: 1848,
 				label: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
 			},
@@ -58,7 +58,7 @@ describe("decodeManifest — a valid manifest per stage round-trips", () => {
 });
 
 describe("CorpusEntry — an unknown stage is rejected", () => {
-	it("rejects an entry whose stage is not one of the five", () => {
+	it("rejects an entry whose stage is neither a live stage nor a recorded one", () => {
 		const result = decodeEntry({stage: "deploy", inputRef: 1, label: {}});
 		assert.isTrue(Result.isFailure(result));
 	});
@@ -79,16 +79,16 @@ describe("CorpusEntry — an unknown stage is rejected", () => {
 });
 
 describe("CorpusEntry — a per-stage label-shape mismatch is rejected", () => {
-	it("rejects a write-code stage carrying a triage-shaped label", () => {
+	it("rejects a build stage carrying a triage-shaped label", () => {
 		const result = decodeEntry({
-			stage: "write-code",
+			stage: "build",
 			inputRef: 1848,
 			label: {type: "chore", priority: "p1", status: "triaged"},
 		});
 		assert.isTrue(Result.isFailure(result));
 	});
 
-	it("rejects a triage stage carrying a write-code-shaped label", () => {
+	it("rejects a triage stage carrying a build-shaped label", () => {
 		const result = decodeEntry({
 			stage: "triage",
 			inputRef: 1848,
@@ -104,6 +104,42 @@ describe("CorpusEntry — a per-stage label-shape mismatch is rejected", () => {
 			label: {verdict: "MAYBE", acFindings: []},
 		});
 		assert.isTrue(Result.isFailure(result));
+	});
+});
+
+// The founder ruling on #4977: a recorded row's stage key is provenance, so the decoder has to keep
+// reading `write-code` even though nothing live is named that any more.
+describe("recorded provenance — a v1 `write-code` row survives the re-key unrelabelled", () => {
+	const recorded = {
+		stage: "write-code",
+		inputRef: 1223,
+		label: {fixesRef: 1223, ciGreen: true, reviewVerdict: "PASS"},
+	};
+
+	it("decodes under the live `build` group without its own key changing", () => {
+		const manifest = {
+			...validManifest,
+			stages: {...validManifest.stages, build: [recorded]},
+		};
+		const result = decodeManifest(JSON.stringify(manifest));
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			assert.strictEqual(result.success.stages.build[0]?.stage, "write-code");
+		}
+	});
+
+	it("is still shape-checked — a triage-shaped label under it is rejected", () => {
+		const result = decodeEntry({
+			stage: "write-code",
+			inputRef: 1223,
+			label: {type: "chore", priority: "p1", status: "triaged"},
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("is not a live stage — STAGES names `build` and not `write-code`", () => {
+		assert.include(STAGES as ReadonlyArray<string>, "build");
+		assert.notInclude(STAGES as ReadonlyArray<string>, "write-code");
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/corpus/build.json
+++ b/packages/fabrika-cli/src/eval/corpus/build.json
@@ -2,7 +2,7 @@
 	"version": 1,
 	"stages": {
 		"triage": [],
-		"write-code": [
+		"build": [
 			{
 				"stage": "write-code",
 				"inputRef": 1223,

--- a/packages/fabrika-cli/src/eval/corpus/review-code.json
+++ b/packages/fabrika-cli/src/eval/corpus/review-code.json
@@ -2,7 +2,7 @@
 	"version": 1,
 	"stages": {
 		"triage": [],
-		"write-code": [],
+		"build": [],
 		"review-code": [
 			{
 				"stage": "review-code",

--- a/packages/fabrika-cli/src/eval/corpus/triage.json
+++ b/packages/fabrika-cli/src/eval/corpus/triage.json
@@ -18,7 +18,7 @@
 				"label": { "type": "chore", "priority": "p1", "status": "triaged" }
 			}
 		],
-		"write-code": [],
+		"build": [],
 		"review-code": [],
 		"review-doc": [],
 		"ship-it": []

--- a/packages/fabrika-cli/src/eval/oracle.ts
+++ b/packages/fabrika-cli/src/eval/oracle.ts
@@ -81,7 +81,7 @@ const TriageArtifact = Schema.Struct({
 	priority: Priority,
 	status: Schema.String,
 });
-const WriteCodeArtifact = Schema.Struct({
+const BuildArtifact = Schema.Struct({
 	fixesRef: Schema.Int,
 	ciGreen: Schema.Boolean,
 	reviewVerdict: Verdict,
@@ -100,7 +100,7 @@ const ShipItArtifact = Schema.Struct({
 });
 
 const decodeTriage = Schema.decodeUnknownResult(TriageArtifact);
-const decodeWriteCode = Schema.decodeUnknownResult(WriteCodeArtifact);
+const decodeBuild = Schema.decodeUnknownResult(BuildArtifact);
 const decodeReviewCode = Schema.decodeUnknownResult(ReviewCodeArtifact);
 const decodeReviewDoc = Schema.decodeUnknownResult(ReviewDocArtifact);
 const decodeShipIt = Schema.decodeUnknownResult(ShipItArtifact);
@@ -124,14 +124,13 @@ const gradeTriage = (label: LabelOf<"triage">, artifact: unknown): Grade => {
 };
 
 /**
- * write-code passes iff the PR carries the labeled `Fixes #N` + CI green + an independent
+ * build passes iff the PR carries the labeled `Fixes #N` + CI green + an independent
  * `review-code: PASS` — i.e. the actual `{fixesRef, ciGreen, reviewVerdict}` equals the label
- * (ADR 0112 §3).
+ * (ADR 0112 §3). The recorded v1 `write-code` rows share this label shape, so they grade here too.
  */
-const gradeWriteCode = (label: LabelOf<"write-code">, artifact: unknown): Grade => {
-	const decoded = decodeWriteCode(artifact);
-	if (Result.isFailure(decoded))
-		return failMalformed(`write-code artifact: ${decoded.failure.message}`);
+const gradeBuild = (label: LabelOf<"build">, artifact: unknown): Grade => {
+	const decoded = decodeBuild(artifact);
+	if (Result.isFailure(decoded)) return failMalformed(`build artifact: ${decoded.failure.message}`);
 	const a = decoded.success;
 	return gradeFields([
 		...cmpScalar("fixesRef", a.fixesRef, label.fixesRef),
@@ -185,8 +184,9 @@ export const gradeEntry = (entry: CorpusEntry, artifact: unknown): Grade => {
 	switch (entry.stage) {
 		case "triage":
 			return gradeTriage(entry.label, artifact);
+		case "build":
 		case "write-code":
-			return gradeWriteCode(entry.label, artifact);
+			return gradeBuild(entry.label, artifact);
 		case "review-code":
 			return gradeReviewCode(entry.label, artifact);
 		case "review-doc":

--- a/packages/fabrika-cli/src/eval/oracle.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/oracle.unit.test.ts
@@ -13,13 +13,22 @@ const cases = {
 		},
 		passing: {type: "chore", priority: "p1", status: "triaged"},
 	},
-	"write-code": {
+	build: {
 		entry: {
-			stage: "write-code",
+			stage: "build",
 			inputRef: 1848,
 			label: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
 		},
 		passing: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
+	},
+	// A recorded v1 row keeps its own stage key (#4977) and must still reach a grader.
+	"write-code": {
+		entry: {
+			stage: "write-code",
+			inputRef: 1223,
+			label: {fixesRef: 1223, ciGreen: true, reviewVerdict: "PASS"},
+		},
+		passing: {fixesRef: 1223, ciGreen: true, reviewVerdict: "PASS"},
 	},
 	"review-code": {
 		entry: {
@@ -71,8 +80,8 @@ describe("gradeEntry — a divergent artifact fails, carrying the observed-vs-ex
 		}
 	});
 
-	it("write-code: a lost review PASS fails with the reviewVerdict diff", () => {
-		const g = gradeEntry(cases["write-code"].entry, {
+	it("build: a lost review PASS fails with the reviewVerdict diff", () => {
+		const g = gradeEntry(cases.build.entry, {
 			fixesRef: 1848,
 			ciGreen: true,
 			reviewVerdict: "FAIL",

--- a/packages/fabrika-cli/src/eval/runner.ts
+++ b/packages/fabrika-cli/src/eval/runner.ts
@@ -25,7 +25,7 @@
 import {Effect, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {reconstructSpend, type StageSpend} from "../spend/token-spend.ts";
-import {type CorpusEntry, type CorpusManifest, STAGES} from "./corpus.ts";
+import {type CorpusEntry, type CorpusManifest, type LiveStage, STAGES} from "./corpus.ts";
 import {type Grade, gradeEntry} from "./oracle.ts";
 
 /**
@@ -162,9 +162,10 @@ export type TranscriptLoader<R = never> = (path: string) => Effect.Effect<string
  * (story 7 → story 6). Each capture run joins to its `CorpusEntry` by (stage, inputRef) for the
  * label; a run whose (stage, inputRef) has no matching corpus entry is skipped (no label to grade
  * against), and a run whose transcript the loader can't find is collected with `TranscriptMissing`.
+ * The join key is the LIVE stage — a recorded row's own provenance key never participates in it.
  */
 export const collectFromCapture = <R>(args: {
-	readonly stage: CorpusEntry["stage"];
+	readonly stage: LiveStage;
 	readonly corpus: CorpusManifest;
 	readonly capture: CaptureManifest;
 	readonly loadTranscript: TranscriptLoader<R>;

--- a/packages/fabrika-cli/src/eval/runner.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/runner.unit.test.ts
@@ -133,7 +133,7 @@ const corpus: CorpusManifest = {
 	version: 1,
 	stages: {
 		triage: [entryA, entryB],
-		"write-code": [],
+		build: [],
 		"review-code": [],
 		"review-doc": [],
 		"ship-it": [],

--- a/packages/fabrika-cli/src/eval/spawn.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/spawn.unit.test.ts
@@ -504,7 +504,7 @@ describe("toCaptureManifest — the existing collector consumes it unchanged", (
 				triage: [
 					{stage: "triage", inputRef: 1, label: {type: "bug", priority: "p0", status: "triaged"}},
 				],
-				"write-code": [],
+				build: [],
 				"review-code": [],
 				"review-doc": [],
 				"ship-it": [],
@@ -576,9 +576,12 @@ describe("flag parsing", () => {
 		assert.strictEqual(parseArms(""), null);
 	});
 
-	it("accepts only real stage names", () => {
+	it("accepts only live stage names", () => {
+		assert.isTrue(isStageName("build"));
 		assert.isTrue(isStageName("review-code"));
 		assert.isFalse(isStageName("review-skill"));
+		// `write-code` survives only as a recorded row's provenance key (#4977) — never as a live stage.
+		assert.isFalse(isStageName("write-code"));
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The live stage vocabulary, asserted where an operator actually meets it: the `fabrika eval`
+ * process (#4978).
+ *
+ * A unit assertion on `STAGES` proves the tuple changed; only a real run proves the flag validation
+ * that reads it did. Both stage flags are checked, because they validate through different code
+ * paths (`isStageName` in `spawn.ts` for `--stage`, a local `isStage` in `command.ts` for
+ * `--baseline-stage`) and a re-key that fixed only one would read green here otherwise.
+ */
+import {execFileSync} from "node:child_process";
+import {mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+/** Spawning under a loaded machine outruns vitest's 5s default (the #4014 false red). */
+const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+const EVAL_SET = fileURLToPath(new URL("./fixtures/skill-creator/evals.json", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to *this* copy rather than whichever install a root pins. */
+const fabrika = (...args: ReadonlyArray<string>): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+const evalRun = (stage: string): Run =>
+	fabrika(
+		"eval",
+		"run",
+		EVAL_SET,
+		"--stage",
+		stage,
+		"--plugin-dir",
+		"/nonexistent-plugin-dir",
+		"--model",
+		"test-model",
+		"--dry-run",
+	);
+
+const emptyRowsFile = (): string => {
+	const path = join(mkdtempSync(join(tmpdir(), "fabrika-stage-vocab-")), "rows.json");
+	writeFileSync(path, "[]\n");
+	return path;
+};
+
+describe("the live stage vocabulary is what fabrika eval accepts", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("--stage build is accepted", () => {
+		const run = evalRun("build");
+		expect(run.code).toBe(0);
+		expect(run.stderr).not.toMatch(/not a known stage/);
+	});
+
+	it("--stage write-code is refused, naming the stages that do exist", () => {
+		const run = evalRun("write-code");
+		expect(run.code).not.toBe(0);
+		expect(run.stderr).toContain("--stage 'write-code' is not a known stage");
+		expect(run.stderr).toContain("build");
+		expect(run.stderr).not.toMatch(/\(.*write-code.*\)/);
+	});
+
+	it("--baseline-stage write-code is refused and --baseline-stage build is accepted", () => {
+		const rows = emptyRowsFile();
+		const refused = fabrika("eval", "report", rows, "--baseline-stage", "write-code");
+		expect(refused.code).not.toBe(0);
+		expect(refused.stderr).toContain("--baseline-stage 'write-code' is not a known stage");
+
+		const accepted = fabrika("eval", "report", rows, "--baseline-stage", "build");
+		expect(accepted.code).toBe(0);
+	});
+});


### PR DESCRIPTION
Fixes #4978

## What changed

The eval harness's live stage vocabulary now names a fabrika skill instead of the superseded v1 one.

- `packages/fabrika-cli/src/eval/corpus.ts` — `STAGES` drops `write-code` and gains `build`; the entry schema splits into `BuildEntry` (the live key) and `RecordedWriteCodeEntry` (the v1 provenance key, same label shape); `CorpusManifest`'s per-stage key is now `build` and admits both; a new exported `LiveStage` type names "a key in the live vocabulary" so it can be told apart from an entry's own `stage`.
- `packages/fabrika-cli/src/eval/oracle.ts` — `WriteCodeArtifact`/`gradeWriteCode` → `BuildArtifact`/`gradeBuild`; the `switch` routes both `build` and the recorded `write-code` to it.
- `packages/fabrika-cli/src/eval/runner.ts` — `collectFromCapture`'s `stage` is typed `LiveStage` rather than `CorpusEntry["stage"]`, because the capture join keys on the live stage and never on a recorded row's provenance key.
- `packages/fabrika-cli/src/eval/corpus/` — `write-code.json` → `build.json` with its group key re-keyed to `build`; the two sibling manifests' empty `"write-code": []` key likewise. **The three recorded rows still carry `"stage": "write-code"`.**
- `packages/fabrika-cli/src/eval/README.md` — the per-stage label list, the worked `--baseline-stage` example, the JSON-shape sample, the corpus file list, the seed list and the `--stage` usage line; plus a new **Live stage key vs recorded provenance** section stating the rule.
- `command.ts` needed no edit — both flags' help text and error messages interpolate `STAGES`, so they re-key with the tuple.

`ship-it` is untouched, per the issue's scope note. `incident-corpus/` and `src/wire/` are untouched.

## The ruling this is built on

Founder ruling on #4977 (comment 5229585322): **recorded provenance wins — old records keep their original stage keys.** A recorded result's stage key is history; re-keying it would republish a v1 measurement as a fabrika one. So the live vocabulary re-keys, and the decoder keeps accepting `write-code` — on an already-recorded row and nowhere else.

## Deviations

**AC3 and AC4 contradict each other under that ruling, and I resolved it in the ruling's favour rather than silently.**

- AC3 requires the three recorded v1 rows to be "disposed exactly as the provenance decision ruled — no row is relabelled as a fabrika-produced baseline". Under the ruling that means they keep their `write-code` stage key.
- AC4 requires that "no `write-code` stage reference remains under `packages/fabrika-cli/src/eval/`". Those rows live under that path.

Both cannot hold. The ruling wins, so AC4 is satisfied in the sense that matters and not literally: `write-code` is gone from the **live** surface — `STAGES`, the manifest group keys, the flags, the docs' worked examples — and survives only as the provenance key on already-recorded rows plus the schema member, grader arm, docs and tests that exist to keep reading it. I did not re-key or delete a recorded row, which is the precise thing the ruling forbids.

Two smaller judgement calls in the same area:

- Prose in `repair-churn.ts` and `README.md` that names the "write-code→review→repair" loop was left alone. It names the pipeline skill, which still exists in this repo at `claude-plugins/kampus-pipeline/skills/write-code/` — it is not a stage reference.
- The recorded rows are grouped under the **live** `build` key in `corpus/build.json` while keeping their own `write-code` stage field. The group key is the live stage (that is what a manifest is keyed on and what the runner joins by); the row's own key is the provenance. Keeping a sixth `write-code` group key instead would have forced every manifest to carry a permanently-dead key — the empty-key rabbit-hole the epic's pitch fences.

## Tests

`TDD: yes` — the failing test came first. `packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts` is new and runs the real process (AC2 asks for behaviour, and a unit assertion on the tuple would not have proved the flag validation that reads it):

- `--stage build` is accepted (exit 0).
- `--stage write-code` is refused, the message names the stages that do exist, and the named list does not contain `write-code`.
- `--baseline-stage write-code` is refused and `--baseline-stage build` is accepted — a second, separate code path (`command.ts`'s local `isStage`) that a half-done re-key would have left green.

Also added: `corpus.unit.test.ts` asserts a recorded `write-code` row decodes under the live `build` group with its own key intact, is still shape-checked, and is not in `STAGES`; `corpus.data.unit.test.ts` asserts the three committed rows are still keyed `write-code`; `spawn.unit.test.ts` asserts `isStageName` accepts `build` and rejects `write-code`.

All three failed before the change and pass after.

## Verification

- `pnpm typecheck` — 30/30 tasks green.
- `packages/fabrika-cli` unit suite — 84 files, 1262 tests, all green.
- `pnpm lint` — clean.
