### PR TITLE
fix(fabrika): review post stamps its write time and upserts the newest comment (#5048)

### DIFF
--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -195,6 +195,7 @@ const post = leafCommand(
 				json,
 				env: process.env,
 				stdin: Effect.sync(readStdin),
+				now: Effect.sync(() => Date.now()),
 			}),
 		);
 	}),

--- a/packages/fabrika-cli/src/review/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/review/fixtures.test-support.ts
@@ -39,14 +39,14 @@ export const checkRuns = (
 ): ExecResult => okOut(JSON.stringify({total_count: declared, check_runs: runs}));
 
 export const comments = (
-	...rows: ReadonlyArray<{id: number; body: string; author?: string}>
+	...rows: ReadonlyArray<{id: number; body: string; author?: string; createdAt?: string}>
 ): ExecResult =>
 	okOut(
 		JSON.stringify(
 			rows.map((row) => ({
 				id: row.id,
 				user: {login: row.author ?? "kampus-bot"},
-				created_at: "2026-08-08T00:00:00Z",
+				created_at: row.createdAt ?? "2026-08-08T00:00:00Z",
 				body: row.body,
 			})),
 		),

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -49,6 +49,10 @@ const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4287 -f body=/;
 
 const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;
 
+/** The pinned write instant, and the stamp `review post` emits from it under every verdict body. */
+const NOW = Effect.succeed(Date.parse("2026-08-09T06:30:00.412Z"));
+const STAMP = "Verdict-written: 2026-08-09T06:30:00Z";
+
 const withShell = <A>(
 	effect: Effect.Effect<A, never, ChildProcessSpawner.ChildProcessSpawner>,
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
@@ -174,6 +178,7 @@ describe("the leak predicate over the assembled verdict", () => {
 		json: false,
 		env: ENV,
 		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: LEAKY}),
+		now: NOW,
 	};
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull()],
@@ -185,7 +190,7 @@ describe("the leak predicate over the assembled verdict", () => {
 			READBACK,
 			okOut(
 				JSON.stringify({
-					body: `review-doc: PASS @ ${HEAD} — guide matches shipped behavior\n\n${LEAKY}`,
+					body: `review-doc: PASS @ ${HEAD} — guide matches shipped behavior\n\n${LEAKY}\n\n${STAMP}`,
 				}),
 			),
 		],
@@ -225,6 +230,7 @@ describe("normalizeForReadback's trailing-newline step", () => {
 		json: false,
 		env: ENV,
 		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "the table\n"}),
+		now: NOW,
 	};
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull()],
@@ -236,7 +242,7 @@ describe("normalizeForReadback's trailing-newline step", () => {
 			READBACK,
 			okOut(
 				JSON.stringify({
-					body: `review-doc: PASS @ ${HEAD} — guide matches shipped behavior   \n\nthe table\n\n\n`,
+					body: `review-doc: PASS @ ${HEAD} — guide matches shipped behavior   \n\nthe table\n\n${STAMP}\n\n\n`,
 				}),
 			),
 		],

--- a/packages/fabrika-cli/src/review/post-verb.ts
+++ b/packages/fabrika-cli/src/review/post-verb.ts
@@ -2,8 +2,9 @@
  * `review post` — the single sanctioned verdict emit.
  *
  * Six steps, each gating the next: recompute the class set, re-resolve the live head, compose the
- * first line through the wire format's `emit`, leak-scan the assembled comment, upsert **one comment
- * per namespace**, and read it back unconditionally from live PR state.
+ * first line through the wire format's `emit` (stamping the write-recency line under it), leak-scan
+ * the assembled comment, upsert **one comment per namespace**, and read it back unconditionally from
+ * live PR state.
  *
  * Every one of those is a scar. #3173's hand-rolled `gh api` emit posted a literal path and
  * self-reported a false PASS, which is why the read-back re-fetches instead of trusting a carried
@@ -38,6 +39,7 @@ import {
 	WRITE_UNKNOWN,
 } from "./codes.ts";
 import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+import {latestByWriteRecency, stampIso, withWrittenAt} from "./write-recency.ts";
 
 const VERB = "review post";
 
@@ -62,6 +64,8 @@ export interface PostOptions {
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
 	readonly stdin: Effect.Effect<StdinRead>;
+	/** The wall clock the write-recency stamp is taken from — a port so a test can pin the instant. */
+	readonly now: Effect.Effect<number>;
 }
 
 interface Posted {
@@ -242,7 +246,10 @@ export const runPost = (
 				: emitMarker({namespace, polarity: polarity as Polarity, sha: inspected, clause});
 		const below =
 			carrier === "advisory" ? `${reviewedHeadLine(inspected)}\n\n${authored.text}` : authored.text;
-		const composed = `${firstLine}\n${below}`;
+		// The stamp goes on here, before the leak scan and before the body is used as the read-back
+		// comparand, so the bytes that are scanned, posted and compared are one string — and so both
+		// the create and the edit path carry it by construction rather than by remembering to.
+		const composed = withWrittenAt(`${firstLine}\n${below}`, stampIso(yield* options.now));
 
 		// Step 4 — the scan runs over the ASSEMBLED comment, so nothing this verb appended escapes it.
 		const leaked = leakRefusal(SURFACE, composed);
@@ -253,9 +260,14 @@ export const runPost = (
 		if (me._tag === "Failure") return unreadable("the authenticated user", pr, me.reason);
 		const comments = yield* listComments(repo, pr);
 		if (comments._tag === "Failure") return unreadable("the comments", pr, comments.reason);
-		const mine = comments.value.find(
-			(comment) =>
-				comment.author === me.value && carriesNamespace(comment.body, carrier, namespace),
+		// The NEWEST match, by write-recency — the same end of the order the resolver reads from. The
+		// list arrives oldest-first, so taking the first match edited the comment least likely to be
+		// in force, and the edit landed where nobody reads (#5048).
+		const mine = latestByWriteRecency(
+			comments.value.filter(
+				(comment) =>
+					comment.author === me.value && carriesNamespace(comment.body, carrier, namespace),
+			),
 		);
 
 		let landed: {readonly id: number; readonly url: string} | null = null;

--- a/packages/fabrika-cli/src/review/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/post-verb.unit.test.ts
@@ -30,7 +30,17 @@ const URL = "https://example.test/pull/4321#issuecomment-5154902211";
 const MARKER = `review-doc: PASS @ ${HEAD} — guide matches shipped behavior`;
 
 const created = okOut(JSON.stringify({id: 5154902211, html_url: URL}));
-const commentBody = (body: string): ExecResult => okOut(JSON.stringify({body}));
+
+/** The instant every run below writes its verdict at, so the stamp the verb emits is predictable. */
+const NOW = Date.parse("2026-08-09T06:30:00.412Z");
+const STAMP = "Verdict-written: 2026-08-09T06:30:00Z";
+
+/**
+ * A read-back of `body` as the verb will have posted it — stamped, since the stamp is part of the
+ * bytes the verb sends and therefore part of what its whole-comment comparison expects back.
+ */
+const commentBody = (body: string): ExecResult =>
+	okOut(JSON.stringify({body: `${body.replace(/\s+$/, "")}\n\n${STAMP}`}));
 
 const options = {
 	pr: 4321,
@@ -43,6 +53,7 @@ const options = {
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: BODY}),
+	now: Effect.succeed(NOW),
 };
 
 const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
@@ -96,6 +107,91 @@ describe("runPost", () => {
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tedited\t");
 		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("stamps the write-recency line on the comment it creates", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
+		expect(write).toContain(STAMP);
+	});
+
+	it("stamps the write-recency line on the comment it edits, too", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 1})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments({id: 42, body: `review-doc: FAIL @ ${OLD_HEAD} — older round`})],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+		]);
+		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		const write = shell.calls.find((call) => PATCH.test(call)) ?? "";
+		expect(write).toContain(STAMP);
+	});
+
+	// The pre-#5048 upsert took the FIRST match, and the list arrives oldest-first — so on a namespace
+	// that already holds two of this author's comments it edited the one the resolver is least likely
+	// to be reading, and reported success.
+	it("edits the NEWEST comment in the namespace when two of this author's already exist", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 2})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[
+				COMMENTS,
+				comments(
+					{
+						id: 42,
+						createdAt: "2026-08-09T03:46:59Z",
+						body: `review-doc: FAIL @ ${OLD_HEAD} — the older duplicate`,
+					},
+					{
+						id: 77,
+						createdAt: "2026-08-09T04:05:28Z",
+						body: `review-doc: FAIL @ ${OLD_HEAD} — the newer duplicate`,
+					},
+				),
+			],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tedited\t");
+		expect(shell.calls.find((call) => PATCH.test(call))).toContain("/issues/comments/77 ");
+		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	// The case slot-creation time gets backwards, and the reason the stamp is the key: comment 42's
+	// slot is the older one, but its verdict was REWRITTEN into that slot after 77 was created. A PATCH
+	// leaves `created_at` where it was, so only the stamp can say 42 now carries the later verdict.
+	it("ranks by the write-recency stamp, not by when the comment slot was opened", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 2})],
+			[FILES, files("src/cart.ts", "README.md")],
+			[USER, okOut("kampus-bot")],
+			[
+				COMMENTS,
+				comments(
+					{
+						id: 42,
+						createdAt: "2026-08-09T03:46:59Z",
+						body: `review-doc: FAIL @ ${OLD_HEAD} — re-posted in place\n\nVerdict-written: 2026-08-09T05:10:00Z`,
+					},
+					{
+						id: 77,
+						createdAt: "2026-08-09T04:05:28Z",
+						body: `review-doc: FAIL @ ${OLD_HEAD} — the newer slot, older verdict`,
+					},
+				),
+			],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls.find((call) => PATCH.test(call))).toContain("/issues/comments/42 ");
 	});
 
 	it("does not edit another author's comment in the same namespace", async () => {

--- a/packages/fabrika-cli/src/review/write-recency.ts
+++ b/packages/fabrika-cli/src/review/write-recency.ts
@@ -1,0 +1,94 @@
+/**
+ * The write-recency stamp: when a verdict was **written**, as distinct from when the comment slot
+ * carrying it was opened.
+ *
+ * `review post` upserts in place — one comment per namespace — so a corrected verdict is PATCHed
+ * into the slot the first one opened. A PATCH does not move `created_at`, so slot-creation time
+ * says nothing about which of two live-head verdicts is the current one: a FAIL corrected into an
+ * old slot reads as OLDER than an advisory merely created later, and the reader that takes the
+ * latest consumes the superseded artifact. That reader is the enqueue gate, and the direction it
+ * fails in is fail-OPEN.
+ *
+ * The stamp is the only field that moves with the verdict, so it is the ordering key and
+ * `created_at` is only its floor ({@link writeRecencyOf}). Deliberately a body-carried line rather
+ * than the REST `updated_at`: `updated_at` moves on any byte edit — a typo fix, a leak redaction —
+ * so a cosmetic touch of the older verdict would silently re-crown it, and invisibly, since
+ * `updated_at` is not rendered anywhere a human reads.
+ *
+ * The bytes are ADR 0058 / v1's `Verdict-written:` line, reimplemented here and never called
+ * (ADR 0238) — the same relationship `./advisory.ts` has to ADR 0151's carrier. They must stay
+ * byte-identical, because v1's `packages/pipeline-cli/src/tools/verdict/verdict-match.ts` is the
+ * consumer that resolves which verdict a gate acts on; `./write-recency.unit.test.ts` pins the
+ * emitted line against that consumer's own matcher so the interop cannot drift unnoticed.
+ */
+
+/**
+ * The stamp line. `g` for {@link writtenAtOf}'s `matchAll` and {@link withWrittenAt}'s replace,
+ * `m` so it anchors per line, `i` because a hand-typed stamp is still a stamp.
+ *
+ * Second precision is load-bearing, not cosmetic: the stamp is compared **lexically** against
+ * `created_at`, and `2026-08-09T04:05:28.123Z` sorts below `2026-08-09T04:05:28Z` (`.` < `Z`) — a
+ * millisecond-precision stamp would read as older than a slot opened in the same second, an
+ * inversion in exactly the tight race this key exists to order.
+ */
+const WRITTEN_AT = /^[ \t]*Verdict-written:[ \t]*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)[ \t]*$/gim;
+
+/** An instant in the stamp's second-precision ISO-8601 UTC shape — `created_at`'s exact shape. */
+export const stampIso = (epochMillis: number): string =>
+	new Date(epochMillis).toISOString().replace(/\.\d{3}Z$/, "Z");
+
+/**
+ * Stamp `iso` onto a verdict body, replacing any stamp it already carries.
+ *
+ * Replacing rather than appending is what keeps a re-post orderable: a body that accumulated two
+ * stamps would order by whichever one the reader happened to take.
+ */
+export const withWrittenAt = (body: string, iso: string): string =>
+	`${body.replace(WRITTEN_AT, "").replace(/\s+$/, "")}\n\nVerdict-written: ${iso}`;
+
+/**
+ * The write time a body stamps on itself, or `null` for an unstamped one. Takes the LAST match, so
+ * a verdict whose prose quotes an earlier stamp still resolves to its own.
+ */
+export const writtenAtOf = (body: string): string | null => {
+	let last: string | null = null;
+	for (const match of body.matchAll(WRITTEN_AT)) last = match[1] ?? last;
+	return last;
+};
+
+/** The fields recency is decided from — structurally satisfied by `../io/issues.ts`'s comment. */
+export interface RecencyComment {
+	readonly id: number;
+	readonly createdAt: string;
+	readonly body: string;
+}
+
+/**
+ * When a comment's verdict was written: its stamp, floored at `created_at`.
+ *
+ * The floor is the fail-safe. A verdict cannot have been written before its slot existed, so an
+ * unstamped body — every comment posted before this landed, and every one hand-rolled through raw
+ * `gh api` — and a backdated stamp both degrade to plain `created_at` ordering, never to something
+ * worse than the behaviour they replace.
+ */
+export const writeRecencyOf = (comment: RecencyComment): string => {
+	const stamped = writtenAtOf(comment.body);
+	return stamped !== null && stamped > comment.createdAt ? stamped : comment.createdAt;
+};
+
+/** Write-recency, then the server-assigned id — a total order, so a same-second pair still settles. */
+export const compareWriteRecency = (a: RecencyComment, b: RecencyComment): number => {
+	const ra = writeRecencyOf(a);
+	const rb = writeRecencyOf(b);
+	return ra < rb ? -1 : ra > rb ? 1 : a.id - b.id;
+};
+
+/**
+ * The newest of `comments` by write-recency, or `undefined` for an empty set.
+ *
+ * The upsert's pick. Taking the first match instead — the API returns comments oldest-first — edits
+ * the oldest comment in the namespace, which is the one the resolver is least likely to be reading.
+ */
+export const latestByWriteRecency = <A extends RecencyComment>(
+	comments: ReadonlyArray<A>,
+): A | undefined => [...comments].sort(compareWriteRecency)[comments.length - 1];

--- a/packages/fabrika-cli/src/review/write-recency.unit.test.ts
+++ b/packages/fabrika-cli/src/review/write-recency.unit.test.ts
@@ -1,0 +1,140 @@
+import {describe, expect, it} from "vitest";
+import {
+	compareWriteRecency,
+	latestByWriteRecency,
+	stampIso,
+	withWrittenAt,
+	writeRecencyOf,
+	writtenAtOf,
+} from "./write-recency.ts";
+
+const at = (id: number, createdAt: string, body = "review-doc: FAIL @ abc1234 — x") => ({
+	id,
+	createdAt,
+	body,
+});
+
+describe("stampIso", () => {
+	it("drops the milliseconds, so a stamp cannot sort below a created_at in the same second", () => {
+		expect(stampIso(Date.parse("2026-08-09T04:05:28.412Z"))).toBe("2026-08-09T04:05:28Z");
+		expect("2026-08-09T04:05:28.412Z" < "2026-08-09T04:05:28Z").toBe(true);
+	});
+});
+
+describe("withWrittenAt / writtenAtOf", () => {
+	it("stamps a body and reads its own stamp back", () => {
+		const body = withWrittenAt(
+			"review-doc: FAIL @ abc1234 — x\n\nthe table\n",
+			"2026-08-09T04:00:00Z",
+		);
+		expect(writtenAtOf(body)).toBe("2026-08-09T04:00:00Z");
+	});
+
+	it("replaces the prior stamp rather than stacking a second one", () => {
+		const once = withWrittenAt("verdict", "2026-08-09T04:00:00Z");
+		const twice = withWrittenAt(once, "2026-08-09T05:00:00Z");
+		expect(twice.match(/Verdict-written:/g)).toHaveLength(1);
+		expect(writtenAtOf(twice)).toBe("2026-08-09T05:00:00Z");
+	});
+
+	it("reads no stamp off an unstamped body", () => {
+		expect(writtenAtOf("review-doc: FAIL @ abc1234 — x")).toBeNull();
+	});
+
+	it("takes the LAST stamp, so a body quoting an earlier one still resolves to its own", () => {
+		const body = withWrittenAt(
+			"we corrected the verdict stamped\n\nVerdict-written: 2026-08-09T01:00:00Z\n",
+			"2026-08-09T06:00:00Z",
+		);
+		expect(writtenAtOf(body)).toBe("2026-08-09T06:00:00Z");
+	});
+});
+
+describe("writeRecencyOf — created_at is the floor, never the key", () => {
+	it("falls back to created_at for an unstamped body", () => {
+		expect(writeRecencyOf(at(1, "2026-08-09T03:00:00Z"))).toBe("2026-08-09T03:00:00Z");
+	});
+
+	it("takes the stamp when it is later than the slot", () => {
+		const body = withWrittenAt("review-doc: FAIL @ abc1234 — x", "2026-08-09T05:00:00Z");
+		expect(writeRecencyOf({id: 1, createdAt: "2026-08-09T03:00:00Z", body})).toBe(
+			"2026-08-09T05:00:00Z",
+		);
+	});
+
+	it("refuses a backdated stamp — a verdict cannot predate the slot that carries it", () => {
+		const body = withWrittenAt("review-doc: FAIL @ abc1234 — x", "2026-08-09T01:00:00Z");
+		expect(writeRecencyOf({id: 1, createdAt: "2026-08-09T03:00:00Z", body})).toBe(
+			"2026-08-09T03:00:00Z",
+		);
+	});
+});
+
+describe("compareWriteRecency", () => {
+	/**
+	 * The case the stamp exists for, in the shape the enqueue gate meets it: a marker is posted, an
+	 * advisory is written 19 minutes later, and then the marker is corrected IN PLACE. The PATCH
+	 * leaves the marker's `created_at` at the original post, so slot time ranks the superseded
+	 * advisory above the live correction. Only the stamp gets it right (#5048).
+	 */
+	it("a re-posted marker outranks an advisory created between the post and the re-post", () => {
+		const marker = {
+			id: 5229629030,
+			createdAt: "2026-08-09T03:46:59Z",
+			body: withWrittenAt(
+				"review-code: FAIL @ abc1234 — a criterion is red",
+				"2026-08-09T04:20:00Z",
+			),
+		};
+		const advisory = {
+			id: 5229688003,
+			createdAt: "2026-08-09T04:05:28Z",
+			body: "review-code: advisory — blocking-set PR\n\nReviewed-head: @ abc1234\n",
+		};
+		expect(compareWriteRecency(marker, advisory)).toBeGreaterThan(0);
+		expect(latestByWriteRecency([marker, advisory])).toBe(marker);
+		// And the defect it replaces: unstamped, the same pair ranks the other way round.
+		const unstamped = {...marker, body: "review-code: FAIL @ abc1234 — a criterion is red"};
+		expect(compareWriteRecency(unstamped, advisory)).toBeLessThan(0);
+	});
+
+	it("breaks a same-instant tie on the server-assigned id", () => {
+		expect(compareWriteRecency(at(2, "2026-08-09T04:00:00Z"), at(9, "2026-08-09T04:00:00Z"))).toBe(
+			-7,
+		);
+	});
+});
+
+describe("latestByWriteRecency", () => {
+	it("is undefined for an empty set — the fail-closed 'nothing to upsert onto'", () => {
+		expect(latestByWriteRecency([])).toBeUndefined();
+	});
+
+	it("takes the newest however the input happens to be ordered", () => {
+		const rows = [at(1, "2026-08-09T05:00:00Z"), at(2, "2026-08-09T03:00:00Z")];
+		expect(latestByWriteRecency(rows)?.id).toBe(1);
+		expect(latestByWriteRecency([...rows].reverse())?.id).toBe(1);
+	});
+});
+
+/**
+ * The interop pin. fabrika reimplements this format and never calls v1 (ADR 0238), so nothing at
+ * build time couples the two — the only thing keeping them one format is that the bytes match. The
+ * literal below is v1's own matcher, copied verbatim from
+ * `packages/pipeline-cli/src/tools/verdict/verdict-match.ts`; if this test goes red, a fabrika-posted
+ * verdict has become unorderable to the resolver the enqueue gate reads, which is the whole defect.
+ */
+describe("the emitted line is what pipeline-cli's resolver reads", () => {
+	const consumerRe =
+		/^[ \t]*Verdict-written:[ \t]*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)[ \t]*$/gim;
+
+	it("matches the consumer's matcher, capturing the instant that was stamped", () => {
+		const body = withWrittenAt(
+			"review-code: FAIL @ abc1234 — a criterion is red\n\n| criterion | verdict |\n",
+			stampIso(Date.parse("2026-08-09T04:20:00.999Z")),
+		);
+		const matches = [...body.matchAll(consumerRe)];
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.[1]).toBe("2026-08-09T04:20:00Z");
+	});
+});


### PR DESCRIPTION
When a review agent corrects a verdict, it edits the comment it already posted rather than adding a
second one. GitHub does not move a comment's creation time when you edit it, so anything posted in
between looked newer — and the gate that decides whether a PR may merge reads the newest verdict. A
correction could land, report success, and never take effect. This makes `fabrika review post` write
the time it actually wrote the verdict into the comment, and edit the newest comment in a namespace
instead of the oldest.

Fixes #5048

## What changed

- **New `packages/fabrika-cli/src/review/write-recency.ts`.** The `Verdict-written:` stamp format
  plus the ordering built on it: `stampIso`, `withWrittenAt`, `writtenAtOf`, `writeRecencyOf`
  (stamp, floored at `created_at`), `compareWriteRecency`, `latestByWriteRecency`.
- **`review post` stamps the assembled body** before the leak scan and before it is used as the
  read-back comparand, so the create path and the edit path carry the stamp by construction rather
  than by remembering to.
- **Step 5's upsert takes the newest match by write-recency**, not `.find()`'s first. The comments
  list arrives oldest-first, so the old code edited the comment least likely to be in force.
- **The write instant enters as a port** (`now` on `PostOptions`), so the emitted stamp is pinnable
  in a test.

## Which implementation is authoritative for the ordering key

**`packages/pipeline-cli/src/tools/verdict/verdict-match.ts` is authoritative**, and fabrika now
matches it. It has to be: it is the *consumer* — `pickInForce` → `compareWriteRecency`, and the
marker-vs-advisory fold `inForceOf` → `newerOf` in `gate-decision.ts` — so it is the side that
decides which verdict is in force at the enqueue gate. An emitter that ordered its own way would
change nothing about what the gate reads.

Matching it means **the same bytes and the same rules**, not the same module: fabrika calls
`pipeline-cli` nowhere, by ADR 0238, because a call is a tether that keeps the tree fabrika replaces
alive. The stamp is therefore reimplemented — the same relationship `review/advisory.ts` already has
to ADR 0151's advisory carrier. The three rules carried across verbatim: second-precision ISO-8601
UTC (a millisecond stamp sorts *below* a `created_at` in the same second, `.` < `Z`), `created_at` as
a floor and never the key, and replace-don't-stack on re-post. Because nothing at build time couples
the two copies, `write-recency.unit.test.ts` ends with an interop pin: the emitted line is matched
against the consumer's own regex, copied verbatim. If that test reds, a fabrika-posted verdict has
become unorderable to the gate.

## The deliberate PATCH case

There is no natural instance of this on the board, so the tests construct one. I checked PR #4991,
the only mixed stamped/unstamped PR: `updated_at == created_at` on all four verdict comments there,
so nothing was ever re-posted in place and `verdict gate` resolves it correctly. A test shaped like
#4991 would pass without touching the defect.

The constructed case, in `write-recency.unit.test.ts`: a `review-code: FAIL` marker in a slot created
`03:46:59Z`, an advisory created `04:05:28Z`, and the marker re-posted in place at `04:20:00Z` — the
PATCH leaves `created_at` at `03:46:59Z`. Stamped, the marker out-ranks the advisory. The same test
asserts the inverse on the unstamped body, so it fails if the stamp is ever dropped.

Three independent falsification runs, each against a deliberately broken build:

| Broken to | Which test reds |
|---|---|
| both defects restored (`.find()`, no stamp) | 12 of 26 in `post-verb.unit.test.ts` |
| `.find()` restored, stamp kept | *edits the NEWEST comment in the namespace…* |
| newest-by-`created_at` instead of by stamp | *ranks by the write-recency stamp, not by when the comment slot was opened* |

## The §CP advisory form is untouched

No change to `advisory.ts`, to `emitAdvisory`, or to the `Reviewed-head:` body line. The advisory
first line still withholds the SHA (ADR 0111), the head is still bound in the body (ADR 0151), and
`--carrier advisory --polarity FAIL` is still the `10` refusal (ADR 0226). The stamp is an added body
line under both carriers; `readAdvisory` and the read-back's advisory arm are unaffected, and the
advisory tests pass unchanged apart from the stamp appearing in their read-back fixtures.

## Should a pre-existing duplicate set be collapsed? — no, and why (AC5)

**Reasoned no-op.** Verdict comments are the append-only gate record: deleting one destroys the
history of what a gate said and when, which is the artifact ADR 0058's SHA binding exists to keep
honest. Collapsing is also unnecessary now — with the newest comment carrying the newest stamp, the
resolver and the upsert agree on the same comment, so a stale duplicate is inert rather than
shadowing. And #4995 (the foreign-comment overwrite defect) makes the direction clear: the sanctioned
way to stop a comment winning is to change the ordering key, never to mutate or remove a comment.
This PR changes the ordering key.

## Deviations

**1. Class: narrowed a suggested fix-shape.** *Said:* AC1 asks for the stamp "reusing pipeline-cli's
existing stamp semantics rather than defining a second one." *Did:* reimplemented the format in
fabrika instead of importing `pipeline-cli`. *Why:* ADR 0238 forbids fabrika importing or shelling
out to `pipeline-cli`, and `packages/fabrika-cli/package.json` depends only on `effect` — an import
would be a new cross-package dependency against a standing decision. I read "semantics, not a second
format" as the AC's intent and carried the bytes and the rules across verbatim. *Disposition:* no
action needed; the interop pin in `write-recency.unit.test.ts` is what makes "one format" checkable
from the outside.

**2. Class: left a sibling item for a follow-up.** *Said:* AC3 asks that the edited comment "is the
one `pickInForce` resolves in force". *Did:* proved the ordering with fabrika's own comparator, and
removed the test I had written against `pickInForce`/`decideNamespace` itself. *Why:*
`packages/pipeline-cli/src/tools/verdict/` is a CODEOWNERS control-plane path, so keeping that test
would have made this `packages/fabrika-cli` fix a §CP PR requiring a human merge (ADR 0053) for a
test that pins already-correct, unchanged behaviour. *Disposition:* follow-up #5057 filed with the
exact test body; it should land on its own small §CP PR.

**3. Class: changed a test that encoded the old behaviour.** *Said:* nothing. *Did:* the read-back
fixtures in `post-verb.unit.test.ts` and `mutation.unit.test.ts` now carry the stamp, and both option
literals gained the pinned `now`. *Why:* the read-back compares the whole comment against the bytes
that were sent, and the stamp is now part of those bytes — an unstamped fixture would fire exit `9`
on a clean run. No assertion was weakened. *Disposition:* no action needed.

**4. Class: spotted a sibling defect, did not fix it.** *Said:* nothing. *Did:* left
`review verdicts`' listing order alone. *Why:* `verdicts-verb.ts` prints markers "newest first" by
reversing the API's slot order, so its display order has the same slot-vs-write blind spot. It is a
listing, not a resolution — nothing decides on it — and re-ordering it is an output-format change
outside this issue's ACs. *Disposition:* for the reviewer to judge; I did not file it separately
because it is a display nit, not a gate defect.
