### PR TITLE
docs(development): route the builder front door to claude-plugins/fabrika/skills/ (#5109)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -163,6 +163,14 @@ flowchart LR
 
 Two more skills serve the docs rather than the chain: [`adr`](./.claude/skills/adr/SKILL.md) records a decision in `.decisions/`, and [`deslop-comments`](./.claude/skills/deslop-comments/SKILL.md) cuts comments that bury the code.
 
+### fabrika — the replacement pipeline, growing beside this one
+
+The chain above is **v1**. Its replacement, **fabrika**, is being rebuilt from first principles as its own plugin under [`claude-plugins/fabrika/`](./claude-plugins/fabrika/): it re-implements v1's work instead of calling into it, so v1 stays deletable (ADR [0238](./.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)).
+
+The skills that have landed live in [`claude-plugins/fabrika/skills/`](./claude-plugins/fabrika/skills/), one directory per skill — **that directory is the list.** Get the current set the way you get the ADRs (ADR [0129](./.decisions/0129-adr-discovery-is-the-claude-md-contract.md)): `ls claude-plugins/fabrika/skills/` for the names, each `SKILL.md`'s frontmatter for its one-line description. Nothing here freezes that list into a table, because the set is still filling one authoring session at a time and a copy would be stale before you read it.
+
+Two things before you map a fabrika skill onto the v1 table above: the nouns moved — `build` is the text-construction skill and `review` is a single skill, not v1's `review-*` family (ADR [0242](./.decisions/0242-fabrika-skill-nouns-redefine-build-and-review.md)) — and the conventions every fabrika skill is held to live in [`claude-plugins/fabrika/docs/`](./claude-plugins/fabrika/docs/README.md).
+
 ## Ops runbooks
 
 When the running system breaks, the procedures live in **[ops/](./ops/README.md)** — a peer


### PR DESCRIPTION
`DEVELOPMENT.md` is the front door a builder reads to learn how work moves through this repo, and it described the pipeline only at v1 paths — the word "fabrika" appeared nowhere in it. So anyone following the doc was routed at the machinery fabrika replaces, with no way to find the nine fabrika skills already on `main`.

This adds one subsection under **The pipeline** that says what fabrika is relative to v1 and routes to `claude-plugins/fabrika/skills/`. It points at the *directory* and tells the reader how to get the current list (`ls` the dir, read each `SKILL.md` frontmatter) rather than freezing a per-skill table, because the set is still filling one authoring session at a time. The existing v1 rows and the lane diagram are untouched — those describe the tree the release sweep deletes, and re-authoring them now is work done twice.

Fixes #5109

## What changed

- `DEVELOPMENT.md` — new `### fabrika — the replacement pipeline, growing beside this one` subsection at the end of `## The pipeline` (8 added lines, nothing removed or edited).

Every added link resolves on `main`: `claude-plugins/fabrika/`, `claude-plugins/fabrika/skills/`, `claude-plugins/fabrika/docs/README.md`, and ADRs 0129 / 0238 / 0242.

## Deviations

- **Class: narrowed a fix-shape the title implied.** *Said:* the issue title is "DEVELOPMENT.md routes the plan gate at v1's path; no routing reference reaches fabrika's copy." *Did:* routed to the fabrika skills directory and did **not** add a link to a fabrika plan gate. *Why:* fabrika has no plan-gate skill on `main` — `check-epic-plan` is still in open PR #5108, and ADR 0242's eight-noun set also names `governance` and `front-door`, neither landed. A doc line pointing at `claude-plugins/fabrika/skills/check-epic-plan/` would be the same defect class this PR fixes: a route to a path that does not exist. The directory-plus-how-to-list shape is also what the triaged acceptance criteria ask for. *Disposition:* no action needed — the routing stays true the moment that skill lands.

- **Class: left a sibling instance for a follow-up.** *Said:* verify the real blast radius, since the stated file list is a floor. *Did:* checked it and fixed only `DEVELOPMENT.md`. *Why:* `grep` across all tracked markdown shows exactly one doc carrying the stale `./.claude/skills/review-plan/…` route, and it is `DEVELOPMENT.md`. `README.md` and `CLAUDE.md` mention fabrika zero times, but the triage ruling on this issue puts both explicitly out of scope as separate doc surfaces with their own conventions. `ROADMAP.md` and `.glossary/TERMS.md` already reference fabrika. *Disposition:* for the reviewer to judge — no other doc carries the stale route, so nothing is left half-fixed here.

- **Class: deviated from a dispatch-specified mechanic.** *Said:* use the `umut/` branch prefix. *Did:* the skill's `step4-branch.sh` derives the prefix from `git config user.name` and produced `usirin/…`; I renamed the branch to `umut/fabrika-development-routing-5109` before the first push. *Why:* the operator instruction is explicit and branch names carry no pipeline semantics. *Disposition:* no action needed.

- **Class: scoped the pre-push checks.** *Said:* always run `pnpm typecheck --force`, never trust a replayed cache. *Did:* did not run a standalone `--force` typecheck; the pre-commit and pre-push hooks ran `typecheck` plus the changed-unit suite (287 files / 2420 tests green) on this worktree. *Why:* the diff is a single markdown file — no TypeScript surface changed, so there is nothing for a forced re-check to catch. *Disposition:* for the reviewer to judge.
