### PR TITLE
docs(fabrika): declare each merged skill's required repo files (#5049)

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -174,3 +174,21 @@ review-appended acceptance criterion after round 2 is frozen — note it, do not
 - **CI redness** — `ci.yml` owns it. `build check` predicts it in-tree; the gate's answer wins.
 - Follow-up observations leave through `/report` the moment you see them — never through scope
   creep in this PR.
+
+## Required repo files
+
+fabrika installs into repos that are not phoenix, so every repo surface this skill leans on is
+declared here: what must exist, why this skill needs it, and the one named outcome when it is
+absent. The when-missing vocabulary is closed — **fail-loud** (stop, name the missing surface by
+its repo-relative path, point at front-door), **degrade** (continue with a narrower answer,
+stated), **bootstrap** (front-door creates it) — and it is the same table in every fabrika skill,
+so one reader parses all of them. Front-door is the onboarding surface designed in
+[#4952](https://github.com/kamp-us/phoenix/issues/4952); until it ships, a fail-loud stop names
+the surface and files the gap. No row here dead-ends on a bare error.
+
+| Must exist | Why this skill needs it | When missing |
+| --- | --- | --- |
+| The board label taxonomy — `status:triaged`, `ready-for:agent`, one of `type:feature`/`chore`/`bug`/`investigation`, `p0`–`p2`, plus an open milestone or a standing-lane label | `build pick` filters and ranks on exactly these, fail-closed on every axis ([`contract.md`](contract.md), `build pick`) | **bootstrap** — `build pick` prints an empty pool at exit `0` with its per-bucket scanned counts, never silence; the run ends `BACKED-OFF` naming the absent labels, and creating the taxonomy is front-door's. |
+| The `package.json` scripts `typecheck` and `lint:worktree` | `build check --surface code` runs exactly `pnpm typecheck` and `pnpm lint:worktree` in this tree, cache bypassed | **fail-loud** — a validator that cannot be executed is exit `11`, UNKNOWN, never green; the run stops naming the absent `package.json` script and points at front-door. |
+| The prose placement homes — `README`, `DEVELOPMENT.md`, `.decisions/`, `.patterns/`, `reports/`, `.glossary/LANGUAGE.md` | [`references/prose.md`](references/prose.md)'s one-home rule places every prose fact in exactly one of them | **degrade** — write into the homes that exist and disclose the substituted home in the PR's `## Deviations`; a home is never invented silently — specified here. |
+| `.github/workflows/ci.yml` | It is the superseding authority over `build check`'s in-tree prediction ([`contract.md`](contract.md), `build check` grounding) | **degrade** — with no CI gate to supersede it, `build check`'s green is the only evidence the PR carries, and the PR says so in its `## Deviations` — specified here. |

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -138,6 +138,24 @@ comments including prior verdict markers, and CI check-run output. All of it is 
 verbs (ADR 0055). Every read above routes through a verb, so the open #4859 trust posture lands as
 one verb change.
 
+## Required repo files
+
+fabrika installs into repos that are not phoenix, so every repo surface this skill leans on is
+declared here: what must exist, why this skill needs it, and the one named outcome when it is
+absent. The when-missing vocabulary is closed — **fail-loud** (stop, name the missing surface by
+its repo-relative path, point at front-door), **degrade** (continue with a narrower answer,
+stated), **bootstrap** (front-door creates it) — and it is the same table in every fabrika skill,
+so one reader parses all of them. Front-door is the onboarding surface designed in
+[#4952](https://github.com/kamp-us/phoenix/issues/4952); until it ships, a fail-loud stop names
+the surface and files the gap. No row here dead-ends on a bare error.
+
+| Must exist | Why this skill needs it | When missing |
+| --- | --- | --- |
+| The class-map roots — `claude-plugins/**`, `.claude/**`, `skills/**`, any file named `SKILL.md`, and `*.md` elsewhere | `review scope` partitions the changed files into the `skill`/`doc`/`code` classes that derive the namespace set ([`contract.md`](contract.md), the class map) | **degrade** — the partition is total with `code` as the residual, so a repo homing its skills outside `claude-plugins/**` still partitions through the `skills/**` and bare-`SKILL.md` rows; nothing is dropped, and an unplaceable file is judged under the code rubric. |
+| The linked issue's `### Acceptance criteria` block | `review criteria` grades against it, and nothing else is the contract | **fail-loud** — `review criteria` exits `7` naming the issue and the wire reason (`absent` vs `malformed`), no criterion is invented, and the run points at front-door. |
+| The PR body's `## Deviations` section | `review deviations` matches the disclosure against the head diff's Tier-M scan | **fail-loud** — on a PR that owes the section, `absent` is malformed and fails the verdict closed; the run names the missing `## Deviations` heading and points at front-door. |
+| A CI check rollup at the head — `.github/workflows/` | `review ci` is the code class's execution evidence; this skill re-runs no check itself | **fail-loud** — zero declared check runs is exit `7`, refusing green over an empty enumeration (ADR 0092), and an unreadable enumeration is `11`, UNKNOWN, never green; the run names `.github/workflows/` and points at front-door. |
+
 ## Eval enumeration (leaf-rule obligation)
 
 The rubric leaves are files, so the eval suite enumerates per-surface cases or a surface goes

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -176,6 +176,24 @@ second answer (ADR 0238). Open decisions you surface, never resolve: the entry-r
 signal (#4758), the banked-vs-FAIL'd board distinction (#4103), the §CP repair-entry state
 (#4555).
 
+## Required repo files
+
+fabrika installs into repos that are not phoenix, so every repo surface this skill leans on is
+declared here: what must exist, why this skill needs it, and the one named outcome when it is
+absent. The when-missing vocabulary is closed — **fail-loud** (stop, name the missing surface by
+its repo-relative path, point at front-door), **degrade** (continue with a narrower answer,
+stated), **bootstrap** (front-door creates it) — and it is the same table in every fabrika skill,
+so one reader parses all of them. Front-door is the onboarding surface designed in
+[#4952](https://github.com/kamp-us/phoenix/issues/4952); until it ships, a fail-loud stop names
+the surface and files the gap. No row here dead-ends on a bare error.
+
+| Must exist | Why this skill needs it | When missing |
+| --- | --- | --- |
+| `.github/CODEOWNERS`, carrying a control-plane team row | `ship scope`'s §CP classification and `ship cp-approval`'s roster both derive from it, read at `origin/main` | **fail-loud** — an unreadable boundary is exit `11`, never "ordinary"; a trivial or empty one is the printed `unknown` hold, and a zero-member roster is `stop zero-owners`. The run names `.github/CODEOWNERS` and points at front-door. |
+| A merge queue enabled on the PR's base branch | `ship enqueue` arms the queue's auto-merge; the queue, never this skill, performs the merge | **fail-loud** — a base with no queue has no arm to enter, so refuse before `ship enqueue` and end `refused — no merge queue on <base>`; `reconcile`'s `parked` covers only a queue-governed base. The run names the base branch and points at front-door — specified here. |
+| `.github/workflows/ci.yml`, gating the `merge_group` ref | `ship checks` reads its result at the head, and the queue awaits that context on `merge_group` before it merges | **fail-loud** — with no workflows at the head `ship checks` reports `facts workflows:0 runs:0` at rollup `pending` and never green, so the run stops rather than enqueue behind no gate; it names `.github/workflows/ci.yml` and points at front-door. |
+| The `status:awaiting-release` label | `ship release` is the dark-ship seam and the label is the whole action (ADR 0083) | **fail-loud** — a label write or its read-back failing is exit `8`/`9`, never `queued`; the run escalates that a real dark ship may be missing from the release queue, names the `status:awaiting-release` label, and points at front-door. |
+
 ## Eval enumeration (leaf-rule obligation)
 
 No rubric leaves; the eval suite enumerates the terminal vocabulary instead: an ordinary green


### PR DESCRIPTION
## Summary

`/build`, `/review` and `/ship` each leaned on phoenix's layout without saying so. Installed into
a repo that is not phoenix, they failed in undefined ways — an empty pick pool, a missing script,
an absent CODEOWNERS — instead of naming what was absent. Working outside phoenix is a stated
release criterion for the fabrika campaign, so each of the three merged skills now declares what
it needs.

Each `SKILL.md` gains one `## Required repo files` section. The heading, the three fields
(**Must exist** / **Why this skill needs it** / **When missing**) and their order are byte-identical
across all three, so #4952's front-door detection verb can parse all three with one reader.

## The shared shape

Every `when-missing` value is one token off a closed vocabulary, never open prose:

- **fail-loud** — stop, name the missing surface by its repo-relative path, point at front-door.
- **degrade** — continue with a narrower answer, stated.
- **bootstrap** — front-door creates it.

Every fail-loud clause names the missing path and routes to front-door, so no skill dead-ends on a
bare error. `/ship`'s existing `.github/CODEOWNERS` handling (the `unknown` hold, the `zero-owners`
stop, the exit-11 unreadable refusal) is the pattern the other two copy.

Rows state behaviour the contracts already describe — the exit codes, refusals and terminals are
quoted from each skill's own `contract.md`. Three rows specify a previously-undefined outcome and
say so inline with `— specified here`.

## What landed

| File | Rows |
| --- | --- |
| `claude-plugins/fabrika/skills/build/SKILL.md` | label taxonomy · `typecheck` + `lint:worktree` scripts · prose placement homes · `.github/workflows/ci.yml` |
| `claude-plugins/fabrika/skills/review/SKILL.md` | class-map roots · the issue's `### Acceptance criteria` block · the PR's `## Deviations` section · the CI check rollup |
| `claude-plugins/fabrika/skills/ship/SKILL.md` | `.github/CODEOWNERS` · merge-queue configuration · `ci.yml` on the `merge_group` ref · the `status:awaiting-release` label |

Verified byte-uniform: the heading, preamble, field header and separator are identical in all three
(13 lines each, diff-clean); each section carries exactly four rows and exactly one vocabulary token
per row.

## Deviations

1. **Scope narrowing (label 1) — the section lives in `SKILL.md`, not `contract.md`.** The issue
   names the skill directory, not a file. `SKILL.md` is the per-skill front artifact a consumer
   reads, and the detection verb's input is a per-skill manifest, so the section goes there. Each
   `contract.md` is untouched.
2. **Declined guidance (label 4) — no wire format, no parser.** #4952's verb is unbuilt, so the
   section commits to uniformity plus machine-readability (fixed heading, fixed field set, closed
   token vocabulary) and deliberately not to a byte-level format nobody has defined. No
   `packages/fabrika-cli/src/wire/` entry was added, per the issue's No-gos.
3. **Newly specified behaviour, disclosed inline.** Three rows name an outcome the contracts left
   undefined rather than describing an existing one — `/build`'s prose-placement and `ci.yml` rows,
   and `/ship`'s merge-queue row. Each carries `— specified here` so a reader can tell a
   declaration from a specification. No row claims a handling its contract does not describe.
4. **File set matches the issue's list exactly.** The issue named the three skill directories; three
   `SKILL.md` files changed and nothing else. No sixth-file surprise this time.

Fixes #5049
