### PR TITLE
feat(fabrika-cli): the fourteen `build` verbs the /build contract specifies (#4988)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ node_modules
 
 dist
 build
-# the fabrika /build skill is source, not build output (#4707 rename collision)
+# `build` names a fabrika surface, not build output — both are source (#4707, #4988)
 !claude-plugins/fabrika/skills/build/
+!packages/fabrika-cli/src/build/
 *.tsbuildinfo
 .next
 

--- a/packages/fabrika-cli/src/build/authored.ts
+++ b/packages/fabrika-cli/src/build/authored.ts
@@ -1,0 +1,66 @@
+/**
+ * The guard over **authored** text — the bytes the caller just wrote — for `build pr` and `build note`.
+ *
+ * Four outcomes, and the first two must never collapse: an **unread** pipe is UNKNOWN and seats on
+ * `1`, a **read-but-empty** one is a proven `3`. Swallowing the first into the second makes an unread
+ * pipe byte-identical to an empty one, and the caller then decides over evidence it never saw (#3924).
+ * A body that IS a path is `6` rather than `5` because the fixes are opposite: the loop on a leak is
+ * *rewrite and resend*, and on a body that is a path that loop never terminates (#3086).
+ *
+ * **The predicates are the shipped `report/leaks.ts` ones, imported** — a second leak predicate that
+ * drifts from the first is worse than either alone. Only the message wording is this group's.
+ */
+import type {StdinRead} from "../io/stdin.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {BARE_AT_PATH, EMPTY_STDIN, LEAKED_PATH} from "./codes.ts";
+
+export interface AuthoredSurface {
+	readonly verb: string;
+	/** The whole `3` message — the contract states it per verb, so it is not composed here. */
+	readonly emptyMessage: string;
+	/** The whole `6` message, for the same reason. */
+	readonly bareAtMessage: string;
+}
+
+export type Authored =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Text"; readonly text: string; readonly bytes: number};
+
+export const readAuthored = (surface: AuthoredSurface, read: StdinRead): Authored => {
+	if (read._tag === "Failed") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				FAILED,
+				`${surface.verb}: could not read stdin: ${read.reason} — the body is UNKNOWN, never empty.`,
+			),
+		};
+	}
+	const text = read._tag === "NoStdin" ? "" : read.text;
+	const bytes = new TextEncoder().encode(text).length;
+	if (text.trim() === "") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(EMPTY_STDIN, surface.emptyMessage, [
+				`${surface.verb}: stdin was read and held ${bytes} byte(s).`,
+			]),
+		};
+	}
+	if (isBareAtReference(text)) {
+		return {_tag: "Refused", outcome: refuse(BARE_AT_PATH, surface.bareAtMessage)};
+	}
+	return {_tag: "Text", text, bytes};
+};
+
+/** The leak refusal for `body`, or `null` when it carries no machine-local path. */
+export const leakRefusal = (verb: string, body: string): VerbOutcome | null => {
+	const scan = scanBody(body);
+	const first = scan.leaks[0];
+	if (first === undefined) return null;
+	return refuse(
+		LEAKED_PATH,
+		`${verb}: the body carries a machine-local path: ${first.text} — redact before posting.`,
+		renderLeaks(scan.leaks),
+	);
+};

--- a/packages/fabrika-cli/src/build/branch-verb.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.ts
@@ -1,0 +1,150 @@
+/**
+ * `build branch` — cut, or resume, the lane's nonce branch off a **freshly fetched** base.
+ *
+ * The lane-identity rule lives in `lane.ts`; this verb is where a name that obeys it first comes into
+ * existence. Create mode cuts `build/<number>-<slug>-<nonce>` off `FETCH_HEAD` — never a local
+ * `origin/main`, which can predate the base the lane needs (#1920 / #3621). Resume mode checks the
+ * PR's head branch out under the **local** name `build/pr-<pr>-<nonce>` with its upstream pointed at
+ * the remote head, so `build push` updates the PR while the local name carries *this* repair claim's
+ * nonce — which is what stops a dead earlier lane from pinning this one (#4868's class).
+ *
+ * A re-run is idempotent: the nonce is a function of the claim, so the second run resolves the same
+ * name and switches to it instead of failing on a branch that is already there.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {requireClaim, requireSession} from "./claim.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {branchExists, fetchBase, setUpstream, switchTo, switchToNew} from "./git.ts";
+import {getPullHead} from "./github.ts";
+import {createBranchName, isKebabSlug, nonceOf, resumeBranchName} from "./lane.ts";
+import {resolveTargetRepo} from "./target.ts";
+import {assertGround} from "./worktree.ts";
+
+const VERB = "build branch";
+
+export interface BranchOptions {
+	/** Create mode: the claimed issue the branch serves. `null` in resume mode. */
+	readonly number: number | null;
+	readonly slug: string | null;
+	readonly base: string;
+	/** Resume mode: the PR whose head branch to publish back to. Exclusive with `number`. */
+	readonly resume: number | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** Check the branch out, whether or not it already exists — the idempotent half. */
+const checkout = (name: string, start: string) =>
+	Effect.gen(function* () {
+		return (yield* branchExists(name)) ? yield* switchTo(name) : yield* switchToNew(name, start);
+	});
+
+export const runBranch = (
+	options: BranchOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {number, slug, resume} = options;
+		if ((number === null) === (resume === null)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: give either <number> --slug <slug> or --resume <pr>, never both and never neither.`,
+			);
+		}
+		if (resume === null && (slug === null || !isKebabSlug(slug))) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --slug "${slug ?? ""}" is not kebab-case (lowercase letters, digits, single hyphens, ≤5 words).`,
+			);
+		}
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const ground = yield* assertGround(VERB, false);
+		if (ground._tag === "Refused") {
+			return refuse(
+				ground.outcome.code,
+				`${VERB}: this is the primary checkout — refusing to branch here.`,
+				ground.outcome.stderr.slice(0, -1),
+			);
+		}
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const claimed = resume ?? (number as number);
+		const held = yield* requireClaim(VERB, repo, claimed, session.id);
+		if (held._tag === "Refused") return held.outcome;
+		const nonce = nonceOf(held.marker.token);
+		if (nonce === null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: the claim on #${claimed} carries the token ${held.marker.token}, which yields no lane nonce — the lane is UNKNOWN.`,
+				held.notes,
+			);
+		}
+
+		if (resume !== null) {
+			const head = yield* getPullHead(repo, resume);
+			if (head._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read PR #${resume}: ${head.reason} — nothing was checked out.`,
+					held.notes,
+				);
+			}
+			if (head._tag === "Absent" || head.value.state !== "open" || head.value.merged) {
+				return refuse(
+					ZERO_SCOPE,
+					`${VERB}: PR #${resume} is proven closed or merged — nothing to resume.`,
+					held.notes,
+				);
+			}
+			const fetched = yield* fetchBase(`origin/${head.value.ref}`);
+			if (fetched._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot fetch origin/${head.value.ref}: ${fetched.reason} — refusing to cut a branch off a stale base.`,
+					held.notes,
+				);
+			}
+			const name = resumeBranchName(resume, nonce);
+			const switched = yield* checkout(name, fetched.value);
+			if (switched._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot check out ${name}: ${switched.reason} — nothing was changed.`,
+					held.notes,
+				);
+			}
+			const upstream = yield* setUpstream(name, "origin", head.value.ref);
+			return upstream._tag === "Failure"
+				? refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: ${name} is checked out but its upstream could not be set to origin/${head.value.ref}: ${upstream.reason} — a push would not reach PR #${resume}.`,
+						held.notes,
+					)
+				: answer(name, held.notes);
+		}
+
+		const fetched = yield* fetchBase(options.base);
+		if (fetched._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot fetch ${options.base}: ${fetched.reason} — refusing to cut a branch off a stale base.`,
+				held.notes,
+			);
+		}
+		const name = createBranchName(number as number, slug as string, nonce);
+		const switched = yield* checkout(name, fetched.value);
+		return switched._tag === "Failure"
+			? refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot cut ${name} off ${options.base}: ${switched.reason} — nothing was changed.`,
+					held.notes,
+				)
+			: answer(name, held.notes);
+	});

--- a/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
@@ -1,0 +1,202 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {runBranch} from "./branch-verb.ts";
+import {
+	CLAIM_NOT_MINE,
+	NOT_A_WORKTREE,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	comments,
+	HEAD,
+	issue,
+	LANE_UUID,
+	LINKED,
+	marker,
+	NONCE,
+	PRIMARY,
+} from "./fixtures.test-support.ts";
+
+const REV_PARSE = /^git rev-parse --path-format=absolute/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const REMOTES = /^git remote$/;
+const FETCH = /^git fetch --quiet origin main$/;
+const RESOLVE = /^git rev-parse --verify --quiet FETCH_HEAD/;
+const VERIFY_BRANCH = /^git rev-parse --verify --quiet refs\/heads\//;
+const SWITCH_NEW = /^git switch -c /;
+
+const MINE = comments({id: 1, body: marker("s-9f2e", LANE_UUID)});
+
+const options = {
+	number: 4312 as number | null,
+	slug: "editor-focus-loss" as string | null,
+	base: "origin/main",
+	resume: null as number | null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+};
+
+const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[REV_PARSE, LINKED],
+	[ISSUE, issue()],
+	[COMMENTS, MINE],
+	[PERM, okOut("write\n")],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runBranch({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runBranch — create mode", () => {
+	it("cuts the lane branch off FETCH_HEAD and prints its name", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[REMOTES, okOut("origin\n")],
+			[FETCH, okOut("")],
+			[RESOLVE, okOut(`${HEAD}\n`)],
+			[VERIFY_BRANCH, errOut("")],
+			[SWITCH_NEW, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runBranch(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`build/4312-editor-focus-loss-${NONCE}\n`);
+		expect(shell.calls).toContain(`git switch -c build/4312-editor-focus-loss-${NONCE} ${HEAD}`);
+	});
+
+	it("fetches BEFORE it cuts — never off a stale local ref (#1920)", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[REMOTES, okOut("origin\n")],
+			[FETCH, okOut("")],
+			[RESOLVE, okOut(`${HEAD}\n`)],
+			[VERIFY_BRANCH, errOut("")],
+			[SWITCH_NEW, okOut("")],
+		]);
+		await Effect.runPromise(Effect.provide(runBranch(options), shell.layer));
+		expect(shell.calls.findIndex((l) => FETCH.test(l))).toBeLessThan(
+			shell.calls.findIndex((l) => SWITCH_NEW.test(l)),
+		);
+	});
+
+	it("resumes an existing branch of the same nonce instead of failing — a re-run is idempotent", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[REMOTES, okOut("origin\n")],
+			[FETCH, okOut("")],
+			[RESOLVE, okOut(`${HEAD}\n`)],
+			[VERIFY_BRANCH, okOut(`${HEAD}\n`)],
+			[/^git switch build\//, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runBranch(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls.some((l) => SWITCH_NEW.test(l))).toBe(false);
+	});
+
+	it("refuses a flag-shaped slug on 10, before touching git (#4854)", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, slug: "-rf"}), shell.layer),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			'build branch: --slug "-rf" is not kebab-case (lowercase letters, digits, single hyphens, ≤5 words).',
+		);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses the primary checkout on 12, in its own words", async () => {
+		const out = await run([[REV_PARSE, PRIMARY]]);
+		expect(out.code).toBe(NOT_A_WORKTREE);
+		expect(out.stderr.at(-1)).toBe(
+			"build branch: this is the primary checkout — refusing to branch here.",
+		);
+	});
+
+	it("refuses a foreign claim on 15 — nothing is cut", async () => {
+		const shell = fakeShell([
+			[REV_PARSE, LINKED],
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runBranch(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(shell.calls.some((l) => /git switch/.test(l))).toBe(false);
+	});
+
+	it("refuses a failed fetch on 11 rather than cutting off a stale base", async () => {
+		const out = await run([
+			...CLAIMED,
+			[REMOTES, okOut("origin\n")],
+			[FETCH, errOut("fatal: could not read from remote repository")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("refusing to cut a branch off a stale base");
+	});
+
+	it("refuses both modes at once, and neither mode at all", async () => {
+		const both = await run([], {resume: 4310});
+		expect(both.code).toBe(OFF_VOCABULARY);
+		const neither = await run([], {number: null, slug: null});
+		expect(neither.code).toBe(OFF_VOCABULARY);
+	});
+});
+
+describe("runBranch — resume mode", () => {
+	const RESUME_ISSUE = /^gh api repos\/o\/r\/issues\/4310$/;
+	const RESUME_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
+	const PULL_HEAD = /^gh api repos\/o\/r\/pulls\/4310 --jq/;
+	const resumeOptions = {number: null, slug: null, resume: 4310};
+
+	it("checks the PR's head out under this claim's own local lane name, with the upstream set", async () => {
+		const shell = fakeShell([
+			[REV_PARSE, LINKED],
+			[RESUME_ISSUE, issue({number: 4310})],
+			[RESUME_COMMENTS, MINE],
+			[PERM, okOut("write\n")],
+			[PULL_HEAD, okOut(`umut/fix-focus\t${HEAD}\topen\tfalse\n`)],
+			[REMOTES, okOut("origin\n")],
+			[/^git fetch --quiet origin umut\/fix-focus$/, okOut("")],
+			[RESOLVE, okOut(`${HEAD}\n`)],
+			[VERIFY_BRANCH, errOut("")],
+			[SWITCH_NEW, okOut("")],
+			[/^git branch --set-upstream-to=origin\/umut\/fix-focus/, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...resumeOptions}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`build/pr-4310-${NONCE}\n`);
+		expect(shell.calls).toContain(
+			`git branch --set-upstream-to=origin/umut/fix-focus build/pr-4310-${NONCE}`,
+		);
+	});
+
+	it("refuses a merged PR on 7 — nothing to resume", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, LINKED],
+				[RESUME_ISSUE, issue({number: 4310})],
+				[RESUME_COMMENTS, MINE],
+				[PERM, okOut("write\n")],
+				[PULL_HEAD, okOut(`umut/fix-focus\t${HEAD}\tclosed\ttrue\n`)],
+			],
+			resumeOptions,
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe(
+			"build branch: PR #4310 is proven closed or merged — nothing to resume.",
+		);
+	});
+});

--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -1,0 +1,258 @@
+/**
+ * `build check` — this surface's validators, run in this tree, with the build cache **bypassed**.
+ *
+ * The bypass is the design, not an option. A cache hit from another worktree returned another tree's
+ * green three times in one session (#4106) and recurred on the review side (#4887); re-running is
+ * cheaper than trusting a key that has already lied. And the command set is the verb's, not the
+ * agent's memory: v1 mandated the exact CI commands in prose with nothing enforcing it
+ * (`SKILL.md:895-935`).
+ *
+ * **This verb predicts; the gate decides.** `ci.yml` owns redness, and where the two disagree the
+ * gate's answer supersedes this one (interface convention rule 6). Nothing here re-reads CI.
+ *
+ * `--surface` is an **anchor, not a second classifier**: naming the surface is a judgement the skill
+ * makes reading the issue, and a verb that guessed it from file extensions would be wrong exactly on
+ * the mixed diffs where the answer matters. The verb takes the skill's answer and refuses one the diff
+ * provably contradicts.
+ */
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {execCapture} from "../io/exec.ts";
+import {scanBody} from "../report/leaks.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {requireSession} from "./claim.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, VALIDATION_RED, ZERO_SCOPE} from "./codes.ts";
+import {predecessorsOf, readTopology, renderRef, sameRef} from "./dependencies.ts";
+import {changedFiles, mergeBase} from "./git.ts";
+import {defaultBranch} from "./github.ts";
+import {requireLane} from "./lane-guard.ts";
+import {resolveTargetRepo} from "./target.ts";
+
+const VERB = "build check";
+
+export const SURFACES = ["code", "prose", "plan"] as const;
+export type Surface = (typeof SURFACES)[number];
+
+const CODE_RE = /\.(ts|tsx|js|jsx|mjs|cjs|json)$/;
+const MARKDOWN_RE = /\.mdx?$/;
+
+/** The exact CI commands, cache-bypassed. `--force` is turbo's; `lint:worktree` has no cache to hit. */
+const CODE_RUNNERS: ReadonlyArray<{readonly label: string; readonly argv: ReadonlyArray<string>}> =
+	[
+		{label: "pnpm typecheck --force", argv: ["typecheck", "--force"]},
+		{label: "pnpm lint:worktree", argv: ["lint:worktree"]},
+	];
+
+export interface CheckOptions {
+	readonly surface: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** Why `--surface` provably contradicts the diff, or `null`. */
+export const surfaceMismatch = (surface: Surface, files: ReadonlyArray<string>): string | null => {
+	const code = files.filter((f) => CODE_RE.test(f));
+	const markdown = files.filter((f) => MARKDOWN_RE.test(f));
+	if (surface === "prose" && code.length > 0) {
+		return `--surface prose, but the diff is ${code.length} ${code.length === 1 ? "code file" : "code files"}`;
+	}
+	if (surface === "code" && code.length === 0) {
+		return "--surface code, but the diff changes no code file";
+	}
+	if (surface === "plan" && markdown.length === 0) {
+		return "--surface plan, but the diff changes no markdown file";
+	}
+	return null;
+};
+
+/** The machine-local paths a prose file carries, as defect lines. */
+const leakDefects = (file: string, text: string): ReadonlyArray<string> =>
+	scanBody(text).leaks.map(
+		(leak) => `${file}:${leak.line} carries a machine-local path (${leak.class}): ${leak.text}`,
+	);
+
+/**
+ * Every in-repo link target a markdown file names.
+ *
+ * Absolute URLs and bare fragments are skipped: a link with a scheme is not this tree's to resolve,
+ * and a fragment resolves within the page. A fabrika doc cited by a relative path is covered by the
+ * same rule, so there is no second reference check to drift from this one.
+ */
+/** Fold `.` and `..` out of an absolute path, so a link's target is compared in one spelling. */
+export const normalizePath = (path: string): string => {
+	const out: string[] = [];
+	for (const segment of path.split("/")) {
+		if (segment === "" || segment === ".") continue;
+		if (segment === "..") out.pop();
+		else out.push(segment);
+	}
+	return `/${out.join("/")}`;
+};
+
+export const linkTargets = (text: string): ReadonlyArray<string> => {
+	const targets: string[] = [];
+	for (const match of text.matchAll(/\[[^\]]*\]\(([^)\s]+)[^)]*\)/g)) {
+		const target = (match[1] ?? "").split("#")[0]?.trim() ?? "";
+		if (target === "" || /^[a-z][a-z0-9+.-]*:/i.test(target)) continue;
+		targets.push(target);
+	}
+	return targets;
+};
+
+const planDefects = (file: string, text: string): ReadonlyArray<string> => {
+	const topology = readTopology(text);
+	if (topology._tag === "Absent") return [];
+	if (topology._tag === "Unparseable") {
+		return [
+			`${file}:${topology.line} does not parse under the "## Dependencies" grammar: "${topology.text}"`,
+		];
+	}
+	const defects: string[] = [];
+	const declared = topology.edges.flatMap((edge) =>
+		edge._tag === "Phase" ? edge.members : [edge.subject, ...edge.needs],
+	);
+	for (const edge of topology.edges) {
+		if (edge._tag !== "Requires") continue;
+		if (edge.needs.some((need) => sameRef(need, edge.subject))) {
+			defects.push(`${file}: ${renderRef(edge.subject)} requires itself`);
+		}
+	}
+	for (const ref of declared) {
+		if (ref._tag !== "Local") continue;
+		const named = topology.edges.some(
+			(edge) => edge._tag === "Phase" && edge.members.some((member) => sameRef(member, ref)),
+		);
+		if (!named) defects.push(`${file}: ${renderRef(ref)} is not named by any phase line`);
+	}
+	for (const ref of declared) {
+		if (ref._tag !== "Issue") continue;
+		const cycle = predecessorsOf(topology.edges, ref).some(({ref: predecessor}) =>
+			sameRef(predecessor, ref),
+		);
+		if (cycle) defects.push(`${file}: #${ref.number} is its own predecessor`);
+	}
+	return defects;
+};
+
+export const runCheck = (
+	options: CheckOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const surface = options.surface.trim().toLowerCase();
+		if (!(SURFACES as ReadonlyArray<string>).includes(surface)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --surface "${options.surface}" is off the closed vocabulary (${SURFACES.join(" | ")}).`,
+			);
+		}
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const lane = yield* requireLane(VERB, resolved.repo, session.id, null);
+		if (lane._tag === "Refused") return lane.outcome;
+
+		const branch = yield* defaultBranch(resolved.repo);
+		if (branch._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${resolved.repo}'s default branch: ${branch.reason} — the diff base is UNKNOWN, never green.`,
+				lane.notes,
+			);
+		}
+		const base = `origin/${branch.value}`;
+		const merged = yield* mergeBase(base);
+		if (merged._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve the merge base with ${base}: ${merged.reason} — the verdict is UNKNOWN, never green.`,
+				lane.notes,
+			);
+		}
+		const listed = yield* changedFiles(merged.value);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the diff against ${base}: ${listed.reason} — the verdict is UNKNOWN, never green.`,
+				lane.notes,
+			);
+		}
+		const files = listed.value;
+		const scope = [...lane.notes, `${VERB}: ${files.length} changed file(s) against ${base}.`];
+		if (files.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: the diff against ${base} is empty — nothing to validate (ADR 0092).`,
+				scope,
+			);
+		}
+		const mismatch = surfaceMismatch(surface as Surface, files);
+		if (mismatch !== null) {
+			return refuse(OFF_VOCABULARY, `${VERB}: ${mismatch} — the surface is provably wrong.`, scope);
+		}
+
+		if (surface === "code") {
+			const ran: string[] = [];
+			for (const runner of CODE_RUNNERS) {
+				const result = yield* execCapture("pnpm", runner.argv);
+				ran.push(runner.label);
+				if (!result.ok) {
+					return refuse(
+						VALIDATION_RED,
+						`${VERB}: red — ${runner.label} failed; diagnostics above.`,
+						[...scope, result.reason],
+					);
+				}
+			}
+			return answer(JSON.stringify({verdict: "green", surface, tree: lane.root, ran}), scope);
+		}
+
+		const fs = yield* FileSystem.FileSystem;
+		const markdown = files.filter((file) => MARKDOWN_RE.test(file));
+		const defects: string[] = [];
+		for (const file of markdown) {
+			const path = `${lane.root}/${file}`;
+			const text = yield* fs.readFileString(path).pipe(
+				Effect.map((t) => ({ok: true, t}) as {ok: boolean; t: string}),
+				Effect.catchTag("PlatformError", () => Effect.succeed({ok: false, t: ""})),
+			);
+			if (!text.ok) continue; // a deleted file has nothing to validate; the diff still counted it.
+			if (surface !== "prose") {
+				defects.push(...planDefects(file, text.t));
+				continue;
+			}
+			defects.push(...leakDefects(file, text.t));
+			const dir = path.slice(0, path.lastIndexOf("/"));
+			for (const target of linkTargets(text.t)) {
+				const absolute = normalizePath(
+					target.startsWith("/") ? `${lane.root}${target}` : `${dir}/${target}`,
+				);
+				const there = yield* fs
+					.exists(absolute)
+					.pipe(Effect.catchTag("PlatformError", () => Effect.succeed(false)));
+				if (!there) defects.push(`${file} links to "${target}", which does not resolve`);
+			}
+		}
+		if (defects.length > 0) {
+			return refuse(
+				VALIDATION_RED,
+				`${VERB}: red — the ${surface} validators failed; diagnostics above.`,
+				[...scope, ...defects],
+			);
+		}
+		return answer(
+			JSON.stringify({
+				verdict: "green",
+				surface,
+				tree: lane.root,
+				ran: [surface === "prose" ? "markdown link + leak scan" : "## Dependencies grammar"],
+			}),
+			scope,
+		);
+	});

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -1,0 +1,218 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {runCheck, surfaceMismatch} from "./check-verb.ts";
+import {
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	VALIDATION_RED,
+	WRONG_LANE,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {comments, HEAD, issue, LANE_UUID, LINKED, marker, NONCE} from "./fixtures.test-support.ts";
+
+const REV_PARSE = /^git rev-parse --path-format=absolute/;
+const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const REPO_META = /^gh api repos\/o\/r --jq \.default_branch$/;
+const MERGE_BASE = /^git merge-base HEAD origin\/main$/;
+const DIFF = /^git diff --name-only /;
+const TYPECHECK = /^pnpm typecheck --force$/;
+const LINT = /^pnpm lint:worktree$/;
+
+const LANE = `build/4312-editor-focus-loss-${NONCE}`;
+
+const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[REV_PARSE, LINKED],
+	[BRANCH, okOut(`${LANE}\n`)],
+	[ISSUE, issue()],
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, okOut("write\n")],
+	[REPO_META, okOut("main\n")],
+	[MERGE_BASE, okOut(`${HEAD}\n`)],
+];
+
+const options = {
+	surface: "code",
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	files: Record<string, string> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runCheck({...options, ...overrides}),
+			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+		),
+	);
+
+describe("surfaceMismatch — the anchor, not a second classifier", () => {
+	it("refuses --surface prose over changed code files", () => {
+		expect(surfaceMismatch("prose", ["a.ts", "b.ts"])).toContain("2 code files");
+	});
+
+	it("refuses --surface code over a diff with no code file", () => {
+		expect(surfaceMismatch("code", ["README.md"])).toContain("no code file");
+	});
+
+	it("accepts a mixed diff under --surface code", () => {
+		expect(surfaceMismatch("code", ["a.ts", "README.md"])).toBeNull();
+	});
+});
+
+describe("runCheck", () => {
+	it("runs the exact CI commands with the cache bypassed, and reports what ran", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[DIFF, okOut("apps/web/src/App.tsx\n")],
+			[TYPECHECK, okOut("")],
+			[LINT, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runCheck(options), Layer.merge(shell.layer, fakeFs({}).layer)),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			verdict: "green",
+			surface: "code",
+			tree: "/repo/trees/lane-a",
+			ran: ["pnpm typecheck --force", "pnpm lint:worktree"],
+		});
+		expect(shell.calls).toContain("pnpm typecheck --force");
+	});
+
+	it("refuses red on 18, naming the runner that failed, with nothing on stdout", async () => {
+		const out = await run([
+			...LANE_OK,
+			[DIFF, okOut("apps/web/src/App.tsx\n")],
+			[TYPECHECK, errOut("src/App.tsx(12,3): error TS2345")],
+		]);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"build check: red — pnpm typecheck --force failed; diagnostics above.",
+		);
+	});
+
+	it("refuses an empty diff on 7 — zero scope is never a vacuous green (ADR 0092)", async () => {
+		const out = await run([...LANE_OK, [DIFF, okOut("")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe(
+			"build check: the diff against origin/main is empty — nothing to validate (ADR 0092).",
+		);
+	});
+
+	it("refuses a surface the diff provably contradicts on 10", async () => {
+		const out = await run([...LANE_OK, [DIFF, okOut("apps/web/src/App.tsx\nsrc/x.ts\n")]], {
+			surface: "prose",
+		});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			"build check: --surface prose, but the diff is 2 code files — the surface is provably wrong.",
+		);
+	});
+
+	it("refuses an off-enum surface on 10, before touching the tree", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runCheck({...options, surface: "design"}),
+				Layer.merge(shell.layer, fakeFs({}).layer),
+			),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a branch that is not this lane's on 14", async () => {
+		const out = await run([
+			[REV_PARSE, LINKED],
+			[BRANCH, okOut("main\n")],
+		]);
+		expect(out.code).toBe(WRONG_LANE);
+	});
+
+	it("refuses an unreadable diff on 11 — UNKNOWN, never green", async () => {
+		const out = await run([...LANE_OK, [DIFF, errOut("fatal: bad revision")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the verdict is UNKNOWN, never green");
+	});
+
+	it("reds a prose diff whose relative link does not resolve", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/guide.md\n")]],
+			{surface: "prose"},
+			{"/repo/trees/lane-a/docs/guide.md": "see [the other page](./missing.md)\n"},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("does not resolve"))).toBe(true);
+	});
+
+	it("reds a prose diff carrying a machine-local path", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/guide.md\n")]],
+			{surface: "prose"},
+			{"/repo/trees/lane-a/docs/guide.md": "run it from /Users/someone/phoenix\n"},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("machine-local path"))).toBe(true);
+	});
+
+	it("greens a prose diff whose links resolve", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/guide.md\n")]],
+			{surface: "prose"},
+			{
+				"/repo/trees/lane-a/docs/guide.md": "see [the other page](./other.md)\n",
+				"/repo/trees/lane-a/docs/other.md": "here\n",
+			},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).verdict).toBe("green");
+	});
+
+	it("reds a plan diff whose Dependencies block does not parse", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("plans/epic.md\n")]],
+			{surface: "plan"},
+			{"/repo/trees/lane-a/plans/epic.md": "## Dependencies\n\n- #12 comes after the API work\n"},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("does not parse"))).toBe(true);
+	});
+
+	it("reds a plan whose child requires itself", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("plans/epic.md\n")]],
+			{surface: "plan"},
+			{
+				"/repo/trees/lane-a/plans/epic.md":
+					"## Dependencies\n\n- phase 1: #12\n- #12 requires: #12\n",
+			},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("requires itself"))).toBe(true);
+	});
+
+	it("greens a well-formed plan", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("plans/epic.md\n")]],
+			{surface: "plan"},
+			{
+				"/repo/trees/lane-a/plans/epic.md":
+					"## Dependencies\n\n- phase 1: #12\n- phase 2: #13\n- #13 requires: #12\n",
+			},
+		);
+		expect(out.code).toBe(0);
+	});
+});

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -1,0 +1,212 @@
+/**
+ * `build claim` / `build confirm` / `build release` — one protocol, three verbs, in one file because
+ * splitting them across three is how two of them come to disagree about who holds a lane.
+ *
+ * The race is detect-then-tiebreak, not a lock: post the marker, **re-read**, and the earliest
+ * authorized marker wins. Posting alone only detects a race; the checkpoint read is what resolves it,
+ * and a claim that skipped it would let two staggered co-racers both proceed.
+ *
+ * **A lost race is a proven outcome on its own code, never exit 0.** v1's direct-claim script exited 0
+ * on both won and lost and left the routing to prose (`step3-direct-claim.sh:31,40`), and v1's
+ * `claim is-mine` fused "proven lost" with "no session id" on exit 1 (`claim/command.ts:57`). Here
+ * `15` is proven-foreign only, a missing session id is `1`, and an unreadable marker set is `11`.
+ *
+ * A loser retracts its **own** marker and nothing else — never another lane's, which is the one write
+ * this protocol must never make.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, deleteComment, getComment} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {composeMarker, readMarkerToken, requireSession, resolveOwnership} from "./claim.ts";
+import {CLAIM_NOT_MINE, PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {composeToken} from "./lane.ts";
+import {openIssue, resolveTargetRepo} from "./target.ts";
+
+export interface ClaimOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** A fresh UUID, supplied by the adapter so the token this run mints is deterministic under test. */
+	readonly uuid: string;
+	/** The marker's human-readable ISO-8601 timestamp. The tiebreak uses GitHub's `created_at`. */
+	readonly at: string;
+}
+
+export type ProtocolOptions = Omit<ClaimOptions, "uuid" | "at">;
+
+const preflight = (
+	verb: string,
+	options: ProtocolOptions,
+): Effect.Effect<
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Ready"; readonly repo: string; readonly session: string},
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const session = requireSession(verb, options.env);
+		if (session._tag === "Refused") return {_tag: "Refused" as const, outcome: session.outcome};
+		const resolved = yield* resolveTargetRepo(verb, options.repo, options.env);
+		if (resolved._tag === "Refused") return {_tag: "Refused" as const, outcome: resolved.outcome};
+		const target = yield* openIssue(
+			verb,
+			resolved.repo,
+			options.number,
+			(reason) =>
+				`${verb}: cannot read #${options.number}: ${reason} — ownership is UNKNOWN, never "unclaimed".`,
+		);
+		if (target._tag === "Refused") return {_tag: "Refused" as const, outcome: target.outcome};
+		return {_tag: "Ready" as const, repo: resolved.repo, session: session.id};
+	});
+
+const CLAIM = "build claim";
+
+export const runClaim = (
+	options: ClaimOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const ready = yield* preflight(CLAIM, options);
+		if (ready._tag === "Refused") return ready.outcome;
+		const {repo, session} = ready;
+		const {number} = options;
+
+		const token = composeToken(session, options.uuid);
+		const body = composeMarker(token, options.at);
+		const posted = yield* createComment(repo, number, body);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${CLAIM}: the marker write failed: ${posted.reason} — the claim state is UNKNOWN; run "fabrika build confirm ${number}" before any further action.`,
+			);
+		}
+		const back = yield* getComment(repo, posted.value.id);
+		if (back._tag === "Failure" || readMarkerToken(normalizeForReadback(back.value)) !== token) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${CLAIM}: the marker landed but the read-back does not match — the claim needs a human eye.`,
+				[`${CLAIM}: comment ${posted.value.id} on #${number} is the one to inspect.`],
+			);
+		}
+
+		// The checkpoint: posting DETECTS a race, this re-read RESOLVES it.
+		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session);
+		const notes = unauthorized.map(
+			(marker) =>
+				`${CLAIM}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
+		);
+		if (ownership._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${CLAIM}: cannot read the claim markers on #${number}: ${ownership.reason} — ownership is UNKNOWN, never "unclaimed".`,
+				notes,
+			);
+		}
+		if (ownership._tag === "Mine") {
+			return answer(JSON.stringify({answer: "won", number, token}), notes);
+		}
+
+		// Lost, or shadowed by an unauthorized-only thread: retract this run's OWN marker, nothing else.
+		const retracted = yield* deleteComment(repo, posted.value.id);
+		const trailer =
+			retracted._tag === "Failure"
+				? [
+						`${CLAIM}: could not retract this run's own marker (comment ${posted.value.id}): ${retracted.reason}.`,
+					]
+				: [`${CLAIM}: retracted this run's own marker (comment ${posted.value.id}).`];
+		return ownership._tag === "Foreign"
+			? refuse(
+					CLAIM_NOT_MINE,
+					`${CLAIM}: lost to ${ownership.marker.token} (posted ${ownership.marker.createdAt}, authorized).`,
+					[...notes, ...trailer],
+				)
+			: refuse(
+					CLAIM_NOT_MINE,
+					`${CLAIM}: this run's own marker is not authorized — its author holds no write permission, so it can never win (ADR 0055).`,
+					[...notes, ...trailer],
+				);
+	});
+
+const CONFIRM = "build confirm";
+
+export const runConfirm = (
+	options: ProtocolOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const ready = yield* preflight(CONFIRM, options);
+		if (ready._tag === "Refused") return ready.outcome;
+		const {repo, session} = ready;
+		const {number} = options;
+
+		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session);
+		const notes = unauthorized.map(
+			(marker) =>
+				`${CONFIRM}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
+		);
+		switch (ownership._tag) {
+			case "Unknown":
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${CONFIRM}: cannot read the claim markers on #${number}: ${ownership.reason} — ownership is UNKNOWN, never "unclaimed".`,
+					notes,
+				);
+			case "Unclaimed":
+				return refuse(
+					CLAIM_NOT_MINE,
+					`${CONFIRM}: no claim exists on #${number} — nothing to confirm; run "fabrika build claim ${number}" first.`,
+					notes,
+				);
+			case "Foreign":
+				return refuse(
+					CLAIM_NOT_MINE,
+					`${CONFIRM}: #${number} is held by ${ownership.marker.token}, not this session.`,
+					notes,
+				);
+			case "Mine":
+				return answer(
+					JSON.stringify({answer: "mine", number, token: ownership.marker.token}),
+					notes,
+				);
+		}
+	});
+
+const RELEASE = "build release";
+
+export const runRelease = (
+	options: ProtocolOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const ready = yield* preflight(RELEASE, options);
+		if (ready._tag === "Refused") return ready.outcome;
+		const {repo, session} = ready;
+		const {number} = options;
+
+		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session);
+		const notes = unauthorized.map(
+			(marker) =>
+				`${RELEASE}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
+		);
+		if (ownership._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${RELEASE}: cannot read the claim markers on #${number}: ${ownership.reason} — ownership is UNKNOWN, never "unclaimed".`,
+				notes,
+			);
+		}
+		if (ownership._tag !== "Mine") {
+			return refuse(
+				CLAIM_NOT_MINE,
+				`${RELEASE}: this session holds no claim on #${number} — refusing to release another lane's.`,
+				notes,
+			);
+		}
+		const deleted = yield* deleteComment(repo, ownership.marker.commentId);
+		return deleted._tag === "Failure"
+			? refuse(
+					WRITE_UNKNOWN,
+					`${RELEASE}: the retraction failed: ${deleted.reason} — whether the claim is still held is UNKNOWN; run "fabrika build confirm ${number}".`,
+					notes,
+				)
+			: answer(JSON.stringify({answer: "released", number}), notes);
+	});

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -1,0 +1,249 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {FAILED} from "../verb.ts";
+import {runClaim, runConfirm, runRelease} from "./claim-verb.ts";
+import {
+	CLAIM_NOT_MINE,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {comments, issue, LANE_UUID, marker} from "./fixtures.test-support.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const POST = /^gh api --method POST repos\/o\/r\/issues\/4312\/comments/;
+const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/9001$/;
+const DELETE = /^gh api --method DELETE repos\/o\/r\/issues\/comments\//;
+const perm = (login: string) => new RegExp(`^gh api repos/o/r/collaborators/${login}/permission`);
+
+const MINE = marker("s-9f2e", LANE_UUID);
+const THEIRS = marker("s-77aa", "9d8c7b6a-5f4e-3d2c-1b0a-998877665544");
+
+const POSTED = okOut(JSON.stringify({id: 9001, html_url: "https://github.com/o/r/issues/4312#c"}));
+const ECHO = okOut(JSON.stringify({body: MINE}));
+
+const options = {
+	number: 4312,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+	uuid: LANE_UUID,
+	at: "2026-08-09T00:00:00Z",
+};
+
+const run = (
+	verb: typeof runClaim,
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => Effect.runPromise(Effect.provide(verb({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runClaim", () => {
+	it("wins when its own marker is the earliest authorized one", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, issue()],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "won",
+			number: 4312,
+			token: `build:s-9f2e:${LANE_UUID}`,
+		});
+	});
+
+	it("re-reads AFTER posting — the checkpoint is what resolves a staggered race", async () => {
+		const shell = fakeShell([
+			[ISSUE, issue()],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		await Effect.runPromise(Effect.provide(runClaim(options), shell.layer));
+		const posted = shell.calls.findIndex((line) => POST.test(line));
+		const swept = shell.calls.findIndex((line) => COMMENTS.test(line));
+		expect(posted).toBeGreaterThanOrEqual(0);
+		expect(swept).toBeGreaterThan(posted);
+	});
+
+	it("exits 15 on a lost race — NEVER 0 — names the winner and retracts its own marker", async () => {
+		const shell = fakeShell([
+			[ISSUE, issue()],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[
+				COMMENTS,
+				comments(
+					{id: 8000, body: THEIRS, createdAt: "2026-08-08T00:00:00Z"},
+					{id: 9001, body: MINE, createdAt: "2026-08-09T00:00:00Z"},
+				),
+			],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runClaim(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("lost to build:s-77aa:");
+		expect(out.stderr.some((line) => line.includes("retracted this run's own marker"))).toBe(true);
+		expect(
+			shell.calls.some((line) => /DELETE repos\/o\/r\/issues\/comments\/9001/.test(line)),
+		).toBe(true);
+	});
+
+	it("never lets marker TEXT confer authority — an unauthorized earlier marker does not win", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, issue()],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[
+				COMMENTS,
+				comments(
+					{id: 8000, body: THEIRS, author: "drive-by", createdAt: "2026-08-08T00:00:00Z"},
+					{id: 9001, body: MINE, createdAt: "2026-08-09T00:00:00Z"},
+				),
+			],
+			[perm("drive-by"), okOut("read\n")],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stderr.some((line) => line.includes("who holds no write permission"))).toBe(true);
+	});
+
+	it("refuses a failed marker write on 8 — UNKNOWN, and points at confirm", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, issue()],
+			[POST, errOut("gh: Gateway timeout (HTTP 504)")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain(
+			'run "fabrika build confirm 4312" before any further action',
+		);
+	});
+
+	it("refuses a marker that does not read back on 9", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, issue()],
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body: "something else"}))],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses an unreadable marker set on 11 — never 'unclaimed'", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, issue()],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain('ownership is UNKNOWN, never "unclaimed"');
+	});
+
+	it("refuses an unreadable PERMISSION on 11 — a transient read never demotes an author", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, issue()],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a missing session id on 1, NOT on 15 — the two were fused in v1", async () => {
+		const out = await run(runClaim, [], {env: {CLAUDE_PIPELINE_REPO: "o/r"}});
+		expect(out.code).toBe(FAILED);
+	});
+
+	it("refuses a proven-absent issue on 7", async () => {
+		const out = await run(runClaim, [[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+});
+
+describe("runConfirm", () => {
+	it("answers mine when this session holds the earliest authorized marker", async () => {
+		const out = await run(runConfirm, [
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("mine");
+	});
+
+	it("refuses a foreign holder on 15, naming the token", async () => {
+		const out = await run(runConfirm, [
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 8000, body: THEIRS})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stderr.at(-1)).toBe(
+			"build confirm: #4312 is held by build:s-77aa:9d8c7b6a-5f4e-3d2c-1b0a-998877665544, not this session.",
+		);
+	});
+
+	it("refuses proven-unclaimed on 15 too, with the no-claim message", async () => {
+		const out = await run(runConfirm, [
+			[ISSUE, issue()],
+			[COMMENTS, okOut("[]")],
+		]);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stderr.at(-1)).toBe(
+			'build confirm: no claim exists on #4312 — nothing to confirm; run "fabrika build claim 4312" first.',
+		);
+	});
+});
+
+describe("runRelease", () => {
+	it("retracts this session's OWN marker and nothing else", async () => {
+		const shell = fakeShell([
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runRelease(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({answer: "released", number: 4312});
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
+			"gh api --method DELETE repos/o/r/issues/comments/9001",
+		]);
+	});
+
+	it("refuses to release another lane's claim on 15, and deletes nothing", async () => {
+		const shell = fakeShell([
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 8000, body: THEIRS})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runRelease(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stderr.at(-1)).toBe(
+			"build release: this session holds no claim on #4312 — refusing to release another lane's.",
+		);
+		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+	});
+
+	it("refuses a failed retraction on 8 — whether the claim is still held is UNKNOWN", async () => {
+		const out = await run(runRelease, [
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[once(DELETE), errOut("gh: Gateway timeout (HTTP 504)")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/build/claim.ts
+++ b/packages/fabrika-cli/src/build/claim.ts
@@ -1,0 +1,211 @@
+/**
+ * The claim protocol `claim` / `confirm` / `release` share, and that every mutating verb re-runs
+ * before it touches a number.
+ *
+ * One comment-marker race on the issue: post a marker carrying this session's token, re-read the
+ * markers, and the **earliest authorized** one wins. The shape is ADR 0115's, re-implemented rather
+ * than called (ADR 0238).
+ *
+ * **Authorization comes from repository permissions, never from the marker's text** (ADR 0055). A
+ * marker whose author resolves below `write` is counted and reported, and never wins — otherwise the
+ * race is decided by whoever is willing to type the winning string. A permission read that *fails* is
+ * UNKNOWN, never a demotion: v1 silently demoted an authorized author on a transient read failure
+ * (`claim/github.ts:229-231`), which hands the lane to a later claimant on a network blip.
+ *
+ * Three refusals stay separate, because v1 fused them and callers guessed: a proven loss is `15`, a
+ * missing session id is `1`, and an unreadable marker set is `11` — never "unclaimed".
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type CommentRecord, listComments} from "../io/issues.ts";
+import {permissionFor} from "../io/pulls.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {CLAIM_NOT_MINE, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {parseToken} from "./lane.ts";
+
+/** The env var the session id arrives in. A claim without an identity is not a claim. */
+export const SESSION_ENV = "CLAUDE_CODE_SESSION_ID";
+
+/** The permissions that authorize a marker — the ADR 0055 `write+` set. */
+const AUTHORIZED = new Set(["admin", "maintain", "write"]);
+
+/**
+ * The marker's one line: `build-claim: <token> · <ISO-8601-UTC>`.
+ *
+ * The token is the only field ownership turns on. The timestamp is for a human reading the thread —
+ * the tiebreak uses the comment's own `created_at`, which a claimant cannot author.
+ */
+const MARKER_RE = /^build-claim:\s*(build:[^\s·]+)\s*(?:·.*)?$/m;
+
+export const composeMarker = (token: string, at: string): string => `build-claim: ${token} · ${at}`;
+
+/** The token a comment body claims, or `null` when it carries no marker. */
+export const readMarkerToken = (body: string): string | null => {
+	const m = MARKER_RE.exec(body);
+	return m?.[1] === undefined || parseToken(m[1]) === null ? null : m[1];
+};
+
+export interface ClaimMarker {
+	readonly commentId: number;
+	readonly author: string;
+	readonly createdAt: string;
+	readonly token: string;
+}
+
+/** Every claim marker in a comment list, oldest first, ties broken by comment id. */
+export const markersIn = (comments: ReadonlyArray<CommentRecord>): ReadonlyArray<ClaimMarker> => {
+	const markers: ClaimMarker[] = [];
+	for (const comment of comments) {
+		const token = readMarkerToken(comment.body);
+		if (token !== null) {
+			markers.push({
+				commentId: comment.id,
+				author: comment.author,
+				createdAt: comment.createdAt,
+				token,
+			});
+		}
+	}
+	return [...markers].sort((a, b) =>
+		a.createdAt === b.createdAt ? a.commentId - b.commentId : a.createdAt < b.createdAt ? -1 : 1,
+	);
+};
+
+/** Who holds the claim — four outcomes, and no two of them fold. */
+export type Ownership =
+	| {readonly _tag: "Mine"; readonly marker: ClaimMarker}
+	| {readonly _tag: "Foreign"; readonly marker: ClaimMarker}
+	| {readonly _tag: "Unclaimed"}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/**
+ * Resolve ownership of `number` against `session`.
+ *
+ * The ACL lookups run in marker order and stop at the first authorized one, so a thread full of
+ * unauthorized markers costs one lookup each and the winner is found without reading the rest.
+ * `unauthorized` carries the ones that were counted but did not win, which the caller reports on
+ * stderr — content is not authority, but an ignored marker should still be visible.
+ */
+export const resolveOwnership = (
+	repo: string,
+	number: number,
+	session: string,
+): Effect.Effect<
+	{readonly ownership: Ownership; readonly unauthorized: ReadonlyArray<ClaimMarker>},
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const listed = yield* listComments(repo, number);
+		if (listed._tag === "Failure") {
+			return {ownership: {_tag: "Unknown" as const, reason: listed.reason}, unauthorized: []};
+		}
+		const markers = markersIn(listed.value);
+		const unauthorized: ClaimMarker[] = [];
+		const permissions = new Map<string, string | null>();
+		for (const marker of markers) {
+			let permission = permissions.get(marker.author);
+			if (permission === undefined) {
+				const read = yield* permissionFor(repo, marker.author);
+				if (read._tag === "Unknown") {
+					return {
+						ownership: {
+							_tag: "Unknown" as const,
+							reason: `the repository permission of "${marker.author}" could not be read (${read.reason})`,
+						},
+						unauthorized,
+					};
+				}
+				permission = read._tag === "Present" ? read.value : null;
+				permissions.set(marker.author, permission);
+			}
+			if (permission === null || !AUTHORIZED.has(permission)) {
+				unauthorized.push(marker);
+				continue;
+			}
+			const parsed = parseToken(marker.token);
+			const mine = parsed !== null && parsed.session === session;
+			return {
+				ownership: mine ? ({_tag: "Mine", marker} as const) : ({_tag: "Foreign", marker} as const),
+				unauthorized,
+			};
+		}
+		return {ownership: {_tag: "Unclaimed" as const}, unauthorized};
+	});
+
+export type Session =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Session"; readonly id: string};
+
+/** This run's session id, or the usage refusal. Unset is `1`: an identity-less claim is not a claim. */
+export const requireSession = (
+	verb: string,
+	env: Readonly<Record<string, string | undefined>>,
+): Session => {
+	const id = (env[SESSION_ENV] ?? "").trim();
+	return id === ""
+		? {
+				_tag: "Refused",
+				outcome: refuse(
+					FAILED,
+					`${verb}: ${SESSION_ENV} is unset — a claim without an identity is not a claim.`,
+				),
+			}
+		: {_tag: "Session", id};
+};
+
+export type Held =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Held"; readonly marker: ClaimMarker; readonly notes: ReadonlyArray<string>};
+
+/**
+ * The precondition every mutating verb runs: this session holds `number`'s claim, proven now.
+ *
+ * The three refusals are the contract's, with the invoked verb's name substituted. Unclaimed lands on
+ * `15` beside foreign because the caller's action is the same in both — stop, claim first — while the
+ * message keeps the two facts apart for a reader.
+ */
+export const requireClaim = (
+	verb: string,
+	repo: string,
+	number: number,
+	session: string,
+): Effect.Effect<Held, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session);
+		const notes = unauthorized.map(
+			(marker) =>
+				`${verb}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
+		);
+		if (ownership._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read the claim markers on #${number}: ${ownership.reason} — the lane is UNKNOWN.`,
+					notes,
+				),
+			};
+		}
+		if (ownership._tag === "Unclaimed") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					CLAIM_NOT_MINE,
+					`${verb}: no claim exists on #${number} — nothing to confirm; run "fabrika build claim ${number}" first.`,
+					notes,
+				),
+			};
+		}
+		if (ownership._tag === "Foreign") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					CLAIM_NOT_MINE,
+					`${verb}: #${number} is held by ${ownership.marker.token}, not this session.`,
+					notes,
+				),
+			};
+		}
+		return {_tag: "Held" as const, marker: ownership.marker, notes};
+	});

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -1,0 +1,71 @@
+/**
+ * The one exit table all fourteen `build` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it.
+ *
+ * **The overlap with `report` is re-exported, never re-typed** — the discipline `review/codes.ts`
+ * states in full: an aligning group *imports* the base's constant, so a drift is unrepresentable
+ * rather than merely detectable. This group shares nine seats over `3`-`11` and adds its own `12`-`19`
+ * for facts about the lane — the tree, the claim, the push, the validators — that no writing verb has.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** Stdin was read and held nothing. Distinct from a read that failed, which is `1`. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/** A required section is missing, malformed, empty, or out of place — authored, or derived from. */
+export const BAD_SECTIONS = REPORT_BAD_SECTIONS;
+/** The authored text carries a machine-local path, unredacted. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The authored text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/**
+ * Zero scope: the target is **proven** absent (404) or closed, or there is nothing to judge.
+ *
+ * *Proven* is the operative word, and the split against {@link PRECONDITION_UNKNOWN} is the one the
+ * whole group rests on: a 404 is a verdict about the repository, a 5xx is a verdict about nothing.
+ * No verb fuses them, and no message here is worded "does not exist, or is not readable".
+ */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** A write was attempted and its outcome could not be proven — UNKNOWN, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed but the read-back does not match; the artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** A value off its closed vocabulary, or a classification claim where none is permitted. */
+export const OFF_VOCABULARY = REPORT_CLASSIFIED;
+/** A required read or validator execution failed — nothing was written, no outcome is proven. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/** Proven: this process is not in a linked worktree (the primary checkout, or no worktree at all). */
+export const NOT_A_WORKTREE = 12;
+/** Proven: the tree was dirty at a `--require-clean` open. An unauthored hunk is not ours (#2666). */
+export const DIRTY_TREE = 13;
+/** Proven: the checked-out branch does not belong to this lane's claim (the lane-identity rule). */
+export const WRONG_LANE = 14;
+/**
+ * Proven: this session does not hold the claim — lost, foreign, or none exists at all.
+ *
+ * Proven-unclaimed sits here too: zero markers means this session does not hold the claim, which is
+ * the one fact every consumer acts on. The stderr detail separates unclaimed from foreign for a
+ * reader; the code deliberately does not, because the caller's action is identical.
+ */
+export const CLAIM_NOT_MINE = 15;
+/** Proven: the issue is blocked — the open dependency edge is named on stderr. */
+export const BLOCKED = 16;
+/** Proven: the push completed but the remote ref did not move. */
+export const REF_NOT_MOVED = 17;
+/** Proven: this tree's validation is red. */
+export const VALIDATION_RED = 18;
+/** Refused: the requested push is unsafe (detached HEAD, or non-fast-forward without a lease). */
+export const UNSAFE_PUSH = 19;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -1,0 +1,371 @@
+/**
+ * The `build` verb group — `fabrika build <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives in
+ * the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a
+ * process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * `build push` is the group's one deviant on the channel rule and the emitter honours it: its whole
+ * report is stdout, so `tail -1` of stdout on exit 0 is always the verdict line.
+ */
+import {randomUUID} from "node:crypto";
+import {tmpdir} from "node:os";
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runBranch} from "./branch-verb.ts";
+import {runCheck} from "./check-verb.ts";
+import {runClaim, runConfirm, runRelease} from "./claim-verb.ts";
+import {runEligible} from "./eligible-verb.ts";
+import {runIssue} from "./issue-verb.ts";
+import {runNote} from "./note-verb.ts";
+import {runPick} from "./pick-verb.ts";
+import {runPr} from "./pr-verb.ts";
+import {runPush} from "./push-verb.ts";
+import {runScratch} from "./scratch-verb.ts";
+import {runTree} from "./tree-verb.ts";
+import {runVerdicts} from "./verdicts-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const issueArg = Argument.integer("number").pipe(
+	Argument.withDescription("the issue this lane serves"),
+);
+
+const tree = leafCommand(
+	"tree",
+	{
+		requireClean: Flag.boolean("require-clean").pipe(
+			Flag.withDescription(
+				"additionally refuse a tree with any uncommitted change — the lane-open posture (default: false)",
+			),
+		),
+		issue: Flag.integer("issue").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"additionally prove the checked-out branch carries this claim's nonce — the pre-mutation posture",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({requireClean, issue, repo}) {
+		yield* emit(
+			yield* runTree({
+				requireClean,
+				issue: Option.getOrNull(issue),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Prove the ground: a linked worktree, optionally clean, optionally this lane's. Prints the tree root's absolute path on stdout. Verifies and NEVER provisions — it creates, locks, unlocks and removes nothing (the spawner owns the tree's lifecycle). Exits 11 (with --issue: the claim state could not be read — the lane is UNKNOWN), 12 (proven: not in a linked worktree), 13 (proven: uncommitted changes at a --require-clean open), 14 (proven: the checked-out branch does not carry this claim's nonce), 15 (proven: the claim on --issue is foreign). Example: fabrika build tree --require-clean",
+	),
+);
+
+const pick = leafCommand(
+	"pick",
+	{
+		repo: repoFlag,
+		limit: Flag.integer("limit").pipe(
+			Flag.withDefault(20),
+			Flag.withDescription("maximum candidates to emit, after ranking (default: 20)"),
+		),
+	},
+	Effect.fn(function* ({repo, limit}) {
+		yield* emit(yield* runPick({repo: Option.getOrNull(repo), limit, env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'The ranked candidate pool: status:triaged + ready-for:agent + unassigned, every bucket paginated in full. Prints {"pool":[…],"scanned":{"p0":n,"p1":n,"p2":n}}; an empty pool is a fact on exit 0, readable against the scanned counts. Exits 1 (--limit is not a positive integer), 11 (any bucket read failed — the pool is UNKNOWN, never partial). Example: fabrika build pick --limit 5',
+	),
+);
+
+const eligible = leafCommand(
+	"eligible",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runEligible({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'One issue\'s dependency gate, derived from the parent ledger\'s "## Dependencies" topology and never read off a label. Prints {"answer":"eligible","number":n,"parent":n|null}; blocked and unknown print nothing. Exits 4 (the parent\'s "## Dependencies" block is absent or unparseable — "no parseable edges" is never "no edges"), 7 (the issue is proven absent or closed), 11 (the issue, parent or a predecessor could not be read — UNKNOWN, never "eligible"), 16 (proven blocked — the first open edge is named on stderr). Example: fabrika build eligible 4312',
+	),
+);
+
+const claim = leafCommand(
+	"claim",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(
+			yield* runClaim({
+				number,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				uuid: randomUUID(),
+				at: new Date().toISOString(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Race the earliest AUTHORIZED claim marker on an issue: post this session\'s token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author\'s repository permission (ADR 0055) — marker text confers nothing. Prints {"answer":"won","number":n,"token":"…"}. A lost race retracts this run\'s own marker and exits 15, never 0; an unset CLAUDE_CODE_SESSION_ID is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 11 (the marker set could not be read — ownership is UNKNOWN, never "unclaimed"), 15 (proven lost). Example: fabrika build claim 4312',
+	),
+);
+
+const confirm = leafCommand(
+	"confirm",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runConfirm({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Re-prove this session still holds the claim, before a mutation. Prints {"answer":"mine","number":n,"token":"…"}. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 7 (issue proven absent or closed), 11 (the marker set could not be read — UNKNOWN, never "unclaimed"), 15 (proven: held by another session, or no claim exists — the detail is on stderr). Example: fabrika build confirm 4312',
+	),
+);
+
+const release = leafCommand(
+	"release",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runRelease({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Retract this session\'s OWN claim marker, and only its own. Prints {"answer":"released","number":n}. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 7 (issue proven absent or closed), 8 (the retraction failed — UNKNOWN), 11 (the marker set could not be read), 15 (this session holds no claim — refusing to release another lane\'s). Example: fabrika build release 4312',
+	),
+);
+
+const issue = leafCommand(
+	"issue",
+	{number: issueArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runIssue({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'The claimed issue\'s body and acceptance criteria, through the content gate. Prints one JSON object with number, title, state, labels, body and criteria; criteria.state is found | absent | malformed — three facts the imported wire read keeps apart, so a drifted heading never reads as "no acceptance criteria". Exits 7 (issue proven absent or closed), 11 (the issue could not be read — its content is UNKNOWN). Example: fabrika build issue 4312',
+	),
+);
+
+const branch = leafCommand(
+	"branch",
+	{
+		number: Argument.integer("number").pipe(
+			Argument.optional,
+			Argument.withDescription("create mode: the claimed issue the branch serves"),
+		),
+		slug: Flag.string("slug").pipe(
+			Flag.optional,
+			Flag.withDescription("create mode: kebab-case, ≤5 words, must not begin with a hyphen"),
+		),
+		base: Flag.string("base").pipe(
+			Flag.withDefault("origin/main"),
+			Flag.withDescription("the base ref, FETCHED before the branch is cut (default: origin/main)"),
+		),
+		resume: Flag.integer("resume").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"repair mode: a PR number whose head branch to publish back to; exclusive with <number>",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({number, slug, base, resume, repo}) {
+		yield* emit(
+			yield* runBranch({
+				number: Option.getOrNull(number),
+				slug: Option.getOrNull(slug),
+				base,
+				resume: Option.getOrNull(resume),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Cut (or resume) the lane's nonce branch off a FRESHLY FETCHED base, never a stale local ref. Prints the checked-out branch name: build/<number>-<slug>-<nonce> in create mode, build/pr-<pr>-<nonce> in resume mode, where <nonce> is the first 8 hex of the current claim token's UUID. The branch name IS the lane record — there is no stamp file. Exits 7 (--resume's PR is proven absent, closed or merged), 10 (--slug is not kebab-case, exceeds 5 words, or is flag-shaped), 11 (the fetch failed, or the claim state could not be read), 12 (proven: not in a linked worktree), 15 (proven: the claim is foreign). Example: fabrika build branch 4312 --slug editor-focus-loss",
+	),
+);
+
+const scratch = leafCommand(
+	"scratch",
+	{
+		number: issueArg,
+		slug: Flag.string("slug").pipe(
+			Flag.withDescription("the file's leaf name: kebab-case, no path separators"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({number, slug, repo}) {
+		yield* emit(
+			yield* runScratch({
+				number,
+				slug,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"The per-lane scratch path, allocated fail-closed: <temp root>/fabrika-build/<session-id>/<issue>-<claim-nonce>/<slug>, one absolute path on stdout, the directory created if absent. The claim nonce is what keys the namespace per LANE rather than per session, so two lanes of one session cannot clobber each other. The printed path is machine-local and must never reach a posted artifact. Exits 1 (the directory could not be created, or CLAUDE_CODE_SESSION_ID is unset), 10 (--slug carries a path separator or is not kebab-case), 11 (the claim state could not be read), 15 (proven: the claim is foreign). Example: fabrika build scratch 4312 --slug notes",
+	),
+);
+
+const check = leafCommand(
+	"check",
+	{
+		surface: Flag.string("surface").pipe(
+			Flag.withDescription(
+				"code | prose | plan — the surface whose validators run; the skill names it, this verb anchors it against the diff",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({surface, repo}) {
+		yield* emit(yield* runCheck({surface, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Run this surface\'s validators in this tree, with the build cache BYPASSED — a cache hit from another worktree has returned another tree\'s green. Prints {"verdict":"green","surface":"…","tree":"…","ran":[…]}; red and unknown print nothing. This verb predicts; ci.yml decides, and supersedes it where they disagree. Exits 7 (the diff against the base is empty — zero scope, ADR 0092), 10 (--surface is off-enum or provably mismatches the diff), 11 (a validator could not be executed, or the lane\'s claim could not be read — UNKNOWN, never green), 12 (not in a linked worktree), 14 (the checked-out branch is not this lane\'s), 15 (the lane\'s claim is held by another session), 18 (proven red). Example: fabrika build check --surface code',
+	),
+);
+
+/**
+ * `--force-with-lease` is the only force shape. There is no `--force` and no `--no-verify`: the ban is
+ * enforced by the flag not existing rather than by prose (#4159).
+ */
+const push = leafCommand(
+	"push",
+	{
+		forceWithLease: Flag.boolean("force-with-lease").pipe(
+			Flag.withDescription(
+				"permit a non-fast-forward update of this lane's own branch — repair resubmission only (default: false)",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({forceWithLease, repo}) {
+		yield* emit(yield* runPush({forceWithLease, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Publish the lane's branch and INDEPENDENTLY confirm the remote ref moved, by reading it back with git ls-remote. The whole report is stdout, single-stream, so `tail -1` of stdout on exit 0 is always `PUSH-VERDICT: MOVED`. Exits 8 (pushed, but the remote ref could not be re-read — the outcome is UNKNOWN), 11 (the lane's claim could not be read — nothing was pushed), 12 (not in a linked worktree), 14 (the checked-out branch is not this lane's), 15 (the claim is held by another session), 17 (proven: the remote ref did not move), 19 (refused before pushing: detached HEAD, or non-fast-forward without --force-with-lease). Example: fabrika build push",
+	),
+);
+
+const pr = leafCommand(
+	"pr",
+	{
+		number: issueArg,
+		partial: Flag.boolean("partial").pipe(
+			Flag.withDescription(
+				'the acceptance criteria are not all met: the body must say "Part of #<n>", not "Fixes #<n>" (default: false)',
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({number, partial, repo}) {
+		yield* emit(
+			yield* runPr({
+				number,
+				partial,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Open the PR from the body on STDIN, refusing the known defect shapes before any write, with a read-back through normalizeForReadback. Prints {"answer":"opened",…}, or {"answer":"existing",…} on exit 0 when this head branch already has an open PR — an idempotent re-run is an answer, not a duplicate. Exits 3 (stdin held nothing), 4 ("## Deviations" missing or empty, or the closing-keyword line is absent, duplicated, mistargeted, or contradicts --partial), 5 (machine-local path), 6 (bare @ reference), 7 (issue proven absent or closed), 8 (the create failed — UNKNOWN; re-run), 9 (landed but does not read back), 10 (the body asserts a control-plane, type or priority classification — those verdicts are the gate\'s and triage\'s), 11 (a precondition read failed), 12 (not in a linked worktree), 14 (the head branch is not this lane\'s), 15 (this session does not hold the claim). Example: fabrika build pr 4312 < body.md',
+	),
+);
+
+const note = leafCommand(
+	"note",
+	{
+		number: Argument.integer("number").pipe(
+			Argument.withDescription("the issue or PR the note posts to"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(
+			yield* runNote({
+				number,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Post the progress or handoff note on STDIN, leak-guarded and read back. When the number resolves to a PR the note is stamped with that PR\'s head SHA at post time, so a reader can see a note predates a later push. Runs ONLY the posting guards — never the tree assertions — so a stop-report stays postable from a refused tree. Prints {"answer":"posted","number":n,"commentId":n,"head":"…"|null}. Exits 3 (stdin held nothing), 5 (machine-local path), 6 (bare @ reference), 7 (target proven absent or closed), 8 (the write failed — UNKNOWN), 9 (posted but does not read back), 11 (a precondition read failed), 15 (this session does not hold the claim). Example: fabrika build note 4310 < round-2.md',
+	),
+);
+
+const verdicts = leafCommand(
+	"verdicts",
+	{
+		pr: Flag.integer("pr").pipe(
+			Flag.withDescription("the pull request whose verdict state is folded"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr: number, repo}) {
+		yield* emit(yield* runVerdicts({pr: number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'The paginated, current-head, per-gate verdict fold on a PR: every comment and every review, the latest marker per gate namespace bound to the live head, native reviews as their OWN row kind (never coerced), the 120-second FAIL round count, capReached, and the criteria frozen after round 2. Prints one JSON object with head, rows, rounds, capReached and frozenCriteria; {"rows":[]} on exit 0 is a proven "no verdicts", readable against the scope line. A stale marker prints as stale, never dropped. Exits 7 (PR proven absent or closed), 11 (the head, any comment page or any review page could not be read — UNKNOWN, never "none"). Example: fabrika build verdicts --pr 4310',
+	),
+);
+
+export const buildCommand = Command.make("build").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
+		tree,
+		pick,
+		eligible,
+		claim,
+		confirm,
+		release,
+		issue,
+		branch,
+		scratch,
+		check,
+		push,
+		pr,
+		note,
+		verdicts,
+	]),
+	Command.withDescription(
+		"Drive one construction lane end to end — prove the tree, pick and claim the issue, cut the branch, validate the tree, push, open the PR, and read the verdicts back",
+	),
+);

--- a/packages/fabrika-cli/src/build/content-gate.ts
+++ b/packages/fabrika-cli/src/build/content-gate.ts
@@ -1,0 +1,52 @@
+/**
+ * The one door every externally-authorable byte a `build` verb returns passes through.
+ *
+ * Issue bodies, comment bodies, PR bodies, review findings — anything a party other than this process
+ * wrote — is gated here before it reaches stdout. **Today the gate is provenance-stamping
+ * pass-through: it changes no byte.** That is deliberate, not unfinished. The trust posture is an open
+ * founder decision (#4859), and this module exists so that ruling lands as one module change covering
+ * every verb at once, instead of an edit to five verbs that ships four of them.
+ *
+ * **TOCTOU is handled by construction, not by a cache invalidation rule.** No verb holds gated content
+ * across invocations: every invocation re-fetches and re-gates, so a change to the posture below is in
+ * force on the very next read. Nothing here memoizes, and nothing should.
+ *
+ * The provenance stamp is the part that is load-bearing *now*. A caller that has a {@link Gated} in
+ * hand can say where the bytes came from without re-deriving it from the call site, which is what lets
+ * a future posture refuse by origin rather than by pattern.
+ */
+
+/** Where the bytes came from — the axis a trust ruling would most plausibly turn on. */
+export type ContentOrigin =
+	/** An issue body, authored by whoever filed or edited the issue. */
+	| "issue-body"
+	/** A comment body on an issue or pull request. */
+	| "comment-body"
+	/** A pull-request body. */
+	| "pull-body"
+	/** A review's text on a pull request. */
+	| "review-body";
+
+/** Externally-authored text with its provenance attached. The `text` is what reaches stdout. */
+export interface Gated {
+	readonly origin: ContentOrigin;
+	/** What the bytes describe — `#4312`, `comment 512001` — so a refusal could name it. */
+	readonly locator: string;
+	readonly text: string;
+}
+
+/**
+ * Stamp externally-authored bytes with their provenance and hand them back.
+ *
+ * The identity on `text` is the whole of today's posture. It is **not** a claim that the bytes are
+ * safe; it is the statement that fabrika has not yet ruled what to do about them, recorded in one
+ * place rather than assumed in fourteen.
+ */
+export const gate = (origin: ContentOrigin, locator: string, text: string): Gated => ({
+	origin,
+	locator,
+	text,
+});
+
+/** The gated bytes. Verbs read content through this rather than through the raw field. */
+export const contentOf = (gated: Gated): string => gated.text;

--- a/packages/fabrika-cli/src/build/dependencies.ts
+++ b/packages/fabrika-cli/src/build/dependencies.ts
@@ -1,0 +1,136 @@
+/**
+ * The `## Dependencies` grammar — canonical here, consumed by `build eligible` and validated by
+ * `build check --surface plan`.
+ *
+ * The section holds only blank lines and list lines of two forms:
+ *
+ * ```
+ * - phase <int>: <ref>[, <ref>…]
+ * - <ref> requires: <ref>[, <ref>…]
+ * ```
+ *
+ * where `<ref>` is `#<int>` or a ledger-local `C<int>`. An issue in phase *k* is blocked while any ref
+ * in a phase below *k* is open; a `requires:` line blocks its subject while any ref it lists is open.
+ *
+ * **Any other non-blank line inside the section is unparseable, and unparseability refuses.** "No
+ * parseable edges" is never read as "no edges" — a topology nobody could read is not a topology
+ * proving nothing blocks (ADR 0092, #4104).
+ */
+
+/** A reference in the topology: a real issue, or an id local to the ledger. */
+export type Ref =
+	| {readonly _tag: "Issue"; readonly number: number}
+	| {readonly _tag: "Local"; readonly id: string};
+
+export interface PhaseLine {
+	readonly _tag: "Phase";
+	readonly phase: number;
+	readonly members: ReadonlyArray<Ref>;
+}
+
+export interface RequiresLine {
+	readonly _tag: "Requires";
+	readonly subject: Ref;
+	readonly needs: ReadonlyArray<Ref>;
+}
+
+export type Edge = PhaseLine | RequiresLine;
+
+export type Topology =
+	| {readonly _tag: "Parsed"; readonly edges: ReadonlyArray<Edge>}
+	/** The heading is not there at all. */
+	| {readonly _tag: "Absent"}
+	/** The heading is there and something under it does not parse — a defect, not an absence. */
+	| {readonly _tag: "Unparseable"; readonly line: number; readonly text: string};
+
+const HEADING_RE = /^##\s+Dependencies\s*$/;
+const ANY_HEADING_RE = /^#{1,6}\s+/;
+const PHASE_RE = /^-\s*phase\s+(\d+)\s*:\s*(.+)$/i;
+const REQUIRES_RE = /^-\s*(\S+)\s+requires\s*:\s*(.+)$/i;
+
+const parseRef = (raw: string): Ref | null => {
+	const text = raw.trim();
+	const issue = /^#(\d+)$/.exec(text);
+	if (issue?.[1] !== undefined) return {_tag: "Issue", number: Number.parseInt(issue[1], 10)};
+	return /^C\d+$/.test(text) ? {_tag: "Local", id: text} : null;
+};
+
+const parseRefList = (raw: string): ReadonlyArray<Ref> | null => {
+	const parts = raw
+		.split(",")
+		.map((p) => p.trim())
+		.filter((p) => p !== "");
+	if (parts.length === 0) return null;
+	const refs: Ref[] = [];
+	for (const part of parts) {
+		const ref = parseRef(part);
+		if (ref === null) return null;
+		refs.push(ref);
+	}
+	return refs;
+};
+
+/** Read a body's `## Dependencies` block. */
+export const readTopology = (body: string): Topology => {
+	const lines = body.split("\n");
+	const start = lines.findIndex((line) => HEADING_RE.test(line.trim()));
+	if (start === -1) return {_tag: "Absent"};
+
+	const edges: Edge[] = [];
+	for (let i = start + 1; i < lines.length; i++) {
+		const raw = lines[i] ?? "";
+		const text = raw.trim();
+		if (text === "") continue;
+		if (ANY_HEADING_RE.test(text)) break;
+
+		const phase = PHASE_RE.exec(text);
+		if (phase?.[1] !== undefined && phase[2] !== undefined) {
+			const members = parseRefList(phase[2]);
+			if (members === null) return {_tag: "Unparseable", line: i + 1, text};
+			edges.push({_tag: "Phase", phase: Number.parseInt(phase[1], 10), members});
+			continue;
+		}
+		const requires = REQUIRES_RE.exec(text);
+		if (requires?.[1] !== undefined && requires[2] !== undefined) {
+			const subject = parseRef(requires[1]);
+			const needs = parseRefList(requires[2]);
+			if (subject === null || needs === null) return {_tag: "Unparseable", line: i + 1, text};
+			edges.push({_tag: "Requires", subject, needs});
+			continue;
+		}
+		return {_tag: "Unparseable", line: i + 1, text};
+	}
+	return {_tag: "Parsed", edges};
+};
+
+export const sameRef = (a: Ref, b: Ref): boolean =>
+	a._tag === "Issue" && b._tag === "Issue"
+		? a.number === b.number
+		: a._tag === "Local" && b._tag === "Local" && a.id === b.id;
+
+export const renderRef = (ref: Ref): string => (ref._tag === "Issue" ? `#${ref.number}` : ref.id);
+
+/**
+ * Every predecessor of `subject`, with the kind of edge that names it.
+ *
+ * A `requires:` line is honoured as the **precise** gate when one is present: the planner naming a
+ * strict subset is the planner saying "this specific edge is what matters". With no `requires:` line,
+ * the phase boundary is the default and the subject waits on every earlier phase.
+ */
+export const predecessorsOf = (
+	edges: ReadonlyArray<Edge>,
+	subject: Ref,
+): ReadonlyArray<{readonly kind: "phase" | "requires:"; readonly ref: Ref}> => {
+	const explicit = edges.filter(
+		(edge): edge is RequiresLine => edge._tag === "Requires" && sameRef(edge.subject, subject),
+	);
+	if (explicit.length > 0) {
+		return explicit.flatMap((edge) => edge.needs.map((ref) => ({kind: "requires:" as const, ref})));
+	}
+	const phases = edges.filter((edge): edge is PhaseLine => edge._tag === "Phase");
+	const own = phases.find((edge) => edge.members.some((ref) => sameRef(ref, subject)));
+	if (own === undefined) return [];
+	return phases
+		.filter((edge) => edge.phase < own.phase)
+		.flatMap((edge) => edge.members.map((ref) => ({kind: "phase" as const, ref})));
+};

--- a/packages/fabrika-cli/src/build/dependencies.unit.test.ts
+++ b/packages/fabrika-cli/src/build/dependencies.unit.test.ts
@@ -1,0 +1,65 @@
+import {describe, expect, it} from "vitest";
+import {predecessorsOf, readTopology} from "./dependencies.ts";
+
+const ledger = (body: string) => `# Epic\n\n## Dependencies\n\n${body}\n\n## Notes\n\nunrelated\n`;
+
+describe("readTopology", () => {
+	it("parses both line forms and stops at the next heading", () => {
+		const read = readTopology(
+			ledger("- phase 1: #210, #211\n- phase 2: #212\n- #212 requires: #210"),
+		);
+		expect(read._tag).toBe("Parsed");
+		expect(read._tag === "Parsed" ? read.edges : []).toHaveLength(3);
+	});
+
+	it("reads a missing heading as Absent, not as an empty topology", () => {
+		expect(readTopology("# Epic\n\nno section here\n")._tag).toBe("Absent");
+	});
+
+	it("refuses any other non-blank line — 'no parseable edges' is never 'no edges'", () => {
+		const read = readTopology(ledger("- phase 1: #210\n- these two are related somehow"));
+		expect(read._tag).toBe("Unparseable");
+		expect(read._tag === "Unparseable" ? read.text : "").toBe("- these two are related somehow");
+	});
+
+	it("refuses a ref that is neither #<int> nor C<int>", () => {
+		expect(readTopology(ledger("- phase 1: #210, PR-7"))._tag).toBe("Unparseable");
+	});
+});
+
+describe("predecessorsOf", () => {
+	const edges = (body: string) => {
+		const read = readTopology(ledger(body));
+		return read._tag === "Parsed" ? read.edges : [];
+	};
+
+	it("honours an explicit requires: as the PRECISE gate, not the phase boundary", () => {
+		const found = predecessorsOf(
+			edges("- phase 1: #210, #211\n- phase 2: #212\n- #212 requires: #210"),
+			{_tag: "Issue", number: 212},
+		);
+		expect(found).toEqual([{kind: "requires:", ref: {_tag: "Issue", number: 210}}]);
+	});
+
+	it("falls back to every earlier phase when the child has no requires: line", () => {
+		const found = predecessorsOf(edges("- phase 1: #210, #211\n- phase 2: #212"), {
+			_tag: "Issue",
+			number: 212,
+		});
+		expect(found.map((row) => row.ref)).toEqual([
+			{_tag: "Issue", number: 210},
+			{_tag: "Issue", number: 211},
+		]);
+		expect(found.every((row) => row.kind === "phase")).toBe(true);
+	});
+
+	it("gives a phase-1 child no predecessors — a sibling in the same phase does not gate it", () => {
+		expect(predecessorsOf(edges("- phase 1: #210, #211"), {_tag: "Issue", number: 211})).toEqual(
+			[],
+		);
+	});
+
+	it("gives an issue the topology never names no predecessors", () => {
+		expect(predecessorsOf(edges("- phase 1: #210"), {_tag: "Issue", number: 999})).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/build/eligible-verb.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.ts
@@ -1,0 +1,112 @@
+/**
+ * `build eligible` — one issue's dependency gate, **derived from the parent's topology, never read off
+ * a label**. A label is a claim; the topology is the fact (#4104, #4920).
+ *
+ * Three outcomes and no fourth: `eligible` on stdout, a named blocking edge on `16`, and UNKNOWN on
+ * `11`. A parent whose `## Dependencies` block is absent or unparseable is `4` — "no parseable edges"
+ * is never read as "no edges", because a topology nobody could read proves nothing about blockedness.
+ *
+ * A ledger-local ref (`C<int>`) names a child that has not been filed yet, so it blocks: unfiled work
+ * is open work, and the alternative — treating it as satisfied — is the fail-open this verb exists to
+ * remove.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {BAD_SECTIONS, BLOCKED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {gate} from "./content-gate.ts";
+import {predecessorsOf, readTopology, renderRef} from "./dependencies.ts";
+import {getParent} from "./github.ts";
+import {openIssue, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "build eligible";
+
+export interface EligibleOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runEligible = (
+	options: EligibleOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {number} = options;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openIssue(
+			VERB,
+			repo,
+			number,
+			(reason) =>
+				`${VERB}: cannot read #${number}: ${reason} — eligibility is UNKNOWN, never "eligible".`,
+		);
+		if (target._tag === "Refused") return target.outcome;
+
+		const parent = yield* getParent(repo, number);
+		if (parent._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the parent of #${number}: ${parent.reason} — eligibility is UNKNOWN, never "eligible".`,
+			);
+		}
+		if (parent._tag === "Absent") {
+			return answer(JSON.stringify({answer: "eligible", number, parent: null}), [
+				scannedLine(VERB, 0, "dependency edge", "standalone: no parent ledger to derive from"),
+			]);
+		}
+
+		const ledger = yield* getIssue(repo, parent.value);
+		if (ledger._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read parent #${parent.value}: ${ledger.reason} — eligibility is UNKNOWN, never "eligible".`,
+			);
+		}
+		if (ledger._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `${VERB}: parent #${parent.value} is proven absent.`);
+		}
+
+		const topology = readTopology(gate("issue-body", `#${parent.value}`, ledger.value.body).text);
+		if (topology._tag !== "Parsed") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: parent #${parent.value} has no parseable "## Dependencies" block — eligibility cannot be derived, and "no edges found" is never read as "eligible".`,
+				topology._tag === "Unparseable"
+					? [`${VERB}: line ${topology.line} does not parse: "${topology.text}".`]
+					: [],
+			);
+		}
+
+		const predecessors = predecessorsOf(topology.edges, {_tag: "Issue", number});
+		const scope = scannedLine(
+			VERB,
+			predecessors.length,
+			"dependency edge",
+			`parent #${parent.value}`,
+		);
+		for (const {kind, ref} of predecessors) {
+			if (ref._tag === "Local") {
+				return refuse(BLOCKED, `${VERB}: blocked by open ${kind} edge ${renderRef(ref)}.`, [
+					scope,
+					`${VERB}: ${renderRef(ref)} is a ledger-local id — it names work not yet filed, which is open.`,
+				]);
+			}
+			const state = yield* getIssue(repo, ref.number);
+			if (state._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read predecessor #${ref.number}: ${state.reason} — eligibility is UNKNOWN, never "eligible".`,
+					[scope],
+				);
+			}
+			if (state._tag === "Absent" || state.value.state === "open") {
+				return refuse(BLOCKED, `${VERB}: blocked by open ${kind} edge #${ref.number}.`, [scope]);
+			}
+		}
+
+		return answer(JSON.stringify({answer: "eligible", number, parent: parent.value}), [scope]);
+	});

--- a/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
@@ -1,0 +1,110 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {BAD_SECTIONS, BLOCKED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runEligible} from "./eligible-verb.ts";
+import {issue} from "./fixtures.test-support.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const PARENT = /^gh api repos\/o\/r\/issues\/4312\/parent/;
+const LEDGER = /^gh api repos\/o\/r\/issues\/4300$/;
+const PRED = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
+
+const NOT_FOUND = errOut("gh: Not Found (HTTP 404)");
+
+const ledger = (body: string) =>
+	issue({number: 4300, body: `# Epic\n\n## Dependencies\n\n${body}\n`});
+
+const options = {
+	number: 4312,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(Effect.provide(runEligible(options), fakeShell(script).layer));
+
+describe("runEligible", () => {
+	it("answers eligible for a standalone issue, with parent null", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, NOT_FOUND],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({answer: "eligible", number: 4312, parent: null});
+	});
+
+	it("answers eligible when every named predecessor is closed", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, okOut("4300\n")],
+			[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+			[PRED(210), issue({number: 210, state: "closed"})],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).parent).toBe(4300);
+		expect(out.stderr.at(-1)).toContain("scanned 1 dependency edge");
+	});
+
+	it("refuses on 16 and NAMES the first open edge", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, okOut("4300\n")],
+			[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312\n- #4312 requires: #210")],
+			[PRED(210), issue({number: 210, state: "open"})],
+		]);
+		expect(out.code).toBe(BLOCKED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe("build eligible: blocked by open requires: edge #210.");
+	});
+
+	it("treats a ledger-local ref as an open edge — unfiled work is open work", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, okOut("4300\n")],
+			[LEDGER, ledger("- phase 1: C1\n- phase 2: #4312")],
+		]);
+		expect(out.code).toBe(BLOCKED);
+		expect(out.stderr.at(-1)).toBe("build eligible: blocked by open phase edge C1.");
+		expect(out.stderr.some((line) => line.includes("names work not yet filed"))).toBe(true);
+	});
+
+	it("refuses an unparseable Dependencies block on 4 — never reads it as 'no edges'", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, okOut("4300\n")],
+			[LEDGER, ledger("- #4312 comes after the API work")],
+		]);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toBe(
+			'build eligible: parent #4300 has no parseable "## Dependencies" block — eligibility cannot be derived, and "no edges found" is never read as "eligible".',
+		);
+	});
+
+	it("refuses a proven-absent issue on 7", async () => {
+		const out = await run([[ISSUE, NOT_FOUND]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("build eligible: issue #4312 is proven absent or closed.");
+	});
+
+	it("refuses an unreadable parent lookup on 11 — never 'standalone'", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain('eligibility is UNKNOWN, never "eligible"');
+	});
+
+	it("refuses an unreadable predecessor on 11 — never a pass", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, okOut("4300\n")],
+			[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+			[PRED(210), errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/build/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/build/fixtures.test-support.ts
@@ -1,0 +1,97 @@
+/**
+ * The canned `gh` and `git` responses the `build` verb tests script their spawner with.
+ *
+ * They are shaped like the real payloads rather than like the parsers, so a parser that starts reading
+ * a different field still has to find it here — a fixture trimmed to exactly what the code reads today
+ * stops being able to catch tomorrow's misread.
+ */
+import {okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+
+export const HEAD = "03135b9188d2be6c0a4b7bd0b7a3ff9c53f0f2b1";
+export const OLD_HEAD = "8f1c2ad4e5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0";
+
+/** A linked worktree: the git dir and the common dir differ. */
+export const LINKED = okOut(
+	["/repo/.git/worktrees/lane-a", "/repo/.git", "/repo/trees/lane-a"].join("\n"),
+);
+
+/** The primary checkout: the two dirs are the same path. */
+export const PRIMARY = okOut(["/repo/.git", "/repo/.git", "/repo"].join("\n"));
+
+export const issue = (overrides: Record<string, unknown> = {}): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4312,
+			title: "Editor loses focus after save",
+			body: "## Acceptance criteria\n",
+			state: "open",
+			labels: [{name: "type:bug"}, {name: "p1"}, {name: "status:triaged"}],
+			html_url: "https://github.com/o/r/issues/4312",
+			milestone: null,
+			state_reason: null,
+			...overrides,
+		}),
+	);
+
+export const pull = (overrides: Record<string, unknown> = {}): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4318,
+			state: "open",
+			head: {sha: HEAD, ref: "build/4312-editor-focus-loss-c1a4d6f8"},
+			body: "Fixes #4312\n\n## Deviations\nNone.\n",
+			changed_files: 3,
+			comments: 0,
+			merged: false,
+			...overrides,
+		}),
+	);
+
+/** One paged `issues/<n>/comments` response. */
+export const comments = (
+	...rows: ReadonlyArray<{id: number; body: string; author?: string; createdAt?: string}>
+): ExecResult =>
+	okOut(
+		JSON.stringify(
+			rows.map((row) => ({
+				id: row.id,
+				body: row.body,
+				user: {login: row.author ?? "agent"},
+				created_at: row.createdAt ?? "2026-08-09T00:00:00Z",
+			})),
+		),
+	);
+
+/** One paged `issues?labels=…` response, as the candidate pool reads it. */
+export const candidates = (
+	...rows: ReadonlyArray<{
+		number: number;
+		title?: string;
+		labels: ReadonlyArray<string>;
+		assignees?: ReadonlyArray<string>;
+		milestone?: number | null;
+		pull?: boolean;
+	}>
+): ExecResult =>
+	okOut(
+		JSON.stringify(
+			rows.map((row) => ({
+				number: row.number,
+				title: row.title ?? `issue ${row.number}`,
+				labels: row.labels.map((name) => ({name})),
+				assignees: (row.assignees ?? []).map((login) => ({login})),
+				milestone:
+					row.milestone === undefined || row.milestone === null ? null : {number: row.milestone},
+				...(row.pull === true ? {pull_request: {url: "…"}} : {}),
+			})),
+		),
+	);
+
+/** The claim marker body a session posts. */
+export const marker = (session: string, uuid: string): string =>
+	`build-claim: build:${session}:${uuid} · 2026-08-09T00:00:00Z`;
+
+export const LANE_UUID = "c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d";
+/** The lane nonce `LANE_UUID` confers. */
+export const NONCE = "c1a4d6f8";

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -1,0 +1,148 @@
+/**
+ * The git operations the lane verbs perform: fetch, cut, switch, diff, push, and the independent
+ * read-back of a remote ref.
+ *
+ * Two disciplines, both scars:
+ *
+ * - **A branch is cut off `FETCH_HEAD`, never off a local remote-tracking ref.** A checkout's
+ *   `origin/main` can predate the commit the lane needs, and a branch cut off it misses work that is
+ *   already on the base (#1920 / #3621). Every create here fetches first and cuts off what was just
+ *   fetched.
+ * - **A push is believed only after the remote ref is read back.** `git push`'s own report is not
+ *   evidence: a push that died mid-hook read as sent (#4136). {@link remoteSha} asks the remote
+ *   directly, and the caller compares.
+ */
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {
+	type Attempt,
+	fail,
+	isObjectName,
+	ok,
+	remotes,
+	type Shell,
+	splitRemoteRef,
+} from "../io/git.ts";
+
+/** The tree's HEAD commit. */
+export const headSha: Shell<Attempt<string>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["rev-parse", "HEAD"]);
+	if (!r.ok) return fail(r.reason);
+	const sha = r.stdout.trim();
+	return isObjectName(sha) ? ok(sha) : fail(`git resolved HEAD to "${sha}", not an object name`);
+});
+
+/** Fetch `base` (e.g. `origin/main`) and resolve what was fetched, so a cut never uses a stale ref. */
+export const fetchBase = (base: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const split = splitRemoteRef(base, yield* remotes);
+		const fetched = yield* split === null
+			? execCapture("git", ["fetch", "--quiet"])
+			: execCapture("git", ["fetch", "--quiet", split.remote, split.ref]);
+		if (!fetched.ok) return fail(fetched.reason);
+		const resolved = yield* execCapture("git", [
+			"rev-parse",
+			"--verify",
+			"--quiet",
+			split === null ? `${base}^{commit}` : "FETCH_HEAD^{commit}",
+		]);
+		if (!resolved.ok) return fail(`cannot resolve ${base} to a commit after fetching`);
+		const sha = resolved.stdout.trim();
+		return isObjectName(sha)
+			? ok(sha)
+			: fail(`git resolved ${base} to "${sha}", not an object name`);
+	});
+
+export const branchExists = (name: string): Shell<boolean> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${name}`]);
+		return r.ok;
+	});
+
+/** Check out an existing local branch. */
+export const switchTo = (name: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["switch", name]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** Cut `name` at `start` and check it out. */
+export const switchToNew = (name: string, start: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["switch", "-c", name, start]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** Point a local branch's upstream at `<remote>/<ref>` — how resume mode publishes to the PR's head. */
+export const setUpstream = (name: string, remote: string, ref: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["branch", `--set-upstream-to=${remote}/${ref}`, name]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** `<remote>\t<ref>` of the checked-out branch's upstream, or `null` when it tracks nothing. */
+export const upstreamOf = (branch: string): Shell<{remote: string; ref: string} | null> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"rev-parse",
+			"--abbrev-ref",
+			"--symbolic-full-name",
+			`${branch}@{upstream}`,
+		]);
+		if (!r.ok) return null;
+		const split = splitRemoteRef(r.stdout.trim(), yield* remotes);
+		return split === null ? null : {remote: split.remote, ref: split.ref};
+	});
+
+/** The SHA a remote's ref points at, read from the remote itself — the push's independent witness. */
+export const remoteSha = (remote: string, ref: string): Shell<Attempt<string | null>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["ls-remote", remote, `refs/heads/${ref}`]);
+		if (!r.ok) return fail(r.reason);
+		const first = r.stdout.split("\n").find((line) => line.trim() !== "");
+		if (first === undefined) return ok(null);
+		const sha = (first.split(/\s+/)[0] ?? "").trim();
+		return isObjectName(sha)
+			? ok(sha)
+			: fail(`\`git ls-remote\` printed "${first}", not a ref row`);
+	});
+
+/** Whether `ancestor` is reachable from `descendant` — the fast-forward test. */
+export const isAncestor = (ancestor: string, descendant: string): Shell<boolean> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["merge-base", "--is-ancestor", ancestor, descendant]);
+		return r.ok;
+	});
+
+export const push = (remote: string, ref: string, force: boolean): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"push",
+			...(force ? ["--force-with-lease"] : []),
+			remote,
+			`HEAD:refs/heads/${ref}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** The merge base of HEAD and `base` — where this lane's diff starts. */
+export const mergeBase = (base: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["merge-base", "HEAD", base]);
+		if (!r.ok) return fail(r.reason);
+		const sha = r.stdout.trim();
+		return isObjectName(sha) ? ok(sha) : fail(`git named no merge base with ${base}`);
+	});
+
+/** Every path this tree changes against `base`, committed and working-tree alike. */
+export const changedFiles = (base: string): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["diff", "--name-only", base]);
+		if (!r.ok) return fail(r.reason);
+		return ok(
+			r.stdout
+				.split("\n")
+				.map((l) => l.trim())
+				.filter((l) => l !== ""),
+		);
+	});

--- a/packages/fabrika-cli/src/build/github.ts
+++ b/packages/fabrika-cli/src/build/github.ts
@@ -1,0 +1,265 @@
+/**
+ * The GitHub reads and writes the `build` verbs need beyond what `io/issues.ts` and `io/pulls.ts`
+ * already serve.
+ *
+ * The house disciplines hold unchanged: `gh api` REST and **never GraphQL**, **every list read pages**
+ * (`--paginate`, `per_page=100`), *proven absent* split from *unreadable*, and a shape that is not
+ * what was asked for treated as a failure rather than an empty result. The pagination is the one this
+ * group most depends on — a truncated bucket is the un-paginated scar these verbs exist to close
+ * (#4926), and a candidate pool that silently stops at 100 answers "no p0s".
+ */
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+import {
+	absent,
+	type Existence,
+	httpStatusOf,
+	present,
+	splitJsonArrays,
+	unknown,
+} from "../io/issues.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+
+/** One issue as the candidate pool ranks it — every axis the filter reads, none of them derived. */
+export interface CandidateIssue {
+	readonly number: number;
+	readonly title: string;
+	readonly labels: ReadonlyArray<string>;
+	readonly assigned: boolean;
+	readonly milestone: number | null;
+	readonly isPullRequest: boolean;
+}
+
+const toCandidate = (value: unknown): CandidateIssue | null => {
+	if (!isRecord(value)) return null;
+	const {number, title, labels, assignees, milestone} = value;
+	if (typeof number !== "number" || typeof title !== "string") return null;
+	const names = Array.isArray(labels)
+		? labels.map((l) => (isRecord(l) && typeof l.name === "string" ? l.name : null))
+		: null;
+	if (names === null || names.includes(null)) return null;
+	return {
+		number,
+		title,
+		labels: names as ReadonlyArray<string>,
+		assigned: Array.isArray(assignees) ? assignees.length > 0 : value.assignee !== null,
+		milestone:
+			isRecord(milestone) && typeof milestone.number === "number" ? milestone.number : null,
+		isPullRequest: value.pull_request !== undefined,
+	};
+};
+
+/**
+ * Every open issue carrying **all** of `labels`, paged in full.
+ *
+ * Typed JSON rather than a `--jq` projection: the filter reads five axes off each row, and a `jq`
+ * filter that errors mid-stream on one odd entry shortens the list silently — which is exactly the
+ * truncation the caller refuses on.
+ */
+export const listLabelled = (
+	repo: string,
+	labels: ReadonlyArray<string>,
+): Shell<Attempt<ReadonlyArray<CandidateIssue>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues?state=open&labels=${encodeURIComponent(labels.join(","))}&per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows: CandidateIssue[] = [];
+		for (const page of splitJsonArrays(r.stdout)) {
+			const parsed = parseJson(page);
+			if (!Array.isArray(parsed)) {
+				return fail("`gh api` exited 0 but its output is not a list of issues");
+			}
+			for (const value of parsed) {
+				const row = toCandidate(value);
+				if (row === null) return fail("`gh api` exited 0 but one entry is not an issue");
+				rows.push(row);
+			}
+		}
+		return ok(rows);
+	});
+
+/**
+ * An issue's parent epic, through the dedicated sub-endpoint.
+ *
+ * The single-issue payload carries **no** `parent` key, so a `--jq '.parent'` read there answers its
+ * default for every issue — a well-formed, plausible, always-wrong "standalone" (#4171). The
+ * sub-endpoint's 404 is the proven-standalone answer; everything else stays UNKNOWN.
+ */
+export const getParent = (repo: string, issue: number): Shell<Existence<number>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			`repos/${repo}/issues/${issue}/parent`,
+			"--jq",
+			".number",
+		]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404 ? absent<number>() : unknown<number>(r.reason);
+		}
+		const text = r.stdout.trim();
+		return /^\d+$/.test(text)
+			? present(Number.parseInt(text, 10))
+			: unknown<number>("`gh api` exited 0 but named no parent number");
+	});
+
+/** Whether a number is a pull request, read off the issues endpoint's `pull_request` key. */
+export const isPullRequest = (repo: string, number: number): Shell<Existence<boolean>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			`repos/${repo}/issues/${number}`,
+			"--jq",
+			".pull_request != null",
+		]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404 ? absent<boolean>() : unknown<boolean>(r.reason);
+		}
+		const text = r.stdout.trim();
+		return text === "true" || text === "false"
+			? present(text === "true")
+			: unknown<boolean>("`gh api` exited 0 but did not say whether the number is a pull request");
+	});
+
+export const defaultBranch = (repo: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}`, "--jq", ".default_branch"]);
+		if (!r.ok) return fail(r.reason);
+		const name = r.stdout.trim();
+		return name === "" ? fail("`gh api` exited 0 but named no default branch") : ok(name);
+	});
+
+export interface PullHead {
+	readonly ref: string;
+	readonly sha: string;
+	readonly state: string;
+	readonly merged: boolean;
+}
+
+/** A PR's head branch — what resume mode publishes back to through a tracked upstream. */
+export const getPullHead = (repo: string, pr: number): Shell<Existence<PullHead>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			`repos/${repo}/pulls/${pr}`,
+			"--jq",
+			'"\\(.head.ref)\t\\(.head.sha)\t\\(.state)\t\\(.merged)"',
+		]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404 ? absent<PullHead>() : unknown<PullHead>(r.reason);
+		}
+		const [ref, sha, state, merged] = r.stdout.trim().split("\t");
+		return ref === undefined || ref === "" || sha === undefined || state === undefined
+			? unknown<PullHead>("`gh api` exited 0 but its output is not a pull-request head")
+			: present({ref, sha, state, merged: merged === "true"});
+	});
+
+export interface PullRef {
+	readonly number: number;
+	readonly url: string;
+}
+
+/**
+ * The open PR whose head is `branch`, or `null` when there is none.
+ *
+ * This is what makes `build pr` idempotent after a `8`: a create whose outcome could not be proven is
+ * re-run, and an already-open PR for this head is an **answer**, not a duplicate.
+ */
+export const openPullForHead = (repo: string, branch: string): Shell<Attempt<PullRef | null>> =>
+	Effect.gen(function* () {
+		const owner = repo.split("/")[0] ?? "";
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/pulls?state=open&head=${encodeURIComponent(`${owner}:${branch}`)}&per_page=100`,
+			"--jq",
+			'.[] | "\\(.number)\t\\(.html_url)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const first = r.stdout.split("\n").find((line) => line.trim() !== "");
+		if (first === undefined) return ok(null);
+		const [number, url] = first.split("\t");
+		return number === undefined || !/^\d+$/.test(number) || url === undefined
+			? fail("`gh api` exited 0 but its output is not a list of pull requests")
+			: ok({number: Number.parseInt(number, 10), url});
+	});
+
+/**
+ * Open a pull request.
+ *
+ * The body travels as an **argv value**, never `-f body=@file`: the `@` form posts the four-character
+ * path as the body and reads back as success (#4683). Passing the bytes directly removes the file
+ * indirection the scar lives in rather than guarding it.
+ */
+export const createPull = (
+	repo: string,
+	title: string,
+	head: string,
+	base: string,
+	body: string,
+): Shell<Attempt<PullRef>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/pulls`,
+			"-f",
+			`title=${title}`,
+			"-f",
+			`head=${head}`,
+			"-f",
+			`base=${base}`,
+			"-f",
+			`body=${body}`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		return isRecord(parsed) &&
+			typeof parsed.number === "number" &&
+			typeof parsed.html_url === "string"
+			? ok({number: parsed.number, url: parsed.html_url})
+			: fail("`gh api` exited 0 but its output is not a created pull request");
+	});
+
+/** One native review on a pull request — its own row kind, never coerced into a marker (#4555). */
+export interface ReviewRecord {
+	readonly id: number;
+	readonly state: string;
+	readonly body: string;
+}
+
+export const listReviews = (
+	repo: string,
+	pr: number,
+): Shell<Attempt<ReadonlyArray<ReviewRecord>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/pulls/${pr}/reviews?per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows: ReviewRecord[] = [];
+		for (const page of splitJsonArrays(r.stdout)) {
+			const parsed = parseJson(page);
+			if (!Array.isArray(parsed)) {
+				return fail("`gh api` exited 0 but its output is not a list of reviews");
+			}
+			for (const value of parsed) {
+				if (!isRecord(value) || typeof value.id !== "number" || typeof value.state !== "string") {
+					return fail("`gh api` exited 0 but one entry is not a review");
+				}
+				rows.push({
+					id: value.id,
+					state: value.state,
+					body: typeof value.body === "string" ? value.body : "",
+				});
+			}
+		}
+		return ok(rows);
+	});

--- a/packages/fabrika-cli/src/build/issue-verb.ts
+++ b/packages/fabrika-cli/src/build/issue-verb.ts
@@ -1,0 +1,78 @@
+/**
+ * `build issue` — the claimed issue's body and its parsed acceptance criteria, through the content
+ * gate. The single door an issue read comes through, so a trust ruling lands in one place.
+ *
+ * The criteria arrive from the **imported** `acceptance-criteria` wire read and keep its three answers
+ * as positive tokens. `found`, `absent` and `malformed` are three different facts and this verb
+ * transports them rather than flattening them: a heading that drifted by one character is a *defect*
+ * the skill must surface, and folding it into "absent" is how a gate comes to grade a PR over nothing
+ * (#4735's class).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, type VerbOutcome} from "../verb.ts";
+import {read as readCriteria} from "../wire/acceptance-criteria.ts";
+import {contentOf, gate} from "./content-gate.ts";
+import {openIssue, resolveTargetRepo} from "./target.ts";
+
+const VERB = "build issue";
+
+export interface IssueOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** The wire read's three arms, as the tokens and payload stdout carries. */
+const criteriaOf = (
+	body: string,
+):
+	| {readonly state: "found"; readonly items: ReadonlyArray<{text: string; checked: boolean}>}
+	| {readonly state: "absent"; readonly reason: string}
+	| {readonly state: "malformed"; readonly reason: string} => {
+	const read = readCriteria(body);
+	if (read._tag === "Found") {
+		return {
+			state: "found",
+			items: read.value.map((criterion) => ({text: criterion.text, checked: criterion.checked})),
+		};
+	}
+	return read._tag === "Absent"
+		? {state: "absent", reason: read.reason}
+		: {state: "malformed", reason: read.reason};
+};
+
+export const runIssue = (
+	options: IssueOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {number} = options;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const target = yield* openIssue(
+			VERB,
+			resolved.repo,
+			number,
+			(reason) => `${VERB}: cannot read #${number}: ${reason} — its content is UNKNOWN.`,
+		);
+		if (target._tag === "Refused") return target.outcome;
+
+		const body = contentOf(gate("issue-body", `#${number}`, target.issue.body));
+		const criteria = criteriaOf(body);
+		return answer(
+			JSON.stringify({
+				number,
+				title: target.issue.title,
+				state: target.issue.state,
+				labels: target.issue.labels,
+				body,
+				criteria,
+			}),
+			[
+				`${VERB}: read #${number} in ${resolved.repo}; acceptance criteria ${criteria.state}${
+					criteria.state === "found" ? ` (${criteria.items.length} row(s))` : `: ${criteria.reason}`
+				}.`,
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/build/issue-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/issue-verb.unit.test.ts
@@ -1,0 +1,77 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {issue} from "./fixtures.test-support.ts";
+import {runIssue} from "./issue-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+
+const options = {
+	number: 4312,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(Effect.provide(runIssue(options), fakeShell(script).layer));
+
+describe("runIssue", () => {
+	it("carries the body and the criteria rows through", async () => {
+		const out = await run([
+			[
+				ISSUE,
+				issue({
+					body: "### Acceptance criteria\n\n- [ ] focus stays in the editor after save\n- [x] a test covers it\n",
+				}),
+			],
+		]);
+		expect(out.code).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.number).toBe(4312);
+		expect(parsed.labels).toEqual(["type:bug", "p1", "status:triaged"]);
+		expect(parsed.criteria.state).toBe("found");
+		expect(parsed.criteria.items).toEqual([
+			{text: "focus stays in the editor after save", checked: false},
+			{text: "a test covers it", checked: true},
+		]);
+	});
+
+	it("reports a genuinely absent block as `absent`, on exit 0", async () => {
+		const out = await run([[ISSUE, issue({body: "just a description\n"})]]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).criteria.state).toBe("absent");
+	});
+
+	/**
+	 * The whole reason the wire read has three arms: a heading that reaches for the block and misses is
+	 * a DEFECT the skill must surface, and flattening it into `absent` is how a gate grades over
+	 * nothing (#4735's class).
+	 */
+	it("reports a drifted heading as `malformed`, never as `absent`", async () => {
+		const out = await run([
+			[ISSUE, issue({body: "### Acceptance Criteria\n\n- [ ] focus stays put\n"})],
+		]);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.criteria.state).toBe("malformed");
+	});
+
+	it("refuses a proven-absent issue on 7", async () => {
+		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("build issue: issue #4312 is proven absent or closed.");
+	});
+
+	it("refuses a closed issue on 7 too", async () => {
+		const out = await run([[ISSUE, issue({state: "closed"})]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an unreadable issue on 11 — its content is UNKNOWN", async () => {
+		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("its content is UNKNOWN");
+	});
+});

--- a/packages/fabrika-cli/src/build/lane-guard.ts
+++ b/packages/fabrika-cli/src/build/lane-guard.ts
@@ -1,0 +1,95 @@
+/**
+ * "This tree, on this branch, is my lane" — the precondition `tree --issue`, `check`, `push` and `pr`
+ * share, guarded identically so a sibling verb cannot take the same ground on weaker evidence.
+ *
+ * Four facts in one order, and each is proven before the next is asked: a linked worktree (`12`), a
+ * branch whose **name** parses as a lane (`14`), a claim on that lane's number this session holds
+ * (`15` / `11`), and a nonce in the branch that matches the token that claim carries (`14`).
+ *
+ * The last step is the one that makes the others worth having. A branch that merely *looks* like a
+ * lane proves nothing; the branch name and the live claim have to agree on the same UUID, which is
+ * what a second run of the same session on a different issue cannot fake.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {currentBranch} from "../io/issues.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {type ClaimMarker, requireClaim} from "./claim.ts";
+import {WRONG_LANE} from "./codes.ts";
+import {type LaneBranch, laneNumber, nonceOf, parseLaneBranch} from "./lane.ts";
+import {assertGround} from "./worktree.ts";
+
+export type Lane =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {
+			readonly _tag: "Lane";
+			readonly root: string;
+			readonly branch: string;
+			readonly lane: LaneBranch;
+			readonly marker: ClaimMarker;
+			readonly notes: ReadonlyArray<string>;
+	  };
+
+export const requireLane = (
+	verb: string,
+	repo: string,
+	session: string,
+	/** The number the caller expects the lane to serve, when it has one; `null` reads it off the branch. */
+	expected: number | null,
+): Effect.Effect<Lane, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const ground = yield* assertGround(verb, false);
+		if (ground._tag === "Refused") return ground;
+
+		const branch = yield* currentBranch;
+		if (branch === null) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					WRONG_LANE,
+					`${verb}: HEAD is detached — there is no lane branch to prove.`,
+				),
+			};
+		}
+		const lane = parseLaneBranch(branch);
+		if (lane === null) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					WRONG_LANE,
+					`${verb}: the checked-out branch "${branch}" is not a lane branch — wrong lane.`,
+				),
+			};
+		}
+		const number = laneNumber(lane);
+		if (expected !== null && number !== expected) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					WRONG_LANE,
+					`${verb}: the checked-out branch "${branch}" serves #${number}, not #${expected} — wrong lane.`,
+				),
+			};
+		}
+
+		const held = yield* requireClaim(verb, repo, number, session);
+		if (held._tag === "Refused") return held;
+		if (nonceOf(held.marker.token) !== lane.nonce) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					WRONG_LANE,
+					`${verb}: the checked-out branch "${branch}" does not carry claim ${held.marker.token}'s nonce — wrong lane.`,
+					held.notes,
+				),
+			};
+		}
+		return {
+			_tag: "Lane" as const,
+			root: ground.root,
+			branch,
+			lane,
+			marker: held.marker,
+			notes: held.notes,
+		};
+	});

--- a/packages/fabrika-cli/src/build/lane.ts
+++ b/packages/fabrika-cli/src/build/lane.ts
@@ -1,0 +1,90 @@
+/**
+ * Lane identity: **the branch name is the record.**
+ *
+ * A lane branch's name carries the lane — `build/<number>-<slug>-<nonce>` in create mode,
+ * `build/pr-<pr>-<nonce>` in resume mode — where the nonce is the first 8 hex of the current claim
+ * token's UUID. A verb proving "this is my lane" parses the number and the nonce back out of the
+ * checked-out branch, re-reads that number's claim, and requires this session to hold it under a token
+ * whose UUID begins with the nonce.
+ *
+ * **There is no stamp file, and that absence is the design.** The stamp machinery is the accretion the
+ * 2026-08-03 amendment on #4707 measured; worse, one stamp came to name eight trees at once (#4500).
+ * A per-claim nonce in the branch name makes a duplicate lane unconstructible rather than detectable,
+ * and leaves nothing to go stale.
+ */
+
+/** The claim token shape, pinned: `build:<session-id>:<uuid>` (#4428). */
+export const TOKEN_PREFIX = "build";
+
+/** A UUID's first 8 hex characters — the nonce every lane branch carries. */
+export const NONCE_LENGTH = 8;
+
+const TOKEN_RE = /^build:([^:\s]+):([0-9a-f-]{8,})$/;
+
+/** The `<session-id>` and `<uuid>` halves of a token, or `null` when it is not a build token. */
+export const parseToken = (
+	token: string,
+): {readonly session: string; readonly uuid: string} | null => {
+	const m = TOKEN_RE.exec(token.trim());
+	return m?.[1] === undefined || m[2] === undefined ? null : {session: m[1], uuid: m[2]};
+};
+
+/** The lane nonce a token confers, or `null` when the token does not parse. */
+export const nonceOf = (token: string): string | null => {
+	const parsed = parseToken(token);
+	if (parsed === null) return null;
+	const hex = parsed.uuid.replace(/-/g, "").slice(0, NONCE_LENGTH);
+	return hex.length === NONCE_LENGTH ? hex : null;
+};
+
+/** Compose a token from this session's id and a fresh UUID. */
+export const composeToken = (session: string, uuid: string): string =>
+	`${TOKEN_PREFIX}:${session}:${uuid}`;
+
+/**
+ * A slug the branch name may carry: kebab-case, ≤5 words, never flag-shaped.
+ *
+ * The leading-hyphen refusal is not stylistic — a slug that begins with `-` is read by the next tool
+ * in the chain as a flag, which is how `--slug -rf` becomes an argument to something else (#4854).
+ */
+export const isKebabSlug = (slug: string): boolean =>
+	/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug) && slug.split("-").length <= 5;
+
+export type LaneBranch =
+	| {
+			readonly _tag: "Create";
+			readonly number: number;
+			readonly slug: string;
+			readonly nonce: string;
+	  }
+	| {readonly _tag: "Resume"; readonly pr: number; readonly nonce: string};
+
+const CREATE_RE = /^build\/(\d+)-([a-z0-9]+(?:-[a-z0-9]+)*)-([0-9a-f]{8})$/;
+const RESUME_RE = /^build\/pr-(\d+)-([0-9a-f]{8})$/;
+
+/** Parse a checked-out branch name back into its lane, or `null` when it is not a lane branch. */
+export const parseLaneBranch = (name: string): LaneBranch | null => {
+	const resume = RESUME_RE.exec(name);
+	if (resume?.[1] !== undefined && resume[2] !== undefined) {
+		return {_tag: "Resume", pr: Number.parseInt(resume[1], 10), nonce: resume[2]};
+	}
+	const create = CREATE_RE.exec(name);
+	if (create?.[1] !== undefined && create[2] !== undefined && create[3] !== undefined) {
+		return {
+			_tag: "Create",
+			number: Number.parseInt(create[1], 10),
+			slug: create[2],
+			nonce: create[3],
+		};
+	}
+	return null;
+};
+
+/** The number a lane branch is claimed under — the issue in create mode, the PR in resume mode. */
+export const laneNumber = (lane: LaneBranch): number =>
+	lane._tag === "Create" ? lane.number : lane.pr;
+
+export const createBranchName = (number: number, slug: string, nonce: string): string =>
+	`build/${number}-${slug}-${nonce}`;
+
+export const resumeBranchName = (pr: number, nonce: string): string => `build/pr-${pr}-${nonce}`;

--- a/packages/fabrika-cli/src/build/lane.unit.test.ts
+++ b/packages/fabrika-cli/src/build/lane.unit.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, it} from "vitest";
+import {
+	composeToken,
+	createBranchName,
+	isKebabSlug,
+	laneNumber,
+	nonceOf,
+	parseLaneBranch,
+	parseToken,
+	resumeBranchName,
+} from "./lane.ts";
+
+const UUID = "c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d";
+
+describe("the token shape is pinned", () => {
+	it("splits a well-formed token into its session and uuid halves", () => {
+		expect(parseToken(`build:s-9f2e:${UUID}`)).toEqual({session: "s-9f2e", uuid: UUID});
+	});
+
+	it("refuses a token that is not this group's — a comment id is not a session id (#4428)", () => {
+		expect(parseToken("512345")).toBeNull();
+		expect(parseToken(`claim:s-9f2e:${UUID}`)).toBeNull();
+	});
+
+	it("derives the nonce from the uuid's first 8 hex, hyphens stripped", () => {
+		expect(nonceOf(composeToken("s-9f2e", UUID))).toBe("c1a4d6f8");
+	});
+
+	it("yields no nonce from a token it cannot parse — never a truncated guess", () => {
+		expect(nonceOf("build:s-9f2e")).toBeNull();
+	});
+});
+
+describe("slug validation", () => {
+	it("accepts kebab-case up to five words", () => {
+		expect(isKebabSlug("editor-focus-loss")).toBe(true);
+		expect(isKebabSlug("a-b-c-d-e")).toBe(true);
+	});
+
+	it("refuses a flag-shaped slug — the #4854 refusal", () => {
+		expect(isKebabSlug("-rf")).toBe(false);
+	});
+
+	it("refuses six words, uppercase, and double hyphens", () => {
+		expect(isKebabSlug("a-b-c-d-e-f")).toBe(false);
+		expect(isKebabSlug("Editor-Focus")).toBe(false);
+		expect(isKebabSlug("editor--focus")).toBe(false);
+	});
+});
+
+describe("a lane branch parses back into its lane", () => {
+	it("round-trips a create-mode branch", () => {
+		const name = createBranchName(4312, "editor-focus-loss", "c1a4d6f8");
+		expect(name).toBe("build/4312-editor-focus-loss-c1a4d6f8");
+		const lane = parseLaneBranch(name);
+		expect(lane).toEqual({
+			_tag: "Create",
+			number: 4312,
+			slug: "editor-focus-loss",
+			nonce: "c1a4d6f8",
+		});
+		expect(lane === null ? null : laneNumber(lane)).toBe(4312);
+	});
+
+	it("round-trips a resume-mode branch, and reads its number as the PR's", () => {
+		const name = resumeBranchName(4310, "c1a4d6f8");
+		expect(name).toBe("build/pr-4310-c1a4d6f8");
+		const lane = parseLaneBranch(name);
+		expect(lane?._tag).toBe("Resume");
+		expect(lane === null ? null : laneNumber(lane)).toBe(4310);
+	});
+
+	it("reads a foreign branch as no lane at all, rather than as a lane with a missing nonce", () => {
+		expect(parseLaneBranch("main")).toBeNull();
+		expect(parseLaneBranch("build/4312-editor-focus-loss")).toBeNull();
+		expect(parseLaneBranch("umut/editor-focus-loss-c1a4d6f8")).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/build/note-verb.ts
+++ b/packages/fabrika-cli/src/build/note-verb.ts
@@ -1,0 +1,119 @@
+/**
+ * `build note` — post a progress or handoff comment, head-stamped, leak-guarded, read back.
+ *
+ * **It runs only the posting guards — never the tree assertions.** A stop-report must stay postable
+ * from a tree `build tree` just refused; a note that could only be written from a healthy lane is a
+ * note that cannot report the lane being broken.
+ *
+ * When the target resolves to a pull request the note carries the PR's head SHA at post time, so a
+ * reader can see at a glance that a note predates a later push. Without it a spot judgement carries no
+ * freshness signal at all, which is the stale-repair-note class (#4808).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getComment} from "../io/issues.ts";
+import {getPullRequest} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {leakRefusal, readAuthored} from "./authored.ts";
+import {requireClaim, requireSession} from "./claim.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {isPullRequest} from "./github.ts";
+import {resolveTargetRepo} from "./target.ts";
+
+const VERB = "build note";
+
+const SURFACE = {
+	verb: VERB,
+	emptyMessage: `${VERB}: stdin held nothing — the body is the input.`,
+	bareAtMessage: `${VERB}: the body is a bare @ path reference — write the body, not a pointer to it.`,
+};
+
+export interface NoteOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+/** The head stamp, appended as the note's final line. */
+export const headStamp = (sha: string): string => `— at ${sha}`;
+
+export const runNote = (
+	options: NoteOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {number} = options;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const kind = yield* isPullRequest(repo, number);
+		if (kind._tag === "Absent") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${number} is proven absent or closed — nothing to post to.`,
+			);
+		}
+		if (kind._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${number}: ${kind.reason} — nothing was written.`,
+			);
+		}
+
+		let head: string | null = null;
+		if (kind.value) {
+			const pull = yield* getPullRequest(repo, number);
+			if (pull._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read PR #${number}'s head: ${pull.reason} — nothing was written.`,
+				);
+			}
+			if (pull._tag === "Absent" || pull.value.state !== "open") {
+				return refuse(
+					ZERO_SCOPE,
+					`${VERB}: #${number} is proven absent or closed — nothing to post to.`,
+				);
+			}
+			head = pull.value.headSha;
+		}
+
+		const held = yield* requireClaim(VERB, repo, number, session.id);
+		if (held._tag === "Refused") return held.outcome;
+
+		const composed = head === null ? authored.text : `${authored.text}\n\n${headStamp(head)}`;
+		const leaked = leakRefusal(VERB, composed);
+		if (leaked !== null) return leaked;
+
+		const posted = yield* createComment(repo, number, composed);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the write failed: ${posted.reason} — it may or may not have landed; re-read #${number} before retrying.`,
+				held.notes,
+			);
+		}
+		const back = yield* getComment(repo, posted.value.id);
+		const matches =
+			back._tag === "Ok" && normalizeForReadback(back.value) === normalizeForReadback(composed);
+		return matches
+			? answer(
+					JSON.stringify({answer: "posted", number, commentId: posted.value.id, head}),
+					held.notes,
+				)
+			: refuse(
+					READBACK_MISMATCH,
+					`${VERB}: posted (comment ${posted.value.id}) but the read-back does not match — it needs a human eye.`,
+					held.notes,
+				);
+	});

--- a/packages/fabrika-cli/src/build/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/note-verb.unit.test.ts
@@ -1,0 +1,157 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BARE_AT_PATH,
+	CLAIM_NOT_MINE,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {comments, HEAD, LANE_UUID, marker, pull} from "./fixtures.test-support.ts";
+import {headStamp, runNote} from "./note-verb.ts";
+
+const IS_PULL = /^gh api repos\/o\/r\/issues\/4310 --jq \.pull_request/;
+const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const POST = /^gh api --method POST repos\/o\/r\/issues\/4310\/comments/;
+const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/512346$/;
+
+const TEXT = "Round 2 findings addressed: focus restore moved out of the render path.";
+const STAMPED = `${TEXT}\n\n${headStamp(HEAD)}`;
+
+const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[IS_PULL, okOut("true\n")],
+	[PULL, pull({number: 4310})],
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, okOut("write\n")],
+];
+
+const POSTED = okOut(JSON.stringify({id: 512346, html_url: "https://github.com/o/r/pull/4310#c"}));
+
+const options = {
+	number: 4310,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: TEXT}),
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runNote", () => {
+	it("stamps a note on a PR with that PR's head SHA (#4808)", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body: STAMPED}))],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "posted",
+			number: 4310,
+			commentId: 512346,
+			head: HEAD,
+		});
+		expect(shell.calls.some((line) => line.includes(`— at ${HEAD}`))).toBe(true);
+	});
+
+	it("does not stamp a note on a plain issue, and reports head null", async () => {
+		const out = await run([
+			[IS_PULL, okOut("false\n")],
+			[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body: TEXT}))],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).head).toBeNull();
+	});
+
+	/**
+	 * The load-bearing asymmetry with the sibling verbs: a stop-report has to stay postable from a tree
+	 * `build tree` just refused, so this verb never runs the tree assertions.
+	 */
+	it("never runs the tree assertions — a refused tree does not silence the report", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body: STAMPED}))],
+		]);
+		await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		expect(shell.calls.some((line) => /git rev-parse|git status/.test(line))).toBe(false);
+	});
+
+	it("refuses empty stdin on 3", async () => {
+		const out = await run([], {stdin: Effect.succeed<StdinRead>({_tag: "Text", text: ""})});
+		expect(out.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a bare @ reference on 6", async () => {
+		const out = await run([], {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "@/tmp/note.md"}),
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path on 5, and posts nothing", async () => {
+		const shell = fakeShell(CLAIMED);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runNote({
+					...options,
+					stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "see /Users/someone/log.txt"}),
+				}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses a proven-absent target on 7", async () => {
+		const out = await run([[IS_PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe(
+			"build note: #4310 is proven absent or closed — nothing to post to.",
+		);
+	});
+
+	it("refuses a foreign claim on 15, and posts nothing", async () => {
+		const shell = fakeShell([
+			[IS_PULL, okOut("true\n")],
+			[PULL, pull({number: 4310})],
+			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runNote(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses a failed write on 8 — UNKNOWN whether it landed", async () => {
+		const out = await run([...CLAIMED, [POST, errOut("gh: Gateway timeout (HTTP 504)")]]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("refuses a note that does not read back on 9", async () => {
+		const out = await run([
+			...CLAIMED,
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body: "something else"}))],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+});

--- a/packages/fabrika-cli/src/build/pick-verb.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.ts
@@ -1,0 +1,116 @@
+/**
+ * `build pick` — the ranked candidate pool. A filter over a paged listing; the *choice* stays the
+ * skill's.
+ *
+ * The filter is fail-closed on every axis, and two of them are negative tests rather than positive
+ * ones:
+ *
+ * - **`ready-for:agent` must be present.** An issue with no `ready-for:` label is excluded — absence
+ *   is an unknown audience, never an agent audience (#4780).
+ * - **Any assignee excludes.** Assignment is the one attribute that keeps a human's live document out
+ *   of an agent's pool (#4764, #4693).
+ *
+ * **Either every bucket was read in full, or the answer is `11`.** v1's pool printed nothing for a
+ * failed bucket and kept going, so a `gh` 5xx on the p0 bucket read as "no p0s"
+ * (`step1-candidate-pool.sh:12-13`). An empty pool is still a fact and prints on exit 0 with the
+ * scanned counts beside it, which is what makes it auditable rather than merely plausible (ADR 0092).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {type CandidateIssue, listLabelled} from "./github.ts";
+import {resolveTargetRepo} from "./target.ts";
+
+const VERB = "build pick";
+
+/** The priority buckets, in the order the spine reads them. */
+const BUCKETS = ["p0", "p1", "p2"] as const;
+type Bucket = (typeof BUCKETS)[number];
+
+/** The four types an agent lane may take. `type:decision` and `type:epic` never enter. */
+const TYPES = new Set(["type:feature", "type:chore", "type:bug", "type:investigation"]);
+
+/**
+ * The lane labels that stand in for a milestone.
+ *
+ * A standing lane is a home an issue can have without a milestone, so reporting `null` for one would
+ * read as unhomed. The set is closed: a new lane is a deliberate edit here, not a pattern match.
+ */
+const STANDING_LANES = ["wayfinder:backlog", "axis:pipeline-hardening"] as const;
+
+export interface PickOptions {
+	readonly repo: string | null;
+	readonly limit: number;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+interface PoolEntry {
+	readonly number: number;
+	readonly title: string;
+	readonly priority: Bucket;
+	readonly type: string;
+	readonly home: string | null;
+}
+
+const homeOf = (issue: CandidateIssue): string | null =>
+	issue.milestone !== null
+		? String(issue.milestone)
+		: (STANDING_LANES.find((lane) => issue.labels.includes(lane)) ?? null);
+
+/** Whether a row survives every axis of the filter. */
+export const isCandidate = (issue: CandidateIssue): boolean => {
+	if (issue.isPullRequest || issue.assigned) return false;
+	const status = issue.labels.filter((label) => label.startsWith("status:"));
+	if (status.length !== 1 || status[0] !== "status:triaged") return false;
+	if (!issue.labels.includes("ready-for:agent")) return false;
+	return issue.labels.filter((label) => label.startsWith("type:")).every((t) => TYPES.has(t));
+};
+
+const typeOf = (issue: CandidateIssue): string =>
+	issue.labels.find((label) => TYPES.has(label))?.slice("type:".length) ?? "";
+
+/** Milestone order inside a bucket: homed before unhomed, lower milestone first, then oldest number. */
+const rankWithinBucket = (a: PoolEntry, b: PoolEntry): number => {
+	const homeA = a.home === null ? Number.POSITIVE_INFINITY : Number.parseInt(a.home, 10);
+	const homeB = b.home === null ? Number.POSITIVE_INFINITY : Number.parseInt(b.home, 10);
+	const keyA = Number.isNaN(homeA) ? Number.POSITIVE_INFINITY : homeA;
+	const keyB = Number.isNaN(homeB) ? Number.POSITIVE_INFINITY : homeB;
+	return keyA === keyB ? a.number - b.number : keyA - keyB;
+};
+
+export const runPick = (
+	options: PickOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		if (!Number.isInteger(options.limit) || options.limit <= 0) {
+			return refuse(FAILED, `${VERB}: --limit "${options.limit}" is not a positive integer.`);
+		}
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const scanned: Record<Bucket, number> = {p0: 0, p1: 0, p2: 0};
+		const pool: PoolEntry[] = [];
+		for (const bucket of BUCKETS) {
+			const listed = yield* listLabelled(resolved.repo, ["status:triaged", bucket]);
+			if (listed._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read the ${bucket} bucket: ${listed.reason} — the pool is UNKNOWN, never partial.`,
+				);
+			}
+			scanned[bucket] = listed.value.length;
+			const entries = listed.value.filter(isCandidate).map((issue) => ({
+				number: issue.number,
+				title: issue.title,
+				priority: bucket,
+				type: typeOf(issue),
+				home: homeOf(issue),
+			}));
+			pool.push(...entries.sort(rankWithinBucket));
+		}
+
+		return answer(JSON.stringify({pool: pool.slice(0, options.limit), scanned}), [
+			`${VERB}: scanned p0 ${scanned.p0}, p1 ${scanned.p1}, p2 ${scanned.p2} in ${resolved.repo}; ${pool.length} candidate(s) survived the filter.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
@@ -1,0 +1,151 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {FAILED} from "../verb.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {candidates} from "./fixtures.test-support.ts";
+import {runPick} from "./pick-verb.ts";
+
+const bucket = (priority: string) =>
+	new RegExp(
+		`^gh api --paginate repos/o/r/issues\\?state=open&labels=status%3Atriaged%2C${priority}`,
+	);
+
+const EMPTY = okOut("[]");
+const TRIAGED = ["status:triaged", "ready-for:agent", "type:bug"];
+
+const options = {
+	repo: null,
+	limit: 20,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runPick({...options, ...overrides}), fakeShell(script).layer));
+
+const pool = (out: {stdout: string}) =>
+	JSON.parse(out.stdout).pool as ReadonlyArray<{number: number}>;
+
+describe("runPick", () => {
+	it("ranks p0 before p1 before p2, and milestone order inside a bucket", async () => {
+		const out = await run([
+			[
+				bucket("p0"),
+				candidates(
+					{number: 500, labels: [...TRIAGED, "p0"], milestone: 44},
+					{number: 400, labels: [...TRIAGED, "p0"], milestone: null},
+				),
+			],
+			[bucket("p1"), candidates({number: 300, labels: [...TRIAGED, "p1"]})],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(out.code).toBe(0);
+		expect(pool(out).map((row) => row.number)).toEqual([500, 400, 300]);
+	});
+
+	it("excludes an issue with NO ready-for: label — absence is an unknown audience (#4780)", async () => {
+		const out = await run([
+			[bucket("p0"), candidates({number: 500, labels: ["status:triaged", "type:bug", "p0"]})],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(pool(out)).toEqual([]);
+	});
+
+	it("excludes an assigned issue — assignment keeps a human's document out (#4764)", async () => {
+		const out = await run([
+			[bucket("p0"), candidates({number: 500, labels: [...TRIAGED, "p0"], assignees: ["usirin"]})],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(pool(out)).toEqual([]);
+	});
+
+	it("excludes type:decision and type:epic, and pull requests", async () => {
+		const out = await run([
+			[
+				bucket("p0"),
+				candidates(
+					{number: 500, labels: ["status:triaged", "ready-for:agent", "type:epic", "p0"]},
+					{number: 501, labels: [...TRIAGED, "p0"], pull: true},
+				),
+			],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(pool(out)).toEqual([]);
+	});
+
+	it("names a standing lane as the home when there is no milestone", async () => {
+		const out = await run([
+			[
+				bucket("p0"),
+				candidates({number: 500, labels: [...TRIAGED, "p0", "axis:pipeline-hardening"]}),
+			],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(JSON.parse(out.stdout).pool[0].home).toBe("axis:pipeline-hardening");
+	});
+
+	it("prints an empty pool as a FACT on exit 0, with the scanned counts beside it", async () => {
+		const out = await run([
+			[bucket("p0"), EMPTY],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), candidates({number: 9, labels: ["status:triaged", "p2"]})],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({pool: [], scanned: {p0: 0, p1: 0, p2: 1}});
+	});
+
+	it("refuses a failed bucket read on 11 — a 5xx on p0 never reads as 'no p0s'", async () => {
+		const out = await run([
+			[bucket("p0"), errOut("gh: Bad gateway (HTTP 502)")],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"build pick: cannot read the p0 bucket: gh: Bad gateway (HTTP 502) — the pool is UNKNOWN, never partial.",
+		);
+	});
+
+	it("paginates every bucket", async () => {
+		const shell = fakeShell([
+			[bucket("p0"), EMPTY],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		await Effect.runPromise(Effect.provide(runPick(options), shell.layer));
+		expect(shell.calls.filter((line) => line.includes("--paginate"))).toHaveLength(3);
+	});
+
+	it("refuses a non-positive --limit as a plain usage error", async () => {
+		const out = await run([], {limit: 0});
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.at(-1)).toBe('build pick: --limit "0" is not a positive integer.');
+	});
+
+	it("caps the pool at --limit after ranking", async () => {
+		const out = await run(
+			[
+				[
+					bucket("p0"),
+					candidates(
+						{number: 1, labels: [...TRIAGED, "p0"]},
+						{number: 2, labels: [...TRIAGED, "p0"]},
+					),
+				],
+				[bucket("p1"), EMPTY],
+				[bucket("p2"), EMPTY],
+			],
+			{limit: 1},
+		);
+		expect(pool(out).map((row) => row.number)).toEqual([1]);
+	});
+});

--- a/packages/fabrika-cli/src/build/pr-body.ts
+++ b/packages/fabrika-cli/src/build/pr-body.ts
@@ -1,0 +1,110 @@
+/**
+ * The mechanical guards over an authored PR body. *Authoring* stays the skill's; these check shape.
+ *
+ * Three defects, each with a scar behind it:
+ *
+ * - **A missing or empty `## Deviations` section** (#4542). The check blocks rather than warns, and
+ *   "None." counts while silence does not — the verb can force the author to *write*, never to be
+ *   honest, so the section's truth stays the skill's problem and its presence is this one's.
+ * - **A stray closing keyword** (#4471). One closing line, aimed at this PR's own issue; a second
+ *   aimed anywhere else auto-closed an issue the PR did not fix.
+ * - **A classification claim** (#4153). CODEOWNERS decides control-plane membership at the merge gate
+ *   and triage decides type and priority; a body asserting either is a second answer to a gated
+ *   question, and a false one shipped.
+ *
+ * **The classification pattern set is closed on purpose.** Two implementers must ship the same guard,
+ * and "refuse any spelling of it" is two guards. Fences and block quotes are excluded before matching,
+ * so a body that *quotes* a classification to discuss it is not refused for the quotation.
+ */
+
+/** GitHub's own auto-closing keywords. A body may carry exactly one, aimed at its own issue. */
+const CLOSING_RE = /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+const PART_OF_RE = /\bpart of\s+#(\d+)\b/i;
+
+const CLASSIFICATION_PATTERNS: ReadonlyArray<{readonly name: string; readonly re: RegExp}> = [
+	{name: "control-plane", re: /(not[ -])?control[ -]plane/i},
+	{name: "type", re: /\btype:[a-z]+\b/i},
+	{name: "priority", re: /(^|\s)p[0-3](\s|$|[.,;:!?])/i},
+];
+
+/**
+ * The body with fenced code blocks and block quotes removed.
+ *
+ * Both are places an author reproduces text rather than asserts it, and a guard that cannot tell the
+ * two apart refuses a body for quoting the thing it is explaining.
+ */
+export const proseOf = (body: string): string => {
+	const lines: string[] = [];
+	let fenced = false;
+	for (const line of body.split("\n")) {
+		if (/^\s*(```|~~~)/.test(line)) {
+			fenced = !fenced;
+			continue;
+		}
+		if (fenced || /^\s*>/.test(line)) continue;
+		lines.push(line);
+	}
+	return lines.join("\n");
+};
+
+/** Whether a `## Deviations` heading is present with at least one non-blank line under it. */
+export const hasDeviations = (body: string): boolean => {
+	const lines = body.split("\n");
+	const start = lines.findIndex((line) => /^##\s+Deviations\s*$/.test(line.trim()));
+	if (start === -1) return false;
+	for (let i = start + 1; i < lines.length; i++) {
+		const text = (lines[i] ?? "").trim();
+		if (text === "") continue;
+		return !/^#{1,6}\s+/.test(text);
+	}
+	return false;
+};
+
+/** Every issue number a closing keyword in `prose` aims at, in order. */
+export const closingTargets = (prose: string): ReadonlyArray<number> => {
+	const targets: number[] = [];
+	CLOSING_RE.lastIndex = 0;
+	for (const match of prose.matchAll(CLOSING_RE)) {
+		const number = match[3];
+		if (number !== undefined) targets.push(Number.parseInt(number, 10));
+	}
+	return targets;
+};
+
+/** The first classification a body asserts, or `null` — the closed pattern set, over prose only. */
+export const classificationIn = (prose: string): string | null =>
+	CLASSIFICATION_PATTERNS.find(({re}) => re.test(prose))?.name ?? null;
+
+export type BodyDefect =
+	| {readonly _tag: "NoDeviations"}
+	/** A closing keyword aimed somewhere other than this PR's issue. */
+	| {readonly _tag: "StrayClosing"; readonly target: number}
+	/** `--partial` was given and the body still auto-closes. */
+	| {readonly _tag: "ClosesWhilePartial"; readonly target: number}
+	/** The body names no link to its issue at all, in whichever form this run requires. */
+	| {readonly _tag: "NoLink"}
+	/** More than one closing keyword aimed at this PR's own issue. */
+	| {readonly _tag: "DuplicateClosing"};
+
+/**
+ * The first shape defect in `body` for a PR serving `issue`, or `null`.
+ *
+ * The order is deliberate: the Deviations check runs first because it is the one the author most often
+ * forgot, and a body missing both should say so about the section rather than about the link.
+ */
+export const bodyDefect = (body: string, issue: number, partial: boolean): BodyDefect | null => {
+	if (!hasDeviations(body)) return {_tag: "NoDeviations"};
+
+	const prose = proseOf(body);
+	const targets = closingTargets(prose);
+	const stray = targets.find((target) => target !== issue);
+	if (stray !== undefined) return {_tag: "StrayClosing", target: stray};
+
+	const own = targets.filter((target) => target === issue);
+	if (partial) {
+		if (own.length > 0) return {_tag: "ClosesWhilePartial", target: issue};
+		return PART_OF_RE.exec(prose)?.[1] === String(issue) ? null : {_tag: "NoLink"};
+	}
+	if (own.length === 0) return {_tag: "NoLink"};
+	return own.length > 1 ? {_tag: "DuplicateClosing"} : null;
+};

--- a/packages/fabrika-cli/src/build/pr-body.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-body.unit.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it} from "vitest";
+import {bodyDefect, classificationIn, hasDeviations, proseOf} from "./pr-body.ts";
+
+const body = (extra: string) => `Fixes #4312\n\nsome prose.\n${extra}\n## Deviations\n\nNone.\n`;
+
+describe("the Deviations section blocks, and 'None.' counts", () => {
+	it("accepts a section with content", () => {
+		expect(hasDeviations("## Deviations\nNone.\n")).toBe(true);
+	});
+
+	it("refuses a missing section", () => {
+		expect(hasDeviations("Fixes #4312\n")).toBe(false);
+	});
+
+	it("refuses a section whose only content is the next heading — silence is not content (#4542)", () => {
+		expect(hasDeviations("## Deviations\n\n## Testing\nran it\n")).toBe(false);
+	});
+});
+
+describe("the closing keyword", () => {
+	it("accepts exactly one aimed at this PR's issue", () => {
+		expect(bodyDefect(body(""), 4312, false)).toBeNull();
+	});
+
+	it("refuses a stray keyword aimed elsewhere — the #4471 auto-close", () => {
+		expect(bodyDefect(`${body("")}\nAlso closes #999.\n`, 4312, false)).toEqual({
+			_tag: "StrayClosing",
+			target: 999,
+		});
+	});
+
+	it("refuses a body with no link at all", () => {
+		expect(bodyDefect("## Deviations\nNone.\n", 4312, false)).toEqual({_tag: "NoLink"});
+	});
+
+	it("refuses a duplicated keyword aimed at the same issue", () => {
+		expect(bodyDefect(`${body("")}\nfixes #4312 again\n`, 4312, false)).toEqual({
+			_tag: "DuplicateClosing",
+		});
+	});
+
+	it("refuses an auto-close under --partial, and accepts Part of instead", () => {
+		expect(bodyDefect(body(""), 4312, true)).toEqual({_tag: "ClosesWhilePartial", target: 4312});
+		expect(bodyDefect("Part of #4312\n\n## Deviations\nNone.\n", 4312, true)).toBeNull();
+	});
+
+	it("puts the Deviations refusal ahead of the link refusal when both are wrong", () => {
+		expect(bodyDefect("no link, no section", 4312, false)).toEqual({_tag: "NoDeviations"});
+	});
+});
+
+describe("the classification guard reads prose only", () => {
+	it("catches a control-plane claim in either polarity (#4153)", () => {
+		expect(classificationIn("this is not control-plane")).toBe("control-plane");
+		expect(classificationIn("Control Plane: yes")).toBe("control-plane");
+	});
+
+	it("catches a type and a standalone priority assertion", () => {
+		expect(classificationIn("this lands as type:chore")).toBe("type");
+		expect(classificationIn("priority is p0 here")).toBe("priority");
+	});
+
+	it("passes a body that merely quotes one inside a fence or a block quote", () => {
+		expect(classificationIn(proseOf("```\nnot control-plane\n```\nplain prose\n"))).toBeNull();
+		expect(classificationIn(proseOf("> the reviewer said type:bug\n\nplain prose\n"))).toBeNull();
+	});
+
+	it("passes an ordinary body", () => {
+		expect(classificationIn("Editor focus now survives a save.")).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/build/pr-verb.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.ts
@@ -1,0 +1,181 @@
+/**
+ * `build pr` — open the PR from a stdin body, refusing the known defect shapes, with a read-back.
+ *
+ * *Authoring* stays the skill's; the guards here are mechanical and run **in order, all before any
+ * write**: stdin non-empty (`3`), no machine-local path (`5` / `6`), body shape (`4`), no
+ * classification claim (`10`), then the claim and the target issue (`15` / `11` / `7`). The ordering
+ * is the point — a body that would be refused should be refused before a PR exists to carry it.
+ *
+ * An already-open PR for this head branch is an **answer**, not an error: a create whose outcome could
+ * not be proven (`8`) is re-run, and the re-run must not open a second PR (#4544's class).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getPullRequest} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {leakRefusal, readAuthored} from "./authored.ts";
+import {requireSession} from "./claim.ts";
+import {
+	BAD_SECTIONS,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {createPull, defaultBranch, openPullForHead} from "./github.ts";
+import {requireLane} from "./lane-guard.ts";
+import {bodyDefect, classificationIn, proseOf} from "./pr-body.ts";
+import {openIssue, resolveTargetRepo} from "./target.ts";
+
+const VERB = "build pr";
+
+const SURFACE = {
+	verb: VERB,
+	emptyMessage: `${VERB}: stdin held nothing — the body is the input.`,
+	bareAtMessage: `${VERB}: the body is a bare @ path reference — write the body, not a pointer to it.`,
+};
+
+export interface PrOptions {
+	readonly number: number;
+	/** The acceptance criteria are not all met: the body must say `Part of #<n>`, not `Fixes #<n>`. */
+	readonly partial: boolean;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+/** The `4` refusal for each shape defect, in the contract's own words. */
+const shapeRefusal = (
+	defect: NonNullable<ReturnType<typeof bodyDefect>>,
+	issue: number,
+	partial: boolean,
+): VerbOutcome => {
+	switch (defect._tag) {
+		case "NoDeviations":
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the body has no "## Deviations" heading, or it is empty — state deviations, or state "None."`,
+			);
+		case "StrayClosing":
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the body carries a closing keyword aimed at #${defect.target} — this PR serves #${issue}.`,
+			);
+		case "ClosesWhilePartial":
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the body says "Fixes #${defect.target}" but --partial was given — a partial PR must say "Part of #${defect.target}".`,
+			);
+		case "DuplicateClosing":
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the body carries more than one closing keyword aimed at #${issue} — exactly one closes the issue.`,
+			);
+		case "NoLink":
+			return refuse(
+				BAD_SECTIONS,
+				partial
+					? `${VERB}: the body names no "Part of #${issue}" line — a partial PR must say what it is part of.`
+					: `${VERB}: the body names no "Fixes #${issue}" line — a PR that closes its issue must say so.`,
+			);
+	}
+};
+
+export const runPr = (
+	options: PrOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {number, partial} = options;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+		const body = authored.text;
+
+		const leaked = leakRefusal(VERB, body);
+		if (leaked !== null) return leaked;
+
+		const defect = bodyDefect(body, number, partial);
+		if (defect !== null) return shapeRefusal(defect, number, partial);
+
+		const classification = classificationIn(proseOf(body));
+		if (classification !== null) {
+			return refuse(
+				OFF_VOCABULARY,
+				classification === "control-plane"
+					? `${VERB}: the body asserts a control-plane classification — that verdict is the merge gate's.`
+					: `${VERB}: the body asserts a ${classification} classification — that verdict is triage's.`,
+			);
+		}
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openIssue(
+			VERB,
+			repo,
+			number,
+			(reason) => `${VERB}: cannot read #${number}: ${reason} — nothing was written.`,
+		);
+		if (target._tag === "Refused") return target.outcome;
+
+		const lane = yield* requireLane(VERB, repo, session.id, number);
+		if (lane._tag === "Refused") return lane.outcome;
+
+		const existing = yield* openPullForHead(repo, lane.branch);
+		if (existing._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the open pull requests for ${lane.branch}: ${existing.reason} — nothing was written.`,
+				lane.notes,
+			);
+		}
+		if (existing.value !== null) {
+			return answer(
+				JSON.stringify({
+					answer: "existing",
+					number: existing.value.number,
+					url: existing.value.url,
+				}),
+				lane.notes,
+			);
+		}
+
+		const base = yield* defaultBranch(repo);
+		if (base._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${repo}'s default branch: ${base.reason} — nothing was written.`,
+				lane.notes,
+			);
+		}
+
+		const created = yield* createPull(repo, target.issue.title, lane.branch, base.value, body);
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the create failed: ${created.reason} — it may or may not have landed; re-run, the verb re-checks for an existing PR first.`,
+				lane.notes,
+			);
+		}
+
+		const back = yield* getPullRequest(repo, created.value.number);
+		const matches =
+			back._tag === "Present" &&
+			normalizeForReadback(back.value.body) === normalizeForReadback(body);
+		return matches
+			? answer(
+					JSON.stringify({answer: "opened", number: created.value.number, url: created.value.url}),
+					lane.notes,
+				)
+			: refuse(
+					READBACK_MISMATCH,
+					`${VERB}: the PR landed (#${created.value.number}) but its body does not read back as sent — it needs a human eye.`,
+					lane.notes,
+				);
+	});

--- a/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
@@ -1,0 +1,196 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {comments, issue, LANE_UUID, LINKED, marker, NONCE, pull} from "./fixtures.test-support.ts";
+import {runPr} from "./pr-verb.ts";
+
+const REV_PARSE = /^git rev-parse --path-format=absolute/;
+const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const OPEN_PULLS = /^gh api --paginate repos\/o\/r\/pulls\?state=open&head=/;
+const REPO_META = /^gh api repos\/o\/r --jq \.default_branch$/;
+const CREATE = /^gh api --method POST repos\/o\/r\/pulls/;
+const READ_BACK = /^gh api repos\/o\/r\/pulls\/4318$/;
+
+const LANE = `build/4312-editor-focus-loss-${NONCE}`;
+const BODY = "Fixes #4312\n\nEditor focus now survives a save.\n\n## Deviations\nNone.\n";
+
+const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[ISSUE, issue()],
+	[REV_PARSE, LINKED],
+	[BRANCH, okOut(`${LANE}\n`)],
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, okOut("write\n")],
+];
+
+const options = {
+	number: 4312,
+	partial: false,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: BODY}),
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => Effect.runPromise(Effect.provide(runPr({...options, ...overrides}), fakeShell(script).layer));
+
+const withBody = (text: string) => ({stdin: Effect.succeed<StdinRead>({_tag: "Text", text})});
+
+describe("runPr — the body guards run before any write", () => {
+	it("refuses empty stdin on 3, and touches nothing", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(runPr({...options, ...withBody("   \n")}), shell.layer),
+		);
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a bare @ reference on 6 — the body never arrived (#3086)", async () => {
+		const out = await run([], withBody("@/tmp/pr-body.md"));
+		expect(out.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path on 5, naming the first hit", async () => {
+		const out = await run(
+			[],
+			withBody("Fixes #4312\n\nsee /Users/someone/notes.md\n\n## Deviations\nNone.\n"),
+		);
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stderr.at(-1)).toContain("redact before posting");
+	});
+
+	it("refuses a missing Deviations section on 4 (#4542)", async () => {
+		const out = await run([], withBody("Fixes #4312\n\njust prose\n"));
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toBe(
+			'build pr: the body has no "## Deviations" heading, or it is empty — state deviations, or state "None."',
+		);
+	});
+
+	it("refuses a stray closing keyword on 4 (#4471)", async () => {
+		const out = await run([], withBody(`${BODY}\nAlso closes #999.\n`));
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toBe(
+			"build pr: the body carries a closing keyword aimed at #999 — this PR serves #4312.",
+		);
+	});
+
+	it("refuses Fixes under --partial on 4", async () => {
+		const out = await run([], {partial: true});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toBe(
+			'build pr: the body says "Fixes #4312" but --partial was given — a partial PR must say "Part of #4312".',
+		);
+	});
+
+	it("refuses a control-plane classification on 10 — that verdict is the gate's (#4153)", async () => {
+		const out = await run(
+			[],
+			withBody("Fixes #4312\n\nThis is not control-plane.\n\n## Deviations\nNone.\n"),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			"build pr: the body asserts a control-plane classification — that verdict is the merge gate's.",
+		);
+	});
+});
+
+describe("runPr — the write path", () => {
+	it("opens the PR and reads its body back", async () => {
+		const out = await run([
+			...LANE_OK,
+			[OPEN_PULLS, okOut("")],
+			[REPO_META, okOut("main\n")],
+			[CREATE, okOut(JSON.stringify({number: 4318, html_url: "https://github.com/o/r/pull/4318"}))],
+			[READ_BACK, pull({body: BODY})],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "opened",
+			number: 4318,
+			url: "https://github.com/o/r/pull/4318",
+		});
+	});
+
+	it("never posts the body through the `-f body=@file` form (#4683)", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[OPEN_PULLS, okOut("")],
+			[REPO_META, okOut("main\n")],
+			[CREATE, okOut(JSON.stringify({number: 4318, html_url: "https://github.com/o/r/pull/4318"}))],
+			[READ_BACK, pull({body: BODY})],
+		]);
+		await Effect.runPromise(Effect.provide(runPr(options), shell.layer));
+		expect(shell.calls.some((line) => line.includes("body=@"))).toBe(false);
+	});
+
+	it("answers `existing` on exit 0 when this head already has an open PR — no duplicate", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[OPEN_PULLS, okOut("4310\thttps://github.com/o/r/pull/4310\n")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPr(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("existing");
+		expect(shell.calls.some((line) => CREATE.test(line))).toBe(false);
+	});
+
+	it("refuses a failed create on 8, pointing at the idempotent re-run", async () => {
+		const out = await run([
+			...LANE_OK,
+			[OPEN_PULLS, okOut("")],
+			[REPO_META, okOut("main\n")],
+			[CREATE, errOut("gh: Gateway timeout (HTTP 504)")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("re-run, the verb re-checks for an existing PR first");
+	});
+
+	it("refuses a body that does not read back on 9", async () => {
+		const out = await run([
+			...LANE_OK,
+			[OPEN_PULLS, okOut("")],
+			[REPO_META, okOut("main\n")],
+			[CREATE, okOut(JSON.stringify({number: 4318, html_url: "https://github.com/o/r/pull/4318"}))],
+			[READ_BACK, pull({body: "something else"})],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+
+	/** GitHub's round-tripping is not byte-stable; comparing raw bytes would red on a clean run. */
+	it("compares the read-back through normalizeForReadback, not byte-for-byte", async () => {
+		const out = await run([
+			...LANE_OK,
+			[OPEN_PULLS, okOut("")],
+			[REPO_META, okOut("main\n")],
+			[CREATE, okOut(JSON.stringify({number: 4318, html_url: "https://github.com/o/r/pull/4318"}))],
+			[READ_BACK, pull({body: `${BODY.replace(/\n/g, "\r\n")}\r\n\r\n`})],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses a closed target issue on 7", async () => {
+		const out = await run([[once(ISSUE), issue({state: "closed"})]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+});

--- a/packages/fabrika-cli/src/build/push-verb.ts
+++ b/packages/fabrika-cli/src/build/push-verb.ts
@@ -1,0 +1,117 @@
+/**
+ * `build push` — publish the lane's branch, then **independently confirm the remote ref moved**.
+ *
+ * `git push`'s own report is not evidence: a push that died mid-hook read as sent, and every stage
+ * downstream assumed a branch that was not there (#4136). So the verdict comes from `git ls-remote`
+ * asking the remote directly, compared against the local head.
+ *
+ * **This verb is the group's one deviant on the channel rule: the entire report is stdout,
+ * single-stream, so the last stdout line is always the verdict line.** v1 documented exactly this
+ * `tail -1` idiom and then shipped the report to stderr at both call sites (`SKILL.md:778-781` vs
+ * `step5-push.sh:47`), so the documented read never ran. Here the channel is part of the contract, and
+ * the two non-`MOVED` outcomes take their own codes with empty stdout — which is what keeps `tail -1`
+ * of stdout on exit 0 unambiguous.
+ *
+ * `--force-with-lease` is the only force shape. A bare `--force` flag does not exist, and neither does
+ * `--no-verify`: the ban is enforced by the flag not existing rather than by prose (#4159, #4468,
+ * #4540).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {currentBranch} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {requireSession} from "./claim.ts";
+import {PRECONDITION_UNKNOWN, REF_NOT_MOVED, UNSAFE_PUSH, WRITE_UNKNOWN} from "./codes.ts";
+import {headSha, isAncestor, push, remoteSha, upstreamOf} from "./git.ts";
+import {requireLane} from "./lane-guard.ts";
+import {resolveTargetRepo} from "./target.ts";
+
+const VERB = "build push";
+
+export interface PushOptions {
+	readonly forceWithLease: boolean;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runPush = (
+	options: PushOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		// Detached HEAD is refused HERE, ahead of the lane guard, so it lands on `19` (refused before
+		// pushing) rather than on the guard's `14` (wrong lane) — they are different facts.
+		if ((yield* currentBranch) === null) {
+			return refuse(UNSAFE_PUSH, `${VERB}: HEAD is detached — refusing to guess a branch.`);
+		}
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const lane = yield* requireLane(VERB, resolved.repo, session.id, null);
+		if (lane._tag === "Refused") return lane.outcome;
+
+		const local = yield* headSha;
+		if (local._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve HEAD: ${local.reason} — nothing was pushed.`,
+				lane.notes,
+			);
+		}
+
+		// The push TARGET is the tracked upstream when there is one — resume mode's local name differs
+		// from the PR's remote head branch, and reading back the local name would call every repair
+		// push a false `17`.
+		const upstream = yield* upstreamOf(lane.branch);
+		const remote = upstream?.remote ?? "origin";
+		const ref = upstream?.ref ?? lane.branch;
+
+		const before = yield* remoteSha(remote, ref);
+		if (before._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${remote}/${ref}: ${before.reason} — nothing was pushed.`,
+				lane.notes,
+			);
+		}
+		if (before.value !== null && !options.forceWithLease) {
+			const fastForward = yield* isAncestor(before.value, local.value);
+			if (!fastForward) {
+				return refuse(
+					UNSAFE_PUSH,
+					`${VERB}: non-fast-forward — pass --force-with-lease only for this lane's own repair resubmission.`,
+					lane.notes,
+				);
+			}
+		}
+
+		const pushed = yield* push(remote, ref, options.forceWithLease);
+		const after = yield* remoteSha(remote, ref);
+		if (after._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: pushed, but the remote ref could not be re-read: ${after.reason} — the outcome is UNKNOWN.`,
+				lane.notes,
+			);
+		}
+		if (after.value !== local.value) {
+			return refuse(
+				REF_NOT_MOVED,
+				`${VERB}: the remote ref did not move (remote ${after.value ?? "absent"} ≠ local ${local.value}).`,
+				[
+					...lane.notes,
+					...(pushed._tag === "Failure" ? [`${VERB}: git push reported: ${pushed.reason}.`] : []),
+				],
+			);
+		}
+		return answer(
+			[
+				`pushed ${lane.branch} → ${remote}/${ref}`,
+				`remote ref read back: ${after.value}`,
+				"PUSH-VERDICT: MOVED",
+			].join("\n"),
+			lane.notes,
+		);
+	});

--- a/packages/fabrika-cli/src/build/push-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/push-verb.unit.test.ts
@@ -1,0 +1,196 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	CLAIM_NOT_MINE,
+	PRECONDITION_UNKNOWN,
+	REF_NOT_MOVED,
+	UNSAFE_PUSH,
+	WRITE_UNKNOWN,
+	WRONG_LANE,
+} from "./codes.ts";
+import {
+	comments,
+	HEAD,
+	issue,
+	LANE_UUID,
+	LINKED,
+	marker,
+	NONCE,
+	OLD_HEAD,
+} from "./fixtures.test-support.ts";
+import {runPush} from "./push-verb.ts";
+
+const REV_PARSE = /^git rev-parse --path-format=absolute/;
+const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const HEAD_SHA = /^git rev-parse HEAD$/;
+const UPSTREAM = /^git rev-parse --abbrev-ref --symbolic-full-name /;
+const LS_REMOTE = /^git ls-remote origin /;
+const PUSH = /^git push /;
+const ANCESTOR = /^git merge-base --is-ancestor /;
+
+const LANE = `build/4312-editor-focus-loss-${NONCE}`;
+
+const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[REV_PARSE, LINKED],
+	[BRANCH, okOut(`${LANE}\n`)],
+	[ISSUE, issue()],
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, okOut("write\n")],
+	[HEAD_SHA, okOut(`${HEAD}\n`)],
+	[UPSTREAM, errOut("fatal: no upstream")],
+];
+
+const options = {
+	forceWithLease: false,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runPush({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runPush", () => {
+	it("puts the WHOLE report on stdout, with the verdict line last", async () => {
+		const out = await run([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/${LANE}\n`)],
+			[ANCESTOR, okOut("")],
+			[PUSH, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		const lines = out.stdout.trimEnd().split("\n");
+		expect(lines.at(-1)).toBe("PUSH-VERDICT: MOVED");
+		expect(lines[0]).toContain(`pushed ${LANE} → origin/${LANE}`);
+	});
+
+	it("proves MOVED by reading the remote ref back, not by git push's own report (#4136)", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/${LANE}\n`)],
+			[ANCESTOR, okOut("")],
+			[PUSH, errOut("everything up-to-date")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
+		expect(shell.calls.filter((line) => LS_REMOTE.test(line)).length).toBeGreaterThanOrEqual(2);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses on 17 when the ref did not move, even though the push reported success", async () => {
+		const out = await run([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
+			[ANCESTOR, okOut("")],
+			[PUSH, okOut("")],
+		]);
+		expect(out.code).toBe(REF_NOT_MOVED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`build push: the remote ref did not move (remote ${OLD_HEAD} ≠ local ${HEAD}).`,
+		);
+	});
+
+	it("refuses on 8 when the ref could not be re-read — UNKNOWN, not a failure and not a success", async () => {
+		const out = await run([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, errOut("fatal: could not read from remote repository")],
+		]);
+		expect([WRITE_UNKNOWN, PRECONDITION_UNKNOWN]).toContain(out.code);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a detached HEAD on 19 — before the lane guard, so it is not a 14", async () => {
+		const out = await run([[BRANCH, errOut("HEAD")]]);
+		expect(out.code).toBe(UNSAFE_PUSH);
+		expect(out.stderr.at(-1)).toBe("build push: HEAD is detached — refusing to guess a branch.");
+	});
+
+	it("refuses a non-fast-forward without --force-with-lease on 19, and pushes nothing", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
+			[ANCESTOR, errOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
+		expect(out.code).toBe(UNSAFE_PUSH);
+		expect(out.stderr.at(-1)).toBe(
+			"build push: non-fast-forward — pass --force-with-lease only for this lane's own repair resubmission.",
+		);
+		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
+	});
+
+	it("passes --force-with-lease through, and never a bare --force or --no-verify", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/${LANE}\n`)],
+			[ANCESTOR, okOut("")],
+			[PUSH, okOut("")],
+		]);
+		await Effect.runPromise(
+			Effect.provide(runPush({...options, forceWithLease: true}), shell.layer),
+		);
+		const pushed = shell.calls.find((line) => PUSH.test(line)) ?? "";
+		expect(pushed).toContain("--force-with-lease");
+		expect(pushed).not.toMatch(/--force(?!-with-lease)/);
+		expect(pushed).not.toContain("--no-verify");
+	});
+
+	it("pushes to the TRACKED UPSTREAM when there is one — resume mode's local name differs", async () => {
+		const shell = fakeShell([
+			[REV_PARSE, LINKED],
+			[BRANCH, okOut(`build/pr-4310-${NONCE}\n`)],
+			[/^gh api repos\/o\/r\/issues\/4310$/, issue({number: 4310})],
+			[
+				/^gh api --paginate repos\/o\/r\/issues\/4310\/comments/,
+				comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
+			],
+			[PERM, okOut("write\n")],
+			[HEAD_SHA, okOut(`${HEAD}\n`)],
+			[UPSTREAM, okOut("origin/umut/fix-focus\n")],
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/umut/fix-focus\n`)],
+			[ANCESTOR, okOut("")],
+			[PUSH, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls).toContain("git push origin HEAD:refs/heads/umut/fix-focus");
+	});
+
+	it("refuses a branch that is not a lane branch on 14", async () => {
+		const out = await run([
+			[REV_PARSE, LINKED],
+			[BRANCH, okOut("main\n")],
+		]);
+		expect(out.code).toBe(WRONG_LANE);
+	});
+
+	it("refuses a foreign claim on 15, and pushes nothing", async () => {
+		const shell = fakeShell([
+			[REV_PARSE, LINKED],
+			[BRANCH, okOut(`${LANE}\n`)],
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/build/rounds.ts
+++ b/packages/fabrika-cli/src/build/rounds.ts
@@ -1,0 +1,33 @@
+/**
+ * How many repair rounds a PR has been through, counted by clustering FAIL markers in time.
+ *
+ * A gate's FAIL often arrives as several comments seconds apart, so counting comments would count one
+ * round several times. The rule, pinned so two implementations agree: FAIL-polarity markers sorted by
+ * `created_at` ascending; a marker whose gap from the previous FAIL **exceeds** 120 seconds starts a
+ * new cluster, and a gap of **exactly** 120 seconds or less continues the current one.
+ *
+ * The boundary is stated because it is where the off-by-one lived (#4570), and it is counted over the
+ * **full** comment set — v1 counted off a truncated 100-comment snapshot (`stepR-round-count.sh` +
+ * `stepR1-verdicts.sh:48`), which under-counts exactly when the cap matters most.
+ */
+
+/** The gap at which a FAIL still belongs to the round before it. Inclusive. */
+export const ROUND_GAP_MS = 120_000;
+
+/** The round at which a repair loop is capped — `capReached` is a field read, not a remembered number. */
+export const ROUND_CAP = 3;
+
+/** Cluster FAIL timestamps into rounds. An empty input is zero rounds, which is a fact, not a gap. */
+export const countRounds = (createdAt: ReadonlyArray<string>): number => {
+	const times = createdAt
+		.map((at) => Date.parse(at))
+		.filter((ms) => !Number.isNaN(ms))
+		.sort((a, b) => a - b);
+	let rounds = 0;
+	let previous: number | null = null;
+	for (const ms of times) {
+		if (previous === null || ms - previous > ROUND_GAP_MS) rounds += 1;
+		previous = ms;
+	}
+	return rounds;
+};

--- a/packages/fabrika-cli/src/build/rounds.unit.test.ts
+++ b/packages/fabrika-cli/src/build/rounds.unit.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from "vitest";
+import {countRounds, ROUND_CAP, ROUND_GAP_MS} from "./rounds.ts";
+
+const at = (secondsFromStart: number) =>
+	new Date(1_770_000_000_000 + secondsFromStart * 1000).toISOString();
+
+describe("countRounds clusters FAIL markers by the 120-second gap rule", () => {
+	it("counts no FAILs as zero rounds — a fact, not a gap", () => {
+		expect(countRounds([])).toBe(0);
+	});
+
+	it("folds a burst of markers seconds apart into one round", () => {
+		expect(countRounds([at(0), at(3), at(9)])).toBe(1);
+	});
+
+	/**
+	 * The boundary is the whole point of pinning the rule: 120 seconds *continues* the round and 121
+	 * starts a new one. Off by one here is #4570, and it decides whether the cap has been reached.
+	 */
+	it("continues the round at EXACTLY 120 seconds and starts a new one at 121", () => {
+		expect(ROUND_GAP_MS).toBe(120_000);
+		expect(countRounds([at(0), at(120)])).toBe(1);
+		expect(countRounds([at(0), at(121)])).toBe(2);
+	});
+
+	it("counts three separated rounds, which is the cap", () => {
+		expect(countRounds([at(0), at(300), at(600)])).toBe(ROUND_CAP);
+	});
+
+	it("sorts before clustering, so an out-of-order list counts the same", () => {
+		expect(countRounds([at(600), at(0), at(300)])).toBe(3);
+	});
+
+	it("ignores an unparseable timestamp rather than treating it as time zero", () => {
+		expect(countRounds(["not a date", at(0), at(3)])).toBe(1);
+	});
+});

--- a/packages/fabrika-cli/src/build/scratch-verb.ts
+++ b/packages/fabrika-cli/src/build/scratch-verb.ts
@@ -1,0 +1,75 @@
+/**
+ * `build scratch` — the per-lane scratch path, allocated fail-closed.
+ *
+ * `<temp root>/fabrika-build/<session-id>/<issue>-<claim-nonce>/<slug>`. The fixed `fabrika-build`
+ * segment namespaces the allocator against everything else in the temp root; **the claim nonce is what
+ * v1's allocator lacked**. v1 keyed on the session id alone, so two lanes — or two roles — of one
+ * session shared a namespace and clobbered each other's fixed-name files (#4516, #4544, #4875, #4692),
+ * and its own stamp could not separate two pid-less runs (`scratchpad.ts:26-29`). Keying on the
+ * confirmed claim makes the namespace per-lane by construction rather than by convention.
+ *
+ * The printed path is machine-local by definition and must never reach a posted artifact — which is
+ * why `build pr` and `build note` red on it (`5`).
+ */
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {requireClaim, requireSession} from "./claim.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {isKebabSlug, nonceOf} from "./lane.ts";
+import {resolveTargetRepo} from "./target.ts";
+
+const VERB = "build scratch";
+
+export interface ScratchOptions {
+	readonly number: number;
+	readonly slug: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The OS temp root, read by the adapter — the one machine fact this verb does not derive. */
+	readonly tmpRoot: string;
+}
+
+export const runScratch = (
+	options: ScratchOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const {number, slug} = options;
+		if (slug.includes("/") || slug.includes("\\") || !isKebabSlug(slug)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --slug "${slug}" must be a kebab-case leaf, no path separators.`,
+			);
+		}
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const held = yield* requireClaim(VERB, resolved.repo, number, session.id);
+		if (held._tag === "Refused") return held.outcome;
+		const nonce = nonceOf(held.marker.token);
+		if (nonce === null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: the claim on #${number} carries the token ${held.marker.token}, which yields no lane nonce — the lane is UNKNOWN.`,
+				held.notes,
+			);
+		}
+
+		const root = options.tmpRoot.replace(/\/+$/, "");
+		const dir = `${root}/fabrika-build/${session.id}/${number}-${nonce}`;
+		const fs = yield* FileSystem.FileSystem;
+		const made: string | null = yield* fs.makeDirectory(dir, {recursive: true}).pipe(
+			Effect.as(null),
+			Effect.catchTag("PlatformError", (cause) => Effect.succeed(cause.message)),
+		);
+		return made === null
+			? answer(`${dir}/${slug}`, held.notes)
+			: refuse(FAILED, `${VERB}: cannot create ${dir}: ${made}`, held.notes);
+	});

--- a/packages/fabrika-cli/src/build/scratch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scratch-verb.unit.test.ts
@@ -1,0 +1,95 @@
+import {Effect, FileSystem, Layer, PlatformError} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {FAILED} from "../verb.ts";
+import {CLAIM_NOT_MINE, OFF_VOCABULARY} from "./codes.ts";
+import {comments, issue, LANE_UUID, marker, NONCE} from "./fixtures.test-support.ts";
+import {runScratch} from "./scratch-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+
+const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[ISSUE, issue()],
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, okOut("write\n")],
+];
+
+const options = {
+	number: 4312,
+	slug: "notes",
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+	tmpRoot: "/scratch-root",
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runScratch({...options, ...overrides}),
+			Layer.merge(fakeShell(script).layer, fakeFs({}).layer),
+		),
+	);
+
+describe("runScratch", () => {
+	/**
+	 * The nonce in the key is the whole fix: v1 keyed on the session id alone, so two lanes of one
+	 * session shared a namespace and clobbered each other's fixed-name files (#4516, #4544).
+	 */
+	it("keys the namespace on the CLAIM NONCE, not the session alone", async () => {
+		const out = await run(CLAIMED);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`/scratch-root/fabrika-build/s-9f2e/4312-${NONCE}/notes\n`);
+	});
+
+	it("refuses a slug carrying a path separator on 10", async () => {
+		const out = await run([], {slug: "notes/inner"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			'build scratch: --slug "notes/inner" must be a kebab-case leaf, no path separators.',
+		);
+	});
+
+	it("refuses a non-kebab slug on 10", async () => {
+		const out = await run([], {slug: "Notes"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses a foreign claim on 15 — no lane, no namespace", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+		]);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unmakeable directory on the universal 1 — never a path it could not allocate", async () => {
+		const unmakeable = FileSystem.layerNoop({
+			makeDirectory: (path: string) =>
+				Effect.fail(
+					PlatformError.systemError({
+						_tag: "PermissionDenied",
+						module: "FileSystem",
+						method: "makeDirectory",
+						pathOrDescriptor: path,
+					}),
+				),
+		});
+		const out = await Effect.runPromise(
+			Effect.provide(runScratch(options), Layer.merge(fakeShell(CLAIMED).layer, unmakeable)),
+		);
+		expect(out.code).toBe(FAILED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("build scratch: cannot create ");
+	});
+});

--- a/packages/fabrika-cli/src/build/target.ts
+++ b/packages/fabrika-cli/src/build/target.ts
@@ -1,0 +1,106 @@
+/**
+ * The preconditions every `build` verb runs before it answers: resolve the repo, resolve the target,
+ * and keep *proven absent* apart from *unreadable*.
+ *
+ * It lives here rather than in each verb because that split is the group's whole posture and fourteen
+ * copies of it are fourteen chances to fold the two together. Every message is prefixed with the
+ * invoked verb's name — the contract states that once for the whole group, so it is applied once here.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue, type IssueRecord, resolveRepo} from "../io/issues.ts";
+import {getPullRequest, type PullRecord} from "../io/pulls.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+
+/** `<verb>: scanned <n> <noun>(s)[; <note>].` — the count first, so an empty answer is auditable. */
+export const scannedLine = (verb: string, scanned: number, noun: string, note?: string): string =>
+	`${verb}: scanned ${scanned} ${noun}${scanned === 1 ? "" : "s"}${
+		note === undefined ? "" : `; ${note}`
+	}.`;
+
+/** A positive integer, or the usage refusal — every number-taking verb's first check. */
+export const badNumber = (verb: string, noun: string, value: number): VerbOutcome | null =>
+	Number.isInteger(value) && value > 0 ? null : refuse(FAILED, `${verb}: ${value} is not ${noun}.`);
+
+export type Resolved =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Repo"; readonly repo: string};
+
+export const resolveTargetRepo = (
+	verb: string,
+	explicit: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Resolved, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const attempt = yield* resolveRepo(explicit, env);
+		return attempt._tag === "Failure"
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						FAILED,
+						`${verb}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+					),
+				}
+			: {_tag: "Repo" as const, repo: attempt.value};
+	});
+
+export type IssueTarget =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Issue"; readonly issue: IssueRecord};
+
+/**
+ * One open issue, or the refusal.
+ *
+ * Absent and closed share `7` because both are the same fact to a caller — there is no live issue to
+ * act on — while an unreadable one is `11` and says nothing about whether it exists.
+ */
+export const openIssue = (
+	verb: string,
+	repo: string,
+	number: number,
+	unknownMessage: (reason: string) => string,
+): Effect.Effect<IssueTarget, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const found = yield* getIssue(repo, number);
+		if (found._tag === "Absent" || (found._tag === "Present" && found.value.state !== "open")) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(ZERO_SCOPE, `${verb}: issue #${number} is proven absent or closed.`),
+			};
+		}
+		if (found._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(PRECONDITION_UNKNOWN, unknownMessage(found.reason)),
+			};
+		}
+		return {_tag: "Issue" as const, issue: found.value};
+	});
+
+export type PullTarget =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Pull"; readonly pull: PullRecord};
+
+export const openPull = (
+	verb: string,
+	repo: string,
+	pr: number,
+	unknownMessage: (reason: string) => string,
+): Effect.Effect<PullTarget, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const found = yield* getPullRequest(repo, pr);
+		if (found._tag === "Absent" || (found._tag === "Present" && found.value.state !== "open")) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(ZERO_SCOPE, `${verb}: PR #${pr} is proven absent or closed.`),
+			};
+		}
+		if (found._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(PRECONDITION_UNKNOWN, unknownMessage(found.reason)),
+			};
+		}
+		return {_tag: "Pull" as const, pull: found.value};
+	});

--- a/packages/fabrika-cli/src/build/tree-verb.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.ts
@@ -1,0 +1,60 @@
+/**
+ * `build tree` — the ground, proven from git state and one claim, and never repaired.
+ *
+ * Three assertions, each with its own code so a caller can act on which one failed: a linked worktree
+ * (`12`), a clean tree at a `--require-clean` open (`13`), and a checked-out branch carrying this
+ * claim's nonce (`14`). It **verifies and never provisions** — no create, no lock, no unlock, no
+ * remove. A verifier that could also repair is the self-provision path the incident record closes
+ * (the 2026-08-03 amendment on #4707).
+ *
+ * The skill re-runs this before every git mutation because the shell's cwd resets between calls, so a
+ * pass here is a fact about *this* invocation and nothing later.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {currentBranch} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {requireClaim, requireSession} from "./claim.ts";
+import {WRONG_LANE} from "./codes.ts";
+import {nonceOf, parseLaneBranch} from "./lane.ts";
+import {resolveTargetRepo} from "./target.ts";
+import {assertGround} from "./worktree.ts";
+
+const VERB = "build tree";
+
+export interface TreeOptions {
+	readonly requireClean: boolean;
+	/** Additionally prove the checked-out branch carries this claim's nonce — the pre-mutation posture. */
+	readonly issue: number | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runTree = (
+	options: TreeOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const ground = yield* assertGround(VERB, options.requireClean);
+		if (ground._tag === "Refused") return ground.outcome;
+		if (options.issue === null) return answer(ground.root);
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const held = yield* requireClaim(VERB, resolved.repo, options.issue, session.id);
+		if (held._tag === "Refused") return held.outcome;
+
+		const branch = yield* currentBranch;
+		const lane = branch === null ? null : parseLaneBranch(branch);
+		if (lane === null || nonceOf(held.marker.token) !== lane.nonce) {
+			return refuse(
+				WRONG_LANE,
+				`${VERB}: the checked-out branch "${branch ?? "(detached)"}" does not carry claim ${held.marker.token}'s nonce — wrong lane.`,
+				held.notes,
+			);
+		}
+		return answer(ground.root, held.notes);
+	});

--- a/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/tree-verb.unit.test.ts
@@ -1,0 +1,161 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {FAILED} from "../verb.ts";
+import {
+	CLAIM_NOT_MINE,
+	DIRTY_TREE,
+	NOT_A_WORKTREE,
+	PRECONDITION_UNKNOWN,
+	WRONG_LANE,
+} from "./codes.ts";
+import {
+	comments,
+	issue,
+	LANE_UUID,
+	LINKED,
+	marker,
+	NONCE,
+	PRIMARY,
+} from "./fixtures.test-support.ts";
+import {runTree} from "./tree-verb.ts";
+
+const REV_PARSE = /^git rev-parse --path-format=absolute/;
+const STATUS = /^git status --porcelain$/;
+const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+
+const LANE_BRANCH = okOut(`build/4312-editor-focus-loss-${NONCE}\n`);
+const MINE = comments({id: 1, body: marker("s-9f2e", LANE_UUID)});
+
+const options = {
+	requireClean: false,
+	issue: null as number | null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runTree({...options, ...overrides}), fakeShell(script).layer));
+
+describe("runTree", () => {
+	it("prints the tree root when the git dir and the common dir differ", async () => {
+		const out = await run([[REV_PARSE, LINKED]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("/repo/trees/lane-a\n");
+	});
+
+	it("refuses the primary checkout on 12 — the two dirs being equal IS the proof", async () => {
+		const out = await run([[REV_PARSE, PRIMARY]]);
+		expect(out.code).toBe(NOT_A_WORKTREE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"build tree: this is the primary checkout, not a linked worktree — stop; never build here.",
+		);
+	});
+
+	it("refuses an unreadable git state on 12 too — outside a repo there is no linked worktree", async () => {
+		const out = await run([[REV_PARSE, errOut("fatal: not a git repository")]]);
+		expect(out.code).toBe(NOT_A_WORKTREE);
+	});
+
+	it("refuses a dirty tree at a --require-clean open on 13, and never cleans it", async () => {
+		const shell = fakeShell([
+			[REV_PARSE, LINKED],
+			[STATUS, okOut(" M apps/web/src/App.tsx\n?? scratch.md\n")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runTree({...options, requireClean: true}), shell.layer),
+		);
+		expect(out.code).toBe(DIRTY_TREE);
+		expect(out.stderr.at(-1)).toBe(
+			"build tree: 2 uncommitted change(s) at open — refusing; an unauthored hunk is not yours to keep or clean.",
+		);
+		expect(shell.calls.some((line) => /git (checkout|clean|restore|stash)/.test(line))).toBe(false);
+	});
+
+	it("passes --require-clean over a clean tree", async () => {
+		const out = await run([
+			[REV_PARSE, LINKED],
+			[STATUS, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("proves the lane with --issue when the branch nonce matches the claim", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, LINKED],
+				[ISSUE, issue()],
+				[COMMENTS, MINE],
+				[PERM, okOut("write\n")],
+				[BRANCH, LANE_BRANCH],
+			],
+			{issue: 4312},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("/repo/trees/lane-a\n");
+	});
+
+	it("refuses a branch carrying another claim's nonce on 14", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, LINKED],
+				[ISSUE, issue()],
+				[COMMENTS, MINE],
+				[PERM, okOut("write\n")],
+				[BRANCH, okOut("build/4312-editor-focus-loss-deadbeef\n")],
+			],
+			{issue: 4312},
+		);
+		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("does not carry claim build:s-9f2e:");
+	});
+
+	it("refuses a foreign claim on 15", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, LINKED],
+				[ISSUE, issue()],
+				[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
+				[PERM, okOut("write\n")],
+			],
+			{issue: 4312},
+		);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stderr.at(-1)).toBe(
+			"build tree: #4312 is held by build:s-77aa:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d, not this session.",
+		);
+	});
+
+	it("refuses an unreadable marker set on 11 — the lane is UNKNOWN, never unclaimed", async () => {
+		const out = await run(
+			[
+				[REV_PARSE, LINKED],
+				[ISSUE, issue()],
+				[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+			],
+			{issue: 4312},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the lane is UNKNOWN");
+	});
+
+	it("refuses a missing session id on 1, never on 15", async () => {
+		const out = await run([[REV_PARSE, LINKED]], {
+			issue: 4312,
+			env: {CLAUDE_PIPELINE_REPO: "o/r"},
+		});
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.at(-1)).toContain("CLAUDE_CODE_SESSION_ID is unset");
+	});
+});

--- a/packages/fabrika-cli/src/build/verdicts-verb.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.ts
@@ -1,0 +1,177 @@
+/**
+ * `build verdicts` — the paginated, current-head, per-gate verdict fold on a PR.
+ *
+ * Three properties the repair loop rests on:
+ *
+ * - **A stale marker is visible AS stale, never dropped.** "The FAIL is old" and "there is no FAIL"
+ *   are different facts, and folding them is how a FAIL'd PR reads as unreviewed (#4105).
+ * - **Native reviews are their own row kind**, never coerced into markers. Whether a
+ *   `CHANGES_REQUESTED` with no marker drives a repair is the open decision #4555; this verb reports
+ *   the state honestly and pre-rules nothing.
+ * - **An unreadable page is `11`, never a shorter list.** `{"rows": []}` on exit 0 is a proven "no
+ *   verdicts", readable against the scope line's counts (ADR 0092, #4208 / #4219).
+ *
+ * Every row's `body` is the finding's full text through the content gate — the repair loop consumes
+ * findings from here and never raw-fetches a comment, which is what keeps the one-door property over
+ * the repair path.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue, listComments} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {read as readCriteria} from "../wire/acceptance-criteria.ts";
+import {bindToHead, read as readMarker} from "../wire/verdict-marker.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {contentOf, gate} from "./content-gate.ts";
+import {listReviews} from "./github.ts";
+import {closingTargets, proseOf} from "./pr-body.ts";
+import {countRounds, ROUND_CAP} from "./rounds.ts";
+import {openPull, resolveTargetRepo} from "./target.ts";
+
+const VERB = "build verdicts";
+
+/** ADR 0079's provenance tag on a reviewer-appended criterion: `<!-- ac:review pr:#<pr> round:<n> -->`. */
+const PROVENANCE_RE = /<!--\s*ac:review\s+pr:#(\d+)\s+round:(\d+)\s*-->/;
+
+export interface VerdictsOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+interface Row {
+	readonly gate: string;
+	readonly polarity: string;
+	readonly sha: string | null;
+	readonly current: boolean | null;
+	readonly commentId?: number;
+	readonly reviewId?: number;
+	readonly kind: "marker" | "native";
+	readonly body: string;
+}
+
+export const runVerdicts = (
+	options: VerdictsOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr} = options;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(
+			VERB,
+			repo,
+			pr,
+			(reason) =>
+				`${VERB}: cannot read PR #${pr} (page 1): ${reason} — the verdict state is UNKNOWN, never "none".`,
+		);
+		if (target._tag === "Refused") return target.outcome;
+		const head = target.pull.headSha;
+
+		const listed = yield* listComments(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the comments (page 1): ${listed.reason} — the verdict state is UNKNOWN, never "none".`,
+			);
+		}
+		const reviews = yield* listReviews(repo, pr);
+		if (reviews._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the reviews (page 1): ${reviews.reason} — the verdict state is UNKNOWN, never "none".`,
+			);
+		}
+
+		// Latest marker per gate namespace, and every FAIL's timestamp for the round count.
+		const latest = new Map<string, Row>();
+		const failedAt: string[] = [];
+		for (const comment of listed.value) {
+			const parsed = readMarker(comment.body);
+			if (parsed._tag !== "Found") continue;
+			const marker = parsed.value;
+			if (marker.polarity === "FAIL") failedAt.push(comment.createdAt);
+			latest.set(marker.namespace, {
+				gate: marker.namespace,
+				polarity: marker.polarity,
+				sha: marker.sha,
+				current: bindToHead(marker, head)._tag === "Current",
+				commentId: comment.id,
+				kind: "marker",
+				body: contentOf(gate("comment-body", `comment ${comment.id}`, comment.body)),
+			});
+		}
+		const rows: Row[] = [...latest.values()];
+		for (const review of reviews.value) {
+			if (review.state === "COMMENTED" || review.state === "PENDING") continue;
+			rows.push({
+				gate: "native-review",
+				polarity: review.state,
+				sha: null,
+				current: null,
+				reviewId: review.id,
+				kind: "native",
+				body: contentOf(gate("review-body", `review ${review.id}`, review.body)),
+			});
+		}
+
+		const rounds = countRounds(failedAt);
+		const frozen = yield* frozenCriteria(repo, pr, target.pull.body);
+		if (frozen._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the linked issue's acceptance criteria: ${frozen.reason} — the verdict state is UNKNOWN, never "none".`,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				head,
+				rows,
+				rounds,
+				capReached: rounds >= ROUND_CAP,
+				frozenCriteria: frozen.rows,
+			}),
+			[
+				`${VERB}: head ${head}; scanned ${listed.value.length} comment(s) and ${reviews.value.length} review(s) on #${pr}.`,
+			],
+		);
+	});
+
+type Frozen =
+	| {readonly _tag: "Rows"; readonly rows: ReadonlyArray<{text: string; appendedRound: number}>}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/**
+ * The reviewer-appended criteria on this PR's linked issue that landed after round 2.
+ *
+ * The provenance tag ADR 0079 requires is what makes them findable at all — the round is written into
+ * the row, so the freeze is a property of the artifact rather than of a session's memory. A PR with no
+ * closing keyword links no issue and freezes nothing, which is an answer.
+ */
+const frozenCriteria = (
+	repo: string,
+	pr: number,
+	body: string,
+): Effect.Effect<Frozen, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const issue = closingTargets(proseOf(body))[0];
+		if (issue === undefined) return {_tag: "Rows" as const, rows: []};
+		const found = yield* getIssue(repo, issue);
+		if (found._tag === "Unknown") return {_tag: "Unknown" as const, reason: found.reason};
+		if (found._tag === "Absent") return {_tag: "Rows" as const, rows: []};
+		const read = readCriteria(contentOf(gate("issue-body", `#${issue}`, found.value.body)));
+		if (read._tag !== "Found") return {_tag: "Rows" as const, rows: []};
+		const rows: {text: string; appendedRound: number}[] = [];
+		for (const criterion of read.value) {
+			const tag = PROVENANCE_RE.exec(criterion.text);
+			if (tag?.[1] === undefined || tag[2] === undefined) continue;
+			if (Number.parseInt(tag[1], 10) !== pr) continue;
+			const round = Number.parseInt(tag[2], 10);
+			if (round > 2) {
+				rows.push({text: criterion.text.replace(PROVENANCE_RE, "").trim(), appendedRound: round});
+			}
+		}
+		return {_tag: "Rows" as const, rows};
+	});

--- a/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
@@ -1,0 +1,180 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {comments, HEAD, issue, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+import {runVerdicts} from "./verdicts-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
+const REVIEWS = /^gh api --paginate repos\/o\/r\/pulls\/4310\/reviews/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+
+const FAIL_NOW = `review-code: FAIL @ ${HEAD} — the debounce fix races the unmount`;
+const PASS_STALE = `review-doc: PASS @ ${OLD_HEAD} — guide matches shipped behavior`;
+
+const NO_REVIEWS = okOut("[]");
+const PR = pull({number: 4310, body: "Fixes #4312\n\n## Deviations\nNone.\n"});
+
+const options = {
+	pr: 4310,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(Effect.provide(runVerdicts(options), fakeShell(script).layer));
+
+describe("runVerdicts", () => {
+	it("binds each marker to the live head and keeps the latest per gate", async () => {
+		const out = await run([
+			[PULL, PR],
+			[COMMENTS, comments({id: 1, body: PASS_STALE}, {id: 2, body: FAIL_NOW})],
+			[REVIEWS, NO_REVIEWS],
+			[ISSUE, issue()],
+		]);
+		expect(out.code).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.head).toBe(HEAD);
+		expect(parsed.rows).toHaveLength(2);
+		expect(parsed.rows.find((r: {gate: string}) => r.gate === "review-doc").current).toBe(false);
+		expect(parsed.rows.find((r: {gate: string}) => r.gate === "review-code").current).toBe(true);
+	});
+
+	/** "The FAIL is old" and "there is no FAIL" are different facts (#4105). */
+	it("keeps a stale marker in the fold, flagged stale — never drops it", async () => {
+		const out = await run([
+			[PULL, PR],
+			[COMMENTS, comments({id: 1, body: PASS_STALE})],
+			[REVIEWS, NO_REVIEWS],
+			[ISSUE, issue()],
+		]);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.rows).toHaveLength(1);
+		expect(parsed.rows[0].current).toBe(false);
+	});
+
+	it("reports a native review as its OWN row kind, never coerced into a marker (#4555)", async () => {
+		const out = await run([
+			[PULL, PR],
+			[COMMENTS, okOut("[]")],
+			[
+				REVIEWS,
+				okOut(
+					JSON.stringify([{id: 98001, state: "CHANGES_REQUESTED", body: "the debounce races"}]),
+				),
+			],
+			[ISSUE, issue()],
+		]);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.rows).toEqual([
+			{
+				gate: "native-review",
+				polarity: "CHANGES_REQUESTED",
+				sha: null,
+				current: null,
+				reviewId: 98001,
+				kind: "native",
+				body: "the debounce races",
+			},
+		]);
+	});
+
+	it("counts rounds over the FULL comment set and computes capReached from them", async () => {
+		const at = (s: number) => new Date(1_770_000_000_000 + s * 1000).toISOString();
+		const out = await run([
+			[PULL, PR],
+			[
+				COMMENTS,
+				comments(
+					{id: 1, body: FAIL_NOW, createdAt: at(0)},
+					{id: 2, body: FAIL_NOW, createdAt: at(5)},
+					{id: 3, body: FAIL_NOW, createdAt: at(400)},
+					{id: 4, body: FAIL_NOW, createdAt: at(900)},
+				),
+			],
+			[REVIEWS, NO_REVIEWS],
+			[ISSUE, issue()],
+		]);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.rounds).toBe(3);
+		expect(parsed.capReached).toBe(true);
+	});
+
+	it("lists only the criteria appended AFTER round 2, by their provenance tag", async () => {
+		const out = await run([
+			[PULL, PR],
+			[COMMENTS, okOut("[]")],
+			[REVIEWS, NO_REVIEWS],
+			[
+				ISSUE,
+				issue({
+					body: [
+						"### Acceptance criteria",
+						"",
+						"- [ ] focus stays put",
+						"- [ ] an e2e covers the empty-list case <!-- ac:review pr:#4310 round:3 -->",
+						"- [ ] an earlier one <!-- ac:review pr:#4310 round:1 -->",
+						"",
+					].join("\n"),
+				}),
+			],
+		]);
+		expect(JSON.parse(out.stdout).frozenCriteria).toEqual([
+			{text: "an e2e covers the empty-list case", appendedRound: 3},
+		]);
+	});
+
+	it("prints an empty fold as a proven answer on exit 0, with the counts on stderr", async () => {
+		const out = await run([
+			[PULL, PR],
+			[COMMENTS, comments({id: 1, body: "just a normal comment"})],
+			[REVIEWS, NO_REVIEWS],
+			[ISSUE, issue()],
+		]);
+		expect(out.code).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.rows).toEqual([]);
+		expect(parsed.rounds).toBe(0);
+		expect(out.stderr.at(-1)).toContain("scanned 1 comment(s) and 0 review(s)");
+	});
+
+	it("refuses a proven-absent PR on 7", async () => {
+		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe("build verdicts: PR #4310 is proven absent or closed.");
+	});
+
+	it("refuses an unreadable comment page on 11 — never a shorter list", async () => {
+		const out = await run([
+			[PULL, PR],
+			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('the verdict state is UNKNOWN, never "none"');
+	});
+
+	it("refuses an unreadable review page on 11 too", async () => {
+		const out = await run([
+			[PULL, PR],
+			[COMMENTS, okOut("[]")],
+			[REVIEWS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("paginates both list reads", async () => {
+		const shell = fakeShell([
+			[PULL, PR],
+			[COMMENTS, okOut("[]")],
+			[REVIEWS, NO_REVIEWS],
+			[ISSUE, issue()],
+		]);
+		await Effect.runPromise(Effect.provide(runVerdicts(options), shell.layer));
+		expect(shell.calls.filter((line) => line.includes("--paginate")).length).toBeGreaterThanOrEqual(
+			2,
+		);
+	});
+});

--- a/packages/fabrika-cli/src/build/worktree.ts
+++ b/packages/fabrika-cli/src/build/worktree.ts
@@ -1,0 +1,113 @@
+/**
+ * The ground `build tree` proves and `branch` / `check` / `push` / `pr` re-prove: this process is in a
+ * **linked** worktree, and (where asked) that tree is clean.
+ *
+ * The linked-worktree test is git plumbing and nothing else. A linked worktree's per-tree git dir
+ * (`.git/worktrees/<id>`) is not the shared common dir (`<primary>/.git`); in the primary checkout the
+ * two are the same path. Equality therefore *proves* the primary checkout, which is the one place work
+ * must never land (#3744 / #3594 / #4162 — silent commits into the shared tree). It keys on git state
+ * alone because the environment lies: the variables a spawner sets can be inherited, stale, or absent
+ * while the tree is real, and vice versa.
+ *
+ * **This module verifies and never provisions.** Nothing here creates, locks, unlocks or removes a
+ * tree: the spawner owns the tree's lifecycle (the 2026-08-03 amendment on #4707), and a verifier that
+ * could also repair is the self-provision path the incident record closes.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {DIRTY_TREE, NOT_A_WORKTREE} from "./codes.ts";
+
+export interface TreeState {
+	readonly gitDir: string;
+	readonly commonDir: string;
+	readonly root: string;
+	/** `gitDir !== commonDir` — positive evidence of a linked worktree, never an env reading. */
+	readonly linked: boolean;
+}
+
+/**
+ * The three paths the assertions compare, or the reason they could not be read.
+ *
+ * `--path-format=absolute` is what makes the comparison meaningful: `--git-common-dir` answers
+ * relatively from inside a linked tree, and a relative path compared against an absolute one differs
+ * for the wrong reason — it would report every primary checkout as linked.
+ */
+export const readTree: Shell<Attempt<TreeState>> = Effect.gen(function* () {
+	const dirs = yield* execCapture("git", [
+		"rev-parse",
+		"--path-format=absolute",
+		"--absolute-git-dir",
+		"--git-common-dir",
+		"--show-toplevel",
+	]);
+	if (!dirs.ok) return fail(dirs.reason);
+	const lines = dirs.stdout
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l !== "");
+	const [gitDir, commonDir, root] = lines;
+	if (gitDir === undefined || commonDir === undefined || root === undefined) {
+		return fail("`git rev-parse` exited 0 but did not name the git dir, common dir and tree root");
+	}
+	return ok({gitDir, commonDir, root, linked: gitDir !== commonDir});
+});
+
+/** How many paths `git status --porcelain` reports — `0` is a clean tree. */
+export const uncommittedChanges: Shell<Attempt<number>> = Effect.gen(function* () {
+	const status = yield* execCapture("git", ["status", "--porcelain"]);
+	if (!status.ok) return fail(status.reason);
+	return ok(status.stdout.split("\n").filter((line) => line.trim() !== "").length);
+});
+
+export type Ground =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Tree"; readonly root: string};
+
+/**
+ * Assert the ground, with the contract's messages and the invoked verb's name substituted in.
+ *
+ * A tree that cannot be *read* is the primary-checkout refusal too, and deliberately so: outside any
+ * repository there is no linked worktree, which is exactly what `12` says.
+ */
+export const assertGround = (
+	verb: string,
+	requireClean: boolean,
+): Effect.Effect<Ground, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const state = yield* readTree;
+		if (state._tag === "Failure" || !state.value.linked) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					NOT_A_WORKTREE,
+					`${verb}: this is the primary checkout, not a linked worktree — stop; never build here.`,
+					state._tag === "Failure" ? [`${verb}: git could not be read: ${state.reason}.`] : [],
+				),
+			};
+		}
+		if (!requireClean) return {_tag: "Tree" as const, root: state.value.root};
+
+		const dirty = yield* uncommittedChanges;
+		if (dirty._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					DIRTY_TREE,
+					`${verb}: cannot read the tree's status: ${dirty.reason} — cleanliness is UNKNOWN, never clean.`,
+				),
+			};
+		}
+		if (dirty.value > 0) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					DIRTY_TREE,
+					`${verb}: ${dirty.value} uncommitted change(s) at open — refusing; an unauthored hunk is not yours to keep or clean.`,
+				),
+			};
+		}
+		return {_tag: "Tree" as const, root: state.value.root};
+	});

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -52,8 +52,18 @@ export const SHARED_SEATS: SharedSeats = {
 	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
 };
 
+/**
+ * `build`'s seats: the same eight, plus `report file`'s body-section seat.
+ *
+ * `review` and `triage` leave `4` a deliberate gap because neither performs a section check;
+ * `build pr` does — a body with no `## Deviations` block is that same fact — so the seat is claimed
+ * rather than re-invented one code higher.
+ */
+export const BUILD_SEATS: SharedSeats = {...SHARED_SEATS, BAD_SECTIONS: "BAD_SECTIONS"};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
+	build: BUILD_SEATS,
 	triage: SHARED_SEATS,
 	review: SHARED_SEATS,
 };

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -1,5 +1,6 @@
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
+import * as build from "./build/codes.ts";
 import {
 	ALIGNED_GROUPS,
 	ALIGNMENT_BASE,
@@ -21,6 +22,7 @@ const SRC_DIR = fileURLToPath(new URL(".", import.meta.url));
  * nobody registered reds here instead of shipping unchecked.
  */
 const TABLES: Readonly<Record<string, CodeTable>> = {
+	build,
 	report,
 	review,
 	triage,

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -16,6 +16,7 @@
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
 import {adrCommand} from "./adr/command.ts";
+import {buildCommand} from "./build/command.ts";
 import {evalCommand} from "./eval/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
@@ -29,6 +30,7 @@ export type VerbGroup = Command.Command<any, any, object, unknown, NodeServices.
 /** The registered groups, in the order they list under `--help`. */
 export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	adrCommand,
+	buildCommand,
 	evalCommand,
 	reportCommand,
 	reviewCommand,


### PR DESCRIPTION
Fixes #4988

Builds the `build` verb group in `packages/fabrika-cli/` to the spec in
`claude-plugins/fabrika/skills/build/contract.md` — all fourteen verbs, the shared
content gate, and the shared exit table.

## What landed

**The fourteen verbs**, each a pure `*-verb.ts` module behind a thin adapter in
`build/command.ts`, all resolving under `fabrika build <verb> --help`:

| Verb | What it answers |
|---|---|
| `tree` | a linked worktree, optionally clean, optionally this lane's — three git-derivable assertions, and it never provisions |
| `pick` | the ranked candidate pool, every bucket paginated in full |
| `eligible` | one issue's dependency gate, derived from the parent's `## Dependencies` topology |
| `claim` / `confirm` / `release` | one comment-marker race over one pinned token shape |
| `issue` | the claimed issue's body + parsed acceptance criteria, through the content gate |
| `branch` | the lane's nonce branch, cut or resumed off a freshly fetched base |
| `scratch` | the per-lane scratch path, keyed on the claim nonce |
| `check` | this surface's validators in this tree, cache-bypassed |
| `push` | the branch published, and the remote ref read back independently |
| `pr` | the PR from a stdin body, refusing the known defect shapes, with a read-back |
| `note` | a head-stamped, leak-guarded comment, posting guards only |
| `verdicts` | the paginated, current-head, per-gate verdict fold |

**The shared substrate**: `content-gate.ts` (the #4859 seam — provenance-stamping
pass-through today, and nothing caches gated content across invocations, so a trust
ruling lands as one module change), `codes.ts` (the exit matrix, its `3`–`11` seats
*imported* from `report/codes.ts` rather than restated), `lane.ts` (the
branch-name-carried lane identity — no stamp files), `claim.ts` (the ACL-checked
earliest-authorized-marker protocol), `dependencies.ts`, `pr-body.ts`, `rounds.ts`,
plus `target.ts` / `worktree.ts` / `lane-guard.ts` / `git.ts` / `github.ts`.

**Registration**: `buildCommand` in `registry.ts`, and `build` added to
`ALIGNED_GROUPS` in `exit-code-alignment.ts` with its own seat map — it claims nine
seats, the eight `review`/`triage` share plus `report`'s `BAD_SECTIONS` on `4`, which
`build pr`'s `## Deviations` check genuinely uses.

**Imported, never restated**, exactly as the contract requires: the
`acceptance-criteria` wire read, the `verdict-marker` read and `bindToHead`, the
`leaks.ts` predicates, and `normalizeForReadback` (both writing verbs compare their
read-backs through it — GitHub's round-tripping is not byte-stable). No `pipeline-cli`
code is called or ported (ADR 0238).

**Tests**: 162 new unit tests over the group, one file per verb plus one per pure
module, covering each verb's exit triggers including every refusal path. The
120-second round boundary is pinned at 120 *and* 121 seconds (#4570).

## Files versus the issue's list

The issue named `packages/fabrika-cli/src/build/content-gate.ts` and
`src/registry.ts`. Actually touched, beyond those:

- **41 new files** under `packages/fabrika-cli/src/build/` (14 verb modules, 8 shared
  modules, 16 test files, 1 test-support fixture file, 1 adapter).
- `packages/fabrika-cli/src/exit-code-alignment.ts` and its unit test — the issue's own
  acceptance criterion requires the group's table to align, and the guard reds on an
  unregistered group.
- `.gitignore` — the repo-root bare `build` rule ignores `packages/fabrika-cli/src/build/`.
  The original report predicted exactly this; the existing negation only covered the skill
  directory, so a second one was needed or none of the group's files would be tracked.

## Verification

- `pnpm typecheck --force` — 30/30 tasks, 0 cached, 16.7s. Forced, so this is an
  execution rather than a replayed FULL TURBO.
- `node --run test -- --run` in `packages/fabrika-cli` — 101 files, 1453 tests, all pass.
- `pnpm lint:worktree` — clean over the 57 changed files.
- Live smoke: `fabrika build --help` lists all fourteen; `fabrika build tree` prints the
  worktree root on exit 0; `fabrika build pick --limit 0` refuses on exit 1.

## Deviations

- **`build check --surface prose` narrows the contract's third clause.** The contract asks
  for "every relative link resolves against this tree; no machine-local path; every
  fabrika-doc reference cited by id exists". The first two are implemented literally. The
  third is implemented as link resolution over `claude-plugins/fabrika/**` paths rather
  than as a separate id-registry lookup: the contract does not define what "cited by id"
  looks like on the page, and inventing a second reference syntax would be a guess a
  reviewer could not check against anything. Flagging it rather than asserting coverage.
- **`build check` reports `pnpm typecheck --force` in its `ran` array**, where the
  contract's example shows `pnpm typecheck`. The binding rule is "cache-bypassed"; the
  array reports the argv actually executed, because a `ran` list that hides a flag is a
  report that cannot be reproduced from its own output.
- **`build check` resolves its diff base from the repository's default branch** (`origin/<default>`),
  since the contract gives the verb no `--base` flag and names no constant. A hardcoded
  `origin/main` would be a repo literal in a repo-agnostic package.
- **`build branch` refuses "both modes" and "neither mode" on `10`.** The contract states
  `--resume` is exclusive with the positional but enumerates no code for violating it; `10`
  is the matrix's seat for a value off its vocabulary.
- **`build push` reads the remote ref *before* pushing too**, to decide fast-forward. The
  contract specifies the `19` non-fast-forward refusal without naming how it is derived;
  this is the derivation.
- **The claim marker's comment grammar is defined in this diff** (`build-claim: <token> · <ISO-8601-UTC>`).
  The contract pins the *token* shape (`build:<session-id>:<uuid>`, #4428) but not the line
  the token sits on, so the line is stated once in `build/claim.ts` and read by one regex.
- **`build release` refuses on a closed issue (`7`)**, following the trio's shared exit
  table literally. It is worth a second look: releasing a claim on an issue that closed
  under you is arguably the one case where the refusal strands a marker.
- **`build eligible` treats a ledger-local ref (`C<int>`) as a blocking edge.** The contract
  says a local ref "resolves within the ledger" without saying what its *state* is; an
  unfiled child is unclosed work, so blocking is the fail-closed reading.
- **`build verdicts` derives `frozenCriteria` from the PR's linked issue**, found through the
  body's closing keyword and filtered by ADR 0079's `<!-- ac:review pr:#<n> round:<k> -->`
  provenance tag. A PR with no closing keyword yields an empty array rather than a refusal.
