### PR TITLE
docs(fabrika): bound the FLIP-PARTIAL claim, not just its format

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/NOTES.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/NOTES.md
@@ -33,6 +33,19 @@ hypothesis).
   Falsified by: epics that ping-pong between the lanes without converging. Seam: `SKILL.md` step 2's
   terminal.
 
+## Defects the eval runs surfaced
+
+A searchable home for findings that would otherwise live only in an issue comment, which GitHub's
+search API does not index.
+
+- <!-- anchor: D1 --> **Post-flip label state was assertable on `FLIP-PARTIAL`**
+  ([#5151](https://github.com/kamp-us/phoenix/issues/5151)). Step 3 banned a fabricated per-child
+  *table* and not the *claim*, so both arms of eval-4 stated what un-flipped children carried after
+  the flip — state no surface in the run had read back. Found in iteration 2 of the eval runs, after
+  eval-4's assertion 5 was repaired (iteration 1 could not see it); held unpatched under the
+  authoring session's freeze rule so the benchmark stayed honest, then bounded in `SKILL.md` step 3
+  with a pointer on the `FLIP-PARTIAL` terminal. The bound's reasoning lives at step 3, not here.
+
 ## Open questions — carried open, not answered
 
 This skill proposes, never resolves; a ruling enters through report → triage.

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -90,9 +90,13 @@ counters. `nothing-to-flip` is a **clean gate that changed nothing**, which is n
 as one that made children pickable.
 
 A non-zero exit prints no answer at all, so read the refusal on stderr: `22` is a partial flip and
-the verb names there the children that did not move — those refs, not a per-child table it never
-printed, are what you post. `21` means the plan moved under you between the check and the flip;
-nothing was written, so re-check rather than retry.
+the verb names there the children that did not move — **those refs are the whole of what you post,
+and you claim nothing about what any child carries now**, in a table or in prose. Nothing in this
+run read that back: the `22` refusal carries the un-flipped refs and no observed labels, and `plan
+read`'s `children[].labels` are pre-flip — they were read at step 1, before the write. So any
+statement about a child's label state *after* the flip is invented rather than observed, and the
+ban is on the claim, not on the format that carries it. `21` means the plan moved under you between
+the check and the flip; nothing was written, so re-check rather than retry.
 
 ## 4 — Post the verdict, bound to the scope you scanned
 
@@ -139,7 +143,8 @@ An unreleased claim is v1's unreclaimable-lock scar, which a human then clears b
 - `PLAN-MOVED` — `21`: the plan changed between the check and a writing verb. Nothing was written
   and no verdict is posted; re-check from step 2.
 - `FLIP-PARTIAL` — `22`: the floor was clean and some children did not move. Post the refs the verb
-  named with `fabrika build note`; the epic needs a human. Never reported as a gate failure.
+  named with `fabrika build note` — refs only, no claim about what any child carries now (step 3);
+  the epic needs a human. Never reported as a gate failure.
 - `PLAN-UNGATEABLE` — `7` or `10`: the target is **proven** not gateable — absent or closed, not a
   `type:epic`, or it has zero children. Nothing was written. Proven, so not `STOPPED`.
 - `WRITE-UNPROVEN` — `8` or `9` from **either** writing verb: a write landed, or may have landed,


### PR DESCRIPTION
On a partial flip (exit `22`), `check-epic-plan` told a run not to fabricate a per-child *table* — but never told it to stop *claiming* what the un-flipped children carry now. Nothing in the run reads that back (the `22` refusal prints refs only, and `plan read`'s label arrays were read pre-flip), so a run could write the same unfounded content as prose and stay inside the letter of the rule. Step 3 now bans the claim in any form, the `FLIP-PARTIAL` terminal points at that bound, and the finding is recorded in the skill's `NOTES.md` so it lives somewhere searchable instead of only in an issue comment.

Fixes #5151

## What changed

- `claude-plugins/fabrika/skills/check-epic-plan/SKILL.md` step 3 — the refs are the whole of what you post, and you claim nothing about what any child carries now, "in a table or in prose". The two grounds are stated once, here: the `22` refusal carries refs and no observed labels, and `plan read`'s `children[].labels` are read at step 1, before the write.
- Same file, §TERM `FLIP-PARTIAL` — carries the bound as a short pointer back to step 3 ("refs only, no claim about what any child carries now"), rather than re-deriving the reasoning at a second site.
- `claude-plugins/fabrika/skills/check-epic-plan/NOTES.md` — new "Defects the eval runs surfaced" section with anchor `D1`, recording the finding, its provenance (iteration 2 of the eval runs, after eval-4's assertion 5 was repaired; held unpatched under the freeze rule), and where the fix landed.

No verb behaviour changed. `packages/fabrika-cli/**` is untouched.

## Acceptance criteria

- [x] Step 3 bounds the assertion, not just the format.
- [x] The §TERM `FLIP-PARTIAL` line is judged against the same bound and carries it (as a pointer, so the *why* is stated once — see Deviations).
- [x] A run reaching `FLIP-PARTIAL` cannot satisfy the skill while asserting post-flip label state in any form: the bound says "in a table or in prose" and closes with "the ban is on the claim, not on the format that carries it".
- [x] `evals/evals.json` eval-4 assertion 5 is untouched — semantically and byte-for-byte. **The eval baseline was not re-run and not re-graded in this PR**, so no grade is re-based; iteration 2's recorded results stand as-run.
- [x] Whether the finding belongs in `NOTES.md` was decided — yes, it does, and it is there under anchor `D1`.
- [x] No verb behaviour changes.

## Deviations

**Class: narrowed a suggested fix-shape.**
- Said: the issue leaves the §TERM decision open — "either carries it or the PR states why step 3 alone suffices".
- Did: §TERM carries the bound as a one-clause pointer to step 3, not a restatement of the reasoning.
- Why: CLAUDE.md's "comments earn their place" rule — a *why* is stated at its single most load-bearing site, and a second copy rots independently. Step 3 is where the run reads the `22` refusal, so the grounds live there; the terminal needs the rule visible, not the derivation.
- Disposition: no action needed.

**Class: left a sibling defect for a follow-up.**
- Said: the issue points at `contract.md`'s exit-`22` row as context.
- Did: left `contract.md` unchanged, including its "the observed set is on stderr" phrasing, which a reader could misread as observed *labels* (it means the set of unchanged refs).
- Why: `contract.md` is the verb contract, and the ticket forbids verb-behaviour changes; re-wording it is a separate judgement about the verb's documented surface, not this bound.
- Disposition: for the reviewer to judge — if it should be re-worded, that is a separate filing.

**Class: left adjacent work untouched.**
- Said: nothing.
- Did: did not touch the `FLIP-PARTIAL` caveat-emit gap (#5150) even though its fix lands on the same §TERM line.
- Why: #5150 is a separate unit with a separate fix surface, explicitly not mine.
- Disposition: no action needed — the issue flags this only as a merge-order note; sequence the two or expect a trivial conflict.