### PR TITLE
fix(fabrika-cli): a truncated paginated read is UNKNOWN, never a short comment list

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -36,7 +36,8 @@ close. Modules reused by import:
 
 - `packages/fabrika-cli/src/io/issues.ts` — `resolveRepo`, `getIssue` (three-way
   `Present` / `Absent` (404 only) / `Unknown`), `listComments` (typed JSON, never `--jq .body`),
-  `splitJsonArrays` (`--paginate`'s concatenated arrays), `addLabels`, `removeLabel` (**folds 404
+  `pagedJson` (`--paginate`'s concatenated arrays, **a truncated read as a failure**), `addLabels`,
+  `removeLabel` (**folds 404
   into success — removal is idempotent**, which is v1 scar F3 gone for free), `listLabels`.
 - `packages/fabrika-cli/src/build/dependencies.ts` — `readTopology` (`Parsed` / `Absent` /
   `Unparseable{line,text}`) and `predecessorsOf`. **This spec adds no second `## Dependencies`

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -21,6 +21,7 @@ import {
 	issue,
 	LANE_UUID,
 	marker,
+	truncatedComments,
 } from "./fixtures.test-support.ts";
 import {runPick} from "./pick-verb.ts";
 import {DEFAULT_ROADMAP} from "./scope-admission.ts";
@@ -180,6 +181,24 @@ describe("runClaim", () => {
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain('ownership is UNKNOWN, never "unclaimed"');
+	});
+
+	it("refuses a TRUNCATED marker read on 11 and keeps its own marker — a short read is not a loss", async () => {
+		const shell = fakeShell([
+			[ISSUE, CLAIMABLE],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("page boundary");
+		expect(out.stderr.some((line) => line.includes("is not authorized"))).toBe(false);
+		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
 	});
 
 	it("refuses an unreadable PERMISSION on 11 — a transient read never demotes an author", async () => {
@@ -390,6 +409,16 @@ describe("runConfirm", () => {
 			'build confirm: no claim exists on #4312 — nothing to confirm; run "fabrika build claim 4312" first.',
 		);
 	});
+
+	it("refuses a truncated read on 11, never as the 'no claim exists' it looks like", async () => {
+		const out = await run(runConfirm, [
+			[ISSUE, CLAIMABLE],
+			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("page boundary");
+	});
 });
 
 describe("runRelease", () => {
@@ -423,6 +452,20 @@ describe("runRelease", () => {
 		expect(out.stderr.at(-1)).toBe(
 			"build release: this session holds no claim on #4312 — refusing to release another lane's.",
 		);
+		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
+	});
+
+	it("refuses a truncated read on 11 and deletes nothing", async () => {
+		const shell = fakeShell([
+			[ISSUE, CLAIMABLE],
+			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runRelease(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(shell.calls.some((line) => DELETE.test(line))).toBe(false);
 	});
 

--- a/packages/fabrika-cli/src/build/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/build/fixtures.test-support.ts
@@ -63,6 +63,17 @@ export const comments = (
 		),
 	);
 
+/**
+ * The same response, cut off before its last comment closes — what a killed `gh --paginate` leaves
+ * on stdout, and the read a claim must never resolve ownership from.
+ */
+export const truncatedComments = (
+	...rows: ReadonlyArray<{id: number; body: string; author?: string; createdAt?: string}>
+): ExecResult => {
+	const whole = comments(...rows).stdout;
+	return okOut(whole.slice(0, whole.lastIndexOf("}")));
+};
+
 /** One paged `issues?labels=…` response, as the candidate pool reads it. */
 export const candidates = (
 	...rows: ReadonlyArray<{

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -437,9 +437,18 @@ export const scanJsonPages = (stdout: string): JsonPages => {
 	};
 };
 
-/** The complete pages alone, for a read whose caller does not seat truncation itself. */
-export const splitJsonArrays = (stdout: string): ReadonlyArray<string> =>
-	scanJsonPages(stdout).pages;
+/**
+ * The pages of a paginated read, or the failure a truncated one is.
+ *
+ * This is the only sanctioned way to consume {@link scanJsonPages} from a list read: it discharges
+ * `truncated` on the caller's behalf, so no reader can receive the pages while dropping the proof
+ * that they are not all of them (#5127). Its predecessor returned `.pages` alone and every caller
+ * silently answered short.
+ */
+export const pagedJson = (stdout: string): Attempt<ReadonlyArray<string>> => {
+	const scanned = scanJsonPages(stdout);
+	return scanned.truncated === null ? ok(scanned.pages) : fail(scanned.truncated);
+};
 
 /** One issue comment, as a claim scan reads it. */
 export interface CommentRecord {
@@ -462,6 +471,10 @@ export interface CommentRecord {
  * The bodies arrive as typed JSON rather than through `--jq .body`: a body carrying an unescaped
  * control character makes `jq -r` error mid-stream, which inside a loop reads back as an empty
  * comment rather than as a failure.
+ *
+ * A truncated read is a failure here for the same reason, one step further out: the claim resolver
+ * reads its markers through this call, and a short comment list would let an unreadable marker set
+ * refuse as a *proven* loss — retracting a marker that had in fact won (#5127).
  */
 export const listComments = (
 	repo: string,
@@ -474,8 +487,10 @@ export const listComments = (
 			`repos/${repo}/issues/${issue}/comments?per_page=100`,
 		]);
 		if (!r.ok) return fail(r.reason);
+		const pages = pagedJson(r.stdout);
+		if (pages._tag === "Failure") return pages;
 		const out: CommentRecord[] = [];
-		for (const page of splitJsonArrays(r.stdout)) {
+		for (const page of pages.value) {
 			const parsed = parseJson(page);
 			if (!Array.isArray(parsed)) {
 				return fail("`gh api` exited 0 but its output is not a list of comments");

--- a/packages/fabrika-cli/src/io/issues.unit.test.ts
+++ b/packages/fabrika-cli/src/io/issues.unit.test.ts
@@ -11,12 +11,12 @@ import {
 	listComments,
 	listOpenMilestones,
 	openQueueIssues,
+	pagedJson,
 	parseTabRows,
 	patchIssueBody,
 	removeLabel,
 	scanJsonPages,
 	setMilestone,
-	splitJsonArrays,
 } from "./issues.ts";
 
 const run = <A>(effect: Effect.Effect<A, never, never>) => Effect.runPromise(effect);
@@ -39,18 +39,30 @@ describe("parseTabRows — shape before interpretation", () => {
 	});
 });
 
-describe("splitJsonArrays", () => {
+describe("pagedJson", () => {
 	it("splits the concatenated pages `--paginate` emits, which JSON.parse rejects whole", () => {
 		expect(() => JSON.parse("[1][2]")).toThrow();
-		expect(splitJsonArrays("[1][2]")).toEqual(["[1]", "[2]"]);
+		expect(pagedJson("[1][2]")).toEqual({_tag: "Ok", value: ["[1]", "[2]"]});
 	});
 
 	it("does not split on a bracket inside a string — a body may contain one", () => {
-		expect(splitJsonArrays('[{"body":"see [1] and ]"}]')).toEqual(['[{"body":"see [1] and ]"}]']);
+		expect(pagedJson('[{"body":"see [1] and ]"}]')).toEqual({
+			_tag: "Ok",
+			value: ['[{"body":"see [1] and ]"}]'],
+		});
 	});
 
 	it("does not split on an escaped quote inside a string", () => {
-		expect(splitJsonArrays('[{"body":"a \\" ] b"}]')).toEqual(['[{"body":"a \\" ] b"}]']);
+		expect(pagedJson('[{"body":"a \\" ] b"}]')).toEqual({
+			_tag: "Ok",
+			value: ['[{"body":"a \\" ] b"}]'],
+		});
+	});
+
+	it("fails on a read that stopped mid-page rather than handing back the pages that closed", () => {
+		const result = pagedJson('[{"id":1}][{"id');
+		expect(result._tag).toBe("Failure");
+		expect(result).toMatchObject({reason: expect.stringContaining("page boundary")});
 	});
 });
 
@@ -233,6 +245,16 @@ describe("listComments", () => {
 			),
 		);
 		expect(result._tag).toBe("Failure");
+	});
+
+	it("refuses a read that stopped mid-page — never the comments that arrived before the cut", async () => {
+		const whole = `[${comment(1, "usirin", "first")}][${comment(2, "cansirin", "second")}]`;
+		const cut = whole.slice(0, whole.lastIndexOf("second") + 3);
+		const result = await run(
+			Effect.provide(listComments("kamp-us/phoenix", 1), fakeShell([[/gh api/, okOut(cut)]]).layer),
+		);
+		expect(result._tag).toBe("Failure");
+		expect(result).toMatchObject({reason: expect.stringContaining("page boundary")});
 	});
 });
 

--- a/packages/fabrika-cli/src/io/pulls.ts
+++ b/packages/fabrika-cli/src/io/pulls.ts
@@ -14,7 +14,7 @@
 import {Effect} from "effect";
 import {execCapture} from "./exec.ts";
 import {type Attempt, fail, ok, type Shell} from "./git.ts";
-import {absent, type Existence, httpStatusOf, present, splitJsonArrays, unknown} from "./issues.ts";
+import {absent, type Existence, httpStatusOf, pagedJson, present, unknown} from "./issues.ts";
 import {isRecord, parseJson} from "./json.ts";
 
 export interface PullRecord {
@@ -87,8 +87,10 @@ export const listPullFiles = (repo: string, pr: number): Shell<Attempt<ReadonlyA
 			`repos/${repo}/pulls/${pr}/files?per_page=100`,
 		]);
 		if (!r.ok) return fail(r.reason);
+		const pages = pagedJson(r.stdout);
+		if (pages._tag === "Failure") return pages;
 		const files: string[] = [];
-		for (const page of splitJsonArrays(r.stdout)) {
+		for (const page of pages.value) {
 			const parsed = parseJson(page);
 			if (!Array.isArray(parsed)) {
 				return fail("`gh api` exited 0 but its output is not a list of changed files");
@@ -143,9 +145,11 @@ export const listCheckRuns = (repo: string, sha: string): Shell<Attempt<CheckRun
 			`repos/${repo}/commits/${sha}/check-runs?per_page=100`,
 		]);
 		if (!r.ok) return fail(r.reason);
+		const pages = pagedJson(r.stdout);
+		if (pages._tag === "Failure") return pages;
 		const runs: CheckRun[] = [];
 		let declared: number | null = null;
-		for (const page of splitJsonArrays(r.stdout)) {
+		for (const page of pages.value) {
 			const parsed = parseJson(page);
 			if (!isRecord(parsed) || !Array.isArray(parsed.check_runs)) {
 				return fail("`gh api` exited 0 but its output is not a check-run rollup");

--- a/packages/fabrika-cli/src/plan/github.ts
+++ b/packages/fabrika-cli/src/plan/github.ts
@@ -20,14 +20,7 @@
 import {Effect} from "effect";
 import {execCapture} from "../io/exec.ts";
 import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
-import {
-	absent,
-	type Existence,
-	httpStatusOf,
-	present,
-	splitJsonArrays,
-	unknown,
-} from "../io/issues.ts";
+import {absent, type Existence, httpStatusOf, pagedJson, present, unknown} from "../io/issues.ts";
 import {isRecord, parseJson} from "../io/json.ts";
 import type {CycleDoc} from "./model.ts";
 
@@ -48,8 +41,10 @@ export const listSubIssues = (repo: string, epic: number): Shell<Attempt<Readonl
 			`repos/${repo}/issues/${epic}/sub_issues?per_page=100`,
 		]);
 		if (!r.ok) return fail(r.reason);
+		const pages = pagedJson(r.stdout);
+		if (pages._tag === "Failure") return pages;
 		const numbers: number[] = [];
-		for (const page of splitJsonArrays(r.stdout)) {
+		for (const page of pages.value) {
 			const parsed = parseJson(page);
 			if (!Array.isArray(parsed)) {
 				return fail("`gh api` exited 0 but its output is not a list of sub-issues");

--- a/packages/fabrika-cli/src/ship/github.ts
+++ b/packages/fabrika-cli/src/ship/github.ts
@@ -17,22 +17,17 @@
 import {Effect} from "effect";
 import {execCapture} from "../io/exec.ts";
 import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
-import {
-	absent,
-	type Existence,
-	httpStatusOf,
-	present,
-	splitJsonArrays,
-	unknown,
-} from "../io/issues.ts";
+import {absent, type Existence, httpStatusOf, pagedJson, present, unknown} from "../io/issues.ts";
 import {isRecord, parseJson} from "../io/json.ts";
 
 const str = (value: unknown): string => (typeof value === "string" ? value : "");
 
 /** Every element of every page, or the failure that stopped the read. */
 const pagedArray = (stdout: string): Attempt<ReadonlyArray<unknown>> => {
+	const pages = pagedJson(stdout);
+	if (pages._tag === "Failure") return pages;
 	const out: unknown[] = [];
-	for (const page of splitJsonArrays(stdout)) {
+	for (const page of pages.value) {
 		const parsed = parseJson(page);
 		if (!Array.isArray(parsed)) return fail("`gh api` exited 0 but its output is not a list");
 		out.push(...parsed);
@@ -45,9 +40,11 @@ const pagedEnvelope = (
 	stdout: string,
 	key: string,
 ): Attempt<{declared: number; entries: ReadonlyArray<unknown>}> => {
+	const pages = pagedJson(stdout);
+	if (pages._tag === "Failure") return pages;
 	const entries: unknown[] = [];
 	let declared: number | null = null;
-	for (const page of splitJsonArrays(stdout)) {
+	for (const page of pages.value) {
 		const parsed = parseJson(page);
 		if (!isRecord(parsed) || !Array.isArray(parsed[key])) {
 			return fail(`\`gh api\` exited 0 but its output carries no ${key} list`);


### PR DESCRIPTION
`listComments` read paginated `gh api` output through a helper that kept the pages which closed and threw away the proof that the stream had been cut. A comment read that stopped mid-page therefore came back short at exit 0. The claim resolver reads its markers through that call, and a claiming run's own marker is the newest comment — so it is the first thing a cut loses. The claim checkpoint then refused with "lost" / "your marker is not authorized" and deleted a marker that had in fact won, yielding a lane it held.

Now a truncated read is a failure. Ownership resolves to `Unknown`, `build claim` / `confirm` / `release` / `requireClaim` refuse on `PRECONDITION_UNKNOWN` (11) instead of `CLAIM_NOT_MINE` (15), and nothing is retracted. The old lenient helper is gone: `pagedJson` returns the pages or the failure, so no reader can take the pages while dropping the proof that they are not all of them. Every remaining lenient caller was converted with it.

Fixes #5127

## Deviations

- **Class: scope narrowing.** Said: the issue's non-binding direction was to route `listComments` and the listed callers through `scanJsonPages` and seat leftovers as exit 11. Did: introduced `pagedJson` in `packages/fabrika-cli/src/io/issues.ts` — `scanJsonPages` plus the `truncated` discharge, returning `Attempt<pages>` — and converted `listComments`, `listPullFiles`, `listCheckRuns`, `listSubIssues`, and ship's `pagedArray`/`pagedEnvelope` to it; `splitJsonArrays` is deleted. Why: the defect is a caller that *can* receive the pages without the truncation proof, so removing the shape that allows it is the fix rather than fixing each caller. Disposition: no action needed.
- **Class: file not named by the issue.** Said: the pointers list five source files. Did: also converted `listCheckRuns` in `packages/fabrika-cli/src/io/pulls.ts` (its `total_count` backstop made it lenient-but-safe, not correct) and updated the one doc that named the deleted helper, `claude-plugins/fabrika/skills/check-epic-plan/contract.md`. Why: a stale module contract naming a symbol that no longer exists misleads the next reader. Disposition: no action needed.
- **Class: left untouched on purpose.** Said: "the converted pattern" lives in `packages/fabrika-cli/src/build/github.ts`. Did: left its two inline `scanJsonPages` + `truncated` checks as they are, rather than rewriting them onto `pagedJson`. Why: they are already correct, and three sibling fabrika lanes are editing that area concurrently — a cosmetic rewrite there buys nothing and risks a collision. Disposition: for the reviewer to judge; a follow-up can collapse them if the one-shape argument is worth the churn.