### PR TITLE
fix(fabrika): read `review scope` and `review diff` out of the commit they name (#5117)

### DIFF
--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -28,6 +28,11 @@ PR), and a namespace outside the set is one you did not judge and must not emit 
 v1 got per-skill now lives here. `scope` also prints the head SHA, the linked issue, `self`, and
 `harness`. Done when the set is read.
 
+The printed head is the commit the file list was **read out of**, not a label beside it: `scope`
+fetches the PR head and reads the changed files from the object database, checking nothing out. It
+refuses rather than partitioning a list it cannot tie to that commit. Carry the printed head into
+every later verb — `--sha` on `diff`, `ci` and `post` — so the whole review is one tree.
+
 ## 2 — Read the contract you grade against, and the prior verdicts
 
 ```bash
@@ -42,10 +47,13 @@ printed — the three-outcome type, not a boolean.
 ## 3 — Judge each class by its rubric
 
 ```bash
-fabrika review diff 4321
+fabrika review diff 4321 --sha 03135b91
 ```
 
-The diff verb refuses a truncated read rather than serving a prefix as the whole PR. Apply the
+The diff verb refuses a truncated read rather than serving a prefix as the whole PR, and serves
+bytes it read **at the commit you scoped** — pass step 1's head as `--sha`, and the verb refuses on
+`12` if that is no longer the PR's head instead of judging a tree the PR has left. A SHA on a
+verdict is a label; bytes read out of that commit are the immunity (#5117). Apply the
 matching rubric file to each class's slice: code → [rubrics/code.md](rubrics/code.md) · doc →
 [rubrics/doc.md](rubrics/doc.md) · skill → [rubrics/skill.md](rubrics/skill.md). Editorial craft on
 any prose surface: apply **fabrika's** shared writing rubric skill verbatim, never v1's copy (ADR
@@ -154,6 +162,7 @@ the surface and files the gap. No row here dead-ends on a bare error.
 | The class-map roots — `claude-plugins/**`, `.claude/**`, `skills/**`, any file named `SKILL.md`, and `*.md` elsewhere | `review scope` partitions the changed files into the `skill`/`doc`/`code` classes that derive the namespace set ([`contract.md`](contract.md), the class map) | **degrade** — the partition is total with `code` as the residual, so a repo homing its skills outside `claude-plugins/**` still partitions through the `skills/**` and bare-`SKILL.md` rows; nothing is dropped, and an unplaceable file is judged under the code rubric. |
 | The linked issue's `### Acceptance criteria` block | `review criteria` grades against it, and nothing else is the contract | **fail-loud** — `review criteria` exits `7` naming the issue and the wire reason (`absent` vs `malformed`), no criterion is invented, and the run points at front-door. |
 | The PR body's `## Deviations` section | `review deviations` matches the disclosure against the head diff's Tier-M scan | **fail-loud** — on a PR that owes the section, `absent` is malformed and fails the verdict closed; the run names the missing `## Deviations` heading and points at front-door. |
+| A git remote in this checkout whose URL names the repo under review | `review scope` and `review diff` fetch `pull/<pr>/head` and read the artifact out of the object database, so the bytes are provably the bound commit's ([`contract.md`](contract.md), the read verbs' commit binding) | **fail-loud** — both verbs exit `11` naming the repo no remote serves; the artifact cannot be tied to a commit, so what it shows is UNKNOWN and no unbound fallback is taken. |
 | A CI check rollup at the head — `.github/workflows/` | `review ci` is the code class's execution evidence; this skill re-runs no check itself | **fail-loud** — zero declared check runs is exit `7`, refusing green over an empty enumeration (ADR 0092), and an unreadable enumeration is `11`, UNKNOWN, never green; the run names `.github/workflows/` and points at front-door. |
 
 ## Eval enumeration (leaf-rule obligation)

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -48,7 +48,11 @@ the same tracked debt the sibling contracts carry.)
   structural read of the same facts. Dropping the worktree also removes the #3607 /tmp-collision
   and #4544 fixed-name-scratch classes by construction, and closes the self-review instruction
   hole without a denylist: a head that is never checked out is a head whose instructions are
-  never loaded.
+  never loaded. **The read verbs' commit binding does not reverse this** (#5117): `review scope`
+  and `review diff` fetch the PR head and read the artifact out of the **object database**
+  (`git diff <base>...<head>`), which writes objects and no working tree. Nothing is checked out,
+  so no head instruction file is ever on disk to be loaded — a diff that adds a worktree or a
+  checkout is still the wrong fix and should be red at review.
 - **A dead-link / ADR-index / skill-frontmatter checker.** `doc-links.yml`,
   `decisions-index.yml`, and `ci.yml`'s `validate-skills.sh` step already gate each. The rubrics
   state the expectation; the verdict stays where it is enforced.
@@ -123,9 +127,9 @@ sibling contract.md — the checked-in `/report` contract is behind its own bina
 | `7` | zero scope: the target is **proven absent (404)** or closed, the PR has zero changed files or zero declared check runs, or a required block is proven absent or malformed — a fail-closed refusal | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `8` | the write itself failed — the outcome is **UNKNOWN** | — | — | — | — | — | — | ✓ | ✓ |
 | `9` | the write landed but the read-back does not match | — | — | — | — | — | — | ✓ | ✓ |
-| `10` | a supplied classification value is off the closed vocabulary — a namespace outside this PR's derived class set, a bad polarity or carrier | — | — | — | — | — | — | ✓ | — |
+| `10` | a supplied classification value is off the closed vocabulary — a namespace outside this PR's derived class set, a bad polarity or carrier, a `--sha` that is not a head SHA | ✓ | ✓ | — | — | — | — | ✓ | — |
 | `11` | a **precondition read failed** — nothing was written and the outcome is UNKNOWN | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `12` | refused: the live head moved past the inspected `--sha` — the verdict binds a tree that is no longer the PR | — | — | — | — | — | — | ✓ | — |
+| `12` | refused: the `--sha` given is not the PR's head — a read taken over, or a verdict bound to, a tree that is no longer the PR | ✓ | ✓ | — | — | — | — | ✓ | — |
 | `13` | refused: the read was completed but its scope is **provably incomplete** — a truncated file list or diff, a check-run enumeration short of `total_count` | ✓ | ✓ | — | ✓ | ✓ | ✓ | — | — |
 | `14` | refused: the invoking token resolves below `write`, or the ACL lookup failed — authorization denied, fail-closed (ADR 0055) | — | — | — | — | — | — | — | ✓ |
 | `15` | refused: the write would drop or mutate an existing row — the append-only fence | — | — | — | — | — | — | — | ✓ |
@@ -143,8 +147,11 @@ absence: a 404 is a fact about the repository, an unreachable GitHub is not a fa
 anything) and not `1` (which would fuse an unreachable GitHub with a bad flag).
 
 **`12` and `13` are this group's own proven refusals**, in the band `triage` used for its
-kill-guards. `12` is the stale-at-post refusal — the one code whose absence would let a verdict
-formed over one tree land on another (#3769 / #4338's class, at the emit seam). `13` is the
+kill-guards. `12` is the stale-head refusal — the one code whose absence would let a verdict
+formed over one tree land on another (#3769 / #4338's class). It seats at both ends of a review:
+at the emit seam (`review post`, where the live head has moved past the judged one) and at the
+read seam (`review scope` / `review diff`, where a `--sha` that is not the PR's head would have
+a human spend a review on a tree the PR has left — #5117). `13` is the
 incomplete-enumeration refusal: the read *succeeded* and is *provably short* — a diff the API
 truncated, a check-run page count below `total_count` — which is neither `11` (nothing failed)
 nor `7` (scope exists; it just was not all seen). Folding `13` into either would render a
@@ -154,6 +161,37 @@ failure) and #4060.
 **`5` and `6` apply only to text the caller just wrote** (a verdict body, an appended
 criterion) — authored text is refusable because the author can fix it. Their fixes are opposite
 (redact-and-resend vs send-the-bytes), which is why they stay two codes, exactly as in `report`.
+
+### The read verbs bind to a commit before they read (#5117)
+
+`review scope` and `review diff` serve the artifact a whole review is formed over, so **the bytes
+have to come from a named commit, not from an endpoint that takes a pull-request number and no
+commit at all.** The platform's PR reads are the second thing: a push landing between scoping and
+reading serves the *new* head's artifact under the *old* head's SHA, and the result is a
+well-formed, confident verdict over code nobody judged. `review post`'s `12` cannot close that —
+it fires after the judging, and a rewind that lands back on the recorded SHA passes it clean.
+
+Both verbs therefore take an optional `--sha` and run one shared binding step first
+(`packages/fabrika-cli/src/review/head.ts`) before any artifact read:
+
+1. An explicit `--sha` must be **the PR's head**, or the verb refuses on `12`. Malformed is `10`.
+2. A configured git remote in this checkout must serve the target repo, `pull/<pr>/head` must
+   fetch, the commit must resolve in the **object database**, and `git rev-parse` must resolve it
+   to *itself* — a local ref or tag spelled as hex resolves elsewhere, which is how a name that
+   verifies still names the wrong tree. The base ref must resolve too, since a diff is a range.
+   Any of these unmet is `11`, naming what is UNKNOWN. There is no permissive fallback to the
+   PR-number endpoints: unbindable is a refusal, never a plausible value.
+3. The artifact is then read with `git diff <base>...<head>` — bytes for `review diff`, the
+   `--name-only -z` path list for `review scope` — under flags that pin the output to the two
+   commits rather than to the invoking user's `~/.gitconfig` (`--no-ext-diff`, explicit
+   `a/`/`b/` prefixes).
+
+Both verbs print the bound commit and its base on stderr, and `review scope`'s `scoped` line
+prints **the commit it read the files out of**, so the head named and the files partitioned are
+never two different trees.
+
+**Nothing is checked out.** A fetch writes objects, not a working tree, so this binding and the
+no-head-worktree decision above hold together rather than trading off.
 
 ### Read-backs compare normalized text, not bytes
 
@@ -175,7 +213,7 @@ message says so (#3785 is the incident where review prose tripped the guard).
 **Invocation**
 
 ```
-fabrika review scope 4321 [--repo <owner/name>] [--json]
+fabrika review scope 4321 [--sha <head>] [--repo <owner/name>] [--json]
 ```
 
 **Inputs**
@@ -183,10 +221,12 @@ fabrika review scope 4321 [--repo <owner/name>] [--json]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the pull-request number to scope |
+| `--sha` | string | no | the PR's live head | the head to read the changed files at; see the binding step above |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
-**Output** — machine channel. First line: `scoped\t<head-sha>\t<issue-number>`. Then one line per
+**Output** — machine channel. First line: `scoped\t<head-sha>\t<issue-number>`, where the head is
+the commit the file list was actually read out of. Then one line per
 present class — `class\t<name>\t<file-count>` where `<name>` is one of `code`, `doc`, `skill` —
 then two flag lines `self\t<true|false>` and `harness\t<true|false>`.
 
@@ -222,7 +262,9 @@ only reports it.
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404), or closed, or has **zero changed files** — a review over nothing (ADR 0092; #4060) |
-| `11` | the PR or its file list could not be read — the scope is UNKNOWN |
+| `10` | `--sha` is not a head SHA |
+| `11` | the PR could not be read, or the commit could not be bound — the scope is UNKNOWN |
+| `12` | `--sha` is not the PR's head — re-scope at the head, never partition a tree the PR has left |
 | `13` | the changed-file enumeration is provably short (received < declared count) |
 
 **Errors**
@@ -232,12 +274,17 @@ only reports it.
 | `review scope: PR #<n> not found in <repo>.` | 7 | refusal |
 | `review scope: PR #<n> is closed — nothing to review.` | 7 | refusal |
 | `review scope: PR #<n> has zero changed files — refusing to derive an empty review (ADR 0092, #4060).` | 7 | refusal |
+| `review scope: --sha "<v>" is not a head SHA — expected 7–40 hex characters.` | 10 | refusal |
 | `review scope: cannot read PR #<n> in <repo>: <reason> — the scope is UNKNOWN.` | 11 | refusal |
-| `review scope: file list shows <k> of <m> declared files — refusing to partition a truncated read (#3999).` | 13 | refusal |
+| `review scope: <what> — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.` | 11 | refusal |
+| `review scope: cannot read the changed files of #<n> at <sha>: <reason> — the scope is UNKNOWN.` | 11 | refusal |
+| `review scope: PR #<n>'s head is <live>, not <asked> — the tree you scoped is not the one under review; re-scope at <live> (ADR 0058).` | 12 | refusal |
+| `review scope: <sha> carries <k> of the <m> files #<n> declares — refusing to partition a short read (#3999).` | 13 | refusal |
 
-**Scope** — one PR's metadata and changed-file list, paginated, count-checked against the
-declared total. The class partition is total over what was read; the refusals exist so it is
-never run over less than everything.
+**Scope** — one PR's metadata, and the changed-file list of one bound commit, count-checked
+against the declared total. The class partition is total over what was read; the refusals exist so
+it is never run over less than everything, and never over a different tree than the head it
+prints.
 
 **Examples**
 
@@ -264,6 +311,9 @@ $ fabrika review scope 4321 --json
 - v1's `classify-skills-only.sh` prints nothing on its code-PR branch and falls off the end (the
   S10 else-less classifier) — every outcome here is a token.
 - ADR 0052 — `self` is the input the skill's BASE-revision fence keys on.
+- #5117 — the file list is the namespace set's only input, and the set is both floor and ceiling:
+  a list read at a later commit than the printed head derives a namespace nobody judged, or drops
+  one. The list and the head are one commit or the verb refuses.
 
 ---
 
@@ -272,7 +322,7 @@ $ fabrika review scope 4321 --json
 **Invocation**
 
 ```
-fabrika review diff 4321 [--repo <owner/name>]
+fabrika review diff 4321 [--sha <head>] [--repo <owner/name>]
 ```
 
 **Inputs**
@@ -280,19 +330,22 @@ fabrika review diff 4321 [--repo <owner/name>]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the pull-request number |
+| `--sha` | string | no | the PR's live head | the head to read the diff at; see the binding step above |
 | `--repo` | string | no | resolved | the repository |
 
-**Output** — machine channel. The unified diff bytes, exactly as the platform serves them. There
-is no empty answer: a PR with zero changed files is `review scope`'s `7`, and this verb reds the
-same way. No `--json`: the diff is the object.
+**Output** — machine channel. The unified diff bytes, read out of the object database at the bound
+commit. There is no empty answer: a PR with zero changed files is `review scope`'s `7`, and this
+verb reds the same way. No `--json`: the diff is the object.
 
 **Exit status**
 
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) or closed, or has zero changed files — the same refusal `review scope` makes, so neither verb serves a review over nothing |
-| `11` | the diff could not be read — UNKNOWN |
-| `13` | the diff is provably incomplete — the platform's truncation markers are present, or the file count in the diff is short of the PR's declared count |
+| `10` | `--sha` is not a head SHA |
+| `11` | the diff could not be read, or the commit could not be bound — UNKNOWN |
+| `12` | `--sha` is not the PR's head — re-review at the head, never judge a tree the PR has left |
+| `13` | the diff is provably incomplete — the file count in the diff at the bound commit is short of the PR's declared count |
 
 **Errors**
 
@@ -301,11 +354,14 @@ same way. No `--json`: the diff is the object.
 | `review diff: PR #<n> not found in <repo>.` | 7 | refusal |
 | `review diff: PR #<n> is closed — nothing to review.` | 7 | refusal |
 | `review diff: PR #<n> has zero changed files — refusing to serve an empty diff as a reviewable one (ADR 0092).` | 7 | refusal |
-| `review diff: cannot read the diff for #<n>: <reason> — UNKNOWN.` | 11 | refusal |
-| `review diff: the diff for #<n> is truncated (<k> of <m> files) — refusing to serve a partial diff as the whole (#3925's class).` | 13 | refusal |
+| `review diff: --sha "<v>" is not a head SHA — expected 7–40 hex characters.` | 10 | refusal |
+| `review diff: <what> — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.` | 11 | refusal |
+| `review diff: cannot read the diff for #<n> at <sha>: <reason> — UNKNOWN.` | 11 | refusal |
+| `review diff: PR #<n>'s head is <live>, not <asked> — the tree you scoped is not the one under review; re-scope at <live> (ADR 0058).` | 12 | refusal |
+| `review diff: the diff at <sha> carries <k> of #<n>'s <m> declared files — refusing to serve a partial diff as the whole (#3925's class).` | 13 | refusal |
 
-**Scope** — one PR's diff, completeness-checked against the PR's declared changed-file count. The
-scanned byte and file counts go to stderr on the answer path.
+**Scope** — one commit's diff, completeness-checked against the PR's declared changed-file count.
+The bound commit, and the scanned byte and file counts, go to stderr on the answer path.
 
 **Examples**
 
@@ -323,6 +379,9 @@ index 0b1c2d3..a1b2c3d 100644
   is the difference between "reviewed" and "reviewed what fit".
 - The split test is honest: this verb is not a relay because its whole job is the completeness
   proof — v1's `pr-diff.sh` was the relay, and nothing checked what it served.
+- #5117 — the completeness proof says the read was not cut short; it says nothing about which
+  commit the bytes came from. A verdict's whole value is that it binds a tree, so the bytes are
+  read at a commit rather than stamped with one afterwards.
 
 ---
 
@@ -613,6 +672,11 @@ entry's substance, never its label. An entry carrying no recognizable label prin
 The Tier-M scan reads the same diff `review diff` serves and inherits its completeness proof:
 a truncated diff is refused here on `13`, because an under-reported hit list beside a `None.`
 reads as a checked-clean disclosure that was never checked.
+
+It does **not** yet inherit the commit binding above: this verb still reads the PR-number diff
+endpoint, so its hit list is bound to no commit. Tracked as #5122 rather than folded in silently —
+the same is true of `review post`'s namespace recompute, whose own `12` narrows but does not close
+the window.
 
 **Exit status**
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -245,8 +245,8 @@ verdict back. The group implements
 
 | Verb | What it answers |
 |---|---|
-| `review scope` | head SHA, linked issue, the code / doc / skill partition of the changed files, and the `self` / `harness` flags |
-| `review diff` | the diff bytes, with truncation refused rather than passed through |
+| `review scope` | head SHA, linked issue, the code / doc / skill partition of the changed files, and the `self` / `harness` flags — the list read at the printed commit, never beside it |
+| `review diff` | the diff bytes at the bound commit, with truncation refused rather than passed through |
 | `review criteria` | the linked issue's acceptance-criteria block, through the registered wire format |
 | `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration |
 | `review verdicts` | every verdict marker on the PR, each with its `current` / `stale` / `unbindable` binding |

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -65,6 +65,95 @@ export const remotes: Shell<ReadonlyArray<string>> = Effect.gen(function* () {
 		: [];
 });
 
+/**
+ * The first remote in `git remote -v` output whose URL names `repo`, or `null`.
+ *
+ * Matched on the parsed `owner/name` rather than on the URL text so the SSH and HTTPS spellings of
+ * one repository are one answer, and case-insensitively because GitHub's own names are.
+ */
+export const matchRemote = (remoteV: string, repo: string): string | null => {
+	const want = repo.trim().toLowerCase();
+	for (const line of remoteV.split("\n")) {
+		const [name, rest] = line.split("\t");
+		if (name === undefined || rest === undefined) continue;
+		const url = rest.replace(/\s*\((fetch|push)\)\s*$/, "");
+		if (parseOwnerRepo(url)?.toLowerCase() === want) return name.trim();
+	}
+	return null;
+};
+
+/** The configured remote serving `repo`, or `null` when this checkout serves some other repository. */
+export const remoteFor = (repo: string): Shell<string | null> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["remote", "-v"]);
+		return r.ok ? matchRemote(r.stdout, repo) : null;
+	});
+
+/** Fetch one ref from a remote into the object database. No ref is checked out. */
+export const fetchRef = (remote: string, ref: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["fetch", "--quiet", remote, ref]);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/**
+ * Resolve `rev` to the full object name of a commit, from the object database.
+ *
+ * `^{commit}` is what makes the answer a commit rather than whatever object the name happens to
+ * reach, and `--verify` is what makes an unresolvable name an error instead of an echo.
+ */
+export const resolveCommit = (rev: string, qualifier = ""): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["rev-parse", "--verify", "--quiet", `${rev}^{commit}`]);
+		if (!r.ok) return fail(`cannot resolve ${rev} to a commit${qualifier}`);
+		const sha = r.stdout.trim();
+		return isObjectName(sha)
+			? ok(sha)
+			: fail(`git resolved ${rev} to "${sha}", which is not an object name`);
+	});
+
+/**
+ * The flags every diff read below is taken under, so the bytes depend on the two commits and not on
+ * the invoking user's `~/.gitconfig`.
+ *
+ * `--no-ext-diff` refuses a configured external differ, and the explicit prefixes defeat
+ * `diff.noprefix` / `diff.mnemonicPrefix` — under either, the `diff --git a/… b/…` header the
+ * completeness proof and the Tier-M walk parse (`../review/diff.ts`) simply stops appearing.
+ */
+const DIFF_FLAGS = [
+	"--no-ext-diff",
+	"--no-color",
+	"--find-renames",
+	"--src-prefix=a/",
+	"--dst-prefix=b/",
+];
+
+/**
+ * The unified diff between the merge base of `base` and `head`, and `head` — read from the object
+ * database, with nothing checked out.
+ *
+ * Three dots, because that is the range a pull request *is*: what the head adds since it diverged,
+ * never the base branch's own later commits.
+ */
+export const diffRange = (base: string, head: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["diff", ...DIFF_FLAGS, `${base}...${head}`]);
+		return r.ok ? ok(r.stdout) : fail(r.reason);
+	});
+
+/** The paths that diff changes, NUL-separated so a path no name grammar survives still arrives whole. */
+export const diffRangePaths = (base: string, head: string): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"diff",
+			...DIFF_FLAGS,
+			"--name-only",
+			"-z",
+			`${base}...${head}`,
+		]);
+		return r.ok ? ok(r.stdout.split("\0").filter((p) => p !== "")) : fail(r.reason);
+	});
+
 /** The default `--repo`: `owner/name` off the `origin` remote's URL. */
 export const originRepo: Shell<Attempt<string>> = Effect.gen(function* () {
 	const r = yield* execCapture("git", ["remote", "get-url", "origin"]);
@@ -85,21 +174,14 @@ export const originRepo: Shell<Attempt<string>> = Effect.gen(function* () {
 export const fetchAndResolve = (base: string): Shell<Attempt<string>> =>
 	Effect.gen(function* () {
 		const split = splitRemoteRef(base, yield* remotes);
-		const fetched = yield* split === null
-			? execCapture("git", ["fetch", "--quiet"])
-			: execCapture("git", ["fetch", "--quiet", split.remote, split.ref]);
-		if (!fetched.ok) return fail(fetched.reason);
-		const resolved = yield* execCapture("git", [
-			"rev-parse",
-			"--verify",
-			"--quiet",
-			`${base}^{commit}`,
-		]);
-		if (!resolved.ok) return fail(`cannot resolve ${base} to a commit after fetching`);
-		const sha = resolved.stdout.trim();
-		return isObjectName(sha)
-			? ok(sha)
-			: fail(`git resolved ${base} to "${sha}", which is not an object name`);
+		if (split === null) {
+			const all = yield* execCapture("git", ["fetch", "--quiet"]);
+			if (!all.ok) return fail(all.reason);
+		} else {
+			const fetched = yield* fetchRef(split.remote, split.ref);
+			if (fetched._tag === "Failure") return fetched;
+		}
+		return yield* resolveCommit(base, " after fetching");
 	});
 
 /**

--- a/packages/fabrika-cli/src/io/git.unit.test.ts
+++ b/packages/fabrika-cli/src/io/git.unit.test.ts
@@ -1,7 +1,12 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, type FakeShell, fakeShell, faultingShell, okOut} from "../fakes.test-support.ts";
-import {fetchAndResolve, isObjectName, parseOwnerRepo, splitRemoteRef} from "./git.ts";
+import {fetchAndResolve, isObjectName, matchRemote, parseOwnerRepo, splitRemoteRef} from "./git.ts";
+
+const REMOTE_V = `origin\tgit@github.com:kamp-us/phoenix.git (fetch)
+origin\tgit@github.com:kamp-us/phoenix.git (push)
+upstream\thttps://github.com/someone/fork.git (fetch)
+upstream\thttps://github.com/someone/fork.git (push)`;
 
 describe("isObjectName", () => {
 	it("accepts a 40-hex sha and rejects anything else", () => {
@@ -27,6 +32,19 @@ describe("parseOwnerRepo", () => {
 		expect(parseOwnerRepo("git@github.com:kamp-us/phoenix.git")).toBe("kamp-us/phoenix");
 		expect(parseOwnerRepo("https://github.com/kamp-us/phoenix.git\n")).toBe("kamp-us/phoenix");
 		expect(parseOwnerRepo("https://github.com/kamp-us/phoenix")).toBe("kamp-us/phoenix");
+	});
+});
+
+describe("matchRemote", () => {
+	it("names the remote serving a repo, in either URL spelling and either case", () => {
+		expect(matchRemote(REMOTE_V, "kamp-us/phoenix")).toBe("origin");
+		expect(matchRemote(REMOTE_V, "Kamp-Us/Phoenix")).toBe("origin");
+		expect(matchRemote(REMOTE_V, "someone/fork")).toBe("upstream");
+	});
+
+	it("is null when this checkout serves some other repository — never a guess", () => {
+		expect(matchRemote(REMOTE_V, "other/thing")).toBeNull();
+		expect(matchRemote("", "kamp-us/phoenix")).toBeNull();
 	});
 });
 

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -52,27 +52,55 @@ const prArg = Argument.integer("pr").pipe(
 	Argument.withDescription("the pull-request number to read"),
 );
 
+/**
+ * The read verbs' `--sha`: the head the caller scoped, asserted so the answer's provenance is the
+ * caller's claim and not whatever the endpoint happened to serve. Omitted, the verb binds to the
+ * PR's live head — which is still read out of the object database, so the answer names its commit
+ * either way.
+ */
+const boundShaFlag = Flag.string("sha").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the head to read the artifact at (default: the PR's live head); the verb reads it out of the object database and refuses when it is not the PR's head",
+	),
+);
+
 const scope = leafCommand(
 	"scope",
-	{pr: prArg, repo: repoFlag, json: jsonFlag},
-	Effect.fn(function* ({pr, repo, json}) {
-		yield* emit(yield* runScope({pr, repo: Option.getOrNull(repo), json, env: process.env}));
+	{pr: prArg, sha: boundShaFlag, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, sha, repo, json}) {
+		yield* emit(
+			yield* runScope({
+				pr,
+				sha: Option.getOrNull(sha),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Partition a PR's changed files into the code / doc / skill artifact classes and report its head SHA, linked issue and self / harness flags. First stdout line is `scoped\\t<head-sha>\\t<issue>`, then one `class\\t<name>\\t<files>` line per present class and the two flag lines; the scanned count is on stderr. Exits 7 (PR absent, closed, or zero changed files — ADR 0092, #4060), 11 (the PR or its file list could not be read — the scope is UNKNOWN), 13 (the file list is provably short of the declared count). Example: fabrika review scope 4321",
+		"Partition a PR's changed files into the code / doc / skill artifact classes and report its head SHA, linked issue and self / harness flags. The file list is read out of the object database at the bound commit, so the printed head and the partitioned files are the same tree. First stdout line is `scoped\\t<head-sha>\\t<issue>`, then one `class\\t<name>\\t<files>` line per present class and the two flag lines; the bound commit and the scanned count are on stderr. Exits 7 (PR absent, closed, or zero changed files — ADR 0092, #4060), 10 (--sha is not a head SHA), 11 (the PR could not be read, or the commit could not be bound — the scope is UNKNOWN), 12 (--sha is not the PR's head — re-scope, never re-bind), 13 (the commit carries fewer files than the PR declares). Example: fabrika review scope 4321 --sha 03135b91",
 	),
 );
 
 const diff = leafCommand(
 	"diff",
-	{pr: prArg, repo: repoFlag},
-	Effect.fn(function* ({pr, repo}) {
-		yield* emit(yield* runDiff({pr, repo: Option.getOrNull(repo), env: process.env}));
+	{pr: prArg, sha: boundShaFlag, repo: repoFlag},
+	Effect.fn(function* ({pr, sha, repo}) {
+		yield* emit(
+			yield* runDiff({
+				pr,
+				sha: Option.getOrNull(sha),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Serve a PR's unified diff bytes on stdout, refusing a truncated one rather than passing it through as the whole. No --json: the diff is the object. Exits 7 (PR absent, closed, or zero changed files), 11 (the diff could not be read — UNKNOWN), 13 (the served diff carries fewer files than the PR declares — #3925's class). Example: fabrika review diff 4321",
+		"Serve a PR's unified diff bytes on stdout, read out of the object database at the bound commit and refusing a truncated one rather than passing it through as the whole. Nothing is checked out. No --json: the diff is the object. Exits 7 (PR absent, closed, or zero changed files), 10 (--sha is not a head SHA), 11 (the diff could not be read, or the commit could not be bound — UNKNOWN), 12 (--sha is not the PR's head — re-review, never re-bind), 13 (the diff carries fewer files than the PR declares — #3925's class). Example: fabrika review diff 4321 --sha 03135b91",
 	),
 );
 

--- a/packages/fabrika-cli/src/review/diff-verb.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.ts
@@ -1,22 +1,29 @@
 /**
- * `review diff` — the PR's diff bytes, with truncation refused rather than silently passed through.
+ * `review diff` — the PR's diff bytes, read out of one commit, with truncation refused rather than
+ * silently passed through.
  *
- * This verb is not a relay, and the completeness proof is why: GitHub truncates large diffs at the
- * API tier, so a gate that judged the visible prefix as the whole PR is the #3925 blind-PASS class
- * one layer down. v1's `pr-diff.sh` was the relay, and nothing checked what it served.
+ * This verb is not a relay, and two proofs are why. **Completeness:** GitHub truncates large diffs at
+ * the API tier, so a gate that judged the visible prefix as the whole PR is the #3925 blind-PASS
+ * class one layer down; v1's `pr-diff.sh` was the relay, and nothing checked what it served.
+ * **Provenance:** the bytes come from the object database at the bound commit (`head.ts`), never from
+ * an endpoint that takes a PR number and no commit — see that module for why a SHA on the verdict is
+ * not the same thing as bytes from that SHA (#5117).
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {getPullDiff} from "../io/pulls.ts";
+import {diffRange} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {filesInDiff} from "./diff.ts";
+import {bindHead, boundLine} from "./head.ts";
 import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
 
 const VERB = "review diff";
 
 export interface DiffOptions {
 	readonly pr: number;
+	/** The head the caller scoped. `null` binds to the PR's live head instead of asserting one. */
+	readonly sha: string | null;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
@@ -41,16 +48,21 @@ export const runDiff = (
 		if (target._tag === "Refused") return target.outcome;
 		const pull = target.pull;
 
-		const served = yield* getPullDiff(repo, pr);
+		const bound = yield* bindHead(VERB, repo, pr, pull, options.sha);
+		if (bound._tag === "Refused") return bound.outcome;
+		const head = bound.head;
+
+		const served = yield* diffRange(head.base, head.sha);
 		if (served._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot read the diff for #${pr}: ${served.reason} — UNKNOWN.`,
+				`${VERB}: cannot read the diff for #${pr} at ${head.sha}: ${served.reason} — UNKNOWN.`,
 			);
 		}
 		const diff = served.value;
 		const seen = filesInDiff(diff);
 		const diagnostics = [
+			boundLine(VERB, head),
 			scannedLine(
 				VERB,
 				seen,
@@ -61,7 +73,7 @@ export const runDiff = (
 		if (seen < pull.changedFiles) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: the diff for #${pr} is truncated (${seen} of ${pull.changedFiles} files) — refusing to serve a partial diff as the whole (#3925's class).`,
+				`${VERB}: the diff at ${head.sha} carries ${seen} of #${pr}'s ${pull.changedFiles} declared files — refusing to serve a partial diff as the whole (#3925's class).`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
@@ -2,53 +2,85 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {
+	INCOMPLETE_SCAN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	STALE_HEAD,
+	ZERO_SCOPE,
+} from "./codes.ts";
 import {runDiff} from "./diff-verb.ts";
-import {DIFF, pull} from "./fixtures.test-support.ts";
+import {binding, DIFF, DIFF_AT, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/** The unbound endpoint this verb no longer reads — scripted so a regression has bytes to serve. */
 const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
+
+/** What that endpoint would hand back mid-flight: a *different* head's diff, one file wide. */
+const MOVED_DIFF = `diff --git a/src/other.ts b/src/other.ts
+--- a/src/other.ts
++++ b/src/other.ts
+@@ -1,1 +1,2 @@
+ const x = 1;
++const y = 2;
+`;
 
 const options = {
 	pr: 4321,
+	sha: null as string | null,
 	repo: null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const shell = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const fake = fakeShell(script);
+	return {
+		fake,
+		out: Effect.runPromise(Effect.provide(runDiff({...options, ...overrides}), fake.layer)),
+	};
 };
 
 const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runDiff({...options, ...overrides}), fakeShell(script).layer));
+) => shell(script, overrides).out;
+
+/** The whole green path: the PR read, the four binding reads, and the diff at the bound commit. */
+const green = (
+	diff: string = DIFF,
+	shape: Parameters<typeof pull>[0] = {},
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull(shape)],
+	...binding(),
+	[DIFF_AT(), okOut(diff)],
+	[RAW, okOut(MOVED_DIFF)],
+];
 
 describe("runDiff", () => {
-	it("serves the diff bytes exactly as the platform did", async () => {
-		const out = await run([
-			[PULL, pull()],
-			[RAW, okOut(DIFF)],
-		]);
+	it("serves the diff bytes exactly as the object database holds them", async () => {
+		const out = await run(green());
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(DIFF);
 	});
 
-	it("reports the file and byte counts it proved the diff against", async () => {
-		const out = await run([
-			[PULL, pull()],
-			[RAW, okOut(DIFF)],
-		]);
-		expect(out.stderr[0]).toContain("scanned 2 files; 2 declared");
-		expect(out.stderr[0]).toContain("bytes");
+	it("reports the commit it bound to and the counts it proved the diff against", async () => {
+		const out = await run(green());
+		expect(out.stderr[0]).toBe(
+			`review diff: bound to ${HEAD} (base 0f1e2d3c4b5a69788796a5b4c3d2e1f009182736) — read from the object database, nothing checked out.`,
+		);
+		expect(out.stderr[1]).toContain("scanned 2 files; 2 declared");
+		expect(out.stderr[1]).toContain("bytes");
 	});
 
-	it("refuses a truncated diff on 13 rather than serving the prefix as the whole", async () => {
-		const out = await run([
-			[PULL, pull({changedFiles: 7})],
-			[RAW, okOut(DIFF)],
-		]);
+	it("refuses a diff short of the declared count on 13 rather than serving the prefix as the whole", async () => {
+		const out = await run(green(DIFF, {changedFiles: 7}));
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
-			"review diff: the diff for #4321 is truncated (2 of 7 files) — refusing to serve a partial diff as the whole (#3925's class).",
+			`review diff: the diff at ${HEAD} carries 2 of #4321's 7 declared files — refusing to serve a partial diff as the whole (#3925's class).`,
 		);
 	});
 
@@ -64,10 +96,106 @@ describe("runDiff", () => {
 		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
 		const unreadable = await run([
 			[PULL, pull()],
-			[RAW, errOut("gh: Bad gateway (HTTP 502)")],
+			...binding(),
+			[DIFF_AT(), errOut("fatal: bad object")],
 		]);
 		expect(unreadable.code).toBe(PRECONDITION_UNKNOWN);
 		expect(unreadable.stdout).toBe("");
 		expect(unreadable.stderr.at(-1)).toContain("UNKNOWN");
+	});
+});
+
+/**
+ * The provenance fence (#5117).
+ *
+ * Each case here fails if the read reverts to the PR-number endpoint: that endpoint is scripted in
+ * every green fixture and serves a *different* head's bytes, so an unbound read does not error — it
+ * answers, plausibly and wrongly. That is the whole hazard, so it is the whole assertion.
+ */
+describe("runDiff binds its bytes to a commit", () => {
+	it("reads the object database and never the PR-number diff endpoint", async () => {
+		const {fake, out} = shell(green());
+		const result = await out;
+		expect(result.stdout).toBe(DIFF);
+		expect(result.stdout).not.toContain("src/other.ts");
+		expect(fake.calls).toContain(
+			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ 0f1e2d3c4b5a69788796a5b4c3d2e1f009182736...${HEAD}`,
+		);
+		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+	});
+
+	it("serves the scoped commit's bytes through a rewind, which the post-time re-resolve passes clean", async () => {
+		// A push landed and was rewound back onto HEAD: the live head still equals --sha, so `review
+		// post`'s STALE_HEAD never fires — only a read taken AT the commit survives this.
+		const {fake, out} = shell(green(), {sha: HEAD});
+		const result = await out;
+		expect(result.code).toBe(0);
+		expect(result.stdout).toBe(DIFF);
+		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+	});
+
+	it("refuses on 12 when --sha is not the PR's head, instead of reading whatever is live", async () => {
+		const {fake, out} = shell(green(), {sha: OLD_HEAD});
+		const result = await out;
+		expect(result.code).toBe(STALE_HEAD);
+		expect(result.stdout).toBe("");
+		expect(result.stderr.at(-1)).toBe(
+			`review diff: PR #4321's head is ${HEAD}, not ${OLD_HEAD} — the tree you scoped is not the one under review; re-scope at ${HEAD} (ADR 0058).`,
+		);
+		expect(fake.calls.some((c) => c.startsWith("git diff"))).toBe(false);
+	});
+
+	it("refuses a --sha that is not a head SHA on 10", async () => {
+		const out = await run(green(), {sha: "HEAD~1"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("is not a head SHA");
+	});
+
+	it("refuses on 11 when no remote in this checkout serves the target repo", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toBe(
+			"review diff: no git remote in this checkout serves o/r — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.",
+		);
+	});
+
+	it("refuses on 11 when the head cannot be fetched, rather than reading a stale object database", async () => {
+		// The override goes FIRST: `fakeShell` answers with the first matching row, so a row placed
+		// after the green binding would never be reached.
+		const out = await run([
+			[PULL, pull()],
+			[/^git fetch --quiet origin pull\/4321\/head$/, errOut("couldn't find remote ref")],
+			...binding(),
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("cannot fetch pull/4321/head from origin");
+	});
+
+	it("refuses on 11 when git resolves the head to a different commit", async () => {
+		// A local ref or tag spelled as hex resolves elsewhere — a name that verifies and still names
+		// the wrong tree, which is why the resolved object name is compared against the one asked for.
+		const out = await run([
+			[PULL, pull()],
+			[
+				new RegExp(`^git rev-parse --verify --quiet ${HEAD}\\^\\{commit\\}$`),
+				okOut(`${OLD_HEAD}\n`),
+			],
+			...binding(),
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain(`git resolved ${HEAD} to ${OLD_HEAD}, a different commit`);
+	});
+
+	it("refuses on 11 when the base end of the range will not resolve", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[/^git fetch --quiet origin main$/, errOut("couldn't find remote ref main")],
+			...binding(),
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("cannot resolve base main");
 	});
 });

--- a/packages/fabrika-cli/src/review/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/review/fixtures.test-support.ts
@@ -9,10 +9,13 @@ import type {ExecResult} from "../io/exec.ts";
 
 export const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
 export const OLD_HEAD = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
+/** The base commit the bound range diffs from — the merge base `git diff base...head` resolves. */
+export const BASE = "0f1e2d3c4b5a69788796a5b4c3d2e1f009182736";
 
 export interface PullShape {
 	readonly state?: string;
 	readonly head?: string;
+	readonly baseRef?: string;
 	readonly body?: string;
 	readonly changedFiles?: number;
 	readonly comments?: number;
@@ -24,11 +27,50 @@ export const pull = (shape: PullShape = {}): ExecResult =>
 			number: 4321,
 			state: shape.state ?? "open",
 			head: {sha: shape.head ?? HEAD},
+			base: {ref: shape.baseRef ?? "main"},
 			body: shape.body ?? "does a thing\n\nFixes #4287\n\n## Deviations\n\nNone.\n",
 			changed_files: shape.changedFiles ?? 2,
 			comments: shape.comments ?? 0,
 		}),
 	);
+
+const DIFF_FLAGS = "--no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/";
+
+const range = (base: string, head: string, extra = ""): RegExp =>
+	new RegExp(`^git diff ${DIFF_FLAGS}${extra} ${base}\\.\\.\\.${head}$`);
+
+/** The bound diff read: `git diff <base>...<head>` under the config-proof flags. */
+export const DIFF_AT = (base: string = BASE, head: string = HEAD): RegExp => range(base, head);
+
+/** The bound path read: the same range, `--name-only -z`. */
+export const PATHS_AT = (base: string = BASE, head: string = HEAD): RegExp =>
+	range(base, head, " --name-only -z");
+
+/** `git diff --name-only -z` output: NUL-separated paths. */
+export const paths = (...names: ReadonlyArray<string>): ExecResult =>
+	okOut(names.map((n) => `${n}\0`).join(""));
+
+/**
+ * Every command `bindHead` issues, scripted green — remote lookup, the `pull/<pr>/head` fetch, the
+ * object-database resolve of the head, and the base's fetch-then-resolve.
+ *
+ * One helper because both read verbs bind identically: two hand-written copies are two chances for a
+ * test to prove a binding the other verb does not make.
+ */
+export const binding = (
+	sha: string = HEAD,
+	base: string = BASE,
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[
+		/^git remote -v$/,
+		okOut("origin\tgit@github.com:o/r.git (fetch)\norigin\tgit@github.com:o/r.git (push)\n"),
+	],
+	[/^git fetch --quiet origin pull\/4321\/head$/, okOut("")],
+	[new RegExp(`^git rev-parse --verify --quiet ${sha}\\^\\{commit\\}$`), okOut(`${sha}\n`)],
+	[/^git remote$/, okOut("origin\n")],
+	[/^git fetch --quiet origin main$/, okOut("")],
+	[/^git rev-parse --verify --quiet origin\/main\^\{commit\}$/, okOut(`${base}\n`)],
+];
 
 export const files = (...names: ReadonlyArray<string>): ExecResult =>
 	okOut(JSON.stringify(names.map((filename) => ({filename}))));

--- a/packages/fabrika-cli/src/review/head.ts
+++ b/packages/fabrika-cli/src/review/head.ts
@@ -1,0 +1,120 @@
+/**
+ * The step every read verb runs before it reads anything: tie the artifact it is about to serve to
+ * one commit, or refuse.
+ *
+ * **A SHA on a verdict is a label; bytes provably read out of that commit are the immunity.** The
+ * platform's PR endpoints take a pull-request number and no commit at all, so a push landing between
+ * scoping and reading serves the *new* head's bytes under the *old* head's SHA — a well-formed,
+ * confident verdict over code nobody judged (#5117, the #4482 class one layer down). The post-time
+ * re-resolve cannot close it: it fires after the judging, and a rewind that lands back on the
+ * recorded SHA passes it clean.
+ *
+ * The binding is therefore taken **here, before the read**, and every read downstream of it goes
+ * through the object database at the resolved commit (`../io/git.ts`). Nothing is checked out —
+ * `contract.md`'s "Considered and deliberately not derived" rules out a head worktree, and that
+ * decision stands: a head that is never checked out is a head whose instructions are never loaded.
+ * A fetch writes objects, not a working tree, so the two properties are not in tension.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {fetchAndResolve, fetchRef, remoteFor, resolveCommit} from "../io/git.ts";
+import type {PullRecord} from "../io/pulls.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {headSha} from "../wire/verdict-marker.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, STALE_HEAD} from "./codes.ts";
+
+/** The two commits every bound read is taken between, each a full object name git itself resolved. */
+export interface BoundHead {
+	readonly sha: string;
+	readonly base: string;
+}
+
+export type Binding =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Bound"; readonly head: BoundHead};
+
+const unknown = (verb: string, what: string): Binding => ({
+	_tag: "Refused",
+	outcome: refuse(
+		PRECONDITION_UNKNOWN,
+		`${verb}: ${what} — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.`,
+	),
+});
+
+/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
+
+/**
+ * Bind this run's read to one commit: the `--sha` the caller scoped, or the PR's live head.
+ *
+ * Four things have to hold, and each is checked against evidence from a different origin — a check
+ * whose two operands come from the same read proves only that the read is self-consistent, which is
+ * exactly what an unbound read already is.
+ *
+ * 1. An explicit `--sha` must be **the PR's head**. A caller reading at a head the PR has moved past
+ *    is judging a tree the platform no longer offers, and `review post` would refuse the verdict
+ *    anyway — refusing here means it refuses *before* a human spends a review on it (ADR 0058).
+ * 2. This checkout must serve the target repository, or nothing local can witness the commit.
+ * 3. The commit must be **present in the object database after fetching `pull/<pr>/head`**, and
+ *    `git rev-parse` must resolve it to itself. That second half is not ceremony: a local ref or tag
+ *    spelled as hex resolves to a different object, which is how a "verified" name still names the
+ *    wrong tree.
+ * 4. The base must resolve too, since a diff is a range and an unresolvable end makes it UNKNOWN.
+ */
+export const bindHead = (
+	verb: string,
+	repo: string,
+	pr: number,
+	pull: PullRecord,
+	asked: string | null,
+): Effect.Effect<Binding, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		let wanted = pull.headSha;
+		if (asked !== null) {
+			const shaped = headSha(asked);
+			if (shaped === null) {
+				return {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						OFF_VOCABULARY,
+						`${verb}: --sha "${asked}" is not a head SHA — expected 7–40 hex characters.`,
+					),
+				};
+			}
+			if (!prefixMatch(pull.headSha, shaped)) {
+				return {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						STALE_HEAD,
+						`${verb}: PR #${pr}'s head is ${pull.headSha}, not ${shaped} — the tree you scoped is not the one under review; re-scope at ${pull.headSha} (ADR 0058).`,
+					),
+				};
+			}
+			wanted = shaped;
+		}
+
+		const remote = yield* remoteFor(repo);
+		if (remote === null) {
+			return unknown(verb, `no git remote in this checkout serves ${repo}`);
+		}
+		const fetched = yield* fetchRef(remote, `pull/${pr}/head`);
+		if (fetched._tag === "Failure") {
+			return unknown(verb, `cannot fetch pull/${pr}/head from ${remote}: ${fetched.reason}`);
+		}
+		const resolved = yield* resolveCommit(wanted);
+		if (resolved._tag === "Failure") {
+			return unknown(verb, `${resolved.reason} after fetching pull/${pr}/head`);
+		}
+		if (!prefixMatch(resolved.value, wanted)) {
+			return unknown(verb, `git resolved ${wanted} to ${resolved.value}, a different commit`);
+		}
+		const base = yield* fetchAndResolve(`${remote}/${pull.baseRef}`);
+		if (base._tag === "Failure") {
+			return unknown(verb, `cannot resolve base ${pull.baseRef}: ${base.reason}`);
+		}
+		return {_tag: "Bound" as const, head: {sha: resolved.value, base: base.value}};
+	});
+
+/** The stderr line that says which commit the answer was read out of. Evidence, on every answer. */
+export const boundLine = (verb: string, head: BoundHead): string =>
+	`${verb}: bound to ${head.sha} (base ${head.base}) — read from the object database, nothing checked out.`;

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -25,13 +25,17 @@ import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {APPEND_ONLY, INCOMPLETE_SCAN, LEAKED_PATH, READBACK_MISMATCH} from "./codes.ts";
 import {
+	binding,
 	checkRuns,
 	comments,
 	DIFF,
+	DIFF_AT,
 	files,
 	HEAD,
 	issue,
 	OLD_HEAD,
+	PATHS_AT,
+	paths,
 	pull,
 } from "./fixtures.test-support.ts";
 
@@ -62,6 +66,7 @@ afterEach(() => {
 	vi.resetModules();
 	vi.doUnmock("./rollup.ts");
 	vi.doUnmock("./diff.ts");
+	vi.doUnmock("../io/git.ts");
 	vi.doUnmock("./append.ts");
 	vi.doUnmock("../wire/verdict-marker.ts");
 	vi.doUnmock("../report/leaks.ts");
@@ -143,15 +148,16 @@ describe("the three-outcome binding", () => {
 });
 
 describe("the diff completeness proof", () => {
-	// The PR declares seven files; the platform served two. Anything but a refusal judges 2/7.
+	// The PR declares seven files; the commit carries two. Anything but a refusal judges 2/7.
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull({changedFiles: 7})],
-		[RAW, okOut(DIFF)],
+		...binding(),
+		[DIFF_AT(), okOut(DIFF)],
 	];
 
-	it("refuses a truncated diff on 13", async () => {
+	it("refuses a short diff on 13", async () => {
 		const {runDiff} = await import("./diff-verb.ts");
-		const out = await withShell(runDiff({pr: 4321, repo: null, env: ENV}), script);
+		const out = await withShell(runDiff({pr: 4321, sha: null, repo: null, env: ENV}), script);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
 	});
@@ -159,9 +165,83 @@ describe("the diff completeness proof", () => {
 	it("MUTANT: a file count that always matches serves the partial diff as the whole (#3925)", async () => {
 		await mutate<typeof import("./diff.ts")>("./diff.ts", () => ({filesInDiff: () => 7}));
 		const {runDiff} = await import("./diff-verb.ts");
-		const out = await withShell(runDiff({pr: 4321, repo: null, env: ENV}), script);
+		const out = await withShell(runDiff({pr: 4321, sha: null, repo: null, env: ENV}), script);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(DIFF);
+	});
+});
+
+/**
+ * The provenance binding (#5117) — the guard whose absence is invisible from inside.
+ *
+ * A drifted read does not error and does not look short: the served artifact is well-formed, the
+ * completeness proof passes, and the verdict carries a SHA. The mutants below restore exactly the
+ * unbound read each verb used to make, and pin the plausible wrong answer that comes back — the
+ * other head's bytes, and a namespace set derived from files the printed commit does not contain.
+ */
+describe("the commit binding on the read verbs", () => {
+	/** What the PR-number endpoints serve once a push has landed: a different head's artifact. */
+	const MOVED_DIFF = `diff --git a/src/other.ts b/src/other.ts
+--- a/src/other.ts
++++ b/src/other.ts
+@@ -1,1 +1,2 @@
+ const x = 1;
++const y = 2;
+`;
+
+	const diffScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({changedFiles: 1})],
+		...binding(),
+		[DIFF_AT(), okOut(DIFF)],
+		[RAW, okOut(MOVED_DIFF)],
+	];
+
+	it("serves the bound commit's bytes", async () => {
+		const {runDiff} = await import("./diff-verb.ts");
+		const out = await withShell(runDiff({pr: 4321, sha: HEAD, repo: null, env: ENV}), diffScript);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(DIFF);
+	});
+
+	it("MUTANT: reading the PR-number diff endpoint serves another head's bytes under this SHA", async () => {
+		await mutate<typeof import("../io/git.ts")>("../io/git.ts", () => ({
+			diffRange: () => Effect.succeed({_tag: "Ok" as const, value: MOVED_DIFF}),
+		}));
+		const {runDiff} = await import("./diff-verb.ts");
+		const out = await withShell(runDiff({pr: 4321, sha: HEAD, repo: null, env: ENV}), diffScript);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(MOVED_DIFF);
+		expect(out.stdout).not.toBe(DIFF);
+	});
+
+	const scopeScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({changedFiles: 1})],
+		...binding(),
+		[PATHS_AT(), paths("src/cart.ts")],
+		[FILES, files("docs/moved.md")],
+	];
+
+	it("partitions the bound commit's file list", async () => {
+		const {runScope} = await import("./scope-verb.ts");
+		const out = await withShell(
+			runScope({pr: 4321, sha: HEAD, repo: null, json: true, env: ENV}),
+			scopeScript,
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({head: HEAD, namespaces: ["review-code"]});
+	});
+
+	it("MUTANT: reading the PR-number file list derives a namespace the printed head never had", async () => {
+		await mutate<typeof import("../io/git.ts")>("../io/git.ts", () => ({
+			diffRangePaths: () => Effect.succeed({_tag: "Ok" as const, value: ["docs/moved.md"]}),
+		}));
+		const {runScope} = await import("./scope-verb.ts");
+		const out = await withShell(
+			runScope({pr: 4321, sha: HEAD, repo: null, json: true, env: ENV}),
+			scopeScript,
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({head: HEAD, namespaces: ["review-doc"]});
 	});
 });
 
@@ -339,19 +419,23 @@ nothing yet.
 describe("the short-read refusal on the changed-file list", () => {
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull({changedFiles: 9})],
-		[FILES, files("src/cart.ts", "README.md")],
+		...binding(),
+		[PATHS_AT(), paths("src/cart.ts", "README.md")],
 	];
 
-	it("refuses a partition over a truncated read on 13", async () => {
+	it("refuses a partition over a short read on 13", async () => {
 		const {runScope} = await import("./scope-verb.ts");
-		const out = await withShell(runScope({pr: 4321, repo: null, json: false, env: ENV}), script);
+		const out = await withShell(
+			runScope({pr: 4321, sha: null, repo: null, json: false, env: ENV}),
+			script,
+		);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
 
 	it("MUTANT: a file list that reports the declared count partitions 2 of 9 files as the whole", async () => {
-		await mutate<typeof import("../io/pulls.ts")>("../io/pulls.ts", (actual) => ({
-			listPullFiles: (repo: string, pr: number) =>
-				Effect.map(actual.listPullFiles(repo, pr), (attempt) =>
+		await mutate<typeof import("../io/git.ts")>("../io/git.ts", (actual) => ({
+			diffRangePaths: (base: string, head: string) =>
+				Effect.map(actual.diffRangePaths(base, head), (attempt) =>
 					attempt._tag === "Ok"
 						? {
 								_tag: "Ok" as const,
@@ -361,16 +445,20 @@ describe("the short-read refusal on the changed-file list", () => {
 				),
 		}));
 		const {runScope} = await import("./scope-verb.ts");
-		const out = await withShell(runScope({pr: 4321, repo: null, json: false, env: ENV}), script);
+		const out = await withShell(
+			runScope({pr: 4321, sha: null, repo: null, json: false, env: ENV}),
+			script,
+		);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("scoped\t");
 	});
 
 	it("proves the harness itself is live — an unscripted call still fails loudly", async () => {
 		const {runScope} = await import("./scope-verb.ts");
-		const out = await withShell(runScope({pr: 4321, repo: null, json: false, env: ENV}), [
-			[PULL, errOut("gh: Bad gateway (HTTP 502)")],
-		]);
+		const out = await withShell(
+			runScope({pr: 4321, sha: null, repo: null, json: false, env: ENV}),
+			[[PULL, errOut("gh: Bad gateway (HTTP 502)")]],
+		);
 		expect(out.code).not.toBe(0);
 	});
 });

--- a/packages/fabrika-cli/src/review/scope-verb.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.ts
@@ -6,13 +6,18 @@
  * make sure it is never run over less than everything. A zero-file PR reds (v1's `class-probe` read
  * 0 files and classified `has-code` exit 0 — #4060), and a file list short of the declared count reds
  * rather than partitioning a truncated read (#3999).
+ *
+ * The file list is read at the **bound commit** (`head.ts`), and the head this verb prints is that
+ * same commit. The namespace set is documented as both floor and ceiling, so a list drawn from a
+ * different commit than the printed head derives a namespace nobody judged — or drops one (#5117).
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {listPullFiles} from "../io/pulls.ts";
+import {diffRangePaths} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {linkedIssueOf, namespacesOf, partition} from "./classes.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {bindHead, boundLine} from "./head.ts";
 import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
 
 const VERB = "review scope";
@@ -22,6 +27,8 @@ export const NULL_TOKEN = "-";
 
 export interface ScopeOptions {
 	readonly pr: number;
+	/** The head the caller scoped. `null` binds to the PR's live head instead of asserting one. */
+	readonly sha: string | null;
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
@@ -43,21 +50,26 @@ export const runScope = (
 		if (target._tag === "Refused") return target.outcome;
 		const pull = target.pull;
 
-		const listed = yield* listPullFiles(repo, pr);
+		const bound = yield* bindHead(VERB, repo, pr, pull, options.sha);
+		if (bound._tag === "Refused") return bound.outcome;
+		const head = bound.head;
+
+		const listed = yield* diffRangePaths(head.base, head.sha);
 		if (listed._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot read PR #${pr} in ${repo}: ${listed.reason} — the scope is UNKNOWN.`,
+				`${VERB}: cannot read the changed files of #${pr} at ${head.sha}: ${listed.reason} — the scope is UNKNOWN.`,
 			);
 		}
 		const files = listed.value;
 		const diagnostics = [
+			boundLine(VERB, head),
 			scannedLine(VERB, files.length, "changed file", `${pull.changedFiles} declared`),
 		];
 		if (files.length < pull.changedFiles) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: file list shows ${files.length} of ${pull.changedFiles} declared files — refusing to partition a truncated read (#3999).`,
+				`${VERB}: ${head.sha} carries ${files.length} of the ${pull.changedFiles} files #${pr} declares — refusing to partition a short read (#3999).`,
 				diagnostics,
 			);
 		}
@@ -68,7 +80,7 @@ export const runScope = (
 			return answer(
 				JSON.stringify({
 					outcome: "scoped",
-					head: pull.headSha,
+					head: head.sha,
 					issue,
 					classes: result.classes,
 					self: result.self,
@@ -81,7 +93,7 @@ export const runScope = (
 		}
 		return answer(
 			[
-				`scoped\t${pull.headSha}\t${issue ?? NULL_TOKEN}`,
+				`scoped\t${head.sha}\t${issue ?? NULL_TOKEN}`,
 				...result.classes.map((entry) => `class\t${entry.name}\t${entry.files}`),
 				`self\t${result.self}`,
 				`harness\t${result.harness}`,

--- a/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
@@ -1,30 +1,66 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell} from "../fakes.test-support.ts";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {files, HEAD, pull} from "./fixtures.test-support.ts";
+import {
+	INCOMPLETE_SCAN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	STALE_HEAD,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	BASE,
+	binding,
+	files,
+	HEAD,
+	OLD_HEAD,
+	PATHS_AT,
+	paths,
+	pull,
+} from "./fixtures.test-support.ts";
 import {runScope} from "./scope-verb.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/** The unbound endpoint this verb no longer reads — scripted so a regression has a list to serve. */
 const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
 
 const options = {
 	pr: 4321,
+	sha: null as string | null,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
+const shell = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const fake = fakeShell(script);
+	return {
+		fake,
+		out: Effect.runPromise(Effect.provide(runScope({...options, ...overrides}), fake.layer)),
+	};
+};
+
 const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(Effect.provide(runScope({...options, ...overrides}), fakeShell(script).layer));
+) => shell(script, overrides).out;
 
-const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[PULL, pull()],
-	[FILES, files("src/cart.ts", "README.md")],
+/**
+ * The green path. The PR-number files endpoint is scripted too, and deliberately answers a
+ * *different* file set — so a read that drifts back to it derives `review-doc` where the bound
+ * commit derives both classes, instead of failing loudly.
+ */
+const happy = (
+	shape: Parameters<typeof pull>[0] = {},
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull(shape)],
+	...binding(),
+	[PATHS_AT(), paths("src/cart.ts", "README.md")],
+	[FILES, files("docs/moved.md", "docs/also.md")],
 ];
 
 describe("runScope", () => {
@@ -55,16 +91,16 @@ describe("runScope", () => {
 	});
 
 	it("prints `-` for a PR with no closing keyword, never a fabricated issue", async () => {
-		const out = await run([
-			[PULL, pull({body: "relates to #4287"})],
-			[FILES, files("a.ts", "b.ts")],
-		]);
+		const out = await run(happy({body: "relates to #4287"}));
 		expect(out.stdout.split("\n")[0]).toBe(`scoped\t${HEAD}\t-`);
 	});
 
-	it("reports what it scanned against what was declared", async () => {
+	it("reports the commit it bound to, then what it scanned against what was declared", async () => {
 		const out = await run(happy());
-		expect(out.stderr[0]).toBe("review scope: scanned 2 changed files; 2 declared.");
+		expect(out.stderr[0]).toBe(
+			`review scope: bound to ${HEAD} (base ${BASE}) — read from the object database, nothing checked out.`,
+		);
+		expect(out.stderr[1]).toBe("review scope: scanned 2 changed files; 2 declared.");
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
@@ -96,23 +132,26 @@ describe("runScope", () => {
 	it("refuses an unreadable file list on 11 — the partition would be over unknown scope", async () => {
 		const out = await run([
 			[PULL, pull()],
-			[FILES, errOut("gh: Bad gateway (HTTP 502)")],
+			[PATHS_AT(), errOut("fatal: bad revision")],
+			...binding(),
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("the scope is UNKNOWN");
 	});
 
 	it("refuses a provably short file list on 13, distinct from 11 and 7", async () => {
 		const out = await run([
 			[PULL, pull({changedFiles: 9})],
-			[FILES, files("a.ts", "b.md")],
+			...binding(),
+			[PATHS_AT(), paths("a.ts", "b.md")],
 		]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.code).not.toBe(PRECONDITION_UNKNOWN);
 		expect(out.code).not.toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
-			"review scope: file list shows 2 of 9 declared files — refusing to partition a truncated read (#3999).",
+			`review scope: ${HEAD} carries 2 of the 9 files #4321 declares — refusing to partition a short read (#3999).`,
 		);
 	});
 
@@ -122,5 +161,58 @@ describe("runScope", () => {
 			Effect.provide(runScope({...options, env: {}}), fakeShell([]).layer),
 		);
 		expect(out.code).toBe(1);
+	});
+});
+
+/**
+ * The provenance fence (#5117).
+ *
+ * The namespace set is documented as both floor and ceiling, so this list is not one input among
+ * many — a list drawn from a later commit derives a namespace nobody judged, or drops one. Every
+ * case here fails if the read reverts to the PR-number endpoint, which the fixture scripts with a
+ * doc-only file set.
+ */
+describe("runScope binds its file list to the commit it prints", () => {
+	it("partitions the bound commit's files, never the PR-number endpoint's", async () => {
+		const {fake, out} = shell(happy());
+		const result = await out;
+		expect(result.stdout).toContain("class\tcode\t1");
+		expect(result.stdout).not.toContain("class\tdoc\t2");
+		expect(fake.calls).toContain(
+			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ --name-only -z ${BASE}...${HEAD}`,
+		);
+		expect(fake.calls.some((c) => c.includes("pulls/4321/files"))).toBe(false);
+	});
+
+	it("prints the head it actually read the files out of", async () => {
+		const {out} = shell(happy(), {sha: HEAD});
+		const result = await out;
+		expect(result.stdout.split("\n")[0]).toBe(`scoped\t${HEAD}\t4287`);
+	});
+
+	it("refuses on 12 when --sha is not the PR's head", async () => {
+		const {fake, out} = shell(happy(), {sha: OLD_HEAD});
+		const result = await out;
+		expect(result.code).toBe(STALE_HEAD);
+		expect(result.stdout).toBe("");
+		expect(result.stderr.at(-1)).toContain("re-scope at");
+		expect(fake.calls.some((c) => c.startsWith("git diff"))).toBe(false);
+	});
+
+	it("refuses a --sha that is not a head SHA on 10", async () => {
+		const out = await run(happy(), {sha: "origin/main"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("is not a head SHA");
+	});
+
+	it("refuses on 11 when the commit cannot be bound, rather than partitioning an unbound list", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toBe(
+			"review scope: no git remote in this checkout serves o/r — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.",
+		);
 	});
 });


### PR DESCRIPTION
fabrika's review gate stamped a commit SHA on every verdict, but the two verbs that fetch what a
reviewer actually reads asked GitHub for "pull request 4321" and never named a commit — so the bytes
were whatever the API served at that moment. If a push landed mid-review, the gate could pass code
nobody looked at, under the old head's SHA, with nothing downstream able to tell. Both verbs now
fetch the head and read the diff out of git's object database at that exact commit, and refuse when
they cannot prove the tie. Nothing is checked out.

Fixes #5117

## What changed

- **`packages/fabrika-cli/src/review/head.ts` (new)** — one shared binding step both read verbs run
  before any artifact read. An explicit `--sha` must be the PR's head (else `12`); a configured
  remote must serve the repo; `pull/<pr>/head` must fetch; the commit must resolve in the object
  database **to itself**; the base must resolve. Any of those unmet is `11` naming what is UNKNOWN.
  There is no fallback to the unbound endpoints.
- **`packages/fabrika-cli/src/io/git.ts`** — `remoteFor` / `matchRemote`, `fetchRef`,
  `resolveCommit`, `diffRange`, `diffRangePaths`. All checkout-free object-database reads, built on
  the primitives already in this file; `fetchAndResolve` now composes `fetchRef` + `resolveCommit`
  rather than re-spawning them.
- **`review diff`** — bytes come from `git diff <base>...<head>`. New optional `--sha`.
- **`review scope`** — the changed-file list comes from the same range, `--name-only -z`, and the
  `scoped` line prints **the commit the list was read out of**. New optional `--sha`.
- **Docs** — `contract.md` gains a shared "The read verbs bind to a commit before they read"
  section, both per-verb tables, and the updated exit matrix; the
  "Considered and deliberately not derived" entry now says explicitly that this binding does *not*
  reverse the no-head-worktree decision. `SKILL.md` steps 1 and 3 describe what the reviewer gets.

## The three unbound reads, each bound individually

The issue named three, and warned they can agree with each other while all three are wrong. None of
them is verified against another:

| Read | Before | Now |
|---|---|---|
| the diff bytes | `gh api -H Accept: …diff repos/<r>/pulls/<pr>` | `git diff <base>...<sha>` at the resolved commit |
| the namespace-set file list | `gh api repos/<r>/pulls/<pr>/files` | `git diff --name-only -z <base>...<sha>`, same resolved commit, and the head printed is that commit |
| the `changedFiles` denominator | platform read, compared against a platform-read numerator | still the platform's declaration — but the numerator is now the bound commit's, and the guard stays one-directional (`seen < declared`), so it can only fire on a genuine shortfall |

## Falsifiability

The binding was removed and the suite re-run before this landed: reverting `diffRange` →
`getPullDiff` and `diffRangePaths` → `listPullFiles` turns **15 tests red** across
`diff-verb.unit.test.ts`, `scope-verb.unit.test.ts` and `mutation.unit.test.ts`. Every green fixture
scripts the PR-number endpoints with a *different* head's artifact, so an unbound read does not
error — it answers plausibly and wrongly, which is exactly what the tests catch.

Two mutation cases pin the wrong answer by name (`mutation.unit.test.ts`, "the commit binding on the
read verbs"):

- `diffRange` restored to the endpoint → exit 0, another head's bytes served under this SHA.
- `diffRangePaths` restored to the endpoint → exit 0, `namespaces: ["review-doc"]` derived at a head
  whose file list is `src/cart.ts` — a namespace nobody judged.

The rewind case is covered directly: with `--sha` equal to the live head (a push landed and was
rewound), `review post`'s `STALE_HEAD` never fires, and the test asserts the served bytes are the
commit's rather than the endpoint's.

`pnpm typecheck --force` clean (30/30, 0 cached), `pnpm lint:worktree` clean, 1922 tests pass.

## Deviations

**Class 1 — scope narrowing (`review deviations` and `review post` left unbound).** Said: bind the
`review` group's unbound reads. Did: bound `review diff` and `review scope` only. Why: the issue's
"One unit, not two" section scopes the unit to the two callers of `getPullDiff` / `listPullFiles` in
the two named verbs, and its acceptance criteria name only those; `review deviations`' Tier-M diff
read and `review post`'s namespace recompute have the same defect at sibling seams. Disposition:
follow-up #5122 filed, and `contract.md` says so at the `review deviations` Tier-M paragraph rather
than leaving it implicit.

**Class 1 — scope narrowing (a local checkout of the target repo is now required).** Said: bind the
reads. Did: made "a configured remote in this checkout serves `--repo`" a precondition — a run from
an unrelated checkout now refuses on `11` where it previously answered from the API. Why: nothing
local can witness a commit in a repository this checkout does not track, and an unbindable read is a
refusal by AC 4, not a fallback. The review flow already reads the repo's objects (`SKILL.md` step 6
reads the merge-base revision with `git show`), so this is not a new dependency. Disposition:
declared as a new row in `SKILL.md`'s "Required repo files" table, fail-loud.

**Class 3 — known defect left unfixed (the completeness denominator).** Said: the issue notes
`pull.changedFiles` is itself a third unbound read whose drift can track the numerator's. Did: left
the denominator as the platform's declaration. Why: the numerator is now commit-bound, and the guard
is one-directional (`seen < declared`), so the pair can only refuse on a genuine shortfall — a
rename-detection difference between git and GitHub moves `seen` *up*, never down, so it cannot
false-refuse. Replacing the denominator with a second git read would compare a read against itself,
which proves nothing. Disposition: for the reviewer to judge.

**Class 6 — pre-existing tests and fixtures changed.** Said: add refusal coverage to the two
per-verb test files. Did: also rewrote their green fixtures onto the git binding, changed the
mutation harness's scope mutant from `listPullFiles` to `diffRangePaths`, and added `base.ref` to
the shared `pull()` fixture. Why: the verbs no longer make the reads those fixtures scripted. No
assertion was weakened — the short-read refusals and both pre-existing mutants still assert the same
outcomes, and the message strings they pin were updated only where the message itself changed to
name the bound commit. Disposition: no action needed.

**Class 7 — out-of-scope change (`fetchAndResolve` refactor, README wording).** Said: fix the read
verbs. Did: also recomposed `fetchAndResolve` onto the new `fetchRef` / `resolveCommit` primitives,
and reworded two `packages/fabrika-cli/README.md` verb-table rows. Why: without the refactor the
same fetch-then-verify sequence would exist twice in one file; the README rows would otherwise
describe behavior the package no longer has. `fetchAndResolve`'s own tests are unchanged and green,
including its two failure-path assertions. Disposition: no action needed.

**Classes 2, 4, 5 — none.** No ADR is departed from (ADR 0058 is applied further, not narrowed; the
contract's no-head-worktree decision is preserved and restated). No guidance was declined — the
issue's binding constraints (no checkout, build on `io/git.ts`, one unit) are each honored. No guard
or gate was bypassed: no suppression, no `biome-ignore`, no skipped test, and no hook was pushed
past.
