### PR TITLE
fix(fabrika-cli): teach the review diff parser git's quoted file headers

### DIFF
--- a/packages/fabrika-cli/src/review/diff.ts
+++ b/packages/fabrika-cli/src/review/diff.ts
@@ -18,8 +18,81 @@
  * producer for that shape is known.
  */
 
-const FILE_HEADER = /^diff --git a\/(.*) b\/(.*)$/;
+/**
+ * Both header forms git emits, per side. A path holding a non-ASCII byte (`core.quotePath`, on by
+ * default), a backslash, or a double quote is written `"a/…"` with C-style escapes, and the two
+ * sides quote independently — a rename to a Turkish name gives `diff --git a/plain.ts "b/ünlü.ts"`.
+ * Matching only the bare form made a quoted file invisible: it undercounted the completeness proof
+ * AND handed that file's hunk lines to the previous file (#5159).
+ */
+const FILE_HEADER =
+	/^diff --git (?:"a\/((?:[^"\\]|\\.)*)"|a\/(.*)) (?:"b\/((?:[^"\\]|\\.)*)"|b\/(.*))$/;
 const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+const NAMED_ESCAPES: Readonly<Record<string, number>> = {
+	a: 0x07,
+	b: 0x08,
+	f: 0x0c,
+	n: 0x0a,
+	r: 0x0d,
+	t: 0x09,
+	v: 0x0b,
+	"\\": 0x5c,
+	'"': 0x22,
+};
+const OCTAL_DIGIT = /^[0-7]$/;
+
+/**
+ * A quoted header path back to the real name.
+ *
+ * Git escapes byte by byte, so one `ç` arrives as `\303\247` — the escapes decode into a byte buffer
+ * that is UTF-8 decoded once at the end. Decoding each escape to its own character instead would
+ * yield mojibake, and `tierMHits` matches `TEST_FILE` against this name, so a name that does not
+ * resolve is a blind scan rather than a cosmetic defect.
+ */
+const unquoteCStyle = (body: string): string => {
+	const utf8 = new TextEncoder();
+	const bytes: number[] = [];
+	for (let i = 0; i < body.length; i += 1) {
+		const ch = body[i] ?? "";
+		if (ch !== "\\") {
+			bytes.push(...utf8.encode(ch));
+			continue;
+		}
+		const next = body[i + 1] ?? "";
+		const named = NAMED_ESCAPES[next];
+		if (named !== undefined) {
+			bytes.push(named);
+			i += 1;
+			continue;
+		}
+		if (OCTAL_DIGIT.test(next)) {
+			let digits = "";
+			while (digits.length < 3 && OCTAL_DIGIT.test(body[i + 1 + digits.length] ?? "")) {
+				digits += body[i + 1 + digits.length] ?? "";
+			}
+			bytes.push(Number.parseInt(digits, 8) & 0xff);
+			i += digits.length;
+			continue;
+		}
+		// An escape git does not emit. Take the character literally: a review gate that reports a
+		// slightly-off path beats one that throws on a diff it cannot parse.
+		bytes.push(...utf8.encode(next));
+		i += 1;
+	}
+	return new TextDecoder().decode(new Uint8Array(bytes));
+};
+
+/** The `a/` and `b/` paths off a `diff --git` header, whichever of the two forms each side took. */
+const headerPaths = (line: string): {readonly before: string; readonly after: string} | null => {
+	const header = FILE_HEADER.exec(line);
+	if (header === null) return null;
+	const [, quotedBefore, bareBefore, quotedAfter, bareAfter] = header;
+	return {
+		before: quotedBefore === undefined ? (bareBefore ?? "") : unquoteCStyle(quotedBefore),
+		after: quotedAfter === undefined ? (bareAfter ?? "") : unquoteCStyle(quotedAfter),
+	};
+};
 
 /** How many files the served diff carries — the numerator of the completeness proof. */
 export const filesInDiff = (diff: string): number =>
@@ -47,10 +120,9 @@ export const changedLines = (diff: string): ReadonlyArray<DiffLine> => {
 	let oldLine = 0;
 	let newLine = 0;
 	for (const raw of diff.split("\n")) {
-		const header = FILE_HEADER.exec(raw);
+		const header = headerPaths(raw);
 		if (header !== null) {
-			const before = header[1] ?? "";
-			const after = header[2] ?? "";
+			const {before, after} = header;
 			file = after === "/dev/null" || after === "" ? before : after;
 			oldLine = 0;
 			newLine = 0;

--- a/packages/fabrika-cli/src/review/diff.unit.test.ts
+++ b/packages/fabrika-cli/src/review/diff.unit.test.ts
@@ -21,10 +21,45 @@ index 1111111..2222222 100644
  });
 `;
 
+/**
+ * Real `git diff` output, copied verbatim from a throwaway repo on git's defaults — a backslash in
+ * the name (quoted whatever `core.quotePath` says) and two Turkish names (quoted because
+ * `core.quotePath` is on). Every `\\` below is one literal backslash in the diff bytes.
+ */
+const QUOTED_DIFF = `diff --git "a/ka\\\\\\303\\247ak.ts" "b/ka\\\\\\303\\247ak.ts"
+index 422c2b7..0f7bc76 100644
+--- "a/ka\\\\\\303\\247ak.ts"
++++ "b/ka\\\\\\303\\247ak.ts"
+@@ -1,2 +1,2 @@
+ a
+-b
++c
+diff --git a/plain.ts b/plain.ts
+index b6ab9e6..187a501 100644
+--- a/plain.ts
++++ b/plain.ts
+@@ -1,2 +1,3 @@
+ const items = read();
++// biome-ignore lint/suspicious/noExplicitAny: not now
+ return items.length;
+diff --git "a/s\\303\\266zl\\303\\274k-ba\\305\\237l\\304\\261k.test.ts" "b/s\\303\\266zl\\303\\274k-ba\\305\\237l\\304\\261k.test.ts"
+index fce2e4b..09058a9 100644
+--- "a/s\\303\\266zl\\303\\274k-ba\\305\\237l\\304\\261k.test.ts"
++++ "b/s\\303\\266zl\\303\\274k-ba\\305\\237l\\304\\261k.test.ts"
+@@ -1,3 +1,2 @@
+ it("x", () => {
+-	expect(sozluk(10)).toBe("on");
+ });
+`;
+
 describe("filesInDiff", () => {
 	it("counts one per `diff --git` header — the numerator of the completeness proof", () => {
 		expect(filesInDiff(DIFF)).toBe(2);
 		expect(filesInDiff("")).toBe(0);
+	});
+
+	it("counts a git-quoted header, so a non-ASCII path no longer forces a false exit 13", () => {
+		expect(filesInDiff(QUOTED_DIFF)).toBe(3);
 	});
 });
 
@@ -60,6 +95,40 @@ describe("changedLines", () => {
 `;
 		expect(changedLines(deleted)[0]?.file).toBe("dev/null");
 	});
+
+	it("gives a quoted-path file its own name and line numbers, unescaped back to the real path", () => {
+		const lines = changedLines(QUOTED_DIFF);
+		expect(lines).toContainEqual({
+			file: "sözlük-başlık.test.ts",
+			line: 2,
+			kind: "removed",
+			text: '	expect(sozluk(10)).toBe("on");',
+		});
+		expect(lines).toContainEqual({
+			file: "ka\\çak.ts",
+			line: 2,
+			kind: "added",
+			text: "c",
+		});
+	});
+
+	it("emits nothing for a quoted header's own `---`/`+++` lines", () => {
+		const lines = changedLines(QUOTED_DIFF);
+		expect(lines.filter((line) => line.text.startsWith('-- "'))).toEqual([]);
+		expect(lines.filter((line) => line.text.startsWith('++ "'))).toEqual([]);
+		expect(lines.filter((line) => line.file === "")).toEqual([]);
+	});
+
+	it("reads a header whose sides quote independently — a rename to a non-ASCII name", () => {
+		const renamed = `diff --git a/plain.ts "b/yeni-\\303\\274nl\\303\\274.ts"
+--- a/plain.ts
++++ "b/yeni-\\303\\274nl\\303\\274.ts"
+@@ -1,1 +1,1 @@
+-a
++b
+`;
+		expect(changedLines(renamed)[0]?.file).toBe("yeni-ünlü.ts");
+	});
 });
 
 describe("tierMHits", () => {
@@ -76,6 +145,39 @@ describe("tierMHits", () => {
 				file: "src/cart.test.ts",
 				line: 13,
 				token: 'expect(renderTotal(10)).toBe("10.00");',
+			},
+		]);
+	});
+
+	it("reports a removed assertion in a test file whose name is non-ASCII", () => {
+		expect(tierMHits(QUOTED_DIFF)).toEqual([
+			{
+				kind: "suppression",
+				file: "plain.ts",
+				line: 2,
+				token: "biome-ignore",
+			},
+			{
+				kind: "removed-assertion",
+				file: "sözlük-başlık.test.ts",
+				line: 2,
+				token: 'expect(sozluk(10)).toBe("on");',
+			},
+		]);
+	});
+
+	it("reports a removed assertion in a test file whose name carries an escaped quote", () => {
+		const diff = `diff --git "a/qu\\"ote.test.ts" "b/qu\\"ote.test.ts"
+@@ -1,2 +1,1 @@
+ a
+-expect(x).toBe(1);
+`;
+		expect(tierMHits(diff)).toEqual([
+			{
+				kind: "removed-assertion",
+				file: 'qu"ote.test.ts',
+				line: 2,
+				token: "expect(x).toBe(1);",
 			},
 		]);
 	});


### PR DESCRIPTION
Git writes a file's diff header in quotes whenever the name holds a non-ASCII byte, a backslash, or a
double quote — `diff --git "a/sözlük.ts" "b/sözlük.ts"`. The review diff parser only knew the plain
form, so a file named in Turkish was invisible to it: the completeness check undercounted and refused
a whole diff as partial, and worse, that file's changed lines were filed under the *previous* file
while the header's own `---`/`+++` lines were reported as changes that never happened. The Tier-M
scan reads those lines, so a deleted `expect(...)` in a Turkish-named test file was reported as
nothing at all.

This teaches the parser both header forms and decodes git's escapes back to the real name.

Fixes #5159

## What changed

- `FILE_HEADER` matches either the bare `a/<path>` or the quoted `"a/<path>"` form, **per side** —
  git quotes the two sides independently, so a rename to a Turkish name emits
  `diff --git a/plain.ts "b/ünlü.ts"`.
- A new `unquoteCStyle` decodes git's C-style escapes — the named ones (`\t`, `\\`, `\"`, …) and the
  octal ones — into a **byte** buffer that is UTF-8 decoded once at the end. Git escapes byte by byte
  (`ç` arrives as `\303\247`), so per-escape decoding would produce mojibake. The name has to
  resolve, not just be counted: `tierMHits` matches `TEST_FILE` against it.
- `changedLines` reads its two paths through one `headerPaths` helper instead of the raw regex
  groups. Because the header now matches, the `continue` fires, the line counters reset, and the
  header's own `---`/`+++` lines are skipped by the existing above-the-first-hunk guard — no separate
  fix was needed for the fabricated entries.
- Six new unit assertions. The fixtures are **verbatim `git diff` output** from a throwaway repo on
  git's defaults, covering a Turkish name, a backslash name (which quotes regardless of
  `core.quotePath`), and an escaped-quote name.

## How it was checked

- Reproduced git's actual quoting first (`core.quotePath` unset, files named `sozluk-çöş.txt`,
  `back\slash.txt`, `qu"ote.txt`, and a rename to a Turkish name) rather than pattern-matching one
  example, and confirmed the two sides quote independently.
- Confirmed the new fixture reproduces the defect on the old regex: it counts **1** file where the
  diff carries **3**.
- `pnpm vitest run` in `packages/fabrika-cli` — 2300 passed. `pnpm typecheck` — 31/31. `pnpm
  lint:worktree` — clean.

The parser is the only thing touched. `diff-verb.ts`, `scope-verb.ts` and `deviations-verb.ts` are
untouched (issue #5139's family), and so is the `diff.ts` module docblock (#5160's lane). One note
for that lane: the docblock's completeness-proof paragraph still says the count is compared against
"the PR's declared `changed_files`", which #5153 already changed to a local git count — this PR
changes what the numerator *can read*, not what it is compared against, so the stale sentence is
still #5160's to fix.

## Deviations

- **Class 3 (known defect left unfixed)** — **Said:** the issue scopes this to the `FILE_HEADER`
  parser. **Did:** left `changedLines`' `after === "/dev/null"` deletion fallback in place, though it
  is unreachable (the regex strips the `b/` prefix, so `after` is at most `dev/null`) and its unit
  fixture uses a `b/dev/null` header real git never emits. **Why:** it is harmless — a real deletion
  header carries the same path on both sides — and changing it would edit a pre-existing assertion
  outside this lane. **Disposition:** follow-up #5166 filed.
- **Class 1 (scope narrowing / shape call)** — **Said:** the AC asks that captured paths be unescaped
  from git's C-style escapes. **Did:** on an escape git does not emit (e.g. `\q`), the decoder takes
  the character literally instead of erroring, where git's own `unquote_c_style` returns an error.
  **Why:** this is a review gate; reporting a slightly-off path beats throwing on a diff it cannot
  parse. **Disposition:** no action needed — no git-produced input reaches that branch.