### PR TITLE
fabrika build eligible: name every open edge, and pin every unreadable input to UNKNOWN

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -51,7 +51,9 @@ it executes the whole loop itself. Then gate your choice:
 fabrika build eligible 4312
 ```
 
-Only `eligible` proceeds. `blocked` names the open dependency — take the next candidate.
+Only `eligible` proceeds. `blocked` (`16`) names every open dependency, so one call tells you the
+whole wait — take the next candidate. `11` is UNKNOWN, not a pass: something on the path could not
+be read, and it is named on stderr.
 
 ## 2 — Claim, and keep proving the claim
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -479,9 +479,17 @@ issue). Blocked and unknown produce no stdout — they are exits `16` and `11`.
 The derivation: resolve the parent epic (three-way — parent found / proven standalone /
 unreadable). For a child, read the parent ledger's `## Dependencies` topology and the states of
 every predecessor: a phase predecessor still open, or an open `requires:` edge, is a block, and
-the *first* blocking edge is named on stderr (#4244). Blockedness is **derived from the topology,
-never read off a label** — a label is a claim, the topology is the fact. The parent body arrives
-through the content gate.
+**every** blocking edge is named on stderr (#4244, #4920) — a lane learns everything it waits on
+from one call, not one edge per call. Blockedness is **derived from the topology, never read off a
+label** — a label is a claim, the topology is the fact. The parent body arrives through the content
+gate.
+
+**Every predecessor is read before the answer is seated**, so the answer never depends on the order
+the topology lists them in. A predecessor whose state could not be read is its **own reported row**
+on stderr, never counted closed: beside a *proven* open edge it leaves the verdict `16` (one proven
+open edge is proof of blockedness whatever else was unreadable) and is named there so the edge list
+is not read as complete; with nothing proven open it is `11`, because the blocking set is only
+complete when every predecessor's state is known.
 
 **The `## Dependencies` grammar — canonical here** (no wire module ships for it yet; when one
 lands in `packages/fabrika-cli/src/wire/`, it implements this section and this section becomes a
@@ -516,11 +524,14 @@ and the whole derivation refuses on `4` — "no parseable edges" is never read a
 | `build eligible: issue #<n> is proven absent or closed.` | 7 | refusal |
 | `build eligible: parent #<p> has no parseable "## Dependencies" block — eligibility cannot be derived, and "no edges found" is never read as "eligible".` | 4 | refusal |
 | `build eligible: cannot read <what>: <reason> — eligibility is UNKNOWN, never "eligible".` | 11 | refusal |
-| `build eligible: blocked by open <edge-kind> #<m>.` | 16 | refusal |
+| `build eligible: <n> predecessors could not be read — eligibility is UNKNOWN, never "eligible".` | 11 | refusal |
+| `build eligible: cannot read <edge-kind> predecessor #<m>: <reason> — its state is UNKNOWN, never counted closed.` | 11 or 16 | detail line, one per unread predecessor |
+| `build eligible: blocked by <n> open dependency edges: <edge-kind> #<m>, <edge-kind> #<k>.` | 16 | refusal |
 
 **Scope** — one issue, its parent (if any), and every predecessor the parent's topology names.
 The scope line on stderr counts the edges checked, so `eligible` is readable as "N edges, all
-closed", never as "no edges found".
+closed", never as "no edges found". An edge whose state could not be read is subtracted from that
+claim by its own stderr row, so "all closed" is never asserted over an edge nobody could see.
 
 **Examples**
 
@@ -531,7 +542,17 @@ $ fabrika build eligible 4312
 
 ```
 $ fabrika build eligible 4319
-build eligible: blocked by open requires: edge #4310.
+build eligible: scanned 2 dependency edges; parent #4300.
+build eligible: blocked by 2 open dependency edges: requires: #4310, requires: #4311.
+$ echo $?
+16
+```
+
+```
+$ fabrika build eligible 4321
+build eligible: scanned 2 dependency edges; parent #4300.
+build eligible: cannot read phase predecessor #4310: gh: Bad gateway (HTTP 502) — its state is UNKNOWN, never counted closed.
+build eligible: blocked by 1 open dependency edge: phase #4311.
 $ echo $?
 16
 ```
@@ -540,7 +561,9 @@ $ echo $?
 
 - #4244 — lane entry must refuse while a `requires:` member is open.
 - #4920 — the eligibility question needed a verb; prose-derived blockedness was re-derived
-  differently per session.
+  differently per session. Its acceptance also fixes two properties of the answer: a `blocked`
+  refusal names **every** open edge, and every unreadable input on the path is `11` with a test
+  pinning it, so no read failure anywhere can resolve to "eligible".
 - #4104 — `status:planned` children invisible to a label-driven picker; topology-derived here.
 - ADR 0092 — an unreadable predecessor is `11`, never a pass.
 

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -110,7 +110,7 @@ const eligible = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		'One issue\'s dependency gate, derived from the parent ledger\'s "## Dependencies" topology and never read off a label. Prints {"answer":"eligible","number":n,"parent":n|null}; blocked and unknown print nothing. Exits 4 (the parent\'s "## Dependencies" block is absent or unparseable — "no parseable edges" is never "no edges"), 7 (the issue is proven absent or closed), 11 (the issue, parent or a predecessor could not be read — UNKNOWN, never "eligible"), 16 (proven blocked — the first open edge is named on stderr). Example: fabrika build eligible 4312',
+		'One issue\'s dependency gate, derived from the parent ledger\'s "## Dependencies" topology and never read off a label. Prints {"answer":"eligible","number":n,"parent":n|null}; blocked and unknown print nothing. Every predecessor is read before the answer is seated, so the verdict does not depend on the order the topology lists them in, and a predecessor that could not be read is named on stderr as its own row rather than counted closed. Exits 4 (the parent\'s "## Dependencies" block is absent or unparseable — "no parseable edges" is never "no edges"), 7 (the issue is proven absent or closed), 11 (the issue, parent or a predecessor could not be read, with nothing proven open — UNKNOWN, never "eligible"), 16 (proven blocked — EVERY open edge is named on stderr, alongside any predecessor that could not be read). Example: fabrika build eligible 4312',
 	),
 );
 

--- a/packages/fabrika-cli/src/build/eligible-verb.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.ts
@@ -2,13 +2,21 @@
  * `build eligible` — one issue's dependency gate, **derived from the parent's topology, never read off
  * a label**. A label is a claim; the topology is the fact (#4104, #4920).
  *
- * Three outcomes and no fourth: `eligible` on stdout, a named blocking edge on `16`, and UNKNOWN on
- * `11`. A parent whose `## Dependencies` block is absent or unparseable is `4` — "no parseable edges"
- * is never read as "no edges", because a topology nobody could read proves nothing about blockedness.
+ * Three outcomes and no fourth: `eligible` on stdout, **every** named blocking edge on `16`, and
+ * UNKNOWN on `11`. A parent whose `## Dependencies` block is absent or unparseable is `4` — "no
+ * parseable edges" is never read as "no edges", because a topology nobody could read proves nothing
+ * about blockedness.
  *
  * A ledger-local ref (`C<int>`) names a child that has not been filed yet, so it blocks: unfiled work
  * is open work, and the alternative — treating it as satisfied — is the fail-open this verb exists to
  * remove.
+ *
+ * **Every predecessor is scanned before the answer is seated, so the answer does not depend on the
+ * order the topology happens to list them in.** One *proven* open edge is proof of blockedness
+ * whatever else could not be read, so a predecessor read that failed alongside it downgrades neither
+ * the verdict nor its edge list — it is named on stderr as its own unread row instead. With nothing
+ * proven open, an unread predecessor is `11`: the set of blocking edges is only complete when every
+ * predecessor's state is known.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -88,24 +96,38 @@ export const runEligible = (
 			"dependency edge",
 			`parent #${parent.value}`,
 		);
+		const open: string[] = [];
+		const unread: string[] = [];
 		for (const {kind, ref} of predecessors) {
 			if (ref._tag === "Local") {
-				return refuse(BLOCKED, `${VERB}: blocked by open ${kind} edge ${renderRef(ref)}.`, [
-					scope,
-					`${VERB}: ${renderRef(ref)} is a ledger-local id — it names work not yet filed, which is open.`,
-				]);
+				open.push(`${kind} ${renderRef(ref)} (unfiled, so open)`);
+				continue;
 			}
 			const state = yield* getIssue(repo, ref.number);
 			if (state._tag === "Unknown") {
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot read predecessor #${ref.number}: ${state.reason} — eligibility is UNKNOWN, never "eligible".`,
-					[scope],
+				unread.push(
+					`${VERB}: cannot read ${kind} predecessor #${ref.number}: ${state.reason} — its state is UNKNOWN, never counted closed.`,
 				);
+				continue;
 			}
-			if (state._tag === "Absent" || state.value.state === "open") {
-				return refuse(BLOCKED, `${VERB}: blocked by open ${kind} edge #${ref.number}.`, [scope]);
-			}
+			if (state._tag === "Absent" || state.value.state === "open")
+				open.push(`${kind} #${ref.number}`);
+		}
+
+		const plural = (n: number, noun: string) => `${n} ${noun}${n === 1 ? "" : "s"}`;
+		if (open.length > 0) {
+			return refuse(
+				BLOCKED,
+				`${VERB}: blocked by ${plural(open.length, "open dependency edge")}: ${open.join(", ")}.`,
+				[scope, ...unread],
+			);
+		}
+		if (unread.length > 0) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: ${plural(unread.length, "predecessor")} could not be read — eligibility is UNKNOWN, never "eligible".`,
+				[scope, ...unread],
+			);
 		}
 
 		return answer(JSON.stringify({answer: "eligible", number, parent: parent.value}), [scope]);

--- a/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
@@ -12,6 +12,7 @@ const LEDGER = /^gh api repos\/o\/r\/issues\/4300$/;
 const PRED = (n: number) => new RegExp(`^gh api repos/o/r/issues/${n}$`);
 
 const NOT_FOUND = errOut("gh: Not Found (HTTP 404)");
+const GATEWAY = errOut("gh: Bad gateway (HTTP 502)");
 
 const ledger = (body: string) =>
 	issue({number: 4300, body: `# Epic\n\n## Dependencies\n\n${body}\n`});
@@ -47,7 +48,7 @@ describe("runEligible", () => {
 		expect(out.stderr.at(-1)).toContain("scanned 1 dependency edge");
 	});
 
-	it("refuses on 16 and NAMES the first open edge", async () => {
+	it("refuses on 16 and NAMES the open edge", async () => {
 		const out = await run([
 			[ISSUE, issue()],
 			[PARENT, okOut("4300\n")],
@@ -56,7 +57,23 @@ describe("runEligible", () => {
 		]);
 		expect(out.code).toBe(BLOCKED);
 		expect(out.stdout).toBe("");
-		expect(out.stderr.at(-1)).toBe("build eligible: blocked by open requires: edge #210.");
+		expect(out.stderr.at(-1)).toBe(
+			"build eligible: blocked by 1 open dependency edge: requires: #210.",
+		);
+	});
+
+	it("names EVERY open edge, not only the first", async () => {
+		const out = await run([
+			[ISSUE, issue()],
+			[PARENT, okOut("4300\n")],
+			[LEDGER, ledger("- phase 1: #210, #211\n- phase 2: #4312")],
+			[PRED(210), issue({number: 210, state: "open"})],
+			[PRED(211), issue({number: 211, state: "open"})],
+		]);
+		expect(out.code).toBe(BLOCKED);
+		expect(out.stderr.at(-1)).toBe(
+			"build eligible: blocked by 2 open dependency edges: phase #210, phase #211.",
+		);
 	});
 
 	it("treats a ledger-local ref as an open edge — unfiled work is open work", async () => {
@@ -66,8 +83,9 @@ describe("runEligible", () => {
 			[LEDGER, ledger("- phase 1: C1\n- phase 2: #4312")],
 		]);
 		expect(out.code).toBe(BLOCKED);
-		expect(out.stderr.at(-1)).toBe("build eligible: blocked by open phase edge C1.");
-		expect(out.stderr.some((line) => line.includes("names work not yet filed"))).toBe(true);
+		expect(out.stderr.at(-1)).toBe(
+			"build eligible: blocked by 1 open dependency edge: phase C1 (unfiled, so open).",
+		);
 	});
 
 	it("refuses an unparseable Dependencies block on 4 — never reads it as 'no edges'", async () => {
@@ -88,23 +106,75 @@ describe("runEligible", () => {
 		expect(out.stderr.at(-1)).toBe("build eligible: issue #4312 is proven absent or closed.");
 	});
 
-	it("refuses an unreadable parent lookup on 11 — never 'standalone'", async () => {
-		const out = await run([
-			[ISSUE, issue()],
-			[PARENT, errOut("gh: Bad gateway (HTTP 502)")],
-		]);
-		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.at(-1)).toContain('eligibility is UNKNOWN, never "eligible"');
+	/**
+	 * One case per unreadable input the derivation has (#4920). Each pins `11`: the whole point is that
+	 * no read failure anywhere on the path can resolve to "eligible", and a suite that leaves one path
+	 * unpinned cannot tell a guard that was removed from one that was never exercised.
+	 */
+	describe("every unreadable input is 11, never a pass", () => {
+		// The parent lookup is scripted to its proven-standalone 404 so this case isolates the issue
+		// read: without its guard the derivation would run to completion and answer `eligible`.
+		it("the issue itself", async () => {
+			const out = await run([
+				[ISSUE, GATEWAY],
+				[PARENT, NOT_FOUND],
+			]);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stdout).toBe("");
+			expect(out.stderr.at(-1)).toBe(
+				'build eligible: cannot read #4312: gh: Bad gateway (HTTP 502) — eligibility is UNKNOWN, never "eligible".',
+			);
+		});
+
+		it("the parent lookup — never 'standalone'", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, GATEWAY],
+			]);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stderr.at(-1)).toContain('eligibility is UNKNOWN, never "eligible"');
+		});
+
+		it("the parent ledger — never 'no dependencies'", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, GATEWAY],
+			]);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stdout).toBe("");
+			expect(out.stderr.at(-1)).toContain("cannot read parent #4300");
+		});
+
+		it("a predecessor, with nothing else proven open", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), GATEWAY],
+			]);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stdout).toBe("");
+			expect(out.stderr.some((line) => line.includes("cannot read phase predecessor #210"))).toBe(
+				true,
+			);
+		});
 	});
 
-	it("refuses an unreadable predecessor on 11 — never a pass", async () => {
+	it("an unread predecessor never masks a proven-open one, and is reported beside it", async () => {
 		const out = await run([
 			[ISSUE, issue()],
 			[PARENT, okOut("4300\n")],
-			[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
-			[PRED(210), errOut("gh: Bad gateway (HTTP 502)")],
+			[LEDGER, ledger("- phase 1: #210, #211\n- phase 2: #4312")],
+			[PRED(210), GATEWAY],
+			[PRED(211), issue({number: 211, state: "open"})],
 		]);
-		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stdout).toBe("");
+		expect(out.code).toBe(BLOCKED);
+		expect(out.stderr.at(-1)).toBe(
+			"build eligible: blocked by 1 open dependency edge: phase #211.",
+		);
+		expect(out.stderr.some((line) => line.includes("cannot read phase predecessor #210"))).toBe(
+			true,
+		);
 	});
 });


### PR DESCRIPTION
`fabrika build eligible` answers whether an issue is ready to pick, derived from its parent
epic's `## Dependencies` topology. It already existed, but a blocked answer named only the
*first* open edge it hit, and it stopped scanning the moment any predecessor read failed — so a
lane learned one blocker per call, and a flaky read on an early edge could hide a definite
blocker further down the list. This changes the answer to name **every** proven-open edge, and to
report a predecessor it could not read as its own line instead of dropping it.

Nothing here can answer "eligible" off a read that failed. Every unreadable input on the path —
the issue, the parent lookup, the parent ledger, any predecessor — exits `11` (UNKNOWN), and this
PR adds one test per path pinning that, because a suite that leaves a path unpinned cannot tell a
guard that was deleted from one that was never exercised.

Fixes #4920

## What changed

- `packages/fabrika-cli/src/build/eligible-verb.ts` — scan every predecessor before seating the
  answer, collect the open edges and the unreadable ones separately, then decide: any proven-open
  edge is `16` naming them all (with each unread predecessor listed beside them, so the edge list
  is never read as complete when it isn't); nothing proven open but something unread is `11`;
  otherwise `eligible`.
- `packages/fabrika-cli/src/build/command.ts` — the `--help` text for `16`/`11` now describes what
  the verb actually does.
- `claude-plugins/fabrika/skills/build/contract.md` — the `build eligible` block: the derivation
  prose, the error table, the Scope note, two worked examples, and the `#4920` grounding row.
- `claude-plugins/fabrika/skills/build/SKILL.md` — the one line that told a lane how to read the
  gate's answers.
- `packages/fabrika-cli/src/build/eligible-verb.unit.test.ts` — the four unreadable-input cases,
  the all-edges case, and the case where an unread predecessor sits beside a proven-open one.

No new exit code is minted: `16` already means *proven blocked* and `11` already means *UNKNOWN*
in `packages/fabrika-cli/src/build/codes.ts`, and both facts here are those facts. Allocating a
new numeral for a meaning that already has one is what makes a caller special-casing the old code
silently miss the new one.

## Where each acceptance criterion is met

Three of the criteria were already met by the verb that landed in #5047 (for #4988) after this
issue was triaged. They are cited rather than rebuilt:

| Criterion | Where |
|---|---|
| fabrika-owned grammar + derivation clause, deferring to no v1 | `claude-plugins/fabrika/skills/build/contract.md` → "The `## Dependencies` grammar — canonical here" (pre-existing) |
| three outcomes, never a boolean, on the convention's exit taxonomy | `eligible` on stdout / `16` / `11`, with `4` for an underivable topology (pre-existing) |
| a `blocked` answer names the blocking edges | **this PR** — every open edge, not the first |
| every unreadable input is UNKNOWN, with a test per path | **this PR** — four cases under "every unreadable input is 11, never a pass" |
| `--help` enumerates every non-zero exit code with its condition | `packages/fabrika-cli/src/build/command.ts` (updated here for the changed conditions) |
| the `build` vs `build-epic` ownership fork recorded | `claude-plugins/fabrika/skills/build-epic/contract.md` → "Considered and not derived: a slice selector separate from `next`" (pre-existing; not re-decided here) |
| no machine-local path in any artifact | repo-relative paths only, here and in the changed files |

## Deviations

- **Class: the work was largely already delivered.** Said: the issue reads as though no
  eligibility verb exists anywhere. Did: verified against the live tree first, found `build
  eligible` shipped in #5047, and scoped this PR to the residual criteria (the plural edge list,
  the unreadable-input tests) plus verification of the rest. Why: rebuilding a landed verb would
  be a second implementation of the same fact. Disposition: no action needed — each criterion is
  mapped to its evidence in the table above.
- **Class: changed a clause a landed contract already stated.** Said: the contract recorded that
  "the *first* blocking edge is named on stderr (#4244)". Did: changed it to name every open edge,
  and updated the contract, the `--help` prose, and the one existing test that asserted the old
  single-edge sentence. Why: this issue's criterion asks for the blocking edges, plural, and #4244
  only requires that lane entry refuse while a `requires:` member is open — which still holds.
  Disposition: for the reviewer to judge.
- **Class: a judgment the issue did not specify.** Said: nothing about what to answer when a
  proven-open edge and an unreadable predecessor appear in the same scan. Did: seated `16`, and
  named the unread predecessor on stderr beside the open edges. Why: one proven-open edge is proof
  of blockedness whatever else was unreadable, and both `16` and `11` are refusals, so this cannot
  fail open; reporting the unread edge is what stops the list from being read as complete.
  Disposition: for the reviewer to judge.
- **Class: dropped an existing stderr line.** Said: a ledger-local `C<int>` edge printed a
  separate explanatory line. Did: folded it into the edge label as `phase C1 (unfiled, so open)`.
  Why: with the list now enumerated, one explanatory line per local edge would be a second wall of
  text repeating what the label already says. Disposition: no action needed — the reason still
  reaches the reader, and the module docblock carries the rationale.
- **Class: branch naming.** Said: the pipeline script derives the branch prefix from
  `git config user.name`, which produced `usirin/`. Did: renamed to `umut/` before any push, per
  the repo's branch convention. Why: dispatch and the repo convention both mandate the `umut/`
  prefix. Disposition: no action needed.
- **Class: adjacent defects left alone.** Said: the issue names v1's `step1-candidate-pool.sh`
  truncation and `step2-epic-read.sh` fail-open reads. Did: touched neither. Why: the issue's own
  no-gos put v1 out of scope, and both are already homed on their own tickets. Disposition: no
  action needed.

## Verification

- `pnpm typecheck --force` — 30/30 tasks, 0 cached, all task paths in this worktree.
- `pnpm lint:worktree` — clean over the changed files.
- `pnpm vitest run` in `packages/fabrika-cli` — 1992 tests, 135 files, all green.

Each new guard was proven falsifiable by temporarily reintroducing the defect and confirming which
cases went red — see the progress comment on #4920 for the mutation-by-mutation record.
