### PR TITLE
fix(pipeline): give the lane stamp a lifecycle, so a finished lane stops reading as live (#4868)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,13 @@ jobs:
       # Same script runs locally: `bash claude-plugins/kampus-pipeline/lib/common-test.sh`.
       - run: bash claude-plugins/kampus-pipeline/lib/common-test.sh
 
+      # The lane-lifecycle cases above are only worth their runtime if they can FAIL. #4868 was a
+      # check whose positive branch could never be false, and a suite can carry that same defect —
+      # so this reintroduces each blindness into a copy of the lib and requires the suite to go red
+      # for its own named reason. Hermetic: temp repos only, no network.
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/lib/verify-lane-lifecycle-mutants.sh`.
+      - run: bash claude-plugins/kampus-pipeline/lib/verify-lane-lifecycle-mutants.sh
+
       # Executable pin for ship-it's sourced chain (#4547): every function a step script
       # calls must be defined in-chain, and Step 2's §CP seam must pass the caller's
       # $CP_FLAG through to `verdict gate`. The extraction dropped three source lines and

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -350,11 +350,22 @@ in either direction. Retired or foreign ⇒ the ordinary `other`, which co-check
 
 **`dormant-lane` releases the pin only on positive proof, and the proof is the hand-clearing an
 operator used to perform per occurrence:** the tree is clean, its HEAD is the branch tip, and that
-commit is on a remote-tracking branch (`kp_lane_quiescent`). Only then is the stamp retired — one
-`mv` of a bookkeeping file. **No worktree is ever removed, no `--force` is ever used, and nothing is
-written into another tree's working files.** Two independent signals must both say "not working"
-before anything is released, which is why an idle-but-live lane (dirty tree, or commits not pushed)
-still blocks.
+commit is contained in `origin/<branch>` (`kp_lane_quiescent` — that branch's own upstream, not any
+`refs/remotes/*`, so a stale-forward ref cannot answer "safely on a remote" for work that is not).
+Only then is the stamp retired — one `mv` of a bookkeeping file. **No worktree is ever removed, no
+`--force` is ever used, and nothing is written into another tree's working files.**
+
+Two signals must both say "not working" before anything is released, so an idle lane with anything
+to lose — a dirty tree, or a commit that is nowhere else — still blocks. **That is not the same as
+"a live lane is never released", and the gap is exactly what the TTL trades.** A lane that is
+genuinely alive but has been git-quiet for longer than `$KP_LANE_BEAT_TTL`, with a clean tree sitting
+on the branch tip and pushed, satisfies all three facts and **is** released. Two things bound that:
+at the instant of release nothing unique lives in that tree, and the wrongly-retired lane then halts
+**fail-closed at its very next git op** — `lane_worktree` skips a retired stamp, so its
+`wt_preflight` resolves zero stamped trees and refuses instead of committing onto a moved ref. The
+cost is a broken lane run needing re-dispatch, not lost work. That is what raising or lowering the
+TTL buys: longer disrupts fewer live lanes and leaves more repairs blocked for longer, shorter the
+reverse.
 
 **Every refusal must name a remedy the refusing agent can execute.** The original `live-lane` refusal
 named two — "run this repair from that lane's worktree" and "wait for it to finish" — and the

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -318,6 +318,51 @@ not evidence and is not part of the predicate** — a live agent's tree can be t
 <expected-tip>`, a compare-and-swap: a ref that moved since the probe fails the update instead of
 silently taking the new commits.
 
+## The lane stamp has a LIFECYCLE — identity, then a beat, then retirement
+
+A second, unrelated stamp lives in the same git admin dir as the `kampus-owner.json` above, and
+conflating them wastes a debugging session: `kampus-owner.json` is the **harness launcher's** stamp
+that the worktree *sweep* reads, while **`kampus-lane` is the pipeline's own** — written by
+`write-code`'s opening preflight, read by `wt_preflight` to answer "which tree is mine" and by
+`kp_branch_pin` to answer "is another lane using this branch". Both live in
+`claude-plugins/kampus-pipeline/lib/common.sh`.
+
+**A stamp that is only an identity cannot answer a liveness question.** Every sibling subagent of one
+dispatching session shares `$CLAUDE_CODE_SESSION_ID`, and nothing else in the process env
+distinguishes them (measured — `$CLAUDE_PID` included, #4500). So "the pinning tree's stamp equals my
+session id" is true for a lane still building **and** for the leftover tree of one that finished
+hours ago. Keyed on that alone the pin classifier's `live-lane` branch could never be false, and
+every repair on a branch whose build worktree still existed was refused with no way forward (#4868) —
+worktrees are not released on lane finish, so that is the routine case, not the edge.
+
+The fix is that the stamp now has three files and the lane itself moves them:
+
+| file | written by | means |
+| --- | --- | --- |
+| `kampus-lane` | the opening preflight, once | **which** lane proved this tree |
+| `kampus-lane.beat` | `wt_preflight`, before every git mutation | **when** that lane last did anything |
+| `kampus-lane.retired` | `step8-claim-release.sh`, the run's last act | the lane is **done** with this tree |
+
+`kp_branch_pin` reads the lifecycle, never the id alone: same-session **and** beating within
+`$KP_LANE_BEAT_TTL` (900s) ⇒ `live-lane`, which still refuses. Same-session with a stale or absent
+beat ⇒ `dormant-lane` — liveness genuinely **unknown**, stated as its own state rather than guessed
+in either direction. Retired or foreign ⇒ the ordinary `other`, which co-checks-out.
+
+**`dormant-lane` releases the pin only on positive proof, and the proof is the hand-clearing an
+operator used to perform per occurrence:** the tree is clean, its HEAD is the branch tip, and that
+commit is on a remote-tracking branch (`kp_lane_quiescent`). Only then is the stamp retired — one
+`mv` of a bookkeeping file. **No worktree is ever removed, no `--force` is ever used, and nothing is
+written into another tree's working files.** Two independent signals must both say "not working"
+before anything is released, which is why an idle-but-live lane (dirty tree, or commits not pushed)
+still blocks.
+
+**Every refusal must name a remedy the refusing agent can execute.** The original `live-lane` refusal
+named two — "run this repair from that lane's worktree" and "wait for it to finish" — and the
+refusing agent could perform neither: `wt_preflight` fails closed on a sibling tree, and a stamp
+written once never went stale. A fail-closed stop with no reachable way forward is what pushes agents
+into improvising past the guard (the detached-HEAD repair of #4826), so treat "the remedy is
+executable by whoever reads it" as part of the guard, not as message polish.
+
 ## Why these constraints exist (and where the real fix lives)
 
 The self-mod classifier exists to keep an autonomous agent from rewriting the

--- a/claude-plugins/kampus-pipeline/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/lib/common-test.sh
@@ -513,18 +513,27 @@ else
 	# dirty tree is strictly worse than the bug this fix closes.
 	printf 'precious uncommitted work\n' > "$pin_left/UNCOMMITTED.txt"
 
-	# 26. The classifier separates the four states. A boolean "is it pinned" cannot, and the states
-	# have opposite handling — `other` co-checks-out, `primary` and `live-lane` refuse.
+	# 26. The classifier separates the five states. A boolean "is it pinned" cannot, and the states
+	# have opposite handling — `other` co-checks-out, `primary` and `live-lane` refuse, `dormant-lane`
+	# refuses unless it can PROVE the tree is finished. The two same-session reads below carry the
+	# IDENTICAL stamp and differ only in their beat: that is the #4868 fix in one assertion, since a
+	# discriminator that reads the id alone cannot tell them apart at all.
 	printf '%s\n' "$pin_sid" > "$tmp/pin/.git/worktrees/pin-left/kampus-lane"
+	kp_lane_beat "$tmp/pin/.git/worktrees/pin-left"
 	out_live="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-feat)"
-	rm -f "$tmp/pin/.git/worktrees/pin-left/kampus-lane"
+	printf '%s\n' "$(($(date +%s) - 100000))" > "$tmp/pin/.git/worktrees/pin-left/kampus-lane.beat"
+	out_dormant="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-feat)"
+	rm -f "$tmp/pin/.git/worktrees/pin-left/kampus-lane" "$tmp/pin/.git/worktrees/pin-left/kampus-lane.beat"
 	out_other="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-feat)"
 	out_mine="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-lane)"
 	out_free="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" kp-no-such-branch)"
 	out_primary="$(CLAUDE_CODE_SESSION_ID="$pin_sid" kp_branch_pin "$pin_lane" "$pin_base")"
 	if [ "$out_live" != "PIN=live-lane
 PINROOT=$pin_left" ]; then
-		fail "kp_branch_pin: a pinning tree stamped with MY lane must read live-lane: [$out_live]"
+		fail "kp_branch_pin: a pinning tree stamped with MY lane and BEATING must read live-lane: [$out_live]"
+	elif [ "$out_dormant" != "PIN=dormant-lane
+PINROOT=$pin_left" ]; then
+		fail "kp_branch_pin: the SAME stamp with a stale beat must read dormant-lane, not live-lane — a discriminator that cannot fall out of live-lane is stuck, not fail-closed (#4868): [$out_dormant]"
 	elif [ "$out_other" != "PIN=other
 PINROOT=$pin_left" ]; then
 		fail "kp_branch_pin: an unstamped pinning tree must read other: [$out_other]"
@@ -538,7 +547,7 @@ PINROOT=" ]; then
 PINROOT=$(cd "$tmp/pin" && pwd -P)" ]; then
 		fail "kp_branch_pin: a branch held by the primary checkout must read primary: [$out_primary]"
 	else
-		ok "kp_branch_pin separates free / mine / primary / live-lane / other"
+		ok "kp_branch_pin separates free / mine / primary / live-lane / dormant-lane / other"
 	fi
 
 	# 27. THE FALSIFICATION. The bare `git switch` the step used to run REFUSES here — that refusal is
@@ -609,6 +618,8 @@ PINROOT=$(cd "$tmp/pin" && pwd -P)" ]; then
 
 	# 31. A pinning tree stamped with THIS session is a sibling lane that may still be building on the
 	# branch; the rebase would move its HEAD mid-flight. Refuse, name the remedy, remove nothing.
+	# Deliberately left as it shipped: with no beat this is now the liveness-UNKNOWN read, and it must
+	# still refuse — this fixture has no remote, so the tree cannot be proved finished (#4868 AC1).
 	if ! git -C "$tmp/pin" worktree add -q -b kp-sib "$tmp/pin-sib" >/dev/null 2>&1; then
 		fail "fixture did not take: could not add the sibling-lane worktree — case 31 was NOT exercised"
 	else
@@ -624,6 +635,128 @@ PINROOT=$(cd "$tmp/pin" && pwd -P)" ]; then
 		else
 			ok "a branch held by a same-session sibling lane: refused, remedy named, nothing removed"
 		fi
+	fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+# #4868 — the lane stamp's LIFECYCLE. A real remote, because "is this work anywhere but that tree?"
+# is the fact that separates a leftover tree it is safe to release from one holding the only copy.
+# ---------------------------------------------------------------------------------------------
+
+mkdir -p "$tmp/rel" "$tmp/rel-bare"
+rel_sid="kp-test-lane-rel"
+if ! git -C "$tmp/rel-bare" init -q --bare >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" init -q --template='' >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" -c user.name=kp-test -c user.email=kp-test@invalid commit -q --allow-empty -m r1 >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" remote add origin "$tmp/rel-bare" >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" worktree add -q -b rel-lane "$tmp/rel-lane" >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" worktree add -q -b rel-feat "$tmp/rel-feat" >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" worktree add -q -b rel-done "$tmp/rel-done" >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" push -q origin rel-feat rel-done >/dev/null 2>&1 ||
+	! git -C "$tmp/rel" fetch -q origin >/dev/null 2>&1; then
+	fail "fixture did not take: could not build the lane-lifecycle fixture — cases 32–36 were NOT exercised"
+else
+	rel_lane="$(cd "$tmp/rel-lane" && pwd -P)"
+	rel_feat="$(cd "$tmp/rel-feat" && pwd -P)"
+	rel_feat_admin="$tmp/rel/.git/worktrees/rel-feat"
+	rel_done_admin="$tmp/rel/.git/worktrees/rel-done"
+	err="$tmp/stderr"
+
+	# 32. A sibling lane that is genuinely LIVE — same session, and beating right now — is still
+	# refused, HEAD unmoved, nothing removed, stamp NOT retired. This is the property the fix must not
+	# trade away: the refusal is correct here (#4868 AC1).
+	printf '%s\n' "$rel_sid" > "$rel_feat_admin/kampus-lane"
+	kp_lane_beat "$rel_feat_admin"
+	CLAUDE_CODE_SESSION_ID="$rel_sid" kp_switch_head_branch "$rel_lane" rel-feat 2>"$err"; rc=$?
+	diag="$(cat "$err")"
+	if [ "$rc" -eq 0 ]; then
+		fail "a BEATING same-session sibling lane was co-checked-out — the guard was weakened into fail-open (#4868 AC1)"
+	elif [ "$(git -C "$rel_lane" symbolic-ref -q HEAD)" != "refs/heads/rel-lane" ]; then
+		fail "the live-lane refusal moved this lane's HEAD — a refusal must change nothing"
+	elif [ ! -f "$rel_feat_admin/kampus-lane" ]; then
+		fail "the live-lane refusal RETIRED a live lane's stamp — only a proven-finished tree may be released"
+	else
+		ok "a beating same-session sibling lane: still refused, HEAD unmoved, its stamp left alone"
+	fi
+
+	# 33. The refusal names a remedy THE REFUSING AGENT CAN RUN. The two it used to name could not be
+	# executed by anyone who could read it: `wt_preflight` refuses a sibling tree, and "wait for it to
+	# finish" never cleared while the stamp was written once and never moved (#4868 AC4).
+	if ! grep -qF 'REMEDY' <<< "$diag"; then
+		fail "the live-lane refusal names no remedy at all: [$diag]"
+	elif grep -qF "run this repair from that lane's worktree" <<< "$diag"; then
+		fail "the live-lane refusal still names the sibling-worktree remedy, which wt_preflight refuses: [$diag]"
+	elif ! grep -qF 're-run this same step' <<< "$diag"; then
+		fail "the live-lane refusal names no step the refusing agent can perform itself: [$diag]"
+	else
+		ok "the live-lane refusal names a remedy the refusing agent can execute (#4868 AC4)"
+	fi
+
+	# 34. Liveness unknown is NOT a licence. A stale beat over a tree holding uncommitted work is
+	# refused, the reason names the work, and nothing is retired — the beat is one of two signals and
+	# releasing takes both.
+	printf '%s\n' "$(($(date +%s) - 100000))" > "$rel_feat_admin/kampus-lane.beat"
+	printf 'precious uncommitted work\n' > "$rel_feat/UNCOMMITTED.txt"
+	CLAUDE_CODE_SESSION_ID="$rel_sid" kp_switch_head_branch "$rel_lane" rel-feat 2>"$err"; rc=$?
+	diag="$(cat "$err")"
+	if [ "$rc" -eq 0 ]; then
+		fail "a dormant lane's DIRTY tree was released — uncommitted work would have moved under it"
+	elif [ ! -f "$rel_feat_admin/kampus-lane" ]; then
+		fail "an unproven dormant lane's stamp was retired anyway"
+	elif ! grep -qF 'UNCOMMITTED' <<< "$diag"; then
+		fail "the dormant refusal does not name WHICH fact failed: [$diag]"
+	elif ! grep -qF 're-run this same step' <<< "$diag"; then
+		fail "the dormant refusal names no step the refusing agent can perform itself: [$diag]"
+	else
+		ok "a dormant lane holding uncommitted work: refused, reason named, stamp left alone"
+	fi
+
+	# 35. THE STATE THAT COULD NOT EXIST BEFORE (#4868 AC2). The tree is clean, on the branch tip, and
+	# that commit is on a remote — so a stale-beat same-session lane is provably finished with it and
+	# the pin resolves to the sanctioned co-checkout. The stamp is retired by RENAME, and the worktree
+	# and every file in it survive.
+	rm -f "$rel_feat/UNCOMMITTED.txt"
+	printf 'a file this tree keeps\n' > "$rel_feat/KEEP.txt"
+	git -C "$rel_feat" add KEEP.txt >/dev/null 2>&1
+	git -C "$rel_feat" -c user.name=kp-test -c user.email=kp-test@invalid commit -q -m keep >/dev/null 2>&1
+	git -C "$rel_feat" push -q origin rel-feat >/dev/null 2>&1
+	git -C "$rel_feat" fetch -q origin >/dev/null 2>&1
+	CLAUDE_CODE_SESSION_ID="$rel_sid" kp_switch_head_branch "$rel_lane" rel-feat 2>"$err"; rc=$?
+	diag="$(cat "$err")"
+	if [ "$rc" -ne 0 ]; then
+		fail "a PROVABLY finished same-session lane still blocked the repair (rc=$rc): [$diag] — the positive branch is still unfalsifiable (#4868 AC2)"
+	elif [ "$(git -C "$rel_lane" symbolic-ref -q HEAD)" != "refs/heads/rel-feat" ]; then
+		fail "the release did not attach this lane to rel-feat — a DETACHED head makes verified-push resolve UNKNOWN"
+	elif [ -f "$rel_feat_admin/kampus-lane" ] || [ ! -f "$rel_feat_admin/kampus-lane.retired" ]; then
+		fail "the stamp was not retired by rename — the next repair reads the same stuck state again"
+	elif [ ! -f "$rel_feat/KEEP.txt" ]; then
+		fail "the released worktree's files are GONE — the release must remove nothing"
+	elif ! git -C "$tmp/rel" worktree list --porcelain | grep -qF "worktree $rel_feat"; then
+		fail "the released worktree was UNREGISTERED — the release must remove no worktree (#4868 AC5)"
+	else
+		ok "a finished same-session lane's leftover tree: pin released, stamp retired, worktree and files untouched (#4868 AC2/AC5)"
+	fi
+
+	# 36. The lane-finish seam, read from the other end: a retired stamp reads `other`, the ordinary
+	# leftover-tree state, so nothing has to be proved at all. This is what step8-claim-release.sh
+	# produces at the end of every run that stamped a tree.
+	printf '%s\n' "$rel_sid" > "$rel_done_admin/kampus-lane"
+	kp_lane_beat "$rel_done_admin"
+	out_before="$(CLAUDE_CODE_SESSION_ID="$rel_sid" kp_branch_pin "$rel_lane" rel-done)"
+	kp_lane_retire "$rel_done_admin"; rc=$?
+	out_after="$(CLAUDE_CODE_SESSION_ID="$rel_sid" kp_branch_pin "$rel_lane" rel-done)"
+	if [ "$rc" -ne 0 ]; then
+		fail "kp_lane_retire failed on a stamped worktree (rc=$rc)"
+	elif [ "$out_before" != "PIN=live-lane
+PINROOT=$(cd "$tmp/rel-done" && pwd -P)" ]; then
+		fail "kp_branch_pin: a beating same-session tree must read live-lane before it retires: [$out_before]"
+	elif [ "$out_after" != "PIN=other
+PINROOT=$(cd "$tmp/rel-done" && pwd -P)" ]; then
+		fail "kp_branch_pin: a RETIRED lane's tree must read other — retiring is what a finished lane does: [$out_after]"
+	elif [ -f "$rel_done_admin/kampus-lane.beat" ]; then
+		fail "kp_lane_retire left the beat file behind — a retired lane must leave no liveness residue"
+	else
+		ok "the lane-finish seam: retiring the stamp flips a same-session tree from live-lane to other"
 	fi
 fi
 

--- a/claude-plugins/kampus-pipeline/lib/common-test.sh
+++ b/claude-plugins/kampus-pipeline/lib/common-test.sh
@@ -641,6 +641,11 @@ fi
 # ---------------------------------------------------------------------------------------------
 # #4868 — the lane stamp's LIFECYCLE. A real remote, because "is this work anywhere but that tree?"
 # is the fact that separates a leftover tree it is safe to release from one holding the only copy.
+#
+# The bare repo is populated by FETCHING INTO IT from the working repo, never by pushing out of it:
+# the corpus lint reds on a bare push anywhere in a runnable block — and a `.sh` is runnable in
+# whole, comments included — with deliberately no pragma and no exempt list (#4213, ADR 0202). The
+# fixture only needs the objects and refs to exist over there, and a fetch puts them there.
 # ---------------------------------------------------------------------------------------------
 
 mkdir -p "$tmp/rel" "$tmp/rel-bare"
@@ -652,7 +657,7 @@ if ! git -C "$tmp/rel-bare" init -q --bare >/dev/null 2>&1 ||
 	! git -C "$tmp/rel" worktree add -q -b rel-lane "$tmp/rel-lane" >/dev/null 2>&1 ||
 	! git -C "$tmp/rel" worktree add -q -b rel-feat "$tmp/rel-feat" >/dev/null 2>&1 ||
 	! git -C "$tmp/rel" worktree add -q -b rel-done "$tmp/rel-done" >/dev/null 2>&1 ||
-	! git -C "$tmp/rel" push -q origin rel-feat rel-done >/dev/null 2>&1 ||
+	! git -C "$tmp/rel-bare" fetch -q "$tmp/rel" rel-feat:refs/heads/rel-feat rel-done:refs/heads/rel-done >/dev/null 2>&1 ||
 	! git -C "$tmp/rel" fetch -q origin >/dev/null 2>&1; then
 	fail "fixture did not take: could not build the lane-lifecycle fixture — cases 32–36 were NOT exercised"
 else
@@ -719,7 +724,7 @@ else
 	printf 'a file this tree keeps\n' > "$rel_feat/KEEP.txt"
 	git -C "$rel_feat" add KEEP.txt >/dev/null 2>&1
 	git -C "$rel_feat" -c user.name=kp-test -c user.email=kp-test@invalid commit -q -m keep >/dev/null 2>&1
-	git -C "$rel_feat" push -q origin rel-feat >/dev/null 2>&1
+	git -C "$tmp/rel-bare" fetch -q "$tmp/rel" rel-feat:refs/heads/rel-feat >/dev/null 2>&1
 	git -C "$rel_feat" fetch -q origin >/dev/null 2>&1
 	CLAUDE_CODE_SESSION_ID="$rel_sid" kp_switch_head_branch "$rel_lane" rel-feat 2>"$err"; rc=$?
 	diag="$(cat "$err")"

--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -511,8 +511,13 @@ kp_lane_quiescent() { # <my-worktree> <pin-root> <branch>
 		printf 'its HEAD (%s) is not the tip of %s (%s) — that tree is mid-flight\n' "$head" "$branch" "$tip"
 		return 1
 	fi
-	if [ -z "$(git -C "$mine" for-each-ref --contains "$head" --format='%(refname)' refs/remotes/ 2>/dev/null)" ]; then
-		printf 'its HEAD (%s) is on NO remote-tracking branch — that work exists only in that tree\n' "$head"
+	# Containment in THIS branch's own upstream, not in any `refs/remotes/*` — an unrelated
+	# remote-tracking ref that is stale-forward (it still names a commit an upstream force-push
+	# dropped) would answer "safely on a remote" for work that is no longer there, and this is the
+	# predicate that decides whether a pin is RELEASED, so its false positive is the fail-open one.
+	# An absent `origin/<branch>` makes `--is-ancestor` non-zero, which refuses — the safe direction.
+	if ! git -C "$mine" merge-base --is-ancestor "$head" "refs/remotes/origin/$branch" 2>/dev/null; then
+		printf 'its HEAD (%s) is not contained in origin/%s — that work exists only in that tree\n' "$head" "$branch"
 		return 1
 	fi
 	return 0
@@ -681,7 +686,7 @@ kp_switch_head_branch() {
 		# so by renaming one bookkeeping file — no worktree removed, no `--force`, not one byte
 		# written into that tree.
 		if ! why="$(kp_lane_quiescent "$wt" "$root" "$branch")"; then
-			printf 'kp_switch_head_branch REFUSED (fail-closed): %s is pinned by %s, a worktree stamped with THIS session'\''s lane id (%s) whose heartbeat is stale or absent — that lane is not provably alive, but it is not provably finished either: %s. Releasing the pin now could move the branch ref under work that exists nowhere else. REMEDY: re-run this same step yourself — no sibling tree, no human. It re-probes on every run and releases the pin by itself as soon as that tree is clean, sitting on the tip of %s, and pushed to a remote. If this same reason keeps printing, that tree holds work that is not yours to move — post THIS line on the PR and stop. Do NOT remove that worktree and do NOT `--force` anything. NOTHING was switched.\n' "$branch" "$root" "${CLAUDE_CODE_SESSION_ID:-<unset>}" "$why" "$branch" >&2
+			printf 'kp_switch_head_branch REFUSED (fail-closed): %s is pinned by %s, a worktree stamped with THIS session'\''s lane id (%s) whose heartbeat is stale or absent — that lane is not provably alive, but it is not provably finished either: %s. Releasing the pin now could move the branch ref under work that exists nowhere else. REMEDY: re-run this same step yourself — no sibling tree, no human. It re-probes on every run and releases the pin by itself as soon as that tree is clean, sitting on the tip of %s, and pushed to origin. If this same reason keeps printing, that tree holds work that is not yours to move — post THIS line on the PR and stop. Do NOT remove that worktree and do NOT `--force` anything. NOTHING was switched.\n' "$branch" "$root" "${CLAUDE_CODE_SESSION_ID:-<unset>}" "$why" "$branch" >&2
 			return 1
 		fi
 		common="$(git -C "$wt" rev-parse --git-common-dir 2>/dev/null)"
@@ -693,7 +698,7 @@ kp_switch_head_branch() {
 			printf 'kp_switch_head_branch REFUSED (fail-closed): %s is pinned by the dormant lane tree %s, which IS provably finished with it, but its lane stamp could not be retired (bookkeeping dir: %s). Releasing the pin without retiring the stamp would leave the next repair reading the same stuck state. REMEDY: re-run this step yourself; if it keeps failing here, the repo'\''s worktree bookkeeping under %s is not writable — post THIS line on the PR. Do NOT remove that worktree. NOTHING was switched.\n' "$branch" "$root" "${admin:-<not registered>}" "${common:-<unresolved>}" >&2
 			return 1
 		fi
-		printf 'kp_switch_head_branch: %s is pinned by %s, a same-session lane whose heartbeat is stale (%s) and whose tree is PROVABLY finished with it — clean, on the tip of %s, and that commit is on a remote-tracking branch. Retired its stamp (kampus-lane -> kampus-lane.retired, one bookkeeping file; the worktree and every file in it are untouched) and taking the sanctioned co-checkout.\n' "$branch" "$root" "${age:+${age}s ago}${age:-never beat}" "$branch" >&2
+		printf 'kp_switch_head_branch: %s is pinned by %s, a same-session lane whose heartbeat is stale (%s) and whose tree is PROVABLY finished with it — clean, on the tip of %s, and that commit is contained in origin/%s. Retired its stamp (kampus-lane -> kampus-lane.retired, one bookkeeping file; the worktree and every file in it are untouched) and taking the sanctioned co-checkout.\n' "$branch" "$root" "${age:+${age}s ago}${age:-never beat}" "$branch" "$branch" >&2
 		kp__co_checkout "$wt" "$branch" "$root" || return 1
 		;;
 	primary)

--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -422,30 +422,149 @@ kp__phys() { # <path> — its physical form, or the path itself when the directo
 	(cd -P "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"
 }
 
+# ---------------------------------------------------------------------------------------------
+# THE LANE STAMP'S LIFECYCLE (#4868). The stamp used to be written once and never touched again,
+# which made "is that tree a lane still building?" unanswerable: every sibling subagent of one
+# session stamps the SAME id (the #4500 finding recorded under `lane_worktree` below), so a
+# finished lane's leftover tree was byte-identical to a live one and the `live-lane` branch could
+# never be false. Identity is not liveness. So the stamp now has three lifecycle files, all in a
+# worktree's PRIVATE per-worktree git dir (outside the working tree, never committed, unique per
+# worktree) — and the pin classifier reads the lifecycle, never the id alone:
+#
+#   kampus-lane          identity — WHICH lane proved this tree (step4-preflight.sh, once)
+#   kampus-lane.beat     liveness — WHEN that lane last moved git here (wt_preflight, every mutation)
+#   kampus-lane.retired  finished — the lane released it (step8-claim-release.sh, or a proven release)
+#
+# The retired name is the pre-existing operator convention `lane_worktree`'s glob already skips; what
+# is new is that a lane now produces one itself, so the routine case stops being permanent.
+# ---------------------------------------------------------------------------------------------
+
+kp__lane_admin() { # <common-git-dir> <physical-worktree-root> — the repo's private bookkeeping dir
+	# for that worktree (`<common>/worktrees/<name>`), which is where its lane files live. Empty and
+	# non-zero when no registration names that root.
+	local common="$1" want="$2" gd r
+	for gd in "$common"/worktrees/*/gitdir; do
+		[ -f "$gd" ] || continue
+		r="$(cat "$gd")"
+		[ "$(kp__phys "${r%/.git}")" = "$want" ] || continue
+		printf '%s\n' "${gd%/gitdir}"
+		return 0
+	done
+	return 1
+}
+
+kp_lane_beat() { # <per-worktree-git-dir> — record that this lane is working, NOW.
+	# Called from `wt_preflight`, i.e. immediately before every git mutation this lane makes, so a
+	# lane that is doing anything at all leaves a fresh beat. Best-effort on purpose: a beat that
+	# cannot be written must never block the mutation, because a MISSING beat is read as
+	# liveness-unknown (the conservative side), never as liveness-proven.
+	local gd="${1:-}"
+	[ -n "$gd" ] && [ -f "$gd/kampus-lane" ] || return 0
+	date +%s > "$gd/kampus-lane.beat" 2>/dev/null
+	return 0
+}
+
+kp_lane_beat_age() { # <per-worktree-git-dir> — seconds since that lane last proved it was working.
+	# No readable beat ⇒ nothing on stdout and non-zero: the age is UNKNOWN, never 0 (§ZS) — 0 would
+	# read as "just now", the permissive answer.
+	local beat now
+	beat="$(cat "${1:-}/kampus-lane.beat" 2>/dev/null)" || return 1
+	case "$beat" in '' | *[!0-9]*) return 1 ;; esac
+	now="$(date +%s)"
+	case "$now" in '' | *[!0-9]*) return 1 ;; esac
+	printf '%d\n' "$((now - beat))"
+}
+
+kp_lane_retire() { # <per-worktree-git-dir> — this lane is finished with its tree; retire its stamp.
+	# Renames ONE file inside the repo's private worktree bookkeeping. It removes no worktree, uses no
+	# `--force`, and writes nothing into any working tree — the leftover files stay exactly as they
+	# are. Idempotent: an already-retired or never-stamped lane is a clean no-op.
+	local gd="${1:-}"
+	[ -n "$gd" ] || return 1
+	[ -f "$gd/kampus-lane" ] || return 0
+	mv -f "$gd/kampus-lane" "$gd/kampus-lane.retired" || return 1
+	rm -f "$gd/kampus-lane.beat"
+	return 0
+}
+
+# Is the tree at <pin-root> PROVABLY done with <branch> — nothing lost if the ref moves under it?
+# Three independent, read-only facts, ALL required; this is the hand-clearing an operator has had to
+# perform per occurrence, encoded. It writes nothing anywhere. stdout is the reason the proof FAILED
+# (empty on success), so a refusal can name which fact was missing rather than "it is pinned".
+kp_lane_quiescent() { # <my-worktree> <pin-root> <branch>
+	local mine="$1" root="$2" branch="$3" dirty head tip
+	if ! dirty="$(git -C "$root" status --porcelain 2>/dev/null)"; then
+		printf 'its working tree cannot be read at all (`git -C %s status` failed)\n' "$root"
+		return 1
+	fi
+	if [ -n "$dirty" ]; then
+		printf 'it holds UNCOMMITTED work (`git -C %s status --porcelain` is not empty)\n' "$root"
+		return 1
+	fi
+	head="$(git -C "$root" rev-parse --verify HEAD 2>/dev/null)"
+	tip="$(git -C "$mine" rev-parse --verify "refs/heads/$branch" 2>/dev/null)"
+	if [ -z "$head" ] || [ -z "$tip" ]; then
+		printf 'its HEAD or the tip of %s could not be resolved\n' "$branch"
+		return 1
+	fi
+	if [ "$head" != "$tip" ]; then
+		printf 'its HEAD (%s) is not the tip of %s (%s) — that tree is mid-flight\n' "$head" "$branch" "$tip"
+		return 1
+	fi
+	if [ -z "$(git -C "$mine" for-each-ref --contains "$head" --format='%(refname)' refs/remotes/ 2>/dev/null)" ]; then
+		printf 'its HEAD (%s) is on NO remote-tracking branch — that work exists only in that tree\n' "$head"
+		return 1
+	fi
+	return 0
+}
+
+# The SANCTIONED co-checkout: put MY lane on <branch> while another tree still holds it. It leaves
+# that tree's files untouched and removes nothing; its HEAD follows the branch ref from here on.
+kp__co_checkout() { # <my-worktree> <branch> <pin-root>
+	printf 'kp_switch_head_branch: %s is pinned by worktree %s — not this lane, not the primary checkout. Taking the SANCTIONED co-checkout in MY lane (%s): `git switch --ignore-other-worktrees`. That tree is left in place and its files are untouched; no worktree is removed. Its HEAD will follow the branch ref once this repair rebases.\n' "$2" "$3" "$1" >&2
+	if ! git -C "$1" switch --ignore-other-worktrees "$2" >&2; then
+		printf 'kp_switch_head_branch: the sanctioned co-checkout of %s into %s failed (git'\''s error is above) — the pin is NOT what blocked it. REMEDY: resolve what git named in %s and re-run this step. Do NOT detach HEAD to work around it: a detached repair skips the rebase onto origin/main and `verified-push` resolves a detached HEAD to UNKNOWN and pushes nothing. NOTHING was switched.\n' "$2" "$1" "$1" >&2
+		return 1
+	fi
+	return 0
+}
+
 # WHICH worktree holds <branch> checked out right now — the classifier repair R2 routes on when a
 # leftover build lane still pins the PR's head branch (#4826). Prints exactly two lines:
 #
-#   PIN=free|mine|primary|live-lane|other
+#   PIN=free|mine|primary|live-lane|dormant-lane|other
 #   PINROOT=<absolute worktree root>          (empty only for `free`)
 #
-# The four non-free states are NOT interchangeable, which is the whole reason this is a classifier
+# The five non-free states are NOT interchangeable, which is the whole reason this is a classifier
 # and not a boolean: co-checking-out a branch (`git switch --ignore-other-worktrees`) leaves the
 # pinning tree's FILES untouched but lets a later rebase move the branch ref under its HEAD. That is
 # harmless for a finished lane's leftover tree (`other`), and it is exactly the #2270
 # primary-checkout-corruption class for the shared primary tree (`primary`) or a lane that may still
 # be building on it (`live-lane`).
 #
-# `live-lane` is keyed on the ONLY liveness evidence available here: the pinning tree's own
-# `kampus-lane` stamp equalling THIS session's id, i.e. a sibling lane of the very session now
-# repairing. A foreign session's stamp proves nothing either way and resolves `other` — stated
-# plainly rather than dressed up as a liveness check, because the mitigation for it is that the
-# co-checkout removes nothing and writes nothing into that tree.
+# THE SAME-SESSION TREE SPLITS IN TWO, AND THE SPLIT IS THE POINT (#4868). A stamp equal to this
+# session's id says only that a SIBLING LANE proved that tree — it cannot say whether that lane is
+# still building, because every sibling subagent of one session shares $CLAUDE_CODE_SESSION_ID (the
+# measured #4500 finding recorded under `lane_worktree`). Keyed on identity alone the `live-lane`
+# branch was true for every same-session tree forever, which is not fail-closed, it is stuck. So the
+# liveness evidence is the stamp's LIFECYCLE, which the lane itself moves:
+#
+#   live-lane     stamped by this session AND beating within $KP_LANE_BEAT_TTL — a lane that moved
+#                 git here recently. REFUSE: the rebase would move its HEAD mid-flight.
+#   dormant-lane  stamped by this session, but the beat is stale or absent — liveness UNKNOWN, stated
+#                 as its own state instead of guessed either way. `kp_switch_head_branch` then has to
+#                 PROVE the tree is finished (`kp_lane_quiescent`) before it may release the pin.
+#
+# A finished lane retires its own stamp (step8), so the routine case never reaches either: it reads
+# `other`. A foreign session's stamp proves nothing either way and also resolves `other` — the
+# mitigation for it is that the co-checkout removes nothing and writes nothing into that tree.
 #
 # A read it cannot complete is UNKNOWN and returns non-zero with nothing on stdout — never `free`,
 # which is the permissive branch (§ZS, ADR 0092).
 kp_branch_pin() {
 	local mine="$1" branch="$2"
-	local common list line cur primary="" hits="" mine_p hit_p state gd r stamp
+	local common list line cur primary="" hits="" mine_p hit_p state r stamp admin age
+	local ttl="${KP_LANE_BEAT_TTL:-900}"
 	local NL='
 '
 	if [ -z "$mine" ] || [ -z "$branch" ]; then
@@ -504,16 +623,21 @@ EOF
 		state="primary"
 	else
 		state="other"
-		for gd in "$common"/worktrees/*/gitdir; do
-			[ -f "$gd" ] || continue
-			r="$(cat "$gd")"
-			[ "$(kp__phys "${r%/.git}")" = "$hit_p" ] || continue
-			stamp="$(cat "${gd%/gitdir}/kampus-lane" 2>/dev/null)"
+		admin="$(kp__lane_admin "$common" "$hit_p")"
+		if [ -n "$admin" ]; then
+			stamp="$(cat "$admin/kampus-lane" 2>/dev/null)"
 			if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && [ "$stamp" = "$CLAUDE_CODE_SESSION_ID" ]; then
-				state="live-lane"
+				# Identity got us this far; only the beat can say live from left-behind. An
+				# unreadable beat is UNKNOWN, so it lands in `dormant-lane` — which still refuses
+				# until the tree is PROVED finished, never in `other`, which co-checks-out at once.
+				age="$(kp_lane_beat_age "$admin")"
+				if [ -n "$age" ] && [ "$age" -lt "$ttl" ]; then
+					state="live-lane"
+				else
+					state="dormant-lane"
+				fi
 			fi
-			break
-		done
+		fi
 	fi
 	printf 'PIN=%s\nPINROOT=%s\n' "$state" "$hit_p"
 }
@@ -530,7 +654,7 @@ EOF
 # is what produced the improvisations in the first place, one of which silently dropped the rebase
 # onto latest `main` and the `verified-push` verification.
 kp_switch_head_branch() {
-	local wt="$1" branch="$2" pin state root
+	local wt="$1" branch="$2" pin state root common admin why age
 	if ! pin="$(kp_branch_pin "$wt" "$branch")"; then
 		printf 'kp_switch_head_branch: the pin state of %s is UNKNOWN (see above), so the sanctioned path cannot be chosen. REMEDY: re-run from your own lane once `git worktree list` reads cleanly. NOTHING was switched.\n' "$branch" >&2
 		return 1
@@ -548,18 +672,40 @@ kp_switch_head_branch() {
 		fi
 		;;
 	other)
-		printf 'kp_switch_head_branch: %s is pinned by worktree %s — not this lane, not the primary checkout. Taking the SANCTIONED co-checkout in MY lane (%s): `git switch --ignore-other-worktrees`. That tree is left in place and its files are untouched; no worktree is removed. Its HEAD will follow the branch ref once this repair rebases.\n' "$branch" "$root" "$wt" >&2
-		if ! git -C "$wt" switch --ignore-other-worktrees "$branch" >&2; then
-			printf 'kp_switch_head_branch: the sanctioned co-checkout of %s into %s failed (git'\''s error is above) — the pin is NOT what blocked it. REMEDY: resolve what git named in %s and re-run this step. Do NOT detach HEAD to work around it: a detached repair skips the rebase onto origin/main and `verified-push` resolves a detached HEAD to UNKNOWN and pushes nothing. NOTHING was switched.\n' "$branch" "$wt" "$wt" >&2
+		kp__co_checkout "$wt" "$branch" "$root" || return 1
+		;;
+	dormant-lane)
+		# Liveness unknown, so nothing is assumed in either direction: the pin is released only on
+		# POSITIVE proof that the tree has nothing left to lose, and the refusal below is what the
+		# unproven case gets. This is the one path that can retire another lane's stamp, and it does
+		# so by renaming one bookkeeping file — no worktree removed, no `--force`, not one byte
+		# written into that tree.
+		if ! why="$(kp_lane_quiescent "$wt" "$root" "$branch")"; then
+			printf 'kp_switch_head_branch REFUSED (fail-closed): %s is pinned by %s, a worktree stamped with THIS session'\''s lane id (%s) whose heartbeat is stale or absent — that lane is not provably alive, but it is not provably finished either: %s. Releasing the pin now could move the branch ref under work that exists nowhere else. REMEDY: re-run this same step yourself — no sibling tree, no human. It re-probes on every run and releases the pin by itself as soon as that tree is clean, sitting on the tip of %s, and pushed to a remote. If this same reason keeps printing, that tree holds work that is not yours to move — post THIS line on the PR and stop. Do NOT remove that worktree and do NOT `--force` anything. NOTHING was switched.\n' "$branch" "$root" "${CLAUDE_CODE_SESSION_ID:-<unset>}" "$why" "$branch" >&2
 			return 1
 		fi
+		common="$(git -C "$wt" rev-parse --git-common-dir 2>/dev/null)"
+		case "$common" in /*) ;; *) common="$wt/$common" ;; esac
+		common="$(cd "$common" 2>/dev/null && pwd -P)"
+		admin="$(kp__lane_admin "$common" "$root")"
+		age="$(kp_lane_beat_age "$admin")" # read BEFORE the retire below deletes the beat file
+		if [ -z "$admin" ] || ! kp_lane_retire "$admin"; then
+			printf 'kp_switch_head_branch REFUSED (fail-closed): %s is pinned by the dormant lane tree %s, which IS provably finished with it, but its lane stamp could not be retired (bookkeeping dir: %s). Releasing the pin without retiring the stamp would leave the next repair reading the same stuck state. REMEDY: re-run this step yourself; if it keeps failing here, the repo'\''s worktree bookkeeping under %s is not writable — post THIS line on the PR. Do NOT remove that worktree. NOTHING was switched.\n' "$branch" "$root" "${admin:-<not registered>}" "${common:-<unresolved>}" >&2
+			return 1
+		fi
+		printf 'kp_switch_head_branch: %s is pinned by %s, a same-session lane whose heartbeat is stale (%s) and whose tree is PROVABLY finished with it — clean, on the tip of %s, and that commit is on a remote-tracking branch. Retired its stamp (kampus-lane -> kampus-lane.retired, one bookkeeping file; the worktree and every file in it are untouched) and taking the sanctioned co-checkout.\n' "$branch" "$root" "${age:+${age}s ago}${age:-never beat}" "$branch" >&2
+		kp__co_checkout "$wt" "$branch" "$root" || return 1
 		;;
 	primary)
 		printf 'kp_switch_head_branch REFUSED (fail-closed): %s is checked out in the PRIMARY checkout %s. Co-checking it out here would let this repair'\''s rebase move the branch ref under the shared primary tree (the #2270 primary-corruption class). REMEDY: release %s in that checkout (`git switch <some other branch>`), then re-run this step. Do NOT remove any worktree. NOTHING was switched.\n' "$branch" "$root" "$branch" >&2
 		return 1
 		;;
 	live-lane)
-		printf 'kp_switch_head_branch REFUSED (fail-closed): %s is checked out in %s, a worktree stamped with THIS session'\''s lane id (%s) — a sibling lane that may still be building on it. The rebase would move its HEAD mid-flight. REMEDY: run this repair from that lane'\''s worktree, or wait for it to finish and re-run. Do NOT remove that worktree — it can hold uncommitted work. NOTHING was switched.\n' "$branch" "$root" "${CLAUDE_CODE_SESSION_ID:-<unset>}" >&2
+		# The remedies this used to name were both unreachable from the refusing agent — `wt_preflight`
+		# refuses a sibling tree, and "wait" never cleared while the stamp was written once and never
+		# moved (#4868). Both are now real: the beat goes stale on its own, and a finishing lane retires
+		# its stamp, so re-running IS the way forward and it is a step this agent can take.
+		printf 'kp_switch_head_branch REFUSED (fail-closed): %s is checked out in %s, a worktree stamped with THIS session'\''s lane id (%s) whose heartbeat is FRESH — a sibling lane that moved git there in the last %ss and is building on it right now. The rebase would move its HEAD mid-flight. REMEDY: re-run this same step yourself in a few minutes — no sibling tree, no human. It clears by itself two ways: a lane retires its stamp when it finishes, and a lane that stops beating drops to liveness-unknown, where this step releases the pin as soon as that tree is provably clean, at the branch tip and pushed. Do NOT remove that worktree — it can hold uncommitted work. NOTHING was switched.\n' "$branch" "$root" "${CLAUDE_CODE_SESSION_ID:-<unset>}" "${KP_LANE_BEAT_TTL:-900}" >&2
 		return 1
 		;;
 	*)
@@ -692,5 +838,10 @@ wt_preflight() {   # MANDATED before every git commit/push/branch op — fail-cl
   case "$RES_COMMON" in /*) ;; *) RES_COMMON="$(pwd -P)/$RES_COMMON" ;; esac
   RES_COMMON="$(cd "$RES_COMMON" && pwd -P)"
   [ "$RES_GITDIR" != "$RES_COMMON" ] || { echo "wt_preflight FAILED (fail-closed): this lane's stamp resolved to the PRIMARY checkout ($WT) — git-dir == common-dir. Refusing to mutate." >&2; return 1; }
+  # BEAT — this runs immediately before every git mutation this lane makes, which is exactly what
+  # makes it liveness evidence rather than another identity check: a lane doing work leaves a fresh
+  # beat, a lane that has stopped stops leaving one. `kp_branch_pin` reads it to tell a sibling lane
+  # still building from a finished lane's leftover tree, which the shared session id cannot (#4868).
+  kp_lane_beat "$RES_GITDIR"
   echo "wt_preflight OK: mutating my lane at $WT (git-dir $RES_GITDIR)"
 }

--- a/claude-plugins/kampus-pipeline/lib/verify-lane-lifecycle-mutants.sh
+++ b/claude-plugins/kampus-pipeline/lib/verify-lane-lifecycle-mutants.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1007,SC2016
+# SC2016 is declared, not waved off: every sed program below matches LITERAL shell text inside
+# common.sh (`$CLAUDE_CODE_SESSION_ID`, `$KP_LANE_BEAT_TTL`), so expanding it here would match nothing
+# and the mutant would be a no-op that "passes" — the exact failure this harness exists to catch.
+#
+# Reviewer-runnable proof that the lane-lifecycle cases in common-test.sh are FALSIFIABLE (#4868).
+#
+# The bug being fixed was a check whose positive branch could never be false, and a suite can carry
+# that same defect: cases that pass whether or not the discriminator discriminates. So each mutant
+# below reintroduces one specific blindness into a COPY of the lib, and this harness requires the
+# suite to go red FOR ITS OWN NAMED REASON — the exact assertion text, not merely a non-zero exit.
+# A mutant that dies for an unrelated reason proves nothing about the case it was aimed at.
+#
+# Usage:  bash claude-plugins/kampus-pipeline/lib/verify-lane-lifecycle-mutants.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, no EXIT trap
+# — on bash 3.2 `-e` plus a cleanup trap launders a `set -u` abort into exit 0, and this harness's
+# whole contract is its exit status.
+set -uo pipefail
+
+LIB="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+fail=0
+
+for f in common.sh common-test.sh; do
+	if [ ! -f "$LIB/$f" ]; then
+		echo "FAIL: zero scope — $LIB/$f does not exist, so nothing was mutated (ADR 0092)"
+		exit 1
+	fi
+done
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+# BASELINE first. If the unmutated suite is red, every mutant below is red too and the whole harness
+# would report a false green on "the mutant died".
+if ! bash "$LIB/common-test.sh" > "$TMP/baseline.log" 2>&1; then
+	echo "FAIL: the UNMUTATED suite is already red — no mutation result below would mean anything:"
+	sed -n 's/^FAIL: /  baseline FAIL: /p' "$TMP/baseline.log"
+	rm -rf "$TMP"
+	exit 1
+fi
+echo "ok: baseline — the unmutated suite is green, so a red below is attributable to the mutation"
+
+# <name> <expected-failure-substring> <sed-program…> — patch a COPY of the lib, run the suite against
+# it, and require BOTH a non-zero exit AND the named assertion. `mutate` never touches $LIB.
+mutate() {
+	local name="$1" want="$2" n=0 rc
+	shift 2
+	local dir="$TMP/m$RANDOM$$"
+	mkdir -p "$dir" || {
+		echo "FAIL: [$name] could not create the mutant dir"
+		fail=1
+		return
+	}
+	cp "$LIB/common.sh" "$LIB/common-test.sh" "$dir/" || {
+		echo "FAIL: [$name] could not copy the lib"
+		fail=1
+		return
+	}
+	for prog in "$@"; do
+		if ! sed "$prog" "$dir/common.sh" > "$dir/common.sh.new"; then
+			echo "FAIL: [$name] sed program did not apply: $prog"
+			fail=1
+			return
+		fi
+		if ! mv "$dir/common.sh.new" "$dir/common.sh"; then
+			echo "FAIL: [$name] could not install the mutated lib"
+			fail=1
+			return
+		fi
+		n=$((n + 1))
+	done
+	# A mutant identical to the original is a no-op that would "pass" every assertion below by
+	# accident. Refuse it: this is the same zero-scope floor the guards themselves keep (ADR 0092).
+	if cmp -s "$dir/common.sh" "$LIB/common.sh"; then
+		echo "FAIL: [$name] the $n sed program(s) changed NOTHING — the mutation never happened, so its death proves nothing"
+		fail=1
+		return
+	fi
+	bash "$dir/common-test.sh" > "$dir/out.log" 2>&1
+	rc=$?
+	if [ "$rc" -eq 0 ]; then
+		echo "FAIL: [$name] the mutant SURVIVED — the suite is green with the blindness reintroduced, so it does not test for it"
+		fail=1
+	elif ! grep -qF "$want" "$dir/out.log"; then
+		echo "FAIL: [$name] the mutant died for the WRONG reason — expected an assertion naming [$want], got:"
+		sed -n 's/^FAIL: /    /p' "$dir/out.log"
+		fail=1
+	else
+		echo "ok: [$name] mutant died for its intended reason — $(grep -F "$want" "$dir/out.log" | head -1 | cut -c1-120)…"
+	fi
+}
+
+# M1 — THE ORIGINAL DEFECT, put back verbatim: decide `live-lane` from the session id alone, with no
+# beat consulted. Every same-session tree then reads live-lane forever, exactly as shipped.
+mutate 'M1 identity-only live-lane (the #4868 defect)' \
+	'the positive branch is still unfalsifiable (#4868 AC2)' \
+	's|if \[ -n "\$age" \] \&\& \[ "\$age" -lt "\$ttl" \]; then|if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then|'
+
+# M2 — keep the beat, drop the PROOF: treat every dormant tree as safe to release. The dormant state
+# stops being a real guard and becomes a slower way to fail open.
+mutate 'M2 quiescence proof always true' \
+	'a dormant lane'"'"'s DIRTY tree was released' \
+	's|^kp_lane_quiescent() { #|kp_lane_quiescent() { return 0; # MUTANT: everything below is dead #|'
+
+# M3 — break the lane-FINISH half: retiring becomes a no-op that reports success. The routine
+# finished-lane case silently stays stuck, and a caller that trusts the return value never knows.
+mutate 'M3 retire is a no-op' \
+	'the stamp was not retired by rename' \
+	's|^kp_lane_retire() { #|kp_lane_retire() { return 0; # MUTANT: everything below is dead #|'
+
+# M4 — treat an UNREADABLE beat as "beating right now". Absent evidence read as the permissive
+# answer is the §ZS violation this whole class keeps reproducing.
+mutate 'M4 missing beat reads as fresh' \
+	'must read dormant-lane, not live-lane' \
+	's|age="\$(kp_lane_beat_age "\$admin")"|age="0" # MUTANT: unknown age is not 0|'
+
+rm -rf "$TMP"
+if [ "$fail" -ne 0 ]; then
+	echo "verify-lane-lifecycle-mutants: FAILED"
+	exit 1
+fi
+echo "verify-lane-lifecycle-mutants: all mutants died for their intended reasons"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-preflight.sh
@@ -105,5 +105,10 @@ printf '%s\n' "$CLAUDE_CODE_SESSION_ID" > "$GITDIR/kampus-lane" || {
 	echo "write-code preflight FAILED: could not stamp the lane at $GITDIR/kampus-lane — no later git mutation could be verified as mine." >&2
 	exit 1
 }
+# Open the stamp's LIFECYCLE at the same moment, not just its identity (#4868). The id is shared by
+# every sibling lane of this session, so on its own it can never tell a live lane from a leftover
+# tree; the beat is what a later reader measures, and `wt_preflight` refreshes it before every git
+# mutation this lane makes. `step8-claim-release.sh` closes the lifecycle by retiring the stamp.
+kp_lane_beat "$GITDIR"
 echo "write-code preflight CONFIRMED (LOUD): in a LINKED worktree at $WT (git-dir != common-dir), stamped for lane $CLAUDE_CODE_SESSION_ID — worktree identity established from git plumbing, INDEPENDENT of \$WORKTREE_ROOT (${WORKTREE_ROOT:+set}${WORKTREE_ROOT:-unset}) and \$CLAUDE_CODE_AGENT (${CLAUDE_CODE_AGENT:-unset}), both of which may misreport. Anchor EVERY Edit/Write and git op to this \$WT (absolute) — never a primary-checkout path." >&2
 printf 'GITDIR=%s\nCOMMON=%s\nWT=%s\n' "$GITDIR" "$COMMON" "$WT"

--- a/claude-plugins/kampus-pipeline/skills/write-code/scripts/step8-claim-release.sh
+++ b/claude-plugins/kampus-pipeline/skills/write-code/scripts/step8-claim-release.sh
@@ -31,3 +31,21 @@ PCLI="$(kp_pcli)" || exit 127
 # --session carries the token we owned the work under (the orchestrator's delegated token on the
 # orchestrated path), because that is the token the marker itself carries.
 "$PCLI" claim release --issue "$N" --session "$MY_CLAIM"
+rc=$?
+
+# The run held TWO things, and both outlived it: the claim on the issue, and the lane stamp on this
+# worktree. An unretired stamp is why a finished lane's leftover tree read as a sibling still
+# building and blocked every later repair on its branch, permanently (#4868). Retire it here, the
+# same "last act of the run that held it" seam, and only once the claim release actually succeeded —
+# a failed release means the run is not over.
+if [ "$rc" -eq 0 ]; then
+	if lane="$(lane_worktree 2>/dev/null)" && gd="$(git -C "$lane" rev-parse --absolute-git-dir 2>/dev/null)" &&
+		kp_lane_retire "$gd"; then
+		echo "write-code Step 8: retired this lane's stamp ($gd/kampus-lane -> kampus-lane.retired). The worktree and its files are untouched; a later repair on this branch now reads it as a leftover tree, not as a lane still building." >&2
+	else
+		# NOT fatal, and deliberately so: the claim IS released, and an unretired stamp degrades to
+		# the liveness-unknown path, which still resolves once the tree is provably finished.
+		echo "write-code Step 8: could not retire this lane's stamp (lane=${lane:-<unresolved>}). The claim WAS released. A later repair on this branch will have to prove this tree finished instead of reading it as retired." >&2
+	fi
+fi
+exit "$rc"


### PR DESCRIPTION
Fixes #4868

## What was wrong

`kp_branch_pin` decided `live-lane` from one string comparison: the pinning worktree's `kampus-lane` stamp against `$CLAUDE_CODE_SESSION_ID`. Every sibling subagent of one dispatching session shares that id, and **nothing ever cleared the stamp** — so a build lane that finished hours ago was byte-identical, at that comparison, to a lane still building. The positive branch could not be false, and every repair on a branch whose build worktree still existed was refused with two remedies the refusing agent could not perform (`wt_preflight` fails closed on a sibling tree; "wait for it to finish" never cleared).

The fix is in the **stamp's lifecycle**, not in how the dispatcher threads claim tokens. That threading is untouched — the claim token was the symptom the report named, not the defect.

## What changed

The stamp gains two lifecycle files beside it, both in the worktree's private git admin dir (never the working tree, never committed):

| file | written by | means |
| --- | --- | --- |
| `kampus-lane` | opening preflight, once | **which** lane proved this tree (unchanged) |
| `kampus-lane.beat` | `wt_preflight`, before every git mutation | **when** that lane last did anything |
| `kampus-lane.retired` | `step8-claim-release.sh`, the run's last act | the lane is **done** with this tree |

`kampus-lane.retired` is the pre-existing convention `lane_worktree` already skipped and **nothing produced**; a lane now produces it itself, so the routine finished-lane case stops being permanent.

`kp_branch_pin` reads that lifecycle:

- same-session **and** beating within `$KP_LANE_BEAT_TTL` (900s) ⇒ `live-lane` — **still refuses**;
- same-session, beat stale or absent ⇒ **`dormant-lane`**, a new state: liveness genuinely unknown, stated as its own state rather than guessed either way;
- retired or foreign ⇒ the ordinary `other`, which co-checks-out.

`dormant-lane` releases the pin **only on positive proof the tree is finished** (`kp_lane_quiescent`): clean working tree, HEAD at the branch tip, and that commit on a remote-tracking branch — the three facts that make a leftover tree provably safe to release. Only then is the stamp retired, by renaming one bookkeeping file. Unproven ⇒ refuse, naming which of the three facts failed. Two independent signals (beat + quiescence) must both say "not working" before anything is released, so an idle-but-live lane with a dirty tree or unpushed commits still blocks.

Both same-session refusals now name a remedy **the refusing agent can execute** — re-run the step — and that is honest for the first time, because both states now actually clear: a lane retires its stamp on finish, and a stopped lane's beat goes stale into the provable-release path.

## Acceptance criteria

- **AC1 — fail-closed preserved.** A beating same-session sibling still classifies `live-lane`, still REFUSES, moves no HEAD and retires no stamp (case 32). Nothing relaxes the comparison; the dormant path *adds* a proof obligation rather than removing one.
- **AC2 — the positive branch is falsifiable.** A finished same-session lane's tree resolves out of `live-lane` two ways: retirement (case 36) and the proven release (case 35).
- **AC3 — not the session id alone.** Liveness is the beat plus, before any release, the quiescence proof. The recorded #4500 finding (the id names a session, not a worktree) is cited at the decision site and is exactly why identity alone is no longer trusted there.
- **AC4 — every refusal names an executable remedy.** The unreachable "run it from that lane's worktree" is gone; the live-lane and dormant-lane refusals both name re-running this step, and the dormant one names the fact that failed so a genuinely-unsafe tree escalates with evidence (case 33, case 34).
- **AC5 — nothing removed, nothing at risk.** No worktree removal, no `--force`, no write into any working tree — the release is one `mv` inside the repo's own bookkeeping (case 35 asserts the worktree stays registered and its files survive).
- **AC6 — coverage.** Case 26 extended to six states; case 31 unchanged and still green; new cases 32–36.

## Falsifiability — the mutation harness

`claude-plugins/kampus-pipeline/lib/verify-lane-lifecycle-mutants.sh` (wired into CI beside `common-test.sh`) reintroduces each blindness into a copy of the lib and requires the suite to go red **for its own named reason**, not merely to exit non-zero. It refuses a no-op mutation and refuses to run at all if the unmutated baseline is not green.

| mutant | intended killing assertion |
| --- | --- |
| M1 — decide `live-lane` from the session id alone (the original defect) | `a PROVABLY finished same-session lane still blocked the repair … the positive branch is still unfalsifiable (#4868 AC2)` |
| M2 — quiescence proof always true | `a dormant lane's DIRTY tree was released — uncommitted work would have moved under it` |
| M3 — retire is a no-op that reports success | `the stamp was not retired by rename — the next repair reads the same stuck state again` |
| M4 — an unreadable beat reads as fresh | `the SAME stamp with a stale beat must read dormant-lane, not live-lane` |

All four die for their intended reason; all fixture paths resolve physically (`cd -P` / `pwd -P`).

## Files touched vs the issue's list

The issue's list was a floor. Touched:

- `claude-plugins/kampus-pipeline/lib/common.sh` — named
- `claude-plugins/kampus-pipeline/lib/common-test.sh` — named
- `claude-plugins/kampus-pipeline/skills/write-code/scripts/step4-preflight.sh` — named
- `claude-plugins/kampus-pipeline/skills/write-code/scripts/step8-claim-release.sh` — named
- `claude-plugins/kampus-pipeline/lib/verify-lane-lifecycle-mutants.sh` — **new**, not named
- `.github/workflows/ci.yml` — **not named**; wires the mutation harness
- `.patterns/worktree-agent-constraints.md` — **not named**; the lifecycle is a pattern a reader needs, and that doc already hosts the neighbouring `kampus-owner.json` stamp that is easy to confuse with this one

Not touched, deliberately: `stepR2-branch-rebase.sh` (the call site needs no change — it routes on the classifier, which absorbs the new state) and anything in the dispatcher's claim-token threading.

## Deviations

- **A new PIN state rather than a two-way answer.** The issue left the residual dead-but-unretired case to the implementer. I made it a first-class `dormant-lane` rather than folding it into `live-lane` (permanently stuck again) or `other` (fail-open). It is the "liveness unknown, with a reachable remedy" shape the report floated as a candidate.
- **Retirement is done at lane finish *and* provable release.** Retirement alone leaves a crashed lane stuck forever; the beat alone would not fix the ~250 already-stamped leftover trees on the host, which carry no beat and therefore land in `dormant-lane` and get released on proof. Both halves are needed for the fix to help today rather than only for future lanes.
- **`step8-claim-release.sh` retires best-effort and never fails the run.** The claim release is the contract that step owns; a stamp that could not be retired degrades to the dormant path, which still resolves. It only retires when the claim release itself succeeded — a failed release means the run is not over.
- **A stale beat is 900s by default (`$KP_LANE_BEAT_TTL`), not tuned against measurement.** A lane can legitimately go quiet for a long edit. The TTL is not load-bearing on its own precisely because nothing is released on the beat alone: the quiescence proof is the safety property, and the TTL only decides which of two refusals you get.
- **CI additions run the harness on every push.** It builds temp git repos; it needs no network and touches no PR.

- **(repair round 1) Tightened `kp_lane_quiescent`'s third fact to `origin/<branch>`, which the FAIL recorded as a non-blocking recommendation.** It was containment in *any* `refs/remotes/*`; a stale-forward remote-tracking ref then answers "safely on a remote" for work the upstream no longer has. This predicate is what decides whether a pin is **released**, so that false positive is its fail-open direction. It is now `git merge-base --is-ancestor "$head" "refs/remotes/origin/$branch"` — and an absent `origin/<branch>` makes that non-zero, i.e. refuses, which is the safe direction. Two refusal messages and the pattern doc were reworded to match.
- **(repair round 1) Fixed the fixture, not the guard, for the red `skill-gh-lint`.** The bare repo is populated by fetching into it from the working repo instead of pushing out of it. Falsified rather than assumed: neutering only the case-35 population makes case 35 fail with `a PROVABLY finished same-session lane still blocked the repair`, so the "this commit is on a remote" fact is still carried. No pragma, no exempt-list entry, no change to `scanBarePush`.
- **(repair round 1) Left the CI wiring alone.** The gate recorded, separately from its criterion, that `skill-gh-lint` is neither a required context nor in `ci-required`'s `needs:`. That is a real gap and it is out of scope here; this round did not touch `ci-required` or the ruleset.
