### PR TITLE
fix(fabrika): give check-epic-plan's FLIP-PARTIAL terminal a caveat surface

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/NOTES.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/NOTES.md
@@ -18,8 +18,12 @@ hypothesis).
   **First measurement (2026-08-09, 6 evals × 2 arms):** the layer produced caveats no floor defect
   covered on eval-1 (`ac-not-checkable` on an unfalsifiable criterion) and eval-3
   (`dependency-implied-not-declared` on an undeclared ordering) — both real, neither a restatement.
-  Counter-evidence from the same runs: `FLIP-PARTIAL` has **no caveat emit path**, so a run that
-  forms caveats on that terminal drops them. That is H1's own falsifier firing on one terminal.
+  Counter-evidence from the same runs: `FLIP-PARTIAL` had **no caveat emit path**, so a run that
+  formed caveats on that terminal dropped them — H1's own falsifier firing on one terminal.
+  **Resolved** ([#5150](https://github.com/kamp-us/phoenix/issues/5150)): that terminal now routes
+  through step 4 as well, verdict before the `build note`, so no clean-floor terminal drops a
+  caveat. The measurement above stands on the two caveats that reached a reader, and the falsifier
+  no longer fires anywhere.
 - <!-- anchor: H2 --> **Scope-digest binding is the right drift key.** Claim: binding a verdict to
   the scanned child set makes staleness structural rather than detected. Falsified by: digests that
   churn on edits the floor does not read, making every verdict Stale. Seam: the digest's field list

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -95,7 +95,9 @@ and you claim nothing about what any child carries now**, in a table or in prose
 run read that back: the `22` refusal carries the un-flipped refs and no observed labels, and `plan
 read`'s `children[].labels` are pre-flip — they were read at step 1, before the write. So any
 statement about a child's label state *after* the flip is invented rather than observed, and the
-ban is on the claim, not on the format that carries it. `21` means the plan moved under you between
+ban is on the claim, not on the format that carries it. A `22` is still a **clean floor**, so it
+does not skip step 4 — post the verdict there first, then those refs (`FLIP-PARTIAL`). `21` means
+the plan moved under you between
 the check and the flip; nothing was written, so re-check rather than retry.
 
 ## 4 — Post the verdict, bound to the scope you scanned
@@ -109,6 +111,15 @@ EOF
 The verb **derives its own polarity** from the floor it re-runs — you supply the digest and the
 caveats, never the verdict. It is the only emit path and it reads its own comment back. Done when
 it answers `posted` with a comment id.
+
+**Every clean floor comes through here, `FLIP-PARTIAL` included** — that terminal is the one place
+the "only emit path" rule was contradicted, and a run that formed caveats there dropped them
+(#5150). A partial flip writes only `status:planned` / `status:triaged` on a subset, both excluded
+from the digest and neither a floor trigger ([`contract.md`](contract.md), `flip-neutral`), so the
+digest you carried still binds and this verb still re-derives a clean floor after a `22`. **Order on
+that terminal: this verdict first, then `fabrika build note` with the un-flipped refs.** The note's
+body is free prose — no closed-kind check, no digest binding, no leak scan — so it carries refs and
+never caveats, and posting the verdict first is what keeps the rule below true.
 
 Your caveat text is authored prose reaching a public surface, so `5` and `6` are live: the verb
 refuses a caveat carrying a machine-local path or a bare `@` reference. **Redact it and re-run, or
@@ -142,9 +153,10 @@ An unreleased claim is v1's unreclaimable-lock scar, which a human then clears b
   success, not a back-off.
 - `PLAN-MOVED` — `21`: the plan changed between the check and a writing verb. Nothing was written
   and no verdict is posted; re-check from step 2.
-- `FLIP-PARTIAL` — `22`: the floor was clean and some children did not move. Post the refs the verb
-  named with `fabrika build note` — refs only, no claim about what any child carries now (step 3);
-  the epic needs a human. Never reported as a gate failure.
+- `FLIP-PARTIAL` — `22`: the floor was clean and some children did not move. Post the verdict with
+  any caveats (step 4), **then** the refs the verb named with `fabrika build note` — refs only, no
+  claim about what any child carries now (step 3); the epic needs a human. Never reported as a gate
+  failure.
 - `PLAN-UNGATEABLE` — `7` or `10`: the target is **proven** not gateable — absent or closed, not a
   `type:epic`, or it has zero children. Nothing was written. Proven, so not `STOPPED`.
 - `WRITE-UNPROVEN` — `8` or `9` from **either** writing verb: a write landed, or may have landed,

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -118,7 +118,7 @@ the "only emit path" rule was contradicted, and a run that formed caveats there 
 from the digest and neither a floor trigger ([`contract.md`](contract.md), `flip-neutral`), so the
 digest you carried still binds and this verb still re-derives a clean floor after a `22`. **Order on
 that terminal: this verdict first, then `fabrika build note` with the un-flipped refs.** The note's
-body is free prose — no closed-kind check, no digest binding, no leak scan — so it carries refs and
+body is free prose — no closed-kind check, no digest binding — so it carries refs and
 never caveats, and posting the verdict first is what keeps the rule below true.
 
 Your caveat text is authored prose reaching a public surface, so `5` and `6` are live: the verb

--- a/claude-plugins/fabrika/skills/check-epic-plan/evals/evals.json
+++ b/claude-plugins/fabrika/skills/check-epic-plan/evals/evals.json
@@ -56,7 +56,7 @@
 			"slug": "partial-flip-needs-a-human",
 			"prompt": "Read the session world in eval-4.md and do what it asks.",
 			"files": ["eval-4.md"],
-			"expected_output": "Terminal FLIP-PARTIAL. #1179 is named as the child that did not move. No per-child observed label table is fabricated — exit 22 printed none. The refs are posted via `fabrika build note`.",
+			"expected_output": "Terminal FLIP-PARTIAL. #1179 is named as the child that did not move. No per-child observed label table is fabricated — exit 22 printed none. The verdict is posted through `fabrika plan verdict` first, then the refs via `fabrika build note`.",
 			"premise_status": "Fictional world. ITERATION 2: assertion 5 rescoped to POST-FLIP state. In iteration 1 it was mis-specified (its stated reason ignored that plan read prints pre-flip labels) and both arms failed it; graded as-run then, repaired here.",
 			"assertions": [
 				"OUTCOME.md names exactly one token from the closed terminal set",
@@ -65,6 +65,7 @@
 				"#1179 is named as the child that did not move",
 				"the run does not assert POST-FLIP label state for any child — exit 22 printed no observed labels, and plan read's label arrays are pre-flip, so any claim about what a child carries NOW is unfounded",
 				"the run posts the un-flipped refs through `fabrika build note` rather than a hand-written comment",
+				"the run posts the verdict through `fabrika plan verdict` on the carried digest, before the build note — a clean floor does not skip the emit path",
 				"the run says the epic needs a human rather than retrying the flip"
 			]
 		},


### PR DESCRIPTION
The `check-epic-plan` skill lets a run write down advisory notes ("caveats") about a plan's quality, and step 4 says there is exactly one place to post them. One ending — `FLIP-PARTIAL`, where the plan was clean but only some children flipped — never went through that place, so any notes the run had formed were thrown away with nothing recording that they existed. That is the ending where a human has to pick the epic up, so it is the worst one to lose context on.

This routes that ending through step 4 too, in a stated order: post the verdict first, then the `fabrika build note` with the refs that did not move.

## What changed

- `SKILL.md` step 4 — states that every clean floor comes through the verdict, `FLIP-PARTIAL` included, and why the verb still works after a `22`: the flip writes only `status:planned` / `status:triaged`, both excluded from the digest serialization and neither a floor trigger (`contract.md`, `flip-neutral`), so the carried digest still binds and the floor still re-derives clean. It also states why the caveats do not ride the `build note` body instead — that body is free prose with no closed-kind check and no digest binding.
- `SKILL.md` step 3 — one clause on the `22` path: a `22` is still a clean floor, so it does not skip step 4. This sits alongside the bound #5192 landed on the same line (no claim about post-flip label state); neither is undone or restated.
- `SKILL.md` §TERM — the `FLIP-PARTIAL` line now names the verdict, then the note, in that order.
- `NOTES.md` anchor `H1` — records the resolution, so the hypothesis' measurement no longer stands on a falsifier that has been fixed.
- `evals/evals.json` eval-4 (the `FLIP-PARTIAL` case) — expected output and one assertion now cover the verdict-before-note order.

No change to `packages/fabrika-cli/src/plan/` verb behavior.

Fixes #5150

## Deviations

- **Class: scope — touched a file the acceptance criteria did not name.** Said: the ACs name `SKILL.md` and `NOTES.md` only. Did: also updated `evals/evals.json` eval-4 — its `expected_output` and one added assertion. Why: eval-4 is the `FLIP-PARTIAL` case, and its stated expectation ("the refs are posted via `fabrika build note`") graded the old behavior; leaving it would have made the skill's own eval contradict the skill on the terminal this PR changes, which is the same self-contradiction AC 3 exists to close. The fixture (`fixtures/eval-4.md`) is untouched — its transcript stops at the `22`, and the world's ground rules already cover a command it does not transcribe. Disposition: for the reviewer to judge; revert the JSON hunk if the narrower reading of the ACs is wanted.
- **Class: judgment call the issue left open — picked one of two offered shapes.** Said: the issue names two unsettled sub-questions (ordering; whether caveats could ride the `build note` body). Did: verdict first, then the note; caveats never in the note. Why: the issue's own reasoning plus the contract — step 4's rule is "never end with the verdict unposted over a caveat", and the note body is not kind-validated and not digest-bound, so it cannot carry model-authored caveat text safely. (Corrected in repair round 1 — the original wording added "not leak-scanned", which is false: `build note` does run the shipped leak predicates. The conclusion is unchanged; it rests on the two real absences.) Disposition: no action needed; both choices are stated in `SKILL.md` rather than left to the runner.
- **Class: something I deliberately did not do.** Said: `NOTES.md` has a "Defects the eval runs surfaced" section, where the sibling defect is recorded as `D1` (#5151). Did: recorded this resolution only under `H1`, added no `D2`. Why: the ACs ask for the `H1` update, and a second record would restate the same why in two places. Disposition: for the reviewer to judge.
- **(repair round 1) Class: corrected a factual claim in this body's own earlier prose.** Said: the "What changed" bullet and the second deviation above both asserted `fabrika build note` has "no leak scan". Did: deleted that clause from both, and from `SKILL.md` step 4. Why: `review-skill: FAIL @ 2bed3af` flagged it, and I re-verified at source — `packages/fabrika-cli/src/build/note-verb.ts` runs `leakRefusal(VERB, composed)` before `createComment`, over the shipped `report/leaks.ts` predicates imported in `packages/fabrika-cli/src/build/authored.ts`; `claude-plugins/fabrika/skills/build/contract.md` calls the verb "leak-guarded". Disposition: done. The earlier entries are left standing with the correction marked inline rather than rewritten away. Nothing else in the round: no routing, ordering or eval change.
- **(repair round 1) Class: the head moved for a second reason.** Said: a repair normally adds fix commits only. Did: also rebased the branch onto latest `origin/main` before fixing (Step R2's freshen), so the push is `--force-with-lease`. Why: the skill's repair path rebases to surface a textual conflict at code time rather than merge time; the rebase was clean. Disposition: no action needed — the re-review binds to the new head.
