### PR TITLE
feat(fabrika-cli): the report's cell key carries the review surface (#4980)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -147,12 +147,12 @@ decision ([#1576](https://github.com/kamp-us/phoenix/issues/1576)) consumes. It 
 runner's graded `{entry, grade, spend}` rows into a per-(stage × model) **scorecard** on the ADR
 0112 §4 two-axis gate, now graded:
 
-- **Quality axis** — a **pass-rate** per (stage × model) over the corpus (`passedRuns / gradedRuns`),
-  the graded generalization of ADR 0112 §3's binary-per-run oracle.
+- **Quality axis** — a **pass-rate** per (stage × surface × model) over the corpus
+  (`passedRuns / gradedRuns`), the graded generalization of ADR 0112 §3's binary-per-run oracle.
 - **Token axis** — the mean **billed** + **ex-cache-read** spend per run (ADR 0112 §2), plus the
   priced **repair-churn cost** (`repair-churn.ts`): the amortized true cost of one *accepted* run
   once the extra cycles a lower pass-rate forces are amortized in.
-- **Net saving vs a baseline** — when a `baseline` (stage × model) is named, each other cell's
+- **Net saving vs a baseline** — when a `baseline` cell is named, each other cell's
   `netSaving = baseline.billedPerRun − candidate.amortizedBilledPerRun`. A **negative** net saving is
   the epic's headline risk — a per-run token saving *eaten* by repair churn — rendered as
   `NET-NEGATIVE` in the table and `netNegative: true` in the JSON, so the crossover the
@@ -167,6 +167,22 @@ Pure + total: a `TranscriptMissing` run still counts toward the pass-rate but is
 spend mean, and a cell with **no** reconstructed spend reports a `null` token axis rather than a
 fabricated zero. `buildScorecard`, `renderTable`, `toJson`, and `decodeReportInput` are the exports.
 
+#### The cell key carries the review surface
+
+A pass-rate measures **one grading regime**, so the cell key is `(stage × surface × model)` and rows
+from different review surfaces are never aggregated into a single undifferentiated `review` number
+([ADR 0243 §4](../../../../.decisions/0243-review-eval-stage-surface-discriminator.md)). The
+exported `CellIdentity` states that as a type: a `review` cell carries a `ReviewSurface`, every other
+stage carries `null`, so a bare `review` cell is unrepresentable rather than merely unproduced. The
+mixed-surface PR of ADR 0243 §3 — one `inputRef`, one row per surface — therefore reports two cells,
+each rendering its own surface. A recorded v1 `review-code` row keeps its own cell and takes the
+surfaceless arm, because its stage key is provenance, not a live `review` row
+([#4977](https://github.com/kamp-us/phoenix/issues/4977)).
+
+The baseline resolves against that same key, so it selects **at most one** cell. `--baseline-stage
+review` therefore requires `--baseline-surface`: without one it names two graders, which is refused
+at the flag rather than resolved to whichever surface buckets first.
+
 ### The CLI surface
 
 ```bash
@@ -176,8 +192,9 @@ fabrika eval report <rows.json>
 # stable machine-readable JSON — a future gate / CI consumes this
 fabrika eval report <rows.json> --json
 
-# price net saving against a baseline (stage × model)
+# price net saving against a baseline (stage × surface × model)
 fabrika eval report <rows.json> --baseline-stage build --baseline-model opus-4.8
+fabrika eval report <rows.json> --baseline-stage review --baseline-surface code --baseline-model opus-4.8
 ```
 
 `<rows.json>` is a serialized `RunRow[]` — the array `collectRuns` emits. `decodeReportInput` is
@@ -189,10 +206,11 @@ total: a malformed body or a shape mismatch exits non-zero with a typed reason, 
 {
   "decisionRef": 1576,                       // the decision this evidence feeds — never made here
   "framing": "This scorecard is measurement feeding the model-tiering decision (#1576); …",
-  "baseline": { "stage": "build", "model": "opus-4.8" } | null,
+  "baseline": { "stage": "build", "surface": null, "model": "opus-4.8" } | null,
   "cells": [
     {
       "stage": "build",
+      "surface": null,                        // "code" | "doc" on a `review` cell; null on every other stage
       "model": "opus-4.8" | null,            // reconstructed from the transcript; null when unattributable
       "gradedRuns": 3,                        // pass-rate denominator (includes transcript-missing runs)
       "passedRuns": 2,

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -27,7 +27,7 @@ import {Console, Crypto, Effect, FileSystem, Path, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
-import {decodeManifest, STAGES} from "./corpus.ts";
+import {decodeManifest, REVIEW_SURFACES, type ReviewSurface, STAGES} from "./corpus.ts";
 import {decodeIncidentProvenance} from "./incident-provenance.ts";
 import {
 	type BaselineKey,
@@ -136,8 +136,18 @@ const baselineModelFlag = Flag.string("baseline-model").pipe(
 	Flag.withDescription("the model of the baseline cell (paired with --baseline-stage)"),
 );
 
+const baselineSurfaceFlag = Flag.string("baseline-surface").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		`the review surface of the baseline cell, required with --baseline-stage review (one of: ${REVIEW_SURFACES.join(", ")})`,
+	),
+);
+
 const isStage = (s: string): s is (typeof STAGES)[number] =>
 	(STAGES as ReadonlyArray<string>).includes(s);
+
+const isReviewSurface = (s: string): s is ReviewSurface =>
+	(REVIEW_SURFACES as ReadonlyArray<string>).includes(s);
 
 const report = leafCommand(
 	"report",
@@ -146,8 +156,9 @@ const report = leafCommand(
 		json: jsonFlag,
 		baselineStage: baselineStageFlag,
 		baselineModel: baselineModelFlag,
+		baselineSurface: baselineSurfaceFlag,
 	},
-	Effect.fn(function* ({rows, json, baselineStage, baselineModel}) {
+	Effect.fn(function* ({rows, json, baselineStage, baselineModel, baselineSurface}) {
 		const run = Effect.gen(function* () {
 			const fs = yield* FileSystem.FileSystem;
 			const text = yield* Effect.mapError(
@@ -163,7 +174,10 @@ const report = leafCommand(
 			}
 
 			// A --baseline-stage that isn't one of the known stages is a user error, not a silent
-			// no-baseline: fail loudly so a typo can't quietly drop the net-saving axis.
+			// no-baseline: fail loudly so a typo can't quietly drop the net-saving axis. The surface
+			// rules below are the same discipline one level down — a `review` baseline that names no
+			// surface names no single grading regime, so it cannot identify a baseline cell at all
+			// (ADR 0243 §4).
 			let baseline: BaselineKey | undefined;
 			if (baselineStage._tag === "Some") {
 				const stage = baselineStage.value;
@@ -173,7 +187,31 @@ const report = leafCommand(
 					);
 					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
 				}
-				baseline = {stage, model: baselineModel._tag === "Some" ? baselineModel.value : null};
+				if (baselineSurface._tag === "Some" && stage !== "review") {
+					yield* Console.error(
+						`fabrika eval: --baseline-surface only applies to --baseline-stage review, not '${stage}'`,
+					);
+					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				}
+				if (stage === "review" && baselineSurface._tag === "None") {
+					yield* Console.error(
+						`fabrika eval: --baseline-stage review needs --baseline-surface (${REVIEW_SURFACES.join(", ")}) — a review pass-rate is one grading regime, never an average of two`,
+					);
+					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				}
+				const model = baselineModel._tag === "Some" ? baselineModel.value : null;
+				if (baselineSurface._tag === "Some") {
+					const surface = baselineSurface.value;
+					if (!isReviewSurface(surface)) {
+						yield* Console.error(
+							`fabrika eval: --baseline-surface '${surface}' is not a known review surface (${REVIEW_SURFACES.join(", ")})`,
+						);
+						return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					}
+					baseline = {stage, surface, model};
+				} else {
+					baseline = {stage, model};
+				}
 			}
 
 			const scorecard = buildScorecard(

--- a/packages/fabrika-cli/src/eval/report.ts
+++ b/packages/fabrika-cli/src/eval/report.ts
@@ -21,10 +21,13 @@
  * (a `TranscriptMissing` run) still COUNT toward the grade (pass-rate) and are reported as such
  * — a cell's spend is the mean over its reconstructed runs, and a cell with zero reconstructed
  * spends reports a null token axis rather than a fabricated zero.
+ *
+ * A pass-rate measures ONE grading regime, so a cell is keyed by (stage × surface × model), not
+ * stage alone: see `CellIdentity` and ADR 0243 §4.
  */
 import {Result} from "effect";
 import * as Schema from "effect/Schema";
-import {CorpusEntry} from "./corpus.ts";
+import {CorpusEntry, type ReviewSurface} from "./corpus.ts";
 import {priceModelSwap, repairChurnCost} from "./repair-churn.ts";
 import type {RunRow} from "./runner.ts";
 
@@ -55,9 +58,20 @@ export interface CellChurn {
 	readonly amortizedBilledPerRun: number;
 }
 
-/** One (stage × model) cell of the scorecard — the graded two-axis picture for that pair. */
-export interface ScorecardCell {
-	readonly stage: CorpusEntry["stage"];
+/**
+ * Which grading regime a cell's rows came from — the non-model half of the bucket key.
+ *
+ * A `review` cell MUST name the surface whose grader produced it, and every other stage carries no
+ * surface, so a bare `review` cell is unrepresentable rather than merely unproduced (ADR 0243 §4).
+ * A recorded v1 key (`review-code`) is provenance, not a live `review` row, so it takes the
+ * surfaceless arm (#4977).
+ */
+export type CellIdentity =
+	| {readonly stage: "review"; readonly surface: ReviewSurface}
+	| {readonly stage: Exclude<CorpusEntry["stage"], "review">; readonly surface: null};
+
+/** The two-axis picture for one (stage × surface × model) cell of the scorecard. */
+export type ScorecardCell = CellIdentity & {
 	/** The model the runs used, reconstructed from the transcript; `null` when unattributable. */
 	readonly model: string | null;
 	/** Total graded runs in the cell (the pass-rate denominator; includes transcript-missing). */
@@ -82,28 +96,43 @@ export interface ScorecardCell {
 	readonly netSaving: number | null;
 	/** True iff `netSaving` is a real number below zero — the unambiguous net-negative flag. */
 	readonly netNegative: boolean;
-}
+};
 
-/** The whole scorecard: the framing pointer plus one cell per (stage × model). */
+/** The whole scorecard: the framing pointer plus one cell per (stage × surface × model). */
 export interface Scorecard {
 	/** The decision this evidence feeds (#1576) — the report never makes it. */
 	readonly decisionRef: number;
 	readonly framing: string;
-	/** The (stage × model) chosen as the per-run baseline saving is measured against, if any. */
-	readonly baseline: {readonly stage: string; readonly model: string | null} | null;
+	/** The cell chosen as the per-run baseline saving is measured against, if any. */
+	readonly baseline: (CellIdentity & {readonly model: string | null}) | null;
 	readonly cells: ReadonlyArray<ScorecardCell>;
 }
 
-/** Which (stage × model) to price the other cells' net saving against. */
+/**
+ * Which cell to price the other cells' net saving against. `surface` is what makes this select at
+ * most one cell: omit it on a non-review stage, and name it on `review`, where a surfaceless key
+ * matches no cell rather than picking a grading regime arbitrarily.
+ */
 export interface BaselineKey {
 	readonly stage: CorpusEntry["stage"];
+	readonly surface?: ReviewSurface;
 	readonly model: string | null;
 }
 
-const cellKey = (stage: string, model: string | null): string => `${stage} ${model ?? ""}`;
+const identityOf = (entry: CorpusEntry): CellIdentity =>
+	entry.stage === "review"
+		? {stage: "review", surface: entry.surface}
+		: {stage: entry.stage, surface: null};
+
+// NUL-separated so no stage/surface/model value can spell a neighbouring key and merge two cells.
+const cellKey = (id: CellIdentity, model: string | null): string =>
+	`${id.stage}\u0000${id.surface ?? ""}\u0000${model ?? ""}`;
+
+const sameCell = (a: {id: CellIdentity; model: string | null}, b: BaselineKey): boolean =>
+	a.id.stage === b.stage && a.id.surface === (b.surface ?? null) && a.model === (b.model ?? null);
 
 interface Bucket {
-	readonly stage: CorpusEntry["stage"];
+	readonly id: CellIdentity;
 	readonly model: string | null;
 	graded: number;
 	passed: number;
@@ -117,11 +146,12 @@ const bucketize = (rows: ReadonlyArray<RunRow>): ReadonlyArray<Bucket> => {
 	const byKey = new Map<string, Bucket>();
 	for (const row of rows) {
 		const model = row.spend._tag === "Reconstructed" ? row.spend.spend.model : null;
-		const key = cellKey(row.entry.stage, model);
+		const id = identityOf(row.entry);
+		const key = cellKey(id, model);
 		let bucket = byKey.get(key);
 		if (bucket === undefined) {
 			bucket = {
-				stage: row.entry.stage,
+				id,
 				model,
 				graded: 0,
 				passed: 0,
@@ -173,14 +203,15 @@ const spendOf = (bucket: Bucket): CellSpend | null =>
 export const buildScorecard = (args: {
 	readonly rows: ReadonlyArray<RunRow>;
 	readonly baseline?: BaselineKey;
-	readonly tokensPerRepairCycle?: (cell: {stage: string; model: string | null}) => number;
+	readonly tokensPerRepairCycle?: (cell: CellIdentity & {model: string | null}) => number;
 }): Scorecard => {
 	const buckets = bucketize(args.rows);
 	const baseline = args.baseline;
+	// Bucket keys are unique on (stage, surface, model) and `sameCell` compares that whole key, so
+	// this finds at most one bucket: a `review` baseline naming no surface matches nothing rather
+	// than silently adopting one of the two graders as the baseline.
 	const baselineBucket =
-		baseline === undefined
-			? undefined
-			: buckets.find((b) => b.stage === baseline.stage && b.model === (baseline.model ?? null));
+		baseline === undefined ? undefined : buckets.find((b) => sameCell(b, baseline));
 	const baselineSpend = baselineBucket !== undefined ? spendOf(baselineBucket) : null;
 
 	const cells = buckets.map((bucket): ScorecardCell => {
@@ -193,8 +224,7 @@ export const buildScorecard = (args: {
 
 		if (spend !== null) {
 			const repairCycle =
-				args.tokensPerRepairCycle?.({stage: bucket.stage, model: bucket.model}) ??
-				spend.billedPerRun;
+				args.tokensPerRepairCycle?.({...bucket.id, model: bucket.model}) ?? spend.billedPerRun;
 			const priced = repairChurnCost({
 				passRate,
 				tokensPerRun: spend.billedPerRun,
@@ -210,10 +240,7 @@ export const buildScorecard = (args: {
 					amortizedBilledPerRun: c.amortizedTokensPerRun,
 				};
 
-				const isBaselineCell =
-					baselineBucket !== undefined &&
-					bucket.stage === baselineBucket.stage &&
-					bucket.model === baselineBucket.model;
+				const isBaselineCell = bucket === baselineBucket;
 				if (baselineSpend !== null && !isBaselineCell) {
 					const swap = priceModelSwap({
 						baselineTokensPerRun: baselineSpend.billedPerRun,
@@ -232,7 +259,7 @@ export const buildScorecard = (args: {
 		}
 
 		return {
-			stage: bucket.stage,
+			...bucket.id,
 			model: bucket.model,
 			gradedRuns: bucket.graded,
 			passedRuns: bucket.passed,
@@ -248,9 +275,7 @@ export const buildScorecard = (args: {
 		decisionRef: DECISION_POINTER,
 		framing: DECISION_FRAMING,
 		baseline:
-			baselineBucket !== undefined
-				? {stage: baselineBucket.stage, model: baselineBucket.model}
-				: null,
+			baselineBucket !== undefined ? {...baselineBucket.id, model: baselineBucket.model} : null,
 		cells,
 	};
 };
@@ -277,8 +302,8 @@ const signedNum = (n: number | null): string => {
 
 /**
  * Render the human-readable table the founder reads to decide #1576 (`token-spend`/`ship-digest`
- * reporter idiom). One row per (stage × model): pass-rate, per-run billed + ex-cache-read spend,
- * churn-amortized billed, and net saving vs the baseline. A net-negative cell is marked
+ * reporter idiom). One row per (stage × surface × model): pass-rate, per-run billed + ex-cache-read
+ * spend, churn-amortized billed, and net saving vs the baseline. A net-negative cell is marked
  * `NET-NEGATIVE` unambiguously — the epic's headline risk made impossible to miss. The framing
  * line states this is evidence for #1576, never a recommendation.
  */
@@ -287,15 +312,17 @@ export const renderTable = (scorecard: Scorecard): string => {
 	lines.push("fabrika eval scorecard — graded two-axis gate (pass-rate × net-token cost)");
 	lines.push(scorecard.framing);
 	if (scorecard.baseline !== null) {
+		const surface = scorecard.baseline.surface === null ? "" : ` (${scorecard.baseline.surface})`;
 		lines.push(
-			`baseline: ${scorecard.baseline.stage} × ${scorecard.baseline.model ?? "(unknown model)"} ` +
-				"— net saving is measured against this cell",
+			`baseline: ${scorecard.baseline.stage}${surface} × ` +
+				`${scorecard.baseline.model ?? "(unknown model)"} — net saving is measured against this cell`,
 		);
 	}
 	lines.push("");
 
 	const header = [
 		"stage",
+		"surface",
 		"model",
 		"pass-rate",
 		"billed/run",
@@ -306,6 +333,7 @@ export const renderTable = (scorecard: Scorecard): string => {
 	];
 	const rows = scorecard.cells.map((cell) => [
 		cell.stage,
+		cell.surface ?? "—",
 		cell.model ?? "(unknown)",
 		`${pct(cell.passRate)} (${cell.passedRuns}/${cell.gradedRuns})`,
 		cell.spend === null ? "—" : num(cell.spend.billedPerRun),

--- a/packages/fabrika-cli/src/eval/report.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/report.unit.test.ts
@@ -3,12 +3,16 @@ import type {StageSpend} from "../spend/token-spend.ts";
 import type {CorpusEntry} from "./corpus.ts";
 import {
 	buildScorecard,
+	type CellIdentity,
 	DECISION_POINTER,
 	renderTable,
 	type ScorecardCell,
 	toJson,
 } from "./report.ts";
 import type {RunRow} from "./runner.ts";
+
+/** `true` iff `T` is a cell identity the report can key on — the type-level probe's operand. */
+type IsCell<T> = T extends CellIdentity ? true : false;
 
 // A triage corpus entry — the report only reads `entry.stage`, so any stage's entry serves.
 const triageEntry = (inputRef: number): CorpusEntry => ({
@@ -50,6 +54,41 @@ const missingSpendRow = (opts: {pass: boolean; inputRef?: number}): RunRow => ({
 const cellFor = (cells: ReadonlyArray<ScorecardCell>, model: string | null): ScorecardCell => {
 	const found = cells.find((c) => c.model === model);
 	assert.isDefined(found, `expected a cell for model ${model}`);
+	return found as ScorecardCell;
+};
+
+// A live `review` entry on either surface — the two label shapes ADR 0243 §1 fixes.
+const reviewEntry = (surface: "code" | "doc", inputRef: number): CorpusEntry =>
+	surface === "code"
+		? {stage: "review", surface: "code", inputRef, label: {verdict: "PASS", acFindings: []}}
+		: {stage: "review", surface: "doc", inputRef, label: {verdict: "PASS", findings: []}};
+
+// A row the v1 `review-code` gate recorded: provenance, carrying no `surface` (#4977).
+const recordedReviewCodeEntry = (inputRef: number): CorpusEntry => ({
+	stage: "review-code",
+	inputRef,
+	label: {verdict: "PASS", acFindings: []},
+});
+
+const entryRow = (opts: {
+	entry: CorpusEntry;
+	pass: boolean;
+	billed: number;
+	model: string;
+}): RunRow => ({
+	entry: opts.entry,
+	grade: opts.pass
+		? {status: "pass"}
+		: {status: "fail", mismatch: {_tag: "MalformedArtifact", reason: "x"}},
+	spend: {_tag: "Reconstructed", spend: spend(opts.billed, opts.model)},
+});
+
+const reviewCellFor = (
+	cells: ReadonlyArray<ScorecardCell>,
+	surface: "code" | "doc",
+): ScorecardCell => {
+	const found = cells.find((c) => c.stage === "review" && c.surface === surface);
+	assert.isDefined(found, `expected a review cell for surface ${surface}`);
 	return found as ScorecardCell;
 };
 
@@ -156,6 +195,137 @@ describe("buildScorecard — the net-negative churn case (the epic's headline ri
 		// but the amortized cost is unbounded (rendered as -∞ saving) — never adopt.
 		assert.strictEqual(flaky.netSaving, Number.NEGATIVE_INFINITY);
 		assert.isFalse(flaky.netNegative);
+	});
+});
+
+// ADR 0243 §4: a pass-rate is a measurement over ONE grading regime, so the report's cell key
+// carries `surface` and rows from different review surfaces are never aggregated into a single
+// undifferentiated `review` number. These assertions are written against rows that ONLY a
+// surface-carrying key separates — same stage, same model, same inputRef — so they cannot pass on a
+// key built from (stage × model) alone.
+describe("buildScorecard — a `review` pass-rate never spans two graders (ADR 0243 §4)", () => {
+	// The mixed-surface PR of ADR 0243 §3: one inputRef, one row per surface, two graders.
+	const mixedSurfaceRows: ReadonlyArray<RunRow> = [
+		entryRow({entry: reviewEntry("code", 42), pass: true, billed: 100, model: "opus"}),
+		entryRow({entry: reviewEntry("doc", 42), pass: false, billed: 100, model: "opus"}),
+	];
+
+	it("buckets the two surfaces of one inputRef separately, each keeping its own pass-rate", () => {
+		const sc = buildScorecard({rows: mixedSurfaceRows});
+
+		assert.strictEqual(sc.cells.length, 2);
+		const code = reviewCellFor(sc.cells, "code");
+		const doc = reviewCellFor(sc.cells, "doc");
+		assert.strictEqual(code.gradedRuns, 1);
+		assert.strictEqual(code.passRate, 1);
+		assert.strictEqual(doc.gradedRuns, 1);
+		assert.strictEqual(doc.passRate, 0);
+	});
+
+	it("produces no cell that aggregates the two surfaces — the averaged 50% is unproducible", () => {
+		const sc = buildScorecard({rows: mixedSurfaceRows});
+
+		// Every cell is homogeneous in its grading regime: the rows it counts are exactly the input
+		// rows sharing its full (stage, surface, model) key. A cell that merged the two surfaces would
+		// count 2 rows against a 1-row key, so no averaged pass-rate can exist anywhere in the
+		// scorecard — not merely be absent from the cell a test happened to look at.
+		for (const cell of sc.cells) {
+			const matching = mixedSurfaceRows.filter(
+				(r) =>
+					r.entry.stage === cell.stage &&
+					("surface" in r.entry ? r.entry.surface : null) === cell.surface,
+			);
+			assert.strictEqual(cell.gradedRuns, matching.length);
+		}
+		assert.isUndefined(sc.cells.find((c) => c.passRate === 0.5));
+	});
+
+	it("names the surface on every review cell, in the JSON and in the rendered table", () => {
+		const sc = buildScorecard({rows: mixedSurfaceRows});
+
+		const parsed = JSON.parse(toJson(sc)) as {
+			cells: ReadonlyArray<{stage: string; surface: string | null}>;
+		};
+		const reviewCells = parsed.cells.filter((c) => c.stage === "review");
+		assert.strictEqual(reviewCells.length, 2);
+		assert.deepStrictEqual(
+			reviewCells.map((c) => c.surface).sort(),
+			["code", "doc"],
+			"a `review` cell that did not name its surface would be a bare two-grader number",
+		);
+
+		const table = renderTable(sc);
+		assert.include(table, "surface");
+		for (const line of table.split("\n").filter((l) => l.startsWith("review"))) {
+			assert.match(line, /^review\s+(code|doc)\s/);
+		}
+	});
+
+	it("refuses a surfaceless `review` cell in the type, not only in the built scorecard", () => {
+		// The runtime half above proves no averaged cell is BUILT; this proves none can be WRITTEN.
+		// `IsCell<T>` is `false` exactly when T is not a `CellIdentity`, so these constants stop
+		// compiling the moment `surface` is weakened from a discriminator into an annotation — and the
+		// positive controls keep them from being vacuously true.
+		const reviewNamesItsSurface: IsCell<{stage: "review"; surface: "code"}> = true;
+		const bareReview: IsCell<{stage: "review"; surface: null}> = false;
+		const recordedProvenanceCarriesNone: IsCell<{stage: "review-code"; surface: null}> = true;
+
+		assert.isTrue(reviewNamesItsSurface);
+		assert.isFalse(bareReview);
+		assert.isTrue(recordedProvenanceCarriesNone);
+	});
+
+	it("keeps a recorded v1 `review-code` row in its own cell, unmerged with the live surface", () => {
+		// A recorded stage key is provenance, never a pointer into the live vocabulary (#4977, ADR
+		// 0244) — so it neither gains a surface nor collapses into the live `review` cell.
+		const sc = buildScorecard({
+			rows: [
+				entryRow({entry: recordedReviewCodeEntry(7), pass: true, billed: 100, model: "opus"}),
+				entryRow({entry: reviewEntry("code", 7), pass: false, billed: 100, model: "opus"}),
+			],
+		});
+
+		assert.strictEqual(sc.cells.length, 2);
+		const recorded = sc.cells.find((c) => c.stage === "review-code");
+		assert.isDefined(recorded);
+		assert.isNull(recorded?.surface);
+		assert.strictEqual(recorded?.gradedRuns, 1);
+		assert.strictEqual(reviewCellFor(sc.cells, "code").gradedRuns, 1);
+	});
+});
+
+describe("buildScorecard — the baseline resolves to exactly one cell under the extended key", () => {
+	const rows: ReadonlyArray<RunRow> = [
+		entryRow({entry: reviewEntry("code", 1), pass: true, billed: 1000, model: "opus"}),
+		entryRow({entry: reviewEntry("doc", 1), pass: true, billed: 1000, model: "opus"}),
+		entryRow({entry: reviewEntry("code", 2), pass: true, billed: 400, model: "sonnet"}),
+	];
+
+	it("a (stage, surface, model) baseline names one cell and prices the others against it", () => {
+		const sc = buildScorecard({rows, baseline: {stage: "review", surface: "code", model: "opus"}});
+
+		assert.isNotNull(sc.baseline);
+		assert.strictEqual(sc.baseline?.surface, "code");
+		const named = sc.cells.filter(
+			(c) =>
+				c.stage === sc.baseline?.stage &&
+				c.surface === sc.baseline?.surface &&
+				c.model === sc.baseline?.model,
+		);
+		assert.strictEqual(named.length, 1, "the baseline key must select exactly one cell");
+		assert.isNull(named[0]?.netSaving ?? null);
+		// The doc cell is a different grading regime, so it is priced as a candidate, not merged.
+		assert.strictEqual(reviewCellFor(sc.cells, "doc").netSaving, 0);
+	});
+
+	it("a surfaceless `review` baseline selects NO cell rather than silently picking one", () => {
+		const sc = buildScorecard({rows, baseline: {stage: "review", model: "opus"}});
+
+		assert.isNull(
+			sc.baseline,
+			"a baseline that cannot name one grading regime must not resolve to an arbitrary surface",
+		);
+		for (const cell of sc.cells) assert.isNull(cell.netSaving);
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
@@ -111,8 +111,53 @@ describe("the live stage vocabulary is what fabrika eval accepts", {
 		});
 	}
 
-	it("--baseline-stage review is accepted", () => {
-		const accepted = fabrika("eval", "report", emptyRowsFile(), "--baseline-stage", "review");
+	it("--baseline-stage review is accepted when it names a surface", () => {
+		const accepted = fabrika(
+			"eval",
+			"report",
+			emptyRowsFile(),
+			"--baseline-stage",
+			"review",
+			"--baseline-surface",
+			"code",
+		);
 		expect(accepted.code).toBe(0);
+	});
+
+	// A `review` baseline with no surface names two graders, so it identifies no cell — refused at
+	// the flag rather than resolved to whichever surface happens to bucket first (ADR 0243 §4).
+	it("--baseline-stage review with no --baseline-surface is refused, naming the surfaces", () => {
+		const refused = fabrika("eval", "report", emptyRowsFile(), "--baseline-stage", "review");
+		expect(refused.code).not.toBe(0);
+		expect(refused.stderr).toContain("--baseline-stage review needs --baseline-surface");
+		expect(refused.stderr).toContain("code, doc");
+	});
+
+	it("--baseline-surface skill is refused — the skill surface has no entry shape yet", () => {
+		const refused = fabrika(
+			"eval",
+			"report",
+			emptyRowsFile(),
+			"--baseline-stage",
+			"review",
+			"--baseline-surface",
+			"skill",
+		);
+		expect(refused.code).not.toBe(0);
+		expect(refused.stderr).toContain("'skill' is not a known review surface");
+	});
+
+	it("--baseline-surface on a non-review stage is refused", () => {
+		const refused = fabrika(
+			"eval",
+			"report",
+			emptyRowsFile(),
+			"--baseline-stage",
+			"build",
+			"--baseline-surface",
+			"code",
+		);
+		expect(refused.code).not.toBe(0);
+		expect(refused.stderr).toContain("--baseline-surface only applies to --baseline-stage review");
 	});
 });


### PR DESCRIPTION
The eval scorecard used to group graded runs by stage and model alone. Now that both review gates share one `review` stage, that key would have quietly mixed rows graded by two different graders into one pass-rate — a number that means nothing. This PR puts the review surface into the key, so each surface gets its own row, and the human table and the JSON both say which grader produced each pass-rate.

It is safe today only because every committed review row is recorded `review-code` provenance, so no surface-carrying row exists yet to average. This lands before one does.

Fixes #4980

## What changed

- `packages/fabrika-cli/src/eval/report.ts` — buckets on `(stage x surface x model)`. The new exported `CellIdentity` is a discriminated union: a `review` cell carries a `ReviewSurface`, every other stage carries `null`. A bare `review` cell is therefore **unrepresentable in the type**, not merely unproduced. `ScorecardCell`, `Scorecard.baseline` and the rendered table all carry it, and the table gains a `surface` column.
- Baseline resolution moved with the key. Bucket keys are unique on the full triple and the baseline predicate compares the whole triple, so it matches **at most one** bucket by construction. A `review` baseline naming no surface matches nothing rather than adopting whichever surface bucketed first.
- `packages/fabrika-cli/src/eval/command.ts` — new `--baseline-surface` flag. `--baseline-stage review` without it is refused at the flag (it names two graders, so it cannot identify one cell); `--baseline-surface` on a non-review stage is refused; an unknown surface is refused naming `code, doc`.
- `packages/fabrika-cli/src/eval/report.unit.test.ts` — the proof, written against rows that only a surface-carrying key separates.
- `packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts` — the flag rules, asserted against a real `fabrika eval report` process.
- `packages/fabrika-cli/src/eval/README.md` — the cell key, the JSON `surface` field, and the baseline rule.

## How the averaged number is proven unproducible, not merely absent

Every new assertion is built from a mixed-surface PR (ADR 0243 section 3): the **same** `inputRef`, the **same** model, one row per surface, one passing and one failing. Under the old `(stage x model)` key those are one cell with a 50% pass-rate; under the new key they are two cells. All six runtime assertions were run against the unmodified `report.ts` first and all six failed for the intended reason (no `surface` on the cell, on the JSON, or on the resolved baseline).

Three layers:

1. **Partition check.** For every cell, the rows it counts are exactly the input rows sharing its full `(stage, surface, model)` key, so no cell anywhere in the scorecard aggregates two regimes — this is not an assertion about the one cell a test happened to look at. Plus an explicit `no cell has passRate 0.5`.
2. **Rendered surfaces.** Both review cells appear in the JSON with distinct non-null `surface` values, and every `review` line of the human table matches `^review\s+(code|doc)\s`.
3. **The type.** An `Inhabits`-style probe asserts `{stage: "review", surface: null}` is **not** a `CellIdentity`, with positive controls (`{stage: "review", surface: "code"}` and `{stage: "review-code", surface: null}`) so it cannot be vacuously true. It stops compiling the moment `surface` is weakened from a discriminator to an annotation.

Recorded provenance is covered too: a v1 `review-code` row and a live `review`/`code` row on the same `inputRef` stay two cells, the recorded one taking the surfaceless arm — ADR 0244 / #4977 hold.

## Verification

- `pnpm typecheck` forced uncached: 30/30 tasks, 0 cached.
- `packages/fabrika-cli`: 86 files, 1321 tests, all passing.
- `pnpm lint:worktree`: clean.

## Deviations

- **Widened the file set (class: scope).** Said: the issue names `report.ts` and `command.ts`. Did: also changed `stage-vocabulary.cli.test.ts` and `src/eval/README.md`. Why: the CLI test pins the baseline flag behaviour at the process, and the README documents the JSON contract and the baseline flags, both of which this key change moves. Disposition: no action needed — the issue's list is a floor.
- **Changed an existing test's expectation (class: test change).** Said: `stage-vocabulary.cli.test.ts` asserted `--baseline-stage review` exits 0. Did: that case now passes `--baseline-surface code`, and a new case asserts the bare form is refused. Why: a surfaceless `review` baseline names two graders and can no longer identify a cell. The original test's intent — `review` is a live stage the flag accepts — is preserved by the amended case. Disposition: for the reviewer to judge.
- **Chose a loud refusal over a silent no-baseline (class: narrowed the fix shape).** Said: the issue asks only that the baseline move with the key. Did: made `--baseline-stage review` without a surface a hard exit rather than letting it resolve to no cell. Why: it matches the existing rule one level up in the same function ("a typo can't quietly drop the net-saving axis") and a silently-dropped baseline is the same failure the ADR is guarding against. Disposition: for the reviewer to judge.
- **Did not define a skill entry shape (class: left a sibling defect alone).** Said: nothing in this issue asks for it. Did: `--baseline-surface skill` is refused, validating against the existing two-member `REVIEW_SURFACES` rather than inventing a third. Why: the founder ruling on #4979 fences the skill surface out; it is #5038's. Disposition: no action needed.