### PR TITLE
refactor(fabrika-cli): move classifyRunSpend + RunSpend into spend/, so the edge points down

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -106,7 +106,9 @@ spawns nothing itself, which is what makes it reproducible offline. That propert
 starts processes from `spawn-io.ts`. The reversal and its bounds are [ADR
 0236](../../../../.decisions/0236-eval-harness-gains-a-spawning-shell.md).
 
-`RunRow` is `{entry, grade, spend}` where `spend` is a **three-arm** `RunSpend` union:
+`RunRow` is `{entry, grade, spend}` where `spend` is a **three-arm** `RunSpend` union — declared,
+with `classifyRunSpend` that produces it, in [`../spend/token-spend.ts`](../spend/token-spend.ts)
+next to the meter it wraps ([#5050](https://github.com/kamp-us/phoenix/issues/5050)):
 `{_tag: "Reconstructed", spend}` (the `token-spend` `StageSpend`), `{_tag: "NoBilledTurns"}`, or
 `{_tag: "TranscriptMissing"}`. None of the three can be mistaken for a genuinely free run — a
 **missing transcript is graded and counted, never a crash**, and a transcript that is present and

--- a/packages/fabrika-cli/src/eval/runner.ts
+++ b/packages/fabrika-cli/src/eval/runner.ts
@@ -24,25 +24,9 @@
  */
 import {Effect, Result} from "effect";
 import * as Schema from "effect/Schema";
-import {reconstructSpend, type StageSpend} from "../spend/token-spend.ts";
+import {classifyRunSpend, type RunSpend} from "../spend/token-spend.ts";
 import {type CorpusEntry, type CorpusManifest, type LiveStage, STAGES} from "./corpus.ts";
 import {type Grade, gradeEntry} from "./oracle.ts";
-
-/**
- * One run's token spend, as one of three distinct outcomes — never a nullable `StageSpend`, so a
- * zero can never be fabricated where a measurement is missing.
- *
- * `NoBilledTurns` is the third: a transcript that exists and parses cleanly but carries **zero**
- * billed assistant turns, which reconstructs to a genuine, well-formed zero indistinguishable from a
- * free run. That is not hypothetical — a `claude -p` run whose skill failed to resolve writes
- * exactly such a transcript, and `token-spend` reports all-zeros at exit 0 (measured on 2.1.220,
- * #4673 §6). Folding it into `Reconstructed` would put the fabricated zero back that this union
- * exists to keep out.
- */
-export type RunSpend =
-	| {readonly _tag: "Reconstructed"; readonly spend: StageSpend}
-	| {readonly _tag: "NoBilledTurns"}
-	| {readonly _tag: "TranscriptMissing"};
 
 /** One graded run row: the corpus entry, its grade against the label, and its token spend. */
 export interface RunRow {
@@ -72,13 +56,6 @@ export const collectRun = (input: RunInput): RunRow => ({
 	grade: gradeEntry(input.entry, input.artifact),
 	spend: classifyRunSpend(input.transcript),
 });
-
-/** Resolve a transcript to one of the three `RunSpend` outcomes. Pure + total. */
-export const classifyRunSpend = (transcript: string | null): RunSpend => {
-	if (transcript === null) return {_tag: "TranscriptMissing"};
-	const spend = reconstructSpend(transcript);
-	return spend.assistantTurns === 0 ? {_tag: "NoBilledTurns"} : {_tag: "Reconstructed", spend};
-};
 
 /**
  * Offline/replay entry point (story 6): collect a graded `{entry, grade, spend}` row per supplied

--- a/packages/fabrika-cli/src/eval/runner.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/runner.unit.test.ts
@@ -1,5 +1,6 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Result} from "effect";
+import type {RunSpend} from "../spend/token-spend.ts";
 import type {CorpusEntry, CorpusManifest} from "./corpus.ts";
 import {
 	type CaptureManifest,
@@ -8,7 +9,6 @@ import {
 	decodeCaptureManifest,
 	type RunInput,
 	type RunRow,
-	type RunSpend,
 } from "./runner.ts";
 
 // One assistant-message transcript line — the shape `token-spend` reconstructs spend from. `billed`

--- a/packages/fabrika-cli/src/eval/spawn.ts
+++ b/packages/fabrika-cli/src/eval/spawn.ts
@@ -22,9 +22,9 @@
  * verdict is the one place a run is allowed to become a `CaptureRun`.
  */
 import {Effect, Result} from "effect";
+import {classifyRunSpend, type RunSpend} from "../spend/token-spend.ts";
 import {STAGES} from "./corpus.ts";
-import type {CaptureManifest, CaptureRun, RunSpend, TranscriptLoader} from "./runner.ts";
-import {classifyRunSpend} from "./runner.ts";
+import type {CaptureManifest, CaptureRun, TranscriptLoader} from "./runner.ts";
 import type {EvalTier} from "./skill-eval-set.ts";
 
 /**

--- a/packages/fabrika-cli/src/eval/spawn.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/spawn.unit.test.ts
@@ -13,8 +13,9 @@ import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Result} from "effect";
+import {classifyRunSpend} from "../spend/token-spend.ts";
 import type {CorpusManifest} from "./corpus.ts";
-import {classifyRunSpend, collectFromCapture, decodeCaptureManifest} from "./runner.ts";
+import {collectFromCapture, decodeCaptureManifest} from "./runner.ts";
 import {
 	buildClaudeArgs,
 	buildLedger,
@@ -556,20 +557,6 @@ describe("suiteExecuted — fails closed on zero scope and on any dead run (ADR 
 
 	it("an all-collected suite is green", () => {
 		assert.isTrue(suiteExecuted(summarizeRuns([completedRun()])));
-	});
-});
-
-describe("RunSpend's third arm — a well-formed zero is not a free run", () => {
-	it("a transcript with billed turns reconstructs", () => {
-		assert.strictEqual(classifyRunSpend(billedTranscript)._tag, "Reconstructed");
-	});
-
-	it("a transcript with zero billed assistant turns is NoBilledTurns, not a zero-valued Reconstructed", () => {
-		assert.strictEqual(classifyRunSpend('{"type":"summary"}')._tag, "NoBilledTurns");
-	});
-
-	it("an absent transcript stays TranscriptMissing", () => {
-		assert.strictEqual(classifyRunSpend(null)._tag, "TranscriptMissing");
 	});
 });
 

--- a/packages/fabrika-cli/src/spend/read-verb.ts
+++ b/packages/fabrika-cli/src/spend/read-verb.ts
@@ -7,14 +7,13 @@
  * The three refusals below are the point of the verb. A measurement that cannot be made must not
  * resolve to a plausible zero, so "the transcript is not there", "the transcript could not be read"
  * and "the transcript was read in full and billed nothing" stay three distinct exit codes — the same
- * split `../eval/runner.ts` draws with its `RunSpend` union, which is why the classification is
- * borrowed from there rather than restated.
+ * split `token-spend.ts`'s `RunSpend` union draws, which is why the classification is borrowed from
+ * there rather than restated.
  */
 import {Effect, type FileSystem, Result} from "effect";
-import {classifyRunSpend} from "../eval/runner.ts";
 import {exists, readFile} from "../io/fs.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
-import type {StageSpend} from "./token-spend.ts";
+import {classifyRunSpend, type StageSpend} from "./token-spend.ts";
 
 const VERB = "fabrika spend read";
 

--- a/packages/fabrika-cli/src/spend/token-spend.ts
+++ b/packages/fabrika-cli/src/spend/token-spend.ts
@@ -21,6 +21,11 @@
  *
  * Pure and total. A line that is not JSON, is not an assistant message, or carries no `usage` is
  * skipped rather than thrown on — a missed message undercounts, it never aborts a measurement.
+ *
+ * `classifyRunSpend` at the bottom is the other half of the same rule: what a transcript's spend
+ * *is* when it cannot be reconstructed. It reads as a spend rule, not an eval one, so it lives here
+ * with its own ingredients — every consumer (`eval/`, `spend read`) imports it from this one owner
+ * (#5050).
  */
 
 /** The four-component reconstruction of a run's billed token spend, plus its comparators. */
@@ -99,4 +104,27 @@ export const reconstructSpend = (transcript: string): StageSpend => {
 	const billed = input + cacheCreate + cacheRead + output;
 	const exCacheRead = input + cacheCreate + output;
 	return {input, cacheCreate, cacheRead, output, billed, exCacheRead, assistantTurns, model};
+};
+
+/**
+ * One run's token spend, as one of three distinct outcomes — never a nullable `StageSpend`, so a
+ * zero can never be fabricated where a measurement is missing.
+ *
+ * `NoBilledTurns` is the third: a transcript that exists and parses cleanly but carries **zero**
+ * billed assistant turns, which reconstructs to a genuine, well-formed zero indistinguishable from a
+ * free run. That is not hypothetical — a `claude -p` run whose skill failed to resolve writes
+ * exactly such a transcript, and `token-spend` reports all-zeros at exit 0 (measured on 2.1.220,
+ * #4673 §6). Folding it into `Reconstructed` would put the fabricated zero back that this union
+ * exists to keep out.
+ */
+export type RunSpend =
+	| {readonly _tag: "Reconstructed"; readonly spend: StageSpend}
+	| {readonly _tag: "NoBilledTurns"}
+	| {readonly _tag: "TranscriptMissing"};
+
+/** Resolve a transcript to one of the three `RunSpend` outcomes. Pure + total. */
+export const classifyRunSpend = (transcript: string | null): RunSpend => {
+	if (transcript === null) return {_tag: "TranscriptMissing"};
+	const spend = reconstructSpend(transcript);
+	return spend.assistantTurns === 0 ? {_tag: "NoBilledTurns"} : {_tag: "Reconstructed", spend};
 };

--- a/packages/fabrika-cli/src/spend/token-spend.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/token-spend.unit.test.ts
@@ -11,7 +11,7 @@
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
-import {reconstructSpend, type StageSpend} from "./token-spend.ts";
+import {classifyRunSpend, reconstructSpend, type StageSpend} from "./token-spend.ts";
 
 const read = (name: string): string =>
 	readFileSync(fileURLToPath(new URL(`./fixtures/one-ruler/${name}`, import.meta.url)), "utf8");
@@ -61,5 +61,32 @@ describe("reconstructSpend — total over anything a transcript can hold", () =>
 		assert.strictEqual(spend.cacheRead, 0);
 		assert.strictEqual(spend.cacheCreate, 0);
 		assert.strictEqual(spend.billed, 4);
+	});
+});
+
+describe("RunSpend's third arm — a well-formed zero is not a free run", () => {
+	const billedTranscript = JSON.stringify({
+		message: {
+			role: "assistant",
+			model: "claude-sonnet-5",
+			usage: {
+				input_tokens: 2,
+				cache_creation_input_tokens: 32_122,
+				cache_read_input_tokens: 0,
+				output_tokens: 19,
+			},
+		},
+	});
+
+	it("a transcript with billed turns reconstructs", () => {
+		assert.strictEqual(classifyRunSpend(billedTranscript)._tag, "Reconstructed");
+	});
+
+	it("a transcript with zero billed assistant turns is NoBilledTurns, not a zero-valued Reconstructed", () => {
+		assert.strictEqual(classifyRunSpend('{"type":"summary"}')._tag, "NoBilledTurns");
+	});
+
+	it("an absent transcript stays TranscriptMissing", () => {
+		assert.strictEqual(classifyRunSpend(null)._tag, "TranscriptMissing");
 	});
 });


### PR DESCRIPTION
One small function was living in the wrong folder. `classifyRunSpend` turns a run's transcript into one of three spend outcomes, and everything it needs already sat in `spend/` — yet it lived in `eval/`, so the `spend read` command had to reach up into the eval harness to use it. That made `spend` and `eval` the only two folders in the package that import each other, and it pulled the corpus schema and the grading oracle into `spend read`'s startup path just to reach four lines of code.

This moves the function and its `RunSpend` type into `packages/fabrika-cli/src/spend/token-spend.ts`, next to the meter they wrap, and repoints every caller. Nothing about how the CLI behaves changes.

Fixes #5050

## What changed

- **`packages/fabrika-cli/src/spend/token-spend.ts`** — now declares `RunSpend` and `classifyRunSpend`, right after `reconstructSpend`, the function it wraps. The three-arm rationale docblock moved verbatim; the file header gains one short paragraph saying why the classification lives here.
- **`packages/fabrika-cli/src/eval/runner.ts`** — the declarations are gone; it imports `classifyRunSpend` and `type RunSpend` from `../spend/token-spend.ts`. Its old `reconstructSpend` / `StageSpend` import is no longer needed and is dropped.
- **`packages/fabrika-cli/src/eval/spawn.ts`**, **`eval/spawn.unit.test.ts`**, **`eval/runner.unit.test.ts`** — repointed at the new home. There is no re-export shim from `runner.ts`; single owner, one import path.
- **`packages/fabrika-cli/src/spend/read-verb.ts`** — imports `classifyRunSpend` from its own group (`./token-spend.ts`), folded into the existing `StageSpend` type import. Its header no longer points at `../eval/runner.ts`.
- **`packages/fabrika-cli/src/spend/token-spend.unit.test.ts`** — the three-arm `RunSpend` tests move here from `eval/spawn.unit.test.ts`, with their own local transcript fixture.
- **`packages/fabrika-cli/src/eval/README.md`** — the `RunSpend` paragraph names the new home and links it.

`packages/fabrika-cli/src/eval/report.ts`'s `RunSpendSchema` is a separate Schema-side union that never imported the type, so it does not move.

## Verification

- `pnpm typecheck --force` (cache bypassed, 30/30 tasks) — clean.
- `pnpm lint:worktree` — 7 files checked, clean.
- `pnpm vitest run` in `packages/fabrika-cli` — 119 files, 1715 tests, all passing.
- `packages/fabrika-cli/src/spend/` now has zero `../eval/` imports; its only cross-group imports are the base groups `io/`, `verb.ts`, `excess-operand.ts`, and the shared test-support fake. The `eval → spend` edge is one-way again.

## Deviations

**Blast radius was wider than the issue's list — class: scope beyond the stated files.**
Said: triage's scope note named two `classifyRunSpend` consumers (`eval/runner.ts:73`, `eval/spawn.unit.test.ts:17`) and three `RunSpend` consumers.
Did: repointed `eval/spawn.ts` as well, which imports both `type RunSpend` (used at four sites) and `classifyRunSpend` — it was not in the stated list. Eight files changed, not five.
Why: the note predated the current `main`; `spawn.ts` is a real consumer and leaving it importing from `eval/runner.ts` would have needed a re-export shim, which breaks the single-owner criterion.
Disposition: no action needed — it is the same mechanical repoint, and the acceptance criteria are unchanged by it.

**Destination chosen, not invented — class: judgment call the issue left open.**
Said: "in `token-spend.ts` or a sibling module."
Did: put it in `token-spend.ts` itself.
Why: the function is a four-line total wrapper over `reconstructSpend` and its type is a union over that file's `StageSpend`; a sibling module would have added a file and a hop for no separation gain.
Disposition: for the reviewer to judge — a sibling `run-spend.ts` is a one-move change if preferred.

**Tests moved with the function — class: test relocation.**
Said: "existing unit tests for the three `RunSpend` arms still pass (moved with the function if appropriate)."
Did: moved the `RunSpend's third arm` describe block out of `eval/spawn.unit.test.ts` into `spend/token-spend.unit.test.ts`, giving it a local copy of the billed-transcript fixture (the original stays in `spawn.unit.test.ts`, which still uses it at a dozen other sites).
Why: they are direct `classifyRunSpend` assertions and belong with the function; duplicating the small fixture literal beat exporting it across groups, which would have re-created the very edge this issue removes.
Disposition: no action needed — assertions are unchanged and both suites pass.
