### PR TITLE
fix(pipeline): teardown-head stops reporting success on the runs it leaks

### DIFF
--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -375,6 +375,15 @@ kp_pcli() {
 	printf '%s\n' "$pcli"
 }
 
+# The head-handle resolver's own status, chosen ABOVE `kp__scratch`'s 2/3/4/5/6 taxonomy (and clear
+# of 126/127) so the two can never collide: the namespace opened fine, it just holds no handle file.
+# It and 5 (namespace never opened) are the ONLY two statuses that mean "nothing was materialized";
+# every other non-zero from a `head-env.sh` means the resolver COULD NOT LOOK, which is UNKNOWN and
+# must never be read as a clean no-op (§ZS, ADR 0092; #4972/#5193). Defined once here because all
+# three review gates carry their own `head-env.sh` / `teardown-head.sh` pair and must not diverge.
+# shellcheck disable=SC2034  # read by the sourcing script, not by this file
+KP_HEAD_HANDLE_ABSENT=20
+
 # The per-run scratch namespace for <slug> (§SP, #3718). `open` is the run's first write of
 # scratch state; `path` re-derives it in every later call. Both print the absolute directory.
 kp_scratch_open() { kp__scratch "open" "$1"; }

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -396,6 +396,18 @@ in-shell trap can reach — is `pipeline-cli worktree-sweep --execute` (#2785): 
 leaked `review-head-*` tree that is clean + idle + unlocked, **without** `--force` (a dirty /
 active / locked one is KEPT — the #2240 liveness guard), so nothing accumulates unbounded.
 
+**Teardown's exit status carries information — a non-zero one means a tree is probably still on the
+primary.** It exits 0 only when it actually removed the tree + ref, or when nothing was materialized
+(the scratch namespace was never opened, or it holds no handle). Every *other* way the handle read
+can fail — the CLI unresolvable, no session id, a foreign namespace, a handle that exists but names
+no tree — now exits **non-zero** and names the cause on stderr, because "I could not look" is
+UNKNOWN, never "nothing to do" (§ZS, ADR 0092). It used to answer no-op for all of them, so the gate
+reported success on the exact runs it leaked (#4972 / #5193). Two consequences for you: read a
+non-zero teardown as a real leak and say so in your run ledger, and remember that a teardown
+registered as your shell's `EXIT` trap makes its status the shell's status. The behaviour is
+re-derived, not asserted, by
+`bash ./.claude/.pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh`.
+
 **The in-worktree typecheck is authoritative** (ADR
 [0067](https://github.com/kamp-us/phoenix/blob/main/.decisions/0067-sparse-typecheck-bootstrap.md),
 reversing ADR 0060's deferred-to-CI workaround). The cone-minus-denylist worktree carries

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
@@ -11,15 +11,22 @@
 #
 # The namespace is per-run and per-session (§SP, #3718), which is what keeps a SIBLING reviewer's
 # tree out of reach — the failure a `git worktree list` re-derivation on a shared leaf name walks
-# straight into, pinning the wrong head (#1807). Exits non-zero with EMPTY stdout when the namespace
-# was never opened, so a caller's `.` fails loudly instead of reading the base tree.
+# straight into, pinning the wrong head (#1807). Exits non-zero with EMPTY stdout when it cannot
+# print a handle, so a caller's `.` fails loudly instead of reading the base tree — and the status is
+# WHICH cause fired: 5 / $KP_HEAD_HANDLE_ABSENT mean nothing was materialized, anything else means
+# the resolver could not look (see `KP_HEAD_HANDLE_ABSENT` in ../../../lib/common.sh).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
-DIR="$(kp_scratch_path review-code-head)" || exit 1
+DIR="$(kp_scratch_path review-code-head)"
+RC=$?
+# Propagate `kp_scratch_path`'s own status instead of flattening it to 1: teardown-head.sh decides
+# no-op-vs-error from this number, and a flattened 1 made "namespace never opened" (5) look the same
+# as "the CLI never ran" (127) — #4972.
+[ "$RC" -eq 0 ] || exit "$RC"
 [ -f "$DIR/head.env" ] || {
-  echo "head-env.sh: no head handle at \$namespace/head.env — run materialize-head.sh first; NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
-  exit 1
+  echo "head-env.sh: namespace $DIR holds no head.env — materialize-head.sh never ran (or was aborted) in THIS session, so nothing was materialized. NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
+  exit "$KP_HEAD_HANDLE_ABSENT"
 }
 printf '%s\n' "$DIR/head.env"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh
@@ -9,20 +9,43 @@
 # a detached, already-pushed throwaway this gate materialized itself, holding no branch and no
 # unpushed work. Idempotent — a namespace that was never opened is a clean no-op, so it may be run
 # after an aborted materialization.
+#
+# It exits 0 ONLY on a real teardown or a real no-op. A handle read that could not RUN is UNKNOWN and
+# exits non-zero: this branch used to answer "nothing to tear down" for every failure, so the gate
+# reported success on the exact path it leaked its worktree and ref (#4972 / #5193, class #4482).
+# The no-op/error split is `head-env.sh`'s exit status — 5 and $KP_HEAD_HANDLE_ABSENT mean nothing
+# was materialized, everything else means the resolver could not look (§ZS, ADR 0092).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 # shellcheck disable=SC1007
-HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" 2>/dev/null)" || {
-  echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
-  exit 0
-}
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# `bash "$HERE/head-env.sh"`, not a direct exec: the sibling is committed non-executable in two of the
+# three gates, and a direct exec there dies 126 — a failure this script then reported as a clean no-op
+# on every single run (#5193). Every other call site in the suite already invokes via `bash`.
+# head-env.sh's stderr is deliberately NOT discarded: it names which cause fired (#4972).
+HANDLE="$(bash "$HERE/head-env.sh")"
+RC=$?
+case "$RC" in
+  0) ;;
+  5 | "$KP_HEAD_HANDLE_ABSENT")
+    echo "teardown-head.sh: no head handle for this run (head-env.sh rc=$RC) — nothing this gate materialized to tear down (no-op)." >&2
+    exit 0
+    ;;
+  *)
+    echo "teardown-head.sh: could NOT read the head handle (head-env.sh rc=$RC) — that is UNKNOWN, not a no-op, and a materialized worktree/ref may be leaking on the shared primary. See head-env.sh's diagnostic above." >&2
+    exit 1
+    ;;
+esac
 # shellcheck disable=SC1090
-. "$HANDLE"
+. "$HANDLE" || {
+  echo "teardown-head.sh: could NOT source the head handle $HANDLE — the tree it names is unreachable, not absent." >&2
+  exit 1
+}
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] || {
-  echo "teardown-head.sh: handle carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\` (no-op)." >&2
-  exit 0
+  echo "teardown-head.sh: handle $HANDLE carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\`, and refusing to call that success: a readable handle is evidence something WAS materialized and is now unreachable." >&2
+  exit 1
 }
 
 rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"   # tear the throwaway tree + ref down

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -452,6 +452,19 @@ abort between Bash calls (which no in-shell trap can reach) is `pipeline-cli wor
 --execute` (#2785): it reclaims a leaked `review-doc-head-*` tree only when clean + idle +
 unlocked, **without** `--force` (dirty / active / locked is KEPT — the #2240 liveness guard).
 
+**Teardown's exit status carries information — a non-zero one means a ref (and, under `--worktree`, a
+tree) is probably still on the primary.** It exits 0 only when it actually removed them, or when
+nothing was materialized (the scratch namespace was never opened, or it holds no handle). Every
+*other* way the handle read can fail — the CLI unresolvable, no session id, a foreign namespace, a
+handle that exists but names nothing — now exits **non-zero** and names the cause on stderr, because
+"I could not look" is UNKNOWN, never "nothing to do" (§ZS, ADR 0092). It used to answer no-op for all
+of them, and in this gate it hit that branch on *every* run: it exec'd its sibling directly and the
+sibling is committed non-executable, so the read died 126 and reported success while leaking (#5193 /
+#4972). Two consequences for you: read a non-zero teardown as a real leak and say so in your run
+ledger, and remember that the trap above makes teardown's status your shell's status. The behaviour
+is re-derived, not asserted, by
+`bash ./.claude/.pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh`.
+
 Never `git checkout` / `git switch` / `gh pr checkout` in the checkout you were launched in —
 not even `git -C`-scoped to your own worktree (the harness cwd-reset would still land a bare one
 on the shared primary and detach the human's `main`, #2270/#1103; §RO is the single source).

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/head-env.sh
@@ -8,7 +8,9 @@
 # `scratchpad file` REFUSES when the namespace was never opened in this run, so a lost handle fails
 # loud instead of silently reading an empty directory — and this script exits non-zero with EMPTY
 # stdout on that path, so a caller's `.` fails loudly rather than falling back to the launched
-# checkout's working copy (§HEAD, #793).
+# checkout's working copy (§HEAD, #793). The status is WHICH cause fired: 5 / $KP_HEAD_HANDLE_ABSENT
+# mean nothing was materialized, anything else means the resolver could not look (see
+# `KP_HEAD_HANDLE_ABSENT` in ../../../lib/common.sh).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -18,6 +20,11 @@ PR="$1"
 # §CLI — resolve the shim by path; `pipeline-cli` is NOT on PATH (ADR 0207; #3314).
 PCLI="$(kp_pcli)" || exit 127
 
-HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)" || exit 1
-[ -s "$HEAD_ENV" ] || { echo "review-doc: §SP — head.env absent/empty; re-run the materialize step in THIS session." >&2; exit 1; }
+HEAD_ENV="$("$PCLI" scratchpad file --slug "review-doc-$PR" --name head.env)"
+RC=$?
+[ "$RC" -eq 0 ] || exit "$RC"   # propagate WHICH cause fired; see the review-code copy's note (#4972)
+[ -s "$HEAD_ENV" ] || {
+  echo "review-doc: §SP — head.env absent/empty, so nothing was materialized; re-run the materialize step in THIS session." >&2
+  exit "$KP_HEAD_HANDLE_ABSENT"
+}
 printf '%s\n' "$HEAD_ENV"   # source it for $PR_REF / $HEAD_SHA (and $REVIEW_WT, if --worktree was used)

--- a/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/scripts/teardown-head.sh
@@ -8,6 +8,12 @@
 # this gate materialized itself, holding no branch and no unpushed work. Idempotent — a namespace
 # that was never opened is a clean no-op, so it may be run after an aborted materialization.
 #
+# It exits 0 ONLY on a real teardown or a real no-op. A handle read that could not RUN is UNKNOWN and
+# exits non-zero: this branch used to answer "nothing to tear down" for every failure, so the gate
+# reported success on the exact path it leaked its worktree and ref (#5193 / #4972, class #4482).
+# The no-op/error split is `head-env.sh`'s exit status — 5 and $KP_HEAD_HANDLE_ABSENT mean nothing
+# was materialized, everything else means the resolver could not look (§ZS, ADR 0092).
+#
 # It installs no `EXIT` trap of its own: under bash 3.2 a cleanup trap's last command becomes the
 # script's exit status, laundering a `set -u` abort into exit 0 (#4476, class #4479). The trap
 # belongs to the CALLER's shell — `trap '…/scripts/teardown-head.sh "$PR"' EXIT`.
@@ -19,15 +25,31 @@ set -uo pipefail
 PR="$1"
 
 # shellcheck disable=SC1007
-HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
-  echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
-  exit 0
-}
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# `bash "$HERE/head-env.sh"`, not a direct exec: every file in this scripts/ dir is committed
+# non-executable, so the direct exec died 126 on EVERY run and reported it as a no-op (#5193).
+# head-env.sh's stderr is deliberately NOT discarded: it names which cause fired (#4972).
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")"
+RC=$?
+case "$RC" in
+  0) ;;
+  5 | "$KP_HEAD_HANDLE_ABSENT")
+    echo "teardown-head.sh: no head handle for this run (head-env.sh rc=$RC) — nothing this gate materialized to tear down (no-op)." >&2
+    exit 0
+    ;;
+  *)
+    echo "teardown-head.sh: could NOT read the head handle (head-env.sh rc=$RC) — that is UNKNOWN, not a no-op, and a materialized ref (and worktree, under --worktree) may be leaking on the shared primary. See head-env.sh's diagnostic above." >&2
+    exit 1
+    ;;
+esac
 # shellcheck disable=SC1090
-. "$HANDLE"
+. "$HANDLE" || {
+  echo "teardown-head.sh: could NOT source the head handle $HANDLE — what it names is unreachable, not absent." >&2
+  exit 1
+}
 [ -n "${PR_REF:-}" ] || {
-  echo "teardown-head.sh: handle carries no PR_REF — refusing to guess what to remove (no-op)." >&2
-  exit 0
+  echo "teardown-head.sh: handle $HANDLE carries no PR_REF — refusing to guess what to remove, and refusing to call that success: a readable handle is evidence something WAS materialized and is now unreachable." >&2
+  exit 1
 }
 
 # The worktree exists only under Step 2's rare `--worktree` mode; the ref always does.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -382,6 +382,19 @@ worktree-sweep --execute` (#2785): it reclaims a leaked `review-skill-head-*` tr
 clean + idle + unlocked, **without** `--force` (dirty / active / locked is KEPT — the #2240
 liveness guard).
 
+**Teardown's exit status carries information — a non-zero one means a tree is probably still on the
+primary.** It exits 0 only when it actually removed the tree + ref, or when nothing was materialized
+(the scratch namespace was never opened, or it holds no handle). Every *other* way the handle read
+can fail — the CLI unresolvable, no session id, a foreign namespace, a handle that exists but names
+no tree — now exits **non-zero** and names the cause on stderr, because "I could not look" is
+UNKNOWN, never "nothing to do" (§ZS, ADR 0092). It used to answer no-op for all of them, and in this
+gate it hit that branch on *every* run: it exec'd its sibling directly and the sibling is committed
+non-executable, so the read died 126 and reported success while leaking (#5193 / #4972). Two
+consequences for you: read a non-zero teardown as a real leak and say so in your run ledger, and
+remember that a teardown registered as your shell's `EXIT` trap makes its status the shell's status.
+The behaviour is re-derived, not asserted, by
+`bash ./.claude/.pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh`.
+
 ---
 
 ## Step 3 — Verify the acceptance criteria one box at a time

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/head-env.sh
@@ -7,8 +7,10 @@
 # The namespace is per-run and per-session (§SP, #3718), which is what keeps a SIBLING reviewer's
 # tree out of reach — the failure a `git worktree list` re-derivation on the shared
 # `review-skill-head-${PR}` leaf walks straight into, pinning the wrong head's skill text (#1807).
-# Exits non-zero with EMPTY stdout when the namespace was never opened, so a caller's `.` fails
-# loudly instead of silently reading the base tree.
+# Exits non-zero with EMPTY stdout when it cannot print a handle, so a caller's `.` fails loudly
+# instead of silently reading the base tree — and the status is WHICH cause fired: 5 /
+# $KP_HEAD_HANDLE_ABSENT mean nothing was materialized, anything else means the resolver could not
+# look (see `KP_HEAD_HANDLE_ABSENT` in ../../../lib/common.sh).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -16,9 +18,11 @@ set -uo pipefail
 [ "$#" -ge 1 ] || { echo "usage: head-env.sh <pr>" >&2; exit 2; }
 PR="$1"
 
-DIR="$(kp_scratch_path "review-skill-head-$PR")" || exit 1
+DIR="$(kp_scratch_path "review-skill-head-$PR")"
+RC=$?
+[ "$RC" -eq 0 ] || exit "$RC"   # propagate WHICH cause fired; see the review-code copy's note (#4972)
 [ -s "$DIR/wt.env" ] || {
-  echo "review-skill: §SP — $DIR/wt.env missing; re-run the head-materialization step in THIS session. NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
-  exit 1
+  echo "review-skill: §SP — $DIR/wt.env missing, so nothing was materialized; re-run the head-materialization step in THIS session. NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
+  exit "$KP_HEAD_HANDLE_ABSENT"
 }
 printf '%s\n' "$DIR/wt.env"

--- a/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/scripts/teardown-head.sh
@@ -7,6 +7,12 @@
 # otherwise (#2785). Safe by construction: the tree it removes is a detached, already-pushed
 # throwaway this gate materialized itself, holding no branch and no unpushed work. Idempotent — a
 # namespace that was never opened is a clean no-op, so it may be run after an aborted materialization.
+#
+# It exits 0 ONLY on a real teardown or a real no-op. A handle read that could not RUN is UNKNOWN and
+# exits non-zero: this branch used to answer "nothing to tear down" for every failure, so the gate
+# reported success on the exact path it leaked its worktree and ref (#5193 / #4972, class #4482).
+# The no-op/error split is `head-env.sh`'s exit status — 5 and $KP_HEAD_HANDLE_ABSENT mean nothing
+# was materialized, everything else means the resolver could not look (§ZS, ADR 0092).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -15,15 +21,31 @@ set -uo pipefail
 PR="$1"
 
 # shellcheck disable=SC1007
-HANDLE="$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh" "$PR" 2>/dev/null)" || {
-  echo "teardown-head.sh: no head handle for this run — nothing this gate materialized to tear down (no-op)." >&2
-  exit 0
-}
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# `bash "$HERE/head-env.sh"`, not a direct exec: every file in this scripts/ dir is committed
+# non-executable, so the direct exec died 126 on EVERY run and reported it as a no-op (#5193).
+# head-env.sh's stderr is deliberately NOT discarded: it names which cause fired (#4972).
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")"
+RC=$?
+case "$RC" in
+  0) ;;
+  5 | "$KP_HEAD_HANDLE_ABSENT")
+    echo "teardown-head.sh: no head handle for this run (head-env.sh rc=$RC) — nothing this gate materialized to tear down (no-op)." >&2
+    exit 0
+    ;;
+  *)
+    echo "teardown-head.sh: could NOT read the head handle (head-env.sh rc=$RC) — that is UNKNOWN, not a no-op, and a materialized worktree/ref may be leaking on the shared primary. See head-env.sh's diagnostic above." >&2
+    exit 1
+    ;;
+esac
 # shellcheck disable=SC1090
-. "$HANDLE"
+. "$HANDLE" || {
+  echo "teardown-head.sh: could NOT source the head handle $HANDLE — the tree it names is unreachable, not absent." >&2
+  exit 1
+}
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] || {
-  echo "teardown-head.sh: handle carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\` (no-op)." >&2
-  exit 0
+  echo "teardown-head.sh: handle $HANDLE carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\`, and refusing to call that success: a readable handle is evidence something WAS materialized and is now unreachable." >&2
+  exit 1
 }
 
 rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Re-derives, rather than asserts, that all THREE `teardown-head.sh` copies fail closed the same way
+# (#5193 + #4972). Reviewer-runnable, self-contained, and it touches neither the primary checkout's
+# worktrees nor its refs: the one case that actually tears something down runs inside a throwaway git
+# repo under $TMPDIR.
+#
+# Six cases per gate:
+#   A  namespace never opened            -> exit 0, quiet no-op (idempotence preserved)
+#   B  namespace open, no handle file    -> exit 0, quiet no-op (nothing was materialized)
+#   C  resolver could not run            -> NON-ZERO (the #4972 / #5193 fail-open, now closed)
+#   D  handle readable but malformed     -> NON-ZERO while still refusing to guess a path
+#   E  handle well-formed                -> exit 0 AND the tree + ref are actually gone
+#   F  source shape                      -> invoked via `bash`, stderr not discarded (#5193's 126)
+#
+# Case E doubles as #5193's live proof for two of the three gates: `review-skill`'s and `review-doc`'s
+# `head-env.sh` are committed 100644, so E only passes because the sibling is now run through `bash`.
+#
+# usage: bash teardown-head-fail-closed-proof.sh          # prints one PASS/FAIL row per case
+# SC2016: case F greps for the LITERAL `bash "$HERE/head-env.sh"` source line, so it must not expand.
+# shellcheck disable=SC1091,SC1007,SC2016
+set -uo pipefail
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$(CDPATH= cd -- "$HERE/../../.." && pwd)"
+# shellcheck source=../../../lib/common.sh
+. "$PLUGIN/lib/common.sh"
+PCLI="$(kp_pcli)" || exit 127
+
+FAILED=0
+ok() { printf 'PASS  %s\n' "$1"; }
+bad() {
+  printf 'FAIL  %s\n' "$1"
+  FAILED=1
+}
+# expect <actual-rc> <zero|nonzero> <label>
+expect() {
+  if [ "$2" = zero ]; then
+    if [ "$1" -eq 0 ]; then ok "$3 (rc=$1)"; else bad "$3 — expected 0, got $1"; fi
+  else
+    if [ "$1" -ne 0 ]; then ok "$3 (rc=$1)"; else bad "$3 — expected non-zero, got 0"; fi
+  fi
+}
+
+PR=99999
+# `<gate> <slug> <leaf> <takes-pr>` — the three copies diverge only in these four fields.
+GATES="review-code review-code-head head.env no
+review-skill review-skill-head-$PR wt.env yes
+review-doc review-doc-$PR head.env yes"
+
+# Run one gate's teardown under a fresh session id; echoes its exit status.
+run_teardown() { # <gate> <takes-pr> <session>
+  local gate="$1" takes_pr="$2" session="$3" script
+  script="$PLUGIN/skills/$gate/scripts/teardown-head.sh"
+  if [ "$takes_pr" = yes ]; then
+    CLAUDE_CODE_SESSION_ID="$session" bash "$script" "$PR" >/dev/null 2>&1
+  else
+    CLAUDE_CODE_SESSION_ID="$session" bash "$script" >/dev/null 2>&1
+  fi
+  echo $?
+}
+
+while read -r GATE SLUG LEAF TAKES_PR; do
+  [ -n "$GATE" ] || continue
+  TD="$PLUGIN/skills/$GATE/scripts/teardown-head.sh"
+
+  # A — a namespace this session never opened is the genuine no-op the header promises.
+  RC="$(run_teardown "$GATE" "$TAKES_PR" "proof-a-$GATE-$$")"
+  expect "$RC" zero "$GATE A never-opened namespace -> exit 0"
+
+  # B — namespace open but no handle file: still nothing was materialized.
+  SESSION="proof-b-$GATE-$$"
+  CLAUDE_CODE_SESSION_ID="$SESSION" "$PCLI" scratchpad open --slug "$SLUG" >/dev/null 2>&1
+  RC="$(run_teardown "$GATE" "$TAKES_PR" "$SESSION")"
+  expect "$RC" zero "$GATE B open-but-no-handle -> exit 0"
+
+  # C — the resolver could not look. No session id is the cheapest real instance of that class
+  # (scratchpad exits 2, MissingSessionId); pre-fix EVERY such code reported as a clean no-op.
+  if [ "$TAKES_PR" = yes ]; then
+    (unset CLAUDE_CODE_SESSION_ID; bash "$TD" "$PR" >/dev/null 2>&1)
+  else
+    (unset CLAUDE_CODE_SESSION_ID; bash "$TD" >/dev/null 2>&1)
+  fi
+  RC=$?
+  expect "$RC" nonzero "$GATE C unreadable handle -> non-zero"
+
+  # D — a handle that exists but names nothing: positive evidence something WAS materialized.
+  SESSION="proof-d-$GATE-$$"
+  DIR="$(CLAUDE_CODE_SESSION_ID="$SESSION" "$PCLI" scratchpad open --slug "$SLUG" 2>/dev/null)"
+  printf '# malformed on purpose: no REVIEW_WT, no PR_REF\n' >"$DIR/$LEAF"
+  RC="$(run_teardown "$GATE" "$TAKES_PR" "$SESSION")"
+  expect "$RC" nonzero "$GATE D malformed handle -> non-zero"
+
+  # E — the happy path, inside a throwaway repo so the primary's worktrees and refs are untouched.
+  SESSION="proof-e-$GATE-$$"
+  DIR="$(CLAUDE_CODE_SESSION_ID="$SESSION" "$PCLI" scratchpad open --slug "$SLUG" 2>/dev/null)"
+  SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/teardown-proof.XXXXXX")"
+  git -C "$SANDBOX" init -q
+  git -C "$SANDBOX" -c user.email=proof@invalid -c user.name=proof commit -q --allow-empty -m proof
+  REF="refs/pr/proof-$GATE-$$"
+  git -C "$SANDBOX" update-ref "$REF" HEAD
+  TREE="$SANDBOX/throwaway-head"
+  mkdir -p "$TREE"
+  printf 'REVIEW_WT=%s\nPR_REF=%s\n' "$TREE" "$REF" >"$DIR/$LEAF"
+  if [ "$TAKES_PR" = yes ]; then
+    (cd "$SANDBOX" && CLAUDE_CODE_SESSION_ID="$SESSION" bash "$TD" "$PR" >/dev/null 2>&1)
+  else
+    (cd "$SANDBOX" && CLAUDE_CODE_SESSION_ID="$SESSION" bash "$TD" >/dev/null 2>&1)
+  fi
+  RC=$?
+  if [ "$RC" -eq 0 ] && [ ! -d "$TREE" ] && ! git -C "$SANDBOX" show-ref --quiet --verify "$REF"; then
+    ok "$GATE E well-formed handle -> tree + ref removed, exit 0"
+  else
+    bad "$GATE E expected a real teardown (rc=$RC, tree-present=$([ -d "$TREE" ] && echo yes || echo no))"
+  fi
+  rm -rf "$SANDBOX"
+
+  # F — the #5193 shape itself: the sibling is run through `bash` (so its committed 100644 mode is
+  # irrelevant) and its stderr survives (so the cause is nameable). Static, because a 126 is exactly
+  # what case C would otherwise have to reproduce by chmod'ing a committed file.
+  if grep -q 'bash "\$HERE/head-env.sh"' "$TD" && ! grep -q 'head-env.sh.*2>/dev/null' "$TD"; then
+    ok "$GATE F sibling invoked via bash, stderr surfaced"
+  else
+    bad "$GATE F direct exec or discarded stderr is back in $GATE/scripts/teardown-head.sh"
+  fi
+done <<EOF
+$GATES
+EOF
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "teardown-head fail-closed proof: FAILED" >&2
+  exit 1
+fi
+echo "teardown-head fail-closed proof: all cases passed for all three gates"


### PR DESCRIPTION
Every review gate's `teardown-head.sh` printed "nothing this gate materialized to tear down (no-op)" and exited 0 whenever it *could not read* its run handle — which is the opposite of what had happened: the throwaway worktree and the per-run ref were still sitting on the shared primary checkout. In `review-skill` and `review-doc` it took that branch on **every** run, because it ran its sibling `head-env.sh` as a direct exec and that file ships non-executable, so the read died 126 with the diagnostic thrown away.

Teardown now runs the sibling through `bash`, keeps its stderr, and reports a clean no-op only when the handle genuinely was never written. Anything else it cannot read is an error that names its cause and exits non-zero.

Fixes #5193
Fixes #4972

## What changed

- **All three `teardown-head.sh` copies** (`review-code`, `review-skill`, `review-doc`) invoke the sibling as `bash "$HERE/head-env.sh"`, so the committed exec bit stops being load-bearing, and they no longer redirect its stderr to `/dev/null`.
- **All three `head-env.sh` copies** propagate their resolver's exit status instead of flattening it to a bare `1`, and exit the new `KP_HEAD_HANDLE_ABSENT` when the scratch namespace opened but holds no handle file.
- **`lib/common.sh`** defines `KP_HEAD_HANDLE_ABSENT=20` once — above `kp__scratch`'s 2/3/4/5/6 taxonomy and clear of 126/127 — so the three gates share one meaning and cannot drift apart.
- **Teardown's exit status is now a real signal:** `0` for a completed teardown and for the two genuine no-ops (namespace never opened, or no handle in it); **non-zero, with the cause named**, for every other read failure and for a handle that is readable but names no tree. It still refuses to guess a path to `rm -rf` — it just stops calling that refusal a success (§ZS, ADR 0092).
- **`skills/shared/scripts/teardown-head-fail-closed-proof.sh`** re-derives all of this rather than asserting it: six cases × three gates, reviewer-runnable in one command. The case that actually tears something down runs inside a throwaway git repo under `$TMPDIR`, so the proof never touches the primary checkout's worktrees or refs.
- The three `SKILL.md` files gained one paragraph each telling a reviewer what a non-zero teardown means and that it propagates through their `EXIT` trap.

## Verification

```
bash ./.claude/.pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh
```

18/18 cases pass. Falsifiability was checked separately against the pre-fix copies restored from `HEAD` into a temp mirror: both the "resolver could not run" case and the "malformed handle" case returned **rc=0** with the reassuring no-op message — the exact failure both issues describe.

`pnpm typecheck`, `pnpm lint:worktree`, `shellcheck -x` on every changed script, `pipeline-cli trap-status-guard check` and `pipeline-cli gh-phoenix lint-skills` on the changed corpus files are all clean. The full unit suite ran green on the pre-push hook.

**No cleanup of the already-leaked trees or refs is in this PR** — that is #4975's and `worktree-sweep`'s path, and both issues' acceptance criteria exclude it explicitly.

## Deviations

**1. Scope reached past the files each issue named, on purpose.**
- Said: #4972 points at `review-code`'s `teardown-head.sh` + `head-env.sh`; #5193 points at `review-skill`'s and `review-doc`'s `teardown-head.sh`.
- Did: also changed `head-env.sh` in all three gates and added `KP_HEAD_HANDLE_ABSENT` to `lib/common.sh`.
- Why: #5193's fourth acceptance criterion is that the three copies do not diverge. A no-op-vs-error split needs one shared status taxonomy; three hand-copied numbers would be the next divergence.
- Disposition: no action needed.

**2. The end-to-end verification is a committed proof, not a live gate run.**
- Said: #5193 asks for verification "by running the affected gate end to end: after teardown, the run's `review-head-*` worktree and its `refs/pr/*` ref are gone".
- Did: the proof drives each real `teardown-head.sh` against a real handle and asserts the tree and the ref are gone — but inside a throwaway repo under `$TMPDIR`, not by running a live `review-skill` gate against a real PR.
- Why: a live gate run would materialize and then remove a worktree and a `refs/pr/*` ref on the shared primary checkout, which this lane was explicitly scoped away from touching. The sandboxed run exercises the same script, the same handle format and the same `rm -rf` / `worktree prune` / `update-ref -d` sequence, and for `review-skill` and `review-doc` it runs against their genuinely non-executable committed `head-env.sh`, so it is a real proof of #5193's 126 being gone.
- Disposition: for the reviewer to judge.

**3. No exec bits were changed.**
- Said: the reports frame the missing `+x` as the cause.
- Did: left every committed file mode alone, including the two `head-env.sh` copies at `100644`.
- Why: the fix removes the dependency on the exec bit instead of papering over it, which is what makes the three copies uniform; chmod'ing the fleet was explicitly out of scope, and 104 of 246 corpus scripts are `100644` with nothing broken by it.
- Disposition: no action needed — #5193 already records the inconsistency as latent.

**4. Four sibling call sites with the same direct-exec form are left unfixed.**
- Said: neither issue's acceptance criteria mention them.
- Did: left `review-code/scripts/{worktree-checks,worktree-typecheck,full-unit-project,glossary-freshness}.sh` exec'ing `head-env.sh` directly.
- Why: their target is committed `100755`, so they work today; fixing them widens a control-plane diff past both issues' criteria.
- Disposition: follow-up #5204 filed.

**5. Two closing keywords, deliberately.**
- Said: the write-code contract's §9 wants one closing keyword per PR.
- Did: `Fixes #5193` and `Fixes #4972`.
- Why: this was dispatched as one unit precisely because the non-divergence criterion makes them one diff, and this PR delivers every acceptance criterion of both. A `Part of` on either would leave an issue open with nothing left to do.
- Disposition: for the reviewer to judge — the seam check will read the second one as a "stray" close directive, and it is not.
