### PR TITLE
feat(fabrika-cli): persist every completed run's spend to a durable append-only ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ apps/web/tests/e2e/.auth
 # Local scratch (uncommitted explorations)
 /.scratch/
 
+# fabrika's durable spend ledger — one appended JSON line per completed eval run (#5009).
+# Per-machine measurement evidence, written by `fabrika eval run`; never committed.
+/.fabrika/
+
 # pipeline-cli data dir: where the SessionStart install.sh drops the installed
 # @kampus/pipeline-cli (deps bundled) the guard hooks resolve (ADR 0103, #1003).
 # Per-machine, never committed — mirrors the plugin's ${CLAUDE_PLUGIN_DATA}.

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -408,6 +408,21 @@ Three behaviours are worth knowing before you call it:
   with a spend magnitude — the no-gate ruling on epic #4779, asserted by a test that a
   very large total still exits `0` rather than left as a note here.
 
+### The spend ledger
+
+`spend read` prices one transcript on demand; the ledger is where measured runs *survive*
+([#5009](https://github.com/kamp-us/phoenix/issues/5009)). `fabrika eval run` appends one
+**JSON Lines** row per completed run to `.fabrika/spend-ledger.jsonl` (repo-relative,
+gitignored, `--spend-ledger` overrides it) once the suite finishes — each line carrying that
+run's spend and the identity of the work it measured. The core is
+[`src/spend/ledger.ts`](./src/spend/ledger.ts): `appendSpendLedger` writes, `readSpendLedger`
+reads back the well-formed rows **and the count of lines it skipped**, so a truncated tail
+costs one line rather than the file. Every line stamps its own `v`, which is the seam a later
+row shape evolves through.
+
+The module imports from `spend/` and `io/` only — never `eval/` — so a reader of the ledger
+does not drag in the eval harness that writes it.
+
 ## Development
 
 ```bash

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -535,7 +535,8 @@ fabrika eval run <evals.json> \
   --plugin-dir <the candidate skill's plugin dir> \
   --model <model> \
   [--arms with-skill,without-skill] [--json-schema <schema.json>] \
-  [--timeout-ms 900000] [--out ledger.json] [--capture-out capture.json] [--dry-run]
+  [--timeout-ms 900000] [--out ledger.json] [--capture-out capture.json] \
+  [--spend-ledger .fabrika/spend-ledger.jsonl] [--dry-run]
 ```
 
 One command runs a skill's whole eval set with nobody watching. Per (case × arm) it invokes
@@ -562,6 +563,25 @@ all: it is already the counted `NoModelTurns:zero-assistant-turns` failure above
 
 The figures come from `src/spend/token-spend.ts` through `classifyRunSpend`. No second sum is added
 here — this change in fact removes the runner's own second `reconstructSpend` call.
+
+### Where those rows survive ([#5009](https://github.com/kamp-us/phoenix/issues/5009))
+
+A spend row used to live only in the `--out` file the operator named, so every measurement was as
+durable as one shell history. Once the suite completes, the runner now appends its rows to a **spend
+ledger** — `.fabrika/spend-ledger.jsonl` by default, `--spend-ledger <path>` to put it elsewhere.
+The default is repo-relative and gitignored; the format and both halves of its contract live in
+[`../spend/ledger.ts`](../spend/ledger.ts).
+
+Three properties are the point:
+
+- **It is the only durable write, and it is on the completion path.** Nothing hooks session start,
+  session end, or a tool call — the epic's second no-go. A `--dry-run` spawns nothing and so records
+  nothing.
+- **A re-run appends.** The earlier suite's lines are still there, byte for byte; nothing truncates,
+  rewrites or repairs a line already on disk.
+- **It cannot change what the run reports.** A ledger that cannot be written is one line on stderr.
+  The exit code and the suite's outcome are untouched, because the measurement is a by-product of the
+  run and must never become a way for it to fail.
 
 **The two arms are `--plugin-dir` present or absent.** That is the whole difference in the argv, and
 it is the arm variable the /skill-creator methodology means by with-skill vs without-skill. Two flags

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -27,6 +27,7 @@ import {Console, Crypto, Effect, FileSystem, Path, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
+import {DEFAULT_SPEND_LEDGER_PATH, persistSpendRows} from "../spend/ledger.ts";
 import {decodeManifest, REVIEW_SURFACES, type ReviewSurface, STAGES} from "./corpus.ts";
 import {decodeIncidentProvenance} from "./incident-provenance.ts";
 import {
@@ -351,6 +352,13 @@ const dryRunFlag = Flag.boolean("dry-run").pipe(
 	Flag.withDescription("print the argv of every planned run and spawn nothing"),
 );
 
+const spendLedgerFlag = Flag.string("spend-ledger").pipe(
+	Flag.withDefault(DEFAULT_SPEND_LEDGER_PATH),
+	Flag.withDescription(
+		`append one spend line per completed run here — the durable ledger the roll-up reads (default: ${DEFAULT_SPEND_LEDGER_PATH})`,
+	),
+);
+
 /**
  * `run` — execute an eval set unattended and emit the capture manifest the existing collector reads.
  *
@@ -373,6 +381,7 @@ const runCommand = leafCommand(
 		timeoutMs: timeoutFlag,
 		out: ledgerOutFlag,
 		captureOut: captureOutFlag,
+		spendLedger: spendLedgerFlag,
 		dryRun: dryRunFlag,
 	},
 	Effect.fn(function* (opts) {
@@ -456,6 +465,14 @@ const runCommand = leafCommand(
 				recordedAt: new Date().toISOString(),
 				outcomes,
 			});
+
+			// The one durable write, on the completion path and nowhere else: the suite has finished, so
+			// every row here measures work that already happened. A ledger that cannot be written is
+			// reported and nothing more — the measurement is a by-product of the run, so failing to
+			// record it must never change what the run reports (epic #4779's no-gate ruling).
+			for (const note of yield* persistSpendRows(opts.spendLedger, ledger.spendRows)) {
+				yield* Console.error(`fabrika eval: ${note}`);
+			}
 
 			if (opts.out._tag === "Some") yield* fs.writeFileString(opts.out.value, ledgerToJson(ledger));
 			if (opts.captureOut._tag === "Some") {

--- a/packages/fabrika-cli/src/io/fs.ts
+++ b/packages/fabrika-cli/src/io/fs.ts
@@ -26,6 +26,8 @@ export class WriteFailed extends Schema.TaggedErrorClass<WriteFailed>()("fabrika
 	reason: Schema.String,
 }) {}
 
+const NEWLINE = 0x0a;
+
 /** Base names in `path`. A directory that could not be listed FAILS; it never resolves to `[]`. */
 export const readDir = (
 	path: string,
@@ -59,6 +61,41 @@ export const exists = (path: string): Effect.Effect<boolean, ReadFailed, FileSys
 		return yield* fs.exists(path);
 	}).pipe(
 		Effect.catchTag("PlatformError", (cause) => new ReadFailed({path, reason: cause.message})),
+	);
+
+/**
+ * Append `text` to `path`, creating the file and its parent directory when they are absent.
+ *
+ * The `"a+"` open flag is the guarantee that matters: every write lands at the end of whatever is
+ * already there, so a re-run adds to a line-oriented file rather than truncating it, and nothing on
+ * disk is rewritten. The one thing done beyond that is healing a missing final newline: a file whose
+ * last write was cut short ends mid-line, and appending straight onto it would fuse the new text
+ * into the damaged line and lose both. A reader can skip one damaged line; it cannot recover a good
+ * one that was glued to it.
+ */
+export const appendFile = (
+	path: string,
+	text: string,
+): Effect.Effect<void, WriteFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathService = yield* Path.Path;
+		yield* fs.makeDirectory(pathService.dirname(path), {recursive: true});
+		yield* Effect.scoped(
+			Effect.gen(function* () {
+				const file = yield* fs.open(path, {flag: "a+"});
+				const size = (yield* file.stat).size;
+				let separator = "";
+				if (size > 0n) {
+					yield* file.seek(size - 1n, "start");
+					const last = yield* file.readAlloc(1);
+					if (last._tag === "Some" && last.value[0] !== NEWLINE) separator = "\n";
+				}
+				yield* file.writeAll(new TextEncoder().encode(`${separator}${text}`));
+			}),
+		);
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
 	);
 
 /** Write `text` to `path`, creating its parent directory. */

--- a/packages/fabrika-cli/src/spend/ledger.ts
+++ b/packages/fabrika-cli/src/spend/ledger.ts
@@ -1,0 +1,217 @@
+/**
+ * The durable spend ledger — where a measured run's cost survives the shell that measured it (#5009).
+ *
+ * Before this, a spend row existed only for as long as the operator kept the `--out` file they named,
+ * so every measurement was ephemeral — the persistence gap epic #4779 names. The ledger is **JSON
+ * Lines**: one self-describing JSON object per line, appended, never rewritten. The format is chosen
+ * for what a partial write does to it — a crash mid-line damages exactly that line, and the reader
+ * below skips it — and for what evolution does to it: every line carries its own `v`, so a later
+ * shape is a new version rather than a migration of the file.
+ *
+ * The one-way import edge is deliberate: this module reaches `spend/` and `io/` only, never `eval/`
+ * (#5050). `LedgerRow` is therefore declared **structurally** rather than imported from the runner —
+ * `eval`'s `SpendRow` satisfies it, and so does a synthetic row in a test — which is what lets the
+ * roll-up read this ledger without depending on the eval harness that writes it.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {appendFile, type WriteFailed} from "../io/fs.ts";
+import type {RunSpend, StageSpend} from "./token-spend.ts";
+
+/**
+ * The default ledger, stated repo-relative so no machine-local path literal reaches a source file.
+ * It is gitignored: a measurement is per-machine evidence, not a committed artifact.
+ */
+export const DEFAULT_SPEND_LEDGER_PATH = ".fabrika/spend-ledger.jsonl";
+
+/** The shape version stamped on every line — the seam a later row shape evolves through. */
+export const LEDGER_ROW_VERSION = 1;
+
+/**
+ * One persisted run: its spend plus the identity of the work that produced it. Every attribution
+ * field is on the row rather than in a file header, because a line has to stand on its own — a
+ * number that cannot name what it measured is a number with no unit of work.
+ */
+export interface LedgerRow {
+	readonly skillName: string;
+	/** Provenance — the key the run was recorded under, never a pointer into the live stage table (#4977). */
+	readonly stage: string;
+	readonly caseId: number;
+	readonly arm: string;
+	readonly model: string;
+	readonly sessionId: string;
+	readonly cliVersion: string | null;
+	/** ISO-8601 UTC, supplied by the caller — this core mints no time of its own. */
+	readonly recordedAt: string;
+	readonly spend: RunSpend;
+}
+
+/** What a read of the ledger text found, and how much of it it could not read. */
+export interface LedgerRead {
+	readonly rows: ReadonlyArray<LedgerRow>;
+	/** Lines that were present but unreadable. Reported, never silently folded into "no rows". */
+	readonly skipped: number;
+}
+
+/**
+ * Encode rows as ledger lines. The fields are picked explicitly rather than spread, so the on-disk
+ * shape is this module's and does not drift with whatever extra fields a caller's row carries.
+ */
+export const encodeSpendRows = (rows: ReadonlyArray<LedgerRow>): string =>
+	rows
+		.map((row) =>
+			JSON.stringify({
+				v: LEDGER_ROW_VERSION,
+				skillName: row.skillName,
+				stage: row.stage,
+				caseId: row.caseId,
+				arm: row.arm,
+				model: row.model,
+				sessionId: row.sessionId,
+				cliVersion: row.cliVersion,
+				recordedAt: row.recordedAt,
+				spend: row.spend,
+			}),
+		)
+		.map((line) => `${line}\n`)
+		.join("");
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const str = (value: unknown): string | null => (typeof value === "string" ? value : null);
+
+const num = (value: unknown): number | null =>
+	typeof value === "number" && Number.isFinite(value) ? value : null;
+
+/**
+ * Decode a persisted spend. A `Reconstructed` arm is accepted only when every component is a real
+ * number: a half-decoded spend would put back the fabricated zero the three-arm union exists to keep
+ * out, so a damaged one is skipped instead.
+ */
+const decodeSpend = (value: unknown): RunSpend | null => {
+	if (!isRecord(value)) return null;
+	if (value._tag === "TranscriptMissing") return {_tag: "TranscriptMissing"};
+	if (value._tag === "NoBilledTurns") return {_tag: "NoBilledTurns"};
+	if (value._tag !== "Reconstructed" || !isRecord(value.spend)) return null;
+	const raw = value.spend;
+	const input = num(raw.input);
+	const cacheCreate = num(raw.cacheCreate);
+	const cacheRead = num(raw.cacheRead);
+	const output = num(raw.output);
+	const billed = num(raw.billed);
+	const exCacheRead = num(raw.exCacheRead);
+	const assistantTurns = num(raw.assistantTurns);
+	if (
+		input === null ||
+		cacheCreate === null ||
+		cacheRead === null ||
+		output === null ||
+		billed === null ||
+		exCacheRead === null ||
+		assistantTurns === null
+	) {
+		return null;
+	}
+	const model = raw.model;
+	if (model !== null && typeof model !== "string") return null;
+	const spend: StageSpend = {
+		input,
+		cacheCreate,
+		cacheRead,
+		output,
+		billed,
+		exCacheRead,
+		assistantTurns,
+		model,
+	};
+	return {_tag: "Reconstructed", spend};
+};
+
+const decodeRow = (line: string): LedgerRow | null => {
+	const decoded = Result.try({try: (): unknown => JSON.parse(line), catch: () => null});
+	if (Result.isFailure(decoded)) return null;
+	const parsed = decoded.success;
+	if (!isRecord(parsed) || parsed.v !== LEDGER_ROW_VERSION) return null;
+	const skillName = str(parsed.skillName);
+	const stage = str(parsed.stage);
+	const caseId = num(parsed.caseId);
+	const arm = str(parsed.arm);
+	const model = str(parsed.model);
+	const sessionId = str(parsed.sessionId);
+	const recordedAt = str(parsed.recordedAt);
+	const spend = decodeSpend(parsed.spend);
+	if (
+		skillName === null ||
+		stage === null ||
+		caseId === null ||
+		arm === null ||
+		model === null ||
+		sessionId === null ||
+		recordedAt === null ||
+		spend === null
+	) {
+		return null;
+	}
+	const cliVersion = parsed.cliVersion;
+	if (cliVersion !== null && typeof cliVersion !== "string") return null;
+	return {skillName, stage, caseId, arm, model, sessionId, cliVersion, recordedAt, spend};
+};
+
+/**
+ * Read a ledger's text into the rows it holds plus the count of lines it could not read.
+ *
+ * Tolerant by construction: a crash between the bytes and the newline leaves a truncated tail, and a
+ * second suite appends after it — so one damaged line must never cost the rows around it. A blank
+ * line is nothing at all, not a skip; anything else that does not decode is counted and reported,
+ * because "the file held 3 rows" and "the file held 3 rows and 40 I could not read" are different
+ * facts and a caller that cannot see the gap will read the first as the whole ledger.
+ */
+export const readSpendLedger = (text: string): LedgerRead => {
+	const rows: Array<LedgerRow> = [];
+	let skipped = 0;
+	for (const line of text.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) continue;
+		const row = decodeRow(trimmed);
+		if (row === null) {
+			skipped += 1;
+			continue;
+		}
+		rows.push(row);
+	}
+	return {rows, skipped};
+};
+
+/**
+ * Append a suite's rows to the ledger, creating it and its parent directory on first use. No rows
+ * means no write at all — an empty file would claim a suite recorded something.
+ */
+export const appendSpendLedger = (
+	path: string,
+	rows: ReadonlyArray<LedgerRow>,
+): Effect.Effect<void, WriteFailed, FileSystem.FileSystem | Path.Path> => {
+	const text = encodeSpendRows(rows);
+	return text === "" ? Effect.void : appendFile(path, text);
+};
+
+/**
+ * Persist a suite's rows and return what the caller should say about it — no notes on success, one
+ * note naming the path and the reason on failure.
+ *
+ * The error channel is `never` on purpose, and it is the whole contract: recording a measurement is a
+ * by-product of a run that already finished, so a ledger that cannot be written must not become a way
+ * for that run to fail (epic #4779's no-gate ruling). Returning the note rather than printing it is
+ * what lets that promise be asserted without a process.
+ */
+export const persistSpendRows = (
+	path: string,
+	rows: ReadonlyArray<LedgerRow>,
+): Effect.Effect<ReadonlyArray<string>, never, FileSystem.FileSystem | Path.Path> =>
+	appendSpendLedger(path, rows).pipe(
+		Effect.as<ReadonlyArray<string>>([]),
+		Effect.catchTag("fabrika-cli/WriteFailed", (failure) =>
+			Effect.succeed([
+				`could not append the spend ledger at ${failure.path}: ${failure.reason} — the suite's result is unaffected.`,
+			]),
+		),
+	);

--- a/packages/fabrika-cli/src/spend/ledger.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/ledger.unit.test.ts
@@ -1,0 +1,230 @@
+/**
+ * The spend ledger's two halves, driven against a temp directory with no model call (#5009).
+ *
+ * The append tier runs on the real Node filesystem on purpose: append-only-ness is a property of the
+ * open flag, and a scripted `FileSystem` double would assert the call rather than the behaviour.
+ */
+import {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	appendSpendLedger,
+	DEFAULT_SPEND_LEDGER_PATH,
+	encodeSpendRows,
+	LEDGER_ROW_VERSION,
+	type LedgerRow,
+	readSpendLedger,
+} from "./ledger.ts";
+import type {RunSpend} from "./token-spend.ts";
+
+const live = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>): Promise<A> =>
+	Effect.runPromise(Effect.provide(effect, NodeServices.layer));
+
+const reconstructed: RunSpend = {
+	_tag: "Reconstructed",
+	spend: {
+		input: 11,
+		cacheCreate: 22,
+		cacheRead: 33,
+		output: 44,
+		billed: 110,
+		exCacheRead: 77,
+		assistantTurns: 3,
+		model: "claude-opus-5",
+	},
+};
+
+const row = (overrides: Partial<LedgerRow> = {}): LedgerRow => ({
+	skillName: "write-code",
+	stage: "build",
+	caseId: 1,
+	arm: "with-skill",
+	model: "claude-opus-5",
+	sessionId: "3f9c1d2b-0000-4000-8000-000000000001",
+	cliVersion: "2.1.220",
+	recordedAt: "2026-08-09T09:00:00.000Z",
+	spend: reconstructed,
+	...overrides,
+});
+
+const withTempDir = async (body: (dir: string) => Promise<void>): Promise<void> => {
+	const dir = mkdtempSync(join(tmpdir(), "fabrika-spend-ledger-"));
+	try {
+		await body(dir);
+	} finally {
+		rmSync(dir, {recursive: true, force: true});
+	}
+};
+
+describe("the default ledger path", () => {
+	it("is repo-relative, so no machine-local literal reaches a source file", () => {
+		assert.strictEqual(DEFAULT_SPEND_LEDGER_PATH.startsWith("/"), false);
+		assert.strictEqual(DEFAULT_SPEND_LEDGER_PATH.startsWith("~"), false);
+		assert.strictEqual(DEFAULT_SPEND_LEDGER_PATH.endsWith(".jsonl"), true);
+	});
+});
+
+describe("encodeSpendRows — one self-describing JSON line per row", () => {
+	it("writes one newline-terminated line per row, each stamped with the row version", () => {
+		const text = encodeSpendRows([row({caseId: 1}), row({caseId: 2, arm: "without-skill"})]);
+		assert.strictEqual(text.endsWith("\n"), true);
+		const lines = text.split("\n").filter((line) => line !== "");
+		assert.strictEqual(lines.length, 2);
+		for (const line of lines) {
+			const parsed = JSON.parse(line) as {v: number};
+			assert.strictEqual(parsed.v, LEDGER_ROW_VERSION);
+		}
+	});
+
+	it("carries every attribution field plus the spend, so a line stands on its own", () => {
+		const parsed = JSON.parse(encodeSpendRows([row()]).trim()) as Record<string, unknown>;
+		assert.deepStrictEqual(parsed, {
+			v: LEDGER_ROW_VERSION,
+			skillName: "write-code",
+			stage: "build",
+			caseId: 1,
+			arm: "with-skill",
+			model: "claude-opus-5",
+			sessionId: "3f9c1d2b-0000-4000-8000-000000000001",
+			cliVersion: "2.1.220",
+			recordedAt: "2026-08-09T09:00:00.000Z",
+			spend: reconstructed,
+		});
+	});
+
+	it("encodes no rows as the empty string, so a suite with nothing to say writes nothing", () => {
+		assert.strictEqual(encodeSpendRows([]), "");
+	});
+
+	it("never emits an embedded newline, which is what keeps one row on one line", () => {
+		const text = encodeSpendRows([row({skillName: "write\ncode"})]);
+		assert.strictEqual(text.split("\n").filter((line) => line !== "").length, 1);
+	});
+});
+
+describe("readSpendLedger — tolerant of anything a partial write can leave behind", () => {
+	it("round-trips every row it wrote, skipping nothing", () => {
+		const rows = [row({caseId: 1}), row({caseId: 2, spend: {_tag: "TranscriptMissing"}})];
+		const read = readSpendLedger(encodeSpendRows(rows));
+		assert.deepStrictEqual(read.rows, rows);
+		assert.strictEqual(read.skipped, 0);
+	});
+
+	it("round-trips all three spend arms, so an unmeasured run stays unmeasured", () => {
+		const arms: ReadonlyArray<RunSpend> = [
+			reconstructed,
+			{_tag: "NoBilledTurns"},
+			{_tag: "TranscriptMissing"},
+		];
+		const read = readSpendLedger(encodeSpendRows(arms.map((spend) => row({spend}))));
+		assert.deepStrictEqual(
+			read.rows.map((r) => r.spend),
+			arms,
+		);
+	});
+
+	it("skips a malformed line and a truncated tail, and reports how many it skipped", () => {
+		const good = encodeSpendRows([row({caseId: 1}), row({caseId: 2})]);
+		const truncated = encodeSpendRows([row({caseId: 3})]).slice(0, 40);
+		const read = readSpendLedger(`${good}not json at all\n${truncated}`);
+		assert.deepStrictEqual(
+			read.rows.map((r) => r.caseId),
+			[1, 2],
+		);
+		assert.strictEqual(read.skipped, 2);
+	});
+
+	it("skips a line that parses but is not a row, rather than yielding a half-row", () => {
+		const read = readSpendLedger(`{"v":1,"skillName":"write-code"}\n`);
+		assert.strictEqual(read.rows.length, 0);
+		assert.strictEqual(read.skipped, 1);
+	});
+
+	it("skips a row whose spend is structurally wrong — a fabricated zero never gets in", () => {
+		const line = JSON.stringify({
+			...JSON.parse(encodeSpendRows([row()]).trim()),
+			spend: {_tag: "Reconstructed", spend: {billed: "lots"}},
+		});
+		const read = readSpendLedger(`${line}\n`);
+		assert.strictEqual(read.rows.length, 0);
+		assert.strictEqual(read.skipped, 1);
+	});
+
+	it("skips a row written by a version it does not know, and counts it", () => {
+		const line = JSON.stringify({...JSON.parse(encodeSpendRows([row()]).trim()), v: 99});
+		const read = readSpendLedger(`${line}\n`);
+		assert.strictEqual(read.rows.length, 0);
+		assert.strictEqual(read.skipped, 1);
+	});
+
+	it("counts blank lines as nothing at all — a trailing newline is not a skip", () => {
+		const read = readSpendLedger(`${encodeSpendRows([row()])}\n   \n`);
+		assert.strictEqual(read.rows.length, 1);
+		assert.strictEqual(read.skipped, 0);
+	});
+
+	it("reads an empty ledger as no rows and no skips, never as a failure", () => {
+		assert.deepStrictEqual(readSpendLedger(""), {rows: [], skipped: 0});
+	});
+});
+
+describe("appendSpendLedger — append-only against a real temp directory", () => {
+	it("creates the ledger and its parent directory on the first suite", async () => {
+		await withTempDir(async (dir) => {
+			const path = join(dir, "nested", "spend-ledger.jsonl");
+			await live(appendSpendLedger(path, [row({caseId: 1})]));
+			assert.strictEqual(readSpendLedger(readFileSync(path, "utf8")).rows.length, 1);
+		});
+	});
+
+	it("leaves the first suite's bytes unchanged when a second suite appends", async () => {
+		await withTempDir(async (dir) => {
+			const path = join(dir, "spend-ledger.jsonl");
+			await live(appendSpendLedger(path, [row({caseId: 1})]));
+			const first = readFileSync(path, "utf8");
+			await live(appendSpendLedger(path, [row({caseId: 2}), row({caseId: 3})]));
+			const second = readFileSync(path, "utf8");
+			assert.strictEqual(second.slice(0, first.length), first);
+			assert.deepStrictEqual(
+				readSpendLedger(second).rows.map((r) => r.caseId),
+				[1, 2, 3],
+			);
+		});
+	});
+
+	it("appends after a malformed line without rewriting it — the reader skips, the writer does not repair", async () => {
+		await withTempDir(async (dir) => {
+			const path = join(dir, "spend-ledger.jsonl");
+			writeFileSync(path, "half a row, no newline");
+			await live(appendSpendLedger(path, [row({caseId: 7})]));
+			const read = readSpendLedger(readFileSync(path, "utf8"));
+			assert.deepStrictEqual(
+				read.rows.map((r) => r.caseId),
+				[7],
+			);
+			assert.strictEqual(read.skipped, 1);
+		});
+	});
+
+	it("writes nothing at all when the suite produced no rows — not even an empty file", async () => {
+		await withTempDir(async (dir) => {
+			const path = join(dir, "spend-ledger.jsonl");
+			await live(appendSpendLedger(path, []));
+			assert.strictEqual(existsSync(path), false);
+		});
+	});
+
+	it("fails rather than reporting a write that did not land", async () => {
+		await withTempDir(async (dir) => {
+			const path = join(dir, "occupied");
+			writeFileSync(path, "");
+			const outcome = await live(
+				Effect.result(appendSpendLedger(join(path, "spend-ledger.jsonl"), [row()])),
+			);
+			assert.strictEqual(outcome._tag, "Failure");
+		});
+	});
+});

--- a/packages/fabrika-cli/src/spend/ledger.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/ledger.unit.test.ts
@@ -16,6 +16,7 @@ import {
 	encodeSpendRows,
 	LEDGER_ROW_VERSION,
 	type LedgerRow,
+	persistSpendRows,
 	readSpendLedger,
 } from "./ledger.ts";
 import type {RunSpend} from "./token-spend.ts";
@@ -214,6 +215,19 @@ describe("appendSpendLedger — append-only against a real temp directory", () =
 			const path = join(dir, "spend-ledger.jsonl");
 			await live(appendSpendLedger(path, []));
 			assert.strictEqual(existsSync(path), false);
+		});
+	});
+
+	it("persists with nothing to say, and says exactly one thing when it could not", async () => {
+		await withTempDir(async (dir) => {
+			const path = join(dir, "spend-ledger.jsonl");
+			assert.deepStrictEqual(await live(persistSpendRows(path, [row()])), []);
+
+			const occupied = join(dir, "occupied");
+			writeFileSync(occupied, "");
+			const notes = await live(persistSpendRows(join(occupied, "spend-ledger.jsonl"), [row()]));
+			assert.strictEqual(notes.length, 1);
+			assert.strictEqual(notes[0]?.includes(occupied), true);
 		});
 	});
 


### PR DESCRIPTION
A fabrika eval run's measured cost used to survive only if the operator remembered to pass `--out` and kept the file. Now, once a suite finishes, the runner appends one JSON line per completed run to a spend ledger — `.fabrika/spend-ledger.jsonl` by default, `--spend-ledger <path>` to move it. Re-running adds lines instead of replacing them, and if the ledger cannot be written the run says so on stderr and otherwise carries on exactly as before.

Fixes #5009

## What changed

- **New `packages/fabrika-cli/src/spend/ledger.ts`** — the durable format and both halves of its contract. `appendSpendLedger` / `persistSpendRows` write; `readSpendLedger` reads back the well-formed rows **and the count of lines it skipped**. Every line stamps its own `v`, which is the seam a later row shape evolves through (issue #5010's roll-up reads this file).
- **`packages/fabrika-cli/src/io/fs.ts`** — an `appendFile` seam: `a+`, parent directory created, and a missing final newline healed before the append so a truncated tail cannot swallow the row written after it.
- **`packages/fabrika-cli/src/eval/command.ts`** — `--spend-ledger` (defaulted), and the one write, placed on the completion path right after the ledger is built. `--dry-run` spawns nothing and so records nothing.
- **`.gitignore`** — `/.fabrika/`, per-machine measurement evidence.
- **READMEs** — the `eval run` section and the package's `spend` group.
- **`packages/fabrika-cli/src/spend/ledger.unit.test.ts`** — 19 cases, temp directory, no model call.

## Why JSON Lines with a per-row `v`

Chosen for what a partial write does to it: a crash mid-line damages exactly that line, the reader skips it and reports the skip, and the next suite appends after it. A per-row version means #5010 can evolve the row shape by adding a version rather than migrating a file, and the reader can say "I skipped 4 lines" instead of quietly returning fewer rows. The module imports `spend/` and `io/` only — never `eval/` — so the roll-up that reads this ledger does not drag in the harness that writes it (the one-way edge PR #5099 established).

## Deviations

- **Class: fix shape narrowed/widened.** Said: "one new ledger module (append + tolerant reader), runner wiring, gitignore, unit tests". Did: also added an `appendFile` seam to `src/io/fs.ts` and updated two READMEs. Why: `io/fs.ts` had no append primitive, and appending is a property of the open flag, not of the ledger core — putting it anywhere else would have hidden the filesystem seam this package deliberately keeps in one place. Disposition: no action needed.
- **Class: an unrequested behaviour was added.** Said: nothing about repairing a damaged file. Did: `appendFile` reads the last byte and inserts a newline when the file does not end in one. Why: without it, appending onto a truncated tail fuses the new row into the damaged line and loses **both** — a tolerant reader can skip one bad line, it cannot recover a good one glued to it. The test `appends after a malformed line without rewriting it` is the case that forced it. Disposition: no action needed; nothing already on disk is rewritten.
- **Class: a judgment call the issue did not specify.** Said: "the reader skips a malformed or truncated line". Did: a row whose `v` this reader does not know is also skipped and counted. Why: reading a future shape with today's field rules would be a silent misread, and the skip count makes it loud. Disposition: for the reviewer to judge — the alternative (accept any row whose v1 fields parse) is the more permissive reading of the same AC.
- **Class: scope left for a follow-up.** Rotation, compaction and the roll-up verb are out of scope per the issue; the ledger grows unbounded by design for now. Disposition: no action needed — #5010 owns the read side, rotation is explicitly not in this lane.