### PR TITLE
feat(fabrika-cli): one `review` eval stage, discriminated and graded per surface (#4979)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -19,11 +19,30 @@ slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) shipped the corp
   shape doesn't match its stage is unrepresentable (make-invalid-states-unrepresentable):
   - `triage` → `{ type, priority, status }`
   - `build` → `{ fixesRef, ciGreen, reviewVerdict }`
-  - `review-code` → `{ verdict, acFindings }`
-  - `review-doc` → `{ verdict, findings }`
+  - `review` + `surface: "code"` → `{ verdict, acFindings }`
+  - `review` + `surface: "doc"` → `{ verdict, findings }`
   - `ship-it` → `{ merged, mergeSha }`
 - `CorpusManifest` — the frozen ground truth: entries grouped under **live** stage keys, each
   key admitting only that stage's entry (the second half of the unrepresentable guarantee).
+
+### The `review` stage's surface sub-discriminator
+
+The v1 review gates merged into one `review` skill, so the corpus keeps **one** `review` stage key
+and every review entry carries a `surface` that selects both its label shape and its grader ([ADR
+0243](../../../../.decisions/0243-review-eval-stage-surface-discriminator.md)). The two label shapes
+genuinely differ (`acFindings` vs `findings`), so the guarantee above now holds over the
+**`(stage, surface)` pair**: a `review` entry whose label doesn't match its surface is
+unrepresentable, and a `review` entry with **no** surface is a decode failure, never a row a
+fallback rubric grades. `gradeEntry` narrows the same way — `stage` to `review`, then `surface` to
+its own grader — because dispatching on `stage` alone is what would silently collapse two rubrics
+onto one grader. One PR reviewed on two surfaces is two rows sharing an `inputRef`, each graded by
+its own grader; that is the intended shape, not a duplicate.
+
+`REVIEW_SURFACES` names `code` and `doc`. ADR 0243 also names a `skill` surface, whose entry shape
+is deliberately **not** defined here: the founder ruling on
+[#4979](https://github.com/kamp-us/phoenix/issues/4979) split designing it into
+[#5038](https://github.com/kamp-us/phoenix/issues/5038), so that a build lane never fixes a schema
+as a side effect.
 
 ### Live stage key vs recorded provenance
 
@@ -35,8 +54,11 @@ The founder ruling on [#4977](https://github.com/kamp-us/phoenix/issues/4977) fi
 to those rows: they keep their original key, because re-keying them would republish a v1
 measurement as a fabrika one. So `build` is the live stage, `write-code` is not a stage any more,
 and the three rows in `corpus/build.json` are still keyed `write-code` — the decoder accepts that
-key on an already-recorded row and nowhere else. Read a record's stage key as *what was run*,
-never as a pointer into `STAGES`; joins (the runner, the scorecard) key on the live stage.
+key on an already-recorded row and nowhere else. The same holds for the review merge: `review` is
+the live stage, `review-code` and `review-doc` are not stages any more, and the rows in
+`corpus/review.json` keep their `review-code` key and carry **no** `surface`, since `surface` is a
+live-schema field. Read a record's stage key as *what was run*, never as a pointer into `STAGES`;
+joins (the runner, the scorecard) key on the live stage.
 - `decodeManifest(text)` — total: returns a typed `Result` failure (`malformed-json` or
   `schema-mismatch`) on bad input, never throws. `encodeManifest(manifest)` round-trips it.
 
@@ -55,9 +77,9 @@ An entry passes iff the observed `artifact` reproduces its known-good `label`, p
 - `triage` — actual `{type, priority, status}` equals the label.
 - `build` — the PR carries the labeled `Fixes #N` + CI green + an independent `review-code: PASS`
   (actual `{fixesRef, ciGreen, reviewVerdict}` equals the label).
-- `review-code` — actual verdict + AC-finding **set** match the label (findings compared order- and
-  duplicate-insensitively).
-- `review-doc` — actual verdict + doc-finding set match the label.
+- `review` / `code` — actual verdict + AC-finding **set** match the label (findings compared order-
+  and duplicate-insensitively).
+- `review` / `doc` — actual verdict + doc-finding set match the label.
 - `ship-it` — actual `{merged, mergeSha}` equals the label.
 
 The grade is a typed value, never a throw:
@@ -355,7 +377,7 @@ The frozen ground truth lives beside this module as one manifest per stage under
 
 - [`corpus/triage.json`](./corpus/triage.json) — triage classifications
 - [`corpus/build.json`](./corpus/build.json) — build outcomes (rows recorded by v1 `write-code`)
-- [`corpus/review-code.json`](./corpus/review-code.json) — review-code verdicts
+- [`corpus/review.json`](./corpus/review.json) — review verdicts (rows recorded by v1 `review-code`)
 
 Each file is a `CorpusManifest` whose non-target stage arrays are empty, so it decodes
 clean on its own and validates through `fabrika eval check`. Every entry is
@@ -483,7 +505,7 @@ with no edits" is checked against the real shape rather than asserted.
 
 ```bash
 fabrika eval run <evals.json> \
-  --stage <triage|build|review-code|review-doc|ship-it> \
+  --stage <triage|build|review|ship-it> \
   --plugin-dir <the candidate skill's plugin dir> \
   --model <model> \
   [--arms with-skill,without-skill] [--json-schema <schema.json>] \

--- a/packages/fabrika-cli/src/eval/corpus.data.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/corpus.data.unit.test.ts
@@ -16,7 +16,7 @@ const decodeFile = (name: string) =>
 
 describe("committed corpus — every manifest decodes clean (a malformed corpus cannot land)", () => {
 	it("finds the three per-stage manifests on disk", () => {
-		assert.deepStrictEqual(manifestFiles, ["build.json", "review-code.json", "triage.json"]);
+		assert.deepStrictEqual(manifestFiles, ["build.json", "review.json", "triage.json"]);
 	});
 
 	for (const name of manifestFiles) {
@@ -32,7 +32,7 @@ describe("committed corpus — meaningful pass-rate, not n=1 (seed + ≥2 per st
 	const expected = [
 		{file: "triage.json", stage: "triage", seed: 1227, min: 3},
 		{file: "build.json", stage: "build", seed: 1223, min: 3},
-		{file: "review-code.json", stage: "review-code", seed: 1199, min: 3},
+		{file: "review.json", stage: "review", seed: 1199, min: 3},
 	] as const;
 
 	for (const {file, stage, seed, min} of expected) {
@@ -62,6 +62,21 @@ describe("committed corpus — the recorded v1 rows keep their provenance (#4977
 				rows.map((row) => row.stage),
 				["write-code", "write-code", "write-code"],
 			);
+		}
+	});
+
+	it("review.json's rows are still keyed review-code under the live `review` group", () => {
+		const result = decodeFile("review.json");
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			const rows = result.success.stages.review;
+			assert.isAtLeast(rows.length, 3);
+			assert.deepStrictEqual(
+				rows.map((row) => row.stage),
+				["review-code", "review-code", "review-code"],
+			);
+			// A recorded row carries no `surface` — that is a live-schema field (ADR 0243 §5).
+			assert.isFalse(rows.some((row) => "surface" in row));
 		}
 	});
 });

--- a/packages/fabrika-cli/src/eval/corpus.ts
+++ b/packages/fabrika-cli/src/eval/corpus.ts
@@ -13,7 +13,9 @@
  * label `{fixesRef, ciGreen, reviewVerdict}` cannot sit under `stage: "triage"`, whose
  * only admissible label is `{type, priority, status}` (make-invalid-states-unrepresentable).
  * The manifest doubles the guarantee: it groups entries under per-stage keys whose value
- * schema is that stage's entry alone, so a mismatched entry can't even be filed.
+ * schema is that stage's entry alone, so a mismatched entry can't even be filed. The single
+ * `review` stage extends that guarantee one level down: it discriminates again on `surface`,
+ * so the guarantee holds over the `(stage, surface)` pair. See ADR 0243.
  *
  * The second non-obvious shape: an entry's `stage` is **recorded provenance** — what actually
  * produced the row — while a manifest's group key is the **live stage**. The two are the same
@@ -27,10 +29,22 @@ import {Result} from "effect";
 import * as Schema from "effect/Schema";
 
 /** The live stage vocabulary: what `--stage` accepts and what a manifest groups entries under. */
-export const STAGES = ["triage", "build", "review-code", "review-doc", "ship-it"] as const;
+export const STAGES = ["triage", "build", "review", "ship-it"] as const;
 
 /** One live stage key. Distinct from an entry's `stage`, which may be a recorded v1 name. */
 export type LiveStage = (typeof STAGES)[number];
+
+/**
+ * The review surfaces the one `review` stage fans into (ADR 0243 §1) — the axis that selects
+ * both a review entry's label shape and its grader. The ADR names a third, `skill`, whose entry
+ * shape is deliberately absent here: it has no designed label shape yet, and the founder ruling on
+ * #4979 fenced designing one out of this lane, so it is #5038's. A surface with no entry shape is
+ * not listed, because this tuple is what a consumer enumerates.
+ */
+export const REVIEW_SURFACES = ["code", "doc"] as const;
+
+/** One review surface — the sub-discriminator of the `review` stage. */
+export type ReviewSurface = (typeof REVIEW_SURFACES)[number];
 
 /** A reproducible input identifier — an issue/PR number (ADR 0112 §1: pinned by identifier). */
 const InputRef = Schema.Int;
@@ -78,25 +92,62 @@ const RecordedWriteCodeEntry = Schema.Struct({
 	label: BuildLabel,
 });
 
-/** review-code's oracle: the verdict plus the acceptance-criteria findings it surfaced. */
-const ReviewCodeEntry = Schema.Struct({
-	stage: Schema.Literal("review-code"),
-	inputRef: InputRef,
-	label: Schema.Struct({
-		verdict: Verdict,
-		acFindings: Schema.Array(Schema.String),
-	}),
+/** The code surface's oracle: the verdict plus the acceptance-criteria findings it surfaced. */
+const ReviewCodeLabel = Schema.Struct({
+	verdict: Verdict,
+	acFindings: Schema.Array(Schema.String),
 });
 
-/** review-doc's oracle: the verdict plus the doc findings it surfaced. */
+/** The doc surface's oracle: the verdict plus the doc findings it surfaced. */
+const ReviewDocLabel = Schema.Struct({
+	verdict: Verdict,
+	findings: Schema.Array(Schema.String),
+});
+
+/**
+ * The `review` stage's two members, each pinning `surface` to a literal and admitting exactly one
+ * label shape. `surface` is required and has no default: a `review` entry with no surface is a
+ * decode failure, never a row a fallback rubric grades (ADR 0243 §1).
+ */
+const ReviewCodeEntry = Schema.Struct({
+	stage: Schema.Literal("review"),
+	surface: Schema.Literal("code"),
+	inputRef: InputRef,
+	label: ReviewCodeLabel,
+});
+
 const ReviewDocEntry = Schema.Struct({
+	stage: Schema.Literal("review"),
+	surface: Schema.Literal("doc"),
+	inputRef: InputRef,
+	label: ReviewDocLabel,
+});
+
+/**
+ * The rows the v1 `review-code` / `review-doc` gates recorded, under the label shapes their
+ * surfaces now carry. They keep their own stage keys for the same reason `write-code` does — a
+ * recorded stage key is provenance, and they carry no `surface`, which is a live-schema field. The
+ * live key `review` is what a manifest groups all four under.
+ */
+const RecordedReviewCodeEntry = Schema.Struct({
+	stage: Schema.Literal("review-code"),
+	inputRef: InputRef,
+	label: ReviewCodeLabel,
+});
+
+const RecordedReviewDocEntry = Schema.Struct({
 	stage: Schema.Literal("review-doc"),
 	inputRef: InputRef,
-	label: Schema.Struct({
-		verdict: Verdict,
-		findings: Schema.Array(Schema.String),
-	}),
+	label: ReviewDocLabel,
 });
+
+/** Everything a manifest's `review` group admits: both live surfaces plus both recorded keys. */
+const ReviewGroupEntry = Schema.Union([
+	ReviewCodeEntry,
+	ReviewDocEntry,
+	RecordedReviewCodeEntry,
+	RecordedReviewDocEntry,
+]);
 
 /** ship-it's oracle: whether the PR merged and the head SHA it merged. */
 const ShipItEntry = Schema.Struct({
@@ -109,8 +160,9 @@ const ShipItEntry = Schema.Struct({
 });
 
 /**
- * One labeled corpus input — a discriminated union on `stage`. Decoding selects the member
- * by its `stage` literal, so a label shape that doesn't belong to that stage is rejected.
+ * One labeled corpus input — a discriminated union on `stage`, and on `(stage, surface)` for the
+ * `review` stage. Decoding selects the member by those literals, so a label shape that doesn't
+ * belong to that stage — or, under `review`, to that surface — is rejected.
  */
 export const CorpusEntry = Schema.Union([
 	TriageEntry,
@@ -118,6 +170,8 @@ export const CorpusEntry = Schema.Union([
 	RecordedWriteCodeEntry,
 	ReviewCodeEntry,
 	ReviewDocEntry,
+	RecordedReviewCodeEntry,
+	RecordedReviewDocEntry,
 	ShipItEntry,
 ]);
 
@@ -126,17 +180,16 @@ export type CorpusEntry = typeof CorpusEntry.Type;
 /**
  * The frozen, version-controlled ground truth: entries grouped under LIVE stage keys. Each
  * group's value schema is that stage's entry alone, so a mismatched entry cannot be filed
- * under the wrong stage — the second half of the unrepresentable-invalid guarantee. `build`
- * additionally admits the recorded `write-code` rows, which share its label shape and keep their
- * own provenance key.
+ * under the wrong stage — the second half of the unrepresentable-invalid guarantee. `build` and
+ * `review` additionally admit the recorded v1 rows, which share their label shapes and keep their
+ * own provenance keys.
  */
 export const CorpusManifest = Schema.Struct({
 	version: Schema.Int,
 	stages: Schema.Struct({
 		triage: Schema.Array(TriageEntry),
 		build: Schema.Array(Schema.Union([BuildEntry, RecordedWriteCodeEntry])),
-		"review-code": Schema.Array(ReviewCodeEntry),
-		"review-doc": Schema.Array(ReviewDocEntry),
+		review: Schema.Array(ReviewGroupEntry),
 		"ship-it": Schema.Array(ShipItEntry),
 	}),
 });

--- a/packages/fabrika-cli/src/eval/corpus.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/corpus.unit.test.ts
@@ -6,12 +6,16 @@ import {
 	type CorpusManifest,
 	decodeManifest,
 	encodeManifest,
+	REVIEW_SURFACES,
 	STAGES,
 } from "./corpus.ts";
 
 const decodeEntry = Schema.decodeUnknownResult(CorpusEntry);
 
-/** A valid manifest carrying exactly one known-good entry for every stage. */
+/** `true` iff `T` is a shape the `CorpusEntry` union admits — the type-level probe's operand. */
+type Inhabits<T> = T extends CorpusEntry ? true : false;
+
+/** A valid manifest carrying a known-good entry for every stage, and one per review surface. */
 const validManifest = {
 	version: 1,
 	stages: {
@@ -25,24 +29,32 @@ const validManifest = {
 				label: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
 			},
 		],
-		"review-code": [
-			{stage: "review-code", inputRef: 1849, label: {verdict: "PASS", acFindings: ["AC1 met"]}},
-		],
-		"review-doc": [
-			{stage: "review-doc", inputRef: 1850, label: {verdict: "FAIL", findings: ["broken link"]}},
+		review: [
+			{
+				stage: "review",
+				surface: "code",
+				inputRef: 1849,
+				label: {verdict: "PASS", acFindings: ["AC1 met"]},
+			},
+			{
+				stage: "review",
+				surface: "doc",
+				inputRef: 1850,
+				label: {verdict: "FAIL", findings: ["broken link"]},
+			},
 		],
 		"ship-it": [{stage: "ship-it", inputRef: 1851, label: {merged: true, mergeSha: "deadbee"}}],
 	},
 } satisfies CorpusManifest;
 
 describe("decodeManifest — a valid manifest per stage round-trips", () => {
-	it("decodes a manifest with one entry per stage", () => {
+	it("decodes a manifest carrying an entry under every live stage", () => {
 		const result = decodeManifest(JSON.stringify(validManifest));
 		assert.isTrue(Result.isSuccess(result));
 		if (Result.isSuccess(result)) {
 			assert.strictEqual(result.success.version, 1);
 			for (const stage of STAGES) {
-				assert.strictEqual(result.success.stages[stage].length, 1);
+				assert.isAtLeast(result.success.stages[stage].length, 1);
 			}
 		}
 	});
@@ -97,13 +109,102 @@ describe("CorpusEntry — a per-stage label-shape mismatch is rejected", () => {
 		assert.isTrue(Result.isFailure(result));
 	});
 
-	it("rejects an out-of-range verdict literal in a review-code label", () => {
+	it("rejects an out-of-range verdict literal in a code-surface review label", () => {
 		const result = decodeEntry({
-			stage: "review-code",
+			stage: "review",
+			surface: "code",
 			inputRef: 1849,
 			label: {verdict: "MAYBE", acFindings: []},
 		});
 		assert.isTrue(Result.isFailure(result));
+	});
+});
+
+// ADR 0243: the merge of review-code + review-doc into one `review` stage is exactly where the
+// module's unrepresentable-invalid guarantee is easiest to lose, because the two surfaces carry
+// genuinely different label shapes (`acFindings` vs `findings`). It now holds over the
+// (stage, surface) PAIR, and these prove it at both layers — the schema and the type.
+describe("review — a label mismatched to its surface stays unrepresentable", () => {
+	const docShapedLabel = {verdict: "PASS", findings: ["broken link"]};
+	const codeShapedLabel = {verdict: "PASS", acFindings: ["AC1 met"]};
+
+	it("rejects a doc-shaped label under surface code", () => {
+		const result = decodeEntry({
+			stage: "review",
+			surface: "code",
+			inputRef: 1,
+			label: docShapedLabel,
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a code-shaped label under surface doc", () => {
+		const result = decodeEntry({
+			stage: "review",
+			surface: "doc",
+			inputRef: 1,
+			label: codeShapedLabel,
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("a manifest carrying the surface-mismatched row fails decodeManifest with schema-mismatch", () => {
+		const bad = {
+			...validManifest,
+			stages: {
+				...validManifest.stages,
+				review: [{stage: "review", surface: "code", inputRef: 1, label: docShapedLabel}],
+			},
+		};
+		const result = decodeManifest(JSON.stringify(bad));
+		assert.isTrue(Result.isFailure(result));
+		if (Result.isFailure(result)) {
+			assert.strictEqual(result.failure.reason, "schema-mismatch");
+		}
+	});
+
+	it("rejects a review entry with no surface at all — no default, no inferred rubric", () => {
+		const result = decodeEntry({stage: "review", inputRef: 1, label: codeShapedLabel});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a surface outside the two this lane defines", () => {
+		const result = decodeEntry({
+			stage: "review",
+			surface: "skill",
+			inputRef: 1,
+			label: codeShapedLabel,
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("is refused by the type, not only by the decoder", () => {
+		// The runtime half above is not the whole guarantee: a `CorpusEntry` type that ADMITTED the
+		// mismatch would still decode-fail, so the compiler has to refuse it too. `Inhabits<T>` is
+		// `false` exactly when T is not a CorpusEntry, so these constants stop compiling the moment
+		// the pair discriminator is weakened into an annotation — and the positive control keeps
+		// them from being vacuously true.
+		const wellFormed: Inhabits<{
+			stage: "review";
+			surface: "code";
+			inputRef: number;
+			label: {verdict: "PASS"; acFindings: ReadonlyArray<string>};
+		}> = true;
+		const surfaceMismatched: Inhabits<{
+			stage: "review";
+			surface: "code";
+			inputRef: number;
+			label: {verdict: "PASS"; findings: ReadonlyArray<string>};
+		}> = false;
+		const surfaceless: Inhabits<{
+			stage: "review";
+			inputRef: number;
+			label: {verdict: "PASS"; acFindings: ReadonlyArray<string>};
+		}> = false;
+
+		assert.isTrue(wellFormed);
+		assert.isFalse(surfaceMismatched);
+		assert.isFalse(surfaceless);
 	});
 });
 
@@ -140,6 +241,58 @@ describe("recorded provenance — a v1 `write-code` row survives the re-key unre
 	it("is not a live stage — STAGES names `build` and not `write-code`", () => {
 		assert.include(STAGES as ReadonlyArray<string>, "build");
 		assert.notInclude(STAGES as ReadonlyArray<string>, "write-code");
+	});
+});
+
+// The same ruling, applied to the two review keys the merge absorbs.
+describe("recorded provenance — the v1 review rows survive the merge unrelabelled", () => {
+	const recordedCode = {
+		stage: "review-code",
+		inputRef: 1199,
+		label: {verdict: "PASS", acFindings: ["AC1 met"]},
+	};
+	const recordedDoc = {
+		stage: "review-doc",
+		inputRef: 1850,
+		label: {verdict: "FAIL", findings: ["broken link"]},
+	};
+
+	it("both decode under the live `review` group without their own keys changing", () => {
+		const manifest = {
+			...validManifest,
+			stages: {...validManifest.stages, review: [recordedCode, recordedDoc]},
+		};
+		const result = decodeManifest(JSON.stringify(manifest));
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			assert.deepStrictEqual(
+				result.success.stages.review.map((row) => row.stage),
+				["review-code", "review-doc"],
+			);
+		}
+	});
+
+	it("are still shape-checked — a doc label under the recorded review-code key is rejected", () => {
+		const result = decodeEntry({
+			stage: "review-code",
+			inputRef: 1199,
+			label: {verdict: "PASS", findings: []},
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("are not live stages — STAGES names `review` and neither v1 key", () => {
+		assert.include(STAGES as ReadonlyArray<string>, "review");
+		assert.notInclude(STAGES as ReadonlyArray<string>, "review-code");
+		assert.notInclude(STAGES as ReadonlyArray<string>, "review-doc");
+	});
+});
+
+// The founder ruling on #4979 fenced the `skill` surface's entry shape out of the lane that built
+// this stage (#5038 designs it). Nothing here may quietly invent one.
+describe("the skill surface has no entry shape yet", () => {
+	it("REVIEW_SURFACES names only the two surfaces whose label shapes ADR 0243 fixes", () => {
+		assert.deepStrictEqual([...REVIEW_SURFACES], ["code", "doc"]);
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/corpus/build.json
+++ b/packages/fabrika-cli/src/eval/corpus/build.json
@@ -19,8 +19,7 @@
 				"label": { "fixesRef": 1032, "ciGreen": true, "reviewVerdict": "PASS" }
 			}
 		],
-		"review-code": [],
-		"review-doc": [],
+		"review": [],
 		"ship-it": []
 	}
 }

--- a/packages/fabrika-cli/src/eval/corpus/review.json
+++ b/packages/fabrika-cli/src/eval/corpus/review.json
@@ -3,7 +3,7 @@
 	"stages": {
 		"triage": [],
 		"build": [],
-		"review-code": [
+		"review": [
 			{
 				"stage": "review-code",
 				"inputRef": 1199,
@@ -41,7 +41,6 @@
 				}
 			}
 		],
-		"review-doc": [],
 		"ship-it": []
 	}
 }

--- a/packages/fabrika-cli/src/eval/corpus/triage.json
+++ b/packages/fabrika-cli/src/eval/corpus/triage.json
@@ -19,8 +19,7 @@
 			}
 		],
 		"build": [],
-		"review-code": [],
-		"review-doc": [],
+		"review": [],
 		"ship-it": []
 	}
 }

--- a/packages/fabrika-cli/src/eval/oracle.ts
+++ b/packages/fabrika-cli/src/eval/oracle.ts
@@ -16,7 +16,7 @@
  */
 import {Result} from "effect";
 import * as Schema from "effect/Schema";
-import type {CorpusEntry} from "./corpus.ts";
+import type {CorpusEntry, ReviewSurface} from "./corpus.ts";
 
 /** A single field's disagreement between the observed artifact and the expected label. */
 export interface FieldMismatch {
@@ -70,7 +70,8 @@ const cmpSet = (
 	return equal ? [] : [{field, observed: JSON.stringify(o), expected: JSON.stringify(e)}];
 };
 
-// Artifact schemas mirror each stage's frozen label shape in corpus.ts (#1848) — the OBSERVED
+// Artifact schemas mirror each stage's frozen label shape in corpus.ts (#1848) — and, for `review`,
+// each SURFACE's, since that is the level the label shape is fixed at (ADR 0243 §1). The OBSERVED
 // decision artifact is the same shape as the EXPECTED label. Kept separate (not exported from
 // corpus.ts) because artifact and label are distinct concepts sharing a shape, not one type.
 const Verdict = Schema.Literals(["PASS", "FAIL"]);
@@ -108,6 +109,13 @@ const decodeShipIt = Schema.decodeUnknownResult(ShipItArtifact);
 // Narrow `entry.label` by discriminating on `entry.stage` (CorpusEntry is a union on `stage`).
 type LabelOf<S extends CorpusEntry["stage"]> = Extract<CorpusEntry, {stage: S}>["label"];
 
+// The `review` stage carries a second discriminator, so its label narrows on the PAIR. Selecting a
+// review grader on `stage` alone is banned (ADR 0243 §2): it collapses two rubrics onto one grader.
+type ReviewLabelOf<S extends ReviewSurface> = Extract<
+	CorpusEntry,
+	{stage: "review"; surface: S}
+>["label"];
+
 // See ADR 0112 §3 for every oracle definition below — do not re-invent a rubric.
 
 /** triage passes iff the actual `{type, priority, status}` equals the label (ADR 0112 §3). */
@@ -139,8 +147,11 @@ const gradeBuild = (label: LabelOf<"build">, artifact: unknown): Grade => {
 	]);
 };
 
-/** review-code passes iff the actual verdict + AC-finding set match the label (ADR 0112 §3). */
-const gradeReviewCode = (label: LabelOf<"review-code">, artifact: unknown): Grade => {
+/**
+ * The `code` surface passes iff the actual verdict + AC-finding set match the label (ADR 0112 §3).
+ * The recorded v1 `review-code` rows share this label shape, so they grade here too.
+ */
+const gradeReviewCode = (label: ReviewLabelOf<"code">, artifact: unknown): Grade => {
 	const decoded = decodeReviewCode(artifact);
 	if (Result.isFailure(decoded))
 		return failMalformed(`review-code artifact: ${decoded.failure.message}`);
@@ -151,8 +162,8 @@ const gradeReviewCode = (label: LabelOf<"review-code">, artifact: unknown): Grad
 	]);
 };
 
-/** review-doc passes iff the actual verdict + doc-finding set match the label (ADR 0112 §3). */
-const gradeReviewDoc = (label: LabelOf<"review-doc">, artifact: unknown): Grade => {
+/** The `doc` surface passes iff the actual verdict + doc-finding set match the label (ADR 0112 §3). */
+const gradeReviewDoc = (label: ReviewLabelOf<"doc">, artifact: unknown): Grade => {
 	const decoded = decodeReviewDoc(artifact);
 	if (Result.isFailure(decoded))
 		return failMalformed(`review-doc artifact: ${decoded.failure.message}`);
@@ -161,6 +172,20 @@ const gradeReviewDoc = (label: LabelOf<"review-doc">, artifact: unknown): Grade 
 		...cmpScalar("verdict", a.verdict, label.verdict),
 		...cmpSet("findings", a.findings, label.findings),
 	]);
+};
+
+/**
+ * Select a `review` entry's grader by its `surface`. This second narrowing is the whole point of
+ * ADR 0243: with one `review` stage and no further key, the two rubrics would collapse onto one
+ * grader silently. Each surface reaches its own grader and its own artifact schema.
+ */
+const gradeReview = (entry: Extract<CorpusEntry, {stage: "review"}>, artifact: unknown): Grade => {
+	switch (entry.surface) {
+		case "code":
+			return gradeReviewCode(entry.label, artifact);
+		case "doc":
+			return gradeReviewDoc(entry.label, artifact);
+	}
 };
 
 /** ship-it passes iff the actual `{merged, mergeSha}` equals the label (ADR 0112 §3). */
@@ -177,8 +202,9 @@ const gradeShipIt = (label: LabelOf<"ship-it">, artifact: unknown): Grade => {
 
 /**
  * Grade one corpus entry's actual run `artifact` against its known-good `label`. Pure + total:
- * the per-stage grader is selected by the entry's `stage` discriminator, and an artifact that
- * fails its stage's shape grades `fail` with a stated reason rather than throwing. See ADR 0112 §3.
+ * the grader is selected by the entry's `stage` discriminator — and, for `review`, by the
+ * `(stage, surface)` pair (ADR 0243 §2) — and an artifact that fails its shape grades `fail` with a
+ * stated reason rather than throwing. See ADR 0112 §3.
  */
 export const gradeEntry = (entry: CorpusEntry, artifact: unknown): Grade => {
 	switch (entry.stage) {
@@ -187,6 +213,8 @@ export const gradeEntry = (entry: CorpusEntry, artifact: unknown): Grade => {
 		case "build":
 		case "write-code":
 			return gradeBuild(entry.label, artifact);
+		case "review":
+			return gradeReview(entry, artifact);
 		case "review-code":
 			return gradeReviewCode(entry.label, artifact);
 		case "review-doc":

--- a/packages/fabrika-cli/src/eval/oracle.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/oracle.unit.test.ts
@@ -30,13 +30,32 @@ const cases = {
 		},
 		passing: {fixesRef: 1223, ciGreen: true, reviewVerdict: "PASS"},
 	},
-	"review-code": {
+	"review/code": {
 		entry: {
-			stage: "review-code",
+			stage: "review",
+			surface: "code",
 			inputRef: 1849,
 			label: {verdict: "PASS", acFindings: ["AC1 met", "AC2 met"]},
 		},
 		passing: {verdict: "PASS", acFindings: ["AC2 met", "AC1 met"]}, // set-equal, reordered
+	},
+	"review/doc": {
+		entry: {
+			stage: "review",
+			surface: "doc",
+			inputRef: 1850,
+			label: {verdict: "FAIL", findings: ["broken link"]},
+		},
+		passing: {verdict: "FAIL", findings: ["broken link"]},
+	},
+	// The recorded v1 review rows keep their own stage keys (#4977) and must still reach a grader.
+	"review-code": {
+		entry: {
+			stage: "review-code",
+			inputRef: 1199,
+			label: {verdict: "PASS", acFindings: ["AC1 met"]},
+		},
+		passing: {verdict: "PASS", acFindings: ["AC1 met"]},
 	},
 	"review-doc": {
 		entry: {
@@ -96,8 +115,8 @@ describe("gradeEntry — a divergent artifact fails, carrying the observed-vs-ex
 		}
 	});
 
-	it("review-code: a dropped AC finding fails with the set diff", () => {
-		const g = gradeEntry(cases["review-code"].entry, {
+	it("review/code: a dropped AC finding fails with the set diff", () => {
+		const g = gradeEntry(cases["review/code"].entry, {
 			verdict: "PASS",
 			acFindings: ["AC1 met"],
 		});
@@ -115,8 +134,8 @@ describe("gradeEntry — a divergent artifact fails, carrying the observed-vs-ex
 		}
 	});
 
-	it("review-doc: a changed verdict fails with the verdict diff", () => {
-		const g = gradeEntry(cases["review-doc"].entry, {verdict: "PASS", findings: ["broken link"]});
+	it("review/doc: a changed verdict fails with the verdict diff", () => {
+		const g = gradeEntry(cases["review/doc"].entry, {verdict: "PASS", findings: ["broken link"]});
 		assert.isTrue(isFail(g));
 		if (isFail(g) && g.mismatch._tag === "LabelMismatch") {
 			assert.deepStrictEqual(g.mismatch.fields, [
@@ -161,10 +180,62 @@ describe("gradeEntry — total on a malformed or absent artifact (never throws)"
 	});
 
 	it("grades fail when an artifact carries an out-of-range verdict literal", () => {
-		const g = gradeEntry(cases["review-code"].entry, {verdict: "MAYBE", acFindings: []});
+		const g = gradeEntry(cases["review/code"].entry, {verdict: "MAYBE", acFindings: []});
 		assert.isTrue(isFail(g));
 		if (isFail(g)) {
 			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
 		}
+	});
+});
+
+/**
+ * ADR 0243 §2 bans dispatching a review grade on `stage` alone, because with one `review` key and
+ * no second discriminator the two rubrics collapse onto one grader — silently, since a `doc`
+ * artifact graded by the `code` rubric would just look like a fail. These assert the collapse did
+ * not happen: each surface reaches its OWN grader and its own artifact schema.
+ */
+describe("gradeEntry — the two review surfaces do not share a grader", () => {
+	it("a doc-shaped artifact under the code surface is malformed, not silently graded", () => {
+		const g = gradeEntry(cases["review/code"].entry, {verdict: "PASS", findings: ["AC1 met"]});
+		assert.isTrue(isFail(g));
+		if (isFail(g)) {
+			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
+			if (g.mismatch._tag === "MalformedArtifact") {
+				assert.match(g.mismatch.reason, /^review-code artifact:/);
+			}
+		}
+	});
+
+	it("a code-shaped artifact under the doc surface is malformed, not silently graded", () => {
+		const g = gradeEntry(cases["review/doc"].entry, {verdict: "FAIL", acFindings: ["broken link"]});
+		assert.isTrue(isFail(g));
+		if (isFail(g)) {
+			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
+			if (g.mismatch._tag === "MalformedArtifact") {
+				assert.match(g.mismatch.reason, /^review-doc artifact:/);
+			}
+		}
+	});
+
+	it("the same inputRef on two surfaces grades independently (a mixed-surface PR, ADR 0243 §3)", () => {
+		const inputRef = 4979;
+		const code: CorpusEntry = {
+			stage: "review",
+			surface: "code",
+			inputRef,
+			label: {verdict: "PASS", acFindings: ["AC1 met"]},
+		};
+		const doc: CorpusEntry = {
+			stage: "review",
+			surface: "doc",
+			inputRef,
+			label: {verdict: "FAIL", findings: ["broken link"]},
+		};
+		assert.deepStrictEqual(gradeEntry(code, {verdict: "PASS", acFindings: ["AC1 met"]}), {
+			status: "pass",
+		});
+		assert.deepStrictEqual(gradeEntry(doc, {verdict: "FAIL", findings: ["broken link"]}), {
+			status: "pass",
+		});
 	});
 });

--- a/packages/fabrika-cli/src/eval/runner.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/runner.unit.test.ts
@@ -134,8 +134,7 @@ const corpus: CorpusManifest = {
 	stages: {
 		triage: [entryA, entryB],
 		build: [],
-		"review-code": [],
-		"review-doc": [],
+		review: [],
 		"ship-it": [],
 	},
 };

--- a/packages/fabrika-cli/src/eval/spawn.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/spawn.unit.test.ts
@@ -505,8 +505,7 @@ describe("toCaptureManifest — the existing collector consumes it unchanged", (
 					{stage: "triage", inputRef: 1, label: {type: "bug", priority: "p0", status: "triaged"}},
 				],
 				build: [],
-				"review-code": [],
-				"review-doc": [],
+				review: [],
 				"ship-it": [],
 			},
 		};
@@ -578,10 +577,13 @@ describe("flag parsing", () => {
 
 	it("accepts only live stage names", () => {
 		assert.isTrue(isStageName("build"));
-		assert.isTrue(isStageName("review-code"));
+		assert.isTrue(isStageName("review"));
 		assert.isFalse(isStageName("review-skill"));
-		// `write-code` survives only as a recorded row's provenance key (#4977) — never as a live stage.
+		// `write-code` and the two v1 review keys survive only as a recorded row's provenance key
+		// (#4977) — never as live stages. The surfaces are a sub-key of `review`, not stages (ADR 0243).
 		assert.isFalse(isStageName("write-code"));
+		assert.isFalse(isStageName("review-code"));
+		assert.isFalse(isStageName("review-doc"));
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
@@ -87,4 +87,32 @@ describe("the live stage vocabulary is what fabrika eval accepts", {
 		const accepted = fabrika("eval", "report", rows, "--baseline-stage", "build");
 		expect(accepted.code).toBe(0);
 	});
+
+	it("--stage review is accepted", () => {
+		const run = evalRun("review");
+		expect(run.code).toBe(0);
+		expect(run.stderr).not.toMatch(/not a known stage/);
+	});
+
+	for (const v1 of ["review-code", "review-doc"]) {
+		it(`--stage ${v1} is refused, naming the stages that do exist`, () => {
+			const run = evalRun(v1);
+			expect(run.code).not.toBe(0);
+			expect(run.stderr).toContain(`--stage '${v1}' is not a known stage`);
+			// The refusal names the live vocabulary, and the v1 key is not offered back inside it.
+			expect(run.stderr).toContain("(triage, build, review, ship-it)");
+			expect(run.stderr).not.toMatch(/\([^)]*review-(code|doc)/);
+		});
+
+		it(`--baseline-stage ${v1} is refused`, () => {
+			const refused = fabrika("eval", "report", emptyRowsFile(), "--baseline-stage", v1);
+			expect(refused.code).not.toBe(0);
+			expect(refused.stderr).toContain(`--baseline-stage '${v1}' is not a known stage`);
+		});
+	}
+
+	it("--baseline-stage review is accepted", () => {
+		const accepted = fabrika("eval", "report", emptyRowsFile(), "--baseline-stage", "review");
+		expect(accepted.code).toBe(0);
+	});
 });


### PR DESCRIPTION
Fixes #4979

Lands the merged `review` eval stage in `packages/fabrika-cli/src/eval/`, in the shape ADR 0243 rules: **one** `review` stage key, and every review entry carrying a `surface` discriminator that selects **both** the admissible label shape and the grader.

## What changed

**`corpus.ts` — the discriminator, not an annotation.** `STAGES` is now `["triage", "build", "review", "ship-it"]`. The `review` member of `CorpusEntry` is itself a union discriminated on `surface`, each member pinning a `Schema.Literal` and admitting exactly one label:

| `stage` | `surface` | admissible `label` |
|---|---|---|
| `review` | `code` | `{verdict, acFindings}` |
| `review` | `doc` | `{verdict, findings}` |

`surface` is required and carries no default — a `review` entry with no surface is a decode failure, never a row a fallback rubric grades.

**`oracle.ts` — dispatch on the pair.** `gradeEntry` narrows `stage` to `review`, then narrows again on `surface`, so each surface reaches its own grader and its own artifact schema. Dispatching a review grade on `stage` alone is exactly the silent two-rubrics-one-grader collapse ADR 0243 §2 bans.

**Recorded provenance is preserved, following the shape #5032 already established.** The already-committed v1 rows keep their `review-code` / `review-doc` stage keys and carry **no** `surface` (a live-schema field), and group under the live `review` key — the same live-key/recorded-key split `build` uses for its `write-code` rows. `corpus/review-code.json` is renamed `corpus/review.json` and its three rows are re-grouped, not re-keyed, mirroring the `write-code.json` → `build.json` rename.

## How the unrepresentability guarantee is shown to survive

The merge is where the guarantee is easiest to lose, because the two surfaces carry genuinely different label shapes (`acFindings` vs `findings`) — a bare `review` key would have made both legal under one key. It is proven at **two** layers, not asserted:

1. **Schema.** `corpus.unit.test.ts` decodes a doc-shaped label under `surface: "code"` (and the converse), a `review` entry with no `surface`, and a `surface` outside the two defined here — each rejected; the manifest-level case asserts the failure `reason` is exactly `schema-mismatch`.
2. **Type.** A `Inhabits<T> = T extends CorpusEntry ? true : false` probe pins three constants: the well-formed pair is `true` (the positive control, so the probe cannot be vacuous), and both the surface-mismatched and surface-less shapes are `false`. **The probe was verified to bind**: flipping `surfaceMismatched` to `true` reds `tsc` with `TS2322: Type 'true' is not assignable to type 'false'` at that line; it was then reverted.

`oracle.unit.test.ts` adds the grader-separation half: a doc-shaped artifact under the code surface returns `MalformedArtifact` with a `review-code artifact:` reason (and the converse with `review-doc artifact:`), so the two surfaces provably do not share a grader; plus one test for ADR 0243 §3's mixed-surface PR — the same `inputRef` under two surfaces grading independently.

## The `skill` surface is NOT defined here

The founder ruling on #4979 (option (ii)) scoped this lane to the `code` and `doc` surfaces only. **No `ReviewSkillEntry` shape was invented.** `REVIEW_SURFACES` names `code` and `doc`, a `surface: "skill"` entry is a decode failure, and a unit test pins that tuple so a later change to it is deliberate. Designing the skill surface's entry shape from the merged /review skill's rigor rubric is #5038.

## Verification

- `pnpm turbo run typecheck --force` — 30/30 successful, **0 cached** (forced, not a replayed FULL TURBO).
- `pnpm --filter @kampus/fabrika-cli exec vitest run` — 85 files, **1295 tests**, all passing.
- `pnpm lint` (biome) — clean.
- `fabrika eval check` run against all three committed manifests — `review.json`, `build.json`, `triage.json` each report `is a valid corpus manifest`.
- `fabrika eval` CLI vocabulary asserted in a real subprocess (`stage-vocabulary.cli.test.ts`): `--stage review` and `--baseline-stage review` accepted; `--stage review-code`, `--stage review-doc` and both `--baseline-stage` equivalents refused, with the refusal naming `(triage, build, review, ship-it)` and asserted **not** to offer a v1 key back inside that list.

## Files touched vs the issue's list

The issue's file list was a floor. Everything it named was touched. Two additions it did not name:

- **`stage-vocabulary.cli.test.ts`** — the file that actually proves AC1 in a real process (`--stage` and `--baseline-stage` validate through two different code paths). The issue named `command.ts`'s help text but not this test; `command.ts` itself needed **no** edit, because its stage-list help text already interpolates `STAGES`.
- **`corpus/build.json` and `corpus/triage.json`** — named indirectly ("the now-stale `review-doc` keys in its sibling manifests"), listed here explicitly.

`command.ts`, `runner.ts`, `report.ts` and `spawn.ts` needed no source edit: each already derives from `STAGES` or from `CorpusEntry["stage"]`.

## Deviations

- **`surface` sits on the entry, not inside the `label`.** ADR 0243's decision sentence reads "every review entry **and label** carries a `surface` discriminator", but its own §1 table fixes the admissible `label` as `{verdict, acFindings}` / `{verdict, findings}` — with no `surface` member — and states that `surface` *selects* the label shape, which it cannot do from inside the thing it selects. Duplicating it into the label would also make two `surface` fields that could be read as disagreeing. The §1 table is followed.
- **`REVIEW_SURFACES` names two surfaces, not the ADR's three.** ADR 0243 §1 names `code | doc | skill`; the founder ruling on #4979 split the `skill` entry shape into #5038 and forbade inventing one here. A tuple consumers enumerate cannot list a surface that has no entry shape, so it lists two, with the omission and its ticket recorded at the declaration.
- **`corpus/review-code.json` is renamed to `corpus/review.json`.** The issue said the file "moves to the new layout" without naming a rename. The rename follows the pattern PR #5032 set for the same re-key (`write-code.json` → `build.json`) — the file is named for the live stage it groups under, while the rows inside keep their recorded key. `git` records it as a rename (97% similarity), so history follows.
- **`reports/token-economics-measurement.md` still names the old manifest filenames** (`write-code.json`, `review-code.json`). It was left untouched: `reports/` holds dated point-in-time snapshots, and PR #5032 left the same line stale for its own re-key. Flagged rather than silently corrected — if a reviewer wants report text kept live, that is a separate call about `reports/` policy, not this lane's.
- **No change under `packages/fabrika-cli/src/wire/`** — the verdict-marker namespace is a separate axis from the eval stage key (ADR 0243 §5 fences it), and `verdict-marker.ts`'s `/^review(-[a-z0-9]+)*$/` already admits every namespace involved.
- **The scorecard's bucket key is untouched.** `report.ts` still keys cells on `entry.stage` alone; carrying `surface` onto it is #4980, explicitly out of scope here.

## Out of scope (per the issue and ADR 0243 §5)

The scorecard's surface-carrying bucket key (#4980), anything under `src/wire/`, and any GitHub label / triage involvement — `surface` is a field in graded ground truth, not a label anyone applies, and runtime rubric routing stays derived from the diff.
