### PR TITLE
fix(ci): skill-gh-lint walks every plugin dir, and reds when it does not (#5004)

### DIFF
--- a/.github/workflows/skill-gh-lint.yml
+++ b/.github/workflows/skill-gh-lint.yml
@@ -21,8 +21,13 @@ name: skill-gh-lint
 # Scans the FULL corpus (not just changed files) so a bad call/frontmatter anywhere
 # is caught regardless of which PR introduced it, and FAILS CLOSED on zero scope per
 # ADR 0092: a lint that scanned nothing is a broken lint, exit 3. The walk roots at
-# the plugin dir so both skills/** and agents/** are covered — a new skill OR agent
-# file is gated automatically.
+# `claude-plugins` — the whole plugin tree, every plugin dir, skills/** and agents/**
+# alike — so a new skill, a new agent, or a whole new PLUGIN is gated automatically.
+# It used to root at `claude-plugins/kampus-pipeline`, which silently excluded the
+# other three plugin dirs (fabrika, pipeline-crew, pipeline-crew-mcp) while the job
+# still reported green: a guard green from an empty corner is indistinguishable from a
+# guard green from clean code (#5004). The per-plugin coverage assertion in the lint
+# step is what now makes that narrowing loud instead of silent.
 on:
   pull_request:
   push:
@@ -51,16 +56,64 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # The corpus lives under claude-plugins/kampus-pipeline/** — skills/** (the
-      # .claude/skills and root skills/ symlinks point into it) AND agents/** (the
-      # subagent definitions, also frontmatter-bearing #1766). Root the walk at the
-      # plugin dir so both are covered; hand the CLI every .md/.sh file. The tool
-      # self-scopes (gh-grep drops self-exempt files; the frontmatter check scopes to
-      # SKILL.md / agents/*.md; the push check takes every .md/.sh) and fails closed
-      # (exit 3) if ANY scope is empty (ADR 0092).
+      # The corpus is the whole `claude-plugins` tree — skills/** (the .claude/skills and
+      # root skills/ symlinks point into it) AND agents/** (the subagent definitions, also
+      # frontmatter-bearing #1766) — across every plugin dir, the same root
+      # trap-status-guard.yml and cli-invocation-guard.yml already walk. Hand the CLI every
+      # .md/.sh file; the tool self-scopes (gh-grep drops self-exempt files; the frontmatter
+      # check scopes to SKILL.md / agents/*.md; the push check takes every .md/.sh) and
+      # fails closed (exit 3) if ANY scope is empty (ADR 0092).
+      #
+      # `set -e` is deliberately absent (.patterns/skill-script-shell-shape.md): every
+      # failure below is a named assertion that prints WHY and exits 3, so a silent abort
+      # can never be read as a pass.
       - name: Lint skill + agent corpus
         run: |
-          set -euo pipefail
-          find claude-plugins/kampus-pipeline -type f \( -name '*.md' -o -name '*.sh' \) -print0 \
-            | sort -z \
-            | xargs -0 node packages/pipeline-cli/src/bin.ts gh-phoenix lint-skills
+          set -uo pipefail
+
+          # The coverage anchor is the literal plugin tree, held SEPARATE from the walk root
+          # on purpose: the assertion below has to stay true when someone narrows the walk.
+          PLUGINS_ROOT=claude-plugins
+          WALK_ROOT=claude-plugins
+
+          # Resolve physically (`cd -P`/`pwd -P`) and compare against an independently
+          # derived path. find(1) does not descend a symlinked root, so a `claude-plugins`
+          # that is a link — or a `..`-folding logical path that resolves elsewhere, which
+          # has produced a false pass in this repo before — would walk nothing.
+          ROOT_PHYS="$(cd -P "$PLUGINS_ROOT" 2>/dev/null && pwd -P)"
+          if [ "$ROOT_PHYS" != "$(pwd -P)/$PLUGINS_ROOT" ]; then
+            echo "skill-gh-lint: FAIL — scan root '$PLUGINS_ROOT' does not physically resolve to \$PWD/$PLUGINS_ROOT (got '${ROOT_PHYS:-<unresolvable>}'); the walk would scan nothing or the wrong tree." >&2
+            exit 3
+          fi
+
+          FILES=()
+          while IFS= read -r -d '' f; do FILES+=("$f"); done \
+            < <(find "$WALK_ROOT" -type f \( -name '*.md' -o -name '*.sh' \) -print0 | sort -z)
+
+          # ADR 0092. This fires BEFORE the CLI's own zero-scope exit 3, because a walk that
+          # matched nothing must not reach a tool that could be handed no arguments at all.
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "skill-gh-lint: FAIL — the walk of '$WALK_ROOT' matched zero files (zero-scope fail-closed, ADR 0092)." >&2
+            exit 3
+          fi
+
+          # The coverage assertion, and the reason this job can no longer go green on a
+          # corner it never looked at (#5004): EVERY plugin dir must contribute at least one
+          # scanned file. Narrow the walk root back to a single plugin and this reds by name,
+          # instead of passing while three quarters of the tree sits outside the gate.
+          UNCOVERED=()
+          for d in "$PLUGINS_ROOT"/*/; do
+            plugin="${d%/}"
+            covered=""
+            for f in "${FILES[@]}"; do
+              case "$f" in "$plugin"/*) covered=1; break ;; esac
+            done
+            [ -n "$covered" ] || UNCOVERED+=("$plugin")
+          done
+          if [ "${#UNCOVERED[@]}" -ne 0 ]; then
+            echo "skill-gh-lint: FAIL — these plugin dirs contributed ZERO scanned files, so the walk does not cover them: ${UNCOVERED[*]}" >&2
+            exit 3
+          fi
+
+          echo "skill-gh-lint: walking ${#FILES[@]} file(s) under '$WALK_ROOT'; every plugin dir under '$PLUGINS_ROOT' is covered."
+          node packages/pipeline-cli/src/bin.ts gh-phoenix lint-skills "${FILES[@]}"

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
@@ -134,6 +134,14 @@ const SELF_EXEMPT_SUFFIXES = [
 	"/skills/write-code/repair.md",
 	"/skills/gh-issue-intake-formats.md",
 	"/packages/pipeline-cli/src/tools/gh-phoenix/README.md",
+	// The one finding the #5004 widening surfaced, and it is prose, not a call: the passage
+	// names `gh issue edit --add-label` to explain why an implementer must NOT reach for it
+	// (that porcelain rejects an unknown label client-side, which would make the contract's
+	// vocabulary precondition look redundant and invite dropping it — after which the REST
+	// call starts minting labels). Naming the forbidden form is the explanation, so the file
+	// is exempt at whole-file granularity, plugin-qualified — never a `fabrika/`- or
+	// `skills/`-wide exemption, which would silently drop future files from a live lint.
+	"/fabrika/skills/triage/contract.md",
 ] as const;
 
 const normalize = (path: string): string => `/${path.replace(/\\/g, "/").replace(/^\/+/, "")}`;

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
@@ -105,6 +105,24 @@ describe("scanFile — flags GraphQL-path gh calls", () => {
 			1,
 		);
 	});
+
+	it("self-exempts fabrika's triage contract per FILE, leaving the rest of fabrika live", () => {
+		assert.isTrue(isSelfExempt("claude-plugins/fabrika/skills/triage/contract.md"));
+		assert.strictEqual(
+			scanFile(
+				"claude-plugins/fabrika/skills/triage/contract.md",
+				"`gh issue edit --add-label` rejects an unknown label client-side",
+			).length,
+			0,
+		);
+		// The exemption is plugin-qualified, so kampus-pipeline's own triage skill stays live.
+		assert.isFalse(isSelfExempt("claude-plugins/kampus-pipeline/skills/triage/contract.md"));
+		assert.isFalse(isSelfExempt("claude-plugins/fabrika/skills/triage/SKILL.md"));
+		assert.strictEqual(
+			scanFile("claude-plugins/fabrika/skills/triage/SKILL.md", "gh issue edit --add-label").length,
+			1,
+		);
+	});
 });
 
 describe("lintCorpus — scope + findings", () => {


### PR DESCRIPTION
The `skill-gh-lint` job only ever looked at one of the four plugin dirs, so the whole `claude-plugins/fabrika/**` tree — where the skills that drive the pipeline now live — sat outside all four of its gates while the job reported green. This widens the walk to the whole `claude-plugins` tree and adds the assertion that keeps the widening honest: every plugin dir has to contribute at least one scanned file, or the job reds and names the dirs it missed. A guard that is green because it looked at nothing is now impossible to tell apart from a guard that is green because the code is clean — that was the actual bug, and it is what this fixes.

Fixes #5004

## What changed

- **`.github/workflows/skill-gh-lint.yml`** — the walk roots at `claude-plugins` (the root `trap-status-guard.yml` and `cli-invocation-guard.yml` already use) instead of `claude-plugins/kampus-pipeline`, and the step gained three named, fail-closed assertions:
  - **coverage** — every dir under `claude-plugins/*/` must contribute at least one scanned file. The coverage anchor (`PLUGINS_ROOT`) is deliberately held separate from the walk root (`WALK_ROOT`), so narrowing the walk again reds instead of passing quietly.
  - **zero scope (ADR 0092)** — a walk that matches no files exits 3 before the CLI is invoked at all.
  - **physical root** — the root is resolved with `cd -P`/`pwd -P` and compared against an independently derived `$PWD/claude-plugins`. `find(1)` does not descend a symlinked root, so a linked or `..`-folding root would walk nothing while looking fine.
  - `set -e` is dropped per [`.patterns/skill-script-shell-shape.md`](.patterns/skill-script-shell-shape.md); every failure path is now a named assertion that prints why and exits 3.
  - The header comment claiming coverage it did not have is corrected.
- **`packages/pipeline-cli/src/tools/gh-phoenix/lint.ts`** — one `SELF_EXEMPT_SUFFIXES` entry, `/fabrika/skills/triage/contract.md`, with the reason: that line names `gh issue edit --add-label` in order to explain why an implementer must **not** reach for it. Whole-file and plugin-qualified — not a `fabrika/`- or `skills/`-wide tolerance.
- **`packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts`** — a per-file granularity test for that exemption: `kampus-pipeline`'s own `skills/triage/contract.md` and fabrika's sibling `SKILL.md` both stay live.

## Mutation proof

Each mutant was produced by rewriting the walk root in the **real** workflow step (extracted verbatim from the YAML) and running it. Each died by its own named assertion, not merely by a non-zero exit; baseline was re-run green after the last one.

| Run | Root | Exit | Assertion that fired |
|---|---|---|---|
| baseline | `claude-plugins` | **0** | `walking 385 file(s) … every plugin dir … is covered` → `lint-skills: clean` |
| mutant A | `claude-plugins/kampus-pipeline` (the old value) | **3** | `FAIL — these plugin dirs contributed ZERO scanned files, so the walk does not cover them: claude-plugins/fabrika claude-plugins/pipeline-crew-mcp claude-plugins/pipeline-crew` |
| mutant B | `claude-plugins/no-such-dir` | **3** | `FAIL — the walk of 'claude-plugins/no-such-dir' matched zero files (zero-scope fail-closed, ADR 0092)` |
| mutant C | `.claude/skills` (a symlink) | **3** | `FAIL — scan root '.claude/skills' does not physically resolve to $PWD/.claude/skills` |
| baseline (restored) | `claude-plugins` | **0** | green again |

Mutant A is the one that matters: it is exactly the pre-fix configuration, and before this PR it exited 0.

## The scope decision (AC 5)

`pipeline-crew` and `pipeline-crew-mcp` **come into scope in this change**, not a later one. Rooting at `claude-plugins` is what makes the coverage assertion mean something — an allowlist of two plugin dirs would just be the same gap with more steps, and it would go stale the next time a plugin is added. Both dirs measure clean (17 `.md`/`.sh` files, zero findings), so including them costs nothing today and closes the gap for every future plugin automatically.

`.github/workflows/adoption-lint.yml` still roots at `claude-plugins/kampus-pipeline`. That is **left alone deliberately** — triage surfaced it as an unresolved observation, not established work, and widening it here would be an undiscussed drive-by.

## Blocking route

Checked, and the answer is nuanced enough to state plainly:

- The repo's `main` ruleset requires three status checks — `ci-required`, `validate skill frontmatter`, `scan changed files for leaks`. `skill-gh-lint` is **not** one of them and is **not** in `ci-required`'s `needs:` list, so it does **not** hard-block a merge at the branch-ruleset layer.
- It **does** block the autonomous merge lane: `ship-it` rolls up **all** REST check-runs at the PR head, so a red `skill-gh-lint` refuses the enqueue.

So the job has real teeth on the path this repo actually merges through, and no teeth against a human force-merge. Making it a required context is a merge-policy change, not this issue's scope — flagged here rather than done silently.

## Deviations

- **Class: fix-shape narrowed/widened vs what the issue named.** Said: the issue named the `find` root plus one exemption entry. Did: both of those, plus three named assertions in the step (coverage, zero-scope, physical-root) and a unit test for the exemption's granularity. Why: the dispatch's standing requirement is that this class of defect — a check that cannot see what it is looking for — must become loud, not merely correct once; the root alone would leave the next narrowing just as silent. Disposition: no action needed; the mutation table above is the evidence the additions carry their weight.
- **Class: judgment call the issue left open.** Said: AC 5 asks the `pipeline-crew` / `pipeline-crew-mcp` question be decided explicitly. Did: brought both into scope. Why: an allowlist would re-create the gap for the next plugin. Disposition: decided and stated in "The scope decision" above.
- **Class: sibling defect left for a follow-up.** Said: nothing about the job's blocking status. Did: confirmed `skill-gh-lint` is not a ruleset-required context and left it that way. Why: promoting a check to required is a merge-policy decision that belongs to the control plane, not to a p2 coverage fix. Disposition: for the reviewer to judge — file it if it should be work.
- **Class: adjacent surface deliberately not touched.** Said: triage explicitly asked that `adoption-lint.yml` not be widened as a drive-by. Did: left it narrow. Disposition: no action needed; it remains triage's open observation.
- **Class: convention deviation.** Said: the standing rule is a `umut/` branch prefix. Did: the branch is `usirin/skill-gh-lint-fabrika-scope-5004-D14312B1`. Why: the skill derives the prefix from this checkout's `git config user.name`, which is `usirin`; renaming would fight the tool that every other lane uses. Disposition: no action needed — same person, and the derivation is the skill's documented behaviour.
