### PR TITLE
fix(hooks): dispatch the worktree sweep instead of running it on SessionStart (#4998)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,7 +88,8 @@
 					},
 					{
 						"type": "command",
-						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" worktree-sweep --execute"
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/worktree-sweep-detach.sh\"",
+						"timeout": 10
 					}
 				]
 			}

--- a/.patterns/plugin-sessionstart-install.md
+++ b/.patterns/plugin-sessionstart-install.md
@@ -70,13 +70,46 @@ The chain is asserted end to end by `packages/pipeline-cli/src/pin-dispatch.hook
 
 **Why the fail-open is non-negotiable (#1050 / #777):** a worktree-creation hook fires with a stripped PATH on a fresh/stale tree, possibly before any install ran. If that hook *crashed* instead of no-op'ing, it would abort the spawn for **all lanes** through the shared `.git/hooks` — the #787/#788/#789 incident class. The fail-open wrapper is the single thing standing between a not-yet-installed CLI and an all-lanes spawn abort. The resilience lives in the **wrapper**, not in each guard — the consolidated `pipeline-cli` dropped the old per-guard `bin.run.ts`/`preflight.ts` stale-tree shim precisely because the wrapper (CLI-absent → no-op) + the bundled-deps install (CLI-present → deps already resolved) replace it.
 
+## The long-running sweep is dispatched, never run inline (#4998)
+
+`SessionStart` hooks run **on the critical path to the first message**, so a hook that scans is a
+hook that makes every launch and resume wait. The orphaned-worktree sweep used to be wired inline as
+`guard.sh worktree-sweep --execute` and cost 52–66s on a checkout with 255 registered worktrees —
+paid at every launch, on a result nothing at session start reads, and growing with the worktree set.
+
+So the entry is `hooks/worktree-sweep-detach.sh`, which dispatches and returns (0.03s):
+
+```
+SessionStart → worktree-sweep-detach.sh    report the previous run, launch, exit 0   (0.03s)
+                    │  nohup, stdin </dev/null, stdout+stderr → the log
+                    ▼
+               worktree-sweep-run.sh        guard.sh worktree-sweep --execute        (detached)
+                    │
+                    ├── ${DATA}/worktree-sweep.log      the run's full output (truncated per run)
+                    ├── ${DATA}/worktree-sweep.status   `running <ts>` → `exit <rc> <ts>`
+                    └── ${DATA}/worktree-sweep.failed.log   kept only when rc != 0
+```
+
+Three properties make the split safe, and none is incidental:
+
+- **The child must not hold the hook's stdout pipe.** A hook runner that reads that pipe to EOF
+  waits for every process holding it — so a backgrounded child inheriting stdout re-blocks the
+  session with no visible symptom. The redirect to the log is what prevents it; its stdin is
+  `/dev/null` for the same reason, so it never competes for the hook payload.
+- **The output is recorded, not dropped.** A guard that quietly stops running is worse than a slow
+  one, so the run's status is written before and after, and the *next* session start prints a loud
+  stderr line when the previous run failed or never recorded an exit.
+- **The fail-open invariant is unchanged (#1050).** Every refusal path in the dispatcher drains
+  stdin and exits 0, and the sweep itself still goes through `guard.sh`, so the version gate and
+  the non-`--force` classifier are untouched.
+
 ## hooks.json — matchers mirror `.claude/settings.json`
 
 The plugin's `hooks.json` (registered via plugin.json's `"hooks": "./hooks.json"`) carries the same matcher→guard map as phoenix's `.claude/settings.json`, so enabling the plugin changes the *invocation path* (installed CLI) without changing *coverage*:
 
 | Event | Matcher | Dispatch |
 |---|---|---|
-| SessionStart | `startup\|resume` | `install.sh`, then `guard.sh spawn-guard freshness` |
+| SessionStart | `startup\|resume` | `install.sh`, then `guard.sh spawn-guard freshness`, then `worktree-sweep-detach.sh` |
 | PreToolUse | `Read\|Edit\|Write` | `guard.sh worktree-guard pre-file` |
 | PreToolUse | `Bash` | `guard.sh worktree-guard pre-bash` |
 | PreToolUse | `EnterWorktree` | `guard.sh worktree-guard pre-enter` |

--- a/claude-plugins/kampus-pipeline/hooks.json
+++ b/claude-plugins/kampus-pipeline/hooks.json
@@ -1,5 +1,5 @@
 {
-	"description": "kampus-pipeline portable guard surface: plants `.claude/.pipeline` (SessionStart + WorktreeCreate + a PreToolUse belt) at the live plugin install so every skill fence resolves in ANY consuming repo, not only a phoenix checkout (#4605), SessionStart-installs @kampus/pipeline-cli into ${CLAUDE_PLUGIN_DATA} (version-aware, idempotent, network-resilient), sweeps orphaned agent worktrees left by aborted/hard-stopped lanes via the safe `worktree-sweep --execute` classifier (#2238), and wires the worktree/spawn guards through a fail-open dispatch wrapper. Mirrors the matchers in phoenix's .claude/settings.json (ADR 0103, #1001). Inert until the plugin is enabled (#1003).",
+	"description": "kampus-pipeline portable guard surface: plants `.claude/.pipeline` (SessionStart + WorktreeCreate + a PreToolUse belt) at the live plugin install so every skill fence resolves in ANY consuming repo, not only a phoenix checkout (#4605), SessionStart-installs @kampus/pipeline-cli into ${CLAUDE_PLUGIN_DATA} (version-aware, idempotent, network-resilient), sweeps orphaned agent worktrees left by aborted/hard-stopped lanes via the safe `worktree-sweep --execute` classifier (#2238), detached from the SessionStart critical path (#4998), and wires the worktree/spawn guards through a fail-open dispatch wrapper. Mirrors the matchers in phoenix's .claude/settings.json (ADR 0103, #1001). Inert until the plugin is enabled (#1003).",
 	"hooks": {
 		"SessionStart": [
 			{
@@ -16,7 +16,8 @@
 					},
 					{
 						"type": "command",
-						"command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/guard.sh worktree-sweep --execute"
+						"command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/worktree-sweep-detach.sh",
+						"timeout": 10
 					}
 				]
 			}

--- a/claude-plugins/kampus-pipeline/hooks/worktree-sweep-detach.sh
+++ b/claude-plugins/kampus-pipeline/hooks/worktree-sweep-detach.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SessionStart entry for the orphaned-worktree sweep: DISPATCH ONLY, never the scan (#4998).
+#
+# The sweep used to sit on the SessionStart hook chain as `guard.sh worktree-sweep --execute`,
+# so every launch and every resume blocked on a full dirty-check of every registered worktree
+# — measured at 52-66s on a checkout with 255 of them, and the set only grows. Nothing at
+# session start reads the sweep's result, so that wait bought nothing.
+#
+# Two redirections on the background child are load-bearing, not tidiness. Its stdin is
+# /dev/null so it never competes for the hook payload this script drains. Its stdout/stderr go
+# to a file so it does not inherit the hook's stdout pipe: a hook runner that reads that pipe
+# to EOF would otherwise wait for the whole sweep anyway, and the fix would be undone with no
+# visible symptom.
+#
+# #1050 FAIL-OPEN INVARIANT (HARD): every path here drains stdin and exits 0, so this entry can
+# never abort a session start.
+set -uo pipefail
+
+HOOKS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+. "$HOOKS_DIR/resolve-data-dir.sh"
+
+DATA="$(resolve_pipeline_data_dir || true)"
+
+drain_and_exit() {
+	cat >/dev/null 2>&1 || true
+	exit 0
+}
+
+# No data dir means no installed CLI to run and nowhere to record the run — the same state
+# guard.sh itself no-ops on. Refuse to dispatch, fail-open.
+if [ -z "$DATA" ] || [ ! -d "$DATA" ]; then
+	drain_and_exit
+fi
+
+LOG="$DATA/worktree-sweep.log"
+FAILED_LOG="$DATA/worktree-sweep.failed.log"
+STATUS="$DATA/worktree-sweep.status"
+
+# Report the PREVIOUS run before starting a new one. A backgrounded guard that quietly stops
+# running is worse than a slow one, and this is the one place its outcome reaches a human.
+PREV="$(head -n 1 "$STATUS" 2>/dev/null)"
+case "$PREV" in
+'' | 'exit 0 '*) ;;
+'running '*)
+	echo "kampus-pipeline: the previous background worktree-sweep ($PREV) never recorded an exit — it was killed or is still running. Last output: $LOG." >&2
+	;;
+*)
+	echo "kampus-pipeline: the previous background worktree-sweep FAILED ($PREV) — worktrees are not being reclaimed. Output kept at $FAILED_LOG." >&2
+	;;
+esac
+
+nohup "$HOOKS_DIR/worktree-sweep-run.sh" >/dev/null 2>&1 </dev/null &
+
+drain_and_exit

--- a/claude-plugins/kampus-pipeline/hooks/worktree-sweep-run.sh
+++ b/claude-plugins/kampus-pipeline/hooks/worktree-sweep-run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# The detached half of the SessionStart sweep (#4998). Runs the sweep entry unchanged —
+# `guard.sh worktree-sweep --execute`, same classifier, still non-`--force` — and records
+# where it got to, so a background run that fails or dies is reported at the next session
+# start instead of vanishing.
+#
+# NEVER put this back on a hook chain directly: it is the long-running half, and inlining it
+# is exactly the blocking cost #4998 removed. worktree-sweep-detach.sh is the hook entry.
+set -uo pipefail
+
+HOOKS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+. "$HOOKS_DIR/resolve-data-dir.sh"
+
+DATA="$(resolve_pipeline_data_dir || true)"
+if [ -z "$DATA" ] || [ ! -d "$DATA" ]; then
+	exit 0
+fi
+
+LOG="$DATA/worktree-sweep.log"
+FAILED_LOG="$DATA/worktree-sweep.failed.log"
+STATUS="$DATA/worktree-sweep.status"
+
+now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+STARTED="$(now)"
+printf 'running %s\n' "$STARTED" >"$STATUS"
+
+{
+	printf '=== worktree-sweep --execute (detached, started %s) ===\n' "$STARTED"
+	"$HOOKS_DIR/guard.sh" worktree-sweep --execute </dev/null
+} >"$LOG" 2>&1
+RC=$?
+
+printf '=== exit %s at %s ===\n' "$RC" "$(now)" >>"$LOG"
+printf 'exit %s %s\n' "$RC" "$(now)" >"$STATUS"
+
+# The log is truncated per run, so a failure would be overwritten by the next session's run
+# before anyone read it. Keep a copy of the one that matters.
+if [ "$RC" -ne 0 ]; then
+	cp "$LOG" "$FAILED_LOG" 2>/dev/null || true
+fi
+
+exit "$RC"

--- a/packages/pipeline-cli/src/worktree-sweep-detach.hook.test.ts
+++ b/packages/pipeline-cli/src/worktree-sweep-detach.hook.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The SessionStart sweep entry returns without waiting for the sweep (#4998).
+ *
+ * The acceptance property is structural, not "the sweep got faster": the hook must return
+ * while the sweep is still running. So these tests drive the REAL scripts against a throwaway
+ * data dir whose stub `pipeline-cli` sleeps — if the hook ever went back to waiting, the
+ * elapsed-time assertion fails by the length of that sleep, whatever the machine's load.
+ *
+ * The other half is that the detached run stays observable: its exit status is recorded and a
+ * failed run is reported at the next session start.
+ */
+import {execFileSync, spawnSync} from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import {tmpdir} from "node:os";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterEach, assert, describe, it} from "@effect/vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "./test-budget.ts";
+
+const repoPath = (rel: string) => fileURLToPath(new URL(`../../../${rel}`, import.meta.url));
+
+const HOOKS = "claude-plugins/kampus-pipeline/hooks";
+const DETACH_SH = repoPath(`${HOOKS}/worktree-sweep-detach.sh`);
+const PIN_SH = repoPath(`${HOOKS}/pin.sh`);
+
+const hookPin = (): string =>
+	execFileSync("bash", ["-c", `. "${PIN_SH}"; printf '%s' "$KAMPUS_PIPELINE_CLI_PIN"`], {
+		encoding: "utf8",
+	});
+
+/** How long the stub sweep runs. Long enough that a blocking hook cannot hide inside jitter. */
+const STUB_SLEEP_S = 5;
+
+/**
+ * A throwaway pipeline data dir holding a stub `pipeline-cli` that sleeps, then drops a
+ * sentinel — so "did the sweep run, and did the hook wait for it?" are separately answerable.
+ */
+const dataDirWithSlowStub = (exitCode: number): string => {
+	const data = mkdtempSync(join(tmpdir(), "sweep-detach-"));
+	const bin = join(data, "node_modules", ".bin", "pipeline-cli");
+	mkdirSync(dirname(bin), {recursive: true});
+	writeFileSync(
+		bin,
+		`#!/usr/bin/env bash\nsleep ${STUB_SLEEP_S}\necho "SWEPT $*"\ntouch "${join(data, "sentinel")}"\nexit ${exitCode}\n`,
+	);
+	chmodSync(bin, 0o755);
+	writeFileSync(join(data, ".pipeline-cli.version"), hookPin());
+	return data;
+};
+
+const runDetach = (data: string) =>
+	spawnSync("bash", [DETACH_SH], {
+		encoding: "utf8",
+		input: '{"session_id":"t","hook_event_name":"SessionStart","source":"startup"}',
+		env: {...process.env, KAMPUS_PIPELINE_DATA: data},
+	});
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** The detached child writes its status file after the hook has already returned — that gap is the point. */
+const waitForFile = async (path: string, budgetMs: number): Promise<void> => {
+	const deadline = Date.now() + budgetMs;
+	while (!existsSync(path) && Date.now() < deadline) await sleep(50);
+};
+
+describe("SessionStart sweep entry — dispatches, never blocks (#4998)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	const dirs: string[] = [];
+	const dataDir = (exitCode = 0) => {
+		const d = dataDirWithSlowStub(exitCode);
+		dirs.push(d);
+		return d;
+	};
+	afterEach(() => {
+		for (const d of dirs.splice(0)) rmSync(d, {recursive: true, force: true});
+	});
+
+	it("returns while the sweep is still running, and the sweep completes after it", async () => {
+		const data = dataDir();
+		const started = Date.now();
+		const {status} = runDetach(data);
+		const elapsedMs = Date.now() - started;
+
+		assert.strictEqual(status, 0, "the hook entry must exit 0");
+		assert.isBelow(
+			elapsedMs,
+			STUB_SLEEP_S * 1000,
+			`the hook returned in ${elapsedMs}ms — it must not wait for the ${STUB_SLEEP_S}s sweep`,
+		);
+		assert.isFalse(
+			existsSync(join(data, "sentinel")),
+			"the sweep must still be running when the hook returns",
+		);
+
+		await waitForFile(join(data, "worktree-sweep.status"), 2000);
+		assert.strictEqual(
+			readFileSync(join(data, "worktree-sweep.status"), "utf8").split(" ")[0],
+			"running",
+			"the detached run must be recorded as in flight",
+		);
+
+		await sleep((STUB_SLEEP_S + 3) * 1000);
+		assert.isTrue(
+			existsSync(join(data, "sentinel")),
+			"the detached sweep must actually run to completion",
+		);
+		assert.match(readFileSync(join(data, "worktree-sweep.status"), "utf8"), /^exit 0 /);
+		assert.match(
+			readFileSync(join(data, "worktree-sweep.log"), "utf8"),
+			/SWEPT worktree-sweep --execute/,
+		);
+	});
+
+	it("keeps a failed run's output and reports it at the next session start", async () => {
+		const data = dataDir(3);
+		runDetach(data);
+		await sleep((STUB_SLEEP_S + 3) * 1000);
+		assert.match(readFileSync(join(data, "worktree-sweep.status"), "utf8"), /^exit 3 /);
+		assert.isTrue(
+			existsSync(join(data, "worktree-sweep.failed.log")),
+			"a failed run's output must survive",
+		);
+
+		const {status, stderr} = runDetach(data);
+		assert.strictEqual(status, 0, "reporting a prior failure must not abort the session");
+		assert.match(stderr, /previous background worktree-sweep FAILED \(exit 3 /);
+	});
+
+	it("fails open when the data dir does not resolve", () => {
+		const {status, stderr} = spawnSync("bash", [DETACH_SH], {
+			encoding: "utf8",
+			input: '{"hook_event_name":"SessionStart"}',
+			env: {
+				...process.env,
+				KAMPUS_PIPELINE_DATA: join(tmpdir(), "sweep-detach-absent"),
+				CLAUDE_PLUGIN_DATA: "",
+				CLAUDE_PROJECT_DIR: "",
+			},
+		});
+		assert.strictEqual(status, 0, "#1050: a refusal to dispatch still exits 0");
+		assert.strictEqual(
+			stderr,
+			"",
+			"an unresolvable data dir is the expected cold-consumer state, not a warning",
+		);
+	});
+});


### PR DESCRIPTION
Starting a session in this repo used to hang for over half a minute. The `SessionStart` hooks ran the orphaned-worktree sweep inline, so every launch and resume waited for a full dirty-check of every registered worktree — and nothing at session start reads that result. The sweep is now dispatched to a detached child and the hook returns immediately, so the session starts while the sweep runs behind it.

The sweep itself is unchanged: same command, same classifier, still removes nothing with `--force`. What changed is only *when the session waits for it* — it doesn't.

Fixes #4998

## What changed

- **New `claude-plugins/kampus-pipeline/hooks/worktree-sweep-detach.sh`** — the `SessionStart` entry. It reports the previous run's outcome, launches the runner detached, and exits 0. Two redirections on the child are load-bearing and commented at the site: its stdin is `/dev/null`, and its stdout/stderr go to a log file so it does not inherit the hook's stdout pipe (a hook runner that reads that pipe to EOF would wait for the sweep anyway, undoing the fix with no visible symptom).
- **New `claude-plugins/kampus-pipeline/hooks/worktree-sweep-run.sh`** — the detached half. Runs `guard.sh worktree-sweep --execute` unchanged and records where it got to.
- **`.claude/settings.json` + `claude-plugins/kampus-pipeline/hooks.json`** — the `SessionStart` sweep entry now points at the dispatcher, with a `timeout: 10` belt so this entry can never block a launch again.
- **New `packages/pipeline-cli/src/worktree-sweep-detach.hook.test.ts`** — drives the real scripts against a throwaway data dir whose stub sweep sleeps 5s, and asserts the hook returns *while the sweep is still running*. This is the structural assertion, not a speed one: if the entry ever goes back to waiting, the test fails by the length of that sleep whatever the machine's load.
- **`.patterns/plugin-sessionstart-install.md`** — extended with the dispatch/detach split and the three properties that make it safe.

## Where the sweep runs now, and what happens to its output

It runs in a detached child launched by the `SessionStart` hook — same cadence as before (once per launch/resume), just off the critical path.

- Full stdout/stderr → `worktree-sweep.log` in the pipeline data dir, truncated per run.
- Exit status → `worktree-sweep.status`: `running <ts>` while in flight, then `exit <rc> <ts>`.
- A non-zero run's output is copied to `worktree-sweep.failed.log`, which the next run does not overwrite.

**Failure mode, stated plainly:** the *next* session start reads that status file before dispatching and prints a loud stderr line when the previous run failed (`exit != 0`) or never recorded an exit (killed mid-run). So a sweep that quietly stops reclaiming worktrees surfaces at the next launch instead of vanishing — the thing that makes a backgrounded guard worse than a slow one.

## Evidence

Measured on this checkout, method recorded rather than inherited from the issue.

**1. The hook entry itself**, invoked the way the hook runner does (`CLAUDE_PROJECT_DIR` exported, a `SessionStart` hook JSON payload on stdin):

| | worktrees registered | run 1 | run 2 |
|---|---|---|---|
| before (`guard.sh worktree-sweep`, dry-run) | 255 | 65.55s | 52.40s |
| after (`worktree-sweep-detach.sh`, real `--execute` dispatched) | 206 | 0.03s | 0.03s |

The "before" number is a **lower bound**: it was timed on the dry-run path, which returns before every git write, precisely so the measurement mutated nothing. The shipped entry it stands in for ran `--execute`.

**2. A real session launch** — the actual `claude` CLI, same prompt, same machine, back to back, one launch per settings state (the primary checkout still carries the inline entry; this branch's worktree carries the dispatcher):

| | wall time |
|---|---|
| before — inline sweep entry | **36.56s** |
| after — dispatch entry | **7.20s** |

Both replied `OK`, so both sessions really started. 206 registered worktrees at measurement time, above the 200 the issue asks for.

**3. The detached run actually completes.** After the timed dispatch above, the status file went `running 06:11:06` → `exit 0 06:11:45`, and the log ends `worktree-sweep: removed 0, pruned 0, kept 206`.

**4. Guards.** `pnpm typecheck --force` (30/30, 0 cached), `pnpm lint:worktree`, and the full `pipeline-cli` suite (182 files / 3044 tests) all green.

## What this PR deliberately does not do

- **No classifier change.** `classifyWorktree` is untouched — no new branch, no age gate, no relaxation of `dirty` or `locked`. Draining the accumulated `review-head-*` trees belongs to #4975 / #4884 / #4017 / #4972, not here.
- **No force anything.** The sweep still calls `git worktree remove` without `--force`, so a dirty tree still errors out and is kept.
- **`guard.sh` is untouched**, so its `#1050` fail-open invariant is preserved; the new dispatcher holds the same invariant on its own paths (drain stdin, exit 0) and a test asserts it.

## §CP

This touches `.claude/settings.json`, so it is control-plane: it banks for human approval and must not self-merge.

## Deviations

- **Class: narrowed/widened fix shape (widened file set).** Said: the issue's pointers named `.claude/settings.json`, `guard.sh`, and the sweep tool. Did: changed `.claude/settings.json` **and** the plugin's `hooks.json`, which carries the same `SessionStart` sweep entry for consumers that enable the plugin; left `guard.sh` and the sweep tool untouched. Why: fixing only phoenix's settings would leave every plugin consumer blocking on the same entry, and the two files are documented as mirrors. Disposition: no action needed.
- **Class: added surface not asked for.** Said: the issue asked for the sweep to come off the blocking path. Did: also added a status/log record and a next-session failure report. Why: the issue's own AC requires the reclaim not be silently dropped, and a backgrounded guard with no observable outcome is exactly that failure. Disposition: no action needed.
- **Class: known residual defect left in place.** Said: nothing about concurrency. Did: added no single-flight lock or cadence gate, so two session starts a few seconds apart still launch two overlapping sweeps that share one log and status file — observed during measurement (the second run's `running` line overwrote the first's). Why: that is exactly today's behaviour too (two inline session starts ran two concurrent sweeps), so it is not a regression, and a lock would be new scheduling policy this issue did not ask for. Disposition: for the reviewer to judge; a follow-up is warranted if the shared status file is considered load-bearing.
- **Class: behaviour change the issue did not name.** Said: nothing about the stale-build warning. Did: the `#3742` "installed != pinned" refusal message from `guard.sh` now lands in the sweep's log instead of the session transcript for this entry. Why: `guard.sh` now runs inside the detached child. Disposition: no action needed — the same warning still reaches the transcript from the `PreToolUse` guards, which fire on the first tool call.
- **Class: measurement caveat.** Said: re-measure before and after. Did: timed the "before" hook on the dry-run path rather than `--execute`. Why: measuring should not remove worktrees; the dry-run returns before every git write, so the figure is a lower bound on the real cost, and the real-session numbers in Evidence §2 cover the shipped path end to end. Disposition: no action needed.
