### PR TITLE
fix(review-code): glossary-freshness reds when a read could not see (#4986)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,9 +649,11 @@ jobs:
       # existing package entry point (#4700). It shipped born-dead: the awk regex would not compile,
       # its exit status was never tested, and the gate printed a clean `not applicable` skip for six
       # weeks. A born-dead detector is invisible to any suite that only asserts the happy skip, so
-      # this harness asserts a MATCH, and carries five mutants — one per claim the fix rests on — so
-      # an assertion that stopped having teeth reds here rather than passing quietly. Hermetic: gh,
-      # git and the CLI shim are stubbed, no network.
+      # this harness asserts a MATCH, and carries eight mutants — one per claim the fix rests on — so
+      # an assertion that stopped having teeth reds here rather than passing quietly. It also pins the
+      # sibling class (#4986): three reads whose failure or empty result used to reach a clean skip,
+      # each driven by the could-not-see state that produced it. Hermetic: gh, git and the CLI shim
+      # are stubbed, no network.
       # Same script runs locally: `bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh`.
       - run: bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -830,10 +830,22 @@ sentinel: fold it as `[UNVERIFIABLE]`, never as a not-applicable skip. **A detec
 RUN reaches that sentinel too**, and the reason it has to is that its silence is indistinguishable
 from a negative: detector (3) shipped with a regex awk refused to compile, exited 2 into a status
 nothing tested, and the gate printed its confident `not applicable` skip on 16 export-changing PRs
-over six weeks (#4700). So each detector's exit status is tested, and an unrun one is UNKNOWN. That
-the detectors can fire *at all* is pinned executably by
-[`scripts/verify-glossary-detector-fires.sh`](scripts/verify-glossary-detector-fires.sh) — a
-positive fixture, because a born-dead detector passes every test that only asserts the happy skip.
+over six weeks (#4700). So each detector's exit status is tested, and an unrun one is UNKNOWN.
+
+**A read that SUCCEEDED while seeing nothing reaches the sentinel too (#4986).** An exit status only
+catches the read that *died*; the read that returns zero rows at exit 0 is the same UNKNOWN wearing a
+plausible answer's clothes. So the two inputs whose emptiness is impossible for a real PR — the file
+list (every PR touches at least one file) and the diff text — carry a **scope assert** on top of their
+status test, and an empty one routes to `CANNOT-EVALUATE`, never to "this PR added no new surface".
+The base read gets the same treatment from the other direction: `git cat-file -e` exits non-zero for
+both "no such path" and "the read failed", so the chain now **asserts the base tree is readable once,
+up front** — which is what makes each later non-zero probe mean *absence* and nothing else.
+
+That the detectors can fire *at all*, and that each of those reads goes loud rather than silent, is
+pinned executably by
+[`scripts/verify-glossary-detector-fires.sh`](scripts/verify-glossary-detector-fires.sh) — positive
+fixtures, because a born-dead detector passes every test that only asserts the happy skip, plus eight
+mutants that each delete one guard and require the assertions to go red.
 
 Fold the result into the per-criterion table as one line, exactly like Step 3b's flag-gating facet —
 so the conjunctive verdict (Step 3) accounts for it like any other criterion:
@@ -861,6 +873,13 @@ reading green.
 > `glossary-freshness: not applicable — no .glossary/TERMS.md on base` and contributes no row. This
 > is the same portability / graceful-absence contract the cycle-doc probe (Step 3b, formats §1) and
 > the milestone default follow — absence is a first-class state, not a defect.
+>
+> **Absent is only distinguishable from unreadable because the base tree is asserted first (#4986).**
+> `git cat-file -e` fails identically for "this path is not there" and "I could not read the base at
+> all", so on an unreadable base *every* probe reads absent and this skip would be printed about a
+> base the gate never saw. The chain asserts `origin/$BASE_REF^{tree}` is readable before any path
+> probe; that assert failing is `CANNOT-EVALUATE`, and only past it does a non-zero probe mean
+> absence.
 >
 > **This probe is the executed guard that LEADS the verdict chain above** — it is the chain's first
 > `if`, so the detector-blind `UNVERIFIABLE` branch is structurally unreachable when the glossary is

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
@@ -25,12 +25,21 @@ REPO="$(kp_repo)" || cannot "target repo unresolved"
 . "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || cannot "no head handle — run materialize-head.sh first (its \`git fetch origin \$BASE_REF\` is what makes these probes fresh)"
 [ -n "${BASE_REF:-}" ] || cannot "handle carries no BASE_REF"
 
+# `git cat-file -e` exits non-zero for BOTH "no such path" and "the read itself failed", so against an
+# unreadable base every probe below reads ABSENT and the graceful-absence branch prints a confident
+# skip about a base it never saw (#4986). This one assert is what makes a later non-zero probe mean
+# absence and nothing else.
+git cat-file -e "origin/$BASE_REF^{tree}" 2>/dev/null || cannot "the base tree origin/$BASE_REF is unreadable — every path probe below would then read ABSENT, and 'I could not read the base' is UNKNOWN, never 'this repo has no .glossary/TERMS.md'"
+
 # the file list WITH status (Step 2 already loaded the diff; this reuses the same files endpoint)
 # --paginate + streaming --jq so the full set past file #100 is seen (the API caps per_page at 100; #725)
 FILES_STATUS="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '.[] | "\(.status)\t\(.filename)"')"
 FILES_RC=$?
 [ "$FILES_RC" -eq 0 ] || cannot "the PR file list could not be read (gh api exited $FILES_RC) — detectors (1) and (2) would then scan an EMPTY file set and report no new surface"
+# A status test only catches the read that DIED; a read that exits 0 with no rows leaves detectors (1)
+# and (2) scanning an empty set and lands on the same clean skip (#4986).
+[ -n "$(printf '%s' "$FILES_STATUS" | tr -d '[:space:]')" ] || cannot "the PR file list came back EMPTY at exit 0 — a PR always touches at least one file, so an empty list is ZERO SCOPE, never 'this PR added no new surface'"
 ADDED="$(printf '%s\n' "$FILES_STATUS" | awk -F'\t' '$1=="added"{print $2}')"
 
 # (1) a NEW feature folder: an added file under apps/web/worker/features/<dir>/... whose <dir>
@@ -75,9 +84,16 @@ $0 ~ entry { in_entry = 1; next }
 /^\+\+\+ / { in_entry = 0; next }
 in_entry && /^\+/ && $0 ~ expre { print }
 '
-PUBLIC_ENTRY_EXPORT_ADDED="$(gh pr diff "$PR" | awk "$DETECTOR3_AWK")"
+# Fetch and filter are read SEPARATELY on purpose: piped together, an empty diff at exit 0 is
+# indistinguishable from awk matching nothing in a real diff — the second is a fact about the PR, the
+# first is UNKNOWN (#4986).
+DETECTOR3_DIFF="$(gh pr diff "$PR")"
 DETECTOR3_RC=$?
-[ "$DETECTOR3_RC" -eq 0 ] || cannot "detector (3), the new-public-export scan, could not run — 'gh pr diff | awk' exited $DETECTOR3_RC; an unrun detector is UNKNOWN, never 'this PR added no export'"
+[ "$DETECTOR3_RC" -eq 0 ] || cannot "detector (3), the new-public-export scan, could not run — 'gh pr diff' exited $DETECTOR3_RC; an unrun detector is UNKNOWN, never 'this PR added no export'"
+[ -n "$(printf '%s' "$DETECTOR3_DIFF" | tr -d '[:space:]')" ] || cannot "detector (3) got an EMPTY diff at exit 0 — the file list above is non-empty, so a PR with no diff text is ZERO SCOPE, never 'this PR added no export'"
+PUBLIC_ENTRY_EXPORT_ADDED="$(printf '%s\n' "$DETECTOR3_DIFF" | awk "$DETECTOR3_AWK")"
+DETECTOR3_AWK_RC=$?
+[ "$DETECTOR3_AWK_RC" -eq 0 ] || cannot "detector (3), the new-public-export scan, could not run — awk exited $DETECTOR3_AWK_RC; an unrun detector is UNKNOWN, never 'this PR added no export'"
 
 # the union: is there ANY new surface?
 NEW_SURFACE="$(printf '%s %s %s' "$NEW_FEATURE_DIRS" "$NEW_PACKAGES" "$PUBLIC_ENTRY_EXPORT_ADDED" | tr -s ' ')"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
@@ -12,18 +12,33 @@
 # add a public export and require a match — plus the loudness contract on the other side: an unrun
 # detector must be CANNOT-EVALUATE, never a plausible empty answer.
 #
-# Falsifiability is asserted, not assumed. The harness generates five MUTANTS, each reverting one
+# A read that could not SEE is the second property, and it is the same shape one branch over (#4986):
+# three reads used to resolve a failure or an empty result to the clean skip. Each now routes through
+# `cannot()`, and each is driven here by a fixture that forces exactly that could-not-see state — an
+# unreadable base tree, an exit-0-but-empty file list, an exit-0-but-empty diff.
+#
+# Falsifiability is asserted, not assumed. The harness generates eight MUTANTS, each reverting one
 # claim this fix rests on, and requires the assertions to go red under each:
 #   M1  the awk regex literal comes back        → positive fixture must go LOUD, not green
-#   M2  the detector status test is deleted     → an unrun detector must fall through to the skip
-#   M3  M1 + M2, i.e. the code as filed         → reproduces #4700 verbatim: a clean skip
+#   M2  detector (3)'s loudness is deleted      → an unrun detector must fall through to the skip
+#   M3  M1 + M2, i.e. the code as filed         → reproduces #4700: a clean skip
 #   M4  `\b` comes back as the word boundary    → one-true-awk does not implement it, so no match
 #   M5  the added-line test and the export test fuse back into one `^\+[^+].*export` regex, where
 #       the `[^+]` eats the `e` of an unindented `+export` before `.*export` can match
+#   M6  the empty-diff scope assert is deleted  → an empty diff must fall through to the skip
+#   M7  the empty-file-list assert is deleted   → an empty file list must fall through to the skip
+#   M8  the base-tree assert is deleted         → an unreadable base must read as "no .glossary"
 # M4 and M5 pin two further deaths found while fixing the filed one: with the character class
 # repaired and nothing else changed, this detector STILL matched nothing. M5 is also why the added-
 # line test and the export test are two separate patterns rather than one — split, `[^+]` is
 # harmless; fused, it silently drops the commonest shape of the surface the detector exists to see.
+# M6–M8 are the #4986 half: each deletes exactly one guard and requires the deleted guard's own
+# could-not-see fixture to reach a `not applicable` skip again.
+#
+# M1 and M3 do not reproduce the filed regex byte-for-byte: the `sed` generator consumes the
+# backslashes, so what lands is the UNESCAPED form of it. That is still unparseable to one-true-awk
+# for the same reason (a `/` inside a bracket expression closes the regex literal), so the property
+# under test — an unparseable program must go loud — is pinned either way.
 #
 # Hermetic: `gh`, `git` and the CLI shim are stubbed, so this needs no auth, no network, and reads
 # no real PR.
@@ -63,19 +78,23 @@ printf 'BASE_REF=main\nHEAD_SHA=%s\n' "0000000000000000000000000000000000000000"
 
 cat > "$BIN/gh" <<'STUB'
 #!/usr/bin/env bash
+# FAIL and EMPTY are two DIFFERENT stub modes, because the defect under test is exactly their
+# conflation: FAIL exits non-zero, EMPTY exits 0 with nothing on stdout (#4986).
 case "$1 ${2:-}" in
-  "pr diff")        [ "$STUB_DIFF"  = FAIL ] && exit 1; cat "$STUB_DIFF";  exit 0 ;;
-  "api --paginate") [ "$STUB_FILES" = FAIL ] && exit 1; cat "$STUB_FILES"; exit 0 ;;
+  "pr diff")        [ "$STUB_DIFF"  = FAIL ] && exit 1; [ "$STUB_DIFF"  = EMPTY ] && exit 0; cat "$STUB_DIFF";  exit 0 ;;
+  "api --paginate") [ "$STUB_FILES" = FAIL ] && exit 1; [ "$STUB_FILES" = EMPTY ] && exit 0; cat "$STUB_FILES"; exit 0 ;;
 esac
 exit 0
 STUB
 
 # Every path EXISTS on base except when the case says otherwise, so detectors (1) and (2) stay mute
 # and detector (3) is the only one that can speak — which is what isolates it under test.
+# `STUB_BASE=FAIL` is the unreadable-base mode: `cat-file` fails on EVERY path, which is what makes
+# "the base could not be read" indistinguishable from "the path is absent" without the tree assert.
 cat > "$BIN/git" <<'STUB'
 #!/usr/bin/env bash
 case "$1" in
-  cat-file) exit 0 ;;
+  cat-file) [ "${STUB_BASE:-ok}" = FAIL ] && exit 1; exit 0 ;;
   ls-tree)  if [ "$2" = "-r" ]; then printf 'kit/package.json\nui/package.json\n'
             else printf 'sozluk\npano\n'; fi
             exit 0 ;;
@@ -127,8 +146,8 @@ printf 'modified\tpackages/kit/src/index.ts\n' > "$TMP/files-plain"
 printf 'modified\tpackages/kit/src/index.ts\nmodified\t.glossary/TERMS.md\n' > "$TMP/files-glossary-touched"
 
 # One case = one run of the script under one PR shape. `$OUT` is its stdout, `$RC` its exit status.
-run_case() {   # $1 = script, $2 = diff fixture (or FAIL), $3 = files fixture (or FAIL)
-	OUT="$(STUB_DIFF="$2" STUB_FILES="$3" STUB_HEAD_DIR="$HEAD" \
+run_case() {   # $1 = script, $2 = diff fixture (or FAIL|EMPTY), $3 = files fixture (or FAIL|EMPTY), $4 = base (ok|FAIL)
+	OUT="$(STUB_DIFF="$2" STUB_FILES="$3" STUB_BASE="${4:-ok}" STUB_HEAD_DIR="$HEAD" \
 		CLAUDE_PIPELINE_REPO=owner/repo CLAUDE_PLUGIN_ROOT="$TMP/plugin" \
 		PATH="$BIN:$PATH" bash "$1" 1 2>"$TMP/err")"
 	RC=$?
@@ -153,7 +172,7 @@ check() {   # $1 = label, $2 = expected stdout substring, $3 = zero|nonzero
 	printf 'OK    %-38s %s\n' "$1" "$2"
 }
 
-echo "scope: $SUT, driven under 6 PR shapes + 5 mutants"
+echo "scope: $SUT, driven under 9 PR shapes + 8 mutants"
 
 # --- the POSITIVE fixture: detector (3) fires, and the gate reaches the new-surface branch ---------
 run_case "$SUT" "$TMP/diff-export-added" "$TMP/files-plain"
@@ -173,6 +192,14 @@ run_case "$SUT" FAIL "$TMP/files-plain"
 check "diff unreadable ⇒ CANNOT-EVALUATE" "CANNOT-EVALUATE (detector (3)" nonzero
 run_case "$SUT" "$TMP/diff-export-added" FAIL
 check "file list unreadable ⇒ CANNOT-EVAL" "CANNOT-EVALUATE (the PR file list" nonzero
+
+# --- and a read that SUCCEEDED while seeing nothing is could-not-see too, not a clean answer (#4986)
+run_case "$SUT" EMPTY "$TMP/files-plain"
+check "empty diff at exit 0 ⇒ CANNOT-EVAL" "EMPTY diff at exit 0" nonzero
+run_case "$SUT" "$TMP/diff-no-export" EMPTY
+check "empty file list ⇒ CANNOT-EVALUATE" "came back EMPTY at exit 0" nonzero
+run_case "$SUT" "$TMP/diff-no-export" "$TMP/files-plain" FAIL
+check "unreadable base ⇒ CANNOT-EVALUATE" "the base tree origin/main is unreadable" nonzero
 
 # --- falsifiability: every claim above must go red under a mutant that reverts it ------------------
 #
@@ -217,12 +244,14 @@ if mutate regex "s%^\$0 ~ entry.*%$LITERAL%"; then
 	expect_mutant "M1 regex literal returns" "CANNOT-EVALUATE (detector (3)" "the born-dead regex now goes LOUD, not green"
 fi
 
-if mutate status '/DETECTOR3_RC/d'; then
+# Detector (3)'s loudness is now three lines, not one — the two status tests plus the scope assert —
+# so reproducing the historic silent skip takes all three. M6 below isolates the scope assert alone.
+if mutate status '/DETECTOR3_RC/d' '/DETECTOR3_AWK_RC/d' '/EMPTY diff at exit 0/d'; then
 	run_case "$MUTANT" FAIL "$TMP/files-plain"
-	expect_mutant "M2 status test deleted" "not applicable" "without the status test an unrun detector reads as a clean skip"
+	expect_mutant "M2 detector (3) loudness deleted" "not applicable" "without them an unrun detector reads as a clean skip"
 fi
 
-if mutate asfiled "s%^\$0 ~ entry.*%$LITERAL%" '/DETECTOR3_RC/d'; then
+if mutate asfiled "s%^\$0 ~ entry.*%$LITERAL%" '/DETECTOR3_RC/d' '/DETECTOR3_AWK_RC/d' '/EMPTY diff at exit 0/d'; then
 	run_case "$MUTANT" "$TMP/diff-export-added" "$TMP/files-plain"
 	expect_mutant "M3 the code as filed (#4700)" "not applicable" "reproduces the filed defect: a clean skip over a real new export"
 fi
@@ -235,6 +264,24 @@ fi
 if mutate addedline 's%^in_entry .*%in_entry \&\& /^\\+[^+].*export/ { print }%'; then
 	run_case "$MUTANT" "$TMP/diff-export-added" "$TMP/files-plain"
 	expect_mutant "M5 one combined added-line regex" "not applicable" "[^+] eats the e of an unindented +export before .*export can match"
+fi
+
+# M6–M8: one guard deleted each, driven by that guard's own could-not-see fixture. Each must land
+# back on a `not applicable` skip — which is the behaviour #4986 filed, and the teeth of the three
+# assertions above.
+if mutate emptydiff '/EMPTY diff at exit 0/d'; then
+	run_case "$MUTANT" EMPTY "$TMP/files-plain"
+	expect_mutant "M6 empty-diff assert deleted" "not applicable" "an empty diff reads as 'this PR added no export'"
+fi
+
+if mutate emptyfiles '/came back EMPTY at exit 0/d'; then
+	run_case "$MUTANT" "$TMP/diff-no-export" EMPTY
+	expect_mutant "M7 empty-file-list assert deleted" "not applicable" "an empty file list reads as 'this PR added no new surface'"
+fi
+
+if mutate basetree '/the base tree origin/d'; then
+	run_case "$MUTANT" "$TMP/diff-no-export" "$TMP/files-plain" FAIL
+	expect_mutant "M8 base-tree assert deleted" "no .glossary/TERMS.md on base" "an unreadable base reads as a repo that never adopted the glossary"
 fi
 
 rm -rf "$TMP"


### PR DESCRIPTION
The `review-code` glossary-freshness gate had three reads that could fail — or come back empty — and still print a clean `not applicable` skip at exit 0, which is the opposite of what the script's own header declares. Each of the three now routes a could-not-see state through `cannot()` → `CANNOT-EVALUATE` → non-zero → `[UNVERIFIABLE]`, so an unreadable input reds the gate instead of passing quietly. The mutation harness gains a fixture and a mutant per read, so a regression to the silent skip is caught rather than re-filed.

Fixes #4986

## What changed

`claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh`

1. **The base read (issue item 1).** `git cat-file -e` exits non-zero for both "no such path" and "the read itself failed", so against an unreadable base *every* probe read ABSENT and the graceful-absence branch printed a confident skip about a base the gate never saw. The chain now asserts `origin/$BASE_REF^{tree}` is readable once, before any path probe; past that assert a non-zero probe means absence and nothing else. This is the "preceded by a base-ref reachability assert" route the acceptance criteria name, and it covers detectors (1), (2) and the `DETECTOR_SURFACES` probe at the same site rather than three times over.
2. **The PR file list (item 2).** It had a status test but no scope assert, so an exit-0-with-no-rows read left detectors (1) and (2) scanning an empty set and landed the chain on the skip. Every real PR touches at least one file, so an empty list is zero scope (§ZS / ADR 0092) and now reds.
3. **The diff read (item 3).** `gh pr diff | awk` conflated "the diff came back empty" with "awk ran over a real diff and matched nothing" — the second is a fact about the PR, the first is UNKNOWN. The two reads are split, each with its own status test, plus a scope assert on the diff text.

`claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh`

- Three new could-not-see fixtures — unreadable base, empty-at-exit-0 file list, empty-at-exit-0 diff — each asserting `CANNOT-EVALUATE` at a non-zero exit. The `gh` stub grows an `EMPTY` mode distinct from `FAIL`, and the `git` stub grows an unreadable-base mode, because conflating those two states is the defect under test.
- Three new mutants (M6/M7/M8), one per guard: each deletes exactly one guard and requires the gate to fall back to a `not applicable` skip.
- M2/M3 widened: detector (3)'s loudness is three lines now, not one, so reproducing the historic silent skip takes all three.
- Rider fixed: the header called M1/M3 a "verbatim" reproduction of the filed regex. The `sed` generator consumes the backslashes, so what lands is the unescaped form — unparseable for the same reason, which is what the property actually rests on. Wording corrected to say that.

`claude-plugins/kampus-pipeline/skills/review-code/SKILL.md` — the Step 3c prose now states the succeeded-but-saw-nothing route and the base-tree assert, so the documented contract matches the script.

`.github/workflows/ci.yml` — the comment above the harness step said it "carries five mutants". It carries eight now; corrected, plus a line naming the #4986 class it also pins. Comment-only, no step or condition changed.

## Proof each read fails closed

Harness, at head: 9 PR shapes + 8 mutants, all green.

```
OK    empty diff at exit 0 ⇒ CANNOT-EVAL   EMPTY diff at exit 0
OK    empty file list ⇒ CANNOT-EVALUATE    came back EMPTY at exit 0
OK    unreadable base ⇒ CANNOT-EVALUATE    the base tree origin/main is unreadable
OK    M6 empty-diff assert deleted         an empty diff reads as 'this PR added no export'
OK    M7 empty-file-list assert deleted    an empty file list reads as 'this PR added no new surface'
OK    M8 base-tree assert deleted          an unreadable base reads as a repo that never adopted the glossary
PASS: detector (3) fires on an added public export, skips when none, and goes CANNOT-EVALUATE when it cannot run
```

The tests are not decorative: removing any one of the three guards from the script reds the harness **twice** — the direct assertion goes `BAD` printing the exact silent skip the issue filed, and the corresponding mutant's byte-identity check reports it reverts nothing. Removing the base-tree assert, for example:

```
BAD   unreadable base ⇒ CANNOT-EVALUATE  stdout missing the base tree origin/main is unreadable
                                         got: glossary-freshness: not applicable — no .glossary/TERMS.md on base
BAD   basetree                           the mutant is byte-identical to the original — it reverts nothing
FAIL: glossary-freshness detector (3) does not fire, or a could-not-run reads as a skip
harness exit: 1
```

Same shape for the empty-file-list and empty-diff guards, both landing back on `not applicable — no new feature folder / public package / export in this PR`.

## Checks run locally

- `verify-glossary-detector-fires.sh` — PASS (this is the CI job `glossary-detector` runs).
- `pipeline-cli gh-phoenix lint-skills` over the three changed files — clean.
- `pipeline-cli trap-status-guard check` over the three changed files — clean (26 fences + 2 shell units, both axes in scope).
- `shellcheck` on both scripts — clean.
- `TURBO_FORCE=true pnpm typecheck` — 30/30, 0 cached, task paths confirmed in this worktree.
- `pnpm lint:worktree` — no biome-handled changed files (the diff is markdown + shell).
- The pre-push hook ran the full unit suite: 287 files / 2420 tests passed.

## Deviations

**Blast radius wider than the issue's file list.** *Said:* the issue's Pointers name `glossary-freshness.sh` and `verify-glossary-detector-fires.sh`. *Did:* also edited `review-code/SKILL.md`. *Why:* the skill's Step 3c prose describes the verdict chain and the graceful-absence probe; leaving it unchanged would document a contract the script no longer has — the "absent" skip is now conditional on the base-tree assert. *Disposition:* included; the doc is the gate's spec and drifting it is its own defect.

**M2/M3 semantics widened rather than left alone.** *Said:* AC 5 asks each new fail-loud path to be exercised by the harness. *Did:* also changed two existing mutants. *Why:* splitting the diff read turned detector (3)'s loudness from one line into three, so `/DETECTOR3_RC/d` alone no longer reproduces the historic silent skip — the mutant would have scored "caught" off the *new* guard rather than the claim it was written to test, which is exactly the false-teeth shape this issue is about. *Disposition:* widened, and M6 added to isolate the new guard on its own.

**Rider taken, not dropped.** *Said:* AC 6 offers to drop the `verbatim` wording fix if the file changed shape. *Did:* the file did change shape, and the fix was applied anyway. *Why:* it is one comment line in a file already open in this diff, and the overstatement is load-bearing for a reader deciding whether M1/M3 pin what they claim. *Disposition:* included.

**A CI comment edit that un-skips the whole app pipeline.** *Said:* the scope is the glossary-freshness reads. *Did:* also corrected the "five mutants" claim in `.github/workflows/ci.yml`, which flips the path filters and pulls in lint/typecheck/unit/integration/e2e/preview-deploy. *Why:* my change is what made that claim stale, and shipping a file that describes the harness incorrectly is the doc-drift defect this issue is a cousin of. *Disposition:* included; comment-only, no step or condition touched. Note for the gate: the first run of the now-un-skipped `e2e` job failed on `.kp-topbar` never appearing on the preview `/sozluk` and a 0-group stats strip — unreachable from this diff, and it went green on a plain re-run of the failed jobs. Full set at head: 45 success, 1 skipped, 0 failure.

**One base-tree assert instead of three per-read asserts.** *Said:* AC 1 asks the graceful-absence probe to distinguish absent from unreadable. *Did:* placed the assert once, up front, ahead of every base read, rather than only in front of the `.glossary/TERMS.md` probe. *Why:* detectors (1) and (2) and the `DETECTOR_SURFACES` probe read the same base with the same conflating primitive; guarding only the one read the issue named would leave the others reporting "this dir is new" against a base they could not read. *Disposition:* single assert, stated once at its enforcement site.
