### PR TITLE
fix(fabrika-cli): key review post's upsert on the carrier, so a §CP advisory re-post edits instead of duplicating (#4992)

### DIFF
--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -708,15 +708,25 @@ With `--json`: `{"outcome":"posted","namespace":…,"polarity":…,"sha":…,"up
    FAIL marker).
 4. **Leak-scan the assembled comment** (`report/leaks.ts`, imported) — an authored machine-local
    path is the `5` refusal.
-5. **Upsert one comment per namespace**: an existing comment by this bot whose first non-blank
-   line carries this namespace's marker is edited in place; otherwise a new comment is created.
-   One namespace, one comment, the marker its literal first line — a second marker stacked on
-   line 2 is un-anchored, resolves its namespace empty, and fail-closes a substantively-passing
-   PR (the live PR #2456 stall).
-6. **Read it back, unconditionally, from live PR state** — re-fetch the comment, hand its body to
-   the format's `read`, and require `Found` with exactly the four fields posted (compared through
-   `normalizeForReadback`). A read-back that trusts a carried variable instead of the live state
-   re-ships #3173's false PASS; the mismatch is the `9` refusal.
+5. **Upsert one comment per namespace, matched under the carrier this post uses**: an existing
+   comment by this bot that already carries this namespace **under this carrier** is edited in
+   place; otherwise a new comment is created. With `marker` the match key is the format's `read`
+   over the first non-blank line. With `--carrier advisory` it is the ADR-0151 pair — the advisory
+   first line plus the `Reviewed-head: @ <sha>` body line, read through `readAdvisory` — because
+   the advisory first line withholds the SHA, so the marker `read` can never match one and a
+   marker-keyed upsert would post a **second** advisory on every re-post. The two keys are
+   disjoint: a `marker` post never edits an advisory comment, and an `advisory` post never edits a
+   marker one. One namespace, one comment, the carrier's anchor on its literal first line — a
+   second marker stacked on line 2 is un-anchored, resolves its namespace empty, and fail-closes a
+   substantively-passing PR (the live PR #2456 stall).
+6. **Read it back, unconditionally, from live PR state**, under the same carrier — re-fetch the
+   comment and, with `marker`, hand its body to the format's `read` and require `Found` with
+   exactly the four fields posted; with `--carrier advisory`, require both ADR-0151 anchors —
+   `readAdvisory` yielding this namespace and a `Reviewed-head:` SHA equal to the one posted, since
+   the format's `read` calls an advisory `Malformed` by design. Either way the whole comment is
+   then compared against the bytes sent (through `normalizeForReadback`). A read-back that trusts a
+   carried variable instead of the live state re-ships #3173's false PASS; the mismatch is the `9`
+   refusal.
 
 **Exit status**
 

--- a/packages/fabrika-cli/src/review/post-verb.ts
+++ b/packages/fabrika-cli/src/review/post-verb.ts
@@ -129,6 +129,23 @@ const mismatchOf = (
 	return bytes;
 };
 
+/**
+ * Whether a comment already holds this namespace's verdict **under this carrier** — step 5's
+ * upsert-match key.
+ *
+ * The key is per-carrier because the two carriers anchor on different bytes, and neither read can
+ * stand in for the other. An advisory withholds the SHA from its first line by design (ADR 0111), so
+ * `read` calls it `Malformed` and a marker-only match never finds a prior advisory: every §CP re-post
+ * created a second comment, against the one-namespace-one-comment invariant this step exists for
+ * (#4992). Matching per carrier also keeps the pair disjoint in the other direction — a marker post
+ * never edits an advisory comment, and vice versa.
+ */
+const carriesNamespace = (body: string, carrier: Carrier, namespace: string): boolean => {
+	if (carrier === "advisory") return readAdvisory(body)?.namespace === namespace;
+	const parsed = readMarker(body);
+	return parsed._tag === "Found" && parsed.value.namespace === namespace;
+};
+
 /** Steps 1, 2 and 5's reads failing is `11`: nothing was written, so the outcome is known-unwritten. */
 const unreadableMessage = (what: string, pr: number, reason: string): string =>
 	`${VERB}: cannot read ${what} for #${pr}: ${reason} — nothing was posted.`;
@@ -236,11 +253,10 @@ export const runPost = (
 		if (me._tag === "Failure") return unreadable("the authenticated user", pr, me.reason);
 		const comments = yield* listComments(repo, pr);
 		if (comments._tag === "Failure") return unreadable("the comments", pr, comments.reason);
-		const mine = comments.value.find((comment) => {
-			if (comment.author !== me.value) return false;
-			const parsed = readMarker(comment.body);
-			return parsed._tag === "Found" && parsed.value.namespace === namespace;
-		});
+		const mine = comments.value.find(
+			(comment) =>
+				comment.author === me.value && carriesNamespace(comment.body, carrier, namespace),
+		);
 
 		let landed: {readonly id: number; readonly url: string} | null = null;
 		let failure: string | null = null;

--- a/packages/fabrika-cli/src/review/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/post-verb.unit.test.ts
@@ -263,6 +263,85 @@ describe("runPost", () => {
 		expect(write).not.toContain(`advisory — ... @ ${HEAD}`);
 	});
 
+	it("edits the existing advisory comment on a re-post, and creates one when there is none", async () => {
+		const advisoryFor = (sha: string): string =>
+			`review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${sha}\n\n${BODY}`;
+		const advisoryOptions = {
+			...options,
+			carrier: "advisory",
+			clause: "blocking-set PR (manual merge)",
+		};
+
+		const fresh = fakeShell([
+			[PULL, pull()],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[READBACK, commentBody(advisoryFor(HEAD))],
+		]);
+		const first = await Effect.runPromise(Effect.provide(runPost(advisoryOptions), fresh.layer));
+		expect(first.code).toBe(0);
+		expect(first.stdout).toContain("\tcreated\t");
+
+		const again = fakeShell([
+			[PULL, pull({comments: 1})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments({id: 42, body: advisoryFor(OLD_HEAD), author: "kampus-bot"})],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, commentBody(advisoryFor(HEAD))],
+		]);
+		const repost = await Effect.runPromise(Effect.provide(runPost(advisoryOptions), again.layer));
+		expect(repost.code).toBe(0);
+		expect(repost.stdout).toContain("\tedited\t");
+		expect(again.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("never crosses the carriers: a marker post skips an advisory comment, and the reverse", async () => {
+		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${OLD_HEAD}\n\n${BODY}`;
+		const overAdvisory = fakeShell([
+			[PULL, pull({comments: 1})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments({id: 42, body: advisory, author: "kampus-bot"})],
+			[CREATE, created],
+			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+		]);
+		const marker = await Effect.runPromise(Effect.provide(runPost(options), overAdvisory.layer));
+		expect(marker.stdout).toContain("\tcreated\t");
+		expect(overAdvisory.calls.some((call) => PATCH.test(call))).toBe(false);
+
+		const overMarker = fakeShell([
+			[PULL, pull({comments: 1})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[
+				COMMENTS,
+				comments({
+					id: 42,
+					body: `review-doc: PASS @ ${OLD_HEAD} — older round`,
+					author: "kampus-bot",
+				}),
+			],
+			[CREATE, created],
+			[
+				READBACK,
+				commentBody(
+					`review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD}\n\n${BODY}`,
+				),
+			],
+		]);
+		const advisoryPost = await Effect.runPromise(
+			Effect.provide(
+				runPost({...options, carrier: "advisory", clause: "blocking-set PR (manual merge)"}),
+				overMarker.layer,
+			),
+		);
+		expect(advisoryPost.stdout).toContain("\tcreated\t");
+		expect(overMarker.calls.some((call) => PATCH.test(call))).toBe(false);
+	});
+
 	it("emits the record with --json", async () => {
 		const out = await run(happy(), {json: true});
 		expect(JSON.parse(out.stdout)).toMatchObject({


### PR DESCRIPTION
When a control-plane review posted its verdict a second time, `fabrika review post` left two
comments instead of editing the first. The upsert only knew how to recognise a first-line verdict
marker, and a §CP advisory deliberately keeps the SHA out of its first line — so the prior advisory
was invisible to it. The upsert now matches on the carrier it is posting under, which restores the
"one namespace, one comment" rule for the advisory path without touching how the marker path
behaves.

Fixes #4992

## What changed

- `packages/fabrika-cli/src/review/post-verb.ts` — step 5's upsert match is now a per-carrier
  predicate: `readAdvisory` (the ADR-0151 pair — advisory first line + `Reviewed-head: @ <sha>`)
  for `--carrier advisory`, the existing marker `read` for `--carrier marker`. The keys are
  disjoint, so a marker post never edits an advisory comment and the reverse. The advisory form
  itself is unchanged — still no bindable first-line `PASS @ <sha>` (ADRs 0111/0151), still
  PASS-only (ADR 0226), still the same §VERDICT key of (PR, namespace, head, run).
- `packages/fabrika-cli/src/review/post-verb.unit.test.ts` — two tests, written first and failing
  before the fix: an advisory re-post over an existing advisory comment reports `edited` and issues
  no create (and a fresh advisory post still reports `created`), plus a carrier-disjointness test
  covering both crossings.
- `claude-plugins/fabrika/skills/review/contract.md` — steps 5 and 6 each name the
  `--carrier advisory` branch, stating the ADR-0151 pair as the upsert-match key and the read-back
  predicate, so the text matches the shipped binary.

No new parser: `advisory.ts` and `wire/verdict-marker.ts` are reused as-is. No comment is edited or
overwritten that this verb did not post — the fix suppresses the duplicate *post*, it does not
mutate foreign comments.

## Verification

- `pnpm typecheck` — green (30/30 tasks).
- `packages/fabrika-cli` review suite — 15 files, 158 tests, green.
- `pnpm lint:worktree` — clean.

## Deviations

None.
