### PR TITLE
fix(fabrika-cli): take review diff's completeness denominator from git, not GitHub (#5139)

### DIFF
--- a/packages/fabrika-cli/src/review/diff-verb.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.ts
@@ -14,7 +14,7 @@
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {diffRange} from "../io/git.ts";
+import {diffRange, diffRangePaths} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {filesInDiff} from "./diff.ts";
@@ -63,6 +63,20 @@ export const runDiff = (
 			);
 		}
 		const diff = served.value;
+
+		// The denominator is a second read of the SAME range under the SAME flags — `--name-only -z`
+		// emits exactly one path per `diff --git` entry, renames paired identically — so the proof
+		// compares one git computation against another. GitHub's `changed_files` is its own merge base
+		// and its own rename detection, so it is reported below and never refused on (#5139).
+		const listed = yield* diffRangePaths(head.base, head.sha);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the file list of the range ${head.base}...${head.sha} for #${pr}: ${listed.reason} — UNKNOWN.`,
+			);
+		}
+		const inRange = listed.value.length;
+
 		const seen = filesInDiff(diff);
 		const diagnostics = [
 			boundLine(VERB, head),
@@ -70,13 +84,18 @@ export const runDiff = (
 				VERB,
 				seen,
 				"file",
-				`${pull.changedFiles} declared, ${new TextEncoder().encode(diff).length} bytes`,
+				`${inRange} in the range per git, ${pull.changedFiles} declared by GitHub, ${new TextEncoder().encode(diff).length} bytes`,
 			),
 		];
-		if (seen < pull.changedFiles) {
+		if (inRange !== pull.changedFiles) {
+			diagnostics.push(
+				`${VERB}: git and GitHub disagree on #${pr}'s file count (${inRange} vs ${pull.changedFiles}) — different merge base and different rename detection; reported, never refused on (#5139).`,
+			);
+		}
+		if (seen < inRange) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: the diff at ${head.sha} carries ${seen} of #${pr}'s ${pull.changedFiles} declared files — refusing to serve a partial diff as the whole (#3925's class).`,
+				`${VERB}: the diff at ${head.sha} carries ${seen} of the ${inRange} files git reports for the same range ${head.base}...${head.sha} — both counts from git, so this diff is provably short; refusing to serve a partial diff as the whole (#3925's class).`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.unit.test.ts
@@ -10,7 +10,16 @@ import {
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {runDiff} from "./diff-verb.ts";
-import {binding, DIFF, DIFF_AT, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+import {
+	binding,
+	DIFF,
+	DIFF_AT,
+	HEAD,
+	OLD_HEAD,
+	PATHS_AT,
+	paths,
+	pull,
+} from "./fixtures.test-support.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
 /** The unbound endpoint this verb no longer reads — scripted so a regression has bytes to serve. */
@@ -48,16 +57,33 @@ const run = (
 	overrides: Partial<typeof options> = {},
 ) => shell(script, overrides).out;
 
-/** The whole green path: the PR read, the four binding reads, and the diff at the bound commit. */
+/**
+ * The whole green path: the PR read, the four binding reads, the diff at the bound commit, and the
+ * `--name-only` read of the SAME range that the completeness proof is taken against.
+ */
 const green = (
 	diff: string = DIFF,
 	shape: Parameters<typeof pull>[0] = {},
+	inRange: ReadonlyArray<string> = ["src/cart.ts", "README.md"],
 ): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 	[PULL, pull(shape)],
 	...binding(),
 	[DIFF_AT(), okOut(diff)],
+	[PATHS_AT(), paths(...inRange)],
 	[RAW, okOut(MOVED_DIFF)],
 ];
+
+/** A rename git pairs into ONE `diff --git` entry — the shape GitHub may count as two files. */
+const RENAME_DIFF = `diff --git a/src/old.ts b/src/new.ts
+similarity index 96%
+rename from src/old.ts
+rename to src/new.ts
+--- a/src/old.ts
++++ b/src/new.ts
+@@ -1,1 +1,2 @@
+ const x = 1;
++const y = 2;
+`;
 
 describe("runDiff", () => {
 	it("serves the diff bytes exactly as the object database holds them", async () => {
@@ -71,17 +97,31 @@ describe("runDiff", () => {
 		expect(out.stderr[0]).toBe(
 			`review diff: bound to ${HEAD} (base 0f1e2d3c4b5a69788796a5b4c3d2e1f009182736) — read from the object database, nothing checked out.`,
 		);
-		expect(out.stderr[1]).toContain("scanned 2 files; 2 declared");
+		expect(out.stderr[1]).toContain(
+			"scanned 2 files; 2 in the range per git, 2 declared by GitHub",
+		);
 		expect(out.stderr[1]).toContain("bytes");
 	});
 
-	it("refuses a diff short of the declared count on 13 rather than serving the prefix as the whole", async () => {
-		const out = await run(green(DIFF, {changedFiles: 7}));
+	it("refuses a diff short of the range's own file list on 13 rather than serving the prefix as the whole", async () => {
+		const out = await run(green(DIFF, {}, ["src/cart.ts", "README.md", "src/dropped.ts"]));
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
-			`review diff: the diff at ${HEAD} carries 2 of #4321's 7 declared files — refusing to serve a partial diff as the whole (#3925's class).`,
+			`review diff: the diff at ${HEAD} carries 2 of the 3 files git reports for the same range 0f1e2d3c4b5a69788796a5b4c3d2e1f009182736...${HEAD} — both counts from git, so this diff is provably short; refusing to serve a partial diff as the whole (#3925's class).`,
 		);
+	});
+
+	it("refuses on 11 when the range's file list cannot be read, rather than proving completeness against nothing", async () => {
+		const out = await run([
+			[PULL, pull()],
+			...binding(),
+			[DIFF_AT(), okOut(DIFF)],
+			[PATHS_AT(), errOut("fatal: bad revision")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("cannot read the file list of the range");
 	});
 
 	it("makes the same zero-file refusal `review scope` does, so neither serves a review over nothing", async () => {
@@ -102,6 +142,36 @@ describe("runDiff", () => {
 		expect(unreadable.code).toBe(PRECONDITION_UNKNOWN);
 		expect(unreadable.stdout).toBe("");
 		expect(unreadable.stderr.at(-1)).toContain("UNKNOWN");
+	});
+});
+
+/**
+ * The single-source fence (#5139).
+ *
+ * Both operands of the exit-`13` inequality are produced by git over one range under one set of
+ * flags. Each case here fails if the denominator drifts back to GitHub's `changed_files`, whose
+ * merge base and rename detection are its own.
+ */
+describe("runDiff proves completeness against git's own count", () => {
+	it("serves a rename git paired into one entry, though GitHub declares it as two files", async () => {
+		const out = await run(green(RENAME_DIFF, {changedFiles: 2}, ["src/new.ts"]));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(RENAME_DIFF);
+	});
+
+	it("reports the git-vs-GitHub disagreement on stderr instead of refusing on it", async () => {
+		const out = await run(green(RENAME_DIFF, {changedFiles: 2}, ["src/new.ts"]));
+		expect(out.stderr.at(-1)).toBe(
+			"review diff: git and GitHub disagree on #4321's file count (1 vs 2) — different merge base and different rename detection; reported, never refused on (#5139).",
+		);
+	});
+
+	it("takes both counts from the same range, and never from the PR's declared count", async () => {
+		const {fake, out} = shell(green());
+		await out;
+		expect(fake.calls).toContain(
+			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ --name-only -z 0f1e2d3c4b5a69788796a5b4c3d2e1f009182736...${HEAD}`,
+		);
 	});
 });
 

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -148,11 +148,13 @@ describe("the three-outcome binding", () => {
 });
 
 describe("the diff completeness proof", () => {
-	// The PR declares seven files; the commit carries two. Anything but a refusal judges 2/7.
+	// The range carries seven files; the served diff carries two. Both counts are git's, over the
+	// same range — anything but a refusal judges 2/7 (#5139).
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull({changedFiles: 7})],
 		...binding(),
 		[DIFF_AT(), okOut(DIFF)],
+		[PATHS_AT(), paths("src/cart.ts", "README.md", "c.ts", "d.ts", "e.ts", "f.ts", "g.ts")],
 	];
 
 	it("refuses a short diff on 13", async () => {
@@ -193,6 +195,7 @@ describe("the commit binding on the read verbs", () => {
 		[PULL, pull({changedFiles: 1})],
 		...binding(),
 		[DIFF_AT(), okOut(DIFF)],
+		[PATHS_AT(), paths("src/cart.ts")],
 		[RAW, okOut(MOVED_DIFF)],
 	];
 


### PR DESCRIPTION
`review diff` refuses on exit `13` when the diff it serves is shorter than the PR's file count. It counted the diff's files with local git but read the total from GitHub's API, and those two systems compute merge base and rename detection differently — so a rename git folds into one `diff --git` entry and GitHub counts as two files could refuse a perfectly healthy PR with a message saying the diff was partial when it wasn't.

Both numbers now come from git, over the same range and the same flags. GitHub's `changed_files` is still printed as a cross-check, but it can no longer trigger a refusal.

Fixes #5139

## What changed

- `diff-verb.ts` reads the range's file list with `diffRangePaths(head.base, head.sha)` and proves completeness against **that** count. `git diff --name-only -z` emits exactly one path per `diff --git` entry, renames paired the same way — verified against git, not assumed — so the two counts are exactly comparable by construction.
- GitHub's `changed_files` stays in the stderr diagnostics (`scanned N files; M in the range per git, K declared by GitHub`), and a git-vs-GitHub disagreement now prints its own line saying it is reported and never refused on.
- The `13` message names the range both counts came from, so a reader can tell which system produced which number.
- An unreadable file list refuses on `11` (UNKNOWN) rather than proving completeness against nothing — the same shape `review scope` already uses.
- `INCOMPLETE_SCAN` keeps the value `13`, and a diff genuinely short of the range it was read from still refuses.

## Tests

- `diff-verb.unit.test.ts`: a rename git pairs into one entry while GitHub declares two files now serves at exit 0; the disagreement is asserted on stderr; the short-diff `13` is re-pinned against git's own count; the `--name-only -z` read of the same range is asserted in the call log; an unreadable file list refuses on 11.
- `mutation.unit.test.ts`: the completeness-proof mutants re-scripted against the range's file list, so `filesInDiff` returning a matching count still serves the partial diff (the mutant stays alive-if-unguarded).
- Full `fabrika-cli` suite green (2289 tests), typecheck and biome clean.

## Deviations

**Class 2 (sibling defect left for a follow-up).** Said: fix the numerator/denominator mismatch. Did: fixed it in `review diff` only. Why: `review scope` (`scope-verb.ts:69`) carries the identical shape — `diffRangePaths(...).length < pull.changedFiles` — but #5139's acceptance criteria scope this issue to `review diff`, and widening it would collide with the sibling fabrika lanes. Disposition: follow-up filed, see the comment on #5139.

**Class 4 (a test that asserted the old behaviour was changed).** Said: repair the refusal, do not remove it. Did: rewrote `refuses a diff short of the declared count on 13` so the short read comes from the range's file list instead of GitHub's declared count, and re-scripted the two `mutation.unit.test.ts` diff scripts with a `--name-only` row. Why: those tests asserted the exact comparison this issue calls a bug; the refusal itself is still pinned, on the repaired operands. Disposition: no action needed — the `13` path has strictly more coverage than before.

**Scope boundary against #4993 — honoured.** No module docblock prose in `diff.ts` / `diff-verb.ts` and no `contract.md` prose is touched. The one new comment sits inline at the comparison site, not in a docblock.