### PR TITLE
docs(fabrika): say what the review diff proof actually rests on (#4993)

### DIFF
--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -152,9 +152,9 @@ formed over one tree land on another (#3769 / #4338's class). It seats at both e
 at the emit seam (`review post`, where the live head has moved past the judged one) and at the
 read seam (`review scope` / `review diff`, where a `--sha` that is not the PR's head would have
 a human spend a review on a tree the PR has left — #5117). `13` is the
-incomplete-enumeration refusal: the read *succeeded* and is *provably short* — a diff the API
-truncated, a check-run page count below `total_count` — which is neither `11` (nothing failed)
-nor `7` (scope exists; it just was not all seen). Folding `13` into either would render a
+incomplete-enumeration refusal: the read *succeeded* and is *provably short* — a diff carrying
+fewer files than the PR declares, a check-run page count below `total_count` — which is neither
+`11` (nothing failed) nor `7` (scope exists; it just was not all seen). Folding `13` into either would render a
 half-seen PR as a fully-judged one, the exact class of #3925 (a gate PASSing on 100% upload
 failure) and #4060.
 
@@ -374,9 +374,16 @@ index 0b1c2d3..a1b2c3d 100644
 
 **Grounding**
 
-- GitHub's diff endpoints truncate large diffs silently at the API tier; a gate that judged the
-  visible prefix as the whole PR is the #3925 blind-PASS class one layer down. The `13` refusal
-  is the difference between "reviewed" and "reviewed what fit".
+- The `13` refusal is about a diff that arrives short, not about a platform that serves prefixes.
+  `application/vnd.github.diff` does **not** truncate: over its limits it refuses with HTTP `406`
+  and `errors[].code = "too_large"`, and under them it serves the diff whole — established by live
+  probe and recorded on #4993. This verb does not read that endpoint anyway; its bytes are local
+  `git diff <base>...<head>` at the bound commit (#5117). What `13` still buys is real: a range can
+  carry fewer files than the PR declares, and serving that prefix as the whole PR is the #3925
+  blind-PASS class one layer down.
+- The proof counts whole files, so it does not see a diff cut inside the last file's hunks — every
+  `diff --git` header is still present, and the count passes. That is a stated bound of the proof,
+  not a failure mode defended against: no producer for that shape is known.
 - The split test is honest: this verb is not a relay because its whole job is the completeness
   proof — v1's `pr-diff.sh` was the relay, and nothing checked what it served.
 - #5117 — the completeness proof says the read was not cut short; it says nothing about which

--- a/packages/fabrika-cli/src/review/diff-verb.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.ts
@@ -1,13 +1,16 @@
 /**
- * `review diff` — the PR's diff bytes, read out of one commit, with truncation refused rather than
+ * `review diff` — the PR's diff bytes, read out of one commit, with a short read refused rather than
  * silently passed through.
  *
- * This verb is not a relay, and two proofs are why. **Completeness:** GitHub truncates large diffs at
- * the API tier, so a gate that judged the visible prefix as the whole PR is the #3925 blind-PASS
- * class one layer down; v1's `pr-diff.sh` was the relay, and nothing checked what it served.
- * **Provenance:** the bytes come from the object database at the bound commit (`head.ts`), never from
- * an endpoint that takes a PR number and no commit — see that module for why a SHA on the verdict is
- * not the same thing as bytes from that SHA (#5117).
+ * This verb is not a relay, and two proofs are why. **Completeness:** a diff carrying fewer files
+ * than the PR declares is refused, because a gate that judged the visible prefix as the whole PR is
+ * the #3925 blind-PASS class one layer down; v1's `pr-diff.sh` was the relay, and nothing checked
+ * what it served. This is not a guard against a truncating platform: the diff media type refuses an
+ * over-limit diff rather than serving a short one, and these bytes never come from it — see
+ * `diff.ts` for what the proof does and does not cover (#4993). **Provenance:** the bytes come from
+ * the object database at the bound commit via `diffRange`, never from an endpoint that takes a PR
+ * number and no commit — see `head.ts` for why a SHA on the verdict is not the same thing as bytes
+ * from that SHA (#5117).
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";

--- a/packages/fabrika-cli/src/review/diff.ts
+++ b/packages/fabrika-cli/src/review/diff.ts
@@ -2,14 +2,20 @@
  * The unified-diff walk: how many files the served diff actually carries, and where each added or
  * removed line sits.
  *
- * **The completeness proof is the file count, and only the file count.** GitHub truncates large
- * diffs at the API tier, and a gate that judged the visible prefix as the whole PR is the #3925
- * blind-PASS class one layer down — so the served diff's `diff --git` header count is compared
- * against the PR's declared `changed_files` and a short one is refused. It is deliberately not
- * compared against a literal truncation marker: the exact bytes GitHub emits for a truncated diff
- * are not verifiable from this repo, and an unverified marker string is a check that silently stops
- * matching (CLAUDE.md's grounding rule). The count is derivable from what the platform already
- * declares, so it is the proof this module makes.
+ * **The completeness proof is the file count, and only the file count.** The bytes are local
+ * `git diff <base>...<head>` at the bound commit (`diff-verb.ts`, #5117), so the proof compares the
+ * `diff --git` header count against the PR's declared `changed_files` and a short one is refused:
+ * serving a prefix as the whole PR is the #3925 blind-PASS class one layer down.
+ *
+ * No truncation marker is matched, because there is nothing to match. `application/vnd.github.diff`
+ * does not truncate — over its limits it refuses with HTTP 406 and `errors[].code = "too_large"`,
+ * under them it serves whole (live probe, recorded on #4993) — and these bytes do not come from
+ * that endpoint anyway. The earlier claim that GitHub truncates at the API tier was asserted from
+ * intuition and is false (CLAUDE.md's grounding rule).
+ *
+ * The count sees whole files only: a diff cut inside the last file's hunks still carries every
+ * header and passes. That is a stated bound of the proof, not a failure mode defended against — no
+ * producer for that shape is known.
  */
 
 const FILE_HEADER = /^diff --git a\/(.*) b\/(.*)$/;


### PR DESCRIPTION
Three of our own docs said GitHub quietly cuts off large diffs. It doesn't — over its limits the diff media type refuses the request outright with HTTP 406, and under them it hands back the whole thing. The verb they describe stopped reading that endpoint anyway; it reads local git at the commit under review. This PR replaces the wrong sentence with what was actually measured, and says once, plainly, what the file-count check can and cannot see. Prose only — no behaviour changes.

Fixes #4993

## What changed

- **`claude-plugins/fabrika/skills/review/contract.md`** — the `review diff` **Grounding** bullet no longer asserts API-tier truncation. It states the observed behaviour (`406` + `errors[].code = "too_large"` over the limits, whole under them, cited to #4993), names the real byte source (local `git diff <base>...<head>` at the bound commit, #5117), and keeps the reason `13` still earns its place.
- **`claude-plugins/fabrika/skills/review/contract.md`** — a **fourth instance** the issue's file list did not name: the shared exit-taxonomy paragraph described `13` as firing on "a diff the API truncated". Now: "a diff carrying fewer files than the PR declares."
- **`packages/fabrika-cli/src/review/diff.ts`** — module docblock. Both stale halves fixed: the truncation claim (false) and the API byte source (no longer read). It now says why no marker is matched — there is no marker, because the endpoint refuses instead of serving short — which is the honest version of the CLAUDE.md grounding note that already sat one sentence below the unsourced assertion.
- **`packages/fabrika-cli/src/review/diff-verb.ts`** — module docblock, same correction in its own frame, pointing at `diff.ts` for the proof's coverage rather than re-deriving it.
- **The bound of the proof, recorded once in each place a reader lands** — a diff cut inside the last file's hunks still carries every `diff --git` header, so the count passes. Stated as a bound, not as a defended-against failure mode: no producer for that shape is known.

## What deliberately did not change

- **The comparison logic is untouched.** `if (seen < pull.changedFiles)` is byte-identical. Whether a local-git numerator may be measured against an API-declared denominator at all is #5139's question, and this lane does not answer it. `git diff` over both `.ts` files shows **zero** changed lines outside the docblocks.
- **No second completeness proof, no marker matching, no runtime check** (issue AC5; the re-triage voided the original AC3 with an explicit do-not-build).
- **No unit case added.** The optional `filesInDiff` mid-file case was declined — see Deviations.

## Verification

- `pnpm typecheck --force` — 30 successful / 30 total, 0 cached.
- `pnpm lint:worktree` — 2 files checked, clean.
- `pnpm --filter @kampus/fabrika-cli test` — 143 files, 2118 tests, all passing (exported behaviour unchanged, as claimed).
- Repo grep for the claim (`API tier`, `truncates diff`, `diff…truncat`) over `packages/`, `claude-plugins/`, `.decisions/`, `.patterns/`: no surviving assertion of API-tier diff truncation.

## Deviations

- **Class: narrowed a suggested fix-shape.** Said: the issue offers an optional `filesInDiff` unit case pinning that a mid-file-cut diff returns the full header count. Did: not added. Why: the issue marks it explicitly not required, there is no producer for that input, and the bound is now recorded in both the contract and the docblock — a test for an unproducible input pins a fact the prose already states. Disposition: no action needed; for the reviewer to judge if they want it pinned in code.
- **Class: left a sibling defect for another owner.** Said: correct the three artifacts. Did: also corrected a fourth site in the same file (the exit-taxonomy `13` paragraph), because the issue's AC requires the grep to come back clean across `claude-plugins/fabrika/skills/review/`. Disposition: in scope by AC, folded in here rather than filed.
- **Class: declined an adjacent change.** Said: nothing about `packages/fabrika-cli/src/review/deviations-verb.ts`. Did: left its runtime refusal string, which calls a short diff "truncated". Why: it makes no API-tier claim, it is a user-facing message pinned by a unit test, and rewording it is a behaviour-adjacent change outside this ticket's prose scope. Disposition: no action needed.
