### PR TITLE
feat(fabrika-cli): build claim learns a purpose axis — plan/gate claims skip the audience fence

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -64,9 +64,10 @@ fabrika build claim 4312
 `won` prints your token; `lost` names the winner — that lane is theirs, back off. **§SCOPE** — exit
 `20` (out of focus) or `21` (audience not agent) means the fence refused before writing any marker,
 including on a number handed straight to you: end the run naming the code, and **never override on
-your own authority**. `--override "<reason>"` is the operator's act, taken only when they ask for it
-in so many words, and the reason it records is theirs, not a rationale you compose. Before **every**
-later mutation addressed to an issue or PR number, re-confirm:
+your own authority**. `--override "<reason>" --override-lane "<lane>"` (both flags required) is the
+operator's act, taken only when they ask for it in so many words, and the reason it records is
+theirs, not a rationale you compose. Before **every** later mutation addressed to an issue or PR
+number, re-confirm:
 
 ```bash
 fabrika build confirm 4312

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -198,9 +198,11 @@ nothing, while `20` and `21` are proven refusals. Nor does a scope refusal borro
 is minted for "the read failed": the matrix already owns that meaning at `11`, and one meaning on two
 codes is the drift the matrix exists to prevent.
 
-**The override — explicit at the call, recorded on the issue.** `build claim --override "<reason>"`
-admits an issue the predicate refused, and writes the reason into the claim marker it posts, so the
-escape hatch costs one deliberate act and leaves a trace; a silent override is not one. **`build
+**The override — explicit at the call, recorded on the issue.** `build claim --override "<reason>"
+--override-lane "<lane>"` admits an issue the predicate refused, and writes **both** fields — the
+lane and the reason — into the claim marker it posts, so the escape hatch costs one deliberate act
+and names who took it; a silent or unattributed override is not one. The two flags are required
+together (the `claim` block below): either one alone is a usage error, not a claim. **`build
 pick` takes no override**: the pool is the browse path, and an operator who means to work an
 out-of-focus issue names its number and overrides where the lane actually opens. **`build confirm`
 and `build release` never run the fence** — it decides what may *start*, so a focus row edited

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -670,8 +670,8 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `build claim: issue #<n> is proven absent or closed.` | 7 | refusal |
-| `build claim: #<n> is homed in milestone <home>, outside the declared focus #<focus> — refusing before any marker; pass --override "<reason>" to claim it anyway.` | 20 | refusal |
-| `build claim: #<n> carries <audience>, not "ready-for:agent" — refusing before any marker; pass --override "<reason>" to claim it anyway.` (`<audience>` is the issue's `ready-for:` label, or the literal `no "ready-for:" label` when it carries none) | 21 | refusal |
+| `build claim: #<n> is homed in milestone <home>, outside the declared focus #<focus> — refusing before any marker; pass --override "<reason>" --override-lane "<lane>" to claim it anyway.` | 20 | refusal |
+| `build claim: #<n> carries <audience>, not "ready-for:agent" — refusing before any marker; pass --override "<reason>" --override-lane "<lane>" to claim it anyway.` (`<audience>` is the issue's `ready-for:` label, or the literal `no "ready-for:" label` when it carries none) | 21 | refusal |
 | `build claim: cannot read the "## Focus" declaration: <reason> — scope is UNKNOWN, never admitted; nothing was written.` | 11 | refusal |
 | `build claim: the "## Focus" declaration does not parse: <detail> — a malformed declaration is never read as "no focus"; nothing was written.` | 4 | refusal |
 | `build claim: --override was given with an empty reason — an override is recorded or it is not one.` | 1 | usage error |
@@ -712,7 +712,7 @@ $ fabrika build claim 4300 --purpose gate
 
 ```
 $ fabrika build claim 4290
-build claim: #4290 is homed in milestone 39, outside the declared focus #44 — refusing before any marker; pass --override "<reason>" to claim it anyway.
+build claim: #4290 is homed in milestone 39, outside the declared focus #44 — refusing before any marker; pass --override "<reason>" --override-lane "<lane>" to claim it anyway.
 $ echo $?
 20
 ```

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -115,7 +115,8 @@ from two separate questions, computed together and answered together:
   names campaign membership and nothing else. Refusal is `20`.
 - **The audience axis** — is the issue's `ready-for:` label `ready-for:agent`? This axis is older
   than the fence (#4780); `build pick` already carried it, and ADR 0245 asks for the scope axis to
-  be added **beside** it, not folded into it. Refusal is `21`.
+  be added **beside** it, not folded into it. Refusal is `21`, and it binds a **build-purpose** claim
+  only (see `build claim`'s `--purpose`, #5175).
 
 **Keep the two names apart.** *Scope admission* is a different question from the audience axis (who
 the work is for), from dependency eligibility (`build eligible` asks whether an issue's predecessors
@@ -581,18 +582,21 @@ shape ambiguous between comment ids and session ids and callers guessed (#4428).
 **Invocation**
 
 ```
-fabrika build claim 4312 [--repo <owner/name>] [--override <reason>]
+fabrika build claim 4312 [--repo <owner/name>] [--purpose plan|gate|build]
+                         [--override <reason> --override-lane <lane>]
 fabrika build confirm 4312 [--repo <owner/name>]
 fabrika build release 4312 [--repo <owner/name>]
 ```
 
-**Inputs** — the first two rows are identical for all three verbs; `--override` is `claim`'s alone:
+**Inputs** — the first two rows are identical for all three verbs; the last three are `claim`'s alone:
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the issue (or, in repair, the PR) the claim concerns |
 | `--repo` | string | no | the `origin` remote's `owner/name` | the repository whose markers are read and written |
-| `--override` | string | no | — | claim an issue the admission test refused on either axis, naming why; the reason is written into the claim marker |
+| `--purpose` | `plan` \| `gate` \| `build` | no | `build` | why this lane claims; the audience axis binds `build` only (#5175). An off-enum value is `10`, never a fallback |
+| `--override` | string | no | — | claim an issue the admission test refused on either axis, naming why; requires `--override-lane` |
+| `--override-lane` | string | no | — | the lane the override is taken for; refused without `--override`. Lane and reason are both written into the claim marker |
 
 **`claim` runs the fence before it writes anything.** After the target-open check and **before
 any marker is posted**, `claim` puts `<number>` through the
@@ -603,12 +607,29 @@ module `build pick` filters on, both axes, never a second derivation. A `refused
 `11` and a malformed declaration is `4`, and neither ever proceeds. Nothing is written on any of the
 four: the issue carries no marker, so a refused claim leaves no trace to retract.
 
+**The purpose decides whether the audience axis binds — it never enters either axis.** `--purpose`
+says why this lane claims: `build` (the default) is bound by both axes, while `plan` and `gate` are
+bound by the scope axis alone. The audience axis asks whether an agent should pick the issue up to
+*build*, and an epic earns `ready-for:agent` only after it has been planned and gated, so fencing
+the planner and the gate on it is circular (founder ruling,
+[#5175](https://github.com/kamp-us/phoenix/issues/5175); 19 of 20 open epics carried no such label).
+The purpose rides **beside** the two axes rather than widening either — each axis still reads the
+issue exactly as it did, and only the composition consults the purpose, which is the shape ADR 0245's
+repair round settled. A `21` is therefore reachable under `--purpose build` only, and `20` is
+reachable under every purpose. `claim`'s purpose line names which reading applied, and the audience
+it saw either way, so a claim admitted over a non-agent audience is readable as one afterwards.
+
 This is the seam where the refusal has teeth. A pool filter is bypassed by an operator naming a
 number, and a number handed straight to `claim` passes through no pool — claiming is the moment work
-starts and the one moment every path goes through (ADR 0245). `--override "<reason>"` admits the
-issue anyway and appends the reason to the claim marker it posts, so the escape hatch costs one
-deliberate act and leaves a record on the issue; an empty `--override` value is a usage error (`1`),
-because an unexplained override is the silent one the rule forbids. `confirm` and `release` do not
+starts and the one moment every path goes through (ADR 0245). `--override "<reason>"
+--override-lane "<lane>"` admits the issue anyway and appends both fields to the claim marker it
+posts, so the escape hatch costs one deliberate act and leaves a record on the issue naming who took
+it and why. **Both fields are required together**: an empty reason, a missing or blank lane, and a
+lane with no override are each a usage error (`1`), because an override that names neither is
+indistinguishable from routine use — which is how a fail-closed fence rots fail-open by convention
+(#5175). The override is for a *proven* refusal an operator means to take; it is not the way a
+plan- or gate-purpose lane gets past the audience axis, which `--purpose` now answers directly.
+`confirm` and `release` do not
 run the fence at all: it governs what may *start*, so a focus row edited mid-lane can neither strand
 a running lane nor block its release.
 
@@ -617,9 +638,9 @@ unset behavior: unset is a usage error, exit `1` — a claim without an identity
 
 **Output** — machine, one JSON object:
 
-- `claim` on a win: `{"answer": "won", "number": 4312, "token": "build:<sid>:<uuid>"}` — plus
-  `"override": "<reason>"` when the win came through `--override`, so the answer records the
-  exception as well as the marker does.
+- `claim` on a win: `{"answer": "won", "number": 4312, "token": "build:<sid>:<uuid>", "purpose":
+  "build"}` — plus `"override": {"lane": "<lane>", "reason": "<reason>"}` when the win came through
+  `--override`, so the answer records the exception as well as the marker does.
 - `confirm` when held: `{"answer": "mine", "number": 4312, "token": "..."}`.
 - `release` when released: `{"answer": "released", "number": 4312}`.
 
@@ -638,10 +659,11 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `7` | the issue is proven absent (404) or closed |
 | `8` | the marker write failed — it may or may not have landed; re-run `confirm` before anything else |
 | `9` | the marker landed but the read-back does not match |
+| `10` | `claim` only: `--purpose` is off the `plan` \| `gate` \| `build` enum — a refusal, never a fallback to `build` |
 | `11` | the marker set could not be read — ownership is UNKNOWN, never "unclaimed"; or, `claim` only, the focus declaration or the issue's home could not be read — scope admission is UNKNOWN, never admitted |
 | `15` | proven: another session's earlier authorized marker wins (`claim`), holds (`confirm`), or `release` was asked for a token this session does not hold |
 | `20` | `claim` only, proven: the issue's home is outside the declared focus — no marker was written |
-| `21` | `claim` only, proven: the issue's audience is not an agent — no marker was written |
+| `21` | `claim --purpose build` only (the default), proven: the issue's audience is not an agent — no marker was written |
 
 **Errors**
 
@@ -653,6 +675,9 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `build claim: cannot read the "## Focus" declaration: <reason> — scope is UNKNOWN, never admitted; nothing was written.` | 11 | refusal |
 | `build claim: the "## Focus" declaration does not parse: <detail> — a malformed declaration is never read as "no focus"; nothing was written.` | 4 | refusal |
 | `build claim: --override was given with an empty reason — an override is recorded or it is not one.` | 1 | usage error |
+| `build claim: --override was given without a lane — pass --override-lane "<lane>" so the escape hatch names who took it.` | 1 | usage error |
+| `build claim: --override-lane was given without --override — a lane names no override on its own.` | 1 | usage error |
+| `build claim: --purpose "<value>" is not one of plan \| gate \| build — an unrecognised purpose refuses, and never falls back to build.` | 10 | usage error |
 | `build claim: the marker write failed: <reason> — the claim state is UNKNOWN; run "fabrika build confirm <n>" before any further action.` | 8 | refusal |
 | `build claim: cannot read the claim markers on #<n>: <reason> — ownership is UNKNOWN, never "unclaimed".` | 11 | refusal |
 | `build claim: lost to <token> (posted <timestamp>, authorized).` | 15 | refusal |
@@ -677,7 +702,12 @@ run that claimed under an inert fence is readable as such afterwards.
 
 ```
 $ fabrika build claim 4312
-{"answer":"won","number":4312,"token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d"}
+{"answer":"won","number":4312,"token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d","purpose":"build"}
+```
+
+```
+$ fabrika build claim 4300 --purpose gate
+{"answer":"won","number":4300,"token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d","purpose":"gate"}
 ```
 
 ```
@@ -688,8 +718,8 @@ $ echo $?
 ```
 
 ```
-$ fabrika build claim 4290 --override "hotfix for the release blocker"
-{"answer":"won","number":4290,"token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d","override":"hotfix for the release blocker"}
+$ fabrika build claim 4290 --override "hotfix for the release blocker" --override-lane build-epic
+{"answer":"won","number":4290,"token":"build:s-9f2e:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d","purpose":"build","override":{"lane":"build-epic","reason":"hotfix for the release blocker"}}
 ```
 
 ```

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -33,15 +33,25 @@ The planner and this gate must not interleave on one epic, so claim it before re
 the claim is `build`'s, reused, not a second lock:
 
 ```bash
-fabrika build claim 4300
+fabrika build claim 4300 --purpose gate
 ```
+
+`--purpose gate` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
+should pick the issue up to **build**, and an epic earns that label only *after* it has been planned
+and gated — so fencing this gate on it is circular, and the founder ruled the fence binds
+build-purpose claims only ([#5175](https://github.com/kamp-us/phoenix/issues/5175)). A `gate` claim
+is admitted without the label; the scope axis still binds, so an out-of-focus epic is still exit
+`20`. Never reach for `--override` to get past the audience axis — that is the fail-open convention
+the purpose exists to remove.
 
 Done when it answers `won`. Exit `15` is a proven loss with the winner named on stderr: end at
 `BACKED-OFF`. Exit `7` is a proven-absent or closed target: end at `PLAN-UNGATEABLE`. The verb takes
 the session identity from `CLAUDE_CODE_SESSION_ID`, and an unset one is exit `1` — a claim without
-an identity is not a claim. **Any other non-zero here (`1`, `8`, `9`, `11`) ends `STOPPED` with no
-note**: you hold no claim, and `build note` requires one, so there is nothing postable — report the
-code in the terminal line instead.
+an identity is not a claim. **Any other non-zero here (`1`, `8`, `9`, `10`, `11`, `20`) ends
+`STOPPED` with no note**: you hold no claim, and `build note` requires one, so there is nothing
+postable — report the code in the terminal line instead. `10` is an off-enum `--purpose`, and `20`
+is a proven out-of-focus epic. Exit `21` is no longer reachable at this step, because a `gate` claim
+is not bound by the audience axis.
 
 ```bash
 fabrika plan read 4300

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -25,8 +25,14 @@ is not — `plan` is still unallocated, and no `epic` verb answers this gate's q
 
 **What fabrika already ships, reused — never respecified.** The claim is the **`build` group's,
 reused as landed verbs** ([`build`'s contract](../build/contract.md)) — the cross-contract shape
-`build-ui` sanctioned: this gate claims the epic with `fabrika build claim`, releases it with
-`fabrika build release`, and posts a successor note with `fabrika build note`. **No second lock is
+`build-ui` sanctioned: this gate claims the epic with `fabrika build claim --purpose gate`, releases
+it with `fabrika build release`, and posts a successor note with `fabrika build note`. The purpose is
+part of the reuse, not a detail of it: `build claim`'s audience axis asks whether an agent should
+pick the issue up to *build*, and an epic earns `ready-for:agent` only after it has been planned and
+gated, so a `gate` claim is admitted without it (founder ruling,
+[#5175](https://github.com/kamp-us/phoenix/issues/5175)). The scope axis is unchanged by the purpose,
+and `--override` stays the exception it was — it now has to name its lane as well as its reason.
+**No second lock is
 derived**, and v1's `epic-lock` is why: its `acquire` short-circuits on a held label *before* any
 liveness probe, so a dead holder's lock is never reclaimed and a human clears it by hand — which is
 also why the skill releases on every terminal where it holds the claim (§TERM), never only on the
@@ -305,8 +311,10 @@ obligation (interface convention rule 3), and the alignment this group opts into
 **The `20`/`21` overlap with `build`, settled ([#5107](https://github.com/kamp-us/phoenix/issues/5107)).**
 This was written when `20`+ was free; the scope-admission fence has since taken `20` `OUT_OF_FOCUS`
 and `21` `AUDIENCE_NOT_AGENT`, both reachable from `fabrika build claim` — step 1 of this gate's
-skill. The overlap **stands**, and the rule that settles it is: *import a code when two groups prove
-the same fact; allocate freely when they do not.* `15` is imported because `plan flip` and
+skill. `21` is no longer among them: step 1 claims with `--purpose gate`, and the audience axis binds
+build-purpose claims only (#5175), so the only admission refusal this gate can meet is `20`. The
+overlap is therefore narrower than when it was settled, and it **stands**, on the same rule: *import
+a code when two groups prove the same fact; allocate freely when they do not.* `15` is imported because `plan flip` and
 `build claim` assert the identical fact (this session holds this issue's claim). `20`/`21` do not
 overlap in fact at all — lane admission is never something a `plan` verb proves, and a defective
 floor or a moved digest is never something a `build` verb proves — and an exit code is read off the

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -25,13 +25,30 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {createComment, deleteComment, getComment, type IssueRecord} from "../io/issues.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
-import {composeMarker, readMarkerToken, requireSession, resolveOwnership} from "./claim.ts";
-import {CLAIM_NOT_MINE, PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {
+	type ClaimOverride,
+	composeMarker,
+	readMarkerToken,
+	requireSession,
+	resolveOwnership,
+} from "./claim.ts";
+import {
+	CLAIM_NOT_MINE,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
 import {composeToken} from "./lane.ts";
 import {
 	admissionOf,
 	admissionRefusal,
+	audienceAxisOf,
+	CLAIM_PURPOSES,
+	DEFAULT_CLAIM_PURPOSE,
 	focusScopeLine,
+	parseClaimPurpose,
+	purposeScopeLine,
 	readDeclaredFocus,
 } from "./scope-admission.ts";
 import {openIssue, resolveTargetRepo} from "./target.ts";
@@ -44,11 +61,55 @@ export interface ClaimOptions {
 	readonly uuid: string;
 	/** The marker's human-readable ISO-8601 timestamp. The tiebreak uses GitHub's `created_at`. */
 	readonly at: string;
+	/** Why this lane claims — `plan` | `gate` | `build`, as typed. Off-enum refuses (#5175). */
+	readonly purpose: string;
 	/** Why this run claims an issue the admission test refused, or `null` for the ordinary path. */
 	readonly override: string | null;
+	/** The lane an override is taken for — required with an override, refused without one. */
+	readonly overrideLane: string | null;
 }
 
-export type ProtocolOptions = Omit<ClaimOptions, "uuid" | "at" | "override">;
+export type ProtocolOptions = Omit<
+	ClaimOptions,
+	"uuid" | "at" | "purpose" | "override" | "overrideLane"
+>;
+
+const CLAIM = "build claim";
+
+type OverrideRead =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Read"; readonly override: ClaimOverride | null};
+
+/**
+ * The override's two required fields, read before anything is written.
+ *
+ * An override is the fence's escape hatch, and an escape hatch that records nothing is how the fence
+ * rots fail-open by convention — so a reason without a lane, a lane without a reason, and a blank
+ * either is a usage refusal rather than a claim with a thin trace (#5175).
+ */
+const readOverride = (reason: string | null, lane: string | null): OverrideRead => {
+	const refusal = (message: string): OverrideRead => ({
+		_tag: "Refused",
+		outcome: refuse(FAILED, `${CLAIM}: ${message}`),
+	});
+	if (reason === null && lane === null) return {_tag: "Read", override: null};
+	if (reason === null) {
+		return refusal(
+			"--override-lane was given without --override — a lane names no override on its own.",
+		);
+	}
+	if (reason.trim() === "") {
+		return refusal(
+			"--override was given with an empty reason — an override is recorded or it is not one.",
+		);
+	}
+	if (lane === null || lane.trim() === "") {
+		return refusal(
+			'--override was given without a lane — pass --override-lane "<lane>" so the escape hatch names who took it.',
+		);
+	}
+	return {_tag: "Read", override: {lane: lane.trim(), reason: reason.trim()}};
+};
 
 const preflight = (
 	verb: string,
@@ -85,8 +146,6 @@ const preflight = (
 		};
 	});
 
-const CLAIM = "build claim";
-
 export const runClaim = (
 	options: ClaimOptions,
 ): Effect.Effect<
@@ -95,12 +154,17 @@ export const runClaim = (
 	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
 > =>
 	Effect.gen(function* () {
-		if (options.override !== null && options.override.trim() === "") {
+		const purpose = parseClaimPurpose(options.purpose);
+		if (purpose === null) {
 			return refuse(
-				FAILED,
-				`${CLAIM}: --override was given with an empty reason — an override is recorded or it is not one.`,
+				OFF_VOCABULARY,
+				`${CLAIM}: --purpose "${options.purpose}" is not one of ${CLAIM_PURPOSES.join(" | ")} — an unrecognised purpose refuses, and never falls back to ${DEFAULT_CLAIM_PURPOSE}.`,
 			);
 		}
+		const overrideRead = readOverride(options.override, options.overrideLane);
+		if (overrideRead._tag === "Refused") return overrideRead.outcome;
+		const override = overrideRead.override;
+
 		const ready = yield* preflight(CLAIM, options);
 		if (ready._tag === "Refused") return ready.outcome;
 		const {repo, session} = ready;
@@ -114,26 +178,30 @@ export const runClaim = (
 			);
 		}
 		const scopeLine = focusScopeLine(CLAIM, read.focus);
-		const admission = admissionOf(read.focus, ready.issue);
+		const purposeLine = purposeScopeLine(CLAIM, purpose, audienceAxisOf(ready.issue));
+		const admission = admissionOf(read.focus, ready.issue, purpose);
 		const refusal = admissionRefusal(CLAIM, admission);
 		// An override answers a PROVEN refusal. UNKNOWN has proven nothing, so there is nothing to
 		// override — a fence that could not read its input must not be talked past by a flag.
 		const overridable = admission._tag === "OutOfFocus" || admission._tag === "AudienceNotAgent";
-		if (refusal !== null && !(overridable && options.override !== null)) {
+		if (refusal !== null && !(overridable && override !== null)) {
 			return {
 				...refusal,
 				stderr: [
 					scopeLine,
+					purposeLine,
 					...refusal.stderr,
 					`${CLAIM}: nothing was written — #${number} carries no marker from this run${
-						overridable ? '; pass --override "<reason>" to claim it anyway' : ""
+						overridable
+							? '; pass --override "<reason>" --override-lane "<lane>" to claim it anyway'
+							: ""
 					}.`,
 				],
 			};
 		}
 
 		const token = composeToken(session, options.uuid);
-		const body = composeMarker(token, options.at, options.override);
+		const body = composeMarker(token, options.at, override);
 		const posted = yield* createComment(repo, number, body);
 		if (posted._tag === "Failure") {
 			return refuse(
@@ -154,6 +222,7 @@ export const runClaim = (
 		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session);
 		const notes = [
 			scopeLine,
+			purposeLine,
 			...unauthorized.map(
 				(marker) =>
 					`${CLAIM}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
@@ -172,7 +241,8 @@ export const runClaim = (
 					answer: "won",
 					number,
 					token,
-					...(options.override === null ? {} : {override: options.override}),
+					purpose,
+					...(override === null ? {} : {override}),
 				}),
 				notes,
 			);

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -8,6 +8,7 @@ import {
 	AUDIENCE_NOT_AGENT,
 	BAD_SECTIONS,
 	CLAIM_NOT_MINE,
+	OFF_VOCABULARY,
 	OUT_OF_FOCUS,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
@@ -56,7 +57,9 @@ const options = {
 	>,
 	uuid: LANE_UUID,
 	at: "2026-08-09T00:00:00Z",
+	purpose: "build",
 	override: null as string | null,
+	overrideLane: null as string | null,
 };
 
 const run = (
@@ -85,6 +88,7 @@ describe("runClaim", () => {
 		expect(JSON.parse(out.stdout)).toEqual({
 			answer: "won",
 			number: 4312,
+			purpose: "build",
 			token: `build:s-9f2e:${LANE_UUID}`,
 		});
 	});
@@ -290,21 +294,24 @@ describe("runClaim — the admission test runs before any marker is written", ()
 		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 	});
 
-	it("claims a refused issue under --override, recording the reason on the marker and in the answer", async () => {
+	it("claims a refused issue under --override, recording the lane and reason on the marker and in the answer", async () => {
 		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN, FOCUSED, {
 			override: "hotfix for the release blocker",
+			overrideLane: "build-epic",
 		});
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({
 			answer: "won",
 			number: 4312,
+			purpose: "build",
 			token: `build:s-9f2e:${LANE_UUID}`,
-			override: "hotfix for the release blocker",
+			override: {lane: "build-epic", reason: "hotfix for the release blocker"},
 		});
 		expect(
 			shell.calls.some(
 				(line) =>
-					POST.test(line) && line.includes("build-claim-override: hotfix for the release blocker"),
+					POST.test(line) &&
+					line.includes("build-claim-override: build-epic · hotfix for the release blocker"),
 			),
 		).toBe(true);
 	});
@@ -313,14 +320,41 @@ describe("runClaim — the admission test runs before any marker is written", ()
 		const {out, shell} = await claimWith(
 			CLAIMABLE,
 			fakeFs({files: {[DEFAULT_ROADMAP]: null}, unprobeable: [DEFAULT_ROADMAP]}),
-			{override: "I know what I am doing"},
+			{override: "I know what I am doing", overrideLane: "build-epic"},
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 	});
 
 	it("refuses an empty --override reason on 1 — an override is recorded or it is not one", async () => {
-		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN, FOCUSED, {override: "  "});
+		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN, FOCUSED, {
+			override: "  ",
+			overrideLane: "build-epic",
+		});
+		expect(out.code).toBe(FAILED);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses an --override that names no lane on 1 — the escape hatch says who took it (#5175)", async () => {
+		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN, FOCUSED, {
+			override: "hotfix for the release blocker",
+		});
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.some((line) => line.includes("--override-lane"))).toBe(true);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses a blank --override-lane on 1 — whitespace names no lane", async () => {
+		const {out, shell} = await claimWith(OUT_OF_CAMPAIGN, FOCUSED, {
+			override: "hotfix for the release blocker",
+			overrideLane: "   ",
+		});
+		expect(out.code).toBe(FAILED);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("refuses an --override-lane with no --override on 1 — a lane names no override alone", async () => {
+		const {out, shell} = await claimWith(CLAIMABLE, FOCUSED, {overrideLane: "build-epic"});
 		expect(out.code).toBe(FAILED);
 		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 	});
@@ -373,6 +407,83 @@ describe("runClaim — the admission test runs before any marker is written", ()
 		expect(confirmed.code).toBe(0);
 		const released = await run(runRelease, script, {}, FOCUSED);
 		expect(released.code).toBe(0);
+	});
+});
+
+/**
+ * The purpose axis (#5175): the audience fence binds a build claim only.
+ *
+ * The epic below is the census shape the ruling rests on — homed in the campaign, `type:epic`, and
+ * carrying no `ready-for:` label at all, because an epic earns one only after it is planned and
+ * gated. Every case runs that one issue and varies nothing but the purpose.
+ */
+describe("runClaim — the purpose axis", () => {
+	const FOCUSED = fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44)}});
+
+	const claimWith = (target: ExecResult, overrides: Partial<typeof options> = {}) => {
+		const shell = fakeShell([
+			[ISSUE, target],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		return Effect.runPromise(
+			Effect.provide(runClaim({...options, ...overrides}), Layer.merge(shell.layer, FOCUSED.layer)),
+		).then((out) => ({out, shell}));
+	};
+
+	const UNLABELLED_EPIC = issue({
+		milestone: {number: 44},
+		labels: labelled("type:epic", "p1", "status:triaged"),
+	});
+	const OUT_OF_CAMPAIGN_EPIC = issue({
+		milestone: {number: 39},
+		labels: labelled("type:epic", "p1", "status:triaged"),
+	});
+
+	it("keeps the fence with no purpose passed — 21, and no marker written", async () => {
+		const {out, shell} = await claimWith(UNLABELLED_EPIC);
+		expect(out.code).toBe(AUDIENCE_NOT_AGENT);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(out.stderr.some((line) => line.includes("audience not agent"))).toBe(true);
+	});
+
+	it("keeps the fence under an explicit --purpose build — the default is not the only path", async () => {
+		const {out, shell} = await claimWith(UNLABELLED_EPIC, {purpose: "build"});
+		expect(out.code).toBe(AUDIENCE_NOT_AGENT);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	for (const purpose of ["plan", "gate"] as const) {
+		it(`admits the same epic under --purpose ${purpose} — past the audience axis, no override`, async () => {
+			const {out} = await claimWith(UNLABELLED_EPIC, {purpose});
+			expect(out.code).toBe(0);
+			expect(JSON.parse(out.stdout)).toEqual({
+				answer: "won",
+				number: 4312,
+				purpose,
+				token: `build:s-9f2e:${LANE_UUID}`,
+			});
+			expect(out.stderr.some((line) => line.includes("the audience axis does not bind"))).toBe(
+				true,
+			);
+		});
+	}
+
+	for (const purpose of ["plan", "gate", "build"] as const) {
+		it(`still refuses an out-of-focus epic on 20 under --purpose ${purpose} — scope is untouched`, async () => {
+			const {out, shell} = await claimWith(OUT_OF_CAMPAIGN_EPIC, {purpose});
+			expect(out.code).toBe(OUT_OF_FOCUS);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		});
+	}
+
+	it("refuses an off-enum purpose on 10 — never a silent fallback to build", async () => {
+		const {out, shell} = await claimWith(UNLABELLED_EPIC, {purpose: "planning"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.some((line) => line.includes("plan | gate | build"))).toBe(true);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 	});
 });
 

--- a/packages/fabrika-cli/src/build/claim.ts
+++ b/packages/fabrika-cli/src/build/claim.ts
@@ -37,6 +37,12 @@ const AUTHORIZED = new Set(["admin", "maintain", "write"]);
  */
 const MARKER_RE = /^build-claim:\s*(build:[^\s·]+)\s*(?:·.*)?$/m;
 
+/** An admission override: the lane it is taken for, and why. Both required — see `readOverride`. */
+export interface ClaimOverride {
+	readonly lane: string;
+	readonly reason: string;
+}
+
 /**
  * The marker body, with an admission override recorded beneath it when one was used.
  *
@@ -45,10 +51,14 @@ const MARKER_RE = /^build-claim:\s*(build:[^\s·]+)\s*(?:·.*)?$/m;
  * parses. On a second line the escape hatch leaves the trace ADR 0245 asks for and the marker grammar
  * is untouched.
  */
-export const composeMarker = (token: string, at: string, override: string | null = null): string =>
+export const composeMarker = (
+	token: string,
+	at: string,
+	override: ClaimOverride | null = null,
+): string =>
 	override === null
 		? `build-claim: ${token} · ${at}`
-		: `build-claim: ${token} · ${at}\nbuild-claim-override: ${override}`;
+		: `build-claim: ${token} · ${at}\nbuild-claim-override: ${override.lane} · ${override.reason}`;
 
 /** The token a comment body claims, or `null` when it carries no marker. */
 export const readMarkerToken = (body: string): string | null => {

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -28,7 +28,12 @@ import {runNote} from "./note-verb.ts";
 import {runPick} from "./pick-verb.ts";
 import {runPr} from "./pr-verb.ts";
 import {runPush} from "./push-verb.ts";
-import {ADMISSION_EXIT_CODES} from "./scope-admission.ts";
+import {
+	ADMISSION_EXIT_CODES,
+	CLAIM_PURPOSES,
+	DEFAULT_CLAIM_PURPOSE,
+	READY_FOR_AGENT,
+} from "./scope-admission.ts";
 import {runScratch} from "./scratch-verb.ts";
 import {runTree} from "./tree-verb.ts";
 import {runVerdicts} from "./verdicts-verb.ts";
@@ -123,15 +128,27 @@ const claim = leafCommand(
 	"claim",
 	{
 		number: issueArg,
+		purpose: Flag.string("purpose").pipe(
+			Flag.withDefault(DEFAULT_CLAIM_PURPOSE),
+			Flag.withDescription(
+				`why this lane claims: ${CLAIM_PURPOSES.join(" | ")} — the audience fence (${READY_FOR_AGENT}) binds build only (default: ${DEFAULT_CLAIM_PURPOSE})`,
+			),
+		),
 		override: Flag.string("override").pipe(
 			Flag.optional,
 			Flag.withDescription(
-				"claim an issue the admission test refused on either axis, naming why; the reason is written into the claim marker",
+				"claim an issue the admission test refused on either axis, naming why; requires --override-lane, and both are written into the claim marker",
+			),
+		),
+		overrideLane: Flag.string("override-lane").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the lane an --override is taken for; required with it, refused without it",
 			),
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, override, repo}) {
+	Effect.fn(function* ({number, purpose, override, overrideLane, repo}) {
 		yield* emit(
 			yield* runClaim({
 				number,
@@ -139,13 +156,15 @@ const claim = leafCommand(
 				env: process.env,
 				uuid: randomUUID(),
 				at: new Date().toISOString(),
+				purpose,
 				override: Option.getOrNull(override),
+				overrideLane: Option.getOrNull(overrideLane),
 			}),
 		);
 	}),
 ).pipe(
 	Command.withDescription(
-		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract; --override "<reason>" admits a proven refusal and records the reason on the marker, and an UNKNOWN admission is never overridable. Prints {"answer":"won","number":n,"token":"…"}, plus "override" when one was used. A lost race retracts this run's own marker and exits 15, never 0; an unset CLAUDE_CODE_SESSION_ID, or an empty --override reason, is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 15 (proven lost), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312`,
+		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used. A lost race retracts this run's own marker and exits 15, never 0; an unset CLAUDE_CODE_SESSION_ID, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum), 15 (proven lost), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
 	),
 );
 

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -12,6 +12,9 @@
  * answering both questions at once is the shape the contract's repair round removed; every outcome
  * below therefore carries **both** axis verdicts, so a caller can never lose one behind the other.
  *
+ * A claim's {@link ClaimPurpose} rides **beside** those axes: it decides whether the audience axis
+ * *binds* this claim, and it never enters either axis's own reading (#5175).
+ *
  * The core is pure and total, and this module is **imported** by the pool and claim seams rather than
  * invoked through a relaying verb (the wrapper shape ADR 0238 bans). Only {@link readDeclaredFocus}
  * touches IO.
@@ -182,6 +185,29 @@ export const scopeAxisOf = (focus: ParsedFocus, issue: IssueFacts): ScopeAxis =>
 	return {_tag: "OutOfFocus", focus: focus.milestone, home: homeOf(issue)};
 };
 
+/**
+ * Why a lane claims — `plan`, `gate`, or `build`. A closed enum, never a policy map.
+ *
+ * The audience axis answers "should an agent pick this up to **build**", and an epic only earns
+ * `ready-for:agent` *after* it has been planned and gated — so fencing the planner and the gate on it
+ * is circular (founder ruling, #5175: 19 of 20 open epics carried no such label). Purpose is how a
+ * claim says which question it is asking, and it is deliberately a third input rather than a widening
+ * of either axis: {@link scopeAxisOf} and {@link audienceAxisOf} read an issue exactly as before, and
+ * only {@link admissionOf}'s composition consults the purpose.
+ */
+export const CLAIM_PURPOSES = ["plan", "gate", "build"] as const;
+export type ClaimPurpose = (typeof CLAIM_PURPOSES)[number];
+
+/** The purpose a claim carries when none is named — behaviour-preserving, so the fence stays on. */
+export const DEFAULT_CLAIM_PURPOSE: ClaimPurpose = "build";
+
+/** The named purpose, or `null` for a value off the enum — a caller refuses, never falls back. */
+export const parseClaimPurpose = (value: string): ClaimPurpose | null =>
+	CLAIM_PURPOSES.find((purpose) => purpose === value) ?? null;
+
+/** Only a build-purpose claim is bound by the audience axis (#5175). Scope binds every purpose. */
+export const audienceAxisBinds = (purpose: ClaimPurpose): boolean => purpose === "build";
+
 /** Absence is an unknown audience, never an agent audience (#4780). */
 export const audienceAxisOf = (issue: IssueFacts): AudienceAxis =>
 	issue.labels.includes(READY_FOR_AGENT)
@@ -218,8 +244,15 @@ export type Admission =
  * campaign in focus its audience label is not the thing to fix, and reporting the audience first would
  * send an operator to re-label work that the scope fence would refuse again. The unreported axis is
  * still on the outcome.
+ *
+ * `purpose` decides only whether an audience refusal is *seated*; the audience verdict itself is read
+ * and reported either way, so a `plan`/`gate` claim admitted over a non-agent audience still says so.
  */
-export const admissionOf = (focus: Focus, issue: IssueFacts): Admission => {
+export const admissionOf = (
+	focus: Focus,
+	issue: IssueFacts,
+	purpose: ClaimPurpose = DEFAULT_CLAIM_PURPOSE,
+): Admission => {
 	if (focus._tag === "Malformed") {
 		return {
 			_tag: "Unknown",
@@ -230,7 +263,9 @@ export const admissionOf = (focus: Focus, issue: IssueFacts): Admission => {
 	const scope = scopeAxisOf(focus, issue);
 	const audience = audienceAxisOf(issue);
 	if (scope._tag === "OutOfFocus") return {_tag: "OutOfFocus", scope, audience};
-	if (audience._tag === "NotAgent") return {_tag: "AudienceNotAgent", scope, audience};
+	if (audience._tag === "NotAgent" && audienceAxisBinds(purpose)) {
+		return {_tag: "AudienceNotAgent", scope, audience};
+	}
 	return {_tag: "Admitted", scope, audience};
 };
 
@@ -273,9 +308,24 @@ export const ADMISSION_EXIT_CODES: ReadonlyArray<{
 	},
 	{
 		code: AUDIENCE_NOT_AGENT,
-		condition: `proven: not admitted on the audience axis — the issue's ${READY_FOR_PREFIX} label is not ${READY_FOR_AGENT}, or is absent`,
+		condition: `proven: not admitted on the audience axis — the issue's ${READY_FOR_PREFIX} label is not ${READY_FOR_AGENT}, or is absent; reachable only under purpose build`,
 	},
 ];
+
+/** The purpose line the claim seam prints, so an exempted audience is read rather than inferred. */
+export const purposeScopeLine = (
+	verb: string,
+	purpose: ClaimPurpose,
+	audience: AudienceAxis,
+): string => {
+	const carried =
+		audience._tag === "Agent"
+			? READY_FOR_AGENT
+			: (audience.label ?? `no ${READY_FOR_PREFIX} label`);
+	return audienceAxisBinds(purpose)
+		? `${verb}: purpose: ${purpose} — the audience axis binds; this issue carries ${carried}.`
+		: `${verb}: purpose: ${purpose} — the audience axis does not bind a ${purpose} claim (#5175); this issue carries ${carried}.`;
+};
 
 /** The scope line both seams print, so an operator sees the fence's state rather than inferring it. */
 export const focusScopeLine = (verb: string, focus: Focus): string => {

--- a/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
@@ -7,7 +7,10 @@ import {
 	type Admission,
 	admissionOf,
 	admissionRefusal,
+	audienceAxisBinds,
 	audienceAxisOf,
+	CLAIM_PURPOSES,
+	DEFAULT_CLAIM_PURPOSE,
 	DEFAULT_ROADMAP,
 	exclusionReasonOf,
 	type Focus,
@@ -15,6 +18,8 @@ import {
 	focusScopeLine,
 	homeOf,
 	type IssueFacts,
+	parseClaimPurpose,
+	purposeScopeLine,
 	readDeclaredFocus,
 	readFocus,
 	STANDING_LANE_LABELS,
@@ -172,6 +177,56 @@ describe("admissionOf", () => {
 		expect(out._tag === "Admitted" && out.scope).toEqual({_tag: "Inert"});
 		expect(focusScopeLine("build pick", noFocus)).toContain("none declared — scope fence inert");
 		expect(focusReport(noFocus)).toEqual({state: "none"});
+	});
+
+	/**
+	 * The purpose axis (#5175). Every case varies the purpose over one unlabelled, in-focus issue —
+	 * the epic shape the ruling rests on — so what changes is only which question the claim asks.
+	 */
+	describe("purpose", () => {
+		const unlabelled = issue({labels: ["status:triaged", "type:epic"]});
+
+		it("defaults to build, so an omitted purpose keeps the fence", () => {
+			expect(DEFAULT_CLAIM_PURPOSE).toBe("build");
+			expect(admissionOf(declared, unlabelled)._tag).toBe("AudienceNotAgent");
+			expect(admissionOf(declared, unlabelled, DEFAULT_CLAIM_PURPOSE)._tag).toBe(
+				"AudienceNotAgent",
+			);
+		});
+
+		for (const purpose of ["plan", "gate"] as const) {
+			it(`admits the same issue under ${purpose}, and still reports the audience it saw`, () => {
+				const out = admissionOf(declared, unlabelled, purpose);
+				expect(out._tag).toBe("Admitted");
+				expect(out._tag === "Admitted" && out.audience).toEqual({_tag: "NotAgent", label: null});
+				expect(audienceAxisBinds(purpose)).toBe(false);
+			});
+		}
+
+		for (const purpose of CLAIM_PURPOSES) {
+			it(`leaves the scope axis alone under ${purpose} — out of focus is still 20`, () => {
+				const out = admissionOf(declared, issue({milestone: 24}), purpose);
+				expect(out._tag).toBe("OutOfFocus");
+				expect(admissionRefusal("build claim", out)?.code).toBe(OUT_OF_FOCUS);
+			});
+		}
+
+		it("reads only the three named purposes — an off-enum value is null, never build", () => {
+			expect(CLAIM_PURPOSES.map(parseClaimPurpose)).toEqual([...CLAIM_PURPOSES]);
+			expect(parseClaimPurpose("planning")).toBeNull();
+			expect(parseClaimPurpose("")).toBeNull();
+			expect(parseClaimPurpose("BUILD")).toBeNull();
+		});
+
+		it("says on the purpose line whether the audience axis bound this claim", () => {
+			const audience = audienceAxisOf(unlabelled);
+			expect(purposeScopeLine("build claim", "build", audience)).toContain(
+				"the audience axis binds",
+			);
+			expect(purposeScopeLine("build claim", "gate", audience)).toContain(
+				"the audience axis does not bind a gate claim (#5175)",
+			);
+		});
 	});
 
 	it("resolves a malformed declaration to UNKNOWN at 4, never to admitted", () => {


### PR DESCRIPTION
`fabrika build claim` refused almost every epic. Its audience fence asks whether an agent should pick an issue up to *build*, and an epic only earns `ready-for:agent` after it has been planned and gated — so the fence blocked the very planning and gating lanes it was never meant to bind. The claim verb now takes `--purpose plan|gate|build`: `build` is the default and keeps the fence exactly as it was, while a `plan` or `gate` claim is admitted without the label. The campaign scope fence is untouched under every purpose, and `--override` now has to name the lane that took it as well as the reason, so the escape hatch cannot quietly become the normal path.

Implements the founder ruling on #5175 (comment 5233727248). Reads #5041 as input — the `ready-for:` cutover sequencing and that label's audience-vs-hold double meaning are **not** resolved here.

Part of #5183 — not `Fixes`. The issue's ninth AC (the `plan-epic` step-1 `--purpose plan` flip) is deferred to #5217, so #5183 stays open with that one box live rather than closing over a gap nobody re-checks.

## What changed

- `packages/fabrika-cli/src/build/scope-admission.ts` — a closed `CLAIM_PURPOSES` enum (`plan` / `gate` / `build`), `DEFAULT_CLAIM_PURPOSE`, `parseClaimPurpose`, `audienceAxisBinds`, and a purpose parameter on `admissionOf` that defaults to `build`. Purpose rides **beside** the two axes: `scopeAxisOf` and `audienceAxisOf` read an issue exactly as before, and only the composition consults it (ADR 0245's repair round removed the one-widened-predicate shape, and this does not reintroduce it). Every outcome still carries both axis verdicts, so a `plan`/`gate` claim admitted over a non-agent audience still reports the audience it saw.
- `packages/fabrika-cli/src/build/claim-verb.ts` — `runClaim` parses the purpose before anything else (an off-enum value is exit `10`, never a fallback to `build`), reads the override's two required fields, and prints a purpose line beside the existing focus line.
- `packages/fabrika-cli/src/build/claim.ts` — `composeMarker` takes a `ClaimOverride {lane, reason}` and records both on the marker's own second line; the marker line the resolver parses is unchanged.
- `packages/fabrika-cli/src/build/command.ts` — the `--purpose` and `--override-lane` flags, and a `--help` that states the default explicitly and enumerates the new `10`.
- `claude-plugins/fabrika/skills/check-epic-plan/` — step 1 claims with `--purpose gate`, and the contract's reuse passage plus its `20`/`21`-overlap section record that a step-1 `21` is no longer reachable for this gate.
- `claude-plugins/fabrika/skills/build/contract.md` — the claim verb's spec follows the shipped verb: the invocation, the inputs table, the purpose and override rules, the answer shape, the `10` seat and the examples. `build/SKILL.md`'s one `--override` mention names the lane too.

`packages/fabrika-cli/src/build/pick-verb.ts` is **not** touched. The default parameter keeps its `admissionOf(focus, issue)` call byte-identical, and its fixtures' exclusion reasons are unchanged — `pick-verb.unit.test.ts` passes without an edit.

## Deviations

**Class: deferred a named acceptance criterion.** *Said:* the issue's ninth AC asks that `plan-epic`'s step-1 claim run `--purpose plan`, in PR #5178 if still open, in a follow-up commit if it merged. *Did:* left `claude-plugins/fabrika/skills/plan-epic/**` untouched and filed #5217 for the flip. *Why:* #5178 has merged, so the AC's own escape valve (say so in Deviations) does not literally apply — this dispatch fenced `claude-plugins/fabrika/skills/plan-epic/**` off to lane #5179, and an operator fence is reason enough on its own. *(Corrected in repair round 1: this entry originally said lane #5179 "owns those files right now" — unsupported. Its PR, #5221, touches zero `plan-epic` files; its whole diff is `packages/fabrika-cli/src/ledger/**`. The deferral stands on the fence, not on a merge-conflict risk.)* *Disposition:* follow-up #5217 filed, naming the two files and the shape to copy from `check-epic-plan`. The CLI half it needs is in this PR, so #5217 is a two-file prose edit whenever #5179 lands.

**Class: changed a test that asserted the prior contract.** *Said:* nothing about existing tests. *Did:* updated `claim-verb.unit.test.ts`'s `--override` case to pass `--override-lane` and to expect `override` as `{lane, reason}` rather than a bare string, and added `purpose` to the two `won` answer assertions. *Why:* the override tightening and the answer shape are both ruled behaviour; the old assertions encode the contract this PR replaces. *Disposition:* no action needed — the fence's own assertions (nothing posted before a refusal) are unchanged, and four new refusal tests cover the tightened override.

**Class: widened the diff past the files the issue named.** *Said:* the issue's surface list names `scope-admission.ts`, `claim-verb.ts`, `command.ts`, `pick-verb.ts` and the two `check-epic-plan` files. *Did:* also edited `claude-plugins/fabrika/skills/build/contract.md`. *Why:* that contract is the `claim` verb's own spec — its invocation line, inputs table, exit table, answer shape and examples all describe the flags this PR changes, so leaving it alone would ship a contract that contradicts the verb. *Disposition:* no action needed; the edit is confined to the claim/admission passages.

**Class: left a pre-existing defect in place.** *Said:* nothing. *Did:* did not reconcile `build/contract.md`'s `20`/`21` **stderr message strings**, which already drifted from the verb's actual wording before this PR. *Why:* it is a pre-existing drift with its own fix, and correcting it here would widen the diff a reviewer has to verify against a change that is not about message text. *Disposition:* for the reviewer to judge whether it wants its own follow-up.

**(repair round 1) Class: left a pre-existing defect in place — now partly discharged.** *Said:* the round-0 entry above left `build/contract.md`'s `20`/`21` stderr wording drift alone. *Did:* repaired only the **override guidance** inside those two rows and the `:715` example (`pass --override "<reason>" --override-lane "<lane>"`), leaving the rest of the wording drift untouched. *Why:* that guidance was correct before this PR and wrong *because of* it — the shipped verb refuses a lane-less `--override` on exit 1 — so it is this PR's contradiction, not pre-existing drift. The remaining wording drift is still pre-existing and out of scope, per the reviewer. *Disposition:* the rest of the drift still wants its own follow-up. *(Corrected in repair round 2: this entry was inaccurate about what was left. It said only "the remaining wording drift is pre-existing", but a **fourth** site — the `:201` prose summary of the override — was also newly-wrong override guidance of exactly this class and went unrepaired and undisclosed, so the entry read as complete when it was not. `:201` is repaired in round 2, along with the one same-class sentence in `build/SKILL.md`; what still stands unrepaired at the `20`/`21` rows is genuinely pre-existing stderr **message-string** drift and nothing else.)*

**(repair round 1) Class: changed the PR's closing seam.** *Said:* round 0 opened with `Fixes #5183`. *Did:* changed it to `Part of #5183`. *Why:* AC-9 is deferred to #5217, and a named follow-up does not discharge an acceptance criterion — `Fixes` would close #5183 while `plan-epic` step 1 still claims with the default `build` purpose. *Disposition:* #5183 stays open with one live box; #5217 carries the flip.

**(repair round 2) Class: widened the diff past the files the issue named.** *Said:* the file list above is nine files; `claude-plugins/fabrika/skills/build/SKILL.md` is not among them. *Did:* also corrected that file's single `--override "<reason>"` mention to name `--override-lane` and state both flags are required. *Why:* same class as the `:201` finding — the sentence was correct before this PR and is incomplete because of it, and three rounds have each found one more site than the last, so this round swept every `--override` mention in the repo instead of the one the verdict named. *Disposition:* no action needed; the edit is one sentence. Every remaining `--override` mention (the `build/contract.md` inputs table, `:624-630`, the `20`/`21` rows, the `:715` example, and both `check-epic-plan` files) was re-checked against `claim-verb.ts` and matches the shipped verb.

**(repair round 2) Class: declined an optional reviewer suggestion.** *Said:* the round-1 verdict's non-blocking nit — two ragged lines in `check-epic-plan/contract.md` (a bold span split across a wrap, one line past the ~100-col prose wrap). *Did:* left them as they are. *Why:* the dispatch recorded the nit as not-to-fix for this round, and it is cosmetic: it changes nothing the contract says. *Disposition:* no follow-up filed; a later touch of that file can absorb it.

## Relation to the three open claim defects

The dispatch flagged #5203 (a build's Step 8 release leaves a repair round unclaimed), #4145 (who owns releasing a delegated claim), and the two-layer assignee/comment split. **This change makes none of them cheaper or harder, and subsumes none of them.** The purpose axis governs *admission* — whether a claim may be taken at all — while all three live in *ownership and release*, after admission has passed. They share the verb, not the question. Scope was deliberately not widened to reach them.

