### PR TITLE
feat(fabrika-cli): record each completed eval run's spend, attributed to the run (#5008)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -496,6 +496,25 @@ locates the pinned session's transcript, classifies the run, and folds the colle
 **capture manifest** `collectFromCapture` already consumes. Grading, spend reconstruction and the
 scorecard are all pre-existing code paths — this verb adds no oracle, no meter and no renderer.
 
+### What each run cost, attributed to the run ([#5008](https://github.com/kamp-us/phoenix/issues/5008))
+
+The runner already reconstructed every run's transcript to detect a silent green and then threw the
+number away. It now keeps it. Each completed run carries its `RunSpend` on its outcome, and the
+ledger's `spendRows` hold one **spend row** per completed run — the spend plus the identity fabrika
+already had for it: skill, stage, case id, arm, model, session id, CLI version, and the suite's
+`recordedAt` stamp. A `Failed` run gets no row; a row's `stage` is provenance — the key the row was
+written under — never a pointer into the live stage table (#4977).
+
+The three-arm `RunSpend` union is reused verbatim, so the states that are not a number stay
+distinguishable to the last layer. `renderLedger` prints per-run `billed` / `ex-cache-read` and a
+suite total, and it prints `n/a (transcript missing)` — never `0` — for a run it could not measure. A
+suite that measured nothing prints `spend: unmeasured`, because a `billed 0` total reads exactly like
+a suite that genuinely cost nothing. A run whose transcript bills zero turns never reaches a row at
+all: it is already the counted `NoModelTurns:zero-assistant-turns` failure above.
+
+The figures come from `src/spend/token-spend.ts` through `classifyRunSpend`. No second sum is added
+here — this change in fact removes the runner's own second `reconstructSpend` call.
+
 **The two arms are `--plugin-dir` present or absent.** That is the whole difference in the argv, and
 it is the arm variable the /skill-creator methodology means by with-skill vs without-skill. Two flags
 are deliberately never emitted: `--no-session-persistence` (it suppresses the transcript this path

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -413,6 +413,9 @@ const runCommand = leafCommand(
 				stage: opts.stage,
 				model: opts.model,
 				cliVersion: yield* claudeVersion(),
+				// Read here rather than in the core: `buildLedger` stays a pure function of its inputs,
+				// which is what lets the unit tier assert an exact recorded row.
+				recordedAt: new Date().toISOString(),
 				outcomes,
 			});
 

--- a/packages/fabrika-cli/src/eval/spawn.ts
+++ b/packages/fabrika-cli/src/eval/spawn.ts
@@ -22,9 +22,9 @@
  * verdict is the one place a run is allowed to become a `CaptureRun`.
  */
 import {Effect, Result} from "effect";
-import {reconstructSpend} from "../spend/token-spend.ts";
 import {STAGES} from "./corpus.ts";
-import type {CaptureManifest, CaptureRun, TranscriptLoader} from "./runner.ts";
+import type {CaptureManifest, CaptureRun, RunSpend, TranscriptLoader} from "./runner.ts";
+import {classifyRunSpend} from "./runner.ts";
 import type {EvalTier} from "./skill-eval-set.ts";
 
 /**
@@ -239,6 +239,12 @@ export type RunOutcome =
 			readonly artifact: unknown;
 			readonly numTurns: number;
 			readonly totalCostUsd: number | null;
+			/**
+			 * What the run's transcript reconstructed to. The three-arm union is reused verbatim rather
+			 * than narrowed to a `StageSpend`, so a transcript that could not be read stays visibly
+			 * unmeasured instead of arriving in the ledger as a zero somebody would read as free.
+			 */
+			readonly spend: RunSpend;
 	  }
 	| {
 			readonly _tag: "Failed";
@@ -263,9 +269,9 @@ const failed = (plan: PlannedRun, failure: RunFailure): RunOutcome => ({
  * `Unknown command:` prefix names the actual cause, so it is reported ahead of the `num_turns === 0`
  * that always accompanies it.
  *
- * `assistantTurns` is the transcript's own reconstruction (`reconstructSpend`), passed in rather
- * than computed here so this stays pure; `null` means no transcript was read yet, which is not
- * itself a signal — `TranscriptNotFound` covers that separately.
+ * `assistantTurns` is the transcript's own reconstruction, passed in rather than computed here so
+ * this stays pure; `null` means no transcript was read yet, which is not itself a signal —
+ * `TranscriptNotFound` covers that separately.
  */
 const noModelTurns = (args: {
 	readonly result: HeadlessResult;
@@ -298,6 +304,16 @@ const noModelTurns = (args: {
 };
 
 /**
+ * The billed-turn count a `RunSpend` attests, or `null` when there is no transcript to attest one.
+ * Deriving it from the union rather than taking it alongside is what makes a count that disagrees
+ * with the spend it was measured from unrepresentable.
+ */
+const billedTurns = (spend: RunSpend): number | null => {
+	if (spend._tag === "TranscriptMissing") return null;
+	return spend._tag === "NoBilledTurns" ? 0 : spend.spend.assistantTurns;
+};
+
+/**
  * Classify one executed run. This is the fail-closed seam: only a run that survives every check
  * becomes `Completed`, and only a `Completed` run reaches the capture manifest.
  */
@@ -305,7 +321,7 @@ export const classifyRun = (args: {
 	readonly plan: PlannedRun;
 	readonly exec: ExecutorResult;
 	readonly transcriptPath: string | null;
-	readonly assistantTurns: number | null;
+	readonly spend: RunSpend;
 }): RunOutcome => {
 	const {plan, exec} = args;
 	if (exec._tag === "SpawnFailed") return failed(plan, {_tag: "SpawnFailed", detail: exec.detail});
@@ -325,7 +341,7 @@ export const classifyRun = (args: {
 	const silentGreen = noModelTurns({
 		result,
 		schemaRequested: plan.jsonSchema !== null,
-		assistantTurns: args.assistantTurns,
+		assistantTurns: billedTurns(args.spend),
 	});
 	if (silentGreen !== null) {
 		return failed(plan, {_tag: "NoModelTurns", ...silentGreen});
@@ -347,6 +363,7 @@ export const classifyRun = (args: {
 		artifact: result.hasStructuredOutput ? result.structuredOutput : null,
 		numTurns: result.numTurns,
 		totalCostUsd: result.totalCostUsd,
+		spend: args.spend,
 	};
 };
 
@@ -370,14 +387,7 @@ export const executeRuns = <RE, RL, RT>(args: {
 			const transcriptPath = yield* args.locateTranscript(plan.sessionId);
 			const transcript =
 				transcriptPath === null ? null : yield* args.loadTranscript(transcriptPath);
-			outcomes.push(
-				classifyRun({
-					plan,
-					exec,
-					transcriptPath,
-					assistantTurns: transcript === null ? null : reconstructSpend(transcript).assistantTurns,
-				}),
-			);
+			outcomes.push(classifyRun({plan, exec, transcriptPath, spend: classifyRunSpend(transcript)}));
 		}
 		return outcomes;
 	});
@@ -407,6 +417,94 @@ export const toCaptureManifest = (
 			: [],
 	),
 });
+
+/**
+ * One completed run's reconstructed spend plus the identity of the run that produced it — the
+ * epic's **spend row** (#4779). Every attribution field is copied onto the row rather than left on
+ * the ledger header, because a row is meant to survive on its own: the persistence slice appends
+ * these one per line, and a line that cannot name what it measured is a number with no unit of work.
+ *
+ * `stage` here is **provenance** — the key this run was recorded under, never a pointer into the
+ * live stage table (#4977). A recorded row keeps the key it was written with, and is never re-keyed.
+ */
+export interface SpendRow {
+	readonly skillName: string;
+	readonly stage: CaptureRun["stage"];
+	readonly caseId: number;
+	readonly arm: EvalArm;
+	/** The model the run was pinned to, which is the axis a scorecard compares along. */
+	readonly model: string;
+	readonly sessionId: string;
+	readonly cliVersion: string | null;
+	/** ISO-8601 UTC, supplied by the shell — the core mints no time of its own. */
+	readonly recordedAt: string;
+	readonly spend: RunSpend;
+}
+
+/**
+ * The spend rows of a suite: one per **completed** run. A `Failed` run contributes none — it produced
+ * no measurable work, and a row for it would be a zero standing where a measurement never happened.
+ */
+export const toSpendRows = (args: {
+	readonly skillName: string;
+	readonly stage: CaptureRun["stage"];
+	readonly model: string;
+	readonly cliVersion: string | null;
+	readonly recordedAt: string;
+	readonly outcomes: ReadonlyArray<RunOutcome>;
+}): ReadonlyArray<SpendRow> =>
+	args.outcomes.flatMap((outcome) =>
+		outcome._tag === "Completed"
+			? [
+					{
+						skillName: args.skillName,
+						stage: args.stage,
+						caseId: outcome.caseId,
+						arm: outcome.arm,
+						model: args.model,
+						sessionId: outcome.sessionId,
+						cliVersion: args.cliVersion,
+						recordedAt: args.recordedAt,
+						spend: outcome.spend,
+					},
+				]
+			: [],
+	);
+
+/**
+ * A suite's summed spend, alongside the count of rows that contributed nothing to it. The two
+ * unmeasured counts are part of the total, not a footnote: a bare `billed` says nothing about how
+ * many runs it covers, and a reader who cannot see the gap will read it as covering all of them.
+ */
+export interface SuiteSpend {
+	readonly measured: number;
+	readonly noBilledTurns: number;
+	readonly transcriptMissing: number;
+	readonly billed: number;
+	readonly exCacheRead: number;
+}
+
+export const totalSpend = (rows: ReadonlyArray<SpendRow>): SuiteSpend => {
+	let measured = 0;
+	let noBilledTurns = 0;
+	let transcriptMissing = 0;
+	let billed = 0;
+	let exCacheRead = 0;
+	for (const row of rows) {
+		if (row.spend._tag === "NoBilledTurns") {
+			noBilledTurns += 1;
+			continue;
+		}
+		if (row.spend._tag === "TranscriptMissing") {
+			transcriptMissing += 1;
+			continue;
+		}
+		measured += 1;
+		billed += row.spend.spend.billed;
+		exCacheRead += row.spend.spend.exCacheRead;
+	}
+	return {measured, noBilledTurns, transcriptMissing, billed, exCacheRead};
+};
 
 /** The counted shape of a suite: how many ran, how many died, and of what. */
 export interface RunSummary {
@@ -467,8 +565,11 @@ export interface RunLedger {
 	readonly stage: CaptureRun["stage"];
 	readonly model: string;
 	readonly cliVersion: string | null;
+	/** When the suite was recorded, ISO-8601 UTC — stamped once and copied onto every spend row. */
+	readonly recordedAt: string;
 	readonly runs: ReadonlyArray<RunOutcome>;
 	readonly capture: CaptureManifest;
+	readonly spendRows: ReadonlyArray<SpendRow>;
 	readonly summary: RunSummary;
 }
 
@@ -477,6 +578,7 @@ export const buildLedger = (args: {
 	readonly stage: CaptureRun["stage"];
 	readonly model: string;
 	readonly cliVersion: string | null;
+	readonly recordedAt: string;
 	readonly outcomes: ReadonlyArray<RunOutcome>;
 }): RunLedger => ({
 	version: 1,
@@ -484,8 +586,10 @@ export const buildLedger = (args: {
 	stage: args.stage,
 	model: args.model,
 	cliVersion: args.cliVersion,
+	recordedAt: args.recordedAt,
 	runs: args.outcomes,
 	capture: toCaptureManifest(args.stage, args.outcomes),
+	spendRows: toSpendRows(args),
 	summary: summarizeRuns(args.outcomes),
 });
 
@@ -514,18 +618,41 @@ export const ledgerToJson = (ledger: RunLedger): string => `${JSON.stringify(led
 export const captureToJson = (capture: CaptureManifest): string =>
 	`${JSON.stringify(capture, null, 2)}\n`;
 
+/**
+ * The two figures for one run, or the named reason there are none. An unmeasured run reads
+ * `n/a (…)` rather than `0`, because the whole point of the three-arm union is that those are
+ * different facts and a rendered `0` would erase the difference at the last step.
+ */
+const renderRunSpend = (spend: RunSpend): string => {
+	if (spend._tag === "TranscriptMissing") return "billed n/a (transcript missing)";
+	if (spend._tag === "NoBilledTurns") return "billed n/a (no billed turns)";
+	return `billed ${spend.spend.billed}, ex-cache-read ${spend.spend.exCacheRead}`;
+};
+
+/** The suite total, and the gap it does not cover. A suite that measured nothing prints no figures. */
+const renderSuiteSpend = (total: SuiteSpend): string => {
+	const unmeasured = [
+		total.transcriptMissing > 0 ? `${total.transcriptMissing} transcript-missing` : null,
+		total.noBilledTurns > 0 ? `${total.noBilledTurns} no-billed-turns` : null,
+	].filter((part) => part !== null);
+	const gap = unmeasured.length === 0 ? "" : ` (${unmeasured.join(", ")})`;
+	if (total.measured === 0) return `  spend: unmeasured — 0 measured run(s)${gap}`;
+	return `  spend: billed ${total.billed} · ex-cache-read ${total.exCacheRead} over ${total.measured} measured run(s)${gap}`;
+};
+
 /** A one-line-per-run human rendering, so an operator sees which arm died of what without a jq. */
 export const renderLedger = (ledger: RunLedger): string => {
 	const lines = [
 		`fabrika eval run: ${ledger.skillName} · stage ${ledger.stage} · model ${ledger.model}`,
 		...ledger.runs.map((outcome) =>
 			outcome._tag === "Completed"
-				? `  case ${outcome.caseId} [${outcome.arm}] ok — ${outcome.numTurns} turns, transcript ${outcome.transcriptPath}`
+				? `  case ${outcome.caseId} [${outcome.arm}] ok — ${outcome.numTurns} turns, ${renderRunSpend(outcome.spend)}, transcript ${outcome.transcriptPath}`
 				: `  case ${outcome.caseId} [${outcome.arm}] FAILED — ${outcome.failure._tag}${
 						outcome.failure._tag === "NoModelTurns" ? `:${outcome.failure.signal}` : ""
 					}`,
 		),
 		`  planned ${ledger.summary.planned} · collected ${ledger.summary.completed} · failed ${ledger.summary.failed}`,
+		renderSuiteSpend(totalSpend(ledger.spendRows)),
 	];
 	return lines.join("\n");
 };

--- a/packages/fabrika-cli/src/eval/spawn.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/spawn.unit.test.ts
@@ -31,9 +31,11 @@ import {
 	planEvalRuns,
 	type RunnableCase,
 	type RunOutcome,
+	renderLedger,
 	suiteExecuted,
 	summarizeRuns,
 	toCaptureManifest,
+	totalSpend,
 } from "./spawn.ts";
 
 const CASES: ReadonlyArray<RunnableCase> = [
@@ -109,12 +111,15 @@ const billedTranscript = JSON.stringify({
 	},
 });
 
+/** Parses cleanly, carries no assistant turn: the well-formed zero `NoBilledTurns` exists to name. */
+const NO_BILLED_TRANSCRIPT = '{"type":"summary"}';
+
 const completedRun = (over: Partial<Parameters<typeof classifyRun>[0]> = {}): RunOutcome =>
 	classifyRun({
 		plan: plan(),
 		exec: exited(resultStdout()),
 		transcriptPath: "/data/projects/x/s.jsonl",
-		assistantTurns: 3,
+		spend: classifyRunSpend(billedTranscript),
 		...over,
 	});
 
@@ -252,7 +257,7 @@ describe("classifyRun — the synthesized failure signal for a silent green (#46
 			plan: plan(),
 			exec: exited(SILENT_GREEN_STDOUT, 0),
 			transcriptPath: "/data/projects/x/s.jsonl",
-			assistantTurns: 0,
+			spend: classifyRunSpend(NO_BILLED_TRANSCRIPT),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed") return;
@@ -266,7 +271,7 @@ describe("classifyRun — the synthesized failure signal for a silent green (#46
 			plan: plan(),
 			exec: exited(resultStdout({num_turns: 0, result: "ok"})),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 4,
+			spend: classifyRunSpend(billedTranscript),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 	});
@@ -276,7 +281,7 @@ describe("classifyRun — the synthesized failure signal for a silent green (#46
 			plan: plan(),
 			exec: exited(resultStdout({modelUsage: {}})),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 4,
+			spend: classifyRunSpend(billedTranscript),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed" || outcome.failure._tag !== "NoModelTurns") return;
@@ -288,7 +293,7 @@ describe("classifyRun — the synthesized failure signal for a silent green (#46
 			plan: plan(),
 			exec: exited(resultStdout()),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 0,
+			spend: classifyRunSpend(NO_BILLED_TRANSCRIPT),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed" || outcome.failure._tag !== "NoModelTurns") return;
@@ -300,7 +305,7 @@ describe("classifyRun — the synthesized failure signal for a silent green (#46
 			plan: plan({jsonSchema: '{"type":"object"}'}),
 			exec: exited(resultStdout()),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 4,
+			spend: classifyRunSpend(billedTranscript),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed" || outcome.failure._tag !== "NoModelTurns") return;
@@ -312,7 +317,7 @@ describe("classifyRun — the synthesized failure signal for a silent green (#46
 			plan: plan({jsonSchema: '{"type":"object"}'}),
 			exec: exited(resultStdout({structured_output: {verdict: "ok"}})),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 4,
+			spend: classifyRunSpend(billedTranscript),
 		});
 		assert.strictEqual(outcome._tag, "Completed");
 		if (outcome._tag !== "Completed") return;
@@ -326,7 +331,7 @@ describe("classifyRun — a dying run is a typed counted outcome, never a crash"
 			plan: plan(),
 			exec: {_tag: "SpawnFailed", detail: "ENOENT: claude not found"},
 			transcriptPath: null,
-			assistantTurns: null,
+			spend: classifyRunSpend(null),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed") return;
@@ -338,7 +343,7 @@ describe("classifyRun — a dying run is a typed counted outcome, never a crash"
 			plan: plan(),
 			exec: {_tag: "TimedOut", boundMs: 900_000},
 			transcriptPath: null,
-			assistantTurns: null,
+			spend: classifyRunSpend(null),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed" || outcome.failure._tag !== "TimedOut") return;
@@ -350,7 +355,7 @@ describe("classifyRun — a dying run is a typed counted outcome, never a crash"
 			plan: plan(),
 			exec: exited("<html>gateway error</html>", 1),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 4,
+			spend: classifyRunSpend(billedTranscript),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed") return;
@@ -362,7 +367,7 @@ describe("classifyRun — a dying run is a typed counted outcome, never a crash"
 			plan: plan(),
 			exec: exited(resultStdout({is_error: true, subtype: "error_during_execution"})),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 4,
+			spend: classifyRunSpend(billedTranscript),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed") return;
@@ -374,7 +379,7 @@ describe("classifyRun — a dying run is a typed counted outcome, never a crash"
 			plan: plan(),
 			exec: exited(resultStdout()),
 			transcriptPath: null,
-			assistantTurns: null,
+			spend: classifyRunSpend(null),
 		});
 		assert.strictEqual(outcome._tag, "Failed");
 		if (outcome._tag !== "Failed") return;
@@ -446,6 +451,7 @@ describe("executeRuns — the suite completes, against a stubbed executor", () =
 			stage: "triage",
 			model: "sonnet",
 			cliVersion: "2.1.220",
+			recordedAt: "2026-08-09T00:00:00Z",
 			outcomes,
 		});
 		assert.strictEqual(ledger.summary.byArm["with-skill"].completed, 1);
@@ -483,7 +489,7 @@ describe("toCaptureManifest — the existing collector consumes it unchanged", (
 				plan: plan({caseId: 2}),
 				exec: exited(SILENT_GREEN_STDOUT),
 				transcriptPath: "/t.jsonl",
-				assistantTurns: 0,
+				spend: classifyRunSpend(NO_BILLED_TRANSCRIPT),
 			}),
 		];
 		const capture = toCaptureManifest("triage", outcomes);
@@ -516,7 +522,7 @@ describe("toCaptureManifest — the existing collector consumes it unchanged", (
 				resultStdout({structured_output: {type: "bug", priority: "p0", status: "triaged"}}),
 			),
 			transcriptPath: "/t.jsonl",
-			assistantTurns: 3,
+			spend: classifyRunSpend(billedTranscript),
 		});
 		const rows = Effect.runSync(
 			collectFromCapture({
@@ -543,7 +549,7 @@ describe("suiteExecuted — fails closed on zero scope and on any dead run (ADR 
 				plan: plan({caseId: 2}),
 				exec: {_tag: "TimedOut", boundMs: 1},
 				transcriptPath: null,
-				assistantTurns: null,
+				spend: classifyRunSpend(null),
 			}),
 		];
 		assert.isFalse(suiteExecuted(summarizeRuns(outcomes)));
@@ -565,6 +571,144 @@ describe("RunSpend's third arm — a well-formed zero is not a free run", () => 
 
 	it("an absent transcript stays TranscriptMissing", () => {
 		assert.strictEqual(classifyRunSpend(null)._tag, "TranscriptMissing");
+	});
+});
+
+/**
+ * #5008: the reconstructed spend stops being thrown away. The suite below drives the whole path —
+ * stubbed executor, stubbed transcript loader, no model call and no spawn — and its centre of gravity
+ * is the states that are NOT a number: a run whose transcript went missing and a run that billed
+ * nothing must each stay their own recorded state rather than collapse into a measured zero.
+ */
+describe("recorded spend — every completed run's number, attributed to the run that produced it", () => {
+	const ONE_RULER = readFileSync(
+		fileURLToPath(new URL("../spend/fixtures/one-ruler/transcript.jsonl", import.meta.url)),
+		"utf8",
+	);
+	const ONE_RULER_EXPECTED = JSON.parse(
+		readFileSync(
+			fileURLToPath(new URL("../spend/fixtures/one-ruler/expected.json", import.meta.url)),
+			"utf8",
+		),
+	) as {billed: number; exCacheRead: number};
+
+	const suite = {
+		skillName: "probe",
+		stage: "triage",
+		model: "sonnet",
+		cliVersion: "2.1.220",
+		recordedAt: "2026-08-09T00:00:00Z",
+	} as const;
+
+	const ledgerOver = (loadTranscript: () => Effect.Effect<string | null>) => {
+		const plans = Effect.runSync(
+			planEvalRuns({
+				cases: [CASES[0] as RunnableCase],
+				arms: BOTH_ARMS,
+				model: suite.model,
+				pluginDir: "/candidate",
+				jsonSchema: null,
+				sessionId: (id, arm) => Effect.succeed(`${id}-${arm}`),
+			}),
+		);
+		const outcomes = Effect.runSync(
+			executeRuns({
+				plans,
+				executor: () => Effect.succeed(exited(resultStdout())),
+				locateTranscript: (sessionId) => Effect.succeed(`/data/${sessionId}.jsonl`),
+				loadTranscript,
+			}),
+		);
+		return buildLedger({...suite, outcomes});
+	};
+
+	it("carries every attribution field on each completed run's row", () => {
+		const ledger = ledgerOver(() => Effect.succeed(ONE_RULER));
+		assert.strictEqual(ledger.spendRows.length, 2);
+		assert.deepStrictEqual(ledger.spendRows[0], {
+			skillName: "probe",
+			stage: "triage",
+			caseId: 1,
+			arm: "with-skill",
+			model: "sonnet",
+			sessionId: "1-with-skill",
+			cliVersion: "2.1.220",
+			recordedAt: "2026-08-09T00:00:00Z",
+			spend: classifyRunSpend(ONE_RULER),
+		});
+		assert.strictEqual(ledger.spendRows[1]?.arm, "without-skill");
+	});
+
+	it("takes its figures from the shared one-ruler meter rather than a second sum", () => {
+		const row = ledgerOver(() => Effect.succeed(ONE_RULER)).spendRows[0];
+		assert.strictEqual(row?.spend._tag, "Reconstructed");
+		if (row?.spend._tag !== "Reconstructed") return;
+		assert.strictEqual(row.spend.spend.billed, ONE_RULER_EXPECTED.billed);
+		assert.strictEqual(row.spend.spend.exCacheRead, ONE_RULER_EXPECTED.exCacheRead);
+	});
+
+	it("records a completed run whose transcript went missing as TranscriptMissing, never a zero", () => {
+		const ledger = ledgerOver(() => Effect.succeed(null));
+		assert.strictEqual(ledger.spendRows.length, 2);
+		assert.strictEqual(ledger.spendRows[0]?.spend._tag, "TranscriptMissing");
+		assert.strictEqual(totalSpend(ledger.spendRows).measured, 0);
+		assert.strictEqual(totalSpend(ledger.spendRows).transcriptMissing, 2);
+	});
+
+	it("keeps a zero-billed-turn run its own state — counted as a dead run, never a spend row", () => {
+		const ledger = ledgerOver(() => Effect.succeed('{"type":"summary"}'));
+		assert.deepStrictEqual(ledger.spendRows, []);
+		assert.strictEqual(ledger.summary.byFailure["NoModelTurns:zero-assistant-turns"], 2);
+	});
+
+	it("gives a failed run no spend row at all", () => {
+		const ledger = buildLedger({
+			...suite,
+			outcomes: [
+				completedRun({spend: classifyRunSpend(ONE_RULER)}),
+				classifyRun({
+					plan: plan({caseId: 2}),
+					exec: {_tag: "TimedOut", boundMs: 1},
+					transcriptPath: null,
+					spend: classifyRunSpend(null),
+				}),
+			],
+		});
+		assert.strictEqual(ledger.spendRows.length, 1);
+		assert.strictEqual(ledger.spendRows[0]?.caseId, 1);
+	});
+
+	it("totals only the measured rows and names the ones it could not measure", () => {
+		const rows = buildLedger({
+			...suite,
+			outcomes: [
+				completedRun({spend: classifyRunSpend(ONE_RULER)}),
+				completedRun({plan: plan({caseId: 2}), spend: classifyRunSpend(null)}),
+			],
+		}).spendRows;
+		assert.deepStrictEqual(totalSpend(rows), {
+			measured: 1,
+			noBilledTurns: 0,
+			transcriptMissing: 1,
+			billed: ONE_RULER_EXPECTED.billed,
+			exCacheRead: ONE_RULER_EXPECTED.exCacheRead,
+		});
+	});
+
+	it("prints per-run billed and ex-cache-read figures plus a suite total", () => {
+		const rendered = renderLedger(ledgerOver(() => Effect.succeed(ONE_RULER)));
+		assert.include(rendered, `billed ${ONE_RULER_EXPECTED.billed}`);
+		assert.include(rendered, `ex-cache-read ${ONE_RULER_EXPECTED.exCacheRead}`);
+		assert.include(rendered, `spend: billed ${ONE_RULER_EXPECTED.billed * 2}`);
+		assert.include(rendered, `ex-cache-read ${ONE_RULER_EXPECTED.exCacheRead * 2}`);
+		assert.include(rendered, "2 measured run(s)");
+	});
+
+	it("says a run's spend is unmeasured rather than printing it as 0", () => {
+		const rendered = renderLedger(ledgerOver(() => Effect.succeed(null)));
+		assert.include(rendered, "billed n/a (transcript missing)");
+		assert.notInclude(rendered, "billed 0");
+		assert.include(rendered, "0 measured run(s)");
 	});
 });
 


### PR DESCRIPTION
`fabrika eval run` already worked out what every run cost — it read each run's transcript to catch a run that reported success without ever reaching a model — and then threw the number away. This keeps it: every completed run now carries its spend, tagged with the run that produced it (skill, stage, case, arm, model, session, CLI version, timestamp), and the run summary prints per-run figures plus a suite total. Nothing new is measured and nothing new can block: the numbers come from the meter that already existed, and this change in fact deletes the runner's second call into it.

Fixes #5008

## What changed

- `RunOutcome.Completed` carries the run's `RunSpend`. The three-arm union is reused verbatim, so "the transcript was missing" stays visibly different from a real zero.
- `classifyRun` takes that `RunSpend` in place of a bare `assistantTurns` count and derives the count from it — a turn count that disagrees with the spend it was measured from is now unrepresentable.
- `RunLedger` gains `spendRows` (one **spend row** per completed run, each self-contained) and `recordedAt`. A `Failed` run contributes no row.
- `renderLedger` prints per-run `billed` / `ex-cache-read` and a suite total, and prints `n/a (transcript missing)` — never `0` — for a run it could not measure. A suite that measured nothing prints `spend: unmeasured` rather than a `billed 0` total.
- `eval/README.md` documents the recorded spend.

Files touched: `packages/fabrika-cli/src/eval/spawn.ts`, `spawn.unit.test.ts`, `command.ts`, `README.md`. `runner.ts` is read-only here — `RunSpend` and `classifyRunSpend` are reused, not edited.

## Acceptance criteria

- [x] Every `Completed` run carries its reconstructed spend and its attribution fields.
- [x] A missing transcript and a zero-billed-turn run stay distinct states; neither is a measured zero. (A zero-billed-turn run never reaches a spend row — the pre-existing silent-green guard already classifies it as the counted `NoModelTurns:zero-assistant-turns` failure. A completed run whose transcript could not be loaded is the `TranscriptMissing` row.)
- [x] A `Failed` run contributes no spend row.
- [x] `renderLedger` prints per-run billed and ex-cache-read figures plus a suite total.
- [x] Unit coverage drives the whole path with a stubbed executor and a stubbed transcript loader — no model call, no process spawn.
- [x] Figures come from `spend/token-spend.ts`; no second four-component sum. The new tests pin the recorded figures to the shared `one-ruler` fixture, and the runner's own second `reconstructSpend` call is removed.
- [x] No session-start, session-end or tool-call hook added.

Verified: `pnpm typecheck --force` (30/30, 0 cached), `pnpm lint:worktree`, `pnpm vitest run` in `packages/fabrika-cli` (1297 passed). The eight new tests were written first and each failed for its intended reason before the implementation landed.

## Deviations

- **Changed a signature the issue did not ask me to change.** Said: attach the reconstructed spend to each `Completed` outcome. Did: also replaced `classifyRun`'s `assistantTurns: number | null` parameter with `spend: RunSpend`, deriving the turn count inside. Why: passing both would let a caller hand in a count that contradicts its own spend, and the existing call site would then reconstruct the same transcript twice — one of those sums is the second meter the issue forbids. Disposition: no action needed; it is a strictly narrower input and every call site is in this package.
- **Rendered an unmeasured suite as `spend: unmeasured` rather than a zero total.** Said: print a suite total. Did: when no run was measured, print `spend: unmeasured — 0 measured run(s) (N transcript-missing)` instead of `billed 0`. Why: a `billed 0` total reads exactly like a suite that genuinely cost nothing, which is the fabricated zero the union exists to prevent, arriving one layer later. Disposition: for the reviewer to judge.
- **Touched a file the issue did not name.** Said: `spawn.ts` / `RunLedger` / `renderLedger`. Did: also `eval/command.ts` (to supply `recordedAt`) and `eval/README.md` (to document the recorded spend). Why: the timestamp is the shell's to read so the core stays a pure function of its inputs, and an undocumented ledger field is a doc that disagrees with the source. Disposition: no action needed.
- **Cited #4977 for the recorded-key-is-provenance rule, not ADR 0244.** Said (dispatch context): honour ADR 0244's provenance rule. Did: stated the rule and cited #4977, the merged expression of it. Why: ADR 0244 is not on `main` yet, so a link to it would be dead on merge. Disposition: no action needed; a follow-up may re-point the citation once 0244 lands.
- **Added no `spend/codes.ts`, and no new `spend → eval` import edge.** Said (dispatch context): decide deliberately. Did: neither. Why: this diff adds no verb and no exit code, so it needs no code module; and the spend row lives in `eval/` precisely because putting it in `spend/` would need `RunSpend` and deepen the one filed `spend → eval` cycle (#5050). Disposition: no action needed; #5050 stays a separate lane.
- **Did not land the `.glossary/TERMS.md` rows for *spend row* / *spend ledger*.** Said (epic plan): route both nouns to the register. Did: used *spend row* in code and docs, filed no glossary change. Why: the epic routes the `/glossary` invocation to the persistence and roll-up slices, once the shape they persist is settled. Disposition: owned by #5009 / #5010, not deferred silently.
