### PR TITLE
feat(fabrika): the four `plan` verbs the check-epic-plan contract specifies (#5107)

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/NOTES.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/NOTES.md
@@ -56,4 +56,4 @@ This skill proposes, never resolves; a ruling enters through report → triage.
 Model-invoked entry skill, one directory, no leaf skills. The caveat kinds are a closed vocabulary
 in `SKILL.md` rather than a rubric leaf — the leaf rule's two-consumer bar is unmet. Eval obligation
 rides that choice: this skill's eval suite enumerates the gate's own cases, which it does across the
-six in [`evals/evals.json`](evals/evals.json).
+ten in [`evals/evals.json`](evals/evals.json).

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -18,9 +18,10 @@ and an implementer needs none of those files to build these verbs.
 **The group name.** `plan` is this gate's, following the one-group-per-skill precedent (`build-ui`
 took `ui`, `build-epic` took `epic`, each reusing `build`'s verbs rather than sharing its group).
 The planner `plan-epic` ([#4712](https://github.com/kamp-us/phoenix/issues/4712), unauthored) takes
-its own group and may reuse these verbs the same way. **The `epic` group is an unimplemented
-spec** — `build-epic`'s contract describes it and no `src/epic/` exists — so nothing here allocates
-against it.
+its own group and may reuse these verbs the same way. **Nothing here allocates against the `epic`
+group.** (When this was written `epic` was an unimplemented spec with no `src/epic/`; it landed via
+[#5092](https://github.com/kamp-us/phoenix/issues/5092), so the premise is stale and the conclusion
+is not — `plan` is still unallocated, and no `epic` verb answers this gate's question.)
 
 **What fabrika already ships, reused — never respecified.** The claim is the **`build` group's,
 reused as landed verbs** ([`build`'s contract](../build/contract.md)) — the cross-contract shape
@@ -301,6 +302,18 @@ read one meaning for it; `ship` importing `review`'s private band is the shipped
 **`20`+ are this group's own.** Codes above the reserved band carry no cross-group *uniqueness*
 obligation (interface convention rule 3), and the alignment this group opts into is checked
 **base-only, never pairwise** (`exit-code-alignment.ts`: `occupied = allocatedCodes(base)`).
+
+**The `20`/`21` overlap with `build`, settled ([#5107](https://github.com/kamp-us/phoenix/issues/5107)).**
+This was written when `20`+ was free; the scope-admission fence has since taken `20` `OUT_OF_FOCUS`
+and `21` `AUDIENCE_NOT_AGENT`, both reachable from `fabrika build claim` — step 1 of this gate's
+skill. The overlap **stands**, and the rule that settles it is: *import a code when two groups prove
+the same fact; allocate freely when they do not.* `15` is imported because `plan flip` and
+`build claim` assert the identical fact (this session holds this issue's claim). `20`/`21` do not
+overlap in fact at all — lane admission is never something a `plan` verb proves, and a defective
+floor or a moved digest is never something a `build` verb proves — and an exit code is read off the
+command that produced it: [SKILL.md](SKILL.md) step 1 is total (`any other non-zero ends STOPPED`)
+and branches on `20`/`21` only off `plan flip` / `plan verdict`. Re-seating at `24`+ would also buy
+nothing, since `epic` already seats `20`–`24` over the same two `build` codes.
 
 | Code | Meaning | `read` | `check` | `flip` | `verdict` |
 |---|---|---|---|---|---|

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -58,7 +58,9 @@ export const SHARED_SEATS: SharedSeats = {
  * `review` and `triage` leave `4` a deliberate gap because neither performs a section check;
  * `build pr` does — a body with no `## Deviations` block is that same fact — so the seat is claimed
  * rather than re-invented one code higher. `epic` claims the identical nine: `epic open` reads the
- * same fact off an epic body with no parseable planned ledger.
+ * same fact off an epic body with no parseable planned ledger. `plan` claims them too: `plan read`
+ * seats `4` for a ledger section declared twice, so under `SHARED_SEATS` the checker would report
+ * `4` as a private code colliding with the base.
  */
 export const BUILD_SEATS: SharedSeats = {...SHARED_SEATS, BAD_SECTIONS: "BAD_SECTIONS"};
 
@@ -66,6 +68,7 @@ export const BUILD_SEATS: SharedSeats = {...SHARED_SEATS, BAD_SECTIONS: "BAD_SEC
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	build: BUILD_SEATS,
 	epic: BUILD_SEATS,
+	plan: BUILD_SEATS,
 	triage: SHARED_SEATS,
 	review: SHARED_SEATS,
 	ship: SHARED_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -10,6 +10,7 @@ import {
 	codeTableGroupsIn,
 	UNALIGNED_GROUPS,
 } from "./exit-code-alignment.ts";
+import * as plan from "./plan/codes.ts";
 import * as report from "./report/codes.ts";
 import * as review from "./review/codes.ts";
 import * as ship from "./ship/codes.ts";
@@ -26,6 +27,7 @@ const SRC_DIR = fileURLToPath(new URL(".", import.meta.url));
 const TABLES: Readonly<Record<string, CodeTable>> = {
 	build,
 	epic,
+	plan,
 	report,
 	review,
 	ship,

--- a/packages/fabrika-cli/src/plan/caveats.ts
+++ b/packages/fabrika-cli/src/plan/caveats.ts
@@ -1,0 +1,65 @@
+/**
+ * The advisory caveats `plan verdict` records beside the verdict — a closed set of kinds, and a
+ * model-authored tail.
+ *
+ * **Caveats annotate; they never block.** There is no code path from a caveat to a polarity (ADR 0047
+ * D2), and **no verb reads a caveat back as input** — it is a note for a human, never a signal a lane
+ * consumes. That is what makes the free-prose tail a bounded exception to the closed-vocabulary rule
+ * rather than a hole in it: the *kind* is closed and checked, the tail is inert.
+ */
+
+export const CAVEAT_KINDS = [
+	"ac-not-checkable",
+	"brief-fidelity",
+	"slice-too-broad",
+	"dependency-implied-not-declared",
+] as const;
+
+export type CaveatKind = (typeof CAVEAT_KINDS)[number];
+
+export interface Caveat {
+	readonly kind: CaveatKind;
+	readonly ref: number;
+	readonly text: string;
+}
+
+export type CaveatRead =
+	| {readonly _tag: "Caveats"; readonly caveats: ReadonlyArray<Caveat>}
+	/** A line that is not a caveat at all — refused, never dropped. */
+	| {readonly _tag: "Unparseable"; readonly line: string}
+	| {readonly _tag: "OffEnum"; readonly kind: string};
+
+const CAVEAT_LINE = /^caveat:\s*([a-z-]+)\s+#(\d+)\s*(?:—|–|--)\s*(.+)$/i;
+
+const isKind = (value: string): value is CaveatKind =>
+	(CAVEAT_KINDS as ReadonlyArray<string>).includes(value);
+
+/** One caveat per non-blank line. An empty input is an ordinary answer, not a refusal. */
+export const readCaveats = (text: string): CaveatRead => {
+	const caveats: Caveat[] = [];
+	for (const raw of text.split("\n")) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const matched = CAVEAT_LINE.exec(line);
+		if (matched?.[1] === undefined || matched[2] === undefined || matched[3] === undefined) {
+			return {_tag: "Unparseable", line};
+		}
+		const kind = matched[1].toLowerCase();
+		if (!isKind(kind)) return {_tag: "OffEnum", kind};
+		caveats.push({kind, ref: Number.parseInt(matched[2], 10), text: matched[3].trim()});
+	}
+	return {_tag: "Caveats", caveats};
+};
+
+/** The caveats rendered verbatim under their kinds, in the closed set's order. */
+export const renderCaveats = (caveats: ReadonlyArray<Caveat>): string => {
+	const sections: string[] = [];
+	for (const kind of CAVEAT_KINDS) {
+		const under = caveats.filter((caveat) => caveat.kind === kind);
+		if (under.length === 0) continue;
+		sections.push(
+			[`### ${kind}`, ...under.map((caveat) => `- #${caveat.ref} — ${caveat.text}`)].join("\n"),
+		);
+	}
+	return sections.join("\n\n");
+};

--- a/packages/fabrika-cli/src/plan/caveats.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/caveats.unit.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, it} from "vitest";
+import {CAVEAT_KINDS, readCaveats, renderCaveats} from "./caveats.ts";
+
+describe("readCaveats", () => {
+	it("reads an empty input as zero caveats — an ordinary answer, not a refusal", () => {
+		expect(readCaveats("")).toEqual({_tag: "Caveats", caveats: []});
+		expect(readCaveats("\n\n")).toEqual({_tag: "Caveats", caveats: []});
+	});
+
+	it("reads one caveat per line, kind, ref and tail apart", () => {
+		expect(
+			readCaveats('caveat: ac-not-checkable #4302 — "works well" states no observable outcome'),
+		).toEqual({
+			_tag: "Caveats",
+			caveats: [
+				{
+					kind: "ac-not-checkable",
+					ref: 4302,
+					text: '"works well" states no observable outcome',
+				},
+			],
+		});
+	});
+
+	/**
+	 * The *kind* is the closed half of the deliberate exception: the tail is advisory prose no verb
+	 * reads back, so the enum check is the only thing keeping a caveat from minting new vocabulary.
+	 */
+	it("refuses a kind off the closed set", () => {
+		expect(readCaveats("caveat: vibes #4302 — feels thin")).toEqual({
+			_tag: "OffEnum",
+			kind: "vibes",
+		});
+	});
+
+	it("refuses a line that is not a caveat at all, rather than dropping it", () => {
+		expect(readCaveats("this plan feels thin")._tag).toBe("Unparseable");
+	});
+
+	it.each(CAVEAT_KINDS)("admits %s", (kind) => {
+		expect(readCaveats(`caveat: ${kind} #1 — note`)._tag).toBe("Caveats");
+	});
+});
+
+describe("renderCaveats", () => {
+	it("groups verbatim under their kinds, in the closed set's order", () => {
+		const read = readCaveats(
+			["caveat: slice-too-broad #2 — too big", "caveat: brief-fidelity #1 — drifted"].join("\n"),
+		);
+		expect(read._tag).toBe("Caveats");
+		if (read._tag !== "Caveats") return;
+		expect(renderCaveats(read.caveats)).toBe(
+			"### brief-fidelity\n- #1 — drifted\n\n### slice-too-broad\n- #2 — too big",
+		);
+	});
+});

--- a/packages/fabrika-cli/src/plan/check-verb.ts
+++ b/packages/fabrika-cli/src/plan/check-verb.ts
@@ -1,0 +1,95 @@
+/**
+ * `plan check` — the deterministic floor, and the whole pass/fail decision.
+ *
+ * **Both arms exit `0`** and the discriminator is a state word on stdout (`clean` / `defective`), per
+ * the interface convention's pipe clause. v1's gate exited `0` on FAIL *and* printed only a `✓`/`✗`
+ * glyph, so `run-gate.sh && proceed` proceeded on a failure. The guard against acting on a defective
+ * plan is not at *this* read at all — it is at the **write**: `plan flip` re-derives the floor itself
+ * and refuses on `20` rather than trusting any caller's reading of an exit code.
+ *
+ * There is deliberately no `20` here: a defective floor is this verb's answer, not its refusal.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {badNumber, resolveTargetRepo} from "../build/target.ts";
+import {answer, type VerbOutcome} from "../verb.ts";
+import type {Floor} from "./defects.ts";
+import {
+	deriveFloorFor,
+	loadLedger,
+	type PlanMessages,
+	requireEpic,
+	scannedChildren,
+} from "./load.ts";
+import type {Ledger} from "./model.ts";
+
+const VERB = "plan check";
+
+export const MESSAGES: PlanMessages = {
+	verb: VERB,
+	grammar: (reason) => `${VERB}: the ledger grammar refused: ${reason}`,
+	zeroChildren: (epic) =>
+		`${VERB}: #${epic} has zero children — refusing to answer over zero scope (ADR 0092).`,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to gate it.`,
+	unreadable: (what, reason) =>
+		`${VERB}: cannot read ${what}: ${reason} — the floor is UNKNOWN, not clean.`,
+};
+
+export interface CheckOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/**
+ * The answer both arms share.
+ *
+ * `defective` outranks everything: a plan with defects is `defective` however many classes were
+ * skipped, and a skipped class never makes the floor clean by omission — it is named on the answer.
+ */
+export const floorAnswer = (ledger: Ledger, floor: Floor): string =>
+	JSON.stringify({
+		answer: floor.defects.length === 0 ? "clean" : "defective",
+		epic: ledger.epic,
+		scanned: ledger.children.map((child) => child.number),
+		digest: ledger.digest,
+		skipped: floor.skipped,
+		defects: floor.defects,
+	});
+
+export const runCheck = (
+	options: CheckOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const bad = badNumber(VERB, "an issue number", options.number);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* requireEpic(MESSAGES, repo, options.number);
+		if (target._tag === "Refused") return target.outcome;
+
+		const read = yield* loadLedger(MESSAGES, repo, target.issue);
+		if (read._tag === "Refused") return read.outcome;
+		const ledger = read.ledger;
+
+		const derived = yield* deriveFloorFor(MESSAGES, repo, ledger);
+		if (derived._tag === "Refused") return derived.outcome;
+		const floor = derived.floor;
+
+		const scanned = scannedChildren(
+			VERB,
+			ledger.children.map((child) => child.number),
+		);
+		// A notice on an exit-0 answer, not an error — which is why it is not in the Errors table.
+		const notice =
+			floor.defects.length === 0
+				? []
+				: [
+						`${VERB}: ${floor.defects.length} hard defect(s) over ${ledger.children.length} child(ren) — see stdout.`,
+					];
+		return answer(floorAnswer(ledger, floor), [scanned, ...notice]);
+	});

--- a/packages/fabrika-cli/src/plan/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/check-verb.unit.test.ts
@@ -1,0 +1,147 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {runCheck} from "./check-verb.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {child, childBody, epic, epicBody, subIssues} from "./fixtures.test-support.ts";
+
+const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
+const CHILD_1 = /^gh api repos\/o\/r\/issues\/4301$/;
+const CHILD_2 = /^gh api repos\/o\/r\/issues\/4302$/;
+const REF_9999 = /^gh api repos\/o\/r\/issues\/9999$/;
+const CYCLE = /^gh api repos\/o\/r\/contents\/product-development-cycle\.md$/;
+
+const options = {
+	number: 4300,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(Effect.provide(runCheck(options), fakeShell(script).layer));
+
+/** An epic whose phase line names exactly the one child a single-child script serves. */
+const ONE_CHILD_EPIC = epic({body: epicBody({dependencies: "- phase 1: #4301"})});
+
+const CLEAN: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[EPIC, epic()],
+	[SUBS, subIssues(4301, 4302)],
+	[CHILD_1, child({number: 4301})],
+	[CHILD_2, child({number: 4302, body: childBody({stories: "2"})})],
+	[CYCLE, okOut("{}")],
+];
+
+describe("runCheck", () => {
+	it("answers clean on exit 0, with the scanned set and the digest", async () => {
+		const out = await run(CLEAN);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			answer: "clean",
+			epic: 4300,
+			scanned: [4301, 4302],
+			skipped: [],
+			defects: [],
+		});
+	});
+
+	/**
+	 * v1's gate exited `0` on FAIL *and* printed only a `✓`/`✗` glyph, so `run-gate.sh && proceed`
+	 * proceeded on a failure. Seat this arm on a non-zero code and the state word stops being the
+	 * discriminator — which is the hole the machine channel exists to close.
+	 */
+	it("answers defective ALSO on exit 0 — the discriminator is the state word", async () => {
+		const out = await run([
+			[EPIC, ONE_CHILD_EPIC],
+			[SUBS, subIssues(4301)],
+			[CHILD_1, child({number: 4301, body: childBody({criteria: "no boxes here"})})],
+			[CYCLE, okOut("{}")],
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.answer).toBe("defective");
+		expect(answer.defects[0]).toMatchObject({type: "ZERO_AC", refs: [4301]});
+	});
+
+	it("names the scanned set on BOTH arms, so a clean answer states its scope", async () => {
+		const clean = await run(CLEAN);
+		expect(clean.stderr[0]).toBe("plan check: scanned 2 children; #4301, #4302.");
+		const defective = await run([
+			[EPIC, ONE_CHILD_EPIC],
+			[SUBS, subIssues(4301)],
+			[CHILD_1, child({number: 4301, body: childBody({criteria: "none"})})],
+			[CYCLE, okOut("{}")],
+		]);
+		expect(defective.stderr[0]).toBe("plan check: scanned 1 child; #4301.");
+		expect(defective.stderr[1]).toContain("hard defect(s) over 1 child(ren) — see stdout.");
+	});
+
+	it("carries `skipped` on the answer when the cycle-doc probe failed", async () => {
+		const out = await run([
+			[EPIC, epic()],
+			[SUBS, subIssues(4301, 4302)],
+			[CHILD_1, child({number: 4301})],
+			[CHILD_2, child({number: 4302, body: childBody({stories: "2"})})],
+			[CYCLE, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			answer: "clean",
+			skipped: ["MISSING_CONTAINMENT"],
+		});
+	});
+
+	/**
+	 * `DANGLING_DEP` is decided by the probe's HTTP status. Answer the probe with a 5xx instead and the
+	 * verb refuses `11` rather than reporting the ref as absent — an unreachable GitHub proves nothing.
+	 */
+	it("derives DANGLING_DEP from a 404 and refuses 11 on anything else", async () => {
+		const referencing = epic({
+			body: epicBody({dependencies: "- phase 1: #4301\n- #4301 requires: #9999"}),
+		});
+		const dangling = await run([
+			[EPIC, referencing],
+			[SUBS, subIssues(4301)],
+			[CHILD_1, child({number: 4301})],
+			[REF_9999, errOut("gh: Not Found (HTTP 404)")],
+			[CYCLE, okOut("{}")],
+		]);
+		expect(JSON.parse(dangling.stdout).defects).toContainEqual({
+			type: "DANGLING_DEP",
+			refs: [9999],
+			detail: "#9999 is referenced but is not a child and is proven absent",
+		});
+
+		const unreadable = await run([
+			[EPIC, referencing],
+			[SUBS, subIssues(4301)],
+			[CHILD_1, child({number: 4301})],
+			[REF_9999, errOut("gh: Bad gateway (HTTP 502)")],
+			[CYCLE, okOut("{}")],
+		]);
+		expect(unreadable.code).toBe(PRECONDITION_UNKNOWN);
+		expect(unreadable.stdout).toBe("");
+		expect(unreadable.stderr.at(-1)).toContain("the floor is UNKNOWN, not clean");
+	});
+
+	it("refuses zero scope on 7 rather than answering `clean` over nothing", async () => {
+		const out = await run([
+			[EPIC, epic()],
+			[SUBS, okOut("[]")],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a non-epic on 10", async () => {
+		const out = await run([[EPIC, epic({labels: [{name: "type:chore"}]})]]);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("refusing to gate it");
+	});
+
+	it("re-runs the fetch itself — it takes no ledger from a caller", async () => {
+		const shell = fakeShell(CLEAN);
+		await Effect.runPromise(Effect.provide(runCheck(options), shell.layer));
+		expect(shell.calls.some((line) => /sub_issues/.test(line))).toBe(true);
+	});
+});

--- a/packages/fabrika-cli/src/plan/codes.ts
+++ b/packages/fabrika-cli/src/plan/codes.ts
@@ -1,0 +1,56 @@
+/**
+ * The one exit table the four `plan` verbs allocate from.
+ *
+ * Three tiers, and the tier decides how a constant gets here rather than what it means:
+ *
+ * - `3`–`11` are `report`'s seats, reached through `build`'s re-exports so there is one hop, not two
+ *   tables to keep level. `ALIGNED_GROUPS` records the claim under `BUILD_SEATS` — *not*
+ *   `SHARED_SEATS`, which omits `BAD_SECTIONS`: `plan read` seats `4`, so the checker would otherwise
+ *   report it as a private code colliding with the base. {@link EMPTY_STDIN} is re-exported though no
+ *   verb reaches it, because an omitted seat reads to the checker as drift.
+ * - `15` is `build`'s, **imported verbatim**. This group holds a `build` claim, so a caller driving
+ *   both in one sweep must read one meaning for it.
+ * - `20`–`23` are this group's own.
+ *
+ * **Why `20`/`21` overlapping `build`'s `OUT_OF_FOCUS`/`AUDIENCE_NOT_AGENT` is safe (#5107).** The
+ * contract seated these when `20`+ was free; the scope-admission fence has since taken both, and both
+ * are reachable from `fabrika build claim`, which is step 1 of the skill that drives these verbs. The
+ * `15` import argued that one code must carry one meaning across a sweep, so the question is fair —
+ * and the answer is that the obligation the `15` import discharges is *not* the one at stake here.
+ * `15` is imported because `plan flip` and `build claim` assert **the same fact** (this session holds
+ * this issue's claim); two verbs proving one fact on two codes is the collision that bites. `20`/`21`
+ * carry facts neither group's verbs can produce for the other: admission of an issue into a lane is
+ * never something a `plan` verb proves, and a defective floor or a moved digest is never something a
+ * `build` verb proves. An exit code is read off the command that produced it — nothing in
+ * [SKILL.md](../../../../claude-plugins/fabrika/skills/check-epic-plan/SKILL.md) branches on `20`/`21`
+ * from `build claim` (its step 1 is total: "any other non-zero ends `STOPPED`"), and it branches on
+ * `20`/`21` only off `plan flip`/`plan verdict`. Re-seating at `24`+ would also buy nothing: `epic`
+ * already seats `20`–`24` over `build`'s `20`/`21`, so there is no unoccupied band above the reserved
+ * one and the alignment checker is base-only by design (interface convention rule 3). The rule this
+ * group follows, stated so a later editor can apply it rather than re-derive it: **import a code when
+ * two groups prove the same fact; allocate freely when they do not.**
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+export {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	CLAIM_NOT_MINE,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "../build/codes.ts";
+
+/** Proven: the floor derived hard defects — refused as a precondition to writing, never as an answer. */
+export const FLOOR_DEFECTIVE = 20;
+/** Proven: the recomputed scope digest differs from the `--digest` the caller carried. */
+export const PLAN_MOVED = 21;
+/** Proven: at least one child is `unchanged` — the flip did not fully apply. */
+export const PARTIAL_FLIP = 22;
+/** Proven: a label the flip must write is absent from the repository's taxonomy (#4285). */
+export const LABEL_ABSENT = 23;

--- a/packages/fabrika-cli/src/plan/command.ts
+++ b/packages/fabrika-cli/src/plan/command.ts
@@ -1,0 +1,129 @@
+/**
+ * The `plan` verb group — `fabrika plan <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives in
+ * the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a
+ * process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * `--polarity` is declared as a string on purpose. A value off its closed vocabulary is a **semantic
+ * refusal** (`10`), not a malformed-flag usage error (`1`), so the check belongs to the verb.
+ */
+
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runCheck} from "./check-verb.ts";
+import {runFlip} from "./flip-verb.ts";
+import {runRead} from "./read-verb.ts";
+import {runVerdict} from "./verdict-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const epicArg = Argument.integer("number").pipe(
+	Argument.withDescription("the epic whose ledger this verb reads"),
+);
+
+const digestFlag = Flag.string("digest").pipe(
+	Flag.withDescription(
+		"the 12-lowercase-hex scope digest `plan check` printed; the verb recomputes it and refuses on 21 if the plan moved",
+	),
+);
+
+const read = leafCommand(
+	"read",
+	{number: epicArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runRead({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Fetch the epic and its native sub-issue children, parse the ledger, and print it as one object: {"answer":"read","epic":n,"children":[…],"epicStories":[…],"cycleDoc":"present|absent|unknown","topology":{…},"digest":"…"}. Fetch and registered parses only — no judgment. Each child carries the three-state assignee slot (assigneesObserved false and assignees null when the payload carried no assignees key), the acceptance-criteria token uncollapsed, and its **Stories:**/**Containment:** fields. Exits 4 (a ledger section or field line appears twice, the ## Dependencies block is unparseable, or a non-empty ### User stories list is not contiguous from 1), 7 (the epic is proven absent or closed, or it has zero sub-issue children), 10 (the issue is not a type:epic), 11 (the epic, the sub-issue list, a child or the cycle-doc probe could not be read). Example: fabrika plan read 4300',
+	),
+);
+
+const check = leafCommand(
+	"check",
+	{number: epicArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runCheck({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'The deterministic floor over the thirteen hard defect types — the whole pass/fail decision. BOTH arms exit 0 and the discriminator is the "answer" state word (clean | defective); a defective floor is this verb\'s answer, never its refusal, and the guard against acting on one lives at `plan flip`\'s own re-gate. "skipped" names a class that could not be derived (today only MISSING_CONTAINMENT, and only when the cycle-doc probe failed) — it never makes the floor clean by omission. Exits 4 (the ledger grammar refused), 7 (zero scope), 10 (the issue is not a type:epic), 11 (a read the floor depends on failed — the floor is UNKNOWN, not clean). Example: fabrika plan check 4300',
+	),
+);
+
+const flip = leafCommand(
+	"flip",
+	{number: epicArg, digest: digestFlag, repo: repoFlag},
+	Effect.fn(function* ({number, digest, repo}) {
+		yield* emit(yield* runFlip({number, digest, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Flip every status:planned child to status:triaged, re-gating first, and report the OBSERVED result per child — flipped | already | unchanged | not-planned, read back from GitHub, never asserted from intent. status:triaged is added before status:planned is removed, always, so a child caught mid-write still carries a status: label. Zero planned children is an answer with terminal "nothing-to-flip", not a refusal. Exits 4 (the grammar refused during the re-gate), 7 (zero children), 8 (a write was attempted and no re-read could prove its outcome), 10 (not a type:epic, or --digest is not 12 lowercase hex), 11 (a read failed — nothing was written), 15 (this session does not hold the epic\'s claim), 20 (the re-gate derived hard defects), 21 (the plan moved since the check), 22 (at least one child is unchanged — the refs are on stderr), 23 (a label the flip must write is absent from the repo taxonomy — refused, never created, #4285). Example: fabrika plan flip 4300 --digest 4d90e1bb27ac',
+	),
+);
+
+const verdict = leafCommand(
+	"verdict",
+	{
+		number: epicArg,
+		digest: digestFlag,
+		polarity: Flag.string("polarity").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"an optional cross-check: PASS or FAIL. The verb derives its own polarity from the floor; a supplied value that disagrees is a 10 refusal, never the posted verdict",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({number, digest, polarity, repo}) {
+		yield* emit(
+			yield* runVerdict({
+				number,
+				digest,
+				polarity: Option.getOrNull(polarity),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Post the gate\'s verdict comment, bound to the scope digest, and read it back. Prints {"answer":"posted","epic":n,"polarity":"PASS","digest":"…","skipped":[],"comment":id,"caveats":k}. The polarity is DERIVED by re-running the floor — a caller never supplies it. Optional stdin carries advisory caveats, one per line, "caveat: <kind> #<ref> — <text>", over the closed set ac-not-checkable | brief-fidelity | slice-too-broad | dependency-implied-not-declared; an empty stdin is an ordinary answer. Exits 4 (the grammar refused), 5/6 (the authored caveats carry a machine-local path, or are a bare @ path reference), 7 (zero children), 8 (posted and unprovable — UNKNOWN), 9 (posted but the read-back does not match), 10 (--digest malformed, not a type:epic, --polarity disagrees with the derived floor, an off-set caveat kind, or a caveat naming a ref outside the scanned set), 11 (a read failed — nothing was posted), 15 (this session does not hold the epic\'s claim), 21 (the plan moved since the check). Example: fabrika plan verdict 4300 --digest 4d90e1bb27ac < caveats.md',
+	),
+);
+
+export const planCommand = Command.make("plan").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
+		read,
+		check,
+		flip,
+		verdict,
+	]),
+	Command.withDescription(
+		"Gate an epic's plan: read its ledger, derive the deterministic floor, flip its planned children into the build pool, and post the verdict bound to the scope digest",
+	),
+);

--- a/packages/fabrika-cli/src/plan/defects.ts
+++ b/packages/fabrika-cli/src/plan/defects.ts
@@ -1,0 +1,316 @@
+/**
+ * The floor: a total function from the ledger to a sorted defect list over a closed thirteen-type
+ * enum. `plan check` is this function plus a fetch; nothing above it can change the answer.
+ *
+ * **Fourteen names, thirteen defects.** `ZERO_SCOPE` is the fourteenth and is seated as exit `7`
+ * rather than as defect zero: v1 made a childless epic defect #1 and early-returned, so the ledger
+ * was never validated and the verdict reported exactly one thing wrong about a plan it had not read.
+ * A refused scope is not a defect list of length one (ADR 0092).
+ *
+ * **A class that cannot be derived is named, never dropped.** `MISSING_CONTAINMENT` rests on a
+ * three-valued probe: `present` derives the class, `absent` derives it and evaluates it false, and
+ * only `unknown` puts it in {@link Floor.skipped}. v1 fused `absent` and `unknown` through a stderr
+ * substring match, so a transient probe failure silently switched the whole class off for a run.
+ *
+ * The priority set is exactly `{p0, p1, p2}` — `p3` was ruled *retired*, not widened (#4101, #2413).
+ */
+
+import type {LedgerScope} from "./digest.ts";
+import type {ChildLedger} from "./model.ts";
+
+/** The emission order, which is also the primary sort key. */
+export const DEFECT_TYPES = [
+	"MISSING_DEPS_SECTION",
+	"DEP_CYCLE",
+	"DANGLING_DEP",
+	"ORPHAN_CHILD",
+	"MISSING_STORIES_SECTION",
+	"UNCOVERED_STORY",
+	"ZERO_AC",
+	"MISSING_STORY",
+	"MISSING_LABEL",
+	"MISSING_CONTAINMENT",
+	"NEEDS_TRIAGE_LABEL",
+	"UNVERIFIABLE_ASSIGNEE",
+	"HELD_CHILD_UNASSIGNED",
+] as const;
+
+export type DefectType = (typeof DEFECT_TYPES)[number];
+
+export interface Defect {
+	readonly type: DefectType;
+	readonly refs: ReadonlyArray<number>;
+	/** A fixed template per type, never free prose. */
+	readonly detail: string;
+}
+
+export interface Floor {
+	readonly defects: ReadonlyArray<Defect>;
+	/** Classes not derived and therefore not asked. A skipped class never makes the floor clean. */
+	readonly skipped: ReadonlyArray<DefectType>;
+}
+
+export const PRIORITY_LABELS: ReadonlyArray<string> = ["p0", "p1", "p2"];
+export const HELD_LABEL = "ready-for:human";
+export const NEEDS_TRIAGE_LABEL = "status:needs-triage";
+
+const issueNumber = (ref: string): number | null => {
+	const matched = /^#(\d+)$/.exec(ref);
+	return matched?.[1] === undefined ? null : Number.parseInt(matched[1], 10);
+};
+
+/** Every issue ref the topology names, deduped and ascending. Ledger-local `C<n>` ids are not issues. */
+export const referencedIssues = (ledger: LedgerScope): ReadonlyArray<number> => {
+	const refs = new Set<number>();
+	for (const phase of ledger.topology.phases) {
+		for (const member of phase.members) {
+			const number = issueNumber(member);
+			if (number !== null) refs.add(number);
+		}
+	}
+	for (const [dependent, prerequisite] of ledger.topology.edges) {
+		for (const ref of [dependent, prerequisite]) {
+			const number = issueNumber(ref);
+			if (number !== null) refs.add(number);
+		}
+	}
+	return [...refs].sort((a, b) => a - b);
+};
+
+/**
+ * The refs `DANGLING_DEP` must probe: everything the topology names that is neither the epic nor one
+ * of its children. The probe itself belongs to the verb; this keeps the *set* derivable and testable.
+ */
+export const refsToProbe = (ledger: LedgerScope): ReadonlyArray<number> => {
+	const children = new Set(ledger.children.map((child) => child.number));
+	return referencedIssues(ledger).filter((ref) => ref !== ledger.epic && !children.has(ref));
+};
+
+/**
+ * The cycles among the topology's edges, each as its sorted member set.
+ *
+ * Tarjan's strongly-connected components: any component of more than one node is a cycle, and a
+ * self-loop is one of size one. Walking components rather than paths is what makes the answer
+ * deduped and order-independent — two edges reported in either order name the same cycle once.
+ */
+const cycles = (
+	edges: ReadonlyArray<readonly [string, string]>,
+): ReadonlyArray<ReadonlyArray<string>> => {
+	const adjacency = new Map<string, string[]>();
+	const nodes = new Set<string>();
+	for (const [dependent, prerequisite] of edges) {
+		nodes.add(dependent);
+		nodes.add(prerequisite);
+		const out = adjacency.get(dependent);
+		if (out === undefined) adjacency.set(dependent, [prerequisite]);
+		else out.push(prerequisite);
+	}
+
+	const index = new Map<string, number>();
+	const low = new Map<string, number>();
+	const onStack = new Set<string>();
+	const stack: string[] = [];
+	const found: string[][] = [];
+	let next = 0;
+
+	const strongConnect = (node: string): void => {
+		index.set(node, next);
+		low.set(node, next);
+		next += 1;
+		stack.push(node);
+		onStack.add(node);
+		for (const target of adjacency.get(node) ?? []) {
+			if (!index.has(target)) {
+				strongConnect(target);
+				low.set(node, Math.min(low.get(node) ?? 0, low.get(target) ?? 0));
+			} else if (onStack.has(target)) {
+				low.set(node, Math.min(low.get(node) ?? 0, index.get(target) ?? 0));
+			}
+		}
+		if (low.get(node) !== index.get(node)) return;
+		const component: string[] = [];
+		for (;;) {
+			const popped = stack.pop();
+			if (popped === undefined) break;
+			onStack.delete(popped);
+			component.push(popped);
+			if (popped === node) break;
+		}
+		const selfLoop = (adjacency.get(node) ?? []).includes(node);
+		if (component.length > 1 || selfLoop) found.push(component.sort());
+	};
+
+	for (const node of [...nodes].sort()) if (!index.has(node)) strongConnect(node);
+	return found.sort((a, b) => (a[0] ?? "").localeCompare(b[0] ?? ""));
+};
+
+const criteriaReading = (child: ChildLedger): "absent" | "malformed" | "empty" | null => {
+	if (child.criteria === "absent") return "absent";
+	if (child.criteria === "malformed") return "malformed";
+	return child.criteriaCount === 0 ? "empty" : null;
+};
+
+const appearsInTopology = (ledger: LedgerScope, child: number): boolean => {
+	const ref = `#${child}`;
+	return (
+		ledger.topology.phases.some((phase) => phase.members.includes(ref)) ||
+		ledger.topology.edges.some(
+			([dependent, prerequisite]) => dependent === ref || prerequisite === ref,
+		)
+	);
+};
+
+const missingLabelKinds = (labels: ReadonlyArray<string>): ReadonlyArray<string> => {
+	const missing: string[] = [];
+	if (!labels.some((label) => label.startsWith("type:"))) missing.push("type:");
+	if (!labels.some((label) => label.startsWith("status:"))) missing.push("status:");
+	if (!labels.some((label) => PRIORITY_LABELS.includes(label))) missing.push("priority");
+	return missing;
+};
+
+export interface FloorInput {
+	readonly ledger: LedgerScope;
+	/** The refs {@link refsToProbe} named that a 404-discriminating probe proved **absent**. */
+	readonly provenAbsent: ReadonlySet<number>;
+}
+
+export const deriveFloor = ({ledger, provenAbsent}: FloorInput): Floor => {
+	const defects: Defect[] = [];
+
+	if (ledger.dependenciesAbsent) {
+		defects.push({
+			type: "MISSING_DEPS_SECTION",
+			refs: [ledger.epic],
+			detail: "no ## Dependencies section",
+		});
+	}
+
+	for (const members of cycles(ledger.topology.edges)) {
+		const refs = members.map(issueNumber).filter((n): n is number => n !== null);
+		defects.push({
+			type: "DEP_CYCLE",
+			refs: [...refs].sort((a, b) => a - b),
+			detail: `cycle: ${[...members, members[0] ?? ""].join(" → ")}`,
+		});
+	}
+
+	for (const ref of refsToProbe(ledger)) {
+		if (!provenAbsent.has(ref)) continue;
+		defects.push({
+			type: "DANGLING_DEP",
+			refs: [ref],
+			detail: `#${ref} is referenced but is not a child and is proven absent`,
+		});
+	}
+
+	if (!ledger.dependenciesAbsent) {
+		for (const child of ledger.children) {
+			if (appearsInTopology(ledger, child.number)) continue;
+			defects.push({
+				type: "ORPHAN_CHILD",
+				refs: [child.number],
+				detail: `#${child.number} appears in no phase or requires line`,
+			});
+		}
+	}
+
+	if (ledger.epicStories.length === 0) {
+		defects.push({
+			type: "MISSING_STORIES_SECTION",
+			refs: [ledger.epic],
+			detail: "the epic declares no user stories",
+		});
+	}
+
+	const claimed = new Set(ledger.children.flatMap((child) => [...(child.stories ?? [])]));
+	for (const story of ledger.epicStories) {
+		if (claimed.has(story)) continue;
+		defects.push({
+			type: "UNCOVERED_STORY",
+			refs: [ledger.epic],
+			detail: `story ${story} is claimed by no child`,
+		});
+	}
+
+	for (const child of ledger.children) {
+		const reading = criteriaReading(child);
+		if (reading !== null) {
+			defects.push({
+				type: "ZERO_AC",
+				refs: [child.number],
+				detail: `acceptance criteria read as ${reading}`,
+			});
+		}
+
+		if (ledger.epicStories.length > 0 && child.stories === null) {
+			defects.push({
+				type: "MISSING_STORY",
+				refs: [child.number],
+				detail:
+					child.storiesValue === null
+						? "no **Stories:** line"
+						: `**Stories:** value does not conform: "${child.storiesValue}"`,
+			});
+		}
+
+		for (const kind of missingLabelKinds(child.labels)) {
+			defects.push({
+				type: "MISSING_LABEL",
+				refs: [child.number],
+				detail: `missing a ${kind} label`,
+			});
+		}
+
+		if (
+			ledger.cycleDoc === "present" &&
+			child.labels.includes("type:feature") &&
+			(child.containment === null || child.containment === "none")
+		) {
+			defects.push({
+				type: "MISSING_CONTAINMENT",
+				refs: [child.number],
+				detail: `type:feature with containment ${child.containment === null ? "unset" : "none"}`,
+			});
+		}
+
+		if (child.labels.includes(NEEDS_TRIAGE_LABEL)) {
+			defects.push({
+				type: "NEEDS_TRIAGE_LABEL",
+				refs: [child.number],
+				detail: `still carries ${NEEDS_TRIAGE_LABEL}`,
+			});
+		}
+
+		if (!child.assigneesObserved) {
+			defects.push({
+				type: "UNVERIFIABLE_ASSIGNEE",
+				refs: [child.number],
+				detail: "the assignees field was not observed",
+			});
+		}
+
+		if (
+			child.labels.includes(HELD_LABEL) &&
+			child.assigneesObserved &&
+			(child.assignees ?? []).length === 0
+		) {
+			defects.push({
+				type: "HELD_CHILD_UNASSIGNED",
+				refs: [child.number],
+				detail: `${HELD_LABEL} with an empty assignee slot`,
+			});
+		}
+	}
+
+	const rank = (type: DefectType): number => DEFECT_TYPES.indexOf(type);
+	const sorted = [...defects].sort((a, b) => {
+		if (a.type !== b.type) return rank(a.type) - rank(b.type);
+		const lowest = (d: Defect): number => d.refs[0] ?? Number.MAX_SAFE_INTEGER;
+		return lowest(a) === lowest(b) ? a.detail.localeCompare(b.detail) : lowest(a) - lowest(b);
+	});
+
+	return {
+		defects: sorted,
+		skipped: ledger.cycleDoc === "unknown" ? ["MISSING_CONTAINMENT"] : [],
+	};
+};

--- a/packages/fabrika-cli/src/plan/defects.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/defects.unit.test.ts
@@ -1,0 +1,237 @@
+import {describe, expect, it} from "vitest";
+import {DEFECT_TYPES, type DefectType, deriveFloor, refsToProbe} from "./defects.ts";
+import type {LedgerScope} from "./digest.ts";
+import type {ChildLedger} from "./model.ts";
+
+const child = (overrides: Partial<ChildLedger> = {}): ChildLedger => ({
+	number: 4301,
+	labels: ["p1", "status:planned", "type:feature"],
+	assignees: [],
+	assigneesObserved: true,
+	criteria: "found",
+	criteriaCount: 2,
+	stories: [1],
+	storiesValue: null,
+	containment: "flag",
+	...overrides,
+});
+
+const scope = (overrides: Partial<LedgerScope> = {}): LedgerScope => ({
+	epic: 4300,
+	children: [child()],
+	epicStories: [1],
+	cycleDoc: "present",
+	topology: {phases: [{phase: 1, members: ["#4301"]}], edges: []},
+	dependenciesAbsent: false,
+	...overrides,
+});
+
+const floorOf = (overrides: Partial<LedgerScope> = {}, absent: ReadonlyArray<number> = []) =>
+	deriveFloor({ledger: scope(overrides), provenAbsent: new Set(absent)});
+
+const types = (overrides: Partial<LedgerScope> = {}, absent: ReadonlyArray<number> = []) =>
+	floorOf(overrides, absent).defects.map((defect) => defect.type);
+
+describe("a clean plan", () => {
+	it("derives no defects and skips no class", () => {
+		expect(floorOf()).toEqual({defects: [], skipped: []});
+	});
+});
+
+describe("each of the thirteen types fires on its own condition", () => {
+	it("MISSING_DEPS_SECTION", () => {
+		expect(types({dependenciesAbsent: true})).toContain("MISSING_DEPS_SECTION");
+	});
+
+	it("DEP_CYCLE, reported once as its sorted member set", () => {
+		const cyclic = floorOf({
+			topology: {
+				phases: [{phase: 1, members: ["#4301"]}],
+				edges: [
+					["#4301", "#4302"],
+					["#4302", "#4301"],
+				],
+			},
+			children: [child(), child({number: 4302})],
+		});
+		const cycles = cyclic.defects.filter((defect) => defect.type === "DEP_CYCLE");
+		expect(cycles).toHaveLength(1);
+		expect(cycles[0]?.refs).toEqual([4301, 4302]);
+		expect(cycles[0]?.detail).toBe("cycle: #4301 → #4302 → #4301");
+	});
+
+	/**
+	 * The probe decides absence; the floor only reads its answer. A ref that was *not* proven absent
+	 * never becomes a defect — remove the `provenAbsent` test and an unreachable GitHub would start
+	 * reporting every referenced issue as dangling.
+	 */
+	it("DANGLING_DEP only for a ref the probe proved absent", () => {
+		const referenced = {
+			topology: {phases: [{phase: 1, members: ["#4301", "#9999"]}], edges: []},
+		};
+		expect(types(referenced, [9999])).toContain("DANGLING_DEP");
+		expect(types(referenced, [])).not.toContain("DANGLING_DEP");
+	});
+
+	it("ORPHAN_CHILD", () => {
+		expect(types({children: [child(), child({number: 4302})]})).toContain("ORPHAN_CHILD");
+	});
+
+	it("MISSING_STORIES_SECTION", () => {
+		expect(types({epicStories: []})).toContain("MISSING_STORIES_SECTION");
+	});
+
+	it("UNCOVERED_STORY", () => {
+		const uncovered = floorOf({epicStories: [1, 2]}).defects.find(
+			(defect) => defect.type === "UNCOVERED_STORY",
+		);
+		expect(uncovered?.detail).toBe("story 2 is claimed by no child");
+	});
+
+	it.each([
+		["absent", "acceptance criteria read as absent"],
+		["malformed", "acceptance criteria read as malformed"],
+	] as const)("ZERO_AC on a %s criteria read", (token, detail) => {
+		const found = floorOf({children: [child({criteria: token, criteriaCount: 0})]}).defects.find(
+			(defect) => defect.type === "ZERO_AC",
+		);
+		expect(found?.detail).toBe(detail);
+	});
+
+	it("ZERO_AC on a Found block with zero criteria", () => {
+		expect(types({children: [child({criteriaCount: 0})]})).toContain("ZERO_AC");
+	});
+
+	it("MISSING_STORY, quoting a non-conforming value", () => {
+		const found = floorOf({
+			children: [child({stories: null, storiesValue: "1, 3 (see #4021)"})],
+		}).defects.find((defect) => defect.type === "MISSING_STORY");
+		expect(found?.detail).toBe('**Stories:** value does not conform: "1, 3 (see #4021)"');
+	});
+
+	it("MISSING_STORY only when the epic declares stories at all", () => {
+		expect(types({epicStories: [], children: [child({stories: null})]})).not.toContain(
+			"MISSING_STORY",
+		);
+	});
+
+	it.each([
+		[["p1", "status:planned"], "missing a type: label"],
+		[["p1", "type:feature"], "missing a status: label"],
+		[["status:planned", "type:feature"], "missing a priority label"],
+	])("MISSING_LABEL for %s", (labels, detail) => {
+		const found = floorOf({children: [child({labels})]}).defects.find(
+			(defect) => defect.type === "MISSING_LABEL",
+		);
+		expect(found?.detail).toBe(detail);
+	});
+
+	/** `p3` was ruled retired, not widened (#4101, #2413) — it does not satisfy the priority slot. */
+	it("MISSING_LABEL does not admit p3 as a priority", () => {
+		expect(
+			types({children: [child({labels: ["p3", "status:planned", "type:feature"]})]}),
+		).toContain("MISSING_LABEL");
+	});
+
+	it.each([
+		[null, "type:feature with containment unset"],
+		["none" as const, "type:feature with containment none"],
+	])("MISSING_CONTAINMENT for %s", (containment, detail) => {
+		const found = floorOf({children: [child({containment})]}).defects.find(
+			(defect) => defect.type === "MISSING_CONTAINMENT",
+		);
+		expect(found?.detail).toBe(detail);
+	});
+
+	it("NEEDS_TRIAGE_LABEL", () => {
+		expect(
+			types({children: [child({labels: ["p1", "status:needs-triage", "type:feature"]})]}),
+		).toContain("NEEDS_TRIAGE_LABEL");
+	});
+
+	/**
+	 * An unread field is UNKNOWN, never "unassigned is fine". Collapse `assigneesObserved` into an
+	 * empty-array check and this class becomes unreachable while `HELD_CHILD_UNASSIGNED` starts
+	 * firing on children nobody looked at.
+	 */
+	it("UNVERIFIABLE_ASSIGNEE when the payload carried no assignees key", () => {
+		expect(types({children: [child({assignees: null, assigneesObserved: false})]})).toContain(
+			"UNVERIFIABLE_ASSIGNEE",
+		);
+	});
+
+	it("HELD_CHILD_UNASSIGNED on an observed-empty slot, never on an unobserved one", () => {
+		const held = ["p1", "status:planned", "type:feature", "ready-for:human"];
+		expect(types({children: [child({labels: held})]})).toContain("HELD_CHILD_UNASSIGNED");
+		expect(
+			types({children: [child({labels: held, assignees: null, assigneesObserved: false})]}),
+		).not.toContain("HELD_CHILD_UNASSIGNED");
+	});
+});
+
+describe("skipped", () => {
+	/**
+	 * v1 fused `absent` and `unknown` through a stderr substring match, so a transient probe failure
+	 * silently switched the whole class off. Drop the `unknown` arm and an unreadable probe would read
+	 * exactly like a repo with no cycle doc.
+	 */
+	it("names MISSING_CONTAINMENT only when the cycle-doc probe failed", () => {
+		expect(floorOf({cycleDoc: "unknown"}).skipped).toEqual(["MISSING_CONTAINMENT"]);
+		expect(floorOf({cycleDoc: "absent"}).skipped).toEqual([]);
+	});
+
+	it("does not derive the class on an unknown probe", () => {
+		expect(types({cycleDoc: "unknown", children: [child({containment: null})]})).not.toContain(
+			"MISSING_CONTAINMENT",
+		);
+	});
+
+	it("derives the class and evaluates it false on an absent cycle doc", () => {
+		expect(types({cycleDoc: "absent", children: [child({containment: null})]})).not.toContain(
+			"MISSING_CONTAINMENT",
+		);
+	});
+
+	it("a skipped class never makes a defective floor clean", () => {
+		const floor = floorOf({cycleDoc: "unknown", children: [child({criteria: "absent"})]});
+		expect(floor.skipped).toEqual(["MISSING_CONTAINMENT"]);
+		expect(floor.defects.map((defect) => defect.type)).toContain("ZERO_AC");
+	});
+});
+
+describe("the list is sorted by emission order, then by the lowest ref", () => {
+	it("orders two types by the table and two of one type by ref", () => {
+		const floor = floorOf({
+			epicStories: [],
+			children: [
+				child({number: 4303, criteria: "absent"}),
+				child({number: 4302, criteria: "absent"}),
+			],
+			topology: {phases: [{phase: 1, members: ["#4302", "#4303"]}], edges: []},
+		});
+		const emitted = floor.defects.map((defect) => `${defect.type}:${defect.refs[0]}`);
+		expect(emitted).toEqual(["MISSING_STORIES_SECTION:4300", "ZERO_AC:4302", "ZERO_AC:4303"]);
+	});
+
+	it("every emitted type is in the closed enum", () => {
+		const closed = new Set<DefectType>(DEFECT_TYPES);
+		for (const type of types({dependenciesAbsent: true, epicStories: []})) {
+			expect(closed.has(type)).toBe(true);
+		}
+	});
+});
+
+describe("refsToProbe", () => {
+	it("names every referenced issue that is neither the epic nor a child", () => {
+		expect(
+			refsToProbe(
+				scope({
+					topology: {
+						phases: [{phase: 1, members: ["#4301", "#4300", "#9999", "C1"]}],
+						edges: [],
+					},
+				}),
+			),
+		).toEqual([9999]);
+	});
+});

--- a/packages/fabrika-cli/src/plan/digest.ts
+++ b/packages/fabrika-cli/src/plan/digest.ts
@@ -1,0 +1,69 @@
+/**
+ * The scope digest: the first 12 lowercase hex of the SHA-256 of a canonical serialization of the
+ * inputs the floor read.
+ *
+ * **The flip is digest-neutral by construction, and this file is where that invariant lives.** The
+ * only two labels `plan flip` writes — `status:planned` and `status:triaged` — are excluded from the
+ * child serialization, so a digest taken at check time still binds after the flip and a verdict
+ * posted afterwards attests the scope the floor actually scanned. Without the exclusion the digest
+ * would be invalidated by the very write it guards, and every clean verdict would bind a scope no
+ * floor had checked. Neither label is a floor trigger either: `MISSING_LABEL` requires *a* `status:`
+ * prefix, which both satisfy, and `NEEDS_TRIAGE_LABEL` names `status:needs-triage`, which the flip
+ * never writes.
+ *
+ * The digest is threaded explicitly and never remembered: `plan check` prints it, and the two
+ * mutating verbs require it as `--digest` and recompute from a fresh read. That is the TOCTOU answer
+ * — the gap between deciding and writing is closed by re-deciding, not by trusting a cached decision.
+ */
+
+import {createHash} from "node:crypto";
+import type {ChildLedger, Ledger} from "./model.ts";
+
+/** Everything the digest is taken over — the ledger minus the digest it is about to carry. */
+export type LedgerScope = Omit<Ledger, "digest">;
+
+/** The two labels the flip writes, excluded from the serialization. See the module docblock. */
+export const FLIP_LABELS: ReadonlyArray<string> = ["status:planned", "status:triaged"];
+
+export const DIGEST_LENGTH = 12;
+
+/** 12 lowercase hex — the one shape `--digest` accepts, so a mistyped value refuses before any read. */
+export const DIGEST_RE = /^[0-9a-f]{12}$/;
+
+const ascending = (values: ReadonlyArray<string>): string => [...values].sort().join(",");
+
+const childLine = (child: ChildLedger): string => {
+	const labels = ascending(child.labels.filter((label) => !FLIP_LABELS.includes(label)));
+	const assignees = child.assigneesObserved ? ascending(child.assignees ?? []) : "?";
+	const ac = child.criteria === "found" ? String(child.criteriaCount) : "?";
+	const stories =
+		child.stories === null
+			? "?"
+			: child.stories.length === 0
+				? "none"
+				: ascending(child.stories.map(String));
+	return `#${child.number}|labels=${labels}|assignees=${assignees}|ac=${ac}|stories=${stories}|containment=${child.containment ?? "?"}`;
+};
+
+const epicLine = (ledger: LedgerScope): string => {
+	const stories = ledger.epicStories.length === 0 ? "" : ledger.epicStories.map(String).join(",");
+	const deps = [...ledger.topology.phases]
+		.map((phase) => `p${phase.phase}:${phase.members.join(",")}`)
+		.sort()
+		.join(";");
+	const edges = ledger.topology.edges
+		.map(([dependent, prerequisite]) => `${dependent}>${prerequisite}`)
+		.sort()
+		.join(";");
+	return `epic=${ledger.epic}|stories=${stories}|cycleDoc=${ledger.cycleDoc}|deps=${deps}|edges=${edges}`;
+};
+
+/** The canonical serialization: one line per child ascending, then the epic line, joined by `\n`. */
+export const serializeScope = (ledger: LedgerScope): string =>
+	[
+		...[...ledger.children].sort((a, b) => a.number - b.number).map(childLine),
+		epicLine(ledger),
+	].join("\n");
+
+export const scopeDigest = (ledger: LedgerScope): string =>
+	createHash("sha256").update(serializeScope(ledger), "utf8").digest("hex").slice(0, DIGEST_LENGTH);

--- a/packages/fabrika-cli/src/plan/digest.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/digest.unit.test.ts
@@ -1,0 +1,96 @@
+import {describe, expect, it} from "vitest";
+import {DIGEST_RE, type LedgerScope, scopeDigest, serializeScope} from "./digest.ts";
+import type {ChildLedger} from "./model.ts";
+
+const child = (overrides: Partial<ChildLedger> = {}): ChildLedger => ({
+	number: 4301,
+	labels: ["p1", "status:planned", "type:feature"],
+	assignees: [],
+	assigneesObserved: true,
+	criteria: "found",
+	criteriaCount: 3,
+	stories: [1, 2],
+	storiesValue: null,
+	containment: "flag",
+	...overrides,
+});
+
+const scope = (overrides: Partial<LedgerScope> = {}): LedgerScope => ({
+	epic: 4300,
+	children: [child()],
+	epicStories: [1, 2],
+	cycleDoc: "present",
+	topology: {phases: [{phase: 1, members: ["#4301"]}], edges: []},
+	dependenciesAbsent: false,
+	...overrides,
+});
+
+describe("the digest is flip-neutral (the invariant the whole gate rests on)", () => {
+	/**
+	 * The only two labels `plan flip` writes are excluded from the serialization, so a digest taken at
+	 * check time still binds after the flip. Delete either name from `FLIP_LABELS` and this reds — and
+	 * in the field every clean verdict would bind a scope no floor had checked.
+	 */
+	it("does not move when a child flips from status:planned to status:triaged", () => {
+		const before = scope();
+		const after = scope({
+			children: [child({labels: ["p1", "status:triaged", "type:feature"]})],
+		});
+		expect(scopeDigest(after)).toBe(scopeDigest(before));
+	});
+
+	it("does not move mid-write, while a child carries both labels", () => {
+		const midWrite = scope({
+			children: [child({labels: ["p1", "status:planned", "status:triaged", "type:feature"]})],
+		});
+		expect(scopeDigest(midWrite)).toBe(scopeDigest(scope()));
+	});
+
+	it("DOES move when any other label changes — the exclusion is two names, not a blanket", () => {
+		const relabelled = scope({
+			children: [child({labels: ["p0", "status:planned", "type:feature"]})],
+		});
+		expect(scopeDigest(relabelled)).not.toBe(scopeDigest(scope()));
+	});
+});
+
+describe("serializeScope", () => {
+	it("is canonical: one line per child ascending, then the epic line, no trailing newline", () => {
+		const two = scope({children: [child({number: 4302}), child({number: 4301})]});
+		const lines = serializeScope(two).split("\n");
+		expect(lines[0]?.startsWith("#4301|")).toBe(true);
+		expect(lines[1]?.startsWith("#4302|")).toBe(true);
+		expect(lines[2]?.startsWith("epic=4300|")).toBe(true);
+		expect(serializeScope(two).endsWith("\n")).toBe(false);
+	});
+
+	it("distinguishes an unobserved assignee slot from an observed-empty one", () => {
+		const unobserved = serializeScope(
+			scope({children: [child({assignees: null, assigneesObserved: false})]}),
+		);
+		expect(unobserved).toContain("assignees=?");
+		expect(serializeScope(scope())).toContain("assignees=|");
+	});
+
+	it("distinguishes an absent story claim from an explicit `none`", () => {
+		expect(serializeScope(scope({children: [child({stories: null})]}))).toContain("stories=?");
+		expect(serializeScope(scope({children: [child({stories: []})]}))).toContain("stories=none");
+	});
+
+	it("carries the phase spine and the requires edges in separate fields", () => {
+		const withEdge = scope({
+			topology: {phases: [{phase: 1, members: ["#4301"]}], edges: [["#4302", "#4301"]]},
+		});
+		expect(serializeScope(withEdge)).toContain("deps=p1:#4301|edges=#4302>#4301");
+	});
+});
+
+describe("scopeDigest", () => {
+	it("is 12 lowercase hex — the shape `--digest` accepts", () => {
+		expect(scopeDigest(scope())).toMatch(DIGEST_RE);
+	});
+
+	it("is stable across two computations of one scope", () => {
+		expect(scopeDigest(scope())).toBe(scopeDigest(scope()));
+	});
+});

--- a/packages/fabrika-cli/src/plan/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/plan/fixtures.test-support.ts
@@ -1,0 +1,88 @@
+/**
+ * The canned `gh` responses the `plan` verb tests script their spawner with.
+ *
+ * Shaped like the real payloads rather than like the parsers, so a parser that starts reading a
+ * different field still has to find it here — a fixture trimmed to exactly what the code reads today
+ * stops being able to catch tomorrow's misread. The child payload carries its `assignees` key by
+ * default and {@link child} can drop it entirely, because *the key was not there* is the fact
+ * `UNVERIFIABLE_ASSIGNEE` rests on and no fixture that always includes it could exercise the split.
+ */
+
+import {okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+
+export const EPIC = 4300;
+export const SESSION = "s-9f2e";
+
+/** An epic body with one phase line, two contiguous stories, and no fenced decoys. */
+export const epicBody = (overrides: {dependencies?: string; stories?: string} = {}): string =>
+	[
+		"An epic.",
+		"",
+		"### User stories",
+		"",
+		overrides.stories ??
+			"1. As a planner, I want a gate.\n2. As a builder, I want pickable children.",
+		"",
+		"## Dependencies",
+		"",
+		overrides.dependencies ?? "- phase 1: #4301, #4302",
+		"",
+	].join("\n");
+
+export const epic = (overrides: Record<string, unknown> = {}): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: EPIC,
+			title: "The plan gate",
+			body: epicBody(),
+			state: "open",
+			labels: [{name: "type:epic"}],
+			html_url: "https://github.com/o/r/issues/4300",
+			milestone: null,
+			state_reason: null,
+			...overrides,
+		}),
+	);
+
+export const subIssues = (...numbers: ReadonlyArray<number>): ExecResult =>
+	okOut(JSON.stringify(numbers.map((number) => ({number, title: `child ${number}`}))));
+
+/** A child body that clears the floor: criteria, a story claim, and a containment marker. */
+export const childBody = (
+	overrides: {stories?: string | null; containment?: string | null; criteria?: string} = {},
+): string =>
+	[
+		"### Acceptance criteria",
+		"",
+		overrides.criteria ?? "- [ ] the verb runs\n- [ ] the guard reds",
+		"",
+		overrides.stories === null ? "" : `**Stories:** ${overrides.stories ?? "1, 2"}`,
+		overrides.containment === null ? "" : `**Containment:** ${overrides.containment ?? "flag"}`,
+		"",
+	].join("\n");
+
+export const child = (options: {
+	number: number;
+	labels?: ReadonlyArray<string>;
+	assignees?: ReadonlyArray<string> | null;
+	body?: string;
+	state?: string;
+}): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: options.number,
+			title: `child ${options.number}`,
+			body: options.body ?? childBody(),
+			state: options.state ?? "open",
+			labels: (options.labels ?? ["type:feature", "p1", "status:planned"]).map((name) => ({name})),
+			// `null` drops the key entirely — the unobserved slot, not an observed-empty one.
+			...(options.assignees === null
+				? {}
+				: {assignees: (options.assignees ?? []).map((login) => ({login}))}),
+			html_url: `https://github.com/o/r/issues/${options.number}`,
+		}),
+	);
+
+export const labelSet = (...names: ReadonlyArray<string>): ExecResult =>
+	okOut(`${names.join("\n")}\n`);

--- a/packages/fabrika-cli/src/plan/flip-verb.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.ts
@@ -1,0 +1,212 @@
+/**
+ * `plan flip` — flip every `status:planned` child to `status:triaged`, re-gating first, and report the
+ * **observed** result per child.
+ *
+ * Four guards, each designed against a named v1 failure:
+ *
+ * 1. **Re-gate.** The floor is re-derived and the digest recomputed here, not read off a prior verb's
+ *    exit code. The gap between deciding and writing is closed by re-deciding.
+ * 2. **Vocabulary precondition.** `POST .../labels` *creates* an unknown label rather than rejecting
+ *    it (#4285), so an absent label would be silently minted. With nothing to write the check is
+ *    skipped — a `nothing-to-flip` success must not refuse over a label it was never going to touch.
+ * 3. **Add before remove, always.** That order is load-bearing, not stylistic: a child caught between
+ *    the two calls carries **both** labels, which still satisfies `MISSING_LABEL`'s "a `status:`
+ *    prefix" and neither of which is in the digest. Under the reverse order a child between the calls
+ *    carries **no** `status:` label, `MISSING_LABEL` flips true, and `plan verdict` would then
+ *    re-derive a defective floor on a run the gate believes clean. A failing child never aborts its
+ *    siblings.
+ * 4. **Re-read every child.** v1 asserted the flip from its pre-mutation intent list and re-read
+ *    nothing, so a child left carrying both labels — the ADD landing and the DELETE failing — was
+ *    reported as pickable.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {requireClaim, requireSession} from "../build/claim.ts";
+import {badNumber, resolveTargetRepo} from "../build/target.ts";
+import {addLabels, listLabels, removeLabel} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	FLOOR_DEFECTIVE,
+	LABEL_ABSENT,
+	OFF_VOCABULARY,
+	PARTIAL_FLIP,
+	PLAN_MOVED,
+	PRECONDITION_UNKNOWN,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {DIGEST_RE, FLIP_LABELS} from "./digest.ts";
+import {getChild} from "./github.ts";
+import {
+	deriveFloorFor,
+	FAN_OUT,
+	loadLedger,
+	type PlanMessages,
+	requireEpic,
+	scannedChildren,
+} from "./load.ts";
+
+const VERB = "plan flip";
+
+const PLANNED = "status:planned";
+const TRIAGED = "status:triaged";
+
+export const MESSAGES: PlanMessages = {
+	verb: VERB,
+	grammar: (reason) => `${VERB}: the ledger grammar refused during the re-gate: ${reason}`,
+	zeroChildren: (epic) =>
+		`${VERB}: #${epic} has zero children — refusing to act over zero scope (ADR 0092).`,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to flip its children.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was written.`,
+};
+
+/** Closed and **total over every child**, not only the ones the flip wrote. */
+export type FlipResult = "flipped" | "already" | "unchanged" | "not-planned";
+
+export interface FlipOptions {
+	readonly number: number;
+	readonly digest: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** The observed labels decide the result — never the intent the write was issued with. */
+export const classify = (
+	before: ReadonlyArray<string>,
+	observed: ReadonlyArray<string>,
+): FlipResult => {
+	if (!before.includes(PLANNED)) return before.includes(TRIAGED) ? "already" : "not-planned";
+	return observed.includes(TRIAGED) && !observed.includes(PLANNED) ? "flipped" : "unchanged";
+};
+
+export const runFlip = (
+	options: FlipOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const bad = badNumber(VERB, "an issue number", options.number);
+		if (bad !== null) return bad;
+		if (!DIGEST_RE.test(options.digest)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --digest must be 12 lowercase hex — got "${options.digest}".`,
+			);
+		}
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* requireEpic(MESSAGES, repo, options.number);
+		if (target._tag === "Refused") return target.outcome;
+
+		const held = yield* requireClaim(VERB, repo, options.number, session.id);
+		if (held._tag === "Refused") return held.outcome;
+
+		const read = yield* loadLedger(MESSAGES, repo, target.issue);
+		if (read._tag === "Refused") return read.outcome;
+		const ledger = read.ledger;
+		const scanned = scannedChildren(
+			VERB,
+			ledger.children.map((child) => child.number),
+		);
+		const notes = [...held.notes, scanned];
+
+		const derived = yield* deriveFloorFor(MESSAGES, repo, ledger);
+		if (derived._tag === "Refused") return derived.outcome;
+		if (derived.floor.defects.length > 0) {
+			return refuse(
+				FLOOR_DEFECTIVE,
+				`${VERB}: the floor is not clean (${derived.floor.defects.length} defect(s)) — refusing to flip.`,
+				notes,
+			);
+		}
+		if (ledger.digest !== options.digest) {
+			return refuse(
+				PLAN_MOVED,
+				`${VERB}: the plan moved since the check (digest ${options.digest} → ${ledger.digest}) — re-check before flipping.`,
+				notes,
+			);
+		}
+
+		const planned = ledger.children.filter((child) => child.labels.includes(PLANNED));
+		if (planned.length > 0) {
+			const labels = yield* listLabels(repo);
+			if (labels._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					MESSAGES.unreadable(`${repo}'s label taxonomy`, labels.reason),
+					notes,
+				);
+			}
+			for (const label of FLIP_LABELS) {
+				if (labels.value.includes(label)) continue;
+				return refuse(
+					LABEL_ABSENT,
+					`${VERB}: label "${label}" is absent from ${repo}'s taxonomy — refusing to create it (#4285).`,
+					notes,
+				);
+			}
+		}
+
+		let writes = 0;
+		yield* Effect.forEach(
+			planned,
+			(child) =>
+				Effect.gen(function* () {
+					const added = yield* addLabels(repo, child.number, [TRIAGED]);
+					if (added._tag === "Ok") writes += 1;
+					const removed = yield* removeLabel(repo, child.number, PLANNED);
+					if (removed._tag === "Ok") writes += 1;
+				}),
+			{concurrency: FAN_OUT, discard: true},
+		);
+
+		const reread = yield* Effect.forEach(
+			ledger.children,
+			(child) => getChild(repo, child.number).pipe(Effect.map((found) => [child, found] as const)),
+			{concurrency: FAN_OUT},
+		);
+
+		const rows: {number: number; observed: ReadonlyArray<string>; result: FlipResult}[] = [];
+		for (const [child, found] of reread) {
+			if (found._tag !== "Present") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: wrote ${writes} label change(s) and could not re-read child #${child.number} — the outcome is UNKNOWN.`,
+					notes,
+				);
+			}
+			const observed = [...found.value.labels].sort();
+			rows.push({number: child.number, observed, result: classify(child.labels, observed)});
+		}
+
+		const unchanged = rows.filter((row) => row.result === "unchanged");
+		if (unchanged.length > 0) {
+			const flipped = rows.filter((row) => row.result === "flipped").length;
+			return refuse(
+				PARTIAL_FLIP,
+				`${VERB}: ${flipped} of ${rows.length} children flipped; ${unchanged.length} unchanged (${unchanged
+					.map((row) => `#${row.number}`)
+					.join(", ")}) — the epic is half-flipped and needs a human.`,
+				notes,
+			);
+		}
+
+		const flipped = rows.filter((row) => row.result === "flipped").length;
+		const already = rows.filter((row) => row.result === "already").length;
+		return answer(
+			JSON.stringify({
+				answer: "flipped",
+				epic: ledger.epic,
+				digest: ledger.digest,
+				terminal: planned.length === 0 ? "nothing-to-flip" : "flipped-all",
+				children: rows,
+				flipped,
+				already,
+			}),
+			notes,
+		);
+	});

--- a/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
@@ -1,0 +1,253 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {comments, LANE_UUID, marker} from "../build/fixtures.test-support.ts";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {runCheck} from "./check-verb.ts";
+import {
+	CLAIM_NOT_MINE,
+	FLOOR_DEFECTIVE,
+	LABEL_ABSENT,
+	OFF_VOCABULARY,
+	PARTIAL_FLIP,
+	PLAN_MOVED,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	child,
+	childBody,
+	epic,
+	epicBody,
+	labelSet,
+	SESSION,
+	subIssues,
+} from "./fixtures.test-support.ts";
+import {runFlip} from "./flip-verb.ts";
+
+const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
+const CHILD = /^gh api repos\/o\/r\/issues\/4301$/;
+const CYCLE = /^gh api repos\/o\/r\/contents\/product-development-cycle\.md$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4300\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
+const ADD = /^gh api --method POST repos\/o\/r\/issues\/4301\/labels/;
+const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4301\/labels/;
+
+const ONE_CHILD_EPIC = epic({body: epicBody({dependencies: "- phase 1: #4301"})});
+
+const env = {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: SESSION} as Record<
+	string,
+	string | undefined
+>;
+
+const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[COMMENTS, comments({id: 1, body: marker(SESSION, LANE_UUID)})],
+	[PERM, okOut("write\n")],
+];
+
+const PLANNED = child({number: 4301, labels: ["type:feature", "p1", "status:planned"]});
+const TRIAGED = child({number: 4301, labels: ["type:feature", "p1", "status:triaged"]});
+
+/** The ledger reads, in the order the flip issues them; `once` lets the re-read differ. */
+const ledger = (
+	first: ExecResult,
+	reread: ExecResult,
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[EPIC, ONE_CHILD_EPIC],
+	[SUBS, subIssues(4301)],
+	[once(CHILD), first],
+	[CYCLE, okOut("{}")],
+	[CHILD, reread],
+];
+
+const digestOf = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>): Promise<string> => {
+	const out = await Effect.runPromise(
+		Effect.provide(
+			runCheck({number: 4300, repo: null, env: {CLAUDE_PIPELINE_REPO: "o/r"}}),
+			fakeShell(script).layer,
+		),
+	);
+	return JSON.parse(out.stdout).digest as string;
+};
+
+const CLEAN_READ: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[EPIC, ONE_CHILD_EPIC],
+	[SUBS, subIssues(4301)],
+	[CHILD, PLANNED],
+	[CYCLE, okOut("{}")],
+];
+
+const run = (digest: string, script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(runFlip({number: 4300, digest, repo: null, env}), shell.layer),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+describe("runFlip", () => {
+	it("flips a planned child and reports the OBSERVED labels", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const {outcome} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, TRIAGED),
+			[LABELS, labelSet("status:planned", "status:triaged", "type:feature")],
+			[ADD, okOut("[]")],
+			[REMOVE, okOut("[]")],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			answer: "flipped",
+			terminal: "flipped-all",
+			flipped: 1,
+			already: 0,
+			children: [
+				{number: 4301, observed: ["p1", "status:triaged", "type:feature"], result: "flipped"},
+			],
+		});
+	});
+
+	/**
+	 * `status:triaged` is added BEFORE `status:planned` is removed, always. Swap the two calls and a
+	 * child caught between them carries no `status:` label at all — `MISSING_LABEL` flips true and
+	 * `plan verdict` then re-derives a defective floor on a run the gate believes clean.
+	 */
+	it("adds before it removes", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const {calls} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, TRIAGED),
+			[LABELS, labelSet("status:planned", "status:triaged")],
+			[ADD, okOut("[]")],
+			[REMOVE, okOut("[]")],
+		]);
+		const add = calls.findIndex((line) => /--method POST .*labels/.test(line));
+		const remove = calls.findIndex((line) => /--method DELETE .*labels/.test(line));
+		expect(add).toBeGreaterThanOrEqual(0);
+		expect(remove).toBeGreaterThan(add);
+	});
+
+	/**
+	 * The flip re-derives the floor itself rather than trusting any caller's reading of `plan check`'s
+	 * exit code. Delete the re-gate and a defective plan flips straight into the build pool.
+	 */
+	it("refuses 20 on a defective floor, and writes nothing", async () => {
+		const defective = child({
+			number: 4301,
+			labels: ["type:feature", "p1", "status:planned"],
+			body: childBody({criteria: "no boxes"}),
+		});
+		const digest = await digestOf([
+			[EPIC, ONE_CHILD_EPIC],
+			[SUBS, subIssues(4301)],
+			[CHILD, defective],
+			[CYCLE, okOut("{}")],
+		]);
+		const {outcome, calls} = await run(digest, [
+			...CLAIMED,
+			...ledger(defective, defective),
+			[LABELS, labelSet("status:planned", "status:triaged")],
+		]);
+		expect(outcome.code).toBe(FLOOR_DEFECTIVE);
+		expect(outcome.stdout).toBe("");
+		expect(calls.some((line) => /--method (POST|DELETE) .*labels/.test(line))).toBe(false);
+	});
+
+	/** The TOCTOU answer: the gap between deciding and writing is closed by re-deciding. */
+	it("refuses 21 when the recomputed digest differs from --digest", async () => {
+		const {outcome, calls} = await run("000000000000", [
+			...CLAIMED,
+			...ledger(PLANNED, TRIAGED),
+			[LABELS, labelSet("status:planned", "status:triaged")],
+		]);
+		expect(outcome.code).toBe(PLAN_MOVED);
+		expect(outcome.stderr.at(-1)).toContain("the plan moved since the check");
+		expect(calls.some((line) => /--method (POST|DELETE) .*labels/.test(line))).toBe(false);
+	});
+
+	/**
+	 * `POST .../labels` creates an unknown label rather than rejecting it (#4285), so an absent label
+	 * would be silently minted. Drop the precondition and the write below invents `status:triaged`.
+	 */
+	it("refuses 23 when a label it must write is absent from the taxonomy", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const {outcome, calls} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, TRIAGED),
+			[LABELS, labelSet("status:planned", "type:feature")],
+		]);
+		expect(outcome.code).toBe(LABEL_ABSENT);
+		expect(outcome.stderr.at(-1)).toContain('label "status:triaged" is absent');
+		expect(calls.some((line) => /--method POST .*labels/.test(line))).toBe(false);
+	});
+
+	it("skips the vocabulary check when there is nothing to flip", async () => {
+		const already = child({number: 4301, labels: ["type:feature", "p1", "status:triaged"]});
+		const digest = await digestOf([
+			[EPIC, ONE_CHILD_EPIC],
+			[SUBS, subIssues(4301)],
+			[CHILD, already],
+			[CYCLE, okOut("{}")],
+		]);
+		const {outcome, calls} = await run(digest, [...CLAIMED, ...ledger(already, already)]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			terminal: "nothing-to-flip",
+			flipped: 0,
+			already: 1,
+		});
+		expect(calls.some((line) => LABELS.test(line))).toBe(false);
+	});
+
+	/**
+	 * v1 asserted the flip from its pre-mutation intent list and re-read nothing, so a child left
+	 * carrying both labels — the ADD landing and the DELETE failing — was reported as pickable.
+	 */
+	it("refuses 22 when the re-read proves a child did not move", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const stuck = child({
+			number: 4301,
+			labels: ["type:feature", "p1", "status:planned", "status:triaged"],
+		});
+		const {outcome} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, stuck),
+			[LABELS, labelSet("status:planned", "status:triaged")],
+			[ADD, okOut("[]")],
+			[REMOVE, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(PARTIAL_FLIP);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("1 unchanged (#4301) — the epic is half-flipped");
+	});
+
+	it("refuses 8 when a write landed and no re-read can prove its outcome", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const {outcome} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, errOut("gh: Bad gateway (HTTP 502)")),
+			[LABELS, labelSet("status:planned", "status:triaged")],
+			[ADD, okOut("[]")],
+			[REMOVE, okOut("[]")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("the outcome is UNKNOWN");
+	});
+
+	it("refuses 15 when this session does not hold the epic's claim", async () => {
+		const {outcome, calls} = await run("4d90e1bb27ac", [
+			[EPIC, ONE_CHILD_EPIC],
+			[COMMENTS, comments({id: 1, body: marker("another-session", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+		]);
+		expect(outcome.code).toBe(CLAIM_NOT_MINE);
+		expect(calls.some((line) => /--method/.test(line))).toBe(false);
+	});
+
+	it("refuses 10 on a --digest that is not 12 lowercase hex, before any read", async () => {
+		const {outcome, calls} = await run("NOTHEX", []);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toContain("--digest must be 12 lowercase hex");
+		expect(calls).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/plan/github.ts
+++ b/packages/fabrika-cli/src/plan/github.ts
@@ -1,0 +1,129 @@
+/**
+ * The two GitHub reads this gate needs that no shipped module already makes, plus the repo-file probe
+ * `MISSING_CONTAINMENT` rests on. Everything else is imported (`io/issues.ts`, `build/target.ts`).
+ *
+ * Both reads keep the package's two standing disciplines, which is why they are here rather than
+ * inline in a verb:
+ *
+ * - **A shape that is not what was asked for is a failure, never an empty result.** A sub-issue list
+ *   that decodes to something else fails; it never reads back as "this epic has no children", which
+ *   would turn a broken read into a clean zero-scope refusal about a real ledger.
+ * - **Absence is decided by HTTP status, never by matching text against `gh`'s stderr.** v1 used
+ *   `/404|not found/i.test(stderr)`, which reads an auth-hidden repo as a proven-absent issue.
+ *
+ * **Why the child read is not `getIssue`.** `IssueRecord` drops the payload's `assignees` key
+ * entirely, and the distinction `UNVERIFIABLE_ASSIGNEE` rests on is exactly *the key was not there* —
+ * a fact no shape that omits the field can carry. {@link ChildPayload} is that shape: a sibling of
+ * `io/issues.ts`'s readers, decoded from the same endpoint, one fetch per child.
+ */
+
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+import {
+	absent,
+	type Existence,
+	httpStatusOf,
+	present,
+	splitJsonArrays,
+	unknown,
+} from "../io/issues.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+import type {CycleDoc} from "./model.ts";
+
+/** The cycle doc the containment class is gated on, at the target repository's root. */
+export const CYCLE_DOC_PATH = "product-development-cycle.md";
+
+/**
+ * The epic's children, from the **native sub-issue link list**, paginated in full.
+ *
+ * Typed-JSON decoded rather than `--jq`: `-r` errors mid-stream on a control character in a title and
+ * reads back as an empty body, which for a child list is a false "no children".
+ */
+export const listSubIssues = (repo: string, epic: number): Shell<Attempt<ReadonlyArray<number>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues/${epic}/sub_issues?per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const numbers: number[] = [];
+		for (const page of splitJsonArrays(r.stdout)) {
+			const parsed = parseJson(page);
+			if (!Array.isArray(parsed)) {
+				return fail("`gh api` exited 0 but its output is not a list of sub-issues");
+			}
+			for (const value of parsed) {
+				if (!isRecord(value) || typeof value.number !== "number") {
+					return fail("`gh api` exited 0 but one entry is not a sub-issue");
+				}
+				numbers.push(value.number);
+			}
+		}
+		return ok(numbers);
+	});
+
+/** One child as the ledger reads it — labels, body, and the three-state assignee slot. */
+export interface ChildPayload {
+	readonly number: number;
+	readonly labels: ReadonlyArray<string>;
+	readonly body: string;
+	readonly state: string;
+	/** The observed logins, or `null` when the payload carried no `assignees` key at all. */
+	readonly assignees: ReadonlyArray<string> | null;
+	readonly assigneesObserved: boolean;
+}
+
+const toChildPayload = (value: unknown): ChildPayload | null => {
+	if (!isRecord(value) || typeof value.number !== "number") return null;
+	const names = Array.isArray(value.labels)
+		? value.labels.map((l) => (isRecord(l) && typeof l.name === "string" ? l.name : null))
+		: null;
+	if (names === null || names.includes(null)) return null;
+
+	const observed = Object.hasOwn(value, "assignees") && Array.isArray(value.assignees);
+	const logins = observed
+		? (value.assignees as ReadonlyArray<unknown>).map((a) =>
+				isRecord(a) && typeof a.login === "string" ? a.login : null,
+			)
+		: null;
+	if (logins?.includes(null) === true) return null;
+
+	return {
+		number: value.number,
+		labels: names as ReadonlyArray<string>,
+		body: typeof value.body === "string" ? value.body : "",
+		state: typeof value.state === "string" ? value.state : "",
+		assignees: logins as ReadonlyArray<string> | null,
+		assigneesObserved: observed,
+	};
+};
+
+export const getChild = (repo: string, child: number): Shell<Existence<ChildPayload>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/issues/${child}`]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404
+				? absent<ChildPayload>()
+				: unknown<ChildPayload>(r.reason);
+		}
+		const payload = toChildPayload(parseJson(r.stdout));
+		return payload === null
+			? unknown<ChildPayload>("`gh api` exited 0 but its output is not an issue")
+			: present(payload);
+	});
+
+/**
+ * Whether the repository carries the cycle doc — three-valued, and the third value is the point.
+ *
+ * A probe that **failed** answers `unknown`, which puts `MISSING_CONTAINMENT` in the floor's
+ * `skipped` array rather than evaluating it false. Folding `unknown` into `absent` is precisely v1's
+ * bug: a transient failure silently switched the whole class off for a run.
+ */
+export const probeCycleDoc = (repo: string): Shell<CycleDoc> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/contents/${CYCLE_DOC_PATH}`]);
+		if (r.ok) return "present" as const;
+		return httpStatusOf(r.reason) === 404 ? ("absent" as const) : ("unknown" as const);
+	});

--- a/packages/fabrika-cli/src/plan/ledger.ts
+++ b/packages/fabrika-cli/src/plan/ledger.ts
@@ -1,0 +1,178 @@
+/**
+ * The ledger grammar this gate reads — the epic's sections and the two per-child field lines.
+ *
+ * Three defect types and the scope digest all rest on it, and v1's equivalents were silently
+ * permissive in ways that changed a plan's meaning without saying so. Three refusals answer three
+ * scars, and each is a refusal rather than a first-match win because the alternative is a plan whose
+ * meaning depends on ordering nobody stated:
+ *
+ * - **A section that appears twice is undecidable**, not "read the first one".
+ * - **A field line that appears twice is undecidable**, likewise.
+ * - **Story ids are the list items' own leading integers**, never their positions, and a non-empty
+ *   list must run from 1 with no gaps or repeats — v1 read positions, so a mis-numbered list
+ *   silently renumbered every story and the coverage defects then pointed at the wrong ones.
+ *
+ * **Fenced code blocks are scanned by nothing here.** v1 had no fence awareness anywhere, so a
+ * documentation example inside a fence set a real child's data.
+ *
+ * `## Dependencies` is deliberately absent from this module: it is read through the imported
+ * `../build/dependencies.ts` parser, and this spec adds no second grammar for it.
+ */
+
+const FENCE = /^ {0,3}(```|~~~)/;
+const ATX_HEADING = /^ {0,3}(#{1,6})[ \t]+(.*?)[ \t]*#*[ \t]*$/;
+const ORDERED_ITEM = /^[ \t]*(\d+)[.)][ \t]+\S/;
+
+/** One body line the grammar may read: everything inside a fence is dropped before anything looks. */
+export interface LedgerLine {
+	readonly text: string;
+	/** 1-based, so a refusal can point at a line a human can find. */
+	readonly line: number;
+}
+
+/** The body's lines with every fenced block removed, fences included. */
+export const unfencedLines = (body: string): ReadonlyArray<LedgerLine> => {
+	const out: LedgerLine[] = [];
+	let fence: string | null = null;
+	for (const [index, text] of body.split("\n").entries()) {
+		const opener = FENCE.exec(text)?.[1];
+		if (fence === null) {
+			if (opener !== undefined) {
+				fence = opener;
+				continue;
+			}
+			out.push({text, line: index + 1});
+			continue;
+		}
+		if (opener?.startsWith(fence) === true) fence = null;
+	}
+	return out;
+};
+
+const normalizeHeading = (text: string): string => text.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+interface Heading {
+	readonly level: number;
+	readonly key: string;
+	readonly index: number;
+}
+
+const headingsIn = (lines: ReadonlyArray<LedgerLine>): ReadonlyArray<Heading> => {
+	const headings: Heading[] = [];
+	for (const [index, {text}] of lines.entries()) {
+		const matched = ATX_HEADING.exec(text);
+		if (matched?.[1] === undefined || matched[2] === undefined) continue;
+		headings.push({level: matched[1].length, key: normalizeHeading(matched[2]), index});
+	}
+	return headings;
+};
+
+/**
+ * How many times `heading` opens a section, at any level.
+ *
+ * Level-indifferent by contract: a ledger is read the same whether its author wrote `##` or `###`,
+ * so a duplicate must be caught the same way. The count is what the caller seats the `4` on.
+ */
+export const sectionCount = (body: string, heading: string): number => {
+	const key = normalizeHeading(heading);
+	return headingsIn(unfencedLines(body)).filter((h) => h.key === key).length;
+};
+
+/** A section's content lines: everything up to the next heading of the same or shallower level. */
+const sectionBody = (body: string, heading: string): ReadonlyArray<LedgerLine> | null => {
+	const lines = unfencedLines(body);
+	const headings = headingsIn(lines);
+	const key = normalizeHeading(heading);
+	const opener = headings.find((h) => h.key === key);
+	if (opener === undefined) return null;
+	const closer = headings.find((h) => h.index > opener.index && h.level <= opener.level);
+	return lines.slice(opener.index + 1, closer?.index ?? lines.length);
+};
+
+export const USER_STORIES_HEADING = "User stories";
+export const STORIES_FIELD = "Stories";
+export const CONTAINMENT_FIELD = "Containment";
+
+/**
+ * The epic's declared story ids.
+ *
+ * `MisNumbered` is a refusal and the two empty readings are not: an absent section or an empty list
+ * reads as zero stories and feeds `MISSING_STORIES_SECTION`, which would otherwise be unreachable.
+ * The contiguity rule applies only to a non-empty list.
+ */
+export type EpicStories =
+	| {readonly _tag: "Stories"; readonly ids: ReadonlyArray<number>}
+	| {readonly _tag: "MisNumbered"; readonly ids: ReadonlyArray<number>};
+
+export const readEpicStories = (body: string): EpicStories => {
+	const section = sectionBody(body, USER_STORIES_HEADING);
+	if (section === null) return {_tag: "Stories", ids: []};
+	const ids: number[] = [];
+	for (const {text} of section) {
+		const matched = ORDERED_ITEM.exec(text);
+		if (matched?.[1] !== undefined) ids.push(Number.parseInt(matched[1], 10));
+	}
+	if (ids.length === 0) return {_tag: "Stories", ids: []};
+	const contiguous = ids.every((id, i) => id === i + 1);
+	return contiguous ? {_tag: "Stories", ids} : {_tag: "MisNumbered", ids};
+};
+
+/** The `**<field>:**` lines outside a fence, in order — the caller refuses on a second one. */
+export const fieldLines = (body: string, field: string): ReadonlyArray<string> => {
+	// Three spellings, because the bolding may close before or after the colon and an unbolded line is
+	// still the field: `**Stories:** v`, `**Stories**: v`, `Stories: v`.
+	const pattern = new RegExp(
+		`^[ \\t]*(?:\\*\\*${field}:\\*\\*|\\*\\*${field}\\*\\*[ \\t]*:|${field}[ \\t]*:)[ \\t]*(.*)$`,
+		"i",
+	);
+	const values: string[] = [];
+	for (const {text} of unfencedLines(body)) {
+		const matched = pattern.exec(text);
+		if (matched?.[1] !== undefined) values.push(matched[1].trim());
+	}
+	return values;
+};
+
+/** The `**Stories:**` value grammar: `none`, or a comma-separated list of bare integers. */
+const STORIES_VALUE = /^(none|\d+(\s*,\s*\d+)*)$/i;
+
+/**
+ * A child's claimed story ids.
+ *
+ * `NonConforming` is deliberately **not** a refusal: it reads as absent — which is what
+ * `MISSING_STORY` tests — and the offending value is carried so the defect's `detail` can quote it.
+ * v1 harvested every bare integer anywhere in the value, so `**Stories:** 1, 3 (see #4021)` silently
+ * claimed story 4021.
+ */
+export type ChildStories =
+	| {readonly _tag: "Ids"; readonly ids: ReadonlyArray<number>}
+	| {readonly _tag: "Absent"}
+	| {readonly _tag: "NonConforming"; readonly value: string};
+
+export const readChildStories = (value: string | undefined): ChildStories => {
+	if (value === undefined) return {_tag: "Absent"};
+	const text = value.trim();
+	if (!STORIES_VALUE.test(text)) return {_tag: "NonConforming", value: text};
+	if (text.toLowerCase() === "none") return {_tag: "Ids", ids: []};
+	return {
+		_tag: "Ids",
+		ids: text.split(",").map((part) => Number.parseInt(part.trim(), 10)),
+	};
+};
+
+export type Containment = "flag" | "exempt" | "none";
+
+/**
+ * A child's containment, leading keyword only, from the closed set.
+ *
+ * Anything unrecognised reads as unset — `null` — which `MISSING_CONTAINMENT` treats identically to
+ * `none`; only `flag` and `exempt` satisfy it.
+ */
+export const readContainment = (value: string | undefined): Containment | null => {
+	const keyword =
+		(value ?? "")
+			.trim()
+			.split(/[\s(,.]/)[0]
+			?.toLowerCase() ?? "";
+	return keyword === "flag" || keyword === "exempt" || keyword === "none" ? keyword : null;
+};

--- a/packages/fabrika-cli/src/plan/ledger.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/ledger.unit.test.ts
@@ -1,0 +1,114 @@
+import {describe, expect, it} from "vitest";
+import {
+	fieldLines,
+	readChildStories,
+	readContainment,
+	readEpicStories,
+	sectionCount,
+	unfencedLines,
+} from "./ledger.ts";
+
+describe("fence awareness", () => {
+	/**
+	 * v1 had no fence awareness anywhere, so a documentation example inside a fence set a real child's
+	 * data. Remove the fence skip in `unfencedLines` and every assertion here goes red.
+	 */
+	it("drops fenced lines, so a documented example is not a declaration", () => {
+		const body = ["**Stories:** 1", "", "```", "**Stories:** 9", "```", ""].join("\n");
+		expect(fieldLines(body, "Stories")).toEqual(["1"]);
+	});
+
+	it("counts a heading inside a fence as no section at all", () => {
+		const body = ["## Dependencies", "", "```md", "## Dependencies", "```", ""].join("\n");
+		expect(sectionCount(body, "Dependencies")).toBe(1);
+	});
+
+	it("keeps the lines outside the fence, in order", () => {
+		expect(unfencedLines("a\n```\nb\n```\nc").map((l) => l.text)).toEqual(["a", "c"]);
+	});
+});
+
+describe("sectionCount", () => {
+	it("is level-indifferent — a ledger reads the same under ## or ###", () => {
+		expect(sectionCount("### Dependencies\n", "Dependencies")).toBe(1);
+	});
+
+	it("counts a duplicate, which is what the caller seats the 4 on", () => {
+		expect(sectionCount("## Dependencies\n\n### Dependencies\n", "Dependencies")).toBe(2);
+	});
+});
+
+describe("readEpicStories", () => {
+	it("reads the items' own leading integers, never their positions", () => {
+		const body = "### User stories\n\n1. one\n2. two\n3. three\n";
+		expect(readEpicStories(body)).toEqual({_tag: "Stories", ids: [1, 2, 3]});
+	});
+
+	/**
+	 * v1 read list *positions* as ids, so a mis-numbered list silently renumbered every story and the
+	 * coverage defects pointed at the wrong ones. Drop the contiguity check and this reads `[1,3]` as
+	 * a clean two-story list.
+	 */
+	it("refuses a gap", () => {
+		const body = "### User stories\n\n1. one\n3. three\n";
+		expect(readEpicStories(body)).toEqual({_tag: "MisNumbered", ids: [1, 3]});
+	});
+
+	it("refuses a repeat", () => {
+		expect(readEpicStories("### User stories\n\n1. one\n1. one again\n")._tag).toBe("MisNumbered");
+	});
+
+	it("reads an absent section as zero stories, not as a refusal", () => {
+		expect(readEpicStories("nothing here")).toEqual({_tag: "Stories", ids: []});
+	});
+
+	it("reads an empty list as zero stories — MISSING_STORIES_SECTION's only input", () => {
+		expect(readEpicStories("### User stories\n\nnone yet\n")).toEqual({_tag: "Stories", ids: []});
+	});
+
+	it("stops at the next heading of the same or shallower level", () => {
+		const body = "### User stories\n\n1. one\n\n### Other\n\n2. not a story\n";
+		expect(readEpicStories(body)).toEqual({_tag: "Stories", ids: [1]});
+	});
+});
+
+describe("readChildStories", () => {
+	it("reads a conforming list", () => {
+		expect(readChildStories("1, 2")).toEqual({_tag: "Ids", ids: [1, 2]});
+	});
+
+	it("reads `none` as the empty list", () => {
+		expect(readChildStories("none")).toEqual({_tag: "Ids", ids: []});
+	});
+
+	it("reads no line at all as absent", () => {
+		expect(readChildStories(undefined)).toEqual({_tag: "Absent"});
+	});
+
+	/**
+	 * v1 harvested every bare integer anywhere in the value, so this line silently claimed story 4021.
+	 * Widen the value regex and the assertion below flips to `{_tag:"Ids"}`.
+	 */
+	it("reads a non-conforming value as absent, and carries it for the detail", () => {
+		expect(readChildStories("1, 3 (see #4021)")).toEqual({
+			_tag: "NonConforming",
+			value: "1, 3 (see #4021)",
+		});
+	});
+});
+
+describe("readContainment", () => {
+	it.each([
+		["flag", "flag"],
+		["exempt", "exempt"],
+		["none", "none"],
+		["flag (behind kampus-plan-gate)", "flag"],
+	])("reads the leading keyword of %s", (value, expected) => {
+		expect(readContainment(value)).toBe(expected);
+	});
+
+	it("reads anything off the closed set as unset", () => {
+		expect(readContainment("probably")).toBeNull();
+		expect(readContainment(undefined)).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/plan/load.ts
+++ b/packages/fabrika-cli/src/plan/load.ts
@@ -1,0 +1,265 @@
+/**
+ * The read all four verbs share: the epic precondition, the ledger fetch, and the floor's one probe.
+ *
+ * `plan check`, `plan flip` and `plan verdict` each re-run this fetch rather than taking a ledger on
+ * stdin or trusting an earlier verb's output — a floor that graded a caller-supplied document would
+ * grade a document the caller could edit.
+ *
+ * Every refusal is worded by the calling verb, because the same fact reads differently at each seam:
+ * an unreadable child is "the ledger is UNKNOWN" to `plan read` and "nothing was written" to
+ * `plan flip`. The codes are identical; only the sentence moves.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type PhaseLine, type RequiresLine, readTopology, renderRef} from "../build/dependencies.ts";
+import {openIssue} from "../build/target.ts";
+import {getIssue, type IssueRecord} from "../io/issues.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {read as readAcceptanceCriteria} from "../wire/acceptance-criteria.ts";
+import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {deriveFloor, type Floor, refsToProbe} from "./defects.ts";
+import {type LedgerScope, scopeDigest} from "./digest.ts";
+import {getChild, listSubIssues, probeCycleDoc} from "./github.ts";
+import {
+	CONTAINMENT_FIELD,
+	fieldLines,
+	readChildStories,
+	readContainment,
+	readEpicStories,
+	STORIES_FIELD,
+	sectionCount,
+	USER_STORIES_HEADING,
+} from "./ledger.ts";
+import type {ChildLedger, CriteriaToken, Ledger, Phase} from "./model.ts";
+
+/** Child reads and child writes run bounded. v1 spawned one `gh api` per child, unbounded. */
+export const FAN_OUT = 8;
+
+export const EPIC_TYPE_LABEL = "type:epic";
+const DEPENDENCIES_HEADING = "Dependencies";
+
+/** The four sentences a verb owns, so this module can refuse in the caller's voice. */
+export interface PlanMessages {
+	readonly verb: string;
+	/** The ledger grammar refused; `reason` is the specific defect. */
+	readonly grammar: (reason: string) => string;
+	readonly zeroChildren: (epic: number) => string;
+	readonly notAnEpic: (epic: number) => string;
+	readonly unreadable: (what: string, reason: string) => string;
+}
+
+export type EpicTarget =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Epic"; readonly issue: IssueRecord};
+
+/** The precondition every verb runs: an open issue that is a `type:epic`. */
+export const requireEpic = (
+	messages: PlanMessages,
+	repo: string,
+	number: number,
+): Effect.Effect<EpicTarget, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const target = yield* openIssue(messages.verb, repo, number, (reason) =>
+			messages.unreadable(`#${number}`, reason),
+		);
+		if (target._tag === "Refused") return {_tag: "Refused" as const, outcome: target.outcome};
+		if (!target.issue.labels.includes(EPIC_TYPE_LABEL)) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(OFF_VOCABULARY, messages.notAnEpic(number)),
+			};
+		}
+		return {_tag: "Epic" as const, issue: target.issue};
+	});
+
+export type LedgerRead =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Ledger"; readonly ledger: Ledger};
+
+const criteriaOf = (body: string): {token: CriteriaToken; count: number} => {
+	const read = readAcceptanceCriteria(body);
+	if (read._tag === "Found") return {token: "found", count: read.value.length};
+	return {token: read._tag === "Absent" ? "absent" : "malformed", count: 0};
+};
+
+/**
+ * The whole ledger, fetched fresh.
+ *
+ * The order is deliberate: the epic's own grammar refuses before a single child is fetched, so a
+ * ledger nobody could read costs one request rather than sixty.
+ */
+export const loadLedger = (
+	messages: PlanMessages,
+	repo: string,
+	epic: IssueRecord,
+): Effect.Effect<LedgerRead, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const number = epic.number;
+		const grammarRefusal = (reason: string): LedgerRead => ({
+			_tag: "Refused" as const,
+			outcome: refuse(BAD_SECTIONS, messages.grammar(reason)),
+		});
+
+		for (const [heading, spelling] of [
+			[DEPENDENCIES_HEADING, "## Dependencies"],
+			[USER_STORIES_HEADING, "### User stories"],
+		] as const) {
+			const count = sectionCount(epic.body, heading);
+			if (count > 1) {
+				return grammarRefusal(
+					`#${number} carries ${count} "${spelling}" sections — a ledger with two of one section has no single meaning.`,
+				);
+			}
+		}
+
+		const topology = readTopology(epic.body);
+		if (topology._tag === "Unparseable") {
+			return grammarRefusal(
+				`#${number}'s ## Dependencies block is unparseable at line ${topology.line}: ${topology.text}`,
+			);
+		}
+
+		const stories = readEpicStories(epic.body);
+		if (stories._tag === "MisNumbered") {
+			return grammarRefusal(
+				`#${number}'s user stories are numbered ${stories.ids.join(", ")} — a story list must run from 1 with no gaps or repeats.`,
+			);
+		}
+
+		const listed = yield* listSubIssues(repo, number);
+		if (listed._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					messages.unreadable(`#${number}'s sub-issue list`, listed.reason),
+				),
+			};
+		}
+		if (listed.value.length === 0) {
+			return {_tag: "Refused" as const, outcome: refuse(ZERO_SCOPE, messages.zeroChildren(number))};
+		}
+
+		const fetched = yield* Effect.forEach(
+			[...listed.value].sort((a, b) => a - b),
+			(child) => getChild(repo, child).pipe(Effect.map((found) => [child, found] as const)),
+			{concurrency: FAN_OUT},
+		);
+
+		const children: ChildLedger[] = [];
+		for (const [number_, found] of fetched) {
+			if (found._tag !== "Present") {
+				return {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						PRECONDITION_UNKNOWN,
+						messages.unreadable(
+							`child #${number_}`,
+							found._tag === "Absent" ? "it is proven absent" : found.reason,
+						),
+					),
+				};
+			}
+			const payload = found.value;
+			for (const [field, spelling] of [
+				[STORIES_FIELD, "**Stories:**"],
+				[CONTAINMENT_FIELD, "**Containment:**"],
+			] as const) {
+				const lines = fieldLines(payload.body, field);
+				if (lines.length > 1) {
+					return grammarRefusal(
+						`#${number}'s child #${number_} carries ${lines.length} "${spelling}" lines — a field declared twice has no single meaning.`,
+					);
+				}
+			}
+			const childStories = readChildStories(fieldLines(payload.body, STORIES_FIELD)[0]);
+			const criteria = criteriaOf(payload.body);
+			children.push({
+				number: payload.number,
+				labels: [...payload.labels].sort(),
+				assignees: payload.assignees === null ? null : [...payload.assignees].sort(),
+				assigneesObserved: payload.assigneesObserved,
+				criteria: criteria.token,
+				criteriaCount: criteria.count,
+				stories: childStories._tag === "Ids" ? childStories.ids : null,
+				storiesValue: childStories._tag === "NonConforming" ? childStories.value : null,
+				containment: readContainment(fieldLines(payload.body, CONTAINMENT_FIELD)[0]),
+			});
+		}
+
+		const parsed = topology._tag === "Parsed" ? topology.edges : [];
+		const phases: Phase[] = parsed
+			.filter((edge): edge is PhaseLine => edge._tag === "Phase")
+			.map((edge) => ({phase: edge.phase, members: edge.members.map(renderRef)}));
+		// Only `requires:` lines become edges. A phase boundary is a total order and cannot cycle, so
+		// `DEP_CYCLE` can only ever arise from an explicit requirement — see the `deps=` vs `edges=`
+		// split in the scope digest, which carries the phase spine separately.
+		const edges = parsed
+			.filter((edge): edge is RequiresLine => edge._tag === "Requires")
+			.flatMap((edge) =>
+				edge.needs.map(
+					(need) => [renderRef(edge.subject), renderRef(need)] as readonly [string, string],
+				),
+			);
+
+		const scope: LedgerScope = {
+			epic: number,
+			children,
+			epicStories: stories.ids,
+			cycleDoc: yield* probeCycleDoc(repo),
+			topology: {phases, edges},
+			dependenciesAbsent: topology._tag === "Absent",
+		};
+		return {_tag: "Ledger" as const, ledger: {...scope, digest: scopeDigest(scope)}};
+	});
+
+/**
+ * The scope line every verb prints on stderr: the count first, then the set.
+ *
+ * A sibling of `build/target.ts`'s `scannedLine` rather than a call to it — that one pluralises by
+ * appending `s`, and the noun here is `children`. The discipline it encodes is the one that matters
+ * and is kept: the count leads, so an answer over a surprising scope is auditable without re-running.
+ */
+export const scannedChildren = (verb: string, numbers: ReadonlyArray<number>): string =>
+	`${verb}: scanned ${numbers.length} child${numbers.length === 1 ? "" : "ren"}; ${numbers
+		.map((n) => `#${n}`)
+		.join(", ")}.`;
+
+export type FloorRead =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Floor"; readonly floor: Floor};
+
+/**
+ * The floor over a loaded ledger, including the one read it needs: the 404-discriminating probe
+ * behind `DANGLING_DEP`.
+ *
+ * An `Unknown` probe refuses on `11` rather than resolving either way — "I could not tell whether
+ * this ref exists" is not "it does", and it is certainly not "it does not".
+ */
+export const deriveFloorFor = (
+	messages: PlanMessages,
+	repo: string,
+	ledger: LedgerScope,
+): Effect.Effect<FloorRead, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const probed = yield* Effect.forEach(
+			refsToProbe(ledger),
+			(ref) => getIssue(repo, ref).pipe(Effect.map((found) => [ref, found] as const)),
+			{concurrency: FAN_OUT},
+		);
+		const provenAbsent = new Set<number>();
+		for (const [ref, found] of probed) {
+			if (found._tag === "Unknown") {
+				return {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						PRECONDITION_UNKNOWN,
+						messages.unreadable(`referenced issue #${ref}`, found.reason),
+					),
+				};
+			}
+			if (found._tag === "Absent") provenAbsent.add(ref);
+		}
+		return {_tag: "Floor" as const, floor: deriveFloor({ledger, provenAbsent})};
+	});

--- a/packages/fabrika-cli/src/plan/model.ts
+++ b/packages/fabrika-cli/src/plan/model.ts
@@ -1,0 +1,71 @@
+/**
+ * The ledger `plan read` prints and the other three verbs re-derive — one shape, so the floor, the
+ * digest and the flip all read the same document.
+ *
+ * Two fields exist only to keep an unread fact from reading as a permissive one, and neither is
+ * collapsible into the value beside it:
+ *
+ * - `assigneesObserved` splits *the payload carried no `assignees` key* from *the key was there and
+ *   held nothing*. `UNVERIFIABLE_ASSIGNEE` rests on exactly that split (#4693's landed shape).
+ * - `criteria` carries the imported wire read's own token rather than a count alone, so an `absent`
+ *   block and a `malformed` one stay distinguishable after the read.
+ */
+
+import type {Containment} from "./ledger.ts";
+
+/** The acceptance-criteria read's arm, carried through and never flattened. */
+export type CriteriaToken = "found" | "absent" | "malformed";
+
+export interface ChildLedger {
+	readonly number: number;
+	readonly labels: ReadonlyArray<string>;
+	/** The observed logins, or `null` when the payload carried no `assignees` key at all. */
+	readonly assignees: ReadonlyArray<string> | null;
+	readonly assigneesObserved: boolean;
+	readonly criteria: CriteriaToken;
+	readonly criteriaCount: number;
+	/** The claimed story ids, or `null` when the line is absent or its value does not conform. */
+	readonly stories: ReadonlyArray<number> | null;
+	/** The non-conforming value, quoted by `MISSING_STORY`'s detail; `null` when there was none. */
+	readonly storiesValue: string | null;
+	readonly containment: Containment | null;
+}
+
+/** The cycle-doc probe, three-valued: only `unknown` puts `MISSING_CONTAINMENT` in `skipped`. */
+export type CycleDoc = "present" | "absent" | "unknown";
+
+/** One phase line, by its declared number — the digest serializes the number, not the position. */
+export interface Phase {
+	readonly phase: number;
+	readonly members: ReadonlyArray<string>;
+}
+
+/** An edge is ordered `[dependent, prerequisite]`: `["#4302","#4301"]` reads *#4302 requires #4301*. */
+export type DependencyEdge = readonly [string, string];
+
+export interface PlanTopology {
+	readonly phases: ReadonlyArray<Phase>;
+	readonly edges: ReadonlyArray<DependencyEdge>;
+}
+
+export interface Ledger {
+	readonly epic: number;
+	readonly children: ReadonlyArray<ChildLedger>;
+	readonly epicStories: ReadonlyArray<number>;
+	readonly cycleDoc: CycleDoc;
+	readonly topology: PlanTopology;
+	/** The epic body carries no `## Dependencies` heading — `MISSING_DEPS_SECTION`'s only input. */
+	readonly dependenciesAbsent: boolean;
+	readonly digest: string;
+}
+
+/** The `topology` value as `plan read` prints it: members per phase, ascending, then the edges. */
+export const renderTopology = (
+	topology: PlanTopology,
+): {
+	readonly phases: ReadonlyArray<ReadonlyArray<string>>;
+	readonly edges: ReadonlyArray<DependencyEdge>;
+} => ({
+	phases: [...topology.phases].sort((a, b) => a.phase - b.phase).map((phase) => [...phase.members]),
+	edges: topology.edges,
+});

--- a/packages/fabrika-cli/src/plan/read-verb.ts
+++ b/packages/fabrika-cli/src/plan/read-verb.ts
@@ -1,0 +1,78 @@
+/**
+ * `plan read` — fetch the epic and its children, parse the ledger, print it as one object.
+ *
+ * The fetch and the registered parses, and no judgment: *what the plan is worth* stays in the skill,
+ * and *whether it clears the floor* is `plan check`'s. Zero children is a `7` refusal rather than an
+ * empty answer — an empty child set is not a clean read of an epic with nothing in it, it is a scope
+ * nobody can grade (ADR 0092).
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {badNumber, resolveTargetRepo} from "../build/target.ts";
+import {answer, type VerbOutcome} from "../verb.ts";
+import {loadLedger, type PlanMessages, requireEpic, scannedChildren} from "./load.ts";
+import {renderTopology} from "./model.ts";
+
+const VERB = "plan read";
+
+export const MESSAGES: PlanMessages = {
+	verb: VERB,
+	grammar: (reason) => `${VERB}: ${reason}`,
+	zeroChildren: (epic) =>
+		`${VERB}: #${epic} has zero sub-issue children — there is no ledger to read (ADR 0092).`,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to read it as one.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — the ledger is UNKNOWN.`,
+};
+
+export interface ReadOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runRead = (
+	options: ReadOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const bad = badNumber(VERB, "an issue number", options.number);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* requireEpic(MESSAGES, repo, options.number);
+		if (target._tag === "Refused") return target.outcome;
+
+		const read = yield* loadLedger(MESSAGES, repo, target.issue);
+		if (read._tag === "Refused") return read.outcome;
+		const ledger = read.ledger;
+
+		return answer(
+			JSON.stringify({
+				answer: "read",
+				epic: ledger.epic,
+				children: ledger.children.map((child) => ({
+					number: child.number,
+					labels: child.labels,
+					assignees: child.assignees,
+					assigneesObserved: child.assigneesObserved,
+					criteria: child.criteria,
+					criteriaCount: child.criteriaCount,
+					stories: child.stories,
+					containment: child.containment,
+				})),
+				epicStories: ledger.epicStories,
+				cycleDoc: ledger.cycleDoc,
+				topology: renderTopology(ledger.topology),
+				digest: ledger.digest,
+			}),
+			[
+				scannedChildren(
+					VERB,
+					ledger.children.map((child) => child.number),
+				),
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/plan/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/read-verb.unit.test.ts
@@ -1,0 +1,170 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {child, childBody, epic, epicBody, labelSet, subIssues} from "./fixtures.test-support.ts";
+import {runRead} from "./read-verb.ts";
+
+const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
+const CHILD_1 = /^gh api repos\/o\/r\/issues\/4301$/;
+const CHILD_2 = /^gh api repos\/o\/r\/issues\/4302$/;
+const CYCLE = /^gh api repos\/o\/r\/contents\/product-development-cycle\.md$/;
+
+const options = {
+	number: 4300,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(Effect.provide(runRead(options), fakeShell(script).layer));
+
+const CLEAN: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[EPIC, epic()],
+	[SUBS, subIssues(4301, 4302)],
+	[CHILD_1, child({number: 4301})],
+	[CHILD_2, child({number: 4302, body: childBody({stories: "2"})})],
+	[CYCLE, okOut('{"name":"product-development-cycle.md"}')],
+];
+
+describe("runRead", () => {
+	it("prints the ledger as one object, with the topology and the digest", async () => {
+		const out = await run(CLEAN);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.answer).toBe("read");
+		expect(answer.epic).toBe(4300);
+		expect(answer.epicStories).toEqual([1, 2]);
+		expect(answer.cycleDoc).toBe("present");
+		expect(answer.topology).toEqual({phases: [["#4301", "#4302"]], edges: []});
+		expect(answer.digest).toMatch(/^[0-9a-f]{12}$/);
+		expect(answer.children.map((c: {number: number}) => c.number)).toEqual([4301, 4302]);
+	});
+
+	it("names the scanned set on stderr, count first", async () => {
+		const out = await run(CLEAN);
+		expect(out.stderr).toContain("plan read: scanned 2 children; #4301, #4302.");
+	});
+
+	/**
+	 * The three-state slot: `assigneesObserved: false` and `assignees: null` mean the payload carried
+	 * no `assignees` key at all. Default the field to `[]` in `toChildPayload` and this reds — and in
+	 * the field `UNVERIFIABLE_ASSIGNEE` silently becomes unreachable.
+	 */
+	it("carries an unobserved assignee slot apart from an observed-empty one", async () => {
+		const out = await run([
+			[EPIC, epic()],
+			[SUBS, subIssues(4301, 4302)],
+			[CHILD_1, child({number: 4301, assignees: null})],
+			[CHILD_2, child({number: 4302, assignees: ["rmoreno"]})],
+			[CYCLE, okOut("{}")],
+		]);
+		const [first, second] = JSON.parse(out.stdout).children;
+		expect(first).toMatchObject({assignees: null, assigneesObserved: false});
+		expect(second).toMatchObject({assignees: ["rmoreno"], assigneesObserved: true});
+	});
+
+	it("refuses zero sub-issue children on 7, with nothing on stdout (ADR 0092)", async () => {
+		const out = await run([
+			[EPIC, epic()],
+			[SUBS, okOut("[]")],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("has zero sub-issue children");
+	});
+
+	it("refuses a non-epic on 10", async () => {
+		const out = await run([[EPIC, epic({labels: [{name: "type:feature"}]})]]);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("is not a type:epic");
+	});
+
+	it("refuses a proven-absent epic on 7 and an unreadable one on 11", async () => {
+		const absent = await run([[EPIC, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(absent.code).toBe(ZERO_SCOPE);
+		const unknown = await run([[EPIC, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(unknown.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	describe("the ledger grammar refuses on 4", () => {
+		it("a section declared twice", async () => {
+			const out = await run([
+				[EPIC, epic({body: `${epicBody()}\n## Dependencies\n\n- phase 2: #4302\n`})],
+			]);
+			expect(out.code).toBe(BAD_SECTIONS);
+			expect(out.stderr.at(-1)).toContain('carries 2 "## Dependencies" sections');
+		});
+
+		it("an unparseable dependencies block", async () => {
+			const out = await run([
+				[EPIC, epic({body: epicBody({dependencies: "- whenever #4301 feels ready"})})],
+			]);
+			expect(out.code).toBe(BAD_SECTIONS);
+			expect(out.stderr.at(-1)).toContain("is unparseable at line");
+		});
+
+		it("a non-empty story list that is not contiguous from 1", async () => {
+			const out = await run([[EPIC, epic({body: epicBody({stories: "1. one\n3. three"})})]]);
+			expect(out.code).toBe(BAD_SECTIONS);
+			expect(out.stderr.at(-1)).toContain("must run from 1 with no gaps or repeats");
+		});
+
+		it("a child field line declared twice", async () => {
+			const twice = `${childBody()}\n**Stories:** 2\n`;
+			const out = await run([
+				[EPIC, epic()],
+				[SUBS, subIssues(4301)],
+				[CHILD_1, child({number: 4301, body: twice})],
+			]);
+			expect(out.code).toBe(BAD_SECTIONS);
+			expect(out.stderr.at(-1)).toContain('carries 2 "**Stories:**" lines');
+		});
+	});
+
+	it("refuses an unreadable child on 11 — never an empty ledger", async () => {
+		const out = await run([
+			[EPIC, epic()],
+			[SUBS, subIssues(4301)],
+			[CHILD_1, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	/**
+	 * A sub-issue list that decodes to something else is a failure, never "this epic has no children"
+	 * — which would turn a broken read into a clean `7` about a real ledger.
+	 */
+	it("refuses a sub-issue list of the wrong shape on 11", async () => {
+		const out = await run([
+			[EPIC, epic()],
+			[SUBS, okOut('[{"id": 1}]')],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	describe("the cycle-doc probe is three-valued", () => {
+		it.each([
+			["present", okOut("{}")],
+			["absent", errOut("gh: Not Found (HTTP 404)")],
+			["unknown", errOut("gh: Bad gateway (HTTP 502)")],
+		] as const)("reads %s", async (expected, response) => {
+			const out = await run([
+				[EPIC, epic()],
+				[SUBS, subIssues(4301)],
+				[CHILD_1, child({number: 4301})],
+				[CYCLE, response],
+			]);
+			expect(JSON.parse(out.stdout).cycleDoc).toBe(expected);
+		});
+	});
+
+	it("reads the child fetches at bounded fan-out, one request per child", async () => {
+		const shell = fakeShell([...CLEAN, [/^gh api --paginate repos\/o\/r\/labels/, labelSet()]]);
+		await Effect.runPromise(Effect.provide(runRead(options), shell.layer));
+		expect(shell.calls.filter((line) => /issues\/430[12]$/.test(line))).toHaveLength(2);
+	});
+});

--- a/packages/fabrika-cli/src/plan/verdict-verb.ts
+++ b/packages/fabrika-cli/src/plan/verdict-verb.ts
@@ -1,0 +1,273 @@
+/**
+ * `plan verdict` — post the gate's verdict comment, bound to the scope digest, and read it back.
+ *
+ * **This verb derives its own polarity by re-running the floor.** `--polarity` exists only as a
+ * cross-check for an operator driving the verb by hand: when it disagrees with the derived floor the
+ * verb refuses on `10` rather than posting either, so the caller's opinion never becomes the posted
+ * verdict. A defective floor is not a refusal here — it posts the `FAIL`, which is the deliverable.
+ *
+ * The verb is the **only** emit path, and it re-reads what it posted: v1 hand-posted a gate verdict at
+ * least once and it read as genuine for weeks.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {requireClaim, requireSession} from "../build/claim.ts";
+import {badNumber, resolveTargetRepo} from "../build/target.ts";
+import {createComment, getComment} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {clause, emit, headSha, type Polarity} from "../wire/verdict-marker.ts";
+import {CAVEAT_KINDS, type Caveat, readCaveats, renderCaveats} from "./caveats.ts";
+import {
+	BARE_AT_PATH,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PLAN_MOVED,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import type {Floor} from "./defects.ts";
+import {DIGEST_RE} from "./digest.ts";
+import {
+	deriveFloorFor,
+	loadLedger,
+	type PlanMessages,
+	requireEpic,
+	scannedChildren,
+} from "./load.ts";
+import type {Ledger} from "./model.ts";
+
+const VERB = "plan verdict";
+
+/** The gate's namespace — its own, never `review`'s. A plan verdict wearing a review namespace is
+ * the family confusion the partition ruling removed (#4891). */
+export const NAMESPACE = "check-epic-plan";
+
+export const MESSAGES: PlanMessages = {
+	verb: VERB,
+	grammar: (reason) => `${VERB}: the ledger grammar refused: ${reason}`,
+	zeroChildren: (epic) => `${VERB}: #${epic} has zero children — there is no scope to attest.`,
+	notAnEpic: (epic) =>
+		`${VERB}: #${epic} is not a type:epic — refusing to post a plan verdict on it.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was posted.`,
+};
+
+/** The clause is a fixed template, not free prose. */
+export const clauseFor = (scanned: number, floor: Floor): string => {
+	const body = floor.defects.length === 0 ? "clean" : `${floor.defects.length} defect(s)`;
+	const skipped = floor.skipped.length === 0 ? "" : `, ${floor.skipped.length} class(es) skipped`;
+	return `${scanned} children scanned, floor ${body}${skipped}`;
+};
+
+/**
+ * The comment: the marker on the first line, then the scanned set, the derived defects on a `FAIL`,
+ * any skipped classes, and the caveats verbatim.
+ *
+ * `null` when the digest or the clause will not brand — both are impossible for a digest this verb
+ * computed, and both are refused rather than papered over, because a marker with an empty field is
+ * exactly what the branded slots exist to make unrepresentable.
+ */
+export const composeVerdict = (
+	ledger: Ledger,
+	floor: Floor,
+	polarity: Polarity,
+	caveats: ReadonlyArray<Caveat>,
+): string | null => {
+	const sha = headSha(ledger.digest);
+	const text = clause(clauseFor(ledger.children.length, floor));
+	if (sha === null || text === null) return null;
+	const sections = [
+		emit({namespace: NAMESPACE, polarity, sha, clause: text}).trimEnd(),
+		`Scanned: ${ledger.children.map((child) => `#${child.number}`).join(", ")}`,
+	];
+	if (floor.defects.length > 0) {
+		sections.push(
+			[
+				"## Defects",
+				...floor.defects.map(
+					(defect) =>
+						`- ${defect.type} ${defect.refs.map((ref) => `#${ref}`).join(", ")} — ${defect.detail}`,
+				),
+			].join("\n"),
+		);
+	}
+	if (floor.skipped.length > 0) {
+		sections.push(["## Skipped classes", ...floor.skipped.map((name) => `- ${name}`)].join("\n"));
+	}
+	if (caveats.length > 0) sections.push(`## Caveats\n\n${renderCaveats(caveats)}`);
+	return `${sections.join("\n\n")}\n`;
+};
+
+export interface VerdictOptions {
+	readonly number: number;
+	readonly digest: string;
+	readonly polarity: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runVerdict = (
+	options: VerdictOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const bad = badNumber(VERB, "an issue number", options.number);
+		if (bad !== null) return bad;
+		if (!DIGEST_RE.test(options.digest)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --digest must be 12 lowercase hex — got "${options.digest}".`,
+			);
+		}
+
+		const stdin = yield* options.stdin;
+		if (stdin._tag === "Failed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable("the caveats on stdin", stdin.reason),
+			);
+		}
+		const authored = stdin._tag === "Text" ? stdin.text : "";
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* requireEpic(MESSAGES, repo, options.number);
+		if (target._tag === "Refused") return target.outcome;
+
+		const held = yield* requireClaim(VERB, repo, options.number, session.id);
+		if (held._tag === "Refused") return held.outcome;
+
+		const read = yield* loadLedger(MESSAGES, repo, target.issue);
+		if (read._tag === "Refused") return read.outcome;
+		const ledger = read.ledger;
+		const notes = [
+			...held.notes,
+			scannedChildren(
+				VERB,
+				ledger.children.map((child) => child.number),
+			),
+		];
+
+		const derived = yield* deriveFloorFor(MESSAGES, repo, ledger);
+		if (derived._tag === "Refused") return derived.outcome;
+		const floor = derived.floor;
+
+		if (ledger.digest !== options.digest) {
+			return refuse(
+				PLAN_MOVED,
+				`${VERB}: the plan moved since the check (digest ${options.digest} → ${ledger.digest}) — re-check before posting.`,
+				notes,
+			);
+		}
+
+		const polarity: Polarity = floor.defects.length === 0 ? "PASS" : "FAIL";
+		if (options.polarity !== null && options.polarity.toUpperCase() !== polarity) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --polarity ${options.polarity} disagrees with the derived floor (${polarity}) — a verdict relays the floor, it does not form one.`,
+				notes,
+			);
+		}
+
+		// The bare-@ probe runs ahead of the caveat grammar, unlike the leak scan below: a body that is
+		// itself an unexpanded `@path` never arrived at all (#3086), so there is no caveat line to grade
+		// and reporting it as an off-vocabulary kind would send the caller looking at the wrong thing.
+		if (isBareAtReference(authored)) {
+			return refuse(
+				BARE_AT_PATH,
+				`${VERB}: the authored caveats carry a bare @ path reference — it cannot be redacted.`,
+				notes,
+			);
+		}
+
+		const parsed = readCaveats(authored);
+		if (parsed._tag === "OffEnum") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: caveat kind "${parsed.kind}" is not in the closed set (${CAVEAT_KINDS.join(", ")}).`,
+				notes,
+			);
+		}
+		if (parsed._tag === "Unparseable") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: "${parsed.line}" is not a caveat line — expected "caveat: <kind> #<ref> — <text>".`,
+				notes,
+			);
+		}
+		const scanned = new Set(ledger.children.map((child) => child.number));
+		for (const caveat of parsed.caveats) {
+			if (scanned.has(caveat.ref)) continue;
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: caveat names #${caveat.ref}, which is not in the scanned set.`,
+				notes,
+			);
+		}
+
+		const leaks = scanBody(authored).leaks;
+		if (leaks.length > 0) {
+			return refuse(
+				LEAKED_PATH,
+				`${VERB}: the authored caveats carry a machine-local path (${leaks.length} hit(s)).`,
+				[...notes, ...renderLeaks(leaks)],
+			);
+		}
+
+		const body = composeVerdict(ledger, floor, polarity, parsed.caveats);
+		if (body === null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(
+					"the verdict marker",
+					`the digest "${ledger.digest}" or the clause will not brand`,
+				),
+				notes,
+			);
+		}
+		const posted = yield* createComment(repo, options.number, body);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the write failed: ${posted.reason} — it may or may not have landed; re-read #${options.number} before retrying.`,
+				notes,
+			);
+		}
+		const back = yield* getComment(repo, posted.value.id);
+		if (back._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the comment posted and could not be re-read — the outcome is UNKNOWN.`,
+				notes,
+			);
+		}
+		if (normalizeForReadback(back.value) !== normalizeForReadback(body)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the comment posted but does not read back — the verdict needs a human eye.`,
+				notes,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "posted",
+				epic: ledger.epic,
+				polarity,
+				digest: ledger.digest,
+				skipped: floor.skipped,
+				comment: posted.value.id,
+				caveats: parsed.caveats.length,
+			}),
+			notes,
+		);
+	});

--- a/packages/fabrika-cli/src/plan/verdict-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/verdict-verb.unit.test.ts
@@ -1,0 +1,295 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {comments, LANE_UUID, marker} from "../build/fixtures.test-support.ts";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {read as readMarker} from "../wire/verdict-marker.ts";
+import {runCheck} from "./check-verb.ts";
+import {
+	BARE_AT_PATH,
+	CLAIM_NOT_MINE,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PLAN_MOVED,
+	READBACK_MISMATCH,
+} from "./codes.ts";
+import {child, childBody, epic, epicBody, SESSION, subIssues} from "./fixtures.test-support.ts";
+import {runVerdict} from "./verdict-verb.ts";
+
+const EPIC = /^gh api repos\/o\/r\/issues\/4300$/;
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
+const CHILD = /^gh api repos\/o\/r\/issues\/4301$/;
+const CYCLE = /^gh api repos\/o\/r\/contents\/product-development-cycle\.md$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4300\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const POST = /^gh api --method POST repos\/o\/r\/issues\/4300\/comments/;
+const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/512346$/;
+
+const ONE_CHILD_EPIC = epic({body: epicBody({dependencies: "- phase 1: #4301"})});
+const CLEAN_CHILD = child({number: 4301});
+const DEFECTIVE_CHILD = child({number: 4301, body: childBody({criteria: "no boxes"})});
+
+const env = {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: SESSION} as Record<
+	string,
+	string | undefined
+>;
+
+const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[COMMENTS, comments({id: 1, body: marker(SESSION, LANE_UUID)})],
+	[PERM, okOut("write\n")],
+];
+
+const ledger = (childPayload: ExecResult): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[EPIC, ONE_CHILD_EPIC],
+	[SUBS, subIssues(4301)],
+	[CHILD, childPayload],
+	[CYCLE, okOut("{}")],
+];
+
+const POSTED = okOut(
+	JSON.stringify({id: 512346, html_url: "https://github.com/o/r/issues/4300#c"}),
+);
+
+const digestOf = async (childPayload: ExecResult): Promise<string> => {
+	const out = await Effect.runPromise(
+		Effect.provide(
+			runCheck({number: 4300, repo: null, env: {CLAUDE_PIPELINE_REPO: "o/r"}}),
+			fakeShell(ledger(childPayload)).layer,
+		),
+	);
+	return JSON.parse(out.stdout).digest as string;
+};
+
+const run = (
+	digest: string,
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: {caveats?: string; polarity?: string | null} = {},
+) => {
+	const shell = fakeShell(script);
+	const stdin: StdinRead =
+		overrides.caveats === undefined
+			? {_tag: "NoStdin", reason: "a TTY"}
+			: {_tag: "Text", text: overrides.caveats};
+	return Effect.runPromise(
+		Effect.provide(
+			runVerdict({
+				number: 4300,
+				digest,
+				polarity: overrides.polarity ?? null,
+				repo: null,
+				env,
+				stdin: Effect.succeed(stdin),
+			}),
+			shell.layer,
+		),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+/** The bytes the verb handed `gh` — the `-f body=` operand is last on the POST line. */
+const postedBody = (calls: ReadonlyArray<string>): string => {
+	const line = calls.find((candidate) => POST.test(candidate)) ?? "";
+	return /-f body=([\s\S]*)$/.exec(line)?.[1] ?? "";
+};
+
+describe("runVerdict", () => {
+	it("posts a PASS bound to the digest and reads it back", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const first = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]]);
+		const body = postedBody(first.calls);
+		const {outcome} = await run(digest, [
+			...CLAIMED,
+			...ledger(CLEAN_CHILD),
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body}))],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "posted",
+			epic: 4300,
+			polarity: "PASS",
+			digest,
+			skipped: [],
+			comment: 512346,
+			caveats: 0,
+		});
+	});
+
+	/**
+	 * The load-bearing half of the two `verdict-marker.ts` edits: `read()` gates on the namespace
+	 * prefix *before* the regex is ever tested, so widening only the regex leaves the verb emitting a
+	 * marker its own read-back guard can never read. Revert either edit and this assertion goes red.
+	 */
+	it("emits a marker the shared format reads back", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const {calls} = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]]);
+		const marked = readMarker(postedBody(calls));
+		expect(marked._tag).toBe("Found");
+		if (marked._tag !== "Found") return;
+		expect(marked.value).toMatchObject({
+			namespace: "check-epic-plan",
+			polarity: "PASS",
+			sha: digest,
+			clause: "1 children scanned, floor clean",
+		});
+	});
+
+	it("derives FAIL from the floor and posts it — a defective floor is the deliverable", async () => {
+		const digest = await digestOf(DEFECTIVE_CHILD);
+		const {calls} = await run(digest, [...CLAIMED, ...ledger(DEFECTIVE_CHILD), [POST, POSTED]]);
+		const body = postedBody(calls);
+		expect(
+			body.startsWith(`check-epic-plan: FAIL @ ${digest} — 1 children scanned, floor 1 defect(s)`),
+		).toBe(true);
+		expect(body).toContain("## Defects");
+		expect(body).toContain("- ZERO_AC #4301 — acceptance criteria read as malformed");
+	});
+
+	/**
+	 * The caller's opinion never becomes the posted verdict: a supplied polarity that contradicts the
+	 * derived floor refuses rather than posting either.
+	 */
+	it("refuses 10 when --polarity disagrees with the derived floor, and posts nothing", async () => {
+		const digest = await digestOf(DEFECTIVE_CHILD);
+		const {outcome, calls} = await run(
+			digest,
+			[...CLAIMED, ...ledger(DEFECTIVE_CHILD), [POST, POSTED]],
+			{polarity: "PASS"},
+		);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toContain("a verdict relays the floor, it does not form one");
+		expect(calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("accepts a --polarity that agrees", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const {calls} = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]], {
+			polarity: "PASS",
+		});
+		expect(calls.some((line) => POST.test(line))).toBe(true);
+	});
+
+	it("records caveats verbatim under their kinds and counts them", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const {calls} = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]], {
+			caveats: 'caveat: ac-not-checkable #4301 — "works well" states no observable outcome',
+		});
+		const body = postedBody(calls);
+		expect(body).toContain("### ac-not-checkable");
+		expect(body).toContain('- #4301 — "works well" states no observable outcome');
+	});
+
+	it("refuses 10 on a caveat kind off the closed set", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const {outcome, calls} = await run(
+			digest,
+			[...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]],
+			{
+				caveats: "caveat: vibes #4301 — feels thin",
+			},
+		);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toContain('caveat kind "vibes" is not in the closed set');
+		expect(calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses 10 on a caveat naming a ref outside the scanned set", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const {outcome} = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]], {
+			caveats: "caveat: brief-fidelity #9999 — drifted",
+		});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toContain("which is not in the scanned set");
+	});
+
+	/** The caveat tail is model-authored prose reaching a public surface — the seat 5/6 exist for. */
+	it("refuses 5 on a machine-local path and 6 on a bare @ reference", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const leaked = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]], {
+			caveats: "caveat: brief-fidelity #4301 — see /Users/someone/notes/plan.md",
+		});
+		expect(leaked.outcome.code).toBe(LEAKED_PATH);
+		expect(leaked.calls.some((line) => POST.test(line))).toBe(false);
+
+		const bare = await run(digest, [...CLAIMED, ...ledger(CLEAN_CHILD), [POST, POSTED]], {
+			caveats: "@/Users/someone/notes/plan.md",
+		});
+		expect(bare.outcome.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses 21 when the plan moved, and posts nothing", async () => {
+		const {outcome, calls} = await run("000000000000", [
+			...CLAIMED,
+			...ledger(CLEAN_CHILD),
+			[POST, POSTED],
+		]);
+		expect(outcome.code).toBe(PLAN_MOVED);
+		expect(calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	/** The verb is the only emit path, and it re-reads what it posted. */
+	it("refuses 9 when the posted comment does not read back", async () => {
+		const digest = await digestOf(CLEAN_CHILD);
+		const {outcome} = await run(digest, [
+			...CLAIMED,
+			...ledger(CLEAN_CHILD),
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses 15 when this session does not hold the epic's claim", async () => {
+		const {outcome, calls} = await run("4d90e1bb27ac", [
+			[EPIC, ONE_CHILD_EPIC],
+			[COMMENTS, comments({id: 1, body: marker("another-session", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+		]);
+		expect(outcome.code).toBe(CLAIM_NOT_MINE);
+		expect(calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses 10 on a malformed --digest before any read", async () => {
+		const {outcome, calls} = await run("nothex", []);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(calls).toEqual([]);
+	});
+
+	it("treats an unreadable stdin as UNKNOWN, never as zero caveats", async () => {
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runVerdict({
+					number: 4300,
+					digest: "4d90e1bb27ac",
+					polarity: null,
+					repo: null,
+					env,
+					stdin: Effect.succeed<StdinRead>({_tag: "Failed", reason: "EIO"}),
+				}),
+				fakeShell([]).layer,
+			),
+		);
+		expect(outcome.code).toBe(11);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("names the skipped classes on the answer and in the marker clause", async () => {
+		const script = [
+			[EPIC, ONE_CHILD_EPIC],
+			[SUBS, subIssues(4301)],
+			[CHILD, CLEAN_CHILD],
+			[CYCLE, errOut("gh: Bad gateway (HTTP 502)")],
+		] as ReadonlyArray<readonly [RegExp, ExecResult]>;
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runCheck({number: 4300, repo: null, env: {CLAUDE_PIPELINE_REPO: "o/r"}}),
+				fakeShell(script).layer,
+			),
+		);
+		const digest = JSON.parse(out.stdout).digest as string;
+		const {calls} = await run(digest, [...CLAIMED, ...script, [POST, POSTED]]);
+		expect(postedBody(calls)).toContain("1 class(es) skipped");
+		expect(postedBody(calls)).toContain("## Skipped classes");
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {adrCommand} from "./adr/command.ts";
 import {buildCommand} from "./build/command.ts";
 import {epicCommand} from "./epic/command.ts";
 import {evalCommand} from "./eval/command.ts";
+import {planCommand} from "./plan/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
 import {shipCommand} from "./ship/command.ts";
@@ -35,6 +36,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	buildCommand,
 	epicCommand,
 	evalCommand,
+	planCommand,
 	reportCommand,
 	reviewCommand,
 	shipCommand,

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -56,7 +56,7 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 		key: "verdict-marker",
 		purpose:
 			"the SHA-bound first line of a gate's verdict comment on a PR — namespace, polarity, the head the reviewer inspected, and the human clause",
-		producers: ["review"],
+		producers: ["review", "check-epic-plan"],
 		consumers: ["build", "ship"],
 		emit: verdictMarker.emitFromFields,
 		read: verdictMarker.readToLines,

--- a/packages/fabrika-cli/src/wire/verdict-marker.ts
+++ b/packages/fabrika-cli/src/wire/verdict-marker.ts
@@ -44,7 +44,7 @@ export type Clause = string & {readonly [CLAUSE]: true};
 export type Polarity = "PASS" | "FAIL";
 
 export interface VerdictMarker {
-	/** The gate that formed the verdict: `review`, or `review-<gate>`. */
+	/** The gate that formed the verdict: `review`, `review-<gate>`, or `check-epic-plan`. */
 	readonly namespace: string;
 	readonly polarity: Polarity;
 	readonly sha: HeadSha;
@@ -56,7 +56,19 @@ export type VerdictMarkerRead = WireRead<VerdictMarker>;
 const SHA_MIN = 7;
 const SHA_MAX = 40;
 
-const NAMESPACE = /^review(-[a-z0-9]+)*$/;
+/**
+ * The gates this format serves: the `review` family, and `check-epic-plan`.
+ *
+ * Widened additively for the plan gate (#5107) — no existing marker's reading changes. A plan verdict
+ * deliberately does **not** reuse the `review` namespace: a plan verdict wearing a review namespace is
+ * the family confusion the partition ruling removed (#4891).
+ */
+const NAMESPACE = /^(review|check-epic-plan)(-[a-z0-9]+)*$/;
+/**
+ * The prefixes {@link read}'s first gate admits, which must widen with {@link NAMESPACE} or the
+ * format can emit a marker it can never read back — the gate runs *before* the regex is ever tested.
+ */
+const NAMESPACE_PREFIXES = ["review", "check-epic-plan"];
 const HEX = /^[0-9a-f]+$/;
 
 /** The conforming separator between the SHA and the clause; the ASCII dashes are read tolerantly. */
@@ -121,16 +133,18 @@ export const read = (artifact: string): VerdictMarkerRead => {
 
 	const matched = MARKER_LINE.exec(line);
 	const namespace = matched?.[2]?.toLowerCase() ?? "";
-	if (matched === undefined || matched === null || !namespace.startsWith("review")) {
+	const reaches = NAMESPACE_PREFIXES.some((prefix) => namespace.startsWith(prefix));
+	if (matched === undefined || matched === null || !reaches) {
 		return {
 			_tag: "Absent",
-			reason: 'the first line does not open with a "review…:" namespace — no marker of this format',
+			reason:
+				'the first line does not open with a "review…:" or "check-epic-plan…:" namespace — no marker of this format',
 		};
 	}
 	const evidence = `first line: "${line.trim()}"`;
 	if (!NAMESPACE.test(namespace)) {
 		return malformed(
-			`the gate namespace "${namespace}" is not kebab-case "review" or "review-<gate>"`,
+			`the gate namespace "${namespace}" is not kebab-case "review", "review-<gate>" or "check-epic-plan"`,
 			evidence,
 		);
 	}
@@ -269,7 +283,7 @@ export const parseFields = (fields: string): VerdictMarkerFields => {
 	if (!NAMESPACE.test(namespace)) {
 		return {
 			_tag: "Unusable",
-			reason: `"${namespace}" is not a "review" or "review-<gate>" namespace`,
+			reason: `"${namespace}" is not a "review", "review-<gate>" or "check-epic-plan" namespace`,
 		};
 	}
 	const polarity = polarityOf((seen.get("polarity") ?? "").trim());

--- a/packages/fabrika-cli/src/wire/verdict-marker.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/verdict-marker.unit.test.ts
@@ -112,6 +112,40 @@ describe("read — Absent", () => {
 	});
 });
 
+/**
+ * The plan gate's namespace, widened additively (#5107).
+ *
+ * The pair below is the point: `read` gates on the namespace **prefix** before `NAMESPACE` is ever
+ * tested, so widening only the regex leaves the format able to emit a marker it can never read back.
+ * Revert either edit and the round-trip case reds while the `review` cases stay green — which is
+ * exactly how the defect would have shipped.
+ */
+describe("read — the check-epic-plan namespace", () => {
+	const DIGEST = "4d90e1bb27ac";
+
+	it("round-trips a plan verdict through emit and read", () => {
+		const text = clause("2 children scanned, floor clean");
+		const sha = headSha(DIGEST);
+		expect(text).not.toBeNull();
+		expect(sha).not.toBeNull();
+		if (text === null || sha === null) return;
+		const result = read(emit({namespace: "check-epic-plan", polarity: "PASS", sha, clause: text}));
+		expect(result._tag).toBe("Found");
+		if (result._tag !== "Found") return;
+		expect(result.value.namespace).toBe("check-epic-plan");
+		expect(result.value.sha).toBe(DIGEST);
+	});
+
+	it("still answers Absent for a namespace that reaches for neither family", () => {
+		expect(read(`checkout: PASS @ ${DIGEST} — done\n`)._tag).toBe("Absent");
+	});
+
+	it("leaves the review family's reading untouched", () => {
+		expect(read(`review-code: PASS @ ${HEAD} — merge-ready\n`)._tag).toBe("Found");
+		expect(read(`review_code: PASS @ ${HEAD} — merge-ready\n`)._tag).toBe("Malformed");
+	});
+});
+
 describe("read — Malformed: the drifts a lenient reader answers `PASS` for", () => {
 	const DRIFTS = [
 		drift("no SHA at all", "review-code: PASS — merge-ready"),


### PR DESCRIPTION
Fixes #5107

`claude-plugins/fabrika/skills/check-epic-plan/contract.md` specified four verbs under a new `plan`
group and the package shipped none of them, so the skill directed a model at four commands that
exited 127. This lands the group, registered in `packages/fabrika-cli/src/registry.ts` so
`fabrika --help` lists it (the index is derived from the registry, never hand-written).

## What landed

| Verb | What it does |
|---|---|
| `plan read` | fetches the epic and its **native sub-issue children** (paginated, typed-JSON decoded, never `--jq`), parses the ledger, prints it as one object with the scope digest |
| `plan check` | the deterministic floor: a total function from the ledger to a sorted defect list over the thirteen hard types. **Both arms exit `0`**; the discriminator is the `answer` state word |
| `plan flip` | re-gates, checks the label taxonomy, adds `status:triaged` before removing `status:planned`, and reports the **observed** per-child result read back from GitHub |
| `plan verdict` | derives its own polarity from the floor, binds the marker to the scope digest, posts, and reads the comment back |

`src/wire/verdict-marker.ts` takes **both** additive edits — the `NAMESPACE` widening *and* the
`read()` pre-gate that runs before the regex is ever tested. That second one is the load-bearing
half: with only the regex widened the verb emits a marker its own read-back guard can never read.
No existing `review*` behaviour changes, and a test in
`packages/fabrika-cli/src/wire/verdict-marker.unit.test.ts` reds if either edit is reverted while
the `review` cases stay green.

Files: `packages/fabrika-cli/src/plan/**` (14 new), plus `src/registry.ts`,
`src/exit-code-alignment.ts` (+ its test), `src/wire/verdict-marker.ts` (+ its test),
`src/wire/registry.ts`, and two doc corrections under
`claude-plugins/fabrika/skills/check-epic-plan/`.

## The `20`/`21` exit-code question, settled explicitly

`build` has since seated `20 OUT_OF_FOCUS` and `21 AUDIENCE_NOT_AGENT`, both reachable from
`fabrika build claim` — step 1 of this gate's skill. The contract was written when `20`+ was free
and it argued that `15` must be imported verbatim "because a caller driving both in one sweep must
read one meaning for it", which raises the same question about `20`/`21`.

**The overlap stands, and the rule that settles it is stated where a later editor will hit it**
(`src/plan/codes.ts`, and amended into the contract's alignment section):

> **Import a code when two groups prove the same fact; allocate freely when they do not.**

`15` is imported because `plan flip` and `build claim` assert the *identical* fact — this session
holds this issue's claim. `20`/`21` do not overlap in fact at all: lane admission is never something
a `plan` verb proves, and a defective floor or a moved digest is never something a `build` verb
proves. An exit code is read off the command that produced it, and `SKILL.md` step 1 is total
(`any other non-zero ends STOPPED`) — it branches on `20`/`21` only off `plan flip` / `plan verdict`.
Re-seating at `24`+ would also buy nothing: `epic` already seats `20`–`24` over the same two `build`
codes, so there is no unoccupied band above the reserved one, and the alignment checker is base-only
by design (interface convention rule 3).

## Nothing fails open

The three properties the contract's gate confirmed are preserved, each with a test that reds if the
guard is removed:

- **Zero scope refuses rather than deriving.** Zero sub-issue children is `7` with empty stdout, not
  a clean read of an epic with nothing in it (ADR 0092). A sub-issue list of the wrong shape is `11`,
  never an empty child list.
- **An underivable class is named in `skipped`, never evaluated false.** The cycle-doc probe is
  three-valued: `present` derives `MISSING_CONTAINMENT`, `absent` derives it and evaluates it false,
  and only `unknown` puts it in `skipped`. v1 fused the last two through a stderr substring match.
- **Absence is decided on HTTP status, never stderr text.** `DANGLING_DEP` fires on a 404 and refuses
  `11` on anything else; the same split governs the epic, each child, and the cycle doc.

Plus the invariant the whole gate rests on: **the flip is digest-neutral**. The only two labels the
flip writes are excluded from the digest serialization, so a digest taken at check time still binds
after the flip — including *mid-write*, while a child carries both labels. `src/plan/digest.unit.test.ts`
proves all three cases and proves the exclusion is two names rather than a blanket.

## Verification

- `pnpm typecheck --force` — 30/30 tasks, no cache replay.
- `pnpm exec vitest run` in `packages/fabrika-cli` — 143 files, 2114 tests, all green (115 of them new).
- `pnpm lint:worktree` — clean.
- Live smoke: `fabrika plan check 4300 --repo <absent>` exits `7` with the proven-absent refusal on
  stderr and nothing on stdout — the verbs run; none exits 127.

## Deviations

Each is a place the implementation departs from the contract's letter, with the reason. None
weakens a guard.

1. **The cycle-doc probe's failure is `cycleDoc: "unknown"`, not exit `11`.** The contract's `plan
   read` exit table lists the probe under `11`, but its floor section says an `unknown` probe puts
   `MISSING_CONTAINMENT` in `skipped`. Both cannot hold — refusing `11` makes the whole `skipped`
   machinery unreachable. I kept the `skipped` design, which is the fail-closed one the gate praised;
   the `11` row is the stale clause.

2. **The three-state assignee slot is read by a `plan`-local `getChild`, not `io/issues.ts`'s
   `getIssue`.** The contract says "labels via `getIssue`", but `IssueRecord` drops the payload's
   `assignees` key entirely, and *the key was not there* is exactly the fact `UNVERIFIABLE_ASSIGNEE`
   rests on. `getChild` is a sibling reader on the same endpoint (one fetch per child, same
   404-discriminating shape), rather than an additive edit to a module five groups read.

3. **The scope line is a local `scannedChildren`, not `build/target.ts`'s `scannedLine`.** That
   helper pluralises by appending `s`, and the noun here is `children`. The discipline it encodes —
   count first, then the set — is kept verbatim.

4. **`plan flip` / `plan verdict` emit `requireClaim`'s own `15` messages** rather than the single
   sentence in the contract's Errors table. The contract says to run the imported `requireClaim`, and
   that verb keeps *unclaimed* and *foreign* apart for a reader on one code; re-wording them would
   discard information the import exists to provide.

5. **A stdin line that is not a caveat at all refuses on `10`.** The contract seats an off-set kind
   and an off-scope ref, but names no outcome for a malformed line. Dropping it silently is the one
   thing that must not happen, so it lands on `10` (a value off its closed vocabulary) with its own
   message. No new code was allocated.

6. **The bare-`@` probe runs ahead of the caveat grammar**, unlike the leak scan, which stays where
   the contract puts it. A body that is itself an unexpanded `@path` never arrived at all (#3086) —
   there is no caveat line to grade, and reporting it as an off-vocabulary *kind* would send the
   caller looking at the wrong thing. Seat and message are the contract's.

7. **`topology.edges` are derived from `requires:` lines only**; the phase spine rides in
   `topology.phases` and in the digest's separate `deps=` field. A phase boundary is a total order
   and cannot cycle, so `DEP_CYCLE` can only arise from an explicit requirement. Defect refs are
   issue numbers, so a ledger-local `C<n>` id is named in a cycle's `detail` but is never probed as a
   `DANGLING_DEP` — it is not an issue.

8. **Two doc corrections carried from the dispatch note**, both in
   `claude-plugins/fabrika/skills/check-epic-plan/`: the contract's "no `src/epic/` exists" premise
   (false since #5092 landed — the conclusion survives, the premise is marked stale), and `NOTES.md`'s
   "the six in `evals/evals.json`", which is ten.

## Out of scope, unchanged

No second lane lock — the claim stays `build claim` / `build release` / `build note`, reused. No
change to the `epic` group or to anything it allocates. The contract's thirteen defect types are
built as written, not re-litigated.
