### PR TITLE
feat(fabrika-cli): one command answers what fabrika's runs cost, from the durable ledger

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -393,6 +393,7 @@ over the meter the `eval` verbs already price runs with — it adds no second su
 | Verb | Answers |
 |---|---|
 | `spend read` | one run's billed token spend, its four `usage` components, the ex-cache-read comparator, its billed turn count and its model |
+| `spend rollup` | what **all** of fabrika's recorded runs cost, summed out of the durable ledger and broken down by day, by skill and by stage-and-arm |
 
 Three behaviours are worth knowing before you call it:
 
@@ -422,6 +423,58 @@ row shape evolves through.
 
 The module imports from `spend/` and `io/` only — never `eval/` — so a reader of the ledger
 does not drag in the eval harness that writes it.
+
+### `spend rollup` — the epic's acceptance test, as one command
+
+```bash
+fabrika spend rollup                                    # everything recorded so far
+fabrika spend rollup --since 2026-08-01 --until 2026-08-09
+fabrika spend rollup --json
+```
+
+This is the one output epic [#4779](https://github.com/kamp-us/phoenix/issues/4779) exists to
+produce ([#5010](https://github.com/kamp-us/phoenix/issues/5010)): a number a human or an agent
+reads on demand. It reads persisted rows only — it spawns nothing, re-parses no transcript, and
+slows no lane. `--ledger` points it at a ledger other than the default; `--since`/`--until` are
+**inclusive at both edges**, and a bare `YYYY-MM-DD` widens to that whole UTC day, so
+`--until 2026-08-09` means "through the 9th" rather than "up to its midnight".
+
+stdout is one record per line, the first field naming the kind:
+
+```
+billed        <n>          exCacheRead <n>   assistantTurns <n>
+runs          <n>          measuredRuns <n>
+skipped       <n>          skippedMalformed <n>   skippedNewerVersion <n>
+undatedRows   <n>
+day        <YYYY-MM-DD>        <billed> <exCacheRead> <assistantTurns> <runs> <measuredRuns>
+skill      <name>              …
+stage-arm  <stage> <arm>       …
+```
+
+Four things about it are load-bearing:
+
+- **Every number it could not count is a number it reports.** The unread-line counts ride on the
+  answer itself (and in `--json`), not just on stderr, because a total that quietly omits 40
+  unreadable lines is worse than an error — it is wrong and looks whole. `undatedRows` is the same
+  rule for a bounded window: a row whose timestamp does not parse cannot be *proven* inside the
+  window, so it is excluded and counted rather than silently kept or dropped.
+- **The skipped count is split, because the two halves ask for opposite things.**
+  `skippedMalformed` is damage — those measurements are gone. `skippedNewerVersion` is intact data
+  written by a newer row shape: the rows are still there and the fix is to upgrade this CLI.
+  Reporting both as one "40 lines lost" is a false alarm in one direction and a missed data loss in
+  the other.
+- **Four refusals, none of them a zero.** `3` is no ledger at that path (nothing recorded yet), `4`
+  is a ledger that could not be read (the spend is UNKNOWN), `5` is one read in full that yielded no
+  rows at all, and `6` is a ledger that *does* hold rows where the given window selects none — an
+  empty window is a different fact from an empty ledger, so it gets its own code. Each refuses with
+  empty stdout.
+- **It cannot gate.** No threshold flag, no budget option, and no exit code that varies with the
+  size of a total — the no-gate ruling on epic #4779, asserted by a test that an arbitrarily large
+  total still exits `0`.
+
+The core is [`src/spend/rollup.ts`](./src/spend/rollup.ts), pure and total: it sums a
+`readSpendLedger` result over a resolved window and groups it three ways.
+[`src/spend/rollup-verb.ts`](./src/spend/rollup-verb.ts) is the IO around it.
 
 ## Development
 

--- a/packages/fabrika-cli/src/spend/command.ts
+++ b/packages/fabrika-cli/src/spend/command.ts
@@ -10,7 +10,9 @@ import {Effect} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import type {VerbOutcome} from "../verb.ts";
+import {DEFAULT_SPEND_LEDGER_PATH} from "./ledger.ts";
 import {runRead} from "./read-verb.ts";
+import {runRollup} from "./rollup-verb.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
 const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
@@ -39,7 +41,52 @@ const read = leafCommand(
 	),
 );
 
+const rollup = leafCommand(
+	"rollup",
+	{
+		// `--ledger`, not `--spend-ledger`: inside `fabrika spend rollup` the group name is already
+		// said, and the description names the writer's flag so the pairing stays findable.
+		ledger: Flag.string("ledger").pipe(
+			Flag.withDefault(DEFAULT_SPEND_LEDGER_PATH),
+			Flag.withDescription(
+				`the durable spend ledger to read — the file \`fabrika eval run --spend-ledger\` appends to (default: ${DEFAULT_SPEND_LEDGER_PATH})`,
+			),
+		),
+		since: Flag.string("since").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"inclusive lower bound — an ISO-8601 instant, or a bare YYYY-MM-DD meaning that UTC day's first millisecond",
+			),
+		),
+		until: Flag.string("until").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"inclusive upper bound — an ISO-8601 instant, or a bare YYYY-MM-DD meaning through that whole UTC day",
+			),
+		),
+		json: Flag.boolean("json").pipe(
+			Flag.withDescription("emit the same answer as JSON on stdout instead of the line grammar"),
+		),
+	},
+	Effect.fn(function* ({ledger, since, until, json}) {
+		yield* emit(
+			yield* runRollup({
+				ledger,
+				since: since._tag === "Some" ? since.value : null,
+				until: until._tag === "Some" ? until.value : null,
+				json,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"What fabrika's runs cost, summed out of the durable spend ledger — the one command that answers it from persisted data, spawning nothing and re-parsing no transcript. stdout is one record per line, first field naming the kind: billed, exCacheRead, assistantTurns, runs, measuredRuns, then skipped/skippedMalformed/skippedNewerVersion/undatedRows, then one `day`, `skill` and `stage-arm` line per bucket. The skipped counts ride on the answer so a partially-unreadable ledger can never present as a quietly smaller total, and they are split because a malformed line is data loss while a newer-version line means upgrade this CLI. --since/--until bound the window (inclusive; a bare YYYY-MM-DD widens to the whole UTC day), --json emits the same answer as an object. Exits 3 (no ledger there — nothing recorded yet), 4 (the ledger could not be read — the spend is UNKNOWN, never zero), 5 (read in full, no rows at all), 6 (rows exist but this window selects none). No threshold, no budget flag, and no exit code that varies with a spend magnitude. Example: fabrika spend rollup --since 2026-08-01",
+	),
+);
+
 export const spendCommand = Command.make("spend").pipe(
-	Command.withSubcommands([read]),
-	Command.withDescription("Read what one fabrika run cost, in tokens, from its transcript"),
+	Command.withSubcommands([read, rollup]),
+	Command.withDescription(
+		"Read what fabrika's runs cost, in tokens — one run from its transcript, or all of them from the durable ledger",
+	),
 );

--- a/packages/fabrika-cli/src/spend/ledger.ts
+++ b/packages/fabrika-cli/src/spend/ledger.ts
@@ -45,11 +45,33 @@ export interface LedgerRow {
 	readonly spend: RunSpend;
 }
 
+/**
+ * Why an unreadable line splits in two rather than staying one number (#5010): the two halves ask
+ * the operator for opposite things. A `malformed` line is damage — bytes that will never decode, so
+ * that measurement is gone. A `newerVersion` line is intact data this build is too old to read, so
+ * the rows are still there and the action is to upgrade the CLI. One counter reported both as "40
+ * lines lost", which is a false alarm in one direction and a missed data loss in the other.
+ *
+ * A `v` *below* the current one counts as malformed on purpose: v1 is the first shape ever written,
+ * so there is no older ledger for such a line to have come from.
+ */
+export interface LedgerSkips {
+	/** Lines that will never decode — a truncated tail, a partial write, corruption. Data loss. */
+	readonly malformed: number;
+	/** Well-formed lines stamped with a `v` this build does not know. Upgrade, not damage. */
+	readonly newerVersion: number;
+}
+
 /** What a read of the ledger text found, and how much of it it could not read. */
 export interface LedgerRead {
 	readonly rows: ReadonlyArray<LedgerRow>;
-	/** Lines that were present but unreadable. Reported, never silently folded into "no rows". */
+	/**
+	 * Lines that were present but unreadable — `malformed + newerVersion`. Reported, never silently
+	 * folded into "no rows"; kept as the sum so a caller that only needs "how much did I miss" does
+	 * not have to add the halves back up.
+	 */
 	readonly skipped: number;
+	readonly skips: LedgerSkips;
 }
 
 /**
@@ -127,11 +149,23 @@ const decodeSpend = (value: unknown): RunSpend | null => {
 	return {_tag: "Reconstructed", spend};
 };
 
-const decodeRow = (line: string): LedgerRow | null => {
+/** One line's three outcomes — the same split {@link LedgerSkips} reports. */
+type LineRead =
+	| {readonly _tag: "Row"; readonly row: LedgerRow}
+	| {readonly _tag: "NewerVersion"}
+	| {readonly _tag: "Malformed"};
+
+const MALFORMED: LineRead = {_tag: "Malformed"};
+const NEWER_VERSION: LineRead = {_tag: "NewerVersion"};
+
+const decodeLine = (line: string): LineRead => {
 	const decoded = Result.try({try: (): unknown => JSON.parse(line), catch: () => null});
-	if (Result.isFailure(decoded)) return null;
+	if (Result.isFailure(decoded)) return MALFORMED;
 	const parsed = decoded.success;
-	if (!isRecord(parsed) || parsed.v !== LEDGER_ROW_VERSION) return null;
+	if (!isRecord(parsed)) return MALFORMED;
+	const version = num(parsed.v);
+	if (version !== null && version > LEDGER_ROW_VERSION) return NEWER_VERSION;
+	if (version !== LEDGER_ROW_VERSION) return MALFORMED;
 	const skillName = str(parsed.skillName);
 	const stage = str(parsed.stage);
 	const caseId = num(parsed.caseId);
@@ -150,11 +184,14 @@ const decodeRow = (line: string): LedgerRow | null => {
 		recordedAt === null ||
 		spend === null
 	) {
-		return null;
+		return MALFORMED;
 	}
 	const cliVersion = parsed.cliVersion;
-	if (cliVersion !== null && typeof cliVersion !== "string") return null;
-	return {skillName, stage, caseId, arm, model, sessionId, cliVersion, recordedAt, spend};
+	if (cliVersion !== null && typeof cliVersion !== "string") return MALFORMED;
+	return {
+		_tag: "Row",
+		row: {skillName, stage, caseId, arm, model, sessionId, cliVersion, recordedAt, spend},
+	};
 };
 
 /**
@@ -168,18 +205,17 @@ const decodeRow = (line: string): LedgerRow | null => {
  */
 export const readSpendLedger = (text: string): LedgerRead => {
 	const rows: Array<LedgerRow> = [];
-	let skipped = 0;
+	let malformed = 0;
+	let newerVersion = 0;
 	for (const line of text.split("\n")) {
 		const trimmed = line.trim();
 		if (trimmed.length === 0) continue;
-		const row = decodeRow(trimmed);
-		if (row === null) {
-			skipped += 1;
-			continue;
-		}
-		rows.push(row);
+		const read = decodeLine(trimmed);
+		if (read._tag === "Row") rows.push(read.row);
+		else if (read._tag === "NewerVersion") newerVersion += 1;
+		else malformed += 1;
 	}
-	return {rows, skipped};
+	return {rows, skipped: malformed + newerVersion, skips: {malformed, newerVersion}};
 };
 
 /**

--- a/packages/fabrika-cli/src/spend/ledger.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/ledger.unit.test.ts
@@ -161,6 +161,26 @@ describe("readSpendLedger — tolerant of anything a partial write can leave beh
 		assert.strictEqual(read.skipped, 1);
 	});
 
+	it("keeps damage and a newer row version apart — they ask the operator for opposite things", () => {
+		const newer = JSON.stringify({...JSON.parse(encodeSpendRows([row()]).trim()), v: 99});
+		const read = readSpendLedger(`not json at all\n${newer}\n${encodeSpendRows([row()])}`);
+		assert.strictEqual(read.rows.length, 1);
+		assert.deepStrictEqual(read.skips, {malformed: 1, newerVersion: 1});
+		assert.strictEqual(read.skipped, 2);
+	});
+
+	it("counts a version BELOW the current one as damage — v1 is the first shape ever written", () => {
+		const older = JSON.stringify({...JSON.parse(encodeSpendRows([row()]).trim()), v: 0});
+		assert.deepStrictEqual(readSpendLedger(`${older}\n`).skips, {malformed: 1, newerVersion: 0});
+	});
+
+	it("keeps `skipped` the sum of its halves, so a caller that only wants the gap still gets it", () => {
+		const newer = JSON.stringify({...JSON.parse(encodeSpendRows([row()]).trim()), v: 7});
+		const read = readSpendLedger(`${newer}\n${newer}\nhalf a row`);
+		assert.strictEqual(read.skipped, read.skips.malformed + read.skips.newerVersion);
+		assert.deepStrictEqual(read.skips, {malformed: 1, newerVersion: 2});
+	});
+
 	it("counts blank lines as nothing at all — a trailing newline is not a skip", () => {
 		const read = readSpendLedger(`${encodeSpendRows([row()])}\n   \n`);
 		assert.strictEqual(read.rows.length, 1);
@@ -168,7 +188,11 @@ describe("readSpendLedger — tolerant of anything a partial write can leave beh
 	});
 
 	it("reads an empty ledger as no rows and no skips, never as a failure", () => {
-		assert.deepStrictEqual(readSpendLedger(""), {rows: [], skipped: 0});
+		assert.deepStrictEqual(readSpendLedger(""), {
+			rows: [],
+			skipped: 0,
+			skips: {malformed: 0, newerVersion: 0},
+		});
 	});
 });
 

--- a/packages/fabrika-cli/src/spend/rollup-verb.ts
+++ b/packages/fabrika-cli/src/spend/rollup-verb.ts
@@ -1,0 +1,154 @@
+/**
+ * `spend rollup` — one command that answers what fabrika's runs cost, from persisted data (#5010).
+ *
+ * It reads the durable ledger and nothing else: no transcript is re-parsed, no process is spawned,
+ * no operator supplies a path to a run. That is what makes it the epic's acceptance test — a number
+ * a human or an agent can ask for on demand without slowing a lane.
+ *
+ * **It cannot gate.** No threshold flag, no budget option, and no exit code that varies with the
+ * size of a total (epic #4779's no-gate ruling). The non-zero codes below are all about whether an
+ * answer could be *produced*, never about how big it was.
+ *
+ * The four refusals are the same discipline `spend read` draws, one level up: an absent ledger, an
+ * unreadable one, one that holds no rows at all, and a window that selects none of the rows it does
+ * hold are four different facts, and none of them is a zero total.
+ */
+import {Effect, type FileSystem, Result} from "effect";
+import {exists, readFile} from "../io/fs.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {readSpendLedger} from "./ledger.ts";
+import {
+	type ResolvedWindow,
+	type Rollup,
+	resolveBound,
+	rollUp,
+	type SpendTotals,
+} from "./rollup.ts";
+
+const VERB = "fabrika spend rollup";
+
+/** No ledger at that path. A proven absence — nothing has been recorded yet. */
+export const LEDGER_ABSENT = 3;
+/** The ledger could not be read, or its absence could not be established. UNKNOWN. */
+export const LEDGER_UNREADABLE = 4;
+/** The ledger was read in full and yielded no rows — empty, or every line unreadable. */
+export const LEDGER_HOLDS_NO_ROWS = 5;
+/** The ledger holds rows; this window selects none of them. Distinct from an empty ledger. */
+export const WINDOW_SELECTED_NO_ROWS = 6;
+
+export interface RollupOptions {
+	/** Path to the durable spend ledger. */
+	readonly ledger: string;
+	/** Inclusive lower bound, or `null` for unbounded. */
+	readonly since: string | null;
+	/** Inclusive upper bound, or `null` for unbounded. A bare date means through that whole UTC day. */
+	readonly until: string | null;
+	readonly json: boolean;
+}
+
+const totalsFields = (totals: SpendTotals): ReadonlyArray<string> => [
+	String(totals.billed),
+	String(totals.exCacheRead),
+	String(totals.assistantTurns),
+	String(totals.runs),
+	String(totals.measuredRuns),
+];
+
+/**
+ * One record per line, first field naming the record's kind — so `grep '^day'` is the breakdown and
+ * the unread counts sit in the same answer as the total they qualify.
+ */
+const render = (rollup: Rollup): string => {
+	const t = rollup.totals;
+	return [
+		`billed\t${t.billed}`,
+		`exCacheRead\t${t.exCacheRead}`,
+		`assistantTurns\t${t.assistantTurns}`,
+		`runs\t${t.runs}`,
+		`measuredRuns\t${t.measuredRuns}`,
+		`skipped\t${rollup.skipped.total}`,
+		`skippedMalformed\t${rollup.skipped.malformed}`,
+		`skippedNewerVersion\t${rollup.skipped.newerVersion}`,
+		`undatedRows\t${rollup.undatedRows}`,
+		...rollup.byDay.map((b) => [`day\t${b.day}`, ...totalsFields(b)].join("\t")),
+		...rollup.bySkill.map((b) => [`skill\t${b.skill}`, ...totalsFields(b)].join("\t")),
+		...rollup.byStageArm.map((b) =>
+			[`stage-arm\t${b.stage}\t${b.arm}`, ...totalsFields(b)].join("\t"),
+		),
+	].join("\n");
+};
+
+/**
+ * How many lines the ledger held but could not yield, said in words — appended to every outcome,
+ * answer and refusal alike. A caller who reads only the total still sees the gap, which is the
+ * whole point: a rollup that skipped 40 lines and says nothing is a smaller number that looks whole.
+ */
+const skippedNote = (skipped: {
+	readonly total: number;
+	readonly malformed: number;
+	readonly newerVersion: number;
+}): string =>
+	skipped.total === 0
+		? "every line in the ledger was read."
+		: `${skipped.total} ledger line(s) could NOT be read and are absent from these figures: ${skipped.malformed} malformed (damage — those measurements are gone), ${skipped.newerVersion} written by a newer row version (upgrade fabrika-cli to include them).`;
+
+export const runRollup = (
+	options: RollupOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const path = options.ledger;
+
+		const sinceAt = options.since === null ? null : resolveBound(options.since, "since");
+		const untilAt = options.until === null ? null : resolveBound(options.until, "until");
+		if (options.since !== null && sinceAt === null) {
+			return refuse(FAILED, `${VERB}: --since ${options.since} is not a time.`);
+		}
+		if (options.until !== null && untilAt === null) {
+			return refuse(FAILED, `${VERB}: --until ${options.until} is not a time.`);
+		}
+		const window: ResolvedWindow = {
+			sinceAt,
+			untilAt,
+			text: {since: options.since, until: options.until},
+		};
+
+		const text = yield* Effect.result(readFile(path));
+		if (Result.isFailure(text)) {
+			// Only a probe that comes back a definite `false` proves the ledger is absent; a probe that
+			// itself fails proves nothing, so it stays UNKNOWN rather than becoming "nothing recorded".
+			const probe = yield* Effect.result(exists(path));
+			if (Result.isFailure(probe) || probe.success) {
+				return refuse(
+					LEDGER_UNREADABLE,
+					`${VERB}: cannot read the ledger at ${path}: ${text.failure.reason} — the spend is UNKNOWN, never zero.`,
+				);
+			}
+			return refuse(
+				LEDGER_ABSENT,
+				`${VERB}: no spend ledger at ${path} — nothing has been recorded yet.`,
+			);
+		}
+
+		const read = readSpendLedger(text.success);
+		const skipped = {total: read.skipped, ...read.skips};
+		if (read.rows.length === 0) {
+			return refuse(
+				LEDGER_HOLDS_NO_ROWS,
+				`${VERB}: ${path} was read in full and yielded no rows — nothing to sum.`,
+				[`${VERB}: ${skippedNote(skipped)}`],
+			);
+		}
+
+		const rollup = rollUp(read, window);
+		const bounds = `${options.since ?? "the first row"} .. ${options.until ?? "the last row"}`;
+		if (rollup.totals.runs === 0) {
+			return refuse(
+				WINDOW_SELECTED_NO_ROWS,
+				`${VERB}: ${read.rows.length} row(s) in ${path}, none of them within ${bounds} — an empty window, not an empty ledger.`,
+				[`${VERB}: ${skippedNote(skipped)}`],
+			);
+		}
+
+		const scope = `${VERB}: summed ${rollup.totals.runs} run(s) from ${path} within ${bounds}; ${rollup.totals.measuredRuns} carried a reconstructed spend. ${skippedNote(skipped)}${rollup.undatedRows === 0 ? "" : ` ${rollup.undatedRows} row(s) carry no readable timestamp and this bounded window excluded them.`}`;
+		return answer(options.json ? JSON.stringify(rollup) : render(rollup), [scope]);
+	});

--- a/packages/fabrika-cli/src/spend/rollup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/rollup-verb.unit.test.ts
@@ -1,0 +1,266 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFs, fakeFs} from "../fakes.test-support.ts";
+import {encodeSpendRows, type LedgerRow} from "./ledger.ts";
+import {
+	LEDGER_ABSENT,
+	LEDGER_HOLDS_NO_ROWS,
+	LEDGER_UNREADABLE,
+	runRollup,
+	WINDOW_SELECTED_NO_ROWS,
+} from "./rollup-verb.ts";
+import type {RunSpend} from "./token-spend.ts";
+
+const PATH = "/repo/.fabrika/spend-ledger.jsonl";
+
+const spendOf = (billed: number, exCacheRead: number, assistantTurns: number): RunSpend => ({
+	_tag: "Reconstructed",
+	spend: {
+		input: exCacheRead,
+		cacheCreate: 0,
+		cacheRead: billed - exCacheRead,
+		output: 0,
+		billed,
+		exCacheRead,
+		assistantTurns,
+		model: "claude-opus-5",
+	},
+});
+
+const row = (overrides: Partial<LedgerRow> = {}): LedgerRow => ({
+	skillName: "write-code",
+	stage: "build",
+	caseId: 1,
+	arm: "with-skill",
+	model: "claude-opus-5",
+	sessionId: "3f9c1d2b-0000-4000-8000-000000000001",
+	cliVersion: "2.1.220",
+	recordedAt: "2026-08-09T09:00:00.000Z",
+	spend: spendOf(100, 40, 3),
+	...overrides,
+});
+
+interface RunOptions {
+	readonly since?: string;
+	readonly until?: string;
+	readonly json?: boolean;
+}
+
+const run = (fs: FakeFs, options: RunOptions = {}) =>
+	Effect.runPromise(
+		Effect.provide(
+			runRollup({
+				ledger: PATH,
+				since: options.since ?? null,
+				until: options.until ?? null,
+				json: options.json ?? false,
+			}),
+			fs.layer,
+		),
+	);
+
+const withText = (text: string | null) => fakeFs({files: {[PATH]: text}});
+
+const withRows = (rows: ReadonlyArray<LedgerRow>) => withText(encodeSpendRows(rows));
+
+/** The line grammar as a lookup: first field → the rest. */
+const fields = (stdout: string): Map<string, ReadonlyArray<string>> =>
+	new Map(
+		stdout
+			.split("\n")
+			.filter((line) => line !== "")
+			.map((line) => {
+				const [kind = "", ...rest] = line.split("\t");
+				return [kind, rest] as const;
+			}),
+	);
+
+describe("spend rollup — the answer", () => {
+	it("answers the window's totals with no transcript path supplied by the operator", async () => {
+		const out = await run(withRows([row(), row({spend: spendOf(50, 20, 1)})]));
+
+		expect(out.code).toBe(0);
+		expect(fields(out.stdout).get("billed")).toEqual(["150"]);
+		expect(fields(out.stdout).get("exCacheRead")).toEqual(["60"]);
+		expect(fields(out.stdout).get("assistantTurns")).toEqual(["4"]);
+		expect(fields(out.stdout).get("runs")).toEqual(["2"]);
+	});
+
+	it("emits a day, a skill and a stage-arm breakdown in the one answer", async () => {
+		const out = await run(
+			withRows([
+				row({recordedAt: "2026-08-08T10:00:00.000Z"}),
+				row({recordedAt: "2026-08-09T10:00:00.000Z", skillName: "review-code", stage: "review"}),
+			]),
+		);
+		const lines = out.stdout.split("\n");
+
+		expect(lines.filter((l) => l.startsWith("day\t"))).toHaveLength(2);
+		expect(lines.filter((l) => l.startsWith("skill\t"))).toHaveLength(2);
+		expect(lines.filter((l) => l.startsWith("stage-arm\t"))).toHaveLength(2);
+		expect(lines).toContain("day\t2026-08-08\t100\t40\t3\t1\t1");
+		expect(lines).toContain("stage-arm\treview\twith-skill\t100\t40\t3\t1\t1");
+	});
+
+	it("emits the same answer as JSON under --json", async () => {
+		const rows = [row(), row({skillName: "review-code"})];
+		const out = await run(withRows(rows), {json: true});
+		const parsed = JSON.parse(out.stdout);
+
+		expect(out.code).toBe(0);
+		expect(parsed.totals).toEqual({
+			billed: 200,
+			exCacheRead: 80,
+			assistantTurns: 6,
+			runs: 2,
+			measuredRuns: 2,
+		});
+		expect(parsed.bySkill.map((b: {skill: string}) => b.skill)).toEqual([
+			"review-code",
+			"write-code",
+		]);
+	});
+
+	it("bounds the window with --since and --until, inclusive at both edges", async () => {
+		const rows = [
+			row({recordedAt: "2026-08-07T12:00:00.000Z"}),
+			row({recordedAt: "2026-08-08T00:00:00.000Z"}),
+			row({recordedAt: "2026-08-09T23:59:59.999Z"}),
+			row({recordedAt: "2026-08-10T00:00:00.000Z"}),
+		];
+		const out = await run(withRows(rows), {since: "2026-08-08", until: "2026-08-09"});
+
+		expect(out.code).toBe(0);
+		expect(fields(out.stdout).get("runs")).toEqual(["2"]);
+	});
+
+	it("prints the ledger path and the window on stderr, never on stdout", async () => {
+		const out = await run(withRows([row()]), {since: "2026-08-01"});
+
+		expect(out.stderr.join("\n")).toContain(PATH);
+		expect(out.stderr.join("\n")).toContain("2026-08-01");
+		expect(out.stdout).not.toContain(PATH);
+	});
+
+	/** The no-gate ruling, asserted rather than noted: it fails the moment a threshold appears. */
+	it("exits 0 on an arbitrarily large total — no exit code varies with a spend magnitude", async () => {
+		const out = await run(withRows([row({spend: spendOf(7_489_969_208, 1, 1)})]));
+
+		expect(out.code).toBe(0);
+		expect(fields(out.stdout).get("billed")).toEqual(["7489969208"]);
+	});
+
+	it("reads persisted rows only — the ledger is the single file it touches, and it writes nothing", async () => {
+		const fs = withRows([row()]);
+		const out = await run(fs);
+
+		// Any transcript re-parse or side write would need a file this layer does not hold, and the
+		// read of it would fail rather than resolve — so a clean answer here is the assertion.
+		expect(out.code).toBe(0);
+		expect(fs.written.size).toBe(0);
+	});
+});
+
+describe("spend rollup — it never presents a partial read as a whole total", () => {
+	it("puts the skipped-line count on stdout beside the total it qualifies", async () => {
+		const good = encodeSpendRows([row()]);
+		const out = await run(withText(`${good}not json at all\nalso not json\n`));
+
+		expect(out.code).toBe(0);
+		expect(fields(out.stdout).get("skipped")).toEqual(["2"]);
+		expect(fields(out.stdout).get("skippedMalformed")).toEqual(["2"]);
+		expect(fields(out.stdout).get("skippedNewerVersion")).toEqual(["0"]);
+	});
+
+	it("splits damage from a newer row version — one is data loss, the other is upgrade the CLI", async () => {
+		const newer = JSON.stringify({...JSON.parse(encodeSpendRows([row()]).trim()), v: 99});
+		const out = await run(withText(`${encodeSpendRows([row()])}${newer}\nhalf a row`));
+
+		expect(fields(out.stdout).get("skippedMalformed")).toEqual(["1"]);
+		expect(fields(out.stdout).get("skippedNewerVersion")).toEqual(["1"]);
+		expect(out.stderr.join("\n")).toContain("upgrade fabrika-cli");
+	});
+
+	it("carries the skipped counts into --json too", async () => {
+		const out = await run(withText(`${encodeSpendRows([row()])}half a row`), {json: true});
+
+		expect(JSON.parse(out.stdout).skipped).toEqual({total: 1, malformed: 1, newerVersion: 0});
+	});
+
+	it("says so on stderr when there was nothing it could not read", async () => {
+		const out = await run(withRows([row()]));
+
+		expect(out.stderr.join("\n")).toContain("every line in the ledger was read");
+	});
+
+	it("names the rows a bounded window could not place in time", async () => {
+		const out = await run(withRows([row(), row({recordedAt: "not a time"})]), {
+			since: "2026-08-01",
+		});
+
+		expect(fields(out.stdout).get("undatedRows")).toEqual(["1"]);
+		expect(out.stderr.join("\n")).toContain("no readable timestamp");
+	});
+});
+
+describe("spend rollup — the refusals", () => {
+	it("refuses a ledger that is provably not there, with empty stdout", async () => {
+		const out = await run(fakeFs({files: {}}));
+
+		expect(out.code).toBe(LEDGER_ABSENT);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("nothing has been recorded yet");
+	});
+
+	it("refuses an unreadable ledger as UNKNOWN, never as absent and never as a zero", async () => {
+		const out = await run(fakeFs({files: {[PATH]: null}, unprobeable: [PATH]}));
+
+		expect(out.code).toBe(LEDGER_UNREADABLE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("UNKNOWN");
+	});
+
+	it("refuses an empty ledger rather than answering a fabricated zero total", async () => {
+		const out = await run(withText(""));
+
+		expect(out.code).toBe(LEDGER_HOLDS_NO_ROWS);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a ledger whose every line is unreadable, and says how many were lost", async () => {
+		const out = await run(withText("half a row\nanother half\n"));
+
+		expect(out.code).toBe(LEDGER_HOLDS_NO_ROWS);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("2 ledger line(s) could NOT be read");
+	});
+
+	it("refuses a window that selects no rows on its OWN code, distinct from an empty ledger", async () => {
+		const out = await run(withRows([row()]), {since: "2027-01-01"});
+
+		expect(out.code).toBe(WINDOW_SELECTED_NO_ROWS);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("an empty window, not an empty ledger");
+	});
+
+	it("seats all four outcomes above the reserved codes, distinct from each other", () => {
+		const codes = [LEDGER_ABSENT, LEDGER_UNREADABLE, LEDGER_HOLDS_NO_ROWS, WINDOW_SELECTED_NO_ROWS];
+		for (const code of codes) expect(code).toBeGreaterThanOrEqual(3);
+		expect(new Set(codes).size).toBe(4);
+	});
+
+	it("refuses a --since that is not a time as a usage error, not as an empty window", async () => {
+		const out = await run(withRows([row()]), {since: "yesterday"});
+
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("is not a time");
+	});
+
+	it("refuses under --json too — a refusal never puts a payload on stdout", async () => {
+		const out = await run(withText(""), {json: true});
+
+		expect(out.code).toBe(LEDGER_HOLDS_NO_ROWS);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/spend/rollup.ts
+++ b/packages/fabrika-cli/src/spend/rollup.ts
@@ -1,0 +1,171 @@
+/**
+ * The spend roll-up — what fabrika's runs cost, summed out of the durable ledger (#5010).
+ *
+ * Pure and total: it takes what {@link readSpendLedger} already produced and a resolved window, and
+ * returns the answer. Nothing here reads a file, spawns anything, or re-parses a transcript — the
+ * rows were measured when the runs finished, and this only adds them up.
+ *
+ * **Every number it cannot count is a number it reports.** A total that quietly omits the lines it
+ * could not read, or the runs it could not place in time, is worse than an error: it is wrong and
+ * looks right. So the unread halves ride out on the answer next to the total, split the way
+ * {@link LedgerSkips} splits them, and a bounded window names how many rows it could not date.
+ */
+import type {LedgerRead, LedgerRow, LedgerSkips} from "./ledger.ts";
+
+/** The four figures a roll-up answers with, plus how many runs stand behind them. */
+export interface SpendTotals {
+	/** Σ `billed` — the headline (ADR 0112 §2). */
+	readonly billed: number;
+	/** Σ `exCacheRead` — the cross-run comparator that does not re-count the cached prefix. */
+	readonly exCacheRead: number;
+	readonly assistantTurns: number;
+	/** Rows in the bucket, measured or not. */
+	readonly runs: number;
+	/** Rows whose spend was actually reconstructed — the rest contributed nothing to the sums. */
+	readonly measuredRuns: number;
+}
+
+export interface DayTotals extends SpendTotals {
+	readonly day: string;
+}
+
+export interface SkillTotals extends SpendTotals {
+	readonly skill: string;
+}
+
+export interface StageArmTotals extends SpendTotals {
+	readonly stage: string;
+	readonly arm: string;
+}
+
+/** The window as the operator wrote it, echoed back so an answer states what it covered. */
+export interface RollupWindow {
+	readonly since: string | null;
+	readonly until: string | null;
+}
+
+/** Lines the ledger held but could not yield, carried onto the answer rather than dropped. */
+export interface RollupSkipped extends LedgerSkips {
+	readonly total: number;
+}
+
+export interface Rollup {
+	readonly window: RollupWindow;
+	readonly totals: SpendTotals;
+	readonly skipped: RollupSkipped;
+	/** Rows a bounded window could not place in time. Always 0 when no bound was given. */
+	readonly undatedRows: number;
+	readonly byDay: ReadonlyArray<DayTotals>;
+	readonly bySkill: ReadonlyArray<SkillTotals>;
+	readonly byStageArm: ReadonlyArray<StageArmTotals>;
+}
+
+/** A resolved window: epoch milliseconds, or `null` for an unbounded edge. */
+export interface ResolvedWindow {
+	readonly sinceAt: number | null;
+	readonly untilAt: number | null;
+	readonly text: RollupWindow;
+}
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Resolve one window edge to epoch milliseconds, or `null` when it is not a time at all.
+ *
+ * A bare `YYYY-MM-DD` widens to the whole UTC day — `--since` to its first millisecond, `--until` to
+ * its last — because an operator who writes `--until 2026-08-09` means "through the 9th", and
+ * midnight would silently drop that day's every run.
+ */
+export const resolveBound = (text: string, edge: "since" | "until"): number | null => {
+	const iso = DATE_ONLY.test(text)
+		? `${text}T${edge === "since" ? "00:00:00.000" : "23:59:59.999"}Z`
+		: text;
+	const at = Date.parse(iso);
+	return Number.isNaN(at) ? null : at;
+};
+
+const EMPTY: SpendTotals = {
+	billed: 0,
+	exCacheRead: 0,
+	assistantTurns: 0,
+	runs: 0,
+	measuredRuns: 0,
+};
+
+const add = (totals: SpendTotals, row: LedgerRow): SpendTotals => {
+	const runs = totals.runs + 1;
+	if (row.spend._tag !== "Reconstructed") return {...totals, runs};
+	const spend = row.spend.spend;
+	return {
+		billed: totals.billed + spend.billed,
+		exCacheRead: totals.exCacheRead + spend.exCacheRead,
+		assistantTurns: totals.assistantTurns + spend.assistantTurns,
+		runs,
+		measuredRuns: totals.measuredRuns + 1,
+	};
+};
+
+const groupBy = <K extends string>(
+	rows: ReadonlyArray<LedgerRow>,
+	key: (row: LedgerRow) => K,
+): ReadonlyArray<readonly [K, SpendTotals]> => {
+	const buckets = new Map<K, SpendTotals>();
+	for (const row of rows) {
+		const k = key(row);
+		buckets.set(k, add(buckets.get(k) ?? EMPTY, row));
+	}
+	return [...buckets.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+};
+
+/** The UTC day a row was recorded on — the stamp's own date, never a clock read here. */
+const dayOf = (row: LedgerRow): string => row.recordedAt.slice(0, 10);
+
+/** A tab cannot appear in a JSON-decoded key without being escaped, so it is a safe joiner. */
+const STAGE_ARM = "\t";
+
+/**
+ * Select the rows a window covers.
+ *
+ * A row whose `recordedAt` is not a time cannot be *proven* inside a bounded window, so a bounded
+ * window drops it and says how many it dropped — the same rule as everywhere else here: an
+ * unplaceable row is reported, never quietly counted in or out. With no bound there is nothing to
+ * prove, so every row is in.
+ */
+export const selectWindow = (
+	rows: ReadonlyArray<LedgerRow>,
+	window: ResolvedWindow,
+): {readonly rows: ReadonlyArray<LedgerRow>; readonly undated: number} => {
+	if (window.sinceAt === null && window.untilAt === null) return {rows, undated: 0};
+	const selected: Array<LedgerRow> = [];
+	let undated = 0;
+	for (const row of rows) {
+		const at = Date.parse(row.recordedAt);
+		if (Number.isNaN(at)) {
+			undated += 1;
+			continue;
+		}
+		if (window.sinceAt !== null && at < window.sinceAt) continue;
+		if (window.untilAt !== null && at > window.untilAt) continue;
+		selected.push(row);
+	}
+	return {rows: selected, undated};
+};
+
+/** Sum a ledger read over a window, grouped three ways. */
+export const rollUp = (read: LedgerRead, window: ResolvedWindow): Rollup => {
+	const {rows, undated} = selectWindow(read.rows, window);
+	return {
+		window: window.text,
+		totals: rows.reduce(add, EMPTY),
+		skipped: {total: read.skipped, ...read.skips},
+		undatedRows: undated,
+		byDay: groupBy(rows, dayOf).map(([day, totals]) => ({day, ...totals})),
+		bySkill: groupBy(rows, (row) => row.skillName).map(([skill, totals]) => ({skill, ...totals})),
+		byStageArm: groupBy(rows, (row) => `${row.stage}${STAGE_ARM}${row.arm}`).map(
+			([key, totals]) => {
+				const [stage = "", arm = ""] = key.split(STAGE_ARM);
+				return {stage, arm, ...totals};
+			},
+		),
+	};
+};

--- a/packages/fabrika-cli/src/spend/rollup.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/rollup.unit.test.ts
@@ -1,0 +1,221 @@
+/**
+ * The roll-up core: summing, grouping, the window, and every number it declines to count (#5010).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import type {LedgerRead, LedgerRow} from "./ledger.ts";
+import {type ResolvedWindow, resolveBound, rollUp, selectWindow} from "./rollup.ts";
+import type {RunSpend} from "./token-spend.ts";
+
+const spendOf = (billed: number, exCacheRead: number, assistantTurns: number): RunSpend => ({
+	_tag: "Reconstructed",
+	spend: {
+		input: exCacheRead,
+		cacheCreate: 0,
+		cacheRead: billed - exCacheRead,
+		output: 0,
+		billed,
+		exCacheRead,
+		assistantTurns,
+		model: "claude-opus-5",
+	},
+});
+
+const row = (overrides: Partial<LedgerRow> = {}): LedgerRow => ({
+	skillName: "write-code",
+	stage: "build",
+	caseId: 1,
+	arm: "with-skill",
+	model: "claude-opus-5",
+	sessionId: "3f9c1d2b-0000-4000-8000-000000000001",
+	cliVersion: "2.1.220",
+	recordedAt: "2026-08-09T09:00:00.000Z",
+	spend: spendOf(100, 40, 3),
+	...overrides,
+});
+
+const read = (rows: ReadonlyArray<LedgerRow>, malformed = 0, newerVersion = 0): LedgerRead => ({
+	rows,
+	skipped: malformed + newerVersion,
+	skips: {malformed, newerVersion},
+});
+
+const UNBOUNDED: ResolvedWindow = {sinceAt: null, untilAt: null, text: {since: null, until: null}};
+
+const window = (since: string | null, until: string | null): ResolvedWindow => ({
+	sinceAt: since === null ? null : resolveBound(since, "since"),
+	untilAt: until === null ? null : resolveBound(until, "until"),
+	text: {since, until},
+});
+
+describe("rollUp — the totals", () => {
+	it("sums billed, ex-cache-read, assistant turns and the run count", () => {
+		const out = rollUp(read([row(), row({spend: spendOf(50, 20, 1)})]), UNBOUNDED);
+		assert.deepStrictEqual(out.totals, {
+			billed: 150,
+			exCacheRead: 60,
+			assistantTurns: 4,
+			runs: 2,
+			measuredRuns: 2,
+		});
+	});
+
+	it("counts an unmeasured run as a run but adds nothing to the figures", () => {
+		const out = rollUp(
+			read([
+				row(),
+				row({spend: {_tag: "TranscriptMissing"}}),
+				row({spend: {_tag: "NoBilledTurns"}}),
+			]),
+			UNBOUNDED,
+		);
+		assert.strictEqual(out.totals.billed, 100);
+		assert.strictEqual(out.totals.runs, 3);
+		assert.strictEqual(out.totals.measuredRuns, 1);
+	});
+
+	/** The no-gate ruling, asserted rather than noted: the core has no threshold to trip. */
+	it("sums an arbitrarily large total without changing anything about the answer's shape", () => {
+		const out = rollUp(read([row({spend: spendOf(7_489_969_208, 1, 1)})]), UNBOUNDED);
+		assert.strictEqual(out.totals.billed, 7_489_969_208);
+		assert.strictEqual(out.totals.runs, 1);
+	});
+});
+
+describe("rollUp — the three breakdowns", () => {
+	const rows = [
+		row({recordedAt: "2026-08-08T10:00:00.000Z", skillName: "write-code", stage: "build"}),
+		row({
+			recordedAt: "2026-08-09T10:00:00.000Z",
+			skillName: "review-code",
+			stage: "review",
+			arm: "no-skill",
+			spend: spendOf(50, 20, 1),
+		}),
+		row({recordedAt: "2026-08-09T20:00:00.000Z", skillName: "write-code", stage: "build"}),
+	];
+
+	it("groups by the UTC day of each row's own stamp", () => {
+		const out = rollUp(read(rows), UNBOUNDED);
+		assert.deepStrictEqual(
+			out.byDay.map((b) => [b.day, b.billed, b.runs]),
+			[
+				["2026-08-08", 100, 1],
+				["2026-08-09", 150, 2],
+			],
+		);
+	});
+
+	it("groups by skill", () => {
+		const out = rollUp(read(rows), UNBOUNDED);
+		assert.deepStrictEqual(
+			out.bySkill.map((b) => [b.skill, b.billed, b.runs]),
+			[
+				["review-code", 50, 1],
+				["write-code", 200, 2],
+			],
+		);
+	});
+
+	it("groups by stage AND arm together — the pair is the comparison, not either alone", () => {
+		const out = rollUp(read(rows), UNBOUNDED);
+		assert.deepStrictEqual(
+			out.byStageArm.map((b) => [b.stage, b.arm, b.billed, b.runs]),
+			[
+				["build", "with-skill", 200, 2],
+				["review", "no-skill", 50, 1],
+			],
+		);
+	});
+
+	it("keeps every breakdown's run count summing back to the total", () => {
+		const out = rollUp(read(rows), UNBOUNDED);
+		for (const buckets of [out.byDay, out.bySkill, out.byStageArm]) {
+			assert.strictEqual(
+				buckets.reduce((n, b) => n + b.runs, 0),
+				out.totals.runs,
+			);
+		}
+	});
+});
+
+describe("resolveBound — what an operator's --since/--until means", () => {
+	it("widens a bare date to the whole UTC day, each edge to its own end", () => {
+		assert.strictEqual(resolveBound("2026-08-09", "since"), Date.parse("2026-08-09T00:00:00.000Z"));
+		assert.strictEqual(resolveBound("2026-08-09", "until"), Date.parse("2026-08-09T23:59:59.999Z"));
+	});
+
+	it("takes a full instant as written", () => {
+		assert.strictEqual(
+			resolveBound("2026-08-09T12:30:00.000Z", "since"),
+			Date.parse("2026-08-09T12:30:00.000Z"),
+		);
+	});
+
+	it("answers null for something that is not a time at all", () => {
+		assert.strictEqual(resolveBound("yesterday", "since"), null);
+		assert.strictEqual(resolveBound("", "until"), null);
+	});
+});
+
+describe("selectWindow — the bounds are inclusive at both edges", () => {
+	const rows = [
+		row({recordedAt: "2026-08-07T23:59:59.999Z", caseId: 1}),
+		row({recordedAt: "2026-08-08T00:00:00.000Z", caseId: 2}),
+		row({recordedAt: "2026-08-09T23:59:59.999Z", caseId: 3}),
+		row({recordedAt: "2026-08-10T00:00:00.000Z", caseId: 4}),
+	];
+
+	it("keeps a row on the first millisecond of --since and the last of --until", () => {
+		const out = selectWindow(rows, window("2026-08-08", "2026-08-09"));
+		assert.deepStrictEqual(
+			out.rows.map((r) => r.caseId),
+			[2, 3],
+		);
+	});
+
+	it("leaves an unbounded edge unbounded", () => {
+		assert.strictEqual(selectWindow(rows, window("2026-08-09", null)).rows.length, 2);
+		assert.strictEqual(selectWindow(rows, window(null, "2026-08-08")).rows.length, 2);
+	});
+
+	it("selects zero rows for a window that covers none of them, without failing", () => {
+		const out = rollUp(read(rows), window("2027-01-01", "2027-01-02"));
+		assert.strictEqual(out.totals.runs, 0);
+		assert.deepStrictEqual(out.byDay, []);
+		assert.deepStrictEqual(out.bySkill, []);
+		assert.deepStrictEqual(out.byStageArm, []);
+	});
+
+	it("drops a row a bounded window cannot place in time, and says how many", () => {
+		const out = rollUp(
+			read([...rows, row({recordedAt: "not a time", caseId: 9})]),
+			window("2026-08-08", "2026-08-09"),
+		);
+		assert.strictEqual(out.totals.runs, 2);
+		assert.strictEqual(out.undatedRows, 1);
+	});
+
+	it("keeps an undated row in when nothing was bounded — there is nothing to prove", () => {
+		const out = rollUp(read([row({recordedAt: "not a time"})]), UNBOUNDED);
+		assert.strictEqual(out.totals.runs, 1);
+		assert.strictEqual(out.undatedRows, 0);
+	});
+});
+
+describe("rollUp — the lines it could not read ride out on the answer", () => {
+	it("carries the skipped total and both halves onto the rollup", () => {
+		const out = rollUp(read([row()], 40, 2), UNBOUNDED);
+		assert.deepStrictEqual(out.skipped, {total: 42, malformed: 40, newerVersion: 2});
+	});
+
+	it("reports the skipped lines even when the window itself selected nothing", () => {
+		const out = rollUp(read([row()], 40, 0), window("2027-01-01", null));
+		assert.strictEqual(out.totals.runs, 0);
+		assert.strictEqual(out.skipped.total, 40);
+	});
+
+	it("echoes the window it covered, so an answer states its own scope", () => {
+		const out = rollUp(read([row()]), window("2026-08-01", null));
+		assert.deepStrictEqual(out.window, {since: "2026-08-01", until: null});
+	});
+});


### PR DESCRIPTION
`fabrika spend rollup` is the epic's acceptance test as one command: it reads the durable spend ledger and tells you what fabrika's runs cost — billed, ex-cache-read, assistant turns, run count — broken down by day, by skill and by stage-and-arm, with `--since`/`--until` to bound the window and `--json` for the same answer as an object. It reads persisted rows only: it spawns nothing, re-parses no transcript, and slows no lane.

The part worth reading twice is what it does with the lines it *cannot* read. A rollup that reports a total while quietly skipping 40 unreadable lines is wrong and looks whole, so the skipped counts ride on the answer itself (stdout and `--json`), not just on stderr. That counter is now split in two, because the halves ask the operator for opposite things: a malformed line is damage (that measurement is gone), a newer-version line is intact data this build is too old to read (upgrade the CLI). And it cannot gate — no threshold flag, no budget option, no exit code that varies with the size of a total.

Fixes #5010

## What landed

- **`packages/fabrika-cli/src/spend/rollup.ts`** — the pure core: sums a `readSpendLedger` result over a resolved window, groups it three ways, and carries every number it declined to count onto the answer.
- **`packages/fabrika-cli/src/spend/rollup-verb.ts`** — the IO around it, with four refusals and no gate.
- **`packages/fabrika-cli/src/spend/ledger.ts`** — `LedgerRead` gains `skips: {malformed, newerVersion}`; `skipped` stays the sum, so #5009's existing contract is unchanged for its existing caller.
- **`packages/fabrika-cli/src/spend/command.ts`** — the `rollup` leaf, with `--ledger` / `--since` / `--until` / `--json`.
- **`packages/fabrika-cli/README.md`** — `spend rollup` documented as the command that answers the epic's acceptance test.
- 27 new unit tests across the core and the verb (81 in `src/spend`, 1786 in the package, all green).

### The four refusals, none of them a zero

| Code | Means |
|---|---|
| `3` | no ledger at that path — nothing has been recorded yet |
| `4` | the ledger could not be read, or its absence could not be established — UNKNOWN |
| `5` | read in full and yielded no rows — empty, or every line unreadable |
| `6` | the ledger holds rows; this window selects none of them |

`6` is the ticket's reviewer-appended criterion: an empty *window* is a different fact from an empty *ledger*, so it gets its own proven code with empty stdout rather than a zero total. `--since`/`--until` are inclusive at both edges, and a bare `YYYY-MM-DD` widens to that whole UTC day — `--until 2026-08-09` means "through the 9th", not "up to its midnight".

## Deviations

- **Class 6 — Pre-existing test changed.** **Said:** `ledger.unit.test.ts` asserted `readSpendLedger("")` deep-equals `{rows: [], skipped: 0}`. **Did:** extended that literal to include the new `skips: {malformed: 0, newerVersion: 0}` field. **Why:** the assertion is exact-shape, so adding a field to `LedgerRead` necessarily updates it; the assertion's meaning (an empty ledger is no rows and no skips, never a failure) is unchanged and three new tests pin the split. **Disposition:** no action needed.
- **Class 4 — Declined guidance.** **Said:** the gate on #5009 flagged that the ledger's ~80-line hand-rolled post-parse shape check would be better as `Result.try(JSON.parse)` → `Schema.decodeUnknownResult(Struct)`, and my dispatch relayed it as "prefer the Schema form if your work touches that boundary". **Did:** kept the hand-rolled decode; only split its front (the `v` read) into three outcomes. **Why:** the same dispatch said not to refactor #5009's module as part of this ticket, and converting the shape check is that refactor — it would put an unrelated rewrite of a just-merged module into a feature PR. **Disposition:** for the reviewer to judge; the finding is already on #5009's PR and untouched by this diff.
- **Class 7 — Out-of-scope change (an addition the AC did not name).** **Said:** the AC asks for billed, ex-cache-read, assistant turns and run count, plus the skipped-line count. **Did:** the answer also carries `measuredRuns` (rows whose spend was actually reconstructed) and `undatedRows` (rows a bounded window could not place in time, so it excluded them). **Why:** the same failure the skipped mandate is about — a `runs` count that includes `TranscriptMissing`/`NoBilledTurns` rows while `billed` excludes them, or a window that silently drops a row whose timestamp does not parse, is a total that under-reports invisibly. Both are two extra integers, tested. **Disposition:** for the reviewer to judge.
- **Class 7 — Out-of-scope surface touched.** **Said:** the issue's file list implies the new rollup files. **Did:** also edited `spend/ledger.ts` (and its test). **Why:** the AC's skipped-count criterion and the reviewer's split mandate both live inside `readSpendLedger`; there is nowhere else to make that split. **Disposition:** no action needed — additive, `skipped` preserved as the sum.