### PR TITLE
fix(fabrika-cli): make a LEDGER_ROW_VERSION bump red the below-current guard (#5116)

### DIFF
--- a/packages/fabrika-cli/src/spend/ledger.ts
+++ b/packages/fabrika-cli/src/spend/ledger.ts
@@ -23,7 +23,19 @@ import type {RunSpend, StageSpend} from "./token-spend.ts";
  */
 export const DEFAULT_SPEND_LEDGER_PATH = ".fabrika/spend-ledger.jsonl";
 
-/** The shape version stamped on every line — the seam a later row shape evolves through. */
+/**
+ * The shape version stamped on every line — the seam a later row shape evolves through.
+ *
+ * **Bumping this past 1 is not a one-line change.** {@link decodeLine} has no below-current branch:
+ * any `v` that is not the current one is damage. That reading is right only while the current version
+ * is the first one ever written, because then no ledger can hold an older line. At `2`, every intact
+ * `v: 1` row starts counting as `malformed` and drops out of the roll-up — the operator is told their
+ * measurements are corrupt while the totals quietly shrink (#5116). So a bump has to decide, in the
+ * same change, what an older intact row becomes: decode it into a {@link LedgerRow}, or count it under
+ * a skip of its own that every {@link LedgerSkips} reader renders. Until one of those lands the bump
+ * reds the below-current guard in `ledger.unit.test.ts`, which is what keeps the decision from being
+ * skipped by someone who never read this.
+ */
 export const LEDGER_ROW_VERSION = 1;
 
 /**
@@ -52,8 +64,8 @@ export interface LedgerRow {
  * the rows are still there and the action is to upgrade the CLI. One counter reported both as "40
  * lines lost", which is a false alarm in one direction and a missed data loss in the other.
  *
- * A `v` *below* the current one counts as malformed on purpose: v1 is the first shape ever written,
- * so there is no older ledger for such a line to have come from.
+ * A `v` *below* the current one counts as malformed, which is true only while the current version is
+ * the first one ever written — see {@link LEDGER_ROW_VERSION} for what a bump obliges.
  */
 export interface LedgerSkips {
 	/** Lines that will never decode — a truncated tail, a partial write, corruption. Data loss. */

--- a/packages/fabrika-cli/src/spend/ledger.unit.test.ts
+++ b/packages/fabrika-cli/src/spend/ledger.unit.test.ts
@@ -51,6 +51,14 @@ const row = (overrides: Partial<LedgerRow> = {}): LedgerRow => ({
 	...overrides,
 });
 
+/**
+ * Widened deliberately. `LEDGER_ROW_VERSION` carries a literal type, so testing it through the
+ * constant itself is a tautology today and a `TS2367` "no overlap" error after a bump — and a
+ * typecheck error tells the bumper nothing about what to do. Widening keeps the below-current guard
+ * a runtime comparison, so the bump lands as a red test carrying its instructions.
+ */
+const CURRENT_VERSION: number = LEDGER_ROW_VERSION;
+
 const withTempDir = async (body: (dir: string) => Promise<void>): Promise<void> => {
 	const dir = mkdtempSync(join(tmpdir(), "fabrika-spend-ledger-"));
 	try {
@@ -169,9 +177,18 @@ describe("readSpendLedger — tolerant of anything a partial write can leave beh
 		assert.strictEqual(read.skipped, 2);
 	});
 
-	it("counts a version BELOW the current one as damage — v1 is the first shape ever written", () => {
-		const older = JSON.stringify({...JSON.parse(encodeSpendRows([row()]).trim()), v: 0});
-		assert.deepStrictEqual(readSpendLedger(`${older}\n`).skips, {malformed: 1, newerVersion: 0});
+	it("stops calling a below-current row damage the moment an older shape can exist (#5116)", () => {
+		const older = JSON.stringify({
+			...JSON.parse(encodeSpendRows([row()]).trim()),
+			v: CURRENT_VERSION - 1,
+		});
+		const {skips} = readSpendLedger(`${older}\n`);
+		assert.strictEqual(skips.newerVersion, 0);
+		assert.strictEqual(
+			skips.malformed,
+			CURRENT_VERSION === 1 ? 1 : 0,
+			`LEDGER_ROW_VERSION is ${CURRENT_VERSION}, so a v${CURRENT_VERSION - 1} line is an intact row written by an older shape — and readSpendLedger still counts it under \`malformed\`, which tells the operator their measurements are damaged while dropping real spend out of the roll-up. Decide it in the bumping change: decode the older shape into a LedgerRow, or count it under a skip of its own that rollup.ts and rollup-verb.ts both render. This guard goes green again by itself once either lands.`,
+		);
 	});
 
 	it("keeps `skipped` the sum of its halves, so a caller that only wants the gap still gets it", () => {


### PR DESCRIPTION
The spend ledger reader treats any row version that is not the current one as damage. That is right today, because `LEDGER_ROW_VERSION` is 1 and nothing older can exist — but the day someone bumps it to 2, every intact `v: 1` row starts being reported as corruption and dropped out of the roll-up. The operator would be told their measurements are damaged while the totals quietly shrink.

Nothing marked that coupling, so the bump looks safe. This PR makes the bump itself red a test that says, in its failure message, exactly what the bumper has to decide. No production behaviour changes.

Fixes #5116

## What changed

- `packages/fabrika-cli/src/spend/ledger.ts` — the `LEDGER_ROW_VERSION` docblock now states what a bump obliges (decode the older shape, or count it under a skip of its own), and the `LedgerSkips` docblock's below-current paragraph names its expiry instead of asserting a rationale that stops being true at `2`. It points at the constant rather than restating the why.
- `packages/fabrika-cli/src/spend/ledger.unit.test.ts` — the below-current test now derives its expectation from `LEDGER_ROW_VERSION` instead of hardcoding `v: 0`, so a bump reds it.

No source behaviour changed: the diff is a docblock and a test.

## The guard, and proof it can fail

```ts
const {skips} = readSpendLedger(`${older}\n`);
assert.strictEqual(skips.newerVersion, 0);
assert.strictEqual(skips.malformed, CURRENT_VERSION === 1 ? 1 : 0, "<the instructions>");
```

Verified by flipping the constant to `2` locally, running the suite, and reverting:

```
FAIL  src/spend/ledger.unit.test.ts > readSpendLedger … > stops calling a below-current row
      damage the moment an older shape can exist (#5116)
AssertionError: LEDGER_ROW_VERSION is 2, so a v1 line is an intact row written by an older
shape — and readSpendLedger still counts it under `malformed`, which tells the operator their
measurements are damaged while dropping real spend out of the roll-up. Decide it in the bumping
change: decode the older shape into a LedgerRow, or count it under a skip of its own that
rollup.ts and rollup-verb.ts both render. This guard goes green again by itself once either
lands.: expected 1 to equal +0
```

Exactly one test in the package reds on the bump; the other 1970 stay green, so the guard is
specific rather than a suite-wide tripwire.

It also **self-retires**. Once the bumping change handles older rows — either by decoding them
into a `LedgerRow`, or by counting them under a distinct skip — `skips.malformed` is `0` and the
guard is green again with no edit. A guard that has to be remembered and deleted is a guard that
gets deleted without being read.

## Why this remedy and not the other two

Triage put two remedies on the table and left the choice open.

**Migrate-on-read is not buildable today.** `v: 1` is the first shape this tool ever wrote, so
there is no older shape to decode. It becomes real only once a `v: 2` shape exists, and at that
moment it is the bumping change's own work.

**A third `olderVersion` counter was the close call, and I declined it.** Three reasons:

1. **It does not stop the regression, it relabels it.** Someone who bumps to `2` with an
   `olderVersion` counter in place still silently drops every `v: 1` measurement from
   `rollup.totals` — they just get a nicer word for it, with nothing red anywhere. The thing that
   actually has to be impossible is the *silent* bump, and only a failing check does that.
2. **It trades a future false alarm for a present one.** A below-current `v` today can only be
   `v: 0` or negative — corruption, or a foreign file. `malformed` is the correct reading for
   those, and an `olderVersion` bucket would tell the operator "older shape, upgrade the CLI"
   about a genuinely damaged line. Triage named this cost explicitly.
3. **It pre-decides a question that belongs to the bumping change.** Routing old rows to a skip
   counter hardcodes "drop them, do not decode them" for a shape nobody has designed yet. The
   guard leaves both doors open and hands the choice to whoever actually knows what `v: 2` looks
   like.

So the coupling marker is the remedy, and the two docblocks carry the reasoning so the message and
the code agree.

## Acceptance criteria

- [x] Bumping `LEDGER_ROW_VERSION` past `1` without handling `version < LEDGER_ROW_VERSION` fails a check — proven red above.
- [x] The mechanism is exercised by a test in `packages/fabrika-cli/src/spend/ledger.unit.test.ts`, not left as a comment.
- [x] `readSpendLedger`'s behaviour for every input that can exist today is unchanged — no production code changed at all.
- [x] No third `LedgerSkips` counter was added, so no skips reader needed updating. `rollup.ts` and `rollup-verb.ts` are untouched.
- [x] The below-current rationale in `ledger.ts` now names its expiry.

## Verification

- `pnpm vitest run` in `packages/fabrika-cli` — 135 files, 1971 tests, all green.
- `pnpm typecheck --force` — 30/30 tasks, 0 cached, all resolved inside this worktree.
- `pnpm lint:worktree` — 2 files checked, clean.

## Deviations

**1 · Declined a remedy the issue offered (class: narrowed a suggested fix-shape).**
- *Said:* the issue offered two remedies — migrate-on-read, or a third `olderVersion` counter — and left the pick to the implementer.
- *Did:* took neither. Shipped a behavioural coupling marker instead: a test whose expectation is derived from `LEDGER_ROW_VERSION`, so the bump reds it.
- *Why:* migrate-on-read has no older shape to decode; the `olderVersion` counter relabels the failure without preventing the silent bump, mis-reads today's genuinely-corrupt `v: 0` lines as "older shape", and pre-decides drop-vs-decode for a shape nobody has designed. Reasoning in full above.
- *Disposition:* for the reviewer to judge. Both alternatives stay open to whoever defines `v: 2`, and the guard goes green on its own if they take either.

**2 · Replaced an existing test rather than adding beside it (class: changed a test that asserted the old behaviour).**
- *Said:* the ACs asked for a test; they did not say to touch the existing `"counts a version BELOW the current one as damage — v1 is the first shape ever written"` case.
- *Did:* replaced it. The new guard covers the same input (`v: CURRENT_VERSION - 1` is `v: 0` today) and asserts the same classification, plus the coupling.
- *Why:* keeping both would leave two tests asserting the same thing today, one of which is silently wrong after a bump — the exact rot this issue is about.
- *Disposition:* no action needed. Coverage is a superset: the old test's `newerVersion: 0` claim is kept as its own unconditional assertion.

**3 · Widened the constant's type in the test (class: a deliberate-looking-wrong line).**
- *Said:* nothing about types.
- *Did:* `const CURRENT_VERSION: number = LEDGER_ROW_VERSION;` with a docblock explaining it.
- *Why:* `LEDGER_ROW_VERSION` carries a literal type, so comparing it to `1` through the constant is a tautology today and a `TS2367` "no overlap" **typecheck** error after a bump. A typecheck error tells the bumper nothing about what to do; the widened comparison lands as a red test carrying the instructions.
- *Disposition:* no action needed, and the reason is stated at the line.

**4 · Filed no new `.patterns/` doc (class: declined a convention obligation).**
- *Said:* CLAUDE.md asks that a pattern you rely on be documented in `.patterns/`.
- *Did:* did not add a doc for the version-bump coupling guard.
- *Why:* `.patterns/index.md`'s own criteria require a pattern used in **2+ places**; this is one site. `.patterns/unconditional-test-assertions.md` already governs the shape the test had to take, and it is satisfied — both assertions are unconditional, no `if`.
- *Disposition:* no action needed. Worth a doc if a second version-coupled constant ever appears.

**5 · Nothing filed outside milestone 44.**
- *Said:* scope is fabrika only.
- *Did:* found no out-of-scope defect worth a note. `packages/fabrika-cli/src/spend/` still has zero imports from `../eval/`; that edge is untouched.
- *Disposition:* no action needed.
