### PR TITLE
fix(fabrika-cli): take review deviations' completeness denominator from git, not GitHub (#5157)

### DIFF
--- a/packages/fabrika-cli/src/review/deviations-verb.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.ts
@@ -16,7 +16,7 @@
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {diffRange} from "../io/git.ts";
+import {diffRange, diffRangePaths} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {readDeviations} from "./deviations.ts";
@@ -68,15 +68,42 @@ export const runDeviations = (
 			return refuse(PRECONDITION_UNKNOWN, unreadable(pr, served.reason));
 		}
 		const diff = served.value;
+
+		// Both operands of the refusal below come from git over the SAME range under the SAME flags:
+		// `--name-only -z` emits one path per `diff --git` entry, so rename pairing and merge-base
+		// choice cancel instead of being compared across systems. What that proves is narrow and worth
+		// stating plainly — the scanned bytes carry every entry this second read lists. It does not
+		// prove the range is the right one, and a fault that shortens both reads alike is invisible to
+		// it. GitHub's `changed_files` is a third party's answer over its own base and its own rename
+		// detection, so it is reported in the diagnostics and never refused on (#5157).
+		const listed = yield* diffRangePaths(head.base, head.sha);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the file list of the range ${head.base}...${head.sha} for #${pr}: ${listed.reason} — the disclosure state is UNKNOWN, never "none".`,
+			);
+		}
+		const inRange = listed.value.length;
+
 		const seen = filesInDiff(diff);
 		const diagnostics = [
 			boundLine(VERB, head),
-			scannedLine(VERB, seen, "file", `${pull.changedFiles} declared`),
+			scannedLine(
+				VERB,
+				seen,
+				"file",
+				`${inRange} in the range per git, ${pull.changedFiles} declared by GitHub`,
+			),
 		];
-		if (seen < pull.changedFiles) {
+		if (inRange !== pull.changedFiles) {
+			diagnostics.push(
+				`${VERB}: git and GitHub disagree on #${pr}'s file count (${inRange} vs ${pull.changedFiles}) — different merge base and different rename detection; reported, never refused on (#5157).`,
+			);
+		}
+		if (seen < inRange) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: the diff for #${pr} is truncated (${seen} of ${pull.changedFiles} files) — refusing a partial Tier-M scan beside a disclosure claim.`,
+				`${VERB}: the scan at ${head.sha} covers ${seen} of the ${inRange} files git lists for the same range ${head.base}...${head.sha} — both counts from git, so these bytes are provably short of the range they were read from; refusing a partial Tier-M scan beside a disclosure claim.`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
@@ -10,7 +10,17 @@ import {
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {runDeviations} from "./deviations-verb.ts";
-import {BASE, binding, DIFF, DIFF_AT, HEAD, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+import {
+	BASE,
+	binding,
+	DIFF,
+	DIFF_AT,
+	HEAD,
+	OLD_HEAD,
+	PATHS_AT,
+	paths,
+	pull,
+} from "./fixtures.test-support.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
 /** The unbound endpoint this verb no longer reads — scripted so a regression has bytes to serve. */
@@ -54,19 +64,36 @@ const run = (
 	overrides: Partial<typeof options> = {},
 ) => shell(script, overrides).out;
 
-/** The green path: the bound range serves `diff`, and the PR-number endpoint serves `endpoint`. */
+/**
+ * The green path: the bound range serves `diff`, the same range's `--name-only` read serves
+ * `inRange` (the completeness denominator), and the PR-number endpoint serves `endpoint`.
+ */
 const scripted = (
 	diff: string,
 	endpoint: string,
 	shape: Parameters<typeof pull>[0] = {},
+	inRange: ReadonlyArray<string> = ["src/cart.ts", "README.md"],
 ): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 	[PULL, pull(shape)],
 	...binding(),
 	[DIFF_AT(), okOut(diff)],
+	[PATHS_AT(), paths(...inRange)],
 	[RAW, okOut(endpoint)],
 ];
 
 const happy = (shape: Parameters<typeof pull>[0] = {}) => scripted(DIFF, DIFF, shape);
+
+/** A rename git pairs into ONE `diff --git` entry — the shape GitHub may count as two files. */
+const RENAME_DIFF = `diff --git a/src/old.ts b/src/new.ts
+similarity index 96%
+rename from src/old.ts
+rename to src/new.ts
+--- a/src/old.ts
++++ b/src/new.ts
+@@ -1,1 +1,2 @@
+ const x = 1;
++const y = 2;
+`;
 
 describe("runDeviations", () => {
 	it("prints none-declared for a `None.` body with a clean diff", async () => {
@@ -103,11 +130,26 @@ describe("runDeviations", () => {
 		expect(out.stdout).toBe("deviations\tabsent\n");
 	});
 
-	it("refuses a truncated diff on 13 — a partial scan must not print beside a claim", async () => {
-		const out = await run(happy({changedFiles: 9}));
+	it("refuses a diff short of the range's own file list on 13 — a partial scan must not print beside a claim", async () => {
+		const out = await run(scripted(DIFF, DIFF, {}, ["src/cart.ts", "README.md", "src/dropped.ts"]));
 		expect(out.code).toBe(INCOMPLETE_SCAN);
 		expect(out.stdout).toBe("");
-		expect(out.stderr.at(-1)).toContain("refusing a partial Tier-M scan beside a disclosure claim");
+		expect(out.stderr.at(-1)).toBe(
+			`review deviations: the scan at ${HEAD} covers 2 of the 3 files git lists for the same range ${BASE}...${HEAD} — both counts from git, so these bytes are provably short of the range they were read from; refusing a partial Tier-M scan beside a disclosure claim.`,
+		);
+	});
+
+	it("refuses on 11 when the range's file list cannot be read, rather than scanning against nothing", async () => {
+		const out = await run([
+			[PULL, pull()],
+			...binding(),
+			[DIFF_AT(), okOut(DIFF)],
+			[PATHS_AT(), errOut("fatal: bad revision")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("cannot read the file list of the range");
+		expect(out.stderr.at(-1)).toContain('the disclosure state is UNKNOWN, never "none"');
 	});
 
 	it("refuses a PR proven absent on 7", async () => {
@@ -126,6 +168,38 @@ describe("runDeviations", () => {
 			expect(out.stdout).toBe("");
 			expect(out.stderr.at(-1)).toContain('the disclosure state is UNKNOWN, never "none"');
 		}
+	});
+});
+
+/**
+ * The single-source fence (#5157).
+ *
+ * The exit-`13` denominator is git's own count over the bound range, not GitHub's `changed_files`.
+ * Each case fails if the denominator drifts back across the system boundary, where a rename git
+ * pairs into one entry and the platform declares two.
+ */
+describe("runDeviations proves its scan complete against git's own count", () => {
+	const renamed = () => scripted(RENAME_DIFF, RENAME_DIFF, {changedFiles: 2}, ["src/new.ts"]);
+
+	it("scans a rename git paired into one entry, though GitHub declares it as two files", async () => {
+		const out = await run(renamed());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("deviations\tnone-declared\n");
+	});
+
+	it("reports the git-vs-GitHub disagreement on stderr instead of refusing on it", async () => {
+		const out = await run(renamed());
+		expect(out.stderr.at(-1)).toBe(
+			"review deviations: git and GitHub disagree on #4321's file count (1 vs 2) — different merge base and different rename detection; reported, never refused on (#5157).",
+		);
+	});
+
+	it("takes the denominator from the same range as the diff it scans", async () => {
+		const {fake, out} = shell(happy());
+		await out;
+		expect(fake.calls).toContain(
+			`git diff --no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/ --name-only -z ${BASE}...${HEAD}`,
+		);
 	});
 });
 
@@ -173,7 +247,9 @@ describe("runDeviations binds its Tier-M scan to a commit", () => {
 		expect(out.stderr[0]).toBe(
 			`review deviations: bound to ${HEAD} (base ${BASE}) — read from the object database, nothing checked out.`,
 		);
-		expect(out.stderr[1]).toBe("review deviations: scanned 2 files; 2 declared.");
+		expect(out.stderr[1]).toBe(
+			"review deviations: scanned 2 files; 2 in the range per git, 2 declared by GitHub.",
+		);
 	});
 
 	it("refuses on 12 when --sha is not the PR's head, scanning nothing", async () => {

--- a/packages/fabrika-cli/src/review/mutation.unit.test.ts
+++ b/packages/fabrika-cli/src/review/mutation.unit.test.ts
@@ -267,6 +267,7 @@ diff --git a/README.md b/README.md
 		[PULL, pull()],
 		...binding(),
 		[DIFF_AT(), okOut(SUPPRESSING_DIFF)],
+		[PATHS_AT(), paths("src/cart.ts", "README.md")],
 		[RAW, okOut(DIFF)],
 	];
 


### PR DESCRIPTION
`review deviations` could refuse a perfectly healthy PR. It proved its Tier-M scan complete by comparing a file count git produced against the count GitHub declares, and those two systems pick their own merge base and their own rename threshold — so a rename git folds into one diff entry while GitHub calls it two files fired exit 13 with a message claiming the diff was truncated when it was not. Both counts now come from git over the same range, and GitHub's number is printed as a cross-check that can report a disagreement but never refuse on one.

Fixes #5157

## What changed

- The denominator is `diffRangePaths(head.base, head.sha)` — the same range, the same flags, one path per `diff --git` entry — instead of `pull.changedFiles`.
- A git-vs-GitHub disagreement gets its own stderr diagnostic saying it is reported and never refused on; `scannedLine` names both counts and which system produced each.
- The refusal message says the bytes are short of *the range they were read from*, both counts from git — it no longer asserts a truncation it cannot see.
- An unreadable file list refuses on `11` (UNKNOWN) rather than proving completeness against nothing. `INCOMPLETE_SCAN` keeps the value `13`, and a scan genuinely short of its own range still refuses on it.
- Unit coverage pins the rename case (git pairs one entry, GitHub declares two → exit `0`), the disagreement diagnostic, the short-scan refusal against the range's own list, the exit-`11` unreadable list, and that the `--name-only -z` read is issued for the same range. `mutation.unit.test.ts` scripts the new read for the deviations provenance cases.

## Which shape this is, and why

This verb is the **#5153 case, not the #5163 case**. Its numerator is a real second count — `filesInDiff` over the diff bytes — so there is something to prove completeness *against*, and the fix is to move the denominator to local git. Deleting the comparison (`review scope`'s repair, where the returned list *is* the scope and there was no second count) would have removed a live completeness guarantee here, so it was not an option.

Accuracy note on the proof, deliberately narrower than PR #5153's inline wording: comparing the two git reads establishes that the scanned bytes carry every entry the `--name-only` read lists. It does not establish that the range is the right range, and a fault that shortens both reads alike is invisible to it. The inline comment says exactly that.

## Deviations

- **Class: narrowed a suggested fix-shape.** **Said:** #5157's first criterion offers two routes — local denominator, or demonstrate the API count's comparability first. **Did:** took the local-denominator route only; no comparability demonstration was attempted. **Why:** the issue's own sequencing note names it the cheaper path, and #5153 landed it next door. **Disposition:** no action needed.
- **Class: declined to re-use a sibling's wording.** **Said:** port PR #5153's landed shape. **Did:** ported the mechanism, but wrote the inline comment and the refusal message to state a narrower claim than #5153's "one git computation against another". **Why:** that phrasing overstates what the two reads prove. **Disposition:** for the reviewer to judge; #5153's own line is untouched here (its file belongs to another lane).
- **Class: touched a file shared with sibling lanes.** **Said:** one file per lane. **Did:** also added the `--name-only` script line to `mutation.unit.test.ts`'s deviations case. **Why:** that harness drives `runDeviations`, so without the scripted read its cases fail loudly on an unscripted call. **Disposition:** no action needed — both prior lanes touched the same file for the same reason; no other lane is live in `src/review/`.