### PR TITLE
feat(fabrika-cli): the scope-admission test — two named axes, one shared core (#5015)

### DIFF
--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -4,8 +4,9 @@
  *
  * **The overlap with `report` is re-exported, never re-typed** — the discipline `review/codes.ts`
  * states in full: an aligning group *imports* the base's constant, so a drift is unrepresentable
- * rather than merely detectable. This group shares nine seats over `3`-`11` and adds its own `12`-`19`
- * for facts about the lane — the tree, the claim, the push, the validators — that no writing verb has.
+ * rather than merely detectable. This group shares nine seats over `3`-`11` and adds its own `12`-`21`
+ * for facts about the lane — the tree, the claim, the push, the validators, and the two admission
+ * axes — that no writing verb has.
  *
  * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
  */
@@ -69,3 +70,14 @@ export const REF_NOT_MOVED = 17;
 export const VALIDATION_RED = 18;
 /** Refused: the requested push is unsafe (detached HEAD, or non-fast-forward without a lease). */
 export const UNSAFE_PUSH = 19;
+/**
+ * Proven: not admitted on the **scope axis** — out of focus (ADR 0245).
+ *
+ * Campaign membership and nothing else. It is a sibling of {@link AUDIENCE_NOT_AGENT}, not the same
+ * question: the two have different remedies, so they never collapse onto one code. Nor does either
+ * borrow {@link BLOCKED} — a scope refusal is not blockedness — or {@link PRECONDITION_UNKNOWN}: `20`
+ * and `21` are *proven* refusals, while a read that failed has proven nothing.
+ */
+export const OUT_OF_FOCUS = 20;
+/** Proven: not admitted on the **audience axis** — the `ready-for:` label is not agent, or absent (#4780). */
+export const AUDIENCE_NOT_AGENT = 21;

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -1,0 +1,370 @@
+/**
+ * The admission test both `build` seams run — **two named axes composed, never one widened term**
+ * (`claude-plugins/fabrika/skills/build/contract.md`, the admission test; ADR 0245).
+ *
+ * - **Scope admission** is campaign membership and nothing else: is the issue's home the milestone in
+ *   exclusive focus? It refuses on {@link OUT_OF_FOCUS}.
+ * - **The audience axis** is who the work is for (`ready-for:agent`), a question older than the fence
+ *   (#4780). This module *hosts* it; it does not redefine it. It refuses on {@link AUDIENCE_NOT_AGENT}.
+ *
+ * They are siblings with different remedies — edit the focus row, or re-label the audience — so they
+ * stay separately named, separately seated and separately reported everywhere. A single predicate
+ * answering both questions at once is the shape the contract's repair round removed; every outcome
+ * below therefore carries **both** axis verdicts, so a caller can never lose one behind the other.
+ *
+ * The core is pure and total, and this module is **imported** by the pool and claim seams rather than
+ * invoked through a relaying verb (the wrapper shape ADR 0238 bans). Only {@link readDeclaredFocus}
+ * touches IO.
+ */
+import {Effect, type FileSystem, Result} from "effect";
+import {exists, type ReadFailed, readFile} from "../io/fs.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {AUDIENCE_NOT_AGENT, BAD_SECTIONS, OUT_OF_FOCUS, PRECONDITION_UNKNOWN} from "./codes.ts";
+
+/** The declaration's file, relative to the repository root. */
+export const DEFAULT_ROADMAP = "ROADMAP.md";
+
+/**
+ * The labels that are a home in their own right (ADR 0208), admitted on the scope axis whatever the
+ * declaration says.
+ *
+ * A standing lane is milestone-less **by design**, so a fence keyed on milestone-presence alone would
+ * starve 199 open issues for a campaign's duration (#5088's measured count). The exemption is the
+ * label match and nothing else: bare milestone-absence never confers it, and the set is closed — a
+ * third lane is a founder ruling and a deliberate edit here, never a pattern match.
+ */
+export const STANDING_LANE_LABELS = ["wayfinder:backlog", "axis:pipeline-hardening"] as const;
+export type StandingLaneLabel = (typeof STANDING_LANE_LABELS)[number];
+
+/** The one audience an agent lane may open against. */
+export const READY_FOR_AGENT = "ready-for:agent";
+const READY_FOR_PREFIX = "ready-for:";
+
+/** Everything either axis reads off an issue — no derived field, and nothing else. */
+export interface IssueFacts {
+	readonly number: number;
+	readonly labels: ReadonlyArray<string>;
+	readonly milestone: number | null;
+}
+
+/** An issue's home: its open milestone's number as a string, or its standing lane. */
+export const homeOf = (issue: IssueFacts): string | null =>
+	issue.milestone !== null
+		? String(issue.milestone)
+		: (STANDING_LANE_LABELS.find((lane) => issue.labels.includes(lane)) ?? null);
+
+/**
+ * The `## Focus` declaration.
+ *
+ * `None` is a **well-formed default**, not a refusal: declaring nothing is the off switch, and a fence
+ * that refused on absence would wedge the board the moment nobody had declared a focus. `Malformed` is
+ * the opposite — a declaration that reads but does not parse proves nothing, and is never read as "no
+ * focus".
+ */
+export type Focus =
+	| {readonly _tag: "Declared"; readonly milestone: number; readonly declared: string}
+	| {readonly _tag: "None"}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+/** A focus that parsed — the only input the scope axis accepts, so `Malformed` cannot reach it. */
+export type ParsedFocus = Exclude<Focus, {readonly _tag: "Malformed"}>;
+
+const HEADING = /^##\s+Focus\s*$/;
+const ANY_HEADING = /^##\s+/;
+const SEPARATOR_CELL = /^:?-{3,}:?$/;
+const MILESTONE_CELL = /^#(\d+)$/;
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const cellsOf = (line: string): ReadonlyArray<string> | null => {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("|")) return null;
+	return trimmed
+		.replace(/^\|/, "")
+		.replace(/\|$/, "")
+		.split("|")
+		.map((cell) => cell.trim());
+};
+
+const isSeparator = (cells: ReadonlyArray<string>): boolean =>
+	cells.every((cell) => SEPARATOR_CELL.test(cell));
+
+const isHeader = (cells: ReadonlyArray<string>): boolean =>
+	cells.length === 2 &&
+	cells[0]?.toLowerCase() === "milestone" &&
+	cells[1]?.toLowerCase() === "declared";
+
+/** Whether the date is the calendar day it spells, not merely four-two-two digits. */
+const isCalendarDate = (year: string, month: string, day: string): boolean => {
+	const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+	return (
+		date.getUTCFullYear() === Number(year) &&
+		date.getUTCMonth() === Number(month) - 1 &&
+		date.getUTCDate() === Number(day)
+	);
+};
+
+/**
+ * Read `ROADMAP.md`'s `## Focus` table.
+ *
+ * The header row is recognised by its column names and the separator by its dashes, so what is left is
+ * a data row **whatever it contains** — which is what makes a mistyped milestone cell malformed rather
+ * than invisible. Skipping unrecognised rows instead would answer "no focus declared" for a broken
+ * table, the well-formed-and-always-wrong shape that fence exists to avoid.
+ */
+export const readFocus = (text: string): Focus => {
+	const lines = text.split("\n");
+	const start = lines.findIndex((line) => HEADING.test(line.trim()));
+	if (start === -1) return {_tag: "None"};
+
+	const rows: ReadonlyArray<string>[] = [];
+	for (let i = start + 1; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		if (ANY_HEADING.test(line.trim())) break;
+		const cells = cellsOf(line);
+		if (cells === null || isSeparator(cells) || isHeader(cells)) continue;
+		rows.push(cells);
+	}
+
+	if (rows.length === 0) return {_tag: "None"};
+	if (rows.length > 1) {
+		return {
+			_tag: "Malformed",
+			reason: `the ## Focus table carries ${rows.length} data rows — exclusive focus admits at most one`,
+		};
+	}
+	const row = rows[0] ?? [];
+	if (row.length !== 2) {
+		return {
+			_tag: "Malformed",
+			reason: `the ## Focus row has ${row.length} cells, not the 2 the grammar declares (Milestone | Declared)`,
+		};
+	}
+	const milestone = MILESTONE_CELL.exec(row[0] ?? "");
+	if (milestone?.[1] === undefined) {
+		return {_tag: "Malformed", reason: `the milestone cell "${row[0]}" is not #<int>`};
+	}
+	const date = ISO_DATE.exec(row[1] ?? "");
+	if (
+		date?.[1] === undefined ||
+		date[2] === undefined ||
+		date[3] === undefined ||
+		!isCalendarDate(date[1], date[2], date[3])
+	) {
+		return {
+			_tag: "Malformed",
+			reason: `the declared cell "${row[1]}" is not an ISO YYYY-MM-DD date`,
+		};
+	}
+	return {_tag: "Declared", milestone: Number.parseInt(milestone[1], 10), declared: row[1] ?? ""};
+};
+
+/** Axis one — campaign membership, and nothing else. */
+export type ScopeAxis =
+	/** A focus is declared and this is its milestone. */
+	| {readonly _tag: "InFocus"; readonly milestone: number}
+	/** A standing lane, admitted whatever the declaration says. */
+	| {readonly _tag: "LaneExempt"; readonly lane: StandingLaneLabel}
+	/** No focus is declared — the fence is off, and says so. */
+	| {readonly _tag: "Inert"}
+	| {readonly _tag: "OutOfFocus"; readonly focus: number; readonly home: string | null};
+
+/** Axis two — who the work is for. Older than the fence (#4780); hosted here, never redefined. */
+export type AudienceAxis =
+	| {readonly _tag: "Agent"}
+	/** `label` is the `ready-for:` label carried, or `null` when the issue carries none. */
+	| {readonly _tag: "NotAgent"; readonly label: string | null};
+
+export const scopeAxisOf = (focus: ParsedFocus, issue: IssueFacts): ScopeAxis => {
+	if (focus._tag === "None") return {_tag: "Inert"};
+	if (issue.milestone === focus.milestone) return {_tag: "InFocus", milestone: focus.milestone};
+	const lane = STANDING_LANE_LABELS.find((label) => issue.labels.includes(label));
+	if (lane !== undefined) return {_tag: "LaneExempt", lane};
+	return {_tag: "OutOfFocus", focus: focus.milestone, home: homeOf(issue)};
+};
+
+/** Absence is an unknown audience, never an agent audience (#4780). */
+export const audienceAxisOf = (issue: IssueFacts): AudienceAxis =>
+	issue.labels.includes(READY_FOR_AGENT)
+		? {_tag: "Agent"}
+		: {
+				_tag: "NotAgent",
+				label: issue.labels.find((label) => label.startsWith(READY_FOR_PREFIX)) ?? null,
+			};
+
+/**
+ * The composed answer: exactly one of four state words, never a boolean.
+ *
+ * Both axis verdicts ride on every outcome, including the refusals, so the two questions stay legible
+ * apart no matter which one refused.
+ */
+export type Admission =
+	| {readonly _tag: "Admitted"; readonly scope: ScopeAxis; readonly audience: AudienceAxis}
+	| {
+			readonly _tag: "OutOfFocus";
+			readonly scope: Extract<ScopeAxis, {readonly _tag: "OutOfFocus"}>;
+			readonly audience: AudienceAxis;
+	  }
+	| {
+			readonly _tag: "AudienceNotAgent";
+			readonly scope: ScopeAxis;
+			readonly audience: Extract<AudienceAxis, {readonly _tag: "NotAgent"}>;
+	  }
+	| {readonly _tag: "Unknown"; readonly code: number; readonly reason: string};
+
+/**
+ * Run both axes over one issue.
+ *
+ * **Scope is reported before audience when both refuse**, deliberately: while an issue sits outside the
+ * campaign in focus its audience label is not the thing to fix, and reporting the audience first would
+ * send an operator to re-label work that the scope fence would refuse again. The unreported axis is
+ * still on the outcome.
+ */
+export const admissionOf = (focus: Focus, issue: IssueFacts): Admission => {
+	if (focus._tag === "Malformed") {
+		return {
+			_tag: "Unknown",
+			code: BAD_SECTIONS,
+			reason: `${focus.reason} — malformed is never read as "no focus"`,
+		};
+	}
+	const scope = scopeAxisOf(focus, issue);
+	const audience = audienceAxisOf(issue);
+	if (scope._tag === "OutOfFocus") return {_tag: "OutOfFocus", scope, audience};
+	if (audience._tag === "NotAgent") return {_tag: "AudienceNotAgent", scope, audience};
+	return {_tag: "Admitted", scope, audience};
+};
+
+/** The word `build pick` reports per excluded issue; `null` for an admitted one. */
+export const exclusionReasonOf = (
+	admission: Admission,
+): "out-of-focus" | "audience-not-agent" | "unreadable" | null => {
+	switch (admission._tag) {
+		case "Admitted":
+			return null;
+		case "OutOfFocus":
+			return "out-of-focus";
+		case "AudienceNotAgent":
+			return "audience-not-agent";
+		default:
+			return "unreadable";
+	}
+};
+
+/**
+ * Every non-zero code this test can produce, with the condition that produces it — single-sourced so a
+ * consuming verb's `--help` enumerates them rather than restating them.
+ */
+export const ADMISSION_EXIT_CODES: ReadonlyArray<{
+	readonly code: number;
+	readonly condition: string;
+}> = [
+	{
+		code: BAD_SECTIONS,
+		condition: "the ## Focus declaration reads but does not parse — malformed, never 'no focus'",
+	},
+	{
+		code: PRECONDITION_UNKNOWN,
+		condition: "the declaration or the issue's home could not be read — admission is UNKNOWN",
+	},
+	{
+		code: OUT_OF_FOCUS,
+		condition:
+			"proven: not admitted on the scope axis — the issue's home is not the declared milestone and no standing-lane label exempts it",
+	},
+	{
+		code: AUDIENCE_NOT_AGENT,
+		condition: `proven: not admitted on the audience axis — the issue's ${READY_FOR_PREFIX} label is not ${READY_FOR_AGENT}, or is absent`,
+	},
+];
+
+/** The scope line both seams print, so an operator sees the fence's state rather than inferring it. */
+export const focusScopeLine = (verb: string, focus: Focus): string => {
+	switch (focus._tag) {
+		case "Declared":
+			return `${verb}: focus: milestone #${focus.milestone}, declared ${focus.declared}.`;
+		case "None":
+			return `${verb}: focus: none declared — scope fence inert.`;
+		default:
+			return `${verb}: focus: unreadable — ${focus.reason}.`;
+	}
+};
+
+/** The `focus` field both seams report on the machine channel, beside the stderr scope line. */
+export const focusReport = (
+	focus: Focus,
+): {readonly state: "declared"; readonly milestone: string} | {readonly state: "none"} =>
+	focus._tag === "Declared"
+		? {state: "declared", milestone: String(focus.milestone)}
+		: {state: "none"};
+
+/**
+ * The seated refusal for a non-admitted outcome, or `null` when the issue is admitted.
+ *
+ * The seating lives here rather than at each seam so `20`, `21`, `4` and `11` cannot drift apart
+ * between the pool and the claim path — the disagreement ADR 0245 calls worse than no fence at all.
+ */
+export const admissionRefusal = (verb: string, admission: Admission): VerbOutcome | null => {
+	switch (admission._tag) {
+		case "Admitted":
+			return null;
+		case "OutOfFocus": {
+			const home = admission.scope.home ?? "no milestone and no standing lane";
+			return refuse(
+				OUT_OF_FOCUS,
+				`${verb}: out of focus — the declared focus is milestone #${admission.scope.focus} and this issue's home is ${home}; edit the ## Focus row, or claim it with an explicit override.`,
+			);
+		}
+		case "AudienceNotAgent":
+			return refuse(
+				AUDIENCE_NOT_AGENT,
+				`${verb}: audience not agent — this issue carries ${
+					admission.audience.label ??
+					`no ${READY_FOR_PREFIX} label, and absence is an unknown audience`
+				}, not ${READY_FOR_AGENT}.`,
+			);
+		default:
+			return refuse(admission.code, `${verb}: ${admission.reason} — admission is UNKNOWN.`);
+	}
+};
+
+/**
+ * An input that could not be read, lifted into the composed outcome.
+ *
+ * Both the declaration and an issue's home come through here, so no seam ever seats `11` for itself
+ * and no read failure can be talked into an `admitted`.
+ */
+export const unknownAdmission = (reason: string): Admission => ({
+	_tag: "Unknown",
+	code: PRECONDITION_UNKNOWN,
+	reason,
+});
+
+/** A declaration read off disk, or the reason it could not be. */
+export type FocusRead =
+	| {readonly _tag: "Read"; readonly focus: Focus}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+const unreadable = (path: string, failure: ReadFailed): FocusRead => ({
+	_tag: "Unreadable",
+	reason: `cannot read the focus declaration at ${path}: ${failure.reason}`,
+});
+
+/**
+ * Read the declaration.
+ *
+ * An **absent file** and an absent section are the same well-formed default — no focus — while a file
+ * that is there and cannot be read is UNKNOWN. The probe is separate from the read for exactly that
+ * split: a probe that cannot be performed is itself UNKNOWN, never "absent".
+ */
+export const readDeclaredFocus = (
+	path: string = DEFAULT_ROADMAP,
+): Effect.Effect<FocusRead, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const probe = yield* Effect.result(exists(path));
+		if (Result.isFailure(probe)) return unreadable(path, probe.failure);
+		if (!probe.success) return {_tag: "Read" as const, focus: {_tag: "None" as const}};
+		const read = yield* Effect.result(readFile(path));
+		return Result.isFailure(read)
+			? unreadable(path, read.failure)
+			: {_tag: "Read" as const, focus: readFocus(read.success)};
+	});

--- a/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
@@ -1,0 +1,242 @@
+import {Effect, FileSystem, Layer, Path, PlatformError} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {AUDIENCE_NOT_AGENT, BAD_SECTIONS, OUT_OF_FOCUS, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {
+	ADMISSION_EXIT_CODES,
+	type Admission,
+	admissionOf,
+	admissionRefusal,
+	audienceAxisOf,
+	DEFAULT_ROADMAP,
+	exclusionReasonOf,
+	type Focus,
+	focusReport,
+	focusScopeLine,
+	homeOf,
+	type IssueFacts,
+	readDeclaredFocus,
+	readFocus,
+	STANDING_LANE_LABELS,
+	scopeAxisOf,
+	unknownAdmission,
+} from "./scope-admission.ts";
+
+const FOCUS_44 = `## Focus
+
+Prose above the table, including a \`Milestone | Declared\` mention that is not a table row.
+
+| Milestone | Declared |
+|-----------|----------|
+| #44 | 2026-08-09 |
+
+**The grammar.** More prose below.
+
+## Dependencies
+`;
+
+const declared: Focus = {_tag: "Declared", milestone: 44, declared: "2026-08-09"};
+const noFocus: Focus = {_tag: "None"};
+
+const issue = (over: Partial<IssueFacts> = {}): IssueFacts => ({
+	number: 1,
+	labels: ["status:triaged", "p0", "ready-for:agent"],
+	milestone: 44,
+	...over,
+});
+
+describe("readFocus", () => {
+	it("reads the one data row, ignoring prose, the header and the separator", () => {
+		expect(readFocus(FOCUS_44)).toEqual(declared);
+	});
+
+	it("reads a missing section as the well-formed default: no focus declared", () => {
+		expect(
+			readFocus("# Roadmap\n\n## Arcs\n\n| Arc | Milestone |\n|---|---|\n| Geçit | #24 |\n"),
+		).toEqual(noFocus);
+	});
+
+	it("reads a present-but-empty table as the same well-formed default", () => {
+		expect(
+			readFocus("## Focus\n\n| Milestone | Declared |\n|-----------|----------|\n\n## Next\n"),
+		).toEqual(noFocus);
+	});
+
+	it("refuses two data rows — exclusive focus admits at most one", () => {
+		const two =
+			"## Focus\n\n| Milestone | Declared |\n|---|---|\n| #44 | 2026-08-09 |\n| #24 | 2026-08-01 |\n";
+		expect(readFocus(two)._tag).toBe("Malformed");
+	});
+
+	it("refuses a milestone cell that is not #<int> — never reading it as 'no focus'", () => {
+		const bare = "## Focus\n\n| Milestone | Declared |\n|---|---|\n| 44 | 2026-08-09 |\n";
+		const parsed = readFocus(bare);
+		expect(parsed._tag).toBe("Malformed");
+		expect(parsed._tag === "Malformed" && parsed.reason).toContain("#<int>");
+	});
+
+	it("refuses a date that is not ISO, and a four-two-two that is not a calendar day", () => {
+		const slashes = "## Focus\n\n| Milestone | Declared |\n|---|---|\n| #44 | 09/08/2026 |\n";
+		const notADay = "## Focus\n\n| Milestone | Declared |\n|---|---|\n| #44 | 2026-02-31 |\n";
+		expect(readFocus(slashes)._tag).toBe("Malformed");
+		expect(readFocus(notADay)._tag).toBe("Malformed");
+	});
+
+	it("refuses a renamed header rather than skipping it into invisibility", () => {
+		const renamed = "## Focus\n\n| Campaign | Declared |\n|---|---|\n| #44 | 2026-08-09 |\n";
+		expect(readFocus(renamed)._tag).toBe("Malformed");
+	});
+});
+
+describe("the two axes stay apart", () => {
+	it("scope reads campaign membership only — an out-of-focus issue is refused whatever its audience", () => {
+		expect(scopeAxisOf(declared, issue({milestone: 24}))).toEqual({
+			_tag: "OutOfFocus",
+			focus: 44,
+			home: "24",
+		});
+		expect(audienceAxisOf(issue({milestone: 24}))).toEqual({_tag: "Agent"});
+	});
+
+	it("audience reads the ready-for: label only — an in-focus issue can still fail it", () => {
+		const humanOwned = issue({labels: ["ready-for:human"]});
+		expect(scopeAxisOf(declared, humanOwned)).toEqual({_tag: "InFocus", milestone: 44});
+		expect(audienceAxisOf(humanOwned)).toEqual({_tag: "NotAgent", label: "ready-for:human"});
+	});
+
+	it("carries both axis verdicts on a refusal, so neither is lost behind the other", () => {
+		const both = admissionOf(declared, issue({milestone: 24, labels: ["ready-for:human"]}));
+		expect(both._tag).toBe("OutOfFocus");
+		expect(both._tag === "OutOfFocus" && both.audience).toEqual({
+			_tag: "NotAgent",
+			label: "ready-for:human",
+		});
+	});
+});
+
+describe("admissionOf", () => {
+	it("admits an in-focus, agent-audience issue", () => {
+		const out = admissionOf(declared, issue());
+		expect(out._tag).toBe("Admitted");
+		expect(out._tag === "Admitted" && out.scope).toEqual({_tag: "InFocus", milestone: 44});
+		expect(admissionRefusal("build claim", out)).toBeNull();
+		expect(exclusionReasonOf(out)).toBeNull();
+	});
+
+	it("refuses an out-of-focus issue on the scope axis, at 20", () => {
+		const out = admissionOf(declared, issue({milestone: 24}));
+		expect(out._tag).toBe("OutOfFocus");
+		expect(exclusionReasonOf(out)).toBe("out-of-focus");
+		expect(admissionRefusal("build claim", out)?.code).toBe(OUT_OF_FOCUS);
+	});
+
+	it("refuses a milestone-less issue with no standing lane, naming the absent home", () => {
+		const out = admissionOf(declared, issue({milestone: null}));
+		const refusal = admissionRefusal("build claim", out);
+		expect(refusal?.code).toBe(OUT_OF_FOCUS);
+		expect(refusal?.stderr.join("\n")).toContain("no milestone and no standing lane");
+	});
+
+	for (const lane of STANDING_LANE_LABELS) {
+		it(`admits ${lane} by exemption despite carrying no milestone`, () => {
+			const standing = issue({milestone: null, labels: ["ready-for:agent", "p2", lane]});
+			expect(homeOf(standing)).toBe(lane);
+			const out = admissionOf(declared, standing);
+			expect(out._tag).toBe("Admitted");
+			expect(out._tag === "Admitted" && out.scope).toEqual({_tag: "LaneExempt", lane});
+		});
+	}
+
+	it("refuses ready-for:human on the audience axis, at 21 — never at 20", () => {
+		const out = admissionOf(declared, issue({labels: ["ready-for:human"]}));
+		expect(out._tag).toBe("AudienceNotAgent");
+		expect(exclusionReasonOf(out)).toBe("audience-not-agent");
+		expect(admissionRefusal("build claim", out)?.code).toBe(AUDIENCE_NOT_AGENT);
+	});
+
+	it("refuses an absent ready-for: label — absence is an unknown audience, never an agent one", () => {
+		const out = admissionOf(declared, issue({labels: ["status:triaged", "p0"]}));
+		expect(out._tag).toBe("AudienceNotAgent");
+		expect(out._tag === "AudienceNotAgent" && out.audience.label).toBeNull();
+		expect(admissionRefusal("build claim", out)?.code).toBe(AUDIENCE_NOT_AGENT);
+	});
+
+	it("still applies the audience axis to a standing lane", () => {
+		const standing = issue({milestone: null, labels: ["axis:pipeline-hardening"]});
+		expect(admissionOf(declared, standing)._tag).toBe("AudienceNotAgent");
+	});
+
+	it("admits everything with no declaration, and records the fence inert", () => {
+		const out = admissionOf(noFocus, issue({milestone: 24}));
+		expect(out._tag).toBe("Admitted");
+		expect(out._tag === "Admitted" && out.scope).toEqual({_tag: "Inert"});
+		expect(focusScopeLine("build pick", noFocus)).toContain("none declared — scope fence inert");
+		expect(focusReport(noFocus)).toEqual({state: "none"});
+	});
+
+	it("resolves a malformed declaration to UNKNOWN at 4, never to admitted", () => {
+		const out = admissionOf({_tag: "Malformed", reason: "two data rows"}, issue());
+		expect(out._tag).toBe("Unknown");
+		expect(exclusionReasonOf(out)).toBe("unreadable");
+		expect(admissionRefusal("build pick", out)?.code).toBe(BAD_SECTIONS);
+	});
+
+	it("resolves an unreadable input to UNKNOWN at 11, and prints nothing on stdout", () => {
+		const out: Admission = unknownAdmission("cannot read #7: gh: Bad Gateway (HTTP 502)");
+		const refusal = admissionRefusal("build claim", out);
+		expect(refusal?.code).toBe(PRECONDITION_UNKNOWN);
+		expect(refusal?.stdout).toBe("");
+	});
+
+	it("reuses the matrix's indefinite code rather than minting a second numeral for it", () => {
+		expect(ADMISSION_EXIT_CODES.map((row) => row.code)).toEqual([
+			BAD_SECTIONS,
+			PRECONDITION_UNKNOWN,
+			OUT_OF_FOCUS,
+			AUDIENCE_NOT_AGENT,
+		]);
+		expect(new Set(ADMISSION_EXIT_CODES.map((row) => row.code)).size).toBe(4);
+		expect(ADMISSION_EXIT_CODES.every((row) => row.condition.trim() !== "")).toBe(true);
+	});
+});
+
+describe("readDeclaredFocus", () => {
+	const read = (layer: Layer.Layer<FileSystem.FileSystem | Path.Path>, path = DEFAULT_ROADMAP) =>
+		Effect.runPromise(Effect.provide(readDeclaredFocus(path), layer));
+
+	it("reads the declaration off the roadmap", async () => {
+		const out = await read(fakeFs({files: {[DEFAULT_ROADMAP]: FOCUS_44}}).layer);
+		expect(out).toEqual({_tag: "Read", focus: declared});
+	});
+
+	it("reads an absent roadmap as no focus declared — the off switch, not a refusal", async () => {
+		const out = await read(fakeFs({files: {}}).layer);
+		expect(out).toEqual({_tag: "Read", focus: noFocus});
+	});
+
+	it("resolves an unprobeable roadmap to UNREADABLE, never to absent", async () => {
+		const out = await read(fakeFs({files: {}, unprobeable: [DEFAULT_ROADMAP]}).layer);
+		expect(out._tag).toBe("Unreadable");
+	});
+
+	it("resolves a roadmap that exists but cannot be read to UNREADABLE", async () => {
+		const layer = Layer.merge(
+			FileSystem.layerNoop({
+				exists: () => Effect.succeed(true),
+				readFileString: (path: string) =>
+					Effect.fail(
+						PlatformError.systemError({
+							_tag: "PermissionDenied",
+							module: "FileSystem",
+							method: "readFileString",
+							pathOrDescriptor: path,
+						}),
+					),
+			}),
+			Path.layer,
+		);
+		const out = await read(layer);
+		expect(out._tag).toBe("Unreadable");
+		expect(out._tag === "Unreadable" && out.reason).toContain(DEFAULT_ROADMAP);
+	});
+});


### PR DESCRIPTION
Adds the one place fabrika decides whether an issue may be worked on at all. It answers **two separate questions side by side** — is this issue in the campaign we declared focus on (scope admission, exit `20`), and is this work meant for an agent (`ready-for:agent`, exit `21`) — and keeps them apart, because they have different fixes: edit the focus row, or re-label the audience. The core is a pure function; only the roadmap read touches the disk.

Fixes #5015

## What landed

- `packages/fabrika-cli/src/build/scope-admission.ts` — the pure core (`readFocus`, `scopeAxisOf`, `audienceAxisOf`, `admissionOf`), the exit-code seating (`admissionRefusal`), the reporting helpers both seams need (`focusScopeLine`, `focusReport`, `exclusionReasonOf`, `homeOf`), and the one IO boundary (`readDeclaredFocus`).
- `packages/fabrika-cli/src/build/codes.ts` — `OUT_OF_FOCUS = 20` and `AUDIENCE_NOT_AGENT = 21`, matching the contract's shared exit matrix.
- `packages/fabrika-cli/src/build/scope-admission.unit.test.ts` — 26 tests.

## How the two axes are kept apart

They are never computed by one function and never collapse onto one code:

- `scopeAxisOf` reads **campaign membership only** — the declared milestone, or a standing-lane label. It cannot see a `ready-for:` label.
- `audienceAxisOf` reads **the `ready-for:` label only**. It cannot see a milestone.
- `admissionOf` composes them. Every outcome — including both refusals — carries **both** axis verdicts, so neither is ever lost behind the other. A test pins that directly: an issue that is both out of focus and `ready-for:human` reports `20` and *still* carries its `NotAgent` audience verdict.
- Separate codes, separate messages, separate remedies. `20` never borrows `16` (blocked), `11` (unreadable) or `21`, and vice versa.

This matches the contract's admission-test section, ADR 0245, and the `scope admission` row in `.glossary/TERMS.md` — whose `Not` column names the `ready-for:` audience axis as explicitly *not* this term.

## Exit-code discipline

Four state words, never a boolean, and no new numeral for a meaning that already has a seat:

| Outcome | Code |
|---|---|
| `admitted` | 0 (the seam proceeds) |
| `refused: out-of-focus` (scope axis) | `20` |
| `refused: audience-not-agent` (audience axis) | `21` |
| `unknown` — declaration malformed | `4` |
| `unknown` — declaration or issue home unreadable | `11` |

UNKNOWN reuses the matrix's existing indefinite code (`11`) rather than minting a second one: a caller special-casing the old code would silently miss a new one, which is fail-open. Malformed sits on `4` (a required section that does not parse) and is **never** read as "no focus declared". A refusal prints nothing on stdout — `admissionRefusal` builds it through the shared `refuse` helper, which enforces that.

## The standing-lane exemption

A milestone-less `axis:pipeline-hardening` or `wayfinder:backlog` issue resolves **admitted by exemption**, never refused. Getting this wrong would silently fence off 199 open issues for a campaign's duration (the count measured on #5088). Both labels are pinned as fixtures, and the audience axis still applies to them — also pinned.

## Deviations

- **Class 1 · Scope narrowing** — **Said:** the issue asks for the module "with a thin verb over it", and two acceptance criteria are about that verb (`--help` enumerating every non-zero exit code; the verb's stdout/stderr channel split). **Did:** shipped the module only — no new CLI subcommand. **Why:** the contract amended by #5013 is the spec and is later than this issue's text. Its admission-test section states the module "is **imported** by `build pick` and `build claim`" and that "no verb exists whose only behaviour is relaying them (the wrapper shape ADR 0238 bans)"; its verb inventory has no admission block, and the `build` SKILL routes `20`/`21` only from `build claim`. Adding an unspecified verb would be improvising a surface the contract closed. The substance of both criteria is preserved and single-sourced here rather than dropped: `ADMISSION_EXIT_CODES` carries every non-zero code with the condition that produces it, for a consuming verb's `--help` to render, and `admissionRefusal` decides the channel split (reason on stderr, nothing on stdout) once, so neither seam re-derives it. **Disposition:** for the reviewer to judge — if the reviewer reads the issue's "thin verb" as governing over the contract, say so and I will add the subcommand in a repair round.
- **Class 3 · Known duplicate left unfixed** — **Said:** ADR 0245 bans "a second implementation of the scope question anywhere". **Did:** `pick-verb.ts` still carries its own local `STANDING_LANES` list and `homeOf`, now duplicated by the shared module's. **Why:** the issue puts "changing any pool or claim verb" out of scope, and #5016 is the child that makes both seams import the shared core — folding pick's copies in now would tread on it. Nothing consumes both definitions yet, so no disagreement is reachable on `main` today. **Disposition:** #5016 covers it; it must delete pick's local copies rather than leave two.
- **Class 7 · Out-of-scope change** — **Said:** the issue's file list names only the new module. **Did:** also edited `packages/fabrika-cli/src/build/codes.ts` to seat `20`/`21` and updated its header's code range. **Why:** the contract's shared exit matrix owns `code → meaning` for the whole group, and this package expresses that by one constant per seat; a code defined inside the predicate module instead would be the drift that table exists to prevent. **Disposition:** no action needed — the stated file list is a floor.
- **Class 1 · Acceptance criterion answered differently than its wording implies** — **Said:** "Every list read paginates, and a truncated or failed read resolves UNKNOWN rather than a partial answer." **Did:** this module performs **no** list read. Its only IO is the roadmap file read; issue facts arrive as a plain `IssueFacts` record from the caller's already-paginated `listLabelled` (pool seam) or single-issue `getIssue` (claim seam). **Why:** re-reading the issue list inside the predicate would be a second read of data the seam already holds, and the pagination discipline already lives in `build/github.ts`. The criterion's real teeth — a failed read never resolving to a partial or permissive answer — are enforced here: `readDeclaredFocus` splits an absent roadmap (well-formed default, no focus) from an unreadable one (UNKNOWN), and `unknownAdmission` is the one lift a seam uses for an unreadable issue home. Both are tested. **Disposition:** for the reviewer to judge.

## Verification

- `pnpm typecheck --force` — 30/30, 0 cached, all task paths in this lane's worktree.
- `pnpm lint` — clean.
- `packages/fabrika-cli` full suite — 122 files, 1782 tests, all passing (26 new).
