### PR TITLE
docs(fabrika): say what review scope's exit 13 actually refuses — an empty read (#5165)

### DIFF
--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -22,7 +22,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 
 | Verb | Purpose | Split test |
 |---|---|---|
-| `review scope` | the PR's head SHA, linked issue, artifact-class partition of its changed files, and the `self` / `harness` flags | partitioning paths against a fixed class map and failing closed on a truncated file list is mechanical; what to do with each class is judgment |
+| `review scope` | the PR's head SHA, linked issue, artifact-class partition of its changed files, and the `self` / `harness` flags | partitioning paths against a fixed class map and failing closed on an empty file list is mechanical; what to do with each class is judgment |
 | `review diff` | the PR's diff bytes, with truncation refused rather than silently passed through | fetching and proving completeness is mechanical; reading the diff is the whole judgment layer |
 | `review criteria` | the linked issue's acceptance-criteria block, read through the registered `acceptance-criteria` wire format | fetch + registered parse + checkbox states are mechanical; grading a criterion is judgment |
 | `review ci` | the live CI check-run rollup at a head, fail-closed on incomplete enumeration | classifying check runs and proving the enumeration complete is mechanical (#4552, #3999); weighing a red check is judgment |
@@ -276,7 +276,7 @@ only reports it.
 | `10` | `--sha` is not a head SHA |
 | `11` | the PR could not be read, or the commit could not be bound — the scope is UNKNOWN |
 | `12` | `--sha` is not the PR's head — re-scope at the head, never partition a tree the PR has left |
-| `13` | the changed-file enumeration is provably short (received < declared count) |
+| `13` | git reports no changed files for the bound commit's range — an empty read, with nothing to partition |
 
 **Errors**
 
@@ -290,12 +290,13 @@ only reports it.
 | `review scope: <what> — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.` | 11 | refusal |
 | `review scope: cannot read the changed files of #<n> at <sha>: <reason> — the scope is UNKNOWN.` | 11 | refusal |
 | `review scope: PR #<n>'s head is <live>, not <asked> — the tree you scoped is not the one under review; re-scope at <live> (ADR 0058).` | 12 | refusal |
-| `review scope: <sha> carries <k> of the <m> files #<n> declares — refusing to partition a short read (#3999).` | 13 | refusal |
+| `review scope: git reports no changed files for the range <base>...<sha>, so <sha> has nothing to partition — refusing to scope an empty read (#3999).` | 13 | refusal |
 
-**Scope** — one PR's metadata, and the changed-file list of one bound commit, count-checked
-against the declared total. The class partition is total over what was read; the refusals exist so
-it is never run over less than everything, and never over a different tree than the head it
-prints.
+**Scope** — one PR's metadata, and the path list git reports for one bound commit's range. That
+list is the scope itself, so it has no second count to be checked against: it is refused when
+**empty**, and GitHub's declared changed-file count is reported beside it as a cross-check that
+never refuses. The class partition is total over what was read; the refusals exist so it is never
+run over less than everything, and never over a different tree than the head it prints.
 
 **Examples**
 
@@ -325,6 +326,11 @@ $ fabrika review scope 4321 --json
 - #5117 — the file list is the namespace set's only input, and the set is both floor and ceiling:
   a list read at a later commit than the printed head derives a namespace nobody judged, or drops
   one. The list and the head are one commit or the verb refuses.
+- #5154 — this verb has no second count of the range, because the list it reads *is* the scope, and
+  GitHub's `changed_files` cannot stand in for one: it is a different computation over its own merge
+  base with its own rename pairing, which counts two files where git's list carries one path. So the
+  disagreement is reported and never refused on, and the only short read git alone establishes — an
+  empty one — is the `13`.
 
 ---
 

--- a/packages/fabrika-cli/src/review/scope-verb.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.ts
@@ -3,9 +3,13 @@
  * files, and the `self` / `harness` flags.
  *
  * The refusals are the point: the partition is total over **what was read**, so the verb exists to
- * make sure it is never run over less than everything. A zero-file PR reds (v1's `class-probe` read
- * 0 files and classified `has-code` exit 0 — #4060), and a file list short of the declared count reds
- * rather than partitioning a truncated read (#3999).
+ * make sure it is never run over less than everything. A PR GitHub reports as having zero changed
+ * files reds on `7` (v1's `class-probe` read 0 files and classified `has-code` exit 0 — #4060), and
+ * a git read that comes back empty reds on `13` — either way there is nothing to partition (#3999).
+ *
+ * Empty is the whole of it. This path list IS the scope, so no second count of the same range exists
+ * to call it short against, and GitHub's `changed_files` is not one: a disagreement with it is
+ * reported and never refused on (#5154 — the reason is at the check below).
  *
  * The file list is read at the **bound commit** (`head.ts`), and the head this verb prints is that
  * same commit. The namespace set is documented as both floor and ceiling, so a list drawn from a


### PR DESCRIPTION
`fabrika review scope` used to red when its file list came back shorter than the count GitHub declares for the PR. PR #5163 deleted that check outright, because there is nothing to compare: the list git returns for the range *is* the scope, so no second count of it exists. What is left is a refusal on an **empty** list. Four pieces of prose still described the deleted check, and one of them quoted an error message the verb no longer prints. This PR makes them say what the code does today. No behaviour change.

Fixes #5165

## What changed

- **`packages/fabrika-cli/src/review/scope-verb.ts` (module docblock)** — names the two refusals that actually exist: a PR GitHub reports as having zero changed files reds on `7`, and a git read that comes back empty reds on `13`. It then states the bound at the precision it holds here: **empty is the whole of it**, because this path list is the scope and has no second count of the same range to be called short against. `review diff`'s cardinality wording does not apply — that verb has two reads, this one has one. GitHub's `changed_files` is named as not being that second count, with the rename-pairing reason left at the check that reports it (CLAUDE.md's state-a-why-once rule), not repeated here.
- **`claude-plugins/fabrika/skills/review/contract.md`, the `review scope` section** — the exit-`13` row now describes the empty read; the **Scope** paragraph says the list is the scope itself and that GitHub's declared count is a cross-check that never refuses; a Grounding bullet records #5154 (why no second count exists). The refusal-message row now matches the string `scope-verb.ts` emits, placeholder-for-placeholder:

  `review scope: git reports no changed files for the range <base>...<sha>, so <sha> has nothing to partition — refusing to scope an empty read (#3999).`

## Verified against live `main`, not the issue body

Every claim was read off the merged source, not reconstructed: #5163 landed at `d82aa691` and deleted the `files.length < pull.changedFiles` comparison, leaving `files.length !== pull.changedFiles` as a reported diagnostic and `files.length === 0` as the exit-`13` refusal. `requireFiles` (exit `7`) and an unreadable list (exit `11`) are unchanged, and the prose still names both. `pnpm typecheck` (31/31) and `pnpm lint:worktree` are clean; the pre-push hook ran typecheck + 2424 changed-unit tests green.

Prose bar taken from PR #5171, which did this job for `review diff`: the phrase "one git computation against another" is not reintroduced anywhere, and the guarantee is stated at the precision it holds for *this* verb rather than copied from that lane.

## Deviations

- **Class 7 (out-of-scope change) — the `review scope` row in contract.md's Verb inventory table (line 25).**
  - *Said:* the acceptance criteria name the docblock plus three spots in the `review scope` section.
  - *Did:* also changed the inventory row's split test, which read "failing closed on a **truncated** file list is mechanical" — the same deleted refusal, one table higher up.
  - *Why:* it is the identical false claim about the identical verb. Fixing the section while leaving the summary row asserting the dropped strictness would ship half the correction.
  - *Disposition:* no action needed — prose only, for the reviewer to judge.
- **Class 3 (known defect left unfixed) — `contract.md`'s `review deviations` rows.**
  - *Said:* #5172 owns those rows and is claimed separately.
  - *Did:* left them untouched, including the error row still reading `the diff for #<n> is truncated (<k> of <m> files)`.
  - *Why:* out of scope, and touching them would conflict with #5172's lane in the same file.
  - *Disposition:* no action needed — #5172 owns it.
- **Class 3 (known defect left unfixed) — the shared exit-taxonomy row for `13` (line 134) still reads "a truncated file list or diff".**
  - *Said:* nothing; the acceptance criteria do not reach the cross-verb table.
  - *Did:* left it alone.
  - *Why:* the row is generic across eight verbs and stays accurate for `review diff`, `review ci` and `review deviations`; rewording it for `review scope` alone would need a call about the whole table, and it overlaps #5172's file region.
  - *Disposition:* for the reviewer to judge — flagging it rather than silently narrowing the table.