### PR TITLE
docs(fabrika): record the exit-code band as per-group, not repo-wide (#5005)

### DIFF
--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -108,6 +108,52 @@ exit taxonomy, and the verdict-vs-invocation rule proven in v1 at
   dependency, a repo-local install it could not execute — and has something specific to say about
   it. Seating that on `1` would make it indistinguishable from a typo in a flag ([#4666](https://github.com/kamp-us/phoenix/issues/4666)).
 
+- **The `3`+ band is scoped to the verb group that seats it. A code above the reserved band means one
+  thing *within* its group and carries no cross-group uniqueness obligation.** Two shipped shapes are
+  both correct, and a group picks by whether its verbs share refusal meanings:
+
+  - **Per verb, no shared table** — the `3`+ row above read literally. `adr` allocates each verb's
+    codes in that verb's own module and ships no `codes.ts`, so `3` is `BASE_UNFETCHABLE` under
+    `adr next`, `NO_SUBJECT` under `adr relate`, `ALREADY_EXISTS` under `adr new`, and
+    `CORPUS_UNREADABLE` under `adr sweep`.
+  - **Per group, one shared table** — `report`, `triage`, `review` and `wire` each ship a
+    `<group>/codes.ts` that every verb in the group allocates from, so a code means one thing across
+    the group whichever verb produced it. That is a **tightening** a group chooses, not a further
+    obligation this rule imposes.
+
+  Neither shape reaches across a group boundary.
+  [`triage/codes.ts`](../../../packages/fabrika-cli/src/triage/codes.ts) seats `12` as *the issue is
+  human-filed*; [`review/codes.ts`](../../../packages/fabrika-cli/src/review/codes.ts) seats `12` as
+  *the live head moved past the inspected `--sha`*. Those are two namespaces, not one collision.
+
+- **The `report` ↔ `triage` ↔ `review` code-for-code alignment is a deliberate, bounded courtesy —
+  not a repo-wide namespace.** Those three groups hold `3`, `5`, `6`, `7`, `8`, `9`, `10` and `11` on
+  one meaning each, and `triage` and `review` *import* the constants from `report` rather than
+  restating numerals, so a drift there is unrepresentable rather than merely detectable. The reason is
+  one caller commonly driving all three in a single sweep.
+  [`exit-code-alignment.ts`](../../../packages/fabrika-cli/src/exit-code-alignment.ts) mechanizes
+  exactly that scope and no more: it checks each aligning group against the **base** and never
+  pairwise against a sibling. Above the shared overlap each group's private band is its own —
+  `review`'s `12`–`15` and `triage`'s `12`–`13` are not required to clear each other, and do not.
+
+  [`wire/codes.ts`](../../../packages/fabrika-cli/src/wire/codes.ts) is the shipped counter-example.
+  It aligns to nothing, and is *registered* as unaligned with its reason so the exemption carries
+  information instead of reading as an oversight. It legitimately reuses `4`, `5`, `6` and `8` —
+  `MALFORMED` / `EMPTY_ARTIFACT` / `ARTIFACT_UNKNOWN` / `UNUSABLE_FIELDS` against `report`'s
+  `BAD_SECTIONS` / `LEAKED_PATH` / `BARE_AT_PATH` / `WRITE_UNKNOWN` — and reuses `3` and `7` besides.
+  Under a cross-group clearance rule `wire` would be the largest violation in the package. It is not a
+  violation at all.
+
+- **One condition would turn a cross-group reuse into a defect: a reader that resolves an exit code
+  without knowing which group produced it.** None exists today, and the interface is what keeps it
+  that way. Every invocation names its group (`fabrika <group> <verb> …`, rule 5); each `--help`
+  enumerates only the codes that verb can reach; and the runtime taxonomy verb is per group —
+  `fabrika triage codes` prints `TRIAGE_EXIT_TABLE`, `fabrika wire codes` prints `WIRE_EXIT_TABLE`,
+  with no cross-group table and no shared lookup. Add such a reader — a dispatcher, a shared decoder,
+  a wrapper that maps a numeral to a meaning before it knows the group — and cross-group clearance
+  becomes a real obligation to encode. Until then, re-seating a shipped code to clear a sibling buys
+  nothing and breaks that group's own symmetry.
+
 - A verb whose result crosses a pipe keeps its exit code binary (`0` / non-zero) and puts the
   discriminator in a stdout state word: a meaningful code does not survive `xargs`.
 

--- a/packages/fabrika-cli/src/review/codes.ts
+++ b/packages/fabrika-cli/src/review/codes.ts
@@ -9,6 +9,13 @@
  * checked-in `/report` contract already sits behind its own binary on `7` and `11` (#4752), which is
  * why the shipped package is the authority and no prose copy is.
  *
+ * **`12`-`15` are this group's private band, and are deliberately not cleared against sibling
+ * groups.** `triage` seats `12`/`13` on its own two refusals; that is two namespaces, not one
+ * collision, because the `3`+ band carries no cross-group uniqueness obligation — see rule 3 of
+ * `../../../../claude-plugins/fabrika/docs/cli-interface-convention.md`, which also names the one
+ * condition that would change it. `../exit-code-alignment.ts` checks this band against the base
+ * only, matching that scope.
+ *
  * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
  * `4` stays a deliberate gap — it is `report file`'s body-section seat, and no verb here performs
  * one; a row for it would be a meaning this group does not have.


### PR DESCRIPTION
The fabrika CLI convention reserves exit codes 0/1/2/127 and hands everything from 3 up to a verb's own proven outcomes — but it never said whether a code above that reserved band has to be unique across verb groups. That gap made `review`'s `12`/`13` and `triage`'s `12`/`13` look like a live collision when they are two separate namespaces. This writes the rule down at the two places the next author will actually look: the convention's rule 3, and `review/codes.ts`'s own header.

Nothing changes value and no check is added. Four statements land in rule 3:

- The `3`+ band is scoped to the group that seats it — no cross-group uniqueness obligation. Two shipped shapes are both correct: a group with one shared `<group>/codes.ts` (`report`, `triage`, `review`, `wire`), and a group that allocates per verb with no `codes.ts` (`adr`, where `3` is a different meaning in each of four verbs).
- The `report` ↔ `triage` ↔ `review` alignment over `3`, `5`, `6`, `7`, `8`, `9`, `10`, `11` is a deliberate, bounded courtesy for a caller driving all three in one sweep — not a repo-wide namespace. `wire` is the shipped counter-example: it legitimately reuses `4`/`5`/`6`/`8` (and `3`/`7` besides) for unrelated meanings, and is registered as unaligned with its reason.
- The one condition that would make a cross-group reuse a defect: a reader that resolves a code without knowing which group produced it. None exists — every invocation names its group, each `--help` enumerates only its verb's codes, and the taxonomy verb is per group.
- `review/codes.ts`'s header now states that `12`-`15` are its private band, deliberately not cleared against siblings, and points at the convention rule instead of restating it.

Every claim above was re-derived from the shipped source, not from the issue text.

Fixes #5005

## Deviations

**Class: the issue's stated fact is stale.** Said: acceptance criterion 6 requires that nothing reference `packages/fabrika-cli/src/exit-code-alignment.ts` "which does not exist". Did: the doc references that file, once, as the mechanized statement of the base-only scope. Why: the file **does** exist on `main` — it landed after this issue was triaged (via the PR for #4924), and its `checkAlignment` compares each aligning group against the base with no pairwise sibling pass, which is precisely the rule being recorded. Honouring the AC literally would have suppressed the strongest available evidence for the rule. Disposition: for the reviewer to judge; the AC's premise is falsified by `main`, and the criterion's intent (don't propagate a pointer to a nonexistent file) is satisfied because the file is real.

**Class: narrowed a stated scope for accuracy.** Said: acceptance criterion 2 asks the rule to cite `wire` as reusing `4` / `5` / `6` / `8`. Did: cited those four explicitly and added that `wire` also reuses `3` and `7`. Why: `wire` allocates `3`-`8` and every one of those numerals is occupied in `report`; naming only four would understate the counter-example. Disposition: no action needed.

**Class: extended beyond the literal AC.** Said: the ACs ask only that the band be described as per verb group. Did: also documented the two legitimate group shapes (one shared `codes.ts` versus per-verb constants), grounded in `adr`'s five verbs seating `3` five different ways. Why: with `adr` and `eval` registered as groups with no `codes.ts`, a doc that said only "per group" would read as though those groups were violating it. Disposition: no action needed.