### PR TITLE
feat(fabrika): the ui verb group — manifest, law, render, golden, evidence (#5061)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -534,6 +534,49 @@ The core is [`src/spend/rollup.ts`](./src/spend/rollup.ts), pure and total: it s
 `readSpendLedger` result over a resolved window and groups it three ways.
 [`src/spend/rollup-verb.ts`](./src/spend/rollup-verb.ts) is the IO around it.
 
+## The `ui` group
+
+What the visual modality adds to a construction lane — the verbs
+[`build-ui`](../../claude-plugins/fabrika/skills/build-ui/SKILL.md) drives
+([#5061](https://github.com/kamp-us/phoenix/issues/5061), spec:
+[`contract.md`](../../claude-plugins/fabrika/skills/build-ui/contract.md)). The lane mechanics are
+the `build` group's, reused as-is; this group is only what rendering adds.
+
+```
+ui manifest                                   # the repo's design surfaces, by convention
+ui law                                        # the typed prohibition registry, schema-validated
+ui render --out after --surface /pano         # render + capture one validated PNG per surface
+ui golden --surface /pano [--candidate <png>]  # resolve the blessed golden, diff a candidate
+ui evidence --pr 4318 --before before --after after   # upload, verify, post, read back
+```
+
+Four things about it are load-bearing:
+
+- **A verb's ceiling is the golden diff.** No `ui` verb emits a PASS/FAIL token, a composition
+  score, or any judgement over pixels — the rendered-surface verdict is `review-ui`'s gate
+  ([#4718](https://github.com/kamp-us/phoenix/issues/4718)), and everything that *looks* at an image
+  is the skill's, not a verb's (founder ruling, 2026-08-09). `ui golden` measures; it never decides.
+- **Everything the group reads is a convention path in the repo it runs in** —
+  `design-system-manifest.md`, `design-prohibitions.json`, `design-harness.json`,
+  `packages/design-capture/golden-pointer.json` — never a hardcoded URL. That is what makes the
+  group portable: phoenix is one instance of a repo it reads, not the repo it knows.
+- **The headless browser is provisioned by installing the package.** `postinstall` runs
+  [`scripts/provision-browser.mjs`](./scripts/provision-browser.mjs), so no operator and no agent
+  ever runs a browser-install step by hand. It is best-effort and never fails the install; it skips
+  when the browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, when
+  `CI` is set (CI images bake their own), or on `FABRIKA_SKIP_BROWSER_PROVISION=1`. A run that then
+  finds no browser exits `11` **carrying the exact remediation command** — never a silent skip.
+- **Absence is answered three ways, never one.** A missing manifest is `12` (un-bootstrapped, route
+  to front-door), a missing registry is `13` (the law is untyped, prose is the source), and an
+  unreadable one is `11` (UNKNOWN) — the skill's prose fallback is legal only in the middle case.
+  The same split runs through `ui golden`: a pointer that could not be read is never an empty
+  blessed set ([#4501](https://github.com/kamp-us/phoenix/issues/4501)).
+
+`ui render` and `ui evidence` both guard the lane precondition (`18` proven-not-mine, `11`
+unreadable); `ui manifest`, `ui law` and `ui golden` are pure reads and take none. Evidence is
+all-or-nothing: one failed upload or upload-verification is `17` with **nothing posted**
+([#3925](https://github.com/kamp-us/phoenix/issues/3925)).
+
 ## The capture machinery
 
 Not a verb group — a **library subpath**, `@kampus/fabrika-cli/capture`. It is the
@@ -555,9 +598,9 @@ ships the machine, never a repo's goldens.
 Three consequences worth knowing before you install it:
 
 - **`@playwright/test` is a hard dependency**, inherited from the machinery, so a fabrika
-  install pulls it in even for a caller that never captures. The browser binary is still a
-  separate `playwright install chromium`, so the capture path fails loudly on a machine
-  without it rather than silently.
+  install pulls it in even for a caller that never captures. The browser binary rides the
+  install too — see [the `ui` group](#the-ui-group)'s provisioning note — and a run on a machine
+  where that did not complete fails loudly, with the remediation command, rather than silently.
 - **Storing golden bytes is an injected `StoreLeg`, not a dependency.** A repo's goldens live
   in its own asset store, so anything naming a host or a credential stayed with the consuming
   repo — phoenix keeps that half in `packages/design-capture/`. This package owns the shape and
@@ -567,8 +610,8 @@ Three consequences worth knowing before you install it:
   private.
 - **The capture bin is still phoenix's** — `node packages/design-capture/src/bin.ts capture …`,
   unchanged. It is a v1 caller, not the adopter-facing surface; the adopter-facing surface is the
-  `ui` verb group, which is [#5061](https://github.com/kamp-us/phoenix/issues/5061)'s work. This
-  move deliberately changed no behavior.
+  `ui` verb group ([#5061](https://github.com/kamp-us/phoenix/issues/5061)) — see
+  [the `ui` group](#the-ui-group). This move deliberately changed no behavior.
 
 ## Development
 

--- a/packages/fabrika-cli/package.json
+++ b/packages/fabrika-cli/package.json
@@ -20,7 +20,8 @@
 		"./package.json": "./package.json"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"scripts"
 	],
 	"engines": {
 		"node": ">=24"
@@ -46,6 +47,7 @@
 	},
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",
+		"postinstall": "node ./scripts/provision-browser.mjs",
 		"prepublishOnly": "pnpm run build",
 		"typecheck": "tsgo -p tsconfig.json",
 		"test": "vitest run",

--- a/packages/fabrika-cli/scripts/provision-browser.mjs
+++ b/packages/fabrika-cli/scripts/provision-browser.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Provision the headless browser `fabrika ui render` needs, **as part of installing the package**.
+ *
+ * The founder preference this encodes: default-available beats install-a-thing. No operator and no
+ * agent ever runs a separate browser-install step by hand, so it rides `postinstall` — which is the
+ * only moment that is guaranteed to happen once per install, for a workspace member and for an
+ * adopter's `pnpm add -g @kampus/fabrika-cli` alike.
+ *
+ * It is **best-effort by design and never fails the install.** A hard failure here would break
+ * `pnpm install` for everyone over a capability only one verb needs, and the run-time story is
+ * already fail-closed and actionable: `ui render` exits `11` naming the exact remediation command.
+ *
+ * Three skips, each a real provisioning state rather than a convenience:
+ *   - `FABRIKA_SKIP_BROWSER_PROVISION=1` — the explicit opt-out.
+ *   - `PLAYWRIGHT_BROWSERS_PATH` set — a managed/prebaked install already owns the browsers.
+ *   - `CI` set with no prebaked path — CI images bake their own browsers, and a ~130MB download in
+ *     every job of every workflow is a cost no job asked for. The run-time `11` covers the case
+ *     where a CI job really did need it.
+ */
+import {spawnSync} from "node:child_process";
+import {existsSync} from "node:fs";
+
+const skip = (reason) => {
+	process.stderr.write(`fabrika: skipping headless-browser provisioning — ${reason}.\n`);
+	process.exit(0);
+};
+
+if (process.env.FABRIKA_SKIP_BROWSER_PROVISION === "1") skip("FABRIKA_SKIP_BROWSER_PROVISION=1");
+if ((process.env.PLAYWRIGHT_BROWSERS_PATH ?? "") !== "")
+	skip("PLAYWRIGHT_BROWSERS_PATH names a managed install");
+if ((process.env.CI ?? "") !== "") skip("CI images prebake their browsers");
+
+let installed = false;
+try {
+	const {chromium} = await import("@playwright/test");
+	installed = existsSync(chromium.executablePath());
+} catch {
+	installed = false;
+}
+if (installed) skip("chromium is already provisioned");
+
+const result = spawnSync("pnpm", ["exec", "playwright", "install", "chromium"], {
+	stdio: "inherit",
+	timeout: 10 * 60 * 1000,
+});
+if (result.status !== 0) {
+	process.stderr.write(
+		"fabrika: headless-browser provisioning did not complete; `fabrika ui render` will refuse with exit 11 and the remediation command until it does.\n",
+	);
+}
+process.exit(0);

--- a/packages/fabrika-cli/src/build/scratch-verb.ts
+++ b/packages/fabrika-cli/src/build/scratch-verb.ts
@@ -21,6 +21,17 @@ import {resolveTargetRepo} from "./target.ts";
 
 const VERB = "build scratch";
 
+/**
+ * The lane's namespace, exported so a sibling group that writes into this lane's scratch derives the
+ * path rather than restating the formula — the `ui` group's capture sets land under it.
+ */
+export const laneScratchDir = (
+	tmpRoot: string,
+	session: string,
+	number: number,
+	nonce: string,
+): string => `${tmpRoot.replace(/\/+$/, "")}/fabrika-build/${session}/${number}-${nonce}`;
+
 export interface ScratchOptions {
 	readonly number: number;
 	readonly slug: string;
@@ -62,8 +73,7 @@ export const runScratch = (
 			);
 		}
 
-		const root = options.tmpRoot.replace(/\/+$/, "");
-		const dir = `${root}/fabrika-build/${session.id}/${number}-${nonce}`;
+		const dir = laneScratchDir(options.tmpRoot, session.id, number, nonce);
 		const fs = yield* FileSystem.FileSystem;
 		const made: string | null = yield* fs.makeDirectory(dir, {recursive: true}).pipe(
 			Effect.as(null),

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -74,6 +74,18 @@ export const BUILD_SEATS: SharedSeats = {...SHARED_SEATS, BAD_SECTIONS: "BAD_SEC
  */
 export const REVIEW_UI_SEATS: SharedSeats = {...SHARED_SEATS, MALFORMED_DOCUMENT: "BAD_SECTIONS"};
 
+/**
+ * `ui`'s seats: `build`'s nine minus the stdin seat.
+ *
+ * No `ui` verb reads stdin, and rather than seat a second meaning on `3` the group holds it empty as
+ * `DELIBERATE_GAP` — so the shared-seat map cannot claim it, and the private-code check reads `3` as
+ * occupied by the base alone.
+ */
+export const UI_SEATS: SharedSeats = (() => {
+	const {EMPTY_STDIN: _stdin, ...rest} = BUILD_SEATS;
+	return rest;
+})();
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	build: BUILD_SEATS,
@@ -83,6 +95,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	review: SHARED_SEATS,
 	"review-ui": REVIEW_UI_SEATS,
 	ship: SHARED_SEATS,
+	ui: UI_SEATS,
 };
 
 /**

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -16,6 +16,7 @@ import * as review from "./review/codes.ts";
 import * as reviewUi from "./review-ui/codes.ts";
 import * as ship from "./ship/codes.ts";
 import * as triage from "./triage/codes.ts";
+import * as ui from "./ui/codes.ts";
 import * as wire from "./wire/codes.ts";
 
 const SRC_DIR = fileURLToPath(new URL(".", import.meta.url));
@@ -34,6 +35,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	"review-ui": reviewUi,
 	ship,
 	triage,
+	ui,
 	wire,
 };
 

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -26,6 +26,7 @@ import {reviewUiCommand} from "./review-ui/command.ts";
 import {shipCommand} from "./ship/command.ts";
 import {spendCommand} from "./spend/command.ts";
 import {triageCommand} from "./triage/command.ts";
+import {uiCommand} from "./ui/command.ts";
 import {wireCommand} from "./wire/command.ts";
 
 /** A registered verb group: a top-level `Command` whose name is the `fabrika <name>` selector. */
@@ -44,5 +45,6 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	shipCommand,
 	spendCommand,
 	triageCommand,
+	uiCommand,
 	wireCommand,
 ];

--- a/packages/fabrika-cli/src/ui/browser.ts
+++ b/packages/fabrika-cli/src/ui/browser.ts
@@ -1,0 +1,97 @@
+/**
+ * The impure browser leg `ui render` injects: navigate one surface, classify what happened, and write
+ * the PNG. Thin by construction — every decision the exit matrix routes on is *typed here and judged
+ * in the verb*, so the whole render orchestration is unit-testable with a fake leg and no browser.
+ *
+ * The three classifications are the contract's, and each is a different fact: a status ≥ 400 or a
+ * navigation that threw is **unreachable** (`15` — no route, dark flag, gated tier), a runtime error
+ * thrown into the page is a **crashed** render (`14`, #2594's signal, read through the shared
+ * `../capture/page-errors.ts` predicate), and anything else that goes wrong leaves the capture
+ * **unknown** (`11`) rather than valid.
+ *
+ * A missing browser provision surfaces here as `Unknown` carrying the exact remediation command —
+ * never a silent skip, and never a "surface is fine" reading.
+ */
+import {mkdir, writeFile} from "node:fs/promises";
+import {dirname} from "node:path";
+import {type Browser, chromium} from "@playwright/test";
+import {Effect} from "effect";
+import {isRenderCrash, type PageError, toPageError} from "../capture/page-errors.ts";
+import {legFailed} from "./leg-failed.ts";
+import type {BrowseLeg, ShotOutcome, ShotRequest} from "./render-verb.ts";
+
+/** The one string an operator is ever asked to run — and only after a provisioning failure. */
+export const PROVISION_REMEDIATION = "pnpm exec playwright install chromium";
+
+const NAVIGATION_TIMEOUT_MS = 30_000;
+
+/** Settle a promise into its value or its failure, so no path here needs a `try`. */
+const attempt = <A>(promise: Promise<A>): Promise<A | Error> =>
+	promise.then(
+		(value) => value,
+		(cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause))),
+	);
+
+const isProvisionFailure = (message: string): boolean =>
+	message.includes("Executable doesn't exist") || message.includes("playwright install");
+
+const shoot = async (browser: Browser, request: ShotRequest): Promise<ShotOutcome> => {
+	const context = await attempt(browser.newContext({viewport: {...request.viewport}}));
+	if (context instanceof Error) return {_tag: "Unknown", reason: context.message};
+	const page = await attempt(context.newPage());
+	if (page instanceof Error) return {_tag: "Unknown", reason: page.message};
+
+	const pageErrors: PageError[] = [];
+	page.on("pageerror", (err) => pageErrors.push(toPageError("pageerror", String(err))));
+	page.on("console", (msg) => {
+		if (msg.type() === "error") pageErrors.push(toPageError("console.error", msg.text()));
+	});
+	const response = await attempt(
+		page.goto(request.url, {waitUntil: "networkidle", timeout: NAVIGATION_TIMEOUT_MS}),
+	);
+	if (response instanceof Error) {
+		await attempt(context.close());
+		return {_tag: "Unreachable", reason: `navigation failed: ${response.message}`};
+	}
+	const status = response?.status() ?? 0;
+	const crash = pageErrors.find(isRenderCrash);
+	const outcome = await (async (): Promise<ShotOutcome> => {
+		if (status === 0) return {_tag: "Unreachable", reason: "the navigation returned no response"};
+		if (status >= 400) return {_tag: "Unreachable", reason: `HTTP ${status}`};
+		if (crash !== undefined) return {_tag: "Crashed", error: crash.text};
+		const buffer = await attempt(page.screenshot({type: "png", fullPage: true}));
+		if (buffer instanceof Error) return {_tag: "Unknown", reason: buffer.message};
+		const written = await attempt(
+			mkdir(dirname(request.outPath), {recursive: true}).then(() =>
+				writeFile(request.outPath, buffer),
+			),
+		);
+		return written instanceof Error
+			? {_tag: "Unknown", reason: written.message}
+			: {_tag: "Captured"};
+	})();
+	await attempt(context.close());
+	return outcome;
+};
+
+/** Drive one page in a fresh context, and hand back the proven outcome. */
+export const playwrightBrowse: BrowseLeg = (request) =>
+	Effect.tryPromise({
+		try: async (): Promise<ShotOutcome> => {
+			const browser = await attempt(chromium.launch());
+			if (browser instanceof Error) {
+				return {
+					_tag: "Unknown",
+					reason: isProvisionFailure(browser.message)
+						? `the headless browser is not provisioned (${browser.message.split("\n")[0]}) — run \`${PROVISION_REMEDIATION}\``
+						: `chromium did not launch: ${browser.message}`,
+				};
+			}
+			const outcome = await shoot(browser, request);
+			await attempt(browser.close());
+			return outcome;
+		},
+		catch: legFailed,
+	}).pipe(
+		Effect.catch((cause) => Effect.succeed<ShotOutcome>({_tag: "Unknown", reason: cause.reason})),
+	);

--- a/packages/fabrika-cli/src/ui/bytes.ts
+++ b/packages/fabrika-cli/src/ui/bytes.ts
@@ -1,0 +1,38 @@
+/**
+ * Binary reads and writes through the `FileSystem` seam — PNGs, which `../io/fs.ts` has no shape for
+ * (it is UTF-8 text throughout). Same discipline: a read that could not be *performed* fails, so an
+ * unreadable capture is never indistinguishable from an empty one.
+ */
+import {Effect, FileSystem, Path} from "effect";
+
+export type ByteRead =
+	| {readonly _tag: "Bytes"; readonly bytes: Uint8Array}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+export const readBytes = (path: string): Effect.Effect<ByteRead, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		return {_tag: "Bytes" as const, bytes: yield* fs.readFile(path)};
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) =>
+			Effect.succeed<ByteRead>({_tag: "Failed", reason: cause.message}),
+		),
+	);
+
+export const writeBytes = (
+	path: string,
+	bytes: Uint8Array,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathService = yield* Path.Path;
+		yield* fs.makeDirectory(pathService.dirname(path), {recursive: true});
+		yield* fs.writeFile(path, bytes);
+		return null;
+	}).pipe(Effect.catchTag("PlatformError", (cause) => Effect.succeed(cause.message)));
+
+export const writeText = (
+	path: string,
+	text: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	writeBytes(path, new TextEncoder().encode(text));

--- a/packages/fabrika-cli/src/ui/codes.ts
+++ b/packages/fabrika-cli/src/ui/codes.ts
@@ -1,0 +1,76 @@
+/**
+ * The one exit table all five `ui` verbs allocate from, so a code means one thing across this group
+ * whichever verb produced it (`claude-plugins/fabrika/skills/build-ui/contract.md`).
+ *
+ * The overlap with `report` is **re-exported, never re-typed** — the discipline `build/codes.ts`
+ * states in full: an aligning group imports the base's constant, so a drift is unrepresentable
+ * rather than merely detectable. This group shares eight seats over `4`-`11` and adds `12`-`19` for
+ * facts about the visual modality — the manifest, the law, the render, the captures, and the lane.
+ *
+ * Seat `3` is the one seat this group deliberately leaves empty: no `ui` verb reads stdin, and an
+ * unused seat is cheaper than a second meaning on a shared number.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** The aligned stdin seat, held empty: no `ui` verb reads stdin, so nothing else may sit here. */
+export const DELIBERATE_GAP = REPORT_EMPTY_STDIN;
+
+/** A required section is missing, malformed, empty, or out of place — in a document a verb parses. */
+export const BAD_SECTIONS = REPORT_BAD_SECTIONS;
+/** The authored text carries a machine-local path, unredacted. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The authored text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/** Zero scope: the target is **proven** absent or closed, or there is nothing to judge. */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** A write was attempted and its outcome could not be proven — UNKNOWN, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed but the read-back does not match; the artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** A value off its closed vocabulary or naming grammar. A malformed *flag* stays `1`. */
+export const OFF_VOCABULARY = REPORT_CLASSIFIED;
+/**
+ * A required read or execution failed — no outcome is proven.
+ *
+ * A stated widening of the report seat, which covers precondition reads only: here it also seats a
+ * harness that never became ready and a capture whose validity could not be determined, because
+ * both leave the render UNKNOWN in exactly the way a failed read leaves a target UNKNOWN.
+ */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/** Proven: no design manifest at the convention path — the repo is un-bootstrapped (#4952). */
+export const NO_MANIFEST = 12;
+/** Proven: the manifest exists but no typed prohibition registry does — the law is untyped. */
+export const UNTYPED_LAW = 13;
+/** Proven: a surface rendered with an uncaught page error — the render is red. */
+export const RENDER_CRASHED = 14;
+/** Proven: a surface is unreachable — the route resolved to nothing this tree can render. */
+export const SURFACE_UNREACHABLE = 15;
+/** Proven: a capture was produced but is invalid — zero bytes, undecodable, or zero area. */
+export const CAPTURE_INVALID = 16;
+/** Proven: at least one evidence upload failed — nothing was posted. */
+export const UPLOAD_FAILED = 17;
+/**
+ * Proven: the lane precondition failed — this session does not hold the claim the checked-out lane
+ * branch names (foreign, none, or an unparseable branch).
+ *
+ * Deliberately `ui`-local rather than borrowing `build`'s `15`: the two groups' matrices diverge
+ * above `11` by the established doctrine, and folding this onto a `build` number would tie one
+ * group's seat allocation to the other's.
+ */
+export const LANE_NOT_MINE = 18;
+/** Proven: no render harness is declared — the repo cannot be rendered headlessly. */
+export const NO_HARNESS = 19;

--- a/packages/fabrika-cli/src/ui/command.ts
+++ b/packages/fabrika-cli/src/ui/command.ts
@@ -1,0 +1,182 @@
+/**
+ * The `ui` verb group — `fabrika ui <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), supplies the impure legs, runs the pure verb, and emits its
+ * outcome. Every decision lives in the `*-verb.ts` modules beside it, which is what makes each
+ * refusal testable without spawning a process or a browser.
+ *
+ * Every leaf is declared with `leafCommand`, never a bare `Command.make` — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ */
+import {tmpdir} from "node:os";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {playwrightBrowse} from "./browser.ts";
+import {runEvidence} from "./evidence-verb.ts";
+import {runGolden} from "./golden-verb.ts";
+import {fetchGolden, ghAttachmentUpload, storeUpload} from "./http.ts";
+import {runLaw} from "./law-verb.ts";
+import {runManifest} from "./manifest-verb.ts";
+import {runRender} from "./render-verb.ts";
+import {spawnHarness} from "./server.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const manifest = leafCommand(
+	"manifest",
+	{},
+	Effect.fn(function* () {
+		yield* emit(yield* runManifest());
+	}),
+).pipe(
+	Command.withDescription(
+		'Resolve this repo\'s design surfaces by convention — manifest, prohibition registry, component inventory, golden pointer, render harness — as presence and paths, never a judgment. Prints {"manifest","registry","inventory","goldenPointer","harness","lawSource"}, each path repo-root-relative or null, with lawSource "registry" or "manifest-prose". Exits 11 (the repo root or a convention path could not be probed — presence is UNKNOWN, never "absent"), 12 (proven: no design manifest — the repo is un-bootstrapped; route to front-door). Example: fabrika ui manifest',
+	),
+);
+
+const law = leafCommand(
+	"law",
+	{},
+	Effect.fn(function* () {
+		yield* emit(yield* runLaw());
+	}),
+).pipe(
+	Command.withDescription(
+		'The typed prohibition registry, schema-validated whole-file, rows in file order. Prints {"lawSource":"registry","rows":[…]}; there is no empty answer, because a law file that names no law is malformed rather than minimal. Exits 4 (the registry exists but violates the schema — missing/extra field, duplicate id, off-enum value, zero rows, unparseable JSON; the whole file is refused), 11 (the registry could not be read — the law is UNKNOWN, never "untyped"), 12 (proven: no design manifest), 13 (proven: manifest present, no registry — the law is untyped and the manifest\'s prose is the source). Example: fabrika ui law',
+	),
+);
+
+const render = leafCommand(
+	"render",
+	{
+		out: Flag.string("out").pipe(
+			Flag.withDescription("kebab-case capture-set name; captures land under the lane scratch dir"),
+		),
+		surface: Flag.string("surface").pipe(
+			Flag.atLeast(1),
+			Flag.withDescription(
+				"a surface id: a bare route (/pano), repeatable; at least one is required — no tool guesses surfaces from a diff",
+			),
+		),
+		firstRender: Flag.string("first-render").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"a listed surface that has no pre-change state; recorded as firstRender and exempted from before/after pairing",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({out, surface, firstRender, repo}) {
+		yield* emit(
+			yield* runRender({
+				out,
+				surfaces: surface,
+				firstRender,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+				startHarness: spawnHarness,
+				browse: playwrightBrowse,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Render the named surfaces in this tree and capture one VALIDATED PNG per surface, into <set>/ under the lane scratch dir, plus a <set>/manifest.json byte-identical to the stdout JSON. Prints {"set","captures":[{"surface","path","width","height","sha256","firstRender"}]} and exits 0 only when EVERY requested surface captured and validated. Emits no verdict, no score and no layout opinion. Exits 4 (design-harness.json violates its schema), 10 (--out is not kebab-case, or a --surface carries the reserved :state suffix), 11 (the harness never became ready, or a capture\'s validity could not be determined — UNKNOWN), 14 (proven: a surface threw during render), 15 (proven: a surface is unreachable), 16 (proven: a capture is invalid), 18 (proven: the lane precondition failed), 19 (proven: no design-harness.json). Example: fabrika ui render --out after --surface /pano',
+	),
+);
+
+const golden = leafCommand(
+	"golden",
+	{
+		surface: Flag.string("surface").pipe(
+			Flag.withDescription("the surface id whose blessed golden to resolve"),
+		),
+		candidate: Flag.string("candidate").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"a candidate PNG to diff against the golden; a relative path resolves against $FABRIKA_INVOCATION_DIR",
+			),
+		),
+	},
+	Effect.fn(function* ({surface, candidate}) {
+		yield* emit(
+			yield* runGolden({
+				surface,
+				candidate: Option.getOrNull(candidate),
+				env: process.env,
+				tmpRoot: tmpdir(),
+				fetch: fetchGolden,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Resolve a surface\'s blessed golden and diff a candidate against it — signal, never verdict. Prints {"surface","blessed","golden","diff"}; an unblessed surface is a FACT on exit 0, but only after a pointer read that succeeded. The diff is the contract\'s number: a pixel differs above a per-channel delta of 10, magnitude is differing/total rounded to 3 decimals, regions are 8-connected boxes merged under 16px, largest first, capped at 20; a dimension mismatch is {"magnitude":1,"regions":[],"dimensionMismatch":true}. Exits 4 (the pointer exists but does not parse — never read as an empty blessed set), 11 (the pointer read, the bytes fetch or their hash check failed — blessing is UNKNOWN), 16 (proven: the candidate is invalid). Example: fabrika ui golden --surface /pano --candidate /…/after/pano.png',
+	),
+);
+
+const evidence = leafCommand(
+	"evidence",
+	{
+		pr: Flag.integer("pr").pipe(
+			Flag.withDescription("the pull request the evidence comment posts to"),
+		),
+		before: Flag.string("before").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the before capture-set name; omit only when every after-surface is firstRender",
+			),
+		),
+		after: Flag.string("after").pipe(Flag.withDescription("the after capture-set name")),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr, before, after, repo}) {
+		yield* emit(
+			yield* runEvidence({
+				pr,
+				before: Option.getOrNull(before),
+				after,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+				storeUpload,
+				attachmentUpload: ghAttachmentUpload,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Upload the before/after captures, verify EVERY upload, post one head-SHA-bound PR comment, and read it back. Prints {"answer":"attached","pr","commentId","head","surfaces"}. Evidence is all-or-nothing: one failed upload or verification is 17 with nothing posted. Exits 4 (an after-surface has no before and no firstRender mark, a set is missing its manifest.json, or design-harness.json violates its schema), 5 (the comment carries a machine-local path), 6 (the comment is a bare @ path reference), 7 (the PR is proven absent, closed or merged), 8 (the post failed — it may or may not have landed), 9 (the comment landed but does not read back as sent), 11 (a precondition read failed — nothing was uploaded or posted), 16 (proven: a capture is invalid or no longer matches its manifest sha), 17 (proven: an upload or its verification failed), 18 (proven: the lane precondition failed). Example: fabrika ui evidence --pr 4318 --before before --after after',
+	),
+);
+
+export const uiCommand = Command.make("ui").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
+		manifest,
+		law,
+		render,
+		golden,
+		evidence,
+	]),
+	Command.withDescription(
+		"What the visual modality adds to a construction lane — resolve the design surfaces and the typed law, render and validate surface captures, diff them against the blessed goldens, and attach the evidence to the PR",
+	),
+);

--- a/packages/fabrika-cli/src/ui/conventions.ts
+++ b/packages/fabrika-cli/src/ui/conventions.ts
@@ -1,0 +1,25 @@
+/**
+ * Where a repo's design surfaces live — **filename conventions, not phoenix facts**.
+ *
+ * The portability ruling on #4941: this group reads whatever repo it runs in, and phoenix is one
+ * instance. v1 fetched the manifest from a hardcoded GitHub URL, which reads the wrong repo's law in
+ * any fork and nothing at all on a network fault; here the law is the tree's own bytes.
+ */
+
+/** The design manifest — the one surface whose absence refuses (`12`). */
+export const MANIFEST_PATH = "design-system-manifest.md";
+/** The typed prohibition registry; absent means the law is untyped (`13`), never an error. */
+export const REGISTRY_PATH = "design-prohibitions.json";
+/** The component inventory; absent is a fact reported as `null`. */
+export const INVENTORY_PATH = "design-system-inventory.md";
+/** The render harness config; absent means this repo declares no headless render path (`19`). */
+export const HARNESS_PATH = "design-harness.json";
+/** The golden pointer, in probe order: the package-local file first, the root fallback second. */
+export const GOLDEN_POINTER_PATHS: ReadonlyArray<string> = [
+	"packages/design-capture/golden-pointer.json",
+	"design-goldens.json",
+];
+
+/** Join a repo-root-relative convention path onto the resolved root. */
+export const atRoot = (root: string, relative: string): string =>
+	`${root.replace(/\/+$/, "")}/${relative}`;

--- a/packages/fabrika-cli/src/ui/diff.ts
+++ b/packages/fabrika-cli/src/ui/diff.ts
@@ -1,0 +1,166 @@
+/**
+ * The candidate-vs-golden raster diff, defined so two implementers compute **one number**.
+ *
+ * Every constant here is the contract's, not a taste call: a pixel differs when the max absolute
+ * per-channel RGBA delta exceeds {@link CHANNEL_THRESHOLD}; `magnitude` is differing pixels over
+ * total pixels rounded to three decimals; regions are the bounding boxes of 8-connected components,
+ * merged when they sit within {@link MERGE_DISTANCE}, largest area first, capped at {@link REGION_CAP}.
+ *
+ * It computes a number and nothing else — see `./golden-verb.ts` for why that is the ceiling.
+ *
+ * The sibling `../capture/golden-diff.ts` computes a *different* number for the review side — masks,
+ * 4-connectivity, an uncapped region list — so this is a second implementation on purpose rather
+ * than a reuse missed: the build-side numbers are pinned by this contract and may not drift with it.
+ */
+import type {RasterImage} from "./png.ts";
+
+/** A pixel differs when the max per-channel absolute delta exceeds this. */
+export const CHANNEL_THRESHOLD = 10;
+/** Boxes closer than this (in either axis) are one region. */
+export const MERGE_DISTANCE = 16;
+/** At most this many regions are reported; hitting the cap is stated on stderr. */
+export const REGION_CAP = 20;
+
+/** A differing region's bounding box, in the contract's `w`/`h` spelling. */
+export interface DiffBox {
+	readonly x: number;
+	readonly y: number;
+	readonly w: number;
+	readonly h: number;
+}
+
+/** The diff object exactly as it appears in a `ui golden` answer. */
+export type UiDiff =
+	| {readonly magnitude: number; readonly regions: ReadonlyArray<DiffBox>}
+	| {
+			readonly magnitude: 1;
+			readonly regions: ReadonlyArray<never>;
+			readonly dimensionMismatch: true;
+	  };
+
+export interface DiffOutcome {
+	readonly diff: UiDiff;
+	/** Whether the region list was truncated at {@link REGION_CAP}. */
+	readonly capped: boolean;
+	/** Regions found before the cap — what the stderr note reports. */
+	readonly found: number;
+}
+
+const gap = (aLow: number, aHigh: number, bLow: number, bHigh: number): number =>
+	aHigh < bLow ? bLow - aHigh : bHigh < aLow ? aLow - bHigh : 0;
+
+const touching = (a: DiffBox, b: DiffBox): boolean =>
+	gap(a.x, a.x + a.w - 1, b.x, b.x + b.w - 1) <= MERGE_DISTANCE &&
+	gap(a.y, a.y + a.h - 1, b.y, b.y + b.h - 1) <= MERGE_DISTANCE;
+
+const union = (a: DiffBox, b: DiffBox): DiffBox => {
+	const x = Math.min(a.x, b.x);
+	const y = Math.min(a.y, b.y);
+	return {
+		x,
+		y,
+		w: Math.max(a.x + a.w, b.x + b.w) - x,
+		h: Math.max(a.y + a.h, b.y + b.h) - y,
+	};
+};
+
+/** Merge to a fixpoint: a merge can bring two previously-distant boxes within range. */
+export const mergeBoxes = (boxes: ReadonlyArray<DiffBox>): ReadonlyArray<DiffBox> => {
+	const merged: DiffBox[] = [...boxes];
+	let changed = true;
+	while (changed) {
+		changed = false;
+		outer: for (let i = 0; i < merged.length; i++) {
+			for (let j = i + 1; j < merged.length; j++) {
+				const a = merged[i] as DiffBox;
+				const b = merged[j] as DiffBox;
+				if (!touching(a, b)) continue;
+				merged.splice(j, 1);
+				merged[i] = union(a, b);
+				changed = true;
+				break outer;
+			}
+		}
+	}
+	return merged;
+};
+
+/** 8-connected components of the differing-pixel mask, as bounding boxes. */
+const components = (width: number, height: number, differs: Uint8Array): DiffBox[] => {
+	const visited = new Uint8Array(width * height);
+	const boxes: DiffBox[] = [];
+	const stack: number[] = [];
+	for (let start = 0; start < differs.length; start++) {
+		if (differs[start] === 0 || visited[start] === 1) continue;
+		let minX = width;
+		let minY = height;
+		let maxX = -1;
+		let maxY = -1;
+		stack.push(start);
+		visited[start] = 1;
+		while (stack.length > 0) {
+			const idx = stack.pop() as number;
+			const x = idx % width;
+			const y = (idx - x) / width;
+			if (x < minX) minX = x;
+			if (x > maxX) maxX = x;
+			if (y < minY) minY = y;
+			if (y > maxY) maxY = y;
+			for (let dy = -1; dy <= 1; dy++) {
+				for (let dx = -1; dx <= 1; dx++) {
+					const nx = x + dx;
+					const ny = y + dy;
+					if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+					const n = ny * width + nx;
+					if (differs[n] === 1 && visited[n] === 0) {
+						visited[n] = 1;
+						stack.push(n);
+					}
+				}
+			}
+		}
+		boxes.push({x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY + 1});
+	}
+	return boxes;
+};
+
+/**
+ * Compute the contract's diff. A dimension mismatch short-circuits to maximal signal — the only
+ * honest comparison when the grids do not align — and is the **one** shape carrying
+ * `dimensionMismatch`, so its presence is a reliable discriminator rather than a flag to test.
+ */
+export const diffAgainstGolden = (golden: RasterImage, candidate: RasterImage): DiffOutcome => {
+	if (golden.width !== candidate.width || golden.height !== candidate.height) {
+		return {
+			diff: {magnitude: 1, regions: [], dimensionMismatch: true},
+			capped: false,
+			found: 0,
+		};
+	}
+	const {width, height} = candidate;
+	const differs = new Uint8Array(width * height);
+	let count = 0;
+	for (let p = 0; p < width * height; p++) {
+		const o = p * 4;
+		const dr = Math.abs((golden.pixels[o] as number) - (candidate.pixels[o] as number));
+		const dg = Math.abs((golden.pixels[o + 1] as number) - (candidate.pixels[o + 1] as number));
+		const db = Math.abs((golden.pixels[o + 2] as number) - (candidate.pixels[o + 2] as number));
+		const da = Math.abs((golden.pixels[o + 3] as number) - (candidate.pixels[o + 3] as number));
+		if (Math.max(dr, dg, db, da) > CHANNEL_THRESHOLD) {
+			differs[p] = 1;
+			count++;
+		}
+	}
+	const total = width * height;
+	const regions = [...mergeBoxes(components(width, height, differs))].sort(
+		(a, b) => b.w * b.h - a.w * a.h,
+	);
+	return {
+		diff: {
+			magnitude: Math.round((count / total) * 1000) / 1000,
+			regions: regions.slice(0, REGION_CAP),
+		},
+		capped: regions.length > REGION_CAP,
+		found: regions.length,
+	};
+};

--- a/packages/fabrika-cli/src/ui/diff.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/diff.unit.test.ts
@@ -1,0 +1,111 @@
+import {describe, expect, it} from "vitest";
+import {CHANNEL_THRESHOLD, diffAgainstGolden, mergeBoxes, REGION_CAP} from "./diff.ts";
+import {solid} from "./fakes.test-support.ts";
+import type {RasterImage} from "./png.ts";
+
+const image = (width: number, height: number, pixels: Uint8Array): RasterImage => ({
+	width,
+	height,
+	pixels,
+});
+
+const withPixel = (
+	width: number,
+	height: number,
+	at: ReadonlyArray<readonly [number, number]>,
+	rgba: readonly [number, number, number, number],
+): Uint8Array => {
+	const pixels = solid(width, height, [0, 0, 0, 255]);
+	for (const [x, y] of at) pixels.set(rgba, (y * width + x) * 4);
+	return pixels;
+};
+
+describe("diffAgainstGolden", () => {
+	it("reports a dimension mismatch as maximal signal, and ONLY that shape carries the key", () => {
+		const diff = diffAgainstGolden(
+			image(2, 2, solid(2, 2, [0, 0, 0, 255])),
+			image(2, 3, solid(2, 3, [0, 0, 0, 255])),
+		).diff;
+		expect(diff).toEqual({magnitude: 1, regions: [], dimensionMismatch: true});
+		const matched = diffAgainstGolden(
+			image(2, 2, solid(2, 2, [0, 0, 0, 255])),
+			image(2, 2, solid(2, 2, [0, 0, 0, 255])),
+		).diff;
+		expect("dimensionMismatch" in matched).toBe(false);
+	});
+
+	it(`ignores a per-channel delta of exactly ${CHANNEL_THRESHOLD} and counts one above it`, () => {
+		const golden = image(2, 1, solid(2, 1, [0, 0, 0, 255]));
+		const atThreshold = image(2, 1, withPixel(2, 1, [[0, 0]], [CHANNEL_THRESHOLD, 0, 0, 255]));
+		const above = image(2, 1, withPixel(2, 1, [[0, 0]], [CHANNEL_THRESHOLD + 1, 0, 0, 255]));
+		expect(diffAgainstGolden(golden, atThreshold).diff.magnitude).toBe(0);
+		expect(diffAgainstGolden(golden, above).diff.magnitude).toBe(0.5);
+	});
+
+	it("rounds magnitude to three decimals", () => {
+		const golden = image(3, 1, solid(3, 1, [0, 0, 0, 255]));
+		const candidate = image(3, 1, withPixel(3, 1, [[0, 0]], [255, 255, 255, 255]));
+		expect(diffAgainstGolden(golden, candidate).diff.magnitude).toBe(0.333);
+	});
+
+	it("merges 8-connected differing pixels into one box, largest area first", () => {
+		const golden = image(4, 4, solid(4, 4, [0, 0, 0, 255]));
+		const candidate = image(
+			4,
+			4,
+			withPixel(
+				4,
+				4,
+				[
+					[0, 0],
+					[1, 1],
+				],
+				[255, 255, 255, 255],
+			),
+		);
+		expect(diffAgainstGolden(golden, candidate).diff.regions).toEqual([{x: 0, y: 0, w: 2, h: 2}]);
+	});
+});
+
+describe("mergeBoxes", () => {
+	it("merges boxes within 16px and leaves distant ones alone", () => {
+		expect(
+			mergeBoxes([
+				{x: 0, y: 0, w: 10, h: 10},
+				{x: 20, y: 0, w: 10, h: 10},
+			]),
+		).toEqual([{x: 0, y: 0, w: 30, h: 10}]);
+		expect(
+			mergeBoxes([
+				{x: 0, y: 0, w: 10, h: 10},
+				{x: 40, y: 0, w: 10, h: 10},
+			]),
+		).toHaveLength(2);
+	});
+
+	it("merges to a fixpoint — a merge can bring two previously-distant boxes into range", () => {
+		expect(
+			mergeBoxes([
+				{x: 0, y: 0, w: 10, h: 10},
+				{x: 60, y: 0, w: 10, h: 10},
+				{x: 25, y: 0, w: 20, h: 10},
+			]),
+		).toEqual([{x: 0, y: 0, w: 70, h: 10}]);
+	});
+});
+
+describe("the region cap", () => {
+	it(`truncates at ${REGION_CAP} regions and reports how many were found`, () => {
+		// One differing pixel every 32px: further apart than the 16px merge distance, so each stays
+		// its own region and the count crosses the cap.
+		const spots = Array.from({length: REGION_CAP + 1}, (_, i) => [i * 32, 0] as const);
+		const width = (REGION_CAP + 1) * 32;
+		const outcome = diffAgainstGolden(
+			image(width, 1, solid(width, 1, [0, 0, 0, 255])),
+			image(width, 1, withPixel(width, 1, spots, [255, 255, 255, 255])),
+		);
+		expect(outcome.found).toBe(REGION_CAP + 1);
+		expect(outcome.capped).toBe(true);
+		expect(outcome.diff.regions).toHaveLength(REGION_CAP);
+	});
+});

--- a/packages/fabrika-cli/src/ui/evidence-verb.ts
+++ b/packages/fabrika-cli/src/ui/evidence-verb.ts
@@ -1,0 +1,374 @@
+/**
+ * `ui evidence` — upload the before/after captures, verify every upload, post one SHA-bound PR
+ * comment, and read it back.
+ *
+ * **Evidence is all-or-nothing.** A comment showing three of five surfaces reads as "this is what
+ * changed" and lies by omission, so a single failed upload or upload-verification is `17` with
+ * nothing posted. That is the one behavior this verb most exists to pin: the upstream capture-side
+ * upload channel is typed `never` and silently projects failures away (`../capture/upload.ts`), which
+ * ADR 0165 accepted for the *review* side's verdict — here, on the construction side, a failed upload
+ * is a refusal.
+ *
+ * The comment carries the PR's current head SHA in its text and a re-attach posts a **new** comment
+ * at the new head: comments are append-only evidence, never edited in place, because evidence at a
+ * stale head misleads (#4808's class).
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {requireSession} from "../build/claim.ts";
+import {contentOf, gate} from "../build/content-gate.ts";
+import {laneScratchDir} from "../build/scratch-verb.ts";
+import {resolveTargetRepo} from "../build/target.ts";
+import {createComment, currentBranch, getComment} from "../io/issues.ts";
+import {getPullRequest} from "../io/pulls.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {readBytes} from "./bytes.ts";
+import {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	CAPTURE_INVALID,
+	LANE_NOT_MINE,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	UPLOAD_FAILED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {atRoot, HARNESS_PATH} from "./conventions.ts";
+import {parseHarness} from "./harness.ts";
+import {requireUiLane} from "./lane.ts";
+import {probe} from "./manifest-verb.ts";
+import {decodePng, sha256Of} from "./png.ts";
+import {pullHeadRef} from "./pull-head.ts";
+import {pairSets, parseSetManifest, type SetCapture} from "./set-manifest.ts";
+
+const VERB = "ui evidence";
+
+export interface UploadTarget {
+	readonly surface: string;
+	readonly role: "before" | "after";
+	readonly fileName: string;
+	readonly sha256: string;
+	readonly bytes: Uint8Array;
+}
+
+export type Upload =
+	| {readonly _tag: "Ok"; readonly url: string}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+export type UploadLeg = (target: UploadTarget) => Effect.Effect<Upload>;
+
+export interface EvidenceOptions {
+	readonly pr: number;
+	readonly before: string | null;
+	readonly after: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly tmpRoot: string;
+	/** Content-addressed PUT + GET-back into the harness's declared store. */
+	readonly storeUpload: (store: string, target: UploadTarget) => Effect.Effect<Upload>;
+	/** GitHub's user-attachment endpoint plus a HEAD probe of every returned URL. */
+	readonly attachmentUpload: (repo: string, target: UploadTarget) => Effect.Effect<Upload>;
+}
+
+/** The posted markdown: one row per surface, before|after side by side, bound to the head SHA. */
+export const composeEvidence = (
+	pairs: ReadonlyArray<{
+		readonly surface: string;
+		readonly before: string | null;
+		readonly after: string;
+	}>,
+	head: string,
+): string => {
+	const rows = pairs.map(({surface, before, after}) =>
+		before === null
+			? `### \`${surface}\` — new surface\n\n![after](${after})`
+			: `### \`${surface}\`\n\n| before | after |\n| --- | --- |\n| ![before](${before}) | ![after](${after}) |`,
+	);
+	return [`**UI evidence** — rendered at head \`${head}\`.`, "", ...rows].join("\n");
+};
+
+const readCapture = (
+	capture: SetCapture,
+	set: string,
+): Effect.Effect<
+	| {readonly _tag: "Bytes"; readonly bytes: Uint8Array}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome},
+	never,
+	FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const read = yield* readBytes(capture.path);
+		if (read._tag === "Failed") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read capture "${capture.surface}" in set "${set}": ${read.reason} — nothing was uploaded or posted.`,
+				),
+			};
+		}
+		if (sha256Of(read.bytes) !== capture.sha256) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					CAPTURE_INVALID,
+					`${VERB}: capture "${capture.surface}" in set "${set}" is invalid (its bytes no longer hash to the manifest's sha256).`,
+				),
+			};
+		}
+		const image = decodePng(read.bytes);
+		return image._tag === "Invalid"
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						CAPTURE_INVALID,
+						`${VERB}: capture "${capture.surface}" in set "${set}" is invalid (${image.detail}).`,
+					),
+				}
+			: {_tag: "Bytes" as const, bytes: read.bytes};
+	});
+
+const readSet = (
+	dir: string,
+	set: string,
+): Effect.Effect<
+	| {readonly _tag: "Set"; readonly captures: ReadonlyArray<SetCapture>}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome},
+	never,
+	FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const manifest = yield* readBytes(`${dir}/manifest.json`);
+		if (manifest._tag === "Failed") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					BAD_SECTIONS,
+					`${VERB}: set "${set}" has no manifest.json — a set without its manifest is not a set; re-run ui render.`,
+				),
+			};
+		}
+		const parsed = parseSetManifest(new TextDecoder().decode(manifest.bytes));
+		return parsed._tag === "Violation"
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						BAD_SECTIONS,
+						`${VERB}: set "${set}"'s manifest.json is not a set manifest: ${parsed.violation}.`,
+					),
+				}
+			: {_tag: "Set" as const, captures: parsed.captures};
+	});
+
+export const runEvidence = (
+	options: EvidenceOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const lane = yield* requireUiLane(
+			VERB,
+			resolved.repo,
+			session.id,
+			(detail, number) =>
+				`${VERB}: this session does not hold the claim on ${number === null ? "the checked-out branch" : `#${number}`} (${detail}) — the lane is not yours.`,
+		);
+		if (lane._tag === "Refused") return lane.outcome;
+
+		const pull = yield* getPullRequest(resolved.repo, options.pr);
+		if (pull._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read PR #${options.pr}: ${pull.reason} — nothing was uploaded or posted.`,
+				lane.notes,
+			);
+		}
+		if (pull._tag === "Absent" || pull.value.state !== "open" || pull.value.merged) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: PR #${options.pr} is proven absent, closed, or merged.`,
+				lane.notes,
+			);
+		}
+		const branch = yield* currentBranch;
+		const headBranch = yield* pullHeadRef(resolved.repo, options.pr);
+		if (headBranch._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read PR #${options.pr}'s head branch: ${headBranch.reason} — nothing was uploaded or posted.`,
+				lane.notes,
+			);
+		}
+		if (headBranch.ref !== branch) {
+			return refuse(
+				LANE_NOT_MINE,
+				`${VERB}: this session does not hold the claim on #${options.pr} (PR #${options.pr} is on "${headBranch.ref}", not the checked-out "${branch ?? "detached HEAD"}") — the lane is not yours.`,
+				lane.notes,
+			);
+		}
+
+		const scratch = laneScratchDir(options.tmpRoot, session.id, lane.number, lane.nonce);
+		const after = yield* readSet(`${scratch}/${options.after}`, options.after);
+		if (after._tag === "Refused") return after.outcome;
+		let beforeCaptures: ReadonlyArray<SetCapture> = [];
+		if (options.before !== null) {
+			const before = yield* readSet(`${scratch}/${options.before}`, options.before);
+			if (before._tag === "Refused") return before.outcome;
+			beforeCaptures = before.captures;
+		}
+		const pairing = pairSets(beforeCaptures, after.captures);
+		if (pairing._tag === "Unexplained") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: after-surface "${pairing.surface}" has no before capture and no firstRender mark — an unexplained missing baseline is a hole in the evidence.`,
+				lane.notes,
+			);
+		}
+
+		const harnessProbe = yield* probe(lane.root, HARNESS_PATH);
+		if (harnessProbe._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot probe ${HARNESS_PATH}: ${harnessProbe.reason} — nothing was uploaded or posted.`,
+				lane.notes,
+			);
+		}
+		let store: string | null = null;
+		if (harnessProbe._tag === "Present") {
+			const raw = yield* readBytes(atRoot(lane.root, HARNESS_PATH));
+			if (raw._tag === "Failed") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read ${HARNESS_PATH}: ${raw.reason} — nothing was uploaded or posted.`,
+					lane.notes,
+				);
+			}
+			const harness = parseHarness(new TextDecoder().decode(raw.bytes));
+			if (harness._tag === "Violation") {
+				return refuse(
+					BAD_SECTIONS,
+					`${VERB}: ${HARNESS_PATH} exists but does not satisfy its schema: ${harness.violation}.`,
+					lane.notes,
+				);
+			}
+			store = harness.config.evidenceStore;
+		}
+
+		const targets: UploadTarget[] = [];
+		for (const pair of pairing.pairs) {
+			for (const [role, capture] of [
+				["before", pair.before],
+				["after", pair.after],
+			] as const) {
+				if (capture === null) continue;
+				const read = yield* readCapture(
+					capture,
+					role === "before" ? (options.before as string) : options.after,
+				);
+				if (read._tag === "Refused")
+					return {...read.outcome, stderr: [...lane.notes, ...read.outcome.stderr]};
+				targets.push({
+					surface: capture.surface,
+					role,
+					fileName: `${role}-${capture.surface.replace(/^\/+/, "").replace(/\//g, "-") || "root"}.png`,
+					sha256: capture.sha256,
+					bytes: read.bytes,
+				});
+			}
+		}
+
+		const uploads = new Map<string, string>();
+		const failures: string[] = [];
+		for (const target of targets) {
+			const outcome = yield* store === null
+				? options.attachmentUpload(resolved.repo, target)
+				: options.storeUpload(store, target);
+			if (outcome._tag === "Failed") {
+				failures.push(`${VERB}: ${target.role} capture of "${target.surface}": ${outcome.reason}`);
+			} else {
+				uploads.set(`${target.role}:${target.surface}`, outcome.url);
+			}
+		}
+		const firstFailure = failures[0];
+		if (firstFailure !== undefined) {
+			return refuse(
+				UPLOAD_FAILED,
+				`${VERB}: upload failed for ${failures.length} of ${targets.length} captures (${firstFailure}) — refusing to post partial evidence; a gallery missing its failures is #3925.`,
+				[...lane.notes, ...failures],
+			);
+		}
+
+		const head = pull.value.headSha;
+		const body = composeEvidence(
+			pairing.pairs.map((pair) => ({
+				surface: pair.surface,
+				before: pair.before === null ? null : (uploads.get(`before:${pair.surface}`) as string),
+				after: uploads.get(`after:${pair.surface}`) as string,
+			})),
+			head,
+		);
+		if (isBareAtReference(body)) {
+			return refuse(
+				BARE_AT_PATH,
+				`${VERB}: the composed comment is a bare @ path reference — write the evidence, not a pointer to it.`,
+				lane.notes,
+			);
+		}
+		const scan = scanBody(body);
+		const firstLeak = scan.leaks[0];
+		if (firstLeak !== undefined) {
+			return refuse(
+				LEAKED_PATH,
+				`${VERB}: the composed comment carries a machine-local path: ${firstLeak.text}.`,
+				[...lane.notes, ...renderLeaks(scan.leaks)],
+			);
+		}
+
+		const posted = yield* createComment(resolved.repo, options.pr, body);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the post failed: ${posted.reason} — it may or may not have landed; re-read the PR before re-running.`,
+				lane.notes,
+			);
+		}
+		const readback = yield* getComment(resolved.repo, posted.value.id);
+		if (readback._tag === "Failure") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the comment landed but does not read back as sent — it needs a human eye.`,
+				[...lane.notes, `${VERB}: the read-back itself failed: ${readback.reason}.`],
+			);
+		}
+		const seen = contentOf(gate("comment-body", `comment ${posted.value.id}`, readback.value));
+		if (normalizeForReadback(seen) !== normalizeForReadback(body)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the comment landed but does not read back as sent — it needs a human eye.`,
+				lane.notes,
+			);
+		}
+		return answer(
+			JSON.stringify({
+				answer: "attached",
+				pr: options.pr,
+				commentId: posted.value.id,
+				head,
+				surfaces: pairing.pairs.length,
+			}),
+			[
+				...lane.notes,
+				`${VERB}: uploaded ${targets.length} capture${targets.length === 1 ? "" : "s"} over ${pairing.pairs.length} surface${pairing.pairs.length === 1 ? "" : "s"}.`,
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
@@ -1,0 +1,298 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {
+	comments,
+	HEAD,
+	issue,
+	LANE_UUID,
+	LINKED,
+	marker,
+	NONCE,
+	pull,
+} from "../build/fixtures.test-support.ts";
+import {fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	BAD_SECTIONS,
+	LANE_NOT_MINE,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	UPLOAD_FAILED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	composeEvidence,
+	type EvidenceOptions,
+	runEvidence,
+	type Upload,
+	type UploadTarget,
+} from "./evidence-verb.ts";
+import {encodePng, type FakeBytesFsOptions, fakeBytesFs, solid} from "./fakes.test-support.ts";
+import {sha256Of} from "./png.ts";
+import {pairSets, parseSetManifest} from "./set-manifest.ts";
+
+const LANE = `build/4312-editor-focus-loss-${NONCE}`;
+const SCRATCH = `/tmp/fabrika-build/s-9f2e/4312-${NONCE}`;
+const PNG = encodePng(2, 2, solid(2, 2, [0, 0, 0, 255]));
+const SHA = sha256Of(PNG);
+
+const setManifest = (set: string, rows: ReadonlyArray<{surface: string; firstRender?: boolean}>) =>
+	JSON.stringify({
+		set,
+		captures: rows.map((row) => ({
+			surface: row.surface,
+			path: `${SCRATCH}/${set}/${row.surface.replace(/^\//, "")}.png`,
+			width: 2,
+			height: 2,
+			sha256: SHA,
+			firstRender: row.firstRender === true,
+		})),
+	});
+
+const files = (): Record<string, Uint8Array | string> => ({
+	[`${SCRATCH}/before/manifest.json`]: setManifest("before", [{surface: "/pano"}]),
+	[`${SCRATCH}/before/pano.png`]: PNG,
+	[`${SCRATCH}/after/manifest.json`]: setManifest("after", [{surface: "/pano"}]),
+	[`${SCRATCH}/after/pano.png`]: PNG,
+});
+
+const POSTED_ID = 512347;
+
+const script = (
+	overrides: ReadonlyArray<readonly [RegExp, ExecResult]> = [],
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	...overrides,
+	[/^git rev-parse --path-format=absolute/, LINKED],
+	[/^git rev-parse --abbrev-ref HEAD$/, okOut(`${LANE}\n`)],
+	[/^gh api repos\/o\/r\/issues\/4312$/, issue()],
+	[
+		/^gh api --paginate repos\/o\/r\/issues\/4312\/comments/,
+		comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
+	],
+	[/^gh api repos\/o\/r\/collaborators\/agent\/permission/, okOut("write\n")],
+	[/^gh api repos\/o\/r\/pulls\/4318 --jq \.head\.ref$/, okOut(`${LANE}\n`)],
+	[/^gh api repos\/o\/r\/pulls\/4318$/, pull({head: {sha: HEAD, ref: LANE}})],
+	[
+		/^gh api --method POST repos\/o\/r\/issues\/4318\/comments/,
+		okOut(
+			JSON.stringify({id: POSTED_ID, html_url: "https://github.com/o/r/pull/4318#issuecomment-1"}),
+		),
+	],
+];
+
+const uploads: Pick<EvidenceOptions, "storeUpload" | "attachmentUpload"> = {
+	storeUpload: (_store: string, target: UploadTarget): Effect.Effect<Upload> =>
+		Effect.succeed({_tag: "Ok", url: `https://depo.example/${target.role}${target.surface}.png`}),
+	attachmentUpload: (_repo: string, target: UploadTarget): Effect.Effect<Upload> =>
+		Effect.succeed({
+			_tag: "Ok",
+			url: `https://github.com/user-attachments/assets/${target.role}${target.surface}`,
+		}),
+};
+
+const options: EvidenceOptions = {
+	pr: 4318,
+	before: "before",
+	after: "after",
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"},
+	tmpRoot: "/tmp",
+	...uploads,
+};
+
+/** The read-back the happy path needs: the posted body, echoed. */
+const withReadback = (
+	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	body: () => string,
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[/^gh api repos\/o\/r\/issues\/comments\/512347$/, okOut(JSON.stringify({body: body()}))],
+	...rows,
+];
+
+const EXPECTED_BODY = composeEvidence(
+	[
+		{
+			surface: "/pano",
+			before: "https://github.com/user-attachments/assets/before/pano",
+			after: "https://github.com/user-attachments/assets/after/pano",
+		},
+	],
+	HEAD,
+);
+
+const run = (
+	rows: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	fs: FakeBytesFsOptions,
+	overrides: Partial<EvidenceOptions> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runEvidence({...options, ...overrides}),
+			Layer.merge(fakeShell(rows).layer, fakeBytesFs(fs).layer),
+		),
+	);
+
+describe("parseSetManifest", () => {
+	it("refuses a manifest that names zero captures", () => {
+		expect(parseSetManifest('{"set":"after","captures":[]}')).toEqual({
+			_tag: "Violation",
+			violation: "it names zero captures",
+		});
+	});
+});
+
+describe("pairSets", () => {
+	it("pairs by surface id and labels a firstRender surface as new", () => {
+		const before = [{surface: "/pano", path: "b", sha256: SHA, firstRender: false}];
+		const after = [
+			{surface: "/pano", path: "a", sha256: SHA, firstRender: false},
+			{surface: "/yeni", path: "y", sha256: SHA, firstRender: true},
+		];
+		const paired = pairSets(before, after);
+		expect(paired).toEqual({
+			_tag: "Pairs",
+			pairs: [
+				{surface: "/pano", before: before[0], after: after[0]},
+				{surface: "/yeni", before: null, after: after[1]},
+			],
+		});
+	});
+
+	it("refuses an after-surface with neither a before nor a firstRender mark", () => {
+		expect(pairSets([], [{surface: "/pano", path: "a", sha256: SHA, firstRender: false}])).toEqual({
+			_tag: "Unexplained",
+			surface: "/pano",
+		});
+	});
+});
+
+describe("runEvidence", () => {
+	it("uploads, posts one head-bound comment, and reads it back", async () => {
+		const outcome = await run(
+			withReadback(script(), () => EXPECTED_BODY),
+			{files: files()},
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "attached",
+			pr: 4318,
+			commentId: POSTED_ID,
+			head: HEAD,
+			surfaces: 1,
+		});
+		expect(EXPECTED_BODY).toContain(HEAD);
+	});
+
+	it("refuses on 17 with NOTHING posted when one upload fails", async () => {
+		const calls = fakeShell(withReadback(script(), () => EXPECTED_BODY));
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runEvidence({
+					...options,
+					attachmentUpload: (_repo, target) =>
+						Effect.succeed(
+							target.role === "before"
+								? {_tag: "Failed", reason: "HTTP 502"}
+								: {_tag: "Ok", url: "https://github.com/user-attachments/assets/x"},
+						),
+				}),
+				Layer.merge(calls.layer, fakeBytesFs({files: files()}).layer),
+			),
+		);
+		expect(outcome.code).toBe(UPLOAD_FAILED);
+		expect(outcome.stdout).toBe("");
+		expect(calls.calls.some((line) => line.includes("--method POST"))).toBe(false);
+	});
+
+	it("refuses an after-surface with no baseline on 4", async () => {
+		const outcome = await run(
+			script(),
+			{
+				files: {
+					[`${SCRATCH}/after/manifest.json`]: setManifest("after", [{surface: "/pano"}]),
+					[`${SCRATCH}/after/pano.png`]: PNG,
+				},
+			},
+			{before: null},
+		);
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stderr.at(-1)).toContain("an unexplained missing baseline");
+	});
+
+	it("refuses a set with no manifest.json on 4", async () => {
+		const outcome = await run(script(), {files: {}});
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stderr.at(-1)).toContain("a set without its manifest is not a set");
+	});
+
+	it("refuses a closed PR on 7", async () => {
+		const outcome = await run(
+			script([
+				[
+					/^gh api repos\/o\/r\/pulls\/4318$/,
+					pull({state: "closed", head: {sha: HEAD, ref: LANE}}),
+				],
+			]),
+			{files: files()},
+		);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses another lane's PR on 18 — an evidence comment there is a cross-lane write", async () => {
+		const outcome = await run(
+			script([
+				[
+					/^gh api repos\/o\/r\/pulls\/4318 --jq \.head\.ref$/,
+					okOut("build/9999-other-aaaaaaaa\n"),
+				],
+			]),
+			{files: files()},
+		);
+		expect(outcome.code).toBe(LANE_NOT_MINE);
+	});
+
+	it("refuses a foreign claim on 18", async () => {
+		const outcome = await run(
+			script([
+				[
+					/^gh api --paginate repos\/o\/r\/issues\/4312\/comments/,
+					comments({id: 1, body: marker("other-session", LANE_UUID)}),
+				],
+			]),
+			{files: files()},
+		);
+		expect(outcome.code).toBe(LANE_NOT_MINE);
+	});
+
+	it("refuses on 8 when the post itself fails — it may or may not have landed", async () => {
+		const outcome = await run(
+			script([
+				[
+					/^gh api --method POST repos\/o\/r\/issues\/4318\/comments/,
+					{ok: false, stdout: "", reason: "HTTP 502"},
+				],
+			]),
+			{files: files()},
+		);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("refuses on 9 when the comment does not read back as sent", async () => {
+		const outcome = await run(
+			withReadback(script(), () => "something else entirely"),
+			{
+				files: files(),
+			},
+		);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses on 11 when a capture cannot be read", async () => {
+		const withoutPng = files();
+		delete withoutPng[`${SCRATCH}/after/pano.png`];
+		const outcome = await run(script(), {files: withoutPng});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("nothing was uploaded or posted");
+	});
+});

--- a/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/evidence-verb.unit.test.ts
@@ -12,9 +12,12 @@ import {
 } from "../build/fixtures.test-support.ts";
 import {fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
+import {isBareAtReference} from "../report/leaks.ts";
 import {
 	BAD_SECTIONS,
+	CAPTURE_INVALID,
 	LANE_NOT_MINE,
+	LEAKED_PATH,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	UPLOAD_FAILED,
@@ -294,5 +297,65 @@ describe("runEvidence", () => {
 		const outcome = await run(script(), {files: withoutPng});
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("nothing was uploaded or posted");
+	});
+
+	it("refuses on 16 when a capture no longer hashes to its manifest sha256, uploading nothing", async () => {
+		const tampered = files();
+		tampered[`${SCRATCH}/after/pano.png`] = encodePng(2, 2, solid(2, 2, [255, 0, 0, 255]));
+		const uploaded: string[] = [];
+		const shell = fakeShell(script());
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runEvidence({
+					...options,
+					attachmentUpload: (_repo, target) => {
+						uploaded.push(target.fileName);
+						return Effect.succeed<Upload>({
+							_tag: "Ok",
+							url: "https://github.com/user-attachments/assets/x",
+						});
+					},
+				}),
+				Layer.merge(shell.layer, fakeBytesFs({files: tampered}).layer),
+			),
+		);
+		expect(outcome.code).toBe(CAPTURE_INVALID);
+		expect(uploaded).toEqual([]);
+		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+	});
+
+	it("refuses a machine-local path in the composed comment on 5, and posts nothing", async () => {
+		const shell = fakeShell(script());
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runEvidence({
+					...options,
+					attachmentUpload: (_repo, target) =>
+						Effect.succeed<Upload>({
+							_tag: "Ok",
+							url: `/Users/someone/captures/${target.fileName}`,
+						}),
+				}),
+				Layer.merge(shell.layer, fakeBytesFs({files: files()}).layer),
+			),
+		);
+		expect(outcome.code).toBe(LEAKED_PATH);
+		expect(outcome.stdout).toBe("");
+		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+	});
+
+	// Seat 6 is the #3086 backstop, and `runEvidence` cannot reach it: `composeEvidence` always leads
+	// with its own `**UI evidence**` header, so the composed body's first token is never an `@` path —
+	// including when an upload leg hands back an `@` path in place of a URL. What is testable, and
+	// what this pins, is that the predicate the seat rides on refuses the #3086 body while no body the
+	// verb composes trips it. Whether the seat should move onto each upload URL instead is #5170.
+	it("keeps the composed comment out of seat 6's bare @ path refusal", () => {
+		expect(isBareAtReference("@/tmp/ui-evidence.md")).toBe(true);
+		expect(isBareAtReference(EXPECTED_BODY)).toBe(false);
+		expect(
+			isBareAtReference(
+				composeEvidence([{surface: "/pano", before: null, after: "@/tmp/after-pano.png"}], HEAD),
+			),
+		).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/ui/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/ui/fakes.test-support.ts
@@ -1,0 +1,134 @@
+/**
+ * The `ui` group's two test seams: a **byte-capable** filesystem layer, and a PNG encoder.
+ *
+ * `../fakes.test-support.ts` speaks UTF-8 (`readFileString`/`writeFileString`), which the shipped
+ * groups only ever needed; every artifact here is a PNG, so the fake has to answer `readFile` and
+ * `writeFile` too. The encoder exists so a capture fixture is a *real* PNG the production decoder
+ * reads — a hand-written byte blob would only prove the decoder agrees with the fixture's author.
+ */
+import {deflateSync} from "node:zlib";
+import {Effect, FileSystem, Layer, Path, PlatformError} from "effect";
+
+const notFound = (method: string, path: string) =>
+	Effect.fail(
+		PlatformError.systemError({
+			_tag: "NotFound",
+			module: "FileSystem",
+			method,
+			pathOrDescriptor: path,
+		}),
+	);
+
+export interface FakeBytesFsOptions {
+	/** Path → contents. A `null` entry exists as a path that cannot be read. */
+	readonly files?: Readonly<Record<string, Uint8Array | string | null>>;
+	/** Paths whose existence check itself fails — distinct from a path that is absent. */
+	readonly unprobeable?: ReadonlyArray<string>;
+	/** Paths whose writes fail. */
+	readonly unwritable?: ReadonlyArray<string>;
+}
+
+export interface FakeBytesFs {
+	readonly layer: Layer.Layer<FileSystem.FileSystem | Path.Path>;
+	readonly written: Map<string, Uint8Array>;
+}
+
+const asBytes = (value: Uint8Array | string): Uint8Array =>
+	typeof value === "string" ? new TextEncoder().encode(value) : value;
+
+export const fakeBytesFs = (options: FakeBytesFsOptions = {}): FakeBytesFs => {
+	const files: Record<string, Uint8Array | string | null> = {...options.files};
+	const written = new Map<string, Uint8Array>();
+	const read = (method: string, path: string) => {
+		const value = files[path];
+		return value === undefined || value === null
+			? notFound(method, path)
+			: Effect.succeed(asBytes(value));
+	};
+	const write = (path: string, bytes: Uint8Array) => {
+		if (options.unwritable?.includes(path) === true) return notFound("writeFile", path);
+		files[path] = bytes;
+		written.set(path, bytes);
+		return Effect.void;
+	};
+	const layer = Layer.merge(
+		FileSystem.layerNoop({
+			readFile: (path: string) => read("readFile", path),
+			readFileString: (path: string) => {
+				const value = files[path];
+				return value === undefined || value === null
+					? notFound("readFileString", path)
+					: Effect.succeed(typeof value === "string" ? value : new TextDecoder().decode(value));
+			},
+			exists: (path: string) =>
+				options.unprobeable?.includes(path) === true
+					? notFound("exists", path)
+					: Effect.succeed(Object.hasOwn(files, path) && files[path] !== null),
+			makeDirectory: () => Effect.void,
+			realPath: (path: string) => Effect.succeed(path),
+			writeFile: (path: string, data: Uint8Array) => write(path, data),
+			writeFileString: (path: string, data: string) => write(path, new TextEncoder().encode(data)),
+		}),
+		Path.layer,
+	);
+	return {layer, written};
+};
+
+const CRC_TABLE = (() => {
+	const table = new Uint32Array(256);
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+		for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		table[n] = c >>> 0;
+	}
+	return table;
+})();
+
+const crc32 = (bytes: Buffer): number => {
+	let c = 0xffffffff;
+	for (const byte of bytes) c = (CRC_TABLE[(c ^ byte) & 0xff] as number) ^ (c >>> 8);
+	return (c ^ 0xffffffff) >>> 0;
+};
+
+const chunk = (type: string, data: Buffer): Buffer => {
+	const length = Buffer.alloc(4);
+	length.writeUInt32BE(data.length);
+	const body = Buffer.concat([Buffer.from(type, "ascii"), data]);
+	const crc = Buffer.alloc(4);
+	crc.writeUInt32BE(crc32(body));
+	return Buffer.concat([length, body, crc]);
+};
+
+/** Encode an 8-bit RGBA raster as a real, decodable PNG (filter 0 on every scanline). */
+export const encodePng = (width: number, height: number, rgba: Uint8Array): Uint8Array => {
+	const stride = width * 4;
+	const raw = Buffer.alloc(height * (stride + 1));
+	for (let y = 0; y < height; y++) {
+		raw[y * (stride + 1)] = 0;
+		Buffer.from(rgba.subarray(y * stride, (y + 1) * stride)).copy(raw, y * (stride + 1) + 1);
+	}
+	const ihdr = Buffer.alloc(13);
+	ihdr.writeUInt32BE(width, 0);
+	ihdr.writeUInt32BE(height, 4);
+	ihdr[8] = 8;
+	ihdr[9] = 6;
+	return new Uint8Array(
+		Buffer.concat([
+			Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+			chunk("IHDR", ihdr),
+			chunk("IDAT", deflateSync(raw)),
+			chunk("IEND", Buffer.alloc(0)),
+		]),
+	);
+};
+
+/** A solid-colour raster, the base every diff fixture perturbs. */
+export const solid = (
+	width: number,
+	height: number,
+	rgba: readonly [number, number, number, number],
+): Uint8Array => {
+	const pixels = new Uint8Array(width * height * 4);
+	for (let p = 0; p < width * height; p++) pixels.set(rgba, p * 4);
+	return pixels;
+};

--- a/packages/fabrika-cli/src/ui/golden-verb.ts
+++ b/packages/fabrika-cli/src/ui/golden-verb.ts
@@ -1,0 +1,159 @@
+/**
+ * `ui golden` — resolve a surface's blessed golden and diff a candidate against it.
+ *
+ * **Signal, never verdict.** No threshold lives in this verb and no PASS/FAIL token is reachable from
+ * it; the acceptance fork is `review-ui`'s (#4718). It reads the pointer and the bytes and writes
+ * neither: blessing stays the founder gallery flow (ADR 0183 §5).
+ *
+ * A missing golden is a **fact** (`blessed: false`, exit 0) — but only after a pointer read that
+ * succeeded. The unreadable pointer resolving to an empty blessed set is #4501, and `4`/`11` are
+ * where that fail-open goes to die.
+ *
+ * The fetched bytes are cached content-addressed under the OS temp root, which makes the cache
+ * lane-independent by construction: a content-addressed file is write-once, so concurrent lanes
+ * cannot clobber each other and this verb needs no lane precondition to stay safe.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {readBytes, writeBytes} from "./bytes.ts";
+import {BAD_SECTIONS, CAPTURE_INVALID, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {atRoot, GOLDEN_POINTER_PATHS} from "./conventions.ts";
+import {diffAgainstGolden, REGION_CAP} from "./diff.ts";
+import {resolveRoot} from "./lane.ts";
+import {probe} from "./manifest-verb.ts";
+import {decodePng, sha256Of} from "./png.ts";
+import {goldenUrl, parsePointer} from "./pointer.ts";
+
+const VERB = "ui golden";
+
+/** The injected fetch of blessed bytes — a store the consuming repo owns, never one fabrika names. */
+export type FetchLeg = (
+	url: string,
+) => Effect.Effect<
+	| {readonly _tag: "Ok"; readonly bytes: Uint8Array}
+	| {readonly _tag: "Failed"; readonly reason: string}
+>;
+
+export interface GoldenOptions {
+	readonly surface: string;
+	readonly candidate: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The OS temp root, read by the adapter — the one machine fact this verb does not derive. */
+	readonly tmpRoot: string;
+	readonly fetch: FetchLeg;
+}
+
+const unresolvable = (surface: string, reason: string): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`${VERB}: cannot resolve the golden for "${surface}": ${reason} — blessing is UNKNOWN, never "unblessed".`,
+	);
+
+const unblessed = (surface: string, note: string): VerbOutcome =>
+	answer(JSON.stringify({surface, blessed: false, golden: null, diff: null}), [`${VERB}: ${note}`]);
+
+export const runGolden = (
+	options: GoldenOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const {surface} = options;
+		const root = yield* resolveRoot(VERB);
+		if (root._tag === "Refused") return root.outcome;
+
+		let pointerPath: string | null = null;
+		for (const relative of GOLDEN_POINTER_PATHS) {
+			const found = yield* probe(root.root, relative);
+			if (found._tag === "Unknown") return unresolvable(surface, found.reason);
+			if (found._tag === "Present") {
+				pointerPath = atRoot(root.root, relative);
+				break;
+			}
+		}
+		if (pointerPath === null) {
+			return unblessed(
+				surface,
+				"no golden pointer at either convention path — no surface is blessed.",
+			);
+		}
+
+		const raw = yield* readBytes(pointerPath);
+		if (raw._tag === "Failed") return unresolvable(surface, raw.reason);
+		const parsed = parsePointer(new TextDecoder().decode(raw.bytes));
+		if (parsed._tag === "Violation") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the golden pointer exists but does not parse: ${parsed.violation} — refusing; an unreadable pointer is not an empty blessed set.`,
+			);
+		}
+		const sha256 = parsed.pointer.surfaces[surface];
+		if (sha256 === undefined) {
+			return unblessed(surface, `the pointer names no golden for "${surface}".`);
+		}
+		const store = parsed.pointer.store;
+		if (store === null) return unresolvable(surface, "the pointer declares no store");
+
+		const cachePath = `${options.tmpRoot.replace(/\/+$/, "")}/fabrika-ui-goldens/${sha256}.png`;
+		const cached = yield* readBytes(cachePath);
+		let goldenBytes: Uint8Array;
+		if (cached._tag === "Bytes" && sha256Of(cached.bytes) === sha256) {
+			goldenBytes = cached.bytes;
+		} else {
+			const fetched = yield* options.fetch(goldenUrl(store, sha256));
+			if (fetched._tag === "Failed") return unresolvable(surface, fetched.reason);
+			if (sha256Of(fetched.bytes) !== sha256) {
+				return unresolvable(
+					surface,
+					`the store answered bytes that hash to something other than ${sha256}`,
+				);
+			}
+			const failure = yield* writeBytes(cachePath, fetched.bytes);
+			if (failure !== null) return unresolvable(surface, `cannot cache the golden: ${failure}`);
+			goldenBytes = fetched.bytes;
+		}
+		const golden = {sha256, path: cachePath};
+
+		if (options.candidate === null) {
+			return answer(JSON.stringify({surface, blessed: true, golden, diff: null}), [
+				`${VERB}: resolved the blessed golden for "${surface}"; no candidate to diff.`,
+			]);
+		}
+
+		const invocationDir = options.env.FABRIKA_INVOCATION_DIR ?? root.root;
+		const candidatePath = options.candidate.startsWith("/")
+			? options.candidate
+			: `${invocationDir.replace(/\/+$/, "")}/${options.candidate}`;
+		const candidateBytes = yield* readBytes(candidatePath);
+		if (candidateBytes._tag === "Failed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the candidate at ${candidatePath}: ${candidateBytes.reason} — the diff is UNKNOWN.`,
+			);
+		}
+		const candidateImage = decodePng(candidateBytes.bytes);
+		if (candidateImage._tag === "Invalid") {
+			return refuse(
+				CAPTURE_INVALID,
+				`${VERB}: the candidate at ${candidatePath} is invalid (${candidateImage.detail}).`,
+			);
+		}
+		const goldenImage = decodePng(goldenBytes);
+		if (goldenImage._tag === "Invalid") {
+			return unresolvable(
+				surface,
+				`the blessed bytes are not a decodable PNG (${goldenImage.detail})`,
+			);
+		}
+		const outcome = diffAgainstGolden(goldenImage.image, candidateImage.image);
+		const notes = [`${VERB}: diffed "${surface}" against its blessed golden.`];
+		if (outcome.capped) {
+			notes.push(
+				`${VERB}: ${outcome.found} regions differ; the list is capped at ${REGION_CAP}, largest area first.`,
+			);
+		}
+		return answer(JSON.stringify({surface, blessed: true, golden, diff: outcome.diff}), notes);
+	});

--- a/packages/fabrika-cli/src/ui/golden-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/golden-verb.unit.test.ts
@@ -1,0 +1,120 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED} from "../build/fixtures.test-support.ts";
+import {fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {BAD_SECTIONS, CAPTURE_INVALID, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {encodePng, type FakeBytesFsOptions, fakeBytesFs, solid} from "./fakes.test-support.ts";
+import {type FetchLeg, runGolden} from "./golden-verb.ts";
+import {sha256Of} from "./png.ts";
+
+const ROOT = "/repo/trees/lane-a";
+const POINTER = `${ROOT}/packages/design-capture/golden-pointer.json`;
+const CANDIDATE = "/scratch/after/pano.png";
+
+const REV_PARSE: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^git rev-parse --path-format=absolute/, LINKED],
+];
+
+const GOLDEN_BYTES = encodePng(2, 2, solid(2, 2, [0, 0, 0, 255]));
+const GOLDEN_SHA = sha256Of(GOLDEN_BYTES);
+
+const pointer = (surfaces: Record<string, string>) =>
+	JSON.stringify({
+		store: "https://depo.example",
+		surfaces: Object.fromEntries(Object.entries(surfaces).map(([id, sha]) => [id, {sha256: sha}])),
+	});
+
+const serving: FetchLeg = () => Effect.succeed({_tag: "Ok", bytes: GOLDEN_BYTES});
+const dead: FetchLeg = () => Effect.succeed({_tag: "Failed", reason: "connection refused"});
+
+const run = (
+	fs: FakeBytesFsOptions,
+	overrides: {candidate?: string | null; fetch?: FetchLeg} = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runGolden({
+				surface: "/pano",
+				candidate: overrides.candidate ?? null,
+				env: {},
+				tmpRoot: "/tmp",
+				fetch: overrides.fetch ?? serving,
+			}),
+			Layer.merge(fakeShell(REV_PARSE).layer, fakeBytesFs(fs).layer),
+		),
+	);
+
+describe("runGolden", () => {
+	it("answers unblessed as a FACT on exit 0 when the pointer names no golden", async () => {
+		const outcome = await run({files: {[POINTER]: pointer({})}});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			surface: "/pano",
+			blessed: false,
+			golden: null,
+			diff: null,
+		});
+	});
+
+	it("answers unblessed when no pointer file exists at either convention path", async () => {
+		const outcome = await run({files: {}});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).blessed).toBe(false);
+	});
+
+	it("resolves the blessed golden content-addressed under the temp root", async () => {
+		const outcome = await run({files: {[POINTER]: pointer({"/pano": GOLDEN_SHA})}});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			surface: "/pano",
+			blessed: true,
+			golden: {sha256: GOLDEN_SHA, path: `/tmp/fabrika-ui-goldens/${GOLDEN_SHA}.png`},
+			diff: null,
+		});
+	});
+
+	it("diffs a candidate and emits magnitude + regions, never a verdict token", async () => {
+		const changed = solid(2, 2, [0, 0, 0, 255]);
+		changed.set([255, 255, 255, 255], 0);
+		const outcome = await run(
+			{files: {[POINTER]: pointer({"/pano": GOLDEN_SHA}), [CANDIDATE]: encodePng(2, 2, changed)}},
+			{candidate: CANDIDATE},
+		);
+		expect(outcome.code).toBe(0);
+		const answer = JSON.parse(outcome.stdout);
+		expect(answer.diff).toEqual({magnitude: 0.25, regions: [{x: 0, y: 0, w: 1, h: 1}]});
+		expect(outcome.stdout).not.toMatch(/PASS|FAIL/);
+	});
+
+	/** #4501: an unreadable pointer resolving to an empty blessed set is the fail-open this refuses. */
+	it("refuses an unparseable pointer on 4 rather than reading it as unblessed", async () => {
+		const outcome = await run({files: {[POINTER]: "{"}});
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("an unreadable pointer is not an empty blessed set");
+	});
+
+	it("refuses on 11 when the golden bytes cannot be fetched", async () => {
+		const outcome = await run({files: {[POINTER]: pointer({"/pano": GOLDEN_SHA})}}, {fetch: dead});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain('blessing is UNKNOWN, never "unblessed"');
+	});
+
+	it("refuses on 11 when the store answers bytes that hash to something else", async () => {
+		const wrong: FetchLeg = () =>
+			Effect.succeed({_tag: "Ok", bytes: encodePng(2, 2, solid(2, 2, [1, 2, 3, 255]))});
+		const outcome = await run({files: {[POINTER]: pointer({"/pano": GOLDEN_SHA})}}, {fetch: wrong});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("hash to something other than");
+	});
+
+	it("refuses an invalid candidate on 16", async () => {
+		const outcome = await run(
+			{files: {[POINTER]: pointer({"/pano": GOLDEN_SHA}), [CANDIDATE]: new Uint8Array(0)}},
+			{candidate: CANDIDATE},
+		);
+		expect(outcome.code).toBe(CAPTURE_INVALID);
+		expect(outcome.stderr.at(-1)).toContain("is invalid (zero bytes)");
+	});
+});

--- a/packages/fabrika-cli/src/ui/harness.ts
+++ b/packages/fabrika-cli/src/ui/harness.ts
@@ -1,0 +1,88 @@
+/**
+ * `design-harness.json` — how this repo renders and where its evidence lives.
+ *
+ * The portable replacement for v1's phoenix-hardcoded "alchemy dev" knowledge: the command, the base
+ * URL and the readiness probe are the repo's own declaration, so the render leg needs no knowledge of
+ * any particular stack. Validated whole-file, the same rule the registry gets.
+ */
+
+/** The capture viewport in CSS px, when the harness does not name one. */
+export const DEFAULT_VIEWPORT = {width: 1280, height: 900} as const;
+/** The readiness bound: a harness that has not answered 200 by here leaves every surface UNKNOWN. */
+export const READY_TIMEOUT_MS = 60_000;
+
+export interface HarnessConfig {
+	readonly command: string;
+	readonly url: string;
+	readonly readyPath: string;
+	readonly viewport: {readonly width: number; readonly height: number};
+	readonly evidenceStore: string | null;
+}
+
+export type HarnessParse =
+	| {readonly _tag: "Config"; readonly config: HarnessConfig}
+	| {readonly _tag: "Violation"; readonly violation: string};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const KNOWN = ["command", "url", "readyPath", "viewport", "evidenceStore"];
+
+const viewportOf = (raw: unknown): {width: number; height: number} | string => {
+	if (raw === undefined) return {...DEFAULT_VIEWPORT};
+	if (!isRecord(raw)) return '"viewport" is not an object';
+	const {width, height} = raw;
+	if (typeof width !== "number" || !Number.isInteger(width) || width <= 0) {
+		return '"viewport.width" is not a positive integer';
+	}
+	if (typeof height !== "number" || !Number.isInteger(height) || height <= 0) {
+		return '"viewport.height" is not a positive integer';
+	}
+	return {width, height};
+};
+
+export const parseHarness = (text: string): HarnessParse => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (err) {
+		return {_tag: "Violation", violation: `the file is not JSON (${(err as Error).message})`};
+	}
+	if (!isRecord(parsed)) return {_tag: "Violation", violation: "the top level is not an object"};
+	const extra = Object.keys(parsed).filter((key) => !KNOWN.includes(key));
+	if (extra[0] !== undefined) {
+		return {_tag: "Violation", violation: `unknown key "${extra[0]}"`};
+	}
+	if (typeof parsed.command !== "string" || parsed.command.trim() === "") {
+		return {_tag: "Violation", violation: '"command" is missing or not a non-empty string'};
+	}
+	if (typeof parsed.url !== "string" || !/^https?:\/\//.test(parsed.url)) {
+		return {_tag: "Violation", violation: '"url" is missing or is not an http(s) base URL'};
+	}
+	const readyPath = parsed.readyPath ?? "/";
+	if (typeof readyPath !== "string" || !readyPath.startsWith("/")) {
+		return {_tag: "Violation", violation: '"readyPath" is not a path beginning with "/"'};
+	}
+	const viewport = viewportOf(parsed.viewport);
+	if (typeof viewport === "string") return {_tag: "Violation", violation: viewport};
+	const evidenceStore = parsed.evidenceStore;
+	if (evidenceStore !== undefined && typeof evidenceStore !== "string") {
+		return {_tag: "Violation", violation: '"evidenceStore" is not a string'};
+	}
+	return {
+		_tag: "Config",
+		config: {
+			command: parsed.command,
+			url: parsed.url.replace(/\/+$/, ""),
+			readyPath,
+			viewport,
+			evidenceStore: evidenceStore ?? null,
+		},
+	};
+};
+
+/** `/` → `root`; every other route becomes its slug (`/pano/yeni` → `pano-yeni`). */
+export const surfaceSlug = (route: string): string => {
+	const trimmed = route.replace(/^\/+/, "").replace(/\/+$/, "");
+	return trimmed === "" ? "root" : trimmed.replace(/\//g, "-");
+};

--- a/packages/fabrika-cli/src/ui/harness.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/harness.unit.test.ts
@@ -1,0 +1,68 @@
+import {describe, expect, it} from "vitest";
+import {DEFAULT_VIEWPORT, parseHarness, surfaceSlug} from "./harness.ts";
+
+const config = (overrides: Record<string, unknown> = {}) =>
+	JSON.stringify({command: "pnpm dev", url: "http://127.0.0.1:5173", ...overrides});
+
+describe("parseHarness", () => {
+	it("defaults readyPath and viewport, and trims the base URL", () => {
+		const parsed = parseHarness(config({url: "http://127.0.0.1:5173/"}));
+		expect(parsed).toEqual({
+			_tag: "Config",
+			config: {
+				command: "pnpm dev",
+				url: "http://127.0.0.1:5173",
+				readyPath: "/",
+				viewport: DEFAULT_VIEWPORT,
+				evidenceStore: null,
+			},
+		});
+	});
+
+	it("carries a declared viewport, readyPath and evidenceStore through", () => {
+		const parsed = parseHarness(
+			config({
+				readyPath: "/health",
+				viewport: {width: 390, height: 844},
+				evidenceStore: "https://depo/x",
+			}),
+		);
+		expect(parsed._tag).toBe("Config");
+		if (parsed._tag !== "Config") return;
+		expect(parsed.config.viewport).toEqual({width: 390, height: 844});
+		expect(parsed.config.readyPath).toBe("/health");
+		expect(parsed.config.evidenceStore).toBe("https://depo/x");
+	});
+
+	it.each([
+		[
+			"no command",
+			JSON.stringify({url: "http://x"}),
+			'"command" is missing or not a non-empty string',
+		],
+		["a non-URL url", config({url: "127.0.0.1"}), '"url" is missing or is not an http(s) base URL'],
+		[
+			"a relative readyPath",
+			config({readyPath: "health"}),
+			'"readyPath" is not a path beginning with "/"',
+		],
+		[
+			"a fractional viewport",
+			config({viewport: {width: 12.5, height: 900}}),
+			'"viewport.width" is not a positive integer',
+		],
+		["an unknown key", config({browser: "chromium"}), 'unknown key "browser"'],
+	])("refuses %s whole-file", (_label, text, violation) => {
+		expect(parseHarness(text)).toEqual({_tag: "Violation", violation});
+	});
+});
+
+describe("surfaceSlug", () => {
+	it.each([
+		["/", "root"],
+		["/pano", "pano"],
+		["/pano/yeni", "pano-yeni"],
+	])("slugs %s as %s", (route, slug) => {
+		expect(surfaceSlug(route)).toBe(slug);
+	});
+});

--- a/packages/fabrika-cli/src/ui/http.ts
+++ b/packages/fabrika-cli/src/ui/http.ts
@@ -1,0 +1,180 @@
+/**
+ * The impure HTTP legs: fetching blessed golden bytes, and the two evidence upload tiers.
+ *
+ * Every one of them **verifies its own effect** rather than trusting a status line: the golden fetch
+ * hands the bytes back for the caller to hash against the pointer, the store tier PUTs then GETs the
+ * same content-addressed URL and hash-compares, and the attachment tier probes every returned URL
+ * with a HEAD. That is the whole difference from the upstream capture-side upload, whose failures are
+ * projected away by an error channel typed `never` (#3925): here a failed verification is a value the
+ * verb refuses on.
+ */
+import {execFileSync} from "node:child_process";
+import {Effect} from "effect";
+import {
+	PNG_CONTENT_TYPE,
+	parseUploadResponse,
+	type UploadOutcome,
+	uploadEndpoint,
+} from "../capture/upload.ts";
+import type {Upload, UploadLeg, UploadTarget} from "./evidence-verb.ts";
+import type {FetchLeg} from "./golden-verb.ts";
+import {legFailed} from "./leg-failed.ts";
+import {sha256Of} from "./png.ts";
+import {goldenUrl} from "./pointer.ts";
+
+/** Settle a promise into its value or its failure, so no path here needs a `try`. */
+const attempt = <A>(promise: Promise<A>): Promise<A | Error> =>
+	promise.then(
+		(value) => value,
+		(cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause))),
+	);
+
+/** Fetch blessed bytes. The caller hashes them — this leg never decides they are the right bytes. */
+export const fetchGolden: FetchLeg = (url) =>
+	Effect.tryPromise({
+		try: async () => {
+			const response = await attempt(fetch(url));
+			if (response instanceof Error) {
+				return {_tag: "Failed" as const, reason: `GET ${url} failed: ${response.message}`};
+			}
+			if (!response.ok) {
+				return {_tag: "Failed" as const, reason: `GET ${url} returned HTTP ${response.status}`};
+			}
+			const body = await attempt(response.arrayBuffer());
+			return body instanceof Error
+				? {_tag: "Failed" as const, reason: `GET ${url} failed while reading: ${body.message}`}
+				: {_tag: "Ok" as const, bytes: new Uint8Array(body)};
+		},
+		catch: legFailed,
+	}).pipe(Effect.catch((cause) => Effect.succeed({_tag: "Failed" as const, reason: cause.reason})));
+
+/** Store tier: content-addressed PUT, then a GET back that must hash to the same address. */
+export const storeUpload = (store: string, target: UploadTarget): Effect.Effect<Upload> =>
+	Effect.tryPromise({
+		try: async (): Promise<Upload> => {
+			const url = goldenUrl(store.replace(/\/+$/, ""), target.sha256);
+			const put = await attempt(
+				fetch(url, {
+					method: "PUT",
+					body: target.bytes,
+					headers: {"content-type": PNG_CONTENT_TYPE},
+				}),
+			);
+			if (put instanceof Error)
+				return {_tag: "Failed", reason: `PUT ${url} failed: ${put.message}`};
+			if (!put.ok) return {_tag: "Failed", reason: `PUT ${url} returned HTTP ${put.status}`};
+			const get = await attempt(fetch(url));
+			if (get instanceof Error)
+				return {_tag: "Failed", reason: `GET ${url} failed: ${get.message}`};
+			if (!get.ok) return {_tag: "Failed", reason: `GET ${url} returned HTTP ${get.status}`};
+			const body = await attempt(get.arrayBuffer());
+			if (body instanceof Error) {
+				return {_tag: "Failed", reason: `GET ${url} failed while reading: ${body.message}`};
+			}
+			const seen = sha256Of(new Uint8Array(body));
+			return seen === target.sha256
+				? {_tag: "Ok", url}
+				: {_tag: "Failed", reason: `${url} reads back as ${seen}, not ${target.sha256}`};
+		},
+		catch: legFailed,
+	}).pipe(Effect.catch((cause) => Effect.succeed<Upload>({_tag: "Failed", reason: cause.reason})));
+
+/**
+ * Attachment tier: GitHub's user-attachment endpoint, then a HEAD probe of the returned URL.
+ *
+ * Two facts stated rather than hidden. The endpoint is **undocumented** (ADR 0165's durability
+ * caveat rides along — hosted copies are display-grade, the set manifest in the lane scratch is the
+ * durable record), and it is an upload API rather than an issues read/write, so it sits outside skill
+ * conventions §11's REST-porcelain scope while every issue/PR read and write in `ui evidence` stays
+ * inside it.
+ */
+export const attachmentUpload =
+	(params: {readonly repositoryId: number; readonly token: string}): UploadLeg =>
+	(target: UploadTarget) =>
+		Effect.tryPromise({
+			try: async (): Promise<Upload> => {
+				const endpoint = uploadEndpoint({
+					repositoryId: params.repositoryId,
+					fileName: target.fileName,
+					size: target.bytes.length,
+					contentType: PNG_CONTENT_TYPE,
+				});
+				const response = await attempt(
+					fetch(endpoint, {
+						method: "POST",
+						headers: {
+							authorization: `token ${params.token}`,
+							accept: "application/vnd.github+json",
+							"content-type": PNG_CONTENT_TYPE,
+						},
+						body: target.bytes,
+					}),
+				);
+				if (response instanceof Error) {
+					return {
+						_tag: "Failed",
+						reason: `the user-attachments upload failed: ${response.message}`,
+					};
+				}
+				const body = await attempt(response.text());
+				const outcome: UploadOutcome = parseUploadResponse({
+					status: response.status,
+					body: body instanceof Error ? body.message : body,
+				});
+				const hostedUrl = outcome.hostedUrl;
+				if (hostedUrl === null) {
+					return {_tag: "Failed", reason: outcome.uploadError ?? "the upload returned no URL"};
+				}
+				const probe = await attempt(fetch(hostedUrl, {method: "HEAD"}));
+				if (probe instanceof Error) {
+					return {_tag: "Failed", reason: `${hostedUrl}: HEAD failed: ${probe.message}`};
+				}
+				return probe.status === 200
+					? {_tag: "Ok", url: hostedUrl}
+					: {_tag: "Failed", reason: `${hostedUrl}: HEAD returned HTTP ${probe.status}`};
+			},
+			catch: legFailed,
+		}).pipe(
+			Effect.catch((cause) => Effect.succeed<Upload>({_tag: "Failed", reason: cause.reason})),
+		);
+
+/**
+ * The attachment tier's two credentials, resolved through the `gh` CLI the rest of the group already
+ * speaks through — never a second auth path. Resolved lazily, at the first upload, so a run that
+ * never reaches the attachment tier never asks for a token, and memoised per repo so a five-surface
+ * evidence post does not shell out ten times.
+ */
+const credentials = new Map<
+	string,
+	{readonly repositoryId: number; readonly token: string} | string
+>();
+
+const resolveCredentials = (
+	repo: string,
+): Effect.Effect<{readonly repositoryId: number; readonly token: string} | string> =>
+	Effect.try({
+		try: () => {
+			const id = Number.parseInt(
+				execFileSync("gh", ["api", `repos/${repo}`, "--jq", ".id"], {encoding: "utf8"}).trim(),
+				10,
+			);
+			const token = execFileSync("gh", ["auth", "token"], {encoding: "utf8"}).trim();
+			return Number.isInteger(id) && token !== ""
+				? {repositoryId: id, token}
+				: "`gh` named no repository id or token";
+		},
+		catch: legFailed,
+	}).pipe(
+		Effect.catch((cause) =>
+			Effect.succeed(`cannot resolve the upload credentials through gh: ${cause.reason}`),
+		),
+	);
+
+export const ghAttachmentUpload = (repo: string, target: UploadTarget): Effect.Effect<Upload> =>
+	Effect.gen(function* () {
+		const cached = credentials.get(repo) ?? (yield* resolveCredentials(repo));
+		credentials.set(repo, cached);
+		return typeof cached === "string"
+			? {_tag: "Failed" as const, reason: cached}
+			: yield* attachmentUpload(cached)(target);
+	});

--- a/packages/fabrika-cli/src/ui/lane.ts
+++ b/packages/fabrika-cli/src/ui/lane.ts
@@ -1,0 +1,107 @@
+/**
+ * The two preconditions the `ui` group shares: where the repo root is, and whether this lane is mine.
+ *
+ * **Lane mechanics are the `build` group's, reused — never respecified.** The parse, the claim
+ * re-read and the nonce agreement all live in `../build/lane-guard.ts`; this module only re-seats
+ * that guard's refusals onto the `ui` matrix, where every proven lane failure — foreign claim, no
+ * claim, a branch that does not parse — is one code (`18`) and an unreadable claim state stays `11`.
+ * Collapsing the three proven shapes onto one code is the contract's call: the caller's next act is
+ * identical for all three, and the distinguishing detail rides on stderr.
+ *
+ * `ui manifest`, `ui law` and `ui golden` are pure reads and take no lane precondition — they call
+ * {@link resolveRoot} and nothing here.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {laneNumber, nonceOf, parseLaneBranch} from "../build/lane.ts";
+import {requireLane} from "../build/lane-guard.ts";
+import {readTree} from "../build/worktree.ts";
+import {currentBranch} from "../io/issues.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {LANE_NOT_MINE, PRECONDITION_UNKNOWN} from "./codes.ts";
+
+export type Root =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Root"; readonly root: string};
+
+/** The repo root every convention path resolves against — never the cwd, never a web URL. */
+export const resolveRoot = (
+	verb: string,
+): Effect.Effect<Root, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const tree = yield* readTree;
+		return tree._tag === "Failure"
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						PRECONDITION_UNKNOWN,
+						`${verb}: cannot resolve the repo root: ${tree.reason} — every convention path is UNKNOWN.`,
+					),
+				}
+			: {_tag: "Root" as const, root: tree.value.root};
+	});
+
+export type UiLane =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {
+			readonly _tag: "Lane";
+			readonly root: string;
+			readonly branch: string;
+			/** The number the branch is claimed under — the issue in create mode, the PR in resume mode. */
+			readonly number: number;
+			/** The claim nonce, which is what makes the scratch namespace per-lane. */
+			readonly nonce: string;
+			readonly notes: ReadonlyArray<string>;
+	  };
+
+/**
+ * Prove the checked-out branch names a lane this session holds.
+ *
+ * `refusal` builds the `18` line, because the two lane-guarding verbs word it differently: `ui
+ * render` names the branch, `ui evidence` names the number it is about to write to. It is handed the
+ * lane number when the branch parses as one and `null` when it does not — the case where there is no
+ * number to name is exactly the case the message must not invent one for.
+ */
+export const requireUiLane = (
+	verb: string,
+	repo: string,
+	session: string,
+	refusal: (detail: string, number: number | null) => string,
+): Effect.Effect<UiLane, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const lane = yield* requireLane(verb, repo, session, null);
+		if (lane._tag === "Refused") {
+			const {outcome} = lane;
+			if (outcome.code === PRECONDITION_UNKNOWN) return {_tag: "Refused" as const, outcome};
+			const detail = outcome.stderr.at(-1) ?? "no detail";
+			const branch = yield* currentBranch;
+			const parsed = branch === null ? null : parseLaneBranch(branch);
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					LANE_NOT_MINE,
+					refusal(detail, parsed === null ? null : laneNumber(parsed)),
+					outcome.stderr.slice(0, -1),
+				),
+			};
+		}
+		const nonce = nonceOf(lane.marker.token);
+		if (nonce === null) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: the claim carries the token ${lane.marker.token}, which yields no lane nonce — the lane is UNKNOWN.`,
+					lane.notes,
+				),
+			};
+		}
+		return {
+			_tag: "Lane" as const,
+			root: lane.root,
+			branch: lane.branch,
+			number: laneNumber(lane.lane),
+			nonce,
+			notes: lane.notes,
+		};
+	});

--- a/packages/fabrika-cli/src/ui/law-verb.ts
+++ b/packages/fabrika-cli/src/ui/law-verb.ts
@@ -1,0 +1,76 @@
+/**
+ * `ui law` — the typed prohibition registry, schema-validated whole-file, rows in file order.
+ *
+ * Three different facts, three different codes, and the skill's prose fallback is legal only in the
+ * first: untyped (`13` — no registry beside the manifest), mistyped (`4` — a registry that violates
+ * the schema), unreadable (`11` — the law is UNKNOWN, never "untyped").
+ */
+import {Effect, type FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readFile} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {BAD_SECTIONS, NO_MANIFEST, PRECONDITION_UNKNOWN, UNTYPED_LAW} from "./codes.ts";
+import {atRoot, MANIFEST_PATH, REGISTRY_PATH} from "./conventions.ts";
+import {resolveRoot} from "./lane.ts";
+import {parseRegistry} from "./law.ts";
+import {probe} from "./manifest-verb.ts";
+
+const VERB = "ui law";
+
+export const runLaw = (): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const root = yield* resolveRoot(VERB);
+		if (root._tag === "Refused") return root.outcome;
+
+		const manifest = yield* probe(root.root, MANIFEST_PATH);
+		if (manifest._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot probe ${MANIFEST_PATH}: ${manifest.reason} — presence is UNKNOWN, never "absent".`,
+			);
+		}
+		if (manifest._tag === "Absent") {
+			return refuse(
+				NO_MANIFEST,
+				`${VERB}: no design manifest at ${MANIFEST_PATH} — run /fabrika (#4952).`,
+			);
+		}
+
+		const registry = yield* probe(root.root, REGISTRY_PATH);
+		if (registry._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${REGISTRY_PATH}: ${registry.reason} — the law is UNKNOWN, never "untyped".`,
+			);
+		}
+		if (registry._tag === "Absent") {
+			return refuse(
+				UNTYPED_LAW,
+				`${VERB}: the law is untyped — no ${REGISTRY_PATH} beside the manifest. The manifest's prose prohibitions are the law; note LAW-SOURCE: manifest-prose in the PR.`,
+			);
+		}
+
+		const text = yield* readFile(atRoot(root.root, REGISTRY_PATH)).pipe(
+			Effect.catchTag("fabrika-cli/ReadFailed", (cause) => Effect.succeed(cause)),
+		);
+		if (typeof text !== "string") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${REGISTRY_PATH}: ${text.reason} — the law is UNKNOWN, never "untyped".`,
+			);
+		}
+		const parsed = parseRegistry(text);
+		if (parsed._tag === "Violation") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: ${REGISTRY_PATH} exists but does not satisfy the registry schema: ${parsed.violation} — refusing the whole file; half a law is not a law.`,
+			);
+		}
+		return answer(JSON.stringify({lawSource: "registry", rows: parsed.rows}), [
+			`${VERB}: validated ${parsed.rows.length} row${parsed.rows.length === 1 ? "" : "s"} against the registry schema.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/ui/law-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/law-verb.unit.test.ts
@@ -1,0 +1,68 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED} from "../build/fixtures.test-support.ts";
+import {fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {BAD_SECTIONS, NO_MANIFEST, PRECONDITION_UNKNOWN, UNTYPED_LAW} from "./codes.ts";
+import {type FakeBytesFsOptions, fakeBytesFs} from "./fakes.test-support.ts";
+import {runLaw} from "./law-verb.ts";
+
+const ROOT = "/repo/trees/lane-a";
+const MANIFEST = `${ROOT}/design-system-manifest.md`;
+const REGISTRY = `${ROOT}/design-prohibitions.json`;
+
+const REV_PARSE: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^git rev-parse --path-format=absolute/, LINKED],
+];
+
+const run = (fs: FakeBytesFsOptions) =>
+	Effect.runPromise(
+		Effect.provide(runLaw(), Layer.merge(fakeShell(REV_PARSE).layer, fakeBytesFs(fs).layer)),
+	);
+
+const ROW = {
+	id: "faint-token-meaning",
+	pillar: "color",
+	class: "blocking",
+	machineCheck: "vlm",
+	source: "design-system-manifest.md#four-pillars",
+	statement: "A meaning-carrying label never sits on a decorative faint token.",
+	counterexample: "Timestamp-styled --text-faint on the error banner's message.",
+};
+
+describe("runLaw", () => {
+	it("emits the registry's rows verbatim under lawSource registry", async () => {
+		const outcome = await run({
+			files: {[MANIFEST]: "# design", [REGISTRY]: JSON.stringify({rows: [ROW]})},
+		});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({lawSource: "registry", rows: [ROW]});
+	});
+
+	/** Untyped, mistyped and unreadable are three different facts — the fallback is legal in one. */
+	it("refuses an untyped law on 13, naming the prose fallback", async () => {
+		const outcome = await run({files: {[MANIFEST]: "# design"}});
+		expect(outcome.code).toBe(UNTYPED_LAW);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("LAW-SOURCE: manifest-prose");
+	});
+
+	it("refuses a schema violation on 4, whole-file", async () => {
+		const outcome = await run({
+			files: {[MANIFEST]: "# design", [REGISTRY]: JSON.stringify({rows: []})},
+		});
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stderr.at(-1)).toContain("half a law is not a law");
+	});
+
+	it("refuses an unreadable registry on 11, never as untyped", async () => {
+		const outcome = await run({files: {[MANIFEST]: "# design"}, unprobeable: [REGISTRY]});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain('the law is UNKNOWN, never "untyped"');
+	});
+
+	it("refuses a missing manifest on 12 — the law question does not arise", async () => {
+		const outcome = await run({files: {}});
+		expect(outcome.code).toBe(NO_MANIFEST);
+	});
+});

--- a/packages/fabrika-cli/src/ui/law.ts
+++ b/packages/fabrika-cli/src/ui/law.ts
@@ -1,0 +1,87 @@
+/**
+ * The typed prohibition registry's schema, validated **whole-file**.
+ *
+ * "Some rows parsed" is never an answer: a generator holding half the law believes it holds the law,
+ * so one bad row refuses the file. Zero rows refuses too — a registry a repo committed asserts a
+ * typed law, and an empty one is a drafting defect to surface rather than a fact to pass through
+ * (ADR 0092's shape at document scale).
+ *
+ * The registry is normative and founder-ratified (the ADR 0194 firewall): nothing in this package
+ * writes it.
+ */
+
+/** One prohibition — exactly the seven fields the #4891 ruling pins. */
+export interface LawRow {
+	readonly id: string;
+	readonly pillar: string;
+	readonly class: "blocking" | "advisory";
+	readonly machineCheck: "verb" | "vlm" | "none";
+	readonly source: string;
+	readonly statement: string;
+	readonly counterexample: string;
+}
+
+export type RegistryParse =
+	| {readonly _tag: "Rows"; readonly rows: ReadonlyArray<LawRow>}
+	/** The first violation, in file order — the message quotes it and refuses the whole file. */
+	| {readonly _tag: "Violation"; readonly violation: string};
+
+const FIELDS = [
+	"id",
+	"pillar",
+	"class",
+	"machineCheck",
+	"source",
+	"statement",
+	"counterexample",
+] as const;
+
+const CLASSES = new Set(["blocking", "advisory"]);
+const MACHINE_CHECKS = new Set(["verb", "vlm", "none"]);
+const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const rowViolation = (index: number, row: unknown, seen: Set<string>): string | null => {
+	const at = `rows[${index}]`;
+	if (!isRecord(row)) return `${at} is not an object`;
+	for (const field of FIELDS) {
+		if (typeof row[field] !== "string") return `${at}.${field} is missing or not a string`;
+	}
+	const extra = Object.keys(row).filter((key) => !FIELDS.includes(key as (typeof FIELDS)[number]));
+	if (extra[0] !== undefined) return `${at} carries an unknown field "${extra[0]}"`;
+	const id = row.id as string;
+	if (!KEBAB.test(id)) return `${at}.id "${id}" is not kebab-case`;
+	if (seen.has(id)) return `${at}.id "${id}" is a duplicate`;
+	seen.add(id);
+	if (!CLASSES.has(row.class as string)) {
+		return `${at}.class "${row.class as string}" is off its enum (blocking | advisory)`;
+	}
+	if (!MACHINE_CHECKS.has(row.machineCheck as string)) {
+		return `${at}.machineCheck "${row.machineCheck as string}" is off its enum (verb | vlm | none)`;
+	}
+	return null;
+};
+
+/** Validate the registry's bytes against the canonical schema; rows come back in file order. */
+export const parseRegistry = (text: string): RegistryParse => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (err) {
+		return {_tag: "Violation", violation: `the file is not JSON (${(err as Error).message})`};
+	}
+	if (!isRecord(parsed)) return {_tag: "Violation", violation: "the top level is not an object"};
+	const rows = parsed.rows;
+	if (!Array.isArray(rows))
+		return {_tag: "Violation", violation: '"rows" is missing or not an array'};
+	if (rows.length === 0)
+		return {_tag: "Violation", violation: '"rows" is empty — a law file that names no law'};
+	const seen = new Set<string>();
+	for (const [index, row] of rows.entries()) {
+		const violation = rowViolation(index, row, seen);
+		if (violation !== null) return {_tag: "Violation", violation};
+	}
+	return {_tag: "Rows", rows: rows as ReadonlyArray<LawRow>};
+};

--- a/packages/fabrika-cli/src/ui/law.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/law.unit.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from "vitest";
+import {parseRegistry} from "./law.ts";
+
+const row = (overrides: Record<string, unknown> = {}) => ({
+	id: "faint-token-meaning",
+	pillar: "color",
+	class: "blocking",
+	machineCheck: "vlm",
+	source: "design-system-manifest.md#four-pillars",
+	statement: "A meaning-carrying label never sits on a decorative faint token.",
+	counterexample: "Timestamp-styled --text-faint on the error banner's message.",
+	...overrides,
+});
+
+const parse = (rows: ReadonlyArray<unknown>) => parseRegistry(JSON.stringify({rows}));
+
+describe("parseRegistry", () => {
+	it("returns the rows verbatim, in file order", () => {
+		const parsed = parse([row(), row({id: "second-row"})]);
+		expect(parsed._tag).toBe("Rows");
+		if (parsed._tag !== "Rows") return;
+		expect(parsed.rows.map((r) => r.id)).toEqual(["faint-token-meaning", "second-row"]);
+	});
+
+	it("refuses zero rows — a law file that names no law is malformed, not minimal", () => {
+		expect(parse([])).toEqual({
+			_tag: "Violation",
+			violation: '"rows" is empty — a law file that names no law',
+		});
+	});
+
+	/** Whole-file, always: a generator holding half the law believes it holds the law. */
+	it.each([
+		[
+			"a missing field",
+			row({statement: undefined}),
+			"rows[0].statement is missing or not a string",
+		],
+		["an unknown field", row({extra: "x"}), 'rows[0] carries an unknown field "extra"'],
+		[
+			"an off-enum class",
+			row({class: "advisery"}),
+			'rows[0].class "advisery" is off its enum (blocking | advisory)',
+		],
+		[
+			"an off-enum machineCheck",
+			row({machineCheck: "eyeball"}),
+			'rows[0].machineCheck "eyeball" is off its enum (verb | vlm | none)',
+		],
+		["a non-kebab id", row({id: "Faint Token"}), 'rows[0].id "Faint Token" is not kebab-case'],
+	])("refuses the whole file on %s", (_label, bad, violation) => {
+		expect(parse([bad])).toEqual({_tag: "Violation", violation});
+	});
+
+	it("refuses a duplicate id, naming the second occurrence", () => {
+		expect(parse([row(), row()])).toEqual({
+			_tag: "Violation",
+			violation: 'rows[1].id "faint-token-meaning" is a duplicate',
+		});
+	});
+
+	it("refuses bytes that are not JSON at all", () => {
+		const parsed = parseRegistry("{");
+		expect(parsed._tag).toBe("Violation");
+	});
+
+	it("refuses a top level that carries no rows array", () => {
+		expect(parseRegistry('{"prohibitions":[]}')).toEqual({
+			_tag: "Violation",
+			violation: '"rows" is missing or not an array',
+		});
+	});
+});

--- a/packages/fabrika-cli/src/ui/leg-failed.ts
+++ b/packages/fabrika-cli/src/ui/leg-failed.ts
@@ -1,0 +1,16 @@
+/**
+ * The one tagged failure the group's impure legs carry in their `E` channel before folding it into a
+ * value the verb can refuse on.
+ *
+ * Tagged rather than a bare `Error` so two legs' failures stay distinguishable in a composed effect —
+ * the same discipline `../io/fs.ts` applies to reads.
+ */
+import * as Schema from "effect/Schema";
+
+export class LegFailed extends Schema.TaggedErrorClass<LegFailed>()("fabrika-cli/ui/LegFailed", {
+	reason: Schema.String,
+}) {}
+
+/** Lower an unknown thrown cause into the tagged failure, keeping its message. */
+export const legFailed = (cause: unknown): LegFailed =>
+	new LegFailed({reason: cause instanceof Error ? cause.message : String(cause)});

--- a/packages/fabrika-cli/src/ui/manifest-verb.ts
+++ b/packages/fabrika-cli/src/ui/manifest-verb.ts
@@ -1,0 +1,103 @@
+/**
+ * `ui manifest` — the repo's design surfaces, by convention: presence and paths, no judgment.
+ *
+ * The manifest is the one surface whose absence refuses, and it refuses on `12` rather than the
+ * generic zero-scope `7`: an un-bootstrapped repo is a *routable* state with a named next step
+ * (front-door's bootstrap, #4952), not an absence to report. Everything else reports `null`, because
+ * "this repo ships no inventory" is a fact a skill acts on.
+ *
+ * A probe that could not be *performed* is `11`. Presence is UNKNOWN, never "absent" — `node:fs`'s
+ * `existsSync` reports an unreadable parent directory as absent, which is how a missing law comes to
+ * look like a repo that never had one.
+ */
+import {Effect, type FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {exists} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {NO_MANIFEST, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {
+	atRoot,
+	GOLDEN_POINTER_PATHS,
+	HARNESS_PATH,
+	INVENTORY_PATH,
+	MANIFEST_PATH,
+	REGISTRY_PATH,
+} from "./conventions.ts";
+import {resolveRoot} from "./lane.ts";
+
+const VERB = "ui manifest";
+
+export type Probe =
+	| {readonly _tag: "Present"; readonly relative: string}
+	| {readonly _tag: "Absent"}
+	| {readonly _tag: "Unknown"; readonly relative: string; readonly reason: string};
+
+/** Probe one convention path. A read fault is its own outcome, never folded into "absent". */
+export const probe = (
+	root: string,
+	relative: string,
+): Effect.Effect<Probe, never, FileSystem.FileSystem> =>
+	exists(atRoot(root, relative)).pipe(
+		Effect.map((found): Probe => (found ? {_tag: "Present", relative} : {_tag: "Absent"})),
+		Effect.catchTag("fabrika-cli/ReadFailed", (cause) =>
+			Effect.succeed<Probe>({_tag: "Unknown", relative, reason: cause.reason}),
+		),
+	);
+
+/** The first present path of a probe order, or the absence/unknown that decided it. */
+const probeOrder = (
+	root: string,
+	relatives: ReadonlyArray<string>,
+): Effect.Effect<Probe, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		for (const relative of relatives) {
+			const found = yield* probe(root, relative);
+			if (found._tag !== "Absent") return found;
+		}
+		return {_tag: "Absent"} as const;
+	});
+
+const unreadable = (found: Probe & {_tag: "Unknown"}, verb: string): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`${verb}: cannot probe ${found.relative}: ${found.reason} — presence is UNKNOWN, never "absent".`,
+	);
+
+export const MISSING_MANIFEST = `${VERB}: no design manifest at ${MANIFEST_PATH} — this repo is not set up for UI construction. Run /fabrika: front-door's bootstrap drafts one from the repo's own CSS and pages (#4952). Never improvise a design language.`;
+
+export const runManifest = (): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const root = yield* resolveRoot(VERB);
+		if (root._tag === "Refused") return root.outcome;
+
+		const manifest = yield* probe(root.root, MANIFEST_PATH);
+		if (manifest._tag === "Unknown") return unreadable(manifest, VERB);
+		if (manifest._tag === "Absent") return refuse(NO_MANIFEST, MISSING_MANIFEST);
+
+		const registry = yield* probe(root.root, REGISTRY_PATH);
+		if (registry._tag === "Unknown") return unreadable(registry, VERB);
+		const inventory = yield* probe(root.root, INVENTORY_PATH);
+		if (inventory._tag === "Unknown") return unreadable(inventory, VERB);
+		const pointer = yield* probeOrder(root.root, GOLDEN_POINTER_PATHS);
+		if (pointer._tag === "Unknown") return unreadable(pointer, VERB);
+		const harness = yield* probe(root.root, HARNESS_PATH);
+		if (harness._tag === "Unknown") return unreadable(harness, VERB);
+
+		const pathOf = (found: Probe): string | null =>
+			found._tag === "Present" ? found.relative : null;
+		return answer(
+			JSON.stringify({
+				manifest: MANIFEST_PATH,
+				registry: pathOf(registry),
+				inventory: pathOf(inventory),
+				goldenPointer: pathOf(pointer),
+				harness: pathOf(harness),
+				lawSource: registry._tag === "Present" ? "registry" : "manifest-prose",
+			}),
+			[`${VERB}: probed 5 convention paths against ${root.root}.`],
+		);
+	});

--- a/packages/fabrika-cli/src/ui/manifest-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/manifest-verb.unit.test.ts
@@ -1,0 +1,84 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED} from "../build/fixtures.test-support.ts";
+import {fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {NO_MANIFEST, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {type FakeBytesFsOptions, fakeBytesFs} from "./fakes.test-support.ts";
+import {runManifest} from "./manifest-verb.ts";
+
+const REV_PARSE: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^git rev-parse --path-format=absolute/, LINKED],
+];
+
+const ROOT = "/repo/trees/lane-a";
+
+const run = (
+	fs: FakeBytesFsOptions,
+	script: ReadonlyArray<readonly [RegExp, ExecResult]> = REV_PARSE,
+) =>
+	Effect.runPromise(
+		Effect.provide(runManifest(), Layer.merge(fakeShell(script).layer, fakeBytesFs(fs).layer)),
+	);
+
+const MANIFEST = `${ROOT}/design-system-manifest.md`;
+
+describe("runManifest", () => {
+	it("reports every convention path, null where the repo ships none", async () => {
+		const outcome = await run({files: {[MANIFEST]: "# design"}});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			manifest: "design-system-manifest.md",
+			registry: null,
+			inventory: null,
+			goldenPointer: null,
+			harness: null,
+			lawSource: "manifest-prose",
+		});
+	});
+
+	it('reads lawSource as "registry" when the typed law is committed', async () => {
+		const outcome = await run({
+			files: {[MANIFEST]: "# design", [`${ROOT}/design-prohibitions.json`]: "{}"},
+		});
+		expect(JSON.parse(outcome.stdout).lawSource).toBe("registry");
+	});
+
+	it("prefers the package-local golden pointer over the root fallback", async () => {
+		const outcome = await run({
+			files: {
+				[MANIFEST]: "# design",
+				[`${ROOT}/packages/design-capture/golden-pointer.json`]: "{}",
+				[`${ROOT}/design-goldens.json`]: "{}",
+			},
+		});
+		expect(JSON.parse(outcome.stdout).goldenPointer).toBe(
+			"packages/design-capture/golden-pointer.json",
+		);
+	});
+
+	it("refuses an un-bootstrapped repo on 12, routing to front-door", async () => {
+		const outcome = await run({files: {}});
+		expect(outcome.code).toBe(NO_MANIFEST);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("no design manifest at design-system-manifest.md");
+	});
+
+	/** Presence is UNKNOWN, never "absent" — the fail-open an existsSync would have taken. */
+	it("refuses an unprobeable convention path on 11", async () => {
+		const outcome = await run({
+			files: {[MANIFEST]: "# design"},
+			unprobeable: [`${ROOT}/design-system-inventory.md`],
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain('presence is UNKNOWN, never "absent"');
+	});
+
+	it("refuses on 11 when the repo root itself cannot be resolved", async () => {
+		const outcome = await run({files: {}}, [
+			[/^git rev-parse/, {ok: false, stdout: "", reason: "not a git repository"}],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("cannot resolve the repo root");
+	});
+});

--- a/packages/fabrika-cli/src/ui/png.ts
+++ b/packages/fabrika-cli/src/ui/png.ts
@@ -1,0 +1,182 @@
+/**
+ * The PNG decoder the `ui` group validates and diffs with — `node:zlib` and nothing else.
+ *
+ * A capture nobody can open is not evidence (#3925's class), so "is this PNG valid?" has to be
+ * answered by actually decoding it: zero bytes, a truncated stream, a corrupt IDAT and a zero-area
+ * image are all facts a header sniff would miss. The decoder is deliberately dependency-free —
+ * fabrika is a published package an adopter installs, and a codec dependency for a few hundred lines
+ * of spec-defined unfiltering buys nothing.
+ *
+ * The supported subset is 8-bit, non-interlaced, colour types 0/2/3/4/6 — what every headless-browser
+ * screenshot emits. Anything else decodes to an {@link Invalid} with the encoding named, never to a
+ * silently wrong raster.
+ */
+import {createHash} from "node:crypto";
+import {inflateSync} from "node:zlib";
+
+/** A decoded image: `pixels` is RGBA, row-major, length exactly `width * height * 4`. */
+export interface RasterImage {
+	readonly width: number;
+	readonly height: number;
+	readonly pixels: Uint8Array;
+}
+
+export type PngRead =
+	| {readonly _tag: "Image"; readonly image: RasterImage}
+	/** Proven invalid: the bytes are not a decodable, non-zero-area PNG. `detail` names why. */
+	| {readonly _tag: "Invalid"; readonly detail: string};
+
+const SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+const CHANNELS: Readonly<Record<number, number>> = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4};
+
+const invalid = (detail: string): PngRead => ({_tag: "Invalid", detail});
+
+const paeth = (a: number, b: number, c: number): number => {
+	const p = a + b - c;
+	const pa = Math.abs(p - a);
+	const pb = Math.abs(p - b);
+	const pc = Math.abs(p - c);
+	if (pa <= pb && pa <= pc) return a;
+	return pb <= pc ? b : c;
+};
+
+/** Reverse the per-scanline filters in place, yielding raw samples row-major. */
+const unfilter = (raw: Buffer, width: number, height: number, bpp: number): Buffer | string => {
+	const stride = width * bpp;
+	if (raw.length < height * (stride + 1)) return "the pixel stream is truncated";
+	const out = Buffer.alloc(height * stride);
+	let pos = 0;
+	for (let y = 0; y < height; y++) {
+		const filter = raw[pos++] as number;
+		const rowStart = y * stride;
+		for (let x = 0; x < stride; x++) {
+			const value = raw[pos + x] as number;
+			const left = x >= bpp ? (out[rowStart + x - bpp] as number) : 0;
+			const up = y > 0 ? (out[rowStart - stride + x] as number) : 0;
+			const upLeft = y > 0 && x >= bpp ? (out[rowStart - stride + x - bpp] as number) : 0;
+			let restored: number;
+			switch (filter) {
+				case 0:
+					restored = value;
+					break;
+				case 1:
+					restored = value + left;
+					break;
+				case 2:
+					restored = value + up;
+					break;
+				case 3:
+					restored = value + ((left + up) >> 1);
+					break;
+				case 4:
+					restored = value + paeth(left, up, upLeft);
+					break;
+				default:
+					return `scanline ${y} carries an unknown filter type ${filter}`;
+			}
+			out[rowStart + x] = restored & 0xff;
+		}
+		pos += stride;
+	}
+	return out;
+};
+
+const toRgba = (
+	samples: Buffer,
+	width: number,
+	height: number,
+	colorType: number,
+	palette: Buffer | null,
+	transparency: Buffer | null,
+): Uint8Array | string => {
+	const channels = CHANNELS[colorType] as number;
+	const pixels = new Uint8Array(width * height * 4);
+	for (let p = 0; p < width * height; p++) {
+		const src = p * channels;
+		const dst = p * 4;
+		if (colorType === 3) {
+			const index = samples[src] as number;
+			if (palette === null || index * 3 + 2 >= palette.length) {
+				return `a palette index (${index}) falls outside the PLTE chunk`;
+			}
+			pixels[dst] = palette[index * 3] as number;
+			pixels[dst + 1] = palette[index * 3 + 1] as number;
+			pixels[dst + 2] = palette[index * 3 + 2] as number;
+			pixels[dst + 3] =
+				transparency !== null && index < transparency.length
+					? (transparency[index] as number)
+					: 255;
+			continue;
+		}
+		const gray = colorType === 0 || colorType === 4;
+		pixels[dst] = samples[src] as number;
+		pixels[dst + 1] = gray ? (samples[src] as number) : (samples[src + 1] as number);
+		pixels[dst + 2] = gray ? (samples[src] as number) : (samples[src + 2] as number);
+		pixels[dst + 3] =
+			colorType === 6
+				? (samples[src + 3] as number)
+				: colorType === 4
+					? (samples[src + 1] as number)
+					: 255;
+	}
+	return pixels;
+};
+
+/** Decode PNG bytes into an RGBA raster, or say — in one sentence — why they are not one. */
+export const decodePng = (bytes: Uint8Array): PngRead => {
+	if (bytes.length === 0) return invalid("zero bytes");
+	if (bytes.length < 8 || SIGNATURE.some((byte, i) => bytes[i] !== byte)) {
+		return invalid("the bytes do not carry a PNG signature");
+	}
+	const buf = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	let offset = 8;
+	let width = 0;
+	let height = 0;
+	let colorType = -1;
+	let bitDepth = 0;
+	let interlace = 0;
+	let palette: Buffer | null = null;
+	let transparency: Buffer | null = null;
+	const idat: Buffer[] = [];
+	while (offset + 8 <= buf.length) {
+		const length = buf.readUInt32BE(offset);
+		const type = buf.toString("ascii", offset + 4, offset + 8);
+		const start = offset + 8;
+		if (start + length > buf.length) return invalid(`the ${type} chunk is truncated`);
+		const data = buf.subarray(start, start + length);
+		if (type === "IHDR") {
+			width = data.readUInt32BE(0);
+			height = data.readUInt32BE(4);
+			bitDepth = data[8] as number;
+			colorType = data[9] as number;
+			interlace = data[12] as number;
+		} else if (type === "PLTE") palette = Buffer.from(data);
+		else if (type === "tRNS") transparency = Buffer.from(data);
+		else if (type === "IDAT") idat.push(Buffer.from(data));
+		else if (type === "IEND") break;
+		offset = start + length + 4;
+	}
+	if (colorType === -1) return invalid("the stream carries no IHDR chunk");
+	if (width === 0 || height === 0) return invalid(`zero area (${width}x${height})`);
+	if (bitDepth !== 8)
+		return invalid(`unsupported bit depth ${bitDepth} — only 8-bit is decodable here`);
+	if (interlace !== 0) return invalid("interlaced PNGs are not decodable here");
+	if (CHANNELS[colorType] === undefined) return invalid(`unsupported colour type ${colorType}`);
+	if (idat.length === 0) return invalid("the stream carries no IDAT chunk");
+
+	let raw: Buffer;
+	try {
+		raw = inflateSync(Buffer.concat(idat));
+	} catch (err) {
+		return invalid(`the pixel stream does not inflate (${(err as Error).message})`);
+	}
+	const samples = unfilter(raw, width, height, CHANNELS[colorType] as number);
+	if (typeof samples === "string") return invalid(samples);
+	const pixels = toRgba(samples, width, height, colorType, palette, transparency);
+	if (typeof pixels === "string") return invalid(pixels);
+	return {_tag: "Image", image: {width, height, pixels}};
+};
+
+/** The lowercase-hex sha256 of some bytes — the content address every capture is named by. */
+export const sha256Of = (bytes: Uint8Array): string =>
+	createHash("sha256").update(bytes).digest("hex");

--- a/packages/fabrika-cli/src/ui/png.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/png.unit.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from "vitest";
+import {encodePng, solid} from "./fakes.test-support.ts";
+import {decodePng, sha256Of} from "./png.ts";
+
+describe("decodePng", () => {
+	it("round-trips an RGBA raster through a real PNG", () => {
+		const pixels = solid(3, 2, [10, 20, 30, 255]);
+		const decoded = decodePng(encodePng(3, 2, pixels));
+		expect(decoded._tag).toBe("Image");
+		if (decoded._tag !== "Image") return;
+		expect(decoded.image.width).toBe(3);
+		expect(decoded.image.height).toBe(2);
+		expect([...decoded.image.pixels]).toEqual([...pixels]);
+	});
+
+	/** Every one of these is what "a capture nobody can open" looks like on disk (#3925's class). */
+	it.each([
+		["zero bytes", new Uint8Array(0), "zero bytes"],
+		[
+			"a non-PNG file",
+			new TextEncoder().encode("not a png at all"),
+			"the bytes do not carry a PNG signature",
+		],
+	])("calls %s invalid, naming why", (_label, bytes, detail) => {
+		expect(decodePng(bytes)).toEqual({_tag: "Invalid", detail});
+	});
+
+	it("calls a PNG truncated mid-IDAT invalid rather than decoding a partial image", () => {
+		const png = encodePng(4, 4, solid(4, 4, [0, 0, 0, 255]));
+		// Past the IEND chunk and into the pixel stream: a cut that only loses IEND is still a
+		// complete image, so the truncation has to reach the data to be a truncation at all.
+		const decoded = decodePng(png.subarray(0, png.length - 20));
+		expect(decoded._tag).toBe("Invalid");
+	});
+});
+
+describe("sha256Of", () => {
+	it("is the content address the pointer and the set manifest both key on", () => {
+		expect(sha256Of(new TextEncoder().encode("abc"))).toBe(
+			"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		);
+	});
+});

--- a/packages/fabrika-cli/src/ui/pointer.ts
+++ b/packages/fabrika-cli/src/ui/pointer.ts
@@ -1,0 +1,68 @@
+/**
+ * The golden pointer as `ui golden` reads it: `{"store": "<base URL>", "surfaces": {"<id>":
+ * {"sha256": "<hex>"}}}`, the bytes resolving as `GET <store>/<sha256>.png`.
+ *
+ * An unreadable pointer is **never** an empty blessed set. v1's probe resolved a failed read to zero
+ * blessed surfaces with `|| true` (#4501), which reads to a caller as "nothing to compare against"
+ * — the fail-open this parser and its `4`/`11` seats exist to refuse.
+ *
+ * Entry fields beyond `sha256` (phoenix's shipped file carries `blessedDate` and `intent`, ADR 0183
+ * §2) are carried by the repo, not by this contract, so they parse and are ignored rather than
+ * refused. A pointer that names surfaces without a `store` is malformed: the bytes are unreachable,
+ * and answering "blessed" for a golden nothing can fetch would be worse than refusing.
+ */
+import {isSha256Hex} from "../capture/golden-pointer.ts";
+
+export interface UiGoldenPointer {
+	readonly store: string | null;
+	readonly surfaces: Readonly<Record<string, string>>;
+}
+
+export type PointerParse =
+	| {readonly _tag: "Pointer"; readonly pointer: UiGoldenPointer}
+	| {readonly _tag: "Violation"; readonly violation: string};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const parsePointer = (text: string): PointerParse => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (err) {
+		return {_tag: "Violation", violation: `the file is not JSON (${(err as Error).message})`};
+	}
+	if (!isRecord(parsed)) return {_tag: "Violation", violation: "the top level is not an object"};
+	const rawSurfaces = parsed.surfaces ?? {};
+	if (!isRecord(rawSurfaces)) return {_tag: "Violation", violation: '"surfaces" is not an object'};
+	const surfaces: Record<string, string> = {};
+	for (const [id, entry] of Object.entries(rawSurfaces)) {
+		if (!isRecord(entry) || typeof entry.sha256 !== "string") {
+			return {_tag: "Violation", violation: `surfaces["${id}"] carries no string sha256`};
+		}
+		if (!isSha256Hex(entry.sha256)) {
+			return {
+				_tag: "Violation",
+				violation: `surfaces["${id}"].sha256 is not a 64-hex content address`,
+			};
+		}
+		surfaces[id] = entry.sha256;
+	}
+	const store = parsed.store;
+	if (store !== undefined && typeof store !== "string") {
+		return {_tag: "Violation", violation: '"store" is not a string'};
+	}
+	if (store === undefined && Object.keys(surfaces).length > 0) {
+		return {
+			_tag: "Violation",
+			violation: 'it names surfaces but carries no "store" — the blessed bytes are unreachable',
+		};
+	}
+	return {
+		_tag: "Pointer",
+		pointer: {store: store === undefined ? null : store.replace(/\/+$/, ""), surfaces},
+	};
+};
+
+/** The immutable URL a surface's blessed bytes resolve at. */
+export const goldenUrl = (store: string, sha256: string): string => `${store}/${sha256}.png`;

--- a/packages/fabrika-cli/src/ui/pointer.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/pointer.unit.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, it} from "vitest";
+import {goldenUrl, parsePointer} from "./pointer.ts";
+
+const SHA = "9c41f2a1b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e";
+
+describe("parsePointer", () => {
+	it("reads the store and every surface's content address", () => {
+		const parsed = parsePointer(
+			JSON.stringify({store: "https://depo.example/", surfaces: {"/pano": {sha256: SHA}}}),
+		);
+		expect(parsed).toEqual({
+			_tag: "Pointer",
+			pointer: {store: "https://depo.example", surfaces: {"/pano": SHA}},
+		});
+	});
+
+	/** Phoenix's shipped pointer predates the `store` key while the corpus is empty. */
+	it("accepts an empty surfaces map with no store", () => {
+		expect(parsePointer('{"surfaces":{}}')).toEqual({
+			_tag: "Pointer",
+			pointer: {store: null, surfaces: {}},
+		});
+	});
+
+	it("carries repo-owned entry fields through rather than refusing them", () => {
+		const parsed = parsePointer(
+			JSON.stringify({
+				store: "https://depo.example",
+				surfaces: {"/pano": {sha256: SHA, blessedDate: "2026-08-09", intent: "the feed"}},
+			}),
+		);
+		expect(parsed._tag).toBe("Pointer");
+	});
+
+	it.each([
+		["bytes that are not JSON", "{", "the file is not JSON"],
+		[
+			"surfaces without a store — the blessed bytes are unreachable",
+			JSON.stringify({surfaces: {"/pano": {sha256: SHA}}}),
+			'it names surfaces but carries no "store"',
+		],
+		[
+			"a sha that is not a content address",
+			JSON.stringify({store: "https://depo.example", surfaces: {"/pano": {sha256: `${SHA}.png`}}}),
+			"is not a 64-hex content address",
+		],
+	])("refuses %s", (_label, text, fragment) => {
+		const parsed = parsePointer(text);
+		expect(parsed._tag).toBe("Violation");
+		if (parsed._tag !== "Violation") return;
+		expect(parsed.violation).toContain(fragment);
+	});
+});
+
+describe("goldenUrl", () => {
+	it("resolves bytes content-addressed under the store", () => {
+		expect(goldenUrl("https://depo.example", SHA)).toBe(`https://depo.example/${SHA}.png`);
+	});
+});

--- a/packages/fabrika-cli/src/ui/pull-head.ts
+++ b/packages/fabrika-cli/src/ui/pull-head.ts
@@ -1,0 +1,26 @@
+/**
+ * The one PR field `ui evidence` needs that `../io/pulls.ts`'s record does not carry: the head
+ * branch. An evidence comment on a PR whose head is some *other* lane's branch is a cross-lane
+ * write, so the check needs the ref itself, not the head SHA the record already holds.
+ *
+ * Read through `gh api` REST like every other GitHub access here (skill conventions §11), and a shape
+ * that is not a branch name is a failure rather than an empty string — an unreadable ref must not
+ * compare equal to a detached HEAD.
+ */
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import type {Shell} from "../io/git.ts";
+
+export type HeadRef =
+	| {readonly _tag: "Ref"; readonly ref: string}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+export const pullHeadRef = (repo: string, pr: number): Shell<HeadRef> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/pulls/${pr}`, "--jq", ".head.ref"]);
+		if (!r.ok) return {_tag: "Unknown" as const, reason: r.reason};
+		const ref = r.stdout.trim();
+		return ref === ""
+			? {_tag: "Unknown" as const, reason: "`gh api` exited 0 but named no head branch"}
+			: {_tag: "Ref" as const, ref};
+	});

--- a/packages/fabrika-cli/src/ui/render-verb.ts
+++ b/packages/fabrika-cli/src/ui/render-verb.ts
@@ -1,0 +1,289 @@
+/**
+ * `ui render` — render the named surfaces in this tree and capture one **validated** PNG each.
+ *
+ * Two properties carry the whole verb. First, scope is exactly the `--surface` operands: nothing here
+ * scans a diff, so "rendered nothing, found nothing wrong" is unrepresentable (ADR 0092), and a
+ * dropped surface is the skill's explicit act — re-invoking without it — never the tool's silent
+ * tolerance (#4305 / #3232). Second, validity is part of the answer: a capture that is zero bytes,
+ * undecodable or zero-area is `16`, because a capture nobody can open is not evidence (#3925's class)
+ * and v1 checked capture success nowhere at all.
+ *
+ * The set manifest is the seam to `ui evidence`: `<set>/manifest.json` holds the exact stdout bytes,
+ * so no value crosses that seam by memory.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {requireSession} from "../build/claim.ts";
+import {isKebabSlug} from "../build/lane.ts";
+import {laneScratchDir} from "../build/scratch-verb.ts";
+import {resolveTargetRepo} from "../build/target.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {readBytes, writeText} from "./bytes.ts";
+import {
+	BAD_SECTIONS,
+	CAPTURE_INVALID,
+	NO_HARNESS,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	RENDER_CRASHED,
+	SURFACE_UNREACHABLE,
+} from "./codes.ts";
+import {atRoot, HARNESS_PATH} from "./conventions.ts";
+import {type HarnessConfig, parseHarness, surfaceSlug} from "./harness.ts";
+import {requireUiLane} from "./lane.ts";
+import {probe} from "./manifest-verb.ts";
+import {decodePng, sha256Of} from "./png.ts";
+
+const VERB = "ui render";
+
+/** One shot's proven outcome — the four the exit matrix routes on, decided by the impure leg. */
+export type ShotOutcome =
+	| {readonly _tag: "Captured"}
+	| {readonly _tag: "Unreachable"; readonly reason: string}
+	| {readonly _tag: "Crashed"; readonly error: string}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+export interface ShotRequest {
+	readonly url: string;
+	readonly outPath: string;
+	readonly viewport: {readonly width: number; readonly height: number};
+}
+
+/** The injected browser leg: navigate, classify, screenshot to `outPath`. */
+export type BrowseLeg = (request: ShotRequest) => Effect.Effect<ShotOutcome>;
+
+export type HarnessStart =
+	| {readonly _tag: "Ready"; readonly stop: Effect.Effect<void>}
+	| {readonly _tag: "Failed"; readonly reason: string}
+	| {readonly _tag: "NotReady"; readonly tail: string};
+
+/** The injected dev-server leg: start the repo's own command, poll readiness, hand back a killer. */
+export type HarnessLeg = (config: HarnessConfig, root: string) => Effect.Effect<HarnessStart>;
+
+export interface RenderOptions {
+	readonly out: string;
+	readonly surfaces: ReadonlyArray<string>;
+	readonly firstRender: ReadonlyArray<string>;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly tmpRoot: string;
+	readonly startHarness: HarnessLeg;
+	readonly browse: BrowseLeg;
+}
+
+interface Capture {
+	readonly surface: string;
+	readonly path: string;
+	readonly width: number;
+	readonly height: number;
+	readonly sha256: string;
+	readonly firstRender: boolean;
+}
+
+type SurfaceResult =
+	| {readonly _tag: "Ok"; readonly capture: Capture}
+	| {readonly _tag: "Bad"; readonly code: number; readonly line: string};
+
+/** A usage/vocabulary refusal on the operands, or `null` when they are well formed. */
+export const checkOperands = (options: RenderOptions): VerbOutcome | null => {
+	if (options.surfaces.length === 0) {
+		return refuse(
+			FAILED,
+			`${VERB}: --surface is required at least once — no tool guesses surfaces from a diff.`,
+		);
+	}
+	if (!isKebabSlug(options.out) || options.out.includes("/")) {
+		return refuse(OFF_VOCABULARY, `${VERB}: --out "${options.out}" is not a kebab-case set name.`);
+	}
+	for (const surface of options.surfaces) {
+		if (surface.includes(":")) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --surface "${surface}" carries a :state suffix — states are a reserved grammar, not yet realized; render the bare route.`,
+			);
+		}
+		if (!surface.startsWith("/")) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --surface "${surface}" is not a bare route — a surface id begins with "/".`,
+			);
+		}
+	}
+	for (const first of options.firstRender) {
+		if (!options.surfaces.includes(first)) {
+			return refuse(
+				FAILED,
+				`${VERB}: --first-render "${first}" names a surface that is not being rendered.`,
+			);
+		}
+	}
+	return null;
+};
+
+const shoot = (
+	options: RenderOptions,
+	config: HarnessConfig,
+	setDir: string,
+	surface: string,
+): Effect.Effect<SurfaceResult, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const outPath = `${setDir}/${surfaceSlug(surface)}.png`;
+		const shot = yield* options.browse({
+			url: `${config.url}${surface}`,
+			outPath,
+			viewport: config.viewport,
+		});
+		if (shot._tag === "Unreachable") {
+			return {
+				_tag: "Bad" as const,
+				code: SURFACE_UNREACHABLE,
+				line: `${VERB}: surface "${surface}" is unreachable in this tree (${shot.reason}) — fix reachability, or drop it explicitly and carry the reason into the PR's Deviations (#4305).`,
+			};
+		}
+		if (shot._tag === "Crashed") {
+			return {
+				_tag: "Bad" as const,
+				code: RENDER_CRASHED,
+				line: `${VERB}: surface "${surface}" threw during render: ${shot.error} — the render is red; fix it before looking.`,
+			};
+		}
+		if (shot._tag === "Unknown") {
+			return {
+				_tag: "Bad" as const,
+				code: PRECONDITION_UNKNOWN,
+				line: `${VERB}: cannot determine the validity of ${outPath}: ${shot.reason} — the capture is UNKNOWN, never valid.`,
+			};
+		}
+		const bytes = yield* readBytes(outPath);
+		if (bytes._tag === "Failed") {
+			return {
+				_tag: "Bad" as const,
+				code: PRECONDITION_UNKNOWN,
+				line: `${VERB}: cannot determine the validity of ${outPath}: ${bytes.reason} — the capture is UNKNOWN, never valid.`,
+			};
+		}
+		const image = decodePng(bytes.bytes);
+		if (image._tag === "Invalid") {
+			return {
+				_tag: "Bad" as const,
+				code: CAPTURE_INVALID,
+				line: `${VERB}: surface "${surface}" captured invalid bytes (${image.detail}) — a capture nobody can open is not evidence (#3925's class).`,
+			};
+		}
+		return {
+			_tag: "Ok" as const,
+			capture: {
+				surface,
+				path: outPath,
+				width: image.image.width,
+				height: image.image.height,
+				sha256: sha256Of(bytes.bytes),
+				firstRender: options.firstRender.includes(surface),
+			},
+		};
+	});
+
+export const runRender = (
+	options: RenderOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const bad = checkOperands(options);
+		if (bad !== null) return bad;
+
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const lane = yield* requireUiLane(
+			VERB,
+			resolved.repo,
+			session.id,
+			(detail: string) =>
+				`${VERB}: this session does not hold the claim the checked-out branch names (${detail}) — the lane is not yours.`,
+		);
+		if (lane._tag === "Refused") return lane.outcome;
+
+		const harnessProbe = yield* probe(lane.root, HARNESS_PATH);
+		if (harnessProbe._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot probe ${HARNESS_PATH}: ${harnessProbe.reason} — the render path is UNKNOWN.`,
+				lane.notes,
+			);
+		}
+		if (harnessProbe._tag === "Absent") {
+			return refuse(
+				NO_HARNESS,
+				`${VERB}: no ${HARNESS_PATH} at the repo root — this repo declares no headless render path; add one (see the harness config schema).`,
+				lane.notes,
+			);
+		}
+		const raw = yield* readBytes(atRoot(lane.root, HARNESS_PATH));
+		if (raw._tag === "Failed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${HARNESS_PATH}: ${raw.reason} — the render path is UNKNOWN.`,
+				lane.notes,
+			);
+		}
+		const harness = parseHarness(new TextDecoder().decode(raw.bytes));
+		if (harness._tag === "Violation") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: ${HARNESS_PATH} exists but does not satisfy its schema: ${harness.violation}.`,
+				lane.notes,
+			);
+		}
+
+		const setDir = `${laneScratchDir(options.tmpRoot, session.id, lane.number, lane.nonce)}/${options.out}`;
+		const started = yield* options.startHarness(harness.config, lane.root);
+		if (started._tag === "Failed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: the render harness could not start: ${started.reason} — every surface is UNKNOWN.`,
+				lane.notes,
+			);
+		}
+		if (started._tag === "NotReady") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: the harness did not answer 200 on ${harness.config.readyPath} within the readiness bound — every surface is UNKNOWN; server stderr tail: ${started.tail}.`,
+				lane.notes,
+			);
+		}
+
+		const results = yield* Effect.forEach(
+			options.surfaces,
+			(surface) => shoot(options, harness.config, setDir, surface),
+			{concurrency: 1},
+		).pipe(Effect.ensuring(started.stop));
+
+		const notes = [
+			...lane.notes,
+			`${VERB}: rendered ${options.surfaces.length} surface${options.surfaces.length === 1 ? "" : "s"} into ${setDir}.`,
+			...results.flatMap((result) => (result._tag === "Bad" ? [result.line] : [])),
+		];
+		const failed = results.filter((result) => result._tag === "Bad");
+		const firstFailure = failed[0];
+		if (firstFailure !== undefined) {
+			// The code routes and the stderr enumerates: with mixed outcomes the SMALLEST applicable
+			// code is reported, and every surface's own outcome is already on stderr above.
+			const code = Math.min(...failed.map((result) => result.code));
+			return refuse(
+				code,
+				`${VERB}: ${failed.length} of ${options.surfaces.length} surfaces did not produce a valid capture — the set is refused whole.`,
+				notes,
+			);
+		}
+
+		const captures = results.flatMap((result) => (result._tag === "Ok" ? [result.capture] : []));
+		const stdout = `${JSON.stringify({set: options.out, captures})}\n`;
+		const failure = yield* writeText(`${setDir}/manifest.json`, stdout);
+		return failure === null
+			? answer(stdout, notes)
+			: refuse(FAILED, `${VERB}: cannot write ${setDir}/manifest.json: ${failure}.`, notes);
+	});

--- a/packages/fabrika-cli/src/ui/render-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/render-verb.unit.test.ts
@@ -1,0 +1,217 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {comments, issue, LANE_UUID, LINKED, marker, NONCE} from "../build/fixtures.test-support.ts";
+import {fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {FAILED} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	CAPTURE_INVALID,
+	LANE_NOT_MINE,
+	NO_HARNESS,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	RENDER_CRASHED,
+	SURFACE_UNREACHABLE,
+} from "./codes.ts";
+import {encodePng, type FakeBytesFsOptions, fakeBytesFs, solid} from "./fakes.test-support.ts";
+import {type BrowseLeg, type HarnessLeg, runRender, type ShotOutcome} from "./render-verb.ts";
+
+const ROOT = "/repo/trees/lane-a";
+const HARNESS = `${ROOT}/design-harness.json`;
+const LANE = `build/4312-editor-focus-loss-${NONCE}`;
+const SET_DIR = `/tmp/fabrika-build/s-9f2e/4312-${NONCE}/after`;
+
+const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^git rev-parse --path-format=absolute/, LINKED],
+	[/^git rev-parse --abbrev-ref HEAD$/, okOut(`${LANE}\n`)],
+	[/^gh api repos\/o\/r\/issues\/4312$/, issue()],
+	[
+		/^gh api --paginate repos\/o\/r\/issues\/4312\/comments/,
+		comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
+	],
+	[/^gh api repos\/o\/r\/collaborators\/agent\/permission/, okOut("write\n")],
+];
+
+const PNG = encodePng(4, 4, solid(4, 4, [0, 0, 0, 255]));
+
+const ready: HarnessLeg = () => Effect.succeed({_tag: "Ready", stop: Effect.void});
+
+const options = {
+	out: "after",
+	surfaces: ["/pano"],
+	firstRender: [] as ReadonlyArray<string>,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+	tmpRoot: "/tmp",
+	startHarness: ready,
+};
+
+/** A browse leg that returns a scripted outcome per surface and "writes" the PNG the fake fs holds. */
+const browsing =
+	(outcome: (url: string) => ShotOutcome): BrowseLeg =>
+	(request) =>
+		Effect.succeed(outcome(request.url));
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	fs: FakeBytesFsOptions,
+	overrides: Partial<typeof options> & {browse?: BrowseLeg} = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runRender({
+				...options,
+				browse: browsing(() => ({_tag: "Captured"})),
+				...overrides,
+			}),
+			Layer.merge(fakeShell(script).layer, fakeBytesFs(fs).layer),
+		),
+	);
+
+const harnessFile = JSON.stringify({command: "pnpm dev", url: "http://127.0.0.1:5173"});
+const captured = {files: {[HARNESS]: harnessFile, [`${SET_DIR}/pano.png`]: PNG}};
+
+describe("runRender operands", () => {
+	it("refuses zero surfaces on 1 — no tool guesses surfaces from a diff", async () => {
+		const outcome = await run([], {}, {surfaces: []});
+		expect(outcome.code).toBe(FAILED);
+	});
+
+	it.each([
+		["a non-kebab --out", {out: "After"}, '--out "After" is not a kebab-case set name'],
+		["a reserved :state suffix", {surfaces: ["/pano:empty"]}, "carries a :state suffix"],
+	])("refuses %s on 10", async (_label, overrides, fragment) => {
+		const outcome = await run([], {}, overrides);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toContain(fragment);
+	});
+
+	it("refuses a --first-render naming a surface it is not rendering", async () => {
+		const outcome = await run([], {}, {firstRender: ["/sozluk"]});
+		expect(outcome.code).toBe(FAILED);
+	});
+});
+
+describe("runRender", () => {
+	it("answers the validated capture set and writes the manifest byte-identically", async () => {
+		const fs = fakeBytesFs(captured);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runRender({...options, browse: browsing(() => ({_tag: "Captured"}))}),
+				Layer.merge(fakeShell(LANE_OK).layer, fs.layer),
+			),
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			set: "after",
+			captures: [
+				{
+					surface: "/pano",
+					path: `${SET_DIR}/pano.png`,
+					width: 4,
+					height: 4,
+					sha256: expect.any(String),
+					firstRender: false,
+				},
+			],
+		});
+		const written = fs.written.get(`${SET_DIR}/manifest.json`);
+		expect(new TextDecoder().decode(written)).toBe(outcome.stdout);
+	});
+
+	it("records a --first-render surface as such", async () => {
+		const outcome = await run(LANE_OK, captured, {firstRender: ["/pano"]});
+		expect(JSON.parse(outcome.stdout).captures[0].firstRender).toBe(true);
+	});
+
+	it.each([
+		[
+			"an unreachable surface",
+			() => ({_tag: "Unreachable", reason: "HTTP 404"}) as ShotOutcome,
+			SURFACE_UNREACHABLE,
+			"is unreachable in this tree",
+		],
+		[
+			"a crashed render",
+			() => ({_tag: "Crashed", error: "TypeError: x"}) as ShotOutcome,
+			RENDER_CRASHED,
+			"threw during render",
+		],
+	])("refuses %s, naming it on stderr", async (_label, shot, code, fragment) => {
+		const outcome = await run(LANE_OK, captured, {browse: browsing(shot)});
+		expect(outcome.code).toBe(code);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain(fragment);
+	});
+
+	it("refuses an invalid capture on 16 — evidence nobody can open is not evidence", async () => {
+		const outcome = await run(LANE_OK, {
+			files: {[HARNESS]: harnessFile, [`${SET_DIR}/pano.png`]: new Uint8Array(0)},
+		});
+		expect(outcome.code).toBe(CAPTURE_INVALID);
+		expect(outcome.stderr.join("\n")).toContain("captured invalid bytes (zero bytes)");
+	});
+
+	it("reports the SMALLEST applicable code when outcomes mix, and enumerates every surface", async () => {
+		const outcome = await run(
+			LANE_OK,
+			{files: {[HARNESS]: harnessFile, [`${SET_DIR}/pano.png`]: PNG}},
+			{
+				surfaces: ["/pano", "/sozluk", "/yeni"],
+				browse: browsing((url) =>
+					url.endsWith("/sozluk")
+						? {_tag: "Crashed", error: "TypeError: x"}
+						: url.endsWith("/yeni")
+							? {_tag: "Unreachable", reason: "HTTP 404"}
+							: {_tag: "Captured"},
+				),
+			},
+		);
+		expect(outcome.code).toBe(RENDER_CRASHED);
+		expect(outcome.stderr.join("\n")).toContain("threw during render");
+		expect(outcome.stderr.join("\n")).toContain("is unreachable in this tree");
+	});
+
+	it("refuses on 11 when the harness never answers", async () => {
+		const outcome = await run(LANE_OK, captured, {
+			startHarness: () => Effect.succeed({_tag: "NotReady", tail: "EADDRINUSE"}),
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("server stderr tail: EADDRINUSE");
+	});
+
+	it("refuses a missing harness declaration on 19", async () => {
+		const outcome = await run(LANE_OK, {files: {}});
+		expect(outcome.code).toBe(NO_HARNESS);
+	});
+
+	it("refuses a harness that violates its schema on 4", async () => {
+		const outcome = await run(LANE_OK, {files: {[HARNESS]: "{}"}});
+		expect(outcome.code).toBe(BAD_SECTIONS);
+	});
+
+	it("refuses a foreign lane on 18", async () => {
+		const foreign = LANE_OK.map((row) =>
+			row[0].source.includes("comments")
+				? ([row[0], comments({id: 1, body: marker("other-session", LANE_UUID)})] as const)
+				: row,
+		);
+		const outcome = await run(foreign, captured);
+		expect(outcome.code).toBe(LANE_NOT_MINE);
+		expect(outcome.stderr.at(-1)).toContain("the lane is not yours");
+	});
+
+	it("refuses on 11 when the claim state cannot be read", async () => {
+		const unreadable = LANE_OK.map((row) =>
+			row[0].source.includes("comments")
+				? ([row[0], {ok: false, stdout: "", reason: "HTTP 502"}] as const)
+				: row,
+		);
+		const outcome = await run(unreadable, captured);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/ui/server.ts
+++ b/packages/fabrika-cli/src/ui/server.ts
@@ -1,0 +1,67 @@
+/**
+ * The impure harness leg: start the repo's own dev-server command, wait for it to answer, and hand
+ * back the killer `ui render` runs on every exit path.
+ *
+ * The command is the repo's declaration (`design-harness.json`), never this package's knowledge of
+ * any stack — that is what makes the group portable. The process is started in its own group and
+ * killed by group, because a dev server is habitually a wrapper that spawns the real listener: kill
+ * the wrapper alone and the port stays held for the next lane.
+ */
+import {spawn} from "node:child_process";
+import {Effect} from "effect";
+import {type HarnessConfig, READY_TIMEOUT_MS} from "./harness.ts";
+import {legFailed} from "./leg-failed.ts";
+import type {HarnessLeg, HarnessStart} from "./render-verb.ts";
+
+const POLL_INTERVAL_MS = 500;
+/** How much of the server's own stderr rides along in the not-ready refusal. */
+const TAIL_LIMIT = 2000;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const answers200 = (url: string): Promise<boolean> =>
+	fetch(url, {redirect: "follow"}).then(
+		(response) => response.status === 200,
+		() => false,
+	);
+
+export const spawnHarness: HarnessLeg = (config: HarnessConfig, root: string) =>
+	Effect.tryPromise({
+		try: async (): Promise<HarnessStart> => {
+			let stderr = "";
+			const child = spawn(config.command, {cwd: root, shell: true, detached: true});
+			child.stderr?.on("data", (chunk: Buffer) => {
+				stderr = `${stderr}${chunk.toString("utf8")}`.slice(-TAIL_LIMIT);
+			});
+			let spawnFailure: string | null = null;
+			child.on("error", (err) => {
+				spawnFailure = err.message;
+			});
+			// Kill the whole group, then fall back to the child alone: a `process.kill(-pid)` on a child
+			// that never became a group leader throws, and losing the fallback would leak the server.
+			const stop = Effect.try({
+				try: () => {
+					if (child.pid !== undefined) process.kill(-child.pid, "SIGTERM");
+				},
+				catch: legFailed,
+			}).pipe(Effect.catch(() => Effect.sync(() => void child.kill("SIGTERM"))));
+
+			const deadline = Date.now() + READY_TIMEOUT_MS;
+			while (Date.now() < deadline) {
+				if (spawnFailure !== null) return {_tag: "Failed", reason: spawnFailure};
+				if (child.exitCode !== null) {
+					return {
+						_tag: "Failed",
+						reason: `the command exited with ${child.exitCode}: ${stderr.trim()}`,
+					};
+				}
+				if (await answers200(`${config.url}${config.readyPath}`)) return {_tag: "Ready", stop};
+				await sleep(POLL_INTERVAL_MS);
+			}
+			await Effect.runPromise(stop);
+			return {_tag: "NotReady", tail: stderr.trim()};
+		},
+		catch: legFailed,
+	}).pipe(
+		Effect.catch((cause) => Effect.succeed<HarnessStart>({_tag: "Failed", reason: cause.reason})),
+	);

--- a/packages/fabrika-cli/src/ui/set-manifest.ts
+++ b/packages/fabrika-cli/src/ui/set-manifest.ts
@@ -1,0 +1,91 @@
+/**
+ * `<set>/manifest.json` — the render→evidence seam, parsed.
+ *
+ * `ui render` writes this file byte-identically to its own stdout, and `ui evidence` reads the set
+ * back through it: no value crosses that seam by memory, and a set whose manifest is absent or
+ * unparseable is refused rather than reconstructed from whatever PNGs happen to be on disk.
+ */
+
+/** One capture as its set manifest records it. */
+export interface SetCapture {
+	readonly surface: string;
+	readonly path: string;
+	readonly sha256: string;
+	readonly firstRender: boolean;
+}
+
+export type SetParse =
+	| {readonly _tag: "Set"; readonly captures: ReadonlyArray<SetCapture>}
+	| {readonly _tag: "Violation"; readonly violation: string};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const parseSetManifest = (text: string): SetParse => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (err) {
+		return {_tag: "Violation", violation: `it does not parse (${(err as Error).message})`};
+	}
+	if (!isRecord(parsed) || !Array.isArray(parsed.captures)) {
+		return {_tag: "Violation", violation: "it carries no captures array"};
+	}
+	if (parsed.captures.length === 0) return {_tag: "Violation", violation: "it names zero captures"};
+	const captures: SetCapture[] = [];
+	for (const capture of parsed.captures) {
+		if (
+			!isRecord(capture) ||
+			typeof capture.surface !== "string" ||
+			typeof capture.path !== "string" ||
+			typeof capture.sha256 !== "string"
+		) {
+			return {_tag: "Violation", violation: "a capture row is missing surface, path or sha256"};
+		}
+		captures.push({
+			surface: capture.surface,
+			path: capture.path,
+			sha256: capture.sha256,
+			firstRender: capture.firstRender === true,
+		});
+	}
+	return {_tag: "Set", captures};
+};
+
+/** An after-surface with its before, or the recorded fact that it is new. */
+export interface Pair {
+	readonly surface: string;
+	readonly before: SetCapture | null;
+	readonly after: SetCapture;
+}
+
+export type Pairing =
+	| {readonly _tag: "Pairs"; readonly pairs: ReadonlyArray<Pair>}
+	| {readonly _tag: "Unexplained"; readonly surface: string};
+
+/**
+ * Pair every after-capture with its before by surface id.
+ *
+ * A `firstRender` surface pairs with nothing and is labeled a new surface; an after-surface with
+ * neither a before nor a `firstRender` mark refuses, because an unexplained missing baseline is a
+ * hole in the evidence, not a layout choice.
+ */
+export const pairSets = (
+	before: ReadonlyArray<SetCapture>,
+	after: ReadonlyArray<SetCapture>,
+): Pairing => {
+	const index = new Map(before.map((capture) => [capture.surface, capture]));
+	const pairs: Pair[] = [];
+	for (const capture of after) {
+		const match = index.get(capture.surface) ?? null;
+		if (match === null && !capture.firstRender) {
+			return {_tag: "Unexplained", surface: capture.surface};
+		}
+		pairs.push({
+			surface: capture.surface,
+			before: capture.firstRender ? null : match,
+			after: capture,
+		});
+	}
+	return {_tag: "Pairs", pairs};
+};

--- a/packages/fabrika-cli/src/ui/ui.cli.test.ts
+++ b/packages/fabrika-cli/src/ui/ui.cli.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The end-to-end half: the **exit status and the exact stdout bytes** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Two spawns: one answer and one
+ * refusal, the pair that cannot be established in-process. Everything else about these verbs is
+ * covered in-process by the `*-verb.unit.test.ts` files beside this one.
+ *
+ * Both cases are hermetic: `ui manifest` reads this repo's own committed convention paths, and the
+ * refusal is an operand check that runs before any IO — no browser, no network, no lane.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {OFF_VOCABULARY} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
+const fabrika = (args: ReadonlyArray<string>): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika ui, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("answers the design surfaces as one JSON object on stdout, exit 0", () => {
+		const run = fabrika(["ui", "manifest"]);
+		expect(run.code).toBe(0);
+		expect(Object.keys(JSON.parse(run.stdout)).sort()).toEqual([
+			"goldenPointer",
+			"harness",
+			"inventory",
+			"lawSource",
+			"manifest",
+			"registry",
+		]);
+	});
+
+	it("refuses an off-grammar set name with NOTHING on stdout", () => {
+		const run = fabrika(["ui", "render", "--out", "After", "--surface", "/pano"]);
+		expect(run.code).toBe(OFF_VOCABULARY);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain('ui render: --out "After" is not a kebab-case set name.');
+	});
+});


### PR DESCRIPTION
Fixes #5061

The `build-ui` contract specified five `ui` verbs and none existed, so every fence in the merged skill naming `fabrika ui …` resolved to nothing. This implements the group exactly as [`claude-plugins/fabrika/skills/build-ui/contract.md`](https://github.com/kamp-us/phoenix/blob/main/claude-plugins/fabrika/skills/build-ui/contract.md) specifies it — the contract is the spec, neither re-derived nor re-litigated.

## What landed

| Verb | What it answers |
|---|---|
| `ui manifest` | the repo's design surfaces by convention — presence + paths, `lawSource` |
| `ui law` | the typed prohibition registry, schema-validated whole-file, rows in file order |
| `ui render` | one **validated** PNG per named surface, plus the set manifest |
| `ui golden` | the blessed golden and the contract's diff number — signal, never verdict |
| `ui evidence` | upload → verify → post one head-bound comment → read it back |

Registered in `packages/fabrika-cli/src/registry.ts`; the group appears under `fabrika --help`.

## The four decisions worth reading the diff for

- **A verb's ceiling is the golden diff.** Nothing in the group can emit a PASS/FAIL token, a score, or a layout opinion — that is `review-ui`'s gate (#4718). The diff is pinned to the contract's exact numbers (per-channel delta > 10, magnitude to 3 decimals, 8-connected regions merged under 16px, largest-area first, capped at 20; the `dimensionMismatch` key appears in no other shape) and lives in its own pure core with those constants named.
- **Absence is answered three ways, never one.** No manifest is `12` (routable: un-bootstrapped), no registry is `13` (the law is untyped, prose is the source), unreadable is `11` (UNKNOWN). The same split runs through `ui golden`: an unreadable pointer is refused on `4`/`11` and never resolved to an empty blessed set — the #4501 fail-open, designed out.
- **Validity is part of the answer.** `ui render` decodes every capture it took (a dependency-free PNG decoder over `node:zlib`, so a published package needs no codec dep) — zero bytes, undecodable and zero-area are `16`. `ui evidence` re-validates each paired PNG against its manifest sha before anything uploads, and a single failed upload or upload-verification is `17` with **nothing posted** (#3925).
- **Lane mechanics are the `build` group's, reused.** `src/ui/lane.ts` wraps `build/lane-guard.ts` and only re-seats its refusals onto the `ui` matrix (`18` proven-not-mine, `11` unreadable). Nothing under `src/build/` was respecified.

## Exit codes

Seats `4`–`11` are **imported** from `report/codes.ts` (a drift is unrepresentable, not merely detectable); `12`–`19` are the group's own. Seat `3` is held empty as `DELIBERATE_GAP` — no `ui` verb reads stdin. `ui` is registered in `src/exit-code-alignment.ts` (`UI_SEATS`) and in the alignment test's table map, so the shipped coverage test grades it.

## Deviations

- **The set manifest is written with the trailing newline `answer()` puts on stdout**, so `<set>/manifest.json` is byte-identical to the stdout bytes rather than to the JSON minus its newline. Asserted in `render-verb.unit.test.ts`.
- **Entry fields beyond `sha256` in the golden pointer parse and are ignored.** Phoenix's shipped pointer carries `blessedDate`/`intent` (ADR 0183 §2); the contract pins only `sha256`, and refusing the repo's own extra fields would refuse the file that exists.
- **The raster diff is a second implementation, not a reuse of `capture/golden-diff.ts`.** That module computes a *different* number for the review side (masks, 4-connectivity, uncapped regions); the build-side numbers are pinned by this contract and may not drift with it. Stated in the module docblock.
- **Two shared files were touched, both required by the ACs:** `src/exit-code-alignment.ts` (+ its test's table map) to register the group's codes, and `src/build/scratch-verb.ts` to *export* the lane-scratch path formula the `ui` capture sets land under rather than restating it. No behavior in `build` changed.
- **The headless browser's `postinstall` provisioner skips when `CI` is set.** The AC requires the browser to self-provision with the package install, and `scripts/provision-browser.mjs` does — but it is **best-effort and never fails the install** (a hard failure there would break `pnpm install` for everyone over a capability one verb needs), and it skips when the browser is already present, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, on `FABRIKA_SKIP_BROWSER_PROVISION=1`, and when `CI` is set — a ~130MB download in every job of every workflow is a cost no job asked for. The run-time half stays fail-closed: `ui render` exits `11` carrying the exact remediation command, never a silent skip. The `CI` skip is a cost judgement, not a contract clause; the gate accepted it as a founder-facing call and filed #5169 for it.

- **(repair round 1)** **One line of `packages/fabrika-cli/README.md` that came in from `main` was reworded.** Sibling PR #5147 landed a sentence calling the `ui` verb group "[#5061](https://github.com/kamp-us/phoenix/issues/5061)'s work" in the future tense; this branch lands that group, so after the rebase the same file both described the group and called it unbuilt. Retargeted the sentence at this PR's own `## The `ui` group` section, keeping the issue reference. Nothing else on `main` was touched.

- **(repair round 2)** **`ui evidence`'s seat `6` (`BARE_AT_PATH`) is covered as a predicate assertion, not as a `runEvidence` refusal — the seat is unreachable from the verb.** The round-1 FAIL asked for three `it` blocks, and seats `5` (`LEAKED_PATH`) and `16` (`CAPTURE_INVALID`) landed exactly as prescribed, driven through `runEvidence`. Seat `6` cannot be: `isBareAtReference` refuses a body whose **first** non-whitespace token is an `@` path, and `composeEvidence` always leads with its `**UI evidence** — rendered at head …` header (`evidence-verb.ts:91`), so no body the verb composes — including one where an upload leg hands back an `@` path in place of a URL — can ever trip it. The seat is a backstop on a body that never arrived (#3086's class), and the third test pins both halves of that: the predicate refuses the #3086 body, and nothing `composeEvidence` produces trips it. Filed as #5170 so the unreachable seat is triaged rather than silently carried.

## Verification

- `pnpm typecheck` (workspace, the exact CI command) — clean.
- `pnpm lint:worktree` — clean.
- `pnpm --filter @kampus/fabrika-cli test` — 175 files / 2478 tests pass, including the `src/ui/**` files covering each verb's exit-trigger table, plus one 2-spawn CLI test for the stdout bytes and exit status a shell caller reads.
- Smoke-run in this checkout: `fabrika ui manifest` answers on exit 0, `fabrika ui law` refuses `13` (phoenix ships no typed registry yet), `fabrika ui golden --surface /pano` answers unblessed on exit 0, `fabrika ui render --out Bad …` refuses `10`.
- **Re-verified after the round-2 rebase onto current `main`**: `pnpm typecheck` clean, `pnpm lint:worktree` clean, `pnpm --filter @kampus/fabrika-cli test` — 175 files / 2478 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
