### PR TITLE
fix(fabrika-cli): bind `review deviations` and `review post` to the commit they name

### DIFF
--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -31,7 +31,8 @@ v1 got per-skill now lives here. `scope` also prints the head SHA, the linked is
 The printed head is the commit the file list was **read out of**, not a label beside it: `scope`
 fetches the PR head and reads the changed files from the object database, checking nothing out. It
 refuses rather than partitioning a list it cannot tie to that commit. Carry the printed head into
-every later verb — `--sha` on `diff`, `ci` and `post` — so the whole review is one tree.
+every later verb — `--sha` on `diff`, `deviations`, `ci` and `post` — so the whole review is one
+tree.
 
 ## 2 — Read the contract you grade against, and the prior verdicts
 
@@ -92,7 +93,7 @@ routes back to the full path, and the verdict stays conjunctive default-deny.
 ## 5 — Verify the §DEV disclosure
 
 ```bash
-fabrika review deviations 4321
+fabrika review deviations 4321 --sha 03135b91
 ```
 
 <!-- anchor: DEV-VOCABULARY --> Match your findings against each entry's **substance**, never its
@@ -161,8 +162,8 @@ the surface and files the gap. No row here dead-ends on a bare error.
 | --- | --- | --- |
 | The class-map roots — `claude-plugins/**`, `.claude/**`, `skills/**`, any file named `SKILL.md`, and `*.md` elsewhere | `review scope` partitions the changed files into the `skill`/`doc`/`code` classes that derive the namespace set ([`contract.md`](contract.md), the class map) | **degrade** — the partition is total with `code` as the residual, so a repo homing its skills outside `claude-plugins/**` still partitions through the `skills/**` and bare-`SKILL.md` rows; nothing is dropped, and an unplaceable file is judged under the code rubric. |
 | The linked issue's `### Acceptance criteria` block | `review criteria` grades against it, and nothing else is the contract | **fail-loud** — `review criteria` exits `7` naming the issue and the wire reason (`absent` vs `malformed`), no criterion is invented, and the run points at front-door. |
-| The PR body's `## Deviations` section | `review deviations` matches the disclosure against the head diff's Tier-M scan | **fail-loud** — on a PR that owes the section, `absent` is malformed and fails the verdict closed; the run names the missing `## Deviations` heading and points at front-door. |
-| A git remote in this checkout whose URL names the repo under review | `review scope` and `review diff` fetch `pull/<pr>/head` and read the artifact out of the object database, so the bytes are provably the bound commit's ([`contract.md`](contract.md), the read verbs' commit binding) | **fail-loud** — both verbs exit `11` naming the repo no remote serves; the artifact cannot be tied to a commit, so what it shows is UNKNOWN and no unbound fallback is taken. |
+| The PR body's `## Deviations` section | `review deviations` matches the disclosure against the bound commit's Tier-M scan | **fail-loud** — on a PR that owes the section, `absent` is malformed and fails the verdict closed; the run names the missing `## Deviations` heading and points at front-door. |
+| A git remote in this checkout whose URL names the repo under review | `review scope`, `review diff`, `review deviations` and `review post`'s namespace recompute fetch `pull/<pr>/head` and read the artifact out of the object database, so the bytes are provably the bound commit's ([`contract.md`](contract.md), the read verbs' commit binding) | **fail-loud** — every one of them exits `11` naming the repo no remote serves; the artifact cannot be tied to a commit, so what it shows is UNKNOWN and no unbound fallback is taken. |
 | A CI check rollup at the head — `.github/workflows/` | `review ci` is the code class's execution evidence; this skill re-runs no check itself | **fail-loud** — zero declared check runs is exit `7`, refusing green over an empty enumeration (ADR 0092), and an unreadable enumeration is `11`, UNKNOWN, never green; the run names `.github/workflows/` and points at front-door. |
 
 ## Eval enumeration (leaf-rule obligation)

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -128,9 +128,9 @@ sibling contract.md — the checked-in `/report` contract is behind its own bina
 | `7` | zero scope: the target is **proven absent (404)** or closed, the PR has zero changed files or zero declared check runs, or a required block is proven absent or malformed — a fail-closed refusal | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `8` | the write itself failed — the outcome is **UNKNOWN** | — | — | — | — | — | — | ✓ | ✓ |
 | `9` | the write landed but the read-back does not match | — | — | — | — | — | — | ✓ | ✓ |
-| `10` | a supplied classification value is off the closed vocabulary — a namespace outside this PR's derived class set, a bad polarity or carrier, a `--sha` that is not a head SHA | ✓ | ✓ | — | — | — | — | ✓ | — |
+| `10` | a supplied classification value is off the closed vocabulary — a namespace outside this PR's derived class set, a bad polarity or carrier, a `--sha` that is not a head SHA | ✓ | ✓ | — | — | — | ✓ | ✓ | — |
 | `11` | a **precondition read failed** — nothing was written and the outcome is UNKNOWN | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `12` | refused: the `--sha` given is not the PR's head — a read taken over, or a verdict bound to, a tree that is no longer the PR | ✓ | ✓ | — | — | — | — | ✓ | — |
+| `12` | refused: the `--sha` given is not the PR's head — a read taken over, or a verdict bound to, a tree that is no longer the PR | ✓ | ✓ | — | — | — | ✓ | ✓ | — |
 | `13` | refused: the read was completed but its scope is **provably incomplete** — a truncated file list or diff, a check-run enumeration short of `total_count` | ✓ | ✓ | — | ✓ | ✓ | ✓ | — | — |
 | `14` | refused: the invoking token resolves below `write`, or the ACL lookup failed — authorization denied, fail-closed (ADR 0055) | — | — | — | — | — | — | — | ✓ |
 | `15` | refused: the write would drop or mutate an existing row — the append-only fence | — | — | — | — | — | — | — | ✓ |

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -48,8 +48,9 @@ the same tracked debt the sibling contracts carry.)
   structural read of the same facts. Dropping the worktree also removes the #3607 /tmp-collision
   and #4544 fixed-name-scratch classes by construction, and closes the self-review instruction
   hole without a denylist: a head that is never checked out is a head whose instructions are
-  never loaded. **The read verbs' commit binding does not reverse this** (#5117): `review scope`
-  and `review diff` fetch the PR head and read the artifact out of the **object database**
+  never loaded. **The commit binding does not reverse this** (#5117, #5122): `review scope`,
+  `review diff`, `review deviations` and `review post`'s namespace recompute fetch the PR head
+  and read the artifact out of the **object database**
   (`git diff <base>...<head>`), which writes objects and no working tree. Nothing is checked out,
   so no head instruction file is ever on disk to be loaded — a diff that adds a worktree or a
   checkout is still the wrong fix and should be red at review.
@@ -162,16 +163,19 @@ failure) and #4060.
 criterion) — authored text is refusable because the author can fix it. Their fixes are opposite
 (redact-and-resend vs send-the-bytes), which is why they stay two codes, exactly as in `report`.
 
-### The read verbs bind to a commit before they read (#5117)
+### The read verbs bind to a commit before they read (#5117, #5122)
 
-`review scope` and `review diff` serve the artifact a whole review is formed over, so **the bytes
-have to come from a named commit, not from an endpoint that takes a pull-request number and no
-commit at all.** The platform's PR reads are the second thing: a push landing between scoping and
-reading serves the *new* head's artifact under the *old* head's SHA, and the result is a
-well-formed, confident verdict over code nobody judged. `review post`'s `12` cannot close that —
-it fires after the judging, and a rewind that lands back on the recorded SHA passes it clean.
+`review scope`, `review diff` and `review deviations` serve the artifact a whole review is formed
+over, so **the bytes have to come from a named commit, not from an endpoint that takes a
+pull-request number and no commit at all.** The platform's PR reads are the second thing: a push
+landing between scoping and reading serves the *new* head's artifact under the *old* head's SHA,
+and the result is a well-formed, confident verdict over code nobody judged. `review post`'s `12`
+cannot close that — it fires after the judging, and a rewind that lands back on the recorded SHA
+passes it clean. So `review post` binds too, at the one read that is not the head re-resolve: the
+file list its derived namespace set comes from.
 
-Both verbs therefore take an optional `--sha` and run one shared binding step first
+The three read verbs therefore take an optional `--sha`, `review post` binds to the `--sha` it
+already requires, and all four run one shared binding step
 (`packages/fabrika-cli/src/review/head.ts`) before any artifact read:
 
 1. An explicit `--sha` must be **the PR's head**, or the verb refuses on `12`. Malformed is `10`.
@@ -181,14 +185,21 @@ Both verbs therefore take an optional `--sha` and run one shared binding step fi
    verifies still names the wrong tree. The base ref must resolve too, since a diff is a range.
    Any of these unmet is `11`, naming what is UNKNOWN. There is no permissive fallback to the
    PR-number endpoints: unbindable is a refusal, never a plausible value.
-3. The artifact is then read with `git diff <base>...<head>` — bytes for `review diff`, the
-   `--name-only -z` path list for `review scope` — under flags that pin the output to the two
-   commits rather than to the invoking user's `~/.gitconfig` (`--no-ext-diff`, explicit
-   `a/`/`b/` prefixes).
+3. The artifact is then read with `git diff <base>...<head>` — bytes for `review diff` and
+   `review deviations`'s Tier-M scan, the `--name-only -z` path list for `review scope` and
+   `review post`'s namespace recompute — under flags that pin the output to the two commits
+   rather than to the invoking user's `~/.gitconfig` (`--no-ext-diff`, explicit `a/`/`b/`
+   prefixes).
 
-Both verbs print the bound commit and its base on stderr, and `review scope`'s `scoped` line
-prints **the commit it read the files out of**, so the head named and the files partitioned are
-never two different trees.
+Every one of them prints the bound commit and its base on stderr, and `review scope`'s `scoped`
+line prints **the commit it read the files out of**, so the head named and the files partitioned
+are never two different trees.
+
+**`review post` binds underneath its `12`, not instead of it.** The stale-head refusal stays this
+verb's first step and keeps its own message: `12` is what says the verdict's tree is gone. The
+binding is what makes the namespace set provably the bound tree's — a separate property, since a
+force-push that rewinds back onto `--sha` passes `12` clean while the PR-number file endpoint
+still answers with some other head's list.
 
 **Nothing is checked out.** A fetch writes objects, not a working tree, so this binding and the
 no-head-worktree decision above hold together rather than trading off.
@@ -633,7 +644,7 @@ review-doc	PASS	03135b91	current	5154902211
 **Invocation**
 
 ```
-fabrika review deviations 4321 [--repo <owner/name>] [--json]
+fabrika review deviations 4321 [--sha <head>] [--repo <owner/name>] [--json]
 ```
 
 **Inputs**
@@ -641,6 +652,7 @@ fabrika review deviations 4321 [--repo <owner/name>] [--json]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the pull-request number |
+| `--sha` | string | no | the PR's live head | the head to read the diff at; see the binding step above |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
@@ -676,21 +688,21 @@ v1's prose (ADR 0238). An entry's optional label is one of `1`–`7`:
 The classes overlap; the label is a routing hint, not the disclosure — a gate matches an
 entry's substance, never its label. An entry carrying no recognizable label prints `-`.
 
-The Tier-M scan reads the same diff `review diff` serves and inherits its completeness proof:
-a truncated diff is refused here on `13`, because an under-reported hit list beside a `None.`
-reads as a checked-clean disclosure that was never checked.
-
-It does **not** yet inherit the commit binding above: this verb still reads the PR-number diff
-endpoint, so its hit list is bound to no commit. Tracked as #5122 rather than folded in silently —
-the same is true of `review post`'s namespace recompute, whose own `12` narrows but does not close
-the window.
+The Tier-M scan reads the same diff `review diff` serves and inherits both of its proofs. Its
+**completeness** proof: a truncated diff is refused here on `13`, because an under-reported hit
+list beside a `None.` reads as a checked-clean disclosure that was never checked. Its **commit
+binding** (#5122): the bytes come from the object database at the bound commit, because a hit list
+read at a head nobody scoped is under- or over-reported against the disclosure it is printed
+beside — and it fails open, answering `none-declared` at exit 0.
 
 **Exit status**
 
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404) |
-| `11` | the PR body or the diff could not be read — the disclosure state is UNKNOWN |
+| `10` | `--sha` is not a head SHA |
+| `11` | the PR body or the diff could not be read, or the commit could not be bound — the disclosure state is UNKNOWN |
+| `12` | `--sha` is not the PR's head — re-scope, never re-bind |
 | `13` | the diff for the Tier-M scan is provably incomplete — a partial scan must not print beside a `None.` |
 
 **Errors**
@@ -698,10 +710,14 @@ the window.
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `review deviations: PR #<n> not found in <repo>.` | 7 | refusal |
+| `review deviations: --sha "<v>" is not a head SHA — expected 7–40 hex characters.` | 10 | refusal |
+| `review deviations: PR #<n>'s head is <live>, not <sha> — the tree you scoped is not the one under review; re-scope at <live> (ADR 0058).` | 12 | refusal |
+| `review deviations: <what> — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.` | 11 | refusal |
 | `review deviations: cannot read #<n>'s body or diff: <reason> — the disclosure state is UNKNOWN, never "none".` | 11 | refusal |
 | `review deviations: the diff for #<n> is truncated (<k> of <m> files) — refusing a partial Tier-M scan beside a disclosure claim.` | 13 | refusal |
 
-**Scope** — one PR body's `## Deviations` section plus the head diff for the Tier-M token scan.
+**Scope** — one PR body's `## Deviations` section plus the bound commit's diff for the Tier-M
+token scan.
 Whether the PR *owes* the section, and whether an entry's substance covers a finding (Tier R),
 are the skill's judgment; this verb reports states and facts, never the §DEV verdict row.
 
@@ -764,14 +780,17 @@ With `--json`: `{"outcome":"posted","namespace":…,"polarity":…,"sha":…,"up
 
 **What the operation does, in order — each step gates the next.**
 
-1. **Recompute the class set** (the same partition `review scope` prints) and refuse a
-   `--namespace` outside it on `10`. This is the disjointness guarantee made structural: v1 got
-   "a gate never emits another gate's marker" free from one-skill-per-namespace; under one owner
-   the emit path itself enforces it, so a namespace this run did not derive cannot be filled
-   even by a confused caller.
-2. **Re-resolve the live head.** `--sha` not prefix-matching it is the `12` refusal: a verdict
+1. **Re-resolve the live head.** `--sha` not prefix-matching it is the `12` refusal: a verdict
    formed over a moved-past tree is re-reviewed, never re-bound. This is `bindToHead`'s `Stale`
    arm applied at the write seam, where its absence costs the most.
+2. **Recompute the class set at the bound commit** (the same partition `review scope` prints,
+   read through the shared binding step above) and refuse a `--namespace` outside it on `10`.
+   This is the disjointness guarantee made structural: v1 got "a gate never emits another gate's
+   marker" free from one-skill-per-namespace; under one owner the emit path itself enforces it,
+   so a namespace this run did not derive cannot be filled even by a confused caller. The set is
+   documented as both floor and ceiling, which is why it is derived from `--sha`'s commit and not
+   from the PR-number file endpoint: `12` above proves the tree is still the live one, not that
+   the list came from it (#5122).
 3. **Compose the first line through the wire format's `emit`**
    (`verdict-marker.ts`, imported — fields `namespace`/`polarity`/`sha`/`clause`), or with
    `--carrier advisory` the fixed advisory line with the `Reviewed-head: @ <sha>` body line;
@@ -810,7 +829,7 @@ With `--json`: `{"outcome":"posted","namespace":…,"polarity":…,"sha":…,"up
 | `8` | the create/edit failed — UNKNOWN whether a comment landed |
 | `9` | the comment landed but the read-back does not yield this marker |
 | `10` | `--namespace` off the wire format's class or outside this PR's derived set; a bad `--polarity`; `--carrier advisory` with `--polarity FAIL` |
-| `11` | a precondition read failed — the PR, its files (for the class set), or the live head |
+| `11` | a precondition read failed — the PR, the live head, or the commit binding / bound file list the class set is derived from |
 | `12` | the live head moved past `--sha` — re-review at the new head, never re-bind |
 
 **Errors**
@@ -830,9 +849,9 @@ With `--json`: `{"outcome":"posted","namespace":…,"polarity":…,"sha":…,"up
 | `review post: create/edit failed: <reason> — UNKNOWN whether the verdict landed; run \`fabrika review verdicts <n>\` before retrying.` | 8 | refusal |
 | `review post: posted, but the read-back does not yield this marker (<wire reason>) — the PR may carry a garbled verdict; inspect comment <id>.` | 9 | refusal |
 
-**Scope** — one PR: its file list (step 1), its live head (step 2), its comments (steps 5–6),
-plus the caller's stdin. Steps 1, 2 and 5's reads failing is `11` — nothing written, outcome
-known-unwritten.
+**Scope** — one PR: its live head (step 1), the bound commit's file list (step 2), its comments
+(steps 5–6), plus the caller's stdin. Steps 1, 2 and 5's reads failing is `11` — nothing written,
+outcome known-unwritten.
 
 **Examples**
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -250,7 +250,7 @@ verdict back. The group implements
 | `review criteria` | the linked issue's acceptance-criteria block, through the registered wire format |
 | `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration |
 | `review verdicts` | every verdict marker on the PR, each with its `current` / `stale` / `unbindable` binding |
-| `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan over the diff |
+| `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan over the diff at the bound commit |
 | `review post` | the single sanctioned verdict emit — compose, bind, one comment per namespace, read back |
 | `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences |
 

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -166,13 +166,21 @@ const verdicts = leafCommand(
 
 const deviations = leafCommand(
 	"deviations",
-	{pr: prArg, repo: repoFlag, json: jsonFlag},
-	Effect.fn(function* ({pr, repo, json}) {
-		yield* emit(yield* runDeviations({pr, repo: Option.getOrNull(repo), json, env: process.env}));
+	{pr: prArg, sha: boundShaFlag, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, sha, repo, json}) {
+		yield* emit(
+			yield* runDeviations({
+				pr,
+				sha: Option.getOrNull(sha),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Report the PR body's `## Deviations` state — found | none-declared | absent | malformed, three distinct facts — with its entries and the Tier-M token scan over the head diff. First stdout line is `deviations\\t<state>`, then one `entry\\t<class-label-or-->\\t<first-line-of-Said>` line per entry and one `tier-m\\t<kind>\\t<file>:<line>\\t<token>` line per hit. Exits 7 (PR proven absent), 11 (the body or diff could not be read — the disclosure state is UNKNOWN, never `none`), 13 (a partial diff must not print a partial scan beside a disclosure claim). Example: fabrika review deviations 4321",
+		"Report the PR body's `## Deviations` state — found | none-declared | absent | malformed, three distinct facts — with its entries and the Tier-M token scan over the diff at the bound commit. First stdout line is `deviations\\t<state>`, then one `entry\\t<class-label-or-->\\t<first-line-of-Said>` line per entry and one `tier-m\\t<kind>\\t<file>:<line>\\t<token>` line per hit. Exits 7 (PR proven absent), 10 (--sha is not a head SHA), 11 (the body or diff could not be read, or the commit could not be bound — the disclosure state is UNKNOWN, never `none`), 12 (--sha is not the PR's head — re-scope, never re-bind), 13 (a partial diff must not print a partial scan beside a disclosure claim). Example: fabrika review deviations 4321 --sha 03135b91",
 	),
 );
 
@@ -229,7 +237,7 @@ const post = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		'Post the verdict on STDIN as ONE comment for this namespace — recompute the class set, re-resolve the live head, compose the first line through the `verdict-marker` wire format, leak-scan the assembled comment, upsert, and read it back from live state. Prints `posted\\t<namespace>\\t<polarity>\\t<sha>\\t<created|edited>\\t<comment-url>`. Exits 3 (empty stdin — an empty verdict reads as UNGATED), 5 (machine-local path in the assembled comment), 6 (bare @ reference), 7 (PR absent or closed), 8 (the create/edit failed — UNKNOWN), 9 (read-back does not yield this marker), 10 (namespace this diff did not derive, bad polarity, or advisory with FAIL), 11 (a precondition read failed — nothing was posted), 12 (the live head moved past --sha — re-review, never re-bind). Example: fabrika review post 4321 --namespace review-doc --polarity PASS --sha 03135b91 --clause "guide matches shipped behavior" < verdict.md',
+		'Post the verdict on STDIN as ONE comment for this namespace — re-resolve the live head, recompute the class set at the bound commit, compose the first line through the `verdict-marker` wire format, leak-scan the assembled comment, upsert, and read it back from live state. Prints `posted\\t<namespace>\\t<polarity>\\t<sha>\\t<created|edited>\\t<comment-url>`. Exits 3 (empty stdin — an empty verdict reads as UNGATED), 5 (machine-local path in the assembled comment), 6 (bare @ reference), 7 (PR absent or closed), 8 (the create/edit failed — UNKNOWN), 9 (read-back does not yield this marker), 10 (namespace this diff did not derive, bad polarity, or advisory with FAIL), 11 (a precondition read failed, or the commit could not be bound — nothing was posted), 12 (the live head moved past --sha — re-review, never re-bind). Example: fabrika review post 4321 --namespace review-doc --polarity PASS --sha 03135b91 --clause "guide matches shipped behavior" < verdict.md',
 	),
 );
 

--- a/packages/fabrika-cli/src/review/deviations-verb.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.ts
@@ -9,15 +9,19 @@
  *
  * The scan inherits `review diff`'s completeness proof, so a truncated diff reds here too — an
  * under-reported hit list beside a `None.` reads as a checked-clean disclosure that was never
- * checked.
+ * checked. It inherits the same commit binding for the same reason (`head.ts`, #5122): a hit list
+ * read from a head nobody scoped is under- or over-reported against the disclosure it is printed
+ * beside, and the falsified-`None.` read this verb exists to make possible is only as good as the
+ * tree the tokens came from.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {getPullDiff} from "../io/pulls.ts";
+import {diffRange} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {readDeviations} from "./deviations.ts";
 import {filesInDiff, tierMHits} from "./diff.ts";
+import {bindHead, boundLine} from "./head.ts";
 import {NULL_TOKEN} from "./scope-verb.ts";
 import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
 
@@ -25,6 +29,8 @@ const VERB = "review deviations";
 
 export interface DeviationsOptions {
 	readonly pr: number;
+	/** The head the caller scoped. `null` binds to the PR's live head instead of asserting one. */
+	readonly sha: string | null;
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
@@ -53,13 +59,20 @@ export const runDeviations = (
 		if (target._tag === "Refused") return target.outcome;
 		const pull = target.pull;
 
-		const served = yield* getPullDiff(repo, pr);
+		const bound = yield* bindHead(VERB, repo, pr, pull, options.sha);
+		if (bound._tag === "Refused") return bound.outcome;
+		const head = bound.head;
+
+		const served = yield* diffRange(head.base, head.sha);
 		if (served._tag === "Failure") {
 			return refuse(PRECONDITION_UNKNOWN, unreadable(pr, served.reason));
 		}
 		const diff = served.value;
 		const seen = filesInDiff(diff);
-		const diagnostics = [scannedLine(VERB, seen, "file", `${pull.changedFiles} declared`)];
+		const diagnostics = [
+			boundLine(VERB, head),
+			scannedLine(VERB, seen, "file", `${pull.changedFiles} declared`),
+		];
 		if (seen < pull.changedFiles) {
 			return refuse(
 				INCOMPLETE_SCAN,

--- a/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
@@ -2,11 +2,18 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {
+	INCOMPLETE_SCAN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	STALE_HEAD,
+	ZERO_SCOPE,
+} from "./codes.ts";
 import {runDeviations} from "./deviations-verb.ts";
-import {DIFF, pull} from "./fixtures.test-support.ts";
+import {BASE, binding, DIFF, DIFF_AT, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/** The unbound endpoint this verb no longer reads — scripted so a regression has bytes to serve. */
 const RAW = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
 
 const SUPPRESSING_DIFF = `diff --git a/src/cart.ts b/src/cart.ts
@@ -25,34 +32,51 @@ diff --git a/src/cart.test.ts b/src/cart.test.ts
 
 const options = {
 	pr: 4321,
+	sha: null as string | null,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
 };
 
+const shell = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const fake = fakeShell(script);
+	return {
+		fake,
+		out: Effect.runPromise(Effect.provide(runDeviations({...options, ...overrides}), fake.layer)),
+	};
+};
+
 const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
-) =>
-	Effect.runPromise(
-		Effect.provide(runDeviations({...options, ...overrides}), fakeShell(script).layer),
-	);
+) => shell(script, overrides).out;
+
+/** The green path: the bound range serves `diff`, and the PR-number endpoint serves `endpoint`. */
+const scripted = (
+	diff: string,
+	endpoint: string,
+	shape: Parameters<typeof pull>[0] = {},
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull(shape)],
+	...binding(),
+	[DIFF_AT(), okOut(diff)],
+	[RAW, okOut(endpoint)],
+];
+
+const happy = (shape: Parameters<typeof pull>[0] = {}) => scripted(DIFF, DIFF, shape);
 
 describe("runDeviations", () => {
 	it("prints none-declared for a `None.` body with a clean diff", async () => {
-		const out = await run([
-			[PULL, pull()],
-			[RAW, okOut(DIFF)],
-		]);
+		const out = await run(happy());
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe("deviations\tnone-declared\n");
 	});
 
 	it("makes a falsified `None.` visible in one read — the claim beside the hits", async () => {
-		const out = await run([
-			[PULL, pull()],
-			[RAW, okOut(SUPPRESSING_DIFF)],
-		]);
+		const out = await run(scripted(SUPPRESSING_DIFF, SUPPRESSING_DIFF));
 		expect(out.stdout).toBe(
 			[
 				"deviations\tnone-declared",
@@ -66,10 +90,7 @@ describe("runDeviations", () => {
 	it("prints an entry's label and the first line of its Said", async () => {
 		const body =
 			"## Deviations\n\n- **Pre-existing test or fixture changed** — **Said:** replaced the two-decimal rendering assertion. **Did:** dropped it.";
-		const out = await run([
-			[PULL, pull({body})],
-			[RAW, okOut(DIFF)],
-		]);
+		const out = await run(happy({body}));
 		expect(out.stdout).toBe(
 			["deviations\tfound", "entry\t6\treplaced the two-decimal rendering assertion.", ""].join(
 				"\n",
@@ -78,18 +99,12 @@ describe("runDeviations", () => {
 	});
 
 	it("keeps absent distinct from none-declared — the skill's verdict depends on it", async () => {
-		const out = await run([
-			[PULL, pull({body: "Fixes #4287\n"})],
-			[RAW, okOut(DIFF)],
-		]);
+		const out = await run(happy({body: "Fixes #4287\n"}));
 		expect(out.stdout).toBe("deviations\tabsent\n");
 	});
 
 	it("refuses a truncated diff on 13 — a partial scan must not print beside a claim", async () => {
-		const out = await run([
-			[PULL, pull({changedFiles: 9})],
-			[RAW, okOut(DIFF)],
-		]);
+		const out = await run(happy({changedFiles: 9}));
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("refusing a partial Tier-M scan beside a disclosure claim");
@@ -104,15 +119,88 @@ describe("runDeviations", () => {
 	it("refuses an unreadable body or diff on 11, and never answers `none`", async () => {
 		for (const script of [
 			[[PULL, errOut("gh: Bad gateway (HTTP 502)")]] as const,
-			[
-				[PULL, pull()],
-				[RAW, errOut("gh: Bad gateway (HTTP 502)")],
-			] as const,
+			[[PULL, pull()], ...binding(), [DIFF_AT(), errOut("fatal: bad revision")]] as const,
 		]) {
 			const out = await run(script as ReadonlyArray<readonly [RegExp, ExecResult]>);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
 			expect(out.stdout).toBe("");
 			expect(out.stderr.at(-1)).toContain('the disclosure state is UNKNOWN, never "none"');
 		}
+	});
+});
+
+/**
+ * The provenance fence (#5122), the sibling of `review scope`'s.
+ *
+ * A `deviation-disclosure` verdict claims "nothing undisclosed that this gate could see", so the hit
+ * list is not one input among many — read at a head nobody scoped it is under- or over-reported
+ * beside the disclosure it is printed next to, and the caller reads a checked-clean answer at exit 0.
+ * Every case below scripts the PR-number endpoint with a *different* head's bytes, so a read that
+ * reverts to it fails on a **wrong answer**, not on a crash.
+ */
+describe("runDeviations binds its Tier-M scan to a commit", () => {
+	it("scans the bound commit's bytes, never the PR-number endpoint's", async () => {
+		const {fake, out} = shell(scripted(SUPPRESSING_DIFF, DIFF));
+		const result = await out;
+		expect(result.code).toBe(0);
+		expect(result.stdout).toContain("tier-m\tsuppression\tsrc/cart.ts:11\t@ts-expect-error");
+		expect(fake.calls).toContain(
+			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ ${BASE}...${HEAD}`,
+		);
+		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+	});
+
+	// The fail-OPEN direction, and the reason this is priced above its fail-closed sibling: the
+	// unbound read answers `none-declared` with an empty hit list beside a `None.` body, at exit 0.
+	it("does not print a clean scan beside a `None.` when the endpoint's head is the clean one", async () => {
+		const out = await run(scripted(SUPPRESSING_DIFF, DIFF));
+		expect(out.stdout).not.toBe("deviations\tnone-declared\n");
+	});
+
+	// The hole `12` cannot close: the head moved forward and was force-pushed back, so `--sha` IS the
+	// live head and every staleness check passes — while the PR-number endpoint still serves the
+	// intermediate head's bytes. Only reading at the commit tells the two trees apart.
+	it("scans the recorded commit after a REWIND back onto it, not what the endpoint serves", async () => {
+		const {fake, out} = shell(scripted(SUPPRESSING_DIFF, DIFF), {sha: HEAD});
+		const result = await out;
+		expect(result.code).toBe(0);
+		expect(result.stdout).toContain("tier-m\tremoved-assertion");
+		expect(fake.calls.some((c) => c.includes("vnd.github.diff"))).toBe(false);
+	});
+
+	it("reports the commit it bound to, ahead of what it scanned", async () => {
+		const out = await run(happy());
+		expect(out.stderr[0]).toBe(
+			`review deviations: bound to ${HEAD} (base ${BASE}) — read from the object database, nothing checked out.`,
+		);
+		expect(out.stderr[1]).toBe("review deviations: scanned 2 files; 2 declared.");
+	});
+
+	it("refuses on 12 when --sha is not the PR's head, scanning nothing", async () => {
+		const {fake, out} = shell(happy(), {sha: OLD_HEAD});
+		const result = await out;
+		expect(result.code).toBe(STALE_HEAD);
+		expect(result.stdout).toBe("");
+		expect(result.stderr.at(-1)).toContain("re-scope at");
+		expect(fake.calls.some((c) => c.startsWith("git diff"))).toBe(false);
+	});
+
+	it("refuses a --sha that is not a head SHA on 10", async () => {
+		const out = await run(happy(), {sha: "origin/main"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("is not a head SHA");
+	});
+
+	it("refuses on 11 when the commit cannot be bound, rather than scanning an unbound diff", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
+			[RAW, okOut(SUPPRESSING_DIFF)],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review deviations: no git remote in this checkout serves o/r — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.",
+		);
 	});
 });

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -243,6 +243,104 @@ describe("the commit binding on the read verbs", () => {
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({head: HEAD, namespaces: ["review-doc"]});
 	});
+
+	// #5122's half: the same unbound read, at the two seams #5117 left behind. Both mutants die
+	// fail-OPEN — a checked-clean disclosure and a posted verdict, each at exit 0.
+	const SUPPRESSING_DIFF = `diff --git a/src/cart.ts b/src/cart.ts
+--- a/src/cart.ts
++++ b/src/cart.ts
+@@ -10,1 +10,2 @@
+ const items = read();
++// @ts-expect-error the types are wrong
+diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1,1 +1,2 @@
+ # phoenix
++a line
+`;
+
+	const deviationsScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull()],
+		...binding(),
+		[DIFF_AT(), okOut(SUPPRESSING_DIFF)],
+		[RAW, okOut(DIFF)],
+	];
+
+	it("scans the bound commit's bytes for Tier-M tokens", async () => {
+		const {runDeviations} = await import("./deviations-verb.ts");
+		const out = await withShell(
+			runDeviations({pr: 4321, sha: HEAD, repo: null, json: false, env: ENV}),
+			deviationsScript,
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("tier-m\tsuppression");
+	});
+
+	it("MUTANT: reading the PR-number diff prints a clean scan beside a `None.` that is false", async () => {
+		await mutate<typeof import("../io/git.ts")>("../io/git.ts", () => ({
+			diffRange: () => Effect.succeed({_tag: "Ok" as const, value: DIFF}),
+		}));
+		const {runDeviations} = await import("./deviations-verb.ts");
+		const out = await withShell(
+			runDeviations({pr: 4321, sha: HEAD, repo: null, json: false, env: ENV}),
+			deviationsScript,
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("deviations\tnone-declared\n");
+	});
+
+	const postOptions = {
+		pr: 4321,
+		namespace: "review-skill",
+		polarity: "PASS",
+		sha: HEAD,
+		clause: "guide matches shipped behavior",
+		carrier: "marker",
+		repo: null,
+		json: false,
+		env: ENV,
+		stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "the table\n"}),
+		now: NOW,
+	};
+	const postScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({changedFiles: 1})],
+		...binding(),
+		[PATHS_AT(), paths("src/cart.ts")],
+		[FILES, files("skills/deploy/SKILL.md")],
+		[USER, okOut("kampus-bot")],
+		[COMMENTS, comments()],
+		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
+		[
+			READBACK,
+			okOut(
+				JSON.stringify({
+					body: `review-skill: PASS @ ${HEAD} — guide matches shipped behavior\n\nthe table\n\n${STAMP}`,
+				}),
+			),
+		],
+	];
+
+	it("refuses a namespace the bound commit's file list does not derive", async () => {
+		const {runPost} = await import("./post-verb.ts");
+		const shell = fakeShell(postScript);
+		const out = await Effect.runPromise(Effect.provide(runPost(postOptions), shell.layer));
+		expect(out.code).toBe(10);
+		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("MUTANT: reading the PR-number file list POSTS a namespace this run never derived", async () => {
+		await mutate<typeof import("../io/git.ts")>("../io/git.ts", () => ({
+			diffRangePaths: () =>
+				Effect.succeed({_tag: "Ok" as const, value: ["skills/deploy/SKILL.md"]}),
+		}));
+		const {runPost} = await import("./post-verb.ts");
+		const shell = fakeShell(postScript);
+		const out = await Effect.runPromise(Effect.provide(runPost(postOptions), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("posted\treview-skill\tPASS");
+		expect(shell.calls.some((call) => CREATE.test(call))).toBe(true);
+	});
 });
 
 describe("the leak predicate over the assembled verdict", () => {
@@ -262,7 +360,9 @@ describe("the leak predicate over the assembled verdict", () => {
 	};
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull()],
-		[FILES, files("src/cart.ts", "README.md")],
+		...binding(),
+		[PATHS_AT(), paths("src/cart.ts", "README.md")],
+		[FILES, files("skills/deploy/SKILL.md")],
 		[USER, okOut("kampus-bot")],
 		[COMMENTS, comments()],
 		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],
@@ -314,7 +414,9 @@ describe("normalizeForReadback's trailing-newline step", () => {
 	};
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull()],
-		[FILES, files("src/cart.ts", "README.md")],
+		...binding(),
+		[PATHS_AT(), paths("src/cart.ts", "README.md")],
+		[FILES, files("skills/deploy/SKILL.md")],
 		[USER, okOut("kampus-bot")],
 		[COMMENTS, comments()],
 		[CREATE, okOut(JSON.stringify({id: 1, html_url: "https://example.test/c/1"}))],

--- a/packages/fabrika-cli/src/review/post-verb.ts
+++ b/packages/fabrika-cli/src/review/post-verb.ts
@@ -1,10 +1,10 @@
 /**
  * `review post` — the single sanctioned verdict emit.
  *
- * Six steps, each gating the next: recompute the class set, re-resolve the live head, compose the
- * first line through the wire format's `emit` (stamping the write-recency line under it), leak-scan
- * the assembled comment, upsert **one comment per namespace**, and read it back unconditionally from
- * live PR state.
+ * Six steps, each gating the next: re-resolve the live head, recompute the class set at the commit
+ * the verdict binds, compose the first line through the wire format's `emit` (stamping the
+ * write-recency line under it), leak-scan the assembled comment, upsert **one comment per
+ * namespace**, and read it back unconditionally from live PR state.
  *
  * Every one of those is a scar. #3173's hand-rolled `gh api` emit posted a literal path and
  * self-reported a false PASS, which is why the read-back re-fetches instead of trusting a carried
@@ -13,11 +13,17 @@
  * is `bindToHead`'s `Stale` arm applied at the write seam, where its absence costs the most. And the
  * marker is the comment's **literal first line** — a second marker stacked on line 2 is un-anchored,
  * resolves its namespace empty, and fail-closes a substantively-passing PR (the PR #2456 stall).
+ *
+ * The head re-resolve runs **before** the recompute, and the recompute reads at the bound commit
+ * (`head.ts`, #5122). `12` labels the tree; only the binding makes the derived set provably that
+ * tree's — the two are separate reads, and a force-push that rewinds back onto `--sha` passes `12`
+ * clean while the PR-number file endpoint serves some other head's list.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
+import {diffRangePaths} from "../io/git.ts";
 import {createComment, getComment, listComments} from "../io/issues.ts";
-import {listPullFiles, patchComment, viewerLogin} from "../io/pulls.ts";
+import {patchComment, viewerLogin} from "../io/pulls.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
@@ -38,6 +44,7 @@ import {
 	STALE_HEAD,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
+import {bindHead, boundLine} from "./head.ts";
 import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
 import {latestByWriteRecency, stampIso, withWrittenAt} from "./write-recency.ts";
 
@@ -216,25 +223,30 @@ export const runPost = (
 		if (target._tag === "Refused") return target.outcome;
 		const live = target.pull.headSha;
 
-		// Step 1 — recompute the class set this run derived, and refuse a namespace outside it.
-		const listed = yield* listPullFiles(repo, pr);
+		// Step 1 — the verdict binds the tree it was formed over, or it is re-reviewed, never re-bound.
+		if (!prefixMatch(live, inspected)) {
+			return refuse(
+				STALE_HEAD,
+				`${VERB}: the live head is ${live}, not ${inspected} — the tree you judged is gone; re-review at ${live} (ADR 0058).`,
+			);
+		}
+
+		// Step 2 — recompute the class set at the bound commit, and refuse a namespace outside it.
+		const bound = yield* bindHead(VERB, repo, pr, target.pull, options.sha);
+		if (bound._tag === "Refused") return bound.outcome;
+		const head = bound.head;
+		const listed = yield* diffRangePaths(head.base, head.sha);
 		if (listed._tag === "Failure") return unreadable("the changed-file list", pr, listed.reason);
 		const derived = namespacesOf(partition(listed.value));
-		const diagnostics = [scannedLine(VERB, listed.value.length, "changed file")];
+		const diagnostics = [
+			boundLine(VERB, head),
+			scannedLine(VERB, listed.value.length, "changed file"),
+		];
 		const namespace = options.namespace.trim().toLowerCase();
 		if (!derived.includes(namespace)) {
 			return refuse(
 				OFF_VOCABULARY,
 				`${VERB}: --namespace ${namespace} is not derived by #${pr}'s diff (present: ${derived.join(", ")}) — a gate never emits a namespace it did not judge.`,
-				diagnostics,
-			);
-		}
-
-		// Step 2 — the verdict binds the tree it was formed over, or it is re-reviewed, never re-bound.
-		if (!prefixMatch(live, inspected)) {
-			return refuse(
-				STALE_HEAD,
-				`${VERB}: the live head is ${live}, not ${inspected} — the tree you judged is gone; re-review at ${live} (ADR 0058).`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/post-verb.unit.test.ts
@@ -14,10 +14,25 @@ import {
 	WRITE_UNKNOWN,
 	ZERO_SCOPE,
 } from "./codes.ts";
-import {comments, files, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+import {
+	BASE,
+	binding,
+	comments,
+	files,
+	HEAD,
+	OLD_HEAD,
+	PATHS_AT,
+	paths,
+	pull,
+} from "./fixtures.test-support.ts";
 import {runPost} from "./post-verb.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+/**
+ * The unbound endpoint this verb no longer reads, scripted with a **skill-only** list — so a read
+ * that drifts back to it derives `review-skill` where the bound commit derives code and doc, and
+ * every case below fails on a wrong answer rather than on a missing script.
+ */
 const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
 const USER = /^gh api user --jq \.login$/;
 const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
@@ -58,7 +73,9 @@ const options = {
 
 const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 	[PULL, pull()],
-	[FILES, files("src/cart.ts", "README.md")],
+	...binding(),
+	[PATHS_AT(), paths("src/cart.ts", "README.md")],
+	[FILES, files("skills/deploy/SKILL.md")],
 	[USER, okOut("kampus-bot")],
 	[COMMENTS, comments()],
 	[CREATE, created],
@@ -90,7 +107,9 @@ describe("runPost", () => {
 	it("edits this namespace's existing comment instead of stacking a second one", async () => {
 		const shell = fakeShell([
 			[PULL, pull({comments: 1})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[
 				COMMENTS,
@@ -119,7 +138,9 @@ describe("runPost", () => {
 	it("stamps the write-recency line on the comment it edits, too", async () => {
 		const shell = fakeShell([
 			[PULL, pull({comments: 1})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments({id: 42, body: `review-doc: FAIL @ ${OLD_HEAD} — older round`})],
 			[PATCH, okOut(JSON.stringify({html_url: URL}))],
@@ -136,7 +157,9 @@ describe("runPost", () => {
 	it("edits the NEWEST comment in the namespace when two of this author's already exist", async () => {
 		const shell = fakeShell([
 			[PULL, pull({comments: 2})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[
 				COMMENTS,
@@ -169,7 +192,9 @@ describe("runPost", () => {
 	it("ranks by the write-recency stamp, not by when the comment slot was opened", async () => {
 		const shell = fakeShell([
 			[PULL, pull({comments: 2})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[
 				COMMENTS,
@@ -197,7 +222,9 @@ describe("runPost", () => {
 	it("does not edit another author's comment in the same namespace", async () => {
 		const shell = fakeShell([
 			[PULL, pull({comments: 1})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments({id: 42, body: MARKER, author: "someone-else"})],
 			[CREATE, created],
@@ -287,7 +314,8 @@ describe("runPost", () => {
 	it("refuses a failed precondition read on 11, with nothing posted", async () => {
 		const shell = fakeShell([
 			[PULL, pull()],
-			[FILES, errOut("gh: Bad gateway (HTTP 502)")],
+			...binding(),
+			[PATHS_AT(), errOut("fatal: bad revision")],
 		]);
 		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -298,7 +326,9 @@ describe("runPost", () => {
 	it("reports a failed write as 8 — UNKNOWN whether the verdict landed", async () => {
 		const out = await run([
 			[PULL, pull()],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments()],
 			[CREATE, errOut("gh: timeout")],
@@ -312,7 +342,9 @@ describe("runPost", () => {
 	it("refuses on 9 when the read-back does not yield this marker (#3173)", async () => {
 		const out = await run([
 			[PULL, pull()],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments()],
 			[CREATE, created],
@@ -326,7 +358,9 @@ describe("runPost", () => {
 	it("reads back from LIVE state — a garbled SHA on the PR reds even though the write returned ok", async () => {
 		const out = await run([
 			[PULL, pull()],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments()],
 			[CREATE, created],
@@ -340,7 +374,9 @@ describe("runPost", () => {
 		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD}\n\n${BODY}`;
 		const shell = fakeShell([
 			[PULL, pull()],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments()],
 			[CREATE, created],
@@ -370,7 +406,9 @@ describe("runPost", () => {
 
 		const fresh = fakeShell([
 			[PULL, pull()],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments()],
 			[CREATE, created],
@@ -382,7 +420,9 @@ describe("runPost", () => {
 
 		const again = fakeShell([
 			[PULL, pull({comments: 1})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments({id: 42, body: advisoryFor(OLD_HEAD), author: "kampus-bot"})],
 			[PATCH, okOut(JSON.stringify({html_url: URL}))],
@@ -398,7 +438,9 @@ describe("runPost", () => {
 		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${OLD_HEAD}\n\n${BODY}`;
 		const overAdvisory = fakeShell([
 			[PULL, pull({comments: 1})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments({id: 42, body: advisory, author: "kampus-bot"})],
 			[CREATE, created],
@@ -410,7 +452,9 @@ describe("runPost", () => {
 
 		const overMarker = fakeShell([
 			[PULL, pull({comments: 1})],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[
 				COMMENTS,
@@ -463,7 +507,9 @@ describe("runPost", () => {
 	it("uses `once` to prove the read-back is a SECOND fetch, not the write's echo", async () => {
 		const out = await run([
 			[PULL, pull()],
-			[FILES, files("src/cart.ts", "README.md")],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
 			[COMMENTS, comments()],
 			[CREATE, created],
@@ -471,5 +517,83 @@ describe("runPost", () => {
 			[READBACK, errOut("never reached")],
 		]);
 		expect(out.code).toBe(0);
+	});
+});
+
+/**
+ * The provenance fence (#5122).
+ *
+ * The derived namespace set is documented as both floor and ceiling for what this verb may emit, so
+ * recomputing it from the PR-number endpoint admits a namespace this run never derived and refuses
+ * one it did — and it does so at exit 0, with a posted verdict. `12` labels the tree the verdict
+ * claims; only the binding makes the set provably that tree's.
+ */
+describe("runPost recomputes its namespace set at the bound commit", () => {
+	it("derives the set from the bound commit, never from the PR-number endpoint", async () => {
+		const shell = fakeShell(happy());
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls).toContain(
+			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ --name-only -z ${BASE}...${HEAD}`,
+		);
+		expect(shell.calls.some((call) => call.includes("pulls/4321/files"))).toBe(false);
+	});
+
+	// The fail-OPEN direction: `review-skill` is derived only by the endpoint's list, so an unbound
+	// recompute POSTS it — a verdict filling a namespace this run never judged, at exit 0.
+	it("refuses a namespace only the unbound endpoint derives, and writes nothing", async () => {
+		const shell = fakeShell(happy());
+		const out = await Effect.runPromise(
+			Effect.provide(runPost({...options, namespace: "review-skill"}), shell.layer),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"review post: --namespace review-skill is not derived by #4321's diff (present: review-code, review-doc) — a gate never emits a namespace it did not judge.",
+		);
+		expect(shell.calls.some((call) => CREATE.test(call) || PATCH.test(call))).toBe(false);
+	});
+
+	// The hole `12` cannot close, and the reason binding had to be added underneath it rather than
+	// swapped in for it: the head moved forward and was force-pushed back onto the recorded SHA, so
+	// the live head prefix-matches `--sha` and step 1 passes clean — while the PR-number endpoint
+	// still answers with the intermediate head's file list.
+	it("derives the REWOUND commit's set even though the live head matches --sha", async () => {
+		const shell = fakeShell(happy());
+		const out = await Effect.runPromise(
+			Effect.provide(runPost({...options, namespace: "review-doc"}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain(`\t${HEAD}\t`);
+		expect(shell.calls.some((call) => call.includes("pulls/4321/files"))).toBe(false);
+	});
+
+	it("names the commit the set was derived at on stderr", async () => {
+		const out = await run(happy());
+		expect(out.stderr[0]).toBe(
+			`review post: bound to ${HEAD} (base ${BASE}) — read from the object database, nothing checked out.`,
+		);
+	});
+
+	it("refuses on 11 when the commit cannot be bound, rather than deriving an unbound set", async () => {
+		const shell = fakeShell([
+			[PULL, pull()],
+			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
+			[FILES, files("skills/deploy/SKILL.md")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(shell.calls.some((call) => CREATE.test(call) || PATCH.test(call))).toBe(false);
+	});
+
+	// The `12` seat is `review post`'s own, ahead of the binding — the binding is added underneath it.
+	it("keeps the 12 refusal on a forward-moved head, before any commit is bound", async () => {
+		const shell = fakeShell(happy());
+		const out = await Effect.runPromise(
+			Effect.provide(runPost({...options, sha: OLD_HEAD}), shell.layer),
+		);
+		expect(out.code).toBe(STALE_HEAD);
+		expect(shell.calls.some((call) => call.startsWith("git diff"))).toBe(false);
 	});
 });


### PR DESCRIPTION
Two of fabrika's review commands were reading a pull request's diff and file list from endpoints that take a PR number and no commit at all. That means the bytes they judged could come from a head nobody scoped — and the failure was silent: the answer looked well-formed and checked-clean, at exit 0. Both now read at the commit they name, through the same binding step `review scope` and `review diff` already use.

Fixes #5122

## What changed

- **`review deviations`** — the Tier-M token scan now runs over `git diff <base>...<head>` at the bound commit instead of `getPullDiff(repo, pr)`. The verb takes the same optional `--sha` its sibling read verbs take, and prints the bound commit on stderr like they do.
- **`review post`** — the derived namespace set is recomputed from `diffRangePaths(base, head)` at the bound commit instead of `listPullFiles(repo, pr)`. The set is documented as both floor and ceiling for what a gate may emit, so deriving it from an unbound read can admit a namespace this run never judged.
- **`12` is preserved, and binding was added underneath it.** `review post`'s stale-head refusal stays this verb's first step and keeps its own message and code. It moved ahead of the namespace recompute so the binding is never attempted on a head the PR has moved past. `12` proves the tree is still the live one; only the binding proves the list came from it.
- **No new exit code.** Refusals reuse `OFF_VOCABULARY` (10), `PRECONDITION_UNKNOWN` (11) and `STALE_HEAD` (12) from `packages/fabrika-cli/src/review/codes.ts`.
- **Nothing is checked out.** `bindHead` fetches `pull/<pr>/head` and reads the object database — a fetch writes objects, not a working tree.
- Contract, skill and README prose updated to match: the shared binding section no longer scopes itself to two verbs, and `review deviations`' "does not yet inherit the commit binding … Tracked as #5122" paragraph is gone.

## Why this was p1

The direction of failure is **open**. A force-push that rewinds back onto the recorded SHA passes `12` clean, while the PR-number endpoints can still serve another head's artifact. The old reads then answered plausibly and wrongly at exit 0 — a `None.` disclosure printed beside an empty Tier-M list that was never scanned over the judged tree, or a verdict posted in a namespace the run never derived.

## Falsifiability

Every new test reds on a **wrong answer**, not a crash, if the binding is reverted. The fixtures script the PR-number endpoints with a *different* head's artifact, so an unbound read has something plausible to serve:

- `deviations-verb.unit.test.ts` → `runDeviations binds its Tier-M scan to a commit`. With the binding reverted, "scans the bound commit's bytes, never the PR-number endpoint's" fails with `expected 'deviations\tnone-declared\n' to contain 'tier-m\tsuppression…'` — exit 0, a clean scan beside a `None.`.
- `post-verb.unit.test.ts` → `runPost recomputes its namespace set at the bound commit`. "refuses a namespace only the unbound endpoint derives, and writes nothing" pins the fail-open by name: the endpoint's list derives `review-skill`, the bound commit's does not, and the unbound read posts it at exit 0.
- `mutation.unit.test.ts` → two mutants beside #5117's, each asserting its intended wrong answer: `MUTANT: reading the PR-number diff prints a clean scan beside a `None.` that is false` and `MUTANT: reading the PR-number file list POSTS a namespace this run never derived`.
- **The REWIND case is covered explicitly**, in both verbs — the hole `12` cannot close. `scans the recorded commit after a REWIND back onto it, not what the endpoint serves` and `derives the REWOUND commit's set even though the live head matches --sha` both run with the live head prefix-matching `--sha`, so every staleness check passes clean and only the binding tells the two trees apart.

Verified by reverting both bindings on a scratch copy: 25 tests red, all on wrong-answer assertions. Restored, full suite green — 143 files, 2135 tests. `pnpm typecheck --force`: 30/30 successful, 0 cached. `pnpm lint:worktree`: clean.

## Deviations

- **Scope narrowing (class 1) — Said:** the dispatch brief scoped me out of "the prose in `claude-plugins/fabrika/skills/review/contract.md`" as #4993's. **Did:** I edited three sections of it anyway — the shared binding section's "Both verbs" scoping, the `review deviations` section, and the `review post` section. **Why:** #5122's own acceptance criteria require exactly those edits, and #5122's scope-boundary note scopes #4993 to the `review diff` **Grounding** prose plus the `diff.ts` / `diff-verb.ts` docblocks. Shipping without them would have left an AC unmet and forced a `Part of #5122`. **Disposition:** I touched neither the `review diff` Grounding section nor `diff.ts` / `diff-verb.ts` (neither file appears in this diff) — for the reviewer to judge, and a rebase against #4993 is expected.
- **Behaviour change not named in the issue (class 7) — Said:** the ACs asked only that `12` still refuse a forward-moved head. **Did:** `review post`'s `12` check also moved *ahead of* the namespace recompute, so a run with both an off-set `--namespace` and a stale head now exits `12` where it previously exited `10`, and the `12` refusal no longer carries the scanned-file diagnostic line. **Why:** the recompute now depends on a binding that must not be attempted on a head the PR has moved past; keeping the old order would have made `bindHead`'s own stale arm fire first with a different message, changing the `12` wording the contract pins. **Disposition:** no action needed — both orderings refuse and write nothing; the contract's step list and the verb's docblock were updated to match.
- **Sibling seams left unbound (class 3) — Said:** nothing. **Did:** `ship/release-verb.ts`, `ship/cp-approval-verb.ts` and `ship/scope-verb.ts` still call `getPullDiff` / `listPullFiles`. **Why:** #5122 names the `review` verb group only. **Disposition:** for the reviewer to judge — I did not file a follow-up, since whether the ship verbs owe the same binding is a triage call, not mine.
- **(repair round 2) Fix kept narrower than the whole file (class 1) — Said:** the `review-code` / `review-skill` FAIL named one unmet clause of AC 5, remedy "two table cells". **Did:** exactly that and nothing else — in `claude-plugins/fabrika/skills/review/contract.md`, section "The shared exit taxonomy", the `deviations` column on the `10` row and on the `12` row goes from `—` to `✓`. The diff for this round is 2 insertions, 2 deletions, one file. **Why:** `review deviations` now binds through `bindHead`, so it returns `OFF_VOCABULARY` (10) and `STALE_HEAD` (12) — which this PR's own per-verb exit-status table, the `command.ts` description string and two passing tests already state; the matrix was the one place still denying it, so the file gave two answers to the same question. **Disposition:** no action needed. The two residuals disclosed in round 1 — the `12` refusal's lost `scannedLine` diagnostic (forced by the ordering) and `src/ship/**` still calling the unbound endpoints — are deliberately untouched here; both are follow-ups, not this finding.
