### PR TITLE
feat(fabrika-cli): `fabrika spend read` — the token meter gets a CLI surface (#5007)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1,12 +1,13 @@
 # @kampus/fabrika-cli
 
 The deterministic verb package [fabrika](../../claude-plugins/fabrika/) skills call.
-`fabrika <group> <verb> …` dispatches to a registered verb group. Six groups are
+`fabrika <group> <verb> …` dispatches to a registered verb group. Seven groups are
 registered: `adr`, the six verbs the `/adr` skill's derived contract specifies; `report`,
 the three the `/report` contract specifies; `triage`, the intake-queue group the `/triage`
 contract specifies; `review`, the eight the `/review` contract specifies; `eval`, the
-graded-corpus harness the fabrika eval layer measures itself with; and `wire`, which owns
-the byte-level formats two skills meet through on a GitHub artifact.
+graded-corpus harness the fabrika eval layer measures itself with; `spend`, what one
+fabrika run cost in tokens; and `wire`, which owns the byte-level formats two skills meet
+through on a GitHub artifact.
 
 ## Who it's for
 
@@ -343,6 +344,31 @@ The token meter these verbs price runs with is fabrika's own
 *specified* by ADR 0112 §2, not chosen, so the two implementations are held to one ruler by
 a committed transcript fixture both packages' unit tiers assert against —
 `src/spend/fixtures/one-ruler/`.
+
+## The `spend` group
+
+What one fabrika run cost, in tokens, read from its transcript. The group is the CLI surface
+over the meter the `eval` verbs already price runs with — it adds no second sum
+([#5007](https://github.com/kamp-us/phoenix/issues/5007), epic
+[#4779](https://github.com/kamp-us/phoenix/issues/4779)).
+
+| Verb | Answers |
+|---|---|
+| `spend read` | one run's billed token spend, its four `usage` components, the ex-cache-read comparator, its billed turn count and its model |
+
+Three behaviours are worth knowing before you call it:
+
+- **The cache-read share stays its own number.** It dominates `billed` and grows with turn
+  count, which makes it the context-bloat signal; folding it into one total is what hides the
+  thing the measurement exists to show.
+- **"I could not measure it" is never a zero.** Exit `3` is a transcript that is provably not
+  there, `4` is one that could not be read (or whose absence could not be established — the
+  spend is UNKNOWN), and `5` is a transcript read in full that carries zero billed assistant
+  turns. That third state is a real transcript a failed run writes, and reporting it as a
+  measured zero would price a broken run as a free one.
+- **It cannot block anything.** No threshold, no budget flag, and no exit code that varies
+  with a spend magnitude — the no-gate ruling on epic #4779, asserted by a test that a
+  very large total still exits `0` rather than left as a note here.
 
 ## Development
 

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {adrCommand} from "./adr/command.ts";
 import {evalCommand} from "./eval/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
+import {spendCommand} from "./spend/command.ts";
 import {triageCommand} from "./triage/command.ts";
 import {wireCommand} from "./wire/command.ts";
 
@@ -31,6 +32,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	evalCommand,
 	reportCommand,
 	reviewCommand,
+	spendCommand,
 	triageCommand,
 	wireCommand,
 ];

--- a/packages/fabrika-cli/src/spend/command.ts
+++ b/packages/fabrika-cli/src/spend/command.ts
@@ -1,0 +1,45 @@
+/**
+ * The `spend` verb group — `fabrika spend <verb>`.
+ *
+ * The adapter and nothing else: it declares the argument and the flag (`--help` is the interface, so
+ * each carries a one-line description), runs the pure verb, and emits its outcome. Every decision
+ * lives in `read-verb.ts` beside it, which is what makes each refusal testable without spawning a
+ * process.
+ */
+import {Effect} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runRead} from "./read-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const read = leafCommand(
+	"read",
+	{
+		transcript: Argument.string("transcript").pipe(
+			Argument.withDescription("path to the run's JSONL transcript"),
+		),
+		json: Flag.boolean("json").pipe(
+			Flag.withDescription("emit the answer as JSON on stdout instead of the line grammar"),
+		),
+	},
+	Effect.fn(function* ({transcript, json}) {
+		yield* emit(yield* runRead({transcript, json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"One run's billed token spend, reconstructed from its transcript (ADR 0112 §2). First stdout line is `spend\\t<billed>\\t<assistantTurns>`, then one `<field>\\t<value>` line each for input, cacheCreate, cacheRead, output, exCacheRead and model — the cache-read share stays its own number because it is the context-bloat signal. --json emits the same eight fields as an object. Exits 3 (no transcript at that path — a proven absence), 4 (the transcript could not be read, or its absence could not be established — the spend is UNKNOWN, never zero), 5 (read in full and carrying zero billed assistant turns — a well-formed zero, not a measured spend). No threshold, no budget flag, and no exit code that varies with a spend magnitude. Example: fabrika spend read agent-3f9c1d2b.jsonl",
+	),
+);
+
+export const spendCommand = Command.make("spend").pipe(
+	Command.withSubcommands([read]),
+	Command.withDescription("Read what one fabrika run cost, in tokens, from its transcript"),
+);

--- a/packages/fabrika-cli/src/spend/read-verb.ts
+++ b/packages/fabrika-cli/src/spend/read-verb.ts
@@ -1,0 +1,79 @@
+/**
+ * `spend read` — one fabrika run's billed token spend, reconstructed from its transcript.
+ *
+ * The meter is imported, never re-derived: `token-spend.ts` owns the four-component sum, and a
+ * second one here is the two-rulers problem its own header already argues against.
+ *
+ * The three refusals below are the point of the verb. A measurement that cannot be made must not
+ * resolve to a plausible zero, so "the transcript is not there", "the transcript could not be read"
+ * and "the transcript was read in full and billed nothing" stay three distinct exit codes — the same
+ * split `../eval/runner.ts` draws with its `RunSpend` union, which is why the classification is
+ * borrowed from there rather than restated.
+ */
+import {Effect, type FileSystem, Result} from "effect";
+import {classifyRunSpend} from "../eval/runner.ts";
+import {exists, readFile} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import type {StageSpend} from "./token-spend.ts";
+
+const VERB = "fabrika spend read";
+
+/** The path holds no transcript. A proven negative — the file is not there. */
+export const TRANSCRIPT_ABSENT = 3;
+/** The transcript could not be read, or its absence could not be established. UNKNOWN. */
+export const TRANSCRIPT_UNREADABLE = 4;
+/** The transcript was read in full and carries zero billed assistant turns. */
+export const NO_BILLED_TURNS = 5;
+
+export interface ReadOptions {
+	/** Path to the run's JSONL transcript. */
+	readonly transcript: string;
+	readonly json: boolean;
+}
+
+/** The header carries the headline; the rows carry the six components it does not. */
+const render = (spend: StageSpend): string =>
+	[
+		`spend\t${spend.billed}\t${spend.assistantTurns}`,
+		`input\t${spend.input}`,
+		`cacheCreate\t${spend.cacheCreate}`,
+		`cacheRead\t${spend.cacheRead}`,
+		`output\t${spend.output}`,
+		`exCacheRead\t${spend.exCacheRead}`,
+		`model\t${spend.model ?? "-"}`,
+	].join("\n");
+
+export const runRead = (
+	options: ReadOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const path = options.transcript;
+
+		const text = yield* Effect.result(readFile(path));
+		if (Result.isFailure(text)) {
+			// The read failing is not yet an answer: only a probe that comes back a definite `false`
+			// proves the file is absent, and a probe that itself fails proves nothing at all.
+			const probe = yield* Effect.result(exists(path));
+			if (Result.isFailure(probe) || probe.success) {
+				return refuse(
+					TRANSCRIPT_UNREADABLE,
+					`${VERB}: cannot read ${path}: ${text.failure.reason} — the spend is UNKNOWN, never zero.`,
+				);
+			}
+		}
+
+		const classified = classifyRunSpend(Result.isFailure(text) ? null : text.success);
+		if (classified._tag === "TranscriptMissing") {
+			return refuse(TRANSCRIPT_ABSENT, `${VERB}: no transcript at ${path} — nothing to measure.`);
+		}
+		if (classified._tag === "NoBilledTurns") {
+			return refuse(
+				NO_BILLED_TURNS,
+				`${VERB}: ${path} was read in full and carries zero billed assistant turns — a well-formed zero, not a measured spend.`,
+			);
+		}
+
+		const spend = classified.spend;
+		const scope = `${VERB}: scanned ${path}, ${spend.assistantTurns} billed assistant turn(s); ${spend.cacheRead} of ${spend.billed} billed tokens are cache reads.`;
+		return answer(options.json ? JSON.stringify(spend) : render(spend), [scope]);
+	});

--- a/packages/fabrika-cli/src/spend/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/read-verb.unit.test.ts
@@ -1,0 +1,134 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFs, fakeFs} from "../fakes.test-support.ts";
+import {NO_BILLED_TURNS, runRead, TRANSCRIPT_ABSENT, TRANSCRIPT_UNREADABLE} from "./read-verb.ts";
+import {reconstructSpend} from "./token-spend.ts";
+
+const PATH = "/runs/one-ruler.jsonl";
+
+const fixture = readFileSync(
+	fileURLToPath(new URL("./fixtures/one-ruler/transcript.jsonl", import.meta.url)),
+	"utf8",
+);
+
+const assistantTurn = (usage: Record<string, number>, model = "claude-opus-5"): string =>
+	JSON.stringify({message: {role: "assistant", model, usage}});
+
+const run = (fs: FakeFs, json = false) =>
+	Effect.runPromise(Effect.provide(runRead({transcript: PATH, json}), fs.layer));
+
+const withText = (text: string | null) => fakeFs({files: {[PATH]: text}});
+
+const rows = (stdout: string): Map<string, string> =>
+	new Map(
+		stdout
+			.split("\n")
+			.filter((line) => line !== "")
+			.slice(1)
+			.map((line) => line.split("\t") as [string, string]),
+	);
+
+describe("spend read — the answer", () => {
+	it("names all eight components, with billed and the turn count on the header line", async () => {
+		const out = await run(withText(fixture));
+		const expected = reconstructSpend(fixture);
+
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe(`spend\t${expected.billed}\t${expected.assistantTurns}`);
+		expect(Object.fromEntries(rows(out.stdout))).toEqual({
+			input: String(expected.input),
+			cacheCreate: String(expected.cacheCreate),
+			cacheRead: String(expected.cacheRead),
+			output: String(expected.output),
+			exCacheRead: String(expected.exCacheRead),
+			model: expected.model,
+		});
+	});
+
+	it("keeps the cache-read share visible rather than folded into the total", async () => {
+		const out = await run(withText(fixture));
+		const {cacheRead, billed} = reconstructSpend(fixture);
+
+		expect(cacheRead).toBeGreaterThan(0);
+		expect(rows(out.stdout).get("cacheRead")).toBe(String(cacheRead));
+		expect(rows(out.stdout).get("exCacheRead")).toBe(String(billed - cacheRead));
+	});
+
+	it("emits the same eight fields as JSON on stdout under --json", async () => {
+		const out = await run(withText(fixture), true);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual(reconstructSpend(fixture));
+		expect(out.stderr.join("")).not.toContain('"billed"');
+	});
+
+	it("prints the scanned path and turn count on stderr, never on stdout", async () => {
+		const out = await run(withText(fixture));
+
+		expect(out.stderr.join("\n")).toContain(PATH);
+		expect(out.stdout).not.toContain(PATH);
+	});
+
+	it("reports a run whose components are all zero but which billed a turn as a measured zero", async () => {
+		const out = await run(withText(assistantTurn({input_tokens: 0, output_tokens: 0})));
+
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("spend\t0\t1");
+	});
+
+	/** The no-gate ruling, asserted rather than noted: it fails the moment a threshold appears. */
+	it("exits 0 on a very large total — no exit code varies with a spend magnitude", async () => {
+		const out = await run(withText(assistantTurn({cache_read_input_tokens: 7_489_969_208})));
+
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("spend\t7489969208\t1");
+	});
+});
+
+describe("spend read — the refusals", () => {
+	it("refuses a transcript that is provably not there, with empty stdout", async () => {
+		const out = await run(fakeFs({files: {}}));
+
+		expect(out.code).toBe(TRANSCRIPT_ABSENT);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain(PATH);
+	});
+
+	it("refuses an unreadable transcript as UNKNOWN, never as absent and never as a zero", async () => {
+		const out = await run(fakeFs({files: {[PATH]: null}, unprobeable: [PATH]}));
+
+		expect(out.code).toBe(TRANSCRIPT_UNREADABLE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("UNKNOWN");
+	});
+
+	it("seats both unreadable states above the reserved codes, distinct from each other", () => {
+		expect(TRANSCRIPT_ABSENT).toBeGreaterThanOrEqual(3);
+		expect(TRANSCRIPT_UNREADABLE).toBeGreaterThanOrEqual(3);
+		expect(new Set([TRANSCRIPT_ABSENT, TRANSCRIPT_UNREADABLE, NO_BILLED_TURNS]).size).toBe(3);
+	});
+
+	it("refuses a transcript with zero billed assistant turns as its own state", async () => {
+		const out = await run(withText('{"type":"summary"}'));
+
+		expect(out.code).toBe(NO_BILLED_TURNS);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("zero billed assistant turns");
+	});
+
+	it("refuses an empty transcript the same way — read in full, nothing billed", async () => {
+		const out = await run(withText(""));
+
+		expect(out.code).toBe(NO_BILLED_TURNS);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses under --json too — a refusal never puts a payload on stdout", async () => {
+		const out = await run(withText('{"type":"summary"}'), true);
+
+		expect(out.code).toBe(NO_BILLED_TURNS);
+		expect(out.stdout).toBe("");
+	});
+});


### PR DESCRIPTION
fabrika can now tell you what one of its own runs cost. The token meter already lived in `packages/fabrika-cli/src/spend/token-spend.ts` but had no command and no registry row, so the number was computed once inside the eval runner and thrown away. This adds the `spend` verb group — `fabrika spend read <transcript>` — which prints the four `usage` components, `billed`, `exCacheRead`, `assistantTurns` and `model`, with `--json` for the same eight fields as an object.

The cache-read share stays its own number rather than folded into a total, because that share *is* the context-bloat signal (96.6% of the crew's measured spend). And a measurement that cannot be made never resolves to a plausible zero: exit `3` is a transcript provably not there, `4` is one that could not be read (or whose absence could not be established — UNKNOWN), `5` is one read in full that billed zero assistant turns. That is the same three-way split `src/eval/runner.ts` already draws with `RunSpend`, so the classification is imported from there rather than restated.

Fixes #5007

## What is in the diff

| File | Why |
|---|---|
| `packages/fabrika-cli/src/spend/read-verb.ts` | the pure verb — returns a `VerbOutcome`, writes no stream and exits nothing |
| `packages/fabrika-cli/src/spend/read-verb.unit.test.ts` | 12 unit tests over the answer and every refusal, driven through the substituted `FileSystem` layer, no process spawned |
| `packages/fabrika-cli/src/spend/command.ts` | the thin Effect CLI adapter, shaped like the `adr` / `review` groups; the leaf is declared with `leafCommand`, not a bare `Command.make` |
| `packages/fabrika-cli/src/registry.ts` | the one registry row — the `--help` index is derived from it, so there is no parallel list to drift |
| `packages/fabrika-cli/README.md` | the `spend` group section, and the intro's group count |

The issue named the first four; the README is the fifth, required by its own last acceptance criterion.

## Acceptance criteria

- [x] `fabrika spend read <transcript>` prints all eight fields; `--json` emits the same fields as JSON. Verified end to end against the committed `src/spend/fixtures/one-ruler/transcript.jsonl`: header `spend\t107123\t3`, then `input` / `cacheCreate` / `cacheRead` / `output` / `exCacheRead` / `model` rows, and the JSON object carrying all eight.
- [x] The group is listed by `fabrika --help` through a `registry.ts` row, with no hand-maintained parallel index.
- [x] An absent or unreadable transcript exits `3` / `4` with empty stdout and a reason on stderr — measured live, not only in the unit tier.
- [x] A zero-billed-turn transcript exits `5`, distinct from a measured zero (a run that billed a turn whose components are all zero exits `0` with `spend\t0\t1`) and from a missing transcript.
- [x] Unit coverage over the answer and every refusal, no process spawned — the seam replaced is `FileSystem`, the same one production uses.
- [x] `reconstructSpend` is the only four-component sum; the verb reaches it through `classifyRunSpend`. No file under `packages/fabrika-cli/` imports from `packages/pipeline-cli/` (grep: only prose references).
- [x] No threshold flag, no budget option, no exit code that varies with a spend magnitude — asserted by a test that a 7,489,969,208-token total still exits `0`.
- [x] `packages/fabrika-cli/README.md` documents the group and its verb.

## Verification

- `pnpm --filter @kampus/fabrika-cli test` — 86 files, 1287 tests pass (12 new).
- `pnpm typecheck --force` — 30/30 successful, **0 cached** (an uncached run, not a FULL TURBO replay).
- `pnpm lint:worktree` — 4 files checked, clean.
- The new test was written first and observed failing for its intended reason (`Cannot find module './read-verb.ts'`), then again per-assertion as the verb was built.

## Deviations

**Class 4 (a judgment call the issue did not specify) — no `spend/codes.ts`.** *Said:* the issue names three new files and the exit-code contract; the sibling `review` group keeps its codes in a `codes.ts`. *Did:* declared the three codes in `read-verb.ts` instead, exactly as `adr/sweep-verb.ts` does. *Why:* the issue asks for a group "shaped like the `adr` and `eval` groups", and neither has a `codes.ts`; a `spend/codes.ts` would also have to be registered in `exit-code-alignment.ts` and its test, widening this diff into the alignment surface for a one-verb group. *Disposition:* no action needed — if the group grows past one verb, a `codes.ts` plus its alignment row is the natural next step.

**Class 4 — the group imports `classifyRunSpend` from `../eval/runner.ts`.** *Said:* the issue says the zero-billed-turn state should "match the three-way `RunSpend` union `packages/fabrika-cli/src/eval/runner.ts` already uses". *Did:* imported that classifier rather than writing a matching one. *Why:* re-stating the classification is a second place for the "well-formed zero" rule to drift, which is the same argument the issue makes about the four-component sum. There is no import cycle (`eval/runner.ts` imports `spend/token-spend.ts`, which imports nothing back), and cross-group imports are already the package's practice (`review/codes.ts` imports `report/codes.ts`). *Disposition:* for the reviewer to judge — if the layering is unwanted, the classifier moves into `spend/` and `eval/runner.ts` imports it from there, which is a small follow-up rather than a change to this contract.

**Class 4 — the `--help` example uses a bare filename.** *Said:* nothing. *Did:* wrote `Example: fabrika spend read agent-3f9c1d2b.jsonl` rather than a realistic transcript location. *Why:* a real transcript path is home-rooted, and no committed artifact may carry one. *Disposition:* no action needed.

**Class 2 (scope left for a sibling) — nothing records a run's spend.** *Said:* the epic wants every eval run's spend attributed and persisted. *Did:* only the read surface. *Why:* that is #5008 (record) and #5009 (persist), and #5009 is blocked behind #5008. *Disposition:* no action needed — those are separate children.

**Class 5 (a suppression) — none. The Tier-M scan's one hit is a false positive.** It flags `process.exit(outcome.code)` in `spend/command.ts`, because the pattern for a skipped test (`xit(`) matches the tail of `.exit(`. That line is the adapter's `emit`, copied verbatim from `adr/command.ts` and `review/command.ts`. No test is skipped and no lint rule is suppressed anywhere in this diff.

Nothing here adds a USD figure, a rate table, a discovery scan over the v1 crew's transcripts, an import from `pipeline-cli`, or a hot-path hook.
