### PR TITLE
docs(design): Pillar 4 gains the motion-alone prohibition

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/taste-animation-review/STANDARDS.md
+++ b/claude-plugins/kampus-pipeline/skills/taste-animation-review/STANDARDS.md
@@ -98,7 +98,7 @@ navigation is the same defect as a blocked first paint, arriving later.
 | `prefers-reduced-motion` | honored by the shared layer, not per component | LAW — manifest, Design-sync authority (the behavioral spine is code-authoritative) |
 | Shipped reduced-motion baseline | `animation-duration: 0.01ms`, `animation-iteration-count: 1`, `transition-duration: 0.01ms`, `scroll-behavior: auto` — global reset in [`global.css`](https://github.com/kamp-us/phoenix/blob/main/apps/web/src/styles/global.css) | LAW — global.css |
 | Hover motion | gated behind `@media (hover: hover) and (pointer: fine)` | CRAFT |
-| Meaning carried by motion | never motion alone — the state must also be readable when motion is off | LAW — Pillar 4, "never signal state or meaning by color alone" (the same rule, one modality over) |
+| Meaning carried by motion | never motion alone — the state must also be readable when motion is off | LAW — Pillar 4, "never signal state or meaning by motion alone" (the manifest's own prohibition, per ADR 0223 — no longer an analogy to the colour rule) |
 | Focus ring during motion | `--focus-ring` + `--focus-ring-offset`, never a hand-rolled per-component `outline` | LAW — Pillar 4 |
 
 **Known divergence (surface, do not resolve locally).** The adopted craft holds that reduced

--- a/design-system-manifest.md
+++ b/design-system-manifest.md
@@ -286,6 +286,7 @@ systematic layer — a11y is a property of the shared primitives, not a per-comp
   per-component `outline` in place of the shared spacer ring (`--focus-ring`).
 - **Never** fall below the 36px tap-target minimum hit area.
 - **Never** signal state or meaning by color alone.
+- **Never** signal state or meaning by motion alone.
 
 ---
 


### PR DESCRIPTION
The design law's accessibility pillar now says out loud what the founder ruled: a state or meaning may never be carried by motion alone. If the only way to tell what a component is doing is to watch it animate, that is a defect — the state has to stay readable when nothing moves.

Until now that obligation was law inside one review skill only, so it reached reviewers but not the agents generating UI. Pillar 4 is what a UI-generating agent reads before it writes anything, so putting the rule there binds it at generation time instead of after the fact.

Two lines change:

- `design-system-manifest.md` — Pillar 4's prohibition list gains a fifth entry, `- **Never** signal state or meaning by motion alone.`, transcribed verbatim from the founder ruling on the issue (comment `5230781219`, option (a) — widen the law). Same terse `**Never** …` register as the four above, no inline justification.
- `claude-plugins/kampus-pipeline/skills/taste-animation-review/STANDARDS.md` — the `LAW`-classified *Meaning carried by motion* row now cites the manifest's own prohibition instead of extending the colour-alone rule by analogy.

The decision record the issue asks for already exists on `main`: ADR [0223](https://github.com/kamp-us/phoenix/blob/main/.decisions/0223-pillar-4-bans-motion-alone.md) records the widening of ADR 0162's ratified law, and 0162's status line already reads `amended-in-part by 0223`. ADR 0223 explicitly defers the manifest transcription to this issue, so this PR is the transcribe half of that ratify → transcribe path. No new ADR is minted.

Under ADR 0162 the wording here is transcribed, not authored — the prohibition text is fixed by the ruling.

Fixes #4385

## Deviations

**Class: narrowed/changed the specified shape.**
- Said: the 2026-07-27 triage comment scoped the work to "the manifest only" and required `taste-animation-review/STANDARDS.md` to be byte-unchanged in the diff.
- Did: edited that file's `LAW`-row provenance as well.
- Why: the later founder ruling (2026-08-09, comment `5230781219`) and the `ready-for:agent` comment supersede that scoping — both state the `LAW` row is reconciled to cite the manifest directly, and the routing note explicitly classifies this PR as control-plane *because* it touches that skill file. The row's assertion is byte-unchanged; only its provenance column moved.
- Disposition: no action needed — this follows the latest ruling; flagged so a reviewer reading the older comment does not read it as scope creep.

**Class: left a sibling defect for a follow-up.**
- Said: nothing.
- Did: left `claude-plugins/kampus-pipeline/skills/review-design/SKILL.md`, which hardcodes a six-item FAIL-class list including "Colour-alone meaning" and no motion sibling, untouched.
- Why: the issue's scope guard names the manifest and the one `LAW` row and nothing else, and that v1 skill is superseded by `review-ui`, which reads the manifest rather than re-enumerating prohibitions — so the new prohibition already reaches the v2 gate through this diff.
- Disposition: for the reviewer to judge; no follow-up filed, since the file is on the release sweep's delete list.

**No other deviation.** No ADR was written, no test changed, no hook pushed past, nothing else in the manifest touched. `pnpm typecheck` and `pnpm lint:worktree` are both green (the diff is markdown-only, so lint is a clean skip).

**(repair round 1) Class: rebased the head after a merge-queue ejection.**
- Said: nothing — this round was dispatched as an ejection recovery, not as a gate FAIL repair. There is no FAIL verdict on this PR: every gate PASSed at `09637382de9875de596577c90c7f7f2c3b7b86ab` and CI was green.
- Did: the merge queue removed this PR at 2026-08-09 22:53:50Z with no `merged` event, so it broke inside the batch rather than on its own merits (`mergeable_state` read `clean` against `main` standalone). Rebased the branch onto current `origin/main` — which had since taken #5205, #5202, #5201 and #5210 — and force-with-lease pushed. The rebase was clean; nothing conflicted, and the diff's substance is byte-identical to the reviewed one (two files, +2/-1).
- Why: a bare re-enqueue on the old head would loop on the same batch conflict. Rebasing onto the current base is the honest recovery, and it surfaces any textual conflict now rather than at merge.
- Disposition: the head move staleness-invalidates both §CP advisories and the human approval (ADR 0058). That is expected — a re-gate at the new head and a fresh control-plane approval follow this round.
