### PR TITLE
feat(fabrika-cli): wire the admission test into the build pool and claim seams

### DIFF
--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -13,15 +13,27 @@
  *
  * A loser retracts its **own** marker and nothing else — never another lane's, which is the one write
  * this protocol must never make.
+ *
+ * **`claim` runs the admission test before it writes anything; `confirm` and `release` never run it.**
+ * The fence decides what may *start* (ADR 0245), so a focus row edited mid-lane must not strand a
+ * running lane or block its release. Claiming is the one moment every path goes through — a number
+ * handed straight to `claim` passes through no pool — which is why the refusal has teeth here and is
+ * advice at the pool.
  */
-import {Effect} from "effect";
+import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {createComment, deleteComment, getComment} from "../io/issues.ts";
+import {createComment, deleteComment, getComment, type IssueRecord} from "../io/issues.ts";
 import {normalizeForReadback} from "../report/compose.ts";
-import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {composeMarker, readMarkerToken, requireSession, resolveOwnership} from "./claim.ts";
 import {CLAIM_NOT_MINE, PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
 import {composeToken} from "./lane.ts";
+import {
+	admissionOf,
+	admissionRefusal,
+	focusScopeLine,
+	readDeclaredFocus,
+} from "./scope-admission.ts";
 import {openIssue, resolveTargetRepo} from "./target.ts";
 
 export interface ClaimOptions {
@@ -32,16 +44,23 @@ export interface ClaimOptions {
 	readonly uuid: string;
 	/** The marker's human-readable ISO-8601 timestamp. The tiebreak uses GitHub's `created_at`. */
 	readonly at: string;
+	/** Why this run claims an issue the admission test refused, or `null` for the ordinary path. */
+	readonly override: string | null;
 }
 
-export type ProtocolOptions = Omit<ClaimOptions, "uuid" | "at">;
+export type ProtocolOptions = Omit<ClaimOptions, "uuid" | "at" | "override">;
 
 const preflight = (
 	verb: string,
 	options: ProtocolOptions,
 ): Effect.Effect<
 	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
-	| {readonly _tag: "Ready"; readonly repo: string; readonly session: string},
+	| {
+			readonly _tag: "Ready";
+			readonly repo: string;
+			readonly session: string;
+			readonly issue: IssueRecord;
+	  },
 	never,
 	ChildProcessSpawner.ChildProcessSpawner
 > =>
@@ -58,22 +77,63 @@ const preflight = (
 				`${verb}: cannot read #${options.number}: ${reason} — ownership is UNKNOWN, never "unclaimed".`,
 		);
 		if (target._tag === "Refused") return {_tag: "Refused" as const, outcome: target.outcome};
-		return {_tag: "Ready" as const, repo: resolved.repo, session: session.id};
+		return {
+			_tag: "Ready" as const,
+			repo: resolved.repo,
+			session: session.id,
+			issue: target.issue,
+		};
 	});
 
 const CLAIM = "build claim";
 
 export const runClaim = (
 	options: ClaimOptions,
-): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
 	Effect.gen(function* () {
+		if (options.override !== null && options.override.trim() === "") {
+			return refuse(
+				FAILED,
+				`${CLAIM}: --override was given with an empty reason — an override is recorded or it is not one.`,
+			);
+		}
 		const ready = yield* preflight(CLAIM, options);
 		if (ready._tag === "Refused") return ready.outcome;
 		const {repo, session} = ready;
 		const {number} = options;
 
+		const read = yield* readDeclaredFocus();
+		if (read._tag === "Unreadable") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${CLAIM}: cannot read the "## Focus" declaration: ${read.reason} — scope is UNKNOWN, never admitted; nothing was written.`,
+			);
+		}
+		const scopeLine = focusScopeLine(CLAIM, read.focus);
+		const admission = admissionOf(read.focus, ready.issue);
+		const refusal = admissionRefusal(CLAIM, admission);
+		// An override answers a PROVEN refusal. UNKNOWN has proven nothing, so there is nothing to
+		// override — a fence that could not read its input must not be talked past by a flag.
+		const overridable = admission._tag === "OutOfFocus" || admission._tag === "AudienceNotAgent";
+		if (refusal !== null && !(overridable && options.override !== null)) {
+			return {
+				...refusal,
+				stderr: [
+					scopeLine,
+					...refusal.stderr,
+					`${CLAIM}: nothing was written — #${number} carries no marker from this run${
+						overridable ? '; pass --override "<reason>" to claim it anyway' : ""
+					}.`,
+				],
+			};
+		}
+
 		const token = composeToken(session, options.uuid);
-		const body = composeMarker(token, options.at);
+		const body = composeMarker(token, options.at, options.override);
 		const posted = yield* createComment(repo, number, body);
 		if (posted._tag === "Failure") {
 			return refuse(
@@ -92,10 +152,13 @@ export const runClaim = (
 
 		// The checkpoint: posting DETECTS a race, this re-read RESOLVES it.
 		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session);
-		const notes = unauthorized.map(
-			(marker) =>
-				`${CLAIM}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
-		);
+		const notes = [
+			scopeLine,
+			...unauthorized.map(
+				(marker) =>
+					`${CLAIM}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
+			),
+		];
 		if (ownership._tag === "Unknown") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
@@ -104,7 +167,15 @@ export const runClaim = (
 			);
 		}
 		if (ownership._tag === "Mine") {
-			return answer(JSON.stringify({answer: "won", number, token}), notes);
+			return answer(
+				JSON.stringify({
+					answer: "won",
+					number,
+					token,
+					...(options.override === null ? {} : {override: options.override}),
+				}),
+				notes,
+			);
 		}
 
 		// Lost, or shadowed by an unauthorized-only thread: retract this run's OWN marker, nothing else.

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -1,17 +1,29 @@
-import {Effect} from "effect";
+import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {FAILED} from "../verb.ts";
 import {runClaim, runConfirm, runRelease} from "./claim-verb.ts";
 import {
+	AUDIENCE_NOT_AGENT,
+	BAD_SECTIONS,
 	CLAIM_NOT_MINE,
+	OUT_OF_FOCUS,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
 	ZERO_SCOPE,
 } from "./codes.ts";
-import {comments, issue, LANE_UUID, marker} from "./fixtures.test-support.ts";
+import {
+	candidates,
+	comments,
+	focusTable,
+	issue,
+	LANE_UUID,
+	marker,
+} from "./fixtures.test-support.ts";
+import {runPick} from "./pick-verb.ts";
+import {DEFAULT_ROADMAP} from "./scope-admission.ts";
 
 const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
 const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
@@ -26,6 +38,14 @@ const THEIRS = marker("s-77aa", "9d8c7b6a-5f4e-3d2c-1b0a-998877665544");
 const POSTED = okOut(JSON.stringify({id: 9001, html_url: "https://github.com/o/r/issues/4312#c"}));
 const ECHO = okOut(JSON.stringify({body: MINE}));
 
+const labelled = (...names: ReadonlyArray<string>) => names.map((name) => ({name}));
+
+/** The claim path's default target: triaged, agent-ready, unhomed — admitted under an inert fence. */
+const CLAIMABLE = issue({labels: labelled("type:bug", "p1", "status:triaged", "ready-for:agent")});
+
+/** No `ROADMAP.md`: no focus declared, so the scope axis admits and the fence reports itself inert. */
+const NO_FOCUS = fakeFs({files: {}});
+
 const options = {
 	number: 4312,
 	repo: null,
@@ -35,18 +55,26 @@ const options = {
 	>,
 	uuid: LANE_UUID,
 	at: "2026-08-09T00:00:00Z",
+	override: null as string | null,
 };
 
 const run = (
 	verb: typeof runClaim,
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
-) => Effect.runPromise(Effect.provide(verb({...options, ...overrides}), fakeShell(script).layer));
+	fs = NO_FOCUS,
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			verb({...options, ...overrides}),
+			Layer.merge(fakeShell(script).layer, fs.layer),
+		),
+	);
 
 describe("runClaim", () => {
 	it("wins when its own marker is the earliest authorized one", async () => {
 		const out = await run(runClaim, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
@@ -62,13 +90,15 @@ describe("runClaim", () => {
 
 	it("re-reads AFTER posting — the checkpoint is what resolves a staggered race", async () => {
 		const shell = fakeShell([
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
 			[perm("agent"), okOut("write\n")],
 		]);
-		await Effect.runPromise(Effect.provide(runClaim(options), shell.layer));
+		await Effect.runPromise(
+			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+		);
 		const posted = shell.calls.findIndex((line) => POST.test(line));
 		const swept = shell.calls.findIndex((line) => COMMENTS.test(line));
 		expect(posted).toBeGreaterThanOrEqual(0);
@@ -77,7 +107,7 @@ describe("runClaim", () => {
 
 	it("exits 15 on a lost race — NEVER 0 — names the winner and retracts its own marker", async () => {
 		const shell = fakeShell([
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[
@@ -90,7 +120,9 @@ describe("runClaim", () => {
 			[perm("agent"), okOut("write\n")],
 			[DELETE, okOut("")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runClaim(options), shell.layer));
+		const out = await Effect.runPromise(
+			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("lost to build:s-77aa:");
@@ -102,7 +134,7 @@ describe("runClaim", () => {
 
 	it("never lets marker TEXT confer authority — an unauthorized earlier marker does not win", async () => {
 		const out = await run(runClaim, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[
@@ -121,7 +153,7 @@ describe("runClaim", () => {
 
 	it("refuses a failed marker write on 8 — UNKNOWN, and points at confirm", async () => {
 		const out = await run(runClaim, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, errOut("gh: Gateway timeout (HTTP 504)")],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
@@ -132,7 +164,7 @@ describe("runClaim", () => {
 
 	it("refuses a marker that does not read back on 9", async () => {
 		const out = await run(runClaim, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
 			[GET_COMMENT, okOut(JSON.stringify({body: "something else"}))],
 		]);
@@ -141,7 +173,7 @@ describe("runClaim", () => {
 
 	it("refuses an unreadable marker set on 11 — never 'unclaimed'", async () => {
 		const out = await run(runClaim, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
@@ -152,7 +184,7 @@ describe("runClaim", () => {
 
 	it("refuses an unreadable PERMISSION on 11 — a transient read never demotes an author", async () => {
 		const out = await run(runClaim, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, comments({id: 9001, body: MINE})],
@@ -172,10 +204,163 @@ describe("runClaim", () => {
 	});
 });
 
+/**
+ * The fence, at the seam where it has teeth.
+ *
+ * Every refusal below asserts on **`shell.calls`** as well as the exit code: "refuses" and "refuses
+ * before writing anything" are different claims, and only the call log can tell them apart. A claim
+ * that posted and then refused would leave a marker on the issue with nothing to retract it.
+ */
+describe("runClaim — the admission test runs before any marker is written", () => {
+	const FOCUSED = fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44)}});
+
+	const claimWith = (target: ExecResult, fs = FOCUSED, overrides: Partial<typeof options> = {}) => {
+		const shell = fakeShell([
+			[ISSUE, target],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		return Effect.runPromise(
+			Effect.provide(runClaim({...options, ...overrides}), Layer.merge(shell.layer, fs.layer)),
+		).then((out) => ({out, shell}));
+	};
+
+	const OUT_OF_CAMPAIGN = issue({
+		milestone: {number: 39},
+		labels: labelled("type:bug", "p1", "status:triaged", "ready-for:agent"),
+	});
+	const HUMAN_AUDIENCE = issue({
+		milestone: {number: 44},
+		labels: labelled("type:bug", "p1", "status:triaged", "ready-for:human"),
+	});
+
+	it("refuses an out-of-focus issue on 20, and posts NOTHING", async () => {
+		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN);
+		expect(out.code).toBe(OUT_OF_FOCUS);
+		expect(out.stdout).toBe("");
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(out.stderr.some((line) => line.includes("out of focus"))).toBe(true);
+		expect(out.stderr.at(-1)).toContain("nothing was written");
+	});
+
+	it("refuses a non-agent audience on 21 — a sibling axis, never folded into 20", async () => {
+		const {out, shell} = await claimWith(HUMAN_AUDIENCE);
+		expect(out.code).toBe(AUDIENCE_NOT_AGENT);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(out.stderr.some((line) => line.includes("ready-for:human"))).toBe(true);
+	});
+
+	it("refuses an unreadable declaration on 11 — scope is UNKNOWN, never admitted", async () => {
+		const {out, shell} = await claimWith(
+			CLAIMABLE,
+			fakeFs({files: {[DEFAULT_ROADMAP]: null}, unprobeable: [DEFAULT_ROADMAP]}),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(out.stderr.at(-1)).toContain("scope is UNKNOWN, never admitted; nothing was written");
+	});
+
+	it("refuses a malformed declaration on 4 — never read as 'no focus'", async () => {
+		const {out, shell} = await claimWith(
+			CLAIMABLE,
+			fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44).replace("2026-08-09", "the 9th")}}),
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("claims a refused issue under --override, recording the reason on the marker and in the answer", async () => {
+		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN, FOCUSED, {
+			override: "hotfix for the release blocker",
+		});
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "won",
+			number: 4312,
+			token: `build:s-9f2e:${LANE_UUID}`,
+			override: "hotfix for the release blocker",
+		});
+		expect(
+			shell.calls.some(
+				(line) =>
+					POST.test(line) && line.includes("build-claim-override: hotfix for the release blocker"),
+			),
+		).toBe(true);
+	});
+
+	it("never lets --override past an UNKNOWN admission — a failed read has proven nothing", async () => {
+		const {out, shell} = await claimWith(
+			CLAIMABLE,
+			fakeFs({files: {[DEFAULT_ROADMAP]: null}, unprobeable: [DEFAULT_ROADMAP]}),
+			{override: "I know what I am doing"},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses an empty --override reason on 1 — an override is recorded or it is not one", async () => {
+		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN, FOCUSED, {override: "  "});
+		expect(out.code).toBe(FAILED);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("names the declaration it judged against on a win, so an inert-fence claim reads as one", async () => {
+		const {out} = await claimWith(
+			issue({milestone: {number: 44}, labels: labelled("status:triaged", "ready-for:agent")}),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stderr).toContain("build claim: focus: milestone #44, declared 2026-08-09.");
+	});
+
+	it("refuses by NUMBER the very issue the pool excluded — the direct handoff is fenced too", async () => {
+		const row = {
+			number: 4312,
+			labels: ["status:triaged", "ready-for:agent", "type:bug"],
+			milestone: 39,
+		};
+		const picked = await Effect.runPromise(
+			Effect.provide(
+				runPick({repo: null, limit: 20, env: options.env}),
+				Layer.merge(
+					fakeShell([
+						[/labels=status%3Atriaged%2Cp0/, candidates(row)],
+						[/labels=status%3Atriaged%2Cp[12]/, okOut("[]")],
+					]).layer,
+					FOCUSED.layer,
+				),
+			),
+		);
+		expect(JSON.parse(picked.stdout).pool).toEqual([]);
+		expect(JSON.parse(picked.stdout).excluded).toEqual([
+			{number: 4312, home: "39", reason: "out-of-focus"},
+		]);
+
+		// The same issue, handed straight to `claim` by number: the pool was bypassed, the fence is not.
+		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN);
+		expect(out.code).toBe(OUT_OF_FOCUS);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("leaves confirm and release outside the fence — a mid-lane focus edit strands no lane", async () => {
+		const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+			[ISSUE, OUT_OF_CAMPAIGN],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		];
+		const confirmed = await run(runConfirm, script, {}, FOCUSED);
+		expect(confirmed.code).toBe(0);
+		const released = await run(runRelease, script, {}, FOCUSED);
+		expect(released.code).toBe(0);
+	});
+});
+
 describe("runConfirm", () => {
 	it("answers mine when this session holds the earliest authorized marker", async () => {
 		const out = await run(runConfirm, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 9001, body: MINE})],
 			[perm("agent"), okOut("write\n")],
 		]);
@@ -185,7 +370,7 @@ describe("runConfirm", () => {
 
 	it("refuses a foreign holder on 15, naming the token", async () => {
 		const out = await run(runConfirm, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 8000, body: THEIRS})],
 			[perm("agent"), okOut("write\n")],
 		]);
@@ -197,7 +382,7 @@ describe("runConfirm", () => {
 
 	it("refuses proven-unclaimed on 15 too, with the no-claim message", async () => {
 		const out = await run(runConfirm, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[COMMENTS, okOut("[]")],
 		]);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
@@ -210,12 +395,14 @@ describe("runConfirm", () => {
 describe("runRelease", () => {
 	it("retracts this session's OWN marker and nothing else", async () => {
 		const shell = fakeShell([
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 9001, body: MINE})],
 			[perm("agent"), okOut("write\n")],
 			[DELETE, okOut("")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runRelease(options), shell.layer));
+		const out = await Effect.runPromise(
+			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({answer: "released", number: 4312});
 		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
@@ -225,11 +412,13 @@ describe("runRelease", () => {
 
 	it("refuses to release another lane's claim on 15, and deletes nothing", async () => {
 		const shell = fakeShell([
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 8000, body: THEIRS})],
 			[perm("agent"), okOut("write\n")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runRelease(options), shell.layer));
+		const out = await Effect.runPromise(
+			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(out.stderr.at(-1)).toBe(
 			"build release: this session holds no claim on #4312 — refusing to release another lane's.",
@@ -239,7 +428,7 @@ describe("runRelease", () => {
 
 	it("refuses a failed retraction on 8 — whether the claim is still held is UNKNOWN", async () => {
 		const out = await run(runRelease, [
-			[ISSUE, issue()],
+			[ISSUE, CLAIMABLE],
 			[COMMENTS, comments({id: 9001, body: MINE})],
 			[perm("agent"), okOut("write\n")],
 			[once(DELETE), errOut("gh: Gateway timeout (HTTP 504)")],

--- a/packages/fabrika-cli/src/build/claim.ts
+++ b/packages/fabrika-cli/src/build/claim.ts
@@ -37,7 +37,18 @@ const AUTHORIZED = new Set(["admin", "maintain", "write"]);
  */
 const MARKER_RE = /^build-claim:\s*(build:[^\s·]+)\s*(?:·.*)?$/m;
 
-export const composeMarker = (token: string, at: string): string => `build-claim: ${token} · ${at}`;
+/**
+ * The marker body, with an admission override recorded beneath it when one was used.
+ *
+ * The override rides on its **own line** rather than in the marker line: ownership turns on the token
+ * alone, and a reason appended inline would be a free-text field inside the one line the resolver
+ * parses. On a second line the escape hatch leaves the trace ADR 0245 asks for and the marker grammar
+ * is untouched.
+ */
+export const composeMarker = (token: string, at: string, override: string | null = null): string =>
+	override === null
+		? `build-claim: ${token} · ${at}`
+		: `build-claim: ${token} · ${at}\nbuild-claim-override: ${override}`;
 
 /** The token a comment body claims, or `null` when it carries no marker. */
 export const readMarkerToken = (body: string): string | null => {

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -28,6 +28,7 @@ import {runNote} from "./note-verb.ts";
 import {runPick} from "./pick-verb.ts";
 import {runPr} from "./pr-verb.ts";
 import {runPush} from "./push-verb.ts";
+import {ADMISSION_EXIT_CODES} from "./scope-admission.ts";
 import {runScratch} from "./scratch-verb.ts";
 import {runTree} from "./tree-verb.ts";
 import {runVerdicts} from "./verdicts-verb.ts";
@@ -97,7 +98,7 @@ const pick = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		'The ranked candidate pool: status:triaged + ready-for:agent + unassigned, every bucket paginated in full. Prints {"pool":[…],"scanned":{"p0":n,"p1":n,"p2":n}}; an empty pool is a fact on exit 0, readable against the scanned counts. Exits 1 (--limit is not a positive integer), 11 (any bucket read failed — the pool is UNKNOWN, never partial). Example: fabrika build pick --limit 5',
+		'The ranked candidate pool: status:triaged + unassigned + admitted by the shared admission test (scope axis against the ROADMAP.md "## Focus" declaration, audience axis on ready-for:agent), every bucket paginated in full. Prints {"pool":[…],"excluded":[{"number","home","reason"}],"scanned":{"p0":n,"p1":n,"p2":n},"focus":{…}}; each excluded issue names which axis refused it, and an empty pool is a fact on exit 0, readable against the scanned counts. Exits 1 (--limit is not a positive integer), 4 (the "## Focus" declaration reads but does not parse — never read as "no focus"), 11 (any bucket read failed or came back truncated, or the declaration could not be read — the pool is UNKNOWN, never partial and never unfiltered). Example: fabrika build pick --limit 5',
 	),
 );
 
@@ -113,10 +114,24 @@ const eligible = leafCommand(
 	),
 );
 
+/** The admission codes as `--help` prose, enumerated from the module rather than restated (ADR 0245). */
+const admissionExits = ADMISSION_EXIT_CODES.map(
+	({code, condition}) => `${code} (${condition})`,
+).join(", ");
+
 const claim = leafCommand(
 	"claim",
-	{number: issueArg, repo: repoFlag},
-	Effect.fn(function* ({number, repo}) {
+	{
+		number: issueArg,
+		override: Flag.string("override").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"claim an issue the admission test refused on either axis, naming why; the reason is written into the claim marker",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({number, override, repo}) {
 		yield* emit(
 			yield* runClaim({
 				number,
@@ -124,12 +139,13 @@ const claim = leafCommand(
 				env: process.env,
 				uuid: randomUUID(),
 				at: new Date().toISOString(),
+				override: Option.getOrNull(override),
 			}),
 		);
 	}),
 ).pipe(
 	Command.withDescription(
-		'Race the earliest AUTHORIZED claim marker on an issue: post this session\'s token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author\'s repository permission (ADR 0055) — marker text confers nothing. Prints {"answer":"won","number":n,"token":"…"}. A lost race retracts this run\'s own marker and exits 15, never 0; an unset CLAUDE_CODE_SESSION_ID is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 11 (the marker set could not be read — ownership is UNKNOWN, never "unclaimed"), 15 (proven lost). Example: fabrika build claim 4312',
+		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract; --override "<reason>" admits a proven refusal and records the reason on the marker, and an UNKNOWN admission is never overridable. Prints {"answer":"won","number":n,"token":"…"}, plus "override" when one was used. A lost race retracts this run's own marker and exits 15, never 0; an unset CLAUDE_CODE_SESSION_ID, or an empty --override reason, is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 15 (proven lost), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312`,
 	),
 );
 

--- a/packages/fabrika-cli/src/build/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/build/fixtures.test-support.ts
@@ -88,6 +88,10 @@ export const candidates = (
 		),
 	);
 
+/** A `ROADMAP.md` whose `## Focus` table declares one milestone — the fence, switched on. */
+export const focusTable = (milestone: number, declared = "2026-08-09"): string =>
+	`# Roadmap\n\n## Focus\n\n| Milestone | Declared |\n|-----------|------------|\n| #${milestone} | ${declared} |\n\n## Arcs\n`;
+
 /** The claim marker body a session posts. */
 export const marker = (session: string, uuid: string): string =>
 	`build-claim: build:${session}:${uuid} · 2026-08-09T00:00:00Z`;

--- a/packages/fabrika-cli/src/build/github.ts
+++ b/packages/fabrika-cli/src/build/github.ts
@@ -16,7 +16,7 @@ import {
 	type Existence,
 	httpStatusOf,
 	present,
-	splitJsonArrays,
+	scanJsonPages,
 	unknown,
 } from "../io/issues.ts";
 import {isRecord, parseJson} from "../io/json.ts";
@@ -56,6 +56,12 @@ const toCandidate = (value: unknown): CandidateIssue | null => {
  * Typed JSON rather than a `--jq` projection: the filter reads five axes off each row, and a `jq`
  * filter that errors mid-stream on one odd entry shortens the list silently — which is exactly the
  * truncation the caller refuses on.
+ *
+ * `--paginate` asks for every page; **this read proves it got them.** A stream that stops mid-page —
+ * a killed `gh`, a severed transport, a `jq` that died between rows — leaves stdout ending inside a
+ * value, and a scan that only collects the pages that *closed* returns a short list on exit 0: a
+ * partial board that reads as the whole board. Unaccounted bytes are therefore a failure here, which
+ * the pool seats as `11`.
  */
 export const listLabelled = (
 	repo: string,
@@ -68,8 +74,10 @@ export const listLabelled = (
 			`repos/${repo}/issues?state=open&labels=${encodeURIComponent(labels.join(","))}&per_page=100`,
 		]);
 		if (!r.ok) return fail(r.reason);
+		const scanned = scanJsonPages(r.stdout);
+		if (scanned.truncated !== null) return fail(scanned.truncated);
 		const rows: CandidateIssue[] = [];
-		for (const page of splitJsonArrays(r.stdout)) {
+		for (const page of scanned.pages) {
 			const parsed = parseJson(page);
 			if (!Array.isArray(parsed)) {
 				return fail("`gh api` exited 0 but its output is not a list of issues");
@@ -244,8 +252,10 @@ export const listReviews = (
 			`repos/${repo}/pulls/${pr}/reviews?per_page=100`,
 		]);
 		if (!r.ok) return fail(r.reason);
+		const scanned = scanJsonPages(r.stdout);
+		if (scanned.truncated !== null) return fail(scanned.truncated);
 		const rows: ReviewRecord[] = [];
-		for (const page of splitJsonArrays(r.stdout)) {
+		for (const page of scanned.pages) {
 			const parsed = parseJson(page);
 			if (!Array.isArray(parsed)) {
 				return fail("`gh api` exited 0 but its output is not a list of reviews");

--- a/packages/fabrika-cli/src/build/pick-verb.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.ts
@@ -5,21 +5,34 @@
  * The filter is fail-closed on every axis, and two of them are negative tests rather than positive
  * ones:
  *
- * - **`ready-for:agent` must be present.** An issue with no `ready-for:` label is excluded — absence
- *   is an unknown audience, never an agent audience (#4780).
+ * - **The admission test decides both the scope and audience axes**, imported from
+ *   [`./scope-admission.ts`](./scope-admission.ts) and re-derived nowhere (ADR 0245). An issue with
+ *   no `ready-for:` label is excluded — absence is an unknown audience, never an agent audience
+ *   (#4780) — and one homed outside the declared focus is excluded with its own reason.
  * - **Any assignee excludes.** Assignment is the one attribute that keeps a human's live document out
  *   of an agent's pool (#4764, #4693).
  *
  * **Either every bucket was read in full, or the answer is `11`.** v1's pool printed nothing for a
  * failed bucket and kept going, so a `gh` 5xx on the p0 bucket read as "no p0s"
- * (`step1-candidate-pool.sh:12-13`). An empty pool is still a fact and prints on exit 0 with the
- * scanned counts beside it, which is what makes it auditable rather than merely plausible (ADR 0092).
+ * (`step1-candidate-pool.sh:12-13`); a bucket whose paginated output stops mid-page is the same fact
+ * and lands on the same code. An unreadable focus declaration refuses the whole pool too — an
+ * unfiltered pool on a failed read is the fail-open shape the fence exists to remove. An empty pool
+ * is still a fact and prints on exit 0 with the scanned counts and the per-issue exclusion reasons
+ * beside it, which is what makes it auditable rather than merely plausible (ADR 0092).
  */
-import {Effect} from "effect";
+import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
-import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {BAD_SECTIONS, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {type CandidateIssue, listLabelled} from "./github.ts";
+import {
+	admissionOf,
+	exclusionReasonOf,
+	focusReport,
+	focusScopeLine,
+	homeOf,
+	readDeclaredFocus,
+} from "./scope-admission.ts";
 import {resolveTargetRepo} from "./target.ts";
 
 const VERB = "build pick";
@@ -30,14 +43,6 @@ type Bucket = (typeof BUCKETS)[number];
 
 /** The four types an agent lane may take. `type:decision` and `type:epic` never enter. */
 const TYPES = new Set(["type:feature", "type:chore", "type:bug", "type:investigation"]);
-
-/**
- * The lane labels that stand in for a milestone.
- *
- * A standing lane is a home an issue can have without a milestone, so reporting `null` for one would
- * read as unhomed. The set is closed: a new lane is a deliberate edit here, not a pattern match.
- */
-const STANDING_LANES = ["wayfinder:backlog", "axis:pipeline-hardening"] as const;
 
 export interface PickOptions {
 	readonly repo: string | null;
@@ -53,17 +58,23 @@ interface PoolEntry {
 	readonly home: string | null;
 }
 
-const homeOf = (issue: CandidateIssue): string | null =>
-	issue.milestone !== null
-		? String(issue.milestone)
-		: (STANDING_LANES.find((lane) => issue.labels.includes(lane)) ?? null);
+/** One issue the admission test kept out, with the axis that refused it (#5013). */
+interface ExclusionEntry {
+	readonly number: number;
+	readonly home: string | null;
+	readonly reason: NonNullable<ReturnType<typeof exclusionReasonOf>>;
+}
 
-/** Whether a row survives every axis of the filter. */
+/**
+ * The axes that are this verb's own — board hygiene, not admission.
+ *
+ * The audience axis is deliberately absent: it lives in the admission test with the scope axis, so an
+ * issue it excludes can be *reported* with its reason instead of vanishing from the pool unexplained.
+ */
 export const isCandidate = (issue: CandidateIssue): boolean => {
 	if (issue.isPullRequest || issue.assigned) return false;
 	const status = issue.labels.filter((label) => label.startsWith("status:"));
 	if (status.length !== 1 || status[0] !== "status:triaged") return false;
-	if (!issue.labels.includes("ready-for:agent")) return false;
 	return issue.labels.filter((label) => label.startsWith("type:")).every((t) => TYPES.has(t));
 };
 
@@ -81,7 +92,11 @@ const rankWithinBucket = (a: PoolEntry, b: PoolEntry): number => {
 
 export const runPick = (
 	options: PickOptions,
-): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
 	Effect.gen(function* () {
 		if (!Number.isInteger(options.limit) || options.limit <= 0) {
 			return refuse(FAILED, `${VERB}: --limit "${options.limit}" is not a positive integer.`);
@@ -89,8 +104,24 @@ export const runPick = (
 		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
 		if (resolved._tag === "Refused") return resolved.outcome;
 
+		const read = yield* readDeclaredFocus();
+		if (read._tag === "Unreadable") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the "## Focus" declaration: ${read.reason} — the pool is UNKNOWN, never unfiltered.`,
+			);
+		}
+		const focus = read.focus;
+		if (focus._tag === "Malformed") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the "## Focus" declaration does not parse: ${focus.reason} — the pool is UNKNOWN, and a malformed declaration is never read as "no focus".`,
+			);
+		}
+
 		const scanned: Record<Bucket, number> = {p0: 0, p1: 0, p2: 0};
 		const pool: PoolEntry[] = [];
+		const excluded: ExclusionEntry[] = [];
 		for (const bucket of BUCKETS) {
 			const listed = yield* listLabelled(resolved.repo, ["status:triaged", bucket]);
 			if (listed._tag === "Failure") {
@@ -100,17 +131,34 @@ export const runPick = (
 				);
 			}
 			scanned[bucket] = listed.value.length;
-			const entries = listed.value.filter(isCandidate).map((issue) => ({
-				number: issue.number,
-				title: issue.title,
-				priority: bucket,
-				type: typeOf(issue),
-				home: homeOf(issue),
-			}));
+			const entries: PoolEntry[] = [];
+			for (const issue of listed.value.filter(isCandidate)) {
+				const reason = exclusionReasonOf(admissionOf(focus, issue));
+				if (reason !== null) {
+					excluded.push({number: issue.number, home: homeOf(issue), reason});
+					continue;
+				}
+				entries.push({
+					number: issue.number,
+					title: issue.title,
+					priority: bucket,
+					type: typeOf(issue),
+					home: homeOf(issue),
+				});
+			}
 			pool.push(...entries.sort(rankWithinBucket));
 		}
 
-		return answer(JSON.stringify({pool: pool.slice(0, options.limit), scanned}), [
-			`${VERB}: scanned p0 ${scanned.p0}, p1 ${scanned.p1}, p2 ${scanned.p2} in ${resolved.repo}; ${pool.length} candidate(s) survived the filter.`,
-		]);
+		return answer(
+			JSON.stringify({
+				pool: pool.slice(0, options.limit),
+				excluded,
+				scanned,
+				focus: focusReport(focus),
+			}),
+			[
+				`${VERB}: scanned p0 ${scanned.p0}, p1 ${scanned.p1}, p2 ${scanned.p2} in ${resolved.repo}; ${pool.length} candidate(s) survived the filter, ${excluded.length} excluded by the admission test.`,
+				focusScopeLine(VERB, focus),
+			],
+		);
 	});

--- a/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.unit.test.ts
@@ -1,11 +1,12 @@
-import {Effect} from "effect";
+import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {FAILED} from "../verb.ts";
-import {PRECONDITION_UNKNOWN} from "./codes.ts";
-import {candidates} from "./fixtures.test-support.ts";
+import {BAD_SECTIONS, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {candidates, focusTable} from "./fixtures.test-support.ts";
 import {runPick} from "./pick-verb.ts";
+import {DEFAULT_ROADMAP} from "./scope-admission.ts";
 
 const bucket = (priority: string) =>
 	new RegExp(
@@ -21,14 +22,30 @@ const options = {
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
+/** No `ROADMAP.md` at all: a well-formed "no focus declared", so the scope axis admits everything. */
+const NO_FOCUS = fakeFs({files: {}});
+
 const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
+	fs = NO_FOCUS,
 ) =>
-	Effect.runPromise(Effect.provide(runPick({...options, ...overrides}), fakeShell(script).layer));
+	Effect.runPromise(
+		Effect.provide(
+			runPick({...options, ...overrides}),
+			Layer.merge(fakeShell(script).layer, fs.layer),
+		),
+	);
 
 const pool = (out: {stdout: string}) =>
 	JSON.parse(out.stdout).pool as ReadonlyArray<{number: number}>;
+
+const excluded = (out: {stdout: string}) =>
+	JSON.parse(out.stdout).excluded as ReadonlyArray<{
+		number: number;
+		home: string | null;
+		reason: string;
+	}>;
 
 describe("runPick", () => {
 	it("ranks p0 before p1 before p2, and milestone order inside a bucket", async () => {
@@ -54,6 +71,7 @@ describe("runPick", () => {
 			[bucket("p2"), EMPTY],
 		]);
 		expect(pool(out)).toEqual([]);
+		expect(excluded(out)).toEqual([{number: 500, home: null, reason: "audience-not-agent"}]);
 	});
 
 	it("excludes an assigned issue — assignment keeps a human's document out (#4764)", async () => {
@@ -99,7 +117,12 @@ describe("runPick", () => {
 			[bucket("p2"), candidates({number: 9, labels: ["status:triaged", "p2"]})],
 		]);
 		expect(out.code).toBe(0);
-		expect(JSON.parse(out.stdout)).toEqual({pool: [], scanned: {p0: 0, p1: 0, p2: 1}});
+		expect(JSON.parse(out.stdout)).toEqual({
+			pool: [],
+			excluded: [{number: 9, home: null, reason: "audience-not-agent"}],
+			scanned: {p0: 0, p1: 0, p2: 1},
+			focus: {state: "none"},
+		});
 	});
 
 	it("refuses a failed bucket read on 11 — a 5xx on p0 never reads as 'no p0s'", async () => {
@@ -121,7 +144,9 @@ describe("runPick", () => {
 			[bucket("p1"), EMPTY],
 			[bucket("p2"), EMPTY],
 		]);
-		await Effect.runPromise(Effect.provide(runPick(options), shell.layer));
+		await Effect.runPromise(
+			Effect.provide(runPick(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+		);
 		expect(shell.calls.filter((line) => line.includes("--paginate"))).toHaveLength(3);
 	});
 
@@ -129,6 +154,105 @@ describe("runPick", () => {
 		const out = await run([], {limit: 0});
 		expect(out.code).toBe(FAILED);
 		expect(out.stderr.at(-1)).toBe('build pick: --limit "0" is not a positive integer.');
+	});
+
+	it("refuses a bucket whose paginated output stops mid-page on 11 — a partial board never reads as the whole board", async () => {
+		const whole = candidates(
+			{number: 1, labels: [...TRIAGED, "p0"]},
+			{number: 2, labels: [...TRIAGED, "p0"]},
+		).stdout;
+		const out = await run([
+			[bucket("p0"), okOut(whole.slice(0, whole.length - 30))],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("does not end on a page boundary");
+		expect(out.stderr.at(-1)).toContain("the pool is UNKNOWN, never partial");
+	});
+
+	it("refuses a bucket whose SECOND page is cut short — the complete first page is not the answer", async () => {
+		const first = candidates({number: 1, labels: [...TRIAGED, "p0"]}).stdout;
+		const second = candidates({number: 2, labels: [...TRIAGED, "p0"]}).stdout;
+		const out = await run([
+			[bucket("p0"), okOut(first + second.slice(0, 20))],
+			[bucket("p1"), EMPTY],
+			[bucket("p2"), EMPTY],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("excludes an out-of-focus issue with its reason, and keeps the in-focus one", async () => {
+		const out = await run(
+			[
+				[
+					bucket("p0"),
+					candidates(
+						{number: 500, labels: [...TRIAGED, "p0"], milestone: 44},
+						{number: 400, labels: [...TRIAGED, "p0"], milestone: 39},
+					),
+				],
+				[bucket("p1"), EMPTY],
+				[bucket("p2"), EMPTY],
+			],
+			{},
+			fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44)}}),
+		);
+		expect(out.code).toBe(0);
+		expect(pool(out).map((row) => row.number)).toEqual([500]);
+		expect(excluded(out)).toEqual([{number: 400, home: "39", reason: "out-of-focus"}]);
+		expect(JSON.parse(out.stdout).focus).toEqual({state: "declared", milestone: "44"});
+	});
+
+	it("admits a standing-lane issue under a declared focus — a lane is milestone-less by design", async () => {
+		const out = await run(
+			[
+				[bucket("p0"), candidates({number: 500, labels: [...TRIAGED, "p0", "wayfinder:backlog"]})],
+				[bucket("p1"), EMPTY],
+				[bucket("p2"), EMPTY],
+			],
+			{},
+			fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44)}}),
+		);
+		expect(pool(out).map((row) => row.number)).toEqual([500]);
+		expect(excluded(out)).toEqual([]);
+	});
+
+	it("refuses an unreadable focus declaration on 11 — never an unfiltered pool", async () => {
+		const out = await run(
+			[[bucket("p0"), EMPTY]],
+			{},
+			fakeFs({files: {[DEFAULT_ROADMAP]: null}, unprobeable: [DEFAULT_ROADMAP]}),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("the pool is UNKNOWN, never unfiltered");
+	});
+
+	it("refuses a malformed focus declaration on 4 — malformed is never read as 'no focus'", async () => {
+		const out = await run(
+			[[bucket("p0"), EMPTY]],
+			{},
+			fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44).replace("#44", "forty-four")}}),
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never read as "no focus"');
+	});
+
+	it("says on stderr which declaration it judged against", async () => {
+		const out = await run(
+			[
+				[bucket("p0"), EMPTY],
+				[bucket("p1"), EMPTY],
+				[bucket("p2"), EMPTY],
+			],
+			{},
+			fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44)}}),
+		);
+		expect(out.stderr.at(-1)).toBe("build pick: focus: milestone #44, declared 2026-08-09.");
 	});
 
 	it("caps the pool at --limit after ranking", async () => {

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -348,18 +348,51 @@ export const listOpenMilestones = (repo: string): Shell<Attempt<ReadonlyArray<Mi
 	});
 
 /**
- * Split `gh api --paginate`'s concatenated top-level JSON values back into one string per page.
+ * The pages a paginated read produced, or the proof that its output stopped mid-flight.
+ *
+ * `Truncated` exists because the alternative is a partial answer that reads as a complete one: a
+ * paginated read whose stdout ends inside a page yields *fewer* rows and no error at all, so a caller
+ * that only ever sees pages cannot tell "the board holds three issues" from "the read died after
+ * three". A caller that receives `Truncated` seats it as UNKNOWN.
+ */
+export interface JsonPages {
+	/** Every page that closed. Complete pages stay readable even when a later one is cut short. */
+	readonly pages: ReadonlyArray<string>;
+	/** Why the output does not end on a page boundary, or `null` when every byte was accounted for. */
+	readonly truncated: string | null;
+}
+
+/**
+ * Split `gh api --paginate`'s concatenated top-level JSON values back into one string per page, and
+ * say so when the output does not end on a page boundary.
  *
  * `--paginate` emits `[…][…]` with no separator, which `JSON.parse` rejects outright — so a
  * single-parse read would fail on exactly the responses pagination exists to reach. Bracket depth is
  * counted outside string literals only, so a `[` inside a comment body cannot split a page.
+ *
+ * Truncation is **everything the scan could not account for**, not an end-of-input special case: an
+ * unclosed value, an unterminated string, a stray `]`, or any non-whitespace byte sitting outside a
+ * completed page. Testing the leftovers rather than the final depth is what makes a half-written page
+ * in the *middle* of the stream as visible as one at its end.
  */
-export const splitJsonArrays = (stdout: string): ReadonlyArray<string> => {
+/** Non-whitespace characters in `[from, to)` — bytes no closed page accounts for. */
+const countOutsideWhitespace = (text: string, from: number, to: number): number => {
+	let count = 0;
+	for (let i = from; i < to; i++) {
+		if (!/\s/.test(text[i] ?? "")) count++;
+	}
+	return count;
+};
+
+export const scanJsonPages = (stdout: string): JsonPages => {
 	const pages: string[] = [];
 	let depth = 0;
 	let start = -1;
 	let inString = false;
 	let escaped = false;
+	/** The index just past the last closed page — everything before it is accounted for. */
+	let closed = 0;
+	let stray = 0;
 	for (let i = 0; i < stdout.length; i++) {
 		const c = stdout[i];
 		if (inString) {
@@ -375,13 +408,29 @@ export const splitJsonArrays = (stdout: string): ReadonlyArray<string> => {
 		} else if (c === "]" || c === "}") {
 			depth--;
 			if (depth === 0 && start >= 0) {
+				stray += countOutsideWhitespace(stdout, closed, start);
 				pages.push(stdout.slice(start, i + 1));
+				closed = i + 1;
 				start = -1;
+			} else if (depth < 0) {
+				depth = 0;
+				stray++;
 			}
 		}
 	}
-	return pages;
+	stray += countOutsideWhitespace(stdout, closed, stdout.length);
+	return {
+		pages,
+		truncated:
+			stray === 0
+				? null
+				: `the paginated output does not end on a page boundary — ${pages.length} complete page(s), then ${stray} byte(s) of an incomplete one`,
+	};
 };
+
+/** The complete pages alone, for a read whose caller does not seat truncation itself. */
+export const splitJsonArrays = (stdout: string): ReadonlyArray<string> =>
+	scanJsonPages(stdout).pages;
 
 /** One issue comment, as a claim scan reads it. */
 export interface CommentRecord {

--- a/packages/fabrika-cli/src/io/issues.unit.test.ts
+++ b/packages/fabrika-cli/src/io/issues.unit.test.ts
@@ -14,6 +14,7 @@ import {
 	parseTabRows,
 	patchIssueBody,
 	removeLabel,
+	scanJsonPages,
 	setMilestone,
 	splitJsonArrays,
 } from "./issues.ts";
@@ -50,6 +51,36 @@ describe("splitJsonArrays", () => {
 
 	it("does not split on an escaped quote inside a string", () => {
 		expect(splitJsonArrays('[{"body":"a \\" ] b"}]')).toEqual(['[{"body":"a \\" ] b"}]']);
+	});
+});
+
+describe("scanJsonPages — a read that stopped mid-flight says so", () => {
+	it("accounts for every byte of a whole read, whitespace between pages included", () => {
+		expect(scanJsonPages("[1]\n[2]\n")).toEqual({pages: ["[1]", "[2]"], truncated: null});
+	});
+
+	it("reports an unclosed page — the shape a killed `gh` leaves behind", () => {
+		const scanned = scanJsonPages('[{"number":1},{"num');
+		expect(scanned.pages).toEqual([]);
+		expect(scanned.truncated).toContain("does not end on a page boundary");
+	});
+
+	it("keeps the complete pages AND reports the cut-short one after them", () => {
+		const scanned = scanJsonPages('[{"number":1}][{"num');
+		expect(scanned.pages).toEqual(['[{"number":1}]']);
+		expect(scanned.truncated).not.toBeNull();
+	});
+
+	it("reports a stray closing bracket rather than swallowing it", () => {
+		expect(scanJsonPages("[1]]").truncated).not.toBeNull();
+	});
+
+	it("reports an unterminated string, where the cut fell inside a body", () => {
+		expect(scanJsonPages('[{"body":"half a sen').truncated).not.toBeNull();
+	});
+
+	it("reads empty output as zero pages, not as truncation", () => {
+		expect(scanJsonPages("")).toEqual({pages: [], truncated: null});
 	});
 });
 


### PR DESCRIPTION
The scope-admission predicate that landed with #5015 was a module nobody called. This PR calls it from the two places that decide whether a lane opens: `build pick`, which now reports every issue it excluded and which axis refused it, and `build claim`, which runs the same test *before* it writes any claim marker — so handing a verb an issue number no longer walks around the fence. It also closes the pagination half of the fence's UNKNOWN rule: a paginated board read whose output stops mid-page is now a refusal, not a short list on exit 0.

Fixes #5016

## What changed

- **`build pick`** (`packages/fabrika-cli/src/build/pick-verb.ts`) reads the `## Focus` declaration once, then runs `admissionOf` per issue. The answer gains `excluded` (`{number, home, reason}` per excluded issue) and `focus`, and stderr gains the scope line. An unreadable declaration is `11`, a malformed one is `4` — never an unfiltered pool.
- **`build claim`** (`packages/fabrika-cli/src/build/claim-verb.ts`) runs the same test after the target-open check and **before** `createComment`. Proven refusals seat `20` / `21` through the module's own `admissionRefusal`, so the two axes stay separately named and separately seated. `--override "<reason>"` admits a proven refusal and records it on the marker (`build-claim-override:` on its own line, leaving the marker grammar untouched) and in the answer. `confirm` and `release` never run the fence.
- **Truncated paginated reads** (`packages/fabrika-cli/src/io/issues.ts`, `packages/fabrika-cli/src/build/github.ts`): a new `scanJsonPages` accounts for every non-whitespace byte of `gh api --paginate` output and reports what no closed page covers. `listLabelled` and `listReviews` now fail on it, which the pool seats as `11`. `splitJsonArrays` keeps its old lenient behaviour for its existing callers.
- **The build-side duplicate lane set is gone.** `pick-verb.ts` no longer carries its own `STANDING_LANES` or `homeOf`; both come from `scope-admission.ts`. The audience test moved out of `isCandidate` for the same reason — one admission test, imported twice.
- **`--help` reads the codes from the module**: `build claim`'s description enumerates `ADMISSION_EXIT_CODES` rather than restating them.

## How the truncated read resolves UNKNOWN, and the test that proves it

`gh api --paginate` output is a concatenation of top-level JSON values. The old scan collected the values that *closed* and silently dropped anything after the last one — so a stream cut mid-page (a killed `gh`, a severed transport) yielded a **shorter list on exit 0**: a partial board that reads as the whole board. `scanJsonPages` now counts the non-whitespace bytes outside every closed page; any leftover is `truncated`, `listLabelled` turns that into a failure, and `build pick` refuses on `11` with `the pool is UNKNOWN, never partial`.

Falsifiable, and checked: deleting the two `if (scanned.truncated !== null) return fail(...)` lines turns `pick-verb.unit.test.ts`'s two truncation tests red (both drop from `11` to `0` with a partial pool). The tests cover both shapes — output cut inside its only page, and a complete first page followed by a cut-short second — plus six direct `scanJsonPages` cases in `io/issues.unit.test.ts`.

## Verified

- `pnpm typecheck --force` (30/30, 0 cached), `pnpm lint:worktree`, `pnpm --filter @kampus/fabrika-cli exec vitest run` (1971 passed).
- Live smoke run against the board: `build pick --limit 3` reports `focus: milestone #44` and 284 exclusions with per-issue reasons; `build claim 4312` (homed in milestone 24) refuses on `20` — and a re-read of that issue's comments confirms **zero** claim markers were written.

## Deviations

- **Narrowed a suggested fix-shape — refusal wording.** *Said:* the contract's error table spells the claim refusals as `#<n> is homed in milestone <home>, outside the declared focus #<focus> — …`. *Did:* used the shipped `admissionRefusal` message from `scope-admission.ts` and added a separate `nothing was written …; pass --override` line beside it. *Why:* re-typing the message at the seam is the second derivation AC5 bans, and `admissionRefusal` is the single source #5015 landed for exactly this. *Disposition:* no action needed — the code and both facts (which axis, that nothing was written) are on stderr; for the reviewer to judge if the literal wording is load-bearing.
- **Split one contract line into two.** *Said:* the contract's `build pick` example prints one stderr scope line carrying both the scanned counts and the declaration. *Did:* emit the counts line and then `focusScopeLine`'s line. *Why:* `focusScopeLine` already prefixes the verb name, so fusing them would either duplicate the prefix or fork the module's message. *Disposition:* no action needed.
- **Widened the truncation guard by one call site.** *Said:* the ticket names the pool and claim seams. *Did:* also guarded `listReviews` in the same file. *Why:* leaving the sibling paged read in the same module unguarded would ship the defect class half-fixed. *Disposition:* no action needed.
- **Added `--override`, which the issue body does not mention.** *Why:* the contract's `build claim` clause requires it, and without it a declared focus is a hard wall with no recorded escape. It refuses an empty reason on `1`, and it deliberately does **not** admit an UNKNOWN admission — a read that failed has proven nothing to override. *Disposition:* no action needed.
- **Left the triage-side duplicates alone.** *Said:* the dispatch note names four copies of the standing-lane set; `triage/facets.ts` and `triage/homes-verb.ts` are the other two. *Did:* collapsed only the build-side copy. *Why:* the note scopes this ticket to the build side, and the triage verbs are a separate group with their own contract. *Disposition:* for the reviewer to judge — noted here so it is not lost; no ticket filed, as milestone 44 owns the fabrika scope.