### PR TITLE
fix(pipeline-cli): a refused invocation is not a verdict — bad flags exit 4, not `stop` (#5072)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1373,7 +1373,7 @@ runs the shared entry point, which cannot hand back a fail-open no:
 ```bash
 # stdout, in order: the §CP scope line, `CP_STATE=<state>`, then `BLOCKING (…)` on every state but
 # `not-control-plane`. Assert on the CP_STATE word — an exit code discriminates outcomes only once
-# the script has RUN, so `… || ordinary` fail-opens on a usage error (1) or a missing binary (127).
+# the script has RUN, so `… || ordinary` fail-opens on a bad invocation (4) or a missing binary (127).
 bash ./.claude/.pipeline/skills/shared/scripts/cp-classify-entry.sh "$REPO" "$PR"
 ```
 
@@ -1399,13 +1399,13 @@ probe unchanged, so this widens no over-match (#2617).
 
 **The exit code discriminates the four states only once the verb has RUN — so a consumer asserts
 on the stdout state word, never on a bare non-zero.** Both naive exit-status shapes are **UNSAFE
-and must not be used**: `… || ordinary` fires on an effect-cli usage error (exit 1, help text on
+and must not be used**: `… || ordinary` fires on a malformed invocation (exit 4, help text on
 stdout, no state word) and on a missing binary (exit 127) exactly as it does on the real verdict,
 routing a §CP change to the ordinary branch; `… && echo BLOCKING` simply emits nothing when the
 verb never ran, so the BLOCKING line the caller relied on never appears. Both fail **open**, and a
 `pipeline-cli` that does not resolve is live here — a bare `pipeline-cli` exits 127 when the shim
 is off `PATH`. That is why `not-control-plane` carries its own exit code **3**, which neither a
-usage error (1), a missing binary (127), nor an unread stdin (4, #3924) produces: an exact
+bad invocation (4, #5072), a missing binary (127), nor an unread stdin (4, #3924) produces: an exact
 `[ "$rc" -eq 3 ]` is proof, `[ "$rc" -ne 0 ]` is not. Every wired consumer below uses the
 state-word form above; a new one that does not is not wired correctly.
 
@@ -1886,8 +1886,16 @@ verb result** at the call site. Read the two apart this way, and never collapse 
 |---|---|---|
 | `"$PCLI" …` exits **127**, or the message names a *path* that does not exist | The CLI **never ran** — resolution failure | **UNKNOWN.** Never clean, never a negative verdict. Re-resolve or route the blocker up. |
 | Exit **1** with `Cannot find module` / `MODULE_NOT_FOUND` naming a `…/pipeline-cli/src/bin.ts` path, and **empty stdout** | The CLI **never ran** — a cwd-relative `node …/src/bin.ts` invocation from a dir that is not the repo root | **UNKNOWN**, exactly as for 127 — even though the exit code collides with several verbs' ordinary "negative" result. This is the collision the ban above exists to remove; if you see it, the call site is non-canonical, not the answer negative (#4236). |
+| Exit **4** | The verb **never decided** — either a malformed invocation (`BAD_INVOCATION_EXIT_CODE`: an unrecognized flag, a typo'd subcommand) or an unread stdin (`STDIN_READ_FAILED_EXIT_CODE`, #3924) | **UNKNOWN.** One never-ran band, deliberately one number. A refused call used to exit `1` — which is `cp-cardinality decide`'s `stop` — so a caller transcribed its own bad flags as a definite "no approval at current head" for four approved §CP PRs (#5072). |
 | Any other non-zero exit | The verb **ran** and returned its own documented contract (e.g. `2` findings / `3` zero scope) | Read it as that verb's result. |
 | Exit 0 | The verb ran and passed | Read it as that verb's result. |
+
+**Read a verb's verdict off its OWN enumerated codes, never off "non-zero".** A verb publishes which
+codes carry a decision (`cp-cardinality decide`: `0` discharge, `1` stop, and nothing else);
+everything outside that set is UNKNOWN. And when a def or a skill tells an agent to *call* a verb,
+show the literal invocation rather than describing its flags — prose that describes an interface
+drifts from the shipped one silently, and the drift lands as a false verdict instead of a visible
+error (#5072).
 
 **A 127 is a PATH/resolution gap. It is NOT worktree teardown.** Teardown is progressive and has
 its own two signatures, in sequence: **exit 1 with `ENOENT` on a file that provably exists on

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -289,6 +289,17 @@ it adds no engine→engine and no human-facing edge.
   green. The §CP unblock logic lives once — in ship-it / `cp-cardinality` — and both the watcher and
   the shipper read that single source, so the trigger fires exactly when the enqueue would discharge
   and no second copy of the §CP discharge forks into this def.
+
+  **What "re-used, never re-derived" covers is the DECISION, not the signals.** `cp-cardinality
+  decide` is a pure function over a roster and two booleans: it takes `--author`,
+  `--non-author-approval-at-head`, `--self-approval-at-head` and the roster on stdin, and resolves
+  nothing over the network — every caller derives the two current-head signals itself. This def used
+  to say the call "resolves the active approver set and the SHA-bound signal flags itself — do NOT
+  re-derive either here", which is false against the shipped CLI, and a seat following it had to
+  invent `--pr`/`--head` to pass the PR and head at all (#5072). So the block below derives the two
+  signals and shows the call literally; `ship-it`'s
+  [`step0-cp-approval.sh`](../../kampus-pipeline/skills/ship-it/scripts/step0-cp-approval.sh) derives
+  the same two for the shipper. Keep those two in step — neither decides.
 - **Every live input the discharge predicate consumes resolves to UNKNOWN when its read could not
   execute — never to a definite answer (fail closed).** This is a rule over the *predicate*, not a
   list of the reads that have failed historically: a tick may interpret an input only after proving
@@ -309,12 +320,13 @@ it adds no engine→engine and no human-facing edge.
   further out), **VERIFIED HEAD** (`.commit_id == $HEAD`, ADR 0058) — and the same disposition on
   failure. Only the assertion differs.
 
-  **The block below is the tick's guards, and only its guards** — it ends where the discharge begins.
-  Proving the inputs is this def's job; *deciding* on them is not, because the decision is ship-it's
-  §CP gate via `cp-cardinality` (the bullet above) and no second copy of it may fork into this def.
-  So the block assembles no approver set, derives no signal flags, and fires nothing — the
-  per-approver membership read above is stated as a rule rather than copied here, since it runs where
-  the approver set is assembled, inside that single-source discharge.
+  **The block below is one PR's whole tick — guards, then the discharge, written out.** The guards
+  prove every input; the discharge derives the two signals and hands the decision to
+  `cp-cardinality`. It is literal and runnable on purpose: a def that *describes* a tool's flags
+  instead of *showing* the call drifts from the shipped interface silently, and the drift surfaces as
+  a false verdict rather than a visible error — a seat reading the old prose invented `--pr`/`--head`,
+  the CLI refused them, and the refusal was recorded as a definite "no approval at current head"
+  (#5072). Copy the call; do not paraphrase it.
 
   ```bash
   # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
@@ -371,23 +383,80 @@ it adds no engine→engine and no human-facing edge.
     *) unknown "machine gates" "checks exit $rc"; return 0 ;;     # 2, 127, crash — the read never ran
   esac
 
-  # → GUARDS END HERE. Every input is proven readable and the gates are proven green, so hand the
-  #   tick to the single-source discharge (the bullet above): ship-it's §CP gate, run through
-  #   `pipeline-cli cp-cardinality decide` on the proven $HEAD / $AUTHOR / $MEMBERS_JSON / $REVIEWS.
-  #   That call resolves the active approver set and the SHA-bound signal flags itself — do NOT
-  #   re-derive either here, which is what forks a second copy of the discharge into this def.
-  #   Read its verdict off its OWN codes: 0 discharges (fire the shipper), 1 is the definite stop;
-  #   every other non-zero means the decision never ran (e.g. exit 4, the unread-stdin code) and is
-  #   this tick's UNKNOWN — never read a stop off "non-zero" (the collision #4204 fixed in
-  #   cp-classify).
-  #
-  #   Transcribe that verdict into the tick record with the SAME three-way vocabulary the guards
-  #   use — `note fired` on 0, `note "definite-stop:no approval at current head"` on 1, and
-  #   `note "unknown:cp-cardinality exit $rc"` on anything else. It is a transcription of the
-  #   branch taken, never a second copy of the decision (#4292).
+  # → GUARDS END HERE. Every input is proven readable and the gates are proven green. What follows
+  #   is the discharge: derive the two current-head signals, then hand the DECISION to the single
+  #   source, `pipeline-cli cp-cardinality decide`. Its whole interface is `--author`,
+  #   `--non-author-approval-at-head`, `--self-approval-at-head` and the roster on stdin — there is
+  #   no `--pr` and no `--head` (#5072).
+
+  # 6. SIGNAL 1 — a current-head APPROVED review by an ACTIVE control-plane member who is NOT the
+  #    author. Pipe the proven payload into REAL `jq`. `gh api --jq` takes no `--arg`: writing
+  #    `gh api … --jq '…' --arg h "$HEAD"` makes gh consume the extras as positional args, error to
+  #    stderr, and yield an EMPTY string that a caller reads as "no approvers" — the same false
+  #    definite one read further out (#5072).
+  APPROVERS="$(printf '%s' "$REVIEWS" | jq -r -s --arg h "$HEAD" \
+    'add | group_by(.user.login) | map(max_by(.submitted_at))
+     | map(select(.state == "APPROVED" and .commit_id == $h) | .user.login) | .[]')" \
+    || { unknown "approver derivation" "jq failed on the reviews payload"; return 0; }
+
+  # Membership is the SHARED three-way read (§CPREAD-APPROVAL's `cp_team_membership`), never a
+  # `--jq '.state'` of your own: `absent` is a definite non-member, a non-zero exit is UNKNOWN. An
+  # UNKNOWN probe must not under-count into a stop that reads as "awaiting approval", so it is
+  # recorded and the scan continues — a later approver proving `active` still discharges honestly.
+  CPREAD="$(dirname "$(dirname "$PCLI")")/skills/shared/scripts/cp-read.sh"
+  NON_AUTHOR_APPROVAL_AT_HEAD=false; MEMBERSHIP_UNKNOWN=false
+  for u in $APPROVERS; do
+    [ "$u" = "$AUTHOR" ] && continue                  # a self-approval is never signal 1 (ADR 0175)
+    if M="$(bash "$CPREAD" "${REPO%%/*}" team-membership "$u" 2>/dev/null)"; then
+      case "$M" in *CP_MEMBERSHIP=active*) NON_AUTHOR_APPROVAL_AT_HEAD=true; break ;; esac
+    else
+      MEMBERSHIP_UNKNOWN=true
+    fi
+  done
+  if [ "$NON_AUTHOR_APPROVAL_AT_HEAD" = false ] && [ "$MEMBERSHIP_UNKNOWN" = true ]; then
+    unknown "approver membership" "at least one probe failed"; return 0
+  fi
+
+  # 7. SIGNAL 2 — the sole-owner self-approval marker, ADR 0175's ONLY N==1 discharge. Derived just
+  #    in that shape, so a normal multi-member tick makes no extra read; cp-cardinality ignores this
+  #    flag whenever N>1, so not deriving it there loses nothing.
+  SELF_APPROVAL_AT_HEAD=false
+  MEMBERS="$(printf '%s' "$MEMBERS_JSON" | jq -r -s 'add | .[].login')" \
+    || { unknown roster "jq failed on the roster payload"; return 0; }
+  if [ "$MEMBERS" = "$AUTHOR" ]; then                 # exactly one member, and it is the author
+    MARKER="$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" 2>/dev/null \
+      | jq -r -s --arg a "$AUTHOR" 'add
+        | map(select(.user.login == $a and (.body | test("(?i)^\\s*\\**\\s*control-plane-self-approval\\b"))))
+        | last | .body // ""')" \
+      || { unknown "self-approval marker" "unreadable comment payload"; return 0; }
+    SELF_SHA="$(printf '%s\n' "$MARKER" \
+      | grep -ioE 'control-plane-self-approval[[:space:]]*@?[[:space:]]*[0-9a-f]{7,40}' \
+      | grep -ioE '[0-9a-f]{7,40}' | tail -n1)"
+    # Guard 1 proved $HEAD is 40-hex, so this prefix match cannot degenerate into "binds any head";
+    # the empty $SELF_SHA case is still excluded explicitly, because that is the other half (#4223).
+    case "$SELF_SHA" in "") : ;; *) case "$HEAD" in "$SELF_SHA"*) SELF_APPROVAL_AT_HEAD=true ;; esac ;; esac
+  fi
+
+  # 8. THE DECISION — roster on stdin, a signal flag passed only when that signal is present at head.
+  #    cp-cardinality selects which signal its branch requires; this block never re-decides.
+  printf '%s\n' "$MEMBERS" | "$PCLI" cp-cardinality decide --author "$AUTHOR" \
+    $([ "$NON_AUTHOR_APPROVAL_AT_HEAD" = true ] && printf -- '--non-author-approval-at-head') \
+    $([ "$SELF_APPROVAL_AT_HEAD" = true ] && printf -- '--self-approval-at-head') >/dev/null 2>&1
+  rc=$?
+  # ENUMERATE the verdict codes; everything else is UNKNOWN. 0 and 1 are the ONLY codes that carry a
+  # decision — 4 is a malformed invocation or an unread stdin (`BAD_INVOCATION_EXIT_CODE` /
+  # `STDIN_READ_FAILED_EXIT_CODE`), 127 is a shim off PATH, anything else is a crash. Reading a stop
+  # off `!= 0` is what recorded four approved §CP PRs as definite stops (#5072).
+  case "$rc" in
+    0) note fired
+       echo "approval-watcher #$PR: §CP discharged at $HEAD — fire the shipper" ;;
+    1) note "definite-stop:no approval at current head"
+       echo "approval-watcher #$PR: no approval at current head (read OK, definite)" ;;
+    *) unknown "cp-cardinality" "decide exit $rc" ;;
+  esac
   ```
 
-  The block above is one PR's guards. The **tick** frames it: re-derive the watch set from the board,
+  The block above is one PR's tick — `tick_one_pr`. The **tick** frames it: re-derive the watch set from the board,
   run the guards + discharge per PR, then write the tick's one durable record — including when the
   derived set is empty, which is the case that most needs recording, and when the derivation itself
   could not be read, which must not land as that same empty.
@@ -414,8 +483,12 @@ it adds no engine→engine and no human-facing edge.
 
   The exit-code idiom is the shipped one, not a new invention: `STDIN_READ_FAILED_EXIT_CODE = 4`
   in [`packages/pipeline-cli/src/read-stdin.ts`](../../../packages/pipeline-cli/src/read-stdin.ts) —
-  "distinct from a gate's own verdict codes: the input was never read." So a tool's verdict codes are
-  the only codes you read a verdict off; any other non-zero is a read that never happened.
+  "distinct from a gate's own verdict codes: the input was never read." Its invocation-side twin is
+  `BAD_INVOCATION_EXIT_CODE` in
+  [`packages/pipeline-cli/src/exit-codes.ts`](../../../packages/pipeline-cli/src/exit-codes.ts), the
+  same 4: the router seats every unrecognized flag there so a refused call can no longer land on the
+  1 that means `stop`. So a tool's verdict codes are the only codes you read a verdict off; any other
+  non-zero is a call that never decided.
 
   **Log "read failed" distinctly from a definite non-firing answer, and name which read failed.**
   They are different facts with the same non-firing outcome, and collapsing them makes a GitHub

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -87,11 +87,16 @@ IO injected so the `EAGAIN` path is testable, lives in
 
 A classifier verb that can clear a hold — `cp-classify`, `guard-content-probe` — seats its
 **proven-ordinary** verdict on `PROVEN_ORDINARY_EXIT_CODE` from
-[`src/exit-codes.ts`](./src/exit-codes.ts), never on `1`. `1` is what effect-cli returns for a
-usage error and what a module-load failure surfaces as; `127` is the shell's missing-binary code.
-A verdict sharing either is unreadable as proof — `[ $? -ne 0 ]` then reads "the tool never ran"
-as "the tool ran and proved it ordinary". This is the verdict-side twin of the stdin rule above
-(#4208, #4219).
+[`src/exit-codes.ts`](./src/exit-codes.ts), never on `1`. `1` is what a module-load failure
+surfaces as; `127` is the shell's missing-binary code. A verdict sharing either is unreadable as
+proof — `[ $? -ne 0 ]` then reads "the tool never ran" as "the tool ran and proved it ordinary".
+This is the verdict-side twin of the stdin rule above (#4208, #4219).
+
+A **malformed invocation** — an unrecognized flag, a typo'd subcommand — is the third way to never
+run, and the router seats it on `BAD_INVOCATION_EXIT_CODE` (`4`, the same never-ran band as
+`STDIN_READ_FAILED_EXIT_CODE`) rather than leaving it on effect-cli's default `1`. It used to land
+on `1`, which is `cp-cardinality decide`'s `stop`: a caller that passed flags the verb never
+accepted recorded four approved §CP PRs as definite stops from a decision that never ran (#5072).
 
 The exit code discriminates verdicts **only once the verb has run**, so a caller asserts on the
 **stdout state word** and treats every other value, including the empty string a failure to

--- a/packages/pipeline-cli/src/exit-codes.ts
+++ b/packages/pipeline-cli/src/exit-codes.ts
@@ -2,11 +2,25 @@
  * The exit-code rule that outranks any per-tool choice: **a verdict a tool PROVED must never share
  * an exit code with a failure to invoke** (#4208, #4219).
  *
- * `1` is what effect-cli returns for a usage error (a bad flag, a typo'd subcommand) and what the
- * runner returns when a module fails to load; `127` is the shell's missing-binary code. A
- * proven-ordinary verdict seated on either is unreadable as proof — `[ $? -ne 0 ]` then reads "the
- * tool never ran" as "the tool ran and proved it ordinary", the fail-open direction every §CP guard
- * exists to close. `STDIN_READ_FAILED_EXIT_CODE = 4` (`read-stdin.ts`) is this same rule on the
- * input side; this is its verdict side, shared so the §CP classifier verbs cannot drift apart.
+ * `1` is what the runner returns when a module fails to load, and `127` is the shell's
+ * missing-binary code. A proven-ordinary verdict seated on either is unreadable as proof —
+ * `[ $? -ne 0 ]` then reads "the tool never ran" as "the tool ran and proved it ordinary", the
+ * fail-open direction every §CP guard exists to close. `STDIN_READ_FAILED_EXIT_CODE = 4`
+ * (`read-stdin.ts`) is this same rule on the input side; this is its verdict side, shared so the
+ * §CP classifier verbs cannot drift apart.
  */
 export const PROVEN_ORDINARY_EXIT_CODE = 3;
+
+/**
+ * A malformed invocation — an unrecognized flag, a missing flag value, a typo'd subcommand. The
+ * router seats every effect-cli parse error here (`run.ts`) instead of leaving it on effect-cli's
+ * default `1`, because `1` is a *verdict* for several verbs: `cp-cardinality decide` exits 1 for
+ * `stop`, so `--pr`/`--head` (flags it never accepted) died on exit 1 and a caller transcribed
+ * "the CLI refused my invocation" as "no approval at current head" — four approved §CP PRs recorded
+ * as definite stops from a decision that never ran (#5072).
+ *
+ * Deliberately the same number as `STDIN_READ_FAILED_EXIT_CODE`: both mean "the tool never got
+ * usable input, so it never decided". A caller's exit table wants ONE never-ran band, not a new
+ * integer per way of failing to start.
+ */
+export const BAD_INVOCATION_EXIT_CODE = 4;

--- a/packages/pipeline-cli/src/run.ts
+++ b/packages/pipeline-cli/src/run.ts
@@ -16,7 +16,8 @@
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Effect, Result} from "effect";
-import {Command} from "effect/unstable/cli";
+import {CliError, Command} from "effect/unstable/cli";
+import {BAD_INVOCATION_EXIT_CODE} from "./exit-codes.ts";
 import {registeredTools} from "./registry.ts";
 import {dispatch} from "./router.ts";
 import {
@@ -63,4 +64,14 @@ const cli = Command.make("pipeline-cli").pipe(
 	Command.withDescription("The pipeline tooling router — `pipeline-cli <tool> …` (epic #994)"),
 );
 
-cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);
+cli.pipe(
+	Command.run({version: VERSION}),
+	// A parse failure is "the verb never ran", so it must not land on the exit code some verb uses
+	// for a verdict. effect-cli fails with a `CliError` (after printing help) and `runMain` would
+	// exit 1 — which `cp-cardinality decide` uses for `stop`. See `BAD_INVOCATION_EXIT_CODE` (#5072).
+	Effect.catchIf(CliError.isCliError, () =>
+		Effect.sync(() => process.exit(BAD_INVOCATION_EXIT_CODE)),
+	),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/pipeline-cli/src/tools/cp-cardinality/README.md
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/README.md
@@ -63,6 +63,22 @@ The decision word (`discharge` | `stop`) goes to **stdout**; a human reason goes
 **stderr**. Exit is **0 on `discharge`, 1 on `stop`**, so the gate bash fails closed with
 `… && carry-on || STOP`.
 
+## The exit codes — 0 and 1 are the only verdicts
+
+| exit | meaning | how a caller reads it |
+| --- | --- | --- |
+| `0` | `discharge` | the decision ran and discharged |
+| `1` | `stop` | the decision ran and stopped — the **definite** "no current-head signal" |
+| `4` | the invocation was malformed (an unrecognized flag) or stdin was never read | **UNKNOWN** — no decision was made |
+| anything else | the tool never ran (127 = shim off PATH, a crash) | **UNKNOWN** |
+
+**Read a stop off an exact `1`, never off "non-zero".** There is no `--pr` and no `--head`; a
+caller that invented them died on effect-cli's old usage-error exit 1 and recorded a definite
+"no approval at current head" for four §CP PRs that were approved at their exact heads — a decision
+that never ran, transcribed as a verdict ([#5072](https://github.com/kamp-us/phoenix/issues/5072)).
+Seating a malformed invocation on `4` (`BAD_INVOCATION_EXIT_CODE`, the same never-ran band as
+`STDIN_READ_FAILED_EXIT_CODE`) is what makes an exit table safe to write.
+
 **The caller owns roster validity — this core cannot recover it.** A bare
 `MEMBERS="$(gh api … --jq …)"` does not fail loudly: `gh` skips `--jq` on an error response and
 writes the error body to **stdout**, so the capture is a one-line JSON blob and this tool is handed

--- a/packages/pipeline-cli/src/tools/cp-cardinality/command.test.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/command.test.ts
@@ -1,0 +1,76 @@
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {BAD_INVOCATION_EXIT_CODE} from "../../exit-codes.ts";
+import {STDIN_READ_FAILED_EXIT_CODE} from "../../read-stdin.ts";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../../test-budget.ts";
+
+// The exit-code contract of `cp-cardinality decide` over the REAL bin, because the defect lives in
+// the invocation boundary the pure core never sees: `--pr`/`--head` (flags this verb never accepted)
+// exited 1, which is also its `stop` verdict, so a caller recorded "no approval at current head" for
+// four §CP PRs whose decision never ran (#5072).
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL("../../../../..", import.meta.url));
+
+const ROSTER = "usirin\\nnotusirin\\n";
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const decide = (flags: string, roster: string = ROSTER): RunResult => {
+	const r = spawnSync(
+		"sh",
+		["-c", `printf '${roster}' | node "${BIN}" cp-cardinality decide ${flags}`],
+		{
+			cwd: REPO_ROOT,
+			encoding: "utf8",
+		},
+	);
+	return {code: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? ""};
+};
+
+describe("cp-cardinality decide — a bad invocation is not a verdict (#5072)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("exits on the bad-invocation code for the flags the field call invented, not on `stop`", () => {
+		const {code, stdout} = decide("--pr 5051 --head deadbeef --author usirin");
+		expect(code).toBe(BAD_INVOCATION_EXIT_CODE);
+		// The whole defect: 1 IS this verb's `stop`. A caller reading either code off a verdict table
+		// would transcribe a refused invocation as a definite "no approval at current head".
+		expect(code).not.toBe(0);
+		expect(code).not.toBe(1);
+		// The decision word is a line of its own on stdout; the help text this failure prints merely
+		// mentions "discharge" in prose, so match the line, not the substring.
+		const lines = stdout.split("\n").map((l) => l.trim());
+		expect(lines).not.toContain("stop");
+		expect(lines).not.toContain("discharge");
+	});
+
+	it("names the unrecognized flags, so the failure is diagnosable without re-running", () => {
+		const {stdout, stderr} = decide("--pr 5051 --author usirin");
+		expect(`${stdout}${stderr}`).toContain("--pr");
+	});
+
+	it("keeps the never-ran band one number — the same code an unread stdin already used", () => {
+		expect(BAD_INVOCATION_EXIT_CODE).toBe(STDIN_READ_FAILED_EXIT_CODE);
+	});
+});
+
+describe("cp-cardinality decide — the verdict codes are untouched", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("discharges on exit 0 with a non-author current-head approval (N>=2)", () => {
+		const {code, stdout} = decide("--author usirin --non-author-approval-at-head");
+		expect(stdout.trim()).toBe("discharge");
+		expect(code).toBe(0);
+	});
+
+	it("stops on exit 1 with no signal (N>=2)", () => {
+		const {code, stdout} = decide("--author usirin");
+		expect(stdout.trim()).toBe("stop");
+		expect(code).toBe(1);
+	});
+});

--- a/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
@@ -12,6 +12,11 @@
  * to **stderr**. Exit code mirrors the decision: 0 on `discharge`, 1 on `stop`, so the gate
  * bash can `pipeline-cli cp-cardinality decide … && carry-on || STOP` and fail closed.
  *
+ * **Those two are the ONLY verdict codes; anything else means no decision was made.** A malformed
+ * invocation exits `BAD_INVOCATION_EXIT_CODE` (4, `exit-codes.ts`) and an unread pipe exits
+ * `STDIN_READ_FAILED_EXIT_CODE` (4) — never 1. A caller that reads a stop off "non-zero" instead of
+ * off an exact `1` transcribes its own bad call as a definite "no approval at current head" (#5072).
+ *
  * IO here (the thin bin); the whole ADR-0175 branch lives in `cp-cardinality.ts` (the pure,
  * unit-tested core). ship-it owns the `gh api` REST resolution of the members roster, the PR
  * author/head, and the two SHA-bound signals — the integration half this tool never touches.

--- a/packages/pipeline-cli/src/tools/cp-classify/README.md
+++ b/packages/pipeline-cli/src/tools/cp-classify/README.md
@@ -45,7 +45,7 @@ The exit code discriminates the four states **only once the verb has run.** It c
 | a hold state (`control-plane` / `content-undetermined` / `unknown`) | 0 | the state word |
 | `not-control-plane` | 3 | `not-control-plane` |
 | unread stdin (`STDIN_READ_FAILED_EXIT_CODE`, #3924) | 4 | *(empty)* |
-| a bad flag (effect-cli usage error) | 1 | the help text — **no state word** |
+| a bad flag (`BAD_INVOCATION_EXIT_CODE`, #5072) | 4 | the help text — **no state word** |
 | a missing binary | 127 | *(empty)* |
 
 **The sanctioned idiom is a positive match on the stdout state word** — what all three rewired
@@ -71,8 +71,8 @@ fi
 §CP change to the ordinary branch; `&&` simply stays silent, so the BLOCKING line the caller was
 relying on never appears. Both fail **open**.
 
-`not-control-plane` therefore carries its own exit code, **3** — one that neither effect-cli's
-usage error (1) nor a missing binary (127) nor an unread stdin (4) produces. An exact
+`not-control-plane` therefore carries its own exit code, **3** — one that neither a malformed
+invocation (4) nor a missing binary (127) nor an unread stdin (4) produces. An exact
 `[ "$rc" -eq 3 ]` test is positive proof; `[ "$rc" -ne 0 ]` is not. This is the
 `STDIN_READ_FAILED_EXIT_CODE` convention (`../../read-stdin.ts`, #3924) applied to the verdict
 itself: *"the tool never ran"* must never be readable as an answer. Note that a pipe hides the

--- a/packages/pipeline-cli/src/tools/cp-classify/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-classify/command.ts
@@ -16,8 +16,8 @@
  * failure-to-run produces — on the one proven-ordinary verdict. The exit code discriminates the
  * four states ONLY ONCE THE VERB HAS RUN; it says nothing about whether it ran, so a caller must
  * assert on the stdout state word (`[ "$CP_STATE" = "not-control-plane" ]`), never on mere
- * non-zero. `… || ordinary` is UNSAFE: it fires on a usage error (1) and a missing binary (127)
- * alike. See the README's "How to call this safely" for the observed failure modes.
+ * non-zero. `… || ordinary` is UNSAFE: it fires on a malformed invocation (4) and a missing binary
+ * (127) alike. See the README's "How to call this safely" for the observed failure modes.
  *
  * `content-undetermined` is an OBLIGATION, not a verdict: resolve it by running the existing
  * `guard-content-probe` verb over each listed `.decisions/**` file at the PR head (ADR 0164). It is

--- a/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
@@ -18,7 +18,7 @@
  * code no failure-to-run produces — on the one proven-ordinary verdict. The exit code discriminates
  * the two verdicts ONLY ONCE THE VERB HAS RUN; it says nothing about whether it ran, so a caller
  * must assert on the stdout state word (`[ "$GC_STATE" = "not-guard-touching" ]`), never on mere
- * non-zero. `… && echo BLOCKING` is UNSAFE — it emits nothing on a usage error (1), a
+ * non-zero. `… && echo BLOCKING` is UNSAFE — it emits nothing on a malformed invocation (4), a
  * module-not-found from a nested cwd (1), or a missing binary (127), so a probe that never ran
  * reads as an ordinary ADR (#4219). See the README's "How to call this safely".
  *


### PR DESCRIPTION
The crew engine's approval-watcher asked `pipeline-cli cp-cardinality decide` for a §CP verdict using two flags that verb has never accepted. The CLI refused the call and exited 1 — which is also the verb's word for "stop" — so the watcher wrote down `definite-stop:no approval at current head` for four §CP PRs that were, in fact, approved at their exact heads. This PR makes a refused call exit on a code no verdict uses, and replaces the prose that invented the flags with the actual, runnable call.

It fails closed either way (nothing merges wrongly). What it fixes is the silent permanent stall, and a ledger that confidently recorded the opposite of the truth.

## What changed

**The CLI — a refused invocation gets its own exit code.**
- `packages/pipeline-cli/src/exit-codes.ts`: new `BAD_INVOCATION_EXIT_CODE = 4`, deliberately the same number as `STDIN_READ_FAILED_EXIT_CODE`. Both mean "the tool never got usable input, so it never decided" — a caller's exit table wants one never-ran band, not a new integer per way of failing to start.
- `packages/pipeline-cli/src/run.ts`: the router catches effect-cli's `CliError` and exits 4 instead of letting `runMain` land on 1. This is router-wide on purpose: `1` is a *verdict* for more than one verb, so the collision had to be removed at the one place every parse error passes through.
- `packages/pipeline-cli/src/tools/cp-cardinality/command.test.ts` (new): spawns the real bin and pins the bad-input code as neither `0` nor `1`, plus non-regression on the two verdict codes.

**The agent def — a literal call instead of a description of one.**
`claude-plugins/pipeline-crew/agents/crew-engineering-manager.md`'s approval-watcher tick block now carries the discharge, written out:
- it derives `--non-author-approval-at-head` itself (exact-login match against an **active** control-plane member, `.commit_id == $HEAD`, non-author), and `--self-approval-at-head` in the sole-owner shape only;
- the approver read pipes into **real `jq`** — `gh api --jq` takes no `--arg`, and that misuse errors to stderr while yielding an empty string a caller reads as "no approvers". An empty or failed read routes to `unknown:`, never to a definite "no approval";
- membership goes through the shared three-way `cp-read.sh team-membership` relay, so an unreadable probe stays UNKNOWN rather than under-counting into a stop;
- the exit table enumerates cp-cardinality's codes — `0` fired, `1` definite stop, **anything else** `unknown:` — so a bad-input exit can no longer be transcribed as `definite-stop`;
- the false sentence "That call resolves the active approver set and the SHA-bound signal flags itself — do NOT re-derive either here" is gone, replaced by what the shipped CLI actually requires of a caller.

**The contract + the stale exit-code prose.**
`gh-issue-intake-formats.md` §CLI gains a row for exit 4 and states the rule this bug is an instance of: read a verdict off a verb's own enumerated codes, and when a def tells an agent to *call* a verb, show the literal invocation — prose that describes an interface drifts from the shipped one silently, and the drift lands as a false verdict instead of a visible error. Six other places that said "usage error (1)" are corrected to 4.

## Run evidence

The tick block's discharge, run verbatim against the four PRs the false records name:

```
#5051 → §CP discharged at d91e9d8fac154319bd78065e3f17f24be7ef0c98 — TICK_NOTES=5051=fired
#5043 → §CP discharged at f00ac85ceccbfc35079d847641df3a1cf213704e — TICK_NOTES=5043=fired
#5037 → §CP discharged at 1fd2cb1736501cb2b6d0c48def7a08d2b77a77e7 — TICK_NOTES=5037=fired
#5014 → §CP discharged at f01b5935e3da1bf8d213f9ed4f2d7ab346e09d7a — TICK_NOTES=5014=fired
```

The old call, before and after the CLI change:

```
$ printf 'usirin\nnotusirin\n' | pipeline-cli cp-cardinality decide --pr 5051 --head abc --author usirin
ERRORS
  Unrecognized flag: --pr in command pipeline-cli cp-cardinality decide
  Unrecognized flag: --head in command pipeline-cli cp-cardinality decide
rc=4          # was 1 — the same code as `stop`
```

Local checks: `pnpm typecheck --force` (30/30, uncached), `pnpm lint:worktree` clean, `pipeline-cli` suite 3055/3055 across 183 files, `cli-invocation-guard check` clean over the 399-file plugin corpus, `gh-phoenix lint-skills` clean.

## Ledger #4753

The four false `definite-stop` records are annotated in place by a follow-up comment — appended, never rewritten. The false tick is the evidence; deleting it would erase the only trace of the defect.

## Deviations

- **Known defect left unfixed (class 3)** — **Said:** #5072 asks that a refused `cp-cardinality decide` call can no longer be read as a definite verdict. **Did:** only the crew-EM approval-watcher tick block was reseated. `ship-it`'s `step0-cp-approval.sh` still reads the discharge as `if … then discharge else stop`, so a future bad invocation there would land on the stop branch — and its stop message asserts it "states a fact", which exit 4 now makes falsifiable. **Why:** it cannot fire today (its flags are correct), and reseating a §CP merge-gate script is its own change, not a ride-along on this one. **Disposition:** follow-up #5098 filed, carrying the falsifiable-"states a fact" note and the fix shape (enumerate 0 / 1 / else, mirroring the block this PR wrote).
- **Scope narrowing (class 1)** — None.
- **Governing-ADR departure (class 2)** — None.
- **Declined guidance (class 4)** — None.
- **Guard or gate bypassed (class 5)** — None.
- **Pre-existing test or fixture changed (class 6)** — None. `command.test.ts` is new; no existing assertion was modified, weakened, or deleted.
- **Out-of-scope change (class 7)** — None. `src/exit-codes.ts` and `src/run.ts` are the router-wide seat the issue's fix shape implies.

## Control plane

This touches `claude-plugins/**` and `packages/pipeline-cli/src/tools/cp-cardinality/`, so expect §CP classification. The classifier at head reports 8 of the 11 changed files as control-plane-owned.

Fixes #5072
