### PR TITLE
docs(fabrika): name review diff's real denominator — the git range, not GitHub (#5160)

### DIFF
--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -356,7 +356,7 @@ verb reds the same way. No `--json`: the diff is the object.
 | `10` | `--sha` is not a head SHA |
 | `11` | the diff could not be read, or the commit could not be bound — UNKNOWN |
 | `12` | `--sha` is not the PR's head — re-review at the head, never judge a tree the PR has left |
-| `13` | the diff is provably incomplete — the file count in the diff at the bound commit is short of the PR's declared count |
+| `13` | the diff is provably incomplete — the file count in the diff at the bound commit is short of the file list git reports for the same range |
 
 **Errors**
 
@@ -369,10 +369,11 @@ verb reds the same way. No `--json`: the diff is the object.
 | `review diff: <what> — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.` | 11 | refusal |
 | `review diff: cannot read the diff for #<n> at <sha>: <reason> — UNKNOWN.` | 11 | refusal |
 | `review diff: PR #<n>'s head is <live>, not <asked> — the tree you scoped is not the one under review; re-scope at <live> (ADR 0058).` | 12 | refusal |
-| `review diff: the diff at <sha> carries <k> of #<n>'s <m> declared files — refusing to serve a partial diff as the whole (#3925's class).` | 13 | refusal |
+| `review diff: the diff at <sha> carries <k> of the <m> files git reports for the same range <base>...<head> — both counts from git, so this diff is provably short; refusing to serve a partial diff as the whole (#3925's class).` | 13 | refusal |
 
-**Scope** — one commit's diff, completeness-checked against the PR's declared changed-file count.
-The bound commit, and the scanned byte and file counts, go to stderr on the answer path.
+**Scope** — one commit's diff, completeness-checked against the file list git reports for the same
+range. The bound commit, the scanned byte and file counts, and GitHub's declared changed-file count
+(reported as a cross-check, never refused on) go to stderr on the answer path.
 
 **Examples**
 
@@ -389,9 +390,17 @@ index 0b1c2d3..a1b2c3d 100644
   `application/vnd.github.diff` does **not** truncate: over its limits it refuses with HTTP `406`
   and `errors[].code = "too_large"`, and under them it serves the diff whole — established by live
   probe and recorded on #4993. This verb does not read that endpoint anyway; its bytes are local
-  `git diff <base>...<head>` at the bound commit (#5117). What `13` still buys is real: a range can
-  carry fewer files than the PR declares, and serving that prefix as the whole PR is the #3925
-  blind-PASS class one layer down.
+  `git diff <base>...<head>` at the bound commit (#5117), and its denominator is a second read of
+  that same range — `git diff --name-only -z`, one path per `diff --git` entry — so both counts come
+  from git under one set of flags rather than from two systems (#5139). GitHub's declared
+  `changed_files` is still read and reported beside them as a cross-check that never refuses; it is a
+  third party's answer over its own merge base and its own rename detection. What `13` still buys is
+  real: the served bytes can carry fewer files than git lists for that range, and serving that prefix
+  as the whole PR is the #3925 blind-PASS class one layer down.
+- State the guarantee at its real precision: the proof is a **cardinality** test, never an
+  entry-identity one. It establishes that the scanned bytes carry at least as many entries as the
+  `--name-only` read lists — not that the two reads name the same files, and not that the range is
+  the right range. A fault that shortens both reads alike stays invisible to it.
 - The proof counts whole files, so it does not see a diff cut inside the last file's hunks — every
   `diff --git` header is still present, and the count passes. That is a stated bound of the proof,
   not a failure mode defended against: no producer for that shape is known.

--- a/packages/fabrika-cli/src/review/diff-verb.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.ts
@@ -3,9 +3,9 @@
  * silently passed through.
  *
  * This verb is not a relay, and two proofs are why. **Completeness:** a diff carrying fewer files
- * than the PR declares is refused, because a gate that judged the visible prefix as the whole PR is
- * the #3925 blind-PASS class one layer down; v1's `pr-diff.sh` was the relay, and nothing checked
- * what it served. This is not a guard against a truncating platform: the diff media type refuses an
+ * than git lists for the same range is refused, because a gate that judged the visible prefix as the
+ * whole PR is the #3925 blind-PASS class one layer down; v1's `pr-diff.sh` was the relay, and
+ * nothing checked what it served. This is not a guard against a truncating platform: the diff media type refuses an
  * over-limit diff rather than serving a short one, and these bytes never come from it — see
  * `diff.ts` for what the proof does and does not cover (#4993). **Provenance:** the bytes come from
  * the object database at the bound commit via `diffRange`, never from an endpoint that takes a PR
@@ -64,9 +64,10 @@ export const runDiff = (
 		}
 		const diff = served.value;
 
-		// The denominator is a second read of the SAME range under the SAME flags — `--name-only -z`
-		// emits exactly one path per `diff --git` entry, renames paired identically — so the proof
-		// compares one git computation against another. GitHub's `changed_files` is its own merge base
+		// Both operands of the refusal below come from git over the SAME range under the SAME flags —
+		// `--name-only -z` emits exactly one path per `diff --git` entry, renames paired identically —
+		// so rename pairing and merge-base choice cancel instead of being compared across systems. What
+		// that does and does not prove is in `diff.ts`. GitHub's `changed_files` is its own merge base
 		// and its own rename detection, so it is reported below and never refused on (#5139).
 		const listed = yield* diffRangePaths(head.base, head.sha);
 		if (listed._tag === "Failure") {

--- a/packages/fabrika-cli/src/review/diff.ts
+++ b/packages/fabrika-cli/src/review/diff.ts
@@ -3,9 +3,19 @@
  * removed line sits.
  *
  * **The completeness proof is the file count, and only the file count.** The bytes are local
- * `git diff <base>...<head>` at the bound commit (`diff-verb.ts`, #5117), so the proof compares the
- * `diff --git` header count against the PR's declared `changed_files` and a short one is refused:
- * serving a prefix as the whole PR is the #3925 blind-PASS class one layer down.
+ * `git diff <base>...<head>` at the bound commit (`diff-verb.ts`, #5117), and the denominator is a
+ * second read of that same range — `git diff --name-only -z`, which emits one path per `diff --git`
+ * entry — so both counts come from git over one range under one set of flags, and rename pairing and
+ * merge-base choice cancel instead of being compared across systems (#5139). GitHub's declared
+ * `changed_files` is still read and reported beside them, and never refused on: it is a third
+ * party's answer over its own merge base and its own rename detection.
+ *
+ * What that proves is narrow, and worth stating at its real precision: the scanned bytes carry **at
+ * least as many** entries as the `--name-only` read lists. It is a cardinality test, never an
+ * entry-identity one — it does not establish that the two reads name the same files, and it does not
+ * establish that the range is the right range, so a fault that shortens both reads alike stays
+ * invisible to it. A short count is refused because serving a prefix as the whole PR is the #3925
+ * blind-PASS class one layer down.
  *
  * No truncation marker is matched, because there is nothing to match. `application/vnd.github.diff`
  * does not truncate — over its limits it refuses with HTTP 406 and `errors[].code = "too_large"`,


### PR DESCRIPTION
`fabrika review diff` used to check its diff against the file count GitHub declares for the PR. PR #5153 changed that: it now checks against a second read of the same local `git diff` range. Three pieces of prose still described the old check, and one of them quoted an error message the tool no longer prints. This PR makes all three say what the code does today. No behaviour changes.

Fixes #5160

## What changed

- **`packages/fabrika-cli/src/review/diff.ts` (module docblock)** — names the real denominator: a second read of the same range, `git diff --name-only -z`, one path per `diff --git` entry, so both counts come from git under one set of flags. It also states the guarantee at its real precision: the scanned bytes carry **at least as many** entries as the `--name-only` read lists — a **cardinality** test, never an entry-identity one. It does not establish that the two reads name the same files, and it does not establish that the range is the right range; a fault that shortens both reads alike stays invisible to it.
- **`packages/fabrika-cli/src/review/diff-verb.ts` (module docblock)** — no longer says the refusal is against what the PR declares. Its inline note beside `diffRangePaths` keeps the same-range/same-flags rationale and points at `diff.ts` for what the proof does and does not cover, rather than restating it (CLAUDE.md's state-a-why-once rule).
- **`claude-plugins/fabrika/skills/review/contract.md`, the `review diff` section** — the exit-`13` row, the **Scope** line and the Grounding paragraph name the git-range denominator, and a second Grounding bullet records the cardinality bound. The refusal-message row now matches the string `diff-verb.ts` emits, placeholder-for-placeholder:

  `review diff: the diff at <sha> carries <k> of the <m> files git reports for the same range <base>...<head> — both counts from git, so this diff is provably short; refusing to serve a partial diff as the whole (#3925's class).`

GitHub's declared `changed_files` is still read and still reported beside the git counts as a cross-check that never refuses — every surface says so, because dropping the mention would be a second inaccuracy. #4993's corrections are preserved byte-for-byte in substance: no API-truncation claim comes back, and the "the count sees whole files only" bound is untouched.

## Verified against live `main`, not the issue body

Four PRs landed in this area after #5160 was filed, so every claim here was read off the source at `main` @ `adcdef87` rather than reconstructed from the issue or any PR description: #5153 (`review diff`, `15a5277b`), #5163 (`review scope`, `d82aa691` — deleted its comparison outright, a deliberately different shape), #5167 (`d5592a9d` — the quoted-path header parser in `diff.ts`) and #5168 (`review deviations`, `adcdef87`). The wording of the guarantee follows #5168's lane, which its gate confirmed.

`pnpm typecheck` (31/31) and `pnpm lint:worktree` are clean; the pre-push hook ran typecheck + changed-unit tests green.

## Deviations

- **Class 7 (out-of-scope change) — the inline comment in `diff-verb.ts` beside `diffRangePaths`.**
  - *Said:* the acceptance criteria name three surfaces — the two module docblocks and `contract.md`'s `review diff` section. The inline comment is not one of them.
  - *Did:* rewrote it anyway. It read "so the proof compares one git computation against another", which overstates what the two reads establish (it is a cardinality test, not an entry-identity one). The replacement keeps the flags rationale and defers to `diff.ts` for the bound.
  - *Why:* it is prose in a named file, describing the exact claim this issue exists to correct. Leaving a known-too-strong statement in place while fixing the docblock above it would ship half the correction.
  - *Disposition:* no action needed — prose only, in scope in spirit, for the reviewer to judge.
- **Class 3 (known defect left unfixed) — `contract.md`'s `review deviations` rows are now stale too.**
  - *Said:* #5160 corrects the `review diff` surface only; #5165 owns `review scope`.
  - *Did:* left the `review deviations` exit-`13` row and error row alone. The error row still reads `the diff for #<n> is truncated (<k> of <m> files)`, while `deviations-verb.ts` now emits `the scan at <sha> covers <k> of the <m> files git lists for the same range …` after #5168.
  - *Why:* out of this issue's scope, and neither #5165 nor any open lane appears to own it.
  - *Disposition:* follow-up filed — see the linked issue in the progress comment on #5160.