### PR TITLE
fix(fabrika-cli): stop refusing review scope on GitHub's declared file count (#5154)

### DIFF
--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -521,14 +521,16 @@ nothing yet.
 	});
 });
 
-describe("the short-read refusal on the changed-file list", () => {
+describe("the empty-read refusal on the changed-file list", () => {
+	// git reports no paths while GitHub declares nine: the emptiness refuses, the disagreement does
+	// not (#5154).
 	const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 		[PULL, pull({changedFiles: 9})],
 		...binding(),
-		[PATHS_AT(), paths("src/cart.ts", "README.md")],
+		[PATHS_AT(), paths()],
 	];
 
-	it("refuses a partition over a short read on 13", async () => {
+	it("refuses a partition over an empty read on 13", async () => {
 		const {runScope} = await import("./scope-verb.ts");
 		const out = await withShell(
 			runScope({pr: 4321, sha: null, repo: null, json: false, env: ENV}),
@@ -537,15 +539,12 @@ describe("the short-read refusal on the changed-file list", () => {
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 	});
 
-	it("MUTANT: a file list that reports the declared count partitions 2 of 9 files as the whole", async () => {
+	it("MUTANT: a file list padded past empty partitions phantom files as the whole", async () => {
 		await mutate<typeof import("../io/git.ts")>("../io/git.ts", (actual) => ({
 			diffRangePaths: (base: string, head: string) =>
 				Effect.map(actual.diffRangePaths(base, head), (attempt) =>
-					attempt._tag === "Ok"
-						? {
-								_tag: "Ok" as const,
-								value: [...attempt.value, ...Array.from({length: 7}, (_, i) => `pad-${i}.ts`)],
-							}
+					attempt._tag === "Ok" && attempt.value.length === 0
+						? {_tag: "Ok" as const, value: ["pad-0.ts"]}
 						: attempt,
 				),
 		}));

--- a/packages/fabrika-cli/src/review/scope-verb.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.ts
@@ -61,15 +61,24 @@ export const runScope = (
 				`${VERB}: cannot read the changed files of #${pr} at ${head.sha}: ${listed.reason} — the scope is UNKNOWN.`,
 			);
 		}
+		// This list IS the scope, so there is no second local count to prove it against — and
+		// GitHub's `changed_files` is not one: a rename git pairs into a single `--name-only` path
+		// while GitHub counts two files, so it is reported below and never refused on (#5154). The
+		// short read git alone establishes — an empty list — still refuses.
 		const files = listed.value;
 		const diagnostics = [
 			boundLine(VERB, head),
-			scannedLine(VERB, files.length, "changed file", `${pull.changedFiles} declared`),
+			scannedLine(VERB, files.length, "changed file", `${pull.changedFiles} declared by GitHub`),
 		];
-		if (files.length < pull.changedFiles) {
+		if (files.length !== pull.changedFiles) {
+			diagnostics.push(
+				`${VERB}: git and GitHub disagree on #${pr}'s file count (${files.length} vs ${pull.changedFiles}) — different merge base and different rename detection; reported, never refused on (#5154).`,
+			);
+		}
+		if (files.length === 0) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: ${head.sha} carries ${files.length} of the ${pull.changedFiles} files #${pr} declares — refusing to partition a short read (#3999).`,
+				`${VERB}: git reports no changed files for the range ${head.base}...${head.sha}, so ${head.sha} has nothing to partition — refusing to scope an empty read (#3999).`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
@@ -100,7 +100,7 @@ describe("runScope", () => {
 		expect(out.stderr[0]).toBe(
 			`review scope: bound to ${HEAD} (base ${BASE}) — read from the object database, nothing checked out.`,
 		);
-		expect(out.stderr[1]).toBe("review scope: scanned 2 changed files; 2 declared.");
+		expect(out.stderr[1]).toBe("review scope: scanned 2 changed files; 2 declared by GitHub.");
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
@@ -140,18 +140,14 @@ describe("runScope", () => {
 		expect(out.stderr.at(-1)).toContain("the scope is UNKNOWN");
 	});
 
-	it("refuses a provably short file list on 13, distinct from 11 and 7", async () => {
-		const out = await run([
-			[PULL, pull({changedFiles: 9})],
-			...binding(),
-			[PATHS_AT(), paths("a.ts", "b.md")],
-		]);
+	it("refuses an empty file list on 13, distinct from 11 and 7", async () => {
+		const out = await run([[PULL, pull({changedFiles: 9})], ...binding(), [PATHS_AT(), paths()]]);
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.code).not.toBe(PRECONDITION_UNKNOWN);
 		expect(out.code).not.toBe(ZERO_SCOPE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toBe(
-			`review scope: ${HEAD} carries 2 of the 9 files #4321 declares — refusing to partition a short read (#3999).`,
+			`review scope: git reports no changed files for the range ${BASE}...${HEAD}, so ${HEAD} has nothing to partition — refusing to scope an empty read (#3999).`,
 		);
 	});
 
@@ -161,6 +157,50 @@ describe("runScope", () => {
 			Effect.provide(runScope({...options, env: {}}), fakeShell([]).layer),
 		);
 		expect(out.code).toBe(1);
+	});
+});
+
+/**
+ * The single-source fence (#5154).
+ *
+ * The file list git returns for the bound range IS the scope; GitHub's `changed_files` has its own
+ * merge base and its own rename detection, so it is reported and never refused on. Each case here
+ * fails if the exit-`13` refusal drifts back onto that declared count.
+ */
+describe("runScope never refuses on GitHub's declared count", () => {
+	/** git pairs the rename into one `--name-only` path; GitHub counts the delete and the add. */
+	const renamed: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({changedFiles: 2})],
+		...binding(),
+		[PATHS_AT(), paths("src/new.ts")],
+	];
+
+	it("scopes a rename git paired into one path, though GitHub declares two files", async () => {
+		const out = await run(renamed);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain(`scoped\t${HEAD}\t4287`);
+		expect(out.stdout).toContain("class\tcode\t1");
+	});
+
+	it("reports the git-vs-GitHub disagreement on stderr instead of refusing on it", async () => {
+		const out = await run(renamed);
+		expect(out.stderr).toContain(
+			"review scope: git and GitHub disagree on #4321's file count (1 vs 2) — different merge base and different rename detection; reported, never refused on (#5154).",
+		);
+	});
+
+	it("keeps GitHub's count visible in the scanned diagnostic", async () => {
+		const out = await run(renamed);
+		expect(out.stderr[1]).toBe("review scope: scanned 1 changed file; 2 declared by GitHub.");
+	});
+
+	it("scopes a list LONGER than GitHub declares, which the old inequality also let through", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 1})],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+		]);
+		expect(out.code).toBe(0);
 	});
 });
 


### PR DESCRIPTION
`review scope` could refuse a perfectly healthy PR. It counted the files git reports for the branch's range, then red-lined on exit 13 whenever that number came in under the file count GitHub declares. Those two numbers are computed by two different systems, so they can legitimately differ — a rename, for instance, is one path to git and two files to GitHub — and the check treated that difference as proof of a short read. GitHub's number now stays on screen as information and never decides the exit code.

## What changed

`packages/fabrika-cli/src/review/scope-verb.ts`:

- The `files.length < pull.changedFiles` refusal is gone. Unlike `review diff` (#5139, PR #5153), there is no second local count to move the denominator to — the list `diffRangePaths(head.base, head.sha)` returns *is* the scope — so the API count leaves the inequality entirely rather than being replaced.
- The surviving exit-`13` condition is the one short read git alone establishes: an **empty** file list, which would otherwise partition nothing. `INCOMPLETE_SCAN` keeps the value `13`.
- GitHub's count stays **visible and reported**: the `scanned` diagnostic now reads `N declared by GitHub`, and a git-vs-GitHub disagreement prints its own line saying it is reported and never refused on.

Untouched on purpose: `openPull(..., {requireFiles: true})` still reds a GitHub-declared zero-file PR on exit `7` (ADR 0092, #4060), and an unreadable file list still refuses on exit `11`.

Tests (`scope-verb.unit.test.ts`): a new `runScope never refuses on GitHub's declared count` block pins the rename case at exit `0` (git pairs one `--name-only` path, GitHub declares two), the disagreement diagnostic, and that GitHub's count stays in the `scanned` line. The old short-read case is re-pointed at the empty list.

Fixes #5154

## Deviations

**Class 2 (sibling defect left for a follow-up) — the module docblock is now stale, deliberately.** Said: `scope-verb.ts`'s docblock states that "a file list short of the declared count reds rather than partitioning a truncated read (#3999)". Did: left it byte-for-byte untouched. Why: #5154's boundary table assigns **all** prose under the fabrika review sources to #4993, and explicitly says the correction is recorded as a comment on #4993, not an edit from here. Disposition: noted for #4993; no action in this PR.

**Class 5 (touched a file another lane shares) — `mutation.unit.test.ts`.** Said: the scope boundary is one file per lane. Did: edited the shared `packages/fabrika-cli/src/review/mutation.unit.test.ts`, whose `the short-read refusal on the changed-file list` block asserted exactly the inequality this PR removes. Why: leaving it would have red-lined the suite; the block is re-anchored onto the surviving empty-list refusal, and its mutant is re-aimed at the same guard. The edit is confined to that one block — the `review diff` blocks PR #5153 touched are untouched. Disposition: flagged here so a sibling fabrika lane rebasing on this file knows.

**Class 3 (declined to inherit a neighbouring formulation) — the inline comment does not claim "one git computation against another".** Said: follow PR #5153's shape. Did: followed its structure, but wrote the rationale as "this list IS the scope, so there is no second local count to prove it against". Why: for `review scope` that is literally what holds — there is no second computation to compare, unlike `review diff` where two git reads are compared. Overstating it would also paper over the header-parser limit recorded in #5159. Disposition: no action needed; #5159 is unaffected here, since `--name-only -z` disables git's path quoting and this verb parses no `diff --git` headers.

**Class 6 (left a neighbouring instance alone).** `review deviations` (`deviations-verb.ts`) carries the same comparison and is tracked as #5157; the `ship` group's look-alike checks compare GitHub against GitHub and are a legitimate pagination guard. Neither is touched. Disposition: #5157 owns the former; the latter is correct as-is.