### PR TITLE
feat(fabrika): taste-color seed skill grounded in the manifest role-token law (#3970)

### DIFF
--- a/claude-plugins/fabrika/skills/taste-color/SKILL.md
+++ b/claude-plugins/fabrika/skills/taste-color/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: taste-color
+description: Pick the colour a surface, border, text run, accent or focus ring is painted with, using the repo's own role-token layer. Trigger before writing or editing any styled UI — a new component, a theme pass, a state or status treatment, a contrast or dark-mode fix — and whenever a review needs the vocabulary to say why a colour choice is wrong. It selects from the design law that already exists; it never mints a colour, a token, or a rule.
+---
+
+# taste-color
+
+You choose colour by **role**, not by value. The repo's design manifest already names one token
+per colouring job; your whole job is picking the right row and refusing to paint anything the law
+does not name. **The failure this skill exists to stop is the invented value** — a raw hex, a
+scale token, or a status colour nobody ratified, which is the single defect class every real
+design FAIL on record shipped.
+
+**Ingestion surface** (convention §9): the repo's design manifest, its component inventory, and
+its blessed goldens — repo files, read as law, no externally-authorable text. **Capability set:**
+read-only. This skill emits guidance; it writes no file, runs no verb, and posts no verdict.
+
+## Grounding and the firewall — advise, never author
+
+Every rule below cites the named manifest or inventory section it comes from. **A colour rule
+with no citation is not a rule** — it is an invention, and this skill does not carry one.
+
+**Skills advise creation; only the founder authors design law** (ADR
+[0194](https://github.com/kamp-us/phoenix/blob/main/.decisions/0194-design-law-jsdoc-firewall.md)).
+So this skill never edits `design-system-manifest.md`, never adds a token, and never promotes a
+preference into a prohibition. It restates law and points at it; the law's own file is the source.
+
+## The role table — one row per colouring job
+
+Read the job in the left column, reach for the token in the middle, and check the cited manifest
+section when you need the *why*. **Never** reach past this table into a raw scale (`--mauve-*`,
+`--tomato-*`) or a semantic scale (`--gray-N`, `--accent-N`) — those are the layers the role
+tokens exist to hide (Pillar 2, last prohibition).
+
+| The job | Role token | Manifest anchor |
+|---|---|---|
+| Default page or card background | `--surface` | `### Surface roles` |
+| A recessed well (inset panel, code block) | `--surface-sunken` | `### Surface roles` |
+| A surface lifted above the page (raised card, popover body) | `--surface-raised` | `### Surface roles` |
+| The lightest hairline separator | `--border-faint` | `### Border roles` |
+| The default control or card border | `--border` | `### Border roles` |
+| An emphasised divider or focused-field border | `--border-strong` | `### Border roles` |
+| Primary body copy and headings | `--text-primary` | `### Text roles` |
+| Secondary body text | `--text-secondary` | `### Text roles` |
+| Meaning-carrying text at its lowest legal rung | `--text-muted` | `### Text roles` |
+| Placeholder, disabled, or hint text — decorative only | `--text-faint` | `### Text roles` |
+| A solid accent fill | `--accent` | `### Accent / link roles` |
+| Text or an icon sitting on a solid `--accent` fill | `--accent-fg` | `### Accent / link roles` |
+| A hover wash or subtle highlight | `--accent-soft` | `### Accent / link roles` |
+| The faintest accent tint | `--accent-faint` | `### Accent / link roles` |
+| Link text | `--link` | `### Accent / link roles` |
+| Any interactive control's focus ring | `--focus-ring` + `--focus-ring-offset` | `### Focus role` |
+
+No row fits? That is the silence case below — not a licence to pick.
+
+## The rules
+
+**Paint every component colour from a role token.** The role layer is the only layer a component
+may reference (`## Semantic token annotations — reach for the role layer only`; Pillar 2, last
+prohibition). A component reaching a scale directly re-themes wrong the day the scale moves.
+*Counterexample: `color: var(--gray-11)` on a byline where `--text-muted` is the role.*
+
+**Never write a literal colour into a component** — no hex, `rgb()`, `hsl()`, or hand-rolled
+colour function. Only the token layer holds literals (`## Semantic token annotations`), so a
+literal in a component is a value outside the system with nothing to keep it in step.
+*Counterexample: `background: #1a1a1a` on a card instead of `--surface`.*
+
+**Keep meaning-carrying text at `--text-muted` or above.** `--text-faint` clears 3:1 and is
+decorative only; the meaning floor is AA 4.5:1 (`### Text roles`; v1 design value 7 — Contrast
+floors; Pillar 4, first prohibition). Below the floor the text is invisible to the readers who
+need it most. *Counterexample: a post timestamp on `--text-faint`.*
+
+**Hold non-text UI at 3:1** — borders, icons, and control affordances (v1 design value 7 —
+Contrast floors). A border under 3:1 is decoration, so anything it was meant to delimit reads as
+undelimited. *Counterexample: `--border-faint` as the only edge of an input field.*
+
+**Carry every state in text, an icon, or shape as well as colour.** Colour alone never signals
+state or meaning (Pillar 4, last prohibition; the inventory's `Badge` when-to-use says the same:
+keep state in text, not colour alone). Colour-blind and greyscale readers lose the signal
+entirely. *Counterexample: an invalid input marked only by a red border.*
+
+**Leave the focus ring to the shared layer.** `--focus-ring` and `--focus-ring-offset` are painted
+once by the single `:focus-visible` rule (`### Focus role`; Pillar 4, second prohibition), so a
+per-component outline is a second focus system that drifts from the first.
+*Counterexample: `outline: 2px solid var(--accent-9)` on a custom button.*
+
+**Drive every icon from `currentColor`.** Icon colour is never hardcoded — icons inherit from the
+role token on their text context, the active vote glyph's `--accent` fill being the one sanctioned
+exception (Pillar 2, icon-colour prohibition). A hardcoded icon stops tracking the text it sits
+beside. *Counterexample: `stroke="#8b8b8b"` on a nav glyph.*
+
+**Signal elevation with the four named shadow levels.** `--shadow-flat` / `--shadow-raised` /
+`--shadow-dropdown` / `--shadow-overlay`, whose dark-mode definitions already lighten the surface
+per level (v1 design value 5 — Elevation). Depth faked by darkening a background invents a fifth
+level and breaks the ramp. *Counterexample: a custom `color-mix()` background to make a card look
+raised.*
+
+**Reach for the primitive that already owns the colour.** `Alert`, `Badge`, `Button`, `Card`, and
+`Surface` carry their own role-token treatment (the component inventory's when-to-use entries;
+Pillar 2, first prohibition). Re-colouring a hand-built equivalent is how a second palette starts.
+*Counterexample: a hand-rolled bordered box tinted by hand where `Card` was the primitive.*
+
+## Where the law is silent, surface the gap — never fill it
+
+The manifest names **no** semantic status palette: there is no `--success`, `--warning`, or
+`--danger` role token, and its closing section (`## Where the ADR is silent, surface the gap — do
+not fill it`) says a gap is founder-ratified, never agent-filled. So when a status colour is
+wanted:
+
+1. Use the primitive that already encodes the status — `Alert`'s semantic variants, `Badge`'s
+   status chip. **Verdict: proceed.**
+2. No primitive covers it? Ship the state in text or an icon at a role token from the table above,
+   which the colour-alone prohibition requires anyway. **Verdict: proceed, colour unresolved.**
+3. Still blocked on a colour the law does not name? **Verdict: stop.** File the gap through
+   `/report` and say in the PR body that the surface waits on ratified law. Never mint the token,
+   never approximate it from a scale, never carry it as a local constant.
+
+The same three steps apply to any colouring job with no row in the table.
+
+## Required repo files
+
+| Must exist | Why this skill needs it | When missing |
+| --- | --- | --- |
+| `design-system-manifest.md` at the repo root | Every role token, contrast floor, and prohibition cited above is read from it — this skill carries no colour law of its own | **fail-loud** — name the missing file, tell the user to run `/fabrika` for the bootstrap, and choose no colour; an improvised palette is the failure this skill exists to prevent. |
+| `design-system-inventory.md` at the repo root | Supplies which primitive already owns a colour treatment, so a hand-built equivalent is not re-coloured | **degrade** — the role table and rules still apply; say in the PR body that primitive selection went unchecked. |
+| A blessed golden for the surface | The visual reference a colour change is cross-checked against | **degrade** — an unblessed surface is a fact, not an error; the manifest's rules are then the only anchor. |


### PR DESCRIPTION
Agents that write UI keep picking colours by eye — a raw hex here, a `--gray-11` there — and the design gate catches it after the fact. This adds `taste-color`, a small skill an agent reads before it paints anything: one table saying which role token belongs to which job, nine rules that each cite the manifest section they come from, and a hard rule that where the design law names no colour, you stop and file the gap instead of inventing one.

Colour is the first taste aspect with no upstream seed to adapt, so every line traces to the repo's own law — the manifest's role layer (surface / border / text / accent / focus), the meaning-carrying text ladder and its contrast floors, the Pillar 2 and Pillar 4 prohibitions — cross-checked against the component inventory. It advises creation and never authors law (ADR 0194).

Fixes #3970

## What's in it

One new file: `claude-plugins/fabrika/skills/taste-color/SKILL.md` (126 lines, zero `.sh` files). Nothing else in the repo is touched.

- **Grounding and the firewall** — a rule with no citation is not a rule; the skill never edits the manifest, adds a token, or promotes a preference into a prohibition (ADR 0194).
- **The role table** — 16 rows, one per colouring job, over the manifest role layer, each row naming its manifest anchor (`### Surface roles`, `### Border roles`, `### Text roles`, `### Accent / link roles`, `### Focus role`). Not prose.
- **Nine rules**, each imperative + concrete value + one-line why + named counterexample, each citing the manifest section or inventory entry it comes from.
- **Where the law is silent, surface the gap** — a three-step gate with a stated verdict per step, worked on the real gap (the manifest names no status palette: no `--success` / `--warning` / `--danger` role token).
- **Required repo files** — the fabrika table, with the closed fail-loud / degrade vocabulary.

## Acceptance criteria

- `taste-color/` exists with valid frontmatter and zero `.sh` files — under `claude-plugins/fabrika/skills/` per the issue's 2026-08-09 amendment (see Deviations).
- Every rule cites a named manifest or inventory section; no rule states a value the grounding artifacts do not carry.
- Explicit where-silent-surface-the-gap clause, and the advise-never-author firewall statement citing ADR 0194.
- Role-selection guidance is a decision table over the manifest role layer, not prose.

## Deviations

**1. Authored into `claude-plugins/fabrika/skills/`, not the path AC 1 spells (scope reading).**
Said: AC 1 names `claude-plugins/kampus-pipeline/skills/`. Did: authored under `claude-plugins/fabrika/skills/`. Why: the issue's own 2026-08-09 amendment re-points that path, and the earlier attempt at this issue (PR #4387) was closed precisely for landing a taste skill in the plugin the v1 sweep deletes. Disposition: no action needed — this follows the amendment, which is the current body.

**2. No `contract.md` and no eval set (narrowed against the fabrika ship gate).**
Said: `claude-plugins/fabrika/docs/skill-conventions.md` §8 wants a derived CLI contract with deterministic tests, plus a green eval set. Did: shipped `SKILL.md` alone. Why: the skill is pure creation guidance — it runs no verb, so there is no CLI API to derive, and the issue's acceptance criteria name neither artifact. Disposition: for the reviewer to judge; if an eval identity is wanted for the taste family, it is a follow-up across all the seeds, not this one.

**3. The v1 taste-library LAW / CRAFT tagging is not carried over (deliberate).**
Said: the v1 `taste-library-conventions.md` tags every rule LAW or CRAFT. Did: every rule instead carries a citation, and an uncitable rule is not written at all. Why: AC 2 already forbids a value absent from the grounding artifacts, so every rule here is law and a per-rule tag would be a no-op — the exact failure mode the fabrika conventions §5 name. Disposition: no action needed.

**4. `cp-classify` could not classify this diff.**
Said: the v1 conventions have an author run `cp-classify-working-diff.sh` before opening the PR. Did: ran it; it returned `unknown [empty-file-set]` from this worktree. Why: the v1 script resolves its diff against the primary checkout, not a linked worktree. Verified by hand instead — `.github/CODEOWNERS` carries no `claude-plugins/fabrika/` entry, so this is an ordinary PR. Disposition: no action needed; the tool is v1's and is going away with it.