### PR TITLE
feat(fabrika-cli): the review stage's third surface — a skill entry graded per rigor check (#5038)

### DIFF
--- a/.decisions/0243-review-eval-stage-surface-discriminator.md
+++ b/.decisions/0243-review-eval-stage-surface-discriminator.md
@@ -83,12 +83,54 @@ admits exactly one label shape:
 |---|---|---|
 | `review` | `code` | `{verdict, acFindings}` |
 | `review` | `doc` | `{verdict, findings}` |
-| `review` | `skill` | the skill rubric's own label shape |
+| `review` | `skill` | `{verdict, rigorFindings: {check, finding}[]}` (§1a) |
 
 A `review` entry whose label shape does not match its `surface` stays **unrepresentable** — the
 guarantee `corpus.ts` states for `stage` now holds for the `(stage, surface)` pair. `surface` is
 therefore required on a `review` entry and carries no default; a `review` entry with no `surface` is
 a decode failure, not a row graded by a fallback rubric.
+
+### 1a. Amendment, 2026-08-09 — the `skill` surface's label shape ([#5038](https://github.com/kamp-us/phoenix/issues/5038))
+
+The table above shipped with its third row open, because the founder ruling on
+[#4979](https://github.com/kamp-us/phoenix/issues/4979) fenced designing that shape out of the lane
+that built the stage. This amendment fills the cell; nothing else in the record changes.
+
+The shape is:
+
+```
+{ verdict, rigorFindings: ReadonlyArray<{check, finding}> }
+```
+
+where `check` is one of a closed four-value vocabulary transcribed from
+[`claude-plugins/fabrika/skills/review/rubrics/skill.md`](../claude-plugins/fabrika/skills/review/rubrics/skill.md):
+`behavioral-correctness`, `trigger-description-quality`, `cross-skill-conflict`,
+`fabrika-conventions`.
+
+**The one live question was flat findings versus per-check attribution, and it resolves to
+per-check.** Three reasons, in the order they carry weight:
+
+- **The source already carries the attribution.** The skill rubric is the only one of the three
+  whose checks are a *numbered, closed set* — `code`'s findings are per acceptance criterion and
+  `doc`'s are a hygiene checklist with no fixed partition, which is why both of those flatten to a
+  bare string array honestly. Flattening here would discard a distinction the rubric states, and no
+  consumer could recover it.
+- **It makes the rubric's own exclusion enforceable.** The rubric assigns gate-invariant
+  preservation to the `governance` skill and says it is "never graded here". With a closed `check`
+  vocabulary that omits it, a row attributing a finding to that check is *unrepresentable* — the
+  fence becomes a decode failure instead of a convention. A flat array cannot express the fence at
+  all, which is the same make-invalid-states-unrepresentable argument §6 uses to reject the superset
+  struct.
+- **It grades what a skill review is actually wrong about.** A right finding filed under the wrong
+  check is a real miss of the rubric, and the pair label is what lets the oracle see it. The grader
+  compares the *set of pairs*, in the same order-and-repeat-insensitive way the other two surfaces
+  compare their finding sets (ADR 0112 §3), so no new grading regime is introduced.
+
+**Not decided here, deliberately:** there is no recorded `review-skill` provenance key, because the
+v1 gate committed no rows under one — a provenance key is minted by history
+([#4977](https://github.com/kamp-us/phoenix/issues/4977)), never in advance. If the rubric later
+renumbers its checks, that is a change to this closed vocabulary and to the rows keyed by it, and it
+comes back through this record.
 
 ### 2. `gradeEntry` dispatches on the pair
 

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -21,6 +21,7 @@ slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) shipped the corp
   - `build` → `{ fixesRef, ciGreen, reviewVerdict }`
   - `review` + `surface: "code"` → `{ verdict, acFindings }`
   - `review` + `surface: "doc"` → `{ verdict, findings }`
+  - `review` + `surface: "skill"` → `{ verdict, rigorFindings: { check, finding }[] }`
   - `ship-it` → `{ merged, mergeSha }`
 - `CorpusManifest` — the frozen ground truth: entries grouped under **live** stage keys, each
   key admitting only that stage's entry (the second half of the unrepresentable guarantee).
@@ -29,20 +30,25 @@ slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) shipped the corp
 
 The v1 review gates merged into one `review` skill, so the corpus keeps **one** `review` stage key
 and every review entry carries a `surface` that selects both its label shape and its grader ([ADR
-0243](../../../../.decisions/0243-review-eval-stage-surface-discriminator.md)). The two label shapes
-genuinely differ (`acFindings` vs `findings`), so the guarantee above now holds over the
-**`(stage, surface)` pair**: a `review` entry whose label doesn't match its surface is
+0243](../../../../.decisions/0243-review-eval-stage-surface-discriminator.md)). The three label
+shapes genuinely differ (`acFindings` vs `findings` vs `rigorFindings`), so the guarantee holds over
+the **`(stage, surface)` pair**: a `review` entry whose label doesn't match its surface is
 unrepresentable, and a `review` entry with **no** surface is a decode failure, never a row a
 fallback rubric grades. `gradeEntry` narrows the same way — `stage` to `review`, then `surface` to
-its own grader — because dispatching on `stage` alone is what would silently collapse two rubrics
+its own grader — because dispatching on `stage` alone is what would silently collapse three rubrics
 onto one grader. One PR reviewed on two surfaces is two rows sharing an `inputRef`, each graded by
 its own grader; that is the intended shape, not a duplicate.
 
-`REVIEW_SURFACES` names `code` and `doc`. ADR 0243 also names a `skill` surface, whose entry shape
-is deliberately **not** defined here: the founder ruling on
-[#4979](https://github.com/kamp-us/phoenix/issues/4979) split designing it into
-[#5038](https://github.com/kamp-us/phoenix/issues/5038), so that a build lane never fixes a schema
-as a side effect.
+`REVIEW_SURFACES` names all three: `code`, `doc` and `skill`.
+
+The `skill` surface's label is the one that is not a flat array of finding strings. Its findings each
+name the rubric check they came from, drawn from the closed vocabulary `SKILL_RIGOR_CHECKS` — the
+four numbered checks in
+[`rubrics/skill.md`](../../../../claude-plugins/fabrika/skills/review/rubrics/skill.md). That rubric
+is the only one of the three whose checks are a fixed set, and it hands gate-invariant preservation
+to the `governance` skill, so a row cannot attribute a finding to a check this surface does not own.
+[ADR 0243 §1a](../../../../.decisions/0243-review-eval-stage-surface-discriminator.md) records the
+derivation and why the findings are not flattened.
 
 ### Live stage key vs recorded provenance
 

--- a/packages/fabrika-cli/src/eval/corpus.ts
+++ b/packages/fabrika-cli/src/eval/corpus.ts
@@ -36,15 +36,29 @@ export type LiveStage = (typeof STAGES)[number];
 
 /**
  * The review surfaces the one `review` stage fans into (ADR 0243 §1) — the axis that selects
- * both a review entry's label shape and its grader. The ADR names a third, `skill`, whose entry
- * shape is deliberately absent here: it has no designed label shape yet, and the founder ruling on
- * #4979 fenced designing one out of this lane, so it is #5038's. A surface with no entry shape is
- * not listed, because this tuple is what a consumer enumerates.
+ * both a review entry's label shape and its grader.
  */
-export const REVIEW_SURFACES = ["code", "doc"] as const;
+export const REVIEW_SURFACES = ["code", "doc", "skill"] as const;
 
 /** One review surface — the sub-discriminator of the `review` stage. */
 export type ReviewSurface = (typeof REVIEW_SURFACES)[number];
+
+/**
+ * The skill rubric's four rigor checks, as a closed vocabulary, in the order
+ * `claude-plugins/fabrika/skills/review/rubrics/skill.md` numbers them. The rubric's fifth
+ * candidate — gate-invariant preservation — is absent on purpose: that check is the `governance`
+ * skill's and the rubric says it is "never graded here", so a corpus row cannot attribute a
+ * finding to it. See ADR 0243 §1a.
+ */
+export const SKILL_RIGOR_CHECKS = [
+	"behavioral-correctness",
+	"trigger-description-quality",
+	"cross-skill-conflict",
+	"fabrika-conventions",
+] as const;
+
+/** One rigor check of the skill rubric. */
+export type SkillRigorCheck = (typeof SKILL_RIGOR_CHECKS)[number];
 
 /** A reproducible input identifier — an issue/PR number (ADR 0112 §1: pinned by identifier). */
 const InputRef = Schema.Int;
@@ -105,7 +119,23 @@ const ReviewDocLabel = Schema.Struct({
 });
 
 /**
- * The `review` stage's two members, each pinning `surface` to a literal and admitting exactly one
+ * The skill surface's oracle: the verdict plus findings that each name the rigor check they came
+ * from. This surface's rubric is the only one of the three whose checks are a numbered, closed set,
+ * so a flat `Array(String)` would throw away an attribution the source already carries — and would
+ * leave the rubric's governance exclusion unexpressible. See ADR 0243 §1a for the derivation.
+ */
+const ReviewSkillLabel = Schema.Struct({
+	verdict: Verdict,
+	rigorFindings: Schema.Array(
+		Schema.Struct({
+			check: Schema.Literals([...SKILL_RIGOR_CHECKS]),
+			finding: Schema.String,
+		}),
+	),
+});
+
+/**
+ * The `review` stage's three members, each pinning `surface` to a literal and admitting exactly one
  * label shape. `surface` is required and has no default: a `review` entry with no surface is a
  * decode failure, never a row a fallback rubric grades (ADR 0243 §1).
  */
@@ -121,6 +151,13 @@ const ReviewDocEntry = Schema.Struct({
 	surface: Schema.Literal("doc"),
 	inputRef: InputRef,
 	label: ReviewDocLabel,
+});
+
+const ReviewSkillEntry = Schema.Struct({
+	stage: Schema.Literal("review"),
+	surface: Schema.Literal("skill"),
+	inputRef: InputRef,
+	label: ReviewSkillLabel,
 });
 
 /**
@@ -141,10 +178,15 @@ const RecordedReviewDocEntry = Schema.Struct({
 	label: ReviewDocLabel,
 });
 
-/** Everything a manifest's `review` group admits: both live surfaces plus both recorded keys. */
+/**
+ * Everything a manifest's `review` group admits: all three live surfaces plus the two recorded
+ * keys. There is no recorded `review-skill` key, because the v1 gate recorded no rows under one —
+ * a provenance key is minted by history, never in advance (#4977).
+ */
 const ReviewGroupEntry = Schema.Union([
 	ReviewCodeEntry,
 	ReviewDocEntry,
+	ReviewSkillEntry,
 	RecordedReviewCodeEntry,
 	RecordedReviewDocEntry,
 ]);
@@ -170,6 +212,7 @@ export const CorpusEntry = Schema.Union([
 	RecordedWriteCodeEntry,
 	ReviewCodeEntry,
 	ReviewDocEntry,
+	ReviewSkillEntry,
 	RecordedReviewCodeEntry,
 	RecordedReviewDocEntry,
 	ShipItEntry,

--- a/packages/fabrika-cli/src/eval/corpus.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/corpus.unit.test.ts
@@ -7,6 +7,7 @@ import {
 	decodeManifest,
 	encodeManifest,
 	REVIEW_SURFACES,
+	SKILL_RIGOR_CHECKS,
 	STAGES,
 } from "./corpus.ts";
 
@@ -41,6 +42,17 @@ const validManifest = {
 				surface: "doc",
 				inputRef: 1850,
 				label: {verdict: "FAIL", findings: ["broken link"]},
+			},
+			{
+				stage: "review",
+				surface: "skill",
+				inputRef: 5038,
+				label: {
+					verdict: "FAIL",
+					rigorFindings: [
+						{check: "trigger-description-quality", finding: "description under-claims"},
+					],
+				},
 			},
 		],
 		"ship-it": [{stage: "ship-it", inputRef: 1851, label: {merged: true, mergeSha: "deadbee"}}],
@@ -120,13 +132,17 @@ describe("CorpusEntry — a per-stage label-shape mismatch is rejected", () => {
 	});
 });
 
-// ADR 0243: the merge of review-code + review-doc into one `review` stage is exactly where the
-// module's unrepresentable-invalid guarantee is easiest to lose, because the two surfaces carry
-// genuinely different label shapes (`acFindings` vs `findings`). It now holds over the
+// ADR 0243: the merge of the v1 review gates into one `review` stage is exactly where the module's
+// unrepresentable-invalid guarantee is easiest to lose, because the three surfaces carry genuinely
+// different label shapes (`acFindings` vs `findings` vs `rigorFindings`). It now holds over the
 // (stage, surface) PAIR, and these prove it at both layers — the schema and the type.
 describe("review — a label mismatched to its surface stays unrepresentable", () => {
 	const docShapedLabel = {verdict: "PASS", findings: ["broken link"]};
 	const codeShapedLabel = {verdict: "PASS", acFindings: ["AC1 met"]};
+	const skillShapedLabel = {
+		verdict: "PASS",
+		rigorFindings: [{check: "fabrika-conventions", finding: "restates a sibling's behavior"}],
+	};
 
 	it("rejects a doc-shaped label under surface code", () => {
 		const result = decodeEntry({
@@ -168,12 +184,57 @@ describe("review — a label mismatched to its surface stays unrepresentable", (
 		assert.isTrue(Result.isFailure(result));
 	});
 
-	it("rejects a surface outside the two this lane defines", () => {
+	it("rejects a surface outside the three ADR 0243 names", () => {
+		const result = decodeEntry({
+			stage: "review",
+			surface: "design",
+			inputRef: 1,
+			label: codeShapedLabel,
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a code-shaped label under surface skill", () => {
 		const result = decodeEntry({
 			stage: "review",
 			surface: "skill",
 			inputRef: 1,
 			label: codeShapedLabel,
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a skill-shaped label under surface doc", () => {
+		const result = decodeEntry({
+			stage: "review",
+			surface: "doc",
+			inputRef: 1,
+			label: skillShapedLabel,
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a rigor finding attributed to a check outside the rubric's closed set", () => {
+		const result = decodeEntry({
+			stage: "review",
+			surface: "skill",
+			inputRef: 1,
+			// The rubric assigns gate-invariant preservation to the `governance` skill and says it is
+			// never graded here — so no corpus row may attribute a finding to it (ADR 0243 §1a).
+			label: {
+				verdict: "FAIL",
+				rigorFindings: [{check: "gate-invariant-preservation", finding: "a guard was dropped"}],
+			},
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a rigor finding that carries no check attribution", () => {
+		const result = decodeEntry({
+			stage: "review",
+			surface: "skill",
+			inputRef: 1,
+			label: {verdict: "FAIL", rigorFindings: [{finding: "a bare string finding"}]},
 		});
 		assert.isTrue(Result.isFailure(result));
 	});
@@ -201,10 +262,37 @@ describe("review — a label mismatched to its surface stays unrepresentable", (
 			inputRef: number;
 			label: {verdict: "PASS"; acFindings: ReadonlyArray<string>};
 		}> = false;
+		const skillWellFormed: Inhabits<{
+			stage: "review";
+			surface: "skill";
+			inputRef: number;
+			label: {
+				verdict: "PASS";
+				rigorFindings: ReadonlyArray<{check: "cross-skill-conflict"; finding: string}>;
+			};
+		}> = true;
+		const skillFlatFindings: Inhabits<{
+			stage: "review";
+			surface: "skill";
+			inputRef: number;
+			label: {verdict: "PASS"; findings: ReadonlyArray<string>};
+		}> = false;
+		const skillUnknownCheck: Inhabits<{
+			stage: "review";
+			surface: "skill";
+			inputRef: number;
+			label: {
+				verdict: "PASS";
+				rigorFindings: ReadonlyArray<{check: "gate-invariant-preservation"; finding: string}>;
+			};
+		}> = false;
 
 		assert.isTrue(wellFormed);
 		assert.isFalse(surfaceMismatched);
 		assert.isFalse(surfaceless);
+		assert.isTrue(skillWellFormed);
+		assert.isFalse(skillFlatFindings);
+		assert.isFalse(skillUnknownCheck);
 	});
 });
 
@@ -288,11 +376,22 @@ describe("recorded provenance — the v1 review rows survive the merge unrelabel
 	});
 });
 
-// The founder ruling on #4979 fenced the `skill` surface's entry shape out of the lane that built
-// this stage (#5038 designs it). Nothing here may quietly invent one.
-describe("the skill surface has no entry shape yet", () => {
-	it("REVIEW_SURFACES names only the two surfaces whose label shapes ADR 0243 fixes", () => {
-		assert.deepStrictEqual([...REVIEW_SURFACES], ["code", "doc"]);
+describe("the review surface vocabulary is ADR 0243's three", () => {
+	it("REVIEW_SURFACES names every surface whose label shape ADR 0243 fixes", () => {
+		assert.deepStrictEqual([...REVIEW_SURFACES], ["code", "doc", "skill"]);
+	});
+
+	it("SKILL_RIGOR_CHECKS names the rubric's four checks and excludes the governance one", () => {
+		assert.deepStrictEqual(
+			[...SKILL_RIGOR_CHECKS],
+			[
+				"behavioral-correctness",
+				"trigger-description-quality",
+				"cross-skill-conflict",
+				"fabrika-conventions",
+			],
+		);
+		assert.notInclude(SKILL_RIGOR_CHECKS as ReadonlyArray<string>, "gate-invariant-preservation");
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/oracle.ts
+++ b/packages/fabrika-cli/src/eval/oracle.ts
@@ -16,7 +16,7 @@
  */
 import {Result} from "effect";
 import * as Schema from "effect/Schema";
-import type {CorpusEntry, ReviewSurface} from "./corpus.ts";
+import {type CorpusEntry, type ReviewSurface, SKILL_RIGOR_CHECKS} from "./corpus.ts";
 
 /** A single field's disagreement between the observed artifact and the expected label. */
 export interface FieldMismatch {
@@ -95,6 +95,15 @@ const ReviewDocArtifact = Schema.Struct({
 	verdict: Verdict,
 	findings: Schema.Array(Schema.String),
 });
+const ReviewSkillArtifact = Schema.Struct({
+	verdict: Verdict,
+	rigorFindings: Schema.Array(
+		Schema.Struct({
+			check: Schema.Literals([...SKILL_RIGOR_CHECKS]),
+			finding: Schema.String,
+		}),
+	),
+});
 const ShipItArtifact = Schema.Struct({
 	merged: Schema.Boolean,
 	mergeSha: Schema.String,
@@ -104,13 +113,14 @@ const decodeTriage = Schema.decodeUnknownResult(TriageArtifact);
 const decodeBuild = Schema.decodeUnknownResult(BuildArtifact);
 const decodeReviewCode = Schema.decodeUnknownResult(ReviewCodeArtifact);
 const decodeReviewDoc = Schema.decodeUnknownResult(ReviewDocArtifact);
+const decodeReviewSkill = Schema.decodeUnknownResult(ReviewSkillArtifact);
 const decodeShipIt = Schema.decodeUnknownResult(ShipItArtifact);
 
 // Narrow `entry.label` by discriminating on `entry.stage` (CorpusEntry is a union on `stage`).
 type LabelOf<S extends CorpusEntry["stage"]> = Extract<CorpusEntry, {stage: S}>["label"];
 
 // The `review` stage carries a second discriminator, so its label narrows on the PAIR. Selecting a
-// review grader on `stage` alone is banned (ADR 0243 §2): it collapses two rubrics onto one grader.
+// review grader on `stage` alone is banned (ADR 0243 §2): it collapses three rubrics onto one.
 type ReviewLabelOf<S extends ReviewSurface> = Extract<
 	CorpusEntry,
 	{stage: "review"; surface: S}
@@ -174,9 +184,37 @@ const gradeReviewDoc = (label: ReviewLabelOf<"doc">, artifact: unknown): Grade =
 	]);
 };
 
+// A rigor finding is a (check, finding) pair, so the set it belongs to is a set of pairs. Rendering
+// each as `check: finding` makes the comparison the same set-equality the other surfaces get while
+// keeping the mismatch readable; the check names are a closed vocabulary with no `: `, so the
+// rendering is injective.
+const renderRigorFinding = (f: {readonly check: string; readonly finding: string}): string =>
+	`${f.check}: ${f.finding}`;
+
+/**
+ * The `skill` surface passes iff the actual verdict + rigor-finding set match the label, where a
+ * finding is graded together with the rubric check it was attributed to — a right finding filed
+ * under the wrong check is a miss, which is the attribution the pair label exists to hold
+ * (ADR 0243 §1a).
+ */
+const gradeReviewSkill = (label: ReviewLabelOf<"skill">, artifact: unknown): Grade => {
+	const decoded = decodeReviewSkill(artifact);
+	if (Result.isFailure(decoded))
+		return failMalformed(`review-skill artifact: ${decoded.failure.message}`);
+	const a = decoded.success;
+	return gradeFields([
+		...cmpScalar("verdict", a.verdict, label.verdict),
+		...cmpSet(
+			"rigorFindings",
+			a.rigorFindings.map(renderRigorFinding),
+			label.rigorFindings.map(renderRigorFinding),
+		),
+	]);
+};
+
 /**
  * Select a `review` entry's grader by its `surface`. This second narrowing is the whole point of
- * ADR 0243: with one `review` stage and no further key, the two rubrics would collapse onto one
+ * ADR 0243: with one `review` stage and no further key, the three rubrics would collapse onto one
  * grader silently. Each surface reaches its own grader and its own artifact schema.
  */
 const gradeReview = (entry: Extract<CorpusEntry, {stage: "review"}>, artifact: unknown): Grade => {
@@ -185,6 +223,8 @@ const gradeReview = (entry: Extract<CorpusEntry, {stage: "review"}>, artifact: u
 			return gradeReviewCode(entry.label, artifact);
 		case "doc":
 			return gradeReviewDoc(entry.label, artifact);
+		case "skill":
+			return gradeReviewSkill(entry.label, artifact);
 	}
 };
 

--- a/packages/fabrika-cli/src/eval/oracle.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/oracle.unit.test.ts
@@ -48,6 +48,28 @@ const cases = {
 		},
 		passing: {verdict: "FAIL", findings: ["broken link"]},
 	},
+	"review/skill": {
+		entry: {
+			stage: "review",
+			surface: "skill",
+			inputRef: 5038,
+			label: {
+				verdict: "FAIL",
+				rigorFindings: [
+					{check: "trigger-description-quality", finding: "description under-claims"},
+					{check: "fabrika-conventions", finding: "restates a sibling's behavior"},
+				],
+			},
+		},
+		// set-equal, reordered
+		passing: {
+			verdict: "FAIL",
+			rigorFindings: [
+				{check: "fabrika-conventions", finding: "restates a sibling's behavior"},
+				{check: "trigger-description-quality", finding: "description under-claims"},
+			],
+		},
+	},
 	// The recorded v1 review rows keep their own stage keys (#4977) and must still reach a grader.
 	"review-code": {
 		entry: {
@@ -146,6 +168,35 @@ describe("gradeEntry — a divergent artifact fails, carrying the observed-vs-ex
 		}
 	});
 
+	it("review/skill: a finding refiled under another check fails with the set diff", () => {
+		const g = gradeEntry(cases["review/skill"].entry, {
+			verdict: "FAIL",
+			rigorFindings: [
+				// Same two findings, one re-attributed to the wrong rubric check.
+				{check: "behavioral-correctness", finding: "description under-claims"},
+				{check: "fabrika-conventions", finding: "restates a sibling's behavior"},
+			],
+		});
+		assert.isTrue(isFail(g));
+		if (isFail(g) && g.mismatch._tag === "LabelMismatch") {
+			assert.deepStrictEqual(g.mismatch.fields, [
+				{
+					field: "rigorFindings",
+					observed: JSON.stringify([
+						"behavioral-correctness: description under-claims",
+						"fabrika-conventions: restates a sibling's behavior",
+					]),
+					expected: JSON.stringify([
+						"fabrika-conventions: restates a sibling's behavior",
+						"trigger-description-quality: description under-claims",
+					]),
+				},
+			]);
+		} else {
+			assert.fail("expected a LabelMismatch");
+		}
+	});
+
 	it("ship-it: a different merge SHA fails with the mergeSha diff", () => {
 		const g = gradeEntry(cases["ship-it"].entry, {merged: true, mergeSha: "cafef00"});
 		assert.isTrue(isFail(g));
@@ -190,11 +241,11 @@ describe("gradeEntry — total on a malformed or absent artifact (never throws)"
 
 /**
  * ADR 0243 §2 bans dispatching a review grade on `stage` alone, because with one `review` key and
- * no second discriminator the two rubrics collapse onto one grader — silently, since a `doc`
+ * no second discriminator the three rubrics collapse onto one grader — silently, since a `doc`
  * artifact graded by the `code` rubric would just look like a fail. These assert the collapse did
  * not happen: each surface reaches its OWN grader and its own artifact schema.
  */
-describe("gradeEntry — the two review surfaces do not share a grader", () => {
+describe("gradeEntry — the three review surfaces do not share a grader", () => {
 	it("a doc-shaped artifact under the code surface is malformed, not silently graded", () => {
 		const g = gradeEntry(cases["review/code"].entry, {verdict: "PASS", findings: ["AC1 met"]});
 		assert.isTrue(isFail(g));
@@ -214,6 +265,28 @@ describe("gradeEntry — the two review surfaces do not share a grader", () => {
 			if (g.mismatch._tag === "MalformedArtifact") {
 				assert.match(g.mismatch.reason, /^review-doc artifact:/);
 			}
+		}
+	});
+
+	it("a doc-shaped artifact under the skill surface is malformed, not silently graded", () => {
+		const g = gradeEntry(cases["review/skill"].entry, {verdict: "FAIL", findings: ["x"]});
+		assert.isTrue(isFail(g));
+		if (isFail(g)) {
+			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
+			if (g.mismatch._tag === "MalformedArtifact") {
+				assert.match(g.mismatch.reason, /^review-skill artifact:/);
+			}
+		}
+	});
+
+	it("a rigor finding attributed to the governance check is malformed, never graded", () => {
+		const g = gradeEntry(cases["review/skill"].entry, {
+			verdict: "FAIL",
+			rigorFindings: [{check: "gate-invariant-preservation", finding: "a guard was dropped"}],
+		});
+		assert.isTrue(isFail(g));
+		if (isFail(g)) {
+			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
 		}
 	});
 

--- a/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/stage-vocabulary.cli.test.ts
@@ -128,11 +128,11 @@ describe("the live stage vocabulary is what fabrika eval accepts", {
 		const refused = fabrika("eval", "report", emptyRowsFile(), "--baseline-stage", "review");
 		expect(refused.code).not.toBe(0);
 		expect(refused.stderr).toContain("--baseline-stage review needs --baseline-surface");
-		expect(refused.stderr).toContain("code, doc");
+		expect(refused.stderr).toContain("code, doc, skill");
 	});
 
-	it("--baseline-surface skill is refused — the skill surface has no entry shape yet", () => {
-		const refused = fabrika(
+	it("--baseline-surface skill is accepted — it is one of ADR 0243's three surfaces", () => {
+		const accepted = fabrika(
 			"eval",
 			"report",
 			emptyRowsFile(),
@@ -141,8 +141,21 @@ describe("the live stage vocabulary is what fabrika eval accepts", {
 			"--baseline-surface",
 			"skill",
 		);
+		expect(accepted.code).toBe(0);
+	});
+
+	it("--baseline-surface names a surface outside the three and is refused", () => {
+		const refused = fabrika(
+			"eval",
+			"report",
+			emptyRowsFile(),
+			"--baseline-stage",
+			"review",
+			"--baseline-surface",
+			"design",
+		);
 		expect(refused.code).not.toBe(0);
-		expect(refused.stderr).toContain("'skill' is not a known review surface");
+		expect(refused.stderr).toContain("'design' is not a known review surface");
 	});
 
 	it("--baseline-surface on a non-review stage is refused", () => {


### PR DESCRIPTION
The eval corpus could record a code review and a doc review, but not a skill review — so that
gate's pass-rate was unmeasurable. This adds the missing third shape: a `review` entry with
`surface: "skill"`, whose label is a verdict plus findings that each name the rubric check they
came from.

The one real decision was flat findings versus per-check attribution, and it goes per-check. The
skill rubric is the only one of the three whose checks are a fixed, numbered set, so flattening
would throw away something the source already says — and a closed check vocabulary makes the
rubric's own exclusion (gate-invariant preservation is the `governance` skill's, "never graded
here") a decode failure instead of a convention. ADR 0243 §1a records the derivation.

Fixes #5038

## What changed

- `packages/fabrika-cli/src/eval/corpus.ts` — `SKILL_RIGOR_CHECKS` (the rubric's four checks as a
  closed vocabulary), `ReviewSkillEntry` with label `{verdict, rigorFindings: {check, finding}[]}`,
  added to the `CorpusEntry` union and to the manifest's `review` group.
- `packages/fabrika-cli/src/eval/oracle.ts` — `gradeReviewSkill` with its own artifact schema,
  reached from `gradeEntry` through the `(stage, surface)` narrowing. It compares the finding set
  as (check, finding) pairs, so a right finding filed under the wrong check is a miss.
- `.decisions/0243-review-eval-stage-surface-discriminator.md` — §1's third table row filled in,
  plus a §1a amendment stating the derivation and the flat-vs-per-check reasoning.
- Tests — corpus schema rejection cases (wrong-surface label both ways, an out-of-vocabulary check,
  an unattributed finding), the type-level probe extended with a positive control and two negative
  legs, and a grader mismatch case.
- `packages/fabrika-cli/src/eval/README.md` and the `--baseline-surface` CLI test, which both
  asserted the skill surface did not exist yet.

## Deviations

- **Class: scope wider than the issue's stated file list.** Said: the issue names `corpus.ts`,
  `oracle.ts` and their tests. Did: also updated `stage-vocabulary.cli.test.ts` and
  `src/eval/README.md`. Why: both asserted, in text and in an assertion, that the skill surface has
  no entry shape — `--baseline-surface skill` was a refusal case, and it flips to accepted because
  the CLI validates against `REVIEW_SURFACES`. Leaving them would have been a red suite and a false
  doc. Disposition: no action needed.
- **Class: chose between two sanctioned options.** Said: pin the shape "as an amendment to ADR 0243
  §1's table, or a new ADR that supersedes that cell". Did: amended 0243 (filled the cell, added
  §1a). Why: the cell was left open on purpose by the same record; a superseding ADR for one table
  row would split the decision across two files. Disposition: for the reviewer to judge.
- **Class: deliberately not built.** No `RecordedReviewSkillEntry` provenance key. The v1 gate
  committed no rows under `review-skill` (`corpus/review.json` carries three `review-code` rows and
  nothing else), and #4977 says a provenance key is minted by history, never in advance.
- **Class: pre-existing red not chased.** `pnpm test` fails in `@kampus/web` with a
  `{_tag: 'Unauthorized'}` from `@distilled.cloud/cloudflare` — a missing local credential, in a
  package this diff does not touch. `pnpm --filter @kampus/fabrika-cli test` is 1540/1540 green and
  `pnpm typecheck --force` is 30/30.