### PR TITLE
feat(fabrika-cli): the review-ui verb group — render, post, note

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1,15 +1,18 @@
 # @kampus/fabrika-cli
 
 The deterministic verb package [fabrika](../../claude-plugins/fabrika/) skills call.
-`fabrika <group> <verb> …` dispatches to a registered verb group. Ten groups are
-registered: `adr`, the six verbs the `/adr` skill's derived contract specifies; `report`,
+`fabrika <group> <verb> …` dispatches to a registered verb group. The registered groups are
+`adr`, the six verbs the `/adr` skill's derived contract specifies; `report`,
 the three the `/report` contract specifies; `triage`, the intake-queue group the `/triage`
 contract specifies; `build`, the fourteen the `/build` contract specifies; `epic`, the
-eight the `/build-epic` contract specifies; `review`, the eight the `/review` contract
-specifies; `ship`, the thirteen the `/ship` contract specifies; `eval`, the graded-corpus
+eight the `/build-epic` contract specifies; `plan`, the epic-plan gate's; `review`, the eight
+the `/review` contract specifies; `review-ui`, the three the `/review-ui` contract specifies
+(capture a PR's preview, emit the `review-ui` verdict, or post a typed blocker note);
+`ship`, the thirteen the `/ship` contract specifies; `eval`, the graded-corpus
 harness the fabrika eval layer measures itself with; `spend`, what one fabrika run cost in
 tokens; and `wire`, which owns the byte-level formats two skills meet through on a GitHub
-artifact.
+artifact. `fabrika --help` lists them from the registry, so that index is never a second
+hand-maintained list.
 
 ## Who it's for
 

--- a/packages/fabrika-cli/src/capture/README.md
+++ b/packages/fabrika-cli/src/capture/README.md
@@ -79,6 +79,16 @@ const records = yield* captureAndUpload({
   `<!-- preview-deploy:web -->` anchor (deploy.yml / ci.yml). **Keyed off the app
   anchor, not the first `workers.dev` URL** — a blind first-match would return the
   wrong app's URL the moment a second app's preview line appears.
+- `readPreviewAnnouncement(commentBody, app)` reads the same block for a caller that
+  must **bind the preview to a head**: it returns the URL *and* the deployed head SHA,
+  is domain-agnostic (an adopter's preview is not on `workers.dev`), and splits
+  `Malformed` from `NoApp` so an unreadable announcement can never resolve to "no
+  preview". `announcedApps` / `isPreviewAnnouncement` are its two probes. The
+  `review-ui render` verb refuses on the SHA mismatch: pixels of an old tree must not
+  bind a new head (ADR 0058).
+- `validateCaptureBytes(pngBytes)` is the capture-validity check — zero bytes,
+  undecodable, or zero area — over the PNG header alone (`decodePngHeader`), so it stays
+  pure and codec-free. A capture nobody can open is not evidence.
 
 Pure cores also exported for reuse/testing: `parseSurfaceSpec`,
 `buildCapturePlan`, `joinPreviewUrl`, `surfaceFileName`, `mergeRecord`,

--- a/packages/fabrika-cli/src/capture/capture.ts
+++ b/packages/fabrika-cli/src/capture/capture.ts
@@ -30,6 +30,14 @@ export interface CapturedSurface {
 	readonly pngBytes: Uint8Array;
 	/** Runtime errors thrown into the page during this render — the #2594 crash signal. */
 	readonly pageErrors: readonly PageError[];
+	/**
+	 * The navigation's HTTP status, absent when the navigation served no response.
+	 *
+	 * Playwright resolves `goto` on a 404 like any other response, so a gate that only sees pixels
+	 * judges an error page as composition. Carried so a caller can seat "unreachable" as its own
+	 * proven outcome instead of inferring it from an image.
+	 */
+	readonly status?: number;
 }
 
 /** A Playwright launch/navigation/screenshot/write failure — surfaced, never swallowed. */
@@ -116,7 +124,10 @@ export const captureShots = (
 									pageErrors.push(toPageError("console.error", msg.text()));
 							});
 							try {
-								await page.goto(shot.url, {waitUntil: "networkidle", timeout: navigationTimeoutMs});
+								const response = await page.goto(shot.url, {
+									waitUntil: "networkidle",
+									timeout: navigationTimeoutMs,
+								});
 								// A clip crops to the changed region; Playwright rejects clip + fullPage
 								// together, so a clipped shot is never full-page.
 								const buffer = await page.screenshot(
@@ -134,6 +145,7 @@ export const captureShots = (
 									fileName: shot.fileName,
 									pngBytes: new Uint8Array(buffer),
 									pageErrors,
+									...(response === null ? {} : {status: response.status()}),
 								};
 							} finally {
 								await context.close();

--- a/packages/fabrika-cli/src/capture/index.ts
+++ b/packages/fabrika-cli/src/capture/index.ts
@@ -82,6 +82,8 @@ export {
 	parseSurfaceSpec,
 	surfaceFileName,
 } from "./plan.ts";
+export type {CaptureValidity, PngHeader} from "./png.ts";
+export {decodePngHeader, validateCaptureBytes} from "./png.ts";
 export type {
 	PrioritySurfaceKey,
 	PrioritySurfaceParams,
@@ -93,7 +95,13 @@ export {
 	resolvePrioritySurfaces,
 	substituteRouteParams,
 } from "./priority-surfaces.ts";
-export {resolvePreviewUrl} from "./resolve.ts";
+export type {AnnouncementRead, PreviewAnnouncement} from "./resolve.ts";
+export {
+	announcedApps,
+	isPreviewAnnouncement,
+	readPreviewAnnouncement,
+	resolvePreviewUrl,
+} from "./resolve.ts";
 export type {
 	RawUploadResponse,
 	UploadAssetOptions,

--- a/packages/fabrika-cli/src/capture/png.ts
+++ b/packages/fabrika-cli/src/capture/png.ts
@@ -1,0 +1,52 @@
+/**
+ * Capture validation: whether a PNG a render produced is a record at all.
+ *
+ * A capture nobody can open is not evidence (#3925's class), so the check is on the bytes rather
+ * than on the render's exit status: zero bytes, an undecodable header, and a zero-area image are
+ * three ways a "successful" screenshot arrives empty, and all three used to reach a gate as pixels.
+ *
+ * PURE and header-only — no codec. The IHDR chunk sits at a fixed offset in every PNG, so the
+ * dimensions are readable without decoding the image, which is what keeps this unit-tested and
+ * dependency-free.
+ */
+
+/** The eight-byte PNG signature every conforming file opens with. */
+const SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+/** Signature (8) + length (4) + `IHDR` (4) + width (4) + height (4). */
+const HEADER_BYTES = 24;
+
+export interface PngHeader {
+	readonly width: number;
+	readonly height: number;
+}
+
+const readUint32 = (bytes: Uint8Array, offset: number): number =>
+	((bytes[offset] ?? 0) << 24) |
+	((bytes[offset + 1] ?? 0) << 16) |
+	((bytes[offset + 2] ?? 0) << 8) |
+	(bytes[offset + 3] ?? 0);
+
+/** The image's declared dimensions, or `null` when the bytes are not a decodable PNG header. */
+export const decodePngHeader = (bytes: Uint8Array): PngHeader | null => {
+	if (bytes.length < HEADER_BYTES) return null;
+	if (SIGNATURE.some((byte, i) => bytes[i] !== byte)) return null;
+	const chunkType = String.fromCharCode(...bytes.slice(12, 16));
+	if (chunkType !== "IHDR") return null;
+	return {width: readUint32(bytes, 16) >>> 0, height: readUint32(bytes, 20) >>> 0};
+};
+
+/** A capture is a record, or it is one of the three named ways it is not. */
+export type CaptureValidity =
+	| {readonly _tag: "Valid"; readonly width: number; readonly height: number}
+	| {readonly _tag: "Invalid"; readonly reason: string};
+
+/** Validate captured bytes: non-empty, decodable, non-zero area. */
+export const validateCaptureBytes = (bytes: Uint8Array): CaptureValidity => {
+	if (bytes.length === 0) return {_tag: "Invalid", reason: "zero bytes"};
+	const header = decodePngHeader(bytes);
+	if (header === null) return {_tag: "Invalid", reason: "undecodable — not a PNG header"};
+	if (header.width === 0 || header.height === 0) {
+		return {_tag: "Invalid", reason: `zero area (${header.width}x${header.height})`};
+	}
+	return {_tag: "Valid", width: header.width, height: header.height};
+};

--- a/packages/fabrika-cli/src/capture/png.unit.test.ts
+++ b/packages/fabrika-cli/src/capture/png.unit.test.ts
@@ -1,0 +1,48 @@
+import {assert, describe, it} from "@effect/vitest";
+import {decodePngHeader, validateCaptureBytes} from "./png.ts";
+
+/** A PNG signature + IHDR chunk at the declared dimensions — the only bytes the header reader needs. */
+const png = (width: number, height: number): Uint8Array => {
+	const bytes = new Uint8Array(24);
+	bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+	bytes.set([0x00, 0x00, 0x00, 0x0d], 8);
+	bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+	new DataView(bytes.buffer).setUint32(16, width);
+	new DataView(bytes.buffer).setUint32(20, height);
+	return bytes;
+};
+
+describe("decodePngHeader", () => {
+	it("reads the declared dimensions out of the IHDR chunk", () => {
+		assert.deepStrictEqual(decodePngHeader(png(1280, 2140)), {width: 1280, height: 2140});
+	});
+
+	it("returns null for bytes that are not a PNG header", () => {
+		assert.strictEqual(decodePngHeader(new Uint8Array(0)), null);
+		assert.strictEqual(decodePngHeader(new TextEncoder().encode("not a png at all!!!!!!!!")), null);
+		const wrongChunk = png(10, 10);
+		wrongChunk.set([0x49, 0x44, 0x41, 0x54], 12);
+		assert.strictEqual(decodePngHeader(wrongChunk), null);
+	});
+});
+
+describe("validateCaptureBytes", () => {
+	it("accepts a decodable, non-zero-area capture", () => {
+		assert.deepStrictEqual(validateCaptureBytes(png(1280, 800)), {
+			_tag: "Valid",
+			width: 1280,
+			height: 800,
+		});
+	});
+
+	it("names each of the three ways a capture is not evidence", () => {
+		assert.deepStrictEqual(validateCaptureBytes(new Uint8Array(0)), {
+			_tag: "Invalid",
+			reason: "zero bytes",
+		});
+		assert.strictEqual(validateCaptureBytes(new Uint8Array(30))._tag, "Invalid");
+		const zeroArea = validateCaptureBytes(png(1280, 0));
+		assert.strictEqual(zeroArea._tag, "Invalid");
+		assert.match(zeroArea._tag === "Invalid" ? zeroArea.reason : "", /zero area/);
+	});
+});

--- a/packages/fabrika-cli/src/capture/resolve.ts
+++ b/packages/fabrika-cli/src/capture/resolve.ts
@@ -15,19 +15,100 @@
 
 const WORKERS_DEV_URL = /https:\/\/[A-Za-z0-9.-]+\.workers\.dev/;
 
-/**
- * Return the `app` (default `web`) preview URL from the sticky comment body, or
- * `null` if the comment carries no block for that app (deploy absent/failed).
- */
-export const resolvePreviewUrl = (commentBody: string, app = "web"): string | null => {
-	const anchor = `<!-- preview-deploy:${app} -->`;
+const ANCHOR_PREFIX = "<!-- preview-deploy:";
+
+/** This app's slice of the sticky comment: its anchor up to the next app's, or `null` if absent. */
+const appBlock = (commentBody: string, app: string): string | null => {
+	const anchor = `${ANCHOR_PREFIX}${app} -->`;
 	const start = commentBody.indexOf(anchor);
 	if (start === -1) return null;
 	const rest = commentBody.slice(start + anchor.length);
 	// Bound to this app's block: stop at the next per-app anchor so a sibling app's
 	// URL can never leak into this match.
-	const nextAnchor = rest.indexOf("<!-- preview-deploy:");
-	const block = nextAnchor === -1 ? rest : rest.slice(0, nextAnchor);
+	const nextAnchor = rest.indexOf(ANCHOR_PREFIX);
+	return nextAnchor === -1 ? rest : rest.slice(0, nextAnchor);
+};
+
+/**
+ * Return the `app` (default `web`) preview URL from the sticky comment body, or
+ * `null` if the comment carries no block for that app (deploy absent/failed).
+ */
+export const resolvePreviewUrl = (commentBody: string, app = "web"): string | null => {
+	const block = appBlock(commentBody, app);
+	if (block === null) return null;
 	const match = WORKERS_DEV_URL.exec(block);
 	return match ? match[0] : null;
+};
+
+/** Whether the body is a preview announcement at all — the anchor, whatever it announces. */
+export const isPreviewAnnouncement = (commentBody: string): boolean =>
+	commentBody.includes(ANCHOR_PREFIX);
+
+/** Every app the announcement carries a block for, in the order the comment names them. */
+export const announcedApps = (commentBody: string): readonly string[] => {
+	const apps: string[] = [];
+	const pattern = /<!-- preview-deploy:([a-z0-9][a-z0-9-]*) -->/g;
+	for (const match of commentBody.matchAll(pattern)) {
+		const app = match[1];
+		if (app !== undefined && !apps.includes(app)) apps.push(app);
+	}
+	return apps;
+};
+
+/** What one app's block announces: where the preview is, and which tree it deployed. */
+export interface PreviewAnnouncement {
+	readonly app: string;
+	readonly url: string;
+	/** The head SHA the preview deployed — what binds pixels to a tree (ADR 0058). */
+	readonly deployedSha: string;
+}
+
+/**
+ * An announcement read, three ways: the app's block is there and parses, it is there and does not,
+ * or the announcement names no such app.
+ *
+ * `Malformed` and `NoApp` are deliberately separate. A malformed announcement is one nobody can
+ * read — an UNKNOWN — while an absent app is a proven fact about what was deployed; folding them
+ * would let a garbled comment resolve to "no preview" and route a reviewer down the can't-see path.
+ */
+export type AnnouncementRead =
+	| {readonly _tag: "Announced"; readonly value: PreviewAnnouncement}
+	| {readonly _tag: "Malformed"; readonly reason: string}
+	| {readonly _tag: "NoApp"};
+
+/** Any absolute http(s) URL — the announcement's domain is the repo's business, not this module's. */
+const ANY_URL = /https?:\/\/[^\s<>()"'`\]]+/;
+const EVERY_URL = new RegExp(ANY_URL.source, "g");
+/**
+ * The deployed head SHA, read only in an **anchored** form — `@ <sha>`, `(<sha>)` (the shape
+ * phoenix's own deploy comment upserts), a backticked SHA, or `head <sha>`.
+ *
+ * A bare hex-looking word is deliberately not read as a SHA: ordinary English words spell in hex
+ * (`defaced`), and a wrong SHA here would bind pixels to a tree nobody deployed.
+ */
+const DEPLOYED_SHA = /(?:@|\(|`|\bhead\b)[ \t]*`?([0-9a-f]{7,40})`?/i;
+
+/**
+ * Read one app's announced preview URL + deployed head out of the sticky comment.
+ *
+ * Keyed off the per-app anchor for the reason {@link resolvePreviewUrl} states, and domain-agnostic
+ * where that older reader hardcodes `workers.dev`: an adopter repo's preview lives wherever its
+ * delivery layer puts it, and a hardcoded domain silently reads such a comment as no comment.
+ */
+export const readPreviewAnnouncement = (commentBody: string, app: string): AnnouncementRead => {
+	const block = appBlock(commentBody, app);
+	if (block === null) return {_tag: "NoApp"};
+	const url = ANY_URL.exec(block)?.[0];
+	if (url === undefined) {
+		return {_tag: "Malformed", reason: `the "${app}" block names no absolute http(s) URL`};
+	}
+	// The URLs come out first: a hex-looking path segment inside one is not a deployed head.
+	const sha = DEPLOYED_SHA.exec(block.replace(EVERY_URL, " "))?.[1];
+	if (sha === undefined) {
+		return {
+			_tag: "Malformed",
+			reason: `the "${app}" block names no deployed head SHA (expected \`@ <sha>\`, a backticked SHA, or "head <sha>")`,
+		};
+	}
+	return {_tag: "Announced", value: {app, url, deployedSha: sha.toLowerCase()}};
 };

--- a/packages/fabrika-cli/src/capture/resolve.unit.test.ts
+++ b/packages/fabrika-cli/src/capture/resolve.unit.test.ts
@@ -5,7 +5,12 @@
  * `workers.dev` URL in the comment, or a second app's line would shadow web's.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {resolvePreviewUrl} from "./resolve.ts";
+import {
+	announcedApps,
+	isPreviewAnnouncement,
+	readPreviewAnnouncement,
+	resolvePreviewUrl,
+} from "./resolve.ts";
 
 // The exact block shape deploy.yml's "Comment preview URL" step upserts.
 const webBlock = (url: string, sha = "abc1234", db = "11111111-2222-3333-4444-555555555555") =>
@@ -45,5 +50,66 @@ describe("resolvePreviewUrl", () => {
 		const apiBlock = `<!-- preview-deploy:api -->\n- **api** — Stage \`pr-9\` → ${apiUrl} <sub>(abc1234)</sub>`;
 		const body = stickyComment(webBlock(webUrl), apiBlock);
 		assert.strictEqual(resolvePreviewUrl(body), webUrl);
+	});
+});
+
+describe("readPreviewAnnouncement", () => {
+	const url = "https://pr-9-web.kampusinfra.workers.dev";
+
+	it("reads the app's URL and the head it deployed, out of that app's own block", () => {
+		const read = readPreviewAnnouncement(stickyComment(webBlock(url, "abc1234")), "web");
+		assert.deepStrictEqual(read, {
+			_tag: "Announced",
+			value: {app: "web", url, deployedSha: "abc1234"},
+		});
+	});
+
+	it("reads the deployed head from an @-anchored or backticked announcement too", () => {
+		const at = `<!-- preview-deploy:web -->\n- **web** → ${url} @ 03135b91aa04`;
+		assert.deepStrictEqual(readPreviewAnnouncement(at, "web"), {
+			_tag: "Announced",
+			value: {app: "web", url, deployedSha: "03135b91aa04"},
+		});
+	});
+
+	it("is domain-agnostic — an adopter's preview host is not workers.dev", () => {
+		const elsewhere = "https://pr-9.preview.example.test";
+		const body = `<!-- preview-deploy:web -->\n- **web** → ${elsewhere} <sub>(abc1234)</sub>`;
+		assert.deepStrictEqual(readPreviewAnnouncement(body, "web"), {
+			_tag: "Announced",
+			value: {app: "web", url: elsewhere, deployedSha: "abc1234"},
+		});
+	});
+
+	it("calls an unreadable block MALFORMED, never absent — unreadable is not a fact about a deploy", () => {
+		const noSha = `<!-- preview-deploy:web -->\n- **web** → ${url}`;
+		assert.strictEqual(readPreviewAnnouncement(noSha, "web")._tag, "Malformed");
+		const noUrl = "<!-- preview-deploy:web -->\n- **web** — the deploy failed (abc1234)";
+		assert.strictEqual(readPreviewAnnouncement(noUrl, "web")._tag, "Malformed");
+	});
+
+	it("does not read a hex-looking path segment inside the URL as the deployed head", () => {
+		const hexPath = "https://deadbeef1.preview.example.test/x";
+		const body = `<!-- preview-deploy:web -->\n- **web** → ${hexPath}`;
+		assert.strictEqual(readPreviewAnnouncement(body, "web")._tag, "Malformed");
+	});
+
+	it("says NoApp for an announcement that carries no block for the app asked about", () => {
+		assert.deepStrictEqual(readPreviewAnnouncement(stickyComment(webBlock(url)), "api"), {
+			_tag: "NoApp",
+		});
+	});
+});
+
+describe("announcedApps / isPreviewAnnouncement", () => {
+	it("names every app the announcement carries, in comment order, once each", () => {
+		const apiBlock = "<!-- preview-deploy:api -->\n- **api** → https://a.test (abc1234)";
+		const webBody = webBlock("https://w.test");
+		assert.deepStrictEqual(announcedApps(stickyComment(apiBlock, webBody)), ["api", "web"]);
+	});
+
+	it("recognizes an announcement by its anchor, and nothing else as one", () => {
+		assert.isTrue(isPreviewAnnouncement(stickyComment(webBlock("https://w.test"))));
+		assert.isFalse(isPreviewAnnouncement("a review comment mentioning preview deploys"));
 	});
 });

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -64,6 +64,16 @@ export const SHARED_SEATS: SharedSeats = {
  */
 export const BUILD_SEATS: SharedSeats = {...SHARED_SEATS, BAD_SECTIONS: "BAD_SECTIONS"};
 
+/**
+ * `review-ui`'s seats: the same eight, plus `4` under its own name.
+ *
+ * The name differs because the meaning is the base's read widened, not renamed: `report file`'s `4`
+ * is a body section that is missing or out of order, and `review-ui` seats the same fact about a
+ * whole derived document — a capture set's `manifest.json`, or `design-harness.json` at the
+ * tier-choice read. Naming the pair is the claim a bare number cannot make.
+ */
+export const REVIEW_UI_SEATS: SharedSeats = {...SHARED_SEATS, MALFORMED_DOCUMENT: "BAD_SECTIONS"};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	build: BUILD_SEATS,
@@ -71,6 +81,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	plan: BUILD_SEATS,
 	triage: SHARED_SEATS,
 	review: SHARED_SEATS,
+	"review-ui": REVIEW_UI_SEATS,
 	ship: SHARED_SEATS,
 };
 

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -13,6 +13,7 @@ import {
 import * as plan from "./plan/codes.ts";
 import * as report from "./report/codes.ts";
 import * as review from "./review/codes.ts";
+import * as reviewUi from "./review-ui/codes.ts";
 import * as ship from "./ship/codes.ts";
 import * as triage from "./triage/codes.ts";
 import * as wire from "./wire/codes.ts";
@@ -30,6 +31,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	plan,
 	report,
 	review,
+	"review-ui": reviewUi,
 	ship,
 	triage,
 	wire,

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -22,6 +22,7 @@ import {evalCommand} from "./eval/command.ts";
 import {planCommand} from "./plan/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
+import {reviewUiCommand} from "./review-ui/command.ts";
 import {shipCommand} from "./ship/command.ts";
 import {spendCommand} from "./spend/command.ts";
 import {triageCommand} from "./triage/command.ts";
@@ -39,6 +40,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	planCommand,
 	reportCommand,
 	reviewCommand,
+	reviewUiCommand,
 	shipCommand,
 	spendCommand,
 	triageCommand,

--- a/packages/fabrika-cli/src/review-ui/codes.ts
+++ b/packages/fabrika-cli/src/review-ui/codes.ts
@@ -1,0 +1,80 @@
+/**
+ * The one exit table the three `review-ui` verbs allocate from, so a code means one thing across
+ * this group whichever verb produced it.
+ *
+ * **The seats it shares with `report` are re-exported, never re-typed** — the discipline
+ * `review/codes.ts` states and the reason `ALIGNED_GROUPS` can check it: a restated numeral is a
+ * second source that drifts silently, an import cannot. Nine seats are shared here (`3`-`11`); `12`
+ * and up are this group's own.
+ *
+ * Because these seats are the base's by identity, this group also **imports** the two generic
+ * guards the `review` group parameterized — `review/target.ts`'s PR precondition and
+ * `review/authored.ts`'s stdin/leak guard — rather than copying them: both seat exactly these
+ * numbers, and a second copy of a fail-closed guard is a second chance to fold *absent* into
+ * *unreadable*.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** Stdin was read and held nothing. Distinct from a read that failed, which is `1`. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/**
+ * A required file this group derives from is absent, does not parse, or violates its schema — a
+ * capture set's `manifest.json`, or `design-harness.json` at the tier-choice read.
+ *
+ * The base's section seat, widened to the whole-file rule the `ui` group states: a document read
+ * for a decision is read whole, and a half-read one decides nothing.
+ */
+export const MALFORMED_DOCUMENT = REPORT_BAD_SECTIONS;
+/** The **authored** text carries a machine-local path. This group offers no `--redact`. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The authored text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/**
+ * Zero scope: the target is **proven absent (404)**, or the PR is closed.
+ *
+ * The same declared widening the `review` group makes — a closed PR is provably not reviewable
+ * scope. *Proven* is the operative word: a 404 is a fact about the repository, an unreachable
+ * GitHub is not a fact about anything and lands on {@link PRECONDITION_UNKNOWN}.
+ */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** A write was attempted and its outcome could not be proven — UNKNOWN, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed but the read-back does not match. The artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** A semantic refusal on a value or a body: off a closed vocabulary, or a marker-shaped note. */
+export const OFF_VOCABULARY = REPORT_CLASSIFIED;
+/** A required read or execution failed — no outcome is proven, and nothing was written. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/**
+ * Refused, proven: the artifact is not the PR's current tree.
+ *
+ * One meaning binds the two triggers — the live head moved past `--sha` at post time, or the
+ * preview's deployed head is not the live head at render time — because *the pixels or the marker
+ * would bind a tree that is not the PR*, and the caller's move is identical either way: re-render,
+ * re-review at the live head (ADR 0058).
+ */
+export const STALE_TREE = 12;
+/** Proven: at least one surface threw an uncaught page error — the render is red (#2594). */
+export const RENDER_CRASHED = 13;
+/** Proven: at least one surface is unreachable — status ≥ 400 or a failed navigation. */
+export const SURFACE_UNREACHABLE = 14;
+/** Proven: a capture was produced but is invalid — zero bytes, undecodable, or zero area. */
+export const INVALID_CAPTURE = 15;
+/** Proven: no preview deployment exists for this PR — the skill's CANT-SEE route (#4305). */
+export const NO_PREVIEW = 16;
+/** Proven: at least one evidence upload or its verification failed — **nothing was posted**. */
+export const UPLOAD_FAILED = 17;

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -1,0 +1,174 @@
+/**
+ * The `review-ui` verb group — `fabrika review-ui <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), wires the two impure legs — the capture render and the verified
+ * evidence upload — runs the pure verb, and emits its outcome. Every decision lives in the
+ * `*-verb.ts` modules beside it.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
+ * silently opts out of the excess-operand guard.
+ *
+ * No `--json` anywhere: each verb's answer is one JSON object, so there is no second output shape
+ * to opt into.
+ */
+import {tmpdir} from "node:os";
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runNote} from "./note-verb.ts";
+import {runPost} from "./post-verb.ts";
+import {captureRenderLeg} from "./render-leg.ts";
+import {runRender} from "./render-verb.ts";
+import {githubAttachmentUploadLeg} from "./upload-leg.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const prArg = Argument.integer("pr").pipe(
+	Argument.withDescription("the pull-request number this verb acts on"),
+);
+
+const render = leafCommand(
+	"render",
+	{
+		pr: Flag.integer("pr").pipe(
+			Flag.withDescription("the pull request whose preview deployment is judged"),
+		),
+		out: Flag.string("out").pipe(
+			Flag.withDescription(
+				"kebab-case capture-set name; captures land under <OS temp>/fabrika-review-ui/<pr>-<head8>/<set>/",
+			),
+		),
+		// `atLeast(1)` is the repeatable form AND the floor: the parser refuses zero surfaces on `1`
+		// before the verb runs, so "rendered nothing, found nothing wrong" is unrepresentable.
+		surface: Flag.string("surface").pipe(
+			Flag.atLeast(1),
+			Flag.withDescription(
+				"a surface id to capture — a bare route such as /pano; repeatable, and zero operands is refused (no tool guesses surfaces from a diff)",
+			),
+		),
+		app: Flag.string("app").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"which app's sub-line of the preview comment to resolve (default: the sole app it names; ambiguity refuses)",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr, out, surface, app, repo}) {
+		yield* emit(
+			yield* runRender({
+				pr,
+				out,
+				surfaces: surface,
+				app: Option.getOrNull(app),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+				render: captureRenderLeg,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, or a --surface carries the reserved :state suffix), 11 (a read failed, the preview comment is malformed or names several apps, or a capture's validity is undeterminable), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
+	),
+);
+
+const post = leafCommand(
+	"post",
+	{
+		pr: prArg,
+		polarity: Flag.string("polarity").pipe(
+			Flag.withDescription("PASS or FAIL — a third token is not a polarity"),
+		),
+		sha: Flag.string("sha").pipe(
+			Flag.withDescription("the head the reviewer actually inspected (7–40 lowercase hex)"),
+		),
+		clause: Flag.string("clause").pipe(
+			Flag.withDescription("the human clause the marker ends with; blank is not a clause"),
+		),
+		evidence: Flag.string("evidence").pipe(
+			Flag.withDescription(
+				"the review-ui render capture-set name whose verified upload is this verdict's evidence",
+			),
+		),
+		carrier: Flag.string("carrier").pipe(
+			Flag.withDefault("marker"),
+			Flag.withDescription(
+				"marker (first-line SHA-bound marker) or advisory (§CP: advisory first line, `Reviewed-head: @ <sha>` in the body); advisory is a PASS path only (default: marker)",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr, polarity, sha, clause, evidence, carrier, repo}) {
+		yield* emit(
+			yield* runPost({
+				pr,
+				polarity,
+				sha,
+				clause,
+				evidence,
+				carrier,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+				tmpRoot: tmpdir(),
+				// The reviewer's own checked-out tree, never the PR head — this skill never checks the
+				// PR out, so the tier choice is read where the verb is running.
+				harnessPath: `${process.cwd()}/design-harness.json`,
+				upload: githubAttachmentUploadLeg(process.env),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Post the review-ui verdict on STDIN as ONE comment for this namespace — re-resolve the live head, read the evidence set through its manifest, re-validate every capture, verify-upload every capture BEFORE anything posts, compose the first line through the `verdict-marker` wire format, leak-scan, upsert, and read it back from live state. There is no --namespace: this group emits review-ui and nothing else. Prints one JSON object. Exits 3 (empty stdin), 4 (the evidence set has no readable manifest.json, or design-harness.json violates its schema), 5 (machine-local path in the assembled comment), 6 (bare @ reference), 7 (PR absent or closed), 8 (the create/edit failed — UNKNOWN), 9 (read-back does not yield this marker), 10 (bad --polarity or --carrier, or advisory with FAIL), 11 (a precondition read failed — nothing uploaded or posted), 12 (the live head moved past --sha, or the set was rendered at another head), 15 (a capture fails its manifest sha), 17 (an evidence upload or its verification failed — nothing was posted). Example: fabrika review-ui post 4321 --polarity FAIL --sha 03135b91 --clause "changes-requested" --evidence judged < verdict.md',
+	),
+);
+
+const note = leafCommand(
+	"note",
+	{pr: prArg, repo: repoFlag},
+	Effect.fn(function* ({pr, repo}) {
+		yield* emit(
+			yield* runNote({
+				pr,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Post the blocker note on STDIN as one new comment — the typed non-verdict write for a proven can't-see or escalation state. Append-only (a dated fact is never edited in place), leak-scanned, and read back. A body whose first line parses as a verdict marker or an advisory carrier is refused: a verdict goes through review-ui post. Prints one JSON object. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (PR absent or closed), 8 (the post failed — UNKNOWN), 9 (the comment does not read back as sent), 10 (the body is verdict-shaped), 11 (a precondition read failed — nothing was posted). Example: fabrika review-ui note 4321 < blocker.md",
+	),
+);
+
+export const reviewUiCommand = Command.make("review-ui").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
+		render,
+		post,
+		note,
+	]),
+	Command.withDescription(
+		"Judge a UI pull request over its preview deployment — capture the named surfaces at the inspected head, and emit the review-ui verdict or a typed blocker note through the one sanctioned write path",
+	),
+);

--- a/packages/fabrika-cli/src/review-ui/manifest.ts
+++ b/packages/fabrika-cli/src/review-ui/manifest.ts
@@ -1,0 +1,160 @@
+/**
+ * The capture set: where its bytes live, what its manifest says, and how a later verb re-reads it.
+ *
+ * `review-ui render` writes the manifest and `review-ui post` reads it, so the two never trade a
+ * carried variable — a set is whatever its `manifest.json` says it is, and a set without a readable
+ * manifest is not a set. The manifest bytes are byte-identical to `render`'s stdout object for the
+ * same reason: one document, two channels, so nothing can be true on one and not the other.
+ *
+ * The set path is **deterministic from the PR and the head**, never a `mktemp -d` nobody recorded
+ * (v1 S4: a PASS whose evidence upload failed was unauditable). The `--out` set name is the run's
+ * own key inside that directory — two concurrent reviews of one head name different sets and never
+ * write each other's bytes (the run-keyed rule #5111 states; a session is not a run).
+ */
+import {createHash} from "node:crypto";
+import {Effect, FileSystem} from "effect";
+import type {PageError} from "../capture/page-errors.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+
+/** One captured surface, as both the stdout object and the manifest record it. */
+export interface CaptureEntry {
+	readonly surface: string;
+	readonly path: string;
+	readonly width: number;
+	readonly height: number;
+	readonly sha256: string;
+	/** Errors thrown into the page during this render — recorded data, never a gate outcome. */
+	readonly pageErrors: readonly PageError[];
+}
+
+export interface CaptureManifest {
+	readonly set: string;
+	readonly pr: number;
+	/** The live head the preview was bound to — what `post` refuses to post stale pixels against. */
+	readonly head: string;
+	readonly previewUrl: string;
+	readonly captures: readonly CaptureEntry[];
+}
+
+/** A kebab-case set name: the grammar `--out` is held to, so a set name is a safe path segment. */
+const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const isKebabSetName = (value: string): boolean => KEBAB.test(value);
+
+/** `<tmp>/fabrika-review-ui/<pr>-<head8>/<set>/` — derived, so the same run re-resolves it. */
+export const setDirectory = (tmpRoot: string, pr: number, head: string, set: string): string =>
+	`${tmpRoot}/fabrika-review-ui/${pr}-${head.slice(0, 8)}/${set}`;
+
+export const manifestPath = (setDir: string): string => `${setDir}/manifest.json`;
+
+export const sha256Hex = (bytes: Uint8Array): string =>
+	createHash("sha256").update(bytes).digest("hex");
+
+/** The one serialization — `render` prints these bytes and writes these bytes. */
+export const serializeManifest = (manifest: CaptureManifest): string => JSON.stringify(manifest);
+
+const isPageErrorList = (value: unknown): value is readonly PageError[] =>
+	Array.isArray(value) &&
+	value.every(
+		(entry) =>
+			typeof entry === "object" &&
+			entry !== null &&
+			typeof (entry as PageError).kind === "string" &&
+			typeof (entry as PageError).text === "string",
+	);
+
+const toEntry = (value: unknown): CaptureEntry | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const record = value as Record<string, unknown>;
+	if (
+		typeof record.surface !== "string" ||
+		typeof record.path !== "string" ||
+		typeof record.width !== "number" ||
+		typeof record.height !== "number" ||
+		typeof record.sha256 !== "string" ||
+		!isPageErrorList(record.pageErrors)
+	) {
+		return null;
+	}
+	return {
+		surface: record.surface,
+		path: record.path,
+		width: record.width,
+		height: record.height,
+		sha256: record.sha256,
+		pageErrors: record.pageErrors,
+	};
+};
+
+export type ManifestRead =
+	| {readonly _tag: "Manifest"; readonly value: CaptureManifest}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+/**
+ * Parse a manifest, whole. Every rejection is a refusal rather than a default: a set whose captures
+ * list half-parsed would post a verdict over evidence it never saw.
+ */
+export const parseManifest = (text: string): ManifestRead => {
+	const parsed = parseJson(text);
+	if (!isRecord(parsed)) {
+		return {_tag: "Malformed", reason: "not a JSON object"};
+	}
+	const record = parsed;
+	if (
+		typeof record.set !== "string" ||
+		typeof record.pr !== "number" ||
+		typeof record.head !== "string" ||
+		typeof record.previewUrl !== "string" ||
+		!Array.isArray(record.captures)
+	) {
+		return {
+			_tag: "Malformed",
+			reason: "the manifest names no set, pr, head, previewUrl and captures",
+		};
+	}
+	const captures: CaptureEntry[] = [];
+	for (const [index, raw] of record.captures.entries()) {
+		const entry = toEntry(raw);
+		if (entry === null) {
+			return {_tag: "Malformed", reason: `capture ${index} is not a capture record`};
+		}
+		captures.push(entry);
+	}
+	if (captures.length === 0) {
+		return {
+			_tag: "Malformed",
+			reason: "the manifest records zero captures — a set with no member is not a set",
+		};
+	}
+	return {
+		_tag: "Manifest",
+		value: {
+			set: record.set,
+			pr: record.pr,
+			head: record.head,
+			previewUrl: record.previewUrl,
+			captures,
+		},
+	};
+};
+
+export type BytesRead =
+	| {readonly _tag: "Bytes"; readonly value: Uint8Array}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+/**
+ * A capture's bytes off disk. Unreadable is its own answer, never an empty buffer — an empty buffer
+ * would validate as "zero bytes" and report an invalid capture where the truth is an unread one.
+ */
+export const readCaptureBytes = (
+	path: string,
+): Effect.Effect<BytesRead, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const bytes = yield* fs.readFile(path);
+		return {_tag: "Bytes" as const, value: bytes};
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) =>
+			Effect.succeed<BytesRead>({_tag: "Unreadable", reason: cause.message}),
+		),
+	);

--- a/packages/fabrika-cli/src/review-ui/manifest.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/manifest.unit.test.ts
@@ -1,0 +1,83 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type CaptureManifest,
+	isKebabSetName,
+	manifestPath,
+	parseManifest,
+	serializeManifest,
+	setDirectory,
+	sha256Hex,
+} from "./manifest.ts";
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+
+const manifest: CaptureManifest = {
+	set: "judged",
+	pr: 4321,
+	head: HEAD,
+	previewUrl: "https://pr-4321.example.test",
+	captures: [
+		{
+			surface: "/pano",
+			path: "/tmp/fabrika-review-ui/4321-03135b91/judged/pano.png",
+			width: 1280,
+			height: 2140,
+			sha256: "9c41",
+			pageErrors: [],
+		},
+	],
+};
+
+describe("the set path", () => {
+	it("is derived from the PR and the head, so a later verb re-resolves it (v1 S4)", () => {
+		assert.strictEqual(
+			setDirectory("/tmp", 4321, HEAD, "judged"),
+			"/tmp/fabrika-review-ui/4321-03135b91/judged",
+		);
+		assert.strictEqual(
+			manifestPath(setDirectory("/tmp", 4321, HEAD, "judged")),
+			"/tmp/fabrika-review-ui/4321-03135b91/judged/manifest.json",
+		);
+	});
+
+	it("holds --out to kebab-case, so a set name is a safe path segment", () => {
+		assert.isTrue(isKebabSetName("judged"));
+		assert.isTrue(isKebabSetName("second-round-2"));
+		assert.isFalse(isKebabSetName("Judged"));
+		assert.isFalse(isKebabSetName("../escape"));
+		assert.isFalse(isKebabSetName(""));
+	});
+});
+
+describe("the manifest round-trip", () => {
+	it("parses back exactly what it serialized", () => {
+		const read = parseManifest(serializeManifest(manifest));
+		assert.deepStrictEqual(read, {_tag: "Manifest", value: manifest});
+	});
+
+	it("refuses a document it cannot read whole, rather than defaulting a field", () => {
+		assert.strictEqual(parseManifest("{")._tag, "Malformed");
+		assert.strictEqual(parseManifest("[]")._tag, "Malformed");
+		assert.strictEqual(parseManifest(JSON.stringify({...manifest, head: 3}))._tag, "Malformed");
+		assert.strictEqual(
+			parseManifest(JSON.stringify({...manifest, captures: [{surface: "/pano"}]}))._tag,
+			"Malformed",
+		);
+	});
+
+	it("refuses a set with zero captures — a set with no member is not a set (ADR 0092)", () => {
+		assert.strictEqual(
+			parseManifest(JSON.stringify({...manifest, captures: []}))._tag,
+			"Malformed",
+		);
+	});
+});
+
+describe("sha256Hex", () => {
+	it("is the content address a later verb re-derives the bytes against", () => {
+		assert.strictEqual(
+			sha256Hex(new TextEncoder().encode("abc")),
+			"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		);
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/namespace.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/namespace.unit.test.ts
@@ -1,0 +1,28 @@
+/**
+ * The `review-ui` namespace against the registered `verdict-marker` wire format.
+ *
+ * The implementation ticket flagged "one registry-side enum addition" as owed. It is not: the
+ * format gates the namespace with a **pattern**, `^(review|check-epic-plan)(-[a-z0-9]+)*$`, not a
+ * closed vocabulary, and `review-ui` already satisfies it. This test is that finding held in place —
+ * a future narrowing of the pattern reds here rather than silently making this group's every
+ * verdict unreadable.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {clause, emit, headSha, read} from "../wire/verdict-marker.ts";
+import {NAMESPACE} from "./post-verb.ts";
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+
+describe("the review-ui namespace", () => {
+	it("round-trips through the shipped format with no registry change", () => {
+		const line = emit({
+			namespace: NAMESPACE,
+			polarity: "FAIL",
+			sha: headSha(HEAD) as never,
+			clause: clause("changes-requested") as never,
+		});
+		const parsed = read(line);
+		assert.strictEqual(parsed._tag, "Found");
+		assert.strictEqual(parsed._tag === "Found" ? parsed.value.namespace : "", "review-ui");
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/note-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/note-verb.ts
@@ -1,0 +1,113 @@
+/**
+ * `review-ui note` — the single sanctioned non-verdict write: one plain comment naming a proven
+ * blocker state (can't-see, escalation), leak-scanned, read back, and **never a marker**.
+ *
+ * The typed refusal of marker-shaped bodies is the whole point. v1's plain-note off-ramps were
+ * invisible to the ship layer precisely because nothing typed them, and the cure is a typed
+ * non-verdict rather than a second marker path: a marker smuggled through here would be a gate
+ * emission nobody read back.
+ *
+ * The note carries **no head**. A blocker note is a dated fact about the PR, not a verdict over a
+ * tree — so it is append-only too: a dated fact is never edited in place.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getComment} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {readAdvisory} from "../review/advisory.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "../review/authored.ts";
+import {openPull, resolveTargetRepo} from "../review/target.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {read as readMarker} from "../wire/verdict-marker.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+
+const VERB = "review-ui note";
+
+const SURFACE: AuthoredSurface = {
+	verb: VERB,
+	noun: "the note",
+	emptyMessage: `${VERB}: no body on stdin.`,
+	bareAtMessage: `${VERB}: the body is a bare "@" path reference — send its bytes on stdin.`,
+	leakCorrection: "cite it repo-relative or by class root.",
+};
+
+export interface NoteOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+/**
+ * Whether the body's first non-blank line reaches for a verdict carrier.
+ *
+ * A `Malformed` marker read counts: bytes reaching for a marker and missing are exactly what a
+ * verdict smuggled through this verb would look like, and admitting them would make the refusal
+ * depend on getting the marker *right*.
+ */
+const carriesVerdict = (body: string): boolean =>
+	readMarker(body)._tag !== "Absent" || readAdvisory(body) !== null;
+
+export const runNote = (
+	options: NoteOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr} = options;
+		if (!Number.isInteger(pr) || pr <= 0) {
+			return refuse(FAILED, `${VERB}: ${pr} is not a pull-request number.`);
+		}
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "nothing to note.",
+			requireFiles: false,
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read the PR for #${pr}: ${reason} — nothing was posted.`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		if (carriesVerdict(authored.text)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: the first line parses as a verdict carrier (marker or advisory line) — a verdict goes through review-ui post, never this verb.`,
+			);
+		}
+		const leaked = leakRefusal(SURFACE, authored.text);
+		if (leaked !== null) return leaked;
+
+		const created = yield* createComment(repo, pr, authored.text);
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the post failed: ${created.reason} — UNKNOWN whether the note landed; re-read the PR before retrying.`,
+			);
+		}
+		const back = yield* getComment(repo, created.value.id);
+		if (back._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the posted note for #${pr}: ${back.reason} — nothing was proven.`,
+			);
+		}
+		if (normalizeForReadback(back.value) !== normalizeForReadback(authored.text)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the comment landed but does not read back as sent — inspect comment ${created.value.id}.`,
+			);
+		}
+		return answer(
+			JSON.stringify({
+				answer: "noted",
+				pr,
+				commentId: created.value.id,
+				commentUrl: created.value.url,
+			}),
+		);
+	});

--- a/packages/fabrika-cli/src/review-ui/note-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/note-verb.unit.test.ts
@@ -1,0 +1,137 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {runNote} from "./note-verb.ts";
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const URL = "https://example.test/pull/4321#issuecomment-512399";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
+const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+
+const NOTE =
+	"review-ui cannot see this PR: no preview-deploy comment exists, so there is nothing to judge\nwithout running the PR's code.\n";
+
+const pull = (state = "open"): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4321,
+			state,
+			head: {sha: HEAD},
+			base: {ref: "main"},
+			body: "",
+			changed_files: 1,
+			comments: 0,
+		}),
+	);
+
+const options = {
+	pr: 4321,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: NOTE}),
+};
+
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull()],
+	[CREATE, okOut(JSON.stringify({id: 512399, html_url: URL}))],
+	[READBACK, okOut(JSON.stringify({body: NOTE}))],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(Effect.provide(runNote({...options, ...overrides}), shell.layer)).then(
+		(outcome) => ({outcome, calls: shell.calls}),
+	);
+};
+
+describe("runNote", () => {
+	it("posts the note and reads it back", async () => {
+		const {outcome} = await run(happy());
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "noted",
+			pr: 4321,
+			commentId: 512399,
+			commentUrl: URL,
+		});
+	});
+
+	it("refuses a marker-shaped body on 10 — a verdict goes through review-ui post", async () => {
+		const marker = `review-ui: PASS @ ${HEAD} — sneaking a verdict through\n`;
+		const {outcome, calls} = await run(happy(), {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: marker}),
+		});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("refuses a body reaching for a marker and missing it, too", async () => {
+		const drifted = "review-ui: PASS — no head at all\n";
+		const {outcome} = await run(happy(), {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: drifted}),
+		});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses an advisory carrier line on 10 as well", async () => {
+		const advisory = `review-ui: advisory — §CP\n\nReviewed-head: @ ${HEAD}\n`;
+		const {outcome} = await run(happy(), {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: advisory}),
+		});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses an empty body on 3 and a leaked machine-local path on 5", async () => {
+		expect(
+			(
+				await run(happy(), {
+					stdin: Effect.succeed<StdinRead>({_tag: "NoStdin", reason: "nothing was piped in"}),
+				})
+			).outcome.code,
+		).toBe(EMPTY_STDIN);
+		const leaky = await run(happy(), {
+			stdin: Effect.succeed<StdinRead>({
+				_tag: "Text",
+				text: "the capture is at ~/code/phoenix/shot.png\n",
+			}),
+		});
+		expect(leaky.outcome.code).toBe(LEAKED_PATH);
+	});
+
+	it("refuses a closed PR on 7", async () => {
+		const {outcome} = await run([[PULL, pull("closed")], ...happy().slice(1)]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses on 8 when the post failed — UNKNOWN whether it landed", async () => {
+		const {outcome} = await run([
+			[PULL, pull()],
+			[CREATE, {ok: false, stdout: "", reason: "gh: 502"}],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("refuses on 9 when the comment does not read back as sent", async () => {
+		const {outcome} = await run([
+			[PULL, pull()],
+			[CREATE, okOut(JSON.stringify({id: 512399, html_url: URL}))],
+			[READBACK, okOut(JSON.stringify({body: "something else"}))],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/post-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/post-verb.ts
@@ -1,0 +1,462 @@
+/**
+ * `review-ui post` — the single sanctioned `review-ui` verdict emit.
+ *
+ * Eight steps, each gating the next: re-resolve the live head, read the evidence set through its
+ * manifest, re-validate every capture against that manifest, **verify-upload every capture before
+ * anything posts**, compose through the wire format, leak-scan the assembled comment, upsert one
+ * comment for this namespace under this carrier, and read it back from live PR state.
+ *
+ * Step 4 is this verb's reason to exist. The capture package's upload leg is `never`-typed by
+ * contract — every transport failure degrades to `{hostedUrl: null, uploadError}` and no consumer
+ * ever read `uploadError` — so a 100%-failed evidence channel decorated months of PASSes (#3925).
+ * Here a failed upload or a failed verification is `17` and **nothing is posted**: ADR 0165's
+ * judge-the-local-bytes still stands (the pixels you judged were local), but the *marker* does not
+ * land over a broken evidence channel.
+ *
+ * There is no `--namespace`. This group emits `review-ui` and nothing else, so a
+ * misdirected-namespace write is unrepresentable rather than refused.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {exists, readFile} from "../io/fs.ts";
+import {createComment, getComment, listComments} from "../io/issues.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+import {patchComment, viewerLogin} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {emitAdvisory, readAdvisory, reviewedHeadLine} from "../review/advisory.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "../review/authored.ts";
+import {openPull, resolveTargetRepo, scannedLine} from "../review/target.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	emit as emitMarker,
+	headSha,
+	type Polarity,
+	read as readMarker,
+	clause as toClause,
+} from "../wire/verdict-marker.ts";
+import {
+	INVALID_CAPTURE,
+	MALFORMED_DOCUMENT,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_TREE,
+	UPLOAD_FAILED,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	type CaptureEntry,
+	manifestPath,
+	parseManifest,
+	readCaptureBytes,
+	setDirectory,
+	sha256Hex,
+} from "./manifest.ts";
+
+const VERB = "review-ui post";
+
+/** This group's one namespace — an input nowhere, so it can never be aimed elsewhere. */
+export const NAMESPACE = "review-ui";
+
+const SURFACE: AuthoredSurface = {
+	verb: VERB,
+	noun: "the assembled comment",
+	emptyMessage: `${VERB}: no body on stdin — an empty verdict reads as ungated; pipe the verdict body in.`,
+	bareAtMessage: `${VERB}: the body is a bare "@" path reference — the body never arrived. Send its bytes on stdin.`,
+	leakCorrection: "cite it repo-relative or by class root.",
+};
+
+export type Carrier = "marker" | "advisory";
+
+/** One capture's upload, verified — or the reason it is not evidence anybody can see. */
+export type UploadResult =
+	| {readonly _tag: "Hosted"; readonly url: string}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+export interface UploadRequest {
+	readonly repo: string;
+	readonly fileName: string;
+	readonly bytes: Uint8Array;
+}
+
+/**
+ * The evidence-upload seam: upload one capture and **probe it back**, individually.
+ *
+ * Injected so the refusal path is testable without the network, and so the two tiers the contract
+ * names (a repo-declared store, else the GitHub user-attachment tier) are a wiring choice rather
+ * than a branch inside the verb.
+ */
+export type UploadLeg = (
+	request: UploadRequest,
+) => Effect.Effect<UploadResult, never, ChildProcessSpawner.ChildProcessSpawner>;
+
+export interface PostOptions {
+	readonly pr: number;
+	readonly polarity: string;
+	readonly sha: string;
+	readonly clause: string;
+	/** The `review-ui render` capture-set name whose verified upload is this verdict's evidence. */
+	readonly evidence: string;
+	readonly carrier: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+	/** The OS temp root the set path hangs off — the same port `render` takes. */
+	readonly tmpRoot: string;
+	/**
+	 * Where the tier-choice document is read from: the **reviewer's own checked-out tree**, never
+	 * the PR head, which this skill never checks out.
+	 */
+	readonly harnessPath: string;
+	readonly upload: UploadLeg;
+}
+
+/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
+
+const unreadable = (what: string, pr: number, reason: string): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`${VERB}: cannot read ${what} for #${pr}: ${reason} — nothing was uploaded or posted.`,
+	);
+
+/**
+ * Whether a comment already holds this namespace's verdict **under this carrier** — the upsert key.
+ *
+ * Per carrier because the two anchor on different bytes: an advisory withholds the SHA from its
+ * first line by design (ADR 0111), so a marker-only match never finds a prior advisory and every
+ * §CP re-post would stack a second comment (#4992).
+ */
+const carriesNamespace = (body: string, carrier: Carrier): boolean => {
+	if (carrier === "advisory") return readAdvisory(body)?.namespace === NAMESPACE;
+	const parsed = readMarker(body);
+	return parsed._tag === "Found" && parsed.value.namespace === NAMESPACE;
+};
+
+/** Why the read-back does not show what was posted, or `null` when it does. */
+const mismatchOf = (
+	body: string,
+	posted: {readonly polarity: string; readonly sha: string; readonly clause: string},
+	carrier: Carrier,
+	composed: string,
+): string | null => {
+	const normalized = normalizeForReadback(body);
+	const bytes =
+		normalized === normalizeForReadback(composed)
+			? null
+			: "the comment's bytes are not the ones that were sent";
+	if (carrier === "advisory") {
+		const advisory = readAdvisory(normalized);
+		if (advisory === null) return "the advisory first line or its Reviewed-head: line is not there";
+		if (advisory.namespace !== NAMESPACE) {
+			return `namespace ${advisory.namespace}, expected ${NAMESPACE}`;
+		}
+		if (advisory.sha !== posted.sha) return `Reviewed-head ${advisory.sha}, expected ${posted.sha}`;
+		return bytes;
+	}
+	const parsed = readMarker(normalized);
+	if (parsed._tag !== "Found") return parsed.reason;
+	const marker = parsed.value;
+	if (marker.namespace !== NAMESPACE) return `namespace ${marker.namespace}, expected ${NAMESPACE}`;
+	if (marker.polarity !== posted.polarity) {
+		return `polarity ${marker.polarity}, expected ${posted.polarity}`;
+	}
+	if (marker.sha !== posted.sha) return `sha ${marker.sha}, expected ${posted.sha}`;
+	if (marker.clause !== posted.clause) {
+		return `clause "${marker.clause}", expected "${posted.clause}"`;
+	}
+	return bytes;
+};
+
+/** The evidence gallery: per surface, the **verified** hosted URL — never a local path. */
+const gallery = (hosted: ReadonlyArray<readonly [CaptureEntry, string]>): string =>
+	[
+		"## Evidence",
+		"",
+		...hosted.flatMap(([entry, url]) => [
+			`### ${entry.surface}`,
+			"",
+			`![${entry.surface}](${url})`,
+			"",
+		]),
+	]
+		.join("\n")
+		.replace(/\n+$/, "");
+
+/**
+ * Which evidence tier this repo declares, read whole (`4` on a document that does not satisfy its
+ * schema) — the `ui evidence` whole-file rule.
+ *
+ * An absent `design-harness.json` is the **attachment tier**, a first-class state and not a defect:
+ * a repo that declares no store hosts its evidence on GitHub.
+ */
+type TierChoice =
+	| {readonly _tag: "Attachment"}
+	| {readonly _tag: "DeclaredStore"; readonly kind: string}
+	| {readonly _tag: "Malformed"; readonly reason: string}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+const readTierChoice = (
+	path: string,
+): Effect.Effect<TierChoice, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const present = yield* Effect.result(exists(path));
+		if (Result.isFailure(present)) {
+			return {_tag: "Unreadable" as const, reason: present.failure.reason};
+		}
+		if (!present.success) return {_tag: "Attachment" as const};
+		const text = yield* Effect.result(readFile(path));
+		if (Result.isFailure(text)) {
+			return {_tag: "Unreadable" as const, reason: text.failure.reason};
+		}
+		const parsed = parseJson(text.success);
+		if (!isRecord(parsed)) {
+			return {_tag: "Malformed" as const, reason: "not a JSON object"};
+		}
+		const store = parsed.evidenceStore;
+		if (store === undefined) return {_tag: "Attachment" as const};
+		if (!isRecord(store) || typeof store.kind !== "string") {
+			return {_tag: "Malformed" as const, reason: "evidenceStore declares no string kind"};
+		}
+		return {_tag: "DeclaredStore" as const, kind: store.kind};
+	});
+
+export const runPost = (
+	options: PostOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const {pr} = options;
+		if (!Number.isInteger(pr) || pr <= 0) {
+			return refuse(FAILED, `${VERB}: ${pr} is not a pull-request number.`);
+		}
+		const polarity = options.polarity.toUpperCase();
+		if (polarity !== "PASS" && polarity !== "FAIL") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --polarity must be PASS or FAIL — got "${options.polarity}".`,
+			);
+		}
+		const carrier = options.carrier.toLowerCase();
+		if (carrier !== "marker" && carrier !== "advisory") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --carrier must be marker or advisory — got "${options.carrier}".`,
+			);
+		}
+		if (carrier === "advisory" && polarity === "FAIL") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --carrier advisory is a PASS path only — post the FAIL marker instead.`,
+			);
+		}
+		const inspected = headSha(options.sha);
+		if (inspected === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --sha "${options.sha}" is not a head SHA — expected 7–40 hex characters.`,
+			);
+		}
+		const clause = toClause(options.clause);
+		if (clause === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --clause is blank — a verdict with no clause says nothing to a human.`,
+			);
+		}
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		// Step 1 — the verdict binds the tree it was formed over, or it is re-reviewed, never re-bound.
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "a verdict on a closed PR gates nothing.",
+			requireFiles: false,
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read the PR for #${pr}: ${reason} — nothing was uploaded or posted.`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const live = target.pull.headSha;
+		if (!prefixMatch(live, inspected)) {
+			return refuse(
+				STALE_TREE,
+				`${VERB}: the live head is ${live}, not ${inspected} — the tree you judged is gone; re-review at ${live} (ADR 0058).`,
+			);
+		}
+
+		// Step 2 — the set is whatever its manifest says it is; an evidence-less verdict must not land.
+		const setDir = setDirectory(options.tmpRoot, pr, live, options.evidence);
+		const document = yield* Effect.result(readFile(manifestPath(setDir)));
+		if (Result.isFailure(document)) {
+			return refuse(
+				MALFORMED_DOCUMENT,
+				`${VERB}: evidence set "${options.evidence}" has no readable manifest.json (${document.failure.reason}) — a set without its manifest is not a set; re-run review-ui render.`,
+			);
+		}
+		const read = parseManifest(document.success);
+		if (read._tag === "Malformed") {
+			return refuse(
+				MALFORMED_DOCUMENT,
+				`${VERB}: evidence set "${options.evidence}" has no readable manifest.json (${read.reason}) — a set without its manifest is not a set; re-run review-ui render.`,
+			);
+		}
+		const manifest = read.value;
+		if (!prefixMatch(manifest.head, inspected)) {
+			return refuse(
+				STALE_TREE,
+				`${VERB}: evidence set "${options.evidence}" was rendered at ${manifest.head.slice(0, 7)}, you are posting at ${inspected.slice(0, 7)} — stale pixels; re-render at the live head.`,
+			);
+		}
+
+		// Step 3 — re-validate every capture against the manifest that claims it.
+		const bytesByEntry: Array<readonly [CaptureEntry, Uint8Array]> = [];
+		for (const entry of manifest.captures) {
+			const bytes = yield* readCaptureBytes(entry.path);
+			if (bytes._tag === "Unreadable") {
+				return unreadable(
+					`capture "${entry.surface}" in set "${options.evidence}"`,
+					pr,
+					bytes.reason,
+				);
+			}
+			const actual = sha256Hex(bytes.value);
+			if (actual !== entry.sha256) {
+				return refuse(
+					INVALID_CAPTURE,
+					`${VERB}: capture "${entry.surface}" in set "${options.evidence}" is invalid or fails its manifest sha (recorded ${entry.sha256.slice(0, 12)}, read ${actual.slice(0, 12)}).`,
+				);
+			}
+			bytesByEntry.push([entry, bytes.value]);
+		}
+
+		// Step 4 — the tier choice, then verify-upload every capture BEFORE anything posts.
+		const tier = yield* readTierChoice(options.harnessPath);
+		if (tier._tag === "Malformed") {
+			return refuse(
+				MALFORMED_DOCUMENT,
+				`${VERB}: design-harness.json exists but does not satisfy its schema: ${tier.reason} — the tier choice is unmakeable.`,
+			);
+		}
+		if (tier._tag === "Unreadable") {
+			return unreadable("design-harness.json", pr, tier.reason);
+		}
+		if (tier._tag === "DeclaredStore") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: design-harness.json declares the "${tier.kind}" evidence store, and this delivery layer wires no store leg for it — the upload target's state is UNKNOWN; nothing was uploaded or posted.`,
+			);
+		}
+		const hosted: Array<readonly [CaptureEntry, string]> = [];
+		const failures: string[] = [];
+		for (const [entry, bytes] of bytesByEntry) {
+			const outcome = yield* options.upload({
+				repo,
+				fileName: `${entry.surface.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "root"}.png`,
+				bytes,
+			});
+			if (outcome._tag === "Hosted") hosted.push([entry, outcome.url]);
+			else failures.push(`${entry.surface}: ${outcome.reason}`);
+		}
+		if (failures.length > 0) {
+			return refuse(
+				UPLOAD_FAILED,
+				`${VERB}: upload failed for ${failures.length} of ${bytesByEntry.length} captures (${failures[0]}) — refusing to post a verdict over a broken evidence channel (#3925).`,
+				failures.map((failure) => `${VERB}: upload failed — ${failure}`),
+			);
+		}
+
+		// Step 5 — compose through the wire format, or through the ADR 0151 advisory shape.
+		const firstLine =
+			carrier === "advisory"
+				? emitAdvisory(NAMESPACE, clause)
+				: emitMarker({
+						namespace: NAMESPACE,
+						polarity: polarity as Polarity,
+						sha: inspected,
+						clause,
+					});
+		const below =
+			carrier === "advisory" ? `${reviewedHeadLine(inspected)}\n\n${authored.text}` : authored.text;
+		const composed = `${firstLine}\n${below.replace(/\n+$/, "")}\n\n${gallery(hosted)}\n`;
+
+		// Step 6 — the scan runs over the ASSEMBLED comment, so nothing this verb appended escapes it.
+		const leaked = leakRefusal(SURFACE, composed);
+		if (leaked !== null) return leaked;
+
+		// Step 7 — one namespace under one carrier, one comment.
+		const me = yield* viewerLogin;
+		if (me._tag === "Failure") return unreadable("the authenticated user", pr, me.reason);
+		const comments = yield* listComments(repo, pr);
+		if (comments._tag === "Failure") return unreadable("the comments", pr, comments.reason);
+		const diagnostics = [scannedLine(VERB, comments.value.length, "comment")];
+		// The NEWEST match by write stamp, stated rather than left to the order the API returned: a
+		// body-only repair legitimately leaves two verdicts at one SHA, and editing the older one
+		// lands the verdict where nobody reads (#5048, and the recency rule #4881 records).
+		const mine = comments.value
+			.filter((comment) => comment.author === me.value && carriesNamespace(comment.body, carrier))
+			.reduce<(typeof comments.value)[number] | undefined>((newest, comment) => {
+				if (newest === undefined) return comment;
+				const [a, b] = [
+					comment.updatedAt === "" ? comment.createdAt : comment.updatedAt,
+					newest.updatedAt === "" ? newest.createdAt : newest.updatedAt,
+				];
+				if (a !== b) return a > b ? comment : newest;
+				return comment.id > newest.id ? comment : newest;
+			}, undefined);
+
+		let landed: {readonly id: number; readonly url: string} | null = null;
+		let failure: string | null = null;
+		if (mine === undefined) {
+			const created = yield* createComment(repo, pr, composed);
+			if (created._tag === "Failure") failure = created.reason;
+			else landed = {id: created.value.id, url: created.value.url};
+		} else {
+			const edited = yield* patchComment(repo, mine.id, composed);
+			if (edited._tag === "Failure") failure = edited.reason;
+			else landed = {id: mine.id, url: edited.value};
+		}
+		if (landed === null) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: create/edit failed: ${failure ?? "unknown"} — UNKNOWN whether the verdict landed; run \`fabrika review verdicts ${pr}\` before retrying.`,
+				diagnostics,
+			);
+		}
+
+		// Step 8 — read it back from live state. The write call's own echo is not evidence (#3173).
+		const back = yield* getComment(repo, landed.id);
+		const mismatch =
+			back._tag === "Failure"
+				? back.reason
+				: mismatchOf(back.value, {polarity, sha: inspected, clause}, carrier, composed);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: posted, but the read-back does not yield this marker (${mismatch}) — inspect comment ${landed.id}.`,
+				diagnostics,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "posted",
+				namespace: NAMESPACE,
+				polarity,
+				sha: inspected,
+				upsert: mine === undefined ? "created" : "edited",
+				carrier,
+				surfaces: manifest.captures.length,
+				commentUrl: landed.url,
+			}),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
@@ -1,0 +1,325 @@
+import {Effect, FileSystem, Layer, Path, PlatformError} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	EMPTY_STDIN,
+	INVALID_CAPTURE,
+	MALFORMED_DOCUMENT,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_TREE,
+	UPLOAD_FAILED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {type CaptureManifest, serializeManifest, sha256Hex} from "./manifest.ts";
+import {runPost, type UploadLeg} from "./post-verb.ts";
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const OLD_HEAD = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
+const SET_DIR = "/tmp/fabrika-review-ui/4321-03135b91/judged";
+const CAPTURE_PATH = `${SET_DIR}/pano.png`;
+const MANIFEST_PATH = `${SET_DIR}/manifest.json`;
+const HARNESS = "/repo/design-harness.json";
+const HOSTED = "https://github.com/user-attachments/assets/9c41";
+const URL = "https://example.test/pull/4321#issuecomment-5154902211";
+
+const BYTES = new TextEncoder().encode("png bytes");
+
+const manifest = (overrides: Partial<CaptureManifest> = {}): CaptureManifest => ({
+	set: "judged",
+	pr: 4321,
+	head: HEAD,
+	previewUrl: "https://pr-4321.example.test",
+	captures: [
+		{
+			surface: "/pano",
+			path: CAPTURE_PATH,
+			width: 1280,
+			height: 2140,
+			sha256: sha256Hex(BYTES),
+			pageErrors: [],
+		},
+	],
+	...overrides,
+});
+
+interface FsShape {
+	readonly strings?: Readonly<Record<string, string>>;
+	readonly bytes?: Readonly<Record<string, Uint8Array>>;
+}
+
+const notFound = (method: string, path: string) =>
+	Effect.fail(
+		PlatformError.systemError({
+			_tag: "NotFound",
+			module: "FileSystem",
+			method,
+			pathOrDescriptor: path,
+		}),
+	);
+
+/** A filesystem that can serve BYTES as well as text — a capture is not UTF-8. */
+const fs = (shape: FsShape): Layer.Layer<FileSystem.FileSystem | Path.Path> =>
+	Layer.merge(
+		FileSystem.layerNoop({
+			readFileString: (path: string) => {
+				const text = shape.strings?.[path];
+				return text === undefined ? notFound("readFileString", path) : Effect.succeed(text);
+			},
+			readFile: (path: string) => {
+				const bytes = shape.bytes?.[path];
+				return bytes === undefined ? notFound("readFile", path) : Effect.succeed(bytes);
+			},
+			exists: (path: string) => Effect.succeed(shape.strings?.[path] !== undefined),
+		}),
+		Path.layer,
+	);
+
+const world = (overrides: FsShape = {}): Layer.Layer<FileSystem.FileSystem | Path.Path> =>
+	fs({
+		strings: {[MANIFEST_PATH]: serializeManifest(manifest()), ...overrides.strings},
+		bytes: {[CAPTURE_PATH]: BYTES, ...overrides.bytes},
+	});
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const USER = /^gh api user --jq \.login$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments /;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/\d+ /;
+const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+
+const pull = (state = "open", head = HEAD): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4321,
+			state,
+			head: {sha: head},
+			base: {ref: "main"},
+			body: "",
+			changed_files: 1,
+			comments: 0,
+		}),
+	);
+
+const comments = (
+	...rows: ReadonlyArray<{id: number; body: string; author?: string; updatedAt?: string}>
+): ExecResult =>
+	okOut(
+		JSON.stringify(
+			rows.map((row) => ({
+				id: row.id,
+				user: {login: row.author ?? "kampus-bot"},
+				created_at: "2026-08-08T00:00:00Z",
+				updated_at: row.updatedAt ?? "2026-08-08T00:00:00Z",
+				body: row.body,
+			})),
+		),
+	);
+
+const hostingLeg: UploadLeg = () => Effect.succeed({_tag: "Hosted", url: HOSTED});
+const failingLeg: UploadLeg = () => Effect.succeed({_tag: "Failed", reason: "HTTP 500"});
+
+const BODY = "| surface | verdict |\n|---|---|\n| /pano | FAIL |\n";
+
+const options = {
+	pr: 4321,
+	polarity: "FAIL",
+	sha: HEAD,
+	clause: "changes-requested",
+	evidence: "judged",
+	carrier: "marker",
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: BODY}),
+	tmpRoot: "/tmp",
+	harnessPath: HARNESS,
+	upload: hostingLeg,
+};
+
+/** The comment as the verb will have posted it, echoed back by the read-back read. */
+const posted = (body: string): ExecResult => okOut(JSON.stringify({body}));
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	layer: Layer.Layer<FileSystem.FileSystem | Path.Path> = world(),
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(runPost({...options, ...overrides}), Layer.merge(shell.layer, layer)),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+const COMPOSED = `review-ui: FAIL @ ${HEAD} — changes-requested\n\n${BODY.trimEnd()}\n\n## Evidence\n\n### /pano\n\n![/pano](${HOSTED})`;
+
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull()],
+	[USER, okOut("kampus-bot")],
+	[COMMENTS, comments()],
+	[CREATE, okOut(JSON.stringify({id: 5154902211, html_url: URL}))],
+	[READBACK, posted(COMPOSED)],
+];
+
+describe("runPost", () => {
+	it("posts one marker-first comment with the verified evidence gallery under it", async () => {
+		const {outcome, calls} = await run(happy());
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "posted",
+			namespace: "review-ui",
+			polarity: "FAIL",
+			sha: HEAD,
+			upsert: "created",
+			carrier: "marker",
+			surfaces: 1,
+			commentUrl: URL,
+		});
+		const write = calls.find((call) => CREATE.test(call)) ?? "";
+		const body = write.slice(write.indexOf("body=") + "body=".length);
+		expect(body.split("\n")[0]).toBe(`review-ui: FAIL @ ${HEAD} — changes-requested`);
+		expect(body).toContain(`![/pano](${HOSTED})`);
+		// The gallery embeds the hosted URL, never the local path the reviewer judged.
+		expect(body).not.toContain(CAPTURE_PATH);
+	});
+
+	it("refuses an empty verdict body on 3 — an empty verdict reads as ungated", async () => {
+		const {outcome} = await run(happy(), {
+			stdin: Effect.succeed<StdinRead>({_tag: "NoStdin", reason: "nothing was piped in"}),
+		});
+		expect(outcome.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a bad polarity, a bad carrier, and advisory+FAIL on 10", async () => {
+		expect((await run(happy(), {polarity: "MAYBE"})).outcome.code).toBe(OFF_VOCABULARY);
+		expect((await run(happy(), {carrier: "letter"})).outcome.code).toBe(OFF_VOCABULARY);
+		expect((await run(happy(), {carrier: "advisory"})).outcome.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses a closed PR on 7", async () => {
+		const {outcome} = await run([[PULL, pull("closed")], ...happy().slice(1)]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses on 12 when the live head moved past --sha, and posts nothing", async () => {
+		const {outcome, calls} = await run([[PULL, pull("open", OLD_HEAD)], ...happy().slice(1)]);
+		expect(outcome.code).toBe(STALE_TREE);
+		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("refuses on 12 when the evidence set was rendered at another head", async () => {
+		const {outcome} = await run(
+			happy(),
+			{},
+			world({strings: {[MANIFEST_PATH]: serializeManifest(manifest({head: OLD_HEAD}))}}),
+		);
+		expect(outcome.code).toBe(STALE_TREE);
+	});
+
+	it("refuses on 4 when the set has no readable manifest — a set without one is not a set", async () => {
+		const absent = await run(happy(), {}, fs({bytes: {[CAPTURE_PATH]: BYTES}}));
+		expect(absent.outcome.code).toBe(MALFORMED_DOCUMENT);
+		const unparseable = await run(happy(), {}, world({strings: {[MANIFEST_PATH]: "{"}}));
+		expect(unparseable.outcome.code).toBe(MALFORMED_DOCUMENT);
+	});
+
+	it("refuses on 4 when design-harness.json exists but violates its schema", async () => {
+		const {outcome} = await run(happy(), {}, world({strings: {[HARNESS]: '{"evidenceStore":{}}'}}));
+		expect(outcome.code).toBe(MALFORMED_DOCUMENT);
+	});
+
+	it("refuses on 15 when a capture no longer matches its manifest sha", async () => {
+		const {outcome} = await run(
+			happy(),
+			{},
+			world({bytes: {[CAPTURE_PATH]: new TextEncoder().encode("other bytes")}}),
+		);
+		expect(outcome.code).toBe(INVALID_CAPTURE);
+	});
+
+	it("keeps an unreadable capture UNKNOWN (11) rather than calling it invalid", async () => {
+		const {outcome} = await run(
+			happy(),
+			{},
+			fs({strings: {[MANIFEST_PATH]: serializeManifest(manifest())}}),
+		);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("posts NOTHING when an evidence upload fails — 17 is this verb's reason to exist", async () => {
+		const {outcome, calls} = await run(happy(), {upload: failingLeg});
+		expect(outcome.code).toBe(UPLOAD_FAILED);
+		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(outcome.stderr.at(-1)).toMatch(/broken evidence channel/);
+	});
+
+	it("edits this namespace's own comment instead of stacking a second marker", async () => {
+		const {outcome, calls} = await run([
+			[PULL, pull()],
+			[USER, okOut("kampus-bot")],
+			[
+				COMMENTS,
+				comments({
+					id: 42,
+					body: `review-ui: PASS @ ${OLD_HEAD} — older round`,
+					author: "kampus-bot",
+				}),
+			],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, posted(COMPOSED)],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).upsert).toBe("edited");
+		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("edits the NEWEST of two markers at one SHA, not whichever came back first (#4881)", async () => {
+		const {outcome, calls} = await run([
+			[PULL, pull()],
+			[USER, okOut("kampus-bot")],
+			[
+				COMMENTS,
+				comments(
+					{
+						id: 41,
+						body: `review-ui: FAIL @ ${HEAD} — first round`,
+						updatedAt: "2026-08-09T09:56:43Z",
+					},
+					{
+						id: 42,
+						body: `review-ui: PASS @ ${HEAD} — after the body-only repair`,
+						updatedAt: "2026-08-09T10:10:48Z",
+					},
+				),
+			],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, posted(COMPOSED)],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(calls.find((call) => PATCH.test(call))).toContain("issues/comments/42");
+	});
+
+	it("refuses on 8 when the write itself failed — UNKNOWN, never 1", async () => {
+		const {outcome} = await run([
+			[PULL, pull()],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, {ok: false, stdout: "", reason: "gh: 502"}],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("refuses on 9 when the read-back does not yield this marker", async () => {
+		const {outcome} = await run([
+			[PULL, pull()],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments()],
+			[CREATE, okOut(JSON.stringify({id: 1, html_url: URL}))],
+			[once(READBACK), posted("someone else's comment entirely")],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/preview.ts
+++ b/packages/fabrika-cli/src/review-ui/preview.ts
@@ -1,0 +1,67 @@
+/**
+ * Which preview a PR announces, resolved off its comment list.
+ *
+ * The parsing is the capture machinery's one resolver module (`../capture/resolve.ts`); what lives
+ * here is the *choice* — which comment, which app, and how the four outcomes route. They are four
+ * and not two on purpose: an absent announcement is a proven fact about the repo (the CANT-SEE
+ * route), while an unreadable one and an ambiguous one are UNKNOWNs a reviewer must not read as
+ * "no preview".
+ *
+ * The comment is picked by **recency, explicitly** — the newest announcement wins, and a repo that
+ * posts a fresh comment per deploy is as readable as one that upserts a sticky one. Leaving the
+ * pick to whatever order the API returned is how a stale announcement comes to bind a new head.
+ */
+import {
+	announcedApps,
+	isPreviewAnnouncement,
+	type PreviewAnnouncement,
+	readPreviewAnnouncement,
+} from "../capture/resolve.ts";
+import type {CommentRecord} from "../io/issues.ts";
+
+export type PreviewResolution =
+	| {readonly _tag: "Resolved"; readonly value: PreviewAnnouncement}
+	/** Proven: no comment carries the preview anchor at all. */
+	| {readonly _tag: "NoPreview"}
+	/** The announcement names several apps and the caller picked none. */
+	| {readonly _tag: "Ambiguous"; readonly apps: readonly string[]}
+	/** The anchor is there and unreadable for this app — unreadable is not absent. */
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+/** The write stamp when the platform gave one, else the filing time — never an arbitrary order. */
+const writtenAt = (comment: CommentRecord): string =>
+	comment.updatedAt === "" ? comment.createdAt : comment.updatedAt;
+
+const newestAnnouncement = (comments: readonly CommentRecord[]): CommentRecord | undefined =>
+	comments
+		.filter((comment) => isPreviewAnnouncement(comment.body))
+		.reduce<CommentRecord | undefined>((newest, comment) => {
+			if (newest === undefined) return comment;
+			const [a, b] = [writtenAt(comment), writtenAt(newest)];
+			if (a !== b) return a > b ? comment : newest;
+			return comment.id > newest.id ? comment : newest;
+		}, undefined);
+
+export const resolvePreview = (
+	comments: readonly CommentRecord[],
+	app: string | null,
+): PreviewResolution => {
+	const announcement = newestAnnouncement(comments);
+	if (announcement === undefined) return {_tag: "NoPreview"};
+	const apps = announcedApps(announcement.body);
+	if (apps.length === 0) {
+		return {
+			_tag: "Malformed",
+			reason: "the comment carries the preview anchor but names no app block",
+		};
+	}
+	if (app === null && apps.length > 1) return {_tag: "Ambiguous", apps};
+	const chosen = app ?? (apps[0] as string);
+	const read = readPreviewAnnouncement(announcement.body, chosen);
+	if (read._tag === "Announced") return {_tag: "Resolved", value: read.value};
+	if (read._tag === "Malformed") return {_tag: "Malformed", reason: read.reason};
+	return {
+		_tag: "Malformed",
+		reason: `the announcement names apps ${apps.join(", ")}, not "${chosen}"`,
+	};
+};

--- a/packages/fabrika-cli/src/review-ui/preview.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/preview.unit.test.ts
@@ -1,0 +1,62 @@
+import {assert, describe, it} from "@effect/vitest";
+import type {CommentRecord} from "../io/issues.ts";
+import {resolvePreview} from "./preview.ts";
+
+const comment = (id: number, body: string, updatedAt = "2026-08-09T00:00:00Z"): CommentRecord => ({
+	id,
+	author: "kampus-bot",
+	createdAt: "2026-08-08T00:00:00Z",
+	updatedAt,
+	body,
+});
+
+const block = (app: string, url: string, sha: string) =>
+	`<!-- preview-deploy:${app} -->\n- **${app}** — Stage \`pr-9\` → ${url} <sub>(${sha})</sub>`;
+
+const WEB = "https://pr-9-web.example.test";
+
+describe("resolvePreview", () => {
+	it("resolves the sole app when the caller named none", () => {
+		const resolution = resolvePreview([comment(1, block("web", WEB, "abc1234"))], null);
+		assert.deepStrictEqual(resolution, {
+			_tag: "Resolved",
+			value: {app: "web", url: WEB, deployedSha: "abc1234"},
+		});
+	});
+
+	it("refuses to guess between apps — ambiguity is the caller's to settle", () => {
+		const body = `${block("api", "https://api.example.test", "abc1234")}\n${block("web", WEB, "abc1234")}`;
+		assert.deepStrictEqual(resolvePreview([comment(1, body)], null), {
+			_tag: "Ambiguous",
+			apps: ["api", "web"],
+		});
+		assert.deepStrictEqual(resolvePreview([comment(1, body)], "web"), {
+			_tag: "Resolved",
+			value: {app: "web", url: WEB, deployedSha: "abc1234"},
+		});
+	});
+
+	it("proves NoPreview only when nothing carries the anchor", () => {
+		assert.deepStrictEqual(resolvePreview([comment(1, "looks fine to me")], null), {
+			_tag: "NoPreview",
+		});
+	});
+
+	it("calls an app the announcement does not carry MALFORMED, not NoPreview", () => {
+		const resolution = resolvePreview([comment(1, block("web", WEB, "abc1234"))], "api");
+		assert.strictEqual(resolution._tag, "Malformed");
+	});
+
+	it("picks the NEWEST announcement by write stamp, not by list order", () => {
+		const older = comment(
+			1,
+			block("web", "https://old.example.test", "1111111"),
+			"2026-08-01T00:00:00Z",
+		);
+		const newer = comment(2, block("web", WEB, "abc1234"), "2026-08-09T10:00:00Z");
+		assert.deepStrictEqual(resolvePreview([newer, older], null), {
+			_tag: "Resolved",
+			value: {app: "web", url: WEB, deployedSha: "abc1234"},
+		});
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/render-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.ts
@@ -26,52 +26,78 @@ import type {RenderLeg, SurfaceRender} from "./render-verb.ts";
  */
 const UNREACHABLE_FLOOR = 400;
 
-export const captureRenderLeg: RenderLeg = (request) =>
-	Effect.gen(function* () {
-		const plan = yield* Effect.try({
-			try: () =>
-				buildCapturePlan(request.previewUrl, [parseSurfaceSpec(request.surface)], DEFAULT_VIEWPORT),
-			catch: (cause) => String(cause),
-		}).pipe(Effect.catch((reason) => Effect.succeed(reason)));
-		if (typeof plan === "string") {
-			return {_tag: "Failed", reason: plan} satisfies SurfaceRender;
-		}
+/**
+ * `captureShots` fails per-shot with `failed to capture <surface> at <url>` and per-run with
+ * `failed to launch chromium` / `failed to close chromium`. Only the per-shot one is a fact about
+ * the surface; the other two say the machinery never ran, which is UNKNOWN.
+ *
+ * Matched as an ALLOW-LIST on purpose: an unrecognised message falls to `Failed` (UNKNOWN), so a
+ * new failure mode in the capture module degrades to "could not tell" and can never become a proven
+ * accusation against the PR — a reviewer with no chromium installed must not be told a surface is
+ * dark-flagged or routeless (#4493).
+ */
+const NAVIGATION_FAILURE_PREFIX = "failed to capture ";
 
-		const captured = yield* captureShots(plan, request.outDir).pipe(
-			Effect.catch((error) => Effect.succeed(error.message)),
-		);
-		// A Playwright navigation failure — no route, a dead host, a timeout — is the unreachable
-		// arm; the machinery reports it as a capture failure naming the surface and its URL.
-		if (typeof captured === "string") {
-			return {_tag: "Unreachable", reason: captured} satisfies SurfaceRender;
-		}
-		const shot = captured[0];
-		if (shot === undefined) {
-			return {_tag: "Failed", reason: "the capture machinery returned no surface"} as SurfaceRender;
-		}
-		if (shot.status !== undefined && shot.status >= UNREACHABLE_FLOOR) {
-			return {_tag: "Unreachable", reason: `status ${shot.status}`} satisfies SurfaceRender;
-		}
-		const crash = shot.pageErrors.find(isRenderCrash);
-		if (crash !== undefined) {
-			return {_tag: "Crashed", firstError: crash.text} satisfies SurfaceRender;
-		}
-		const validity = validateCaptureBytes(shot.pngBytes);
-		if (validity._tag === "Invalid") {
-			return {_tag: "Invalid", detail: validity.reason} satisfies SurfaceRender;
-		}
-		return {
-			_tag: "Rendered",
-			entry: {
-				surface: request.surface,
-				path: shot.localPath,
-				width: validity.width,
-				height: validity.height,
-				sha256: sha256Hex(shot.pngBytes),
-				// `console.error` output is recorded, never a gate outcome — and this list is only ever
-				// written from a successfully-read error channel (v1's extractor returned empty on a
-				// parse failure, fusing "no crashes" with "never looked").
-				pageErrors: shot.pageErrors,
-			},
-		} satisfies SurfaceRender;
-	});
+/** The capture call, injectable so the classification below is testable without a browser. */
+export type CaptureShots = typeof captureShots;
+
+export const makeCaptureRenderLeg =
+	(capture: CaptureShots = captureShots): RenderLeg =>
+	(request) =>
+		Effect.gen(function* () {
+			const plan = yield* Effect.try({
+				try: () =>
+					buildCapturePlan(
+						request.previewUrl,
+						[parseSurfaceSpec(request.surface)],
+						DEFAULT_VIEWPORT,
+					),
+				catch: (cause) => String(cause),
+			}).pipe(Effect.catch((reason) => Effect.succeed(reason)));
+			if (typeof plan === "string") {
+				return {_tag: "Failed", reason: plan} satisfies SurfaceRender;
+			}
+
+			const captured = yield* capture(plan, request.outDir).pipe(
+				Effect.catch((error) => Effect.succeed(error.message)),
+			);
+			if (typeof captured === "string") {
+				return captured.startsWith(NAVIGATION_FAILURE_PREFIX)
+					? ({_tag: "Unreachable", reason: captured} satisfies SurfaceRender)
+					: ({_tag: "Failed", reason: captured} satisfies SurfaceRender);
+			}
+			const shot = captured[0];
+			if (shot === undefined) {
+				return {
+					_tag: "Failed",
+					reason: "the capture machinery returned no surface",
+				} as SurfaceRender;
+			}
+			if (shot.status !== undefined && shot.status >= UNREACHABLE_FLOOR) {
+				return {_tag: "Unreachable", reason: `status ${shot.status}`} satisfies SurfaceRender;
+			}
+			const crash = shot.pageErrors.find(isRenderCrash);
+			if (crash !== undefined) {
+				return {_tag: "Crashed", firstError: crash.text} satisfies SurfaceRender;
+			}
+			const validity = validateCaptureBytes(shot.pngBytes);
+			if (validity._tag === "Invalid") {
+				return {_tag: "Invalid", detail: validity.reason} satisfies SurfaceRender;
+			}
+			return {
+				_tag: "Rendered",
+				entry: {
+					surface: request.surface,
+					path: shot.localPath,
+					width: validity.width,
+					height: validity.height,
+					sha256: sha256Hex(shot.pngBytes),
+					// `console.error` output is recorded, never a gate outcome — and this list is only ever
+					// written from a successfully-read error channel (v1's extractor returned empty on a
+					// parse failure, fusing "no crashes" with "never looked").
+					pageErrors: shot.pageErrors,
+				},
+			} satisfies SurfaceRender;
+		});
+
+export const captureRenderLeg: RenderLeg = makeCaptureRenderLeg();

--- a/packages/fabrika-cli/src/review-ui/render-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.ts
@@ -1,0 +1,77 @@
+/**
+ * The production {@link RenderLeg}: drive the fabrika-owned capture machinery over one surface and
+ * classify what came back.
+ *
+ * Nothing here renders, screenshots, validates bytes or reads page errors on its own — every one of
+ * those is the capture module's (`../capture/`), imported the way `build`'s verbs import `wire`.
+ * What this file owns is the **classification**: turning a capture into one of the proven outcomes
+ * `render`'s exit codes route on.
+ *
+ * **One `captureShots` call per surface**, which costs a browser launch per surface and buys the
+ * thing the contract requires: per-surface outcomes. A single batched call fails the whole effect on
+ * the first bad shot, so a mixed set could report at most one surface's fate and the rest would go
+ * unenumerated — the "judged nothing, found nothing wrong" shape (#3925) in a different disguise.
+ */
+import {Effect} from "effect";
+import {captureShots} from "../capture/capture.ts";
+import {isRenderCrash} from "../capture/page-errors.ts";
+import {buildCapturePlan, DEFAULT_VIEWPORT, parseSurfaceSpec} from "../capture/plan.ts";
+import {validateCaptureBytes} from "../capture/png.ts";
+import {sha256Hex} from "./manifest.ts";
+import type {RenderLeg, SurfaceRender} from "./render-verb.ts";
+
+/**
+ * A navigation that served no response, or a status the machinery could not attach, is UNREACHABLE
+ * rather than fine: the alternative is judging an error page's pixels as composition.
+ */
+const UNREACHABLE_FLOOR = 400;
+
+export const captureRenderLeg: RenderLeg = (request) =>
+	Effect.gen(function* () {
+		const plan = yield* Effect.try({
+			try: () =>
+				buildCapturePlan(request.previewUrl, [parseSurfaceSpec(request.surface)], DEFAULT_VIEWPORT),
+			catch: (cause) => String(cause),
+		}).pipe(Effect.catch((reason) => Effect.succeed(reason)));
+		if (typeof plan === "string") {
+			return {_tag: "Failed", reason: plan} satisfies SurfaceRender;
+		}
+
+		const captured = yield* captureShots(plan, request.outDir).pipe(
+			Effect.catch((error) => Effect.succeed(error.message)),
+		);
+		// A Playwright navigation failure — no route, a dead host, a timeout — is the unreachable
+		// arm; the machinery reports it as a capture failure naming the surface and its URL.
+		if (typeof captured === "string") {
+			return {_tag: "Unreachable", reason: captured} satisfies SurfaceRender;
+		}
+		const shot = captured[0];
+		if (shot === undefined) {
+			return {_tag: "Failed", reason: "the capture machinery returned no surface"} as SurfaceRender;
+		}
+		if (shot.status !== undefined && shot.status >= UNREACHABLE_FLOOR) {
+			return {_tag: "Unreachable", reason: `status ${shot.status}`} satisfies SurfaceRender;
+		}
+		const crash = shot.pageErrors.find(isRenderCrash);
+		if (crash !== undefined) {
+			return {_tag: "Crashed", firstError: crash.text} satisfies SurfaceRender;
+		}
+		const validity = validateCaptureBytes(shot.pngBytes);
+		if (validity._tag === "Invalid") {
+			return {_tag: "Invalid", detail: validity.reason} satisfies SurfaceRender;
+		}
+		return {
+			_tag: "Rendered",
+			entry: {
+				surface: request.surface,
+				path: shot.localPath,
+				width: validity.width,
+				height: validity.height,
+				sha256: sha256Hex(shot.pngBytes),
+				// `console.error` output is recorded, never a gate outcome — and this list is only ever
+				// written from a successfully-read error channel (v1's extractor returned empty on a
+				// parse failure, fusing "no crashes" with "never looked").
+				pageErrors: shot.pageErrors,
+			},
+		} satisfies SurfaceRender;
+	});

--- a/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-leg.unit.test.ts
@@ -1,0 +1,72 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type CapturedSurface, CaptureError} from "../capture/capture.ts";
+import {type CaptureShots, makeCaptureRenderLeg} from "./render-leg.ts";
+import type {SurfaceRender} from "./render-verb.ts";
+
+const PREVIEW = "https://pr-4321-web.example.test";
+
+const request = {surface: "/pano", previewUrl: PREVIEW, outDir: "/tmp/shots"};
+
+const failing =
+	(message: string): CaptureShots =>
+	() =>
+		Effect.fail(new CaptureError({message}));
+
+/** A 24-byte PNG header declaring 8x4 — enough for `validateCaptureBytes`, no codec needed. */
+const pngHeader = (): Uint8Array => {
+	const bytes = new Uint8Array(24);
+	bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+	bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+	bytes[19] = 8;
+	bytes[23] = 4;
+	return bytes;
+};
+
+const succeeding =
+	(shot: Partial<CapturedSurface>): CaptureShots =>
+	() =>
+		Effect.succeed([
+			{
+				surface: "/pano",
+				route: "/pano",
+				state: null,
+				localPath: "/tmp/shots/pano.png",
+				fileName: "pano.png",
+				pngBytes: pngHeader(),
+				pageErrors: [],
+				...shot,
+			},
+		]);
+
+const run = (capture: CaptureShots): SurfaceRender =>
+	Effect.runSync(makeCaptureRenderLeg(capture)(request));
+
+describe("captureRenderLeg", () => {
+	// The wiring, not the seam: render-verb's own test INJECTS a `Failed` value, so it passes even
+	// when the only code that could produce one never does. These drive the real classification with
+	// the three messages `captureShots` actually fails with.
+	it("keeps a broken browser provision UNKNOWN (Failed), never a proven claim about the surface", () => {
+		expect(run(failing("failed to launch chromium"))._tag).toBe("Failed");
+		expect(run(failing("failed to close chromium"))._tag).toBe("Failed");
+	});
+
+	it("reads a per-shot navigation failure as the proven Unreachable arm", () => {
+		expect(run(failing(`failed to capture /pano at ${PREVIEW}/pano`))).toEqual({
+			_tag: "Unreachable",
+			reason: `failed to capture /pano at ${PREVIEW}/pano`,
+		});
+	});
+
+	it("falls to UNKNOWN on an unrecognised capture failure", () => {
+		expect(run(failing("some future failure mode"))._tag).toBe("Failed");
+	});
+
+	it("still routes a 4xx navigation to Unreachable", () => {
+		expect(run(succeeding({status: 404}))._tag).toBe("Unreachable");
+	});
+
+	it("reports a decodable capture as Rendered", () => {
+		expect(run(succeeding({status: 200}))._tag).toBe("Rendered");
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/render-verb.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.ts
@@ -1,0 +1,252 @@
+/**
+ * `review-ui render` — capture named surfaces from the PR's preview deployment at the inspected
+ * head, one validated PNG per surface, each surface's outcome proven.
+ *
+ * The order is the contract's and every step gates the next: resolve the PR and its live head,
+ * resolve the announced preview, **bind the preview to the head**, then render each surface and
+ * classify what came back. Full success is the only `0` — v1's capture leg carried no status
+ * assertion and no capture-count check, so a crashed helper meant zero surfaces judged, zero
+ * violations, PASS (#3925).
+ *
+ * The renderer is an injected seam ({@link RenderLeg}) so every refusal below is testable without a
+ * browser; `render-leg.ts` is the one that drives the capture machinery.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {writeFile} from "../io/fs.ts";
+import {listComments} from "../io/issues.ts";
+import {openPull, resolveTargetRepo, scannedLine} from "../review/target.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	INVALID_CAPTURE,
+	NO_PREVIEW,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	RENDER_CRASHED,
+	STALE_TREE,
+	SURFACE_UNREACHABLE,
+} from "./codes.ts";
+import {
+	type CaptureEntry,
+	type CaptureManifest,
+	isKebabSetName,
+	manifestPath,
+	serializeManifest,
+	setDirectory,
+} from "./manifest.ts";
+import {resolvePreview} from "./preview.ts";
+
+const VERB = "review-ui render";
+
+/** What one surface's render is asked for: the preview it hangs off, and where its PNG belongs. */
+export interface SurfaceRenderRequest {
+	/** The surface id — a bare route, since `:state` is refused upstream. */
+	readonly surface: string;
+	readonly previewUrl: string;
+	readonly outDir: string;
+}
+
+/**
+ * One surface's proven outcome. Four arms, never three: an execution that never became answerable
+ * (`Failed`) is UNKNOWN and must not read as a surface that rendered badly.
+ */
+export type SurfaceRender =
+	| {readonly _tag: "Rendered"; readonly entry: CaptureEntry}
+	| {readonly _tag: "Unreachable"; readonly reason: string}
+	| {readonly _tag: "Crashed"; readonly firstError: string}
+	| {readonly _tag: "Invalid"; readonly detail: string}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+export type RenderLeg = (request: SurfaceRenderRequest) => Effect.Effect<SurfaceRender>;
+
+export interface RenderOptions {
+	readonly pr: number;
+	readonly out: string;
+	readonly surfaces: readonly string[];
+	readonly app: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The OS temp root the deterministic set path hangs off — a port so a test can pin it. */
+	readonly tmpRoot: string;
+	readonly render: RenderLeg;
+}
+
+const unreadable = (what: string, pr: number, reason: string): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`${VERB}: cannot read ${what} for #${pr}: ${reason} — the render is UNKNOWN.`,
+	);
+
+/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
+
+const shortSha = (sha: string): string => sha.slice(0, 7);
+
+/**
+ * The reported code when per-surface outcomes mix: the **smallest** applicable of `13`/`14`/`15`.
+ *
+ * The code routes and the stderr enumerates. Dropping a surface is the skill's explicit
+ * re-invocation without it, on the record — never this verb's tolerance.
+ */
+const routeCode = (renders: readonly SurfaceRender[]): number | null => {
+	if (renders.some((r) => r._tag === "Crashed")) return RENDER_CRASHED;
+	if (renders.some((r) => r._tag === "Unreachable")) return SURFACE_UNREACHABLE;
+	if (renders.some((r) => r._tag === "Invalid")) return INVALID_CAPTURE;
+	return null;
+};
+
+const outcomeLine = (surface: string, render: SurfaceRender): string => {
+	switch (render._tag) {
+		case "Rendered":
+			return `${VERB}: surface "${surface}" captured: ${render.entry.width}x${render.entry.height}, ${render.entry.pageErrors.length} page error(s)`;
+		case "Unreachable":
+			return `${VERB}: surface "${surface}" is unreachable at the preview (${render.reason}) — judge what renders, and hold the gap against the PR's Deviations (#4305).`;
+		case "Crashed":
+			return `${VERB}: surface "${surface}" threw during render: ${render.firstError} — the render is red; a broken page is not composition to judge.`;
+		case "Invalid":
+			return `${VERB}: surface "${surface}" captured invalid bytes (${render.detail}) — a capture nobody can open is not evidence (#3925's class).`;
+		case "Failed":
+			return `${VERB}: surface "${surface}" could not be rendered: ${render.reason} — the outcome is UNKNOWN.`;
+	}
+};
+
+export const runRender = (
+	options: RenderOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const {pr} = options;
+		if (!Number.isInteger(pr) || pr <= 0) {
+			return refuse(FAILED, `${VERB}: ${pr} is not a pull-request number.`);
+		}
+		if (options.surfaces.length === 0) {
+			return refuse(
+				FAILED,
+				`${VERB}: no --surface operands — "rendered nothing, found nothing wrong" is not an answer (ADR 0092).`,
+			);
+		}
+		if (!isKebabSetName(options.out)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --out "${options.out}" is not a kebab-case set name.`,
+			);
+		}
+		const stateful = options.surfaces.find((surface) => surface.includes(":"));
+		if (stateful !== undefined) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --surface "${stateful}" carries a :state suffix — states are a reserved grammar, not yet realized; render the bare route.`,
+			);
+		}
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "nothing to judge.",
+			requireFiles: false,
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read the PR for #${pr}: ${reason} — the render is UNKNOWN.`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const head = target.pull.headSha;
+
+		const comments = yield* listComments(repo, pr);
+		if (comments._tag === "Failure") return unreadable("the comments", pr, comments.reason);
+		const scanned = scannedLine(VERB, comments.value.length, "comment");
+
+		const preview = resolvePreview(comments.value, options.app);
+		if (preview._tag === "NoPreview") {
+			return refuse(
+				NO_PREVIEW,
+				`${VERB}: no preview-deploy comment on PR #${pr} — nothing to judge without running the PR's code; the run is CANT-SEE.`,
+				[scanned],
+			);
+		}
+		if (preview._tag === "Ambiguous") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: the preview comment names apps ${preview.apps.join(", ")} — pass --app to pick one.`,
+				[scanned],
+			);
+		}
+		if (preview._tag === "Malformed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: the preview comment carries the anchor but no parseable URL + SHA (${preview.reason}) — a malformed announcement is unreadable, not absent.`,
+				[scanned],
+			);
+		}
+		const announced = preview.value;
+
+		// The pixels bind the tree they were taken from. A preview that lags the push would stamp an
+		// old tree with a new head — the stale-verdict class at the capture seam (#4808, ADR 0058).
+		if (!prefixMatch(head, announced.deployedSha)) {
+			return refuse(
+				STALE_TREE,
+				`${VERB}: the preview deploys ${shortSha(announced.deployedSha)}, the live head is ${shortSha(head)} — stale preview; pixels of an old tree must not bind a new head (#4808's class).`,
+				[scanned],
+			);
+		}
+
+		const setDir = setDirectory(options.tmpRoot, pr, head, options.out);
+		const renders: SurfaceRender[] = [];
+		for (const surface of options.surfaces) {
+			renders.push(yield* options.render({surface, previewUrl: announced.url, outDir: setDir}));
+		}
+		const enumerated = [
+			scanned,
+			...options.surfaces.map((surface, i) => outcomeLine(surface, renders[i] as SurfaceRender)),
+		];
+
+		const failed = renders.find((render) => render._tag === "Failed");
+		if (failed !== undefined && failed._tag === "Failed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read a capture's validity for #${pr}: ${failed.reason} — the render is UNKNOWN.`,
+				enumerated,
+			);
+		}
+		const routed = routeCode(renders);
+		if (routed !== null) {
+			// The refusal names a surface the ROUTED code applies to, not merely the first bad one: a
+			// message about an unreachable surface over a `13` would send the caller after the wrong fix.
+			const tag =
+				routed === RENDER_CRASHED
+					? "Crashed"
+					: routed === SURFACE_UNREACHABLE
+						? "Unreachable"
+						: "Invalid";
+			const index = renders.findIndex((render) => render._tag === tag);
+			return refuse(
+				routed,
+				outcomeLine(options.surfaces[index] as string, renders[index] as SurfaceRender),
+				enumerated,
+			);
+		}
+
+		const manifest: CaptureManifest = {
+			set: options.out,
+			pr,
+			head,
+			previewUrl: announced.url,
+			captures: renders.map((render) => (render as {entry: CaptureEntry}).entry),
+		};
+		const document = serializeManifest(manifest);
+		// A set without its manifest is not a set: `post` reads the set through it, so a manifest that
+		// did not land makes the captures unusable as evidence and the run UNKNOWN.
+		const written = yield* Effect.result(writeFile(manifestPath(setDir), document));
+		if (Result.isFailure(written)) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot write the set manifest for #${pr}: ${written.failure.reason} — the captures exist but the set does not.`,
+				enumerated,
+			);
+		}
+		return answer(document, enumerated);
+	});

--- a/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/render-verb.unit.test.ts
@@ -1,0 +1,207 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	INVALID_CAPTURE,
+	NO_PREVIEW,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	RENDER_CRASHED,
+	STALE_TREE,
+	SURFACE_UNREACHABLE,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {parseManifest} from "./manifest.ts";
+import {type RenderLeg, runRender, type SurfaceRender} from "./render-verb.ts";
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const PREVIEW = "https://pr-4321-web.example.test";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+
+const pull = (state = "open", head = HEAD): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4321,
+			state,
+			head: {sha: head},
+			base: {ref: "main"},
+			body: "",
+			changed_files: 2,
+			comments: 1,
+		}),
+	);
+
+const announcement = (sha: string = HEAD.slice(0, 7)): ExecResult =>
+	okOut(
+		JSON.stringify([
+			{
+				id: 7,
+				user: {login: "kampus-bot"},
+				created_at: "2026-08-09T00:00:00Z",
+				updated_at: "2026-08-09T00:00:00Z",
+				body: `<!-- preview-deploy:web -->\n- **web** — Stage \`pr-4321\` → ${PREVIEW} <sub>(${sha})</sub>`,
+			},
+		]),
+	);
+
+const rendered = (surface: string, outDir: string): SurfaceRender => ({
+	_tag: "Rendered",
+	entry: {
+		surface,
+		path: `${outDir}/${surface.replace(/^\//, "")}.png`,
+		width: 1280,
+		height: 2140,
+		sha256: "9c41",
+		pageErrors: [],
+	},
+});
+
+/** A leg that answers per surface, so a mixed set is as expressible as a clean one. */
+const legOf =
+	(answers: Readonly<Record<string, SurfaceRender>>): RenderLeg =>
+	(request) =>
+		Effect.succeed(answers[request.surface] ?? rendered(request.surface, request.outDir));
+
+const options = {
+	pr: 4321,
+	out: "judged",
+	surfaces: ["/pano"],
+	app: null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	tmpRoot: "/tmp",
+	render: legOf({}),
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const fs = fakeFs({});
+	return Effect.runPromise(
+		Effect.provide(
+			runRender({...options, ...overrides}),
+			Layer.merge(fakeShell(script).layer, fs.layer),
+		),
+	).then((outcome) => ({outcome, written: fs.written}));
+};
+
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull()],
+	[COMMENTS, announcement()],
+];
+
+describe("runRender", () => {
+	it("captures the surface, prints the manifest, and writes the same bytes to the set", async () => {
+		const {outcome, written} = await run(happy());
+		expect(outcome.code).toBe(0);
+		const manifest = parseManifest(outcome.stdout);
+		expect(manifest._tag).toBe("Manifest");
+		expect(written.get("/tmp/fabrika-review-ui/4321-03135b91/judged/manifest.json")).toBe(
+			outcome.stdout.trimEnd(),
+		);
+	});
+
+	it("enumerates every surface's outcome on stderr, success included", async () => {
+		const {outcome} = await run(happy(), {surfaces: ["/pano", "/pano/yeni"]});
+		expect(outcome.code).toBe(0);
+		expect(outcome.stderr.filter((line) => line.includes("captured:"))).toHaveLength(2);
+	});
+
+	it("refuses zero surfaces — `rendered nothing, found nothing wrong` is not an answer", async () => {
+		const {outcome} = await run(happy(), {surfaces: []});
+		expect(outcome.code).toBe(1);
+	});
+
+	it("refuses a non-kebab --out and a reserved :state suffix on 10", async () => {
+		expect((await run(happy(), {out: "Judged"})).outcome.code).toBe(OFF_VOCABULARY);
+		expect((await run(happy(), {surfaces: ["/pano:empty"]})).outcome.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses a closed PR on 7 — a closed PR is provably not reviewable scope", async () => {
+		const {outcome} = await run([
+			[PULL, pull("closed")],
+			[COMMENTS, announcement()],
+		]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("proves CANT-SEE (16) only when no comment carries the preview anchor", async () => {
+		const none = okOut(
+			JSON.stringify([
+				{id: 1, user: {login: "x"}, created_at: "", updated_at: "", body: "looks fine"},
+			]),
+		);
+		const {outcome} = await run([
+			[PULL, pull()],
+			[COMMENTS, none],
+		]);
+		expect(outcome.code).toBe(NO_PREVIEW);
+	});
+
+	it("calls a malformed announcement UNKNOWN (11), never absent", async () => {
+		const malformed = okOut(
+			JSON.stringify([
+				{
+					id: 1,
+					user: {login: "x"},
+					created_at: "",
+					updated_at: "",
+					body: "<!-- preview-deploy:web -->\n- **web** — the deploy failed",
+				},
+			]),
+		);
+		const {outcome} = await run([
+			[PULL, pull()],
+			[COMMENTS, malformed],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a preview that lags the live head on 12 — old pixels never bind a new head", async () => {
+		const {outcome} = await run([
+			[PULL, pull()],
+			[COMMENTS, announcement("0b1c2d3")],
+		]);
+		expect(outcome.code).toBe(STALE_TREE);
+		expect(outcome.stderr.at(-1)).toMatch(/stale preview/);
+	});
+
+	it("routes mixed outcomes by the smallest applicable code, enumerating all of them", async () => {
+		const {outcome} = await run(happy(), {
+			surfaces: ["/a", "/b", "/c"],
+			render: legOf({
+				"/a": {_tag: "Unreachable", reason: "status 404"},
+				"/b": {_tag: "Crashed", firstError: "TypeError: x is null"},
+				"/c": {_tag: "Invalid", detail: "zero bytes"},
+			}),
+		});
+		expect(outcome.code).toBe(RENDER_CRASHED);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.some((line) => line.includes("unreachable"))).toBe(true);
+		expect(outcome.stderr.some((line) => line.includes("invalid bytes"))).toBe(true);
+		// The refusal names a surface the ROUTED code applies to, not merely the first bad one.
+		expect(outcome.stderr.at(-1)).toMatch(/surface "\/b" threw during render/);
+	});
+
+	it("seats an unreachable-only set on 14 and an invalid-only set on 15", async () => {
+		const unreachable = await run(happy(), {
+			render: legOf({"/pano": {_tag: "Unreachable", reason: "status 404"}}),
+		});
+		expect(unreachable.outcome.code).toBe(SURFACE_UNREACHABLE);
+		const invalid = await run(happy(), {
+			render: legOf({"/pano": {_tag: "Invalid", detail: "zero bytes"}}),
+		});
+		expect(invalid.outcome.code).toBe(INVALID_CAPTURE);
+	});
+
+	it("keeps a render that never became answerable UNKNOWN (11), not a bad render", async () => {
+		const {outcome} = await run(happy(), {
+			render: legOf({"/pano": {_tag: "Failed", reason: "the browser provision is broken"}}),
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/review-ui/upload-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/upload-leg.ts
@@ -1,0 +1,89 @@
+/**
+ * The production {@link UploadLeg}: upload one capture to the GitHub user-attachment tier and
+ * **probe the result back** before calling it evidence.
+ *
+ * The upload itself is the capture module's `uploadAsset`, imported — what this file adds is the
+ * half that module deliberately does not have. Its error channel is `never` by contract, because
+ * for the v1 gate hosting was display-only; here the hosted URL is a precondition of the verdict,
+ * so an unverified URL is a failure rather than a decoration (#3925).
+ *
+ * The probe is a real fetch of the returned URL. A 2xx is the only outcome that makes the upload
+ * evidence a human can open; everything else — a non-2xx, a transport fault — is `Failed` and the
+ * caller refuses on `17` with nothing posted.
+ */
+import {Effect} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import {uploadAsset} from "../capture/upload.ts";
+import {execCapture} from "../io/exec.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+import type {UploadLeg, UploadResult} from "./post-verb.ts";
+
+/** The repo's numeric id, which the undocumented attachment endpoint requires (404 without it). */
+const repositoryId = (repo: string) =>
+	Effect.gen(function* () {
+		const result = yield* execCapture("gh", ["api", `repos/${repo}`]);
+		if (!result.ok) return null;
+		const parsed = parseJson(result.stdout);
+		return isRecord(parsed) && typeof parsed.id === "number" ? parsed.id : null;
+	});
+
+/** The token the endpoint authenticates with — the env first, else whatever `gh` is logged in as. */
+const uploadToken = (env: Readonly<Record<string, string | undefined>>) =>
+	Effect.gen(function* () {
+		const fromEnv = env.GITHUB_TOKEN ?? env.GH_TOKEN ?? "";
+		if (fromEnv.trim() !== "") return fromEnv.trim();
+		const result = yield* execCapture("gh", ["auth", "token"]);
+		const token = result.stdout.trim();
+		return result.ok && token !== "" ? token : null;
+	});
+
+const verify = (url: string): Effect.Effect<string | null> =>
+	HttpClient.execute(HttpClientRequest.get(url)).pipe(
+		Effect.map((response) =>
+			response.status >= 200 && response.status < 400
+				? null
+				: `the hosted asset probed back HTTP ${response.status}`,
+		),
+		Effect.catch((error: unknown) =>
+			Effect.succeed(`the hosted asset could not be probed back: ${String(error)}`),
+		),
+		Effect.provide(FetchHttpClient.layer),
+	);
+
+export const githubAttachmentUploadLeg = (
+	env: Readonly<Record<string, string | undefined>>,
+): UploadLeg =>
+	Effect.fn(function* (request) {
+		const id = yield* repositoryId(request.repo);
+		if (id === null) {
+			return {
+				_tag: "Failed",
+				reason: `cannot resolve ${request.repo}'s numeric id`,
+			} as UploadResult;
+		}
+		const token = yield* uploadToken(env);
+		if (token === null) {
+			return {
+				_tag: "Failed",
+				reason: "no upload token — set GITHUB_TOKEN or log in with `gh auth login`",
+			} as UploadResult;
+		}
+		const outcome = yield* uploadAsset({
+			pngBytes: request.bytes,
+			repositoryId: id,
+			token,
+			fileName: request.fileName,
+		}).pipe(Effect.provide(FetchHttpClient.layer));
+		if (outcome.hostedUrl === null) {
+			return {
+				_tag: "Failed",
+				reason: outcome.uploadError ?? "the upload returned no hosted URL",
+			} as UploadResult;
+		}
+		const unverified = yield* verify(outcome.hostedUrl);
+		return unverified === null
+			? ({_tag: "Hosted", url: outcome.hostedUrl} as UploadResult)
+			: ({_tag: "Failed", reason: unverified} as UploadResult);
+	});


### PR DESCRIPTION
The `review-ui` skill shipped with a contract for three commands that did not exist, so any agent following it hit a command-not-found wall. This adds them. `review-ui render` screenshots the surfaces a reviewer names off the PR's preview deploy, `review-ui post` uploads that evidence and posts the one head-bound verdict comment, and `review-ui note` is the plain "I cannot see this PR" write that is structurally not a verdict.

The rule the group is built around: a verdict never lands over evidence nobody can see. Uploads are verified one by one *before* anything is posted, and a single failure means nothing is posted at all.

Fixes #5071

## What changed

- **`packages/fabrika-cli/src/review-ui/`** — the new group. `codes.ts` (nine seats shared with the `report` base by import, `12`–`17` its own), `target`-free thin verbs over the generic guards the `review` group already parameterized, plus `manifest.ts` (the capture set's on-disk contract), `preview.ts` (which announcement, which app), and the two injected legs (`render-leg.ts`, `upload-leg.ts`) that keep every refusal testable without a browser or the network.
- **`registry.ts`** — the group is registered, so it appears in the derived `fabrika --help` index.
- **`exit-code-alignment.ts`** — `review-ui` registers in `ALIGNED_GROUPS` against `report` with `REVIEW_UI_SEATS` (the eight shared meanings plus `4` under this group's own name, the whole-file rule).
- **`packages/fabrika-cli/src/capture/`** — extended, not duplicated: `readPreviewAnnouncement` now yields the deployed head SHA and is domain-agnostic, `png.ts` is the header-only capture-validity check, and `CapturedSurface` carries the navigation status so "unreachable" is a proven outcome rather than pixels of an error page.
- **Tests** — 46 unit tests in the group's own directory, in the `build`/`review` shape.

## Acceptance criteria

- [x] The group is registered and appears in `fabrika --help`.
- [x] All three verbs exist; every enumerated non-zero exit is reachable at its stated trigger, one JSON object on stdout, refusals on stderr.
- [x] `review-ui` is in `ALIGNED_GROUPS` against `report`; `12`–`17` live in the group's own table.
- [x] Rendering, capture validation and preview resolution are imported from the fabrika-owned capture module. (Golden resolution and raster diffing are not reimplemented either — these three verbs do not read goldens; that is `ui golden`'s, which the skill calls.)
- [x] `review-ui post` posts nothing when an upload or its verification fails (`17`), and reads its comment back from live PR state.
- [x] `review-ui note` refuses a marker-shaped or advisory-shaped first line on `10`.
- [x] The `verdict-marker` namespace question is settled: **no change is owed.** `packages/fabrika-cli/src/wire/verdict-marker.ts` gates the namespace with the pattern `^(review|check-epic-plan)(-[a-z0-9]+)*$`, not a closed vocabulary, and `review-ui` already satisfies it. `src/review-ui/namespace.unit.test.ts` pins that, so a future narrowing reds instead of silently making this group's verdicts unreadable.
- [x] Unit tests sit in the group's own directory.

## Deviations

**1 · Scope — shared surface touched (class: touched a file outside the named area).**
Said: implement the review-ui verbs in the review-side area. Did: also extended `packages/fabrika-cli/src/capture/` — added `png.ts`, added the announcement reader to `resolve.ts`, and added an optional `status` field to `CapturedSurface`. Why: the AC forbids reimplementing rendering and capture validation inside the group, and the shipped resolver read no deployed SHA and hardcoded the `workers.dev` domain, so the contract's head-binding refusal was not expressible. Every change is additive — `resolvePreviewUrl` is untouched and its tests still pass. Disposition: for the reviewer to judge; a sibling lane is implementing the `build-ui` `ui` group over the same capture module, so this is the one file set both lanes could meet on.

**2 · Narrowed the fix-shape (class: narrowed a suggested shape).**
Said: `review-ui post` uploads through the two-tier store — a repo-declared store when there is one, the GitHub attachment tier otherwise. Did: the attachment tier is wired; a `design-harness.json` that *declares* an `evidenceStore` refuses on `11` naming the missing leg, rather than uploading. Why: the store half is the consuming repo's injected `StoreLeg` by design (the capture module owns the shape, never the store), and this delivery layer wires none. Disposition: no repo in the tree declares one today, so the reachable path is the attachment tier; the refusal is loud rather than a silent fallback.

**3 · Cost accepted for per-surface outcomes (class: a judgment call the issue did not specify).**
Said: nothing. Did: `render` drives one `captureShots` call per surface — a browser launch per surface. Why: a single batched call fails the whole effect on the first bad shot, so a mixed set could report at most one surface's fate and the rest would go unenumerated, which is the "judged nothing, found nothing wrong" shape the contract exists to remove. Disposition: no action needed at 1–3 surfaces per run; noted so a future batching change knows what it must preserve.

**4 · Fixed a grammar the contract left open (class: a decision the spec did not make).**
Said: the preview comment "names, per app: the deployed URL and the deployed head SHA". Did: the SHA is read only in an anchored form — `(sha)` (what phoenix's own deploy comment upserts), `@ sha`, a backticked SHA, or `head sha`. Why: a bare hex-looking token is not safe to read as a SHA (ordinary words spell in hex — `defaced`), and a wrong SHA here binds pixels to a tree nobody deployed. Disposition: for the reviewer to judge; widening later is additive.

**5 · Did not carry a sibling's body line (class: declined an available mechanism).**
Said: the issue's design-input addendum requires a verdict resolver to order by recency explicitly. Did: the upsert picks the newest matching comment by the platform's own `updated_at`, and `review-ui post` writes **no** `Verdict-written:` stamp (the sibling `review post` does). Why: the contract specifies the composed comment exactly — first line, body, gallery — and a stamp line it does not name would be an undisclosed byte in a read-back-compared artifact; `updated_at` satisfies the recency rule without minting one. Disposition: for the reviewer to judge.

**6 · Added an injected seam to make the fix testable (class: a judgment call the verdict did not specify) — (repair round 1).**
Said: the gate's remedy was "classify on the `CaptureError` message in `render-leg.ts` … add a `render-leg.unit.test.ts`". Did: the classification is exactly that (an allow-list on the per-shot `failed to capture …` message, everything else falling to `Failed`/`11`), plus `captureRenderLeg` became `makeCaptureRenderLeg(capture = captureShots)` with the shipped binding unchanged. Why: the capture call was not injectable, so a test could only have re-injected a `SurfaceRender` — the very false confidence the verdict flagged. The package uses injected seams everywhere and mocks no modules, so this is the local idiom. Disposition: no behavior change; `captureRenderLeg` keeps its name, type and callers.

**7 · Correction to deviation 1 above (class: a disclosure that was imprecise) — (repair round 1).**
Deviation 1 said "`resolvePreviewUrl` is untouched". It was edited: its body was extracted into a new `appBlock` helper, behavior-identical, with its pre-existing tests unmodified and green. Recorded here rather than by rewriting the original entry, so the log stays a log. The verdict's other footnote is also accepted: the stated reason for omitting the `Verdict-written:` stamp (deviation 5) was wrong — a stamp would round-trip fine through `normalizeForReadback`. The real weakness is that the upsert picks by `updated_at`, which `src/review/write-recency.ts` documents as the wrong key. Not repaired in this round (the gate ruled it non-blocking and follow-up-worthy); disclosed so it is not lost.
