### PR TITLE
feat(fabrika-cli): carry a run's pinned model and arm onto the capture manifest (#4996)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -162,7 +162,7 @@ spawns nothing itself, which is what makes it reproducible offline. That propert
 starts processes from `spawn-io.ts`. The reversal and its bounds are [ADR
 0236](../../../../.decisions/0236-eval-harness-gains-a-spawning-shell.md).
 
-`RunRow` is `{entry, grade, spend}` where `spend` is a **three-arm** `RunSpend` union — declared,
+`RunRow` is `{entry, grade, spend, provenance}` where `spend` is a **three-arm** `RunSpend` union — declared,
 with `classifyRunSpend` that produces it, in [`../spend/token-spend.ts`](../spend/token-spend.ts)
 next to the meter it wraps ([#5050](https://github.com/kamp-us/phoenix/issues/5050)):
 `{_tag: "Reconstructed", spend}` (the `token-spend` `StageSpend`), `{_tag: "NoBilledTurns"}`, or
@@ -194,6 +194,32 @@ Two modes, story-split:
 ```ts
 import {collectRuns, collectFromCapture, decodeCaptureManifest} from "./runner.ts";
 ```
+
+### What provenance a capture manifest carries ([#4996](https://github.com/kamp-us/phoenix/issues/4996))
+
+A ledger (`--out`) and a capture manifest (`--capture-out`) are not equally attributable, and the
+gap used to be silent. The ledger names the suite's skill, stage, model, CLI version and
+`recordedAt` on its header and repeats them on every spend row; the manifest is the file the
+scorecard and `collectFromCapture` actually read, and it survives on its own long after the ledger
+is gone. So each `CaptureRun` now carries the two facts a graded row cannot be re-derived without:
+
+| field | carried | why |
+|---|---|---|
+| `stage`, `inputRef` | yes | the join key onto the corpus's ground-truth label |
+| `model` | yes | the model the run was **pinned** to (`--model`) — the axis the scorecard compares along |
+| `arm` | yes | `with-skill` / `without-skill`, otherwise unrecoverable once both arms fold into one file |
+| `transcriptPath` | yes | but it points **outside the repo**, under the `claude` data root: machine-local and perishable |
+| skill name, CLI version, `recordedAt` | **no** | ledger-only; a manifest is a per-run artifact, not a suite record |
+
+`model` and `arm` are `null` on a manifest written before they existed, and an absent key decodes
+to `null` rather than failing — every already-written manifest stays readable. Read `null` as
+*unrecorded*, never as a claim about the run.
+
+The scorecard consumes this as a **preference, not a replacement**: `report.ts` buckets a row on
+the model the run recorded, and falls back to the model reconstructed from the transcript only
+when the row recorded none. That is what stops a row whose transcript is gone from bucketing as
+`(unknown)` — it degrades exactly to the old behaviour, and only for the rows that predate the
+field.
 
 Presenting the collected rows (the two-axis scorecard) is the report slice
 ([#1853](https://github.com/kamp-us/phoenix/issues/1853)), documented next.
@@ -269,7 +295,7 @@ total: a malformed body or a shape mismatch exits non-zero with a typed reason, 
     {
       "stage": "build",
       "surface": null,                        // "code" | "doc" on a `review` cell; null on every other stage
-      "model": "opus-4.8" | null,            // reconstructed from the transcript; null when unattributable
+      "model": "opus-4.8" | null,            // the run's recorded model, else the transcript's; null when neither
       "gradedRuns": 3,                        // pass-rate denominator (includes transcript-missing runs)
       "passedRuns": 2,
       "passRate": 0.6667,                     // the graded quality axis

--- a/packages/fabrika-cli/src/eval/report.ts
+++ b/packages/fabrika-cli/src/eval/report.ts
@@ -25,11 +25,11 @@
  * A pass-rate measures ONE grading regime, so a cell is keyed by (stage × surface × model), not
  * stage alone: see `CellIdentity` and ADR 0243 §4.
  */
-import {Result} from "effect";
+import {Effect, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {CorpusEntry, type ReviewSurface} from "./corpus.ts";
 import {priceModelSwap, repairChurnCost} from "./repair-churn.ts";
-import type {RunRow} from "./runner.ts";
+import {EVAL_ARMS, type RunRow} from "./runner.ts";
 
 /** The issue the report's evidence feeds — the tiering DECISION, which this report never makes. */
 export const DECISION_POINTER = 1576;
@@ -72,7 +72,10 @@ export type CellIdentity =
 
 /** The two-axis picture for one (stage × surface × model) cell of the scorecard. */
 export type ScorecardCell = CellIdentity & {
-	/** The model the runs used, reconstructed from the transcript; `null` when unattributable. */
+	/**
+	 * The model the runs used: the one the run recorded, else the one its transcript reconstructs
+	 * to. `null` only when neither attests one.
+	 */
 	readonly model: string | null;
 	/** Total graded runs in the cell (the pass-rate denominator; includes transcript-missing). */
 	readonly gradedRuns: number;
@@ -142,10 +145,20 @@ interface Bucket {
 	transcriptMissing: number;
 }
 
+/**
+ * Which model a row is bucketed under. The run's own recorded model wins over the one its
+ * transcript reconstructs to: the recorded value is what the run was *pinned* to, while the
+ * transcript is machine-local and perishable, so reconstruction is the fallback for a row that
+ * recorded nothing — not the source (#4996). A row with a recorded model therefore keeps its
+ * bucket even when its transcript is gone, instead of collapsing into `(unknown)`.
+ */
+const modelOf = (row: RunRow): string | null =>
+	row.provenance.model ?? (row.spend._tag === "Reconstructed" ? row.spend.spend.model : null);
+
 const bucketize = (rows: ReadonlyArray<RunRow>): ReadonlyArray<Bucket> => {
 	const byKey = new Map<string, Bucket>();
 	for (const row of rows) {
-		const model = row.spend._tag === "Reconstructed" ? row.spend.spend.model : null;
+		const model = modelOf(row);
 		const id = identityOf(row.entry);
 		const key = cellKey(id, model);
 		let bucket = byKey.get(key);
@@ -399,10 +412,20 @@ const GradeSchema = Schema.Union([
 	Schema.Struct({status: Schema.Literal("fail"), mismatch: MismatchSchema}),
 ]);
 
+// A rows file written before provenance existed carries no `provenance` key, and must keep decoding
+// — it degrades to the transcript-reconstruction bucketing that was the only source back then.
+const RunProvenanceSchema = Schema.Struct({
+	model: Schema.NullOr(Schema.String),
+	arm: Schema.NullOr(Schema.Literals([...EVAL_ARMS])),
+});
+
 const RunRowSchema = Schema.Struct({
 	entry: CorpusEntry,
 	grade: GradeSchema,
 	spend: RunSpendSchema,
+	provenance: RunProvenanceSchema.pipe(
+		Schema.withDecodingDefault(Effect.succeed({model: null, arm: null})),
+	),
 });
 
 /** The report's input file: the array of graded rows `collectRuns` emits, serialized to JSON. */

--- a/packages/fabrika-cli/src/eval/report.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/report.unit.test.ts
@@ -1,15 +1,17 @@
 import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
 import type {StageSpend} from "../spend/token-spend.ts";
 import type {CorpusEntry} from "./corpus.ts";
 import {
 	buildScorecard,
 	type CellIdentity,
 	DECISION_POINTER,
+	decodeReportInput,
 	renderTable,
 	type ScorecardCell,
 	toJson,
 } from "./report.ts";
-import type {RunRow} from "./runner.ts";
+import type {RunProvenance, RunRow} from "./runner.ts";
 
 /** `true` iff `T` is a cell identity the report can key on — the type-level probe's operand. */
 type IsCell<T> = T extends CellIdentity ? true : false;
@@ -34,21 +36,36 @@ const spend = (billed: number, model: string): StageSpend => ({
 	model,
 });
 
+// A row that recorded no provenance — the pre-#4996 shape, which buckets off the transcript alone.
+const unrecorded: RunProvenance = {model: null, arm: null};
+
 // One graded run row: a pass/fail grade + a reconstructed spend at `billed` tokens on `model`.
-const row = (opts: {pass: boolean; billed: number; model: string; inputRef?: number}): RunRow => ({
+const row = (opts: {
+	pass: boolean;
+	billed: number;
+	model: string;
+	inputRef?: number;
+	provenance?: RunProvenance;
+}): RunRow => ({
 	entry: triageEntry(opts.inputRef ?? 1),
 	grade: opts.pass
 		? {status: "pass"}
 		: {status: "fail", mismatch: {_tag: "MalformedArtifact", reason: "x"}},
 	spend: {_tag: "Reconstructed", spend: spend(opts.billed, opts.model)},
+	provenance: opts.provenance ?? unrecorded,
 });
 
-const missingSpendRow = (opts: {pass: boolean; inputRef?: number}): RunRow => ({
+const missingSpendRow = (opts: {
+	pass: boolean;
+	inputRef?: number;
+	provenance?: RunProvenance;
+}): RunRow => ({
 	entry: triageEntry(opts.inputRef ?? 1),
 	grade: opts.pass
 		? {status: "pass"}
 		: {status: "fail", mismatch: {_tag: "MalformedArtifact", reason: "x"}},
 	spend: {_tag: "TranscriptMissing"},
+	provenance: opts.provenance ?? unrecorded,
 });
 
 const cellFor = (cells: ReadonlyArray<ScorecardCell>, model: string | null): ScorecardCell => {
@@ -81,6 +98,7 @@ const entryRow = (opts: {
 		? {status: "pass"}
 		: {status: "fail", mismatch: {_tag: "MalformedArtifact", reason: "x"}},
 	spend: {_tag: "Reconstructed", spend: spend(opts.billed, opts.model)},
+	provenance: unrecorded,
 });
 
 const reviewCellFor = (
@@ -326,6 +344,69 @@ describe("buildScorecard — the baseline resolves to exactly one cell under the
 			"a baseline that cannot name one grading regime must not resolve to an arbitrary surface",
 		);
 		for (const cell of sc.cells) assert.isNull(cell.netSaving);
+	});
+});
+
+/**
+ * #4996: the model a run was pinned to is a recorded fact; the transcript is a machine-local,
+ * perishable reconstruction of it. So the recorded value sources the bucket key and the
+ * reconstruction is only the fallback — otherwise a surviving row loses its model with its
+ * transcript and lands in `(unknown)`.
+ */
+describe("buildScorecard — the bucket key prefers the model the run recorded", () => {
+	it("a transcript-missing row with a recorded model keeps its model bucket, not `(unknown)`", () => {
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 100, model: "opus", provenance: {model: "opus", arm: "with-skill"}}),
+			missingSpendRow({pass: true, provenance: {model: "opus", arm: "without-skill"}}),
+		];
+		const sc = buildScorecard({rows});
+		assert.strictEqual(sc.cells.length, 1, "both rows belong to the same recorded-model cell");
+		const cell = cellFor(sc.cells, "opus");
+		assert.strictEqual(cell.gradedRuns, 2);
+		// The unmeasured run still stays out of the spend mean — it is attributed, not fabricated.
+		assert.strictEqual(cell.spend?.billedPerRun, 100);
+		assert.strictEqual(cell.spend?.transcriptMissingRuns, 1);
+		assert.isFalse(renderTable(sc).includes("(unknown)"));
+	});
+
+	it("the recorded model wins over a transcript that reconstructs to a different one", () => {
+		const rows: ReadonlyArray<RunRow> = [
+			row({
+				pass: true,
+				billed: 100,
+				model: "whatever-the-transcript-said",
+				provenance: {model: "opus-4.8", arm: "with-skill"},
+			}),
+		];
+		const sc = buildScorecard({rows});
+		assert.strictEqual(sc.cells[0]?.model, "opus-4.8");
+	});
+
+	it("a row that recorded nothing still buckets on its reconstructed model", () => {
+		const sc = buildScorecard({rows: [row({pass: true, billed: 100, model: "sonnet"})]});
+		assert.strictEqual(sc.cells[0]?.model, "sonnet");
+	});
+});
+
+describe("decodeReportInput — a rows file written before provenance existed still decodes", () => {
+	it("reads an absent `provenance` as unrecorded rather than failing the file", () => {
+		const legacy = JSON.stringify([
+			{
+				entry: {
+					stage: "triage",
+					inputRef: 1,
+					label: {type: "bug", priority: "p0", status: "triaged"},
+				},
+				grade: {status: "pass"},
+				spend: {_tag: "Reconstructed", spend: spend(100, "sonnet")},
+			},
+		]);
+		const decoded = decodeReportInput(legacy);
+		assert.isTrue(Result.isSuccess(decoded));
+		if (!Result.isSuccess(decoded)) return;
+		assert.deepStrictEqual(decoded.success[0]?.provenance, {model: null, arm: null});
+		// …and it still scores exactly as it did before, off the transcript's model.
+		assert.strictEqual(buildScorecard({rows: decoded.success}).cells[0]?.model, "sonnet");
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/runner.ts
+++ b/packages/fabrika-cli/src/eval/runner.ts
@@ -28,22 +28,57 @@ import {classifyRunSpend, type RunSpend} from "../spend/token-spend.ts";
 import {type CorpusEntry, type CorpusManifest, type LiveStage, STAGES} from "./corpus.ts";
 import {type Grade, gradeEntry} from "./oracle.ts";
 
-/** One graded run row: the corpus entry, its grade against the label, and its token spend. */
+/**
+ * The with/without methodology's arm variable is **skill availability**, and `--plugin-dir` is the
+ * toggle: it loads the skill under test for that session only. `--disable-slash-commands` is NOT a
+ * usable toggle — measured against a loaded plugin it short-circuits to `num_turns: 0`, `$0`,
+ * `"Unknown command: …"` and never reaches the model (#4673 §4).
+ *
+ * The vocabulary lives here, beside the `CaptureRun` schema that constrains it, so a manifest can
+ * name an arm without the collector depending on the executor built on top of it. `spawn.ts`
+ * re-exports it, so its consumers are unchanged.
+ */
+export const EVAL_ARMS = ["with-skill", "without-skill"] as const;
+
+export type EvalArm = (typeof EVAL_ARMS)[number];
+
+/**
+ * What a recorded run says about itself: the model it was pinned to, and the arm it belongs to.
+ *
+ * Both are nullable because a run recorded before this provenance existed attests neither, and a
+ * legacy row must keep collecting rather than fail (#4996). `null` means *unrecorded*, never
+ * "no model" — the scorecard reads it as "fall back to the transcript", not as a value to bucket on.
+ */
+export interface RunProvenance {
+	readonly model: string | null;
+	readonly arm: EvalArm | null;
+}
+
+/** The provenance of a run that recorded none — a legacy row, or a hand-assembled replay input. */
+export const NO_PROVENANCE: RunProvenance = {model: null, arm: null};
+
+/**
+ * One graded run row: the corpus entry, its grade against the label, its token spend, and the
+ * provenance of the run that produced it.
+ */
 export interface RunRow {
 	readonly entry: CorpusEntry;
 	readonly grade: Grade;
 	readonly spend: RunSpend;
+	readonly provenance: RunProvenance;
 }
 
 /**
  * One offline run input: a corpus entry paired with its captured transcript text + recorded
  * artifact. `transcript === null` means the transcript was not found — the run is still graded
  * against its label and counted (with `TranscriptMissing` spend), never dropped or crashed.
+ * An omitted `provenance` collects as `NO_PROVENANCE`.
  */
 export interface RunInput {
 	readonly entry: CorpusEntry;
 	readonly transcript: string | null;
 	readonly artifact: unknown;
+	readonly provenance?: RunProvenance;
 }
 
 /**
@@ -55,6 +90,7 @@ export const collectRun = (input: RunInput): RunRow => ({
 	entry: input.entry,
 	grade: gradeEntry(input.entry, input.artifact),
 	spend: classifyRunSpend(input.transcript),
+	provenance: input.provenance ?? NO_PROVENANCE,
 });
 
 /**
@@ -74,12 +110,20 @@ export const collectRuns = (inputs: ReadonlyArray<RunInput>): ReadonlyArray<RunR
  * `<parent-session-id>/subagents/agent-<id>.jsonl` (ADR 0112 §2), or a headless `claude -p` run's
  * `<claude-data-root>/projects/<cwd-slug>/<session-id>.jsonl` — a top-level session, so NOT under
  * `subagents/`. Both reconstruct through the same `token-spend` core.
+ *
+ * `model` and `arm` carry the run's own provenance onto the manifest, so a graded row keeps it after
+ * the ledger is gone (#4996). Both decode to `null` when the key is absent, which is what keeps
+ * every already-written manifest readable — an absent key is *unrecorded*, never a claim.
  */
 export const CaptureRun = Schema.Struct({
 	stage: Schema.Literals([...STAGES]),
 	inputRef: Schema.Int,
 	transcriptPath: Schema.String,
 	artifact: Schema.Unknown,
+	model: Schema.NullOr(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
+	arm: Schema.NullOr(Schema.Literals([...EVAL_ARMS])).pipe(
+		Schema.withDecodingDefault(Effect.succeed(null)),
+	),
 });
 
 export type CaptureRun = typeof CaptureRun.Type;
@@ -159,6 +203,7 @@ export const collectFromCapture = <R>(args: {
 				entry,
 				transcript: yield* args.loadTranscript(run.transcriptPath),
 				artifact: run.artifact,
+				provenance: {model: run.model, arm: run.arm},
 			});
 		}
 		return collectRuns(inputs);

--- a/packages/fabrika-cli/src/eval/runner.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/runner.unit.test.ts
@@ -149,12 +149,16 @@ describe("collectFromCapture — capture-manifest fold against the corpus (story
 					inputRef: 100,
 					transcriptPath: "session-x/subagents/agent-a.jsonl",
 					artifact: entryA.label,
+					model: "opus-4.8",
+					arm: "with-skill",
 				},
 				{
 					stage: "triage",
 					inputRef: 200,
 					transcriptPath: "session-x/subagents/agent-b.jsonl",
 					artifact: {type: "feature", priority: "p2", status: "triaged"}, // diverges → fail
+					model: "opus-4.8",
+					arm: "without-skill",
 				},
 			],
 		};
@@ -174,6 +178,9 @@ describe("collectFromCapture — capture-manifest fold against the corpus (story
 		assert.strictEqual(rows[0]?.grade.status, "pass");
 		assert.strictEqual(rows[1]?.grade.status, "fail");
 		assert.strictEqual(rows[0]?.spend._tag, "Reconstructed");
+		// The manifest's recorded provenance rides onto the graded row (#4996).
+		assert.deepStrictEqual(rows[0]?.provenance, {model: "opus-4.8", arm: "with-skill"});
+		assert.deepStrictEqual(rows[1]?.provenance, {model: "opus-4.8", arm: "without-skill"});
 	});
 
 	it("a capture run whose transcript the loader can't find folds in with TranscriptMissing", () => {
@@ -185,6 +192,8 @@ describe("collectFromCapture — capture-manifest fold against the corpus (story
 					inputRef: 100,
 					transcriptPath: "gone.jsonl",
 					artifact: entryA.label,
+					model: "opus-4.8",
+					arm: "with-skill",
 				},
 			],
 		};
@@ -205,7 +214,15 @@ describe("collectFromCapture — capture-manifest fold against the corpus (story
 		const capture: CaptureManifest = {
 			version: 1,
 			runs: [
-				{stage: "triage", inputRef: 999, transcriptPath: "x.jsonl", artifact: {}}, // no entry #999
+				// no entry #999
+				{
+					stage: "triage",
+					inputRef: 999,
+					transcriptPath: "x.jsonl",
+					artifact: {},
+					model: "opus-4.8",
+					arm: "with-skill",
+				},
 			],
 		};
 		const rows = Effect.runSync(
@@ -231,6 +248,52 @@ describe("decodeCaptureManifest — total on malformed input (never throws)", ()
 		if (Result.isSuccess(result)) {
 			assert.strictEqual(result.success.runs.length, 1);
 		}
+	});
+
+	// #4996: provenance was added to a format that already had files on disk. A manifest written
+	// before it must still decode and still collect — it degrades to what it always did (the model
+	// recovered from the transcript), rather than failing.
+	it("a manifest with no recorded model or arm decodes, reading both as unrecorded", () => {
+		const result = decodeCaptureManifest(
+			JSON.stringify({
+				version: 1,
+				runs: [{stage: "triage", inputRef: 100, transcriptPath: "a.jsonl", artifact: {}}],
+			}),
+		);
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			assert.strictEqual(result.success.runs[0]?.model, null);
+			assert.strictEqual(result.success.runs[0]?.arm, null);
+		}
+	});
+
+	it("a legacy manifest still collects, with the row carrying no recorded provenance", () => {
+		const decoded = decodeCaptureManifest(
+			JSON.stringify({
+				version: 1,
+				runs: [
+					{
+						stage: "triage",
+						inputRef: 100,
+						transcriptPath: "session-x/subagents/agent-a.jsonl",
+						artifact: entryA.label,
+					},
+				],
+			}),
+		);
+		assert.isTrue(Result.isSuccess(decoded));
+		if (!Result.isSuccess(decoded)) return;
+		const rows = Effect.runSync(
+			collectFromCapture({
+				stage: "triage",
+				corpus,
+				capture: decoded.success,
+				loadTranscript: () => Effect.succeed(transcript(10, 5, 100, 20)),
+			}),
+		);
+		assert.strictEqual(rows.length, 1);
+		assert.strictEqual(rows[0]?.grade.status, "pass");
+		assert.deepStrictEqual(rows[0]?.provenance, {model: null, arm: null});
 	});
 
 	it("returns a typed malformed-json failure on a non-JSON body", () => {

--- a/packages/fabrika-cli/src/eval/spawn.ts
+++ b/packages/fabrika-cli/src/eval/spawn.ts
@@ -24,18 +24,18 @@
 import {Effect, Result} from "effect";
 import {classifyRunSpend, type RunSpend} from "../spend/token-spend.ts";
 import {STAGES} from "./corpus.ts";
-import type {CaptureManifest, CaptureRun, TranscriptLoader} from "./runner.ts";
+import {
+	type CaptureManifest,
+	type CaptureRun,
+	EVAL_ARMS,
+	type EvalArm,
+	type TranscriptLoader,
+} from "./runner.ts";
 import type {EvalTier} from "./skill-eval-set.ts";
 
-/**
- * The with/without methodology's arm variable is **skill availability**, and `--plugin-dir` is the
- * toggle: it loads the skill under test for that session only. `--disable-slash-commands` is NOT a
- * usable toggle — measured against a loaded plugin it short-circuits to `num_turns: 0`, `$0`,
- * `"Unknown command: …"` and never reaches the model (#4673 §4).
- */
-export const EVAL_ARMS = ["with-skill", "without-skill"] as const;
-
-export type EvalArm = (typeof EVAL_ARMS)[number];
+// The arm vocabulary lives with the `CaptureRun` schema that constrains it (`runner.ts`); it is
+// re-exported here because this is where its consumers have always imported it from.
+export {EVAL_ARMS, type EvalArm};
 
 /**
  * The minimum a case must offer to be run. Declared structurally rather than imported as
@@ -398,20 +398,28 @@ export const executeRuns = <RE, RL, RT>(args: {
  * eval set exercises one pipeline stage) and `inputRef` is the case id, which is what joins a run
  * to its corpus ground truth. A `Failed` run contributes nothing: an uncollected run cannot be
  * graded, and grading it would be the fabricated pass this whole guard exists to prevent.
+ *
+ * Each run also carries the model it was pinned to and the arm it belongs to, because the manifest
+ * is the artifact that outlives the ledger: a scorecard built from it alone would otherwise have to
+ * recover the model from a machine-local transcript, and would say `(unknown)` when that transcript
+ * is gone (#4996).
  */
-export const toCaptureManifest = (
-	stage: CaptureRun["stage"],
-	outcomes: ReadonlyArray<RunOutcome>,
-): CaptureManifest => ({
+export const toCaptureManifest = (args: {
+	readonly stage: CaptureRun["stage"];
+	readonly model: string;
+	readonly outcomes: ReadonlyArray<RunOutcome>;
+}): CaptureManifest => ({
 	version: 1,
-	runs: outcomes.flatMap((outcome) =>
+	runs: args.outcomes.flatMap((outcome) =>
 		outcome._tag === "Completed"
 			? [
 					{
-						stage,
+						stage: args.stage,
 						inputRef: outcome.caseId,
 						transcriptPath: outcome.transcriptPath,
 						artifact: outcome.artifact,
+						model: args.model,
+						arm: outcome.arm,
 					},
 				]
 			: [],
@@ -555,9 +563,9 @@ export const suiteExecuted = (summary: RunSummary): boolean =>
 
 /**
  * The runner's on-disk output: the ledger of every planned run's typed outcome, plus the capture
- * manifest folded out of the collectable ones. Both arms are in `runs`, each naming its own, so
- * with-skill and without-skill stay distinguishable after collection — `CaptureRun` has no arm
- * field and gains none.
+ * manifest folded out of the collectable ones. Both arms are in `runs`, each naming its own, and
+ * since #4996 each `CaptureRun` names its own arm and model too — so with-skill and without-skill
+ * stay distinguishable after collection even where only the manifest survives.
  */
 export interface RunLedger {
 	readonly version: 1;
@@ -588,7 +596,7 @@ export const buildLedger = (args: {
 	cliVersion: args.cliVersion,
 	recordedAt: args.recordedAt,
 	runs: args.outcomes,
-	capture: toCaptureManifest(args.stage, args.outcomes),
+	capture: toCaptureManifest(args),
 	spendRows: toSpendRows(args),
 	summary: summarizeRuns(args.outcomes),
 });

--- a/packages/fabrika-cli/src/eval/spawn.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/spawn.unit.test.ts
@@ -493,13 +493,17 @@ describe("toCaptureManifest — the existing collector consumes it unchanged", (
 				spend: classifyRunSpend(NO_BILLED_TRANSCRIPT),
 			}),
 		];
-		const capture = toCaptureManifest("triage", outcomes);
+		const capture = toCaptureManifest({stage: "triage", model: "sonnet", outcomes});
 		assert.strictEqual(capture.runs.length, 1);
 		assert.strictEqual(capture.runs[0]?.inputRef, 1);
 	});
 
 	it("what it writes round-trips through the existing decodeCaptureManifest", () => {
-		const capture = toCaptureManifest("triage", [completedRun()]);
+		const capture = toCaptureManifest({
+			stage: "triage",
+			model: "sonnet",
+			outcomes: [completedRun()],
+		});
 		const decoded = decodeCaptureManifest(captureToJson(capture));
 		assert.isTrue(Result.isSuccess(decoded));
 	});
@@ -528,12 +532,47 @@ describe("toCaptureManifest — the existing collector consumes it unchanged", (
 			collectFromCapture({
 				stage: "triage",
 				corpus,
-				capture: toCaptureManifest("triage", [outcome]),
+				capture: toCaptureManifest({stage: "triage", model: "sonnet", outcomes: [outcome]}),
 				loadTranscript: () => Effect.succeed(billedTranscript),
 			}),
 		);
 		assert.strictEqual(rows.length, 1);
 		assert.strictEqual(rows[0]?.grade.status, "pass");
+	});
+});
+
+/**
+ * #4996: the run's pinned provenance rides the manifest, which is the artifact that outlives the
+ * ledger. The fold is where the model and arm are still in hand, so it is where they are recorded.
+ */
+describe("toCaptureManifest — a manifest run names the model it was pinned to and its arm", () => {
+	it("stamps the suite's pinned model and each run's own arm onto its manifest row", () => {
+		const outcomes: ReadonlyArray<RunOutcome> = [
+			completedRun(),
+			completedRun({plan: plan({caseId: 2, arm: "without-skill"})}),
+		];
+		const capture = toCaptureManifest({stage: "triage", model: "opus-4.8", outcomes});
+		assert.deepStrictEqual(
+			capture.runs.map((run) => ({inputRef: run.inputRef, model: run.model, arm: run.arm})),
+			[
+				{inputRef: 1, model: "opus-4.8", arm: "with-skill"},
+				{inputRef: 2, model: "opus-4.8", arm: "without-skill"},
+			],
+		);
+	});
+
+	it("the provenance survives the JSON round-trip the collector reads", () => {
+		const capture = toCaptureManifest({
+			stage: "triage",
+			model: "opus-4.8",
+			outcomes: [completedRun({plan: plan({arm: "without-skill"})})],
+		});
+		const decoded = decodeCaptureManifest(captureToJson(capture));
+		assert.isTrue(Result.isSuccess(decoded));
+		if (Result.isSuccess(decoded)) {
+			assert.strictEqual(decoded.success.runs[0]?.model, "opus-4.8");
+			assert.strictEqual(decoded.success.runs[0]?.arm, "without-skill");
+		}
 	});
 });
 


### PR DESCRIPTION
When `fabrika eval run` finishes, the file that survives is the capture manifest — it is what the scorecard and the collector read, long after the run ledger is gone. Until now it did not say which model a run was pinned to or which arm it belonged to, so the scorecard had to recover the model from the run's transcript, which lives outside the repo and disappears. A row whose transcript was gone showed up as `(unknown)`, and nobody could tell a with-skill result from a baseline one.

This records both facts on each manifest run at the point they are still in hand, and has the scorecard read them. Nothing already on disk breaks: a manifest or rows file written before these fields decodes with them as `null` and scores exactly as it did before.

Fixes #4996

## What changed

- `runner.ts` — `CaptureRun` gains `model` and `arm`; both decode to `null` when the key is absent, so every already-written manifest stays readable. A graded `RunRow` now carries a `RunProvenance` (`{model, arm}`), which `collectFromCapture` fills from the manifest row. The arm vocabulary (`EVAL_ARMS` / `EvalArm`) moves here, beside the schema that constrains it.
- `spawn.ts` — `toCaptureManifest` takes `{stage, model, outcomes}` and stamps the suite's pinned model plus each run's own arm onto its manifest row. It re-exports `EVAL_ARMS` / `EvalArm`, so its consumers are unchanged.
- `report.ts` — a row buckets on the model it recorded, falling back to transcript reconstruction only when it recorded none. A transcript-missing row with a recorded model therefore keeps its model bucket instead of `(unknown)`. `decodeReportInput` reads an absent `provenance` as unrecorded.
- `src/eval/README.md` — a new section states, field by field, what a capture manifest carries and what stays ledger-only, and why `null` means *unrecorded* rather than a claim.
- Unit tests over the `toCaptureManifest` fold (model + arm per run, and their JSON round-trip), the preference order in `bucketize`, and the legacy-decode path on both the manifest and the rows file.

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint:worktree` — clean.
- `packages/fabrika-cli` unit suite — 143 files, 2143 tests, all passing.

## Deviations

**Class: narrowed a suggested fix-shape.** Said: the issue's scope names `runner.ts`, `spawn.ts`, `report.ts`, the README and the module's unit-test fixtures. Did: all of those, plus a move of `EVAL_ARMS` / `EvalArm` from `spawn.ts` down into `runner.ts`. Why: `CaptureRun`'s new `arm` field needs the literal vocabulary, and having the collector import it from the executor built on top of it would invert the module's layering. `spawn.ts` re-exports both, so no consumer changes. Disposition: no action needed — for the reviewer to judge.

**Class: chose one of two viable encodings.** Said: nothing about how absence is represented. Did: encoded "unrecorded" as `null` with a schema decoding default, rather than an optional key that is simply missing. Why: one absence encoding across `CaptureRun` and `RunRow` keeps `null` reading the same way at every layer, and it makes the fallback in `report.ts` a single `??`. Disposition: no action needed.

**Class: left a sibling observation alone.** Said: carry the model and the arm. Did: exactly that — CLI version, skill name and `recordedAt` stay ledger-only, and the README records that as the deliberate line. Why: the issue scopes the manifest's provenance to model and arm; the suite-level fields are a suite record, not a per-run fact. Disposition: recorded in the README table so the asymmetry is a choice, not a discovery.

**Class: did not act on an unverified premise.** Said: the issue flags an unverified 2026-08-08 founder ruling that fabrika skills must be evaluated on Opus in both arms, and tells the builder to file it separately rather than fold it in. Did: nothing about pinning the model's *value* — no Opus default, no allowlist. Why: the issue's own instruction, and its no-go list. Disposition: for the reviewer to judge; no follow-up filed, since the issue already records the split.