### PR TITLE
docs(decisions): point ADR 0244 at corpus/review.json, the file that exists

### DIFF
--- a/.decisions/0244-live-stage-key-vs-recorded-provenance.md
+++ b/.decisions/0244-live-stage-key-vs-recorded-provenance.md
@@ -29,7 +29,7 @@ unrelated jobs, and the re-key forced the difference into the open:
 - **As a record.** A committed corpus row's own `stage` field says which pipeline produced the
   labeled artifact. The module's README states the label is what the baseline *actually produced*,
   and three rows in [`corpus/build.json`](../packages/fabrika-cli/src/eval/corpus/build.json) plus
-  three in [`corpus/review-code.json`](../packages/fabrika-cli/src/eval/corpus/review-code.json)
+  three in [`corpus/review.json`](../packages/fabrika-cli/src/eval/corpus/review.json)
   are genuine v1 artifacts (issues/PRs #1223, #106, #1032, #1199, #1294, #1115).
 
 Treating those as one thing gives two bad options. Retiring the rows throws away the only graded
@@ -163,7 +163,7 @@ re-key of `STAGES` — to those files.
   red them. Two things still can, and are the forcing constraints an implementing child inherits:
   retiring any row drops a group below its minimum (or removes a seed) and **must** amend that test
   in the same change, and renaming a manifest file breaks the test's exact
-  `["build.json", "review-code.json", "triage.json"]` filename list.
+  `["build.json", "review.json", "triage.json"]` filename list.
 - The test now also pins the ruling itself: it asserts `build.json`'s three rows are still keyed
   `write-code`. A future re-key attempt fails CI rather than quietly republishing a v1 measurement.
 - Consumers get a small standing obligation: never resolve a row's `stage` against `STAGES`. Only
@@ -187,3 +187,21 @@ Closes [#4977](https://github.com/kamp-us/phoenix/issues/4977). Unblocks
 - **recorded provenance (stage)** — a committed corpus row's own `stage` field: which pipeline
   actually produced the labeled artifact, frozen at record time. Not a pointer into `STAGES`, and
   never re-keyed.
+
+## Amendment (2026-08-09, #5082) — two stale corpus filenames corrected
+
+This entry was written against a corpus layout that had already changed. ADR 0243 collapsed the
+review stage to one key with a `surface` discriminator and renamed the manifest
+`corpus/review-code.json` to `corpus/review.json`; that landed on `main` a couple of hours before
+this entry did, which still carried the old filename in two places:
+
+- the link under "As a record.", which pointed at a path that no longer exists — a dead link that
+  reds the repo-wide `doc-links` gate on every pull request that runs it;
+- the `["build.json", "review-code.json", "triage.json"]` filename list under Consequences, which
+  described `corpus.data.unit.test.ts`'s exact-filename assertion inaccurately — that test asserts
+  `["build.json", "review.json", "triage.json"]`.
+
+Both now read `review.json`. **No decision or reasoning changed** — only two stale filenames. The
+ruling this entry records stands exactly as written: recorded provenance wins, and the old rows
+keep their original `review-code` stage keys, which is why `review-code` still appears throughout
+this entry as a recorded stage key.


### PR DESCRIPTION
ADR 0244 pointed at a corpus manifest that had already been renamed. The `doc-links` job scans every tracked markdown file, so that one dead link turned red on every pull request that ran it — charged to whichever innocent PR happened to run next, not to the push that broke it. This corrects the two stale filenames in the ADR and records the correction in a dated amendment.

Two strings changed, both `review-code.json` to `review.json`:

- **line 32** — the markdown link under "As a record." pointed at `corpus/review-code.json`, which does not exist. This is the link lychee reds on.
- **line 166** — the prose filename list `["build.json", "review-code.json", "triage.json"]` described the exact-filename assertion in `packages/fabrika-cli/src/eval/corpus.data.unit.test.ts`, which actually asserts `["build.json", "review.json", "triage.json"]`. So the ADR contradicted the test it was describing.

The cause: ADR 0243 collapsed the review stage to one key with a `surface` discriminator and renamed the manifest at 05:06Z; ADR 0244 landed at 06:53Z still carrying the old name. `doc-links` triggers on `pull_request` only while scanning the whole tree, so the push to `main` was never checked.

A dated `## Amendment (2026-08-09, #5082)` section is appended, matching the shape `.decisions/0178-worktreecreate-hook-provisioning.md` (and 0189, 0107) already use. It states that only two stale filenames changed and no decision or reasoning did. Every other `review-code` in the ADR is a *recorded stage key* — exactly what the ADR decides to preserve — and is left alone.

Fixes #5082

## Deviations

**Class: sibling defect left for a follow-up.**

- **Said:** the issue scopes the fix to two stale corpus *filenames*, and the acceptance criteria bound it to those.
- **Did:** corrected exactly those two, and left line 160's `` `triage` / `build` / `review-code` groups `` untouched.
- **Why:** that occurrence is a manifest *group key*, not a filename, so it falls outside the stated criteria — but it is genuinely stale too. ADR 0243 re-keyed the group to `review`; the test's expectation table now reads `{file: "review.json", stage: "review", seed: 1199, min: 3}`. Fixing it here would widen a p0 unblock beyond its agreed scope.
- **Disposition:** follow-up filed as #5089. Not a blocker for this PR — it is prose, breaks no gate and no link.

**Class: gate hazard deliberately not addressed.**

- **Said:** the report names two separable things; triage scoped this issue to the ADR repair only.
- **Did:** did not touch `.github/workflows/doc-links.yml`.
- **Why:** the `pull_request`-only trigger that let this reach `main` undetected is a separate unit, explicitly out of scope per the triage amendment.
- **Disposition:** no action needed here; the intake desk owns that ticket.