### PR TITLE
docs(fabrika): quote the refusal `review deviations` actually emits (#5172)

### DIFF
--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -703,12 +703,18 @@ v1's prose (ADR 0238). An entry's optional label is one of `1`–`7`:
 The classes overlap; the label is a routing hint, not the disclosure — a gate matches an
 entry's substance, never its label. An entry carrying no recognizable label prints `-`.
 
-The Tier-M scan reads the same diff `review diff` serves and inherits both of its proofs. Its
-**completeness** proof: a truncated diff is refused here on `13`, because an under-reported hit
-list beside a `None.` reads as a checked-clean disclosure that was never checked. Its **commit
-binding** (#5122): the bytes come from the object database at the bound commit, because a hit list
-read at a head nobody scoped is under- or over-reported against the disclosure it is printed
-beside — and it fails open, answering `none-declared` at exit 0.
+The Tier-M scan reads the same diff `review diff` serves and applies both of its proofs to it. Its
+**completeness** proof is the one `review diff` states: the denominator is a second read of the same
+range — `git diff --name-only -z`, one path per `diff --git` entry — so both counts come from git
+under one set of flags. That makes it a **cardinality** test and nothing more: it establishes that
+the scanned bytes carry at least as many entries as the `--name-only` read lists, not that the two
+reads name the same files, and not that the range is the right range — a fault that shortens both
+reads alike stays invisible to it. A scan short of that denominator is refused on `13`, because an
+under-reported hit list beside a `None.` reads as a checked-clean disclosure that was never checked.
+GitHub's declared `changed_files` is read and reported beside the two counts as a cross-check that
+never refuses. Its **commit binding** (#5122): the bytes come from the object database at the bound
+commit, because a hit list read at a head nobody scoped is under- or over-reported against the
+disclosure it is printed beside — and it fails open, answering `none-declared` at exit 0.
 
 **Exit status**
 
@@ -718,7 +724,7 @@ beside — and it fails open, answering `none-declared` at exit 0.
 | `10` | `--sha` is not a head SHA |
 | `11` | the PR body or the diff could not be read, or the commit could not be bound — the disclosure state is UNKNOWN |
 | `12` | `--sha` is not the PR's head — re-scope, never re-bind |
-| `13` | the diff for the Tier-M scan is provably incomplete — a partial scan must not print beside a `None.` |
+| `13` | the Tier-M scan is provably incomplete — the diff scanned at the bound commit carries fewer files than the file list git reports for the same range, and a partial scan must not print beside a `None.` |
 
 **Errors**
 
@@ -729,10 +735,13 @@ beside — and it fails open, answering `none-declared` at exit 0.
 | `review deviations: PR #<n>'s head is <live>, not <sha> — the tree you scoped is not the one under review; re-scope at <live> (ADR 0058).` | 12 | refusal |
 | `review deviations: <what> — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.` | 11 | refusal |
 | `review deviations: cannot read #<n>'s body or diff: <reason> — the disclosure state is UNKNOWN, never "none".` | 11 | refusal |
-| `review deviations: the diff for #<n> is truncated (<k> of <m> files) — refusing a partial Tier-M scan beside a disclosure claim.` | 13 | refusal |
+| `review deviations: cannot read the file list of the range <base>...<head> for #<n>: <reason> — the disclosure state is UNKNOWN, never "none".` | 11 | refusal |
+| `review deviations: the scan at <sha> covers <k> of the <m> files git lists for the same range <base>...<head> — both counts from git, so these bytes are provably short of the range they were read from; refusing a partial Tier-M scan beside a disclosure claim.` | 13 | refusal |
 
-**Scope** — one PR body's `## Deviations` section plus the bound commit's diff for the Tier-M
-token scan.
+**Scope** — one PR body's `## Deviations` section plus the bound commit's diff for the Tier-M token
+scan, completeness-checked against the file list git reports for the same range. The bound commit,
+the scanned file count, that range count and GitHub's declared changed-file count (reported as a
+cross-check, never refused on) go to stderr on the answer path.
 Whether the PR *owes* the section, and whether an entry's substance covers a finding (Tier R),
 are the skill's judgment; this verb reports states and facts, never the §DEV verdict row.
 
@@ -759,6 +768,10 @@ tier-m	removed-assertion	src/cart.test.ts:14	expect(renderTotal(10)).toBe("10.00
 - "A `deviation-disclosure: PASS` means 'nothing undisclosed that this gate could see'" — the M
   tier is exactly what this gate *can* see deterministically; the verb is that clause's
   mechanical floor.
+- #5157 — the completeness denominator is a second local-git read of the same range, not GitHub's
+  declared `changed_files`: GitHub computes over its own merge base with its own rename detection,
+  which counts two files where git's list carries one path. So the disagreement is reported in the
+  diagnostics and never refused on, and the `13` rests on git alone.
 
 ---
 


### PR DESCRIPTION
The `review deviations` section of fabrika's review contract still described the old
completeness check — and quoted a refusal message the verb stopped printing when PR #5168
moved it to a local-git denominator. Anyone reading the contract to check real output would
not have matched a single character past the last clause. This rewrites the four stale
surfaces so the doc says what the code does.

What changed, all in `claude-plugins/fabrika/skills/review/contract.md`:

- The exit-`13` **Errors** row now matches `packages/fabrika-cli/src/review/deviations-verb.ts`'s
  emitted string placeholder-for-placeholder. Machine-diffed, not eyeballed: the template
  literal was extracted from the source, its interpolations substituted for the row's
  placeholders, and the result compared byte-for-byte against the row — EXACT.
- The exit-`13` **Exit status** row names the denominator instead of being silent about it:
  the diff scanned at the bound commit carries fewer files than the file list git reports for
  the same range.
- The proofs paragraph states the guarantee at the precision it actually holds. It is a
  **cardinality** test — the scanned bytes carry at least as many entries as the `--name-only`
  read lists — never an entry-identity one, and it does not establish that the range is the
  right range; a fault that shortens both reads alike stays invisible to it. The scan
  *applies* `review diff`'s proofs rather than inheriting them, since it performs its own two
  reads. The commit-binding half (#5122) is unchanged.
- The **Scope** line names the completeness denominator and the diagnostics the answer path
  prints, including GitHub's declared `changed_files` as a cross-check that never refuses.
- A `#5157` **Grounding** bullet records why GitHub's count cannot be the denominator.

Third acceptance criterion, discharged rather than skipped: the "inherits both of its proofs"
sentence was re-read against the `review diff` rows PR #5171 landed, and rewritten to match
them — that is the paragraph bullet above.

Prose only. `deviations-verb.ts` is untouched, no emitted string or exit code moves, and the
`review diff` (#5160) and `review scope` (#5165) sections the two sibling lanes just corrected
are left alone. Branched off current `main`, which already carries both; no conflict.

Fixes #5172

## Deviations

- **Class 7 — out-of-scope change (one added Errors row).** *Said:* the issue scopes the edit
  to three surfaces and says the other five Errors rows are left alone unless they diverge.
  *Did:* also added a **missing** exit-`11` row for
  `review deviations: cannot read the file list of the range <base>...<head> for #<n>: <reason> — the disclosure state is UNKNOWN, never "none".`
  *Why:* PR #5168 introduced that refusal along with the new denominator, and the table never
  gained a row for it — same drift, same commit, same section, and a conformance read hits an
  undocumented refusal without it. It was machine-diffed EXACT the same way.
  *Disposition:* no action needed; for the reviewer to judge if the tighter reading of "leave
  the other rows alone" was meant to exclude adding one.
- **Class 1 — scope narrowing (Scope + Grounding beyond the three named surfaces).** *Said:*
  three surfaces named. *Did:* also touched the **Scope** line and added one **Grounding**
  bullet. *Why:* both siblings did exactly this for their sections, so leaving them out would
  have made the three `contract.md` sections describe their denominators three different ways.
  *Disposition:* no action needed — same shape as PR #5171 and PR #5176.