### PR TITLE
feat(fabrika-cli): write the stage-admission rule and enforce it as a data test (#4981)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -68,6 +68,56 @@ joins (the runner, the scorecard) key on the live stage.
 - `decodeManifest(text)` — total: returns a typed `Result` failure (`malformed-json` or
   `schema-mismatch`) on bad input, never throws. `encodeManifest(manifest)` round-trips it.
 
+## Stage-admission rule — a stage exists when its skill does
+
+`STAGES` is not a plan of the fabrika skill set. It is a record of what this harness can actually
+grade, so a name enters it when **both** of these are already true, and not before:
+
+1. **Its skill exists** — there is a `SKILL.md` for it under
+   [`claude-plugins/fabrika/skills/`](../../../../claude-plugins/fabrika/skills), so
+   `fabrika eval run --stage <name>` has something real to spawn.
+2. **There is something to grade under it** — committed ground truth (a corpus entry, or an eval
+   set) that a grader arm can score, landing in the same change as the stage key.
+
+Admitting a name earlier buys a permanently-empty manifest key and a grader arm nothing can reach,
+and the vocabulary then describes stages nobody runs — the drift epic
+[#4960](https://github.com/kamp-us/phoenix/issues/4960) exists to remove. So growth is per-skill and
+demand-driven: the change that authors a skill's first cases is the change that adds its `STAGES`
+member, its `CorpusManifest` key and its `oracle.ts` grader arm, together.
+
+`stage-admission.data.unit.test.ts` is the enforcement — a `STAGES` member with no grader arm, no
+manifest key, or no skill on disk turns the suite red, and an empty `STAGES` is a failure rather than
+a vacuous pass (ADR [0092](../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)).
+
+A stage key and its skill's directory name need not be identical; `ship-it` is the one that differs
+today (its skill is `ship`). Renaming it is deliberately not this harness's call — #4960 leaves
+`ship-it` alone pending the lane that owns skill naming.
+
+### Fabrika surfaces that deliberately have no stage today
+
+Named here so the gap reads as a decision rather than an oversight:
+
+- `build-ui` — the skill exists, but no ground truth has been committed for a rendered-visual build,
+  so clause 2 is unmet. It is admitted the moment its first cases land.
+- `review-ui` — the same shape: the skill exists, its ground truth does not.
+- `governance` — no skill exists yet. `review`'s skill rubric hands gate-invariant preservation to
+  it, so the name is referenced before the skill is written; clause 1 is unmet.
+- `check-epic-plan` — no skill exists yet. Plan review is `review`'s explicit non-scope, and until
+  the skill is authored there is nothing to spawn.
+- `build-epic`, `report`, `adr` — authored skills with no committed ground truth, so clause 2 is
+  unmet for them too. They are not excluded on principle; nobody has recorded a baseline yet.
+
+### Stages carrying zero committed corpus entries
+
+A stage that is admitted but ungraded is a **recorded choice**, not an oversight, and it is listed
+here so a reader can tell the two apart. The data test keeps this list honest in both directions: a
+stage that drops to zero entries without being listed turns the suite red, and so does a stage
+listed here that actually carries entries.
+
+- `ship-it` — admitted before this rule was written, and no `ship` run has been recorded as ground
+  truth yet. It stays in the vocabulary because `--stage ship-it` is accepted and its grader is
+  reachable; its pass-rate is simply undefined until entries land.
+
 ## The graded oracle ([#1849](https://github.com/kamp-us/phoenix/issues/1849))
 
 `gradeEntry(entry, artifact): Grade` (`oracle.ts`) is the per-corpus-entry quality grade. ADR

--- a/packages/fabrika-cli/src/eval/stage-admission.data.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/stage-admission.data.unit.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The stage-admission rule, enforced instead of merely written down (#4981, epic #4960).
+ *
+ * The rule is in `README.md`: a stage enters `STAGES` when its skill exists and there is something
+ * to grade under it, and not before. Prose alone cannot hold it — `STAGES` is a plain tuple that no
+ * type relates to `oracle.ts`'s grader arms, to `CorpusManifest`'s keys, or to the skills on disk,
+ * so a name added to it typechecks clean while grading nothing. These are data tests over the real
+ * `STAGES`, `oracle.ts`, corpus manifests and README, so adding an inadmissible stage turns the
+ * suite red.
+ *
+ * The grader-arm check calls `gradeEntry` with a probe entry rather than reading the switch as text:
+ * a stage with no arm falls off the end of a `default`-less switch and returns `undefined`, which is
+ * the failure a source-text match would only approximate.
+ */
+import {existsSync, readdirSync, readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import {
+	type CorpusEntry,
+	decodeManifest,
+	type LiveStage,
+	REVIEW_SURFACES,
+	STAGES,
+} from "./corpus.ts";
+import {type Grade, gradeEntry} from "./oracle.ts";
+
+/**
+ * Which fabrika skill each live stage grades. A stage key and its skill's directory need not be the
+ * same string — `ship-it`'s skill is `ship`, and renaming the stage is not this harness's call
+ * (#4960). Typed total over `LiveStage`, so a new stage with no entry also fails `pnpm typecheck`.
+ */
+const STAGE_SKILLS: Record<LiveStage, string> = {
+	triage: "triage",
+	build: "build",
+	review: "review",
+	"ship-it": "ship",
+};
+
+const skillPath = (skill: string): string =>
+	fileURLToPath(
+		new URL(`../../../../claude-plugins/fabrika/skills/${skill}/SKILL.md`, import.meta.url),
+	);
+
+const CORPUS_DIR = fileURLToPath(new URL("./corpus", import.meta.url));
+
+const README = readFileSync(fileURLToPath(new URL("./README.md", import.meta.url)), "utf8");
+
+/** The lines of one `##`/`###` README section, up to the next heading of either depth. */
+const sectionBody = (heading: string): string => {
+	const start = README.indexOf(`\n${heading}\n`);
+	if (start === -1) return "";
+	const rest = README.slice(start + heading.length + 2);
+	const end = rest.search(/\n#{2,3} /);
+	return end === -1 ? rest : rest.slice(0, end);
+};
+
+/** The first backticked token of each top-level bullet in a section — the section's named stages. */
+const bulletedNames = (heading: string): ReadonlyArray<string> =>
+	[...sectionBody(heading).matchAll(/^- `([^`]+)`/gm)].map((match) => match[1] as string);
+
+const UNGRADED_HEADING = "### Stages carrying zero committed corpus entries";
+const NO_STAGE_HEADING = "### Fabrika surfaces that deliberately have no stage today";
+
+/** Every committed manifest, decoded — a manifest that does not decode is `corpus.data`'s failure. */
+const committedManifests = readdirSync(CORPUS_DIR)
+	.filter((name) => name.endsWith(".json"))
+	.map((name) => decodeManifest(readFileSync(`${CORPUS_DIR}/${name}`, "utf8")))
+	.flatMap((result) => (Result.isSuccess(result) ? [result.success] : []));
+
+// Widened on purpose: a stage with no manifest key has no group here, and that must count as zero
+// entries so the ungraded-list assertion reports it — not throw before it can.
+const committedEntryCount = (stage: LiveStage): number =>
+	committedManifests.reduce((total, manifest) => {
+		const groups = manifest.stages as Readonly<Record<string, ReadonlyArray<unknown>>>;
+		return total + (groups[stage]?.length ?? 0);
+	}, 0);
+
+/**
+ * A probe entry for one stage, built across the JSON boundary — which is both how a real corpus row
+ * arrives and the only way to hand `gradeEntry` a stage the type system says cannot exist. Writing
+ * it as a literal is impossible by construction: an inadmissible stage is not in `CorpusEntry`, and
+ * that gap is the whole thing being probed.
+ */
+const probeEntry = (stage: string, surface?: string): CorpusEntry =>
+	JSON.parse(JSON.stringify({stage, surface, inputRef: 0, label: {}}));
+
+/**
+ * One probe per grader arm a stage owns. `review` fans on `surface` (ADR 0243), so it is probed on
+ * every surface — a stage whose second discriminator lost an arm fails here too.
+ */
+const probesFor = (stage: LiveStage): ReadonlyArray<CorpusEntry> =>
+	stage === "review"
+		? REVIEW_SURFACES.map((surface) => probeEntry(stage, surface))
+		: [probeEntry(stage)];
+
+describe("stage admission — the rule fails closed before it checks anything", () => {
+	// Without this, an emptied STAGES generates zero per-stage cases and the suite passes vacuously.
+	it("STAGES is non-empty", () => {
+		assert.isAtLeast(STAGES.length, 1, "an empty stage vocabulary is a failure, not a pass");
+	});
+});
+
+describe("stage admission — every stage has a grader arm, a manifest key and a skill", () => {
+	for (const stage of STAGES) {
+		it(`${stage} reaches a grader arm in oracle.ts`, () => {
+			for (const probe of probesFor(stage)) {
+				// A stage with no `case` falls off the switch and yields undefined, never a Grade.
+				const grade: Grade | undefined = gradeEntry(probe, {});
+				assert.isDefined(grade, `${stage} has no grader arm in oracle.ts's gradeEntry switch`);
+			}
+		});
+
+		it(`${stage}'s skill exists on disk`, () => {
+			const skill = STAGE_SKILLS[stage] as string | undefined;
+			assert.isDefined(skill, `${stage} names no fabrika skill in STAGE_SKILLS`);
+			assert.isTrue(
+				existsSync(skillPath(skill as string)),
+				`${stage} has no skill at claude-plugins/fabrika/skills/${skill}/SKILL.md — a stage exists when its skill does`,
+			);
+		});
+	}
+
+	it("CorpusManifest carries exactly one key per stage, and no others", () => {
+		const probe = {
+			version: 1,
+			stages: Object.fromEntries(STAGES.map((stage) => [stage, []])),
+		};
+		const decoded = decodeManifest(JSON.stringify(probe));
+		assert.isTrue(
+			Result.isSuccess(decoded),
+			"a manifest keyed by exactly STAGES must decode — a stage with no CorpusManifest key does not",
+		);
+		if (Result.isSuccess(decoded)) {
+			assert.deepStrictEqual(Object.keys(decoded.success.stages).sort(), [...STAGES].sort());
+		}
+	});
+});
+
+describe("stage admission — an ungraded stage is a recorded choice (README)", () => {
+	it("every stage with zero committed entries is named in the README's ungraded list", () => {
+		const zeroEntry = STAGES.filter((stage) => committedEntryCount(stage) === 0);
+		const listed = bulletedNames(UNGRADED_HEADING);
+		assert.isNotEmpty(
+			sectionBody(UNGRADED_HEADING),
+			`the README must carry the "${UNGRADED_HEADING}" section`,
+		);
+		assert.deepStrictEqual(
+			[...listed].sort(),
+			[...zeroEntry].sort(),
+			"the README's ungraded list must be exactly the stages carrying zero committed entries",
+		);
+	});
+
+	it("the deliberately-stage-less surfaces are not stages", () => {
+		const stageless = bulletedNames(NO_STAGE_HEADING);
+		assert.isNotEmpty(stageless, `the README must carry the "${NO_STAGE_HEADING}" section`);
+		for (const surface of stageless) {
+			assert.notInclude(
+				[...STAGES] as ReadonlyArray<string>,
+				surface,
+				`${surface} is listed as stage-less but is in STAGES`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
Fixes #4981

## What changed

**The rule, written down.** `packages/fabrika-cli/src/eval/README.md` gains a `## Stage-admission rule — a stage exists when its skill does` section. A name enters `STAGES` only when both clauses hold: its skill exists under `claude-plugins/fabrika/skills/`, and there is committed ground truth a grader arm can score. Two sub-sections make the gaps readable as decisions rather than oversights:

- **Fabrika surfaces that deliberately have no stage today** — `build-ui` and `review-ui` (skills exist, no ground truth yet), `governance` and `check-epic-plan` (no skill yet), and `build-epic` / `report` / `adr` (skills exist, no ground truth). Each carries which clause it fails.
- **Stages carrying zero committed corpus entries** — `ship-it` today, admitted before the rule was written and still ungraded.

The section also records that a stage key and its skill directory need not match (`ship-it`'s skill is `ship`), and that renaming it is deliberately not this harness's call per epic #4960.

**The rule, enforced.** New `packages/fabrika-cli/src/eval/stage-admission.data.unit.test.ts` (12 cases) beside `corpus.data.unit.test.ts`:

- Every `STAGES` member reaches a grader arm in `oracle.ts`, checked by *calling* `gradeEntry` with a probe entry rather than matching the switch as text. `gradeEntry`'s switch has no `default`, so a stage with no arm returns `undefined` — the failure is observed, not approximated. `review` is probed on all three surfaces (ADR 0243).
- Every `STAGES` member has a `CorpusManifest` key, checked by decoding a manifest keyed by exactly `STAGES`. Because every group is required and excess keys are rejected, this one decode catches both directions.
- Every `STAGES` member names a fabrika skill that exists on disk. `STAGE_SKILLS` is typed `Record<LiveStage, string>`, so a new stage with no entry also reds `pnpm typecheck` — the runtime assertion is the second layer.
- The README's ungraded list equals, exactly, the set of stages with zero committed corpus entries — so a stage that quietly drops to zero reds, and so does a stale listing.
- The deliberately-stage-less surfaces named in the README are not in `STAGES`.
- `STAGES` is asserted non-empty, because an emptied tuple would generate zero per-stage cases and pass vacuously (ADR 0092).

## Proof the test actually fails

Adding `governance` to `STAGES` (with a matching `STAGE_SKILLS` entry, so the check reaches disk rather than stopping at the map) turned 5 cases red:

```
× governance reaches a grader arm in oracle.ts
    governance has no grader arm in oracle.ts's gradeEntry switch: expected undefined to not equal undefined
× governance's skill exists on disk
    governance has no skill at claude-plugins/fabrika/skills/governance/SKILL.md — a stage exists when its skill does: expected false to be true
× CorpusManifest carries exactly one key per stage, and no others
× every stage with zero committed entries is named in the README's ungraded list
    expected [ 'ship-it' ] to deeply equal [ 'governance', 'ship-it' ]
× the deliberately-stage-less surfaces are not stages
    governance is listed as stage-less but is in STAGES
  Tests  5 failed | 9 passed (14)
```

Both temporary edits were reverted; the committed tree is green.

## Verification

- `pnpm typecheck --force` — 30/30 successful, 0 cached (no replayed `FULL TURBO`).
- `@kampus/fabrika-cli` suite — 120 files, 1737 tests, all passing.
- `pnpm format` (biome) clean. The probe entry is built across the `JSON.parse` boundary rather than with `as unknown as`, which the repo's biome plugin forbids; no suppression comment was added.

## Scope

Two files, both under `packages/fabrika-cli/src/eval/`. No stage name added or removed, no `spend/` → `eval/` import introduced, and the evals-green ship gate is untouched (epic #4649's lane).

## Deviations

Walked §DEV's seven classes against this diff (2 files, 216 additions, 0 deletions). Classes 1, 2, 3, 4, 6 and 7 did not fire: every acceptance criterion of #4981 is delivered as asked, no ADR is contradicted or narrowed, no adjacent defect was seen and left, no reviewer or triage guidance was declined, no pre-existing test or fixture was modified or deleted, and both touched files are the ones the issue implies. One entry under class 5:

- **Guard or gate bypassed** — **Said:** `biome-plugins/no-type-assertions.grit` forbids constructing a value the type system rejects via `$expr as unknown as $type`, and points at `Schema.decodeUnknown` as the sanctioned alternative. **Did:** the test's `probeEntry` helper builds a `CorpusEntry` carrying a stage the literal union says cannot exist, by serializing an object literal and reading it back through `JSON.parse` — a boundary the lint rule cannot see, so it is in effect the unchecked assertion the rule exists to catch, laundered through a different channel. No `biome-ignore` was added, because there is nothing for the linter to suppress. **Why:** the whole point of the probe is a stage the schema rejects, so `Schema.decodeUnknown` cannot produce it by construction, and a single narrowing `as CorpusEntry` does not compile (insufficient overlap). The JSON boundary is the only remaining route; the rationale is recorded in the helper's own docblock at the site. It is bounded to one test fixture builder and reaches no production path. **Disposition:** for the reviewer to judge — reviewed and ruled sound in `review-code` @ `403076a5`, which recorded the same honest caveat rather than charging it as a defect. No ADR needed, no follow-up filed.

The two design calls the gate examined — probing `gradeEntry` by call rather than matching `oracle.ts` as source text, and the `JSON.parse` construction above — were both ruled sound at that head. The first is an implementation choice no spec spoke to, so it is not disclosed as a deviation; the second is disclosed above because it steps around a live lint rule's intent, whatever the verdict on it.
