### PR TITLE
feat(fabrika-cli): normalize the eval --model value to one canonical id (#5158)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -621,6 +621,22 @@ locates the pinned session's transcript, classifies the run, and folds the colle
 **capture manifest** `collectFromCapture` already consumes. Grading, spend reconstruction and the
 scorecard are all pre-existing code paths — this verb adds no oracle, no meter and no renderer.
 
+### The `--model` contract ([#5158](https://github.com/kamp-us/phoenix/issues/5158))
+
+`--model` is **required** and its value is **normalized, not policed**. The spelling you pass is
+canonicalized through fabrika's one alias table ([`../models.ts`](../models.ts)) before it reaches a
+planned run, so `--model <alias>` and `--model <its canonical id>` are the same run, the same argv,
+and — because the ledger and capture manifest record the canonical spelling — the same scorecard
+cell. That is the whole change: there is **no allowlist**, **no default**, and **no rejection**. A
+model the table has never heard of canonicalizes to itself and runs exactly as named, which is what
+keeps [#4680](https://github.com/kamp-us/phoenix/issues/4680)'s model-churn re-run contract (ADR
+0236 §2) intact — a new model can be evaluated the day it exists, without editing this package.
+`fabrika eval report --baseline-model` is normalized the same way, so a baseline named in either
+spelling still matches the cell it means. The ruling behind this is
+[#5148](https://github.com/kamp-us/phoenix/issues/5148) (option B), and the table lives in one place
+by ADR [0238](../../../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md) — nothing under
+`src/eval/` declares a second copy.
+
 ### What each run cost, attributed to the run ([#5008](https://github.com/kamp-us/phoenix/issues/5008))
 
 The runner already reconstructed every run's transcript to detect a silent green and then threw the

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -134,7 +134,9 @@ const baselineStageFlag = Flag.string("baseline-stage").pipe(
 
 const baselineModelFlag = Flag.string("baseline-model").pipe(
 	Flag.optional,
-	Flag.withDescription("the model of the baseline cell (paired with --baseline-stage)"),
+	Flag.withDescription(
+		"the model of the baseline cell (paired with --baseline-stage) — normalized the same way as --model, so an alias still matches the cell recorded under its canonical id",
+	),
 );
 
 const baselineSurfaceFlag = Flag.string("baseline-surface").pipe(
@@ -311,7 +313,7 @@ const pluginDirFlag = Flag.string("plugin-dir").pipe(
 
 const modelFlag = Flag.string("model").pipe(
 	Flag.withDescription(
-		"the model every run is pinned to — required, because a scorecard is only comparable when it names one",
+		"the model every run is pinned to — required, because a scorecard is only comparable when it names one; a known alias is normalized to its canonical id, anything else runs as given",
 	),
 );
 

--- a/packages/fabrika-cli/src/eval/report.ts
+++ b/packages/fabrika-cli/src/eval/report.ts
@@ -27,6 +27,7 @@
  */
 import {Effect, Result} from "effect";
 import * as Schema from "effect/Schema";
+import {canonicalModel} from "../models.ts";
 import {CorpusEntry, type ReviewSurface} from "./corpus.ts";
 import {priceModelSwap, repairChurnCost} from "./repair-churn.ts";
 import {EVAL_ARMS, type RunRow} from "./runner.ts";
@@ -131,8 +132,13 @@ const identityOf = (entry: CorpusEntry): CellIdentity =>
 const cellKey = (id: CellIdentity, model: string | null): string =>
 	`${id.stage}\u0000${id.surface ?? ""}\u0000${model ?? ""}`;
 
+// The baseline's model is canonicalized on the way in for the same reason a row's is: a baseline
+// named in the other spelling of the cell's model matched nothing and reported `null` rather than
+// reporting wrong, which is fail-quiet (#5158).
 const sameCell = (a: {id: CellIdentity; model: string | null}, b: BaselineKey): boolean =>
-	a.id.stage === b.stage && a.id.surface === (b.surface ?? null) && a.model === (b.model ?? null);
+	a.id.stage === b.stage &&
+	a.id.surface === (b.surface ?? null) &&
+	a.model === canonicalModel(b.model);
 
 interface Bucket {
 	readonly id: CellIdentity;
@@ -151,9 +157,16 @@ interface Bucket {
  * transcript is machine-local and perishable, so reconstruction is the fallback for a row that
  * recorded nothing — not the source (#4996). A row with a recorded model therefore keeps its
  * bucket even when its transcript is gone, instead of collapsing into `(unknown)`.
+ *
+ * Whichever of the two attests it, the spelling is canonicalized through fabrika's one alias table
+ * (`../models.ts`) before it becomes a bucket key, so an alias and its canonical id are one cell
+ * rather than two pass-rates over the same model (#5158). An unknown model canonicalizes to itself
+ * and keeps its own cell — this normalizes, it never allowlists.
  */
 const modelOf = (row: RunRow): string | null =>
-	row.provenance.model ?? (row.spend._tag === "Reconstructed" ? row.spend.spend.model : null);
+	canonicalModel(
+		row.provenance.model ?? (row.spend._tag === "Reconstructed" ? row.spend.spend.model : null),
+	);
 
 const bucketize = (rows: ReadonlyArray<RunRow>): ReadonlyArray<Bucket> => {
 	const byKey = new Map<string, Bucket>();

--- a/packages/fabrika-cli/src/eval/report.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/report.unit.test.ts
@@ -1,5 +1,6 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Result} from "effect";
+import {MODEL_ALIASES} from "../models.ts";
 import type {StageSpend} from "../spend/token-spend.ts";
 import type {CorpusEntry} from "./corpus.ts";
 import {
@@ -114,13 +115,13 @@ describe("buildScorecard — single (stage × model)", () => {
 	it("computes pass-rate and mean per-run billed + ex-cache-read spend for one cell", () => {
 		// 3 runs, 2 pass ⇒ pass-rate 2/3; billed 100/200/300 ⇒ mean 200.
 		const rows: ReadonlyArray<RunRow> = [
-			row({pass: true, billed: 100, model: "opus"}),
-			row({pass: true, billed: 200, model: "opus"}),
-			row({pass: false, billed: 300, model: "opus"}),
+			row({pass: true, billed: 100, model: "opus-4.8"}),
+			row({pass: true, billed: 200, model: "opus-4.8"}),
+			row({pass: false, billed: 300, model: "opus-4.8"}),
 		];
 		const sc = buildScorecard({rows});
 		assert.strictEqual(sc.cells.length, 1);
-		const cell = cellFor(sc.cells, "opus");
+		const cell = cellFor(sc.cells, "opus-4.8");
 		assert.strictEqual(cell.stage, "triage");
 		assert.strictEqual(cell.gradedRuns, 3);
 		assert.strictEqual(cell.passedRuns, 2);
@@ -136,13 +137,13 @@ describe("buildScorecard — single (stage × model)", () => {
 
 	it("a transcript-missing run counts toward pass-rate but not toward the spend mean", () => {
 		const rows: ReadonlyArray<RunRow> = [
-			row({pass: true, billed: 100, model: "opus"}),
+			row({pass: true, billed: 100, model: "opus-4.8"}),
 			missingSpendRow({pass: true}),
 		];
 		const sc = buildScorecard({rows});
 		// Both runs land in the same (stage × model) cell — the missing-transcript run has model null,
 		// so it buckets separately. Assert the two are distinct and both counted.
-		const opusCell = cellFor(sc.cells, "opus");
+		const opusCell = cellFor(sc.cells, "opus-4.8");
 		assert.strictEqual(opusCell.gradedRuns, 1);
 		assert.strictEqual(opusCell.spend?.billedPerRun, 100);
 		const nullCell = cellFor(sc.cells, null);
@@ -160,14 +161,14 @@ describe("buildScorecard — multi-model comparison against a baseline", () => {
 		// Candidate: sonnet, pass-rate 1.0, 400 billed/run ⇒ zero churn, amortized 400.
 		// Net saving of sonnet = baseline 1000 − sonnet amortized 400 = +600.
 		const rows: ReadonlyArray<RunRow> = [
-			row({pass: true, billed: 1000, model: "opus", inputRef: 1}),
+			row({pass: true, billed: 1000, model: "opus-4.8", inputRef: 1}),
 			row({pass: true, billed: 400, model: "sonnet", inputRef: 2}),
 		];
-		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus-4.8"}});
 		assert.isNotNull(sc.baseline);
-		assert.strictEqual(sc.baseline?.model, "opus");
+		assert.strictEqual(sc.baseline?.model, "opus-4.8");
 
-		const opus = cellFor(sc.cells, "opus");
+		const opus = cellFor(sc.cells, "opus-4.8");
 		// The baseline cell measures no net saving against itself.
 		assert.isNull(opus.netSaving);
 		assert.isFalse(opus.netNegative);
@@ -186,11 +187,11 @@ describe("buildScorecard — the net-negative churn case (the epic's headline ri
 		//   expected extra cycles = (1−0.5)/0.5 = 1; churn = 1 × 700 = 700; amortized = 700 + 700 = 1400.
 		//   net saving = 1000 − 1400 = −400 ⇒ NET-NEGATIVE: churn ate the saving.
 		const rows: ReadonlyArray<RunRow> = [
-			row({pass: true, billed: 1000, model: "opus", inputRef: 1}),
+			row({pass: true, billed: 1000, model: "opus-4.8", inputRef: 1}),
 			row({pass: true, billed: 700, model: "sonnet", inputRef: 2}),
 			row({pass: false, billed: 700, model: "sonnet", inputRef: 3}),
 		];
-		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus-4.8"}});
 		const sonnet = cellFor(sc.cells, "sonnet");
 		assert.approximately(sonnet.passRate, 0.5, 1e-9);
 		assert.strictEqual(sonnet.churn?.expectedExtraCycles, 1);
@@ -202,10 +203,10 @@ describe("buildScorecard — the net-negative churn case (the epic's headline ri
 
 	it("a never-passing model (pass-rate 0) prices +Infinity churn and is net-negative", () => {
 		const rows: ReadonlyArray<RunRow> = [
-			row({pass: true, billed: 1000, model: "opus", inputRef: 1}),
+			row({pass: true, billed: 1000, model: "opus-4.8", inputRef: 1}),
 			row({pass: false, billed: 10, model: "flaky", inputRef: 2}),
 		];
-		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus-4.8"}});
 		const flaky = cellFor(sc.cells, "flaky");
 		assert.strictEqual(flaky.passRate, 0);
 		assert.strictEqual(flaky.churn?.churnTokens, Number.POSITIVE_INFINITY);
@@ -224,8 +225,8 @@ describe("buildScorecard — the net-negative churn case (the epic's headline ri
 describe("buildScorecard — a `review` pass-rate never spans two graders (ADR 0243 §4)", () => {
 	// The mixed-surface PR of ADR 0243 §3: one inputRef, one row per surface, two graders.
 	const mixedSurfaceRows: ReadonlyArray<RunRow> = [
-		entryRow({entry: reviewEntry("code", 42), pass: true, billed: 100, model: "opus"}),
-		entryRow({entry: reviewEntry("doc", 42), pass: false, billed: 100, model: "opus"}),
+		entryRow({entry: reviewEntry("code", 42), pass: true, billed: 100, model: "opus-4.8"}),
+		entryRow({entry: reviewEntry("doc", 42), pass: false, billed: 100, model: "opus-4.8"}),
 	];
 
 	it("buckets the two surfaces of one inputRef separately, each keeping its own pass-rate", () => {
@@ -298,8 +299,8 @@ describe("buildScorecard — a `review` pass-rate never spans two graders (ADR 0
 		// 0244) — so it neither gains a surface nor collapses into the live `review` cell.
 		const sc = buildScorecard({
 			rows: [
-				entryRow({entry: recordedReviewCodeEntry(7), pass: true, billed: 100, model: "opus"}),
-				entryRow({entry: reviewEntry("code", 7), pass: false, billed: 100, model: "opus"}),
+				entryRow({entry: recordedReviewCodeEntry(7), pass: true, billed: 100, model: "opus-4.8"}),
+				entryRow({entry: reviewEntry("code", 7), pass: false, billed: 100, model: "opus-4.8"}),
 			],
 		});
 
@@ -314,13 +315,16 @@ describe("buildScorecard — a `review` pass-rate never spans two graders (ADR 0
 
 describe("buildScorecard — the baseline resolves to exactly one cell under the extended key", () => {
 	const rows: ReadonlyArray<RunRow> = [
-		entryRow({entry: reviewEntry("code", 1), pass: true, billed: 1000, model: "opus"}),
-		entryRow({entry: reviewEntry("doc", 1), pass: true, billed: 1000, model: "opus"}),
+		entryRow({entry: reviewEntry("code", 1), pass: true, billed: 1000, model: "opus-4.8"}),
+		entryRow({entry: reviewEntry("doc", 1), pass: true, billed: 1000, model: "opus-4.8"}),
 		entryRow({entry: reviewEntry("code", 2), pass: true, billed: 400, model: "sonnet"}),
 	];
 
 	it("a (stage, surface, model) baseline names one cell and prices the others against it", () => {
-		const sc = buildScorecard({rows, baseline: {stage: "review", surface: "code", model: "opus"}});
+		const sc = buildScorecard({
+			rows,
+			baseline: {stage: "review", surface: "code", model: "opus-4.8"},
+		});
 
 		assert.isNotNull(sc.baseline);
 		assert.strictEqual(sc.baseline?.surface, "code");
@@ -337,7 +341,7 @@ describe("buildScorecard — the baseline resolves to exactly one cell under the
 	});
 
 	it("a surfaceless `review` baseline selects NO cell rather than silently picking one", () => {
-		const sc = buildScorecard({rows, baseline: {stage: "review", model: "opus"}});
+		const sc = buildScorecard({rows, baseline: {stage: "review", model: "opus-4.8"}});
 
 		assert.isNull(
 			sc.baseline,
@@ -356,12 +360,17 @@ describe("buildScorecard — the baseline resolves to exactly one cell under the
 describe("buildScorecard — the bucket key prefers the model the run recorded", () => {
 	it("a transcript-missing row with a recorded model keeps its model bucket, not `(unknown)`", () => {
 		const rows: ReadonlyArray<RunRow> = [
-			row({pass: true, billed: 100, model: "opus", provenance: {model: "opus", arm: "with-skill"}}),
-			missingSpendRow({pass: true, provenance: {model: "opus", arm: "without-skill"}}),
+			row({
+				pass: true,
+				billed: 100,
+				model: "opus-4.8",
+				provenance: {model: "opus-4.8", arm: "with-skill"},
+			}),
+			missingSpendRow({pass: true, provenance: {model: "opus-4.8", arm: "without-skill"}}),
 		];
 		const sc = buildScorecard({rows});
 		assert.strictEqual(sc.cells.length, 1, "both rows belong to the same recorded-model cell");
-		const cell = cellFor(sc.cells, "opus");
+		const cell = cellFor(sc.cells, "opus-4.8");
 		assert.strictEqual(cell.gradedRuns, 2);
 		// The unmeasured run still stays out of the spend mean — it is attributed, not fabricated.
 		assert.strictEqual(cell.spend?.billedPerRun, 100);
@@ -385,6 +394,55 @@ describe("buildScorecard — the bucket key prefers the model the run recorded",
 	it("a row that recorded nothing still buckets on its reconstructed model", () => {
 		const sc = buildScorecard({rows: [row({pass: true, billed: 100, model: "sonnet"})]});
 		assert.strictEqual(sc.cells[0]?.model, "sonnet");
+	});
+});
+
+/**
+ * #5158 (ruled option B on #5148): one model, one cell. The alias pair is READ from fabrika's one
+ * table rather than typed here — a spelling written into a test is the second source the ruling
+ * forbids, and it would keep passing after the table moved on.
+ */
+const aliasEntry = Object.entries(MODEL_ALIASES)[0];
+if (aliasEntry === undefined) {
+	throw new Error("MODEL_ALIASES declares no alias — there is nothing for the report to normalize");
+}
+const [aliasedModel, canonicalId] = aliasEntry;
+
+describe("buildScorecard — a model's aliases are one cell, an unknown model is its own", () => {
+	it("two spellings of one model produce a single cell, not two pass-rates", () => {
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 100, model: aliasedModel, inputRef: 1}),
+			row({pass: false, billed: 300, model: canonicalId, inputRef: 2}),
+		];
+		const sc = buildScorecard({rows});
+		assert.strictEqual(sc.cells.length, 1, "the alias and the canonical id are the same model");
+		const cell = cellFor(sc.cells, canonicalId);
+		assert.strictEqual(cell.gradedRuns, 2);
+		assert.strictEqual(cell.passRate, 0.5);
+		assert.strictEqual(cell.spend?.billedPerRun, 200);
+	});
+
+	it("a model the table has never seen passes through unchanged and keeps its own cell", () => {
+		const unknown = "a-model-the-table-has-never-seen";
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 100, model: unknown, inputRef: 1}),
+			row({pass: true, billed: 100, model: aliasedModel, inputRef: 2}),
+		];
+		const sc = buildScorecard({rows});
+		// Normalize-only: no allowlist and no rejection, so the unrecognized model still reports.
+		assert.strictEqual(cellFor(sc.cells, unknown).gradedRuns, 1);
+		assert.strictEqual(sc.cells.length, 2);
+	});
+
+	it("a --baseline-model given as an alias matches the cell recorded under the canonical id", () => {
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 1000, model: canonicalId, inputRef: 1}),
+			row({pass: true, billed: 400, model: "sonnet", inputRef: 2}),
+		];
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: aliasedModel}});
+		// Pre-#5158 this matched no bucket and every netSaving came back null — fail-quiet.
+		assert.strictEqual(sc.baseline?.model, canonicalId);
+		assert.strictEqual(cellFor(sc.cells, "sonnet").netSaving, 600);
 	});
 });
 
@@ -412,8 +470,8 @@ describe("decodeReportInput — a rows file written before provenance existed st
 
 describe("report — the output carries no model recommendation, only evidence for #1576", () => {
 	it("the scorecard and both rendered surfaces point at the decision and recommend nothing", () => {
-		const rows: ReadonlyArray<RunRow> = [row({pass: true, billed: 100, model: "opus"})];
-		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		const rows: ReadonlyArray<RunRow> = [row({pass: true, billed: 100, model: "opus-4.8"})];
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus-4.8"}});
 		assert.strictEqual(sc.decisionRef, DECISION_POINTER);
 		assert.strictEqual(DECISION_POINTER, 1576);
 

--- a/packages/fabrika-cli/src/eval/spawn.ts
+++ b/packages/fabrika-cli/src/eval/spawn.ts
@@ -22,6 +22,7 @@
  * verdict is the one place a run is allowed to become a `CaptureRun`.
  */
 import {Effect, Result} from "effect";
+import {canonicalModel} from "../models.ts";
 import {classifyRunSpend, type RunSpend} from "../spend/token-spend.ts";
 import {STAGES} from "./corpus.ts";
 import {
@@ -47,6 +48,18 @@ export interface RunnableCase {
 	readonly prompt: string;
 	readonly tier: EvalTier;
 }
+
+/**
+ * The one spelling a run is pinned under: `--model`'s value canonicalized through fabrika's single
+ * alias table (`../models.ts`), which declares it — nothing here holds a second copy (ADR 0238).
+ *
+ * Normalize-only, by the ruling on #5148: an alias resolves to its canonical id, and **everything
+ * else passes through unchanged** — no allowlist, no default, no rejection — so a model the table
+ * has never seen still runs and #4680's model-churn re-run contract (ADR 0236 §2) survives. The
+ * `?? model` arm keeps a blank value exactly as unnormalized as it is today; refusing it here would
+ * be the rejection the ruling rules out.
+ */
+const pinnedModel = (model: string): string => canonicalModel(model) ?? model;
 
 /** One planned invocation: exactly one (case × arm), with the session id its transcript will land under. */
 export interface PlannedRun {
@@ -86,7 +99,7 @@ export const planEvalRuns = <R>(args: {
 					arm,
 					sessionId: yield* args.sessionId(evalCase.id, arm),
 					prompt: evalCase.prompt,
-					model: args.model,
+					model: pinnedModel(args.model),
 					pluginDir: arm === "with-skill" ? args.pluginDir : null,
 					jsonSchema: args.jsonSchema,
 				});
@@ -588,18 +601,24 @@ export const buildLedger = (args: {
 	readonly cliVersion: string | null;
 	readonly recordedAt: string;
 	readonly outcomes: ReadonlyArray<RunOutcome>;
-}): RunLedger => ({
-	version: 1,
-	skillName: args.skillName,
-	stage: args.stage,
-	model: args.model,
-	cliVersion: args.cliVersion,
-	recordedAt: args.recordedAt,
-	runs: args.outcomes,
-	capture: toCaptureManifest(args),
-	spendRows: toSpendRows(args),
-	summary: summarizeRuns(args.outcomes),
-});
+}): RunLedger => {
+	// The recorded model is canonicalized here too, not only on the plans: the capture manifest and
+	// the spend rows are what the scorecard buckets on, and a header spelt differently from the argv
+	// would split one model across two cells (#5158).
+	const model = pinnedModel(args.model);
+	return {
+		version: 1,
+		skillName: args.skillName,
+		stage: args.stage,
+		model,
+		cliVersion: args.cliVersion,
+		recordedAt: args.recordedAt,
+		runs: args.outcomes,
+		capture: toCaptureManifest({...args, model}),
+		spendRows: toSpendRows({...args, model}),
+		summary: summarizeRuns(args.outcomes),
+	};
+};
 
 /** The stage names a `--stage` flag accepts — re-exported so the shell needn't reach into `runner.ts`. */
 export const isStageName = (value: string): value is CaptureRun["stage"] =>

--- a/packages/fabrika-cli/src/eval/spawn.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/spawn.unit.test.ts
@@ -13,6 +13,7 @@ import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Result} from "effect";
+import {MODEL_ALIASES} from "../models.ts";
 import {classifyRunSpend} from "../spend/token-spend.ts";
 import type {CorpusManifest} from "./corpus.ts";
 import {collectFromCapture, decodeCaptureManifest} from "./runner.ts";
@@ -173,6 +174,64 @@ describe("planEvalRuns — one invocation per (case × arm)", () => {
 			plans.map((p) => p.tier),
 			["graded", "deterministic"],
 		);
+	});
+});
+
+/**
+ * #5158 (ruled option B on #5148): `--model` is normalized to one canonical spelling before it
+ * reaches a plan, and is normalized ONLY — an unknown value still runs. The alias pair is read from
+ * fabrika's one table rather than typed, so a test can never become a second source.
+ */
+describe("planEvalRuns — the model a run is pinned to is canonicalized, never allowlisted", () => {
+	const aliasEntry = Object.entries(MODEL_ALIASES)[0];
+	if (aliasEntry === undefined) {
+		throw new Error("MODEL_ALIASES declares no alias — there is nothing for a run to normalize");
+	}
+	const [aliasedModel, canonicalId] = aliasEntry;
+
+	const plansFor = (model: string) =>
+		Effect.runSync(
+			planEvalRuns({
+				cases: [CASES[0] as RunnableCase],
+				arms: ["with-skill"],
+				model,
+				pluginDir: "/candidate",
+				jsonSchema: null,
+				sessionId: (id) => Effect.succeed(`${id}`),
+			}),
+		);
+
+	it("an alias reaches the plan — and the argv — as its canonical id", () => {
+		const planned = plansFor(aliasedModel);
+		assert.strictEqual(planned[0]?.model, canonicalId);
+		assert.include([...buildClaudeArgs(planned[0] as PlannedRun)], canonicalId);
+	});
+
+	it("a model the table has never seen is planned exactly as given", () => {
+		const unknown = "a-model-the-table-has-never-seen";
+		assert.strictEqual(plansFor(unknown)[0]?.model, unknown);
+	});
+
+	it("the ledger and its capture manifest record the canonical spelling too", () => {
+		const outcomes = Effect.runSync(
+			executeRuns({
+				plans: plansFor(aliasedModel),
+				executor: () => Effect.succeed(exited(resultStdout())),
+				locateTranscript: (sessionId) => Effect.succeed(`/data/${sessionId}.jsonl`),
+				loadTranscript: () => Effect.succeed(billedTranscript),
+			}),
+		);
+		const ledger = buildLedger({
+			skillName: "probe",
+			stage: "triage",
+			model: aliasedModel,
+			cliVersion: "2.1.220",
+			recordedAt: "2026-08-09T00:00:00Z",
+			outcomes,
+		});
+		assert.strictEqual(ledger.model, canonicalId);
+		assert.strictEqual(ledger.capture.runs[0]?.model, canonicalId);
+		assert.strictEqual(ledger.spendRows[0]?.model, canonicalId);
 	});
 });
 


### PR DESCRIPTION
Fixes #5158

## What changed

`fabrika eval`'s `--model` value is now canonicalized to one spelling before it reaches anything that keys on it. The alias table is **consumed**, never re-declared: `packages/fabrika-cli/src/models.ts` (landed by #5075 / PR #5201) exports `MODEL_ALIASES` + `canonicalModel`, and both eval sites import it.

- `src/eval/spawn.ts` — a module-local `pinnedModel` calls `canonicalModel`; `planEvalRuns` pins every `PlannedRun.model` through it (so `buildClaudeArgs` emits the canonical id), and `buildLedger` records the canonical spelling on the ledger header, the **capture manifest** and every **spend row** — the three artifacts the scorecard actually reads.
- `src/eval/report.ts` — `modelOf` canonicalizes a row's model before it becomes a bucket key, so an alias and its canonical id are **one cell**, not two pass-rates over the same model; `sameCell` canonicalizes the baseline key, so `--baseline-model <alias>` matches the cell recorded under the canonical id instead of matching nothing and reporting `null`.
- `src/eval/command.ts` — the `--model` and `--baseline-model` help text state the contract.
- `src/eval/README.md` — a `### The --model contract (#5158)` paragraph: normalized, **not** allowlisted, **no** default, unknown values still run.

**Normalize-only, exactly as ruled (option B on #5148).** No allowlist, no default, no rejection. An unknown model canonicalizes to itself and runs as named, so #4680's model-churn re-run contract (ADR 0236 §2) is untouched. Nothing imports from `packages/pipeline-cli/` (ADR 0238).

## Acceptance criteria

- [x] `--model` normalizes before the value reaches `PlannedRun.model` (`planEvalRuns`), so `buildClaudeArgs`, `cellKey` and `sameCell` all see one spelling.
- [x] Pass-through for an unknown value — no allowlist, no rejection, no default.
- [x] The map is consumed from `packages/fabrika-cli/src/models.ts` as the single source; nothing under `src/eval/` declares a second copy and nothing imports `pipeline-cli`.
- [x] No model identifier is committed as a literal policy value — the policy table stays in `models.ts` behind its ADR-0116-shaped config seam; the new tests read their alias pair **out of `MODEL_ALIASES`** rather than typing a spelling.
- [x] Unit tests: two aliases of one model produce one cell; an unknown model string passes through unchanged (asserted on both the report and the plan side).
- [x] Unit test: `--baseline-model` given as an alias matches a cell recorded under the canonical id.
- [x] `src/eval/README.md` states the `--model` contract in one paragraph.

## Verification

- `pnpm --filter @kampus/fabrika-cli exec vitest run` — 183 files / 2604 tests pass.
- `pnpm typecheck` — 31/31 tasks green.
- `pnpm lint:worktree` — clean.

## Deviations

1. **The existing report fixtures were renamed from `"opus"` to `"opus-4.8"` (18 lines in `report.unit.test.ts`).** `"opus"` is a *real* alias in `MODEL_ALIASES`, so once bucketing canonicalizes, those pre-existing tests would have been silently asserting the new normalization instead of the pass-rate/net-saving arithmetic they exist to check (and several would have failed outright). `"opus-4.8"` is the non-alias placeholder this package already uses in `spawn.unit.test.ts`, `runner.unit.test.ts` and the README, so the rename keeps each test measuring what it was written to measure. It widens the diff by a rename; it changes no assertion.
2. **Normalization is applied inside the cores (`planEvalRuns`, `buildLedger`, `modelOf`, `sameCell`), not once at the CLI flag.** The issue names the flag, and a `Flag.map` would have been fewer lines — but the scorecard also reads **rows recorded by earlier runs**, whose spelling no live flag can reach. Canonicalizing at the bucket key is the only placement that satisfies the "two aliases, one cell" criterion for already-written rows, and doing the same on the plan/ledger side makes a raw model string unrepresentable past those entry points rather than merely unused.
3. **A blank `--model` is not rejected.** `canonicalModel` answers `null` for an empty/whitespace value; `pinnedModel` falls back to the value as given, preserving today's behaviour exactly. Refusing it would be the rejection the ruling rules out, and it is not in scope here.

No other deviations: no allowlist, no default pin, no second alias table, no scope beyond the eval `--model` path.
